### PR TITLE
fix(platform): let task readers comment on the discussion thread (#2339)

### DIFF
--- a/services/platform/app/features/tasks/components/task-comments.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.tsx
@@ -42,23 +42,25 @@ interface TaskComment {
  * Task comment thread, unified onto the task's `task_discussion` thread (one
  * conversation surface shared with project discussions). A flat message list —
  * author identity (resolved name + avatar), relative timestamps, the `(edited)`
- * marker, and inline edit/delete. Composer + edit are gated on `canEdit`
- * (project write); edit is author-only; delete is author-or-admin (re-enforced
- * server-side). Agent replies (from `run_on_task`) render as agent-authored
- * messages here. A task with no comments yet shows just the composer.
+ * marker, and inline edit/delete. Composer + edit are gated on `canComment`
+ * (read-level — any org member who can open the task, mirroring a project
+ * discussion reply); edit is author-only; delete is author-or-admin (all
+ * re-enforced server-side). Agent replies (from `run_on_task`) render as
+ * agent-authored messages here. A task with no comments yet shows just the
+ * composer.
  */
 export function TaskComments({
   taskId,
   organizationId,
   projectId,
-  canEdit,
+  canComment,
   currentUserId,
   isAdmin,
 }: {
   taskId: Id<'tasks'>;
   organizationId: string;
   projectId: Id<'projects'>;
-  canEdit: boolean;
+  canComment: boolean;
   currentUserId?: string;
   isAdmin?: boolean;
 }) {
@@ -186,7 +188,7 @@ export function TaskComments({
             />
           )}
 
-          {!isEditing && canEdit && (
+          {!isEditing && canComment && (
             <Row
               gap={3}
               className="mt-1 text-xs opacity-0 transition-opacity group-focus-within/comment:opacity-100 group-hover/comment:opacity-100"
@@ -235,7 +237,7 @@ export function TaskComments({
         ))}
       </Stack>
 
-      {canEdit && (
+      {canComment && (
         <Row gap={2} align="start" className="mt-4">
           {currentUser && (
             <AssigneeAvatar

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -404,7 +404,7 @@ function EditTaskBody({
 }) {
   const { t } = useT('tasks');
   const { t: tCommon } = useT('common');
-  const { task, canEdit } = useTask(taskId);
+  const { task, canEdit, canComment } = useTask(taskId);
   const { project } = useProject(task?.projectId);
   const identifier = formatTaskIdentifier(project?.key, task?.number);
   const projectKey = project?.key ?? null;
@@ -674,7 +674,7 @@ function EditTaskBody({
             taskId={task._id}
             organizationId={task.organizationId}
             projectId={task.projectId}
-            canEdit={canEdit}
+            canComment={canComment}
             currentUserId={me?.userId}
             isAdmin={me?.isAdmin}
           />

--- a/services/platform/app/features/tasks/hooks/queries.ts
+++ b/services/platform/app/features/tasks/hooks/queries.ts
@@ -50,6 +50,9 @@ export function useTask(taskId: Id<'tasks'> | undefined) {
     task: data?.task ?? null,
     canEdit: data?.canEdit ?? false,
     canClaim: data?.canClaim ?? false,
+    // Commenting is read-level: default false until the read resolves so the
+    // composer doesn't flash, then true for any member who can open the task.
+    canComment: data?.canComment ?? false,
     isLoading,
   };
 }

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -954,7 +954,12 @@ export const addTaskComment = mutation({
     const task = await loadTaskOrThrow(ctx, args.taskId);
     const project = await loadProjectOrThrow(ctx, task.projectId);
     const auth = await getAuthContext(ctx, task.organizationId);
-    assertTaskWritable(project, auth);
+    // Commenting is a READ-level action on the unified task_discussion surface:
+    // any org member who can read the task may post, exactly like a project
+    // discussion reply (`discussions/postReply` + `can_access_thread`'s
+    // discussion branch). Gating this on write access (editor+) locked plain
+    // members — including a task's own assignee — out of collaboration (#2339).
+    assertTaskReadable(project, auth);
 
     const body = args.body.trim();
     if (body.length === 0 || body.length > TASK_COMMENT_MAX) {
@@ -1088,7 +1093,9 @@ export const editTaskDiscussionMessage = mutation({
       ctx,
       args.messageId,
     );
-    assertTaskWritable(project, auth);
+    // Read-level like posting (see addTaskComment) — a member who could post
+    // must be able to fix their own comment. Delete already uses this gate.
+    assertTaskReadable(project, auth);
     // Only the human author can edit their own comment.
     if (meta.authorType !== 'user' || meta.authorId !== auth.userId) {
       throw new ConvexError({ code: 'TASK_COMMENT_FORBIDDEN' });

--- a/services/platform/convex/tasks/queries.test.ts
+++ b/services/platform/convex/tasks/queries.test.ts
@@ -54,6 +54,28 @@ async function seedProject(t: T, name: string): Promise<Id<'projects'>> {
   );
 }
 
+async function seedTask(
+  t: T,
+  projectId: Id<'projects'>,
+  assigneeId?: string,
+): Promise<Id<'tasks'>> {
+  return await t.run((ctx) =>
+    ctx.db.insert('tasks', {
+      organizationId: ORG,
+      projectId,
+      title: 'Task',
+      status: 'todo',
+      rank: 'a0',
+      number: 1,
+      createdBy: 'user_1',
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+      ...(assigneeId ? { assigneeType: 'user' as const, assigneeId } : {}),
+    }),
+  );
+}
+
 function upsertIssue(
   t: T,
   projectId: Id<'projects'>,
@@ -179,6 +201,31 @@ describe('listTasksByProject canEdit', () => {
       });
     // Reads succeed (no throw) but writes are gated off.
     expect(result.canEdit).toBe(false);
+  });
+});
+
+// Commenting is a READ-level action on the unified task_discussion surface: any
+// org member who can read a task may post, exactly like a project discussion
+// reply — so `getTask` reports canComment true even for a read-only member who
+// cannot edit the task. The modal gates the comment composer off this flag, not
+// canEdit, so a plain member (including a task's own assignee) keeps a composer
+// instead of a fully read-only modal (#2339).
+describe('getTask canComment', () => {
+  it('reports canComment true (canEdit false) for a read-only member', async () => {
+    const t = convexTest(schema, modules);
+    const projectId = await seedProject(t, 'A'); // org-wide → readable by all
+    const taskId = await seedTask(t, projectId, 'user_member'); // member is the assignee
+    await seedMember(t, 'user_member', 'member');
+
+    const result = await t
+      .withIdentity({ subject: 'user_member' })
+      .query(api.tasks.queries.getTask, { taskId, organizationId: ORG });
+
+    expect(result).not.toBeNull();
+    // A read-only member cannot edit the task…
+    expect(result?.canEdit).toBe(false);
+    // …but CAN comment on it (the composer stays available).
+    expect(result?.canComment).toBe(true);
   });
 });
 

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -333,7 +333,7 @@ export const listTasksByOrg = query({
   },
 });
 
-/** Fetch a single task with the caller's edit/claim affordances. */
+/** Fetch a single task with the caller's edit/claim/comment affordances. */
 export const getTask = query({
   args: { taskId: v.id('tasks'), organizationId: v.string() },
   returns: v.union(
@@ -342,6 +342,12 @@ export const getTask = query({
       task: taskRowValidator,
       canEdit: v.boolean(),
       canClaim: v.boolean(),
+      // Whether the caller may post/comment on the task's discussion. Commenting
+      // is a READ-level action (any org member who can read the task, mirroring
+      // a project discussion reply — see `addTaskComment`), so it's true for
+      // read-only members who cannot otherwise edit the task (#2339). The modal
+      // gates the comment composer off this rather than `canEdit`.
+      canComment: v.boolean(),
     }),
   ),
   handler: async (ctx, args) => {
@@ -352,7 +358,14 @@ export const getTask = query({
       task.projectId,
       args.organizationId,
     );
-    return { task, canEdit, canClaim: canEdit && canClaimTask(task) };
+    // Reaching here means the caller passed the read gate in
+    // `loadAccessibleProject`, which is exactly the requirement to comment.
+    return {
+      task,
+      canEdit,
+      canClaim: canEdit && canClaimTask(task),
+      canComment: true,
+    };
   },
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2339. Task comments live on the unified `task_discussion` thread, which is read-level (any org member can read/reply), but the task-side comment mutations (`addTaskComment`, `editTaskDiscussionMessage`) gated on **write** access (`assertTaskWritable` → `canEdit`, editor roles only). So a plain member — even the assignee — saw a fully read-only modal with no composer, and the mutation would have rejected anyway.

Aligned the comment mutations to `assertTaskReadable` (matching `deleteTaskDiscussionMessage`, which was already read-level, and the discussion surface's own read/reply model). `getTask` now returns a first-class `canComment` capability, and `TaskComments` gates the composer + own-edit/delete on it. Task field edits (status/priority/assignee/title/description) remain gated on `canEdit`, so this doesn't regress the read-only task controls.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `convex/tasks` tests (108, incl. a `canComment:true`/`canEdit:false` regression for a read-only assignee) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (composer reuses existing `tasks`/`common` keys).

## Test plan
As a plain member who is the assignee, open a task → the comment composer is present and posting works; status/priority controls remain read-only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

