### PR TITLE
fix: show agent display names in workforce metrics leaderboard and attention lists (#2066)

### DIFF
--- a/services/platform/app/features/agents/workforce/hooks.test.tsx
+++ b/services/platform/app/features/agents/workforce/hooks.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentDisplayName } from './hooks';
+
+// `useAgentDisplayName` resolves a slug -> locale-aware display name from the
+// same roster the agents List uses. We drive the two real inputs — the
+// `useListAgents` roster and the active i18n locale — through mutable module
+// state so each case can stage its own roster/locale. The resolver itself
+// (`toConfigurableAgent` + `resolveAgentLocale`) runs for real.
+let mockAgents: unknown[] | undefined = [];
+let mockLocale = 'en';
+
+vi.mock('../hooks/queries', () => ({
+  useListAgents: () => ({ agents: mockAgents, isLoading: false }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: mockLocale } }),
+}));
+
+beforeEach(() => {
+  mockAgents = [];
+  mockLocale = 'en';
+});
+
+describe('useAgentDisplayName', () => {
+  it('resolves a known slug to its configured display name', () => {
+    mockAgents = [{ name: 'assistant', displayName: 'E2E Assistant' }];
+    const { result } = renderHook(() => useAgentDisplayName('org-1'));
+    expect(result.current('assistant')).toBe('E2E Assistant');
+  });
+
+  it('falls back to the raw slug verbatim for an unknown/uninstalled agent', () => {
+    mockAgents = [{ name: 'assistant', displayName: 'E2E Assistant' }];
+    const { result } = renderHook(() => useAgentDisplayName('org-1'));
+    expect(result.current('not-installed')).toBe('not-installed');
+  });
+
+  it('resolves app-owned composite `<appSlug>/<name>` slugs by their composite key', () => {
+    mockAgents = [
+      {
+        name: 'workforce/software-developer',
+        displayName: 'Software Developer',
+        appSlug: 'workforce',
+        folder: 'workforce',
+      },
+    ];
+    const { result } = renderHook(() => useAgentDisplayName('org-1'));
+    expect(result.current('workforce/software-developer')).toBe(
+      'Software Developer',
+    );
+  });
+
+  it('is locale-aware — switching the active locale changes the resolved name', () => {
+    mockAgents = [
+      {
+        name: 'assistant',
+        displayName: 'Assistant',
+        i18n: { de: { displayName: 'Assistent' } },
+      },
+    ];
+
+    const { result, rerender } = renderHook(() => useAgentDisplayName('org-1'));
+    expect(result.current('assistant')).toBe('Assistant');
+
+    mockLocale = 'de';
+    rerender();
+    expect(result.current('assistant')).toBe('Assistent');
+  });
+
+  it('skips agents whose resolved display name is empty, falling back to the slug', () => {
+    mockAgents = [{ name: 'assistant', displayName: '' }];
+    const { result } = renderHook(() => useAgentDisplayName('org-1'));
+    expect(result.current('assistant')).toBe('assistant');
+  });
+
+  it('returns the slug while the roster is still loading (undefined agents)', () => {
+    mockAgents = undefined;
+    const { result } = renderHook(() => useAgentDisplayName('org-1'));
+    expect(result.current('assistant')).toBe('assistant');
+  });
+});

--- a/services/platform/app/features/agents/workforce/hooks.ts
+++ b/services/platform/app/features/agents/workforce/hooks.ts
@@ -1,6 +1,13 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
 import { useConvexAction } from '@/app/hooks/use-convex-action';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
+import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
+
+import { useListAgents } from '../hooks/queries';
+import { toConfigurableAgent } from '../utils/agent-list-item';
 
 export interface WorkforceTrendPoint {
   dateKey: string;
@@ -131,4 +138,37 @@ export function useNeedsAttention(organizationId: string) {
 
 export function useSetTaskAutomation() {
   return useConvexAction(api.governance.mutations.setTaskAutomationEnabled);
+}
+
+/**
+ * Resolves an agent slug to its locale-aware display name for the workforce
+ * surfaces (leaderboard + needs-attention lists). The metrics queries are
+ * reactive DB reads and the agent display names live in config FILES (only the
+ * Node-runtime `listAgents` action can read them), so the backend payload
+ * carries only `agentSlug`. We resolve the friendly name client-side from the
+ * same roster the agents List uses — keeping the slug as the fallback (and for
+ * the routing param), so an unknown/uninstalled slug still renders sensibly.
+ *
+ * App-owned agents key on their composite `<appSlug>/<name>` slug, which is the
+ * same value the metrics rollups record, so those resolve too.
+ */
+export function useAgentDisplayName(
+  organizationId: string,
+): (slug: string) => string {
+  const { agents } = useListAgents(organizationId);
+  const { i18n } = useTranslation();
+  const locale = i18n.language;
+
+  const bySlug = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const raw of agents ?? []) {
+      const agent = toConfigurableAgent(raw);
+      if (!agent) continue;
+      const { displayName } = resolveAgentLocale(agent, locale);
+      if (displayName) map.set(agent.name, displayName);
+    }
+    return map;
+  }, [agents, locale]);
+
+  return useMemo(() => (slug: string) => bySlug.get(slug) ?? slug, [bySlug]);
 }

