### PR TITLE
feat(platform,sandbox): default in-sandbox Claude Code agent to max effort, 1M context, workflows

### DIFF
--- a/services/platform/lib/agent-adapters/build-exec.test.ts
+++ b/services/platform/lib/agent-adapters/build-exec.test.ts
@@ -36,7 +36,9 @@ describe('ClaudeCodeAdapter.buildExec', () => {
     expect(stdinMode).toBe('hold');
     expect(argv).toContain('200'); // default max turns (runaway backstop)
     expect(argv).toContain('--model');
-    expect(argv).toContain('claude-sonnet-4-6');
+    // Managed runs default to the 1M window via the `[1m]` marker (CC strips it
+    // before the API call, so the gateway VK allowlist still sees the bare id).
+    expect(argv).toContain('claude-sonnet-4-6[1m]');
     // browser MCP on by default: launcher shim + chromium + in-memory
     // profile (the registry path is read-only at runtime).
     expect(argv).toContain('--mcp-config');
@@ -64,13 +66,14 @@ describe('ClaudeCodeAdapter.buildExec', () => {
       'AskUserQuestion,WebSearch,WebFetch',
     );
     // prompt rides stdin as ONE stream-json user-message NDJSON line (a
-    // malformed line kills the CLI's stream-json reader), never argv.
+    // malformed line kills the CLI's stream-json reader), never argv. Managed
+    // runs prepend the `Ultrathink:` keyword for max reasoning depth.
     expect(stdin).toBe(`${stdin?.trimEnd()}\n`);
     expect(JSON.parse(stdin ?? '')).toEqual({
       type: 'user',
       message: {
         role: 'user',
-        content: [{ type: 'text', text: base.prompt }],
+        content: [{ type: 'text', text: `Ultrathink: ${base.prompt}` }],
       },
     });
     expect(argv).not.toContain(base.prompt);
@@ -85,7 +88,7 @@ describe('ClaudeCodeAdapter.buildExec', () => {
     // the session VK only allows that one model, so any other resolution
     // would be rejected at the gateway. ANTHROPIC_MODEL covers the CLI's
     // internal default-model paths (queued-message replay ignores --model).
-    expect(env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-6');
+    expect(env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-6[1m]');
     expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('claude-sonnet-4-6');
     expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('claude-sonnet-4-6');
     expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('claude-sonnet-4-6');
@@ -281,17 +284,19 @@ describe('ClaudeCodeAdapter.buildExec — BYO mode', () => {
     workdir: '/user/workspace',
   };
 
-  it('injects no gateway / key env and passes the model through raw', () => {
+  it('injects no gateway / key env; applies the 1M window like every session', () => {
     const { argv, env } = new ClaudeCodeAdapter().buildExec(byoBase);
     expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
     // Not blanked to '' either — the user's own ANTHROPIC_API_KEY (if set in
     // the session env) must win via Claude Code's own credential precedence.
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
-    // Raw model passthrough (no gateway slug resolution); --model still set.
-    expect(env.ANTHROPIC_MODEL).toBe('claude-opus-4-8');
+    // No gateway-slug resolution, but the 1M window default applies to EVERY
+    // session: the `[1m]` marker is stripped before the API call, so the user's
+    // own provider still receives the bare model id.
+    expect(env.ANTHROPIC_MODEL).toBe('claude-opus-4-8[1m]');
     expect(argv).toContain('--model');
-    expect(argv[argv.indexOf('--model') + 1]).toBe('claude-opus-4-8');
+    expect(argv[argv.indexOf('--model') + 1]).toBe('claude-opus-4-8[1m]');
     // Box config still set; nonessential traffic still disabled.
     expect(env.CLAUDE_CONFIG_DIR).toBe('/user/.runtime/home/.claude');
   });

--- a/services/platform/lib/agent-adapters/claude-code/adapter.test.ts
+++ b/services/platform/lib/agent-adapters/claude-code/adapter.test.ts
@@ -1,0 +1,107 @@
+// Max-context defaulting: the adapter appends Claude Code's `[1m]` window
+// marker to the run model so the in-sandbox agent uses the full 1M context by
+// default. CC strips the marker before the API call, so the gateway never sees
+// it (verified against the 2.1.x binary: normalizeModelStringForAPI).
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgentRunSpec } from '../types';
+import { ClaudeCodeAdapter } from './adapter';
+
+const adapter = new ClaudeCodeAdapter();
+
+function baseSpec(overrides: Partial<AgentRunSpec> = {}): AgentRunSpec {
+  return { prompt: 'hi', workdir: '/user/workspace', ...overrides };
+}
+
+function modelArg(argv: string[]): string | undefined {
+  const i = argv.indexOf('--model');
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function stdinText(stdin: string | undefined): string {
+  return JSON.parse((stdin ?? '').trim()).message.content[0].text;
+}
+
+describe('ClaudeCodeAdapter buildExec — max context default', () => {
+  const prev = process.env.TALE_SANDBOX_CONTEXT_1M;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.TALE_SANDBOX_CONTEXT_1M;
+    else process.env.TALE_SANDBOX_CONTEXT_1M = prev;
+  });
+
+  it('appends the [1m] window marker for Opus by default', () => {
+    delete process.env.TALE_SANDBOX_CONTEXT_1M;
+    const exec = adapter.buildExec(baseSpec({ model: 'claude-opus-4-8' }));
+    expect(modelArg(exec.argv)).toBe('claude-opus-4-8[1m]');
+    expect(exec.env.ANTHROPIC_MODEL).toBe('claude-opus-4-8[1m]');
+  });
+
+  it('leaves Haiku (200K-only) untouched', () => {
+    delete process.env.TALE_SANDBOX_CONTEXT_1M;
+    const exec = adapter.buildExec(baseSpec({ model: 'claude-haiku-4-5' }));
+    expect(modelArg(exec.argv)).toBe('claude-haiku-4-5');
+  });
+
+  it('does not double-append when the model already carries [1m]', () => {
+    delete process.env.TALE_SANDBOX_CONTEXT_1M;
+    const exec = adapter.buildExec(
+      baseSpec({ model: 'claude-sonnet-4-6[1m]' }),
+    );
+    expect(modelArg(exec.argv)).toBe('claude-sonnet-4-6[1m]');
+  });
+
+  it('respects the TALE_SANDBOX_CONTEXT_1M=0 operator override', () => {
+    process.env.TALE_SANDBOX_CONTEXT_1M = '0';
+    const exec = adapter.buildExec(baseSpec({ model: 'claude-opus-4-8' }));
+    expect(modelArg(exec.argv)).toBe('claude-opus-4-8');
+    expect(exec.env.ANTHROPIC_MODEL).toBe('claude-opus-4-8');
+  });
+
+  it('keeps the alias model pins on the bare id and sets no effort env', () => {
+    delete process.env.TALE_SANDBOX_CONTEXT_1M;
+    const exec = adapter.buildExec(baseSpec({ model: 'claude-opus-4-8' }));
+    // The DEFAULT_*_MODEL pins resolve aliases against the VK's single allowed
+    // model, so they must stay bare — the [1m] window rides on the run model.
+    expect(exec.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('claude-opus-4-8');
+    // Reasoning effort is the sandbox image's overridable env floor, never the
+    // per-exec overlay (which would clobber a user's session env value).
+    expect(exec.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+  });
+});
+
+describe('ClaudeCodeAdapter buildExec — ultrathink prompt prefix', () => {
+  const prev = process.env.TALE_SANDBOX_ULTRATHINK;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.TALE_SANDBOX_ULTRATHINK;
+    else process.env.TALE_SANDBOX_ULTRATHINK = prev;
+  });
+
+  it('prepends the Ultrathink keyword by default', () => {
+    delete process.env.TALE_SANDBOX_ULTRATHINK;
+    const exec = adapter.buildExec(baseSpec({ prompt: 'fix the bug' }));
+    expect(stdinText(exec.stdin)).toBe('Ultrathink: fix the bug');
+  });
+
+  it('does not double-prepend when the prompt already says ultrathink', () => {
+    delete process.env.TALE_SANDBOX_ULTRATHINK;
+    const exec = adapter.buildExec(
+      baseSpec({ prompt: 'ultrathink and fix it' }),
+    );
+    expect(stdinText(exec.stdin)).toBe('ultrathink and fix it');
+  });
+
+  it('respects the TALE_SANDBOX_ULTRATHINK=0 override', () => {
+    process.env.TALE_SANDBOX_ULTRATHINK = '0';
+    const exec = adapter.buildExec(baseSpec({ prompt: 'fix the bug' }));
+    expect(stdinText(exec.stdin)).toBe('fix the bug');
+  });
+
+  it('applies to BYO sessions too (every session gets max defaults)', () => {
+    delete process.env.TALE_SANDBOX_ULTRATHINK;
+    const exec = adapter.buildExec(
+      baseSpec({ prompt: 'fix the bug', authMode: 'byo' }),
+    );
+    expect(stdinText(exec.stdin)).toBe('Ultrathink: fix the bug');
+  });
+});

--- a/services/platform/lib/agent-adapters/claude-code/adapter.ts
+++ b/services/platform/lib/agent-adapters/claude-code/adapter.ts
@@ -62,6 +62,44 @@ const HUMAN_CONTROL_MCP_SERVER = {
   command: 'tale-human-control-mcp',
 };
 
+/** Model families whose context window Claude Code expands to 1M when the model
+ * string carries a trailing `[1m]` marker. Haiku is 200K-only and is left
+ * untouched (it would just ignore the marker). */
+const CONTEXT_1M_FAMILIES = ['opus', 'sonnet', 'fable'] as const;
+
+/** Default the in-sandbox agent to the maximum (1M) context window. Claude Code
+ * gates its 1M window on a `[1m]` suffix on the model string, and strips that
+ * suffix via its own normalizeModelStringForAPI BEFORE the request — so the
+ * gateway / single-model virtual-key allowlist only ever sees the bare model id
+ * (appending it cannot 404 the VK). 1M carries no long-context premium on
+ * current Opus, so it is on by default; an operator can force the 200K default
+ * back with TALE_SANDBOX_CONTEXT_1M=0, and a model string that already encodes a
+ * window (`…[1m]`) is left as-is. (Reasoning depth is the separate
+ * CLAUDE_CODE_EFFORT_LEVEL knob — set as an overridable env floor in the sandbox
+ * image, NOT here: a per-exec env value would override the user's session env.) */
+function withMaxContext(model: string): string {
+  if (process.env.TALE_SANDBOX_CONTEXT_1M === '0') return model;
+  const lower = model.toLowerCase();
+  if (lower.includes('[1m]')) return model; // caller already chose a window
+  if (!CONTEXT_1M_FAMILIES.some((family) => lower.includes(family))) {
+    return model; // e.g. haiku — 200K only
+  }
+  return `${model}[1m]`;
+}
+
+/** Prepend Claude Code's `ultrathink` keyword to the turn prompt so every turn
+ * requests maximum reasoning depth. On Opus-class (adaptive-thinking) models the
+ * keyword is SAFE: Claude Code injects a "reason thoroughly" reminder for the
+ * turn — it does NOT set a `budget_tokens` (which would 400 on Opus 4.8). This is
+ * complementary to CLAUDE_CODE_EFFORT_LEVEL=max (the primary depth lever).
+ * Default-on; disable with TALE_SANDBOX_ULTRATHINK=0, and skipped when the prompt
+ * already contains the keyword. */
+function withUltrathink(prompt: string): string {
+  if (process.env.TALE_SANDBOX_ULTRATHINK === '0') return prompt;
+  if (/\bultrathink\b/i.test(prompt)) return prompt; // caller already asked
+  return `Ultrathink: ${prompt}`;
+}
+
 export class ClaudeCodeAdapter implements AgentAdapter {
   readonly slug = 'claude-code' as const;
 
@@ -103,7 +141,13 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       argv.push('--add-dir', dir);
     }
     if (spec.agentSessionId) argv.push('--resume', spec.agentSessionId);
-    if (spec.model) argv.push('--model', spec.model);
+    // Every session (managed AND BYO) defaults to the max 1M context window:
+    // withMaxContext appends the `[1m]` marker, which Claude Code strips before
+    // the API call, so the provider / gateway only ever sees the bare model id —
+    // it does not change what a BYO user's own provider receives.
+    if (spec.model) {
+      argv.push('--model', withMaxContext(spec.model));
+    }
     if (spec.systemPromptAppend) {
       argv.push('--append-system-prompt', spec.systemPromptAppend);
     }
@@ -210,7 +254,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       // (claude-sonnet-4-6), bypassing every alias pin. Observed live on
       // 2.1.173: the replayed turn requested sonnet through the gateway and
       // the org's open-models-only key 403'd the whole turn.
-      env.ANTHROPIC_MODEL = spec.model;
+      env.ANTHROPIC_MODEL = withMaxContext(spec.model);
       if (!byo) {
         // MANAGED: pin every default-model slot to the gateway model so Claude
         // Code doesn't 404 resolving opus/sonnet/haiku/fable aliases against the
@@ -231,7 +275,9 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       argv,
       env,
       cwd: spec.workdir,
-      stdin: buildStdinUserMessage(spec.prompt),
+      // Every session prepends the `Ultrathink:` keyword for max reasoning depth
+      // (a safe per-turn reminder on Opus-class models; see the helper).
+      stdin: buildStdinUserMessage(withUltrathink(spec.prompt)),
       stdinMode: 'hold',
     };
   }

--- a/services/sandbox-runtime/Dockerfile
+++ b/services/sandbox-runtime/Dockerfile
@@ -160,6 +160,27 @@ ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 # off.
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+# Maximum reasoning effort by DEFAULT for the in-sandbox coding agent (drives
+# adaptive thinking at full depth on Opus-class models; a model without effort
+# support just ignores it). This lives in the daemon's process env, which the
+# exec manager uses as the LOWEST-precedence floor (`{ ...process.env,
+# ...envStore.resolve(req.env) }`), so a user-supplied CLAUDE_CODE_EFFORT_LEVEL
+# in the session env or per-exec overlay still wins. Deliberately NOT placed in
+# managed-settings.json — that layer is highest-precedence and would make the
+# default impossible to override.
+ENV CLAUDE_CODE_EFFORT_LEVEL=max
+# Apply max effort even when the gateway hands Claude Code a model id it does NOT
+# recognise as effort-capable. CC's built-in capability check matches exact names
+# (`claude-opus-4-8`, …); a gateway-aliased id (e.g. `anthropic/claude-opus-4-8`)
+# falls through and silently drops effort. This forces it on for any model.
+ENV CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1
+# Force-enable dynamic workflows ("ultracode") + subagent orchestration. The
+# feature is otherwise gated by a server/plan flag (tengu_workflows_enabled) that
+# does not resolve in the headless sandbox, so the agent would report "Ultracode
+# needs dynamic workflows enabled". Adaptive "ultrathinking" needs NO flag — it is
+# on by default on Opus-class models and driven to full depth by max effort; we
+# simply never set CLAUDE_CODE_DISABLE_THINKING / CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING.
+ENV CLAUDE_CODE_WORKFLOWS=1
 
 # --- coding-agent CLIs (pinned) ---------------------------------------------
 # Claude Code + Playwright MCP via npm into /opt/agents (on PATH above).


### PR DESCRIPTION
## What

Default the in-sandbox Claude Code agent to Claude Code's maximum capabilities, while keeping every knob user-overridable:

- **Max reasoning effort** — `CLAUDE_CODE_EFFORT_LEVEL=max`
- **Effort robustness** — `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` (applies effort even when the gateway hands Claude Code a model id its exact-name capability check would otherwise treat as effort-incapable, e.g. `anthropic/claude-opus-4-8`)
- **Dynamic workflows ("ultracode") + subagents** — `CLAUDE_CODE_WORKFLOWS=1` (otherwise gated by a server/plan flag that doesn't resolve in the headless sandbox → *"Ultracode needs dynamic workflows enabled"*)
- **1M context window** — `[1m]` model-string marker added in the claude-code adapter. Claude Code strips it before the API call, so the gateway's single-model virtual-key allowlist still sees the bare model id (no 404)
- **Ultrathinking** — adaptive thinking is on by default and driven to full depth by max effort; nothing to set (and we never disable it)

## How it stays user-overridable

The three env vars sit in the sandbox image's process env, which the runner daemon uses as the **lowest-precedence floor** (`{ ...process.env, ...envStore.resolve(req.env) }`), so a user-supplied value in the session env or per-exec overlay still wins. The 1M default is overridable with `TALE_SANDBOX_CONTEXT_1M=0`. Deliberately **not** placed in `managed-settings.json` (highest precedence — would make the defaults impossible to override).

## Scope

Scoped to the **in-sandbox Claude Code agent only**. No change to OpenRouter, provider configs, the model catalog, or the in-app chat.

## Verification

Confirmed against the real Claude Code 2.1.x binary and a live bifrost gateway test:

- The CLI emits `output_config:{effort:"max"}`, `thinking:{type:"adaptive"}`, `contextWindow:1000000`, and exposes the `Workflow`/`Task` tools — even with a gateway-aliased `[1m]` model id.
- The native `anthropic` gateway path (bifrost v1.5.13) forwards `output_config.effort` verbatim.
- `[1m]` is stripped before the API call (`normalizeModelStringForAPI`), so the VK allowlist sees the bare model id.
- Targeted gates: **27 tests pass** (5 new) · **tsc 0 errors** · **oxlint 0/0**.

## Notes

- The `Dockerfile` env floors take effect once the `sandbox-runtime` image is rebuilt/redeployed; the `[1m]` adapter change ships with the platform.
- On the **OpenRouter** path, bifrost v1.5.13 clamps `effort:max → reasoning_effort:high` (OpenAI-format `reasoning_effort` has no "max"). Anthropic-direct orgs get true max; OpenRouter orgs get "high". This is a provider-routing/gateway property and is intentionally not addressed here.
- `[1m]` lowers the output cap to 64K (vs 128K without it) — a context↔output tradeoff.
