### PR TITLE
fix(sandbox): stage session exec temp on the workspace, not /tmp

### DIFF
--- a/services/platform/tests/integration/container-sandbox-runtime-test.ts
+++ b/services/platform/tests/integration/container-sandbox-runtime-test.ts
@@ -279,5 +279,76 @@ console.log('--- runnerd boots under the daemon entrypoint ---');
 }
 
 console.log('');
+console.log(
+  '--- session exec temp lands on the workspace, not the /tmp tmpfs ---',
+);
+// Regression for run_code ENOSPC: pip stages a whole target install set in
+// $TMPDIR, so the daemon entrypoint must point TMPDIR at the disk-backed
+// workspace — the default profile's /tmp is a 128m memory-backed tmpfs.
+// Boot under the production session contract (read-only rootfs, sized /tmp)
+// and assert (a) runnerd's TMPDIR is on the workspace and (b) a temp write
+// bigger than the /tmp tmpfs succeeds. Both fail on a TMPDIR=/tmp entrypoint.
+{
+  const cid = await stdoutOf([
+    'docker',
+    'run',
+    '-d',
+    '--user',
+    '10001',
+    '--read-only',
+    '--tmpfs',
+    '/tmp:exec,nosuid,nodev,size=128m',
+    '--tmpfs',
+    '/user:uid=10001,gid=10001',
+    IMAGE,
+    'daemon',
+  ]);
+  try {
+    let ready = false;
+    for (let i = 0; i < 20; i++) {
+      if (
+        await ok([
+          'docker',
+          'exec',
+          cid,
+          'sh',
+          '-c',
+          'curl -fsS http://127.0.0.1:8200/readyz',
+        ])
+      ) {
+        ready = true;
+        break;
+      }
+      await sleep(500);
+    }
+    if (!ready) {
+      fail('runnerd did not become ready under the session contract');
+    } else {
+      // Execs inherit runnerd's (PID 1) env — read TMPDIR from there.
+      const { exitCode, combined } = await capture([
+        'docker',
+        'exec',
+        cid,
+        'sh',
+        '-c',
+        `T=$(tr '\\0' '\\n' </proc/1/environ | sed -n 's/^TMPDIR=//p') && \
+         test "$T" = /user/.runtime/tmp && \
+         dd if=/dev/zero of="$T/enospc-probe" bs=1M count=200 2>/dev/null && \
+         rm -f "$T/enospc-probe"`,
+      ]);
+      if (exitCode === 0) {
+        pass('TMPDIR is /user/.runtime/tmp and holds a 200 MB temp write');
+      } else {
+        fail(
+          `session TMPDIR not on the workspace or too small (got: ${combined.slice(0, 200)})`,
+        );
+      }
+    }
+  } finally {
+    if (cid) await ok(['docker', 'rm', '-f', cid]);
+  }
+}
+
+console.log('');
 console.log(`${BOLD}Passed: ${passed}  Failed: ${failed}${NC}`);
 process.exit(failed === 0 ? 0 : 1);

--- a/services/platform/tests/integration/container-sandbox-runtime-test.ts
+++ b/services/platform/tests/integration/container-sandbox-runtime-test.ts
@@ -45,6 +45,10 @@ function runAs(uid: number, cmd: string) {
     String(uid),
     '--tmpfs',
     `/workspace:uid=${uid},gid=${uid}`,
+    // A writable HOME, like every real sandbox run (the entrypoint exports one
+    // on the workspace) — opencode writes cache/log state even on --version.
+    '--env',
+    'HOME=/workspace',
     '--entrypoint',
     'sh',
     IMAGE,
@@ -242,8 +246,10 @@ console.log('--- runnerd boots under the daemon entrypoint ---');
     '-d',
     '--user',
     '10001',
+    // The workspace skeleton lives under /user (sessions path model) — the
+    // daemon entrypoint mkdirs there and dies without a writable mount.
     '--tmpfs',
-    '/workspace:uid=10001,gid=10001',
+    '/user:uid=10001,gid=10001',
     IMAGE,
     'daemon',
   ]);

--- a/services/sandbox-runtime/entrypoint.sh
+++ b/services/sandbox-runtime/entrypoint.sh
@@ -747,11 +747,17 @@ if [ "$1" = "daemon" ]; then
   # state (~/.claude, ~/.config/opencode, ~/.gitconfig) survives every exec
   # and container restart within the session. Idempotent — the dirs already
   # exist on a container restart against the same workspace volume.
+  # Exec temp (TMPDIR below) is wiped like the steer queue: no exec is live at
+  # a container (re)start, so anything left there is garbage from a previous
+  # incarnation — this keeps the old /tmp lifecycle (temp died with the
+  # container) now that the dir persists on the workspace.
+  $DROP rm -rf /user/.runtime/tmp
   $DROP mkdir -p \
     /user/workspace \
     /user/uploads \
     /user/output \
     /user/.runtime/home \
+    /user/.runtime/tmp \
     /user/.runtime/deps/python \
     /user/.runtime/deps/node
   # Stale per-exec steer queues (mid-turn message injection): a container
@@ -762,7 +768,13 @@ if [ "$1" = "daemon" ]; then
   # Same install env the one-shot path exports, so inline pip/npm from a
   # session exec lands in the writable, on-PYTHONPATH/NODE_PATH location.
   export HOME=/user/.runtime/home
