### PR TITLE
test(platform): add mock /v1/moderations gateway route (#2358)

### DIFF
--- a/services/platform/lib/mocks/contract/openai-compat.test.ts
+++ b/services/platform/lib/mocks/contract/openai-compat.test.ts
@@ -117,6 +117,19 @@ describe('Prism-served AI endpoints (deterministic examples)', () => {
     expect(body.data[0].embedding.length).toBeGreaterThan(0);
   });
 
+  test('POST /v1/moderations returns a benign OpenAI-shaped verdict', async () => {
+    const res = await post('/v1/moderations', {
+      model: 'omni-moderation-latest',
+      input: 'hello there',
+    });
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results[0].flagged).toBe(false);
+    expect(typeof body.results[0].categories).toBe('object');
+    expect(typeof body.results[0].category_scores).toBe('object');
+  });
+
   test('POST /v1/images/generations returns base64 image data', async () => {
     const res = await post('/v1/images/generations', {
       model: 'img',

--- a/services/platform/lib/mocks/specs/providers/openai-compat.openapi.yaml
+++ b/services/platform/lib/mocks/specs/providers/openai-compat.openapi.yaml
@@ -105,6 +105,68 @@ paths:
                 usage:
                   prompt_tokens: 8
                   total_tokens: 8
+  /moderations:
+    post:
+      operationId: createModeration
+      summary: Classify text against the moderation categories.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                model: { type: string }
+                input:
+                  oneOf:
+                    - type: string
+                    - type: array
+              required: [input]
+      responses:
+        '200':
+          description: A moderation result in the OpenAI moderations shape.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, model, results]
+                properties:
+                  id: { type: string }
+                  model: { type: string }
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      required: [flagged, categories, category_scores]
+                      properties:
+                        flagged: { type: boolean }
+                        categories:
+                          type: object
+                          additionalProperties: { type: boolean }
+                        category_scores:
+                          type: object
+                          additionalProperties: { type: number }
+              # Benign verdict so the governance moderation "Run test" resolves
+              # to a deterministic PASS in the hermetic stack. Category keys
+              # cover the OpenAI preset's default mappings (harassment, hate,
+              # violence, sexual, self-harm) so a `flag`-mode mapping resolves.
+              example:
+                id: modr-mock
+                model: omni-moderation-latest
+                results:
+                  - flagged: false
+                    categories:
+                      harassment: false
+                      hate: false
+                      violence: false
+                      sexual: false
+                      self-harm: false
+                    category_scores:
+                      harassment: 0.0001
+                      hate: 0.0001
+                      violence: 0.0001
+                      sexual: 0.0001
+                      self-harm: 0.0001
   /images/generations:
     post:
       operationId: createImage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2358. The governance moderation panel's **Run test** reaches the local mock gateway end-to-end, but `services/platform/lib/mocks` had no `/v1/moderations` route, so Prism returned `404` (`NO_PATH_MATCHED_ERROR`) and the verdict was always "HTTP 404 — the endpoint URL is wrong". This blocked automating `tests/manual/governance.md` F17 in the mode-A hermetic stack.

Adds a `/moderations` path to the OpenAI-compat spec (mounted at `/v1`) returning a deterministic, benign OpenAI-shaped moderation result. The response matches what `openai_moderation` `responseShape` parses (`results[0].flagged`, `results[0].categories` record-of-bool, `results[0].category_scores`), and its category keys cover the OpenAI preset's default `flag`-mode mappings (harassment, hate, violence, sexual, self-harm) so the round-trip resolves to a green **pass**.

## Checklist

- [x] `bun run check` — ran the `@tale/platform` `openai-compat` contract suite (14 passed, up from 13); oxfmt + oxlint clean on the touched TS. YAML matches the spec's existing 2-space style (no YAML formatter configured; Prism validated the spec by serving it).
- [x] `bun run lint:sast` — N/A (mock/test spec only; Opengrep binary not cached in this env).
- [x] Translations — N/A.
- [x] Docs — N/A (test/mock harness).
- [x] READMEs — N/A.

## Test plan

- Added a contract test: `POST /v1/moderations` returns `200` with `results[0].flagged === false` and object `categories` / `category_scores` — served by Prism from the spec example through the real in-process gateway.
- In the mode-A stack: Governance → moderation provider → apply the OpenAI preset, point the endpoint at the mock gateway's `/v1/moderations`, **Run test** now resolves to a pass instead of a 404.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

