### PR TITLE
feat(platform): auto-seed a ready-to-log-in dev account on docker:dev boot

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -146,6 +146,17 @@ services:
       # push), default on in dev. Set to 0 to fall back to the one-shot boot
       # deploy and the static prebuilt dist/ only.
       TALE_DEV_HOT_RELOAD: ${TALE_DEV_HOT_RELOAD:-1}
+      # Auto-seed a ready-to-log-in dev account on boot (default on in this
+      # dev overlay only): dev@tale.test / TaleDev!Passw0rd owning a
+      # scaffolded "Dev Workspace" org — a fresh stack needs no manual /setup
+      # pass before testing. Set TALE_DEV_SEED_USER=0 to opt out (the /setup
+      # wizard then appears as before); override the identity via
+      # TALE_DEV_SEED_USER_EMAIL / TALE_DEV_SEED_USER_PASSWORD. The seeder
+      # (services/platform/convex/provisioning/seed_dev_user.ts) additionally
+      # refuses to run when SITE_URL is not a loopback host, so an accidental
+      # carry-over into a reachable deployment stays inert. Never used by
+      # `tale deploy` (production ignores this overlay).
+      TALE_DEV_SEED_USER: ${TALE_DEV_SEED_USER:-1}
 
   docs:
     volumes:

