### PR TITLE
fix(platform): agents/apps low-severity correctness & UX gaps (#2087)

### DIFF
--- a/services/platform/app/features/agents/components/agent-metrics-scorecard.test.tsx
+++ b/services/platform/app/features/agents/components/agent-metrics-scorecard.test.tsx
@@ -18,14 +18,19 @@ import { render, screen } from '@/tests/utils/render';
 // copy the E2E asserted is exactly the "no run data" branch.
 
 // The route file calls createFileRoute(...) at module scope and the component
-// reads Route.useParams() for the org/agent ids. Partial-mock the router so the
-// real exports stay intact while Route.useParams() returns deterministic ids.
+// reads Route.useParams() for the org/agent ids and Route.useSearch() for the
+// period window. Partial-mock the router so the real exports stay intact while
+// those hooks return deterministic values (and useNavigate is a no-op — the
+// period selector's navigate never fires in a render-only test).
 const mockUseParams = vi.fn(() => ({ id: 'org-1', agentId: 'e2e-agent' }));
+const mockUseSearch = vi.fn(() => ({ period: undefined }));
 vi.mock('@tanstack/react-router', async (orig) => ({
   ...(await orig<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => vi.fn(),
   createFileRoute: () => (config: Record<string, unknown>) => ({
     ...config,
     useParams: () => mockUseParams(),
+    useSearch: () => mockUseSearch(),
   }),
 }));
 

--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -356,11 +356,20 @@ export function AgentNavigation({
           'config' in result
         ) {
           const parsed = agentJsonSchema.safeParse(result.config);
-          if (!parsed.success) return;
-          setSelectedEntry(entry);
-          setSnapshotConfig(parsed.data);
-          setIsDiffOpen(true);
+          if (parsed.success) {
+            setSelectedEntry(entry);
+            setSnapshotConfig(parsed.data);
+            setIsDiffOpen(true);
+            return;
+          }
         }
+        // The read resolved but yielded nothing loadable — a missing, corrupt,
+        // or schema-divergent snapshot. Tell the user instead of silently doing
+        // nothing (a click that opens no diff otherwise reads as a freeze).
+        toast({
+          title: t('agents.historyLoadFailed'),
+          variant: 'destructive',
+        });
       } catch (err) {
         console.error(err);
         toast({

--- a/services/platform/app/features/agents/organigram/organigram-canvas.tsx
+++ b/services/platform/app/features/agents/organigram/organigram-canvas.tsx
@@ -206,10 +206,6 @@ export function OrganigramCanvas({
           delegateSlugs: current[slug] ?? [],
         });
       }
-      // Reseed the baseline from the authoritative server state.
-      const result = await refetch();
-      const fresh = buildReportsMap(result.data?.nodes ?? []);
-      overrideConfig(fresh);
       toast({ title: t('saved'), variant: 'success' });
     } catch (error) {
       const code = errorCode(error);
@@ -223,6 +219,20 @@ export function OrganigramCanvas({
         variant: 'destructive',
       });
     } finally {
+      // Always reseed the baseline from authoritative server state — even on a
+      // PARTIAL failure. The loop persists agents one at a time, so a mid-loop
+      // throw leaves the already-written agents committed on disk; without this
+      // resync their saved edges keep reading as unsaved and Discard would
+      // revert them to a stale baseline.
+      try {
+        const result = await refetch();
+        overrideConfig(buildReportsMap(result.data?.nodes ?? []));
+      } catch (reseedError) {
+        console.error(
+          '[organigram] baseline reseed after save failed',
+          reseedError,
+        );
+      }
       setIsSaving(false);
     }
   }, [

--- a/services/platform/app/features/apps/components/app-lifecycle-actions.tsx
+++ b/services/platform/app/features/apps/components/app-lifecycle-actions.tsx
@@ -110,7 +110,7 @@ export function AppLifecycleActions({
     setBusy(true);
     try {
       await uninstall(appSlug);
-      toast({ title: t('install.uninstalled') });
+      toast({ title: t('install.uninstalled'), variant: 'success' });
       dialogs.setOpen.uninstall(false);
       onChanged?.();
     } catch (error) {

--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -47,6 +47,7 @@ import {
   useAppInstallActions,
   useAppInstallStates,
 } from '../hooks/use-install-state';
+import { useRequiredIntegrations } from '../hooks/use-required-integrations';
 import { AppView } from '../registry/app-view';
 import { AppRuntimeProvider, resolvePackLabel } from '../runtime/app-runtime';
 import { ResourceDetailProvider } from '../runtime/resource-detail';
@@ -76,6 +77,17 @@ function ReadinessChecklist({
 }) {
   const { t } = useT('apps');
   const { reinstall, isPending } = useAppInstallActions(organizationId);
+  // Resolve each blocked slug to its integration display title, the same lookup
+  // the install wizard's `labelFor` uses — so the checklist reads "Connect
+  // GitHub", not the raw "github" slug.
+  const { required } = useRequiredIntegrations(
+    organizationId,
+    blockedIntegrations,
+  );
+  const titleBySlug = useMemo(
+    () => new Map(required.map((r) => [r.slug, r.integration.title])),
+    [required],
+  );
 
   if (
     status === 'active' &&
@@ -110,7 +122,9 @@ function ReadinessChecklist({
         {blockedIntegrations.map((slug) => (
           <HStack key={slug} gap={3} className="items-center justify-between">
             <Text variant="muted" className="text-sm">
-              {t('readiness.connect', { integration: slug })}
+              {t('readiness.connect', {
+                integration: titleBySlug.get(slug) ?? slug,
+              })}
             </Text>
             <Button variant="secondary" onClick={() => onConnect(slug)}>
               {t('readiness.connectButton')}

--- a/services/platform/app/features/apps/registry/connected/data-table.tsx
+++ b/services/platform/app/features/apps/registry/connected/data-table.tsx
@@ -71,6 +71,15 @@ function cell(col: string, value: unknown): React.ReactNode {
   return JSON.stringify(value).slice(0, 60);
 }
 
+/** Stable row key: the row's `_id`/`id` when present, else the array index.
+ *  These lists are reactive and often newest-first, so a plain index key
+ *  remounts every row when the head changes — keying by identity keeps row
+ *  state (expansion, focus) attached to its record. */
+function rowKey(row: Record<string, unknown>, index: number): string | number {
+  const id = row._id ?? row.id;
+  return typeof id === 'string' || typeof id === 'number' ? id : index;
+}
+
 /** Columns to show: explicit, else inferred from the first row (minus id-like keys). */
 function inferColumns(
   rows: Record<string, unknown>[],
@@ -169,7 +178,7 @@ export function DataTable({
             typeof rawRowActionId === 'string' ? rawRowActionId : undefined;
           const isExpanded = expandable && expandedId === subjectId;
           return (
-            <Fragment key={i}>
+            <Fragment key={rowKey(row, i)}>
               <TableRow
                 className={cn(expandable && 'cursor-pointer')}
                 onClick={

--- a/services/platform/app/features/apps/registry/connected/run-list.tsx
+++ b/services/platform/app/features/apps/registry/connected/run-list.tsx
@@ -96,8 +96,13 @@ export function RunList({ title, workflowSlug }: RunListProps) {
             {runs.slice(0, 25).map((run, i) => {
               const id = str(run, '_id');
               const status = str(run, 'status');
+              // Key by the stable execution `_id`, not the array index — the
+              // query is reactive and newest-first, so a new run unshifts every
+              // row's index and index keys would remount the whole list (losing
+              // focus/scroll and misattributing row state). Fall back to the
+              // index only for a row missing an id.
               return (
-                <TableRow key={i}>
+                <TableRow key={id || i}>
                   <TableCell>{id ? `${id.slice(0, 8)}…` : '—'}</TableCell>
                   <TableCell>
                     <Badge variant={STATUS_VARIANT[status] ?? 'slate'}>

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/metrics.search.test.ts
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/metrics.search.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchSchema } from './metrics';
+
+// The per-agent scorecard threads the shared metrics period (7/30/90) instead
+// of a hard-pinned 30-day window. It reuses the workforce dashboard's coercion,
+// so it carries the same #1987 regression guard: a shared/bookmarked
+// `/agents/<id>/metrics?period=90` URL is parsed by the router as the JSON
+// number 90, which must not crash the route via SearchParamError.
+describe('agent scorecard searchSchema', () => {
+  it('coerces numeric period values to the string enum', () => {
+    expect(searchSchema.parse({ period: 90 }).period).toBe('90');
+    expect(searchSchema.parse({ period: 30 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 7 }).period).toBe('7');
+  });
+
+  it('accepts string period values', () => {
+    expect(searchSchema.parse({ period: '90' }).period).toBe('90');
+  });
+
+  it('falls back to the default window for out-of-range values', () => {
+    expect(searchSchema.parse({ period: 999 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 'nonsense' }).period).toBe('30');
+  });
+
+  it('leaves an omitted period undefined', () => {
+    expect(searchSchema.parse({}).period).toBeUndefined();
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/metrics.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/metrics.tsx
@@ -6,7 +6,9 @@ import { Stack } from '@tale/ui/layout';
 import { StatCard, StatCardGrid } from '@tale/ui/stat-card-grid';
 import { Text } from '@tale/ui/text';
 import { TrendIndicator } from '@tale/ui/trend-indicator';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useCallback, useMemo } from 'react';
+import { z } from 'zod';
 
 import { ContentArea } from '@/app/components/layout/content-area';
 import {
@@ -15,6 +17,8 @@ import {
   type ChartSeries,
 } from '@/app/components/metrics/charts';
 import { MetricsLayout } from '@/app/components/metrics/metrics-layout';
+import { Select } from '@/app/components/ui/forms/select';
+import type { PeriodDays } from '@/app/features/agents/workforce/workforce-dashboard';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { api } from '@/convex/_generated/api';
@@ -22,10 +26,23 @@ import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { seo } from '@/lib/utils/seo';
 
+export const searchSchema = z.object({
+  // Same coercion as the workforce dashboard route (`agents/metrics.tsx`): the
+  // router parses a bare `?period=90` as the JSON number 90, so coerce to a
+  // string before the enum and fall back to the default 30-day window for any
+  // out-of-range value so a shared/bookmarked URL never renders the error page.
+  period: z.coerce
+    .string()
+    .pipe(z.enum(['7', '30', '90']))
+    .catch('30')
+    .optional(),
+});
+
 export const Route = createFileRoute('/dashboard/$id/agents/$agentId/metrics')({
   head: () => ({
     meta: seo('agents'),
   }),
+  validateSearch: searchSchema,
   component: AgentMetricsTab,
 });
 
@@ -140,11 +157,43 @@ function AgentMetricsTab() {
   const { t } = useT('workforce');
   const { t: tTasks } = useT('tasks');
   const { id: organizationId, agentId } = Route.useParams();
+  const { period } = Route.useSearch();
+  const navigate = useNavigate();
   const { formatRelative } = useFormatDate();
+
+  // Honor the shared metrics period (7/30/90) instead of a hard-pinned 30-day
+  // window — the scorecard now carries the same selector as the workforce
+  // dashboard, and the window drives both the query and the subtitle.
+  const periodDays: PeriodDays = period === '7' ? 7 : period === '90' ? 90 : 30;
+
+  const periodOptions = useMemo(
+    () => [
+      { value: '7', label: t('period.last7Days') },
+      { value: '30', label: t('period.last30Days') },
+      { value: '90', label: t('period.last90Days') },
+    ],
+    [t],
+  );
+
+  const handleChangePeriod = useCallback(
+    (next: PeriodDays) => {
+      const periodParam: '7' | '30' | '90' =
+        next === 7 ? '7' : next === 90 ? '90' : '30';
+      void navigate({
+        to: '/dashboard/$id/agents/$agentId/metrics',
+        params: { id: organizationId, agentId },
+        search: { period: periodParam },
+        replace: true,
+      });
+    },
+    [navigate, organizationId, agentId],
+  );
 
   const { data } = useConvexQuery(
     api.task_metrics.queries.getAgentScorecard,
-    organizationId ? { organizationId, agentSlug: agentId, days: 30 } : 'skip',
+    organizationId
+      ? { organizationId, agentSlug: agentId, days: periodDays }
+      : 'skip',
   );
   // The query returns v.any(); the payload shape is owned by getAgentScorecard.
   const scorecard: ScorecardPayload | undefined = data ?? undefined;
@@ -184,7 +233,21 @@ function AgentMetricsTab() {
     <ContentArea variant="narrow" gap={6}>
       <MetricsLayout
         title={t('scorecard.title')}
-        description={t('scorecard.subtitle')}
+        description={t('scorecard.subtitle', { days: periodDays })}
+        toolbar={
+          <div className="w-44">
+            <Select
+              aria-label={t('period.label')}
+              options={periodOptions}
+              value={String(periodDays)}
+              onValueChange={(v) => {
+                const next = Number(v);
+                if (next === 7 || next === 30 || next === 90)
+                  handleChangePeriod(next);
+              }}
+            />
+          </div>
+        }
       >
         <StatCardGrid cols={2}>
           <StatCard

--- a/services/platform/convex/agents/audit_mutations.ts
+++ b/services/platform/convex/agents/audit_mutations.ts
@@ -25,7 +25,6 @@ const ALLOWED_ACTIONS = [
   // Organigram delegation edits (the chart's single write paths).
   'set_agent_manager',
   'set_agent_delegates',
-  'set_agent_parents',
 ] as const;
 type AllowedAction = (typeof ALLOWED_ACTIONS)[number];
 

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -582,10 +582,9 @@ export const saveAgent = action({
       : memberAuth;
 
     // `delegates` (the organigram delegation edges) has exactly ONE write
-    // path: the organigram actions (`setAgentDelegates` / `setAgentParents`).
-    // The settings form must never carry it — a stale form would silently
-    // re-wire delegation — so the incoming value is dropped and the on-disk
-    // value re-applied here.
+    // path: the organigram `setAgentDelegates` action. The settings form must
+    // never carry it — a stale form would silently re-wire delegation — so the
+    // incoming value is dropped and the on-disk value re-applied here.
     config = {
       ...config,
       delegates: prevAgent.ok ? prevAgent.config.delegates : undefined,

--- a/services/platform/convex/agents/file_utils.ts
+++ b/services/platform/convex/agents/file_utils.ts
@@ -140,9 +140,9 @@ export interface AgentJsonConfig {
   /**
    * Organigram delegation edges: slugs of the agents THIS agent delegates to
    * (its direct reports). Many-to-many; the only forbidden edge is a
-   * self-edge. Written ONLY by the organigram write paths (`writeAgentDelegates`
-   * / `writeAgentParents`); `saveAgent` preserves the on-disk value so a stale
-   * settings form can never silently re-wire delegation. Mirrors
+   * self-edge. Written ONLY by the organigram write path (`writeAgentDelegates`);
+   * `saveAgent` preserves the on-disk value so a stale settings form can never
+   * silently re-wire delegation. Mirrors
    * `agentJsonSchema.delegates`.
    */
   delegates?: string[];

--- a/services/platform/convex/agents/internal_actions.ts
+++ b/services/platform/convex/agents/internal_actions.ts
@@ -53,9 +53,9 @@ interface AgentIndex {
 const agentListCache = new Map<string, AgentIndex>();
 
 /**
- * Write-through cache drop for org-chart writes (`writeAgentDelegates` /
- * `writeAgentParents`): a delegation edit must be visible to the next chart
- * read in THIS isolate without waiting out the TTL. Other isolates converge
+ * Write-through cache drop for org-chart writes (`writeAgentDelegates`): a
+ * delegation edit must be visible to the next chart read in THIS isolate
+ * without waiting out the TTL. Other isolates converge
  * within the 60s TTL, same as every other agent-file edit.
  */
 export function invalidateAgentListCache(orgSlug: string): void {

--- a/services/platform/convex/agents/org_chart_actions.ts
+++ b/services/platform/convex/agents/org_chart_actions.ts
@@ -9,10 +9,12 @@
  *    deterministic primary manager, and per-node guardrail snapshots (month
  *    spend vs budget, running count, paused badge). Dangling/self edges are
  *    dropped; cycles are allowed.
- *  - `setAgentDelegates` / `setAgentParents` (developer-capability-gated):
- *    edit one agent's outgoing / incoming edges — validated (no self-edge,
- *    real targets), written atomically to the JSON file(s), audited, and
- *    write-through cache-dropped so the next read sees it immediately.
+ *  - `setAgentDelegates` (developer-capability-gated): edit one agent's
+ *    outgoing delegation edges — validated (no self-edge, real targets),
+ *    written atomically to the JSON file, audited, and write-through
+ *    cache-dropped so the next read sees it immediately. Incoming ("reports
+ *    to") edits are staged client-side in the organigram draft as delegate
+ *    changes on the other agents and persisted through this same path.
  *
  * `saveAgent` (file_actions) deliberately strips incoming `delegates` and
  * re-applies the on-disk value, so the organigram remains the only editor of
@@ -29,7 +31,6 @@ import {
   buildChartFromRoster,
   readWorkforceRoster,
   writeAgentDelegates,
-  writeAgentParents,
 } from './workforce_ops';
 
 export interface OrgChartNode {
@@ -147,41 +148,6 @@ export const setAgentDelegates = action({
       resourceId: args.agentSlug,
       previousState: { delegates: previous },
       newState: { delegates: args.delegateSlugs },
-    });
-    return { ok: true };
-  },
-});
-
-/**
- * Set the agents that delegate to `agentSlug` (its incoming edges / "reports
- * to" list) by adjusting each parent's `delegates`. Validation + the file
- * writes live in `writeAgentParents`.
- */
-export const setAgentParents = action({
-  args: {
-    organizationId: v.string(),
-    agentSlug: v.string(),
-    parentSlugs: v.array(v.string()),
-  },
-  returns: v.object({ ok: v.boolean() }),
-  handler: async (ctx, args): Promise<{ ok: boolean }> => {
-    const auth = await requireOrgAdminOrDeveloper(ctx, args.organizationId);
-
-    const { previous } = await writeAgentParents({
-      orgSlug: auth.orgSlug,
-      agentSlug: args.agentSlug,
-      parentSlugs: args.parentSlugs,
-    });
-
-    await ctx.runMutation(internal.agents.audit_mutations.logAgentAuditEvent, {
-      organizationId: auth.orgId,
-      actorId: auth.userId,
-      ...(auth.email ? { actorEmail: auth.email } : {}),
-      actorRole: auth.member.role,
-      action: 'set_agent_parents',
-      resourceId: args.agentSlug,
-      previousState: { parents: previous },
-      newState: { parents: args.parentSlugs },
     });
     return { ok: true };
   },

--- a/services/platform/convex/agents/workforce_ops.ts
+++ b/services/platform/convex/agents/workforce_ops.ts
@@ -507,50 +507,6 @@ export async function writeAgentDelegates(args: {
   return { previous };
 }
 
-/**
- * Set the agents that delegate to `agentSlug` (its incoming edges / the
- * "reports to" list). Adjusts each candidate parent's `delegates` to match.
- * Throws the same codes as {@link writeAgentDelegates}. Returns the previous
- * parent list.
- */
-export async function writeAgentParents(args: {
-  orgSlug: string;
-  agentSlug: string;
-  parentSlugs: string[];
-}): Promise<{ previous: string[] }> {
-  const { orgSlug, agentSlug } = args;
-  if (RESERVED.has(agentSlug)) {
-    throw new ConvexError({ code: 'RESERVED_AGENT_SLUG' });
-  }
-  const roster = await readWorkforceRoster(orgSlug);
-  const slugs = new Set(roster.map((entry) => entry.slug));
-  if (!slugs.has(agentSlug)) {
-    throw new ConvexError({ code: 'AGENT_NOT_FOUND' });
-  }
-  const desired = new Set(sanitizeTargets(args.parentSlugs, agentSlug, slugs));
-  const previous = buildChartFromRoster(roster).parentsAll.get(agentSlug) ?? [];
-
-  for (const entry of roster) {
-    if (entry.slug === agentSlug) continue;
-    const has = entry.delegates.includes(agentSlug);
-    const should = desired.has(entry.slug);
-    if (has === should) continue;
-    const filePath = await resolveAgentPath(orgSlug, entry.slug);
-    const config = await readAgentConfig(filePath).catch(() => null);
-    if (!config) continue;
-    const updated = should
-      ? [...new Set([...(config.delegates ?? []), agentSlug])]
-      : (config.delegates ?? []).filter((slug) => slug !== agentSlug);
-    if (updated.length > 0) config.delegates = updated;
-    else delete config.delegates;
-    await snapshotAgentHistory(orgSlug, entry.slug);
-    await atomicWrite(filePath, serializeAgentJson(config));
-  }
-
-  invalidateAgentListCache(orgSlug);
-  return { previous };
-}
-
 // ---------------------------------------------------------------------------
 // Agent-tool surface (consumed by the `agent_read` / `agent_write`
 // agent tools)

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7866,7 +7866,7 @@
       "agent": "Agent",
       "completed": "Abgeschlossen",
       "runs": "Läufe (fehlgeschl.)",
-      "bounceRate": "Änderungswünsche",
+      "bounceRate": "Änderungsrate",
       "cost": "Ausgaben"
     },
     "attention": {
@@ -7878,7 +7878,7 @@
     },
     "scorecard": {
       "title": "Agent-Metriken",
-      "subtitle": "Letzte 30 Tage — Ergebnisse, Review-Qualität und Kosten dieses Agenten.",
+      "subtitle": "Letzte {days} Tage — Ergebnisse, Review-Qualität und Kosten dieses Agenten.",
       "tasksCompleted": "Abgeschlossene Aufgaben",
       "reviewOutcome": "Direkt-Freigabequote",
       "reviewDetail": "{passed} freigegeben · {changes} Änderungswünsche · {escalations} Eskalationen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7866,7 +7866,7 @@
       "agent": "Agent",
       "completed": "Completed",
       "runs": "Runs (failed)",
-      "bounceRate": "Changes requested",
+      "bounceRate": "Change rate",
       "cost": "Spend"
     },
     "attention": {
@@ -7878,7 +7878,7 @@
     },
     "scorecard": {
       "title": "Agent Metrics",
-      "subtitle": "Last 30 days — outcomes, review quality, and cost for this agent.",
+      "subtitle": "Last {days} days — outcomes, review quality, and cost for this agent.",
       "tasksCompleted": "Tasks completed",
       "reviewOutcome": "First-pass approval",
       "reviewDetail": "{passed} approved · {changes} changes requested · {escalations} escalations",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7867,7 +7867,7 @@
       "agent": "Agent",
       "completed": "Terminées",
       "runs": "Exécutions (échecs)",
-      "bounceRate": "Modifications demandées",
+      "bounceRate": "Taux de modifications",
       "cost": "Dépenses"
     },
     "attention": {
@@ -7879,7 +7879,7 @@
     },
     "scorecard": {
       "title": "Métriques de l'agent",
-      "subtitle": "Les 30 derniers jours — résultats, qualité des revues et coûts de cet agent.",
+      "subtitle": "Les {days} derniers jours — résultats, qualité des revues et coûts de cet agent.",
       "tasksCompleted": "Tâches terminées",
       "reviewOutcome": "Approbation du premier coup",
       "reviewDetail": "{passed} approuvées · {changes} modifications demandées · {escalations} escalades",


### PR DESCRIPTION
## Summary

Resolves the batch of low-severity agents-editor / delegation / metrics / apps
correctness & UX gaps itemized in #2087. Each is independently fixable; grouped
here as a single polish pass.

| # | Fix |
| --- | --- |
| **38** | Agent **history restore** no longer silently no-ops on a missing/corrupt/schema-divergent snapshot — `handleSelectEntry` now surfaces the existing `historyLoadFailed` toast when the read resolves but yields nothing loadable. |
| **39** | **Organigram** save reseeds the dirty baseline in a `finally`, so a partial (mid-loop) failure resyncs the agents already committed on disk — committed edges stop showing as unsaved and **Discard** no longer misrepresents them. |
| **40** | Deleted the **dead** `setAgentParents` action + `writeAgentParents` and dropped `set_agent_parents` from the audit allowlist (incoming "reports to" edits already persist through `setAgentDelegates`); refreshed the comments that named them. |
| **42** | Reworded the mislabeled leaderboard **`bounceRate`** header (a count label over a percentage cell) to a rate label in `en`/`de`/`fr`. |
| **43** | Threaded the shared metrics **period** (7/30/90) into the per-agent **scorecard** via a `validateSearch` enum + selector; unpinned the 30-day query and parameterized the subtitle. Added a search-schema guard test. |
| **46** | The apps **readiness checklist** resolves each blocked integration's display **title** (same lookup as the install wizard) instead of the raw slug. |
| **47** | Added `variant: 'success'` to the **uninstall** toast so it matches its sibling lifecycle actions (green check, not the neutral Info icon). |
| **48** | Keyed the apps **run-list** and the shared connected **DataTable** rows by `_id` (fallback to index) instead of the array index, on reactive newest-first lists. |

## Testing

- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` — 0 warnings / 0 errors
- `oxfmt --check` — clean
- `bunx knip` — clean
- Server + PII vitest projects — **74177 passed**
- `test:ui` (jsdom) vitest — **2765 passed** (incl. updated scorecard mock)
- `test:browser` organigram editor — passed
- Added `metrics.search.test.ts` locking the new scorecard `period` search schema (mirrors the workforce route's #1987 regression guard)

Closes #2087
