### PR TITLE
fix(platform): stop changelog toast re-firing on non-semver builds

### DIFF
--- a/services/platform/app/hooks/use-changelog-notification.test.ts
+++ b/services/platform/app/hooks/use-changelog-notification.test.ts
@@ -125,6 +125,42 @@ describe('useChangelogNotification', () => {
     expect(result.needsBaseline).toBe(false);
   });
 
+  it('stays quiet on a non-semver build once its version is recorded (#2552)', () => {
+    // docker:dev runs with TALE_VERSION=dev. Comparing 'dev' vs 'dev' cannot
+    // be parsed as semver, but identical strings are never "newer": no toast,
+    // no dot, and no compare-failed warning on every render.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockVersion = 'dev';
+    mockUseQuery.mockReturnValue(
+      row({ lastSeenChangelogVersion: 'dev', lastToastedVersion: 'dev' }),
+    );
+
+    const result = useChangelogNotification();
+
+    expect(result.hasUnseenVersion).toBe(false);
+    expect(result.shouldShowToast).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('still treats differing unparseable versions as newer', () => {
+    // The parse-failure fallback stays: a malformed *stored* value must not
+    // lock the notification dot off.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockUseQuery.mockReturnValue(
+      row({
+        lastSeenChangelogVersion: 'garbage',
+        lastToastedVersion: 'garbage',
+      }),
+    );
+
+    const result = useChangelogNotification();
+
+    expect(result.hasUnseenVersion).toBe(true);
+    expect(result.shouldShowToast).toBe(true);
+    warnSpy.mockRestore();
+  });
+
   it('records the current version when markSeen is called', () => {
     mockUseQuery.mockReturnValue(null);
 

--- a/services/platform/app/hooks/use-changelog-notification.ts
+++ b/services/platform/app/hooks/use-changelog-notification.ts
@@ -7,13 +7,18 @@ import { compareVersions } from '@/lib/compare-versions';
 import { getEnv } from '@/lib/env';
 
 // `candidate` strictly newer than `baseline`. Missing baseline means
-// "never acknowledged" → treat anything as newer. Parse failures fall
-// back to "newer" so a malformed stored value doesn't lock the dot off.
+// "never acknowledged" → treat anything as newer. Identical strings are
+// never newer, whatever their format — this keeps non-semver builds
+// (e.g. TALE_VERSION=dev under docker:dev) quiet once their version is
+// recorded instead of re-toasting on every render (#2552). Parse
+// failures on *differing* values fall back to "newer" so a malformed
+// stored value doesn't lock the dot off.
 function isNewer(
   candidate: string,
   baseline: string | undefined | null,
 ): boolean {
   if (!baseline) return true;
+  if (candidate === baseline) return false;
   try {
     return compareVersions(candidate, baseline) > 0;
   } catch (err) {


### PR DESCRIPTION
## Problem

In a `docker:dev` stack (`TALE_VERSION=dev`), the green **Upgraded to vdev** changelog toast re-fires on essentially every in-app navigation, the account button shows a permanent "Update available" badge, and the console floods with `useChangelogNotification: compare failed (dev vs dev) Error: Cannot compare versions: unable to extract semver from "dev"`.

## Root cause

`isNewer()` in `services/platform/app/hooks/use-changelog-notification.ts` calls `compareVersions()`, which throws for non-semver strings like `dev`. The catch logged a warning and returned `true` ("treat as newer" — a fallback meant for malformed *stored* values), so `shouldShowToast` stayed true even after `markToasted` recorded `lastToastedVersion='dev'`. Every remount of `ChangelogToastTrigger` (fresh `firedRef` per navigation) fired the toast again, and both the dot and toast comparisons warned on every render.

## Fix

Short-circuit `candidate === baseline` to "not newer" before any parsing — identical strings can never be newer, whatever their format. Non-semver builds go quiet as soon as their version is recorded; differing unparseable values keep the treat-as-newer fallback so a malformed stored value still cannot lock the notification dot off. Release builds are unaffected (semver-equal strings already compared to 0).

## Testing

- New regression test `stays quiet on a non-semver build once its version is recorded (#2552)` — fails on the old code (toast/dot true + warning), passes now with zero `console.warn` calls.
- New test locking the retained fallback for differing unparseable values.
- `use-changelog-notification`, `changelog-toast-trigger`, and `user-button` suites green (25 tests); `@tale/platform` typecheck, oxlint, and oxfmt clean.

Closes #2552