### PR TITLE
fix: unify dashboard nav and chat history into one collapsible panel (#2428)

### DIFF
--- a/services/platform/app/features/chat/components/chat-dashboard-sidebar.test.tsx
+++ b/services/platform/app/features/chat/components/chat-dashboard-sidebar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import enMessages from '../../../../messages/en.json';
+import { ChatDashboardSidebar } from './chat-dashboard-sidebar';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    Link: ({
+      children,
+      ...rest
+    }: {
+      children: React.ReactNode;
+      to?: string;
+      params?: Record<string, string>;
+      preload?: string;
+      className?: string;
+      onClick?: () => void;
+    }) => (
+      <a href={rest.to} {...rest}>
+        {children}
+      </a>
+    ),
+    useLocation: () => ({ pathname: '/dashboard/org-1/chat' }),
+    useNavigate: () => vi.fn(),
+    useParams: () => ({}),
+    useRouter: () => ({ preloadRoute: vi.fn() }),
+  };
+});
+
+vi.mock('@/app/components/ui/navigation/navigation', () => ({
+  Navigation: () => <nav data-testid="dashboard-nav">nav</nav>,
+}));
+
+vi.mock('./chat-history-sidebar', () => ({
+  ChatHistorySidebar: () => (
+    <div data-testid="chat-history-sidebar">history</div>
+  ),
+}));
+
+vi.mock('../context/chat-layout-context', () => ({
+  useChatLayout: () => ({
+    isHistoryOpen: true,
+    setIsHistoryOpen: vi.fn(),
+  }),
+}));
+
+vi.mock('@/app/hooks/use-prefers-reduced-motion', () => ({
+  usePrefersReducedMotion: () => false,
+}));
+
+describe('ChatDashboardSidebar', () => {
+  it('renders nav rail and history panel landmark', () => {
+    render(<ChatDashboardSidebar organizationId="org-1" />);
+
+    expect(screen.getByTestId('dashboard-nav')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-history-sidebar')).toBeInTheDocument();
+    expect(
+      screen.getByRole('complementary', {
+        name: enMessages.chat.unifiedSidebar.landmark,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  describe('accessibility', () => {
+    it('passes axe audit', async () => {
+      const { container } = render(
+        <ChatDashboardSidebar organizationId="org-1" />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+});

--- a/services/platform/app/features/chat/components/chat-dashboard-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-dashboard-sidebar.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { Row, Stack } from '@tale/ui/layout';
+import { Link, useLocation } from '@tanstack/react-router';
+import { m } from 'framer-motion';
+import { useCallback, useMemo } from 'react';
+
+import { Navigation } from '@/app/components/ui/navigation/navigation';
+import { Sheet } from '@/app/components/ui/overlays/sheet';
+import { useAbility } from '@/app/hooks/use-ability';
+import {
+  useNavigationItems,
+  type NavItem,
+} from '@/app/hooks/use-navigation-items';
+import { usePrefersReducedMotion } from '@/app/hooks/use-prefers-reduced-motion';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import { useChatLayout } from '../context/chat-layout-context';
+import { ChatHistorySidebar } from './chat-history-sidebar';
+
+const HISTORY_PANEL_WIDTH = 'var(--chat-history-width, 18rem)';
+
+interface ChatDashboardSidebarProps {
+  organizationId: string;
+}
+
+function MobileNavLink({
+  item,
+  onNavigate,
+}: {
+  item: NavItem;
+  onNavigate: () => void;
+}) {
+  const location = useLocation();
+  const ability = useAbility();
+  const pathname = location.pathname;
+
+  if (item.can && !ability.can(item.can[0], item.can[1])) {
+    return null;
+  }
+
+  const isActive = item.isActivePath
+    ? item.isActivePath(pathname)
+    : pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+  const Icon = item.icon;
+  const content = (
+    <>
+      {Icon && (
+        <Icon
+          className={cn(
+            'size-5 shrink-0',
+            isActive ? 'text-foreground' : 'text-muted-foreground',
+          )}
+          aria-hidden="true"
+        />
+      )}
+      <span className="truncate text-sm font-medium">{item.label}</span>
+    </>
+  );
+
+  const className = cn(
+    'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors',
+    'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+    isActive ? 'bg-muted text-foreground' : 'hover:bg-muted/60 text-foreground',
+  );
+
+  if (item.external) {
+    return (
+      <li>
+        <a
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={className}
+          onClick={onNavigate}
+        >
+          {content}
+        </a>
+      </li>
+    );
+  }
+
+  return (
+    <li>
+      <Link
+        to={item.to}
+        params={item.params}
+        preload="render"
+        className={className}
+        onClick={onNavigate}
+      >
+        {content}
+      </Link>
+    </li>
+  );
+}
+
+function MobileNavigationList({
+  organizationId,
+  onNavigate,
+}: {
+  organizationId: string;
+  onNavigate: () => void;
+}) {
+  const { t: tCommon } = useT('common');
+  const { primary, pinned } = useNavigationItems(organizationId);
+  const items = useMemo(() => [...primary, ...pinned], [primary, pinned]);
+
+  return (
+    <nav aria-label={tCommon('aria.mainNavigation')}>
+      <ul role="list" className="flex flex-col gap-1 px-2 py-2">
+        {items.map((item) => (
+          <MobileNavLink key={item.href} item={item} onNavigate={onNavigate} />
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+export interface ChatMobileSidebarSheetProps {
+  organizationId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Unified mobile drawer: primary nav destinations plus chat history. */
+export function ChatMobileSidebarSheet({
+  organizationId,
+  open,
+  onOpenChange,
+}: ChatMobileSidebarSheetProps) {
+  const { t } = useT('chat');
+  const handleNavigate = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
+  const handleChatSelect = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={onOpenChange}
+      side="left"
+      title={t('unifiedSidebar.title')}
+      className="flex w-[min(100vw,20rem)] flex-col p-0 md:hidden"
+      hideClose
+    >
+      <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
+        <MobileNavigationList
+          organizationId={organizationId}
+          onNavigate={handleNavigate}
+        />
+        <div className="border-border min-h-0 flex-1 overflow-hidden border-t">
+          <ChatHistorySidebar
+            organizationId={organizationId}
+            onChatSelect={handleChatSelect}
+            className="h-full"
+          />
+        </div>
+      </Stack>
+    </Sheet>
+  );
+}
+
+/**
+ * Desktop unified left panel: icon nav rail plus an expandable chat-history
+ * column. Collapsed state shows only the rail; expanded adds the history list.
+ */
+export function ChatDashboardSidebar({
+  organizationId,
+}: ChatDashboardSidebarProps) {
+  const { isHistoryOpen } = useChatLayout();
+  const { t } = useT('chat');
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const transition = prefersReducedMotion
+    ? { duration: 0 }
+    : { duration: 0.3, ease: [0.25, 0.1, 0.25, 1] as const };
+
+  return (
+    <aside
+      aria-label={t('unifiedSidebar.landmark')}
+      className="bg-background relative hidden h-full shrink-0 md:flex"
+    >
+      <Row gap={0} align="stretch" className="border-border h-full border-r">
+        <div className="h-full w-[var(--nav-size)] shrink-0 px-2">
+          <Navigation organizationId={organizationId} />
+        </div>
+
+        <m.div
+          id="chat-history-panel"
+          initial={false}
+          animate={{ width: isHistoryOpen ? HISTORY_PANEL_WIDTH : 0 }}
+          transition={transition}
+          className="relative overflow-hidden"
+          aria-hidden={!isHistoryOpen}
+        >
+          <Stack
+            gap={0}
+            className="border-border bg-background h-full overflow-hidden border-l"
+            style={{ width: HISTORY_PANEL_WIDTH }}
+          >
+            <ChatHistorySidebar organizationId={organizationId} />
+          </Stack>
+        </m.div>
+      </Row>
+    </aside>
+  );
+}

--- a/services/platform/app/features/chat/components/chat-header.test.tsx
+++ b/services/platform/app/features/chat/components/chat-header.test.tsx
@@ -38,6 +38,10 @@ vi.mock('./chat-history-sidebar', () => ({
   ChatHistorySidebar: () => <div data-testid="chat-history-sidebar" />,
 }));
 
+vi.mock('./chat-dashboard-sidebar', () => ({
+  ChatMobileSidebarSheet: () => null,
+}));
+
 // Stub the threads source so the header's SearchCommand doesn't reach Convex
 // (the source hook calls `useThreads`, which needs a ConvexProvider). The
 // returned state is driven by `sourceRef` so tests can vary results/status.

--- a/services/platform/app/features/chat/components/chat-header.tsx
+++ b/services/platform/app/features/chat/components/chat-header.tsx
@@ -19,7 +19,6 @@ import {
 import { useEffect, useState, useCallback, useMemo } from 'react';
 
 import { AdaptiveHeaderRoot } from '@/app/components/layout/adaptive-header';
-import { Sheet } from '@/app/components/ui/overlays/sheet';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { useChatLayout } from '@/app/features/chat/context/chat-layout-context';
 import { useFormatDate } from '@/app/hooks/use-format-date';
@@ -28,7 +27,7 @@ import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
-import { ChatHistorySidebar } from './chat-history-sidebar';
+import { ChatMobileSidebarSheet } from './chat-dashboard-sidebar';
 import { ExportChatDialog } from './export-chat-dialog';
 import { ShareChatDialog } from './share-chat-dialog';
 import { createThreadsSearchSource } from './threads-search-source';
@@ -41,7 +40,7 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
   const navigate = useNavigate();
   const { isHistoryOpen, setIsHistoryOpen } = useChatLayout();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [isMobileHistoryOpen, setIsMobileHistoryOpen] = useState(false);
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const isMac = useIsMac();
@@ -93,18 +92,14 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
     setIsSearchOpen((prev) => !prev);
   }, []);
 
-  const handleToggleHistory = useCallback(() => {
+  const handleToggleSidebar = useCallback(() => {
     const isMobile = window.matchMedia('(max-width: 767px)').matches;
     if (isMobile) {
-      setIsMobileHistoryOpen((prev) => !prev);
+      setIsMobileSidebarOpen((prev) => !prev);
     } else {
       setIsHistoryOpen(!isHistoryOpen);
     }
   }, [isHistoryOpen, setIsHistoryOpen]);
-
-  const handleChatSelect = useCallback(() => {
-    setIsMobileHistoryOpen(false);
-  }, []);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -118,12 +113,12 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
       if (isMod && !e.shiftKey && (e.key === 'h' || e.key === 'H')) {
         e.preventDefault();
         e.stopPropagation();
-        handleToggleHistory();
+        handleToggleSidebar();
       }
     };
     window.addEventListener('keydown', onKeyDown, true);
     return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [isMac, handleToggleSearch, handleToggleHistory]);
+  }, [isMac, handleToggleSearch, handleToggleSidebar]);
 
   // The per-thread voice toggle moved to the composer (next to dictation),
   // so the header dropdown now only carries the export action.
@@ -145,20 +140,11 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
 
   return (
     <>
-      <Sheet
-        open={isMobileHistoryOpen}
-        onOpenChange={setIsMobileHistoryOpen}
-        side="left"
-        title={tChat('chatHistory')}
-        className="w-[18rem] p-0 md:hidden"
-        hideClose
-      >
-        <ChatHistorySidebar
-          organizationId={organizationId}
-          onChatSelect={handleChatSelect}
-          className="h-full"
-        />
-      </Sheet>
+      <ChatMobileSidebarSheet
+        organizationId={organizationId}
+        open={isMobileSidebarOpen}
+        onOpenChange={setIsMobileSidebarOpen}
+      />
 
       <div className="border-border bg-background/95 hidden h-13 items-center border-b px-4 backdrop-blur-xs md:flex">
         <Tooltip
@@ -176,10 +162,12 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
           <Button
             size="icon"
             variant="ghost"
-            onClick={handleToggleHistory}
+            onClick={handleToggleSidebar}
             aria-label={
               isHistoryOpen ? tChat('hideHistory') : tChat('showHistory')
             }
+            aria-expanded={isHistoryOpen}
+            aria-controls="chat-history-panel"
             // Negative margin pulls the icon's glyph to the header's content
             // edge so it lines up with page titles (which start at px-4), since
             // a ghost icon button carries its own p-2 inset. Same idiom as the
@@ -254,15 +242,16 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
           <Button
             size="icon"
             variant="ghost"
-            onClick={handleToggleHistory}
-            title={
-              isMobileHistoryOpen ? tChat('hideHistory') : tChat('showHistory')
+            onClick={handleToggleSidebar}
+            aria-label={
+              isMobileSidebarOpen ? tChat('hideHistory') : tChat('showHistory')
             }
+            aria-expanded={isMobileSidebarOpen}
           >
             <MessagesSquare
               className={cn(
                 baseIconClasses,
-                isMobileHistoryOpen && 'text-accent-foreground',
+                isMobileSidebarOpen && 'text-accent-foreground',
               )}
             />
           </Button>

--- a/services/platform/app/features/chat/context/chat-layout-context.tsx
+++ b/services/platform/app/features/chat/context/chat-layout-context.tsx
@@ -147,7 +147,13 @@ export function ChatLayoutProvider({
   const [pendingMessage, setPendingMessage] = useState<PendingMessage | null>(
     null,
   );
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const sidebarExpandedKey = user?.userId
+    ? `chat-dashboard-sidebar-expanded-${user.userId}-${organizationId}`
+    : `chat-dashboard-sidebar-expanded-${organizationId}`;
+  const [isHistoryOpen, setIsHistoryOpen] = usePersistedState(
+    sidebarExpandedKey,
+    false,
+  );
   const [insertedPrompt, setInsertedPrompt] = useState<string | null>(null);
   const [quotedText, setQuotedText] = useState<string | null>(null);
   const [editingImageRef, setEditingImageRef] =
@@ -266,6 +272,7 @@ export function ChatLayoutProvider({
       clearChatState,
       pendingMessage,
       isHistoryOpen,
+      setIsHistoryOpen,
       selectedAgent,
       setSelectedAgent,
       selectedModelOverrides,

--- a/services/platform/app/globals.css
+++ b/services/platform/app/globals.css
@@ -10,4 +10,5 @@
  */
 :root {
   --nav-size: 3.5rem;
+  --chat-history-width: 18rem;
 }

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -6,7 +6,12 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Spinner } from '@tale/ui/spinner';
 import { Text } from '@tale/ui/text';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Outlet, createFileRoute, useNavigate } from '@tanstack/react-router';
+import {
+  Outlet,
+  createFileRoute,
+  useLocation,
+  useNavigate,
+} from '@tanstack/react-router';
 import { useMutation } from 'convex/react';
 import { useEffect, useRef } from 'react';
 
@@ -41,6 +46,7 @@ import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 import { defineAbilityFor, type AppAbility } from '@/lib/permissions/ability';
+import { cn } from '@/lib/utils/cn';
 
 // Fire-and-forget warm of an action-backed config catalog into the SAME
 // TanStack Query cache entry the `useActionQuery` hooks read (matching key +
@@ -115,6 +121,10 @@ export const Route = createFileRoute('/dashboard/$id')({
 
 function DashboardLayout() {
   const { id: organizationId } = Route.useParams();
+  const location = useLocation();
+  const isChatSurface = location.pathname.startsWith(
+    `/dashboard/${organizationId}/chat`,
+  );
   usePasswordExpiryGate(organizationId);
 
   // Theme the app to this org's branding. BrandingProvider sits above the
@@ -301,7 +311,12 @@ function DashboardLayout() {
                   </Row>
                 </header>
 
-                <div className="bg-background hidden h-full px-2 md:flex md:flex-[0_0_var(--nav-size)]">
+                <div
+                  className={cn(
+                    'bg-background hidden h-full px-2 md:flex md:flex-[0_0_var(--nav-size)]',
+                    isChatSurface && 'md:hidden',
+                  )}
+                >
                   {hasRole ? (
                     <Navigation organizationId={organizationId} />
                   ) : (
@@ -427,9 +442,9 @@ export function DashboardShellFrame() {
       <div className="bg-background border-border border-b px-4 pt-(--safe-top) md:hidden">
         <Skeletonize loading>
           <Row gap={2} className="min-h-12">
-            {/* Leading action icons (chat history / search / new chat). */}
+            {/* Leading action icons (sidebar menu / search). */}
             <Row gap={0} align="stretch" className="flex-1">
-              {Array.from({ length: 3 }, (_, i) => (
+              {Array.from({ length: 2 }, (_, i) => (
                 // eslint-disable-next-line react/no-array-index-key
                 <Row key={i} gap={0} justify="center" className="p-2">
                   <SkeletonBox>

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.test.tsx
@@ -18,6 +18,8 @@ vi.mock('@tanstack/react-router', () => ({
     useParams: mockUseParams,
     ...config,
   }),
+  createRootRouteWithContext: () => () => (config: Record<string, unknown>) =>
+    config,
   Link: ({ children }: { children: React.ReactNode }) => (
     <a href="/">{children}</a>
   ),

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -2,7 +2,6 @@ import { Button } from '@tale/ui/button';
 import { Row, Stack } from '@tale/ui/layout';
 import { createFileRoute, useMatch, useNavigate } from '@tanstack/react-router';
 import { useQuery } from 'convex/react';
-import { m, AnimatePresence } from 'framer-motion';
 import { useState, useEffect, useRef } from 'react';
 import { z } from 'zod';
 
@@ -11,8 +10,8 @@ import { SuspenseBoundary } from '@/app/components/error-boundaries/core/suspens
 import { PageLayout } from '@/app/components/layout/page-layout';
 import { ArenaModeProvider } from '@/app/features/chat/components/arena/arena-mode-context';
 import { BudgetBanner } from '@/app/features/chat/components/budget-banner';
+import { ChatDashboardSidebar } from '@/app/features/chat/components/chat-dashboard-sidebar';
 import { ChatHeader } from '@/app/features/chat/components/chat-header';
-import { ChatHistorySidebar } from '@/app/features/chat/components/chat-history-sidebar';
 import { ChatInterface } from '@/app/features/chat/components/chat-interface';
 import { ChatMessagesSkeleton } from '@/app/features/chat/components/chat-messages-skeleton';
 import {
@@ -227,7 +226,7 @@ function ThreadGate({
 }
 
 function ChatLayoutContent({ organizationId }: { organizationId: string }) {
-  const { isHistoryOpen, clearChatState } = useChatLayout();
+  const { clearChatState } = useChatLayout();
   const { resetWorkspace } = useWorkspace();
   const { reset: resetChatPanel } = useChatPanel();
 
@@ -294,61 +293,46 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
 
   return (
     <PageLayout className="bg-background h-full overflow-hidden">
-      <LayoutErrorBoundary organizationId={organizationId}>
-        <ChatHeader organizationId={organizationId} threadId={threadId} />
-      </LayoutErrorBoundary>
-
       <Row gap={0} align="stretch" className="min-h-0 flex-1 overflow-hidden">
-        <AnimatePresence initial={false}>
-          {isHistoryOpen && (
-            <m.div
-              initial={{ width: 0 }}
-              animate={{ width: '18rem' }}
-              exit={{ width: 0 }}
-              transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
-              className="relative hidden w-[18rem] shrink-0 md:block"
-            >
-              <Stack
-                gap={0}
-                className="border-border bg-background h-full overflow-hidden border-r"
-              >
-                <LayoutErrorBoundary organizationId={organizationId}>
-                  <ChatHistorySidebar organizationId={organizationId} />
-                </LayoutErrorBoundary>
-              </Stack>
-            </m.div>
-          )}
-        </AnimatePresence>
+        <LayoutErrorBoundary organizationId={organizationId}>
+          <ChatDashboardSidebar organizationId={organizationId} />
+        </LayoutErrorBoundary>
 
-        {/* BranchProvider wraps the message column AND the right-side panes so
-            the canvas resolves files against the same active-branch thread the
-            message list uses. Without this, the canvas reads files from the raw
-            route threadId and branch-tip files vanish after streaming. */}
-        <BranchProvider threadId={threadId} organizationId={organizationId}>
-          <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
-            <BudgetBanner organizationId={organizationId} />
-            <LayoutErrorBoundary organizationId={organizationId}>
-              <ThreadGate
-                organizationId={organizationId}
-                threadId={threadId}
-                newChatCount={newChatCount}
-              />
-            </LayoutErrorBoundary>
-          </Stack>
-
-          {/* The four panes are registrars — they publish descriptors to the
-              unified right panel and render nothing themselves. The single
-              <ChatPanel> shell renders the shared strip / tabs / bodies. Plan
-              and Canvas always mount; the sandbox panes (Files + Live browser)
-              register only when `sandboxPanesAvailable`. */}
-          <PlanPane />
-          <CanvasPane organizationId={organizationId} />
-          <WorkspaceFilesPane available={sandboxPanesAvailable} />
-          <LiveBrowserPane available={sandboxPanesAvailable} />
+        <Stack gap={0} className="min-h-0 min-w-0 flex-1 overflow-hidden">
           <LayoutErrorBoundary organizationId={organizationId}>
-            <ChatPanel />
+            <ChatHeader organizationId={organizationId} threadId={threadId} />
           </LayoutErrorBoundary>
-        </BranchProvider>
+
+          {/* BranchProvider wraps the message column AND the right-side panes so
+              the canvas resolves files against the same active-branch thread the
+              message list uses. Without this, the canvas reads files from the raw
+              route threadId and branch-tip files vanish after streaming. */}
+          <BranchProvider threadId={threadId} organizationId={organizationId}>
+            <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
+              <BudgetBanner organizationId={organizationId} />
+              <LayoutErrorBoundary organizationId={organizationId}>
+                <ThreadGate
+                  organizationId={organizationId}
+                  threadId={threadId}
+                  newChatCount={newChatCount}
+                />
+              </LayoutErrorBoundary>
+            </Stack>
+
+            {/* The four panes are registrars — they publish descriptors to the
+                unified right panel and render nothing themselves. The single
+                <ChatPanel> shell renders the shared strip / tabs / bodies. Plan
+                and Canvas always mount; the sandbox panes (Files + Live browser)
+                register only when `sandboxPanesAvailable`. */}
+            <PlanPane />
+            <CanvasPane organizationId={organizationId} />
+            <WorkspaceFilesPane available={sandboxPanesAvailable} />
+            <LiveBrowserPane available={sandboxPanesAvailable} />
+            <LayoutErrorBoundary organizationId={organizationId}>
+              <ChatPanel />
+            </LayoutErrorBoundary>
+          </BranchProvider>
+        </Stack>
       </Row>
     </PageLayout>
   );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1413,6 +1413,10 @@
     "showHistory": "Verlauf anzeigen",
     "hideHistory": "Verlauf ausblenden",
     "chatHistory": "Chatverlauf",
+    "unifiedSidebar": {
+      "title": "Menü",
+      "landmark": "Dashboard-Seitenleiste"
+    },
     "newProject": "Neues Projekt",
     "typeMessageHere": "Gib hier deine Nachricht ein...",
     "send": "Nachricht senden",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1412,7 +1412,6 @@
     "hideSearch": "Suche ausblenden",
     "showHistory": "Verlauf anzeigen",
     "hideHistory": "Verlauf ausblenden",
-    "chatHistory": "Chatverlauf",
     "unifiedSidebar": {
       "title": "Menü",
       "landmark": "Dashboard-Seitenleiste"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1416,6 +1416,10 @@
     "showHistory": "Show chats",
     "hideHistory": "Hide chats",
     "chatHistory": "Chats",
+    "unifiedSidebar": {
+      "title": "Menu",
+      "landmark": "Dashboard sidebar"
+    },
     "newProject": "New project",
     "typeMessageHere": "Type your message here…",
     "send": "Send message",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1415,7 +1415,6 @@
     "hideSearch": "Hide search",
     "showHistory": "Show chats",
     "hideHistory": "Hide chats",
-    "chatHistory": "Chats",
     "unifiedSidebar": {
       "title": "Menu",
       "landmark": "Dashboard sidebar"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1413,7 +1413,6 @@
     "hideSearch": "Masquer la recherche",
     "showHistory": "Afficher l'historique",
     "hideHistory": "Masquer l'historique",
-    "chatHistory": "Historique",
     "unifiedSidebar": {
       "title": "Menu",
       "landmark": "Barre latérale du tableau de bord"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1414,6 +1414,10 @@
     "showHistory": "Afficher l'historique",
     "hideHistory": "Masquer l'historique",
     "chatHistory": "Historique",
+    "unifiedSidebar": {
+      "title": "Menu",
+      "landmark": "Barre latérale du tableau de bord"
+    },
     "newProject": "Nouveau projet",
     "typeMessageHere": "Saisis ton message ici…",
     "send": "Envoyer le message",

--- a/services/platform/tests/e2e/helpers/chat.ts
+++ b/services/platform/tests/e2e/helpers/chat.ts
@@ -123,6 +123,28 @@ export async function expectCannedReply(page: Page): Promise<void> {
   });
 }
 
+/** Desktop/mobile history toggle — label flips once the panel is open. */
+function historySidebarToggle(page: Page): Locator {
+  return page
+    .getByRole('button', { name: t('chat.showHistory') })
+    .or(page.getByRole('button', { name: t('chat.hideHistory') }))
+    .first();
+}
+
+/**
+ * Ensure the chat history column is expanded. After #2428 the open/closed
+ * preference persists per user+org, so callers must not assume "Show chats" is
+ * always present — only click when `aria-expanded` is false.
+ */
+export async function ensureHistorySidebarOpen(page: Page): Promise<void> {
+  const toggle = historySidebarToggle(page);
+  await expect(toggle).toBeVisible({ timeout: TIMEOUT.VISIBLE });
+  if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+}
+
 /**
  * Delete a thread deterministically by its id via the history sidebar. Scopes
  * to the row carrying `data-thread-id` (added to `ChatRow`) — never `.first()`,
@@ -132,11 +154,7 @@ export async function deleteThreadById(
   page: Page,
   threadId: string,
 ): Promise<void> {
-  // Open the history sidebar (the toggle's label is "Show" while collapsed).
-  await page
-    .getByRole('button', { name: t('chat.showHistory') })
-    .first()
-    .click();
+  await ensureHistorySidebarOpen(page);
 
   const row = page.locator(`[data-thread-id="${threadId}"]`);
   await expect(row).toBeVisible({ timeout: TIMEOUT.VISIBLE });

--- a/services/platform/tests/e2e/specs/chat-threads.spec.ts
+++ b/services/platform/tests/e2e/specs/chat-threads.spec.ts
@@ -1,6 +1,7 @@
 import {
   composer,
   deleteThreadById,
+  ensureHistorySidebarOpen,
   expectCannedReply,
   sendNewThreadMessage,
 } from '../helpers/chat';
@@ -29,10 +30,7 @@ test('starts a thread, reopens it by URL, then deletes it', async ({
   await expectCannedReply(page);
 
   // Open the history sidebar and confirm the populated "Chats" section renders.
-  await page
-    .getByRole('button', { name: t('chat.showHistory') })
-    .first()
-    .click();
+  await ensureHistorySidebarOpen(page);
   await expect(
     page.getByText(t('chat.chatsSection'), { exact: true }).first(),
   ).toBeVisible({ timeout: TIMEOUT.VISIBLE });


### PR DESCRIPTION
## Summary

- Merges the dashboard icon rail and chat history into a single left panel on the chat route (`ChatDashboardSidebar`), with one expand/collapse control (header toggle + ⌘H / Ctrl+H) and persisted preference per user+org.
- Hides the duplicate dashboard nav rail on chat routes so desktop no longer shows two adjacent sidebars; the history column animates beside the nav rail with reduced-motion support.
- Mobile uses a unified drawer (`ChatMobileSidebarSheet`) with primary nav destinations and chat history together, replacing the history-only sheet.

Closes #2428

## Test plan

- [x] Unit tests: `chat-dashboard-sidebar.test.tsx`, `chat-header.test.tsx`
- [ ] Desktop: open chat → toggle sidebar (collapsed icon rail vs expanded with history); reload and confirm preference persists
- [ ] Mobile: open menu drawer → verify nav links + chat history; select a chat and confirm drawer closes
- [ ] Regression: project folder collapse, DnD, archived section, preload-on-hover, legal-hold indicators still work in history list
- [ ] Non-chat dashboard routes still show the standalone nav rail


Made with [Cursor](https://cursor.com)