### PR TITLE
fix(platform): search and pagination UX polish

### DIFF
--- a/packages/ui/src/components/search/search-command-input.tsx
+++ b/packages/ui/src/components/search/search-command-input.tsx
@@ -55,7 +55,7 @@ export function SearchCommandInput({
         />
       </span>
       <input
-        type="search"
+        type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={onKeyDown}

--- a/packages/ui/src/components/search/search-command.tsx
+++ b/packages/ui/src/components/search/search-command.tsx
@@ -293,7 +293,7 @@ export function SearchCommand({
                       initial={reduceMotion ? false : { opacity: 0, y: 4 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ duration: reduceMotion ? 0 : 0.18 }}
-                      className="text-fg-muted px-6 py-10 text-center"
+                      className="text-fg-muted flex min-h-72 flex-col items-center justify-center px-6 text-center"
                       role="alert"
                     >
                       <p className="text-fg-base text-sm font-medium">
@@ -309,7 +309,7 @@ export function SearchCommand({
                       initial={reduceMotion ? false : { opacity: 0, y: 4 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ duration: reduceMotion ? 0 : 0.18 }}
-                      className="text-fg-muted px-6 py-10 text-center"
+                      className="text-fg-muted flex min-h-72 flex-col items-center justify-center px-6 text-center"
                       aria-live="polite"
                     >
                       <p className="text-fg-base text-sm font-medium">

--- a/packages/ui/src/components/search/search-empty.tsx
+++ b/packages/ui/src/components/search/search-empty.tsx
@@ -26,17 +26,23 @@ export function SearchEmpty({
   reduceMotion,
 }: SearchEmptyProps) {
   const isShortQuery = !!shortQuery && shortQuery.length > 0;
+  // The hint states (no input yet, or a too-short query) read best centered in
+  // the panel; the recents *list* stays top-aligned where a list belongs.
+  const centerVertically = isShortQuery || recents.length === 0;
 
   return (
     <motion.div
       initial={reduceMotion ? false : { opacity: 0, y: 4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
-      className="px-4 py-6"
+      className={cn(
+        'px-4 py-6',
+        centerVertically && 'flex min-h-72 flex-col justify-center',
+      )}
     >
       {isShortQuery ? (
         <div
-          className="text-fg-muted mb-6 flex flex-col items-center justify-center gap-2 px-4 py-6 text-center"
+          className="text-fg-muted flex flex-col items-center justify-center gap-2 px-4 py-6 text-center"
           aria-live="polite"
         >
           <span className="border-border-base bg-bg-elevated/40 inline-flex size-10 items-center justify-center rounded-full border">
@@ -101,7 +107,7 @@ export function SearchEmpty({
           </ul>
         </section>
       ) : (
-        <div className="text-fg-muted mb-6 flex flex-col items-center justify-center gap-2 px-4 py-6 text-center">
+        <div className="text-fg-muted flex flex-col items-center justify-center gap-2 px-4 py-6 text-center">
           <span className="border-border-base bg-bg-elevated/40 inline-flex size-10 items-center justify-center rounded-full border">
             <Search aria-hidden className="size-4" />
           </span>

--- a/services/platform/app/components/ui/data-table/data-table-pagination.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-pagination.tsx
@@ -67,6 +67,13 @@ export function DataTablePagination({
   // Use provided totalPages or calculate from total and pageSize
   const totalPageCount = totalPages ?? Math.ceil(total / pageSize);
 
+  // When everything fits on a single page there's nothing to navigate, so the
+  // page-size selector, prev/next buttons and page dropdown are just noise
+  // (e.g. a 1-member org). Collapse them to the bare count. Guard against
+  // cursor-based pagination (unknown total) where neighbours still exist.
+  const isSinglePage =
+    totalPageCount <= 1 && hasNextPage !== true && hasPreviousPage !== true;
+
   // Determine if buttons should be disabled
   const isPrevDisabled =
     isLoading || currentPage === 1 || hasPreviousPage === false;
@@ -99,7 +106,7 @@ export function DataTablePagination({
         className,
       )}
     >
-      {showPageSizeSelector && onPageSizeChange && (
+      {!isSinglePage && showPageSizeSelector && onPageSizeChange && (
         <div className="mr-4 hidden items-center gap-2 sm:flex">
           <Text as="span" variant="caption">
             {t('pagination.rowsPerPage')}
@@ -117,22 +124,24 @@ export function DataTablePagination({
         </div>
       )}
 
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handlePrevious}
-        disabled={isPrevDisabled}
-        className="p-1.5"
-        title={t('aria.previousPage')}
-      >
-        {isLoading ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : (
-          <ChevronLeft className="size-4" />
-        )}
-      </Button>
+      {!isSinglePage && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handlePrevious}
+          disabled={isPrevDisabled}
+          className="p-1.5"
+          title={t('aria.previousPage')}
+        >
+          {isLoading ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <ChevronLeft className="size-4" />
+          )}
+        </Button>
+      )}
 
-      {totalPageCount > 0 && (
+      {!isSinglePage && totalPageCount > 0 && (
         <Select
           value={currentPage.toString()}
           onValueChange={handlePageSelect}
@@ -145,20 +154,22 @@ export function DataTablePagination({
         />
       )}
 
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handleNext}
-        disabled={isNextDisabled}
-        className="p-1.5"
-        title={t('aria.nextPage')}
-      >
-        {isLoading ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : (
-          <ChevronRight className="size-4" />
-        )}
-      </Button>
+      {!isSinglePage && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleNext}
+          disabled={isNextDisabled}
+          className="p-1.5"
+          title={t('aria.nextPage')}
+        >
+          {isLoading ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <ChevronRight className="size-4" />
+          )}
+        </Button>
+      )}
 
       {total > 0 && (
         <Text

--- a/services/platform/app/features/projects/components/project-rename-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-rename-dialog.tsx
@@ -101,7 +101,6 @@ export function ProjectRenameDialog({
       open={open}
       onOpenChange={onOpenChange}
       title={t('rowActions.renameDialogTitle')}
-      description={t('rowActions.renameDialogDescription')}
       submitText={t('rowActions.renameSubmit')}
       submittingText={t('rowActions.renameSubmitting')}
       isSubmitting={isSubmitting}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7482,7 +7482,6 @@
       "duplicateSuccess": "Projekt dupliziert",
       "duplicateError": "Projekt konnte nicht dupliziert werden",
       "renameDialogTitle": "Projekt umbenennen",
-      "renameDialogDescription": "Den Projektnamen ändern.",
       "renameSubmit": "Speichern",
       "renameSubmitting": "Wird gespeichert…"
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5111,7 +5111,6 @@
       "duplicateSuccess": "Project duplicated",
       "duplicateError": "Couldn't duplicate project",
       "renameDialogTitle": "Rename project",
-      "renameDialogDescription": "Change the project name.",
       "renameSubmit": "Save",
       "renameSubmitting": "Saving…"
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7483,7 +7483,6 @@
       "duplicateSuccess": "Projet dupliqué",
       "duplicateError": "Impossible de dupliquer le projet",
       "renameDialogTitle": "Renommer le projet",
-      "renameDialogDescription": "Modifier le nom du projet.",
       "renameSubmit": "Enregistrer",
       "renameSubmitting": "Enregistrement…"
     },


### PR DESCRIPTION
## Summary

- Remove duplicate search close button and center empty states
- Drop redundant subtitle from project rename dialog
- Collapse pagination chrome when table fits on one page

## Pre-PR checklist

- [ ] Ran `bun run check` (format, lint, typecheck, all tests).
- [ ] No hand-rolled skeletons or magic `h-[…]` on skeletons — or N/A.
- [ ] Updated `services/platform/messages/{en,de,fr}.json` — or N/A.
- [ ] Updated `/docs/{en,de,fr}/` for every user-visible change — or N/A.
- [ ] Every touched docs page has a real opening and closing — or N/A.
- [ ] Ran `bun run --filter @tale/docs lint` and test — or N/A.
- [ ] Updated `README.md`, `README.de.md`, `README.fr.md` — or N/A.