### PR TITLE
fix(cli): un-export unused OrphanedDataVolume interface

### DIFF
--- a/tools/cli/src/lib/docker/detect-legacy-convex-data.ts
+++ b/tools/cli/src/lib/docker/detect-legacy-convex-data.ts
@@ -27,7 +27,7 @@ import { volumeExists } from './ensure-volumes';
 /** Pre-0.2.33 fixed compose project name (`docker compose -p tale`). */
 const LEGACY_PROJECT_NAME = 'tale';
 
-export interface OrphanedDataVolume {
+interface OrphanedDataVolume {
   /** The pre-0.3.2 volume that still holds the Convex data. */
   legacy: string;
   /** The volume the current compose files mount instead. */


### PR DESCRIPTION
Knip fails on main since #2533's CLI commit: `OrphanedDataVolume` is exported from `detect-legacy-convex-data.ts` but never imported anywhere. Un-exports it (it's only used internally as the return element type). `bunx knip` and the cli typecheck pass locally.