### PR TITLE
feat(platform): vision and image generation for OpenAI-compat API

### DIFF
--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -36,6 +36,7 @@ Cookies authentifizieren die Browser-Session; API-Aufrufe aus dem Browser innerh
 | Agents                                           | verschiedene | `/api/v1/agents/...`                | API-Key     | List, get, run.                                            |
 | Chat                                             | verschiedene | `/api/v1/chat/...`                  | API-Key     | Stream Chat-Completions gegen einen Agent oder ein Modell. |
 | OpenAI-kompatibel                                | POST         | `/api/v1/chat/completions`          | API-Key     | OpenAI-Chat-Completions-Form; bestehende SDKs nutzen.      |
+| OpenAI-kompatibel                                | POST         | `/api/v1/images/generations`        | API-Key     | Bilder generieren; OpenAI-Images-Form.                     |
 | OpenAI-kompatibel                                | GET          | `/api/v1/models`                    | API-Key     | Verfügbare Modelle im OpenAI-Format auflisten.             |
 | Automatisierungen                                | verschiedene | `/api/v1/automations/...`           | API-Key     | List, get, trigger, executions.                            |
 | Workflow-Trigger                                 | POST         | `/api/v1/workflows/triggers/<name>` | Trigger-Key | Webhook-getriggerte Workflow-Auslösungen.                  |
@@ -51,6 +52,16 @@ Exakte Feld-Formen für jeden Endpoint leben im OpenAPI-Dokument, das die Plattf
 `POST /api/v1/chat/completions` akzeptiert einen Payload in OpenAI-Chat-Completions-Form und gibt eine streaming- oder nicht-streaming-Antwort in derselben Form zurück. Das Feld `model` wird als Agent-ID interpretiert — übergib eine Agent-ID, um durch die Anweisungen, das Wissen und die Tools dieses Agents zu routen. Übergib einen rohen Modellnamen (z. B. `gpt-4o`), um Agents zu überspringen und den Provider direkt aufzurufen.
 
 Bestehende OpenAI-SDKs funktionieren mit einer Änderung: zeig die Base-URL auf `https://your-host.example.com/api/v1` und tausch den API-Key. Streaming nutzt Server-Sent Events.
+
+### Vision
+
+Um ein Bild zu senden, gib der User-Nachricht statt eines Strings ein Array-`content` aus Teilen — einen `text`-Teil plus einen oder mehrere `image_url`-Teile, jeder mit einer `data:`-URL oder einer öffentlichen `https`-URL. Das ist die Standard-OpenAI-Vision-Form, ein SDK, das multimodale Nachrichten schon baut, braucht also keine Änderung. Ein einfacher String-`content` funktioniert weiter für reine Text-Turns; nur Bild-Input braucht die Array-Form.
+
+### Bildgenerierung
+
+`POST /api/v1/images/generations` nimmt `{ model, prompt, n?, response_format? }` und gibt die OpenAI-Images-Form zurück — `{ created, data: [...] }`. `response_format` ist `url` (Standard — jeder Eintrag ist eine Download-URL) oder `b64_json` (jeder Eintrag ist Base64-Bild-Bytes); `n` ist auf 4 gedeckelt. Ruf es über das `images.generate` eines beliebigen OpenAI-SDKs auf.
+
+Ein Bildgenerierungs-Modell an `/api/v1/chat/completions` zu übergeben funktioniert ebenfalls: Das generierte Bild kommt an der Assistant-Nachricht als `choices[0].message.images[]` zurück — jeweils eine `image_url` — passend zur Konvention bildfähiger Gateways, sodass der Aufruf gegen ein zurückgegebenes Bild abgerechnet wird statt gegen ein verworfenes. Um ein bestehendes Bild zu bearbeiten, schick dieselbe Anfrage mit einem `text`-Teil und einem `image_url`-Teil mit einer `data:`-URL an ein Modell, das Bearbeitung unterstützt; das bearbeitete Bild kommt auf demselben Weg zurück. Nur `data:`-URLs werden als Bearbeitungs-Eingaben gelesen — Tale holt eine `http`-Bild-URL nie serverseitig.
 
 ## Fehlermodell
 

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -36,6 +36,7 @@ Cookies authenticate the browser session; API calls from the browser inside the 
 | Agents                                             | various | `/api/v1/agents/...`                | API key       | List, get, run.                                    |
 | Chat                                               | various | `/api/v1/chat/...`                  | API key       | Stream chat completions against an agent or model. |
 | OpenAI-compatible                                  | POST    | `/api/v1/chat/completions`          | API key       | OpenAI Chat Completions shape; use existing SDKs.  |
+| OpenAI-compatible                                  | POST    | `/api/v1/images/generations`        | API key       | Generate images; OpenAI Images shape.              |
 | OpenAI-compatible                                  | GET     | `/api/v1/models`                    | API key       | List available models in OpenAI format.            |
 | Automations                                        | various | `/api/v1/automations/...`           | API key       | List, get, trigger, executions.                    |
 | Workflow triggers                                  | POST    | `/api/v1/workflows/triggers/<name>` | Trigger key   | Webhook-triggered workflow invocations.            |
@@ -51,6 +52,16 @@ Exact field shapes for each endpoint live in the OpenAPI document the platform e
 `POST /api/v1/chat/completions` accepts a payload in OpenAI Chat Completions shape and returns a streaming or non-streaming response in the same shape. The `model` field is interpreted as the agent ID — pass an agent's ID to route through that agent's instructions, knowledge, and tools. Pass a raw model name (e.g. `gpt-4o`) to bypass agents and call the provider directly.
 
 Existing OpenAI SDKs work with one change: point the base URL at `https://your-host.example.com/api/v1` and substitute the API key. Streaming uses Server-Sent Events.
+
+### Vision
+
+To send an image, give the user message an array `content` of parts instead of a string — a `text` part plus one or more `image_url` parts, each carrying a `data:` URL or a public `https` URL. This is the standard OpenAI vision shape, so an SDK that already builds multimodal messages needs no change. A plain string `content` still works for text-only turns; only image input requires the array form.
+
+### Image generation
+
+`POST /api/v1/images/generations` takes `{ model, prompt, n?, response_format? }` and returns the OpenAI Images shape — `{ created, data: [...] }`. `response_format` is `url` (the default — each entry is a download URL) or `b64_json` (each entry is base64 image bytes); `n` is capped at 4. Call it through any OpenAI SDK's `images.generate`.
+
+Passing an image-generation model to `/api/v1/chat/completions` works too: the generated image comes back on the assistant message as `choices[0].message.images[]` — each an `image_url` — matching the convention image-capable gateways use, so the call is billed against a returned image rather than a dropped one. To edit an existing image, send that same request with a `text` part and an `image_url` part carrying a `data:` URL to a model that supports editing; the edited image returns the same way. Only `data:` URLs are read as edit inputs — Tale never fetches an `http` image URL server-side.
 
 ## Error model
 

--- a/docs/fr/develop/api-reference.md
+++ b/docs/fr/develop/api-reference.md
@@ -36,6 +36,7 @@ Les cookies authentifient la session navigateur ; les appels API depuis le navig
 | Agents                                                     | diverses | `/api/v1/agents/...`               | Clé API         | List, get, run.                                            |
 | Chat                                                       | diverses | `/api/v1/chat/...`                 | Clé API         | Stream de complétions chat contre un agent ou un modèle.   |
 | Compatible OpenAI                                          | POST     | `/api/v1/chat/completions`         | Clé API         | Forme Chat Completions OpenAI ; utilise les SDK existants. |
+| Compatible OpenAI                                          | POST     | `/api/v1/images/generations`       | Clé API         | Génère des images ; forme Images OpenAI.                   |
 | Compatible OpenAI                                          | GET      | `/api/v1/models`                   | Clé API         | Liste les modèles disponibles au format OpenAI.            |
 | Automatisations                                            | diverses | `/api/v1/automations/...`          | Clé API         | List, get, trigger, executions.                            |
 | Déclencheurs de workflow                                   | POST     | `/api/v1/workflows/triggers/<nom>` | Clé déclencheur | Invocations de workflow déclenchées par webhook.           |
@@ -51,6 +52,16 @@ Les formes exactes de champs pour chaque endpoint vivent dans le document OpenAP
 `POST /api/v1/chat/completions` accepte un payload en forme Chat Completions OpenAI et retourne une réponse streaming ou non en même forme. Le champ `model` est interprété comme l'ID d'agent — passe un ID d'agent pour router via les instructions, connaissances et outils de cet agent. Passe un nom de modèle brut (ex. `gpt-4o`) pour contourner les agents et appeler le fournisseur directement.
 
 Les SDK OpenAI existants marchent avec un changement : pointe l'URL de base sur `https://your-host.example.com/api/v1` et substitue la clé API. Le streaming utilise les Server-Sent Events.
