### PR TITLE
fix(platform): stream OneDrive downloads into storage to avoid OOM

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1077,6 +1077,7 @@ import type * as onedrive_refresh_credentials from "../onedrive/refresh_credenti
 import type * as onedrive_refresh_token from "../onedrive/refresh_token.js";
 import type * as onedrive_run_config_sync from "../onedrive/run_config_sync.js";
 import type * as onedrive_run_folder_reconcile from "../onedrive/run_folder_reconcile.js";
+import type * as onedrive_stream_to_storage from "../onedrive/stream_to_storage.js";
 import type * as onedrive_types from "../onedrive/types.js";
 import type * as onedrive_update_sync_config from "../onedrive/update_sync_config.js";
 import type * as onedrive_upload_and_create_document from "../onedrive/upload_and_create_document.js";
@@ -2745,6 +2746,7 @@ declare const fullApi: ApiFromModules<{
   "onedrive/refresh_token": typeof onedrive_refresh_token;
   "onedrive/run_config_sync": typeof onedrive_run_config_sync;
   "onedrive/run_folder_reconcile": typeof onedrive_run_folder_reconcile;
+  "onedrive/stream_to_storage": typeof onedrive_stream_to_storage;
   "onedrive/types": typeof onedrive_types;
   "onedrive/update_sync_config": typeof onedrive_update_sync_config;
   "onedrive/upload_and_create_document": typeof onedrive_upload_and_create_document;

--- a/services/platform/convex/onedrive/import_files.test.ts
+++ b/services/platform/convex/onedrive/import_files.test.ts
@@ -13,13 +13,13 @@ function makeDeps(overrides: Partial<ImportFilesDependencies> = {}) {
     getFileMetadata: vi
       .fn()
       .mockResolvedValue({ success: true, data: { hash: undefined } }),
-    downloadFile: vi.fn().mockResolvedValue({
+    downloadToStorage: vi.fn().mockResolvedValue({
       success: true,
-      content: new ArrayBuffer(8),
+      storageId: 'storage-1' as Id<'_storage'>,
       mimeType: 'text/plain',
+      size: 10,
     }),
     findDocumentByExternalId: vi.fn().mockResolvedValue(null),
-    storeFile: vi.fn().mockResolvedValue('storage-1' as Id<'_storage'>),
     createDocument,
     updateDocument: vi.fn().mockResolvedValue(undefined),
     getOrCreateFolderPath: vi
@@ -131,11 +131,69 @@ describe('importFiles sync configs', () => {
       'storage-1',
       'a.docx',
       'text/plain',
-      8,
+      10,
       'doc-1',
     );
     expect(deps.linkDocumentToFile).toHaveBeenCalledWith('storage-1', 'doc-1');
     expect(deps.scheduleHubDocumentRagIndexing).toHaveBeenCalledWith('doc-1');
+  });
+
+  it('records the transferred byte size, falling back to the listing size', async () => {
+    // stored.size (from the download Content-Length) wins over the listing size.
+    const deps = makeDeps({
+      downloadToStorage: vi.fn().mockResolvedValue({
+        success: true,
+        storageId: 'storage-1' as Id<'_storage'>,
+        mimeType: 'text/plain',
+        size: 4096,
+      }),
+    });
+    await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'one-time' },
+      deps,
+    );
+    expect(deps.saveFileMetadata).toHaveBeenCalledWith(
+      'storage-1',
+      'a.docx',
+      'text/plain',
+      4096,
+      'doc-1',
+    );
+
+    // When the source omits Content-Length, fall back to the listing size (10).
+    const depsNoSize = makeDeps({
+      downloadToStorage: vi.fn().mockResolvedValue({
+        success: true,
+        storageId: 'storage-1' as Id<'_storage'>,
+        mimeType: 'text/plain',
+      }),
+    });
+    await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'one-time' },
+      depsNoSize,
+    );
+    expect(depsNoSize.saveFileMetadata).toHaveBeenCalledWith(
+      'storage-1',
+      'a.docx',
+      'text/plain',
+      10,
+      'doc-1',
+    );
+  });
+
+  it('fails the item when the streamed download+store fails', async () => {
+    const deps = makeDeps({
+      downloadToStorage: vi
+        .fn()
+        .mockResolvedValue({ success: false, error: 'boom' }),
+    });
+    const result = await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'one-time' },
+      deps,
+    );
+    expect(result.failedCount).toBe(1);
+    expect(result.results[0]).toMatchObject({ status: 'error', error: 'boom' });
+    expect(deps.createDocument).not.toHaveBeenCalled();
   });
 
   it('still queues indexing when content hash is unchanged', async () => {
@@ -158,6 +216,6 @@ describe('importFiles sync configs', () => {
     expect(deps.scheduleHubDocumentRagIndexing).toHaveBeenCalledWith(
       'doc-existing',
     );
-    expect(deps.downloadFile).not.toHaveBeenCalled();
+    expect(deps.downloadToStorage).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/onedrive/import_files.ts
+++ b/services/platform/convex/onedrive/import_files.ts
@@ -51,22 +51,28 @@ export interface ImportFilesDependencies {
     siteId?: string,
     driveId?: string,
   ) => Promise<{ success: boolean; data?: FileMetadata; error?: string }>;
-  downloadFile: (
-    itemId: string,
-    token: string,
-    siteId?: string,
-    driveId?: string,
-  ) => Promise<{
+  /**
+   * Download the source file and land it in Convex storage in one step,
+   * returning only the storage id — the bytes never come back into the
+   * caller's heap. Backed by a streaming `'use node'` action so a large file
+   * (e.g. a 57 MB PDF) can't OOM the 64 MB workflow isolate the import runs in.
+   */
+  downloadToStorage: (args: {
+    itemId: string;
+    token: string;
+    siteId?: string;
+    driveId?: string;
+  }) => Promise<{
     success: boolean;
-    content?: ArrayBuffer;
+    storageId?: Id<'_storage'>;
     mimeType?: string;
+    size?: number;
     error?: string;
   }>;
   findDocumentByExternalId: (args: {
     organizationId: string;
     externalItemId: string;
   }) => Promise<{ _id: Id<'documents'>; contentHash?: string } | null>;
-  storeFile: (blob: Blob) => Promise<Id<'_storage'>>;
   createDocument: (args: {
     organizationId: string;
     title: string;
@@ -201,25 +207,25 @@ export async function importFiles(
         continue;
       }
 
-      const downloadResult = await deps.downloadFile(
-        item.id,
-        args.token,
-        item.siteId,
-        item.driveId,
-      );
+      const stored = await deps.downloadToStorage({
+        itemId: item.id,
+        token: args.token,
+        siteId: item.siteId,
+        driveId: item.driveId,
+      });
 
-      if (!downloadResult.success || !downloadResult.content) {
-        throw new Error(downloadResult.error || 'Failed to download file');
+      if (!stored.success || !stored.storageId) {
+        throw new Error(stored.error || 'Failed to download file');
       }
 
-      const blob = new Blob([downloadResult.content], {
-        type: downloadResult.mimeType || 'application/octet-stream',
-      });
-      const storageId = await deps.storeFile(blob);
+      const storageId = stored.storageId;
       const contentType = resolveFileType(
         item.name,
-        downloadResult.mimeType || 'application/octet-stream',
+        stored.mimeType || 'application/octet-stream',
       );
+      // Prefer the transferred byte count; fall back to the listing size when
+      // the source omitted Content-Length.
+      const fileSize = stored.size ?? item.size;
 
       const storagePath = item.relativePath
         ? `${args.organizationId}/${item.relativePath}`
@@ -301,7 +307,7 @@ export async function importFiles(
         storageId,
         item.name,
         contentType,
-        blob.size,
+        fileSize,
         documentId,
       );
 

--- a/services/platform/convex/onedrive/import_files_deps.ts
+++ b/services/platform/convex/onedrive/import_files_deps.ts
@@ -4,7 +4,6 @@
 
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
-import { downloadFile } from './download_file';
 import { getFileMetadata } from './get_file_metadata';
 import type { ImportFilesDependencies } from './import_files';
 
@@ -19,8 +18,13 @@ export function createImportFilesDeps(
   return {
     getFileMetadata: (itemId, token, siteId, driveId) =>
       getFileMetadata(itemId, token, siteId, driveId),
-    downloadFile: (itemId, token, siteId, driveId) =>
-      downloadFile(itemId, token, siteId, driveId),
+    // Streams the file into storage inside a 'use node' action so the bytes
+    // never enter this (possibly 64 MB) isolate — see stream_to_storage.ts.
+    downloadToStorage: (streamArgs) =>
+      ctx.runAction(
+        internal.onedrive.internal_actions.streamItemToStorage,
+        streamArgs,
+      ),
     findDocumentByExternalId: async (findArgs) => {
       const doc = await ctx.runQuery(
         internal.documents.internal_queries.findDocumentByExternalId,
@@ -28,7 +32,6 @@ export function createImportFilesDeps(
       );
       return doc ? { _id: doc._id, contentHash: doc.contentHash } : null;
     },
-    storeFile: async (blob) => ctx.storage.store(blob),
     createDocument: async (createArgs) =>
       ctx.runMutation(
         internal.documents.internal_mutations.createDocument,

--- a/services/platform/convex/onedrive/internal_actions.ts
+++ b/services/platform/convex/onedrive/internal_actions.ts
@@ -15,6 +15,7 @@ import { listFolderContents as listFolderContentsImpl } from './list_folder_cont
 import { readFile as readFileImpl } from './read_file';
 import { resolveMicrosoftRefreshCredentials } from './refresh_credentials';
 import { refreshToken as refreshTokenImpl } from './refresh_token';
+import { streamItemToStorage as streamItemToStorageImpl } from './stream_to_storage';
 import { uploadAndCreateDocument as uploadAndCreateDocumentImpl } from './upload_and_create_document';
 import { createUploadAndCreateDocDeps } from './upload_and_create_document_deps';
 
@@ -140,6 +141,25 @@ export const downloadAndStoreFile = internalAction({
         );
       },
     });
+  },
+});
+
+export const streamItemToStorage = internalAction({
+  args: {
+    itemId: v.string(),
+    token: v.string(),
+    siteId: v.optional(v.string()),
+    driveId: v.optional(v.string()),
+  },
+  returns: v.object({
+    success: v.boolean(),
+    storageId: v.optional(v.id('_storage')),
+    mimeType: v.optional(v.string()),
+    size: v.optional(v.number()),
+    error: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    return await streamItemToStorageImpl(ctx, args);
   },
 });
 

--- a/services/platform/convex/onedrive/stream_to_storage.ts
+++ b/services/platform/convex/onedrive/stream_to_storage.ts
@@ -1,0 +1,99 @@
+/**
+ * Stream a OneDrive/SharePoint file straight into Convex storage.
+ *
+ * The import pipeline used to `fetch(...).arrayBuffer()` the whole file and
+ * wrap it in a `Blob` before `ctx.storage.store` — two full copies in the
+ * caller's heap. Inside the workflow isolate (64 MB cap) a large file (e.g. a
+ * 57 MB PDF) blows the limit and the action OOMs. Here we instead pipe the
+ * download response body directly into a Convex upload URL: the bytes flow
+ * through as a stream and never fully materialize in the JS heap, so file size
+ * is bounded by the transfer, not by the action's memory.
+ */
+
+import { fetchJson } from '../../lib/utils/type-utils';
+import type { Id } from '../_generated/dataModel';
+import type { ActionCtx } from '../_generated/server';
+
+export interface StreamToStorageResult {
+  success: boolean;
+  storageId?: Id<'_storage'>;
+  mimeType?: string;
+  /** Byte size from the download `Content-Length`, when the source sends it. */
+  size?: number;
+  error?: string;
+}
+
+export async function streamItemToStorage(
+  ctx: ActionCtx,
+  args: {
+    itemId: string;
+    token: string;
+    siteId?: string;
+    driveId?: string;
+  },
+): Promise<StreamToStorageResult> {
+  const url =
+    args.siteId && args.driveId
+      ? `https://graph.microsoft.com/v1.0/sites/${args.siteId}/drives/${args.driveId}/items/${args.itemId}/content`
+      : `https://graph.microsoft.com/v1.0/me/drive/items/${args.itemId}/content`;
+
+  try {
+    const download = await fetch(url, {
+      headers: { Authorization: `Bearer ${args.token}` },
+    });
+
+    if (!download.ok) {
+      const errorText = await download.text();
+      return {
+        success: false,
+        error: `Failed to download file: ${download.status} ${errorText}`,
+      };
+    }
+    if (!download.body) {
+      return { success: false, error: 'Download response had no body' };
+    }
+
+    const mimeType =
+      download.headers.get('content-type') || 'application/octet-stream';
+    const contentLength = download.headers.get('content-length');
+
+    // Pipe the download stream straight into the Convex upload endpoint. The
+    // `duplex: 'half'` request is required by the Fetch spec to send a
+    // streaming body; forward the source Content-Length so the endpoint gets a
+    // sized (non-chunked) upload when the source provides it.
+    const uploadUrl = await ctx.storage.generateUploadUrl();
+    const upload = await fetch(uploadUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': mimeType,
+        ...(contentLength ? { 'Content-Length': contentLength } : {}),
+      },
+      body: download.body,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+
+    if (!upload.ok) {
+      const errorText = await upload.text().catch(() => '');
+      return {
+        success: false,
+        error: `Failed to store file: ${upload.status} ${errorText}`,
+      };
+    }
+
+    const { storageId } = await fetchJson<{ storageId: Id<'_storage'> }>(
+      upload,
+    );
+
+    return {
+      success: true,
+      storageId,
+      mimeType,
+      size: contentLength ? Number(contentLength) : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}


### PR DESCRIPTION
## Problem

Syncing a large OneDrive file (a 56.8 MB PDF) crashes the sync with:

> JavaScript execution ran out of memory (maximum memory usage: 64 MB)

The failure is fatal — an OOM isn't a catchable exception, so the whole sync run dies (and retries into the same wall), not just the one file.

## Root cause

The import pipeline downloaded each file with `response.arrayBuffer()` and wrapped it in a `Blob` before `ctx.storage.store` — **two full copies of the file in the caller's heap**. The folder-sync reconcile runs inside the workflow isolate (64 MB cap), so a ~57 MB file pushes peak memory (~113 MB) past the limit. Effective per-file ceiling was only ~25–28 MB.

## Fix

New `'use node'` action `streamItemToStorage` pipes the Graph `/content` response body **straight into a Convex upload URL** (`generateUploadUrl`), so the bytes stream through and never materialize in the isolate's heap. File size is now bounded by the transfer, not the action's memory.

- `importFiles`' `downloadFile` + `storeFile` deps are replaced by a single `downloadToStorage` that delegates to the streaming action.
- Source `Content-Length` is forwarded for a sized (non-chunked) upload; the transferred byte count is recorded (falling back to the listing size).
- Shared by both the folder-sync and picker imports via `createImportFilesDeps`.

## Testing

- `bun run --filter @tale/platform test -- convex/onedrive` — 35 passing, including new cases for size passthrough and streamed-download failure handling.
- typecheck / oxlint / oxfmt clean.

## Needs live verification

The streamed upload body (`duplex: 'half'`) is the one new element — the `generateUploadUrl` + POST base is already proven in this codebase. Re-sync the 56.8 MB PDF to confirm it lands without OOM. If the runtime rejects the streamed body it fails gracefully (that item errors; no OOM/crash).

Note: storing the file ≠ indexing it — RAG text-extraction of a very large PDF may hit its own memory limit next (separate pipeline).