### PR TITLE
fix(platform): make project file attach lifecycle leak-proof

### DIFF
--- a/services/platform/app/features/projects/components/project-files-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-files-tab.test.tsx
@@ -38,12 +38,10 @@ vi.mock('../hooks/queries', () => ({
   }),
 }));
 
+const detachMutateAsync = vi.fn().mockResolvedValue(undefined);
 vi.mock('../hooks/mutations', () => ({
-  useAttachDocumentToProject: () => ({
-    mutateAsync: vi.fn().mockResolvedValue({ documentId: 'doc-x' }),
-  }),
   useDetachDocumentFromProject: () => ({
-    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    mutateAsync: detachMutateAsync,
   }),
 }));
 
@@ -161,5 +159,36 @@ describe('ProjectFilesTab', () => {
     expect(screen.getByText('Pending.pdf')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Pending.pdf' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Preview file' })).toBeNull();
+  });
+
+  // Regression coverage for issue #2546 — "Remove from project" silently
+  // published the file to the org-wide Knowledge Hub. The confirmation must
+  // name that consequence and the mutation must carry the explicit
+  // destination.
+  it('names the org-wide consequence in the detach confirmation and detaches with an explicit destination', async () => {
+    documentsFixture = [makeDoc()];
+    const { user } = renderTab();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Remove from project' }),
+    );
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Remove from project',
+    });
+    expect(
+      within(dialog).getByText(/visible to everyone in the organization/i),
+    ).toBeInTheDocument();
+
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Remove from project' }),
+    );
+
+    await waitFor(() => {
+      expect(detachMutateAsync).toHaveBeenCalledWith({
+        documentId: 'doc-1',
+        destination: 'organization',
+      });
+    });
   });
 });

--- a/services/platform/app/features/projects/components/project-files-tab.tsx
+++ b/services/platform/app/features/projects/components/project-files-tab.tsx
@@ -28,10 +28,7 @@ import {
   resolveFileType,
 } from '@/lib/shared/file-types';
 
