### PR TITLE
fix: tale.dev contact form 503 — WEB_DISCORD_WEBHOOK_URL unset (#2389)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -47,3 +47,7 @@ INSTANCE_NAME=tale_platform
 # Sandbox spawner — fixed test-only HMAC token so the smoke script can sign
 # /v1/execute. Production deploys auto-mint via the CLI's ensure-env helper.
 SANDBOX_TOKEN=test-sandbox-token-do-not-use-in-production-deadbeefcafef00d
+
+# Tale web — placeholder webhook so container smoke tests pass /api/health.
+# Not a real Discord endpoint; form delivery is not exercised in CI.
+WEB_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/000000000000000000/test-ci-placeholder

--- a/compose.web.yml
+++ b/compose.web.yml
@@ -11,6 +11,7 @@
 #
 # Environment variables (see services/web/.env.example):
 #   WEB_DISCORD_WEBHOOK_URL   Discord webhook URL for /api/forms/submit.
+#   WEB_FORMS_REQUIRED        When true, /api/health returns 503 if the webhook is unset.
 #   PORT, HOSTNAME            Server bind config (defaults 3001 / 0.0.0.0).
 #
 # Image:

--- a/packages/ui/src/server/index.ts
+++ b/packages/ui/src/server/index.ts
@@ -110,6 +110,13 @@ export interface ReactServerOptions {
    */
   securityHeaders?: SecurityHeadersConfig;
   /**
+   * Optional override for `/api/health`. Return a `Response` to replace the
+   * default `{ status, version }` payload (e.g. web adds `checks.forms` and
+   * may return 503 when required env is missing). Return `null` to use the
+   * built-in handler (shutting-down probe + `{ status: 'ok', version }`).
+   */
+  buildHealthResponse?: (ctx: { shuttingDown: boolean }) => Response | null;
+  /**
    * Service-specific routes evaluated BEFORE static file serving and locale
    * negotiation. Return `null` (or `undefined`) to fall through to the
    * default pipeline. Use for service-only API endpoints (e.g. web's
@@ -216,6 +223,7 @@ export function startReactServer(opts: ReactServerOptions): void {
     redirectPrefix = '',
     shutdownMarkerPath,
     securityHeaders,
+    buildHealthResponse,
     extraRoutes,
     artifacts,
   } = opts;
@@ -285,11 +293,16 @@ export function startReactServer(opts: ReactServerOptions): void {
           : response;
 
       if (url.pathname === '/api/health') {
-        if (shutdownMarkerPath && existsSync(shutdownMarkerPath)) {
+        const shuttingDown = Boolean(
+          shutdownMarkerPath && existsSync(shutdownMarkerPath),
+        );
+        if (shuttingDown) {
           return finalize(
             Response.json({ status: 'shutting_down' }, { status: 503 }),
           );
         }
+        const customHealth = buildHealthResponse?.({ shuttingDown });
+        if (customHealth) return finalize(customHealth);
         return finalize(
           Response.json({
             status: 'ok',

--- a/services/web/.env.example
+++ b/services/web/.env.example
@@ -1,0 +1,15 @@
+# Tale Web (marketing site) — environment configuration
+# Copy to services/web/.env for local Docker runs, or set at deploy time.
+
+# HTTP listen port (default 3001; the Dockerfile sets this).
+PORT=3001
+
+# Discord webhook for Contact / Request Demo form submissions.
+# Create in Discord: Server Settings → Integrations → Webhooks → New Webhook.
+# Required for production tale.dev — without it, /api/forms/submit returns 503.
+WEB_DISCORD_WEBHOOK_URL=
+
+# When true, /api/health returns 503 if WEB_DISCORD_WEBHOOK_URL is unset so
+# deploy health checks surface the misconfiguration before users hit the form.
+# Recommended for production deployments that expose contact/demo forms.
+WEB_FORMS_REQUIRED=false

--- a/services/web/README.md
+++ b/services/web/README.md
@@ -22,3 +22,6 @@ of the box. Set these at deploy time (compose, systemd, K8s), or via a local
   (`/api/forms/submit` forwards a Discord embed here). If unset, the endpoint
   returns `503` and the forms are disabled. Create one in Discord via Server
   Settings → Integrations → Webhooks → New Webhook.
+- `WEB_FORMS_REQUIRED` — when `true`, `/api/health` returns `503` if
+  `WEB_DISCORD_WEBHOOK_URL` is unset so deploy health checks catch the
+  misconfiguration before users do. Recommended for production tale.dev.

--- a/services/web/app/components/blocks/form-card.tsx
+++ b/services/web/app/components/blocks/form-card.tsx
@@ -15,6 +15,7 @@ import {
 import { SiteContainer } from '@/app/components/layout/site-container';
 import { MIN_SUBMIT_DELAY_MS, type SubmitRequest } from '@/lib/forms/schemas';
 import { submitForm } from '@/lib/forms/submit-client';
+import { formSubmitErrorMessage } from '@/lib/forms/submit-errors';
 import { useT } from '@/lib/i18n/client';
 
 const easeOut = [0.22, 1, 0.36, 1] as const;
@@ -78,9 +79,7 @@ export function FormCard<T extends BasePayload>({
     } as SubmitRequest);
 
     if (!result.ok) {
-      setServerError(
-        result.status === 429 ? t('errors.rateLimited') : t('errors.generic'),
-      );
+      setServerError(formSubmitErrorMessage(result.status, t));
       return;
     }
     setSubmitted(true);

--- a/services/web/lib/forms/health.test.ts
+++ b/services/web/lib/forms/health.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+
+import { formsHealthCheck, webHealthStatus } from './health';
+
+describe('formsHealthCheck', () => {
+  test('ok when webhook is set', () => {
+    expect(formsHealthCheck('https://discord.com/api/webhooks/x/y')).toEqual({
+      ok: true,
+    });
+  });
+
+  test('fails when webhook is empty', () => {
+    expect(formsHealthCheck('')).toEqual({
+      ok: false,
+      error: 'WEB_DISCORD_WEBHOOK_URL unset',
+    });
+  });
+});
+
+describe('webHealthStatus', () => {
+  test('returns 200 with checks when forms are optional', () => {
+    const result = webHealthStatus({
+      webhookUrl: '',
+      formsRequired: false,
+      version: '1.0.0',
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({
+      status: 'ok',
+      version: '1.0.0',
+      checks: { forms: { ok: false, error: 'WEB_DISCORD_WEBHOOK_URL unset' } },
+    });
+  });
+
+  test('returns 503 when forms are required but webhook is unset', () => {
+    const result = webHealthStatus({
+      webhookUrl: '',
+      formsRequired: true,
+      version: '1.0.0',
+    });
+    expect(result.status).toBe(503);
+    expect(result.body.status).toBe('degraded');
+  });
+
+  test('returns 200 when forms are required and webhook is set', () => {
+    const result = webHealthStatus({
+      webhookUrl: 'https://discord.com/api/webhooks/x/y',
+      formsRequired: true,
+      version: '1.0.0',
+    });
+    expect(result.status).toBe(200);
+    expect(result.body.status).toBe('ok');
+    expect(result.body.checks).toEqual({ forms: { ok: true } });
+  });
+});

--- a/services/web/lib/forms/health.ts
+++ b/services/web/lib/forms/health.ts
@@ -1,0 +1,23 @@
+type HealthCheck = { ok: boolean; error?: string };
+
+export function formsHealthCheck(webhookUrl: string): HealthCheck {
+  if (webhookUrl) return { ok: true };
+  return { ok: false, error: 'WEB_DISCORD_WEBHOOK_URL unset' };
+}
+
+export function webHealthStatus(opts: {
+  webhookUrl: string;
+  formsRequired: boolean;
+  version: string;
+}): { status: number; body: Record<string, unknown> } {
+  const checks = { forms: formsHealthCheck(opts.webhookUrl) };
+  const formsBlocking = opts.formsRequired && !checks.forms.ok;
+  return {
+    status: formsBlocking ? 503 : 200,
+    body: {
+      status: formsBlocking ? 'degraded' : 'ok',
+      version: opts.version,
+      checks,
+    },
+  };
+}

--- a/services/web/lib/forms/submit-errors.test.ts
+++ b/services/web/lib/forms/submit-errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+
+import { formSubmitErrorMessage } from './submit-errors';
+
+describe('formSubmitErrorMessage', () => {
+  const t = (key: string) => key;
+
+  test('maps 429 to rateLimited', () => {
+    expect(formSubmitErrorMessage(429, t)).toBe('errors.rateLimited');
+  });
+
+  test('maps 5xx to serverUnavailable', () => {
+    expect(formSubmitErrorMessage(500, t)).toBe('errors.serverUnavailable');
+    expect(formSubmitErrorMessage(503, t)).toBe('errors.serverUnavailable');
+    expect(formSubmitErrorMessage(502, t)).toBe('errors.serverUnavailable');
+  });
+
+  test('maps other errors to generic', () => {
+    expect(formSubmitErrorMessage(400, t)).toBe('errors.generic');
+    expect(formSubmitErrorMessage(0, t)).toBe('errors.generic');
+  });
+});

--- a/services/web/lib/forms/submit-errors.ts
+++ b/services/web/lib/forms/submit-errors.ts
@@ -1,0 +1,11 @@
+/** Maps a form-submit HTTP status to the user-facing i18n key message. */
+export function formSubmitErrorMessage(
+  status: number,
+  t: (
+    key: 'errors.rateLimited' | 'errors.serverUnavailable' | 'errors.generic',
+  ) => string,
+): string {
+  if (status === 429) return t('errors.rateLimited');
+  if (status >= 500) return t('errors.serverUnavailable');
+  return t('errors.generic');
+}

--- a/services/web/messages/de.json
+++ b/services/web/messages/de.json
@@ -476,6 +476,7 @@
     "errors": {
       "generic": "Etwas ist schiefgelaufen. Versuch es erneut.",
       "rateLimited": "Zu viele Anfragen. Warte einen Moment, dann versuch es erneut.",
+      "serverUnavailable": "Deine Nachricht konnte gerade nicht gesendet werden. Versuch es in ein paar Minuten erneut.",
       "tooFast": "Moment — prüf deine Angaben, bevor du absendest."
     },
     "success": {

--- a/services/web/messages/en.json
+++ b/services/web/messages/en.json
@@ -476,6 +476,7 @@
     "errors": {
       "generic": "Something went wrong. Try again.",
       "rateLimited": "Too many submissions. Wait a moment, then try again.",
+      "serverUnavailable": "We couldn't send your message right now. Please try again in a few minutes.",
       "tooFast": "Hold on — review your details before submitting."
     },
     "success": {

--- a/services/web/messages/fr.json
+++ b/services/web/messages/fr.json
@@ -476,6 +476,7 @@
     "errors": {
       "generic": "Quelque chose s'est mal passé. Réessaie.",
       "rateLimited": "Trop d'envois. Patiente un instant et réessaie.",
+      "serverUnavailable": "Nous n'avons pas pu envoyer ton message pour le moment. Réessaie dans quelques minutes.",
       "tooFast": "Un instant — vérifie tes informations avant d'envoyer."
     },
     "success": {

--- a/services/web/server.ts
+++ b/services/web/server.ts
@@ -15,6 +15,7 @@ import {
 } from '@tale/ui/server';
 
 import { buildDiscordPayload } from './lib/forms/discord-embeds';
+import { webHealthStatus } from './lib/forms/health';
 import { checkRateLimit } from './lib/forms/rate-limit';
 import { MIN_SUBMIT_DELAY_MS, submitRequest } from './lib/forms/schemas';
 
@@ -23,8 +24,20 @@ import { MIN_SUBMIT_DELAY_MS, submitRequest } from './lib/forms/schemas';
 // ---------------------------------------------------------------------------
 
 const DISCORD_WEBHOOK_URL = process.env.WEB_DISCORD_WEBHOOK_URL ?? '';
+const FORMS_REQUIRED = process.env.WEB_FORMS_REQUIRED === 'true';
 const MAX_BODY_BYTES = 4 * 1024;
 const DISCORD_WEBHOOK_TIMEOUT_MS = 10_000;
+
+if (!DISCORD_WEBHOOK_URL) {
+  console.error(
+    '[forms] WEB_DISCORD_WEBHOOK_URL is not set — /api/forms/submit returns 503',
+  );
+  if (FORMS_REQUIRED) {
+    console.error(
+      '[forms] WEB_FORMS_REQUIRED=true — /api/health returns 503 until the webhook is configured',
+    );
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Precompiled artifact server
@@ -152,6 +165,14 @@ startReactServer({
   shutdownMarkerPath: process.env.SHUTDOWN_MARKER_PATH,
   securityHeaders: defaultReactServerSecurityHeaders,
   artifacts: artifactsServer,
+  buildHealthResponse: () => {
+    const { status, body } = webHealthStatus({
+      webhookUrl: DISCORD_WEBHOOK_URL,
+      formsRequired: FORMS_REQUIRED,
+      version: process.env.TALE_VERSION ?? 'dev',
+    });
+    return Response.json(body, { status });
+  },
   extraRoutes: (request, url) => {
     if (url.pathname === '/api/forms/submit') {
       return handleFormSubmit(request);

--- a/services/web/tests/manual/forms.md
+++ b/services/web/tests/manual/forms.md
@@ -39,7 +39,7 @@ true }`) but **silently discarded**, so nothing is delivered. A **503**
 | Case(s)          | Status         | e2e spec                                                                |
 | ---------------- | -------------- | ----------------------------------------------------------------------- |
 | F1 (render only) | 🔶 partial     | `smoke.spec.ts` (`/contact` shows a form + the **Get in touch** button) |
-| F2–F6, B1–B9     | ⛔ manual-only | — (no spec drives a submit; the endpoint itself has no test)            |
+| F2–F6, B1–B10    | ⛔ manual-only | — (no spec drives a submit; the endpoint itself has no test)            |
 
 Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
 
@@ -67,6 +67,7 @@ Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no s
 | B7  | Oversize payload    | curl a body > 4 KiB (e.g. a 5000-char `message`)                                                                                       | HTTP **413** `Payload too large`; via the UI the 2000-char Zod cap yields **Too long** first                                                                                                                                                                  |
 | B8  | Malformed JSON      | `curl -X POST {base}/api/forms/submit -d 'not json'`                                                                                   | HTTP **400** `Invalid JSON`; a schema-invalid JSON body returns **400** `Validation failed`; `GET` returns **405**                                                                                                                                            |
 | B9  | Dev server (mode C) | Valid submit against `bun run dev`                                                                                                     | The generic error **Something went wrong. Try again.** (`forms.errors.generic`) — the endpoint only exists in `server.ts`; environment, not a bug                                                                                                             |
+| B10 | Webhook unset (503) | Mode B with `WEB_DISCORD_WEBHOOK_URL` empty: submit a valid contact form after ≥ 3 s                                                   | HTTP **503**; `role="alert"` shows **We couldn't send your message right now. Please try again in a few minutes.** (`forms.errors.serverUnavailable`). With `WEB_FORMS_REQUIRED=true`, `GET /api/health` also returns **503** and `checks.forms.ok: false`    |
 
 ## Accessibility (WCAG 2.1 AA)
 
@@ -85,16 +86,16 @@ Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no s
 
 ## Issues Found
 
-| #   | Test ID | Route / URL                              | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                                                                         | Screenshot |
-| --- | ------- | ---------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| 1   | F6      | `POST https://tale.dev/api/forms/submit` | crit                         | Production returns HTTP **503** `{"ok":false,"error":"Service not configured"}` (2026-07-06 honeypot probe) — `WEB_DISCORD_WEBHOOK_URL` is unset, so **every** contact and demo submission fails with the generic error. This is the original tale.dev contact-form 503, still live | —          |
-| 2   | F5      | `/de/contact`, `/fr/contact`             | low                          | The privacy-policy checkbox link is a hard `<a href="/legal/privacy-policy">` — on localized forms it leaves the locale tree (English legal page) and bypasses the SPA router                                                                                                       | —          |
+| #   | Test ID | Route / URL                              | Severity (crit/high/med/low) | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Screenshot |
+| --- | ------- | ---------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | F6      | `POST https://tale.dev/api/forms/submit` | crit                         | Production returns HTTP **503** `{"ok":false,"error":"Service not configured"}` (2026-07-06 honeypot probe) — `WEB_DISCORD_WEBHOOK_URL` is unset, so **every** contact and demo submission fails. The UI shows **We couldn't send your message right now. Please try again in a few minutes.** (`forms.errors.serverUnavailable`), not the generic error. Set `WEB_DISCORD_WEBHOOK_URL` + `WEB_FORMS_REQUIRED=true` in the deployment; `/api/health` should report `checks.forms.ok: true` after fix | —          |
+| 2   | F5      | `/de/contact`, `/fr/contact`             | low                          | The privacy-policy checkbox link is a hard `<a href="/legal/privacy-policy">` — on localized forms it leaves the locale tree (English legal page) and bypasses the SPA router                                                                                                                                                                                                                                                                                                                        | —          |
 
 ## Test summary
 
 ```
 Area: Forms (web)
-Functional: ___/6   Boundary: ___/9   A11y: ___/4   Perf: ___/1
+Functional: ___/6   Boundary: ___/10   A11y: ___/4   Perf: ___/1
 Issues: ___ (crit __ / high __ / med __ / low __)
 Status: PASS / FAIL
 ```


### PR DESCRIPTION
## Summary

Closes #2389

Production tale.dev contact/demo forms return HTTP 503 because `WEB_DISCORD_WEBHOOK_URL` is unset. This PR closes the deploy guard and UX gaps in code; operators still need to set the webhook secret in production.

- Add `services/web/.env.example` documenting `WEB_DISCORD_WEBHOOK_URL` and `WEB_FORMS_REQUIRED`
- Extend `@tale/ui/server` with `buildHealthResponse` hook; web `/api/health` returns `checks.forms` and HTTP 503 when `WEB_FORMS_REQUIRED=true` and webhook unset
- Map HTTP ≥500 form errors to `forms.errors.serverUnavailable` in `FormCard`
- Unit tests for health checks and submit error mapping; CI placeholder webhook in `.env.test`

## Operator steps (required for production)

1. Create or locate the Discord webhook for tale.dev form notifications
2. Set in production web deployment:
   - `WEB_DISCORD_WEBHOOK_URL=<webhook URL>`
   - `WEB_FORMS_REQUIRED=true`
3. Redeploy; verify `GET /api/health` returns 200 with `checks.forms.ok: true`
4. Submit contact form on https://tale.dev/contact

## Test plan

- [x] `bun run --filter @tale/web test` — 31 tests pass
- [x] `bun run --filter @tale/ui test` — 1071 tests pass
- [x] Typecheck web + ui packages
- [ ] CI green
- [ ] Operator sets env vars and verifies live form submission


Made with [Cursor](https://cursor.com)