### PR TITLE
fix(platform): SSO login for title-less Entra users + login-failure observability

### DIFF
--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -80,7 +80,14 @@ if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
     release: getEnv('TALE_VERSION'),
-    integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
+    integrations: [
+      Sentry.tanstackRouterBrowserTracingIntegration(router),
+      // Sentry captures thrown/unhandled errors by default but treats a plain
+      // `console.error(...)` as a breadcrumb, not an issue. Promote error-level
+      // console calls to issues so deliberately-logged failures are visible too.
+      // Kept to `error` only (not `warn`) to bound event volume.
+      Sentry.captureConsoleIntegration({ levels: ['error'] }),
+    ],
     tracesSampleRate: getEnv('SENTRY_TRACES_SAMPLE_RATE'),
   });
 }

--- a/services/platform/convex/enterprise_sso/entra_id/adapter.test.ts
+++ b/services/platform/convex/enterprise_sso/entra_id/adapter.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SsoProviderConfig } from '../types';
+import { entraIdAdapter } from './adapter';
+
+// `getUserInfo` ignores the config (reads the signed-in user from Graph `/me`),
+// so a bare cast is enough to exercise the response mapping.
+const fakeConfig = {} as unknown as SsoProviderConfig;
+
+function stubGraphMe(data: Record<string, unknown>): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () => ({ ok: true, json: async () => data }) as unknown as Response,
+    ),
+  );
+}
+
+describe('entraIdAdapter.getUserInfo — jobTitle normalisation (SSO serverError regression)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('maps Graph `jobTitle: null` to undefined so a title-less user can sign in', async () => {
+    // Microsoft Graph returns `jobTitle: null` for users with no job title;
+    // leaking that null tripped `handleSsoLogin`'s `v.optional(v.string())`
+    // validator and failed the whole login with a generic serverError.
+    stubGraphMe({
+      id: 'user-1',
+      mail: 'user@example.com',
+      displayName: 'User One',
+      jobTitle: null,
+    });
+
+    const info = await entraIdAdapter.getUserInfo(fakeConfig, 'access-token');
+
+    expect(info.jobTitle).toBeUndefined();
+    expect(info.externalId).toBe('user-1');
+    expect(info.email).toBe('user@example.com');
+  });
+
+  it('preserves a real job title', async () => {
+    stubGraphMe({
+      id: 'user-2',
+      mail: 'eng@example.com',
+      displayName: 'Eng Two',
+      jobTitle: 'Software Engineer',
+    });
+
+    const info = await entraIdAdapter.getUserInfo(fakeConfig, 'access-token');
+
+    expect(info.jobTitle).toBe('Software Engineer');
+  });
+
+  it('maps an empty-string job title to undefined', async () => {
+    stubGraphMe({
+      id: 'user-3',
+      mail: 'x@example.com',
+      displayName: 'X',
+      jobTitle: '',
+    });
+
+    const info = await entraIdAdapter.getUserInfo(fakeConfig, 'access-token');
+
+    expect(info.jobTitle).toBeUndefined();
+  });
+});

--- a/services/platform/convex/enterprise_sso/entra_id/adapter.ts
+++ b/services/platform/convex/enterprise_sso/entra_id/adapter.ts
@@ -170,7 +170,13 @@ async function getUserInfo(
     externalId: data.id,
     email: data.mail || data.userPrincipalName,
     name: data.displayName || data.givenName || '',
-    jobTitle: data.jobTitle,
+    // Graph returns every `$select`ed field even when empty, so a user with no
+    // job title comes back as `jobTitle: null` (not an omitted key). Our
+    // `SsoUserInfo.jobTitle` is a non-nullable optional string and the
+    // downstream `handleSsoLogin` validator (`v.optional(v.string())`) rejects
+    // `null` — normalise null/"" to `undefined` here at the boundary so a
+    // title-less user can still sign in.
+    jobTitle: data.jobTitle || undefined,
   };
 }
 

--- a/services/platform/convex/enterprise_sso/login/authorize_handler.ts
+++ b/services/platform/convex/enterprise_sso/login/authorize_handler.ts
@@ -6,6 +6,7 @@ import { generatePkcePair } from '../pkce';
 import { getAdapter } from '../registry';
 import { signValue } from '../sign_cookie_value';
 import type { SsoPromptMode } from '../types';
