### PR TITLE
feat: prerender web and docs SEO to match the live page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,8 @@ services/web/public/fr/
 # build artifacts under services/* (each service has its own dist/dist-ssr)
 services/*/dist
 services/*/dist-ssr
+# precompiled SEO + LLM artifact set (built in the Docker builder stage)
+services/*/dist-seo
 # vite-plugin-pwa dev-mode service worker output (regenerated on each dev run)
 services/*/dist-pwa
 services/*/dev-dist

--- a/packages/ui/src/seo/document-meta.ts
+++ b/packages/ui/src/seo/document-meta.ts
@@ -1,197 +1,66 @@
-import { ALL_LOCALES, type SupportedLocale } from '@tale/ui/i18n/locales';
-import { useEffect } from 'react';
-
-interface DocumentMeta {
-  title: string;
-  description: string;
-  /** Path on the current host, e.g. `/pricing`, `/de/legal/privacy-policy`. */
-  canonicalPath?: string;
-  /** Override the site title suffix. Defaults to `Tale`. */
-  siteName?: string;
-  /** Origin without trailing slash, e.g. `https://example.com`. */
-  siteUrl: string;
-  /** Optional OpenGraph image URL. */
-  ogImage?: string;
-  /**
-   * Optional fallback OpenGraph image URL used when `ogImage` is not set.
-   * Should be an absolute URL (or a path resolved against `siteUrl`) pointing
-   * to a 1200×630 PNG so crawlers always have a social card to render.
-   * Example: `${siteUrl}/images/og-default.png`.
-   */
-  defaultOgImage?: string;
-  /** Set `noindex,nofollow` for legal-style pages. */
-  noindex?: boolean;
-  /** When provided, emit hreflang alternates per locale. */
-  hreflang?: {
-    locale: SupportedLocale;
-    /** Map from each base locale to the absolute URL of that locale's variant. */
-    alternates: Partial<Record<SupportedLocale, string>>;
-  };
-  /** Stringified JSON-LD blocks to inject as <script type="application/ld+json">. */
-  jsonLd?: string[];
-}
-
-function setMeta(
-  selector: string,
-  attr: 'name' | 'property',
-  key: string,
-  content: string,
-) {
-  let el = document.head.querySelector<HTMLMetaElement>(selector);
-  if (!el) {
-    el = document.createElement('meta');
-    el.setAttribute(attr, key);
-    document.head.appendChild(el);
-  }
-  el.setAttribute('content', content);
-}
-
-function setLink(rel: string, href: string, hreflang?: string) {
-  const selector = hreflang
-    ? `link[rel="${rel}"][hreflang="${hreflang}"]`
-    : `link[rel="${rel}"]`;
-  let el = document.head.querySelector<HTMLLinkElement>(selector);
-  if (!el) {
-    el = document.createElement('link');
-    el.setAttribute('rel', rel);
-    if (hreflang) el.setAttribute('hreflang', hreflang);
-    document.head.appendChild(el);
-  }
-  el.setAttribute('href', href);
-}
-
-function clearAlternates() {
-  document.head
-    .querySelectorAll('link[rel="alternate"][hreflang]')
-    .forEach((el) => el.remove());
-}
-
-const JSON_LD_DATA_ATTR = 'data-tale-jsonld';
-
-function clearJsonLd() {
-  document.head
-    .querySelectorAll(
-      `script[type="application/ld+json"][${JSON_LD_DATA_ATTR}]`,
-    )
-    .forEach((el) => el.remove());
-}
-
-function appendJsonLd(blocks: readonly string[]) {
-  for (const block of blocks) {
-    const script = document.createElement('script');
-    script.type = 'application/ld+json';
-    script.setAttribute(JSON_LD_DATA_ATTR, '1');
-    script.text = block;
-    document.head.appendChild(script);
-  }
-}
-
 /**
- * Mutate `<head>` in an effect to mirror SSR-injected meta tags. Covers
- * <title>, description, canonical, OpenGraph + Twitter cards, hreflang
- * alternates, JSON-LD, and noindex. The SSR-rendered HTML already carries
- * placeholder versions of these tags so crawlers see them immediately;
- * this hook keeps them in sync as the user navigates client-side.
+ * Per-route `<head>` management. The page declares its meta once; this hook
+ * is the single place that turns it into tags. The same resolved tags feed
+ * two emitters (see `head-tags.ts`):
+ *
+ *   - **client** — applied to `document.head` in an effect as the user
+ *     navigates the SPA.
+ *   - **server** — captured into a {@link HeadSink} during `renderToString`
+ *     (the prerenderer wraps the app in `<HeadSinkContext.Provider>`), then
+ *     serialised into each route's prerendered `index.html`.
+ *
+ * Because both paths consume `resolveDocumentHead(meta)`, the prerendered
+ * head is exactly the head the live page renders — no parallel list to drift.
  */
