### PR TITLE
feat(platform): unambiguous multi-org SSO sign-in with org picker

### DIFF
--- a/docs/de/platform/admin/enterprise-sso.md
+++ b/docs/de/platform/admin/enterprise-sso.md
@@ -53,6 +53,12 @@ Wenn ein Anbieter OAuth2, aber kein Discovery-Dokument bietet, wählen Sie **OAu
 
 Tale unterstützt sowohl IdP-initiiertes SAML (der IdP sendet eine Assertion an die ACS-URL) als auch SP-initiiertes SAML (ein Mitglied klickt auf **Mit SSO anmelden** und Tale leitet zum IdP weiter). Signierte Assertions sind erforderlich; verschlüsselte Assertions werden unterstützt, wenn Sie ein SP-Schlüsselpaar bereitstellen.
 
+## Mehrere Organisationen auf einem Deployment
+
+Ein Deployment kann mehrere Organisationen mit jeweils eigener Verbindung beherbergen. Die Anmeldung wird über das Feld **E-Mail-Domäne** zugeordnet: Setzen Sie es auf jeder Verbindung (zum Beispiel `example.com`), dann erreichen Mitglieder, die ihre E-Mail-Adresse auf der Anmeldeseite eingeben, den IdP ihrer Organisation. Bei einer einzigen aktivierten Verbindung ist das Feld optional — die Anmeldung fällt auf diese Verbindung zurück. Bei mehreren gibt es keinen Rückfall: Eine Anmeldung, die sich nicht zuordnen lässt, fragt nach der E-Mail-Adresse der Organisation, statt eine Verbindung zu raten.
+
+Verbindungen **ohne** E-Mail-Domäne sind über den Adressabgleich nicht erreichbar; der SSO-Bildschirm listet sie deshalb unter ihrem **Anzeigename** zur manuellen Auswahl auf. Dieser Anzeigename ist auf der Anmeldeseite für alle sichtbar — setzen Sie eine E-Mail-Domäne, um eine Verbindung von der Liste fernzuhalten.
+
 ## Bereitstellung: Rollen und Teams
 
 Jedes Protokoll teilt sich eine Bereitstellungsrichtlinie:

--- a/docs/en/platform/admin/enterprise-sso.md
+++ b/docs/en/platform/admin/enterprise-sso.md
@@ -53,6 +53,12 @@ If a provider exposes OAuth2 but no discovery document, choose **OAuth2** and en
 
 Tale supports both IdP-initiated SAML (the IdP posts an assertion to the ACS URL) and SP-initiated SAML (a member clicks **Sign in with SSO** and Tale redirects to the IdP). Signed assertions are required; encrypted assertions are supported when you supply an SP keypair.
 
+## Several organizations on one deployment
+
+A deployment can host more than one organization, each with its own connection. Sign-in routes by the **Email domain** field: set it on each connection (for example `example.com`), and members who enter their email on the login page reach their organization's IdP. With a single enabled connection the field is optional — sign-in falls back to that connection. With several, there is no fallback: a sign-in attempt that cannot be routed asks for the organization email address instead of guessing a connection.
+
+Connections **without** an email domain cannot be reached by address matching, so the SSO screen lists them by **Display name** for manual selection. That display name is visible to anyone on the login page — set an email domain on a connection to keep it off the list.
+
 ## Provisioning: roles and teams
 
 Every protocol shares one provisioning policy:

--- a/docs/fr/platform/admin/enterprise-sso.md
+++ b/docs/fr/platform/admin/enterprise-sso.md
@@ -53,6 +53,12 @@ Si un fournisseur expose OAuth2 mais pas de document de découverte, choisissez 
 
 Tale prend en charge le SAML initié par l'IdP (l'IdP envoie une assertion à l'URL ACS) et le SAML initié par le SP (un membre clique sur **Se connecter avec le SSO** et Tale redirige vers l'IdP). Les assertions signées sont requises ; les assertions chiffrées sont prises en charge si vous fournissez une paire de clés SP.
 
+## Plusieurs organisations sur un même déploiement
+
+Un déploiement peut héberger plusieurs organisations, chacune avec sa propre connexion. L’authentification est orientée selon le champ **Domaine de messagerie** : définissez-le sur chaque connexion (par exemple `example.com`), et les membres qui saisissent leur adresse e-mail sur la page de connexion atteignent l’IdP de leur organisation. Avec une seule connexion activée, le champ est facultatif — l’authentification retombe sur cette connexion. Avec plusieurs, il n’y a pas de repli : une tentative impossible à orienter demande l’adresse e-mail de l’organisation au lieu de deviner une connexion.
+
+Les connexions **sans** domaine de messagerie ne peuvent pas être atteintes par correspondance d’adresse ; l’écran SSO les liste donc sous leur **Nom affiché** pour une sélection manuelle. Ce nom est visible par quiconque sur la page de connexion — définissez un domaine de messagerie pour retirer une connexion de la liste.
+
 ## Provisionnement : rôles et équipes
 
 Chaque protocole partage une politique de provisionnement :

--- a/services/platform/app/features/auth/hooks/queries.ts
+++ b/services/platform/app/features/auth/hooks/queries.ts
@@ -26,6 +26,16 @@ export function useIsSsoConfigured() {
   );
 }
 
+// The SSO step's manual picker: enabled connections without an email domain
+// (unreachable by email routing). Pre-auth like isConfigured.
+export function useSsoSelectableOrgs() {
+  return useConvexQuery(
+    api.enterprise_sso.queries.listSelectable,
+    {},
+    { requireAuth: false },
+  );
+}
+
 export function useHasMicrosoftAccount() {
   return useConvexQuery(api.accounts.queries.hasMicrosoftAccount, {});
 }

