### PR TITLE
ci(cli): bump Bun to 1.3.13 and verify macOS code signature

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -92,15 +92,19 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: '1.3.12'
+          # 1.3.12's `bun build --compile` emits a truncated macOS code
+          # signature (oven-sh/bun#29120): users' kernels SIGKILL the binary
+          # while CI's SIP-disabled runners run it fine. Keep >= 1.3.13 and
+          # keep the "Verify macOS code signature" step below.
+          bun-version: '1.3.13'
 
       - name: Restore Bun install cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: bun-install-${{ runner.os }}-1.3.12-${{ hashFiles('bun.lock') }}
+          key: bun-install-${{ runner.os }}-1.3.13-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            bun-install-${{ runner.os }}-1.3.12-
+            bun-install-${{ runner.os }}-1.3.13-
 
       - name: Install dependencies
         working-directory: tools/cli
@@ -142,6 +146,14 @@ jobs:
             chmod +x ${{ matrix.artifact }}
           fi
           ./${{ matrix.artifact }} --version
+
+      # Running the binary is not enough on macOS: GitHub runners have SIP
+      # disabled, so they execute binaries whose signature the stock kernel
+      # rejects with SIGKILL. Validate the signature statically instead.
+      - name: Verify macOS code signature
+        if: matrix.platform == 'macos'
+        working-directory: tools/cli/dist
+        run: codesign --verify --strict --verbose=2 ${{ matrix.artifact }}
 
       - name: Run smoke tests
         working-directory: tools/cli

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -139,6 +139,17 @@ jobs:
         working-directory: tools/cli/dist
         run: mv ${{ matrix.binary }} ${{ matrix.artifact }}
 
+      # Bun finalizes the compiled binary after signing it, so the signature
+      # never seals the shipped bytes (and 1.3.12's was outright truncated —
+      # oven-sh/bun#29120). Strip and ad-hoc re-sign so the final file carries
+      # a valid seal; without one, stock macOS kernels SIGKILL the binary.
+      - name: Normalize macOS code signature
+        if: matrix.platform == 'macos'
+        working-directory: tools/cli/dist
+        run: |
+          codesign --remove-signature ${{ matrix.artifact }}
+          codesign -s - ${{ matrix.artifact }}
+
       - name: Verify binary
         working-directory: tools/cli/dist
         run: |


### PR DESCRIPTION
Bun 1.3.12's `bun build --compile` emits a truncated macOS code signature (oven-sh/bun#29120). Every released `tale_macos` binary since the pin is SIGKILLed on users' Macs (`Killed: 9`), while CI's SIP-disabled runners execute it fine — so the smoke test stayed green. Verified locally: the v0.2.97 release asset reports "code object is not signed at all" and dies on launch; after `codesign --remove-signature && codesign -s -` it runs.

- Pin Bun 1.3.13 (contains the upstream fix).
- Add a static `codesign --verify --strict` step so this class of breakage fails the build even on SIP-disabled runners.