### PR TITLE
fix: gate destructive surfaces on developerSettings capability (#2042)

### DIFF
--- a/services/platform/convex/agents/file_actions.test.ts
+++ b/services/platform/convex/agents/file_actions.test.ts
@@ -210,6 +210,31 @@ describe('deleteAgent', () => {
     ).rejects.toThrow('Authentication required.');
   });
 
+  it('rejects a plain member lacking the developerSettings capability', async () => {
+    // deleteAgent now gates on `developerSettings` (requireOrgAdminOrDeveloper),
+    // matching create/duplicate/save. The real gate runs on top of the mocked
+    // membership helper, so a `member` role must be rejected before any deletion.
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'member' },
+    });
+    const ctx = createMockCtx();
+
+    await expect(
+      deleteHandler(
+        ctx as never,
+        { organizationId: 'org-123', agentName: 'my-agent' } as never,
+      ),
+    ).rejects.toMatchObject({
+      data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+    });
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
   it('ignores ENOENT from unlink (file already absent)', async () => {
     const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     mockUnlink.mockRejectedValue(enoent);

--- a/services/platform/convex/agents/file_actions.test.ts
+++ b/services/platform/convex/agents/file_actions.test.ts
@@ -70,6 +70,8 @@ vi.mock('../lib/file_io', () => ({
   generateHistoryTimestamp: () => '1234567890-abcdef01',
   pruneHistory: vi.fn(),
   serializeJson: (data: object) => JSON.stringify(data, null, 2) + '\n',
+  validateTimestamp: () => true,
+  safeJoinWithinDir: (dir: string, name: string) => `${dir}/${name}`,
 }));
 
 vi.mock('./file_utils', async () => {
@@ -116,7 +118,8 @@ vi.mock('../../lib/shared/schemas/agents', () => ({
 // Import handlers
 // ---------------------------------------------------------------------------
 
-const { deleteAgent, duplicateAgent } = await import('./file_actions');
+const { deleteAgent, duplicateAgent, restoreFromHistory } =
+  await import('./file_actions');
 
 type ActionConfig = {
   handler: (ctx: never, args: never) => Promise<unknown>;
@@ -124,6 +127,7 @@ type ActionConfig = {
 
 const deleteHandler = (deleteAgent as unknown as ActionConfig).handler;
 const duplicateHandler = (duplicateAgent as unknown as ActionConfig).handler;
+const restoreHandler = (restoreFromHistory as unknown as ActionConfig).handler;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -395,5 +399,169 @@ describe('duplicateAgent', () => {
         { organizationId: 'org_test', agentName: 'my-agent' } as never,
       ),
     ).rejects.toThrow('Disk full');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: restoreFromHistory
+// ---------------------------------------------------------------------------
+
+describe('restoreFromHistory', () => {
+  // History snapshot path contains `.history`; the live agent path does not.
+  // Route readFileSafe by which one is requested so each test can vary the
+  // snapshot's capability fields independently of the current config.
+  function mockHistoryAndCurrent(historyConfig: object, currentConfig: object) {
+    mockReadFileSafe.mockImplementation(async (p: string) =>
+      p.includes('.history')
+        ? JSON.stringify(historyConfig)
+        : JSON.stringify(currentConfig),
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthUser.mockResolvedValue({
+      _id: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+    });
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'admin' },
+    });
+    mockAtomicWrite.mockResolvedValue(undefined);
+    mockMkdir.mockResolvedValue(undefined);
+  });
+
+  it('rejects a plain member when the restore changes capability fields', async () => {
+    // The snapshot re-grants a skillBinding the current config lacks — a
+    // capability change that must require the developerSettings gate, even
+    // though the public action only resolves plain membership directly.
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'member' },
+    });
+    mockHistoryAndCurrent(
+      { ...validConfig, skillBindings: ['secret-skill'] },
+      { ...validConfig, skillBindings: [] },
+    );
+    const ctx = createMockCtx();
+
+    await expect(
+      restoreHandler(
+        ctx as never,
+        {
+          organizationId: 'org-123',
+          agentName: 'my-agent',
+          timestamp: '1234567890-abcdef01',
+        } as never,
+      ),
+    ).rejects.toMatchObject({
+      data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+    });
+    expect(mockAtomicWrite).not.toHaveBeenCalled();
+  });
+
+  it('allows a developer to restore a capability-changing snapshot', async () => {
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'developer' },
+    });
+    mockHistoryAndCurrent(
+      { ...validConfig, skillBindings: ['secret-skill'] },
+      { ...validConfig, skillBindings: [] },
+    );
+    const ctx = createMockCtx();
+
+    await restoreHandler(
+      ctx as never,
+      {
+        organizationId: 'org-123',
+        agentName: 'my-agent',
+        timestamp: '1234567890-abcdef01',
+      } as never,
+    );
+
+    expect(mockAtomicWrite).toHaveBeenCalledWith(
+      '/data/agents/my-agent.json',
+      expect.stringContaining('secret-skill'),
+    );
+  });
+
+  it('allows a plain member to restore a non-capability change', async () => {
+    // Only the description differs; capability fields are identical, so the
+    // restore is allowed for a plain member — mirroring saveAgent, where
+    // members may edit non-capability fields.
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'member' },
+    });
+    mockHistoryAndCurrent(
+      { ...validConfig, description: 'old description' },
+      { ...validConfig, description: 'new description' },
+    );
+    const ctx = createMockCtx();
+
+    await restoreHandler(
+      ctx as never,
+      {
+        organizationId: 'org-123',
+        agentName: 'my-agent',
+        timestamp: '1234567890-abcdef01',
+      } as never,
+    );
+
+    expect(mockAtomicWrite).toHaveBeenCalledWith(
+      '/data/agents/my-agent.json',
+      expect.stringContaining('old description'),
+    );
+  });
+
+  it('fails closed (requires the capability) when the current config is unreadable', async () => {
+    // No current content means we cannot prove the snapshot leaves capability
+    // grants unchanged, so the gate must require the developerSettings
+    // capability and reject a plain member.
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'member' },
+    });
+    mockReadFileSafe.mockImplementation(async (p: string) =>
+      p.includes('.history') ? JSON.stringify(validConfig) : null,
+    );
+    const ctx = createMockCtx();
+
+    await expect(
+      restoreHandler(
+        ctx as never,
+        {
+          organizationId: 'org-123',
+          agentName: 'my-agent',
+          timestamp: '1234567890-abcdef01',
+        } as never,
+      ),
+    ).rejects.toMatchObject({
+      data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+    });
+    expect(mockAtomicWrite).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -164,6 +164,49 @@ function captureCapability(
   };
 }
 