--- a/scripts/docker-dev-env-override.ts
+++ b/scripts/docker-dev-env-override.ts
@@ -49,6 +49,13 @@ const RUNTIME_DENYLIST = new Set([
   'NPM_CONFIG_PREFIX',
   'NPM_CONFIG_UPDATE_NOTIFIER',
   'NoDefaultCurrentDirectoryInExePath',
+  // Temp-dir overrides: a host TMPDIR (e.g. a sandboxed shell's private tmp)
+  // does not exist inside the container, so coreutils/Bun that honor it
+  // (mktemp in docker-entrypoint.sh, Bun's own tmpfile handling) fail with
+  // ENOENT and crash-loop the entrypoint. The container must use its own /tmp.
+  'TMPDIR',
+  'TMP',
+  'TEMP',
   // Host-relative networking vars: their value is meaningful only on the host,
   // never inside the container, so forwarding them breaks container-internal
   // networking — the same correctness floor as PATH/HOME above.

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1145,6 +1145,7 @@ import type * as provisioning from "../provisioning.js";
 import type * as provisioning_provision_default_agents from "../provisioning/provision_default_agents.js";
 import type * as provisioning_provision_default_prompts from "../provisioning/provision_default_prompts.js";
 import type * as provisioning_provision_task_ops_pack from "../provisioning/provision_task_ops_pack.js";
+import type * as provisioning_seed_dev_user from "../provisioning/seed_dev_user.js";
 import type * as provisioning_seed_starter from "../provisioning/seed_starter.js";
 import type * as rag_documents from "../rag/documents.js";
 import type * as rag_lib_config from "../rag/lib/config.js";
@@ -2779,6 +2780,7 @@ declare const fullApi: ApiFromModules<{
   "provisioning/provision_default_agents": typeof provisioning_provision_default_agents;
   "provisioning/provision_default_prompts": typeof provisioning_provision_default_prompts;
   "provisioning/provision_task_ops_pack": typeof provisioning_provision_task_ops_pack;
+  "provisioning/seed_dev_user": typeof provisioning_seed_dev_user;
   "provisioning/seed_starter": typeof provisioning_seed_starter;
   "rag/documents": typeof rag_documents;
   "rag/lib/config": typeof rag_lib_config;

--- a/services/platform/convex/provisioning/seed_dev_user.ts
+++ b/services/platform/convex/provisioning/seed_dev_user.ts
@@ -1,0 +1,163 @@
+/**
+ * Dev-login seeder — makes a fresh `bun run docker:dev` stack immediately
+ * testable: creates the owner account (`dev@tale.test` by default) and a
+ * "Dev Workspace" organization through the SAME Better Auth endpoints the
+ * first-run setup wizard uses, so every org-creation side effect (config
+ * scaffold, workflow/prompt/agent provisioning, starter content) fires
+ * exactly as if a human completed `/setup`.
+ *
+ * Invoked by the platform docker-entrypoint after `convex deploy` (next to
+ * `provisioning:provisionAll`), gated there on NODE_ENV=development plus the
+ * TALE_DEV_SEED_USER flag. Defense in depth: this module re-checks the flag
+ * AND refuses to run unless SITE_URL is a loopback host (see
+ * `lib/utils/dev-seed-config.ts` — NODE_ENV is unreliable inside the Convex
+ * runtime, so SITE_URL is the "not production" signal).
+ *
+ * Idempotent: an existing user short-circuits account creation; an existing
+ * membership short-circuits org creation — so a re-run (every boot) is a
+ * no-op, and a half-seeded state (user without org) self-heals.
+ */
+
+import { v } from 'convex/values';
+
+import { resolveDevSeedConfig } from '../../lib/utils/dev-seed-config';
+import { getString, isRecord } from '../../lib/utils/type-utils';
+import { components, internal } from '../_generated/api';
+import { internalAction, internalMutation } from '../_generated/server';
+import type { MutationCtx } from '../_generated/server';
+import { createAuth } from '../auth';
+
+const DEV_SEED_ORG_NAME = 'Dev Workspace';
+const DEV_SEED_ORG_SLUG = 'dev-workspace';
+
+/** Better Auth adapter lookup: the user's id by email, if the user exists. */
+async function findUserIdByEmail(
+  ctx: MutationCtx,
+  email: string,
+): Promise<string | undefined> {
+  const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'user',
+    paginationOpts: { cursor: null, numItems: 1 },
+    where: [{ field: 'email', value: email, operator: 'eq' }],
+  });
+  const row: unknown = result?.page?.[0];
+  return isRecord(row) ? getString(row, '_id') : undefined;
+}
+
+/**
+ * Ensure the dev account exists; returns its Better Auth user id. Mirrors
+ * `users/create_user_without_session.ts`: `auth.api.signUpEmail` gives proper
+ * password hashing without minting a session.
+ */
+export const ensureDevUser = internalMutation({
+  args: { email: v.string(), password: v.string() },
+  returns: v.object({ userId: v.string(), created: v.boolean() }),
+  // Explicit return annotations on all three handlers: the action below
+  // references this module's own functions via `internal.provisioning.
+  // seed_dev_user.*`, and without annotations that self-reference makes the
+  // module's type circular through _generated/api.d.ts (same reason
+  // seed_starter.ts annotates `Promise<null>`).
+  handler: async (ctx, args): Promise<{ userId: string; created: boolean }> => {
+    const existingId = await findUserIdByEmail(ctx, args.email);
+    if (existingId) return { userId: existingId, created: false };
+
+    const auth = createAuth(ctx);
+    // Wizard parity (account-step.tsx): name defaults to the email.
+    await auth.api.signUpEmail({
+      body: { email: args.email, password: args.password, name: args.email },
+    });
+
+    const userId = await findUserIdByEmail(ctx, args.email);
+    if (!userId) {
+      throw new Error(
+        `Dev user ${args.email} was signed up but could not be found afterwards`,
+      );
+    }
+    return { userId, created: true };
+  },
+});
+
+/**
+ * Ensure the dev user owns an organization; returns the org id. Runs through
+ * `auth.api.createOrganization` with the server-only `userId` body field (a
+ * sanctioned headless "system action" in Better Auth — no session required),
+ * so `afterCreateOrganization` fires the full scaffold/provisioning chain.
+ */
+export const ensureDevOrg = internalMutation({
+  args: { userId: v.string() },
+  returns: v.object({ organizationId: v.string(), created: v.boolean() }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ organizationId: string; created: boolean }> => {
+    const membership = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: 'member',
+        paginationOpts: { cursor: null, numItems: 1 },
+        where: [{ field: 'userId', value: args.userId, operator: 'eq' }],
+      },
+    );
+    const existingRow: unknown = membership?.page?.[0];
+    const existingOrgId = isRecord(existingRow)
+      ? getString(existingRow, 'organizationId')
+      : undefined;
+    if (existingOrgId) return { organizationId: existingOrgId, created: false };
+
+    const auth = createAuth(ctx);
+    // Wizard parity (workspace-step.tsx): metadata carries creatorId +
+    // defaultLocale (seeds the prompt library language).
+    const organization = await auth.api.createOrganization({
+      body: {
+        name: DEV_SEED_ORG_NAME,
+        slug: DEV_SEED_ORG_SLUG,
+        userId: args.userId,
+        metadata: { creatorId: args.userId, defaultLocale: 'en' },
+      },
+    });
+    if (!organization) {
+      throw new Error('Dev organization creation returned no organization');
+    }
+    return { organizationId: organization.id, created: true };
+  },
+});
+
+/**
+ * Entry point for the docker-entrypoint (`bunx convex run
+ * provisioning/seed_dev_user:seedDevUser`). Returns a status string the
+ * entrypoint can log; never throws for the "seeding disabled" cases so the
+ * boot sequence stays quiet when the flag is off.
+ */
+export const seedDevUser = internalAction({
+  args: {},
+  returns: v.object({ status: v.string(), detail: v.string() }),
+  handler: async (ctx): Promise<{ status: string; detail: string }> => {
+    const config = resolveDevSeedConfig(process.env);
+    if (!config.enabled) {
+      console.log(`[seedDevUser] skipped: ${config.reason}`);
+      return { status: 'skipped', detail: config.reason };
+    }
+
+    const user = await ctx.runMutation(
+      internal.provisioning.seed_dev_user.ensureDevUser,
+      { email: config.email, password: config.password },
+    );
+    const org = await ctx.runMutation(
+      internal.provisioning.seed_dev_user.ensureDevOrg,
+      { userId: user.userId },
+    );
+    if (org.created) {
+      // Wizard parity (workspace-step.tsx → organizations/actions.ts):
+      // the wizard triggers this after org creation, alongside the
+      // afterCreateOrganization provisioners.
+      await ctx.runMutation(
+        internal.agents.seed_system_defaults.seedSystemDefaultAgents,
+        { organizationId: org.organizationId },
+      );
+    }
+
+    const detail = `user ${config.email} ${user.created ? 'created' : 'already existed'}; organization ${org.created ? 'created' : 'already existed'}`;
+    console.log(`[seedDevUser] ${detail}`);
+    return { status: 'seeded', detail };
+  },
+});

