### PR TITLE
fix(convex): throw ConvexError codes from documents mutations (#2010)

### DIFF
--- a/services/platform/convex/documents/compare_documents.ts
+++ b/services/platform/convex/documents/compare_documents.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { internal } from '../_generated/api';
 import { action } from '../_generated/server';
@@ -17,7 +17,10 @@ export const compareDocuments = action({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const isMember = await ctx.runQuery(
@@ -28,7 +31,10 @@ export const compareDocuments = action({
       },
     );
     if (!isMember) {
-      throw new Error('Unauthorized: not a member of this organization');
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: 'Unauthorized: not a member of this organization',
+      });
     }
 
     // Convex `_storage` is global — membership in args.organizationId is
@@ -44,9 +50,11 @@ export const compareDocuments = action({
       },
     );
     if (!ownsStorage) {
-      throw new Error(
-        'Unauthorized: one or more storage ids do not belong to this organization',
-      );
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message:
+          'Unauthorized: one or more storage ids do not belong to this organization',
+      });
     }
     // FOLLOW-UP / round-2 M5: this gate is org-level, not team-ACL-level.
     // A same-org user who does NOT have access to a team-scoped document

--- a/services/platform/convex/documents/create_document.ts
+++ b/services/platform/convex/documents/create_document.ts
@@ -2,6 +2,8 @@
  * Create a new document
  */
 
+import { ConvexError } from 'convex/values';
+
 import type { MutationCtx } from '../_generated/server';
 import { buildFolderPath } from '../folders/queries';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
