### PR TITLE
fix(platform): one token-based edge palette for the automation canvas

### DIFF
--- a/services/platform/app/components/flow/edge-palette.ts
+++ b/services/platform/app/components/flow/edge-palette.ts
@@ -1,0 +1,40 @@
+/**
+ * The ONE edge visual language for React Flow canvases built on `FlowCanvas`
+ * (the automations step editor today). Every edge encodes exactly one of these
+ * documented meanings (#2370):
+ *
+ *  - `flow`     — nominal progression: the main spine between steps, including
+ *                 a loop's exit toward the next step. Calm and neutral so the
+ *                 eye follows the happy path; only decisions draw color.
+ *  - `positive` — a decision's yes/true outcome (green = "the check passed").
+ *  - `negative` — a decision's no/false outcome. Amber, **never red**: "No" is
+ *                 a branch the author designed, not an error state.
+ *  - `error`    — an explicit error/failure route out of a step. The only red
+ *                 line on the canvas, reserved for genuine failure handling.
+ *
+ * Loop-back edges reuse the `flow` color but render dashed — the *shape*
+ * encodes the cycle, so color keeps its one meaning.
+ *
+ * All values are semantic theme tokens (light + dark), never hex. Strokes and
+ * arrowheads share one width/size so every edge carries the same arrow.
+ */
+export const FLOW_EDGE_COLORS = {
+  flow: 'hsl(var(--muted-foreground))',
+  positive: 'hsl(var(--success))',
+  negative: 'hsl(var(--warning))',
+  error: 'hsl(var(--destructive))',
+} as const;
+
+export type FlowEdgeSemantic = keyof typeof FLOW_EDGE_COLORS;
+
+/** One stroke width for every edge on the canvas. */
+export const FLOW_EDGE_STROKE_WIDTH = 2;
+
+/** One arrowhead size for every edge on the canvas. */
+export const FLOW_EDGE_MARKER_SIZE = 18;
+
+/**
+ * Which badge treatment an edge label gets. Kept semantic (not raw colors) so
+ * the edge renderer can pick AA-contrast token classes per theme.
+ */
+export type FlowEdgeLabelVariant = 'positive' | 'negative' | 'neutral';

