### PR TITLE
fix(platform): accept sub-cent model costs on edit (#2338)

### DIFF
--- a/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.test.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { screen, waitFor } from '@testing-library/react';
+import type userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          `${ns}.${key}`,
+        );
+      }
+      return `${ns}.${key}`;
+    },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: {
+    model_catalog: {
+      queries: { getModelCapabilities: 'getModelCapabilities' },
+    },
+  },
+}));
+
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => ({ data: [] }),
+}));
+
+const saveConfigMock = vi.fn();
+const configMock = vi.fn();
+vi.mock('../../hooks/use-provider-config-context', () => ({
+  useProviderConfig: () => ({
+    config: configMock(),
+    isSaving: false,
+    saveConfig: saveConfigMock,
+  }),
+}));
+
+vi.mock('../../hooks/mutations', () => ({
+  useSaveProviderSecret: () => ({ mutateAsync: vi.fn() }),
+  useFetchConfiguredProviderModels: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock('../../utils/error-dispatch', () => ({
+  dispatchForbiddenDeveloperSettings: () => false,
+  dispatchInvalidProviderConfig: () => false,
+  dispatchOrgAccessError: () => false,
+  dispatchVersionConflict: () => false,
+}));
+
+import { ModelsSection } from './models-section';
+
+// GPT-OSS 120B in the shipped catalog: $0.039/1M input tokens is stored as
+// 3.9 cents — a sub-cent value the edit form must round-trip losslessly.
+const subCentModel = {
+  id: 'gpt-oss-120b',
+  displayName: 'GPT-OSS 120B',
+  tags: ['chat'] as const,
+  cost: { inputCentsPerMillion: 3.9, outputCentsPerMillion: 18 },
+};
+
+function renderSection() {
+  return render(
+    <ModelsSection
+      organizationId="org-1"
+      providerName="openrouter"
+      maskedModelKeys={{}}
+      isLoading={false}
+    />,
+  );
+}
+
+async function openEdit(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    await screen.findByRole('button', {
+      name: /^settings\.providers\.editModel$/,
+    }),
+  );
+}
+
+function getInputCostField() {
+  return screen.getByRole('spinbutton', {
+    name: /^settings\.providers\.inputCostLabel/,
+  });
+}
+
+async function submitEdit(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    screen.getByRole('button', { name: 'settings.providers.save' }),
+  );
+  await waitFor(() => expect(saveConfigMock).toHaveBeenCalledTimes(1));
+  return saveConfigMock.mock.calls[0][0];
+}
+
+describe('ModelsSection sub-cent cost editing', () => {
+  beforeEach(() => {
+    saveConfigMock.mockReset();
+    saveConfigMock.mockResolvedValue(undefined);
+    configMock.mockReturnValue({
+      displayName: 'OpenRouter',
+      models: [{ ...subCentModel }],
+    });
+  });
+
+  it('lets the cost inputs accept sub-cent values (step="any")', async () => {
+    const { user } = renderSection();
+    await openEdit(user);
+
+    const field = getInputCostField();
+    // Pre-filled from 3.9 cents → $0.039/1M, previously blocked by step=0.01.
+    expect(field).toHaveValue(0.039);
+    expect(field).toHaveAttribute('step', 'any');
+  });
+
+  it('round-trips a pre-filled sub-cent catalog cost without silent rounding', async () => {
+    const { user } = renderSection();
+    await openEdit(user);
+
+    // Touch only the display name; the untouched 3.9-cent cost must survive
+    // the save instead of snapping to 4 (the old Math.round behaviour).
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /^settings\.providers\.displayName/,
+      }),
+      ' v2',
+    );
+
+    const payload = await submitEdit(user);
+    expect(payload.models[0].cost.inputCentsPerMillion).toBe(3.9);
+    expect(payload.models[0].cost.outputCentsPerMillion).toBe(18);
+  });
+
+  it('saves a freshly entered sub-cent cost at full precision', async () => {
+    const { user } = renderSection();
+    await openEdit(user);
+
+    const field = getInputCostField();
+    await user.clear(field);
+    await user.type(field, '0.005');
+
+    const payload = await submitEdit(user);
+    // $0.005/1M → 0.5 cents; step=0.01 would have rejected it outright.
+    expect(payload.models[0].cost.inputCentsPerMillion).toBe(0.5);
+  });
+});

