### PR TITLE
feat(platform): sectioned agent pickers in project settings

### DIFF
--- a/services/platform/app/features/documents/components/team-multi-select.test.tsx
+++ b/services/platform/app/features/documents/components/team-multi-select.test.tsx
@@ -25,6 +25,20 @@ describe('TeamMultiSelect', () => {
     expect(screen.getByText('Organization-wide')).toBeInTheDocument();
   });
 
+  it('renders muted placeholder when emptyPlaceholderStyle is muted', () => {
+    render(
+      <TeamMultiSelect
+        {...defaultProps}
+        orgWideLabel="No additional teams"
+        emptyPlaceholderStyle="muted"
+      />,
+    );
+
+    const placeholder = screen.getByText('No additional teams');
+    expect(placeholder).toBeInTheDocument();
+    expect(placeholder).toHaveClass('text-muted-foreground');
+  });
+
   it('shows selected teams as chips', () => {
     render(
       <TeamMultiSelect

--- a/services/platform/app/features/documents/components/team-multi-select.tsx
+++ b/services/platform/app/features/documents/components/team-multi-select.tsx
@@ -14,22 +14,31 @@ interface TeamMultiSelectProps {
   teams: Team[];
   selectedTeamIds: string[];
   onSelectionChange: (teamIds: string[]) => void;
+  /** Label shown when no teams are selected in the multiselect. */
   orgWideLabel: string;
+  /**
+   * How the empty-state label renders. `chip` reads as a selected tag (org-wide
+   * defaults on documents/agents); `muted` reads as placeholder text when empty
+   * means "no additional teams" rather than org-wide access.
+   * @default 'chip'
+   */
+  emptyPlaceholderStyle?: 'chip' | 'muted';
   disabled?: boolean;
 }
 
 /**
  * Team picker for document / project / agent sharing. A thin wrapper over the
  * shared {@link MultiSelect} primitive: it adapts the `{ id, name }` team shape
- * to options and renders the "org-wide" implicit-default chip as the empty
- * placeholder. The popover gains search + scroll for free, so the same control
- * scales from a handful of teams to hundreds.
+ * to options and renders an empty-state label (chip or muted placeholder).
+ * The popover gains search + scroll for free, so the same control scales from a
+ * handful of teams to hundreds.
  */
 export function TeamMultiSelect({
   teams,
   selectedTeamIds,
   onSelectionChange,
   orgWideLabel,
+  emptyPlaceholderStyle = 'chip',
   disabled,
 }: TeamMultiSelectProps) {
   const { t } = useT('common');
@@ -39,17 +48,22 @@ export function TeamMultiSelect({
     [teams],
   );
 
+  const placeholder =
+    emptyPlaceholderStyle === 'muted' ? (
+      orgWideLabel
+    ) : (
+      <span className="bg-muted inline-flex items-center rounded px-2 py-0.5 text-xs font-medium">
+        {orgWideLabel}
+      </span>
+    );
+
   return (
     <MultiSelect
       value={selectedTeamIds}
       onValueChange={onSelectionChange}
       options={options}
       disabled={disabled || teams.length === 0}
-      placeholder={
-        <span className="bg-muted inline-flex items-center rounded px-2 py-0.5 text-xs font-medium">
-          {orgWideLabel}
-        </span>
-      }
+      placeholder={placeholder}
       searchPlaceholder={t('search.placeholder')}
       emptyText={t('search.noResults')}
       modal

--- a/services/platform/app/features/projects/components/project-agents-tab.tsx
+++ b/services/platform/app/features/projects/components/project-agents-tab.tsx
@@ -15,6 +15,8 @@ import {
 } from '@/app/components/ui/editor';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { useListAgents } from '@/app/features/agents/hooks/queries';
+import { toConfigurableAgent } from '@/app/features/agents/utils/agent-list-item';
+import { buildAgentSectionOptions } from '@/app/features/agents/utils/agent-picker-options';
 import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -78,26 +80,43 @@ export function ProjectAgentsTab({
 
   const agentOptions = useMemo<SlugOption[]>(() => {
     if (!rawAgents) return [];
-    const out: SlugOption[] = [];
-    for (const a of rawAgents) {
-      if (!a || typeof a.name !== 'string' || 'status' in a) continue;
-      const resolved = resolveAgentLocale(a, locale);
-      // Some system agents (e.g. `image-generator`) carry no localized
-      // displayName — fall back to a humanized slug rather than dropping
-      // them from the picker, otherwise admins can't restrict/recommend
-      // them at all.
+    const entries: Array<{
+      agent: NonNullable<ReturnType<typeof toConfigurableAgent>>;
+      label: string;
+      description?: string;
+    }> = [];
+    for (const raw of rawAgents) {
+      const agent = toConfigurableAgent(raw);
+      if (!agent) continue;
+      const resolved = resolveAgentLocale(agent, locale);
       const label =
         resolved.displayName && resolved.displayName.length > 0
           ? resolved.displayName
-          : humanizeSlug(a.name);
-      out.push({
-        value: a.name,
-        label,
-        description: resolved.description,
-      });
+          : humanizeSlug(agent.name);
+      entries.push({ agent, label, description: resolved.description });
     }
-    return out;
-  }, [rawAgents, locale]);
+    const byName = new Map(entries.map((entry) => [entry.agent.name, entry]));
+
+    return buildAgentSectionOptions(
+      entries.map((entry) => entry.agent),
+      (agent) => ({
+        value: agent.name,
+        label: byName.get(agent.name)?.label ?? humanizeSlug(agent.name),
+        description: byName.get(agent.name)?.description,
+      }),
+      {
+        platform: t('agents.sectionAgents'),
+        coding: t('agents.sectionCodingAgents'),
+        image: t('agents.sectionImageAgents'),
+      },
+      (section) =>
+        [...section].sort((a, b) =>
+          (byName.get(a.name)?.label ?? a.name).localeCompare(
+            byName.get(b.name)?.label ?? b.name,
+          ),
+        ),
+    );
+  }, [rawAgents, locale, t]);
 
   const modelOptions = useMemo<SlugOption[]>(() => {
     const out: SlugOption[] = [];

--- a/services/platform/app/features/projects/components/project-sharing-section.tsx
+++ b/services/platform/app/features/projects/components/project-sharing-section.tsx
@@ -216,7 +216,8 @@ export function ProjectSharingSection({
               teams={shareableTeams}
               selectedTeamIds={sharedWithTeamIds}
               onSelectionChange={handleSharedTeamsChange}
-              orgWideLabel={t('list.sharingOrgWide')}
+              orgWideLabel={t('settings.noAdditionalTeams')}
+              emptyPlaceholderStyle="muted"
               disabled={isPending}
             />
           </div>

--- a/services/platform/app/features/projects/components/project-slug-list-editor.test.tsx
+++ b/services/platform/app/features/projects/components/project-slug-list-editor.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen, within } from '@/tests/utils/render';
+
+import {
+  ProjectSlugListEditor,
+  type SlugOption,
+} from './project-slug-list-editor';
+
+const OPTIONS: SlugOption[] = [
+  {
+    value: 'assistant',
+    label: 'Assistant',
+    description: 'General-purpose AI assistant',
+  },
+  {
+    value: 'coder',
+    label: 'Coder',
+    description: 'Writes, runs, and reviews code',
+  },
+];
+
+describe('ProjectSlugListEditor', () => {
+  it('keeps the ghost add button as the popover trigger when open', async () => {
+    const { user } = render(
+      <ProjectSlugListEditor
+        value={[]}
+        onChange={vi.fn()}
+        options={OPTIONS}
+        addLabel="Add agent"
+        mode="recommended"
+      />,
+    );
+
+    const addButton = screen.getByRole('button', { name: 'Add agent' });
+    await user.click(addButton);
+
+    expect(screen.getByRole('button', { name: 'Add agent' })).toBe(addButton);
+    expect(screen.queryByRole('combobox')).toBeInTheDocument();
+    expect(
+      screen.getByText('General-purpose AI assistant'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('General-purpose AI assistant').className,
+    ).toContain('line-clamp-2');
+  });
+
+  it('appends the selected slug and closes the picker', async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <ProjectSlugListEditor
+        value={[]}
+        onChange={onChange}
+        options={OPTIONS}
+        addLabel="Add agent"
+        mode="recommended"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add agent' }));
+    const listbox = screen.getByRole('listbox');
+    await user.click(within(listbox).getByRole('option', { name: /Coder/i }));
+
+    expect(onChange).toHaveBeenCalledWith(['coder']);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('hides the add control when every option is already selected', () => {
+    render(
+      <ProjectSlugListEditor
+        value={['assistant', 'coder']}
+        onChange={vi.fn()}
+        options={OPTIONS}
+        addLabel="Add agent"
+        mode="recommended"
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Add agent' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/projects/components/project-slug-list-editor.tsx
+++ b/services/platform/app/features/projects/components/project-slug-list-editor.tsx
@@ -14,6 +14,7 @@ import {
   SearchableSelect,
   type SearchableSelectOption,
 } from '@/app/components/ui/forms/searchable-select';
+import { pruneEmptyAgentSections } from '@/app/features/agents/utils/agent-picker-options';
 import { useT } from '@/lib/i18n/client';
 
 export interface SlugOption extends SearchableSelectOption {
@@ -98,7 +99,10 @@ export function ProjectSlugListEditor({
   const selectedSet = useMemo(() => new Set(localValue), [localValue]);
 
   const remainingOptions = useMemo(
-    () => options.filter((opt) => !selectedSet.has(opt.value)),
+    () =>
+      pruneEmptyAgentSections(
+        options.filter((opt) => !selectedSet.has(opt.value)),
+      ),
     [options, selectedSet],
   );
 
@@ -250,23 +254,24 @@ export function ProjectSlugListEditor({
       ) : null}
 
       {!disabled && remainingOptions.length > 0 ? (
-        pickerOpen ? (
-          <SearchableSelect
-            value={null}
-            onValueChange={handleAdd}
-            options={remainingOptions}
-            placeholder={addLabel}
-            open
-            onOpenChange={setPickerOpen}
-          />
-        ) : (
-          <div>
-            <Button variant="ghost" onClick={() => setPickerOpen(true)}>
+        <SearchableSelect
+          value={null}
+          onValueChange={handleAdd}
+          options={remainingOptions}
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          align="start"
+          contentClassName="w-[28rem] max-w-[calc(100vw-2rem)]"
+          searchPlaceholder={tCommon('search.placeholder')}
+          emptyText={tCommon('search.noResults')}
+          aria-label={addLabel}
+          trigger={
+            <Button type="button" variant="ghost">
               <Plus className="size-4" aria-hidden="true" />
               {addLabel}
             </Button>
-          </div>
-        )
+          }
+        />
       ) : null}
     </Stack>
   );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -8012,6 +8012,7 @@
       "owningTeamHelp": "Mitglieder dieses Teams haben Vollzugriff. Organisationsadmins haben immer Zugriff.",
       "alsoSharedWith": "Auch geteilt mit",
       "alsoSharedWithHelp": "Wähle weitere Teams, die dieses Projekt sehen sollen.",
+      "noAdditionalTeams": "Keine weiteren Teams",
       "visibility": "Sichtbarkeit",
       "visibilityTeam": "Nur Team",
       "visibilityShared": "Bestimmte Teams",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5381,6 +5381,7 @@
       "owningTeamHelp": "Members of this team get full access. Admins of the org always have access.",
       "alsoSharedWith": "Also shared with",
       "alsoSharedWithHelp": "Pick additional teams that should see this project.",
+      "noAdditionalTeams": "No additional teams",
       "visibility": "Visibility",
       "visibilityTeam": "Team-only",
       "visibilityShared": "Specific teams",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -8013,6 +8013,7 @@
       "owningTeamHelp": "Les membres de cette équipe ont un accès complet. Les administrateurs de l'organisation ont toujours accès.",
       "alsoSharedWith": "Également partagé avec",
       "alsoSharedWithHelp": "Choisis d'autres équipes qui devraient voir ce projet.",
+      "noAdditionalTeams": "Aucune équipe supplémentaire",
       "visibility": "Visibilité",
       "visibilityTeam": "Équipe uniquement",
       "visibilityShared": "Équipes spécifiques",


### PR DESCRIPTION
Rebuilds the project **agents tab** and **slug-list editor** to reuse the shared agent-section picker (grouped Agents / Coding agents / Image via `agent-picker-options`), and switches the project **sharing** team-picker to the muted empty-state (`team-multi-select` `emptyPlaceholderStyle`) with a "No additional teams" label.

**Stacked on** #2594 (coding-agent taxonomy) — depends on `agent-picker-options` + `display-category`. Pure frontend.

## Test
`bun run --filter @tale/platform test -- project-slug-list-editor team-multi-select` + typecheck.