### PR TITLE
refactor(platform): remove dead agent-webhook publish gate (#2359)

### DIFF
--- a/services/platform/app/features/agents/components/agent-webhook-section.tsx
+++ b/services/platform/app/features/agents/components/agent-webhook-section.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Alert } from '@tale/ui/alert';
 import { Button } from '@tale/ui/button';
 import { CodeBlock } from '@tale/ui/code-block';
 import { Row } from '@tale/ui/layout';
@@ -60,7 +59,6 @@ export function AgentWebhookSection({
 
   const siteUrl = useSiteUrl();
   const basePath = getEnv('BASE_PATH');
-  const isPublished = true; // All agents are live in the file-based architecture
 
   const getWebhookUrl = useCallback(
     (token: string) => `${siteUrl}${basePath}/api/agents/wh/${token}`,
@@ -306,12 +304,6 @@ export function AgentWebhookSection({
           </Button>
         }
       />
-      {!isPublished && (
-        <Alert
-          variant="warning"
-          description={t('agents.webhook.notPublished')}
-        />
-      )}
 
       <DataTable
         columns={columns}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5569,7 +5569,6 @@
       "webhook": {
         "title": "Webhook",
         "description": "Eindeutige URLs erstellen, um mit diesem Agent von externen Systemen zu chatten.",
-        "notPublished": "Veröffentliche diesen Agent, um Webhook-Zugriff zu aktivieren.",
         "createButton": "Webhook erstellen",
         "createdTitle": "Webhook erstellt",
         "urlWarning": "Speichere diese Webhook-URL. Das Token in der URL dient als Authentifizierungsnachweis.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5833,7 +5833,6 @@
       "webhook": {
         "title": "Webhooks",
         "description": "Create unique URLs to chat with this agent from external systems.",
-        "notPublished": "Publish this agent to enable webhook access.",
         "createButton": "Create webhook",
         "createdTitle": "Webhook created",
         "urlWarning": "Save this webhook URL. The token in the URL acts as the authentication credential.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5570,7 +5570,6 @@
       "webhook": {
         "title": "Webhooks",
         "description": "Crée des URL uniques pour discuter avec cet agent depuis des systèmes externes.",
-        "notPublished": "Publie cet agent pour activer l'accès par webhook.",
         "createButton": "Créer un webhook",
         "createdTitle": "Webhook créé",
         "urlWarning": "Enregistre cette URL de webhook. Le jeton dans l'URL sert d'identifiant d'authentification.",

--- a/services/platform/tests/manual/agents.md
+++ b/services/platform/tests/manual/agents.md
@@ -98,13 +98,12 @@ confirmation only); create-agent validation is the component test above.
 | F19 | External BYO creds    | External agent (from F17) → Instructions tab → **Credentials** section (`settings.agents.form.byo.sectionTitle`) → select **Bring your own credentials (BYO)** (`settings.agents.form.byo.byoLabel`) → fill **Provider model id** (`settings.agents.form.byo.modelLabel`, placeholder **"e.g. claude-opus-4-20250514"**, `settings.agents.form.byo.modelPlaceholder`) → **Save**                                                                                            | After reload the BYO selection and the model id rehydrate (persistence is mode A; actually running on BYO credentials needs mode B / live keys)                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | F20 | Environment & secrets | Environment tab (**"Environment & secrets"**, `settings.agents.env.title`) → **Add variable** (`envEditor.add`) → fill **NAME** (`envEditor.keyPlaceholder`) + **value** (`envEditor.valuePlaceholder`); the **Type** select (`envEditor.valueType`) offers **Value / Secret / Token source** (`envEditor.secret` / `envEditor.typeTokenSource`) — pick **Secret** on one row → **Save** (`envEditor.save`)                                                                 | Toast **"Environment saved"** (`envEditor.saved`); after reload the rows persist and the secret's value is masked (type=password immediately; hint-mask like `pla••••e-2` after reload). Sub-asserts: an invalid NAME (e.g. `1BAD`) raises the `envEditor.badKey` error and a duplicate NAME the `envEditor.dupKey` error — both fire as **transient toasts on Save**, not inline field errors                                                                                                                                                                         |
 
-> **F11 publish gate (verified live — none exists)**: the
-> **"Publish this agent to enable webhook access."** warning
-> (`settings.agents.webhook.notPublished`) is unreachable dead code —
-> `agent-webhook-section.tsx` hardcodes `isPublished = true` ("all agents are
-> live in the file-based architecture"). **Create webhook** stays enabled even
-> with **Visible in chat** off. If the warning ever appears, that is a
-> regression worth filing.
+> **F11 publish gate (none exists — by design)**: every agent is live in the
+> file-based architecture, so there is no "publish" gate on webhook access.
+> **Create webhook** is always enabled, even with **Visible in chat** off. The
+> former dead `isPublished`/`notPublished` warning branch was removed (#2359);
+> if any "publish this agent" warning reappears, that is a regression worth
+> filing.
 
 ## Boundary & error tests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2359. `agent-webhook-section.tsx` hardcoded `const isPublished = true` ("all agents are live in the file-based architecture"), so the `!isPublished` "Publish this agent to enable webhook access." warning branch was unreachable dead code — verified live in the manual pass (Create webhook stays enabled even with "Visible in chat" off). This removes the dead const and `Alert` branch (and the now-unused `Alert` import), drops the orphaned `settings.agents.webhook.notPublished` key from all three locales, and updates the agents manual-guide note that documented the dead gate.

Behaviour-preserving: the removed branch never rendered.

## Checklist

- [x] `bun run check` passes — `@tale/platform` lint (0 warnings/0 errors), typecheck (code 0), i18n parity + usage checks (enforce mode, 23 passed), and the component test (passes). Full-repo `check` includes a Python `ruff` step (`uvx`) not installed in this environment; unrelated to this change.
- [x] `bun run lint:sast` — N/A: dead-code removal, no new sinks.
- [x] Translations updated in `messages/{en,de,fr}.json` — removed the orphaned `notPublished` key from all three; parity/usage checks pass.
- [x] Docs updated — N/A for `docs/`; updated the manual test guide note in `tests/manual/agents.md` that referenced the dead gate.
- [x] `README` updated — N/A.

## Test plan

- `bunx vitest --run --project server lib/i18n/messages.test.ts` — parity + usage (enforce mode) pass, confirming the removed key leaves no orphan and no dangling `t()` reference.
- `bunx vitest --run --config vitest.ui.config.ts agent-webhook-section` — the section still renders its heading, create affordance, and empty state.
- Manual: the Webhooks tab renders identically; no "publish this agent" warning ever appeared (the branch was dead), so there is no visible change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09e4496b-e2f5-46a4-bf0e-e8b7c0abe2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09e4496b-e2f5-46a4-bf0e-e8b7c0abe2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