--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -72,6 +72,9 @@ VITE_PID=""
 # Set by the dev hot-reload watchers (empty in prod).
 CONVEX_DEV_PID=""
 FRONTEND_WATCH_PID=""
+# Outcome of the dev-login seed step (seeded/skipped/failed, empty when the
+# gate is off) — the final banner only prints credentials for "seeded".
+DEV_SEED_STATUS=""
 
 shutdown() {
   log_section "Platform graceful shutdown"
@@ -213,6 +216,19 @@ dump_diagnostics() {
   echo "  Memory:      $(free -h 2>/dev/null | awk '/^Mem:/ {print $3" / "$2}')"
   echo "──────────────────────────────────────"
   echo
+}
+
+# Dev-login seeding (docker:dev convenience): coarse gate deciding whether to
+# invoke the seed action and print the credentials banner. Dev image only +
+# the TALE_DEV_SEED_USER flag (default on in compose.dev.yml, opt out with
+# 0/false/no/off). The action itself (convex/provisioning/seed_dev_user.ts)
+# owns the real gating, including refusing non-loopback SITE_URLs.
+dev_seed_enabled() {
+  [ "${NODE_ENV:-}" = "development" ] || return 1
+  case "$(printf '%s' "${TALE_DEV_SEED_USER:-}" | tr '[:upper:]' '[:lower:]')" in
+    '' | 0 | false | no | off) return 1 ;;
+    *) return 0 ;;
+  esac
 }
 
 # ============================================================================
