### PR TITLE
fix(platform): add missing organization ID description i18n key

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5384,6 +5384,7 @@
       "nameRequired": "Organisationsname ist erforderlich",
       "localeDescription": "Die Hauptsprache deiner Organisation.",
       "organizationId": "Organisations-ID",
+      "organizationIdDescription": "Die eindeutige Kennung deiner Organisation.",
       "membersSectionTitle": "Mitglieder",
       "membersDescription": "Personen, die Zugriff auf diese Organisation haben.",
       "membersEntityLabel": "Mitglieder",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5649,6 +5649,7 @@
       "nameRequired": "Organization name is required",
       "localeDescription": "Primary language for your organization.",
       "organizationId": "Organization ID",
+      "organizationIdDescription": "The unique identifier for your organization.",
       "membersSectionTitle": "Members",
       "membersDescription": "People who have access to this organization.",
       "membersEntityLabel": "members",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5385,6 +5385,7 @@
       "nameRequired": "Le nom de l'organisation est requis",
       "localeDescription": "La langue principale de ton organisation.",
       "organizationId": "ID de l'organisation",
+      "organizationIdDescription": "L'identifiant unique de ton organisation.",
       "membersSectionTitle": "Membres",
       "membersDescription": "Personnes ayant accès à cette organisation.",
       "membersEntityLabel": "membres",


### PR DESCRIPTION
Closes #2563

## Summary

On `/dashboard/{org}/settings/organization`, the Organization ID field's description rendered the raw i18n key `organization.organizationIdDescription` — the component (`organization-settings.tsx:202`) references the key, but it was missing from every locale file, so next-intl printed the key itself.

This adds the key next to its siblings in `services/platform/messages/{en,de,fr}.json`, each written natively in the sibling register:

- en: "The unique identifier for your organization."
- de: "Die eindeutige Kennung deiner Organisation."
- fr: "L'identifiant unique de ton organisation."

`de-CH.json` is override-only and inherits the de wording via the fallback chain — no Swiss divergence (no ß, no currency/number formatting), so no override is added.

## Test plan

- `bunx vitest --run --project server lib/i18n/messages.test.ts` — 23 passed. The enforce-mode parity check now guards the key: verified it fails (`fr.json is missing 1 keys: settings.organization.organizationIdDescription`) when the key is removed from one locale, and passes with all three in place.
- `bun run --filter @tale/platform typecheck` — clean.
- `bun run --filter @tale/platform lint` — 0 warnings, 0 errors.

## Out of scope (same class, reported separately)

`organization.copyOrganizationId` — the copy-button aria-label on the same row (`organization-settings.tsx:207`) — is also missing from all locales (screen readers get the raw key). Not fixed here per issue scope; noted so it can be tracked. The parity/usage suite catches JSON→code orphans and cross-locale drift, but nothing catches a code-referenced key missing from `en.json` — the recurring class behind #2055/#1978/#2563.