### PR TITLE
feat(platform): render ODT document previews

### DIFF
--- a/services/platform/app/features/documents/components/document-preview-odt.tsx
+++ b/services/platform/app/features/documents/components/document-preview-odt.tsx
@@ -7,17 +7,17 @@ import { useCallback } from 'react';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
-import { useDocxPreview } from '../hooks/use-document-preview';
+import { useOdtPreview } from '../hooks/use-document-preview';
 import { documentProseClasses } from './document-prose-classes';
 import { PreviewPane } from './preview-pane';
 
-interface DocumentPreviewDocxProps {
+interface DocumentPreviewOdtProps {
   url: string;
 }
 
-export function DocumentPreviewDocx({ url }: DocumentPreviewDocxProps) {
+export function DocumentPreviewOdt({ url }: DocumentPreviewOdtProps) {
   const { t } = useT('documents');
-  const { data: html, isLoading, error } = useDocxPreview(url);
+  const { data: html, isLoading, error } = useOdtPreview(url);
 
   const htmlRef = useCallback(
     (el: HTMLDivElement | null) => {

--- a/services/platform/app/features/documents/components/document-preview-routing.test.tsx
+++ b/services/platform/app/features/documents/components/document-preview-routing.test.tsx
@@ -37,6 +37,12 @@ vi.mock('./document-preview-docx', () => ({
   ),
 }));
 
+vi.mock('./document-preview-odt', () => ({
+  DocumentPreviewOdt: ({ url }: { url: string }) => (
+    <div data-testid="odt-preview" data-url={url} />
+  ),
+}));
+
 vi.mock('./document-preview-xlsx', () => ({
   DocumentPreviewXlsx: ({ url }: { url: string }) => (
     <div data-testid="xlsx-preview" data-url={url} />
@@ -118,6 +124,29 @@ describe('DocumentPreview routing', () => {
     );
 
     expect(screen.getByTestId('docx-preview')).toBeInTheDocument();
+  });
+
+  it('routes .odt files to ODT preview', () => {
+    render(
+      <DocumentPreview
+        url="https://example.com/doc.odt"
+        fileName="report.odt"
+      />,
+    );
+
+    expect(screen.getByTestId('odt-preview')).toBeInTheDocument();
+  });
+
+  it('routes an extension-less title to ODT preview via mimeType', () => {
+    render(
+      <DocumentPreview
+        url="https://example.com/blob"
+        fileName="Meeting notes"
+        mimeType="application/vnd.oasis.opendocument.text"
+      />,
+    );
+
+    expect(screen.getByTestId('odt-preview')).toBeInTheDocument();
   });
 
   it('routes uppercase image extensions correctly', () => {

--- a/services/platform/app/features/documents/components/document-preview.tsx
+++ b/services/platform/app/features/documents/components/document-preview.tsx
@@ -6,7 +6,10 @@ import { Image } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
-import { mimeToExtension } from '@/lib/shared/file-types';
+import {
+  getDocumentPreviewKind,
+  mimeToExtension,
+} from '@/lib/shared/file-types';
 import { getFileExtension } from '@/lib/utils/document-helpers';
 import { lazyComponent } from '@/lib/utils/lazy-component';
 import { isTextBasedFile } from '@/lib/utils/text-file-types';
@@ -29,6 +32,15 @@ const DocumentPreviewDocx = lazyComponent(
   () =>
     import('./document-preview-docx').then((m) => ({
       default: m.DocumentPreviewDocx,
+    })),
+  {
+    loading: () => <PreviewPaneSkeleton />,
+  },
+);
+const DocumentPreviewOdt = lazyComponent(
+  () =>
+    import('./document-preview-odt').then((m) => ({
+      default: m.DocumentPreviewOdt,
     })),
   {
     loading: () => <PreviewPaneSkeleton />,
@@ -62,18 +74,6 @@ const DocumentPreviewImage = lazyComponent(
   },
 );
 
-const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
-  'JPG',
-  'JPEG',
-  'PNG',
-  'GIF',
-  'WEBP',
-  'SVG',
-  'BMP',
-  'ICO',
-  'AVIF',
-]);
-
 export interface DocumentPreviewProps {
   url: string;
   fileName?: string;
@@ -97,19 +97,27 @@ export function DocumentPreview({
     return getFileExtension(fileName || url);
   }, [fileName, url, mimeType]);
 
-  if (extension === 'PDF') {
+  // Binary formats route via the shared extension → renderer map so the
+  // upload-accept and preview-support lists share one definition (#2380).
+  const previewKind = getDocumentPreviewKind(extension);
+
+  if (previewKind === 'pdf') {
     return <DocumentPreviewPDF url={url} />;
   }
 
-  if (extension === 'DOCX' || extension === 'DOC') {
+  if (previewKind === 'docx') {
     return <DocumentPreviewDocx url={url} />;
   }
 
-  if (extension === 'XLSX' || extension === 'XLS') {
+  if (previewKind === 'odt') {
+    return <DocumentPreviewOdt url={url} />;
+  }
+
+  if (previewKind === 'xlsx') {
     return <DocumentPreviewXlsx url={url} />;
   }
 
-  if (IMAGE_EXTENSIONS.has(extension)) {
+  if (previewKind === 'image') {
     return <DocumentPreviewImage url={url} fileName={fileName} />;
   }
 

--- a/services/platform/app/features/documents/components/document-prose-classes.ts
+++ b/services/platform/app/features/documents/components/document-prose-classes.ts
@@ -1,0 +1,29 @@
+import { cn } from '@/lib/utils/cn';
+
+// `@tailwindcss/typography` is not loaded in this monorepo, so `prose` is a
+// no-op and Tailwind preflight strips heading / list defaults. Style each
+// element explicitly so converted document HTML (mammoth DOCX, ODT) renders
+// like a document. Shared by `document-preview-docx` and
+// `document-preview-odt`.
+export const documentProseClasses = cn(
+  '[&_h1]:mt-6 [&_h1]:mb-3 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:first:mt-0',
+  '[&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:first:mt-0',
+  '[&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:text-lg [&_h3]:font-semibold',
+  '[&_h4]:mt-3 [&_h4]:mb-1.5 [&_h4]:text-base [&_h4]:font-semibold',
+  '[&_p]:my-2 [&_p]:leading-relaxed',
+  '[&_ul]:my-2 [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-6',
+  '[&_ol]:my-2 [&_ol]:list-decimal [&_ol]:space-y-1 [&_ol]:pl-6',
+  '[&_li]:leading-relaxed',
+  '[&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:no-underline',
+  '[&_strong]:font-semibold',
+  '[&_em]:italic',
+  '[&_code]:bg-muted [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em]',
+  '[&_pre]:bg-muted [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:p-3 [&_pre]:text-sm',
+  '[&_pre_code]:bg-transparent [&_pre_code]:p-0',
+  '[&_blockquote]:border-border [&_blockquote]:text-muted-foreground [&_blockquote]:my-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic',
+  '[&_hr]:border-border [&_hr]:my-6',
+  '[&_img]:my-3 [&_img]:max-w-full [&_img]:rounded',
+  '[&_table]:my-3 [&_table]:w-full [&_table]:border-collapse',
+  '[&_th]:border-border [&_th]:border [&_th]:px-2 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-semibold',
+  '[&_td]:border-border [&_td]:border [&_td]:px-2 [&_td]:py-1.5 [&_td]:align-top',
+);

--- a/services/platform/app/features/documents/hooks/use-document-preview.ts
+++ b/services/platform/app/features/documents/hooks/use-document-preview.ts
@@ -4,6 +4,8 @@ import DOMPurify from 'dompurify';
 
 import { useReactQuery } from '@/app/hooks/use-react-query';
 
+import { odtBytesToHtml } from '../utils/odt-preview';
+
 export function useDocxPreview(url: string) {
   return useReactQuery({
     queryKey: ['docx-preview', url],
@@ -14,6 +16,22 @@ export function useDocxPreview(url: string) {
       const mammoth = await import('mammoth');
       const result = await mammoth.convertToHtml({ arrayBuffer: ab });
       return DOMPurify.sanitize(result.value || '');
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useOdtPreview(url: string) {
+  return useReactQuery({
+    queryKey: ['odt-preview', url],
+    queryFn: async ({ signal }) => {
+      const res = await fetch(url, { signal });
+      if (!res.ok) throw new Error(`Failed to fetch document (${res.status})`);
+      const ab = await res.arrayBuffer();
+      // jszip is dynamically imported inside `odtBytesToHtml` (parity with
+      // the mammoth/xlsx imports below); output is sanitized before render.
+      const html = await odtBytesToHtml(ab);
+      return DOMPurify.sanitize(html);
     },
     staleTime: 5 * 60 * 1000,
   });

--- a/services/platform/app/features/documents/utils/odt-preview.test.ts
+++ b/services/platform/app/features/documents/utils/odt-preview.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import JSZip from 'jszip';
+import { describe, expect, it } from 'vitest';
+
+import { odtBytesToHtml, odtContentXmlToHtml } from './odt-preview';
+
+// Matches the `content.xml` shape of the backend extractor's fixture
+// (`convex/lib/knowledge/extraction/odt.test.ts`): heading + paragraph +
+// a 2-item list + a 2x2 table.
+const SAMPLE_CONTENT_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" office:version="1.2">
+ <office:body><office:text>
+  <text:h text:outline-level="1">Sample ODT Test Document</text:h>
+  <text:p>This paragraph proves ODT preview works.</text:p>
+  <text:list><text:list-item><text:p>First requirement</text:p></text:list-item><text:list-item><text:p>Second requirement</text:p></text:list-item></text:list>
+  <table:table table:name="T1">
+   <table:table-row><table:table-cell><text:p>Cell A1</text:p></table:table-cell><table:table-cell><text:p>Cell B1</text:p></table:table-cell></table:table-row>
+   <table:table-row><table:table-cell><text:p>Cell A2</text:p></table:table-cell><table:table-cell><text:p>Cell B2</text:p></table:table-cell></table:table-row>
+  </table:table>
+ </office:text></office:body>
+</office:document-content>`;
+
+/** Package `content.xml` as a minimal ODT archive (matches the ODF layout). */
+async function buildOdt(contentXml: string): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  // ODF requires the `mimetype` entry to be stored first and uncompressed.
+  zip.file('mimetype', 'application/vnd.oasis.opendocument.text', {
+    compression: 'STORE',
+  });
+  zip.file('content.xml', contentXml);
+  return zip.generateAsync({ type: 'arraybuffer' });
+}
+
+/** Parse produced HTML for structural assertions. */
+function toDom(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  return el;
+}
+
+describe('odtBytesToHtml (sample fixture)', () => {
+  it('renders heading, paragraph, list items, and table cells as HTML', async () => {
+    const html = await odtBytesToHtml(await buildOdt(SAMPLE_CONTENT_XML));
+    const dom = toDom(html);
+
+    expect(dom.querySelector('h1')?.textContent).toBe(
+      'Sample ODT Test Document',
+    );
+    expect(dom.querySelector('p')?.textContent).toBe(
+      'This paragraph proves ODT preview works.',
+    );
+    const items = Array.from(dom.querySelectorAll('ul li')).map((li) =>
+      li.textContent?.trim(),
+    );
+    expect(items).toEqual(['First requirement', 'Second requirement']);
+    const cells = Array.from(dom.querySelectorAll('table tr td')).map((td) =>
+      td.textContent?.trim(),
+    );
+    expect(cells).toEqual(['Cell A1', 'Cell B1', 'Cell A2', 'Cell B2']);
+  });
+
+  it('preserves reading order: heading before list before table', async () => {
+    const html = await odtBytesToHtml(await buildOdt(SAMPLE_CONTENT_XML));
+    expect(html.indexOf('Sample ODT Test Document')).toBeLessThan(
+      html.indexOf('First requirement'),
+    );
+    expect(html.indexOf('First requirement')).toBeLessThan(
+      html.indexOf('Cell A1'),
+    );
+  });
+});
+
+describe('odtContentXmlToHtml (inline content and whitespace)', () => {
+  const wrap = (body: string) =>
+    `<?xml version="1.0"?><office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"><office:body><office:text>${body}</office:text></office:body></office:document-content>`;
+
+  it('joins spans within a paragraph and honours line breaks', () => {
+    const html = odtContentXmlToHtml(
+      wrap(
+        '<text:p><text:span>Hello</text:span><text:span> World</text:span></text:p><text:p>Line one<text:line-break/>Line two</text:p>',
+      ),
+    );
+    const dom = toDom(html);
+    const paragraphs = dom.querySelectorAll('p');
+    expect(paragraphs[0].textContent).toBe('Hello World');
+    expect(paragraphs[1].querySelector('br')).not.toBeNull();
+    expect(paragraphs[1].textContent).toBe('Line oneLine two');
+  });
+
+  it('clamps heading outline levels to h1–h4', () => {
+    const html = odtContentXmlToHtml(
+      wrap(
+        '<text:h text:outline-level="2">Second</text:h><text:h text:outline-level="9">Deep</text:h>',
+      ),
+    );
+    const dom = toDom(html);
+    expect(dom.querySelector('h2')?.textContent).toBe('Second');
+    expect(dom.querySelector('h4')?.textContent).toBe('Deep');
+  });
+
+  it('drops empty spacing paragraphs and escapes markup-looking text', () => {
+    const html = odtContentXmlToHtml(
+      wrap(
+        '<text:p></text:p><text:p>&lt;script&gt;alert(1)&lt;/script&gt; safe</text:p>',
+      ),
+    );
+    const dom = toDom(html);
+    expect(dom.querySelectorAll('p')).toHaveLength(1);
+    expect(dom.querySelector('script')).toBeNull();
+    expect(dom.querySelector('p')?.textContent).toBe(
+      '<script>alert(1)</script> safe',
+    );
+  });
+});
+
+describe('odtBytesToHtml (errors)', () => {
+  it('rejects a payload that is not a zip archive', async () => {
+    const notAZip = new TextEncoder().encode('this is definitely not a zip');
+    await expect(odtBytesToHtml(notAZip.buffer)).rejects.toThrow(
+      /invalid or corrupt/i,
+    );
+  });
+
+  it('rejects an archive without content.xml', async () => {
+    const zip = new JSZip();
+    zip.file('mimetype', 'application/vnd.oasis.opendocument.text');
+    zip.file('other.xml', '<x/>');
+    const bytes = await zip.generateAsync({ type: 'arraybuffer' });
+    await expect(odtBytesToHtml(bytes)).rejects.toThrow(
+      /no readable content\.xml/i,
+    );
+  });
+
+  it('rejects malformed content.xml', async () => {
+    const bytes = await buildOdt('<office:document-content');
+    await expect(odtBytesToHtml(bytes)).rejects.toThrow(/could not parse/i);
+  });
+
+  it('rejects content.xml without an <office:text> body', async () => {
+    const bytes = await buildOdt(
+      '<?xml version="1.0"?><office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"><office:body></office:body></office:document-content>',
+    );
+    await expect(odtBytesToHtml(bytes)).rejects.toThrow(
+      /missing an <office:text> body/i,
+    );
+  });
+});

--- a/services/platform/app/features/documents/utils/odt-preview.ts
+++ b/services/platform/app/features/documents/utils/odt-preview.ts
@@ -1,0 +1,214 @@
+/**
+ * OpenDocument Text (ODT) → HTML conversion for the document preview.
+ *
+ * An ODT is a zip whose `content.xml` is ODF XML. We unzip with jszip (the
+ * same library the backend extractor's GuardedZip wraps) and walk the ODF
+ * text tree with the platform `DOMParser` — headings (`text:h`), paragraphs
+ * (`text:p`), spans (`text:span`), lists (`text:list`/`text:list-item`) and
+ * tables (`table:table`/`table:table-row`/`table:table-cell`) — emitting
+ * semantic HTML that the DOCX preview's prose styles already know how to
+ * render. Mirrors the block subset of the backend extractor
+ * (`convex/lib/knowledge/extraction/odt.ts`); exotic ODF features degrade to
+ * plain paragraphs.
+ *
+ * All text lands in the output via `createTextNode`, so the produced markup
+ * contains no document-controlled HTML; callers still sanitize with DOMPurify
+ * before injecting (parity with the DOCX/XLSX preview hooks).
+ */
+
+import type JSZipType from 'jszip';
+
+const OFFICE_NS = 'urn:oasis:names:tc:opendocument:xmlns:office:1.0';
+
+/** Decompression cap for `content.xml` (zip-bomb guard), in UTF-16 units. */
+const MAX_CONTENT_XML_CHARS = 50 * 1024 * 1024;
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === 1;
+}
+
+/** The `text:c` repeat count of a `text:s` (spaces) element, default 1. */
+function spaceCount(el: Element): number {
+  const raw =
+    el.getAttribute('text:c') ?? el.getAttributeNS(null, 'c') ?? undefined;
+  const count = Number(raw);
+  return Number.isFinite(count) && count > 0 ? count : 1;
+}
+
+/**
+ * Append the inline content of an ODF element (text runs, spans, links, and
+ * the whitespace elements `text:tab`, `text:line-break`, `text:s`) to `dest`.
+ */
+function appendInline(src: Element, dest: Element, out: Document): void {
+  for (const node of Array.from(src.childNodes)) {
+    if (node.nodeType === 3 /* TEXT_NODE */) {
+      dest.appendChild(out.createTextNode(node.nodeValue ?? ''));
+      continue;
+    }
+    if (!isElement(node)) continue;
+    switch (node.localName) {
+      case 'tab':
+        // Non-breaking spaces survive HTML whitespace collapsing.
+        dest.appendChild(out.createTextNode('    '));
+        break;
+      case 'line-break':
+        dest.appendChild(out.createElement('br'));
+        break;
+      case 's':
+        dest.appendChild(out.createTextNode(' '.repeat(spaceCount(node))));
+        break;
+      case 'note':
+        // Footnotes/endnotes render inline in ODF; skip them in the preview.
+        break;
+      default:
+        // Spans, links, and unknown inline wrappers: keep their text content.
+        appendInline(node, dest, out);
+    }
+  }
+}
+
+/** Heading level from `text:outline-level`, clamped to h1–h4. */
+function headingTag(el: Element): string {
+  const raw = el.getAttribute('text:outline-level');
+  const level = Number(raw);
+  if (!Number.isFinite(level)) return 'h1';
+  return `h${Math.min(Math.max(Math.trunc(level), 1), 4)}`;
+}
+
+/** Render an ODF table as `<table><tr><td>…`. */
+function appendTable(table: Element, parent: Element, out: Document): void {
+  const htmlTable = out.createElement('table');
+
+  const appendRow = (row: Element): void => {
+    const tr = out.createElement('tr');
+    for (const cell of Array.from(row.children)) {
+      // Skip `table:covered-table-cell` (merged-cell placeholders).
+      if (cell.localName !== 'table-cell') continue;
+      const td = out.createElement('td');
+      appendBlocks(Array.from(cell.children), td, out);
+      tr.appendChild(td);
+    }
+    htmlTable.appendChild(tr);
+  };
+
+  for (const child of Array.from(table.children)) {
+    if (child.localName === 'table-row') {
+      appendRow(child);
+    } else if (child.localName === 'table-header-rows') {
+      // Row groups wrap rows — descend into them.
+      for (const row of Array.from(child.children)) {
+        if (row.localName === 'table-row') appendRow(row);
+      }
+    }
+  }
+
+  if (htmlTable.childNodes.length > 0) parent.appendChild(htmlTable);
+}
+
+/** Render an ODF list as `<ul><li>…` (nested lists recurse). */
+function appendList(list: Element, parent: Element, out: Document): void {
+  const ul = out.createElement('ul');
+  for (const item of Array.from(list.children)) {
+    if (item.localName !== 'list-item' && item.localName !== 'list-header') {
+      continue;
+    }
+    const li = out.createElement('li');
+    appendBlocks(Array.from(item.children), li, out);
+    ul.appendChild(li);
+  }
+  if (ul.childNodes.length > 0) parent.appendChild(ul);
+}
+
+/**
+ * Walk ordered block-level ODF children (`text:h`, `text:p`, `text:list`,
+ * `table:table`, transparent `text:section`s), appending HTML to `parent`.
+ */
+function appendBlocks(nodes: Element[], parent: Element, out: Document): void {
+  for (const node of nodes) {
+    switch (node.localName) {
+      case 'h': {
+        const heading = out.createElement(headingTag(node));
+        appendInline(node, heading, out);
+        if (heading.textContent?.trim()) parent.appendChild(heading);
+        break;
+      }
+      case 'p': {
+        const p = out.createElement('p');
+        appendInline(node, p, out);
+        // Keep empty paragraphs out; ODF uses them for vertical spacing.
+        if (p.textContent?.trim() || p.querySelector('br')) {
+          parent.appendChild(p);
+        }
+        break;
+      }
+      case 'list':
+        appendList(node, parent, out);
+        break;
+      case 'table':
+        appendTable(node, parent, out);
+        break;
+      case 'section':
+      case 'soft-page-break':
+        appendBlocks(Array.from(node.children), parent, out);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+/**
+ * Convert the `content.xml` of an ODT to semantic HTML.
+ * Throws on malformed XML or a missing `<office:text>` body.
+ */
+export function odtContentXmlToHtml(contentXml: string): string {
+  const doc = new DOMParser().parseFromString(contentXml, 'application/xml');
+  if (doc.getElementsByTagName('parsererror').length > 0) {
+    throw new Error('ODT preview failed: could not parse content.xml');
+  }
+
+  const body = Array.from(doc.getElementsByTagNameNS(OFFICE_NS, 'text'))[0];
+  if (!body) {
+    throw new Error(
+      'ODT preview failed: content.xml is missing an <office:text> body (not a valid OpenDocument Text file)',
+    );
+  }
+
+  const out = document.implementation.createHTMLDocument('');
+  appendBlocks(Array.from(body.children), out.body, out);
+  return out.body.innerHTML;
+}
+
+/**
+ * Convert raw ODT bytes to semantic HTML: unzip, read `content.xml`, convert.
+ * Throws on an invalid/corrupt archive, a missing or oversized `content.xml`,
+ * or unparseable ODF XML.
+ */
+export async function odtBytesToHtml(bytes: ArrayBuffer): Promise<string> {
+  // Dynamic import keeps jszip out of the preview route's initial chunk
+  // (parity with the mammoth/xlsx imports in `use-document-preview.ts`).
+  const { default: JSZip } = await import('jszip');
+
+  let zip: JSZipType;
+  try {
+    zip = await JSZip.loadAsync(bytes);
+  } catch (err) {
+    throw new Error('ODT preview failed: invalid or corrupt archive', {
+      cause: err,
+    });
+  }
+
+  const entry = zip.file('content.xml');
+  if (!entry) {
+    throw new Error(
+      'ODT preview failed: no readable content.xml (not a valid OpenDocument Text file)',
+    );
+  }
+
+  const contentXml = await entry.async('string');
+  if (contentXml.length > MAX_CONTENT_XML_CHARS) {
+    throw new Error('ODT preview failed: content.xml exceeds the size limit');
+  }
+
+  return odtContentXmlToHtml(contentXml);
+}

--- a/services/platform/lib/shared/file-types.test.ts
+++ b/services/platform/lib/shared/file-types.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
+import { isTextBasedFile } from '../utils/text-file-types';
 import {
   detectMediaMime,
+  DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS,
   extractExtension,
+  getDocumentPreviewKind,
   isAllowedDocumentUpload,
   isRagIndexableFile,
   mimeToExtension,
@@ -428,5 +431,28 @@ describe('isRagIndexableFile', () => {
     // Extension wins over MIME — a .doc reported as text/plain is still
     // a .doc to RAG's extension gate.
     expect(isRagIndexableFile('legacy.doc', 'text/plain')).toBe(false);
+  });
+});
+
+describe('upload-accept / preview-support parity (#2380)', () => {
+  // Formats the upload dialog accepts that knowingly have no preview
+  // renderer yet. Shrink this list when a renderer is added; never grow it
+  // silently — a newly accepted format must ship with a preview (or be
+  // deliberately added here).
+  const KNOWN_UNPREVIEWABLE = new Set(['ppt', 'pptx']);
+
+  it('every accepted upload extension is previewable or a known exception', () => {
+    const unpreviewable = [...DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS].filter(
+      (ext) =>
+        getDocumentPreviewKind(ext) === undefined &&
+        !isTextBasedFile(`file.${ext}`),
+    );
+    expect(new Set(unpreviewable)).toEqual(KNOWN_UNPREVIEWABLE);
+  });
+
+  it('odt is accepted and routes to the odt renderer', () => {
+    expect(DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS.has('odt')).toBe(true);
+    expect(getDocumentPreviewKind('odt')).toBe('odt');
+    expect(getDocumentPreviewKind('ODT')).toBe('odt');
   });
 });

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -480,7 +480,7 @@ const DOCUMENT_UPLOAD_ALLOWED_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /** Allowed extensions for document uploads (fallback when MIME is unreliable) */
-const DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
+export const DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
   'pdf',
   'doc',
   'docx',
@@ -731,6 +731,54 @@ export function isAllowedDocumentUpload(
 export function mimeToExtension(mime: string): string | undefined {
   const base = mime.split(';')[0].trim().toLowerCase();
   return MIME_TO_EXTENSION[base];
+}
+
+// ---------------------------------------------------------------------------
+// Document preview capability
+// ---------------------------------------------------------------------------
+
+/**
+ * Renderers the document preview (`DocumentPreview`) can route to for binary
+ * formats. Text-based files are decided separately via `isTextBasedFile`
+ * (extension + MIME + known filenames), so they are not listed here.
+ */
+export type DocumentPreviewKind = 'pdf' | 'docx' | 'odt' | 'xlsx' | 'image';
+
+/**
+ * Extension (lowercase, no dot) → preview renderer. The single source of
+ * truth for which binary formats the preview supports — `DocumentPreview`
+ * routes off this map, and `file-types.test.ts` checks it against
+ * {@link DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS} so the upload-accept and
+ * preview-support lists cannot drift apart silently (issue #2380).
+ */
+const PREVIEW_KIND_BY_EXTENSION: Readonly<Record<string, DocumentPreviewKind>> =
+  {
+    pdf: 'pdf',
+    doc: 'docx',
+    docx: 'docx',
+    odt: 'odt',
+    xls: 'xlsx',
+    xlsx: 'xlsx',
+    jpg: 'image',
+    jpeg: 'image',
+    png: 'image',
+    gif: 'image',
+    webp: 'image',
+    svg: 'image',
+    bmp: 'image',
+    ico: 'image',
+    avif: 'image',
+  };
+
+/**
+ * The preview renderer for a file extension (any case, no dot), or
+ * `undefined` when no dedicated renderer exists — callers fall back to the
+ * text preview via `isTextBasedFile`, then to the "not available" state.
+ */
+export function getDocumentPreviewKind(
+  extension: string,
+): DocumentPreviewKind | undefined {
+  return PREVIEW_KIND_BY_EXTENSION[extension.toLowerCase()];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The document upload dialog advertises ODT and `.odt` uploads succeed, but opening the document showed "Preview not available". This adds a real ODT preview and a guard so the accept and preview lists can't drift apart again.

Closes #2380

## How the preview is produced

- **No new dependency.** The renderer reuses what the platform already ships: `jszip` (the library the backend extractor's `GuardedZip` wraps) unzips the ODT in the browser, and the platform `DOMParser` walks the ODF `content.xml` text tree — headings (`text:h`, outline level → `h1`–`h4`), paragraphs, spans, lists, tables, and the ODF whitespace elements (`text:tab`, `text:line-break`, `text:s`).
- The walk mirrors the block subset of the existing backend extractor (`convex/lib/knowledge/extraction/odt.ts`, which is `'use node'`/Buffer-bound and not importable client-side) but emits semantic HTML instead of plain text. All text lands via `createTextNode`, and the hook sanitizes with DOMPurify before injection — parity with the DOCX (mammoth) and XLSX (SheetJS) preview hooks in `use-document-preview.ts`.
- The output renders in the same prose-styled pane as DOCX: the prose classes moved from `document-preview-docx.tsx` into a shared `document-prose-classes.ts`, and `DocumentPreviewOdt` is a lazy chunk like its siblings. mammoth cannot read OpenDocument, so the DOCX converter itself could not be reused.
- `content.xml` decompression is capped (50M chars) as a zip-bomb guard; corrupt archives, missing `content.xml`, malformed XML, and a missing `<office:text>` body all reject and degrade to the existing "Failed to load document" / "Preview not available" paths.

## Shared definition (acceptance criterion 2)

- `lib/shared/file-types.ts` now owns an extension → preview-renderer map (`getDocumentPreviewKind`); `DocumentPreview` routes its binary-format branches off it instead of inline extension checks.
- A parity test in `file-types.test.ts` walks `DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS` and fails if any accepted format is neither previewable nor text-based, with `ppt`/`pptx` as the explicit known exceptions — accepting a new format without a preview now breaks the build.

## Localization

No new user-visible strings: the ODT pane reuses the existing `documents:preview.loading` / `preview.failedToLoad` / `preview.notAvailable*` keys, so all locales are already covered.

## Tests

- `odt-preview.test.ts` — converter happy path (heading/paragraph/list/table from a real jszip-built archive), inline/whitespace edges (spans, line breaks, heading clamping, empty-paragraph dropping, markup-looking text stays escaped), and four error paths (non-zip, no `content.xml`, malformed XML, no `<office:text>`).
- `document-preview-routing.test.tsx` — `.odt` routes to the ODT renderer, including extension-less titles via `application/vnd.oasis.opendocument.text`.
- `file-types.test.ts` — accept/preview parity + ODT routing.

## Checks run

- `vitest --project client app/features/documents` — 21 files, 129 tests passed
- `vitest --project server lib/shared/file-types*.test.ts convex/lib/knowledge/extraction/odt.test.ts` — 118 tests passed
- `bun run typecheck` (platform) — clean
- `bun run lint` (platform) — only pre-existing failure in `app/features/agents/utils/resolve-agent-catalog-icon.ts` (unrelated, fixed separately); no findings in touched files