### PR TITLE
feat(platform): notify org members on inbound conversation messages

### DIFF
--- a/builtin-configs/workflows/conversations/notify-members-on-inbound-message.json
+++ b/builtin-configs/workflows/conversations/notify-members-on-inbound-message.json
@@ -1,0 +1,102 @@
+{
+  "name": "Notify members on inbound conversation message",
+  "description": "When a customer message lands in Conversations (email sync, IMAP, or a manual inbound reply), every active org member gets an inbox notification with the sender and subject. Outbound messages, closed threads, spam, and archived threads are ignored. Repeated messages in the same conversation are deduped for six hours per recipient. Install from the catalog when you want this — it is off by default. Members can mute these under Settings > Notifications > Conversation messages.",
+  "i18n": {
+    "en": {
+      "name": "Notify members on inbound conversation message",
+      "description": "When a customer message arrives in an open conversation, every active member gets an inbox notification with the sender and subject."
+    },
+    "de": {
+      "name": "Mitglieder bei eingehender Konversationsnachricht benachrichtigen",
+      "description": "Kommt eine Kundennachricht in einer offenen Konversation an, erhält jedes aktive Mitglied eine Posteingangs-Benachrichtigung mit Absender und Betreff."
+    },
+    "fr": {
+      "name": "Notifier les membres à l'arrivée d'un message entrant",
+      "description": "Quand un message client arrive dans une conversation ouverte, chaque membre actif reçoit une notification avec l'expéditeur et l'objet."
+    }
+  },
+  "version": "1.0.0",
+  "metadata": {
+    "labels": ["Conversations", "Automation"]
+  },
+  "triggers": {
+    "events": [
+      {
+        "eventType": "conversation.message_received"
+      }
+    ]
+  },
+  "config": {
+    "timeout": 120000,
+    "variables": {
+      "workflowId": "conversations_inbound_notify"
+    }
+  },
+  "steps": [
+    {
+      "stepSlug": "start",
+      "name": "Start",
+      "stepType": "start",
+      "config": {},
+      "nextSteps": {
+        "success": "inbound_only"
+      }
+    },
+    {
+      "stepSlug": "inbound_only",
+      "name": "Inbound customer message?",
+      "stepType": "condition",
+      "config": {
+        "expression": "input.message.direction == 'inbound'",
+        "description": "Only notify when the customer wrote in — outbound replies and internal notes are ignored."
+      },
+      "nextSteps": {
+        "true": "open_only",
+        "false": "done"
+      }
+    },
+    {
+      "stepSlug": "open_only",
+      "name": "Open conversation?",
+      "stepType": "condition",
+      "config": {
+        "expression": "input.conversation.status == 'open' || input.conversation.status == null || input.conversation.status == ''",
+        "description": "Skip closed, spam, and archived threads."
+      },
+      "nextSteps": {
+        "true": "notify_members",
+        "false": "done"
+      }
+    },
+    {
+      "stepSlug": "notify_members",
+      "name": "Notify org members",
+      "stepType": "action",
+      "config": {
+        "type": "notification",
+        "parameters": {
+          "operation": "notify_users",
+          "audience": "org_members",
+          "type": "conversation_message",
+          "titleKey": "conversationInboundMessage",
+          "bodyKey": "conversationInboundMessageBody",
+          "params": {
+            "subject": "{{input.conversation.subject}}",
+            "sender": "{{input.message.metadata.sender}}"
+          },
+          "conversationId": "{{input.conversation._id}}"
+        }
+      },
+      "nextSteps": {
+        "success": "done"
+      }
+    },
+    {
+      "stepSlug": "done",
+      "name": "Done",
+      "stepType": "output",
+      "config": {},
+      "nextSteps": {}
+    }
+  ]
+}