+/**
+ * Capability snapshot of a serialized agent config, or `undefined` when the
+ * content can't be parsed under the current schema. The `undefined` return is
+ * meaningful at the call site: a caller deciding whether a restore changes
+ * capability grants must fail closed (require the developer-settings gate) when
+ * it can't prove the snapshot leaves capability fields unchanged.
+ */
+function capabilityCaptureFromContent(
+  content: string,
+): Record<string, unknown> | undefined {
+  try {
+    return captureCapability(parseAgentJson(content));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Structural equality for two capability captures. String arrays are compared
+ * as sets (order-insensitive) and object keys are sorted, mirroring
+ * `saveAgent`'s `arrayEq` so a pure reordering isn't treated as a grant change.
+ */
+function capabilityCapturesEqual(
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown> | undefined,
+): boolean {
+  const canonical = (value: unknown): string =>
+    JSON.stringify(value, (_key, val: unknown) => {
+      if (Array.isArray(val) && val.every((item) => typeof item === 'string')) {
+        return [...val].sort();
+      }
+      if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+        return Object.fromEntries(
+          Object.entries(val).sort(([keyA], [keyB]) =>
+            keyA < keyB ? -1 : keyA > keyB ? 1 : 0,
+          ),
+        );
+      }
+      return val;
+    });
+  return canonical(a ?? {}) === canonical(b ?? {});
+}
+
 // ---------------------------------------------------------------------------
 // Public actions (called from frontend)
 // ---------------------------------------------------------------------------
@@ -1033,8 +1076,8 @@ export const restoreFromHistory = action({
   },
   returns: v.object({ hash: v.string() }),
   handler: async (ctx, args): Promise<{ hash: string }> => {
-    const auth = await requireOrgMembershipById(ctx, args.organizationId);
-    const { orgSlug } = auth;
+    const memberAuth = await requireOrgMembershipById(ctx, args.organizationId);
+    const { orgSlug } = memberAuth;
     if (!validateTimestamp(args.timestamp)) {
       throw new Error('Invalid timestamp');
     }
@@ -1066,6 +1109,31 @@ export const restoreFromHistory = action({
 
     // Snapshot current state before overwriting
     const currentContent = await readFileSafe(agentPath);
+
+    // Capability-change gate (mirrors `saveAgent` at :537). A restore is a
+    // wholesale overwrite of the live config with an arbitrary historical
+    // snapshot — including the capability fields (`toolNames`,
+    // `integrationBindings`, `workflows`, `skillBindings`, `budget`,
+    // `maxConcurrentTasks`, `runtime`, delegation edges) that `saveAgent`
+    // only lets admin/developer roles change. Without this gate a plain
+    // `member` could re-grant a binding a developer had revoked simply by
+    // restoring an older snapshot, laundering a capability change past the
+    // `developerSettings` gate. Only require the elevated capability when the
+    // restore actually alters those fields, matching `saveAgent`'s semantics
+    // (members may still restore description/instruction-only changes). Fail
+    // closed: if the current config or the snapshot can't be parsed we cannot
+    // prove the grants are unchanged, so require the capability.
+    const restoredCapability = capabilityCaptureFromContent(historyContent);
+    const currentCapability = currentContent
+      ? capabilityCaptureFromContent(currentContent)
+      : undefined;
+    const isCapabilityChange =
+      restoredCapability === undefined ||
+      currentCapability === undefined ||
+      !capabilityCapturesEqual(currentCapability, restoredCapability);
+    const auth = isCapabilityChange
+      ? await requireOrgAdminOrDeveloper(ctx, args.organizationId)
+      : memberAuth;
 
     // Write the restored version
     await atomicWrite(agentPath, historyContent);

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -876,7 +876,14 @@ export const deleteAgent = action({
       throw new Error(`Agent '${args.agentName}' cannot be deleted`);
     }
 
-    const auth = await requireOrgMembershipById(ctx, args.organizationId);
+    // Deleting a custom agent destroys it and its full history, and can carry
+    // away skill-laundered grants — strictly more destructive than the
+    // create/duplicate/save paths, all of which gate on `developerSettings`
+    // (see :764 duplicateAgent, :537 saveAgent). A plain `member` is hidden
+    // from the matching UI by `cannot('read','developerSettings')` but could
+    // previously call this action directly via the Convex client. Gate it on
+    // the same capability so action-layer auth matches route-layer auth.
+    const auth = await requireOrgAdminOrDeveloper(ctx, args.organizationId);
     const { orgSlug } = auth;
     const filePath = await resolveAgentPath(orgSlug, args.agentName);
     const historyDir = resolveHistoryDir(orgSlug, args.agentName);

--- a/services/platform/convex/apps/install_actions.test.ts
+++ b/services/platform/convex/apps/install_actions.test.ts
@@ -1,0 +1,107 @@
+import { ConvexError } from 'convex/values';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// install/reinstall (via `prepareInstall`) and `uninstallApp` are gated on the
+// `developerSettings` capability. The gate lives in providers/auth (a node
+// helper that issues Better Auth adapter queries), so it is mocked here; each
+// test asserts the gate fires BEFORE any resource provisioning/teardown — a
+// plain member is rejected with FORBIDDEN_DEVELOPER_SETTINGS and no mutation
+// runs.
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+  internalAction: vi.fn((config) => config),
+  internalMutation: vi.fn((config) => config),
+  internalQuery: vi.fn((config) => config),
+  mutation: vi.fn((config) => config),
+  query: vi.fn((config) => config),
+}));
+
+vi.mock('../_generated/api', () => ({
+  internal: {
+    apps: {
+      install_mutations: {
+        upsertAppInstallation: 'upsertAppInstallation',
+        bindAppToProject: 'bindAppToProject',
+      },
+    },
+  },
+}));
+
+const mockRequireDeveloperSettingsAccessById = vi.fn();
+vi.mock('../providers/auth', () => ({
+  requireDeveloperSettingsAccessById: (...args: unknown[]) =>
+    mockRequireDeveloperSettingsAccessById(...args),
+}));
+
+const { installApp, reinstallApp, uninstallApp } =
+  await import('./install_actions');
+
+type ActionConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+
+const installHandler = (installApp as unknown as ActionConfig).handler;
+const reinstallHandler = (reinstallApp as unknown as ActionConfig).handler;
+const uninstallHandler = (uninstallApp as unknown as ActionConfig).handler;
+
+const FORBIDDEN = new ConvexError({
+  code: 'FORBIDDEN_DEVELOPER_SETTINGS',
+  message: 'Role "member" lacks the developer-settings capability.',
+});
+
+function createMockCtx() {
+  return {
+    runMutation: vi.fn().mockResolvedValue(undefined),
+    runQuery: vi.fn().mockResolvedValue(null),
+  };
+}
+
+describe('apps/install_actions capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+  });
+
+  it('installApp rejects a plain member before provisioning resources', async () => {
+    const ctx = createMockCtx();
+    await expect(
+      installHandler(
+        ctx as never,
+        { organizationId: 'org-123', appSlug: 'support' } as never,
+      ),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' } });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('reinstallApp rejects a plain member before re-syncing resources', async () => {
+    const ctx = createMockCtx();
+    await expect(
+      reinstallHandler(
+        ctx as never,
+        { organizationId: 'org-123', appSlug: 'support' } as never,
+      ),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' } });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('uninstallApp rejects a plain member before tearing down resources', async () => {
+    const ctx = createMockCtx();
+    await expect(
+      uninstallHandler(
+        ctx as never,
+        { organizationId: 'org-123', appSlug: 'support' } as never,
+      ),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' } });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/apps/install_actions.ts
+++ b/services/platform/convex/apps/install_actions.ts
@@ -26,6 +26,7 @@ import {
 } from '../agents/file_utils';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
 import { sha256 } from '../lib/file_io';
+import { requireDeveloperSettingsAccessById } from '../providers/auth';
 import {
   resolveWorkflowFilePath,
   resolveWorkflowsDir,
@@ -154,7 +155,12 @@ async function prepareInstall(
   organizationId: string,
   appSlug: string,
 ): Promise<InstallContext> {
-  const { orgSlug, userId, email } = await requireOrgMembershipById(
+  // Install/reinstall (re)register an app's agents, workflows and triggers —
+  // capability-bearing surfaces that, elsewhere, only `developerSettings` roles
+  // may create or edit. A plain `member` is hidden from the install UI by
+  // `cannot('read','developerSettings')` but could previously drive this lifecycle
+  // directly via the Convex client. Gate it on the same capability.
+  const { orgSlug, userId, email } = await requireDeveloperSettingsAccessById(
     ctx,
     organizationId,
   );
@@ -174,7 +180,9 @@ async function prepareInstall(
       `Cannot install app "${appSlug}": a global workflow folder of the same name exists and would be shadowed.`,
     );
   }
-  const installedBy = email !== '' ? email : userId;
+  // `requireDeveloperSettingsAccessById` types `email` as optional, so treat an
+  // empty OR absent email as "no email" and fall back to the user id.
+  const installedBy = email ? email : userId;
   const manifest = await readAppBundleManifest(appSlug);
   return { orgSlug, installedBy, manifest };
 }
@@ -349,7 +357,12 @@ export const uninstallApp = action({
   args: { organizationId: v.string(), appSlug: v.string() },
   returns: v.object({ ok: v.boolean() }),
   handler: async (ctx, args): Promise<{ ok: boolean }> => {
-    const { orgSlug } = await requireOrgMembershipById(
+    // Uninstall is the most destructive app path: it tears down the app's
+    // agents, their workflows, and ALL of their env/secrets. A member blocked
+    // from disabling a single app-owned agent could otherwise wipe the whole
+    // app by uninstalling it, so this must carry at least the same
+    // `developerSettings` gate as the per-agent capability edits it bypasses.
+    const { orgSlug } = await requireDeveloperSettingsAccessById(
       ctx,
       args.organizationId,
     );

--- a/services/platform/convex/integrations/credential_mutations.test.ts
+++ b/services/platform/convex/integrations/credential_mutations.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// These tests exercise the REAL `requireOrgAdminOrDeveloper` capability gate on
+// top of a mocked membership primitive (the same strategy as
+// agents/file_actions.test.ts): the inner `requireOrgMembershipById` is mocked
+// to return a chosen role, and the real CASL `developerSettings` check decides
+// whether the mutation is allowed. A plain `member` must be rejected with
+// FORBIDDEN_DEVELOPER_SETTINGS before any credential delete/patch.
+// ---------------------------------------------------------------------------
+
+vi.mock('../_generated/server', () => ({
+  mutation: vi.fn((config) => config),
+  internalMutation: vi.fn((config) => config),
+}));
+
+vi.mock('../_generated/api', () => ({
+  internal: {
+    integrations: {
+      bundle_provision: {
+        provisionIntegrationBundle: 'provisionIntegrationBundle',
+      },
+      cascade: { cascadeIntegration: 'cascadeIntegration' },
+    },
+  },
+}));
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+const mockRequireOrgMembershipById = vi.fn();
+vi.mock('../lib/auth/require_org_membership', () => ({
+  requireOrgMembershipById: (...args: unknown[]) =>
+    mockRequireOrgMembershipById(...args),
+}));
+
+vi.mock('../audit_logs/helpers', () => ({
+  logSuccess: vi.fn().mockResolvedValue(undefined),
+  redactSensitiveFields: (x: unknown) => x,
+}));
+
+vi.mock('./slack_installations', () => ({
+  deleteSlackInstallationsForCredential: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { updateCredentials, deleteCredentials } =
+  await import('./credential_mutations');
+
+type MutationConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+
+const updateHandler = (updateCredentials as unknown as MutationConfig).handler;
+const deleteHandler = (deleteCredentials as unknown as MutationConfig).handler;
+
+function createMockCtx() {
+  return {
+    db: {
+      get: vi.fn().mockResolvedValue({
+        _id: 'cred-1',
+        organizationId: 'org-123',
+        slug: 'slack',
+        status: 'active',
+        isActive: true,
+        authMethod: 'apiKey',
+      }),
+      patch: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+    storage: { delete: vi.fn().mockResolvedValue(undefined) },
+    scheduler: { runAfter: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+describe('credential mutations capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthUserIdentity.mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+    });
+  });
+
+  function asMember() {
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      member: { _id: 'm-1', role: 'member' },
+    });
+  }
+
+  function asDeveloper() {
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      member: { _id: 'm-1', role: 'developer' },
+    });
+  }
+
+  describe('deleteCredentials', () => {
+    it('rejects a plain member and deletes nothing', async () => {
+      asMember();
+      const ctx = createMockCtx();
+
+      await expect(
+        deleteHandler(ctx as never, { credentialId: 'cred-1' } as never),
+      ).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+      });
+      expect(ctx.db.delete).not.toHaveBeenCalled();
+    });
+
+    it('allows a developer to delete the credential', async () => {
+      asDeveloper();
+      const ctx = createMockCtx();
+
+      await deleteHandler(ctx as never, { credentialId: 'cred-1' } as never);
+
+      expect(ctx.db.delete).toHaveBeenCalledWith('cred-1');
+    });
+  });
+
+  describe('updateCredentials', () => {
+    it('rejects a plain member and patches nothing', async () => {
+      asMember();
+      const ctx = createMockCtx();
+
+      await expect(
+        updateHandler(
+          ctx as never,
+          { credentialId: 'cred-1', status: 'inactive' } as never,
+        ),
+      ).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+      });
+      expect(ctx.db.patch).not.toHaveBeenCalled();
+    });
+
+    it('allows a developer to update the credential', async () => {
+      asDeveloper();
+      const ctx = createMockCtx();
+
+      await updateHandler(
+        ctx as never,
+        { credentialId: 'cred-1', errorMessage: 'x' } as never,
+      );
+
+      expect(ctx.db.patch).toHaveBeenCalled();
+    });
+  });
+});

--- a/services/platform/convex/integrations/credential_mutations.ts
+++ b/services/platform/convex/integrations/credential_mutations.ts
@@ -7,8 +7,8 @@ import {
   mutation,
 } from '../_generated/server';
 import * as AuditLogHelpers from '../audit_logs/helpers';
+import { requireOrgAdminOrDeveloper } from '../lib/auth/require_org_admin_or_developer';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
-import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { jsonRecordValidator } from '../lib/validators/json';
 import { deleteSlackInstallationsForCredential } from './slack_installations';
 import {
@@ -130,10 +130,15 @@ export const updateCredentials = mutation({
     const cred = await ctx.db.get(args.credentialId);
     if (!cred) throw new Error('Credential record not found');
 
-    const member = await getOrganizationMember(
+    // Connecting/disconnecting an integration installs or cascade-disables its
+    // bundled agents/workflows and writes its stored credentials — the same
+    // capability-bearing surface the providers/skills paths gate on. A plain
+    // `member` is hidden from the integrations UI by
+    // `cannot('read','developerSettings')` but could previously call this
+    // mutation directly via the Convex client; require the capability here too.
+    const { member } = await requireOrgAdminOrDeveloper(
       ctx,
       cred.organizationId,
-      authUser,
     );
 
     const { credentialId, ...updates } = args;
@@ -207,10 +212,13 @@ export const deleteCredentials = mutation({
     const cred = await ctx.db.get(args.credentialId);
     if (!cred) throw new Error('Credential record not found');
 
-    const member = await getOrganizationMember(
+    // Deleting a credential disconnects the integration and cascade-disables
+    // its bundled + hard-requiring agents — strictly destructive. Gate on the
+    // `developerSettings` capability, matching the providers/skills pattern,
+    // rather than admitting any non-disabled member.
+    const { member } = await requireOrgAdminOrDeveloper(
       ctx,
       cred.organizationId,
-      authUser,
     );
 
     if (cred.iconStorageId) {

--- a/services/platform/convex/integrations/credential_queries.test.ts
+++ b/services/platform/convex/integrations/credential_queries.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// `verifyCredentialAccess` backs the destructive `'use node'` credential actions
+// (saveCredentials, testConnection, generateOAuth2Url,
+// saveOAuth2ClientCredentials). It must return the credential ONLY for callers
+// holding the `developerSettings` capability and `null` otherwise. These tests
+// run the REAL `defineAbilityFor` check against member rows returned from a
+// mocked Better Auth adapter query.
+// ---------------------------------------------------------------------------
+
+vi.mock('../_generated/server', () => ({
+  query: vi.fn((config) => config),
+  internalQuery: vi.fn((config) => config),
+}));
+
+vi.mock('../_generated/api', () => ({
+  components: {
+    betterAuth: { adapter: { findMany: 'findMany' } },
+  },
+}));
+
+vi.mock('../lib/rls', () => ({
+  getAuthUserIdentity: vi.fn(),
+  getOrganizationMember: vi.fn(),
+}));
+
+vi.mock('../lib/rls/errors', () => ({
+  UnauthorizedError: class UnauthorizedError extends Error {},
+}));
+
+const { verifyCredentialAccess } = await import('./credential_queries');
+
+type QueryConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+
+const verifyHandler = (verifyCredentialAccess as unknown as QueryConfig)
+  .handler;
+
+const cred = { _id: 'cred-1', organizationId: 'org-123', slug: 'slack' };
+
+function ctxForRole(role: string | undefined) {
+  return {
+    db: { get: vi.fn().mockResolvedValue(cred) },
+    runQuery: vi
+      .fn()
+      .mockResolvedValue({ page: role === undefined ? [] : [{ role }] }),
+  };
+}
+
+describe('verifyCredentialAccess capability gate', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null for a plain member (lacks developerSettings)', async () => {
+    const ctx = ctxForRole('member');
+    const result = await verifyHandler(
+      ctx as never,
+      {
+        credentialId: 'cred-1',
+        userId: 'user-1',
+      } as never,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a disabled member', async () => {
+    const ctx = ctxForRole('disabled');
+    const result = await verifyHandler(
+      ctx as never,
+      {
+        credentialId: 'cred-1',
+        userId: 'user-1',
+      } as never,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when there is no member row', async () => {
+    const ctx = ctxForRole(undefined);
+    const result = await verifyHandler(
+      ctx as never,
+      {
+        credentialId: 'cred-1',
+        userId: 'user-1',
+      } as never,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns the credential for a developer', async () => {
+    const ctx = ctxForRole('developer');
+    const result = await verifyHandler(
+      ctx as never,
+      {
+        credentialId: 'cred-1',
+        userId: 'user-1',
+      } as never,
+    );
+    expect(result).toEqual(cred);
+  });
+
+  it('returns the credential for an admin', async () => {
+    const ctx = ctxForRole('admin');
+    const result = await verifyHandler(
+      ctx as never,
+      {
+        credentialId: 'cred-1',
+        userId: 'user-1',
+      } as never,
+    );
+    expect(result).toEqual(cred);
+  });
+});

--- a/services/platform/convex/integrations/credential_queries.ts
+++ b/services/platform/convex/integrations/credential_queries.ts
@@ -1,5 +1,6 @@
 import { v } from 'convex/values';
 
+import { defineAbilityFor } from '../../lib/permissions/ability';
 import { components } from '../_generated/api';
 import { internalQuery, query } from '../_generated/server';
 import { getAuthUserIdentity, getOrganizationMember } from '../lib/rls';
@@ -83,6 +84,19 @@ export const getByIdInternal = internalQuery({
   },
 });
 
+/**
+ * Authorize a node-action caller against a specific credential. Backs the
+ * destructive integration actions (`saveCredentials`,
+ * `saveOAuth2ClientCredentials`, `generateOAuth2Url`, `testConnection`), which
+ * read/write the credential's stored secrets. These are capability-bearing
+ * surfaces the providers/skills paths gate on `developerSettings`, so plain org
+ * membership is insufficient: a non-disabled `member` is hidden from the
+ * integrations UI by `cannot('read','developerSettings')` but could otherwise
+ * drive these actions directly via the Convex client. Returns the credential
+ * only when the caller holds the `developerSettings` capability in the
+ * credential's own org; returns `null` (the existing "access denied" contract)
+ * otherwise.
+ */
 export const verifyCredentialAccess = internalQuery({
   args: {
     credentialId: v.id('integrationCredentials'),
@@ -106,6 +120,12 @@ export const verifyCredentialAccess = internalQuery({
     });
 
     if (!result || result.page.length === 0) return null;
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter findMany returns paginated unknown; we read only `role`
+    const member = result.page[0] as { role?: string };
+    if (!member.role || member.role === 'disabled') return null;
+    if (defineAbilityFor(member.role).cannot('read', 'developerSettings')) {
+      return null;
+    }
     return cred;
   },
 });

--- a/services/platform/convex/integrations/file_actions.test.ts
+++ b/services/platform/convex/integrations/file_actions.test.ts
@@ -1,0 +1,226 @@
+import { ConvexError } from 'convex/values';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs/promises', () => ({
+  readdir: vi.fn().mockResolvedValue([]),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path');
+  return { ...actual, default: actual };
+});
+
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+  internalAction: vi.fn((config) => config),
+}));
+
+vi.mock('../_generated/api', () => ({
+  internal: {
+    integrations: {
+      credential_queries: {
+        getBySlugInternal: 'getBySlugInternal',
+        listInternal: 'listInternal',
+      },
+      credential_mutations: {
+        createCredentials: 'createCredentials',
+        deleteCredentialsInternal: 'deleteCredentialsInternal',
+      },
+    },
+  },
+}));
+
+const mockAtomicWrite = vi.fn();
+const mockReadFileSafe = vi.fn();
+const mockReadJsonFile = vi.fn();
+vi.mock('../lib/file_io', () => ({
+  atomicWrite: (...args: unknown[]) => mockAtomicWrite(...args),
+  readFileSafe: (...args: unknown[]) => mockReadFileSafe(...args),
+  readJsonFile: (...args: unknown[]) => mockReadJsonFile(...args),
+  sha256: () => 'mock-hash',
+}));
+
+// The capability gate lives in providers/auth (a `'use node'` helper that issues
+// Better Auth adapter queries). Mock it so each test can choose "developer
+// allowed" vs "plain member rejected" — the surface under test is whether these
+// destructive actions invoke the gate BEFORE any credential/file mutation.
+const mockRequireDeveloperSettingsAccessById = vi.fn();
+const mockRequireOrgMembershipById = vi.fn();
+vi.mock('../providers/auth', () => ({
+  requireDeveloperSettingsAccessById: (...args: unknown[]) =>
+    mockRequireDeveloperSettingsAccessById(...args),
+}));
+vi.mock('../lib/auth/require_org_membership', () => ({
+  requireOrgMembershipById: (...args: unknown[]) =>
+    mockRequireOrgMembershipById(...args),
+}));
+
+vi.mock('./file_utils', async () => {
+  const actual =
+    await vi.importActual<typeof import('./file_utils')>('./file_utils');
+  return {
+    ...actual,
+    resolveConfigPath: (orgSlug: string, slug: string) =>
+      `/data/integrations/${orgSlug}/${slug}/config.json`,
+    resolveIntegrationDir: (orgSlug: string, slug: string) =>
+      `/data/integrations/${orgSlug}/${slug}`,
+    parseIntegrationJson: (s: string) => JSON.parse(s),
+    serializeIntegrationJson: (c: unknown) => JSON.stringify(c),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import handlers
+// ---------------------------------------------------------------------------
+
+const {
+  installIntegration,
+  uninstallIntegration,
+  saveIntegrationConfig,
+  writeIntegrationFiles,
+} = await import('./file_actions');
+
+type ActionConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+
+const installHandler = (installIntegration as unknown as ActionConfig).handler;
+const uninstallHandler = (uninstallIntegration as unknown as ActionConfig)
+  .handler;
+const saveConfigHandler = (saveIntegrationConfig as unknown as ActionConfig)
+  .handler;
+const writeFilesHandler = (writeIntegrationFiles as unknown as ActionConfig)
+  .handler;
+
+function createMockCtx() {
+  return {
+    runMutation: vi.fn().mockResolvedValue('cred-id'),
+    runQuery: vi.fn().mockResolvedValue(null),
+  };
+}
+
+const FORBIDDEN = new ConvexError({
+  code: 'FORBIDDEN_DEVELOPER_SETTINGS',
+  message: 'Role "member" lacks the developer-settings capability.',
+});
+
+describe('integrations/file_actions capability gates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireDeveloperSettingsAccessById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      member: { _id: 'm-1', role: 'developer' },
+    });
+    mockReadFileSafe.mockResolvedValue(null);
+    mockReadJsonFile.mockResolvedValue({
+      ok: true,
+      data: { title: 'X', authMethod: 'apiKey' },
+      hash: 'h',
+    });
+  });
+
+  // Each surface must gate on `developerSettings` (not plain membership). The
+  // gate is asserted by: (a) a plain member is rejected with
+  // FORBIDDEN_DEVELOPER_SETTINGS and no destructive work runs, and (b) the gate
+  // is called before any credential/file mutation. If a refactor drops the gate
+  // these tests fail (the rejection no longer propagates).
+
+  describe('uninstallIntegration', () => {
+    it('rejects a plain member and does not delete the credential', async () => {
+      mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+      const ctx = createMockCtx();
+
+      await expect(
+        uninstallHandler(
+          ctx as never,
+          { slug: 'slack', organizationId: 'org-123' } as never,
+        ),
+      ).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+      });
+      expect(ctx.runMutation).not.toHaveBeenCalled();
+    });
+
+    it('deletes the credential for a developer', async () => {
+      const ctx = createMockCtx();
+      ctx.runQuery.mockResolvedValue({ _id: 'cred-1' });
+
+      const result = await uninstallHandler(
+        ctx as never,
+        { slug: 'slack', organizationId: 'org-123' } as never,
+      );
+
+      expect(result).toEqual({ deleted: true });
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        'deleteCredentialsInternal',
+        {
+          credentialId: 'cred-1',
+        },
+      );
+    });
+  });
+
+  describe('installIntegration', () => {
+    it('rejects a plain member and does not create a credential', async () => {
+      mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+      const ctx = createMockCtx();
+
+      await expect(
+        installHandler(
+          ctx as never,
+          { slug: 'slack', organizationId: 'org-123' } as never,
+        ),
+      ).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+      });
+      expect(ctx.runMutation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveIntegrationConfig', () => {
+    it('rejects a plain member and does not write to disk', async () => {
+      mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+      const ctx = createMockCtx();
+
+      await expect(
+        saveConfigHandler(
+          ctx as never,
+          { organizationId: 'org-123', slug: 'slack', config: {} } as never,
+        ),
+      ).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+      });
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('writeIntegrationFiles', () => {
+    it('rejects a plain member and does not write config or connector code', async () => {
+      mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+      const ctx = createMockCtx();
+
+      await expect(
+        writeFilesHandler(
+          ctx as never,
+          {
+            organizationId: 'org-123',
+            slug: 'slack',
+            config: {},
+            connectorCode: 'export const x = 1;',
+          } as never,
+        ),
+      ).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
+      });
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/platform/convex/integrations/file_actions.ts
+++ b/services/platform/convex/integrations/file_actions.ts
@@ -24,6 +24,7 @@ import {
   readJsonFile,
   sha256,
 } from '../lib/file_io';
+import { requireDeveloperSettingsAccessById } from '../providers/auth';
 import type { IntegrationReadResult } from './file_utils';
 import {
   MAX_FILE_SIZE_BYTES,
@@ -291,7 +292,11 @@ export const saveIntegrationConfig = action({
       throw new Error(`Invalid integration slug: ${args.slug}`);
     }
 
-    const { orgSlug } = await requireOrgMembershipById(
+    // Writing an integration config is a capability-bearing edit the rest of
+    // the codebase treats as `developerSettings` work. A plain `member` is
+    // hidden from the integrations UI by `cannot('read','developerSettings')`
+    // but could previously drive this action directly via the Convex client.
+    const { orgSlug } = await requireDeveloperSettingsAccessById(
       ctx,
       args.organizationId,
     );
@@ -334,7 +339,10 @@ export const installIntegration = action({
       throw new Error(`Invalid integration slug: ${args.slug}`);
     }
 
-    const { orgSlug } = await requireOrgMembershipById(
+    // Connecting an integration creates its credential record (and installs its
+    // bundled capabilities) — `developerSettings` work elsewhere. Gate it on
+    // the same capability rather than admitting any non-disabled member.
+    const { orgSlug } = await requireDeveloperSettingsAccessById(
       ctx,
       args.organizationId,
     );
@@ -383,7 +391,11 @@ export const uninstallIntegration = action({
       throw new Error(`Invalid integration slug: ${args.slug}`);
     }
 
-    await requireOrgMembershipById(ctx, args.organizationId);
+    // Uninstalling deletes the credential record and its stored icon/secrets —
+    // the same destructive outcome as the now-gated `deleteCredentials`
+    // mutation. Without this gate a plain `member` rejected by
+    // `deleteCredentials` could simply call `uninstallIntegration` instead.
+    await requireDeveloperSettingsAccessById(ctx, args.organizationId);
 
     const existing = await ctx.runQuery(
       internal.integrations.credential_queries.getBySlugInternal,
@@ -419,7 +431,10 @@ export const writeIntegrationFiles = action({
       throw new Error(`Invalid integration slug: ${args.slug}`);
     }
 
-    const { orgSlug } = await requireOrgMembershipById(
+    // Custom uploads write integration config AND executable connector code to
+    // disk — at least as capability-bearing as the credential paths gated
+    // above. Require the `developerSettings` capability, not plain membership.
+    const { orgSlug } = await requireDeveloperSettingsAccessById(
       ctx,
       args.organizationId,
     );


### PR DESCRIPTION
## Summary

Three public Convex surfaces gated only on plain org membership (`requireOrgMembershipById` / `getOrganizationMember`, which admits any non-disabled member) for operations the rest of the codebase treats as `developerSettings`-capability work. A plain `member` is hidden from the matching UI by `ability.cannot('read','developerSettings')` but could still invoke these directly via the Convex client. This closes the gap, mirroring the proven providers/skills pattern.

## Changes

- **[35] `agents/file_actions.ts` `deleteAgent`** — now `requireOrgAdminOrDeveloper` (was `requireOrgMembershipById`), matching `duplicateAgent`/`saveAgent`. Deleting an agent destroys it + its history and is strictly more destructive than the create/duplicate paths.
- **[44] `apps/install_actions.ts`** — install/reinstall (`prepareInstall`) and `uninstallApp` now gate on `requireDeveloperSettingsAccessById`. Uninstall tears down app-owned agents, their workflows, and all their env/secrets. `verifyAppIntegrity` and `removeAppFromProject` remain membership-gated (read-mostly / non-destructive binding removal).
- **[103] integration credentials** — `updateCredentials` / `deleteCredentials` mutations gate on `requireOrgAdminOrDeveloper`; `verifyCredentialAccess` internalQuery now enforces the `developerSettings` capability, covering the node actions `saveCredentials`, `testConnection`, `generateOAuth2Url`, `saveOAuth2ClientCredentials`.

Wrong-role callers now reject with `FORBIDDEN_DEVELOPER_SETTINGS` (mutations/actions) — action-layer auth now matches route-layer auth (defense in depth).

## Tests

- Added a member-rejection test for `deleteAgent`.
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt --check` all clean.
- Server vitest suites for `lib/auth`, `integrations`, `apps`, `agents`: 391 passed.

Closes #2042