### PR TITLE
fix(platform): repair i18n orphan and knip gates on main

### DIFF
--- a/services/platform/lib/i18n/keys-dynamic.txt
+++ b/services/platform/lib/i18n/keys-dynamic.txt
@@ -268,6 +268,7 @@ apps.list.created
 apps.list.start
 apps.list.markDone
 apps.list.merge
+apps.list.review
 
 # Spawned-job card: the status line is `t(statusKey)` in job-card.tsx, where
 # `statusKey` comes from a job.status → key object map — a runtime lookup the

--- a/services/platform/lib/shared/sandbox-workdir.ts
+++ b/services/platform/lib/shared/sandbox-workdir.ts
@@ -13,7 +13,7 @@
 
 export const SANDBOX_WORKSPACE_ABS_ROOT = '/user/workspace';
 
-export const SANDBOX_WORKDIR_MAX_LENGTH = 256;
+const SANDBOX_WORKDIR_MAX_LENGTH = 256;
 
 /** One path segment: no separators, no whitespace, no control chars. */
 const WORKDIR_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;


### PR DESCRIPTION
Main's Lint and Test workflows are red after #2541/#2542:

1. `apps.list.review` (from #2542's issue-desk view) is consumed dynamically via the view config's `labelKey` — added to `keys-dynamic.txt` next to its `apps.list.*` siblings.
2. `SANDBOX_WORKDIR_MAX_LENGTH` (from #2541) is only used inside `sandbox-workdir.ts` — un-exported (knip).

Verified locally: i18n messages suite 23/23, platform typecheck clean, `bunx knip` clean.