### PR TITLE
test(docs): wire docs voice/pronoun guard on docs prose (#2438)

### DIFF
--- a/services/docs/tests/docs.test.ts
+++ b/services/docs/tests/docs.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Voice/pronoun/terminology guard for the translated documentation corpus.
+ *
+ * Wires the shared i18n framework's `defineDocsTests` against `docs/<locale>/**`
+ * prose. Before this file, `defineDocsTests` was exported but never called, so
+ * the per-locale voice doctrine (`du` for de, `tu` for fr — see
+ * `.agents/skills/write-translations/locales/*​/AGENTS.md`) ran only against the
+ * message-catalog JSON, never against the documentation pages themselves.
+ *
+ * Every markdown- and `both`-scoped check now runs against the docs tree. Mode
+ * follows the framework's rollout convention (see `config.ts`): checks whose
+ * corpus is already clean stay on their `enforce` default; checks that surface
+ * pre-existing violations run in `report` (findings are collected into the
+ * end-of-run summary without failing the suite) so the guard lands green and
+ * can be ratcheted to `enforce` file-by-file as the corpus is converted.
+ *
+ * The DE/FR docs prose is currently written pervasively in formal voice
+ * (`Sie`/`vous`), so `pronouns-formal` starts in `report`; flip it to `enforce`
+ * once the corpus is converted to the informal `du`/`tu` doctrine.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineDocsTests } from '@tale/ui/i18n/tests';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** `docs/` — the content tree the docs site reads from. */
+const DOCS_ROOT = path.resolve(HERE, '../../../docs');
+
+defineDocsTests({
+  docsRoot: DOCS_ROOT,
+  modes: {
+    // Pinned to `report` until the docs corpus is converted; each currently
+    // carries pre-existing violations. Ratchet to `enforce` per check once
+    // clean. See the run summary for the outstanding findings.
+    'pronouns-formal': 'report',
+    'terminology-loanword': 'report',
+    'terminology-ui-label': 'report',
+    'voice-strikes': 'report',
+    'grammar-articles': 'report',
+    // Already enforced by the docs service's own `structure-prose.test.ts`
+    // (with its markdown-context carve-outs); kept in `report` here to avoid a
+    // second, differently-scoped enforcement of the same rule.
+    'prose-exclamation': 'report',
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2438. `defineDocsTests` was exported but never invoked, so no test read `docs/<locale>/**` prose. Adds `services/docs/tests/docs.test.ts` as the missing entrypoint — it walks the docs tree per locale and runs the markdown/`both`-scoped voice/pronoun/terminology/style checks.

Running the checks surfaced that the DE/FR docs corpus is pervasively formal (`Öffnen Sie`, `Ihre…`, `vous`) with large pre-existing violation counts (88 `pronouns-formal`, 267 `terminology-ui-label`, etc.). Per the issue's own "enforce where clean, report otherwise, then ratchet" guidance and to avoid turning CI red on a pre-existing corpus, those checks are pinned to `report` mode (findings collected, suite green) while already-clean checks keep their `enforce` defaults. Each flips to `enforce` with a one-word edit once the corpus is converted.

## Checklist
- [x] `bun run check` — `@tale/docs` `docs.test` (22) + `@tale/ui` i18n (54) passing; oxfmt/lint/typecheck clean. (A pre-existing unrelated `content-manifest.test.ts` failure exists on `main` too and is not touched here.)
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations / Docs prose — no prose changed (guard wiring only).

## Test plan
`bun run --filter @tale/docs test -- docs.test` → runs the voice/pronoun checks against docs prose and passes; genuine future violations in clean-check categories will fail.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