@@ -16,7 +18,10 @@ export async function createDocument(
   if (args.folderId) {
     const folder = await ctx.db.get(args.folderId);
     if (!folder || folder.organizationId !== args.organizationId) {
-      throw new Error('Folder not found');
+      throw new ConvexError({
+        code: 'FOLDER_NOT_FOUND',
+        message: 'Folder not found',
+      });
     }
   }
 

--- a/services/platform/convex/documents/create_document_from_upload.test.ts
+++ b/services/platform/convex/documents/create_document_from_upload.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('convex/values', () => {
+vi.mock('convex/values', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
   const stub = () => 'validator';
   return {
+    // Preserve the real `ConvexError` so the handler's structured throws
+    // construct correctly; only the `v` validator builders are stubbed.
+    ...actual,
     v: {
       string: stub,
       number: stub,
@@ -147,7 +151,9 @@ describe('createDocumentFromUpload', () => {
     const ctx = createMockCtx();
     const handler = await getHandler();
 
-    await expect(handler(ctx, baseArgs)).rejects.toThrow('Unauthenticated');
+    await expect(handler(ctx, baseArgs)).rejects.toMatchObject({
+      data: { code: 'UNAUTHENTICATED' },
+    });
   });
 
   it('saves file metadata via runMutation when fileSize is provided', async () => {
@@ -211,7 +217,7 @@ describe('createDocumentFromUpload', () => {
 
     await expect(
       handler(ctx, { ...baseArgs, folderId: 'folder_1' }),
-    ).rejects.toThrow('Folder not found');
+    ).rejects.toMatchObject({ data: { code: 'FOLDER_NOT_FOUND' } });
   });
 
   it('validates folder org matches', async () => {
@@ -225,7 +231,7 @@ describe('createDocumentFromUpload', () => {
 
     await expect(
       handler(ctx, { ...baseArgs, folderId: 'folder_1' }),
-    ).rejects.toThrow('Folder not found');
+    ).rejects.toMatchObject({ data: { code: 'FOLDER_NOT_FOUND' } });
   });
 
   it('rejects when user lacks team access to folder', async () => {
@@ -241,7 +247,7 @@ describe('createDocumentFromUpload', () => {
 
     await expect(
       handler(ctx, { ...baseArgs, folderId: 'folder_1' }),
-    ).rejects.toThrow('Folder not accessible');
+    ).rejects.toMatchObject({ data: { code: 'FOLDER_NOT_ACCESSIBLE' } });
   });
 
   it('links document to file after document creation', async () => {

--- a/services/platform/convex/documents/delete_document.ts
+++ b/services/platform/convex/documents/delete_document.ts
@@ -2,6 +2,8 @@
  * Delete a document (for public API)
  */
 
+import { ConvexError } from 'convex/values';
+
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 
@@ -11,7 +13,10 @@ export async function deleteDocument(
 ): Promise<void> {
   const document = await ctx.db.get(documentId);
   if (!document) {
-    throw new Error('Document not found');
+    throw new ConvexError({
+      code: 'DOCUMENT_NOT_FOUND',
+      message: 'Document not found',
+    });
   }
 
   await ctx.db.delete(documentId);

--- a/services/platform/convex/documents/mutation_error_codes.test.ts
+++ b/services/platform/convex/documents/mutation_error_codes.test.ts
@@ -1,0 +1,184 @@
+// Regression gate for issue #2010 — documents mutations must throw structured
+// `ConvexError` (not raw `Error`) for not-found, folder, and authz rejections
+// so that `withRestAuth` can map them to 4xx and the UI gets actionable error
+// codes instead of opaque 500s.
+//
+// The mutation/internalMutation factories are mocked to hand the config
+// straight through (same pattern as vendors/mutation_error_codes.test.ts) so
+// the handler bodies are unit-testable without a running backend. The real
+// `ConvexError` is preserved via `importOriginal` so the structured throws
+// construct correctly.
+
+import { ConvexError } from 'convex/values';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('convex/values', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const stub = () => 'validator';
+  return {
+    ...actual,
+    v: {
+      string: stub,
+      number: stub,
+      boolean: stub,
+      optional: stub,
+      id: stub,
+      object: stub,
+      union: stub,
+      literal: stub,
+      array: stub,
+      null: stub,
+    },
+  };
+});
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    mutation: (config: Record<string, unknown>) => config,
+    internalMutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+vi.mock('../governance/legal_hold_guard', () => ({
+  assertNotHeld: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: vi.fn().mockResolvedValue({
+    _id: 'member_1',
+    organizationId: 'org_1',
+    userId: 'user_1',
+    role: 'member',
+  }),
+}));
+
+vi.mock('../../lib/shared/schemas/utils/json-value', () => ({
+  jsonValueValidator: 'validator',
+  jsonRecordValidator: 'validator',
+}));
+
+vi.mock('./validators', () => ({
+  sourceProviderValidator: 'validator',
+}));
+
+import * as internalMutations from './internal_mutations';
+import * as mutations from './mutations';
+
+interface MutHandler {
+  handler: (ctx: unknown, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+function asHandler(m: unknown): MutHandler {
+  return m as MutHandler;
+}
+
+// Run a handler and return whatever it throws (or null if it resolves).
+async function captureError(
+  m: unknown,
+  ctx: unknown,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  try {
+    await asHandler(m).handler(ctx, args);
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error instanceof ConvexError) {
+    const data = error.data;
+    if (typeof data === 'object' && data !== null && 'code' in data) {
+      const code = (data as { code: unknown }).code;
+      return typeof code === 'string' ? code : undefined;
+    }
+  }
+  return undefined;
+}
+
+const AUTH_USER = { userId: 'user_1' };
+
+describe('documents mutations error codes (issue #2010)', () => {
+  describe('client-callable mutations.ts', () => {
+    it('updateDocument throws UNAUTHENTICATED when caller is anonymous', async () => {
+      mockGetAuthUserIdentity.mockResolvedValueOnce(null);
+      const ctx = { db: { get: vi.fn() } };
+      const err = await captureError(mutations.updateDocument, ctx, {
+        documentId: 'd1',
+        title: 'New',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('UNAUTHENTICATED');
+    });
+
+    it('updateDocument throws DOCUMENT_NOT_FOUND when document is missing', async () => {
+      mockGetAuthUserIdentity.mockResolvedValueOnce(AUTH_USER);
+      const ctx = { db: { get: vi.fn().mockResolvedValue(null) } };
+      const err = await captureError(mutations.updateDocument, ctx, {
+        documentId: 'd1',
+        title: 'New',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('DOCUMENT_NOT_FOUND');
+    });
+
+    it('deleteDocument throws UNAUTHENTICATED when caller is anonymous', async () => {
+      mockGetAuthUserIdentity.mockResolvedValueOnce(null);
+      const ctx = { db: { get: vi.fn() } };
+      const err = await captureError(mutations.deleteDocument, ctx, {
+        documentId: 'd1',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('UNAUTHENTICATED');
+    });
+
+    it('deleteDocument throws DOCUMENT_NOT_FOUND when document is missing', async () => {
+      mockGetAuthUserIdentity.mockResolvedValueOnce(AUTH_USER);
+      const ctx = { db: { get: vi.fn().mockResolvedValue(null) } };
+      const err = await captureError(mutations.deleteDocument, ctx, {
+        documentId: 'd1',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('DOCUMENT_NOT_FOUND');
+    });
+  });
+
+  describe('REST-path internal_mutations.ts', () => {
+    it('updateDocument throws not_found ConvexError on cross-tenant access', async () => {
+      const existing = { _id: 'd1', organizationId: 'org_1' };
+      const ctx = { db: { get: vi.fn().mockResolvedValue(existing) } };
+      const err = await captureError(internalMutations.updateDocument, ctx, {
+        documentId: 'd1',
+        title: 'New',
+        callerOrgId: 'org_2',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('not_found');
+    });
+
+    it('createDocument throws FOLDER_NOT_FOUND when folder is missing', async () => {
+      const ctx = { db: { get: vi.fn().mockResolvedValue(null) } };
+      const err = await captureError(internalMutations.createDocument, ctx, {
+        organizationId: 'org_1',
+        title: 'doc.pdf',
+        folderId: 'folder_missing',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('FOLDER_NOT_FOUND');
+    });
+  });
+});

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import {
   isAllowedDocumentUpload,
@@ -38,12 +38,18 @@ export const updateDocument = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const document = await ctx.db.get(args.documentId);
     if (!document) {
-      throw new Error('Document not found');
+      throw new ConvexError({
+        code: 'DOCUMENT_NOT_FOUND',
+        message: 'Document not found',
+      });
     }
 
     await getOrganizationMember(ctx, document.organizationId, authUser);
@@ -64,12 +70,18 @@ export const deleteDocument = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const document = await ctx.db.get(args.documentId);
     if (!document) {
-      throw new Error('Document not found');
+      throw new ConvexError({
+        code: 'DOCUMENT_NOT_FOUND',
+        message: 'Document not found',
+      });
     }
 
     await getOrganizationMember(ctx, document.organizationId, authUser);
@@ -132,7 +144,10 @@ export const createDocumentFromUpload = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     await getOrganizationMember(ctx, args.organizationId, authUser);
@@ -153,15 +168,18 @@ export const createDocumentFromUpload = mutation({
       args.fileSize ?? undefined,
     );
     if (!policyCheck.allowed) {
-      throw new Error(
-        policyCheck.reason ?? 'Upload rejected by organization policy',
-      );
+      throw new ConvexError({
+        code: 'UPLOAD_POLICY_REJECTED',
+        message: policyCheck.reason ?? 'Upload rejected by organization policy',
+      });
     }
 
     if (!isAllowedDocumentUpload(resolvedContentType, args.fileName)) {
-      throw new Error(
-        'Unsupported file type. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images (JPEG, PNG, GIF, WEBP).',
-      );
+      throw new ConvexError({
+        code: 'UNSUPPORTED_FILE_TYPE',
+        message:
+          'Unsupported file type. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images (JPEG, PNG, GIF, WEBP).',
+      });
     }
 
     let effectiveTeamId = args.teamId;
@@ -169,12 +187,18 @@ export const createDocumentFromUpload = mutation({
     if (args.folderId) {
       const folder = await ctx.db.get(args.folderId);
       if (!folder || folder.organizationId !== args.organizationId) {
-        throw new Error('Folder not found');
+        throw new ConvexError({
+          code: 'FOLDER_NOT_FOUND',
+          message: 'Folder not found',
+        });
       }
       if (folder.teamId) {
         const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
         if (!hasTeamAccess(folder, userTeamIds)) {
-          throw new Error('Folder not accessible');
+          throw new ConvexError({
+            code: 'FOLDER_NOT_ACCESSIBLE',
+            message: 'Folder not accessible',
+          });
         }
         effectiveTeamId = folder.teamId;
       }

--- a/services/platform/convex/documents/update_document.ts
+++ b/services/platform/convex/documents/update_document.ts
@@ -2,6 +2,7 @@
  * Update a document (for public API)
  */
 
+import { ConvexError } from 'convex/values';
 import _ from 'lodash';
 
 import { isRecord } from '../../lib/utils/type-utils';
@@ -29,18 +30,27 @@ export async function updateDocument(
 ): Promise<void> {
   const document = await ctx.db.get(args.documentId);
   if (!document) {
-    throw new Error('Document not found');
+    throw new ConvexError({
+      code: 'DOCUMENT_NOT_FOUND',
+      message: 'Document not found',
+    });
   }
 
   if (args.teamIds !== undefined && args.teamIds.length > 0) {
     if (!args.userId) {
-      throw new Error('userId is required when updating teamIds');
+      throw new ConvexError({
+        code: 'USER_ID_REQUIRED',
+        message: 'userId is required when updating teamIds',
+      });
     }
 
     if (document.folderId) {
       const folder = await ctx.db.get(document.folderId);
       if (folder?.teamId) {
-        throw new Error('Cannot change team: inherited from parent folder');
+        throw new ConvexError({
+          code: 'TEAM_INHERITED_FROM_FOLDER',
+          message: 'Cannot change team: inherited from parent folder',
+        });
       }
     }
 
@@ -48,9 +58,10 @@ export async function updateDocument(
     const userTeamSet = new Set(userTeamIds);
     for (const id of args.teamIds) {
       if (!userTeamSet.has(id)) {
-        throw new Error(
-          'Cannot assign document to a team you do not belong to',
-        );
+        throw new ConvexError({
+          code: 'TEAM_ACCESS_DENIED',
+          message: 'Cannot assign document to a team you do not belong to',
+        });
       }
     }
   }

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -2,6 +2,8 @@
  * Update a document (internal helper)
  */
 
+import { ConvexError } from 'convex/values';
+
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
@@ -30,13 +32,19 @@ export async function updateDocumentInternal(
   const { documentId, contentHash, ...updateData } = args;
   const document = await ctx.db.get(documentId);
   if (!document) {
-    throw new Error('Document not found');
+    throw new ConvexError({
+      code: 'DOCUMENT_NOT_FOUND',
+      message: 'Document not found',
+    });
   }
 
   if (updateData.folderId) {
     const folder = await ctx.db.get(updateData.folderId);
     if (!folder || folder.organizationId !== document.organizationId) {
-      throw new Error('Folder not found');
+      throw new ConvexError({
+        code: 'FOLDER_NOT_FOUND',
+        message: 'Folder not found',
+      });
     }
   }
 

--- a/services/platform/convex/lib/rest/helpers.ts
+++ b/services/platform/convex/lib/rest/helpers.ts
@@ -332,6 +332,8 @@ function httpStatusForConvexCode(code: string | undefined): number {
     case 'VENDOR_NOT_FOUND':
     case 'CUSTOMER_NOT_FOUND':
     case 'WEBSITE_NOT_FOUND':
+    case 'DOCUMENT_NOT_FOUND':
+    case 'FOLDER_NOT_FOUND':
       return 404;
     case 'validation':
     case 'EMAIL_REQUIRED':


### PR DESCRIPTION
Closes #2010

## Problem
Document CRUD mutations (create / update / delete / compare / upload) threw bare `throw new Error(...)` for not-found, permission and validation rejections — opaque "Server Error" in the UI and 500s via REST.

## Fix
- CRUD mutation throw sites now raise `ConvexError` with structured UPPER_SNAKE codes: `DOCUMENT_NOT_FOUND`, `FOLDER_NOT_FOUND`, `FOLDER_NOT_ACCESSIBLE`, `FORBIDDEN`, `TEAM_ACCESS_DENIED`, `UNSUPPORTED_FILE_TYPE`, `UPLOAD_POLICY_REJECTED`, `UNAUTHENTICATED`, …
- REST mapping updated in `lib/rest/helpers.ts`.

## Scope
Internal document-generation / storage helpers (`generate_document`, `generate_docx`, `upload_base64_to_storage`, `read_file_base64_from_storage`, `internal_actions`) intentionally keep their operational `Error` throws — they're not the client-facing CRUD rejections this issue targets.

## Tests
New `documents/mutation_error_codes.test.ts`. Documents server suite green (331 tests); `tsc --noEmit` exit 0, `oxlint` 0 errors, `oxfmt --check` clean (9 files).