### PR TITLE
feat(platform,sandbox): live-browser human takeover — always-on control, native chrome, paste & key fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "setup:clean": "bun services/platform/scripts/setup-clean.ts",
     "docker:build": "bunx turbo run docker:build",
     "docker:up": "docker compose up -d",
-    "docker:dev": "docker network inspect tale-sandbox-net >/dev/null 2>&1 || docker network create --internal --ipv6=false --driver=bridge tale-sandbox-net; bun scripts/docker-dev-env-override.ts | docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml -f - up --build -d",
+    "docker:dev": "bun scripts/ensure-sandbox-runtime-image.ts && ( docker network inspect tale-sandbox-net >/dev/null 2>&1 || docker network create --internal --ipv6=false --driver=bridge tale-sandbox-net ) && bun scripts/docker-dev-env-override.ts | docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml -f - up --build -d",
     "docker:dev:down": "docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml down",
     "docker:dev:logs": "docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml logs -f",
     "docker:down": "docker compose down",

--- a/scripts/ensure-sandbox-runtime-image.ts
+++ b/scripts/ensure-sandbox-runtime-image.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+/*
+  Build the sandbox *runtime* image (`tale-sandbox-runtime:latest`) on demand,
+  but only when it is missing locally — a prestep of `docker:dev`.
+
+  Why this exists: `docker:dev` runs `docker compose up --build`, which builds
+  every compose *service*. But the per-execution sandbox runtime is NOT a compose
+  service — it is the image the `sandbox` spawner `docker run`s at runtime (one
+  ephemeral container per /v1/execute call or agent session), referenced only as
+  the spawner's `SANDBOX_RUNTIME_IMAGE` default. compose never sees it, so
+  `--build` never builds it. On a fresh checkout the image is absent and the first
+  Claude-Code / agent message 502s with `Unable to find image
+  'tale-sandbox-runtime:latest' locally` — it is not a public image, so the
+  implicit `docker pull` also fails ("pull access denied").
+
+  `tale deploy` sidesteps this by pulling + re-tagging the CI-built image from
+  GHCR (tools/cli/src/lib/actions/deploy.ts); local dev has no such step, so we
+  build from source here. Idempotent and cheap on the hot path: when the image
+  already exists this is a sub-second `docker image inspect`, so `docker:dev`
+  stays lightweight. Set SANDBOX_RUNTIME_FORCE_BUILD=1 to rebuild even when
+  present.
+
+  Build flags mirror CI (.github/workflows/build.yml) and the tag `tale deploy`
+  applies: context = repo root, `-f services/sandbox-runtime/Dockerfile` (which
+  also activates services/sandbox-runtime/Dockerfile.dockerignore), tagged
+  tale-sandbox-runtime:latest — the spawner's SANDBOX_RUNTIME_IMAGE default.
+*/
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import { doneLine, errorLine, infoLine } from '@tale/shared/tux';
+
+const IMAGE = 'tale-sandbox-runtime:latest';
+const DOCKERFILE = 'services/sandbox-runtime/Dockerfile';
+const repoRoot = join(import.meta.dir, '..');
+
+const force = ['1', 'true', 'yes'].includes(
+  (process.env.SANDBOX_RUNTIME_FORCE_BUILD ?? '').toLowerCase(),
+);
+
+// `docker image inspect` exits 0 iff the image is present locally. A non-zero
+// `.error` means docker itself could not be spawned (not installed / not on
+// PATH) — fail loudly rather than silently attempting a build that cannot run.
+function imageExists(): boolean {
+  const probe = spawnSync('docker', ['image', 'inspect', IMAGE], {
+    stdio: 'ignore',
+  });
+  if (probe.error) {
+    errorLine(
+      `Cannot run docker (${probe.error.message}). Install Docker and retry.`,
+    );
+    process.exit(1);
+  }
+  return probe.status === 0;
+}
+
+if (!force && imageExists()) {
+  infoLine(`Sandbox runtime image ${IMAGE} present — skipping build.`);
+  process.exit(0);
+}
+
+infoLine(
+  force
+    ? `Rebuilding sandbox runtime image ${IMAGE} (SANDBOX_RUNTIME_FORCE_BUILD set)…`
+    : `Sandbox runtime image ${IMAGE} missing — building it once (a few minutes on first run)…`,
+);
+
+const build = spawnSync(
+  'docker',
+  ['build', '-t', IMAGE, '-f', DOCKERFILE, '.'],
+  { cwd: repoRoot, stdio: 'inherit' },
+);
+if (build.error) {
+  errorLine(
+    `Cannot run docker (${build.error.message}). Install Docker and retry.`,
+  );
+  process.exit(1);
+}
+if (build.status !== 0) {
+  errorLine(
+    `Failed to build ${IMAGE} (docker build exited ${build.status ?? 'on a signal'}).`,
+  );
+  process.exit(build.status ?? 1);
+}
+
+doneLine(`Built ${IMAGE}.`);

