### PR TITLE
fix(ui): render asChild button icon inside slotted child (#1976)

### DIFF
--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -138,6 +138,27 @@ describe('Button', () => {
       expect(tooltip).toHaveTextContent('Rich tip');
     });
 
+    it('forwards an icon into the slotted child without a Fragment className warning (asChild + icon)', () => {
+      // Regression for #1976: `asChild` + `icon` used to wrap the icon and the
+      // child in a bare Fragment and hand it to Radix Slot, which forwarded
+      // `className` onto the Fragment ("Invalid prop `className` supplied to
+      // `React.Fragment`"). The icon must land inside the slotted anchor.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      render(
+        <Button asChild icon={Mail} variant="secondary">
+          <a href="/test">Open</a>
+        </Button>,
+      );
+      const link = screen.getByRole('link', { name: 'Open' });
+      expect(link.querySelector('svg')).toBeInTheDocument();
+      expect(
+        errorSpy.mock.calls.some((args) =>
+          String(args[0]).includes('React.Fragment'),
+        ),
+      ).toBe(false);
+      errorSpy.mockRestore();
+    });
+
     it('renders no tooltip trigger when used as a Slot (asChild)', () => {
       // A Slot is typically another overlay's trigger; wrapping it in a tooltip
       // trigger would break that composition, so the tooltip is suppressed.

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -1,4 +1,4 @@
-import { Slot } from '@radix-ui/react-slot';
+import { Slot, Slottable } from '@radix-ui/react-slot';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { Link } from '@tanstack/react-router';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -182,23 +182,36 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
         children
       );
 
-    const content =
-      asChild && !isLoading && !Icon ? (
-        children
-      ) : isLoading ? (
-        <>
-          <Loader2
-            className={cn(iconClass, 'animate-spin motion-reduce:animate-none')}
-            aria-hidden="true"
-          />
-          {label}
-        </>
+    const leading = isLoading ? (
+      <Loader2
+        key="leading"
+        className={cn(iconClass, 'animate-spin motion-reduce:animate-none')}
+        aria-hidden="true"
+      />
+    ) : Icon ? (
+      <Icon key="leading" className={iconClass} aria-hidden="true" />
+    ) : null;
+
+    // Under `asChild` the single child element (e.g. a Link) IS the rendered
+    // control, so a leading icon/spinner must be injected as its sibling via
+    // `Slottable` — Radix then merges props onto that child and keeps the icon
+    // inside it. The icon and `Slottable` are passed as an ARRAY (direct Slot
+    // children), never a Fragment: Slot doesn't descend into a Fragment to find
+    // the `Slottable`, and forwarding `className` onto a Fragment triggers
+    // React's "Invalid prop `className` supplied to `React.Fragment`" (#1976).
+    // With no leading element the child is passed straight through.
+    const content = asChild ? (
+      leading ? (
+        [leading, <Slottable key="child">{children}</Slottable>]
       ) : (
-        <>
-          {Icon ? <Icon className={iconClass} aria-hidden="true" /> : null}
-          {label}
-        </>
-      );
+        children
+      )
+    ) : (
+      <>
+        {leading}
+        {label}
+      </>
+    );
 
     return (
       <Comp


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1976. The shared `Button` logged React's "Invalid prop `className` supplied to `React.Fragment`" (three times) on the agent **Delegation** tab. The organigram side panel renders `<Button asChild icon={ExternalLink}><Link/></Button>`, and `ButtonBase` built its content as a bare `<>{icon}{children}</>` Fragment and handed it to Radix `Slot`. `Slot` clones its single child (the Fragment) with the merged `className`, so `className` landed on a `React.Fragment`.

The fix uses Radix `Slottable`: under `asChild`, the leading icon/spinner and the slotted child are passed as **direct** Slot children (an array, not a Fragment). `Slot` then merges props onto the real child element (e.g. the `Link`) and keeps the icon inside it. This fixes the whole class of `asChild` + `icon`/`isLoading` usages, not just the one call site.

## Checklist

- [x] `bun run check` passes — ran `@tale/ui` test (82 passed), lint (0 warnings/errors), typecheck (clean), oxfmt.
- [x] `bun run lint:sast` — N/A (no security-relevant change; Opengrep binary not cached in this env).
- [x] Translations — N/A (no user-visible string changed).
- [x] Docs — N/A (internal component behaviour; no user-facing change).
- [x] READMEs — N/A.

## Test plan

- Added a regression test in `button.test.tsx`: `<Button asChild icon={Mail}><a>Open</a></Button>` renders the `<svg>` **inside** the anchor and produces no `React.Fragment` `console.error`. It fails on the old Fragment-based rendering and passes now.
- Verified rendered DOM: the anchor carries the merged button classes and contains the icon followed by the label.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