+import { recordSsoLoginFailure } from './login_audit';
 import { redirectWithError } from './redirect_with_error';
 
 const VALID_PROMPTS: Record<string, SsoPromptMode> = {
@@ -39,9 +40,15 @@ export async function ssoAuthorizeHandler(
   // browser), so the redirect prefers the public SITE_URL.
   const normalizedOrigin = normalizeOrigin(new URL(req.url).origin);
   const publicOrigin = process.env.SITE_URL || normalizedOrigin;
+  // Hoisted so the catch can write a durable audit row for the failed attempt
+  // (populated as the login hint and connection are resolved below).
+  let resolvedOrganizationId: string | undefined;
+  let resolvedProviderId: string | undefined;
+  let attemptedEmail: string | undefined;
   try {
     const url = new URL(req.url);
     const email = url.searchParams.get('email');
+    attemptedEmail = email ?? undefined;
     const organizationId = url.searchParams.get('organizationId') || undefined;
     const promptParam = url.searchParams.get('prompt');
     const seamlessParam = url.searchParams.get('seamless');
@@ -69,6 +76,8 @@ export async function ssoAuthorizeHandler(
     if (!config) {
       return new Response('No SSO configuration found', { status: 404 });
     }
+    resolvedOrganizationId = config.organizationId;
+    resolvedProviderId = config.providerId;
 
     const adapter = getAdapter(config.providerId);
     if (!adapter) {
@@ -155,6 +164,14 @@ export async function ssoAuthorizeHandler(
     // A misconfigured issuer (extractTenantId throws) or any other unhandled
     // failure now lands readably on the login page instead of a raw 500 — the
     // real cause is logged above for the operator.
+    await recordSsoLoginFailure(ctx, {
+      organizationId: resolvedOrganizationId,
+      stage: 'authorize',
+      errorMessage: error instanceof Error ? error.message : String(error),
+      errorKey: 'sso.errors.serverError',
+      attemptedEmail,
+      providerId: resolvedProviderId,
+    });
     return redirectWithError(publicOrigin, 'sso.errors.serverError');
   }
 }

--- a/services/platform/convex/enterprise_sso/login/callback_handler.ts
+++ b/services/platform/convex/enterprise_sso/login/callback_handler.ts
@@ -12,6 +12,7 @@ import {
 } from '../entra_id/error_codes';
 import { getAdapter } from '../registry';
 import { signCookieValue, verifySignedValue } from '../sign_cookie_value';
+import { recordSsoLoginFailure } from './login_audit';
 import { redirectWithError } from './redirect_with_error';
 
 const SESSION_COOKIE_NAME = 'better-auth.session_token';
@@ -47,6 +48,11 @@ export async function ssoCallbackHandler(
   // (unreachable from a browser), so error redirects must target the public
   // SITE_URL — refined to the state's own origin once the state is parsed.
   let publicOrigin = process.env.SITE_URL || new URL(req.url).origin;
+  // Hoisted so the catch can write a durable audit row attributing the failure
+  // to the right org/connection/user (populated as each is resolved below).
+  let resolvedOrganizationId: string | undefined;
+  let resolvedProviderId: string | undefined;
+  let attemptedEmail: string | undefined;
   try {
     const url = new URL(req.url);
     const code = url.searchParams.get('code');
@@ -188,6 +194,8 @@ export async function ssoCallbackHandler(
     if (!config) {
       return redirectWithError(frontendOrigin, 'SSO configuration not found');
     }
+    resolvedOrganizationId = config.organizationId;
+    resolvedProviderId = config.providerId;
 
     const adapter = getAdapter(config.providerId);
     if (!adapter) {
@@ -236,6 +244,7 @@ export async function ssoCallbackHandler(
     });
 
     const userInfo = await adapter.getUserInfo(ssoConfig, tokens.accessToken);
+    attemptedEmail = userInfo.email;
 
     if (tokens.idToken) {
       const authContext = parseIdTokenAuthContext(tokens.idToken);
@@ -340,6 +349,14 @@ export async function ssoCallbackHandler(
     const message = error instanceof Error ? error.message : String(error);
     const errorCode = parseEntraErrorCode(message);
     const errorInfo = errorCode ? getEntraErrorInfo(errorCode) : undefined;
+    await recordSsoLoginFailure(ctx, {
+      organizationId: resolvedOrganizationId,
+      stage: 'callback',
+      errorMessage: message,
+      errorKey: errorInfo?.messageKey ?? 'sso.errors.serverError',
+      attemptedEmail,
+      providerId: resolvedProviderId,
+    });
     if (errorCode && errorInfo) {
       return redirectWithError(
         publicOrigin,

--- a/services/platform/convex/enterprise_sso/login/login_audit.ts
+++ b/services/platform/convex/enterprise_sso/login/login_audit.ts
@@ -1,0 +1,69 @@
+import { internal } from '../../_generated/api';
+import type { ActionCtx } from '../../_generated/server';
+
+// Error messages carry Graph/AADSTS response bodies and stack fragments; cap the
+// audited length so one row can't balloon (the chain hashes every field).
+const MAX_AUDIT_ERROR_LEN = 500;
+
+interface RecordSsoLoginFailureArgs {
+  /**
+   * The connection's org, once resolved. Undefined when the failure happened
+   * before we knew which connection to use (bad state, unknown org) — audit
+   * rows are per-org and hash-chained, so there is no org to attach them to and
+   * we skip the write, leaving the `console.error` as the only trace.
+   */
+  organizationId: string | undefined;
+  stage: 'authorize' | 'callback';
+  errorMessage: string;
+  /** The i18n key the user was bounced to, e.g. `sso.errors.serverError`. */
+  errorKey?: string;
+  /** Email the user was signing in with, when known (login hint / userinfo). */
+  attemptedEmail?: string;
+  providerId?: string;
+}
+
+/**
+ * Write a durable `auth`/`failure` audit row for a failed SSO login so the
+ * failure is visible beyond an ephemeral `console.error` (the callback catches
+ * the error and redirects, so it never surfaces as a failed request). Reached
+ * from the OIDC authorize/callback http actions' catch blocks.
+ *
+ * Best-effort: no-ops without a resolved org, and never throws — an audit-write
+ * failure must not mask the real login error or break the redirect back to the
+ * login page.
+ */
+export async function recordSsoLoginFailure(
+  ctx: ActionCtx,
+  args: RecordSsoLoginFailureArgs,
+): Promise<void> {
+  if (!args.organizationId) return;
+
+  // Normalise an empty `?email=` hint to "no email" so it doesn't land as a
+  // blank actor id / email on the row.
+  const email = args.attemptedEmail || undefined;
+
+  const metadata: Record<string, string> = { stage: args.stage };
+  if (args.errorKey) metadata['errorKey'] = args.errorKey;
+  if (args.providerId) metadata['providerId'] = args.providerId;
+
+  try {
+    await ctx.runMutation(
+      internal.audit_logs.internal_mutations.createAuditLog,
+      {
+        organizationId: args.organizationId,
+        actorId: email ?? 'unknown',
+        actorEmail: email,
+        actorType: 'user',
+        action: 'sso_login_failed',
+        category: 'auth',
+        resourceType: 'sso',
+        resourceId: args.organizationId,
+        status: 'failure',
+        errorMessage: args.errorMessage.slice(0, MAX_AUDIT_ERROR_LEN),
+        metadata,
+      },
+    );
+  } catch (e) {
+    console.error('[SSO] Failed to write login-failure audit log:', e);
+  }
+}


### PR DESCRIPTION
## Why

An Entra user with **no job title** could not sign in via SSO — they hit a generic red *"Single sign-on could not complete due to a server error"* page. The real cause was invisible: it only appeared as a `console.error` in the Convex logs (the callback catches the error and returns a 302, so it logs as a *success*), and never reached our error dashboard.

This PR fixes the bug and closes the observability gaps that hid it.

## What

**1. Root fix — `fix(platform): allow SSO login for Entra users without a job title`**
Microsoft Graph returns every `$select`ed field even when empty, so a title-less user comes back as `jobTitle: null` (not an omitted key). That `null` leaked through the Entra adapter into `handleSsoLogin`, whose `jobTitle: v.optional(v.string())` validator **rejects `null`** (Convex `optional` accepts `undefined`, not `null`) — throwing an `ArgumentValidationError` before the handler ran and failing the whole login. Normalised `null`/`""` → `undefined` at the adapter boundary, with a regression test through `entraIdAdapter.getUserInfo`.

**2. Frontend — `feat(platform): report error-level browser console logs to Sentry`**
Sentry captures thrown/unhandled errors by default but treats a plain `console.error(...)` as a *breadcrumb*, not an issue. Added `captureConsoleIntegration({ levels: ['error'] })` so deliberately-logged frontend failures surface as issues too. Scoped to `error` only to bound event volume (the GlitchTip org is quota-throttled).

**3. Backend — `feat(platform): audit SSO login failures for observability`**
The OIDC authorize/callback handlers catch server-side failures and redirect, so a failure never surfaces as a failed request. Both catch blocks now write a durable, org-scoped `auth`/`failure` audit row (`action: sso_login_failed`, real error + stage/provider in metadata) via the existing audit-log writer. Best-effort: no-ops when the org isn't resolved yet and never throws, so it can't mask the login error or break the redirect.

## Notes
- No new i18n keys — reuses `sso.errors.serverError`. The `sso_login_failed` audit action renders via the audit table's `defaultValue` fallback, consistent with the existing `sso_configure`/`sso_enabled` actions (none carry explicit labels).
- No schema/migration change — reuses the `createAuditLog` internal mutation and existing `auditLogs` table.
- Complementary (not in this PR): enabling the Convex dashboard **Sentry exception-reporting integration** would surface uncaught function throws (like this one) in GlitchTip with `func` tags.

## Testing
- `entra_id/adapter.test.ts`: `jobTitle: null` → `undefined`, empty string → `undefined`, real title preserved (would fail pre-fix).
- SSO authorize/callback handler suites: green (13 tests).
- `bunx tsc --noEmit` clean; `oxlint --type-aware` clean; SAST clean.