### PR TITLE
fix(platform): a11y polish — aria-live, captions, touch targets (#1980)

### DIFF
--- a/services/platform/app/components/ui/editor/editor-actions.test.tsx
+++ b/services/platform/app/components/ui/editor/editor-actions.test.tsx
@@ -38,6 +38,18 @@ beforeEach(() => {
   toastMock.mockReset();
 });
 
+describe('EditorActions — mobile touch targets (#1980)', () => {
+  it('grows the Save and Discard buttons to 44px on mobile', () => {
+    render(<EditorActions controller={makeController()} />);
+    for (const name of ['actions.discard', 'actions.save']) {
+      expect(screen.getByRole('button', { name })).toHaveClass(
+        'max-sm:min-h-11',
+        'max-sm:min-w-11',
+      );
+    }
+  });
+});
+
 describe('EditorActions — suppressServerErrorToast', () => {
   it('toasts a server error by default', async () => {
     const controller = makeController({

--- a/services/platform/app/components/ui/editor/editor-actions.tsx
+++ b/services/platform/app/components/ui/editor/editor-actions.tsx
@@ -167,6 +167,11 @@ export function EditorActions({
         icon={Undo2}
         iconClassName="size-3.5"
         collapseLabel
+        // The `sm` size is 32px tall and, once the label collapses to an icon
+        // below the `sm` breakpoint, narrower than the 44px WCAG 2.5.5 touch
+        // target. Grow the hit area to 44×44px on mobile only; the dense
+        // desktop size is kept from `sm` up (WCAG 2.5.5 / #1980).
+        className="max-sm:min-h-11 max-sm:min-w-11"
         disabled={discardDisabled}
         aria-disabled={discardDisabled ? 'true' : undefined}
       >
@@ -176,6 +181,7 @@ export function EditorActions({
         type={formId ? 'submit' : 'button'}
         size="sm"
         form={formId}
+        className="max-sm:min-h-11 max-sm:min-w-11"
         onClick={formId ? undefined : () => void runSave()}
         disabled={saveDisabled}
         aria-busy={controller.isSaving ? 'true' : undefined}

--- a/services/platform/app/features/agents/components/agents-table.test.tsx
+++ b/services/platform/app/features/agents/components/agents-table.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
@@ -81,6 +81,15 @@ describe('AgentsTable', () => {
         <AgentsTable organizationId="test-org-id" />,
       );
       await checkAccessibility(container);
+    });
+
+    it('gives the table an sr-only caption (#1980)', () => {
+      const { container } = render(
+        <AgentsTable organizationId="test-org-id" />,
+      );
+      const caption = container.querySelector('caption');
+      expect(caption).not.toBeNull();
+      expect(caption).toHaveTextContent('settings.agents.tableCaption');
     });
   });
 });

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -291,6 +291,7 @@ export function AgentsTable({
       className="p-4"
       {...list.tableProps}
       columns={columns}
+      caption={tSettings('agents.tableCaption')}
       stickyLayout={stickyLayout}
       // Folders aren't selectable; built-in agents and app-owned agents are not
       // deletable — so the header checkbox + bulk bar only ever target

--- a/services/platform/app/features/documents/components/documents-table.test.tsx
+++ b/services/platform/app/features/documents/components/documents-table.test.tsx
@@ -134,5 +134,14 @@ describe('DocumentsTable', () => {
         rules: { 'aria-allowed-attr': { enabled: false } },
       });
     });
+
+    it('gives the table an sr-only caption (#1980)', () => {
+      const { container } = render(
+        <DocumentsTable organizationId="test-org-id" />,
+      );
+      const caption = container.querySelector('caption');
+      expect(caption).not.toBeNull();
+      expect(caption).toHaveTextContent('documents.tableCaption');
+    });
   });
 });

--- a/services/platform/app/features/documents/components/documents-table.tsx
+++ b/services/platform/app/features/documents/components/documents-table.tsx
@@ -376,6 +376,7 @@ export function DocumentsTable({
 
       <DataTable
         columns={columns}
+        caption={tDocuments('tableCaption')}
         onRowClick={handleRowClick}
         onRowMouseEnter={handleRowMouseEnter}
         rowClassName={getRowClassName}

--- a/services/platform/app/features/notifications/components/notification-list-panel.test.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.test.tsx
@@ -36,6 +36,16 @@ const markMyRead = { mutateAsync: vi.fn(), isPending: false };
 const orgLoadMore = vi.fn();
 const myLoadMore = vi.fn();
 
+interface MockNotification {
+  _id: string;
+  createdAt: number;
+  read: boolean;
+  titleKey: string;
+  bodyKey: string;
+  params?: Record<string, unknown>;
+  link?: undefined;
+}
+
 const streamState = {
   org: 'Exhausted' as
     | 'LoadingFirstPage'
@@ -52,6 +62,9 @@ const streamState = {
   // so the button renders.
   orgUnread: 0,
   myUnread: 0,
+  // Row payloads for the arrival-announcement suite. Empty by default so the
+  // other suites stay focused on the button controls.
+  orgResults: [] as MockNotification[],
 };
 
 // --- Org stream hooks (`../hooks/*`) --------------------------------------
@@ -68,7 +81,7 @@ vi.mock('../hooks/queries', async () => {
   return {
     ...actual,
     useNotificationsList: () => ({
-      results: [],
+      results: streamState.orgResults,
       status: streamState.org,
       loadMore: orgLoadMore,
     }),
@@ -91,6 +104,13 @@ vi.mock('@/app/features/inbox/hooks/queries', () => ({
   useUnreadNotificationCount: () => streamState.myUnread,
 }));
 
+// Stub the row so the arrival suite can add unread items without wiring up the
+// row's router/date-format dependencies — the announcer reads the raw streams,
+// not the rendered rows.
+vi.mock('./notification-row', () => ({
+  NotificationRow: () => <li data-testid="notification-row" />,
+}));
+
 function renderPanel() {
   return render(<NotificationListPanel organizationId="org-1" />);
 }
@@ -105,6 +125,7 @@ beforeEach(() => {
   streamState.my = 'Exhausted';
   streamState.orgUnread = 0;
   streamState.myUnread = 0;
+  streamState.orgResults = [];
 });
 
 describe('NotificationListPanel', () => {
@@ -152,6 +173,39 @@ describe('NotificationListPanel', () => {
       expect(
         screen.getByRole('button', { name: 'Mark all as read' }),
       ).toBeEnabled();
+    });
+  });
+
+  // A polite, sr-only live region announces notifications that arrive while the
+  // panel is open, so screen-reader users hear them (#1980). The list already
+  // present on first render is never announced.
+  describe('new-arrival announcements (#1980)', () => {
+    function makeNotification(createdAt: number): MockNotification {
+      return {
+        _id: `n-${createdAt}`,
+        createdAt,
+        read: false,
+        titleKey: 'title',
+        bodyKey: 'body',
+        params: {},
+      };
+    }
+
+    it('does not announce the list already present on first render', () => {
+      streamState.orgResults = [makeNotification(1000)];
+      renderPanel();
+      expect(screen.getByRole('status').textContent).toBe('');
+    });
+
+    it('announces a notification that arrives while the panel is open', () => {
+      const { rerender } = renderPanel();
+      // Region starts empty; then a newer notification arrives.
+      expect(screen.getByRole('status').textContent).toBe('');
+
+      streamState.orgResults = [makeNotification(Date.now())];
+      rerender(<NotificationListPanel organizationId="org-1" />);
+
+      expect(screen.getByRole('status')).toHaveTextContent('New notifications');
     });
   });
 

--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@tale/ui/button';
 import { Tabs } from '@tale/ui/tabs';
 import { CheckCheck, ChevronLeft, Inbox, Loader2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   useMarkAllNotificationsRead as useMarkAllMyNotificationsRead,
@@ -49,6 +49,11 @@ interface NotificationListPanelProps {
 }
 
 const LOAD_MORE_NUM_ITEMS = 25;
+
+// How long the arrival announcement stays in the live region before it is
+// cleared, so a subsequent arrival re-announces even when the text is
+// identical (screen readers skip a live region whose text did not change).
+const ARRIVAL_ANNOUNCE_HOLD_MS = 1000;
 
 // Strip a leading `notifications.` namespace prefix that was accidentally
 // stored in earlier rows — we already bind the namespace with
@@ -162,6 +167,44 @@ export function NotificationListPanel({
     }
   }, [results, myNotifications, hiddenIds]);
 
+  // Announce newly-arrived notifications to screen readers. A polite, sr-only
+  // live region (below) speaks a short message whenever a notification with a
+  // timestamp newer than any seen so far appears — so SR users hear arrivals
+  // that land while the panel is open. The first render only sets the baseline,
+  // so the list already present when the panel opened is never announced.
+  const [arrivalAnnouncement, setArrivalAnnouncement] = useState('');
+  const latestSeenAtRef = useRef<number | null>(null);
+  const clearAnnounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let newest = 0;
+    for (const n of results) if (n.createdAt > newest) newest = n.createdAt;
+    for (const n of myNotifications)
+      if (n.createdAt > newest) newest = n.createdAt;
+
+    const seenAt = latestSeenAtRef.current;
+    if (seenAt === null) {
+      latestSeenAtRef.current = newest;
+      return;
+    }
+    if (newest > seenAt) {
+      latestSeenAtRef.current = newest;
+      setArrivalAnnouncement(t('newNotifications'));
+      if (clearAnnounceRef.current) clearTimeout(clearAnnounceRef.current);
+      clearAnnounceRef.current = setTimeout(
+        () => setArrivalAnnouncement(''),
+        ARRIVAL_ANNOUNCE_HOLD_MS,
+      );
+    }
+  }, [results, myNotifications, t]);
+
+  useEffect(
+    () => () => {
+      if (clearAnnounceRef.current) clearTimeout(clearAnnounceRef.current);
+    },
+    [],
+  );
+
   // Filter client-side so toggling Unread/All never changes the query key (a
   // query reset would re-flash the skeleton). `hiddenIds` covers the optimistic
   // "just marked read" gap before the server-side `read` flag catches up.
@@ -192,6 +235,14 @@ export function NotificationListPanel({
 
   return (
     <div className={cn('flex h-[24rem] flex-col', className)}>
+      <div
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {arrivalAnnouncement}
+      </div>
       <div className="border-border flex flex-col gap-2 border-b px-4 py-3">
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-1.5">

--- a/services/platform/convex/notifications/notification_messages.ts
+++ b/services/platform/convex/notifications/notification_messages.ts
@@ -32,6 +32,7 @@ type LocaleStrings = Record<string, string>;
 export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
   en: {
     title: 'Notifications',
+    newNotifications: 'New notifications',
     ariaUnread: 'Unread',
     emptyCaughtUpTitle: "You're all caught up",
     emptyCaughtUpDescription: "We'll let you know when anything new comes in.",
@@ -91,6 +92,7 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
   },
   de: {
     title: 'Benachrichtigungen',
+    newNotifications: 'Neue Benachrichtigungen',
     ariaUnread: 'Ungelesen',
     emptyCaughtUpTitle: 'Alles erledigt',
     emptyCaughtUpDescription: 'Wir melden uns, sobald etwas Neues eintrifft.',
@@ -155,6 +157,7 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
   },
   fr: {
     title: 'Notifications',
+    newNotifications: 'Nouvelles notifications',
     ariaUnread: 'Non lu',
     emptyCaughtUpTitle: 'Tout est à jour',
     emptyCaughtUpDescription:

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2466,6 +2466,7 @@
   },
   "documents": {
     "entityLabel": "Dokumente",
+    "tableCaption": "Dokumente und Ordner",
     "searchPlaceholder": "Dokumente suchen",
     "deleteFolder": {
       "title": "Ordner löschen",
@@ -4541,6 +4542,7 @@
     "filterAll": "Alle",
     "loadMore": "Mehr laden",
     "loading": "Lädt…",
+    "newNotifications": "Neue Benachrichtigungen",
     "accountLocked": "Konto vorübergehend gesperrt: {email}",
     "lockoutDetails": "{consecutiveFailures} fehlgeschlagene Anmeldeversuche von {ip}.",
     "auditIntegrityFailed": "Integritätsprüfung des Audit-Logs fehlgeschlagen",
@@ -5310,6 +5312,7 @@
         "metrics": "Metriken"
       },
       "entityLabel": "Agenten",
+      "tableCaption": "Installierte Agents",
       "createAgent": "Agent erstellen",
       "createMenu": {
         "blank": "Leer",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2466,6 +2466,7 @@
   },
   "documents": {
     "entityLabel": "documents",
+    "tableCaption": "Documents and folders",
     "searchPlaceholder": "Search documents",
     "deleteFolder": {
       "title": "Delete folder",
@@ -4541,6 +4542,7 @@
     "filterAll": "All",
     "loadMore": "Load more",
     "loading": "Loading…",
+    "newNotifications": "New notifications",
     "accountLocked": "Account temporarily locked: {email}",
     "lockoutDetails": "{consecutiveFailures} failed sign-in attempts from {ip}.",
     "auditIntegrityFailed": "Audit log integrity check failed",
@@ -5574,6 +5576,7 @@
         "metrics": "Metrics"
       },
       "entityLabel": "agents",
+      "tableCaption": "Installed agents",
       "createAgent": "Create agent",
       "createMenu": {
         "blank": "Blank",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2467,6 +2467,7 @@
   },
   "documents": {
     "entityLabel": "documents",
+    "tableCaption": "Documents et dossiers",
     "searchPlaceholder": "Rechercher des documents",
     "deleteFolder": {
       "title": "Supprimer le dossier",
@@ -4542,6 +4543,7 @@
     "filterAll": "Tous",
     "loadMore": "Charger plus",
     "loading": "Chargement…",
+    "newNotifications": "Nouvelles notifications",
     "accountLocked": "Compte temporairement verrouillé : {email}",
     "lockoutDetails": "{consecutiveFailures} tentatives de connexion échouées depuis {ip}.",
     "auditIntegrityFailed": "Échec du contrôle d'intégrité du journal d'audit",
@@ -5311,6 +5313,7 @@
         "metrics": "Métriques"
       },
       "entityLabel": "agents",
+      "tableCaption": "Agents installés",
       "createAgent": "Créer un agent",
       "createMenu": {
         "blank": "Vierge",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1980 — all three items:
- **aria-live for new notifications** — a polite `sr-only` live region in `NotificationListPanel` announces newly-arrived notifications (baseline on first render so the existing list isn't announced; load-more/mark-read don't announce), following the `voice-output-announcer` pattern.
- **DataTable `<caption>`s** — the shared `DataTable` already renders an `sr-only` `<caption>`; passed one on the agents and documents lists.
- **44px mobile touch targets** — `EditorActions` Save/Discard get `max-sm:min-h-11 max-sm:min-w-11` (44px) below `sm`, where they collapse to icon-only; desktop size unchanged.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, `test:ui` (23, incl. caption/touch-target/announcer tests) + i18n (47) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — added `notifications.newNotifications`, `settings.agents.tableCaption`, `documents.tableCaption` to en/de/fr.

## Test plan
With a screen reader, receive a new notification (announced), inspect the agents/documents tables (captioned), and check the mobile Save/Discard hit targets are ≥44px.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

