### PR TITLE
fix(cli): fail installers on dead binary and unsupported arch

### DIFF
--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -248,18 +248,27 @@ function Install-Binary {
     }
 }
 
-# Smoke-test the freshly installed binary by running --version. The version
-# string is folded into the success message when available.
+# Smoke-test the freshly installed binary by running --version. A binary that
+# cannot execute (corrupt download, blocked by policy) must fail the install
+# here — reporting success for a dead binary strands the user at the very
+# next command with no explanation.
 function Verify-Installation {
     if (-not (Test-Path $script:DestPath)) {
         Write-Err "Installation failed. tale not found at $script:DestPath"
     }
     try {
         $version = & $script:DestPath --version 2>&1
-        Write-Ok "Successfully installed tale ($version)"
+        if ($LASTEXITCODE -eq 0 -and $version) {
+            Write-Ok "Successfully installed tale ($version)"
+            return
+        }
     } catch {
-        Write-Ok "Successfully installed tale"
+        # fall through to the failure report below
     }
+    Write-Info "The installed binary did not run. Common causes:"
+    Write-Info "  - A corrupt download: re-run this installer to fetch it again."
+    Write-Info "  - Antivirus or an execution policy blocking $script:DestPath."
+    Write-Err "Installation failed. 'tale --version' did not succeed."
 }
 
 function Main {
@@ -273,9 +282,9 @@ function Main {
     if (-not $script:ExistingTale) {
         Write-Info "Restart your terminal for PATH changes to take effect."
     }
-    # Hand off to the guided, TypeScript-driven setup: it installs Docker if
-    # needed and scaffolds a project — zero prerequisites from here.
-    Write-Ok "Next: run 'tale setup' to install Docker (if needed) and create your project."
+    # Hand off to the CLI: `tale init` scaffolds a project (no prerequisites);
+    # `tale dev` then installs/starts Docker on demand and launches locally.
+    Write-Ok "Next: run 'tale init' to create your project, then 'tale dev' to launch it."
 }
 
 Main

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -20,14 +20,24 @@ error() { printf "\033[1;31mError: %s\033[0m\n" "$1" >&2; exit 1; }
 
 # Map `uname -s` to the platform suffix used in our release asset names
 # (tale_linux, tale_macos). Sets the $PLATFORM global.
+# Releases ship exactly one binary per OS — arm64 for macOS, x86_64 for
+# Linux — so reject other architectures up front with a build-from-source
+# pointer instead of letting the kernel fail later with a cryptic exec error.
 detect_platform() {
-    local os
+    local os arch
     os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
 
     case "$os" in
         linux*)  PLATFORM="linux" ;;
         darwin*) PLATFORM="macos" ;;
         *)       error "Unsupported OS: $os" ;;
+    esac
+
+    case "$PLATFORM-$arch" in
+        macos-arm64 | linux-x86_64 | linux-amd64) ;;
+        macos-*) error "The released macOS binary is arm64-only; this Mac reports ${arch}. Build from source instead: clone https://github.com/${REPO} and run 'bun run build:mac' in tools/cli." ;;
+        linux-*) error "No released binary for linux/${arch} (x86_64 only). Build from source instead: clone https://github.com/${REPO} and run 'bun run build:linux' in tools/cli." ;;
     esac
 }
 
@@ -210,20 +220,29 @@ install_binary() {
     fi
 }
 
-# Smoke-test the freshly installed binary by running --version. The version
-# string is folded into the success message when available.
+# Smoke-test the freshly installed binary by running --version. A binary that
+# cannot execute (killed by the kernel, wrong architecture, corrupt download)
+# must fail the install here — reporting success for a dead binary strands the
+# user at the very next command with no explanation.
 verify_installation() {
-    if command -v "$BINARY_NAME" &>/dev/null; then
-        local version
-        version=$("$BINARY_NAME" --version 2>/dev/null || true)
-        if [ -n "$version" ]; then
-            success "Successfully installed ${BINARY_NAME} (${version})"
-        else
-            success "Successfully installed ${BINARY_NAME}"
-        fi
-    else
+    if ! command -v "$BINARY_NAME" &>/dev/null; then
         error "Installation failed. ${BINARY_NAME} not found in PATH"
     fi
+
+    local version
+    if version=$("$BINARY_NAME" --version 2>/dev/null) && [ -n "$version" ]; then
+        success "Successfully installed ${BINARY_NAME} (${version})"
+        return
+    fi
+
+    info "The installed binary did not run. Common causes:"
+    if [ "$PLATFORM" = "macos" ]; then
+        info "  - macOS refused the binary's code signature ('Killed: 9')."
+        info "    Repair it with: codesign --remove-signature \"$(command -v ${BINARY_NAME})\" && codesign -s - \"$(command -v ${BINARY_NAME})\""
+        info "  - Gatekeeper quarantine: xattr -d com.apple.quarantine \"$(command -v ${BINARY_NAME})\""
+    fi
+    info "  - A corrupt download: re-run this installer to fetch it again."
+    error "Installation failed. '${BINARY_NAME} --version' did not succeed."
 }
 
 main() {


### PR DESCRIPTION
The installers' smoke test swallowed execution failures and printed "Successfully installed tale" even when the binary cannot run — observed live with the mis-signed v0.2.97 macOS asset, where the install reports green and the very next command dies with `Killed: 9` and no explanation.

- `verify_installation` (sh + ps1) now fails with recovery hints when `tale --version` doesn't succeed (macOS: codesign repair + quarantine commands).
- `detect_platform` rejects unsupported architectures up front (released assets are darwin-arm64 and linux-x86_64 only) with a build-from-source pointer, instead of a cryptic exec-format error.
- The Windows installer's final line advertised `tale setup`, a command that does not exist — corrected to `tale init` / `tale dev`.