+
+### Vision
+
+Pour envoyer une image, donne au message utilisateur un `content` en tableau de parties plutôt qu'une chaîne — une partie `text` plus une ou plusieurs parties `image_url`, chacune portant une URL `data:` ou une URL `https` publique. C'est la forme vision standard d'OpenAI, donc un SDK qui construit déjà des messages multimodaux n'a besoin d'aucun changement. Un `content` en chaîne simple marche toujours pour les tours en texte seul ; seule l'entrée image exige la forme tableau.
+
+### Génération d'images
+
+`POST /api/v1/images/generations` prend `{ model, prompt, n?, response_format? }` et retourne la forme Images OpenAI — `{ created, data: [...] }`. `response_format` vaut `url` (par défaut — chaque entrée est une URL de téléchargement) ou `b64_json` (chaque entrée est des octets d'image en base64) ; `n` est plafonné à 4. Appelle-le via le `images.generate` de n'importe quel SDK OpenAI.
+
+Passer un modèle de génération d'images à `/api/v1/chat/completions` marche aussi : l'image générée revient sur le message assistant sous `choices[0].message.images[]` — chacune une `image_url` — suivant la convention des passerelles capables d'images, de sorte que l'appel est facturé contre une image retournée plutôt que contre une image perdue. Pour éditer une image existante, envoie cette même requête avec une partie `text` et une partie `image_url` portant une URL `data:` à un modèle qui prend en charge l'édition ; l'image éditée revient de la même façon. Seules les URL `data:` sont lues comme entrées d'édition — Tale ne va jamais chercher une URL d'image `http` côté serveur.
 
 ## Modèle d'erreur
 

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1038,7 +1038,9 @@ import type * as onedrive_upload_to_storage from "../onedrive/upload_to_storage.
 import type * as onedrive_validators from "../onedrive/validators.js";
 import type * as onedrive_with_microsoft_token from "../onedrive/with_microsoft_token.js";
 import type * as openai_compat_citations from "../openai_compat/citations.js";
+import type * as openai_compat_content from "../openai_compat/content.js";
 import type * as openai_compat_http_actions from "../openai_compat/http_actions.js";
+import type * as openai_compat_image_generation from "../openai_compat/image_generation.js";
 import type * as openai_compat_internal_actions from "../openai_compat/internal_actions.js";
 import type * as openai_compat_internal_mutations from "../openai_compat/internal_mutations.js";
 import type * as openai_compat_internal_queries from "../openai_compat/internal_queries.js";
@@ -2650,7 +2652,9 @@ declare const fullApi: ApiFromModules<{
   "onedrive/validators": typeof onedrive_validators;
   "onedrive/with_microsoft_token": typeof onedrive_with_microsoft_token;
   "openai_compat/citations": typeof openai_compat_citations;
+  "openai_compat/content": typeof openai_compat_content;
   "openai_compat/http_actions": typeof openai_compat_http_actions;
+  "openai_compat/image_generation": typeof openai_compat_image_generation;
   "openai_compat/internal_actions": typeof openai_compat_internal_actions;
   "openai_compat/internal_mutations": typeof openai_compat_internal_mutations;
   "openai_compat/internal_queries": typeof openai_compat_internal_queries;

--- a/services/platform/convex/http.ts
+++ b/services/platform/convex/http.ts
@@ -63,6 +63,8 @@ import { sanitizeError } from './lib/utils/sanitize_secrets';
 import {
   chatCompletionsHandler,
   chatCompletionsOptionsHandler,
+  imagesGenerationsHandler,
+  imagesGenerationsOptionsHandler,
   modelsListHandler,
   modelsOptionsHandler,
 } from './openai_compat/http_actions';
@@ -984,6 +986,18 @@ http.route({
   path: '/api/v1/chat/completions',
   method: 'OPTIONS',
   handler: chatCompletionsOptionsHandler,
+});
+
+http.route({
+  path: '/api/v1/images/generations',
+  method: 'POST',
+  handler: imagesGenerationsHandler,
+});
+
+http.route({
+  path: '/api/v1/images/generations',
+  method: 'OPTIONS',
+  handler: imagesGenerationsOptionsHandler,
 });
 
 http.route({

--- a/services/platform/convex/lib/rate_limiter/index.ts
+++ b/services/platform/convex/lib/rate_limiter/index.ts
@@ -424,6 +424,14 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
     period: MINUTE,
     capacity: 50,
   },
+  // Tighter than openai:chat — image generation is materially more expensive
+  // per call than a chat completion.
+  'openai:images': {
+    kind: 'token bucket',
+    rate: 10,
+    period: MINUTE,
+    capacity: 15,
+  },
   // Looser than openai:chat — listing models is cheap and frequently polled
   // by clients on startup.
   'openai:models': {

--- a/services/platform/convex/openai_compat/content.test.ts
+++ b/services/platform/convex/openai_compat/content.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAiUserContent,
+  extractText,
+  hasUsableUserContent,
+  imageUrlsOf,
+  type OpenAIContentPart,
+} from './content';
+
+describe('extractText', () => {
+  it('returns a string content unchanged', () => {
+    expect(extractText('hello world')).toBe('hello world');
+  });
+
+  it('joins text parts and ignores image parts', () => {
+    const content: OpenAIContentPart[] = [
+      { type: 'text', text: 'describe this' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+      { type: 'text', text: 'in detail' },
+    ];
+    expect(extractText(content)).toBe('describe this\nin detail');
+  });
+
+  it('returns empty string for an image-only array', () => {
+    const content: OpenAIContentPart[] = [
+      { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+    ];
+    expect(extractText(content)).toBe('');
+  });
+});
+
+describe('hasUsableUserContent', () => {
+  it('accepts a non-empty string', () => {
+    expect(hasUsableUserContent('hi')).toBe(true);
+  });
+
+  it('rejects an empty string', () => {
+    expect(hasUsableUserContent('')).toBe(false);
+  });
+
+  it('accepts an array with a text part', () => {
+    expect(hasUsableUserContent([{ type: 'text', text: 'hi' }])).toBe(true);
+  });
+
+  it('accepts an array with only an image part (vision)', () => {
+    expect(
+      hasUsableUserContent([
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+      ]),
+    ).toBe(true);
+  });
+
+  it('rejects an empty array', () => {
+    expect(hasUsableUserContent([])).toBe(false);
+  });
+
+  it('rejects an array of unrecognized parts', () => {
+    expect(hasUsableUserContent([{ type: 'audio' }, { foo: 1 }])).toBe(false);
+  });
+
+  it('rejects a null/undefined content', () => {
+    expect(hasUsableUserContent(null)).toBe(false);
+    expect(hasUsableUserContent(undefined)).toBe(false);
+  });
+});
+
+describe('imageUrlsOf', () => {
+  it('returns image_url URLs in order, ignoring text parts', () => {
+    const content: OpenAIContentPart[] = [
+      { type: 'text', text: 'edit this' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+      { type: 'image_url', image_url: { url: 'https://example.com/b.png' } },
+    ];
+    expect(imageUrlsOf(content)).toEqual([
+      'data:image/png;base64,AAAA',
+      'https://example.com/b.png',
+    ]);
+  });
+
+  it('returns empty for a string or text-only content', () => {
+    expect(imageUrlsOf('hello')).toEqual([]);
+    expect(imageUrlsOf([{ type: 'text', text: 'hi' }])).toEqual([]);
+  });
+});
+
+describe('buildAiUserContent', () => {
+  it('returns the sanitized text for plain string content', () => {
+    expect(buildAiUserContent('original', 'sanitized')).toBe('sanitized');
+  });
+
+  it('returns a plain string when the array has no image parts', () => {
+    const content: OpenAIContentPart[] = [{ type: 'text', text: 'hi' }];
+    expect(buildAiUserContent(content, 'sanitized')).toBe('sanitized');
+  });
+
+  it('builds text + image parts, substituting the sanitized text', () => {
+    const content: OpenAIContentPart[] = [
+      { type: 'text', text: 'raw secret 4111-1111-1111-1111' },
+      { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+    ];
+    expect(buildAiUserContent(content, 'raw secret [REDACTED]')).toEqual([
+      { type: 'text', text: 'raw secret [REDACTED]' },
+      { type: 'image', image: 'https://example.com/a.png' },
+    ]);
+  });
+
+  it('omits the text part when the sanitized text is empty (image-only)', () => {
+    const content: OpenAIContentPart[] = [
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+    ];
+    expect(buildAiUserContent(content, '')).toEqual([
+      { type: 'image', image: 'data:image/png;base64,AAAA' },
+    ]);
+  });
+});

--- a/services/platform/convex/openai_compat/content.ts
+++ b/services/platform/convex/openai_compat/content.ts
@@ -1,0 +1,114 @@
+/**
+ * OpenAI Chat Completions message-content helpers.
+ *
+ * The OpenAI wire format lets a message's `content` be either a plain string
+ * or an array of typed parts (`text` + `image_url`) — the latter is the ONLY
+ * way to send images, so vision requests always use it. These pure helpers
+ * normalize that shape and convert it to AI SDK user-message content. Kept free
+ * of Convex/Node imports so they can be unit-tested directly.
+ */
+
+export interface OpenAITextPart {
+  type: 'text';
+  text: string;
+}
+
+export interface OpenAIImagePart {
+  type: 'image_url';
+  image_url: { url: string; detail?: string };
+}
+
+export type OpenAIContentPart = OpenAITextPart | OpenAIImagePart;
+
+export type OpenAIMessageContent = string | OpenAIContentPart[];
+
+/** AI SDK user-message content part (text or image). */
+export type AiUserContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image'; image: string };
+
+export function isContentPartArray(
+  content: unknown,
+): content is OpenAIContentPart[] {
+  return Array.isArray(content);
+}
+
+function isTextPart(part: unknown): part is OpenAITextPart {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    (part as { type?: unknown }).type === 'text' &&
+    typeof (part as { text?: unknown }).text === 'string'
+  );
+}
+
+function imageUrlOf(part: unknown): string | null {
+  if (
+    typeof part === 'object' &&
+    part !== null &&
+    (part as { type?: unknown }).type === 'image_url'
+  ) {
+    const url = (part as { image_url?: { url?: unknown } }).image_url?.url;
+    if (typeof url === 'string' && url.length > 0) return url;
+  }
+  return null;
+}
+
+/** Collect the `image_url` URLs from a message's content, in order. */
+export function imageUrlsOf(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  const urls: string[] = [];
+  for (const part of content) {
+    const url = imageUrlOf(part);
+    if (url) urls.push(url);
+  }
+  return urls;
+}
+
+/** Concatenate the text parts of a message's content (newline-joined). */
+export function extractText(content: OpenAIMessageContent): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter(isTextPart)
+    .map((p) => p.text)
+    .join('\n');
+}
+
+/**
+ * Whether a user message's content is usable: a non-empty string, or an array
+ * carrying at least one text or image part. This is what the request validator
+ * should accept — the old `typeof content === 'string'` check rejected every
+ * multimodal (image) request.
+ */
+export function hasUsableUserContent(content: unknown): boolean {
+  if (typeof content === 'string') return content.length > 0;
+  if (!Array.isArray(content)) return false;
+  return content.some((p) => isTextPart(p) || imageUrlOf(p) !== null);
+}
+
+/**
+ * Build AI SDK user-message content from OpenAI content plus a (possibly
+ * PII-sanitized) replacement for the text portion. Images are passed through as
+ * AI SDK `image` parts (the URL string — a `data:` URL or an `http(s)` URL the
+ * provider fetches). Returns a plain string when there are no image parts so
+ * the text-only path stays unchanged.
+ */
+export function buildAiUserContent(
+  content: OpenAIMessageContent,
+  sanitizedText: string,
+): string | AiUserContentPart[] {
+  if (typeof content === 'string') return sanitizedText;
+
+  const imageParts: AiUserContentPart[] = [];
+  for (const part of content) {
+    const url = imageUrlOf(part);
+    if (url) imageParts.push({ type: 'image', image: url });
+  }
+  if (imageParts.length === 0) return sanitizedText;
+
+  const parts: AiUserContentPart[] = [];
+  if (sanitizedText.length > 0)
+    parts.push({ type: 'text', text: sanitizedText });
+  parts.push(...imageParts);
+  return parts;
+}

--- a/services/platform/convex/openai_compat/http_actions.ts
+++ b/services/platform/convex/openai_compat/http_actions.ts
@@ -20,12 +20,22 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { extractClientIp } from '../workflows/triggers/helpers/validate';
 import {
+  buildAiUserContent,
+  extractText,
+  hasUsableUserContent,
+  type OpenAIMessageContent,
+} from './content';
+import {
   buildChatCompletion,
   buildChatCompletionChunk,
   buildChatCompletionWithToolCalls,
+  buildImagesGenerationsResponse,
   buildStreamingUsageChunk,
   formatSSEChunk,
   formatSSEDone,
+  mapFinishReason,
+  type OpenAIChatImage,
+  type OpenAIImageDatum,
   openAIErrorResponse,
   type OpenAIToolCall,
   type OpenAIUsage,
@@ -44,7 +54,9 @@ const CORS_HEADERS = {
 
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
-  content: string | null;
+  // String, or an array of content parts (text + image_url) for multimodal
+  // (vision) input — the latter is the only way to send images.
+  content: OpenAIMessageContent | null;
   tool_calls?: Array<{
     id: string;
     type: 'function';
@@ -179,15 +191,25 @@ function convertToModelMessages(
 
   for (const msg of messages) {
     if (msg.role === 'user') {
-      result.push({ role: 'user', content: msg.content ?? '' });
+      // Preserve multimodal (image) parts; no sanitization on the continuation
+      // path (matches the pre-existing behaviour for tool-calling history).
+      const content = msg.content ?? '';
+      result.push({
+        role: 'user',
+        content:
+          typeof content === 'string'
+            ? content
+            : buildAiUserContent(content, extractText(content)),
+      });
     } else if (msg.role === 'system') {
-      result.push({ role: 'system', content: msg.content ?? '' });
+      result.push({ role: 'system', content: extractText(msg.content ?? '') });
     } else if (msg.role === 'assistant') {
       if (msg.tool_calls && msg.tool_calls.length > 0) {
         // Assistant message with tool calls
         const content: Array<Record<string, unknown>> = [];
-        if (msg.content) {
-          content.push({ type: 'text', text: msg.content });
+        const assistantText = extractText(msg.content ?? '');
+        if (assistantText) {
+          content.push({ type: 'text', text: assistantText });
         }
         for (const tc of msg.tool_calls) {
           content.push({
@@ -201,7 +223,7 @@ function convertToModelMessages(
       } else {
         result.push({
           role: 'assistant',
-          content: msg.content ?? '',
+          content: extractText(msg.content ?? ''),
         });
       }
     } else if (msg.role === 'tool' && msg.tool_call_id) {
@@ -225,7 +247,7 @@ function convertToModelMessages(
             type: 'tool-result',
             toolCallId: msg.tool_call_id,
             toolName,
-            output: { type: 'text', value: msg.content ?? '' },
+            output: { type: 'text', value: extractText(msg.content ?? '') },
           },
         ],
       });
@@ -320,13 +342,21 @@ export const chatCompletionsHandler = httpAction(async (ctx, request) => {
   }
 
   const lastUserMessage = messages.findLast((m) => m.role === 'user');
-  if (!lastUserMessage || typeof lastUserMessage.content !== 'string') {
+  if (!lastUserMessage || !hasUsableUserContent(lastUserMessage.content)) {
     return openAIErrorResponse(
-      'No user message found in messages array',
+      'No user message with usable content found in messages array',
       'invalid_request_error',
       400,
     );
   }
+  // `content` is a non-empty string or content-part array here. The action
+  // receives the joined text (for sanitization signals) plus the structured
+  // content when multimodal, so image parts reach the model.
+  const lastUserContent = lastUserMessage.content ?? '';
+  const lastUserText = extractText(lastUserContent);
+  const userContent = Array.isArray(lastUserContent)
+    ? lastUserContent
+    : undefined;
 
   const shouldStream = body.stream === true;
   const includeUsage =
@@ -356,7 +386,8 @@ export const chatCompletionsHandler = httpAction(async (ctx, request) => {
   return handleDirectModelMode(ctx, {
     model,
     messages,
-    lastUserMessage: lastUserMessage.content,
+    lastUserMessage: lastUserText,
+    userContent,
     tools,
     toolChoice: body.tool_choice,
     shouldStream,
@@ -392,6 +423,7 @@ async function handleDirectModelMode(
     model: string;
     messages: OpenAIMessage[];
     lastUserMessage: string;
+    userContent?: OpenAIMessageContent;
     tools?: ChatCompletionsRequestBody['tools'];
     toolChoice?: unknown;
     shouldStream: boolean;
@@ -409,6 +441,7 @@ async function handleDirectModelMode(
     requestId: string;
     text: string | null;
     toolCalls: OpenAIToolCall[] | null;
+    images: OpenAIChatImage[] | null;
     finishReason: string;
     inputTokens: number;
     outputTokens: number;
@@ -426,6 +459,7 @@ async function handleDirectModelMode(
         userEmail: opts.user.email,
         userName: opts.user.name,
         message: opts.lastUserMessage,
+        userContent: opts.userContent,
         tools: opts.tools,
         toolChoice: opts.toolChoice,
         conversationMessages: opts.conversationMessages,
@@ -444,6 +478,7 @@ async function handleDirectModelMode(
     completion_tokens: result.outputTokens,
     total_tokens: result.totalTokens,
   };
+  const finishReason = mapFinishReason(result.finishReason);
 
   // Tool calls returned — return them to client
   if (result.toolCalls && result.toolCalls.length > 0) {
@@ -469,7 +504,8 @@ async function handleDirectModelMode(
     return jsonResponse(response);
   }
 
-  // No tool calls — return text
+  // No tool calls — return text (and any generated images).
+  const images = result.images ?? undefined;
   if (opts.shouldStream) {
     return streamDirectTextResponse(
       completionId,
@@ -477,6 +513,8 @@ async function handleDirectModelMode(
       result.text ?? '',
       created,
       opts.includeUsage ? usage : undefined,
+      finishReason,
+      images,
     );
   }
 
@@ -487,6 +525,7 @@ async function handleDirectModelMode(
     created,
     [],
     usage,
+    { finishReason, images },
   );
   return jsonResponse(response);
 }
@@ -608,6 +647,8 @@ function streamDirectTextResponse(
   text: string,
   created: number,
   usage?: OpenAIUsage,
+  finishReason: 'stop' | 'length' | 'tool_calls' = 'stop',
+  images?: OpenAIChatImage[],
 ): Response {
   const encoder = new TextEncoder();
   const { readable, writable } = new TransformStream();
@@ -635,11 +676,24 @@ function streamDirectTextResponse(
         await writer.write(encoder.encode(formatSSEChunk(contentChunk)));
       }
 
+      // Generated images (image-generation models) — emitted as an `images`
+      // delta, matching the OpenRouter streaming convention.
+      if (images && images.length > 0) {
+        const imagesChunk = buildChatCompletionChunk(
+          completionId,
+          model,
+          { images },
+          null,
+          created,
+        );
+        await writer.write(encoder.encode(formatSSEChunk(imagesChunk)));
+      }
+
       const finishChunk = buildChatCompletionChunk(
         completionId,
         model,
         {},
-        'stop',
+        finishReason,
         created,
       );
       await writer.write(encoder.encode(formatSSEChunk(finishChunk)));
@@ -781,10 +835,137 @@ export const modelsListHandler = httpAction(async (ctx, request) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /api/v1/images/generations
+// ---------------------------------------------------------------------------
+
+interface ImagesGenerationsRequestBody {
+  model?: string;
+  prompt?: string;
+  n?: number;
+  size?: string;
+  response_format?: string;
+}
+
+export const imagesGenerationsHandler = httpAction(async (ctx, request) => {
+  const ip = extractClientIp(request.headers);
+  try {
+    await checkIpRateLimit(ctx, 'openai:images', ip);
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      return openAIErrorResponse(
+        'Rate limit exceeded',
+        'rate_limit_exceeded',
+        429,
+        'rate_limit_exceeded',
+      );
+    }
+    throw error;
+  }
+
+  let user: { userId: string; email: string; name: string };
+  try {
+    user = await authenticateRequest(ctx, request);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return openAIErrorResponse(
+        error.message,
+        'invalid_request_error',
+        401,
+        'invalid_api_key',
+      );
+    }
+    throw error;
+  }
+
+  const orgSlugHeader =
+    request.headers.get('x-organization-slug') ??
+    request.headers.get('X-Organization-Slug');
+
+  let orgInfo: { organizationId: string; orgSlug: string };
+  try {
+    orgInfo = await ctx.runQuery(
+      internal.openai_compat.internal_queries.resolveUserOrganization,
+      { userId: user.userId, orgSlug: orgSlugHeader ?? undefined },
+    );
+  } catch (error) {
+    return mapResolveOrgError(error);
+  }
+
+  let body: ImagesGenerationsRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return openAIErrorResponse(
+      'Invalid JSON body',
+      'invalid_request_error',
+      400,
+    );
+  }
+
+  const model = body.model;
+  if (!model || typeof model !== 'string') {
+    return openAIErrorResponse(
+      'Missing or invalid "model" field',
+      'invalid_request_error',
+      400,
+      'model_required',
+    );
+  }
+  const prompt = body.prompt;
+  if (!prompt || typeof prompt !== 'string') {
+    return openAIErrorResponse(
+      'Missing or invalid "prompt" field',
+      'invalid_request_error',
+      400,
+    );
+  }
+  if (
+    body.response_format != null &&
+    body.response_format !== 'url' &&
+    body.response_format !== 'b64_json'
+  ) {
+    return openAIErrorResponse(
+      '"response_format" must be "url" or "b64_json"',
+      'invalid_request_error',
+      400,
+    );
+  }
+
+  let result: { requestId: string; model: string; data: OpenAIImageDatum[] };
+  try {
+    result = await ctx.runAction(
+      internal.openai_compat.internal_actions.imagesGenerateDirect,
+      {
+        modelId: model,
+        organizationId: orgInfo.organizationId,
+        userId: user.userId,
+        userEmail: user.email,
+        userName: user.name,
+        prompt,
+        n: typeof body.n === 'number' ? body.n : undefined,
+        responseFormat: body.response_format,
+      },
+    );
+  } catch (error) {
+    return handleChatError(error, model);
+  }
+
+  const created = Math.floor(Date.now() / 1000);
+  return jsonResponse(buildImagesGenerationsResponse(created, result.data));
+});
+
+// ---------------------------------------------------------------------------
 // OPTIONS handlers (CORS preflight)
 // ---------------------------------------------------------------------------
 
 export const chatCompletionsOptionsHandler = httpAction(async () => {
+  return new Response(null, {
+    status: 204,
+    headers: { ...CORS_HEADERS, 'Access-Control-Max-Age': '86400' },
+  });
+});
+
+export const imagesGenerationsOptionsHandler = httpAction(async () => {
   return new Response(null, {
     status: 204,
     headers: { ...CORS_HEADERS, 'Access-Control-Max-Age': '86400' },

--- a/services/platform/convex/openai_compat/image_generation.ts
+++ b/services/platform/convex/openai_compat/image_generation.ts
@@ -1,0 +1,141 @@
+'use node';
+
+/**
+ * Image generation for the OpenAI-compatible endpoint.
+ *
+ * Reuses the shared `generateImageBlobs` / `persistImageBlob` core (the same
+ * code the in-product image agent and the inline `generate_image` tool use) so
+ * the API path can never drift from how the rest of the app calls image
+ * models. Used by BOTH the `/api/v1/images/generations` handler and the
+ * `/api/v1/chat/completions` image branch (when an `image-generation`-tagged
+ * model is requested) so the two surfaces share one code path.
+ */
+
+import type { ActionCtx } from '../_generated/server';
+import {
+  type GeneratedImageBlob,
+  generateImageBlobs,
+  type ImageUsage,
+  parseDataUri,
+  type PersistedImage,
+  persistImageBlob,
+} from '../agents/image_generation/generate_image_blobs';
+import { roundCents } from '../governance/cost_estimation';
+import { imageUrlsOf } from './content';
+
+/** Hard ceiling on `n` so one request can't fan out into an unbounded number
+ * of (separately billed) model calls. OpenAI's own cap for most image models. */
+export const MAX_IMAGES_PER_REQUEST = 4;
+
+/**
+ * Decode `data:` URLs from an OpenAI content-part array into image bytes — the
+ * reference images for an edit request. Only `data:` URLs are accepted (the
+ * standard way to pass a local image): we never fetch a user-supplied `http`
+ * URL server-side, which would be an SSRF surface. `http(s)` image parts are
+ * left for the model to fetch on the vision (text) path.
+ */
+export function extractDataUriImages(
+  userContent: unknown,
+): GeneratedImageBlob[] {
+  const out: GeneratedImageBlob[] = [];
+  for (const url of imageUrlsOf(userContent)) {
+    if (url.startsWith('data:')) {
+      const blob = parseDataUri(url);
+      if (blob) out.push(blob);
+    }
+  }
+  return out;
+}
+
+export interface ApiImageResult {
+  /** Persisted images (Convex storage + browser-reachable download URL). */
+  persisted: PersistedImage[];
+  /** Raw bytes, for `response_format: 'b64_json'` callers. */
+  blobs: GeneratedImageBlob[];
+  usage: ImageUsage;
+  /** USD the gateway billed, summed across calls, when reported. */
+  providerCostUsd?: number;
+  /** Estimated cost in cents (provider USD ?? per-image rate), when derivable. */
+  costCents?: number;
+  modelId: string;
+  providerName: string;
+  /** Whether `n` was clamped to {@link MAX_IMAGES_PER_REQUEST}. */
+  clamped: boolean;
+}
+
+/**
+ * Resolve and call an image model `n` times, persisting every produced image.
+ * `modelRef` is `provider:model-id` or a bare `model-id`; empty falls back to
+ * the org's `image-generation` default. Throws when the model returns no image
+ * (so callers can record a failure rather than bill for nothing).
+ */
+export async function generateApiImages(
+  ctx: ActionCtx,
+  opts: {
+    modelRef: string;
+    prompt: string;
+    n?: number;
+    organizationId: string;
+    namePrefix?: string;
+    /** Reference images (decoded `data:` URLs) — present ⇒ edit mode. */
+    attachmentBytes?: GeneratedImageBlob[];
+  },
+): Promise<ApiImageResult> {
+  const requested = opts.n ?? 1;
+  const n = Math.max(1, Math.min(requested, MAX_IMAGES_PER_REQUEST));
+  const clamped = requested > MAX_IMAGES_PER_REQUEST;
+
+  const blobs: GeneratedImageBlob[] = [];
+  const usage: ImageUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  let providerCostUsd: number | undefined;
+  let modelId = '';
+  let providerName = '';
+  let imageCentsPerImage: number | undefined;
+
+  for (let i = 0; i < n; i++) {
+    const out = await generateImageBlobs(ctx, {
+      modelRef: opts.modelRef,
+      textPrompt: opts.prompt,
+      attachmentBytes: opts.attachmentBytes,
+      organizationId: opts.organizationId,
+    });
+    blobs.push(...out.imageBlobs);
+    if (out.usage) {
+      usage.inputTokens += out.usage.inputTokens;
+      usage.outputTokens += out.usage.outputTokens;
+      usage.totalTokens += out.usage.totalTokens;
+    }
+    if (out.providerCostUsd != null) {
+      providerCostUsd = (providerCostUsd ?? 0) + out.providerCostUsd;
+    }
+    modelId = out.resolved.modelData.modelId;
+    providerName = out.resolved.modelData.providerName;
+    imageCentsPerImage = out.resolved.modelData.imageCentsPerImage;
+  }
+
+  const persisted = await Promise.all(
+    blobs.map((blob, idx) =>
+      persistImageBlob(ctx, blob, opts.namePrefix ?? 'openai-image', idx),
+    ),
+  );
+
+  // Prefer the gateway's billed USD (megapixel-priced models don't fit a flat
+  // per-image rate); fall back to the model's static per-image price.
+  const costCents =
+    providerCostUsd != null
+      ? roundCents(providerCostUsd * 100)
+      : imageCentsPerImage != null
+        ? blobs.length * imageCentsPerImage
+        : undefined;
+
+  return {
+    persisted,
+    blobs,
+    usage,
+    providerCostUsd,
+    costCents,
+    modelId,
+    providerName,
+    clamped,
+  };
+}

--- a/services/platform/convex/openai_compat/internal_actions.ts
+++ b/services/platform/convex/openai_compat/internal_actions.ts
@@ -15,6 +15,7 @@ import { isRecord } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
+import type { GeneratedImageBlob } from '../agents/image_generation/generate_image_blobs';
 import {
   loadGuardrailsSnapshot,
   sanitizeMessage,
@@ -24,6 +25,13 @@ import { reasoningScopeKey } from '../lib/agent_response/reasoning/scope';
 import { buildCallProviderOptions } from '../lib/provider_options';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 import { resolveLanguageModelWithFallback } from '../providers/failover';
+import { buildAiUserContent } from './content';
+import {
+  type ApiImageResult,
+  extractDataUriImages,
+  generateApiImages,
+} from './image_generation';
+import type { OpenAIChatImage } from './response_format';
 import { convertOpenAITools, generateToolCallId } from './tool_conversion';
 
 /**
@@ -74,6 +82,106 @@ async function sanitizeUserMessage(
   return result.text;
 }
 
+/**
+ * Write an AI audit-log row for a direct-model request. Status is derived from
+ * the real outcome — a `failure` row is written when inference throws — so the
+ * audit trail can't systematically under-report failures (it previously only
+ * ever wrote `status: 'success'`, leaving real failures with no record at all).
+ * Best-effort: a telemetry write must never mask the underlying result/error.
+ */
+async function writeAiAudit(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    userId?: string;
+    userEmail?: string;
+    action: string;
+    resourceType: string;
+    requestId: string;
+    status: 'success' | 'failure';
+    errorMessage?: string;
+    metadata: Record<string, unknown>;
+  },
+): Promise<void> {
+  await ctx
+    .runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
+      organizationId: args.organizationId,
+      actorId: args.userId ?? 'system',
+      actorEmail: args.userEmail,
+      actorType: 'api' as const,
+      action: args.action,
+      category: 'ai' as const,
+      resourceType: args.resourceType,
+      resourceId: args.requestId,
+      status: args.status,
+      ...(args.errorMessage ? { errorMessage: args.errorMessage } : {}),
+      metadata: { requestId: args.requestId, ...args.metadata },
+    })
+    .catch((error) => {
+      console.error('[OpenAI-compat] Failed to write AI audit log:', error);
+    });
+}
+
+/**
+ * Shared pre-flight for direct-model requests: per-org budget ceiling, then
+ * model-access RBAC (writing a `denied` audit row and throwing on refusal).
+ * Shared by chat completions and image generation so the two endpoints enforce
+ * the same governance.
+ */
+async function enforceBudgetAndAccess(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    userId: string;
+    userEmail?: string;
+    modelId: string;
+  },
+): Promise<void> {
+  const budgetResult = await ctx.runQuery(
+    internal.governance.internal_queries.checkBudgetForRequest,
+    { organizationId: args.organizationId, userId: args.userId },
+  );
+  if (!budgetResult.allowed) {
+    throw new Error(
+      budgetResult.reason ??
+        'Usage limit reached for this period. Contact your administrator.',
+    );
+  }
+
+  // Strip provider qualifier so governance policies (which store plain model
+  // ids) match regardless of routing.
+  const accessCheck = await ctx.runQuery(
+    internal.governance.internal_queries.checkModelAccessInternal,
+    {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      modelId: stripModelRefQualifier(args.modelId),
+    },
+  );
+  if (!accessCheck.allowed) {
+    await ctx.runMutation(
+      internal.audit_logs.internal_mutations.createAuditLog,
+      {
+        organizationId: args.organizationId,
+        actorId: args.userId,
+        actorEmail: args.userEmail,
+        actorType: 'api',
+        action: 'model_access.denied',
+        category: 'ai',
+        resourceType: 'openai_compat_request',
+        status: 'denied',
+        metadata: {
+          requestedModelId: args.modelId,
+          reason: accessCheck.reason ?? null,
+        },
+      },
+    );
+    throw new Error(
+      accessCheck.reason ?? 'You do not have access to the selected model.',
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Result type for direct model completions
 // ---------------------------------------------------------------------------
@@ -86,6 +194,8 @@ interface DirectModelResult {
     type: 'function';
     function: { name: string; arguments: string };
   }> | null;
+  /** Generated images (image-generation models), surfaced as chat images. */
+  images: OpenAIChatImage[] | null;
   finishReason: string;
   inputTokens: number;
   outputTokens: number;
@@ -105,6 +215,12 @@ export const chatDirectModel = internalAction({
     userEmail: v.optional(v.string()),
     userName: v.optional(v.string()),
     message: v.string(),
+    /**
+     * Structured last-user-message content (OpenAI `content` parts: text +
+     * image_url). When present, drives multimodal/vision input; `message`
+     * carries the joined text for sanitization signals and back-compat.
+     */
+    userContent: v.optional(v.any()),
     tools: v.optional(v.any()),
     toolChoice: v.optional(v.any()),
     conversationMessages: v.optional(v.any()),
@@ -113,59 +229,19 @@ export const chatDirectModel = internalAction({
   },
   returns: v.any(),
   handler: async (ctx, args): Promise<DirectModelResult> => {
-    // Pre-call budget enforcement. Matches chat/workflow paths so the
-    // OpenAI-compat endpoint shares the same per-org budget ceiling.
-    const budgetResult = await ctx.runQuery(
-      internal.governance.internal_queries.checkBudgetForRequest,
-      {
-        organizationId: args.organizationId,
-        userId: args.userId,
-      },
-    );
-    if (!budgetResult.allowed) {
-      throw new Error(
-        budgetResult.reason ??
-          'Usage limit reached for this period. Contact your administrator.',
-      );
-    }
-
-    // Model access RBAC. Strip provider qualifier so governance policies
-    // (which store plain model ids) match regardless of routing.
-    const accessCheck = await ctx.runQuery(
-      internal.governance.internal_queries.checkModelAccessInternal,
-      {
-        organizationId: args.organizationId,
-        userId: args.userId,
-        modelId: stripModelRefQualifier(args.modelId),
-      },
-    );
-    if (!accessCheck.allowed) {
-      await ctx.runMutation(
-        internal.audit_logs.internal_mutations.createAuditLog,
-        {
-          organizationId: args.organizationId,
-          actorId: args.userId,
-          actorEmail: args.userEmail,
-          actorType: 'api',
-          action: 'model_access.denied',
-          category: 'ai',
-          resourceType: 'openai_compat_request',
-          status: 'denied',
-          metadata: {
-            requestedModelId: args.modelId,
-            reason: accessCheck.reason ?? null,
-          },
-        },
-      );
-      throw new Error(
-        accessCheck.reason ?? 'You do not have access to the selected model.',
-      );
-    }
+    // Per-org budget ceiling + model-access RBAC (shared with the chat/workflow
+    // paths and the image endpoint).
+    await enforceBudgetAndAccess(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      userEmail: args.userEmail,
+      modelId: args.modelId,
+    });
 
     // Resolve model directly — no agent config. Pass orgSlug so each org
     // uses its own provider files / API keys.
     const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
-    const message = await sanitizeUserMessage(
+    const sanitizedText = await sanitizeUserMessage(
       ctx,
       args.message,
       args.organizationId,
@@ -174,6 +250,12 @@ export const chatDirectModel = internalAction({
       args.userEmail ?? '',
       args.modelId,
     );
+    // Build AI SDK user content. With multimodal `userContent` (vision), keep
+    // the image parts and substitute the PII-sanitized text; otherwise it's the
+    // sanitized string unchanged.
+    const userMessageContent = args.userContent
+      ? buildAiUserContent(args.userContent, sanitizedText)
+      : sanitizedText;
     const resolved = await resolveLanguageModelWithFallback(ctx, {
       modelId: args.modelId,
       tag: 'chat',
@@ -192,6 +274,33 @@ export const chatDirectModel = internalAction({
     // Direct model mode is stateless — no thread/message persistence.
     // Transient ID for audit log correlation only.
     const requestId = `direct-${Date.now().toString(36)}`;
+
+    const hasConversation =
+      args.conversationMessages &&
+      Array.isArray(args.conversationMessages) &&
+      args.conversationMessages.length > 0;
+
+    // Image-generation models produce image bytes, not text. `streamText` reads
+    // only `result.text`, so routing them through the text path drops the image
+    // while still billing tokens. Detect the `image-generation` tag and route to
+    // the shared image core so the image is returned (and billed once, against a
+    // real deliverable). An attached `data:` image turns this into an edit (the
+    // model must carry the `image-edit` tag). Tool-continuation turns can't be
+    // image turns.
+    if (
+      resolved.modelData.tags.includes('image-generation') &&
+      !hasConversation
+    ) {
+      return await runChatImageGeneration(ctx, {
+        requestId,
+        modelRef: `${resolved.modelData.providerName}:${resolved.modelData.modelId}`,
+        prompt: sanitizedText,
+        attachmentBytes: extractDataUriImages(args.userContent),
+        organizationId: args.organizationId,
+        userId: args.userId,
+        userEmail: args.userEmail,
+      });
+    }
 
     // Fetch mandatory system prompt governance policy
     const systemPromptPolicy = await ctx.runQuery(
@@ -222,16 +331,12 @@ export const chatDirectModel = internalAction({
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generationParams is v.any() from Convex validator; shape is controlled by http_actions.ts buildGenerationParams
     const genParams = (args.generationParams ?? {}) as Record<string, unknown>;
 
-    // Build messages — use full conversation if provided, otherwise single message
-    const hasConversation =
-      args.conversationMessages &&
-      Array.isArray(args.conversationMessages) &&
-      args.conversationMessages.length > 0;
-
+    // Build messages — use full conversation if provided, otherwise the single
+    // (possibly multimodal) user turn.
     const messages: ModelMessage[] = hasConversation
       ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- conversationMessages is built by convertToModelMessages in http_actions.ts; shape matches ModelMessage[]
         (args.conversationMessages as ModelMessage[])
-      : [{ role: 'user' as const, content: message }];
+      : [{ role: 'user', content: userMessageContent }];
 
     // Adaptive Reasoning Governor: scale reasoning + temperature to the
     // request's difficulty. The stateless API path has no per-thread state, but
@@ -249,7 +354,7 @@ export const chatDirectModel = internalAction({
       baseProviderOptions: buildCallProviderOptions(resolved.modelData),
       signals: {
         kind: 'chat',
-        promptText: typeof message === 'string' ? message : undefined,
+        promptText: sanitizedText,
         toolCount: aiTools ? Object.keys(aiTools).length : 0,
       },
       profile: reasoningProfile ?? undefined,
@@ -259,36 +364,67 @@ export const chatDirectModel = internalAction({
       genParams.temperature != null
         ? Number(genParams.temperature)
         : reasoningDecision.temperature;
-    const result = streamText({
-      model: resolved.languageModel,
-      system: systemPrompt,
-      messages,
-      ...(callProviderOptions ? { providerOptions: callProviderOptions } : {}),
-      ...(aiTools && { tools: aiTools }),
-      ...(args.toolChoice != null && {
-        toolChoice: mapToolChoice(args.toolChoice),
-      }),
-      ...(effectiveTemperature != null && {
-        temperature: effectiveTemperature,
-      }),
-      ...(genParams.maxTokens != null && {
-        maxTokens: Number(genParams.maxTokens),
-      }),
-      ...(genParams.topP != null && { topP: Number(genParams.topP) }),
-      ...(genParams.frequencyPenalty != null && {
-        frequencyPenalty: Number(genParams.frequencyPenalty),
-      }),
-      ...(genParams.presencePenalty != null && {
-        presencePenalty: Number(genParams.presencePenalty),
-      }),
-      ...(Array.isArray(genParams.stopSequences) && {
-        stopSequences: genParams.stopSequences,
-      }),
-    });
+    // Run inference. Any provider/inference failure is recorded as a `failure`
+    // audit row before re-throwing — otherwise real failures leave no audit
+    // trail at all (the success row below is unreachable once this throws).
+    let text: string;
+    let finishReason: string;
+    let steps: Awaited<ReturnType<typeof streamText>['steps']>;
+    let usage: Awaited<ReturnType<typeof streamText>['usage']>;
+    try {
+      const result = streamText({
+        model: resolved.languageModel,
+        system: systemPrompt,
+        messages,
+        ...(callProviderOptions
+          ? { providerOptions: callProviderOptions }
+          : {}),
+        ...(aiTools && { tools: aiTools }),
+        ...(args.toolChoice != null && {
+          toolChoice: mapToolChoice(args.toolChoice),
+        }),
+        ...(effectiveTemperature != null && {
+          temperature: effectiveTemperature,
+        }),
+        ...(genParams.maxTokens != null && {
+          maxTokens: Number(genParams.maxTokens),
+        }),
+        ...(genParams.topP != null && { topP: Number(genParams.topP) }),
+        ...(genParams.frequencyPenalty != null && {
+          frequencyPenalty: Number(genParams.frequencyPenalty),
+        }),
+        ...(genParams.presencePenalty != null && {
+          presencePenalty: Number(genParams.presencePenalty),
+        }),
+        ...(Array.isArray(genParams.stopSequences) && {
+          stopSequences: genParams.stopSequences,
+        }),
+      });
 
-    const text: string = await result.text;
-    const finishReason: string = await result.finishReason;
-    const steps = await result.steps;
+      text = await result.text;
+      finishReason = await result.finishReason;
+      steps = await result.steps;
+      usage = await result.usage;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      await writeAiAudit(ctx, {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        userEmail: args.userEmail,
+        action: 'ai.completion',
+        resourceType: 'agent_completion',
+        requestId,
+        status: 'failure',
+        errorMessage,
+        metadata: {
+          model: resolved.modelData.modelId,
+          provider: resolved.modelData.providerName,
+          agentType: 'direct_model',
+        },
+      });
+      throw error;
+    }
 
     // Extract tool calls from steps
     interface ToolCallContent {
@@ -314,15 +450,15 @@ export const chatDirectModel = internalAction({
       }));
 
     // Track usage
-    const usage = await result.usage;
     const inputTokens = usage?.inputTokens ?? 0;
     const outputTokens = usage?.outputTokens ?? 0;
     const totalTokens = inputTokens + outputTokens;
 
+    let costCents: number | undefined;
     if (args.organizationId && (inputTokens > 0 || outputTokens > 0)) {
       const { estimateCostCents } =
         await import('../governance/cost_estimation');
-      const costCents = estimateCostCents(
+      costCents = estimateCostCents(
         resolved.modelData.modelId,
         inputTokens,
         outputTokens,
@@ -348,45 +484,254 @@ export const chatDirectModel = internalAction({
             error,
           );
         });
-
-      await ctx
-        .runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
-          organizationId: args.organizationId,
-          actorId: args.userId ?? 'system',
-          actorType: 'api' as const,
-          action: 'ai.completion',
-          category: 'ai' as const,
-          resourceType: 'agent_completion',
-          resourceId: requestId,
-          status: 'success' as const,
-          metadata: {
-            model: resolved.modelData.modelId,
-            inputTokens,
-            outputTokens,
-            totalTokens,
-            costEstimateCents: costCents,
-            requestId,
-            agentType: 'direct_model',
-            toolCallCount: toolCalls.length,
-          },
-        })
-        .catch((error) => {
-          console.error(
-            '[OpenAI-compat:directModel] Failed to write AI audit log:',
-            error,
-          );
-        });
     }
+
+    // Audit every completed request — status reflects the real outcome.
+    await writeAiAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      userEmail: args.userEmail,
+      action: 'ai.completion',
+      resourceType: 'agent_completion',
+      requestId,
+      status: 'success',
+      metadata: {
+        model: resolved.modelData.modelId,
+        provider: resolved.modelData.providerName,
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        costEstimateCents: costCents ?? null,
+        finishReason,
+        agentType: 'direct_model',
+        toolCallCount: toolCalls.length,
+      },
+    });
 
     return {
       requestId,
       text: text || null,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
+      images: null,
       finishReason,
       inputTokens,
       outputTokens,
       totalTokens,
       resolvedModel: resolved.modelData.modelId,
     };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Image generation
+// ---------------------------------------------------------------------------
+
+/** Ledger + success audit for a completed image generation. Best-effort. */
+async function recordImageUsageAndAudit(
+  ctx: ActionCtx,
+  opts: {
+    requestId: string;
+    action: string;
+    organizationId: string;
+    userId?: string;
+    userEmail?: string;
+    img: ApiImageResult;
+  },
+): Promise<void> {
+  const { img } = opts;
+  if (
+    opts.organizationId &&
+    (img.costCents != null || img.usage.totalTokens > 0)
+  ) {
+    await ctx
+      .runMutation(
+        internal.governance.internal_mutations.incrementUsageLedger,
+        {
+          organizationId: opts.organizationId,
+          userId: opts.userId ?? 'system',
+          inputTokens: img.usage.inputTokens,
+          outputTokens: img.usage.outputTokens,
+          costEstimateCents: img.costCents ?? 0,
+          timestamp: Date.now(),
+          model: img.modelId,
+          provider: img.providerName,
+        },
+      )
+      .catch((error) => {
+        console.error(
+          '[OpenAI-compat:image] Failed to increment usage ledger:',
+          error,
+        );
+      });
+  }
+  await writeAiAudit(ctx, {
+    organizationId: opts.organizationId,
+    userId: opts.userId,
+    userEmail: opts.userEmail,
+    action: opts.action,
+    resourceType: 'image_generation',
+    requestId: opts.requestId,
+    status: 'success',
+    metadata: {
+      model: img.modelId,
+      provider: img.providerName,
+      imageCount: img.persisted.length,
+      inputTokens: img.usage.inputTokens,
+      outputTokens: img.usage.outputTokens,
+      costEstimateCents: img.costCents ?? null,
+      clamped: img.clamped,
+    },
+  });
+}
+
+/**
+ * Generate image(s) for an `image-generation`-tagged model requested via
+ * `/chat/completions`, returning them as chat `message.images[]`. Budget + RBAC
+ * have already run in the caller. A failure is audited before re-throwing.
+ */
+async function runChatImageGeneration(
+  ctx: ActionCtx,
+  opts: {
+    requestId: string;
+    modelRef: string;
+    prompt: string;
+    attachmentBytes?: GeneratedImageBlob[];
+    organizationId: string;
+    userId: string;
+    userEmail?: string;
+  },
+): Promise<DirectModelResult> {
+  try {
+    const img = await generateApiImages(ctx, {
+      modelRef: opts.modelRef,
+      prompt: opts.prompt,
+      n: 1,
+      organizationId: opts.organizationId,
+      namePrefix: 'openai-chat-image',
+      attachmentBytes: opts.attachmentBytes,
+    });
+    await recordImageUsageAndAudit(ctx, {
+      requestId: opts.requestId,
+      action: 'ai.image_generation',
+      organizationId: opts.organizationId,
+      userId: opts.userId,
+      userEmail: opts.userEmail,
+      img,
+    });
+    return {
+      requestId: opts.requestId,
+      text: null,
+      toolCalls: null,
+      images: img.persisted.map((p) => ({
+        type: 'image_url' as const,
+        image_url: { url: p.downloadUrl },
+      })),
+      finishReason: 'stop',
+      inputTokens: img.usage.inputTokens,
+      outputTokens: img.usage.outputTokens,
+      totalTokens: img.usage.totalTokens,
+      resolvedModel: img.modelId,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await writeAiAudit(ctx, {
+      organizationId: opts.organizationId,
+      userId: opts.userId,
+      userEmail: opts.userEmail,
+      action: 'ai.image_generation',
+      resourceType: 'image_generation',
+      requestId: opts.requestId,
+      status: 'failure',
+      errorMessage,
+      metadata: { modelRef: opts.modelRef },
+    });
+    throw error;
+  }
+}
+
+interface ImagesGenerateResult {
+  requestId: string;
+  model: string;
+  data: Array<{ url?: string; b64_json?: string }>;
+  /** Whether `n` was clamped to the per-request ceiling. */
+  clamped: boolean;
+}
+
+/**
+ * `POST /api/v1/images/generations` backend. Reuses the shared image core, so
+ * it behaves identically to the in-product image agent. Enforces the same
+ * budget + RBAC as chat, sanitizes the prompt, and audits success/failure.
+ */
+export const imagesGenerateDirect = internalAction({
+  args: {
+    modelId: v.string(),
+    organizationId: v.string(),
+    userId: v.string(),
+    userEmail: v.optional(v.string()),
+    userName: v.optional(v.string()),
+    prompt: v.string(),
+    n: v.optional(v.number()),
+    responseFormat: v.optional(v.string()),
+  },
+  returns: v.any(),
+  handler: async (ctx, args): Promise<ImagesGenerateResult> => {
+    await enforceBudgetAndAccess(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      userEmail: args.userEmail,
+      modelId: args.modelId,
+    });
+
+    const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
+    const prompt = await sanitizeUserMessage(
+      ctx,
+      args.prompt,
+      args.organizationId,
+      orgSlug,
+      args.userId,
+      args.userEmail ?? '',
+      args.modelId,
+    );
+
+    const requestId = `img-${Date.now().toString(36)}`;
+    try {
+      const img = await generateApiImages(ctx, {
+        modelRef: args.modelId,
+        prompt,
+        n: args.n,
+        organizationId: args.organizationId,
+        namePrefix: 'openai-image',
+      });
+      await recordImageUsageAndAudit(ctx, {
+        requestId,
+        action: 'ai.image_generation',
+        organizationId: args.organizationId,
+        userId: args.userId,
+        userEmail: args.userEmail,
+        img,
+      });
+      const data =
+        args.responseFormat === 'b64_json'
+          ? img.blobs.map((b) => ({
+              b64_json: Buffer.from(b.bytes).toString('base64'),
+            }))
+          : img.persisted.map((p) => ({ url: p.downloadUrl }));
+      return { requestId, model: img.modelId, data, clamped: img.clamped };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      await writeAiAudit(ctx, {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        userEmail: args.userEmail,
+        action: 'ai.image_generation',
+        resourceType: 'image_generation',
+        requestId,
+        status: 'failure',
+        errorMessage,
+        metadata: { model: args.modelId },
+      });
+      throw error;
+    }
   },
 });

--- a/services/platform/convex/openai_compat/response_format.test.ts
+++ b/services/platform/convex/openai_compat/response_format.test.ts
@@ -5,10 +5,12 @@ import {
   buildChatCompletion,
   buildChatCompletionChunk,
   buildChatCompletionWithToolCalls,
+  buildImagesGenerationsResponse,
   buildStreamingUsageChunk,
   formatSSECitations,
   formatSSEChunk,
   formatSSEDone,
+  mapFinishReason,
   type OpenAIUsage,
 } from './response_format';
 
@@ -82,6 +84,31 @@ describe('buildChatCompletion', () => {
     });
   });
 
+  it('defaults finish_reason to stop and omits images', () => {
+    const result = buildChatCompletion('id', 'm', 'hi', 1700000000);
+    expect(result.choices[0].finish_reason).toBe('stop');
+    expect(result.choices[0].message.images).toBeUndefined();
+  });
+
+  it('carries an explicit finish_reason and generated images', () => {
+    const result = buildChatCompletion(
+      'id',
+      'm',
+      '',
+      1700000000,
+      [],
+      undefined,
+      {
+        finishReason: 'length',
+        images: [{ type: 'image_url', image_url: { url: 'https://x/a.png' } }],
+      },
+    );
+    expect(result.choices[0].finish_reason).toBe('length');
+    expect(result.choices[0].message.images).toEqual([
+      { type: 'image_url', image_url: { url: 'https://x/a.png' } },
+    ]);
+  });
+
   it('passes through custom usage values', () => {
     const usage: OpenAIUsage = {
       prompt_tokens: 100,
@@ -99,6 +126,39 @@ describe('buildChatCompletion', () => {
     );
 
     expect(result.usage).toEqual(usage);
+  });
+});
+
+describe('mapFinishReason', () => {
+  it('maps AI SDK finish reasons to the OpenAI enum', () => {
+    expect(mapFinishReason('stop')).toBe('stop');
+    expect(mapFinishReason('length')).toBe('length');
+    expect(mapFinishReason('tool-calls')).toBe('tool_calls');
+    expect(mapFinishReason('tool_calls')).toBe('tool_calls');
+  });
+
+  it('falls back to stop for unknown/undefined reasons', () => {
+    expect(mapFinishReason('content-filter')).toBe('stop');
+    expect(mapFinishReason(undefined)).toBe('stop');
+  });
+});
+
+describe('buildImagesGenerationsResponse', () => {
+  it('wraps url data in the OpenAI images shape', () => {
+    const result = buildImagesGenerationsResponse(1700000000, [
+      { url: 'https://x/a.png' },
+    ]);
+    expect(result).toEqual({
+      created: 1700000000,
+      data: [{ url: 'https://x/a.png' }],
+    });
+  });
+
+  it('carries b64_json data', () => {
+    const result = buildImagesGenerationsResponse(1700000000, [
+      { b64_json: 'AAAA' },
+    ]);
+    expect(result.data).toEqual([{ b64_json: 'AAAA' }]);
   });
 });
 

--- a/services/platform/convex/openai_compat/response_format.ts
+++ b/services/platform/convex/openai_compat/response_format.ts
@@ -29,7 +29,37 @@ export interface OpenAIToolCall {
   function: { name: string; arguments: string };
 }
 
+/**
+ * Generated-image entry attached to an assistant chat message. Matches the
+ * OpenRouter / Vercel-Gateway `choices[0].message.images[]` convention (and
+ * what `fetchChatCompletionImages` already parses) so image-producing chat
+ * models surface their output instead of having it silently dropped.
+ */
+export interface OpenAIChatImage {
+  type: 'image_url';
+  image_url: { url: string };
+}
+
 type FinishReason = 'stop' | 'length' | 'tool_calls';
+
+/**
+ * Map an AI SDK `finishReason` to the OpenAI `finish_reason` enum so the
+ * completion reports what actually happened (e.g. a truncated `length` finish)
+ * instead of a hardcoded `stop`.
+ */
+export function mapFinishReason(
+  aiFinishReason: string | undefined,
+): FinishReason {
+  switch (aiFinishReason) {
+    case 'length':
+      return 'length';
+    case 'tool-calls':
+    case 'tool_calls':
+      return 'tool_calls';
+    default:
+      return 'stop';
+  }
+}
 
 interface ChatCompletionResponse {
   id: string;
@@ -42,6 +72,7 @@ interface ChatCompletionResponse {
       role: 'assistant';
       content: string | null;
       tool_calls?: OpenAIToolCall[];
+      images?: OpenAIChatImage[];
     };
     finish_reason: FinishReason;
   }>;
@@ -56,7 +87,9 @@ export function buildChatCompletion(
   created: number,
   citations: Citation[] = [],
   usage: OpenAIUsage = ZERO_USAGE,
+  opts: { finishReason?: FinishReason; images?: OpenAIChatImage[] } = {},
 ): ChatCompletionResponse {
+  const hasImages = opts.images != null && opts.images.length > 0;
   return {
     id: `chatcmpl-${id}`,
     object: 'chat.completion',
@@ -65,8 +98,12 @@ export function buildChatCompletion(
     choices: [
       {
         index: 0,
-        message: { role: 'assistant', content },
-        finish_reason: 'stop',
+        message: {
+          role: 'assistant',
+          content,
+          ...(hasImages ? { images: opts.images } : {}),
+        },
+        finish_reason: opts.finishReason ?? 'stop',
       },
     ],
     usage,
@@ -115,6 +152,7 @@ interface ChatCompletionChunkDelta {
     type?: 'function';
     function?: { name?: string; arguments?: string };
   }>;
+  images?: OpenAIChatImage[];
 }
 
 interface ChatCompletionChunk {
@@ -181,6 +219,29 @@ export function formatSSEDone(): string {
 
 export function formatSSECitations(citations: Citation[]): string {
   return `data: ${JSON.stringify({ citations })}\n\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Images generations response (OpenAI `/v1/images/generations` format)
+// ---------------------------------------------------------------------------
+
+export interface OpenAIImageDatum {
+  /** Present when `response_format: 'url'` (default). */
+  url?: string;
+  /** Present when `response_format: 'b64_json'`. */
+  b64_json?: string;
+}
+
+interface ImagesGenerationsResponse {
+  created: number;
+  data: OpenAIImageDatum[];
+}
+
+export function buildImagesGenerationsResponse(
+  created: number,
+  data: OpenAIImageDatum[],
+): ImagesGenerationsResponse {
+  return { created, data };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The OpenAI-compatible endpoint (`/api/v1/...`) was **text-only**, with three related gaps found while testing it against a live instance:

1. **Vision rejected.** A user message with array `content` (`[{type:"text"}, {type:"image_url"}]`) — the *only* way to send an image — returned a misleading `400 "No user message found in messages array"`. Text (string `content`) worked; any multimodal request failed.
2. **Image generation dropped + billed.** There was no `/images/generations` endpoint (`404`), and an image model called via `/chat/completions` returned `200` with the image **silently dropped** while still **billing tokens** (e.g. flux billed 3072 completion tokens for an empty response).
3. **Audit only ever `success`.** The AI audit row hardcoded `status: 'success'` and sat *after* the awaited inference, so a real inference failure threw first and left **no audit record at all** — the trail systematically under-reported failures. Combined with (2): you paid, got no image, and the audit said success.

## What changed

- **Vision** — accept array `content`; image parts flow to the model. Pure conversion lives in `openai_compat/content.ts` (unit-tested).
- **Image generation** — new `POST /api/v1/images/generations` (OpenAI Images shape; honours `n`, capped at 4, and `response_format` `url`/`b64_json`). Image models via `/chat/completions` now return `choices[0].message.images[]` (OpenRouter convention). Both reuse the existing `generateImageBlobs` / `persistImageBlob` core (`openai_compat/image_generation.ts`).
- **Image editing** — a `text` part + an `image_url` `data:` URL to an `image-edit` model edits that image. Only `data:` URLs are read as edit inputs (never fetch a user `http` URL server-side → no SSRF).
- **Audit integrity** — inference is wrapped; a `failure` row is written with the error before re-throwing, and `finish_reason` is derived from the real outcome instead of a hardcoded `stop`.
- Tighter `openai:images` rate-limit bucket; docs updated in **en/de/fr**.

No schema change / migration — the `failure` audit status already exists; the OpenAI-compat surface touches no tables.

## Verified live (dev backend, real models)

| Scenario | Result |
|---|---|
| Vision (`claude-sonnet-4.6` + image) | `200` — model read "TALE-7391", green circle, blue border, white bg |
| `POST /images/generations` (`gemini-2.5-flash-image`, `b64_json`) | `200` — real 1024×1024 apple PNG |
| Image model via chat (`flux.2-pro`) | `200` — image in `message.images[]`, download URL serves a valid PNG |
| **Image edit** (`gemini-2.5-flash-image` + `data:` apple) | `200` — red apple → green apple, same composition (genuine edit) |
| Forced inference failure (embedding model via chat) | `500` + audit row `status: "failure"` with `errorMessage`, chained into the integrity hash chain |
| Regression: plain text + streaming | unchanged (`PONG`, SSE `[DONE]`) |

## Gates

`typecheck` ✅ · `lint` ✅ · SAST `0 findings` ✅ · `oxfmt` ✅ · tests: **57 platform (openai_compat) + 144 docs** ✅

## Out of scope (follow-up if wanted)

- A dedicated multipart `POST /api/v1/images/edits` endpoint (the chat path covers editing today).