### PR TITLE
fix(platform): chat nav rail flash, SSO jobTitle null, and login observability

### DIFF
--- a/services/platform/app/features/chat/components/chat-dashboard-sidebar.test.tsx
+++ b/services/platform/app/features/chat/components/chat-dashboard-sidebar.test.tsx
@@ -33,10 +33,6 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   };
 });
 
-vi.mock('@/app/components/ui/navigation/navigation', () => ({
-  Navigation: () => <nav data-testid="dashboard-nav">nav</nav>,
-}));
-
 vi.mock('./chat-history-sidebar', () => ({
   ChatHistorySidebar: () => (
     <div data-testid="chat-history-sidebar">history</div>
@@ -55,10 +51,9 @@ vi.mock('@/app/hooks/use-prefers-reduced-motion', () => ({
 }));
 
 describe('ChatDashboardSidebar', () => {
-  it('renders nav rail and history panel landmark', () => {
+  it('renders the expandable history panel landmark', () => {
     render(<ChatDashboardSidebar organizationId="org-1" />);
 
-    expect(screen.getByTestId('dashboard-nav')).toBeInTheDocument();
     expect(screen.getByTestId('chat-history-sidebar')).toBeInTheDocument();
     expect(
       screen.getByRole('complementary', {

--- a/services/platform/app/features/chat/components/chat-dashboard-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-dashboard-sidebar.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { Row, Stack } from '@tale/ui/layout';
+import { Stack } from '@tale/ui/layout';
 import { Link, useLocation } from '@tanstack/react-router';
 import { m } from 'framer-motion';
 import { useCallback, useMemo } from 'react';
 
-import { Navigation } from '@/app/components/ui/navigation/navigation';
 import { Sheet } from '@/app/components/ui/overlays/sheet';
 import { useAbility } from '@/app/hooks/use-ability';
 import {
@@ -166,8 +165,9 @@ export function ChatMobileSidebarSheet({
 }
 
 /**
- * Desktop unified left panel: icon nav rail plus an expandable chat-history
- * column. Collapsed state shows only the rail; expanded adds the history list.
+ * Desktop chat-history column beside the layout's shared nav rail. The icon
+ * rail lives once in {@link DashboardLayout}; this panel only expands/collapses
+ * the thread list so route transitions never mount a second Navigation.
  */
 export function ChatDashboardSidebar({
   organizationId,
@@ -183,30 +183,24 @@ export function ChatDashboardSidebar({
   return (
     <aside
       aria-label={t('unifiedSidebar.landmark')}
-      className="bg-background relative hidden h-full shrink-0 md:flex"
+      className="bg-background border-border relative hidden h-full shrink-0 border-r md:flex"
     >
-      <Row gap={0} align="stretch" className="border-border h-full border-r">
-        <div className="h-full w-[var(--nav-size)] shrink-0 px-2">
-          <Navigation organizationId={organizationId} />
-        </div>
-
-        <m.div
-          id="chat-history-panel"
-          initial={false}
-          animate={{ width: isHistoryOpen ? HISTORY_PANEL_WIDTH : 0 }}
-          transition={transition}
-          className="relative overflow-hidden"
-          aria-hidden={!isHistoryOpen}
+      <m.div
+        id="chat-history-panel"
+        initial={false}
+        animate={{ width: isHistoryOpen ? HISTORY_PANEL_WIDTH : 0 }}
+        transition={transition}
+        className="relative overflow-hidden"
+        aria-hidden={!isHistoryOpen}
+      >
+        <Stack
+          gap={0}
+          className="bg-background h-full overflow-hidden"
+          style={{ width: HISTORY_PANEL_WIDTH }}
         >
-          <Stack
-            gap={0}
-            className="border-border bg-background h-full overflow-hidden border-l"
-            style={{ width: HISTORY_PANEL_WIDTH }}
-          >
-            <ChatHistorySidebar organizationId={organizationId} />
-          </Stack>
-        </m.div>
-      </Row>
+          <ChatHistorySidebar organizationId={organizationId} />
+        </Stack>
+      </m.div>
     </aside>
   );
 }

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -80,7 +80,14 @@ if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
     release: getEnv('TALE_VERSION'),
-    integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
+    integrations: [
+      Sentry.tanstackRouterBrowserTracingIntegration(router),
+      // Sentry captures thrown/unhandled errors by default but treats a plain
+      // `console.error(...)` as a breadcrumb, not an issue. Promote error-level
+      // console calls to issues so deliberately-logged failures are visible too.
+      // Kept to `error` only (not `warn`) to bound event volume.
+      Sentry.captureConsoleIntegration({ levels: ['error'] }),
+    ],
     tracesSampleRate: getEnv('SENTRY_TRACES_SAMPLE_RATE'),
   });
 }

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -6,12 +6,7 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Spinner } from '@tale/ui/spinner';
 import { Text } from '@tale/ui/text';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  Outlet,
-  createFileRoute,
-  useLocation,
-  useNavigate,
-} from '@tanstack/react-router';
+import { Outlet, createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation } from 'convex/react';
 import { useEffect, useRef } from 'react';
 
@@ -121,10 +116,6 @@ export const Route = createFileRoute('/dashboard/$id')({
 
 function DashboardLayout() {
   const { id: organizationId } = Route.useParams();
-  const location = useLocation();
-  const isChatSurface = location.pathname.startsWith(
-    `/dashboard/${organizationId}/chat`,
-  );
   usePasswordExpiryGate(organizationId);
 
   // Theme the app to this org's branding. BrandingProvider sits above the
@@ -218,8 +209,17 @@ function DashboardLayout() {
   const abilityRef = useRef<{ role: string | null; ability: AppAbility }>(null);
 
   const status = memberContext?.status;
+  const resolvedRole = status === 'ok' ? memberContext.role : null;
+  // Keep the last known role while the membership query refetches after a cache
+  // invalidation — otherwise hasRole drops to false for a frame and the rail
+  // swaps Navigation ↔ NavRailPlaceholder (visible flash on every click).
   const currentRole =
-    memberContext?.status === 'ok' ? memberContext.role : null;
+    resolvedRole ??
+    (isQueryLoading &&
+    memberContext === undefined &&
+    abilityRef.current?.role != null
+      ? abilityRef.current.role
+      : null);
 
   if (!abilityRef.current || abilityRef.current.role !== currentRole) {
     abilityRef.current = {
@@ -311,12 +311,7 @@ function DashboardLayout() {
                   </Row>
                 </header>
 
-                <div
-                  className={cn(
-                    'bg-background hidden h-full px-2 md:flex md:flex-[0_0_var(--nav-size)]',
-                    isChatSurface && 'md:hidden',
-                  )}
-                >
+                <div className="bg-background hidden h-full px-2 md:flex md:flex-[0_0_var(--nav-size)]">
                   {hasRole ? (
                     <Navigation organizationId={organizationId} />
                   ) : (

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -41,8 +41,6 @@ import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 import { defineAbilityFor, type AppAbility } from '@/lib/permissions/ability';
-import { cn } from '@/lib/utils/cn';
-
 // Fire-and-forget warm of an action-backed config catalog into the SAME
 // TanStack Query cache entry the `useActionQuery` hooks read (matching key +
 // `staleTime: Infinity` + the `action(args)` queryFn), so the catalog loads
@@ -209,7 +207,8 @@ function DashboardLayout() {
   const abilityRef = useRef<{ role: string | null; ability: AppAbility }>(null);
 
   const status = memberContext?.status;
-  const resolvedRole = status === 'ok' ? memberContext.role : null;
+  const resolvedRole =
+    memberContext?.status === 'ok' ? memberContext.role : null;
   // Keep the last known role while the membership query refetches after a cache
   // invalidation — otherwise hasRole drops to false for a frame and the rail
   // swaps Navigation ↔ NavRailPlaceholder (visible flash on every click).

--- a/services/platform/app/routes/dashboard/dashboard-layout.test.tsx
+++ b/services/platform/app/routes/dashboard/dashboard-layout.test.tsx
@@ -398,4 +398,35 @@ describe('DashboardLayout', () => {
     expect(screen.getByTestId('outlet')).toBeInTheDocument();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
+
+  it('keeps the live nav rail during a membership refetch with no placeholder flash', () => {
+    mockUseConvexAuth.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+    });
+    mockUseCurrentMemberContext.mockReturnValue({
+      data: {
+        status: 'ok',
+        role: 'admin',
+        memberId: 'm1',
+        organizationId: 'org-1',
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { rerender } = render(<DashboardLayout />);
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    mockUseCurrentMemberContext.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    rerender(<DashboardLayout />);
+
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
 });

--- a/services/platform/convex/enterprise_sso/entra_id/adapter.test.ts
+++ b/services/platform/convex/enterprise_sso/entra_id/adapter.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SsoProviderConfig } from '../types';
+import { entraIdAdapter } from './adapter';
+
+// `getUserInfo` ignores the config (reads the signed-in user from Graph `/me`),
+// so a bare cast is enough to exercise the response mapping.
+const fakeConfig = {} as unknown as SsoProviderConfig;
+
+function stubGraphMe(data: Record<string, unknown>): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () => ({ ok: true, json: async () => data }) as unknown as Response,
+    ),
+  );
+}
+
+describe('entraIdAdapter.getUserInfo — jobTitle normalisation (SSO serverError regression)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('maps Graph `jobTitle: null` to undefined so a title-less user can sign in', async () => {
+    // Microsoft Graph returns `jobTitle: null` for users with no job title;
+    // leaking that null tripped `handleSsoLogin`'s `v.optional(v.string())`
+    // validator and failed the whole login with a generic serverError.
+    stubGraphMe({
+      id: 'user-1',
+      mail: 'user@example.com',
+      displayName: 'User One',
+      jobTitle: null,
+    });
+
+    const info = await entraIdAdapter.getUserInfo(fakeConfig, 'access-token');
+
+    expect(info.jobTitle).toBeUndefined();
+    expect(info.externalId).toBe('user-1');
+    expect(info.email).toBe('user@example.com');
+  });
+
+  it('preserves a real job title', async () => {
+    stubGraphMe({
+      id: 'user-2',
+      mail: 'eng@example.com',
+      displayName: 'Eng Two',
+      jobTitle: 'Software Engineer',
+    });
+
+    const info = await entraIdAdapter.getUserInfo(fakeConfig, 'access-token');
+
+    expect(info.jobTitle).toBe('Software Engineer');
+  });
+
+  it('maps an empty-string job title to undefined', async () => {
+    stubGraphMe({
+      id: 'user-3',
+      mail: 'x@example.com',
+      displayName: 'X',
+      jobTitle: '',
+    });
+
+    const info = await entraIdAdapter.getUserInfo(fakeConfig, 'access-token');
+
+    expect(info.jobTitle).toBeUndefined();
+  });
+});

--- a/services/platform/convex/enterprise_sso/entra_id/adapter.ts
+++ b/services/platform/convex/enterprise_sso/entra_id/adapter.ts
@@ -170,7 +170,13 @@ async function getUserInfo(
     externalId: data.id,
     email: data.mail || data.userPrincipalName,
     name: data.displayName || data.givenName || '',
-    jobTitle: data.jobTitle,
+    // Graph returns every `$select`ed field even when empty, so a user with no
+    // job title comes back as `jobTitle: null` (not an omitted key). Our
+    // `SsoUserInfo.jobTitle` is a non-nullable optional string and the
+    // downstream `handleSsoLogin` validator (`v.optional(v.string())`) rejects
+    // `null` — normalise null/"" to `undefined` here at the boundary so a
+    // title-less user can still sign in.
+    jobTitle: data.jobTitle || undefined,
   };
 }
 

--- a/services/platform/convex/enterprise_sso/login/authorize_handler.ts
+++ b/services/platform/convex/enterprise_sso/login/authorize_handler.ts
@@ -6,6 +6,7 @@ import { generatePkcePair } from '../pkce';
 import { getAdapter } from '../registry';
 import { signValue } from '../sign_cookie_value';
 import type { SsoPromptMode } from '../types';
+import { recordSsoLoginFailure } from './login_audit';
 import { redirectWithError } from './redirect_with_error';
 
 const VALID_PROMPTS: Record<string, SsoPromptMode> = {
@@ -39,9 +40,15 @@ export async function ssoAuthorizeHandler(
   // browser), so the redirect prefers the public SITE_URL.
   const normalizedOrigin = normalizeOrigin(new URL(req.url).origin);
   const publicOrigin = process.env.SITE_URL || normalizedOrigin;
+  // Hoisted so the catch can write a durable audit row for the failed attempt
+  // (populated as the login hint and connection are resolved below).
+  let resolvedOrganizationId: string | undefined;
+  let resolvedProviderId: string | undefined;
+  let attemptedEmail: string | undefined;
   try {
     const url = new URL(req.url);
     const email = url.searchParams.get('email');
+    attemptedEmail = email ?? undefined;
     const organizationId = url.searchParams.get('organizationId') || undefined;
     const promptParam = url.searchParams.get('prompt');
     const seamlessParam = url.searchParams.get('seamless');
@@ -69,6 +76,8 @@ export async function ssoAuthorizeHandler(
     if (!config) {
       return new Response('No SSO configuration found', { status: 404 });
     }
+    resolvedOrganizationId = config.organizationId;
+    resolvedProviderId = config.providerId;
 
     const adapter = getAdapter(config.providerId);
     if (!adapter) {
@@ -155,6 +164,14 @@ export async function ssoAuthorizeHandler(
     // A misconfigured issuer (extractTenantId throws) or any other unhandled
     // failure now lands readably on the login page instead of a raw 500 — the
     // real cause is logged above for the operator.
+    await recordSsoLoginFailure(ctx, {
+      organizationId: resolvedOrganizationId,
+      stage: 'authorize',
+      errorMessage: error instanceof Error ? error.message : String(error),
+      errorKey: 'sso.errors.serverError',
+      attemptedEmail,
+      providerId: resolvedProviderId,
+    });
     return redirectWithError(publicOrigin, 'sso.errors.serverError');
   }
 }

--- a/services/platform/convex/enterprise_sso/login/callback_handler.ts
+++ b/services/platform/convex/enterprise_sso/login/callback_handler.ts
@@ -12,6 +12,7 @@ import {
 } from '../entra_id/error_codes';
 import { getAdapter } from '../registry';
 import { signCookieValue, verifySignedValue } from '../sign_cookie_value';
+import { recordSsoLoginFailure } from './login_audit';
 import { redirectWithError } from './redirect_with_error';
 
 const SESSION_COOKIE_NAME = 'better-auth.session_token';
@@ -47,6 +48,11 @@ export async function ssoCallbackHandler(
   // (unreachable from a browser), so error redirects must target the public
   // SITE_URL — refined to the state's own origin once the state is parsed.
   let publicOrigin = process.env.SITE_URL || new URL(req.url).origin;
+  // Hoisted so the catch can write a durable audit row attributing the failure
+  // to the right org/connection/user (populated as each is resolved below).
+  let resolvedOrganizationId: string | undefined;
+  let resolvedProviderId: string | undefined;
+  let attemptedEmail: string | undefined;
   try {
     const url = new URL(req.url);
     const code = url.searchParams.get('code');
@@ -188,6 +194,8 @@ export async function ssoCallbackHandler(
     if (!config) {
       return redirectWithError(frontendOrigin, 'SSO configuration not found');
     }
+    resolvedOrganizationId = config.organizationId;
+    resolvedProviderId = config.providerId;
 
     const adapter = getAdapter(config.providerId);
     if (!adapter) {
@@ -236,6 +244,7 @@ export async function ssoCallbackHandler(
     });
 
     const userInfo = await adapter.getUserInfo(ssoConfig, tokens.accessToken);
+    attemptedEmail = userInfo.email;
 
     if (tokens.idToken) {
       const authContext = parseIdTokenAuthContext(tokens.idToken);
@@ -340,6 +349,14 @@ export async function ssoCallbackHandler(
     const message = error instanceof Error ? error.message : String(error);
     const errorCode = parseEntraErrorCode(message);
     const errorInfo = errorCode ? getEntraErrorInfo(errorCode) : undefined;
+    await recordSsoLoginFailure(ctx, {
+      organizationId: resolvedOrganizationId,
+      stage: 'callback',
+      errorMessage: message,
+      errorKey: errorInfo?.messageKey ?? 'sso.errors.serverError',
+      attemptedEmail,
+      providerId: resolvedProviderId,
+    });
     if (errorCode && errorInfo) {
       return redirectWithError(
         publicOrigin,

--- a/services/platform/convex/enterprise_sso/login/login_audit.ts
+++ b/services/platform/convex/enterprise_sso/login/login_audit.ts
@@ -1,0 +1,69 @@
+import { internal } from '../../_generated/api';
+import type { ActionCtx } from '../../_generated/server';
+
+// Error messages carry Graph/AADSTS response bodies and stack fragments; cap the
+// audited length so one row can't balloon (the chain hashes every field).
+const MAX_AUDIT_ERROR_LEN = 500;
+
+interface RecordSsoLoginFailureArgs {
+  /**
+   * The connection's org, once resolved. Undefined when the failure happened
+   * before we knew which connection to use (bad state, unknown org) — audit
+   * rows are per-org and hash-chained, so there is no org to attach them to and
+   * we skip the write, leaving the `console.error` as the only trace.
+   */
+  organizationId: string | undefined;
+  stage: 'authorize' | 'callback';
+  errorMessage: string;
+  /** The i18n key the user was bounced to, e.g. `sso.errors.serverError`. */
+  errorKey?: string;
+  /** Email the user was signing in with, when known (login hint / userinfo). */
+  attemptedEmail?: string;
+  providerId?: string;
+}
+
+/**
+ * Write a durable `auth`/`failure` audit row for a failed SSO login so the
+ * failure is visible beyond an ephemeral `console.error` (the callback catches
+ * the error and redirects, so it never surfaces as a failed request). Reached
+ * from the OIDC authorize/callback http actions' catch blocks.
+ *
+ * Best-effort: no-ops without a resolved org, and never throws — an audit-write
+ * failure must not mask the real login error or break the redirect back to the
+ * login page.
+ */
+export async function recordSsoLoginFailure(
+  ctx: ActionCtx,
+  args: RecordSsoLoginFailureArgs,
+): Promise<void> {
+  if (!args.organizationId) return;
+
+  // Normalise an empty `?email=` hint to "no email" so it doesn't land as a
+  // blank actor id / email on the row.
+  const email = args.attemptedEmail || undefined;
+
+  const metadata: Record<string, string> = { stage: args.stage };
+  if (args.errorKey) metadata['errorKey'] = args.errorKey;
+  if (args.providerId) metadata['providerId'] = args.providerId;
+
+  try {
+    await ctx.runMutation(
+      internal.audit_logs.internal_mutations.createAuditLog,
+      {
+        organizationId: args.organizationId,
+        actorId: email ?? 'unknown',
+        actorEmail: email,
+        actorType: 'user',
+        action: 'sso_login_failed',
+        category: 'auth',
+        resourceType: 'sso',
+        resourceId: args.organizationId,
+        status: 'failure',
+        errorMessage: args.errorMessage.slice(0, MAX_AUDIT_ERROR_LEN),
+        metadata,
+      },
+    );
+  } catch (e) {
+    console.error('[SSO] Failed to write login-failure audit log:', e);
+  }
+}


### PR DESCRIPTION
## Summary

### Chat nav rail
- Remove duplicate `Navigation` from `ChatDashboardSidebar` — the layout's shared nav rail is now the only instance on chat routes, so route transitions no longer mount a second rail.
- Hold the last known member role during membership refetch so `hasRole` does not briefly drop to false and swap the live rail for `NavRailPlaceholder` (visible flash on every click).

### SSO login & observability
- Normalise Entra `jobTitle: null` to `undefined` at the adapter boundary so users without a job title can complete SSO login (was failing `v.optional(v.string())` validation).
- Report browser `console.error` calls to Sentry via `captureConsoleIntegration({ levels: ['error'] })` so deliberately logged frontend failures surface as issues, not just breadcrumbs.
- Write durable auth/failure audit rows from OIDC authorize/callback catch blocks — server-side SSO failures redirect to the login page and only appear in logs today.

## Test plan

- [x] `chat-dashboard-sidebar.test.tsx` — history panel landmark renders without a nested nav rail
- [x] `dashboard-layout.test.tsx` — nav rail stays live during membership refetch (no placeholder flash)
- [x] `entra_id/adapter.test.ts` — null/empty jobTitle normalised to undefined
- [ ] Manual: open chat on desktop, toggle history panel, navigate between dashboard routes — single stable nav rail throughout
- [ ] Manual: SSO login with an Entra user that has no job title
- [ ] Manual: trigger an SSO authorize/callback failure and confirm an audit row appears

## Definition of done

- [x] **Green gate** — UI tests (15/15) and Entra adapter tests (3/3) pass locally
- [x] **Security gate** — opengrep clean on commits
- [x] **Tests** — regression tests for sidebar dedup, refetch flash, and jobTitle null
- [x] **Migration** — N/A
- [x] **Locales** — N/A (no new user-visible strings)
- [x] **Docs** — N/A
- [x] **Accessibility** — existing landmarks preserved; no new interactive elements
- [x] **Sweep** — chat sidebar, dashboard layout, Entra adapter, SSO handlers, Sentry init
- [ ] **Observed** — not manually verified in browser this session
- [x] **Commits** — four atomic commits on `fix/platform-chat-nav-rail-flash`