### PR TITLE
fix(platform): reliably close issue-desk tasks when their GitHub issue closes

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -1,7 +1,7 @@
 {
   "name": "Issue resolution desk",
   "description": "A config-driven, repo-agnostic issue-resolution desk. A GitHub issue (bound to a task by the github sync) is picked up by an implementer Claude Code agent that runs in the platform's own ephemeral sandbox on the user's BYO Claude credentials: it derives the repo from the issue, clones it, and FIRST checks whether an open pull request already resolves the issue — if one does it pushes its update onto that existing PR's branch (closing any redundant duplicate PRs) rather than opening a competing one; otherwise it fixes the issue on a tale/<id> branch, runs the project's OWN tests to verify, commits, pushes (broker-injected github token + the in-image credential helper, private repos included), opens (or updates) a pull request, and then WAITS for the project's CI to pass green — fixing failures and re-pushing until it does. The sandbox step is durable: it transparently spans the 10-minute Convex action ceiling (segmenting into re-attached windows), so a 40-50 minute CI run never times the step out, with no separate CI-poll step. A separate reviewer agent fetches the PR, re-runs the tests, confirms CI is green, and posts review comments. A toolless LLM judge then reads the review and decides merge-readiness: if yes, the task parks at In review and the workflow ends (the human merges); if no, it loops back to the implementer with the review feedback, repeating until the judge approves — or until the rework loop hits a configurable cap (config.variables.maxReworkLoops, default 3, adjustable per deployment), after which the desk stops looping, comments on the task, and parks it at In review for a human to take over. Cross-step state lives on the git branch + PR (plus a reworkCount loop counter in workflow variables); the per-step sandboxes are stateless. Every step carries ui/role annotations so the generic operator workspace renders it with no per-vertical UI code.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "metadata": {
     "pack": "issue-desk",
     "autoInstall": false
@@ -32,7 +32,85 @@
       "stepType": "start",
       "config": {},
       "nextSteps": {
-        "success": "ack"
+        "success": "precheck_has_ref"
+      }
+    },
+    {
+      "stepSlug": "precheck_has_ref",
+      "name": "Do we have the issue coordinates?",
+      "stepType": "condition",
+      "config": {
+        "expression": "input.owner && input.repo && input.issueNumber",
+        "description": "The pre-check needs owner/repo/issue_number to call get_issue. A task with a malformed or non-GitHub external ref (nothing parsed) skips straight to the normal flow, where the implementer derives the repo from the issue URL itself — so a bad ref never hard-fails the run."
+      },
+      "nextSteps": {
+        "true": "precheck_issue",
+        "false": "ack"
+      }
+    },
+    {
+      "stepSlug": "precheck_issue",
+      "name": "Fetch the issue's current state",
+      "stepType": "action",
+      "config": {
+        "type": "integration",
+        "parameters": {
+          "name": "github",
+          "operation": "get_issue",
+          "params": {
+            "owner": "{{input.owner}}",
+            "repo": "{{input.repo}}",
+            "issue_number": "{{input.issueNumber}}"
+          }
+        }
+      },
+      "nextSteps": {
+        "success": "precheck_issue_open"
+      }
+    },
+    {
+      "stepSlug": "precheck_issue_open",
+      "name": "Is the issue still open?",
+      "stepType": "condition",
+      "config": {
+        "expression": "steps.precheck_issue.output.data.result.data.state == 'open'",
+        "description": "If the issue is still open, run the normal resolve → review flow. If it is ALREADY closed (merged, fixed elsewhere, won't-fix, duplicate) there is nothing for the desk to do — skip the whole implement/review loop (saving the implementer + reviewer sandbox spend) and mark the task done."
+      },
+      "nextSteps": {
+        "true": "ack",
+        "false": "already_resolved_comment"
+      }
+    },
+    {
+      "stepSlug": "already_resolved_comment",
+      "name": "Note the issue was already closed",
+      "stepType": "action",
+      "config": {
+        "type": "task",
+        "parameters": {
+          "operation": "comment",
+          "taskId": "{{input.task._id}}",
+          "body": "[automated] GitHub issue #{{input.issueNumber}} is already closed upstream — nothing for the desk to resolve. Marking this task done."
+        }
+      },
+      "nextSteps": {
+        "success": "already_resolved_done"
+      }
+    },
+    {
+      "stepSlug": "already_resolved_done",
+      "name": "Mark as Done (issue already closed)",
+      "stepType": "action",
+      "config": {
+        "type": "task",
+        "parameters": {
+          "operation": "update_status",
+          "taskId": "{{input.task._id}}",
+          "status": "done"
+        }
+      },
+      "nextSteps": {
+        "success": "done"
       }
     },
     {

--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json
@@ -1,21 +1,21 @@
 {
   "name": "Reconcile task state from GitHub",
-  "description": "Scheduled, UPDATE-ONLY reconcile of the issue-desk board against GitHub. Each run lists the repository's issues and, for every issue that ALREADY has a task on this board (matched by the stable external ref \"owner/repo#number\"), syncs its open/closed lifecycle: a closed issue moves its task to done, a reopened issue pulls a terminal task back to backlog. It NEVER creates a task — the desk's manual 'create task from issue' intake owns creation — so the board is never flooded. This is what closes the loop when a desk pull request is merged OUT OF BAND (GitHub UI, CI auto-merge, a teammate): the implementer's PR carries 'Closes #<issue>', so merging it closes the issue, and this reconcile then moves the parked 'in review' task to done. Runs org-scoped with no projectId (the update path keys off each found task's own project), via the generic task workflow action and the github connector — no GitHub-specific or issue-desk-specific backend code.",
+  "description": "Scheduled, UPDATE-ONLY reconcile of the issue-desk board against GitHub, driven by the BOARD's own tasks — not by a repository issue listing. Each run enumerates the NON-TERMINAL tasks bound to this repo's issues (via the generic task action's list_open_external), fetches each issue's current open/closed state (github get_issue), and moves a task to done when its issue has closed — e.g. the desk's PR merged OUT OF BAND (GitHub UI, CI auto-merge, a teammate). Task-first on purpose: there is no 'newest N issues' page window, so an OLD closed issue still closes its task (the previous issue-first design silently reconciled only the newest 100 issues and missed every task pointing at an older one). It NEVER creates a task and never reopens a terminal one — the desk's manual 'create task from issue' intake owns creation, and this pass only closes still-open work. Runs org-scoped via the generic task workflow action (list_open_external + upsert_external) and the github connector (get_issue) — no GitHub-specific or issue-desk-specific backend code.",
   "i18n": {
     "en": {
       "name": "Reconcile task state from GitHub",
-      "description": "Closes a board task when its GitHub issue closes (e.g. the desk's PR merged) and reopens it if the issue reopens. Update-only — never creates tasks."
+      "description": "Closes a board task when its GitHub issue has closed (e.g. the desk's PR merged). Checks the board's own open tasks, so it never misses one. Update-only — never creates tasks."
     },
     "de": {
       "name": "Aufgabenstatus aus GitHub abgleichen",
-      "description": "Schließt eine Board-Aufgabe, wenn ihr GitHub-Issue geschlossen wird (z. B. nach dem Merge des Desk-PRs), und öffnet sie bei einem erneut geöffneten Issue wieder. Nur Aktualisierung — legt nie neue Aufgaben an."
+      "description": "Schließt eine Board-Aufgabe, wenn ihr GitHub-Issue geschlossen wurde (z. B. nach dem Merge des Desk-PRs). Prüft die offenen Aufgaben des Boards selbst und übersieht so keine. Nur Aktualisierung — legt nie neue Aufgaben an."
     },
     "fr": {
       "name": "Réconcilier l'état des tâches depuis GitHub",
-      "description": "Termine une tâche du tableau lorsque son ticket GitHub est fermé (par ex. après le merge de la PR du desk) et la rouvre si le ticket est rouvert. Mise à jour uniquement — ne crée jamais de tâche."
+      "description": "Termine une tâche du tableau lorsque son ticket GitHub est fermé (par ex. après le merge de la PR du desk). Parcourt les tâches ouvertes du tableau lui-même, sans jamais en manquer. Mise à jour uniquement — ne crée jamais de tâche."
     }
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "metadata": {
     "pack": "issue-desk"
   },
@@ -34,9 +34,7 @@
       {
         "cron": "*/15 * * * *",
         "timezone": "UTC",
-        "variables": {
-          "state": "all"
-        }
+        "variables": {}
       }
     ]
   },
@@ -44,7 +42,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": ["list_issues"]
+        "operations": ["get_issue"]
       }
     ]
   },
