### PR TITLE
fix(platform): make the E2E suite run on an isolated stack, fix rbac spec

### DIFF
--- a/packages/e2e/src/config.ts
+++ b/packages/e2e/src/config.ts
@@ -32,9 +32,34 @@ const DEFAULT_PROJECTS: PlaywrightTestConfig['projects'] = [
   { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
 ];
 
+/**
+ * Exempt loopback from any ambient HTTP(S) proxy for this runner and every
+ * child it spawns (webServers, browsers). Playwright's webServer availability
+ * probe follows the proxy env vars, and a local proxy that answers an HTTP
+ * error for unreachable loopback ports makes the probe read a dead port as
+ * "already available" — the runner then skips booting the stack and every
+ * test dies on ECONNREFUSED. Appends rather than overwrites, and leaves the
+ * proxy itself intact for genuine egress (package/binary downloads).
+ */
+function exemptLoopbackFromProxy(env: NodeJS.ProcessEnv): void {
+  for (const key of ['NO_PROXY', 'no_proxy'] as const) {
+    const entries = new Set(
+      (env[key] ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    );
+    entries.add('localhost');
+    entries.add('127.0.0.1');
+    entries.add('::1');
+    env[key] = [...entries].join(',');
+  }
+}
+
 export function createPlaywrightConfig(
   options: CreatePlaywrightConfigOptions,
 ): PlaywrightTestConfig {
+  exemptLoopbackFromProxy(process.env);
   const {
     testDir,
     port,

--- a/services/platform/playwright.config.ts
+++ b/services/platform/playwright.config.ts
@@ -104,6 +104,12 @@ export default createPlaywrightConfig({
         // the E2E CI job, so the bring-up can only fail and waste the cold-boot
         // budget — skip it. Applies in both mock and live-stack modes.
         TALE_DEV_SKIP_DOCKER: '1',
+        // Same E2E marker CI exports at the workflow level: crons.ts drops the
+        // sub-hourly sweeps that starve a loaded local backend past its ~1s
+        // function timeout, and dev-engine renices the backend. Only applies
+        // when Playwright boots the stack itself — a reused stack keeps its
+        // own env, so a dev stack's crons are never affected.
+        TALE_E2E: '1',
         // Never pop a browser when the orchestrator is the e2e webServer — a
         // local (non-CI) `bun test:e2e` that spawns the stack would otherwise
         // steal focus on every run. The READY banner still prints the URL.

--- a/services/platform/scripts/dev-engine.ts
+++ b/services/platform/scripts/dev-engine.ts
@@ -48,6 +48,7 @@ import {
 } from './convex-supervisor';
 import { DEV_GATES } from './dev-gates';
 import {
+  adoptCliEndpoints,
   DEFAULT_CONVEX_HOST,
   DEFAULT_CONVEX_PORT,
   isTruthy,
@@ -924,7 +925,19 @@ export async function runDevFleet() {
       }
     }
 
+    // Re-read the CLI-written .env.local and back-fill CONVEX_DEPLOYMENT /
+    // CONVEX_URL / CONVEX_SITE_PROXY_URL (see adoptCliEndpoints in dev-modes:
+    // a fresh checkout beside another stack gets NON-default ports, and the
+    // probes + Vite proxy would otherwise silently target the neighbour).
+    function adoptCliEndpointsFromEnvLocal() {
+      adoptCliEndpoints(
+        process.env,
+        parseDotEnv(join(platformRoot, '.env.local')),
+      );
+    }
+
     async function waitForConvex() {
+      if (!useExternalConvex) adoptCliEndpointsFromEnvLocal();
       const target = probeTarget();
       try {
         await runCommand('bunx', [
@@ -1081,14 +1094,11 @@ export async function runDevFleet() {
       );
     }
 
-    // Re-read CONVEX_DEPLOYMENT from .env.local in case `convex dev` wrote it
-    // after our initial loadEnvFiles() call (happens on first run with fresh DB)
-    const platformEnvLocalPath = join(platformRoot, '.env.local');
-    const freshEnv = parseDotEnv(platformEnvLocalPath);
-    if (freshEnv.CONVEX_DEPLOYMENT && !process.env.CONVEX_DEPLOYMENT) {
-      // Picked up the freshly-written local deployment (routine, no log).
-      process.env.CONVEX_DEPLOYMENT = freshEnv.CONVEX_DEPLOYMENT;
-    }
+    // Re-read .env.local in case `convex dev` wrote it after our initial
+    // loadEnvFiles() call (happens on first run with a fresh DB) — picks up
+    // CONVEX_DEPLOYMENT and the CLI-allocated backend endpoints. Idempotent
+    // with the adoption inside waitForConvex (external mode skips that one).
+    adoptCliEndpointsFromEnvLocal();
 
     // Load the local deployment's admin key now that `convex dev` has written
     // it — enables the WebDAV /dav/* route in dev. External backends supply

--- a/services/platform/scripts/dev-modes.test.ts
+++ b/services/platform/scripts/dev-modes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  adoptCliEndpoints,
   DEFAULT_CONVEX_HOST,
   DEFAULT_CONVEX_PORT,
   isTruthy,
@@ -47,6 +48,48 @@ describe('shouldOpenBrowser', () => {
 
   it('opens when explicitly enabled', () => {
     expect(shouldOpenBrowser(env({ TALE_DEV_OPEN: '1' }))).toBe(true);
+  });
+});
+
+describe('adoptCliEndpoints', () => {
+  // The regression this guards: a fresh checkout's .env.local (written by the
+  // Convex CLI) carries only VITE_* endpoint vars on CLI-picked ports; without
+  // adoption, probes and the Vite proxy fall back to :3210/:3211 and silently
+  // target whichever NEIGHBOURING stack owns the default ports.
+  it('back-fills deployment + endpoints from a CLI-written .env.local', () => {
+    const processEnv = env({});
+    adoptCliEndpoints(processEnv, {
+      CONVEX_DEPLOYMENT: 'anonymous:anonymous-agent',
+      VITE_CONVEX_URL: 'http://127.0.0.1:3212',
+      VITE_CONVEX_SITE_URL: 'http://127.0.0.1:3213',
+    });
+    expect(processEnv.CONVEX_DEPLOYMENT).toBe('anonymous:anonymous-agent');
+    expect(processEnv.CONVEX_URL).toBe('http://127.0.0.1:3212');
+    expect(processEnv.CONVEX_SITE_PROXY_URL).toBe('http://127.0.0.1:3213');
+  });
+
+  it('never overrides explicit values already in the environment', () => {
+    const processEnv = env({
+      CONVEX_DEPLOYMENT: 'anonymous:anonymous-platform',
+      CONVEX_URL: 'http://127.0.0.1:3210',
+      CONVEX_SITE_PROXY_URL: 'http://127.0.0.1:3211',
+    });
+    adoptCliEndpoints(processEnv, {
+      CONVEX_DEPLOYMENT: 'anonymous:anonymous-agent',
+      VITE_CONVEX_URL: 'http://127.0.0.1:3212',
+      VITE_CONVEX_SITE_URL: 'http://127.0.0.1:3213',
+    });
+    expect(processEnv.CONVEX_DEPLOYMENT).toBe('anonymous:anonymous-platform');
+    expect(processEnv.CONVEX_URL).toBe('http://127.0.0.1:3210');
+    expect(processEnv.CONVEX_SITE_PROXY_URL).toBe('http://127.0.0.1:3211');
+  });
+
+  it('leaves the environment untouched when .env.local has no endpoints', () => {
+    const processEnv = env({});
+    adoptCliEndpoints(processEnv, {});
+    expect(processEnv.CONVEX_DEPLOYMENT).toBeUndefined();
+    expect(processEnv.CONVEX_URL).toBeUndefined();
+    expect(processEnv.CONVEX_SITE_PROXY_URL).toBeUndefined();
   });
 });
 

--- a/services/platform/scripts/dev-modes.ts
+++ b/services/platform/scripts/dev-modes.ts
@@ -32,6 +32,34 @@ export function shouldOpenBrowser(
   return isTruthy(flag);
 }
 
+/**
+ * Adopt the backend endpoints the Convex CLI allocated for THIS project from a
+ * freshly-parsed .env.local. On a fresh checkout the CLI writes only
+ * VITE_CONVEX_URL / VITE_CONVEX_SITE_URL (and CONVEX_DEPLOYMENT) — and when the
+ * default ports are taken (a second stack on one machine, e.g. an isolated E2E
+ * worktree beside `bun dev`) it picks OTHER ports. Everything that keys on
+ * CONVEX_URL / CONVEX_SITE_PROXY_URL (the readiness probe, the health check,
+ * the auth-route wait, the Vite proxy) falls back to :3210/:3211, so without
+ * this back-fill an isolated stack false-positives its probes against a
+ * NEIGHBOURING backend and silently proxies every /api and /ws_api request
+ * into it — test writes landing in the dev database. Explicit values win:
+ * only unset keys are filled. Pure given both env records.
+ */
+export function adoptCliEndpoints(
+  env: NodeJS.ProcessEnv,
+  freshEnv: Record<string, string>,
+): void {
+  if (freshEnv.CONVEX_DEPLOYMENT && !env.CONVEX_DEPLOYMENT) {
+    env.CONVEX_DEPLOYMENT = freshEnv.CONVEX_DEPLOYMENT;
+  }
+  if (!env.CONVEX_URL && freshEnv.VITE_CONVEX_URL) {
+    env.CONVEX_URL = freshEnv.VITE_CONVEX_URL;
+  }
+  if (!env.CONVEX_SITE_PROXY_URL && freshEnv.VITE_CONVEX_SITE_URL) {
+    env.CONVEX_SITE_PROXY_URL = freshEnv.VITE_CONVEX_SITE_URL;
+  }
+}
+
 export interface ConvexTarget {
   host: string;
   port: number;

--- a/services/platform/scripts/sync-convex-env-from-dotenv.ts
+++ b/services/platform/scripts/sync-convex-env-from-dotenv.ts
@@ -75,6 +75,14 @@ function parseDotEnv(filePath: string): Record<string, string> {
 // pass that removes Convex vars missing from the merged dotenv map.
 const ORCHESTRATOR_MANAGED_KEYS = [
   'BETTER_AUTH_SECRET',
+  // Derived from PORT by the dev orchestrator (envNormalizeCommon) when no
+  // .env sets it. Better Auth builds its trusted-origins list from the
+  // DEPLOYMENT env's SITE_URL (convex/auth.ts), so a stack on a non-default
+  // port (e.g. an isolated E2E stack on :3100) must sync the orchestrator's
+  // value — the :3000 fallback below would make Better Auth answer every
+  // Origin-carrying browser request with INVALID_ORIGIN, org creation
+  // included, which strands the onboarding wizard on its workspace step.
+  'SITE_URL',
   // Derived from INSTANCE_SECRET by the dev orchestrator (ensureWebdavHmacKey),
   // not present in any .env file. Required by the webdav createAppPassword
   // mutation via requireHmacSecret().
@@ -289,7 +297,10 @@ async function main() {
   const envMap = findEnv();
 
   if (!envMap.SITE_URL) {
-    const inferred = 'http://localhost:3000';
+    // Standalone invocation (no orchestrator in the parent chain): derive the
+    // same value envNormalizeCommon would, so a custom PORT still yields a
+    // trusted-origin-correct SITE_URL.
+    const inferred = `http://localhost:${process.env.PORT || '3000'}`;
     console.log(
       `[sync-convex-env] SITE_URL not set in .env; using default: ${inferred}`,
     );

--- a/services/platform/tests/e2e/README.md
+++ b/services/platform/tests/e2e/README.md
@@ -82,7 +82,21 @@ bunx playwright show-report services/platform/playwright-report
 
 First run: install the browser once with `bunx playwright install chromium`.
 
-`reuseExistingServer` applies outside CI: if you already have `bun run dev` on :3000, the suite reuses it — **your stack's config dir and provider keys**, not the fixtures. In that mode run with `E2E_MOCK_LLM=0` so the chat specs assert the round-trip instead of the canned text (canned-content and `chat-scenarios` assertions are skipped), and a real provider key is required.
+`reuseExistingServer` applies outside CI: if you already have `bun run dev` on :3000, the suite reuses it — **your stack's config dir and provider keys**, not the fixtures. In that mode run with `E2E_MOCK_LLM=0` so the chat specs assert the round-trip instead of the canned text (canned-content and `chat-scenarios` assertions are skipped), and a real provider key is required. The default (mock) mode cannot pass against a reused dev stack — the worker bootstrap fails fast with a diagnosis instead of a wall of bare locator timeouts.
+
+### Isolated stack next to a running dev stack
+
+To run the hermetic suite while your dev stack keeps :3000/:3210, use a worktree on another port — a separate checkout gets its **own anonymous Convex deployment** with its own state (the Convex CLI auto-picks free ports and `scripts/dev.ts` adopts them for the probes and the Vite proxy), so nothing touches your dev database:
+
+```bash
+git worktree add ../tale-e2e HEAD && cd ../tale-e2e && bun install
+cd services/platform
+PORT=3100 E2E_BASE_URL=http://localhost:3100 bunx playwright test
+```
+
+Do **not** point a hermetic run at the dev deployment instead: the env sync overwrites deployment vars (`ENCRYPTION_SECRET_HEX`, `SITE_URL`, the mock bases) and every E2E write would land in your dev data.
+
+Ambient HTTP(S) proxies (`HTTP_PROXY`/`HTTPS_PROXY`) are exempted for loopback automatically by `@tale/e2e/config` — a local proxy that answers errors for dead ports otherwise convinces Playwright's availability probe that the stack is "already up", it skips booting it, and every test dies on `ECONNREFUSED`.
 
 State hygiene: each worker signs up a fresh `e2e-*@tale.test` user and creates a fresh org; per-worker `owner-w<n>.json` storageState and per-org config dirs are gitignored. The suite never deletes shared state.
 

--- a/services/platform/tests/e2e/helpers/auth.ts
+++ b/services/platform/tests/e2e/helpers/auth.ts
@@ -90,48 +90,97 @@ export async function signInViaApi(
  * straight on `/dashboard/<orgId>`, in which case the wizard is skipped.
  */
 export async function createOrgViaWizard(page: Page): Promise<string> {
-  await page.goto('/dashboard');
-  await page.waitForURL(RESOLVED_URL, { timeout: TIMEOUT.FIRST_PAINT });
+  // The wizard's forward actions run through Better Auth endpoints that
+  // enforce the trusted-origin (CSRF) check for real browser requests. A
+  // rejection leaves the wizard visually stuck with no error the locators can
+  // see, so record auth failures and surface the last one if a step times out.
+  // (signUpViaApi never trips this: an APIRequestContext sends neither cookies
+  // nor Sec-Fetch metadata, which is exactly what arms the check.)
+  // Holder object rather than a plain `let`: the value is only ever written
+  // inside the response callback, and TS control-flow analysis would narrow a
+  // never-reassigned-in-scope local back to its `null` initializer at the
+  // read site (→ `never` under restrict-template-expressions).
+  const authFailure: { last: string | null } = { last: null };
+  const onResponse = (response: {
+    url(): string;
+    status(): number;
+    text(): Promise<string>;
+  }): void => {
+    if (response.url().includes('/api/auth/') && response.status() >= 400) {
+      authFailure.last = `${response.status()} from ${response.url()}`;
+      // Body is the actual diagnosis (e.g. INVALID_ORIGIN vs a validation
+      // error) — capture it asynchronously, best-effort.
+      void response
+        .text()
+        .then((body) => {
+          authFailure.last = `${response.status()} from ${response.url()}: ${body.slice(0, 300)}`;
+        })
+        .catch(() => {});
+    }
+  };
+  page.on('response', onResponse);
 
-  if (page.url().includes('/dashboard/create-organization')) {
-    const orgName = `E2E Org ${Date.now().toString(36)}`;
-    await page
-      .getByLabel(t('settings.organization.organizationName'))
-      .fill(orgName);
+  try {
+    await page.goto('/dashboard');
+    await page.waitForURL(RESOLVED_URL, { timeout: TIMEOUT.FIRST_PAINT });
 
-    // Step 1 → Next creates the org and advances to the provider step.
-    const nextButton = page.getByRole('button', {
-      name: t('common.actions.next'),
-      exact: true,
-    });
-    await expect(nextButton).toBeEnabled({ timeout: TIMEOUT.FIRST_PAINT });
-    await nextButton.click();
+    if (page.url().includes('/dashboard/create-organization')) {
+      // Same shape as uniqueCredentials: a ms timestamp ALONE collides when
+      // parallel workers bootstrap in the same instant, and the org slug
+      // derives from the name — a collision 400s the create call.
+      const orgName = `E2E Org ${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+      await page
+        .getByLabel(t('settings.organization.organizationName'))
+        .fill(orgName);
 
-    // Skip the optional provider step, then Finish to the dashboard. Next
-    // creates the org (org.create + default-workflow init), which on a cold or
-    // loaded backend can take well past the default expect timeout before the
-    // provider step (and its Skip button) renders — so wait generously.
-    const skipButton = page.getByRole('button', {
-      name: t('common.actions.skip'),
-      exact: true,
-    });
-    await expect(skipButton).toBeVisible({ timeout: TIMEOUT.FIRST_PAINT });
-    await skipButton.click();
-
-    await page
-      .getByRole('button', {
-        name: t('onboarding.finish.goToDashboard'),
+      // Step 1 → Next creates the org and advances to the provider step.
+      const nextButton = page.getByRole('button', {
+        name: t('common.actions.next'),
         exact: true,
-      })
-      .click();
-  }
+      });
+      await expect(nextButton).toBeEnabled({ timeout: TIMEOUT.FIRST_PAINT });
+      await nextButton.click();
 
-  await page.waitForURL(ORG_ID_URL, { timeout: TIMEOUT.FIRST_PAINT });
-  const organizationId = ORG_ID_URL.exec(page.url())?.[1];
-  if (!organizationId) {
-    throw new Error(`Could not extract organization id from ${page.url()}`);
+      // Skip the optional provider step, then Finish to the dashboard. Next
+      // creates the org (org.create + default-workflow init), which on a cold or
+      // loaded backend can take well past the default expect timeout before the
+      // provider step (and its Skip button) renders — so wait generously.
+      const skipButton = page.getByRole('button', {
+        name: t('common.actions.skip'),
+        exact: true,
+      });
+      try {
+        await expect(skipButton).toBeVisible({ timeout: TIMEOUT.FIRST_PAINT });
+      } catch (err) {
+        if (authFailure.last) {
+          throw new Error(
+            `Create-organization never advanced past the workspace step — the last auth API failure was ${authFailure.last}. ` +
+              `A 403 INVALID_ORIGIN here means the deployment's SITE_URL does not match the app origin (${BASE_URL}), ` +
+              `so Better Auth rejects the browser's org-create call. See tests/e2e/README.md ("Running locally").`,
+            { cause: err },
+          );
+        }
+        throw err;
+      }
+      await skipButton.click();
+
+      await page
+        .getByRole('button', {
+          name: t('onboarding.finish.goToDashboard'),
+          exact: true,
+        })
+        .click();
+    }
+
+    await page.waitForURL(ORG_ID_URL, { timeout: TIMEOUT.FIRST_PAINT });
+    const organizationId = ORG_ID_URL.exec(page.url())?.[1];
+    if (!organizationId) {
+      throw new Error(`Could not extract organization id from ${page.url()}`);
+    }
+    return organizationId;
+  } finally {
+    page.off('response', onResponse);
   }
-  return organizationId;
 }
 
 /**
@@ -165,7 +214,24 @@ export async function waitForSeededOrg(
       await expect(seededRow).toBeVisible({ timeout: TIMEOUT.VISIBLE });
       return;
     } catch (err) {
-      if (attempt === ATTEMPTS) throw err;
+      if (attempt === ATTEMPTS) {
+        // The seeded agent only exists when the stack seeds new orgs from
+        // tests/e2e/fixtures/config. The by-far most common way to get here is
+        // NOT a slow scaffold but the mock-mode/reuse trap: a dev stack was
+        // already serving this port, Playwright reused it
+        // (reuseExistingServer), and its orgs seed from THAT stack's config
+        // dir — no fixture agent can ever appear. Diagnose instead of leaving
+        // 15 bare locator timeouts.
+        throw new Error(
+          `Seeded agent "${SEEDED_AGENT_DISPLAY_NAME}" never appeared for org ${organizationId} at ${BASE_URL}. ` +
+            `If a stack was already running on this port, Playwright reused it — with ITS config dir, not the E2E fixtures — ` +
+            `and the hermetic mock mode cannot pass against it. Either stop that stack (or run the suite from an isolated ` +
+            `worktree on another port) so the suite boots its own, or explicitly target a live stack with E2E_MOCK_LLM=0. ` +
+            `If Playwright DID boot this stack itself, org seeding is genuinely broken — check the [WebServer] logs. ` +
+            `See tests/e2e/README.md ("Running locally").`,
+          { cause: err },
+        );
+      }
       await page.reload();
     }
   }

--- a/services/platform/tests/e2e/specs/rbac.spec.ts
+++ b/services/platform/tests/e2e/specs/rbac.spec.ts
@@ -74,6 +74,27 @@ test('admin adds a member who cannot see the add-member control', async ({
     const memberPage = await memberContext.newPage();
     await memberPage.goto(`/dashboard/${organizationId}/settings/organization`);
 
+    // An admin-provisioned credential must be rotated on first login: the app
+    // forces the member through /forced-change-password/<orgId> before any
+    // other page mounts. Complete it, then return to the settings page.
+    await memberPage.waitForURL(/\/forced-change-password\//, {
+      timeout: TIMEOUT.FIRST_PAINT,
+    });
+    const rotatedPassword = `${E2E_PASSWORD}-r0!`;
+    await memberPage
+      .getByLabel(t('auth.changePassword.newPassword'), { exact: true })
+      .fill(rotatedPassword);
+    await memberPage
+      .getByLabel(t('auth.changePassword.confirmPassword'), { exact: true })
+      .fill(rotatedPassword);
+    await memberPage
+      .getByRole('button', { name: t('auth.forcedChange.submit') })
+      .click();
+    await memberPage.waitForURL(/\/dashboard\//, {
+      timeout: TIMEOUT.FIRST_PAINT,
+    });
+    await memberPage.goto(`/dashboard/${organizationId}/settings/organization`);
+
     // Anchor on the settings rail (always rendered for every role), so we
     // assert after the settings shell has mounted. The org-name field itself is
     // admin-gated — a plain `member` sees an empty org page — so it can't be


### PR DESCRIPTION
## Summary

Running the platform E2E suite locally beside a running dev stack was impossible — and worse, it silently leaked into the dev deployment. This PR makes an isolated stack (worktree checkout on another port) fully self-consistent, hardens the runner against ambient proxies, converts the two silent bootstrap failure modes into one actionable diagnosis each, and fixes the one genuinely broken spec.

Four root causes, each proven by observation on an isolated worktree stack:

1. **A fresh checkout's stack proxied into the NEIGHBOURING deployment.** The Convex CLI writes only `VITE_CONVEX_URL`/`VITE_CONVEX_SITE_URL` (on CLI-picked free ports) to `.env.local`, while the readiness/health probes and the Vite proxy key on `CONVEX_URL`/`CONVEX_SITE_PROXY_URL` and fall back to `:3210`/`:3211` — every `/api` and `/ws_api` request of the isolated app landed in the dev backend (test users written into the dev database). `dev-engine` now adopts the CLI-allocated endpoints before any probe runs (`adoptCliEndpoints` in `dev-modes`, unit-tested).
2. **`sync-convex-env-from-dotenv` hardcoded the `SITE_URL` fallback to `:3000`.** Better Auth builds its trusted-origins list from the deployment env's `SITE_URL`, so on any other port every Origin-carrying browser request got `403 INVALID_ORIGIN` — org creation included, stranding the onboarding wizard on its workspace step. (The suite's API-level sign-up masked this: an `APIRequestContext` sends neither cookies nor Sec-Fetch metadata, which is exactly what arms Better Auth's check.) `SITE_URL` is now orchestrator-managed; the standalone fallback derives from `PORT`.
3. **An ambient HTTP(S) proxy poisoned Playwright's webServer probe.** With `HTTP_PROXY` set and no `NO_PROXY`, the availability probe of a dead port gets the proxy's error page, reads it as "already available", skips booting the stack, and every test dies on `ECONNREFUSED`. `createPlaywrightConfig` now exempts loopback from proxies for the runner and everything it spawns.
4. **`rbac.spec.ts` was genuinely outdated:** an admin-provisioned member is now forced through `/forced-change-password/<orgId>` on first login (deterministic 2/2 repro), so the member view never mounted. The spec completes the rotation before asserting.

Plus: the worker-org bootstrap now fails fast with a diagnosis (wizard auth failures carry the real status + response body; the seeded-agent timeout explains the mock-mode/dev-stack-reuse trap) instead of 15 bare locator timeouts; org names get a random suffix (same-millisecond parallel bootstraps derived colliding slugs → `400`); the locally-spawned webServer exports `TALE_E2E=1` like CI; the README documents the isolated-worktree recipe.

## Checklist

- [x] `bun run check` passes — run in the isolated worktree; format, lint, typecheck green; the platform vitest suite's known load-induced timeout flakiness triaged (failing files pass in isolation, none touch this diff).
- [x] `bun run lint:sast` passes — 0 findings.
- [x] Translations — **N/A**: no user-visible product strings; the new messages are test-infra error diagnoses (dev-facing, English by convention).
- [x] Docs — `tests/e2e/README.md` updated (isolated recipe, proxy + reuse caveats). Product docs untouched (no user-facing change).
- [x] `README*` — **N/A**: no setup or top-level behaviour change.

## Test plan

- **Regression tests**: `scripts/dev-modes.test.ts` covers `adoptCliEndpoints` (back-fill, explicit-wins, no-op) — fails on the old engine behaviour by construction (the function didn't exist; the probes/proxy used the neighbour's ports).
- **Observed end-to-end on an isolated worktree stack** (`PORT=3100`, dev stack untouched on `:3000/:3210`): full first-run registration → org creation → provider **Skip** → dashboard; seeded "E2E Assistant" present; clean-cookie login round-trip — all previously impossible (`INVALID_ORIGIN`).
- The 5 spec files that produced the original 15 failures pass on the isolated stack; `rbac.spec.ts` passes with the forced-change step (26s standalone, also green in the full run).
- **Full suite green on the isolated stack: 80 passed, 0 failed, 4.6 min** (`E2E_WORKERS=3`, dev stack live on `:3000/:3210` the whole time, untouched).
- Reviewer focus: `adoptCliEndpoints` call sites in `dev-engine.ts` (before the readiness probe AND after the CLI writes `.env.local`) — ordering is what keeps a cold fresh checkout from probing the neighbour.
