### PR TITLE
fix: implement cursor agent cli as a sandbox external agent (claude code parity) (#2423)

### DIFF
--- a/docs/de/develop/ai-assisted-development.md
+++ b/docs/de/develop/ai-assisted-development.md
@@ -48,6 +48,17 @@ Die Rules-Datei nennt drei Regeln, die jeder Editor beim Bearbeiten durchsetzt:
 
 Wenn der Editor eine Änderung vorschlägt, frag ihn, welche Datei in `.tale/reference/` er zugrunde gelegt hat. Wenn er das nicht kann, erzeug den Spiegel mit `tale update` neu und versuch es nochmal.
 
+## Cursor: Config-Ebene vs. Runtime-Ebene
+
+Cursor taucht in Tale an zwei getrennten Stellen auf — verwechsle sie nicht.
+
+| Ebene       | Was sie tut                                                                                                                         | Wo sie lebt                                                                                            |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Config**  | Hilft Cursor (oder einem anderen AI-Editor), Tale-Projekt-JSON auf deinem Rechner zu bearbeiten                                     | `.cursor/rules/tale.mdc`, `CLAUDE.md`, `.tale/reference/` — alles, was `tale init` schreibt            |
+| **Runtime** | Führt die Cursor Agent CLI headless in einer isolierten Sandbox aus, wenn du mit dem eingebauten **Cursor**-External-Agent chattest | Chat-Picker → **Cursor**; Agent-JSON mit `primaryBehavior: "external-agent"` und `agentKind: "cursor"` |
+
+Rules-Datei und Schema-Spiegel auf dieser Seite sind die **Config-Ebene**: Sie steuern einen lokalen Editor, während du Agents, Workflows und Integrations änderst. Die **Runtime-Ebene** ist ein verwalteter Sandbox-Turn — `agent -p --output-format stream-json` mit deinem `CURSOR_API_KEY`, normalisierter Fortschritt im Chat und Session-Resume über Follow-ups. Credentials, Modelle und Abrechnung für Runtime-Turns stehen in [External agents](/de/platform/agents/external-agent), nicht hier.
+
 ## Wo das hingehört
 
 AI-gestützte Entwicklung ist der Bearbeitungspfad; Deployment ist der Veröffentlichungspfad. Sobald eine Config die Editor-Validierung passiert, gleicht [`tale deploy`](/de/self-hosted/install/cli-install) sie gegen die Plattform ab — derselbe Schema-Check, diesmal als Schranke. Für Features, die der Editor nicht erreicht (der In-Product-Builder, der visuelle Workflow-Editor), ist der [Platform-Reiter](/de/platform) die kanonische Oberfläche; der AI-Editor-Pfad hier ist für Projekte, die Config-as-Code bevorzugen.

--- a/docs/en/develop/ai-assisted-development.md
+++ b/docs/en/develop/ai-assisted-development.md
@@ -48,6 +48,17 @@ The rules file names three rules each editor enforces while editing:
 
 When the editor proposes a change, ask it to cite the file in `.tale/reference/` it relied on. If it cannot, regenerate the mirror with `tale update` and try again.
 
+## Cursor: config plane vs runtime plane
+
+Cursor shows up in Tale in two separate places — do not conflate them.
+
+| Plane       | What it does                                                                                                              | Where it lives                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Config**  | Helps Cursor (or any AI editor) edit Tale project JSON on your machine                                                    | `.cursor/rules/tale.mdc`, `CLAUDE.md`, `.tale/reference/` — everything `tale init` writes               |
+| **Runtime** | Runs the Cursor Agent CLI headlessly inside an isolated sandbox when you chat with the built-in **Cursor** external agent | Chat picker → **Cursor**; agent JSON with `primaryBehavior: "external-agent"` and `agentKind: "cursor"` |
+
+The rules file and schema mirror on this page are the **config plane**: they steer a local editor while you change agents, workflows, and integrations. The **runtime plane** is a managed sandbox turn — `agent -p --output-format stream-json` with your `CURSOR_API_KEY`, normalized progress in chat, and session resume across follow-ups. Credentials, models, and billing for runtime turns are covered in [External agents](/platform/agents/external-agent), not here.
+
 ## Where this fits
 
 AI-assisted development is the editing path; deployment is the publishing path. Once a config passes editor validation, [`tale deploy`](/self-hosted/install/cli-install) reconciles it against the platform — the same schema check, this time as a gate. For features the editor cannot reach (the in-product builder, the visual workflow editor), the [Platform tab](/platform) is the canonical surface; the AI-editor path here is for projects that prefer config-as-code.

--- a/docs/fr/develop/ai-assisted-development.md
+++ b/docs/fr/develop/ai-assisted-development.md
@@ -48,6 +48,17 @@ Le fichier de règles nomme trois règles que chaque éditeur applique pendant l
 
 Quand l'éditeur propose un changement, demande-lui de citer le fichier dans `.tale/reference/` sur lequel il s'est appuyé. S'il ne peut pas, régénère le miroir avec `tale update` et réessaie.
 
+## Cursor : plan config vs plan runtime
+
+Cursor apparaît dans Tale à deux endroits distincts — ne les confonds pas.
+
+| Plan        | Rôle                                                                                                                           | Où ça vit                                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| **Config**  | Aide Cursor (ou tout éditeur IA) à éditer le JSON d'un projet Tale sur ta machine                                              | `.cursor/rules/tale.mdc`, `CLAUDE.md`, `.tale/reference/` — tout ce que `tale init` écrit                       |
+| **Runtime** | Lance la CLI Cursor Agent en mode headless dans un bac à sable isolé quand tu discutes avec l'agent externe **Cursor** intégré | Sélecteur de chat → **Cursor** ; JSON d'agent avec `primaryBehavior: "external-agent"` et `agentKind: "cursor"` |
+
+Le fichier de règles et le miroir de schéma sur cette page sont le **plan config** : ils guident un éditeur local pendant que tu modifies agents, workflows et intégrations. Le **plan runtime**, c'est un tour de bac à sable géré — `agent -p --output-format stream-json` avec ta `CURSOR_API_KEY`, progression normalisée dans le chat et reprise de session entre les relances. Credentials, modèles et facturation des tours runtime sont dans [External agents](/fr/platform/agents/external-agent), pas ici.
+
 ## Où cela s'inscrit
 
 Le développement assisté par IA est le chemin d'édition ; le déploiement est le chemin de publication. Une fois qu'une config passe la validation de l'éditeur, [`tale deploy`](/fr/self-hosted/install/cli-install) la rapproche de la plateforme — le même contrôle de schéma, cette fois comme barrière. Pour les fonctionnalités que l'éditeur n'atteint pas (le constructeur dans le produit, l'éditeur visuel de workflow), l'[onglet Platform](/fr/platform) est la surface canonique ; le chemin éditeur IA ici est pour les projets qui préfèrent la config-as-code.


