### PR TITLE
test(platform): confirm dialog gates self-service passkey removal (#2081)

### DIFF
--- a/services/platform/app/features/settings/account/components/passkey-section.test.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen, waitFor, within } from '@/tests/utils/render';
+
+// Regression cover for #2081: the self-service passkey "Remove" action must not
+// revoke a phishing-resistant credential on a single click — it has to go
+// through a destructive confirmation first (the fix landed in #2112). These
+// tests pin that seam so the confirm step can't silently regress back to a
+// one-click delete.
+
+// A single seeded passkey the list query returns. Hoisted so the
+// `@tanstack/react-query` mock factory (evaluated before the imports below) can
+// read it.
+const { PASSKEY } = vi.hoisted(() => ({
+  PASSKEY: { id: 'pk-1', name: 'YubiKey 5C', createdAt: 1_700_000_000_000 },
+}));
+
+// A local, credentialed session is the precondition for the passkeys UI to
+// render at all (SSO-only users don't manage local credentials here).
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => ({
+    data: { authenticated: true, hasCredential: true },
+  }),
+}));
+
+// WebAuthn client. `deletePasskey` is the irreversible call under guard: it must
+// fire only after the confirmation is accepted, never on the row action click.
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    passkey: {
+      deletePasskey: vi.fn().mockResolvedValue({}),
+      listUserPasskeys: vi.fn(),
+      addPasskey: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// The register dialog drives its own browser ceremony + unrelated deps; it is
+// irrelevant to the revoke-confirm seam under test.
+vi.mock('./passkey-register-dialog', () => ({
+  PasskeyRegisterDialog: () => null,
+}));
+
+// Exercise the section through the list result only: return the seeded passkey
+// synchronously (there is no QueryClientProvider in a component test) and stub
+// the client the post-revoke `invalidate()` reads. AppShell — the shared render
+// wrapper — carries no react-query itself, so overriding these two hooks only
+// affects the section under test.
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQuery: () => ({ data: [PASSKEY], isLoading: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+import { authClient } from '@/lib/auth-client';
+
+import { PasskeySection } from './passkey-section';
+
+// The trash icon action and the confirm dialog's confirm button share the
+// "Remove" accessible name (both bound to `passkeys.revokeButton`), so the
+// confirm click is always scoped inside the dialog.
+const REMOVE = 'Remove';
+const CONFIRM_TITLE = /remove passkey\?/i;
+
+describe('PasskeySection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('revoke confirmation', () => {
+    it('opens a confirm dialog instead of revoking on the row action click', async () => {
+      const { user } = render(<PasskeySection />);
+
+      // The row exposes a single icon-only "Remove" action.
+      await user.click(screen.getByRole('button', { name: REMOVE }));
+
+      // A single click must NOT delete the credential; it opens a destructive
+      // confirmation dialog and waits.
+      expect(authClient.passkey.deletePasskey).not.toHaveBeenCalled();
+      expect(
+        await screen.findByRole('dialog', { name: CONFIRM_TITLE }),
+      ).toBeInTheDocument();
+    });
+
+    it('revokes only after the destructive confirmation is accepted', async () => {
+      const { user } = render(<PasskeySection />);
+
+      await user.click(screen.getByRole('button', { name: REMOVE }));
+      const dialog = await screen.findByRole('dialog', { name: CONFIRM_TITLE });
+
+      // Confirming inside the dialog is what actually revokes the passkey.
+      await user.click(within(dialog).getByRole('button', { name: REMOVE }));
+
+      await waitFor(() =>
+        expect(authClient.passkey.deletePasskey).toHaveBeenCalledWith({
+          id: PASSKEY.id,
+        }),
+      );
+    });
+
+    it('does not revoke when the confirmation is dismissed', async () => {
+      const { user } = render(<PasskeySection />);
+
+      await user.click(screen.getByRole('button', { name: REMOVE }));
+      const dialog = await screen.findByRole('dialog', { name: CONFIRM_TITLE });
+
+      await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      expect(authClient.passkey.deletePasskey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('passes an axe audit with the confirm dialog open', async () => {
+      const { user, baseElement } = render(<PasskeySection />);
+
+      await user.click(screen.getByRole('button', { name: REMOVE }));
+      await screen.findByRole('dialog', { name: CONFIRM_TITLE });
+
+      await checkAccessibility(baseElement);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #2081 asked for a destructive-confirm step before the self-service passkey **Remove** action permanently revokes a phishing-resistant credential.

The **functional fix already landed on `main` in #2112** (merged 2026-06-29): `passkey-section.tsx` now routes the trash `IconButton` through a destructive `DeleteDialog`, so a single click no longer deletes the credential, and the confirmation copy (`passkeys.revokeConfirmTitle` / `revokeConfirmDescription`) exists across `en`/`de`/`fr`.

What was still missing — and explicitly flagged by a maintainer when closing this issue (*"a small follow-up test asserting the confirm dialog gates the delete would be worthwhile hardening"*) — was a co-located regression test. This PR adds exactly that. No production code changes; it locks the existing guard against regression.

## Changes

- **New** `services/platform/app/features/settings/account/components/passkey-section.test.tsx` — a jsdom / Testing-Library suite that pins the confirm-gates-delete seam:
  - the row **Remove** action opens a confirmation dialog and does **not** call `authClient.passkey.deletePasskey`;
  - `deletePasskey` fires **only** after the destructive confirmation is accepted (asserted with the passkey id);
  - dismissing the confirmation does not revoke;
  - an axe audit passes with the confirm dialog open.

## Verification

- `vitest --config vitest.ui.config.ts …/passkey-section.test.tsx` — **4 passed** (CI runs this via `turbo run test:ui`).
- Platform `oxfmt --check`, `oxlint --type-aware`, `tsc --noEmit`: clean.

Closes #2081
