### PR TITLE
fix(platform): compose doc title suffix from org name (#2373)

### DIFF
--- a/services/platform/app/components/branding/branding-provider.tsx
+++ b/services/platform/app/components/branding/branding-provider.tsx
@@ -12,6 +12,8 @@ import {
 
 import { useBranding } from '@/app/features/settings/branding/hooks/queries';
 import { useActiveOrganizationId } from '@/app/lib/active-organization';
+import { setTitleSuffix } from '@/app/lib/title-suffix';
+import { router } from '@/app/router';
 import { adjustColorForTheme, hexToHsl, isLightColor } from '@/lib/utils/color';
 
 interface BrandingState {
@@ -42,8 +44,6 @@ export function useBrandingContext() {
 interface BrandingProviderProps {
   children: ReactNode;
 }
-
-const DEFAULT_TITLE_SUFFIX = 'Tale';
 
 const CSS_OVERRIDES = ['primary', 'primary-foreground'] as const;
 
@@ -85,39 +85,21 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
 
   const originalFaviconHrefRef = useRef<string | null>(null);
 
-  // App title override
+  // App title suffix: publish the org name to the title-suffix cache so the
+  // route `head`/`seo()` composes "<page> - <org>" at head time. On a hard
+  // reload the cache is seeded synchronously from localStorage, so the correct
+  // suffix already renders on first paint; here we only handle the first time
+  // an org name becomes known (or changes). Sign-out clears the cache so the
+  // logged-out shell falls back to "Tale".
   useEffect(() => {
     const customName = branding?.appName;
-    const targetSuffix = customName || DEFAULT_TITLE_SUFFIX;
-
-    const updateTitle = () => {
-      const title = document.title;
-      const updated = title.replace(/- [^-]+$/, `- ${targetSuffix}`);
-      if (updated !== title) {
-        document.title = updated;
-      }
-    };
-
-    updateTitle();
-
-    const observer = new MutationObserver(updateTitle);
-    const titleElement = document.querySelector('title');
-    if (titleElement) {
-      observer.observe(titleElement, { childList: true });
+    if (!customName) return;
+    if (setTitleSuffix(customName)) {
+      // The head for the current match already ran with the previous suffix
+      // (e.g. the "Tale" fallback on a first-ever login). Re-run heads so the
+      // live document title picks up the org name now that it is known.
+      void router.invalidate();
     }
-
-    return () => {
-      observer.disconnect();
-      if (customName) {
-        const title = document.title;
-        if (title.includes(`- ${customName}`)) {
-          document.title = title.replace(
-            `- ${customName}`,
-            `- ${DEFAULT_TITLE_SUFFIX}`,
-          );
-        }
-      }
-    };
   }, [branding?.appName]);
 
   // Favicon override

--- a/services/platform/app/hooks/use-convex-auth.ts
+++ b/services/platform/app/hooks/use-convex-auth.ts
@@ -1,6 +1,7 @@
 export { useConvexAuth } from 'convex/react';
 
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { clearTitleSuffix } from '@/app/lib/title-suffix';
 import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 
@@ -18,6 +19,10 @@ function useConvexAuthUser() {
 
   const signOut = async () => {
     await authClient.signOut();
+    // Forget the cached org name so the logged-out shell renders "Tale" rather
+    // than the previous org's suffix (the sign-out flows hard-navigate, so the
+    // next document title is composed from a fresh, empty cache).
+    clearTitleSuffix();
   };
 
   return {

--- a/services/platform/app/hooks/use-session-idle-watchdog.tsx
+++ b/services/platform/app/hooks/use-session-idle-watchdog.tsx
@@ -7,6 +7,7 @@ import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { toast } from '@/app/hooks/use-toast';
+import { clearTitleSuffix } from '@/app/lib/title-suffix';
 import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { getEnv } from '@/lib/env';
@@ -175,6 +176,9 @@ export function useSessionIdleWatchdog(): void {
       } catch (err) {
         console.error('[session-idle] sign-out failed', err);
       }
+      // Forget the cached org name so the login page renders "Tale", not the
+      // previous org's title suffix.
+      clearTitleSuffix();
       // Intentional hard navigation (not the router): a full reload tears
       // down the Convex client, React Query cache, and any in-memory auth
       // state on sign-out. Same precedent as user-button and dashboard.tsx.

--- a/services/platform/app/lib/title-suffix.ts
+++ b/services/platform/app/lib/title-suffix.ts
@@ -1,0 +1,65 @@
+const STORAGE_KEY = 'tale:title-suffix';
+
+const isBrowser = typeof window !== 'undefined';
+
+/**
+ * Last-known organization name used as the document-title suffix
+ * (`"<page> - <org>"`), cached so a hard reload can render the correct suffix
+ * on first paint instead of flashing the "Tale" fallback while branding loads.
+ *
+ * The route `head`/`seo()` reads this synchronously at head time;
+ * `BrandingProvider` writes it once the org's branding resolves, and the
+ * sign-out flow clears it so the logged-out shell falls back to "Tale".
+ *
+ * Deliberately a single value (not keyed per org): the common reload stays in
+ * the same org, so the last-known name is the right guess, and a rare
+ * cross-org deep link converges to the correct suffix as soon as that org's
+ * branding loads.
+ */
+function readStored(): string | undefined {
+  if (!isBrowser) return undefined;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) ?? undefined;
+  } catch (error) {
+    console.warn('Failed to read cached title suffix:', error);
+    return undefined;
+  }
+}
+
+let cachedSuffix: string | undefined = readStored();
+
+/** The cached org-name suffix, or `undefined` when none is known. */
+export function getTitleSuffix(): string | undefined {
+  return cachedSuffix;
+}
+
+/**
+ * Cache the org name used as the title suffix (or clear it with `undefined`).
+ * Returns `true` when the value actually changed, so the caller can refresh an
+ * already-rendered title (the head for the current match ran with the previous
+ * suffix — e.g. the "Tale" fallback on a first-ever login).
+ */
+export function setTitleSuffix(name: string | undefined): boolean {
+  const next = name && name.length > 0 ? name : undefined;
+  if (next === cachedSuffix) return false;
+  cachedSuffix = next;
+  if (isBrowser) {
+    try {
+      if (next === undefined) {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, next);
+      }
+    } catch (error) {
+      // Quota / security errors — the in-memory value still applies this
+      // session; only the cross-reload persistence is lost.
+      console.warn('Failed to persist cached title suffix:', error);
+    }
+  }
+  return true;
+}
+
+/** Forget the cached org name so the title falls back to "Tale" (sign-out). */
+export function clearTitleSuffix(): void {
+  setTitleSuffix(undefined);
+}

--- a/services/platform/lib/utils/seo.test.ts
+++ b/services/platform/lib/utils/seo.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const FALLBACK_SUFFIX = 'Tale';
+
+// The metadata i18n lookup is stubbed so the test asserts the suffix-selection
+// logic, not the message bundle: `suffix` returns the static fallback, and
+// `<key>.title` / `<key>.description` echo the key.
+vi.mock('@/lib/i18n/i18n', () => ({
+  i18n: {
+    t: (key: string) => {
+      if (key === 'suffix') return FALLBACK_SUFFIX;
+      if (key === 'chat.title') return 'Chat';
+      if (key === 'chat.description') return 'Chat with AI to get help.';
+      return '';
+    },
+  },
+}));
+
+const getTitleSuffix = vi.fn<() => string | undefined>();
+vi.mock('@/app/lib/title-suffix', () => ({
+  getTitleSuffix: () => getTitleSuffix(),
+}));
+
+const { seo } = await import('./seo');
+
+function titleOf(tags: Array<Record<string, string>>): string | undefined {
+  return tags.find((tag) => 'title' in tag)?.title;
+}
+
+describe('seo', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the cached org name as the title suffix once known', () => {
+    getTitleSuffix.mockReturnValue('QA Guides Org');
+
+    // oxlint-disable-next-line typescript/no-explicit-any -- narrowing the metadata-page key union is irrelevant to this composition test
+    const tags = seo('chat' as any);
+
+    expect(titleOf(tags)).toBe('Chat - QA Guides Org');
+    expect(tags).toContainEqual({
+      name: 'og:title',
+      content: 'Chat - QA Guides Org',
+    });
+  });
+
+  it('falls back to "Tale" when no org name is cached (logged out)', () => {
+    getTitleSuffix.mockReturnValue(undefined);
+
+    // oxlint-disable-next-line typescript/no-explicit-any -- see above
+    const tags = seo('chat' as any);
+
+    expect(titleOf(tags)).toBe(`Chat - ${FALLBACK_SUFFIX}`);
+  });
+});

--- a/services/platform/lib/utils/seo.ts
+++ b/services/platform/lib/utils/seo.ts
@@ -1,3 +1,4 @@
+import { getTitleSuffix } from '@/app/lib/title-suffix';
 import { i18n } from '@/lib/i18n/i18n';
 import type { Messages } from '@/lib/i18n/types';
 
@@ -23,7 +24,12 @@ type MetadataPage = {
  * within the platform (e.g. Slack unfurls in internal channels).
  */
 export function seo(key: MetadataPage) {
-  const suffix = i18n.t('suffix', { ns: 'metadata' });
+  // The title suffix is the active org's name once known (cached across
+  // reloads by `title-suffix`), falling back to the static "Tale" when logged
+  // out or before any org branding has loaded. Composing it here — rather than
+  // patching `document.title` after the fact — means the correct suffix
+  // renders at head time on first paint.
+  const suffix = getTitleSuffix() ?? i18n.t('suffix', { ns: 'metadata' });
   const title = i18n.t(`${key}.title`, { ns: 'metadata' });
   const description = i18n.t(`${key}.description`, { ns: 'metadata' });
   const fullTitle = `${title} - ${suffix}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2373. `seo()` composed `"<title> - <suffix>"` with a static i18n "Tale", and `branding-provider.tsx` post-patched `document.title` via a MutationObserver after branding loaded — so the tab title flashed "- Tale" for ~2s on reload and stayed wrong mid-session before data landed.

Now the suffix is composed at head time: a synchronous `localStorage`-backed cache (`app/lib/title-suffix.ts`, seeded at module load) feeds `seo()` (`getTitleSuffix() ?? t('suffix')`), so reloads render the org name immediately. The MutationObserver is removed; `branding-provider` publishes the name to the cache and calls `router.invalidate()` once only when the name is newly learned/changed. Sign-out clears the cache so logged-out routes keep "Tale". Meets all three acceptance criteria.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new `seo.test.ts` (2) + idle-watchdog/not-found/layout/branding suites (52) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (org name is data; "Tale" fallback unchanged).

## Test plan
Log in as an org with a name, hard-reload a route → the tab title shows the org name with no "- Tale" flash; sign out → titles revert to "Tale".
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

