### PR TITLE
feat(platform): delete uploaded apps and badge them as private (#2355)

### DIFF
--- a/services/platform/app/features/apps/components/app-delete-action.tsx
+++ b/services/platform/app/features/apps/components/app-delete-action.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+/** Delete a private (uploaded) app's bundle (⋯ menu → confirm).
+ *
+ * Only offered for uploaded apps that are NOT built-in and NOT currently
+ * installed — for an installed app the ⋯ menu shows Reinstall/Uninstall
+ * ({@link AppLifecycleActions}) instead, and the server refuses a built-in slug
+ * or an active install. Removes the org's `apps/<slug>/` dir for good. */
+import { ConvexError } from 'convex/values';
+import { Trash2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
+import {
+  EntityRowActions,
+  useEntityRowDialogs,
+} from '@/app/components/ui/entity/entity-row-actions';
+import { toast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
+
+import { useDeleteApp } from '../hooks/upload-mutations';
+
+interface AppDeleteActionProps {
+  appSlug: string;
+  appName: string;
+  organizationId: string;
+  /** Extra classes for the ⋯ trigger (e.g. card overlay positioning). */
+  triggerClassName?: string;
+  /** Called after a successful delete (e.g. to navigate away from the page). */
+  onDeleted?: () => void;
+}
+
+export function AppDeleteAction({
+  appSlug,
+  appName,
+  organizationId,
+  triggerClassName,
+  onDeleted,
+}: AppDeleteActionProps) {
+  const { t } = useT('apps');
+  const deleteApp = useDeleteApp();
+  const dialogs = useEntityRowDialogs(['delete']);
+  const [busy, setBusy] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await deleteApp.mutateAsync({ organizationId, slug: appSlug });
+      toast({ title: t('upload.deleteSuccess'), variant: 'success' });
+      dialogs.setOpen.delete(false);
+      onDeleted?.();
+    } catch (error) {
+      // The server refuses while the app is still installed — point the operator
+      // at Uninstall first rather than a generic failure.
+      const data = error instanceof ConvexError ? error.data : undefined;
+      const code =
+        data && typeof data === 'object' && 'code' in data
+          ? data.code
+          : undefined;
+      toast({
+        title:
+          code === 'APP_INSTALLED'
+            ? t('upload.deleteInstalledBlocked')
+            : t('upload.deleteFailed'),
+        variant: 'destructive',
+      });
+      if (code !== 'APP_INSTALLED') console.error(error);
+      dialogs.setOpen.delete(false);
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, deleteApp, organizationId, appSlug, t, dialogs, onDeleted]);
+
+  return (
+    <>
+      <EntityRowActions
+        actions={[
+          {
+            key: 'delete',
+            label: t('upload.delete'),
+            icon: Trash2,
+            destructive: true,
+            onClick: () => dialogs.open.delete(),
+          },
+        ]}
+        ariaLabel={t('upload.deleteMenuLabel', { name: appName })}
+        triggerClassName={triggerClassName}
+        disabled={busy}
+      />
+
+      <DeleteDialog
+        open={dialogs.isOpen.delete}
+        onOpenChange={dialogs.setOpen.delete}
+        title={t('upload.deleteTitle')}
+        description={t('upload.deleteDescription')}
+        preview={{ primary: appName }}
+        warning={t('upload.deleteWarning')}
+        deleteText={t('upload.delete')}
+        isDeleting={busy}
+        onDelete={() => void handleDelete()}
+      />
+    </>
+  );
+}

--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -25,7 +25,7 @@ import { Grid, HStack, Row, VStack } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Tabs } from '@tale/ui/tabs';
 import { Text } from '@tale/ui/text';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { LayoutGrid, Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -53,6 +53,7 @@ import { AppView } from '../registry/app-view';
 import { AppRuntimeProvider, resolvePackLabel } from '../runtime/app-runtime';
 import { ResourceDetailProvider } from '../runtime/resource-detail';
 import { AppConfigDrawer } from './app-config-drawer';
+import { AppDeleteAction } from './app-delete-action';
 import { AppLifecycleActions } from './app-lifecycle-actions';
 import { AppInstallWizard } from './install-wizard/app-install-wizard';
 
@@ -583,6 +584,7 @@ function AppDetails({
   labels,
   wizardOpen,
   onWizardOpenChange,
+  isPrivate,
 }: {
   organizationId: string;
   appSlug: string;
@@ -594,8 +596,12 @@ function AppDetails({
   // while the wizard is open, so the flow reaches its integration/Done steps.
   wizardOpen: boolean;
   onWizardOpenChange: (open: boolean) => void;
+  /** A private (uploaded) app — earns a "Private" badge and a Delete affordance
+   *  (built-in catalog apps have neither). */
+  isPrivate: boolean;
 }) {
   const { t } = useT('apps');
+  const navigate = useNavigate();
   const { install, isPending } = useAppInstallActions(organizationId);
   const needsWizard =
     app.scope === 'project' || app.requiredIntegrations.length > 0;
@@ -637,7 +643,7 @@ function AppDetails({
             <Text as="span" className="text-xl font-semibold">
               {app.name}
             </Text>
-            <div>
+            <HStack gap={2} className="flex-wrap items-center">
               <Badge variant="slate">
                 {t(
                   app.scope === 'project'
@@ -645,22 +651,38 @@ function AppDetails({
                     : 'details.scopeOrg',
                 )}
               </Badge>
-            </div>
+              {isPrivate && <Badge variant="outline">{t('private')}</Badge>}
+            </HStack>
           </VStack>
         </HStack>
-        <Button
-          disabled={isPending}
-          onClick={() =>
-            needsWizard
-              ? onWizardOpenChange(true)
-              : notifyOnInstallFailure(
-                  install(appSlug),
-                  t('install.installFailed'),
-                )
-          }
-        >
-          {t('install.install')}
-        </Button>
+        <HStack gap={2} className="shrink-0 items-center">
+          <Button
+            disabled={isPending}
+            onClick={() =>
+              needsWizard
+                ? onWizardOpenChange(true)
+                : notifyOnInstallFailure(
+                    install(appSlug),
+                    t('install.installFailed'),
+                  )
+            }
+          >
+            {t('install.install')}
+          </Button>
+          {isPrivate && (
+            <AppDeleteAction
+              appSlug={appSlug}
+              appName={app.name}
+              organizationId={organizationId}
+              onDeleted={() =>
+                void navigate({
+                  to: '/dashboard/$id/apps',
+                  params: { id: organizationId },
+                })
+              }
+            />
+          )}
+        </HStack>
       </HStack>
 
       <Text variant="muted">
@@ -748,6 +770,11 @@ export function AppPage({
     apps.find((a) => a.slug === appSlug) ??
     catalog.find((a) => a.slug === appSlug);
   const state = bySlug.get(appSlug);
+  // Private (uploaded) apps live in the org dir but not the built-in catalog —
+  // the deletable, badge-worthy kind (mirrors the union in apps-grid.tsx).
+  const isPrivate =
+    apps.some((a) => a.slug === appSlug) &&
+    !catalog.some((a) => a.slug === appSlug);
   const { bindings } = useAppBindings(organizationId, appSlug);
   // Owned here (not in AppDetails) so the pre-install details page survives the
   // install: the wizard's Install step flips `state`, which would otherwise
@@ -817,6 +844,7 @@ export function AppPage({
         labels={labels}
         wizardOpen={detailsWizardOpen}
         onWizardOpenChange={setDetailsWizardOpen}
+        isPrivate={isPrivate}
       />
     );
   }

--- a/services/platform/app/features/apps/components/apps-grid.test.tsx
+++ b/services/platform/app/features/apps/components/apps-grid.test.tsx
@@ -34,6 +34,13 @@ vi.mock('../hooks/use-install-state', () => ({
   useAppInstallActions: () => ({ install: vi.fn(), isPending: false }),
 }));
 
+// The delete affordance's mutation hook needs a Convex client the test harness
+// doesn't provide — stub it (the behaviour under test is which cards render the
+// Private badge + Delete menu, not the delete call itself).
+vi.mock('../hooks/upload-mutations', () => ({
+  useDeleteApp: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
 // Render the card Link as a plain anchor (no router needed); aria-label carries
 // the app name so we can assert the rendered set and its order.
 vi.mock('@tanstack/react-router', () => ({
@@ -149,6 +156,33 @@ describe('AppsGrid catalog/installed union (#1979)', () => {
     expect(screen.getByText('Installed Shared')).toBeInTheDocument();
     expect(screen.getByText('From the org install.')).toBeInTheDocument();
     expect(screen.queryByText('Catalog Shared')).not.toBeInTheDocument();
+  });
+
+  // #2355: a private (uploaded) app lives in the org install list but not the
+  // built-in catalog. It must be distinguishable (a "Private" badge) and
+  // deletable (a Delete ⋯ menu) — a built-in catalog card gets neither.
+  it('badges + offers Delete only for a private (uploaded) app', () => {
+    useAppsMock.mockReturnValue({
+      apps: [app({ slug: 'my-upload', name: 'My Upload' })],
+      isLoading: false,
+      error: null,
+    });
+    useAppCatalogMock.mockReturnValue({
+      apps: [app({ slug: 'builtin', name: 'Builtin App' })],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AppsGrid organizationId="org_1" />);
+
+    // Exactly one Private badge — on the uploaded app, not the built-in one.
+    expect(screen.getByText('Private')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete My Upload' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete Builtin App' }),
+    ).not.toBeInTheDocument();
   });
 
   it('sorts the union by name', () => {

--- a/services/platform/app/features/apps/components/apps-grid.tsx
+++ b/services/platform/app/features/apps/components/apps-grid.tsx
@@ -31,6 +31,7 @@ import {
   useAppInstallActions,
   useAppInstallStates,
 } from '../hooks/use-install-state';
+import { AppDeleteAction } from './app-delete-action';
 import { AppLifecycleActions } from './app-lifecycle-actions';
 import { AppInstallWizard } from './install-wizard/app-install-wizard';
 
@@ -111,6 +112,14 @@ export function AppsGrid({
       a.name.localeCompare(b.name),
     );
   }, [installed, catalog]);
+  // A private (uploaded) app lives in the org's apps dir but not the built-in
+  // catalog. It's the only kind the UI offers a Delete for (the server refuses
+  // any built-in slug regardless), and it earns a "Private" badge so it's
+  // distinguishable from a built-in card sharing the same display name.
+  const catalogSlugs = useMemo(
+    () => new Set(catalog.map((a) => a.slug)),
+    [catalog],
+  );
   const { bySlug } = useAppInstallStates(organizationId);
   const { install, isPending } = useAppInstallActions(organizationId);
   // The app whose install wizard is open. Project-scoped apps (need a target
@@ -186,6 +195,7 @@ export function AppsGrid({
         <CatalogGrid>
           {filteredApps.map((app) => {
             const state = bySlug.get(app.slug);
+            const isPrivate = !catalogSlugs.has(app.slug);
             return (
               <CatalogCard
                 key={app.slug}
@@ -196,7 +206,12 @@ export function AppsGrid({
                 }
                 title={app.name}
                 description={app.description}
-                badge={<InstallBadge state={state} />}
+                badge={
+                  <>
+                    {isPrivate && <Badge variant="slate">{t('private')}</Badge>}
+                    <InstallBadge state={state} />
+                  </>
+                }
                 actions={
                   state ? (
                     <>
@@ -222,20 +237,31 @@ export function AppsGrid({
                       </div>
                     </>
                   ) : (
-                    <Button
-                      disabled={isPending}
-                      onClick={() =>
-                        app.scope === 'project' ||
-                        app.requiredIntegrations.length > 0
-                          ? setWizardApp(app)
-                          : notifyOnInstallFailure(
-                              install(app.slug),
-                              t('install.installFailed'),
-                            )
-                      }
-                    >
-                      {t('install.install')}
-                    </Button>
+                    <>
+                      <Button
+                        disabled={isPending}
+                        onClick={() =>
+                          app.scope === 'project' ||
+                          app.requiredIntegrations.length > 0
+                            ? setWizardApp(app)
+                            : notifyOnInstallFailure(
+                                install(app.slug),
+                                t('install.installFailed'),
+                              )
+                        }
+                      >
+                        {t('install.install')}
+                      </Button>
+                      {isPrivate && (
+                        <div className="ml-auto">
+                          <AppDeleteAction
+                            appSlug={app.slug}
+                            appName={app.name}
+                            organizationId={organizationId}
+                          />
+                        </div>
+                      )}
+                    </>
                   )
                 }
               />

--- a/services/platform/app/features/apps/hooks/upload-mutations.ts
+++ b/services/platform/app/features/apps/hooks/upload-mutations.ts
@@ -29,3 +29,16 @@ export function useUploadAppBundle() {
     onSuccess: (_data, variables) => invalidate(variables.organizationId),
   });
 }
+
+/**
+ * Delete a private (uploaded) app's on-disk bundle. The server refuses a
+ * built-in slug or an app with an active install (uninstall it first), so this
+ * is only offered on uploaded, not-installed apps. Invalidates the hub list so
+ * the deleted card drops out.
+ */
+export function useDeleteApp() {
+  const invalidate = useInvalidateApps();
+  return useConvexAction(api.apps.upload_actions.deleteApp, {
+    onSuccess: (_data, variables) => invalidate(variables.organizationId),
+  });
+}

--- a/services/platform/convex/apps/upload_actions.test.ts
+++ b/services/platform/convex/apps/upload_actions.test.ts
@@ -1,0 +1,155 @@
+import { rm } from 'node:fs/promises';
+
+import { ConvexError } from 'convex/values';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// `deleteApp` (#2355) guards, in isolation. The action is `'use node'` and pulls
+// in the fs resolvers + the built-in-catalog probe + the developer-settings
+// gate; all are mocked so each test exercises exactly one branch and asserts the
+// destructive `rm` fires only on the allowed path.
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+}));
+
+vi.mock('../_generated/api', () => ({
+  internal: {
+    apps: {
+      upload_mutations: {
+        verifyAppUploadIntent: 'verifyAppUploadIntent',
+        deleteAppUploadIntent: 'deleteAppUploadIntent',
+        claimAppUploadSlot: 'claimAppUploadSlot',
+        releaseAppUploadSlot: 'releaseAppUploadSlot',
+      },
+      install_mutations: {
+        getAppInstallationInternal: 'getAppInstallationInternal',
+      },
+    },
+  },
+}));
+
+const mockRequireOrgAdminOrDeveloper = vi.fn();
+vi.mock('../lib/auth/require_org_admin_or_developer', () => ({
+  requireOrgAdminOrDeveloper: (...args: unknown[]) =>
+    mockRequireOrgAdminOrDeveloper(...args),
+}));
+
+const mockAppExistsInBuiltinCatalog = vi.fn();
+vi.mock('./install_fs', () => ({
+  appExistsInBuiltinCatalog: (...args: unknown[]) =>
+    mockAppExistsInBuiltinCatalog(...args),
+}));
+
+const mockReadFileSafe = vi.fn();
+vi.mock('../lib/file_io', () => ({
+  atomicWriteBuffer: vi.fn(),
+  readFileSafe: (...args: unknown[]) => mockReadFileSafe(...args),
+  verifyPathWithinBase: vi.fn(),
+}));
+
+vi.mock('./file_utils', () => ({
+  resolveAppDir: (orgSlug: string, slug: string) =>
+    `/cfg/${orgSlug}/apps/${slug}`,
+  resolveAppManifestPath: (orgSlug: string, slug: string) =>
+    `/cfg/${orgSlug}/apps/${slug}/app.json`,
+  resolveAppsDir: (orgSlug: string) => `/cfg/${orgSlug}/apps`,
+}));
+
+vi.mock('./bundle_parse', () => ({ parseAppBundleZip: vi.fn() }));
+
+const { deleteApp } = await import('./upload_actions');
+
+type ActionConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+const deleteHandler = (deleteApp as unknown as ActionConfig).handler;
+
+function createMockCtx(installRecord: unknown = null) {
+  return { runQuery: vi.fn().mockResolvedValue(installRecord) } as never;
+}
+
+async function catchError(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => {
+      throw new Error('expected the handler to reject');
+    },
+    (err) => err,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireOrgAdminOrDeveloper.mockResolvedValue({ orgSlug: 'acme' });
+});
+
+describe('apps/upload_actions deleteApp (#2355)', () => {
+  it('rejects an invalid slug before touching auth or the filesystem', async () => {
+    const err = (await catchError(
+      deleteHandler(createMockCtx(), {
+        organizationId: 'org',
+        slug: '../evil',
+      } as never),
+    )) as ConvexError<{ code: string }>;
+    expect(err).toBeInstanceOf(ConvexError);
+    expect(err.data.code).toBe('INVALID_SLUG');
+    expect(mockRequireOrgAdminOrDeveloper).not.toHaveBeenCalled();
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('refuses to delete a built-in catalog app', async () => {
+    mockAppExistsInBuiltinCatalog.mockResolvedValue(true);
+    const err = (await catchError(
+      deleteHandler(createMockCtx(), {
+        organizationId: 'org',
+        slug: 'issue-desk',
+      } as never),
+    )) as ConvexError<{ code: string }>;
+    expect(err.data.code).toBe('APP_IS_BUILTIN');
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('refuses while an install record still exists', async () => {
+    mockAppExistsInBuiltinCatalog.mockResolvedValue(false);
+    const err = (await catchError(
+      deleteHandler(createMockCtx({ appSlug: 'my-upload' }), {
+        organizationId: 'org',
+        slug: 'my-upload',
+      } as never),
+    )) as ConvexError<{ code: string }>;
+    expect(err.data.code).toBe('APP_INSTALLED');
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('removes the org app dir for a private, not-installed app', async () => {
+    mockAppExistsInBuiltinCatalog.mockResolvedValue(false);
+    mockReadFileSafe.mockResolvedValue('{"name":"X"}');
+    const result = await deleteHandler(createMockCtx(null), {
+      organizationId: 'org',
+      slug: 'my-upload',
+    } as never);
+    expect(result).toEqual({ deleted: true });
+    expect(rm).toHaveBeenCalledWith('/cfg/acme/apps/my-upload', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('is a no-op when no bundle is on disk', async () => {
+    mockAppExistsInBuiltinCatalog.mockResolvedValue(false);
+    mockReadFileSafe.mockResolvedValue(null);
+    const result = await deleteHandler(createMockCtx(null), {
+      organizationId: 'org',
+      slug: 'my-upload',
+    } as never);
+    expect(result).toEqual({ deleted: false });
+    expect(rm).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/apps/upload_actions.ts
+++ b/services/platform/convex/apps/upload_actions.ts
@@ -29,7 +29,10 @@ import path from 'node:path';
 
 import { ConvexError, v } from 'convex/values';
 
-import { MAX_APP_BUNDLE_TOTAL_BYTES } from '../../lib/shared/schemas/apps';
+import {
+  isValidAppSlug,
+  MAX_APP_BUNDLE_TOTAL_BYTES,
+} from '../../lib/shared/schemas/apps';
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import { action, type ActionCtx } from '../_generated/server';
@@ -238,5 +241,70 @@ export const uploadAppBundle = action({
     }
 
     return { ok: true as const, slug: parsed.slug };
+  },
+});
+
+/**
+ * Delete a PRIVATE (uploaded) app's on-disk bundle — the inverse of
+ * `uploadAppBundle`. Removes `<config>/<org>/apps/<slug>/` so the app leaves the
+ * Apps hub for good. Two guards keep it safe:
+ *
+ *   1. A first-party BUILT-IN app can never be deleted here — the catalog is
+ *      read-only, and its dir doesn't even live under the org (this is a no-op
+ *      on disk, but we refuse loudly so the UI never offers it).
+ *   2. An app with an active install record is refused (`APP_INSTALLED`): deleting
+ *      the bundle out from under a live install would orphan its agent/workflow
+ *      rows, schedules, and env/secrets. Uninstall first (which, for a private
+ *      app, keeps the bundle on disk), then delete.
+ *
+ * Idempotent: a slug with no bundle on disk returns `{ deleted: false }`.
+ */
+export const deleteApp = action({
+  args: {
+    organizationId: v.string(),
+    slug: v.string(),
+  },
+  returns: v.object({ deleted: v.boolean() }),
+  handler: async (ctx, args): Promise<{ deleted: boolean }> => {
+    if (!isValidAppSlug(args.slug)) {
+      throw new ConvexError({
+        code: 'INVALID_SLUG',
+        message: `Invalid app slug: ${args.slug}`,
+      });
+    }
+    // Same gate as upload (developer-settings capability): whoever can upload a
+    // private app can remove it.
+    const auth = await requireOrgAdminOrDeveloper(ctx, args.organizationId);
+
+    if (await appExistsInBuiltinCatalog(args.slug)) {
+      throw new ConvexError({
+        code: 'APP_IS_BUILTIN',
+        message: `"${args.slug}" is a built-in app and cannot be deleted.`,
+      });
+    }
+
+    const record = await ctx.runQuery(
+      internal.apps.install_mutations.getAppInstallationInternal,
+      { organizationId: args.organizationId, appSlug: args.slug },
+    );
+    if (record) {
+      throw new ConvexError({
+        code: 'APP_INSTALLED',
+        message: `Uninstall "${args.slug}" before deleting its upload.`,
+      });
+    }
+
+    // No manifest on disk → nothing to delete (the app was never uploaded here,
+    // or was already removed). Report a no-op rather than a spurious success.
+    const manifest = await readFileSafe(
+      resolveAppManifestPath(auth.orgSlug, args.slug),
+    );
+    if (manifest === null) return { deleted: false };
+
+    await rm(resolveAppDir(auth.orgSlug, args.slug), {
+      recursive: true,
+      force: true,
+    });
+    return { deleted: true };
   },
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6,6 +6,7 @@
     "addMenu": {
       "label": "App hinzufügen"
     },
+    "private": "Privat",
     "upload": {
       "uploadApp": "App hochladen",
       "dialogTitle": "Private App hochladen",
@@ -36,7 +37,15 @@
       "uploadFailed": "App konnte nicht hochgeladen werden",
       "replaceTitle": "Bestehende App ersetzen?",
       "replaceDescription": "Eine private App namens „{slug}“ existiert bereits. Beim Hochladen wird ihr aktueller Inhalt überschrieben.",
-      "replaceConfirm": "Ersetzen"
+      "replaceConfirm": "Ersetzen",
+      "delete": "Hochgeladene App löschen",
+      "deleteMenuLabel": "{name} löschen",
+      "deleteTitle": "Hochgeladene App löschen",
+      "deleteDescription": "Entfernt die hochgeladene App und ihre Dateien aus dieser Organisation. Integrierte Apps lassen sich nicht löschen.",
+      "deleteWarning": "Das App-Bundle wird dauerhaft entfernt. Deinstalliere die App zuerst, falls sie noch installiert ist.",
+      "deleteSuccess": "Hochgeladene App gelöscht",
+      "deleteFailed": "Die hochgeladene App konnte nicht gelöscht werden",
+      "deleteInstalledBlocked": "Deinstalliere die App, bevor du sie löschst."
     },
     "empty": {
       "title": "Noch keine Apps",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6,6 +6,7 @@
     "addMenu": {
       "label": "Add app"
     },
+    "private": "Private",
     "upload": {
       "uploadApp": "Upload app",
       "dialogTitle": "Upload private app",
@@ -36,7 +37,15 @@
       "uploadFailed": "Failed to upload app",
       "replaceTitle": "Replace existing app?",
       "replaceDescription": "A private app named \"{slug}\" already exists. Uploading will overwrite its current contents.",
-      "replaceConfirm": "Replace"
+      "replaceConfirm": "Replace",
+      "delete": "Delete upload",
+      "deleteMenuLabel": "Delete {name}",
+      "deleteTitle": "Delete uploaded app",
+      "deleteDescription": "This removes the uploaded app and its files from this organization. Built-in apps can't be deleted.",
+      "deleteWarning": "The app bundle is permanently removed. Uninstall the app first if it's still installed.",
+      "deleteSuccess": "Upload deleted",
+      "deleteFailed": "Couldn't delete the upload",
+      "deleteInstalledBlocked": "Uninstall the app before deleting its upload."
     },
     "empty": {
       "title": "No apps yet",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6,6 +6,7 @@
     "addMenu": {
       "label": "Ajouter une application"
     },
+    "private": "Privé",
     "upload": {
       "uploadApp": "Téléverser une application",
       "dialogTitle": "Téléverser une application privée",
@@ -36,7 +37,15 @@
       "uploadFailed": "Échec du téléversement de l'application",
       "replaceTitle": "Remplacer l'application existante ?",
       "replaceDescription": "Une application privée nommée « {slug} » existe déjà. Le téléversement écrasera son contenu actuel.",
-      "replaceConfirm": "Remplacer"
+      "replaceConfirm": "Remplacer",
+      "delete": "Supprimer le téléversement",
+      "deleteMenuLabel": "Supprimer {name}",
+      "deleteTitle": "Supprimer l'application téléversée",
+      "deleteDescription": "Retire l'application téléversée et ses fichiers de cette organisation. Les applications intégrées ne peuvent pas être supprimées.",
+      "deleteWarning": "Le bundle de l'application est supprimé définitivement. Désinstalle d'abord l'application si elle est encore installée.",
+      "deleteSuccess": "Téléversement supprimé",
+      "deleteFailed": "Échec de la suppression du téléversement",
+      "deleteInstalledBlocked": "Désinstalle l'application avant de la supprimer."
     },
     "empty": {
       "title": "Aucune application",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2355. Uploaded private apps had no delete path and looked identical to builtin cards.
- **Delete:** new `deleteApp` action (inverse of `uploadAppBundle`) removes the org's `apps/<slug>/` dir, guarded so **builtins are never deletable** (`APP_IS_BUILTIN`) and deletion is **refused while installed** (`APP_INSTALLED` — uninstall first), same admin/developer gate as upload, idempotent. New `useDeleteApp` + a reusable `AppDeleteAction` (⋯ menu → `ConfirmDialog`), wired into the hub card and the details page.
- **Distinguish:** a "Private" badge on private-app cards and the details page (present in the org install list but absent from the builtin catalog).

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, backend `convex/apps` (49, incl. new `upload_actions.test.ts`: invalid slug, builtin refusal, installed refusal, success, no-op) + `apps` UI (81) + i18n (platform 23, ui 54) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — added `apps.private` + `apps.upload.delete*` to en/de/fr (DE `du`, FR `tu`).

## Test plan
Upload a private app → its card shows "Private" and a delete action (with confirm); deleting a builtin or an installed app is refused with a clear message.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

