### PR TITLE
fix(platform): stop stranding turns on failed human-input gate calls

### DIFF
--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -31,6 +31,7 @@ import { hasThoughtSteps } from '../utils/thought-predicates';
 import { ApprovalCardRenderer } from './approval-card-renderer';
 import { BranchNavigator } from './branch-navigator';
 import { CollapsibleSystemMessage } from './collapsible-system-message';
+import { GenerationIncompleteNotice } from './generation-incomplete-notice';
 import { InlineEditInput } from './inline-edit-input';
 import { InlineMemoryProposals } from './inline-memory-proposals';
 import { MessageBubble } from './message-bubble';
@@ -674,6 +675,17 @@ export const ChatMessages = memo(function ChatMessages({
         return (
           <div key={message.key} data-message-key={message.key}>
             <ModelFallbackNotice
+              body={message.systemMessageBody ?? message.content}
+            />
+          </div>
+        );
+      }
+
+      // Retry-exhausted turns: structured body, localized warning line.
+      if (message.systemMessageTag === SYSTEM_MSG_TAG.GENERATION_INCOMPLETE) {
+        return (
+          <div key={message.key} data-message-key={message.key}>
+            <GenerationIncompleteNotice
               body={message.systemMessageBody ?? message.content}
             />
           </div>

--- a/services/platform/app/features/chat/components/generation-incomplete-notice.tsx
+++ b/services/platform/app/features/chat/components/generation-incomplete-notice.tsx
@@ -1,0 +1,34 @@
+import { AlertTriangle } from 'lucide-react';
+
+import { useT } from '@/lib/i18n/client';
+import { parseGenerationIncompleteBody } from '@/lib/shared/constants/system-message-tags';
+
+interface GenerationIncompleteNoticeProps {
+  /** The `[GENERATION_INCOMPLETE]` body (structured `tools=a,b`). */
+  body: string;
+}
+
+/**
+ * Renders a `[GENERATION_INCOMPLETE]` system message — a turn that exhausted
+ * its retries without a final answer — as a localized one-line warning, in
+ * place of the old English fallback sentence that posed as the assistant's
+ * own reply.
+ */
+export function GenerationIncompleteNotice({
+  body,
+}: GenerationIncompleteNoticeProps) {
+  const { t } = useT('chat');
+  const { tools } = parseGenerationIncompleteBody(body);
+
+  const line =
+    tools && tools.length > 0
+      ? t('generationIncompleteWithTools', { tools: tools.join(', ') })
+      : t('generationIncomplete');
+
+  return (
+    <div className="text-warning flex items-center gap-1.5 px-4 py-1 text-xs">
+      <AlertTriangle className="size-3.5 shrink-0" aria-hidden="true" />
+      <span>{line}</span>
+    </div>
+  );
+}

--- a/services/platform/app/features/chat/utils/build-message-segments.test.ts
+++ b/services/platform/app/features/chat/utils/build-message-segments.test.ts
@@ -96,6 +96,46 @@ describe('buildMessageSegments', () => {
     expect((segments[0] as { output: unknown }).output).toEqual(folded);
   });
 
+  it('surfaces a laundered SDK tool failure as output-error', () => {
+    // A tool call whose input failed schema validation never executed; the
+    // SDK's error round-trips as a plain string output with state
+    // 'output-available' (the `error-json` marker is unwrapped away by the
+    // agent component). The builder must re-derive the error state so the
+    // chip doesn't render like a successful call.
+    const errorText =
+      'Invalid input for tool request_human_input: Type validation failed: ' +
+      'Value: {"fields":["{\\"label\\":\\"继续按计划调研\\"}"]}';
+    const { segments } = buildMessageSegments([
+      {
+        type: 'tool-request_human_input',
+        toolCallId: 'h1',
+        state: 'output-available',
+        output: errorText,
+      },
+    ]);
+    expect(segments[0]).toMatchObject({
+      kind: 'tool',
+      state: 'output-error',
+      errorText,
+    });
+  });
+
+  it('does not flag ordinary string outputs as errors', () => {
+    const { segments } = buildMessageSegments([
+      {
+        type: 'tool-web',
+        toolCallId: 'w1',
+        state: 'output-available',
+        output: 'Fetched 3 pages about invalid input handling.',
+      },
+    ]);
+    expect(segments[0]).toMatchObject({
+      kind: 'tool',
+      state: 'output-available',
+      errorText: undefined,
+    });
+  });
+
   it('detects redacted reasoning (done + empty)', () => {
     const { segments, hasReasoning } = buildMessageSegments([
       { type: 'reasoning', text: '', state: 'done' },

--- a/services/platform/app/features/chat/utils/build-message-segments.ts
+++ b/services/platform/app/features/chat/utils/build-message-segments.ts
@@ -62,6 +62,20 @@ const EMPTY: MessageSegments = {
   isStreaming: false,
 };
 
+/**
+ * The AI SDK reports a tool call that failed BEFORE execution (input failed
+ * schema validation, or the tool doesn't exist) as a plain tool-result whose
+ * output is the error string. The persisted error marker (`output.type:
+ * 'error-json'`) is unwrapped away by the agent component's UIMessage
+ * conversion, so by the time parts reach the client the failure reads as
+ * `state: 'output-available'` — a normal-looking chip for a call that never
+ * ran. Detect those outputs by the SDK's stable message prefixes so the chip
+ * renders as an error. If an SDK upgrade changes the wording, this only
+ * degrades back to today's unstyled output — never a false error.
+ */
+const SDK_TOOL_FAILURE_RE =
+  /^(Invalid input for tool |Model tried to call unavailable tool ')/;
+
 export function buildMessageSegments(
   parts: readonly unknown[] | undefined,
 ): MessageSegments {
@@ -137,14 +151,20 @@ export function buildMessageSegments(
       const errorText =
         typeof raw.errorText === 'string' ? raw.errorText : undefined;
 
+      const launderedFailure =
+        state === 'output-available' &&
+        errorText === undefined &&
+        typeof output === 'string' &&
+        SDK_TOOL_FAILURE_RE.test(output);
+
       const segment: Extract<ThoughtStep, { kind: 'tool' }> = {
         kind: 'tool',
         id: toolCallId,
         toolName,
-        state,
+        state: launderedFailure ? 'output-error' : state,
         input,
         output,
-        errorText,
+        errorText: launderedFailure ? output : errorText,
       };
 
       if (SKILL_TOOL_NAMES.has(toolName)) {

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -712,6 +712,7 @@ import type * as lib_agent_response_reasoning_types from "../lib/agent_response/
 import type * as lib_agent_response_resolve_template_variables from "../lib/agent_response/resolve_template_variables.js";
 import type * as lib_agent_response_retry_policy from "../lib/agent_response/retry_policy.js";
 import type * as lib_agent_response_sanitize_prompt from "../lib/agent_response/sanitize_prompt.js";
+import type * as lib_agent_response_stop_conditions from "../lib/agent_response/stop_conditions.js";
 import type * as lib_agent_response_stream_finalizers from "../lib/agent_response/stream_finalizers.js";
 import type * as lib_agent_response_structured_response_instructions from "../lib/agent_response/structured_response_instructions.js";
 import type * as lib_agent_response_types from "../lib/agent_response/types.js";
@@ -858,6 +859,7 @@ import type * as lib_search_strategies_documents from "../lib/search/strategies/
 import type * as lib_search_types from "../lib/search/types.js";
 import type * as lib_secret_box from "../lib/secret_box.js";
 import type * as lib_shared_schemas_utils_json_value from "../lib/shared/schemas/utils/json_value.js";
+import type * as lib_skills_guidance from "../lib/skills/guidance.js";
 import type * as lib_skills_precedence from "../lib/skills/precedence.js";
 import type * as lib_sops from "../lib/sops.js";
 import type * as lib_strip_nulls from "../lib/strip_nulls.js";
@@ -961,6 +963,8 @@ import type * as migrations_versions_v0_2_89_01_usage_ledger_apikey_budget_scope
 import type * as migrations_versions_v0_2_89_01_usage_ledger_apikey_budget_scope_meta from "../migrations/versions/v0_2_89/01_usage_ledger_apikey_budget_scope/meta.js";
 import type * as migrations_versions_v0_2_89_02_thread_files_absolute_paths_index from "../migrations/versions/v0_2_89/02_thread_files_absolute_paths/index.js";
 import type * as migrations_versions_v0_2_89_02_thread_files_absolute_paths_meta from "../migrations/versions/v0_2_89/02_thread_files_absolute_paths/meta.js";
+import type * as migrations_versions_v0_2_89_03_claude_code_fable_default_index from "../migrations/versions/v0_2_89/03_claude_code_fable_default/index.js";
+import type * as migrations_versions_v0_2_89_03_claude_code_fable_default_meta from "../migrations/versions/v0_2_89/03_claude_code_fable_default/meta.js";
 import type * as model_catalog_mutations from "../model_catalog/mutations.js";
 import type * as model_catalog_queries from "../model_catalog/queries.js";
 import type * as model_catalog_sync from "../model_catalog/sync.js";
@@ -1010,6 +1014,7 @@ import type * as node_only_sandbox_thread_session from "../node_only/sandbox/thr
 import type * as node_only_sandbox_token_pool_select from "../node_only/sandbox/token_pool_select.js";
 import type * as node_only_sandbox_token_source_pool from "../node_only/sandbox/token_source_pool.js";
 import type * as node_only_sandbox_workflow_sandbox_exec from "../node_only/sandbox/workflow_sandbox_exec.js";
+import type * as node_only_sandbox_workflow_skills from "../node_only/sandbox/workflow_skills.js";
 import type * as node_only_sandbox_workspace_files from "../node_only/sandbox/workspace_files.js";
 import type * as node_only_sql_helpers_execute_mssql_query from "../node_only/sql/helpers/execute_mssql_query.js";
 import type * as node_only_sql_helpers_execute_mysql_query from "../node_only/sql/helpers/execute_mysql_query.js";
@@ -2341,6 +2346,7 @@ declare const fullApi: ApiFromModules<{
   "lib/agent_response/resolve_template_variables": typeof lib_agent_response_resolve_template_variables;
   "lib/agent_response/retry_policy": typeof lib_agent_response_retry_policy;
   "lib/agent_response/sanitize_prompt": typeof lib_agent_response_sanitize_prompt;
+  "lib/agent_response/stop_conditions": typeof lib_agent_response_stop_conditions;
   "lib/agent_response/stream_finalizers": typeof lib_agent_response_stream_finalizers;
   "lib/agent_response/structured_response_instructions": typeof lib_agent_response_structured_response_instructions;
   "lib/agent_response/types": typeof lib_agent_response_types;
@@ -2487,6 +2493,7 @@ declare const fullApi: ApiFromModules<{
   "lib/search/types": typeof lib_search_types;
   "lib/secret_box": typeof lib_secret_box;
   "lib/shared/schemas/utils/json_value": typeof lib_shared_schemas_utils_json_value;
+  "lib/skills/guidance": typeof lib_skills_guidance;
   "lib/skills/precedence": typeof lib_skills_precedence;
   "lib/sops": typeof lib_sops;
   "lib/strip_nulls": typeof lib_strip_nulls;
@@ -2590,6 +2597,8 @@ declare const fullApi: ApiFromModules<{
   "migrations/versions/v0_2_89/01_usage_ledger_apikey_budget_scope/meta": typeof migrations_versions_v0_2_89_01_usage_ledger_apikey_budget_scope_meta;
   "migrations/versions/v0_2_89/02_thread_files_absolute_paths/index": typeof migrations_versions_v0_2_89_02_thread_files_absolute_paths_index;
   "migrations/versions/v0_2_89/02_thread_files_absolute_paths/meta": typeof migrations_versions_v0_2_89_02_thread_files_absolute_paths_meta;
+  "migrations/versions/v0_2_89/03_claude_code_fable_default/index": typeof migrations_versions_v0_2_89_03_claude_code_fable_default_index;
+  "migrations/versions/v0_2_89/03_claude_code_fable_default/meta": typeof migrations_versions_v0_2_89_03_claude_code_fable_default_meta;
   "model_catalog/mutations": typeof model_catalog_mutations;
   "model_catalog/queries": typeof model_catalog_queries;
   "model_catalog/sync": typeof model_catalog_sync;
@@ -2639,6 +2648,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/token_pool_select": typeof node_only_sandbox_token_pool_select;
   "node_only/sandbox/token_source_pool": typeof node_only_sandbox_token_source_pool;
   "node_only/sandbox/workflow_sandbox_exec": typeof node_only_sandbox_workflow_sandbox_exec;
+  "node_only/sandbox/workflow_skills": typeof node_only_sandbox_workflow_skills;
   "node_only/sandbox/workspace_files": typeof node_only_sandbox_workspace_files;
   "node_only/sql/helpers/execute_mssql_query": typeof node_only_sql_helpers_execute_mssql_query;
   "node_only/sql/helpers/execute_mysql_query": typeof node_only_sql_helpers_execute_mysql_query;

--- a/services/platform/convex/agent_tools/human_input/request_human_input_tool.test.ts
+++ b/services/platform/convex/agent_tools/human_input/request_human_input_tool.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+
+import { requestHumanInputArgs } from './request_human_input_tool';
+
+describe('requestHumanInputArgs coercion', () => {
+  it('accepts well-formed input unchanged', () => {
+    const result = requestHumanInputArgs.parse({
+      question: 'Please confirm',
+      fields: [{ label: 'Proceed?', type: 'yes_no', required: true }],
+    });
+    expect(result.fields).toEqual([
+      { label: 'Proceed?', type: 'yes_no', required: true },
+    ]);
+  });
+
+  it('parses field elements sent as JSON strings (observed model failure)', () => {
+    // Verbatim failure shape from production: gpt-5.5 emitted each fields[]
+    // element as a JSON-encoded string, which failed validation before the
+    // tool executed — the turn halted with no card on screen.
+    const result = requestHumanInputArgs.parse({
+      question: '我已经拟定了对比亚迪的调研计划，您是否同意按此计划继续？',
+      fields: [
+        '{"label":"继续按计划调研 (Proceed with plan)","type":"yes_no"}',
+        '{"label":"需要调整的重点 / 补充要求 (Adjustments/Additions)","type":"textarea"}',
+      ],
+    });
+    expect(result.fields).toEqual([
+      { label: '继续按计划调研 (Proceed with plan)', type: 'yes_no' },
+      {
+        label: '需要调整的重点 / 补充要求 (Adjustments/Additions)',
+        type: 'textarea',
+      },
+    ]);
+  });
+
+  it('parses the whole fields array sent as one JSON string', () => {
+    const result = requestHumanInputArgs.parse({
+      question: 'Pick one',
+      fields: '[{"label":"Choice","type":"text"}]',
+    });
+    expect(result.fields).toEqual([{ label: 'Choice', type: 'text' }]);
+  });
+
+  it('parses select options sent as JSON strings', () => {
+    const result = requestHumanInputArgs.parse({
+      question: 'Which meal?',
+      fields: [
+        {
+          label: 'Meal',
+          type: 'single_select',
+          options: ['{"label":"Pasta"}', '{"label":"Curry"}'],
+        },
+      ],
+    });
+    expect(result.fields[0]).toMatchObject({
+      type: 'single_select',
+      options: [{ label: 'Pasta' }, { label: 'Curry' }],
+    });
+  });
+
+  it('still rejects genuinely malformed input with a zod error', () => {
+    expect(() =>
+      requestHumanInputArgs.parse({
+        question: 'Broken',
+        fields: ['not json at all'],
+      }),
+    ).toThrow();
+    expect(() =>
+      requestHumanInputArgs.parse({
+        question: 'Broken',
+        fields: ['"a json string, not an object"'],
+      }),
+    ).toThrow();
+  });
+
+  it('keeps the model-facing JSON schema fully described (no degradation)', () => {
+    // The AI SDK advertises tools via toJSONSchema(..., { io: 'input' }).
+    // z.preprocess must stay transparent there — if this regresses, the model
+    // sees `fields` as unconstrained and loses all field-shape guidance.
+    const jsonSchema = z.toJSONSchema(requestHumanInputArgs, {
+      target: 'draft-7',
+      io: 'input',
+    });
+    const fields = (
+      jsonSchema as unknown as {
+        properties: { fields: { type?: string; items: { oneOf?: unknown[] } } };
+      }
+    ).properties.fields;
+    expect(fields.type).toBe('array');
+    expect(fields.items.oneOf).toBeDefined();
+    expect(JSON.stringify(fields.items)).toContain('yes_no');
+    expect(JSON.stringify(fields.items)).toContain('single_select');
+  });
+});

--- a/services/platform/convex/agent_tools/human_input/request_human_input_tool.ts
+++ b/services/platform/convex/agent_tools/human_input/request_human_input_tool.ts
@@ -17,6 +17,25 @@ import { internal } from '../../_generated/api';
 import { getApprovalThreadId } from '../../threads/get_parent_thread_id';
 import type { ToolDefinition } from '../types';
 
+/**
+ * Models occasionally emit nested array elements as JSON-encoded STRINGS
+ * instead of objects (`fields: ["{\"label\":...,\"type\":\"yes_no\"}"]`),
+ * which fails input validation before the tool ever executes — the turn then
+ * halts with no card on screen. Parse such strings back into objects/arrays
+ * before validation; anything else passes through and fails with the normal
+ * zod error. This is transparent to the model-facing JSON schema:
+ * `toJSONSchema(..., { io: 'input' })` renders the inner schema unchanged.
+ */
+const coerceJsonObjectString = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === 'object' && parsed !== null ? parsed : value;
+  } catch {
+    return value;
+  }
+};
+
 const optionSchema = z.object({
   label: z.string().describe('Display label for the option.'),
   description: z
@@ -30,6 +49,8 @@ const optionSchema = z.object({
       'Optional value to return (defaults to label if not provided). When multiple options share similar labels, provide explicit distinct values to avoid ambiguity.',
     ),
 });
+
+const coercedOptionSchema = z.preprocess(coerceJsonObjectString, optionSchema);
 
 const uniqueOptionValues = (options: z.output<typeof optionSchema>[]) => {
   const values = options.map((opt) => opt.value ?? opt.label);
@@ -74,7 +95,7 @@ const fieldSchema = z.discriminatedUnion('type', [
         'Use "single_select" when the user picks ONE option, "multi_select" when the user picks ONE OR MORE.',
       ),
     options: z
-      .array(optionSchema)
+      .array(coercedOptionSchema)
       .min(2)
       .refine(uniqueOptionValues, {
         message:
@@ -86,7 +107,7 @@ const fieldSchema = z.discriminatedUnion('type', [
     ...sharedFieldProps,
     type: z.literal('yes_no').describe('Binary yes/no confirmation.'),
     options: z
-      .array(optionSchema)
+      .array(coercedOptionSchema)
       .length(2)
       .refine(uniqueOptionValues, {
         message:
@@ -105,7 +126,7 @@ const fieldSchema = z.discriminatedUnion('type', [
         'Editable checklist of todo items. Renders as rows the user can add / edit / remove before confirming. Response is a JSON-stringified array of `{id, content}` objects.',
       ),
     initialTodos: z
-      .array(todoItemInputSchema)
+      .array(z.preprocess(coerceJsonObjectString, todoItemInputSchema))
       .optional()
       .describe(
         'Pre-filled todos for the user to review/edit. IDs should be stable short slugs (e.g. q1, q2).',
@@ -124,7 +145,7 @@ const contextField = {
     ),
 };
 
-const requestHumanInputArgs = z.object({
+export const requestHumanInputArgs = z.object({
   // `question` is declared FIRST and described as REQUIRED so the model never
   // omits it. Previously the optional `context` came first and `question` read
   // as auxiliary, producing calls with no `question` that failed validation.
@@ -134,8 +155,10 @@ const requestHumanInputArgs = z.object({
       'REQUIRED. The primary question or heading shown above the form fields — ALWAYS include this string (e.g., "Please provide the following details for the purchase contract"). It is the main prompt; `context` is only optional supporting detail and is NOT a substitute for `question`.',
     ),
   fields: z
-    .array(fieldSchema)
-    .min(1)
+    .preprocess(
+      coerceJsonObjectString,
+      z.array(z.preprocess(coerceJsonObjectString, fieldSchema)).min(1),
+    )
     .describe(
       'REQUIRED. Form fields to display (at least one). Each field gets its own labeled input. Use unique labels — they serve as keys in the response.',
     ),

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -22,12 +22,16 @@ import {
   type MessageDoc,
 } from '@convex-dev/agent';
 import type { StreamMessage } from '@convex-dev/agent/validators';
-import { hasToolCall, type ModelMessage, stepCountIs } from 'ai';
+import { type ModelMessage, stepCountIs } from 'ai';
 
 import {
   classifyChatErrorCode,
   encodeChatError,
 } from '../../../lib/shared/chat-errors';
+import {
+  formatGenerationIncompleteBody,
+  SYSTEM_MSG_TAG,
+} from '../../../lib/shared/constants/system-message-tags';
 import { tuningInstructionSuffix } from '../../../lib/shared/response-tuning';
 import { isRecord, getString } from '../../../lib/utils/type-utils';
 import { components, internal } from '../../_generated/api';
@@ -100,10 +104,12 @@ import { buildReasoningOptions } from './reasoning/build_reasoning_options';
 import { reasoningScopeKey } from './reasoning/scope';
 import { resolveTemplateVariables } from './resolve_template_variables';
 import {
+  endedOnHumanInputGate,
   mergeUsage,
   needsToolResultRetry,
   shouldRetryGeneration,
 } from './retry_policy';
+import { hasValidToolCall } from './stop_conditions';
 import {
   finalizePersistentStream,
   linkApprovalsToLatestAssistantMessage,
@@ -209,13 +215,18 @@ export async function generateAgentResponse(
   // tool only surfaces an approval card and tells the model to stop and wait —
   // but "stop" was a prompt-only contract the model could (and did) ignore,
   // most visibly the researcher barrelling past its plan-confirmation card
-  // straight into web searches. `hasToolCall` turns the gate into a real stop.
-  // Scoped to agents that actually expose the tool so no other agent's loop
-  // behaviour changes. Setting `stopWhen` makes the SDK ignore the config's
-  // `maxSteps`, so the step cap is re-applied here via `stepCountIs` (mirroring
-  // the default in create_agent_config.ts).
+  // straight into web searches. `hasValidToolCall` turns the gate into a real
+  // stop — but only for calls that passed input validation: an invalid call
+  // never created a card, so the loop must keep going and let the model fix
+  // its arguments. Scoped to agents that actually expose the tool so no other
+  // agent's loop behaviour changes. Setting `stopWhen` makes the SDK ignore
+  // the config's `maxSteps`, so the step cap is re-applied here via
+  // `stepCountIs` (mirroring the default in create_agent_config.ts).
   const humanInputStopWhen = convexToolNames?.includes('request_human_input')
-    ? [stepCountIs(args.maxSteps ?? 40), hasToolCall('request_human_input')]
+    ? [
+        stepCountIs(args.maxSteps ?? 40),
+        hasValidToolCall('request_human_input'),
+      ]
     : undefined;
 
   const debugLog = createDebugLog(
@@ -911,6 +922,11 @@ export async function generateAgentResponse(
 
     let didRetry = false;
     let retryInProgress = false;
+    // Set when the retry-exhausted fallback fired: `result.text` then holds a
+    // diagnostic for RETURN-value consumers (delegate ToolResponses, logs) and
+    // must NOT be persisted as the assistant's own words — the user-facing
+    // outcome is the tagged [GENERATION_INCOMPLETE] system message instead.
+    let fallbackNoticeSaved = false;
 
     const promptToSend = hookPromptContent ?? promptMessage;
 
@@ -1782,11 +1798,17 @@ export async function generateAgentResponse(
         }
       }
 
-      // Fallback: if text is still missing after continue, provide a minimal response
-      // so the user always sees something rather than an empty message
+      // Fallback: if text is still missing after continue, provide a minimal
+      // response so the user always sees something rather than an empty
+      // message. EXCEPT when the turn ended on a VALID `request_human_input`
+      // gate: that turn intentionally has no trailing text — the question card
+      // IS the response — and firing the incomplete-notice here put a spurious
+      // "unable to generate a complete response" line under every question
+      // card the model asked without a closing sentence.
       if (
-        !result.text?.trim() ||
-        needsToolResultRetry(result.text, result.steps)
+        (!result.text?.trim() ||
+          needsToolResultRetry(result.text, result.steps)) &&
+        !endedOnHumanInputGate(result.steps)
       ) {
         const toolNames = extractToolNamesFromSteps(result.steps ?? []);
         debugLog('All retries exhausted, using fallback message', {
@@ -1794,10 +1816,32 @@ export async function generateAgentResponse(
           finishReason: result.finishReason,
         });
         didRetry = true;
+        // Diagnostic for return-value consumers only (delegate ToolResponses,
+        // logs) — never persisted as the assistant's words (see
+        // `fallbackNoticeSaved`).
         result.text =
           toolNames.length > 0
             ? `I attempted to process your request using ${toolNames.join(', ')}, but was unable to generate a complete response. Please try again.`
             : 'I was unable to generate a response. Please try again.';
+        // Machine-readable body — the chat UI renders a localized warning line
+        // (same pattern as MODEL_FALLBACK) instead of an English sentence
+        // masquerading as the assistant's own reply.
+        try {
+          await saveMessage(ctx, components.agent, {
+            threadId,
+            message: {
+              role: 'system',
+              content:
+                `${SYSTEM_MSG_TAG.GENERATION_INCOMPLETE} ${formatGenerationIncompleteBody({ tools: toolNames })}`.trim(),
+            },
+          });
+          fallbackNoticeSaved = true;
+        } catch (msgError) {
+          console.error(
+            '[generateAgentResponse] Failed to save generation-incomplete message:',
+            msgError,
+          );
+        }
       }
     } catch (timeoutError) {
       if (!(timeoutError instanceof AgentTimeoutError)) throw timeoutError;
@@ -1971,9 +2015,13 @@ export async function generateAgentResponse(
 
     // Persist retry/fallback text to the saved message so it survives page reloads.
     // Retries use saveMessages: 'none', so the SDK-saved message still has the
-    // original (empty/preamble) text. Update it with the final result.
+    // original (empty/preamble) text. Update it with the final result — unless
+    // the text is the retry-exhausted diagnostic, whose user-facing form is the
+    // [GENERATION_INCOMPLETE] system message already saved above (if that save
+    // failed, fall through so the user still sees *something*).
     if (
       didRetry &&
+      !fallbackNoticeSaved &&
       savedMessageId &&
       result.text &&
       !(await checkCancelled())

--- a/services/platform/convex/lib/agent_response/retry_policy.ts
+++ b/services/platform/convex/lib/agent_response/retry_policy.ts
@@ -58,14 +58,15 @@ export function needsToolResultRetry(
 
 /**
  * The interactive approval-gate tool. When the agent loop is halted because the
- * model called this (see the `stopWhen: hasToolCall('request_human_input')` in
- * generate_response.ts), the stop is INTENTIONAL — an approval card is now shown
- * and the turn must wait for the user's response in a future turn.
+ * model called this (see the `stopWhen: hasValidToolCall('request_human_input')`
+ * in generate_response.ts), the stop is INTENTIONAL — an approval card is now
+ * shown and the turn must wait for the user's response in a future turn.
  */
 const HUMAN_INPUT_GATE_TOOL = 'request_human_input';
 
 /**
- * True when the generation's LAST step ended by calling `request_human_input`.
+ * True when the generation's LAST step ended by VALIDLY calling
+ * `request_human_input`.
  *
  * That is the deliberate approval-gate halt and MUST be treated as terminal: the
  * AI SDK reports `finishReason: 'tool-calls'` for it (or `'stop'` with no
@@ -73,18 +74,25 @@ const HUMAN_INPUT_GATE_TOOL = 'request_human_input';
  * incomplete response and auto-continue — barrelling straight past the gate the
  * stop exists to enforce (researcher plan-confirmation, disambiguation cards…).
  *
+ * A call the SDK marked `invalid: true` (input failed schema validation) never
+ * executed and created NO card — treating it as the gate halt would suppress
+ * the retry and strand the turn on a question the user can never see. Invalid
+ * calls therefore stay retryable.
+ *
  * Scoped to the LAST step: when `stopWhen` fires, the gate call is always the
  * final step. A gate call in an earlier step (the model kept going on its own)
  * is not a gate halt and stays retryable.
  */
 export function endedOnHumanInputGate(steps: unknown[] | undefined): boolean {
   if (!steps || steps.length === 0) return false;
-  type StepLike = { toolCalls?: Array<{ toolName: string }> };
+  type StepLike = {
+    toolCalls?: Array<{ toolName: string; invalid?: boolean }>;
+  };
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- dynamic data from AI SDK
   const typedSteps = steps as StepLike[];
   const lastStep = typedSteps[typedSteps.length - 1];
   return (lastStep?.toolCalls ?? []).some(
-    (call) => call.toolName === HUMAN_INPUT_GATE_TOOL,
+    (call) => call.toolName === HUMAN_INPUT_GATE_TOOL && call.invalid !== true,
   );
 }
 

--- a/services/platform/convex/lib/agent_response/should_retry_generation.test.ts
+++ b/services/platform/convex/lib/agent_response/should_retry_generation.test.ts
@@ -9,7 +9,7 @@ import {
 
 // Helper to create step-like objects matching AI SDK shape
 function makeStep(opts: {
-  toolCalls?: Array<{ toolName: string }>;
+  toolCalls?: Array<{ toolName: string; invalid?: boolean }>;
   text?: string;
 }) {
   return opts;
@@ -196,6 +196,22 @@ describe('shouldRetryGeneration', () => {
         reason: 'finish-reason-tool-calls',
       });
     });
+
+    it('still retries when the gate call failed input validation', () => {
+      // Regression: a call the SDK marked `invalid: true` never executed, so
+      // no approval card exists. Treating it as the gate halt suppressed the
+      // retry and stranded the turn on a question the user could never see.
+      const steps = [
+        makeStep({
+          toolCalls: [{ toolName: 'request_human_input', invalid: true }],
+        }),
+      ];
+      const result = shouldRetryGeneration('tool-calls', '', steps, false);
+      expect(result).toEqual({
+        retry: true,
+        reason: 'finish-reason-tool-calls',
+      });
+    });
   });
 
   describe('already-retried guard', () => {
@@ -261,6 +277,27 @@ describe('endedOnHumanInputGate', () => {
     expect(
       endedOnHumanInputGate([makeStep({ toolCalls: [{ toolName: 'web' }] })]),
     ).toBe(false);
+  });
+
+  it('returns false when the gate call failed input validation', () => {
+    const steps = [
+      makeStep({
+        toolCalls: [{ toolName: 'request_human_input', invalid: true }],
+      }),
+    ];
+    expect(endedOnHumanInputGate(steps)).toBe(false);
+  });
+
+  it('returns true when a valid gate call sits next to an invalid one', () => {
+    const steps = [
+      makeStep({
+        toolCalls: [
+          { toolName: 'request_human_input', invalid: true },
+          { toolName: 'request_human_input' },
+        ],
+      }),
+    ];
+    expect(endedOnHumanInputGate(steps)).toBe(true);
   });
 
   it('returns true when last step has tool calls (preamble-only)', () => {

--- a/services/platform/convex/lib/agent_response/stop_conditions.test.ts
+++ b/services/platform/convex/lib/agent_response/stop_conditions.test.ts
@@ -1,0 +1,54 @@
+import type { StepResult, ToolSet } from 'ai';
+import { describe, expect, it } from 'vitest';
+
+import { hasValidToolCall } from './stop_conditions';
+
+// Minimal step doubles — the condition only reads `toolCalls` off the last step.
+function makeSteps(
+  ...stepToolCalls: Array<Array<{ toolName: string; invalid?: boolean }>>
+): Array<StepResult<ToolSet>> {
+  const steps = stepToolCalls.map((toolCalls) => ({ toolCalls }));
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for AI SDK StepResult
+  return steps as unknown as Array<StepResult<ToolSet>>;
+}
+
+const stop = hasValidToolCall('request_human_input');
+
+describe('hasValidToolCall', () => {
+  it('fires on a valid matching call in the last step', () => {
+    const steps = makeSteps([{ toolName: 'request_human_input' }]);
+    expect(stop({ steps })).toBe(true);
+  });
+
+  it('does NOT fire on a call marked invalid (input validation failed)', () => {
+    // Regression: the SDK's `hasToolCall` matches toolName alone, so a call
+    // whose input failed schema validation halted the loop even though no
+    // approval card was created — stranding the turn with no card and no
+    // chance for the model to fix its arguments.
+    const steps = makeSteps([
+      { toolName: 'request_human_input', invalid: true },
+    ]);
+    expect(stop({ steps })).toBe(false);
+  });
+
+  it('fires when a valid call sits next to an invalid one', () => {
+    const steps = makeSteps([
+      { toolName: 'request_human_input', invalid: true },
+      { toolName: 'request_human_input' },
+    ]);
+    expect(stop({ steps })).toBe(true);
+  });
+
+  it('only inspects the LAST step', () => {
+    const steps = makeSteps(
+      [{ toolName: 'request_human_input' }],
+      [{ toolName: 'web' }],
+    );
+    expect(stop({ steps })).toBe(false);
+  });
+
+  it('does not fire on other tools or empty steps', () => {
+    expect(stop({ steps: makeSteps([{ toolName: 'web' }]) })).toBe(false);
+    expect(stop({ steps: makeSteps() })).toBe(false);
+  });
+});

--- a/services/platform/convex/lib/agent_response/stop_conditions.ts
+++ b/services/platform/convex/lib/agent_response/stop_conditions.ts
@@ -1,0 +1,25 @@
+/**
+ * Custom stop conditions for the agent tool loop.
+ *
+ * `hasValidToolCall` replaces the AI SDK's `hasToolCall` for the
+ * `request_human_input` approval gate. The SDK matcher fires on tool NAME
+ * alone — including calls whose input failed schema validation (the SDK marks
+ * them `invalid: true` but leaves them in `step.toolCalls`). An invalid call
+ * never executed, so no approval card exists; halting on it strands the turn
+ * with no card, no retry, and only the generic fallback text. Stopping only on
+ * a VALID call lets the model see the tool-error result and correct its
+ * arguments on the next step.
+ */
+
+import type { StopCondition, ToolSet } from 'ai';
+
+export function hasValidToolCall<TOOLS extends ToolSet>(
+  toolName: string,
+): StopCondition<TOOLS> {
+  return ({ steps }) =>
+    (steps[steps.length - 1]?.toolCalls ?? []).some(
+      (toolCall) =>
+        toolCall.toolName === toolName &&
+        !('invalid' in toolCall && toolCall.invalid === true),
+    );
+}

--- a/services/platform/lib/shared/constants/system-message-tags.test.ts
+++ b/services/platform/lib/shared/constants/system-message-tags.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   SYSTEM_MSG_TAG,
+  formatGenerationIncompleteBody,
   getSystemMessageDisplay,
+  parseGenerationIncompleteBody,
   parseSystemMessageTag,
 } from './system-message-tags';
 
@@ -110,5 +112,29 @@ describe('getSystemMessageDisplay', () => {
 
   it('returns info for null tag', () => {
     expect(getSystemMessageDisplay(null)).toBe('info');
+  });
+
+  it('returns warning for GENERATION_INCOMPLETE', () => {
+    expect(getSystemMessageDisplay(SYSTEM_MSG_TAG.GENERATION_INCOMPLETE)).toBe(
+      'warning',
+    );
+  });
+});
+
+describe('generation-incomplete body round-trip', () => {
+  it('round-trips tool names, including ones needing encoding', () => {
+    const body = formatGenerationIncompleteBody({
+      tools: ['delegate_researcher', 'request_human_input', 'a,b'],
+    });
+    expect(parseGenerationIncompleteBody(body).tools).toEqual([
+      'delegate_researcher',
+      'request_human_input',
+      'a,b',
+    ]);
+  });
+
+  it('formats an empty tool list to an empty body and parses it back', () => {
+    expect(formatGenerationIncompleteBody({})).toBe('');
+    expect(parseGenerationIncompleteBody('').tools).toBeUndefined();
   });
 });

--- a/services/platform/lib/shared/constants/system-message-tags.ts
+++ b/services/platform/lib/shared/constants/system-message-tags.ts
@@ -13,6 +13,7 @@ export const SYSTEM_MSG_TAG = {
   INTEGRATION_OPERATION_COMPLETED: '[INTEGRATION_OPERATION_COMPLETED]',
   INTEGRATION_OPERATION_FAILED: '[INTEGRATION_OPERATION_FAILED]',
   MODEL_FALLBACK: '[MODEL_FALLBACK]',
+  GENERATION_INCOMPLETE: '[GENERATION_INCOMPLETE]',
 } as const;
 
 export type SystemMsgTag = (typeof SYSTEM_MSG_TAG)[keyof typeof SYSTEM_MSG_TAG];
@@ -57,6 +58,7 @@ const DISPLAY_MAP: Record<SystemMsgTag, SystemMessageDisplay> = {
   [SYSTEM_MSG_TAG.INTEGRATION_OPERATION_COMPLETED]: 'info',
   [SYSTEM_MSG_TAG.INTEGRATION_OPERATION_FAILED]: 'error',
   [SYSTEM_MSG_TAG.MODEL_FALLBACK]: 'warning',
+  [SYSTEM_MSG_TAG.GENERATION_INCOMPLETE]: 'warning',
 };
 
 export function getSystemMessageDisplay(
@@ -110,6 +112,49 @@ export function parseModelFallbackBody(body: string): ModelFallbackBody {
     if (key === 'from') result.from = value;
     else if (key === 'to') result.to = value;
     else if (key === 'reason') result.reason = value;
+  }
+  return result;
+}
+
+/**
+ * Structured payload carried in a `[GENERATION_INCOMPLETE]` system-message
+ * body — written when a turn exhausts its retries without producing a final
+ * answer. Machine-readable (URL-encoded tool names, no localized prose) so the
+ * chat UI can render a localized warning instead of an English sentence
+ * masquerading as the assistant's own words.
+ */
+interface GenerationIncompleteBody {
+  /** Names of the tools the model called during the incomplete turn. */
+  tools?: string[];
+}
+
+export function formatGenerationIncompleteBody(
+  body: GenerationIncompleteBody,
+): string {
+  return body.tools && body.tools.length > 0
+    ? `tools=${body.tools.map((t) => encodeURIComponent(t)).join(',')}`
+    : '';
+}
+
+export function parseGenerationIncompleteBody(
+  body: string,
+): GenerationIncompleteBody {
+  const result: GenerationIncompleteBody = {};
+  for (const token of body.trim().split(/\s+/)) {
+    const eq = token.indexOf('=');
+    if (eq <= 0) continue;
+    if (token.slice(0, eq) !== 'tools') continue;
+    result.tools = token
+      .slice(eq + 1)
+      .split(',')
+      .filter((t) => t.length > 0)
+      .map((t) => {
+        try {
+          return decodeURIComponent(t);
+        } catch {
+          return t;
+        }
+      });
   }
   return result;
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1837,6 +1837,8 @@
     "modelFallbackNotice": "{from} war nicht verfügbar – zu {to} gewechselt.",
     "modelFallbackDefaultModel": "das Standardmodell",
     "modelFallbackUnknown": "das vorherige Modell",
+    "generationIncomplete": "Die Antwort konnte nicht abgeschlossen werden. Bitte versuche es erneut.",
+    "generationIncompleteWithTools": "Die Antwort konnte nach der Ausführung von {tools} nicht abgeschlossen werden. Bitte versuche es erneut.",
     "workspaceFiles": {
       "title": "Arbeitsbereichsdateien",
       "toggleLabel": "Arbeitsbereichsdateien",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1856,6 +1856,8 @@
     "modelFallbackNotice": "{from} was unavailable — switched to {to}.",
     "modelFallbackDefaultModel": "the default model",
     "modelFallbackUnknown": "the previous model",
+    "generationIncomplete": "The response couldn't be completed. Please try again.",
+    "generationIncompleteWithTools": "The response couldn't be completed after running {tools}. Please try again.",
     "liveBrowser": {
       "title": "Live browser",
       "toggleLabel": "Live browser",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1838,6 +1838,8 @@
     "modelFallbackNotice": "{from} était indisponible — passage à {to}.",
     "modelFallbackDefaultModel": "le modèle par défaut",
     "modelFallbackUnknown": "le modèle précédent",
+    "generationIncomplete": "La réponse n'a pas pu être terminée. Merci de réessayer.",
+    "generationIncompleteWithTools": "La réponse n'a pas pu être terminée après l'exécution de {tools}. Merci de réessayer.",
     "workspaceFiles": {
       "title": "Fichiers de l'espace de travail",
       "toggleLabel": "Fichiers de l'espace de travail",


### PR DESCRIPTION
## Problem

In multi-agent research threads (Assistant → delegate_researcher), users hit a cluster of confusing failures around `request_human_input`:

1. **Chip without card.** When a model malformed the tool args (observed: gpt-5.5 passing `fields` as an array of JSON-encoded *strings*), the AI SDK marked the call `invalid` and never executed it — no approval card was created. But both loop gates matched on tool **name** alone: `stopWhen: hasToolCall(...)` halted the turn on the failed call, and `endedOnHumanInputGate` suppressed the retry. Result: an "Ask a human" chip that looks successful, no card, no retry, and the English fallback sentence in the chat.
2. **Spurious fallback under every question card.** A turn that ends on a *valid* gate call intentionally has no trailing text (the card is the response), but it fell into the retry-exhausted fallback anyway — putting "I attempted to process your request using …, but was unable to generate a complete response." under cards that were created and answered just fine.
3. **English error prose posing as the assistant.** That fallback sentence was written into the assistant message itself — unlocalized and indistinguishable from a real reply.
4. **Failed tool calls rendered like successful ones** — the error marker (`error-json`) is unwrapped away by the agent component's UIMessage conversion, so failed chips showed the normal wrench icon with the error text buried in the expanded output.

## Fix

**Backend** (`fix(platform): keep invalid human-input gate calls retryable`)
- New `hasValidToolCall` stop condition: only gate calls that passed input validation halt the loop, so the model sees the tool-error and corrects its arguments (still capped by `stepCountIs`).
- `endedOnHumanInputGate` ignores `invalid: true` calls — they stay retryable.
- The retry-exhausted fallback is skipped when the turn ended on a valid gate.
- When the fallback does fire, the user-facing outcome is a tagged `[GENERATION_INCOMPLETE] tools=…` system message (MODEL_FALLBACK pattern); the English diagnostic remains only as the return value for delegate ToolResponses and is no longer persisted as the assistant's words.
- `request_human_input` coerces stringified array elements (fields / options / initialTodos) back into objects before validation — verified transparent to the model-facing JSON schema (`toJSONSchema(io: 'input')`).

**Frontend** (`feat(platform): render failed tool calls and incomplete turns`)
- The segment builder re-derives `output-error` for pre-execution tool failures from the SDK's stable error prefixes, so the chip shows the destructive state.
- `[GENERATION_INCOMPLETE]` renders as a localized one-line warning (en/de/fr).

## Verification

- New/extended unit tests: `stop_conditions.test.ts`, `should_retry_generation.test.ts` (invalid-call cases), `request_human_input_tool.test.ts` (incl. the verbatim production payload and a JSON-schema non-degradation assertion), `build-message-segments.test.ts`, `system-message-tags.test.ts`.
- E2E on the dev stack: a prompt forcing a confirmation question produced the card, hard-stopped the turn, locked the composer, and resumed correctly after answering — with **no** spurious "couldn't be completed" line (it reproduced before the gate guard, confirming the root cause live).
- `bun run check`: format/lint/typecheck and all other workspaces green; 7–8 convexTest suites hit 5s timeouts under full-suite load on the dev machine (rotating set, all unrelated modules) and pass in isolation — known convexTest flakiness, expect green in CI.

## Context

Part of the multi-agent UX cleanup (thread forensics: stale research-plan pane, double confirmation, opaque delegate JSON). The resource-ownership unification (todos/files root-homing + attribution) is intentionally deferred behind an architecture decision on async dynamic sub-agents.