--- a/services/platform/app/features/conversations/components/conversations.tsx
+++ b/services/platform/app/features/conversations/components/conversations.tsx
@@ -15,7 +15,7 @@ import {
   SendHorizontalIcon,
   ShieldXIcon,
 } from 'lucide-react';
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { SearchInput } from '@/app/components/ui/forms/search-input';
@@ -39,6 +39,8 @@ interface ConversationsProps {
   status?: Conversation['status'];
   organizationId: string;
   search?: string;
+  /** Deep-link from notifications (`?conversation=`). */
+  initialConversationId?: string;
   paginatedResult: UsePaginatedQueryResult<ConversationItem>;
   conversationCount: number | undefined;
   totalConversationCount: number | undefined;
@@ -81,15 +83,22 @@ export function Conversations({
   status,
   organizationId,
   search: initialSearch,
+  initialConversationId,
   paginatedResult,
   conversationCount,
   totalConversationCount,
 }: ConversationsProps) {
   const navigate = useNavigate();
 
-  const [selectedConversationId, setSelectedConversationId] = useState<
-    string | null
-  >(null);
+  const [selectedConversationId, setSelectedConversationId] = useState(
+    initialConversationId ?? null,
+  );
+
+  useEffect(() => {
+    if (initialConversationId) {
+      setSelectedConversationId(initialConversationId);
+    }
+  }, [initialConversationId]);
 
   // `searchQuery` is the single source of truth for the filter. It is seeded
   // once from the `?search=` URL param; thereafter the URL is kept in sync from

--- a/services/platform/app/features/notifications/lib/notification-target.test.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.test.ts
@@ -21,6 +21,24 @@ describe('personalNotificationTarget', () => {
     });
   });
 
