### PR TITLE
fix(platform): keep chat sidebar skeleton until projects load

### DIFF
--- a/services/platform/app/features/chat/components/chat-history-sidebar.test.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.test.tsx
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import enMessages from '../../../../messages/en.json';
+import { ChatHistorySidebar } from './chat-history-sidebar';
+
+// Controllable hook results (hoisted so the vi.mock factories can close over
+// them). Each test drives what the threads / projects queries return to
+// exercise the skeleton gate across loading permutations.
+const { threadsRef, projectsRef } = vi.hoisted(() => {
+  interface ThreadsState {
+    threads:
+      | Array<{ _id: string; title: string; _creationTime: number }>
+      | undefined;
+    isLoading: boolean;
+    isLoadingFirstPage: boolean;
+    canLoadMore: boolean;
+    isLoadingMore: boolean;
+    loadMore: () => void;
+  }
+  interface ProjectsState {
+    projects: Array<{
+      _id: string;
+      name: string;
+      icon?: string;
+      color?: string;
+      pinnedAt?: number;
+    }>;
+    isLoading: boolean;
+  }
+  return {
+    threadsRef: { current: undefined as unknown as ThreadsState },
+    projectsRef: { current: undefined as unknown as ProjectsState },
+  };
+});
+
+const loadedThreads = () => ({
+  threads: [{ _id: 'thread-1', title: 'Budget kickoff', _creationTime: 1 }],
+  isLoading: false,
+  isLoadingFirstPage: false,
+  canLoadMore: false,
+  isLoadingMore: false,
+  loadMore: vi.fn(),
+});
+
+const loadingThreads = () => ({
+  threads: undefined,
+  isLoading: true,
+  isLoadingFirstPage: true,
+  canLoadMore: false,
+  isLoadingMore: false,
+  loadMore: vi.fn(),
+});
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+  useRouter: () => ({ preloadRoute: vi.fn() }),
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useThreads: () => threadsRef.current,
+  useArchivedThreads: () => ({
+    threads: [],
+    isLoading: false,
+    canLoadMore: false,
+    isLoadingMore: false,
+    loadMore: vi.fn(),
+  }),
+  useActiveApprovals: () => ({ approvals: [], isLoading: false }),
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useUpdateThread: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/app/features/projects/hooks/queries', () => ({
+  useProjects: () => projectsRef.current,
+  useProjectThreads: () => ({ threads: [], isLoading: false }),
+}));
+
+vi.mock('@/app/features/projects/hooks/mutations', () => ({
+  useSetProjectPinned: () => ({ mutate: vi.fn() }),
+  // Consumed by the drag-and-drop provider wrapping the loaded list.
+  useMoveThreadToProject: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
+  useActiveHoldTargetIds: () => ({ data: undefined, isLoading: true }),
+}));
+
+// Heavy children that reach Convex on their own — irrelevant to the
+// skeleton gate under test.
+vi.mock('@/app/features/projects/components/project-create-dialog', () => ({
+  ProjectCreateDialog: () => null,
+}));
+
+vi.mock('./chat-actions', () => ({
+  ChatActions: () => null,
+}));
+
+describe('ChatHistorySidebar skeleton gate', () => {
+  beforeEach(() => {
+    threadsRef.current = loadedThreads();
+    projectsRef.current = { projects: [], isLoading: false };
+    window.localStorage.clear();
+  });
+
+  it('shows the skeleton while the threads first page loads', () => {
+    threadsRef.current = loadingThreads();
+    projectsRef.current = { projects: [], isLoading: true };
+
+    render(<ChatHistorySidebar organizationId="org-1" />);
+
+    // `busy: true` pins the query to the Skeletonize wrapper (dnd-kit mounts
+    // its own bare `role="status"` live region in the loaded state).
+    expect(screen.getByRole('status', { busy: true })).toBeInTheDocument();
+    expect(
+      screen.queryByText(enMessages.chat.projectsSection),
+    ).not.toBeInTheDocument();
+  });
+
+  // Regression for #2544: threads can resolve before projects; dismissing the
+  // skeleton on threads alone lets project folder rows pop in after the first
+  // real paint (layout shift).
+  it('keeps the skeleton until projects have loaded too', () => {
+    threadsRef.current = loadedThreads();
+    projectsRef.current = { projects: [], isLoading: true };
+
+    render(<ChatHistorySidebar organizationId="org-1" />);
+
+    expect(screen.getByRole('status', { busy: true })).toBeInTheDocument();
+    expect(
+      screen.queryByText(enMessages.chat.projectsSection),
+    ).not.toBeInTheDocument();
+  });
+
+  it('swaps to real content once both threads and projects resolve', () => {
+    threadsRef.current = loadedThreads();
+    projectsRef.current = {
+      projects: [{ _id: 'project-1', name: 'Apollo' }],
+      isLoading: false,
+    };
+
+    render(<ChatHistorySidebar organizationId="org-1" />);
+
+    expect(
+      screen.queryByRole('status', { busy: true }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(enMessages.chat.projectsSection),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Apollo')).toBeInTheDocument();
+    expect(screen.getByText('Budget kickoff')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -212,7 +212,8 @@ export function ChatHistorySidebar({
     loadMore: loadMoreArchived,
   } = useArchivedThreads({ teamId: selectedTeamId, organizationId });
 
-  const { projects } = useProjects(organizationId);
+  const { projects, isLoading: isLoadingProjects } =
+    useProjects(organizationId);
 
   const { approvals } = useActiveApprovals(organizationId);
 
@@ -486,7 +487,10 @@ export function ChatHistorySidebar({
     [setCollapsedProjects],
   );
 
-  const showSkeleton = !isMounted || isLoadingFirstPage;
+  // Wait for BOTH async sections (chat threads first page + project folders)
+  // before swapping the skeleton for real content — dismissing on threads
+  // alone lets project rows pop in after first paint (layout shift, #2544).
+  const showSkeleton = !isMounted || isLoadingFirstPage || isLoadingProjects;
   const isEmpty = (chats?.length ?? 0) === 0;
 
   // Defined once and reused by both the empty-state and populated headers so


### PR DESCRIPTION
## Problem

The chat history sidebar skeleton gated only on the threads first-page load (`showSkeleton = !isMounted || isLoadingFirstPage`). When threads resolved before the separate projects query, the skeleton swapped to real content with zero project rows, and project folder rows popped in afterwards — a visible layout shift.

## Change

- Destructure `isLoading` from `useProjects(organizationId)` in `ChatHistorySidebar` and extend the gate: `showSkeleton = !isMounted || isLoadingFirstPage || isLoadingProjects`.
- Add `chat-history-sidebar.test.tsx` (client project) covering the skeleton gate: threads loading → skeleton; threads resolved + projects loading → skeleton stays (regression case — red on the old code); both resolved → real content (Projects header, folder row, chat row) and no busy status region.

The issue's optional ideas (adaptive skeleton row counts, archived-footer skeleton) are left out — the skeleton already mirrors the loaded structure and the fix stays minimal.

## Verification

- New test red on old code (regression case failed exactly), green after the fix.
- `vitest --project client app/features/chat app/features/projects`: 933 passed; the single failure (`chat-input-agent-toolbar.test.tsx`, missing ConvexProvider) reproduces on clean `origin/main` and is unrelated.
- `tsc --noEmit` (platform), `oxlint --type-aware` and `oxfmt --check` on changed files: clean.

Closes #2544