### PR TITLE
fix(platform): address automations/websites low-severity gaps (#2090)

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -201,6 +201,12 @@ export interface DataTableProps<TData, TValue = unknown> {
   rowClassName?: string | ((row: Row<TData>) => string);
   /** Callback when a row is clicked */
   onRowClick?: (row: Row<TData>) => void;
+  /**
+   * Per-row guard for `onRowClick`. When provided, only rows for which it
+   * returns `true` are clickable (cursor + click handler); the rest render as
+   * plain rows. Defaults to every row being clickable when `onRowClick` is set.
+   */
+  isRowClickable?: (row: Row<TData>) => boolean;
   /** Whether rows are clickable (adds cursor pointer) */
   clickableRows?: boolean;
   /** Called when the pointer enters a row; use with usePreloadRoute for programmatic preloading */
@@ -283,6 +289,7 @@ export function DataTable<TData, TValue = unknown>({
   className,
   rowClassName,
   onRowClick,
+  isRowClickable,
   onRowMouseEnter,
   clickableRows = false,
   // Header configuration props
@@ -951,6 +958,11 @@ export function DataTable<TData, TValue = unknown>({
                   ? rowClassName(row)
                   : rowClassName;
               const isNewRow = animatingRows.has(row.id);
+              // A row is click-navigable only when `onRowClick` is set and the
+              // optional `isRowClickable` guard admits it — so tables can leave
+              // dead rows (e.g. a metrics row with no destination) inert.
+              const rowClickable =
+                !!onRowClick && (isRowClickable?.(row) ?? true);
 
               return (
                 <Fragment key={row.id}>
@@ -963,7 +975,7 @@ export function DataTable<TData, TValue = unknown>({
                       // rows, so multi-line cells still grow past it.
                       'h-12',
                       index === rows.length - 1 ? 'border-b-0' : '',
-                      clickableRows || onRowClick ? 'cursor-pointer' : '',
+                      clickableRows || rowClickable ? 'cursor-pointer' : '',
                       isNewRow && 'animate-row-enter',
                       rowClassNameValue,
                     )}
@@ -974,7 +986,9 @@ export function DataTable<TData, TValue = unknown>({
                       if (enableExpanding) {
                         row.toggleExpanded();
                       }
-                      onRowClick?.(row);
+                      if (rowClickable) {
+                        onRowClick?.(row);
+                      }
                     }}
                   >
                     {enableExpanding && (

--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -2,7 +2,6 @@
 
 import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
-import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -18,7 +17,6 @@ import { useListPage } from '@/app/hooks/use-list-page';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { parseDebugWaitingFor } from '@/convex/workflow_engine/helpers/engine/debug_gate';
 import { useT } from '@/lib/i18n/client';
-import { formatDuration } from '@/lib/utils/format/number';
 import { slugToUrlParam } from '@/lib/utils/workflow-slug';
 
 import {
@@ -27,6 +25,7 @@ import {
   useListExecutions,
   useSearchExecution,
 } from '../hooks/queries';
+import { formatDurationSeconds } from '../metrics/format-duration';
 import { useExecutionsTableConfig } from './use-executions-table-config';
 
 interface ExecutionsTableProps {
@@ -132,7 +131,6 @@ export function ExecutionsTable({
 }: ExecutionsTableProps) {
   const navigate = useNavigate();
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const { locale } = useLocale();
   const { t: tCommon } = useT('common');
   const { t: tTables } = useT('tables');
   const { t: tAutomations } = useT('automations');
@@ -215,12 +213,14 @@ export function ExecutionsTable({
         return tCommon('actions.loading');
       }
       if (execution.completedAt && execution.startedAt) {
-        const duration = execution.completedAt - execution.startedAt;
-        return formatDuration(duration, locale);
+        const durationMs = execution.completedAt - execution.startedAt;
+        // Humanize to match the metrics tables (e.g. "2m", "1h 5m") instead of
+        // rendering raw milliseconds. formatDurationSeconds takes whole seconds.
+        return formatDurationSeconds(Math.round(durationMs / 1000));
       }
       return tTables('cells.empty');
     },
-    [tCommon, tTables, locale],
+    [tCommon, tTables],
   );
 
   const columns = useMemo<ColumnDef<Execution>[]>(

--- a/services/platform/app/features/automations/metrics/metrics-page.tsx
+++ b/services/platform/app/features/automations/metrics/metrics-page.tsx
@@ -92,6 +92,13 @@ export function WorkflowMetricsPage({
             completed={summary?.completed ?? 0}
             failed={summary?.failed ?? 0}
             running={summary?.running ?? 0}
+            pending={Math.max(
+              0,
+              (summary?.total ?? 0) -
+                (summary?.completed ?? 0) -
+                (summary?.failed ?? 0) -
+                (summary?.running ?? 0),
+            )}
           />
         </div>
       </Grid>

--- a/services/platform/app/features/automations/metrics/status-breakdown.tsx
+++ b/services/platform/app/features/automations/metrics/status-breakdown.tsx
@@ -17,15 +17,19 @@ interface StatusBreakdownProps {
   completed: number;
   failed: number;
   running: number;
+  pending: number;
 }
 
 export function StatusBreakdown({
   completed,
   failed,
   running,
+  pending,
 }: StatusBreakdownProps) {
   const { t } = useT('automations');
-  const total = completed + failed + running;
+  // Include pending so the donut center agrees with the "Total runs" KPI, which
+  // counts every in-window run regardless of status.
+  const total = completed + failed + running + pending;
 
   const segments: DonutSegment[] = [
     {
@@ -45,6 +49,12 @@ export function StatusBreakdown({
       label: t('metrics.chart.running'),
       value: running,
       color: CHART_COLORS.neutral,
+    },
+    {
+      key: 'pending',
+      label: t('metrics.chart.pending'),
+      value: pending,
+      color: CHART_COLORS.warning,
     },
   ];
 

--- a/services/platform/app/features/automations/metrics/top-workflows-table.tsx
+++ b/services/platform/app/features/automations/metrics/top-workflows-table.tsx
@@ -146,12 +146,11 @@ export function TopWorkflowsTable({
       <DataTable
         columns={columns}
         data={rows}
-        getRowId={(row) =>
-          row.wfDefinitionId ?? row.workflowSlug ?? Math.random().toString()
-        }
+        getRowId={(row) => row.wfDefinitionId ?? row.workflowSlug ?? 'unknown'}
         isLoading={isLoading}
         approxRowCount={isLoading ? 5 : rows.length}
         onRowClick={handleRowClick}
+        isRowClickable={(row) => !!row.original.workflowSlug}
         emptyState={{
           icon: BarChart3,
           title: t('metrics.empty.title'),

--- a/services/platform/app/features/automations/triggers/components/schedule-create-dialog.tsx
+++ b/services/platform/app/features/automations/triggers/components/schedule-create-dialog.tsx
@@ -109,7 +109,7 @@ export function ScheduleCreateDialog({
         cronExpression: z
           .string()
           .trim()
-          .min(1, 'Cron expression is required')
+          .min(1, t('triggers.schedules.form.validation.cronRequired'))
           .refine((value) => {
             try {
               CronExpressionParser.parse(value);
@@ -117,9 +117,9 @@ export function ScheduleCreateDialog({
             } catch {
               return false;
             }
-          }, 'Must be a valid 5-field cron expression'),
+          }, t('triggers.schedules.form.validation.cronInvalid')),
       }),
-    [],
+    [t],
   );
 
   const form = useForm<ScheduleFormData>({

--- a/services/platform/app/features/automations/triggers/components/secret-reveal-dialog.tsx
+++ b/services/platform/app/features/automations/triggers/components/secret-reveal-dialog.tsx
@@ -87,7 +87,9 @@ export function SecretRevealDialog({
                 variant="ghost"
                 onClick={() => handleCopy(secret.value, index)}
                 className="absolute top-1/2 right-2 -translate-y-1/2"
-                aria-label={`Copy ${secret.label}`}
+                aria-label={tCommon('actions.copyField', {
+                  label: secret.label,
+                })}
               >
                 {copiedIndex === index ? (
                   <Check className="size-4 text-green-500" />

--- a/services/platform/convex/agent_tools/websites/website_write_tool.ts
+++ b/services/platform/convex/agent_tools/websites/website_write_tool.ts
@@ -12,10 +12,12 @@ import { z } from 'zod/v4';
 
 import { internal } from '../../_generated/api';
 import { toId } from '../../lib/type_cast_helpers';
+import { SCAN_INTERVAL_VALUES } from '../../websites/validators';
 import { requireOrganizationId } from '../tasks/helpers/context';
 import type { ToolDefinition } from '../types';
 
 const STATUS = z.enum(['idle', 'scanning', 'active', 'error']);
+const SCAN_INTERVAL = z.enum(SCAN_INTERVAL_VALUES);
 
 // Optional attributes shared by create and update. `domain` and `scanInterval`
 // carry create-specific .describe() text, so they stay declared inline per
@@ -30,14 +32,14 @@ const websiteWriteArgs = z.discriminatedUnion('operation', [
   z.object({
     operation: z.literal('create'),
     domain: z.string().describe('Domain to register (e.g. example.com)'),
-    scanInterval: z.string().optional().describe('e.g. "6h", "1d"'),
+    scanInterval: SCAN_INTERVAL.optional().describe('e.g. "6h", "1d"'),
     ...websiteFields,
   }),
   z.object({
     operation: z.literal('update'),
     websiteId: z.string().describe('Convex Id<"websites">'),
     domain: z.string().optional(),
-    scanInterval: z.string().optional(),
+    scanInterval: SCAN_INTERVAL.optional(),
     ...websiteFields,
   }),
 ]);

--- a/services/platform/convex/websites/actions.ts
+++ b/services/platform/convex/websites/actions.ts
@@ -64,6 +64,8 @@ export const createWebsite = action({
     domain: v.string(),
     title: v.optional(v.string()),
     description: v.optional(v.string()),
+    // Runtime validation happens at the internal mutation chokepoint
+    // (`provisionWebsite`), which every write path funnels through.
     scanInterval: v.string(),
   },
   returns: v.id('websites'),
@@ -168,6 +170,8 @@ export const updateWebsite = action({
     domain: v.optional(v.string()),
     title: v.optional(v.string()),
     description: v.optional(v.string()),
+    // Runtime validation happens at the internal mutation chokepoint
+    // (`patchWebsite`), which every write path funnels through.
     scanInterval: v.optional(v.string()),
   },
   returns: v.null(),

--- a/services/platform/convex/websites/create_website.test.ts
+++ b/services/platform/convex/websites/create_website.test.ts
@@ -1,6 +1,7 @@
 import { convexTest } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
+import { internal } from '../_generated/api';
 import schema from '../schema';
 import { createWebsite } from './create_website';
 
@@ -96,5 +97,43 @@ describe('createWebsite duplicate guard (#2056)', () => {
 
     const row = await t.run((ctx) => ctx.db.get(id));
     expect(row?.domain).toBe('fresh.example.org');
+  });
+});
+
+describe('provisionWebsite scanInterval guard (#2090)', () => {
+  // Regression: an out-of-enum scanInterval must be rejected at the write
+  // chokepoint. Otherwise it is stored verbatim and silently crawled at the 6h
+  // default (scanIntervalToSeconds falls back to 21600 for unknown values).
+  it('rejects an out-of-enum scanInterval with INVALID_SCAN_INTERVAL', async () => {
+    const t = convexTest(schema, modules);
+
+    let code: string | undefined;
+    try {
+      await t.mutation(internal.websites.internal_mutations.provisionWebsite, {
+        organizationId: ORG,
+        domain: 'https://guarded.example.com',
+        scanInterval: '3h',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('INVALID_SCAN_INTERVAL');
+  });
+
+  it('stores a website when the scanInterval is in the allowed enum', async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(
+      internal.websites.internal_mutations.provisionWebsite,
+      {
+        organizationId: ORG,
+        domain: 'https://valid.example.com',
+        scanInterval: '12h',
+      },
+    );
+
+    const row = await t.run((ctx) => ctx.db.get(id));
+    expect(row?.scanInterval).toBe('12h');
   });
 });

--- a/services/platform/convex/websites/internal_mutations.ts
+++ b/services/platform/convex/websites/internal_mutations.ts
@@ -1,9 +1,28 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { internalMutation } from '../_generated/server';
 import * as WebsitesHelpers from './helpers';
-import { websiteStatusValidator } from './validators';
+import {
+  isValidScanInterval,
+  SCAN_INTERVAL_VALUES,
+  websiteStatusValidator,
+} from './validators';
+
+// Every website write funnels through `provisionWebsite`/`patchWebsite`, so
+// guarding the scan interval here rejects an out-of-enum value from any caller
+// (REST, the agent write tool, the Convex actions) before it is stored and
+// silently crawled at the 6h default. The DB column stays `v.string()`, so no
+// migration is needed — the guard is a runtime check, not a schema change.
+function assertScanInterval(scanInterval: string): void {
+  if (!isValidScanInterval(scanInterval)) {
+    throw new ConvexError({
+      code: 'INVALID_SCAN_INTERVAL',
+      scanInterval,
+      allowed: [...SCAN_INTERVAL_VALUES],
+    });
+  }
+}
 
 export const provisionWebsite = internalMutation({
   args: {
@@ -16,6 +35,7 @@ export const provisionWebsite = internalMutation({
     metadata: v.optional(jsonRecordValidator),
   },
   handler: async (ctx, args) => {
+    assertScanInterval(args.scanInterval);
     return await WebsitesHelpers.createWebsite(ctx, args);
   },
 });
@@ -47,6 +67,9 @@ export const patchWebsite = internalMutation({
     callerOrgId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    if (args.scanInterval !== undefined) {
+      assertScanInterval(args.scanInterval);
+    }
     return await WebsitesHelpers.updateWebsite(ctx, args);
   },
 });

--- a/services/platform/convex/websites/rest_api.ts
+++ b/services/platform/convex/websites/rest_api.ts
@@ -24,6 +24,7 @@ import {
 } from '../lib/rest/helpers';
 import { toId } from '../lib/type_cast_helpers';
 import { toWebsiteDomain } from './create_website';
+import { isValidScanInterval, SCAN_INTERVAL_VALUES } from './validators';
 
 const PREFIX = '/api/v1/websites/';
 
@@ -55,6 +56,12 @@ export const createWebsite = withRestAuth('rest:api', async (rc, request) => {
   }
   if (!body.scanInterval) {
     return jsonError('Missing required field: scanInterval', 400);
+  }
+  if (!isValidScanInterval(body.scanInterval)) {
+    return jsonError(
+      `Invalid scanInterval. Allowed values: ${SCAN_INTERVAL_VALUES.join(', ')}`,
+      400,
+    );
   }
 
   const domain = toWebsiteDomain(body.domain);
@@ -171,6 +178,16 @@ export const patchWebsite = withRestAuth('rest:api', async (rc, request) => {
   }
 
   const body = await request.json();
+
+  if (
+    body.scanInterval !== undefined &&
+    !isValidScanInterval(body.scanInterval)
+  ) {
+    return jsonError(
+      `Invalid scanInterval. Allowed values: ${SCAN_INTERVAL_VALUES.join(', ')}`,
+      400,
+    );
+  }
 
   await rc.ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
     websiteId: toId<'websites'>(id),

--- a/services/platform/convex/websites/validators.ts
+++ b/services/platform/convex/websites/validators.ts
@@ -14,6 +14,31 @@ export const websiteStatusValidator = v.union(
   v.literal('deleting'),
 );
 
+/**
+ * The allowed scan-interval cadences. This is the single source of truth for
+ * every write path (REST, the agent write tool, and the Convex actions) —
+ * `scanIntervalToSeconds` maps exactly these values, so an unrecognized value
+ * would silently fall back to the 6h default and get crawled at the wrong rate.
+ */
+export const SCAN_INTERVAL_VALUES = [
+  '60m',
+  '6h',
+  '12h',
+  '1d',
+  '5d',
+  '7d',
+  '30d',
+] as const;
+
+export type ScanInterval = (typeof SCAN_INTERVAL_VALUES)[number];
+
+export function isValidScanInterval(value: unknown): value is ScanInterval {
+  return (
+    typeof value === 'string' &&
+    (SCAN_INTERVAL_VALUES as readonly string[]).includes(value)
+  );
+}
+
 export const websiteValidator = v.object({
   _id: v.string(),
   _creationTime: v.number(),

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -759,7 +759,8 @@
         "noDataDescription": "Führe einen Workflow aus, um die Verteilung zu sehen",
         "completed": "Abgeschlossen",
         "failed": "Fehlgeschlagen",
-        "running": "Läuft"
+        "running": "Läuft",
+        "pending": "Ausstehend"
       },
       "table": {
         "title": "Top-Workflows",
@@ -857,6 +858,10 @@
           "variablesLabel": "Workflow-Variablen",
           "variablesDescription": "Eingabeparameter, die bei jedem geplanten Lauf übergeben werden. Vorausgefüllt aus dem Eingabeschema des Workflows.",
           "variablesInvalid": "Variablen müssen ein gültiges JSON-Objekt sein",
+          "validation": {
+            "cronRequired": "Cron-Ausdruck ist erforderlich",
+            "cronInvalid": "Muss ein gültiger Cron-Ausdruck mit 5 Feldern sein"
+          },
           "presets": {
             "every5Minutes": "Alle 5 Minuten",
             "hourly": "Jede Stunde",
@@ -1079,7 +1084,7 @@
       "createFailed": "Automatisierung konnte nicht erstellt werden"
     },
     "validation": {
-      "duplicateName": "Eine Automatisierung mit diesem Namen existiert bereits",
+      "duplicateName": "Eine Automatisierung mit einem passenden Bezeichner existiert bereits. Wähle einen eindeutigeren Namen.",
       "invalidName": "Der Name muss mindestens einen Buchstaben oder eine Ziffer enthalten"
     },
     "deleteAutomation": {
@@ -1985,6 +1990,7 @@
       "viewSource": "Quelle anzeigen",
       "source": "Quelle",
       "copy": "Kopieren",
+      "copyField": "{label} kopieren",
       "copied": "Kopiert!",
       "showInfo": "Info anzeigen",
       "clearAll": "Alle löschen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -762,7 +762,8 @@
         "noDataDescription": "Run a workflow to see breakdown",
         "completed": "Completed",
         "failed": "Failed",
-        "running": "Running"
+        "running": "Running",
+        "pending": "Pending"
       },
       "table": {
         "title": "Top workflows",
@@ -860,6 +861,10 @@
           "variablesLabel": "Workflow variables",
           "variablesDescription": "Input parameters passed to each scheduled run. Pre-filled from the workflow's input schema.",
           "variablesInvalid": "Variables must be valid JSON object",
+          "validation": {
+            "cronRequired": "Cron expression is required",
+            "cronInvalid": "Must be a valid 5-field cron expression"
+          },
           "presets": {
             "every5Minutes": "Every 5 minutes",
             "hourly": "Every hour",
@@ -1082,7 +1087,7 @@
       "createFailed": "Failed to create automation"
     },
     "validation": {
-      "duplicateName": "An automation with this name already exists",
+      "duplicateName": "An automation with a matching identifier already exists. Try a more distinct name.",
       "invalidName": "Name must contain at least one letter or number"
     },
     "deleteAutomation": {
@@ -1988,6 +1993,7 @@
       "viewSource": "View source",
       "source": "Source",
       "copy": "Copy",
+      "copyField": "Copy {label}",
       "copied": "Copied!",
       "showInfo": "Show info",
       "clearAll": "Clear all",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -760,7 +760,8 @@
         "noDataDescription": "Exécute un workflow pour voir la répartition",
         "completed": "Terminées",
         "failed": "Échouées",
-        "running": "En cours"
+        "running": "En cours",
+        "pending": "En attente"
       },
       "table": {
         "title": "Top workflows",
@@ -858,6 +859,10 @@
           "variablesLabel": "Variables du workflow",
           "variablesDescription": "Paramètres d'entrée transmis à chaque exécution planifiée. Pré-remplis depuis le schéma d'entrée du workflow.",
           "variablesInvalid": "Les variables doivent être un objet JSON valide",
+          "validation": {
+            "cronRequired": "L'expression cron est requise",
+            "cronInvalid": "Doit être une expression cron valide à 5 champs"
+          },
           "presets": {
             "every5Minutes": "Toutes les 5 minutes",
             "hourly": "Toutes les heures",
@@ -1080,7 +1085,7 @@
       "createFailed": "Échec de la création de l'automatisation"
     },
     "validation": {
-      "duplicateName": "Une automatisation avec ce nom existe déjà",
+      "duplicateName": "Une automatisation avec un identifiant équivalent existe déjà. Choisis un nom plus distinct.",
       "invalidName": "Le nom doit contenir au moins une lettre ou un chiffre"
     },
     "deleteAutomation": {
@@ -1986,6 +1991,7 @@
       "viewSource": "Voir la source",
       "source": "Source",
       "copy": "Copier",
+      "copyField": "Copier {label}",
       "copied": "Copié !",
       "showInfo": "Afficher les informations",
       "clearAll": "Tout effacer",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2090 — all seven enumerated items:
- **Cron validation** i18n'd (`schedules.form.validation.cronRequired`/`cronInvalid`).
- **Copy aria-label** now uses `common.actions.copyField` with the field name.
- **Duplicate-name message** reworded to describe an identifier collision, not a raw slug.
- **Dead null-slug rows / random key** — `DataTable` gained an optional `isRowClickable` predicate; the top-workflows table only makes rows with a slug clickable and uses a deterministic key.
- **Raw-ms duration** — executions Duration humanized via `formatDurationSeconds`.
- **Donut excludes pending** — `StatusBreakdown` adds a Pending segment so the center total matches the Total-runs KPI.
- **Unvalidated scanInterval** — validated at the internal-mutation chokepoint (`provisionWebsite`/`patchWebsite` throw `INVALID_SCAN_INTERVAL`), covering REST, agent tool, and Convex actions without a schema migration.

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean, component tests (56) + `websites`/`create_website` (incl. 2 new) + platform i18n (12) + `@tale/ui` i18n (54) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — new/changed keys in en/de/fr (DE `du`, FR `tu`), parity green.

## Test plan
Exercise the schedule cron field (validation), a webhook copy button (aria-label), the top-workflows table (no dead rows), executions duration (humanized), the metrics donut (pending segment), and a bad `scanInterval` (rejected).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

