### PR TITLE
fix(platform): show org-config capabilities in model popover (#2357)

### DIFF
--- a/services/platform/app/features/settings/providers/hooks/queries.ts
+++ b/services/platform/app/features/settings/providers/hooks/queries.ts
@@ -10,6 +10,11 @@ import type {
   ProviderJson,
 } from '@/lib/shared/schemas/providers';
 
+import {
+  mergeModelCapabilities,
+  modelCapabilitiesFromConfig,
+} from '../utils/model-capabilities';
+
 /**
  * Shape returned by the `readProvider` action. The action declares `v.any()`,
  * so consumers cast to this to read `envSecretStatus` (issue #1711) and the
@@ -99,13 +104,14 @@ export function useHasModelSecret(
 }
 
 /**
- * Cached OpenRouter/provider capabilities (cost, context window, reasoning,
- * prompt-caching, tools/vision) for a set of model ids, keyed by id. Backs the
- * `ModelInfoPopover` info button across every model selector. The daily cron
- * and the live "Fetch models" action both populate `modelCapabilityCache`;
- * ids without a cache row are simply absent from the map (the popover then
- * hides those rows). Pass the currently-visible ids only — the query reads one
- * row per id.
+ * Capabilities (cost, context window, reasoning, prompt-caching, tools/vision)
+ * for a set of model ids, keyed by id. Backs the `ModelInfoPopover` info button
+ * across every model selector. Two sources are merged per field: the synced
+ * catalog cache (`modelCapabilityCache`, populated by the daily cron and the
+ * live "Fetch models" action) and the operator-declared org-config fields on
+ * each provider's model. Operator declarations win per field and are available
+ * before the first sync, so the popover stays useful pre-sync (issue #2357).
+ * Pass the currently-visible ids only — the catalog query reads one row per id.
  */
 export function useModelCapabilities(
   organizationId: string,
@@ -115,10 +121,16 @@ export function useModelCapabilities(
     api.model_catalog.queries.getModelCapabilities,
     { organizationId, modelIds },
   );
+  // Org-config capabilities are read from the provider list (the same source
+  // the pickers already subscribe to); skip the fetch when no ids are wanted,
+  // mirroring the gated catalog query above.
+  const { providers } = useListProviders(organizationId, {
+    enabled: modelIds.length > 0,
+  });
   return useMemo(() => {
-    const map = new Map<string, ModelInfoCapabilities>();
+    const catalog = new Map<string, ModelInfoCapabilities>();
     for (const c of data ?? []) {
-      map.set(c.modelId, {
+      catalog.set(c.modelId, {
         contextWindow: c.contextWindow,
         maxOutputTokens: c.maxOutputTokens,
         inputCentsPerMillion: c.inputCentsPerMillion,
@@ -129,6 +141,23 @@ export function useModelCapabilities(
         supportsVision: c.supportsVision,
       });
     }
+    const config = new Map<string, ModelInfoCapabilities>();
+    for (const provider of providers) {
+      if (
+        !provider ||
+        !('models' in provider) ||
+        !Array.isArray(provider.models)
+      )
+        continue;
+      for (const model of provider.models) {
+        config.set(model.id, modelCapabilitiesFromConfig(model));
+      }
+    }
+    const map = new Map<string, ModelInfoCapabilities>();
+    for (const id of new Set([...catalog.keys(), ...config.keys()])) {
+      const merged = mergeModelCapabilities(config.get(id), catalog.get(id));
+      if (merged) map.set(id, merged);
+    }
     return map;
-  }, [data]);
+  }, [data, providers]);
 }

--- a/services/platform/app/features/settings/providers/utils/model-capabilities.test.ts
+++ b/services/platform/app/features/settings/providers/utils/model-capabilities.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ModelInfoCapabilities } from '@/app/features/chat/components/model-info-popover';
+
+import {
+  mergeModelCapabilities,
+  modelCapabilitiesFromConfig,
+} from './model-capabilities';
+
+describe('modelCapabilitiesFromConfig', () => {
+  it('projects the operator-declared capability fields', () => {
+    expect(
+      modelCapabilitiesFromConfig({
+        tags: ['chat'],
+        maxOutputTokens: 8192,
+        contextWindow: 200_000,
+        reasoning: { knob: 'budgetTokens' },
+        promptCaching: { mode: 'explicit-breakpoints' },
+        cost: { inputCentsPerMillion: 300, outputCentsPerMillion: 1500 },
+      }),
+    ).toEqual({
+      contextWindow: 200_000,
+      maxOutputTokens: 8192,
+      inputCentsPerMillion: 300,
+      outputCentsPerMillion: 1500,
+      reasoning: { knob: 'budgetTokens' },
+      promptCaching: { mode: 'explicit-breakpoints' },
+      supportsVision: undefined,
+    });
+  });
+
+  it('derives supportsVision from the vision tag but never asserts false', () => {
+    expect(
+      modelCapabilitiesFromConfig({ tags: ['chat', 'vision'] }).supportsVision,
+    ).toBe(true);
+    expect(
+      modelCapabilitiesFromConfig({ tags: ['chat'] }).supportsVision,
+    ).toBeUndefined();
+  });
+});
+
+describe('mergeModelCapabilities', () => {
+  const catalog: ModelInfoCapabilities = {
+    contextWindow: 128_000,
+    maxOutputTokens: 4096,
+    inputCentsPerMillion: 250,
+    outputCentsPerMillion: 1000,
+    supportsTools: true,
+    supportsVision: false,
+  };
+
+  it('returns the org-config fields when the catalog is absent (pre-sync)', () => {
+    const config = modelCapabilitiesFromConfig({
+      tags: ['chat'],
+      contextWindow: 200_000,
+      reasoning: { knob: 'effort' },
+    });
+    expect(mergeModelCapabilities(config, undefined)).toBe(config);
+  });
+
+  it('returns the catalog when there is no org-config entry', () => {
+    expect(mergeModelCapabilities(undefined, catalog)).toBe(catalog);
+  });
+
+  it('prefers org-config fields and fills the rest from the catalog', () => {
+    const config = modelCapabilitiesFromConfig({
+      tags: ['chat', 'vision'],
+      contextWindow: 200_000,
+      reasoning: { knob: 'budgetTokens' },
+    });
+    expect(mergeModelCapabilities(config, catalog)).toEqual({
+      contextWindow: 200_000,
+      maxOutputTokens: 4096,
+      inputCentsPerMillion: 250,
+      outputCentsPerMillion: 1000,
+      reasoning: { knob: 'budgetTokens' },
+      promptCaching: undefined,
+      supportsTools: true,
+      supportsVision: true,
+    });
+  });
+
+  it('returns undefined when both sides are absent', () => {
+    expect(mergeModelCapabilities(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/services/platform/app/features/settings/providers/utils/model-capabilities.ts
+++ b/services/platform/app/features/settings/providers/utils/model-capabilities.ts
@@ -1,0 +1,63 @@
+import type { ModelInfoCapabilities } from '@/app/features/chat/components/model-info-popover';
+import type { ModelDefinition } from '@/lib/shared/schemas/providers';
+
+/**
+ * Project the model-info-popover capability fields an operator can declare
+ * directly in a provider's org-config `ModelDefinition`. The synced catalog
+ * cache is the richer source, but these operator-declared fields are
+ * authoritative and available before the first catalog sync — so the popover
+ * can still render them pre-sync (issue #2357).
+ *
+ * `supportsVision` is derived from the `'vision'` tag (never asserted `false`
+ * from a tag's absence, so the catalog can still fill it). `supportsTools` has
+ * no org-config field and is left entirely to the catalog.
+ */
+export function modelCapabilitiesFromConfig(
+  model: Pick<
+    ModelDefinition,
+    | 'tags'
+    | 'maxOutputTokens'
+    | 'contextWindow'
+    | 'reasoning'
+    | 'promptCaching'
+    | 'cost'
+  >,
+): ModelInfoCapabilities {
+  return {
+    contextWindow: model.contextWindow,
+    maxOutputTokens: model.maxOutputTokens,
+    inputCentsPerMillion: model.cost?.inputCentsPerMillion,
+    outputCentsPerMillion: model.cost?.outputCentsPerMillion,
+    reasoning: model.reasoning,
+    promptCaching: model.promptCaching,
+    supportsVision: model.tags.includes('vision') ? true : undefined,
+  };
+}
+
+/**
+ * Merge operator-declared org-config capabilities with synced catalog
+ * metadata. Operator declarations win per field — they are intentional, and
+ * the runtime already honours `reasoning`/`promptCaching` overrides — while
+ * the catalog fills every field the config leaves undefined. Either side may
+ * be absent: there is no catalog before the first sync, and most models
+ * declare nothing.
+ */
+export function mergeModelCapabilities(
+  config: ModelInfoCapabilities | undefined,
+  catalog: ModelInfoCapabilities | undefined,
+): ModelInfoCapabilities | undefined {
+  if (!config) return catalog;
+  if (!catalog) return config;
+  return {
+    contextWindow: config.contextWindow ?? catalog.contextWindow,
+    maxOutputTokens: config.maxOutputTokens ?? catalog.maxOutputTokens,
+    inputCentsPerMillion:
+      config.inputCentsPerMillion ?? catalog.inputCentsPerMillion,
+    outputCentsPerMillion:
+      config.outputCentsPerMillion ?? catalog.outputCentsPerMillion,
+    reasoning: config.reasoning ?? catalog.reasoning,
+    promptCaching: config.promptCaching ?? catalog.promptCaching,
+    supportsTools: config.supportsTools ?? catalog.supportsTools,
+    supportsVision: config.supportsVision ?? catalog.supportsVision,
+  };
+}

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -878,6 +878,16 @@ export const listProviders = action({
               // these out; without projecting it here, hidden models leaked
               // into the picker.
               hidden: m.hidden,
+              // Operator-declared capability fields the model-info popover
+              // renders. The synced catalog is the richer source, but these
+              // authoritative fields are available before the first sync, so
+              // projecting them lets the popover fall back to org-config
+              // pre-sync (issue #2357).
+              maxOutputTokens: m.maxOutputTokens,
+              contextWindow: m.contextWindow,
+              cost: m.cost,
+              reasoning: m.reasoning,
+              promptCaching: m.promptCaching,
             })),
             i18n: result.config.i18n,
           };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2357. The model-info popover rendered capabilities only from the synced catalog cache, so operator-declared org-config capabilities were dropped — and pre-sync (no catalog rows) it showed almost nothing. Two causes: `useModelCapabilities` never read org-config, and `listProviders` projected a narrow model shape that omitted `contextWindow`/`maxOutputTokens`/`cost`/`reasoning`/`promptCaching`.

Fixed at the shared read layer (so all popover call sites benefit): widened the `listProviders` model projection, added a pure tested `modelCapabilitiesFromConfig` + `mergeModelCapabilities` (org-config wins, catalog fills the rest), and `useModelCapabilities` now merges org-config over catalog per model.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new util test + client component tests (44) + providers server tests (202) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (reuses `chat.modelSelector.info.*`).

## Test plan
Declare model capabilities in org-config for a provider without synced catalog metadata → the model-details popover shows those capabilities (and org-config overrides catalog where both exist).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

