### PR TITLE
fix(platform): gate moderation enable on a configured endpoint (#2344)

### DIFF
--- a/services/platform/app/features/settings/governance/components/moderation-provider-config.test.tsx
+++ b/services/platform/app/features/settings/governance/components/moderation-provider-config.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { render, screen } from '@/tests/utils/render';
 
@@ -10,11 +10,20 @@ vi.mock('@/app/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+// Hoisted so the save spy is inspectable across renders (each render must see
+// the SAME `mutateAsync`, not a fresh `vi.fn()`).
+const { saveMutateAsync } = vi.hoisted(() => ({
+  saveMutateAsync: vi.fn().mockResolvedValue(null),
+}));
+
 // `ApiKeyPanel` / `TestConnectionPanel` only mount once enabled, so their
 // secret/test hooks are never called in these fixtures — stubbed so the module
 // mock stays complete.
 vi.mock('../hooks/mutations', () => ({
-  useUpsertGovernancePolicy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpsertGovernancePolicy: () => ({
+    mutateAsync: saveMutateAsync,
+    isPending: false,
+  }),
   useSaveModerationSecret: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useTestModerationProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
@@ -53,6 +62,34 @@ function setLoading() {
 }
 
 describe('ModerationProviderConfig', () => {
+  beforeEach(() => {
+    saveMutateAsync.mockClear();
+  });
+
+  // #2344: enabling the provider before an endpoint URL is configured used to
+  // autosave, fail the server-side Zod gate (`endpoint.url` must be a valid
+  // URL), and silently revert with a raw ConvexError toast. The toggle must now
+  // defer the save and surface an inline hint instead.
+  describe('enable without a configured endpoint (#2344)', () => {
+    it('does not autosave the enable when the endpoint URL is missing', async () => {
+      setLoaded();
+      const { user } = render(
+        <ModerationProviderConfigView organizationId="org-1" />,
+      );
+      await user.click(screen.getByRole('switch'));
+      expect(saveMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('expands the config with an inline endpoint hint', async () => {
+      setLoaded();
+      const { user } = render(
+        <ModerationProviderConfigView organizationId="org-1" />,
+      );
+      await user.click(screen.getByRole('switch'));
+      expect(screen.getByText(/set an endpoint first/i)).toBeInTheDocument();
+    });
+  });
+
   describe('loaded state', () => {
     it('renders the real enable switch (in the a11y tree)', () => {
       setLoaded();

--- a/services/platform/app/features/settings/governance/components/moderation-provider-config.tsx
+++ b/services/platform/app/features/settings/governance/components/moderation-provider-config.tsx
@@ -306,9 +306,18 @@ export function ModerationProviderConfigView({
   const handleToggleEnabled = useCallback(
     (checked: boolean) => {
       setEnabled(checked);
+      // Enabling with an unconfigured endpoint fails the server's Zod gate
+      // (`endpoint.url` must be a valid URL) and the enable silently never
+      // persists. Flip the toggle locally so the config — including the
+      // Endpoint editor — expands, but defer the save until a URL exists; the
+      // inline hint tells the admin what's missing. Mirrors the
+      // custom_jsonpath deferral below. Disabling always persists.
+      if (checked && !url.trim()) {
+        return;
+      }
       void saveWith(buildConfig({ enabled: checked }));
     },
-    [buildConfig, saveWith],
+    [buildConfig, saveWith, url],
   );
 
   const handleAppliesToInput = useCallback(
@@ -491,6 +500,13 @@ export function ModerationProviderConfigView({
 
         {enabled && (
           <>
+            {!url.trim() && (
+              <Alert
+                variant="warning"
+                description={t('moderationProvider.enableNeedsEndpoint')}
+              />
+            )}
+
             <FormSection label={t('moderationProvider.applyTo')}>
               <Stack gap={2}>
                 <label className="flex items-center gap-2">

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3379,6 +3379,7 @@
       "presetApplied": "Preset angewendet",
       "presetAppliedMappings": "{count} Standard-Kategorie-Zuordnungen hinzugefügt (alle im flag-Modus — unten feinjustieren).",
       "customJsonPathHint": "Öffne unten „Endpoint“, trage deine HTTPS-URL, das Request-Body-Template und den JSONPath für Kategorien ein. Der Schalter bleibt nicht gespeichert, bis diese Felder gesetzt sind.",
+      "enableNeedsEndpoint": "Lege zuerst einen Endpoint fest. Öffne unten „Endpoint“ und trage die URL der Moderations-API ein — das Aktivieren bleibt nicht gespeichert, bis er konfiguriert ist.",
       "apiKey": "API-Schlüssel",
       "apiKeyDescription": "Hier eingefügt, serverseitig mit AES-256-GCM verschlüsselt und in `governanceSecrets` gespeichert. Der Klartextwert ersetzt `{secretPlaceholder}` in deinen Endpoint-Headern zur Request-Zeit. Verwende den vollständigen Header-Wert für Authorization-Header (z. B. 'Bearer sk-…'); den reinen Schlüssel für Azures `Ocp-Apim-Subscription-Key`.",
       "apiKeyPlaceholder": "Bearer sk-... oder reiner API-Schlüssel",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3379,6 +3379,7 @@
       "presetApplied": "Preset applied",
       "presetAppliedMappings": "Added {count} default category mappings (all in flag mode — tune them below).",
       "customJsonPathHint": "Open Endpoint below, fill in your HTTPS URL, request body template, and the JSONPath for categories. The switch won't persist until those fields are set.",
+      "enableNeedsEndpoint": "Set an endpoint first. Open Endpoint below and add the moderation API URL — enabling won't persist until it's configured.",
       "apiKey": "API key",
       "apiKeyDescription": "Pasted here, encrypted with AES-256-GCM on the server, and stored in governanceSecrets. The plaintext value replaces `{secretPlaceholder}` in your endpoint headers at request time. Use the full header value for Authorization-style headers (e.g. 'Bearer sk-…'); raw key for Azure's Ocp-Apim-Subscription-Key.",
       "apiKeyPlaceholder": "Bearer sk-... or raw API key",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3380,6 +3380,7 @@
       "presetApplied": "Preset appliqué",
       "presetAppliedMappings": "{count} correspondances de catégories par défaut ajoutées (toutes en mode flag — à ajuster ci-dessous).",
       "customJsonPathHint": "Ouvre « Endpoint » ci-dessous, renseigne ton URL HTTPS, le template de corps de requête et le JSONPath des catégories. Le commutateur ne persistera pas tant que ces champs ne sont pas définis.",
+      "enableNeedsEndpoint": "Définis d'abord un endpoint. Ouvre « Endpoint » ci-dessous et ajoute l'URL de l'API de modération — l'activation ne persistera pas tant qu'il n'est pas configuré.",
       "apiKey": "Clé API",
       "apiKeyDescription": "Collée ici, chiffrée avec AES-256-GCM côté serveur et stockée dans `governanceSecrets`. La valeur en clair remplace `{secretPlaceholder}` dans les headers de ton endpoint au moment de la requête. Utilise la valeur complète pour les headers de type Authorization (p. ex. 'Bearer sk-…') ; la clé brute pour `Ocp-Apim-Subscription-Key` d'Azure.",
       "apiKeyPlaceholder": "Bearer sk-... ou clé API brute",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2344. Toggling the moderation provider "Enabled" autosaved immediately; on a fresh org the endpoint URL is empty, so the server's Zod gate rejected the save with a ConvexError and the enable silently didn't persist. Following the existing `custom_jsonpath` deferral pattern in the same file, `handleToggleEnabled` now flips the toggle locally (expanding the Endpoint editor) but **defers the save** when enabling with an empty URL, and an inline warning `Alert` prompts the admin to configure the endpoint — no failing request, no raw toast. (The raw-toast half from #2062 was already handled by `mapGovernanceSaveError`; the gate means the failing save no longer fires here anyway.)

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `moderation-provider-config` UI tests (8, incl. 2 new regressions) + platform i18n parity (12) + `@tale/ui` i18n (54) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — added `moderationProvider.enableNeedsEndpoint` to en/de/fr (DE `du`, FR `tu`).

## Test plan
On a fresh org, toggle moderation "Enabled" without an endpoint → the section expands with an inline "configure the endpoint" hint and no error toast; the toggle persists once a valid endpoint is saved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

