### PR TITLE
fix(platform): surface agent webhook URL copy failures (#2353)

### DIFF
--- a/services/platform/app/features/agents/components/agent-webhook-section.test.tsx
+++ b/services/platform/app/features/agents/components/agent-webhook-section.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render, screen } from '@/tests/utils/render';
+import { fireEvent, render, screen, waitFor } from '@/tests/utils/render';
 
+import type { AgentWebhook } from '../hooks/queries';
 import { AgentWebhookSection } from './agent-webhook-section';
 
 // Migrated from the `agent-editor` E2E "webhook tab: renders the section and
@@ -12,14 +13,13 @@ import { AgentWebhookSection } from './agent-webhook-section';
 // than a mutate. None of that needs a backend — with an empty webhook list the
 // whole section is pure client-side UI — so it belongs at the component tier.
 //
-// We mock the webhook query to an empty list (the freshly-created-agent state
-// the E2E saw) and the webhook mutations (only touched on create/toggle/delete,
-// never at mount), and assert the same three seams: the "Webhooks" section
-// heading (h2), the "Create webhook" button, and the "No webhooks yet" empty
-// state.
+// We mock the webhook query (a mutable list so a test can seed a row), and the
+// webhook mutations (only touched on create/toggle/delete, never at mount).
+
+let mockWebhooks: AgentWebhook[] = [];
 
 vi.mock('../hooks/queries', () => ({
-  useAgentWebhooks: () => ({ webhooks: [], isLoading: false }),
+  useAgentWebhooks: () => ({ webhooks: mockWebhooks, isLoading: false }),
 }));
 
 vi.mock('../hooks/mutations', () => ({
@@ -47,6 +47,7 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
 const TITLE = 'Webhooks';
 const CREATE_BUTTON = 'Create webhook';
 const EMPTY_TITLE = 'No webhooks yet';
+const COPY_URL = 'Copy webhook URL';
 
 // The DataTable's actions column intentionally uses an empty header (header:
 // ''), a standard data-table pattern. Disable the empty-table-header rule so we
@@ -55,6 +56,20 @@ const EMPTY_TITLE = 'No webhooks yet';
 const axeOptions = {
   rules: { 'empty-table-header': { enabled: false } },
 };
+
+function webhookRow(overrides: Partial<AgentWebhook> = {}): AgentWebhook {
+  return {
+    _id: 'wh-1',
+    token: 'tok-abc',
+    isActive: true,
+    lastTriggeredAt: undefined,
+    ...overrides,
+  } as AgentWebhook;
+}
+
+afterEach(() => {
+  mockWebhooks = [];
+});
 
 describe('AgentWebhookSection', () => {
   it('renders the section heading, create affordance, and empty state', async () => {
@@ -78,5 +93,65 @@ describe('AgentWebhookSection', () => {
     expect(screen.getByText(EMPTY_TITLE)).toBeInTheDocument();
 
     await checkAccessibility(container, axeOptions);
+  });
+
+  // Regression for #2353: a denied clipboard write used to be swallowed by a
+  // comment-only catch, so the user believed the URL was copied. The shared
+  // `useCopy` hook now logs the failure (and shows a destructive toast); assert
+  // the failure surfaces and the row is NOT flipped to its "copied" state.
+  describe('copy webhook URL', () => {
+    beforeEach(() => {
+      mockWebhooks = [webhookRow()];
+    });
+
+    it('surfaces a denied clipboard write instead of swallowing it', async () => {
+      const errorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      render(
+        <AgentWebhookSection organizationId="org-1" agentSlug="e2e-editor" />,
+      );
+
+      const writeText = vi
+        .spyOn(navigator.clipboard, 'writeText')
+        .mockRejectedValue(new Error('clipboard denied'));
+
+      const copyButton = screen.getByRole('button', { name: COPY_URL });
+      fireEvent.click(copyButton);
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledTimes(1);
+      });
+
+      // The failure is logged, not swallowed by a comment-only catch.
+      await waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          'Copy to clipboard failed:',
+          expect.any(Error),
+        );
+      });
+
+      // The button never flips to its transient "copied" check on failure.
+      expect(copyButton.querySelector('.text-green-500')).toBeNull();
+    });
+
+    it('copies the webhook URL on success', async () => {
+      render(
+        <AgentWebhookSection organizationId="org-1" agentSlug="e2e-editor" />,
+      );
+
+      const writeText = vi
+        .spyOn(navigator.clipboard, 'writeText')
+        .mockResolvedValue(undefined);
+
+      fireEvent.click(screen.getByRole('button', { name: COPY_URL }));
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          'https://example.test/api/agents/wh/tok-abc',
+        );
+      });
+    });
   });
 });

