### PR TITLE
fix(platform): lengthen toast auto-dismiss to 5s for readability (#2361)

### DIFF
--- a/services/platform/app/components/ui/feedback/toaster.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.tsx
@@ -49,8 +49,13 @@ export function Toaster() {
   const { toasts } = useToast();
   const position: ToastPosition = toasts[0]?.position ?? 'top-right';
 
+  // 5s auto-dismiss: long enough to read a title + description without rushing
+  // (WCAG 2.2.1 favours generous timing), while Radix pauses the timer on
+  // hover/focus and when the window loses focus so slower readers can still
+  // finish. The prior 3.5s was tight enough that even 5s test waits and human
+  // readers routinely missed save/copy/delete toasts.
   return (
-    <ToastPrimitives.Provider duration={3500}>
+    <ToastPrimitives.Provider duration={5000}>
       {toasts.map(
         ({
           id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2361. Toasts auto-dismissed after `3500ms`, short enough that four independent automated QA sessions needed a `MutationObserver` to catch save/copy/delete toasts (5s text-waits reliably missed them), and short enough to hurt slower human readers.

Bumps the Radix `ToastProvider` `duration` to `5000ms`. Radix already pauses the timer on hover/focus and when the window loses focus, so this only affects the untouched auto-dismiss window — aligning with WCAG 2.2.1's preference for generous timing without making toasts sticky.

## Checklist

- [x] `bun run check` — oxfmt + oxlint clean on the touched file; no type surface changed (a numeric literal). No test pinned the old `3500` value.
- [x] `bun run lint:sast` — N/A (Opengrep not cached; no security-relevant change).
- [x] Translations — N/A (no strings).
- [x] Docs — N/A (timing tweak).
- [x] READMEs — N/A.

## Test plan

- Trigger any save/copy/delete toast — it now stays readable for 5s and still pauses while hovered/focused, and closes early via the close button or swipe.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

