### PR TITLE
feat(skills): validate SKILL.md frontmatter as strict YAML (#2391)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -449,6 +449,12 @@
     "tools/skills": {
       "name": "@tale/skills",
       "version": "0.1.0",
+      "bin": {
+        "tale-skills": "./src/index.ts",
+      },
+      "dependencies": {
+        "yaml": "2.8.3",
+      },
       "devDependencies": {
         "@types/bun": "1.3.11",
         "typescript": "6.0.2",

--- a/tools/skills/package.json
+++ b/tools/skills/package.json
@@ -13,6 +13,9 @@
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test"
   },
+  "dependencies": {
+    "yaml": "2.8.3"
+  },
   "devDependencies": {
     "@types/bun": "1.3.11",
     "typescript": "6.0.2"

--- a/tools/skills/src/guards.ts
+++ b/tools/skills/src/guards.ts
@@ -4,6 +4,8 @@
  * the SOURCE tree (`skills/<name>/`), before anything is synced.
  */
 
+import { parseDocument } from 'yaml';
+
 import { isShipExcluded } from './exclude';
 import type { FileTree } from './tree';
 
@@ -121,6 +123,109 @@ export function checkCommandRefs(
     if (seen.has(ref)) continue;
     seen.add(ref);
     if (!source.has(ref)) violations.push({ skill, referenced: ref });
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Guard 3 — strict-YAML frontmatter.
+//
+// Every harness that reads a SKILL.md parses its `---` frontmatter block as
+// YAML. Our sync is byte-level and never parsed it, so frontmatter that trips a
+// strict parser (the classic being a `: ` colon-space inside an unquoted
+// `description:`, read as a nested mapping) shipped green here and choked
+// downstream. This guard parses the block with a strict YAML parser and asserts
+// the shape every harness relies on: a mapping with a non-empty string `name`
+// (matching the skill directory) and a non-empty string `description`. Extra
+// keys (e.g. `license` on the document skills) are allowed.
+// ---------------------------------------------------------------------------
+
+/** A SKILL.md whose YAML frontmatter is malformed or fails the required shape. */
+export interface FrontmatterViolation {
+  readonly skill: string;
+  /** Human-readable problem, with a `SKILL.md` line reference where available. */
+  readonly problem: string;
+}
+
+/**
+ * Capture the YAML body of a leading `---` fenced frontmatter block. Anchored at
+ * the start of the file; the closing fence is a `---` line (end-of-file allowed
+ * for a block with no trailing body).
+ */
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+/**
+ * Validate a skill's SKILL.md frontmatter as strict YAML. Reports: a missing
+ * frontmatter block, a YAML parse error (with line), a non-mapping document, a
+ * missing/empty/non-string `name` or one that does not match the skill
+ * directory, and a missing/empty/non-string `description`. A missing SKILL.md is
+ * left to {@link checkCommandRefs} to report.
+ */
+export function checkFrontmatter(
+  skill: string,
+  expectedName: string,
+  source: FileTree,
+): FrontmatterViolation[] {
+  const skillMd = source.get('SKILL.md');
+  if (skillMd === undefined) return [];
+  const text = new TextDecoder().decode(skillMd);
+  const match = FRONTMATTER_RE.exec(text);
+  if (match === null) {
+    return [
+      {
+        skill,
+        problem:
+          'SKILL.md has no YAML frontmatter block (it must open with a `---` fenced block)',
+      },
+    ];
+  }
+
+  const doc = parseDocument(match[1]);
+  if (doc.errors.length > 0) {
+    const err = doc.errors[0];
+    // The frontmatter body starts on file line 2 (line 1 is the opening `---`).
+    const line = (err.linePos?.[0]?.line ?? 1) + 1;
+    const detail = err.message.replace(/ at line \d+, column \d+:[\s\S]*$/, '');
+    return [
+      {
+        skill,
+        problem: `SKILL.md frontmatter is not valid YAML at line ${line}: ${detail}`,
+      },
+    ];
+  }
+
+  const value = doc.toJS() as unknown;
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return [
+      {
+        skill,
+        problem:
+          'SKILL.md frontmatter must be a YAML mapping of `key: value` pairs',
+      },
+    ];
+  }
+
+  const record = value as Record<string, unknown>;
+  const violations: FrontmatterViolation[] = [];
+  const { name, description } = record;
+  if (typeof name !== 'string' || name.trim() === '') {
+    violations.push({
+      skill,
+      problem:
+        'SKILL.md frontmatter `name` is missing or not a non-empty string',
+    });
+  } else if (name !== expectedName) {
+    violations.push({
+      skill,
+      problem: `SKILL.md frontmatter \`name\` is "${name}" but must match the skill directory "${expectedName}"`,
+    });
+  }
+  if (typeof description !== 'string' || description.trim() === '') {
+    violations.push({
+      skill,
+      problem:
+        'SKILL.md frontmatter `description` is missing or not a non-empty string',
+    });
   }
   return violations;
 }

--- a/tools/skills/src/sync.ts
+++ b/tools/skills/src/sync.ts
@@ -21,9 +21,11 @@
  * projected.
  *
  * `runSync` does three things, in both modes:
- *   1. Guards the SHIPPED skill roots (`builtin-configs/skills/`, `skills/`)
- *      against the portability contract — a shipped skill whose code can't run
- *      where it lands, or whose SKILL.md points at a missing script, never passes.
+ *   1. Guards the skill roots — the SHIPPED roots (`builtin-configs/skills/`,
+ *      `skills/`) against the portability contract (a shipped skill whose code
+ *      can't run where it lands, or whose SKILL.md points at a missing script),
+ *      and ALL roots' SKILL.md frontmatter against strict YAML — never passes on
+ *      a violation.
  *   2. Projects `builtin-configs/skills/<workflow>/` → `.agents/skills/<workflow>/`
  *      (the generated copy a repo-dev harness reads; never hand-edit it).
  *   3. Mirrors `.agents/skills/` → `.claude/skills/` (the only Claude Code copy).
@@ -38,8 +40,10 @@ import { join } from 'node:path';
 
 import {
   checkCommandRefs,
+  checkFrontmatter,
   checkImports,
   type CommandRefViolation,
+  type FrontmatterViolation,
   type ImportViolation,
 } from './guards';
 import {
@@ -89,6 +93,15 @@ const WORKFLOW_SKILLS: readonly string[] = [
  * it is docs-only and references repo paths, not skill-relative scripts.
  */
 const SHIPPED_ROOTS: readonly string[] = ['builtin-configs/skills', 'skills'];
+
+/**
+ * Repo-relative roots whose every SKILL.md frontmatter must parse as strict
+ * YAML. This covers ALL three roots the tool walks — including the docs-only
+ * `.agents/skills` guides — because every harness that reads a skill (Cursor,
+ * Codex, Claude Code, external product-org agents) parses the frontmatter, so a
+ * malformed block breaks a consumer wherever it lives.
+ */
+const FRONTMATTER_ROOTS: readonly string[] = [MIRROR_SOURCE, ...SHIPPED_ROOTS];
 
 export interface SyncOptions {
   /** Absolute path to the repo root (the parent of `.agents/`). */
@@ -167,12 +180,15 @@ function skillDirsIn(repoRoot: string, root: string): string[] {
 interface GuardPlan {
   readonly imports: readonly ImportViolation[];
   readonly commands: readonly CommandRefViolation[];
+  readonly frontmatter: readonly FrontmatterViolation[];
 }
 
 /**
- * Run the portability guards over every shipped skill. The skill label is its
- * repo-relative path (`builtin-configs/skills/pptx`) so a violation names the
- * exact bundle. Pure read.
+ * Run the guards over the skill roots. The portability guards (imports, command
+ * refs) apply only to the SHIPPED roots; the strict-YAML frontmatter guard
+ * applies to ALL roots the tool walks (see {@link FRONTMATTER_ROOTS}). The skill
+ * label is its repo-relative path (`builtin-configs/skills/pptx`) so a violation
+ * names the exact bundle. Pure read.
  */
 export function planGuards(repoRoot: string): GuardPlan {
   const imports: ImportViolation[] = [];
@@ -185,7 +201,15 @@ export function planGuards(repoRoot: string): GuardPlan {
       commands.push(...checkCommandRefs(label, source));
     }
   }
-  return { imports, commands };
+  const frontmatter: FrontmatterViolation[] = [];
+  for (const root of FRONTMATTER_ROOTS) {
+    for (const name of skillDirsIn(repoRoot, root)) {
+      const label = `${root}/${name}`;
+      const source = readTree(join(repoRoot, root, name));
+      frontmatter.push(...checkFrontmatter(label, name, source));
+    }
+  }
+  return { imports, commands, frontmatter };
 }
 
 /** Write missing+changed files and delete stale extras for one tree target. */
@@ -272,7 +296,7 @@ function formatProjectionDrift(drift: readonly ProjectionPlan[]): string {
 
 function formatGuardFailures(plan: GuardPlan): string {
   const lines = [
-    '[skills:check] FAILED — a shipped skill violates the portability contract.',
+    '[skills:check] FAILED — a skill violates the portability or frontmatter contract.',
     '',
   ];
   if (plan.imports.length > 0) {
@@ -292,6 +316,13 @@ function formatGuardFailures(plan: GuardPlan): string {
     }
     lines.push('');
   }
+  if (plan.frontmatter.length > 0) {
+    lines.push('  SKILL.md frontmatter is not valid strict YAML:');
+    for (const v of plan.frontmatter) {
+      lines.push(`    ${v.skill}: ${v.problem}`);
+    }
+    lines.push('');
+  }
   lines.push('Fix the shipped skill, then run: bun run skills:sync');
   return lines.join('\n');
 }
@@ -304,7 +335,11 @@ function formatGuardFailures(plan: GuardPlan): string {
  */
 export async function runSync(opts: SyncOptions): Promise<number> {
   const guards = planGuards(opts.repoRoot);
-  if (guards.imports.length > 0 || guards.commands.length > 0) {
+  if (
+    guards.imports.length > 0 ||
+    guards.commands.length > 0 ||
+    guards.frontmatter.length > 0
+  ) {
     console.error(formatGuardFailures(guards));
     return 1;
   }

--- a/tools/skills/tests/frontmatter.test.ts
+++ b/tools/skills/tests/frontmatter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+
+import { checkFrontmatter } from '../src/guards';
+import { type FileTree } from '../src/tree';
+
+/** Build a FileTree from a plain object (utf-8 encoded values). */
+function tree(entries: Record<string, string>): FileTree {
+  const map: FileTree = new Map();
+  const enc = new TextEncoder();
+  for (const [key, value] of Object.entries(entries)) {
+    map.set(key, enc.encode(value));
+  }
+  return map;
+}
+
+/** A SKILL.md with the given frontmatter body between `---` fences. */
+function skillMd(frontmatter: string): FileTree {
+  return tree({ 'SKILL.md': `---\n${frontmatter}\n---\n\n# Body\n` });
+}
+
+describe('checkFrontmatter', () => {
+  test('passes a well-formed name + description', () => {
+    const source = skillMd('name: demo\ndescription: A short description.');
+    expect(checkFrontmatter('demo', 'demo', source)).toEqual([]);
+  });
+
+  test('allows extra keys (e.g. license on the document skills)', () => {
+    const source = skillMd(
+      'name: docx\ndescription: Work with .docx files.\nlicense: MIT',
+    );
+    expect(checkFrontmatter('docx', 'docx', source)).toEqual([]);
+  });
+
+  test('accepts a colon-space inside a quoted description', () => {
+    const source = skillMd(
+      "name: demo\ndescription: 'Use this: it works when quoted.'",
+    );
+    expect(checkFrontmatter('demo', 'demo', source)).toEqual([]);
+  });
+
+  test('fails on a `: ` colon-space in an unquoted description (strict YAML)', () => {
+    const source = skillMd('name: demo\ndescription: uses: colons unquoted');
+    const violations = checkFrontmatter('demo', 'demo', source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].skill).toBe('demo');
+    expect(violations[0].problem).toContain('not valid YAML');
+    // The offending value is on file line 3 (line 1 is the opening `---`).
+    expect(violations[0].problem).toContain('line 3');
+  });
+
+  test('fails when the frontmatter block is missing', () => {
+    const source = tree({ 'SKILL.md': '# Body without frontmatter\n' });
+    const violations = checkFrontmatter('demo', 'demo', source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].problem).toContain('no YAML frontmatter block');
+  });
+
+  test('fails when `name` is missing', () => {
+    const source = skillMd('description: Only a description here.');
+    expect(checkFrontmatter('demo', 'demo', source)).toEqual([
+      {
+        skill: 'demo',
+        problem:
+          'SKILL.md frontmatter `name` is missing or not a non-empty string',
+      },
+    ]);
+  });
+
+  test('fails when `description` is missing', () => {
+    const source = skillMd('name: demo');
+    expect(checkFrontmatter('demo', 'demo', source)).toEqual([
+      {
+        skill: 'demo',
+        problem:
+          'SKILL.md frontmatter `description` is missing or not a non-empty string',
+      },
+    ]);
+  });
+
+  test('fails when `description` is empty', () => {
+    const source = skillMd("name: demo\ndescription: ''");
+    const violations = checkFrontmatter('demo', 'demo', source);
+    expect(violations.map((v) => v.problem)).toContain(
+      'SKILL.md frontmatter `description` is missing or not a non-empty string',
+    );
+  });
+
+  test('fails when `description` is not a string', () => {
+    const source = skillMd('name: demo\ndescription: 42');
+    const violations = checkFrontmatter('demo', 'demo', source);
+    expect(violations.map((v) => v.problem)).toContain(
+      'SKILL.md frontmatter `description` is missing or not a non-empty string',
+    );
+  });
+
+  test('fails when `name` does not match the skill directory', () => {
+    const source = skillMd('name: other\ndescription: A description.');
+    const violations = checkFrontmatter('demo', 'demo', source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].problem).toContain('must match the skill directory');
+  });
+
+  test('fails when the frontmatter is a scalar, not a mapping', () => {
+    const source = skillMd('just a string');
+    const violations = checkFrontmatter('demo', 'demo', source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].problem).toContain('must be a YAML mapping');
+  });
+
+  test('ignores a skill with no SKILL.md (reported elsewhere)', () => {
+    expect(checkFrontmatter('demo', 'demo', tree({ 'other.md': 'x' }))).toEqual(
+      [],
+    );
+  });
+});

--- a/tools/skills/tests/repo-sync.test.ts
+++ b/tools/skills/tests/repo-sync.test.ts
@@ -33,4 +33,8 @@ describe('committed skills are in sync with their source', () => {
     expect(guards.imports).toEqual([]);
     expect(guards.commands).toEqual([]);
   });
+
+  test('every skill has strict-YAML frontmatter', () => {
+    expect(planGuards(repoRoot).frontmatter).toEqual([]);
+  });
 });

--- a/tools/skills/tests/sync.test.ts
+++ b/tools/skills/tests/sync.test.ts
@@ -158,7 +158,12 @@ describe('runSync — workflow-skill projection', () => {
   test('check fails (pointing at builtin-configs) when the projected copy is hand-edited', async () => {
     scaffoldWorkflow();
     await run(false);
-    writeFileSync(projected('fix-bug/SKILL.md'), 'tampered');
+    // Tamper the body while keeping valid frontmatter, so this exercises the
+    // projection-drift path (not the frontmatter guard, which runs earlier).
+    writeFileSync(
+      projected('fix-bug/SKILL.md'),
+      '---\nname: fix-bug\ndescription: x\n---\n\n# Tampered\n',
+    );
     const checked = await run(true);
     expect(checked.code).toBe(1);
     expect(checked.out).toContain('workflow-skill projection is out of date');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2391. `skills:check` now parses each `SKILL.md` frontmatter block as strict YAML and validates its shape. New `checkFrontmatter` guard (using the `yaml` package's `parseDocument` for line/column info) fails on: missing `---` block, YAML parse errors, a non-mapping document, missing/empty/non-string `name`, `name` ≠ directory, and missing/empty/non-string `description`. Extra keys (e.g. `license`) are allowed. Wired into `sync.ts` across all three skill roots and into `--check`; the required shape was inferred from the 37 existing valid skills, so no skills were reformatted.

## Checklist
- [x] `bun run check` — `@tale/skills` lint (0/0), typecheck clean, tests (56); `bun run skills:check` OK on the existing set (no drift); verified a malformed-YAML fixture makes `skills:check` exit 1 with a clear line reference.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations / Docs — N/A (tool-internal check messages).

## Notes
- `bun.lock` + `tools/skills/package.json` updated (`yaml@2.8.3`, already used elsewhere).

## Test plan
Run `bun run skills:check` → passes; introduce malformed frontmatter in a SKILL.md → it fails with `SKILL.md line N` context.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

