### PR TITLE
fix(proxy): route /api/health to the platform through Caddy

### DIFF
--- a/services/platform/tests/integration/container-smoke-test.ts
+++ b/services/platform/tests/integration/container-smoke-test.ts
@@ -216,6 +216,26 @@ async function main(): Promise<number> {
     r.fail('Proxy /health (internal :2020)');
   }
 
+  // Through-proxy platform health: the documented external readiness probe
+  // ({SITE_URL}/api/health — README.md, tests/manual/SETUP.md §1C). Guards the
+  // Caddyfile route: without an explicit /api/health handle the generic /api/*
+  // catch-all sends it to Convex, which 404s (#2553). Self-signed cert, so
+  // skip verification; busybox wget --spider fails on any non-2xx status.
+  if (
+    await dockerExecOk(proxyContainer, [
+      'wget',
+      '--no-check-certificate',
+      '--no-verbose',
+      '--tries=1',
+      '--spider',
+      'https://localhost/api/health',
+    ])
+  ) {
+    r.pass('Proxy routes /api/health to platform');
+  } else {
+    r.fail('Proxy routes /api/health to platform');
+  }
+
   // DB: use pg_isready via docker exec
   const dbContainer = await compose.containerName('db');
   if (

--- a/services/platform/tests/manual/SETUP.md
+++ b/services/platform/tests/manual/SETUP.md
@@ -93,7 +93,7 @@ bun run docker:dev:down   # tear down when finished
   cert — run `docker exec tale-proxy caddy trust`, or ignore HTTPS errors in
   the driving browser; `save-auth-state.ts` below already does).
 - **Readiness**: `curl -skf https://localhost/api/health` returns
-  `{"status":"ok"}` once the platform is up.
+  `{"status":"ok","version":"…"}` once the platform is up.
 - **Seeded login**: the entrypoint creates **`dev@tale.test` /
   `TaleDev!Passw0rd`** owning a "Dev Workspace" org on every boot (idempotent;
   default-on via `TALE_DEV_SEED_USER=1` in `compose.dev.yml`, loopback-only by

--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -147,6 +147,16 @@
 		reverse_proxy convex:6791
 	}
 
+	# HTTP: Platform health endpoint (/api/health -> platform:3000)
+	# The platform owns this route (see services/platform/server.ts); without
+	# this handle the generic /api/* catch-all below sends it to Convex, which
+	# answers 404 "No matching routes found". README.md and the manual-test
+	# SETUP.md document {SITE_URL}/api/health as the external readiness probe,
+	# so it must route through the proxy (#2553).
+	handle /api/health {
+		reverse_proxy platform:3000
+	}
+
 	# HTTP: Convex internal action callbacks (/api/actions/* -> convex:3210)
 	handle /api/actions/* {
 		reverse_proxy convex:3210


### PR DESCRIPTION
## Problem

`services/platform/tests/manual/SETUP.md` §1C documents `curl -skf https://localhost/api/health` as the mode-C (`docker:dev`) readiness probe, and `README.md` (all locales) documents `{SITE_URL}/api/health` as the operator health check — but through the proxy the command exits 22 with body `No matching routes found`. A tester scripting the documented `until curl …` loop waits forever.

## Root cause

`services/proxy/Caddyfile` has explicit handles for `/api/*/sync`, `/api/actions/*`, `/api/sandbox/*`, `/api/storage/*`, then a generic `handle /api/*` catch-all that forwards to `convex:3211`. No route forwards `/api/health` to `platform:3000`, so the path falls into the catch-all and Convex's HTTP router answers 404. The endpoint itself is owned by the platform (`services/platform/server.ts`, `app.get('/api/health', …)`), and Caddy's own active health check dials `platform:3000` directly — which is why the stack is healthy while the external URL 404s.

## Fix

- **`services/proxy/Caddyfile`** — add `handle /api/health { reverse_proxy platform:3000 }` ahead of the generic `/api/*` catch-all, keeping the external contract the READMEs and SETUP.md document.
- **`services/platform/tests/manual/SETUP.md`** — correct the expected body to `{"status":"ok","version":"…"}` (the endpoint always includes `version`).
- **`services/platform/tests/integration/container-smoke-test.ts`** — regression check: probe `https://localhost/api/health` through the proxy container next to the existing internal `:2020` check; fails on the old config (404 from Convex), passes on the new.

## Verification

- `caddy validate` on the new Caddyfile: `Valid configuration`.
- `caddy adapt` route tree confirms `/api/health → platform:3000` sorts ahead of both `/api/*` routes (admin-API matcher and catch-all).
- Live experiment with real Caddy + stub upstreams on a Docker network:
  - old Caddyfile: `wget --no-check-certificate https://localhost/api/health` → **404**, convex stub log shows it received `GET /api/health` (reproduces the issue);
  - new Caddyfile: same probe → **200** `{"status":"ok","version":"stub"}` from the platform stub, exit 0 — including the exact `wget --spider` command the smoke test now uses.
- Swept other `/api/health` consumers (compose healthchecks, CLI deploy/rollback drain, smoke test `:13000` probe, `server.test.ts`) — all dial the platform directly, unaffected.
- `oxlint` and `@tale/platform` typecheck green on the touched TS file.

Closes #2553