### PR TITLE
fix(platform): avoid duplicate OneDrive sync schedule on re-provision

### DIFF
--- a/services/platform/convex/onedrive/ensure_sync_workflow_provision.test.ts
+++ b/services/platform/convex/onedrive/ensure_sync_workflow_provision.test.ts
@@ -84,4 +84,66 @@ describe('ensureSyncWorkflowEngineProvision', () => {
     expect(compensated.schedulesActive).toBe(1);
     expect(compensated.complete).toBe(true);
   });
+
+  async function slugSchedules(t: T) {
+    return await t.run(async (ctx) => {
+      const rows: Array<{ cron: string; active: boolean }> = [];
+      for await (const sched of ctx.db
+        .query('wfSchedules')
+        .withIndex('by_workflowSlug', (q) => q.eq('workflowSlug', SLUG))) {
+        if (sched.organizationId === ORG) {
+          rows.push({ cron: sched.cronExpression, active: sched.isActive });
+        }
+      }
+      return rows;
+    });
+  }
+
+  async function retune(
+    t: T,
+    patch: { cronExpression: string; isActive?: boolean },
+  ) {
+    await t.run(async (ctx) => {
+      for await (const sched of ctx.db
+        .query('wfSchedules')
+        .withIndex('by_workflowSlug', (q) => q.eq('workflowSlug', SLUG))) {
+        if (sched.organizationId === ORG) {
+          await ctx.db.patch(sched._id, patch);
+        }
+      }
+    });
+  }
+
+  it('keeps an operator-retuned interval instead of adding the builtin cron', async () => {
+    const t = convexTest(schema, modules);
+    await runProvision(t);
+
+    // Operator retunes the interval (e.g. via the trigger editor) to every 2 min.
+    await retune(t, { cronExpression: '*/2 * * * *' });
+
+    const compensated = await runProvision(t);
+
+    expect(compensated.schedulesCreated).toBe(0);
+    expect(compensated.schedulesActive).toBe(1);
+    expect(compensated.complete).toBe(true);
+    expect(await slugSchedules(t)).toEqual([
+      { cron: '*/2 * * * *', active: true },
+    ]);
+  });
+
+  it('revives a paused, retuned schedule instead of adding the builtin cron', async () => {
+    const t = convexTest(schema, modules);
+    await runProvision(t);
+
+    await retune(t, { cronExpression: '*/2 * * * *', isActive: false });
+
+    const compensated = await runProvision(t);
+
+    expect(compensated.schedulesCreated).toBe(0);
+    expect(compensated.schedulesReactivated).toBe(1);
+    expect(compensated.schedulesActive).toBe(1);
+    expect(await slugSchedules(t)).toEqual([
+      { cron: '*/2 * * * *', active: true },
+    ]);
+  });
 });

--- a/services/platform/convex/onedrive/ensure_sync_workflow_provision.ts
+++ b/services/platform/convex/onedrive/ensure_sync_workflow_provision.ts
@@ -38,39 +38,38 @@ export type SyncWorkflowProvisionResult = {
   /** `wfInstallations` row was absent before this run. */
   installationCreated: boolean;
   schedulesRequired: number;
+  /** Active org-level schedule rows for this automation (any cron). */
   schedulesActive: number;
   schedulesCreated: number;
   schedulesReactivated: number;
   eventsCreated: number;
-  /** Every declared schedule has an active row. */
+  /** The automation has at least one active schedule. */
   complete: boolean;
 };
 