### PR DESCRIPTION
## Summary

Closes #2423.

The Cursor external-agent runtime shipped in #2481 (adapter, parser, registry, schema, UI, sandbox CLI pin, e2e tests, en/de/fr `external-agent.md`). This PR completes the remaining documentation item from the issue: a **config plane vs runtime plane** section in `docs/*/develop/ai-assisted-development.md` so `.cursor/rules` local editing is not confused with the sandbox `agentKind: "cursor"` runtime.

## Acceptance criteria (issue #2423)

- [x] Cursor runs as `primaryBehavior: external-agent` with documented `agentKind` (`builtin-configs/agents/chat/cursor.json`, external-agent docs)
- [x] BYO turns use user secrets (`CURSOR_API_KEY`); no VK mint (`supportsManaged: false`, schema enforces `authMode: "byo"`)
- [x] Chat renders normalized progress via shared `AgentEvent` parser (Claude Code parity)
- [x] Headless CLI contract documented (`agent -p --output-format stream-json`; adapter + fixtures)
- [x] Config vs runtime plane clarified (`ai-assisted-development.md`, this PR)

**Note:** Cursor cannot route through the platform LLM gateway (CLI has no OpenAI-compatible base-URL override), so managed gateway metering does not apply — BYO/env-backed only, as documented in `external-agent.md`.

## Test plan

- [x] `bunx vitest --run --project server lib/agent-adapters/` — 77 passed
- [x] `bunx oxfmt --check` on edited docs — green


Made with [Cursor](https://cursor.com)