### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,43 @@ skills (`pptx`, …) and the workspace skills under [`skills/`](skills/) are pro
 
 Built-in harness skills cover the rest — `react-doctor` (React smells), `code-review` / `security-review`
 (automated diff review), `claude-api`, `update-config`. Use them; don't reimplement them.
+
+## Cursor Cloud specific instructions
+
+Environment-specific notes for cloud agents. Standard setup/commands live in
+[`docs/en/develop/contributor-setup.md`](docs/en/develop/contributor-setup.md) and root `package.json`
+scripts — read those first; this section only records the non-obvious caveats.
+
+- **Primary product = the platform** (`@tale/platform`): a Vite SPA on `http://localhost:3000` backed by a
+  local Convex backend on `:3210`. `bun install` (the update script) wires up every workspace; `bun run dev`
+  boots Convex + Vite and prints a `READY` banner after ~30–90s (cold start; a pre-banner
+  connection-refused on `:3000` is normal). `web`/`docs` are separate sites (`bun run --filter @tale/web dev`,
+  `@tale/docs`).
+
+- **Docker is NOT installed in this VM.** Run `TALE_DEV_SKIP_DOCKER=1 bun run dev` (plain `bun run dev` also
+  works — it warns and continues without Docker). Without Docker these features are unavailable and that is
+  expected, not a broken env: LLM chat/agents (no sandbox LLM gateway), the knowledge base / RAG (no
+  Postgres), and code-running sandboxes / external agents. Everything else (auth, onboarding, org/agent/project
+  CRUD, settings) works.
+
+- **Node must strip TypeScript types by default (Node ≥ 22.18).** `bun run dev` launches `vite` under Node
+  (not Bun, on purpose), and `vite.config.ts` imports workspace `.ts` plugins, so an older Node fails config
+  load with `ERR_UNKNOWN_FILE_EXTENSION ".ts"` and the orchestrator dies with `Vite dev server exited with
+code 1`. The VM's default `/exec-daemon/node` is v22.14 (no type-stripping); a newer nvm Node (v22.22.2) is
+  symlinked as `node` into `~/.bun/bin` (first on `PATH`) so `env node` resolves to it. If `bun run dev` ever
+  dies with that Vite error, check `node --version` is ≥ 22.18.
+
+- **Chat needs an AI provider key.** With no OpenRouter/other key configured, the Chat dashboard renders
+  "Something went wrong" / "No API key is configured" and Convex logs `NoProviderAvailableError`. Add a key in
+  onboarding or **Settings → AI providers** to enable chat; skip it for non-LLM work.
+
+- **First page load may be a blank white screen** while Vite optimizes deps on the very first request — a hard
+  refresh (Ctrl+Shift+R) loads the app. This is dev cold-start only.
+
+- **Reset local state** with `bun run setup:clean --force` (wipes `services/platform/.convex/local/`); the org
+  config lives on disk under `.tale-config/<org>/` (also safe to delete for a clean first-run). `bun run dev`
+  auto-generates dev secrets into a gitignored root `.env`.
+
+- **Pre-flight**: `bun run setup:check` (Bun ≥1.3, ports 3000/3210 free, Convex CLI). **Gate**: `bun run check`
+  (format + lint + typecheck + tests) is the full merge gate; scope to a workspace while iterating with
+  `bun run --filter @tale/<name> <lint|test|typecheck>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Tale development environment for Cursor Cloud agents and documents the non-obvious caveats discovered during setup. The only repo change is an added `## Cursor Cloud specific instructions` section in `AGENTS.md`; the VM update script is configured separately as `bun install`.

The primary product — the `@tale/platform` SPA (`http://localhost:3000`) backed by a local Convex backend — was booted via `bun run dev` and exercised end-to-end (see walkthrough).

## Environment notes captured

- Docker is not installed in the VM → run `TALE_DEV_SKIP_DOCKER=1 bun run dev` (LLM chat/RAG/sandbox are feature-gated off without it).
- `vite` loads its config under Node and imports workspace `.ts` plugins, so it needs a type-stripping Node (≥ 22.18); a newer nvm Node is symlinked as `node` since the default `/exec-daemon/node` (v22.14) fails config load.
- Chat requires an AI provider key; without one the Chat dashboard shows "Something went wrong" (expected).
- First page load can be a blank screen until Vite finishes dep optimization (hard refresh).

## Checklist

- [x] `bun run check` passes — N/A for full run; ran the relevant subset: `@tale/shared` and `@tale/platform` test suites (210 + 74,421 tests) and `@tale/shared` lint all green, plus `bun run skills:check`.
- [ ] `bun run lint:sast` passes (Opengrep) — N/A (docs-only change).
- [ ] Translations updated — N/A (no `messages/` keys changed).
- [ ] Docs updated in `docs/{en,de,fr}/` — N/A (`AGENTS.md` agent-facing instructions only, not user-facing product docs).
- [ ] `README.md` updated — N/A.

## Test plan

1. `bun install`
2. `bun run setup:check` (all green)
3. `TALE_DEV_SKIP_DOCKER=1 bun run dev` → wait for `READY`, open `http://localhost:3000`
4. Complete first-run onboarding (owner account → organization → dashboard) and create an agent; confirm it persists in the Agents list.

## Walkthrough

[tale_onboarding_create_agent_demo.mp4](https://cursor.com/agents/bc-851978e0-98ca-43bf-94ed-6e64c098f0ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftale_onboarding_create_agent_demo.mp4)

End-to-end first run: create owner account, create the "Tale Dev" organization, reach the dashboard, then create and persist a "Hello World Agent".

[Onboarding complete screen](https://cursor.com/agents/bc-851978e0-98ca-43bf-94ed-6e64c098f0ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftale_onboarding_complete.webp)
[Agents list showing the created Hello World Agent](https://cursor.com/agents/bc-851978e0-98ca-43bf-94ed-6e64c098f0ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftale_agent_created.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-851978e0-98ca-43bf-94ed-6e64c098f0ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-851978e0-98ca-43bf-94ed-6e64c098f0ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

