### PR TITLE
fix(platform): record REST api-key last-used on auth (#2317)

### DIFF
--- a/services/platform/convex/lib/rest/helpers.test.ts
+++ b/services/platform/convex/lib/rest/helpers.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { httpStatusForConvexCode } from './helpers';
+import type { HttpCtx } from './helpers';
+import { authenticateRequest, httpStatusForConvexCode } from './helpers';
+
+// `authenticateRequest` resolves identity through Better Auth; stub `createAuth`
+// so the tests drive the session result directly without the real auth stack.
+const getSession = vi.fn();
+vi.mock('../../auth', () => ({
+  createAuth: vi.fn(() => ({ api: { getSession } })),
+}));
+
+function bearerRequest(token: string): Request {
+  return new Request('https://app.example.com/api/v1/agents', {
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
+
+function ctxWith(runMutation: ReturnType<typeof vi.fn>): HttpCtx {
+  return { runMutation } as unknown as HttpCtx;
+}
 
 /**
  * The REST wrapper (`withRestAuth`) maps typed `ConvexError` codes to HTTP
@@ -32,4 +50,74 @@ describe('httpStatusForConvexCode', () => {
       expect(httpStatusForConvexCode(code)).toBe(500);
     },
   );
+});
+
+/**
+ * Regression for #2317: a successful REST api-key authentication must stamp the
+ * key's `lastRequest`, otherwise the Settings → API table forever reads
+ * "Never used". Better Auth's own session-hook write is a no-op in this HTTP
+ * action context, so the helper writes the field directly on the component row.
+ */
+describe('authenticateRequest — records api-key last-used (#2317)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stamps lastRequest on the authenticated api-key row', async () => {
+    getSession.mockResolvedValue({
+      user: { id: 'user_1', email: 'a@b.com', name: 'A' },
+      session: { id: 'apikey_123' },
+    });
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+
+    const user = await authenticateRequest(
+      ctxWith(runMutation),
+      bearerRequest('tale_secret'),
+    );
+
+    expect(user).toEqual({ userId: 'user_1', email: 'a@b.com', name: 'A' });
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    const [, args] = runMutation.mock.calls[0];
+    expect(args.input.model).toBe('apikey');
+    expect(args.input.where).toEqual([
+      { field: '_id', value: 'apikey_123', operator: 'eq' },
+    ]);
+    expect(typeof args.input.update.lastRequest).toBe('number');
+  });
+
+  it('still authenticates when the last-used stamp fails (best-effort)', async () => {
+    getSession.mockResolvedValue({
+      user: { id: 'user_1', email: 'a@b.com', name: 'A' },
+      session: { id: 'apikey_123' },
+    });
+    const runMutation = vi.fn().mockRejectedValue(new Error('write blocked'));
+
+    const user = await authenticateRequest(
+      ctxWith(runMutation),
+      bearerRequest('tale_secret'),
+    );
+
+    expect(user.userId).toBe('user_1');
+    expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an invalid key and never stamps', async () => {
+    getSession.mockResolvedValue(null);
+    const runMutation = vi.fn();
+
+    await expect(
+      authenticateRequest(ctxWith(runMutation), bearerRequest('tale_bad')),
+    ).rejects.toThrow('Invalid API key or session');
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request without a Bearer token', async () => {
+    const runMutation = vi.fn();
+    const request = new Request('https://app.example.com/api/v1/agents');
+
+    await expect(
+      authenticateRequest(ctxWith(runMutation), request),
+    ).rejects.toThrow('Missing or invalid Authorization header');
+    expect(runMutation).not.toHaveBeenCalled();
+  });
 });

--- a/services/platform/convex/lib/rest/helpers.ts
+++ b/services/platform/convex/lib/rest/helpers.ts
@@ -7,7 +7,7 @@
 
 import { ConvexError } from 'convex/values';
 
-import { internal } from '../../_generated/api';
+import { components, internal } from '../../_generated/api';
 import { httpAction } from '../../_generated/server';
 import { createAuth } from '../../auth';
 import {
@@ -96,6 +96,42 @@ export function jsonError(message: string, status: number): Response {
 // ---------------------------------------------------------------------------
 
 /**
+ * Stamp the API key's `lastRequest` so the Settings → API table can show a
+ * real "Last used" instead of "Never used".
+ *
+ * Better Auth's api-key session hook is supposed to record this itself, but its
+ * write goes through the component adapter, which the Convex Better Auth plugin
+ * turns into a no-op outside a mutation-capable request — so a plain `getSession`
+ * auth on a `/api/v1/*` HTTP action never persists it. We write the field
+ * directly on the component row instead (same mechanism as the create-time
+ * suffix stamp in `auth.ts`), which is deterministic in the HTTP-action context.
+ *
+ * Best-effort: a stamp failure must never break an otherwise valid request, so
+ * this swallows its own errors — the worst case is the pre-existing behaviour of
+ * the row still reading "Never used".
+ */
+async function recordApiKeyLastUsed(
+  ctx: HttpCtx,
+  apiKeyId: string,
+): Promise<void> {
+  try {
+    await ctx.runMutation(components.betterAuth.adapter.updateMany, {
+      input: {
+        model: 'apikey',
+        where: [{ field: '_id', value: apiKeyId, operator: 'eq' }],
+        update: { lastRequest: Date.now() },
+      },
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+  } catch (err) {
+    console.warn(
+      '[rest-auth] failed to record API key last-used',
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
  * Authenticate a REST request via Bearer token.
  * Extracts the API key from the Authorization header and validates it
  * through BetterAuth, returning the authenticated user info.
@@ -125,6 +161,15 @@ export async function authenticateRequest(
 
     if (!session?.user) {
       throw new AuthError('Invalid API key or session');
+    }
+
+    // For an api-key session, Better Auth sets `session.id` to the api-key
+    // row's id (see @better-auth/api-key session hook). Stamp last-used so the
+    // key stops reading "Never used" after real authenticated calls (#2317).
+    const apiKeyId =
+      typeof session.session?.id === 'string' ? session.session.id : undefined;
+    if (apiKeyId) {
+      await recordApiKeyLastUsed(ctx, apiKeyId);
     }
 
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2317. Generic `/api/v1/*` REST endpoints authenticate through `withRestAuth` → `authenticateRequest`; Better Auth's api-key `lastRequest` write is a no-op through the Convex adapter's hook, so the "Last used" column stayed "Never used" forever. After a successful api-key auth, this now writes `lastRequest` directly on the component `apikey` row (keyed by the session id, the same direct-mutation mechanism `auth.ts` uses for the create-time suffix stamp). The write is best-effort (try/catch) so a stamp failure can never break a valid request.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `rest/helpers.test.ts` (11, incl. 4 new: stamps correct id/shape, still authenticates when stamp fails, rejects invalid key without stamping, rejects missing Bearer) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (existing `lastUsed`/`neverUsed` strings unchanged).
- [x] Migration — N/A (reuses the existing optional `lastRequest` field).

## Test plan
Create a REST key, make an authenticated `/api/v1/*` call, reload Settings → API → REST → the key's "Last used" updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

