### PR TITLE
test(platform): stub SandboxWorkdirChip in toolbar spacing test

### DIFF
--- a/services/platform/app/features/chat/components/chat-input-agent-toolbar.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input-agent-toolbar.test.tsx
@@ -52,6 +52,9 @@ vi.mock('./external-agent-mode-toggle', () => ({
 vi.mock('./sandbox-state-indicator', () => ({
   SandboxStateIndicator: () => <div data-testid="sandbox-stub" />,
 }));
+vi.mock('./sandbox-workdir-chip', () => ({
+  SandboxWorkdirChip: () => null,
+}));
 vi.mock('./composer-capability-pills', () => ({
   ComposerCapabilityPills: () => null,
 }));


### PR DESCRIPTION
Main's UI test job is red: #2541 added `SandboxWorkdirChip` (which calls Convex hooks) to `ChatInput`, but `chat-input-agent-toolbar.test.tsx` stubs every heavy child except it — the render dies on `useAction` outside a `ConvexProvider`. Adds the missing stub, matching the test's existing pattern. Verified: the test passes locally.