### PR TITLE
docs(skills): store write-notes scratch files globally

### DIFF
--- a/.agents/skills/write-notes/SKILL.md
+++ b/.agents/skills/write-notes/SKILL.md
@@ -29,13 +29,33 @@ understanding changes mid-task. Skip it only for a trivial one-line change in a 
   how you'd catch the mistake. The insight is in what you _don't_ yet know — a note that only sounds
   confident hides the bug it should have surfaced.
 - **Where it goes.** Wherever your team records intent before work — a task/issue comment, the draft PR
-  description, or a scratch `notes/` file in your working area. It is a thinking artifact, not a
-  committed source file; keep it unless your project tracks notes.
+  description, or a scratch file in the global notes directory (see below). It is a thinking artifact,
+  not a committed source file; keep it unless your project tracks notes.
 - **Keep it short and honest.** A few lines per answer, not an essay. Write what's true now; update it
   when you learn more. A note that launders a guess into confidence is worse than none.
 - **Then act.** Only once the note's open questions are resolved (or asked) do you start the work — and
   the skill's own gates confirm you did: Gate A's first box, **Note**, checks this note exists; Gate B
   checks you finished what it planned.
+
+## Where scratch files go
+
+A note written to disk goes in one **global, user-local directory — never inside the repository**.
+A scratch file in the clone shows up in `git status`, is one `git add -A` away from being committed,
+and dies with the clone; the global directory survives branch switches and re-clones. Resolve the
+location in this order:
+
+1. `TALE_AGENT_NOTES_DIR` — an absolute path, if set. The explicit override for power users and CI.
+2. Otherwise the OS default:
+   - **Linux:** `$XDG_DATA_HOME/tale/agent-notes/` (or `~/.local/share/tale/agent-notes/` when
+     `XDG_DATA_HOME` is unset)
+   - **macOS:** `~/Library/Application Support/Tale/agent-notes/`
+   - **Windows:** `%APPDATA%\Tale\agent-notes\`
+
+Inside it, key notes by repository so parallel checkouts stay separated, and date the file:
+`<repo-slug>/<date>-<topic>.md` — e.g. `tale-project-tale/2026-07-06-fix-webhook-retry.md`. Create
+the directories on first use. **Never create a `notes/` directory (or any scratch file) under the
+repo root** — a task/issue comment or the draft PR description remain the alternatives when your
+team should see the note.
 
 ## Why a note, not just a thought
 

--- a/.claude/skills/write-notes/SKILL.md
+++ b/.claude/skills/write-notes/SKILL.md
@@ -29,13 +29,33 @@ understanding changes mid-task. Skip it only for a trivial one-line change in a 
   how you'd catch the mistake. The insight is in what you _don't_ yet know — a note that only sounds
   confident hides the bug it should have surfaced.
 - **Where it goes.** Wherever your team records intent before work — a task/issue comment, the draft PR
-  description, or a scratch `notes/` file in your working area. It is a thinking artifact, not a
-  committed source file; keep it unless your project tracks notes.
+  description, or a scratch file in the global notes directory (see below). It is a thinking artifact,
+  not a committed source file; keep it unless your project tracks notes.
 - **Keep it short and honest.** A few lines per answer, not an essay. Write what's true now; update it
   when you learn more. A note that launders a guess into confidence is worse than none.
 - **Then act.** Only once the note's open questions are resolved (or asked) do you start the work — and
   the skill's own gates confirm you did: Gate A's first box, **Note**, checks this note exists; Gate B
   checks you finished what it planned.
+
+## Where scratch files go
+
+A note written to disk goes in one **global, user-local directory — never inside the repository**.
+A scratch file in the clone shows up in `git status`, is one `git add -A` away from being committed,
+and dies with the clone; the global directory survives branch switches and re-clones. Resolve the
+location in this order:
+
+1. `TALE_AGENT_NOTES_DIR` — an absolute path, if set. The explicit override for power users and CI.
+2. Otherwise the OS default:
+   - **Linux:** `$XDG_DATA_HOME/tale/agent-notes/` (or `~/.local/share/tale/agent-notes/` when
+     `XDG_DATA_HOME` is unset)
+   - **macOS:** `~/Library/Application Support/Tale/agent-notes/`
+   - **Windows:** `%APPDATA%\Tale\agent-notes\`
+
+Inside it, key notes by repository so parallel checkouts stay separated, and date the file:
+`<repo-slug>/<date>-<topic>.md` — e.g. `tale-project-tale/2026-07-06-fix-webhook-retry.md`. Create
+the directories on first use. **Never create a `notes/` directory (or any scratch file) under the
+repo root** — a task/issue comment or the draft PR description remain the alternatives when your
+team should see the note.
 
 ## Why a note, not just a thought
 

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,10 @@ trivy-reports/
 .agents/*
 !.agents/skills/
 
+# Agent scratch notes belong in the global notes directory (see the
+# write-notes skill), never in the clone — ignore repo-root drift.
+/notes/
+
 # ---------------------------------------------------------------------------
 # Built-in configs — the seed catalog (TALE_CONFIG_BUILTIN_DIR), fully tracked
 # ---------------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Tale is a monorepo on Bun workspaces; every workspace script runs through `bun r
 The biggest quality lever is deciding well, not typing fast. Work in this order — each step is a skill; load it:
 
 1. **Classify the task** and follow its discipline end-to-end: a defect → [`fix-bug`](.agents/skills/fix-bug/SKILL.md); structure-not-behaviour → [`make-improvement`](.agents/skills/make-improvement/SKILL.md); new behaviour → [`implement-feature`](.agents/skills/implement-feature/SKILL.md); a review → [`review-code`](.agents/skills/review-code/SKILL.md) / [`review-pr`](.agents/skills/review-pr/SKILL.md). Exploring is read-only and returns the conclusion; a migration is phased and reversible, each phase green.