@@ -63,83 +61,82 @@
             "repo": {
               "description": "GitHub repository name, e.g. \"tale\".",
               "type": "string"
-            },
-            "state": {
-              "description": "Which issues to list: \"all\" (default) reconciles both closes and reopens; \"closed\" only closes.",
-              "type": "string"
             }
           },
           "required": ["owner", "repo"]
         }
       },
       "nextSteps": {
-        "success": "list_issues"
+        "success": "list_open_tasks"
       }
     },
     {
-      "stepSlug": "list_issues",
-      "name": "List GitHub Issues",
+      "stepSlug": "list_open_tasks",
+      "name": "List the board's open GitHub tasks",
+      "stepType": "action",
+      "config": {
+        "type": "task",
+        "parameters": {
+          "operation": "list_open_external",
+          "externalSystem": "github",
+          "owner": "{{input.owner}}",
+          "repo": "{{input.repo}}"
+        }
+      },
+      "nextSteps": {
+        "success": "check_has_tasks"
+      }
+    },
+    {
+      "stepSlug": "check_has_tasks",
+      "name": "Skip Loop If No Open Tasks",
+      "stepType": "condition",
+      "config": {
+        "expression": "(steps.list_open_tasks.output.data.refs | length) > 0",
+        "description": "The loop step throws on an empty items array (not covered by continueOnError), so route the empty case straight to done."
+      },
+      "nextSteps": {
+        "true": "loop_tasks",
+        "false": "done"
+      }
+    },
+    {
+      "stepSlug": "loop_tasks",
+      "name": "Loop Through Open Tasks",
+      "stepType": "loop",
+      "config": {
+        "continueOnError": true,
+        "itemVariable": "task",
+        "items": "{{steps.list_open_tasks.output.data.refs}}"
+      },
+      "nextSteps": {
+        "loop": "get_issue",
+        "done": "done"
+      }
+    },
+    {
+      "stepSlug": "get_issue",
+      "name": "Fetch the issue's current state",
       "stepType": "action",
       "config": {
         "type": "integration",
         "parameters": {
           "name": "github",
-          "operation": "list_issues",
+          "operation": "get_issue",
           "params": {
-            "owner": "{{input.owner}}",
-            "repo": "{{input.repo}}",
-            "state": "{{input.state || 'all'}}",
-            "per_page": 100
+            "owner": "{{loop.item.owner}}",
+            "repo": "{{loop.item.repo}}",
+            "issue_number": "{{loop.item.issueNumber}}"
           }
         }
       },
       "nextSteps": {
-        "success": "check_has_issues"
-      }
-    },
-    {
-      "stepSlug": "check_has_issues",
-      "name": "Skip Loop If No Issues",
-      "stepType": "condition",
-      "config": {
-        "expression": "(steps.list_issues.output.data.result.data | length) > 0",
-        "description": "The loop step throws on an empty items array (not covered by continueOnError), so route the empty case straight to done."
-      },
-      "nextSteps": {
-        "true": "loop_issues",
-        "false": "done"
-      }
-    },
-    {
-      "stepSlug": "loop_issues",
-      "name": "Loop Through Issues",
-      "stepType": "loop",
-      "config": {
-        "continueOnError": true,
-        "itemVariable": "issue",
-        "items": "{{steps.list_issues.output.data.result.data}}"
-      },
-      "nextSteps": {
-        "loop": "skip_pull_requests",
-        "done": "done"
-      }
-    },
-    {
-      "stepSlug": "skip_pull_requests",
-      "name": "Skip Pull Requests",
-      "stepType": "condition",
-      "config": {
-        "expression": "!loop.item.pull_request",
-        "description": "GitHub's issues endpoint returns pull requests too; PR objects carry a `pull_request` field that plain issues lack. Only real issues map to tasks; PRs route straight back to the loop."
-      },
-      "nextSteps": {
-        "true": "reconcile_task",
-        "false": "loop_issues"
+        "success": "reconcile_task"
       }
     },
     {
       "stepSlug": "reconcile_task",
-      "name": "Reconcile Task From Issue",
+      "name": "Close the task if its issue has closed",
       "stepType": "action",
       "config": {
         "type": "task",
@@ -147,14 +144,14 @@
           "operation": "upsert_external",
           "createIfMissing": false,
           "externalSystem": "github",
-          "externalId": "{{input.owner + '/' + input.repo + '#' + loop.item.number}}",
-          "externalUrl": "{{loop.item.html_url}}",
-          "title": "{{loop.item.title}}",
-          "externalState": "{{loop.item.state}}"
+          "externalId": "{{loop.item.externalId}}",
+          "externalUrl": "{{steps.get_issue.output.data.result.data.html_url}}",
+          "title": "{{steps.get_issue.output.data.result.data.title}}",
+          "externalState": "{{steps.get_issue.output.data.result.data.state}}"
         }
       },
       "nextSteps": {
-        "success": "loop_issues"
+        "success": "loop_tasks"
       }
     },
     {

--- a/services/platform/convex/tasks/internal_queries.ts
+++ b/services/platform/convex/tasks/internal_queries.ts
@@ -15,6 +15,8 @@ import { v } from 'convex/values';
 import type { Doc } from '../_generated/dataModel';
 import { internalQuery, type QueryCtx } from '../_generated/server';
 import { getThreadMessages } from '../threads/get_thread_messages';
+import { TERMINAL_STATUSES } from './helpers';
+import { parseIssueNumber, parseRepoRef } from './issue_ref';
 import { taskActorTypeValidator, taskStatusValidator } from './schema';
 
 const AGENT_TASK_LIST_CAP = 200;
@@ -470,5 +472,95 @@ export const listOpenTasksForAssignee = internalQuery({
       if (rows.length >= 50) break;
     }
     return rows;
+  },
+});
+
+/** Safety ceiling for a single reconcile pass. Not a page window: it never
+ *  silently drops the tail (unlike the old issue-list `per_page:100`) — hitting
+ *  it is logged so an operator sees a board that has outgrown one pass. Set far
+ *  above any realistic open-task count for one repo. */
+const RECONCILE_REFS_CAP = 5000;
+
+/**
+ * External refs for the NON-TERMINAL tasks on a board that are bound to one
+ * repo's issues — the enumeration a task-first reconcile loops over to re-check
+ * each open task's upstream issue state (closed → done). Keyed off the board's
+ * own tasks, NOT a repository issue listing, so there is no "newest N issues"
+ * window: a task whose issue is old still gets reconciled.
+ *
+ * Range-scans just this repo's rows on `by_org_external` via the stable
+ * `owner/repo#` externalId prefix (the `#` delimiter keeps repo `tale` from
+ * matching `tale-foo`), skips archived/terminal tasks, and parses each ref into
+ * the `{ owner, repo, issueNumber }` a `get_issue` call needs (JEXL can't split
+ * a string). Terminal tasks are excluded on purpose: this pass only closes open
+ * work, never reopens (per the reconcile's non-terminal-only scope).
+ */
+export const listOpenExternalTaskRefs = internalQuery({
+  args: {
+    organizationId: v.string(),
+    externalSystem: v.string(),
+    owner: v.string(),
+    repo: v.string(),
+  },
+  returns: v.array(
+    v.object({
+      taskId: v.id('tasks'),
+      externalId: v.string(),
+      owner: v.string(),
+      repo: v.string(),
+      issueNumber: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    // Range-scan exactly this repo's refs. Lower bound is the "owner/repo#"
+    // prefix; the exclusive upper bound bumps the trailing "#" (0x23) to the
+    // next byte "$" (0x24), so the scan spans every "owner/repo#<n>" ref and
+    // stops before any other key — a sibling repo like "owner/repo-2#…" sorts
+    // outside it. ASCII-only and agnostic to the numeric suffix.
+    const prefix = `${args.owner}/${args.repo}#`;
+    const prefixEnd = `${args.owner}/${args.repo}$`;
+    const refs: Array<{
+      taskId: Doc<'tasks'>['_id'];
+      externalId: string;
+      owner: string;
+      repo: string;
+      issueNumber: number;
+    }> = [];
+    let capped = false;
+    for await (const task of ctx.db
+      .query('tasks')
+      .withIndex('by_org_external', (q) =>
+        q
+          .eq('organizationId', args.organizationId)
+          .eq('externalSystem', args.externalSystem)
+          .gte('externalId', prefix)
+          .lt('externalId', prefixEnd),
+      )) {
+      if (task.archivedAt) continue;
+      if (TERMINAL_STATUSES.has(task.status)) continue;
+      if (!task.externalId) continue;
+      const repoRef = parseRepoRef(task.externalId);
+      const issueNumber = parseIssueNumber(task.externalId);
+      // A ref that doesn't parse to owner/repo#N can't address an issue; skip it
+      // rather than feed a broken get_issue call.
+      if (!repoRef || issueNumber === null) continue;
+      refs.push({
+        taskId: task._id,
+        externalId: task.externalId,
+        owner: repoRef.owner,
+        repo: repoRef.repo,
+        issueNumber,
+      });
+      if (refs.length >= RECONCILE_REFS_CAP) {
+        capped = true;
+        break;
+      }
+    }
+    if (capped) {
+      console.warn(
+        `[reconcile] listOpenExternalTaskRefs hit the ${RECONCILE_REFS_CAP} cap for ${prefix} — some open tasks were not returned this pass`,
+      );
+    }
+    return refs;
   },
 });

--- a/services/platform/convex/tasks/public_actions.test.ts
+++ b/services/platform/convex/tasks/public_actions.test.ts
@@ -95,6 +95,8 @@ describe('startTaskWorkflow', () => {
     expect(runActionCalls[0].args.input).toEqual({
       task: TASK,
       issueNumber: 1851,
+      owner: 'tale-project',
+      repo: 'tale',
       appConfig: {},
     });
     expect(runActionCalls[0].args.subject).toEqual({

--- a/services/platform/convex/tasks/public_actions.ts
+++ b/services/platform/convex/tasks/public_actions.ts
@@ -21,6 +21,10 @@ async function startWorkflowForTask(
   args: { organizationId: string; task: Doc<'tasks'>; workflowSlug: string },
 ): Promise<string | null> {
   const issueNumber = parseIssueNumber(args.task.externalId);
+  // owner/repo from the same "owner/repo#N" ref, so a workflow can address the
+  // upstream issue (e.g. the desk pre-check's get_issue) without re-parsing;
+  // null for a non-issue/malformed ref, which the workflow guards on.
+  const repoRef = parseRepoRef(args.task.externalId);
   // An app-owned workflow (slug `<app>/<name>`) gets its install's PER-PROJECT
   // config injected as `input.appConfig`, resolved by THIS task's project so two
   // projects bound to the same app never see each other's config. Empty for a
@@ -43,7 +47,13 @@ async function startWorkflowForTask(
         organizationId: args.organizationId,
         workflowSlug: args.workflowSlug,
         triggeredBy: 'user',
-        input: { task: args.task, issueNumber, appConfig },
+        input: {
+          task: args.task,
+          issueNumber,
+          owner: repoRef?.owner ?? null,
+          repo: repoRef?.repo ?? null,
+          appConfig,
+        },
         subject: { type: 'task', id: args.task._id },
       },
     );

--- a/services/platform/convex/tasks/queries.test.ts
+++ b/services/platform/convex/tasks/queries.test.ts
@@ -154,3 +154,75 @@ describe('tasks active-org coherence', () => {
     ).rejects.toThrow(/different organization/i);
   });
 });
+
+// The task-first reconcile enumerates the board's OPEN github tasks and rechecks
+// each issue's state. This pins the enumeration: only non-terminal tasks, only
+// the exact repo (the "#"→"$" range boundary must not leak a sibling repo whose
+// name extends this one, e.g. `tale-x`), parsed into the issue refs get_issue
+// needs. A regression here reintroduces the class of bug this reconcile replaced
+// (tasks silently skipped → their closed issues never close the task).
+describe('listOpenExternalTaskRefs', () => {
+  it('returns only non-terminal tasks for the exact repo, parsed into refs', async () => {
+    const t = convexTest(schema, modules);
+    const project = await seedProject(t, 'Desk');
+
+    // Non-terminal, repo "tale" → returned.
+    await upsertIssue(t, project, 'github', 'tale-project/tale#2033');
+    await upsertIssue(t, project, 'github', 'tale-project/tale#2117');
+    // Closed on create → the task lands as `done` (terminal) → excluded (this
+    // pass only closes still-open work, never revisits terminal tasks).
+    await t.mutation(
+      internal.tasks.internal_mutations.agentUpsertTaskByExternalRef,
+      {
+        organizationId: ORG,
+        actorId: 'user_1',
+        projectId: project,
+        externalSystem: 'github',
+        externalId: 'tale-project/tale#500',
+        title: 'already closed',
+        externalState: 'closed',
+      },
+    );
+    // Sibling repo whose name extends "tale" → must NOT leak past the
+    // "tale-project/tale#".."tale-project/tale$" range boundary.
+    await upsertIssue(t, project, 'github', 'tale-project/tale-x#1');
+    // Different owner, and a non-github system → both excluded.
+    await upsertIssue(t, project, 'github', 'other-org/tale#7');
+    await upsertIssue(t, project, 'jira', 'tale-project/tale#42');
+
+    const refs = await t.query(
+      internal.tasks.internal_queries.listOpenExternalTaskRefs,
+      {
+        organizationId: ORG,
+        externalSystem: 'github',
+        owner: 'tale-project',
+        repo: 'tale',
+      },
+    );
+
+    expect(
+      refs
+        .map(({ externalId, owner, repo, issueNumber }) => ({
+          externalId,
+          owner,
+          repo,
+          issueNumber,
+        }))
+        .sort((a, b) => a.issueNumber - b.issueNumber),
+    ).toEqual([
+      {
+        externalId: 'tale-project/tale#2033',
+        owner: 'tale-project',
+        repo: 'tale',
+        issueNumber: 2033,
+      },
+      {
+        externalId: 'tale-project/tale#2117',
+        owner: 'tale-project',
+        repo: 'tale',
+        issueNumber: 2117,
+      },
+    ]);
+    expect(refs.every((r) => typeof r.taskId === 'string')).toBe(true);
+  });
+});

--- a/services/platform/convex/workflow_engine/action_defs/task/task_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/task/task_action.ts
@@ -89,6 +89,12 @@ type TaskActionParams =
       assigneeId: string;
     }
   | {
+      operation: 'list_open_external';
+      externalSystem: string;
+      owner: string;
+      repo: string;
+    }
+  | {
       operation: 'archive';
       taskId: string;
     }
@@ -111,7 +117,7 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
   type: 'task',
   title: 'Task Operation',
   description:
-    'Create, read, and update tasks on the project board (create, get, update_status, assign, comment, archive, subtask_progress, list_dependents, list_open_for_assignee, upsert_external) plus the pack maintenance sweeps (sweep kinds: stale, due_soon, overdue_ladder, archivable — atomic mark-and-return, safe under repeated crons). upsert_external idempotently links an external item (e.g. a GitHub issue) to a task by (externalSystem, externalId). organizationId is read from workflow context variables.',
+    'Create, read, and update tasks on the project board (create, get, update_status, assign, comment, archive, subtask_progress, list_dependents, list_open_for_assignee, list_open_external, upsert_external) plus the pack maintenance sweeps (sweep kinds: stale, due_soon, overdue_ladder, archivable — atomic mark-and-return, safe under repeated crons). upsert_external idempotently links an external item (e.g. a GitHub issue) to a task by (externalSystem, externalId). organizationId is read from workflow context variables.',
   parametersValidator: v.union(
     v.object({
       operation: v.literal('create'),
@@ -170,6 +176,12 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
       operation: v.literal('list_open_for_assignee'),
       assigneeType: taskActorTypeValidator,
       assigneeId: v.string(),
+    }),
+    v.object({
+      operation: v.literal('list_open_external'),
+      externalSystem: v.string(),
+      owner: v.string(),
+      repo: v.string(),
     }),
     v.object({
       operation: v.literal('archive'),
@@ -322,6 +334,19 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
           },
         );
         return { operation: 'list_open_for_assignee', tasks };
+      }
+
+      case 'list_open_external': {
+        const refs = await ctx.runQuery(
+          internal.tasks.internal_queries.listOpenExternalTaskRefs,
+          {
+            organizationId,
+            externalSystem: params.externalSystem,
+            owner: params.owner,
+            repo: params.repo,
+          },
+        );
+        return { operation: 'list_open_external', refs };
       }
 
       case 'archive': {

--- a/services/platform/convex/workflow_engine/helpers/nodes/loop/utils/get_input_data.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/loop/utils/get_input_data.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LoopNodeConfig } from '../../../../types/nodes';
+import type { StepExecutionContext } from '../../../../types/workflow';
+import { getInputData } from './get_input_data';
+
+/** getInputData only reads ctx.variables; the rest of the context is not
+ *  exercised, so a minimal stub keeps the test focused on item resolution. */
+function ctxWith(variables: Record<string, unknown>): StepExecutionContext {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal test stub
+  return { variables } as unknown as StepExecutionContext;
+}
+
+describe('getInputData', () => {
+  it('resolves a raw template string to its array', () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test config
+    const config = { items: '{{issues}}' } as unknown as LoopNodeConfig;
+    const issues = [{ number: 1 }, { number: 2 }];
+
+    expect(getInputData(ctxWith({ issues }), config)).toEqual(issues);
+  });
+
+  it('uses an already-resolved items array as-is, never re-interpreting element text as JEXL', () => {
+    // The generic step-config pass (execute_step_handler → replaceVariables)
+    // has ALREADY resolved config.items from its `{{…}}` template into this
+    // concrete array before the loop node runs. Loop items are routinely
+    // user-controlled (e.g. GitHub issue titles/bodies) and legitimately
+    // contain mustache-like `{{…}}` — spreads (`{{...opts}}`), ellipses
+    // (`{{..}}`), Handlebars/Vue snippets. Re-running replaceVariables over the
+    // resolved array would parse those as JEXL and throw
+    // `Token . unexpected in expression: ..`, killing the whole loop before a
+    // single item is processed. They must pass through verbatim.
+    const resolvedItems = [
+      { number: 7, title: 'Fix spread call foo({{...opts}})' },
+      { number: 8, body: 'see {{..}} and {{ a.b.c }} in the template' },
+    ];
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test config
+    const config = { items: resolvedItems } as unknown as LoopNodeConfig;
+
+    expect(() => getInputData(ctxWith({}), config)).not.toThrow();
+    expect(getInputData(ctxWith({}), config)).toEqual(resolvedItems);
+  });
+});

--- a/services/platform/convex/workflow_engine/helpers/nodes/loop/utils/get_input_data.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/loop/utils/get_input_data.ts
@@ -17,7 +17,22 @@ export function getInputData(
     throw new Error('Loop items configuration is required (config.items)');
   }
 
-  const resolved = replaceVariables(itemsConfig, vars);
+  // `config.items` has ALREADY been resolved from its `{{…}}` template by the
+  // generic step-config pass (execute_step_handler → replaceVariables) before
+  // the loop node runs, so only a still-raw template string needs resolving
+  // here. A value that is already concrete — the normal case: the resolved
+  // array of items — must be used AS-IS. Re-running replaceVariables over it
+  // would recurse into every element and RE-INTERPRET any `{{…}}` inside as a
+  // JEXL expression; loop items are routinely user-controlled (e.g. GitHub
+  // issue titles/bodies), which legitimately contain `{{…}}` (spreads,
+  // ellipses, Handlebars/Vue snippets). That double pass turns benign text
+  // into a `Token . unexpected` JEXL crash that kills the whole loop before a
+  // single item is processed — and it isn't caught by continueOnError, which
+  // only guards the loop body, not item resolution.
+  const resolved =
+    typeof itemsConfig === 'string'
+      ? replaceVariables(itemsConfig, vars)
+      : itemsConfig;
 
   if (!Array.isArray(resolved)) {
     throw new Error(

--- a/services/platform/convex/workflow_executions/queries.ts
+++ b/services/platform/convex/workflow_executions/queries.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 
 import { deriveRunIndicator } from '../../lib/shared/platform/run_capacity';
 import { queryWithRLS } from '../lib/rls';
+import { TERMINAL_STATUSES } from '../tasks/helpers';
 import { getExecutionStepJournal as getExecutionStepJournalHelper } from '../workflows/executions/get_execution_step_journal';
 import { getExecutionStepStatuses as getExecutionStepStatusesHelper } from '../workflows/executions/get_execution_step_statuses';
 import { getOrgWorkflowMetrics as getOrgWorkflowMetricsHelper } from '../workflows/executions/get_org_workflow_metrics';
@@ -108,6 +109,10 @@ export const getLatestExecutionForSubject = queryWithRLS({
  * summary) so a list can show a per-row chip + retry without subscribing each
  * visible row to the heavy execution summary: Convex pushes an update only when
  * the indicator flips, not on every ~4s poll of a running execution.
+ *
+ * A RESOLVED subject returns `null`: a task already done/cancelled keeps showing
+ * its real terminal status, never a stale "Failed" chip or a Re-run offer for a
+ * past crashed automation — the work is closed regardless of that run.
  */
 export const getSubjectRunIndicator = queryWithRLS({
   args: {
@@ -120,6 +125,22 @@ export const getSubjectRunIndicator = queryWithRLS({
     failedExecutionId: v.union(v.id('wfExecutions'), v.null()),
   }),
   handler: async (ctx, args) => {
+    // A resolved subject has no actionable run state to surface. For a task
+    // that's already done/cancelled, keep its real terminal badge instead of
+    // overriding it with a "Failed" chip (or offering a Re-run) for an old run.
+    // RLS wraps the wfExecutions query below; `ctx.db.get` bypasses it, so match
+    // the org explicitly.
+    if (args.subjectType === 'task') {
+      const taskId = ctx.db.normalizeId('tasks', args.subjectId);
+      const task = taskId ? await ctx.db.get(taskId) : null;
+      if (
+        task &&
+        task.organizationId === args.organizationId &&
+        TERMINAL_STATUSES.has(task.status)
+      ) {
+        return { state: null, failedExecutionId: null };
+      }
+    }
     const row = await ctx.db
       .query('wfExecutions')
       .withIndex('by_org_subject', (q) =>

--- a/services/platform/convex/workflow_executions/subject_run_indicator.test.ts
+++ b/services/platform/convex/workflow_executions/subject_run_indicator.test.ts
@@ -1,0 +1,150 @@
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api, internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+/**
+ * getSubjectRunIndicator surfaces a subject's latest-run state (Failed / Queued)
+ * in place of its status badge. But a RESOLVED subject has nothing to surface: a
+ * task already done/cancelled must keep its real terminal status, never a stale
+ * "Failed" chip or a Re-run for a past crashed automation. This pins that.
+ *
+ * Mirrors mutations_error_codes.test.ts: identity via withIdentity, org
+ * membership via a seeded `memberMirror` row (the RLS local-table fast path).
+ */
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'workflow_executions';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_run_indicator';
+const USER_ID = 'user_ri';
+const IDENTITY = {
+  subject: USER_ID,
+  email: 'ri@example.com',
+  name: 'RI Tester',
+};
+
+type T = ReturnType<typeof convexTest>;
+
+function newT(): T {
+  return convexTest(schema, modules);
+}
+
+async function seedMember(t: T): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      organizationId: ORG,
+      userId: USER_ID,
+      memberId: 'member_ri',
+      role: 'member',
+      createdAt: 0,
+    });
+  });
+}
+
+async function seedProject(t: T): Promise<Id<'projects'>> {
+  return await t.run((ctx) =>
+    ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Desk',
+      createdBy: USER_ID,
+      createdAt: 0,
+      updatedAt: 0,
+    }),
+  );
+}
+
+/** `externalState:'open'` creates a backlog (non-terminal) task; `'closed'`
+ *  creates a done (terminal) one — the two cases this test contrasts. */
+async function seedTask(
+  t: T,
+  projectId: Id<'projects'>,
+  externalId: string,
+  externalState: 'open' | 'closed',
+): Promise<Id<'tasks'>> {
+  const res = await t.mutation(
+    internal.tasks.internal_mutations.agentUpsertTaskByExternalRef,
+    {
+      organizationId: ORG,
+      actorId: 'workflow',
+      projectId,
+      externalSystem: 'github',
+      externalId,
+      title: `Task ${externalId}`,
+      externalState,
+    },
+  );
+  if (!res.taskId) throw new Error('seedTask: expected a created task');
+  return res.taskId;
+}
+
+async function seedFailedRun(
+  t: T,
+  taskId: Id<'tasks'>,
+): Promise<Id<'wfExecutions'>> {
+  return await t.run((ctx) =>
+    ctx.db.insert('wfExecutions', {
+      organizationId: ORG,
+      wfDefinitionId: 'issue-desk/desk-process',
+      status: 'failed',
+      currentStepSlug: 'implement',
+      startedAt: 0,
+      updatedAt: 0,
+      subjectType: 'task',
+      subjectId: taskId,
+    }),
+  );
+}
+
+describe('getSubjectRunIndicator terminal-subject suppression', () => {
+  it('surfaces Failed (+ the run id) for a NON-terminal task whose latest run failed', async () => {
+    const t = newT();
+    await seedMember(t);
+    const project = await seedProject(t);
+    const taskId = await seedTask(t, project, 'o/r#1', 'open');
+    const execId = await seedFailedRun(t, taskId);
+
+    const res = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow_executions.queries.getSubjectRunIndicator, {
+        organizationId: ORG,
+        subjectType: 'task',
+        subjectId: taskId,
+      });
+
+    expect(res).toEqual({ state: 'failed', failedExecutionId: execId });
+  });
+
+  it('suppresses the failed-run indicator once the task is done', async () => {
+    const t = newT();
+    await seedMember(t);
+    const project = await seedProject(t);
+    const taskId = await seedTask(t, project, 'o/r#2', 'closed');
+    await seedFailedRun(t, taskId);
+
+    const res = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow_executions.queries.getSubjectRunIndicator, {
+        organizationId: ORG,
+        subjectType: 'task',
+        subjectId: taskId,
+      });
+
+    expect(res).toEqual({ state: null, failedExecutionId: null });
+  });
+});


