### PR TITLE
fix(platform): scope project files to their owning project

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -194,6 +194,7 @@ import type * as agents_provision_defaults_mutations from "../agents/provision_d
 import type * as agents_queries from "../agents/queries.js";
 import type * as agents_recover_stuck_chat_turns from "../agents/recover_stuck_chat_turns.js";
 import type * as agents_resolve_agent_config from "../agents/resolve_agent_config.js";
+import type * as agents_resolve_referenced_files from "../agents/resolve_referenced_files.js";
 import type * as agents_resolve_role_to_agent from "../agents/resolve_role_to_agent.js";
 import type * as agents_rest_api from "../agents/rest_api.js";
 import type * as agents_run_agent_on_discussion from "../agents/run_agent_on_discussion.js";
@@ -1884,6 +1885,7 @@ declare const fullApi: ApiFromModules<{
   "agents/queries": typeof agents_queries;
   "agents/recover_stuck_chat_turns": typeof agents_recover_stuck_chat_turns;
   "agents/resolve_agent_config": typeof agents_resolve_agent_config;
+  "agents/resolve_referenced_files": typeof agents_resolve_referenced_files;
   "agents/resolve_role_to_agent": typeof agents_resolve_role_to_agent;
   "agents/rest_api": typeof agents_rest_api;
   "agents/run_agent_on_discussion": typeof agents_run_agent_on_discussion;

--- a/services/platform/convex/agent_tools/documents/helpers/retrieve_document.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/retrieve_document.ts
@@ -6,6 +6,7 @@ import { createDebugLog } from '../../../lib/debug_log';
 import { orgSlugFromId } from '../../../lib/helpers/org_slug';
 import { toId } from '../../../lib/type_cast_helpers';
 import { wrapUntrusted } from '../../../lib/untrusted_content';
+import type { AgentKnowledgeCtx } from '../../rag/rag_search_tool';
 import type { documentRetrieveArgs } from '../document_retrieve_tool';
 import {
   fetchDocumentContent,
@@ -46,16 +47,27 @@ export async function retrieveDocument(
   );
 
   if (document) {
-    const accessibleIds: string[] = await ctx.runQuery(
-      internal.documents.internal_queries.getAccessibleDocumentIds,
-      { organizationId, userId },
-    );
+    // Project files pass when this chat's verified project scope covers the
+    // owning project (parity with rag_search); Knowledge Hub docs follow the
+    // caller's accessible-id set (team rules, project docs excluded).
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolCtx from @convex-dev/agent lacks our agent knowledge properties injected at runtime
+    const extended = ctx as AgentKnowledgeCtx;
+    const inProjectScope =
+      document.projectId != null &&
+      (extended.agentProjectIds ?? []).includes(String(document.projectId));
 
-    if (!accessibleIds.includes(document._id)) {
-      throw new Error(
-        `Access denied for document "${args.fileId}". ` +
-          "You may not have access to this document's team.",
+    if (!inProjectScope) {
+      const accessibleIds: string[] = await ctx.runQuery(
+        internal.documents.internal_queries.getAccessibleDocumentIds,
+        { organizationId, userId },
       );
+
+      if (!accessibleIds.includes(document._id)) {
+        throw new Error(
+          `Access denied for document "${args.fileId}". ` +
+            "You may not have access to this document's team or project.",
+        );
+      }
     }
   } else {
     // No hub document — fall back to chat-attachment path via fileMetadata.

--- a/services/platform/convex/agent_tools/rag/helpers/list_indexed_documents.ts
+++ b/services/platform/convex/agent_tools/rag/helpers/list_indexed_documents.ts
@@ -29,6 +29,7 @@ export async function listIndexedDocuments(
         includeTeamKnowledge: extended.includeTeamKnowledge,
         includeOrgKnowledge: extended.includeOrgKnowledge,
         knowledgeFileIds: extended.knowledgeFileIds,
+        agentProjectIds: extended.agentProjectIds,
         limit: args.limit,
         cursor: args.cursor,
       },

--- a/services/platform/convex/agent_tools/rag/helpers/verify_thread_scoped_access.ts
+++ b/services/platform/convex/agent_tools/rag/helpers/verify_thread_scoped_access.ts
@@ -3,8 +3,11 @@
  *
  * Three access classes — see `fileMetadata.threadId` JSDoc:
  *   - Document Hub: `documentId` set, `threadId` unset → org-wide knowledge.
- *     Authorized when same-org. (Agent's pre-configured allow-list, computed
- *     by `getAgentScopedFileIds`, is a stricter sub-policy applied
+ *     Authorized when same-org, UNLESS the backing document is
+ *     project-scoped (`projectId` set) — then the caller's project scope
+ *     (`allowedProjectIds`, the thread's verified project) must cover it.
+ *     (Agent's pre-configured allow-list, computed by
+ *     `getAgentScopedFileIds`, is a stricter sub-policy applied
  *     separately for default search; explicit fileIds skip that.)
  *   - Chat upload (post thread-binding): `threadId` set →
  *     authorized only when the bound `threadId` is in the caller's
@@ -35,11 +38,18 @@ export const verifyStorageIdsInThreadScope = internalQuery({
      * only Document Hub / legacy files via the same-org grandfather.
      */
     accessibleThreadIds: v.array(v.string()),
+    /**
+     * Project IDs whose project-scoped documents the caller may read
+     * (the chat thread's own project). Empty for non-project callers —
+     * project files are then refused outright.
+     */
+    allowedProjectIds: v.optional(v.array(v.string())),
     storageIds: v.array(v.string()),
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
     const allowedThreadIds = new Set(args.accessibleThreadIds);
+    const allowedProjectIds = new Set(args.allowedProjectIds ?? []);
 
     for (const storageId of args.storageIds) {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- storage id is a wire string; the by_storageId index lookup expects the branded Id<'_storage'>
@@ -54,9 +64,21 @@ export const verifyStorageIdsInThreadScope = internalQuery({
       if (meta.threadId !== undefined) {
         // Chat upload bound to a thread — must be in caller's chain.
         if (!allowedThreadIds.has(meta.threadId)) return false;
+      } else if (meta.documentId !== undefined) {
+        // Document Hub row: a project-scoped document is NOT org-wide
+        // knowledge — it passes only when the caller's project scope
+        // covers its owning project.
+        const doc = await ctx.db.get(meta.documentId);
+        if (!doc) return false;
+        if (
+          doc.projectId != null &&
+          !allowedProjectIds.has(String(doc.projectId))
+        ) {
+          return false;
+        }
       }
-      // Else: documentId set (Document Hub) or both unset (legacy /
-      // integration) → same-org grandfather, already passed.
+      // Else: both unset (legacy / integration) → same-org grandfather,
+      // already passed.
     }
     return true;
   },

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -269,12 +269,15 @@ RESPONSE (list_indexed):
         const accessibleThreadsRetrieve = ctx.threadId
           ? await getThreadAncestorChain(ctx, ctx.threadId, orgIdRetrieve)
           : [];
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolCtx from @convex-dev/agent lacks our agent knowledge properties injected at runtime
+        const extendedRetrieve = ctx as AgentKnowledgeCtx;
         const retrieveAuthorized = await ctx.runQuery(
           internal.agent_tools.rag.helpers.verify_thread_scoped_access
             .verifyStorageIdsInThreadScope,
           {
             organizationId: orgIdRetrieve,
             accessibleThreadIds: accessibleThreadsRetrieve,
+            allowedProjectIds: extendedRetrieve.agentProjectIds,
             storageIds: [args.fileId],
           },
         );
@@ -451,12 +454,15 @@ RESPONSE (list_indexed):
         const accessibleThreadsSearch = ctx.threadId
           ? await getThreadAncestorChain(ctx, ctx.threadId, orgIdSearch)
           : [];
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolCtx from @convex-dev/agent lacks our agent knowledge properties injected at runtime
+        const extendedSearch = ctx as AgentKnowledgeCtx;
         const searchAuthorized = await ctx.runQuery(
           internal.agent_tools.rag.helpers.verify_thread_scoped_access
             .verifyStorageIdsInThreadScope,
           {
             organizationId: orgIdSearch,
             accessibleThreadIds: accessibleThreadsSearch,
+            allowedProjectIds: extendedSearch.agentProjectIds,
             storageIds: args.fileIds,
           },
         );

--- a/services/platform/convex/agents/chat_turn.ts
+++ b/services/platform/convex/agents/chat_turn.ts
@@ -26,97 +26,16 @@ import {
   DEFAULT_CHAT_AGENT_SLUG,
 } from '../../lib/shared/constants/agents';
 import { internal } from '../_generated/api';
-import type { Id } from '../_generated/dataModel';
-import { mutation, type MutationCtx } from '../_generated/server';
+import { mutation } from '../_generated/server';
 import { notifyChatMentions } from '../collab/notify';
 import { resolveSurfaceMentions } from '../collab/resolve_surface_mentions';
 import { isDrainingNow } from '../control/drain';
-import { isActiveDocument } from '../documents/_helpers';
 import { userContextValidator } from '../lib/agent_response/validators';
-import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
-import { hasTeamAccess } from '../lib/team_access';
 import { persistentStreaming } from '../streaming/helpers';
 import { cancelGeneration } from '../threads/cancel_generation';
 import { normalizeMessageKey } from './auto_route_helpers';
-
-/** Hard cap on `@`-mentioned knowledge-base documents per turn. Mirrored by
- *  the composer (`MAX_KB_MENTIONS` in use-kb-mentions.ts). */
-const MAX_KB_REFERENCES = 5;
-
-/** Branded-Id variant of `KbReferencedFile` (kb_reference_block.ts) for the
- *  scheduled-action payload. */
-interface ResolvedKbReference {
-  documentId: Id<'documents'>;
-  fileId: Id<'_storage'>;
-  fileName: string;
-  fileType: string;
-  fileSize: number;
-}
-
-/**
- * Resolve + authorize the composer's `@`-mentioned documents synchronously so
- * an invalid reference fails the send with a client-visible ConvexError
- * instead of a mid-generation surprise. Each reference must be: same org,
- * active, team-accessible to the sender, blob-backed, and RAG-indexed —
- * the same gate the picker query applies, re-checked server-side.
- *
- * Bounded work on the Track-B fast path: ≤ MAX_KB_REFERENCES point reads plus
- * one team lookup.
- */
-async function resolveReferencedFiles(
-  ctx: MutationCtx,
-  args: {
-    organizationId: string;
-    userId: string;
-    referencedDocumentIds: Id<'documents'>[];
-  },
-): Promise<ResolvedKbReference[]> {
-  if (args.referencedDocumentIds.length > MAX_KB_REFERENCES) {
-    throw new ConvexError({ code: 'KB_REF_INVALID' });
-  }
-  const userTeamIds = await getUserTeamIds(ctx, args.userId);
-  // Org-wide sentinel mirrors get_accessible_document_ids.ts.
-  const teamSet = new Set([`org_${args.organizationId}`, ...userTeamIds]);
-
-  const resolved: ResolvedKbReference[] = [];
-  const seen = new Set<string>();
-  for (const documentId of args.referencedDocumentIds) {
-    if (seen.has(documentId)) continue;
-    seen.add(documentId);
-
-    const doc = await ctx.db.get(documentId);
-    // One opaque code for every failure mode so the error doesn't reveal
-    // whether an inaccessible document exists.
-    if (
-      !doc ||
-      doc.organizationId !== args.organizationId ||
-      !isActiveDocument(doc) ||
-      !hasTeamAccess(doc, teamSet)
-    ) {
-      throw new ConvexError({ code: 'KB_REF_INVALID' });
-    }
-    const fileId = doc.fileId;
-    if (!fileId) {
-      throw new ConvexError({ code: 'KB_REF_INVALID' });
-    }
-    const fm = await ctx.db
-      .query('fileMetadata')
-      .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
-      .first();
-    if (!fm || fm.ragStatus !== 'completed') {
-      throw new ConvexError({ code: 'KB_REF_INVALID' });
-    }
-    resolved.push({
-      documentId,
-      fileId,
-      fileName: doc.title?.trim() || fm.fileName,
-      fileType: doc.mimeType ?? fm.contentType,
-      fileSize: fm.size,
-    });
-  }
-  return resolved;
-}
+import { resolveReferencedFiles } from './resolve_referenced_files';
 
 export const chatWithAgentTurn = mutation({
   args: {
@@ -174,6 +93,33 @@ export const chatWithAgentTurn = mutation({
       throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
+    // Projects: validate access BEFORE the prewarm branch (a denial throws
+    // synchronously and the client shows a PROJECT_* toast — same UX as
+    // before Track B). Prewarm forwards projectId to the generation action,
+    // whose startChat persists the thread↔project binding — an unvalidated
+    // prewarm must never bind a caller's thread to a project they can't
+    // access. The PROJECT_MISMATCH check stays below (needs thread meta).
+    if (args.projectId) {
+      const projectAccess = await ctx.runQuery(
+        internal.projects.internal_queries.assertProjectAccessForChat,
+        {
+          projectId: args.projectId,
+          organizationId: args.organizationId,
+          userId: authUser.userId,
+        },
+      );
+      if (!projectAccess.allowed) {
+        throw new ConvexError({
+          code:
+            projectAccess.reason === 'not_found'
+              ? 'PROJECT_NOT_FOUND'
+              : projectAccess.reason === 'org_mismatch'
+                ? 'PROJECT_ORG_MISMATCH'
+                : 'PROJECT_FORBIDDEN',
+        });
+      }
+    }
+
     // Cache pre-warm: invisible. Skip markGenerating / stream / supersede /
     // project persist entirely — just schedule the throwaway priming
     // generation. Don't spend a routing classifier on a prewarm (the real turn
@@ -224,48 +170,10 @@ export const chatWithAgentTurn = mutation({
       throw new ConvexError({ code: 'BACKEND_DRAINING' });
     }
 
-    // Projects: validate access here (DB query) so a denial throws
-    // synchronously and the client shows a PROJECT_* toast (same UX as before
-    // Track B). The thread↔project persist + PROJECT_MISMATCH check stay in
-    // startChat (reached via the node action).
-    if (args.projectId) {
-      const projectAccess = await ctx.runQuery(
-        internal.projects.internal_queries.assertProjectAccessForChat,
-        {
-          projectId: args.projectId,
-          organizationId: args.organizationId,
-          userId: authUser.userId,
-        },
-      );
-      if (!projectAccess.allowed) {
-        throw new ConvexError({
-          code:
-            projectAccess.reason === 'not_found'
-              ? 'PROJECT_NOT_FOUND'
-              : projectAccess.reason === 'org_mismatch'
-                ? 'PROJECT_ORG_MISMATCH'
-                : 'PROJECT_FORBIDDEN',
-        });
-      }
-    }
-
-    // Resolve + authorize `@`-mentioned knowledge-base documents BEFORE any
-    // state is committed, so a stale/inaccessible reference throws
-    // synchronously (client toast) and never leaves the thread generating.
-    const referencedFiles =
-      args.referencedDocumentIds && args.referencedDocumentIds.length > 0
-        ? await resolveReferencedFiles(ctx, {
-            organizationId: args.organizationId,
-            userId: authUser.userId,
-            referencedDocumentIds: args.referencedDocumentIds,
-          })
-        : undefined;
-
-    // markGenerating inline (mirrors threads/internal_mutations:markGenerating)
-    // — commit the spinner state + allocate the stream synchronously so the
-    // subscription lights up with minimal delay. For Auto mode the resolved
-    // agent isn't known yet (routing happens in the node action), so the slug
-    // is patched there.
+    // Thread metadata is read BEFORE resolving `@`-references: the reference
+    // gate needs the thread's project scope (a project file is pinable only
+    // inside its own project's chat). Also used further down for
+    // markGenerating (mirrors threads/internal_mutations:markGenerating).
     const meta = await ctx.db
       .query('threadMetadata')
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
@@ -285,6 +193,21 @@ export const chatWithAgentTurn = mutation({
     if (args.projectId && meta.projectId && meta.projectId !== args.projectId) {
       throw new ConvexError({ code: 'PROJECT_MISMATCH' });
     }
+
+    // Resolve + authorize `@`-mentioned knowledge-base documents BEFORE any
+    // state is committed, so a stale/inaccessible reference throws
+    // synchronously (client toast) and never leaves the thread generating.
+    // The thread's persisted project wins; args.projectId covers the first
+    // send into a not-yet-persisted project thread (access-validated above).
+    const referencedFiles =
+      args.referencedDocumentIds && args.referencedDocumentIds.length > 0
+        ? await resolveReferencedFiles(ctx, {
+            organizationId: args.organizationId,
+            userId: authUser.userId,
+            referencedDocumentIds: args.referencedDocumentIds,
+            threadProjectId: meta.projectId ?? args.projectId,
+          })
+        : undefined;
 
     // Supersede an in-flight generation: if this thread is already generating,
     // cancel the running turn (aborts its SDK stream → the running action's

--- a/services/platform/convex/agents/resolve_referenced_files.test.ts
+++ b/services/platform/convex/agents/resolve_referenced_files.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { resolveReferencedFiles } from './resolve_referenced_files';
+
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: vi.fn(),
+}));
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: vi.fn(),
+}));
+
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+
+const mockGetUserTeamIds = vi.mocked(getUserTeamIds);
+const mockGetOrganizationMember = vi.mocked(getOrganizationMember);
+
+interface FakeFileMeta {
+  fileName: string;
+  contentType: string;
+  size: number;
+  ragStatus?: 'queued' | 'running' | 'completed' | 'failed';
+}
+
+/** `db.get` serves documents AND projects from one map (both are point reads
+ *  by id); `db.query('fileMetadata')` mirrors the by_storageId point lookup. */
+function createCtx(
+  rowsById: Record<string, Record<string, unknown>>,
+  fileMetaByStorageId: Record<string, FakeFileMeta>,
+) {
+  return {
+    db: {
+      get: vi.fn(async (id: string) => rowsById[id] ?? null),
+      query: vi.fn(() => ({
+        withIndex: (
+          _name: string,
+          cb: (q: { eq: (field: string, value: unknown) => object }) => unknown,
+        ) => {
+          let storageId: unknown;
+          cb({
+            eq: (_field, value) => {
+              storageId = value;
+              return {};
+            },
+          });
+          return {
+            first: () =>
+              Promise.resolve(fileMetaByStorageId[String(storageId)] ?? null),
+          };
+        },
+      })),
+    },
+  } as unknown as MutationCtx;
+}
+
+const COMPLETED_META: FakeFileMeta = {
+  fileName: 'file.pdf',
+  contentType: 'application/pdf',
+  size: 10,
+  ragStatus: 'completed',
+};
+
+const ROWS: Record<string, Record<string, unknown>> = {
+  d_hub: { organizationId: 'org1', title: 'Hub doc', fileId: 'f_hub' },
+  d_team_b: {
+    organizationId: 'org1',
+    title: 'Team B doc',
+    teamId: 'team_b',
+    fileId: 'f_team_b',
+  },
+  d_proj: {
+    organizationId: 'org1',
+    title: 'Project doc',
+    projectId: 'p1',
+    fileId: 'f_proj',
+  },
+  p1: { _id: 'p1', organizationId: 'org1', teamId: 'team_a' },
+};
+
+const FILE_META: Record<string, FakeFileMeta> = {
+  f_hub: COMPLETED_META,
+  f_team_b: COMPLETED_META,
+  f_proj: COMPLETED_META,
+};
+
+const BASE_ARGS = {
+  organizationId: 'org1',
+  userId: 'user1',
+};
+
+function refs(...ids: string[]) {
+  return ids as Id<'documents'>[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserTeamIds.mockResolvedValue(['team_a']);
+  mockGetOrganizationMember.mockResolvedValue({
+    userId: 'user1',
+    role: 'member',
+  } as Awaited<ReturnType<typeof getOrganizationMember>>);
+});
+
+describe('resolveReferencedFiles', () => {
+  it('resolves an org-wide hub document', async () => {
+    const ctx = createCtx(ROWS, FILE_META);
+    const resolved = await resolveReferencedFiles(ctx, {
+      ...BASE_ARGS,
+      referencedDocumentIds: refs('d_hub'),
+    });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({
+      documentId: 'd_hub',
+      fileId: 'f_hub',
+      fileName: 'Hub doc',
+    });
+  });
+
+  it('rejects a hub document from a team the sender is not in', async () => {
+    const ctx = createCtx(ROWS, FILE_META);
+    await expect(
+      resolveReferencedFiles(ctx, {
+        ...BASE_ARGS,
+        referencedDocumentIds: refs('d_team_b'),
+      }),
+    ).rejects.toMatchObject({ data: { code: 'KB_REF_INVALID' } });
+  });
+
+  it('resolves a project document inside its own project thread', async () => {
+    const ctx = createCtx(ROWS, FILE_META);
+    const resolved = await resolveReferencedFiles(ctx, {
+      ...BASE_ARGS,
+      referencedDocumentIds: refs('d_proj'),
+      threadProjectId: 'p1' as Id<'projects'>,
+    });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({
+      documentId: 'd_proj',
+      fileId: 'f_proj',
+    });
+  });
+
+  it('rejects a project document in a global (no-project) chat, even for a project member', async () => {
+    const ctx = createCtx(ROWS, FILE_META);
+    await expect(
+      resolveReferencedFiles(ctx, {
+        ...BASE_ARGS,
+        referencedDocumentIds: refs('d_proj'),
+      }),
+    ).rejects.toMatchObject({ data: { code: 'KB_REF_INVALID' } });
+  });
+
+  it("rejects a project document pinned from a different project's thread", async () => {
+    const ctx = createCtx(ROWS, FILE_META);
+    await expect(
+      resolveReferencedFiles(ctx, {
+        ...BASE_ARGS,
+        referencedDocumentIds: refs('d_proj'),
+        threadProjectId: 'p2' as Id<'projects'>,
+      }),
+    ).rejects.toMatchObject({ data: { code: 'KB_REF_INVALID' } });
+  });
+
+  it('rejects a project document when the sender has no access to the project', async () => {
+    mockGetUserTeamIds.mockResolvedValue(['team_z']);
+    const ctx = createCtx(ROWS, FILE_META);
+    await expect(
+      resolveReferencedFiles(ctx, {
+        ...BASE_ARGS,
+        referencedDocumentIds: refs('d_proj'),
+        threadProjectId: 'p1' as Id<'projects'>,
+      }),
+    ).rejects.toMatchObject({ data: { code: 'KB_REF_INVALID' } });
+  });
+
+  it('rejects when more than MAX_KB_REFERENCES documents are pinned', async () => {
+    const ctx = createCtx(ROWS, FILE_META);
+    await expect(
+      resolveReferencedFiles(ctx, {
+        ...BASE_ARGS,
+        referencedDocumentIds: refs('a', 'b', 'c', 'd', 'e', 'f'),
+      }),
+    ).rejects.toMatchObject({ data: { code: 'KB_REF_INVALID' } });
+  });
+
+  it('rejects a document whose blob is not RAG-indexed', async () => {
+    const ctx = createCtx(ROWS, {
+      ...FILE_META,
+      f_hub: { ...COMPLETED_META, ragStatus: 'queued' },
+    });
+    await expect(
+      resolveReferencedFiles(ctx, {
+        ...BASE_ARGS,
+        referencedDocumentIds: refs('d_hub'),
+      }),
+    ).rejects.toMatchObject({ data: { code: 'KB_REF_INVALID' } });
+  });
+});

--- a/services/platform/convex/agents/resolve_referenced_files.ts
+++ b/services/platform/convex/agents/resolve_referenced_files.ts
@@ -1,0 +1,108 @@
+/**
+ * Resolve + authorize the composer's `@`-mentioned documents synchronously so
+ * an invalid reference fails the send with a client-visible ConvexError
+ * instead of a mid-generation surprise. Each reference must be: same org,
+ * active, scope-accessible to the sender, blob-backed, and RAG-indexed —
+ * the same gate the picker query applies, re-checked server-side. Knowledge
+ * Hub docs follow team access; a project-scoped doc is pinable only when the
+ * chat thread belongs to that same project AND the sender can read the
+ * project (a global chat cannot pin it even for a project member).
+ *
+ * Bounded work on the Track-B fast path: ≤ MAX_KB_REFERENCES point reads plus
+ * one team lookup (and a member + project read per project-doc reference).
+ */
+
+import { ConvexError } from 'convex/values';
+
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { isActiveDocument } from '../documents/_helpers';
+import {
+  canReadDocument,
+  hasKnowledgeHubDocumentAccess,
+  isProjectScopedDocument,
+} from '../documents/access';
+import { getUserTeamIds } from '../lib/get_user_teams';
+
+/** Hard cap on `@`-mentioned knowledge-base documents per turn. Mirrored by
+ *  the composer (`MAX_KB_MENTIONS` in use-kb-mentions.ts). */
+export const MAX_KB_REFERENCES = 5;
+
+/** Branded-Id variant of `KbReferencedFile` (kb_reference_block.ts) for the
+ *  scheduled-action payload. */
+export interface ResolvedKbReference {
+  documentId: Id<'documents'>;
+  fileId: Id<'_storage'>;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+}
+
+export async function resolveReferencedFiles(
+  ctx: MutationCtx,
+  args: {
+    organizationId: string;
+    userId: string;
+    referencedDocumentIds: Id<'documents'>[];
+    threadProjectId?: Id<'projects'>;
+  },
+): Promise<ResolvedKbReference[]> {
+  if (args.referencedDocumentIds.length > MAX_KB_REFERENCES) {
+    throw new ConvexError({ code: 'KB_REF_INVALID' });
+  }
+  const userTeamIds = await getUserTeamIds(ctx, args.userId);
+  // Org-wide sentinel mirrors get_accessible_document_ids.ts.
+  const teamSet = new Set([`org_${args.organizationId}`, ...userTeamIds]);
+
+  const resolved: ResolvedKbReference[] = [];
+  const seen = new Set<string>();
+  for (const documentId of args.referencedDocumentIds) {
+    if (seen.has(documentId)) continue;
+    seen.add(documentId);
+
+    const doc = await ctx.db.get(documentId);
+    // One opaque code for every failure mode so the error doesn't reveal
+    // whether an inaccessible document exists.
+    if (
+      !doc ||
+      doc.organizationId !== args.organizationId ||
+      !isActiveDocument(doc)
+    ) {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    if (isProjectScopedDocument(doc)) {
+      const inSameProjectThread =
+        args.threadProjectId != null && doc.projectId === args.threadProjectId;
+      if (
+        !inSameProjectThread ||
+        !(await canReadDocument(ctx, doc, {
+          userId: args.userId,
+          organizationId: args.organizationId,
+        }))
+      ) {
+        throw new ConvexError({ code: 'KB_REF_INVALID' });
+      }
+    } else if (!hasKnowledgeHubDocumentAccess(doc, teamSet)) {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    const fileId = doc.fileId;
+    if (!fileId) {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    const fm = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+      .first();
+    if (!fm || fm.ragStatus !== 'completed') {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    resolved.push({
+      documentId,
+      fileId,
+      fileName: doc.title?.trim() || fm.fileName,
+      fileType: doc.mimeType ?? fm.contentType,
+      fileSize: fm.size,
+    });
+  }
+  return resolved;
+}

--- a/services/platform/convex/documents/access.test.ts
+++ b/services/platform/convex/documents/access.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  canReadDocument,
+  checkProjectDocumentAccess,
+  hasKnowledgeHubDocumentAccess,
+  isProjectScopedDocument,
+} from './access';
+
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: vi.fn(),
+}));
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: vi.fn(),
+}));
+
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+
+const mockGetUserTeamIds = vi.mocked(getUserTeamIds);
+const mockGetOrganizationMember = vi.mocked(getOrganizationMember);
+
+function createMockCtx(projects: Record<string, Record<string, unknown>>) {
+  return {
+    db: {
+      get: vi.fn(async (id: string) => projects[id] ?? null),
+    },
+  } as unknown as Parameters<typeof canReadDocument>[0];
+}
+
+type AnyDoc = Parameters<typeof canReadDocument>[1];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isProjectScopedDocument', () => {
+  it('is true only when projectId is set', () => {
+    expect(isProjectScopedDocument({ projectId: 'p1' } as AnyDoc)).toBe(true);
+    expect(isProjectScopedDocument({} as AnyDoc)).toBe(false);
+    expect(isProjectScopedDocument({ teamId: 't1' } as AnyDoc)).toBe(false);
+  });
+});
+
+describe('hasKnowledgeHubDocumentAccess', () => {
+  it('excludes project docs even when the user is in every team', () => {
+    const doc = { projectId: 'p1' } as AnyDoc;
+    expect(hasKnowledgeHubDocumentAccess(doc, ['team-a', 'team-b'])).toBe(
+      false,
+    );
+  });
+
+  it('treats team-less hub docs as org-wide', () => {
+    expect(hasKnowledgeHubDocumentAccess({} as AnyDoc, [])).toBe(true);
+  });
+
+  it('applies team rules to team-scoped hub docs', () => {
+    const doc = { teamId: 'team-a' } as AnyDoc;
+    expect(hasKnowledgeHubDocumentAccess(doc, ['team-a'])).toBe(true);
+    expect(hasKnowledgeHubDocumentAccess(doc, ['team-b'])).toBe(false);
+  });
+});
+
+describe('canReadDocument', () => {
+  const orgArgs = { userId: 'user1', organizationId: 'org1' };
+
+  it('denies a document from another organization', async () => {
+    const ctx = createMockCtx({});
+    const doc = { organizationId: 'org2' } as AnyDoc;
+    expect(await canReadDocument(ctx, doc, orgArgs)).toBe(false);
+  });
+
+  it('delegates hub docs to team access', async () => {
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const ctx = createMockCtx({});
+    const orgWide = { organizationId: 'org1' } as AnyDoc;
+    const otherTeam = { organizationId: 'org1', teamId: 'team-b' } as AnyDoc;
+    expect(await canReadDocument(ctx, orgWide, orgArgs)).toBe(true);
+    expect(await canReadDocument(ctx, otherTeam, orgArgs)).toBe(false);
+  });
+
+  it('allows a project doc when the user is in an owning team', async () => {
+    mockGetOrganizationMember.mockResolvedValue({
+      userId: 'user1',
+      role: 'member',
+    } as Awaited<ReturnType<typeof getOrganizationMember>>);
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const ctx = createMockCtx({
+      p1: { _id: 'p1', organizationId: 'org1', teamId: 'team-a' },
+    });
+    const doc = { organizationId: 'org1', projectId: 'p1' } as AnyDoc;
+    expect(await canReadDocument(ctx, doc, orgArgs)).toBe(true);
+  });
+
+  it('denies a project doc when the user is outside the project teams', async () => {
+    mockGetOrganizationMember.mockResolvedValue({
+      userId: 'user1',
+      role: 'member',
+    } as Awaited<ReturnType<typeof getOrganizationMember>>);
+    mockGetUserTeamIds.mockResolvedValue(['team-b']);
+    const ctx = createMockCtx({
+      p1: { _id: 'p1', organizationId: 'org1', teamId: 'team-a' },
+    });
+    const doc = { organizationId: 'org1', projectId: 'p1' } as AnyDoc;
+    expect(await canReadDocument(ctx, doc, orgArgs)).toBe(false);
+  });
+
+  it('allows org admins into any project doc', async () => {
+    mockGetOrganizationMember.mockResolvedValue({
+      userId: 'user1',
+      role: 'admin',
+    } as Awaited<ReturnType<typeof getOrganizationMember>>);
+    mockGetUserTeamIds.mockResolvedValue([]);
+    const ctx = createMockCtx({
+      p1: { _id: 'p1', organizationId: 'org1', teamId: 'team-a' },
+    });
+    const doc = { organizationId: 'org1', projectId: 'p1' } as AnyDoc;
+    expect(await canReadDocument(ctx, doc, orgArgs)).toBe(true);
+  });
+
+  it('denies when the owning project is gone or in another org', async () => {
+    mockGetOrganizationMember.mockResolvedValue({
+      userId: 'user1',
+      role: 'admin',
+    } as Awaited<ReturnType<typeof getOrganizationMember>>);
+    mockGetUserTeamIds.mockResolvedValue([]);
+    const ctx = createMockCtx({
+      foreign: { _id: 'foreign', organizationId: 'org2' },
+    });
+    const dangling = { organizationId: 'org1', projectId: 'gone' } as AnyDoc;
+    const crossOrg = {
+      organizationId: 'org1',
+      projectId: 'foreign',
+    } as AnyDoc;
+    expect(await canReadDocument(ctx, dangling, orgArgs)).toBe(false);
+    expect(await canReadDocument(ctx, crossOrg, orgArgs)).toBe(false);
+  });
+
+  it('denies when membership resolution fails', async () => {
+    mockGetOrganizationMember.mockRejectedValue(new Error('no member'));
+    const ctx = createMockCtx({
+      p1: { _id: 'p1', organizationId: 'org1' },
+    });
+    const doc = { organizationId: 'org1', projectId: 'p1' } as AnyDoc;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await canReadDocument(ctx, doc, orgArgs)).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('checkProjectDocumentAccess', () => {
+  const orgArgs = { userId: 'user1', organizationId: 'org1' };
+  const projectDoc = { organizationId: 'org1', projectId: 'p1' } as AnyDoc;
+  const projects = {
+    p1: { _id: 'p1', organizationId: 'org1', teamId: 'team_a' },
+  };
+
+  function memberWithRole(role: string) {
+    mockGetOrganizationMember.mockResolvedValue({
+      userId: 'user1',
+      role,
+    } as Awaited<ReturnType<typeof getOrganizationMember>>);
+  }
+
+  it('returns null for a non-project document', async () => {
+    const ctx = createMockCtx(projects);
+    const hubDoc = { organizationId: 'org1' } as AnyDoc;
+    expect(await checkProjectDocumentAccess(ctx, hubDoc, orgArgs)).toBeNull();
+  });
+
+  it('grants read but not edit to a plain member of the owning team', async () => {
+    memberWithRole('member');
+    mockGetUserTeamIds.mockResolvedValue(['team_a']);
+    const ctx = createMockCtx(projects);
+    const access = await checkProjectDocumentAccess(ctx, projectDoc, orgArgs);
+    expect(access).toMatchObject({ canRead: true, canEdit: false });
+  });
+
+  it('grants edit to editor-tier roles in the owning team', async () => {
+    memberWithRole('editor');
+    mockGetUserTeamIds.mockResolvedValue(['team_a']);
+    const ctx = createMockCtx(projects);
+    const access = await checkProjectDocumentAccess(ctx, projectDoc, orgArgs);
+    expect(access).toMatchObject({ canRead: true, canEdit: true });
+  });
+
+  it('denies everything outside the project teams', async () => {
+    memberWithRole('editor');
+    mockGetUserTeamIds.mockResolvedValue(['team_z']);
+    const ctx = createMockCtx(projects);
+    const access = await checkProjectDocumentAccess(ctx, projectDoc, orgArgs);
+    expect(access).toMatchObject({ canRead: false, canEdit: false });
+  });
+});

--- a/services/platform/convex/documents/access.ts
+++ b/services/platform/convex/documents/access.ts
@@ -2,17 +2,29 @@
  * Shared document access layer.
  *
  * Documents live in exactly one of two scopes (`projectId` and `teamId` are
- * mutually exclusive):
+ * mutually exclusive — enforced in `attachDocumentToProject`):
  *
- * - Knowledge Hub (org/team library): `projectId` unset.
+ * - Knowledge Hub (org/team library): `projectId` unset. Team rules apply —
+ *   no teams means org-wide (`hasTeamAccess`).
  * - Project files: `projectId` set. Never part of the Knowledge Hub; readable
- *   only through the owning project's own surfaces.
+ *   only by users with access to the owning project (`checkProjectAccess`).
  *
- * The scope decision has one owner — this module — so every hub read path
- * (lists, pickers, agent scopes, REST, WebDAV) applies the same predicate.
+ * `hasTeamAccess` alone cannot tell the scopes apart — a project doc has no
+ * team fields and would read as org-wide. The scope decision has one owner —
+ * this module — so every hub read path (lists, pickers, agent scopes, REST,
+ * WebDAV) filters through `hasKnowledgeHubDocumentAccess` (sync, list-safe)
+ * or `canReadDocument` (async, resolves project access for single-doc reads).
  */
 
 import type { Doc } from '../_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { hasTeamAccess } from '../lib/team_access';
+import {
+  checkProjectAccess,
+  type ProjectAccessResult,
+} from '../projects/access';
 
 type DocumentScopeFields = Pick<
   Doc<'documents'>,
@@ -26,4 +38,91 @@ type DocumentScopeFields = Pick<
  */
 export function isProjectScopedDocument(doc: DocumentScopeFields): boolean {
   return doc.projectId != null;
+}
+
+/**
+ * Whether a user can see a document in Knowledge Hub surfaces (library
+ * lists, `@` mention picker, agent document tools, workflow ACLs).
+ *
+ * Project-scoped documents are never hub-visible, regardless of the user's
+ * project access — project files surface through the project's own queries
+ * (`listProjectDocuments`) instead.
+ */
+export function hasKnowledgeHubDocumentAccess(
+  doc: DocumentScopeFields,
+  userTeamIds: string[] | Set<string>,
+): boolean {
+  if (isProjectScopedDocument(doc)) return false;
+  return hasTeamAccess(doc, userTeamIds);
+}
+
+const NO_PROJECT_ACCESS: ProjectAccessResult = {
+  canRead: false,
+  canEdit: false,
+  canAdminister: false,
+};
+
+/**
+ * Resolve the caller's access matrix on a project-scoped document's owning
+ * project (read for viewing, edit for update/delete — the same standard as
+ * `attachDocumentToProject`/`detachDocumentFromProject`). Returns null when
+ * the document is not project-scoped; callers fall back to team rules then.
+ * Costs a member + team lookup, so it is for single-document paths only.
+ */
+export async function checkProjectDocumentAccess(
+  ctx: QueryCtx | MutationCtx,
+  doc: Doc<'documents'>,
+  args: { userId: string; organizationId: string },
+): Promise<ProjectAccessResult | null> {
+  if (!isProjectScopedDocument(doc) || !doc.projectId) return null;
+  if (doc.organizationId !== args.organizationId) return NO_PROJECT_ACCESS;
+
+  const project = await ctx.db.get(doc.projectId);
+  // A dangling projectId (project deleted) keeps the doc locked rather than
+  // silently falling open to org-wide.
+  if (!project || project.organizationId !== args.organizationId) {
+    return NO_PROJECT_ACCESS;
+  }
+
+  try {
+    const member = await getOrganizationMember(ctx, args.organizationId, {
+      userId: args.userId,
+      email: undefined,
+      name: undefined,
+    });
+    const userTeamIds = await getUserTeamIds(ctx, member.userId);
+    return checkProjectAccess(project, userTeamIds, member.role);
+  } catch (err) {
+    // Membership resolution failing (user removed mid-request, auth mirror
+    // miss) means no provable access — deny rather than leak.
+    console.warn(
+      '[documents/access] project document membership resolve failed',
+      err instanceof Error ? err.message : err,
+    );
+    return NO_PROJECT_ACCESS;
+  }
+}
+
+/**
+ * Whether a user can read a specific document, whatever its scope.
+ *
+ * Knowledge Hub docs follow team access; project docs require access to the
+ * owning project (org role + team membership vs the project's teams). Use on
+ * single-document paths (point reads, mutation guards) — it costs a member +
+ * team lookup for project docs, so it is not for per-row list filtering.
+ */
+export async function canReadDocument(
+  ctx: QueryCtx | MutationCtx,
+  doc: Doc<'documents'>,
+  args: { userId: string; organizationId: string },
+): Promise<boolean> {
+  if (doc.organizationId !== args.organizationId) return false;
+
+  if (!isProjectScopedDocument(doc)) {
+    const userTeamIds = await getUserTeamIds(ctx, args.userId);
+    return hasKnowledgeHubDocumentAccess(doc, userTeamIds);
+  }
+
+  const access = await checkProjectDocumentAccess(ctx, doc, args);
+  return access?.canRead ?? false;
 }

--- a/services/platform/convex/documents/get_accessible_document_ids.test.ts
+++ b/services/platform/convex/documents/get_accessible_document_ids.test.ts
@@ -79,6 +79,25 @@ describe('getAccessibleDocumentIds', () => {
     expect(ids).toEqual([]);
   });
 
+  it('excludes project-scoped documents even for team members', async () => {
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const ctx = createMockCtx([
+      { _id: 'doc1', ragInfo: { status: 'completed' } },
+      {
+        _id: 'doc2',
+        ragInfo: { status: 'completed' },
+        projectId: 'proj-1',
+      },
+    ]);
+
+    const ids = await getAccessibleDocumentIds(ctx, {
+      organizationId: 'org1',
+      userId: 'user1',
+    });
+
+    expect(ids).toEqual(['doc1']);
+  });
+
   it('includes documents regardless of ragInfo status', async () => {
     mockGetUserTeamIds.mockResolvedValue([]);
     const ctx = createMockCtx([

--- a/services/platform/convex/documents/get_accessible_document_ids.ts
+++ b/services/platform/convex/documents/get_accessible_document_ids.ts
@@ -1,7 +1,7 @@
 import type { QueryCtx } from '../_generated/server';
 import { getUserTeamIds } from '../lib/get_user_teams';
-import { hasTeamAccess } from '../lib/team_access';
 import { isActiveDocument } from './_helpers';
+import { hasKnowledgeHubDocumentAccess } from './access';
 
 /**
  * Get all document IDs accessible to a user within an organization.
@@ -31,7 +31,7 @@ export async function getAccessibleDocumentIds(
     // Trashed/expired docs (e.g. via WebDAV DELETE) must not be retrievable by
     // agents — this helper gates document_retrieve's access check.
     if (!isActiveDocument(doc)) continue;
-    if (hasTeamAccess(doc, teamSet)) {
+    if (hasKnowledgeHubDocumentAccess(doc, teamSet)) {
       ids.push(doc._id);
     }
   }

--- a/services/platform/convex/documents/get_documents_cursor.ts
+++ b/services/platform/convex/documents/get_documents_cursor.ts
@@ -9,8 +9,8 @@ import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { getMetadataString } from '../lib/metadata/get_metadata_string';
 import { paginateWithFilter, DEFAULT_PAGE_SIZE } from '../lib/pagination';
-import { hasTeamAccess } from '../lib/team_access';
 import { isActiveDocument } from './_helpers';
+import { hasKnowledgeHubDocumentAccess } from './access';
 import { transformDocumentsBatch } from './transform_to_document_item';
 import type { DocumentItemResponse } from './types';
 
@@ -60,7 +60,7 @@ export async function getDocumentsCursor(
     }
 
     if (args.userTeamIds !== undefined) {
-      if (!hasTeamAccess(doc, args.userTeamIds)) {
+      if (!hasKnowledgeHubDocumentAccess(doc, args.userTeamIds)) {
         return false;
       }
     }

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -176,6 +176,7 @@ export const listIndexedForAgent = internalQuery({
     includeTeamKnowledge: v.optional(v.boolean()),
     includeOrgKnowledge: v.optional(v.boolean()),
     knowledgeFileIds: v.optional(v.array(v.string())),
+    agentProjectIds: v.optional(v.array(v.string())),
     limit: v.optional(v.number()),
     cursor: v.optional(v.string()),
   },

--- a/services/platform/convex/documents/list_documents_for_agent.test.ts
+++ b/services/platform/convex/documents/list_documents_for_agent.test.ts
@@ -52,6 +52,7 @@ interface MockDoc {
   extension?: string;
   fileId?: string;
   teamId?: string;
+  projectId?: string;
   folderId?: string;
   metadata?: Record<string, unknown>;
 }
@@ -423,6 +424,20 @@ describe('listDocumentsForAgent', () => {
       const result = await listDocumentsForAgent(ctx as unknown as QueryCtx, {
         ...baseArgs,
         userTeamIds: [],
+      });
+
+      expect(result.documents).toHaveLength(1);
+    });
+
+    it('filters out project-scoped documents even for team members', async () => {
+      const ctx = createMockCtx({}, [
+        makeDoc({ _id: 'doc1', teamId: undefined }),
+        makeDoc({ _id: 'doc2', teamId: undefined, projectId: 'proj1' }),
+      ]);
+
+      const result = await listDocumentsForAgent(ctx as unknown as QueryCtx, {
+        ...baseArgs,
+        userTeamIds: ['team1'],
       });
 
       expect(result.documents).toHaveLength(1);

--- a/services/platform/convex/documents/list_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_documents_for_agent.ts
@@ -17,6 +17,7 @@ import {
 } from '../lib/fuzzy_match';
 import { hasTeamAccess } from '../lib/team_access';
 import { isActiveDocument } from './_helpers';
+import { hasKnowledgeHubDocumentAccess } from './access';
 
 const MAX_SCAN = 10_000;
 const DEFAULT_LIMIT = 20;
@@ -139,7 +140,7 @@ export async function listDocumentsForAgent(
     // Team filter
     if (args.teamId) {
       if (doc.teamId !== args.teamId) continue;
-    } else if (!hasTeamAccess(doc, teamIdSet)) {
+    } else if (!hasKnowledgeHubDocumentAccess(doc, teamIdSet)) {
       continue;
     }
 

--- a/services/platform/convex/documents/list_documents_paginated.test.ts
+++ b/services/platform/convex/documents/list_documents_paginated.test.ts
@@ -140,6 +140,33 @@ describe('listDocumentsPaginated', () => {
     expect(result.page.map((d) => d.id)).toEqual(['d_1', 'd_2']);
   });
 
+  it('filters out project-scoped documents even for team members', async () => {
+    const docs = [
+      {
+        _id: 'd_1',
+        _creationTime: 1000,
+        title: 'Hub doc',
+        organizationId: 'org_1',
+      },
+      {
+        _id: 'd_2',
+        _creationTime: 1001,
+        title: 'Project file',
+        organizationId: 'org_1',
+        projectId: 'proj_1',
+      },
+    ];
+    const { ctx } = createMockQueryBuilder(docs);
+
+    const result = await listDocumentsPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      organizationId: 'org_1',
+      userTeamIds: ['team_a'],
+    });
+
+    expect(result.page.map((d) => d.id)).toEqual(['d_1']);
+  });
+
   it('allows all documents when no team restrictions', async () => {
     const docs = [
       {

--- a/services/platform/convex/documents/list_documents_paginated.ts
+++ b/services/platform/convex/documents/list_documents_paginated.ts
@@ -12,8 +12,8 @@ import type { PaginationOptions } from 'convex/server';
 
 import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
-import { hasTeamAccess } from '../lib/team_access';
 import { isActiveDocument } from './_helpers';
+import { hasKnowledgeHubDocumentAccess } from './access';
 import { transformDocumentsBatch } from './transform_to_document_item';
 import type { DocumentItemResponse } from './types';
 
@@ -82,7 +82,7 @@ export async function listDocumentsPaginated(
   const userTeamSet = new Set(args.userTeamIds);
   const accessibleDocs = result.page.filter(
     (doc: Doc<'documents'>) =>
-      isActiveDocument(doc) && hasTeamAccess(doc, userTeamSet),
+      isActiveDocument(doc) && hasKnowledgeHubDocumentAccess(doc, userTeamSet),
   );
 
   const transformedPage = await transformDocumentsBatch(ctx, accessibleDocs);

--- a/services/platform/convex/documents/list_indexed_documents_for_agent.test.ts
+++ b/services/platform/convex/documents/list_indexed_documents_for_agent.test.ts
@@ -7,6 +7,7 @@ interface MockDoc {
   fileId?: string;
   title?: string;
   teamId?: string;
+  projectId?: string;
   sourceModifiedAt?: number;
   indexed?: boolean;
 }
@@ -94,6 +95,52 @@ describe('listIndexedDocumentsForAgent', () => {
       name: 'Guide.docx',
       sourceModifiedAt: 1700100000000,
     });
+  });
+
+  it('never lists project-scoped documents in the org-wide bucket', async () => {
+    const ctx = createMockCtx([
+      { _id: 'doc1', fileId: 'file1', title: 'Hub doc' },
+      {
+        _id: 'doc2',
+        fileId: 'file2',
+        title: 'Project file',
+        projectId: 'proj-1',
+      },
+    ]);
+
+    const result = await listIndexedDocumentsForAgent(ctx, {
+      organizationId: 'org1',
+      includeOrgKnowledge: true,
+    });
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].name).toBe('Hub doc');
+  });
+
+  it('lists project documents only under a matching project scope', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'doc1',
+        fileId: 'file1',
+        title: 'Project file',
+        projectId: 'proj-1',
+      },
+      {
+        _id: 'doc2',
+        fileId: 'file2',
+        title: 'Other project file',
+        projectId: 'proj-2',
+      },
+    ]);
+
+    const result = await listIndexedDocumentsForAgent(ctx, {
+      organizationId: 'org1',
+      includeOrgKnowledge: false,
+      agentProjectIds: ['proj-1'],
+    });
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].name).toBe('Project file');
   });
 
   it('filters by team scoping', async () => {

--- a/services/platform/convex/documents/list_indexed_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_indexed_documents_for_agent.ts
@@ -80,12 +80,15 @@ export async function listIndexedDocumentsForAgent(
     includeTeamKnowledge?: boolean;
     includeOrgKnowledge?: boolean;
     knowledgeFileIds?: string[];
+    /** Project IDs whose files are listable (thread's own project only). */
+    agentProjectIds?: string[];
     limit?: number;
     cursor?: string;
   },
 ): Promise<AgentIndexedDocumentListResult> {
   const limit = Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
   const knowledgeFileIdSet = new Set(args.knowledgeFileIds ?? []);
+  const agentProjectIdSet = new Set<string>(args.agentProjectIds ?? []);
 
   // Build effective team set: prefer agentTeamIds, fall back to single agentTeamId
   const agentTeamIdSet = new Set<string>();
@@ -150,10 +153,14 @@ export async function listIndexedDocumentsForAgent(
       if (!isActiveDocument(doc)) continue;
 
       const fileId = String(doc.fileId);
+      // Project docs are team-less by invariant and must NOT ride the
+      // org-wide bucket — they are listable only via an explicit project
+      // scope (mirrors get_agent_scoped_file_ids).
       const isMatch =
         knowledgeFileIdSet.has(fileId) ||
         (needsTeamDocs && doc.teamId && agentTeamIdSet.has(doc.teamId)) ||
-        (needsOrgDocs && !doc.teamId);
+        (needsOrgDocs && !doc.teamId && !doc.projectId) ||
+        (doc.projectId != null && agentProjectIdSet.has(String(doc.projectId)));
 
       if (!isMatch) continue;
 

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -24,6 +24,7 @@ import {
   PROJECT_AUDIT_ACTIONS,
   PROJECT_RESOURCE_TYPE,
 } from '../projects/audit_actions';
+import { checkProjectDocumentAccess, isProjectScopedDocument } from './access';
 import { createDocument } from './create_document';
 import { extractExtension } from './extract_extension';
 import { updateDocument as updateDocumentHelper } from './update_document';
@@ -61,6 +62,20 @@ export const updateDocument = mutation({
 
     await getOrganizationMember(ctx, document.organizationId, authUser);
 
+    // Project files: org membership alone is not enough — require edit
+    // access to the owning project (the same standard as attach/detach).
+    // Team assignment on a project doc is rejected inside the helper
+    // (projectId/teamId mutual exclusivity).
+    if (isProjectScopedDocument(document)) {
+      const access = await checkProjectDocumentAccess(ctx, document, {
+        userId: authUser.userId,
+        organizationId: document.organizationId,
+      });
+      if (!access?.canEdit) {
+        throw new ConvexError({ code: 'PROJECT_FORBIDDEN' });
+      }
+    }
+
     await updateDocumentHelper(ctx, {
       ...args,
       teamIds: args.teamIds,
@@ -92,6 +107,18 @@ export const deleteDocument = mutation({
     }
 
     await getOrganizationMember(ctx, document.organizationId, authUser);
+
+    // Project files: deletion requires edit access to the owning project
+    // (mirrors the update gate above and the attach/detach standard).
+    if (isProjectScopedDocument(document)) {
+      const access = await checkProjectDocumentAccess(ctx, document, {
+        userId: authUser.userId,
+        organizationId: document.organizationId,
+      });
+      if (!access?.canEdit) {
+        throw new ConvexError({ code: 'PROJECT_FORBIDDEN' });
+      }
+    }
 
     // Synchronous hold check so the user sees an immediate error instead
     // of a silent success while the async cleanup throws (round-2 v08 B4).

--- a/services/platform/convex/documents/queries.ts
+++ b/services/platform/convex/documents/queries.ts
@@ -12,8 +12,8 @@ import { countItemsInOrg } from '../lib/helpers/count_items_in_org';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { isActiveOrg } from '../lib/rls/organization/assert_active_org';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
-import { hasTeamAccess } from '../lib/team_access';
 import { isActiveDocument } from './_helpers';
+import { canReadDocument, hasKnowledgeHubDocumentAccess } from './access';
 import { listDocumentsPaginated as listDocumentsPaginatedHelper } from './list_documents_paginated';
 import { searchDocumentsForMention as searchDocumentsForMentionHelper } from './search_documents_for_mention';
 import { transformDocumentsBatch } from './transform_to_document_item';
@@ -61,7 +61,7 @@ export const listDocuments = query({
       )
       .order('desc')) {
       if (!isActiveDocument(doc)) continue;
-      if (!hasTeamAccess(doc, userTeamIds)) continue;
+      if (!hasKnowledgeHubDocumentAccess(doc, userTeamIds)) continue;
 
       documents.push(doc);
     }
@@ -71,11 +71,12 @@ export const listDocuments = query({
 });
 
 /**
- * Point-query a single document by id, with the SAME access control as
- * `listDocuments` (org membership + team access + active lifecycle). Lets the
- * client fetch one document directly instead of pulling the whole collection
- * and filtering client-side. Returns null on not-found or any access failure
- * (never leaks a document from another org/team).
+ * Point-query a single document by id (org membership + active lifecycle +
+ * scope access). Unlike `listDocuments` — which is a Knowledge Hub surface
+ * and never shows project files — this by-ID read also admits a
+ * project-scoped document when the caller has access to the owning project
+ * (`canReadDocument`). Returns null on not-found or any access failure
+ * (never leaks a document from another org/team/project).
  */
 export const getDocumentById = query({
   args: {
@@ -102,8 +103,11 @@ export const getDocumentById = query({
       return null;
     }
 
-    const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
-    if (!hasTeamAccess(doc, userTeamIds)) return null;
+    const canRead = await canReadDocument(ctx, doc, {
+      userId: authUser.userId,
+      organizationId: args.organizationId,
+    });
+    if (!canRead) return null;
 
     const [item] = await transformDocumentsBatch(ctx, [doc]);
     return item ?? null;

--- a/services/platform/convex/documents/rest_api.ts
+++ b/services/platform/convex/documents/rest_api.ts
@@ -45,7 +45,15 @@ export const listDocuments = withRestAuth('rest:api', async (rc, request) => {
     },
   );
 
-  return jsonOk(result);
+  // REST is a Knowledge Hub surface: project-scoped documents are managed
+  // through the project UI/APIs and are not addressable here. Filtered
+  // post-pagination (the shared internal query also feeds the OneDrive
+  // prune scan, which must keep seeing project-attached synced docs), so a
+  // page may run short of `limit` — same trade as the in-app listings.
+  return jsonOk({
+    ...result,
+    page: result.page.filter((doc) => doc.projectId == null),
+  });
 });
 
 export const createDocument = withRestAuth('rest:api', async (rc, request) => {
@@ -122,6 +130,12 @@ export const getDocument = withRestAuth('rest:api', async (rc, request) => {
     return jsonError('Document not found', 404);
   }
 
+  // Project files are not addressable via the hub REST API (opaque 404 —
+  // don't reveal that an inaccessible document exists).
+  if (document.projectId != null) {
+    return jsonError('Document not found', 404);
+  }
+
   return jsonOk(document);
 });
 
@@ -134,6 +148,20 @@ export const patchDocument = withRestAuth('rest:api', async (rc, request) => {
   }
 
   const body = await request.json();
+
+  // Project files are not editable via the hub REST API. Opaque 404, same
+  // as GET — the shared internal mutation stays open for sync/workflow
+  // callers, so the gate lives at this surface.
+  const existing = await rc.ctx.runQuery(
+    internal.documents.internal_queries.getDocumentByIdRaw,
+    {
+      documentId: toId<'documents'>(id),
+      callerOrgId: rc.org.organizationId,
+    },
+  );
+  if (!existing || existing.projectId != null) {
+    return jsonError('Document not found', 404);
+  }
 
   await rc.ctx.runMutation(
     internal.documents.internal_mutations.updateDocument,
@@ -160,6 +188,19 @@ export const deleteDocument = withRestAuth('rest:api', async (rc, request) => {
 
   if (!id) {
     return jsonError('Missing document ID', 400);
+  }
+
+  // Project files are not deletable via the hub REST API (opaque 404; the
+  // shared internal mutation stays open for retention/erasure callers).
+  const existing = await rc.ctx.runQuery(
+    internal.documents.internal_queries.getDocumentByIdRaw,
+    {
+      documentId: toId<'documents'>(id),
+      callerOrgId: rc.org.organizationId,
+    },
+  );
+  if (!existing || existing.projectId != null) {
+    return jsonError('Document not found', 404);
   }
 
   await rc.ctx.runMutation(

--- a/services/platform/convex/documents/search_documents_for_mention.test.ts
+++ b/services/platform/convex/documents/search_documents_for_mention.test.ts
@@ -215,6 +215,46 @@ describe('searchDocumentsForMention', () => {
     ]);
   });
 
+  it('never offers project-scoped documents, even to team members', async () => {
+    const { ctx } = createCtx(
+      [
+        { ...baseDoc, _id: 'd_hub', title: 'Doc hub', fileId: 'f_1' },
+        {
+          ...baseDoc,
+          _id: 'd_project',
+          title: 'Doc project',
+          fileId: 'f_2',
+          projectId: 'proj_1',
+        },
+      ],
+      {
+        f_1: {
+          fileName: 'hub.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+        f_2: {
+          fileName: 'project.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+      },
+    );
+
+    const results = await searchDocumentsForMention(
+      ctx as unknown as QueryCtx,
+      {
+        organizationId: 'org_1',
+        term: 'doc',
+        userTeamIds: ['team_a'],
+      },
+    );
+
+    expect(results.map((r) => r.documentId)).toEqual(['d_hub']);
+  });
+
   it('returns newest docs on an empty query and falls back to the blob file name when the title is empty', async () => {
     const { ctx } = createCtx(
       [

--- a/services/platform/convex/documents/search_documents_for_mention.ts
+++ b/services/platform/convex/documents/search_documents_for_mention.ts
@@ -19,7 +19,7 @@ import type { PaginationResult } from 'convex/server';
 import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { documentsSearchStrategy, runEntitySearch } from '../lib/search';
-import { hasTeamAccess } from '../lib/team_access';
+import { hasKnowledgeHubDocumentAccess } from './access';
 
 export const MENTION_RESULT_LIMIT = 10;
 const MAX_SCAN_SLICES = 5;
@@ -83,7 +83,8 @@ export async function searchDocumentsForMention(
         organizationId: args.organizationId,
         term: args.term,
         paginationOpts: { cursor, numItems: SCAN_SLICE_SIZE },
-        accessFilter: (doc) => !!doc.fileId && hasTeamAccess(doc, teamSet),
+        accessFilter: (doc) =>
+          !!doc.fileId && hasKnowledgeHubDocumentAccess(doc, teamSet),
       },
     );
 

--- a/services/platform/convex/documents/update_document.ts
+++ b/services/platform/convex/documents/update_document.ts
@@ -44,6 +44,17 @@ export async function updateDocument(
       });
     }
 
+    // `projectId`/`teamId` are mutually exclusive (enforced at
+    // attachDocumentToProject): a project document can never be
+    // team-assigned. Detach it from the project first.
+    if (document.projectId != null) {
+      throw new ConvexError({
+        code: 'DOCUMENT_SCOPE_CONFLICT',
+        message:
+          'A project document cannot be assigned to teams. Detach it from the project first.',
+      });
+    }
+
     if (document.folderId) {
       const folder = await ctx.db.get(document.folderId);
       if (folder?.teamId) {

--- a/services/platform/convex/documents/update_document_internal.test.ts
+++ b/services/platform/convex/documents/update_document_internal.test.ts
@@ -248,3 +248,35 @@ describe('updateDocumentInternal folder-move RAG sync', () => {
     expect(scheduled[0].args).toMatchObject({ documentId: 'd1' });
   });
 });
+
+describe('updateDocumentInternal project-doc scope invariant', () => {
+  it('rejects team assignment on a project-scoped document', async () => {
+    const { ctx, patches } = createMockCtx(
+      { ...baseDoc, projectId: 'proj_1' },
+      null,
+    );
+
+    await expect(
+      updateDocumentInternal(ctx, {
+        documentId: 'd1' as never,
+        teamId: 'team_1',
+      }),
+    ).rejects.toMatchObject({ data: { code: 'DOCUMENT_SCOPE_CONFLICT' } });
+    expect(patches).toHaveLength(0);
+  });
+
+  it('still allows non-team updates on a project-scoped document', async () => {
+    const { ctx, patches } = createMockCtx(
+      { ...baseDoc, projectId: 'proj_1' },
+      null,
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      title: 'Renamed inside project',
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].data).toMatchObject({ title: 'Renamed inside project' });
+  });
+});

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -38,6 +38,17 @@ export async function updateDocumentInternal(
     });
   }
 
+  // `projectId`/`teamId` are mutually exclusive (enforced at
+  // attachDocumentToProject) — hold the invariant for every caller,
+  // including REST and sync paths.
+  if (updateData.teamId !== undefined && document.projectId != null) {
+    throw new ConvexError({
+      code: 'DOCUMENT_SCOPE_CONFLICT',
+      message:
+        'A project document cannot be assigned to a team. Detach it from the project first.',
+    });
+  }
+
   if (updateData.folderId) {
     const folder = await ctx.db.get(updateData.folderId);
     if (!folder || folder.organizationId !== document.organizationId) {

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -35,6 +35,7 @@ import {
 import { tuningInstructionSuffix } from '../../../lib/shared/response-tuning';
 import { isRecord, getString } from '../../../lib/utils/type-utils';
 import { components, internal } from '../../_generated/api';
+import type { Id } from '../../_generated/dataModel';
 import { queryRagContext } from '../../agent_tools/rag/query_rag_context';
 import { queryWebContext } from '../../agent_tools/web/helpers/query_web_context';
 import {
@@ -578,6 +579,48 @@ export async function generateAgentResponse(
     const needsWebContext =
       !prewarm && (webSearchMode === 'context' || webSearchMode === 'both');
 
+    // Resolve the thread's project once (single point read, ~free): files
+    // uploaded to a project must be retrievable in that project's chat, so
+    // the thread's project is unioned into the agent's (config-provided)
+    // project scope for BOTH context injection below and the rag_search tool
+    // (contextWithOrg). The project-instructions block reuses the same id.
+    // Degrades to "no project scope" on failure rather than aborting.
+    //
+    // The stored thread↔project binding is NOT proof of access at send time
+    // (membership may have been revoked since the thread was created), so the
+    // sender's CURRENT project access is re-verified before the scope widens.
+    // Turns without a user identity get no thread-project scope — only the
+    // agent's own config can grant one there.
+    let threadProjectId: Id<'projects'> | null = null;
+    try {
+      const storedProjectId = await ctx.runQuery(
+        internal.projects.internal_queries.getProjectIdForThread,
+        { threadId },
+      );
+      if (storedProjectId && userId && organizationId) {
+        const projectAccess = await ctx.runQuery(
+          internal.projects.internal_queries.assertProjectAccessForChat,
+          { projectId: storedProjectId, organizationId, userId },
+        );
+        if (projectAccess.allowed) {
+          threadProjectId = storedProjectId;
+        } else {
+          console.warn(
+            '[generateAgentResponse] sender lacks project access; skipping project scope',
+            { threadId, reason: projectAccess.reason },
+          );
+        }
+      }
+    } catch (err) {
+      console.warn(
+        '[generateAgentResponse] thread project resolve failed; skipping project scope',
+        err instanceof Error ? err.message : err,
+      );
+    }
+    const effectiveAgentProjectIds = threadProjectId
+      ? [...new Set([...(agentProjectIds ?? []), String(threadProjectId)])]
+      : agentProjectIds;
+
     // Start context injection queries (non-blocking) for context/both modes
     let knowledgeContextPromise:
       | Promise<
@@ -607,7 +650,7 @@ export async function generateAgentResponse(
               includeTeamKnowledge,
               includeOrgKnowledge,
               knowledgeFileIds,
-              agentProjectIds,
+              agentProjectIds: effectiveAgentProjectIds,
             },
           );
         } catch (err) {
@@ -682,21 +725,21 @@ export async function generateAgentResponse(
       });
     }
 
-    // Project instructions block — resolves the thread's projectId (if any)
-    // and assembles the XML-wrapped block to inject into the system prompt
-    // between agent instructions and user personalization. Empty when the
-    // chat is not inside a project. Parallel with personalization for TTFT.
+    // Project instructions block — assembles the XML-wrapped block to inject
+    // into the system prompt between agent instructions and user
+    // personalization. Empty when the chat is not inside a project (the
+    // thread's projectId was resolved once above, shared with the RAG scope).
+    // Parallel with personalization for TTFT.
     const projectInstructionsPromise: Promise<ProjectInstructionsBlock> =
       (async () => {
         try {
-          const projectId = await ctx.runQuery(
-            internal.projects.internal_queries.getProjectIdForThread,
-            { threadId },
-          );
-          if (!projectId) {
+          if (!threadProjectId) {
             return { text: '', tokens: 0, fingerprint: '' };
           }
-          return await buildProjectInstructions({ ctx, projectId });
+          return await buildProjectInstructions({
+            ctx,
+            projectId: threadProjectId,
+          });
         } catch (err) {
           console.error('[generate_response] projectInstructions failed', err);
           return { text: '', tokens: 0, fingerprint: '' };
@@ -908,6 +951,8 @@ export async function generateAgentResponse(
 
     // Build context with organization info.
     // actionDeadlineMs is exposed via variables so tool handlers can check remaining budget.
+    // agentProjectIds carries the thread's project too, so the rag_search
+    // tool searches project files inside their own project's chat.
     const contextWithOrg = {
       ...ctx,
       organizationId,
@@ -918,7 +963,7 @@ export async function generateAgentResponse(
       includeTeamKnowledge,
       includeOrgKnowledge,
       knowledgeFileIds,
-      agentProjectIds,
+      agentProjectIds: effectiveAgentProjectIds,
     };
 
     let didRetry = false;

--- a/services/platform/convex/lib/rls/helpers/rls_rules.ts
+++ b/services/platform/convex/lib/rls/helpers/rls_rules.ts
@@ -7,6 +7,7 @@ import type { Rules } from 'convex-helpers/server/rowLevelSecurity';
 import type { MemberRole } from '../../../../lib/shared/schemas/organizations';
 import type { DataModel } from '../../../_generated/dataModel';
 import type { QueryCtx } from '../../../_generated/server';
+import { hasKnowledgeHubDocumentAccess } from '../../../documents/access';
 import { getUserTeamIds } from '../../get_user_teams';
 import { hasTeamAccess } from '../../team_access';
 import { getAuthUserIdentity } from '../auth/get_auth_user_identity';
@@ -91,12 +92,18 @@ export async function rlsRules(
       },
     },
 
-    // Documents - organization-scoped with team-based access control
+    // Documents - organization-scoped with team-based access control.
+    // Project-scoped documents (projectId set) are denied outright: they are
+    // not Knowledge Hub rows, and their read/edit paths go through the
+    // project mutations' own guards (documents/access.ts), never through
+    // RLS-wrapped db access. Defense-in-depth for future wrapped callers.
     documents: {
       read: async (_, doc) => {
         if (!user) return false;
         if (!userOrgIds.has(doc.organizationId)) return false;
-        if (!hasTeamAccess(doc, await resolveTeamIds())) return false;
+        if (!hasKnowledgeHubDocumentAccess(doc, await resolveTeamIds())) {
+          return false;
+        }
         const membership = userOrganizations.find(
           (m) => m.organizationId === doc.organizationId,
         );
@@ -105,7 +112,9 @@ export async function rlsRules(
       modify: async (_, doc) => {
         if (!user) return false;
         if (!userOrgIds.has(doc.organizationId)) return false;
-        if (!hasTeamAccess(doc, await resolveTeamIds())) return false;
+        if (!hasKnowledgeHubDocumentAccess(doc, await resolveTeamIds())) {
+          return false;
+        }
         const membership = userOrganizations.find(
           (m) => m.organizationId === doc.organizationId,
         );
@@ -114,7 +123,9 @@ export async function rlsRules(
       insert: async ({ user: ruleUser }, doc) => {
         if (!ruleUser) return false;
         if (!userOrgIds.has(doc.organizationId)) return false;
-        if (!hasTeamAccess(doc, await resolveTeamIds())) return false;
+        if (!hasKnowledgeHubDocumentAccess(doc, await resolveTeamIds())) {
+          return false;
+        }
         const membership = userOrganizations.find(
           (m) => m.organizationId === doc.organizationId,
         );


### PR DESCRIPTION
## Summary

Documents attached to a project (`projectId` set, `teamId` cleared by the attach invariant) read as **org-wide** to `hasTeamAccess`, so every Knowledge surface leaked them to the whole org — hub lists, the `@` mention picker and pin path, the `rag_search`/`document_find`/`document_retrieve` agent tools, the per-user-key REST API, and update/delete mutations — while project-chat RAG never searched them (nothing mapped the thread's project into `agentProjectIds`). This PR gives the scope decision one owner (`convex/documents/access.ts`) and enforces it at every surface, and wires the thread's project into RAG scope after re-verifying the sender's current project access.

Follow-ups: WebDAV exclusion #2545, attach-lifecycle gaps #2546.

## What changed

- **New access owner** — `documents/access.ts`: `isProjectScopedDocument`, `hasKnowledgeHubDocumentAccess` (sync, list-safe: project docs are never hub-visible), `checkProjectDocumentAccess` / `canReadDocument` (async: project docs resolve via `checkProjectAccess` on the owning project).
- **Knowledge read paths** — `listDocuments`, `listDocumentsPaginated`, `getDocumentsCursor`, `searchDocumentsForMention`, `getAccessibleDocumentIds`, `listDocumentsForAgent` filter through the hub helper; `getDocumentById` uses `canReadDocument` so project members can still open their files by ID.
- **rag_search** — `list_indexed` org bucket excludes project docs and gains a project bucket (`agentProjectIds`); `retrieve`/`search` storage-id verification (`verify_thread_scoped_access`) loads the backing hub doc and requires the caller's project scope to cover it. `document_retrieve` honors the same scope for parity.
- **`@` pins** — `resolveReferencedFiles` extracted to `agents/resolve_referenced_files.ts`: a project doc is pinable only when the thread belongs to that project **and** the sender can read it; thread metadata is read before reference resolution to supply the scope.
- **Mutations** — `updateDocument`/`deleteDocument` require project **edit** access (the attach/detach standard) for project docs; `teamId(s)` assignment on a project doc is rejected in both update helpers (projectId/teamId mutual exclusivity, all callers incl. REST/sync).
- **RAG scope wiring** — `generate_response` resolves `getProjectIdForThread` once, re-verifies the **sender's current** access via `assertProjectAccessForChat` (a revoked member's old project threads no longer grant scope), and unions the project into `agentProjectIds` for context injection and the `rag_search` tool context. `chat_turn` validates `args.projectId` **before** the prewarm branch, so an unvalidated prewarm can never bind a thread to a foreign project.
- **REST `/api/v1/documents`** — hub-only (keys are per-user sessions): list filters project docs post-pagination; GET/PATCH/DELETE answer an opaque 404. Shared internals stay open for sync/retention/erasure callers.
- **RLS** — documents read/modify/insert deny project docs (defense-in-depth; no documents path is RLS-wrapped today).

Independent adversarial review of the initial six-path fix found the `rag_search` bucket and the prewarm/stale-binding holes; both are closed here rather than deferred.

## Checklist

- [x] `bun run check` passes — 42/47 tasks green in the worktree; the sole failure (`@tale/ui` `app-shell.test.tsx`) is a git-worktree artifact (Vite denies the hoisted `node_modules` font path outside the worktree root) and the same file passes 5/5 in the main checkout. This diff touches no `packages/ui` code.
- [x] `bun run lint:sast` passes — 0 findings on this diff; the repo-wide scan's single finding is pre-existing in `services/sandbox-runtime` (untouched).
- [x] Translations — **N/A**: no new user-visible strings; the gates reuse existing error codes (`PROJECT_FORBIDDEN`, `DOCUMENT_SCOPE_CONFLICT`) and the REST handlers reuse the existing "Document not found" wording.
- [x] Docs — **N/A**: `docs/en/platform/projects/manage-files.md` already documents exactly this behaviour ("The Files tab is not a knowledge base…", project chat sees project files); this fix makes the docs true.
- [x] READMEs — **N/A**: no env var, CLI flag, or config change. No schema change → no migration.

## Test plan

Every leak class carries a red→green regression test (watched failing on the pre-fix code):

- `documents/access.test.ts` — hub/project split, `canReadDocument`, `checkProjectDocumentAccess` role matrix (15 cases).
- `agents/resolve_referenced_files.test.ts` — pin gate: own-project thread allowed; global chat / foreign project / no project access rejected (8 cases).
- Extended: `list_documents_paginated`, `get_accessible_document_ids`, `search_documents_for_mention`, `list_documents_for_agent`, `list_indexed_documents_for_agent` (org bucket + project bucket), `update_document_internal` (teamId-on-project-doc invariant).
- Suites: `convex/documents/` + `convex/agents/` + `convex/agent_tools/` — 937 tests green; typecheck/oxlint/oxfmt clean.

Manual verification for a reviewer (dev stack, two users, one team-scoped project):

1. Upload a file in the project's Files tab → it does **not** appear in Knowledge → Documents (any user), and `rag_search {operation:'list_indexed'}` in a global chat does not list it.
2. In a global chat, the `@` picker never offers it; sending a crafted `referencedDocumentIds` pin fails with `KB_REF_INVALID`.
3. In the project's chat, the default assistant (knowledgeMode `tool`) retrieves the file's content via `rag_search`; `document_retrieve` of the same fileId also succeeds.
4. As an org member outside the project's team: `getDocumentById` returns null; update/delete throw `PROJECT_FORBIDDEN`; REST `GET/PATCH/DELETE /api/v1/documents/:id` return 404 and the list omits it.

Not live-observed end-to-end: project-chat RAG retrieval on a seeded stack (step 3) — the unit tests pin every decision point and the wiring is typecheck-verified, but I could not run a full RAG corpus in this environment; step 3 is the one to smoke first.