-2. **Write the note first** ([`write-notes`](.agents/skills/write-notes/SKILL.md)) — answer the active skill's form before any edit.
+2. **Write the note first** ([`write-notes`](.agents/skills/write-notes/SKILL.md)) — answer the active skill's form before any edit; scratch files go in the global notes directory the skill defines, never in the clone.
 3. **Unknowns outside the repo?** Research before deciding ([`deep-research`](.agents/skills/deep-research/SKILL.md)) — questions first, sources in order, evidence in the note.
 4. **Search before you write** ([`search-codebase`](.agents/skills/search-codebase/SKILL.md)) — orient, find the concept to reuse, enumerate the blast radius. The request names one site; the task is the concept.
 5. **UI in scope?** Learn the design system ([`design-ui`](.agents/skills/design-ui/SKILL.md)), then build to it ([`implement-ui`](.agents/skills/implement-ui/SKILL.md)).

--- a/builtin-configs/skills/write-notes/SKILL.md
+++ b/builtin-configs/skills/write-notes/SKILL.md
@@ -29,13 +29,33 @@ understanding changes mid-task. Skip it only for a trivial one-line change in a 
   how you'd catch the mistake. The insight is in what you _don't_ yet know — a note that only sounds
   confident hides the bug it should have surfaced.
 - **Where it goes.** Wherever your team records intent before work — a task/issue comment, the draft PR
-  description, or a scratch `notes/` file in your working area. It is a thinking artifact, not a
-  committed source file; keep it unless your project tracks notes.
+  description, or a scratch file in the global notes directory (see below). It is a thinking artifact,
+  not a committed source file; keep it unless your project tracks notes.
 - **Keep it short and honest.** A few lines per answer, not an essay. Write what's true now; update it
   when you learn more. A note that launders a guess into confidence is worse than none.
 - **Then act.** Only once the note's open questions are resolved (or asked) do you start the work — and
   the skill's own gates confirm you did: Gate A's first box, **Note**, checks this note exists; Gate B
   checks you finished what it planned.
+
+## Where scratch files go
+
+A note written to disk goes in one **global, user-local directory — never inside the repository**.
+A scratch file in the clone shows up in `git status`, is one `git add -A` away from being committed,
+and dies with the clone; the global directory survives branch switches and re-clones. Resolve the
+location in this order:
+
+1. `TALE_AGENT_NOTES_DIR` — an absolute path, if set. The explicit override for power users and CI.
+2. Otherwise the OS default:
+   - **Linux:** `$XDG_DATA_HOME/tale/agent-notes/` (or `~/.local/share/tale/agent-notes/` when
+     `XDG_DATA_HOME` is unset)
+   - **macOS:** `~/Library/Application Support/Tale/agent-notes/`
+   - **Windows:** `%APPDATA%\Tale\agent-notes\`
+
+Inside it, key notes by repository so parallel checkouts stay separated, and date the file:
+`<repo-slug>/<date>-<topic>.md` — e.g. `tale-project-tale/2026-07-06-fix-webhook-retry.md`. Create
+the directories on first use. **Never create a `notes/` directory (or any scratch file) under the
+repo root** — a task/issue comment or the draft PR description remain the alternatives when your
+team should see the note.
 
 ## Why a note, not just a thought
 


### PR DESCRIPTION
## Summary

Implements #2495 — `write-notes` scratch files get a global, user-local home instead of a repo-root `notes/` directory.

- **`builtin-configs/skills/write-notes/SKILL.md`** (source of truth): new **Where scratch files go** section — resolution order `TALE_AGENT_NOTES_DIR` (absolute-path override) → OS default (`$XDG_DATA_HOME/tale/agent-notes/` on Linux, `~/Library/Application Support/Tale/agent-notes/` on macOS, `%APPDATA%\Tale\agent-notes\` on Windows), notes keyed `<repo-slug>/<date>-<topic>.md`, and an explicit never-under-the-repo-root rule. Issue comments / draft PR descriptions stay as alternate surfaces. Projections (`.agents/skills/`, `.claude/skills/`) regenerated with `bun run skills:sync`.
- **`.gitignore`**: ignore repo-root `/notes/` (root-anchored so tracked `docs/*/release-notes/` dirs are unaffected) — belt-and-suspenders against drift.
- **`AGENTS.md`** step 2: one-line pointer to the global location.

Deliberately not added to `.env.example`: no code reads `TALE_AGENT_NOTES_DIR` — it is a skill-text convention, and `.env` files are per-clone, which would defeat the point.

## Verification

- `bun run skills:sync` + `bun run skills:check` — green, no drift.
- `bun run format` — clean.
- macOS spot-check: wrote a note under `~/Library/Application Support/Tale/agent-notes/tale-project-tale/`; `git status` stays clean.
- Gitignore spot-check: `git check-ignore` matches a repo-root `notes/` file via the new `/notes/` rule; `release-notes/` docs remain tracked.

Closes #2495