--- a/services/platform/app/features/auth/log-in-sso-email-prompt.test.tsx
+++ b/services/platform/app/features/auth/log-in-sso-email-prompt.test.tsx
@@ -1,0 +1,219 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+// On a deployment where several orgs enable SSO, the organization email is the
+// routing key. Clicking "Continue with SSO" must step into the dedicated SSO
+// screen (`?method=sso`) that asks for it — an SSO user never touches the
+// credential form, and no request leaves the page until the email routes.
+
+// ── Router ───────────────────────────────────────────────────────────────────
+const { mockNavigate, mockSearch } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockSearch: { value: {} as Record<string, unknown> },
+}));
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => ({ component: null }),
+  useNavigate: () => mockNavigate,
+  useSearch: () => mockSearch.value,
+}));
+
+// ── i18n (identity: assertions target the raw keys) ─────────────────────────
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (_ns: string) => ({ t: (key: string) => key }),
+}));
+
+// ── SEO util ─────────────────────────────────────────────────────────────────
+vi.mock('@/lib/utils/seo', () => ({ seo: () => [] }));
+
+// ── Auth queries: a multi-connection deployment ──────────────────────────────
+const { mockSelectableOrgs } = vi.hoisted(() => ({
+  mockSelectableOrgs: { value: [] as Record<string, string>[] },
+}));
+vi.mock('@/app/features/auth/hooks/queries', () => ({
+  useHasAnyUsers: () => ({ data: true, isLoading: false }),
+  useIsSsoConfigured: () => ({
+    data: { enabled: true, providerType: 'entra-id', multiple: true },
+  }),
+  useSsoSelectableOrgs: () => ({ data: mockSelectableOrgs.value }),
+}));
+
+// ── React Query client / toast / auth client ────────────────────────────────
+vi.mock('@/app/hooks/use-react-query-client', () => ({
+  useReactQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+vi.mock('@/lib/auth-client', () => ({
+  authClient: { signIn: { email: vi.fn() } },
+}));
+
+// ── Component (imported after all vi.mock calls) ─────────────────────────────
+import { LogInPage } from '@/app/routes/_auth/log-in';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockSearch.value = {};
+  mockSelectableOrgs.value = [];
+  vi.stubGlobal('fetch', mockFetch);
+  // `redirectToSso` reads SITE_URL via getEnv, which throws when the runtime
+  // env bridge is absent — provide it like the real page load does.
+  window.__ENV__ = {
+    SITE_URL: 'http://localhost:3000',
+    BASE_PATH: '',
+  } as Window['__ENV__'];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  delete window.__ENV__;
+});
+
+describe('LogInPage – multi-connection SSO steps into the dedicated email screen', () => {
+  it('clicking the SSO button navigates to ?method=sso instead of redirecting', async () => {
+    const { user } = render(<LogInPage />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'login.continueWithSso' }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const call = mockNavigate.mock.calls[0][0] as {
+      to: string;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(call.to).toBe('/log-in');
+    expect(call.search({})).toMatchObject({ method: 'sso' });
+    // No discovery round-trip, no IdP redirect from the credential screen.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('renders only the SSO email step under ?method=sso (no credential form)', () => {
+    mockSearch.value = { method: 'sso' };
+
+    render(<LogInPage />);
+
+    expect(screen.getByText('login.ssoDescription')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'login.continueWithSso' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'login.ssoBackToLogin' }),
+    ).toBeInTheDocument();
+    // The password login is a different method — it must not render here.
+    expect(screen.queryByLabelText(/^password\b/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'login.loginButton' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('asks for the email when continuing with an empty field', async () => {
+    mockSearch.value = { method: 'sso' };
+    const { user } = render(<LogInPage />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'login.continueWithSso' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('login.ssoEmailRequired')).toBeInTheDocument();
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('says when no connection matches the typed email domain', async () => {
+    mockSearch.value = { method: 'sso' };
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ ssoEnabled: false }), { status: 200 }),
+    );
+    const { user } = render(<LogInPage />);
+
+    await user.type(
+      screen.getByLabelText('email', { exact: false }),
+      'someone@unrouted.example',
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'login.continueWithSso' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('login.ssoEmailNoMatch')).toBeInTheDocument();
+    });
+    // Discovery ran once; the authorize redirect did not happen.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the hint as soon as the email is edited', async () => {
+    mockSearch.value = { method: 'sso' };
+    const { user } = render(<LogInPage />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'login.continueWithSso' }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText('login.ssoEmailRequired')).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByLabelText('email', { exact: false }),
+      'member@a.example',
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('login.ssoEmailRequired'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('lists domain-less connections for manual selection', () => {
+    mockSearch.value = { method: 'sso' };
+    mockSelectableOrgs.value = [
+      { organizationId: 'org_x', displayName: 'Org X SSO', protocol: 'oidc' },
+      { organizationId: 'org_y', displayName: 'Org Y SSO', protocol: 'saml' },
+    ];
+
+    render(<LogInPage />);
+
+    expect(screen.getByText('login.ssoPickOrganization')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Org X SSO' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Org Y SSO' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the picker when every connection has an email domain', () => {
+    mockSearch.value = { method: 'sso' };
+
+    render(<LogInPage />);
+
+    expect(
+      screen.queryByText('login.ssoPickOrganization'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('the back button returns to the credential screen', async () => {
+    mockSearch.value = { method: 'sso' };
+    const { user } = render(<LogInPage />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'login.ssoBackToLogin' }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const call = mockNavigate.mock.calls[0][0] as {
+      to: string;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(call.to).toBe('/log-in');
+    expect(call.search({ method: 'sso' })).toMatchObject({
+      method: undefined,
+    });
+  });
+});

--- a/services/platform/app/features/auth/log-in-sso-error.test.tsx
+++ b/services/platform/app/features/auth/log-in-sso-error.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/lib/utils/seo', () => ({ seo: () => [] }));
 vi.mock('@/app/features/auth/hooks/queries', () => ({
   useHasAnyUsers: () => ({ data: true, isLoading: false }),
   useIsSsoConfigured: () => ({ data: { enabled: true } }),
+  useSsoSelectableOrgs: () => ({ data: [] }),
 }));
 
 vi.mock('@/app/hooks/use-react-query-client', () => ({

--- a/services/platform/app/features/auth/login-form-error-clearing.test.tsx
+++ b/services/platform/app/features/auth/login-form-error-clearing.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@/lib/utils/seo', () => ({ seo: () => [] }));
 vi.mock('@/app/features/auth/hooks/queries', () => ({
   useHasAnyUsers: () => ({ data: true, isLoading: false }),
   useIsSsoConfigured: () => ({ data: { enabled: false } }),
+  useSsoSelectableOrgs: () => ({ data: [] }),
 }));
 
 // ── React Query client ───────────────────────────────────────────────────────

--- a/services/platform/app/features/auth/login-idle-notice.test.tsx
+++ b/services/platform/app/features/auth/login-idle-notice.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@/lib/utils/seo', () => ({ seo: () => [] }));
 vi.mock('@/app/features/auth/hooks/queries', () => ({
   useHasAnyUsers: () => ({ data: true, isLoading: false }),
   useIsSsoConfigured: () => ({ data: { enabled: false } }),
+  useSsoSelectableOrgs: () => ({ data: [] }),
 }));
 
 // ── React Query client ───────────────────────────────────────────────────────

--- a/services/platform/app/features/documents/components/microsoft-reauth-button.tsx
+++ b/services/platform/app/features/documents/components/microsoft-reauth-button.tsx
@@ -4,6 +4,7 @@ import { Button } from '@tale/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { useState, useCallback } from 'react';
 
+import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { getEnv } from '@/lib/env';
 import { useT } from '@/lib/i18n/client';
 
@@ -22,14 +23,25 @@ export function MicrosoftReauthButton({
 }: MicrosoftReauthButtonProps) {
   const { t } = useT('auth');
   const [isLoading, setIsLoading] = useState(false);
+  const organizationId = useOrganizationId();
 
   const handleReauth = useCallback(() => {
     setIsLoading(true);
     const siteUrl = getEnv('SITE_URL');
     const basePath = getEnv('BASE_PATH');
     const callbackUri = `${siteUrl}${basePath}/http_api/api/sso/callback`;
-    window.location.href = `${siteUrl}${basePath}/http_api/api/sso/authorize?redirect_uri=${encodeURIComponent(callbackUri)}`;
-  }, []);
+    const authorizeUrl = new URL(
+      `${siteUrl}${basePath}/http_api/api/sso/authorize`,
+    );
+    authorizeUrl.searchParams.set('redirect_uri', callbackUri);
+    // This button lives inside the dashboard, so the org is always known —
+    // pin the connection instead of relying on the single-enabled fallback
+    // (which is ambiguous on multi-org deployments).
+    if (organizationId) {
+      authorizeUrl.searchParams.set('organizationId', organizationId);
+    }
+    window.location.href = authorizeUrl.toString();
+  }, [organizationId]);
 
   const getButtonText = () => {
     if (error === 'ConsentRequired') {

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
@@ -495,3 +495,31 @@ describe('EnterpriseSsoForm deployment warnings + redirect URL (A2.1)', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('EnterpriseSsoForm multi-org email-domain warning', () => {
+  it('warns when enabled without a domain while other orgs also use SSO', () => {
+    renderForm({
+      ...connectedOidc,
+      domain: null,
+      otherOrgsEnabled: true,
+    });
+    expect(screen.getByText(/no email domain set/i)).toBeInTheDocument();
+  });
+
+  it('does not warn when a domain is set', () => {
+    renderForm({
+      ...connectedOidc,
+      otherOrgsEnabled: true,
+    });
+    expect(screen.queryByText(/no email domain set/i)).not.toBeInTheDocument();
+  });
+
+  it('does not warn when this is the only enabled connection', () => {
+    renderForm({
+      ...connectedOidc,
+      domain: null,
+      otherOrgsEnabled: false,
+    });
+    expect(screen.queryByText(/no email domain set/i)).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
@@ -695,6 +695,22 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
               placeholder="example.com"
               {...register('domain')}
             />
+            {/* Multi-org deployments route sign-in by this domain. Leaving it
+                empty makes the connection unroutable by address — it is then
+                listed publicly by display name on the SSO screen. Warn, don't
+                block: the operator may want exactly that. */}
+            {config?.enabled &&
+              config.otherOrgsEnabled === true &&
+              !(watch('domain') ?? '').trim() && (
+                <Alert
+                  variant="warning"
+                  icon={AlertTriangle}
+                  title={t('integrations.enterpriseSso.domainWarning.title')}
+                  description={t(
+                    'integrations.enterpriseSso.domainWarning.description',
+                  )}
+                />
+              )}
           </Section>
 
           {isOidcLike ? (

--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -21,6 +21,7 @@ import { ConditionalAccessError } from '@/app/features/auth/components/condition
 import {
   useHasAnyUsers,
   useIsSsoConfigured,
+  useSsoSelectableOrgs,
 } from '@/app/features/auth/hooks/queries';
 import { useReactQueryClient } from '@/app/hooks/use-react-query-client';
 import { toast } from '@/app/hooks/use-toast';
@@ -47,6 +48,10 @@ const searchSchema = z.object({
   error: z.string().optional().catch(undefined),
   error_code: z.string().optional().catch(undefined),
   recovery: z.string().optional().catch(undefined),
+  // `method=sso` renders the dedicated SSO step (organization email → routed
+  // to the org's IdP). Entered from the SSO button when several orgs have SSO
+  // enabled — an SSO user never touches the credential form.
+  method: z.literal('sso').optional().catch(undefined),
 });
 
 export const Route = createFileRoute('/_auth/log-in')({
@@ -75,6 +80,7 @@ export function LogInPage() {
     error: ssoError,
     error_code: ssoErrorCode,
     recovery: ssoRecovery,
+    method,
   } = useSearch({ from: '/_auth/log-in' });
   const { t } = useT('auth');
   const { t: tCommon } = useT('common');
@@ -109,6 +115,9 @@ export function LogInPage() {
 
   const { data: hasUsers, isLoading: isLoadingUsers } = useHasAnyUsers();
   const { data: ssoConfig } = useIsSsoConfigured();
+  // Connections without an email domain can't be reached by email routing —
+  // the SSO step offers them as a manual choice instead.
+  const { data: selectableOrgs } = useSsoSelectableOrgs();
 
   // When trusted headers auth is enabled, the reverse proxy has already
   // authenticated the user. Navigate to the Convex HTTP endpoint that reads
@@ -177,6 +186,11 @@ export function LogInPage() {
   });
 
   const [loginError, setLoginError] = useState<string | null>(null);
+  // The dedicated SSO step (`?method=sso`): its own email field — an SSO user
+  // never touches the credential form — plus inline guidance when the address
+  // is missing or no connection matches its domain.
+  const [ssoEmail, setSsoEmail] = useState('');
+  const [ssoEmailHint, setSsoEmailHint] = useState<string | null>(null);
   // Standing, count-free advisory shown on a failed credential attempt. We
   // deliberately never reveal attempts-remaining: a live counter would break
   // the uniform "wrong email or password" response and hand an attacker both
@@ -304,57 +318,113 @@ export function LogInPage() {
     }
   };
 
-  const handleSsoLogin = useCallback(async () => {
-    const siteUrl = getEnv('SITE_URL');
-    const basePath = getEnv('BASE_PATH');
-    const base = `${siteUrl}${basePath}/http_api/api/sso`;
+  // Discover the org by email domain (#2082) and hand the browser to the IdP.
+  // Returns false when several connections exist and none matches — the
+  // authorize endpoint would refuse to guess, so the caller asks for a
+  // correction instead of round-tripping into a bounce.
+  const redirectToSso = useCallback(
+    async (email: string): Promise<boolean> => {
+      const siteUrl = getEnv('SITE_URL');
+      const basePath = getEnv('BASE_PATH');
+      const base = `${siteUrl}${basePath}/http_api/api/sso`;
+      const multiple = ssoConfig?.multiple === true;
 
-    // Route by the typed email's domain so a deployment with more than one SSO
-    // connection reaches the IdP of the matching org, instead of always the
-    // first enabled connection (#2082). With no email (the common single-org
-    // case) or an inconclusive lookup, fall back to the global connection.
-    const email = form.getValues('email').trim();
-    let organizationId: string | undefined;
-    let protocol: string = ssoConfig?.providerType === 'saml' ? 'saml' : 'oidc';
-    if (email) {
-      try {
-        const res = await fetch(`${base}/discover`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email }),
-        });
-        if (res.ok) {
-          const data: unknown = await res.json();
-          if (isRecord(data) && data.ssoEnabled === true) {
-            const orgId = getString(data, 'organizationId');
-            const proto = getString(data, 'protocol');
-            if (orgId) {
-              organizationId = orgId;
-              if (proto) protocol = proto;
+      let organizationId: string | undefined;
+      let protocol: string =
+        ssoConfig?.providerType === 'saml' ? 'saml' : 'oidc';
+      if (email) {
+        try {
+          const res = await fetch(`${base}/discover`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email }),
+          });
+          if (res.ok) {
+            const data: unknown = await res.json();
+            if (isRecord(data) && data.ssoEnabled === true) {
+              const orgId = getString(data, 'organizationId');
+              const proto = getString(data, 'protocol');
+              if (orgId) {
+                organizationId = orgId;
+                if (proto) protocol = proto;
+              }
             }
           }
+        } catch (error) {
+          console.warn(
+            '[sso] discovery failed; using default connection',
+            error,
+          );
         }
-      } catch (error) {
-        console.warn('[sso] discovery failed; using default connection', error);
+        if (multiple && !organizationId) return false;
       }
-    }
 
-    // SAML uses SP-initiated redirect (AuthnRequest); OIDC/OAuth2 use the
-    // authorization-code flow via /authorize.
-    if (protocol === 'saml') {
-      const samlUrl = new URL(`${base}/saml/login`);
-      if (organizationId) samlUrl.searchParams.set('org', organizationId);
-      window.location.href = samlUrl.toString();
+      // SAML uses SP-initiated redirect (AuthnRequest); OIDC/OAuth2 use the
+      // authorization-code flow via /authorize.
+      if (protocol === 'saml') {
+        const samlUrl = new URL(`${base}/saml/login`);
+        if (organizationId) samlUrl.searchParams.set('org', organizationId);
+        window.location.href = samlUrl.toString();
+        return true;
+      }
+      const authorizeUrl = new URL(`${base}/authorize`);
+      authorizeUrl.searchParams.set('redirect_uri', `${base}/callback`);
+      if (email) authorizeUrl.searchParams.set('email', email);
+      if (organizationId) {
+        authorizeUrl.searchParams.set('organizationId', organizationId);
+      }
+      window.location.href = authorizeUrl.toString();
+      return true;
+    },
+    [ssoConfig?.providerType, ssoConfig?.multiple],
+  );
+
+  const handleSsoLogin = useCallback(async () => {
+    // With several orgs' connections enabled the organization email is the
+    // routing key — step into the dedicated SSO screen that asks for it. An
+    // SSO user never fills the credential form, so its email is not consulted.
+    if (ssoConfig?.multiple === true) {
+      setSsoEmailHint(null);
+      void navigate({
+        to: '/log-in',
+        search: (prev) => ({ ...prev, method: 'sso' }),
+      });
       return;
     }
-    const authorizeUrl = new URL(`${base}/authorize`);
-    authorizeUrl.searchParams.set('redirect_uri', `${base}/callback`);
-    if (email) authorizeUrl.searchParams.set('email', email);
-    if (organizationId) {
-      authorizeUrl.searchParams.set('organizationId', organizationId);
+    // Single connection: straight to the IdP, as before.
+    await redirectToSso(form.getValues('email').trim());
+  }, [ssoConfig?.multiple, navigate, redirectToSso, form]);
+
+  const handleSsoStepContinue = useCallback(async () => {
+    const email = ssoEmail.trim();
+    if (!email) {
+      setSsoEmailHint(t('login.ssoEmailRequired'));
+      return;
     }
-    window.location.href = authorizeUrl.toString();
-  }, [ssoConfig?.providerType, form]);
+    const routed = await redirectToSso(email);
+    if (!routed) setSsoEmailHint(t('login.ssoEmailNoMatch'));
+  }, [ssoEmail, redirectToSso, t]);
+
+  // Manual pick from the domain-less list: the org is explicit, so skip
+  // discovery and pin it straight on the sign-in URL.
+  const handleSsoOrgPick = useCallback(
+    (organizationId: string, protocol: string) => {
+      const siteUrl = getEnv('SITE_URL');
+      const basePath = getEnv('BASE_PATH');
+      const base = `${siteUrl}${basePath}/http_api/api/sso`;
+      if (protocol === 'saml') {
+        const samlUrl = new URL(`${base}/saml/login`);
+        samlUrl.searchParams.set('org', organizationId);
+        window.location.href = samlUrl.toString();
+        return;
+      }
+      const authorizeUrl = new URL(`${base}/authorize`);
+      authorizeUrl.searchParams.set('redirect_uri', `${base}/callback`);
+      authorizeUrl.searchParams.set('organizationId', organizationId);
+      window.location.href = authorizeUrl.toString();
+    },
+    [],
+  );
 
   // Passkey / WebAuthn sign-in (#1508). Drives the browser's get-credential
   // ceremony; on success the session is live, so refresh the cache and route
@@ -402,6 +472,99 @@ export function LogInPage() {
 
   if (isLoadingUsers || (trustedHeadersEnabled && !hasTrustedHeadersError)) {
     return null;
+  }
+
+  // Dedicated SSO step: only the organization email — it routes the sign-in
+  // to the right org's IdP. The credential form never appears here.
+  if (method === 'sso') {
+    return (
+      <AuthFormLayout title={t('login.ssoTitle')}>
+        <Stack gap={6}>
+          <p className="text-muted-foreground text-center text-sm">
+            {t('login.ssoDescription')}
+          </p>
+          <FormSection>
+            <Form
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSsoStepContinue();
+              }}
+            >
+              <Input
+                id="sso-email"
+                type="email"
+                label={t('email')}
+                placeholder={t('emailPlaceholder')}
+                autoComplete="email"
+                className="shadow-xs"
+                value={ssoEmail}
+                onChange={(event) => {
+                  setSsoEmail(event.target.value);
+                  setSsoEmailHint(null);
+                }}
+              />
+              {ssoEmailHint && (
+                <p
+                  role="alert"
+                  aria-live="polite"
+                  className="text-destructive -mt-2.5 flex items-start gap-1.5 text-sm font-medium"
+                >
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+                  {ssoEmailHint}
+                </p>
+              )}
+              <Button type="submit" fullWidth>
+                <span className="mr-3 inline-flex size-4">
+                  <MicrosoftIcon />
+                </span>
+                {t('login.continueWithSso')}
+              </Button>
+            </Form>
+          </FormSection>
+          {/* Connections without an email domain can never match an address —
+              offer them as an explicit choice instead of a dead end. */}
+          {selectableOrgs && selectableOrgs.length > 0 && (
+            <>
+              <div className="flex items-center gap-3" aria-hidden="true">
+                <span className="bg-border h-px flex-1" />
+                <span className="text-muted-foreground text-xs">
+                  {t('login.ssoPickOrganization')}
+                </span>
+                <span className="bg-border h-px flex-1" />
+              </div>
+              <Stack gap={3}>
+                {selectableOrgs.map((org) => (
+                  <Button
+                    key={org.organizationId}
+                    type="button"
+                    variant="secondary"
+                    fullWidth
+                    onClick={() =>
+                      handleSsoOrgPick(org.organizationId, org.protocol)
+                    }
+                  >
+                    {org.displayName}
+                  </Button>
+                ))}
+              </Stack>
+            </>
+          )}
+          <Button
+            type="button"
+            variant="link"
+            onClick={() => {
+              setSsoEmailHint(null);
+              void navigate({
+                to: '/log-in',
+                search: (prev) => ({ ...prev, method: undefined }),
+              });
+            }}
+          >
+            {t('login.ssoBackToLogin')}
+          </Button>
+        </Stack>
+      </AuthFormLayout>
+    );
   }
 
   const showSsoButton = ssoConfig?.enabled;

--- a/services/platform/convex/enterprise_sso/config/queries.ts
+++ b/services/platform/convex/enterprise_sso/config/queries.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../lib/shared/schemas/enterprise_sso';
 // Raw `query` + explicit membership gate — matches the members/SCIM family
 // (org membership is resolved via Better Auth's cross-component adapter).
-import { query } from '../../_generated/server';
+import { type QueryCtx, query } from '../../_generated/server';
 import { readConfigCacheRow } from '../../lib/config_cache/read';
 import { getPublicHttpApiUrl } from '../../lib/helpers/public_storage_url';
 import { getAuthUserIdentity } from '../../lib/rls/auth/get_auth_user_identity';
@@ -93,6 +93,9 @@ const connectionViewValidator = v.object({
       authSecretSet: v.boolean(),
     }),
   ),
+  // Another org on this deployment also has an enabled connection — without an
+  // email domain this one is unroutable by address, so the form warns.
+  otherOrgsEnabled: v.optional(v.boolean()),
 });
 
 /**
@@ -115,6 +118,26 @@ function publicBase(): string | null {
   } catch {
     return null;
   }
+}
+
+/** True when any OTHER org on this deployment has an enabled connection — the
+ *  multi-org state where a domain-less connection is unroutable by email and
+ *  only reachable via the login page's manual picker. */
+async function otherOrgsHaveEnabledConnections(
+  ctx: QueryCtx,
+  organizationId: string,
+): Promise<boolean> {
+  for await (const row of ctx.db
+    .query('configCache')
+    .withIndex('by_domain_key', (q) =>
+      q.eq('domain', SSO_CONFIG_DOMAIN).eq('key', SSO_CONNECTION_KEY),
+    )) {
+    if (row.organizationId === organizationId) continue;
+    if (row.enabled !== true) continue;
+    const parsed = ssoConnectionFileSchema.safeParse(row.config);
+    if (parsed.success && parsed.data.enabled) return true;
+  }
+  return false;
 }
 
 export const get = query({
@@ -179,6 +202,11 @@ export const get = query({
       baseUrl: scimBaseUrl,
     };
 
+    const otherOrgsEnabled = await otherOrgsHaveEnabledConnections(
+      ctx,
+      args.organizationId,
+    );
+
     if (!config) {
       return {
         configured: false,
@@ -200,6 +228,7 @@ export const get = query({
         samlAcsUrl,
         oidcCallbackUrl,
         deployment: deploymentHealth(),
+        otherOrgsEnabled,
       };
     }
 
@@ -249,6 +278,7 @@ export const get = query({
       samlAcsUrl,
       oidcCallbackUrl,
       deployment: deploymentHealth(),
+      otherOrgsEnabled,
     };
   },
 });

--- a/services/platform/convex/enterprise_sso/internal_queries.test.ts
+++ b/services/platform/convex/enterprise_sso/internal_queries.test.ts
@@ -1,0 +1,244 @@
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api, internal } from '../_generated/api';
+import schema from '../schema';
+
+/**
+ * Regression tests for multi-org connection resolution: with more than one
+ * enabled connection and no org context, sign-in resolution must report
+ * `'ambiguous'` (and email discovery must return null on a non-matching
+ * domain) instead of silently picking whichever connection the index yields
+ * first — the guess sent users to another org's IdP.
+ */
+
+// Build the module map keyed from the convex root (same pattern as the SCIM
+// http_actions test) so convex-test can resolve the internal queries.
+const TEST_DIR_FROM_CONVEX_ROOT = 'enterprise_sso';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+function oidcConnection(opts: { domain?: string; issuer?: string } = {}) {
+  return {
+    enabled: true,
+    protocol: 'oidc',
+    displayName: 'Enterprise SSO',
+    ...(opts.domain ? { domain: opts.domain } : {}),
+    oidc: {
+      providerId: 'entra-id',
+      issuer:
+        opts.issuer ??
+        'https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0',
+      scopes: ['openid', 'profile', 'email'],
+    },
+  };
+}
+
+function samlConnection() {
+  return {
+    enabled: true,
+    protocol: 'saml',
+    displayName: 'Enterprise SSO',
+    saml: {
+      idpEntityId: 'https://idp.example.com/metadata',
+      idpSsoUrl: 'https://idp.example.com/sso',
+      idpCertificate: 'MIIC-fake',
+    },
+  };
+}
+
+async function seedConnection(
+  t: ReturnType<typeof convexTest>,
+  organizationId: string,
+  config: Record<string, unknown>,
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('configCache', {
+      organizationId,
+      domain: 'sso',
+      key: 'connection',
+      config,
+      enabled: config.enabled === true,
+      syncedAt: 1_700_000_000_000,
+    });
+  });
+}
+
+describe('resolveSignInConfig without org context', () => {
+  it('resolves the connection when exactly one is enabled', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection());
+
+    const config = await t.query(
+      internal.enterprise_sso.internal_queries.resolveSignInConfig,
+      {},
+    );
+
+    expect(config).not.toBeNull();
+    expect(config).not.toBe('ambiguous');
+    if (config && config !== 'ambiguous') {
+      expect(config.organizationId).toBe('org_a');
+    }
+  });
+
+  it('returns "ambiguous" when two orgs have enabled connections', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection());
+    await seedConnection(t, 'org_b', oidcConnection());
+
+    const config = await t.query(
+      internal.enterprise_sso.internal_queries.resolveSignInConfig,
+      {},
+    );
+
+    expect(config).toBe('ambiguous');
+  });
+
+  it('still resolves the pinned org when organizationId is given', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection());
+    await seedConnection(t, 'org_b', oidcConnection());
+
+    const config = await t.query(
+      internal.enterprise_sso.internal_queries.resolveSignInConfig,
+      { organizationId: 'org_b' },
+    );
+
+    expect(config).not.toBe('ambiguous');
+    if (config && config !== 'ambiguous') {
+      expect(config.organizationId).toBe('org_b');
+    }
+  });
+
+  it('ignores disabled rows when counting (one enabled + one disabled resolves)', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', { ...oidcConnection(), enabled: false });
+    await seedConnection(t, 'org_b', oidcConnection());
+
+    const config = await t.query(
+      internal.enterprise_sso.internal_queries.resolveSignInConfig,
+      {},
+    );
+
+    expect(config).not.toBe('ambiguous');
+    if (config && config !== 'ambiguous') {
+      expect(config.organizationId).toBe('org_b');
+    }
+  });
+});
+
+describe('resolveSamlConfig without org context', () => {
+  it('returns "ambiguous" when two orgs have enabled connections', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', samlConnection());
+    await seedConnection(t, 'org_b', samlConnection());
+
+    const config = await t.query(
+      internal.enterprise_sso.internal_queries.resolveSamlConfig,
+      {},
+    );
+
+    expect(config).toBe('ambiguous');
+  });
+});
+
+describe('isConfigured (login page probe)', () => {
+  it('reports multiple:false with a single enabled connection', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection());
+
+    const probe = await t.query(api.enterprise_sso.queries.isConfigured, {});
+
+    expect(probe.enabled).toBe(true);
+    expect(probe.multiple).toBe(false);
+  });
+
+  it('reports multiple:true with two enabled connections', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection());
+    await seedConnection(t, 'org_b', oidcConnection());
+
+    const probe = await t.query(api.enterprise_sso.queries.isConfigured, {});
+
+    expect(probe.enabled).toBe(true);
+    expect(probe.multiple).toBe(true);
+  });
+});
+
+describe('listSelectable (manual picker for domain-less connections)', () => {
+  it('lists only enabled connections without an email domain', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_domainless', oidcConnection());
+    await seedConnection(
+      t,
+      'org_routed',
+      oidcConnection({ domain: 'a.example' }),
+    );
+    await seedConnection(t, 'org_disabled', {
+      ...oidcConnection(),
+      enabled: false,
+    });
+
+    const list = await t.query(api.enterprise_sso.queries.listSelectable, {});
+
+    expect(list).toEqual([
+      {
+        organizationId: 'org_domainless',
+        displayName: 'Enterprise SSO',
+        protocol: 'oidc',
+      },
+    ]);
+  });
+});
+
+describe('discoverByEmail with several enabled connections', () => {
+  it('routes to the org whose configured domain matches the email', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection({ domain: 'a.example' }));
+    await seedConnection(t, 'org_b', oidcConnection({ domain: 'b.example' }));
+
+    const match = await t.query(
+      internal.enterprise_sso.internal_queries.discoverByEmail,
+      { email: 'user@b.example' },
+    );
+
+    expect(match).toEqual({ organizationId: 'org_b', protocol: 'oidc' });
+  });
+
+  it('returns null instead of guessing when no domain matches', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection({ domain: 'a.example' }));
+    await seedConnection(t, 'org_b', oidcConnection({ domain: 'b.example' }));
+
+    const match = await t.query(
+      internal.enterprise_sso.internal_queries.discoverByEmail,
+      { email: 'user@other.example' },
+    );
+
+    expect(match).toBeNull();
+  });
+
+  it('keeps the single-connection fallback (no domain configured)', async () => {
+    const t = convexTest(schema, modules);
+    await seedConnection(t, 'org_a', oidcConnection());
+
+    const match = await t.query(
+      internal.enterprise_sso.internal_queries.discoverByEmail,
+      { email: 'user@anything.example' },
+    );
+
+    expect(match).toEqual({ organizationId: 'org_a', protocol: 'oidc' });
+  });
+});

