### PR TITLE
fix(platform): survive special files in the config watcher

### DIFF
--- a/services/platform/lib/config-watcher.test.ts
+++ b/services/platform/lib/config-watcher.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { createConfigWatcher } from './config-watcher';
+
+// Convex writes its executor socket (`…/.executor.sock`) under the config
+// dir on self-hosted installs. fs.watch cannot open special files — without
+// the socket guards in createConfigWatcher the resulting ENXIO escaped
+// chokidar and crash-looped the platform on first boot. This test recreates
+// that layout with a real unix socket: the watcher must survive it and still
+// deliver events for ordinary config writes.
+describe('createConfigWatcher — special files in the config dir', () => {
+  let configDir: string;
+  let socketServer: Server | undefined;
+  let watcher: ReturnType<typeof createConfigWatcher> | undefined;
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), 'config-watcher-test-'));
+  });
+
+  afterEach(async () => {
+    await watcher?.close();
+    await new Promise<void>((resolve) => {
+      if (!socketServer) return resolve();
+      socketServer.close(() => resolve());
+    });
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test('survives a unix socket and still emits for config writes', async () => {
+    const socketDir = join(configDir, 'convex', 'tmp');
+    mkdirSync(socketDir, { recursive: true });
+    socketServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+      socketServer?.once('error', reject);
+      socketServer?.listen(join(socketDir, '.executor.sock'), resolve);
+    });
+
+    watcher = createConfigWatcher(configDir);
+    const events: unknown[] = [];
+    watcher.onChange((event) => {
+      events.push(event);
+    });
+
+    // Give chokidar time to walk the tree (and hit the socket) before the
+    // config write below — the pre-fix failure mode was a crash right here.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const agentDir = join(configDir, 'default', 'agents');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'helper.json'), '{}');
+
+    await expect
+      .poll(() => events.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+  });
+});

--- a/services/platform/lib/config-watcher.ts
+++ b/services/platform/lib/config-watcher.ts
@@ -101,7 +101,22 @@ export function createConfigWatcher(configDir: string): ConfigWatcher {
     ignored: [
       /(^|[/\\])\.history/, // history directories
       ATOMIC_WRITE_TMP_RE, // atomicWrite temp files
+      // Special files (unix sockets, FIFOs): fs.watch cannot open them, and
+      // the resulting ENXIO escaped chokidar and killed the platform. Convex
+      // writes its executor socket under the config dir on self-hosted
+      // installs, so a fresh instance crash-looped on first boot. The name
+      // pattern catches the known case even when stats are unavailable; the
+      // stats matcher covers every other special file.
+      /\.sock$/,
+      (_path, stats) =>
+        stats != null && !stats.isFile() && !stats.isDirectory(),
     ],
+  });
+
+  // A watch failure on one path must never take the platform down — log it
+  // and keep watching the rest of the tree.
+  watcher.on('error', (error) => {
+    console.warn('[config-watcher] watch error (ignored):', error);
   });
 
   // Per-key tail debounce: collapses bursts of events for the same


### PR DESCRIPTION
A fresh self-hosted install crash-looped on first boot, before the owner could ever sign up: Convex's executor writes a unix socket under the config dir (`…/convex/tmp/.tmpXXX/.executor.sock`), `fs.watch` cannot open special files, and the resulting ENXIO escaped chokidar (under Bun the throw is asynchronous and uncatchable) and killed the platform. The entrypoint restarts it, the socket is still there, repeat forever. Reproduced live on the released 0.2.97 image via the documented quickstart.

Fix: ignore `*.sock` and any non-file/non-directory entry in the watcher, and log watch errors instead of dying. The regression test recreates the layout with a real unix socket in the watched tree.