### PR TITLE
feat(ui): make CardGrid responsive to its container, not the viewport

### DIFF
--- a/packages/ui/src/components/layout/card.test.tsx
+++ b/packages/ui/src/components/layout/card.test.tsx
@@ -102,14 +102,20 @@ describe('Card', () => {
   });
 
   describe('CardGrid', () => {
-    it('renders a responsive grid of children', () => {
+    it('renders a container-query-responsive grid of children', () => {
       const { container } = render(
         <CardGrid>
           <Card>a</Card>
           <Card>b</Card>
         </CardGrid>,
       );
-      expect(container.firstChild).toHaveClass('grid');
+      // Outer element establishes the query container; the inner element is the
+      // grid whose columns scale with that container's width.
+      expect(container.firstChild).toHaveClass('@container');
+      expect(container.querySelector('.grid')).toHaveClass(
+        '@xl:grid-cols-2',
+        '@7xl:grid-cols-4',
+      );
     });
   });
 

--- a/packages/ui/src/components/layout/card.tsx
+++ b/packages/ui/src/components/layout/card.tsx
@@ -169,21 +169,35 @@ CardMedia.displayName = 'CardMedia';
 
 export interface CardGridProps extends Omit<
   ComponentProps<typeof Grid>,
-  'cols' | 'sm' | 'lg'
+  'cols' | 'sm' | 'md' | 'lg' | 'xl'
 > {
   cols?: ComponentProps<typeof Grid>['cols'];
-  sm?: ComponentProps<typeof Grid>['sm'];
-  lg?: ComponentProps<typeof Grid>['lg'];
 }
 
 /**
- * Responsive card grid: 1 → 2 (sm) → 3 (lg) columns, gap-4 — the browse-and-act
- * default. A thin wrapper over `Grid`; override `cols`/`sm`/`md`/`lg`/`gap` for
- * other shapes.
+ * Responsive card grid for the browse-and-act surfaces (catalogs, apps). Columns
+ * scale with the grid's OWN width via container queries, not the viewport, so a
+ * card stays ~290px+ whether the grid sits full-bleed or in a sidebar-narrowed
+ * panel, and caps at 4 columns so cards keep breathing room (titles never
+ * truncate): 1 → 2 (≥36rem) → 3 (≥56rem) → 4 (≥80rem), gap-4. The enclosing
+ * `@container` makes the inner grid query that width. Column counts are
+ * utilities (not `Grid` props) because container breakpoints have no
+ * viewport-prop equivalent.
  */
 export const CardGrid = forwardRef<HTMLDivElement, CardGridProps>(
-  ({ cols = 1, sm = 2, lg = 3, gap = 4, ...props }, ref) => (
-    <Grid ref={ref} cols={cols} sm={sm} lg={lg} gap={gap} {...props} />
+  ({ cols = 1, gap = 4, className, ...props }, ref) => (
+    <div className="@container">
+      <Grid
+        ref={ref}
+        cols={cols}
+        gap={gap}
+        className={cn(
+          '@xl:grid-cols-2 @4xl:grid-cols-3 @7xl:grid-cols-4',
+          className,
+        )}
+        {...props}
+      />
+    </div>
   ),
 );
 CardGrid.displayName = 'CardGrid';


### PR DESCRIPTION
## What

`CardGrid` scaled its columns with the **viewport**, so a card grid collapsed to one column inside a sidebar-narrowed panel even on a wide page — and had no upper bound, stretching cards too wide on large screens.

This wraps the grid in an `@container` and drives column counts with **container queries**, so columns track the grid's *own* width:

- `1 → 2 (≥36rem) → 3 (≥56rem) → 4 (≥80rem)`, **capped at 4** so titles never truncate and cards keep breathing room.
- Looks right whether the grid is full-bleed or in a narrow panel.

## Blast radius

Column counts move from `Grid`'s viewport props to utility classes (container breakpoints have no viewport-prop equivalent), so the unused `sm`/`md`/`lg`/`xl` props are **dropped** from `CardGridProps`. Verified **no consumer passes them** (~15 `CardGrid` call sites across audit-logs, metrics, apps, analytics, catalog-grid, stat-card-grid…).

## Testing

- `@tale/ui` typecheck + full `@tale/platform` typecheck (all CardGrid consumers): 0 errors
- `card.test.tsx` updated to assert the `@container` wrapper + container-query column classes — 15/15 green
- `oxfmt`, `oxlint --type-aware`, opengrep SAST clean