### PR TITLE
fix(platform): map token-source save field errors, drop raw ConvexError (#2350)

### DIFF
--- a/services/platform/app/features/settings/token-sources/components/token-sources-manager.test.tsx
+++ b/services/platform/app/features/settings/token-sources/components/token-sources-manager.test.tsx
@@ -4,6 +4,7 @@ import { screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { toast } from '@/app/hooks/use-toast';
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
 
@@ -24,6 +25,8 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+const { saveMock } = vi.hoisted(() => ({ saveMock: vi.fn() }));
 
 vi.mock('@/app/hooks/use-action-query', () => ({
   // The list query is enabled; the form-sheet detail query is disabled in
@@ -50,7 +53,7 @@ vi.mock('@/app/hooks/use-action-query', () => ({
 }));
 
 vi.mock('@/app/hooks/use-convex-action', () => ({
-  useConvexAction: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useConvexAction: () => ({ mutateAsync: saveMock, isPending: false }),
 }));
 
 vi.mock('@/app/hooks/use-list-page', () => ({
@@ -87,5 +90,40 @@ describe('TokenSourcesManager', () => {
     ).toBeInTheDocument();
 
     await checkAccessibility(baseElement);
+  });
+
+  it('maps server field errors inline and never leaks the raw ConvexError (#2350)', async () => {
+    saveMock.mockRejectedValueOnce({
+      data: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid token source configuration',
+        fieldErrors: { slug: ['Required'], endpoint: ['Invalid URL'] },
+      },
+    });
+
+    const { user } = render(<TokenSourcesManager organizationId="org-1" />);
+    await user.click(
+      screen.getByRole('button', { name: /tokenSources\.new/i }),
+    );
+    await user.click(
+      await screen.findByRole('button', { name: /tokenSources\.save$/i }),
+    );
+
+    // Per-field messages surface inline on the offending inputs…
+    expect(await screen.findByText('Required')).toBeInTheDocument();
+    expect(screen.getByText('Invalid URL')).toBeInTheDocument();
+
+    // …the toast carries a clean localized description, never the raw JSON.
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'common.editor.fixHighlightedFields',
+      }),
+    );
+    const rawLeaked = vi
+      .mocked(toast)
+      .mock.calls.some((c) =>
+        JSON.stringify(c).includes('Invalid token source configuration'),
+      );
+    expect(rawLeaked).toBe(false);
   });
 });

--- a/services/platform/app/features/settings/token-sources/components/token-sources-manager.tsx
+++ b/services/platform/app/features/settings/token-sources/components/token-sources-manager.tsx
@@ -121,6 +121,7 @@ function readTokenSourceFieldErrors(
   const raw = data.fieldErrors;
   if (raw == null || typeof raw !== 'object') return undefined;
   const out: Record<string, string> = {};
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `raw` is runtime-checked to be a non-null object above; entries are narrowed per-field below
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
     if (!Array.isArray(value)) continue;
     const msg = value

--- a/services/platform/app/features/settings/token-sources/components/token-sources-manager.tsx
+++ b/services/platform/app/features/settings/token-sources/components/token-sources-manager.tsx
@@ -26,6 +26,7 @@ import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Sheet } from '@/app/components/ui/overlays/sheet';
+import { readConvexErrorData } from '@/app/features/settings/providers/utils/error-dispatch';
 import { configKeys } from '@/app/hooks/config-query-keys';
 import { useActionQuery } from '@/app/hooks/use-action-query';
 import { useConvexAction } from '@/app/hooks/use-convex-action';
@@ -103,6 +104,31 @@ interface LoadedTokenSource {
     selection?: Selection;
   };
   hasSecret: boolean;
+}
+
+/**
+ * Map a `VALIDATION_ERROR` ConvexError's `fieldErrors` (a Zod `flatten()`
+ * shape) into a flat record of joined per-field messages keyed by the config
+ * field name (`slug`, `displayName`, `endpoint`, …). Returns undefined for any
+ * other error so the caller falls back to a clean generic toast rather than
+ * leaking the raw ConvexError JSON + request id.
+ */
+function readTokenSourceFieldErrors(
+  err: unknown,
+): Record<string, string> | undefined {
+  const data = readConvexErrorData(err);
+  if (data?.code !== 'VALIDATION_ERROR') return undefined;
+  const raw = data.fieldErrors;
+  if (raw == null || typeof raw !== 'object') return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const msg = value
+      .filter((m): m is string => typeof m === 'string')
+      .join('; ');
+    if (msg) out[key] = msg;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function fromConfig(res: LoadedTokenSource): FormState {
@@ -364,8 +390,19 @@ function TokenSourceFormSheet({
   );
 
   const [form, setForm] = useState(editSlug ? null : emptyForm());
-  const set = (p: Partial<FormState>): void =>
+  // Server-side per-field validation errors, keyed by config field name. Each
+  // edited field clears its own error so the inline message can't go stale.
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const set = (p: Partial<FormState>): void => {
     setForm((f) => (f ? { ...f, ...p } : f));
+    setFieldErrors((prev) => {
+      const keys = Object.keys(p);
+      if (!keys.some((k) => k in prev)) return prev;
+      const next = { ...prev };
+      for (const k of keys) delete next[k];
+      return next;
+    });
+  };
 
   // Populate from the detail query the first time it resolves for this slug;
   // never clobber in-progress edits (guarded on `existingSlug`).
@@ -380,6 +417,7 @@ function TokenSourceFormSheet({
 
   const onSave = async (): Promise<void> => {
     if (!form) return;
+    setFieldErrors({});
     const auth =
       form.authMethod === 'none'
         ? { method: 'none' as const }
@@ -416,9 +454,22 @@ function TokenSourceFormSheet({
       toast({ title: t('tokenSources.saved'), variant: 'success' });
       onSaved();
     } catch (err) {
+      // Prefer inline per-field errors from the server's VALIDATION_ERROR; the
+      // raw ConvexError message is a JSON blob with a request id, so it must
+      // never reach the toast. Anything else gets a clean generic message.
+      const mapped = readTokenSourceFieldErrors(err);
+      if (mapped) {
+        setFieldErrors(mapped);
+        toast({
+          title: t('tokenSources.saveError'),
+          description: tCommon('editor.fixHighlightedFields'),
+          variant: 'destructive',
+        });
+        return;
+      }
       toast({
         title: t('tokenSources.saveError'),
-        description: err instanceof Error ? err.message : String(err),
+        description: tCommon('errors.generic'),
         variant: 'destructive',
       });
     }
@@ -464,12 +515,14 @@ function TokenSourceFormSheet({
               disabled={form.existingSlug !== null || saving}
               placeholder="coolai"
               className="font-mono"
+              errorMessage={fieldErrors.slug}
               onChange={(e) => set({ slug: e.target.value })}
             />
             <Input
               label={t('tokenSources.displayName')}
               value={form.displayName}
               disabled={saving}
+              errorMessage={fieldErrors.displayName}
               onChange={(e) => set({ displayName: e.target.value })}
             />
             <Input
@@ -478,6 +531,7 @@ function TokenSourceFormSheet({
               disabled={saving}
               placeholder="https://broker.example.com/api/tokens"
               className="font-mono"
+              errorMessage={fieldErrors.endpoint}
               onChange={(e) => set({ endpoint: e.target.value })}
             />
 
@@ -520,6 +574,7 @@ function TokenSourceFormSheet({
                 disabled={saving}
                 placeholder="X-Api-Key"
                 className="font-mono"
+                errorMessage={fieldErrors.auth}
                 onChange={(e) => set({ headerName: e.target.value })}
               />
             )}
@@ -605,6 +660,7 @@ function TokenSourceFormSheet({
               disabled={saving}
               placeholder="CLAUDE_CODE_OAUTH_TOKEN"
               className="font-mono"
+              errorMessage={fieldErrors.targetEnvVar}
               onChange={(e) => set({ targetEnvVar: e.target.value })}
             />
             <Select


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2350. Saving a token source with invalid/empty fields showed a destructive toast whose description was the raw `ConvexError` JSON (including the request id), and the server's `fieldErrors` never reached the form.

`saveTokenSource` throws `ConvexError({ code: 'VALIDATION_ERROR', fieldErrors })` (a Zod `flatten()` shape). The form now:

- reads that payload (reusing the existing `readConvexErrorData` from the providers feature — no new duck-typed copy) and maps each field's messages onto the matching input via `errorMessage` (`slug`, `displayName`, `endpoint`, `targetEnvVar`, custom-header name);
- shows a clean, localized toast — `common.editor.fixHighlightedFields` for validation errors, `common.errors.generic` otherwise — instead of the raw error string;
- clears each field's error as the user edits it, so inline messages can't go stale.

No new i18n keys (both toast strings already exist in every locale).

## Checklist

- [x] `bun run check` — `@tale/platform` `test:ui` for the touched component (2 passed), typecheck clean, oxfmt + oxlint clean.
- [x] `bun run lint:sast` — N/A (Opengrep binary not cached in this env; no security-relevant change).
- [x] Translations — N/A (reuses existing `common.*` keys present in en/de/fr).
- [x] Docs — N/A (error-surface polish; no documented behaviour changes).
- [x] READMEs — N/A.

## Test plan

- Added a regression test: a rejected save with `{ data: { code: 'VALIDATION_ERROR', fieldErrors: { slug, endpoint } } }` renders `Required` / `Invalid URL` inline, toasts the localized `fixHighlightedFields` description, and asserts the raw `"Invalid token source configuration"` payload never reaches any toast.
- Manual: Settings → Token sources → New → Save with required fields empty → per-field errors appear; the toast is clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

