### PR TITLE
fix(platform): ignore transitive markdown math deps in knip

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -63,9 +63,11 @@ export default {
       ],
       project: ['**/*.{ts,tsx}'],
       ignoreDependencies: [
-        // Listed in `optimizeDeps.include` in vite.config.ts as a string literal so vite prebundles it;
-        // consumed transitively via @tale/ui components, never imported by name from platform code.
+        // Listed in `optimizeDeps.include` in vite.config.ts as string literals so vite prebundles them;
+        // consumed transitively via @tale/ui markdown source, never imported by name from platform code.
         '@radix-ui/react-slot',
+        'rehype-katex',
+        'remark-math',
         // Peer of @vitest/browser-playwright, required at runtime by vitest's browser test mode
         // but never imported directly.
         '@vitest/browser',


### PR DESCRIPTION
## Summary

Fixes the Knip job failure on main after #2502 merged `rehype-katex` and `remark-math` into `@tale/platform` for Vite resolution. Platform never imports them directly — they are consumed via `@tale/ui` markdown source and listed in `optimizeDeps.include`.

Adds both packages to `ignoreDependencies` for the platform workspace in `knip.config.ts`, matching the existing `@radix-ui/react-slot` pattern.

## Test plan

- [x] `bun run knip:check` — passes locally

## Definition of done

- [x] **Green gate** — knip:check passes
- [x] **Security gate** — N/A
- [x] **Tests** — N/A
- [x] **Migration** — N/A
- [x] **Locales** — N/A
- [x] **Docs** — N/A
- [x] **Accessibility** — N/A
- [x] **Sweep** — N/A
- [x] **Observed** — knip run green locally
- [x] **Commits** — single atomic commit