### PR TITLE
fix(platform): fix type-aware lint errors breaking main

### DIFF
--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -309,7 +309,7 @@ export function TabNavigation({
       if (settled) settled.style.transition = '';
       resizeRestoreTimerRef.current = null;
     }, 150);
-  }, [updateIndicator]);
+  }, [updateIndicator, measureScrollable]);
   useEffect(
     () => () => {
       if (resizeRestoreTimerRef.current) {

--- a/services/platform/app/features/projects/components/project-mode-radio.tsx
+++ b/services/platform/app/features/projects/components/project-mode-radio.tsx
@@ -2,6 +2,7 @@
 
 import { Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
+import { useId } from 'react';
 
 import {
   RadioGroup,
@@ -42,19 +43,25 @@ export function ProjectModeRadio({
   disabled,
   legend,
 }: ProjectModeRadioProps) {
+  const groupId = useId();
   return (
     <RadioGroup
       value={value}
-      onValueChange={(next) => onChange(next as ProjectModeRadioValue)}
+      onValueChange={(next) => {
+        const match = options.find((opt) => opt.value === next);
+        if (match) onChange(match.value);
+      }}
       disabled={disabled}
       aria-label={legend}
       className="gap-2"
     >
       {options.map((opt) => {
         const checked = opt.value === value;
+        const optionId = `${groupId}-${opt.value}`;
         return (
           <label
             key={opt.value}
+            htmlFor={optionId}
             className={cn(
               'border-border flex cursor-pointer items-start gap-3 rounded-md border p-3',
               checked && 'border-primary bg-primary/5',
@@ -62,6 +69,7 @@ export function ProjectModeRadio({
             )}
           >
             <RadioGroupItem
+              id={optionId}
               value={opt.value}
               disabled={disabled}
               className="mt-1"


### PR DESCRIPTION
## Summary

`main` is currently **red on `Lint`** (run on `72f23b1c6` failed): #2597 ("polish app hub, project copy, and mode radios") merged with three `--type-aware` lint errors that a Turbo lint cache-hit masked at merge time. Every open PR now inherits the failure. This unblocks all of them.

- **`project-mode-radio.tsx`** — the `RadioGroup` `onValueChange` narrowed its `string` argument with an unsafe `as ProjectModeRadioValue` cast → look the value up in `options` (typed, and only fires for real options). The row `<label>` wrapped a custom `RadioGroupItem` with no association (`jsx-a11y/label-has-associated-control`) → give the item a `useId`-based `id` and point the label's `htmlFor` at it — real association, identical visuals.
- **`tab-navigation.tsx`** — `updateIndicatorForResize` calls `measureScrollable` but omitted it from the `useCallback` deps (`measureScrollable` is a stable `useCallback([])`, so adding it is a no-op at runtime).

## Test plan

- [x] `bun run --filter @tale/platform lint` → **0 warnings, 0 errors** (4515 files)
- [x] `bun run --filter @tale/platform typecheck` → green
- [x] No visual change — the mode-radio card chrome and click-to-select behaviour are unchanged