### PR TITLE
fix(platform): agent roster install, crawler pacing, Convex module integrity

### DIFF
--- a/docs/de/develop/contributor-setup.md
+++ b/docs/de/develop/contributor-setup.md
@@ -70,10 +70,11 @@ Jeder `convex dev`-Push legt ein neues Function-Bundle unter `services/platform/
 
 `bun run dev` führt Wartung automatisch aus, bevor Convex startet:
 
-- **Prune**, wenn der Modul-Speicher 1.500 Blobs oder 2 GB überschreitet — behält die 1.000 neuesten Function-Bundle-Blobs unter `convex_local_storage/modules/`. SQLite-Datenbank, Uploads und Org-Konfig bleiben unberührt.
+- **Prune**, wenn der Modul-Speicher 1.500 Blobs oder 2 GB überschreitet — löscht nur unreferenzierte historische Function-Bundle-Blobs unter `convex_local_storage/modules/` und behält jedes Blob, das das aktuelle Deployment noch lädt (plus bis zu 1.000 neueste unreferenzierte Reste). SQLite-Datenbank, Uploads und Org-Konfig bleiben unberührt. Lassen sich die Live-Referenzen nicht lesen, oder wirken sie leer obwohl noch Blobs auf der Platte liegen, wird der Prune übersprungen statt zu raten.
+- **Integritätsprüfung** — fehlt ein Live-Modul-Blob schon auf der Platte, stoppt `bun run dev` mit einem klaren Fehler und verweist auf `setup:clean`. Weitermachen würde ein halb totes Backend starten (Chat und Crons scheitern mit undurchsichtigen Serverfehlern).
 - **Snapshot-Export-Artefakte löschen**, wenn die gecachte Convex-Backend-Version nicht mehr zur lokalen Deployment-Konfiguration passt — entfernt `export.zip` und Import/Export-Reste, die einen fehlgeschlagenen Re-Import auslösen können, ohne Dev-Daten zu löschen.
 
-Setz `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1`, um das zu deaktivieren. `bun run setup:check` warnt (nicht blockierend), wenn der Modul-Speicher den Prune-Schwellenwert schon überschreitet.
+Setz `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1`, um Prune/Snapshot-Cleanup zu deaktivieren (die Integritätsprüfung läuft weiter). `bun run setup:check` warnt (nicht blockierend), wenn der Modul-Speicher den Prune-Schwellenwert schon überschreitet.
 
 ## Lokale Convex-Dev-Daten zurücksetzen
 

--- a/docs/en/develop/contributor-setup.md
+++ b/docs/en/develop/contributor-setup.md
@@ -70,10 +70,11 @@ Every `convex dev` push stores a new function-bundle blob under `services/platfo
 
 `bun run dev` runs maintenance automatically before it spawns Convex:
 
-- **Prune** when module storage exceeds 1,500 blobs or 2 GB — keeps the 1,000 newest function-bundle blobs under `convex_local_storage/modules/`. Your SQLite database, uploaded files, and org config are untouched.
+- **Prune** when module storage exceeds 1,500 blobs or 2 GB — deletes only unreferenced historical function-bundle blobs under `convex_local_storage/modules/`, keeping every blob the current deployment still loads (plus up to 1,000 newest unreferenced leftovers). Your SQLite database, uploaded files, and org config are untouched. If the deployment's live references can't be read, or look empty while blobs remain on disk, prune is skipped rather than guessing.
+- **Integrity gate** — if a live module blob is already missing on disk, `bun run dev` stops with a clear error pointing at `setup:clean`. Continuing would boot into a half-dead backend (chat and crons fail with opaque server errors).
 - **Clear snapshot export artifacts** when the cached Convex backend binary no longer matches the one recorded in your local deployment — removes `export.zip` and related import/export debris that can trigger a failed re-import on cold start, without wiping dev data.
 
-Set `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1` to opt out. `bun run setup:check` warns (non-blocking) when module storage is already over the prune threshold.
+Set `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1` to opt out of prune/snapshot cleanup (the integrity gate still runs). `bun run setup:check` warns (non-blocking) when module storage is already over the prune threshold.
 
 ## Resetting local Convex dev data
 

