### PR TITLE
fix(platform): keep search input bordered while autofill-suppressed

### DIFF
--- a/services/platform/app/components/ui/forms/search-input.test.tsx
+++ b/services/platform/app/components/ui/forms/search-input.test.tsx
@@ -64,6 +64,22 @@ describe('SearchInput', () => {
     });
   });
 
+  describe('default chrome', () => {
+    // The input is natively readOnly until focus purely to suppress
+    // password-manager autofill; that trick must not select Input's
+    // borderless read-only display variant (#2131) — a search box is
+    // always an editable control and keeps the bordered default chrome.
+    it('keeps the bordered default variant while readOnly-until-focus', () => {
+      render(
+        <SearchInput value="" onChange={vi.fn()} placeholder="Search..." />,
+      );
+      const input = screen.getByPlaceholderText('Search...');
+      expect(input).toHaveAttribute('readonly');
+      expect(input).toHaveClass('bg-input');
+      expect(input).not.toHaveClass('bg-transparent');
+    });
+  });
+
   describe('interactions', () => {
     it('calls onChange when typing', async () => {
       const handleChange = vi.fn();

--- a/services/platform/app/components/ui/forms/search-input.tsx
+++ b/services/platform/app/components/ui/forms/search-input.tsx
@@ -113,6 +113,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             data-form-type="other"
             data-bwignore="true"
             readOnly={isReadOnly}
+            // The readOnly above is an anti-autofill trick, not a read-only
+            // display state — pin the bordered variant so Input's native
+            // readOnly → borderless auto-selection doesn't strip the chrome.
+            variant="default"
             className={cn(
               'pl-10 max-w-70 h-9',
               hasError && 'border-destructive focus-visible:ring-destructive',


### PR DESCRIPTION
## Summary

Every `SearchInput` rendered borderless until focused — e.g. the "Search apps…" box on the Apps page looked like plain text.

Two features collided:

- `SearchInput` keeps its input natively `readOnly` until focus purely to suppress password-manager/browser autofill (#1592).
- `Input` later gained a borderless read-only display variant that **auto-selects** whenever the input is natively `readOnly` and no explicit `variant` is pinned (#2131).

So every unfocused SearchInput was misread as a read-only display field and lost its ring/background; focusing removed the `readonly` attribute and the border popped back in.

## Fix

Pin `variant="default"` on the composed `Input` inside `SearchInput` — the anti-autofill `readOnly` is a focus trick, not a read-only display state. `Input`'s explicit-variant override is an existing, tested escape hatch, and `SearchInputProps` doesn't expose `variant`, so callers can't fight the pin. `Input`'s auto-selection stays intact for genuine read-only fields.

Regression test: an unfocused SearchInput carries the `readonly` attribute yet keeps the bordered default chrome (`bg-input`, not `bg-transparent`). Watched it fail on the old code and pass on the fix.

## Done checklist

- [x] **Gate green** — oxfmt `--check`, `oxlint --type-aware`, `tsc --noEmit`, full `client` vitest project (380 files / 2772 tests) all pass locally.
- [x] **Security / SAST clean** — `bun run lint:sast`: 0 findings (no boundary touched).
- [x] **Migration** — N/A: no data-model or config-schema change.
- [x] **Tests carry the change** — regression test red→green; `input.test.tsx`'s readOnly-variant cases still green (happy + edge covered; no error path involved beyond the existing error-state tests, which pass).
- [x] **i18n** — N/A: no user-visible strings added or changed.
- [x] **Docs** — N/A: restores the intended existing appearance; nothing configurable changed.
- [x] **Accessibility** — unchanged semantics; existing axe audits in the suite pass.
- [x] **Behaviour observed** — Storybook `Forms/SearchInput` Default story rendered in real Chromium: the unfocused input shows the bordered chrome again.
- [x] **Instructions/docs for changed paths** — N/A: no documented path, command, or pattern changed.
- [x] **Atomic conventional commit**, branched off `main`.

## Blast radius

Only `search-input.tsx` uses the readonly-until-focus trick (`removeAttribute('readonly')`). The other toggled `readOnly={...}` usages (`chat.tsx:178`, `skills-table.tsx:263`) are component-level props, not `Input` composition, and are unaffected.