### PR TITLE
fix(platform): count folder members, not rows, in list footers (#2348)

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -165,8 +165,14 @@ export interface DataTableProps<TData, TValue = unknown> {
     threshold?: number;
     /** Lowercase plural entity label (e.g., "websites"). Enables "Showing all X {entity}" footer. */
     entityLabel?: string;
-    /** Unfiltered total count. When different from data.length, shows "Showing X of Y {entity}". */
+    /** Unfiltered total count. When different from the shown count, shows "Showing X of Y {entity}". */
     totalCount?: number;
+    /**
+     * Entities the visible rows represent, when a row can aggregate several —
+     * a folder row stands in for its members, so the footer must count the
+     * entities behind it, not the row itself (#2348). Defaults to data.length.
+     */
+    displayedCount?: number;
   };
   /**
    * Approximate row count for the skeleton display.
@@ -1143,19 +1149,25 @@ export function DataTable<TData, TValue = unknown>({
     </div>
   );
 
+  // A row can aggregate several entities (a folder row stands in for its
+  // members), so the count shown must be the entities behind the visible rows,
+  // not the row count itself (#2348).
+  const shownEntityCount = infiniteScroll
+    ? (infiniteScroll.displayedCount ?? data.length)
+    : 0;
   const entityCountFooter = infiniteScroll &&
     infiniteScroll.entityLabel &&
     data.length > 0 && (
       <output className="bg-background border-border text-muted-foreground sticky bottom-0 z-10 block px-3 py-3 text-left text-xs">
         {infiniteScroll.totalCount !== undefined &&
-        infiniteScroll.totalCount !== data.length
+        infiniteScroll.totalCount !== shownEntityCount
           ? t('pagination.showingFiltered', {
-              filtered: data.length,
+              filtered: shownEntityCount,
               total: infiniteScroll.totalCount,
               entity: infiniteScroll.entityLabel,
             })
           : t('pagination.showingAll', {
-              count: data.length,
+              count: shownEntityCount,
               entity: infiniteScroll.entityLabel,
             })}
       </output>

--- a/services/platform/app/features/agents/components/agent-catalog.tsx
+++ b/services/platform/app/features/agents/components/agent-catalog.tsx
@@ -43,6 +43,7 @@ import {
   agentRequiredIntegrations,
   toConfigurableAgent,
 } from '../utils/agent-list-item';
+import { folderLabel } from '../utils/folder-label';
 import { AgentCatalogIcon } from './agent-catalog-icon';
 
 interface AgentCatalogProps {
@@ -78,21 +79,6 @@ type InstallStateRow = NonNullable<
 
 /** Number of placeholder cards rendered while the catalog roster loads. */
 const PLACEHOLDER_CARD_COUNT = 6;
-
-/**
- * Localized title for a folder section. Known folders have dedicated keys
- * (`agentCatalog.folders.workforce` …); unknown folders fall back to a
- * capitalized form of the raw value so a new department still renders a sane
- * label even before a translation exists. `defaultValue` keeps i18next from
- * surfacing a raw key while the localized string lands.
- */
-function folderLabel(t: TFunction, folder: string): string {
-  const fallback = folder
-    ? folder.charAt(0).toUpperCase() + folder.slice(1)
-    : t('folders.general', { defaultValue: 'General' });
-  if (!folder) return fallback;
-  return t(`folders.${folder}`, { defaultValue: fallback });
-}
 
 export function AgentCatalog({ organizationId }: AgentCatalogProps) {
   const { t } = useT('agentCatalog');

--- a/services/platform/app/features/agents/components/agents-table.test.tsx
+++ b/services/platform/app/features/agents/components/agents-table.test.tsx
@@ -1,23 +1,21 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
 
-vi.mock('@/lib/i18n/client', () => ({
-  useT: (ns: string) => ({
-    t: (key: string, params?: Record<string, string>) => {
-      if (params) {
-        return Object.entries(params).reduce(
-          (acc, [k, v]) => acc.replace(`{${k}}`, v),
-          `${ns}.${key}`,
-        );
-      }
-      return `${ns}.${key}`;
-    },
-  }),
-}));
+interface MockAgent {
+  name: string;
+  displayName: string;
+  folder?: string;
+}
+
+const mockAgents: { current: MockAgent[] } = { current: [] };
+const mockInstalls: {
+  current: { agentSlug: string; enabled: boolean }[];
+} = { current: [] };
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
@@ -51,21 +49,17 @@ vi.mock('@/app/components/branding/branding-provider', () => ({
 }));
 
 vi.mock('../hooks/queries', () => ({
-  useListAgents: () => ({ agents: [], isLoading: false }),
-  useAgentInstallations: () => ({ data: [], isLoading: false }),
+  useListAgents: () => ({ agents: mockAgents.current, isLoading: false }),
+  useAgentInstallations: () => ({
+    data: mockInstalls.current,
+    isLoading: false,
+  }),
 }));
 
 vi.mock('../hooks/mutations', () => ({
   useDeleteAgent: () => ({ mutateAsync: vi.fn() }),
-}));
-
-vi.mock('../hooks/use-agents-table-config', () => ({
-  useAgentsTableConfig: () => ({
-    columns: [],
-    searchPlaceholder: 'Search agents',
-    stickyLayout: undefined,
-    pageSize: 10,
-  }),
+  useDuplicateAgent: () => ({ mutateAsync: vi.fn() }),
+  useInstallCatalogAgent: () => ({ mutateAsync: vi.fn() }),
 }));
 
 vi.mock('./agents-action-menu', () => ({
@@ -74,7 +68,22 @@ vi.mock('./agents-action-menu', () => ({
 
 import { AgentsTable } from './agents-table';
 
+function setAgents(agents: MockAgent[]) {
+  mockAgents.current = agents;
+  mockInstalls.current = agents.map((a) => ({
+    agentSlug: a.name,
+    enabled: true,
+  }));
+}
+
 describe('AgentsTable', () => {
+  beforeEach(() => {
+    setAgents([
+      { name: 'assistant', displayName: 'Assistant', folder: 'chat' },
+      { name: 'researcher', displayName: 'Researcher', folder: 'chat' },
+    ]);
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(
@@ -89,7 +98,41 @@ describe('AgentsTable', () => {
       );
       const caption = container.querySelector('caption');
       expect(caption).not.toBeNull();
-      expect(caption).toHaveTextContent('settings.agents.tableCaption');
+      expect(caption).toHaveTextContent('Installed agents');
+    });
+  });
+
+  describe('folder rows (#2348)', () => {
+    // Regression for #2348: a folder row aggregates its member agents, so the
+    // footer must count agents (the entity the label names), never the folder
+    // row itself ("Showing all 1 agents" for one folder holding two agents).
+    it('counts agents, not folder rows, in the footer', () => {
+      render(<AgentsTable organizationId="test-org-id" />);
+
+      expect(screen.getByText('Showing all 2 agents')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Showing all 1 agents'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Regression for #2348: the Name cell showed the raw lowercase path
+    // segment ("chat") while the catalog shows the localized folder label.
+    it('shows the localized folder label, not the raw segment', () => {
+      render(<AgentsTable organizationId="test-org-id" />);
+
+      expect(screen.getByText('Chat')).toBeInTheDocument();
+      expect(screen.queryByText('chat')).not.toBeInTheDocument();
+    });
+
+    it('counts every row when nothing is grouped', () => {
+      setAgents([
+        { name: 'alpha', displayName: 'Alpha' },
+        { name: 'beta', displayName: 'Beta' },
+      ]);
+
+      render(<AgentsTable organizationId="test-org-id" />);
+
+      expect(screen.getByText('Showing all 2 agents')).toBeInTheDocument();
     });
   });
 });

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -284,6 +284,10 @@ export function AgentsTable({
     },
     getRowId: (row) => (row.type === 'agent' ? row.name : `folder:${row.path}`),
     entityLabel: tSettings('agents.entityLabel'),
+    // The footer counts agents, and a folder row stands in for every agent
+    // nested under it — counting rows would count the folder itself as one
+    // agent while hiding its members (#2348).
+    countRow: (row) => (row.type === 'folder' ? row.agentCount : 1),
   });
 
   return (

--- a/services/platform/app/features/agents/hooks/use-agents-table-config.tsx
+++ b/services/platform/app/features/agents/hooks/use-agents-table-config.tsx
@@ -17,6 +17,7 @@ import { stripModelRefQualifier } from '@/lib/shared/utils/model-ref';
 
 import { AgentRowActions } from '../components/agent-row-actions';
 import type { AgentTableItem } from '../components/agents-table';
+import { folderLabel } from '../utils/folder-label';
 
 interface AgentsTableConfig {
   columns: ColumnDef<AgentTableItem>[];
@@ -45,6 +46,10 @@ export function useAgentsTableConfig({
   showFolderPath = false,
 }: AgentsTableConfigOptions): AgentsTableConfig {
   const { t } = useT('settings');
+  // Folder rows show the same localized display name as the catalog's folder
+  // sections, never the raw path segment (#2348).
+  const { t: tCatalog } = useT('agentCatalog');
+  const { t: tTables } = useT('tables');
 
   const columns = useMemo<ColumnDef<AgentTableItem>[]>(
     () => [
@@ -68,7 +73,7 @@ export function useAgentsTableConfig({
                   <Folder className="text-muted-foreground size-4 shrink-0" />
                 )}
                 <Text as="span" variant="label" truncate>
-                  {row.original.name}
+                  {folderLabel(tCatalog, row.original.name)}
                 </Text>
                 {isApp && <Badge variant="slate">{t('agents.appBadge')}</Badge>}
                 <Badge variant="outline">{row.original.agentCount}</Badge>
@@ -128,7 +133,11 @@ export function useAgentsTableConfig({
       },
       {
         id: 'actions',
-        header: '',
+        // sr-only label, matching `createActionsColumn` — an empty header cell
+        // fails the axe `empty-table-header` audit.
+        header: () => (
+          <span className="sr-only">{tTables('headers.actions')}</span>
+        ),
         // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns with
         // every other table's actions column.
         size: ACTIONS_COLUMN_SIZE,
@@ -149,7 +158,15 @@ export function useAgentsTableConfig({
         },
       },
     ],
-    [t, organizationId, onDuplicated, onDeleted, showFolderPath],
+    [
+      t,
+      tCatalog,
+      tTables,
+      organizationId,
+      onDuplicated,
+      onDeleted,
+      showFolderPath,
+    ],
   );
 
   return {

--- a/services/platform/app/features/agents/utils/folder-label.ts
+++ b/services/platform/app/features/agents/utils/folder-label.ts
@@ -1,0 +1,19 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * Localized display name for an agent folder. Known folders have dedicated
+ * keys (`agentCatalog.folders.workforce` …); unknown folders fall back to a
+ * capitalized form of the raw value so a new department still renders a sane
+ * label even before a translation exists. `defaultValue` keeps i18next from
+ * surfacing a raw key while the localized string lands. Shared by the catalog
+ * sections, the agents list's folder rows, and the folder breadcrumb so the
+ * same folder never reads as a raw slug in one place and a name in another
+ * (#2348). `t` must be bound to the `agentCatalog` namespace.
+ */
+export function folderLabel(t: TFunction, folder: string): string {
+  const fallback = folder
+    ? folder.charAt(0).toUpperCase() + folder.slice(1)
+    : t('folders.general', { defaultValue: 'General' });
+  if (!folder) return fallback;
+  return t(`folders.${folder}`, { defaultValue: fallback });
+}

--- a/services/platform/app/features/automations/components/automations-table.test.tsx
+++ b/services/platform/app/features/automations/components/automations-table.test.tsx
@@ -103,10 +103,12 @@ describe('AutomationsTable', () => {
   });
 
   describe('count footer', () => {
-    // Regression for #2094: a folder collapses its child workflows into one
-    // row, so the footer must not count those hidden children against the
-    // visible folder rows ("Showing 1 of 15 automations").
-    it('counts visible rows, not grouped child workflows, in the folder view', () => {
+    // Regression for #2094 + #2348: a folder collapses its child workflows
+    // into one row. The footer counts automations — the unit the entity label
+    // names — so it must neither mix units ("Showing 1 of 15 automations",
+    // #2094) nor count the folder row itself as one automation ("Showing all
+    // 1 automations", the sibling class fixed for agents in #2348).
+    it('counts grouped workflows, not folder rows, in the folder view', () => {
       mockWorkflows.current = Array.from({ length: 15 }, (_, i) => ({
         slug: `projects/workflow-${i}`,
         name: `Workflow ${i}`,
@@ -117,9 +119,14 @@ describe('AutomationsTable', () => {
       render(<AutomationsTable organizationId="test-org-id" />);
 
       // One folder row ("projects") stands in for all 15 child workflows.
-      expect(screen.getByText('Showing all 1 automations')).toBeInTheDocument();
+      expect(
+        screen.getByText('Showing all 15 automations'),
+      ).toBeInTheDocument();
       expect(
         screen.queryByText('Showing 1 of 15 automations'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Showing all 1 automations'),
       ).not.toBeInTheDocument();
     });
 

--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -388,19 +388,19 @@ export function AutomationsTable({
           hasMore: false,
           onLoadMore: () => {},
           entityLabel: tAutomations('entityLabel'),
-          // The footer reads "Showing {data.length} of {totalCount}", so both
-          // must count the same unit as the rows on screen. While searching the
-          // list is flat — every row is a workflow — so the denominator is the
-          // full workflow universe ("Showing 5 of 15 automations"). In the
-          // folder view rows are folders + direct workflows (a grouped folder
-          // hides its 15 children behind one row); there's no paged-away subset
-          // (hasMore is false), so the total is the visible row count and the
-          // footer reads "Showing all N automations" instead of mixing units
-          // ("Showing 1 of 15 automations" counted folder rows against child
-          // workflows).
+          // The footer counts automations, never rows (#2094, #2348). While
+          // searching the list is flat — every row is a workflow — so the
+          // shown count is the row count and the denominator is the full
+          // workflow universe ("Showing 5 of 15 automations"). In the folder
+          // view a folder row stands in for every workflow nested under it,
+          // so both counts are the scoped workflow universe (nothing is paged
+          // away — hasMore is false) and the footer reads "Showing all N
+          // automations" in the unit the entity label names, instead of
+          // counting the folder row itself as one automation.
           totalCount: isSearching
             ? (validWorkflows?.length ?? 0)
-            : tableItems.length,
+            : scopedWorkflows.length,
+          displayedCount: isSearching ? undefined : scopedWorkflows.length,
         }}
         emptyState={
           searchQuery

--- a/services/platform/app/hooks/use-list-page.ts
+++ b/services/platform/app/hooks/use-list-page.ts
@@ -79,6 +79,13 @@ interface UseListPageOptions<TData> {
   /** Lowercase plural entity label (e.g., "websites"). Enables "Showing all X {entity}" footer. */
   entityLabel?: string;
   /**
+   * Entities a row represents in the footer count. A folder row aggregates
+   * its members, so counting rows would count the folder as one entity
+   * (#2348). Defaults to 1 per row; only affects the infinite-scroll entity
+   * footer.
+   */
+  countRow?: (row: TData) => number;
+  /**
    * Display mode for the table.
    * - `'infiniteScroll'` (default): renders an infinite-scroll list that loads more as the user scrolls.
    * - `'pagination'`: renders client-side pagination controls with next/previous navigation.
@@ -102,8 +109,10 @@ interface ListPageInfiniteScrollTableProps<TData> {
     isLoadingMore: boolean;
     isInitialLoading: boolean;
     entityLabel?: string;
-    /** Unfiltered total from rawData.length — differs from data.length when filters are active */
+    /** Unfiltered total from rawData — differs from the shown count when filters are active */
     totalCount?: number;
+    /** Entities the visible rows represent when rows aggregate (see `countRow`) */
+    displayedCount?: number;
   };
   approxRowCount?: number;
 }
@@ -153,6 +162,15 @@ function isControlledFilters(
   return 'configs' in filters;
 }
 
+/** Sums the entities the rows represent — 1 per row unless `countRow` says otherwise. */
+function countEntities<TData>(
+  rows: readonly TData[],
+  countRow?: (row: TData) => number,
+): number {
+  if (!countRow) return rows.length;
+  return rows.reduce((sum, row) => sum + countRow(row), 0);
+}
+
 // ---------------------------------------------------------------------------
 // Hook Implementation
 // ---------------------------------------------------------------------------
@@ -168,6 +186,7 @@ export function useListPage<TData>(
     getRowId,
     approxRowCount,
     entityLabel,
+    countRow,
     displayMode = 'infiniteScroll',
   } = options;
 
@@ -421,7 +440,13 @@ export function useListPage<TData>(
             ? dataSource.status === 'LoadingFirstPage'
             : dataSource.data === undefined,
         entityLabel,
-        totalCount: entityLabel ? rawData.length : undefined,
+        // In entity units when rows aggregate (countRow) — a folder row stands
+        // in for its members, so summing per-row counts keeps the footer's
+        // numerator and denominator in the unit the entity label names (#2348).
+        totalCount: entityLabel ? countEntities(rawData, countRow) : undefined,
+        displayedCount: countRow
+          ? countEntities(displayed, countRow)
+          : undefined,
       },
     },
     processedData: processed,

--- a/services/platform/app/routes/dashboard/$id/agents.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents.tsx
@@ -17,6 +17,7 @@ import {
   TabNavigation,
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
+import { folderLabel } from '@/app/features/agents/utils/folder-label';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
@@ -113,14 +114,17 @@ function AgentsLayout() {
                         <span key={path} className="flex items-center gap-1">
                           <ChevronRight className="text-muted-foreground size-4 shrink-0" />
                           {isLast ? (
-                            <span>{segment}</span>
+                            // Localized folder display name, matching the
+                            // list's folder rows and the catalog sections —
+                            // never the raw path segment (#2348).
+                            <span>{folderLabel(tCatalog, segment)}</span>
                           ) : (
                             <button
                               type="button"
                               onClick={() => goToFolder(path)}
                               className="text-muted-foreground hover:text-foreground transition-colors"
                             >
-                              {segment}
+                              {folderLabel(tCatalog, segment)}
                             </button>
                           )}
                         </span>


### PR DESCRIPTION
## Summary

Fixes the two symptoms of #2348 on the agents list (`/agents/all`), plus the same latent counting class on the automations list:

- **Footer counted folder rows as agents** — "Showing all 1 agents" for one folder holding two. The DataTable entity footer now accepts `displayedCount` (entities the visible rows represent), `useListPage` exposes it via a `countRow` option, and the agents list counts a folder row as its `agentCount` members. The footer now reads "Showing all 2 agents".
- **Folder Name cell showed the raw lowercase segment** (`chat`) — folder rows and the folder breadcrumb now reuse the catalog's localized folder label (`agentCatalog.folders.*`, extracted to `features/agents/utils/folder-label.ts`), so the same folder never reads as a raw slug in one surface and a display name in another. No new locale strings needed — the keys exist in every locale, with the existing capitalize fallback for unknown folders.
- **Sweep (same class, sibling of #2094):** the automations list footer now also counts grouped workflows instead of folder rows ("Showing all 15 automations" for one folder of 15); its regression test updated accordingly.
- The agents actions column gets an sr-only header (matching `createActionsColumn`) — required now that the agents table test audits the real columns with axe.

## Root cause

The shared entity footer counted table rows (`data.length` / `rawData.length`) while the entity label names agents — in the folder view a row can be a folder aggregating N agents, so the row unit and the labelled entity diverge.

## Tests

- `agents-table.test.tsx`: regression tests for both symptoms (footer counts agents; folder row shows "Chat") — observed red on the old code, green after; test now renders the real table config + real i18n instead of mocks.
- `automations-table.test.tsx`: folder-view expectation updated to entity units (asserts "Showing all 15 automations", rejects both the #2094 and #2348 readings).
- Verified: platform `test:ui` for all touched areas (20 files / 116 tests green), `typecheck` clean, `lint` clean, `oxfmt --check` clean. E2e skipped locally.

Closes #2348
