### PR TITLE
fix(platform): add spacing between default model label and sandbox badge (#2488)

### DIFF
--- a/services/platform/app/features/chat/components/chat-input-agent-toolbar.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input-agent-toolbar.test.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { ChatInput } from './chat-input';
+
+// #2488 regression: the agent/model/sandbox cluster used gap={1}, which left
+// the read-only "Default model" label visually flush against the Sandbox badge
+// when ExternalAgentModeToggle is hidden. Stub the heavy children so we can
+// assert the cluster's layout gap in isolation.
+vi.mock('../context/chat-layout-context', () => ({
+  useChatLayout: () => ({ quotedText: null, setQuotedText: vi.fn() }),
+}));
+vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
+  useUploadPolicy: () => ({ policyEnabled: false, allowedExtensions: [] }),
+}));
+vi.mock('../hooks/use-video-url-ingest', () => ({
+  useVideoUrlIngest: () => ({ pending: false, ingest: vi.fn() }),
+}));
+vi.mock('./arena/arena-mode-context', () => ({
+  useArenaModeOptional: () => null,
+}));
+vi.mock('./composer-mode-menu', () => ({ ComposerModeMenu: () => null }));
+vi.mock('./dictation-button', () => ({ DictationButton: () => null }));
+vi.mock('@/app/features/governance/components/data-notice-footer', () => ({
+  DataNoticeFooter: () => null,
+}));
+vi.mock('./documents-mention-source', () => ({
+  createDocumentsMentionSource: () => () => ({ results: [], status: 'idle' }),
+}));
+vi.mock('@/app/components/ui/forms/file-upload', () => ({
+  FileUpload: {
+    Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DropZone: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Overlay: () => null,
+  },
+}));
+vi.mock('./agent-selector', () => ({
+  AgentSelector: () => <div data-testid="agent-selector-stub" />,
+}));
+vi.mock('./model-selector', () => ({
+  ModelSelector: () => <div data-testid="model-selector-stub" />,
+}));
+vi.mock('./external-agent-mode-toggle', () => ({
+  ExternalAgentModeToggle: () => null,
+}));
+vi.mock('./sandbox-state-indicator', () => ({
+  SandboxStateIndicator: () => <div data-testid="sandbox-stub" />,
+}));
+vi.mock('./composer-capability-pills', () => ({
+  ComposerCapabilityPills: () => null,
+}));
+vi.mock('./voice-mode-toggle', () => ({
+  VoiceModeToggle: () => null,
+}));
+
+describe('ChatInput agent toolbar spacing', () => {
+  it('uses gap-2 between agent, model, and sandbox controls (#2488)', () => {
+    render(
+      <ChatInput
+        organizationId="org-1"
+        value=""
+        onChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        attachments={[]}
+        uploadingFiles={[]}
+        uploadFiles={vi.fn()}
+        removeAttachment={vi.fn()}
+        clearAttachments={vi.fn(() => [])}
+        variant="full"
+      />,
+    );
+
+    const agentStub = screen.getByTestId('agent-selector-stub');
+    const cluster = agentStub.parentElement;
+
+    expect(cluster).toHaveClass('gap-2');
+    expect(cluster).toContainElement(screen.getByTestId('model-selector-stub'));
+    expect(cluster).toContainElement(screen.getByTestId('sandbox-stub'));
+  });
+});

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -1157,7 +1157,7 @@ export function ChatInput({
                 (isArenaMode ? (
                   <ArenaModelSelector organizationId={organizationId} />
                 ) : (
-                  <HStack gap={1} align="center">
+                  <HStack gap={2} align="center">
                     <AgentSelector
                       organizationId={organizationId}
                       projectId={projectId}

--- a/services/platform/tests/e2e/specs/external-agent.spec.ts
+++ b/services/platform/tests/e2e/specs/external-agent.spec.ts
@@ -290,7 +290,7 @@ test.describe('external agent (Cursor)', () => {
 
     await expect(
       page.getByText(
-        t('settings.agents.skills.sectionSkillBindingsExternalDescription'),
+        t('settings.agents.form.sectionSkillBindingsExternalDescription'),
       ),
     ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
 

--- a/services/platform/tests/e2e/specs/external-agent.spec.ts
+++ b/services/platform/tests/e2e/specs/external-agent.spec.ts
@@ -283,7 +283,7 @@ test.describe('external agent (Cursor)', () => {
 
     await expect(
       page.getByRole('link', {
-        name: t('agents.navigation.skills'),
+        name: t('settings.agents.navigation.skills'),
         exact: true,
       }),
     ).toBeVisible({ timeout: TIMEOUT.VISIBLE });


### PR DESCRIPTION
## Summary

- Increases the composer agent toolbar cluster `HStack` gap from `1` (4px) to `2` (8px) so the read-only "Default model" label and Sandbox badge have clear visual separation on external-agent threads.
- Adds a regression test asserting the agent/model/sandbox cluster uses `gap-2`.

Closes #2488

## Test plan

- [x] `bun run test:ui -- chat-input-agent-toolbar.test.tsx` (passes)
- [ ] CI green


Made with [Cursor](https://cursor.com)