### PR TITLE
fix(platform): say why the composer blocks a send with no provider key

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -1013,6 +1013,15 @@ export function ChatInput({
                 optionId={(index) => `${mentionListboxId}-option-${index}`}
               />
             )}
+            {/* A blocked send must say so where the user is looking: the
+                disabled button's tooltip and the Enter toast are invisible
+                until interacted with, which read as "the app is dead" on a
+                fresh install with no provider key. */}
+            {sendBlocked && sendBlockedReason && !isLoading && (
+              <p role="status" className="text-destructive px-1 pb-1 text-xs">
+                {sendBlockedReason}
+              </p>
+            )}
             <label
               id={textareaLabelId}
               htmlFor={textareaId}

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -366,6 +366,19 @@ export function ChatInterface({
     'hasApiKey' in activeProvider &&
     !activeProvider.hasApiKey &&
     !activeModelInfo?.hasApiKeyOverride;
+  // A brand-new org ships the model catalog with no credentials at all. In
+  // that state even "Auto" cannot route anywhere — but no concrete provider
+  // resolves, so activeModelMissingApiKey stays false and the composer used
+  // to disable Send without ever stating a reason. Only blocks once the
+  // provider list has loaded and none of them carries a key.
+  const noProviderHasApiKey =
+    providersForEdit.length > 0 &&
+    providersForEdit.every(
+      // Only a provider that definitively reports "no key" counts — a shape
+      // without the field (redacted/partial) must never cause a false block.
+      (p) => !!p && 'hasApiKey' in p && p.hasApiKey === false,
+    ) &&
+    !activeModelInfo?.hasApiKeyOverride;
   const { active: activeEditingImage } = useEffectiveEditingImage(threadImages);
   const { setEditingImageRef, setDismissedImageKey } = useChatLayout();
 
@@ -1400,7 +1413,8 @@ export function ChatInterface({
                     (isImageGenAgent &&
                       !!activeEditingImage &&
                       !currentModelSupportsEdit) ||
-                    activeModelMissingApiKey
+                    activeModelMissingApiKey ||
+                    noProviderHasApiKey
                   }
                   sendBlockedReason={
                     isImageGenAgent &&
@@ -1409,7 +1423,9 @@ export function ChatInterface({
                       ? t('imageEdit.modelCannotEdit')
                       : activeModelMissingApiKey
                         ? t('modelSelector.noApiKey')
-                        : undefined
+                        : noProviderHasApiKey
+                          ? t('modelSelector.noProviderKey')
+                          : undefined
                   }
                   onSavePrompt={(content) =>
                     setSavePromptData({ messageId: '', content })

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1322,6 +1322,7 @@
       "viewProvider": "Anbietereinstellungen anzeigen",
       "viewInfo": "Modelldetails",
       "noApiKey": "Für den Anbieter dieses Modells ist kein API-Schlüssel konfiguriert — füge in Einstellungen → KI-Anbieter einen hinzu.",
+      "noProviderKey": "Noch kein KI-Anbieter verbunden — hinterlege in Einstellungen → KI-Anbieter einen API-Schlüssel, um loszulegen.",
       "info": {
         "provider": "Anbieter",
         "type": "Typ",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1322,6 +1322,7 @@
       "viewProvider": "View provider settings",
       "viewInfo": "Model details",
       "noApiKey": "No API key configured for this model's provider — add one in Settings → AI providers.",
+      "noProviderKey": "No AI provider is connected yet — add an API key in Settings → AI providers to start chatting.",
       "info": {
         "provider": "Provider",
         "type": "Type",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1323,6 +1323,7 @@
       "viewProvider": "Voir les paramètres du fournisseur",
       "viewInfo": "Détails du modèle",
       "noApiKey": "Aucune clé API configurée pour le fournisseur de ce modèle — ajoutes-en une dans Paramètres → Fournisseurs d’IA.",
+      "noProviderKey": "Aucun fournisseur d’IA n’est encore connecté — ajoute une clé API dans Paramètres → Fournisseurs d’IA pour commencer à discuter.",
       "info": {
         "provider": "Fournisseur",
         "type": "Type",


### PR DESCRIPTION
Observed live on a fresh install (the documented quickstart, provider step skipped — the common evaluator path): the model picker lists the seeded catalog (Claude, GPT, Gemini) as if usable, the user types a first message, presses Enter — and nothing happens. Send is disabled with no visible reason anywhere; even Settings → AI providers shows the OpenRouter row with "49 models" and no missing-key state. It is the sharpest dead-end of the first-run experience.

Root cause: the missing-key detection resolves a *concrete* provider for the selected model. With **Auto** selected nothing resolves, so `activeModelMissingApiKey` stays false, `sendBlocked` is never set, and the existing feedback paths (hover tooltip on the disabled button, destructive toast on Enter) never fire.

Fix:
- Detect the org-wide state: provider list loaded and **every** provider definitively reports no key (field present and false — a redacted shape never causes a false block) → `sendBlocked` with a localized reason (en/de/fr).
- Render the blocked reason as a visible `role=status` notice above the composer — the tooltip and Enter-toast are invisible until interacted with, which reads as "the app is dead".

Follow-up candidates (out of scope): admin deep-link to Settings → AI providers in the notice, and a missing-key badge on catalog models in the picker.

Typecheck green; chat-input tests 20/20; Opengrep 0 findings.