### PR TITLE
feat(skills): add create-issue workflow skill

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-issue
+description: 'Use this skill whenever you file a GitHub issue — a bug report, an improvement, a feature request, or an epic — and whenever you hit a defect or missing capability that is out of scope for the change at hand. It owns the filing discipline: search open and closed issues for duplicates first (comment and link instead of re-filing), ground the report in observed behaviour with a repro and code pointers, write to the house format (typed title, Problem / Current behaviour / Proposed change / Acceptance criteria), label from the existing label set, cross-link related issues, then file with gh issue create. Load it the moment a task says "file an issue", "create a ticket", "report a bug", "open an issue", or "track this". Never file an ungrounded or duplicate issue — it wastes the triage it was meant to start. To investigate and fix the defect use fix-bug; to land a finished change use create-pr.'
+---
+
+# create-issue
+
+The intake mile: turn a finding into an issue a triager can act on **without re-deriving your
+context**. It mirrors `create-pr` — that skill lands a finished change; this one files work that
+should happen. The failures it exists to catch: a duplicate of an open issue, and a report with no
+repro, no code pointers, and no definition of done.
+
+## When this applies
+
+When asked to file an issue or ticket, and whenever you find a bug, gap, or worthwhile improvement
+that is out of scope for the current task — file it rather than fixing it silently or letting it
+evaporate. To chase and fix the defect yourself, use `fix-bug`; to review a pull request, use
+`review-pr`.
+
+## Write a note first
+
+**Invoke `write-notes`** and answer this form — it seeds the issue body:
+
+- **Finding:** Describe what you observed vs what you expected, with the evidence (commands, output, screenshots).
+- **Duplicates:** Describe what searches you ran over existing issues and what they returned (issue numbers).
+- **Pointers:** Name the files and symbols implicated, from an actual codebase search (`search-codebase`).
+- **Type & done:** Classify it (bug / improvement / feature / epic) and describe what "resolved" verifiably looks like.
+
+## Run the routine in order — each step gates the next
+
+1. **Search before you file.** Query existing issues — `gh issue list --search "<terms>" --state all`
+   — with several phrasings: the user-visible words, the exact error text, the symbol names. An
+   **open** match means you comment your evidence and links there instead of re-filing; a **closed**
+   match gets cross-linked in the new issue (it may be a regression — say so).
+2. **Ground the report.** Observed behaviour with a reproduction or evidence a stranger can follow
+   (exact commands, minimal input, quoted error output); expected behaviour and why you expect it;
+   code pointers from a real search (`search-codebase`), not from memory.
+3. **Write to the house format.** Read the templates (`.github/ISSUE_TEMPLATE/`, contributing docs)
+   and a few recent well-received issues, and match them. Absent a convention, default to: a typed
+   title prefix — `Bug:` / `Improvement:` / `Feature:` / `Epic:` — plus a short scope, and the
+   sections **Problem / Current behaviour / Proposed change / Acceptance criteria** (each criterion
+   a verifiable `- [ ]` item). One problem per issue; a second finding is a second issue,
+   cross-linked.
+4. **Label and cross-link.** Pick labels from the existing label set (`gh label list`) — never
+   invent one, and never guess a milestone or assignee. Cross-link related issues, epics, and PRs by
+   `#number` so the graph stays navigable.
+5. **File it and report back.** `gh issue create --title "..." --body-file -` with a heredoc body
+   (quoting survives; no escaping bugs). Follow the repo's attribution rules — some ban attribution
+   or generated-by lines entirely. Report the issue URL to whoever asked.
+
+## Before you file — tick every box
+
+Tick every box, or N/A with a reason; an unticked box means not ready to file:
+
+- [ ] **Deduplicated** — searched open and closed issues under multiple phrasings; no open duplicate
+      exists, or you commented on it instead of filing.
+- [ ] **Reproducible** — observed behaviour carries a repro or evidence a stranger can follow.
+- [ ] **Expected behaviour stated** — what should happen, and why you expect it.
+- [ ] **Code pointers included** — files/symbols from an actual search, not from memory.
+- [ ] **House format** — typed title, the repo's (or default) sections, verifiable acceptance
+      criteria, one problem per issue.
+- [ ] **Labelled and linked** — labels exist in the repo's label set; related issues/epics/PRs are
+      cross-linked.
+- [ ] **Clean body** — the repo's attribution rules followed; the issue URL reported back.
+
+## Patterns
+
+Don't:
+
+- **File "X is broken" with no repro** — the first triage comment will just ask for one; you had it
+  and threw it away.
+- **Paste a whole log** — quote the failing lines and link or attach the rest.
+- **Bundle several findings into one issue** — they can't be prioritized, assigned, or closed
+  independently.
+- **Skip filing because the fix looks quick** — an unfiled finding outside your scope is a finding
+  lost; file it and stay on task.

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-issue
+description: 'Use this skill whenever you file a GitHub issue — a bug report, an improvement, a feature request, or an epic — and whenever you hit a defect or missing capability that is out of scope for the change at hand. It owns the filing discipline: search open and closed issues for duplicates first (comment and link instead of re-filing), ground the report in observed behaviour with a repro and code pointers, write to the house format (typed title, Problem / Current behaviour / Proposed change / Acceptance criteria), label from the existing label set, cross-link related issues, then file with gh issue create. Load it the moment a task says "file an issue", "create a ticket", "report a bug", "open an issue", or "track this". Never file an ungrounded or duplicate issue — it wastes the triage it was meant to start. To investigate and fix the defect use fix-bug; to land a finished change use create-pr.'
+---
+
+# create-issue
+
+The intake mile: turn a finding into an issue a triager can act on **without re-deriving your
+context**. It mirrors `create-pr` — that skill lands a finished change; this one files work that
+should happen. The failures it exists to catch: a duplicate of an open issue, and a report with no
+repro, no code pointers, and no definition of done.
+
+## When this applies
+
+When asked to file an issue or ticket, and whenever you find a bug, gap, or worthwhile improvement
+that is out of scope for the current task — file it rather than fixing it silently or letting it
+evaporate. To chase and fix the defect yourself, use `fix-bug`; to review a pull request, use
+`review-pr`.
+
+## Write a note first
+
+**Invoke `write-notes`** and answer this form — it seeds the issue body:
+
+- **Finding:** Describe what you observed vs what you expected, with the evidence (commands, output, screenshots).
+- **Duplicates:** Describe what searches you ran over existing issues and what they returned (issue numbers).
+- **Pointers:** Name the files and symbols implicated, from an actual codebase search (`search-codebase`).
+- **Type & done:** Classify it (bug / improvement / feature / epic) and describe what "resolved" verifiably looks like.
+
+## Run the routine in order — each step gates the next
+
+1. **Search before you file.** Query existing issues — `gh issue list --search "<terms>" --state all`
+   — with several phrasings: the user-visible words, the exact error text, the symbol names. An
+   **open** match means you comment your evidence and links there instead of re-filing; a **closed**
+   match gets cross-linked in the new issue (it may be a regression — say so).
+2. **Ground the report.** Observed behaviour with a reproduction or evidence a stranger can follow
+   (exact commands, minimal input, quoted error output); expected behaviour and why you expect it;
+   code pointers from a real search (`search-codebase`), not from memory.
+3. **Write to the house format.** Read the templates (`.github/ISSUE_TEMPLATE/`, contributing docs)
+   and a few recent well-received issues, and match them. Absent a convention, default to: a typed
+   title prefix — `Bug:` / `Improvement:` / `Feature:` / `Epic:` — plus a short scope, and the
+   sections **Problem / Current behaviour / Proposed change / Acceptance criteria** (each criterion
+   a verifiable `- [ ]` item). One problem per issue; a second finding is a second issue,
+   cross-linked.
+4. **Label and cross-link.** Pick labels from the existing label set (`gh label list`) — never
+   invent one, and never guess a milestone or assignee. Cross-link related issues, epics, and PRs by
+   `#number` so the graph stays navigable.
+5. **File it and report back.** `gh issue create --title "..." --body-file -` with a heredoc body
+   (quoting survives; no escaping bugs). Follow the repo's attribution rules — some ban attribution
+   or generated-by lines entirely. Report the issue URL to whoever asked.
+
+## Before you file — tick every box
+
+Tick every box, or N/A with a reason; an unticked box means not ready to file:
+
+- [ ] **Deduplicated** — searched open and closed issues under multiple phrasings; no open duplicate
+      exists, or you commented on it instead of filing.
+- [ ] **Reproducible** — observed behaviour carries a repro or evidence a stranger can follow.
+- [ ] **Expected behaviour stated** — what should happen, and why you expect it.
+- [ ] **Code pointers included** — files/symbols from an actual search, not from memory.
+- [ ] **House format** — typed title, the repo's (or default) sections, verifiable acceptance
+      criteria, one problem per issue.
+- [ ] **Labelled and linked** — labels exist in the repo's label set; related issues/epics/PRs are
+      cross-linked.
+- [ ] **Clean body** — the repo's attribution rules followed; the issue URL reported back.
+
+## Patterns
+
+Don't:
+
+- **File "X is broken" with no repro** — the first triage comment will just ask for one; you had it
+  and threw it away.
+- **Paste a whole log** — quote the failing lines and link or attach the rest.
+- **Bundle several findings into one issue** — they can't be prioritized, assigned, or closed
+  independently.
+- **Skip filing because the fix looks quick** — an unfiled finding outside your scope is a finding
+  lost; file it and stay on task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ skills (`pptx`, …) and the workspace skills under [`skills/`](skills/) are pro
 | [`review-code`](.agents/skills/review-code/SKILL.md)               | reviewing a working diff — yours or a colleague's — before it merges                              |
 | [`review-pr`](.agents/skills/review-pr/SKILL.md)                   | reviewing a GitHub pull request end-to-end                                                        |
 | [`create-pr`](.agents/skills/create-pr/SKILL.md)                   | taking a finished change to a clean, mergeable PR (gate + ripple + commit)                        |
