### PR TITLE
feat(platform): add search to automations and apps catalogs

### DIFF
--- a/services/platform/app/features/apps/components/apps-grid.tsx
+++ b/services/platform/app/features/apps/components/apps-grid.tsx
@@ -8,13 +8,14 @@ import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { Card, CardGrid } from '@tale/ui/card';
 import { EmptyState } from '@tale/ui/empty-state';
-import { HStack, Row, VStack } from '@tale/ui/layout';
+import { HStack, Row, Stack, VStack } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Text } from '@tale/ui/text';
 import { Link } from '@tanstack/react-router';
 import { LayoutGrid } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
+import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { useT } from '@/lib/i18n/client';
 
 import { notifyOnInstallFailure } from '../hooks/install-failure-toast';
@@ -47,6 +48,17 @@ export function AppsGrid({ organizationId }: { organizationId: string }) {
   // project) and apps with required integrations (need a connect step) route
   // through the wizard; org-scoped apps with no requirements install in one click.
   const [wizardApp, setWizardApp] = useState<AppSummary | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredApps = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return apps;
+    return apps.filter(
+      (app) =>
+        app.name.toLowerCase().includes(q) ||
+        (app.description ?? '').toLowerCase().includes(q),
+    );
+  }, [apps, searchQuery]);
 
   if (isLoading && apps.length === 0) return <SkeletonText lines={4} />;
   if (apps.length === 0) {
@@ -60,80 +72,99 @@ export function AppsGrid({ organizationId }: { organizationId: string }) {
   }
 
   return (
-    <CardGrid>
-      {apps.map((app) => {
-        const state = bySlug.get(app.slug);
-        // Every card opens the org-level app page. For a project-scoped app that
-        // page is its membership hub (the list of bound projects + Add); we never
-        // deep-link a single project from the hub, so the card behaves identically
-        // whether the app is in 0, 1, or N projects.
-        const cardLink = {
-          to: '/dashboard/$id/apps/$appSlug',
-          params: { id: organizationId, appSlug: app.slug },
-        } as const;
-        return (
-          <div key={app.slug} className="relative h-full">
-            <Link {...cardLink} aria-label={app.name} className="block h-full">
-              <Card interactive className="h-full">
-                <VStack gap={3}>
-                  <HStack gap={3} className="items-start justify-between">
-                    <HStack gap={3} className="min-w-0 items-start">
-                      <Row
-                        gap={0}
-                        justify="center"
-                        className="bg-muted text-muted-foreground size-9 shrink-0 rounded-md"
-                      >
-                        <LayoutGrid className="size-5" />
-                      </Row>
-                      <VStack gap={1} className="min-w-0">
-                        <Text as="span" className="font-semibold" truncate>
-                          {app.name}
-                        </Text>
-                        <Text variant="muted" className="line-clamp-2 text-sm">
-                          {app.description}
-                        </Text>
-                      </VStack>
-                    </HStack>
-                    {state && <InstallBadge state={state} />}
-                  </HStack>
-                  {/* Reserve the footer row for the overlaid action (Install for
-                      not-installed apps, the lifecycle ⋯ menu for installed). */}
-                  <div className="h-8" />
-                </VStack>
-              </Card>
-            </Link>
-            {/* Interactive controls live OUTSIDE the card Link so they don't
-                trigger navigation; the dropdown content portals out. */}
-            {state ? (
-              <div className="absolute right-3 bottom-3 z-10">
-                <AppLifecycleActions
-                  appSlug={app.slug}
-                  appName={app.name}
-                  organizationId={organizationId}
-                  context="org"
-                />
-              </div>
-            ) : (
-              <div className="absolute bottom-3 left-3 z-10">
-                <Button
-                  disabled={isPending}
-                  onClick={() =>
-                    app.scope === 'project' ||
-                    app.requiredIntegrations.length > 0
-                      ? setWizardApp(app)
-                      : notifyOnInstallFailure(
-                          install(app.slug),
-                          t('install.installFailed'),
-                        )
-                  }
+    <Stack gap={4}>
+      <SearchInput
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        placeholder={t('searchPlaceholder')}
+        className="w-64"
+      />
+      {filteredApps.length === 0 ? (
+        <EmptyState icon={LayoutGrid} title={t('searchNoResults')} />
+      ) : (
+        <CardGrid>
+          {filteredApps.map((app) => {
+            const state = bySlug.get(app.slug);
+            // Every card opens the org-level app page. For a project-scoped app that
+            // page is its membership hub (the list of bound projects + Add); we never
+            // deep-link a single project from the hub, so the card behaves identically
+            // whether the app is in 0, 1, or N projects.
+            const cardLink = {
+              to: '/dashboard/$id/apps/$appSlug',
+              params: { id: organizationId, appSlug: app.slug },
+            } as const;
+            return (
+              <div key={app.slug} className="relative h-full">
+                <Link
+                  {...cardLink}
+                  aria-label={app.name}
+                  className="block h-full"
                 >
-                  {t('install.install')}
-                </Button>
+                  <Card interactive className="h-full">
+                    <VStack gap={3}>
+                      <HStack gap={3} className="items-start justify-between">
+                        <HStack gap={3} className="min-w-0 items-start">
+                          <Row
+                            gap={0}
+                            justify="center"
+                            className="bg-muted text-muted-foreground size-9 shrink-0 rounded-md"
+                          >
+                            <LayoutGrid className="size-5" />
+                          </Row>
+                          <VStack gap={1} className="min-w-0">
+                            <Text as="span" className="font-semibold" truncate>
+                              {app.name}
+                            </Text>
+                            <Text
+                              variant="muted"
+                              className="line-clamp-2 text-sm"
+                            >
+                              {app.description}
+                            </Text>
+                          </VStack>
+                        </HStack>
+                        {state && <InstallBadge state={state} />}
+                      </HStack>
+                      {/* Reserve the footer row for the overlaid action (Install for
+                      not-installed apps, the lifecycle ⋯ menu for installed). */}
+                      <div className="h-8" />
+                    </VStack>
+                  </Card>
+                </Link>
+                {/* Interactive controls live OUTSIDE the card Link so they don't
+                trigger navigation; the dropdown content portals out. */}
+                {state ? (
+                  <div className="absolute right-3 bottom-3 z-10">
+                    <AppLifecycleActions
+                      appSlug={app.slug}
+                      appName={app.name}
+                      organizationId={organizationId}
+                      context="org"
+                    />
+                  </div>
+                ) : (
+                  <div className="absolute bottom-3 left-3 z-10">
+                    <Button
+                      disabled={isPending}
+                      onClick={() =>
+                        app.scope === 'project' ||
+                        app.requiredIntegrations.length > 0
+                          ? setWizardApp(app)
+                          : notifyOnInstallFailure(
+                              install(app.slug),
+                              t('install.installFailed'),
+                            )
+                      }
+                    >
+                      {t('install.install')}
+                    </Button>
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-        );
-      })}
+            );
+          })}
+        </CardGrid>
+      )}
       {wizardApp && (
         <AppInstallWizard
           open
@@ -147,6 +178,6 @@ export function AppsGrid({ organizationId }: { organizationId: string }) {
           requiredIntegrations={wizardApp.requiredIntegrations}
         />
       )}
-    </CardGrid>
+    </Stack>
   );
 }

--- a/services/platform/app/features/automations/components/automations-catalog.tsx
+++ b/services/platform/app/features/automations/components/automations-catalog.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { Stack } from '@tale/ui/layout';
-import { SectionHeader } from '@tale/ui/section-header';
 import { useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
+import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
@@ -25,15 +26,19 @@ export function AutomationsCatalog({
 }: AutomationsCatalogProps) {
   const { t } = useT('automations');
   const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
 
   return (
     <Stack gap={6} className="p-6">
-      <SectionHeader
-        title={t('catalog.title')}
-        description={t('catalog.subtitle')}
+      <SearchInput
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        placeholder={t('search.placeholder')}
+        className="w-64 shrink-0"
       />
       <WorkflowTemplateGrid
         organizationId={organizationId}
+        searchQuery={searchQuery}
         scrollable={false}
         onTemplateInstalled={() => {
           toast({ title: t('catalog.installed'), variant: 'success' });

--- a/services/platform/app/features/automations/components/workflow-template-grid.test.tsx
+++ b/services/platform/app/features/automations/components/workflow-template-grid.test.tsx
@@ -148,6 +148,33 @@ describe('WorkflowTemplateGrid', () => {
     expect(defaultProps.onTemplateInstalled).not.toHaveBeenCalled();
   });
 
+  describe('search filtering', () => {
+    it('filters templates by name', () => {
+      render(<WorkflowTemplateGrid {...defaultProps} searchQuery="welcome" />);
+
+      expect(screen.getByLabelText('Welcome Flow')).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Order Processing'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('filters templates by description', () => {
+      render(<WorkflowTemplateGrid {...defaultProps} searchQuery="process" />);
+
+      expect(screen.getByLabelText('Order Processing')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Welcome Flow')).not.toBeInTheDocument();
+    });
+
+    it('shows the search-specific empty state when nothing matches', () => {
+      render(<WorkflowTemplateGrid {...defaultProps} searchQuery="zzzznope" />);
+
+      expect(
+        screen.getByText('No automations match your search.'),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText('Welcome Flow')).not.toBeInTheDocument();
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<WorkflowTemplateGrid {...defaultProps} />);

--- a/services/platform/app/features/automations/components/workflow-template-grid.tsx
+++ b/services/platform/app/features/automations/components/workflow-template-grid.tsx
@@ -24,6 +24,8 @@ import { parseWorkflowTemplates } from '../utils/workflow-templates';
 interface WorkflowTemplateGridProps {
   organizationId: string;
   integrationName?: string;
+  /** Free-text filter over template name + description (catalog page only). */
+  searchQuery?: string;
   onTemplateInstalled: (slug: string) => void;
   /**
    * Constrain the grid to its own scroll area (the create dialog). The full
@@ -58,6 +60,7 @@ function TemplateBrandChips({ integrations }: { integrations: string[] }) {
 export function WorkflowTemplateGrid({
   organizationId,
   integrationName,
+  searchQuery,
   onTemplateInstalled,
   scrollable = true,
 }: WorkflowTemplateGridProps) {
@@ -75,10 +78,16 @@ export function WorkflowTemplateGrid({
   const [installingSlug, setInstallingSlug] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const filteredTemplates = useMemo(
-    () => parseWorkflowTemplates(workflows, integrationName),
-    [workflows, integrationName],
-  );
+  const filteredTemplates = useMemo(() => {
+    const templates = parseWorkflowTemplates(workflows, integrationName);
+    const q = searchQuery?.trim().toLowerCase();
+    if (!q) return templates;
+    return templates.filter(
+      (template) =>
+        template.name.toLowerCase().includes(q) ||
+        (template.description ?? '').toLowerCase().includes(q),
+    );
+  }, [workflows, integrationName, searchQuery]);
 
   const handleSelectTemplate = useCallback(
     async (slug: string) => {
@@ -122,7 +131,13 @@ export function WorkflowTemplateGrid({
   }
 
   if (filteredTemplates.length === 0) {
-    return <Text variant="muted">{t('templates.noTemplates')}</Text>;
+    return (
+      <Text variant="muted">
+        {searchQuery?.trim()
+          ? t('search.noResults')
+          : t('templates.noTemplates')}
+      </Text>
+    );
   }
 
   return (

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1,6 +1,8 @@
 {
   "apps": {
     "title": "Apps",
+    "searchPlaceholder": "Apps durchsuchen…",
+    "searchNoResults": "Keine Apps entsprechen Ihrer Suche.",
     "upload": {
       "uploadApp": "App hochladen",
       "dialogTitle": "Private App hochladen",
@@ -670,8 +672,6 @@
       "metrics": "Metriken"
     },
     "catalog": {
-      "title": "Automatisierungs-Katalog",
-      "subtitle": "Durchsuche vorgefertigte Automatisierungen und installiere sie.",
       "installed": "Automatisierung installiert"
     },
     "aria": {
@@ -727,7 +727,8 @@
       "createStepsHint": "Erstelle Schritte, um die Automatisierungsübersicht zu sehen, oder nutze den KI-Assistenten für den Einstieg."
     },
     "search": {
-      "placeholder": "Automatisierungen suchen"
+      "placeholder": "Automatisierungen suchen",
+      "noResults": "Keine Automatisierungen entsprechen Ihrer Suche."
     },
     "entityLabel": "Automatisierungen",
     "createWithAI": "Automatisierung mit KI erstellen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1,6 +1,8 @@
 {
   "apps": {
     "title": "Apps",
+    "searchPlaceholder": "Search apps…",
+    "searchNoResults": "No apps match your search.",
     "upload": {
       "uploadApp": "Upload app",
       "dialogTitle": "Upload private app",
@@ -670,8 +672,6 @@
       "metrics": "Metrics"
     },
     "catalog": {
-      "title": "Automation catalog",
-      "subtitle": "Browse and install ready-made automations for your workspace.",
       "installed": "Automation installed"
     },
     "aria": {
@@ -727,7 +727,8 @@
       "createStepsHint": "Create steps to see the automation overview, or use the AI assistant to help you get started."
     },
     "search": {
-      "placeholder": "Search automations"
+      "placeholder": "Search automations",
+      "noResults": "No automations match your search."
     },
     "entityLabel": "automations",
     "createWithAI": "Create automation with AI",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1,6 +1,8 @@
 {
   "apps": {
     "title": "Applications",
+    "searchPlaceholder": "Rechercher des applications…",
+    "searchNoResults": "Aucune application ne correspond à votre recherche.",
     "upload": {
       "uploadApp": "Téléverser une application",
       "dialogTitle": "Téléverser une application privée",
@@ -671,8 +673,6 @@
       "metrics": "Métriques"
     },
     "catalog": {
-      "title": "Catalogue d'automatisations",
-      "subtitle": "Parcours des automatisations prêtes à l'emploi et installe-les.",
       "installed": "Automatisation installée"
     },
     "aria": {
@@ -728,7 +728,8 @@
       "createStepsHint": "Crée des étapes pour voir l'aperçu de l'automatisation, ou utilise l'assistant IA pour t'aider à démarrer."
     },
     "search": {
-      "placeholder": "Rechercher des automatisations"
+      "placeholder": "Rechercher des automatisations",
+      "noResults": "Aucune automatisation ne correspond à votre recherche."
     },
     "entityLabel": "automatisations",
     "createWithAI": "Créer une automatisation avec l'IA",


### PR DESCRIPTION
## What

Both browse-and-install catalogs get a **search input** so you can find a specific template/app instead of scanning the whole grid (raised because the sync automation was hard to locate).

- **Apps catalog** (`apps-grid.tsx`) — filters app cards by name/description, with a search-specific empty state.
- **Automations catalog** (`automations-catalog.tsx` + `workflow-template-grid.tsx`) — filters templates by name/description through a new **optional `searchQuery` prop** on `WorkflowTemplateGrid`. The create-dialog picker reuses the same grid and just omits the prop, so its behaviour is unchanged. Shows a search-specific empty state.

The automations catalog **drops its now-redundant title/subtitle header** (and the unused `catalog.title`/`catalog.subtitle` strings) so the search field leads the page.

## Notes

- The read-only-role **install gating** (`canInstall`, #2076) in `WorkflowTemplateGrid` is preserved untouched — search is layered on top.
- Filtering is client-side over the already-loaded list (no new queries).

## Testing

- `tsc --noEmit`: 0 errors
- `WorkflowTemplateGrid` tests extended with search cases (filter by name, filter by description, search-specific empty state) — 10/10 green
- i18n parity (en/de/fr) green; `oxfmt`, `oxlint --type-aware`, opengrep SAST clean