### PR TITLE
fix(platform,proxy): silence fresh-install version noise and phantom docs health checks

### DIFF
--- a/services/platform/app/components/user-button.test.tsx
+++ b/services/platform/app/components/user-button.test.tsx
@@ -60,6 +60,7 @@ vi.mock('@/app/hooks/use-changelog-notification', () => ({
     stateLoaded: true,
     hasUnseenVersion: false,
     shouldShowToast: false,
+    needsBaseline: false,
     markSeen: vi.fn(),
     markToasted: vi.fn(),
   }),

--- a/services/platform/app/features/changelog/components/changelog-toast-trigger.test.tsx
+++ b/services/platform/app/features/changelog/components/changelog-toast-trigger.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockToast = vi.fn();
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string) => `${ns}.${key}`,
+  }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
+}));
+
+vi.mock('@radix-ui/react-toast', () => ({
+  Action: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const mockMarkSeen = vi.fn();
+const mockMarkToasted = vi.fn();
+const notification = {
+  shouldShowToast: false,
+  needsBaseline: false,
+  currentVersion: 'v0.2.97' as string | undefined,
+  lastSeenVersion: undefined as string | undefined,
+  markSeen: mockMarkSeen,
+  markToasted: mockMarkToasted,
+};
+
+vi.mock('@/app/hooks/use-changelog-notification', () => ({
+  useChangelogNotification: () => ({ ...notification }),
+}));
+
+import { ChangelogToastTrigger } from './changelog-toast-trigger';
+
+describe('ChangelogToastTrigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notification.shouldShowToast = false;
+    notification.needsBaseline = false;
+    notification.currentVersion = 'v0.2.97';
+    notification.lastSeenVersion = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('seeds the baseline silently on a fresh install instead of toasting', () => {
+    notification.needsBaseline = true;
+
+    render(<ChangelogToastTrigger />);
+
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockMarkSeen).toHaveBeenCalledTimes(1);
+    expect(mockMarkToasted).not.toHaveBeenCalled();
+  });
+
+  it('toasts once and records it when an update was installed', () => {
+    notification.shouldShowToast = true;
+    notification.lastSeenVersion = 'v0.2.96';
+
+    render(<ChangelogToastTrigger />);
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'changelog.toast.title' }),
+    );
+    expect(mockMarkToasted).toHaveBeenCalledTimes(1);
+    expect(mockMarkSeen).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while the notification state is unresolved', () => {
+    render(<ChangelogToastTrigger />);
+
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockMarkSeen).not.toHaveBeenCalled();
+    expect(mockMarkToasted).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a current version', () => {
+    notification.needsBaseline = true;
+    notification.currentVersion = undefined;
+
+    render(<ChangelogToastTrigger />);
+
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockMarkSeen).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/changelog/components/changelog-toast-trigger.tsx
+++ b/services/platform/app/features/changelog/components/changelog-toast-trigger.tsx
@@ -15,11 +15,17 @@ import { useT } from '@/lib/i18n/client';
  * even across sessions. The red dot on UserButton persists separately
  * (governed by `markSeen`) until the user actually views the release
  * notes.
