### PR TITLE
fix(sandbox): suppress SAST false positives in pi and openclaw runners

### DIFF
--- a/services/sandbox-runtime/tale-openclaw-run
+++ b/services/sandbox-runtime/tale-openclaw-run
@@ -275,6 +275,7 @@ def main() -> int:
             "0",
         ]
         proc = subprocess.run(
+            # nosemgrep: tools.opengrep.rules.python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args -- fixed openclaw argv plus adapter-provided flags, list-form exec (no shell); launching the agent CLI inside the sandbox is this runner's purpose, same trust model as the sibling tale-*-run launchers
             cmd,
             cwd=args.workdir,
             env=env,

--- a/services/sandbox-runtime/tale-pi-run
+++ b/services/sandbox-runtime/tale-pi-run
@@ -133,6 +133,7 @@ def main() -> int:
             cmd += ["--session", args.resume]
 
         proc = subprocess.Popen(
+            # nosemgrep: tools.opengrep.rules.python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args -- fixed pi argv plus adapter-provided flags, list-form exec (no shell); launching the agent CLI inside the sandbox is this runner's purpose, same trust model as the sibling tale-*-run launchers
             cmd,
             cwd=args.workdir,
             env=env,


### PR DESCRIPTION
## Summary

The required **Opengrep** gate has been failing on `main` since the pi (#2550) and openclaw (#2555) sandbox runners landed: both trip `dangerous-subprocess-use-tainted-env-args` on their agent-CLI launch call. Their sibling `tale-gemini-run` (#2535) shipped with the sanctioned inline `# nosemgrep` suppression for exactly this pattern; the two newer runners did not — so every PR now fails the gate regardless of its diff (e.g. the latest `main` run on 5124b7454 and current open PRs).

Both findings are false positives by the same argument the gemini suppression documents: list-form `subprocess` exec (no shell) of a fixed argv plus adapter-provided flags, and launching the agent CLI inside the sandbox is the runner's entire purpose. This adds the same one-line suppression (with per-runner reason) to `tale-pi-run` and `tale-openclaw-run`.

## Test plan

- `bun run lint:sast`: both `dangerous-subprocess-use-tainted-env-args` findings gone (0 matches). Note when running from a non-standard checkout path the rule-ID namespace shifts and unrelated *excluded* rules (e.g. `wget-unencrypted-url`, listed in `tools/opengrep/excluded-rules.txt`) resurface — path artifact only; CI runs from the repo root where IDs match.
- Diff is two comment lines; no behaviour change.