+| [`create-issue`](.agents/skills/create-issue/SKILL.md)             | filing a GitHub issue — dedupe first, grounded repro + code pointers, house format, labels        |
 | [`test-code`](.agents/skills/test-code/SKILL.md)                   | writing tests, or proving behaviour by observing the real outcome                                 |
 | [`write-skill`](.agents/skills/write-skill/SKILL.md)               | adding, editing, or moving a skill                                                                |
 | [`write-docs`](.agents/skills/write-docs/SKILL.md)                 | writing/editing a docs page, or running the docs test suite                                       |

--- a/builtin-configs/skills/create-issue/SKILL.md
+++ b/builtin-configs/skills/create-issue/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-issue
+description: 'Use this skill whenever you file a GitHub issue — a bug report, an improvement, a feature request, or an epic — and whenever you hit a defect or missing capability that is out of scope for the change at hand. It owns the filing discipline: search open and closed issues for duplicates first (comment and link instead of re-filing), ground the report in observed behaviour with a repro and code pointers, write to the house format (typed title, Problem / Current behaviour / Proposed change / Acceptance criteria), label from the existing label set, cross-link related issues, then file with gh issue create. Load it the moment a task says "file an issue", "create a ticket", "report a bug", "open an issue", or "track this". Never file an ungrounded or duplicate issue — it wastes the triage it was meant to start. To investigate and fix the defect use fix-bug; to land a finished change use create-pr.'
+---
+
+# create-issue
+
+The intake mile: turn a finding into an issue a triager can act on **without re-deriving your
+context**. It mirrors `create-pr` — that skill lands a finished change; this one files work that
+should happen. The failures it exists to catch: a duplicate of an open issue, and a report with no
+repro, no code pointers, and no definition of done.
+
+## When this applies
+
+When asked to file an issue or ticket, and whenever you find a bug, gap, or worthwhile improvement
+that is out of scope for the current task — file it rather than fixing it silently or letting it
+evaporate. To chase and fix the defect yourself, use `fix-bug`; to review a pull request, use
+`review-pr`.
+
+## Write a note first
+
+**Invoke `write-notes`** and answer this form — it seeds the issue body:
+
+- **Finding:** Describe what you observed vs what you expected, with the evidence (commands, output, screenshots).
+- **Duplicates:** Describe what searches you ran over existing issues and what they returned (issue numbers).
+- **Pointers:** Name the files and symbols implicated, from an actual codebase search (`search-codebase`).
+- **Type & done:** Classify it (bug / improvement / feature / epic) and describe what "resolved" verifiably looks like.
+
+## Run the routine in order — each step gates the next
+
+1. **Search before you file.** Query existing issues — `gh issue list --search "<terms>" --state all`
+   — with several phrasings: the user-visible words, the exact error text, the symbol names. An
+   **open** match means you comment your evidence and links there instead of re-filing; a **closed**
+   match gets cross-linked in the new issue (it may be a regression — say so).
+2. **Ground the report.** Observed behaviour with a reproduction or evidence a stranger can follow
+   (exact commands, minimal input, quoted error output); expected behaviour and why you expect it;
+   code pointers from a real search (`search-codebase`), not from memory.
+3. **Write to the house format.** Read the templates (`.github/ISSUE_TEMPLATE/`, contributing docs)
+   and a few recent well-received issues, and match them. Absent a convention, default to: a typed
+   title prefix — `Bug:` / `Improvement:` / `Feature:` / `Epic:` — plus a short scope, and the
+   sections **Problem / Current behaviour / Proposed change / Acceptance criteria** (each criterion
+   a verifiable `- [ ]` item). One problem per issue; a second finding is a second issue,
+   cross-linked.
+4. **Label and cross-link.** Pick labels from the existing label set (`gh label list`) — never
+   invent one, and never guess a milestone or assignee. Cross-link related issues, epics, and PRs by
+   `#number` so the graph stays navigable.
+5. **File it and report back.** `gh issue create --title "..." --body-file -` with a heredoc body
+   (quoting survives; no escaping bugs). Follow the repo's attribution rules — some ban attribution
+   or generated-by lines entirely. Report the issue URL to whoever asked.
+
+## Before you file — tick every box
+
+Tick every box, or N/A with a reason; an unticked box means not ready to file:
+
+- [ ] **Deduplicated** — searched open and closed issues under multiple phrasings; no open duplicate
+      exists, or you commented on it instead of filing.
+- [ ] **Reproducible** — observed behaviour carries a repro or evidence a stranger can follow.
+- [ ] **Expected behaviour stated** — what should happen, and why you expect it.
+- [ ] **Code pointers included** — files/symbols from an actual search, not from memory.
+- [ ] **House format** — typed title, the repo's (or default) sections, verifiable acceptance
+      criteria, one problem per issue.
+- [ ] **Labelled and linked** — labels exist in the repo's label set; related issues/epics/PRs are
+      cross-linked.
+- [ ] **Clean body** — the repo's attribution rules followed; the issue URL reported back.
+
+## Patterns
+
+Don't:
+
+- **File "X is broken" with no repro** — the first triage comment will just ask for one; you had it
+  and threw it away.
+- **Paste a whole log** — quote the failing lines and link or attach the rest.
+- **Bundle several findings into one issue** — they can't be prioritized, assigned, or closed
+  independently.
+- **Skip filing because the fix looks quick** — an unfiled finding outside your scope is a finding
+  lost; file it and stay on task.

