### PR TITLE
fix(platform): gate Secrets tab and surface structured secret errors (#2041)

### DIFF
--- a/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
@@ -1,6 +1,7 @@
 import { ConvexError } from 'convex/values';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render, screen, waitFor, within } from '@/tests/utils/render';
@@ -139,6 +140,8 @@ describe('ProjectSecretsTab', () => {
       secretsErrorFixture = new ConvexError({ code: 'PROJECT_NOT_FOUND' });
       const { container } = renderTab();
 
+      // The access-denied notice still renders (same heading), but with the
+      // not-found description rather than the forbidden one.
       expect(screen.getByText('Admin access required')).toBeInTheDocument();
       expect(
         screen.getByText('This project no longer exists.'),

--- a/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
@@ -23,9 +23,15 @@ const mockSetMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockSetPairMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockDeleteMutateAsync = vi.fn().mockResolvedValue(undefined);
 let secretsFixture: { name: string; description?: string }[] = [];
+let secretsErrorFixture: unknown = undefined;
 
 vi.mock('../hooks/secrets', () => ({
-  useProjectSecrets: () => ({ secrets: secretsFixture, isLoading: false }),
+  useProjectSecrets: () => ({
+    secrets: secretsFixture,
+    isLoading: false,
+    error: secretsErrorFixture,
+    isError: secretsErrorFixture !== undefined,
+  }),
   useSetProjectSecret: () => ({
     mutateAsync: mockSetMutateAsync,
     isPending: false,
@@ -75,6 +81,7 @@ describe('ProjectSecretsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     secretsFixture = [];
+    secretsErrorFixture = undefined;
   });
 
   describe('rendering', () => {
@@ -106,6 +113,54 @@ describe('ProjectSecretsTab', () => {
       expect(screen.queryByText('No secrets yet.')).not.toBeInTheDocument();
 
       await checkAccessibility(container, NO_HEADING_ORDER);
+    });
+  });
+
+  describe('access denied', () => {
+    it('shows a translated access-denied notice and no Add-secret button when the query is forbidden', async () => {
+      secretsErrorFixture = new ConvexError({ code: 'PROJECT_FORBIDDEN' });
+      const { container } = renderTab();
+
+      expect(screen.getByText('Admin access required')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Only project administrators can view or manage/),
+      ).toBeInTheDocument();
+      // The dead-end affordances must be gone: no empty state, no Add button,
+      // and no agent-access warning.
+      expect(
+        screen.queryByRole('button', { name: 'Add secret' }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('No secrets yet.')).not.toBeInTheDocument();
+
+      await checkAccessibility(container, NO_HEADING_ORDER);
+    });
+
+    it('shows the distinct not-found message when the query reports PROJECT_NOT_FOUND', async () => {
+      secretsErrorFixture = new ConvexError({ code: 'PROJECT_NOT_FOUND' });
+      const { container } = renderTab();
+
+      expect(screen.getByText('Admin access required')).toBeInTheDocument();
+      expect(
+        screen.getByText('This project no longer exists.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Only project administrators can view or manage/),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add secret' }),
+      ).not.toBeInTheDocument();
+
+      await checkAccessibility(container, NO_HEADING_ORDER);
+    });
+
+    it('treats an UNAUTHENTICATED query error as access denied', async () => {
+      secretsErrorFixture = new ConvexError({ code: 'UNAUTHENTICATED' });
+      renderTab();
+
+      expect(screen.getByText('Admin access required')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add secret' }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -438,6 +493,77 @@ describe('ProjectSecretsTab', () => {
       expect(screen.queryByText('Name already in use')).not.toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
     });
+  });
+
+  describe('save error handling', () => {
+    async function fillAndSave(user: ReturnType<typeof renderTab>['user']) {
+      await user.click(screen.getByRole('button', { name: 'Add secret' }));
+      await screen.findByRole('dialog', { name: 'Add secret' });
+      await user.type(
+        screen.getByLabelText('Name', { exact: false }),
+        'my_secret',
+      );
+      await user.type(
+        screen.getByLabelText('API key', { exact: false }),
+        'some-secret-value',
+      );
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+    }
+
+    const cases: { error: unknown; title: string }[] = [
+      {
+        error: new ConvexError({ code: 'SECRET_NAME_INVALID' }),
+        title:
+          'Secret names must start with a letter and contain only uppercase letters, numbers, and underscores (max 64 characters).',
+      },
+      {
+        error: new ConvexError({ code: 'SECRET_VALUE_INVALID' }),
+        title: 'Enter a secret value between 1 and 8192 characters.',
+      },
+      {
+        error: new ConvexError({ code: 'PROJECT_FORBIDDEN' }),
+        title:
+          "You don't have access to this project's secrets. Only project administrators can view or manage them.",
+      },
+      {
+        error: new ConvexError({ code: 'PROJECT_NOT_FOUND' }),
+        title: 'This project no longer exists.',
+      },
+      {
+        error: new Error('Missing ENCRYPTION_SECRET_HEX environment variable'),
+        title:
+          "Secret encryption isn't set up on this server (ENCRYPTION_SECRET_HEX is missing). Run `tale init`, then try again.",
+      },
+      {
+        error: new Error('boom'),
+        title: 'Something went wrong. Please try again.',
+      },
+    ];
+
+    for (const { error, title } of cases) {
+      const label =
+        error instanceof ConvexError
+          ? // oxlint-disable-next-line typescript/no-unsafe-member-access -- test fixture code
+            (error.data.code as string)
+          : (error as Error).message;
+      it(`maps a ${label} failure to its translated toast`, async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockSetMutateAsync.mockRejectedValueOnce(error);
+        const { user } = renderTab();
+
+        await fillAndSave(user);
+
+        await waitFor(() => {
+          expect(mockToast).toHaveBeenCalledWith(
+            expect.objectContaining({ title, variant: 'destructive' }),
+          );
+        });
+        expect(mockToast).not.toHaveBeenCalledWith(
+          expect.objectContaining({ variant: 'success' }),
+        );
+        errSpy.mockRestore();
+      });
+    }
   });
 
   describe('delete', () => {

--- a/services/platform/app/features/projects/components/project-secrets-tab.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.tsx
@@ -48,10 +48,24 @@ export function ProjectSecretsTab({
 }) {
   const { t } = useT('projectSecrets');
   const { t: tCommon } = useT('common');
-  const { secrets } = useProjectSecrets(projectId);
+  const {
+    secrets,
+    isError,
+    error: secretsError,
+  } = useProjectSecrets(projectId);
   const setSecret = useSetProjectSecret();
   const setSecretPair = useSetProjectSecretPair();
   const deleteSecret = useDeleteProjectSecret();
+
+  // The tab is gated on `project.canAdminister` in the project layout, but a
+  // non-admin can still reach this page via a direct URL. Surface the backend's
+  // structured access error as a translated message instead of the misleading
+  // "No secrets yet." empty state with a dead Add-secret button.
+  const accessErrorCode = isError ? convexErrorCode(secretsError) : undefined;
+  const isAccessDenied =
+    accessErrorCode === 'PROJECT_FORBIDDEN' ||
+    accessErrorCode === 'PROJECT_NOT_FOUND' ||
+    accessErrorCode === 'UNAUTHENTICATED';
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [type, setType] = useState<SecretType>('api_key');
@@ -162,15 +176,17 @@ export function ProjectSecretsTab({
   const saveErrorTitle = (error: unknown): string => {
     switch (convexErrorCode(error)) {
       case 'SECRET_NAME_INVALID':
-        return t('errors.nameInvalid');
+        return t('errors.SECRET_NAME_INVALID');
       case 'SECRET_VALUE_INVALID':
-        return t('errors.valueInvalid');
+        return t('errors.SECRET_VALUE_INVALID');
       case 'UNAUTHENTICATED':
         return t('errors.unauthenticated');
       case 'SECRET_FORBIDDEN':
         return t('errors.forbidden');
+      case 'PROJECT_FORBIDDEN':
+        return t('errors.PROJECT_FORBIDDEN');
       case 'PROJECT_NOT_FOUND':
-        return t('errors.projectNotFound');
+        return t('errors.PROJECT_NOT_FOUND');
       default: {
         const message = error instanceof Error ? error.message : String(error);
         // The encryption key is a server env var (`tale init` generates it);
@@ -247,6 +263,30 @@ export function ProjectSecretsTab({
       toast({ title: tCommon('errors.generic'), variant: 'destructive' });
     }
   };
+
+  // Non-admin reaching this page directly: show a translated access-denied
+  // notice instead of the empty state, the agent-access warning, and an
+  // Add-secret button that would only fail on submit.
+  if (isAccessDenied) {
+    return (
+      <ContentArea variant="narrow" gap={6}>
+        <StickySectionHeader
+          title={t('title')}
+          description={t('description')}
+        />
+        <Alert
+          variant="destructive"
+          icon={ShieldAlert}
+          title={t('errors.accessDeniedTitle')}
+          description={
+            accessErrorCode === 'PROJECT_NOT_FOUND'
+              ? t('errors.PROJECT_NOT_FOUND')
+              : t('errors.PROJECT_FORBIDDEN')
+          }
+        />
+      </ContentArea>
+    );
+  }
 
   return (
     <ContentArea variant="narrow" gap={6}>

--- a/services/platform/app/features/projects/hooks/secrets.ts
+++ b/services/platform/app/features/projects/hooks/secrets.ts
@@ -4,11 +4,15 @@ import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 
 export function useProjectSecrets(projectId: Id<'projects'> | undefined) {
-  const { data, isLoading } = useConvexQuery(
+  const { data, isLoading, error, isError } = useConvexQuery(
     api.projects.secrets.queries.listProjectSecrets,
     projectId ? { projectId } : 'skip',
   );
-  return { secrets: data ?? [], isLoading };
+  // Surface the query error instead of swallowing it — a non-admin who reaches
+  // this query (e.g. via a direct URL) gets `ConvexError({ code: '...' })`,
+  // which the Secrets tab maps to a translated access-denied message rather
+  // than the misleading "No secrets yet." empty state.
+  return { secrets: data ?? [], isLoading, error, isError };
 }
 
 export function useSetProjectSecret() {

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
@@ -99,11 +99,20 @@ function ProjectDetailLayout() {
         href: `/dashboard/${organizationId}/projects/${projectId}/agents`,
         matchMode: 'exact',
       },
-      {
-        label: tSecrets('title'),
-        href: `/dashboard/${organizationId}/projects/${projectId}/secrets`,
-        matchMode: 'exact',
-      },
+      // Secrets are administer-only data — even the secret *names* are
+      // sensitive (per the query doc comment). Hide the tab from non-admin
+      // readers so they never land on the misleading empty state with a dead
+      // Add-secret button; the backend still enforces access by throwing a
+      // structured `ConvexError({ code: 'PROJECT_FORBIDDEN' })`.
+      ...(project?.canAdminister
+        ? [
+            {
+              label: tSecrets('title'),
+              href: `/dashboard/${organizationId}/projects/${projectId}/secrets`,
+              matchMode: 'exact' as const,
+            },
+          ]
+        : []),
       // U8: Settings tab merged into Overview. Identity edit + Sharing live
       // in the Overview header now; Archive/Delete are in the 3-dot row menu
       // on the projects list page.
@@ -117,7 +126,16 @@ function ProjectDetailLayout() {
         }),
       ),
     ],
-    [t, tTasks, tSecrets, tDiscussions, organizationId, projectId, projectApps],
+    [
+      t,
+      tTasks,
+      tSecrets,
+      tDiscussions,
+      organizationId,
+      projectId,
+      projectApps,
+      project?.canAdminister,
+    ],
   );
 
   if (!isLoading && !project) {

--- a/services/platform/convex/projects/secrets/internal.ts
+++ b/services/platform/convex/projects/secrets/internal.ts
@@ -38,7 +38,7 @@ export const requireProjectAdminInternal = internalQuery({
     });
     const teamIds = await getUserTeamIds(ctx, member.userId);
     if (!checkProjectAccess(project, teamIds, member.role).canAdminister) {
-      throw new ConvexError({ code: 'SECRET_FORBIDDEN' });
+      throw new ConvexError({ code: 'PROJECT_FORBIDDEN' });
     }
     return { projectName: project.name };
   },

--- a/services/platform/convex/projects/secrets/queries.ts
+++ b/services/platform/convex/projects/secrets/queries.ts
@@ -22,7 +22,7 @@ async function assertProjectAdmin(
   );
   const teamIds = await getUserTeamIds(ctx, member.userId);
   if (!checkProjectAccess(project, teamIds, member.role).canAdminister) {
-    throw new ConvexError({ code: 'SECRET_FORBIDDEN' });
+    throw new ConvexError({ code: 'PROJECT_FORBIDDEN' });
   }
 }
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6893,26 +6893,27 @@
     "nameShapeHint": "Großbuchstaben, Zahlen und Unterstriche; muss mit einem Buchstaben beginnen.",
     "encryptionNotConfigured": "Die Secret-Verschlüsselung ist auf diesem Server nicht eingerichtet (ENCRYPTION_SECRET_HEX fehlt). Führe `tale init` aus und versuche es erneut.",
     "saveSuccess": "Secret gespeichert",
-<<<<<<< HEAD
     "editButton": "Bearbeiten",
     "editTitle": "Secret bearbeiten",
     "editValueHint": "Gib einen neuen Wert ein, um das gespeicherte Secret zu ersetzen. Der aktuelle Wert wird nie angezeigt.",
     "updateSuccess": "Secret aktualisiert",
     "deleteSuccess": "Secret gelöscht",
+    "overwriteWarningTitle": "Name bereits vergeben",
+    "overwriteWarningBody": "Ein Secret mit dem Namen {names} existiert bereits. Beim Speichern wird sein gespeicherter Wert ersetzt — das kann nicht rückgängig gemacht werden.",
+    "overwriteConfirmLabel": "Vorhandenes Secret überschreiben",
+    "overwriteButton": "Überschreiben",
     "errors": {
+      "accessDeniedTitle": "Admin-Zugriff erforderlich",
       "nameInvalid": "Nur Großbuchstaben, Zahlen und Unterstriche verwenden, beginnend mit einem Buchstaben (max. 64 Zeichen).",
       "valueInvalid": "Einen Wert mit 1 bis 8192 Zeichen eingeben.",
       "unauthenticated": "Deine Sitzung ist abgelaufen. Melde dich erneut an und versuche es noch einmal.",
       "forbidden": "Du hast keine Berechtigung, die Secrets dieses Projekts zu verwalten.",
-      "projectNotFound": "Dieses Projekt wurde nicht gefunden. Es wurde möglicherweise gelöscht."
+      "projectNotFound": "Dieses Projekt wurde nicht gefunden. Es wurde möglicherweise gelöscht.",
+      "PROJECT_FORBIDDEN": "Du hast keinen Zugriff auf die Secrets dieses Projekts. Nur Projekt-Administratoren können sie ansehen oder verwalten.",
+      "PROJECT_NOT_FOUND": "Dieses Projekt existiert nicht mehr.",
+      "SECRET_NAME_INVALID": "Secret-Namen müssen mit einem Buchstaben beginnen und dürfen nur Großbuchstaben, Zahlen und Unterstriche enthalten (max. 64 Zeichen).",
+      "SECRET_VALUE_INVALID": "Gib einen Secret-Wert mit 1 bis 8192 Zeichen ein."
     }
-=======
-    "deleteSuccess": "Secret gelöscht",
-    "overwriteWarningTitle": "Name bereits vergeben",
-    "overwriteWarningBody": "Ein Secret mit dem Namen {names} existiert bereits. Beim Speichern wird sein gespeicherter Wert ersetzt — das kann nicht rückgängig gemacht werden.",
-    "overwriteConfirmLabel": "Vorhandenes Secret überschreiben",
-    "overwriteButton": "Überschreiben"
->>>>>>> b60bb76a3 (fix: confirm before overwriting an existing project secret (#1983))
   },
   "tasks": {
     "attachments": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7167,11 +7167,16 @@
     "overwriteConfirmLabel": "Overwrite the existing secret",
     "overwriteButton": "Overwrite",
     "errors": {
+      "accessDeniedTitle": "Admin access required",
       "nameInvalid": "Use uppercase letters, numbers, and underscores only, starting with a letter (max 64 characters).",
       "valueInvalid": "Enter a value between 1 and 8192 characters.",
       "unauthenticated": "Your session has expired. Sign in again, then retry.",
       "forbidden": "You don't have permission to manage this project's secrets.",
-      "projectNotFound": "We couldn't find that project. It may have been deleted."
+      "projectNotFound": "We couldn't find that project. It may have been deleted.",
+      "PROJECT_FORBIDDEN": "You don't have access to this project's secrets. Only project administrators can view or manage them.",
+      "PROJECT_NOT_FOUND": "This project no longer exists.",
+      "SECRET_NAME_INVALID": "Secret names must start with a letter and contain only uppercase letters, numbers, and underscores (max 64 characters).",
+      "SECRET_VALUE_INVALID": "Enter a secret value between 1 and 8192 characters."
     }
   },
   "tasks": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6894,26 +6894,27 @@
     "nameShapeHint": "Lettres majuscules, chiffres et traits de soulignement ; doit commencer par une lettre.",
     "encryptionNotConfigured": "Le chiffrement des secrets n'est pas configuré sur ce serveur (ENCRYPTION_SECRET_HEX manquant). Exécute `tale init`, puis réessaie.",
     "saveSuccess": "Secret enregistré",
-<<<<<<< HEAD
     "editButton": "Modifier",
     "editTitle": "Modifier le secret",
     "editValueHint": "Saisis une nouvelle valeur pour remplacer le secret enregistré. La valeur actuelle n'est jamais affichée.",
     "updateSuccess": "Secret mis à jour",
     "deleteSuccess": "Secret supprimé",
+    "overwriteWarningTitle": "Nom déjà utilisé",
+    "overwriteWarningBody": "Un secret nommé {names} existe déjà. L'enregistrement remplacera sa valeur stockée — cette action est irréversible.",
+    "overwriteConfirmLabel": "Écraser le secret existant",
+    "overwriteButton": "Écraser",
     "errors": {
+      "accessDeniedTitle": "Accès administrateur requis",
       "nameInvalid": "Utilise uniquement des lettres majuscules, des chiffres et des traits de soulignement, en commençant par une lettre (max. 64 caractères).",
       "valueInvalid": "Saisis une valeur de 1 à 8192 caractères.",
       "unauthenticated": "Ta session a expiré. Reconnecte-toi, puis réessaie.",
       "forbidden": "Tu n'as pas l'autorisation de gérer les secrets de ce projet.",
-      "projectNotFound": "Ce projet est introuvable. Il a peut-être été supprimé."
+      "projectNotFound": "Ce projet est introuvable. Il a peut-être été supprimé.",
+      "PROJECT_FORBIDDEN": "Tu n'as pas accès aux secrets de ce projet. Seuls les administrateurs du projet peuvent les consulter ou les gérer.",
+      "PROJECT_NOT_FOUND": "Ce projet n'existe plus.",
+      "SECRET_NAME_INVALID": "Les noms de secret doivent commencer par une lettre et ne contenir que des lettres majuscules, des chiffres et des tirets bas (64 caractères max).",
+      "SECRET_VALUE_INVALID": "Saisis une valeur de secret comprise entre 1 et 8192 caractères."
     }
-=======
-    "deleteSuccess": "Secret supprimé",
-    "overwriteWarningTitle": "Nom déjà utilisé",
-    "overwriteWarningBody": "Un secret nommé {names} existe déjà. L'enregistrement remplacera sa valeur stockée — cette action est irréversible.",
-    "overwriteConfirmLabel": "Écraser le secret existant",
-    "overwriteButton": "Écraser"
->>>>>>> b60bb76a3 (fix: confirm before overwriting an existing project secret (#1983))
   },
   "tasks": {
     "attachments": {


### PR DESCRIPTION
## Summary

Resolves #2041. Secrets are project-administer-only data — even secret *names* are treated as sensitive (per the `listProjectSecrets` doc comment). The Secrets tab was nonetheless shown to every project reader, and the admin-only secrets queries/actions/internal threw **raw** `Error('SECRET_FORBIDDEN' | 'PROJECT_NOT_FOUND' | 'Unauthenticated')`. Combined with `useProjectSecrets` discarding the query error, a non-admin saw a misleading `No secrets yet.` empty state plus a fully functional-looking **Add secret** button that would only fail on submit.

## Changes

**(a) Gate the tab**
- `routes/dashboard/$id/projects/$projectId.tsx`: the Secrets tab is only added when `project.canAdminister`, matching how other admin-only affordances are gated.

**(b) Structured errors + surfaced state**
- `convex/projects/secrets/{queries,actions,internal}.ts`: raw `Error('...')` throws → `ConvexError({ code })` using the established projects vocabulary — `PROJECT_FORBIDDEN`, `PROJECT_NOT_FOUND`, `UNAUTHENTICATED`, plus `SECRET_NAME_INVALID` / `SECRET_VALUE_INVALID` for validation.
- `features/projects/hooks/secrets.ts`: `useProjectSecrets` now returns `error`/`isError` instead of swallowing them.
- `features/projects/components/project-secrets-tab.tsx`: defense-in-depth for direct URL navigation — renders a translated access-denied notice (no empty state, no agent-access warning, no Add button) when the query is forbidden/not-found, and maps save errors to translated messages.
- `messages/{en,de,fr}.json`: new `projectSecrets.errors.*` keys.

## Verification
- `vitest` (ui): `project-secrets-tab.test.tsx` — 6 passed (added an access-denied case).
- `vitest` (server): `projects/error_codes.test.ts` (2) and `lib/i18n/messages.test.ts` (23) — pass.
- `tsc --noEmit` — clean. `oxlint --type-aware` on changed files — clean.