### PR TITLE
fix(platform): repair main regressions from #2515

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -298,7 +298,9 @@ describe('DataTable loading states', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not render a toolbar row for action-only headers', () => {
+    it('keeps the primary action reachable on action-only headers', () => {
+      // Regression: hiding the toolbar for action-only tables removed the only
+      // create affordance from token sources / API keys / teams / triggers.
       render(
         <DataTable
           columns={columns}
@@ -310,8 +312,8 @@ describe('DataTable loading states', () => {
       );
 
       expect(
-        screen.queryByRole('button', { name: 'Add Item' }),
-      ).not.toBeInTheDocument();
+        screen.getByRole('button', { name: 'Add Item' }),
+      ).toBeInTheDocument();
     });
 
     it('renders table border container during loading', () => {

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -550,10 +550,13 @@ export function DataTable<TData, TValue = unknown>({
     !!dateRange ||
     !!filtersContent;
 
-  // Only render the toolbar row when there is search/filter chrome. A lone
-  // primary action without chrome belongs on SettingsSection.action — otherwise
-  // the button sits in an empty row between the section title and the table.
-  const hasHeader = hasToolbarChrome;
+  // Render the toolbar row when there is search/filter chrome — or when the
+  // caller passed a primary action with nowhere else to live. A lone primary
+  // action ideally belongs on SettingsSection.action, but hiding the toolbar
+  // for action-only tables silently removes their only create affordance
+  // (token sources, API keys, teams, automation triggers); hide it only once
+  // a table has been migrated off `addAction`/`actionMenu`.
+  const hasHeader = hasToolbarChrome || !!primaryAction;
 
   // Build the header content
   const headerContent = hasHeader ? (

--- a/services/platform/app/features/agents/components/agent-catalog.test.tsx
+++ b/services/platform/app/features/agents/components/agent-catalog.test.tsx
@@ -138,11 +138,12 @@ describe('AgentCatalog', () => {
     expect(screen.getByText('noResults.title')).toBeInTheDocument();
   });
 
-  it('shows no status badge for a not-yet-installed agent', () => {
+  it('exposes only the sr-only "available" status for a not-yet-installed agent', () => {
     render(<AgentCatalog organizationId="org-1" />);
     expect(screen.queryByText('status.enabled')).not.toBeInTheDocument();
     expect(screen.queryByText('status.disabled')).not.toBeInTheDocument();
-    expect(screen.queryByText('status.available')).not.toBeInTheDocument();
+    // The icon's status dot is decorative; its text twin is sr-only.
+    expect(screen.getByText('status.available')).toHaveClass('sr-only');
     expect(screen.getByRole('button', { name: 'install' })).toBeInTheDocument();
   });
 

--- a/services/platform/app/features/agents/utils/resolve-agent-catalog-icon.ts
+++ b/services/platform/app/features/agents/utils/resolve-agent-catalog-icon.ts
@@ -99,7 +99,7 @@ export function resolveAgentCatalogIcon(agent: {
 
 /** Slug identifies the Claude Code chat product — not every claude-code runtime. */
 function isClaudeCodeProductSlug(slug: string): boolean {
-  const base = slug.includes('/') ? slug.split('/').pop()! : slug;
+  const base = slug.split('/').pop() ?? slug;
   return base === 'claude-code' || base.startsWith('claude-code-');
 }
 

--- a/services/platform/lib/i18n/keys-dynamic.txt
+++ b/services/platform/lib/i18n/keys-dynamic.txt
@@ -288,3 +288,10 @@ jobCard.statusCancelled
 # handlers but under a namespace the client-source scanner can't resolve.
 auth.sso.errors.serverError
 auth.sso.errors.multipleConnections
+
+# Skill load-error detail titles: skill-load-error.ts maps machine error codes
+# (yaml_syntax, not_found, …) to `skills.loadErrorDetail.title.*` /
+# `skills.notFound` keys in a plain object, resolved later via the `settings`
+# scope — an enum-driven dispatch the regex scanner can't follow.
+settings.skills.loadErrorDetail
+settings.skills.notFound

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -232,7 +232,6 @@
       "colStatus": "Status",
       "colStarted": "Gestartet",
       "watchLive": "Live ansehen",
-      "backToApp": "Zurück zur App",
       "queuedForCapacity": "Wartet auf Kapazität",
       "queuedForCapacityHint": "Wartet auf einen freien Sandbox-Platz. Startet automatisch, sobald Kapazität frei wird.",
       "failed": "Fehlgeschlagen",
@@ -5767,21 +5766,7 @@
       },
       "columns": {
         "name": "Skill",
-        "description": "Beschreibung",
-        "loadError": "SKILL.md konnte nicht gelesen werden"
-      },
-      "loadError": {
-        "yamlSyntaxLine": "YAML-Syntaxfehler (Zeile {line})",
-        "yamlSyntax": "YAML-Syntaxfehler im Frontmatter",
-        "missingFrontmatter": "YAML-Frontmatter fehlt",
-        "unclosedFrontmatter": "YAML-Frontmatter nicht geschlossen",
-        "frontmatterTooLarge": "Frontmatter zu groß",
-        "invalidFrontmatter": "Ungültiges Frontmatter",
-        "emptyFrontmatter": "Leeres Frontmatter",
-        "notFound": "SKILL.md nicht gefunden",
-        "symlink": "SKILL.md ist ein Symlink",
-        "inaccessible": "SKILL.md konnte nicht gelesen werden",
-        "generic": "SKILL.md konnte nicht gelesen werden"
+        "description": "Beschreibung"
       },
       "loadErrorDetail": {
         "fixHint": "Ersetze das Bundle durch ein gültiges Zip oder lösche den Skill.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -69,9 +69,6 @@
       "requiresTitle": "What you'll need",
       "requiresHint": "You'll connect these during setup."
     },
-    "addMenu": {
-      "label": "Add app"
-    },
     "install": {
       "install": "Install",
       "installed": "Installed",
@@ -235,7 +232,6 @@
       "colStatus": "Status",
       "colStarted": "Started",
       "watchLive": "Watch live",
-      "backToApp": "Back to app",
       "queuedForCapacity": "Queued for capacity",
       "queuedForCapacityHint": "Waiting for a free sandbox slot. Starts automatically once capacity frees up.",
       "failed": "Failed",
@@ -6034,21 +6030,7 @@
       },
       "columns": {
         "name": "Skill",
-        "description": "Description",
-        "loadError": "Failed to read SKILL.md"
-      },
-      "loadError": {
-        "yamlSyntaxLine": "YAML syntax error (line {line})",
-        "yamlSyntax": "YAML syntax error in frontmatter",
-        "missingFrontmatter": "Missing YAML frontmatter",
-        "unclosedFrontmatter": "Unclosed YAML frontmatter",
-        "frontmatterTooLarge": "Frontmatter too large",
-        "invalidFrontmatter": "Invalid frontmatter",
-        "emptyFrontmatter": "Empty frontmatter",
-        "notFound": "SKILL.md not found",
-        "symlink": "SKILL.md is a symlink",
-        "inaccessible": "Couldn't read SKILL.md",
-        "generic": "Failed to read SKILL.md"
+        "description": "Description"
       },
       "loadErrorDetail": {
         "fixHint": "Replace the bundle with a valid zip, or delete this skill.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5767,21 +5767,7 @@
       },
       "columns": {
         "name": "Skill",
-        "description": "Description",
-        "loadError": "Impossible de lire SKILL.md"
-      },
-      "loadError": {
-        "yamlSyntaxLine": "Erreur de syntaxe YAML (ligne {line})",
-        "yamlSyntax": "Erreur de syntaxe YAML dans le frontmatter",
-        "missingFrontmatter": "Frontmatter YAML manquant",
-        "unclosedFrontmatter": "Frontmatter YAML non fermé",
-        "frontmatterTooLarge": "Frontmatter trop volumineux",
-        "invalidFrontmatter": "Frontmatter invalide",
-        "emptyFrontmatter": "Frontmatter vide",
-        "notFound": "SKILL.md introuvable",
-        "symlink": "SKILL.md est un lien symbolique",
-        "inaccessible": "Impossible de lire SKILL.md",
-        "generic": "Impossible de lire SKILL.md"
+        "description": "Description"
       },
       "loadErrorDetail": {
         "fixHint": "Remplace le bundle par un zip valide, ou supprime ce skill.",


### PR DESCRIPTION
Main has been red (Lint, Unit, UI, and two Playwright shards) since #2515 landed. Three independent regressions, one commit each:

1. **Action-only tables lost their create button** — #2515 gated the DataTable toolbar on search/filter chrome, but six tables pass their add button via `actionMenu`/`addAction` with no chrome: token sources, API keys, teams, and the three automation trigger sections (schedules/events/webhooks). Their only create affordance silently disappeared — this is what the failing `token-sources.spec.ts` and `automation-editor.spec.ts` (webhook trigger) e2e specs click. The toolbar now also renders when a primary action is present; pages already swept onto `SettingsSection.action` (AI providers) are unaffected. Follow-up: migrate the six tables onto section-header actions, then re-tighten the gate.
2. **Lint**: non-null assertion in `resolve-agent-catalog-icon.ts` (`no-non-null-assertion`); replaced with `?? slug`.
3. **Unit (i18n usage test)**: `skill-load-error.ts` maps error codes to `settings.skills.loadErrorDetail.*` / `settings.skills.notFound` dynamically — added the prefixes to `keys-dynamic.txt`; removed the now-dead `settings.skills.loadError.*` / `settings.skills.columns.loadError` keys from en/de/fr. Also updated the stale agent-catalog test that predated #2515's sr-only status label.

Verified locally: `bun run lint` clean (20/20), platform typecheck clean, unit 74 792/74 792, UI 3 113/3 113.