-export function useDocumentMeta({
-  title,
-  description,
-  canonicalPath,
-  siteName = 'Tale',
-  siteUrl,
-  ogImage,
-  defaultOgImage,
-  noindex,
-  hreflang,
-  jsonLd,
-}: DocumentMeta) {
+
+import { useContext, useEffect } from 'react';
+
+import { HeadSinkContext } from './head-sink';
+import {
+  applyHeadToDocument,
+  resolveDocumentHead,
+  type DocumentHeadInput,
+} from './head-tags';
+
+type DocumentMeta = DocumentHeadInput;
+
+export function useDocumentMeta(meta: DocumentMeta): void {
+  const {
+    title,
+    description,
+    canonicalPath,
+    siteName = 'Tale',
+    siteUrl,
+    ogImage,
+    defaultOgImage,
+    noindex,
+    hreflang,
+    jsonLd,
+  } = meta;
+
+  // SSR capture. Effects don't run under `renderToString`, so record the
+  // resolved tags during render. On the client the provider is absent, so
+  // `sink` is null here and only the effect below runs.
+  const sink = useContext(HeadSinkContext);
+  if (sink) {
+    sink.tags = resolveDocumentHead(meta);
+  }
+
   useEffect(() => {
-    const fullTitle = title.includes(siteName)
-      ? title
-      : `${title} | ${siteName}`;
-    document.title = fullTitle;
-    const resolvedOgImage = ogImage ?? defaultOgImage;
-
-    setMeta('meta[name="description"]', 'name', 'description', description);
-    setMeta('meta[property="og:title"]', 'property', 'og:title', fullTitle);
-    setMeta(
-      'meta[property="og:description"]',
-      'property',
-      'og:description',
-      description,
+    applyHeadToDocument(
+      resolveDocumentHead({
+        title,
+        description,
+        canonicalPath,
+        siteName,
+        siteUrl,
+        ogImage,
+        defaultOgImage,
+        noindex,
+        hreflang,
+        jsonLd,
+      }),
     );
-    setMeta(
-      'meta[property="og:site_name"]',
-      'property',
-      'og:site_name',
-      siteName,
-    );
-    setMeta('meta[property="og:type"]', 'property', 'og:type', 'website');
-    setMeta(
-      'meta[name="twitter:card"]',
-      'name',
-      'twitter:card',
-      resolvedOgImage ? 'summary_large_image' : 'summary',
-    );
-    setMeta('meta[name="twitter:title"]', 'name', 'twitter:title', fullTitle);
-    setMeta(
-      'meta[name="twitter:description"]',
-      'name',
-      'twitter:description',
-      description,
-    );
-    if (resolvedOgImage) {
-      setMeta(
-        'meta[property="og:image"]',
-        'property',
-        'og:image',
-        resolvedOgImage,
-      );
-      setMeta(
-        'meta[name="twitter:image"]',
-        'name',
-        'twitter:image',
-        resolvedOgImage,
-      );
-    }
-
-    if (noindex) {
-      setMeta('meta[name="robots"]', 'name', 'robots', 'noindex,nofollow');
-    } else {
-      setMeta('meta[name="robots"]', 'name', 'robots', 'index,follow');
-    }
-
-    if (canonicalPath !== undefined) {
-      // Strip a trailing slash unless the path is exactly `/` so canonical
-      // and og:url are stable (e.g. `/pricing/` → `/pricing`).
-      const normalizedPath =
-        canonicalPath !== '/' && canonicalPath.endsWith('/')
-          ? canonicalPath.slice(0, -1)
-          : canonicalPath;
-      const canonical = `${siteUrl}${normalizedPath}`;
-      setLink('canonical', canonical);
-      setMeta('meta[property="og:url"]', 'property', 'og:url', canonical);
-    } else {
-      document.head.querySelector('link[rel="canonical"]')?.remove();
-      document.head.querySelector('meta[property="og:url"]')?.remove();
-    }
-
-    clearAlternates();
-    if (hreflang) {
-      for (const locale of ALL_LOCALES) {
-        const alt =
-          // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- ALL_LOCALES iteration; lookups fall back to base
-          hreflang.alternates[locale as SupportedLocale] ??
-          // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- base-locale fallback may be undefined
-          hreflang.alternates[locale.split('-')[0] as SupportedLocale];
-        if (alt) setLink('alternate', alt, locale);
-      }
-      const enUrl = hreflang.alternates.en;
-      if (enUrl) setLink('alternate', enUrl, 'x-default');
-    }
-
-    clearJsonLd();
-    if (jsonLd && jsonLd.length > 0) appendJsonLd(jsonLd);
   }, [
     title,
     description,
@@ -205,3 +74,8 @@ export function useDocumentMeta({
     jsonLd,
   ]);
 }
+
+// Re-exported so the SSR entry points import the capture seam + serialiser
+// from one place (`@tale/ui/seo/document-meta`).
+export { HeadSinkContext, createHeadSink } from './head-sink';
+export { renderHeadToHtml } from './head-tags';

--- a/packages/ui/src/seo/head-sink.ts
+++ b/packages/ui/src/seo/head-sink.ts
@@ -1,0 +1,26 @@
+/**
+ * SSR head-collection seam. During `renderToString`, the prerenderer wraps
+ * the app in `<HeadSinkContext.Provider value={sink}>` and reads
+ * `sink.tags` afterwards. `useDocumentMeta` records into the sink *during
+ * render* (effects don't run under `renderToString`), so the captured head
+ * is exactly what the route declared.
+ *
+ * On the client the provider is absent (`useContext` returns `null`), so
+ * the hook falls back to its `useEffect` DOM path — zero client behaviour
+ * change.
+ */
+
+import { createContext } from 'react';
+
+import type { HeadTag } from './head-tags';
+
+interface HeadSink {
+  /** Last writer wins — one `useDocumentMeta` call per render in practice. */
+  tags: HeadTag[];
+}
+
+export function createHeadSink(): HeadSink {
+  return { tags: [] };
+}
+
+export const HeadSinkContext = createContext<HeadSink | null>(null);

--- a/packages/ui/src/seo/head-tags.test.ts
+++ b/packages/ui/src/seo/head-tags.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Guards the "prerendered head == live page head" contract. The prerenderer
+ * (`renderHeadToHtml`) and the client hook (`applyHeadToDocument`) both
+ * consume the *same* `resolveDocumentHead(meta)` output, so this suite pins
+ * that one resolver and proves the two emitters stay in agreement.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  applyHeadToDocument,
+  renderHeadToHtml,
+  resolveDocumentHead,
+  type DocumentHeadInput,
+} from './head-tags';
+
+const base: DocumentHeadInput = {
+  title: 'Pricing',
+  description: 'Two ways to run Tale.',
+  canonicalPath: '/pricing',
+  siteUrl: 'https://tale.dev',
+};
+
+describe('resolveDocumentHead', () => {
+  it('suffixes the site name and emits the core SEO tag set', () => {
+    const tags = resolveDocumentHead(base);
+    expect(tags).toContainEqual({ tag: 'title', text: 'Pricing | Tale' });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'name',
+      key: 'description',
+      content: 'Two ways to run Tale.',
+    });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'property',
+      key: 'og:title',
+      content: 'Pricing | Tale',
+    });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'name',
+      key: 'robots',
+      content: 'index,follow',
+    });
+    expect(tags).toContainEqual({
+      tag: 'link',
+      rel: 'canonical',
+      href: 'https://tale.dev/pricing',
+    });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'property',
+      key: 'og:url',
+      content: 'https://tale.dev/pricing',
+    });
+  });
+
+  it('does not double-suffix a title that already contains the site name', () => {
+    const tags = resolveDocumentHead({ ...base, title: 'Tale: Home' });
+    expect(tags.find((t) => t.tag === 'title')).toEqual({
+      tag: 'title',
+      text: 'Tale: Home',
+    });
+  });
+
+  it('emits noindex robots and no canonical/og:url for a path-less page', () => {
+    const tags = resolveDocumentHead({
+      title: 'Legal',
+      description: 'x',
+      siteUrl: 'https://tale.dev',
+      noindex: true,
+    });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'name',
+      key: 'robots',
+      content: 'noindex,nofollow',
+    });
+    expect(tags.some((t) => t.tag === 'link' && t.rel === 'canonical')).toBe(
+      false,
+    );
+    expect(tags.some((t) => t.tag === 'meta' && t.key === 'og:url')).toBe(
+      false,
+    );
+  });
+
+  it('strips a trailing slash from the canonical (but keeps root `/`)', () => {
+    expect(
+      resolveDocumentHead({ ...base, canonicalPath: '/pricing/' }),
+    ).toContainEqual({
+      tag: 'link',
+      rel: 'canonical',
+      href: 'https://tale.dev/pricing',
+    });
+    expect(resolveDocumentHead({ ...base, canonicalPath: '/' })).toContainEqual(
+      {
+        tag: 'link',
+        rel: 'canonical',
+        href: 'https://tale.dev/',
+      },
+    );
+  });
+
+  it('emits hreflang alternates (incl. x-default) and JSON-LD scripts', () => {
+    const tags = resolveDocumentHead({
+      ...base,
+      hreflang: {
+        locale: 'en',
+        alternates: {
+          en: 'https://tale.dev/pricing',
+          de: 'https://tale.dev/de/pricing',
+        },
+      },
+      jsonLd: ['{"@type":"Article"}'],
+    });
+    expect(tags).toContainEqual({
+      tag: 'link',
+      rel: 'alternate',
+      href: 'https://tale.dev/de/pricing',
+      hreflang: 'de',
+    });
+    expect(tags).toContainEqual({
+      tag: 'link',
+      rel: 'alternate',
+      href: 'https://tale.dev/pricing',
+      hreflang: 'x-default',
+    });
+    expect(tags).toContainEqual({
+      tag: 'script',
+      jsonLd: '{"@type":"Article"}',
+    });
+  });
+
+  it('upgrades twitter:card and adds image tags when an og image is set', () => {
+    const tags = resolveDocumentHead({
+      ...base,
+      defaultOgImage: 'https://tale.dev/og.png',
+    });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'name',
+      key: 'twitter:card',
+      content: 'summary_large_image',
+    });
+    expect(tags).toContainEqual({
+      tag: 'meta',
+      attr: 'property',
+      key: 'og:image',
+      content: 'https://tale.dev/og.png',
+    });
+  });
+});
+
+describe('renderHeadToHtml', () => {
+  it('serializes and HTML-escapes attribute values', () => {
+    const html = renderHeadToHtml(
+      resolveDocumentHead({ ...base, description: 'A "quote" & <tag>' }),
+    );
+    expect(html).toContain('<title>Pricing | Tale</title>');
+    expect(html).toContain('content="A &quot;quote&quot; &amp; &lt;tag&gt;"');
+    expect(html).toContain(
+      '<link rel="canonical" href="https://tale.dev/pricing" />',
+    );
+  });
+
+  it('escapes `<` and `&` inside JSON-LD so the script cannot break out', () => {
+    const html = renderHeadToHtml(
+      resolveDocumentHead({ ...base, jsonLd: ['{"a":"</script><b>&"}'] }),
+    );
+    expect(html).toContain('\\u003c/script');
+    expect(html).not.toContain('</script><b>');
+  });
+});
+
+describe('applyHeadToDocument ↔ renderHeadToHtml parity', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('produces a client DOM that matches the prerendered tags', () => {
+    applyHeadToDocument(resolveDocumentHead(base));
+    expect(document.title).toBe('Pricing | Tale');
+    expect(
+      document.head
+        .querySelector('meta[name="description"]')
+        ?.getAttribute('content'),
+    ).toBe('Two ways to run Tale.');
+    expect(
+      document.head
+        .querySelector('link[rel="canonical"]')
+        ?.getAttribute('href'),
+    ).toBe('https://tale.dev/pricing');
+    expect(
+      document.head
+        .querySelector('meta[name="robots"]')
+        ?.getAttribute('content'),
+    ).toBe('index,follow');
+  });
+
+  it('clears stale alternates + JSON-LD and drops canonical on the next route', () => {
+    applyHeadToDocument(
+      resolveDocumentHead({
+        ...base,
+        hreflang: {
+          locale: 'en',
+          alternates: {
+            en: 'https://tale.dev/pricing',
+            de: 'https://tale.dev/de/pricing',
+          },
+        },
+        jsonLd: ['{"@type":"Article"}'],
+      }),
+    );
+    expect(
+      document.head.querySelectorAll('link[rel="alternate"][hreflang]').length,
+    ).toBeGreaterThan(0);
+    expect(
+      document.head.querySelectorAll('script[type="application/ld+json"]')
+        .length,
+    ).toBe(1);
+
+    // Navigate to a path-less route with no alternates / JSON-LD.
+    applyHeadToDocument(
+      resolveDocumentHead({
+        title: 'X',
+        description: 'y',
+        siteUrl: 'https://tale.dev',
+      }),
+    );
+    expect(document.head.querySelector('link[rel="canonical"]')).toBeNull();
+    expect(document.head.querySelector('meta[property="og:url"]')).toBeNull();
+    expect(
+      document.head.querySelectorAll('link[rel="alternate"][hreflang]').length,
+    ).toBe(0);
+    expect(
+      document.head.querySelectorAll('script[type="application/ld+json"]')
+        .length,
+    ).toBe(0);
+  });
+});