--- a/services/platform/app/features/workspace/components/live-browser-context.tsx
+++ b/services/platform/app/features/workspace/components/live-browser-context.tsx
@@ -15,8 +15,9 @@ import {
 interface LiveBrowserState {
   isOpen: boolean;
   /** When true the pane connects with `?control=1` (writable VNC, human
-   * takeover) instead of the read-only mirror. Set by the take-control card;
-   * the strip/menu always open in view mode. */
+   * takeover) instead of the read-only mirror. Set by the in-pane Take/Release
+   * control toggle or the agent's take-control card; the strip/menu always open
+   * in view mode. */
   control: boolean;
 }
 

--- a/services/platform/app/features/workspace/components/live-browser-pane.tsx
+++ b/services/platform/app/features/workspace/components/live-browser-pane.tsx
@@ -367,24 +367,25 @@ function ControlToggle({
   onToggle: (next: boolean) => void;
 }) {
   const { t } = useT('chat');
-  return control ? (
-    <Button
-      variant="secondary"
-      size="sm"
-      icon={Eye}
-      onClick={() => onToggle(false)}
-    >
-      {t('liveBrowser.releaseControl', { defaultValue: 'Release control' })}
-    </Button>
-  ) : (
-    <Button
-      variant="primary"
-      size="sm"
-      icon={Hand}
-      onClick={() => onToggle(true)}
-    >
-      {t('liveBrowser.takeControl', { defaultValue: 'Take control' })}
-    </Button>
+  const label = control
+    ? t('liveBrowser.releaseControl', { defaultValue: 'Release control' })
+    : t('liveBrowser.takeControl', { defaultValue: 'Take control' });
+  // Match the sibling header actions (Reset/expand/collapse): a ghost icon
+  // button, not a heavy filled CTA. A primary-tinted icon signals when the human
+  // is actively driving; the tooltip/aria carry the label.
+  const Icon = control ? Eye : Hand;
+  return (
+    <Tooltip content={label} side="bottom">
+      <Button
+        variant="ghost"
+        size="icon"
+        className={control ? 'text-primary size-7' : 'size-7'}
+        onClick={() => onToggle(!control)}
+        aria-label={label}
+      >
+        <Icon className="size-3.5" />
+      </Button>
+    </Tooltip>
   );
 }
 

--- a/services/platform/app/features/workspace/components/live-browser-pane.tsx
+++ b/services/platform/app/features/workspace/components/live-browser-pane.tsx
@@ -7,7 +7,14 @@ import { Spinner } from '@tale/ui/spinner';
 import { Text } from '@tale/ui/text';
 import { useMatch } from '@tanstack/react-router';
 import { useAction } from 'convex/react';
-import { MonitorPlay, MonitorOff, RefreshCw, RotateCcw } from 'lucide-react';
+import {
+  Eye,
+  Hand,
+  MonitorPlay,
+  MonitorOff,
+  RefreshCw,
+  RotateCcw,
+} from 'lucide-react';
 import {
   memo,
   useCallback,
@@ -343,18 +350,41 @@ function ScreencastViewport({
   );
 }
 
-/** The control badge ("View only" / "You're in control") shown in the shell
- *  tab-bar header while the live-browser tab is active. */
-function ControlBadge({ control }: { control: boolean }) {
+/**
+ * Take / release writable control of the live browser. Control is ALWAYS
+ * available to the thread owner while a session is active — it is not gated on
+ * an agent `request_human_control` handoff (that flow still exists for the agent
+ * to ASK and to pause/resume). Flipping this reconnects the RFB socket to the
+ * writable (`control=1`) or read-only endpoint via the context `control` state.
+ * Once in control, drive the browser's own menu bar (omnibox, back/forward,
+ * reload) directly in the stream.
+ */
+function ControlToggle({
+  control,
+  onToggle,
+}: {
+  control: boolean;
+  onToggle: (next: boolean) => void;
+}) {
   const { t } = useT('chat');
   return control ? (
-    <span className="border-primary/40 text-primary bg-primary/10 shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
-      {t('liveBrowser.controlling')}
-    </span>
+    <Button
+      variant="secondary"
+      size="sm"
+      icon={Eye}
+      onClick={() => onToggle(false)}
+    >
+      {t('liveBrowser.releaseControl', { defaultValue: 'Release control' })}
+    </Button>
   ) : (
-    <span className="border-border text-muted-foreground bg-muted/60 shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
-      {t('liveBrowser.viewOnly', { defaultValue: 'View only' })}
-    </span>
+    <Button
+      variant="primary"
+      size="sm"
+      icon={Hand}
+      onClick={() => onToggle(true)}
+    >
+      {t('liveBrowser.takeControl', { defaultValue: 'Take control' })}
+    </Button>
   );
 }
 
@@ -428,7 +458,7 @@ function LiveBrowserPaneComponent({ available }: LiveBrowserPaneProps) {
   });
   const threadId = threadMatch?.params?.threadId;
 
-  const { control, isOpen } = useLiveBrowser();
+  const { control, isOpen, setControl } = useLiveBrowser();
 
   // "Active" = there's something worth streaming: a turn is actively running,
   // or the sandbox is warm (`active`). A `stopped`/`creating`/`degraded`
@@ -479,7 +509,9 @@ function LiveBrowserPaneComponent({ available }: LiveBrowserPaneProps) {
 
     const headerActions: ReactNode = (
       <>
-        <ControlBadge control={control} />
+        {sessionActive && (
+          <ControlToggle control={control} onToggle={setControl} />
+        )}
         {sessionActive && (
           <Tooltip
             content={t('liveBrowser.reset', {
@@ -527,6 +559,7 @@ function LiveBrowserPaneComponent({ available }: LiveBrowserPaneProps) {
     threadId,
     t,
     control,
+    setControl,
     sessionActive,
     confirmOpen,
     resetting,

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -965,6 +965,7 @@ import type * as node_only_integration_sandbox_types from "../node_only/integrat
 import type * as node_only_sandbox_agent_message_parts from "../node_only/sandbox/agent_message_parts.js";
 import type * as node_only_sandbox_agent_run_outcome from "../node_only/sandbox/agent_run_outcome.js";
 import type * as node_only_sandbox_api_error_detection from "../node_only/sandbox/api_error_detection.js";
+import type * as node_only_sandbox_browser_view from "../node_only/sandbox/browser_view.js";
 import type * as node_only_sandbox_helpers_session_client from "../node_only/sandbox/helpers/session_client.js";
 import type * as node_only_sandbox_helpers_spawner_client from "../node_only/sandbox/helpers/spawner_client.js";
 import type * as node_only_sandbox_integration_skills from "../node_only/sandbox/integration_skills.js";
@@ -2560,6 +2561,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/agent_message_parts": typeof node_only_sandbox_agent_message_parts;
   "node_only/sandbox/agent_run_outcome": typeof node_only_sandbox_agent_run_outcome;
   "node_only/sandbox/api_error_detection": typeof node_only_sandbox_api_error_detection;
+  "node_only/sandbox/browser_view": typeof node_only_sandbox_browser_view;
   "node_only/sandbox/helpers/session_client": typeof node_only_sandbox_helpers_session_client;
   "node_only/sandbox/helpers/spawner_client": typeof node_only_sandbox_helpers_spawner_client;
   "node_only/sandbox/integration_skills": typeof node_only_sandbox_integration_skills;

--- a/services/platform/convex/approvals/human_control_mutations.ts
+++ b/services/platform/convex/approvals/human_control_mutations.ts
@@ -93,13 +93,17 @@ async function resumeAfterHandoff(
 }
 
 /**
- * Take control of the live browser for a pending handoff: claim the single-
- * controller lease so a `?control=1` screencast connection is authorized to the
- * WRITABLE x11vnc. Called by the screencast-auth oracle (http.ts) for a control
- * upgrade. v1 control boundary is the thread OWNER (stricter than the view
- * boundary — a writable browser is more powerful than a mirror), matching how
- * only the owner approves a plan. Idempotent for the same holder (reconnects
- * re-acquire); refuses a second concurrent controller.
+ * Authorize a `?control=1` screencast upgrade to the WRITABLE x11vnc. Called by
+ * the screencast-auth oracle (http.ts), which has already confirmed the session
+ * is `active` and run the org-scoped canAccessThread view boundary.
+ *
+ * Control is ALWAYS available to the thread OWNER — it is intentionally NOT
+ * gated on an agent-issued `request_human_control` handoff. The agent can still
+ * ask (that flow parks the turn and resumes on return), but the human can grab
+ * the wheel at any time to scroll/click/type or drive the browser's own menu
+ * bar. The owner boundary is stricter than the view boundary on purpose: a
+ * writable browser is more powerful than a mirror, so shared viewers stay
+ * read-only (a denied control request still streams the read-only mirror).
  */
 export const claimHumanControlLease = internalMutation({
   args: {
@@ -111,9 +115,6 @@ export const claimHumanControlLease = internalMutation({
     reason: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
-    // The caller (screencast-auth oracle) already ran the org-scoped
-    // canAccessThread view boundary; here we derive everything from the thread
-    // itself and additionally require OWNERSHIP for control.
     const meta = await ctx.db
       .query('threadMetadata')
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
@@ -121,35 +122,9 @@ export const claimHumanControlLease = internalMutation({
     if (!meta) {
       return { ok: false, reason: 'no_thread' };
     }
-    // Owner-only control in v1 (a shared viewer can watch, not drive).
+    // Owner-only control: a shared viewer can watch, not drive.
     if (meta.userId !== args.userId) {
       return { ok: false, reason: 'forbidden' };
-    }
-    // Control is only meaningful while the agent has actually asked for it.
-    const approval = await ctx.db
-      .query('approvals')
-      .withIndex('by_threadId_status_resourceType', (q) =>
-        q
-          .eq('threadId', args.threadId)
-          .eq('status', 'pending')
-          .eq('resourceType', 'external_agent_human_control'),
-      )
-      .first();
-    if (!approval) {
-      return { ok: false, reason: 'no_request' };
-    }
-    const metadata = isRecord(approval.metadata) ? approval.metadata : {};
-    const holder =
-      typeof metadata.controlHolderUserId === 'string'
-        ? metadata.controlHolderUserId
-        : undefined;
-    if (holder !== undefined && holder !== args.userId) {
-      return { ok: false, reason: 'held_by_other' };
-    }
-    if (holder !== args.userId) {
-      await ctx.db.patch(approval._id, {
-        metadata: { ...metadata, controlHolderUserId: args.userId },
-      });
     }
     return { ok: true };
   },

--- a/services/platform/convex/http.ts
+++ b/services/platform/convex/http.ts
@@ -753,11 +753,11 @@ http.route({
     }
 
     // Writable control (`?control=1`) is a SEPARATE, stricter grant than view:
-    // the human gets a writable VNC only while the agent has a pending
-    // request_human_control handoff, only if they OWN the thread, and only one
-    // controller at a time (the single-controller lease). A denied control
-    // request still streams read-only (control:false) — the pane just stays a
-    // mirror — so a second viewer can watch while one person drives.
+    // it's available to the thread OWNER at any time (not gated on an agent
+    // request_human_control handoff), so a human can grab the wheel whenever the
+    // session is active. A denied control request (a non-owner viewer) still
+    // streams read-only (control:false) — the pane just stays a mirror — so a
+    // second viewer can watch while the owner drives.
     let control = false;
     if (url.searchParams.get('control') === '1') {
       try {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1802,6 +1802,8 @@
       "ariaLabel": "Live-Ansicht des Browsers des Agents (schreibgeschützt)",
       "ariaLabelControl": "Live-Browser – du steuerst ihn",
       "controlling": "Du hast die Kontrolle",
+      "takeControl": "Kontrolle übernehmen",
+      "releaseControl": "Kontrolle abgeben",
       "reset": "Browser zurücksetzen (meldet von allen Seiten ab)",
       "resetConfirmTitle": "Browser zurücksetzen?",
       "resetConfirmBody": "Startet den Browser mit einem leeren Profil neu und meldet dich von allen Seiten ab, bei denen der Agent angemeldet war. Nutze dies nur, wenn der Browser hängt und sich nicht von selbst erholt.",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1790,7 +1790,6 @@
     "liveBrowser": {
       "title": "Live-Browser",
       "toggleLabel": "Live-Browser",
-      "viewOnly": "Nur ansehen",
       "connecting": "Verbinden…",
       "streaming": "Live",
       "disconnected": "Übertragung beendet",
@@ -1801,7 +1800,6 @@
       "emptyHint": "Starte eine Anfrage — sobald der Agent einen Browser öffnet, siehst du es hier live.",
       "ariaLabel": "Live-Ansicht des Browsers des Agents (schreibgeschützt)",
       "ariaLabelControl": "Live-Browser – du steuerst ihn",
-      "controlling": "Du hast die Kontrolle",
       "takeControl": "Kontrolle übernehmen",
       "releaseControl": "Kontrolle abgeben",
       "reset": "Browser zurücksetzen (meldet von allen Seiten ab)",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1802,6 +1802,8 @@
       "ariaLabel": "Live view of the agent’s browser (read-only)",
       "ariaLabelControl": "Live browser — you are controlling it",
       "controlling": "You’re in control",
+      "takeControl": "Take control",
+      "releaseControl": "Release control",
       "reset": "Reset browser (clears logins)",
       "resetConfirmTitle": "Reset browser?",
       "resetConfirmBody": "Restarts the browser with a clean profile and signs out of every site the agent logged into. Use this only if the browser is stuck and won’t recover on its own.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1790,7 +1790,6 @@
     "liveBrowser": {
       "title": "Live browser",
       "toggleLabel": "Live browser",
-      "viewOnly": "View only",
       "connecting": "Connecting…",
       "streaming": "Live",
       "disconnected": "Stream ended",
@@ -1801,7 +1800,6 @@
       "emptyHint": "Start a turn — when the agent opens a browser you’ll see it here, live.",
       "ariaLabel": "Live view of the agent’s browser (read-only)",
       "ariaLabelControl": "Live browser — you are controlling it",
-      "controlling": "You’re in control",
       "takeControl": "Take control",
       "releaseControl": "Release control",
       "reset": "Reset browser (clears logins)",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1803,6 +1803,8 @@
       "ariaLabel": "Vue en direct du navigateur de l'agent (lecture seule)",
       "ariaLabelControl": "Navigateur en direct — tu le contrôles",
       "controlling": "Tu as le contrôle",
+      "takeControl": "Prendre le contrôle",
+      "releaseControl": "Rendre le contrôle",
       "reset": "Réinitialiser le navigateur (efface les connexions)",
       "resetConfirmTitle": "Réinitialiser le navigateur ?",
       "resetConfirmBody": "Redémarre le navigateur avec un profil vierge et te déconnecte de tous les sites où l'agent s'était connecté. À n'utiliser que si le navigateur est bloqué et ne se rétablit pas tout seul.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1791,7 +1791,6 @@
     "liveBrowser": {
       "title": "Navigateur en direct",
       "toggleLabel": "Navigateur en direct",
-      "viewOnly": "Lecture seule",
       "connecting": "Connexion…",
       "streaming": "En direct",
       "disconnected": "Diffusion terminée",
@@ -1802,7 +1801,6 @@
       "emptyHint": "Lance une requête — dès que l'agent ouvre un navigateur, tu le verras ici, en direct.",
       "ariaLabel": "Vue en direct du navigateur de l'agent (lecture seule)",
       "ariaLabelControl": "Navigateur en direct — tu le contrôles",
-      "controlling": "Tu as le contrôle",
       "takeControl": "Prendre le contrôle",
       "releaseControl": "Rendre le contrôle",
       "reset": "Réinitialiser le navigateur (efface les connexions)",

--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -52,6 +52,10 @@ describe('security headers', () => {
     expect(pp).toContain('camera=()');
     expect(pp).toContain('geolocation=(self)');
     expect(pp).toContain('clipboard-write=(self)');
+    // Live-browser human takeover bridges a host paste via
+    // navigator.clipboard.readText(); an empty allowlist would emit
+    // `clipboard-read=()` and silently block the read.
+    expect(pp).toContain('clipboard-read=(self)');
   });
 
   // Regression guard for issue #1925 — "Verify the web client passes the

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -479,10 +479,12 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
       camera: [],
       microphone: ['self'],
       // Active features: location-request approval card uses geolocation;
-      // copy-to-clipboard hook is wired into many UI surfaces.
+      // copy-to-clipboard hook is wired into many UI surfaces; live-browser
+      // human takeover reads the host clipboard (`navigator.clipboard.readText`)
+      // to bridge a paste into the remote session — both need same-origin grants.
       geolocation: ['self'],
       clipboardWrite: ['self'],
-      clipboardRead: [],
+      clipboardRead: ['self'],
       usb: [],
       payment: [],
       bluetooth: [],

--- a/services/sandbox-runtime/entrypoint.sh
+++ b/services/sandbox-runtime/entrypoint.sh
@@ -626,9 +626,15 @@ start_browser_stack() {
   # process means watchers retain a structural read-only guarantee — there is no
   # flag a watcher's client can flip to gain input. Same display ⇒ a human's
   # clicks here and the agent's CDP drive both land on the one Chromium.
+  #
+  # -xkb is REQUIRED for correct keysym entry: without it x11vnc falls back to
+  # legacy modtweak, which can't synthesize shifted-symbol keysyms (_, +, @, #,
+  # {, }, |, etc.) against a modern XKB keymap and mangles them (e.g. `_` lands
+  # as a space). The XKEYBOARD path maps each keysym to the right keycode+level.
+  # Only the writable :5901 injects input, so :5900 (-viewonly) doesn't need it.
   # shellcheck disable=SC2086
   _supervise $DROP x11vnc -display :99 -rfbport 5901 -localhost \
-    -forever -shared -nopw -noxdamage
+    -forever -shared -nopw -noxdamage -xkb
 
   # Headed Chromium with a CDP endpoint on loopback. The proxy bridge mirrors
   # the tale-playwright-mcp shim (Chromium ignores HTTPS_PROXY/NO_PROXY env):

--- a/services/sandbox-runtime/entrypoint.sh
+++ b/services/sandbox-runtime/entrypoint.sh
@@ -608,7 +608,10 @@ start_browser_stack() {
   # the network (loopback unix socket only); -ac disables host access control
   # (only the in-container procs can reach the socket anyway).
   # shellcheck disable=SC2086 # $DROP must word-split (empty, or the setpriv prefix)
-  _supervise $DROP Xvfb :99 -screen 0 1280x720x24 -nolisten tcp -ac
+  # 800 tall (not 720) leaves room for Chromium's own toolbar+tab strip (~72px)
+  # so the page viewport the agent renders into stays ~720 once the browser chrome
+  # is shown (see --window-size below; we no longer run fullscreen/kiosk).
+  _supervise $DROP Xvfb :99 -screen 0 1280x800x24 -nolisten tcp -ac
   export DISPLAY=:99
 
   # Read-only mirror on :5900 — the DEFAULT path every watcher gets. -localhost
@@ -640,14 +643,20 @@ start_browser_stack() {
   # the tale-playwright-mcp shim (Chromium ignores HTTPS_PROXY/NO_PROXY env):
   # forward the egress proxy + bypass list as flags so the managed browser has
   # the same egress posture the self-launched one would.
+  #
+  # We deliberately do NOT run fullscreen/kiosk: a human taking control needs the
+  # browser's own menu bar (omnibox + back/forward/reload) to navigate, so we show
+  # the native chrome and size the window to fill the display (no WM runs here, so
+  # --window-size + --window-position place it). The toolbar also surfaces the
+  # current URL to read-only watchers for free.
   set -- "${CHROME_BIN}" \
     --remote-debugging-port=9222 \
     --remote-debugging-address=127.0.0.1 \
     --user-data-dir="${TALE_BROWSER_PROFILE}" \
     --no-sandbox \
     --disable-gpu \
-    --start-fullscreen \
-    --window-size=1280,720 \
+    --window-position=0,0 \
+    --window-size=1280,800 \
     --ignore-certificate-errors \
     --test-type \
     --disable-infobars \


### PR DESCRIPTION
Makes the sandbox **live-browser human takeover** actually usable end-to-end. Started as two input-fidelity bug fixes; now also removes the friction of agent-gated control and exposes the browser's own menu bar.

## Bug fixes

### Host→sandbox paste did nothing
The platform's `Permissions-Policy` emitted `clipboard-read=()`, disabling `navigator.clipboard.readText()` for every origin — so `bridgeHostPaste()` threw `NotAllowedError` (swallowed into a `console.warn`). `clipboard-write=(self)` was allowed, so the remote→host mirror worked while paste-in didn't. **Fix:** `clipboardRead: ['self']` in `server.ts` + a regression assertion. Verified on the wire before the fix: `… clipboard-write=(self), clipboard-read=() …`.

### Typing `_` produced a space (also `+ @ # { } | …`)
The writable x11vnc on `:5901` ran without `-xkb`, so legacy modtweak mis-synthesized shifted-symbol keysyms against the XKB keymap. **Fix:** add `-xkb` (the `-viewonly` `:5900` injects no input, so it doesn't need it).

## Feature: always-on control + native browser chrome

### Control is always available to the thread owner
Previously the human could only take control while an agent-issued `request_human_control` handoff was pending — too cumbersome in practice. Dropped that gate in `claimHumanControlLease`; the screencast-auth oracle already enforces an **active session + owner-only**. The agent's request/park/resume flow still exists for when the agent *asks*, but the human can grab the wheel at any time. A new in-pane **Take control / Release control** toggle (replacing the passive status badge) drives it. Ad-hoc control runs concurrently and does **not** pause the agent.

### Expose the browser's own menu bar
Rather than build a custom CDP toolbar, stop launching Chromium fullscreen/kiosk so its **native chrome** (omnibox, back/forward, reload) shows in the stream; pin `--window-position=0,0` and grow the Xvfb display `720→800` so the page viewport the agent renders into stays ~720 under the toolbar. The toolbar also surfaces the current URL to read-only watchers for free.

## Test plan
- [x] `server.test.ts` security-headers suite (35 tests) incl. new `clipboard-read=(self)` assertion.
- [x] Platform `tsc --noEmit` clean; `oxlint --type-aware` 0/0; `bash -n` on `entrypoint.sh`; opengrep pre-commit clean.
- [x] i18n parity: `takeControl`/`releaseControl` added to en/de/fr.
- [ ] **Runtime (needs image rebuilds):** Platform → `clipboard-read=(self)` + paste works; Sandbox (new session) → native toolbar visible, `_ + @ # { } |` type correctly, back/forward/reload/omnibox usable, Take/Release toggle flips writable↔read-only.

## Notes
- Sandbox runtime isn't in production → no migration.
- `controlHolderUserId` / `no_request` / `held_by_other` lease bits are now unused (single owner makes the lease redundant); the optional type field is left in place.