### PR TITLE
fix: agent bound skills tab is not scrollable (#2487)

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -408,3 +408,56 @@ describe('DataTable addAction contract', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('DataTable non-sticky wheel scroll', () => {
+  it('chains vertical wheel scroll from the table frame to a scrollable ancestor', () => {
+    const scrollParent = document.createElement('div');
+    scrollParent.style.height = '200px';
+    scrollParent.style.overflow = 'auto';
+    Object.defineProperty(scrollParent, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    });
+    Object.defineProperty(scrollParent, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    });
+    let top = 0;
+    Object.defineProperty(scrollParent, 'scrollTop', {
+      get: () => top,
+      set: (value: number) => {
+        top = value;
+      },
+      configurable: true,
+    });
+
+    const inner = document.createElement('div');
+    inner.style.height = '800px';
+
+    scrollParent.appendChild(inner);
+    document.body.appendChild(scrollParent);
+
+    render(
+      <DataTable columns={columns} data={sampleRows} approxRowCount={3} />,
+      { container: inner },
+    );
+
+    const trap = inner.querySelector('.overflow-x-auto');
+    expect(trap).toBeInstanceOf(HTMLElement);
+    if (!(trap instanceof HTMLElement)) return;
+    Object.defineProperty(trap, 'scrollHeight', {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(trap, 'clientHeight', {
+      value: 400,
+      configurable: true,
+    });
+
+    trap.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 48, bubbles: true, cancelable: true }),
+    );
+
+    expect(scrollParent.scrollTop).toBe(48);
+  });
+});

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -52,6 +52,7 @@ import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
+import { chainVerticalWheelToScrollParent } from '@/lib/utils/scroll-wheel-chain';
 
 import {
   DataTableActionMenu,
@@ -329,6 +330,9 @@ export function DataTable<TData, TValue = unknown>({
 
   // Ref to the scroll container for sticky layout (needed for IntersectionObserver root)
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Non-sticky layout: horizontal scrollport that must chain vertical wheel to
+  // the page scroller (see chainVerticalWheelToScrollParent).
+  const horizontalScrollRef = useRef<HTMLDivElement>(null);
 
   // Track previous row count for animation on load more
   const prevRowCountRef = useRef(0);
@@ -336,6 +340,17 @@ export function DataTable<TData, TValue = unknown>({
 
   // Stable noop callback for when infiniteScroll is not provided
   const noop = useCallback(() => {}, []);
+
+  useEffect(() => {
+    if (stickyLayout) return undefined;
+    const el = horizontalScrollRef.current;
+    if (!el) return undefined;
+    const onWheel = (event: WheelEvent) => {
+      chainVerticalWheelToScrollParent(el, event);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [stickyLayout]);
 
   useEffect(() => {
     const currentCount = data.length;
@@ -1162,7 +1177,7 @@ export function DataTable<TData, TValue = unknown>({
               content too. `overflow-hidden` on the frame clips the rounded
               corners (safe here: this layout has no sticky header). */}
           <div className="border-border overflow-hidden rounded-lg border">
-            <div className="overflow-x-auto">
+            <div ref={horizontalScrollRef} className="overflow-x-auto">
               <div className="w-fit min-w-full">
                 {tableContent}
                 {infiniteScrollContent}

--- a/services/platform/app/features/automations/components/automations-table.test.tsx
+++ b/services/platform/app/features/automations/components/automations-table.test.tsx
@@ -70,6 +70,10 @@ vi.mock('../hooks/file-mutations', () => ({
   useInstallWorkflow: () => ({ mutateAsync: vi.fn() }),
 }));
 
+vi.mock('@/app/components/catalog/use-catalog-sync', () => ({
+  useCatalogSync: () => ({ menuItem: null, dialog: null }),
+}));
+
 describe('AutomationsTable', () => {
   beforeEach(() => {
     mockWorkflows.current = [

--- a/services/platform/app/features/skills/components/skills-table.test.tsx
+++ b/services/platform/app/features/skills/components/skills-table.test.tsx
@@ -1,7 +1,13 @@
+import { AppShell } from '@tale/ui/app-shell';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { ContentArea } from '@/app/components/layout/content-area';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
+import { useSkillsTableConfig } from '@/app/features/skills/hooks/use-skills-table-config';
+import { i18n } from '@/lib/i18n/i18n';
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render, screen } from '@/tests/utils/render';
 
@@ -53,6 +59,14 @@ vi.mock('./skill-upload/skill-upload-dialog', () => ({
   SkillUploadDialog: () => null,
 }));
 
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <AppShell i18n={i18n} locale={{ mode: 'client' }}>
+      {children}
+    </AppShell>
+  );
+}
+
 function renderSkillsSettings() {
   // Mirrors app/routes/dashboard/$id/settings/skills/index.tsx so the assertion
   // exercises the same heading + table composition the E2E loaded. SkillsTable
@@ -70,6 +84,27 @@ function renderSkillsSettings() {
       >
         <SkillsTable organizationId="org-1" initialDetailSlug={null} />
       </SettingsSection>
+    </QueryClientProvider>,
+  );
+}
+
+function renderAgentBoundSkills() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ContentArea variant="narrow" gap={6}>
+        <SkillsTable
+          organizationId="org-1"
+          hideActionMenu
+          bindingMode={{
+            selected: [],
+            onChange: vi.fn(),
+            max: 10,
+          }}
+        />
+      </ContentArea>
     </QueryClientProvider>,
   );
 }
@@ -102,5 +137,100 @@ describe('SkillsTable (settings)', () => {
     await checkAccessibility(container, {
       rules: { 'empty-table-header': { enabled: false } },
     });
+  });
+});
+
+describe('SkillsTable (agent bound skills)', () => {
+  it('uses the non-sticky page-scroll layout in binding mode', () => {
+    const { result } = renderHook(
+      () =>
+        useSkillsTableConfig({
+          organizationId: 'org-1',
+          bindingMode: {
+            selected: [],
+            onChange: vi.fn(),
+            max: 10,
+          },
+        }),
+      { wrapper: Providers },
+    );
+
+    expect(result.current.stickyLayout).toBe(false);
+  });
+
+  // Regression for #2487: the agent Bound skills tab renders under PageLayout
+  // (page-owned vertical scroll). The table must NOT use the sticky inner
+  // scroll container and must chain vertical wheel from its horizontal frame.
+  it('does not render the sticky wheel-trap scroll container', () => {
+    const { container } = renderAgentBoundSkills();
+
+    expect(container.querySelector('.overscroll-contain')).toBeNull();
+    expect(container.querySelector('.overflow-x-auto')).not.toBeNull();
+  });
+
+  it('chains vertical wheel scroll from the table frame to a scrollable ancestor', () => {
+    const scrollParent = document.createElement('div');
+    scrollParent.style.height = '200px';
+    scrollParent.style.overflow = 'auto';
+    Object.defineProperty(scrollParent, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    });
+    Object.defineProperty(scrollParent, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    });
+    let top = 0;
+    Object.defineProperty(scrollParent, 'scrollTop', {
+      get: () => top,
+      set: (value: number) => {
+        top = value;
+      },
+      configurable: true,
+    });
+
+    const inner = document.createElement('div');
+    inner.style.height = '800px';
+
+    scrollParent.appendChild(inner);
+    document.body.appendChild(scrollParent);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ContentArea variant="narrow" gap={6}>
+          <SkillsTable
+            organizationId="org-1"
+            hideActionMenu
+            bindingMode={{
+              selected: [],
+              onChange: vi.fn(),
+              max: 10,
+            }}
+          />
+        </ContentArea>
+      </QueryClientProvider>,
+      { container: inner },
+    );
+
+    const trap = inner.querySelector('.overflow-x-auto');
+    expect(trap).toBeInstanceOf(HTMLElement);
+    if (!(trap instanceof HTMLElement)) return;
+    Object.defineProperty(trap, 'scrollHeight', {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(trap, 'clientHeight', {
+      value: 400,
+      configurable: true,
+    });
+
+    trap.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 48, bubbles: true, cancelable: true }),
+    );
+
+    expect(scrollParent.scrollTop).toBe(48);
   });
 });

--- a/services/platform/app/hooks/scroll-wheel-chain.test.ts
+++ b/services/platform/app/hooks/scroll-wheel-chain.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { chainVerticalWheelToScrollParent } from '@/lib/utils/scroll-wheel-chain';
+
+function wheelEvent(deltaY: number): WheelEvent {
+  return new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true });
+}
+
+function mockScrollMetrics(
+  el: HTMLElement,
+  {
+    scrollHeight,
+    clientHeight,
+    scrollTop = 0,
+  }: {
+    scrollHeight: number;
+    clientHeight: number;
+    scrollTop?: number;
+  },
+) {
+  let top = scrollTop;
+  Object.defineProperty(el, 'scrollHeight', {
+    value: scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'clientHeight', {
+    value: clientHeight,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'scrollTop', {
+    get: () => top,
+    set: (value: number) => {
+      top = value;
+    },
+    configurable: true,
+  });
+}
+
+describe('chainVerticalWheelToScrollParent', () => {
+  it('scrolls a scrollable ancestor when the container has no vertical overflow', () => {
+    const scrollParent = document.createElement('div');
+    scrollParent.style.overflow = 'auto';
+    mockScrollMetrics(scrollParent, { scrollHeight: 800, clientHeight: 200 });
+
+    const trap = document.createElement('div');
+    trap.style.overflowX = 'auto';
+    mockScrollMetrics(trap, { scrollHeight: 400, clientHeight: 400 });
+
+    scrollParent.appendChild(trap);
+    document.body.appendChild(scrollParent);
+
+    const event = wheelEvent(40);
+    chainVerticalWheelToScrollParent(trap, event);
+
+    expect(scrollParent.scrollTop).toBe(40);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does nothing when there is no scrollable ancestor', () => {
+    const trap = document.createElement('div');
+    trap.style.overflowX = 'auto';
+    mockScrollMetrics(trap, { scrollHeight: 400, clientHeight: 400 });
+    document.body.appendChild(trap);
+
+    const event = wheelEvent(40);
+    chainVerticalWheelToScrollParent(trap, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('ignores zero vertical delta', () => {
+    const scrollParent = document.createElement('div');
+    scrollParent.style.overflow = 'auto';
+    mockScrollMetrics(scrollParent, { scrollHeight: 800, clientHeight: 200 });
+
+    const trap = document.createElement('div');
+    scrollParent.appendChild(trap);
+    document.body.appendChild(scrollParent);
+
+    const event = wheelEvent(0);
+    chainVerticalWheelToScrollParent(trap, event);
+
+    expect(scrollParent.scrollTop).toBe(0);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/services/platform/lib/utils/scroll-wheel-chain.ts
+++ b/services/platform/lib/utils/scroll-wheel-chain.ts
@@ -1,0 +1,52 @@
+function isVerticallyScrollable(el: HTMLElement): boolean {
+  if (el.scrollHeight <= el.clientHeight) return false;
+  const { overflow, overflowY } = getComputedStyle(el);
+  if (
+    overflowY === 'auto' ||
+    overflowY === 'scroll' ||
+    overflowY === 'overlay'
+  ) {
+    return true;
+  }
+  // Shorthand `overflow: auto|scroll` — some runtimes (incl. jsdom) leave
+  // `overflowY` as `visible` while the shorthand is set on the element.
+  return overflow === 'auto' || overflow === 'scroll';
+}
+
+function findScrollableAncestor(start: HTMLElement | null): HTMLElement | null {
+  let node = start;
+  while (node) {
+    if (isVerticallyScrollable(node)) return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
+ * When a horizontally-scrollable container cannot absorb vertical wheel delta,
+ * scroll the nearest scrollable ancestor instead. Prevents the classic wheel
+ * trap over `overflow-x-auto` regions inside page-level scrollers (e.g.
+ * Settings → Skills and the agent Bound skills tab).
+ */
+export function chainVerticalWheelToScrollParent(
+  container: HTMLElement,
+  event: WheelEvent,
+): void {
+  const { deltaY } = event;
+  if (deltaY === 0) return;
+
+  if (container.scrollHeight > container.clientHeight) {
+    const { scrollTop, clientHeight, scrollHeight } = container;
+    const atTop = scrollTop <= 0;
+    const atBottom = scrollTop + clientHeight >= scrollHeight - 1;
+    if ((deltaY < 0 && !atTop) || (deltaY > 0 && !atBottom)) {
+      return;
+    }
+  }
+
+  const scrollParent = findScrollableAncestor(container.parentElement);
+  if (!scrollParent) return;
+
+  scrollParent.scrollTop += deltaY;
+  event.preventDefault();
+}

--- a/services/platform/tests/e2e/specs/external-agent.spec.ts
+++ b/services/platform/tests/e2e/specs/external-agent.spec.ts
@@ -290,7 +290,7 @@ test.describe('external agent (Cursor)', () => {
 
     await expect(
       page.getByText(
-        t('settings.agents.skills.sectionSkillBindingsExternalDescription'),
+        t('settings.agents.form.sectionSkillBindingsExternalDescription'),
       ),
     ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
 


### PR DESCRIPTION
Closes #2487

## Summary
- The agent **Bound skills** tab (and other non-sticky `DataTable` pages like Settings → Skills) could not be scrolled with the wheel when the pointer was over the table. The non-sticky layout’s horizontal scroll frame (`overflow-x-auto`) became a scroll target but had no vertical overflow, so wheel events were consumed without chaining to the page scroller (`PageLayout` / settings `ContentArea`).
- Fix at the shared `DataTable` level: attach a wheel listener on the horizontal scrollport that forwards vertical delta to the nearest scrollable ancestor when the frame cannot scroll vertically (`chainVerticalWheelToScrollParent`).
- Regression tests cover the utility, `DataTable`, and agent binding-mode `SkillsTable`.

## Related
- Also addresses the remaining wheel-trap for Settings → Skills (#2381) when `stickyLayout: false` — the horizontal frame trap persisted after #2436 disabled sticky layout.

## Test plan
- [x] `bunx vitest --run --config vitest.ui.config.ts --pool=forks app/hooks/scroll-wheel-chain.test.ts app/components/ui/data-table/data-table.test.tsx app/features/skills/components/skills-table.test.tsx` — 28 passed
- [x] `bun run lint` — 0 errors
- [ ] Live wheel verification on agent Bound skills tab (requires full platform + seeded org)


Made with [Cursor](https://cursor.com)