--- a/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.tsx
@@ -122,6 +122,18 @@ const EMPTY_MODEL_FORM: ModelFormState = {
   promptCachingMaxBreakpoints: '',
 };
 
+/**
+ * Convert a USD cost-input value into cents for storage. Catalog prices carry
+ * sub-cent precision (e.g. GPT-OSS 120B at $0.039/1M → 3.9 cents), so a plain
+ * `Math.round(... * 100)` would silently snap 3.9 → 4 on save. Rounding to
+ * three decimals of a cent instead preserves every real catalog value while
+ * stripping the IEEE-754 noise a bare `× 100` leaves behind (0.039 * 100 =
+ * 3.9000000000000004).
+ */
+function usdInputToCents(usd: string): number {
+  return Math.round(Number(usd) * 1e5) / 1e3;
+}
+
 export function ModelsSection({
   organizationId,
   providerName,
@@ -452,18 +464,16 @@ export function ModelsSection({
               ...(hasTokenCost
                 ? {
                     inputCentsPerMillion: form.inputCostPerMillion
-                      ? Math.round(Number(form.inputCostPerMillion) * 100)
+                      ? usdInputToCents(form.inputCostPerMillion)
                       : 0,
                     outputCentsPerMillion: form.outputCostPerMillion
-                      ? Math.round(Number(form.outputCostPerMillion) * 100)
+                      ? usdInputToCents(form.outputCostPerMillion)
                       : 0,
                   }
                 : {}),
               ...(hasImageCost
                 ? {
-                    imageCentsPerImage: Math.round(
-                      Number(form.imageCostPerImage) * 100,
-                    ),
+                    imageCentsPerImage: usdInputToCents(form.imageCostPerImage),
                   }
                 : {}),
             }
@@ -1143,7 +1153,7 @@ export function ModelsSection({
                   }
                   placeholder={t('providers.inputCostPlaceholder')}
                   min={0}
-                  step={0.01}
+                  step="any"
                 />
                 <Input
                   label={t('providers.outputCostLabel')}
@@ -1157,7 +1167,7 @@ export function ModelsSection({
                   }
                   placeholder={t('providers.outputCostPlaceholder')}
                   min={0}
-                  step={0.01}
+                  step="any"
                 />
               </HStack>
               {form.tags.includes('image-generation') && (
@@ -1173,7 +1183,7 @@ export function ModelsSection({
                   }
                   placeholder={t('providers.imageCostPlaceholder')}
                   min={0}
-                  step={0.01}
+                  step="any"
                 />
               )}
               <Text className="text-muted-foreground text-xs">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2338. The edit-model cost inputs used `step={0.01}`, so a pre-filled sub-cent catalog price (e.g. `$0.039`/1M → `3.9` cents) failed native HTML validation and Save silently no-oped with no feedback. Switched the three cost inputs (`inputCost`, `outputCost`, `imageCost`) to `step="any"` and replaced the `Math.round(x*100)` conversion with a precision-preserving helper so fractional cents round-trip losslessly instead of snapping to whole cents. The schema already permits fractional cents.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `models-section` UI test (3 cases: `step="any"`, lossless round-trip of a pre-filled `3.9`-cent cost, sub-cent save) passing.
- [x] `bun run lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (no strings).
- [x] Docs / READMEs — N/A.

## Test plan
Edit a model whose catalog cost has sub-cent precision → Save persists instead of silently no-oping; entering a sub-cent value saves at full precision.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