-import {
-  useAttachDocumentToProject,
-  useDetachDocumentFromProject,
-} from '../hooks/mutations';
+import { useDetachDocumentFromProject } from '../hooks/mutations';
 import { useProject, useProjectDocuments } from '../hooks/queries';
 
 interface ProjectFilesTabProps {
@@ -47,7 +44,6 @@ export function ProjectFilesTab({
   const { project } = useProject(projectId);
   const { documents, isLoading } = useProjectDocuments(projectId);
   const { mutateAsync: detachDocument } = useDetachDocumentFromProject();
-  const { mutateAsync: attachDocument } = useAttachDocumentToProject();
   const { mutateAsync: generateUploadUrl } = useConvexMutation(
     api.files.mutations.generateUploadUrl,
   );
@@ -90,7 +86,10 @@ export function ProjectFilesTab({
         throw new Error('upload response missing storageId');
       }
       const { storageId } = uploadJson;
-      const { documentId } = await createDocumentFromUpload({
+      // One mutation, scoped at insert: the former create-then-attach pair
+      // left the file org-wide in the Knowledge Hub whenever the attach half
+      // failed (issue #2546).
+      await createDocumentFromUpload({
         organizationId,
         fileId: toId<'_storage'>(storageId),
         fileName: file.name,
@@ -104,16 +103,10 @@ export function ProjectFilesTab({
         teamId: undefined,
         folderId: undefined,
         fileSize: file.size,
+        projectId,
       });
-      await attachDocument({ documentId, projectId });
     },
-    [
-      generateUploadUrl,
-      createDocumentFromUpload,
-      attachDocument,
-      organizationId,
-      projectId,
-    ],
+    [generateUploadUrl, createDocumentFromUpload, organizationId, projectId],
   );
 
   const handleFilesSelected = useCallback(
@@ -187,7 +180,7 @@ export function ProjectFilesTab({
   const handleDetach = useCallback(
     async (documentId: Id<'documents'>) => {
       try {
-        await detachDocument({ documentId });
+        await detachDocument({ documentId, destination: 'organization' });
         toast({ title: t('files.detachSuccess'), variant: 'success' });
       } catch (error) {
         if (error instanceof ConvexError) {
@@ -377,7 +370,8 @@ export function ProjectFilesTab({
         }}
         title={t('files.detachAction')}
         description={t('files.detachConfirm', {
-          defaultValue: 'Remove this file from the project?',
+          defaultValue:
+            'Remove this file from the project? It moves to Knowledge and becomes visible to everyone in the organization.',
         })}
         variant="destructive"
         confirmText={t('files.detachAction')}

--- a/services/platform/app/features/projects/hooks/mutations.ts
+++ b/services/platform/app/features/projects/hooks/mutations.ts
@@ -35,10 +35,6 @@ export function useUpdateProjectIntegrationSettings() {
   );
 }
 
-export function useAttachDocumentToProject() {
-  return useConvexMutation(api.projects.mutations.attachDocumentToProject);
-}
-
 export function useDetachDocumentFromProject() {
   return useConvexMutation(api.projects.mutations.detachDocumentFromProject);
 }

--- a/services/platform/convex/documents/create_document.ts
+++ b/services/platform/convex/documents/create_document.ts
@@ -15,6 +15,15 @@ export async function createDocument(
   ctx: MutationCtx,
   args: CreateDocumentArgs,
 ): Promise<CreateDocumentResult> {
+  // A document carries `teamId` OR `projectId`, never both — the same
+  // invariant `attachDocumentToProject` enforces (documents/schema.ts).
+  if (args.projectId && args.teamId) {
+    throw new ConvexError({
+      code: 'DOCUMENT_SCOPE_CONFLICT',
+      message: 'A document cannot be both project- and team-scoped',
+    });
+  }
+
   if (args.folderId) {
     const folder = await ctx.db.get(args.folderId);
     if (!folder || folder.organizationId !== args.organizationId) {
@@ -46,6 +55,7 @@ export async function createDocument(
     externalItemId: args.externalItemId,
     contentHash: args.contentHash,
     ...teamFields,
+    projectId: args.projectId,
     sourceCreatedAt: args.sourceCreatedAt,
     sourceModifiedAt: args.sourceModifiedAt,
     createdBy: args.createdBy,

--- a/services/platform/convex/documents/create_document_from_upload.test.ts
+++ b/services/platform/convex/documents/create_document_from_upload.test.ts
@@ -51,13 +51,14 @@ vi.mock('../auth', () => ({
 // Sources import these directly (not via the lib/rls barrel), so mock the
 // concrete module. The real getAuthUserIdentity is left unmocked so the
 // migrated auth path runs against the mock ctx's ctx.auth.getUserIdentity().
+const mockGetOrgMember = vi.fn();
 vi.mock('../lib/rls/organization/get_organization_member', () => ({
-  getOrganizationMember: vi.fn().mockResolvedValue({
-    _id: 'member_1',
-    organizationId: 'org_1',
-    userId: 'user_1',
-    role: 'member',
-  }),
+  getOrganizationMember: (...args: unknown[]) => mockGetOrgMember(...args),
+}));
+
+const mockCreateAuditLog = vi.fn();
+vi.mock('../audit_logs/helpers', () => ({
+  createAuditLog: (...args: unknown[]) => mockCreateAuditLog(...args),
 }));
 
 vi.mock('../lib/get_user_teams', () => ({
@@ -144,6 +145,12 @@ describe('createDocumentFromUpload', () => {
       documentId: 'doc_created',
     });
     mockHasTeamAccess.mockReturnValue(true);
+    mockGetOrgMember.mockResolvedValue({
+      _id: 'member_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'member',
+    });
   });
 
   it('rejects unauthenticated requests', async () => {
@@ -305,5 +312,153 @@ describe('createDocumentFromUpload', () => {
         teamId: 'team_from_folder',
       }),
     );
+  });
+});
+
+// Regression coverage for issue #2546 — the Files-tab two-step upload
+// (org-wide create, then attach) stranded org-wide hub docs whenever the
+// attach half failed. `createDocumentFromUpload` now accepts a `projectId`
+// and scopes the document at insert, so a project upload never exists as an
+// org-wide row — validation failures reject before anything is written.
+describe('createDocumentFromUpload — project-scoped upload', () => {
+  const PROJECT = {
+    _id: 'project_1',
+    organizationId: 'org_1',
+    name: 'Apollo',
+    teamId: undefined,
+    sharedWithTeamIds: undefined,
+  };
+
+  function projectCtx(project: Record<string, unknown> | null = PROJECT) {
+    const ctx = createMockCtx();
+    ctx.db.get.mockImplementation((id: string) =>
+      Promise.resolve(id === 'project_1' ? project : null),
+    );
+    return ctx;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateDocument.mockResolvedValue({
+      success: true,
+      documentId: 'doc_created',
+    });
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    // Project writes require an editor-capable role (mirrors
+    // `assertWritable` in convex/projects/mutations.ts).
+    mockGetOrgMember.mockResolvedValue({
+      _id: 'member_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'editor',
+    });
+  });
+
+  it('creates the document project-scoped in the same insert', async () => {
+    const ctx = projectCtx();
+    const handler = await getHandler();
+
+    const result = await handler(ctx, { ...baseArgs, projectId: 'project_1' });
+
+    expect(result).toEqual({ success: true, documentId: 'doc_created' });
+    expect(mockCreateDocument).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ projectId: 'project_1' }),
+    );
+  });
+
+  it('records a project file-attach audit entry and bumps the project', async () => {
+    const ctx = projectCtx();
+    const handler = await getHandler();
+
+    await handler(ctx, { ...baseArgs, projectId: 'project_1' });
+
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        action: 'project.file.attached',
+        resourceId: 'project_1',
+        resourceName: 'Apollo',
+        metadata: expect.objectContaining({ documentId: 'doc_created' }),
+      }),
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith('project_1', {
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it('rejects a project upload combined with a team scope', async () => {
+    const ctx = projectCtx();
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...baseArgs, projectId: 'project_1', teamId: 'team_1' }),
+    ).rejects.toMatchObject({ data: { code: 'DOCUMENT_SCOPE_CONFLICT' } });
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects a project upload combined with a folder', async () => {
+    const ctx = projectCtx();
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, {
+        ...baseArgs,
+        projectId: 'project_1',
+        folderId: 'folder_1',
+      }),
+    ).rejects.toMatchObject({ data: { code: 'DOCUMENT_SCOPE_CONFLICT' } });
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the project does not exist', async () => {
+    const ctx = projectCtx(null);
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...baseArgs, projectId: 'project_1' }),
+    ).rejects.toMatchObject({ data: { code: 'PROJECT_NOT_FOUND' } });
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects a project that belongs to another organization', async () => {
+    const ctx = projectCtx({ ...PROJECT, organizationId: 'org_other' });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...baseArgs, projectId: 'project_1' }),
+    ).rejects.toMatchObject({ data: { code: 'ORG_FORBIDDEN' } });
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller who can read but not edit the project', async () => {
+    mockGetOrgMember.mockResolvedValue({
+      _id: 'member_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'member',
+    });
+    const ctx = projectCtx();
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...baseArgs, projectId: 'project_1' }),
+    ).rejects.toMatchObject({ data: { code: 'RBAC_FORBIDDEN' } });
+    // Failed validation must not write anything — no document row and no
+    // file-metadata row (the stranded-file symptom from the two-step flow).
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller outside the project teams', async () => {
+    // getUserTeamIds is mocked to ['team_1']; a project owned by another
+    // team is unreadable for a non-admin.
+    const ctx = projectCtx({ ...PROJECT, teamId: 'team_locked' });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...baseArgs, projectId: 'project_1' }),
+    ).rejects.toMatchObject({ data: { code: 'PROJECT_FORBIDDEN' } });
+    expect(mockCreateDocument).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -10,6 +10,7 @@ import {
 } from '../../lib/shared/schemas/utils/json-value';
 import { internal } from '../_generated/api';
 import { mutation } from '../_generated/server';
+import { createAuditLog } from '../audit_logs/helpers';
 import { assertNotHeld } from '../governance/legal_hold_guard';
 import { checkUploadPolicy } from '../governance/upload_enforcement';
 import { markEntryChainDeleted } from '../knowledge_entries/helpers';
@@ -18,6 +19,11 @@ import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { hasTeamAccess } from '../lib/team_access';
 import { stopSyncForDeletedDocument } from '../onedrive/deactivate_sync_configs';
+import { checkProjectAccess } from '../projects/access';
+import {
+  PROJECT_AUDIT_ACTIONS,
+  PROJECT_RESOURCE_TYPE,
+} from '../projects/audit_actions';
 import { createDocument } from './create_document';
 import { extractExtension } from './extract_extension';
 import { updateDocument as updateDocumentHelper } from './update_document';
@@ -143,6 +149,10 @@ export const createDocumentFromUpload = mutation({
     teamId: v.optional(v.string()),
     folderId: v.optional(v.id('folders')),
     fileSize: v.optional(v.number()),
+    // Scope the document to a project at insert. The former two-step flow
+    // (org-wide create, then attachDocumentToProject) left the file in the
+    // org-wide hub whenever the attach half failed (issue #2546).
+    projectId: v.optional(v.id('projects')),
   },
   returns: v.object({
     success: v.boolean(),
@@ -157,7 +167,50 @@ export const createDocumentFromUpload = mutation({
       });
     }
 
-    await getOrganizationMember(ctx, args.organizationId, authUser);
+    const member = await getOrganizationMember(
+      ctx,
+      args.organizationId,
+      authUser,
+    );
+
+    // Project-scoped upload: validate the target project before anything is
+    // written so a rejected upload leaves no stranded rows behind. Mirrors
+    // `assertWritable` in convex/projects/mutations.ts.
+    const project = args.projectId ? await ctx.db.get(args.projectId) : null;
+    if (args.projectId) {
+      if (args.teamId || args.folderId) {
+        throw new ConvexError({
+          code: 'DOCUMENT_SCOPE_CONFLICT',
+          message: 'A project document cannot also carry a team or folder',
+        });
+      }
+      if (!project) {
+        throw new ConvexError({
+          code: 'PROJECT_NOT_FOUND',
+          message: 'Project not found',
+        });
+      }
+      if (project.organizationId !== args.organizationId) {
+        throw new ConvexError({
+          code: 'ORG_FORBIDDEN',
+          message: 'Project belongs to a different organization',
+        });
+      }
+      const teamIds = await getUserTeamIds(ctx, authUser.userId);
+      const access = checkProjectAccess(project, teamIds, member.role);
+      if (!access.canRead) {
+        throw new ConvexError({
+          code: 'PROJECT_FORBIDDEN',
+          message: 'You do not have access to this project',
+        });
+      }
+      if (!access.canEdit) {
+        throw new ConvexError({
+          code: 'RBAC_FORBIDDEN',
+          message: 'You do not have permission to add files to this project',
+        });
+      }
+    }
 
     const resolvedContentType = resolveFileType(
       args.fileName,
@@ -234,6 +287,7 @@ export const createDocumentFromUpload = mutation({
       contentHash: args.contentHash,
       sourceProvider: 'upload',
       teamId: effectiveTeamId,
+      projectId: args.projectId,
       metadata: args.metadata,
       createdBy: authUser.userId,
       folderId: args.folderId,
@@ -247,6 +301,28 @@ export const createDocumentFromUpload = mutation({
           documentId: result.documentId,
         },
       );
+    }
+
+    if (project) {
+      // Same trail `attachDocumentToProject` writes, so a create-in-project
+      // upload is auditable as a file-attach scope transition.
+      await ctx.db.patch(project._id, { updatedAt: Date.now() });
+      await createAuditLog(ctx, {
+        organizationId: args.organizationId,
+        actorId: userId,
+        actorEmail: authUser.email,
+        actorType: 'user',
+        action: PROJECT_AUDIT_ACTIONS.fileAttached,
+        category: 'data',
+        resourceType: PROJECT_RESOURCE_TYPE,
+        resourceId: String(project._id),
+        resourceName: project.name,
+        metadata: {
+          documentId: String(result.documentId),
+          previousTeamId: null,
+        },
+        status: 'success',
+      });
     }
 
     return {

--- a/services/platform/convex/documents/types.ts
+++ b/services/platform/convex/documents/types.ts
@@ -68,6 +68,12 @@ export interface CreateDocumentArgs {
   externalItemId?: string;
   contentHash?: string;
   teamId?: string;
+  /**
+   * Project scope, set at insert so a project upload never exists as an
+   * org-wide row, even transiently (issue #2546). Mutually exclusive with
+   * `teamId` — see `documents/schema.ts`.
+   */
+  projectId?: Id<'projects'>;
   createdBy?: string;
   folderId?: Id<'folders'>;
   folderPath?: string;

--- a/services/platform/convex/projects/detach_document_from_project.test.ts
+++ b/services/platform/convex/projects/detach_document_from_project.test.ts
@@ -1,0 +1,198 @@
+// Regression coverage for issue #2546 — "Remove from project" cleared
+// `documents.projectId` with no destination semantics, silently publishing
+// the file to the org-wide Knowledge Hub. Detach now demands an explicit
+// destination at the API surface and the audit log records the scope
+// transition.
+//
+// The mutation factory is mocked to hand the config straight through (same
+// pattern as documents/create_document_from_upload.test.ts) so the handler
+// bodies are unit-testable without a running backend; the real `ConvexError`
+// is preserved so structured throws construct correctly.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('convex/values', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const stub = () => 'validator';
+  return {
+    ...actual,
+    v: {
+      string: stub,
+      number: stub,
+      boolean: stub,
+      optional: stub,
+      id: stub,
+      object: stub,
+      union: stub,
+      literal: stub,
+      array: stub,
+      null: stub,
+      record: stub,
+    },
+  };
+});
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    mutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+const mockGetOrgMember = vi.fn();
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: (...args: unknown[]) => mockGetOrgMember(...args),
+}));
+
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: vi.fn().mockResolvedValue(['team_1']),
+}));
+
+vi.mock('../lib/rate_limiter/helpers', () => ({
+  checkUserRateLimit: vi.fn().mockResolvedValue(undefined),
+  RateLimitExceededError: class RateLimitExceededError extends Error {
+    retryAfter = 0;
+  },
+}));
+
+const mockCreateAuditLog = vi.fn();
+vi.mock('../audit_logs/helpers', () => ({
+  createAuditLog: (...args: unknown[]) => mockCreateAuditLog(...args),
+}));
+
+vi.mock('../workflows/triggers/emit_event', () => ({
+  emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+// `defineTable` insists on real validators, which the `v` stub above breaks;
+// mutations.ts only pulls the mode validators from the schema module.
+vi.mock('./schema', () => ({
+  projectModeValidator: 'validator',
+  projectKnowledgeModeValidator: 'validator',
+  projectIntegrationsModeValidator: 'validator',
+}));
+
+type Handler = (
+  ctx: unknown,
+  args: Record<string, unknown>,
+) => Promise<unknown>;
+
+async function getMutation(): Promise<{
+  args: Record<string, unknown>;
+  handler: Handler;
+}> {
+  const { detachDocumentFromProject } = await import('./mutations');
+  return detachDocumentFromProject as unknown as {
+    args: Record<string, unknown>;
+    handler: Handler;
+  };
+}
+
+const AUTH_USER = { userId: 'user_1', email: 'test@example.com' };
+
+const PROJECT = {
+  _id: 'project_1',
+  organizationId: 'org_1',
+  name: 'Apollo',
+  teamId: undefined,
+  sharedWithTeamIds: undefined,
+};
+
+const DOC = {
+  _id: 'doc_1',
+  organizationId: 'org_1',
+  projectId: 'project_1',
+};
+
+function createMockCtx(fixtures: Record<string, unknown>) {
+  return {
+    db: {
+      get: vi.fn((id: string) => Promise.resolve(fixtures[id] ?? null)),
+      patch: vi.fn().mockResolvedValue(undefined),
+      insert: vi.fn().mockResolvedValue('row_new'),
+    },
+  };
+}
+
+describe('detachDocumentFromProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthUserIdentity.mockResolvedValue(AUTH_USER);
+    mockGetOrgMember.mockResolvedValue({
+      _id: 'member_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'editor',
+    });
+  });
+
+  it('declares an explicit destination argument (no silent publish)', async () => {
+    const detach = await getMutation();
+
+    // The Convex arg validator is the enforcement: a caller cannot detach
+    // without stating where the file lands.
+    expect(detach.args).toHaveProperty('destination');
+  });
+
+  it('clears projectId and audits the scope transition', async () => {
+    const ctx = createMockCtx({ doc_1: DOC, project_1: PROJECT });
+    const detach = await getMutation();
+
+    await detach.handler(ctx, {
+      documentId: 'doc_1',
+      destination: 'organization',
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('doc_1', {
+      projectId: undefined,
+    });
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        action: 'project.file.detached',
+        resourceId: 'project_1',
+        metadata: expect.objectContaining({
+          documentId: 'doc_1',
+          destination: 'organization',
+        }),
+      }),
+    );
+  });
+
+  it('is a no-op for a document not attached to any project', async () => {
+    const ctx = createMockCtx({
+      doc_1: { ...DOC, projectId: undefined },
+    });
+    const detach = await getMutation();
+
+    await detach.handler(ctx, {
+      documentId: 'doc_1',
+      destination: 'organization',
+    });
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(mockCreateAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('still requires project edit access', async () => {
+    mockGetOrgMember.mockResolvedValue({
+      _id: 'member_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'member',
+    });
+    const ctx = createMockCtx({ doc_1: DOC, project_1: PROJECT });
+    const detach = await getMutation();
+
+    await expect(
+      detach.handler(ctx, { documentId: 'doc_1', destination: 'organization' }),
+    ).rejects.toMatchObject({ data: { code: 'RBAC_FORBIDDEN' } });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/projects/mutations.ts
+++ b/services/platform/convex/projects/mutations.ts
@@ -8,8 +8,10 @@
  *
  * Mutual exclusivity rule for documents:
  *   A document carries `teamId` OR `projectId`, never both.
- *   `attachDocumentToProject` clears `teamId`. `detachDocumentFromProject`
- *   leaves both null (doc becomes a library doc).
+ *   `attachDocumentToProject` requires `teamId` empty.
+ *   `detachDocumentFromProject` leaves both null (doc becomes an org-wide
+ *   library doc) — which is why it demands an explicit `destination` and
+ *   audits the scope transition (issue #2546).
  */
 
 import { ConvexError, v } from 'convex/values';
@@ -951,6 +953,14 @@ export const attachDocumentToProject = mutation({
 export const detachDocumentFromProject = mutation({
   args: {
     documentId: v.id('documents'),
+    /**
+     * Where the file lands once the project gate is removed. Detach cannot
+     * restore a team scope (attach requires `teamId` empty), so the document
+     * becomes org-wide — the caller must say so explicitly instead of the
+     * doc being published silently (issue #2546). Widen to a union if team
+     * destinations or delete-on-detach are added.
+     */
+    destination: v.literal('organization'),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -981,7 +991,12 @@ export const detachDocumentFromProject = mutation({
       resourceType: PROJECT_RESOURCE_TYPE,
       resourceId: String(project._id),
       resourceName: project.name,
-      metadata: { documentId: String(args.documentId) },
+      // Record the scope transition: the resource is the project the file
+      // left; `destination` names where it became visible.
+      metadata: {
+        documentId: String(args.documentId),
+        destination: args.destination,
+      },
       status: 'success',
     });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7918,6 +7918,7 @@
       "ragStatusCompleted": "Indexiert",
       "ragStatusFailed": "Fehlgeschlagen",
       "detachAction": "Aus Projekt entfernen",
+      "detachConfirm": "Diese Datei aus dem Projekt entfernen? Sie wird nach „Wissen“ verschoben und ist dann für alle in der Organisation sichtbar.",
       "previewAction": "Datei anzeigen",
       "detachSuccess": "Dokument aus Projekt entfernt",
       "detachError": "Dokument konnte nicht entfernt werden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5300,6 +5300,7 @@
       "ragStatusCompleted": "Indexed",
       "ragStatusFailed": "Failed",
       "detachAction": "Remove from project",
+      "detachConfirm": "Remove this file from the project? It moves to Knowledge and becomes visible to everyone in the organization.",
       "previewAction": "Preview file",
       "detachSuccess": "Document removed from project",
       "detachError": "Couldn't remove document",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7919,6 +7919,7 @@
       "ragStatusCompleted": "Indexé",
       "ragStatusFailed": "Échec",
       "detachAction": "Retirer du projet",
+      "detachConfirm": "Retirer ce fichier du projet ? Il sera déplacé vers « Connaissances » et deviendra visible par toute l'organisation.",
       "previewAction": "Aperçu du fichier",
       "detachSuccess": "Document retiré du projet",
       "detachError": "Impossible de retirer le document",


### PR DESCRIPTION
## Problem

Two leaks in the project-file attach lifecycle (#2546):

1. **Two-step upload window.** The Files tab uploaded via `createDocumentFromUpload` (an org-wide hub doc) and attached it to the project in a second mutation. If the attach half failed, the file was stranded org-wide in the Knowledge Hub with no marker it was meant for a project.
2. **Detach = silent publish.** `detachDocumentFromProject` cleared `projectId` with no destination semantics — "Remove from project" silently made the file visible to the whole organization, and the audit entry recorded no scope transition.

## Fix

- `createDocumentFromUpload` accepts an optional `projectId` and scopes the document **at insert** (`convex/documents/mutations.ts`): validated before anything is written — project exists, same org, caller can edit (mirrors `assertWritable`), and mutually exclusive with `teamId`/`folderId`. It writes the same `project.file.attached` audit entry and project `updatedAt` bump the attach mutation writes. `createDocument` also guards the `teamId`/`projectId` exclusivity invariant.
- `detachDocumentFromProject` now requires an explicit `destination: 'organization'` arg (extensible union) and records the scope transition in the audit metadata.
- The Files tab uploads with a single mutation (no create-then-attach pair), and its detach confirmation names the consequence ("It moves to Knowledge and becomes visible to everyone in the organization") — new `files.detachConfirm` locale string in en/de/fr.

## Tests (red on old code, green now)

- `convex/documents/create_document_from_upload.test.ts`: project-scoped insert, attach audit entry, and rejection paths (scope conflict, missing project, cross-org, non-editor, outside project teams) — each rejection asserts nothing was written (the stranded-file symptom).
- `convex/projects/detach_document_from_project.test.ts` (new): destination arg declared, scope transition audited, no-op and RBAC paths locked.
- `app/features/projects/components/project-files-tab.test.tsx`: the confirmation names the org-wide consequence and confirming detaches with the explicit destination.

Platform server suite (711 files / 74,966 tests), typecheck, oxlint, i18n parity, and knip all green.

Closes #2546