### PR TITLE
docs(sandbox): define exec durationMs semantics across backends

### DIFF
--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -50,6 +50,14 @@ export interface SessionExecResultShape {
   exitCode: number | null;
   stdoutPreview: string;
   stderrPreview: string;
+  /**
+   * End-to-end run wall-clock measured PLATFORM-SIDE around the whole
+   * `runAndHarvestInSession` call: package installs + every step exec + the
+   * `/user/output` harvest. NOT the canonical per-exec execution time — that
+   * is runnerd's `exit.durationMs` (spawn → exit inside the container; see
+   * the sandbox wire `SessionExecResponse.durationMs`), which this run
+   * aggregates over several execs and extends with harvest I/O.
+   */
   durationMs: number;
   files: Array<{
     path: string;

--- a/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
+++ b/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
@@ -480,6 +480,11 @@ export const sandboxRunResultValidator = v.object({
   exitCode: v.optional(v.number()),
   stdoutPreview: v.optional(v.string()),
   stderrPreview: v.optional(v.string()),
+  /** Whole-run wall-clock, platform-measured — script mode: the session-exec
+   * run duration (installs + steps + harvest, `SessionExecResultShape`);
+   * agent mode: the run's wall-clock from its checkpoint `startedAt`, across
+   * segments. NOT the canonical per-exec execution time (runnerd's
+   * `exit.durationMs`). */
   durationMs: v.optional(v.number()),
   error: v.optional(v.string()),
   /** Structured refusal reason when the task-metrics admission gate rejected

--- a/services/sandbox-runtime/daemon/src/exec-manager.test.ts
+++ b/services/sandbox-runtime/daemon/src/exec-manager.test.ts
@@ -93,6 +93,32 @@ describe('ExecManager', () => {
     expect(exit?.seq).toBe(maxSeq);
   });
 
+  test('exit durationMs is the runner-measured process wall-clock (spawn → drained exit)', async () => {
+    const mgr = new ExecManager(new EnvStore(), () => {});
+    const { events, emit } = collect();
+    const beforeMs = Date.now();
+    await mgr.run(
+      { ...base, execId: 'dur1', shell: 'sleep 0.12', cwd: ROOT },
+      emit,
+    );
+    const afterMs = Date.now();
+    const start = events.find(
+      (e): e is Extract<RunnerdExecEvent, { t: 'start' }> => e.t === 'start',
+    );
+    const exit = events.find(
+      (e): e is Extract<RunnerdExecEvent, { t: 'exit' }> => e.t === 'exit',
+    );
+    if (!start || !exit) throw new Error('missing start/exit event');
+    // The clock starts at spawn time, inside the run() window.
+    expect(start.startedAtMs).toBeGreaterThanOrEqual(beforeMs);
+    expect(start.startedAtMs).toBeLessThanOrEqual(afterMs);
+    // The measurement covers the child's own runtime (a 120ms sleep; allow
+    // Date.now() granularity slack) and never exceeds the outer wall-clock —
+    // i.e. it contains NO out-of-process phase (staging, harvest, scheduling).
+    expect(exit.durationMs).toBeGreaterThanOrEqual(110);
+    expect(exit.durationMs).toBeLessThanOrEqual(afterMs - start.startedAtMs);
+  });
+
   test('shell form runs via bash -lc, propagates non-zero exit', async () => {
     const mgr = new ExecManager(new EnvStore(), () => {});
     const { events, emit } = collect();

--- a/services/sandbox-runtime/daemon/src/exec-manager.ts
+++ b/services/sandbox-runtime/daemon/src/exec-manager.ts
@@ -458,6 +458,10 @@ export class ExecManager {
         ringEmit({
           t: 'exit',
           exitCode: code,
+          // The canonical execution wall-clock (protocol.ts `exit.durationMs`):
+          // startedAtMs was taken immediately before spawn(), and finish() runs
+          // only once stdio is drained — nothing outside the process
+          // (scheduling, staging, harvest) can leak into the measurement.
           durationMs: Date.now() - startedAtMs,
           truncated: { stdout: stdoutTrunc, stderr: stderrTrunc },
           timedOut: record.timedOut,

--- a/services/sandbox-runtime/daemon/src/protocol.ts
+++ b/services/sandbox-runtime/daemon/src/protocol.ts
@@ -112,6 +112,16 @@ export type RunnerdExecEvent = (
   | {
       t: 'exit';
       exitCode: number;
+      /**
+       * CANONICAL execution wall-clock: measured by the daemon itself, from
+       * immediately before `spawn()` (the `start` event's `startedAtMs`) to
+       * the child's exit with all stdio drained. Excludes everything outside
+       * the process — container/Pod scheduling, image pull, session startup,
+       * endpoint resolution, input staging, output harvest — so it is
+       * identical on the docker and kubernetes backends, which host the same
+       * daemon. Consumers (the spawner's `SessionExecResponse.durationMs`,
+       * usage analytics) forward this value verbatim.
+       */
       durationMs: number;
       truncated: { stdout: boolean; stderr: boolean };
       timedOut: boolean;

--- a/services/sandbox/src/session/runnerd-protocol.ts
+++ b/services/sandbox/src/session/runnerd-protocol.ts
@@ -166,6 +166,15 @@ export type RunnerdExecEvent = (
   | {
       t: 'exit';
       exitCode: number;
+      /**
+       * CANONICAL execution wall-clock: measured by runnerd itself, from
+       * immediately before `spawn()` (the `start` event's `startedAtMs`) to
+       * the child's exit with all stdio drained. Excludes everything outside
+       * the process — container/Pod scheduling, image pull, session startup,
+       * endpoint resolution, input staging, output harvest — so it is
+       * identical on the docker and kubernetes backends, which host the same
+       * daemon. Forwarded verbatim into `SessionExecResponse.durationMs`.
+       */
       durationMs: number;
       truncated: { stdout: boolean; stderr: boolean };
       /** Set when the daemon killed the process group at timeoutMs. */

--- a/services/sandbox/src/session/session-routes.test.ts
+++ b/services/sandbox/src/session/session-routes.test.ts
@@ -114,6 +114,16 @@ beforeAll(() => {
         // Sentinel: simulate a process that raced the deadline but still exited
         // cleanly (exitCode 0 + timedOut) — the H8 wire-coherence case.
         const cleanTimeout = text.includes('__timeout_clean__');
+        // Sentinel: simulate a pre-spawn `fail` line (the process never ran,
+        // so runnerd reports no measurement).
+        if (text.includes('__fail__')) {
+          return new Response(
+            ndjson([
+              { t: 'fail', code: 'INVALID_CWD', message: 'cwd rejected' },
+            ]),
+            { headers: { 'content-type': 'application/x-ndjson' } },
+          );
+        }
         return new Response(
           ndjson([
             { t: 'start', execId: 'e1', startedAtMs: 1 },
@@ -335,6 +345,43 @@ describe('SessionRoutes (fake runnerd)', () => {
     expect(destroyed.has('sess1')).toBe(true);
     // gone from registry
     expect((await routes.handleGet('sess1')).status).toBe(404);
+  });
+
+  test('result forwards runnerd exit durationMs VERBATIM (the runner-measured wall-clock)', async () => {
+    const routes = new SessionRoutes(cfg, fakeBackend);
+    await routes.handleCreate(
+      JSON.stringify({ sessionId: 'sess_dur', organizationId: 'org_d' }),
+    );
+    const execRes = routes.handleExec(
+      new Request('http://x/v1/sessions/sess_dur/exec', { method: 'POST' }),
+      'sess_dur',
+      JSON.stringify({ execId: 'e1', command: ['echo', 'hi'] }),
+    );
+    const { events } = await readSse(execRes);
+    const payload = events.find((e) => e.event === 'result')?.data ?? {};
+    // The fake runnerd's exit line carries durationMs: 5 — the spawner must
+    // forward it untouched, never re-measure around its own stream handling.
+    expect(payload.durationMs).toBe(5);
+  });
+
+  test('a pre-spawn fail synthesizes durationMs 0 (never ran ⇒ not measured)', async () => {
+    const routes = new SessionRoutes(cfg, fakeBackend);
+    await routes.handleCreate(
+      JSON.stringify({ sessionId: 'sess_fail', organizationId: 'org_f' }),
+    );
+    const execRes = routes.handleExec(
+      new Request('http://x/v1/sessions/sess_fail/exec', { method: 'POST' }),
+      'sess_fail',
+      JSON.stringify({ execId: 'e1', command: ['echo', '__fail__'] }),
+    );
+    const { events } = await readSse(execRes);
+    const payload = events.find((e) => e.event === 'result')?.data ?? {};
+    expect(payload.status).toBe('failed');
+    expect(payload.exitCode).toBeNull();
+    expect(payload.errorCode).toBe('INVALID_CWD');
+    // 0 is the "not measured" sentinel (wire.ts contract) — the process never
+    // spawned, so no runner wall-clock exists to forward.
+    expect(payload.durationMs).toBe(0);
   });
 
   test('a clean exit (0) that raced the deadline reports completed WITHOUT a TIMEOUT marker', async () => {

--- a/services/sandbox/src/session/session-routes.ts
+++ b/services/sandbox/src/session/session-routes.ts
@@ -582,6 +582,8 @@ export class SessionRoutes {
             result = {
               status: 'failed',
               exitCode: null,
+              // Sentinel: the process never ran, so there is no runnerd
+              // measurement to forward (wire.ts `durationMs` contract).
               durationMs: 0,
               stdoutBase64: '',
               stderrBase64: '',
@@ -622,6 +624,8 @@ export class SessionRoutes {
           send('result', {
             status: 'failed',
             exitCode: null,
+            // Sentinel: the terminal `exit` line was lost with the container,
+            // so there is no measurement to forward (wire.ts contract).
             durationMs: 0,
             stdoutBase64: concatBase64(stdoutChunks),
             stderrBase64: concatBase64(stderrChunks),
@@ -1056,6 +1060,8 @@ function forwardExecEvent(
       send('result', {
         status: 'failed',
         exitCode: null,
+        // Sentinel: the process never ran, so there is no runnerd
+        // measurement to forward (wire.ts `durationMs` contract).
         durationMs: 0,
         stdoutBase64: '',
         stderrBase64: '',

--- a/services/sandbox/src/wire.ts
+++ b/services/sandbox/src/wire.ts
@@ -137,6 +137,17 @@ export type SandboxSessionProfile =
 export interface SessionExecResponse {
   status: 'completed' | 'failed' | 'cancelled';
   exitCode: number | null;
+  /**
+   * Execution wall-clock, forwarded VERBATIM from runnerd's terminal `exit`
+   * line: measured inside the session container from immediately before
+   * `spawn()` to the child's exit with all stdio drained. It excludes every
+   * out-of-process phase — container/Pod scheduling, image pull, session
+   * startup, endpoint resolution, input staging, output harvest — and is
+   * therefore identical on the docker and kubernetes backends (the same
+   * daemon measures on both). Exactly 0 when there is no measurement to
+   * forward: a pre-spawn `fail` (the process never ran) or a lost terminal
+   * line (`SESSION_LOST`) — 0 means "not measured", never "ran for 0ms".
+   */
   durationMs: number;
   stdoutBase64: string;
   stderrBase64: string;


### PR DESCRIPTION
## What

Defines the exact, cross-backend semantics of the sandbox execution duration and locks them with tests.

## Context

Issue #1848 asked for a precise cross-backend definition of `timing.executeMs`: Docker measured it pre-harvest, while the k8s backend approximated it as `durationMs - harvestMs - uploadMs` (still containing pod scheduling + image pull + startup).

That field no longer exists: the sessions refactor (#2301) deleted the one-shot exec path (`exec-response.ts`, `local-workspace-run.ts`, the k8s one-shot assemble) and already implements the mechanism the issue proposed — **runnerd, the in-container daemon, measures the runner wall-clock directly and reports it in the terminal result line**. What was still missing is the written contract, and the platform layer reuses the same field name (`durationMs`) for a different quantity.

## The canonical semantics

> `durationMs` is the runner-measured process wall-clock: from immediately before `spawn()` inside the session container to the child's exit with all stdio drained, measured by runnerd itself. It excludes every out-of-process phase — container/Pod scheduling, image pull, session startup, endpoint resolution, input staging, output harvest — and is therefore identical on the docker and kubernetes backends (the same daemon measures on both). When the spawner has no measurement to forward (pre-spawn `fail`, `SESSION_LOST`), it synthesizes `0`: "not measured", never "ran for 0 ms".

## Changes

- TSDoc the contract on every declaration site: `exit.durationMs` in the runnerd protocol (daemon source of truth + spawner mirror), `SessionExecResponse.durationMs` in the spawner wire, and the measurement site in `exec-manager.ts`.
- Mark the three spawner sites that synthesize `durationMs: 0` as the "not measured" sentinel.
- Document the platform's `SessionExecResultShape.durationMs` (installs + steps + harvest, platform-measured) and the workflow `sandboxRunResultValidator.durationMs` (whole-run wall-clock) as **distinct** quantities, so analytics can't confuse them with the canonical per-exec time.
- Tests: `exec-manager.test.ts` asserts `durationMs` covers the child's runtime and never exceeds the outer wall-clock (no out-of-process phase can leak in); `session-routes.test.ts` asserts the spawner forwards runnerd's value verbatim on `exit` and synthesizes `0` on a pre-spawn `fail`.

No behaviour change — contract documentation + regression tests only.

## Checks

- `bun test` in `services/sandbox` (210 pass) and `services/sandbox-runtime/daemon` (65 pass)
- `tsc --noEmit` in `services/sandbox`, `services/sandbox-runtime/daemon`, `services/platform`
- `oxlint --type-aware` on the touched workspaces/files — clean

Closes #1848