### PR TITLE
fix(platform): show generated images large with a reachable edit (#2362)

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -895,6 +895,7 @@ function MessageBubbleComponent({
                   key={part.url}
                   filePart={part}
                   organizationId={organizationId}
+                  isAssistantImage={isAssistantImage}
                   onImageClick={
                     galleryIdx >= 0 ? () => openGallery(galleryIdx) : undefined
                   }

--- a/services/platform/app/features/chat/components/message-bubble/file-displays.test.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/file-displays.test.tsx
@@ -72,4 +72,31 @@ describe('FilePartDisplay', () => {
     );
     expect(screen.getByRole('img', { name: 'slide-1.jpg' })).toBeDefined();
   });
+
+  // REGRESSION (#2362): assistant-generated images rendered as a ~36px
+  // thumbnail (object-cover) instead of a readable display size.
+  it('renders an assistant-generated image at a readable display size', () => {
+    fileUrlData = 'http://localhost:3000/api/storage/kg2test123';
+    render(<FilePartDisplay filePart={part()} isAssistantImage />);
+    const img = screen.getByRole('img', { name: 'slide-1.jpg' });
+    expect(img.className).toContain('object-contain');
+    expect(img.className).not.toContain('object-cover');
+  });
+
+  // REGRESSION (#2362): the Edit affordance was hover-only (opacity-0), so it
+  // was unreachable on touch/coarse pointers. It must be always-visible and
+  // keyboard-focusable.
+  it('renders a reachable, always-visible Edit button when editing is enabled', () => {
+    fileUrlData = 'http://localhost:3000/api/storage/kg2test123';
+    render(
+      <FilePartDisplay
+        filePart={part()}
+        isAssistantImage
+        onEditImage={vi.fn()}
+      />,
+    );
+    const editButton = screen.getByRole('button', { name: 'Edit this image' });
+    expect(editButton.className).not.toContain('opacity-0');
+    expect(editButton.className).not.toContain('group-hover');
+  });
 });

--- a/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
@@ -335,16 +335,23 @@ export const FilePartDisplay = memo(function FilePartDisplay({
   filePart,
   onImageClick,
   onEditImage,
+  isAssistantImage,
   organizationId,
 }: {
   filePart: FilePart;
   onImageClick?: () => void;
   /**
-   * Shortcut for image-generation agents: when set, renders an ↻ Edit button
-   * overlay on image thumbnails. Clicking it promotes this image to the
-   * composer's editing reference (pre-attached on next send).
+   * Shortcut for image-generation agents: when set, renders an Edit button
+   * overlay on the image. Clicking it promotes this image to the composer's
+   * editing reference (pre-attached on next send).
    */
   onEditImage?: () => void;
+  /**
+   * True when this file part is an assistant-generated image. Generated images
+   * are the focal output of a turn, so they render at a readable display size
+   * rather than the small 36px thumbnail used for incidental images.
+   */
+  isAssistantImage?: boolean;
   organizationId?: string;
 }) {
   const { t } = useT('chat');
@@ -365,23 +372,24 @@ export const FilePartDisplay = memo(function FilePartDisplay({
   if (fileId !== undefined && liveUrl === null) return null;
 
   if (isImage) {
-    // When onEditImage is provided, this is an assistant-generated image for
-    // an image-generation agent — render it full-size so the output is the
-    // focal point of the message. Otherwise keep the small 36px thumbnail
-    // used for incidental images on chat messages.
-    const isLarge = Boolean(onEditImage);
+    // Assistant-generated images (and any image carrying an edit shortcut) are
+    // the focal output of a turn — render them at a readable display size so
+    // the result is legible and its Edit affordance is reachable. Incidental
+    // images (e.g. on a user turn) keep the small 36px thumbnail.
+    const isLarge = Boolean(isAssistantImage) || Boolean(onEditImage);
     const containerClasses = isLarge
       ? 'relative inline-block max-w-md overflow-hidden rounded-xl ring-1 ring-border'
       : 'group relative inline-block';
     const buttonClasses = isLarge
-      ? 'block w-full cursor-pointer border-none bg-transparent p-0 transition-opacity hover:opacity-95 focus:outline-none'
+      ? 'block w-full cursor-pointer border-none bg-transparent p-0 transition-opacity hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
       : 'ring-border focus:ring-ring size-9 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 ring-1 transition-opacity hover:opacity-80 focus:ring-2 focus:ring-offset-2 focus:outline-none';
     const imgClasses = isLarge
       ? 'block h-auto w-full object-contain'
       : 'size-full object-cover';
-    const editButtonClasses = isLarge
-      ? 'bg-background/90 ring-border text-foreground hover:bg-background absolute top-2 right-2 flex size-8 items-center justify-center rounded-full shadow-sm ring-1 transition-opacity focus:outline-none'
-      : 'bg-background/95 ring-border text-foreground hover:bg-background absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full opacity-0 shadow-sm ring-1 transition-opacity group-hover:opacity-100 focus:opacity-100 focus:outline-none';
+    // The Edit affordance is always visible and keyboard-focusable — never
+    // hover-only — so it stays reachable on touch/coarse pointers.
+    const editButtonClasses =
+      'bg-background/90 ring-border text-foreground hover:bg-background focus-visible:ring-ring absolute top-2 right-2 flex size-8 items-center justify-center rounded-full shadow-sm ring-1 transition-colors focus:outline-none focus-visible:ring-2';
 
     return (
       <div className={containerClasses}>
@@ -408,10 +416,7 @@ export const FilePartDisplay = memo(function FilePartDisplay({
             aria-label={t('imageEdit.editThis')}
             title={t('imageEdit.editThis')}
           >
-            <Pencil
-              className={isLarge ? 'size-4' : 'size-3'}
-              strokeWidth={1.75}
-            />
+            <Pencil className="size-4" strokeWidth={1.75} />
           </button>
         )}
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2362. `FilePartDisplay` chose its size with `isLarge = Boolean(onEditImage)`, and `onEditImage` is only wired when the selected agent is classified `image-generation`. So a generated image from an image-capable (but not image-gen-classified) agent rendered as a `size-9` (36×36) `object-cover` thumbnail with a hover-only edit overlay, leaving the `chat.imageEdit.*` flow unreachable.

Now the size keys off the semantic fact that it's a generated image (`isAssistantImage || onEditImage`, rendered `max-w-md`/`object-contain`), and the edit affordance is a single always-visible, keyboard-focusable button with a visible `focus-visible` ring (semantic tokens, light+dark).

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `file-displays`/`message-bubble` UI tests (27, incl. 2 new regressions) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (reuses `chat.imageEdit.*`).

## Test plan
Generate an image in chat → it renders at a readable size, and the Edit control is visible and keyboard-reachable (not hover-only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

