### PR TITLE
fix(cli): unbreak the macOS install and first-run tale dev experience

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -92,15 +92,19 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: '1.3.12'
+          # 1.3.12's `bun build --compile` emits a truncated macOS code
+          # signature (oven-sh/bun#29120): users' kernels SIGKILL the binary
+          # while CI's SIP-disabled runners run it fine. Keep >= 1.3.13 and
+          # keep the "Verify macOS code signature" step below.
+          bun-version: '1.3.13'
 
       - name: Restore Bun install cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: bun-install-${{ runner.os }}-1.3.12-${{ hashFiles('bun.lock') }}
+          key: bun-install-${{ runner.os }}-1.3.13-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            bun-install-${{ runner.os }}-1.3.12-
+            bun-install-${{ runner.os }}-1.3.13-
 
       - name: Install dependencies
         working-directory: tools/cli
@@ -142,6 +146,14 @@ jobs:
             chmod +x ${{ matrix.artifact }}
           fi
           ./${{ matrix.artifact }} --version
+
+      # Running the binary is not enough on macOS: GitHub runners have SIP
+      # disabled, so they execute binaries whose signature the stock kernel
+      # rejects with SIGKILL. Validate the signature statically instead.
+      - name: Verify macOS code signature
+        if: matrix.platform == 'macos'
+        working-directory: tools/cli/dist
+        run: codesign --verify --strict --verbose=2 ${{ matrix.artifact }}
 
       - name: Run smoke tests
         working-directory: tools/cli

--- a/packages/shared/src/classify/sources/docker-compose.test.ts
+++ b/packages/shared/src/classify/sources/docker-compose.test.ts
@@ -17,6 +17,14 @@ describe('classifyDockerCompose', () => {
     expect(c('a1b2c3d4e5f6: Already exists').kind).toBe('progress');
   });
 