--- a/services/platform/convex/lib/skills/guidance.test.ts
+++ b/services/platform/convex/lib/skills/guidance.test.ts
@@ -107,8 +107,9 @@ describe('buildSkillsGuidance', () => {
     expect(out).not.toContain('bun run');
     expect(out).not.toContain('.agents/');
     expect(out).not.toContain('builtin-configs');
-    // Staged but deliberately not a numbered step.
+    // Staged but deliberately not numbered steps.
     expect(out).not.toContain('review-pr');
+    expect(out).not.toContain('create-issue');
   });
 
   it('uses runtime-neutral skill invocation wording', () => {

--- a/services/platform/convex/lib/skills/guidance.ts
+++ b/services/platform/convex/lib/skills/guidance.ts
@@ -14,9 +14,10 @@ export const SKILLS_GUIDANCE_HEADING = '## Working with skills';
 /**
  * The workflow skills stageable into a session, in guidance order. This is
  * the staging allowlist for workflow_skills.ts; every entry must exist under
- * builtin-configs/skills/<name>/ (guarded by guidance.test.ts). review-pr is
- * staged but not a numbered step — reviewing someone else's PR is not part of
- * the do-work loop the guidance encodes.
+ * builtin-configs/skills/<name>/ (guarded by guidance.test.ts). review-pr and
+ * create-issue are staged but not numbered steps — reviewing someone else's PR
+ * and filing an issue are situational, not part of the do-work loop the
+ * guidance encodes.
  */
 export const WORKFLOW_SKILL_NAMES: readonly string[] = [
   'write-notes',
@@ -32,6 +33,7 @@ export const WORKFLOW_SKILL_NAMES: readonly string[] = [
   'review-code',
   'review-pr',
   'create-pr',
+  'create-issue',
   'test-code',
 ];
 

--- a/tools/skills/src/sync.ts
+++ b/tools/skills/src/sync.ts
@@ -78,6 +78,7 @@ const WORKFLOW_SKILLS: readonly string[] = [
   'fix-bug',
   'review-code',
   'create-pr',
+  'create-issue',
   'review-pr',
   'test-code',
   'write-notes',


### PR DESCRIPTION
Closes #2392

## What

Adds the `create-issue` workflow skill — filing a well-formed GitHub issue as a first-class workflow, mirroring `create-pr` on the intake side:

1. **Dedupe first** — search open and closed issues under multiple phrasings; comment/link on an open match instead of re-filing.
2. **Ground the report** — observed behaviour with a repro a stranger can follow, expected behaviour with why, code pointers from an actual codebase search.
3. **House format** — read the repo's templates/conventions; absent them, default to the typed title prefix (`Bug:` / `Improvement:` / `Feature:` / `Epic:`) and Problem / Current behaviour / Proposed change / Acceptance criteria sections; labels only from the existing label set; cross-links by `#number`.
4. **`gh issue create` mechanics** — heredoc body, the repo's attribution rules, report the URL back.

Plus a `write-notes` form, a true `- [ ]` before-you-file gate, and anti-patterns. Kept generic and portable (no repo paths; siblings referenced by slug) per the workflow-skill contract.

## Where it lives

- Source of truth: `builtin-configs/skills/create-issue/SKILL.md` (scaffolded with `bun run gen skill`; no README, matching every sibling workflow skill).
- `WORKFLOW_SKILLS` in `tools/skills/src/sync.ts` → projected into `.agents/skills/create-issue/` and mirrored to `.claude/skills/create-issue/` via `bun run skills:sync`.
- Indexed in the AGENTS.md skills table (after `create-pr`).
- Staged into product sessions via `WORKFLOW_SKILL_NAMES` in `services/platform/convex/lib/skills/guidance.ts` — like `review-pr`, staged but deliberately not a numbered guidance step (guard extended in `guidance.test.ts`).

## Definition of done

- [x] Green gate — `bun run skills:check` OK; `bun run format` clean; oxlint 0 findings on touched files; `vitest` on `guidance.test.ts` + `workflow_skills.test.ts`: 21/21 passed. Platform typecheck has 3 pre-existing `TS2304` errors in `app/features/settings/providers/components/providers-list.test.tsx` — verified identical on clean `origin/main`, unrelated to this change.
- [x] Security gate — pre-commit SAST ran, 0 findings.
- [x] Tests — `WORKFLOW_SKILL_NAMES` guard covers the new entry (must exist under `builtin-configs/skills/`); non-step assertion extended for `create-issue`.
- [ ] Migration — N/A (no data-model or org-config schema change).
- [ ] Locales — N/A (skills are English-source agent guides, not localized UI strings).
- [ ] Docs — N/A beyond AGENTS.md index row (skills are self-documenting; no docs/ page references the skill list).
- [ ] Accessibility — N/A (no UI).
- [x] Sweep — registries enumerated: `WORKFLOW_SKILLS` (sync.ts), AGENTS.md index, `WORKFLOW_SKILL_NAMES` (guidance.ts) all updated; `tools/cli/src/generated/embedded-files.ts` is regenerated at build time (precedent: #2326 added four workflow skills without touching it).
- [x] Observed — `skills:sync` projection verified byte-identical across all three homes (`diff -r`).
- [x] Commits — one atomic conventional commit, branched off `main`, no attribution lines.