### PR TITLE
fix(platform): clear orphaned sharedWithTeamIds when a project goes org-wide (#2046)

### DIFF
--- a/services/platform/app/features/projects/components/project-sharing-section.tsx
+++ b/services/platform/app/features/projects/components/project-sharing-section.tsx
@@ -136,12 +136,15 @@ export function ProjectSharingSection({
   const handleOwningTeamChange = useCallback(
     (value: string) => {
       const nextOwningTeam = value === NONE_OWNING_TEAM ? null : value;
-      // Drop the new owning team from the shared list if it's there — mirrors
-      // the server-side rule that the owning team can't appear in
-      // `sharedWithTeamIds`.
-      const nextShared = sharedWithTeamIds.filter(
-        (id) => id !== nextOwningTeam,
-      );
+      // Going org-wide clears every share — a "shared-with" team is additional
+      // to an owning team, so without an owner those shares would silently keep
+      // the project restricted while the Select reads "Org-wide" (mirrors the
+      // server-side `normalizeSharing`). Otherwise drop just the new owning team
+      // from the shared list (the owning team can't also appear in it).
+      const nextShared =
+        nextOwningTeam === null
+          ? []
+          : sharedWithTeamIds.filter((id) => id !== nextOwningTeam);
       commit({ teamId: nextOwningTeam, sharedWithTeamIds: nextShared });
     },
     [commit, sharedWithTeamIds],

--- a/services/platform/convex/projects/access.test.ts
+++ b/services/platform/convex/projects/access.test.ts
@@ -5,6 +5,7 @@ import {
   getProjectTeamIds,
   hasProjectAccess,
   isOrgWideProject,
+  normalizeSharing,
 } from './access';
 
 describe('getProjectTeamIds', () => {
@@ -60,6 +61,45 @@ describe('isOrgWideProject', () => {
   it('returns false when project has any team', () => {
     expect(isOrgWideProject({ teamId: 'team-1' })).toBe(false);
     expect(isOrgWideProject({ sharedWithTeamIds: ['team-2'] })).toBe(false);
+  });
+});
+
+describe('normalizeSharing', () => {
+  it('clears shared teams when going org-wide (no owning team)', () => {
+    // The bug: switching the owning team to "Org-wide" used to keep
+    // `sharedWithTeamIds`, leaving the project restricted to those teams while
+    // the UI showed "Org-wide".
+    expect(normalizeSharing(null, ['team-b'])).toEqual({
+      teamId: null,
+      sharedWithTeamIds: [],
+    });
+  });
+
+  it('leaves an already org-wide project org-wide', () => {
+    expect(normalizeSharing(null, [])).toEqual({
+      teamId: null,
+      sharedWithTeamIds: [],
+    });
+  });
+
+  it('preserves shared teams when an owning team is set', () => {
+    expect(normalizeSharing('team-a', ['team-b', 'team-c'])).toEqual({
+      teamId: 'team-a',
+      sharedWithTeamIds: ['team-b', 'team-c'],
+    });
+  });
+
+  it('keeps an owning team with no shares unchanged', () => {
+    expect(normalizeSharing('team-a', [])).toEqual({
+      teamId: 'team-a',
+      sharedWithTeamIds: [],
+    });
+  });
+
+  it('result is genuinely org-wide per isOrgWideProject', () => {
+    const normalized = normalizeSharing(null, ['team-b']);
+    expect(isOrgWideProject(normalized)).toBe(true);
+    expect(getProjectTeamIds(normalized)).toEqual([]);
   });
 });
 

--- a/services/platform/convex/projects/access.ts
+++ b/services/platform/convex/projects/access.ts
@@ -56,6 +56,26 @@ export function isOrgWideProject(project: ProjectAccessInput | null): boolean {
 }
 
 /**
+ * Normalize a sharing target before persisting it.
+ *
+ * A "shared-with" team is always *additional* to an owning team, so a project
+ * with no owning team cannot retain shared teams: keeping them would leave the
+ * project restricted to those teams (`getProjectTeamIds` non-empty) while every
+ * surface — the Sharing Select, the overview/table "Org-wide" label — reports
+ * it as org-wide. Dropping the owning team therefore clears the shared list so
+ * "Org-wide" genuinely means org-wide and effective access matches the UI.
+ */
+export function normalizeSharing(
+  teamId: string | null,
+  sharedWithTeamIds: string[],
+): { teamId: string | null; sharedWithTeamIds: string[] } {
+  if (teamId === null) {
+    return { teamId: null, sharedWithTeamIds: [] };
+  }
+  return { teamId, sharedWithTeamIds };
+}
+
+/**
  * Check whether the user has any access to the project.
  */
 export function hasProjectAccess(

--- a/services/platform/convex/projects/mutations.ts
+++ b/services/platform/convex/projects/mutations.ts
@@ -31,7 +31,12 @@ import {
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { emitEvent } from '../workflows/triggers/emit_event';
-import { ADMIN_ROLES, checkProjectAccess, isOrgWideProject } from './access';
+import {
+  ADMIN_ROLES,
+  checkProjectAccess,
+  isOrgWideProject,
+  normalizeSharing,
+} from './access';
 import { PROJECT_AUDIT_ACTIONS, PROJECT_RESOURCE_TYPE } from './audit_actions';
 import {
   projectIntegrationsModeValidator,
@@ -548,25 +553,35 @@ export const updateProjectSharing = mutation({
       args.teamId === null ? null : (args.teamId ?? project.teamId ?? null);
     validateSharing(effectiveTeamId, sharedWithTeamIds);
 
-    const patch: Partial<Doc<'projects'>> = { updatedAt: Date.now() };
     const previousState = {
       teamId: project.teamId ?? null,
       sharedWithTeamIds: project.sharedWithTeamIds ?? [],
     };
+
+    // Resolve the requested shares (fall back to the stored ones when the arg
+    // is omitted), then normalize: dropping the owning team (→ org-wide) clears
+    // the shared list so the project can't be left silently restricted to teams
+    // that the UI no longer surfaces. Without this, going "Org-wide" while
+    // `sharedWithTeamIds` is non-empty orphans those shares.
+    const requestedShared =
+      sharedWithTeamIds !== undefined
+        ? sharedWithTeamIds
+        : previousState.sharedWithTeamIds;
+    const normalized = normalizeSharing(effectiveTeamId, requestedShared);
+
     const newState = {
-      teamId: previousState.teamId,
-      sharedWithTeamIds: previousState.sharedWithTeamIds,
+      teamId: normalized.teamId,
+      sharedWithTeamIds: normalized.sharedWithTeamIds,
     };
 
-    if (args.teamId !== undefined) {
-      patch.teamId = args.teamId ?? undefined;
-      newState.teamId = args.teamId ?? null;
-    }
-    if (sharedWithTeamIds !== undefined) {
-      patch.sharedWithTeamIds =
-        sharedWithTeamIds.length > 0 ? sharedWithTeamIds : undefined;
-      newState.sharedWithTeamIds = sharedWithTeamIds;
-    }
+    const patch: Partial<Doc<'projects'>> = {
+      teamId: newState.teamId ?? undefined,
+      sharedWithTeamIds:
+        newState.sharedWithTeamIds.length > 0
+          ? newState.sharedWithTeamIds
+          : undefined,
+      updatedAt: Date.now(),
+    };
 
     await ctx.db.patch(args.projectId, patch);
 


### PR DESCRIPTION
## Summary

Fixes #2046. Switching a project's owning team to **Org-wide** used to leave `sharedWithTeamIds` intact, so `getProjectTeamIds()` still returned those teams: the project stayed restricted to them while the Sharing Select, overview header, and projects table all displayed "Org-wide". The orphaned shares were also unreachable from the UI (the "Also shared with" control is hidden when there's no owning team).

A shared-with team is always *additional* to an owning team, so a project with no owning team cannot retain shares.

## Changes

- **Server** (`convex/projects/access.ts`, `mutations.ts`): new pure `normalizeSharing()` helper, applied in `updateProjectSharing` so an effective owning team of `null` clears `sharedWithTeamIds`. Authoritative backstop regardless of caller (also cleans legacy orphaned rows on next save).
- **Client** (`project-sharing-section.tsx`): `handleOwningTeamChange` now clears the shared list when the owning team becomes Org-wide, instead of `filter(id => id !== null)` which never matched.
- **Tests** (`access.test.ts`): unit coverage for `normalizeSharing`, including that the result is genuinely org-wide per `isOrgWideProject`/`getProjectTeamIds`.

## Verification

- `vitest --project server convex/projects/` — 38 passed
- `tsc --noEmit` — exit 0
- `oxlint --type-aware` on changed files — 0 warnings/errors

Closes #2046