+  it('surfaces per-image pull milestones as info, keeping layer churn collapsed', () => {
+    expect(c(' db Pulling ').kind).toBe('info');
+    expect(c(' db Pulling ').text).toBe('db pulling');
+    expect(c(' ✔ platform Pulled ').text).toBe('platform pulled');
+    expect(c(' db Pulled \r').text).toBe('db pulled');
+    expect(c('a1b2c3d4e5f6: Pulling fs layer').kind).toBe('progress');
+  });
+
   it('relabels each lifecycle verb to a clean lowercased status', () => {
     expect(c(' Container tale-db-1  Started').text).toBe('tale-db-1 started');
     expect(c(' Container tale-db-1  Created').text).toBe('tale-db-1 created');

--- a/packages/shared/src/classify/sources/docker-compose.ts
+++ b/packages/shared/src/classify/sources/docker-compose.ts
@@ -16,6 +16,11 @@ import { noise } from '../kinds';
 
 const DOCKER_LAYER =
   /^[0-9a-f]{12,}:\s+(Pulling fs layer|Waiting|Downloading|Verifying Checksum|Download complete|Extracting|Pull complete|Already exists)/;
+// Per-image pull milestones ("db Pulling" / "db Pulled"). Unlike the layer
+// churn above these are few and meaningful — on a first run the pull is the
+// only thing happening for minutes, so they must surface, not collapse.
+const DOCKER_IMAGE_PULL =
+  /^\s*(?:[⠿⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇✔✓]\s*)?(\S+)\s+(Pulling|Pulled)\s*$/;
 const DOCKER_LIFECYCLE =
   /^\s*(?:[⠿⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇✔✓]\s*)?(Container|Network|Volume)\s+(\S+)\s+(Creating|Created|Starting|Started|Healthy|Running|Recreate|Recreated|Removing|Removed|Waiting|Stopping|Stopped)\b/;
 const DOCKER_ERROR =
@@ -28,6 +33,15 @@ export const classifyDockerCompose: Classifier = (line) => {
     return {
       kind: 'progress',
       status: { phase: 'pull' },
+      raw: line,
+      source: 'docker-compose',
+    };
+  }
+  const pull = body.match(DOCKER_IMAGE_PULL);
+  if (pull) {
+    return {
+      kind: 'info',
+      text: `${pull[1]} ${pull[2].toLowerCase()}`,
       raw: line,
       source: 'docker-compose',
     };

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -248,18 +248,27 @@ function Install-Binary {
     }
 }
 
-# Smoke-test the freshly installed binary by running --version. The version
-# string is folded into the success message when available.
+# Smoke-test the freshly installed binary by running --version. A binary that
+# cannot execute (corrupt download, blocked by policy) must fail the install
+# here — reporting success for a dead binary strands the user at the very
+# next command with no explanation.
 function Verify-Installation {
     if (-not (Test-Path $script:DestPath)) {
         Write-Err "Installation failed. tale not found at $script:DestPath"
     }
     try {
         $version = & $script:DestPath --version 2>&1
-        Write-Ok "Successfully installed tale ($version)"
+        if ($LASTEXITCODE -eq 0 -and $version) {
+            Write-Ok "Successfully installed tale ($version)"
+            return
+        }
     } catch {
-        Write-Ok "Successfully installed tale"
+        # fall through to the failure report below
     }
+    Write-Info "The installed binary did not run. Common causes:"
+    Write-Info "  - A corrupt download: re-run this installer to fetch it again."
+    Write-Info "  - Antivirus or an execution policy blocking $script:DestPath."
+    Write-Err "Installation failed. 'tale --version' did not succeed."
 }
 
 function Main {
@@ -273,9 +282,9 @@ function Main {
     if (-not $script:ExistingTale) {
         Write-Info "Restart your terminal for PATH changes to take effect."
     }
-    # Hand off to the guided, TypeScript-driven setup: it installs Docker if
-    # needed and scaffolds a project — zero prerequisites from here.
-    Write-Ok "Next: run 'tale setup' to install Docker (if needed) and create your project."
+    # Hand off to the CLI: `tale init` scaffolds a project (no prerequisites);
+    # `tale dev` then installs/starts Docker on demand and launches locally.
+    Write-Ok "Next: run 'tale init' to create your project, then 'tale dev' to launch it."
 }
 
 Main

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -20,14 +20,24 @@ error() { printf "\033[1;31mError: %s\033[0m\n" "$1" >&2; exit 1; }
 
 # Map `uname -s` to the platform suffix used in our release asset names
 # (tale_linux, tale_macos). Sets the $PLATFORM global.
+# Releases ship exactly one binary per OS — arm64 for macOS, x86_64 for
+# Linux — so reject other architectures up front with a build-from-source
+# pointer instead of letting the kernel fail later with a cryptic exec error.
 detect_platform() {
-    local os
+    local os arch
     os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
 
     case "$os" in
         linux*)  PLATFORM="linux" ;;
         darwin*) PLATFORM="macos" ;;
         *)       error "Unsupported OS: $os" ;;
+    esac
+
+    case "$PLATFORM-$arch" in
+        macos-arm64 | linux-x86_64 | linux-amd64) ;;
+        macos-*) error "The released macOS binary is arm64-only; this Mac reports ${arch}. Build from source instead: clone https://github.com/${REPO} and run 'bun run build:mac' in tools/cli." ;;
+        linux-*) error "No released binary for linux/${arch} (x86_64 only). Build from source instead: clone https://github.com/${REPO} and run 'bun run build:linux' in tools/cli." ;;
     esac
 }
 
@@ -210,20 +220,29 @@ install_binary() {
     fi
 }
 
