### PR TITLE
fix(platform): consume Enter on empty mention picker (#2346)

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input.test.tsx
@@ -1,0 +1,99 @@
+import { type SearchSource } from '@tale/ui/search';
+import { forwardRef, useState, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { type ActorMentionData } from './actor-mention-popover';
+import { ChatInput } from './chat-input';
+
+// ChatInput pulls in the whole composer toolbar (agent/model pickers,
+// dictation, governance footer) plus several Convex-backed hooks. This test
+// exercises only the `@`-mention keyboard handling, so the heavy children and
+// data hooks are stubbed to no-ops — the same tier-down approach as
+// composer-mode-menu.test.tsx.
+vi.mock('../context/chat-layout-context', () => ({
+  useChatLayout: () => ({ quotedText: null, setQuotedText: vi.fn() }),
+}));
+vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
+  useUploadPolicy: () => ({ policyEnabled: false, allowedExtensions: [] }),
+}));
+vi.mock('../hooks/use-video-url-ingest', () => ({
+  useVideoUrlIngest: () => ({ pending: false, ingest: vi.fn() }),
+}));
+vi.mock('./arena/arena-mode-context', () => ({
+  useArenaModeOptional: () => null,
+}));
+vi.mock('./composer-mode-menu', () => ({ ComposerModeMenu: () => null }));
+vi.mock('./dictation-button', () => ({
+  DictationButton: forwardRef(() => null),
+}));
+vi.mock('@/app/features/governance/components/data-notice-footer', () => ({
+  DataNoticeFooter: () => null,
+}));
+// The KB source is instantiated unconditionally (fixed hook order) and reaches
+// Convex — stub it to an idle no-op source; this test drives the actor picker.
+vi.mock('./documents-mention-source', () => ({
+  createDocumentsMentionSource: () => () => ({ results: [], status: 'idle' }),
+}));
+// FileUpload.DropZone reads a Root context that ChatInput's caller supplies in
+// production; render it (and its overlay) as plain passthroughs here.
+vi.mock('@/app/components/ui/forms/file-upload', () => ({
+  FileUpload: {
+    DropZone: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Overlay: () => null,
+  },
+}));
+
+// Actor source that never matches — reproduces the "No matches" empty state.
+const emptyActorSource: SearchSource<ActorMentionData> = () => ({
+  results: [],
+  status: 'ready',
+});
+
+function Harness({
+  onSendMessage,
+}: {
+  onSendMessage: (message: string) => void;
+}) {
+  const [value, setValue] = useState('');
+  return (
+    <ChatInput
+      value={value}
+      onChange={setValue}
+      onSendMessage={onSendMessage}
+      organizationId="org-1"
+      attachments={[]}
+      uploadingFiles={[]}
+      uploadFiles={vi.fn()}
+      removeAttachment={vi.fn()}
+      clearAttachments={() => []}
+      actorMentionSource={emptyActorSource}
+      variant="assistant"
+    />
+  );
+}
+
+describe('ChatInput @-mention keyboard handling', () => {
+  it('swallows Enter on the "No matches" empty picker instead of sending', async () => {
+    const onSendMessage = vi.fn();
+    const { user } = render(<Harness onSendMessage={onSendMessage} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.click(textarea);
+    await user.type(textarea, '@zzzz');
+
+    // Picker is open on its empty state.
+    expect(screen.getByText('No matches')).toBeInTheDocument();
+
+    // Enter must NOT publish the literal query, and it dismisses the picker.
+    await user.keyboard('{Enter}');
+    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(screen.queryByText('No matches')).not.toBeInTheDocument();
+
+    // With the picker dismissed, a second Enter sends as usual.
+    await user.keyboard('{Enter}');
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onSendMessage).toHaveBeenCalledWith('@zzzz', undefined, undefined);
+  });
+});

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -761,13 +761,17 @@ export function ChatInput({
         return;
       }
       if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
+        e.preventDefault();
         const selected = mentionResults[clampedMentionHighlight]?.data;
         if (selected) {
-          e.preventDefault();
           handleSelectMention(selected);
           return;
         }
-        // No results to pick: Enter falls through to send below.
+        // "No matches" empty state: swallow Enter/Tab and dismiss the picker
+        // so it never falls through to send the literal `@query` (#2346). A
+        // second Enter then sends, matching the picker-closed behaviour.
+        setMentionTrigger(null);
+        return;
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2346. When the chat @-mention picker showed "No matches", `Enter`/`Tab` were only consumed if a result was selectable — with zero results the key fell through to the composer and sent the literal `@query` as a reply. Now `preventDefault()` runs unconditionally for `Enter`/`Tab` while the picker is open, and the empty state dismisses the picker instead of falling through; a second `Enter` then sends (matching picker-closed behaviour).

## Checklist
- [x] `bun run check` — typecheck clean; `chat-input` UI regression test (empty-picker Enter does not send + dismisses; second Enter sends) passing. (The only lint error observed was a foreign file from a concurrent task, not touched here.)
- [x] `bun run lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (the "No matches" copy already exists in en/de/fr).
- [x] Docs / READMEs — N/A.

## Test plan
Type `@zzzz` (no matches) and press Enter → nothing is sent and the picker closes; press Enter again → the message sends.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

