### PR TITLE
fix: sandbox/k8s: stage attestation (prestage.json) lives on a runner-writable path (#1847)

### DIFF
--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
@@ -10,6 +10,7 @@ import { TEST_SESSION_CONFIG } from '../../session/session-test-config.ts';
 import type { SpawnerConfig } from '../../types.ts';
 import { EXEC_SPEC_MOUNT_DIR, secretNameFor } from './exec-spec.ts';
 import { buildSandboxPod, podNameFor } from './k8s-pod-spec.ts';
+import { ATTEST_DIR, PRESTAGE_PATH } from './k8s-protocol.ts';
 
 const cfg: SpawnerConfig = {
   backend: 'kubernetes',
@@ -242,6 +243,28 @@ describe('buildSandboxPod', () => {
       const m = c.volumeMounts?.find((x) => x.name === 'workspace');
       expect(m?.mountPath).toBe('/user');
     }
+  });
+
+  test('SECURITY: stage attestation volume is mounted into stage + harvest, NEVER the runner', () => {
+    const pod = buildSandboxPod(cfg, goodInput);
+    // The attestation channel exists at Pod level as its own emptyDir...
+    const vol = pod.spec?.volumes?.find((v) => v.name === 'attest');
+    expect(vol?.emptyDir).toBeDefined();
+    // ...mounted into the trusted helpers that write/read the attestation...
+    for (const c of [stage(pod), harvest(pod)]) {
+      const m = c.volumeMounts?.find((x) => x.name === 'attest');
+      expect(m?.mountPath).toBe(ATTEST_DIR);
+    }
+    // ...and NOT into the runner: user code shares /user read-write, so an
+    // attestation there could be forged before harvest reads it. Keeping it on
+    // a runner-inaccessible volume is the integrity fix (issue #1847).
+    expect(
+      runner(pod).volumeMounts?.find((m) => m.name === 'attest'),
+    ).toBeUndefined();
+    // Belt-and-suspenders: the attestation path must live OFF the shared
+    // /user emptyDir entirely.
+    expect(PRESTAGE_PATH.startsWith('/user/')).toBe(false);
+    expect(PRESTAGE_PATH.startsWith(`${ATTEST_DIR}/`)).toBe(true);
   });
 
   test('workspace sizeLimit is operator-configurable', () => {

--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
@@ -13,10 +13,11 @@
 // Exec-free Pod shape (one Pod, shared `/user` emptyDir, no PVC required):
 //   - initContainer `stage` (the SPAWNER image, k8s-stage.ts): downloads
 //     inputs from presigned URLs into /user and writes the multi-step
-//     wrapper + the prior-stage attestation. initContainers complete before
-//     app containers, so the runner finds a fully-staged workspace — no
-//     sentinel handshake. A required-input failure exits non-zero → Pod fails
-//     → spawner surfaces PRE_STAGE_FAILED.
+//     wrapper, plus the prior-stage attestation onto the dedicated `attest`
+//     volume (runner-inaccessible, so user code can't forge it).
+//     initContainers complete before app containers, so the runner finds a
+//     fully-staged workspace — no sentinel handshake. A required-input failure
+//     exits non-zero → Pod fails → spawner surfaces PRE_STAGE_FAILED.
 //   - container `runner` (the runtime image): command override runs the
 //     image's real /entrypoint.sh as a CHILD of `sh -c` (NOT `exec`), so the
 //     wrapper resumes after it to capture the exit code into EXIT_CODE_PATH.
@@ -42,7 +43,12 @@ import type {
 import type { Language, SpawnerConfig } from '../../types.ts';
 import type { CacheStores } from '../types.ts';
 import { EXEC_SPEC_MOUNT_DIR, secretNameFor } from './exec-spec.ts';
-import { EXIT_CODE_PATH, STDERR_PATH, TALE_DIR } from './k8s-protocol.ts';
+import {
+  ATTEST_DIR,
+  EXIT_CODE_PATH,
+  STDERR_PATH,
+  TALE_DIR,
+} from './k8s-protocol.ts';
 
 interface SandboxPodInput {
   executionId: string;
@@ -201,6 +207,12 @@ export function buildSandboxPod(
     // Scratch for the helper containers' Bun runtime (HOME=/helper-tmp) under
     // readOnlyRootFilesystem. Separate from the runner's /tmp.
     { name: 'helper-tmp', emptyDir: { medium: 'Memory', sizeLimit: '64Mi' } },
+    // The stage attestation channel. Mounted ONLY into the trusted stage
+    // (writer) and harvest (reader) helpers below — NOT the runner. Keeping it
+    // off the shared `/user` emptyDir is the integrity fix: the runner can't
+    // reach this volume, so user code can't forge the prior-stage attestation
+    // the platform's PRE_STAGE_FAILED gate trusts.
+    { name: 'attest', emptyDir: { medium: 'Memory', sizeLimit: '8Mi' } },
   ];
   if (usePvcCache && inp.cache) {
     runnerMounts.push(
@@ -243,6 +255,8 @@ export function buildSandboxPod(
     { name: 'workspace', mountPath: WORKSPACE_MOUNT },
     { name: 'exec-spec', mountPath: EXEC_SPEC_MOUNT_DIR, readOnly: true },
     { name: 'helper-tmp', mountPath: '/helper-tmp' },
+    // The attestation channel — runner-inaccessible (see the 'attest' volume).
+    { name: 'attest', mountPath: ATTEST_DIR },
   ];
   const helperResources = {
     requests: { cpu: '100m', memory: '256Mi' },

--- a/services/sandbox/src/backend/kubernetes/k8s-protocol.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-protocol.ts
@@ -5,11 +5,20 @@
 //   - the runner writes its exit code to EXIT_CODE_PATH and redirects its
 //     stderr to STDERR_PATH (the K8s log API merges stdout+stderr, so stderr
 //     stays on disk and the runner's logs are clean stdout for phase parsing).
-//   - the stage initContainer writes PRESTAGE_PATH (attestation + stage timing).
-//   - the harvest container reads all three, uploads outputs, and prints ONE
-//     result line (`__TALE_RESULT__ {json}`) to its OWN stdout, which the
-//     owning spawner replica reads back via readNamespacedPodLog. No websocket,
-//     no cross-replica callback — the result rides the harvest container's logs.
+//     These are the runner's OWN outputs — it is free to write them.
+//   - the stage initContainer writes the prior-stage attestation to
+//     PRESTAGE_PATH and the harvest container reads it back. The attestation is
+//     an integrity claim the platform's PRE_STAGE_FAILED gate trusts, so it
+//     deliberately does NOT live on `/user`: that emptyDir is runner-writable
+//     (same uid, shared volume), so user code could forge priorStage / stageMs
+//     there. It sits on the dedicated ATTEST_DIR volume instead, mounted only
+//     into the trusted stage/harvest helpers — never the runner (see
+//     k8s-pod-spec.ts).
+//   - the harvest container reads exit-code/stderr + the attestation, uploads
+//     outputs, and prints ONE result line (`__TALE_RESULT__ {json}`) to its OWN
+//     stdout, which the owning spawner replica reads back via
+//     readNamespacedPodLog. No websocket, no cross-replica callback — the
+//     result rides the harvest container's logs.
 
 import type { OutputFile, PriorStageResult, UploadStats } from '../../types.ts';
 import type { SandboxStepResult } from '../../wire.ts';
@@ -17,7 +26,13 @@ import type { SandboxStepResult } from '../../wire.ts';
 export const TALE_DIR = '/user/.runtime/tale';
 export const EXIT_CODE_PATH = `${TALE_DIR}/exit-code`;
 export const STDERR_PATH = `${TALE_DIR}/stderr.log`;
-export const PRESTAGE_PATH = `${TALE_DIR}/prestage.json`;
+
+// The stage attestation lives on its OWN volume, NOT under `/user`. The runner
+// shares the `/user` emptyDir read-write, so an attestation there could be
+// forged by user code before harvest reads it; ATTEST_DIR is mounted only into
+// the trusted stage (writer) and harvest (reader) helpers (k8s-pod-spec.ts).
+export const ATTEST_DIR = '/attest';
+export const PRESTAGE_PATH = `${ATTEST_DIR}/prestage.json`;
 
 /** What the stage initContainer persists for the harvest container to forward. */
 export interface PrestageFile {

--- a/services/sandbox/src/backend/kubernetes/k8s-stage.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-stage.ts
@@ -18,7 +18,11 @@ import { mkdir, writeFile } from 'node:fs/promises';
 
 import { stageWorkspace } from '../../exec-common.ts';
 import { EXEC_SPEC_PATH, parseExecSpec } from './exec-spec.ts';
-import { PRESTAGE_PATH, TALE_DIR, type PrestageFile } from './k8s-protocol.ts';
+import {
+  ATTEST_DIR,
+  PRESTAGE_PATH,
+  type PrestageFile,
+} from './k8s-protocol.ts';
 
 async function main(): Promise<void> {
   const raw = await readFile(EXEC_SPEC_PATH, 'utf8');
@@ -29,8 +33,10 @@ async function main(): Promise<void> {
   const stageMs = Date.now() - startedAt;
 
   // Persist for the harvest container (it forwards priorStage + stageMs into
-  // the result line the spawner reads).
-  await mkdir(TALE_DIR, { recursive: true });
+  // the result line the spawner reads). ATTEST_DIR is a dedicated volume the
+  // runner cannot mount, so user code can't forge the attestation before
+  // harvest reads it.
+  await mkdir(ATTEST_DIR, { recursive: true });
   const prestage: PrestageFile = {
     stageMs,
     ...(priorStage !== undefined && { priorStage }),


### PR DESCRIPTION
## Problem

On the k8s exec-free backend, the `stage` initContainer wrote the prior-stage attestation (`prestage.json`: `priorStage` staged/skipped lists + sha256s, `stageMs`) to `/user/.runtime/tale/prestage.json`, and the `harvest` container read it back. But the whole `/user` emptyDir is mounted read-write into the **runner** container (same uid, shared volume), so user code could forge the attestation before harvest read it.

Impact: the platform's `PRE_STAGE_FAILED` gate diffs `priorStage.staged` against its manifest, so a forged attestation could make a partially-staged workspace look fully staged. Blast radius is the user's own run, but the integrity claim was hollow on k8s (the docker path computes it spawner-side, outside the runtime's reach).

## Fix

Move the attestation channel off the runner-writable `/user` volume onto a dedicated `attest` emptyDir that is mounted **only** into the trusted `stage` (writer) and `harvest` (reader) helper containers — never the runner. This mirrors the existing per-exec-Secret isolation: the runner has no mount for it, so under `readOnlyRootFilesystem` user code cannot create or write the attestation path at all.

The runner's *own* outputs (`exit-code`, `stderr.log`) stay under `/user/.runtime/tale` — those are legitimately the runner's to write, matching the docker path.

### Changes
- `k8s-protocol.ts`: add `ATTEST_DIR = /attest`; `PRESTAGE_PATH` now resolves there instead of under `TALE_DIR` (`/user/...`). `EXIT_CODE_PATH` / `STDERR_PATH` unchanged.
- `k8s-pod-spec.ts`: add the `attest` emptyDir volume; mount it into the helper containers only.
- `k8s-stage.ts`: `mkdir(ATTEST_DIR)` + write the attestation there.
- `k8s-harvest.ts`: unchanged (reads `PRESTAGE_PATH`).

### Tests
- New `k8s-pod-spec.test.ts` security test: the `attest` volume is mounted into stage + harvest, never the runner, and `PRESTAGE_PATH` lives off `/user`.
- Full sandbox suite green: `bun test` (366 pass), `tsc --noEmit`, `oxlint --type-aware`, `oxfmt --check` all clean.

Pure backend infra change — no user-visible strings, env vars, API fields, or schema changes, so no docs/i18n/migration ripple.

Closes #1847