### PR TITLE
fix(platform): persist agent auth-mode flip in install wizard (#2342)

### DIFF
--- a/services/platform/convex/agents/file_actions.test.ts
+++ b/services/platform/convex/agents/file_actions.test.ts
@@ -34,6 +34,7 @@ vi.mock('../_generated/api', () => ({
       mutations: { cleanupAgentBinding: 'cleanupAgentBinding' },
       internal_queries: { getBindingByAgent: 'getBindingByAgent' },
       installations: { getInstallationInternal: 'getInstallationInternal' },
+      audit_mutations: { logAgentAuditEvent: 'logAgentAuditEvent' },
     },
     organizations: {
       internal_queries: {
@@ -121,7 +122,7 @@ vi.mock('../../lib/shared/schemas/agents', () => ({
 // Import handlers
 // ---------------------------------------------------------------------------
 
-const { deleteAgent, duplicateAgent, restoreFromHistory } =
+const { deleteAgent, duplicateAgent, restoreFromHistory, setAgentAuthMode } =
   await import('./file_actions');
 
 type ActionConfig = {
@@ -131,6 +132,8 @@ type ActionConfig = {
 const deleteHandler = (deleteAgent as unknown as ActionConfig).handler;
 const duplicateHandler = (duplicateAgent as unknown as ActionConfig).handler;
 const restoreHandler = (restoreFromHistory as unknown as ActionConfig).handler;
+const setAuthModeHandler = (setAgentAuthMode as unknown as ActionConfig)
+  .handler;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -586,6 +589,100 @@ describe('restoreFromHistory', () => {
     ).rejects.toMatchObject({
       data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' },
     });
+    expect(mockAtomicWrite).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: setAgentAuthMode
+// ---------------------------------------------------------------------------
+
+describe('setAgentAuthMode', () => {
+  const externalByoConfig = {
+    displayName: 'Desk Implementer',
+    description: 'Runs as Claude Code',
+    primaryBehavior: 'external-agent',
+    agentKind: 'claude-code',
+    authMode: 'byo',
+    // An unresolvable model: `saveAgent` would throw UNKNOWN_MODEL on this,
+    // which is exactly what used to block the flip (#2342).
+    supportedModels: ['openrouter:anthropic/claude-opus-4.6'],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgMembershipById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      member: { _id: 'm-1', role: 'member' },
+    });
+    mockReadJsonFile.mockResolvedValue({
+      ok: true,
+      data: externalByoConfig,
+      hash: 'abc123',
+    });
+    mockAtomicWrite.mockResolvedValue(undefined);
+  });
+
+  it('persists the managed flip even when supportedModels are unresolvable', async () => {
+    // Regression (#2342): the flip must NOT re-validate supportedModels against
+    // the provider catalog — an agent whose declared model the org hasn't
+    // configured still gets its auth mode persisted.
+    const ctx = createMockCtx();
+
+    const result = await setAuthModeHandler(
+      ctx as never,
+      {
+        organizationId: 'org-123',
+        agentName: 'issue-desk/desk-implementer',
+        authMode: 'managed',
+      } as never,
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockAtomicWrite).toHaveBeenCalledTimes(1);
+    const [writtenPath, writtenContent] = mockAtomicWrite.mock.calls[0];
+    expect(writtenPath).toBe('/data/agents/issue-desk/desk-implementer.json');
+    expect(JSON.parse(writtenContent).authMode).toBe('managed');
+  });
+
+  it('is a no-op write when the mode is already set', async () => {
+    const ctx = createMockCtx();
+
+    const result = await setAuthModeHandler(
+      ctx as never,
+      {
+        organizationId: 'org-123',
+        agentName: 'issue-desk/desk-implementer',
+        authMode: 'byo',
+      } as never,
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockAtomicWrite).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-external agent', async () => {
+    mockReadJsonFile.mockResolvedValue({
+      ok: true,
+      data: { ...validConfig, primaryBehavior: 'chat' },
+      hash: 'abc123',
+    });
+    const ctx = createMockCtx();
+
+    await expect(
+      setAuthModeHandler(
+        ctx as never,
+        {
+          organizationId: 'org-123',
+          agentName: 'my-agent',
+          authMode: 'managed',
+        } as never,
+      ),
+    ).rejects.toThrow('authMode only applies to an external-agent.');
     expect(mockAtomicWrite).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -23,7 +23,7 @@ import { isValidAppSlug } from '../../lib/shared/schemas/apps';
 import { parseModelRef } from '../../lib/shared/utils/model-ref';
 import { normalizeAgentConfig } from '../../lib/shared/utils/normalize-agent-config';
 import { resolveAgentLocale } from '../../lib/shared/utils/resolve-agent-locale';
-import { api, internal } from '../_generated/api';
+import { internal } from '../_generated/api';
 import { action, internalAction, type ActionCtx } from '../_generated/server';
 import { listInstalledAppSlugsFromDisk } from '../apps/file_utils';
 import type { SerializableAgentConfig } from '../lib/agent_chat/types';
@@ -426,10 +426,18 @@ export const listAppAgents = action({
 
 /**
  * Flip an external agent's `authMode` (managed ⇄ byo) on the org's copied agent
- * config — the install wizard's per-agent mode choice. Read-modify-write through
- * `saveAgent` so validation, history, and the capability gate all apply; the
- * runtime reads `authMode` straight off this config, so the choice takes effect
- * on the next run.
+ * config — the install wizard's per-agent mode choice. Persists the single
+ * field change with a direct read-modify-write; the runtime reads `authMode`
+ * straight off this config, so the choice takes effect on the next run.
+ *
+ * Deliberately NOT routed through `saveAgent`: that path re-validates
+ * `supportedModels` against the org's provider catalog and throws
+ * (`UNKNOWN_MODEL`) for any declared model the org hasn't configured — a state
+ * that's orthogonal to the credential mode and legitimate for a copied app
+ * agent (BYO treats supportedModels as hints, not a requirement). Coupling the
+ * flip to that check made the wizard's "Managed" choice silently fail to
+ * persist for exactly those agents (#2342). The `authMode` flip is not a
+ * capability change, so no elevated-auth gate applies.
  */
 export const setAgentAuthMode = action({
   args: {
@@ -439,10 +447,8 @@ export const setAgentAuthMode = action({
   },
   returns: v.object({ ok: v.boolean() }),
   handler: async (ctx, args): Promise<{ ok: boolean }> => {
-    const { orgSlug } = await requireOrgMembershipById(
-      ctx,
-      args.organizationId,
-    );
+    const auth = await requireOrgMembershipById(ctx, args.organizationId);
+    const { orgSlug } = auth;
     const read = await readAgentFile(orgSlug, args.agentName);
     if (!read.ok) {
       throw new Error(`Cannot set auth mode: ${read.message}`);
@@ -453,11 +459,27 @@ export const setAgentAuthMode = action({
     if (read.config.authMode === args.authMode) {
       return { ok: true };
     }
-    await ctx.runAction(api.agents.file_actions.saveAgent, {
-      organizationId: args.organizationId,
-      agentName: args.agentName,
-      config: { ...read.config, authMode: args.authMode },
+
+    // Normalize + serialize exactly as `saveAgent` does on write, so the file
+    // stays canonical — minus the model cross-validation the flip must not run.
+    const orgLocale = await ctx.runQuery(
+      internal.organizations.internal_queries.getOrganizationDefaultLocale,
+      { organizationId: args.organizationId },
+    );
+    const normalized = normalizeAgentConfig(
+      { ...read.config, authMode: args.authMode },
+      orgLocale,
+    );
+    const filePath = await resolveAgentPath(orgSlug, args.agentName);
+    await atomicWrite(filePath, serializeAgentJson(normalized));
+    invalidateAgentListCache(orgSlug);
+
+    await logAgentAudit(ctx, auth, 'update_agent', args.agentName, {
+      resourceName: args.agentName,
+      previousState: captureCapability(read.config),
+      newState: captureCapability(normalized),
     });
+
     return { ok: true };
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2342. `setAgentAuthMode` persisted the "Managed" choice by routing a full config write through `saveAgent`, which cross-validates every `supportedModels` entry against the org's provider catalog and throws `UNKNOWN_MODEL`. Agents referencing a model the org hasn't configured (e.g. a copied app agent) therefore had their auth-mode flip silently rejected — the toggle flipped locally but never persisted, and the agent stayed "needs setup" and reverted to BYOK.

An auth-mode flip is orthogonal to model availability, so `setAgentAuthMode` now persists just that field via a direct normalize → serialize → `atomicWrite` (+ cache invalidation + audit log), without the unrelated model cross-validation.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `agents/file_actions.test.ts` (21, incl. a red→green regression: persists the managed flip despite unresolvable models) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (silent-persistence bug; no strings).

## Test plan
On an agent whose `supportedModels` include a model the org hasn't configured, choose "Managed" in the readiness wizard → reopen: it stays Managed instead of reverting to BYOK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

