### PR TITLE
fix(platform): type-sound row clone in folder-listing test

### DIFF
--- a/services/platform/convex/documents/list_files_by_folder.test.ts
+++ b/services/platform/convex/documents/list_files_by_folder.test.ts
@@ -40,9 +40,9 @@ function createMockCtx(folders: MockFolder[], documents: MockDocument[]) {
             },
           };
           cb(qb);
-          const source: Record<string, unknown>[] = structuredClone(
-            table === 'folders' ? folders : documents,
-          );
+          const source: Record<string, unknown>[] = (
+            table === 'folders' ? folders : documents
+          ).map((row) => Object.fromEntries(Object.entries(row)));
           const rows = source.filter((row) =>
             Object.entries(filters).every(([k, val]) => row[k] === val),
           );


### PR DESCRIPTION
Main is red on **Type check** since #2324 squash-merged with its CI-only lint fix in the `structuredClone` form: `structuredClone` preserves the `MockFolder[] | MockDocument[]` element types, which are not assignable to `Record<string, unknown>[]` (TS2322 at `convex/documents/list_files_by_folder.test.ts:43`).

One line: `Object.fromEntries(Object.entries(row))` keeps the defensive per-row shallow copy, satisfies the type-aware `no-map-spread` rule that motivated the original change, and produces the `Record<string, unknown>` element type the dynamic index filter needs.

Verified locally: strict typecheck clean, the 4 folder-listing tests pass, platform oxlint clean.