### PR TITLE
fix(platform): import missing components in providers-list test

### DIFF
--- a/services/platform/app/features/settings/providers/components/providers-list.test.tsx
+++ b/services/platform/app/features/settings/providers/components/providers-list.test.tsx
@@ -94,6 +94,9 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'org-1',
 }));
 
+import { SettingsSection } from '@/app/features/settings/components/settings-section';
+
+import { ProviderDetailDrawer } from './provider-detail-drawer';
 import { ProvidersSettingsSection } from './providers-settings-section';
 
 function renderList(initialDetailProvider?: string) {


### PR DESCRIPTION
Main's typecheck is red since c77c0b38d (#2515): `providers-list.test.tsx` uses `SettingsSection` and `ProviderDetailDrawer` without importing them (TS2304 at lines 159–167). Adds the two missing imports; no behaviour change.

Unblocks typecheck/Lint on main and every open PR based on it.