### PR TITLE
fix(platform): persist thinking duration for tokenless turns (#2372)

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -561,9 +561,10 @@ function MessageBubbleComponent({
         <MessageThoughtHeader
           isStreaming={!!isAssistantStreaming}
           hasAnswerStarted={hasAnswerStarted}
-          // markGenerating → first answer token, routing INCLUDED; falls back to
-          // the legacy timeToFirstTokenMs for old messages. When NEITHER exists
-          // (a reasoning/tool-only or aborted turn) the header shows the honest
+          // markGenerating → thinking-window close (first answer token, or the
+          // turn's end for a reasoning/tool-only or aborted turn), routing
+          // INCLUDED; falls back to the legacy timeToFirstTokenMs for old
+          // messages. Only legacy rows with NEITHER field fall through to the
           // duration-less "Showed its reasoning" summary.
           durationMs={thinkingDurationMs ?? timeToFirstTokenMs}
           tokenCount={outputTokens}

--- a/services/platform/convex/lib/agent_response/abort_watcher.ts
+++ b/services/platform/convex/lib/agent_response/abort_watcher.ts
@@ -113,3 +113,20 @@ export async function resolveTurnStartMs(
     return fallbackMs;
   }
 }
+
+/**
+ * The pre-answer "thinking" wall-clock the chat "Thought for Ns" summary shows,
+ * measured from the turn start (`resolveTurnStartMs`) to the moment the thinking
+ * window closes. It closes at the FIRST answer token; a reasoning/tool-only or
+ * aborted turn never produces one, so it closes at the turn's end (`nowMs`)
+ * instead. Persisting this for those turns keeps the duration on the message
+ * after a reload rather than dropping it (`undefined`), which previously left
+ * only the "N tools" / "Showed its reasoning" fallback.
+ */
+export function computeThinkingDurationMs(
+  firstTokenTime: number | null,
+  turnStartMs: number,
+  nowMs: number,
+): number {
+  return (firstTokenTime ?? nowMs) - turnStartMs;
+}

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -71,6 +71,7 @@ import { createDebugLog } from '../debug_log';
 import { orgSlugFromId } from '../helpers/org_slug';
 import { summarizeForLog } from '../log_redact';
 import {
+  computeThinkingDurationMs,
   resolveTurnStartMs,
   startAbortWatcher,
   type AbortWatcher,
@@ -2059,10 +2060,21 @@ export async function generateAgentResponse(
     // Pre-answer wall-clock the user actually waited, anchored to the TURN start
     // (markGenerating, before routing) so it includes the Auto-router classifier
     // — what the chat "Thought for Ns" summary should show. Resolved here
-    // (post-stream) so the extra read never delays first token.
-    const thinkingDurationMs = firstTokenTime
-      ? firstTokenTime - (await resolveTurnStartMs(ctx, threadId, startTime))
-      : undefined;
+    // (post-stream) so the extra read never delays first token. The thinking
+    // window closes at the first answer token; a reasoning/tool-only or aborted
+    // turn never produces one, so it closes at the turn's end instead — this
+    // keeps "Thought for Ns" on those messages after a reload. Turns with no
+    // thinking phase at all are gated out by the UI (hasActualThought).
+    const resolvedTurnStartMs = await resolveTurnStartMs(
+      ctx,
+      threadId,
+      startTime,
+    );
+    const thinkingDurationMs = computeThinkingDurationMs(
+      firstTokenTime,
+      resolvedTurnStartMs,
+      Date.now(),
+    );
 
     debugLog('Response generated', {
       durationMs,
@@ -2677,10 +2689,20 @@ export async function generateAgentResponse(
     if (metadataMessageId) {
       try {
         const durationMs = Date.now() - startTime;
-        const thinkingDurationMs = firstTokenTime
-          ? firstTokenTime -
-            (await resolveTurnStartMs(ctx, threadId, startTime))
-          : undefined;
+        // Persist the thinking window even for an aborted/errored turn that
+        // never produced a first answer token: it closes at the turn's end so
+        // the reloaded message still shows "Thought for Ns" (see the success
+        // path above for the full rationale).
+        const resolvedTurnStartMs = await resolveTurnStartMs(
+          ctx,
+          threadId,
+          startTime,
+        );
+        const thinkingDurationMs = computeThinkingDurationMs(
+          firstTokenTime,
+          resolvedTurnStartMs,
+          Date.now(),
+        );
         const { toolCalls, toolsUsage, citations } = extractToolCallsFromSteps(
           result.steps ?? [],
         );

--- a/services/platform/convex/lib/agent_response/thinking_duration.test.ts
+++ b/services/platform/convex/lib/agent_response/thinking_duration.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeThinkingDurationMs } from './abort_watcher';
+
+describe('computeThinkingDurationMs', () => {
+  const turnStartMs = 1_000;
+
+  it('measures to the first answer token when one arrived', () => {
+    expect(computeThinkingDurationMs(11_000, turnStartMs, 20_000)).toBe(10_000);
+  });
+
+  it('falls back to the turn end for a reasoning/tool-only turn (no answer token)', () => {
+    // Regression for #2372: a turn that never produced a first answer token
+    // must still persist a thinking duration so "Thought for Ns" survives a
+    // reload, rather than dropping to undefined.
+    expect(computeThinkingDurationMs(null, turnStartMs, 20_000)).toBe(19_000);
+  });
+
+  it('never returns undefined for a no-token turn', () => {
+    expect(
+      computeThinkingDurationMs(null, turnStartMs, 20_000),
+    ).not.toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2372. The "Thought for N seconds" duration was persisted only when a turn produced a first *answer* token (`firstTokenTime`), so reasoning-only, tool-only, and aborted turns stored `undefined` and lost the label on history reload. The thinking window now closes at the first answer token *or*, when none arrives, at the turn's end — mirroring the live client timer's latch. The pure calc is extracted to `computeThinkingDurationMs` and unit-tested. The UI is still gated by `hasActualThought`, so turns with no thinking phase don't render the header; legacy rows keep the existing graceful fallback.

**No schema/migration change** — writes into the existing optional `thinkingDurationMs` field.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `thinking_duration` test (3 cases) passing.
- [x] `bun run lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (no strings).
- [x] Migration — N/A (existing field).
- [x] Docs / READMEs — N/A.

## Test plan
Run a reasoning-only/aborted turn, reload the thread → "Thought for N seconds" now shows instead of falling back to "Showed its reasoning".
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

