### PR TITLE
fix(convex): repair email conversation resolution type and lint errors

### DIFF
--- a/services/platform/convex/workflow_engine/action_defs/conversation/helpers/check_conversation_exists.ts
+++ b/services/platform/convex/workflow_engine/action_defs/conversation/helpers/check_conversation_exists.ts
@@ -10,7 +10,11 @@ export async function checkConversationExists(
   ctx: ActionCtx,
   organizationId: string,
   externalMessageId: string,
-): Promise<{ _id: Id<'conversations'>; metadata?: unknown } | null> {
+): Promise<{
+  _id: Id<'conversations'>;
+  metadata?: unknown;
+  direction?: 'inbound' | 'outbound';
+} | null> {
   const normalized = normalizeExternalMessageId(externalMessageId);
   if (!normalized) return null;
 
@@ -20,5 +24,9 @@ export async function checkConversationExists(
       organizationId,
       externalMessageId: normalized,
     },
-  )) as { _id: Id<'conversations'>; metadata?: unknown } | null;
+  )) as {
+    _id: Id<'conversations'>;
+    metadata?: unknown;
+    direction?: 'inbound' | 'outbound';
+  } | null;
 }

--- a/services/platform/convex/workflow_engine/action_defs/conversation/helpers/resolve_email_conversation_target.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/conversation/helpers/resolve_email_conversation_target.test.ts
@@ -27,7 +27,7 @@ function mockCtx({
 }: {
   messageConversationId?: Id<'conversations'>;
   rootConversationId?: Id<'conversations'>;
-}): ActionCtx {
+}) {
   return {
     runQuery: vi.fn(async (_ref, args: { externalMessageId?: string }) => {
       if (
@@ -45,14 +45,14 @@ function mockCtx({
       return null;
     }),
     runMutation: vi.fn(),
-  } as unknown as ActionCtx;
+  };
 }
 
 describe('resolveEmailConversationTarget', () => {
   it('resolves via in-reply-to against stored messages', async () => {
     const ctx = mockCtx({ messageConversationId: CONV_ID });
     const target = await resolveEmailConversationTarget(
-      ctx,
+      ctx as unknown as ActionCtx,
       ORG,
       email({
         headers: {
@@ -69,7 +69,7 @@ describe('resolveEmailConversationTarget', () => {
   it('returns null for references-only email (no in-reply-to)', async () => {
     const ctx = mockCtx({ rootConversationId: CONV_ID });
     const target = await resolveEmailConversationTarget(
-      ctx,
+      ctx as unknown as ActionCtx,
       ORG,
       email({
         headers: {
@@ -90,7 +90,7 @@ describe('resolveEmailConversationTarget', () => {
     ]);
 
     const target = await resolveEmailConversationTarget(
-      ctx,
+      ctx as unknown as ActionCtx,
       ORG,
       email({
         headers: {
@@ -109,7 +109,7 @@ describe('resolveEmailConversationTarget', () => {
   it('returns null for unrelated email', async () => {
     const ctx = mockCtx({});
     const target = await resolveEmailConversationTarget(
-      ctx,
+      ctx as unknown as ActionCtx,
       ORG,
       email({ headers: { 'message-id': '<news@paystack.com>' } }),
     );


### PR DESCRIPTION
## Summary
Repairs two regressions that landed with #2437 and turned `main` red:
- **Type check (TS2339)** — `create_conversation_from_sent_email.ts:176` read `existingRootConversation.direction`, but `checkConversationExists` returned `{ _id; metadata? }`. It now also returns `direction` (the underlying query already provides it), so the customer address is derived correctly.
- **Lint (`unbound-method`)** — `resolve_email_conversation_target.test.ts` cast the mock ctx to `ActionCtx`, making `expect(ctx.runQuery)…` an unbound method reference. The mock is now a plain object cast at each call site, matching the repo's other ctx-mock tests.

## Test plan
- [x] `bun run --filter @tale/platform typecheck`
- [x] `bun run --filter @tale/platform lint`
- [x] `bun run --filter @tale/platform test` (resolver + conversation helper specs)

Made with [Cursor](https://cursor.com)