+  it('builds a conversation deep-link when conversationId is present', () => {
+    const target = personalNotificationTarget({
+      organizationId: ORG,
+      taskId: undefined,
+      params: {
+        conversationId: 'conv_abc',
+        conversationStatus: 'open',
+        subject: 'Help',
+        sender: 'customer@example.com',
+      },
+    });
+    expect(target).toEqual({
+      to: '/dashboard/$id/conversations/$status',
+      params: { id: ORG, status: 'open' },
+      search: { conversation: 'conv_abc' },
+    });
+  });
+
   it('builds a chat deep-link when chat + threadId are present', () => {
     const target = personalNotificationTarget({
       organizationId: ORG,

--- a/services/platform/app/features/notifications/lib/notification-target.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.ts
@@ -1,5 +1,25 @@
 import { isRecord } from '@/lib/utils/type-utils';
 
+const CONVERSATION_URL_STATUSES = [
+  'open',
+  'closed',
+  'archived',
+  'spam',
+] as const;
+
+type ConversationUrlStatus = (typeof CONVERSATION_URL_STATUSES)[number];
+
+function isConversationUrlStatus(raw: string): raw is ConversationUrlStatus {
+  return (CONVERSATION_URL_STATUSES as readonly string[]).includes(raw);
+}
+
+function conversationUrlStatus(raw: unknown): ConversationUrlStatus {
+  if (typeof raw === 'string' && isConversationUrlStatus(raw)) {
+    return raw;
+  }
+  return 'open';
+}
+
 /**
  * A typed TanStack-Router navigate descriptor for a notification's in-app deep
  * link. `to` is constrained to the routes we actually emit, so each member is
@@ -20,6 +40,11 @@ export type NotificationTarget =
   | {
       to: '/dashboard/$id/chat/$threadId';
       params: { id: string; threadId: string };
+    }
+  | {
+      to: '/dashboard/$id/conversations/$status';
+      params: { id: string; status: 'open' | 'closed' | 'archived' | 'spam' };
+      search: { conversation: string };
     }
   | {
       to: '/dashboard/$id/agents/$agentId';
@@ -96,7 +121,18 @@ export function personalNotificationTarget(args: {
     typeof params?.projectId === 'string' ? params.projectId : undefined;
   const threadId =
     typeof params?.threadId === 'string' ? params.threadId : undefined;
+  const conversationId = params?.conversationId;
 
+  if (typeof conversationId === 'string') {
+    return {
+      to: '/dashboard/$id/conversations/$status',
+      params: {
+        id,
+        status: conversationUrlStatus(params?.conversationStatus),
+      },
+      search: { conversation: conversationId },
+    };
+  }
   if (params?.chat === true && threadId) {
     return {
       to: '/dashboard/$id/chat/$threadId',

--- a/services/platform/app/features/settings/notifications/components/notification-preferences-settings.tsx
+++ b/services/platform/app/features/settings/notifications/components/notification-preferences-settings.tsx
@@ -22,7 +22,8 @@ type InAppPrefKey =
   | 'taskReview'
   | 'escalation'
   | 'automationAlerts'
-  | 'digest';
+  | 'digest'
+  | 'conversationMessages';
 
 const IN_APP_PREF_KEYS: InAppPrefKey[] = [
   'taskAssigned',
@@ -33,6 +34,7 @@ const IN_APP_PREF_KEYS: InAppPrefKey[] = [
   'escalation',
   'automationAlerts',
   'digest',
+  'conversationMessages',
 ];
 
 export function NotificationPreferencesSettings() {
@@ -75,6 +77,7 @@ function NotificationPreferencesSettingsView({
         escalation?: boolean;
         automationAlerts?: boolean;
         digest?: boolean;
+        conversationMessages?: boolean;
         actionableEmail?: boolean;
       }
     | undefined;

--- a/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
@@ -30,6 +30,7 @@ const conversationStatusMap: Record<ValidStatus, ConversationStatus> = {
 
 const searchSchema = z.object({
   search: z.string().optional(),
+  conversation: z.string().optional(),
 });
 
 export const Route = createFileRoute('/dashboard/$id/conversations/$status')({
@@ -67,7 +68,7 @@ export const Route = createFileRoute('/dashboard/$id/conversations/$status')({
 
 function ConversationsStatusPage() {
   const { id: organizationId, status } = Route.useParams();
-  const { search } = Route.useSearch();
+  const { search, conversation } = Route.useSearch();
 
   const mappedStatus =
     (isValidStatus(status) ? conversationStatusMap[status] : undefined) ??
@@ -100,6 +101,7 @@ function ConversationsStatusPage() {
       status={mappedStatus}
       organizationId={organizationId}
       search={search && search.length > 0 ? search : undefined}
+      initialConversationId={conversation}
       paginatedResult={paginatedResult}
       conversationCount={conversationCount}
       totalConversationCount={totalConversationCount}

--- a/services/platform/convex/collab/internal_mutations.ts
+++ b/services/platform/convex/collab/internal_mutations.ts
@@ -26,8 +26,16 @@ import { queueActionableEmail } from './notify_email';
 import { notificationTypeValidator } from './schema';
 
 const DEDUPE_WINDOW_MS = 6 * 60 * 60 * 1000;
-const MAX_RECIPIENTS = 100;
+const MEMBER_PAGE_SIZE = 100;
+const MAX_RECIPIENTS = 500;
 const ADMIN_ROLES = new Set(['owner', 'admin']);
+const MEMBER_ROLES = new Set([
+  'owner',
+  'admin',
+  'developer',
+  'editor',
+  'member',
+]);
 
 const audienceValidator = v.union(
   v.literal('user_ids'),
@@ -35,25 +43,50 @@ const audienceValidator = v.union(
   v.literal('task_subscribers'),
   v.literal('project_creator'),
   v.literal('org_admins'),
+  v.literal('org_members'),
 );
 
 async function orgAdminUserIds(
   ctx: MutationCtx,
   organizationId: string,
 ): Promise<string[]> {
-  const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
-    model: 'member',
-    paginationOpts: { cursor: null, numItems: MAX_RECIPIENTS },
-    where: [{ field: 'organizationId', value: organizationId, operator: 'eq' }],
-  });
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter findMany returns paginated unknown
-  const page = (result as { page?: Array<Record<string, unknown>> })?.page;
+  return orgMemberUserIds(ctx, organizationId, ADMIN_ROLES);
+}
+
+async function orgMemberUserIds(
+  ctx: MutationCtx,
+  organizationId: string,
+  roles: Set<string> = MEMBER_ROLES,
+): Promise<string[]> {
   const ids: string[] = [];
-  for (const member of page ?? []) {
-    const role = getString(member, 'role');
-    const userId = getString(member, 'userId');
-    if (role && userId && ADMIN_ROLES.has(role)) ids.push(userId);
+  let cursor: string | null = null;
+
+  while (ids.length < MAX_RECIPIENTS) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter findMany returns paginated unknown
+    const result = (await ctx.runQuery(components.betterAuth.adapter.findMany, {
+      model: 'member',
+      paginationOpts: {
+        cursor,
+        numItems: Math.min(MEMBER_PAGE_SIZE, MAX_RECIPIENTS - ids.length),
+      },
+      where: [
+        { field: 'organizationId', value: organizationId, operator: 'eq' },
+      ],
+    })) as {
+      page?: Array<Record<string, unknown>>;
+      isDone?: boolean;
+      continueCursor?: string | null;
+    };
+    const page = result.page;
+    for (const member of page ?? []) {
+      const role = getString(member, 'role');
+      const userId = getString(member, 'userId');
+      if (role && userId && roles.has(role)) ids.push(userId);
+    }
+    if (result.isDone === true || !result.continueCursor) break;
+    cursor = result.continueCursor;
   }
+
   return ids;
 }
 
@@ -98,6 +131,7 @@ export const notifyFromAutomation = internalMutation({
     params: v.optional(jsonRecordValidator),
     taskId: v.optional(v.id('tasks')),
     projectId: v.optional(v.id('projects')),
+    conversationId: v.optional(v.id('conversations')),
     userIds: v.optional(v.array(v.string())),
   },
   returns: v.object({ notified: v.number() }),
@@ -111,6 +145,12 @@ export const notifyFromAutomation = internalMutation({
     const projectId = args.projectId ?? task?.projectId;
     const project = projectId ? await ctx.db.get(projectId) : null;
     if (project && project.organizationId !== args.organizationId) {
+      return { notified: 0 };
+    }
+    const conversation = args.conversationId
+      ? await ctx.db.get(args.conversationId)
+      : null;
+    if (conversation && conversation.organizationId !== args.organizationId) {
       return { notified: 0 };
     }
 
@@ -140,6 +180,9 @@ export const notifyFromAutomation = internalMutation({
       case 'org_admins':
         recipients = await orgAdminUserIds(ctx, args.organizationId);
         break;
+      case 'org_members':
+        recipients = await orgMemberUserIds(ctx, args.organizationId);
+        break;
       default: {
         const unhandled: never = args.audience;
         throw new Error(`Unsupported audience: ${JSON.stringify(unhandled)}`);
@@ -147,9 +190,28 @@ export const notifyFromAutomation = internalMutation({
     }
 
     const unique = [...new Set(recipients)].slice(0, MAX_RECIPIENTS);
-    const resourceType = args.taskId ? 'task' : 'dashboard';
+    const resourceType = args.taskId
+      ? 'task'
+      : args.conversationId
+        ? 'conversation'
+        : 'dashboard';
     const resourceId: string =
-      args.taskId ?? args.projectId ?? args.organizationId;
+      args.taskId ??
+      args.conversationId ??
+      args.projectId ??
+      args.organizationId;
+
+    const notificationParams = {
+      ...args.params,
+      ...(args.conversationId
+        ? {
+            conversationId: String(args.conversationId),
+            ...(conversation?.status
+              ? { conversationStatus: conversation.status }
+              : {}),
+          }
+        : {}),
+    };
 
     let notified = 0;
     const now = Date.now();
@@ -174,7 +236,7 @@ export const notifyFromAutomation = internalMutation({
         type: args.type,
         titleKey: args.titleKey,
         bodyKey: args.bodyKey,
-        params: args.params,
+        params: notificationParams,
         resourceType,
         resourceId,
         taskId: args.taskId ?? (task ? task._id : undefined),
@@ -188,7 +250,7 @@ export const notifyFromAutomation = internalMutation({
         type: args.type,
         titleKey: args.titleKey,
         bodyKey: args.bodyKey,
-        params: args.params,
+        params: notificationParams,
         resourceType,
         resourceId,
         taskId: args.taskId ?? (task ? task._id : undefined),

--- a/services/platform/convex/collab/notifications.ts
+++ b/services/platform/convex/collab/notifications.ts
@@ -42,6 +42,7 @@ const notificationRowValidator = v.object({
     v.literal('wf_execution'),
     v.literal('runtime'),
     v.literal('dashboard'),
+    v.literal('conversation'),
   ),
   resourceId: v.string(),
   taskId: v.optional(v.id('tasks')),

--- a/services/platform/convex/collab/notify.ts
+++ b/services/platform/convex/collab/notify.ts
@@ -30,6 +30,7 @@ const PREF_FIELD: Record<
   | 'escalation'
   | 'automationAlerts'
   | 'digest'
+  | 'conversationMessages'
 > = {
   task_assigned: 'taskAssigned',
   task_status_changed: 'taskStatusChanged',
@@ -42,6 +43,7 @@ const PREF_FIELD: Record<
   budget_alert: 'automationAlerts',
   runtime_offline: 'automationAlerts',
   workforce_digest: 'digest',
+  conversation_message: 'conversationMessages',
 };
 
 /** Tri-state email delivery toggle — independent of in-app per-type prefs. */

--- a/services/platform/convex/collab/preferences.ts
+++ b/services/platform/convex/collab/preferences.ts
@@ -17,6 +17,7 @@ const prefsValidator = v.object({
   escalation: v.optional(v.boolean()),
   automationAlerts: v.optional(v.boolean()),
   digest: v.optional(v.boolean()),
+  conversationMessages: v.optional(v.boolean()),
   actionableEmail: v.optional(v.boolean()),
 });
 
@@ -46,6 +47,7 @@ export const getNotificationPreferences = query({
       escalation: row?.escalation,
       automationAlerts: row?.automationAlerts,
       digest: row?.digest,
+      conversationMessages: row?.conversationMessages,
       actionableEmail: row?.actionableEmail,
     };
   },
@@ -62,6 +64,7 @@ export const setNotificationPreferences = mutation({
     escalation: v.optional(v.boolean()),
     automationAlerts: v.optional(v.boolean()),
     digest: v.optional(v.boolean()),
+    conversationMessages: v.optional(v.boolean()),
     actionableEmail: v.optional(v.boolean()),
   },
   returns: v.null(),
@@ -88,6 +91,7 @@ export const setNotificationPreferences = mutation({
       escalation: args.escalation,
       automationAlerts: args.automationAlerts,
       digest: args.digest,
+      conversationMessages: args.conversationMessages,
       actionableEmail: args.actionableEmail,
       updatedAt: Date.now(),
     };

--- a/services/platform/convex/collab/schema.ts
+++ b/services/platform/convex/collab/schema.ts
@@ -33,6 +33,8 @@ export const notificationTypeValidator = v.union(
   v.literal('runtime_offline'),
   // Daily/weekly workforce digest.
   v.literal('workforce_digest'),
+  // Inbound customer message in Conversations (automation-driven).
+  v.literal('conversation_message'),
 );
 
 export const notificationActorTypeValidator = v.union(
@@ -57,6 +59,7 @@ export const userNotificationsTable = defineTable({
     v.literal('wf_execution'),
     v.literal('runtime'),
     v.literal('dashboard'),
+    v.literal('conversation'),
   ),
   resourceId: v.string(),
   taskId: v.optional(v.id('tasks')),
@@ -109,6 +112,8 @@ export const notificationPreferencesTable = defineTable({
   // Groups automation_failed / budget_alert / runtime_offline.
   automationAlerts: v.optional(v.boolean()),
   digest: v.optional(v.boolean()),
+  /** Inbound customer messages in Conversations (automation-driven). */
+  conversationMessages: v.optional(v.boolean()),
   /** Master toggle for actionable return-loop email delivery. */
   actionableEmail: v.optional(v.boolean()),
   updatedAt: v.number(),

--- a/services/platform/convex/conversations/create_conversation_with_message.test.ts
+++ b/services/platform/convex/conversations/create_conversation_with_message.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
+import { emitEvent } from '../workflows/triggers/emit_event';
 import { createConversationWithMessage } from './create_conversation_with_message';
 import type { CreateConversationWithMessageArgs } from './create_conversation_with_message';
 
@@ -15,6 +16,10 @@ vi.mock('./create_conversation', () => ({
     success: true,
     conversationId: 'created_conversation' as Id<'conversations'>,
   }),
+}));
+
+vi.mock('../workflows/triggers/emit_event', () => ({
+  emitEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 const ORG_ID = 'org_1';
@@ -51,6 +56,40 @@ describe('createConversationWithMessage — client-facing failures use ConvexErr
       createConversationWithMessage(ctx, makeArgs()),
     ).rejects.toMatchObject({
       data: { code: 'conversation_not_found' },
+    });
+  });
+
+  it('emits conversation.message_received after the initial message is stored', async () => {
+    const conversation = {
+      _id: 'created_conversation' as Id<'conversations'>,
+      organizationId: ORG_ID,
+      status: 'open',
+    };
+    const message = {
+      _id: 'message_id' as Id<'conversationMessages'>,
+      direction: 'inbound',
+    };
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce(conversation)
+      .mockResolvedValueOnce(message)
+      .mockResolvedValueOnce(conversation);
+    const ctx = {
+      db: {
+        get,
+        insert: vi
+          .fn()
+          .mockResolvedValue('message_id' as Id<'conversationMessages'>),
+        patch: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as MutationCtx;
+
+    await createConversationWithMessage(ctx, makeArgs());
+
+    expect(emitEvent).toHaveBeenCalledWith(ctx, {
+      organizationId: ORG_ID,
+      eventType: 'conversation.message_received',
+      eventData: { conversation, message },
     });
   });
 });

--- a/services/platform/convex/conversations/create_conversation_with_message.ts
+++ b/services/platform/convex/conversations/create_conversation_with_message.ts
@@ -11,6 +11,7 @@ import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import * as AuditLogHelpers from '../audit_logs/helpers';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
+import { emitEvent } from '../workflows/triggers/emit_event';
 import { createConversation } from './create_conversation';
 import type { CreateConversationArgs } from './types';
 
@@ -150,6 +151,16 @@ export async function createConversationWithMessage(
       sender: args.initialMessage.sender,
     },
   });
+
+  const message = await ctx.db.get(messageId);
+  const updatedConversation = await ctx.db.get(conversationId);
+  if (message && updatedConversation) {
+    await emitEvent(ctx, {
+      organizationId: args.organizationId,
+      eventType: 'conversation.message_received',
+      eventData: { conversation: updatedConversation, message },
+    });
+  }
 
   return {
     success: true,

--- a/services/platform/convex/notifications/email_notification.test.ts
+++ b/services/platform/convex/notifications/email_notification.test.ts
@@ -30,6 +30,21 @@ describe('buildPersonalNotificationUrl', () => {
     ).toBe('https://app.example.com/dashboard/org_1/chat/thread_chat');
   });
 
+  it('builds a conversation deep link when conversationId is present', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: 'org_1',
+        params: {
+          conversationId: 'conv_abc',
+          conversationStatus: 'open',
+        },
+        siteUrl: 'https://app.example.com',
+      }),
+    ).toBe(
+      'https://app.example.com/dashboard/org_1/conversations/open?conversation=conv_abc',
+    );
+  });
+
   it('builds a discussion deep link when threadId and projectId are present', () => {
     expect(
       buildPersonalNotificationUrl({

--- a/services/platform/convex/notifications/email_notification.ts
+++ b/services/platform/convex/notifications/email_notification.ts
@@ -37,6 +37,14 @@ export function buildPersonalNotificationUrl(args: {
   if (args.params?.chat === true && typeof threadId === 'string') {
     return `${base}/dashboard/${args.organizationId}/chat/${encodeURIComponent(threadId)}`;
   }
+  const conversationId = args.params?.conversationId;
+  if (typeof conversationId === 'string') {
+    const status =
+      typeof args.params?.conversationStatus === 'string'
+        ? args.params.conversationStatus
+        : 'open';
+    return `${base}/dashboard/${args.organizationId}/conversations/${encodeURIComponent(status)}?conversation=${encodeURIComponent(conversationId)}`;
+  }
   if (typeof threadId === 'string' && typeof projectId === 'string') {
     return `${base}/dashboard/${args.organizationId}/projects/${projectId}/discussions?thread=${encodeURIComponent(threadId)}`;
   }

--- a/services/platform/convex/workflow_engine/action_defs/notification/notification_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/notification/notification_action.ts
@@ -7,7 +7,7 @@
  * Operations:
  *  - `notify_users`: per-user inbox rows to a declarative audience
  *    (`task_assignee` | `task_subscribers` | `project_creator` |
- *    `org_admins` | explicit `user_ids`). Preferences respected, repeated
+ *    `org_admins` | `org_members` | explicit `user_ids`). Preferences respected, repeated
  *    cron firings deduped — see `collab/internal_mutations.ts`.
  *  - `notify_org_channel`: one org-wide notification-bell entry (the
  *    admin-facing operational feed), severity-tagged.
@@ -34,7 +34,8 @@ type NotificationActionParams =
         | 'task_assignee'
         | 'task_subscribers'
         | 'project_creator'
-        | 'org_admins';
+        | 'org_admins'
+        | 'org_members';
       type:
         | 'task_assigned'
         | 'task_status_changed'
@@ -46,12 +47,14 @@ type NotificationActionParams =
         | 'automation_failed'
         | 'budget_alert'
         | 'runtime_offline'
-        | 'workforce_digest';
+        | 'workforce_digest'
+        | 'conversation_message';
       titleKey: string;
       bodyKey: string;
       params?: ConvexJsonRecord;
       taskId?: string;
       projectId?: string;
+      conversationId?: string;
       userIds?: string[];
     }
   | {
@@ -68,6 +71,7 @@ const audienceValidator = v.union(
   v.literal('task_subscribers'),
   v.literal('project_creator'),
   v.literal('org_admins'),
+  v.literal('org_members'),
 );
 
 const userNotificationTypeValidator = v.union(
@@ -82,13 +86,14 @@ const userNotificationTypeValidator = v.union(
   v.literal('budget_alert'),
   v.literal('runtime_offline'),
   v.literal('workforce_digest'),
+  v.literal('conversation_message'),
 );
 
 export const notificationAction: ActionDefinition<NotificationActionParams> = {
   type: 'notification',
   title: 'Notification Operation',
   description:
-    'Notify humans from an automation: notify_users writes per-user inbox notifications to a declarative audience (task_assignee, task_subscribers, project_creator, org_admins, user_ids) with preference + dedupe handling; notify_org_channel writes one org-wide bell entry. titleKey/bodyKey are i18n keys with params interpolation. organizationId is read from workflow context variables.',
+    'Notify humans from an automation: notify_users writes per-user inbox notifications to a declarative audience (task_assignee, task_subscribers, project_creator, org_admins, org_members, user_ids) with preference + dedupe handling; notify_org_channel writes one org-wide bell entry. titleKey/bodyKey are i18n keys with params interpolation. organizationId is read from workflow context variables.',
   parametersValidator: v.union(
     v.object({
       operation: v.literal('notify_users'),
@@ -99,6 +104,7 @@ export const notificationAction: ActionDefinition<NotificationActionParams> = {
       params: v.optional(jsonRecordValidator),
       taskId: v.optional(v.id('tasks')),
       projectId: v.optional(v.id('projects')),
+      conversationId: v.optional(v.id('conversations')),
       userIds: v.optional(v.array(v.string())),
     }),
     v.object({
@@ -135,6 +141,9 @@ export const notificationAction: ActionDefinition<NotificationActionParams> = {
             taskId: params.taskId ? toId<'tasks'>(params.taskId) : undefined,
             projectId: params.projectId
               ? toId<'projects'>(params.projectId)
+              : undefined,
+            conversationId: params.conversationId
+              ? toId<'conversations'>(params.conversationId)
               : undefined,
             userIds: params.userIds,
           },

--- a/services/platform/convex/workflows/conversations_inbound_notify.test.ts
+++ b/services/platform/convex/workflows/conversations_inbound_notify.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { workflowJsonSchema } from '../../lib/shared/schemas/workflows';
+
+const WORKFLOW_PATH = fileURLToPath(
+  new URL(
+    '../../../../builtin-configs/workflows/conversations/notify-members-on-inbound-message.json',
+    import.meta.url,
+  ),
+);
+
+describe('notify-members-on-inbound-message workflow template', () => {
+  it('parses as valid workflow JSON and listens for inbound conversation events', () => {
+    const raw = JSON.parse(readFileSync(WORKFLOW_PATH, 'utf-8'));
+    const parsed = workflowJsonSchema.safeParse(raw);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    expect(parsed.data.triggers?.events).toEqual([
+      { eventType: 'conversation.message_received' },
+    ]);
+    expect(parsed.data.metadata?.autoInstall).toBeUndefined();
+
+    const openStep = parsed.data.steps.find(
+      (step) => step.stepSlug === 'open_only',
+    );
+    expect(openStep?.stepType).toBe('condition');
+
+    const notifyStep = parsed.data.steps.find(
+      (step) => step.stepSlug === 'notify_members',
+    );
+    expect(notifyStep?.stepType).toBe('action');
+    expect(notifyStep?.config).toMatchObject({
+      type: 'notification',
+      parameters: {
+        operation: 'notify_users',
+        audience: 'org_members',
+        type: 'conversation_message',
+        titleKey: 'conversationInboundMessage',
+      },
+    });
+  });
+});

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4622,6 +4622,10 @@
       "digest": {
         "label": "Zusammenfassung",
         "description": "Regelmäßige Übersicht der Workforce-Aktivität."
+      },
+      "conversationMessages": {
+        "label": "Konversationsnachrichten",
+        "description": "Wenn eine Kundennachricht in Konversationen ankommt."
       }
     }
   },
@@ -6993,6 +6997,8 @@
     "humanInputEscalatedBody": "Ein Workflow wartet seit {ageHours} Stunden auf menschliche Eingabe.",
     "workforceDigest": "Tägliche Workforce-Übersicht",
     "workforceDigestBody": "{created} erstellt · {completed} abgeschlossen · {runs} Agenten-Läufe ({failed} fehlgeschlagen) · {pendingReviews} warten auf Review · {queued} in Warteschlange · {breakers} pausiert.",
+    "conversationInboundMessage": "Neue Konversationsnachricht",
+    "conversationInboundMessageBody": "Von {sender}: \"{subject}\" — öffne Konversationen, um zu antworten.",
     "agentEscalation": "Agenten-Eskalation",
     "agentEscalationBody": "{agent} hat eskaliert: {reason}",
     "email": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4625,6 +4625,10 @@
       "digest": {
         "label": "Digest",
         "description": "Periodic summary of workforce activity."
+      },
+      "conversationMessages": {
+        "label": "Conversation messages",
+        "description": "When a customer message arrives in Conversations."
       }
     }
   },
@@ -7260,6 +7264,8 @@
     "humanInputEscalatedBody": "A workflow has been waiting on human input for {ageHours} hours.",
     "workforceDigest": "Daily workforce digest",
     "workforceDigestBody": "{created} created · {completed} completed · {runs} agent runs ({failed} failed) · {pendingReviews} awaiting review · {queued} queued · {breakers} paused.",
+    "conversationInboundMessage": "New conversation message",
+    "conversationInboundMessageBody": "From {sender}: \"{subject}\" — open Conversations to reply.",
     "agentEscalation": "Agent escalation",
     "agentEscalationBody": "{agent} escalated: {reason}",
     "email": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4622,6 +4622,10 @@
       "digest": {
         "label": "Résumé",
         "description": "Résumé périodique de l'activité de la workforce."
+      },
+      "conversationMessages": {
+        "label": "Messages de conversation",
+        "description": "Quand un message client arrive dans Conversations."
       }
     }
   },
@@ -6993,6 +6997,8 @@
     "humanInputEscalatedBody": "Un workflow attend une saisie humaine depuis {ageHours} heures.",
     "workforceDigest": "Synthèse quotidienne de la workforce",
     "workforceDigestBody": "{created} créées · {completed} terminées · {runs} exécutions d'agents ({failed} en échec) · {pendingReviews} en attente de revue · {queued} en file · {breakers} en pause.",
+    "conversationInboundMessage": "Nouveau message de conversation",
+    "conversationInboundMessageBody": "De {sender} : « {subject} » — ouvre Conversations pour répondre.",
     "agentEscalation": "Escalade d'agent",
     "agentEscalationBody": "{agent} a escaladé : {reason}",
     "email": {


### PR DESCRIPTION
## Summary
- Emit `conversation.message_received` from `createConversationWithMessage` so new threads trigger automations
- Add built-in catalog workflow **Notify members on inbound conversation message** (opt-in, not autoInstall)
- Extend notification action with `org_members` audience (paginated up to 500), `conversation_message` type/pref, and conversation deep links

## Depends on
- #2496 (return-loop notification infra)

## Test plan
- [x] `bun run --filter @tale/platform test -- convex/workflows/conversations_inbound_notify.test.ts convex/conversations/create_conversation_with_message.test.ts`
- [ ] Manual: catalog sync → install workflow → inbound message notifies org members
- [ ] Manual: conversation notification deep link opens `?conversation=` panel

## Definition of done
- [x] Green gate — targeted tests pass locally
- [x] Security gate — SAST clean on commit
- [x] Tests — inbound notify integration test + createConversation event test
- [x] Migration — N/A (optional fields + catalog JSON)
- [x] Locales — en/de/fr conversation pref + message copy
- [x] Docs — N/A
- [x] Accessibility — N/A (backend + existing notification surfaces)
- [x] Sweep — workflow JSON, notification_action, schema, prefs, deep links
- [ ] Observed — not browser-verified in this session
- [x] Commits — atomic conventional commit stacked on #2496