### PR TITLE
fix(platform): emit one model-fallback notice per retry (#2354)

### DIFF
--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -947,22 +947,13 @@ export async function runGenerationCore(
           reason: reasonCode,
         });
 
-        // Save a structured system message so the user sees the fallback.
-        try {
-          await saveMessage(ctx, components.agent, {
-            threadId,
-            message: { role: 'system', content: fallbackBody },
-          });
-        } catch (msgError) {
-          console.error(
-            '[runAgentGeneration] Failed to save fallback message:',
-            msgError,
-          );
-        }
-
-        // Convert any stale failed/pending assistant message from this attempt
-        // (suppressErrorCleanup left it untouched) into the same structured
-        // fallback note so the thread doesn't show an orphaned error bubble.
+        // Reuse any stale failed/pending assistant message from this attempt
+        // (suppressErrorCleanup left it untouched) AS the fallback note: the
+        // thread then shows the switch exactly once instead of an orphaned
+        // error bubble. Saving a NEW system message unconditionally on top of
+        // this conversion rendered the same "{from} unavailable — switched to
+        // {to}" notice twice per retry (#2354).
+        let reusedStaleBubble = false;
         try {
           const msgs = await listMessages(ctx, components.agent, {
             threadId,
@@ -982,9 +973,26 @@ export async function runGenerationCore(
                 message: { role: 'system', content: fallbackBody },
               },
             });
+            reusedStaleBubble = true;
           }
         } catch (cleanupError) {
           debugLog('FALLBACK_CLEANUP_ERROR', { error: cleanupError });
+        }
+
+        // Only persist a fresh system message when there was no stale bubble to
+        // repurpose — otherwise the notice would appear twice for one retry.
+        if (!reusedStaleBubble) {
+          try {
+            await saveMessage(ctx, components.agent, {
+              threadId,
+              message: { role: 'system', content: fallbackBody },
+            });
+          } catch (msgError) {
+            console.error(
+              '[runAgentGeneration] Failed to save fallback message:',
+              msgError,
+            );
+          }
         }
 
         // Advance to the next model; the dead-provider guard at the top of the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2354. When the router fell back to another model, a single retry produced the "{from} was unavailable — switched to {to}" notice **twice**: the catch block both `saveMessage`d a fresh `system` fallback note **and** converted the attempt's stale failed/pending assistant bubble into the *same* fallback body.

Reordered so the stale assistant bubble is repurposed as the notice first, and a fresh system message is persisted only when there was no bubble to reuse. That keeps both original intents — the user always sees the switch, and there's no orphaned error bubble — while guaranteeing exactly one notice per retry.

## Checklist

- [x] `bun run check` — `@tale/platform` typecheck clean; oxfmt + oxlint clean on the touched file.
- [x] `bun run lint:sast` — N/A (Opengrep not cached; no security-relevant change).
- [x] Translations — N/A (no strings; the notice body/label are unchanged).
- [x] Docs — N/A (defect fix).
- [x] READMEs — N/A.

## Test plan

- With a pinned/default model that fails at the provider (e.g. an invalid provider key) and a configured fallback, send a chat message: the thread now shows a single consolidated "{from} was unavailable — switched to {to}" notice per retry instead of a duplicated pair.

Note: `runAgentGeneration` is a large integration action with no existing unit harness (siblings like `start_agent_chat`/`skills_runtime` are the unit-tested seams), so this reordering is verified by typecheck + manual repro rather than a new mock harness.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

