### PR TITLE
fix(platform): clear oxlint errors in tasks queries and approval action

### DIFF
--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -252,10 +252,11 @@ export const listTasksByProjectPaginated = query({
     );
     return {
       ...result,
-      page: result.page.map((task) => ({
-        ...task,
-        pendingReview: pendingByTask.has(String(task._id)),
-      })),
+      page: result.page.map((task) =>
+        Object.assign(task, {
+          pendingReview: pendingByTask.has(String(task._id)),
+        }),
+      ),
     };
   },
 });

--- a/services/platform/convex/workflow_engine/action_defs/approval/approval_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/approval/approval_action.ts
@@ -142,7 +142,7 @@ export const approvalAction: ActionDefinition<ApprovalActionParams> = {
         // carries it — without it the gate degrades to a raw JSON dump.
         return {
           operation: 'request_review',
-          taskId: String(params.taskId),
+          taskId: params.taskId,
           ...result,
         };
       }


### PR DESCRIPTION
Main's Lint workflow is red after #2542: `no-map-spread` in `convex/tasks/queries.ts` (spread-in-map → `Object.assign` on the fresh page rows) and `no-unnecessary-type-conversion` in `approval_action.ts` (`params.taskId` is already a string). Verified: oxlint clean on both files, platform typecheck clean, tasks + approval suites 112/112.