--- a/packages/ui/src/seo/head-tags.ts
+++ b/packages/ui/src/seo/head-tags.ts
@@ -1,0 +1,285 @@
+/**
+ * Framework-agnostic `<head>` model shared by the runtime hook and the
+ * build-time prerenderer. One function — {@link resolveDocumentHead} —
+ * turns a page's declared meta into an ordered list of {@link HeadTag}
+ * descriptors. Two emitters consume that list:
+ *
+ *   - {@link applyHeadToDocument} mutates `document.head` (client, in an
+ *     effect) — what the live SPA does as the user navigates.
+ *   - {@link renderHeadToHtml} serialises the same descriptors to an HTML
+ *     string the prerenderer injects into each route's `index.html`.
+ *
+ * Because both emitters consume the *same* resolved descriptors, the
+ * prerendered `<head>` is — by construction — byte-for-byte the head the
+ * live page would render. There is no second source of truth to drift.
+ */
+
+import { ALL_LOCALES, type SupportedLocale } from '@tale/ui/i18n/locales';
+
+export interface DocumentHeadInput {
+  title: string;
+  description: string;
+  /** Path on the current host, e.g. `/pricing`, `/de/legal/privacy-policy`. */
+  canonicalPath?: string;
+  /** Override the site title suffix. Defaults to `Tale`. */
+  siteName?: string;
+  /** Origin without trailing slash, e.g. `https://example.com`. */
+  siteUrl: string;
+  /** Optional OpenGraph image URL. */
+  ogImage?: string;
+  /** Fallback OpenGraph image used when `ogImage` is unset. */
+  defaultOgImage?: string;
+  /** Set `noindex,nofollow` for legal-style pages. */
+  noindex?: boolean;
+  /** When provided, emit hreflang alternates per locale. */
+  hreflang?: {
+    locale: SupportedLocale;
+    alternates: Partial<Record<SupportedLocale, string>>;
+  };
+  /** Stringified JSON-LD blocks to inject as <script type="application/ld+json">. */
+  jsonLd?: string[];
+}
+
+export type HeadTag =
+  | { tag: 'title'; text: string }
+  | { tag: 'meta'; attr: 'name' | 'property'; key: string; content: string }
+  | { tag: 'link'; rel: string; href: string; hreflang?: string }
+  | { tag: 'script'; jsonLd: string };
+
+/**
+ * Resolve a page's declared meta into the ordered tag list. Pure — no DOM,
+ * no React — so it runs identically on the server and the client.
+ */
+export function resolveDocumentHead(meta: DocumentHeadInput): HeadTag[] {
+  const {
+    title,
+    description,
+    canonicalPath,
+    siteName = 'Tale',
+    siteUrl,
+    ogImage,
+    defaultOgImage,
+    noindex,
+    hreflang,
+    jsonLd,
+  } = meta;
+
+  const fullTitle = title.includes(siteName) ? title : `${title} | ${siteName}`;
+  const resolvedOgImage = ogImage ?? defaultOgImage;
+  const tags: HeadTag[] = [];
+
+  tags.push({ tag: 'title', text: fullTitle });
+  const m = (attr: 'name' | 'property', key: string, content: string) =>
+    tags.push({ tag: 'meta', attr, key, content });
+
+  m('name', 'description', description);
+  m('property', 'og:title', fullTitle);
+  m('property', 'og:description', description);
+  m('property', 'og:site_name', siteName);
+  m('property', 'og:type', 'website');
+  m(
+    'name',
+    'twitter:card',
+    resolvedOgImage ? 'summary_large_image' : 'summary',
+  );
+  m('name', 'twitter:title', fullTitle);
+  m('name', 'twitter:description', description);
+  if (resolvedOgImage) {
+    m('property', 'og:image', resolvedOgImage);
+    m('name', 'twitter:image', resolvedOgImage);
+  }
+  m('name', 'robots', noindex ? 'noindex,nofollow' : 'index,follow');
+
+  if (canonicalPath !== undefined) {
+    // Strip a trailing slash unless the path is exactly `/`, so canonical and
+    // og:url are stable (e.g. `/pricing/` → `/pricing`).
+    const normalizedPath =
+      canonicalPath !== '/' && canonicalPath.endsWith('/')
+        ? canonicalPath.slice(0, -1)
+        : canonicalPath;
+    const canonical = `${siteUrl}${normalizedPath}`;
+    tags.push({ tag: 'link', rel: 'canonical', href: canonical });
+    m('property', 'og:url', canonical);
+  }
+
+  if (hreflang) {
+    for (const locale of ALL_LOCALES) {
+      const alt =
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- ALL_LOCALES iteration; lookups fall back to base
+        hreflang.alternates[locale as SupportedLocale] ??
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- base-locale fallback may be undefined
+        hreflang.alternates[locale.split('-')[0] as SupportedLocale];
+      if (alt) {
+        tags.push({
+          tag: 'link',
+          rel: 'alternate',
+          href: alt,
+          hreflang: locale,
+        });
+      }
+    }
+    const enUrl = hreflang.alternates.en;
+    if (enUrl) {
+      tags.push({
+        tag: 'link',
+        rel: 'alternate',
+        href: enUrl,
+        hreflang: 'x-default',
+      });
+    }
+  }
+
+  if (jsonLd) {
+    for (const block of jsonLd) tags.push({ tag: 'script', jsonLd: block });
+  }
+
+  return tags;
+}
+
+// ---------------------------------------------------------------------------
+// Server emitter — serialise to HTML
+// ---------------------------------------------------------------------------
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Escape a JSON-LD block for safe embedding inside a `<script>` element.
+ * Only `<` and `&` can prematurely close the script or be misparsed; both
+ * stay valid JSON when escaped as `\uXXXX`.
+ */
+function escapeJsonLd(value: string): string {
+  return value.replace(/</g, '\\u003c').replace(/&/g, '\\u0026');
+}
+
+/** Marks JSON-LD scripts the client hook owns, so it can dedupe on re-render. */
+const JSON_LD_DATA_ATTR = 'data-tale-jsonld';
+
+/** Serialise resolved tags to an HTML string for the prerenderer. */
+export function renderHeadToHtml(tags: readonly HeadTag[]): string {
+  return tags
+    .map((t) => {
+      let html: string;
+      switch (t.tag) {
+        case 'title':
+          html = `<title>${escapeText(t.text)}</title>`;
+          break;
+        case 'meta':
+          html = `<meta ${t.attr}="${t.key}" content="${escapeAttr(t.content)}" />`;
+          break;
+        case 'link':
+          html = `<link rel="${t.rel}"${
+            t.hreflang ? ` hreflang="${escapeAttr(t.hreflang)}"` : ''
+          } href="${escapeAttr(t.href)}" />`;
+          break;
+        case 'script':
+          html = `<script type="application/ld+json" ${JSON_LD_DATA_ATTR}="1">${escapeJsonLd(
+            t.jsonLd,
+          )}</script>`;
+          break;
+      }
+      return html;
+    })
+    .join('\n    ');
+}
+
+// ---------------------------------------------------------------------------
+// Client emitter — mutate document.head
+// ---------------------------------------------------------------------------
+
+function upsertMeta(
+  attr: 'name' | 'property',
+  key: string,
+  content: string,
+): void {
+  const selector = `meta[${attr}="${key}"]`;
+  let el = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', content);
+}
+
+function upsertLink(rel: string, href: string, hreflang?: string): void {
+  const selector = hreflang
+    ? `link[rel="${rel}"][hreflang="${hreflang}"]`
+    : `link[rel="${rel}"]`;
+  let el = document.head.querySelector<HTMLLinkElement>(selector);
+  if (!el) {
+    el = document.createElement('link');
+    el.setAttribute('rel', rel);
+    if (hreflang) el.setAttribute('hreflang', hreflang);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('href', href);
+}
+
+/**
+ * Apply resolved tags to `document.head`, mirroring the prerendered output.
+ * Upserts singletons (title, description, canonical, og/twitter, robots);
+ * clears-then-re-adds the variable-count groups (hreflang alternates,
+ * JSON-LD) so stale entries from a previous route don't linger; removes
+ * canonical/og:url when the new route declares no canonical.
+ */
+export function applyHeadToDocument(tags: readonly HeadTag[]): void {
+  document.head
+    .querySelectorAll('link[rel="alternate"][hreflang]')
+    .forEach((el) => el.remove());
+  document.head
+    .querySelectorAll(
+      `script[type="application/ld+json"][${JSON_LD_DATA_ATTR}]`,
+    )
+    .forEach((el) => el.remove());
+
+  let hasCanonical = false;
+  let hasOgUrl = false;
+
+  for (const t of tags) {
+    switch (t.tag) {
+      case 'title':
+        document.title = t.text;
+        break;
+      case 'meta':
+        upsertMeta(t.attr, t.key, t.content);
+        if (t.key === 'og:url') hasOgUrl = true;
+        break;
+      case 'link':
+        if (t.rel === 'alternate') {
+          upsertLink('alternate', t.href, t.hreflang);
+        } else {
+          upsertLink(t.rel, t.href);
+          if (t.rel === 'canonical') hasCanonical = true;
+        }
+        break;
+      case 'script': {
+        const script = document.createElement('script');
+        script.type = 'application/ld+json';
+        script.setAttribute(JSON_LD_DATA_ATTR, '1');
+        script.text = t.jsonLd;
+        document.head.appendChild(script);
+        break;
+      }
+    }
+  }
+
+  if (!hasCanonical) {
+    document.head.querySelector('link[rel="canonical"]')?.remove();
+  }
+  if (!hasOgUrl) {
+    document.head.querySelector('meta[property="og:url"]')?.remove();
+  }
+}

--- a/services/docs/app/entry-server.tsx
+++ b/services/docs/app/entry-server.tsx
@@ -1,5 +1,10 @@
 import { AppShell } from '@tale/ui/app-shell';
 import {
+  createHeadSink,
+  HeadSinkContext,
+  renderHeadToHtml,
+} from '@tale/ui/seo/document-meta';
+import {
   createMemoryHistory,
   createRouter,
   RouterProvider,
@@ -13,6 +18,8 @@ import { routeTree } from './routeTree.gen';
 
 interface RenderResult {
   html: string;
+  /** Serialised per-route `<head>` captured during render (see HeadSink). */
+  head: string;
 }
 
 const basepath =
@@ -26,6 +33,10 @@ export async function render(url: string): Promise<RenderResult> {
     history: createMemoryHistory({ initialEntries: [url] }),
   });
   await router.load();
+  // Collect the route's `<head>` during render — `useDocumentMeta` writes
+  // into the sink as the tree renders (effects don't run under
+  // `renderToString`). Mirror any change here in `app/main.tsx`.
+  const sink = createHeadSink();
   // `theme={{ defaultTheme: 'light' }}` matches the CSR path's pinned
   // light theme and keeps SSR/CSR hydration in sync. AppShell's default
   // `'system'` would otherwise resolve to dark for OS-dark crawlers
@@ -33,10 +44,12 @@ export async function render(url: string): Promise<RenderResult> {
   // M9.
   const html = renderToString(
     <StrictMode>
-      <AppShell i18n={i18n} theme={{ defaultTheme: 'light' }}>
-        <RouterProvider router={router} />
-      </AppShell>
+      <HeadSinkContext.Provider value={sink}>
+        <AppShell i18n={i18n} theme={{ defaultTheme: 'light' }}>
+          <RouterProvider router={router} />
+        </AppShell>
+      </HeadSinkContext.Provider>
     </StrictMode>,
   );
-  return { html };
+  return { html, head: renderHeadToHtml(sink.tags) };
 }

--- a/services/docs/app/main.tsx
+++ b/services/docs/app/main.tsx
@@ -13,6 +13,16 @@ import './locals.css';
 const root = document.getElementById('root');
 if (!root) throw new Error('Missing #root element');
 
+// Intentionally `createRoot`, NOT `hydrateRoot`. The prerendered HTML
+// (scripts/prerender.ts) still carries the full body + correct `<head>` for
+// crawlers and instant first paint, but a doc page's body is fetched by an
+// async route loader (`$.tsx` → `ensureDocBody`, a lazy dynamic import). On the
+// client that body isn't in cache on the first synchronous render, so
+// hydration would mismatch the SSR markup. createRoot adopts the URL + theme
+// deterministically and re-renders to the identical final DOM. (Web is
+// createRoot too — its non-Start TanStack Router Suspense markers don't
+// rehydrate cleanly; see services/web/app/main.tsx.)
+//
 // `<AppShell>` is mounted without `locale` because docs reads its locale
 // from the URL — `__root.tsx` calls `<LocaleSync>` directly with
 // `useCurrentLocale()`.

--- a/services/docs/index.html
+++ b/services/docs/index.html
@@ -31,6 +31,13 @@
       content="#0a0a0a"
       media="(prefers-color-scheme: dark)"
     />
+    <!-- seo:start -->
+    <!--
+      Per-route SEO tags. In production the prerenderer (scripts/prerender.ts)
+      replaces everything between seo:start/seo:end with the exact `<head>`
+      the route's `useDocumentMeta` renders (incl. robots, hreflang, JSON-LD).
+      These defaults are what dev and the SPA-shell fallback show pre-JS.
+    -->
     <title>Tale documentation</title>
     <meta
       name="description"
@@ -51,6 +58,7 @@
       name="twitter:description"
       content="Documentation for Tale — the orchestration layer for AI agents."
     />
+    <!-- seo:end -->
     <link
       rel="alternate"
       type="text/plain"

--- a/services/docs/scripts/prerender.ts
+++ b/services/docs/scripts/prerender.ts
@@ -1,28 +1,30 @@
 // Prerender every doc route to a static HTML file under ./dist. Mirrors
 // services/web/scripts/prerender.ts but enumerates pages from the content
 // tree instead of a hand-maintained list.
+//
+// Each route's `<head>` is captured from the page's own `useDocumentMeta`
+// during SSR (see `app/entry-server.tsx` + `@tale/ui/seo` HeadSink), so the
+// prerendered head matches the live page exactly — including robots, hreflang
+// alternates, and Article/Breadcrumb JSON-LD, which the old regex injector
+// dropped.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { DEFAULT_DOCS_SITE_URL } from '../lib/site-url';
 import { listAllContent } from './walk-content';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, '..');
 const DIST = resolve(ROOT, 'dist');
 const SSR_BUNDLE = resolve(ROOT, 'dist-ssr', 'entry-server.js');
