### PR TITLE
fix(platform): link automation executions to the canvas run view (#2347)

### DIFF
--- a/services/platform/app/features/automations/executions/executions-table.test.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
@@ -10,6 +11,29 @@ import { ExecutionsTable } from './executions-table';
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
   useParams: () => ({ id: 'test-org-id' }),
+  // Render a real anchor so the row action stays a keyboard-reachable link and
+  // its `to`/`params`/`search` are assertable (the canvas deep link, #2347).
+  Link: ({
+    to,
+    params,
+    search,
+    children,
+    ...props
+  }: {
+    to: string;
+    params?: unknown;
+    search?: unknown;
+    children?: ReactNode;
+  }) => (
+    <a
+      href={to}
+      data-params={JSON.stringify(params)}
+      data-search={JSON.stringify(search)}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('@tale/ui/i18n/locale-provider', async (importOriginal) => ({
@@ -99,6 +123,36 @@ describe('ExecutionsTable', () => {
       expect(
         within(table).queryByText('status.mysteryState'),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  // Regression for #2347: the Executions tab only expanded inline JSON, with no
+  // path to the canvas run view. Each row now exposes a labelled "View on
+  // canvas" link that deep-links to `/automations/$amId?execution={runId}`,
+  // reusing the same `execution` param the tester panel writes.
+  describe('canvas run link', () => {
+    it('links each row to the canvas with its execution id', () => {
+      mockTableData = [
+        executionRow('exec-a', 'completed'),
+        executionRow('exec-b', 'failed'),
+      ];
+
+      render(<ExecutionsTable amId="am-1" organizationId="test-org-id" />);
+
+      const links = screen.getAllByRole('link', { name: 'View on canvas' });
+      expect(links).toHaveLength(2);
+      expect(links[0]).toHaveAttribute(
+        'href',
+        '/dashboard/$id/automations/$amId',
+      );
+      expect(links[0]).toHaveAttribute(
+        'data-search',
+        JSON.stringify({ execution: 'exec-a' }),
+      );
+      expect(links[0]).toHaveAttribute(
+        'data-params',
+        JSON.stringify({ id: 'test-org-id', amId: 'am-1' }),
+      );
     });
   });
 });

--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -5,19 +5,21 @@ import { Button } from '@tale/ui/button';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { type ColumnDef, type Row } from '@tanstack/react-table';
 import { parseISO, startOfDay, endOfDay } from 'date-fns';
-import { Copy, Check } from 'lucide-react';
+import { Copy, Check, Workflow } from 'lucide-react';
 import { useState, useMemo, useCallback, memo } from 'react';
 
 import { JsonViewer } from '@/app/components/ui/data-display/json-viewer';
+import { ACTIONS_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { useListPage } from '@/app/hooks/use-list-page';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { parseDebugWaitingFor } from '@/convex/workflow_engine/helpers/engine/debug_gate';
 import { useT } from '@/lib/i18n/client';
 import { formatDuration } from '@/lib/utils/format/number';
+import { slugToUrlParam } from '@/lib/utils/workflow-slug';
 
 import {
   useApproxExecutionCount,
@@ -301,6 +303,35 @@ export function ExecutionsTable({
           </Text>
         ),
       },
+      {
+        id: 'actions',
+        size: ACTIONS_COLUMN_SIZE,
+        meta: { isAction: true },
+        // The row's inline JSON detail is the only affordance the list used to
+        // offer; the per-node canvas run view was reachable only by
+        // hand-editing `?execution=` (#2347). Link each row to the canvas with
+        // that param set, reusing the same mechanism the tester panel writes.
+        // `stopPropagation` keeps the click from also toggling the JSON row.
+        cell: ({ row }) => (
+          <HStack justify="end">
+            <Button
+              asChild
+              variant="ghost"
+              size="icon-sm"
+              title={tAutomations('executions.viewOnCanvas')}
+            >
+              <Link
+                to="/dashboard/$id/automations/$amId"
+                params={{ id: organizationId, amId: slugToUrlParam(amId) }}
+                search={{ execution: row.original._id }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Workflow className="size-4" aria-hidden="true" />
+              </Link>
+            </Button>
+          </HStack>
+        ),
+      },
     ],
     [
       copiedId,
@@ -310,6 +341,9 @@ export function ExecutionsTable({
       calculateDuration,
       tTables,
       tCommon,
+      tAutomations,
+      organizationId,
+      amId,
     ],
   );
 

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -51,6 +51,10 @@ const AutomationSteps = lazy(() =>
 
 const searchSchema = z.object({
   panel: z.string().optional(),
+  // Viewed-run id for the canvas run view (per-node badges + "Viewing run …"
+  // banner). Written by the tester panel and by the Executions tab's "View on
+  // canvas" row action, and read via `ExecutionStatusProvider` (#2347).
+  execution: z.string().optional(),
 });
 
 export const Route = createFileRoute('/dashboard/$id/automations/$amId')({

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -938,7 +938,8 @@
     "executions": {
       "title": "Ausführungen",
       "entityLabel": "Ausführungen",
-      "searchPlaceholder": "Nach Ausführungs-ID suchen"
+      "searchPlaceholder": "Nach Ausführungs-ID suchen",
+      "viewOnCanvas": "Auf dem Canvas ansehen"
     },
     "createDialog": {
       "title": "Automatisierung erstellen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -938,7 +938,8 @@
     "executions": {
       "title": "Executions",
       "entityLabel": "executions",
-      "searchPlaceholder": "Search by execution ID"
+      "searchPlaceholder": "Search by execution ID",
+      "viewOnCanvas": "View on canvas"
     },
     "createDialog": {
       "title": "Create automation",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -939,7 +939,8 @@
     "executions": {
       "title": "Exécutions",
       "entityLabel": "exécutions",
-      "searchPlaceholder": "Rechercher par ID d'exécution"
+      "searchPlaceholder": "Rechercher par ID d'exécution",
+      "viewOnCanvas": "Voir sur le canevas"
     },
     "createDialog": {
       "title": "Créer une automatisation",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2347. The Executions tab only expanded inline JSON; the canvas run view (`?execution={runId}`) was reachable only by hand-editing the URL. Adds a labelled **"View on canvas"** row action that deep-links to the workflow canvas with the run's `execution` search param set (reusing the existing param the tester panel writes), and makes `execution` a typed optional in the `$amId` route search schema. Icon-only control is named via `title`→`aria-label`; the action stops propagation so it doesn't also toggle the JSON detail row.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `executions-table` UI test (3, incl. regression + axe) passing, `@tale/ui` i18n parity/voice (54) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — added `automations.executions.viewOnCanvas` to en/de/fr (DE `du`, FR `tu`/`canevas`).
- [x] Docs / READMEs — N/A.

## Test plan
Automations → a workflow with completed runs → Executions → click "View on canvas" on a row → lands on the canvas showing that run's per-node status.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

