### PR TITLE
fix(platform): unify agent detail breadcrumb crumb typography

### DIFF
--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.breadcrumb.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.breadcrumb.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// Route tests run in the `server` project (no `setup-ui.ts`); jsdom ships no
+// `matchMedia`, which `useIsMobile` (via `AdaptiveHeaderRoot`) reads on mount.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// Regression coverage for #2543: the detail breadcrumb rendered parent crumbs
+// ("Agents", folder segments) as plain links outside the page `Heading`, so
+// they fell back to the inherited body typography while the leaf agent name
+// carried the `text-base font-semibold` page-title style — a visible weight
+// and size mismatch. The whole `ol` trail now carries the page-title
+// typography (parents are dimmed via colour only), and folder segments render
+// their localized display label via `folderLabel`, never the raw path slug.
+
+const { mockUseParams } = vi.hoisted(() => ({
+  mockUseParams: () => ({ id: 'org-1', agentId: 'agent-1' }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    useParams: mockUseParams,
+    ...config,
+  }),
+  // Class passthrough matters: the assertions below read the crumbs' classes.
+  Link: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href="/" className={className}>
+      {children}
+    </a>
+  ),
+  Outlet: () => null,
+  // `LayoutErrorBoundary` (inside `PageLayout`) resets on pathname changes.
+  useLocation: () => ({ pathname: '/dashboard/org-1/agents/agent-1' }),
+}));
+
+vi.mock('@convex-dev/react-query', () => ({
+  convexQuery: (fn: unknown, args: unknown) => ({
+    queryKey: ['convex-query', fn, args],
+  }),
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: {
+    users: { queries: { getCurrentUser: 'getCurrentUser-ref' } },
+    agents: { file_actions: { readAgent: 'readAgent-ref' } },
+  },
+}));
+
+// Loaded agent: the config resolves the leaf display name; the roster row
+// carries the folder that becomes the parent folder crumb.
+vi.mock('@/app/features/agents/hooks/queries', () => ({
+  useReadAgent: () => ({
+    data: {
+      ok: true,
+      config: { displayName: 'Support Agent', supportedModels: [] },
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useListAgents: () => ({
+    agents: [
+      { name: 'agent-1', displayName: 'Support Agent', folder: 'workforce' },
+    ],
+  }),
+}));
+
+// The tab strip drags in mutation hooks and dialogs irrelevant to the header.
+vi.mock('@/app/features/agents/components/agent-navigation', () => ({
+  AgentNavigation: () => null,
+}));
+
+import { AdaptiveHeaderProvider } from '@/app/components/layout/adaptive-header';
+
+import { Route } from './$agentId';
+
+// The router mock above replaces `createFileRoute`, so `Route` is the plain
+// config object and `Route.component` is the layout under test.
+const AgentDetailLayout = (
+  Route as unknown as { component: () => React.ReactElement }
+).component;
+
+function renderDetailLayout() {
+  return render(
+    <AdaptiveHeaderProvider>
+      <AgentDetailLayout />
+    </AdaptiveHeaderProvider>,
+  );
+}
+
+/** Tailwind font-size / font-weight utilities on an element — a crumb with
+ *  any of these diverges from the typography the trail inherits. */
+function typographyOverrides(el: Element): string[] {
+  return [...el.classList].filter((c) =>
+    /^(font-.+|text-(xs|sm|base|lg|xl|\d+xl))$/.test(c),
+  );
+}
+
+describe('agent detail breadcrumb typography (#2543)', () => {
+  it('gives parent crumbs and the leaf the same page-title typography', () => {
+    renderDetailLayout();
+
+    // The trail itself carries the page-title typography, so every crumb
+    // inherits the same size and weight…
+    const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    const trail = nav.querySelector('ol');
+    expect(trail).toHaveClass('text-base', 'font-semibold');
+
+    // …matching the leaf `Heading size="base"` (also the `AdaptiveHeaderTitle`
+    // style of the list view and the automations detail breadcrumb).
+    const leaf = screen.getByRole('heading', { level: 1 });
+    expect(leaf).toHaveTextContent('Support Agent');
+    expect(leaf).toHaveClass('text-base', 'font-semibold');
+
+    // Parent crumbs override colour only — no size/weight utility may diverge
+    // from what the trail inherits.
+    for (const crumb of [
+      screen.getByRole('link', { name: 'Agents' }),
+      screen.getByRole('link', { name: 'Workforce' }),
+    ]) {
+      expect(typographyOverrides(crumb)).toEqual([]);
+    }
+  });
+
+  it('shows the localized folder label, never the raw path slug', () => {
+    renderDetailLayout();
+
+    expect(screen.getByRole('link', { name: 'Workforce' })).toBeInTheDocument();
+    expect(screen.queryByText('workforce')).not.toBeInTheDocument();
+  });
+
+  it('marks only the leaf as the current page', () => {
+    const { container } = renderDetailLayout();
+
+    const current = container.querySelectorAll('[aria-current="page"]');
+    expect(current).toHaveLength(1);
+    expect(current[0]).toBe(screen.getByRole('heading', { level: 1 }));
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/app/features/agents/hooks/queries';
 import { AgentConfigProvider } from '@/app/features/agents/hooks/use-agent-config-context';
 import { toConfigurableAgent } from '@/app/features/agents/utils/agent-list-item';
+import { folderLabel } from '@/app/features/agents/utils/folder-label';
 import { configKeys } from '@/app/hooks/config-query-keys';
 import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
@@ -69,6 +70,7 @@ function AgentDetailLayout() {
   const { id: organizationId, agentId } = Route.useParams();
   const { t } = useT('settings');
   const { t: tCommon } = useT('common');
+  const { t: tCatalog } = useT('agentCatalog');
 
   const { data, isLoading, error, refetch } = useReadAgent(
     organizationId,
@@ -132,7 +134,11 @@ function AgentDetailLayout() {
         aria-label={tCommon('aria.breadcrumb')}
         className="flex min-w-0 items-center"
       >
-        <ol className="flex min-w-0 items-center">
+        {/* The whole trail carries the page-title typography (`text-base
+            font-semibold`, matching `Heading size="base"` and the list view's
+            `AdaptiveHeaderTitle`) so parent crumbs and the leaf share one size
+            and weight — parents are dimmed via colour only (#2543). */}
+        <ol className="flex min-w-0 items-center text-base font-semibold">
           <li className="hidden items-center md:flex">
             <Link
               to="/dashboard/$id/agents"
@@ -160,7 +166,10 @@ function AgentDetailLayout() {
                   search={{ folder: path }}
                   className="text-muted-foreground hover:text-foreground focus-visible:ring-ring cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
                 >
-                  {segment}
+                  {/* Localized folder display name, matching the list view's
+                      folder breadcrumb and the catalog sections — never the
+                      raw path segment (#2348). */}
+                  {folderLabel(tCatalog, segment)}
                 </Link>
               </li>
             );


### PR DESCRIPTION
## Problem

On the agent detail page (`/dashboard/$id/agents/$agentId`) the breadcrumb trail rendered parent crumbs (`Agents`, folder segments) as plain links outside the page `Heading`, so they fell back to inherited body typography while only the leaf agent name carried the `text-base font-semibold` page-title style — a visible size/weight mismatch against the automations detail breadcrumb and the agents list header, which style the whole trail uniformly. Folder segments also showed the raw path slug (`workforce`) instead of the localized display label.

## Change

- The `ol` trail now carries the page-title typography (`text-base font-semibold`, matching `Heading size="base"` / `AdaptiveHeaderTitle`), so parent crumbs and the leaf share one size and weight; parents stay dimmed via colour tokens only (`text-muted-foreground` → `hover:text-foreground`).
- Folder segments render `folderLabel(tCatalog, segment)` — the same localized label used by the agents list breadcrumb and the catalog sections (#2348) — never the raw slug.
- The semantic structure is untouched: `nav > ol`, parent crumbs as real links, `aria-current="page"` on the leaf `h1` only.

## Sweep

Checked every other breadcrumb for the same inconsistency:
- Detail breadcrumbs — projects `$projectId`, apps, automations `$amId`: already the canonical single-`Heading` trail. ✅
- List drill-downs — agents, automations: full trail inside `AdaptiveHeaderTitle` (h1). ✅
- Documents `BreadcrumbNavigation`: a content-area breadcrumb with its own intentional compact style, not the page-header pattern — ruled out.

## Verification

- New regression suite `$agentId.breadcrumb.test.tsx` pins the trail typography, the localized folder label, and the leaf-only `aria-current` — verified red on the old code (2/3 fail), green on the fix.
- All agent route suites pass (5 files, 16 tests); platform typecheck and oxlint clean.

Closes #2543