### PR TITLE
fix(platform): make the chat UI clock-safe (timer rewind + message position error)

### DIFF
--- a/services/platform/app/features/automations/components/automation-assistant.tsx
+++ b/services/platform/app/features/automations/components/automation-assistant.tsx
@@ -9,6 +9,7 @@ import { ChatMessages } from '@/app/features/chat/components/chat-messages';
 import { BranchProvider } from '@/app/features/chat/context/branch-context';
 import { ChatLayoutProvider } from '@/app/features/chat/context/chat-layout-context';
 import { ThreadMessageMetadataProvider } from '@/app/features/chat/hooks/queries';
+import { ClockOffsetProvider } from '@/app/hooks/use-clock-offset';
 import { useT } from '@/lib/i18n/client';
 
 import { useAssistantChat } from '../hooks/use-assistant-chat';
@@ -36,7 +37,7 @@ function AutomationAssistantContent({
     isLoadingMore,
     isLoading,
     isSendPending,
-    generationStartMs,
+    thinkingAnchor,
     inputValue,
     setInputValue,
     attachments,
@@ -88,7 +89,7 @@ function AutomationAssistantContent({
         >
           <ThreadMessageMetadataProvider
             threadId={threadId}
-            generationStartMs={generationStartMs}
+            thinkingAnchor={thinkingAnchor}
           >
             <ChatMessages
               items={items}
@@ -99,7 +100,7 @@ function AutomationAssistantContent({
               loadMore={loadMore}
               isLoading={isLoading}
               isSendPending={isSendPending}
-              generationStartMs={generationStartMs}
+              thinkingAnchor={thinkingAnchor}
               lastUserMessageRef={lastUserMessageRef}
               containerRef={containerRef}
               activeApproval={activeApproval}
@@ -145,9 +146,11 @@ export function AutomationAssistant(props: AutomationAssistantProps) {
   // live on separate routes, so they never mount simultaneously.
   return (
     <ChatLayoutProvider organizationId={props.organizationId}>
-      <FileUpload.Root>
-        <AutomationAssistantContent {...props} />
-      </FileUpload.Root>
+      <ClockOffsetProvider>
+        <FileUpload.Root>
+          <AutomationAssistantContent {...props} />
+        </FileUpload.Root>
+      </ClockOffsetProvider>
     </ChatLayoutProvider>
   );
 }

--- a/services/platform/app/features/automations/hooks/use-assistant-chat.ts
+++ b/services/platform/app/features/automations/hooks/use-assistant-chat.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import type { ThinkingAnchor } from '@/app/features/chat/components/thought-timeline/use-thinking-timer';
 import { useChatLayout } from '@/app/features/chat/context/chat-layout-context';
 import {
   useCreateThread,
@@ -15,6 +16,10 @@ import { useMergedChatItems } from '@/app/features/chat/hooks/use-merged-chat-it
 import { useMessageProcessing } from '@/app/features/chat/hooks/use-message-processing';
 import { usePendingMessages } from '@/app/features/chat/hooks/use-pending-messages';
 import { useThreadApprovals } from '@/app/features/chat/hooks/use-thread-approvals';
+import {
+  useClockOffset,
+  useReportServerNow,
+} from '@/app/hooks/use-clock-offset';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
@@ -91,7 +96,7 @@ export function useAssistantChat({
   const [threadId, setThreadId] = useState<string | null>(null);
   const isSendingRef = useRef(false);
 
-  const { setPendingMessage } = useChatLayout();
+  const { pendingMessage, setPendingMessage } = useChatLayout();
 
   const assistantAgentSlug = 'workflow-assistant';
 
@@ -128,6 +133,36 @@ export function useAssistantChat({
     threadId && organizationId ? { threadId, organizationId } : 'skip',
   );
   const generationStartMs = threadMeta?.generationStartTime ?? null;
+
+  // Thinking-timer anchor (same clock-safe contract as the main chat): prefer
+  // the immutable client send time so the live timer never swaps client→server
+  // mid-turn; the server start (converted to the client frame) is the reload
+  // fallback. Feeds the offset authority from the serverNow this query carries.
+  useReportServerNow(threadMeta?.serverNow);
+  const { toClientEpoch } = useClockOffset();
+  const clientTurnStartRef = useRef<number | null>(null);
+  const clientTurnStartMs =
+    pendingMessage && !pendingMessage.editedMessageId
+      ? pendingMessage.timestamp.getTime()
+      : isPending
+        ? clientTurnStartRef.current
+        : null;
+  clientTurnStartRef.current = clientTurnStartMs;
+  const serverStartClientMs =
+    generationStartMs === null ? null : toClientEpoch(generationStartMs);
+  const thinkingAnchor = useMemo<ThinkingAnchor>(() => {
+    const reanchorKey =
+      clientTurnStartMs !== null
+        ? `c:${clientTurnStartMs}`
+        : serverStartClientMs !== null
+          ? `s:${serverStartClientMs}`
+          : 'none';
+    return {
+      clientStartMs: clientTurnStartMs,
+      serverStartClientMs,
+      reanchorKey,
+    };
+  }, [clientTurnStartMs, serverStartClientMs]);
 
   const approvals = useThreadApprovals(organizationId, threadId ?? undefined);
   const { requests: resolvedHumanInputRequests } =
@@ -323,7 +358,7 @@ export function useAssistantChat({
     isLoadingMore,
     isLoading,
     isSendPending: isPending,
-    generationStartMs,
+    thinkingAnchor,
     inputValue,
     setInputValue,
     attachments,

--- a/services/platform/app/features/chat/clock-safety.test.ts
+++ b/services/platform/app/features/chat/clock-safety.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guardrail: the chat UI must never subtract a SERVER epoch timestamp
+ * (`generationStartTime`, a message `_creationTime`, `startedAt`) from a CLIENT
+ * `Date.now()`. That mix is ~0 on localhost but seconds in production — the
+ * "Thinking · Ns" timer rewind and the streaming-reply-above-user mis-order.
+ * Every "now" in these files must come from `use-clock-offset`
+ * (`clientEpochNow` / `serverEpochNow` / `toClientEpoch`), whose module is the
+ * ONLY sanctioned raw-clock site.
+ *
+ * Pure source-walk (no DOM). This IS the guard: the pinned oxlint build ships
+ * neither `no-restricted-syntax` nor `no-restricted-properties`, so a config
+ * rule can't express "no Date.now() in these files" — a source-walk in the test
+ * gate does. Mirrors `settings/governance/components/skeleton-conventions.test.ts`.
+ */
+const PLATFORM_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+
+const read = (rel: string): string =>
+  readFileSync(resolve(PLATFORM_ROOT, rel), 'utf8');
+
+/** Files that render live timers / relative-time from server timestamps. */
+const GUARDED_FILES = [
+  'app/features/chat/components/thought-timeline/use-thinking-timer.ts',
+  'app/features/chat/components/thought-timeline/thinking-indicator.tsx',
+  'app/features/chat/components/thought-timeline/message-thought-header.tsx',
+  'app/features/chat/components/chat-interface.tsx',
+  'app/features/chat/components/workflow-run-approval-card.tsx',
+  'app/features/chat/hooks/use-merged-chat-items.ts',
+  'app/hooks/use-relative-now.ts',
+  'lib/utils/format/relative-time.ts',
+];
+
+describe('chat clock-safety', () => {
+  it.each(GUARDED_FILES)(
+    '%s never calls Date.now() directly (use use-clock-offset)',
+    (rel) => {
+      expect(read(rel)).not.toMatch(/\bDate\.now\s*\(/);
+    },
+  );
+
+  it('the message sort orders by (order, stepOrder), not a _creationTime clock fallback', () => {
+    const src = read('app/features/chat/hooks/use-merged-chat-items.ts');
+    expect(src).toContain('stepOrder');
+    // The old clock-mixing comparator key.
+    expect(src).not.toMatch(/_creationTime\s*\?\?/);
+  });
+
+  it('the thinking timer reads "now" through the clock authority', () => {
+    const src = read(
+      'app/features/chat/components/thought-timeline/use-thinking-timer.ts',
+    );
+    expect(src).toContain('clientEpochNow');
+  });
+
+  it('use-clock-offset remains the sanctioned raw-clock home', () => {
+    // The offset module is intentionally OUT of the guarded set and IS allowed
+    // to read the wall clock — that is where the offset is measured.
+    expect(read('app/hooks/use-clock-offset.tsx')).toMatch(/\bDate\.now\s*\(/);
+  });
+});

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -15,6 +15,10 @@ import {
 import { PanelFooter } from '@/app/components/layout/panel-footer';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
 import { PageDropOverlay } from '@/app/components/ui/page-drop-overlay';
+import {
+  useClockOffset,
+  useReportServerNow,
+} from '@/app/hooks/use-clock-offset';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { usePageFileDrop } from '@/app/hooks/use-page-file-drop';
@@ -98,6 +102,7 @@ import {
 } from './queued-message-tray';
 import { SelectionQuoteButton } from './selection-quote-button';
 import { SteerStatusProvider } from './steer-status';
+import type { ThinkingAnchor } from './thought-timeline/use-thinking-timer';
 import { WelcomeView } from './welcome-view';
 
 const SavePromptDialog = lazyComponent<
@@ -324,6 +329,13 @@ export function ChatInterface({
       ? { threadId: dataThreadId, organizationId }
       : 'skip',
   );
+  // Feed the server clock into the offset authority from the subscription we
+  // already hold (no extra query). Every downstream timer/relative-time then
+  // runs in one clock frame instead of mixing a client wall clock with server
+  // epochs. `toClientEpoch` is used below to convert the server turn-start
+  // anchor for the reload/history fallback.
+  useReportServerNow(threadMeta?.serverNow);
+  const { toClientEpoch } = useClockOffset();
   const isGenerating = threadMeta?.isGenerating;
   const agentLingering = sessionProgress?.agentIdleAt != null;
   const agentActivelyWorking = (isGenerating ?? false) && !agentLingering;
@@ -519,8 +531,12 @@ export function ChatInterface({
         : null;
   clientTurnStartRef.current = clientTurnStartMs;
 
-  const effectiveGenerationStartMs = useMemo(() => {
-    if (generationStartMs === null) return clientTurnStartMs;
+  // Server turn-start CONVERTED into the client clock frame — the reload/history
+  // fallback (used only when there is no in-session client anchor). Keeps the
+  // follow-up (persist-at-pick) re-anchor: the latest current-turn user message's
+  // server time once the turn has >=2 user messages, else the turn start.
+  const serverStartClientMs = useMemo(() => {
+    if (generationStartMs === null) return null;
     let lastFollowUpMs: number | undefined;
     let currentTurnUserCount = 0;
     for (const msg of messages) {
@@ -533,10 +549,33 @@ export function ChatInterface({
         lastFollowUpMs = msg._creationTime;
       }
     }
-    return currentTurnUserCount >= 2 && lastFollowUpMs !== undefined
-      ? lastFollowUpMs
-      : generationStartMs;
-  }, [generationStartMs, messages, clientTurnStartMs]);
+    const rawServer =
+      currentTurnUserCount >= 2 && lastFollowUpMs !== undefined
+        ? lastFollowUpMs
+        : generationStartMs;
+    return toClientEpoch(rawServer);
+  }, [generationStartMs, messages, toClientEpoch]);
+
+  // The thinking-timer anchor. PREFER the immutable client send time whenever it
+  // exists this session: it is present for the whole in-flight turn (latched
+  // above) and advances to a follow-up's send time, so the live timer NEVER
+  // swaps from a client epoch to a server epoch mid-turn — the cause of the
+  // "Thinking · Ns" rewind. The server value (already client-frame) is used only
+  // on reload/history. `reanchorKey` flips only on a deliberate re-anchor (new
+  // turn / follow-up), which the timer latches on; unrelated recomputes don't.
+  const thinkingAnchor = useMemo<ThinkingAnchor>(() => {
+    const reanchorKey =
+      clientTurnStartMs !== null
+        ? `c:${clientTurnStartMs}`
+        : serverStartClientMs !== null
+          ? `s:${serverStartClientMs}`
+          : 'none';
+    return {
+      clientStartMs: clientTurnStartMs,
+      serverStartClientMs,
+      reanchorKey,
+    };
+  }, [clientTurnStartMs, serverStartClientMs]);
 
   // Merge messages with approvals and human input requests
   const {
@@ -1278,7 +1317,7 @@ export function ChatInterface({
                 <ThreadMessageMetadataProvider
                   threadId={dataThreadId ?? null}
                   liveRoute={liveRoute ?? null}
-                  generationStartMs={effectiveGenerationStartMs}
+                  thinkingAnchor={thinkingAnchor}
                 >
                   <SteerStatusProvider
                     threadId={dataThreadId}
@@ -1295,7 +1334,7 @@ export function ChatInterface({
                       isSendPending={isSendPending}
                       isAutoRoute={isAutoRoute}
                       liveRoute={liveRoute}
-                      generationStartMs={effectiveGenerationStartMs}
+                      thinkingAnchor={thinkingAnchor}
                       isQueued={threadMeta?.isQueued ?? false}
                       liveAssistantMessageId={
                         sessionProgress?.status === 'running'

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -36,6 +36,7 @@ import { InlineEditInput } from './inline-edit-input';
 import { InlineMemoryProposals } from './inline-memory-proposals';
 import { MessageBubble } from './message-bubble';
 import { ModelFallbackNotice } from './model-fallback-notice';
+import type { ThinkingAnchor } from './thought-timeline/use-thinking-timer';
 import { VirtualizedChatMessageList } from './virtualized-chat-message-list';
 import { VoiceOutputAnnouncer } from './voice-output-announcer';
 
@@ -198,10 +199,11 @@ interface ChatMessagesProps {
    *  the thread's transient `liveRoute`), so the gap shell can show "Routed to X"
    *  as soon as the router decides instead of waiting for turn completion. */
   liveRoute?: { agentName: string; reason: RouteReason };
-  /** The in-flight turn's server start (`generationStartTime`), anchoring the
-   *  gap-shell "Thinking · Ns" timer to the same clock the in-bubble timeline
-   *  uses — so it neither resets at the handoff nor across the new-chat remount. */
-  generationStartMs?: number | null;
+  /** The in-flight turn's thinking-timer anchor (client-frame start + reload
+   *  fallback + re-anchor key), anchoring the gap-shell "Thinking · Ns" timer to
+   *  the same client-frame clock the in-bubble timeline uses — so it neither
+   *  resets at the handoff nor across the new-chat remount, and never rewinds. */
+  thinkingAnchor?: ThinkingAnchor | null;
   /** Park-on-capacity: the in-flight turn is waiting for a free sandbox slot, so
    *  the gap-shell shows "Queued for capacity" instead of "Thinking". */
   isQueued?: boolean;
@@ -268,7 +270,7 @@ export const ChatMessages = memo(function ChatMessages({
   isSendPending,
   isAutoRoute,
   liveRoute,
-  generationStartMs,
+  thinkingAnchor,
   isQueued,
   liveAssistantMessageId,
   lastUserMessageRef,
@@ -531,7 +533,7 @@ export const ChatMessages = memo(function ChatMessages({
         queued: boolean;
         routedAgentName?: string;
         routeReason?: RouteReason;
-        turnStartMs?: number;
+        anchor?: ThinkingAnchor;
       }
     | undefined => {
     const turnShellActive = items.some(
@@ -555,7 +557,7 @@ export const ChatMessages = memo(function ChatMessages({
       queued: isQueued ?? false,
       routedAgentName: liveRoute?.agentName,
       routeReason: liveRoute?.reason,
-      turnStartMs: generationStartMs ?? undefined,
+      anchor: thinkingAnchor ?? undefined,
     };
   }, [
     items,
@@ -565,7 +567,7 @@ export const ChatMessages = memo(function ChatMessages({
     isAutoRoute,
     liveRoute,
     isQueued,
-    generationStartMs,
+    thinkingAnchor,
   ]);
   // Tracks the pending key so the last user message keeps a stable React key
   // across the pending→real swap (prevents DOM teardown/rebuild flicker).

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -86,6 +86,7 @@ import {
   ThinkingDots,
   ThinkingIndicator,
 } from './thought-timeline';
+import type { ThinkingAnchor } from './thought-timeline/use-thinking-timer';
 import { VoiceOutputIndicator } from './voice-output-indicator';
 
 export { ImagePreviewDialog } from './message-bubble/image-preview-dialog';
@@ -149,7 +150,7 @@ interface MessageBubbleProps extends ComponentPropsWithoutRef<'div'> {
     queued: boolean;
     routedAgentName?: string;
     routeReason?: RouteReason;
-    turnStartMs?: number;
+    anchor?: ThinkingAnchor;
   };
 }
 
@@ -343,11 +344,11 @@ function MessageBubbleComponent({
   // This also closes the brief window where a short answer has finished
   // streaming (isStreaming flipped false) but its metadata hasn't propagated.
   const threadLiveRoute = useThreadLiveRoute();
-  // The in-flight turn's server start, shared with the gap shell so the
-  // in-bubble timeline's live timer continues the SAME clock (no reset at the
-  // handoff). Null on idle threads / history bubbles — those read the persisted
-  // thinkingDurationMs instead.
-  const turnStartMs = useThreadGenerationStart() ?? undefined;
+  // The in-flight turn's thinking-timer anchor, shared with the gap shell so the
+  // in-bubble timeline's live timer continues the SAME client-frame clock (no
+  // reset/rewind at the handoff). Null on idle threads / history bubbles — those
+  // read the persisted thinkingDurationMs instead.
+  const anchor = useThreadGenerationStart() ?? undefined;
   const liveRouteForBubble =
     isAssistantStreaming || !metadata ? threadLiveRoute : null;
   // Latch the live route per-bubble: at turn-end the live route is cleared (its
@@ -615,7 +616,7 @@ function MessageBubbleComponent({
       queued={thinkingShell.queued}
       routedAgentName={thinkingShell.routedAgentName}
       routeReason={thinkingShell.routeReason}
-      turnStartMs={thinkingShell.turnStartMs}
+      anchor={thinkingShell.anchor}
     />
   ) : null;
   // The header is the SINGLE thinking control: it owns the reasoning blocks (a
@@ -651,7 +652,7 @@ function MessageBubbleComponent({
           toolCount={messageSegments.toolCount}
           skillCount={messageSegments.skillCount}
           hasReasoning={messageSegments.hasReasoning}
-          turnStartMs={turnStartMs}
+          anchor={anchor}
           reasoningSteps={reasoningSteps}
         />
       ) : null,
@@ -663,7 +664,7 @@ function MessageBubbleComponent({
       timeToFirstTokenMs,
       outputTokens,
       messageSegments,
-      turnStartMs,
+      anchor,
       reasoningSteps,
     ],
   );
@@ -1300,8 +1301,7 @@ export const MessageBubble = memo(
         nextProps.thinkingShell?.routedAgentName &&
       prevProps.thinkingShell?.routeReason ===
         nextProps.thinkingShell?.routeReason &&
-      prevProps.thinkingShell?.turnStartMs ===
-        nextProps.thinkingShell?.turnStartMs
+      prevProps.thinkingShell?.anchor === nextProps.thinkingShell?.anchor
     );
   },
 );

--- a/services/platform/app/features/chat/components/message-info-dialog.tsx
+++ b/services/platform/app/features/chat/components/message-info-dialog.tsx
@@ -16,6 +16,7 @@ import remarkGfm from 'remark-gfm';
 
 import { ViewDialog } from '@/app/components/ui/dialog/view-dialog';
 import { Field, FieldGroup } from '@/app/components/ui/forms/field';
+import { useClockOffset } from '@/app/hooks/use-clock-offset';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useCopyButton } from '@/app/hooks/use-copy';
 import { useFormatDate } from '@/app/hooks/use-format-date';
@@ -492,6 +493,7 @@ export function MessageInfoDialog({
   routedAgentName,
 }: MessageInfoDialogProps) {
   const { formatDate, locale } = useFormatDate();
+  const { serverEpochNow } = useClockOffset();
   const { t } = useT('chat');
   const { t: tCommon } = useT('common');
   const { copied: idCopied, onClick: handleCopyId } = useCopyButton(messageId);
@@ -733,7 +735,7 @@ export function MessageInfoDialog({
           <Field label={t('messageInfo.timestamp')}>
             <Text as="div">{formatDate(timestamp, 'long')}</Text>
             <Text as="div" variant="muted" className="text-xs">
-              {formatRelativeTime(timestamp, locale)}
+              {formatRelativeTime(timestamp, locale, serverEpochNow())}
             </Text>
           </Field>
 

--- a/services/platform/app/features/chat/components/thought-timeline/message-thought-header.tsx
+++ b/services/platform/app/features/chat/components/thought-timeline/message-thought-header.tsx
@@ -8,7 +8,11 @@ import { cn } from '@/lib/utils/cn';
 import type { ThoughtStep } from '../../utils/thought-step-types';
 import { ReasoningStepRow, STEP_INDENT } from './step-rows';
 import { ThoughtHeader } from './thought-header';
-import { toSeconds, useThinkingTimer } from './use-thinking-timer';
+import {
+  toSeconds,
+  useThinkingTimer,
+  type ThinkingAnchor,
+} from './use-thinking-timer';
 
 interface MessageThoughtHeaderProps {
   isStreaming: boolean;
@@ -18,7 +22,7 @@ interface MessageThoughtHeaderProps {
   toolCount: number;
   skillCount: number;
   hasReasoning: boolean;
-  turnStartMs?: number;
+  anchor?: ThinkingAnchor;
   /** The turn's reasoning blocks, in chronological order. When present this
    *  header becomes the SINGLE thinking control: a chevron reveals all of them
    *  below (collapsed by default), so they're no longer rendered inline among
@@ -48,7 +52,7 @@ export function MessageThoughtHeader({
   toolCount,
   skillCount,
   hasReasoning,
-  turnStartMs,
+  anchor,
   reasoningSteps,
   className,
 }: MessageThoughtHeaderProps) {
@@ -57,10 +61,7 @@ export function MessageThoughtHeader({
   const [expanded, setExpanded] = useState(false);
   const active = isStreaming;
   const thinking = active && !hasAnswerStarted;
-  const { liveElapsedMs, liveDurationMs } = useThinkingTimer(
-    turnStartMs,
-    thinking,
-  );
+  const { liveElapsedMs, liveDurationMs } = useThinkingTimer(anchor, thinking);
 
   // Build the "·"-separated summary shown once the turn ends. Each segment is
   // included only when its value is known.

--- a/services/platform/app/features/chat/components/thought-timeline/thinking-indicator.tsx
+++ b/services/platform/app/features/chat/components/thought-timeline/thinking-indicator.tsx
@@ -7,13 +7,17 @@ import type { RouteReason } from '../../utils/route-reason';
 import { activityLabel } from './activity-label';
 import { RoutingStepRow } from './step-rows';
 import { ThoughtHeader } from './thought-header';
-import { toSeconds, useThinkingTimer } from './use-thinking-timer';
+import {
+  toSeconds,
+  useThinkingTimer,
+  type ThinkingAnchor,
+} from './use-thinking-timer';
 
 /**
  * The post-send / resume gap affordance shown in the message list BEFORE the
  * assistant bubble exists. It renders the SAME `ThoughtHeader` strip the bubble
  * will render — same brain, same position, same ticking timer (anchored to the
- * shared server `turnStartMs`, so the clock continues seamlessly across the
+ * shared `anchor`, so the clock continues seamlessly across the
  * handoff) — plus the inline "Routed to X" chip once Auto routing resolves,
  * exactly as the bubble shows it via `MessageSegments`. Because the markup and
  * the timer are identical on both sides, the handoff has zero horizontal/
@@ -29,7 +33,7 @@ export function ThinkingIndicator({
   queued = false,
   routedAgentName,
   routeReason,
-  turnStartMs,
+  anchor,
 }: {
   className?: string;
   /** 'routing' while the Auto router is still deciding (no agent yet); 'thinking'
@@ -41,11 +45,11 @@ export function ThinkingIndicator({
   queued?: boolean;
   routedAgentName?: string;
   routeReason?: RouteReason;
-  turnStartMs?: number;
+  anchor?: ThinkingAnchor;
 }) {
   const { t } = useT('chat');
   // The gap is always a pre-answer "thinking" window, so the timer ticks.
-  const { liveElapsedMs } = useThinkingTimer(turnStartMs, true);
+  const { liveElapsedMs } = useThinkingTimer(anchor, true);
 
   // "Routing · Ns" while the router decides; "Thinking · Ns" once it has (or for
   // a pinned agent). Once resolved, chat-interface passes phase 'thinking' with

--- a/services/platform/app/features/chat/components/thought-timeline/use-thinking-timer.test.tsx
+++ b/services/platform/app/features/chat/components/thought-timeline/use-thinking-timer.test.tsx
@@ -1,16 +1,30 @@
+import { act, renderHook } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { toSeconds, useThinkingTimer } from './use-thinking-timer';
+import {
+  toSeconds,
+  useThinkingTimer,
+  type ThinkingAnchor,
+} from './use-thinking-timer';
+
+function makeAnchor(partial: Partial<ThinkingAnchor>): ThinkingAnchor {
+  return {
+    clientStartMs: null,
+    serverStartClientMs: null,
+    reanchorKey: 'k',
+    ...partial,
+  };
+}
 
 function Probe({
-  turnStartMs,
+  anchor,
   thinking,
 }: {
-  turnStartMs?: number;
+  anchor?: ThinkingAnchor;
   thinking: boolean;
 }) {
-  const { liveElapsedMs } = useThinkingTimer(turnStartMs, thinking);
+  const { liveElapsedMs } = useThinkingTimer(anchor, thinking);
   return (
     <span>
       {liveElapsedMs === null ? 'null' : String(toSeconds(liveElapsedMs))}
@@ -20,28 +34,63 @@ function Probe({
 
 // `renderToStaticMarkup` renders WITHOUT running effects, so it captures the
 // exact first paint the user sees — the frame the interval/effect has not yet
-// corrected. That's the frame the flicker lives in.
-describe('useThinkingTimer', () => {
+// corrected. That's the frame the flicker lived in.
+describe('useThinkingTimer — first paint (SSR, no effects)', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('exposes the elapsed on the very FIRST render while thinking mid-turn', () => {
     // Regression (flicker ~1s after send): the in-bubble MessageThoughtHeader
     // mounts and takes over from the pre-answer ThinkingIndicator the instant the
     // first reasoning/tool step lands. A fresh `useState(null)` made its first
-    // paint show a bare "Thinking" (no "· Ns"), so the whole timer read as
-    // snapping back to zero before the effect refilled it one frame later.
-    // Anchored to the SAME turnStartMs, the elapsed must be present immediately.
+    // paint show a bare "Thinking" (no "· Ns"). Anchored to the SAME anchor, the
+    // elapsed must be present immediately.
     const now = 1_700_000_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(now);
     const html = renderToStaticMarkup(
-      <Probe turnStartMs={now - 3000} thinking />,
+      <Probe
+        anchor={makeAnchor({ clientStartMs: now - 3000, reanchorKey: 'c' })}
+        thinking
+      />,
     );
     expect(html).toBe('<span>3</span>');
   });
 
-  it('falls back to the client clock on the first render when no turnStartMs yet', () => {
-    // Pre-markGenerating window: the server anchor has not landed. The first
-    // paint still shows a value (elapsed 0 → floored to 1s), never a null gap.
+  it('PREFERS the client send anchor over the server value (never swaps clocks → no rewind)', () => {
+    // The rewind's root: a live turn must count from the immutable client send
+    // time, not the later server generationStartTime. With BOTH present the
+    // client value (3s) wins over the server value (which would read only 1s).
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const html = renderToStaticMarkup(
+      <Probe
+        anchor={makeAnchor({
+          clientStartMs: now - 3000,
+          serverStartClientMs: now - 1000,
+          reanchorKey: 'c',
+        })}
+        thinking
+      />,
+    );
+    expect(html).toBe('<span>3</span>');
+  });
+
+  it('uses the server (client-frame) anchor on reload when there is no client anchor', () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const html = renderToStaticMarkup(
+      <Probe
+        anchor={makeAnchor({
+          clientStartMs: null,
+          serverStartClientMs: now - 4000,
+          reanchorKey: 's',
+        })}
+        thinking
+      />,
+    );
+    expect(html).toBe('<span>4</span>');
+  });
+
+  it('falls back to the client clock on the first render when no anchor yet', () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(now);
     const html = renderToStaticMarkup(<Probe thinking />);
@@ -52,8 +101,96 @@ describe('useThinkingTimer', () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(now);
     const html = renderToStaticMarkup(
-      <Probe turnStartMs={now - 3000} thinking={false} />,
+      <Probe
+        anchor={makeAnchor({ clientStartMs: now - 3000, reanchorKey: 'c' })}
+        thinking={false}
+      />,
     );
     expect(html).toBe('<span>null</span>');
+  });
+});
+
+describe('useThinkingTimer — ticking over time', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('never rewinds when the server anchor materialises mid-turn (the prod bug)', () => {
+    // Simulate prod: the client send anchor is present from the start; a moment
+    // later the server generationStartTime arrives — LATER than the client send
+    // (send → markGenerating latency), so anchoring to it would rewind. The
+    // reanchorKey is unchanged (client anchor still present), so the timer must
+    // hold its client frame and keep counting up, never dropping.
+    const t0 = 1_700_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(t0);
+
+    const { result, rerender } = renderHook(
+      ({ anchor }: { anchor: ThinkingAnchor }) =>
+        useThinkingTimer(anchor, true),
+      {
+        initialProps: {
+          anchor: makeAnchor({ clientStartMs: t0, reanchorKey: `c:${t0}` }),
+        },
+      },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    const before = toSeconds(result.current.liveElapsedMs ?? 0);
+    expect(before).toBeGreaterThanOrEqual(3); // ~3s elapsed since the client send
+
+    // Server anchor arrives 1.5s LATER than the client send — same reanchorKey.
+    rerender({
+      anchor: makeAnchor({
+        clientStartMs: t0,
+        serverStartClientMs: t0 + 1500,
+        reanchorKey: `c:${t0}`,
+      }),
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    const after = toSeconds(result.current.liveElapsedMs ?? 0);
+
+    // Monotonic: the displayed seconds never decreased across the transition.
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  it('re-anchors exactly once when the reanchorKey changes (follow-up send)', () => {
+    const t0 = 1_700_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(t0);
+
+    const { result, rerender } = renderHook(
+      ({ anchor }: { anchor: ThinkingAnchor }) =>
+        useThinkingTimer(anchor, true),
+      {
+        initialProps: {
+          anchor: makeAnchor({ clientStartMs: t0, reanchorKey: `c:${t0}` }),
+        },
+      },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(toSeconds(result.current.liveElapsedMs ?? 0)).toBeGreaterThanOrEqual(
+      5,
+    );
+
+    // A follow-up is sent 5s in — new client send time, new reanchorKey. The
+    // timer deliberately resets to count from the follow-up.
+    const t1 = t0 + 5000;
+    rerender({
+      anchor: makeAnchor({ clientStartMs: t1, reanchorKey: `c:${t1}` }),
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // ~1s since the follow-up, not ~6s since the original send.
+    expect(toSeconds(result.current.liveElapsedMs ?? 0)).toBeLessThanOrEqual(2);
   });
 });

--- a/services/platform/app/features/chat/components/thought-timeline/use-thinking-timer.ts
+++ b/services/platform/app/features/chat/components/thought-timeline/use-thinking-timer.ts
@@ -8,6 +8,8 @@ import {
   useState,
 } from 'react';
 
+import { useClockOffset } from '@/app/hooks/use-clock-offset';
+
 /** Round ms to the nearest second, floored at 1 so a sub-second window reads as
  *  "1s" rather than "0s". Shared by every header that renders a thinking timer. */
 export function toSeconds(ms: number): number {
@@ -15,60 +17,99 @@ export function toSeconds(ms: number): number {
 }
 
 /**
- * Thinking-window timing, anchored to the turn's SERVER start (`turnStartMs` =
- * generationStartTime, stamped at markGenerating BEFORE routing). ONE stable
- * clock shared by the gap-shell `ThinkingIndicator` and the in-bubble
- * `MessageThoughtHeader`, so the timer neither resets at the routing→agent
- * handoff nor across the new-chat remount, and INCLUDES the routing wait.
+ * The thinking-timer anchor, resolved once per turn in `chat-interface`. BOTH
+ * fields live in the raw CLIENT clock frame, so `clientEpochNow() - start` is
+ * always a single-clock subtraction — never client-now minus a server epoch
+ * (the old rewind):
  *
- * `clientFallbackRef` covers only the brief pre-markGenerating window before the
- * server value arrives. `liveElapsedMs` ticks every second while `thinking`;
- * `liveDurationMs` latches the final value the instant thinking ends
- * (useLayoutEffect, so the summary paints "Thought for Ns" in one frame).
+ * - `clientStartMs` — the immutable optimistic send time (`pendingMessage.
+ *   timestamp`). PREFERRED, and present for the entire in-flight turn (it
+ *   advances to a follow-up's send time), so a live turn NEVER swaps clocks.
+ * - `serverStartClientMs` — the server turn-start (`generationStartTime`, incl.
+ *   the follow-up re-anchor) CONVERTED into the client frame via the clock
+ *   offset. Used only when there is no client anchor (page reload / history).
+ * - `reanchorKey` — changes ONLY on a deliberate re-anchor (new turn / follow-up).
+ *   The timer latches its start by this key and ignores value drift otherwise,
+ *   so an anchor that wobbles (offset re-sync, a recomputed memo) can never move
+ *   the zero-point mid-turn.
+ */
+export interface ThinkingAnchor {
+  clientStartMs: number | null;
+  serverStartClientMs: number | null;
+  reanchorKey: string;
+}
+
+/**
+ * Thinking-window timing. ONE stable clock shared by the gap-shell
+ * `ThinkingIndicator` and the in-bubble `MessageThoughtHeader` (both receive the
+ * same `anchor`), so the timer neither resets at the routing→agent handoff nor
+ * across the new-chat remount, and INCLUDES the routing wait.
+ *
+ * `liveElapsedMs` ticks every second while `thinking`; `liveDurationMs` latches
+ * the final value the instant thinking ends (useLayoutEffect, so the summary
+ * paints "Thought for Ns" in one frame). Every reading of "now" goes through
+ * `clientEpochNow()` from the clock authority (the sanctioned raw-clock accessor)
+ * so this module never touches the raw wall clock directly.
  */
 export function useThinkingTimer(
-  turnStartMs: number | undefined,
+  anchor: ThinkingAnchor | undefined,
   thinking: boolean,
 ): { liveElapsedMs: number | null; liveDurationMs: number | null } {
+  const { clientEpochNow } = useClockOffset();
   const clientFallbackRef = useRef<number | null>(null);
   const prevThinkingRef = useRef(thinking);
 
-  const resolveStart = useCallback(() => {
-    if (typeof turnStartMs === 'number') return turnStartMs;
+  // Latch the resolved start by `reanchorKey`: set on first resolve and again
+  // only when the key changes (an intended re-anchor). Value drift under an
+  // unchanged key is ignored — the belt-and-braces that freezes the frame even
+  // if the upstream anchor ever wobbles.
+  const latchedStartRef = useRef<{ key: string; start: number } | null>(null);
+
+  const resolveStart = useCallback((): number => {
+    const desired =
+      anchor?.clientStartMs ?? anchor?.serverStartClientMs ?? null;
+    if (desired !== null) {
+      const key = anchor?.reanchorKey ?? 'none';
+      const latched = latchedStartRef.current;
+      if (!latched || latched.key !== key) {
+        latchedStartRef.current = { key, start: desired };
+        return desired;
+      }
+      return latched.start;
+    }
+    // No anchor yet (the brief pre-markGenerating window): a stable client
+    // fallback so the pre-answer indicator can tick before any anchor exists.
     if (clientFallbackRef.current === null) {
-      clientFallbackRef.current = Date.now();
+      clientFallbackRef.current = clientEpochNow();
     }
     return clientFallbackRef.current;
-  }, [turnStartMs]);
+  }, [anchor, clientEpochNow]);
 
   // Lazy initial value so a timer that MOUNTS mid-thinking paints the correct
-  // elapsed on its FIRST render. The in-bubble `MessageThoughtHeader` takes over
-  // from the pre-answer `ThinkingIndicator` the instant the first reasoning/tool
-  // step lands (~1s after send); with a plain `useState(null)` that fresh
-  // instance rendered one frame of "Thinking" with NO "· Ns" before its effect
-  // refilled the value — the whole timer read as snapping back to zero, a
-  // visible flicker at the handoff. Anchored to the SAME `turnStartMs` as the
-  // unmounted timer, so the value is continuous across the handoff, not reset.
+  // elapsed on its FIRST render (the in-bubble header takes over from the
+  // pre-answer indicator ~1s after send; a plain `useState(null)` would flash
+  // "Thinking" with no "· Ns"). Anchored to the SAME `anchor`, so the value is
+  // continuous across the handoff, not reset.
   const [liveElapsedMs, setLiveElapsedMs] = useState<number | null>(() =>
-    thinking ? Date.now() - resolveStart() : null,
+    thinking ? clientEpochNow() - resolveStart() : null,
   );
   const [liveDurationMs, setLiveDurationMs] = useState<number | null>(null);
 
   useLayoutEffect(() => {
     if (prevThinkingRef.current && !thinking) {
-      setLiveDurationMs(Date.now() - resolveStart());
+      setLiveDurationMs(clientEpochNow() - resolveStart());
     }
     prevThinkingRef.current = thinking;
-  }, [thinking, resolveStart]);
+  }, [thinking, resolveStart, clientEpochNow]);
 
   useEffect(() => {
     if (!thinking) return undefined;
-    setLiveElapsedMs(Date.now() - resolveStart());
+    setLiveElapsedMs(clientEpochNow() - resolveStart());
     const id = setInterval(() => {
-      setLiveElapsedMs(Date.now() - resolveStart());
+      setLiveElapsedMs(clientEpochNow() - resolveStart());
     }, 1000);
     return () => clearInterval(id);
-  }, [thinking, resolveStart]);
+  }, [thinking, resolveStart, clientEpochNow]);
 
   return { liveElapsedMs, liveDurationMs };
 }

--- a/services/platform/app/features/chat/components/workflow-run-approval-card.tsx
+++ b/services/platform/app/features/chat/components/workflow-run-approval-card.tsx
@@ -39,6 +39,7 @@ import {
   useWorkflowHumanInputApproval,
 } from '@/app/features/chat/hooks/use-execution-status';
 import { mapExecutionError } from '@/app/features/operator/lib/map-execution-error';
+import { useClockOffset } from '@/app/hooks/use-clock-offset';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useCopyButton } from '@/app/hooks/use-copy';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -66,8 +67,8 @@ interface WorkflowRunApprovalCardProps {
   className?: string;
 }
 
-function formatElapsed(startMs: number) {
-  const elapsed = Math.floor((Date.now() - startMs) / 1000);
+function formatElapsed(startMs: number, nowMs: number) {
+  const elapsed = Math.floor((nowMs - startMs) / 1000);
   if (elapsed < 60) return `${elapsed}s`;
   const minutes = Math.floor(elapsed / 60);
   if (minutes < 60) return `${minutes}m ${elapsed % 60}s`;
@@ -102,6 +103,7 @@ function WorkflowRunApprovalCardComponent({
   const { t: tHumanInput } = useT('humanInputRequest');
   const { t: tShared } = useT('common');
   const { user } = useAuth();
+  const { serverEpochNow } = useClockOffset();
   const [isApproving, setIsApproving] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -142,12 +144,15 @@ function WorkflowRunApprovalCardComponent({
 
   useEffect(() => {
     if (!isRunning || !executionStatus?.startedAt) return undefined;
-    setElapsed(formatElapsed(executionStatus.startedAt));
+    const startedAt = executionStatus.startedAt;
+    // `startedAt` is a server timestamp; measure "now" in the server frame so the
+    // elapsed never mixes clocks (client wall clock − server epoch).
+    setElapsed(formatElapsed(startedAt, serverEpochNow()));
     const interval = setInterval(() => {
-      setElapsed(formatElapsed(executionStatus.startedAt));
+      setElapsed(formatElapsed(startedAt, serverEpochNow()));
     }, 1000);
     return () => clearInterval(interval);
-  }, [isRunning, executionStatus?.startedAt]);
+  }, [isRunning, executionStatus?.startedAt, serverEpochNow]);
 
   const isPending = status === 'pending';
   const isProcessing = isApproving || isRejecting;

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -33,6 +33,7 @@ import type {
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
 import { isRecord } from '@/lib/utils/type-utils';
 
+import type { ThinkingAnchor } from '../components/thought-timeline/use-thinking-timer';
 import type { RouteReason } from '../utils/route-reason';
 
 export interface Thread {
@@ -934,13 +935,13 @@ export function useThreadLiveRoute(): ThreadLiveRoute | null {
   return useContext(ThreadLiveRouteContext);
 }
 
-/** The in-flight turn's server start (`generationStartTime`, stamped at
- *  markGenerating BEFORE Auto routing). The authoritative anchor for the live
- *  "Thinking · Ns" timer — identical across the gap-shell→bubble handoff and
- *  the new-chat remount, so the timer never resets. `null` on idle threads. */
-const ThreadGenerationStartContext = createContext<number | null>(null);
+/** The in-flight turn's thinking-timer anchor (client-frame start + reload
+ *  fallback + re-anchor key; see `ThinkingAnchor`). Shared by the gap shell and
+ *  the in-bubble header so the timer is identical across the handoff and the
+ *  new-chat remount, and never rewinds. `null` on idle threads. */
+const ThreadGenerationStartContext = createContext<ThinkingAnchor | null>(null);
 
-export function useThreadGenerationStart(): number | null {
+export function useThreadGenerationStart(): ThinkingAnchor | null {
   return useContext(ThreadGenerationStartContext);
 }
 
@@ -980,17 +981,18 @@ function useThreadMessageMetadata(
 export function ThreadMessageMetadataProvider({
   threadId,
   liveRoute = null,
-  generationStartMs = null,
+  thinkingAnchor = null,
   children,
 }: {
   threadId: string | null;
   /** The in-flight turn's resolved Auto route (slug→display-name mapped by the
    *  caller), exposed to streaming bubbles via `useThreadLiveRoute`. */
   liveRoute?: ThreadLiveRoute | null;
-  /** The in-flight turn's server start, exposed to bubbles via
+  /** The in-flight turn's thinking-timer anchor, exposed to bubbles via
    *  `useThreadGenerationStart` so the in-bubble timeline anchors its live timer
-   *  to the same clock as the gap shell (no reset across the handoff). */
-  generationStartMs?: number | null;
+   *  to the same client-frame clock as the gap shell (no reset/rewind across the
+   *  handoff). */
+  thinkingAnchor?: ThinkingAnchor | null;
   children: ReactNode;
 }) {
   const value = useThreadMessageMetadata(threadId);
@@ -1004,7 +1006,7 @@ export function ThreadMessageMetadataProvider({
       { value: liveRoute },
       createElement(
         ThreadGenerationStartContext.Provider,
-        { value: generationStartMs },
+        { value: thinkingAnchor },
         children,
       ),
     ),

--- a/services/platform/app/features/chat/hooks/use-merged-chat-items.test.ts
+++ b/services/platform/app/features/chat/hooks/use-merged-chat-items.test.ts
@@ -9,6 +9,7 @@ function makeMessage(
   id: string,
   creationTime: number,
   role: 'user' | 'assistant' = 'user',
+  opts?: { order?: number; stepOrder?: number },
 ): ChatMessage {
   return {
     id,
@@ -17,6 +18,8 @@ function makeMessage(
     role,
     timestamp: new Date(creationTime),
     _creationTime: creationTime,
+    ...(opts?.order !== undefined && { order: opts.order }),
+    ...(opts?.stepOrder !== undefined && { stepOrder: opts.stepOrder }),
   };
 }
 
@@ -274,6 +277,89 @@ describe('useMergedChatItems', () => {
     );
     expect(getMessageId(result.current.messages[0])).toBe('m1');
     expect(getMessageId(result.current.messages[1])).toBe('m2');
+  });
+});
+
+describe('useMergedChatItems — clock-safe ordering (order, stepOrder)', () => {
+  it('keeps the user before its streaming reply even when the reply has an EARLIER (client-stamped) creationTime', () => {
+    // Prod skew: the agent SDK stamps a streaming delta's `_creationTime` on the
+    // CLIENT, so it can be earlier than the user row's SERVER `_creationTime`.
+    // A `_creationTime` sort would drop the reply ABOVE the user ("错位").
+    // `(order, stepOrder)` — user (5,0), reply (5,1) — is correct either clock.
+    const user = makeMessage('u', 2000, 'user', { order: 5, stepOrder: 0 });
+    const reply = makeMessage('a', 500, 'assistant', {
+      order: 5,
+      stepOrder: 1,
+    });
+    const { result } = renderHook(() =>
+      useMergedChatItems({ ...emptyParams, messages: [reply, user] }),
+    );
+    expect(result.current.messages.map(getMessageId)).toEqual(['u', 'a']);
+  });
+
+  it('does not reorder across the streaming→finalize transition', () => {
+    const user = makeMessage('u', 2000, 'user', { order: 5, stepOrder: 0 });
+    // Finalize: the reply's server `_creationTime` is now LATER than the user's —
+    // ordering must be identical to the streaming frame above (no snap).
+    const reply = makeMessage('a', 3000, 'assistant', {
+      order: 5,
+      stepOrder: 1,
+    });
+    const { result } = renderHook(() =>
+      useMergedChatItems({ ...emptyParams, messages: [user, reply] }),
+    );
+    expect(result.current.messages.map(getMessageId)).toEqual(['u', 'a']);
+  });
+
+  it('orders multiple turns by (order, stepOrder) regardless of input order', () => {
+    const msgs = [
+      makeMessage('a2', 10, 'assistant', { order: 5, stepOrder: 1 }),
+      makeMessage('u1', 20, 'user', { order: 4, stepOrder: 0 }),
+      makeMessage('u2', 30, 'user', { order: 5, stepOrder: 0 }),
+      makeMessage('a1', 40, 'assistant', { order: 4, stepOrder: 1 }),
+    ];
+    const { result } = renderHook(() =>
+      useMergedChatItems({ ...emptyParams, messages: msgs }),
+    );
+    expect(result.current.messages.map(getMessageId)).toEqual([
+      'u1',
+      'a1',
+      'u2',
+      'a2',
+    ]);
+  });
+
+  it('places an optimistic pending user (no server order) after all real rows, before the shell', () => {
+    const realUser = makeMessage('u1', 1000, 'user', {
+      order: 4,
+      stepOrder: 0,
+    });
+    const realReply = makeMessage('a1', 2000, 'assistant', {
+      order: 4,
+      stepOrder: 1,
+    });
+    const pendingUser = makeMessage('pending-9', 9000, 'user'); // no server order
+    const shell: ChatMessage = {
+      id: 'pending-assistant-9',
+      key: 'pending-assistant-9',
+      content: '',
+      role: 'assistant',
+      timestamp: new Date(9001),
+      isStreaming: true,
+      isOptimisticShell: true,
+    };
+    const { result } = renderHook(() =>
+      useMergedChatItems({
+        ...emptyParams,
+        messages: [shell, pendingUser, realReply, realUser],
+      }),
+    );
+    expect(result.current.messages.map(getMessageId)).toEqual([
+      'u1',
+      'a1',
+      'pending-9',
+      'pending-assistant-9',
+    ]);
   });
 });
 

--- a/services/platform/app/features/chat/hooks/use-merged-chat-items.ts
+++ b/services/platform/app/features/chat/hooks/use-merged-chat-items.ts
@@ -29,6 +29,18 @@ export type ChatItem =
 
 type ApprovalChatItem = Exclude<ChatItem, { type: 'message' }>;
 
+/** Sort rank for the message stream (see the sort in `useMergedChatItems`).
+ *  Real/streaming rows (1) order by the server `(order, stepOrder)`; the
+ *  optimistic pending user (2, no server order) follows them; the optimistic
+ *  assistant shell (3) is the in-flight response, always last. Keeping non-real
+ *  rows OUT of the numeric `(order, stepOrder)` compare is what makes the sort
+ *  clock-safe — no client timestamp is ever weighed against a server one. */
+function messageRank(m: ChatMessage): 1 | 2 | 3 {
+  if (m.isOptimisticShell) return 3;
+  if (m.order === undefined) return 2;
+  return 1;
+}
+
 interface UseMergedChatItemsParams {
   messages: ChatMessage[];
   integrationApprovals: IntegrationApproval[] | undefined;
@@ -234,22 +246,33 @@ export function useMergedChatItems({
       data: message,
     }));
 
-    // Sort messages chronologically
+    // Order by the SERVER's canonical `(order, stepOrder)` — never by a clock.
+    // Mixing a client-clock key (the optimistic user's send `timestamp`, or the
+    // agent SDK's CLIENT-stamped streaming-delta `_creationTime`) with a server
+    // `_creationTime` in one numeric compare is what let a streaming reply sort
+    // ABOVE its just-sent user row under prod skew, then snap back at finalize
+    // ("错位"). `messageRank` keeps non-real rows out of that compare:
+    //   1 real/streaming → (order, stepOrder); a prompt is (N,0), its reply steps
+    //     (N,1..k), the next turn (N+1,…). The streaming row shares its finalized
+    //     row's (order, stepOrder), so ordering is identical across finalize.
+    //   2 optimistic pending user (no server order) → after all real rows.
+    //   3 optimistic assistant shell → the in-flight response, always last.
     messageItems.sort((a, b) => {
       if (a.type !== 'message' || b.type !== 'message') return 0;
-      // The optimistic assistant shell is the in-flight response to the LAST
-      // user turn. It carries no server `_creationTime`, only its send-time
-      // `timestamp`, which predates the real user row's server time — so sorting
-      // it chronologically drops it BEFORE the just-arrived user row for the
-      // frame(s) before it promotes, re-parenting the Thinking bubble from the
-      // response area up into history (a visible remount/position flash). It is
-      // always the newest item, so pin it last regardless of its timestamp.
-      const aShell = !!a.data.isOptimisticShell;
-      const bShell = !!b.data.isOptimisticShell;
-      if (aShell !== bShell) return aShell ? 1 : -1;
-      const aTime = a.data._creationTime ?? a.data.timestamp.getTime();
-      const bTime = b.data._creationTime ?? b.data.timestamp.getTime();
-      return aTime - bTime;
+      const ra = messageRank(a.data);
+      const rb = messageRank(b.data);
+      if (ra !== rb) return ra - rb;
+      if (ra === 1) {
+        if (a.data.order !== b.data.order) {
+          return (a.data.order ?? 0) - (b.data.order ?? 0);
+        }
+        return (a.data.stepOrder ?? 0) - (b.data.stepOrder ?? 0);
+      }
+      if (ra === 2) {
+        // Two optimistic pending users (rare) — keep send order, still client-only.
+        return a.data.timestamp.getTime() - b.data.timestamp.getTime();
+      }
+      return 0; // both shells — only ever one; keep stable.
     });
 
     // Inline human-input cards — ACTIVE ones too, so the card occupies one

--- a/services/platform/app/features/chat/hooks/use-message-processing.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.ts
@@ -78,6 +78,12 @@ export interface ChatMessage {
   fileParts?: FilePart[];
   _creationTime?: number;
   order?: number;
+  /** Position of this row WITHIN its prompt group (the SDK's `stepOrder`): a
+   *  user prompt is `(order, 0)`, its assistant reply steps `(order, 1..k)`.
+   *  `(order, stepOrder)` is the server's canonical, clock-free ordering — used
+   *  by useMergedChatItems so a streaming reply can't transiently sort above its
+   *  user row under clock skew. Undefined on optimistic/pending rows. */
+  stepOrder?: number;
   isStreaming?: boolean;
   /** One-cycle isStreaming carry-over for a message that landed terminal WITH
    *  text after being observed streaming-and-empty: kept streaming so
@@ -133,6 +139,7 @@ function chatMessageRenderEqual(a: ChatMessage, b: ChatMessage): boolean {
     a.content === b.content &&
     a._creationTime === b._creationTime &&
     a.order === b.order &&
+    a.stepOrder === b.stepOrder &&
     a.isStreaming === b.isStreaming &&
     a.isFinalReveal === b.isFinalReveal &&
     a.isAborted === b.isAborted &&
@@ -505,6 +512,7 @@ export function useMessageProcessing(
           fileParts: fileParts.length > 0 ? fileParts : undefined,
           _creationTime: m._creationTime,
           order: m.order,
+          stepOrder: m.stepOrder,
           isStreaming,
           isFinalReveal,
           isAborted:

--- a/services/platform/app/hooks/use-clock-offset.test.tsx
+++ b/services/platform/app/hooks/use-clock-offset.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ClockOffsetProvider,
+  useClockOffset,
+  useReportServerNow,
+} from './use-clock-offset';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ClockOffsetProvider>{children}</ClockOffsetProvider>;
+}
+
+/** Report a server sample then read the resulting clock in one hook. */
+function useProbe(serverNow?: number) {
+  useReportServerNow(serverNow);
+  return useClockOffset();
+}
+
+describe('useClockOffset', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('is the identity clock outside a provider', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+    const { result } = renderHook(() => useClockOffset());
+    expect(result.current.offsetMs).toBe(0);
+    expect(result.current.toClientEpoch(5000)).toBe(5000);
+    expect(result.current.serverEpochNow()).toBe(1000);
+    expect(result.current.clientEpochNow()).toBe(1000);
+  });
+
+  it('learns offset = serverNow - clientNow from the first sample', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+    const { result, rerender } = renderHook(
+      ({ serverNow }: { serverNow?: number }) => useProbe(serverNow),
+      {
+        wrapper,
+        initialProps: { serverNow: undefined as number | undefined },
+      },
+    );
+    // No sample yet → identity.
+    expect(result.current.offsetMs).toBe(0);
+
+    // Server is 8s ahead of the client.
+    rerender({ serverNow: 9000 });
+    expect(result.current.offsetMs).toBe(8000);
+    // A server epoch maps back into the client frame…
+    expect(result.current.toClientEpoch(9000)).toBe(1000);
+    // …and "now" is available in both frames.
+    expect(result.current.serverEpochNow()).toBe(9000);
+    expect(result.current.clientEpochNow()).toBe(1000);
+  });
+
+  it('ignores jitter within the threshold but adopts a real re-sync', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+    const { result, rerender } = renderHook(
+      ({ serverNow }: { serverNow?: number }) => useProbe(serverNow),
+      { wrapper, initialProps: { serverNow: 9000 as number | undefined } },
+    );
+    expect(result.current.offsetMs).toBe(8000);
+
+    // +100ms of latency jitter → ignored, frame stays put.
+    rerender({ serverNow: 9100 });
+    expect(result.current.offsetMs).toBe(8000);
+
+    // A genuine clock correction (> threshold) → adopted.
+    rerender({ serverNow: 20000 });
+    expect(result.current.offsetMs).toBe(19000);
+  });
+});

--- a/services/platform/app/hooks/use-clock-offset.tsx
+++ b/services/platform/app/hooks/use-clock-offset.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * Client↔server clock authority.
+ *
+ * The chat UI must never subtract a SERVER epoch timestamp (`generationStartTime`,
+ * a message `_creationTime`, `startedAt`) from a CLIENT `Date.now()`: the two
+ * clocks differ by the network latency + wall-clock skew, which is ~0 on
+ * localhost but seconds in production — the source of the "Thinking · Ns" timer
+ * rewind and the message mis-order. This provider learns a coarse offset between
+ * the two clocks from the reactive `serverNow` field on `getThreadMeta` and
+ * exposes conversions so every live timer / relative-time computation runs in a
+ * SINGLE clock frame.
+ *
+ * This module is the ONE sanctioned home for raw `Date.now()` in the chat time
+ * paths (the lint/source-walk guard bans it everywhere else and points here).
+ *
+ * Accuracy: `offsetMs = serverNow − Date.now()` at sample receipt. Because the
+ * sample was stamped one downlink-latency before it arrived, this UNDERESTIMATES
+ * the true skew by ~one-way latency (≈ half the round-trip) — a stable sub-second
+ * residual, never a rewind. That is well within tolerance for second-granularity
+ * timers and minute-granularity relative-time.
+ */
+
+/**
+ * A new sample within this delta of the held offset is treated as latency
+ * jitter, not a real re-sync, so the exposed offset (and every timer anchored
+ * through it) stays put instead of wobbling on each reactive `getThreadMeta`
+ * tick. 2s comfortably exceeds real RTT variance while still adopting a genuine
+ * clock correction.
+ */
+const RESYNC_THRESHOLD_MS = 2_000;
+
+export interface ClockOffset {
+  /** `serverClock − clientClock` in ms (see module header for the ~half-RTT bias). */
+  offsetMs: number;
+  /** Map a SERVER-epoch timestamp into the CLIENT clock frame. */
+  toClientEpoch: (serverMs: number) => number;
+  /** "Now" in the SERVER clock frame (`Date.now() + offset`). */
+  serverEpochNow: () => number;
+  /** "Now" in the CLIENT clock frame (plain `Date.now()`). */
+  clientEpochNow: () => number;
+}
+
+/** Identity offset — behaves exactly like raw `Date.now()`. Used outside a
+ *  provider (SSR, tests, non-chat surfaces) and until the first sample lands. */
+const DEFAULT_CLOCK_OFFSET: ClockOffset = {
+  offsetMs: 0,
+  toClientEpoch: (serverMs) => serverMs,
+  serverEpochNow: () => Date.now(),
+  clientEpochNow: () => Date.now(),
+};
+
+const ClockOffsetContext = createContext(DEFAULT_CLOCK_OFFSET);
+const ReportServerNowContext = createContext<(serverNow?: number) => void>(
+  () => undefined,
+);
+
+export function ClockOffsetProvider({ children }: { children: ReactNode }) {
+  const [offsetMs, setOffsetMs] = useState(0);
+  const hasSampleRef = useRef(false);
+  const offsetRef = useRef(0);
+
+  const report = useCallback((serverNow?: number) => {
+    if (serverNow == null || !Number.isFinite(serverNow)) return;
+    const candidate = serverNow - Date.now();
+    // Adopt the first sample unconditionally; afterwards only a change beyond
+    // the jitter threshold (a real re-sync), so unrelated getThreadMeta re-runs
+    // (liveRoute flips, queued flag) never shift the timer frame.
+    if (
+      !hasSampleRef.current ||
+      Math.abs(candidate - offsetRef.current) > RESYNC_THRESHOLD_MS
+    ) {
+      hasSampleRef.current = true;
+      offsetRef.current = candidate;
+      setOffsetMs(candidate);
+    }
+  }, []);
+
+  const clock = useMemo<ClockOffset>(
+    () => ({
+      offsetMs,
+      toClientEpoch: (serverMs: number) => serverMs - offsetMs,
+      serverEpochNow: () => Date.now() + offsetMs,
+      clientEpochNow: () => Date.now(),
+    }),
+    [offsetMs],
+  );
+
+  return (
+    <ReportServerNowContext.Provider value={report}>
+      <ClockOffsetContext.Provider value={clock}>
+        {children}
+      </ClockOffsetContext.Provider>
+    </ReportServerNowContext.Provider>
+  );
+}
+
+/** Read the client↔server clock conversions. Safe outside a provider (identity). */
+export function useClockOffset(): ClockOffset {
+  return useContext(ClockOffsetContext);
+}
+
+/**
+ * Feed the reactive server clock in. Call once with `threadMeta.serverNow` from
+ * the component that already subscribes to `getThreadMeta` — no new
+ * subscription. `undefined` samples (query loading / no thread) are ignored.
+ */
+export function useReportServerNow(serverNow?: number): void {
+  const report = useContext(ReportServerNowContext);
+  useEffect(() => {
+    report(serverNow);
+  }, [report, serverNow]);
+}

--- a/services/platform/app/hooks/use-relative-now.ts
+++ b/services/platform/app/hooks/use-relative-now.ts
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 
 import { formatRelativeTime } from '@/lib/utils/format/relative-time';
 
+import { useClockOffset } from './use-clock-offset';
+
 const SECOND_MS = 1_000;
 const MINUTE_MS = 60 * SECOND_MS;
 const HOUR_MS = 60 * MINUTE_MS;
@@ -41,6 +43,10 @@ export function useRelativeNow(
   options?: RelativeNowOptions,
 ): string | null {
   const { locale } = useLocale();
+  // `timestamp` is a server `_creationTime`; measure "now" in the SERVER frame
+  // (client wall clock + learned offset) so a freshly-created row never reads as
+  // "in 3s" / a few seconds off under client↔server clock skew.
+  const { serverEpochNow } = useClockOffset();
   const paused = options?.paused === true;
   const [, setTick] = useState(0);
 
@@ -48,7 +54,7 @@ export function useRelativeNow(
     if (paused || timestamp === undefined) return undefined;
     let handle: number;
     const schedule = () => {
-      const diff = Math.max(0, Date.now() - timestamp);
+      const diff = Math.max(0, serverEpochNow() - timestamp);
       // Below a minute, wake exactly on the next 5s boundary so the label
       // flips precisely when its value changes; above, a per-minute tick.
       const next =
@@ -62,11 +68,11 @@ export function useRelativeNow(
     };
     schedule();
     return () => window.clearTimeout(handle);
-  }, [paused, timestamp]);
+  }, [paused, timestamp, serverEpochNow]);
 
   if (paused || timestamp === undefined) return null;
 
-  const diff = Math.max(0, Date.now() - timestamp);
+  const diff = Math.max(0, serverEpochNow() - timestamp);
   if (diff < MINUTE_MS) {
     // Quantise to 5-second steps: 0s, 5s, 10s … 55s. Floor (not round) so the
     // value never jumps ahead of the elapsed time.
@@ -75,5 +81,5 @@ export function useRelativeNow(
   if (diff < HOUR_MS) {
     return `${Math.floor(diff / MINUTE_MS)}m`;
   }
-  return formatRelativeTime(timestamp, locale, 'narrow');
+  return formatRelativeTime(timestamp, locale, serverEpochNow(), 'narrow');
 }

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/app/features/workspace/components/workspace-context';
 import { WorkspaceFilesProvider } from '@/app/features/workspace/components/workspace-files-context';
 import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { ClockOffsetProvider } from '@/app/hooks/use-clock-offset';
 import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { lazyComponent } from '@/lib/utils/lazy-component';
@@ -353,19 +354,24 @@ function ChatLayout() {
 
   return (
     <ChatLayoutProvider organizationId={organizationId}>
-      <ArenaModeProvider>
-        <WorkspaceProvider>
-          <WorkspaceFilesProvider>
-            <LiveBrowserProvider>
-              <ChatPanelProvider>
-                <StreamingToolProvider>
-                  <ChatLayoutContent organizationId={organizationId} />
-                </StreamingToolProvider>
-              </ChatPanelProvider>
-            </LiveBrowserProvider>
-          </WorkspaceFilesProvider>
-        </WorkspaceProvider>
-      </ArenaModeProvider>
+      {/* Learns the client↔server clock offset from getThreadMeta.serverNow so
+          the sidebar's relative-time and the interface's thinking timer never
+          mix clocks. Wraps the whole chat surface (sidebar + interface). */}
+      <ClockOffsetProvider>
+        <ArenaModeProvider>
+          <WorkspaceProvider>
+            <WorkspaceFilesProvider>
+              <LiveBrowserProvider>
+                <ChatPanelProvider>
+                  <StreamingToolProvider>
+                    <ChatLayoutContent organizationId={organizationId} />
+                  </StreamingToolProvider>
+                </ChatPanelProvider>
+              </LiveBrowserProvider>
+            </WorkspaceFilesProvider>
+          </WorkspaceProvider>
+        </ArenaModeProvider>
+      </ClockOffsetProvider>
     </ChatLayoutProvider>
   );
 }

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -345,6 +345,13 @@ export const getThreadMeta = query({
       // sandbox session and --resume transcript are bound to it, so the
       // global (per-user) picker state must not re-route such a thread.
       agentSlug: v.union(v.string(), v.null()),
+      // Server wall-clock at query time (transaction time). The client derives a
+      // client↔server clock offset from this (see use-clock-offset) so live
+      // timers and relative-time never subtract a server epoch from a client
+      // `Date.now()`. Reactive — refreshes whenever this query re-runs, which it
+      // does while a thread generates; it does NOT self-tick between re-runs,
+      // which is exactly what a coarse offset needs.
+      serverNow: v.number(),
     }),
   ),
   handler: async (ctx, args) => {
@@ -415,6 +422,7 @@ export const getThreadMeta = query({
           : null,
       externalAgentMode: metadata.externalAgentMode ?? null,
       agentSlug: metadata.agentSlug ?? null,
+      serverNow: Date.now(),
     };
   },
 });

--- a/services/platform/lib/utils/format/relative-time.ts
+++ b/services/platform/lib/utils/format/relative-time.ts
@@ -13,14 +13,21 @@ const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
  * `style: 'narrow'` produces the most compact form per locale (e.g. "3m ago"
  * in en); `'long'` produces the spelled-out form. Picks the largest unit that
  * fits, falling back to seconds for sub-minute deltas.
+ *
+ * `nowMs` is "now" in the SAME clock frame as `date` — pass `serverEpochNow()`
+ * from `useClockOffset` when `date` is a server `_creationTime`, so the delta is
+ * never a client wall clock minus a server epoch (which skews "just now" into
+ * "in 3s"/"5s ago" under real clock offset). Required so the frame is explicit
+ * at every call site.
  */
 export function formatRelativeTime(
   date: Date | number,
   locale: string,
+  nowMs: number,
   style: 'long' | 'short' | 'narrow' = 'long',
 ): string {
   const ms = typeof date === 'number' ? date : date.getTime();
-  const diffSeconds = (ms - Date.now()) / 1000;
+  const diffSeconds = (ms - nowMs) / 1000;
   const rtf = new Intl.RelativeTimeFormat(locale || undefined, {
     numeric: 'auto',
     style,


### PR DESCRIPTION
## Problem

On demo.tale.dev (latest code, incl. #2510) the chat **"Thinking · Ns" timer visibly rewinds** (2s→1s), loses its number, then blanks before the "Thought for Ns" summary; and intermittently the **assistant reply renders above the just-sent user message** then snaps back ("错位"). Neither reproduces under `bun dev`.

Reproduced live with a 60 ms DOM recorder: the timer's implied zero-point jumped **+1.4 s forward** in 0.4 s at the rewind.

## Root cause — one class of bug

The UI mixes a **client** wall clock (`Date.now()`, optimistic `pendingMessage.timestamp`) with **server** epoch timestamps (`generationStartTime`, `_creationTime`). On localhost the latency/skew is ~0 so the mix is invisible; in prod it is ~1–2 s so it surfaces. #2510 fixed the *component handoff* reset but left the *anchor-value* client→server swap in place.

- **Timer:** `effectiveGenerationStartMs` returned the client send time until `generationStartTime` arrived, then **swapped to the server value** mid-turn; elapsed is `Date.now()` − anchor, so the swap shifted the zero-point by the send→markGenerating latency + skew → rewind.
- **错位:** the single global sort keyed on `_creationTime ?? timestamp.getTime()`, folding client-clock keys (the optimistic user's send time, and the agent SDK's **client-stamped** streaming-delta `_creationTime`) into the same numeric compare as server `_creationTime`.

## The fix (one PR, layered commits)

- **A — clock authority:** `serverNow` on `getThreadMeta` + a sticky `useClockOffset` provider that learns `offsetMs = serverNow − Date.now()` and converts between frames. The one sanctioned raw-`Date.now()` site.
- **B — ordering:** surface the SDK `stepOrder`; sort real rows by server `(order, stepOrder)`, pin optimistic/shell rows positionally — no clock in the compare. Ordering is identical across the streaming→finalize transition, so the snap is gone.
- **C — timer:** a `ThinkingAnchor` descriptor that **prefers the immutable client send time** (present for the whole turn, advances at a follow-up), so a live turn never swaps clocks; the server start (offset-converted) is the reload/history fallback; the start latches by a `reanchorKey` and ignores drift.
- **D — same-class sites:** `formatRelativeTime`/`useRelativeNow`/message-info dialog and the workflow-run elapsed now measure "now" via `serverEpochNow()`.
- **E — guard:** a source-walk test fails if any timer/sort/relative-time file calls `Date.now()` directly (the pinned oxlint ships no `no-restricted-syntax`/`-properties` rule, so a test-gate walk is the enforcement).

## Why it works in dev but not prod

The whole class only manifests under real client↔server latency + clock skew, which is ~0 on localhost. The fix keeps every live-duration and ordering computation in a **single clock frame**, so the discrepancy can't surface anywhere.

## Testing

- `use-clock-offset` (offset math, sticky threshold), `use-thinking-timer` (first-paint anchor precedence + a fake-timer monotonicity/no-rewind + follow-up re-anchor), `use-merged-chat-items` (skew/finalize/multi-turn ordering), and the source-walk guard — **all green**.
- Typecheck, lint (0/0), format: clean. 945 chat + automations + hooks UI tests pass. (The 4–6 flaky server suites are pre-existing convexTest concurrency flakiness — they pass in isolation and touch none of these files.)
- **On-demo verification runs post-deploy** (localhost can't reproduce): inject a client clock offset to force prod skew, then assert the "Thinking · Ns" seconds are monotonic non-decreasing and the user bubble precedes the assistant at every sample.