### PR TITLE
refactor(platform): move organigram Save/Discard into the tab nav (#2374)

### DIFF
--- a/services/platform/app/features/agents/organigram/organigram-canvas.tsx
+++ b/services/platform/app/features/agents/organigram/organigram-canvas.tsx
@@ -3,19 +3,21 @@
 import { Button } from '@tale/ui/button';
 import { EmptyState } from '@tale/ui/empty-state';
 import { Row } from '@tale/ui/layout';
-import { Text } from '@tale/ui/text';
 import {
-  Panel,
   useNodesInitialized,
   useReactFlow,
   type EdgeTypes,
   type NodeTypes,
 } from '@xyflow/react';
-import { Loader2, Network, Plus, Save, Undo2 } from 'lucide-react';
+import { Network, Plus } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { FlowCanvas } from '@/app/components/flow/flow-canvas';
 import { useElkLayout } from '@/app/components/flow/layout/use-elk-layout';
+import {
+  useRegisterActiveEditor,
+  type EditorController,
+} from '@/app/components/ui/editor';
 import { useConfigDirtyState } from '@/app/components/ui/editor/use-config-dirty-state';
 import { useRegisterDirtySource } from '@/app/components/ui/editor/use-dirty-source';
 import { CreateAgentDialog } from '@/app/features/agents/components/agent-create-dialog';
@@ -44,6 +46,11 @@ import {
   ORG_ELK_OPTIONS,
 } from './organigram-layout';
 import { OrganigramPanel } from './organigram-panel';
+
+// The organigram commits every touched agent at once, so it has no per-tab
+// dirty keys to surface as a dot — a stable empty set keeps the controller
+// literal referentially cheap.
+const EMPTY_DIRTY_KEYS: ReadonlySet<string> = new Set();
 
 const nodeTypes: NodeTypes = { agent: AgentOrgNode, humans: HumansNode };
 // Reuse the automations edge renderer so the chart's arrows match the canvas.
@@ -82,6 +89,22 @@ function FocusOnNode({ slug }: { slug: string }) {
 }
 
 /**
+ * Registers the organigram's staged-draft controller as the active editor so
+ * the agents tab strip renders the shared Save/Discard cluster (matching the
+ * automation and agent editors) instead of a floating canvas overlay. Rendered
+ * only when the user can edit, so a read-only viewer never sees the cluster.
+ * Renders nothing.
+ */
+function OrganigramEditorRegistrar({
+  controller,
+}: {
+  controller: EditorController;
+}) {
+  useRegisterActiveEditor(controller);
+  return null;
+}
+
+/**
  * The organigram: the agents-only, many-to-many DELEGATION graph on the shared
  * {@link FlowCanvas}. The graph is read-only on the canvas — all editing
  * happens in the side panel. Edits are STAGED into a draft and only persisted
@@ -101,7 +124,6 @@ export function OrganigramCanvas({
   focusSlug?: string;
 }) {
   const { t } = useT('organigram');
-  const { t: tCommon } = useT('common');
   const { chart, isLoading, refetch } = useOrgChart(organizationId);
   const setDelegatesAction = useConvexAction(
     api.agents.org_chart_actions.setAgentDelegates,
@@ -246,6 +268,23 @@ export function OrganigramCanvas({
     t,
   ]);
 
+  // The unified editor contract the agents tab strip consumes via
+  // `useActiveEditor` → `EditorActions`. The organigram is always valid (there
+  // are no per-field validation gates), so `isValid` is constant; `isLoading`
+  // gates Save while the chart is still fetching.
+  const editorController: EditorController = useMemo(
+    () => ({
+      isDirty,
+      isSaving,
+      isValid: true,
+      isLoading,
+      dirtyKeys: EMPTY_DIRTY_KEYS,
+      save: handleSave,
+      reset: resetConfig,
+    }),
+    [isDirty, isSaving, isLoading, handleSave, resetConfig],
+  );
+
   // Rendered in both the empty state and the populated canvas, so define it
   // once. Pulls the chart (action-backed, non-reactive) and lands on the new
   // agent so its delegation can be wired up immediately.
@@ -287,6 +326,10 @@ export function OrganigramCanvas({
       align="stretch"
       className="border-border h-[calc(100vh-220px)] min-h-105 overflow-hidden rounded-lg border"
     >
+      {/* Save/Discard live in the agents tab strip (shared EditorActions),
+          not on the canvas — register the controller so the strip can drive
+          them. Edit-only; a viewer never registers. */}
+      {canEdit && <OrganigramEditorRegistrar controller={editorController} />}
       <div className="relative min-w-0 flex-1">
         <FlowCanvas
           nodes={nodes}