-async function countActiveSchedulesForCrons(
+/**
+ * Org-level (project-less) schedule rows for this automation, regardless of
+ * cron or active state. The sync engine owns a single, retunable schedule, so
+ * provisioning keys on the automation — not on the builtin's exact cron: an
+ * operator who changes the interval must not get a second trigger bolted on.
+ */
+async function listAutomationSchedules(
   ctx: MutationCtx,
   organizationId: string,
   workflowSlug: string,
-  schedules: readonly DeclaredSchedule[],
-): Promise<number> {
-  let active = 0;
-  for (const declared of schedules) {
-    for await (const sched of ctx.db
-      .query('wfSchedules')
-      .withIndex('by_workflowSlug', (q) =>
-        q.eq('workflowSlug', workflowSlug),
-      )) {
-      if (
-        sched.organizationId === organizationId &&
-        sched.cronExpression === declared.cron &&
-        sched.projectId === undefined &&
-        sched.isActive
-      ) {
-        active += 1;
-        break;
-      }
+): Promise<Array<{ isActive: boolean }>> {
+  const rows: Array<{ isActive: boolean }> = [];
+  for await (const sched of ctx.db
+    .query('wfSchedules')
+    .withIndex('by_workflowSlug', (q) => q.eq('workflowSlug', workflowSlug))) {
+    if (
+      sched.organizationId === organizationId &&
+      sched.projectId === undefined
+    ) {
+      rows.push({ isActive: sched.isActive });
     }
   }
-  return active;
+  return rows;
 }
 
 /**
@@ -108,11 +107,23 @@ export async function compensateSyncWorkflowEngineProvision(
     contentHash: args.contentHash,
   });
 
+  // A schedule row already present for this automation — even one the operator
+  // retuned to a different interval, or paused — is authoritative. Only declare
+  // the builtin schedule when none exists yet; otherwise `activate: true` below
+  // just revives it. This is what stops a divergent builtin cron from being
+  // inserted as a second, concurrently-firing trigger.
+  const priorSchedules = await listAutomationSchedules(
+    ctx,
+    args.organizationId,
+    args.workflowSlug,
+  );
+  const declareSchedules = priorSchedules.length === 0 ? schedules : [];
+
   const triggers = await provisionDeclaredWorkflowTriggersImpl(ctx, {
     organizationId: args.organizationId,
     workflowSlug: args.workflowSlug,
     events: args.events,
-    schedules,
+    schedules: declareSchedules,
     activate: true,
   });
 
@@ -122,16 +133,12 @@ export async function compensateSyncWorkflowEngineProvision(
     contentHash: args.contentHash,
   });
 
-  const schedulesActive = await countActiveSchedulesForCrons(
-    ctx,
-    args.organizationId,
-    args.workflowSlug,
-    schedules,
-  );
+  const schedulesActive = (
+    await listAutomationSchedules(ctx, args.organizationId, args.workflowSlug)
+  ).filter((sched) => sched.isActive).length;
 
   const schedulesRequired = schedules.length;
-  const complete =
-    schedulesRequired === 0 || schedulesActive >= schedulesRequired;
+  const complete = schedulesRequired === 0 || schedulesActive >= 1;
 
   return {
     installationCreated: priorInstall === null,


### PR DESCRIPTION
## Problem

The OneDrive/SharePoint sync engine re-provisions its `wfSchedules` trigger on **every** sync-config upsert (each time a folder is added to sync). The provisioning guard was *create-if-absent keyed on the exact cron string* — the identity it matched on was `(org, workflowSlug, cronExpression, projectId === undefined)`.

That means once an operator retunes the sync interval (e.g. to `*/2 * * * *` via the trigger editor), the builtin's declared `*/15 * * * *` no longer matches any existing row, so the next re-provision **inserts a second schedule**. Both rows stay `isActive: true`, so the automation ends up firing on two different intervals at once. The `wfSchedules` table has no unique constraint to catch it, and nothing reconciled the divergent row.

## Fix

Key provisioning on the **automation**, not on the cron. The sync engine owns a single, retunable schedule, so:

- If **any** org-level (project-less) schedule row for the slug already exists — active or paused, any cron — keep it and declare nothing new. The existing `activate: true` path still revives a paused one.
- Only when there is no schedule row at all do we declare the builtin schedule to create the first one.
- Completeness now means "the automation has an active schedule", not "the declared cron has a row".

The change is contained to `onedrive/ensure_sync_workflow_provision.ts`; the shared `provisionDeclaredWorkflowTriggersImpl` (used by two other provisioning paths that may legitimately declare multiple distinct crons) is untouched.

## Behaviour

- Repeated "Sync import" on the same folder → still exactly one schedule. ✓
- Operator retunes interval to 2 min, then adds another sync folder → keeps the 2-min schedule, does **not** add a 15-min one. ✓ (was: duplicate)
- Fresh install → creates the builtin schedule as before. ✓

Note: `activate: true` is preserved, so adding a sync folder re-activates a *paused* schedule (existing behaviour, consistent with "ensure the automation has a live schedule").

## Tests

- 3 existing provision tests still green (incl. reactivate-without-duplicate).
- 2 new regression tests (both fail on the old code):
  - operator-retuned active `*/2` → asserts `schedulesCreated: 0` and a single `*/2` row remains.
  - retuned + paused `*/2` → asserts it is revived (`schedulesReactivated: 1`), not duplicated.
- `@tale/platform` typecheck + `bun run lint` clean; all 37 OneDrive tests pass.