### PR TITLE
fix(platform): preload Inter to stop tab-nav FOUT (#2369)

### DIFF
--- a/packages/ui/src/assets.d.ts
+++ b/packages/ui/src/assets.d.ts
@@ -1,0 +1,8 @@
+// Vite `?url` asset imports resolve to the emitted, hashed public path (a
+// string). This package pins `compilerOptions.types` (see tsconfig.json), so
+// `vite/client`'s ambient declarations aren't in scope — declare the query
+// import we rely on (fonts.ts preloads the Inter woff2 subsets by URL).
+declare module '*.woff2?url' {
+  const src: string;
+  export default src;
+}

--- a/packages/ui/src/fonts.ts
+++ b/packages/ui/src/fonts.ts
@@ -19,3 +19,43 @@ import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
 import '@fontsource/inter/600.css';
 import '@fontsource/inter/700.css';
+// @fontsource ships `font-display: swap`, and a webfont is only fetched once the
+// browser lays out text that uses it — which here is *after* the JS bundle has
+// parsed and React has painted. On a cold load the tab labels (and other chrome)
+// therefore paint first in the metric-matched 'Inter Fallback' and visibly swap
+// to Inter a beat later: a FOUT (see globals.css `Inter Fallback` — it fixes the
+// metrics, not the glyph shapes, so the swap is still visible).
+//
+// Preloading the above-the-fold Latin subsets starts their download at app boot,
+// in parallel with the JS bundle, so Inter is normally in the browser cache
+// before the first paint and no fallback ever shows. We keep `swap` rather than
+// `optional` so text always renders immediately (no invisible-text block) and so
+// @fontsource stays the single source of truth for the @font-face set — the
+// preload only reorders the fetch, it doesn't redefine the faces.
+//
+// Only the Latin subset (weights 400 body / 500 for `font-medium` chrome like the
+// tab labels) is preloaded: every shipped UI locale is Latin, and non-Latin
+// subsets (Cyrillic/Greek/…) stay lazily fetched on demand. `?url` yields the
+// hashed, same-origin build asset; `crossorigin` (anonymous) must match the CORS
+// mode @font-face fetches use, or the preload is discarded and the font
+// re-downloads.
+import interLatin400Url from '@fontsource/inter/files/inter-latin-400-normal.woff2?url';
+import interLatin500Url from '@fontsource/inter/files/inter-latin-500-normal.woff2?url';
+
+if (typeof document !== 'undefined') {
+  for (const href of [interLatin400Url, interLatin500Url]) {
+    if (
+      document.head.querySelector(`link[rel="preload"][href="${href}"]`) !==
+      null
+    ) {
+      continue;
+    }
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'font';
+    link.type = 'font/woff2';
+    link.href = href;
+    link.crossOrigin = 'anonymous';
+    document.head.appendChild(link);
+  }
+}

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -177,12 +177,14 @@ export function TabNavigation({
     updateIndicator();
   }, [updateIndicator]);
 
-  // Re-measure once web fonts finish loading. The indicator width/left come
-  // from `offsetWidth`/`offsetLeft`, which on a cold reload are first measured
-  // against the system-fallback glyph metrics (Inter ships `font-display:
-  // swap`). Without this the underline stays sized for the fallback text after
-  // Inter swaps in. `updateIndicator` no-ops when the values are unchanged, so
-  // the extra call is cheap when the font was already cached.
+  // Re-measure once web fonts finish loading — belt-and-braces. The indicator
+  // width/left come from `offsetWidth`/`offsetLeft`, measured against whatever
+  // glyphs are painted. Inter is now preloaded at app boot (see
+  // packages/ui/src/fonts.ts), so on a cold load it is normally cached before
+  // the first paint and no fallback→Inter swap occurs. This guard still covers
+  // the slow-network case where Inter lands after the first measure: without it
+  // the underline would stay sized for the fallback text. `updateIndicator`
+  // no-ops when the values are unchanged, so the extra call is cheap.
   useEffect(() => {
     if (typeof document === 'undefined' || !('fonts' in document)) {
       return undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2369. Inter is self-hosted via `@fontsource` with `font-display: swap`, and the webfont is only fetched once text using it first paints — after the JS bundle mounts React — so tab labels first paint in the metric-matched `Inter Fallback` and then visibly swap. This preloads the above-the-fold Latin Inter subsets (400 body, 500 chrome/tab labels) at app boot in the shared `@tale/ui` `fonts.ts`, so the woff2 downloads in parallel with the JS bundle and Inter is normally cached before first paint. `swap` is kept (no invisible-text block); `@fontsource` remains the single source of the `@font-face` set — the preload only reorders the fetch.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), `@tale/platform` + `@tale/ui` typecheck clean, oxfmt clean.
- [x] `bun run lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (no strings).
- [x] Docs / READMEs — N/A.

## Test plan
Hard-reload a dashboard route on a cold cache → tab-navigation labels render in Inter without a visible fallback→Inter swap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

