### PR TITLE
fix(platform): widen agent webhooks tab to full content width (#2378)

### DIFF
--- a/services/platform/app/features/agents/components/agent-webhook-section.tsx
+++ b/services/platform/app/features/agents/components/agent-webhook-section.tsx
@@ -290,7 +290,10 @@ export function AgentWebhookSection({
   }, [usageUrl, t]);
 
   return (
-    <ContentArea variant="narrow" gap={6}>
+    // Full content width (not the 544px `narrow` column the other agent tabs
+    // use): this tab's webhook table shows long URLs that are unreadable when
+    // squeezed into a narrow column inside the ~1220px main area (#2378).
+    <ContentArea variant="page" gap={6}>
       <SectionHeader
         title={t('agents.webhook.title')}
         description={t('agents.webhook.description')}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2378. The agent **Webhooks** tab wrapped its content — including the webhook URL table (URL / Active / Last triggered) — in `ContentArea variant="narrow"` (a 544px column) while the surrounding main area is ~1220px wide, so long webhook URLs were unreadably truncated.

Switches the section to `variant="page"` (full content width). The loaded agent-editor `<Outlet />` isn't wrapped in a shared `ContentArea`, so each tab sets its own — this change affects only the webhooks tab.

**Sweep (per the acceptance criteria):** the webhook section is the only `variant="narrow"` surface in the agent editor that renders a `DataTable`; the other narrow tabs (instructions, tools, skills, metrics, knowledge, general) are forms/detail views where the 544px measure is appropriate, so they're intentionally left narrow.

## Checklist

- [x] `bun run check` — `@tale/platform` `test:ui` for the section (3 passed), oxfmt + oxlint clean. Single enum-value change, no type surface.
- [x] `bun run lint:sast` — N/A (Opengrep not cached; layout-only change).
- [x] Translations — N/A (no strings).
- [x] Docs — N/A (layout width).
- [x] READMEs — N/A.

## Test plan

- Open an agent → **Webhooks** on a desktop-width viewport: the table now spans the content area and webhook URLs are readable without truncation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

