### PR TITLE
fix(platform): block send on client when budget exceeded (#2345)

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input.test.tsx
@@ -40,9 +40,16 @@ vi.mock('./documents-mention-source', () => ({
 // production; render it (and its overlay) as plain passthroughs here.
 vi.mock('@/app/components/ui/forms/file-upload', () => ({
   FileUpload: {
+    Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
     DropZone: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     Overlay: () => null,
   },
+}));
+
+// The send-gate tests below assert a blocked Enter toasts instead of sending.
+const mockToast = vi.fn();
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
 }));
 
 // Actor source that never matches — reproduces the "No matches" empty state.
@@ -95,5 +102,68 @@ describe('ChatInput @-mention keyboard handling', () => {
     await user.keyboard('{Enter}');
     expect(onSendMessage).toHaveBeenCalledTimes(1);
     expect(onSendMessage).toHaveBeenCalledWith('@zzzz', undefined, undefined);
+  });
+});
+
+const BUDGET_REASON = 'Your usage limit has been reached for this period.';
+
+function renderInput(overrides?: Partial<Parameters<typeof ChatInput>[0]>) {
+  const onSendMessage = vi.fn();
+  const utils = render(
+    <ChatInput
+      organizationId="org-1"
+      value="over-budget message"
+      onChange={vi.fn()}
+      onSendMessage={onSendMessage}
+      attachments={[]}
+      uploadingFiles={[]}
+      uploadFiles={vi.fn()}
+      removeAttachment={vi.fn()}
+      clearAttachments={vi.fn(() => [])}
+      variant="assistant"
+      sendBlocked
+      sendBlockedReason={BUDGET_REASON}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onSendMessage };
+}
+
+// #2345 regression: budget enforcement used to be server-side only, so the
+// composer left Send enabled and pressing Enter was a silent no-op. The client
+// now feeds the budget-exceeded state into ChatInput's `sendBlocked`/
+// `sendBlockedReason` gate (chat-interface).
+describe('ChatInput send gate', () => {
+  it('states the block reason and disables Send when sendBlocked', () => {
+    renderInput();
+
+    expect(screen.getByRole('status')).toHaveTextContent(BUDGET_REASON);
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+
+  it('turns a keyboard Enter into a toast instead of sending', async () => {
+    mockToast.mockClear();
+    const { user, onSendMessage } = renderInput();
+
+    await user.click(screen.getByRole('textbox'));
+    await user.keyboard('{Enter}');
+
+    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      title: BUDGET_REASON,
+      variant: 'destructive',
+    });
+  });
+
+  it('sends normally once the block clears', async () => {
+    const { user, onSendMessage } = renderInput({
+      sendBlocked: false,
+      sendBlockedReason: undefined,
+    });
+
+    await user.click(screen.getByRole('textbox'));
+    await user.keyboard('{Enter}');
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -30,7 +30,10 @@ import { lazyComponent } from '@/lib/utils/lazy-component';
 import { stripModelRefQualifier } from '../../../../lib/shared/utils/model-ref';
 import { useDeletePrompt } from '../../prompts/hooks/mutations';
 import { useSavedSourceMessageIds } from '../../prompts/hooks/queries';
-import { useMyFeatureFlags } from '../../settings/governance/hooks/queries';
+import {
+  useMyBudgetStatus,
+  useMyFeatureFlags,
+} from '../../settings/governance/hooks/queries';
 import { useListProviders } from '../../settings/providers/hooks/queries';
 import { useBranchContext } from '../context/branch-context';
 import { useChatLayout } from '../context/chat-layout-context';
@@ -718,6 +721,19 @@ export function ChatInterface({
 
   const userContext = useUserContext();
   const teamFilter = useOptionalTeamFilter();
+
+  // Client-side budget gate. The server enforces the budget authoritatively
+  // (a refused turn), but without this the composer left Send enabled and the
+  // user only learned they were over budget after the message landed as an
+  // inline turn error (#2345). Reuse the same query the BudgetBanner and the
+  // server use; `exceeded` is team-independent (checkBudget always spans all
+  // teams for hard blocks), so send is blocked whatever team is selected.
+  // Loading returns `undefined` → the gate stays false, never a false block.
+  const { data: budgetStatus } = useMyBudgetStatus(
+    organizationId,
+    teamFilter?.selectedTeamId,
+  );
+  const budgetExceeded = budgetStatus?.exceeded === true;
 
   // Projects feature: when the chat was opened from a project's "New
   // chat in this project" CTA, the projectId is passed as a URL search
@@ -1444,6 +1460,7 @@ export function ChatInterface({
                   cancelVideoJob={cancelVideoJob}
                   retryVideoJob={retryVideoJob}
                   sendBlocked={
+                    budgetExceeded ||
                     (isImageGenAgent &&
                       !!activeEditingImage &&
                       !currentModelSupportsEdit) ||
@@ -1451,15 +1468,17 @@ export function ChatInterface({
                     noProviderHasApiKey
                   }
                   sendBlockedReason={
-                    isImageGenAgent &&
-                    !!activeEditingImage &&
-                    !currentModelSupportsEdit
-                      ? t('imageEdit.modelCannotEdit')
-                      : activeModelMissingApiKey
-                        ? t('modelSelector.noApiKey')
-                        : noProviderHasApiKey
-                          ? t('modelSelector.noProviderKey')
-                          : undefined
+                    budgetExceeded
+                      ? t('budgetExceededDefault')
+                      : isImageGenAgent &&
+                          !!activeEditingImage &&
+                          !currentModelSupportsEdit
+                        ? t('imageEdit.modelCannotEdit')
+                        : activeModelMissingApiKey
+                          ? t('modelSelector.noApiKey')
+                          : noProviderHasApiKey
+                            ? t('modelSelector.noProviderKey')
+                            : undefined
                   }
                   onSavePrompt={(content) =>
                     setSavePromptData({ messageId: '', content })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2345. Budget enforcement was server-side only, so the composer's Send stayed enabled and the budget-exceeded toast never fired client-side — the refusal only showed up as an inline turn error after sending. Added an additive client guard in `chat-interface.tsx` that reads the same `useMyBudgetStatus` query the budget banner/server use and OR-s `exceeded` into the existing `sendBlocked`/`sendBlockedReason` mechanism. Send now disables with a visible reason, and a keyboard Enter fires the destructive toast instead of silently dispatching. Server enforcement is unchanged; loading state never falsely blocks.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new `chat-input.test.tsx` (3, first coverage of the composer send-gate) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (reuses existing `chat.budgetExceededDefault`).

## Test plan
Exceed the org/team budget → the composer Send is disabled with a reason and Enter shows the budget toast; once usage resets, Send re-enables.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