@@ -319,43 +362,6 @@ export function OrganigramCanvas({
             ) : undefined
           }
         >
-          {canEdit && isDirty && (
-            <Panel position="top-right" className="m-3">
-              <Row
-                gap={2}
-                className="ring-border bg-background rounded-lg p-1.5 pl-3 shadow-sm ring-1"
-              >
-                <Text variant="muted" className="text-xs">
-                  {t('unsavedChanges')}
-                </Text>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  icon={Undo2}
-                  iconClassName="size-3.5"
-                  disabled={isSaving}
-                  onClick={resetConfig}
-                >
-                  {tCommon('actions.discard')}
-                </Button>
-                <Button
-                  type="button"
-                  disabled={isSaving}
-                  aria-busy={isSaving ? 'true' : undefined}
-                  onClick={() => void handleSave()}
-                >
-                  {isSaving ? (
-                    <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none sm:mr-1.5" />
-                  ) : (
-                    <Save className="size-3.5 sm:mr-1.5" />
-                  )}
-                  {isSaving
-                    ? tCommon('actions.saving')
-                    : tCommon('actions.save')}
-                </Button>
-              </Row>
-            </Panel>
-          )}
           {focusSlug && focusExists && <FocusOnNode slug={focusSlug} />}
         </FlowCanvas>
       </div>

--- a/services/platform/app/routes/dashboard/$id/agents.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents.tsx
@@ -14,6 +14,11 @@ import {
 } from '@/app/components/layout/adaptive-header';
 import { PageLayout } from '@/app/components/layout/page-layout';
 import {
+  ActiveEditorProvider,
+  EditorActions,
+  useActiveEditor,
+} from '@/app/components/ui/editor';
+import {
   TabNavigation,
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
@@ -95,58 +100,74 @@ function AgentsLayout() {
   }
 
   return (
-    <PageLayout
-      organizationId={organizationId}
-      header={
-        !isDetailPage ? (
-          <>
-            <AdaptiveHeaderRoot standalone={false}>
-              <AdaptiveHeaderTitle>
-                {segments.length > 0 ? (
-                  <span className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => goToFolder('')}
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {t('agents.title')}
-                    </button>
-                    {segments.map((segment, i) => {
-                      const path = segments.slice(0, i + 1).join('/');
-                      const isLast = i === segments.length - 1;
-                      return (
-                        <span key={path} className="flex items-center gap-1">
-                          <ChevronRight className="text-muted-foreground size-4 shrink-0" />
-                          {isLast ? (
-                            <span>{segment}</span>
-                          ) : (
-                            <button
-                              type="button"
-                              onClick={() => goToFolder(path)}
-                              className="text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                              {segment}
-                            </button>
-                          )}
-                        </span>
-                      );
-                    })}
-                  </span>
-                ) : (
-                  t('agents.title')
-                )}
-              </AdaptiveHeaderTitle>
-            </AdaptiveHeaderRoot>
-            <TabNavigation
-              items={tabs}
-              standalone={false}
-              ariaLabel={t('agents.title')}
-            />
-          </>
-        ) : undefined
-      }
-    >
-      {!abilityLoading && <Outlet />}
-    </PageLayout>
+    <ActiveEditorProvider>
+      <PageLayout
+        organizationId={organizationId}
+        header={
+          !isDetailPage ? (
+            <>
+              <AdaptiveHeaderRoot standalone={false}>
+                <AdaptiveHeaderTitle>
+                  {segments.length > 0 ? (
+                    <span className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => goToFolder('')}
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        {t('agents.title')}
+                      </button>
+                      {segments.map((segment, i) => {
+                        const path = segments.slice(0, i + 1).join('/');
+                        const isLast = i === segments.length - 1;
+                        return (
+                          <span key={path} className="flex items-center gap-1">
+                            <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+                            {isLast ? (
+                              <span>{segment}</span>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => goToFolder(path)}
+                                className="text-muted-foreground hover:text-foreground transition-colors"
+                              >
+                                {segment}
+                              </button>
+                            )}
+                          </span>
+                        );
+                      })}
+                    </span>
+                  ) : (
+                    t('agents.title')
+                  )}
+                </AdaptiveHeaderTitle>
+              </AdaptiveHeaderRoot>
+              <TabNavigation
+                items={tabs}
+                standalone={false}
+                ariaLabel={t('agents.title')}
+              >
+                <AgentsEditorActionsSlot />
+              </TabNavigation>
+            </>
+          ) : undefined
+        }
+      >
+        {!abilityLoading && <Outlet />}
+      </PageLayout>
+    </ActiveEditorProvider>
   );
