### PR TITLE
fix(platform): link missing-key errors to provider settings (#2375)

### DIFF
--- a/services/platform/app/features/chat/components/chat-error-display.test.tsx
+++ b/services/platform/app/features/chat/components/chat-error-display.test.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import { ChatErrorDisplay } from './chat-error-display';
+
+// Toggle per test: whether the current member can manage AI providers
+// (owner / admin / developer, via the `developerSettings` ability gate).
+let mockCanManageProviders = false;
+vi.mock('@/app/hooks/use-ability', () => ({
+  useAbility: () => ({
+    can: (_action: string, subject: string) =>
+      subject === 'developerSettings' ? mockCanManageProviders : false,
+    cannot: (_action: string, subject: string) =>
+      subject === 'developerSettings' ? !mockCanManageProviders : true,
+  }),
+  useAbilityLoading: () => false,
+}));
+
+// The provider-settings link is a TanStack `Link` (via `LinkButton`); stub it
+// as a plain anchor whose href echoes the route so tests can assert the deep
+// link target without a RouterProvider.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        errorGenerating: 'Something went wrong',
+        errorDetailsSummary: 'Technical details',
+        errorHintMissingApiKey:
+          'No API key is configured for this organization yet.',
+        errorHintRateLimited: 'Too many requests. Please wait a moment.',
+        openProviderSettings: 'Open provider settings',
+        askAdminProviderKey:
+          'Ask an admin to add an API key in Settings → AI providers.',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+// A raw provider error the shared classifier maps to `missing_api_key`.
+const MISSING_KEY_ERROR = 'MissingApiKeyError: no key configured';
+// A rate-limit error — the actionable provider link must NOT appear.
+const RATE_LIMIT_ERROR = 'Error: 429 rate limit exceeded';
+
+describe('ChatErrorDisplay provider-settings link', () => {
+  beforeEach(() => {
+    mockCanManageProviders = false;
+  });
+
+  it('links to provider settings on a missing-key error for a manager', () => {
+    mockCanManageProviders = true;
+    render(
+      <ChatErrorDisplay error={MISSING_KEY_ERROR} organizationId="org-1" />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Open provider settings' });
+    expect(link).toHaveAttribute('href', '/dashboard/$id/settings/providers');
+    expect(
+      screen.queryByText(
+        'Ask an admin to add an API key in Settings → AI providers.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an "ask an admin" hint for a member who cannot manage providers', () => {
+    mockCanManageProviders = false;
+    render(
+      <ChatErrorDisplay error={MISSING_KEY_ERROR} organizationId="org-1" />,
+    );
+
+    expect(
+      screen.getByText(
+        'Ask an admin to add an API key in Settings → AI providers.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Open provider settings' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders no provider action for a non-missing-key error', () => {
+    mockCanManageProviders = true;
+    render(
+      <ChatErrorDisplay error={RATE_LIMIT_ERROR} organizationId="org-1" />,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Open provider settings' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Ask an admin to add an API key in Settings → AI providers.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('omits the provider action when no organization id is available', () => {
+    mockCanManageProviders = true;
+    render(<ChatErrorDisplay error={MISSING_KEY_ERROR} />);
+
+    expect(
+      screen.queryByRole('link', { name: 'Open provider settings' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('has no accessibility violations for the manager link', async () => {
+    mockCanManageProviders = true;
+    const { container } = render(
+      <ChatErrorDisplay error={MISSING_KEY_ERROR} organizationId="org-1" />,
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/chat/components/chat-error-display.tsx
+++ b/services/platform/app/features/chat/components/chat-error-display.tsx
@@ -8,11 +8,17 @@ import { RotateCcw, TriangleAlert } from 'lucide-react';
 import { useT } from '@/lib/i18n/client';
 
 import { sanitizeChatError } from '../utils/sanitize-chat-error';
+import { ProviderKeyErrorAction } from './provider-settings-action';
 
 interface ChatErrorDisplayProps {
   /** Raw error string stored on the message (the verbatim provider error). */
   error: string | undefined;
   onRetry?: () => void;
+  /**
+   * Org for the "Open provider settings" deep link on a missing-API-key error.
+   * Optional so surfaces without an org context (if any) still render the hint.
+   */
+  organizationId?: string;
 }
 
 /**
@@ -23,7 +29,11 @@ interface ChatErrorDisplayProps {
  * is otherwise mislabeled as a token-limit problem). Unknown ("generic") errors
  * open the disclosure by default since the raw text is the only signal.
  */
-export function ChatErrorDisplay({ error, onRetry }: ChatErrorDisplayProps) {
+export function ChatErrorDisplay({
+  error,
+  onRetry,
+  organizationId,
+}: ChatErrorDisplayProps) {
   const { t: tChat } = useT('chat');
   const sanitized = sanitizeChatError(error);
 
@@ -51,6 +61,9 @@ export function ChatErrorDisplay({ error, onRetry }: ChatErrorDisplayProps) {
             {sanitized.rawMessage}
           </p>
         </CollapsibleDetails>
+      )}
+      {sanitized.code === 'missing_api_key' && organizationId && (
+        <ProviderKeyErrorAction organizationId={organizationId} />
       )}
       {onRetry && (
         <Button

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -4,6 +4,7 @@ import { Button } from '@tale/ui/button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { type SearchSource } from '@tale/ui/search';
 import { Text } from '@tale/ui/text';
+import type { ToastActionElement } from '@tale/ui/toast';
 import { ArrowUp, CircleStop } from 'lucide-react';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useCallback, useId, useRef, useMemo, useState } from 'react';
@@ -178,6 +179,14 @@ interface ChatInputProps extends Omit<
   /** Tooltip shown on the send button when `sendBlocked` is true. */
   sendBlockedReason?: string;
   /**
+   * Optional action for the send-blocked toast — only set for the actionable
+   * missing-API-key subcase (a deep link to provider settings). The generic
+   * blocked-reason toast carries none.
+   */
+  sendBlockedAction?: ToastActionElement;
+  /** Optional secondary line for the send-blocked toast (e.g. an admin hint). */
+  sendBlockedDescription?: string;
+  /**
    * Fired when the composer becomes active (focus). Used to pre-warm the prompt
    * cache so the next message is served warm. Best-effort and debounced by the
    * caller; safe to omit.
@@ -265,6 +274,8 @@ export function ChatInput({
   projectId,
   sendBlocked = false,
   sendBlockedReason,
+  sendBlockedAction,
+  sendBlockedDescription,
   onComposerActivate,
   kbMentions,
   addKbMention,
@@ -506,7 +517,12 @@ export function ChatInput({
     // model's provider has no API key).
     const hasInput = !!value.trim() || attachments.length > 0;
     if (hasInput && !isLoading && sendBlocked && sendBlockedReason) {
-      toast({ title: sendBlockedReason, variant: 'destructive' });
+      toast({
+        title: sendBlockedReason,
+        description: sendBlockedDescription,
+        action: sendBlockedAction,
+        variant: 'destructive',
+      });
       return;
     }
 

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -90,6 +90,10 @@ import { EditingBanner, imageRefToAttachment } from './editing-banner';
 import { useEffectiveEditingImage } from './editing-banner';
 import { HumanControlCard } from './human-control-card';
 import {
+  ProviderSettingsToastAction,
+  useCanManageProviders,
+} from './provider-settings-action';
+import {
   QueuedMessageTray,
   type PendingTrayEntry,
 } from './queued-message-tray';
@@ -411,6 +415,25 @@ export function ChatInterface({
     !activeModelInfo?.hasApiKeyOverride;
   const { active: activeEditingImage } = useEffectiveEditingImage(threadImages);
   const { setEditingImageRef, setDismissedImageKey } = useChatLayout();
+
+  // Send-block breakdown: the missing-API-key subcase is the only one with an
+  // actionable fix, so it — and only it — carries the "Open provider settings"
+  // deep link (or an "ask an admin" hint for members who can't manage
+  // providers). The image-edit block takes priority in the reason string, so
+  // exclude it here to keep the two blocked reasons in lockstep.
+  const imageEditBlocked =
+    isImageGenAgent && !!activeEditingImage && !currentModelSupportsEdit;
+  const missingKeyBlocked =
+    !imageEditBlocked && (activeModelMissingApiKey || noProviderHasApiKey);
+  const canManageProviders = useCanManageProviders();
+  const sendBlockedAction =
+    missingKeyBlocked && canManageProviders ? (
+      <ProviderSettingsToastAction organizationId={organizationId} />
+    ) : undefined;
+  const sendBlockedDescription =
+    missingKeyBlocked && !canManageProviders
+      ? t('askAdminProviderKey')
+      : undefined;
 
   // Thread status — disable input for archived threads. Status is derived from
   // the URL threadId (root thread), not dataThreadId (which may be a branch
@@ -1461,18 +1484,14 @@ export function ChatInterface({
                   retryVideoJob={retryVideoJob}
                   sendBlocked={
                     budgetExceeded ||
-                    (isImageGenAgent &&
-                      !!activeEditingImage &&
-                      !currentModelSupportsEdit) ||
+                    imageEditBlocked ||
                     activeModelMissingApiKey ||
                     noProviderHasApiKey
                   }
                   sendBlockedReason={
                     budgetExceeded
                       ? t('budgetExceededDefault')
-                      : isImageGenAgent &&
-                          !!activeEditingImage &&
-                          !currentModelSupportsEdit
+                      : imageEditBlocked
                         ? t('imageEdit.modelCannotEdit')
                         : activeModelMissingApiKey
                           ? t('modelSelector.noApiKey')
@@ -1480,6 +1499,8 @@ export function ChatInterface({
                             ? t('modelSelector.noProviderKey')
                             : undefined
                   }
+                  sendBlockedAction={sendBlockedAction}
+                  sendBlockedDescription={sendBlockedDescription}
                   onSavePrompt={(content) =>
                     setSavePromptData({ messageId: '', content })
                   }

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -869,13 +869,21 @@ function MessageBubbleComponent({
               </Row>
             )}
             {message.isFailed && (
-              <ChatErrorDisplay error={message.error} onRetry={onRetry} />
+              <ChatErrorDisplay
+                error={message.error}
+                onRetry={onRetry}
+                organizationId={organizationId}
+              />
             )}
           </div>
         ) : (
           message.isAborted &&
           (message.error ? (
-            <ChatErrorDisplay error={message.error} onRetry={onRetry} />
+            <ChatErrorDisplay
+              error={message.error}
+              onRetry={onRetry}
+              organizationId={organizationId}
+            />
           ) : (
             <div className="text-muted-foreground flex items-center gap-1.5 text-sm italic">
               <Square className="size-3" />

--- a/services/platform/app/features/chat/components/provider-settings-action.tsx
+++ b/services/platform/app/features/chat/components/provider-settings-action.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { LinkButton, buttonVariants } from '@tale/ui/button';
+import type { ToastActionElement } from '@tale/ui/toast';
+import { Link } from '@tanstack/react-router';
+import { Settings } from 'lucide-react';
+
+import { useAbility } from '@/app/hooks/use-ability';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Owner / admin / developer can reach Settings → AI providers and add a key —
+ * the same `developerSettings` gate the providers route itself uses. Members
+ * without it are pointed at an admin instead. Kept as a single hook so the
+ * toast (chat-input send-block) and the inline chat-error display agree on who
+ * gets the link.
+ */
+export function useCanManageProviders(): boolean {
+  return useAbility().can('read', 'developerSettings');
+}
+
+/**
+ * Toast action that deep-links to the org's AI-provider settings. Wrapped in a
+ * Radix `Toast.Action` (so it carries an `altText` for screen readers and
+ * dismisses the toast on activation) around a router `Link` — a raw Link, not
+ * `LinkButton`, because `Toast.Action asChild` merges its handlers onto the DOM
+ * child and `LinkButton` does not forward them.
+ */
+export function ProviderSettingsToastAction({
+  organizationId,
+}: {
+  organizationId: string;
+}): ToastActionElement {
+  const { t } = useT('chat');
+  const label = t('openProviderSettings');
+  return (
+    <ToastPrimitives.Action altText={label} asChild>
+      <Link
+        to="/dashboard/$id/settings/providers"
+        params={{ id: organizationId }}
+        className={cn(
+          buttonVariants({ variant: 'secondary', size: 'sm' }),
+          'gap-1.5',
+        )}
+      >
+        <Settings className="size-4" aria-hidden="true" />
+        {label}
+      </Link>
+    </ToastPrimitives.Action>
+  );
+}
+
+/**
+ * Inline "Open provider settings" affordance for the missing-API-key chat error.
+ * Renders the deep link for members who can manage providers, and an
+ * "ask an admin" hint for everyone else.
+ */
+export function ProviderKeyErrorAction({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const { t } = useT('chat');
+  const canManage = useCanManageProviders();
+
+  if (!canManage) {
+    return (
+      <p className="text-muted-foreground text-[13px]">
+        {t('askAdminProviderKey')}
+      </p>
+    );
+  }
+
+  return (
+    <LinkButton
+      variant="secondary"
+      size="sm"
+      icon={Settings}
+      href="/dashboard/$id/settings/providers"
+      params={{ id: organizationId }}
+      className="w-fit gap-1.5"
+    >
+      {t('openProviderSettings')}
+    </LinkButton>
+  );
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1422,6 +1422,8 @@
     "errorGenerating": "Etwas ist schiefgelaufen",
     "errorDetailsSummary": "Technische Details",
     "retryGeneration": "Erneut versuchen",
+    "openProviderSettings": "Anbietereinstellungen öffnen",
+    "askAdminProviderKey": "Bitte einen Admin, in Einstellungen → KI-Anbieter einen API-Schlüssel hinzuzufügen.",
     "showMore": "Mehr anzeigen",
     "showLess": "Weniger anzeigen",
     "editMessage": "Nachricht bearbeiten",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1425,6 +1425,8 @@
     "errorGenerating": "Something went wrong",
     "errorDetailsSummary": "Technical details",
     "retryGeneration": "Try again",
+    "openProviderSettings": "Open provider settings",
+    "askAdminProviderKey": "Ask an admin to add an API key in Settings → AI providers.",
     "showMore": "Show more",
     "showLess": "Show less",
     "editMessage": "Edit message",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1423,6 +1423,8 @@
     "errorGenerating": "Une erreur s'est produite",
     "errorDetailsSummary": "Détails techniques",
     "retryGeneration": "Réessayer",
+    "openProviderSettings": "Ouvrir les paramètres du fournisseur",
+    "askAdminProviderKey": "Demande à un administrateur d’ajouter une clé API dans Paramètres → Fournisseurs d’IA.",
     "showMore": "Voir plus",
     "showLess": "Voir moins",
     "editMessage": "Modifier le message",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2375. A missing-API-key block stated the problem but offered no fix path. Now both surfaces carry a permission-aware link to provider settings:
- **Inline chat-error display** — for the `missing_api_key` classification, an "Open provider settings" `LinkButton` to `/dashboard/$id/settings/providers`, or an "ask an admin" hint for members who can't manage providers.
- **Send-blocked toast** — the missing-key subcase (discriminated from the shared image-edit block) attaches a `Toast.Action` link (managers) or admin hint (others).

Permission uses the existing `useAbility().can('read','developerSettings')` gate (the same one the providers route uses). A11y: keyboard/SR-accessible link that dismisses the toast; semantic tokens.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, new `chat-error-display.test.tsx` (5, incl. a11y + ask-admin/no-org/non-missing cases) + `message-bubble` (7) + platform i18n parity (23) + `@tale/ui` i18n (54) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — added `chat.openProviderSettings` + `chat.askAdminProviderKey` to en/de/fr (DE `du`, FR `tu`).

## Test plan
Send with a model whose provider has no key → the block toast and the inline error both offer "Open provider settings" (managers) or "ask an admin" (others).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

