### PR TITLE
fix(platform): keep install wizard open from app details page (#2341)

### DIFF
--- a/services/platform/app/features/apps/components/app-page.test.tsx
+++ b/services/platform/app/features/apps/components/app-page.test.tsx
@@ -14,10 +14,13 @@ import { AppPage } from './app-page';
  * slug — otherwise every discovery card contradicts itself with "App not found".
  */
 
-const { useAppsMock, useAppCatalogMock } = vi.hoisted(() => ({
-  useAppsMock: vi.fn(),
-  useAppCatalogMock: vi.fn(),
-}));
+const { useAppsMock, useAppCatalogMock, useAppInstallStatesMock } = vi.hoisted(
+  () => ({
+    useAppsMock: vi.fn(),
+    useAppCatalogMock: vi.fn(),
+    useAppInstallStatesMock: vi.fn(),
+  }),
+);
 
 vi.mock('../hooks/use-apps', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/use-apps')>()),
@@ -26,14 +29,35 @@ vi.mock('../hooks/use-apps', async (importOriginal) => ({
 }));
 
 vi.mock('../hooks/use-install-state', () => ({
-  // A catalog-only app is not installed, so it has no install state.
-  useAppInstallStates: () => ({ bySlug: new Map(), isLoading: false }),
+  useAppInstallStates: useAppInstallStatesMock,
   useAppBindings: () => ({ bindings: [], isLoading: false }),
   useAppInstallActions: () => ({
     install: vi.fn(),
     uninstall: vi.fn(),
     verify: vi.fn(),
     isPending: false,
+  }),
+}));
+
+// Probe the wizard as a lightweight open/closed marker so the test asserts the
+// details page keeps hosting it across the install-state transition, without
+// pulling in the wizard's Convex/integration machinery.
+vi.mock('./install-wizard/app-install-wizard', () => ({
+  AppInstallWizard: ({ open }: { open: boolean }) =>
+    open ? <div>wizard step probe</div> : null,
+}));
+
+// The installed views (MembershipHub/InstalledAppBody) reach into Convex-backed
+// readiness; stub them so the #2341 test observes a clean assertion (the wizard
+// disappearing on the old code) rather than a Convex-provider crash.
+vi.mock('../hooks/use-app-agent-readiness', () => ({
+  useAppAgentReadiness: () => ({ agents: [], refetch: vi.fn() }),
+}));
+vi.mock('../hooks/use-required-integrations', () => ({
+  useRequiredIntegrations: () => ({
+    required: [],
+    blockedSlugs: [],
+    isLoading: false,
   }),
 }));
 
@@ -55,6 +79,11 @@ function catalogApp(overrides: Partial<AppSummary> = {}): AppSummary {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: nothing installed, so an app resolves to its pre-install details.
+  useAppInstallStatesMock.mockReturnValue({
+    bySlug: new Map(),
+    isLoading: false,
+  });
 });
 
 describe('AppPage catalog discovery (#1979)', () => {
@@ -110,5 +139,51 @@ describe('AppPage catalog discovery (#1979)', () => {
     expect(
       screen.getByRole('heading', { name: 'App not found', level: 3 }),
     ).toBeInTheDocument();
+  });
+});
+
+/**
+ * Regression net for #2341: the pre-install details page hosts the install
+ * wizard. The wizard's Install step installs the app, which flips the reactive
+ * install state to defined — and AppPage keys the details page on `!state`.
+ * Before the fix that transition unmounted the details page (and its open
+ * wizard) mid-flow, so a project-scoped install closed silently after Install
+ * instead of continuing to its integration/Done steps.
+ */
+describe('AppPage keeps the install wizard mounted across install (#2341)', () => {
+  const projectApp = () =>
+    catalogApp({
+      slug: 'issue-desk',
+      name: 'Issue Resolution Desk',
+      scope: 'project',
+    });
+
+  it('keeps hosting the wizard after the install lands install state', async () => {
+    useAppsMock.mockReturnValue({ apps: [], isLoading: false, error: null });
+    useAppCatalogMock.mockReturnValue({
+      apps: [projectApp()],
+      isLoading: false,
+      error: null,
+    });
+
+    const { user, rerender } = render(
+      <AppPage organizationId="org_1" appSlug="issue-desk" />,
+    );
+
+    // Open the wizard from the pre-install details page.
+    await user.click(screen.getByRole('button', { name: 'Install' }));
+    expect(screen.getByText('wizard step probe')).toBeInTheDocument();
+
+    // The Install step installs the app: its reactive state now resolves. The
+    // details page must survive this so the wizard reaches its later steps.
+    useAppInstallStatesMock.mockReturnValue({
+      bySlug: new Map([
+        ['issue-desk', { status: 'active', blockedIntegrations: [] }],
+      ]),
+      isLoading: false,
+    });
+    rerender(<AppPage organizationId="org_1" appSlug="issue-desk" />);
+
+    expect(screen.getByText('wizard step probe')).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -581,15 +581,22 @@ function AppDetails({
   appSlug,
   app,
   labels,
+  wizardOpen,
+  onWizardOpenChange,
 }: {
   organizationId: string;
   appSlug: string;
   app: AppSummary;
   labels: Record<string, string>;
+  // Controlled by AppPage: installing flips the app's install state, which
+  // would otherwise unmount this pre-install page (and the open wizard) the
+  // instant the wizard's Install step runs. AppPage keeps this page mounted
+  // while the wizard is open, so the flow reaches its integration/Done steps.
+  wizardOpen: boolean;
+  onWizardOpenChange: (open: boolean) => void;
 }) {
   const { t } = useT('apps');
   const { install, isPending } = useAppInstallActions(organizationId);
-  const [wizardOpen, setWizardOpen] = useState(false);
   const needsWizard =
     app.scope === 'project' || app.requiredIntegrations.length > 0;
 
@@ -645,7 +652,7 @@ function AppDetails({
           disabled={isPending}
           onClick={() =>
             needsWizard
-              ? setWizardOpen(true)
+              ? onWizardOpenChange(true)
               : notifyOnInstallFailure(
                   install(appSlug),
                   t('install.installFailed'),
@@ -703,7 +710,7 @@ function AppDetails({
       {needsWizard && (
         <AppInstallWizard
           open={wizardOpen}
-          onOpenChange={setWizardOpen}
+          onOpenChange={onWizardOpenChange}
           organizationId={organizationId}
           appSlug={appSlug}
           appName={app.name}
@@ -742,6 +749,11 @@ export function AppPage({
     catalog.find((a) => a.slug === appSlug);
   const state = bySlug.get(appSlug);
   const { bindings } = useAppBindings(organizationId, appSlug);
+  // Owned here (not in AppDetails) so the pre-install details page survives the
+  // install: the wizard's Install step flips `state`, which would otherwise
+  // unmount AppDetails and its still-open wizard before its integration/Done
+  // steps run. While the wizard is open we keep rendering AppDetails.
+  const [detailsWizardOpen, setDetailsWizardOpen] = useState(false);
 
   const labels = useMemo<Record<string, string>>(
     () => resolvePackLabels(app?.messages, locale),
@@ -793,14 +805,18 @@ export function AppPage({
 
   // ORG route, not installed — a pre-install details page (full description +
   // what it includes / needs) with Install as the CTA. The wizard (project pick
-  // for a project-scoped app / required integrations) lives inside it.
-  if (!state) {
+  // for a project-scoped app / required integrations) lives inside it. Stay on
+  // this page while its wizard is open even after the install lands `state`, so
+  // the flow continues to its integration/Done steps instead of vanishing.
+  if (!state || detailsWizardOpen) {
     return (
       <AppDetails
         organizationId={organizationId}
         appSlug={appSlug}
         app={app}
         labels={labels}
+        wizardOpen={detailsWizardOpen}
+        onWizardOpenChange={setDetailsWizardOpen}
       />
     );
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2341. `AppPage` keyed the pre-install details view on install state (`if (!state) return <AppDetails/>`). `AppDetails` hosts the install wizard; the wizard's **Install** step flips the reactive install state, so on the next render `AppPage` swapped `AppDetails` out for the installed view, **unmounting the still-open wizard mid-flow** — it "closed silently" right after Install, skipping its integration/Done steps. (The membership-hub and apps-grid launch paths were immune, hence the inconsistency.)

Lifted the wizard-open flag into `AppPage` and kept rendering `AppDetails` while the wizard is open (`!state || detailsWizardOpen`), passing controlled `wizardOpen`/`onWizardOpenChange` down. The page now survives the install transition and the wizard runs through all its steps.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `app-page`/`app-install-wizard`/`apps-grid` UI tests (12, incl. a #2341 regression that fails on the old code) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (lifecycle/prop plumbing only).

## Test plan
Open an app's details page → Install → the wizard advances to its integration/Done steps instead of closing after Install.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

