### PR TITLE
fix(platform): make apps hub cards link to the app detail page

### DIFF
--- a/services/platform/app/components/catalog/catalog-grid.tsx
+++ b/services/platform/app/components/catalog/catalog-grid.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Slot } from '@radix-ui/react-slot';
 import { Card, CardGrid, CardMedia } from '@tale/ui/card';
 import { type ReactNode } from 'react';
 
@@ -54,6 +55,14 @@ interface CatalogCardProps {
    * buttons own the clicks; `onClick` is then ignored (no nested buttons).
    */
   actions?: ReactNode;
+  /**
+   * Makes the whole card navigate: a single link element (e.g. a router
+   * `<Link>` carrying an `aria-label` for its accessible name) stretched over
+   * the card as an overlay. Unlike `onClick`, this composes with `actions` —
+   * the footer stays operable above the overlay (a link can't nest buttons,
+   * so the overlay sits underneath them). Ignored on the `onClick` button card.
+   */
+  link?: ReactNode;
   /** Makes the whole card a button (only when there are no `actions`). */
   onClick?: () => void;
   disabled?: boolean;
@@ -70,6 +79,7 @@ export function CatalogCard({
   badge,
   meta,
   actions,
+  link,
   onClick,
   disabled,
   active,
@@ -100,7 +110,10 @@ export function CatalogCard({
         <div className="mt-2 flex flex-wrap items-center gap-1.5">{meta}</div>
       ) : null}
       {actions ? (
-        <div className="mt-auto flex items-center justify-end gap-2 pt-3">
+        // `relative` lifts the footer above the stretched `link` overlay
+        // (positioned siblings paint in DOM order), keeping every action
+        // clickable on a linked card.
+        <div className="relative mt-auto flex items-center justify-end gap-2 pt-3">
           {actions}
         </div>
       ) : null}
@@ -136,13 +149,24 @@ export function CatalogCard({
   return (
     <Card
       padding="md"
+      interactive={Boolean(link)}
       className={cn(
         'flex h-full flex-col',
+        link && 'relative',
         catalogCardSurfaceClass,
         active && 'ring-2 ring-primary',
         className,
       )}
     >
+      {link ? (
+        // Stretched-overlay link (same pattern as the conversations list): the
+        // whole card is one click/tab target while the footer actions — later
+        // positioned siblings — stay operable above it. The overlay carries
+        // its own focus ring since focus lands on the anchor, not the card.
+        <Slot className="focus-visible:ring-ring absolute inset-0 rounded-[inherit] focus-visible:ring-2 focus-visible:outline-none">
+          {link}
+        </Slot>
+      ) : null}
       {inner}
     </Card>
   );

--- a/services/platform/app/features/apps/components/apps-grid.test.tsx
+++ b/services/platform/app/features/apps/components/apps-grid.test.tsx
@@ -15,10 +15,13 @@ import { AppsGrid } from './apps-grid';
  * union/precedence/sort is asserted directly.
  */
 
-const { useAppsMock, useAppCatalogMock } = vi.hoisted(() => ({
-  useAppsMock: vi.fn(),
-  useAppCatalogMock: vi.fn(),
-}));
+const { useAppsMock, useAppCatalogMock, useAppInstallStatesMock } = vi.hoisted(
+  () => ({
+    useAppsMock: vi.fn(),
+    useAppCatalogMock: vi.fn(),
+    useAppInstallStatesMock: vi.fn(),
+  }),
+);
 
 vi.mock('../hooks/use-apps', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/use-apps')>()),
@@ -27,10 +30,12 @@ vi.mock('../hooks/use-apps', async (importOriginal) => ({
 }));
 
 vi.mock('../hooks/use-install-state', () => ({
-  // Keep the install-state map empty so every card renders the catalog
-  // (not-installed) Install branch; the union we are testing comes from
-  // useApps (installed list) vs useAppCatalog, independent of install state.
-  useAppInstallStates: () => ({ bySlug: new Map(), isLoading: false }),
+  // Defaults to an empty install-state map (see beforeEach) so every card
+  // renders the catalog (not-installed) Install branch; the union tests come
+  // from useApps (installed list) vs useAppCatalog, independent of install
+  // state. The #2554 navigation tests override it to reach the installed
+  // (Open) branch.
+  useAppInstallStates: useAppInstallStatesMock,
   useAppInstallActions: () => ({ install: vi.fn(), isPending: false }),
 }));
 
@@ -76,6 +81,10 @@ function app(overrides: Partial<AppSummary> = {}): AppSummary {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  useAppInstallStatesMock.mockReturnValue({
+    bySlug: new Map(),
+    isLoading: false,
+  });
 });
 
 describe('AppsGrid catalog/installed union (#1979)', () => {
@@ -101,9 +110,9 @@ describe('AppsGrid catalog/installed union (#1979)', () => {
 
   // The card title is the union's identity: CatalogCard renders the app name
   // as the card's title text, in DOM order = the sorted union. Assert against
-  // those titles rather than card-level links — the refactor moved navigation
-  // into the footer action (Open/Install), so install-state-empty cards no
-  // longer carry a link, but the union/precedence/sort invariant is unchanged.
+  // those titles rather than card-level links (covered separately by the
+  // #2554 navigation tests below) so the union/precedence/sort invariant
+  // stays independent of the card's link markup.
   it('renders the union of installed and catalog apps, keyed by slug', () => {
     useAppsMock.mockReturnValue({
       apps: [app({ slug: 'installed-only', name: 'Installed Only' })],
@@ -205,5 +214,69 @@ describe('AppsGrid catalog/installed union (#1979)', () => {
     expect(
       screen.getAllByText(/Apple|Mango|Zebra/).map((el) => el.textContent),
     ).toStrictEqual(['Apple', 'Mango', 'Zebra']);
+  });
+});
+
+/**
+ * Regression net for #2554: every hub card — including an AVAILABLE
+ * (uninstalled) one, whose only footer action is the Install button — must be
+ * a real link to the app's detail page with accessible name = the app name
+ * (apps.md A1), so the detail page is reachable by mouse and keyboard from
+ * the hub. The card link is a stretched overlay; the footer actions must stay
+ * operable above it.
+ */
+describe('AppsGrid card navigation (#2554)', () => {
+  it('renders an available (uninstalled) app card as a link named after the app', () => {
+    useAppsMock.mockReturnValue({ apps: [], isLoading: false, error: null });
+    useAppCatalogMock.mockReturnValue({
+      apps: [app({ slug: 'issue-desk', name: 'Issue resolution desk' })],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AppsGrid organizationId="org_1" />);
+
+    // A real anchor (keyboard reachable by role) with a11y name = app name.
+    expect(
+      screen.getByRole('link', { name: 'Issue resolution desk' }),
+    ).toBeInTheDocument();
+    // The Install action still renders alongside the card link.
+    expect(screen.getByRole('button', { name: 'Install' })).toBeEnabled();
+  });
+
+  it('renders an installed app card as a link named after the app, next to Open', () => {
+    useAppsMock.mockReturnValue({
+      apps: [app({ slug: 'installed-app', name: 'Installed App' })],
+      isLoading: false,
+      error: null,
+    });
+    useAppCatalogMock.mockReturnValue({
+      apps: [app({ slug: 'installed-app', name: 'Installed App' })],
+      isLoading: false,
+      error: null,
+    });
+    useAppInstallStatesMock.mockReturnValue({
+      bySlug: new Map([
+        [
+          'installed-app',
+          {
+            appSlug: 'installed-app',
+            status: 'active' as const,
+            installedAt: 1,
+            blockedIntegrations: [],
+          },
+        ],
+      ]),
+      isLoading: false,
+    });
+
+    render(<AppsGrid organizationId="org_1" />);
+
+    expect(
+      screen.getByRole('link', { name: 'Installed App' }),
+    ).toBeInTheDocument();
+    // The footer Open link stays a distinct, operable control above the
+    // card's overlay link.
+    expect(screen.getByRole('link', { name: 'Open' })).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/apps/components/apps-grid.tsx
+++ b/services/platform/app/features/apps/components/apps-grid.tsx
@@ -2,9 +2,10 @@
 
 /** The Apps hub landing: a config-driven grid of apps in the shared catalog
  * style (the same `CatalogCard` grid the agents, automations, and integrations
- * catalogs use). Each app is a first-class apps/<slug>/app.json bundle. A card
- * shows the app's install state badge and carries the lifecycle in its footer:
- * Install (not installed) or Open + the ⋯ menu (installed). */
+ * catalogs use). Each app is a first-class apps/<slug>/app.json bundle. Every
+ * card is a link to the app's detail page (accessible name = the app name),
+ * shows the app's install state badge, and carries the lifecycle in its
+ * footer: Install (not installed) or Open + the ⋯ menu (installed). */
 import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { Card, CardGrid } from '@tale/ui/card';
@@ -206,6 +207,17 @@ export function AppsGrid({
                 }
                 title={app.name}
                 description={app.description}
+                // Every card — installed or still available — is a link to the
+                // app's detail page (accessible name = the app name), so the
+                // detail page is reachable by mouse and keyboard from the hub
+                // before deciding to install (#2554).
+                link={
+                  <Link
+                    to="/dashboard/$id/apps/$appSlug"
+                    params={{ id: organizationId, appSlug: app.slug }}
+                    aria-label={app.name}
+                  />
+                }
                 badge={
                   <>
                     {isPrivate && <Badge variant="slate">{t('private')}</Badge>}


### PR DESCRIPTION
## Problem

On `/dashboard/{org}/apps`, the card for an **available (uninstalled)** app was a plain `<div>`: its only interactive element was the Install button, so the app's detail page was unreachable by mouse or keyboard from the hub. The manual test guide's accessibility expectation (`services/platform/tests/manual/apps.md` A1) says each hub card is a link with accessible name = the app name.

Root cause: the apps-v2 rework moved navigation into the card footer actions — `CatalogCard` renders a static container whenever `actions` are present — and only installed cards received an **Open** link. Available cards had no path to `/apps/{slug}` at all.

## Fix

- `CatalogCard` gains a `link` slot: a single link element rendered as a stretched overlay (`absolute inset-0`, own focus ring), reusing the overlay pattern already shipped in the conversations list and chat history sidebar. The footer actions row is `relative`, so it paints above the overlay and every action stays clickable.
- The apps hub passes an overlay `<Link>` to the detail route with `aria-label={app.name}` on **every** card — installed and available — so apps.md A1 holds uniformly.

## Verification

- Regression tests in `apps-grid.test.tsx` (red on `main`, green here): an available card exposes `role=link` with accessible name = the app name and the Install button stays enabled; an installed card carries both the card link and the footer Open link.
- Real-browser hit-testing of the overlay structure (Playwright): a click on the card body hits the link, a click on Install hits the button, and tab order is card link → Install.
- Touched suites green (apps-grid, integration-card, agent-catalog, workflow-template-grid), `@tale/platform` typecheck green, oxlint clean.

Closes #2554