### PR TITLE
fix(platform): consolidate audit-log export into one dropdown (#2379)

### DIFF
--- a/services/platform/app/features/settings/audit-logs/components/audit-logs-page.test.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-logs-page.test.tsx
@@ -38,8 +38,9 @@ vi.mock('@/app/hooks/use-convex-query', () => ({
   useConvexQuery: () => ({ data: [], isLoading: false }),
 }));
 
+const exportMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/app/hooks/use-convex-action', () => ({
-  useConvexAction: () => ({ mutate: vi.fn(), isPending: false }),
+  useConvexAction: () => ({ mutate: exportMutate, isPending: false }),
 }));
 
 vi.mock('@/app/hooks/use-toast', () => ({
@@ -78,6 +79,7 @@ vi.mock('@/app/hooks/use-current-member-context', () => ({
 }));
 afterEach(() => {
   memberRole.current = 'owner';
+  exportMutate.mockClear();
 });
 
 // The DataTable reads the org id from the router; outside a RouterProvider that
@@ -186,6 +188,30 @@ describe('AuditLogsPage', () => {
     renderPage();
     expect(screen.queryByText('Chain integrity')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Logs' })).toBeInTheDocument();
+  });
+
+  it('consolidates export into one dropdown whose format items trigger the export', async () => {
+    // The two side-by-side "Export CSV"/"Export JSON" buttons are now one
+    // labelled "Export" trigger opening a keyboard-reachable format menu.
+    const { user } = renderPage();
+
+    expect(
+      screen.queryByRole('button', { name: /Export CSV/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Export JSON/ }),
+    ).not.toBeInTheDocument();
+
+    const trigger = screen.getByRole('button', { name: 'Export audit logs' });
+    await user.click(trigger);
+
+    const csvItem = await screen.findByRole('menuitem', { name: 'CSV' });
+    expect(screen.getByRole('menuitem', { name: 'JSON' })).toBeInTheDocument();
+
+    await user.click(csvItem);
+    expect(exportMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'csv' }),
+    );
   });
 
   it('passes an axe audit of the tab strip and active audit table', async () => {

--- a/services/platform/app/features/settings/audit-logs/components/audit-logs-page.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-logs-page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
+import { DropdownMenu } from '@tale/ui/dropdown-menu';
 import { Row } from '@tale/ui/layout';
 import { Tabs } from '@tale/ui/tabs';
-import { Download } from 'lucide-react';
+import { ChevronDown, Download } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
@@ -190,30 +191,38 @@ export function AuditLogsPage({
                 />
               )}
               {isAdminUser && (
-                <>
-                  <Button
-                    variant="secondary"
-                    icon={Download}
-                    onClick={() => handleExport('csv')}
-                    disabled={exportAction.isPending}
-                    aria-label={t('logs.audit.export.csvLabel')}
-                  >
-                    {exportAction.isPending
-                      ? t('logs.audit.export.inProgress')
-                      : t('logs.audit.export.csv')}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    icon={Download}
-                    onClick={() => handleExport('json')}
-                    disabled={exportAction.isPending}
-                    aria-label={t('logs.audit.export.jsonLabel')}
-                  >
-                    {exportAction.isPending
-                      ? t('logs.audit.export.inProgress')
-                      : t('logs.audit.export.json')}
-                  </Button>
-                </>
+                <DropdownMenu
+                  align="end"
+                  trigger={
+                    <Button
+                      variant="secondary"
+                      icon={Download}
+                      disabled={exportAction.isPending}
+                      aria-label={t('logs.audit.export.triggerLabel')}
+                    >
+                      {exportAction.isPending
+                        ? t('logs.audit.export.inProgress')
+                        : t('logs.audit.export.label')}
+                      <ChevronDown className="ml-2 size-4" aria-hidden="true" />
+                    </Button>
+                  }
+                  items={[
+                    [
+                      {
+                        type: 'item',
+                        label: t('logs.audit.export.csv'),
+                        icon: Download,
+                        onClick: () => handleExport('csv'),
+                      },
+                      {
+                        type: 'item',
+                        label: t('logs.audit.export.json'),
+                        icon: Download,
+                        onClick: () => handleExport('json'),
+                      },
+                    ],
+                  ]}
+                />
               )}
             </Row>
           }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6463,10 +6463,10 @@
           "agent": "Agent"
         },
         "export": {
-          "csv": "CSV exportieren",
-          "json": "JSON exportieren",
-          "csvLabel": "Audit-Protokolle als CSV exportieren",
-          "jsonLabel": "Audit-Protokolle als JSON exportieren",
+          "label": "Exportieren",
+          "triggerLabel": "Audit-Protokolle exportieren",
+          "csv": "CSV",
+          "json": "JSON",
           "inProgress": "Exportieren...",
           "complete": "Export abgeschlossen",
           "error": "Export fehlgeschlagen"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6727,10 +6727,10 @@
           "agent": "Agent"
         },
         "export": {
-          "csv": "Export CSV",
-          "json": "Export JSON",
-          "csvLabel": "Export audit logs as CSV",
-          "jsonLabel": "Export audit logs as JSON",
+          "label": "Export",
+          "triggerLabel": "Export audit logs",
+          "csv": "CSV",
+          "json": "JSON",
           "inProgress": "Exporting...",
           "complete": "Export complete",
           "error": "Export failed"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6464,10 +6464,10 @@
           "agent": "Agent"
         },
         "export": {
-          "csv": "Exporter en CSV",
-          "json": "Exporter en JSON",
-          "csvLabel": "Exporter les journaux d'audit au format CSV",
-          "jsonLabel": "Exporter les journaux d'audit au format JSON",
+          "label": "Exporter",
+          "triggerLabel": "Exporter les journaux d'audit",
+          "csv": "CSV",
+          "json": "JSON",
           "inProgress": "Exportation...",
           "complete": "Exportation terminée",
           "error": "Échec de l'exportation"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2379. On Settings → Governance → Logs, the two side-by-side "Export CSV" / "Export JSON" buttons are replaced with a single "Export" dropdown button (built on the shared `@tale/ui` `DropdownMenu` + `Button`, matching the History-menu pattern). The existing `handleExport('csv'|'json')` handlers are unchanged — only the trigger is consolidated. The trigger carries an `aria-label`, the chevron is `aria-hidden`, and the menu items are keyboard-reachable Radix `menuitem`s. A sweep confirmed this was the only surface with per-format sibling export buttons.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `audit-logs-page` UI tests (7, incl. a regression asserting the old buttons are gone and the menu exports CSV) + `@tale/ui` i18n (54) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — reworked `logs.audit.export` in en/de/fr (added `label`/`triggerLabel`, bare `CSV`/`JSON`, removed unused `csvLabel`/`jsonLabel`).

## Test plan
Settings → Governance → Logs → click "Export" → choose CSV or JSON from the menu → the corresponding export runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

