### PR TITLE
docs: add community files and point READMEs at hosted docs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for a security problem. Report it privately
+through GitHub: the repository's **Security** tab → **Report a vulnerability**.
+If you cannot use GitHub, email `security@tale.dev`.
+
+Include what you can — the affected component, reproduction steps, and impact.
+Reporters are credited in the resulting advisory if they wish.
+
+## Supported versions
+
+Tale is a rolling-release 0.x project. Security fixes land in the latest release
+only; there are no backports to earlier versions. Keep your deployment current
+with `tale update` followed by `tale deploy`.
+
+## What to expect
+
+- Acknowledgement and triage within 72 hours.
+- A fix or workaround shared privately with the reporter within 14 days.
+- A GitHub Security Advisory published with the patched release.
+
+The advisory format, severity scale, and full disclosure timeline are documented
+in [Security advisories](https://tale.dev/docs/self-hosted/operate/security/advisories).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting the
+maintainers via GitHub — through GitHub's private reporting mechanisms (such as
+[reporting abuse](https://docs.github.com/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam))
+or by reaching out to a repository maintainer directly.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.de.md
+++ b/README.de.md
@@ -11,8 +11,8 @@ Verbinde **OpenClaw**, **Hermes Agent**, **Claude Code**, **Codex**, **Cursor**,
 Bündle ihr Wissen, delegiere Aufgaben und bau deinen Schwarm aus Agents.
 
 [![Lizenz: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-tale-0a0a0a.svg)](docs/de/index.md)
-[![Self-hosted](https://img.shields.io/badge/self--hosted-Docker-2496ed.svg)](docs/de/self-hosted/install/quickstart.md)
+[![Docs](https://img.shields.io/badge/docs-tale-0a0a0a.svg)](https://tale.dev/docs/de)
+[![Self-hosted](https://img.shields.io/badge/self--hosted-Docker-2496ed.svg)](https://tale.dev/docs/de/self-hosted/install/quickstart)
 
 [Schnellstart](#schnellstart) · [Was kannst du tun?](#was-kannst-du-tun) · [Befehle](#befehlsreferenz) · [Dokumentation](#dokumentation) · [Mitwirken](#mitwirken)
 
@@ -27,7 +27,7 @@ Tale ist eine **selbstgehostete KI-Plattform**, die die Agents und CLIs, die dei
 **Wähl deinen Weg:**
 
 - **Tale lokal ausprobieren** — installier die CLI und lauf zwei Befehle auf deiner eigenen Maschine. Beginn mit [Schnellstart](#schnellstart) unten.
-- **Tale Cloud nutzen** — lass Tale den Stack betreiben, melde dich an und bring dein Team an Bord. Beginn mit [Cloud-Onboarding](docs/de/cloud/onboarding.md).
+- **Tale Cloud nutzen** — lass Tale den Stack betreiben, melde dich an und bring dein Team an Bord. Beginn mit [Cloud-Onboarding](https://tale.dev/docs/de/cloud/onboarding).
 - **Mitwirken** — lass Tale aus dem Quellcode laufen und gib eine Änderung zurück. Beginn mit [Contributor-Setup](docs/de/develop/contributor-setup.md).
 
 ## Schnellstart
@@ -71,7 +71,7 @@ Sobald "Tale is running" erscheint, öffnet `tale dev` https://localhost (oder d
 
 > **Hinweis:** Dein Browser zeigt eine Zertifikatswarnung für selbstsignierte Zertifikate. Die ist sicher zu akzeptieren.
 
-Eine ausführliche Einrichtungsanleitung findest du im [Self-hosted-Quickstart](docs/de/self-hosted/install/quickstart.md).
+Eine ausführliche Einrichtungsanleitung findest du im [Self-hosted-Quickstart](https://tale.dev/docs/de/self-hosted/install/quickstart).
 
 ## Was kannst du tun?
 
@@ -116,7 +116,7 @@ tale cleanup                       # Inaktive Container entfernen
 tale reset --force                 # Alle Container entfernen
 ```
 
-In der [CLI-Referenz](tools/cli/README.md) findest du alle Optionen und Flags. Eine bestehende Installation aktualisierst du mit zwei Befehlen: `tale update` hebt die CLI und deine Projektdateien auf die neue Version, `tale deploy` rollt danach die Container. Das vollständige Runbook findest du in [Self-hosted Upgrades](docs/de/self-hosted/operate/upgrades.md).
+In der [CLI-Referenz](tools/cli/README.md) findest du alle Optionen und Flags. Eine bestehende Installation aktualisierst du mit zwei Befehlen: `tale update` hebt die CLI und deine Projektdateien auf die neue Version, `tale deploy` rollt danach die Container. Das vollständige Runbook findest du in [Self-hosted Upgrades](https://tale.dev/docs/de/self-hosted/operate/upgrades).
 
 ## In Produktion deployen
 
@@ -124,11 +124,11 @@ In der [CLI-Referenz](tools/cli/README.md) findest du alle Optionen und Flags. E
 tale deploy
 ```
 
-Die CLI macht Blue-Green-Zero-Downtime-Deployments mit automatischen Health-Checks und Rollback. Für die volle Produktions-Einrichtung inkl. Reverse-Proxy-Konfiguration und Subpath-Deployment siehe den [Produktions-Deployment-Guide](docs/de/self-hosted/install/linux-server.md).
+Die CLI macht Blue-Green-Zero-Downtime-Deployments mit automatischen Health-Checks und Rollback. Für die volle Produktions-Einrichtung inkl. Reverse-Proxy-Konfiguration und Subpath-Deployment siehe den [Produktions-Deployment-Guide](https://tale.dev/docs/de/self-hosted/install/linux-server).
 
 ## Authentifizierungs-Optionen
 
-Tale nutzt standardmässig passwortbasierte Authentifizierung. Der erste User legt das Owner-Konto an; alle weiteren werden vom Admin angelegt. Für Self-Service-Login verbindest du SSO oder Trusted Headers über Microsoft Entra ID — siehe die [Integrationen-Übersicht](docs/de/platform/integrations/overview.md) für den Microsoft-365-Connector, der sowohl Dokumentensynchronisation als auch SSO bedient.
+Tale nutzt standardmässig passwortbasierte Authentifizierung. Der erste User legt das Owner-Konto an; alle weiteren werden vom Admin angelegt. Für Self-Service-Login verbindest du SSO oder Trusted Headers über Microsoft Entra ID — siehe die [Integrationen-Übersicht](https://tale.dev/docs/de/platform/integrations/overview) für den Microsoft-365-Connector, der sowohl Dokumentensynchronisation als auch SSO bedient.
 
 - **Microsoft Entra ID (SSO):** Single Sign-On mit Microsoft 365 / Azure AD inkl. automatischem Provisioning
 - **Trusted Headers:** Für Deployments hinter einem authentifizierenden Reverse-Proxy (Authelia, Authentik, oauth2-proxy)
@@ -172,62 +172,62 @@ Praktisch, wenn du schnelle Vite-Reloads willst, aber ein stabiles Convex-Backen
 
 ## Dokumentation
 
-Doku-Seite und Plattform-UI laufen in drei Basis-Sprachen (`en`, `de`, `fr`) plus regionalen Varianten, wo lokale Formulierungen abweichen (heute: `de-CH`; der Loader erkennt jedes neue `xx-YY`-Bundle automatisch). Varianten tragen nur die Strings, die von ihrer Basis abweichen; fehlende Keys fallen über die Basis bis auf Englisch zurück. Start unter [`docs/de/index.md`](docs/de/index.md), um nach Persona einzusteigen.
+Doku-Seite und Plattform-UI laufen in drei Basis-Sprachen (`en`, `de`, `fr`) plus regionalen Varianten, wo lokale Formulierungen abweichen (heute: `de-CH`; der Loader erkennt jedes neue `xx-YY`-Bundle automatisch). Varianten tragen nur die Strings, die von ihrer Basis abweichen; fehlende Keys fallen über die Basis bis auf Englisch zurück. Start unter [tale.dev/docs/de](https://tale.dev/docs/de), um nach Persona einzusteigen (Quelle: [`docs/de/index.md`](docs/de/index.md)).
 
 <details>
 <summary><strong>Für alltägliche Nutzer</strong></summary>
 
-- **[Chat-Übersicht](docs/de/platform/chat/overview.md)** — die vier Bereiche des Bildschirms, wo es tiefer geht
-- **[KI-Chat-Grundlagen](docs/de/platform/chat/basics.md)** — Composer, Agents, Modell-Picker, Streaming, Zitate
-- **[Tiefenrecherche](docs/de/platform/chat/deep-research.md)** — der Researcher-Agent mit Live-Plan und PDF-Bericht
-- **[Anhänge](docs/de/platform/chat/attachments.md)** — Dateien im Chat, RAG vs wörtlich
-- **[Geteilte Chats](docs/de/platform/chat/shared-threads.md)** — Chat per Link mit der Org teilen, in einen eigenen forken
-- **[Genehmigungen](docs/de/platform/approvals/concepts.md)** — KI-Aktionen prüfen
+- **[Chat-Übersicht](https://tale.dev/docs/de/platform/chat/overview)** — die vier Bereiche des Bildschirms, wo es tiefer geht
+- **[KI-Chat-Grundlagen](https://tale.dev/docs/de/platform/chat/basics)** — Composer, Agents, Modell-Picker, Streaming, Zitate
+- **[Tiefenrecherche](https://tale.dev/docs/de/platform/chat/deep-research)** — der Researcher-Agent mit Live-Plan und PDF-Bericht
+- **[Anhänge](https://tale.dev/docs/de/platform/chat/attachments)** — Dateien im Chat, RAG vs wörtlich
+- **[Geteilte Chats](https://tale.dev/docs/de/platform/chat/shared-threads)** — Chat per Link mit der Org teilen, in einen eigenen forken
+- **[Genehmigungen](https://tale.dev/docs/de/platform/approvals/concepts)** — KI-Aktionen prüfen
 
 </details>
 
 <details>
 <summary><strong>Für Bauende (Agents, Automatisierungen, Integrationen)</strong></summary>
 
-- **[Agent-Konzepte](docs/de/platform/agents/concepts.md)** — das Vier-Knöpfe-Modell hinter jedem Agent
-- **[Einen Agent erstellen](docs/de/platform/agents/create.md)** — spezialisierte KI-Assistenten von Anfang bis Ende
-- **[Agent-Tools](docs/de/platform/agents/tools.md)** — die eingebauten Tool-Familien
-- **[Projekte](docs/de/platform/projects/overview.md)** — geteilter Workspace für Dateien, Chats und Projekt-Agents
-- **[Automatisierungs-Konzepte](docs/de/platform/automations/concepts.md)** — Workflows, Trigger, Genehmigungstore
-- **[Integrationen-Übersicht](docs/de/platform/integrations/overview.md)** — Slack, Teams, Gmail, Outlook, Microsoft 365, Google Drive, Confluence, WebDAV, GitHub, Shopify, Tavily, MCP
-- **[Modelle out of the box](docs/de/platform/models.md)** — OpenRouter als einziger Default-Provider, plus die ausgelieferten Modelllisten
+- **[Agent-Konzepte](https://tale.dev/docs/de/platform/agents/concepts)** — das Vier-Knöpfe-Modell hinter jedem Agent
+- **[Einen Agent erstellen](https://tale.dev/docs/de/platform/agents/create)** — spezialisierte KI-Assistenten von Anfang bis Ende
+- **[Agent-Tools](https://tale.dev/docs/de/platform/agents/tools)** — die eingebauten Tool-Familien
+- **[Projekte](https://tale.dev/docs/de/platform/projects/overview)** — geteilter Workspace für Dateien, Chats und Projekt-Agents
+- **[Automatisierungs-Konzepte](https://tale.dev/docs/de/platform/automations/concepts)** — Workflows, Trigger, Genehmigungstore
+- **[Integrationen-Übersicht](https://tale.dev/docs/de/platform/integrations/overview)** — Slack, Teams, Gmail, Outlook, Microsoft 365, Google Drive, Confluence, WebDAV, GitHub, Shopify, Tavily, MCP
+- **[Modelle out of the box](https://tale.dev/docs/de/platform/models)** — OpenRouter als einziger Default-Provider, plus die ausgelieferten Modelllisten
 
 </details>
 
 <details>
 <summary><strong>Für Admins</strong></summary>
 
-- **[Mitglieder und Rollen](docs/de/platform/admin/members-and-roles.md)** — Userverwaltung und Berechtigungs-Matrix
-- **[Modelle out of the box](docs/de/platform/models.md)** — welche Modelle die Defaults mitbringen; Provider tauschen oder hinzufügen
-- **[Integrationen-Übersicht](docs/de/platform/integrations/overview.md)** — Drittanbieter-Konnektoren, MCP-Server, eigene Konfigurationen
-- **[Cloud-Trust und Compliance](docs/de/cloud/trust-and-compliance.md)** — Frameworks, geteilte Verantwortung, Belege für Auditoren
+- **[Mitglieder und Rollen](https://tale.dev/docs/de/platform/admin/members-and-roles)** — Userverwaltung und Berechtigungs-Matrix
+- **[Modelle out of the box](https://tale.dev/docs/de/platform/models)** — welche Modelle die Defaults mitbringen; Provider tauschen oder hinzufügen
+- **[Integrationen-Übersicht](https://tale.dev/docs/de/platform/integrations/overview)** — Drittanbieter-Konnektoren, MCP-Server, eigene Konfigurationen
+- **[Cloud-Trust und Compliance](https://tale.dev/docs/de/cloud/trust-and-compliance)** — Frameworks, geteilte Verantwortung, Belege für Auditoren
 
 </details>
 
 <details>
 <summary><strong>Für Operators</strong></summary>
 
-- **[Self-hosted-Übersicht](docs/de/self-hosted/overview.md)** — Architektur und Dienste
-- **[Quickstart](docs/de/self-hosted/install/quickstart.md)** — Single-Host-Installation in zwanzig Minuten
-- **[Produktions-Deployment](docs/de/self-hosted/install/linux-server.md)** — Linux-Server mit TLS, Firewall, Non-Root-User
-- **[Docker-Compose-Referenz](docs/de/self-hosted/install/docker-compose-reference.md)** — Basis-Datei und Overlays
+- **[Self-hosted-Übersicht](https://tale.dev/docs/de/self-hosted/overview)** — Architektur und Dienste
+- **[Quickstart](https://tale.dev/docs/de/self-hosted/install/quickstart)** — Single-Host-Installation in zwanzig Minuten
+- **[Produktions-Deployment](https://tale.dev/docs/de/self-hosted/install/linux-server)** — Linux-Server mit TLS, Firewall, Non-Root-User
+- **[Docker-Compose-Referenz](https://tale.dev/docs/de/self-hosted/install/docker-compose-reference)** — Basis-Datei und Overlays
 - **[Tale CLI](tools/cli/README.md)** — CLI-Referenz
-- **[Environment-Referenz](docs/de/self-hosted/configuration/environment-reference.md)** — alle Environment-Variablen
-- **[Container-Architektur](docs/de/self-hosted/operate/container-architecture.md)** — sieben Container, was was besitzt
+- **[Environment-Referenz](https://tale.dev/docs/de/self-hosted/configuration/environment-reference)** — alle Environment-Variablen
+- **[Container-Architektur](https://tale.dev/docs/de/self-hosted/operate/container-architecture)** — sieben Container, was was besitzt
 
 </details>
 
 <details>
 <summary><strong>Für Developer</strong></summary>
 
-- **[API-Referenz](docs/de/develop/api-reference.md)** — REST-API für Agenten, Chat, Wissen und Workflows
-- **[Webhooks](docs/de/develop/webhooks.md)** — Workflow- und Agent-Webhooks mit Signaturprüfung
-- **[Develop-Übersicht](docs/de/develop/overview.md)** — die Entwickler-Oberfläche von Anfang bis Ende
+- **[API-Referenz](https://tale.dev/docs/de/develop/api-reference)** — REST-API für Agenten, Chat, Wissen und Workflows
+- **[Webhooks](https://tale.dev/docs/de/develop/webhooks)** — Workflow- und Agent-Webhooks mit Signaturprüfung
+- **[Develop-Übersicht](https://tale.dev/docs/de/develop/overview)** — die Entwickler-Oberfläche von Anfang bis Ende
 
 </details>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,8 +11,8 @@ Connecte **OpenClaw**, **Hermes Agent**, **Claude Code**, **Codex**, **Cursor**,
 Mets en commun leurs connaissances, délègue des tâches et construis ton essaim d'agents.
 
 [![Licence : MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-tale-0a0a0a.svg)](docs/fr/index.md)
-[![Auto-hébergé](https://img.shields.io/badge/self--hosted-Docker-2496ed.svg)](docs/fr/self-hosted/install/quickstart.md)
+[![Docs](https://img.shields.io/badge/docs-tale-0a0a0a.svg)](https://tale.dev/docs/fr)
+[![Auto-hébergé](https://img.shields.io/badge/self--hosted-Docker-2496ed.svg)](https://tale.dev/docs/fr/self-hosted/install/quickstart)
 
 [Démarrage rapide](#démarrage-rapide) · [Que peux-tu faire ?](#que-peux-tu-faire) · [Commandes](#référence-des-commandes) · [Documentation](#documentation) · [Contribuer](#contribuer)
 
@@ -27,7 +27,7 @@ Tale est une **plateforme IA auto-hébergée** qui transforme les agents et CLI 
 **Choisis ta voie :**
 
 - **Essayer Tale en local** — installe la CLI et lance deux commandes sur ta propre machine. Commence par [Démarrage rapide](#démarrage-rapide) ci-dessous.
-- **Utiliser Tale Cloud** — laisse Tale exploiter la stack, inscris-toi et embarque ton équipe. Commence par [Onboarding Cloud](docs/fr/cloud/onboarding.md).
+- **Utiliser Tale Cloud** — laisse Tale exploiter la stack, inscris-toi et embarque ton équipe. Commence par [Onboarding Cloud](https://tale.dev/docs/fr/cloud/onboarding).
 - **Contribuer** — fais tourner Tale depuis le code source et renvoie une modification. Commence par [Configuration contributeur](docs/fr/develop/contributor-setup.md).
 
 ## Démarrage rapide
@@ -71,7 +71,7 @@ Dès que tu vois « Tale is running », `tale dev` ouvre https://localhost (ou t
 
 > **Note :** ton navigateur affichera un avertissement de certificat pour les certificats auto-signés. C'est sûr de l'accepter.
 
-Pour les instructions détaillées d'installation, voir le [démarrage rapide auto-hébergé](docs/fr/self-hosted/install/quickstart.md).
+Pour les instructions détaillées d'installation, voir le [démarrage rapide auto-hébergé](https://tale.dev/docs/fr/self-hosted/install/quickstart).
 
 ## Que peux-tu faire ?
 
@@ -116,7 +116,7 @@ tale cleanup                       # Supprimer les conteneurs inactifs
 tale reset --force                 # Supprimer tous les conteneurs
 ```
 
-Voir la [référence du CLI](tools/cli/README.md) pour toutes les options et flags. Mettre à jour un déploiement existant tient en deux commandes : `tale update` fait passer le CLI et tes fichiers de projet à la nouvelle version, puis `tale deploy` fait tourner les conteneurs. Le runbook complet se trouve dans [Mises à niveau auto-hébergées](docs/fr/self-hosted/operate/upgrades.md).
+Voir la [référence du CLI](tools/cli/README.md) pour toutes les options et flags. Mettre à jour un déploiement existant tient en deux commandes : `tale update` fait passer le CLI et tes fichiers de projet à la nouvelle version, puis `tale deploy` fait tourner les conteneurs. Le runbook complet se trouve dans [Mises à niveau auto-hébergées](https://tale.dev/docs/fr/self-hosted/operate/upgrades).
 
 ## Déployer en production
 
@@ -124,11 +124,11 @@ Voir la [référence du CLI](tools/cli/README.md) pour toutes les options et fla
 tale deploy
 ```
 
-Le CLI gère des déploiements blue-green sans downtime avec health-checks et rollback automatiques. Pour l'installation production complète (configuration reverse proxy et déploiement en sous-chemin), voir le [guide de déploiement production](docs/fr/self-hosted/install/linux-server.md).
+Le CLI gère des déploiements blue-green sans downtime avec health-checks et rollback automatiques. Pour l'installation production complète (configuration reverse proxy et déploiement en sous-chemin), voir le [guide de déploiement production](https://tale.dev/docs/fr/self-hosted/install/linux-server).
 
 ## Options d'authentification
 
-Tale utilise par défaut l'authentification par mot de passe. Le premier utilisateur crée le compte propriétaire ; tous les autres sont créés par un admin. Pour activer le login en self-service, branche un SSO ou des trusted headers via Microsoft Entra ID — voir l'[aperçu des intégrations](docs/fr/platform/integrations/overview.md) pour le connecteur Microsoft 365 qui alimente à la fois la synchro de documents et le SSO.
+Tale utilise par défaut l'authentification par mot de passe. Le premier utilisateur crée le compte propriétaire ; tous les autres sont créés par un admin. Pour activer le login en self-service, branche un SSO ou des trusted headers via Microsoft Entra ID — voir l'[aperçu des intégrations](https://tale.dev/docs/fr/platform/integrations/overview) pour le connecteur Microsoft 365 qui alimente à la fois la synchro de documents et le SSO.
 
 - **Microsoft Entra ID (SSO) :** single sign-on avec Microsoft 365 / Azure AD avec provisioning automatique
 - **Trusted headers :** pour les déploiements derrière un reverse proxy authentifiant (Authelia, Authentik, oauth2-proxy)
@@ -172,62 +172,62 @@ Pratique quand tu veux des reloads Vite rapides mais un backend Convex stable qu
 
 ## Documentation
 
-Le site de doc et l'UI de la plateforme tournent en trois langues de base (`en`, `de`, `fr`) plus des variantes régionales lorsque la formulation locale diffère (aujourd'hui : `de-CH` ; le chargeur détecte tout nouveau bundle `xx-YY` automatiquement). Les variantes ne portent que les chaînes qui diffèrent de leur base ; les clés manquantes retombent via la base jusqu'à l'anglais. Démarre par [`docs/fr/index.md`](docs/fr/index.md) pour choisir un point d'entrée par persona.
+Le site de doc et l'UI de la plateforme tournent en trois langues de base (`en`, `de`, `fr`) plus des variantes régionales lorsque la formulation locale diffère (aujourd'hui : `de-CH` ; le chargeur détecte tout nouveau bundle `xx-YY` automatiquement). Les variantes ne portent que les chaînes qui diffèrent de leur base ; les clés manquantes retombent via la base jusqu'à l'anglais. Démarre par [tale.dev/docs/fr](https://tale.dev/docs/fr) pour choisir un point d'entrée par persona (source : [`docs/fr/index.md`](docs/fr/index.md)).
 
 <details>
 <summary><strong>Pour les utilisateurs au quotidien</strong></summary>
 
-- **[Aperçu du chat](docs/fr/platform/chat/overview.md)** — les quatre parties de l'écran, où creuser
-- **[Bases du chat IA](docs/fr/platform/chat/basics.md)** — composer, agents, sélecteur de modèles, streaming, citations
-- **[Recherche approfondie](docs/fr/platform/chat/deep-research.md)** — l'agent Chercheur avec plan en direct et rapport PDF
-- **[Pièces jointes](docs/fr/platform/chat/attachments.md)** — fichiers dans le chat, RAG vs tel quel
-- **[Chats partagés](docs/fr/platform/chat/shared-threads.md)** — partager un chat avec l'organisation, dupliquer en un chat à toi
-- **[Approbations](docs/fr/platform/approvals/concepts.md)** — relire les actions IA
+- **[Aperçu du chat](https://tale.dev/docs/fr/platform/chat/overview)** — les quatre parties de l'écran, où creuser
+- **[Bases du chat IA](https://tale.dev/docs/fr/platform/chat/basics)** — composer, agents, sélecteur de modèles, streaming, citations
+- **[Recherche approfondie](https://tale.dev/docs/fr/platform/chat/deep-research)** — l'agent Chercheur avec plan en direct et rapport PDF
+- **[Pièces jointes](https://tale.dev/docs/fr/platform/chat/attachments)** — fichiers dans le chat, RAG vs tel quel
+- **[Chats partagés](https://tale.dev/docs/fr/platform/chat/shared-threads)** — partager un chat avec l'organisation, dupliquer en un chat à toi
+- **[Approbations](https://tale.dev/docs/fr/platform/approvals/concepts)** — relire les actions IA
 
 </details>
 
 <details>
 <summary><strong>Pour les bâtisseurs (agents, automatisations, intégrations)</strong></summary>
 
-- **[Concepts d'agent](docs/fr/platform/agents/concepts.md)** — le modèle à quatre boutons derrière chaque agent
-- **[Créer un agent](docs/fr/platform/agents/create.md)** — assistants IA spécialisés de bout en bout
-- **[Outils d'agent](docs/fr/platform/agents/tools.md)** — les familles d'outils intégrées
-- **[Projets](docs/fr/platform/projects/overview.md)** — espace de travail partagé pour fichiers, chats et agents de Projet
-- **[Concepts d'automatisation](docs/fr/platform/automations/concepts.md)** — workflows, déclencheurs, portes d'approbation
-- **[Aperçu des intégrations](docs/fr/platform/integrations/overview.md)** — Slack, Teams, Gmail, Outlook, Microsoft 365, Google Drive, Confluence, WebDAV, GitHub, Shopify, Tavily, MCP
-- **[Modèles livrés en standard](docs/fr/platform/models.md)** — OpenRouter comme unique fournisseur par défaut, plus les listes de modèles livrées
+- **[Concepts d'agent](https://tale.dev/docs/fr/platform/agents/concepts)** — le modèle à quatre boutons derrière chaque agent
+- **[Créer un agent](https://tale.dev/docs/fr/platform/agents/create)** — assistants IA spécialisés de bout en bout
+- **[Outils d'agent](https://tale.dev/docs/fr/platform/agents/tools)** — les familles d'outils intégrées
+- **[Projets](https://tale.dev/docs/fr/platform/projects/overview)** — espace de travail partagé pour fichiers, chats et agents de Projet
+- **[Concepts d'automatisation](https://tale.dev/docs/fr/platform/automations/concepts)** — workflows, déclencheurs, portes d'approbation
+- **[Aperçu des intégrations](https://tale.dev/docs/fr/platform/integrations/overview)** — Slack, Teams, Gmail, Outlook, Microsoft 365, Google Drive, Confluence, WebDAV, GitHub, Shopify, Tavily, MCP
+- **[Modèles livrés en standard](https://tale.dev/docs/fr/platform/models)** — OpenRouter comme unique fournisseur par défaut, plus les listes de modèles livrées
 
 </details>
 
 <details>
 <summary><strong>Pour les admins</strong></summary>
 
-- **[Membres et rôles](docs/fr/platform/admin/members-and-roles.md)** — gestion des utilisateurs et matrice de permissions
-- **[Modèles livrés en standard](docs/fr/platform/models.md)** — quels modèles les défauts embarquent ; échanger ou ajouter un fournisseur
-- **[Aperçu des intégrations](docs/fr/platform/integrations/overview.md)** — connecteurs tiers, serveurs MCP, configurations personnalisées
-- **[Cloud trust et conformité](docs/fr/cloud/trust-and-compliance.md)** — cadres, responsabilité partagée, preuves à remettre aux auditeurs
+- **[Membres et rôles](https://tale.dev/docs/fr/platform/admin/members-and-roles)** — gestion des utilisateurs et matrice de permissions
+- **[Modèles livrés en standard](https://tale.dev/docs/fr/platform/models)** — quels modèles les défauts embarquent ; échanger ou ajouter un fournisseur
+- **[Aperçu des intégrations](https://tale.dev/docs/fr/platform/integrations/overview)** — connecteurs tiers, serveurs MCP, configurations personnalisées
+- **[Cloud trust et conformité](https://tale.dev/docs/fr/cloud/trust-and-compliance)** — cadres, responsabilité partagée, preuves à remettre aux auditeurs
 
 </details>
 
 <details>
 <summary><strong>Pour les opérateurs</strong></summary>
 
-- **[Aperçu auto-hébergé](docs/fr/self-hosted/overview.md)** — architecture et services
-- **[Démarrage rapide](docs/fr/self-hosted/install/quickstart.md)** — installation sur un seul hôte en vingt minutes
-- **[Déploiement production](docs/fr/self-hosted/install/linux-server.md)** — serveur Linux avec TLS, pare-feu, utilisateur non-root
-- **[Référence Docker Compose](docs/fr/self-hosted/install/docker-compose-reference.md)** — fichier de base et overlays
+- **[Aperçu auto-hébergé](https://tale.dev/docs/fr/self-hosted/overview)** — architecture et services
+- **[Démarrage rapide](https://tale.dev/docs/fr/self-hosted/install/quickstart)** — installation sur un seul hôte en vingt minutes
+- **[Déploiement production](https://tale.dev/docs/fr/self-hosted/install/linux-server)** — serveur Linux avec TLS, pare-feu, utilisateur non-root
+- **[Référence Docker Compose](https://tale.dev/docs/fr/self-hosted/install/docker-compose-reference)** — fichier de base et overlays
 - **[CLI Tale](tools/cli/README.md)** — référence du CLI
-- **[Référence d'environnement](docs/fr/self-hosted/configuration/environment-reference.md)** — toutes les variables d'environnement
-- **[Architecture des conteneurs](docs/fr/self-hosted/operate/container-architecture.md)** — sept conteneurs, qui possède quoi
+- **[Référence d'environnement](https://tale.dev/docs/fr/self-hosted/configuration/environment-reference)** — toutes les variables d'environnement
+- **[Architecture des conteneurs](https://tale.dev/docs/fr/self-hosted/operate/container-architecture)** — sept conteneurs, qui possède quoi
 
 </details>
 
 <details>
 <summary><strong>Pour les développeurs</strong></summary>
 
-- **[Référence API](docs/fr/develop/api-reference.md)** — API REST pour les agents, le chat, les connaissances et les workflows
-- **[Webhooks](docs/fr/develop/webhooks.md)** — webhooks de workflows et d'agents avec vérification de signature
-- **[Aperçu développeur](docs/fr/develop/overview.md)** — la surface développeur de bout en bout
+- **[Référence API](https://tale.dev/docs/fr/develop/api-reference)** — API REST pour les agents, le chat, les connaissances et les workflows
+- **[Webhooks](https://tale.dev/docs/fr/develop/webhooks)** — webhooks de workflows et d'agents avec vérification de signature
+- **[Aperçu développeur](https://tale.dev/docs/fr/develop/overview)** — la surface développeur de bout en bout
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Connect **OpenClaw**, **Hermes Agent**, **Claude Code**, **Codex**, **Cursor**, 
 Pool their knowledge, delegate tasks, and build your swarm of agents.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-tale-0a0a0a.svg)](docs/en/index.md)
-[![Self-hosted](https://img.shields.io/badge/self--hosted-Docker-2496ed.svg)](docs/en/self-hosted/install/quickstart.md)
+[![Docs](https://img.shields.io/badge/docs-tale-0a0a0a.svg)](https://tale.dev/docs)
+[![Self-hosted](https://img.shields.io/badge/self--hosted-Docker-2496ed.svg)](https://tale.dev/docs/self-hosted/install/quickstart)
 
 [Quick start](#quick-start) · [What you can do](#what-can-you-do) · [Commands](#command-reference) · [Documentation](#documentation) · [Contributing](#contributing)
 
@@ -27,7 +27,7 @@ Tale is a **self-hosted AI platform** that turns the agents and CLIs your team a
 **Pick your path:**
 
 - **Try Tale locally** — install the CLI and run two commands on your own machine. Start with [Quick start](#quick-start) below.
-- **Use Tale Cloud** — let Tale operate the stack, sign up, and onboard your team. Start with [Cloud onboarding](docs/en/cloud/onboarding.md).
+- **Use Tale Cloud** — let Tale operate the stack, sign up, and onboard your team. Start with [Cloud onboarding](https://tale.dev/docs/cloud/onboarding).
 - **Contribute** — run Tale from source and ship a change back. Start with [Contributor setup](docs/en/develop/contributor-setup.md).
 
 ## Quick start
@@ -71,7 +71,7 @@ When you see "Tale is running", `tale dev` opens https://localhost (or your conf
 
 > **Note:** Your browser will show a certificate warning for self-signed certificates. This is safe to accept.
 
-For detailed setup instructions, see the [self-hosted quickstart](docs/en/self-hosted/install/quickstart.md).
+For detailed setup instructions, see the [self-hosted quickstart](https://tale.dev/docs/self-hosted/install/quickstart).
 
 ## What can you do?
 
@@ -116,7 +116,7 @@ tale cleanup                       # Remove inactive containers
 tale reset --force                 # Remove all containers
 ```
 
-See the [CLI reference](tools/cli/README.md) for all options and flags. Upgrading an existing deployment takes two commands: `tale update` moves the CLI and your project files to the new version, then `tale deploy` rolls the containers. See [Self-hosted upgrades](docs/en/self-hosted/operate/upgrades.md) for the full runbook.
+See the [CLI reference](tools/cli/README.md) for all options and flags. Upgrading an existing deployment takes two commands: `tale update` moves the CLI and your project files to the new version, then `tale deploy` rolls the containers. See [Self-hosted upgrades](https://tale.dev/docs/self-hosted/operate/upgrades) for the full runbook.
 
 ## Deploy to production
 
@@ -124,11 +124,11 @@ See the [CLI reference](tools/cli/README.md) for all options and flags. Upgradin
 tale deploy
 ```
 
-The CLI handles blue-green zero-downtime deployments with automatic health checks and rollback. For full production setup including reverse proxy configuration and subpath deployment, see the [Production deployment guide](docs/en/self-hosted/install/linux-server.md).
+The CLI handles blue-green zero-downtime deployments with automatic health checks and rollback. For full production setup including reverse proxy configuration and subpath deployment, see the [Production deployment guide](https://tale.dev/docs/self-hosted/install/linux-server).
 
 ## Authentication options
 
-Tale uses password-based authentication by default. The first user creates the owner account; all other users are created by an admin. To enable self-service login, connect SSO or trusted headers via Microsoft Entra ID — see the [Integrations overview](docs/en/platform/integrations/overview.md) for the Microsoft 365 connector that powers both document sync and SSO.
+Tale uses password-based authentication by default. The first user creates the owner account; all other users are created by an admin. To enable self-service login, connect SSO or trusted headers via Microsoft Entra ID — see the [Integrations overview](https://tale.dev/docs/platform/integrations/overview) for the Microsoft 365 connector that powers both document sync and SSO.
 
 - **Microsoft Entra ID (SSO):** Single sign-on with Microsoft 365 / Azure AD with automatic provisioning
 - **Trusted headers:** For deployments behind an authenticating reverse proxy (Authelia, Authentik, oauth2-proxy)
@@ -172,62 +172,62 @@ Useful when you want fast Vite reloads but a stable Convex backend that mirrors 
 
 ## Documentation
 
-The docs site and platform UI both ship three base locales (`en`, `de`, `fr`) plus regional variants where local wording differs (today: `de-CH`; the loader picks up any new `xx-YY` bundle automatically). Variants carry only the strings that differ from their base; missing keys fall back through the base to English. Start at [`docs/en/index.md`](docs/en/index.md) to pick an entry point by persona.
+The docs site and platform UI both ship three base locales (`en`, `de`, `fr`) plus regional variants where local wording differs (today: `de-CH`; the loader picks up any new `xx-YY` bundle automatically). Variants carry only the strings that differ from their base; missing keys fall back through the base to English. Start at [tale.dev/docs](https://tale.dev/docs) to pick an entry point by persona (source: [`docs/en/index.md`](docs/en/index.md)).
 
 <details>
 <summary><strong>For everyday users</strong></summary>
 
-- **[Chat overview](docs/en/platform/chat/overview.md)** — the four parts of the screen, where to read deeper
-- **[AI chat basics](docs/en/platform/chat/basics.md)** — composer, agents, model picker, streaming, citations
-- **[Deep research](docs/en/platform/chat/deep-research.md)** — the Researcher agent with live plan and PDF report
-- **[Attachments](docs/en/platform/chat/attachments.md)** — files in chat, RAG vs verbatim
-- **[Shared chats](docs/en/platform/chat/shared-threads.md)** — share a chat with the org, fork into your own
-- **[Approvals](docs/en/platform/approvals/concepts.md)** — review AI actions
+- **[Chat overview](https://tale.dev/docs/platform/chat/overview)** — the four parts of the screen, where to read deeper
+- **[AI chat basics](https://tale.dev/docs/platform/chat/basics)** — composer, agents, model picker, streaming, citations
+- **[Deep research](https://tale.dev/docs/platform/chat/deep-research)** — the Researcher agent with live plan and PDF report
+- **[Attachments](https://tale.dev/docs/platform/chat/attachments)** — files in chat, RAG vs verbatim
+- **[Shared chats](https://tale.dev/docs/platform/chat/shared-threads)** — share a chat with the org, fork into your own
+- **[Approvals](https://tale.dev/docs/platform/approvals/concepts)** — review AI actions
 
 </details>
 
 <details>
 <summary><strong>For builders (agents, automations, integrations)</strong></summary>
 
-- **[Agent concepts](docs/en/platform/agents/concepts.md)** — the four-knob model behind every agent
-- **[Create an agent](docs/en/platform/agents/create.md)** — specialised AI assistants end to end
-- **[Agent tools](docs/en/platform/agents/tools.md)** — the built-in tool families
-- **[Projects](docs/en/platform/projects/overview.md)** — shared workspace for files, chats, project agents
-- **[Automation concepts](docs/en/platform/automations/concepts.md)** — workflows, triggers, approval gates
-- **[Integrations overview](docs/en/platform/integrations/overview.md)** — Slack, Teams, Gmail, Outlook, Microsoft 365, Google Drive, Confluence, WebDAV, GitHub, Shopify, Tavily, MCP
-- **[Models out of the box](docs/en/platform/models.md)** — OpenRouter as the single default provider, plus the shipped model lists
+- **[Agent concepts](https://tale.dev/docs/platform/agents/concepts)** — the four-knob model behind every agent
+- **[Create an agent](https://tale.dev/docs/platform/agents/create)** — specialised AI assistants end to end
+- **[Agent tools](https://tale.dev/docs/platform/agents/tools)** — the built-in tool families
+- **[Projects](https://tale.dev/docs/platform/projects/overview)** — shared workspace for files, chats, project agents
+- **[Automation concepts](https://tale.dev/docs/platform/automations/concepts)** — workflows, triggers, approval gates
+- **[Integrations overview](https://tale.dev/docs/platform/integrations/overview)** — Slack, Teams, Gmail, Outlook, Microsoft 365, Google Drive, Confluence, WebDAV, GitHub, Shopify, Tavily, MCP
+- **[Models out of the box](https://tale.dev/docs/platform/models)** — OpenRouter as the single default provider, plus the shipped model lists
 
 </details>
 
 <details>
 <summary><strong>For admins</strong></summary>
 
-- **[Members and roles](docs/en/platform/admin/members-and-roles.md)** — user management and permission matrix
-- **[Models out of the box](docs/en/platform/models.md)** — which models the defaults ship with; swap or add providers
-- **[Integrations overview](docs/en/platform/integrations/overview.md)** — third-party connectors, MCP servers, custom configs
-- **[Cloud trust and compliance](docs/en/cloud/trust-and-compliance.md)** — frameworks, shared responsibility, evidence to hand auditors
+- **[Members and roles](https://tale.dev/docs/platform/admin/members-and-roles)** — user management and permission matrix
+- **[Models out of the box](https://tale.dev/docs/platform/models)** — which models the defaults ship with; swap or add providers
+- **[Integrations overview](https://tale.dev/docs/platform/integrations/overview)** — third-party connectors, MCP servers, custom configs
+- **[Cloud trust and compliance](https://tale.dev/docs/cloud/trust-and-compliance)** — frameworks, shared responsibility, evidence to hand auditors
 
 </details>
 
 <details>
 <summary><strong>For operators</strong></summary>
 
-- **[Self-hosted overview](docs/en/self-hosted/overview.md)** — architecture and services
-- **[Quickstart](docs/en/self-hosted/install/quickstart.md)** — single-host install in twenty minutes
-- **[Production deployment](docs/en/self-hosted/install/linux-server.md)** — Linux server with TLS, firewall, non-root user
-- **[Docker Compose reference](docs/en/self-hosted/install/docker-compose-reference.md)** — base file and overlays
+- **[Self-hosted overview](https://tale.dev/docs/self-hosted/overview)** — architecture and services
+- **[Quickstart](https://tale.dev/docs/self-hosted/install/quickstart)** — single-host install in twenty minutes
+- **[Production deployment](https://tale.dev/docs/self-hosted/install/linux-server)** — Linux server with TLS, firewall, non-root user
+- **[Docker Compose reference](https://tale.dev/docs/self-hosted/install/docker-compose-reference)** — base file and overlays
 - **[Tale CLI](tools/cli/README.md)** — CLI reference
-- **[Environment reference](docs/en/self-hosted/configuration/environment-reference.md)** — all environment variables
-- **[Container architecture](docs/en/self-hosted/operate/container-architecture.md)** — seven containers, what owns what
+- **[Environment reference](https://tale.dev/docs/self-hosted/configuration/environment-reference)** — all environment variables
+- **[Container architecture](https://tale.dev/docs/self-hosted/operate/container-architecture)** — seven containers, what owns what
 
 </details>
 
 <details>
 <summary><strong>For developers</strong></summary>
 
-- **[API reference](docs/en/develop/api-reference.md)** — REST API for agents, chat, knowledge, and workflows
-- **[Webhooks](docs/en/develop/webhooks.md)** — workflow and agent webhooks with signature verification
-- **[Develop overview](docs/en/develop/overview.md)** — the developer surface end to end
+- **[API reference](https://tale.dev/docs/develop/api-reference)** — REST API for agents, chat, knowledge, and workflows
+- **[Webhooks](https://tale.dev/docs/develop/webhooks)** — workflow and agent webhooks with signature verification
+- **[Develop overview](https://tale.dev/docs/develop/overview)** — the developer surface end to end
 
 </details>
 


### PR DESCRIPTION
Follow-ups from the getting-started audit:

- **SECURITY.md**: private reporting via the Security tab (plus the existing security@tale.dev), supported-versions statement honest for rolling-release 0.x, response expectations restating the timelines the repo already publishes in the advisories doc.
- **CODE_OF_CONDUCT.md**: Contributor Covenant v2.1; enforcement contact is the maintainers via GitHub (no conduct@ address exists to cite).
- **READMEs (en/de/fr)**: the docs badge and product-doc links pointed at in-repo markdown whose site-root-relative internal links 404 on GitHub — they now target the hosted site (URL scheme verified against the docs router), keeping contributor-facing in-repo links where they belong.

Docs suite 144/144 green, including the README parity test.