--- a/services/platform/convex/enterprise_sso/internal_queries.ts
+++ b/services/platform/convex/enterprise_sso/internal_queries.ts
@@ -48,11 +48,15 @@ async function loadConnection(
   return { organizationId, config: parsed.data };
 }
 
-/** First ENABLED connection across orgs (single-org deployments / email-first
- *  discovery). Ranges the `(domain, key)` slice of `configCache`. */
+/** The ONLY enabled connection across orgs (single-org deployments /
+ *  email-first discovery). Ranges the `(domain, key)` slice of `configCache`.
+ *  With two or more enabled connections there is no right answer without org
+ *  context, so this returns `'ambiguous'` — callers must ask (email-first
+ *  routing) rather than guess; guessing sent users to another org's IdP. */
 async function loadSingleEnabled(
   ctx: QueryCtx,
-): Promise<LoadedConnection | null> {
+): Promise<LoadedConnection | 'ambiguous' | null> {
+  let found: LoadedConnection | null = null;
   for await (const row of ctx.db
     .query('configCache')
     .withIndex('by_domain_key', (q) =>
@@ -61,10 +65,11 @@ async function loadSingleEnabled(
     if (row.enabled !== true) continue;
     const parsed = ssoConnectionFileSchema.safeParse(row.config);
     if (parsed.success && parsed.data.enabled) {
-      return { organizationId: row.organizationId, config: parsed.data };
+      if (found) return 'ambiguous';
+      found = { organizationId: row.organizationId, config: parsed.data };
     }
   }
-  return null;
+  return found;
 }
 
 const resolvedSignInConfigValidator = v.object({
@@ -89,16 +94,23 @@ const resolvedSignInConfigValidator = v.object({
 /**
  * Resolve the org's OIDC/OAuth2 sign-in config (NON-secret). Returns null when
  * no enabled OIDC/OAuth2 connection exists. When `organizationId` is omitted,
- * resolves the single enabled connection. The caller fetches the client id /
- * secret separately from the secrets sidecar.
+ * resolves the single enabled connection — or `'ambiguous'` when several orgs
+ * have one, so the caller can ask for the user's email instead of guessing.
+ * The caller fetches the client id / secret separately from the secrets
+ * sidecar.
  */
 export const resolveSignInConfig = internalQuery({
   args: { organizationId: v.optional(v.string()) },
-  returns: v.union(resolvedSignInConfigValidator, v.null()),
+  returns: v.union(
+    resolvedSignInConfigValidator,
+    v.null(),
+    v.literal('ambiguous'),
+  ),
   handler: async (ctx, args) => {
     const conn = args.organizationId
       ? await loadConnection(ctx, args.organizationId)
       : await loadSingleEnabled(ctx);
+    if (conn === 'ambiguous') return 'ambiguous';
     if (!conn || !conn.config.enabled || !conn.config.oidc) return null;
     const c = conn.config.oidc;
     const p = conn.config.provisioning;
@@ -157,8 +169,11 @@ export const resolveProvisioning = internalQuery({
 
 /**
  * Resolve the SAML config (NON-secret) for the ACS / metadata handlers. Returns
- * null when no enabled SAML connection exists. The SP private key is fetched
- * separately from the secrets sidecar by the ACS handler.
+ * null when no enabled SAML connection exists. When `organizationId` is
+ * omitted, resolves the single enabled connection — or `'ambiguous'` when
+ * several orgs have one (same contract as `resolveSignInConfig`). The SP
+ * private key is fetched separately from the secrets sidecar by the ACS
+ * handler.
  */
 export const resolveSamlConfig = internalQuery({
   args: { organizationId: v.optional(v.string()) },
@@ -174,11 +189,13 @@ export const resolveSamlConfig = internalQuery({
       attributeMappings: v.optional(attributeMappingValidator),
     }),
     v.null(),
+    v.literal('ambiguous'),
   ),
   handler: async (ctx, args) => {
     const conn = args.organizationId
       ? await loadConnection(ctx, args.organizationId)
       : await loadSingleEnabled(ctx);
+    if (conn === 'ambiguous') return 'ambiguous';
     if (!conn || !conn.config.enabled || !conn.config.saml) return null;
     const s = conn.config.saml;
     return {
@@ -211,6 +228,7 @@ export const discoverByEmail = internalQuery({
   handler: async (ctx, args) => {
     const domain = args.email.split('@')[1]?.toLowerCase();
     let firstEnabled: LoadedConnection | null = null;
+    let enabledCount = 0;
     let domainMatch: LoadedConnection | null = null;
     for await (const row of ctx.db
       .query('configCache')
@@ -223,13 +241,17 @@ export const discoverByEmail = internalQuery({
         continue;
       }
       const conn = { organizationId: row.organizationId, config: parsed.data };
+      enabledCount += 1;
       if (!firstEnabled) firstEnabled = conn;
       if (domain && parsed.data.domain?.toLowerCase() === domain) {
         domainMatch = conn;
         break;
       }
     }
-    const chosen = domainMatch ?? firstEnabled;
+    // No domain match: fall back only when the answer is unambiguous (exactly
+    // one enabled connection). With several, guessing routed users to another
+    // org's IdP — return null so the login flow asks for the right email.
+    const chosen = domainMatch ?? (enabledCount === 1 ? firstEnabled : null);
     if (!chosen || !chosen.config.protocol) return null;
     return {
       organizationId: chosen.organizationId,

--- a/services/platform/convex/enterprise_sso/login/authorize_handler.test.ts
+++ b/services/platform/convex/enterprise_sso/login/authorize_handler.test.ts
@@ -81,6 +81,31 @@ describe('ssoAuthorizeHandler — failure path is a readable redirect, not a 500
     expect(target.pathname).toBe('/log-in');
   });
 
+  it('bounces to the login page asking for the email when several orgs have SSO (no guess)', async () => {
+    // Multi-org deployments: resolveSignInConfig reports 'ambiguous' when no
+    // org context is given. The old behaviour silently used the first enabled
+    // connection — the user landed on another org's IdP.
+    process.env.SITE_URL = 'https://app.example.com';
+    const runAction = vi.fn();
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue('ambiguous'),
+      runAction,
+    } as unknown as ActionCtx;
+
+    const res = await ssoAuthorizeHandler(ctx, authorizeRequest());
+    delete process.env.SITE_URL;
+
+    expect(res.status).toBe(302);
+    const target = new URL(res.headers.get('Location') as string);
+    expect(target.origin).toBe('https://app.example.com');
+    expect(target.pathname).toBe('/log-in');
+    expect(target.searchParams.get('error')).toBe(
+      'sso.errors.multipleConnections',
+    );
+    // It must never have proceeded to fetch secrets for a guessed connection.
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
   it('redirects to the login page when BETTER_AUTH_SECRET is unset', async () => {
     // A missing secret is a deployment misconfig; assert it does not 500 either
     // (this branch already returned a 500 body before — keep it non-fatal for

--- a/services/platform/convex/enterprise_sso/login/authorize_handler.ts
+++ b/services/platform/convex/enterprise_sso/login/authorize_handler.ts
@@ -60,6 +60,13 @@ export async function ssoAuthorizeHandler(
       internal.enterprise_sso.internal_queries.resolveSignInConfig,
       { organizationId },
     );
+    if (config === 'ambiguous') {
+      // Several orgs have SSO enabled and this request carried no org context.
+      // Never guess a connection (that sends the user to another org's IdP) —
+      // bounce to the login page and ask for the organization email, which
+      // routes via /api/sso/discover.
+      return redirectWithError(publicOrigin, 'sso.errors.multipleConnections');
+    }
     if (!config) {
       return new Response('No SSO configuration found', { status: 404 });
     }

--- a/services/platform/convex/enterprise_sso/login/callback_handler.ts
+++ b/services/platform/convex/enterprise_sso/login/callback_handler.ts
@@ -177,6 +177,14 @@ export async function ssoCallbackHandler(
       internal.enterprise_sso.internal_queries.resolveSignInConfig,
       { organizationId: state.organizationId },
     );
+    if (config === 'ambiguous') {
+      // Only reachable for a state minted without an org (pre-#2082 flows) on
+      // a deployment where several orgs enable SSO — never guess a connection.
+      return redirectWithError(
+        frontendOrigin,
+        'sso.errors.multipleConnections',
+      );
+    }
     if (!config) {
       return redirectWithError(frontendOrigin, 'SSO configuration not found');
     }

--- a/services/platform/convex/enterprise_sso/queries.ts
+++ b/services/platform/convex/enterprise_sso/queries.ts
@@ -20,8 +20,11 @@ export const isConfigured = query({
     enabled: v.boolean(),
     providerType: v.optional(v.string()),
     seamlessSsoEnabled: v.optional(v.boolean()),
+    multiple: v.optional(v.boolean()),
   }),
   handler: async (ctx) => {
+    let first: { providerType?: string } | null = null;
+    let enabledCount = 0;
     for await (const row of ctx.db
       .query('configCache')
       .withIndex('by_domain_key', (q) =>
@@ -30,13 +33,69 @@ export const isConfigured = query({
       if (row.enabled !== true) continue;
       const parsed = ssoConnectionFileSchema.safeParse(row.config);
       if (!parsed.success || !parsed.data.enabled) continue;
-      return {
-        enabled: true,
+      enabledCount += 1;
+      first ??= {
         providerType: parsed.data.oidc?.providerId ?? parsed.data.protocol,
-        // Seamless (silent) SSO is now driven by a query param, not stored config.
-        seamlessSsoEnabled: false,
       };
+      if (enabledCount > 1) break;
     }
-    return { enabled: false };
+    if (!first) return { enabled: false };
+    return {
+      enabled: true,
+      providerType: first.providerType,
+      // Seamless (silent) SSO is now driven by a query param, not stored config.
+      seamlessSsoEnabled: false,
+      // With several orgs' connections enabled, sign-in must be routed by the
+      // organization email — the login page asks for it before redirecting.
+      multiple: enabledCount > 1,
+    };
+  },
+});
+
+/** Practical cap for the login-page picker — also bounds what an anonymous
+ *  visitor can enumerate in one query. */
+const MAX_SELECTABLE_CONNECTIONS = 20;
+
+/**
+ * Public login-page query: the enabled connections WITHOUT an email domain.
+ * Email routing can never reach them (matching is by exact domain), so the SSO
+ * step lists them for manual selection instead of dead-ending. Deliberate
+ * disclosure: their display names are visible pre-auth — setting a domain on a
+ * connection removes it from this list, so the operator controls the exposure.
+ */
+export const listSelectable = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      organizationId: v.string(),
+      displayName: v.string(),
+      protocol: v.string(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const selectable: {
+      organizationId: string;
+      displayName: string;
+      protocol: string;
+    }[] = [];
+    for await (const row of ctx.db
+      .query('configCache')
+      .withIndex('by_domain_key', (q) =>
+        q.eq('domain', SSO_CONFIG_DOMAIN).eq('key', SSO_CONNECTION_KEY),
+      )) {
+      if (row.enabled !== true) continue;
+      const parsed = ssoConnectionFileSchema.safeParse(row.config);
+      if (!parsed.success || !parsed.data.enabled || !parsed.data.protocol) {
+        continue;
+      }
+      if (parsed.data.domain) continue;
+      selectable.push({
+        organizationId: row.organizationId,
+        displayName: parsed.data.displayName,
+        protocol: parsed.data.protocol,
+      });
+      if (selectable.length >= MAX_SELECTABLE_CONNECTIONS) break;
+    }
+    return selectable;
   },
 });

--- a/services/platform/convex/enterprise_sso/saml/acs_handler.ts
+++ b/services/platform/convex/enterprise_sso/saml/acs_handler.ts
@@ -42,6 +42,12 @@ export async function samlAcsHandler(
       internal.enterprise_sso.internal_queries.resolveSamlConfig,
       { organizationId: relayState },
     );
+    if (config === 'ambiguous') {
+      // IdP-initiated POST without a RelayState org on a deployment where
+      // several orgs enable SSO — never guess which connection to validate
+      // the assertion against.
+      return loginRedirect(origin, 'sso.errors.multipleConnections');
+    }
     if (!config) {
       return loginRedirect(origin, 'SAML is not configured');
     }

--- a/services/platform/convex/enterprise_sso/saml/login_handler.ts
+++ b/services/platform/convex/enterprise_sso/saml/login_handler.ts
@@ -1,5 +1,6 @@
 import { internal } from '../../_generated/api';
 import type { ActionCtx } from '../../_generated/server';
+import { redirectWithError } from '../login/redirect_with_error';
 import { samlEndpoints } from './metadata_handler';
 
 /**
@@ -18,6 +19,12 @@ export async function samlLoginHandler(
       internal.enterprise_sso.internal_queries.resolveSamlConfig,
       { organizationId: org },
     );
+    if (config === 'ambiguous') {
+      // Several orgs have SSO enabled and no org context was given — same
+      // never-guess rule as the OIDC authorize handler.
+      const publicOrigin = process.env.SITE_URL || new URL(req.url).origin;
+      return redirectWithError(publicOrigin, 'sso.errors.multipleConnections');
+    }
     if (!config) {
       return new Response('SAML is not configured', { status: 404 });
     }

--- a/services/platform/convex/enterprise_sso/saml/metadata_handler.ts
+++ b/services/platform/convex/enterprise_sso/saml/metadata_handler.ts
@@ -30,10 +30,14 @@ export async function samlMetadataHandler(
   try {
     const url = new URL(req.url);
     const org = url.searchParams.get('org') ?? undefined;
-    const config = await ctx.runQuery(
+    const resolved = await ctx.runQuery(
       internal.enterprise_sso.internal_queries.resolveSamlConfig,
       { organizationId: org },
     );
+    // SP metadata is org-independent apart from the signing certificate — an
+    // ambiguous (multi-org, no `org` param) lookup serves the generic defaults,
+    // same as no connection at all.
+    const config = resolved === 'ambiguous' ? null : resolved;
     const { spEntityId, acsUrl } = samlEndpoints();
     const wantSigned = config?.wantAssertionsSigned ?? true;
 

--- a/services/platform/lib/i18n/keys-dynamic.txt
+++ b/services/platform/lib/i18n/keys-dynamic.txt
@@ -264,6 +264,8 @@ apps.list.merge
 # (`redirectWithError`), which the login page renders via `t(ssoError)` — a
 # runtime value the scanner can't tie back. The Entra AADSTS→message map lives
 # in convex/enterprise_sso/entra_id/error_codes.ts; the generic server-error
-# fallback (`sso.errors.serverError`) is passed as a literal from the handlers
-# but under a namespace the client-source scanner can't resolve.
+# fallback (`sso.errors.serverError`) and the multi-org "enter your email"
+# bounce (`sso.errors.multipleConnections`) are passed as literals from the
+# handlers but under a namespace the client-source scanner can't resolve.
 auth.sso.errors.serverError
+auth.sso.errors.multipleConnections

--- a/services/platform/lib/shared/schemas/enterprise_sso.ts
+++ b/services/platform/lib/shared/schemas/enterprise_sso.ts
@@ -194,6 +194,9 @@ export const ssoConnectionViewSchema = z.object({
       authSecretSet: z.boolean(),
     })
     .optional(),
+  /** Another org on this deployment also has an enabled connection — without
+   *  an email domain this one is unroutable by address (form warns). */
+  otherOrgsEnabled: z.boolean().optional(),
 });
 export type SsoConnectionView = z.infer<typeof ssoConnectionViewSchema>;
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -560,6 +560,12 @@
       "signingIn": "Anmeldung läuft...",
       "loginButton": "Anmelden",
       "continueWithSso": "Weiter mit SSO",
+      "ssoTitle": "Mit SSO anmelden",
+      "ssoDescription": "Gib die E-Mail-Adresse deiner Organisation ein — sie bestimmt die passende Anmeldung.",
+      "ssoBackToLogin": "Zurück zur Anmeldung",
+      "ssoPickOrganization": "Oder wähle deine Organisation",
+      "ssoEmailRequired": "Gib die E-Mail-Adresse deiner Organisation ein, um mit SSO fortzufahren.",
+      "ssoEmailNoMatch": "Für diese E-Mail-Domäne ist Single Sign-On nicht eingerichtet. Prüfe die Adresse oder wende dich an deine Administration.",
       "continueWithPasskey": "Mit einem Passkey anmelden",
       "passkeyFailed": "Passkey-Anmeldung fehlgeschlagen oder abgebrochen. Versuche es erneut oder nutze dein Passwort.",
       "wrongCredentials": "Falsche E-Mail oder falsches Passwort",
@@ -665,6 +671,7 @@
     "sso": {
       "errors": {
         "serverError": "Single Sign-On konnte wegen eines Serverfehlers nicht abgeschlossen werden. Versuche es erneut oder wende dich an deine Administration, falls das Problem bestehen bleibt.",
+        "multipleConnections": "Hier nutzen mehrere Organisationen Single Sign-On. Gib zuerst die E-Mail-Adresse deiner Organisation ein und versuche es dann erneut.",
         "mfaRequired": "Für die Anmeldung ist eine Multi-Faktor-Authentifizierung erforderlich.",
         "conditionalAccessBlocked": "Die Anmeldung wurde durch eine Richtlinie für bedingten Zugriff blockiert.",
         "userNotAssigned": "Dein Konto ist dieser Anwendung nicht zugewiesen. Wende dich an deine Administration, um Zugriff anzufordern.",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5959,6 +5959,10 @@
         },
         "redirectUrlLabel": "In Entra zu registrierende Weiterleitungs-URL",
         "redirectUrlHelp": "Registrieren Sie genau diese URL als \"Web\"-Weiterleitungs-URI in Ihrer App-Registrierung — sie muss exakt übereinstimmen (Schema, Host, Pfad, kein abschließender Schrägstrich), sonst schlägt die Anmeldung mit AADSTS50011 fehl.",
+        "domainWarning": {
+          "title": "Keine E-Mail-Domäne gesetzt",
+          "description": "Mehrere Organisationen dieses Deployments nutzen SSO. Ohne E-Mail-Domäne kann die Anmeldung Mitglieder nicht per Adresse dieser Verbindung zuordnen — sie wird stattdessen öffentlich unter ihrem Anzeigenamen auf dem SSO-Bildschirm gelistet."
+        },
         "deploymentWarning": {
           "title": "Deployment für SSO nicht vollständig konfiguriert",
           "callbackMissing": "Die Weiterleitungs-URL ist leer, weil SITE_URL auf dem Server nicht gesetzt ist. Die SSO-Anmeldung schlägt fehl, bis dies konfiguriert ist.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -560,6 +560,12 @@
       "signingIn": "Signing in...",
       "loginButton": "Log in",
       "continueWithSso": "Continue with SSO",
+      "ssoTitle": "Sign in with SSO",
+      "ssoDescription": "Enter your organization email address — it selects your organization's sign-in.",
+      "ssoBackToLogin": "Back to log in",
+      "ssoPickOrganization": "Or choose your organization",
+      "ssoEmailRequired": "Enter your organization email address to continue with SSO.",
+      "ssoEmailNoMatch": "Single sign-on is not set up for this email domain. Check the address, or contact your administrator.",
       "continueWithPasskey": "Sign in with a passkey",
       "passkeyFailed": "Passkey sign-in failed or was cancelled. Try again or use your password.",
       "wrongCredentials": "Wrong email or password",
@@ -665,6 +671,7 @@
     "sso": {
       "errors": {
         "serverError": "Single sign-on could not complete due to a server error. Please try again, or contact your administrator if it persists.",
+        "multipleConnections": "More than one organization uses single sign-on here. Enter your organization email address first, then try again.",
         "mfaRequired": "Multi-factor authentication is required to sign in.",
         "conditionalAccessBlocked": "Sign-in was blocked by a conditional-access policy.",
         "userNotAssigned": "Your account is not assigned to this application. Contact your administrator to request access.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6223,6 +6223,10 @@
         },
         "redirectUrlLabel": "Redirect URL to register in Entra",
         "redirectUrlHelp": "Register this exact URL as a \"Web\" redirect URI in your app registration — it must byte-match (scheme, host, path, no trailing slash) or sign-in fails with AADSTS50011.",
+        "domainWarning": {
+          "title": "No email domain set",
+          "description": "Several organizations on this deployment use SSO. Without an email domain, sign-in cannot route members to this connection by address — it is instead listed publicly by its display name on the SSO screen."
+        },
         "deploymentWarning": {
           "title": "Deployment not fully configured for SSO",
           "callbackMissing": "The redirect URL is empty because SITE_URL is not set on the server. SSO sign-in will fail until it is configured.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -561,6 +561,12 @@
       "signingIn": "Connexion en cours...",
       "loginButton": "Se connecter",
       "continueWithSso": "Continuer avec SSO",
+      "ssoTitle": "Se connecter avec SSO",
+      "ssoDescription": "Saisis l’adresse e-mail de ton organisation — elle détermine la connexion à utiliser.",
+      "ssoBackToLogin": "Retour à la connexion",
+      "ssoPickOrganization": "Ou choisis ton organisation",
+      "ssoEmailRequired": "Saisis l’adresse e-mail de ton organisation pour continuer avec SSO.",
+      "ssoEmailNoMatch": "L’authentification unique n’est pas configurée pour ce domaine de messagerie. Vérifie l’adresse ou contacte ton administration.",
       "continueWithPasskey": "Se connecter avec un passkey",
       "passkeyFailed": "La connexion par passkey a échoué ou a été annulée. Réessaie ou utilise ton mot de passe.",
       "wrongCredentials": "Courriel ou mot de passe incorrect",
@@ -666,6 +672,7 @@
     "sso": {
       "errors": {
         "serverError": "L’authentification unique n’a pas pu aboutir en raison d’une erreur serveur. Réessaie, ou contacte ton administration si le problème persiste.",
+        "multipleConnections": "Plusieurs organisations utilisent l’authentification unique ici. Saisis d’abord l’adresse e-mail de ton organisation, puis réessaie.",
         "mfaRequired": "Une authentification multifacteur est requise pour te connecter.",
         "conditionalAccessBlocked": "La connexion a été bloquée par une stratégie d’accès conditionnel.",
         "userNotAssigned": "Ton compte n’est pas affecté à cette application. Contacte ton administration pour demander l’accès.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5960,6 +5960,10 @@
         },
         "redirectUrlLabel": "URL de redirection à enregistrer dans Entra",
         "redirectUrlHelp": "Enregistrez exactement cette URL comme URI de redirection « Web » dans votre inscription d'application — elle doit correspondre au caractère près (schéma, hôte, chemin, sans barre oblique finale), sinon la connexion échoue avec AADSTS50011.",
+        "domainWarning": {
+          "title": "Aucun domaine de messagerie défini",
+          "description": "Plusieurs organisations de ce déploiement utilisent le SSO. Sans domaine de messagerie, la connexion ne peut pas orienter les membres par adresse — elle est alors listée publiquement sous son nom affiché sur l’écran SSO."
+        },
         "deploymentWarning": {
           "title": "Déploiement non entièrement configuré pour le SSO",
           "callbackMissing": "L'URL de redirection est vide car SITE_URL n'est pas défini sur le serveur. La connexion SSO échouera tant qu'il ne sera pas configuré.",


### PR DESCRIPTION
## Summary

With several orgs' SSO connections enabled on one deployment, sign-in resolution silently used whichever enabled connection the `configCache` index yielded first (#2082 fixed the callback half; the authorize side kept the guess) — no-context entries landed users on **another org's IdP** with no indication anything was wrong.

This PR makes multi-org sign-in explicit end-to-end:

- **Server never guesses.** `loadSingleEnabled` reports `'ambiguous'` on a second enabled connection; `resolveSignInConfig` / `resolveSamlConfig` propagate it, and the authorize / SAML login / callback / ACS handlers bounce readably to the login page (`sso.errors.multipleConnections`) instead of picking one. `discoverByEmail` falls back only when **exactly one** connection is enabled.
- **Dedicated SSO step.** On a multi-connection deployment, *Continue with SSO* navigates to `/log-in?method=sso` — organization email only (routes by domain via `/api/sso/discover`), no credential form. Inline hints for missing email / unmatched domain.
- **Manual org picker.** Connections **without** an email domain can never match an address, so the step lists them by display name for manual selection (`listSelectable`, capped at 20). Deliberate pre-auth disclosure, operator-controlled: setting a domain removes a connection from the list. Documented.
- **Org-context entries pin their org.** The dashboard OneDrive reauth button now passes `organizationId`.
- **Single-connection deployments are unchanged** — one click straight to the IdP.

## Verification

- Regression tests verified red→green: 3 new cases fail on the old resolution code, pass on the new.
- Live e2e on the dev stack against a **real Entra tenant**: single-connection direct login; domain-routed login incl. **JIT user creation** (name from IdP claims, `member` role, owner untouched); manual-picker login (existing-user find branch); ambiguous bounce; unmatched-domain hint; readable error for a broken connection. MFA included.
- 9 convex-test cases (resolution / discovery / `isConfigured.multiple` / `listSelectable`), 8 UI cases (step navigation, hints, picker, back), 1 handler case (ambiguous → 302).

## Done checklist

- [x] Gate green — format / oxlint (type-aware) / tsc / platform server+UI tests / i18n parity / docs suite pass locally
- [x] Security / SAST clean — opengrep 0 findings (incl. pre-commit scan)
- [x] Migration — N/A: no data-model or config-schema change (`configCache` read-only)
- [x] Tests carry the change — happy path + edges + error paths (18 new/updated cases)
- [x] User-visible strings localized — en / de / fr (7 keys; de-CH holds only overrides)
- [x] Docs updated — multi-org routing + picker section in `enterprise-sso.md` (3 locales)
- [x] Accessibility — labelled inputs, `role=alert` + `aria-live` hints, keyboard-reachable buttons
- [x] Behaviour verified by observing the real outcome — real Entra logins, three entry paths
- [x] Instructions/docs describing changed paths updated
- [x] Atomic conventional commit, branched off main

## Notes for review

- Start with `internal_queries.ts` — the resolution semantics (`'ambiguous'` sentinel) drive everything else.
- Behaviour change: multi-org deployments that happened to work via first-enabled fallback now ask for the organization email — intended.
- `listSelectable` intentionally exposes domain-less connections' display names pre-auth; trade-off documented in code and docs.