-  export TMPDIR=/tmp
+  # Exec temp on the workspace (disk-backed on both backends), NOT the /tmp
+  # tmpfs: pip stages the ENTIRE resolved package set in $TMPDIR before copying
+  # it to PIP_TARGET, and the tmpfs is small AND memory-backed (its pages are
+  # charged to the container's memory cgroup) — on the default profile's 128 MB
+  # /tmp any install set past ~128 MB died with ENOSPC (e.g. markitdown[pptx]'s
+  # 223 MB). /tmp itself stays for small control files (redsocks.conf, X11).
+  export TMPDIR=/user/.runtime/tmp
   export PIP_TARGET=/user/.runtime/deps/python
   export PYTHONPATH=/user/.runtime/deps/python${PYTHONPATH:+:$PYTHONPATH}
   export PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/services/sandbox/docs/sessions.md
+++ b/services/sandbox/docs/sessions.md
@@ -93,6 +93,13 @@ since the user is non-root): 2 CPU, 4 GiB, 512 pids, no cumulative-CPU ulimit
 (`~/.claude`, `~/.config/opencode`, `~/.gitconfig`) survives every exec and an
 in-place container restart — this _is_ the session-persistence mechanism.
 
+`TMPDIR=/user/.runtime/tmp` also lives on the workspace (disk-backed), not the
+`/tmp` tmpfs: pip stages a whole target install set in `$TMPDIR`, and the tmpfs
+is small and memory-backed (charged to the container's memory cgroup), so any
+install past the tmpfs size would die with ENOSPC. The entrypoint wipes the dir
+at container (re)start — no exec is live then — preserving the old /tmp
+lifecycle. `/tmp` remains for small control files (redsocks.conf, X11 socket).
+
 ## Kubernetes specifics
 
 One long-lived Pod per session (`buildSessionPod`), `restartPolicy: Always`


### PR DESCRIPTION
## Problem

`run_code` on the demo env failed installing `markitdown[pptx]` with a baffling `[Errno 28] No space left on device` — on a host with plenty of disk.

Root cause: session execs inherit `TMPDIR=/tmp` from the daemon entrypoint, and `/tmp` is a small, **memory-backed** tmpfs (128 MB on the run_code `default` profile — hardcoded in `docker-session-args.ts`; 512 MB agent / K8s). pip stages the **entire resolved package set** in `$TMPDIR` (`pip-target-*`) before copying it to `PIP_TARGET`, so any install set past the tmpfs size dies with ENOSPC — `markitdown[pptx]` pulls magika → onnxruntime + numpy + Pillow + lxml = 223 MB. pip removes its temp dir on failure, so the box looks empty afterwards, which is what made the report so confusing.

Deterministic repro (fails at `size=128m`, passes at `512m`):

```sh
docker run --rm --read-only --tmpfs /tmp:exec,nosuid,nodev,size=128m \
  --user 65534:65534 --ulimit fsize=104857600 \
  -e TMPDIR=/tmp -e HOME=/user/.runtime/home -e PIP_TARGET=/user/.runtime/deps/python \
  -v "$WORK":/user --entrypoint /bin/bash tale-sandbox-runtime:latest \
  -c 'mkdir -p /user/.runtime/deps/python /user/.runtime/home && python3 -m pip install "markitdown[pptx]"'
```

## Fix

Point `TMPDIR` at the persistent workspace — `/user/.runtime/tmp` (host bind mount on Docker, size-bounded PVC on K8s) — created with the workspace skeleton and wiped at container (re)start (no exec is live at boot; same reasoning as the steer-queue cleanup, and the same lifecycle `/tmp` had). Enlarging the tmpfs instead would eat the default profile's `--memory=1500m` budget, since tmpfs pages are charged to the container's memory cgroup. `/tmp` stays for small control files (redsocks.conf, X11 socket). This also makes the pre-existing "install temp follows TMPDIR (workspace disk)" note in `docker-session-args.ts` actually true.

The first commit repairs two drifted checks in the conformance suite found on the way (daemon-boot section still mounted the workspace tmpfs at `/workspace` — stale since the #2301 path model moved it to `/user` — and `runAs` lacked a writable HOME, which newer opencode needs even for `--version`).

## Verification

- **RED**: new regression section fails against the old entrypoint (observed).
- **GREEN**: full conformance suite 19/19 after rebuild (`bun run docker:test:sandbox-runtime`), including the new section — daemon booted under the production session contract (read-only rootfs, 128m `/tmp`), runnerd's `TMPDIR` read from `/proc/1/environ` is `/user/.runtime/tmp`, and a 200 MB temp write succeeds.
- **End to end**: the originally failing `pip install "markitdown[pptx]"` passes under the same 128m `/tmp` constraint with the new TMPDIR (EXIT=0).

## Notes for deploy

- Existing Docker session containers keep the old env until recreated (`docker start` reuses the container); new sessions pick the fix up with the image.
- Residual, out of scope: the default profile's `fsize=100MB` ulimit still EFBIGs any single file >100 MB (e.g. a torch wheel) — separate change if we want it.

## Done checklist

- [x] Gate green — typecheck, oxlint, `bash -n`, conformance suite 19/19 (scoped to the touched surface; no vitest suites touch these files)
- [x] Security / SAST clean — `bun run lint:sast`: 232 rules, 0 findings
- [x] Migration — N/A: no data-model/org-config change; env applied at entrypoint boot
- [x] Tests carry the change — regression section (happy: workspace TMPDIR + 200 MB write; error: fails on TMPDIR=/tmp; edge: boots under full production contract)
- [x] i18n — N/A: no user-visible strings (the error text was pip's own)
- [x] Docs — `services/sandbox/docs/sessions.md` updated
- [x] Accessibility — N/A: no UI
- [x] Behaviour verified by observing the real outcome — original pip failure reproduced, then passes post-fix
- [x] Instructions/docs describing changed paths updated — sessions.md is the only place documenting the session env
- [x] Atomic conventional commits off main