--- a/services/platform/app/features/agents/workforce/workforce-dashboard.tsx
+++ b/services/platform/app/features/agents/workforce/workforce-dashboard.tsx
@@ -36,6 +36,7 @@ import { cn } from '@/lib/utils/cn';
 import { formatNumber } from '@/lib/utils/format/number';
 
 import {
+  useAgentDisplayName,
   useNeedsAttention,
   useSetTaskAutomation,
   useWorkforceHealth,
@@ -82,6 +83,9 @@ export function WorkforceDashboard({
   const { health } = useWorkforceHealth(organizationId);
   const { attention } = useNeedsAttention(organizationId);
   const setAutomation = useSetTaskAutomation();
+  // Slug → friendly display name (locale-aware), resolved from the agent roster
+  // since the metrics payload carries only the machine slug.
+  const agentDisplayName = useAgentDisplayName(organizationId);
 
   const totals = metrics?.totals;
   const prevTotals = metrics?.previousTotals;
@@ -163,8 +167,9 @@ export function WorkforceDashboard({
             params={{ id: organizationId, agentId: row.original.agentSlug }}
             className="text-foreground block max-w-[320px] truncate text-sm font-medium underline-offset-2 hover:underline focus-visible:underline"
             onClick={(event) => event.stopPropagation()}
+            title={row.original.agentSlug}
           >
-            {row.original.agentSlug}
+            {agentDisplayName(row.original.agentSlug)}
           </Link>
         ),
         size: 320,
@@ -226,7 +231,7 @@ export function WorkforceDashboard({
         meta: { align: 'right' as const },
       },
     ],
-    [t, organizationId],
+    [t, organizationId, agentDisplayName],
   );
 
   const onToggle = (enabled: boolean) => {
@@ -479,7 +484,8 @@ export function WorkforceDashboard({
             emptyLabel={t('attention.none')}
             items={attention.queuedRuns.map((run, index) => ({
               key: `${run.agentSlug}-${run.taskId ?? index}`,
-              label: run.agentSlug,
+              label: agentDisplayName(run.agentSlug),
+              title: run.agentSlug,
               meta: formatRelative(new Date(run.queuedAt)),
               taskId: run.taskId,
             }))}
@@ -491,7 +497,8 @@ export function WorkforceDashboard({
             emptyLabel={t('attention.none')}
             items={attention.trippedBreakers.map((breaker, index) => ({
               key: `${breaker.agentSlug}-${breaker.taskId ?? index}`,
-              label: breaker.agentSlug,
+              label: agentDisplayName(breaker.agentSlug),
+              title: breaker.agentSlug,
               meta: formatRelative(new Date(breaker.trippedAt)),
               taskId: breaker.taskId,
             }))}
@@ -515,6 +522,8 @@ function AttentionList({
   items: Array<{
     key: string;
     label: string;
+    /** Tooltip on the label — e.g. the raw agent slug behind a display name. */
+    title?: string;
     meta?: string;
     taskId?: string;
     projectId?: string;
@@ -553,11 +562,14 @@ function AttentionList({
                   }}
                   search={{ task: item.taskId }}
                   className="min-w-0 truncate hover:underline"
+                  title={item.title}
                 >
                   {item.label}
                 </Link>
               ) : (
-                <span className="min-w-0 truncate">{item.label}</span>
+                <span className="min-w-0 truncate" title={item.title}>
+                  {item.label}
+                </span>
               )}
               {item.meta && (
                 <span className="text-muted-foreground shrink-0 text-xs">


### PR DESCRIPTION
## Summary

The Workforce Metrics dashboard (`/dashboard/$id/agents/metrics`) rendered the **raw machine slug** as the primary label everywhere an agent appeared:

- Leaderboard "Agent" column rendered `agentSlug` as the Link text (e.g. `assistant`, or the composite `workforce/software-developer` for app-owned agents).
- The "Queued runs" and "Paused by circuit breaker" attention lists used `agentSlug` as their primary label.

This is inconsistent with the agents roster List and the agent-editor header, which both resolve and render the configured locale-aware `displayName`.

## Root cause

The metrics backend (`getWorkforceMetrics.leaderboard`, `getNeedsAttention.queuedRuns`/`.trippedBreakers`) are reactive Convex **queries**. Agent display names live in config **files**, which only the Node-runtime `listAgents` **action** can read — so a query cannot resolve them and the payload carries only `agentSlug`.

## Fix

Resolve the friendly name **client-side** from the same roster the agents List already uses, mirroring `agents-table.tsx`:

- New `useAgentDisplayName(organizationId)` hook in `workforce/hooks.ts` builds a locale-aware `slug → displayName` map from `useListAgents` + `resolveAgentLocale`, falling back to the slug for unknown/uninstalled agents (and app-owned composite slugs resolve too).
- `workforce-dashboard.tsx` renders the display name as the primary label in the leaderboard "Agent" cell and in the queued-runs / tripped-breaker lists, keeping the raw slug as a `title` tooltip and preserving the slug as the `$agentId` routing param (the row click/Link is unchanged).

## Verification

- `bunx tsc --noEmit` — passes.
- `bunx oxlint --type-aware` on the changed files — 0 warnings, 0 errors.

Closes #2066