### PR TITLE
fix(platform): correct export-chat PDF button label in test

### DIFF
--- a/services/platform/app/features/chat/components/export-chat-dialog.test.tsx
+++ b/services/platform/app/features/chat/components/export-chat-dialog.test.tsx
@@ -151,7 +151,7 @@ describe('ExportChatDialog', () => {
     expect(
       screen.getByRole('button', { name: 'Download Markdown' }),
     ).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Print to PDF' })).toBeDisabled();
   });
 
   it('reaches zero when messages are deselected one by one', async () => {
@@ -176,6 +176,6 @@ describe('ExportChatDialog', () => {
     expect(
       screen.getByRole('button', { name: 'Download Markdown' }),
     ).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Print to PDF' })).toBeDisabled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The export-chat dialog tests (added in #2140) asserted on a `Download PDF` button, but the shipped label is `Print to PDF`. The two `Deselect all` tests therefore failed under the `Test / UI` job (`vitest.ui.config.ts`), turning `main` red.

## Fix

Align the two remaining assertions with the actual button label (`Print to PDF`), matching the sibling assertion already present in the file.

## Verification

`bunx vitest --run --config vitest.ui.config.ts app/features/chat/components/export-chat-dialog.test.tsx` → 6 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36be31fb-c949-426b-a2cd-2a096746de44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36be31fb-c949-426b-a2cd-2a096746de44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

