### PR TITLE
fix(platform): keep trailing dots visible between tool calls

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble-trailing-loader.test.tsx
+++ b/services/platform/app/features/chat/components/message-bubble-trailing-loader.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import type { Message } from './message-bubble/types';
+
+vi.mock('../hooks/queries', () => ({
+  useMessageMetadata: () => ({ metadata: undefined }),
+  useChatAgents: () => ({ agents: undefined }),
+  useFileUrls: () => ({ data: undefined }),
+  useThreadLiveRoute: () => null,
+  useThreadGenerationStart: () => null,
+}));
+
+vi.mock('../hooks/use-effective-agent', () => ({
+  useEffectiveAgent: () => ({ agent: undefined }),
+}));
+
+vi.mock('../hooks/use-on-demand-speech', () => ({
+  useOnDemandSpeech: () => ({ requested: false }),
+}));
+
+vi.mock('../hooks/use-voice-output', () => ({
+  useVoiceModeEffective: () => ({ enabled: false }),
+  useVoiceOutputChunker: () => undefined,
+}));
+
+vi.mock('../context/chat-layout-context', () => ({
+  useChatLayout: () => ({
+    setEditingImageRef: vi.fn(),
+    setDismissedImageKey: vi.fn(),
+  }),
+}));
+
+vi.mock('./message-segments', () => ({
+  MessageSegments: ({ messageId }: { messageId: string }) => (
+    <div data-testid={`segments-${messageId}`} />
+  ),
+}));
+
+vi.mock('./thought-timeline', () => ({
+  MessageThoughtHeader: () => <div data-testid="thought-header" />,
+  ThinkingDots: () => <span data-testid="trailing-thinking-dots" />,
+}));
+
+vi.mock('./message-bubble/artifact-pills', () => ({
+  MessageArtifactPills: () => null,
+}));
+
+vi.mock('./message-info-dialog', () => ({
+  MessageInfoDialog: () => null,
+}));
+
+function streamingAssistant(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'assistant-msg-1',
+    role: 'assistant',
+    content: '',
+    timestamp: new Date('2026-01-01T00:00:00Z'),
+    threadId: 'thread-1',
+    isStreaming: true,
+    parts: [
+      {
+        type: 'text',
+        text: 'Looking further for the kickoff time.',
+        state: 'streaming',
+      },
+      {
+        type: 'tool-web',
+        toolCallId: 'w1',
+        state: 'output-available',
+        output: 'page 1',
+      },
+      {
+        type: 'tool-web',
+        toolCallId: 'w2',
+        state: 'output-available',
+        output: 'page 2',
+      },
+      { type: 'text', text: 'Still checking schedules.', state: 'done' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('MessageBubble trailing loader', () => {
+  it('shows trailing dots between settled web tools when interim text is still streaming', async () => {
+    const { MessageBubble } = await import('./message-bubble');
+
+    render(
+      <MessageBubble
+        message={streamingAssistant()}
+        organizationId="org-1"
+        hideFeedback
+      />,
+    );
+
+    expect(screen.getByTestId('trailing-thinking-dots')).toBeInTheDocument();
+  });
+
+  it('hides trailing dots while a tool is mid-flight', async () => {
+    const { MessageBubble } = await import('./message-bubble');
+
+    render(
+      <MessageBubble
+        message={streamingAssistant({
+          parts: [
+            {
+              type: 'tool-web',
+              toolCallId: 'w1',
+              state: 'output-available',
+              output: 'page 1',
+            },
+            {
+              type: 'tool-web',
+              toolCallId: 'w2',
+              state: 'input-available',
+              input: { operation: 'fetch_url', url: 'https://example.com' },
+            },
+          ],
+        })}
+        organizationId="org-1"
+        hideFeedback
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('trailing-thinking-dots'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -454,7 +454,7 @@ function MessageBubbleComponent({
     !isBlocked &&
     messageSegments.segments.length > 0 &&
     !hasVisibleActiveSegment(messageSegments.segments, {
-      active: !!isAssistantStreaming,
+      active: true,
       headerOwnsReasoning: headerOwnsReasoningForLoader,
     });
 

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -52,6 +52,7 @@ import {
 } from '../hooks/use-voice-output';
 import {
   buildMessageSegments,
+  hasVisibleActiveSegment,
   type MessageSegment,
 } from '../utils/build-message-segments';
 import {
@@ -431,23 +432,31 @@ function MessageBubbleComponent({
   // `hasAnswerStarted` is the boolean `!!displayContent`, which flips once
   // (empty → non-empty) and then stays stable through the answer stream.
   const hasAnswerStarted = !!displayContent;
-  // Trailing "still working" affordance: while the turn streams but EVERY
-  // segment is SETTLED — `messageSegments.isStreaming` is the any-segment-live
-  // predicate (in-flight tool, streaming reasoning/text anywhere, not just the
-  // tail; parallel tool calls can settle out of order, leaving an in-flight
-  // spinner mid-list behind a settled tail) — show pulsing dots at the end of
-  // the bubble so a long external-agent turn never reads as finished between
-  // tool calls. When any segment is itself active, that element is the
-  // affordance and the dots stay hidden: exactly one live signal per bubble.
+  // Trailing "still working" affordance: while the turn streams but no segment
+  // renders its own live affordance (tool spinner, inline reasoning, trailing
+  // text typewriter) — show pulsing dots at the end of the bubble so a long
+  // turn never reads as finished between tool calls. Uses
+  // `hasVisibleActiveSegment` (not the broader `messageSegments.isStreaming`)
+  // so an intermediate text part still marked `streaming` but followed by a
+  // settled tool row does not suppress the dots during the gap before the
+  // next tool call lands. When a segment IS visibly active, that element owns
+  // the signal and the dots stay hidden: exactly one live signal per bubble.
   // `isFinalReveal` excludes the one-cycle isStreaming carry-over a native
   // turn uses to mount its typewriter animated — the turn is already done.
+  const headerOwnsReasoningForLoader =
+    messageSegments.hasReasoning ||
+    messageSegments.toolCount > 0 ||
+    messageSegments.skillCount > 0;
   const showTrailingLoader =
     !isUser &&
     !!isAssistantStreaming &&
     !message.isFinalReveal &&
     !isBlocked &&
     messageSegments.segments.length > 0 &&
-    !messageSegments.isStreaming;
+    !hasVisibleActiveSegment(messageSegments.segments, {
+      active: !!isAssistantStreaming,
+      headerOwnsReasoning: headerOwnsReasoningForLoader,
+    });
 
   // Post-answer toolbar gating: the toolbar appears only after the typewriter
   // has fully REVEALED the answer, not merely when the server stream ends —

--- a/services/platform/app/features/chat/utils/build-message-segments.test.ts
+++ b/services/platform/app/features/chat/utils/build-message-segments.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildMessageSegments } from './build-message-segments';
+import {
+  buildMessageSegments,
+  hasVisibleActiveSegment,
+} from './build-message-segments';
 
 describe('buildMessageSegments', () => {
   it('returns empty for undefined/empty parts', () => {
@@ -239,5 +242,80 @@ describe('buildMessageSegments', () => {
       { type: 'reasoning', text: 'ok', state: 'done' },
     ] as unknown[]);
     expect(segments).toHaveLength(1);
+  });
+});
+
+describe('hasVisibleActiveSegment', () => {
+  const active = { active: true, headerOwnsReasoning: true };
+
+  it('returns false when the turn is not active', () => {
+    const { segments } = buildMessageSegments([
+      { type: 'tool-web', toolCallId: 'w1', state: 'input-available' },
+    ]);
+    expect(
+      hasVisibleActiveSegment(segments, { ...active, active: false }),
+    ).toBe(false);
+  });
+
+  it('flags an in-flight tool as visibly active', () => {
+    const { segments } = buildMessageSegments([
+      { type: 'tool-web', toolCallId: 'w1', state: 'input-available' },
+    ]);
+    expect(hasVisibleActiveSegment(segments, active)).toBe(true);
+  });
+
+  it('flags the trailing text typewriter as visibly active', () => {
+    const { segments } = buildMessageSegments([
+      { type: 'text', text: 'partial answer', state: 'streaming' },
+    ]);
+    expect(hasVisibleActiveSegment(segments, active)).toBe(true);
+  });
+
+  it('does not treat intermediate streaming text followed by a settled tool as visibly active', () => {
+    // Interim narration between tool calls can leave an earlier text run still
+    // marked `streaming` while a later text run (and settled tools) already
+    // landed — only the final text run owns the typewriter, so the earlier
+    // run renders statically and the trailing dots must stay up.
+    const { segments, isStreaming } = buildMessageSegments([
+      {
+        type: 'text',
+        text: 'Looking further for the kickoff time.',
+        state: 'streaming',
+      },
+      {
+        type: 'tool-web',
+        toolCallId: 'w1',
+        state: 'output-available',
+        output: 'page 1',
+      },
+      {
+        type: 'tool-web',
+        toolCallId: 'w2',
+        state: 'output-available',
+        output: 'page 2',
+      },
+      { type: 'text', text: 'Still checking schedules.', state: 'done' },
+    ]);
+    expect(isStreaming).toBe(true);
+    expect(hasVisibleActiveSegment(segments, active)).toBe(false);
+  });
+
+  it('suppresses inline reasoning when the header owns it', () => {
+    const { segments } = buildMessageSegments([
+      { type: 'reasoning', text: 'planning', state: 'streaming' },
+    ]);
+    expect(hasVisibleActiveSegment(segments, active)).toBe(false);
+  });
+
+  it('flags inline reasoning when the header does not own it', () => {
+    const { segments } = buildMessageSegments([
+      { type: 'reasoning', text: 'planning', state: 'streaming' },
+    ]);
+    expect(
+      hasVisibleActiveSegment(segments, {
+        active: true,
+        headerOwnsReasoning: false,
+      }),
+    ).toBe(true);
   });
 });

--- a/services/platform/app/features/chat/utils/build-message-segments.ts
+++ b/services/platform/app/features/chat/utils/build-message-segments.ts
@@ -217,6 +217,32 @@ export function buildMessageSegments(
 }
 
 /**
+ * True when a segment renders its OWN live affordance (tool spinner, inline
+ * reasoning dots, or the trailing text typewriter). The bubble-level trailing
+ * `ThinkingDots` must hide only in that case — an intermediate text part still
+ * marked `streaming` but not `isLast` (a settled tool row follows it) has no
+ * visible affordance and must NOT suppress the trailing dots.
+ */
+export function hasVisibleActiveSegment(
+  segments: readonly MessageSegment[],
+  opts: { active: boolean; headerOwnsReasoning: boolean },
+): boolean {
+  if (!opts.active) return false;
+  return segments.some((s) => {
+    if (s.kind === 'tool') {
+      return s.state === 'input-streaming' || s.state === 'input-available';
+    }
+    if (s.kind === 'reasoning') {
+      return s.state === 'streaming' && !opts.headerOwnsReasoning;
+    }
+    if (s.kind === 'text') {
+      return s.isLast && s.state === 'streaming';
+    }
+    return false;
+  });
+}
+
+/**
  * The live activity of a streaming turn, localized by `activityLabel`. Only the
  * gap-shell `ThinkingIndicator` constructs it now (phase-based "Routing"/
  * "Thinking"): the in-bubble header renders a STABLE "Thinking" and lets the


### PR DESCRIPTION
## Summary
- Add `hasVisibleActiveSegment` so the bubble-level trailing `ThinkingDots` hide only when a segment renders its own live affordance (tool spinner, inline reasoning, or trailing typewriter).
- Fix dead-air gaps during chained `web` tool turns where interim text stayed marked `streaming` but rendered statically, incorrectly suppressing the bottom loader.
- Add unit and integration regression tests for the intermediate-text-between-tools case.

## Test plan
- [x] `bun run test:ui -- app/features/chat/utils/build-message-segments.test.ts`
- [x] `bun run test:ui -- app/features/chat/components/message-bubble-trailing-loader.test.tsx`
- [x] `bun run test:ui -- app/features/chat/` (819 passed)
- [ ] Manual: trigger a multi-step `web` tool turn and confirm bottom dots or tool spinner stay visible between calls