### PR TITLE
fix(platform): single-file OneDrive sync — dedup, stop, and prune on delete

### DIFF
--- a/docs/de/platform/knowledge/documents.md
+++ b/docs/de/platform/knowledge/documents.md
@@ -17,7 +17,7 @@ Das Dokument an einen Agent zu binden ist ein separater Schritt. Öffne den Agen
 
 Dokumente können statt von der Festplatte auch aus OneDrive oder SharePoint kommen. Öffne **Wissen > Dokumente > Dokumente hochladen > Von Microsoft 365**, wähle Dateien oder Ordner und entscheide dich für einen Import-Modus. **Einmaliger Import** holt die Dateien einmal; sie verhalten sich wie Uploads von der Festplatte. **Synchronisierungsimport** hält die Auswahl synchron: neue Dateien im OneDrive-Ordner erscheinen bei einem späteren Sync-Lauf, geänderte Dateien werden neu indexiert, und an der Quelle gelöschte Dateien verschwinden aus dem Workspace. Beide Modi erhalten die Ordnerstruktur deiner Auswahl. Die Synchronisierung deckt persönliche OneDrive-Ordner ab — eine SharePoint-Auswahl importiert immer einmalig.
 
-Um die Synchronisierung eines Ordners zu beenden, öffne das Menü der Ordner-Zeile und klicke auf **Synchronisierung beenden**; die importierten Dateien bleiben im Workspace und werden nicht mehr aktualisiert. Auch das Löschen eines synchronisierten Ordners beendet die Synchronisierung. In beiden Fällen bleiben die Dateien in OneDrive unberührt.
+Um die Synchronisierung zu beenden — bei einem ganzen synchronisierten Ordner oder einer einzelnen synchronisierten Datei — öffne das Menü der Zeile und klicke auf **Synchronisierung beenden**; die importierten Dokumente bleiben im Workspace und werden nicht mehr aktualisiert. Auch das Löschen eines synchronisierten Ordners oder einer einzelnen synchronisierten Datei beendet die Synchronisierung. In allen Fällen bleiben die Dateien in OneDrive unberührt.
 
 ## Was die Indexierungs-Pipeline tut
 

--- a/docs/en/platform/knowledge/documents.md
+++ b/docs/en/platform/knowledge/documents.md
@@ -17,7 +17,7 @@ Binding the document to an agent is a separate step. Open the agent and add the 
 
 Documents can come from OneDrive or SharePoint instead of disk. Open **Knowledge > Documents > Upload documents > From Microsoft 365**, pick files or folders, and choose the import mode. **One-time import** brings the files in once; they behave like uploads from disk. **Sync import** keeps the selection synchronized: new files in the OneDrive folder appear on a later sync pass, changed files re-index, and files deleted at the source leave the workspace. Both modes preserve the folder structure of your selection. Sync covers personal OneDrive folders — a SharePoint selection always imports once.
 
-To stop syncing a folder, open the folder row's menu and click **Stop syncing**; the imported files stay in the workspace and stop updating. Deleting a synced folder also stops the sync. In both cases the files in OneDrive are untouched.
+To stop syncing — a whole synced folder or a single synced file — open the row's menu and click **Stop syncing**; the imported documents stay in the workspace and stop updating. Deleting a synced folder, or a single synced file, also stops its sync. In every case the originals in OneDrive are untouched.
 
 ## What the indexing pipeline does
 

--- a/docs/fr/platform/knowledge/documents.md
+++ b/docs/fr/platform/knowledge/documents.md
@@ -17,7 +17,7 @@ Lier le document à un agent est une étape séparée. Ouvre l'agent et ajoute l
 
 Les documents peuvent venir de OneDrive ou SharePoint au lieu du disque. Ouvre **Connaissance > Documents > Téléverser des documents > Depuis Microsoft 365**, choisis des fichiers ou des dossiers, puis le mode d'importation. **Importation unique** apporte les fichiers une fois ; ils se comportent comme des téléversements depuis le disque. **Importation synchronisée** garde la sélection synchronisée : les nouveaux fichiers du dossier OneDrive apparaissent lors d'un passage de sync ultérieur, les fichiers modifiés sont réindexés, et les fichiers supprimés à la source quittent l'espace de travail. Les deux modes préservent la structure de dossiers de ta sélection. La synchronisation couvre les dossiers OneDrive personnels — une sélection SharePoint s'importe toujours une seule fois.
 
-Pour arrêter la synchronisation d'un dossier, ouvre le menu de la ligne du dossier et clique sur **Arrêter la synchronisation** ; les fichiers importés restent dans l'espace de travail et cessent d'être mis à jour. Supprimer un dossier synchronisé arrête aussi la synchronisation. Dans les deux cas, les fichiers dans OneDrive restent intacts.
+Pour arrêter la synchronisation — d'un dossier synchronisé entier ou d'un seul fichier synchronisé — ouvre le menu de la ligne et clique sur **Arrêter la synchronisation** ; les documents importés restent dans l'espace de travail et cessent d'être mis à jour. Supprimer un dossier synchronisé, ou un seul fichier synchronisé, arrête aussi sa synchronisation. Dans tous les cas, les fichiers dans OneDrive restent intacts.
 
 ## Ce que fait la pipeline d'indexation
 

