### PR TITLE
test(platform): close out the auth/2FA/SSO gaps of #2085 with regression cover

### DIFF
--- a/services/platform/app/features/auth/components/two-factor-grace-banner.test.tsx
+++ b/services/platform/app/features/auth/components/two-factor-grace-banner.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// Regression cover for #2085[05]: this banner is persistent dashboard chrome,
+// not a live interruption — it must expose the polite `status` role so screen
+// readers announce it after the current utterance, never the assertive
+// `alert` role it originally shipped with.
+
+const { mockStatus } = vi.hoisted(() => ({
+  mockStatus: { value: undefined as unknown },
+}));
+
+vi.mock('@/app/context/account-bootstrap-context', () => ({
+  useTwoFactorStatus: () => mockStatus.value,
+}));
+
+// The CTA is a TanStack Router <Link>; a plain anchor keeps the test free of a
+// full router while preserving the accessible link semantics under assertion.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { TwoFactorGraceBanner } from './two-factor-grace-banner';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function graceStatus(overrides?: Record<string, unknown>) {
+  return {
+    authenticated: true,
+    twoFactorEnabled: false,
+    hasPasskey: false,
+    enforced: true,
+    decision: 'grace',
+    graceUntil: Date.now() + 3 * DAY_MS,
+    hasCredential: true,
+    exemptSsoUsers: false,
+    backupCodesRemaining: null,
+    ...overrides,
+  };
+}
+
+describe('TwoFactorGraceBanner', () => {
+  it('renders as a polite status region, never an assertive alert (#2085[05])', () => {
+    mockStatus.value = graceStatus();
+
+    render(<TwoFactorGraceBanner organizationId="org-1" />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent(/two-factor authentication required/i);
+    expect(
+      screen.getByRole('link', { name: 'Set up now' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the user is not in the grace window', () => {
+    mockStatus.value = graceStatus({ decision: 'ok', graceUntil: null });
+
+    render(<TwoFactorGraceBanner organizationId="org-1" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/auth/components/two-factor-low-backup-codes-banner.test.tsx
+++ b/services/platform/app/features/auth/components/two-factor-low-backup-codes-banner.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// Regression cover for #2085[05]: like its grace sibling, this persistent
+// dashboard banner must be a polite `status` live region — an assertive
+// `alert` role would interrupt screen-reader users on every dashboard visit.
+
+const { mockStatus } = vi.hoisted(() => ({
+  mockStatus: { value: undefined as unknown },
+}));
+
+vi.mock('@/app/context/account-bootstrap-context', () => ({
+  useTwoFactorStatus: () => mockStatus.value,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { TwoFactorLowBackupCodesBanner } from './two-factor-low-backup-codes-banner';
+
+function enrolledStatus(backupCodesRemaining: number | null) {
+  return {
+    authenticated: true,
+    twoFactorEnabled: true,
+    hasPasskey: false,
+    enforced: false,
+    decision: 'ok',
+    graceUntil: null,
+    hasCredential: true,
+    exemptSsoUsers: false,
+    backupCodesRemaining,
+  };
+}
+
+describe('TwoFactorLowBackupCodesBanner', () => {
+  it('renders as a polite status region, never an assertive alert (#2085[05])', () => {
+    mockStatus.value = enrolledStatus(2);
+
+    render(<TwoFactorLowBackupCodesBanner organizationId="org-1" />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Only 2 backup codes remaining');
+    expect(
+      screen.getByRole('link', { name: 'Regenerate now' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while the backup-code pool is healthy', () => {
+    mockStatus.value = enrolledStatus(8);
+
+    render(<TwoFactorLowBackupCodesBanner organizationId="org-1" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/auth/hooks/use-password-expiry-gate.test.ts
+++ b/services/platform/app/features/auth/hooks/use-password-expiry-gate.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression cover for #2085[06]: the forced-change-password route is
+// `/forced-change-password/$id`, so the pathname ends with the org id — never
+// the literal segment. The gate's original `endsWith('forced-change-password')`
+// short-circuit could therefore never match, and the gate kept re-navigating
+// to the page the user was already on. These tests pin the inclusion match.
+
+const { mockNavigate, mockLocation, mockExpiry } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockLocation: { value: { pathname: '/dashboard/org-1' } },
+  mockExpiry: { value: undefined as unknown },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => mockLocation.value,
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: 'org-1' }),
+}));
+
+vi.mock('@/app/context/account-bootstrap-context', () => ({
+  usePasswordExpiry: () => mockExpiry.value,
+}));
+
+import { usePasswordExpiryGate } from './use-password-expiry-gate';
+
+describe('usePasswordExpiryGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects an expired credential to the forced-change page', () => {
+    mockExpiry.value = { expired: true, hasCredential: true };
+    mockLocation.value = { pathname: '/dashboard/org-1' };
+
+    renderHook(() => usePasswordExpiryGate('org-1'));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/forced-change-password/$id',
+      params: { id: 'org-1' },
+      replace: true,
+    });
+  });
+
+  it('short-circuits on the forced-change page itself, whose pathname ends with the id (#2085[06])', () => {
+    mockExpiry.value = { expired: true, hasCredential: true };
+    // The real pathname shape: the id is the last segment, so an
+    // endsWith('forced-change-password') check would miss it and loop.
+    mockLocation.value = { pathname: '/forced-change-password/org-1' };
+
+    renderHook(() => usePasswordExpiryGate('org-1'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while the credential is not expired', () => {
+    mockExpiry.value = { expired: false, hasCredential: true };
+    mockLocation.value = { pathname: '/dashboard/org-1' };
+
+    renderHook(() => usePasswordExpiryGate('org-1'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/auth/two-factor-enroll-guard.test.tsx
+++ b/services/platform/app/features/auth/two-factor-enroll-guard.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, waitFor } from '@/tests/utils/render';
+
+// Regression cover for #2085[04]: the /2fa-enroll wall must not trap a user
+// who has no reason to be there. An already-enrolled user is bounced back out
+// (parity with the forced-change-password guard), while a not-yet-enrolled
+// user — enforced or voluntary — stays and gets the enrollment form. The
+// guard is scoped to the initial password step so an in-progress enrollment
+// is never interrupted (verifyTotp flips twoFactorEnabled before the backup
+// codes are shown).
+
+const { mockNavigate, mockSearch, mockStatus } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockSearch: { value: {} as Record<string, unknown> },
+  mockStatus: { value: undefined as unknown },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: unknown) => options,
+  // LogoLink renders a router <Link> in the page header.
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+  redirect: vi.fn(),
+  useNavigate: () => mockNavigate,
+  useSearch: () => mockSearch.value,
+}));
+
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => ({ data: mockStatus.value }),
+}));
+
+vi.mock('@/app/hooks/use-react-query-client', () => ({
+  useReactQueryClient: () => ({
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// The page calls the bare `toast` export; the verify step's CopyableField
+// pulls `useToast` via `useCopy`.
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: vi.fn(),
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    getSession: vi.fn(),
+    twoFactor: {
+      enable: vi.fn(),
+      verifyTotp: vi.fn(),
+    },
+  },
+}));
+
+// The passkey dialog drives a WebAuthn browser ceremony irrelevant to the
+// guard under test.
+vi.mock(
+  '@/app/features/settings/account/components/passkey-register-dialog',
+  () => ({ PasskeyRegisterDialog: () => null }),
+);
+
+import { TwoFactorEnrollPage } from '@/app/routes/2fa-enroll';
+import { authClient } from '@/lib/auth-client';
+
+function status(overrides?: Record<string, unknown>) {
+  return {
+    authenticated: true,
+    twoFactorEnabled: false,
+    hasPasskey: false,
+    enforced: true,
+    decision: 'blocked',
+    graceUntil: null,
+    hasCredential: true,
+    exemptSsoUsers: false,
+    backupCodesRemaining: null,
+    ...overrides,
+  };
+}
+
+describe('TwoFactorEnrollPage – enrollment-wall guard (#2085[04])', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearch.value = {};
+  });
+
+  it('bounces an already-enrolled user off the wall', async () => {
+    mockStatus.value = status({ twoFactorEnabled: true, decision: 'ok' });
+
+    render(<TwoFactorEnrollPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/dashboard',
+        replace: true,
+      }),
+    );
+  });
+
+  it('honours redirectTo when bouncing an enrolled user', async () => {
+    mockStatus.value = status({ twoFactorEnabled: true, decision: 'ok' });
+    mockSearch.value = { redirectTo: '/dashboard/org-1/settings/account' };
+
+    render(<TwoFactorEnrollPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/dashboard/org-1/settings/account',
+        replace: true,
+      }),
+    );
+  });
+
+  it('keeps a not-yet-enrolled user on the wall with the enrollment form', () => {
+    mockStatus.value = status();
+
+    render(<TwoFactorEnrollPage />);
+
+    expect(
+      screen.getByRole('button', { name: 'Enable two-factor' }),
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('never interrupts an in-progress enrollment when the status flips mid-flow', async () => {
+    mockStatus.value = status();
+    vi.mocked(authClient.twoFactor.enable).mockResolvedValue({
+      data: {
+        totpURI: 'otpauth://totp/Tale:user?secret=JBSWY3DPEHPK3PXP',
+        backupCodes: ['aaaa-bbbb', 'cccc-dddd'],
+      },
+      error: null,
+      // oxlint-disable-next-line typescript/no-explicit-any -- better-auth's full response envelope is irrelevant to the guard under test
+    } as any);
+
+    const { user, rerender } = render(<TwoFactorEnrollPage />);
+
+    await user.type(screen.getByLabelText('Password'), 'hunter2!');
+    await user.click(screen.getByRole('button', { name: 'Enable two-factor' }));
+    await screen.findByLabelText('Verification code');
+
+    // verifyTotp flips twoFactorEnabled server-side before the backup codes
+    // are acknowledged — the guard must not bounce the user off the wall now.
+    mockStatus.value = status({ twoFactorEnabled: true, decision: 'ok' });
+    rerender(<TwoFactorEnrollPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Verification code')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/settings/account/components/two-factor-section.test.tsx
+++ b/services/platform/app/features/settings/account/components/two-factor-section.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, waitFor, within } from '@/tests/utils/render';
+
+// Regression cover for #2085[19]: disabling 2FA from the Account page must
+// warn when the org enforces 2FA — otherwise the user disables it with no
+// hint and is hard-walled back into enrollment at their next sign-in. The
+// design is warn-not-block (the enrollment wall is the actual enforcement),
+// so the disable call itself must keep working.
+
+const { mockStatus } = vi.hoisted(() => ({
+  mockStatus: { value: {} as Record<string, unknown> },
+}));
+
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => ({ data: mockStatus.value }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    twoFactor: {
+      disable: vi.fn().mockResolvedValue({}),
+      enable: vi.fn(),
+      verifyTotp: vi.fn(),
+      generateBackupCodes: vi.fn(),
+    },
+  },
+}));
+
+// The backup-codes dialog lives in a root provider; the section only needs
+// the show() callback.
+vi.mock('./backup-codes-dialog-provider', () => ({
+  useShowBackupCodes: () => vi.fn(),
+}));
+
+// FormDialog resolves the org id from router params for its unsaved-changes
+// guard; there is no router in a component test.
+vi.mock('@/app/hooks/use-organization-id', () => ({
+  useOrganizationId: () => 'org-1',
+}));
+
+import { authClient } from '@/lib/auth-client';
+
+import { TwoFactorSection } from './two-factor-section';
+
+function enrolledStatus(enforced: boolean) {
+  return {
+    authenticated: true,
+    twoFactorEnabled: true,
+    hasPasskey: false,
+    enforced,
+    decision: 'ok',
+    graceUntil: null,
+    hasCredential: true,
+    exemptSsoUsers: false,
+    backupCodesRemaining: 10,
+  };
+}
+
+const ENFORCED_WARNING =
+  /your organization requires two-factor authentication\. if you disable it/i;
+
+describe('TwoFactorSection – disable under org enforcement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a standing warning in the disable dialog when the org enforces 2FA (#2085[19])', async () => {
+    mockStatus.value = enrolledStatus(true);
+    const { user } = render(<TwoFactorSection />);
+
+    await user.click(screen.getByRole('button', { name: 'Disable' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Disable' });
+    expect(within(dialog).getByText(ENFORCED_WARNING)).toBeInTheDocument();
+  });
+
+  it('shows no enforcement warning when the org does not enforce 2FA', async () => {
+    mockStatus.value = enrolledStatus(false);
+    const { user } = render(<TwoFactorSection />);
+
+    await user.click(screen.getByRole('button', { name: 'Disable' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Disable' });
+    expect(
+      within(dialog).queryByText(ENFORCED_WARNING),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still allows the disable to proceed (warn, not block)', async () => {
+    mockStatus.value = enrolledStatus(true);
+    const { user } = render(<TwoFactorSection />);
+
+    await user.click(screen.getByRole('button', { name: 'Disable' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Disable' });
+
+    await user.type(within(dialog).getByLabelText('Password'), 'hunter2!');
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() =>
+      expect(authClient.twoFactor.disable).toHaveBeenCalledWith({
+        password: 'hunter2!',
+      }),
+    );
+  });
+});

--- a/services/platform/app/routes/2fa-enroll.tsx
+++ b/services/platform/app/routes/2fa-enroll.tsx
@@ -73,7 +73,8 @@ function downloadBackupCodes(codes: string[]) {
   URL.revokeObjectURL(url);
 }
 
-function TwoFactorEnrollPage() {
+// Exported for tests (mirrors `LogInPage` in `_auth/log-in.tsx`).
+export function TwoFactorEnrollPage() {
   const { t } = useT('twoFactor');
   const navigate = useNavigate();
   const queryClient = useReactQueryClient();


### PR DESCRIPTION
## Summary

Closes #2085.

All six code fixes enumerated in #2085 already landed on `main` via #2118 and its follow-ups (6ecb7c70b, c1ac55609, 4c85d2fee, a5ac8abe0) — I verified each site against the current code. What was missing to close the issue out safely was regression cover: only [12] and [13] were pinned by tests. This PR adds the missing regression tests (happy path + the guarded edge per item) so none of the fixed behaviours can silently regress, and re-verifies the two already-pinned items.

## Item map

| Item | Fix (already on main) | Regression cover |
| --- | --- | --- |
| [04] /2fa-enroll wall traps non-blocked users | `app/routes/2fa-enroll.tsx` already-enrolled bounce (4c85d2fee, scoped by a5ac8abe0) | **Added** `app/features/auth/two-factor-enroll-guard.test.tsx` (30c10cbd8): bounce + redirectTo, stays for un-enrolled, never interrupts mid-enrollment |
| [05] banners use assertive `role="alert"` | both banners ship `role="status"` (c1ac55609) | **Added** `two-factor-grace-banner.test.tsx` + `two-factor-low-backup-codes-banner.test.tsx` (affdd0800): polite status role, no alert, hide conditions |
| [06] dead `endsWith('forced-change-password')` guard | `use-password-expiry-gate.ts` inclusion match (c1ac55609) | **Added** `use-password-expiry-gate.test.ts` (b32cf23a1): short-circuit on the real `/forced-change-password/<id>` shape, redirect when expired, no-op otherwise |
| [12] inert "auto-assign roles from the IdP" toggle | `RoleMappingRulesEditor` in the SSO form (4c85d2fee) | Already pinned: `enterprise-sso-form.test.tsx` "adds a role-mapping rule and saves it (#2085[12])" — re-run green |
| [13] SCIM Group PATCH clear-all drops adds | composition in `scim/internal_mutations.ts` (6ecb7c70b) | Already pinned: `scim/provisioning_logic.test.ts` (#2085[13]) — re-run green |
| [19] enforced-2FA disable has no warning | `disableEnforcedWarning` in the disable dialog (4c85d2fee) | **Added** `two-factor-section.test.tsx` (385aafc92): warning when enforced, none otherwise, warn-not-block |

Each new test was watched fail against the pre-fix code (guard/role/match/warning reverted locally) and pass against the current code. Only production-code change: `TwoFactorEnrollPage` is now exported from the route file for the test, mirroring `LogInPage`.

## Tests

- `bunx vitest --run --config vitest.ui.config.ts` on the five new files + `enterprise-sso-form.test.tsx` → 6 files, 31 tests passing
- `bunx vitest --run --project server convex/scim/` → 3 files, 54 tests passing
- `bunx tsc --noEmit` (platform) clean
- `bunx oxlint --type-aware` on changed files → 0 warnings, 0 errors
- `oxfmt --check` clean; opengrep SAST on changed files → 0 findings

No new user-visible strings (no locale changes needed).