### PR TITLE
test: manual test guides for the web and docs services

### DIFF
--- a/services/docs/tests/manual/README.md
+++ b/services/docs/tests/manual/README.md
@@ -1,0 +1,58 @@
+# Manual test plans (AI-directed) — docs site
+
+Modular, codebase-grounded test playbooks for the Tale **documentation site**
+(`https://tale.dev/docs`), written so either a human QA tester or an AI agent
+driving a browser can execute them against a running instance (or the live
+site). One guide per area; each lists concrete test cases (functional,
+boundary/error, accessibility, performance), cross-references the automated
+test that already covers each case, and carries an **Issues Found** table for
+collecting defects.
+
+These are manual / exploratory / accessibility passes — **not** the automated
+suites. The docs already have a strong **static** gate: the vitest content
+suite (`tests/*.test.ts`) validates links, images, navigation entries, locale
+mirrors, frontmatter, and page structure at build time, and the Playwright
+smoke spec ([`tests/e2e/specs/smoke.spec.ts`](../e2e/specs/smoke.spec.ts))
+checks the rendered shell. What **no** automation covers is the reader-facing
+runtime behaviour — search quality, scroll-spy, copy buttons, theme, mobile
+drawer — and that is what these guides exercise. The platform app has its own
+guide set in
+[`services/platform/tests/manual/`](../../../platform/tests/manual/README.md);
+new guides here copy its
+[TEMPLATE.md](../../../platform/tests/manual/TEMPLATE.md) (which documents the
+authoring conventions).
+
+## How to use
+
+1. Bring the site up (or pick the live site) via [SETUP.md](SETUP.md), then
+   run its smoke checklist.
+2. Run [navigation.md](navigation.md) first, then the rest in any order.
+3. For each defect, add a row to that guide's **Issues Found** table (test id,
+   route, severity, description, screenshot).
+4. Finish with [accessibility.md](accessibility.md) as the cross-cutting
+   sweep.
+
+## Guides
+
+| Guide                                | Area                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| [navigation.md](navigation.md)       | sidebar integrity, breadcrumbs, prev/next, TOC scroll-spy, 404s      |
+| [search.md](search.md)               | search dialog, shortcuts, results, recents, per-locale index         |
+| [locale.md](locale.md)               | `/de` + `/fr` trees, language switcher, translated chrome            |
+| [content.md](content.md)             | code blocks + copy buttons, heading deep links, images, page actions |
+| [accessibility.md](accessibility.md) | cross-cutting WCAG 2.1 AA sweep (incl. theme switching)              |
+
+## Coverage matrix
+
+Status reflects the **area** as a whole; each guide's own _Automated coverage_
+table is case-by-case. "vitest content suite" = the static corpus checks —
+they prove the **source** is well-formed, not that the **rendered site**
+behaves.
+
+| Guide         | Status         | Automated by                                                                                                          |
+| ------------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| navigation    | 🔶 partial     | `smoke.spec.ts` (sidebar links render) + vitest `navigation.test.ts` (every nav entry resolves to a page)             |
+| search        | 🔶 partial     | `smoke.spec.ts` (palette opens) + `app/features/search/dialog.test.tsx`; ranking/recents/locale index manual          |
+| locale        | 🔶 partial     | vitest `locale-tree.test.ts` + `locale-outline.test.ts` + `docs.test.ts` (mirrors exist, outlines match, voice rules) |
+| content       | 🔶 partial     | vitest `links.test.ts`, `images.test.ts`, `structure-*.test.ts`, `frontmatter.test.ts` (source-level only)            |
+| accessibility | ⛔ manual-only | — (no axe layer in this service's e2e; shared `@tale/ui` components carry `vitest-axe`)                               |

--- a/services/docs/tests/manual/SETUP.md
+++ b/services/docs/tests/manual/SETUP.md
@@ -1,0 +1,53 @@
+# Setup & smoke
+
+Bring the docs site up (or point at the live one) and confirm the shell
+renders. Every guide in this directory assumes the environment this file
+produces. Run this first; run it once per session.
+
+These are the manual / AI-directed playbooks — they drive a **running** site
+through a browser. They are distinct from the automated Playwright smoke suite
+([`tests/e2e/specs/smoke.spec.ts`](../e2e/specs/smoke.spec.ts)) and the large
+vitest **content** suite (`services/docs/tests/*.test.ts` — links, images,
+navigation, locale mirrors, structure), which run headless against the
+markdown corpus. The site is public — **no sign-in exists or is needed**.
+
+## 1. Pick a mode
+
+| Mode         | Command / URL                                               | Notes                                                                 |
+| ------------ | ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| **A. Live**  | `https://tale.dev/docs`                                     | production base path is `/docs/` (`DOCS_BASE_URL`)                    |
+| **B. Local** | `bun run --filter @tale/docs dev` → `http://localhost:3002` | builds the per-locale search index first, then Vite; base path is `/` |
+
+Content comes from the repo-root [`docs/`](../../../../docs/) tree
+(`docs/{en,de,fr}/**.md` + `docs/nav.json`); the URL of a page is its slug —
+`docs/en/platform/chat/basics.md` serves at `{base}/platform/chat/basics`,
+German at `{base}/de/platform/chat/basics`.
+
+## 2. Conventions
+
+- **`{base}`** in the guides = `https://tale.dev/docs` (mode A) or
+  `http://localhost:3002` (mode B).
+- **Labels**: controls name their i18n key from
+  [`services/docs/messages/en.json`](../../messages/en.json) (shared-UI
+  controls from `packages/ui/src/i18n/messages/en.json`). A few controls are
+  hard-coded English (noted inline in the guides) — treat untranslated output
+  on `/de`/`/fr` for those as a **candidate finding**, not a locale bug in
+  your run.
+- **Checkable expectations**: URL/hash changes, visible elements, clipboard
+  contents, values that survive a reload.
+- **Screenshots**: `services/docs/tests/screenshots/<YYYY-MM-DD_HH_MM>/<area>/`
+  — create the folder before a run.
+
+## 3. Smoke — the shell renders
+
+| Check          | Route / control                           | Verify                                                                                                                               |
+| -------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Landing        | `{base}/`                                 | h1 **Tale documentation** renders; sidebar + header visible                                                                          |
+| Sidebar        | `{base}/`                                 | the six top groups render: **Start here**, **Cloud**, **Self-hosted**, **Platform**, **Tutorials**, **Development** (`nav.groups.*`) |
+| A content page | `{base}/self-hosted/install/quickstart`   | body + **On this page** TOC render                                                                                                   |
+| Search         | header **Open search** (`nav.openSearch`) | the dialog opens with the **Search documentation…** input                                                                            |
+| Locales        | `{base}/de`, `{base}/fr`                  | localized landing renders                                                                                                            |
+
+```
+Smoke: ___/5 checks pass   Console errors: ___   Status: PASS / FAIL
+```

--- a/services/docs/tests/manual/accessibility.md
+++ b/services/docs/tests/manual/accessibility.md
@@ -1,0 +1,76 @@
+# Accessibility — Manual Test Plan (cross-cutting)
+
+> **Purpose**: A WCAG 2.1 **Level AA** sweep across the docs site, including
+> the theme switcher and the mobile drawer. Tale's standard (root
+> [`AGENTS.md`](../../../../AGENTS.md) → Accessibility) is mandatory. Per-area
+> guides carry their own `A#` rows; this guide is the holistic pass and the
+> place to log _systemic_ findings.
+
+## Scope & routes
+
+Run each check on: `{base}/` (landing), one long content page
+(`{base}/self-hosted/install/quickstart`), the search dialog, and the 404
+page. Add a ≤ 767 px viewport pass for the mobile drawer rows.
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md). Drive the keyboard checks with the
+keyboard only; a screen reader helps the announce checks. There is **no axe
+layer in this service's e2e suite** — full-page audits are manual/assisted
+here; shared `@tale/ui` components carry `vitest-axe` coverage.
+
+> **Agent note**: assert structure via DOM scans. Known hard-coded English
+> strings in the shell (skip link **Skip to main content**, code-copy, page
+> actions) — verify they exist and work here; their missing localization is
+> logged once via [locale.md](locale.md).
+
+## Automated coverage
+
+| Layer                           | Status         | Where                                                                                       |
+| ------------------------------- | -------------- | ------------------------------------------------------------------------------------------- |
+| Per-component axe (WCAG 2.1 AA) | ✅ automated   | `@tale/ui` component tests (`checkAccessibility()` via `vitest-axe`) + Storybook a11y addon |
+| Source heading hierarchy        | ✅ automated   | vitest `structure-headings.test.ts` (per-page heading rules in the corpus)                  |
+| Full-page audits (A1–A8)        | ⛔ manual-only | — this guide                                                                                |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only.
+
+## Functional / structural tests
+
+| ID  | Test              | Steps (route + control)                                                                                  | Expected (verifiable)                                                                                                                                                                                                                                                                        |
+| --- | ----------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Skip link         | On each surface, Tab once from page top                                                                  | First focusable is the **Skip to main content** link; it becomes visible on focus; Enter moves focus into the main content                                                                                                                                                                   |
+| A2  | Landmarks         | Query `main, header, footer, nav, aside`                                                                 | Exactly one `<main>`; sidebar `<nav aria-label="Documentation">`; breadcrumbs `<nav>` labelled **Breadcrumbs**; TOC `<aside>` labelled **On this page**; one `<header>`, one `<footer>`                                                                                                      |
+| A3  | Rendered headings | Walk headings top→bottom on landing + content page                                                       | Exactly one `<h1>` (the page title); rendered levels never skip                                                                                                                                                                                                                              |
+| A4  | Keyboard reach    | Tab through: header (logo, search, menu), sidebar, body links, page actions, prev/next, footer switchers | Everything is focusable and operable by keyboard in a sensible order; no keyboard trap; hover-revealed copy buttons appear on focus                                                                                                                                                          |
+| A5  | Visible focus     | Repeat A4 watching the focus indicator — in **both** themes                                              | A visible focus ring on every stop (`focus-visible:ring` styles); never invisible against its background                                                                                                                                                                                     |
+| A6  | Theme switch      | Footer theme switcher: **Switch theme** (`themeSwitcher.ariaLabel`) → **Dark**, reload                   | Semantics: labelled control with **Light**/**Dark**/**System** options (`themeSwitcher.*`), current option programmatically marked; the choice persists (`localStorage['tale-theme']`); contrast spot-checks (body ≥ 4.5:1, muted text ≥ 4.5:1, code tokens ≥ 4.5:1) pass in **both** themes |
+| A7  | Mobile drawer     | ≤ 767 px: header **Open navigation menu** (`nav.openMenu`)                                               | Button toggles to **Close navigation menu** (`nav.closeMenu`) with `aria-expanded`; the drawer contains the search trigger + full nav tree; Esc closes it; choosing a page closes it and navigates; body scroll locks while open                                                             |
+| A8  | Reduced motion    | With `prefers-reduced-motion: reduce`, expand sidebar groups, open search, use back-to-top               | Collapse/expand and scroll behaviours present without animation (framer-motion reduced paths; instant scroll)                                                                                                                                                                                |
+
+## Boundary & error tests
+
+| ID  | Test       | Input                                   | Expected                                                                                                                         |
+| --- | ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Zoom 200 % | Browser zoom 200 % on a content page    | No loss of content/function; body column reflows; sticky chrome doesn't swallow the viewport                                     |
+| B2  | 404 page   | Open `{base}/nope` with a screen reader | The **Page not found** heading is the page `<h1>`; the suggestions list is a labelled `<nav>` (**Did you mean**) with real links |
+
+## Performance
+
+| ID  | Metric | Target                                                                                                    |
+| --- | ------ | --------------------------------------------------------------------------------------------------------- |
+| P1  | CLS    | No visible layout shift while a content page loads (fonts/highlighting swap without reflowing the column) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ----------- | ---------------------------- | ----------- | ---------- |
+|     |         |             |                              |             |            |
+
+## Test summary
+
+```
+Area: Accessibility (docs)
+Structural: ___/8   Boundary: ___/2   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/docs/tests/manual/content.md
+++ b/services/docs/tests/manual/content.md
@@ -1,0 +1,90 @@
+# Content rendering — Manual Test Plan
+
+> **Purpose**: Exercise how a docs page renders and what a reader can do with
+> it — syntax-highlighted code blocks with copy buttons, heading deep links
+> (anchor + copy-link), the page-actions cluster (**Copy page**, **Open in**,
+> the `.md` view), **Edit on GitHub**, reading-time/last-updated metadata, and
+> images. Source-level integrity (every link resolves, every fence has a
+> language, headings well-formed) is already automated by the vitest content
+> suite — this guide covers the **rendered** behaviour it can't see.
+
+## Scope & routes
+
+Any content page works; the rows use
+`{base}/self-hosted/install/quickstart` (several code blocks in multiple
+languages, deep heading structure). Renderer:
+`app/pages/docs-page.tsx` → shared `@tale/ui` markdown stack
+(`RoutedMarkdown`, `highlighted-code.tsx`, `anchored-heading.tsx`) +
+`app/features/page-actions/page-actions.tsx`.
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — either mode. Clipboard rows
+(F2/F5/F6) need a secure context (https or localhost) and clipboard
+permission.
+
+> **Agent note**: the code **Copy code** button and the heading **Copy link to
+> this section** button are hover/focus-revealed (`opacity-0` until
+> `group-hover`/`focus-visible`) — focus or hover their container first. All
+> three copy affordances flip to a "copied" label for **1.5 s** with
+> `aria-live="polite"`; assert the clipboard content, not the flash. The
+> page-actions labels are **hard-coded English** (see [locale.md](locale.md)).
+
+## Automated coverage
+
+| Case(s)                 | Status         | Where                                                                                                                                                               |
+| ----------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1 (source shape)       | ✅ automated   | vitest `structure-code.test.ts` (every fence declares a language), `structure-headings.test.ts`, `links.test.ts`, `images.test.ts` (image paths resolve + alt text) |
+| F1–F8 (rendered), B1–B3 | ⛔ manual-only | — (no e2e renders a content page beyond the smoke shell)                                                                                                            |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test               | Steps (route + control)                                                                                              | Expected (verifiable)                                                                                                                                                                                                                                  |
+| --- | ------------------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| F1  | Code highlighting  | On the quickstart, inspect the `bash` and `powershell` blocks — in **both** themes                                   | Shiki token colouring renders (not a plain `<pre>`); the palette follows the active theme; long blocks (> 12 lines) show line numbers                                                                                                                  |
+| F2  | Copy code          | Hover/focus a code block; click **Copy code** (hard-coded aria-label)                                                | The button flips to **Copied** (`aria-live="polite"`, reverts after 1.5 s); the clipboard holds the block's source **without** a trailing newline artefact; paste matches what's displayed                                                             |
+| F3  | Heading anchors    | Hover an H2; click the anchor affordance, then click **Copy link to this section**                                   | The heading has a stable GitHub-style id (verified live: `#step-1-install-the-cli`); the URL hash updates; the copy-link button flips to **Link copied** and the clipboard holds the absolute URL incl. hash                                           |
+| F4  | Deep link entry    | Open the F3 URL (with hash) in a fresh tab                                                                           | The page loads scrolled to that heading, offset below the sticky header (`scroll-mt`), the right sidebar/TOC state matches ([navigation.md](navigation.md) F5)                                                                                         |
+| F5  | Copy page          | Click **Copy page** in the page-actions cluster                                                                      | Button flips to **Copied**; the clipboard holds the page **as markdown** (frontmatter title + body, not HTML)                                                                                                                                          |
+| F6  | Open in / .md view | Open the **Open in** menu; inspect **Open in ChatGPT**, **Open in Claude**, **Open in Cursor**, **View as Markdown** | Menu opens (Esc closes, focus returns); the three "Open in" items deep-link to `chatgpt.com` / `claude.ai` / `cursor://` with the page's `.md` URL embedded in the prompt; **View as Markdown** serves `{pageUrl}.md` as plaintext markdown (HTTP 200) |
+| F7  | Edit on GitHub     | Click **Edit on GitHub** (`docs.editOnGithub`)                                                                       | Opens `https://github.com/tale-project/tale/edit/main/docs/{locale}/{slug}.md` — the path matches the page actually being read (spot-check on a `/de` page too)                                                                                        |
+| F8  | Page metadata      | Read the meta row under the H1                                                                                       | **{n} min read** (`docs.readingTime`) with a plausible n, and — when the build carries a date — **Last updated {date}** (`docs.lastUpdated`)                                                                                                           |
+
+## Boundary & error tests
+
+| ID  | Test                  | Input                                                                                                                 | Expected                                                                                                                                         |
+| --- | --------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| B1  | Clipboard unavailable | Deny clipboard permission (or insecure context); click **Copy code**                                                  | No crash — the failure is logged (`console.warn '[code-block] clipboard write failed'`), the button doesn't get stuck in **Copied**              |
+| B2  | Images                | Sweep rendered pages for `<img>` (the corpus currently ships none — `images.test.ts` guards paths/alt when they land) | Any image renders (no broken-image icon), has non-empty `alt`, and doesn't overflow its column; record **N/A** if the corpus still has no images |
+| B3  | External links        | Click an external link in the body (e.g. the OpenRouter link)                                                         | Opens the external site; external links don't hijack the SPA router; internal links stay client-side navigations                                 |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check          | Expected                                                                                                                                                                       |
+| --- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A1  | Copy controls  | All copy affordances are real `<button>`s with accessible names that update on state (**Copy code** → **Copied**), reachable by keyboard (focus reveals the hover-hidden ones) |
+| A2  | Content markup | The body is semantic HTML — real headings (levels never skip), `<ul>/<ol>` lists, `<code>`/`<pre>` for code; blockquote asides render as `<blockquote>`                        |
+| A3  | Actions menu   | The **Open in** menu is keyboard-operable; Esc closes it and restores focus to the trigger                                                                                     |
+
+## Performance
+
+| ID  | Metric           | Target                                                                                                                                 |
+| --- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| P1  | Highlight settle | Code blocks are highlighted **< 1 s** after page render (Shiki runs client-side post-hydration; the plain fallback must never persist) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ----------- | ---------------------------- | ----------- | ---------- |
+|     |         |             |                              |             |            |
+
+## Test summary
+
+```
+Area: Content rendering (docs)
+Functional: ___/8   Boundary: ___/3   A11y: ___/3   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/docs/tests/manual/locale.md
+++ b/services/docs/tests/manual/locale.md
@@ -1,0 +1,84 @@
+# Locale versions — Manual Test Plan
+
+> **Purpose**: Exercise the localized docs — English unprefixed, German and
+> French under `/de/…` and `/fr/…` (the vitest suite guarantees every English
+> page has a DE/FR mirror), the footer language switcher, translated chrome
+> vs. hard-coded strings, and `<html lang>`. The per-locale **search** index
+> is covered in [search.md](search.md) F6.
+
+## Scope & routes
+
+| Surface        | Route                                                             |
+| -------------- | ----------------------------------------------------------------- |
+| English tree   | `{base}/`, `{base}/{slug}`                                        |
+| German tree    | `{base}/de`, `{base}/de/{slug}`                                   |
+| French tree    | `{base}/fr`, `{base}/fr/{slug}`                                   |
+| Switcher       | footer (shared `LanguageSwitcher`, `@tale/ui`)                    |
+| Content source | `docs/{en,de,fr}/**.md`; messages `services/docs/messages/*.json` |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — either mode.
+
+> **Agent note**: the switcher trigger is the footer button aria-labelled
+> **Switch language** (`languageSwitcher.ariaLabel`) showing the current
+> locale name; items are `menuitem`s **English** / **Deutsch** / **Français**.
+> Several docs-shell controls are hard-coded English (the skip link, the code
+> **Copy code** button, the page-actions menu, heading **Copy link to this
+> section**) — on `/de` they will read English; log them once as a
+> localization finding, not per page.
+
+## Automated coverage
+
+| Case(s)            | Status         | Where                                                                                                                                         |
+| ------------------ | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| F2 (mirror exists) | ✅ automated   | vitest `locale-tree.test.ts` (every EN page has DE/FR mirrors) + `locale-outline.test.ts` (same outline) + `docs.test.ts` (voice/terminology) |
+| F1, F3–F5, B1–B2   | ⛔ manual-only | — (no e2e drives the switcher or asserts rendered locale chrome)                                                                              |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test                  | Steps (route + control)                                                                     | Expected (verifiable)                                                                                                                                                                   |
+| --- | --------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Switch preserves page | On `{base}/self-hosted/install/quickstart`, footer → **Switch language** → **Deutsch**      | URL commits `{base}/de/self-hosted/install/quickstart` — same page, German content; switching back to **English** drops the prefix                                                      |
+| F2  | German tree           | Open `{base}/de` and one nested page                                                        | Landing + page render translated content from `docs/de/`; sidebar group labels are German (`messages/de.json` `nav.groups.*`); breadcrumbs/TOC/prev-next chrome is German (`docs.*`)    |
+| F3  | French tree           | Open `{base}/fr` and one nested page                                                        | Same as F2 for French                                                                                                                                                                   |
+| F4  | `<html lang>`         | Read `document.documentElement.lang` on `{base}/`, `{base}/de`, `{base}/fr`                 | `en` / `de` / `fr` respectively — stays correct after SPA navigation between locales                                                                                                    |
+| F5  | Current-locale mark   | Open the switcher on `{base}/fr`                                                            | The trigger shows **Français**; the menu marks it `aria-current="true"`; picking the current locale is a no-op                                                                          |
+| F6  | Locale cookie         | With the `tale_locale=de` cookie set (e.g. after visiting `tale.dev/de`), request `{base}/` | The server 302-redirects to `{base}/de` (verified live) — the docs and the marketing site share the `tale_locale` cookie (`packages/ui/src/i18n/cookie.ts`), so one language spans both |
+
+## Boundary & error tests
+
+| ID  | Test           | Input                            | Expected                                                                                                                |
+| --- | -------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| B1  | Localized 404  | Open `{base}/de/nope-not-a-page` | The 404 renders in **German** (`messages/de.json` `docs.notFoundTitle` etc.); **Back to docs home** targets `{base}/de` |
+| B2  | Unknown prefix | Open `{base}/es/quickstart`      | Not a locale — treated as an unknown English-tree slug: the styled 404 (with suggestions), no crash                     |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check             | Expected                                                                                                                    |
+| --- | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Switcher keyboard | Same contract as the marketing site: labelled trigger, `menu`/`menuitem` semantics, ArrowUp/Down cycling, Esc returns focus |
+| A2  | Lang attribute    | `<html lang>` always matches the rendered language (F4)                                                                     |
+
+## Performance
+
+| ID  | Metric        | Target                                            |
+| --- | ------------- | ------------------------------------------------- |
+| P1  | Locale switch | The sibling-locale page settles in **< 1 s** warm |
+
+## Issues Found
+
+| #   | Test ID | Route / URL                                               | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Screenshot |
+| --- | ------- | --------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | F2      | `https://tale.dev/docs/de/self-hosted/install/quickstart` | med                          | Hard-coded English chrome on localized pages (2026-07-06 live pass): the skip link **Skip to main content** (`app/routes/__root.tsx`), the sidebar landmark `aria-label="Documentation"` (`docs-sidebar.tsx`), the code **Copy code**/**Copied** button (`@tale/ui` `highlighted-code.tsx`), the page actions **Copy page**/**Open in …** (`page-actions.tsx`), and the heading **Copy link to this section** (`@tale/ui` `anchored-heading.tsx`). Breadcrumbs/TOC are correctly German (**Brotkrumennavigation**, **Auf dieser Seite**) | —          |
+
+## Test summary
+
+```
+Area: Locale versions (docs)
+Functional: ___/6   Boundary: ___/2   A11y: ___/2   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/docs/tests/manual/navigation.md
+++ b/services/docs/tests/manual/navigation.md
@@ -1,0 +1,89 @@
+# Navigation — Manual Test Plan
+
+> **Purpose**: Exercise every way a reader moves through the docs — the
+> sidebar tree (`docs/nav.json`), collapsible sub-groups, breadcrumbs,
+> previous/next links, the on-page TOC with scroll-spy, the back-to-top
+> button, the mobile drawer, and the styled 404 with did-you-mean
+> suggestions. Search has its own guide ([search.md](search.md)).
+
+## Scope & routes
+
+| Surface        | Route                                                               |
+| -------------- | ------------------------------------------------------------------- |
+| Landing        | `{base}/`                                                           |
+| Content page   | any slug, e.g. `{base}/self-hosted/install/quickstart`              |
+| Nested group   | `{base}/platform/chat/…` (sub-groups inside **Platform**)           |
+| Unknown URL    | `{base}/nope-not-a-page` → styled 404                               |
+| Sidebar source | [`docs/nav.json`](../../../../docs/nav.json) → `lib/content/nav.ts` |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — either mode. The sidebar tree is
+build-time static; `navigation.test.ts` already guarantees every entry
+resolves to a page, so this guide focuses on **behaviour**, not link rot.
+
+> **Agent note**: the sidebar is the `<nav aria-label="Documentation">`
+> landmark; the active link carries `aria-current="page"`. Group toggles are
+> buttons with `aria-expanded`. The TOC is the `<aside>` labelled **On this
+> page** (`docs.onThisPage`) and only renders at the `xl` breakpoint —
+> use a ≥ 1280 px viewport for F5/F6. Scroll-spy marks the active TOC item
+> with `aria-current="true"`.
+
+## Automated coverage
+
+| Case(s)      | Status         | Where                                                                                 |
+| ------------ | -------------- | ------------------------------------------------------------------------------------- |
+| F1           | 🔶 partial     | `smoke.spec.ts` (sidebar shows links) + vitest `navigation.test.ts` (entries resolve) |
+| F2–F8, B1–B3 | ⛔ manual-only | —                                                                                     |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test               | Steps (route + control)                                                                                        | Expected (verifiable)                                                                                                                                                                                                                              |
+| --- | ------------------ | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Sidebar tree       | On `{base}/`, read the sidebar                                                                                 | The six top groups render in `nav.json` order: **Start here**, **Cloud**, **Self-hosted**, **Platform**, **Tutorials**, **Development** (`nav.groups.*`); clicking a page link commits its slug URL and renders that page                          |
+| F2  | Sub-group collapse | In **Platform**, click a sub-group header (e.g. **Chat**, `nav.groups.chat`)                                   | The button toggles `aria-expanded` and the child links show/hide; collapsing does **not** navigate                                                                                                                                                 |
+| F3  | Active state       | Open `{base}/platform/chat/basics` directly (deep link)                                                        | The sidebar auto-expands every ancestor group of the active page; the active link has `aria-current="page"` and is scrolled into view within the sidebar                                                                                           |
+| F4  | Breadcrumbs        | On a nested page, read the `<nav aria-label>` = **Breadcrumbs** (`docs.breadcrumbs`)                           | Trail = **Home** (`docs.home`, links to `{base}/`) → group labels → current page (marked `aria-current="page"`, not a link); the landing page (`index`) shows **no** breadcrumbs; clicking a crumb navigates there                                 |
+| F5  | TOC + scroll-spy   | ≥ 1280 px viewport, on a long page (e.g. `{base}/self-hosted/install/quickstart`): scroll through the sections | The **On this page** aside lists the page's H2/H3s; as sections cross the viewport the matching item gains `aria-current="true"`; clicking an item smooth-scrolls to the heading and updates the URL hash without adding a history entry per click |
+| F6  | Prev/next          | On a page in the middle of a group, scroll to the page bottom                                                  | **Previous** (`docs.previous`) and **Next** (`docs.next`) cards link to the flattened-nav neighbours; the first page has no Previous, the last no Next; clicking navigates and scrolls to top                                                      |
+| F7  | Back to top        | Scroll a long page > 600 px down                                                                               | The **Back to top** button (`docs.backToTop`) fades in (fixed, bottom-right); clicking it returns to the top and it disappears again                                                                                                               |
+| F8  | Header + logo      | Click the header logo (aria-label **Tale documentation home**, `nav.homeAriaLabel`) from a deep page           | Returns to `{base}/` (locale-preserving: from `/de/…` it returns to `{base}/de`)                                                                                                                                                                   |
+
+## Boundary & error tests
+
+| ID  | Test             | Input                                                     | Expected                                                                                                                                                                                                                                                                                                               |
+| --- | ---------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Unknown URL      | Open `{base}/platform/chat/basicz` (typo)                 | The styled 404 renders **inside the docs shell**: heading **Page not found** (`docs.notFoundTitle`), body `docs.notFoundBody`, a **Did you mean** list (`docs.notFoundSuggestions`) whose Levenshtein-closest suggestion includes `platform/chat/basics`, and a **Back to docs home** button (`docs.notFoundBackHome`) |
+| B2  | Deep garbage URL | Open `{base}/x/y/z/deep/garbage`                          | Same 404 page; suggestions still render (fallback list); no crash, no blank screen                                                                                                                                                                                                                                     |
+| B3  | Stale hash       | Open a page with a hash that matches no heading (`#nope`) | The page renders at the top; no scroll error, no console exception                                                                                                                                                                                                                                                     |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check           | Expected                                                                                                                                                          |
+| --- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Landmarks       | One `<main>`; the sidebar is `<nav aria-label="Documentation">`; breadcrumbs `<nav aria-label>` = **Breadcrumbs**; the TOC an `<aside>` labelled **On this page** |
+| A2  | Keyboard        | The whole sidebar (group toggles + links) and the TOC operate by keyboard; Enter/Space toggles groups; focus visible throughout                                   |
+| A3  | Current markers | Active sidebar link `aria-current="page"`; active TOC item `aria-current="true"`; breadcrumb leaf `aria-current="page"`                                           |
+
+## Performance
+
+| ID  | Metric       | Target                                                                                   |
+| --- | ------------ | ---------------------------------------------------------------------------------------- |
+| P1  | Page-to-page | A sidebar navigation settles (new body rendered) in **< 1 s** warm — content is prebuilt |
+
+## Issues Found
+
+| #   | Test ID | Route / URL                                  | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                                      | Screenshot |
+| --- | ------- | -------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| 1   | B1      | `https://tale.dev/docs/platform/chat/basicz` | low                          | The styled 404 works (suggestions correctly offer **Platform / Chat / Basics** — 2026-07-06 live pass), but the document title stays **Tale documentation** instead of reflecting **Page not found**; the HTTP status is also 200 (SPA fallback) | —          |
+
+## Test summary
+
+```
+Area: Navigation (docs)
+Functional: ___/8   Boundary: ___/3   A11y: ___/3   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/docs/tests/manual/search.md
+++ b/services/docs/tests/manual/search.md
@@ -1,0 +1,85 @@
+# Search — Manual Test Plan
+
+> **Purpose**: Exercise the docs search — the header trigger and the
+> **Cmd/Ctrl+K** shortcut, the shared `@tale/ui` `SearchCommand` dialog over a
+> prebuilt MiniSearch index (one per locale,
+> `scripts/build-search-index.ts`), result navigation, empty/short/no-result
+> states, and the recent-searches store.
+
+## Scope & routes
+
+| Surface       | Where                                                                                        |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| Trigger       | header button **Open search** (`nav.openSearch`) — icon at mobile, labelled field at desktop |
+| Shortcut      | **Cmd/Ctrl+K** anywhere (`app/routes/__root.tsx`)                                            |
+| Dialog        | `app/features/search/dialog.tsx` → `@tale/ui` `SearchCommand`                                |
+| Index         | `{base}/search-index-{locale}.json` (static, built per locale)                               |
+| Recents store | `localStorage['tale.docs.recentSearches.v1']`                                                |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — either mode (mode B builds the
+index in its `dev` script). Clear the recents key for a clean F5 run.
+
+> **Agent note**: the dialog is lazy-loaded — the first open may take a beat.
+> Strings resolve from the `search.*` namespace in
+> `services/docs/messages/{locale}.json` (the docs keys override the `@tale/ui`
+> defaults). Assert navigation by URL commit, not by result-row styling.
+
+## Automated coverage
+
+| Case(s)          | Status         | Where                                                                                    |
+| ---------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| F1               | ✅ automated   | `smoke.spec.ts` (open via header button → placeholder input visible)                     |
+| F2–F6            | 🔶 partial     | component `app/features/search/dialog.test.tsx` (wiring); real index + navigation manual |
+| B1–B3, A1–A3, P1 | ⛔ manual-only | —                                                                                        |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test             | Steps (route + control)                                                                         | Expected (verifiable)                                                                                                                                                                                                                                                    |
+| --- | ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| F1  | Open + close     | Click **Open search** (`nav.openSearch`); then press **Esc**; then press **Cmd/Ctrl+K**         | The dialog opens with the **Search documentation…** input (`search.placeholder`) focused; Esc closes it; the shortcut opens it from any page and closes it again when pressed while open                                                                                 |
+| F2  | Empty state      | Open the dialog, type nothing                                                                   | Shows **Start typing to search the docs.** (`search.empty`) + hint (`search.emptyHint`) — or **Recent searches** once F5 has history                                                                                                                                     |
+| F3  | Results + select | Type `quickstart`                                                                               | Result rows from the index appear (match highlighting); a result count matching `search.results` is announced; **Enter** (or click) on the top hit commits its page URL and closes the dialog                                                                            |
+| F4  | Keyboard nav     | With results open, press **ArrowDown/ArrowUp**, then **Enter**                                  | Selection moves row to row (footer shows the tips `search.tipNavigate` / `search.tipSelect` / `search.tipClose`); Enter opens the selected page                                                                                                                          |
+| F5  | Recents          | Search + open a result; reopen the dialog empty                                                 | **Recent searches** (`search.recent`) lists the query; the row's **Remove from recent** control (`search.removeRecent`) deletes one; **Clear** (`search.clearRecent`) empties the list; the store `tale.docs.recentSearches.v1` reflects each step and survives a reload |
+| F6  | Locale index     | On `{base}/de`, open search and type a German term from a translated page (e.g. `Schnellstart`) | Hits come from the **German** index (`search-index-de.json`) and link into `/de/…` pages; the dialog strings render German (`messages/de.json` `search.*`)                                                                                                               |
+
+## Boundary & error tests
+
+| ID  | Test          | Input                                               | Expected                                                                                                                       |
+| --- | ------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| B1  | Short query   | A single character                                  | **Keep typing to search…** (`search.keepTyping`) — no result list, no error                                                    |
+| B2  | No results    | `xyzzyplugh`                                        | **No results found** (`search.noResultsTitle`) + **Try different keywords or browse the navigation.** (`search.noResultsHint`) |
+| B3  | Hostile query | `"><script>alert(1)</script>` and a 500-char string | Treated as plain text — no markup injection in the result panel, no console error, the dialog stays responsive                 |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check         | Expected                                                                                                                                                   |
+| --- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Dialog        | The search is a labelled dialog (**Search documentation**, `search.title`); focus lands in the input on open; **Esc** closes and focus returns to the page |
+| A2  | Trigger       | The header trigger is a labelled control (**Open search**) reachable by Tab at both mobile and desktop widths                                              |
+| A3  | Announcements | The result count (`search.results`) is exposed to AT; selected rows are conveyed programmatically, not colour-only                                         |
+
+## Performance
+
+| ID  | Metric        | Target                                                                         |
+| --- | ------------- | ------------------------------------------------------------------------------ |
+| P1  | First results | Results render **< 500 ms** after typing on a warm session (client-side index) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ----------- | ---------------------------- | ----------- | ---------- |
+|     |         |             |                              |             |            |
+
+## Test summary
+
+```
+Area: Search (docs)
+Functional: ___/6   Boundary: ___/3   A11y: ___/3   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/platform/tests/manual/README.md
+++ b/services/platform/tests/manual/README.md
@@ -10,8 +10,9 @@ the automated Playwright spec that already covers each case, and carries an
 These are manual / exploratory / accessibility passes — **not** the automated
 suites. Unit and component tests live in `services/*/`; the full-app Playwright
 suite lives in [`services/platform/tests/e2e/`](../../services/platform/tests/e2e/README.md).
-The `web` and `docs` services have their own smoke specs and are out of scope
-here.
+The `web` and `docs` services have their own guide sets in
+[`services/web/tests/manual/`](../../../web/tests/manual/README.md) and
+[`services/docs/tests/manual/`](../../../docs/tests/manual/README.md).
 
 ## How to use
 

--- a/services/web/tests/manual/README.md
+++ b/services/web/tests/manual/README.md
@@ -1,0 +1,60 @@
+# Manual test plans (AI-directed) — marketing site
+
+Modular, codebase-grounded test playbooks for the Tale **marketing site**
+(`https://tale.dev`), written so either a human QA tester or an AI agent
+driving a browser can execute them against a running instance (or the live
+site). One guide per area; each lists concrete test cases (functional,
+boundary/error, accessibility, performance), cross-references the automated
+Playwright smoke spec that already covers each case, and carries an
+**Issues Found** table for collecting defects.
+
+These are manual / exploratory / accessibility passes — **not** the automated
+suites. The Playwright smoke suite lives in
+[`tests/e2e/specs/smoke.spec.ts`](../e2e/specs/smoke.spec.ts); the vitest i18n
+suite in `lib/i18n/messages.test.ts`. The platform app has its own, much larger
+guide set in
+[`services/platform/tests/manual/`](../../../platform/tests/manual/README.md);
+new guides here copy its
+[TEMPLATE.md](../../../platform/tests/manual/TEMPLATE.md) (which documents the
+authoring conventions).
+
+## How to use
+
+1. Bring the site up (or pick the live site) via [SETUP.md](SETUP.md), then run
+   its smoke checklist (every page loads).
+2. Run [navigation.md](navigation.md) first, then the rest in any order.
+3. **Never deliver a test submission through the live forms** — the
+   honeypot-probe rule in [forms.md](forms.md) exists so a full pass doesn't
+   spam the team's Discord.
+4. For each defect, add a row to that guide's **Issues Found** table (test id,
+   route, severity, description, screenshot).
+5. Finish with [accessibility.md](accessibility.md) and
+   [responsive.md](responsive.md) as cross-cutting sweeps.
+
+## Guides
+
+| Guide                                | Area                                                                     |
+| ------------------------------------ | ------------------------------------------------------------------------ |
+| [navigation.md](navigation.md)       | page inventory, header/footer nav, legal pages, hash links, 404s         |
+| [forms.md](forms.md)                 | contact + request-demo forms end-to-end, incl. the Discord delivery path |
+| [locale.md](locale.md)               | locale switching, `/de` + `/fr` trees, translated content                |
+| [seo.md](seo.md)                     | prerendered titles/canonicals, sitemap, robots, llms.txt, noindex        |
+| [theme.md](theme.md)                 | light/dark/system switching, persistence, no-flash, themed imagery       |
+| [responsive.md](responsive.md)       | mobile menu, narrow viewports, no-overflow                               |
+| [accessibility.md](accessibility.md) | cross-cutting WCAG 2.1 AA sweep                                          |
+
+## Coverage matrix
+
+The automated suite is a smoke layer only — four tests. Everything deeper is
+manual. Status reflects the **area** as a whole; each guide's own _Automated
+coverage_ table is case-by-case.
+
+| Guide         | Status         | Automated by                                                                      |
+| ------------- | -------------- | --------------------------------------------------------------------------------- |
+| navigation    | 🔶 partial     | `smoke.spec.ts` (home renders + pricing nav link + no console errors; `/pricing`) |
+| forms         | 🔶 partial     | `smoke.spec.ts` (`/contact` renders a form + submit button — **no submit path**)  |
+| locale        | 🔶 partial     | `smoke.spec.ts` (`/de` renders) + vitest `lib/i18n/messages.test.ts` (key parity) |
+| seo           | ⛔ manual-only | — (prerender/artifact output has no spec)                                         |
+| theme         | ⛔ manual-only | —                                                                                 |
+| responsive    | ⛔ manual-only | —                                                                                 |
+| accessibility | ⛔ manual-only | — (no axe layer in this service's e2e)                                            |

--- a/services/web/tests/manual/SETUP.md
+++ b/services/web/tests/manual/SETUP.md
@@ -1,0 +1,72 @@
+# Setup & smoke
+
+Bring the marketing site up (or point at the live one) and confirm every page
+loads. Every guide in this directory assumes the environment this file
+produces. Run this first; run it once per session.
+
+These are the manual / AI-directed playbooks — they drive a **running** site
+through a browser. They are distinct from the automated Playwright smoke suite
+([`tests/e2e/specs/smoke.spec.ts`](../e2e/specs/smoke.spec.ts)) and the vitest
+i18n suite (`lib/i18n/messages.test.ts`), which boot and tear down their own
+server. The site is public — **no sign-in exists or is needed**.
+
+## 1. Pick a mode
+
+| Mode              | Command / URL                                                                                                                                     | Forms endpoint                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **A. Live site**  | `https://tale.dev`                                                                                                                                | real — see the live-safety rule in [forms.md](forms.md)                               |
+| **B. Local prod** | `bun run --filter @tale/web build`, then `WEB_DISCORD_WEBHOOK_URL=<your test webhook> bun run --filter @tale/web start` → `http://localhost:3001` | works; delivery goes to **your** webhook                                              |
+| **C. Local dev**  | `bun run --filter @tale/web dev` → `http://localhost:3001`                                                                                        | **absent** — `/api/forms/submit` exists only in `server.ts`; a dev submit fails (404) |
+
+Mode A is the default for a full pass (it exercises the prerendered HTML, the
+SEO artifacts, and the real form pipeline). Mode B is required for the Discord
+**delivery** rows in [forms.md](forms.md) — create a throwaway Discord webhook
+so test submissions never reach the team channel. Mode C is fine for
+everything except forms and prerendered-HTML checks ([seo.md](seo.md) F-rows
+need the built output or the live site — the dev server serves the unbuilt
+`index.html` fallback head).
+
+## 2. Conventions
+
+- **Routes**: English pages live at the root (`/pricing`); German and French
+  are URL-prefixed (`/de/pricing`, `/fr/pricing`). `{lang}` in the guides
+  means `de` or `fr` — there is **no** `/en` prefix (it redirects to `/`).
+- **Labels**: every control referenced in a guide names its i18n key
+  resolvable from [`services/web/messages/en.json`](../../messages/en.json);
+  shared-UI controls (theme/language switcher) resolve from
+  `packages/ui/src/i18n/messages/en.json` + `global.json`. Locate by role +
+  visible name, never by CSS.
+- **Checkable expectations**: a URL change, an element/text that becomes
+  visible, a response status, or a value that survives a reload. For
+  prerendered head checks, read the **served HTML** (`curl` / view-source),
+  not the hydrated DOM.
+- **Screenshots**: `services/web/tests/screenshots/<YYYY-MM-DD_HH_MM>/<area>/`
+  — create the folder before a run.
+- **Live-site safety**: never send a real submission through the production
+  contact/demo forms — every delivered submission pings the team's Discord.
+  [forms.md](forms.md) documents the honeypot probe that verifies the
+  endpoint without delivering.
+
+## 3. Smoke — every page loads
+
+Visit each route and confirm it renders (hero/heading visible), no blank
+screen, and no console error. Deep coverage lives in the per-area guides.
+
+| Route                                      | Verify                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------- |
+| `/`                                        | hero **The Orchestrator for AI Agents** (`home.hero.title`)         |
+| `/pricing`                                 | heading **Simple, Transparent Pricing** (`pricing.title`)           |
+| `/hardware-pricing`                        | heading **Hardware Pricing** (`hardwarePricing.title`)              |
+| `/contact`                                 | heading **Contact us** (`contact.title`) + form                     |
+| `/request-demo`                            | heading **What drives your business?** (`requestDemo.title`) + form |
+| `/legal/privacy-policy`                    | legal document renders                                              |
+| `/legal/terms-of-service`                  | legal document renders                                              |
+| `/legal/data-processing-agreement`         | document + **DPA**/**TOM** tabs (`legal.tabs.*`)                    |
+| `/legal/technical-organizational-measures` | document + tabs                                                     |
+| `/legal/personalization`                   | legal document renders                                              |
+| `/de`                                      | German hero **Der Orchestrator für KI-Agents**                      |
+| `/fr`                                      | French hero **L'orchestrateur pour agents IA**                      |
+
+```
+Smoke: ___/12 routes load   Console errors: ___   Status: PASS / FAIL
+```

--- a/services/web/tests/manual/accessibility.md
+++ b/services/web/tests/manual/accessibility.md
@@ -1,0 +1,78 @@
+# Accessibility — Manual Test Plan (cross-cutting)
+
+> **Purpose**: A WCAG 2.1 **Level AA** sweep across the marketing site. Tale's
+> standard (root [`AGENTS.md`](../../../../AGENTS.md) → Accessibility) is
+> mandatory, not aspirational. Per-area guides carry their own `A#` rows
+> (forms wiring in [forms.md](forms.md), switcher semantics in
+> [locale.md](locale.md)/[theme.md](theme.md), touch targets in
+> [responsive.md](responsive.md)); this guide is the holistic pass and the
+> place to log _systemic_ findings.
+
+## Scope & routes
+
+Run each check on a representative set: `/` (long marketing page with
+animations), `/pricing` (segmented controls + slider + compare table),
+`/contact` (form), `/legal/data-processing-agreement` (long document + tabs).
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md). Drive the keyboard checks with
+the keyboard only. A screen reader (VoiceOver, `Cmd+F5`) helps the announce
+checks. There is **no axe layer in this service's e2e suite** — full-page
+audits are manual/assisted here; shared `@tale/ui` components carry their own
+`vitest-axe` coverage.
+
+> **Agent note**: assert structure against the live DOM (`page.evaluate` DOM
+> scans), not screenshots. The site animates on scroll (framer-motion) — for
+> A7 set `prefers-reduced-motion: reduce` in the browser context **before**
+> loading.
+
+## Automated coverage
+
+| Layer                           | Status         | Where                                                                                       |
+| ------------------------------- | -------------- | ------------------------------------------------------------------------------------------- |
+| Per-component axe (WCAG 2.1 AA) | ✅ automated   | `@tale/ui` component tests (`checkAccessibility()` via `vitest-axe`) + Storybook a11y addon |
+| Full-page audits (A1–A8)        | ⛔ manual-only | — this guide                                                                                |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only.
+
+## Functional / structural tests
+
+| ID  | Test           | Steps (route + control)                                                                                                    | Expected (verifiable)                                                                                                                                                                                                                                                          |
+| --- | -------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A1  | Skip link      | On each surface, press Tab once from page top                                                                              | First focusable is **Skip to main content** (`nav.skipToMain`, `href="#main"`); it becomes visible on focus (`sr-only focus:not-sr-only`); Enter moves focus into `<main id="main">`                                                                                           |
+| A2  | Landmarks      | Query `main, header, footer, nav` on each surface                                                                          | Exactly one `<main>`, one `<header>`, one `<footer>`; every `<nav>` exposes an accessible name (footer columns are labelled by their headings; the legal tab strip is labelled **Document sections**). Verified live: the **header primary nav is unlabelled** — see Issues #1 |
+| A3  | Heading order  | Walk headings top→bottom on `/` and `/pricing`                                                                             | One `<h1>` per page (the hero / page title); levels never skip (no `h1`→`h3`)                                                                                                                                                                                                  |
+| A4  | Keyboard reach | Tab through `/pricing`: billing radiogroup, currency radiogroup, users slider, FAQ accordions, compare-table info triggers | Every interactive control receives focus and operates by keyboard (radios switch, the slider arrows, accordions toggle with Enter/Space); nothing is mouse-only                                                                                                                |
+| A5  | Contrast       | Sample body text, muted text (`text-fg-muted`), primary/secondary buttons — in **both** themes                             | Body ≥ 4.5:1, large text ≥ 3:1, non-text UI ≥ 3:1; colour is never the only signal (e.g. compare-table cells pair icon + `sr-only`/label text: **Included** / **Not included**, `pricing.compare.cellLabels.*`)                                                                |
+| A6  | Visible focus  | Tab through header, hero CTAs, footer links, switchers — both themes                                                       | A focus ring is visible on every focused control (the shared controls use `focus-visible:ring-2`); no `outline: none` without a replacement                                                                                                                                    |
+| A7  | Reduced motion | With `prefers-reduced-motion: reduce`, load `/` and scroll through it                                                      | Sections present without fade/slide (framer-motion `useReducedMotion` paths); the hash scroll (`/#features`) jumps instantly; no parallax/marquee keeps moving                                                                                                                 |
+| A8  | Images + icons | Query `img` and icon-only controls on `/`                                                                                  | Every meaningful `<img>` has a descriptive `alt` (hero/product mocks); decorative icons are `aria-hidden`; icon-only buttons/links (GitHub, hamburger) expose labels (`footer.githubAriaLabel`, `nav.openMenu`)                                                                |
+
+## Boundary & error tests
+
+| ID  | Test                | Input                                    | Expected                                                                                        |
+| --- | ------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| B1  | Form error announce | Submit an empty `/contact` form          | Errors are announced (see [forms.md](forms.md) A2) and focus is **not** thrown to the page top  |
+| B2  | Zoom 200 %          | Browser zoom 200 % on `/` and `/contact` | No loss of content or function; no overlapping text; sticky header doesn't swallow the viewport |
+
+## Performance
+
+| ID  | Metric      | Target                                                                    |
+| --- | ----------- | ------------------------------------------------------------------------- |
+| P1  | CLS on load | No visible layout shift while `/` loads (hero images have reserved space) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL                     | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                       | Screenshot |
+| --- | ------- | ------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | A2      | `https://tale.dev/` (all pages) | low                          | The header's primary `<nav>` has no accessible name while the three footer navs are labelled (2026-07-06 live DOM scan: `navs: [unlabelled, Product, Resources, Legal]`) — screen-reader users can't tell the nav landmarks apart | —          |
+
+## Test summary
+
+```
+Area: Accessibility (web)
+Structural: ___/8   Boundary: ___/2   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/web/tests/manual/forms.md
+++ b/services/web/tests/manual/forms.md
@@ -1,0 +1,100 @@
+# Forms — Manual Test Plan
+
+> **Purpose**: Exercise the two marketing forms — **Contact** and **Request
+> demo** — end-to-end: client validation, the `/api/forms/submit` endpoint, the
+> anti-spam layers (honeypot, time trap, rate limit, body cap), and the Discord
+> delivery path. This is the pipeline whose live 503 motivated these guides:
+> the endpoint returns **503** whenever `WEB_DISCORD_WEBHOOK_URL` is unset.
+
+## Scope & routes
+
+| Surface      | Route                                                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Contact form | `/contact` (also `/{lang}/contact`)                                                                                       |
+| Demo form    | `/request-demo` (also `/{lang}/request-demo`)                                                                             |
+| Submit API   | `POST /api/forms/submit` (`server.ts` → `lib/forms/schemas.ts`, `lib/forms/rate-limit.ts`, `lib/forms/discord-embeds.ts`) |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md). Delivery rows (F2/F3) need **mode
+B** with `WEB_DISCORD_WEBHOOK_URL` pointing at a **throwaway** Discord webhook
+you can read. Mode C (vite dev) has **no** submit endpoint — every submit fails
+with the generic error; only the validation rows (B1–B4) are testable there.
+
+> **Live-site safety**: on `https://tale.dev`, never complete a real
+> submission — it delivers to the team's Discord. Verify endpoint health with
+> the honeypot probe (F6): a honeypot-tripped request is accepted (`{ ok:
+true }`) but **silently discarded**, so nothing is delivered. A **503**
+> response instead means the webhook env var is missing in production — that is
+> the defect to file.
+
+> **Agent note**: the form sets `startedAt` on mount and the client rejects
+> submits younger than **3 s** (`MIN_SUBMIT_DELAY_MS`) — pause ≥ 3 s between
+> page load and submit or you'll hit B5 instead of the happy path. Field errors
+> render via the shared `Field` component; the server error renders as a
+> `role="alert"` paragraph above the submit button.
+
+## Automated coverage
+
+| Case(s)          | Status         | e2e spec                                                                |
+| ---------------- | -------------- | ----------------------------------------------------------------------- |
+| F1 (render only) | 🔶 partial     | `smoke.spec.ts` (`/contact` shows a form + the **Get in touch** button) |
+| F2–F6, B1–B9     | ⛔ manual-only | — (no spec drives a submit; the endpoint itself has no test)            |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test                       | Steps (route + control)                                                                                                                                                                                                                                                                                                                                                                 | Expected (verifiable)                                                                                                                                                                                                                                                                    |
+| --- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Contact happy path         | `/contact` (mode B): fill **Name** (`contact.fieldName`), **Email** (`forms.email`), optional **Company** (`contact.fieldCompany`), **Message** ≥ 10 chars (`contact.fieldMessage`); tick the privacy checkbox (**I confirm that I have read the** … **Privacy Policy**, `forms.privacyPrefix` + `forms.privacyLink`); wait ≥ 3 s after load; click **Get in touch** (`contact.submit`) | The form is replaced by a `role="status"` success card: **Thanks — we got it** (`forms.success.title`) + **We'll be in touch within one business day.** (`forms.success.description`) with a **Send another** button (`forms.success.sendAnother`); the POST returned 200 `{ ok: true }` |
+| F2  | Contact Discord embed      | After F1, open your test Discord channel                                                                                                                                                                                                                                                                                                                                                | One message from username **Tale website** with an embed titled **New contact message** listing Name/Email/Company fields and the message body                                                                                                                                           |
+| F3  | Demo happy path + embed    | `/request-demo` (mode B): fill **Name**, **Email**, optional **Phone** (`requestDemo.fieldPhone`), **Company**, pick one or more **Interested in** options (`requestDemo.fieldInterests`: `requestDemo.interests.*`), optional **Additional comment** (`requestDemo.fieldMessage`); privacy; wait ≥ 3 s; **Get in touch** (`requestDemo.submit`)                                        | Success card as in F1; the Discord embed is titled **New demo request** and includes the selected interests                                                                                                                                                                              |
+| F4  | Send another               | After F1, click **Send another** (`forms.success.sendAnother`)                                                                                                                                                                                                                                                                                                                          | The empty form returns (all fields reset to defaults, privacy unchecked); a second valid submit succeeds again                                                                                                                                                                           |
+| F5  | Privacy policy link        | On either form, click **Privacy Policy** (`forms.privacyLink`)                                                                                                                                                                                                                                                                                                                          | Lands on `/legal/privacy-policy` and the document renders. Note: the link is a plain `<a href="/legal/privacy-policy">` — on `/de/contact` it still targets the **English** legal page (candidate localization finding)                                                                  |
+| F6  | Endpoint probe (live-safe) | `curl -X POST {base}/api/forms/submit -H 'content-type: application/json' -d '{"form":"contact","payload":{"name":"probe","email":"probe@example.com","message":"manual-test endpoint probe","privacy":true,"startedAt":0,"website":"http://spam.example"}}'`                                                                                                                           | HTTP 200 `{"ok":true}` and **nothing** arrives in Discord (honeypot `website` non-empty → silently discarded). HTTP **503** `Service not configured` = `WEB_DISCORD_WEBHOOK_URL` unset — file it. (`startedAt: 0` is fine: the 3 s trap only rejects **recent** timestamps)              |
+
+## Boundary & error tests
+
+| ID  | Test                | Input                                                                                                                                  | Expected                                                                                                                                                                                                                                                      |
+| --- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Required fields     | Submit an empty contact form                                                                                                           | Inline field errors: **Required** on Name and Email, **Tell us a bit more (10+ characters)** on the empty Message (the min-length rule fires first — verified live), and **You must accept the privacy policy** (`forms.privacyRequired`); no request is sent |
+| B2  | Invalid email       | `not-an-email` in **Email**                                                                                                            | Inline error **Invalid email**; no request sent                                                                                                                                                                                                               |
+| B3  | Short message       | Contact **Message** = `too short` (< 10 chars)                                                                                         | Inline error **Tell us a bit more (10+ characters)**                                                                                                                                                                                                          |
+| B4  | Invalid phone       | Demo **Phone** = `abc` (letters) and `12` (< 4 chars)                                                                                  | Inline errors **Invalid phone number** / **Too short**; empty phone is allowed                                                                                                                                                                                |
+| B5  | Time trap           | Fill a valid contact form and submit **within 3 s** of page load                                                                       | `role="alert"` error **Hold on — review your details before submitting.** (`forms.errors.tooFast`); the same submit succeeds after waiting                                                                                                                    |
+| B6  | Rate limit          | Mode B: 6 valid submits from one IP within 60 s (use **Send another** or curl F6-style payloads **without** the honeypot… mode B only) | The 6th returns HTTP **429** with a `retry-after` header; the UI shows **Too many submissions. Wait a moment, then try again.** (`forms.errors.rateLimited`); after the window it succeeds again (limit: 5/min/IP)                                            |
+| B7  | Oversize payload    | curl a body > 4 KiB (e.g. a 5000-char `message`)                                                                                       | HTTP **413** `Payload too large`; via the UI the 2000-char Zod cap yields **Too long** first                                                                                                                                                                  |
+| B8  | Malformed JSON      | `curl -X POST {base}/api/forms/submit -d 'not json'`                                                                                   | HTTP **400** `Invalid JSON`; a schema-invalid JSON body returns **400** `Validation failed`; `GET` returns **405**                                                                                                                                            |
+| B9  | Dev server (mode C) | Valid submit against `bun run dev`                                                                                                     | The generic error **Something went wrong. Try again.** (`forms.errors.generic`) — the endpoint only exists in `server.ts`; environment, not a bug                                                                                                             |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check          | Expected                                                                                                                                                                               |
+| --- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Field labels   | Every visible input has a programmatic label (the `Field` component wires `label[for]`); the honeypot block is `aria-hidden` with `tabindex="-1"` — invisible to AT and skipped by Tab |
+| A2  | Error announce | Field errors are associated with their inputs; the server error is `role="alert"`; the success card is `role="status"`                                                                 |
+| A3  | Keyboard only  | Complete F1 with the keyboard alone — Tab order: Name → Email → (Company/Phone/interests) → Message → privacy checkbox → **Get in touch**; Space toggles the checkbox                  |
+| A4  | Submit state   | While submitting, the button shows its loading state and a second Enter doesn't double-submit (one POST in the network log)                                                            |
+
+## Performance
+
+| ID  | Metric           | Target                                                                                                               |
+| --- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| P1  | Submit roundtrip | Success card visible **< 2 s** after clicking submit (mode B, local webhook; server aborts the webhook call at 10 s) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL                              | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                                                                         | Screenshot |
+| --- | ------- | ---------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | F6      | `POST https://tale.dev/api/forms/submit` | crit                         | Production returns HTTP **503** `{"ok":false,"error":"Service not configured"}` (2026-07-06 honeypot probe) — `WEB_DISCORD_WEBHOOK_URL` is unset, so **every** contact and demo submission fails with the generic error. This is the original tale.dev contact-form 503, still live | —          |
+| 2   | F5      | `/de/contact`, `/fr/contact`             | low                          | The privacy-policy checkbox link is a hard `<a href="/legal/privacy-policy">` — on localized forms it leaves the locale tree (English legal page) and bypasses the SPA router                                                                                                       | —          |
+
+## Test summary
+
+```
+Area: Forms (web)
+Functional: ___/6   Boundary: ___/9   A11y: ___/4   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/web/tests/manual/locale.md
+++ b/services/web/tests/manual/locale.md
@@ -1,0 +1,91 @@
+# Locale switching — Manual Test Plan
+
+> **Purpose**: Exercise the three-locale model — English at the canonical root
+> path, German and French URL-prefixed (`/de/…`, `/fr/…`), plus the
+> region-resolved `de-CH` message overlay that never appears in URLs. Covers
+> the footer language switcher, direct locale-URL entry, `<html lang>` sync,
+> and translated content. Prerendered per-locale head tags live in
+> [seo.md](seo.md).
+
+## Scope & routes
+
+| Surface      | Route                                                                        |
+| ------------ | ---------------------------------------------------------------------------- |
+| English tree | `/`, `/pricing`, `/contact`, … (no prefix)                                   |
+| German tree  | `/de`, `/de/pricing`, `/de/contact`, `/de/legal/{slug}`, …                   |
+| French tree  | `/fr`, `/fr/pricing`, `/fr/contact`, `/fr/legal/{slug}`, …                   |
+| Redirects    | `/en` and any non-`de`/`fr` prefix → `/` (`app/routes/$lang.tsx`)            |
+| Switcher     | footer, every page (`packages/ui/src/components/site/language-switcher.tsx`) |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — any mode. Messages live in
+`services/web/messages/{en,de,de-CH,fr}.json` (+ untranslated shared terms in
+`global.json`); the switcher's own labels come from
+`packages/ui/src/i18n/messages/global.json`.
+
+> **Agent note**: the switcher is a custom `menu` popover, not a native
+> `<select>` — open it (button aria-label **Switch language**,
+> `languageSwitcher.ariaLabel`), then click a `menuitem` (**English**,
+> **Deutsch**, **Français**, `languageSwitcher.locales.*`). The de-CH row (F6)
+> depends on `navigator.language` — launch the browser with `--lang=de-CH` (or
+> a `de-CH` context locale).
+
+## Automated coverage
+
+| Case(s)          | Status         | e2e spec / test                                                       |
+| ---------------- | -------------- | --------------------------------------------------------------------- |
+| F2 (render only) | 🔶 partial     | `smoke.spec.ts` (`/de` renders)                                       |
+| —                | ✅ automated   | vitest `lib/i18n/messages.test.ts` (locale files stay key-compatible) |
+| F1, F3–F6, B1–B2 | ⛔ manual-only | —                                                                     |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test                   | Steps (route + control)                                                                                                     | Expected (verifiable)                                                                                                                                                                                                                   |
+| --- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Switch preserves path  | On `/pricing?billing=monthly`, open the footer **Switch language** menu (`languageSwitcher.ariaLabel`) and pick **Deutsch** | URL commits `/de/pricing?billing=monthly` — same page, same search params; picking **English** from there returns to `/pricing?billing=monthly` (prefix dropped, not remapped elsewhere)                                                |
+| F2  | German content         | Open `/de`                                                                                                                  | Hero renders the German title (`home.hero.title` from `messages/de.json` — **Der Orchestrator für KI-Agents**); header nav labels are German; no untranslated English leaks in the shell                                                |
+| F3  | French content         | Open `/fr` and `/fr/contact`                                                                                                | French hero (**L'orchestrateur pour agents IA**) and a fully French contact form (labels from `messages/fr.json`)                                                                                                                       |
+| F4  | `<html lang>` sync     | On `/`, read `document.documentElement.lang`; switch to **Deutsch**; read again                                             | `en` → `de` without a full page reload (`LocaleSync` in `app/routes/__root.tsx`); on `/fr` it reads `fr`                                                                                                                                |
+| F5  | Localized legal docs   | Open `/de/legal/privacy-policy` and `/fr/legal/privacy-policy`                                                              | Each renders the document in that locale (per-locale content under `app/content/legal/`); the DPA/TOM tab labels stay the abbreviations **DPA**/**TOM**                                                                                 |
+| F6  | de-CH regional overlay | Browser locale `de-CH`: open `/de`                                                                                          | URL stays `/de` (regional variants never URL-prefix); strings present in `messages/de-CH.json` render the Swiss variant over the `de` base (`resolveRegionalLocale`); `<html lang>` reflects the base `de` route                        |
+| F7  | Switcher current mark  | Open the switcher on `/de/pricing`                                                                                          | The trigger shows **Deutsch**; in the menu the **Deutsch** item is marked current (`aria-current="true"` + check icon); choosing the current locale is a no-op (menu closes, URL unchanged)                                             |
+| F8  | Locale cookie          | Visit `/de`; then request `/` again (fresh tab or `curl -H 'Cookie: tale_locale=de' {base}/`)                               | Visiting a locale tree sets the `tale_locale` cookie (`packages/ui/src/i18n/cookie.ts`); the server then 302-redirects `/` to `/de` (verified live) — and the docs site honours the **same** cookie, keeping both sites in one language |
+
+## Boundary & error tests
+
+| ID  | Test           | Input                          | Expected                                                                                                             |
+| --- | -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| B1  | `/en` prefix   | Open `/en`, then `/en/pricing` | Redirects to `/` — English never carries a prefix; note the dropped sub-path (see [navigation.md](navigation.md) B3) |
+| B2  | Unknown prefix | Open `/es`, `/it/pricing`      | Redirect to `/` — the `$lang` param only accepts `de`/`fr`; no crash, no 500                                         |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check             | Expected                                                                                                                                                                                         |
+| --- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A1  | Switcher keyboard | Trigger is a labelled button (`aria-haspopup="menu"`, `aria-expanded`); open menu focuses the current locale; **ArrowUp/ArrowDown** cycle items, **Esc** closes and returns focus to the trigger |
+| A2  | Menu semantics    | The popover is `role="menu"` with `role="menuitem"` children; the active locale carries `aria-current="true"`; flags are `aria-hidden` (text labels carry the meaning)                           |
+| A3  | Lang attribute    | `<html lang>` always matches the rendered language (F4) — screen readers pick the right pronunciation                                                                                            |
+
+## Performance
+
+| ID  | Metric        | Target                                                                             |
+| --- | ------------- | ---------------------------------------------------------------------------------- |
+| P1  | Locale switch | The SPA navigation to the sibling locale page settles in **< 1 s** on a warm build |
+
+## Issues Found
+
+| #   | Test ID | Route / URL | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ----------- | ---------------------------- | ----------- | ---------- |
+|     |         |             |                              |             |            |
+
+## Test summary
+
+```
+Area: Locale switching (web)
+Functional: ___/8   Boundary: ___/2   A11y: ___/3   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/web/tests/manual/navigation.md
+++ b/services/web/tests/manual/navigation.md
@@ -1,0 +1,99 @@
+# Navigation & pages — Manual Test Plan
+
+> **Purpose**: Exercise the whole page inventory and every way to move between
+> pages — the header nav, the footer columns, the legal-document pages (tabs,
+> print), in-page hash links, browser history, and the 404 paths. The mobile
+> hamburger drawer lives in [responsive.md](responsive.md); the footer's
+> language/theme switchers live in [locale.md](locale.md) / [theme.md](theme.md).
+
+## Scope & routes
+
+| Surface          | Route                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Home             | `/` (also `/{lang}`)                                                                                                       |
+| Pricing          | `/pricing`                                                                                                                 |
+| Hardware pricing | `/hardware-pricing`                                                                                                        |
+| Contact          | `/contact`                                                                                                                 |
+| Request demo     | `/request-demo`                                                                                                            |
+| Legal documents  | `/legal/{privacy-policy\|terms-of-service\|data-processing-agreement\|technical-organizational-measures\|personalization}` |
+| Locale trees     | `/{lang}/…` for `de` and `fr` (see [locale.md](locale.md))                                                                 |
+| Redirect         | `/en` and any unknown `/{lang}` prefix → `/` (`app/routes/$lang.tsx`)                                                      |
+| Unknown route    | `/nope-not-a-route` → redirects to `/` (B1); `/legal/bad-slug` → bare not-found fallback (B2)                              |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — any mode; no sign-in. All routes
+render without a backend.
+
+> **Agent note**: header/footer render on every route, so nav checks can chain
+> page-to-page. Hash-scroll (F7) is smooth by default and instant under
+> `prefers-reduced-motion` — wait on the target section's position, not on an
+> animation. External links open new tabs; assert `target`/`rel` attributes
+> instead of following them.
+
+## Automated coverage
+
+| Case(s)        | Status         | e2e spec                                                     |
+| -------------- | -------------- | ------------------------------------------------------------ |
+| F1             | 🔶 partial     | `smoke.spec.ts` (home renders, **Pricing** nav link visible) |
+| F9             | 🔶 partial     | `smoke.spec.ts` (`/pricing` renders — no interaction)        |
+| F2–F8, F10–F11 | ⛔ manual-only | —                                                            |
+| B1–B4          | ⛔ manual-only | —                                                            |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test                     | Steps (route + control)                                                                                                                                                                                                                                                                       | Expected (verifiable)                                                                                                                                                                                                                                                               |
+| --- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Header nav               | On `/`, click **Platform** (`nav.platform`), **Pricing** (`nav.pricing`), **Hardware** (`nav.hardware`) in the header                                                                                                                                                                         | URL commits `/`, `/pricing`, `/hardware-pricing` respectively; each page's heading renders ([SETUP.md](SETUP.md) smoke table)                                                                                                                                                       |
+| F2  | Read docs                | Header → **Read docs** (`nav.readDocs`)                                                                                                                                                                                                                                                       | An external link to `https://tale.dev/docs` with `target="_blank"` and `rel="noopener noreferrer"`; following it lands on the docs site                                                                                                                                             |
+| F3  | Request demo CTA         | Header → **Request demo** (`nav.requestDemo`); also the hero CTAs **Request demo** (`home.hero.ctaPrimary`) and **Get started** (`home.hero.ctaSecondary`)                                                                                                                                    | Header CTA and hero primary CTA navigate to `/request-demo`; **Get started** is an external link to the docs quickstart (`{docs}/self-hosted/install/quickstart`)                                                                                                                   |
+| F4  | Logo home link           | On `/pricing`, click the Tale logo (aria-label **Tale home**, `nav.homeAriaLabel`)                                                                                                                                                                                                            | URL commits `/` (or `/{lang}` when on a locale tree); hero renders                                                                                                                                                                                                                  |
+| F5  | Footer Product column    | Footer **Product** (`footer.product`): **Features** (`footer.features`), **Pricing** (`footer.pricing`), **Hardware Pricing** (`footer.hardwarePricing`), **Contact** (`footer.contact`)                                                                                                      | **Features** navigates to `/#features` and scrolls the features section into view; the others commit `/pricing`, `/hardware-pricing`, `/contact`                                                                                                                                    |
+| F6  | Footer Legal column      | Footer **Legal** (`footer.legal`): the four legal links + **Service Agreement** (`footer.serviceAgreement`) + **Hardware Agreement** (`footer.hardwareAgreement`)                                                                                                                             | Legal links commit `/legal/{slug}` and the document renders; the two agreement links download/serve PDFs from `/files/Service_Agreement_Template.pdf` and `/files/Hardware_Agreement_Template.pdf` (HTTP 200, `content-type` PDF)                                                   |
+| F7  | Footer Resources + brand | Footer **Resources** (`footer.resources`) → **AI Training Courses** (`footer.aiTraining`); brand column: address block, VAT id link, GitHub icon (aria-label **GitHub**, `footer.githubAriaLabel`)                                                                                            | **AI Training Courses** is an external link (edoobox) opening in a new tab; the VAT id links to `uid.admin.ch`; the GitHub icon links to `https://github.com/tale-project/tale`                                                                                                     |
+| F8  | Legal tabs + print       | Open `/legal/data-processing-agreement`; use the tabs **DPA** / **TOM** (`legal.tabs.data-processing-agreement` / `legal.tabs.technical-organizational-measures`, `<nav aria-label>` = **Document sections**, `legal.documentTabsAria`); click **Print or save as PDF** (`legal.downloadPdf`) | Tabs switch between the two sibling documents (URL commits the sibling slug); the active tab is marked; the print button opens the browser print dialog (`window.print`)                                                                                                            |
+| F9  | Pricing controls         | On `/pricing`, toggle **Billing period** (`pricing.billing.ariaLabel`): **Monthly** / **Yearly (2 months free)**; toggle **Currency** (`pricing.region.ariaLabel`): **CHF** / **EUR**; move the **Number of users** slider (`pricing.users.label`)                                            | Prices update; the state is reflected in URL search params (`?billing=`, `?region=`, `?users=`) and survives a reload; the **Community** plan shows **Free**, the **Enterprise** plan a computed per-user price; users below 25 clamp with the tooltip (`pricing.users.minTooltip`) |
+| F10 | Hardware controls        | On `/hardware-pricing`, switch **Deployment mode** (`hardwarePricing.modesAriaLabel`), **Payment option** (`hardwarePricing.billing.ariaLabel`): **Leasing** / **Buying**, and the leasing **term**                                                                                           | Tier cards swap per mode; leasing shows `/month` suffixes, buying a one-off price; state lands in `?mode=`, `?billing=`, `?term=` and survives a reload                                                                                                                             |
+| F11 | FAQ + history            | On `/`, expand two FAQ items (`home.faq.*.q`, accordion allows multiple open); click **Contact our team** (`home.faq.contactTeam`); then browser Back                                                                                                                                         | Both items stay open simultaneously; the link commits `/contact`; Back returns to `/` with the page intact (no blank view)                                                                                                                                                          |
+
+## Boundary & error tests
+
+| ID  | Test               | Input                                            | Expected                                                                                                                                                                                                                                  |
+| --- | ------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Unknown route      | Open `/nope-not-a-route`, then `/nope/deep-page` | No crash — but observed live: **both silently redirect to `/`** (the `$lang` route captures the first segment, fails locale validation, and redirects home). There is no 404 page and no signal to the visitor — see Issues #1            |
+| B2  | Unknown legal slug | Open `/legal/not-a-document`                     | The route throws `notFound()`; observed live: no custom `notFoundComponent` is registered, so TanStack's **unstyled default** renders — plain **"Not Found"** text inside `<main>`, document title stays the home default — see Issues #1 |
+| B3  | `/en` prefix       | Open `/en`, then `/en/pricing`                   | Both redirect to `/` (the `$lang` route only accepts `de`/`fr`); note the sub-path is **dropped**, not remapped to `/pricing`                                                                                                             |
+| B4  | Bad search params  | Open `/pricing?billing=zzz&region=XX&users=abc`  | The page renders with defaults (no crash, no NaN price); the invalid params are ignored or normalized                                                                                                                                     |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check          | Expected                                                                                                                                           |
+| --- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Skip link      | First focusable element is the **Skip to main content** link (`nav.skipToMain`) targeting `#main`; activating it moves focus into `<main>`         |
+| A2  | Landmarks      | Exactly one `<main id="main">` per page; footer link columns are `<nav>` elements labelled by their column heading; one `<header>`, one `<footer>` |
+| A3  | Legal tabs nav | The DPA/TOM tab strip is a `<nav aria-label>` = **Document sections** (`legal.documentTabsAria`); the active tab is programmatically marked        |
+| A4  | Focus visible  | Tabbing through header links, footer links, and the pricing segmented controls shows a visible focus ring on each                                  |
+
+## Performance
+
+| ID  | Metric            | Target                                                                                           |
+| --- | ----------------- | ------------------------------------------------------------------------------------------------ |
+| P1  | In-app navigation | A header-nav route commit settles in **< 1 s** on a warm local build (SPA transition, no reload) |
+| P2  | Hash scroll       | `/#features` from the footer scrolls the section into view in **< 1 s**                          |
+
+## Issues Found
+
+| #   | Test ID | Route / URL                                                                     | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                                                                  | Screenshot |
+| --- | ------- | ------------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | B1/B2   | `https://tale.dev/nope-not-a-route`, `/nope/deep-page`, `/legal/not-a-document` | med                          | No branded 404 anywhere (2026-07-06 live pass): unknown single- and multi-segment routes silently redirect to `/`; an unknown legal slug renders TanStack's bare "Not Found" text with the home document title. Also HTTP 200 in every case — see [seo.md](seo.md) Issues #1 | —          |
+
+## Test summary
+
+```
+Area: Navigation & pages (web)
+Functional: ___/11   Boundary: ___/4   A11y: ___/4   Perf: ___/2
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/web/tests/manual/responsive.md
+++ b/services/web/tests/manual/responsive.md
@@ -1,0 +1,89 @@
+# Responsive — Manual Test Plan (cross-cutting)
+
+> **Purpose**: Verify the marketing site adapts across viewports — the mobile
+> hamburger drawer (the desktop nav is `hidden lg:flex`, so the split is the
+> Tailwind **`lg` breakpoint, 1024 px**), single-column reflow, the wide
+> pricing/hardware compare tables, and that no page overflows horizontally at
+> phone width. Cross-cutting: it re-walks pages other guides own at narrow
+> widths.
+
+## Scope & routes
+
+Test at three widths — **390×844** (phone), **1023×768** (just below the
+breakpoint — still mobile chrome), **1280×800** (desktop). Drive the width with
+`browser_resize` (or a context `viewport`).
+
+| Surface (re-walked at mobile width) | Route                              |
+| ----------------------------------- | ---------------------------------- |
+| Home (hero, features, FAQ)          | `/`                                |
+| Pricing (cards + compare table)     | `/pricing`                         |
+| Hardware pricing (compare table)    | `/hardware-pricing`                |
+| Contact form                        | `/contact`                         |
+| Request demo form                   | `/request-demo`                    |
+| Legal document (long prose + tabs)  | `/legal/data-processing-agreement` |
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — any mode; everything here is
+read-only (no form submits needed).
+
+> **Agent note**: set the viewport **before** the first `goto`. The hamburger
+> is the header button **Open menu** (`nav.openMenu`), `aria-expanded` +
+> `aria-controls="mobile-nav"`; open, it becomes **Close menu**
+> (`nav.closeMenu`) and the body scroll locks (`body.style.overflow ===
+'hidden'`). To prove "no horizontal overflow", assert
+> `document.documentElement.scrollWidth === clientWidth`.
+
+## Automated coverage
+
+| Case(s)                 | Status         | e2e spec                                       |
+| ----------------------- | -------------- | ---------------------------------------------- |
+| F1–F5, B1–B2, A1–A2, P1 | ⛔ manual-only | — (`smoke.spec.ts` runs desktop-viewport only) |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test              | Steps (route + control)                                                             | Expected (verifiable)                                                                                                                                                                                                                       |
+| --- | ----------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Hamburger drawer  | At 390 px on `/`, click **Open menu** (`nav.openMenu`)                              | The button flips to **Close menu** with `aria-expanded="true"`; the drawer (`#mobile-nav`) lists **Platform**/**Pricing**/**Hardware** + **Read docs** + **Request demo**; body scroll locks; the desktop inline nav is hidden (`lg:` only) |
+| F2  | Drawer navigation | In the open drawer, tap **Pricing**                                                 | URL commits `/pricing`, the drawer **closes itself**, scroll unlocks (`body.style.overflow` restored); **Esc** also closes it                                                                                                               |
+| F3  | No overflow       | At 390 px, on each scoped route, read `document.documentElement.scrollWidth`        | `scrollWidth === clientWidth (390)` on every page — no horizontal scrollbar, nothing off-canvas                                                                                                                                             |
+| F4  | Compare tables    | At 390 px, on `/pricing` and `/hardware-pricing`, scroll to the **Compare** section | The wide comparison table is horizontally scrollable **inside its own container** (the page itself doesn't overflow — F3 still holds); segmented controls wrap or shrink without clipping                                                   |
+| F5  | Forms at 390 px   | `/contact`: focus each field, open the keyboard-sized viewport                      | Fields stack one column, labels visible, the submit button full-width and reachable; no field is clipped                                                                                                                                    |
+
+## Boundary & error tests
+
+| ID  | Test                | Input                                        | Expected                                                                                                                                                        |
+| --- | ------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Breakpoint crossing | Resize 1023 px → 1024 px on `/`              | At **1023 px** the hamburger is visible and the inline nav hidden; at **1024 px** the inline nav + header CTAs appear and the hamburger disappears — clean swap |
+| B2  | Resize with drawer  | Open the drawer at 390 px, resize to 1280 px | No stuck scroll-lock: the page scrolls again and the desktop header renders normally (record if the lock persists — that's a finding)                           |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check         | Expected                                                                                                                               |
+| --- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Touch targets | The hamburger is ≥ 44×44 CSS px (rendered `h-11 w-11`); drawer links and footer controls are comfortably tappable (≥ 44 px height)     |
+| A2  | Reflow        | At **320 px** width content reflows to one column with no loss of information or function (WCAG 1.4.10); `scrollWidth === clientWidth` |
+
+## Performance
+
+| ID  | Metric      | Target                                                                                                      |
+| --- | ----------- | ----------------------------------------------------------------------------------------------------------- |
+| P1  | Drawer open | The drawer is fully visible **< 300 ms** after the tap (animation is skipped entirely under reduced motion) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL + width | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ------------------- | ---------------------------- | ----------- | ---------- |
+|     |         |                     |                              |             |            |
+
+## Test summary
+
+```
+Area: Responsive (web)
+Functional: ___/5   Boundary: ___/2   A11y: ___/2   Perf: ___/1
+Widths: 320 ☐  390 ☐  1023 ☐  1024 ☐  1280 ☐
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/web/tests/manual/seo.md
+++ b/services/web/tests/manual/seo.md
@@ -1,0 +1,85 @@
+# SEO & prerendered head — Manual Test Plan
+
+> **Purpose**: Verify the SEO surface the build pipeline produces — prerendered
+> per-page/per-locale `<title>`, meta description, canonical, and social tags
+> (`scripts/prerender.ts` + `useDocumentMeta`, site origin `https://tale.dev`),
+> the `dist-seo` artifacts (`sitemap.xml`, `robots.txt`, `llms.txt`,
+> `llms-full.txt`), and the noindex rule on legal pages. These checks read the
+> **served HTML** (curl / view-source), not the hydrated DOM.
+
+## Scope & routes
+
+| Surface         | Route                                                                              |
+| --------------- | ---------------------------------------------------------------------------------- |
+| Marketing pages | `/`, `/pricing`, `/hardware-pricing`, `/contact`, `/request-demo` (× `/de`, `/fr`) |
+| Legal pages     | `/legal/{slug}` (× locales) — **noindex**                                          |
+| Sitemap         | `/sitemap.xml`                                                                     |
+| Robots          | `/robots.txt`                                                                      |
+| LLM artifacts   | `/llms.txt`, `/llms-full.txt`                                                      |
+
+## Prerequisites
+
+Mode A (live) or mode B (local **build** + `bun run --filter @tale/web start`)
+per [SETUP.md](SETUP.md) — the vite dev server serves the unbuilt `index.html`
+head (fallback title) and none of the artifacts, so mode C proves nothing
+here.
+
+> **Agent note**: this guide is mostly `curl`-driven; a browser is only needed
+> for F7. Expected title/description strings resolve from the `seo.*`
+> namespace in `messages/{locale}.json`; the prerenderer appends the
+> `&nbsp;| Tale` brand suffix (e.g. `<title>Pricing | Tale</title>`).
+
+## Automated coverage
+
+| Case(s)      | Status         | e2e spec                                              |
+| ------------ | -------------- | ----------------------------------------------------- |
+| F1–F7, B1–B2 | ⛔ manual-only | — (no spec reads the prerendered output or artifacts) |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test                   | Steps                                                                                      | Expected (verifiable)                                                                                                                                                                                                                                                                         |
+| --- | ---------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Prerendered titles     | `curl -s {base}/{page}` for every marketing page; grep `<title>`                           | Each serves its own `seo.{page}.title` + ` \| Tale` **in the raw HTML** (home: **Tale: The Orchestrator for AI Agents**; `/pricing`: **Pricing \| Tale**; `/contact`: **Contact us \| Tale**; `/request-demo`: **Request a demo \| Tale**; `/hardware-pricing`: **Hardware Pricing \| Tale**) |
+| F2  | Meta description + OG  | Same fetches; grep `meta name="description"`, `og:title`, `og:description`, `twitter:card` | Description matches `seo.{page}.description`; `og:*`/`twitter:*` mirror title + description; `og:site_name` = **Tale**                                                                                                                                                                        |
+| F3  | Canonical per locale   | `curl -s {base}/pricing` and `{base}/de/pricing`; grep `rel="canonical"`                   | `https://tale.dev/pricing` and `https://tale.dev/de/pricing` respectively — each locale page is its own canonical; `<html lang>` is `en` / `de` in the raw HTML                                                                                                                               |
+| F4  | Localized titles       | `curl -s {base}/de/pricing`; grep `<title>`                                                | The German title from `messages/de.json` `seo.pricing.title` (live: **Preise \| Tale**) — prerendering is per locale, not English-only                                                                                                                                                        |
+| F5  | Sitemap                | `curl -s {base}/sitemap.xml`                                                               | Lists every marketing page and legal page; legal URLs carry `xhtml:link rel="alternate" hreflang` entries for `en`/`de`/`fr`/`x-default`; no unknown or dead URLs (spot-check a few return the right page)                                                                                    |
+| F6  | Robots + LLM artifacts | `curl -s {base}/robots.txt`, `/llms.txt`, `/llms-full.txt`                                 | robots: `Allow: /`, `Disallow: /api/`, `Disallow: /_search/`, and **two** sitemap lines (`https://tale.dev/sitemap.xml` + `https://tale.dev/docs/sitemap.xml`); both llms files serve plaintext markdown summaries (HTTP 200, non-empty)                                                      |
+| F7  | Content pre-JS         | View-source of `/` (or curl) — do not execute JS                                           | The hero heading text (**The Orchestrator for AI Agents**) is present in the served HTML — the page is meaningful to crawlers without hydration                                                                                                                                               |
+| F8  | Legal noindex          | `curl -s {base}/legal/privacy-policy`; grep `robots`                                       | `<meta name="robots" content="noindex,nofollow">` present on legal pages; **absent** on marketing pages                                                                                                                                                                                       |
+
+## Boundary & error tests
+
+| ID  | Test           | Input                                                            | Expected                                                                                                                                                                                                                                                                               |
+| --- | -------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Soft 404       | `curl -s -o /dev/null -w '%{http_code}' {base}/nope-not-a-route` | **Known gap**: the SPA fallback serves the shell with HTTP **200** and the generic fallback head — an unknown URL is indistinguishable from a page to crawlers. Record the status + served title; a real 404 status (or at least `noindex` on the not-found view) is the desired state |
+| B2  | Trailing slash | `curl -sI {base}/pricing/`                                       | Resolves to the same page (no duplicate-content split: either serves identical canonical `https://tale.dev/pricing` or redirects); record which                                                                                                                                        |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check       | Expected                                                                                          |
+| --- | ----------- | ------------------------------------------------------------------------------------------------- |
+| A1  | Page titles | Every page's `<title>` is unique and describes the page (WCAG 2.4.2) — F1/F4 double as this check |
+
+## Performance
+
+| ID  | Metric     | Target                                                                             |
+| --- | ---------- | ---------------------------------------------------------------------------------- |
+| P1  | First byte | `curl -w '%{time_starttransfer}'` on `/` **< 1 s** (static prerendered file serve) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL                         | Severity (crit/high/med/low) | Description                                                                                                                                                                                                             | Screenshot |
+| --- | ------- | ----------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | B1      | `https://tale.dev/nope-not-a-route` | med                          | Soft 404 confirmed live (2026-07-06): unknown URLs return HTTP **200** with the home shell (client then redirects to `/`) — crawlers can index garbage URLs as duplicates of the home page; no 404 status, no `noindex` | —          |
+
+## Test summary
+
+```
+Area: SEO & prerendered head (web)
+Functional: ___/8   Boundary: ___/2   A11y: ___/1   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/services/web/tests/manual/theme.md
+++ b/services/web/tests/manual/theme.md
@@ -1,0 +1,80 @@
+# Theme (dark mode) — Manual Test Plan
+
+> **Purpose**: Exercise light/dark/system theming — the footer's segmented
+> theme switcher, persistence (`localStorage['tale-theme']`), the
+> pre-hydration no-flash script in `index.html`, system-preference tracking,
+> and the theme-dependent imagery. Contrast in both themes lives in
+> [accessibility.md](accessibility.md) A5.
+
+## Scope & routes
+
+Theme is global — test on `/` and spot-check `/pricing`, `/contact`, and one
+legal page. The switcher renders in the footer on every page
+(`packages/ui/src/components/site/theme-switcher.tsx`, `variant="segmented"`;
+provider `packages/ui/src/theme/theme-provider.tsx`).
+
+## Prerequisites
+
+Bring the site up per [SETUP.md](SETUP.md) — any mode. To drive the system
+row (F3) toggle the OS appearance, or emulate `prefers-color-scheme` in
+DevTools / the browser context.
+
+> **Agent note**: the resolved theme is the `dark` class on
+> `document.documentElement` (plus `style.colorScheme`) — assert that, not
+> pixel colours. The switcher is a `role="radiogroup"` labelled **Switch
+> theme** (`themeSwitcher.ariaLabel`) with three `role="radio"` buttons
+> **Light** / **Dark** / **System** (`themeSwitcher.light|dark|system`).
+
+## Automated coverage
+
+| Case(s)          | Status         | e2e spec |
+| ---------------- | -------------- | -------- |
+| F1–F6, B1, A1–A3 | ⛔ manual-only | —        |
+
+Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
+
+## Functional tests
+
+| ID  | Test             | Steps (route + control)                                                              | Expected (verifiable)                                                                                                                                                                                                           |
+| --- | ---------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Explicit switch  | Footer → **Switch theme** radiogroup: click **Dark**, then **Light**                 | `document.documentElement.classList.contains('dark')` flips true/false; the page palette follows; `localStorage['tale-theme']` reads `dark` / `light`                                                                           |
+| F2  | Persistence      | Set **Dark**; reload; navigate to `/pricing`                                         | The dark theme survives the reload and the navigation; the **Dark** radio stays `aria-checked="true"`                                                                                                                           |
+| F3  | System mode      | Click **System**; flip the OS/emulated `prefers-color-scheme` between light and dark | The page follows the OS **live** (no reload needed); `localStorage['tale-theme']` reads `system`                                                                                                                                |
+| F4  | No flash on load | With **Dark** stored, hard-reload `/` (disable cache)                                | No white flash before first paint — the inline `index.html` script applies the `dark` class pre-hydration; same check with system-dark + no stored value                                                                        |
+| F5  | Themed imagery   | On `/`, toggle Light ↔ Dark and inspect the hero image                               | The hero swaps between `/marketing/hero-light.png` and `/marketing/hero-dark.png` (only one visible per theme); feature-section screenshots follow the same pattern; the favicon/`theme-color` metas are media-gated per scheme |
+| F6  | Default          | Fresh profile (no `tale-theme` key), OS light                                        | Site renders light and the **System** radio is checked — system is the default; no key is written until the user picks one                                                                                                      |
+
+## Boundary & error tests
+
+| ID  | Test              | Input                                                 | Expected                                                   |
+| --- | ----------------- | ----------------------------------------------------- | ---------------------------------------------------------- | ---- | --------------------------------- |
+| B1  | Corrupted storage | `localStorage.setItem('tale-theme','banana')`; reload | Falls back to **system** (the provider only accepts `light | dark | system`); no crash, no flash loop |
+
+## Accessibility (WCAG 2.1 AA)
+
+| ID  | Check           | Expected                                                                                                                                        |
+| --- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Radiogroup      | The control is `role="radiogroup"` aria-labelled **Switch theme**; each option is `role="radio"` with `aria-checked` and a text-resolvable name |
+| A2  | Keyboard        | The radios are reachable by Tab and switchable by keyboard; focus ring visible in **both** themes                                               |
+| A3  | No content loss | Toggling theme changes no layout/content — only colours/imagery; text remains readable during the flip (transitions suppressed by the provider) |
+
+## Performance
+
+| ID  | Metric     | Target                                                                                                                       |
+| --- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| P1  | Theme flip | The palette swap paints in **< 200 ms** with no partial-transition flicker (provider suppresses transitions during the flip) |
+
+## Issues Found
+
+| #   | Test ID | Route / URL | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ----------- | ---------------------------- | ----------- | ---------- |
+|     |         |             |                              |             |            |
+
+## Test summary
+
+```
+Area: Theme (web)
+Functional: ___/6   Boundary: ___/1   A11y: ___/3   Perf: ___/1
+Issues: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```


### PR DESCRIPTION
## Summary

Adds AI-directed manual test guides for the two services the platform's manual suite explicitly scoped out — the marketing site and the docs site — in the exact format established by `services/platform/tests/manual/` (same `TEMPLATE.md` shape, case-mode conventions F#/B#/A#/P#, i18n-keyed labels, Automated-coverage cross-links, Issues tables).

- **`services/web/tests/manual/`** — README + SETUP + 7 guides: navigation & page inventory (incl. 404s), forms end-to-end (contact + request-demo, the Discord delivery path, and a live-safe honeypot probe that verifies the endpoint without delivering), locale switching, SEO/prerendered head (sitemap, robots, llms.txt, noindex), theme, responsive, accessibility.
- **`services/docs/tests/manual/`** — README + SETUP + 5 guides: sidebar/breadcrumbs/TOC navigation (incl. the styled 404 with did-you-mean suggestions), search, locale versions, content rendering (code copy buttons, heading deep links, page actions, images), accessibility.
- Each guide's *Automated coverage* table cross-links the service's Playwright smoke spec (and, for docs, the vitest content suites), so manual effort goes to the 🔶/⛔ rows.
- The platform manual README now links to the new guide sets instead of scoping web/docs out.

## Live pass

A manual pass was executed against the live sites (2026-07-06) and its findings are logged in the guides' Issues tables:

- **crit** — `POST https://tale.dev/api/forms/submit` still returns **503 "Service not configured"** (`WEB_DISCORD_WEBHOOK_URL` unset): every production contact/demo submission fails. Verified with a honeypot-tripped probe, so nothing was delivered to Discord.
- **med** — no branded 404 on the marketing site: unknown routes silently redirect to `/` (swallowed by the `$lang` route) or render TanStack's bare "Not Found"; unknown URLs also serve HTTP 200 (soft 404).
- **med** — docs shell ships hard-coded English on `/de`/`/fr` pages (skip link, `Copy code`, page actions, sidebar landmark label).
- **low** — web header primary `<nav>` is unlabelled; docs 404 keeps the default document title.

Positive checks (search relevance, TOC/scroll-spy, breadcrumbs, edit-on-GitHub locale paths, theme persistence, mobile drawers, locale cookie negotiation across both sites, prerendered titles/canonicals/hreflang) are annotated inline as *verified live*.

## Checks

- `oxfmt --check` green on all touched files.
- Relative links in the new guides validated against the tree.
- No code changes — markdown only.

Closes #2390