--- a/services/platform/app/features/documents/components/document-row-actions.test.tsx
+++ b/services/platform/app/features/documents/components/document-row-actions.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
@@ -63,6 +65,66 @@ describe('DocumentRowActions', () => {
         />,
       );
       await checkAccessibility(container);
+    });
+  });
+
+  describe('stop sync visibility', () => {
+    const openMenu = async () => {
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole('button', { name: 'common.actions.openMenu' }),
+      );
+    };
+
+    it('offers stop-sync on a directly-selected single-file sync', async () => {
+      render(
+        <DocumentRowActions
+          documentId="doc-1"
+          itemType="file"
+          name="Document 1.docx"
+          sourceMode="auto"
+          syncConfigId="cfg-file"
+          isDirectlySelected
+        />,
+      );
+      await openMenu();
+      expect(
+        screen.getByText('documents.actions.stopSync'),
+      ).toBeInTheDocument();
+    });
+
+    it('hides stop-sync on a file synced as part of a folder', async () => {
+      // The file carries the folder config id; stopping it here would cancel
+      // the whole folder, so the file row must not offer it.
+      render(
+        <DocumentRowActions
+          documentId="doc-2"
+          itemType="file"
+          name="Document 1.docx"
+          sourceMode="auto"
+          syncConfigId="cfg-folder"
+          isDirectlySelected={false}
+        />,
+      );
+      await openMenu();
+      expect(
+        screen.queryByText('documents.actions.stopSync'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('still offers stop-sync on a synced folder', async () => {
+      render(
+        <DocumentRowActions
+          documentId="folder-1"
+          itemType="folder"
+          name="Meetings"
+          syncConfigId="cfg-folder"
+        />,
+      );
+      await openMenu();
+      expect(
+        screen.getByText('documents.actions.stopSync'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/services/platform/app/features/documents/components/document-row-actions.tsx
+++ b/services/platform/app/features/documents/components/document-row-actions.tsx
@@ -195,7 +195,14 @@ export function DocumentRowActions({
         label: tDocuments('actions.stopSync'),
         icon: CloudOff,
         onClick: handleStopSync,
-        visible: canWrite && itemType === 'folder' && !!syncConfigId,
+        // A synced folder, or a single file the user picked to sync directly.
+        // A file synced as *part of* a folder carries that folder's config id,
+        // so stopping it from the file row would cancel the whole folder —
+        // those are stopped from the folder row instead.
+        visible:
+          canWrite &&
+          !!syncConfigId &&
+          (itemType === 'folder' || !!isDirectlySelected),
         disabled: isCancellingSync,
       },
       {
@@ -226,6 +233,7 @@ export function DocumentRowActions({
       parentFolderTeamId,
       isHeld,
       syncConfigId,
+      isDirectlySelected,
     ],
   );
 

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -371,6 +371,7 @@ import type * as documents_extract_extension from "../documents/extract_extensio
 import type * as documents_find_document_by_external_id from "../documents/find_document_by_external_id.js";
 import type * as documents_find_document_by_file_id from "../documents/find_document_by_file_id.js";
 import type * as documents_find_document_by_title from "../documents/find_document_by_title.js";
+import type * as documents_find_documents_by_external_id from "../documents/find_documents_by_external_id.js";
 import type * as documents_generate_document from "../documents/generate_document.js";
 import type * as documents_generate_document_helpers from "../documents/generate_document_helpers.js";
 import type * as documents_generate_docx from "../documents/generate_docx.js";
@@ -1071,12 +1072,14 @@ import type * as onedrive_list_sharepoint_drives from "../onedrive/list_sharepoi
 import type * as onedrive_list_sharepoint_files from "../onedrive/list_sharepoint_files.js";
 import type * as onedrive_list_sharepoint_sites from "../onedrive/list_sharepoint_sites.js";
 import type * as onedrive_mutations from "../onedrive/mutations.js";
+import type * as onedrive_prune_synced_documents from "../onedrive/prune_synced_documents.js";
 import type * as onedrive_read_file from "../onedrive/read_file.js";
 import type * as onedrive_reconcile_folder_sync from "../onedrive/reconcile_folder_sync.js";
 import type * as onedrive_refresh_credentials from "../onedrive/refresh_credentials.js";
 import type * as onedrive_refresh_token from "../onedrive/refresh_token.js";
 import type * as onedrive_run_config_sync from "../onedrive/run_config_sync.js";
 import type * as onedrive_run_folder_reconcile from "../onedrive/run_folder_reconcile.js";
+import type * as onedrive_run_single_file_reconcile from "../onedrive/run_single_file_reconcile.js";
 import type * as onedrive_stream_to_storage from "../onedrive/stream_to_storage.js";
 import type * as onedrive_types from "../onedrive/types.js";
 import type * as onedrive_update_sync_config from "../onedrive/update_sync_config.js";
@@ -2040,6 +2043,7 @@ declare const fullApi: ApiFromModules<{
   "documents/find_document_by_external_id": typeof documents_find_document_by_external_id;
   "documents/find_document_by_file_id": typeof documents_find_document_by_file_id;
   "documents/find_document_by_title": typeof documents_find_document_by_title;
+  "documents/find_documents_by_external_id": typeof documents_find_documents_by_external_id;
   "documents/generate_document": typeof documents_generate_document;
   "documents/generate_document_helpers": typeof documents_generate_document_helpers;
   "documents/generate_docx": typeof documents_generate_docx;
@@ -2740,12 +2744,14 @@ declare const fullApi: ApiFromModules<{
   "onedrive/list_sharepoint_files": typeof onedrive_list_sharepoint_files;
   "onedrive/list_sharepoint_sites": typeof onedrive_list_sharepoint_sites;
   "onedrive/mutations": typeof onedrive_mutations;
+  "onedrive/prune_synced_documents": typeof onedrive_prune_synced_documents;
   "onedrive/read_file": typeof onedrive_read_file;
   "onedrive/reconcile_folder_sync": typeof onedrive_reconcile_folder_sync;
   "onedrive/refresh_credentials": typeof onedrive_refresh_credentials;
   "onedrive/refresh_token": typeof onedrive_refresh_token;
   "onedrive/run_config_sync": typeof onedrive_run_config_sync;
   "onedrive/run_folder_reconcile": typeof onedrive_run_folder_reconcile;
+  "onedrive/run_single_file_reconcile": typeof onedrive_run_single_file_reconcile;
   "onedrive/stream_to_storage": typeof onedrive_stream_to_storage;
   "onedrive/types": typeof onedrive_types;
   "onedrive/update_sync_config": typeof onedrive_update_sync_config;

--- a/services/platform/convex/documents/find_documents_by_external_id.ts
+++ b/services/platform/convex/documents/find_documents_by_external_id.ts
@@ -1,0 +1,30 @@
+/**
+ * All documents in an org that carry a given external item id.
+ *
+ * The singular {@link findDocumentByExternalId} returns only the first match —
+ * enough for the id-keyed upsert, which expects at most one row per external
+ * id. This plural variant collects every row sharing the id so the single-file
+ * sync reconcile can find and collapse the duplicate rows a prior no-dedup sync
+ * run created for the same source file. Indexed by
+ * `by_organizationId_and_externalItemId`.
+ *
+ * Like the singular lookup, this intentionally does NOT filter on
+ * lifecycleStatus — it backs sync-key reconcile, not a user read surface.
+ */
+
+import type { Doc } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+
+export async function findDocumentsByExternalId(
+  ctx: QueryCtx,
+  args: { organizationId: string; externalItemId: string },
+): Promise<Doc<'documents'>[]> {
+  return ctx.db
+    .query('documents')
+    .withIndex('by_organizationId_and_externalItemId', (q) =>
+      q
+        .eq('organizationId', args.organizationId)
+        .eq('externalItemId', args.externalItemId),
+    )
+    .collect();
+}

--- a/services/platform/convex/documents/helpers.ts
+++ b/services/platform/convex/documents/helpers.ts
@@ -37,5 +37,6 @@ export * from './read_file_base64_from_storage';
 export * from './extract_extension';
 export * from './find_document_by_title';
 export * from './find_document_by_external_id';
+export * from './find_documents_by_external_id';
 export * from './find_document_by_file_id';
 export * from './update_document_internal';

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -68,6 +68,20 @@ export const findDocumentByExternalId = internalQuery({
   },
 });
 
+/**
+ * Every document sharing one external item id — used by the single-file sync
+ * reconcile to collapse duplicate rows down to the one canonical doc.
+ */
+export const findDocumentsByExternalId = internalQuery({
+  args: {
+    organizationId: v.string(),
+    externalItemId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await DocumentsHelpers.findDocumentsByExternalId(ctx, args);
+  },
+});
+
 export const findDocumentByFileId = internalQuery({
   args: {
     organizationId: v.string(),

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -17,6 +17,7 @@ import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { hasTeamAccess } from '../lib/team_access';
+import { stopSyncForDeletedDocument } from '../onedrive/deactivate_sync_configs';
 import { createDocument } from './create_document';
 import { extractExtension } from './extract_extension';
 import { updateDocument as updateDocumentHelper } from './update_document';
@@ -98,6 +99,12 @@ export const deleteDocument = mutation({
       undefined,
       document.createdBy ?? undefined,
     );
+
+    // A directly-selected single-file OneDrive sync maps 1:1 to this document,
+    // so deleting it means "stop syncing it" — otherwise the next scheduled
+    // run re-imports the file the user just removed. No-op for manual uploads
+    // and folder-member docs.
+    await stopSyncForDeletedDocument(ctx, document);
 
     // Knowledge entries are backed by hub documents — deleting the backing
     // document from the Documents tab must not orphan the entry, so mark

--- a/services/platform/convex/onedrive/deactivate_sync_configs.test.ts
+++ b/services/platform/convex/onedrive/deactivate_sync_configs.test.ts
@@ -5,8 +5,13 @@
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
+import type { Id } from '../_generated/dataModel';
 import schema from '../schema';
-import { deactivateSyncConfigsForPath } from './deactivate_sync_configs';
+import {
+  deactivateSyncConfigById,
+  deactivateSyncConfigsForPath,
+  stopSyncForDeletedDocument,
+} from './deactivate_sync_configs';
 
 // convex-test module map keyed relative to the convex/ root (this file is at
 // convex/onedrive/, mirror sandbox/admission.test.ts).
@@ -82,6 +87,104 @@ describe('deactivateSyncConfigsForPath', () => {
     expect(deactivated).toBe(0);
     await t.run(async (ctx) => {
       expect((await ctx.db.get(otherOrgId))?.status).toBe('active');
+    });
+  });
+});
+
+describe('deactivateSyncConfigById', () => {
+  it('flips an active config to inactive', async () => {
+    const t = convexTest(schema, modules);
+    const id = await seedConfig(t, 'Document 1.docx');
+
+    const flipped = await t.run((ctx) =>
+      deactivateSyncConfigById(ctx, ORG, id),
+    );
+
+    expect(flipped).toBe(true);
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(id))?.status).toBe('inactive');
+    });
+  });
+
+  it('is a no-op for another org, an already-inactive, or a missing config', async () => {
+    const t = convexTest(schema, modules);
+    const otherOrg = await seedConfig(t, 'X', 'active', 'org_other');
+    const already = await seedConfig(t, 'Y', 'inactive');
+
+    await t.run(async (ctx) => {
+      expect(await deactivateSyncConfigById(ctx, ORG, otherOrg)).toBe(false);
+      expect(await deactivateSyncConfigById(ctx, ORG, already)).toBe(false);
+      expect(
+        await deactivateSyncConfigById(
+          ctx,
+          ORG,
+          'nonexistent' as Id<'onedriveSyncConfigs'>,
+        ),
+      ).toBe(false);
+      expect((await ctx.db.get(otherOrg))?.status).toBe('active');
+    });
+  });
+});
+
+describe('stopSyncForDeletedDocument', () => {
+  it('stops the sync for a directly-selected single-file doc', async () => {
+    const t = convexTest(schema, modules);
+    const configId = await seedConfig(t, 'Document 1.docx');
+
+    const stopped = await t.run((ctx) =>
+      stopSyncForDeletedDocument(ctx, {
+        organizationId: ORG,
+        metadata: {
+          sourceMode: 'auto',
+          isDirectlySelected: true,
+          syncConfigId: configId,
+        },
+      }),
+    );
+
+    expect(stopped).toBe(true);
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(configId))?.status).toBe('inactive');
+    });
+  });
+
+  it('leaves a folder-member doc alone (would stop the whole folder)', async () => {
+    const t = convexTest(schema, modules);
+    const configId = await seedConfig(t, 'Meetings');
+
+    const stopped = await t.run((ctx) =>
+      stopSyncForDeletedDocument(ctx, {
+        organizationId: ORG,
+        metadata: {
+          sourceMode: 'auto',
+          isDirectlySelected: false,
+          syncConfigId: configId,
+        },
+      }),
+    );
+
+    expect(stopped).toBe(false);
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(configId))?.status).toBe('active');
+    });
+  });
+
+  it('ignores manual uploads and docs with no sync config', async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      expect(
+        await stopSyncForDeletedDocument(ctx, {
+          organizationId: ORG,
+          metadata: { sourceMode: 'manual', isDirectlySelected: true },
+        }),
+      ).toBe(false);
+      expect(
+        await stopSyncForDeletedDocument(ctx, {
+          organizationId: ORG,
+          metadata: {},
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/services/platform/convex/onedrive/deactivate_sync_configs.ts
+++ b/services/platform/convex/onedrive/deactivate_sync_configs.ts
@@ -2,7 +2,10 @@
  * Deactivate Sync Configs - Stop syncing when the target folder is deleted.
  */
 
+import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
+import type { DocumentMetadata } from '../documents/types';
+import { toId } from '../lib/type_cast_helpers';
 
 /**
  * Deactivate every active sync config whose synced tree lives at or below
@@ -30,4 +33,55 @@ export async function deactivateSyncConfigsForPath(
   }
 
   return deactivated;
+}
+
+/**
+ * Deactivate one sync config by id (org-scoped). No-op when the config is
+ * missing, belongs to another org, or is already inactive. Returns whether a
+ * row was flipped.
+ */
+export async function deactivateSyncConfigById(
+  ctx: MutationCtx,
+  organizationId: string,
+  configId: Id<'onedriveSyncConfigs'>,
+): Promise<boolean> {
+  const config = await ctx.db.get(configId);
+  if (
+    !config ||
+    config.organizationId !== organizationId ||
+    config.status === 'inactive'
+  ) {
+    return false;
+  }
+  await ctx.db.patch(configId, { status: 'inactive' });
+  return true;
+}
+
+/**
+ * Deleting a directly-selected single-file synced document means "stop syncing
+ * it" — otherwise the next scheduled run re-imports the file the user just
+ * removed (whack-a-mole). Only a directly-selected single-file config maps 1:1
+ * to a document; a folder-member doc carries the *folder's* config id, so it is
+ * left alone (the folder-delete path owns folder-config deactivation, and a
+ * folder keeps syncing its other members). No-op for manual uploads too.
+ * Returns whether a config was deactivated.
+ */
+export async function stopSyncForDeletedDocument(
+  ctx: MutationCtx,
+  document: { organizationId: string; metadata?: unknown },
+): Promise<boolean> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- metadata stored via v.any(); shape is DocumentMetadata written by our sync code
+  const meta = (document.metadata ?? {}) as DocumentMetadata;
+  if (
+    meta.sourceMode !== 'auto' ||
+    meta.isDirectlySelected !== true ||
+    !meta.syncConfigId
+  ) {
+    return false;
+  }
+  return deactivateSyncConfigById(
+    ctx,
+    document.organizationId,
+    toId<'onedriveSyncConfigs'>(meta.syncConfigId),
+  );
 }

--- a/services/platform/convex/onedrive/get_file_metadata.ts
+++ b/services/platform/convex/onedrive/get_file_metadata.ts
@@ -8,6 +8,9 @@ export interface FileMetadataResult {
     size?: number;
   };
   error?: string;
+  /** Graph returned 404 — the item no longer exists at the source (deleted or
+   *  trashed), as opposed to a transient / permission / throttle failure. */
+  notFound?: boolean;
 }
 
 export async function getFileMetadata(
@@ -36,6 +39,7 @@ export async function getFileMetadata(
       return {
         success: false,
         error: `Failed to get file metadata: ${response.status} ${errorText}`,
+        notFound: response.status === 404,
       };
     }
 

--- a/services/platform/convex/onedrive/import_files.test.ts
+++ b/services/platform/convex/onedrive/import_files.test.ts
@@ -181,6 +181,44 @@ describe('importFiles sync configs', () => {
     );
   });
 
+  it('fills the size from the Graph item metadata when the listing omits it', async () => {
+    // A recursive listing can omit `size` for a freshly copied/uploaded item,
+    // and the download may arrive without a Content-Length. The Graph
+    // item-metadata size then fills both the stored file size and the row's
+    // metadata.size so the hub never renders it as "—".
+    const deps = makeDeps({
+      getFileMetadata: vi.fn().mockResolvedValue({
+        success: true,
+        data: { hash: undefined, size: 2048 },
+      }),
+      downloadToStorage: vi.fn().mockResolvedValue({
+        success: true,
+        storageId: 'storage-1' as Id<'_storage'>,
+        mimeType: 'text/plain',
+        // no `size`: source omitted Content-Length
+      }),
+    });
+
+    const itemNoSize: ImportItem = {
+      ...folderItems[0],
+      size: undefined as unknown as number,
+    };
+    await importFiles(
+      { ...baseArgs, items: [itemNoSize], importType: 'sync' },
+      deps,
+    );
+
+    const metadata = vi.mocked(deps.createDocument).mock.calls[0][0].metadata;
+    expect(metadata.size).toBe(2048);
+    expect(deps.saveFileMetadata).toHaveBeenCalledWith(
+      'storage-1',
+      'a.docx',
+      'text/plain',
+      2048,
+      'doc-1',
+    );
+  });
+
   it('fails the item when the streamed download+store fails', async () => {
     const deps = makeDeps({
       downloadToStorage: vi

--- a/services/platform/convex/onedrive/import_files.ts
+++ b/services/platform/convex/onedrive/import_files.ts
@@ -223,9 +223,12 @@ export async function importFiles(
         item.name,
         stored.mimeType || 'application/octet-stream',
       );
-      // Prefer the transferred byte count; fall back to the listing size when
-      // the source omitted Content-Length.
-      const fileSize = stored.size ?? item.size;
+      // Size, most-reliable first: the transferred byte count, then the Graph
+      // item-metadata size (always present for a file), then the listing size.
+      // A recursive listing can omit `size` for a freshly copied/uploaded item
+      // (list_folder_contents forwards it verbatim); without this fallback the
+      // row's metadata.size stays undefined and the hub renders it as "—".
+      const fileSize = stored.size ?? metadataResult.data.size ?? item.size;
 
       const storagePath = item.relativePath
         ? `${args.organizationId}/${item.relativePath}`
@@ -240,7 +243,7 @@ export async function importFiles(
         itemPath: item.relativePath || '',
         sourceMode: args.importType === 'sync' ? 'auto' : 'manual',
         storagePath,
-        size: item.size,
+        size: fileSize,
         ...(syncConfigId && { syncConfigId }),
         ...(item.selectedParentId && {
           selectedParentId: item.selectedParentId,

--- a/services/platform/convex/onedrive/list_folder_contents.ts
+++ b/services/platform/convex/onedrive/list_folder_contents.ts
@@ -98,7 +98,9 @@ function toFileItem(
   return {
     id: item.id,
     name: item.name,
-    size: item.size,
+    // Graph can omit `size` for a freshly copied/uploaded item; floor it to a
+    // real number like the picker (`list_files`) and SharePoint listers do.
+    size: item.size || 0,
     mimeType: item.file?.mimeType,
     lastModified: lastModifiedStr ? Date.parse(lastModifiedStr) : undefined,
     ...(pathPrefix !== undefined && {

--- a/services/platform/convex/onedrive/prune_synced_documents.ts
+++ b/services/platform/convex/onedrive/prune_synced_documents.ts
@@ -1,0 +1,54 @@
+/**
+ * Schedule deletes for a set of synced documents, the way the drive-reconcile
+ * path does: a blob-bearing doc goes through the RAG-purging delete (so its
+ * vector index is dropped too), a metadata-only doc deletes directly. Deletes
+ * are staggered 100ms apart to spare the scheduler + RAG service, and each
+ * carries a snapshot guard (expectedExternalItemId/expectedFileId) so it aborts
+ * if an interleaving re-upload re-bound the row.
+ *
+ * Shared by the folder reconcile (files that left the folder) and the
+ * single-file reconcile (duplicate rows collapsed to one) so there is one
+ * prune path, not a divergent second copy.
+ */
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import type { ActionCtx } from '../_generated/server';
+import { toId } from '../lib/type_cast_helpers';
+import type { SyncedDocumentRef } from './reconcile_folder_sync';
+
+export async function scheduleSyncedDocumentDeletes(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    refs: SyncedDocumentRef[];
+    /** Reap now-empty ancestor folders up to (but not including) this id. */
+    cleanupAncestorsUpTo?: Id<'folders'>;
+  },
+): Promise<void> {
+  for (let i = 0; i < args.refs.length; i++) {
+    const ref = args.refs[i];
+    if (ref.fileId) {
+      await ctx.scheduler.runAfter(
+        i * 100,
+        internal.documents.internal_actions.deleteDocumentFromRag,
+        {
+          documentId: toId<'documents'>(ref.documentId),
+          expectedExternalItemId: ref.externalItemId,
+          expectedFileId: toId<'_storage'>(ref.fileId),
+          cleanupAncestorsUpTo: args.cleanupAncestorsUpTo,
+        },
+      );
+    } else {
+      await ctx.scheduler.runAfter(
+        i * 100,
+        internal.documents.internal_mutations.deleteDocumentById,
+        {
+          documentId: toId<'documents'>(ref.documentId),
+          callerOrgId: args.organizationId,
+          cleanupAncestorsUpTo: args.cleanupAncestorsUpTo,
+        },
+      );
+    }
+  }
+}

--- a/services/platform/convex/onedrive/run_config_sync.ts
+++ b/services/platform/convex/onedrive/run_config_sync.ts
@@ -9,8 +9,8 @@
 
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
-import { toConvexJsonRecord } from '../lib/type_cast_helpers';
 import { reconcileFolder } from './run_folder_reconcile';
+import { reconcileSingleFile } from './run_single_file_reconcile';
 
 export interface SyncConfigItem {
   configId: string;
@@ -27,6 +27,9 @@ export interface SyncOneResult {
   skipped: number;
   deleted: number;
   errorsCount: number;
+  /** Single-file sync only: the source file was deleted at the origin (404),
+   *  so its mirror was removed and the config should be deactivated. */
+  sourceDeleted?: boolean;
 }
 
 /** Resolve a usable Graph token for a user, refreshing once if expired. */
@@ -91,33 +94,24 @@ export async function syncOneConfig(
     };
   }
 
-  // Single-file config: download and upsert one document.
-  const file = await ctx.runAction(
-    internal.onedrive.internal_actions.readFileFromOneDrive,
-    { itemId: config.itemId, token },
-  );
-  if (!file.success || !file.content) {
-    throw new Error(file.error ?? 'Failed to read file from OneDrive');
-  }
-  const uploaded = await ctx.runAction(
-    internal.onedrive.internal_actions.uploadToStorage,
-    {
-      organizationId,
-      fileName: config.itemName,
-      fileData: file.content,
-      contentType: file.mimeType ?? 'application/octet-stream',
-      metadata: toConvexJsonRecord({
-        oneDriveItemId: config.itemId,
-        itemPath: config.itemPath ?? '',
-        syncConfigId: config.configId,
-        sourceMode: 'auto',
-        syncedAt: new Date().toISOString(),
-      }),
-      createdBy: config.userId,
-    },
-  );
-  if (!uploaded.success) {
-    throw new Error(uploaded.error ?? 'Failed to upload file to storage');
-  }
-  return { created: 1, skipped: 0, deleted: 0, errorsCount: 0 };
+  // Single-file config: reconcile the one tracked file through the shared
+  // import pipeline (dedup by external id → update the existing doc in place)
+  // and collapse any duplicate rows a prior no-dedup version created for it.
+  const result = await reconcileSingleFile(ctx, {
+    organizationId,
+    configId: config.configId,
+    itemId: config.itemId,
+    itemName: config.itemName,
+    itemPath: config.itemPath,
+    userId: config.userId,
+    teamId: config.teamId,
+    token,
+  });
+  return {
+    created: result.created,
+    skipped: result.skipped,
+    deleted: result.deleted,
+    errorsCount: result.errorsCount,
+    sourceDeleted: result.sourceDeleted,
+  };
 }

--- a/services/platform/convex/onedrive/run_folder_reconcile.ts
+++ b/services/platform/convex/onedrive/run_folder_reconcile.ts
@@ -11,10 +11,10 @@ import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { ActionCtx } from '../_generated/server';
 import type { DocumentRecord, DocumentMetadata } from '../documents/types';
-import { toId } from '../lib/type_cast_helpers';
 import { importFiles } from './import_files';
 import { createImportFilesDeps } from './import_files_deps';
 import type { FileItem } from './list_folder_contents';
+import { scheduleSyncedDocumentDeletes } from './prune_synced_documents';
 import {
   buildSyncImportItems,
   selectDocumentsToPrune,
@@ -122,39 +122,17 @@ export async function reconcileFolder(
         )) ?? undefined)
       : undefined;
 
-  // Delete each orphan through the RAG-purging path so its vector index is
-  // dropped too — deleteDocumentById alone removes only the row + blob and
-  // would leave the OneDrive doc searchable in RAG. Mirrors the drive-reconcile
-  // path in document_action.ts: blob-bearing docs go via deleteDocumentFromRag
-  // (staggered 100ms to spare the scheduler + RAG service); metadata-only docs
-  // delete directly. The snapshot (expectedExternalItemId/expectedFileId) makes
-  // the delete abort if an interleaving re-upload re-bound the row.
-  for (let i = 0; i < toPrune.length; i++) {
-    const documentId = toPrune[i];
-    const ref = refById.get(documentId);
-    if (ref?.fileId) {
-      await ctx.scheduler.runAfter(
-        i * 100,
-        internal.documents.internal_actions.deleteDocumentFromRag,
-        {
-          documentId: toId<'documents'>(documentId),
-          expectedExternalItemId: ref.externalItemId,
-          expectedFileId: toId<'_storage'>(ref.fileId),
-          cleanupAncestorsUpTo,
-        },
-      );
-    } else {
-      await ctx.scheduler.runAfter(
-        i * 100,
-        internal.documents.internal_mutations.deleteDocumentById,
-        {
-          documentId: toId<'documents'>(documentId),
-          callerOrgId: args.organizationId,
-          cleanupAncestorsUpTo,
-        },
-      );
-    }
-  }
+  // Delete each orphan through the shared prune path (RAG-purging for
+  // blob-bearing docs, direct for metadata-only), which reaps the emptied
+  // ancestor folders up to the sync root.
+  const refsToPrune = toPrune
+    .map((documentId) => refById.get(documentId))
+    .filter((ref): ref is SyncedDocumentRef => ref !== undefined);
+  await scheduleSyncedDocumentDeletes(ctx, {
+    organizationId: args.organizationId,
+    refs: refsToPrune,
+    cleanupAncestorsUpTo,
+  });
 
   const errorsCount = importResult.results.filter(
     (r) => r.status === 'error',

--- a/services/platform/convex/onedrive/run_single_file_reconcile.test.ts
+++ b/services/platform/convex/onedrive/run_single_file_reconcile.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// String refs so the hand-built ctx can dispatch runQuery/scheduler by name.
+vi.mock('../_generated/api', () => ({
+  internal: {
+    documents: {
+      internal_queries: {
+        findDocumentsByExternalId: 'findDocumentsByExternalId',
+      },
+      internal_mutations: { deleteDocumentById: 'deleteDocumentById' },
+      internal_actions: { deleteDocumentFromRag: 'deleteDocumentFromRag' },
+    },
+  },
+}));
+
+// The import pipeline is exercised by import_files.test.ts; here we only care
+// about the dedup-and-heal wiring around it, so drive it from the test.
+const importFilesMock = vi.fn();
+vi.mock('./import_files', () => ({
+  importFiles: (...callArgs: unknown[]) => importFilesMock(...callArgs),
+}));
+vi.mock('./import_files_deps', () => ({
+  createImportFilesDeps: vi.fn(() => ({})),
+}));
+
+// getFileMetadata is only consulted on the import-error path to tell a deleted
+// source (404) from a transient failure.
+const getFileMetadataMock = vi.fn();
+vi.mock('./get_file_metadata', () => ({
+  getFileMetadata: (...callArgs: unknown[]) => getFileMetadataMock(...callArgs),
+}));
+
+import type { ActionCtx } from '../_generated/server';
+import { reconcileSingleFile } from './run_single_file_reconcile';
+
+interface DocRow {
+  _id: string;
+  externalItemId?: string;
+  fileId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ScheduledCall {
+  delayMs: number;
+  ref: string;
+  args: Record<string, unknown>;
+}
+
+function createCtx(sameExternalId: DocRow[]) {
+  const scheduled: ScheduledCall[] = [];
+
+  const runQuery = vi.fn((ref: string) => {
+    if (ref === 'findDocumentsByExternalId') {
+      return Promise.resolve(sameExternalId);
+    }
+    throw new Error(`unexpected runQuery ref: ${ref}`);
+  });
+
+  const runAfter = vi.fn(
+    (delayMs: number, ref: string, args: Record<string, unknown>) => {
+      scheduled.push({ delayMs, ref, args });
+      return Promise.resolve();
+    },
+  );
+
+  return {
+    ctx: {
+      runQuery,
+      scheduler: { runAfter },
+    } as unknown as ActionCtx,
+    scheduled,
+    runQuery,
+  };
+}
+
+const baseArgs = {
+  organizationId: 'org-1',
+  configId: 'cfg-1',
+  itemId: 'item-1',
+  itemName: 'Document 1.docx',
+  itemPath: 'Document 1.docx',
+  userId: 'user-1',
+  token: 'tok',
+};
+
+describe('reconcileSingleFile', () => {
+  it('imports one item through the shared pipeline keyed on the file', async () => {
+    importFilesMock.mockResolvedValue({
+      results: [{ status: 'success', documentId: 'canonical' }],
+      successCount: 1,
+      skippedCount: 0,
+    });
+    const { ctx } = createCtx([{ _id: 'canonical', externalItemId: 'item-1' }]);
+
+    await reconcileSingleFile(ctx, baseArgs);
+
+    const [importArgs] = importFilesMock.mock.calls[0];
+    expect(importArgs.importType).toBe('sync');
+    expect(importArgs.items).toEqual([
+      {
+        id: 'item-1',
+        name: 'Document 1.docx',
+        size: 0,
+        relativePath: 'Document 1.docx',
+        isDirectlySelected: true,
+      },
+    ]);
+  });
+
+  it('collapses duplicate rows a prior no-dedup run created, keeping the canonical', async () => {
+    importFilesMock.mockResolvedValue({
+      results: [{ status: 'success', documentId: 'canonical' }],
+      successCount: 1,
+      skippedCount: 0,
+    });
+    // The 9.7 KB original (canonical, just upserted) plus two size-less strays
+    // a prior run inserted for the same file — one with a blob, one without.
+    const { ctx, scheduled } = createCtx([
+      {
+        _id: 'canonical',
+        externalItemId: 'item-1',
+        fileId: 'storage-canon',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+      {
+        _id: 'stray-blob',
+        externalItemId: 'item-1',
+        fileId: 'storage-stray',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+      {
+        _id: 'stray-meta',
+        externalItemId: 'item-1',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+    ]);
+
+    const result = await reconcileSingleFile(ctx, baseArgs);
+
+    expect(result.deleted).toBe(2);
+    expect(result.created).toBe(1);
+    // Blob-bearing stray → RAG-purging delete with the snapshot guard;
+    // metadata-only stray → direct delete. The canonical is never scheduled.
+    expect(scheduled).toEqual([
+      {
+        delayMs: 0,
+        ref: 'deleteDocumentFromRag',
+        args: {
+          documentId: 'stray-blob',
+          expectedExternalItemId: 'item-1',
+          expectedFileId: 'storage-stray',
+          cleanupAncestorsUpTo: undefined,
+        },
+      },
+      {
+        delayMs: 100,
+        ref: 'deleteDocumentById',
+        args: {
+          documentId: 'stray-meta',
+          callerOrgId: 'org-1',
+          cleanupAncestorsUpTo: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('never reaps manual uploads or another config’s rows sharing the id', async () => {
+    importFilesMock.mockResolvedValue({
+      results: [{ status: 'success', documentId: 'canonical' }],
+      successCount: 1,
+      skippedCount: 0,
+    });
+    const { ctx, scheduled } = createCtx([
+      {
+        _id: 'canonical',
+        externalItemId: 'item-1',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+      // A manual upload that happens to share the external id — never a stray.
+      {
+        _id: 'manual',
+        externalItemId: 'item-1',
+        fileId: 'storage-manual',
+        metadata: { sourceMode: 'manual' },
+      },
+      // A row owned by a different sync config — not ours to prune.
+      {
+        _id: 'other-config',
+        externalItemId: 'item-1',
+        fileId: 'storage-other',
+        metadata: { syncConfigId: 'cfg-2', sourceMode: 'auto' },
+      },
+    ]);
+
+    const result = await reconcileSingleFile(ctx, baseArgs);
+
+    expect(result.deleted).toBe(0);
+    expect(scheduled).toEqual([]);
+  });
+
+  it('throws and prunes nothing on a transient import failure (not a 404)', async () => {
+    importFilesMock.mockResolvedValue({
+      results: [{ status: 'error', error: 'throttled' }],
+      successCount: 0,
+      skippedCount: 0,
+    });
+    // A non-404 failure (permission / throttle / network) must keep the doc.
+    getFileMetadataMock.mockResolvedValue({ success: false, notFound: false });
+    const { ctx, scheduled, runQuery } = createCtx([
+      {
+        _id: 'stray',
+        externalItemId: 'item-1',
+        fileId: 'storage-1',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+    ]);
+
+    await expect(reconcileSingleFile(ctx, baseArgs)).rejects.toThrow(
+      'throttled',
+    );
+    // No canonical row established and the source is not gone → never prune.
+    expect(scheduled).toEqual([]);
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('removes the mirror and reports sourceDeleted when the source is 404 gone', async () => {
+    importFilesMock.mockResolvedValue({
+      results: [{ status: 'error', error: 'Failed to get file metadata: 404' }],
+      successCount: 0,
+      skippedCount: 0,
+    });
+    getFileMetadataMock.mockResolvedValue({ success: false, notFound: true });
+    // Both owned rows are removed — there is no canonical to keep when the
+    // source file is gone.
+    const { ctx, scheduled } = createCtx([
+      {
+        _id: 'doc-a',
+        externalItemId: 'item-1',
+        fileId: 'storage-a',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+      {
+        _id: 'doc-b',
+        externalItemId: 'item-1',
+        metadata: { syncConfigId: 'cfg-1', sourceMode: 'auto' },
+      },
+    ]);
+
+    const result = await reconcileSingleFile(ctx, baseArgs);
+
+    expect(result.sourceDeleted).toBe(true);
+    expect(result.deleted).toBe(2);
+    expect(scheduled.map((s) => s.ref)).toEqual([
+      'deleteDocumentFromRag',
+      'deleteDocumentById',
+    ]);
+  });
+});

--- a/services/platform/convex/onedrive/run_single_file_reconcile.ts
+++ b/services/platform/convex/onedrive/run_single_file_reconcile.ts
@@ -1,0 +1,146 @@
+/**
+ * Reconcile one synced OneDrive file: run the shared import pipeline for the
+ * single item (dedup by external id → update the one existing doc in place),
+ * collapse any duplicate rows a prior no-dedup sync run created for it, and —
+ * when the source file is gone at the origin — remove the mirror.
+ *
+ * Before this, the single-file config path re-uploaded the file and inserted a
+ * brand-new document on every scheduled run (no external-id lookup), so a
+ * single synced file accumulated one stray, size-less ("—") duplicate per run,
+ * and a deletion at the source was never reflected (the doc lingered while the
+ * config silently errored). Routing it through `importFiles` gives it the same
+ * dedup / content-hash-skip / streaming-download / size handling the folder
+ * path has; the heal step reaps strays; and a definitive 404 prunes the mirror
+ * the way the folder reconcile prunes a file that left the folder.
+ */
+
+import { internal } from '../_generated/api';
+import type { ActionCtx } from '../_generated/server';
+import type { DocumentMetadata } from '../documents/types';
+import { getFileMetadata } from './get_file_metadata';
+import { importFiles, type ImportItem } from './import_files';
+import { createImportFilesDeps } from './import_files_deps';
+import { scheduleSyncedDocumentDeletes } from './prune_synced_documents';
+import type { SyncedDocumentRef } from './reconcile_folder_sync';
+
+export interface ReconcileSingleFileResult {
+  created: number;
+  skipped: number;
+  deleted: number;
+  errorsCount: number;
+  /** The source file no longer exists (404): the mirror was removed and the
+   *  caller should deactivate the config so it stops retrying. */
+  sourceDeleted?: boolean;
+}
+
+interface SingleFileArgs {
+  organizationId: string;
+  configId: string;
+  itemId: string;
+  itemName: string;
+  itemPath?: string;
+  userId: string;
+  teamId?: string;
+  token: string;
+}
+
+/**
+ * Every auto-synced document this config owns for its file. All point at the
+ * same source item, so on a normal run all but the canonical are strays, and
+ * on a source deletion all are removed. Manual uploads and other configs'
+ * rows (matched only by external id) are excluded.
+ */
+async function collectOwnedRefs(
+  ctx: ActionCtx,
+  args: SingleFileArgs,
+): Promise<SyncedDocumentRef[]> {
+  const rows = await ctx.runQuery(
+    internal.documents.internal_queries.findDocumentsByExternalId,
+    { organizationId: args.organizationId, externalItemId: args.itemId },
+  );
+  return rows
+    .filter((doc) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- metadata stored via v.any(); shape is DocumentMetadata written by our sync code
+      const meta = (doc.metadata ?? {}) as DocumentMetadata;
+      return meta.syncConfigId === args.configId && meta.sourceMode === 'auto';
+    })
+    .map((doc) => ({
+      documentId: doc._id,
+      externalItemId: doc.externalItemId,
+      fileId: doc.fileId,
+    }));
+}
+
+export async function reconcileSingleFile(
+  ctx: ActionCtx,
+  args: SingleFileArgs,
+): Promise<ReconcileSingleFileResult> {
+  // One import item for the single tracked file. `importFiles` fetches the
+  // Graph metadata itself and resolves the real size, so 0 here is just a
+  // placeholder the resolution overrides.
+  const item: ImportItem = {
+    id: args.itemId,
+    name: args.itemName,
+    size: 0,
+    relativePath: args.itemPath ?? args.itemName,
+    isDirectlySelected: true,
+  };
+
+  const importResult = await importFiles(
+    {
+      items: [item],
+      organizationId: args.organizationId,
+      importType: 'sync',
+      teamId: args.teamId,
+      token: args.token,
+      userId: args.userId,
+    },
+    createImportFilesDeps(ctx, args.organizationId),
+  );
+
+  const primary = importResult.results[0];
+  const canonicalId = primary?.documentId;
+
+  if (!canonicalId) {
+    // Import failed. Only a definitive 404 (source deleted/trashed) removes the
+    // mirror — a transient / permission / throttle failure keeps the doc and
+    // errors the config. Re-read metadata on this rare error path to tell them
+    // apart (a move keeps the item id, so this 404 means truly gone).
+    const meta = await getFileMetadata(args.itemId, args.token);
+    if (!meta.success && meta.notFound) {
+      const owned = await collectOwnedRefs(ctx, args);
+      await scheduleSyncedDocumentDeletes(ctx, {
+        organizationId: args.organizationId,
+        refs: owned,
+      });
+      return {
+        created: 0,
+        skipped: 0,
+        deleted: owned.length,
+        errorsCount: 0,
+        sourceDeleted: true,
+      };
+    }
+    // Throw so the caller marks the config `error` — and so we never prune with
+    // no canonical to keep. Mirrors the old single-file path's throw-on-failure.
+    throw new Error(primary?.error ?? 'Failed to sync file from OneDrive');
+  }
+
+  // Heal: collapse the duplicate rows a prior no-dedup sync run created for
+  // this file, keeping the row we just upserted.
+  const strays = (await collectOwnedRefs(ctx, args)).filter(
+    (ref) => ref.documentId !== canonicalId,
+  );
+  await scheduleSyncedDocumentDeletes(ctx, {
+    organizationId: args.organizationId,
+    refs: strays,
+  });
+
+  return {
+    created: importResult.successCount,
+    skipped: importResult.skippedCount,
+    deleted: strays.length,
+    errorsCount: importResult.results.filter((r) => r.status === 'error')
+      .length,
+  };
+}

--- a/services/platform/convex/workflow_engine/action_defs/onedrive/onedrive_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/onedrive/onedrive_action.ts
@@ -366,12 +366,15 @@ export const onedriveAction: ActionDefinition<OneDriveActionParams> = {
         // status; never throw, so one failing config can't abort the loop.
         try {
           const result = await syncOneConfig(ctx, { organizationId, config });
+          // A single-file sync whose source was deleted (404) removed its
+          // mirror and asks to stop — deactivate rather than keep it active
+          // and re-404 every run.
           await ctx.runMutation(
             internal.onedrive.internal_mutations.updateSyncConfig,
             {
               configId: params.configId,
               organizationId,
-              status: 'active',
+              status: result.sourceDeleted ? 'inactive' : 'active',
               lastSyncAt: Date.now(),
               lastSyncStatus: 'success',
             },


### PR DESCRIPTION
## Why

Single-file OneDrive sync (a directly-selected file, `itemType: 'file'`) had several lifecycle holes, reported from the field (duplicate `Document N.docx` rows, one real and one/more size-less "—"):

1. **Duplicates every run.** The single-file config path re-uploaded the file and **inserted a brand-new document on every scheduled run** — no external-id dedup — so a single synced file accumulated one stray, size-less duplicate per sync pass.
2. **Size shows "—".** The hub reads size from `metadata.size`; the recursive folder listing forwarded Graph's `size` verbatim and could omit it for a freshly copied/uploaded item.
3. **No way to stop it.** The row's **Stop sync** action was gated to folders, so a single-file sync could not be stopped from the UI.
4. **Whack-a-mole.** Deleting the synced document left the config active → the next run re-imported it.
5. **Source deletion invisible.** When the source file was deleted in OneDrive, the config silently flipped to `error` but the mirror document **lingered, looking healthy** (folder sync prunes departed files; single-file sync didn't).

## What changed

- **Route single-file sync through the shared `importFiles` pipeline** (`run_single_file_reconcile.ts`) — same dedup, content-hash skip, streaming download, size and RAG handling the folder path has. Follows the file by id (move/rename keep the Graph id).
- **Self-heal existing duplicates:** after import, collapse every row sharing the file's external id down to the one canonical doc — only rows this config owns (`syncConfigId` + `sourceMode: auto`); manual uploads and other configs are never touched. Extracted a **shared prune scheduler** so both reconcilers use one delete path.
- **Size:** resolve from transferred bytes → Graph item metadata → listing size; floor the listing size to `0` like the picker/SharePoint listers.
- **Stop sync from a file row** for a directly-selected single-file sync. A file synced *as part of a folder* carries the folder's config id, so it stays hidden (stopping it there would cancel the whole folder).
- **Delete stops sync:** deleting a directly-selected single-file synced doc deactivates its config (folder members untouched).
- **Source deleted (404) prunes the mirror** + deactivates the config — strictly guarded to a definitive 404; a transient/permission/throttle failure keeps the doc and errors the config as before.

## Testing

- `run_single_file_reconcile.test.ts` — dedup import, collapse duplicates, never-reap manual/other-config rows, transient-failure throws, **404 → prune + `sourceDeleted`**.
- `import_files.test.ts` — size resolved from Graph metadata when the listing omits it (verified red→green).
- `deactivate_sync_configs.test.ts` — `deactivateSyncConfigById` + `stopSyncForDeletedDocument` (single-file stops, folder-member/manual untouched).
- `document-row-actions.test.tsx` — Stop-sync visible for single-file, hidden for folder-member, still shown for folders (verified red→green).
- Platform `onedrive/` + `documents/` + workflow-engine onedrive suites green (387); docs suite green (166); typecheck / lint / SAST clean.

## Definition of done

- [x] **Green gate** — typecheck, lint, SAST clean; all touched-area tests pass. (Full-suite has pre-existing convexTest starvation flakes in unrelated files — SCIM, RLS, migrations — which pass in isolation.)
- [x] **Security** — SAST clean; the new config deactivation is org-scoped and tested for cross-org no-op.
- [x] **Tests** — happy + edge + error across the new suites.
- [x] **Migration** — N/A (no schema change; `notFound`/`sourceDeleted` are in-memory result fields).
- [x] **Locales** — no new strings; the reused `actions.stopSync*` keys exist in en/fr/de.
- [x] **Docs** — `knowledge/documents.md` updated (en + fr + de) for stop-sync/delete on single files.
- [x] **Accessibility** — reuses the existing `EntityRowActions` menu (a11y-audited); no new controls.
- [x] **Sweep** — all `importFiles` callers, the listing path, the delete path, and the row-action gate reviewed.
- [ ] **Observed** — unit/component tests observe the real outcome (incl. driving the real Radix menu); **not** end-to-end against a live OneDrive account (needs a running stack + Graph tokens).
- [x] **Commits** — atomic, conventional, off `main`.