-# Smoke-test the freshly installed binary by running --version. The version
-# string is folded into the success message when available.
+# Smoke-test the freshly installed binary by running --version. A binary that
+# cannot execute (killed by the kernel, wrong architecture, corrupt download)
+# must fail the install here — reporting success for a dead binary strands the
+# user at the very next command with no explanation.
 verify_installation() {
-    if command -v "$BINARY_NAME" &>/dev/null; then
-        local version
-        version=$("$BINARY_NAME" --version 2>/dev/null || true)
-        if [ -n "$version" ]; then
-            success "Successfully installed ${BINARY_NAME} (${version})"
-        else
-            success "Successfully installed ${BINARY_NAME}"
-        fi
-    else
+    if ! command -v "$BINARY_NAME" &>/dev/null; then
         error "Installation failed. ${BINARY_NAME} not found in PATH"
     fi
+
+    local version
+    if version=$("$BINARY_NAME" --version 2>/dev/null) && [ -n "$version" ]; then
+        success "Successfully installed ${BINARY_NAME} (${version})"
+        return
+    fi
+
+    info "The installed binary did not run. Common causes:"
+    if [ "$PLATFORM" = "macos" ]; then
+        info "  - macOS refused the binary's code signature ('Killed: 9')."
+        info "    Repair it with: codesign --remove-signature \"$(command -v ${BINARY_NAME})\" && codesign -s - \"$(command -v ${BINARY_NAME})\""
+        info "  - Gatekeeper quarantine: xattr -d com.apple.quarantine \"$(command -v ${BINARY_NAME})\""
+    fi
+    info "  - A corrupt download: re-run this installer to fetch it again."
+    error "Installation failed. '${BINARY_NAME} --version' did not succeed."
 }
 
 main() {

--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -71,20 +71,28 @@ async function openBrowser(url: string): Promise<void> {
   }
 }
 
