### PR TITLE
fix(shared): surface per-image pull milestones from compose

### DIFF
--- a/packages/shared/src/classify/sources/docker-compose.test.ts
+++ b/packages/shared/src/classify/sources/docker-compose.test.ts
@@ -17,6 +17,14 @@ describe('classifyDockerCompose', () => {
     expect(c('a1b2c3d4e5f6: Already exists').kind).toBe('progress');
   });
 
+  it('surfaces per-image pull milestones as info, keeping layer churn collapsed', () => {
+    expect(c(' db Pulling ').kind).toBe('info');
+    expect(c(' db Pulling ').text).toBe('db pulling');
+    expect(c(' ✔ platform Pulled ').text).toBe('platform pulled');
+    expect(c(' db Pulled \r').text).toBe('db pulled');
+    expect(c('a1b2c3d4e5f6: Pulling fs layer').kind).toBe('progress');
+  });
+
   it('relabels each lifecycle verb to a clean lowercased status', () => {
     expect(c(' Container tale-db-1  Started').text).toBe('tale-db-1 started');
     expect(c(' Container tale-db-1  Created').text).toBe('tale-db-1 created');

--- a/packages/shared/src/classify/sources/docker-compose.ts
+++ b/packages/shared/src/classify/sources/docker-compose.ts
@@ -16,6 +16,11 @@ import { noise } from '../kinds';
 
 const DOCKER_LAYER =
   /^[0-9a-f]{12,}:\s+(Pulling fs layer|Waiting|Downloading|Verifying Checksum|Download complete|Extracting|Pull complete|Already exists)/;
+// Per-image pull milestones ("db Pulling" / "db Pulled"). Unlike the layer
+// churn above these are few and meaningful — on a first run the pull is the
+// only thing happening for minutes, so they must surface, not collapse.
+const DOCKER_IMAGE_PULL =
+  /^\s*(?:[⠿⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇✔✓]\s*)?(\S+)\s+(Pulling|Pulled)\s*$/;
 const DOCKER_LIFECYCLE =
   /^\s*(?:[⠿⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇✔✓]\s*)?(Container|Network|Volume)\s+(\S+)\s+(Creating|Created|Starting|Started|Healthy|Running|Recreate|Recreated|Removing|Removed|Waiting|Stopping|Stopped)\b/;
 const DOCKER_ERROR =
@@ -28,6 +33,15 @@ export const classifyDockerCompose: Classifier = (line) => {
     return {
       kind: 'progress',
       status: { phase: 'pull' },
+      raw: line,
+      source: 'docker-compose',
+    };
+  }
+  const pull = body.match(DOCKER_IMAGE_PULL);
+  if (pull) {
+    return {
+      kind: 'info',
+      text: `${pull[1]} ${pull[2].toLowerCase()}`,
       raw: line,
       source: 'docker-compose',
     };


### PR DESCRIPTION
On a first `tale dev`, pulling several GB of images is the only thing happening for many minutes, but the compose classifier collapsed every pull line as noise/progress — the terminal showed nothing at all between "Starting Tale" and (eventually) container lifecycle lines. Surface the per-image `<service> Pulling` / `<service> Pulled` milestones as info lines (the per-layer churn stays collapsed). Observed live: a fresh install on a slow connection sat visually dead for 30+ minutes.