### PR TITLE
fix(platform): notifications ordering, no dead rows, nav (#2377)

### DIFF
--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -27,6 +27,7 @@ import {
   useNotificationsUnreadCount,
   type NotificationsFilter,
 } from '../hooks/queries';
+import { mergeNotificationsByRecency } from '../lib/merge-notifications';
 import {
   orgNotificationTarget,
   personalNotificationTarget,
@@ -179,6 +180,13 @@ export function NotificationListPanel({
       ),
     [myNotifications, hiddenIds, filter],
   );
+  // One chronologically sorted stream across BOTH sources (#2377): an old
+  // personal item must never outrank a newer org alert. The per-source visual
+  // distinction stays an icon/namespace concern, not a positional one.
+  const mergedItems = useMemo(
+    () => mergeNotificationsByRecency(myItems, items),
+    [myItems, items],
+  );
   const unreadCount = (unread ?? 0) + myUnread;
   // Drive one "Load more" affordance off BOTH streams: it's enabled while
   // either has another page, shows progress while either is fetching, and a
@@ -277,54 +285,60 @@ export function NotificationListPanel({
           )
         ) : (
           <ul role="list" className="divide-border divide-y">
-            {myItems.map((n) => {
+            {mergedItems.map((entry) => {
+              if (entry.kind === 'personal') {
+                const n = entry.item;
+                const params = isRecord(n.params) ? n.params : undefined;
+                const approvalId =
+                  n.type === 'task_review_requested' &&
+                  typeof params?.approvalId === 'string'
+                    ? params.approvalId
+                    : undefined;
+                const target = personalNotificationTarget({
+                  organizationId,
+                  taskId: n.taskId,
+                  params: n.params,
+                });
+                return (
+                  <NotificationRow
+                    key={`personal:${n._id}`}
+                    title={tInbox(n.titleKey)}
+                    body={tInbox(
+                      n.bodyKey,
+                      // `params` is the i18n interpolation map (stored as
+                      // v.any()); narrow to what t() accepts.
+                      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- jsonRecord interpolation map
+                      params as Record<string, string | number>,
+                    )}
+                    createdAt={n.createdAt}
+                    read={n.read}
+                    target={target}
+                    onActivate={() => {
+                      if (!n.read) handleMarkMyRead(n._id);
+                      onNavigate?.();
+                    }}
+                    onMarkRead={() => handleMarkMyRead(n._id)}
+                    markReadPending={markMyRead.isPending}
+                  >
+                    {approvalId && (
+                      <ReviewActions
+                        notificationId={n._id}
+                        approvalId={approvalId}
+                      />
+                    )}
+                  </NotificationRow>
+                );
+              }
+              const n = entry.item;
               const params = isRecord(n.params) ? n.params : undefined;
-              const approvalId =
-                n.type === 'task_review_requested' &&
-                typeof params?.approvalId === 'string'
-                  ? params.approvalId
-                  : undefined;
-              const target = personalNotificationTarget({
+              const target = orgNotificationTarget(
                 organizationId,
-                taskId: n.taskId,
-                params: n.params,
-              });
-              return (
-                <NotificationRow
-                  key={n._id}
-                  title={tInbox(n.titleKey)}
-                  body={tInbox(
-                    n.bodyKey,
-                    // `params` is the i18n interpolation map (stored as
-                    // v.any()); narrow to what t() accepts.
-                    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- jsonRecord interpolation map
-                    params as Record<string, string | number>,
-                  )}
-                  createdAt={n.createdAt}
-                  read={n.read}
-                  target={target}
-                  onActivate={() => {
-                    if (!n.read) handleMarkMyRead(n._id);
-                    if (target) onNavigate?.();
-                  }}
-                  onMarkRead={() => handleMarkMyRead(n._id)}
-                  markReadPending={markMyRead.isPending}
-                >
-                  {approvalId && (
-                    <ReviewActions
-                      notificationId={n._id}
-                      approvalId={approvalId}
-                    />
-                  )}
-                </NotificationRow>
+                n.link,
+                n.category,
               );
-            })}
-            {items.map((n) => {
-              const params = isRecord(n.params) ? n.params : undefined;
-              const target = orgNotificationTarget(organizationId, n.link);
               return (
                 <NotificationRow
-                  key={n._id}
+                  key={`org:${n._id}`}
                   title={t(stripNsPrefix(n.titleKey), params)}
                   body={t(stripNsPrefix(n.bodyKey), params)}
                   createdAt={n.createdAt}
@@ -332,7 +346,7 @@ export function NotificationListPanel({
                   target={target}
                   onActivate={() => {
                     if (!n.read) handleMarkRead(n._id);
-                    if (target) onNavigate?.();
+                    onNavigate?.();
                   }}
                   onMarkRead={() => handleMarkRead(n._id)}
                   markReadPending={markRead.isPending}

--- a/services/platform/app/features/notifications/lib/merge-notifications.test.ts
+++ b/services/platform/app/features/notifications/lib/merge-notifications.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeNotificationsByRecency } from './merge-notifications';
+
+describe('mergeNotificationsByRecency', () => {
+  it('interleaves both streams newest-first across sources (#2377)', () => {
+    const personal = [
+      { id: 'p-new', createdAt: 300 },
+      { id: 'p-old', createdAt: 100 },
+    ];
+    const org = [
+      { id: 'o-mid', createdAt: 200 },
+      { id: 'o-oldest', createdAt: 50 },
+    ];
+
+    const merged = mergeNotificationsByRecency(personal, org);
+
+    expect(merged.map((e) => `${e.kind}:${e.item.id}`)).toEqual([
+      'personal:p-new',
+      'org:o-mid',
+      'personal:p-old',
+      'org:o-oldest',
+    ]);
+  });
+
+  it('keeps personal before org when timestamps tie (stable order)', () => {
+    const personal = [{ id: 'p', createdAt: 100 }];
+    const org = [{ id: 'o', createdAt: 100 }];
+
+    const merged = mergeNotificationsByRecency(personal, org);
+
+    expect(merged.map((e) => e.kind)).toEqual(['personal', 'org']);
+  });
+
+  it('handles an empty stream on either side', () => {
+    expect(
+      mergeNotificationsByRecency([], [{ id: 'o', createdAt: 1 }]),
+    ).toEqual([{ kind: 'org', item: { id: 'o', createdAt: 1 } }]);
+    expect(
+      mergeNotificationsByRecency([{ id: 'p', createdAt: 1 }], []),
+    ).toEqual([{ kind: 'personal', item: { id: 'p', createdAt: 1 } }]);
+  });
+});

--- a/services/platform/app/features/notifications/lib/merge-notifications.ts
+++ b/services/platform/app/features/notifications/lib/merge-notifications.ts
@@ -1,0 +1,32 @@
+/**
+ * Merge the two notification streams — the org-wide bell (`notifications`) and
+ * the per-user inbox (`userNotifications`) — into ONE chronologically sorted
+ * list. The bell renders both, and the user reads them as a single stream, so
+ * an old personal item must never outrank a newer org alert (or vice versa).
+ *
+ * Each element keeps a `kind` discriminant so the caller renders it against the
+ * right i18n namespace and deep-link resolver; visual distinction between the
+ * two sources stays an icon/badge concern, not a positional one.
+ */
+export type MergedNotification<Personal, Org> =
+  | { kind: 'personal'; item: Personal }
+  | { kind: 'org'; item: Org };
+
+/**
+ * Interleave `personal` and `org` items by `createdAt`, newest first. The sort
+ * is stable (ES2019+), so items sharing a timestamp keep personal-before-org
+ * order — deterministic for tests and render keys.
+ */
+export function mergeNotificationsByRecency<
+  Personal extends { createdAt: number },
+  Org extends { createdAt: number },
+>(
+  personal: readonly Personal[],
+  org: readonly Org[],
+): Array<MergedNotification<Personal, Org>> {
+  const merged: Array<MergedNotification<Personal, Org>> = [
+    ...personal.map((item) => ({ kind: 'personal' as const, item })),
+    ...org.map((item) => ({ kind: 'org' as const, item })),
+  ];
+  return merged.sort((a, b) => b.item.createdAt - a.item.createdAt);
+}

--- a/services/platform/app/features/notifications/lib/notification-target.test.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.test.ts
@@ -21,45 +21,62 @@ describe('personalNotificationTarget', () => {
     });
   });
 
-  it('returns null when projectId is missing (legacy rows)', () => {
-    expect(
-      personalNotificationTarget({
-        organizationId: ORG,
-        taskId: 'task_abc',
-        params: { title: 'No project here' },
-      }),
-    ).toBeNull();
-  });
-
-  it('returns null when taskId is missing', () => {
+  it('falls back to the project when taskId is missing but projectId is present', () => {
     expect(
       personalNotificationTarget({
         organizationId: ORG,
         taskId: undefined,
         params: { projectId: 'proj_xyz' },
       }),
-    ).toBeNull();
+    ).toEqual({
+      to: '/dashboard/$id/projects/$projectId',
+      params: { id: ORG, projectId: 'proj_xyz' },
+    });
   });
 
-  it('tolerates non-record params', () => {
+  it('falls back to the org home when there is no project context (legacy/digest)', () => {
+    expect(
+      personalNotificationTarget({
+        organizationId: ORG,
+        taskId: 'task_abc',
+        params: { title: 'No project here' },
+      }),
+    ).toEqual({ to: '/dashboard/$id', params: { id: ORG } });
+  });
+
+  it('falls back to the org home for non-record params (never a dead row)', () => {
     expect(
       personalNotificationTarget({
         organizationId: ORG,
         taskId: 'task_abc',
         params: undefined,
       }),
-    ).toBeNull();
+    ).toEqual({ to: '/dashboard/$id', params: { id: ORG } });
   });
 });
 
 describe('orgNotificationTarget', () => {
-  it('returns null when there is no link', () => {
-    expect(orgNotificationTarget(ORG, undefined)).toBeNull();
+  it('falls back to governance for a linkless security alert', () => {
+    expect(orgNotificationTarget(ORG, undefined, 'security')).toEqual({
+      to: '/dashboard/$id/settings/governance',
+      params: { id: ORG },
+    });
+  });
+
+  it('falls back to the automations hub for a linkless system/workflow alert', () => {
+    expect(orgNotificationTarget(ORG, undefined, 'system')).toEqual({
+      to: '/dashboard/$id/automations',
+      params: { id: ORG },
+    });
   });
 
   it('maps an agent link to the agent detail route', () => {
     expect(
-      orgNotificationTarget(ORG, { kind: 'agent', agentSlug: 'researcher' }),
+      orgNotificationTarget(
+        ORG,
+        { kind: 'agent', agentSlug: 'researcher' },
+        'system',
+      ),
     ).toEqual({
       to: '/dashboard/$id/agents/$agentId',
       params: { id: ORG, agentId: 'researcher' },
@@ -67,7 +84,9 @@ describe('orgNotificationTarget', () => {
   });
 
   it('maps audit-logs to the governance logs route', () => {
-    expect(orgNotificationTarget(ORG, { kind: 'audit-logs' })).toEqual({
+    expect(
+      orgNotificationTarget(ORG, { kind: 'audit-logs' }, 'security'),
+    ).toEqual({
       to: '/dashboard/$id/settings/governance/logs',
       params: { id: ORG },
     });
@@ -75,7 +94,11 @@ describe('orgNotificationTarget', () => {
 
   it('carries the broken-row logId into the logs route search (#1845)', () => {
     expect(
-      orgNotificationTarget(ORG, { kind: 'audit-logs', logId: 'log_bad' }),
+      orgNotificationTarget(
+        ORG,
+        { kind: 'audit-logs', logId: 'log_bad' },
+        'security',
+      ),
     ).toEqual({
       to: '/dashboard/$id/settings/governance/logs',
       params: { id: ORG },
@@ -84,18 +107,18 @@ describe('orgNotificationTarget', () => {
   });
 
   it('maps dsar to the data-subject-requests route', () => {
-    expect(orgNotificationTarget(ORG, { kind: 'dsar' })).toEqual({
+    expect(orgNotificationTarget(ORG, { kind: 'dsar' }, 'security')).toEqual({
       to: '/dashboard/$id/settings/governance/data-subject-requests',
       params: { id: ORG },
     });
   });
 
   it('maps security-monitoring to the governance security route', () => {
-    expect(orgNotificationTarget(ORG, { kind: 'security-monitoring' })).toEqual(
-      {
-        to: '/dashboard/$id/settings/governance/security-monitoring',
-        params: { id: ORG },
-      },
-    );
+    expect(
+      orgNotificationTarget(ORG, { kind: 'security-monitoring' }, 'security'),
+    ).toEqual({
+      to: '/dashboard/$id/settings/governance/security-monitoring',
+      params: { id: ORG },
+    });
   });
 });

--- a/services/platform/app/features/notifications/lib/notification-target.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.ts
@@ -30,6 +30,32 @@ export type NotificationTarget =
   | {
       to: '/dashboard/$id/settings/governance/security-monitoring';
       params: { id: string };
+    }
+  // --- Fallbacks (#2377): every notification navigates somewhere sensible so
+  // no row is a silently dead, cursor-default line. ---
+  // Project overview — a personal row that names a project but no specific task.
+  | {
+      to: '/dashboard/$id/projects/$projectId';
+      params: { id: string; projectId: string };
+    }
+  // Automations hub — landing for a generic system/workflow org alert with no
+  // more specific link (workflow notifications flow through the automations
+  // engine, so their home is the automations list).
+  | {
+      to: '/dashboard/$id/automations';
+      params: { id: string };
+    }
+  // Governance overview — landing for a security org alert with no more
+  // specific link (the security/audit/DSAR pages all live under Governance).
+  | {
+      to: '/dashboard/$id/settings/governance';
+      params: { id: string };
+    }
+  // Org home — last-resort landing for a personal row with no project context
+  // (e.g. a digest, or a legacy row written before `projectId` was stored).
+  | {
+      to: '/dashboard/$id';
+      params: { id: string };
     };
 
 /**
@@ -47,37 +73,53 @@ export type OrgNotificationLink =
 /**
  * Deep-link target for a PERSONAL notification (`userNotifications`). Every
  * task-bound type (assignment / status / comment / mention / review) routes to
- * the task inside its project. Returns `null` when the row lacks the context to
- * build a link — legacy rows written before `projectId` was stored in `params`,
- * or non-task resources we don't deep-link yet.
+ * the task inside its project; a row that names a project but no task opens the
+ * project; anything else falls back to the org home. Always returns a target —
+ * a personal row is never a dead, unclickable line (#2377).
  */
 export function personalNotificationTarget(args: {
   organizationId: string;
   taskId: string | undefined;
   params: unknown;
-}): NotificationTarget | null {
+}): NotificationTarget {
+  const id = args.organizationId;
   const params = isRecord(args.params) ? args.params : undefined;
-  const projectId = params?.projectId;
-  if (args.taskId && typeof projectId === 'string') {
+  const projectId =
+    typeof params?.projectId === 'string' ? params.projectId : undefined;
+  if (args.taskId && projectId) {
     return {
       to: '/dashboard/$id/projects/$projectId/tasks',
-      params: { id: args.organizationId, projectId },
+      params: { id, projectId },
       search: { task: args.taskId },
     };
   }
-  return null;
+  if (projectId) {
+    return {
+      to: '/dashboard/$id/projects/$projectId',
+      params: { id, projectId },
+    };
+  }
+  return { to: '/dashboard/$id', params: { id } };
 }
 
 /**
- * Deep-link target for an ORG notification's stored `link`. Returns `null` when
- * the notification carries no link (legacy rows, or generic workflow alerts).
+ * Deep-link target for an ORG notification. A stored `link` routes to its
+ * specific page; a linkless row (legacy or generic workflow/system alert) falls
+ * back by `category` — security alerts land on Governance, everything else on
+ * the Automations hub. Always returns a target, so an org row is never a dead,
+ * unclickable line (#2377).
  */
 export function orgNotificationTarget(
   organizationId: string,
   link: OrgNotificationLink | undefined,
-): NotificationTarget | null {
-  if (!link) return null;
+  category: 'security' | 'system',
+): NotificationTarget {
   const id = organizationId;
+  if (!link) {
+    return category === 'security'
+      ? { to: '/dashboard/$id/settings/governance', params: { id } }
+      : { to: '/dashboard/$id/automations', params: { id } };
+  }
   switch (link.kind) {
     case 'agent':
       return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2377 — all three parts:
- **Global newest-first ordering** — a pure `mergeNotificationsByRecency` sorts the loaded personal + org pages by `createdAt` desc (stable tie-break) instead of concatenating per source, so a newer org alert can't be outranked by an older personal item.
- **No dead rows** — both target resolvers now always return a target (legacy personal rows → project/org-home fallback; linkless org rows → category fallback), so no read notification renders as an inert line.
- **Nav target for every type** — personal task→modal (unchanged), project→project overview, else org home; org `link.kind` routes unchanged, linkless `security`→Governance and `system`→Automations. Where the payload carried no run/execution id, it maps to the most sensible existing landing page (no invented routes; noted).

## Checklist
- [x] `bun run check` — type-aware lint (0/0), typecheck clean (validates every router `to` target), `test:ui` (22, incl. new merge + target-fallback tests) passing.
- [x] `lint:sast` — N/A (Opengrep not cached).
- [x] Translations — N/A (ordering/route logic only).

## Test plan
Open notifications with mixed personal/org items → newest-first across sources; every row (including legacy/linkless) navigates somewhere sensible on click.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8e6702-d7c3-4ace-98dc-063889516542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

