### PR TITLE
fix(platform): hide uninstalled app agents from assignee and mention pickers

### DIFF
--- a/services/platform/convex/agents/file_actions.test.ts
+++ b/services/platform/convex/agents/file_actions.test.ts
@@ -716,10 +716,17 @@ describe('listAgents app scope (#2564)', () => {
       runMutation: vi.fn().mockResolvedValue(undefined),
       runQuery: vi.fn().mockResolvedValue(['issue-desk']),
     };
-    mockReaddir.mockResolvedValue([
-      'desk-implementer.json',
-      'desk-reviewer.json',
-    ]);
+    // Both issue-desk (installed) and issue-desk-qa (uploaded, never installed)
+    // may exist on disk; only the installed slug should be scanned.
+    mockReaddir.mockImplementation(async (dir: string) => {
+      if (dir === '/data/apps/issue-desk/agents') {
+        return ['desk-implementer.json', 'desk-reviewer.json'];
+      }
+      if (dir === '/data/apps/issue-desk-qa/agents') {
+        return ['desk-implementer.json', 'desk-reviewer.json'];
+      }
+      throw new Error(`unexpected readdir: ${dir}`);
+    });
     mockReadJsonFile.mockImplementation(async () => ({
       ok: true,
       data: {
@@ -736,7 +743,11 @@ describe('listAgents app scope (#2564)', () => {
     expect(ctx.runQuery).toHaveBeenCalledWith('listAppInstallationsInternal', {
       organizationId: 'org-123',
     });
+    expect(mockReaddir).toHaveBeenCalledTimes(1);
     expect(mockReaddir).toHaveBeenCalledWith('/data/apps/issue-desk/agents');
+    expect(mockReaddir).not.toHaveBeenCalledWith(
+      '/data/apps/issue-desk-qa/agents',
+    );
     expect(rows.some((row) => row.slug === 'issue-desk/desk-implementer')).toBe(
       true,
     );

--- a/services/platform/convex/agents/file_actions.test.ts
+++ b/services/platform/convex/agents/file_actions.test.ts
@@ -36,6 +36,11 @@ vi.mock('../_generated/api', () => ({
       installations: { getInstallationInternal: 'getInstallationInternal' },
       audit_mutations: { logAgentAuditEvent: 'logAgentAuditEvent' },
     },
+    apps: {
+      install_mutations: {
+        listAppInstallationsInternal: 'listAppInstallationsInternal',
+      },
+    },
     organizations: {
       internal_queries: {
         getOrganizationDefaultLocale: 'getOrganizationDefaultLocale',
@@ -68,6 +73,7 @@ vi.mock('../lib/file_io', () => ({
   atomicWrite: (...args: unknown[]) => mockAtomicWrite(...args),
   readJsonFile: (...args: unknown[]) => mockReadJsonFile(...args),
   readFileSafe: (...args: unknown[]) => mockReadFileSafe(...args),
+  handleDirReadError: vi.fn(),
   sha256: () => 'mock-hash',
   generateHistoryTimestamp: () => '1234567890-abcdef01',
   pruneHistory: vi.fn(),
@@ -89,6 +95,8 @@ vi.mock('./file_utils', async () => {
       `/data/agents/${rel}`,
     resolveHistoryDir: (_orgSlug: string, agentName: string) =>
       `/data/agents/.history/${agentName}`,
+    resolveAppAgentsDir: (_orgSlug: string, app: string) =>
+      `/data/apps/${app}/agents`,
     walkAgentRelativePaths: async () => [],
   };
 });
@@ -118,12 +126,21 @@ vi.mock('../../lib/shared/schemas/agents', () => ({
   },
 }));
 
+vi.mock('../../lib/shared/schemas/apps', () => ({
+  isValidAppSlug: () => true,
+}));
+
 // ---------------------------------------------------------------------------
 // Import handlers
 // ---------------------------------------------------------------------------
 
-const { deleteAgent, duplicateAgent, restoreFromHistory, setAgentAuthMode } =
-  await import('./file_actions');
+const {
+  deleteAgent,
+  duplicateAgent,
+  restoreFromHistory,
+  setAgentAuthMode,
+  listAgents,
+} = await import('./file_actions');
 
 type ActionConfig = {
   handler: (ctx: never, args: never) => Promise<unknown>;
@@ -134,6 +151,7 @@ const duplicateHandler = (duplicateAgent as unknown as ActionConfig).handler;
 const restoreHandler = (restoreFromHistory as unknown as ActionConfig).handler;
 const setAuthModeHandler = (setAgentAuthMode as unknown as ActionConfig)
   .handler;
+const listAgentsHandler = (listAgents as unknown as ActionConfig).handler;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -684,5 +702,62 @@ describe('setAgentAuthMode', () => {
       ),
     ).rejects.toThrow('authMode only applies to an external-agent.');
     expect(mockAtomicWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe('listAgents app scope (#2564)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgMembershipById.mockResolvedValue({ orgSlug: 'default' });
+  });
+
+  it('lists app agents only for installed apps, not every on-disk bundle', async () => {
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue(undefined),
+      runQuery: vi.fn().mockResolvedValue(['issue-desk']),
+    };
+    mockReaddir.mockResolvedValue([
+      'desk-implementer.json',
+      'desk-reviewer.json',
+    ]);
+    mockReadJsonFile.mockImplementation(async () => ({
+      ok: true,
+      data: {
+        displayName: 'Desk Agent',
+      },
+      hash: 'hash',
+    }));
+
+    const rows = (await listAgentsHandler(
+      ctx as never,
+      { organizationId: 'org-123' } as never,
+    )) as Array<{ slug: string; appSlug?: string }>;
+
+    expect(ctx.runQuery).toHaveBeenCalledWith('listAppInstallationsInternal', {
+      organizationId: 'org-123',
+    });
+    expect(mockReaddir).toHaveBeenCalledWith('/data/apps/issue-desk/agents');
+    expect(rows.some((row) => row.slug === 'issue-desk/desk-implementer')).toBe(
+      true,
+    );
+    expect(rows.some((row) => row.slug === 'issue-desk/desk-reviewer')).toBe(
+      true,
+    );
+    expect(rows.some((row) => row.slug.startsWith('issue-desk-qa/'))).toBe(
+      false,
+    );
+  });
+
+  it('returns no app agents when nothing is installed', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue([]);
+
+    const rows = (await listAgentsHandler(
+      ctx as never,
+      { organizationId: 'org-123' } as never,
+    )) as Array<{ slug: string }>;
+
+    expect(mockReaddir).not.toHaveBeenCalled();
+    expect(rows).toEqual([]);
   });
 });

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -25,7 +25,6 @@ import { normalizeAgentConfig } from '../../lib/shared/utils/normalize-agent-con
 import { resolveAgentLocale } from '../../lib/shared/utils/resolve-agent-locale';
 import { internal } from '../_generated/api';
 import { action, internalAction, type ActionCtx } from '../_generated/server';
-import { listInstalledAppSlugsFromDisk } from '../apps/file_utils';
 import type { SerializableAgentConfig } from '../lib/agent_chat/types';
 import { requireOrgAdminOrDeveloper } from '../lib/auth/require_org_admin_or_developer';
 import {
@@ -303,9 +302,13 @@ export const listAgents = action({
     );
 
     // App-owned agents (org/apps/<app>/agents/) — invisible to the global walk
-    // above. Surface them too, grouped under their app (folder = app slug) and
-    // tagged with appSlug so the global agents list can mark the group.
-    const appSlugs = await listInstalledAppSlugsFromDisk(orgSlug);
+    // above. Surface only INSTALLED apps: uploaded private bundles also live
+    // under org/apps/ but must not contribute agents until install (and private
+    // uploads keep the bundle on disk after uninstall, so a disk scan is wrong).
+    const appSlugs = await ctx.runQuery(
+      internal.apps.install_mutations.listAppInstallationsInternal,
+      { organizationId: args.organizationId },
+    );
     const appResults = (
       await Promise.all(
         appSlugs.map(async (app) => {

--- a/services/platform/convex/apps/file_utils.ts
+++ b/services/platform/convex/apps/file_utils.ts
@@ -52,10 +52,11 @@ export function resolveCatalogAppDir(slug: string): string {
 }
 
 /**
- * Slugs of the apps installed in this org, by scanning `org/apps/` subdirectories.
- * The on-disk bundle is the source of truth for which app owns a resource, so the
- * global agent/workflow lists use this to know which app dirs to also scan and
- * tag. A missing `org/apps/` root means no installed apps.
+ * Slugs of every app BUNDLE present on disk under `org/apps/` (uploaded private
+ * apps and installed shells). NOT the install signal — `appInstallations` is
+ * authoritative for which apps are live. Used where all bundles must be
+ * discovered (e.g. hub listing); agent/workflow pickers must query
+ * `listAppInstallationsInternal` instead. A missing `org/apps/` root → `[]`.
  */
 export async function listInstalledAppSlugsFromDisk(
   orgSlug: string,

--- a/services/platform/convex/apps/install_mutations.test.ts
+++ b/services/platform/convex/apps/install_mutations.test.ts
@@ -517,3 +517,27 @@ describe('reconcileAppSchedules', () => {
     });
   });
 });
+
+describe('listAppInstallationsInternal (#2564)', () => {
+  it('returns only app slugs with an appInstallations row', async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('appInstallations', {
+        organizationId: ORG,
+        appSlug: 'issue-desk',
+        installedAt: 0,
+        installedBy: 'tester',
+        status: 'active',
+        requiredIntegrations: [],
+        resources: [],
+      });
+    });
+
+    const slugs = await t.query(
+      internal.apps.install_mutations.listAppInstallationsInternal,
+      { organizationId: ORG },
+    );
+
+    expect(slugs).toEqual(['issue-desk']);
+  });
+});


### PR DESCRIPTION
## Summary

- `listAgents` enumerated app-owned agents by scanning every bundle on disk under `org/apps/`, including uploaded-but-never-installed private apps.
- Switched to `listAppInstallationsInternal` (the `appInstallations` DB table) so only installed apps contribute agents to the task assignee picker and comment @-mention picker.
- Clarified `listInstalledAppSlugsFromDisk` doc comment: disk bundles ≠ installed apps.

Closes #2564

## Test plan

- [x] `convex/agents/file_actions.test.ts` — `listAgents` lists app agents only for installed apps; returns none when nothing is installed
- [x] `convex/apps/install_mutations.test.ts` — `listAppInstallationsInternal` returns only slugs with an `appInstallations` row
- [ ] Manual: upload a private app without installing → agents absent from assignee/@-mention pickers; install → appear; uninstall → gone

## Definition of done

- [x] **Green gate** — regression tests pass locally (`file_actions.test.ts` 23/23)
- [x] **Security gate** — no boundary changes; read-only query swap
- [x] **Tests** — handler unit tests + query integration test added
- [x] **Migration** — N/A (no schema change)
- [x] **Locales** — N/A (backend-only)
- [x] **Docs** — N/A (internal behaviour fix)
- [x] **Accessibility** — N/A (no UI changes)
- [x] **Sweep** — `workflows/file_actions.ts` still uses disk scan for automations list (out of scope per issue)
- [x] **Observed** — unit tests verify installed-only enumeration
- [x] **Commits** — single atomic conventional commit on desk branch


Made with [Cursor](https://cursor.com)