+}
+
+/**
+ * Reads the active child controller (the Overview tab's organigram) and renders
+ * the unified Save/Discard cluster in the agents tab strip — the same slot the
+ * automation and agent editors use. Tabs without an editor (List, Catalog,
+ * Metrics) leave the active editor null and the cluster doesn't render.
+ */
+function AgentsEditorActionsSlot() {
+  const controller = useActiveEditor();
+  if (!controller) return null;
+  return <EditorActions controller={controller} entityKind="organigram" />;
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -8024,8 +8024,7 @@
       "title": "Menschen",
       "subtitle": "Agenten der obersten Ebene: {count}"
     },
-    "saved": "Delegation gespeichert",
-    "unsavedChanges": "Nicht gespeicherte Änderungen"
+    "saved": "Delegation gespeichert"
   },
   "workforce": {
     "subtitle": "Wie deine KI-Workforce arbeitet: Ergebnisse, menschliche Eingriffe und Kosten — immer zusammen.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -8024,8 +8024,7 @@
       "title": "Humans",
       "subtitle": "Top-level agents: {count}"
     },
-    "saved": "Delegation saved",
-    "unsavedChanges": "Unsaved changes"
+    "saved": "Delegation saved"
   },
   "workforce": {
     "subtitle": "How your AI workforce performs: outcomes, human intervention, and cost — always together.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -8025,8 +8025,7 @@
       "title": "Humains",
       "subtitle": "Agents de premier niveau : {count}"
     },
-    "saved": "Délégation enregistrée",
-    "unsavedChanges": "Modifications non enregistrées"
+    "saved": "Délégation enregistrée"
   },
   "workforce": {
     "subtitle": "Les performances de ta workforce IA : résultats, interventions humaines et coûts — toujours ensemble.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2374. The organigram's Save/Discard lived in a floating React Flow `<Panel>` overlay; every other editor (automations, agent editor) puts them in the tab-navigation bar. Reused that exact shared pattern: the canvas now registers an `EditorController` (built from its existing staged-draft dirty state) via `useRegisterActiveEditor`, and the agents layout renders the shared `EditorActions` in its `TabNavigation`. Behaviour is identical (staged draft, save-per-agent, baseline reseed) and it inherits the ⌘S shortcut and unified saved-flash for free. The controls only appear for editors (`canEdit`); List/Catalog/Metrics register no editor.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `organigram-editor` browser test green, editor/nav/agent UI suites (257) + i18n `messages` (40, incl. enforce-mode parity/usage) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — reused `common.actions.*`; removed the now-orphaned `organigram.unsavedChanges` from en/de/fr (enforce-mode usage check).
- [x] Docs / READMEs — N/A.

## Test plan
Open an agent's Delegation/organigram, edit delegation → Save/Discard now appear in the tab-nav bar (not a floating overlay); Save/Discard and ⌘S behave as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