@@ -447,6 +463,32 @@ deploy_convex_functions() {
       log_ok "Convex data migrations complete"
     else
       log_error "Convex data migrations failed (exit code: $migrations_exit) — platform will continue; legacy data may need manual backfill."
+    fi
+
+    # Dev-only: seed a ready-to-log-in account + organization so a fresh
+    # docker:dev stack is testable without a manual /setup pass. Idempotent
+    # (re-runs no-op) and non-fatal like provisioning: a failure logs, the
+    # next boot retries, and /setup keeps working as the fallback. The action
+    # may also refuse to seed (e.g. non-loopback SITE_URL) — track the real
+    # outcome so the credentials banner never advertises an account that was
+    # not created.
+    if dev_seed_enabled; then
+      log_info "Seeding dev login account (TALE_DEV_SEED_USER)..."
+      local seed_output seed_exit=0
+      seed_output=$(timeout 120 bunx convex run provisioning/seed_dev_user:seedDevUser \
+        --url "$CONVEX_URL" \
+        --admin-key "$ADMIN_KEY" 2>&1) || seed_exit=$?
+      printf '%s\n' "$seed_output"
+      if [ $seed_exit -eq 0 ] && printf '%s' "$seed_output" | grep -q '"status": "seeded"'; then
+        DEV_SEED_STATUS=seeded
+        log_ok "Dev login ready"
+      elif [ $seed_exit -eq 0 ]; then
+        DEV_SEED_STATUS=skipped
+        log_info "Dev login seeding skipped (see action output above)"
+      else
+        DEV_SEED_STATUS=failed
+        log_warn "Dev login seed failed (exit code: $seed_exit) — continuing; register via /setup or retry on next boot."
+      fi
     fi
 
     return 0
@@ -735,6 +777,16 @@ echo "   Application:       ${DISPLAY_BASE_URL}"
 echo "   Convex API (WS):   ${DISPLAY_BASE_URL}/ws_api"
 echo "   Convex Actions:    ${DISPLAY_BASE_URL}/http_api"
 echo "   Convex Dashboard:  ${DISPLAY_BASE_URL}/convex-dashboard"
+if [ "$DEV_SEED_STATUS" = "seeded" ]; then
+  # Defaults mirror convex/provisioning/seed_dev_user.ts (keep in lockstep).
+  # A custom password is intentionally never echoed.
+  echo "   Dev login:         ${TALE_DEV_SEED_USER_EMAIL:-dev@tale.test}"
+  if [ -z "${TALE_DEV_SEED_USER_PASSWORD:-}" ]; then
+    echo "   Dev password:      TaleDev!Passw0rd"
+  else
+    echo "   Dev password:      (from TALE_DEV_SEED_USER_PASSWORD)"
+  fi
+fi
 echo
 
 wait "$VITE_PID"

--- a/services/platform/lib/utils/dev-seed-config.test.ts
+++ b/services/platform/lib/utils/dev-seed-config.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEV_SEED_DEFAULT_EMAIL,
+  DEV_SEED_DEFAULT_PASSWORD,
+  resolveDevSeedConfig,
+} from './dev-seed-config';
+
+describe('resolveDevSeedConfig', () => {
+  it('enables with the default identity when the flag is on and SITE_URL is loopback', () => {
+    const config = resolveDevSeedConfig({
+      TALE_DEV_SEED_USER: '1',
+      SITE_URL: 'https://localhost',
+    });
+    expect(config).toEqual({
+      enabled: true,
+      email: DEV_SEED_DEFAULT_EMAIL,
+      password: DEV_SEED_DEFAULT_PASSWORD,
+      usesDefaultPassword: true,
+    });
+  });
+
+  it('falls back to the loopback default when SITE_URL is unset', () => {
+    const config = resolveDevSeedConfig({ TALE_DEV_SEED_USER: '1' });
+    expect(config.enabled).toBe(true);
+  });
+
+  it('normalizes a custom identity and flags the non-default password', () => {
+    const config = resolveDevSeedConfig({
+      TALE_DEV_SEED_USER: 'true',
+      SITE_URL: 'https://127.0.0.1',
+      TALE_DEV_SEED_USER_EMAIL: '  Admin@Tale.TEST ',
+      TALE_DEV_SEED_USER_PASSWORD: 'Custom!Passw0rd',
+    });
+    expect(config).toEqual({
+      enabled: true,
+      email: 'admin@tale.test',
+      password: 'Custom!Passw0rd',
+      usesDefaultPassword: false,
+    });
+  });
+
+  it.each(['', '0', 'false', 'no', 'off', 'OFF', 'False'])(
+    'stays disabled for opt-out flag value %j',
+    (flag) => {
+      const config = resolveDevSeedConfig({
+        TALE_DEV_SEED_USER: flag,
+        SITE_URL: 'https://localhost',
+      });
+      expect(config).toMatchObject({ enabled: false });
+    },
+  );
+
+  it('stays disabled when the flag is absent entirely', () => {
+    const config = resolveDevSeedConfig({ SITE_URL: 'https://localhost' });
+    expect(config).toMatchObject({
+      enabled: false,
+      reason: expect.stringContaining('TALE_DEV_SEED_USER') as string,
+    });
+  });
+
+  it('refuses a non-loopback SITE_URL even with the flag on', () => {
+    const config = resolveDevSeedConfig({
+      TALE_DEV_SEED_USER: '1',
+      SITE_URL: 'https://tale.example.com',
+    });
+    expect(config).toMatchObject({
+      enabled: false,
+      reason: expect.stringContaining('loopback') as string,
+    });
+  });
+
+  it('refuses an unparseable SITE_URL instead of guessing', () => {
+    const config = resolveDevSeedConfig({
+      TALE_DEV_SEED_USER: '1',
+      SITE_URL: 'not a url',
+    });
+    expect(config).toMatchObject({ enabled: false });
+  });
+});

