### PR TITLE
fix(platform): resolve token-source secretEnv before "configured" badge (#2319)

### DIFF
--- a/services/platform/convex/token_sources/file_actions.test.ts
+++ b/services/platform/convex/token_sources/file_actions.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The Convex codegen wrapper is unavailable in a unit test — passthrough the
+// `action({...})` config so we can call its `handler` directly.
+vi.mock('../_generated/server', () => ({
+  action: (config: unknown) => config,
+  internalAction: (config: unknown) => config,
+}));
+
+// `getTokenSource` is membership-gated; the gate itself is covered elsewhere,
+// so stub it to a resolved member and focus this spec on the `hasSecret`
+// computation (the false-positive env-ref regression, #2319).
+const mockRequireOrgMembershipById = vi.fn();
+vi.mock('../lib/auth/require_org_membership', () => ({
+  requireOrgMembershipById: (...args: unknown[]) =>
+    mockRequireOrgMembershipById(...args),
+}));
+
+const { getTokenSource } = await import('./file_actions');
+
+type ActionConfig = {
+  handler: (ctx: never, args: never) => Promise<{ hasSecret: boolean } | null>;
+};
+const getHandler = (getTokenSource as unknown as ActionConfig).handler;
+
+const CONFIG_ENV = 'TALE_CONFIG_DIR';
+const SECRET_ENV = 'TALE_TOKEN_SOURCE_EXAMPLE';
+const ORG_SLUG = 'default';
+const SLUG = 'example-broker';
+
+let configRoot: string;
+let prevConfigDir: string | undefined;
+let prevSecretEnv: string | undefined;
+
+async function writeSource(secretEnv: string | undefined): Promise<void> {
+  const dir = path.join(configRoot, ORG_SLUG, 'token-sources');
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, `${SLUG}.json`),
+    JSON.stringify({
+      slug: SLUG,
+      displayName: 'Example Broker',
+      endpoint: 'https://broker.example.com/api/tokens',
+      auth: { method: 'bearer', ...(secretEnv && { secretEnv }) },
+      responseMapping: { tokensPath: '$.tokens', tokenField: 'access_token' },
+      targetEnvVar: 'CLAUDE_CODE_OAUTH_TOKEN',
+    }),
+    'utf8',
+  );
+}
+
+const ctx = {} as never;
+const args = { organizationId: 'org_test', slug: SLUG } as never;
+
+beforeEach(async () => {
+  configRoot = await mkdtemp(path.join(tmpdir(), 'token-sources-'));
+  prevConfigDir = process.env[CONFIG_ENV];
+  process.env[CONFIG_ENV] = configRoot;
+  prevSecretEnv = process.env[SECRET_ENV];
+  delete process.env[SECRET_ENV];
+  mockRequireOrgMembershipById.mockReset();
+  mockRequireOrgMembershipById.mockResolvedValue({
+    orgId: 'org-123',
+    orgSlug: ORG_SLUG,
+    userId: 'user-1',
+    email: 'a@b.com',
+    name: 'A',
+    member: { _id: 'm-1', role: 'owner' },
+  });
+});
+
+afterEach(async () => {
+  if (prevConfigDir === undefined) delete process.env[CONFIG_ENV];
+  else process.env[CONFIG_ENV] = prevConfigDir;
+  if (prevSecretEnv === undefined) delete process.env[SECRET_ENV];
+  else process.env[SECRET_ENV] = prevSecretEnv;
+  await rm(configRoot, { recursive: true, force: true });
+});
+
+describe('getTokenSource hasSecret', () => {
+  it('reports not-configured when secretEnv is declared but the env var is unset', async () => {
+    await writeSource(SECRET_ENV);
+    const res = await getHandler(ctx, args);
+    expect(res?.hasSecret).toBe(false);
+  });
+
+  it('reports not-configured when the declared env var is set but empty', async () => {
+    await writeSource(SECRET_ENV);
+    process.env[SECRET_ENV] = '';
+    const res = await getHandler(ctx, args);
+    expect(res?.hasSecret).toBe(false);
+  });
+
+  it('reports configured when the declared env var is actually set', async () => {
+    await writeSource(SECRET_ENV);
+    process.env[SECRET_ENV] = 'broker-secret-value';
+    const res = await getHandler(ctx, args);
+    expect(res?.hasSecret).toBe(true);
+  });
+
+  it('reports configured when a secret sidecar exists regardless of env', async () => {
+    await writeSource(SECRET_ENV);
+    await writeFile(
+      path.join(configRoot, ORG_SLUG, 'token-sources', `${SLUG}.secrets.json`),
+      `${JSON.stringify({ authSecret: 'stored' })}\n`,
+      'utf8',
+    );
+    const res = await getHandler(ctx, args);
+    expect(res?.hasSecret).toBe(true);
+  });
+});

--- a/services/platform/convex/token_sources/file_actions.ts
+++ b/services/platform/convex/token_sources/file_actions.ts
@@ -97,14 +97,17 @@ export const getTokenSource = action({
     const read = await loadTokenSource(orgSlug, args.slug);
     if (!read.ok) return null;
     // "Configured" = a secret sidecar exists (presence, not decryptability) OR
-    // the auth declares a `secretEnv` env-ref. Never decrypt here — the value
-    // is write-only and a momentary SOPS-key gap must not read as "no secret".
+    // the auth's `secretEnv` env-ref is actually set in this deployment. Never
+    // decrypt the sidecar here — the value is write-only and a momentary
+    // SOPS-key gap must not read as "no secret". The env-ref, however, must be
+    // resolved: a declared-but-unset `secretEnv` is NOT configured (it mirrors
+    // the pool fetcher, which reads `process.env[secretEnv]` at request time).
     const sidecarExists = await tokenSourceSecretExists(orgSlug, args.slug);
     const auth = read.config.auth;
     const hasEnvRef =
       auth.method !== 'none' &&
       typeof auth.secretEnv === 'string' &&
-      auth.secretEnv.length > 0;
+      (process.env[auth.secretEnv] ?? '').length > 0;
     return { config: read.config, hasSecret: sidecarExists || hasEnvRef };
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2319. `getTokenSource` reported `hasSecret: true` whenever the config merely *declared* a `secretEnv` name, so a token source using an unset/empty env var showed a false "Secret configured" badge. It now resolves the value at request time (`(process.env[auth.secretEnv] ?? '').length > 0`), mirroring the runtime pool fetcher, so a declared-but-unset env var reads as not configured. The sidecar-file check is unchanged (still never decrypts).

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new server test `token_sources/file_actions.test.ts` (4 cases) passing.
- [x] `bun run lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (no strings; only the boolean behind the existing badge).
- [x] Docs / READMEs — N/A.

## Test plan
Declare a token source with an unset `secretEnv` → the edit form shows "not configured"; set the env var → "Secret configured".
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

