### PR TITLE
fix(platform): stop data notice flash during policy load (#2376)

### DIFF
--- a/services/platform/app/features/governance/components/data-notice-footer.test.tsx
+++ b/services/platform/app/features/governance/components/data-notice-footer.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { DataNoticeFooter } from './data-notice-footer';
+
+// Drives the mocked `useConvexQuery` return. `undefined` data models the
+// loading (or skipped) state; `null` models a resolved read with no stored
+// policy row; an object models a resolved policy.
+const { state } = vi.hoisted(() => ({
+  state: { data: undefined as unknown },
+}));
+
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => ({ data: state.data }),
+}));
+
+function noticeEl() {
+  return screen.queryByRole('note', { name: /confidentiality notice/i });
+}
+
+describe('DataNoticeFooter', () => {
+  it('renders nothing while the policy query is loading (#2376)', () => {
+    // Regression: defaulting to enabled during load caused a show→hide flash
+    // for orgs whose stored policy resolves to disabled.
+    state.data = undefined;
+    render(<DataNoticeFooter organizationId="org-1" />);
+    expect(noticeEl()).not.toBeInTheDocument();
+  });
+
+  it('renders the notice for an org with no stored policy (product default on)', () => {
+    state.data = null;
+    render(<DataNoticeFooter organizationId="org-1" />);
+    expect(noticeEl()).toBeInTheDocument();
+  });
+
+  it('renders the notice when the resolved policy enables it', () => {
+    state.data = { config: { enabled: true } };
+    render(<DataNoticeFooter organizationId="org-1" />);
+    expect(noticeEl()).toBeInTheDocument();
+  });
+
+  it('renders nothing when the resolved policy disables it — stable, no flash', () => {
+    state.data = { config: { enabled: false } };
+    render(<DataNoticeFooter organizationId="org-1" />);
+    expect(noticeEl()).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/governance/hooks/use-data-classification-notice.ts
+++ b/services/platform/app/features/governance/hooks/use-data-classification-notice.ts
@@ -60,9 +60,17 @@ export function useDataClassificationNotice(
     'Treat this chat as you would email — avoid customer data, credentials, and unreleased information.',
   );
 
-  if (policy?.data === undefined) {
+  // While the query is loading (`data === undefined`) or skipped (no org),
+  // render nothing. Defaulting to `enabled: true` during load caused a
+  // show→hide flash for orgs whose stored policy resolves to disabled: the
+  // notice appeared on the loading default, then vanished once the real
+  // config arrived. Once the policy resolves, a missing row (`data === null`)
+  // falls through to the product default (on) below, so a never-configured
+  // org still gets a stable notice — it just appears when the data lands
+  // rather than flashing in and out.
+  if (policy.data === undefined) {
     return {
-      enabled: organizationId !== undefined,
+      enabled: false,
       message: fallback,
     };
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2376. `use-data-classification-notice` defaulted `enabled: true` while the `getPolicy` query was loading, so an org that resolves to disabled showed the "AI can make mistakes" notice for ~300ms then hid it (a show→hide flash). The hook now returns `enabled: false` while loading/skipped, so nothing renders until the real config lands. The product default is confirmed "on unless explicitly disabled" (the resolved path and a missing policy row both default to `true`, matching the sibling `voice_output` policy), so the two states now agree — no schema/seed change needed.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new `data-notice-footer` test (4: loading→hidden regression, no-policy→visible, resolved on/off) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (render-timing only).

## Test plan
Reload a chat page for an org with the notice disabled → no flash; for an org that never touched governance → the notice shows stably (product default on).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

