### PR TITLE
fix(platform): repair red main — branding ConvexError test + orphan secret keys

### DIFF
--- a/services/platform/convex/branding/file_actions.test.ts
+++ b/services/platform/convex/branding/file_actions.test.ts
@@ -98,10 +98,11 @@ describe('branding requireBrandingAdmin authorization (#2044)', () => {
         (e: unknown) => e,
       );
       // Owner/admin clear the capability gate; the invalid image type then
-      // throws a plain Error — proving the role was not rejected.
-      expect(err).toBeInstanceOf(Error);
-      expect(err).not.toBeInstanceOf(ConvexError);
-      expect((err as Error).message).toContain('Invalid image type');
+      // fails with IMAGE_TYPE_INVALID (not ORG_FORBIDDEN) — proving the role
+      // was not rejected at the gate.
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('IMAGE_TYPE_INVALID');
+      expect(errorCode(err)).not.toBe('ORG_FORBIDDEN');
     },
   );
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6909,10 +6909,8 @@
     "errors": {
       "accessDeniedTitle": "Admin-Zugriff erforderlich",
       "nameInvalid": "Nur Großbuchstaben, Zahlen und Unterstriche verwenden, beginnend mit einem Buchstaben (max. 64 Zeichen).",
-      "valueInvalid": "Einen Wert mit 1 bis 8192 Zeichen eingeben.",
       "unauthenticated": "Deine Sitzung ist abgelaufen. Melde dich erneut an und versuche es noch einmal.",
       "forbidden": "Du hast keine Berechtigung, die Secrets dieses Projekts zu verwalten.",
-      "projectNotFound": "Dieses Projekt wurde nicht gefunden. Es wurde möglicherweise gelöscht.",
       "PROJECT_FORBIDDEN": "Du hast keinen Zugriff auf die Secrets dieses Projekts. Nur Projekt-Administratoren können sie ansehen oder verwalten.",
       "PROJECT_NOT_FOUND": "Dieses Projekt existiert nicht mehr.",
       "SECRET_NAME_INVALID": "Secret-Namen müssen mit einem Buchstaben beginnen und dürfen nur Großbuchstaben, Zahlen und Unterstriche enthalten (max. 64 Zeichen).",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7173,10 +7173,8 @@
     "errors": {
       "accessDeniedTitle": "Admin access required",
       "nameInvalid": "Use uppercase letters, numbers, and underscores only, starting with a letter (max 64 characters).",
-      "valueInvalid": "Enter a value between 1 and 8192 characters.",
       "unauthenticated": "Your session has expired. Sign in again, then retry.",
       "forbidden": "You don't have permission to manage this project's secrets.",
-      "projectNotFound": "We couldn't find that project. It may have been deleted.",
       "PROJECT_FORBIDDEN": "You don't have access to this project's secrets. Only project administrators can view or manage them.",
       "PROJECT_NOT_FOUND": "This project no longer exists.",
       "SECRET_NAME_INVALID": "Secret names must start with a letter and contain only uppercase letters, numbers, and underscores (max 64 characters).",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6910,10 +6910,8 @@
     "errors": {
       "accessDeniedTitle": "Accès administrateur requis",
       "nameInvalid": "Utilise uniquement des lettres majuscules, des chiffres et des traits de soulignement, en commençant par une lettre (max. 64 caractères).",
-      "valueInvalid": "Saisis une valeur de 1 à 8192 caractères.",
       "unauthenticated": "Ta session a expiré. Reconnecte-toi, puis réessaie.",
       "forbidden": "Tu n'as pas l'autorisation de gérer les secrets de ce projet.",
-      "projectNotFound": "Ce projet est introuvable. Il a peut-être été supprimé.",
       "PROJECT_FORBIDDEN": "Tu n'as pas accès aux secrets de ce projet. Seuls les administrateurs du projet peuvent les consulter ou les gérer.",
       "PROJECT_NOT_FOUND": "Ce projet n'existe plus.",
       "SECRET_NAME_INVALID": "Les noms de secret doivent commencer par une lettre et ne contenir que des lettres majuscules, des chiffres et des tirets bas (64 caractères max).",


### PR DESCRIPTION
## Problem

`main` (`150fd5e72`) is red: the **Unit** job fails on three tests, and every open PR that merges main inherits the failure.

- `convex/branding/file_actions.test.ts` — the two "owner/admin clear the capability gate" cases asserted the invalid-image-type path throws a **plain `Error`**. PR #2241 (surface branding image upload errors via ConvexError) changed that path to throw a `ConvexError({ code: 'IMAGE_TYPE_INVALID' })`, so the assertions `not.toBeInstanceOf(ConvexError)` now fail.
- `lib/i18n/messages.test.ts` — `projectSecrets.errors.projectNotFound` and `projectSecrets.errors.valueInvalid` are orphan keys (defined in en/de/fr, referenced nowhere). They are stale camelCase leftovers from before the Secrets UI moved to the uppercase `PROJECT_NOT_FOUND` / `SECRET_VALUE_INVALID` error codes.

## Fix

- Update the owner/admin branding assertions to expect the `ConvexError` with code `IMAGE_TYPE_INVALID` (still proving the role cleared the gate — the code is not `ORG_FORBIDDEN`). Behaviour under test is unchanged; only the expectation is corrected to match the shipped error shape.
- Remove the two orphan `projectSecrets.errors` keys from `en.json`, `de.json`, and `fr.json`. The live `PROJECT_NOT_FOUND` / `SECRET_VALUE_INVALID` keys the UI actually uses are untouched.

## Verification

- `convex/branding/file_actions.test.ts` + `lib/i18n/messages.test.ts`: 29/29 green (were 3 failing).
- Full `lib/i18n/` suite: 47/47 green (usage + parity).
- `oxfmt --check` clean on all four changed files.

## Unblocks

The open PRs (#2327, #2328) fail Unit only because they merged this red main; they go green once this lands and they rebase.

Made with [Cursor](https://cursor.com)