### PR TITLE
feat(platform): explicit run_code modes with packages-only install

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -53,6 +53,8 @@ import {
   useChatAgents,
   useResolvedHumanInputRequests,
   useSessionProgress,
+  isAgentActivelyWorking,
+  isAgentLingeringSteerReady,
 } from '../hooks/queries';
 import { useArenaThreadSetup } from '../hooks/use-arena-thread-setup';
 import { useChatScroll } from '../hooks/use-chat-scroll';
@@ -339,8 +341,11 @@ export function ChatInterface({
   useReportServerNow(threadMeta?.serverNow);
   const { toClientEpoch } = useClockOffset();
   const isGenerating = threadMeta?.isGenerating;
-  const agentLingering = sessionProgress?.agentIdleAt != null;
-  const agentActivelyWorking = (isGenerating ?? false) && !agentLingering;
+  const agentActivelyWorking = isAgentActivelyWorking(
+    isGenerating,
+    sessionProgress,
+  );
+  const agentLingeringSteerReady = isAgentLingeringSteerReady(sessionProgress);
 
   // Bridge the active message's live `file_write` tool calls into the
   // StreamingToolContext for the canvas pane. See hook.
@@ -1458,7 +1463,7 @@ export function ChatInterface({
                 className="mx-auto w-full max-w-(--chat-max-width)"
                 placeholder={
                   queueModeActive
-                    ? agentLingering
+                    ? agentLingeringSteerReady
                       ? t('queue.placeholderIdle')
                       : t('queue.placeholder')
                     : isImageGenAgent

--- a/services/platform/app/features/chat/components/sandbox-chip.test.tsx
+++ b/services/platform/app/features/chat/components/sandbox-chip.test.tsx
@@ -18,7 +18,11 @@ vi.mock('../context/chat-layout-context', () => ({
   }),
 }));
 
-vi.mock('../hooks/queries', () => ({
+// Partial mock: hooks are stubbed, but pure helpers (isAgentActivelyWorking
+// & co.) stay real — the component's working-state derivation is behaviour
+// under test, not test plumbing.
+vi.mock('../hooks/queries', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../hooks/queries')>()),
   useChatAgents: () => ({
     agents: [{ name: 'claude-code', primaryBehavior: 'external-agent' }],
   }),

--- a/services/platform/app/features/chat/components/sandbox-chip.tsx
+++ b/services/platform/app/features/chat/components/sandbox-chip.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils/cn';
 import { useChatLayout } from '../context/chat-layout-context';
 import {
   useChatAgents,
+  isAgentActivelyWorking,
   useSessionProgress,
   useThreadSandboxState,
 } from '../hooks/queries';
@@ -212,14 +213,9 @@ export function SandboxChip({
   }, [persist]);
 
   if (!isExternal) return null;
-  // "Working" means a turn is actively running — NOT a finished turn whose
-  // process is merely lingering idle on held-open stdin (agentIdleAt set) to
-  // receive the next message. Subtracting the lingering marker keeps this pill
-  // in lockstep with the composer's running-state (see `agentActivelyWorking`
-  // in chat-interface): both read `status === 'running' && agentIdleAt == null`
-  // so the page never shows "Working" beside a "finished" composer.
-  const running =
-    progress?.status === 'running' && progress?.agentIdleAt == null;
+  // "Working" means a turn is actively running — NOT steer-ready linger on
+  // held-open stdin. Background tasks still count as working.
+  const running = isAgentActivelyWorking(meta?.isGenerating, progress);
 
   const Spinner = prefersReducedMotion ? Loader2 : SpinningLoader;
 

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -350,6 +350,31 @@ export function useSessionProgress(threadId: string | null | undefined) {
   return data ?? null;
 }
 
+export type SessionProgress = NonNullable<
+  ReturnType<typeof useSessionProgress>
+>;
+
+/** Active-work affordances (Working pill, stop, streaming) — false during
+ * steer-ready linger, true while background tasks still run. */
+export function isAgentActivelyWorking(
+  isGenerating: boolean | undefined,
+  progress: SessionProgress | null,
+): boolean {
+  if (!isGenerating) return false;
+  if (progress?.agentIdleAt == null) return true;
+  return (progress.pendingBackgroundTasks ?? 0) > 0;
+}
+
+/** Linger with no background work — steer/next message can go through stdin. */
+export function isAgentLingeringSteerReady(
+  progress: SessionProgress | null,
+): boolean {
+  return (
+    progress?.agentIdleAt != null &&
+    (progress.pendingBackgroundTasks ?? 0) === 0
+  );
+}
+
 /**
  * The thread's live sandbox-session lifecycle state (creating/active/degraded/
  * stopped + pinned), for the ambient "Sandbox" status pill. Null for normal

--- a/services/platform/app/features/chat/hooks/use-message-processing.test.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.test.ts
@@ -14,7 +14,10 @@ const queryResults = new Map<string, unknown>();
 // Drives the mocked `useSessionProgress` (the thread's live sandbox op).
 // null = no sandbox op / no linger (the normal-chat + actively-generating
 // cases); set `agentIdleAt` to simulate an external-agent turn lingering.
-let mockSessionProgress: { agentIdleAt?: number } | null = null;
+let mockSessionProgress: {
+  agentIdleAt?: number;
+  pendingBackgroundTasks?: number;
+} | null = null;
 
 function functionPath(queryRef: unknown): string {
   if (typeof queryRef === 'object' && queryRef !== null) {
@@ -59,9 +62,13 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'org-1',
 }));
 
-vi.mock('./queries', () => ({
-  useSessionProgress: vi.fn(() => mockSessionProgress),
-}));
+vi.mock('./queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./queries')>();
+  return {
+    ...actual,
+    useSessionProgress: vi.fn(() => mockSessionProgress),
+  };
+});
 
 const mockChatLayout: { pendingMessage: unknown } = { pendingMessage: null };
 vi.mock('../context/chat-layout-context', () => ({
@@ -783,6 +790,33 @@ describe('useMessageProcessing', () => {
         (m) => m.key === 'msg-2',
       );
       expect(lingeringMsg?.isStreaming).toBe(false);
+    });
+
+    it('keeps the last pending assistant streaming while background tasks run during linger', () => {
+      setGenerating(true);
+      mockSessionProgress = {
+        agentIdleAt: 1_700_000_000_000,
+        pendingBackgroundTasks: 1,
+      };
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({ id: 'msg-1', order: 0, role: 'user', text: 'Go' }),
+          createUIMessage({
+            id: 'msg-2',
+            order: 1,
+            role: 'assistant',
+            text: 'Running sleep in background…',
+            status: 'pending',
+            parts: settledToolParts,
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      const activeMsg = result.current.messages.find((m) => m.key === 'msg-2');
+      expect(activeMsg?.isStreaming).toBe(true);
     });
 
     it('does not treat the last pending assistant as streaming once generation stops', () => {

--- a/services/platform/app/features/chat/hooks/use-message-processing.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.ts
@@ -22,7 +22,7 @@ import {
   sameParts,
 } from '../utils/message-equality';
 import { hasInFlightTool } from '../utils/thought-predicates';
-import { useSessionProgress } from './queries';
+import { isAgentActivelyWorking, useSessionProgress } from './queries';
 
 const INTERNAL_ATTACHMENT_MARKER =
   /\n?\n?\[ATTACHED FILES - Pre-analysis was not available\. Use your tools to process these files\.\]/;
@@ -251,8 +251,10 @@ export function useMessageProcessing(
   // agree. `useSessionProgress` is null for normal-chat threads (no sandbox
   // op), so `effectiveGenerating` collapses to plain `isGenerating` there.
   const sessionProgress = useSessionProgress(threadId);
-  const agentLingering = sessionProgress?.agentIdleAt != null;
-  const effectiveGenerating = !!isGenerating && !agentLingering;
+  const effectiveGenerating = isAgentActivelyWorking(
+    isGenerating,
+    sessionProgress,
+  );
 
   // Client-side pending-send signal. When the user has just clicked send
   // but the new user message hasn't been persisted yet, `pendingMessage` is

--- a/services/platform/app/features/workspace/components/live-browser-pane.tsx
+++ b/services/platform/app/features/workspace/components/live-browser-pane.tsx
@@ -466,7 +466,9 @@ function LiveBrowserPaneComponent({ available }: LiveBrowserPaneProps) {
   const state = useThreadSandboxState(threadId);
   const progress = useSessionProgress(threadId);
   const running =
-    progress?.status === 'running' && progress?.agentIdleAt == null;
+    progress?.status === 'running' &&
+    (progress.agentIdleAt == null ||
+      (progress.pendingBackgroundTasks ?? 0) > 0);
   const sessionActive = running || state?.status === 'active';
 
   // Manual "Reset browser" — the last-resort recovery for a wedged browser the

--- a/services/platform/app/routes/dashboard/$id/settings/governance/run-code-policy.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/run-code-policy.tsx
@@ -16,7 +16,10 @@ import { useUpsertGovernancePolicy } from '@/app/features/settings/governance/ho
 import { useGovernancePolicy } from '@/app/features/settings/governance/hooks/queries';
 import { useAbility } from '@/app/hooks/use-ability';
 import { useToast } from '@/app/hooks/use-toast';
-import { packageBaseName } from '@/convex/agent_tools/files/_shared';
+import {
+  evaluatePackageAgainstPolicy,
+  packageBaseName,
+} from '@/convex/agent_tools/files/_shared';
 import { useT } from '@/lib/i18n/client';
 import { runCodePolicyConfigSchema } from '@/lib/shared/schemas/governance';
 import { cn } from '@/lib/utils/cn';
@@ -57,8 +60,9 @@ interface FormState {
 }
 
 // Parse a comma- or newline-separated list of package names into a deduped
-// array. Blank lines / empty entries are dropped; matching is case-sensitive
-// (pip and npm both treat names case-sensitively on disk).
+// array. Blank lines / empty entries are dropped. Entries keep their typed
+// casing for display; evaluation lowercases both sides
+// (`evaluatePackageAgainstPolicy`).
 function parseList(value: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
@@ -89,24 +93,30 @@ interface DecisionDeny {
 
 type Decision = DecisionAllow | DecisionDeny;
 
+// Thin i18n adapter over the shared evaluator — the tester must show exactly
+// what the runtime gate will decide, so the semantics live in one place.
 function evaluateSpec(
   spec: string,
   bucket: Bucket,
   draft: PolicyDraft,
 ): Decision {
-  const base = packageBaseName(spec);
-  const allow = bucket === 'python' ? draft.pythonAllow : draft.nodeAllow;
-  const deny = bucket === 'python' ? draft.pythonDeny : draft.nodeDeny;
-
-  if (draft.defaultMode === 'allowlist') {
-    return allow.includes(base)
-      ? { decision: 'allowed', reasonKey: 'reasonAllowlistMatch' }
-      : { decision: 'denied', reasonKey: 'reasonAllowlistMiss' };
+  const verdict = evaluatePackageAgainstPolicy(spec, bucket, draft);
+  if (verdict.allowed) {
+    return {
+      decision: 'allowed',
+      reasonKey:
+        verdict.reason === 'allowlist_match'
+          ? 'reasonAllowlistMatch'
+          : 'reasonDenylistNotMatched',
+    };
   }
-  // denylist mode: blocked iff base is on the deny list.
-  return deny.includes(base)
-    ? { decision: 'denied', reasonKey: 'reasonDenylistMatch' }
-    : { decision: 'allowed', reasonKey: 'reasonDenylistNotMatched' };
+  return {
+    decision: 'denied',
+    reasonKey:
+      verdict.reason === 'deny_match'
+        ? 'reasonDenylistMatch'
+        : 'reasonAllowlistMiss',
+  };
 }
 
 interface TestRow {

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -75,6 +75,7 @@ import type * as agent_tools_human_input_actions from "../agent_tools/human_inpu
 import type * as agent_tools_human_input_internal_mutations from "../agent_tools/human_input/internal_mutations.js";
 import type * as agent_tools_human_input_mutations from "../agent_tools/human_input/mutations.js";
 import type * as agent_tools_human_input_request_human_input_tool from "../agent_tools/human_input/request_human_input_tool.js";
+import type * as agent_tools_inline_language from "../agent_tools/inline_language.js";
 import type * as agent_tools_integrations_approval_result from "../agent_tools/integrations/approval_result.js";
 import type * as agent_tools_integrations_capture_sources from "../agent_tools/integrations/capture_sources.js";
 import type * as agent_tools_integrations_create_bound_integration_tool from "../agent_tools/integrations/create_bound_integration_tool.js";
@@ -1770,6 +1771,7 @@ declare const fullApi: ApiFromModules<{
   "agent_tools/human_input/internal_mutations": typeof agent_tools_human_input_internal_mutations;
   "agent_tools/human_input/mutations": typeof agent_tools_human_input_mutations;
   "agent_tools/human_input/request_human_input_tool": typeof agent_tools_human_input_request_human_input_tool;
+  "agent_tools/inline_language": typeof agent_tools_inline_language;
   "agent_tools/integrations/approval_result": typeof agent_tools_integrations_approval_result;
   "agent_tools/integrations/capture_sources": typeof agent_tools_integrations_capture_sources;
   "agent_tools/integrations/create_bound_integration_tool": typeof agent_tools_integrations_create_bound_integration_tool;

--- a/services/platform/convex/agent_tools/files/_shared.ts
+++ b/services/platform/convex/agent_tools/files/_shared.ts
@@ -222,6 +222,7 @@ export function refinePackagesObject(
  * Extract the base package name from a pip/npm spec for allowlist matching.
  *   `python-pptx==1.0.2` → `python-pptx`
  *   `pypdf>=5.1,<6`     → `pypdf`
+ *   `sharp@1.2.3`       → `sharp`
  *   `@scope/pkg@1.2.3`  → `@scope/pkg`
  */
 export function packageBaseName(spec: string): string {
@@ -232,8 +233,10 @@ export function packageBaseName(spec: string): string {
     const at = trimmed.indexOf('@', 1);
     return at === -1 ? trimmed : trimmed.slice(0, at);
   }
-  // Strip first occurrence of any version delimiter.
-  const delim = trimmed.search(/[<>=!~ \t]/);
+  // Strip first occurrence of any version delimiter — `@` included, so the
+  // unscoped npm `name@version` form matches its policy entry too (pip's
+  // PEP 508 `name @ url` form is already split at the space).
+  const delim = trimmed.search(/[<>=!~ \t@]/);
   return delim === -1 ? trimmed : trimmed.slice(0, delim);
 }
 

--- a/services/platform/convex/agent_tools/files/_shared.ts
+++ b/services/platform/convex/agent_tools/files/_shared.ts
@@ -237,6 +237,44 @@ export function packageBaseName(spec: string): string {
   return delim === -1 ? trimmed : trimmed.slice(0, delim);
 }
 
+/**
+ * THE run_code package-policy semantics — the runtime gate
+ * (`run_code_tool.ts`) and the admin policy tester (`run-code-policy.tsx`)
+ * both decide through this function so they can never drift: matching is on
+ * the spec's base name, case-insensitive (pip normalizes names per PEP 503;
+ * npm names are lowercase by registry rule), and an explicit deny always
+ * wins — even in allowlist mode.
+ */
+export type PackagePolicyDecision =
+  | { allowed: true; reason: 'allowlist_match' | 'denylist_not_matched' }
+  | { allowed: false; reason: 'deny_match' | 'allowlist_miss' };
+
+export function evaluatePackageAgainstPolicy(
+  spec: string,
+  bucket: 'python' | 'node',
+  policy: {
+    defaultMode: 'allowlist' | 'denylist';
+    pythonAllow: string[];
+    pythonDeny: string[];
+    nodeAllow: string[];
+    nodeDeny: string[];
+  },
+): PackagePolicyDecision {
+  const base = packageBaseName(spec).toLowerCase();
+  const norm = (list: string[]) => list.map((s) => s.trim().toLowerCase());
+  const deny = norm(bucket === 'python' ? policy.pythonDeny : policy.nodeDeny);
+  if (deny.includes(base)) return { allowed: false, reason: 'deny_match' };
+  if (policy.defaultMode === 'allowlist') {
+    const allow = norm(
+      bucket === 'python' ? policy.pythonAllow : policy.nodeAllow,
+    );
+    return allow.includes(base)
+      ? { allowed: true, reason: 'allowlist_match' }
+      : { allowed: false, reason: 'allowlist_miss' };
+  }
+  return { allowed: true, reason: 'denylist_not_matched' };
+}
+
 /** Convert a `_shared.ts` zod refinement helper signature into the form
  *  consumed by zod's `.superRefine(val, ctx)` callback. */
 export function makeZodPackagesRefiner(): (

--- a/services/platform/convex/agent_tools/inline_language.test.ts
+++ b/services/platform/convex/agent_tools/inline_language.test.ts
@@ -1,0 +1,157 @@
+// The inline run_code pre-flight: LANGUAGE_MISMATCH scoring (per-declared-
+// language signal tables over literal-stripped code) and PREFER_PACKAGES
+// install detection. The false-positive cases matter as much as the true
+// positives — the validator is fail-open by contract.
+
+import { describe, expect, it } from 'vitest';
+
+import { stripLiterals, validateInlineCode } from './inline_language';
+
+describe('stripLiterals', () => {
+  it('blanks quoted strings so their content cannot score', () => {
+    const out = stripLiterals('echo "import os" > /user/output/x.py', 'bash');
+    expect(out).not.toContain('import os');
+  });
+
+  it('blanks bash heredoc bodies', () => {
+    const code = 'python3 <<EOF\nimport os\nprint(os.getcwd())\nEOF\necho ok';
+    const out = stripLiterals(code, 'bash');
+    expect(out).not.toContain('import os');
+    expect(out).toContain('echo ok');
+  });
+
+  it('strips comments but keeps the shebang line', () => {
+    const out = stripLiterals('#!/bin/bash\n# import os\nls', 'bash');
+    expect(out).toContain('#!/bin/bash');
+    expect(out).not.toContain('import os');
+  });
+
+  it('strips node line comments without eating URLs', () => {
+    const out = stripLiterals(
+      "const u = 'https://x.test' // import os\n",
+      'node',
+    );
+    expect(out).toContain('const u =');
+    expect(out).not.toContain('import os');
+  });
+});
+
+describe('validateInlineCode — LANGUAGE_MISMATCH', () => {
+  it('rejects Python source declared as bash (the classic failure)', () => {
+    const issue = validateInlineCode('import os\nprint(os.getcwd())', 'bash');
+    expect(issue?.code).toBe('LANGUAGE_MISMATCH');
+    expect(issue?.message).toContain('looks like python');
+    expect(issue?.message).toContain('resubmit with language: "python"');
+  });
+
+  it('rejects a Python def declared as node', () => {
+    const issue = validateInlineCode(
+      'def main():\n    return 1\nmain()',
+      'node',
+    );
+    expect(issue?.code).toBe('LANGUAGE_MISMATCH');
+  });
+
+  it('rejects JS declared as python', () => {
+    const issue = validateInlineCode(
+      "const fs = require('node:fs')\nconsole.log(fs.readdirSync('.'))",
+      'python',
+    );
+    expect(issue?.code).toBe('LANGUAGE_MISMATCH');
+    expect(issue?.message).toContain('looks like node');
+  });
+
+  it('rejects a shell script declared as python', () => {
+    const issue = validateInlineCode(
+      '#!/bin/bash\nfor f in *.txt; do\n  echo "$f"\ndone',
+      'python',
+    );
+    expect(issue?.code).toBe('LANGUAGE_MISMATCH');
+    expect(issue?.message).toContain('looks like bash');
+  });
+
+  it('never auto-corrects: the verdict only names the suspected language', () => {
+    const issue = validateInlineCode('import os\nprint(1)', 'bash');
+    expect(issue?.message).toContain('not auto-corrected');
+  });
+
+  it.each([
+    ['plain bash', 'ls -la /user/output && du -sh /user/uploads', 'bash'],
+    [
+      'bash driving python via heredoc',
+      'python3 <<EOF\nimport os\nprint(1)\nEOF',
+      'bash',
+    ],
+    [
+      'bash echoing python source',
+      'echo "import os" > /user/output/gen.py',
+      'bash',
+    ],
+    ['bash pipeline', 'cat data.csv | grep -v "^#" | sort | head -5', 'bash'],
+    [
+      'python with strings full of shell',
+      'import subprocess\nsubprocess.run(["ls", "-la"])',
+      'python',
+    ],
+    [
+      'node ESM',
+      "import fs from 'node:fs'\nconst names = fs.readdirSync('/user/output')\nconsole.log(names)",
+      'node',
+    ],
+    ['python one-liner', 'print(sum(range(10)))', 'python'],
+    ['bash with a single weak signal', 'print_report --format=json', 'bash'],
+  ] as const)('fails open on %s', (_label, code, language) => {
+    expect(validateInlineCode(code, language)).toBeNull();
+  });
+});
+
+describe('validateInlineCode — PREFER_PACKAGES', () => {
+  it.each([
+    ['bash pip install', 'pip install pandas', 'bash'],
+    [
+      'bash pip3 with chained run',
+      'pip3 install requests && python3 x.py',
+      'bash',
+    ],
+    ['python -m pip', 'python3 -m pip install numpy', 'bash'],
+    ['pip install typed as python', 'pip install pandas', 'python'],
+    ['npm global install', 'npm install -g typescript', 'bash'],
+    ['npm i --global', 'npm i --global sharp', 'bash'],
+    [
+      'python subprocess pip',
+      "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'pip', 'install', 'foo'])",
+      'python',
+    ],
+    [
+      'node execSync npm -g',
+      "const { execSync } = require('node:child_process')\nexecSync('npm install -g sharp')",
+      'node',
+    ],
+  ] as const)(
+    'routes %s to the packages parameter',
+    (_label, code, language) => {
+      const issue = validateInlineCode(code, language);
+      expect(issue?.code).toBe('PREFER_PACKAGES');
+      expect(issue?.message).toContain('`packages` parameter');
+    },
+  );
+
+  it.each([
+    ['requirements file', 'pip install -r requirements.txt', 'bash'],
+    ['editable install', 'pip install -e .', 'bash'],
+    ['local dir install', 'pip install .', 'bash'],
+    [
+      'project-local npm install',
+      'cd /user/code && npm install && node index.mjs',
+      'bash',
+    ],
+    ['quoted mention only', 'echo "run pip install pandas yourself"', 'bash'],
+    [
+      'commented mention next to a spawn',
+      'import subprocess\n# TODO: pip install later\nsubprocess.run(["ls"])',
+      'python',
+    ],
+  ] as const)('keeps %s allowed', (_label, code, language) => {
+    expect(validateInlineCode(code, language)).toBeNull();
+  });
+});

--- a/services/platform/convex/agent_tools/inline_language.ts
+++ b/services/platform/convex/agent_tools/inline_language.ts
@@ -1,0 +1,279 @@
+/**
+ * Pre-sandbox validation for inline `run_code` snippets.
+ *
+ * Two structured, repairable rejections:
+ * - `LANGUAGE_MISMATCH` — the snippet's syntax contradicts the declared
+ *   `language` (the classic failure: Python code sent as bash dies with
+ *   `import: command not found` and costs a sandbox round-trip).
+ * - `PREFER_PACKAGES` — ad-hoc package installs in inline code (`pip install
+ *   x`, `npm install -g y`); those must go through the `packages` parameter
+ *   where the org policy can see them.
+ *
+ * FAIL-OPEN BY DESIGN. A missed mismatch costs one sandbox round-trip plus a
+ * stderr hint; a false rejection blocks a legitimate run. So only
+ * high-confidence contradictions reject: string/heredoc/comment bodies are
+ * stripped before scoring, signals are weighted (3 = individually decisive,
+ * i.e. never valid in the declared language; 2 = strong), and the threshold
+ * is score ≥ 4, or ≥ 3 including a 3-point signal. The declared language is
+ * never auto-corrected — the model resubmits.
+ */
+
+export type InlineLanguage = 'python' | 'node' | 'bash';
+
+export interface InlineCodeIssue {
+  code: 'LANGUAGE_MISMATCH' | 'PREFER_PACKAGES';
+  message: string;
+}
+
+/**
+ * Blank out the parts of a snippet that are data, not code, so quoted text
+ * (`echo "import os"`) and heredoc bodies (often a different language by
+ * design) never score as language signals. Lossy on purpose — mangling an
+ * exotic construct only *loses* signals, which fails open.
+ */
+export function stripLiterals(code: string, language: InlineLanguage): string {
+  let out = code;
+  if (language === 'bash') {
+    out = out.replace(
+      /<<-?\s*(['"]?)(\w+)\1[^\n]*\n[\s\S]*?\n\s*\2\s*(?=\n|$)/g,
+      '<<HEREDOC',
+    );
+  }
+  if (language === 'python') {
+    out = out.replace(/[rbfu]{0,2}(?:'''[\s\S]*?'''|"""[\s\S]*?""")/gi, "''");
+  }
+  // Backtick spans: JS template literals; in bash they are command
+  // substitution (code), but treating them as literal only loses signals.
+  out = out.replace(/`(?:\\.|[^`\\])*`/g, '``');
+  out = out.replace(/"(?:\\.|[^"\\\n])*"/g, '""');
+  out = out.replace(/'(?:\\.|[^'\\\n])*'/g, "''");
+  if (language === 'node') {
+    out = out
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  } else {
+    // `#` comments — but never the `#!` shebang, which is a scoring signal.
+    out = out.replace(/(^|[^&\w])#(?!!)[^\n]*/g, '$1');
+  }
+  return out;
+}
+
+interface Signal {
+  weight: 2 | 3;
+  /** Matched against the stripped code — or the raw shebang line. */
+  test: RegExp;
+  shebang?: boolean;
+  describe: string;
+}
+
+/** Signals that a snippet is written in the KEYED language — scored only for
+ * languages other than the declared one, so e.g. `#!/bin/bash` under
+ * `language: "bash"` never counts against itself. */
+const LANGUAGE_SIGNALS: Record<InlineLanguage, Signal[]> = {
+  python: [
+    {
+      weight: 3,
+      test: /^#!.*\bpython/,
+      shebang: true,
+      describe: 'a Python shebang',
+    },
+    {
+      weight: 3,
+      test: /^\s*def\s+\w+\s*\([^)\n]*\)\s*:/m,
+      describe: 'a Python `def …():` definition',
+    },
+    {
+      // Bare `import x` / `import x as y` / `from x import y` — an ESM
+      // import never ends at the module name (it needs `from '…'` or a
+      // string), so the line-end anchor keeps Node imports out.
+      weight: 3,
+      test: /^\s*(?:from\s+[\w.]+\s+import\s+[\w.*]|import\s+[\w.]+(?:\s+as\s+\w+)?\s*$)/m,
+      describe: 'a Python import statement',
+    },
+    {
+      weight: 2,
+      test: /^\s*(?:elif\b|except\b|raise\s)/m,
+      describe: 'Python-only keywords (elif/except/raise)',
+    },
+    { weight: 2, test: /\bf(?:''|"")/, describe: 'a Python f-string' },
+    { weight: 2, test: /^\s*print\s*\(/m, describe: '`print(…)`' },
+  ],
+  node: [
+    {
+      weight: 3,
+      test: /^#!.*\bnode/,
+      shebang: true,
+      describe: 'a Node shebang',
+    },
+    {
+      weight: 3,
+      test: /\bconsole\.(?:log|error|warn|info)\s*\(/,
+      describe: '`console.*(…)`',
+    },
+    {
+      // `const` declarations — `let` is a bash builtin, so it can't serve.
+      weight: 3,
+      test: /^\s*const\s+[\w{[$]/m,
+      describe: 'a `const` declaration',
+    },
+    {
+      weight: 3,
+      test: /^\s*import\s+.+\s+from\s+(?:''|"")/m,
+      describe: 'an ESM import',
+    },
+    { weight: 2, test: /=>\s*[{(]|\)\s*=>/, describe: 'an arrow function' },
+    {
+      weight: 2,
+      test: /\brequire\s*\(\s*(?:''|"")\s*\)/,
+      describe: '`require(…)`',
+    },
+  ],
+  bash: [
+    {
+      weight: 3,
+      test: /^#!.*\b(?:ba|z|da)?sh\b/,
+      shebang: true,
+      describe: 'a shell shebang',
+    },
+    {
+      weight: 3,
+      test: /^\s*(?:fi|done|esac)\s*(?:;.*)?$/m,
+      describe: 'shell block keywords (fi/done/esac)',
+    },
+    {
+      weight: 2,
+      test: /^\s*(?:sudo|apt-get|apt|yum|apk)\s+\w/m,
+      describe: 'a system package-manager command',
+    },
+    { weight: 2, test: /^\s*echo\s+(?![-+=*/])/m, describe: '`echo …`' },
+    {
+      weight: 2,
+      test: /\|\s*(?:grep|awk|sed|xargs|sort|uniq|head|tail)\b/,
+      describe: 'a coreutils pipeline',
+    },
+    {
+      weight: 2,
+      test: /^\s*(?:export\s+\w+=|cd\s+\/)/m,
+      describe: '`export VAR=` / `cd /…`',
+    },
+  ],
+};
+
+const INSTALL_HINT =
+  'Declare installs in the `packages` parameter instead of running them from inline code — the org run_code policy applies there and the install is checked before anything runs. Either {"mode":"install","packages":{"python":["<name>"]}} as its own call, or add `packages` to this one. (`pip install -r/-e …` and project-local `npm install` runs stay allowed inline.)';
+
+/** Bare `pip install <name>` — requirement-file (-r), editable (-e), and
+ * local-dir installs have no `packages` equivalent and stay allowed. */
+const PIP_INSTALL_REGEX =
+  /(?:^|[;&|(\s])(?:(?:python3?|uv)\s+-m\s+)?pip3?\s+install\s+(?!(?:-r|--requirement|-e|--editable)\b|\.)/m;
+/** Global npm installs only — a project-local `npm install` is a build step,
+ * not package provisioning. */
+const NPM_GLOBAL_INSTALL_REGEX =
+  /(?:^|[;&|(\s])npm\s+(?:install|i|add)\s+(?:-g\b|--global\b)/m;
+
+function detectInlineInstall(
+  raw: string,
+  stripped: string,
+  language: InlineLanguage,
+): InlineCodeIssue | null {
+  if (
+    PIP_INSTALL_REGEX.test(stripped) ||
+    NPM_GLOBAL_INSTALL_REGEX.test(stripped)
+  ) {
+    return { code: 'PREFER_PACKAGES', message: INSTALL_HINT };
+  }
+  // Process-spawned installs keep their tokens inside string literals, so
+  // the stripped scan can't see them. Scan with comments removed but strings
+  // KEPT — and only next to a spawn call, so a comment or prose mention of
+  // pip never trips this.
+  const spawnsProcess =
+    language === 'python'
+      ? /\b(?:subprocess\.|os\.system|check_call|check_output)/.test(stripped)
+      : language === 'node'
+        ? /\b(?:child_process|execSync|spawn(?:Sync)?\s*\()/.test(stripped)
+        : false;
+  const uncommented = stripComments(raw, language);
+  if (
+    spawnsProcess &&
+    /\b(?:pip3?\b[^\n]{0,60}\binstall\b|npm\b[^\n]{0,60}\binstall\b[^\n]{0,60}(?:-g\b|--global\b))/.test(
+      uncommented,
+    )
+  ) {
+    return { code: 'PREFER_PACKAGES', message: INSTALL_HINT };
+  }
+  return null;
+}
+
+/** Comments out, string literals kept — for scans that must see quoted
+ * install commands but not commented-out ones. */
+function stripComments(code: string, language: InlineLanguage): string {
+  if (language === 'node') {
+    return code
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  }
+  return code.replace(/(^|[^&\w])#(?!!)[^\n]*/g, '$1');
+}
+
+function detectLanguageMismatch(
+  raw: string,
+  stripped: string,
+  declared: InlineLanguage,
+): InlineCodeIssue | null {
+  const shebang = raw.startsWith('#!')
+    ? raw.slice(0, raw.indexOf('\n') === -1 ? raw.length : raw.indexOf('\n'))
+    : null;
+  let best: {
+    language: InlineLanguage;
+    score: number;
+    hasDecisive: boolean;
+    hits: string[];
+  } | null = null;
+  for (const language of ['python', 'node', 'bash'] as const) {
+    if (language === declared) continue;
+    let score = 0;
+    let hasDecisive = false;
+    const hits: string[] = [];
+    for (const signal of LANGUAGE_SIGNALS[language]) {
+      const subject = signal.shebang ? shebang : stripped;
+      if (subject === null || !signal.test.test(subject)) continue;
+      score += signal.weight;
+      hasDecisive ||= signal.weight === 3;
+      hits.push(signal.describe);
+    }
+    if (best === null || score > best.score) {
+      best = { language, score, hasDecisive, hits };
+    }
+  }
+  if (
+    best !== null &&
+    (best.score >= 4 || (best.score >= 3 && best.hasDecisive))
+  ) {
+    return {
+      code: 'LANGUAGE_MISMATCH',
+      message: `\`language\` is "${declared}" but the snippet looks like ${best.language} — it contains ${best.hits.join(', ')}. The language is not auto-corrected: resubmit with language: "${best.language}", or rewrite the snippet in ${declared}.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Layer-2 check `run_code` runs on inline snippets before touching the
+ * sandbox. `null` means "run it" — including every uncertain case.
+ */
+export function validateInlineCode(
+  code: string,
+  language: InlineLanguage,
+): InlineCodeIssue | null {
+  try {
+    const stripped = stripLiterals(code, language);
+    return (
+      detectInlineInstall(code, stripped, language) ??
+      detectLanguageMismatch(code, stripped, language)
+    );
+  } catch (err) {
+    // Fail open: a validator crash must never block a run.
+    console.warn('[run_code] inline language validation failed:', err);
+    return null;
+  }
+}

--- a/services/platform/convex/agent_tools/run_code_tool.test.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.test.ts
@@ -245,6 +245,21 @@ describe('checkPackagesAgainstPolicy', () => {
     );
     expect(allowed.ok).toBe(true);
   });
+
+  it('strips the unscoped npm name@version form before matching', () => {
+    // Found via E2E: `Sharp@1.2.3` sailed past a `sharp` deny entry — the
+    // base-name splitter only knew scoped `@scope/pkg@ver` specs.
+    const res = checkPackagesAgainstPolicy(policy({ nodeDeny: ['sharp'] }), {
+      node: ['Sharp@1.2.3'],
+    });
+    expect(res.ok).toBe(false);
+
+    const scoped = checkPackagesAgainstPolicy(
+      policy({ nodeDeny: ['@img/sharp'] }),
+      { node: ['@img/sharp@0.34.0'] },
+    );
+    expect(scoped.ok).toBe(false);
+  });
 });
 
 const baseRun = {

--- a/services/platform/convex/agent_tools/run_code_tool.test.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.test.ts
@@ -1,60 +1,249 @@
-// run_code arg-schema mode mutex (entryPath / steps / code) + the
+// run_code arg schema (mode-discriminated union with strict variants), the
+// provider-facing flatten contract, the package policy gate, and the
 // terminal-output result message. Pure zod + string formatting — the only
 // mock is createTool so importing the tool module doesn't pull the agent
 // runtime.
 
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
 
 vi.mock('@convex-dev/agent', () => ({
   createTool: vi.fn((def: unknown) => def),
 }));
 
-import { formatRunCodeResultMessage, runCodeArgs } from './run_code_tool';
+import type { RunCodePolicyConfig } from '../../lib/shared/schemas/governance';
+import { flattenUnionSchema } from '../providers/resolve_model';
+import {
+  checkPackagesAgainstPolicy,
+  formatRunCodeResultMessage,
+  runCodeArgs,
+} from './run_code_tool';
 
 describe('runCodeArgs', () => {
-  it('accepts each mode alone', () => {
+  it('accepts each mode', () => {
     expect(
-      runCodeArgs.safeParse({ entryPath: '/user/code/a.py' }).success,
+      runCodeArgs.safeParse({ mode: 'script', entryPath: '/user/code/a.py' })
+        .success,
     ).toBe(true);
     expect(
-      runCodeArgs.safeParse({ steps: [{ path: '/user/code/a.py' }] }).success,
+      runCodeArgs.safeParse({
+        mode: 'inline',
+        code: 'print(1)',
+        language: 'python',
+      }).success,
     ).toBe(true);
     expect(
-      runCodeArgs.safeParse({ code: 'print(1)', language: 'python' }).success,
+      runCodeArgs.safeParse({
+        mode: 'install',
+        packages: { python: ['pandas'] },
+      }).success,
     ).toBe(true);
   });
 
-  it('rejects zero modes and combined modes', () => {
-    expect(runCodeArgs.safeParse({}).success).toBe(false);
+  it('accepts packages as an adjunct on script and inline', () => {
     expect(
       runCodeArgs.safeParse({
+        mode: 'script',
         entryPath: '/user/code/a.py',
-        code: 'echo hi',
-        language: 'bash',
+        packages: { python: ['pandas'], node: ['sharp'] },
       }).success,
-    ).toBe(false);
+    ).toBe(true);
     expect(
       runCodeArgs.safeParse({
-        entryPath: '/user/code/a.py',
-        steps: [{ path: '/user/code/b.py' }],
+        mode: 'inline',
+        code: 'import pandas',
+        language: 'python',
+        packages: { python: ['pandas'] },
       }).success,
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it('ties language to code in both directions', () => {
-    const missing = runCodeArgs.safeParse({ code: 'echo hi' });
-    expect(missing.success).toBe(false);
-    if (!missing.success) {
-      expect(missing.error.issues.some((i) => i.path[0] === 'language')).toBe(
+  it('rejects a missing mode with all three examples', () => {
+    const res = runCodeArgs.safeParse({ entryPath: '/user/code/a.py' });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      const text = res.error.issues.map((i) => i.message).join('\n');
+      expect(text).toContain('"script"');
+      expect(text).toContain('"inline"');
+      expect(text).toContain('"install"');
+      expect(text).toContain('entryPath');
+    }
+  });
+
+  it('rejects cross-mode fields instead of silently stripping them', () => {
+    // The flattened provider schema advertises every field on every mode, so
+    // this combination WILL arrive. Non-strict variants would drop `code` and
+    // run something else than the model asked for.
+    const res = runCodeArgs.safeParse({
+      mode: 'script',
+      entryPath: '/user/code/a.py',
+      code: 'print(1)',
+      language: 'python',
+    });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error.issues.some((i) => i.code === 'unrecognized_keys')).toBe(
         true,
       );
     }
     expect(
       runCodeArgs.safeParse({
+        mode: 'inline',
+        code: 'print(1)',
+        language: 'python',
         entryPath: '/user/code/a.py',
-        language: 'bash',
       }).success,
     ).toBe(false);
+  });
+
+  it('rejects the removed steps array', () => {
+    expect(
+      runCodeArgs.safeParse({
+        mode: 'script',
+        entryPath: '/user/code/a.py',
+        steps: [{ path: '/user/code/b.py' }],
+      }).success,
+    ).toBe(false);
+    expect(
+      runCodeArgs.safeParse({ steps: [{ path: '/user/code/b.py' }] }).success,
+    ).toBe(false);
+  });
+
+  it('requires language with inline code', () => {
+    expect(
+      runCodeArgs.safeParse({ mode: 'inline', code: 'print(1)' }).success,
+    ).toBe(false);
+  });
+
+  it('requires at least one non-empty package bucket for install', () => {
+    expect(
+      runCodeArgs.safeParse({ mode: 'install', packages: {} }).success,
+    ).toBe(false);
+    expect(
+      runCodeArgs.safeParse({ mode: 'install', packages: { python: [] } })
+        .success,
+    ).toBe(false);
+    expect(runCodeArgs.safeParse({ mode: 'install' }).success).toBe(false);
+  });
+
+  it('keeps the per-spec packages refinement', () => {
+    expect(
+      runCodeArgs.safeParse({
+        mode: 'install',
+        packages: { python: [''] },
+      }).success,
+    ).toBe(false);
+    expect(
+      runCodeArgs.safeParse({
+        mode: 'install',
+        packages: { python: ['python:pandas'] },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('provider schema flatten (OpenAI oneOf workaround)', () => {
+  it('flattens to a single object keeping mode as the only required field', () => {
+    const json = z.toJSONSchema(runCodeArgs, { io: 'input' }) as Record<
+      string,
+      unknown
+    >;
+    // The union must surface at the root for the middleware to fire.
+    expect(json.oneOf ?? json.anyOf).toBeDefined();
+
+    const flat = flattenUnionSchema(json);
+    expect(flat.type).toBe('object');
+    expect(flat.required).toEqual(['mode']);
+    expect(flat.additionalProperties).toBe(false);
+
+    const properties = flat.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(Object.keys(properties)).toEqual(
+      expect.arrayContaining([
+        'mode',
+        'entryPath',
+        'code',
+        'language',
+        'packages',
+        'timeoutMs',
+      ]),
+    );
+    expect(properties.mode.enum).toEqual(['script', 'inline', 'install']);
+  });
+});
+
+describe('checkPackagesAgainstPolicy', () => {
+  const policy = (over: Partial<RunCodePolicyConfig>): RunCodePolicyConfig => ({
+    defaultMode: 'denylist',
+    pythonAllow: [],
+    pythonDeny: [],
+    nodeAllow: [],
+    nodeDeny: [],
+    ...over,
+  });
+
+  it('allows everything without a policy', () => {
+    expect(checkPackagesAgainstPolicy(null, { python: ['anything'] }).ok).toBe(
+      true,
+    );
+  });
+
+  it('blocks denied python packages', () => {
+    const res = checkPackagesAgainstPolicy(
+      policy({ pythonDeny: ['requests'] }),
+      { python: ['requests'] },
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it('blocks denied node packages (both buckets are checked)', () => {
+    // Regression: the node bucket used to be skipped entirely.
+    const res = checkPackagesAgainstPolicy(policy({ nodeDeny: ['sharp'] }), {
+      python: ['pandas'],
+      node: ['sharp'],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.package).toBe('sharp');
+      expect(res.message).toContain('node package "sharp"');
+    }
+  });
+
+  it('enforces the allowlist on the node bucket', () => {
+    const res = checkPackagesAgainstPolicy(
+      policy({ defaultMode: 'allowlist', pythonAllow: ['pandas'] }),
+      { python: ['pandas'], node: ['left-pad'] },
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.message).toContain('not on the org allowlist');
+  });
+
+  it('lets deny win over allow in allowlist mode', () => {
+    const res = checkPackagesAgainstPolicy(
+      policy({
+        defaultMode: 'allowlist',
+        pythonAllow: ['requests'],
+        pythonDeny: ['requests'],
+      }),
+      { python: ['requests'] },
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.message).toContain('explicitly denied');
+  });
+
+  it('matches case-insensitively on the version-stripped base name', () => {
+    const res = checkPackagesAgainstPolicy(policy({ pythonDeny: ['pandas'] }), {
+      python: ['Pandas==2.2.1'],
+    });
+    expect(res.ok).toBe(false);
+
+    const allowed = checkPackagesAgainstPolicy(
+      policy({ defaultMode: 'allowlist', pythonAllow: ['python-pptx'] }),
+      { python: ['python-pptx>=1.0'] },
+    );
+    expect(allowed.ok).toBe(true);
   });
 });
 
@@ -120,5 +309,43 @@ describe('formatRunCodeResultMessage', () => {
       stdoutPreview: 'a\n```\nb\n',
     });
     expect(msg).toContain('````\na\n```\nb\n````');
+  });
+
+  it('reports an install-only success without the harvest lecture', () => {
+    const msg = formatRunCodeResultMessage(
+      { ...baseRun, stdoutPreview: 'Successfully installed pandas-2.2.1\n' },
+      { installOnly: true, packageCount: 2 },
+    );
+    expect(msg).toContain('run_code installed 2 package(s) in 42ms');
+    expect(msg).toContain('persist for later run_code calls in this turn');
+    expect(msg).toContain('Successfully installed pandas-2.2.1');
+    expect(msg).not.toContain('nothing was printed');
+  });
+
+  it('surfaces INSTALL_FAILED with the installer output', () => {
+    const msg = formatRunCodeResultMessage(
+      {
+        ...baseRun,
+        status: 'failed',
+        exitCode: 1,
+        errorCode: 'INSTALL_FAILED',
+        errorMessage: 'pip install failed (exit 1)',
+        stderrPreview: 'ERROR: No matching distribution found for nope\n',
+      },
+      { installOnly: true, packageCount: 1 },
+    );
+    expect(msg).toContain('run_code FAILED: INSTALL_FAILED');
+    expect(msg).toContain('pip install failed (exit 1)');
+    expect(msg).toContain('No matching distribution');
+  });
+
+  it('appends the language hint when bash choked on Python source', () => {
+    const msg = formatRunCodeResultMessage({
+      ...baseRun,
+      status: 'failed',
+      exitCode: 127,
+      stderrPreview: 'line 1: import: command not found\n',
+    });
+    expect(msg).toContain('Resubmit with `language` matching the code');
   });
 });

--- a/services/platform/convex/agent_tools/run_code_tool.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.ts
@@ -1,15 +1,16 @@
 /**
  * run_code — execute code in the thread workspace sandbox.
  *
- * Reads every file currently in the calling thread's `threadFiles` table,
- * mounts them at `/user/code/<path>` inside the sandbox, runs either
- * a single entry script or a sequential list of steps, and harvests any
- * files produced under `/user/output/` back into the workspace
- * (source `'run_output'`).
+ * Three modes behind an explicit `mode` discriminator: `script` runs a
+ * workspace file staged via `file_write`, `inline` runs a snippet directly,
+ * `install` provisions packages without running anything. Every mode may
+ * declare `packages` to install first; files produced under `/user/output/`
+ * are harvested back into the workspace (source `'run_output'`).
  *
  * The thread workspace IS the workspace — there is no separate file
  * injection channel. The LLM must `file_write` everything it wants the
- * sandbox to see first, then call `run_code`.
+ * sandbox to execute as a script; multi-step work is sequential run_code
+ * calls against the turn's persistent session (there is no `steps` array).
  */
 
 import type { ToolCtx } from '@convex-dev/agent';
@@ -23,104 +24,138 @@ import {
 import { internal } from '../_generated/api';
 import { buildDownloadUrl } from '../lib/helpers/public_storage_url';
 import { getWorkspaceThreadId } from '../threads/get_parent_thread_id';
-import { refinePackagesObject } from './files/_shared';
-import { packageBaseName } from './files/_shared';
+import {
+  evaluatePackageAgainstPolicy,
+  packageBaseName,
+  refinePackagesObject,
+} from './files/_shared';
 import { appendFilePart } from './files/helpers/append_file_part';
 import {
   buildSandboxState,
   formatSandboxState,
 } from './files/helpers/sandbox_state';
 import { parseWorkspacePath, relOf } from './files/sandbox_paths';
+import { validateInlineCode } from './inline_language';
 import type { ToolDefinition } from './types';
 
-const RUN_CODE_MAX_STEPS = 10;
-
-export const runCodeArgs = z
-  .object({
-    entryPath: z
-      .string()
-      .min(1)
-      .max(200)
+const packagesField = z
+  .strictObject({
+    python: z
+      .array(z.string().max(120))
+      .max(20)
       .optional()
-      .describe(
-        'Single-script mode: absolute path of a script under `/user/code`, e.g. `/user/code/gen.py`. Mutually exclusive with `steps`.',
-      ),
-    steps: z
-      .array(z.object({ path: z.string().min(1).max(200) }))
-      .min(1)
-      .max(RUN_CODE_MAX_STEPS)
+      .describe('pip specs, e.g. ["pandas", "python-pptx==1.0.2"].'),
+    node: z
+      .array(z.string().max(120))
+      .max(20)
       .optional()
-      .describe(
-        'Multi-step mode: scripts to execute sequentially in one container — each `path` is an absolute `/user/code/<script>`. Step N sees step N-1 outputs in `/user/output/`. Mutually exclusive with `entryPath`.',
-      ),
-    code: z
-      .string()
-      .min(1)
-      .max(65_536)
-      .optional()
-      .describe(
-        'Inline mode: source code to execute directly — no file_write needed. Requires `language`. Mutually exclusive with `entryPath` / `steps`.',
-      ),
-    language: z
-      .enum(['python', 'node', 'bash'])
-      .optional()
-      .describe(
-        'Interpreter for `code` (inline mode only): `python` → python3, `node` → Node as ESM (`import` / top-level `await`, no `require`), `bash` → bash.',
-      ),
-    packages: z
-      .object({
-        python: z.array(z.string().max(120)).max(20).optional(),
-        node: z.array(z.string().max(120)).max(20).optional(),
-      })
-      .optional()
-      .describe(
-        'Packages to install before executing. Pip specs go in `python`; npm specs in `node`. The org policy may reject specs not on its allowlist.',
-      )
-      .superRefine((val, ctx) => {
-        refinePackagesObject(val, (issue) => ctx.addIssue(issue));
-      }),
-    timeoutMs: z
-      .number()
-      .int()
-      .min(1_000)
-      .max(300_000)
-      .optional()
-      .describe('Wall-clock cap in ms (default 30000, max 300000).'),
-    sourceCitation: z
-      .object({
-        skillSlug: z.string().min(1).max(64),
-        fileReferences: z.array(z.string().min(1).max(200)).max(10),
-      })
-      .optional()
-      .describe(
-        'Optional provenance — when the script content was inspired by a skill, record which one. Surfaced on the audit row.',
-      ),
+      .describe('npm specs (installed globally), e.g. ["sharp"].'),
   })
   .superRefine((val, ctx) => {
-    const modes = [val.entryPath, val.steps, val.code].filter(
-      (m) => m !== undefined,
-    ).length;
-    if (modes !== 1) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['entryPath'],
-        message:
-          'Pass exactly one of `entryPath`, `steps`, or `code` — the modes are mutually exclusive.',
-      });
-    }
-    if (val.code !== undefined && val.language === undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['language'],
-        message: '`language` is required with `code` (python | node | bash).',
-      });
-    }
-    if (val.language !== undefined && val.code === undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['language'],
-        message: '`language` is only valid with `code`.',
-      });
+    refinePackagesObject(val, (issue) => ctx.addIssue(issue));
+  });
+
+/** Fields every mode accepts — spread into each strict variant. */
+const runCodeSharedFields = {
+  timeoutMs: z
+    .number()
+    .int()
+    .min(1_000)
+    .max(300_000)
+    .optional()
+    .describe(
+      'Wall-clock cap in ms for the script/snippet run (default 30000; mode "install" defaults to 120000; max 300000). Declared package installs get their own budget and do not eat into this.',
+    ),
+  sourceCitation: z
+    .object({
+      skillSlug: z.string().min(1).max(64),
+      fileReferences: z.array(z.string().min(1).max(200)).max(10),
+    })
+    .optional()
+    .describe(
+      'Optional provenance — when the script content was inspired by a skill, record which one. Surfaced on the audit row.',
+    ),
+};
+
+const MODE_ERROR =
+  'Pass mode: "script" | "inline" | "install". Examples: {"mode":"inline","code":"print(1)","language":"python"} · {"mode":"script","entryPath":"/user/code/gen.py","packages":{"python":["pandas"]}} · {"mode":"install","packages":{"python":["pandas"]}}';
+
+// Strict variants on purpose: the provider-facing schema is flattened for
+// OpenAI (all per-mode fields look optional — see `flattenUnionSchema` in
+// resolve_model.ts), so cross-mode combinations like `mode: "script"` +
+// `code` WILL arrive. Non-strict objects would silently strip the extra
+// field and run something else than the model asked for; strict ones reject
+// with a repairable unrecognized-keys error.
+export const runCodeArgs = z
+  .discriminatedUnion(
+    'mode',
+    [
+      z.strictObject({
+        mode: z
+          .literal('script')
+          .describe('Run a workspace script staged with file_write.'),
+        entryPath: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe(
+            'Absolute script path under /user/code, e.g. "/user/code/gen.py" — the extension picks the interpreter (.py / .js / .cjs / .mjs / .sh).',
+          ),
+        packages: packagesField
+          .optional()
+          .describe(
+            'Installed before the run; persist for later run_code calls in this turn.',
+          ),
+        ...runCodeSharedFields,
+      }),
+      z.strictObject({
+        mode: z
+          .literal('inline')
+          .describe('Execute a snippet directly — nothing is staged.'),
+        code: z
+          .string()
+          .min(1)
+          .max(65_536)
+          .describe(
+            'Source to execute. Not stored in the workspace — for anything worth re-running or editing, file_write + mode "script" instead.',
+          ),
+        language: z
+          .enum(['python', 'node', 'bash'])
+          .describe(
+            'Interpreter for `code`: python → python3, node → Node as ESM (`import` / top-level `await`, no `require`), bash → bash. Must match the code — contradictions are rejected, not auto-corrected.',
+          ),
+        packages: packagesField
+          .optional()
+          .describe(
+            'Installed before the snippet runs; persist for later run_code calls in this turn.',
+          ),
+        ...runCodeSharedFields,
+      }),
+      z.strictObject({
+        mode: z
+          .literal('install')
+          .describe('Install packages only — no code runs.'),
+        packages: packagesField.describe(
+          'At least one non-empty bucket. Installed packages persist for later run_code calls in this turn.',
+        ),
+        ...runCodeSharedFields,
+      }),
+    ],
+    { error: MODE_ERROR },
+  )
+  .superRefine((val, ctx) => {
+    if (val.mode === 'install') {
+      const hasSpec =
+        (val.packages.python?.length ?? 0) > 0 ||
+        (val.packages.node?.length ?? 0) > 0;
+      if (!hasSpec) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['packages'],
+          message:
+            'mode "install" needs at least one package, e.g. {"mode": "install", "packages": {"python": ["pandas"]}}.',
+        });
+      }
     }
   });
 
@@ -128,7 +163,7 @@ type RunCodeArgs = z.infer<typeof runCodeArgs>;
 
 const SCRIPT_EXT_REGEX = /\.(py|cjs|mjs|js|sh)$/i;
 
-function checkPackagesAgainstPolicy(
+export function checkPackagesAgainstPolicy(
   policy: RunCodePolicyConfig | null,
   packages: { python?: string[]; node?: string[] } | undefined,
 ):
@@ -137,44 +172,31 @@ function checkPackagesAgainstPolicy(
       ok: false;
       code: 'PACKAGE_NOT_ALLOWED';
       package: string;
-      reason: string;
+      message: string;
     } {
   if (!packages || !policy) return { ok: true };
-  const check = (
-    specs: readonly string[] | undefined,
-    allow: readonly string[],
-    deny: readonly string[],
-    bucket: 'python' | 'node',
-  ) => {
-    if (!specs) return null;
-    const denySet = new Set(deny.map((s) => s.trim().toLowerCase()));
-    const allowSet = new Set(allow.map((s) => s.trim().toLowerCase()));
-    for (const spec of specs) {
+  const buckets = [
+    ['python', packages.python],
+    ['node', packages.node],
+  ] as const;
+  for (const [bucket, specs] of buckets) {
+    for (const spec of specs ?? []) {
+      const verdict = evaluatePackageAgainstPolicy(spec, bucket, policy);
+      if (verdict.allowed) continue;
       const base = packageBaseName(spec).toLowerCase();
-      if (denySet.has(base)) {
-        return {
-          ok: false as const,
-          code: 'PACKAGE_NOT_ALLOWED' as const,
-          package: spec,
-          reason: `${bucket} package "${base}" is explicitly denied by org policy.`,
-        };
-      }
-      if (policy.defaultMode === 'allowlist' && !allowSet.has(base)) {
-        return {
-          ok: false as const,
-          code: 'PACKAGE_NOT_ALLOWED' as const,
-          package: spec,
-          reason: `${bucket} package "${base}" is not on the org allowlist (mode=allowlist).`,
-        };
-      }
+      const why =
+        verdict.reason === 'deny_match'
+          ? `${bucket} package "${base}" is explicitly denied by org policy.`
+          : `${bucket} package "${base}" is not on the org allowlist (mode=allowlist).`;
+      return {
+        ok: false as const,
+        code: 'PACKAGE_NOT_ALLOWED' as const,
+        package: spec,
+        message: `${why} Remove it from \`packages\`, or ask an org admin to update the run_code policy.`,
+      };
     }
-    return null;
-  };
-  return (
-    check(packages.python, policy.pythonAllow, policy.pythonDeny, 'python') ?? {
-      ok: true,
-    }
-  );
+  }
+  return { ok: true };
 }
 
 /** Fence that survives `text` itself containing triple-backtick runs. */
@@ -206,23 +228,29 @@ If your script genuinely had no deliverable (e.g. a sanity check or package inst
  * its stdout); stderr only on failure — successful runs route package-install
  * noise there. Previews arrive pre-capped (4096 chars) from session_exec.
  */
-export function formatRunCodeResultMessage(run: {
-  status: 'completed' | 'failed' | 'cancelled';
-  exitCode: number | null;
-  errorCode?: string;
-  errorMessage?: string;
-  stdoutPreview: string;
-  stderrPreview: string;
-  durationMs: number;
-  files: Array<{ path: string }>;
-}): string {
+export function formatRunCodeResultMessage(
+  run: {
+    status: 'completed' | 'failed' | 'cancelled';
+    exitCode: number | null;
+    errorCode?: string;
+    errorMessage?: string;
+    stdoutPreview: string;
+    stderrPreview: string;
+    durationMs: number;
+    files: Array<{ path: string }>;
+  },
+  opts?: { installOnly?: boolean; packageCount?: number },
+): string {
   const success = run.status === 'completed';
   const stdout = run.stdoutPreview.trim();
   const stderr = run.stderrPreview.trim();
 
   let header: string;
   if (success) {
-    if (run.files.length > 0) {
+    if (opts?.installOnly) {
+      // No deliverable expected — the harvest lecture would be noise here.
+      header = `run_code installed ${opts.packageCount ?? 'the requested'} package(s) in ${run.durationMs}ms. They persist for later run_code calls in this turn.`;
+    } else if (run.files.length > 0) {
       header = `run_code succeeded in ${run.durationMs}ms. Produced ${run.files.length} output file(s) at /user/output/: ${run.files.map((f) => f.path).join(', ')}.`;
     } else if (stdout.length > 0) {
       header = `run_code succeeded in ${run.durationMs}ms. (No output files were harvested — only files written under \`/user/output/\` come back into the workspace.)`;
@@ -231,7 +259,7 @@ export function formatRunCodeResultMessage(run: {
     }
   } else {
     header = run.errorCode
-      ? `run_code FAILED: ${run.errorCode}${run.errorMessage ? ` — ${run.errorMessage}` : ''}. Read the output below, fix the script, then call run_code again.`
+      ? `run_code FAILED: ${run.errorCode}${run.errorMessage ? ` — ${run.errorMessage}` : ''}. Read the output below, fix the problem, then call run_code again.`
       : `run_code finished with status=${run.status}${run.exitCode !== null ? ` (exit code ${run.exitCode})` : ''}.`;
   }
 
@@ -244,6 +272,13 @@ export function formatRunCodeResultMessage(run: {
     const fence = fenceFor(stderr);
     blocks.push(`stderr:\n${fence}\n${stderr}\n${fence}`);
   }
+  // Backstop for language mismatches the pre-flight heuristic let through:
+  // bash choking on Python source has this one unmistakable signature.
+  if (!success && stderr.includes('import: command not found')) {
+    blocks.push(
+      'Hint: `import: command not found` means bash tried to execute Python source. Resubmit with `language` matching the code (probably "python").',
+    );
+  }
   return blocks.join('\n\n');
 }
 
@@ -251,34 +286,22 @@ export const runCodeTool: ToolDefinition = {
   name: 'run_code' as const,
   availability: 'any' as const,
   tool: createTool({
-    description: `**run_code** — execute code in the thread's sandbox. Python 3, Node.js, and bash are available. Run an inline snippet (\`code\`), or script files staged in the workspace (\`entryPath\` / \`steps\`).
+    description: `**run_code** — execute code in the thread's sandbox (Python 3, Node as ESM, bash). Pick a \`mode\`:
 
-INLINE MODE (quick commands and snippets — use it like a shell):
-\`run_code({code: "ls -la /user/output", language: "bash"})\` executes the snippet directly — no file_write needed — and the result message contains its terminal output. Good for one-off commands, inspecting the sandbox, quick computations, and installs. \`language\` is required: \`python\` → python3, \`node\` → Node as ESM (\`import\` / top-level \`await\`, no \`require\`), \`bash\` → bash. The snippet is not stored in the workspace — for anything worth re-running or editing, use file_write + entryPath instead.
+- \`{"mode": "inline", "code": "ls -la /user/output", "language": "bash"}\` — run a snippet directly, like a shell. For one-off commands, quick computations, sandbox inspection. The snippet is not stored — for anything worth re-running or editing, use mode "script".
+- \`{"mode": "script", "entryPath": "/user/code/gen.py"}\` — run a workspace script. \`file_write\` it first; the extension picks the interpreter (.py / .js / .cjs / .mjs / .sh).
+- \`{"mode": "install", "packages": {"python": ["pandas"]}}\` — install packages without running code (use for big installs or a separate install checkpoint).
 
-SCRIPT-FILE WORKFLOW (extension-routed: \`.py\` → python3, \`.js\`/\`.cjs\`/\`.mjs\` → node, \`.sh\` → bash):
-1. \`file_write\` every script you need (the workspace IS the sandbox source tree)
-2. \`run_code({entryPath: "/user/code/<script>"})\` for a one-shot
-   OR \`run_code({steps: [{path: "/user/code/step_a.py"}, {path: "/user/code/step_b.py"}]})\` for sequential steps sharing one container
-3. Any file the script writes under \`/user/output/\` is harvested back into the thread workspace and appears in the canvas
+PACKAGES: declare pip specs in \`packages.python\`, npm specs in \`packages.node\` — available on every mode; they install before the code runs and persist for later run_code calls in this turn. The org policy gates them. Do NOT install ad-hoc from inline code — \`pip install x\` / \`npm install -g y\` snippets are rejected with PREFER_PACKAGES (\`pip install -r\` and project-local \`npm install\` remain fine).
 
-PACKAGES:
-- Pip specs go in \`packages.python\`, npm specs in \`packages.node\` — these install **before** the script runs.
-- You can also install on demand from inside the script: \`subprocess.run([sys.executable, "-m", "pip", "install", "foo"])\` from Python, \`npm install -g bar\` from a bash step, etc. Installed packages are importable/requireable immediately on the next line.
-- A bash step can also drive \`python\` (alias for python3), \`node\`, \`pip\`, \`npm\` directly — same writable install paths as the language-specific steps.
-- The org policy gates what \`packages.python\` / \`packages.node\` can declare — denied packages return a structured error so you can adapt. Inline installs are governed by the sandbox egress allowlist instead.
+MULTI-STEP: call run_code repeatedly — the sandbox session persists within the turn (installed packages, files under \`/user/output/\`). There is no steps array.
 
-TIMEOUTS / LIMITS:
-- Default 30s wall-clock, max 300s
-- Memory cap 1 GB
-- Max 16 harvested output files per run
+PATHS (pre-populated from the thread workspace):
+- \`/user/code/\`    — scripts you authored via \`file_write\` (what \`entryPath\` runs);
+- \`/user/output/\`  — deliverables: ONLY files written here are harvested back into the workspace and canvas; previous runs' outputs also live here;
+- \`/user/uploads/\` — files the user uploaded into the thread.
 
-The sandbox sees three directories pre-populated from the thread workspace:
-- \`/user/code/\`    — scripts you authored via \`file_write\` (this is where \`entryPath\` / \`steps\` resolve);
-- \`/user/output/\`  — deliverables: files from previous \`run_code\` calls and files you saved there with \`file_write\`; this is also where the current run writes its outputs (any file written here is harvested back into the thread);
-- \`/user/uploads/\` — files the user uploaded into the thread (kept separate from code-output artifacts).
-
-Reading a previous run's output → \`/user/output/<name>\`. Reading a user-uploaded asset → \`/user/uploads/<name>\`. Only scripts you wrote with \`file_write\` are executable as \`entryPath\` / \`steps\`.
+LIMITS: default 30s per run (\`timeoutMs\`, max 300s); declared package installs get their own budget (up to 5 min); 1 GB memory; max 16 harvested output files per run.
 
 Every result message embeds the run's terminal output (stdout inline, capped at 4 KB; stderr too on failure) plus a **\`sandboxState\`** manifest — the current files under each dir, each with its \`fileId\`. Read it before acting: don't regenerate an output already listed there, and hand a file's \`fileId\` to the \`image\` (analyze) or \`document_write\` tool.`,
     // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag -- the match is prose in this LLM tool-description string, not rendered HTML
@@ -305,11 +328,25 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
       // outputs land where the parent agent and the canvas read them.
       const workspaceThreadId = await getWorkspaceThreadId(ctx, threadId);
 
-      // Script-file modes resolve + validate paths against the workspace.
-      // Inline mode (`code`) skips all of it — the snippet is staged by the
-      // exec action itself and may run against an empty workspace.
+      // Inline pre-flight (Layer 2): the declared interpreter must plausibly
+      // match the snippet, and ad-hoc installs are routed to `packages` where
+      // the org policy can see them. Fail-open — see inline_language.ts.
+      if (args.mode === 'inline') {
+        const issue = validateInlineCode(args.code, args.language);
+        if (issue !== null) {
+          return {
+            ok: false as const,
+            code: issue.code,
+            message: issue.message,
+          };
+        }
+      }
+
+      // Script mode resolves entryPath against the workspace; inline and
+      // install modes skip it — the exec action stages what they need and
+      // may run against an empty workspace.
       let stepPaths: string[] = [];
-      if (args.code === undefined) {
+      if (args.mode === 'script') {
         // Load every workspace file. The path the LLM passed must exist.
         const rows = await ctx.runQuery(
           internal.thread_files.internal_queries.listThreadFiles,
@@ -324,84 +361,52 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
             ok: false as const,
             code: 'EMPTY_WORKSPACE' as const,
             message:
-              'No files in the thread workspace. Use file_write to stage scripts first, or pass `code` to run a snippet directly.',
+              'No files in the thread workspace. Use file_write to stage the script first, or run the code directly with mode "inline".',
           };
         }
 
-        // Resolve target paths the LLM asked us to execute.
-        if (args.steps !== undefined) {
-          stepPaths = args.steps.map((s) => s.path);
-        } else {
-          // entryPath is guaranteed by the superRefine mutex above when
-          // steps and code are absent, but TS narrows it loosely — guard
-          // explicitly.
-          if (args.entryPath === undefined) {
-            return {
-              ok: false as const,
-              code: 'INVALID_STEP_PATH' as const,
-              message: 'run_code requires entryPath, steps, or code.',
-            };
-          }
-          stepPaths = [args.entryPath];
+        // entryPath is the absolute `/user/code/<script>` path file_write
+        // returned. Resolve to the sandbox-relative form the spawner +
+        // matching use. Only `/user/code` scripts run.
+        let parsed;
+        try {
+          parsed = parseWorkspacePath(args.entryPath);
+        } catch {
+          parsed = null;
         }
-        // entry/steps are absolute `/user/code/<script>` paths (what
-        // file_write returns). Resolve to the sandbox-relative form the
-        // spawner + matching use. Only `/user/code` scripts run.
-        {
-          const rels: string[] = [];
-          for (const raw of stepPaths) {
-            let parsed;
-            try {
-              parsed = parseWorkspacePath(raw);
-            } catch {
-              parsed = null;
-            }
-            if (parsed === null || parsed.source !== 'agent_write') {
-              return {
-                ok: false as const,
-                code: 'INVALID_STEP_PATH' as const,
-                message: `Step path "${raw}" must be an absolute workspace script under /user/code/ (e.g. /user/code/gen.py).`,
-              };
-            }
-            rels.push(parsed.rel);
-          }
-          stepPaths = rels;
+        if (parsed === null || parsed.source !== 'agent_write') {
+          return {
+            ok: false as const,
+            code: 'INVALID_ENTRY_PATH' as const,
+            message: `entryPath "${args.entryPath}" must be an absolute workspace script under /user/code/ (e.g. /user/code/gen.py).`,
+          };
+        }
+        const rel = parsed.rel;
+        if (!SCRIPT_EXT_REGEX.test(rel)) {
+          return {
+            ok: false as const,
+            code: 'INVALID_ENTRY_PATH' as const,
+            message: `entryPath "${args.entryPath}" has no recognized script extension (.py / .js / .cjs / .mjs / .sh).`,
+          };
         }
         // /user/code/ is the executable surface — keyed on LOCATION, not the
         // `source` provenance (file_write also authors /user/output
         // deliverables now, which must never become executable). If the user
         // wants to run a user-uploaded script, they can copy it into
         // /user/code/ with file_write.
-        const seen = new Set<string>();
         const knownPaths = new Set(
           workspaceFiles
             .filter((f: { path: string }) => f.path.startsWith('/user/code/'))
             .map((f: { path: string }) => relOf(f.path)),
         );
-        for (const p of stepPaths) {
-          if (!SCRIPT_EXT_REGEX.test(p)) {
-            return {
-              ok: false as const,
-              code: 'INVALID_STEP_PATH' as const,
-              message: `Step path "${p}" has no recognized script extension (.py / .js / .cjs / .mjs / .sh).`,
-            };
-          }
-          if (seen.has(p)) {
-            return {
-              ok: false as const,
-              code: 'DUPLICATE_STEP_PATH' as const,
-              message: `Step path "${p}" appears more than once. Each step must be unique within a single run_code call.`,
-            };
-          }
-          if (!knownPaths.has(p)) {
-            return {
-              ok: false as const,
-              code: 'STEP_PATH_NOT_FOUND' as const,
-              message: `Step path "${p}" is not in the workspace. Call file_write first.`,
-            };
-          }
-          seen.add(p);
+        if (!knownPaths.has(rel)) {
+          return {
+            ok: false as const,
+            code: 'ENTRY_PATH_NOT_FOUND' as const,
+            message: `entryPath "${args.entryPath}" is not in the workspace. Call file_write first.`,
+          };
         }
+        stepPaths = [rel];
       }
 
       // Org package policy check. The `run_code` governance policy is the
@@ -437,18 +442,14 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
         packagesByLang.node = args.packages.node;
       }
 
+      // A standalone install gets a 120s default — a cold pip/npm resolve
+      // rarely fits the 30s interactive default the run modes keep.
+      const timeoutMs =
+        args.timeoutMs ?? (args.mode === 'install' ? 120_000 : undefined);
+
       // Execute in the thread's persistent sandbox session — it stages inputs
       // and harvests outputs; prior outputs persist in the workspace across
       // runs (no re-stage / re-harvest churn).
-      // Inline mode: superRefine ties `language` to `code`, but TS narrows
-      // them independently — guard explicitly.
-      if (args.code !== undefined && args.language === undefined) {
-        return {
-          ok: false as const,
-          code: 'INVALID_STEP_PATH' as const,
-          message: '`language` is required with `code` (python | node | bash).',
-        };
-      }
       let raw: unknown;
       try {
         raw = await ctx.runAction(
@@ -457,13 +458,12 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
             organizationId,
             threadId: workspaceThreadId,
             uploadedBy: userId,
-            stepPaths: stepPaths.map((rel) => `/user/code/${rel}`),
-            ...(args.code !== undefined &&
-              args.language !== undefined && {
-                inlineCode: { content: args.code, language: args.language },
-              }),
+            stepPaths: stepPaths.map((p) => `/user/code/${p}`),
+            ...(args.mode === 'inline' && {
+              inlineCode: { content: args.code, language: args.language },
+            }),
             ...(Object.keys(packagesByLang).length > 0 && { packagesByLang }),
-            ...(args.timeoutMs !== undefined && { timeoutMs: args.timeoutMs }),
+            ...(timeoutMs !== undefined && { timeoutMs }),
           },
         );
       } catch (err) {
@@ -491,7 +491,6 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
           contentType: string;
         }>;
         executionId: string;
-        steps?: Array<unknown>;
       };
 
       const success = run.status === 'completed';
@@ -522,7 +521,12 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
         }
       }
 
-      const message = formatRunCodeResultMessage(run);
+      const message = formatRunCodeResultMessage(run, {
+        installOnly: args.mode === 'install',
+        packageCount:
+          (args.packages?.python?.length ?? 0) +
+          (args.packages?.node?.length ?? 0),
+      });
 
       // Sandbox-state manifest: the current workspace files grouped by area,
       // each with its `fileId` (storage id). Reported on every run (success
@@ -551,7 +555,6 @@ Every result message embeds the run's terminal output (stdout inline, capped at 
         runStderrPreview: run.stderrPreview,
         durationMs: run.durationMs,
         files: run.files,
-        ...(run.steps !== undefined && { steps: run.steps }),
         sandboxState,
         message: messageWithState,
       };

--- a/services/platform/convex/node_only/sandbox/run_agent.ts
+++ b/services/platform/convex/node_only/sandbox/run_agent.ts
@@ -1154,6 +1154,7 @@ export async function runAgentInSessionImpl(
       ...(lastEventAt !== undefined && { lastEventAt }),
       lastSeq: cursor.lastSeq,
       ...(sendIdle && { agentIdle }),
+      pendingBackgroundTasks: pendingTasks.size,
       ...(capturedSessionId !== undefined && {
         agentSessionId: capturedSessionId,
       }),

--- a/services/platform/convex/node_only/sandbox/session_exec.test.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.test.ts
@@ -85,11 +85,16 @@ function execResult(over: Partial<Record<string, unknown>> = {}) {
   };
 }
 
-function callArg(call: number): { command: string[]; timeoutMs: number } {
+function callArg(call: number): {
+  command: string[];
+  timeoutMs: number;
+  cwd: string;
+} {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test helper over the mocked wire body
   return drainSessionExecResilient.mock.calls[call][1] as {
     command: string[];
     timeoutMs: number;
+    cwd: string;
   };
 }
 
@@ -123,6 +128,9 @@ describe('runStepsInSession — install semantics', () => {
       '--no-input',
       'pandas',
     ]);
+    // Installs run from the workspace root — /user/code may not exist yet on
+    // a fresh session with nothing staged, and runnerd rejects a missing cwd.
+    expect(callArg(0).cwd).toBe('/user');
   });
 
   it('fails the run when pip exits non-zero: INSTALL_FAILED, nothing else runs', async () => {
@@ -183,6 +191,8 @@ describe('runStepsInSession — install semantics', () => {
     expect(callArg(0).timeoutMs).toBe(120_000);
     expect(callArg(1).timeoutMs).toBe(30_000);
     expect(callArg(1).command).toEqual(['python3', '/user/code/a.py']);
+    expect(callArg(0).cwd).toBe('/user');
+    expect(callArg(1).cwd).toBe('/user/code');
   });
 
   it('keeps a caller-raised timeout for the install too, capped at 300s', async () => {

--- a/services/platform/convex/node_only/sandbox/session_exec.test.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.test.ts
@@ -1,11 +1,28 @@
-// Inline-snippet staging contract: the synthesized path routes the right
-// interpreter (extension-dispatched by interpreterCommand) and stays inside
-// the hidden .inline dir, which is never a threadFile and thus invisible to
-// sandboxState. Pure function — no mocks.
+// Inline-snippet staging contract (pure functions), the executeCodeInSession
+// arg mutex, and runStepsInSession's install semantics — pip/npm exit codes
+// must fail the run (INSTALL_FAILED) and installs get their own floored
+// budget. The session wire is mocked at the session_client boundary, the same
+// seam the crawler render tests use.
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { inlineStagePath, stagePathOf } from './session_exec';
+const drainSessionExecResilient = vi.fn();
+
+vi.mock('./helpers/session_client', () => ({
+  drainSessionExecResilient: (...args: unknown[]) =>
+    drainSessionExecResilient(...args),
+  sessionDeleteFiles: vi.fn(),
+  sessionListFiles: vi.fn().mockResolvedValue([]),
+  sessionReadFile: vi.fn(),
+  sessionStageFiles: vi.fn(),
+}));
+
+import {
+  execInputsError,
+  inlineStagePath,
+  runStepsInSession,
+  stagePathOf,
+} from './session_exec';
 
 describe('inlineStagePath', () => {
   it('routes each language to the extension the runtime dispatches on', () => {
@@ -24,5 +41,195 @@ describe('inlineStagePath', () => {
   it('round-trips through stagePathOf like every other step path', () => {
     const rel = inlineStagePath('python', 'x');
     expect(stagePathOf(`/user/${rel}`)).toBe(rel);
+  });
+});
+
+describe('execInputsError', () => {
+  it('accepts script, inline, and install-only combinations', () => {
+    expect(execInputsError({ stepPaths: ['/user/code/a.py'] })).toBeNull();
+    expect(
+      execInputsError({ stepPaths: [], inlineCode: { content: 'x' } }),
+    ).toBeNull();
+    expect(
+      execInputsError({
+        stepPaths: [],
+        packagesByLang: { python: ['pandas'] },
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects steps + inline together and the fully-empty call', () => {
+    expect(
+      execInputsError({
+        stepPaths: ['/user/code/a.py'],
+        inlineCode: { content: 'x' },
+      }),
+    ).toContain('not both');
+    expect(execInputsError({ stepPaths: [] })).toContain('requires');
+    // Declared-but-empty package buckets don't make an empty call executable.
+    expect(
+      execInputsError({ stepPaths: [], packagesByLang: { python: [] } }),
+    ).toContain('requires');
+  });
+});
+
+function execResult(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    status: 'completed',
+    exitCode: 0,
+    durationMs: 5,
+    stdoutBase64: Buffer.from('').toString('base64'),
+    stderrBase64: Buffer.from('').toString('base64'),
+    truncated: { stdout: false, stderr: false },
+    ...over,
+  };
+}
+
+function callArg(call: number): { command: string[]; timeoutMs: number } {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test helper over the mocked wire body
+  return drainSessionExecResilient.mock.calls[call][1] as {
+    command: string[];
+    timeoutMs: number;
+  };
+}
+
+describe('runStepsInSession — install semantics', () => {
+  beforeEach(() => {
+    drainSessionExecResilient.mockReset();
+  });
+
+  it('runs a packages-only call to completed and surfaces installer stdout', async () => {
+    drainSessionExecResilient.mockResolvedValue(
+      execResult({
+        stdoutBase64: Buffer.from(
+          'Successfully installed pandas-2.2.1\n',
+        ).toString('base64'),
+      }),
+    );
+    const run = await runStepsInSession('sid', {
+      stepPaths: [],
+      packagesByLang: { python: ['pandas'] },
+    });
+    expect(run.status).toBe('completed');
+    expect(run.exitCode).toBe(0);
+    expect(run.errorCode).toBeUndefined();
+    expect(run.stdout).toContain('Successfully installed pandas-2.2.1');
+    expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
+    expect(callArg(0).command).toEqual([
+      'python3',
+      '-m',
+      'pip',
+      'install',
+      '--no-input',
+      'pandas',
+    ]);
+  });
+
+  it('fails the run when pip exits non-zero: INSTALL_FAILED, nothing else runs', async () => {
+    drainSessionExecResilient.mockResolvedValue(
+      execResult({
+        exitCode: 1,
+        stderrBase64: Buffer.from(
+          'ERROR: No matching distribution found for nope\n',
+        ).toString('base64'),
+      }),
+    );
+    const run = await runStepsInSession('sid', {
+      stepPaths: ['/user/code/a.py'],
+      packagesByLang: { python: ['nope'], node: ['sharp'] },
+    });
+    expect(run.status).toBe('failed');
+    expect(run.errorCode).toBe('INSTALL_FAILED');
+    expect(run.errorMessage).toContain('pip install failed (exit 1)');
+    expect(run.stderr).toContain('No matching distribution');
+    // Short-circuit: neither the npm install nor the step ran.
+    expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails on npm after a clean pip and names the failing tool', async () => {
+    drainSessionExecResilient
+      .mockResolvedValueOnce(execResult())
+      .mockResolvedValueOnce(execResult({ exitCode: 127 }));
+    const run = await runStepsInSession('sid', {
+      stepPaths: [],
+      packagesByLang: { python: ['pandas'], node: ['sharp'] },
+    });
+    expect(run.status).toBe('failed');
+    expect(run.errorCode).toBe('INSTALL_FAILED');
+    expect(run.errorMessage).toContain('npm install failed (exit 127)');
+    expect(drainSessionExecResilient).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a non-completed install status as INSTALL_FAILED even with exit 0', async () => {
+    drainSessionExecResilient.mockResolvedValue(
+      execResult({ status: 'failed', errorCode: 'TIMEOUT' }),
+    );
+    const run = await runStepsInSession('sid', {
+      stepPaths: [],
+      packagesByLang: { python: ['torch'] },
+    });
+    expect(run.status).toBe('failed');
+    expect(run.errorCode).toBe('INSTALL_FAILED');
+    expect(run.errorMessage).toContain('TIMEOUT');
+  });
+
+  it('floors the install budget at 120s while the step keeps its own timeout', async () => {
+    drainSessionExecResilient.mockResolvedValue(execResult());
+    await runStepsInSession('sid', {
+      stepPaths: ['/user/code/a.py'],
+      packagesByLang: { python: ['pandas'] },
+      timeoutMs: 30_000,
+    });
+    expect(callArg(0).timeoutMs).toBe(120_000);
+    expect(callArg(1).timeoutMs).toBe(30_000);
+    expect(callArg(1).command).toEqual(['python3', '/user/code/a.py']);
+  });
+
+  it('keeps a caller-raised timeout for the install too, capped at 300s', async () => {
+    drainSessionExecResilient.mockResolvedValue(execResult());
+    await runStepsInSession('sid', {
+      stepPaths: [],
+      packagesByLang: { python: ['torch'] },
+      timeoutMs: 240_000,
+    });
+    expect(callArg(0).timeoutMs).toBe(240_000);
+  });
+
+  it('does not add install execs for package-less callers (workflow/crawler path)', async () => {
+    drainSessionExecResilient.mockResolvedValue(
+      execResult({
+        stdoutBase64: Buffer.from('hello\n').toString('base64'),
+      }),
+    );
+    const run = await runStepsInSession('sid', {
+      stepPaths: ['/user/code/a.py'],
+      timeoutMs: 45_000,
+    });
+    expect(run.status).toBe('completed');
+    expect(run.stdout).toBe('hello\n');
+    expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
+    expect(callArg(0).command).toEqual(['python3', '/user/code/a.py']);
+    expect(callArg(0).timeoutMs).toBe(45_000);
+  });
+
+  it('keeps install noise out of a successful script run stdout', async () => {
+    drainSessionExecResilient
+      .mockResolvedValueOnce(
+        execResult({
+          stdoutBase64: Buffer.from(
+            'Collecting pandas\nSuccessfully installed pandas-2.2.1\n',
+          ).toString('base64'),
+        }),
+      )
+      .mockResolvedValueOnce(
+        execResult({
+          stdoutBase64: Buffer.from('report written\n').toString('base64'),
+        }),
+      );
+    const run = await runStepsInSession('sid', {
+      stepPaths: ['/user/code/a.py'],
+      packagesByLang: { python: ['pandas'] },
+    });
+    expect(run.stdout).toBe('report written\n');
   });
 });

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -139,13 +139,21 @@ export async function runStepsInSession(
   const abort = new AbortController();
   const stdoutParts: string[] = [];
   const stderrParts: string[] = [];
-  const runExec = async (command: string[], perTimeout: number) =>
+  const runExec = async (
+    command: string[],
+    perTimeout: number,
+    // Steps run from /user/code (staging created it — a step implies a staged
+    // script). Installs run from the workspace root: /user always exists,
+    // while /user/code doesn't on a fresh session with nothing staged (an
+    // install-only call), and runnerd rejects a non-existent cwd.
+    cwd: '/user/code' | '/user' = '/user/code',
+  ) =>
     drainSessionExecResilient(
       sessionId,
       {
         execId: randomUUID(),
         command,
-        cwd: '/user/code',
+        cwd,
         collectOutput: true,
         timeoutMs: perTimeout,
       },
@@ -172,7 +180,7 @@ export async function runStepsInSession(
     installs.push({ tool: 'npm', command: ['npm', 'install', '-g', ...node] });
   }
   for (const { tool, command } of installs) {
-    const r = await runExec(command, installTimeoutMs);
+    const r = await runExec(command, installTimeoutMs, '/user');
     const failed = r.status !== 'completed' || (r.exitCode ?? 0) !== 0;
     // Install-only runs (and failures) surface installer stdout — it carries
     // the resolved versions / the resolver error. Successful script runs drop

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -83,6 +83,10 @@ export interface SessionExecResultShape {
    * aggregates over several execs and extends with harvest I/O.
    */
   durationMs: number;
+  /** Set on failure when the cause is classified — e.g. `INSTALL_FAILED`
+   * (a declared package's pip/npm install exited non-zero). */
+  errorCode?: string;
+  errorMessage?: string;
   files: Array<{
     path: string;
     storageId: string;
@@ -110,6 +114,8 @@ export interface StepRunResult {
   exitCode: number | null;
   stdout: string;
   stderr: string;
+  errorCode?: string;
+  errorMessage?: string;
 }
 
 /**
@@ -147,21 +153,48 @@ export async function runStepsInSession(
     );
 
   // Install declared packages first (persist in the session for later runs).
+  // Installs get their own budget, floored at 120s — a cold pip/npm resolve
+  // rarely fits the 30s interactive default — and capped at the 300s schema
+  // max. A failed install fails the whole run: running the steps anyway would
+  // surface a confusing downstream ImportError (or, with no steps, report a
+  // success that never happened).
   const py = args.packagesByLang?.python ?? [];
   const node = args.packagesByLang?.node ?? [];
+  const installTimeoutMs = Math.min(Math.max(timeoutMs, 120_000), 300_000);
+  const installs: Array<{ tool: 'pip' | 'npm'; command: string[] }> = [];
   if (py.length > 0) {
-    const r = await runExec(
-      ['python3', '-m', 'pip', 'install', '--no-input', ...py],
-      Math.min(timeoutMs, 300_000),
-    );
-    stderrParts.push(Buffer.from(r.stderrBase64, 'base64').toString('utf8'));
+    installs.push({
+      tool: 'pip',
+      command: ['python3', '-m', 'pip', 'install', '--no-input', ...py],
+    });
   }
   if (node.length > 0) {
-    const r = await runExec(
-      ['npm', 'install', '-g', ...node],
-      Math.min(timeoutMs, 300_000),
-    );
+    installs.push({ tool: 'npm', command: ['npm', 'install', '-g', ...node] });
+  }
+  for (const { tool, command } of installs) {
+    const r = await runExec(command, installTimeoutMs);
+    const failed = r.status !== 'completed' || (r.exitCode ?? 0) !== 0;
+    // Install-only runs (and failures) surface installer stdout — it carries
+    // the resolved versions / the resolver error. Successful script runs drop
+    // it so install noise never drowns the script's own stdout; warnings
+    // still route to stderr as before.
+    if (args.stepPaths.length === 0 || failed) {
+      stdoutParts.push(Buffer.from(r.stdoutBase64, 'base64').toString('utf8'));
+    }
     stderrParts.push(Buffer.from(r.stderrBase64, 'base64').toString('utf8'));
+    if (failed) {
+      const detail = r.errorMessage ?? r.errorCode;
+      return {
+        status: r.status === 'cancelled' ? 'cancelled' : 'failed',
+        exitCode: r.exitCode,
+        stdout: stdoutParts.join(''),
+        stderr: stderrParts.join(''),
+        errorCode: 'INSTALL_FAILED',
+        errorMessage: `${tool} install failed${
+          r.exitCode !== null ? ` (exit ${r.exitCode})` : ''
+        }${detail !== undefined ? `: ${detail}` : ''}`,
+      };
+    }
   }
 
   // Run each step in order; stop at the first failure.
@@ -231,13 +264,18 @@ export async function runAndHarvestInSession(
   });
 
   // Harvest top-level /user/output, upserting only new/changed files (sha256).
+  // Install-only runs skip it — an install can't produce deliverables, and the
+  // sha256 dedupe would re-read every existing output file for nothing.
   const files: Array<{
     path: string;
     storageId: string;
     size: number;
     contentType: string;
   }> = [];
-  const entries = (await sessionListFiles(sessionId, OUTPUT_DIR)) ?? [];
+  const entries =
+    args.stepPaths.length === 0
+      ? []
+      : ((await sessionListFiles(sessionId, OUTPUT_DIR)) ?? []);
   for (const e of entries) {
     if (e.type !== 'file') continue;
     if (files.length >= SANDBOX_MAX_OUTPUT_FILES_PER_RUN) break;
@@ -315,11 +353,35 @@ export async function runAndHarvestInSession(
     executionId: execId,
     status: run.status,
     exitCode: run.exitCode,
+    ...(run.errorCode !== undefined && { errorCode: run.errorCode }),
+    ...(run.errorMessage !== undefined && { errorMessage: run.errorMessage }),
     stdoutPreview: run.stdout.slice(0, 4096),
     stderrPreview: run.stderr.slice(0, 4096),
     durationMs: Date.now() - startedAt,
     files,
   };
+}
+
+/** Arg mutex for {@link executeCodeInSession}: script XOR inline — or, for an
+ * install-only run, neither, iff packages are declared. Returns the rejection
+ * message, or `null` when the combination is executable. */
+export function execInputsError(args: {
+  stepPaths: string[];
+  inlineCode?: unknown;
+  packagesByLang?: { python?: string[]; node?: string[] };
+}): string | null {
+  const hasSteps = args.stepPaths.length > 0;
+  const hasInline = args.inlineCode !== undefined;
+  const hasPackages =
+    (args.packagesByLang?.python?.length ?? 0) > 0 ||
+    (args.packagesByLang?.node?.length ?? 0) > 0;
+  if (hasSteps && hasInline) {
+    return 'executeCodeInSession takes stepPaths or inlineCode, not both.';
+  }
+  if (!hasSteps && !hasInline && !hasPackages) {
+    return 'executeCodeInSession requires stepPaths, inlineCode, or packagesByLang.';
+  }
+  return null;
 }
 
 export const executeCodeInSession = internalAction({
@@ -328,7 +390,8 @@ export const executeCodeInSession = internalAction({
     threadId: v.string(),
     uploadedBy: v.string(),
     // Absolute /user/code/<script> paths (already validated by run_code_tool).
-    // Empty in inline mode (exactly one of stepPaths / inlineCode is set).
+    // Empty in inline mode (stepPaths and inlineCode are mutually exclusive)
+    // and in install-only mode (no steps, no inline code, only packagesByLang).
     stepPaths: v.array(v.string()),
     // Inline snippet mode: stage `content` as a hidden one-shot script and run
     // it as the single step. Mutually exclusive with a non-empty stepPaths.
@@ -358,6 +421,8 @@ export const executeCodeInSession = internalAction({
       v.literal('cancelled'),
     ),
     exitCode: v.union(v.number(), v.null()),
+    errorCode: v.optional(v.string()),
+    errorMessage: v.optional(v.string()),
     stdoutPreview: v.string(),
     stderrPreview: v.string(),
     durationMs: v.number(),
@@ -371,11 +436,8 @@ export const executeCodeInSession = internalAction({
     ),
   }),
   handler: async (ctx, args): Promise<SessionExecResultShape> => {
-    if (args.stepPaths.length > 0 === (args.inlineCode !== undefined)) {
-      throw new Error(
-        'executeCodeInSession requires exactly one of stepPaths / inlineCode.',
-      );
-    }
+    const inputsError = execInputsError(args);
+    if (inputsError !== null) throw new Error(inputsError);
     const { sessionId, created } = await ctx.runAction(
       internal.node_only.sandbox.thread_session.ensureThreadSession,
       {

--- a/services/platform/convex/providers/resolve_model.ts
+++ b/services/platform/convex/providers/resolve_model.ts
@@ -181,7 +181,9 @@ type JSONSchema7Object = Record<string, unknown>;
  * All properties become optional except those required by every variant
  * (typically just the discriminator field like `operation`).
  */
-function flattenUnionSchema(schema: JSONSchema7Object): JSONSchema7Object {
+export function flattenUnionSchema(
+  schema: JSONSchema7Object,
+): JSONSchema7Object {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON Schema oneOf/anyOf are arrays of schema objects
   const variants = (schema.oneOf ?? schema.anyOf) as
     | JSONSchema7Object[]

--- a/services/platform/convex/sandbox/session_mutations.ts
+++ b/services/platform/convex/sandbox/session_mutations.ts
@@ -828,6 +828,8 @@ export const upsertSessionOp = internalMutation({
     /** Lingering transition (claude-code stdin-hold): true stamps agentIdleAt,
      * false clears it. Omitted ⇒ untouched (the usual throttled flush). */
     agentIdle: v.optional(v.boolean()),
+    /** Background-task ledger depth (0 clears the field). */
+    pendingBackgroundTasks: v.optional(v.number()),
   },
   returns: v.id('sandboxSessionOps'),
   handler: async (ctx, args) => {
@@ -884,9 +886,16 @@ export const upsertSessionOp = internalMutation({
     if (args.agentIdle !== undefined) {
       patch.agentIdleAt = args.agentIdle ? now : undefined;
     }
+    if (args.pendingBackgroundTasks !== undefined) {
+      patch.pendingBackgroundTasks =
+        args.pendingBackgroundTasks > 0
+          ? args.pendingBackgroundTasks
+          : undefined;
+    }
     if (terminal) {
       patch.finishedAt = now;
       patch.agentIdleAt = undefined;
+      patch.pendingBackgroundTasks = undefined;
     }
 
     if (existing) {

--- a/services/platform/convex/sandbox/session_ops_coverage.test.ts
+++ b/services/platform/convex/sandbox/session_ops_coverage.test.ts
@@ -103,6 +103,37 @@ describe('upsertSessionOp', () => {
     expect(row?.agentIdleAt).toBeUndefined();
     expect(typeof row?.finishedAt).toBe('number');
   });
+
+  it('pendingBackgroundTasks>0 is stored; 0 clears; terminal clears', async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.sandbox.session_mutations.upsertSessionOp, {
+      ...base,
+      status: 'running',
+      pendingBackgroundTasks: 2,
+    });
+    let row = await getOp(t, 'sid-1', 'exec-1');
+    expect(row?.pendingBackgroundTasks).toBe(2);
+
+    await t.mutation(internal.sandbox.session_mutations.upsertSessionOp, {
+      ...base,
+      status: 'running',
+      pendingBackgroundTasks: 0,
+    });
+    row = await getOp(t, 'sid-1', 'exec-1');
+    expect(row?.pendingBackgroundTasks).toBeUndefined();
+
+    await t.mutation(internal.sandbox.session_mutations.upsertSessionOp, {
+      ...base,
+      status: 'running',
+      pendingBackgroundTasks: 1,
+    });
+    await t.mutation(internal.sandbox.session_mutations.upsertSessionOp, {
+      ...base,
+      status: 'completed',
+    });
+    row = await getOp(t, 'sid-1', 'exec-1');
+    expect(row?.pendingBackgroundTasks).toBeUndefined();
+  });
 });
 
 describe('claimSessionOpFinalize', () => {

--- a/services/platform/convex/sandbox/session_queries_public.ts
+++ b/services/platform/convex/sandbox/session_queries_public.ts
@@ -45,6 +45,9 @@ export const getActiveSessionOp = query({
       // on held-open stdin (so we can still inject queued/steer messages). Lets
       // the UI distinguish "lingering/ready" from "actively working".
       agentIdleAt: v.optional(v.number()),
+      /** >0 while the model is parked on in-session background work (bash,
+       * workflow tasks). Keeps active-work affordances during quiet-idle. */
+      pendingBackgroundTasks: v.optional(v.number()),
       // The turn's CURRENT live segment message — the single bubble the drain
       // is streaming into. Anchors the chat's thinking indicator (the live
       // region) instead of positional scans; changes only at segment seams,
@@ -85,6 +88,10 @@ export const getActiveSessionOp = query({
       ...(latest.assistantMessageId !== undefined && {
         assistantMessageId: latest.assistantMessageId,
       }),
+      ...(latest.pendingBackgroundTasks !== undefined &&
+        latest.pendingBackgroundTasks > 0 && {
+          pendingBackgroundTasks: latest.pendingBackgroundTasks,
+        }),
     };
   },
 });

--- a/services/platform/convex/sandbox/sessions_schema.ts
+++ b/services/platform/convex/sandbox/sessions_schema.ts
@@ -180,6 +180,10 @@ export const sandboxSessionOpsTable = defineTable({
    * staged into a lingering exec would sit unconsumed: no tool/stop
    * boundaries fire while the model idles). Cleared when activity resumes. */
   agentIdleAt: v.optional(v.number()),
+  /** Background-task ledger depth while running (task_started minus settled).
+   * Lets the chat UI distinguish steer-ready linger (0) from parked-on-work
+   * linger (>0) without inferring from silence alone. */
+  pendingBackgroundTasks: v.optional(v.number()),
   /** Resume cursor: highest runnerd event seq consumed (for the continuation
    * action to re-attach without missing/duplicating events). */
   lastSeq: v.optional(v.number()),

--- a/services/platform/tests/sandbox-output-paths.test.ts
+++ b/services/platform/tests/sandbox-output-paths.test.ts
@@ -37,4 +37,14 @@ describe('run_code tool — container path contract', () => {
   it('points deliverables at the real harvest dir /user/output', () => {
     expect(runCodeToolSource).toContain('/user/output');
   });
+
+  it('teaches every mode with a copy-paste JSON example', () => {
+    for (const example of [
+      '"mode": "inline"',
+      '"mode": "script"',
+      '"mode": "install"',
+    ]) {
+      expect(runCodeToolSource).toContain(example);
+    }
+  });
 });

--- a/services/sandbox/docs/run-code-persistent-sessions.md
+++ b/services/sandbox/docs/run-code-persistent-sessions.md
@@ -154,9 +154,9 @@ just stay there:
 - **Packages.** Installed in a turn, they persist in the workspace (pip/npm
   target under the persistent `/user`), so re-declaring `packages` becomes
   optional, not required. This removes the `/dev/null` "install-only" hack: a
-  bare `pip install …` step in a persistent session simply persists. (We can
-  still accept a `packages`-only `run_code` with no `entryPath`/`steps` as a
-  first-class "prepare env" call — a small, separate ergonomics win.)
+  bare `pip install …` step in a persistent session simply persists. (The
+  first-class "prepare env" call shipped as `run_code`'s `mode: "install"` —
+  packages-only, no script.)
 
 ## 7. `run_code` always returns the sandbox state manifest
 


### PR DESCRIPTION
## Summary

Replaces `run_code`'s `entryPath`/`steps`/`code` mutex with an explicit `mode` discriminator — `script | inline | install` — as strict schema variants, and ships the P0 reliability/governance fixes that came out of the plan review.

- **`mode: "install"`** (new): packages-only provisioning — no script, skips the empty-workspace gate and the output harvest, 120s default timeout. Installed packages persist for later `run_code` calls in the turn's session.
- **`steps` removed** (breaking for the tool schema only): multi-step work is sequential `run_code` calls against the turn-scoped session; the mode error message carries copy-paste examples for repair.
- **Strict variants are load-bearing:** the provider-facing schema is flattened for OpenAI (`flattenUnionSchema`), which advertises every field on every mode — non-strict objects would silently strip cross-mode keys (e.g. `code` alongside `mode: "script"`) and run something other than what the model asked. Strict variants reject with a repairable `unrecognized_keys` error. Snapshot test locks `required === ['mode']`.
- **P0 — install failures propagate:** `runStepsInSession` previously ignored pip/npm exit codes (a failed install was invisible on successful runs since stderr only surfaces on failure). Now: non-zero install → short-circuit, `INSTALL_FAILED` with the failing tool + exit code; installs get their own budget (`min(max(timeoutMs, 120s), 300s)`); `errorCode`/`errorMessage` threaded through `SessionExecResultShape` and the action's returns validator. Workflow + crawler callers never pass packages — regression-tested unaffected.
- **P0 — node packages now hit the policy gate:** `checkPackagesAgainstPolicy` only ever checked the python bucket. Runtime and the admin policy tester now share one `evaluatePackageAgainstPolicy` (case-insensitive base-name match, deny wins even in allowlist mode) — this also fixes two pre-existing admin/runtime semantic divergences.
- **Inline pre-flight (fail-open):** new `inline_language.ts` scores per-declared-language signals over literal-stripped code — `LANGUAGE_MISMATCH` for interpreter/syntax contradictions (the `import: command not found` classic, plus a stderr backstop hint), `PREFER_PACKAGES` for ad-hoc `pip install` / `npm install -g` (route through the policy-gated `packages` param; `-r`/`-e`/project-local npm stay allowed).

Second commit (bundled intentionally): `pendingBackgroundTasks` ledger on `sandboxSessionOps` + `isAgentActivelyWorking`/`isAgentLingeringSteerReady` chat helpers, so the Working pill / stop / streaming affordances persist while background tasks run and stdin-steer engages only on true idle.

## Definition of done

- [x] Green gate — format, oxlint (type-aware), tsc, full platform vitest suite (75k pass; 4 convexTest files are the known starvation flake — pass in isolation)
- [x] Security gate — opengrep SAST 0 findings (repo scan + pre-commit staged scans)
- [x] Tests — 76 targeted: strict-union schema (accept/reject/steps/cross-mode), policy node×python×allow/deny/case, install semantics incl. packages-only + timeout floor + short-circuit, inline heuristic TP/FP matrix, flatten snapshot, tool-description path/mode contract
- [x] Migration — N/A for the run_code commit (no persisted schema change); the sessions field is optional + `migrations:check` classifies it data-safe
- [x] Locales — N/A: all new strings are LLM-facing; `INSTALL_FAILED` canvas keys already exist in en/de/fr
- [x] Docs — sandbox design doc updated (`mode: "install"` shipped); docs/ has no run_code pages (verified); builtin-configs carry no steps/pip guidance (verified)
- [x] Accessibility — N/A: no UI structure change (admin route swaps internal logic only)
- [x] Sweep — error-code renames grep-verified single-file; `runCodeArgs`/`executeCodeInSession` consumers enumerated; e2e/examples/skills carry no old-arg references
- [x] Observed — schema + heuristic behavior exercised via live bun scripts; session semantics via mocked-wire tests; **browser E2E running now, evidence follows as a PR comment**
- [x] Commits — atomic conventional pair, branched off main

## Test plan

Browser E2E on the dev stack immediately after opening (scenarios: inline happy path, install-only success + failure, script+packages, PREFER_PACKAGES rejection + model adaptation, language-mismatch rejection, org policy deny incl. node bucket, admin tester parity). Results land as a comment on this PR.