### PR DESCRIPTION
## Why

The issue-desk board was leaving tasks open after their GitHub issue had already
closed. Digging in surfaced a chain of problems, fixed here as four atomic commits.

## What changed

1. **Loop steps no longer re-interpret resolved items** (`get_input_data.ts`)
   The reconcile cron was crashing on **every** run with
   `Token . unexpected in expression: ..`. Root cause: a loop's `config.items` is
   already resolved to an array by the generic step-config pass, then the loop node
   re-ran `replaceVariables` over it — re-interpreting `{{..}}`/`{{...}}` inside
   GitHub issue titles/bodies (user content) as JEXL. It's not caught by
   `continueOnError` (which guards the loop body, not item resolution), so the whole
   reconcile died before touching a single task.

2. **Reconcile is now task-first, not issue-first** (`reconcile.json` v2, new
   `listOpenExternalTaskRefs` query, `list_open_external` task-action op)
   It listed the repo's newest 100 issues and matched them to tasks — so a board
   whose tasks point at older issues (outside that window) never got reconciled.
   Now it enumerates the board's own **non-terminal** github tasks (cursor-scanned by
   repo prefix, no page cap) and re-checks each issue's state, closing the task when
   its issue has closed. Bounded by the board, complete regardless of issue age.

3. **Desk-process short-circuits an already-closed issue** (`desk-process.json` v1.5,
   `owner`/`repo` threaded into the workflow input)
   Before spending the implementer + reviewer sandboxes (~$25, up to an hour), a
   pre-check fetches the issue; if it's already closed it comments and marks the task
   done. A task with no parseable issue ref falls through to the normal flow.