+ *
+ * On a fresh install (`needsBaseline`: no notification row exists yet)
+ * there is no previous version to have updated from, so nothing is
+ * announced — the current version is recorded silently as the baseline
+ * so the next release toasts normally.
  */
 export function ChangelogToastTrigger() {
   const { t } = useT('changelog');
   const {
     shouldShowToast,
+    needsBaseline,
     currentVersion,
     lastSeenVersion,
     markSeen,
@@ -28,8 +34,18 @@ export function ChangelogToastTrigger() {
   const firedRef = useRef(false);
 
   useEffect(() => {
-    if (!shouldShowToast || !currentVersion) return;
+    if (!currentVersion) return;
     if (firedRef.current) return;
+
+    if (needsBaseline) {
+      // Fresh install: record the current version (seen + toasted) without
+      // notifying. `markSeen` writes both fields in one mutation.
+      firedRef.current = true;
+      markSeen();
+      return;
+    }
+
+    if (!shouldShowToast) return;
     firedRef.current = true;
 
     toast({
@@ -54,6 +70,7 @@ export function ChangelogToastTrigger() {
     markToasted();
   }, [
     shouldShowToast,
+    needsBaseline,
     currentVersion,
     lastSeenVersion,
     markSeen,

--- a/services/platform/app/hooks/use-changelog-notification.test.ts
+++ b/services/platform/app/hooks/use-changelog-notification.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The hook only calls `useQuery`/`useMutation`; with those mocked it runs as
+// a plain function (same approach as use-current-member-context.test.ts).
+const mockUseQuery = vi.fn();
+const mockMarkSeenMutation = vi.fn(() => Promise.resolve(null));
+const mockMarkToastedMutation = vi.fn(() => Promise.resolve(null));
+
+vi.mock('convex/react', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (fn: unknown) =>
+    fn === 'markChangelogSeen' ? mockMarkSeenMutation : mockMarkToastedMutation,
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: {
+    users: {
+      notification_state: {
+        getUserNotificationState: 'getUserNotificationState',
+        markChangelogSeen: 'markChangelogSeen',
+        markToastShown: 'markToastShown',
+      },
+    },
+  },
+}));
+
+let mockVersion: string | undefined = 'v0.2.97';
+vi.mock('@/lib/env', () => ({
+  getEnv: () => mockVersion,
+}));
+
+import { useChangelogNotification } from './use-changelog-notification';
+
+/** A loaded notification-state row, as `getUserNotificationState` returns it. */
+function row(fields: {
+  lastSeenChangelogVersion?: string;
+  lastToastedVersion?: string;
+}) {
+  return { userId: 'u1', updatedAt: 0, ...fields };
+}
+
+describe('useChangelogNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVersion = 'v0.2.97';
+  });
+
+  it('shows neither dot nor toast on a fresh install (no row recorded)', () => {
+    // No previous version recorded means fresh install, not an update.
+    mockUseQuery.mockReturnValue(null);
+
+    const result = useChangelogNotification();
+
+    expect(result.stateLoaded).toBe(true);
+    expect(result.hasUnseenVersion).toBe(false);
+    expect(result.shouldShowToast).toBe(false);
+    expect(result.needsBaseline).toBe(true);
+  });
+
+  it('holds everything back while the state query is loading', () => {
+    mockUseQuery.mockReturnValue(undefined);
+
+    const result = useChangelogNotification();
+
+    expect(result.stateLoaded).toBe(false);
+    expect(result.hasUnseenVersion).toBe(false);
+    expect(result.shouldShowToast).toBe(false);
+    expect(result.needsBaseline).toBe(false);
+  });
+
+  it('shows dot and toast when the recorded versions are older', () => {
+    mockUseQuery.mockReturnValue(
+      row({
+        lastSeenChangelogVersion: 'v0.2.96',
+        lastToastedVersion: 'v0.2.96',
+      }),
+    );
+
+    const result = useChangelogNotification();
+
+    expect(result.hasUnseenVersion).toBe(true);
+    expect(result.shouldShowToast).toBe(true);
+    expect(result.needsBaseline).toBe(false);
+  });
+
+  it('stays quiet when the recorded versions match the current one', () => {
+    mockUseQuery.mockReturnValue(
+      row({
+        lastSeenChangelogVersion: 'v0.2.97',
+        lastToastedVersion: 'v0.2.97',
+      }),
+    );
+
+    const result = useChangelogNotification();
+
+    expect(result.hasUnseenVersion).toBe(false);
+    expect(result.shouldShowToast).toBe(false);
+    expect(result.needsBaseline).toBe(false);
+  });
+
+  it('keeps the unseen dot for a user who was toasted but never viewed', () => {
+    // A row exists (not a fresh install) but the user never opened the
+    // release notes: the dot must persist, without re-toasting.
+    mockUseQuery.mockReturnValue(row({ lastToastedVersion: 'v0.2.97' }));
+
+    const result = useChangelogNotification();
+
+    expect(result.hasUnseenVersion).toBe(true);
+    expect(result.shouldShowToast).toBe(false);
+    expect(result.needsBaseline).toBe(false);
+  });
+
+  it('skips the query and reports nothing without a TALE_VERSION', () => {
+    mockVersion = undefined;
+    mockUseQuery.mockReturnValue(undefined);
+
+    const result = useChangelogNotification();
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      'getUserNotificationState',
+      'skip',
+    );
+    expect(result.hasUnseenVersion).toBe(false);
+    expect(result.shouldShowToast).toBe(false);
+    expect(result.needsBaseline).toBe(false);
+  });
+
+  it('records the current version when markSeen is called', () => {
+    mockUseQuery.mockReturnValue(null);
+
+    useChangelogNotification().markSeen();
+
+    expect(mockMarkSeenMutation).toHaveBeenCalledWith({ version: 'v0.2.97' });
+  });
+});

--- a/services/platform/app/hooks/use-changelog-notification.ts
+++ b/services/platform/app/hooks/use-changelog-notification.ts
@@ -36,6 +36,13 @@ interface ChangelogNotification {
   stateLoaded: boolean;
   hasUnseenVersion: boolean;
   shouldShowToast: boolean;
+  /**
+   * True when the state has loaded and no notification row exists at all —
+   * a fresh install / brand-new account, not an update. The current version
+   * should be recorded silently (via `markSeen`) instead of notifying;
+   * `ChangelogToastTrigger` owns that seeding.
+   */
+  needsBaseline: boolean;
   markSeen: () => void;
   markToasted: () => void;
 }
@@ -58,14 +65,26 @@ export function useChangelogNotification(): ChangelogNotification {
   // to avoid a spurious flash.
   const stateLoaded = state !== undefined;
 
+  // `state === null` means no row exists for this user at all: nothing was
+  // ever recorded, so there is no previous version to have "updated" from.
+  // That is a fresh install (or brand-new account), not an update — showing
+  // "update available" / "updated to vX" there is noise. The trigger seeds
+  // the baseline instead (see `needsBaseline`), so the NEXT release still
+  // notifies. Rows that exist but miss one field keep the old "treat as
+  // newer" behaviour: e.g. a user who was toasted but never opened the
+  // release notes must keep the unseen dot.
+  const isFreshInstall = stateLoaded && state === null;
+
   const hasUnseenVersion =
     !!currentVersion &&
     stateLoaded &&
+    !isFreshInstall &&
     isNewer(currentVersion, state?.lastSeenChangelogVersion ?? null);
 
   const shouldShowToast =
     !!currentVersion &&
     stateLoaded &&
+    !isFreshInstall &&
     isNewer(currentVersion, state?.lastToastedVersion ?? null);
 
   return {
@@ -74,6 +93,7 @@ export function useChangelogNotification(): ChangelogNotification {
     stateLoaded,
     hasUnseenVersion,
     shouldShowToast,
+    needsBaseline: !!currentVersion && isFreshInstall,
     markSeen: () => {
       if (!currentVersion) return;
       markSeenMutation({ version: currentVersion }).catch((err) => {

--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -51,12 +51,15 @@
 
 	encode gzip zstd
 
+	# Passive health checking only (circuit breaker) — deliberately no active
+	# health checks here. The docs service is optional: the CLI-generated
+	# stacks and the bare compose.yml don't ship it (only the dev chain with
+	# compose.docs.yml does), and an active checker dials `docs` on every
+	# interval, filling the proxy log with "dial tcp: lookup docs ... no such
+	# host" errors forever on stacks without it. Passive checks only observe
+	# real requests, so an absent upstream stays silent; a present-but-down
+	# docs container still gets circuit-broken after max_fails.
 	reverse_proxy docs:3002 {
-		health_uri /api/health
-		health_interval 5s
-		health_timeout 3s
-		health_status 200
-
 		fail_duration 10s
 		max_fails 2
 		unhealthy_status 500 502 503 504
@@ -267,7 +270,9 @@
 		# start_period), and a 2s probe logged a failed health check every two
 		# seconds until it came up, which read as "repeated proxy failures"
 		# during normal startup (#1447). Caddy still routes correctly once the
-		# backend is up; 5s matches the docs upstream and cuts the boot noise.
+		# backend is up; 5s cuts the boot noise. Unlike the optional docs
+		# upstream above, the platform is always part of the stack, so active
+		# checks never probe a permanently absent host.
 		health_uri /api/health
 		health_interval 5s
 		health_timeout 2s


### PR DESCRIPTION
Two first-run polish defects observed live on a fresh install:

**Fresh install showed "Update verfügbar" + an "updated to v0.2.97" toast during onboarding.** Root cause: `isNewer(candidate, baseline)` treats a missing baseline as "newer", and a brand-new user has no notification-state row — the signal was never a real version comparison. Fix: a loaded-but-null state row now suppresses both signals and silently records the current version as the baseline, so the *next* release still notifies. Regression suites observed red on old code, green on new (11 new tests; 37 adjacent tests green).

**`tale logs proxy` spammed `lookup docs … no such host` every 5s.** The Caddyfile actively health-checked the optional `docs:3002` upstream, which only exists in the repo's dev compose chain — never in CLI-generated stacks. Fix: drop the active checks on that upstream only, keeping the passive circuit breaker (absent upstream = silent; present-but-down docs still circuit-broken). Validated with `caddy validate` inside the image the Dockerfile uses, replicating the entrypoint's sed substitutions.

Accepted side effect: an existing user who never loaded the app since the changelog feature shipped gets silently seeded instead of one back-dated toast.