### PR TITLE
fix(platform): gate agent-editor loader prefetch on auth (#1977)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression coverage for #1977: the `$agentId` loader warms the agent config
+// by calling the Convex action directly (bypassing the auth gate that
+// `useActionQuery` applies to `useReadAgent`). Firing it on a cold load — before
+// the WebSocket auth handshake completes — ran the action unauthenticated and
+// logged a `UNAUTHENTICATED` console Server Error. The loader now gates on the
+// same signal the app's authed queries use: the `getCurrentUser` auth probe
+// having resolved a user into the shared cache.
+
+const { mockUseParams } = vi.hoisted(() => ({
+  mockUseParams: () => ({ id: 'org-1', agentId: 'agent-1' }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    useParams: mockUseParams,
+    ...config,
+  }),
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <a href="/">{children}</a>
+  ),
+  Outlet: () => null,
+}));
+
+// A sentinel query key so the test can assert the loader probes `getCurrentUser`.
+vi.mock('@convex-dev/react-query', () => ({
+  convexQuery: (fn: unknown, args: unknown) => ({
+    queryKey: ['convex-query', fn, args],
+  }),
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: {
+    users: { queries: { getCurrentUser: 'getCurrentUser-ref' } },
+    agents: { file_actions: { readAgent: 'readAgent-ref' } },
+  },
+}));
+
+type LoaderContext = {
+  queryClient: {
+    getQueryData: ReturnType<typeof vi.fn>;
+    prefetchQuery: ReturnType<typeof vi.fn>;
+  };
+  convexQueryClient: { convexClient: { action: ReturnType<typeof vi.fn> } };
+};
+
+// The router mock replaces `createFileRoute`, so `Route` is the plain config
+// object and `Route.loader` is the loader function under test.
+let loader: (args: {
+  context: LoaderContext;
+  params: { id: string; agentId: string };
+}) => void;
+
+function makeContext(currentUser: unknown): LoaderContext {
+  return {
+    queryClient: {
+      getQueryData: vi.fn().mockReturnValue(currentUser),
+      prefetchQuery: vi.fn(),
+    },
+    convexQueryClient: { convexClient: { action: vi.fn() } },
+  };
+}
+
+beforeEach(async () => {
+  const mod = await import('@/app/routes/dashboard/$id/agents/$agentId');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  loader = (mod.Route as any).loader;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('$agentId route loader auth gating (#1977)', () => {
+  it('does not prefetch the agent config before auth is established', () => {
+    // Cold load / reload: the getCurrentUser auth probe has not resolved yet,
+    // so its cache entry is empty. The loader must skip the direct action call
+    // so no UNAUTHENTICATED error is thrown/logged; the auth-gated useReadAgent
+    // hook fetches once the handshake completes.
+    const context = makeContext(undefined);
+
+    loader({ context, params: { id: 'org-1', agentId: 'agent-1' } });
+
+    expect(context.queryClient.getQueryData).toHaveBeenCalledWith([
+      'convex-query',
+      'getCurrentUser-ref',
+      {},
+    ]);
+    expect(context.queryClient.prefetchQuery).not.toHaveBeenCalled();
+  });
+
+  it('prefetches the agent config once authenticated (warm hover preload)', () => {
+    // In-app row-hover preload: the getCurrentUser probe has resolved a user
+    // into the cache, so the WebSocket is authenticated and the warm prefetch
+    // may fire.
+    const context = makeContext({ _id: 'user-1' });
+
+    loader({ context, params: { id: 'org-1', agentId: 'agent-1' } });
+
+    expect(context.queryClient.prefetchQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -1,3 +1,4 @@
+import { convexQuery } from '@convex-dev/react-query';
 import { Heading } from '@tale/ui/heading';
 import { Stack } from '@tale/ui/layout';
 import { SkeletonBox, SkeletonText } from '@tale/ui/skeleton';
@@ -34,6 +35,19 @@ export const Route = createFileRoute('/dashboard/$id/agents/$agentId')({
   }),
   loader: ({ context, params }) => {
     const { id: organizationId, agentId: agentName } = params;
+    // This warm calls the Convex action directly, bypassing the auth gate that
+    // useActionQuery applies to useReadAgent. On a cold load / reload the loader
+    // runs before the WebSocket auth handshake completes, so firing it then ran
+    // the action unauthenticated → a thrown `UNAUTHENTICATED` ConvexError logged
+    // as a console Server Error on every cold entry. Gate on the same signal the
+    // app's authed queries use — the getCurrentUser auth probe having resolved a
+    // user into the shared cache — so the row-hover preload (already in-app and
+    // authenticated) still warms the config, while a cold load defers to the
+    // auth-gated useReadAgent hook, which fetches the moment auth is ready.
+    const isAuthenticated = !!context.queryClient.getQueryData(
+      convexQuery(api.users.queries.getCurrentUser, {}).queryKey,
+    );
+    if (!isAuthenticated) return;
     // Warm the agent config (filesystem-backed action) so the detail paints
     // without a skeleton — also runs on the agents list's row-hover preload.
     // Mirrors useReadAgent's key + args so the component reads it warm.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1977. The agent-editor route loader warmed the agent config by calling the `readAgent` Convex action directly, bypassing the auth gate every React-hook query uses (`useReadAgent` → `enabled: isAuthenticated`). With `defaultPreload: 'intent'`, the loader ran before the Convex auth handshake completed on cold-load/reload, so the server threw `UNAUTHENTICATED` and logged a console Server Error.

The loader now gates the prefetch on the same signal the app's authed queries use — the `getCurrentUser` probe having resolved into the query cache. Pre-auth (cold load) it skips and defers to the auth-gated hook (which fetches the moment auth is ready); when already authenticated (in-app hover preload) the warm prefetch fires as before. Genuine auth errors are not swallowed — the pre-auth call simply never happens.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new `$agentId.test.tsx` (2: skips + probes when unauthenticated, fires once when authenticated) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (loader logic).

## Test plan
Hard-reload an agent-editor route (`/dashboard/{org}/agents/{id}/…`) → no `UNAUTHENTICATED` console Server Error; the editor still loads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

