### PR TITLE
fix(platform): hide picker-hidden models from agent add-model list (#2340)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -262,6 +262,13 @@ function InstructionsTab() {
         continue;
       if (config.provider && provider.name !== config.provider) continue;
       for (const model of provider.models) {
+        // Models flagged "Hidden from model pickers" must not appear in the
+        // agent's Add-model picker — the flag's contract covers agent model
+        // selection too (see providers schema), matching the chat composer
+        // (model-selector.tsx) and the create-agent dialog. Already-selected
+        // models are dropped as candidates below, so a hidden model an agent
+        // already references stays in its saved list without being re-offered.
+        if (model.hidden === true) continue;
         const variants = Array.isArray(model.quantizations)
           ? model.quantizations
           : undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2340. Models flagged **"Hidden from model pickers"** were still listed in the agent editor's **Instructions & models → Add model** picker, even though the flag's contract (see `services/platform/lib/shared/schemas/providers.ts`) explicitly covers "chat composer, **agent model selection**". The chat `model-selector.tsx` and the create-agent dialog already filter it; only the agent editor's `availableOptions` (in `instructions.tsx`) did not.

The fix skips `model.hidden === true` when building the picker candidates — the same one-liner the create-agent dialog uses. Already-selected models are dropped as candidates further down, so a hidden model an agent already references stays in its saved list and keeps working; it just isn't re-offered in the Add picker.

## Checklist

- [x] `bun run check` — ran `@tale/platform` typecheck (clean), oxfmt, oxlint (0 warnings/errors) on the touched file.
- [x] `bun run lint:sast` — N/A (no security-relevant change; Opengrep binary not cached in this env).
- [x] Translations — N/A (no strings changed).
- [x] Docs — N/A (behaviour now matches the already-documented flag contract).
- [x] READMEs — N/A.

## Test plan

- Settings → AI providers → a model → Edit model → enable **Hidden from model pickers** → Save.
- Open any agent → **Instructions & models → Add model** — the hidden model is no longer listed (previously it leaked here while the chat composer correctly dropped it).
- An agent that already references a now-hidden model keeps it in its saved model list.

Note: this mirrors the established, schema-documented filter in `model-selector.tsx` (covered by `model-selector.test.tsx`) and `agent-create-dialog.tsx`; no new route-level harness was added for the one-line filter, consistent with the sibling fixes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

