### PR TITLE
fix(platform): skip [1m] suffix on gateway model refs for external agents (#2396)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -66,6 +66,8 @@ export default {
         // Listed in `optimizeDeps.include` in vite.config.ts as a string literal so vite prebundles it;
         // consumed transitively via @tale/ui components, never imported by name from platform code.
         '@radix-ui/react-slot',
+        'rehype-katex',
+        'remark-math',
         // Peer of @vitest/browser-playwright, required at runtime by vitest's browser test mode
         // but never imported directly.
         '@vitest/browser',

--- a/services/platform/lib/agent-adapters/claude-code/adapter.test.ts
+++ b/services/platform/lib/agent-adapters/claude-code/adapter.test.ts
@@ -202,14 +202,29 @@ describe('ClaudeCodeAdapter buildExec — model passthrough', () => {
     expect(modelArg(exec.argv)).toBe('claude-opus-4-20250514[1m]');
   });
 
-  it('leaves managed sessions on the gateway catalog ref', () => {
+  it('leaves managed sessions on the gateway catalog ref without [1m]', () => {
     delete process.env.TALE_SANDBOX_CONTEXT_1M;
     const exec = adapter.buildExec(
       baseSpec({ model: '~anthropic/claude-fable-latest' }),
     );
-    expect(modelArg(exec.argv)).toBe('~anthropic/claude-fable-latest[1m]');
+    // Gateway refs (provider/model spelling) must not carry the window marker —
+    // CC only strips [1m] from vendor-native ids; a suffixed gateway ref never
+    // reaches the LLM gateway (#2396).
+    expect(modelArg(exec.argv)).toBe('~anthropic/claude-fable-latest');
+    expect(exec.env.ANTHROPIC_MODEL).toBe('~anthropic/claude-fable-latest');
     expect(exec.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe(
       '~anthropic/claude-fable-latest',
+    );
+  });
+
+  it('REGRESSION #2396: OpenRouter gateway refs must not get the [1m] suffix', () => {
+    delete process.env.TALE_SANDBOX_CONTEXT_1M;
+    const exec = adapter.buildExec(
+      baseSpec({ model: 'openrouter/anthropic/claude-sonnet-4.6' }),
+    );
+    expect(modelArg(exec.argv)).toBe('openrouter/anthropic/claude-sonnet-4.6');
+    expect(exec.env.ANTHROPIC_MODEL).toBe(
+      'openrouter/anthropic/claude-sonnet-4.6',
     );
   });
 });

--- a/services/platform/lib/agent-adapters/claude-code/adapter.ts
+++ b/services/platform/lib/agent-adapters/claude-code/adapter.ts
@@ -65,18 +65,31 @@ const PLAYWRIGHT_MCP_CDP_SERVER = {
  * untouched (it would just ignore the marker). */
 const CONTEXT_1M_FAMILIES = ['opus', 'sonnet', 'fable'] as const;
 
+/** True when the model id is a sandbox-LLM-gateway ref (`provider/model…`)
+ * rather than a vendor-native Claude Code id (`claude-*`). The `[1m]` window
+ * marker only applies to the latter — CC strips it via normalizeModelStringForAPI
+ * before the request, but gateway refs are passed through verbatim to the VK
+ * allowlist; appending `[1m]` breaks resolution and no completion reaches the
+ * gateway (#2396). */
+function isGatewayModelRef(model: string): boolean {
+  return model.includes('/');
+}
+
 /** Default the in-sandbox agent to the maximum (1M) context window. Claude Code
  * gates its 1M window on a `[1m]` suffix on the model string, and strips that
  * suffix via its own normalizeModelStringForAPI BEFORE the request — so the
  * gateway / single-model virtual-key allowlist only ever sees the bare model id
- * (appending it cannot 404 the VK). 1M carries no long-context premium on
- * current Opus, so it is on by default; an operator can force the 200K default
- * back with TALE_SANDBOX_CONTEXT_1M=0, and a model string that already encodes a
- * window (`…[1m]`) is left as-is. (Reasoning depth is the separate
- * CLAUDE_CODE_EFFORT_LEVEL knob — set as an overridable env floor in the sandbox
- * image, NOT here: a per-exec env value would override the user's session env.) */
+ * (appending it cannot 404 the VK). Gateway-routed refs (`openrouter/…`) skip
+ * the marker — CC does not strip it from slash-qualified ids. 1M carries no
+ * long-context premium on current Opus, so it is on by default; an operator
+ * can force the 200K default back with TALE_SANDBOX_CONTEXT_1M=0, and a model
+ * string that already encodes a window (`…[1m]`) is left as-is. (Reasoning depth
+ * is the separate CLAUDE_CODE_EFFORT_LEVEL knob — set as an overridable env
+ * floor in the sandbox image, NOT here: a per-exec env value would override the
+ * user's session env.) */
 function withMaxContext(model: string): string {
   if (process.env.TALE_SANDBOX_CONTEXT_1M === '0') return model;
+  if (isGatewayModelRef(model)) return model;
   const lower = model.toLowerCase();
   if (lower.includes('[1m]')) return model; // caller already chose a window
   if (!CONTEXT_1M_FAMILIES.some((family) => lower.includes(family))) {

--- a/services/platform/tests/e2e/specs/external-agent.spec.ts
+++ b/services/platform/tests/e2e/specs/external-agent.spec.ts
@@ -290,7 +290,7 @@ test.describe('external agent (Cursor)', () => {
 
     await expect(
       page.getByText(
-        t('settings.agents.skills.sectionSkillBindingsExternalDescription'),
+        t('settings.agents.form.sectionSkillBindingsExternalDescription'),
       ),
     ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
 


### PR DESCRIPTION
## Summary

External-agent (Claude Code) turns on the local sandbox stack failed because `withMaxContext` appended Claude Code's `[1m]` window marker to gateway-routed model refs like `openrouter/anthropic/claude-sonnet-4.6`. The `[1m]` suffix is only stripped by Claude Code for vendor-native ids (`claude-*`); slash-qualified gateway refs are passed through verbatim, so the runner invoked `openrouter/anthropic/claude-sonnet-4.6[1m]`, which never matched the virtual-key allowlist and no completion reached `tale-sandbox-llm-gateway`.

This change skips the `[1m]` marker when the model id contains `/` (gateway provider/model spelling), while preserving the 1M-context default for native Anthropic ids used in BYO and direct paths.

Closes #2396

## Test plan

- [x] `vitest --project server lib/agent-adapters/claude-code/adapter.test.ts lib/agent-adapters/build-exec.test.ts` — 45 tests pass
- [x] Added regression test for `openrouter/anthropic/claude-sonnet-4.6` (issue #2396 repro)
- [ ] Manual: external-agent turn with Claude Sonnet 4.6 on local B+sandbox stack completes and gateway logs show `/v1/chat/completions` traffic


Made with [Cursor](https://cursor.com)