-const SITE_URL = process.env.DOCS_SITE_URL ?? DEFAULT_DOCS_SITE_URL;
 // Mount-point prefix passed to the router during SSR so it resolves URLs
 // against the same basepath the client uses. Empty for root deployments.
 const BASE_PATH = (process.env.DOCS_BASE_URL ?? '/').replace(/\/$/, '');
 
 interface Route {
   url: string;
-  title: string;
-  description: string;
-  noindex?: boolean;
+  locale: string;
 }
 
 function pathFor(locale: string, slug: string): string {
@@ -31,49 +33,23 @@ function pathFor(locale: string, slug: string): string {
   return cleaned ? `/${locale}/${cleaned}` : `/${locale}`;
 }
 
-function escapeAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+/** Replace the seo:start/seo:end block with the route's captured `<head>`. */
+function injectHead(template: string, head: string): string {
+  return template.replace(
+    /<!-- seo:start -->[\s\S]*?<!-- seo:end -->/,
+    () => `<!-- seo:start -->\n    ${head}\n    <!-- seo:end -->`,
+  );
 }
 
-function injectSeo(template: string, route: Route): string {
-  const canonical = `${SITE_URL}${route.url}`;
-  return template
-    .replace(
-      /<title>[^<]*<\/title>/,
-      `<title>${escapeAttr(route.title)}</title>`,
-    )
-    .replace(
-      /<meta\s+name="description"[^>]*>/,
-      `<meta name="description" content="${escapeAttr(route.description)}" />`,
-    )
-    .replace(
-      /<link\s+rel="canonical"[^>]*>/,
-      `<link rel="canonical" href="${canonical}" />`,
-    )
-    .replace(
-      /<meta\s+property="og:url"[^>]*>/,
-      `<meta property="og:url" content="${canonical}" />`,
-    )
-    .replace(
-      /<meta\s+property="og:title"[^>]*>/,
-      `<meta property="og:title" content="${escapeAttr(route.title)}" />`,
-    )
-    .replace(
-      /<meta\s+property="og:description"[^>]*>/,
-      `<meta property="og:description" content="${escapeAttr(route.description)}" />`,
-    )
-    .replace(
-      /<meta\s+name="twitter:title"[^>]*>/,
-      `<meta name="twitter:title" content="${escapeAttr(route.title)}" />`,
-    )
-    .replace(
-      /<meta\s+name="twitter:description"[^>]*>/,
-      `<meta name="twitter:description" content="${escapeAttr(route.description)}" />`,
-    );
+function injectBody(template: string, html: string): string {
+  return template.replace(
+    '<div id="root"></div>',
+    () => `<div id="root">${html}</div>`,
+  );
+}
+
+function setHtmlLang(template: string, locale: string): string {
+  return template.replace(/<html lang="[^"]*"/, () => `<html lang="${locale}"`);
 }
 
 async function main() {
@@ -81,21 +57,13 @@ async function main() {
   const template = await readFile(resolve(DIST, 'index.html'), 'utf-8');
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const mod = (await import(pathToFileURL(SSR_BUNDLE).href)) as {
-    render: (url: string) => Promise<{ html: string }>;
+    render: (url: string) => Promise<{ html: string; head: string }>;
   };
 
   const records = await listAllContent();
   const routes: Route[] = records.map((record) => ({
     url: pathFor(record.locale, record.slug),
-    title:
-      typeof record.frontmatter.title === 'string'
-        ? `${record.frontmatter.title} | Tale`
-        : 'Tale',
-    description:
-      typeof record.frontmatter.description === 'string'
-        ? record.frontmatter.description
-        : '',
-    noindex: record.frontmatter.noindex === true,
+    locale: record.locale,
   }));
 
   // De-duplicate (the locale fallback chain doesn't apply to URLs, only content).
@@ -105,12 +73,13 @@ async function main() {
     if (seen.has(route.url)) continue;
     seen.add(route.url);
     process.stdout.write(`prerender ${route.url} ... `);
-    const { html } = await mod.render(`${BASE_PATH}${route.url}`);
-    const withSeo = injectSeo(template, route);
-    const final = withSeo.replace(
-      '<div id="root"></div>',
-      `<div id="root">${html}</div>`,
+
+    const { html, head } = await mod.render(`${BASE_PATH}${route.url}`);
+    const final = setHtmlLang(
+      injectBody(injectHead(template, head), html),
+      route.locale,
     );
+
     const outPath =
       route.url === '/'
         ? resolve(DIST, 'index.html')

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -47,13 +47,16 @@ ENV NODE_ENV=production \
     WEB_DOCS_URL=${WEB_DOCS_URL} \
     VITE_DOCS_URL=${WEB_DOCS_URL}
 WORKDIR /app/services/web
-# Build the SPA + SSR bundle, then precompile the SEO + LLM artifact set
-# into `dist-seo/`. The compile step uses the SSR bundle (loaded as a
-# `file://` import) to render marketing route bodies at build time, plus
-# reads legal markdown from `app/content/legal/` — neither source is
-# available in the runner stage, so this MUST run in the builder.
+# Build the SPA + SSR bundle, prerender every marketing/legal route (× locale)
+# to static `dist/<route>/index.html` with the route's real `<head>` + body,
+# then precompile the SEO + LLM artifact set into `dist-seo/`. The prerender
+# and compile steps both use the SSR bundle (loaded as a `file://` import) and
+# read legal markdown from `app/content/legal/` — neither source is available
+# in the runner stage, so these MUST run in the builder. (`bun run build` does
+# the first three; they are spelled out here to interleave seo-compile.)
 RUN bun --bun vite build \
     && bun --bun vite build --ssr app/entry-server.tsx --outDir dist-ssr \
+    && bun --bun scripts/prerender.ts \
     && bun --bun /app/packages/ui/bin/seo-compile.ts ./scripts/seo.config.ts --out dist-seo \
     && bun build server.ts --target=bun --outfile=server.js --external bun --external canvas
 WORKDIR /app

--- a/services/web/README.md
+++ b/services/web/README.md
@@ -4,7 +4,7 @@ Tale marketing site
 
 ```bash
 bun run --filter @tale/web dev       # Vite dev server on :3001
-bun run --filter @tale/web build     # Production bundle
+bun run --filter @tale/web build     # client + SSR bundle, then prerender routes to static HTML
 bun run --filter @tale/web typecheck
 bun run --filter @tale/web test
 ```

--- a/services/web/app/entry-server.tsx
+++ b/services/web/app/entry-server.tsx
@@ -1,5 +1,10 @@
 import { AppShell } from '@tale/ui/app-shell';
 import {
+  createHeadSink,
+  HeadSinkContext,
+  renderHeadToHtml,
+} from '@tale/ui/seo/document-meta';
+import {
   RouterProvider,
   createMemoryHistory,
   createRouter,
@@ -14,6 +19,8 @@ import { routeTree } from './routeTree.gen';
 
 export interface RenderResult {
   html: string;
+  /** Serialised per-route `<head>` captured during render (see HeadSink). */
+  head: string;
 }
 
 export async function render(url: string): Promise<RenderResult> {
@@ -34,13 +41,20 @@ export async function render(url: string): Promise<RenderResult> {
 
   await router.load();
 
+  // Collect the route's `<head>` as the tree renders — `useDocumentMeta`
+  // writes into the sink during render (effects don't run under
+  // `renderToString`). Mirror any change here in `app/main.tsx`.
+  const sink = createHeadSink();
+
   const html = renderToString(
     <StrictMode>
-      <AppShell i18n={i18n} theme>
-        <RouterProvider router={router} />
-      </AppShell>
+      <HeadSinkContext.Provider value={sink}>
+        <AppShell i18n={i18n} theme>
+          <RouterProvider router={router} />
+        </AppShell>
+      </HeadSinkContext.Provider>
     </StrictMode>,
   );
 
-  return { html };
+  return { html, head: renderHeadToHtml(sink.tags) };
 }

--- a/services/web/app/main.tsx
+++ b/services/web/app/main.tsx
@@ -13,6 +13,16 @@ import './locals.css';
 const root = document.getElementById('root');
 if (!root) throw new Error('Missing #root element');
 
+// Intentionally `createRoot`, NOT `hydrateRoot`. The prerendered HTML
+// (scripts/prerender.ts) carries the route's full body + exact `<head>` for
+// crawlers and instant first paint, but this is a plain (non-Start) TanStack
+// Router: it wraps the `<Outlet>` in a Suspense boundary whose SSR markers
+// (`<!--$-->`) aren't dehydrated/rehydrated, so `hydrateRoot` reports a
+// recoverable mismatch (React #418) and regenerates the tree anyway. createRoot
+// adopts the URL + theme deterministically and renders the identical final DOM
+// without the warning. (Docs is createRoot for the same family of reason —
+// async route loaders; see services/docs/app/main.tsx.)
+//
 // `<AppShell>` is mounted without `locale` because the marketing site reads
 // its locale from the URL — `__root.tsx` calls `<LocaleSync>` directly with
 // `useCurrentLocale()`. Mirror any change here in `app/entry-server.tsx`.

--- a/services/web/index.html
+++ b/services/web/index.html
@@ -3,12 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tale: The Orchestration Layer for AI Agents</title>
-    <meta
-      name="description"
-      content="Tale is a self-hosted AI platform for data-sensitive organizations — local AI models, agents, and automations on your own infrastructure. ISO 27001 & SOC 2 certified. Swiss-based."
-    />
-    <link rel="canonical" href="https://tale.dev/" />
     <meta name="theme-color" content="#fcfcfc" />
     <script>
       (function () {
@@ -42,6 +36,19 @@
       media="(prefers-color-scheme: dark)"
     />
 
+    <!-- seo:start -->
+    <!--
+      Per-route SEO tags. In production the prerenderer (scripts/prerender.ts)
+      replaces everything between seo:start/seo:end with the exact `<head>`
+      the route's `useDocumentMeta` renders. These defaults are what dev and
+      the SPA-shell fallback (un-prerendered routes) show before JS boots.
+    -->
+    <title>Tale: The Orchestration Layer for AI Agents</title>
+    <meta
+      name="description"
+      content="Tale is a self-hosted AI platform for data-sensitive organizations — local AI models, agents, and automations on your own infrastructure. ISO 27001 & SOC 2 certified. Swiss-based."
+    />
+    <link rel="canonical" href="https://tale.dev/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Tale" />
     <meta property="og:url" content="https://tale.dev/" />
@@ -53,7 +60,6 @@
       property="og:description"
       content="Self-hosted AI platform for data-sensitive organizations — local AI models, agents, and automations on your own infrastructure. ISO 27001 & SOC 2 certified."
     />
-
     <meta name="twitter:card" content="summary" />
     <meta
       name="twitter:title"
@@ -63,6 +69,7 @@
       name="twitter:description"
       content="Self-hosted AI platform for data-sensitive organizations. ISO 27001 & SOC 2 certified."
     />
+    <!-- seo:end -->
 
     <link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt" />
     <link

--- a/services/web/lib/seo/marketing-routes.ts
+++ b/services/web/lib/seo/marketing-routes.ts
@@ -1,3 +1,5 @@
+import enMessages from '../../messages/en.json';
+
 interface MarketingRoute {
   /** Site-relative URL, e.g. `/`, `/pricing`. */
   url: string;
@@ -7,38 +9,30 @@ interface MarketingRoute {
 
 /**
  * Marketing routes the on-demand artifact server is allowed to serve.
- * Used by `lib/seo/artifacts-server.ts` for sitemap/llms.txt entries and
- * SSR-rendered `.md` exports. Legal pages live alongside as markdown
- * files under `app/content/legal/` and are picked up automatically.
+ * Used by `lib/seo/artifacts-server.ts` for sitemap/llms.txt entries and by
+ * `scripts/prerender.ts` for the static route list. Legal pages live
+ * alongside as markdown under `app/content/legal/` and are picked up
+ * automatically.
+ *
+ * Title + description come from the `seo` i18n namespace — the exact strings
+ * each page renders via `useT('seo')` + `useDocumentMeta` — so the sitemap,
+ * llms.txt, and the prerendered `<head>` all describe a page identically.
+ * There is no second copy to drift.
  */
-export const MARKETING_ROUTES: readonly MarketingRoute[] = [
-  {
-    url: '/',
-    title: 'Tale: The Orchestration Layer for AI Agents',
-    description:
-      'Self-hosted AI platform for data-sensitive organisations — local AI models, agents, and automations on your own infrastructure.',
-  },
-  {
-    url: '/pricing',
-    title: 'Pricing',
-    description:
-      'One price for your entire team — no per-seat fees, no hidden costs.',
-  },
-  {
-    url: '/hardware-pricing',
-    title: 'Hardware pricing',
-    description:
-      'High-performance AI hardware — Quality, Hybrid, and Speed configurations.',
-  },
-  {
-    url: '/contact',
-    title: 'Contact',
-    description: 'Get in touch with the Tale team.',
-  },
-  {
-    url: '/request-demo',
-    title: 'Request a demo',
-    description:
-      'Talk with a domain expert about your use case for sovereign AI.',
-  },
-];
+const ROUTE_SEO_KEYS = [
+  { url: '/', key: 'home' },
+  { url: '/pricing', key: 'pricing' },
+  { url: '/hardware-pricing', key: 'hardwarePricing' },
+  { url: '/contact', key: 'contact' },
+  { url: '/request-demo', key: 'requestDemo' },
+] as const;
+
+const seo = enMessages.seo;
+
+export const MARKETING_ROUTES: readonly MarketingRoute[] = ROUTE_SEO_KEYS.map(
+  ({ url, key }) => ({
+    url,
+    title: seo[key].title,
+    description: seo[key].description,
+  }),
+);

--- a/services/web/scripts/prerender.ts
+++ b/services/web/scripts/prerender.ts
@@ -1,15 +1,21 @@
-// Prerender each marketing route to a static HTML file under ./dist.
-// Runs after `vite build` (client) and `vite build --ssr` (server entry).
+// Prerender each marketing route (× locale) to a static HTML file under
+// ./dist. Runs after `vite build` (client) and `vite build --ssr` (server
+// entry).
 //
-// The output preserves SPA hydration: each route's index.html embeds the
-// rendered markup inside `<div id="root">…</div>` plus per-route SEO meta,
-// so search engines and previews see fully-formed HTML while users still
-// boot the same JS bundle on top.
+// Each route's `index.html` embeds the rendered markup inside
+// `<div id="root">…</div>` and the route's real `<head>` — captured from the
+// page's own `useDocumentMeta` during SSR (see `app/entry-server.tsx` +
+// `@tale/ui/seo` HeadSink). The prerendered head is therefore identical to
+// what the live page renders; there is no separate hand-maintained meta list.
+// Search engines and previews get fully-formed, localized HTML; users boot
+// the same JS bundle and hydrate on top.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { localizedPath, type SupportedLocale } from '../lib/i18n/locales';
+import { MARKETING_ROUTES } from '../lib/seo/marketing-routes';
 import { enumerateLegalRoutes } from './legal-routes';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -17,87 +23,42 @@ const ROOT = resolve(SCRIPT_DIR, '..');
 const DIST = resolve(ROOT, 'dist');
 const SSR_BUNDLE = resolve(ROOT, 'dist-ssr', 'entry-server.js');
 
-interface RouteSeo {
+// English (root, no prefix) + the URL-prefixed locales. Marketing pages reuse
+// one component tree across all three; the SSR entry aligns i18n to the URL.
+const BASE_LOCALES: readonly SupportedLocale[] = ['en', 'de', 'fr'];
+
+interface PrerenderRoute {
   url: string;
-  title: string;
-  description: string;
+  locale: SupportedLocale;
 }
 
-const STATIC_ROUTES: RouteSeo[] = [
-  {
-    url: '/',
-    title: 'Tale: The Orchestration Layer for AI Agents',
-    description:
-      'Self-hosted AI platform for data-sensitive organizations — local AI models, agents, and automations on your own infrastructure. ISO 27001 & SOC 2 certified.',
-  },
-  {
-    url: '/pricing',
-    title: 'Pricing — Simple, Transparent Pricing | Tale',
-    description:
-      'One price for your entire team — no per-seat fees, no hidden costs. Community, Pro, and Enterprise plans for self-hosted AI in production.',
-  },
-  {
-    url: '/hardware-pricing',
-    title: 'Hardware Pricing | Tale',
-    description:
-      'High-performance AI hardware — priced right. Run state-of-the-art models, anywhere. Quality, Hybrid, and Speed configurations available.',
-  },
-  {
-    url: '/contact',
-    title: 'Contact us | Tale',
-    description:
-      'Get in touch with the Tale team. Connect with one of our domain experts to discuss your goals and find the best AI solution for your organization.',
-  },
-  {
-    url: '/request-demo',
-    title: 'Request a demo | Tale',
-    description:
-      'We help data-sensitive organizations automate workflows with private, reliable AI. Connect with a domain expert to explore solutions for your business.',
-  },
-];
-
-const SITE_URL = 'https://tale.dev';
-
-function injectSeo(template: string, route: RouteSeo): string {
-  const canonical = `${SITE_URL}${route.url === '/' ? '/' : route.url}`;
-  return template
-    .replace(/<title>[^<]*<\/title>/, `<title>${route.title}</title>`)
-    .replace(
-      /<meta\s+name="description"[^>]*>/,
-      `<meta name="description" content="${escapeAttr(route.description)}" />`,
-    )
-    .replace(
-      /<link\s+rel="canonical"[^>]*>/,
-      `<link rel="canonical" href="${canonical}" />`,
-    )
-    .replace(
-      /<meta\s+property="og:url"[^>]*>/,
-      `<meta property="og:url" content="${canonical}" />`,
-    )
-    .replace(
-      /<meta\s+property="og:title"[^>]*>/,
-      `<meta property="og:title" content="${escapeAttr(route.title)}" />`,
-    )
-    .replace(
-      /<meta\s+property="og:description"[^>]*>/,
-      `<meta property="og:description" content="${escapeAttr(route.description)}" />`,
-    )
-    .replace(
-      /<meta\s+name="twitter:title"[^>]*>/,
-      `<meta name="twitter:title" content="${escapeAttr(route.title)}" />`,
-    )
-    .replace(
-      /<meta\s+name="twitter:description"[^>]*>/,
-      `<meta name="twitter:description" content="${escapeAttr(route.description)}" />`,
-    );
+/** Replace the seo:start/seo:end block with the route's captured `<head>`. */
+function injectHead(template: string, head: string): string {
+  return template.replace(
+    /<!-- seo:start -->[\s\S]*?<!-- seo:end -->/,
+    () => `<!-- seo:start -->\n    ${head}\n    <!-- seo:end -->`,
+  );
 }
 
-function escapeAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+function injectBody(template: string, html: string): string {
+  return template.replace(
+    '<div id="root"></div>',
+    () => `<div id="root">${html}</div>`,
+  );
+}
+
+function setHtmlLang(template: string, locale: string): string {
+  return template.replace(/<html lang="[^"]*"/, () => `<html lang="${locale}"`);
+}
+
+function collectRoutes(legalUrls: PrerenderRoute[]): PrerenderRoute[] {
+  const marketing: PrerenderRoute[] = [];
+  for (const locale of BASE_LOCALES) {
+    for (const route of MARKETING_ROUTES) {
+      marketing.push({ url: localizedPath(locale, route.url), locale });
+    }
+  }
+  return [...marketing, ...legalUrls];
 }
 
 async function main(): Promise<void> {
@@ -105,27 +66,26 @@ async function main(): Promise<void> {
   const template = await readFile(resolve(DIST, 'index.html'), 'utf-8');
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const mod = (await import(pathToFileURL(SSR_BUNDLE).href)) as {
-    render: (url: string) => Promise<{ html: string }>;
+    render: (url: string) => Promise<{ html: string; head: string }>;
   };
 
-  const legalRoutes: RouteSeo[] = (await enumerateLegalRoutes()).map(
-    (route) => ({
-      url: route.url,
-      title: route.title ? `${route.title} | Tale` : 'Tale',
-      description: route.description,
-    }),
+  const legalUrls: PrerenderRoute[] = (await enumerateLegalRoutes()).map(
+    (route) => ({ url: route.url, locale: route.locale }),
   );
-  const routes: RouteSeo[] = [...STATIC_ROUTES, ...legalRoutes];
+  const routes = collectRoutes(legalUrls);
 
-  process.stdout.write(`prerendering ${routes.length} routes...\n`);
+  const seen = new Set<string>();
+  process.stdout.write(`prerendering up to ${routes.length} routes...\n`);
 
   for (const route of routes) {
+    if (seen.has(route.url)) continue;
+    seen.add(route.url);
     process.stdout.write(`prerender ${route.url} ... `);
-    const { html } = await mod.render(route.url);
-    const withSeo = injectSeo(template, route);
-    const final = withSeo.replace(
-      '<div id="root"></div>',
-      `<div id="root">${html}</div>`,
+
+    const { html, head } = await mod.render(route.url);
+    const final = setHtmlLang(
+      injectBody(injectHead(template, head), html),
+      route.locale,
     );
 
     const outPath =
@@ -139,7 +99,7 @@ async function main(): Promise<void> {
   }
 
   process.stdout.write(
-    `prerendered ${routes.length} routes in ${((Date.now() - started) / 1000).toFixed(1)}s\n`,
+    `prerendered ${seen.size} routes in ${((Date.now() - started) / 1000).toFixed(1)}s\n`,
   );
 }
 


### PR DESCRIPTION
## Summary

The web and docs Vite SPAs prerender routes for SEO, but the served HTML diverged from the live page: web prod **never ran the prerender step** (empty shell to crawlers); the prerendered `<head>` was a hardcoded English copy that **drifted from each page's localized i18n meta**; and docs **dropped robots / og / twitter-card / hreflang / JSON-LD** (so `noindex` pages shipped indexable). There were ~4 copies of the marketing titles/descriptions, none of them the one the page actually renders.

This makes the prerendered output, by construction, the **same content the live page renders**:

- **`@tale/ui`** — resolve a route's `<head>` once (`resolveDocumentHead`) and feed both emitters: `applyHeadToDocument` (client effect) and `renderHeadToHtml` (prerender). `useDocumentMeta` records into a `HeadSink` during SSR, so the captured head is exactly what the page declares — no parallel meta list to drift.
- **web / docs** `entry-server` returns `{ html, head }`; `prerender.ts` injects the head into a `<!-- seo:start/end -->` block, the body into `#root`, and sets `<html lang>`.
- **web** now prerenders routes × locales (`/de/pricing`, `/fr/…`) and runs prerender in its **Dockerfile** (was missing); `marketing-routes.ts` (sitemap / llms.txt source) reads the same `seo` i18n namespace, removing the last divergent copy.
- **guard** — `head-tags.test.ts` pins the prerender ↔ client parity.

Both apps keep `createRoot` (not `hydrateRoot`): this is plain (non-Start) TanStack Router, whose Suspense `<Outlet>` markers don't rehydrate cleanly (React #418), and docs loads page bodies via an async route loader. The prerendered HTML still serves crawlers + first paint; the client re-renders the identical DOM with **zero console errors**. The rationale is documented in both `main.tsx` files.

## Checklist

- [x] `bun run check` — format / lint / typecheck + tests pass for the affected workspaces (`@tale/ui` unit **153**, `@tale/web` **23**, `@tale/docs` **144**), plus global `format:check` and `knip`. ⚠️ The single full-monorepo `bun run check` invocation was interrupted by a **concurrent branch checkout in this shared local clone** (it removed the new `head-tags.test.ts` mid-run → "Cannot find module"; the other **997** `@tale/ui` tests passed and `@tale/platform` exited 130/SIGINT). Not a code failure — CI runs the full gate on this PR.
- [ ] `bun run lint:sast` — **N/A.** No new runtime boundary; this is build-time HTML serialization over trusted i18n / frontmatter content, and every value is escaped (`escapeAttr` / `escapeText`, JSON-LD `<`/`&` → `\uXXXX`).
- [ ] Translations in `services/platform/messages/{en,de,fr}.json` — **N/A.** No platform strings; this reads the existing web `seo` namespace and adds **no new keys**.
- [ ] Docs in `docs/{en,de,fr}/` — **N/A.** No user-visible product change; only crawler-facing HTML `<head>`/structure. (`services/web/README.md` build line updated.)
- [x] `README.md` — `services/web/README.md` updated to note `build` prerenders routes to static HTML. Root `README.*` N/A.

## Test plan

- `bun run --filter @tale/web build` → **30** routes incl. `/de/pricing`, `/fr/legal/*`; `bun run --filter @tale/docs build` → **423** routes.
- Inspect `dist/pricing/index.html` and `dist/de/pricing/index.html`: `<title>`/description equal the live i18n `seo` strings (the stale *"Simple, Transparent Pricing / no per-seat fees / Pro plans"* copy is gone), localized `<html lang>` + canonical + og; `<div id="root">` populated.
- A `noindex` docs page (`de/legal/privacy`) now carries `<meta name="robots" content="noindex,nofollow">`; all 423 docs pages carry hreflang + Article/Breadcrumb JSON-LD; exactly one `<title>` per page.
- Serve each (`bun server.ts`) and load `/pricing`, `/de/pricing`, and a docs page in a browser: rendered, interactive, **0 console errors** (verified via Playwright; screenshot of the localized German pricing page confirmed).
