### PR TITLE
fix(platform): remove dead code left by template picker rework

### DIFF
--- a/services/platform/app/features/automations/components/workflow-template-grid.tsx
+++ b/services/platform/app/features/automations/components/workflow-template-grid.tsx
@@ -7,7 +7,6 @@ import { useMemo } from 'react';
 
 import {
   CatalogCard,
-  CatalogCardIcon,
   CatalogGrid,
 } from '@/app/components/catalog/catalog-grid';
 import { useAbility } from '@/app/hooks/use-ability';

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -972,6 +972,7 @@ import type * as node_only_documents_internal_actions from "../node_only/documen
 import type * as node_only_imap_smtp_helpers_fetch_messages from "../node_only/imap_smtp/helpers/fetch_messages.js";
 import type * as node_only_imap_smtp_helpers_map_to_email_type from "../node_only/imap_smtp/helpers/map_to_email_type.js";
 import type * as node_only_imap_smtp_helpers_send_message from "../node_only/imap_smtp/helpers/send_message.js";
+import type * as node_only_imap_smtp_helpers_smtp_transport from "../node_only/imap_smtp/helpers/smtp_transport.js";
 import type * as node_only_imap_smtp_helpers_test_connection from "../node_only/imap_smtp/helpers/test_connection.js";
 import type * as node_only_imap_smtp_internal_actions from "../node_only/imap_smtp/internal_actions.js";
 import type * as node_only_imap_smtp_types from "../node_only/imap_smtp/types.js";
@@ -2606,6 +2607,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/imap_smtp/helpers/fetch_messages": typeof node_only_imap_smtp_helpers_fetch_messages;
   "node_only/imap_smtp/helpers/map_to_email_type": typeof node_only_imap_smtp_helpers_map_to_email_type;
   "node_only/imap_smtp/helpers/send_message": typeof node_only_imap_smtp_helpers_send_message;
+  "node_only/imap_smtp/helpers/smtp_transport": typeof node_only_imap_smtp_helpers_smtp_transport;
   "node_only/imap_smtp/helpers/test_connection": typeof node_only_imap_smtp_helpers_test_connection;
   "node_only/imap_smtp/internal_actions": typeof node_only_imap_smtp_internal_actions;
   "node_only/imap_smtp/types": typeof node_only_imap_smtp_types;

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -953,7 +953,6 @@
     },
     "templates": {
       "description": "Wähle eine Vorlage mit vorkonfigurierten Schritten.",
-      "installFailed": "Automatisierung konnte nicht aus Vorlage erstellt werden",
       "fetching": "Vorlage wird geladen...",
       "noTemplates": "Keine Vorlagen für diese Integration verfügbar."
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -953,7 +953,6 @@
     },
     "templates": {
       "description": "Choose a template to get started with pre-configured steps.",
-      "installFailed": "Unable to create automation from template",
       "fetching": "Loading template...",
       "noTemplates": "No templates available for this integration."
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -954,7 +954,6 @@
     },
     "templates": {
       "description": "Choisis un modèle pour démarrer avec des étapes préconfigurées.",
-      "installFailed": "Impossible de créer l'automatisation à partir du modèle",
       "fetching": "Chargement du modèle...",
       "noTemplates": "Aucun modèle disponible pour cette intégration."
     },

--- a/services/platform/tests/e2e/specs/automation.spec.ts
+++ b/services/platform/tests/e2e/specs/automation.spec.ts
@@ -36,8 +36,17 @@ test('runs the seeded test automation to completion', async ({ page, org }) => {
         name: t('automations.createDialog.tabTemplate'),
       })
       .click();
+    // Clicking a template card only selects it; the dialog's footer Install
+    // button performs the install and navigates to the new automation.
     await page
       .getByRole('button', { name: SEEDED_WORKFLOW_NAME, exact: true })
+      .click();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', {
+        name: t('automations.createDialog.install'),
+        exact: true,
+      })
       .click();
   }
   await page.waitForURL(/\/automations\/test(?:[/?#]|$)/, {


### PR DESCRIPTION
## Summary

Main is red after the template picker rework (#2411) — its PR merged with Lint, Test, Build, and E2E all failing (no branch protection), so `65e528f01` on main inherits the breakage. This PR fixes all three pieces of #2411 fallout:

- **Lint**: `CatalogCardIcon` is imported but unused in `workflow-template-grid.tsx` — the rework renders its own `TemplateBrandIcon` media tile instead. Import removed.
- **Test (Unit)**: the i18n orphan-key check flags `automations.templates.installFailed`. The rework removed its only usage (install errors now surface via the existing `toast.createFailed`), so the key is deleted from `en.json`, `de.json`, and `fr.json`. A repo-wide grep confirms no remaining references.
- **E2E (Playwright)**: `automation.spec.ts › runs the seeded test automation to completion` still clicked a template card and waited for navigation. Since #2411, clicking a card only selects it; the dialog's footer **Install** button performs the install + navigation. The spec now clicks Install after selecting the card.

Also includes a `_generated/api.d.ts` refresh (separate commit): it registers the existing `node_only/imap_smtp/helpers/smtp_transport` module that a previous commit forgot to include — the file is auto-generated and committed by convention.

## Verification

- `bun run lint` (platform): 0 errors (was 1)
- `vitest run lib/i18n/messages.test.ts`: 23/23 pass (was 1 fail)
- `vitest run app/features/automations/components/workflow-template-grid.test.tsx`: 8/8 pass
- `bunx tsc --noEmit` (platform): clean
- E2E spec fix verified against the new dialog code path (`handleInstallSelected` in `automation-create-dialog.tsx`); the org-fixture spec can only run hermetically, so final proof is this PR's own E2E run — watching it.

## Definition of done

- [x] Green gate — platform format/lint/typecheck/tests pass locally
- [x] Security gate — N/A: deletions, a test locator change, and generated types only; no boundary touched
- [x] Tests — N/A new tests: the failing guards (oxlint unused-import rule, i18n orphan-key test, the E2E spec itself) are the regression tests
- [x] Migration — N/A: no data-model or config-schema change
- [x] Locales — orphan key removed from all three locales (en, de, fr)
- [x] Docs — N/A: no user-visible behaviour change
- [x] Accessibility — N/A: no UI structure change
- [x] Sweep — repo-wide grep for `templates.installFailed`, `CatalogCardIcon`, and template-install E2E flows; all sites accounted for
- [x] Observed — failing Lint/Unit checks re-run locally and observed green; E2E observed via this PR's checks
- [x] Commits — atomic, conventional, branched off main