--- a/docs/fr/develop/contributor-setup.md
+++ b/docs/fr/develop/contributor-setup.md
@@ -70,10 +70,11 @@ Chaque push `convex dev` stocke un nouveau bundle de fonctions sous `services/pl
 
 `bun run dev` lance la maintenance automatiquement avant de spawner Convex :
 
-- **Prune** quand le stockage modules dépasse 1 500 blobs ou 2 Go — garde les 1 000 bundles de fonctions les plus récents sous `convex_local_storage/modules/`. La base SQLite, les fichiers uploadés et la config org restent intacts.
+- **Prune** quand le stockage modules dépasse 1 500 blobs ou 2 Go — ne supprime que les blobs historiques non référencés sous `convex_local_storage/modules/`, en gardant chaque blob que le déploiement actuel charge encore (plus jusqu'à 1 000 restes non référencés les plus récents). La base SQLite, les fichiers uploadés et la config org restent intacts. Si les références live ne peuvent pas être lues, ou semblent vides alors que des blobs restent sur disque, le prune est ignoré plutôt que de deviner.
+- **Contrôle d'intégrité** — si un blob de module live manque déjà sur disque, `bun run dev` s'arrête avec une erreur claire qui pointe vers `setup:clean`. Continuer démarrerait un backend à moitié mort (chat et crons échouent avec des erreurs serveur opaques).
 - **Supprime les artefacts d'export snapshot** quand la version binaire Convex en cache ne correspond plus à celle enregistrée dans le déploiement local — retire `export.zip` et les restes d'import/export qui peuvent déclencher un ré-import raté au cold start, sans effacer les données de dev.
 
-Règle `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1` pour désactiver. `bun run setup:check` avertit (sans bloquer) quand le stockage modules dépasse déjà le seuil de prune.
+Règle `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1` pour désactiver le prune/nettoyage snapshot (le contrôle d'intégrité tourne quand même). `bun run setup:check` avertit (sans bloquer) quand le stockage modules dépasse déjà le seuil de prune.
 
 ## Réinitialiser les données Convex de dev locales
 

--- a/services/platform/app/features/agents/components/agents-action-menu.test.tsx
+++ b/services/platform/app/features/agents/components/agents-action-menu.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string) => `${ns}.${key}`,
+  }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+const saveAgentMock = vi.fn();
+const installAgentMock = vi.fn();
+vi.mock('../hooks/mutations', () => ({
+  useSaveAgent: () => ({ mutateAsync: saveAgentMock }),
+  useInstallCatalogAgent: () => ({ mutateAsync: installAgentMock }),
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useListAgents: () => ({ agents: [] }),
+}));
+
+vi.mock('./agent-create-dialog', () => ({
+  CreateAgentDialog: () => null,
+}));
+
+// Capture the upload dialog's `onSaveOne` so the tests can drive the exact
+// upload seam without a real file parse — the pairing under test lives in
+// the callback, not in the dialog.
+type SaveOne = (
+  entry: { baseName: string; json: Record<string, unknown> },
+  opts: { overwrite: boolean },
+) => Promise<void>;
+let capturedOnSaveOne: SaveOne | null = null;
+vi.mock('@/app/features/shared/upload-configs/upload-configs-dialog', () => ({
+  UploadConfigsDialog: (props: { onSaveOne: SaveOne }) => {
+    capturedOnSaveOne = props.onSaveOne;
+    return null;
+  },
+}));
+
+import { AgentsActionMenu } from './agents-action-menu';
+
+describe('AgentsActionMenu upload flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnSaveOne = null;
+    saveAgentMock.mockResolvedValue({ hash: 'h' });
+    installAgentMock.mockResolvedValue(null);
+  });
+
+  // Regression: the roster lists only INSTALLED agents (file ∩ enabled
+  // install row), so an upload that writes the file without creating the
+  // install row leaves the agent permanently invisible. The upload flow must
+  // pair `saveAgent` with `installCatalogAgent`, same as Blank create.
+  it('installs an uploaded agent so it appears in the installed-only roster', async () => {
+    render(<AgentsActionMenu organizationId="org-1" />);
+    expect(capturedOnSaveOne).not.toBeNull();
+
+    await capturedOnSaveOne?.(
+      { baseName: 'claude-code', json: { displayName: 'Claude Code' } },
+      { overwrite: false },
+    );
+
+    expect(saveAgentMock).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      agentName: 'claude-code',
+      isNew: true,
+      config: { displayName: 'Claude Code' },
+    });
+    expect(installAgentMock).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      agentSlug: 'claude-code',
+    });
+  });
+
+  it('keeps the uploaded file and logs when auto-install fails (e.g. non-admin)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installAgentMock.mockRejectedValueOnce(new Error('forbidden'));
+    render(<AgentsActionMenu organizationId="org-1" />);
+    expect(capturedOnSaveOne).not.toBeNull();
+
+    await expect(
+      capturedOnSaveOne?.(
+        { baseName: 'claude-code', json: {} },
+        { overwrite: true },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(saveAgentMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/services/platform/app/features/agents/components/agents-action-menu.tsx
+++ b/services/platform/app/features/agents/components/agents-action-menu.tsx
@@ -12,7 +12,7 @@ import { UploadConfigsDialog } from '@/app/features/shared/upload-configs/upload
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
-import { useSaveAgent } from '../hooks/mutations';
+import { useInstallCatalogAgent, useSaveAgent } from '../hooks/mutations';
 import { useListAgents } from '../hooks/queries';
 import { CreateAgentDialog } from './agent-create-dialog';
 
@@ -42,6 +42,7 @@ export function AgentsActionMenu({
   const { t } = useT('settings');
   const navigate = useNavigate();
   const { mutateAsync: saveAgent } = useSaveAgent();
+  const { mutateAsync: installAgent } = useInstallCatalogAgent();
   const { agents } = useListAgents(organizationId);
   const existingNames = useMemo(
     () => collectStringField(agents, 'name'),
@@ -104,6 +105,18 @@ export function AgentsActionMenu({
             isNew: !overwrite,
             config: entry.json,
           });
+          // Install (enable) the uploaded agent so it appears in the
+          // installed-only Agents list — the config file is the source, the
+          // install record makes it live (same pairing as Blank create). A
+          // failure (e.g. non-admin) leaves the file in place to install later.
+          try {
+            await installAgent({ organizationId, agentSlug: entry.baseName });
+          } catch (installErr) {
+            console.warn(
+              '[AgentsActionMenu] agent uploaded but auto-install failed',
+              installErr,
+            );
+          }
         }}
         onAfterAllSaved={() => {
           toast({

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -314,6 +314,7 @@ import type * as conversations_update_conversations from "../conversations/updat
 import type * as conversations_validators from "../conversations/validators.js";
 import type * as crawler_helpers_content_filter from "../crawler/helpers/content_filter.js";
 import type * as crawler_helpers_fetch_rendered_html from "../crawler/helpers/fetch_rendered_html.js";
+import type * as crawler_helpers_parse_html from "../crawler/helpers/parse_html.js";
 import type * as crawler_helpers_structured_data from "../crawler/helpers/structured_data.js";
 import type * as crawler_index_pages from "../crawler/index_pages.js";
 import type * as crawler_lib_discovery from "../crawler/lib/discovery.js";
@@ -2064,6 +2065,7 @@ declare const fullApi: ApiFromModules<{
   "conversations/validators": typeof conversations_validators;
   "crawler/helpers/content_filter": typeof crawler_helpers_content_filter;
   "crawler/helpers/fetch_rendered_html": typeof crawler_helpers_fetch_rendered_html;
+  "crawler/helpers/parse_html": typeof crawler_helpers_parse_html;
   "crawler/helpers/structured_data": typeof crawler_helpers_structured_data;
   "crawler/index_pages": typeof crawler_index_pages;
   "crawler/lib/discovery": typeof crawler_lib_discovery;

--- a/services/platform/convex/agents/provision_defaults.test.ts
+++ b/services/platform/convex/agents/provision_defaults.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for the default-agent provisioner's provision-guard semantics —
+ * in particular `reinstallMissing`: the explicit "Update built-in agents"
+ * sync must heal a DELETED `agentInstallations` row of an autoInstall agent,
+ * while background sweeps (no flag) keep respecting the never-reprovision
+ * guard, and an existing (even disabled) row is never touched.
+ *
+ * Same direct-handler pattern as `organizations/builtin_sync.test.ts`: the
+ * codegen surface is mocked so `internalAction(config)` returns the config,
+ * and the walk runs against a real temp org dir.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+  internalAction: vi.fn((config) => config),
+}));
+
+vi.mock('../_generated/api', () => ({
+  internal: {
+    agents: {
+      provision_defaults: {
+        syncDefaultAgentInstallations: 'syncDefaultAgentInstallations',
+      },
+      provision_defaults_mutations: {
+        getProvision: 'getProvision',
+        recordProvision: 'recordProvision',
+        hasAnyProvisionQuery: 'hasAnyProvisionQuery',
+      },
+      installations: {
+        upsertInstallation: 'upsertInstallation',
+        getInstallationInternal: 'getInstallationInternal',
+      },
+    },
+  },
+}));
+
+// The rate limiter is only used by `ensureAgentsProvisioned`, not the sweep
+// under test — stub it so the module import carries no component dependency.
+vi.mock('../lib/rate_limiter', () => ({
+  rateLimiter: { limit: vi.fn().mockResolvedValue({ ok: true }) },
+}));
+
+const { syncDefaultAgentInstallations } = await import('./provision_defaults');
+
+type SweepArgs = {
+  organizationId: string;
+  orgSlug: string;
+  attempt?: number;
+  reinstallMissing?: boolean;
+};
+type ActionConfig = {
+  handler: (
+    ctx: never,
+    args: SweepArgs,
+  ) => Promise<{ provisioned: number; skipped: number; failed: number }>;
+};
+const sweep = (syncDefaultAgentInstallations as unknown as ActionConfig)
+  .handler;
+
+let configRoot: string;
+let savedConfigDir: string | undefined;
+
+/** Per-slug fixtures the mocked runQuery serves. */
+let provisionRows: Record<string, { contentHash: string }>;
+let installRows: Record<string, { enabled: boolean }>;
+
+function createMockCtx() {
+  const runQuery = vi.fn((fn: unknown, args: { agentSlug: string }) => {
+    if (fn === 'getProvision') {
+      return Promise.resolve(provisionRows[args.agentSlug] ?? null);
+    }
+    if (fn === 'getInstallationInternal') {
+      return Promise.resolve(installRows[args.agentSlug] ?? null);
+    }
+    return Promise.resolve(null);
+  });
+  const runMutation = vi.fn().mockResolvedValue(null);
+  return { runQuery, runMutation, scheduler: { runAfter: vi.fn() } };
+}
+
+async function writeAgent(
+  relPath: string,
+  config: Record<string, unknown>,
+): Promise<void> {
+  const abs = path.join(configRoot, 'acme', 'agents', relPath);
+  await mkdir(path.dirname(abs), { recursive: true });
+  await writeFile(
+    abs,
+    JSON.stringify({
+      displayName: 'x',
+      systemInstructions: 'You are a test agent.',
+      supportedModels: ['openrouter:anthropic/claude-sonnet-4.6'],
+      ...config,
+    }),
+    'utf-8',
+  );
+}
+
+/** The upsertInstallation calls a sweep made, keyed by slug. */
+function installedSlugs(ctx: ReturnType<typeof createMockCtx>): string[] {
+  return ctx.runMutation.mock.calls
+    .filter(([fn]) => fn === 'upsertInstallation')
+    .map(([, args]) => (args as { agentSlug: string }).agentSlug);
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  savedConfigDir = process.env.TALE_CONFIG_DIR;
+  configRoot = await mkdtemp(path.join(tmpdir(), 'provision-defaults-'));
+  process.env.TALE_CONFIG_DIR = configRoot;
+  provisionRows = {};
+  installRows = {};
+});
+
+afterEach(async () => {
+  if (savedConfigDir === undefined) {
+    delete process.env.TALE_CONFIG_DIR;
+  } else {
+    process.env.TALE_CONFIG_DIR = savedConfigDir;
+  }
+  await rm(configRoot, { recursive: true, force: true });
+});
+
+describe('syncDefaultAgentInstallations — provision guard', () => {
+  it('installs an unprovisioned autoInstall agent and records the provision', async () => {
+    await writeAgent('chat/assistant.json', {
+      slug: 'assistant',
+      metadata: { autoInstall: true },
+    });
+    await writeAgent('chat/claude-code.json', { slug: 'claude-code' });
+
+    const ctx = createMockCtx();
+    const result = await sweep(ctx as never, {
+      organizationId: 'org1',
+      orgSlug: 'acme',
+    });
+
+    // Only the autoInstall-flagged file installs; the other is catalog-only.
+    expect(result).toEqual({ provisioned: 1, skipped: 0, failed: 0 });
+    expect(installedSlugs(ctx)).toEqual(['assistant']);
+  });
+
+  it('background sweep never re-provisions a previously provisioned agent (deleted row stays deleted)', async () => {
+    await writeAgent('chat/assistant.json', {
+      slug: 'assistant',
+      metadata: { autoInstall: true },
+    });
+    provisionRows['assistant'] = { contentHash: 'h1' };
+    // No install row — the org deleted it after the original provision.
+
+    const ctx = createMockCtx();
+    const result = await sweep(ctx as never, {
+      organizationId: 'org1',
+      orgSlug: 'acme',
+    });
+
+    expect(result).toEqual({ provisioned: 0, skipped: 1, failed: 0 });
+    expect(installedSlugs(ctx)).toEqual([]);
+  });
+
+  // Regression: "Update built-in agents" must restore an autoInstall agent
+  // whose install row was deleted — the explicit sync is operator consent,
+  // unlike the background sweep the guard exists for.
+  it('reinstallMissing heals a provisioned agent whose install row was deleted', async () => {
+    await writeAgent('chat/assistant.json', {
+      slug: 'assistant',
+      metadata: { autoInstall: true },
+    });
+    provisionRows['assistant'] = { contentHash: 'h1' };
+
+    const ctx = createMockCtx();
+    const result = await sweep(ctx as never, {
+      organizationId: 'org1',
+      orgSlug: 'acme',
+      reinstallMissing: true,
+    });
+
+    expect(result).toEqual({ provisioned: 1, skipped: 0, failed: 0 });
+    expect(installedSlugs(ctx)).toEqual(['assistant']);
+  });
+
+  it('reinstallMissing leaves an existing (disabled) install row untouched', async () => {
+    await writeAgent('chat/assistant.json', {
+      slug: 'assistant',
+      metadata: { autoInstall: true },
+    });
+    provisionRows['assistant'] = { contentHash: 'h1' };
+    installRows['assistant'] = { enabled: false };
+
+    const ctx = createMockCtx();
+    const result = await sweep(ctx as never, {
+      organizationId: 'org1',
+      orgSlug: 'acme',
+      reinstallMissing: true,
+    });
+
+    expect(result).toEqual({ provisioned: 0, skipped: 1, failed: 0 });
+    expect(installedSlugs(ctx)).toEqual([]);
+  });
+});

--- a/services/platform/convex/agents/provision_defaults.ts
+++ b/services/platform/convex/agents/provision_defaults.ts
@@ -11,9 +11,11 @@
  *   2. records the provision so the org is never re-provisioned behind its
  *      back (a later uninstall/disable sticks).
  *
- * Invoked from the org-creation hook (after the scaffold copies the catalog)
- * and from the all-orgs deploy runner. Self-retries when the agents dir does
- * not exist yet (scaffold still running). Mirrors
+ * Invoked from the org-creation hook (after the scaffold copies the catalog),
+ * from the all-orgs deploy runner, and from the explicit "Update built-in
+ * agents" catalog sync (`organizations/builtin_sync.ts`, which passes
+ * `reinstallMissing` — see that arg's doc). Self-retries when the agents dir
+ * does not exist yet (scaffold still running). Mirrors
  * `workflows/provision_defaults.ts`.
  */
 
@@ -87,6 +89,14 @@ export const syncDefaultAgentInstallations = internalAction({
     organizationId: v.string(),
     orgSlug: v.string(),
     attempt: v.optional(v.number()),
+    /**
+     * Restore an autoInstall agent whose `agentInstallations` row was DELETED,
+     * even though its provision row says it was provisioned before. Set only
+     * by the explicit "Update built-in agents" catalog sync — an operator
+     * action is consent, unlike this sweep's background invocations. A row
+     * that exists but is disabled stays untouched (disable is deliberate).
+     */
+    reinstallMissing: v.optional(v.boolean()),
   },
   returns: v.object({
     provisioned: v.number(),
@@ -134,8 +144,21 @@ export const syncDefaultAgentInstallations = internalAction({
           { organizationId: args.organizationId, agentSlug },
         );
         if (existing) {
-          skipped += 1;
-          continue;
+          // Provisioned before — normally final (a later uninstall sticks).
+          // On an explicit sync (`reinstallMissing`) a MISSING install row is
+          // healed; an existing (even disabled) row is still respected.
+          if (args.reinstallMissing !== true) {
+            skipped += 1;
+            continue;
+          }
+          const installed = await ctx.runQuery(
+            internal.agents.installations.getInstallationInternal,
+            { organizationId: args.organizationId, agentSlug },
+          );
+          if (installed !== null) {
+            skipped += 1;
+            continue;
+          }
         }
 
         await ctx.runMutation(

--- a/services/platform/convex/betterAuth/_generated/component.ts
+++ b/services/platform/convex/betterAuth/_generated/component.ts
@@ -176,6 +176,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | {
                 data: {
                   backupCodes: string;
+                  failedVerificationCount?: null | number;
+                  lockedUntil?: null | number;
                   secret: string;
                   userId: string;
                   verified?: null | boolean;
@@ -610,6 +612,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "backupCodes"
                     | "userId"
                     | "verified"
+                    | "failedVerificationCount"
+                    | "lockedUntil"
                     | "_id";
                   mode?: "sensitive" | "insensitive";
                   operator?:
@@ -1091,6 +1095,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "backupCodes"
                     | "userId"
                     | "verified"
+                    | "failedVerificationCount"
+                    | "lockedUntil"
                     | "_id";
                   mode?: "sensitive" | "insensitive";
                   operator?:
@@ -1777,6 +1783,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 model: "twoFactor";
                 update: {
                   backupCodes?: string;
+                  failedVerificationCount?: null | number;
+                  lockedUntil?: null | number;
                   secret?: string;
                   userId?: string;
                   verified?: null | boolean;
@@ -1788,6 +1796,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "backupCodes"
                     | "userId"
                     | "verified"
+                    | "failedVerificationCount"
+                    | "lockedUntil"
                     | "_id";
                   mode?: "sensitive" | "insensitive";
                   operator?:
@@ -2387,6 +2397,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 model: "twoFactor";
                 update: {
                   backupCodes?: string;
+                  failedVerificationCount?: null | number;
+                  lockedUntil?: null | number;
                   secret?: string;
                   userId?: string;
                   verified?: null | boolean;
@@ -2398,6 +2410,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "backupCodes"
                     | "userId"
                     | "verified"
+                    | "failedVerificationCount"
+                    | "lockedUntil"
                     | "_id";
                   mode?: "sensitive" | "insensitive";
                   operator?:

--- a/services/platform/convex/crawler/helpers/content_filter.ts
+++ b/services/platform/convex/crawler/helpers/content_filter.ts
@@ -33,8 +33,9 @@
  * behaviourally-equivalent rather than bit-identical to crawl4ai.
  */
 
-import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
+
+import { parseHtml } from './parse_html';
 
 const THRESHOLD = 0.4;
 
@@ -154,7 +155,7 @@ export function scoreNode(node: DomNode): number {
  * parent doesn't strand already-evaluated children).
  */
 export function pruneHtml(html: string): string {
-  const dom = new JSDOM(html);
+  const dom = parseHtml(html);
   const { document } = dom.window;
 
   // 1. Pre-remove structural / non-content tags.

--- a/services/platform/convex/crawler/helpers/parse_html.test.ts
+++ b/services/platform/convex/crawler/helpers/parse_html.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { parseHtml, stripStyleBlocks } from './parse_html';
+
+describe('stripStyleBlocks', () => {
+  it('drops inline style blocks, including attributed and multiline ones', () => {
+    const html = [
+      '<html><head>',
+      '<style>body { color: red; }</style>',
+      '<STYLE media="print">\n@page { margin: 0; }\n</STYLE>',
+      '<style type="text/css" data-x="1">.a{}</style >',
+      '</head><body><a href="/x">x</a></body></html>',
+    ].join('\n');
+    const stripped = stripStyleBlocks(html);
+    expect(stripped).not.toContain('color: red');
+    expect(stripped).not.toContain('@page');
+    expect(stripped).not.toContain('.a{}');
+    expect(stripped).toContain('<a href="/x">x</a>');
+  });
+
+  it('leaves style attributes and non-style tags alone', () => {
+    const html = '<div style="color:blue"><p>text</p></div>';
+    expect(stripStyleBlocks(html)).toBe(html);
+  });
+});
+
+describe('parseHtml', () => {
+  it('extracts title, links, and meta through the quiet parse', () => {
+    const { document } = parseHtml(
+      `<html><head>
+         <title>Probe</title>
+         <meta property="og:title" content="Probe OG" />
+         <style>main { display: grid; }</style>
+       </head>
+       <body><a href="https://example.com/a">a</a></body></html>`,
+    ).window;
+    expect(document.querySelector('title')?.textContent).toBe('Probe');
+    expect(
+      document
+        .querySelector('meta[property="og:title"]')
+        ?.getAttribute('content'),
+    ).toBe('Probe OG');
+    expect(document.querySelector('a[href]')?.getAttribute('href')).toBe(
+      'https://example.com/a',
+    );
+    // The stripped stylesheet never reaches the DOM (no CSSOM work) and can't
+    // leak into text extraction.
+    expect(document.body?.textContent).not.toContain('display: grid');
+  });
+
+  // Regression: a bare `new JSDOM(html)` logs "Could not parse CSS
+  // stylesheet" through the default virtual console for every broken sheet —
+  // at crawl volume that floods the backend log pipeline (observed live as
+  // per-page error spam during a site scan).
+  it('parses pages with broken CSS without emitting console errors', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { document } = parseHtml(
+        `<html><head><style>@invalid { ; } } garbage {{{</style></head>
+         <body><a href="/ok">ok</a></body></html>`,
+      ).window;
+      expect(document.querySelector('a[href]')?.getAttribute('href')).toBe(
+        '/ok',
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/services/platform/convex/crawler/helpers/parse_html.ts
+++ b/services/platform/convex/crawler/helpers/parse_html.ts
@@ -1,0 +1,41 @@
+'use node';
+
+/**
+ * Shared JSDOM entry point for the crawler — every wild-page HTML parse in
+ * this subsystem goes through here (content pruning, structured data, title,
+ * BFS link discovery).
+ *
+ * Two things make a bare `new JSDOM(html)` expensive at crawl volume, and
+ * neither buys the crawler anything (no consumer reads styles):
+ *
+ *  - jsdom eagerly parses every inline `<style>` block into a CSSOM; real
+ *    pages ship large, often non-standard stylesheets, so this is pure CPU +
+ *    heap burn. Blocks are stripped BEFORE construction. (External
+ *    stylesheets are never fetched — no `resources` loader — and `style=""`
+ *    attributes parse lazily, so those cost nothing here.)
+ *  - each failed sheet logs "Could not parse CSS stylesheet" through the
+ *    default virtual console; at pages/second that floods the backend log
+ *    pipeline. A shared listener-less VirtualConsole drops the residue.
+ *
+ * This matters doubly because crawler actions run INSIDE the shared Convex
+ * backend process — cycles and log lines here are taken directly from
+ * interactive traffic (see scan_scheduler.ts's pacing notes).
+ */
+import { JSDOM, VirtualConsole } from 'jsdom';
+
+const STYLE_BLOCK_RE = /<style\b[^>]*>[\s\S]*?<\/style\s*>/gi;
+
+// Listener-less: jsdomError events (CSS parse failures & friends) are
+// silently dropped. Scripts never run (no `runScripts`), so nothing a page
+// could log is lost either.
+const quietConsole = new VirtualConsole();
+
+/** Drop inline `<style>…</style>` blocks (the eager-CSSOM cost) from raw HTML. */
+export function stripStyleBlocks(html: string): string {
+  return html.replace(STYLE_BLOCK_RE, '');
+}
+
+/** Parse crawled HTML into a JSDOM without CSS work or jsdomError log spam. */
+export function parseHtml(html: string): JSDOM {
+  return new JSDOM(stripStyleBlocks(html), { virtualConsole: quietConsole });
+}

--- a/services/platform/convex/crawler/helpers/structured_data.ts
+++ b/services/platform/convex/crawler/helpers/structured_data.ts
@@ -11,7 +11,7 @@
  *   - meta:      description / keywords / author `<meta name="...">` tags
  */
 
-import { JSDOM } from 'jsdom';
+import { parseHtml } from './parse_html';
 
 export interface StructuredData {
   opengraph?: Record<string, string>;
@@ -22,7 +22,7 @@ export interface StructuredData {
 export function extractStructuredDataFromHtml(html: string): StructuredData {
   const structured: StructuredData = {};
   try {
-    const { document } = new JSDOM(html).window;
+    const { document } = parseHtml(html).window;
 
     // OpenGraph.
     const ogData: Record<string, string> = {};
@@ -84,7 +84,7 @@ export function extractStructuredDataFromHtml(html: string): StructuredData {
 /** Extract the document `<title>` from raw HTML. */
 export function extractTitleFromHtml(html: string): string | null {
   try {
-    const { document } = new JSDOM(html).window;
+    const { document } = parseHtml(html).window;
     const title = document.querySelector('title')?.textContent?.trim();
     return title && title.length > 0 ? title : null;
   } catch {

--- a/services/platform/convex/crawler/lib/discovery.ts
+++ b/services/platform/convex/crawler/lib/discovery.ts
@@ -29,7 +29,6 @@
  */
 
 import { XMLParser } from 'fast-xml-parser';
-import { JSDOM } from 'jsdom';
 
 import { logger } from '../../lib/knowledge/logger';
 import {
@@ -37,6 +36,7 @@ import {
   htmlToRawMarkdown,
 } from '../helpers/content_filter';
 import { fetchRenderedHtml } from '../helpers/fetch_rendered_html';
+import { parseHtml } from '../helpers/parse_html';
 import {
   extractStructuredDataFromHtml,
   extractTitleFromHtml,
@@ -312,7 +312,7 @@ async function discoverUrlsBfs(
       // Extract same-domain links.
       let links: string[] = [];
       try {
-        const { document } = new JSDOM(html).window;
+        const { document } = parseHtml(html).window;
         const anchors = Array.from(document.querySelectorAll('a[href]'));
         for (const a of anchors) {
           const href = a.getAttribute('href');

--- a/services/platform/convex/crawler/scan_scheduler.ts
+++ b/services/platform/convex/crawler/scan_scheduler.ts
@@ -49,6 +49,18 @@ const MAX_SCAN_CONTINUATIONS = envInt('CRAWLER_MAX_SCAN_CONTINUATIONS', 100);
 // A URL that fails this many fetches is dropped from both the crawl list and the
 // remaining-work count, so a permanently-broken page can't wedge the loop.
 const MAX_FETCH_FAIL_COUNT = 10;
+// Duty-cycle pacing. Crawl actions run INSIDE the shared Convex backend
+// process (see helpers/parse_html.ts) — an unpaced chain runs flat-out for
+// SCAN_ACTION_BUDGET_MS × MAX_SCAN_CONTINUATIONS and starves interactive
+// traffic (observed: backend-wide "Try again later" mutation failures and a
+// WebSocket 1011 disconnect loop while one site scanned). A pause between
+// fetch batches and between chain continuations keeps the backend
+// responsive; both are operator-tunable like the other CRAWLER_* knobs.
+const FETCH_BATCH_PACING_MS = envInt('CRAWLER_FETCH_BATCH_PACING_MS', 2_000);
+const CONTINUATION_PACING_MS = envInt('CRAWLER_CONTINUATION_PACING_MS', 5_000);
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Scan ONE website incrementally. On the first action of a chain
@@ -170,6 +182,9 @@ export const scanWebsite = internalAction({
         stagnantBatches =
           nowUncrawled < prevUncrawled ? 0 : stagnantBatches + 1;
         prevUncrawled = nowUncrawled;
+        // Yield between batches so interactive traffic gets the backend (a
+        // trailing pause on the final batch is a harmless 2s).
+        await sleep(FETCH_BATCH_PACING_MS);
       }
 
       // 3. More to crawl? Continue in a fresh action (resets the budget) until
@@ -183,7 +198,7 @@ export const scanWebsite = internalAction({
         continuation < MAX_SCAN_CONTINUATIONS
       ) {
         await ctx.scheduler.runAfter(
-          0,
+          CONTINUATION_PACING_MS,
           internal.crawler.scan_scheduler.scanWebsite,
           { domain, orgSlug, continuation: continuation + 1 },
         );
@@ -216,10 +231,13 @@ export const scanDueWebsites = internalAction({
   handler: async (ctx): Promise<null> => {
     if (isE2ECronSuppressed()) return null;
     const due = await getDueWebsites();
-    for (const w of due) {
+    for (const [i, w] of due.entries()) {
       await updateScanStatus(w.domain, 'scanning');
+      // Stagger the per-site chains instead of launching every due site at
+      // once — N concurrent chains multiply the in-process load the pacing
+      // above meters out.
       await ctx.scheduler.runAfter(
-        0,
+        i * CONTINUATION_PACING_MS,
         internal.crawler.scan_scheduler.scanWebsite,
         { domain: w.domain, orgSlug: w.owner_org_slug },
       );

--- a/services/platform/convex/organizations/builtin_sync.test.ts
+++ b/services/platform/convex/organizations/builtin_sync.test.ts
@@ -203,12 +203,13 @@ describe('syncDomainFromBuiltin — tree domains (agents/workflows)', () => {
       await readFile(path.join(historyDir, entries[0] ?? ''), 'utf-8'),
     ).toBe('{"slug":"assistant","v":"user-edited"}');
 
-    // Post-sync hooks: cache drop + default-agent provisioner scheduled.
+    // Post-sync hooks: cache drop + default-agent provisioner scheduled with
+    // `reinstallMissing` (the explicit sync is consent to heal deleted rows).
     expect(mockInvalidateAgentListCache).toHaveBeenCalledWith('acme');
     expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
       0,
       'syncDefaultAgentInstallations',
-      { organizationId: 'org1', orgSlug: 'acme' },
+      { organizationId: 'org1', orgSlug: 'acme', reinstallMissing: true },
     );
   });
 
@@ -227,14 +228,22 @@ describe('syncDomainFromBuiltin — tree domains (agents/workflows)', () => {
     expect(existsSync(orgDst('agents', 'newcomer.json'))).toBe(true);
     expect(existsSync(orgDst('agents', '.history'))).toBe(false);
 
-    // Second run: already in sync — no writes, no hooks.
+    // Second run: already in sync — no writes, no file hooks. The
+    // provisioner is STILL scheduled (with `reinstallMissing`): the explicit
+    // sync doubles as the recovery path for a deleted install row, which is
+    // invisible to the file comparison.
     const ctx2 = createMockCtx();
     const second = await syncHandler(ctx2 as never, {
       organizationId: 'org1',
       domain: 'agents',
     });
     expect(second).toEqual({ updated: 0, backedUp: 0 });
-    expect(ctx2.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(ctx2.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      'syncDefaultAgentInstallations',
+      { organizationId: 'org1', orgSlug: 'acme', reinstallMissing: true },
+    );
+    expect(mockInvalidateAgentListCache).toHaveBeenCalledTimes(1);
   });
 
   it('preserves org-side secrets and existing history trails through an agents sync', async () => {

--- a/services/platform/convex/organizations/builtin_sync.ts
+++ b/services/platform/convex/organizations/builtin_sync.ts
@@ -374,6 +374,24 @@ export const syncDomainFromBuiltin = action({
       }
     }
 
+    // Agents: run the autoInstall provisioner even when no FILE changed — the
+    // explicit "Update built-in agents" action doubles as the recovery path
+    // for a deleted install ROW. `reinstallMissing` marks the run as
+    // operator-consented, so an autoInstall agent whose row was removed is
+    // restored (the provisioner's background default never re-provisions
+    // behind the org's back).
+    if (domainName === 'agents') {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.agents.provision_defaults.syncDefaultAgentInstallations,
+        {
+          organizationId: args.organizationId,
+          orgSlug,
+          reinstallMissing: true,
+        },
+      );
+    }
+
     if (updated === 0) return { updated, backedUp };
 
     // Post-sync hooks — the same provisioning the org-create flow runs after
@@ -381,11 +399,6 @@ export const syncDomainFromBuiltin = action({
     // become live without a second manual step.
     if (domainName === 'agents') {
       invalidateAgentListCache(orgSlug);
-      await ctx.scheduler.runAfter(
-        0,
-        internal.agents.provision_defaults.syncDefaultAgentInstallations,
-        { organizationId: args.organizationId, orgSlug },
-      );
     } else if (domainName === 'workflows') {
       await ctx.scheduler.runAfter(
         0,

--- a/services/platform/scripts/convex-local-maintenance.test.ts
+++ b/services/platform/scripts/convex-local-maintenance.test.ts
@@ -1,8 +1,15 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
   applyConvexLocalMaintenance,
+  findMissingReferencedModuleBlobs,
   formatBytes,
+  formatModuleIntegrityError,
   MODULE_BLOB_KEEP_COUNT,
   MODULE_BLOB_PRUNE_BYTES_THRESHOLD,
   MODULE_BLOB_PRUNE_COUNT_THRESHOLD,
@@ -10,6 +17,7 @@ import {
   readReferencedModuleBlobNames,
   resolveLatestCachedBackendVersion,
   selectModuleBlobsToPrune,
+  shouldSkipPruneForEmptyReferences,
   summarizeModuleBlobs,
   type MaintenanceDeps,
   type ModuleBlobEntry,
@@ -65,6 +73,30 @@ describe('selectModuleBlobsToPrune', () => {
   });
 });
 
+describe('shouldSkipPruneForEmptyReferences', () => {
+  it('skips when the DB yielded no live packages but blobs remain on disk', () => {
+    expect(shouldSkipPruneForEmptyReferences(new Set(), 50)).toBe(true);
+  });
+
+  it('does not skip when there are live references', () => {
+    expect(shouldSkipPruneForEmptyReferences(new Set(['a']), 50)).toBe(false);
+  });
+
+  it('does not skip when the modules dir is empty (fresh / torn-down)', () => {
+    expect(shouldSkipPruneForEmptyReferences(new Set(), 0)).toBe(false);
+  });
+});
+
+describe('findMissingReferencedModuleBlobs', () => {
+  it('lists referenced names with no matching on-disk blob', () => {
+    expect(
+      findMissingReferencedModuleBlobs(new Set(['live', 'gone']), [
+        blob('/modules/live.blob', 1, 1),
+      ]),
+    ).toEqual(['gone']);
+  });
+});
+
 describe('applyConvexLocalMaintenance', () => {
   const pruneAll = {
     kind: 'prune-modules',
@@ -94,8 +126,28 @@ describe('applyConvexLocalMaintenance', () => {
       }),
     );
     expect(result.removedModuleBlobs).toBe(0);
+    expect(result.integrityError).toBeNull();
     expect(result.warning).toContain('Skipped Convex module prune');
     expect(removed).toEqual([[]]);
+  });
+
+  it('skips the prune when references are empty but blobs remain on disk', () => {
+    const removed: string[] = [];
+    const result = applyConvexLocalMaintenance(
+      pruneAll,
+      deps({
+        listModuleBlobs: () => [
+          blob('/modules/a.blob', 100, 10),
+          blob('/modules/b.blob', 200, 10),
+        ],
+        readReferencedBlobNames: () => new Set(),
+        removePaths: (paths) => removed.push(...paths),
+      }),
+    );
+    expect(result.removedModuleBlobs).toBe(0);
+    expect(result.integrityError).toBeNull();
+    expect(result.warning).toContain('no live package references');
+    expect(removed).toEqual([]);
   });
 
   it('prunes only unreferenced blobs when references are known', () => {
@@ -114,6 +166,58 @@ describe('applyConvexLocalMaintenance', () => {
     expect(removed).toEqual(['/modules/stale.blob']);
     expect(result.removedModuleBlobs).toBe(1);
     expect(result.warning).toBeNull();
+    expect(result.integrityError).toBeNull();
+  });
+
+  it('sets integrityError and skips prune when a live blob is already missing', () => {
+    const removed: string[] = [];
+    const result = applyConvexLocalMaintenance(
+      pruneAll,
+      deps({
+        listModuleBlobs: () => [blob('/modules/stale.blob', 200, 10)],
+        readReferencedBlobNames: () => new Set(['live']),
+        removePaths: (paths) => removed.push(...paths),
+      }),
+    );
+    expect(removed).toEqual([]);
+    expect(result.removedModuleBlobs).toBe(0);
+    expect(result.integrityError).toContain('module storage is incomplete');
+    expect(result.integrityError).toContain('live');
+    expect(formatModuleIntegrityError(['live'])).toContain('setup:clean');
+  });
+
+  it('sets integrityError after prune if a live blob disappeared', () => {
+    let listed = 0;
+    const result = applyConvexLocalMaintenance(
+      pruneAll,
+      deps({
+        listModuleBlobs: () => {
+          listed += 1;
+          // First call (pre-check): live present. Second call (post-prune): gone.
+          if (listed === 1) {
+            return [
+              blob('/modules/live.blob', 100, 10),
+              blob('/modules/stale.blob', 200, 10),
+            ];
+          }
+          return [];
+        },
+        readReferencedBlobNames: () => new Set(['live']),
+        removePaths: () => {},
+      }),
+    );
+    expect(result.integrityError).toContain('module storage is incomplete');
+  });
+
+  it('checks integrity even when the plan is a no-op', () => {
+    const result = applyConvexLocalMaintenance(
+      { kind: 'none', clearSnapshotArtifacts: false, warning: null },
+      deps({
+        listModuleBlobs: () => [],
+        readReferencedBlobNames: () => new Set(['live']),
+      }),
+    );
+    expect(result.integrityError).toContain('module storage is incomplete');
   });
 });
 
@@ -122,6 +226,126 @@ describe('readReferencedModuleBlobNames', () => {
     expect(readReferencedModuleBlobNames('/nope.sqlite3', () => false)).toEqual(
       new Set(),
     );
+  });
+
+  // bun:sqlite is unavailable under vitest's Node pool — build the fixture and
+  // assert the join via a short Bun subprocess (same driver production uses).
+  it('reads live package storageKeys from a Convex-shaped documents table', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'convex-maint-'));
+    const sqlitePath = join(dir, 'convex_local_backend.sqlite3');
+    const scriptPath = join(dir, 'assert-refs.ts');
+    try {
+      writeFileSync(
+        scriptPath,
+        `
+import { Database } from "bun:sqlite";
+import { readReferencedModuleBlobNames } from ${JSON.stringify(join(import.meta.dirname, 'convex-local-maintenance.ts'))};
+
+const sqlitePath = ${JSON.stringify(sqlitePath)};
+const db = new Database(sqlitePath, { safeIntegers: true });
+db.exec(\`
+  CREATE TABLE documents (
+    id BLOB NOT NULL,
+    ts INTEGER NOT NULL,
+    table_id BLOB NOT NULL,
+    json_value TEXT NULL,
+    deleted INTEGER NOT NULL,
+    prev_ts INTEGER,
+    PRIMARY KEY (ts, table_id, id)
+  );
+\`);
+const tableId = new Uint8Array(16).fill(1);
+const insert = db.query(
+  "INSERT INTO documents (id, ts, table_id, json_value, deleted) VALUES (?, ?, ?, ?, ?)",
+);
+const livePackageId = "k42livepackage000000000000000001";
+insert.run(
+  new Uint8Array(16).fill(2),
+  10n,
+  tableId,
+  JSON.stringify({
+    _id: "h42livemodule",
+    sourcePackageId: livePackageId,
+    analyzeResult: null,
+    path: "crons.js",
+  }),
+  0n,
+);
+insert.run(
+  new Uint8Array(16).fill(3),
+  10n,
+  tableId,
+  JSON.stringify({
+    _id: livePackageId,
+    storageKey: "modules/live-component.blob",
+    packageSize: 42,
+  }),
+  0n,
+);
+insert.run(
+  new Uint8Array(16).fill(3),
+  5n,
+  tableId,
+  JSON.stringify({
+    _id: livePackageId,
+    storageKey: "modules/old-revision.blob",
+    packageSize: 41,
+  }),
+  0n,
+);
+insert.run(
+  new Uint8Array(16).fill(4),
+  10n,
+  tableId,
+  JSON.stringify({
+    _id: "k42orphanpackage000000000000001",
+    storageKey: "modules/orphan.blob",
+    packageSize: 1,
+  }),
+  0n,
+);
+insert.run(
+  new Uint8Array(16).fill(5),
+  10n,
+  tableId,
+  JSON.stringify({
+    _id: "h42deletedmodule",
+    sourcePackageId: "k42deletedpkg00000000000000001",
+    analyzeResult: null,
+    path: "gone.js",
+  }),
+  1n,
+);
+insert.run(
+  new Uint8Array(16).fill(6),
+  10n,
+  tableId,
+  JSON.stringify({
+    _id: "k42deletedpkg00000000000000001",
+    storageKey: "modules/deleted-pkg.blob",
+    packageSize: 9,
+  }),
+  0n,
+);
+db.close();
+
+const refs = readReferencedModuleBlobNames(sqlitePath);
+const got = [...refs].sort().join(",");
+if (got !== "live-component") {
+  console.error("unexpected refs:", got);
+  process.exit(1);
+}
+console.log("ok");
+`,
+      );
+      const result = spawnSync('bun', [scriptPath], {
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('ok');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/services/platform/scripts/convex-local-maintenance.test.ts
+++ b/services/platform/scripts/convex-local-maintenance.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  applyConvexLocalMaintenance,
   formatBytes,
   MODULE_BLOB_KEEP_COUNT,
   MODULE_BLOB_PRUNE_BYTES_THRESHOLD,
   MODULE_BLOB_PRUNE_COUNT_THRESHOLD,
   planConvexLocalMaintenance,
+  readReferencedModuleBlobNames,
   resolveLatestCachedBackendVersion,
   selectModuleBlobsToPrune,
   summarizeModuleBlobs,
+  type MaintenanceDeps,
   type ModuleBlobEntry,
 } from './convex-local-maintenance';
 
@@ -36,7 +39,89 @@ describe('selectModuleBlobsToPrune', () => {
       blob('/b.blob', 300, 10),
       blob('/c.blob', 200, 10),
     ];
-    expect(selectModuleBlobsToPrune(entries, 2)).toEqual(['/a.blob']);
+    expect(selectModuleBlobsToPrune(entries, 2, new Set())).toEqual([
+      '/a.blob',
+    ]);
+  });
+
+  // Regression for the July 2026 dev incident: components are re-pushed
+  // rarely, so their blobs are the OLDEST files — an mtime-only prune deletes
+  // exactly the code the deployment still loads.
+  it('never selects a blob the deployment still references, even past keepCount', () => {
+    const entries = [
+      blob('/modules/live-old.blob', 100, 10),
+      blob('/modules/stale-1.blob', 200, 10),
+      blob('/modules/stale-2.blob', 300, 10),
+      blob('/modules/newest.blob', 400, 10),
+    ];
+    expect(selectModuleBlobsToPrune(entries, 1, new Set(['live-old']))).toEqual(
+      ['/modules/stale-2.blob', '/modules/stale-1.blob'],
+    );
+  });
+
+  it('prunes nothing when the reference set is unknown', () => {
+    const entries = [blob('/a.blob', 100, 10), blob('/b.blob', 200, 10)];
+    expect(selectModuleBlobsToPrune(entries, 0, null)).toEqual([]);
+  });
+});
+
+describe('applyConvexLocalMaintenance', () => {
+  const pruneAll = {
+    kind: 'prune-modules',
+    reason: 'test',
+    keepCount: 0,
+    clearSnapshotArtifacts: false,
+    warning: null,
+  } as const;
+
+  function deps(overrides: Partial<MaintenanceDeps>): MaintenanceDeps {
+    return {
+      listModuleBlobs: () => [blob('/modules/a.blob', 100, 10)],
+      removePaths: () => {},
+      isBackendRunning: () => false,
+      readReferencedBlobNames: () => new Set(),
+      ...overrides,
+    };
+  }
+
+  it('skips the prune (and says why) when references cannot be read', () => {
+    const removed: string[][] = [];
+    const result = applyConvexLocalMaintenance(
+      pruneAll,
+      deps({
+        readReferencedBlobNames: () => null,
+        removePaths: (paths) => removed.push(paths),
+      }),
+    );
+    expect(result.removedModuleBlobs).toBe(0);
+    expect(result.warning).toContain('Skipped Convex module prune');
+    expect(removed).toEqual([[]]);
+  });
+
+  it('prunes only unreferenced blobs when references are known', () => {
+    const removed: string[] = [];
+    const result = applyConvexLocalMaintenance(
+      pruneAll,
+      deps({
+        listModuleBlobs: () => [
+          blob('/modules/live.blob', 100, 10),
+          blob('/modules/stale.blob', 200, 10),
+        ],
+        readReferencedBlobNames: () => new Set(['live']),
+        removePaths: (paths) => removed.push(...paths),
+      }),
+    );
+    expect(removed).toEqual(['/modules/stale.blob']);
+    expect(result.removedModuleBlobs).toBe(1);
+    expect(result.warning).toBeNull();
+  });
+});
+
+describe('readReferencedModuleBlobNames', () => {
+  it('treats a missing database as an empty reference set', () => {
+    expect(readReferencedModuleBlobNames('/nope.sqlite3', () => false)).toEqual(
+      new Set(),
+    );
   });
 });
 

--- a/services/platform/scripts/convex-local-maintenance.ts
+++ b/services/platform/scripts/convex-local-maintenance.ts
@@ -63,6 +63,11 @@ export interface MaintenanceDeps {
   listModuleBlobs: () => ModuleBlobEntry[];
   removePaths: (paths: string[]) => void;
   isBackendRunning: () => boolean;
+  /**
+   * Blob basenames (no `.blob`) the current deployment still references —
+   * see {@link readReferencedModuleBlobNames}. `null` = unknown (skip prune).
+   */
+  readReferencedBlobNames: () => ReadonlySet<string> | null;
 }
 
 export interface MaintenanceResult {
@@ -91,13 +96,32 @@ export function summarizeModuleBlobs(
   return { count: entries.length, totalBytes };
 }
 
-/** Pick the blob paths to delete, keeping the `keepCount` newest by mtime. Pure. */
+/**
+ * Pick the blob paths to delete. Pure.
+ *
+ * A blob referenced by the CURRENT deployment must never be pruned — deleting
+ * it breaks every function of the component it belongs to (components are
+ * re-pushed rarely, so their blobs are often the OLDEST files in the dir; an
+ * mtime-only prune deletes exactly the code the backend still loads, which is
+ * how a July 2026 incident took out chat/crons/streaming on a dev machine).
+ * `referenced` is the deployment's live blob-name set (basenames without
+ * `.blob`):
+ *  - `null` means the reference set could not be read — fail safe, prune
+ *    nothing;
+ *  - otherwise keep every referenced blob, and keep the `keepCount` newest
+ *    (by mtime) of the unreferenced remainder.
+ */
 export function selectModuleBlobsToPrune(
   entries: readonly ModuleBlobEntry[],
   keepCount: number,
+  referenced: ReadonlySet<string> | null,
 ): string[] {
-  if (entries.length <= keepCount) return [];
-  const sorted = [...entries].sort((a, b) => b.mtimeMs - a.mtimeMs);
+  if (referenced === null) return [];
+  const blobName = (path: string): string =>
+    (path.split('/').pop() ?? path).replace(/\.blob$/, '');
+  const prunable = entries.filter((e) => !referenced.has(blobName(e.path)));
+  if (prunable.length <= keepCount) return [];
+  const sorted = [...prunable].sort((a, b) => b.mtimeMs - a.mtimeMs);
   return sorted.slice(keepCount).map((entry) => entry.path);
 }
 
@@ -296,16 +320,31 @@ export function applyConvexLocalMaintenance(
 
   let removedModuleBlobs = 0;
   let freedBytes = 0;
+  let pruneSkippedWarning: string | null = null;
   const pathsToRemove = [...snapshotArtifactPaths];
 
   if (plan.kind === 'prune-modules') {
-    const entries = deps.listModuleBlobs();
-    const toRemove = selectModuleBlobsToPrune(entries, plan.keepCount);
-    for (const entry of entries) {
-      if (toRemove.includes(entry.path)) freedBytes += entry.sizeBytes;
+    const referenced = deps.readReferencedBlobNames();
+    if (referenced === null) {
+      // Can't tell which blobs the deployment still loads — deleting on mtime
+      // alone would risk removing live component code. Skip, keep the data.
+      pruneSkippedWarning =
+        'Skipped Convex module prune — could not read the deployment’s ' +
+        'module references from the local database, and pruning without them ' +
+        'can delete live component code.';
+    } else {
+      const entries = deps.listModuleBlobs();
+      const toRemove = selectModuleBlobsToPrune(
+        entries,
+        plan.keepCount,
+        referenced,
+      );
+      for (const entry of entries) {
+        if (toRemove.includes(entry.path)) freedBytes += entry.sizeBytes;
+      }
+      pathsToRemove.push(...toRemove);
+      removedModuleBlobs = toRemove.length;
     }
-    pathsToRemove.push(...toRemove);
-    removedModuleBlobs = toRemove.length;
   }
 
   deps.removePaths(pathsToRemove);
@@ -323,13 +362,20 @@ export function applyConvexLocalMaintenance(
     );
   }
 
+  const warning =
+    pruneSkippedWarning !== null
+      ? plan.warning
+        ? `${plan.warning} ${pruneSkippedWarning}`
+        : pruneSkippedWarning
+      : plan.warning;
+
   return {
     action: removedModuleBlobs > 0 ? 'prune-modules' : 'none',
     removedModuleBlobs,
     removedSnapshotArtifacts,
     freedBytes,
     message: messages.length > 0 ? messages.join(' ') : null,
-    warning: plan.warning,
+    warning,
   };
 }
 
@@ -349,7 +395,112 @@ export function convexLocalPaths(platformRoot: string) {
     defaultDir,
     configPath: join(defaultDir, 'config.json'),
     modulesDir: join(defaultDir, 'convex_local_storage', 'modules'),
+    sqlitePath: join(defaultDir, 'convex_local_backend.sqlite3'),
   };
+}
+
+/**
+ * Blob basenames the current deployment still references, read from the local
+ * backend's SQLite (read-only; callers only prune while the backend is down).
+ *
+ * The join mirrors how the backend loads code: the latest live revision of
+ * every `_modules` row names its `sourcePackageId`; the latest live revision
+ * of each of those source packages carries the `storageKey` whose blob file
+ * must exist on disk. Everything else in `modules/` is history from
+ * superseded pushes and safe to prune.
+ *
+ * Returns `null` when the references can't be established (unreadable DB,
+ * missing driver, unexpected shape) — callers must then skip pruning. A
+ * missing DB file returns an empty set: no deployment, no live references.
+ * Revision timestamps exceed `Number.MAX_SAFE_INTEGER` (nanoseconds), so the
+ * reduce compares BigInts via `safeIntegers`.
+ */
+export function readReferencedModuleBlobNames(
+  sqlitePath: string,
+  exists: (path: string) => boolean = existsSync,
+): ReadonlySet<string> | null {
+  if (!exists(sqlitePath)) return new Set();
+  try {
+    // Lazy so the pure planning half of this module stays importable outside
+    // the Bun runtime (vitest runs on node).
+    // oxlint-disable-next-line typescript/no-require-imports -- bun builtin
+    const { Database } = require('bun:sqlite') as {
+      Database: new (
+        path: string,
+        opts: { readonly: boolean; safeIntegers: boolean },
+      ) => {
+        query: (sql: string) => {
+          all: () => {
+            id: unknown;
+            ts: bigint;
+            deleted: unknown;
+            v: string;
+          }[];
+        };
+        close: () => void;
+      };
+    };
+    const db = new Database(sqlitePath, {
+      readonly: true,
+      safeIntegers: true,
+    });
+    try {
+      const latestLive = (
+        like: string,
+      ): Map<string, Record<string, unknown>> => {
+        const rows = db
+          .query(
+            `SELECT id, ts, deleted, json_value v FROM documents WHERE ${like}`,
+          )
+          .all();
+        const latest = new Map<
+          string,
+          { ts: bigint; deleted: unknown; v: string }
+        >();
+        for (const row of rows) {
+          const key = String(row.id);
+          const prev = latest.get(key);
+          if (!prev || row.ts > prev.ts) latest.set(key, row);
+        }
+        const live = new Map<string, Record<string, unknown>>();
+        for (const [key, row] of latest) {
+          if (row.deleted) continue;
+          live.set(key, JSON.parse(row.v) as Record<string, unknown>);
+        }
+        return live;
+      };
+
+      const currentPackageIds = new Set<string>();
+      for (const doc of latestLive(
+        "json_value LIKE '%sourcePackageId%' AND json_value LIKE '%analyzeResult%'",
+      ).values()) {
+        if (typeof doc.sourcePackageId === 'string') {
+          currentPackageIds.add(doc.sourcePackageId);
+        }
+      }
+
+      const referenced = new Set<string>();
+      for (const doc of latestLive(
+        "json_value LIKE '%storageKey%' AND json_value LIKE '%packageSize%'",
+      ).values()) {
+        if (typeof doc._id !== 'string' || !currentPackageIds.has(doc._id)) {
+          continue;
+        }
+        if (typeof doc.storageKey !== 'string') continue;
+        const name = doc.storageKey.split('/').pop() ?? doc.storageKey;
+        referenced.add(name.replace(/\.blob$/, ''));
+      }
+      return referenced;
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    console.warn(
+      '[convex-maintenance] failed to read module references:',
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
 }
 
 function isConvexBackendRunning(): boolean {
@@ -407,6 +558,8 @@ export function runConvexLocalMaintenance(
         }
       },
       isBackendRunning: isConvexBackendRunning,
+      readReferencedBlobNames: () =>
+        readReferencedModuleBlobNames(paths.sqlitePath),
     },
     snapshotArtifactPaths,
   );

--- a/services/platform/scripts/convex-local-maintenance.ts
+++ b/services/platform/scripts/convex-local-maintenance.ts
@@ -77,6 +77,11 @@ export interface MaintenanceResult {
   freedBytes: number;
   message: string | null;
   warning: string | null;
+  /**
+   * Set when live module blobs are missing on disk. Callers must treat this as
+   * fatal — the deployment cannot be repaired by pruning.
+   */
+  integrityError: string | null;
 }
 
 /** Human-readable byte count for dev logs. */
@@ -123,6 +128,53 @@ export function selectModuleBlobsToPrune(
   if (prunable.length <= keepCount) return [];
   const sorted = [...prunable].sort((a, b) => b.mtimeMs - a.mtimeMs);
   return sorted.slice(keepCount).map((entry) => entry.path);
+}
+
+/** Basename (no `.blob`) for a module blob path. */
+export function moduleBlobBasename(path: string): string {
+  return (path.split('/').pop() ?? path).replace(/\.blob$/, '');
+}
+
+/**
+ * Live blob names the deployment references that are not present on disk.
+ * Pure. Empty when every referenced blob has a matching `*.blob` file.
+ */
+export function findMissingReferencedModuleBlobs(
+  referenced: ReadonlySet<string>,
+  onDiskEntries: readonly ModuleBlobEntry[],
+): string[] {
+  const onDisk = new Set(onDiskEntries.map((e) => moduleBlobBasename(e.path)));
+  const missing: string[] = [];
+  for (const name of referenced) {
+    if (!onDisk.has(name)) missing.push(name);
+  }
+  return missing.sort();
+}
+
+/**
+ * An empty reference set with blobs still on disk means the reader found a
+ * database but no live packages — treating that as "prune freely" would
+ * recreate the mtime-only incident. Fail closed and skip the prune.
+ */
+export function shouldSkipPruneForEmptyReferences(
+  referenced: ReadonlySet<string>,
+  onDiskBlobCount: number,
+): boolean {
+  return referenced.size === 0 && onDiskBlobCount > 0;
+}
+
+/** Fatal message when live module blobs are missing from disk. */
+export function formatModuleIntegrityError(missing: readonly string[]): string {
+  const sample = missing.slice(0, 5).join(', ');
+  const more = missing.length > 5 ? ` (+${missing.length - 5} more)` : '';
+  return (
+    `Local Convex module storage is incomplete: ${missing.length} live ` +
+    `function-bundle blob(s) referenced by the deployment are missing on disk` +
+    (sample ? ` (e.g. ${sample}${more})` : '') +
+    '. Automatic prune cannot repair this. Stop other Convex processes, then ' +
+    'run `bun run setup:clean` (type `delete local convex`) and `bun run dev` ' +
+    'to bootstrap a fresh deployment.'
+  );
 }
 
 function backendVersionMismatchWarning(
@@ -291,6 +343,11 @@ export function staleSnapshotArtifactPaths(
 /**
  * Apply the maintenance plan. Refuses to run while `convex-local-backend` is up —
  * deleting blobs from under a live backend corrupts the deployment.
+ *
+ * Always checks module integrity when references are known: missing live blobs
+ * set `integrityError` and skip any prune. Callers must treat `integrityError`
+ * as fatal (block Convex bring-up) — pruning cannot repair a half-deleted
+ * deployment.
  */
 export function applyConvexLocalMaintenance(
   plan: MaintenanceAction,
@@ -304,11 +361,8 @@ export function applyConvexLocalMaintenance(
     freedBytes: 0,
     message: null,
     warning: plan.warning,
+    integrityError: null,
   };
-
-  const needsWork =
-    plan.kind === 'prune-modules' || plan.clearSnapshotArtifacts;
-  if (!needsWork) return base;
 
   if (deps.isBackendRunning()) {
     return {
@@ -318,13 +372,29 @@ export function applyConvexLocalMaintenance(
     };
   }
 
+  const referenced = deps.readReferencedBlobNames();
+  const entries = deps.listModuleBlobs();
+
+  if (referenced !== null && referenced.size > 0) {
+    const missing = findMissingReferencedModuleBlobs(referenced, entries);
+    if (missing.length > 0) {
+      return {
+        ...base,
+        integrityError: formatModuleIntegrityError(missing),
+      };
+    }
+  }
+
+  const needsWork =
+    plan.kind === 'prune-modules' || plan.clearSnapshotArtifacts;
+  if (!needsWork) return base;
+
   let removedModuleBlobs = 0;
   let freedBytes = 0;
   let pruneSkippedWarning: string | null = null;
   const pathsToRemove = [...snapshotArtifactPaths];
 
   if (plan.kind === 'prune-modules') {
-    const referenced = deps.readReferencedBlobNames();
     if (referenced === null) {
       // Can't tell which blobs the deployment still loads — deleting on mtime
       // alone would risk removing live component code. Skip, keep the data.
@@ -332,8 +402,14 @@ export function applyConvexLocalMaintenance(
         'Skipped Convex module prune — could not read the deployment’s ' +
         'module references from the local database, and pruning without them ' +
         'can delete live component code.';
+    } else if (shouldSkipPruneForEmptyReferences(referenced, entries.length)) {
+      // DB readable but no live packages found while blobs remain — fail
+      // closed rather than treating "empty" as "prune everything by mtime".
+      pruneSkippedWarning =
+        'Skipped Convex module prune — the local database has module blobs ' +
+        'on disk but no live package references were found. Pruning without ' +
+        'references can delete live component code.';
     } else {
-      const entries = deps.listModuleBlobs();
       const toRemove = selectModuleBlobsToPrune(
         entries,
         plan.keepCount,
@@ -349,11 +425,28 @@ export function applyConvexLocalMaintenance(
 
   deps.removePaths(pathsToRemove);
 
+  // Re-check after deletes so a buggy selection cannot leave a half-dead tree.
+  if (referenced !== null && referenced.size > 0 && removedModuleBlobs > 0) {
+    const after = deps.listModuleBlobs();
+    const missingAfter = findMissingReferencedModuleBlobs(referenced, after);
+    if (missingAfter.length > 0) {
+      return {
+        action: 'none',
+        removedModuleBlobs,
+        removedSnapshotArtifacts: snapshotArtifactPaths.length,
+        freedBytes,
+        message: null,
+        warning: plan.warning,
+        integrityError: formatModuleIntegrityError(missingAfter),
+      };
+    }
+  }
+
   const removedSnapshotArtifacts = snapshotArtifactPaths.length;
   const messages: string[] = [];
   if (removedModuleBlobs > 0) {
     messages.push(
-      `Pruned ${removedModuleBlobs} stale Convex module blob(s) (${formatBytes(freedBytes)} freed; kept newest ${plan.kind === 'prune-modules' ? plan.keepCount : MODULE_BLOB_KEEP_COUNT}). ${plan.kind === 'prune-modules' ? plan.reason : ''}`.trim(),
+      `Pruned ${removedModuleBlobs} stale Convex module blob(s) (${formatBytes(freedBytes)} freed; kept newest ${plan.kind === 'prune-modules' ? plan.keepCount : MODULE_BLOB_KEEP_COUNT}, never live references). ${plan.kind === 'prune-modules' ? plan.reason : ''}`.trim(),
     );
   }
   if (removedSnapshotArtifacts > 0) {
@@ -376,6 +469,7 @@ export function applyConvexLocalMaintenance(
     freedBytes,
     message: messages.length > 0 ? messages.join(' ') : null,
     warning,
+    integrityError: null,
   };
 }
 

--- a/services/platform/scripts/dev-engine.ts
+++ b/services/platform/scripts/dev-engine.ts
@@ -1067,11 +1067,14 @@ export async function runDevFleet() {
         );
       }
 
-      // Convex never GCs old function-bundle blobs locally; prune or reset
-      // before the pre-warm so cold starts stay inside the CLI's 30s window.
-      // Non-essential: a maintenance failure must never block backend bring-up.
+      // Non-essential prune/snapshot cleanup must never block backend bring-up,
+      // but a missing live module blob is fatal — continuing would boot into
+      // the half-dead state (chat/crons InternalServerError + WS drop).
       try {
         const maintenance = runConvexLocalMaintenance(platformRoot);
+        if (maintenance.integrityError) {
+          throw new Error(maintenance.integrityError);
+        }
         if (maintenance.warning) {
           warnLine(maintenance.warning);
         }
@@ -1079,9 +1082,11 @@ export async function runDevFleet() {
           infoLine(maintenance.message);
         }
       } catch (err) {
-        warnLine(
-          `Convex local maintenance skipped (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
-        );
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('module storage is incomplete')) {
+          throw err;
+        }
+        warnLine(`Convex local maintenance skipped (non-fatal): ${msg}`);
       }
 
       // One live line for the whole backend bring-up: the `npx convex dev

--- a/services/platform/scripts/dev-engine.ts
+++ b/services/platform/scripts/dev-engine.ts
@@ -1070,23 +1070,24 @@ export async function runDevFleet() {
       // Non-essential prune/snapshot cleanup must never block backend bring-up,
       // but a missing live module blob is fatal — continuing would boot into
       // the half-dead state (chat/crons InternalServerError + WS drop).
+      // Gate on the typed `integrityError` field (not a message substring) so a
+      // wording change cannot demote the fatal path to a warn.
+      let maintenance: ReturnType<typeof runConvexLocalMaintenance> | null =
+        null;
       try {
-        const maintenance = runConvexLocalMaintenance(platformRoot);
-        if (maintenance.integrityError) {
-          throw new Error(maintenance.integrityError);
-        }
-        if (maintenance.warning) {
-          warnLine(maintenance.warning);
-        }
-        if (maintenance.message) {
-          infoLine(maintenance.message);
-        }
+        maintenance = runConvexLocalMaintenance(platformRoot);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes('module storage is incomplete')) {
-          throw err;
-        }
         warnLine(`Convex local maintenance skipped (non-fatal): ${msg}`);
+      }
+      if (maintenance?.integrityError) {
+        throw new Error(maintenance.integrityError);
+      }
+      if (maintenance?.warning) {
+        warnLine(maintenance.warning);
+      }
+      if (maintenance?.message) {
+        infoLine(maintenance.message);
       }
 
       // One live line for the whole backend bring-up: the `npx convex dev


### PR DESCRIPTION
## Summary

Four independent platform incident fixes on one branch:

1. **Agent roster** — Upload only wrote the agent file; the roster lists file ∩ enabled install row, so uploads stayed invisible. Pair upload with `installCatalogAgent` (same as Blank create). Explicit “Update built-in agents” now always schedules the provisioner with `reinstallMissing` so a deleted autoInstall row can heal.
2. **Crawler load** — Unpaced site scans + JSDOM CSS parsing starved the shared Convex backend (mutation failures / WS 1011). Pace fetch batches and continuations; route HTML through a quiet `parseHtml` that strips `<style>` blocks.
3. **Convex local maintenance** — mtime-only prune deleted live component module blobs. Read live references from local SQLite, never prune them, skip prune when refs are unknown/empty-with-blobs, and fail bring-up when live blobs are already missing. Integrity is gated on the typed `integrityError` field (not a message substring).

## Checklist

- [x] `bun run check` passes (format, lint, typecheck, all tests). — **Partial:** `@tale/platform` lint/typecheck + focused tests + `@tale/docs` test green. Full `bun run check` still fails on pre-existing `@tale/skills#test` projection drift (`labels:` in `builtin-configs` vs `.agents/skills`) already present on `main`; out of scope for this PR.
- [x] `bun run lint:sast` passes (Opengrep) — 0 findings.
- [x] Translations updated in `services/platform/messages/{en,de,fr}.json` — **N/A** (no new message keys).
- [x] Docs updated in `docs/{en,de,fr}/` for any user-visible change — contributor-setup prune/integrity wording.
- [x] `README.md` / `README.de.md` / `README.fr.md` updated — **N/A**.

## Test plan

- [x] `vitest` focused suites: `convex-local-maintenance`, `provision_defaults`, `parse_html`, `builtin_sync`, `agents-action-menu` (46 tests).
- [x] `@tale/platform` lint + typecheck; `@tale/docs` test (174); `lint:sast`.
- [ ] Upload an agent as admin → appears in roster; as non-admin → file kept, install failure logged.
- [ ] Delete an autoInstall agent’s install row → “Update built-in agents” restores it; disabled rows stay disabled.
- [ ] Run a multi-page website scan → backend stays responsive; no CSS stylesheet flood in logs.
- [ ] Corrupt/missing live module blob → `bun run dev` stops with integrity error pointing at `setup:clean`.
- [ ] Healthy local deployment over prune threshold → unreferenced blobs pruned; live blobs kept.