4. **No stale "Failed"/Re-run on a resolved task** (`getSubjectRunIndicator`)
   A `done`/`cancelled` task kept showing a "Failed" chip + Re-run for a past crashed
   run, hiding its real status. A resolved subject now surfaces nothing.

## Verification

- **Live** (test org): reconcile v2 completes cleanly and closed **18** stale tasks in
  one pass (including the reported #2117); the loop crash is gone; run-indicator data
  confirms the fix hits the exact reported task.
- **Tests**: loop crash (exact-repro regression), reconcile enumeration scope,
  run-indicator surface + suppress. Typecheck + oxlint + opengrep (SAST) clean.
- **Gap (honest)**: the desk-process pre-check was **not** observed end-to-end — the
  workflow trigger requires a user identity the CLI can't supply. Every primitive it
  uses is live-proven (its `get_issue` path is identical to the reconcile's), and a
  bad issue ref falls through safely, but the wiring itself wasn't run.

## Done checklist

- [x] Gate green — typecheck, oxlint, and all touched tests pass locally
- [x] Security / SAST clean — opengrep 0 findings; new query is org-scoped; the
  run-indicator task lookup checks org explicitly (RLS bypass on `ctx.db.get`)
- [x] Migration — **N/A**, no data-model or config-schema change (workflow JSON + code)
- [x] Tests carry the change — happy + edge + error, except the desk-process pre-check
  (workflow JSON; its primitives are covered) — see gap above
- [x] Localized strings — `reconcile.json` description updated in en/de/fr; no other
  new user-facing strings (automated comments follow the existing plain-English
  convention; no new UI labels)
- [x] Docs — **N/A**, internal workflow behavior; the workflow `description` fields are
  the documentation and were updated
- [x] Accessibility — **N/A**, no new UI; net effect removes a chip/button on done rows
- [x] Behaviour verified by observing the real outcome (see Verification; pre-check gap noted)
- [x] Instructions/paths — none changed
- [x] Atomic conventional commits, branched off `main`

## Note for deploy

Installed orgs run a **copied** workflow definition, so they pick up reconcile v2 /
desk-process v1.5 only on **app reinstall / re-sync**, not automatically.