--- a/services/platform/app/features/automations/components/automation-edge.test.tsx
+++ b/services/platform/app/features/automations/components/automation-edge.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { screen } from '@testing-library/react';
+import { Position } from '@xyflow/react';
+import type { CSSProperties, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+// BaseEdge/EdgeLabelRenderer need a live React Flow store; the label badge —
+// what these tests assert — does not. Keep the pure path helpers real.
+vi.mock('@xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@xyflow/react')>();
+  return {
+    ...actual,
+    BaseEdge: ({ path, style }: { path: string; style?: CSSProperties }) => (
+      <svg>
+        <path data-testid="base-edge" d={path} style={style} />
+      </svg>
+    ),
+    EdgeLabelRenderer: ({ children }: { children: ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+import { AutomationEdge } from './automation-edge';
+
+const baseProps = {
+  id: 'e-cond-target-yes',
+  source: 'cond',
+  target: 'next',
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 0,
+  targetY: 200,
+  sourcePosition: Position.Bottom,
+  targetPosition: Position.Top,
+};
+
+// A routed path long enough (>= 90px) that the label badge is shown.
+const longRoute = [
+  { x: 0, y: 0 },
+  { x: 0, y: 60 },
+  { x: 120, y: 60 },
+  { x: 120, y: 200 },
+];
+
+describe('AutomationEdge branch label badge (#2370)', () => {
+  it('renders a positive branch label with the success treatment', () => {
+    render(
+      <AutomationEdge
+        {...baseProps}
+        data={{ label: 'Yes', labelVariant: 'positive', elkPoints: longRoute }}
+      />,
+    );
+
+    const badge = screen.getByText('Yes');
+    expect(badge).toHaveClass('text-success', 'border-success');
+  });
+
+  it('renders a negative branch label in amber — never the error red', () => {
+    render(
+      <AutomationEdge
+        {...baseProps}
+        data={{ label: 'No', labelVariant: 'negative', elkPoints: longRoute }}
+      />,
+    );
+
+    const badge = screen.getByText('No');
+    expect(badge).toHaveClass('text-amber-700', 'border-warning');
+    expect(badge).not.toHaveClass('text-destructive');
+    expect(badge).not.toHaveClass('border-destructive');
+  });
+
+  it('falls back to the neutral treatment for a custom branch key', () => {
+    render(
+      <AutomationEdge
+        {...baseProps}
+        data={{ label: 'Check Has Cursor', elkPoints: longRoute }}
+      />,
+    );
+
+    expect(screen.getByText('Check Has Cursor')).toHaveClass(
+      'text-muted-foreground',
+    );
+  });
+
+  it('hides the label on a routed edge too short to fit it', () => {
+    render(
+      <AutomationEdge
+        {...baseProps}
+        targetY={40}
+        data={{
+          label: 'Yes',
+          labelVariant: 'positive',
+          elkPoints: [
+            { x: 0, y: 0 },
+            { x: 0, y: 40 },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText('Yes')).toBeNull();
+  });
+});

--- a/services/platform/app/features/automations/components/automation-edge.tsx
+++ b/services/platform/app/features/automations/components/automation-edge.tsx
@@ -11,24 +11,27 @@ import {
 import type { CSSProperties } from 'react';
 import { useMemo } from 'react';
 
+import type { FlowEdgeLabelVariant } from '@/app/components/flow/edge-palette';
 import type { ElkPoint } from '@/app/components/flow/layout/elk-layout';
+import { cn } from '@/lib/utils/cn';
 
 const EMPTY_STYLE: CSSProperties = {};
+
+/** AA-contrast badge treatments per branch semantic (edge-palette.ts): colored
+ *  text + border on a solid background, so the badge masks the line behind it
+ *  and stays legible in both themes. */
+const LABEL_VARIANT_CLASSES: Record<FlowEdgeLabelVariant, string> = {
+  positive: 'border-success text-success',
+  negative: 'border-warning text-amber-700 dark:text-amber-300',
+  neutral: 'border-muted-foreground/50 text-muted-foreground',
+};
 
 interface AutomationEdgeProps extends EdgeProps {
   type?: 'smoothstep' | 'bezier' | 'straight' | 'default';
   data?: {
     label?: string;
-    labelStyle?: {
-      fill?: string;
-      fontSize?: string;
-      fontWeight?: number;
-    };
-    labelBgStyle?: {
-      fill?: string;
-      stroke?: string;
-      strokeWidth?: number;
-    };
+    /** Semantic treatment for the label badge (Yes / No / custom branch). */
+    labelVariant?: FlowEdgeLabelVariant;
     // Smart label positioning options
     labelPosition?: 'center' | 'source' | 'target'; // Position along edge
     labelOffset?: { x: number; y: number }; // Manual offset from calculated position
@@ -294,23 +297,13 @@ export function AutomationEdge({
             masks the line behind it. Hidden on short edges to avoid overlap. */}
         {data?.label && showLabel && (
           <div
+            className={cn(
+              'pointer-events-none absolute rounded-md border bg-background px-1.5 text-[11px] leading-normal font-semibold whitespace-nowrap',
+              LABEL_VARIANT_CLASSES[data.labelVariant ?? 'neutral'],
+            )}
             style={{
-              position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
-              pointerEvents: 'none',
               zIndex: -1, // Below nodes (nodes are at z-index 0 or higher)
-              padding: '0px 6px',
-              lineHeight: 1.5,
-              borderRadius: '6px',
-              whiteSpace: 'nowrap',
-              backgroundColor:
-                data.labelBgStyle?.fill || 'hsl(var(--background))',
-              border: data.labelBgStyle?.stroke
-                ? `${data.labelBgStyle.strokeWidth || 1}px solid ${data.labelBgStyle.stroke}`
-                : 'none',
-              color: data.labelStyle?.fill || 'hsl(var(--foreground))',
-              fontSize: data.labelStyle?.fontSize || '11px',
-              fontWeight: data.labelStyle?.fontWeight || 600,
             }}
           >
             {data.label}

--- a/services/platform/app/features/automations/components/automation-steps.tsx
+++ b/services/platform/app/features/automations/components/automation-steps.tsx
@@ -23,7 +23,7 @@ import { parseDebugWaitingFor } from '@/convex/workflow_engine/helpers/engine/de
 import { useT } from '@/lib/i18n/client';
 
 import { useAutomationLayout } from '../hooks/use-automation-layout';
-import { type StepDef } from '../utils/step-icons';
+import { getStepMinimapStroke, type StepDef } from '../utils/step-icons';
 import { AutomationCallbacksProvider } from './automation-callbacks-context';
 import { AutomationEdge } from './automation-edge';
 import { AutomationGroupNode } from './automation-group-node';
@@ -84,22 +84,12 @@ const MINIMAP_STYLES = `
   .react-flow__minimap-mask { fill: hsl(var(--muted) / 0.6) !important; }
 `;
 
+// Stroke each minimap node in its step type's accent hue via theme-token
+// variables (never hex) — applied as an inline style, so it wins over
+// xyflow's stylesheet defaults regardless of CSS order.
 function minimapNodeStrokeColor(node: Node): string {
   const stepType = node.data?.stepType;
-  switch (stepType) {
-    case 'start':
-      return '#3b82f6';
-    case 'llm':
-      return '#a855f7';
-    case 'condition':
-      return '#f59e0b';
-    case 'loop':
-      return '#06b6d4';
-    case 'action':
-      return '#f97316';
-    default:
-      return '#71717a';
-  }
+  return getStepMinimapStroke(typeof stepType === 'string' ? stepType : '');
 }
 
 function AutomationStepsInner({

--- a/services/platform/app/features/automations/hooks/use-automation-layout.test.ts
+++ b/services/platform/app/features/automations/hooks/use-automation-layout.test.ts
@@ -1,25 +1,30 @@
 import { describe, it, expect } from 'vitest';
 
+import { FLOW_EDGE_COLORS } from '@/app/components/flow/edge-palette';
+
 import { resolveConditionBranchEdge } from './use-automation-layout';
 
-// Regression test for #1486: condition branches with a custom key used to
-// render as an unlabeled gray line, making the flow ambiguous. Every branch
-// must now carry a label.
-describe('resolveConditionBranchEdge (#1486)', () => {
-  it('maps negative keys to a red "false" edge (case-insensitive)', () => {
+// Regression tests for #1486 (custom condition branches used to render as an
+// unlabeled gray line) and #2370 (a condition's "No" branch used to render in
+// the destructive red, which reads as an error — branches are never red).
+describe('resolveConditionBranchEdge (#1486, #2370)', () => {
+  it('maps negative keys to an amber "false" branch, never red (case-insensitive)', () => {
     for (const key of ['false', 'No', 'REJECT', 'failure', 'error']) {
       expect(resolveConditionBranchEdge(key)).toEqual({
-        color: 'hsl(var(--destructive))',
+        color: FLOW_EDGE_COLORS.negative,
         label: 'false',
+        variant: 'negative',
       });
     }
+    expect(FLOW_EDGE_COLORS.negative).not.toContain('destructive');
   });
 
-  it('maps positive keys to a green "true" edge (case-insensitive)', () => {
+  it('maps positive keys to a green "true" branch (case-insensitive)', () => {
     for (const key of ['true', 'Yes', 'APPROVE', 'success', 'default']) {
       expect(resolveConditionBranchEdge(key)).toEqual({
-        color: 'hsl(var(--chart-2))',
+        color: FLOW_EDGE_COLORS.positive,
         label: 'true',
+        variant: 'positive',
       });
     }
   });
@@ -27,6 +32,24 @@ describe('resolveConditionBranchEdge (#1486)', () => {
   it('labels a custom branch key with its own name (no longer unlabeled)', () => {
     const result = resolveConditionBranchEdge('Check Has Cursor');
     expect(result.label).toBe('Check Has Cursor');
-    expect(result.color).toBeTruthy();
+    expect(result.variant).toBe('neutral');
+    expect(result.color).toBe(FLOW_EDGE_COLORS.flow);
+  });
+});
+
+// The palette itself is the documented visual language — pin that every value
+// is a semantic theme token (light + dark), never a raw hex.
+describe('FLOW_EDGE_COLORS (#2370)', () => {
+  it('only uses semantic theme tokens', () => {
+    for (const color of Object.values(FLOW_EDGE_COLORS)) {
+      expect(color).toMatch(/^hsl\(var\(--[a-z-]+\)\)$/);
+    }
+  });
+
+  it('reserves red for error routes only', () => {
+    expect(FLOW_EDGE_COLORS.error).toBe('hsl(var(--destructive))');
+    expect(FLOW_EDGE_COLORS.flow).not.toContain('destructive');
+    expect(FLOW_EDGE_COLORS.positive).not.toContain('destructive');
+    expect(FLOW_EDGE_COLORS.negative).not.toContain('destructive');
   });
 });

--- a/services/platform/app/features/automations/hooks/use-automation-layout.ts
+++ b/services/platform/app/features/automations/hooks/use-automation-layout.ts
@@ -4,6 +4,12 @@ import type { Edge, Node } from '@xyflow/react';
 import { MarkerType } from '@xyflow/react';
 import React, { useMemo } from 'react';
 
+import type { FlowEdgeLabelVariant } from '@/app/components/flow/edge-palette';
+import {
+  FLOW_EDGE_COLORS,
+  FLOW_EDGE_MARKER_SIZE,
+  FLOW_EDGE_STROKE_WIDTH,
+} from '@/app/components/flow/edge-palette';
 import type { ElkLayoutOptions } from '@/app/components/flow/layout/elk-layout';
 import { useElkLayout } from '@/app/components/flow/layout/use-elk-layout';
 import { useT } from '@/lib/i18n/client';
@@ -26,7 +32,6 @@ const AUTOMATION_ELK_OPTIONS: ElkLayoutOptions = {
   compoundPadding: { top: 84, right: 24, bottom: 32, left: 24 },
 };
 
-const LOOP_EXIT_KEYS = new Set(['done', 'complete', 'finished', 'exit']);
 const NEGATIVE_BRANCH_KEYS = new Set([
   'reject',
   'false',
@@ -41,28 +46,38 @@ const POSITIVE_BRANCH_KEYS = new Set([
   'success',
   'default',
 ]);
-// Calm, theme-aware gray for the main "spine" (non-branching) connections, so
-// the eye follows the happy path and only decisions/outcomes draw color.
-const NEUTRAL_EDGE_COLOR = 'hsl(var(--muted-foreground))';
+// Next-step keys on an action/llm step that mean "the step itself failed" —
+// the only routes drawn in the error red (see edge-palette.ts).
+const ERROR_PATH_KEYS = new Set(['failure', 'error']);
 
 /**
  * Resolve the color + label for a condition step's branch edge. Standard
- * positive/negative outcomes map to green/"true" and red/"false"; any other
- * (custom) branch key keeps a neutral color but is labeled with its own key,
- * so the path is identifiable rather than an unlabeled gray line (#1486).
+ * positive/negative outcomes map to green/"true" and amber/"false" — never red,
+ * a "No" is a designed branch, not an error (#2370); any other (custom) branch
+ * key keeps a neutral color but is labeled with its own key, so the path is
+ * identifiable rather than an unlabeled gray line (#1486).
  */
 export function resolveConditionBranchEdge(key: string): {
   color: string;
   label: string;
+  variant: FlowEdgeLabelVariant;
 } {
   const keyLower = key.toLowerCase();
   if (NEGATIVE_BRANCH_KEYS.has(keyLower)) {
-    return { color: 'hsl(var(--destructive))', label: 'false' };
+    return {
+      color: FLOW_EDGE_COLORS.negative,
+      label: 'false',
+      variant: 'negative',
+    };
   }
   if (POSITIVE_BRANCH_KEYS.has(keyLower)) {
-    return { color: 'hsl(var(--chart-2))', label: 'true' };
+    return {
+      color: FLOW_EDGE_COLORS.positive,
+      label: 'true',
+      variant: 'positive',
+    };
   }
-  return { color: NEUTRAL_EDGE_COLOR, label: key };
+  return { color: FLOW_EDGE_COLORS.flow, label: key, variant: 'neutral' };
 }
 
 export function useAutomationLayout(steps: StepDef[]) {
@@ -233,25 +248,20 @@ export function useAutomationLayout(steps: StepDef[]) {
               return;
             }
 
-            const isLoopExit = LOOP_EXIT_KEYS.has(keyLower);
             const isNegativePath = NEGATIVE_BRANCH_KEYS.has(keyLower);
             const isPositivePath = POSITIVE_BRANCH_KEYS.has(keyLower);
 
-            let edgeColor = NEUTRAL_EDGE_COLOR;
+            // One documented meaning per color (edge-palette.ts): the spine —
+            // including a loop's exit toward the next step — stays neutral;
+            // only decision outcomes and genuine error routes draw color.
+            let edgeColor: string = FLOW_EDGE_COLORS.flow;
             let edgeLabel: string | undefined = undefined;
-            let edgeStyle: React.CSSProperties = {
-              strokeWidth: 2,
-              stroke: edgeColor,
-            };
+            let labelVariant: FlowEdgeLabelVariant = 'neutral';
 
-            if (step.stepType === 'loop') {
-              if (isLoopExit) {
-                edgeColor = 'hsl(var(--chart-2))';
-                edgeStyle = { strokeWidth: 2, stroke: edgeColor };
-              }
-            } else if (step.stepType === 'condition') {
+            if (step.stepType === 'condition') {
               const branch = resolveConditionBranchEdge(key);
               edgeColor = branch.color;
+              labelVariant = branch.variant;
               // Show plain-language Yes/No at decisions; keep any custom branch
               // key (e.g. a named outcome) as-is so it stays identifiable.
               edgeLabel =
@@ -260,15 +270,20 @@ export function useAutomationLayout(steps: StepDef[]) {
                   : branch.label === 'false'
                     ? t('edges.no')
                     : branch.label;
-              edgeStyle = { strokeWidth: 2, stroke: edgeColor };
             } else if (step.stepType === 'action' || step.stepType === 'llm') {
-              if (isNegativePath) {
-                edgeColor = 'hsl(var(--destructive))';
+              if (ERROR_PATH_KEYS.has(keyLower)) {
+                edgeColor = FLOW_EDGE_COLORS.error;
+              } else if (isNegativePath) {
+                edgeColor = FLOW_EDGE_COLORS.negative;
               } else if (isPositivePath) {
-                edgeColor = 'hsl(var(--chart-2))';
+                edgeColor = FLOW_EDGE_COLORS.positive;
               }
-              edgeStyle = { strokeWidth: 2, stroke: edgeColor };
             }
+
+            const edgeStyle: React.CSSProperties = {
+              strokeWidth: FLOW_EDGE_STROKE_WIDTH,
+              stroke: edgeColor,
+            };
 
             const targetStepData = sortedSteps.find(
               (s) => s.stepSlug === targetStepSlug,
@@ -322,17 +337,19 @@ export function useAutomationLayout(steps: StepDef[]) {
                     : -2,
               markerEnd: {
                 type: MarkerType.ArrowClosed,
-                width: 18,
-                height: 18,
+                width: FLOW_EDGE_MARKER_SIZE,
+                height: FLOW_EDGE_MARKER_SIZE,
                 color: edgeColor,
               },
               style: {
                 ...edgeStyle,
+                // Loop-back edges: same neutral color, dashed — the shape
+                // encodes the cycle so color keeps its one meaning.
                 ...(isBackwardConnection
                   ? {
                       strokeDasharray: '5,5',
                       opacity: 0.7,
-                      strokeWidth: 2,
+                      strokeWidth: FLOW_EDGE_STROKE_WIDTH,
                     }
                   : {}),
               },
@@ -342,22 +359,9 @@ export function useAutomationLayout(steps: StepDef[]) {
               data: {
                 isBackward: isBackwardConnection,
                 label: edgeLabel,
-                // Outline badge in the branch color (colored text + border on a
-                // solid background), matching its arrow without a heavy fill.
-                labelStyle: edgeLabel
-                  ? {
-                      fill: edgeColor,
-                      fontSize: '11px',
-                      fontWeight: 600,
-                    }
-                  : undefined,
-                labelBgStyle: edgeLabel
-                  ? {
-                      fill: 'hsl(var(--background))',
-                      stroke: edgeColor,
-                      strokeWidth: 1.5,
-                    }
-                  : undefined,
+                // Semantic badge treatment; the edge renderer resolves it to
+                // AA-contrast token classes per theme (edge-palette.ts).
+                labelVariant: edgeLabel ? labelVariant : undefined,
                 isBackwardConnection,
               },
             });

--- a/services/platform/app/features/automations/utils/step-icons.tsx
+++ b/services/platform/app/features/automations/utils/step-icons.tsx
@@ -155,6 +155,29 @@ export function getStepTypeColor(stepType: string): string {
   }
 }
 
+/** Minimap stroke color per step type — the same theme-token hue as the card's
+ *  accent border (`getStepAccentBorder` keeps each `--color-*` variable alive),
+ *  so the overview and the canvas tell one story. Token vars, never hex. */
+export function getStepMinimapStroke(stepType: string): string {
+  switch (stepType) {
+    case 'start':
+    case 'trigger':
+      return 'var(--color-blue-500)';
+    case 'llm':
+      return 'var(--color-violet-500)';
+    case 'condition':
+      return 'var(--color-amber-500)';
+    case 'loop':
+      return 'var(--color-cyan-500)';
+    case 'action':
+      return 'var(--color-indigo-500)';
+    case 'output':
+      return 'var(--color-slate-400)';
+    default:
+      return 'hsl(var(--muted-foreground))';
+  }
+}
+
 /** Left-accent border color per step type — lets the reader recognize a step's
  *  kind at a glance (blue = start, amber = decision, cyan = loop, …). */
 export function getStepAccentBorder(stepType: string): string {


### PR DESCRIPTION
## What

Defines one documented visual language for automation-canvas edges in the shared flow primitives and adopts it in the automations editor (issue #2370).

- **New shared palette** `services/platform/app/components/flow/edge-palette.ts` — every edge encodes exactly one documented meaning:
  - `flow` — nominal progression (spine + loop exit): neutral `--muted-foreground`
  - `positive` — a decision's Yes/true outcome: `--success`
  - `negative` — a decision's No/false outcome: `--warning` amber — **never red**; a "No" is a designed branch, not an error
  - `error` — an explicit `error`/`failure` route out of an action/llm step: the only `--destructive` red on the canvas
  - loop-back edges reuse the flow color but dashed — the shape encodes the cycle
  - one shared stroke width and arrowhead size for every edge
- **Branch label badges** (Yes/No/custom) move from free-form inline colors to semantic variants resolved to AA-contrast token classes per theme (e.g. `text-amber-700 dark:text-amber-300`), fixing the sub-AA amber/red 11px text.
- **Minimap node strokes** drop hardcoded hex (`#3b82f6`, `#f97316", …) for the step types' accent-token variables (`var(--color-blue-500)` …), colocated with the accent-border mapping in `step-icons.tsx` — the minimap now matches the card accents (action was orange in the minimap but indigo on canvas).

All colors are semantic theme tokens (light + dark), never hex.

## Acceptance criteria from #2370

- Edge color/shape encodes a documented meaning, no red for non-error branches — the palette module is the documentation; red is reserved for error routes.
- No edge crosses a node box; labels off the path — already handled by the ELK orthogonal routing on main; the label badge keeps masking the line and hides on short edges (now pinned by component tests).
- Consistent arrowheads/node widths — already on main (ArrowClosed everywhere, fixed 300px nodes); now centralized as shared constants.
- Organigram parity — N/A: the org-chart consumer was removed in #2415; the automations editor is the only FlowCanvas consumer.

## Tests

- `use-automation-layout.test.ts` — branch resolution repinned (negative → amber, positive → success, custom → neutral) + palette guard tests (tokens only, red reserved for errors).
- New `automation-edge.test.tsx` — label badge variants (positive/negative/neutral classes, never destructive) and short-edge label hiding.

## Checks

- `vitest --config vitest.ui.config.ts app/features/automations app/components/flow`: 28 files, 105 tests passed
- `tsc --noEmit` (platform): clean
- `oxlint --type-aware` on touched dirs: 0 warnings/errors
- `oxfmt --check` on touched files: clean

Closes #2370