--- a/services/platform/lib/utils/dev-seed-config.ts
+++ b/services/platform/lib/utils/dev-seed-config.ts
@@ -1,0 +1,72 @@
+/**
+ * Gating + identity resolution for the docker:dev dev-login seeder
+ * (`convex/provisioning/seed_dev_user.ts`). Pure and dependency-free so the
+ * rules (flag spellings, loopback-only, credential overrides) are
+ * unit-testable, and kept out of the convex module so the generated API type
+ * graph only sees the Convex functions themselves.
+ */
+
+/** Mirrors the e2e convention (`TaleE2E!Passw0rd`): satisfies the default
+ * password policy (length/lower/upper/digit/special). Insecure by design —
+ * it guards a loopback-only dev stack, same threat model as the
+ * `x-dev-secrets` defaults in compose.dev.yml. */
+export const DEV_SEED_DEFAULT_EMAIL = 'dev@tale.test';
+export const DEV_SEED_DEFAULT_PASSWORD = 'TaleDev!Passw0rd';
+
+/** Opt-out spellings shared with the other dev toggles (SANDBOX_BROWSER_VIEW,
+ * TALE_DEV_HOT_RELOAD): any of these disables the flag. */
+const FALSY_FLAG_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+/** Same loopback list as the HTTPS guard at the top of convex/auth.ts. */
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+export type DevSeedConfig =
+  | {
+      enabled: true;
+      email: string;
+      password: string;
+      usesDefaultPassword: boolean;
+    }
+  | { enabled: false; reason: string };
+
+/**
+ * Resolve the seed configuration from an env map.
+ */
+export function resolveDevSeedConfig(
+  env: Record<string, string | undefined>,
+): DevSeedConfig {
+  const flag = env.TALE_DEV_SEED_USER?.trim().toLowerCase();
+  if (!flag || FALSY_FLAG_VALUES.has(flag)) {
+    return { enabled: false, reason: 'TALE_DEV_SEED_USER is not enabled' };
+  }
+
+  // Loopback-only: a known password on a reachable hostname is an account
+  // takeover, not a convenience. SITE_URL is the production signal here for
+  // the same reason as convex/auth.ts's HTTPS guard.
+  const siteUrl = env.SITE_URL || 'http://127.0.0.1:3000';
+  let hostname: string;
+  try {
+    hostname = new URL(siteUrl).hostname;
+  } catch {
+    return {
+      enabled: false,
+      reason: `SITE_URL is not a valid URL: ${siteUrl}`,
+    };
+  }
+  if (!LOOPBACK_HOSTNAMES.has(hostname)) {
+    return {
+      enabled: false,
+      reason: `SITE_URL host "${hostname}" is not loopback — refusing to seed a known dev password`,
+    };
+  }
+
+  const password = env.TALE_DEV_SEED_USER_PASSWORD || DEV_SEED_DEFAULT_PASSWORD;
+  return {
+    enabled: true,
+    email: (env.TALE_DEV_SEED_USER_EMAIL || DEV_SEED_DEFAULT_EMAIL)
+      .toLowerCase()
+      .trim(),
+    password,
+    usesDefaultPassword: password === DEV_SEED_DEFAULT_PASSWORD,
+  };
+}

