### PR TITLE
fix(cli): keep dev readiness watch alive and trust local TLS

### DIFF
--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -71,20 +71,28 @@ async function openBrowser(url: string): Promise<void> {
   }
 }
 
-/** Poll `${url}/health` until it answers 200 or the attempt budget runs out. */
+/**
+ * Poll `${url}/health` until it answers 200 or the attempt budget runs out.
+ * The dev/trial proxy serves a self-signed localhost certificate, so the
+ * probe must accept it — with default TLS verification every attempt would
+ * fail and readiness would never be observed.
+ */
 async function waitForHealth(
   url: string,
   signal?: AbortSignal,
+  maxAttempts = 120,
 ): Promise<boolean> {
   const healthUrl = `${url}/health`;
-  const maxAttempts = 120;
   for (let i = 0; i < maxAttempts; i++) {
     if (signal?.aborted) return false;
     try {
       const fetchSignal = signal
         ? AbortSignal.any([AbortSignal.timeout(2000), signal])
         : AbortSignal.timeout(2000);
-      const res = await fetch(healthUrl, { signal: fetchSignal });
+      const res = await fetch(healthUrl, {
+        signal: fetchSignal,
+        tls: { rejectUnauthorized: false },
+      });
       if (res.ok) return true;
     } catch (err) {
       if (signal?.aborted) return false;
@@ -283,14 +291,25 @@ export async function runDev(options: DevOptions): Promise<void> {
   );
 
   const announce = (async (): Promise<void> => {
-    const ok = await waitForHealth(url, abortController.signal);
-    if (abortController.signal.aborted) return;
-    if (!ok) {
-      warnLine(
-        'Services did not become healthy in time — check the log above.',
-      );
-      return;
+    // Patient by design: a first run pulls several GB of images before any
+    // service can answer, so a bounded wait would declare failure mid-pull
+    // and the READY block would never print. Poll until the stack answers or
+    // compose exits (abort), with a one-time note so the wait never looks
+    // hung.
+    const NOTE_AFTER_MS = 120_000;
+    const started = Date.now();
+    let noted = false;
+    let ok = false;
+    while (!ok && !abortController.signal.aborted) {
+      ok = await waitForHealth(url, abortController.signal, 30);
+      if (!ok && !noted && Date.now() - started >= NOTE_AFTER_MS) {
+        noted = true;
+        infoLine(
+          'Still waiting for services — a first run downloads several GB of images before they can start. Leave this running; rerun with --verbose for full output.',
+        );
+      }
     }
+    if (!ok || abortController.signal.aborted) return;
     const adminKey = await fetchAdminKeyWhenReady(abortController.signal);
     if (abortController.signal.aborted) return;
     void openBrowser(url);

--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -33,6 +33,7 @@ import { ensureDocker } from '../docker/ensure-docker';
 import { ensureNetwork, ensureSandboxNetwork } from '../docker/ensure-network';
 import { ensureVolumes } from '../docker/ensure-volumes';
 import { exec } from '../docker/exec';
+import { getContainerHealth } from '../docker/get-container-health';
 import { findChildProject, findProject } from '../project/find-project';
 import { resolveOrAssignProjectContext } from '../project/project-context';
 import { withLock } from '../state/with-lock';
@@ -72,35 +73,25 @@ async function openBrowser(url: string): Promise<void> {
 }
 
 /**
- * Poll `${url}/health` until it answers 200 or the attempt budget runs out.
- * The dev/trial proxy serves a self-signed localhost certificate, so the
- * probe must accept it — with default TLS verification every attempt would
- * fail and readiness would never be observed.
+ * Wait for the platform container's Docker healthcheck to report healthy.
+ * The old probe fetched `${url}/health` — but that path is answered by the
+ * proxy alone (it returns 200 with no platform container at all), and the
+ * dev proxy's self-signed certificate failed default TLS verification on
+ * every poll, so readiness was never observed. The container health is the
+ * signal deploy already trusts, needs no TLS exception, and only flips once
+ * the app itself is serving.
  */
 async function waitForHealth(
-  url: string,
   signal?: AbortSignal,
   maxAttempts = 120,
 ): Promise<boolean> {
-  const healthUrl = `${url}/health`;
+  const containerName = `${getProjectId()}-platform`;
   for (let i = 0; i < maxAttempts; i++) {
     if (signal?.aborted) return false;
-    try {
-      const fetchSignal = signal
-        ? AbortSignal.any([AbortSignal.timeout(2000), signal])
-        : AbortSignal.timeout(2000);
-      const res = await fetch(healthUrl, {
-        signal: fetchSignal,
-        tls: { rejectUnauthorized: false },
-      });
-      if (res.ok) return true;
-    } catch (err) {
-      if (signal?.aborted) return false;
-      logger.debug(
-        `Health check attempt ${i + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    if ((await getContainerHealth(containerName)) === 'healthy') {
+      return true;
     }
-    await Bun.sleep(1000);
+    await Bun.sleep(2000);
   }
   return false;
 }
@@ -260,7 +251,9 @@ export async function runDev(options: DevOptions): Promise<void> {
     const healthy = await runStep(
       { active: 'Waiting for services', done: 'Services healthy' },
       async () => {
-        if (!(await waitForHealth(url, abortController.signal))) {
+        // First boot bootstraps Convex functions and migrations inside the
+        // platform container — allow up to 10 minutes before warning.
+        if (!(await waitForHealth(abortController.signal, 300))) {
           throw new StepWarning(
             'not healthy yet — they may still be warming up; check `tale logs`',
           );
@@ -279,7 +272,8 @@ export async function runDev(options: DevOptions): Promise<void> {
   //    compose, which stops the stack gracefully (the original contract) — no
   //    manual signal handling, no compose-down spew. Build/pull/HMR noise is
   //    classified away; only meaningful lifecycle/warn/error lines surface. A
-  //    concurrent announcer prints the READY block once /health answers. ──
+  //    concurrent announcer prints the READY block once the platform
+  //    container reports healthy. ──
   const classify = createStreamClassifier(
     chain(
       classifyBuildKit,
@@ -301,7 +295,7 @@ export async function runDev(options: DevOptions): Promise<void> {
     let noted = false;
     let ok = false;
     while (!ok && !abortController.signal.aborted) {
-      ok = await waitForHealth(url, abortController.signal, 30);
+      ok = await waitForHealth(abortController.signal, 30);
       if (!ok && !noted && Date.now() - started >= NOTE_AFTER_MS) {
         noted = true;
         infoLine(


### PR DESCRIPTION
Two compounding defects meant `tale dev`'s READY block (URL, admin key, auto-opened browser) could never appear:

1. The health probe fetched `https://localhost/health` with default TLS verification, which rejects the stack's self-signed certificate — every poll failed (`DEPTH_ZERO_SELF_SIGNED_CERT`), so readiness was never observed on any machine, warm or cold.
2. The announcer gave up permanently after ~2 minutes with "Services did not become healthy in time — check the log above" (an empty log, since pull output is classified away) — mid-way through a first-run image pull the docs themselves budget at 5–10 minutes.

Observed live on a fresh install: stack becomes healthy, CLI stays silent forever.

Fix: gate readiness on the **platform container's Docker healthcheck** (the signal deploy already trusts) instead of an HTTP probe — no TLS exception needed (SAST-clean), and unlike `/health`, which the proxy answers even with no platform container at all, it only flips once the app itself serves. The foreground announcer polls until compose exits, with a one-time first-run note so a long pull never looks hung; the detached path allows 10 minutes for the first-boot Convex bootstrap.