### PR TITLE
fix: localize backend status enums and trash relative time (#2052)

### DIFF
--- a/services/platform/app/features/automations/executions/executions-table.test.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { render, screen, within } from '@/tests/utils/render';
 
 import { ExecutionsTable } from './executions-table';
 
@@ -29,10 +29,15 @@ vi.mock('../hooks/queries', () => ({
   useSearchExecution: () => ({ data: undefined }),
 }));
 
+// The page reads its rows through `useListPage`. The default is an empty table;
+// individual tests reassign `mockTableData` to a stable array to drive the
+// status column. Keep the reference stable across re-renders (a fresh array per
+// render would retrigger the table's row-diff effect).
+let mockTableData: unknown[] = [];
 vi.mock('@/app/hooks/use-list-page', () => ({
   useListPage: () => ({
     tableProps: {
-      data: [],
+      data: mockTableData,
       search: { value: '', onChange: vi.fn(), placeholder: 'Search...' },
       filters: [],
       onClearFilters: vi.fn(),
@@ -40,9 +45,22 @@ vi.mock('@/app/hooks/use-list-page', () => ({
   }),
 }));
 
+// Minimal `Doc<'wfExecutions'>` shape the columns read.
+function executionRow(id: string, status: string) {
+  return {
+    _id: id,
+    _creationTime: 0,
+    status,
+    startedAt: 1_700_000_000_000,
+    completedAt: 1_700_000_001_000,
+    triggeredBy: 'manual',
+  };
+}
+
 describe('ExecutionsTable', () => {
   describe('accessibility', () => {
     it('passes axe audit', async () => {
+      mockTableData = [];
       const { container } = render(
         <ExecutionsTable amId="am-1" organizationId="test-org-id" />,
       );
@@ -52,6 +70,35 @@ describe('ExecutionsTable', () => {
           'empty-table-header': { enabled: false },
         },
       });
+    });
+  });
+
+  // Regression for #2052 [93]: the status badge used to render the raw backend
+  // enum (e.g. `completed`, `waiting_for_input`) instead of the localized
+  // label. The cell now maps snake_case statuses to the camelCase
+  // `common.status.*` keys and falls back to the raw value for unknown statuses.
+  describe('status badge localization', () => {
+    it('renders localized labels and falls back to the raw value', () => {
+      mockTableData = [
+        executionRow('exec-completed', 'completed'),
+        executionRow('exec-waiting', 'waiting_for_input'),
+        executionRow('exec-paused', 'paused_debug'),
+        executionRow('exec-unknown', 'mystery_state'),
+      ];
+
+      render(<ExecutionsTable amId="am-1" organizationId="test-org-id" />);
+
+      const table = screen.getByRole('table');
+      // Base status -> translated label.
+      expect(within(table).getByText('Completed')).toBeInTheDocument();
+      // snake_case -> camelCase key -> translated label.
+      expect(within(table).getByText('Waiting for input')).toBeInTheDocument();
+      expect(within(table).getByText('Paused (debug)')).toBeInTheDocument();
+      // Unknown status has no key -> raw value rendered, no key leak.
+      expect(within(table).getByText('mystery_state')).toBeInTheDocument();
+      expect(
+        within(table).queryByText('status.mysteryState'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -176,17 +176,19 @@ export function ExecutionsTable({
             ? 'paused_debug'
             : 'waiting_for_input'
           : statusVal;
+      // Map snake_case backend statuses (waiting_for_input, paused_debug) to
+      // the camelCase common.status.* keys; fall back to the raw value for any
+      // status without a translation.
+      const statusKey = displayStatus.replace(/_([a-z])/g, (_match, char) =>
+        char.toUpperCase(),
+      );
       return (
         <Badge
           dot
           variant={STATUS_BADGE_VARIANTS[displayStatus] || 'outline'}
-          className="text-xs capitalize"
+          className="text-xs"
         >
-          {displayStatus === 'waiting_for_input'
-            ? tCommon('status.waitingForInput')
-            : displayStatus === 'paused_debug'
-              ? tCommon('status.pausedDebug')
-              : statusVal}
+          {tCommon(`status.${statusKey}`, { defaultValue: displayStatus })}
         </Badge>
       );
     },

--- a/services/platform/app/features/products/components/product-status-badge.tsx
+++ b/services/platform/app/features/products/components/product-status-badge.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Badge } from '@tale/ui/badge';
+
+import { useT } from '@/lib/i18n/client';
+
+interface ProductStatusBadgeProps {
+  status: string;
+  className?: string;
+}
+
+/**
+ * Renders a product status as a localized badge. Maps the stored backend value
+ * through the shared `common.status.<key>` keys and falls back to the raw value
+ * for any status without a translation.
+ */
+export function ProductStatusBadge({
+  status,
+  className,
+}: ProductStatusBadgeProps) {
+  const { t: tCommon } = useT('common');
+  return (
+    <Badge
+      variant={status === 'active' ? 'blue' : 'outline'}
+      className={className}
+    >
+      {tCommon(`status.${status}`, { defaultValue: status })}
+    </Badge>
+  );
+}

--- a/services/platform/app/features/products/components/product-view-dialog.tsx
+++ b/services/platform/app/features/products/components/product-view-dialog.tsx
@@ -15,6 +15,7 @@ import { useT } from '@/lib/i18n/client';
 import { formatCurrency } from '@/lib/utils/format/number';
 
 import { ProductImage } from './product-image';
+import { ProductStatusBadge } from './product-status-badge';
 
 interface ViewProductDialogProps {
   isOpen: boolean;
@@ -125,12 +126,7 @@ export function ProductViewDialog({
               </Text>
             )}
             {product.status && (
-              <Badge
-                variant={product.status === 'active' ? 'blue' : 'outline'}
-                className="mt-2 capitalize"
-              >
-                {product.status}
-              </Badge>
+              <ProductStatusBadge status={product.status} className="mt-2" />
             )}
           </div>
         </HStack>

--- a/services/platform/app/features/products/components/products-crud.test.tsx
+++ b/services/platform/app/features/products/components/products-crud.test.tsx
@@ -68,6 +68,7 @@ vi.mock('@/app/hooks/use-toast', () => ({
 
 import { ProductCreateDialog } from './product-create-dialog';
 import { ProductRowActions } from './product-row-actions';
+import { ProductStatusBadge } from './product-status-badge';
 
 // Doc<'products'> shape the row/edit dialog reads. Cast the branded Id via
 // `unknown` so the fixture stays a plain object.
@@ -191,5 +192,46 @@ describe('Product row actions: delete', () => {
 
     expect(mockDeleteAsync).toHaveBeenCalledTimes(1);
     expect(mockDeleteAsync).toHaveBeenCalledWith({ productId: 'product-1' });
+  });
+});
+
+// Regression for #2052 [71]: the products table Status column and the view
+// dialog used to render the raw backend enum (`active`, `draft`, …) with a
+// `capitalize` class. The shared badge now resolves the value through the
+// `common.status.<key>` keys and falls back to the raw value for unknown ones.
+describe('ProductStatusBadge', () => {
+  describe('accessibility', () => {
+    it('passes axe audit', async () => {
+      const { container } = render(<ProductStatusBadge status="active" />);
+      await checkAccessibility(container);
+    });
+  });
+
+  it('renders the localized label with the blue variant for active', () => {
+    render(<ProductStatusBadge status="active" />);
+
+    const badge = screen.getByText('Active');
+    expect(badge).toBeInTheDocument();
+    // `active` -> `blue` variant.
+    expect(badge.closest('[title="Active"]')).toHaveClass('bg-blue-100');
+  });
+
+  it('renders the localized label with the outline variant for a non-active status', () => {
+    render(<ProductStatusBadge status="draft" />);
+
+    const badge = screen.getByText('Draft');
+    expect(badge).toBeInTheDocument();
+    const wrapper = badge.closest('[title="Draft"]');
+    // Non-active -> default `outline` variant, not the blue active style.
+    expect(wrapper).toHaveClass('border');
+    expect(wrapper).not.toHaveClass('bg-blue-100');
+  });
+
+  it('falls back to the raw value for an unknown status', () => {
+    render(<ProductStatusBadge status="mystery" />);
+
+    // No translation key -> raw value rendered, no `status.*` key leak.
+    expect(screen.getByText('mystery')).toBeInTheDocument();
+    expect(screen.queryByText('status.mystery')).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/products/hooks/use-products-table-config.tsx
+++ b/services/platform/app/features/products/hooks/use-products-table-config.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Badge } from '@tale/ui/badge';
 import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 
@@ -10,6 +9,7 @@ import { formatCurrency } from '@/lib/utils/format/number';
 
 import { ProductImage } from '../components/product-image';
 import { ProductRowActions } from '../components/product-row-actions';
+import { ProductStatusBadge } from '../components/product-status-badge';
 
 export type Product = Doc<'products'>;
 
@@ -94,11 +94,7 @@ export const useProductsTableConfig = createTableConfigHook<'products'>(
       size: 110,
       cell: ({ row }) =>
         row.original.status ? (
-          <Badge
-            variant={row.original.status === 'active' ? 'blue' : 'outline'}
-          >
-            {row.original.status}
-          </Badge>
+          <ProductStatusBadge status={row.original.status} />
         ) : (
           <Text as="span" variant="caption" className="text-muted-foreground">
             -

--- a/services/platform/app/features/settings/governance/components/trash-page.test.tsx
+++ b/services/platform/app/features/settings/governance/components/trash-page.test.tsx
@@ -46,6 +46,18 @@ vi.mock('@/app/hooks/use-ability', () => ({
   useAbilityLoading: () => false,
 }));
 
+// The "Trashed" column renders via the shared, locale-aware <TableDateCell>.
+// Stub the date hook so the relative output is deterministic (mirrors the
+// sibling table-date-cell test).
+vi.mock('@/app/hooks/use-format-date', () => ({
+  useFormatDate: () => ({
+    formatDate: (_date: unknown, preset?: string) =>
+      preset === 'relative' ? '5 minutes ago' : 'Jan 1, 2025',
+    locale: 'en',
+    timezone: 'UTC',
+  }),
+}));
+
 const HEADING = 'Trash';
 const EMPTY_NOTICE =
   'Nothing in the trash. Retention will move expired rows here once their grace window starts.';
@@ -115,5 +127,46 @@ describe('TrashPage', () => {
 
     // The empty notice must NOT show once rows exist.
     expect(screen.queryByText(EMPTY_NOTICE)).not.toBeInTheDocument();
+  });
+
+  // Regression for #2052 [110]: the "Trashed" column used a local
+  // hardcoded-English `formatRelative()` helper. It now renders through the
+  // shared, locale-aware <TableDateCell preset="relative" />.
+  it('renders the locale-aware relative time, with an em-dash fallback for a missing date', () => {
+    mockListTrashedRows.mockReturnValue({
+      data: {
+        rows: [
+          {
+            resourceType: 'document' as const,
+            id: 'row-dated',
+            status: 'trashed' as const,
+            statusChangedAt: 1_700_000_000_000,
+            createdAt: 1_700_000_000_000,
+            displayName: 'Quarterly report',
+            ownerId: 'user-1',
+            ownerName: 'Ada Lovelace',
+          },
+          {
+            resourceType: 'document' as const,
+            id: 'row-undated',
+            status: 'trashed' as const,
+            statusChangedAt: null,
+            createdAt: null,
+            displayName: 'Orphan draft',
+            ownerId: 'user-2',
+            ownerName: 'Grace Hopper',
+          },
+        ],
+        nextCursor: null,
+      },
+      isLoading: false,
+    });
+
+    render(<TrashPage organizationId="org-1" />);
+
+    // Locale-aware relative output (from the shared cell), not raw English.
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+    // Null date -> the shared cell's em-dash fallback (no NaN/crash).
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/settings/governance/components/trash-page.tsx
+++ b/services/platform/app/features/settings/governance/components/trash-page.tsx
@@ -17,6 +17,7 @@ import { Undo2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
+import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
 import {
   DataTableFilters,
   type FilterConfig,
@@ -333,9 +334,11 @@ export function TrashPage({ organizationId }: Props) {
                             </span>
                           </TableCell>
                           <TableCell className="text-muted-foreground text-xs">
-                            {formatRelative(
-                              row.statusChangedAt ?? row.createdAt,
-                            )}
+                            <TableDateCell
+                              date={row.statusChangedAt ?? row.createdAt}
+                              preset="relative"
+                              className="text-xs"
+                            />
                           </TableCell>
                           <TableCell className="text-right">
                             <Button
@@ -439,15 +442,4 @@ export function TrashPage({ organizationId }: Props) {
       </ConfirmDialog>
     </>
   );
-}
-
-function formatRelative(ms: number): string {
-  const elapsedMs = Date.now() - ms;
-  if (elapsedMs < 60_000) return 'just now';
-  const days = Math.floor(elapsedMs / 86_400_000);
-  if (days >= 1) return `${days}d ago`;
-  const hours = Math.floor(elapsedMs / 3_600_000);
-  if (hours >= 1) return `${hours}h ago`;
-  const minutes = Math.floor(elapsedMs / 60_000);
-  return `${minutes}m ago`;
 }


### PR DESCRIPTION
## Summary

Fixes three surfaces that rendered raw English instead of the active locale, even though i18n keys / a shared helper already existed.

- **[71] Product status** — `product-view-dialog.tsx` and the products table status column rendered the raw backend enum (`active`, `draft`, …) with a `capitalize` class. Extracted a shared `ProductStatusBadge` that maps the value through `tCommon('status.<key>')` with a raw-value fallback for unknown statuses; dropped `capitalize`.
- **[93] Execution status** — `executions-table.tsx` `getStatusBadge` rendered the untranslated `statusVal` for `running`/`completed`/`failed`/`pending`. Now maps snake_case backend statuses to the camelCase `common.status.*` keys (`waiting_for_input` → `waitingForInput`, `paused_debug` → `pausedDebug`) and translates via `tCommon` with a fallback; dropped `capitalize`.
- **[110] Governance Trash relative time** — replaced the hardcoded-English local `formatRelative()` helper with the shared i18n-aware `<TableDateCell preset="relative" />` (locale-aware via dayjs `fromNow`) and deleted the dead helper.

## Verification

- `bunx tsc --noEmit` — passes
- `bunx oxlint --type-aware` on changed files — 0 warnings, 0 errors
- UI tests: `executions-table`, `trash-page`, `products-crud` — all pass

Closes #2052