### PR TITLE
fix: add Performance/metrics tab to loaded agent-editor nav (#1990)

### DIFF
--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -219,6 +219,14 @@ export function AgentNavigation({
       dirtyKeys: AGENT_TAB_DIRTY_KEYS.delegation,
     },
     {
+      // Read-only performance scorecard — no editable config, so no dirtyKeys.
+      // Mirrors the loading skeleton's nav (which already lists it) so the tab
+      // doesn't flicker out once the editor loads.
+      label: t('agents.navigation.metrics'),
+      href: `${basePath}/metrics`,
+      matchMode: 'exact',
+    },
+    {
       label: t('agents.navigation.conversationStarters'),
       href: `${basePath}/conversation-starters`,
       matchMode: 'exact',


### PR DESCRIPTION
## Summary

The per-agent Performance (metrics) sub-page (`/dashboard/{org}/agents/{agentId}/metrics`) renders a full scorecard and appears in the editor's loading **skeleton** nav, but the **loaded** `AgentNavigation` omitted it. The tab flickered in during load then vanished, leaving the route reachable only by typing the URL — a dead end with no nav item linking back.

## Fix

Added the `agents.navigation.metrics` ("Performance") item to `AgentNavigation.navigationItems`, positioned between **Delegation** and **Conversation starters** to mirror the skeleton's order. The tab is a read-only scorecard with no editable config, so it carries no `dirtyKeys` (matching the optional-`dirtyKeys` contract on `TabNavigationItem`).

## Verification
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` on the changed file — 0 warnings/errors
- `agent-navigation.test.tsx` (a11y audit) — passes

Closes #1990