### PR TITLE
fix(platform): offset toasts below the top header band (#1986)

### DIFF
--- a/services/platform/app/components/ui/feedback/toaster.test.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.test.tsx
@@ -36,4 +36,16 @@ describe('Toaster', () => {
     const viewport = document.body.querySelector('ol');
     expect(viewport?.textContent).toContain('Update available');
   });
+
+  // Regression (#1986): the viewport must clear the top header band, not sit
+  // flush against the top edge. A right-anchored Sheet's header lands in the
+  // top-right corner — the same spot as the toast — so a flush toast covered
+  // the panel title. The `4rem` top padding drops the first toast below that
+  // header band.
+  it('offsets the viewport below the top header band', () => {
+    render(<Toaster />);
+
+    const viewport = document.body.querySelector('ol');
+    expect(viewport?.className).toContain('pt-[calc(4rem+var(--safe-top))]');
+  });
 });

--- a/services/platform/app/components/ui/feedback/toaster.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.tsx
@@ -122,7 +122,18 @@ export function Toaster() {
                 // (e.g. the top-right "Create agent" button / the Save bar). Each
                 // toast Root re-enables `pointer-events-auto`, so toasts stay
                 // interactive (close / swipe) while the gaps click through.
-                'pointer-events-none fixed z-100 flex max-h-screen w-auto max-w-sm min-w-[18.75rem] flex-col p-3 pt-[calc(0.75rem+var(--safe-top))] pr-[calc(0.75rem+var(--safe-right))] pl-[calc(0.75rem+var(--safe-left))]',
+                //
+                // `pt-[calc(4rem+…)]` drops the first toast below the top header
+                // band instead of flush against the top edge. The desktop app
+                // header (`h-13`) sits top-left, but a right-anchored Sheet's
+                // header lands top-right — the same corner as the viewport — so a
+                // toast at the very top covered the panel title (issue #1986).
+                // 4rem = the `h-13` header (3.25rem) + the prior 0.75rem gap, and
+                // it also clears a Sheet's taller ~3.5rem header. The offset is
+                // padding INSIDE the `top-0`/`max-h-screen` box, so the stack
+                // still fits the viewport and the cleared strip stays
+                // `pointer-events-none` (controls under it remain clickable).
+                'pointer-events-none fixed z-100 flex max-h-screen w-auto max-w-sm min-w-[18.75rem] flex-col p-3 pt-[calc(4rem+var(--safe-top))] pr-[calc(0.75rem+var(--safe-right))] pl-[calc(0.75rem+var(--safe-left))]',
                 viewportPositionClasses[position],
               )}
             />,


### PR DESCRIPTION
## Summary

The global toast viewport rendered flush at the top-right corner (`pt-[calc(0.75rem+…)]`, `top-0 right-0`). A right-anchored `Sheet` — e.g. the Integrations detail panel opened via `?slug=tavily` — places its header in that *same* corner, so the transient **"Tale is ready to work offline"** toast painted over the panel title ("Integration de…" truncated beneath it).

This is not integrations-specific: any right-anchored Sheet's title lives in the top-right, where the toast lands. (On normal pages the page title sits top-**left**, so it never collided — which is why only Sheets showed the bug.)

## Change

- **`toaster.tsx`** — bump the viewport's top padding to `pt-[calc(4rem+var(--safe-top))]` so the first toast drops below the top header band. `4rem` = the desktop app header (`h-13` = 3.25rem) + the prior 0.75rem gap, and it also clears a Sheet's taller ~3.5rem header.
  - The offset is padding **inside** the existing `top-0`/`max-h-screen` box, so the stack still fits the viewport and the cleared strip stays `pointer-events-none` (controls beneath remain clickable). The intentional `z-100`-over-modal behaviour (keeping the "update available" toast's action clickable over an open Sheet) is unchanged.
- **`toaster.test.tsx`** — regression test asserting the viewport keeps the offset.

## Verification

- `toaster.test.tsx`: 3/3 pass (incl. new regression test)
- Full platform UI suite (`test:ui`, jsdom): **382 files / 2769 tests pass**
- `oxlint --type-aware` on changed files: 0 warnings, 0 errors
- `tsc --noEmit` (platform): clean
- `oxfmt --check` on changed files: clean
- `commitlint`: 0 problems

No user-visible strings changed, so no i18n/docs updates are required.

Closes #1986