-/** Poll `${url}/health` until it answers 200 or the attempt budget runs out. */
+/**
+ * Poll `${url}/health` until it answers 200 or the attempt budget runs out.
+ * The dev/trial proxy serves a self-signed localhost certificate, so the
+ * probe must accept it — with default TLS verification every attempt would
+ * fail and readiness would never be observed.
+ */
 async function waitForHealth(
   url: string,
   signal?: AbortSignal,
+  maxAttempts = 120,
 ): Promise<boolean> {
   const healthUrl = `${url}/health`;
-  const maxAttempts = 120;
   for (let i = 0; i < maxAttempts; i++) {
     if (signal?.aborted) return false;
     try {
       const fetchSignal = signal
         ? AbortSignal.any([AbortSignal.timeout(2000), signal])
         : AbortSignal.timeout(2000);
-      const res = await fetch(healthUrl, { signal: fetchSignal });
+      const res = await fetch(healthUrl, {
+        signal: fetchSignal,
+        tls: { rejectUnauthorized: false },
+      });
       if (res.ok) return true;
     } catch (err) {
       if (signal?.aborted) return false;
@@ -283,14 +291,25 @@ export async function runDev(options: DevOptions): Promise<void> {
   );
 
   const announce = (async (): Promise<void> => {
-    const ok = await waitForHealth(url, abortController.signal);
-    if (abortController.signal.aborted) return;
-    if (!ok) {
-      warnLine(
-        'Services did not become healthy in time — check the log above.',
-      );
-      return;
+    // Patient by design: a first run pulls several GB of images before any
+    // service can answer, so a bounded wait would declare failure mid-pull
+    // and the READY block would never print. Poll until the stack answers or
+    // compose exits (abort), with a one-time note so the wait never looks
+    // hung.
+    const NOTE_AFTER_MS = 120_000;
+    const started = Date.now();
+    let noted = false;
+    let ok = false;
+    while (!ok && !abortController.signal.aborted) {
+      ok = await waitForHealth(url, abortController.signal, 30);
+      if (!ok && !noted && Date.now() - started >= NOTE_AFTER_MS) {
+        noted = true;
+        infoLine(
+          'Still waiting for services — a first run downloads several GB of images before they can start. Leave this running; rerun with --verbose for full output.',
+        );
+      }
     }
+    if (!ok || abortController.signal.aborted) return;
     const adminKey = await fetchAdminKeyWhenReady(abortController.signal);
     if (abortController.signal.aborted) return;
     void openBrowser(url);

--- a/tools/cli/src/lib/actions/logs.ts
+++ b/tools/cli/src/lib/actions/logs.ts
@@ -50,24 +50,27 @@ export async function logs(options: LogsOptions): Promise<void> {
   let containerName: string;
 
   if (isRotatableService(service)) {
-    // Rotatable services need a color
-    let targetColor: DeploymentColor;
-
+    // Rotatable services carry a color once deployed; `tale dev` runs them
+    // colour-less. Resolve in that order so the quickstart's
+    // `tale logs platform` works before any deployment exists.
     if (color) {
-      targetColor = color;
+      containerName = `${getProjectId()}-${service}-${color}`;
     } else {
-      // Auto-detect from current deployment state
       const currentColor = await getCurrentColor(deployDir);
-      if (!currentColor) {
-        logger.error('No active deployment found');
-        logger.info('Use --color to specify blue or green explicitly');
-        throw new Error('No active deployment');
+      if (currentColor) {
+        logger.info(`Auto-detected active color: ${currentColor}`);
+        containerName = `${getProjectId()}-${service}-${currentColor}`;
+      } else {
+        const devContainer = `${getProjectId()}-${service}`;
+        if (await containerExists(devContainer)) {
+          containerName = devContainer;
+        } else {
+          logger.error('No active deployment found');
+          logger.info('Use --color to specify blue or green explicitly');
+          throw new Error('No active deployment');
+        }
       }
-      targetColor = currentColor;
-      logger.info(`Auto-detected active color: ${targetColor}`);
     }
-
-    containerName = `${getProjectId()}-${service}-${targetColor}`;
   } else {
     // Stateful services don't have colors
     if (color) {


### PR DESCRIPTION
## Why

A live walkthrough of the documented quickstart (tale.dev → docs → install → `tale init` → `tale dev`) found the self-serve path broken at two independent points:

1. **Every released macOS binary since the Bun 1.3.12 pin is killed by the kernel** (`Killed: 9`). Bun 1.3.12's `--compile` emits a truncated code signature (oven-sh/bun#29120, fixed in 1.3.13). CI's smoke test passes because GitHub's macOS runners run with SIP disabled; user machines SIGKILL the binary. The installer then reported **“Successfully installed tale”** anyway, because its `--version` probe swallowed the failure.
2. **`tale dev` never announces readiness.** The health probe fetches `https://localhost/health` with default TLS verification, which rejects the stack's self-signed certificate — so the READY block, browser auto-open, and admin key were unreachable on every run. On first runs the announcer also gave up after ~2 minutes (mid image-pull, which the docs budget at 5–10 minutes) with a false *“Services did not become healthy in time — check the log above”* — while pull progress was classified away, so the log above was empty.

## What

- **ci(cli):** Bun 1.3.12 → 1.3.13; add `codesign --verify --strict` for the macOS artifact so signature breakage fails the build instead of shipping.
- **fix(cli) installers:** `verify_installation` now fails with recovery hints when the binary can't run (both bash and PowerShell); unsupported architectures (Intel macOS, non-x86_64 Linux) are rejected up front with a build-from-source pointer; the Windows installer's next-step line no longer advertises the non-existent `tale setup`.
- **fix(cli) dev:** the health probe accepts the stack's own self-signed localhost certificate; the readiness watcher polls until compose exits instead of giving up, with a one-time first-run note.
- **fix(shared):** compose per-image pull milestones (`db Pulling` / `db Pulled`) classify as info so a first run shows signs of life; layer churn stays collapsed.
- **fix(cli) logs:** `tale logs platform` falls back to the colour-less dev container when no deployment exists, so the quickstart's troubleshooting command works on a dev-only stack.

## Testing

- `tools/cli`: `bun run typecheck` clean, `bun test` 244 pass / 0 fail.
- `packages/shared`: classifier suite 12/12 (new milestone cases included).
- Verified live on macOS 26 (arm64): released v0.2.97 binary is SIGKILLed with 'code object is not signed at all'; after `codesign --remove-signature && codesign -s -` the same binary runs — confirming the signature (not the code) is the killer, and that 1.3.13's fixed signer resolves it.
- Reproduced the silent first run + false health warning twice against ghcr with `tale dev` v0.2.97; confirmed `fetch` of the self-signed endpoint fails with `DEPTH_ZERO_SELF_SIGNED_CERT` under default TLS and succeeds with `tls: { rejectUnauthorized: false }`.