--- a/services/platform/app/features/agents/components/agent-webhook-section.tsx
+++ b/services/platform/app/features/agents/components/agent-webhook-section.tsx
@@ -15,6 +15,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { Switch } from '@/app/components/ui/forms/switch';
+import { useCopy } from '@/app/hooks/use-copy';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -44,6 +45,7 @@ export function AgentWebhookSection({
 }: AgentWebhookSectionProps) {
   const { t } = useT('settings');
   const { toast } = useToast();
+  const { copy } = useCopy();
 
   const { webhooks } = useAgentWebhooks(organizationId, agentSlug);
 
@@ -131,19 +133,18 @@ export function AgentWebhookSection({
   const handleCopyUrl = useCallback(
     async (token: string) => {
       const url = getWebhookUrl(token);
-      try {
-        await navigator.clipboard.writeText(url);
-        setCopiedToken(token);
-        toast({
-          title: t('agents.webhook.toast.urlCopied'),
-          variant: 'success',
-        });
-        setTimeout(() => setCopiedToken(null), 2000);
-      } catch {
-        // Clipboard API not available
-      }
+      // `useCopy` logs and shows a destructive toast when the clipboard write
+      // is denied — never leave the user believing a failed copy succeeded.
+      const copied = await copy(url);
+      if (!copied) return;
+      setCopiedToken(token);
+      toast({
+        title: t('agents.webhook.toast.urlCopied'),
+        variant: 'success',
+      });
+      setTimeout(() => setCopiedToken(null), 2000);
     },
-    [getWebhookUrl, toast, t],
+    [getWebhookUrl, copy, toast, t],
   );
 
   const { formatDate: formatDateLong } = useFormatDate();

--- a/services/platform/app/hooks/use-copy.ts
+++ b/services/platform/app/hooks/use-copy.ts
@@ -49,7 +49,7 @@ interface UseCopyReturn {
  * });
  * ```
  */
-function useCopy(options: UseCopyOptions = {}): UseCopyReturn {
+export function useCopy(options: UseCopyOptions = {}): UseCopyReturn {
   const {
     copiedDuration = 2000,
     onSuccess,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2353. The agent Webhooks table's "Copy webhook URL" action swallowed a denied clipboard write in a comment-only `catch`, so a user whose clipboard write failed (e.g. an automated browser without permission) got zero feedback and believed the URL was copied. This routes the copy through the shared `useCopy` hook — the same primitive the #2050 sweep standardized on — which logs the failure and shows a destructive toast, and only flips the row to its transient "copied" check when the write actually succeeds.

`useCopy` was the documented base primitive but was not exported (only `useCopyButton`, which takes a fixed value, was). Exporting it lets the per-row table cell reuse it instead of hand-rolling a bespoke clipboard call.

## Checklist

- [x] `bun run check` passes — ran format (oxfmt), `@tale/platform` lint (0 warnings/0 errors), typecheck (code 0), and the component test suite for this file (3 passed). Full-repo `check` includes a Python `ruff` step (`uvx`) not installed in this environment; unrelated to this TS-only change.
- [x] `bun run lint:sast` — N/A: no new sinks (no SQL/shell/network); pure client clipboard + toast wiring.
- [x] Translations updated — N/A: reuses the existing `common:errors.failedToCopy` (already in en/de/fr) via `useCopy`; no new keys.
- [x] Docs updated — N/A: no user-facing copy or behaviour beyond restoring expected error feedback.
- [x] `README` updated — N/A.

## Test plan

- Added regression coverage in `agent-webhook-section.test.tsx`:
  - "surfaces a denied clipboard write instead of swallowing it" — mocks `navigator.clipboard.writeText` to reject, asserts the failure is logged (`console.error`) and the row does **not** flip to its copied-check state. Verified this test **fails on the old comment-only-catch code** and **passes on the fix**.
  - "copies the webhook URL on success" — asserts the correct URL is written to the clipboard.
- Manual: Agents → agent → Webhooks → row action "Copy webhook URL" in an environment where clipboard write is denied now shows a destructive toast instead of silently appearing to succeed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09e4496b-e2f5-46a4-bf0e-e8b7c0abe2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09e4496b-e2f5-46a4-bf0e-e8b7c0abe2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