--- a/services/platform/lib/utils/dev-seed-config.ts
+++ b/services/platform/lib/utils/dev-seed-config.ts
@@ -20,7 +20,7 @@ const FALSY_FLAG_VALUES = new Set(['0', 'false', 'no', 'off']);
 /** Same loopback list as the HTTPS guard at the top of convex/auth.ts. */
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 
-export type DevSeedConfig =
+type DevSeedConfig =
   | {
       enabled: true;
       email: string;


### PR DESCRIPTION
## Summary

`bun run docker:dev` now boots into a **ready-to-log-in** stack: after `convex deploy` + provisioning, the platform entrypoint runs an idempotent seed action that auto-completes registration — the owner account **`dev@tale.test` / `TaleDev!Passw0rd`** owning a scaffolded **Dev Workspace** organization. A fresh environment needs no manual `/setup` wizard pass before testing; the credentials are printed in the boot banner.

Also fixes a robustness bug this work surfaced: the docker:dev env-override forwarded the host's `TMPDIR` into containers, crash-looping the platform entrypoint (`mktemp` ENOENT) on hosts with a custom temp dir (e.g. sandboxed shells).

## How it works

- `provisioning/seed_dev_user:seedDevUser` (internalAction) runs from the entrypoint next to `provisioning:provisionAll`. It creates the user via `auth.api.signUpEmail` (the `create_user_without_session.ts` pattern) and the org via `auth.api.createOrganization` with the server-only `userId` body field — a sanctioned headless "system action" in Better Auth 1.6.11 — so the full `afterCreateOrganization` chain (org-config scaffold, workflow pack, prompts, agents, starter content, audit, member mirror) fires exactly as for a human signup. Wizard parity includes `seedSystemDefaultAgents`.
- **Gating (3 layers):** `TALE_DEV_SEED_USER` flag (default **on** only in compose.dev.yml; opt out with `0/false/no/off`; identity overridable via `TALE_DEV_SEED_USER_EMAIL/_PASSWORD`) → entrypoint requires `NODE_ENV=development` → the action itself refuses **non-loopback `SITE_URL`s** (the house "not production" signal, since NODE_ENV is unreliable in the Convex runtime). The banner prints credentials only when the action reports `status: seeded`, and never echoes a custom password.
- **Idempotent:** existing user / existing membership short-circuit, so every re-boot no-ops and a half-seeded state self-heals.
- Playwright e2e (boots via `scripts/dev.ts`) and container tests (`compose.test.yml`, prod target) are on different boot chains and unaffected.

## Verification (all observed on a real stack)

- Fresh boot: entrypoint logs `[seedDevUser] user dev@tale.test created; organization created` → `Dev login ready`.
- **Real browser**: `https://localhost` → redirected to `/log-in` (not `/setup`) → logged in with the dev credentials → landed on `/dashboard/<orgId>/chat` ("Chat - Dev Workspace") with seeded Assistant agent live.
- API: `POST /api/auth/sign-in/email` → 200 + session cookies; `organization/list` → Dev Workspace with correct slug/metadata.
- Scaffold: `/app/data/dev-workspace/` populated (agents/prompts/workflows/governance/…).
- Idempotency: container restart → `user … already existed; organization already existed`, no duplicates.
- Unit tests: 13 cases on the gating/identity resolver (flag spellings, loopback refusal, overrides).
- Gate: `tsc --noEmit` exit 0, oxlint clean, oxfmt clean on touched files.

## Notes for reviewers

- The seed module's handlers carry explicit return annotations: the action references its own module through `internal.provisioning.seed_dev_user.*`, which is circular through `_generated/api.d.ts` and otherwise collapses type inference project-wide (same reason `seed_starter.ts` annotates `Promise<null>`).
- **Pre-existing codegen drift on `main`** (not included here): `convex codegen` also wants to add `node_only/imap_smtp/helpers/smtp_transport` to `api.d.ts` — that entry is missing from the committed file, and adding it currently breaks typecheck in unrelated `agent_tools/*` files. This PR's `api.d.ts` adds only the new seed module entry. Worth a follow-up.
- Local opengrep pre-commit scan was skipped (binary not cached in this environment) — relying on CI's SAST gate.

## Done checklist

- [x] **The gate is green** — tsc exit 0, oxlint/oxfmt clean, 13/13 unit tests pass locally.
- [x] **Security / SAST** — 3-layer gating (dev flag / NODE_ENV / loopback-only); custom passwords never echoed; local opengrep skipped (binary not cached) → CI SAST covers.
- [x] **Migration** — N/A: no schema change (better-auth rows only, created through its own API).
- [x] **Tests carry the change** — happy path + edge (flag spellings, unset SITE_URL) + error (non-loopback, invalid URL); live-stack verification for the Convex/entrypoint path.
- [x] **Localization** — N/A: no product strings (entrypoint operator logs are English like the rest of the script).
- [x] **Docs** — compose.dev.yml comment block documents flag, credentials, opt-out and overrides (house convention for TALE_DEV_* flags, cf. TALE_DEV_HOT_RELOAD); README/docs don't document docker:dev login today (checked).
- [x] **Accessibility** — N/A: no UI change.
- [x] **Behaviour verified by observing the real outcome** — real browser login + API + idempotent restart (see Verification).
- [x] **Instructions/docs for changed paths** — no skill/doc references the touched paths (checked).
- [x] **Atomic, conventional commits** off `main`; no attribution trailers.
