### PR TITLE
feat(platform): compose a new email from contacts

### DIFF
--- a/services/platform/app/features/contacts/components/contact-row-actions.tsx
+++ b/services/platform/app/features/contacts/components/contact-row-actions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Pencil, Trash2 } from 'lucide-react';
+import { useNavigate } from '@tanstack/react-router';
+import { Mail, Pencil, Trash2 } from 'lucide-react';
 import { useMemo } from 'react';
 
 import {
@@ -14,12 +15,17 @@ import { useT } from '@/lib/i18n/client';
 import { ContactDeleteDialog } from './contact-delete-dialog';
 import { ContactEditDialog } from './contact-edit-dialog';
 
+/** Placeholder email a contact record carries when it has no real address. */
+const UNKNOWN_CONTACT_EMAIL = 'unknown@example.com';
+
 interface ContactRowActionsProps {
   contact: Doc<'contacts'>;
 }
 
 export function ContactRowActions({ contact }: ContactRowActionsProps) {
   const { t: tCommon } = useT('common');
+  const { t: tConversations } = useT('conversations');
+  const navigate = useNavigate();
   const ability = useAbility();
   const canWrite = ability.can('write', 'knowledgeWrite');
   const dialogs = useEntityRowDialogs(['edit', 'delete']);
@@ -28,8 +34,28 @@ export function ContactRowActions({ contact }: ContactRowActionsProps) {
     canWrite &&
     (contact.source === 'manual_import' || contact.source === 'file_upload');
 
+  // Emailing a contact is independent of edit rights — a synced, non-editable
+  // contact is still a valid recipient, as long as it has a real address.
+  const canEmail = Boolean(
+    contact.email && contact.email !== UNKNOWN_CONTACT_EMAIL,
+  );
+
   const actions = useMemo(
     () => [
+      {
+        key: 'email',
+        label: tConversations('compose.newEmail'),
+        icon: Mail,
+        // Opens the inbox's compose pane, seeded with this contact — the same
+        // surface as the header "Compose", so there's one compose experience.
+        onClick: () =>
+          void navigate({
+            to: '/dashboard/$id/conversations/$status',
+            params: { id: contact.organizationId, status: 'open' },
+            search: { compose: 'new', composeContact: contact._id },
+          }),
+        visible: canEmail,
+      },
       {
         key: 'edit',
         label: tCommon('actions.edit'),
@@ -46,28 +72,40 @@ export function ContactRowActions({ contact }: ContactRowActionsProps) {
         visible: canEdit,
       },
     ],
-    [tCommon, dialogs.open, canEdit],
+    [
+      tCommon,
+      tConversations,
+      dialogs.open,
+      canEdit,
+      canEmail,
+      navigate,
+      contact,
+    ],
   );
 
-  if (!canEdit) return null;
+  if (!canEdit && !canEmail) return null;
 
   return (
     <>
       <EntityRowActions actions={actions} />
 
-      <ContactEditDialog
-        contact={contact}
-        isOpen={dialogs.isOpen.edit}
-        onOpenChange={dialogs.setOpen.edit}
-        asChild
-      />
+      {canEdit && (
+        <>
+          <ContactEditDialog
+            contact={contact}
+            isOpen={dialogs.isOpen.edit}
+            onOpenChange={dialogs.setOpen.edit}
+            asChild
+          />
 
-      <ContactDeleteDialog
-        contact={contact}
-        isOpen={dialogs.isOpen.delete}
-        onOpenChange={dialogs.setOpen.delete}
-        asChild
-      />
+          <ContactDeleteDialog
+            contact={contact}
+            isOpen={dialogs.isOpen.delete}
+            onOpenChange={dialogs.setOpen.delete}
+            asChild
+          />
+        </>
+      )}
     </>
   );
 }

--- a/services/platform/app/features/conversations/components/compose-email-pane.tsx
+++ b/services/platform/app/features/conversations/components/compose-email-pane.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { Center, Row, Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import { Loader2Icon, Trash2Icon, XIcon } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { PanelFooter } from '@/app/components/layout/panel-footer';
+import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
+import { Input } from '@/app/components/ui/forms/input';
+import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
+import { useAuth } from '@/app/hooks/use-convex-auth';
+import { usePersistedState } from '@/app/hooks/use-persisted-state';
+import { toast } from '@/app/hooks/use-toast';
+import type { Id } from '@/convex/_generated/dataModel';
+import { toId } from '@/convex/lib/type_cast_helpers';
+import { useT } from '@/lib/i18n/client';
+import { lazyComponent } from '@/lib/utils/lazy-component';
+
+import {
+  useComposeEmailConversation,
+  useGenerateUploadUrl,
+} from '../hooks/mutations';
+import { useEmailIntegrations } from '../hooks/queries';
+import {
+  emailDomain,
+  isSenderAddressValid,
+  supportsDynamicSender,
+} from '../lib/email-integrations';
+import { ContactRecipientPicker } from './contact-recipient-picker';
+import { messageDraftKeys, type AttachedFile } from './message-editor/types';
+
+// Milkdown is heavy; load it only once compose is open (mirrors the reply
+// composer in the conversation panel).
+const MessageEditor = lazyComponent(
+  () =>
+    import('./message-editor').then((mod) => ({ default: mod.MessageEditor })),
+  {
+    loading: () => (
+      <Center className="p-4">
+        <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+      </Center>
+    ),
+  },
+);
+
+export interface ComposeEmailPaneProps {
+  organizationId: string;
+  /** Seed the recipient (e.g. arriving from a contact row). */
+  initialContactId?: string;
+  /** Navigate to the created conversation after a successful send. */
+  onSent: (conversationId: string) => void;
+  /** Dismiss compose (keeps the draft — Discard clears it). */
+  onClose: () => void;
+}
+
+interface UploadedAttachment {
+  storageId: Id<'_storage'>;
+  fileName: string;
+  contentType: string;
+  size: number;
+}
+
+/**
+ * Compose a brand-new outbound email, rendered IN the inbox reading pane where a
+ * thread normally shows: the same header/scroll/footer skeleton as
+ * `ConversationPanel`, with the reply composer (Milkdown) at the bottom.
+ *
+ * Draft lifecycle: every field (recipient, inbox, sender override, subject) plus
+ * the body is persisted per user + org, so closing or navigating away and
+ * reopening resumes the in-progress email. Arriving from a contact row seeds the
+ * recipient. A successful send — and the explicit Discard — clear the whole
+ * draft. The body draft is owned by `MessageEditor` (keyed via
+ * {@link messageDraftKeys}); Discard clears that same key.
+ *
+ * "Empty" fields are stored as `''` rather than `null`: `usePersistedState`'s
+ * type guard rejects a stored string when the initial value is `null`, which
+ * would silently drop a restored recipient/inbox.
+ */
+export function ComposeEmailPane({
+  organizationId,
+  initialContactId,
+  onSent,
+  onClose,
+}: ComposeEmailPaneProps) {
+  const { t } = useT('conversations');
+  const { t: tCommon } = useT('common');
+  const { user } = useAuth();
+  const { emailIntegrations, isLoading: integrationsLoading } =
+    useEmailIntegrations(organizationId);
+  const { mutateAsync: composeEmail } = useComposeEmailConversation();
+  const { mutateAsync: generateUploadUrl } = useGenerateUploadUrl();
+
+  const draftPrefix = user?.userId
+    ? `compose-${user.userId}-${organizationId}`
+    : `compose-${organizationId}`;
+  const composeBodyMessageId = `compose-${organizationId}`;
+
+  const [contactId, setContactId, clearContactId] = usePersistedState(
+    `${draftPrefix}-contact`,
+    initialContactId ?? '',
+  );
+  const [integrationName, setIntegrationName, clearIntegrationName] =
+    usePersistedState(`${draftPrefix}-inbox`, '');
+  const [senderAddress, setSenderAddress, clearSenderAddress] =
+    usePersistedState(`${draftPrefix}-sender`, '');
+  const [subject, setSubject, clearSubject] = usePersistedState(
+    `${draftPrefix}-subject`,
+    '',
+  );
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+
+  // Seeded recipient (from a contact row) wins over a restored draft contact.
+  useEffect(() => {
+    if (initialContactId) setContactId(initialContactId);
+  }, [initialContactId, setContactId]);
+
+  const selectedIntegration = useMemo(
+    () => emailIntegrations.find((i) => i.slug === integrationName) ?? null,
+    [emailIntegrations, integrationName],
+  );
+
+  // Once inboxes load: keep the persisted inbox only if it's still connected,
+  // else auto-select the sole inbox (or clear when there's a choice to make).
+  useEffect(() => {
+    if (integrationsLoading) return;
+    const stillConnected =
+      integrationName !== '' &&
+      emailIntegrations.some((i) => i.slug === integrationName);
+    if (stillConnected) return;
+    setIntegrationName(
+      emailIntegrations.length === 1 ? emailIntegrations[0].slug : '',
+    );
+  }, [
+    integrationsLoading,
+    emailIntegrations,
+    integrationName,
+    setIntegrationName,
+  ]);
+
+  // Sender is an OVERRIDE over the inbox's configured address: empty means "use
+  // the inbox default", so switching inbox (which clears the override) falls
+  // back cleanly without an effect that could clobber a restored override.
+  const senderDefault = selectedIntegration?.fromAddress ?? '';
+  const senderInputValue = senderAddress || senderDefault;
+  const effectiveSender = senderAddress.trim() || senderDefault;
+  const dynamicSender = supportsDynamicSender(selectedIntegration);
+  const senderDomain = senderDefault ? emailDomain(senderDefault) : '';
+  const senderValid =
+    !dynamicSender || isSenderAddressValid(effectiveSender, senderDomain);
+
+  const hasEmailIntegration = emailIntegrations.length > 0;
+  const canSend = Boolean(
+    contactId &&
+    integrationName &&
+    subject.trim() &&
+    hasEmailIntegration &&
+    senderValid,
+  );
+
+  const handleInboxChange = (slug: string) => {
+    setIntegrationName(slug);
+    clearSenderAddress();
+  };
+
+  const clearDraftFields = useCallback(() => {
+    clearContactId();
+    clearIntegrationName();
+    clearSenderAddress();
+    clearSubject();
+  }, [clearContactId, clearIntegrationName, clearSenderAddress, clearSubject]);
+
+  const discardDraft = useCallback(() => {
+    clearDraftFields();
+    // The body/instruction drafts live inside MessageEditor's own persistence;
+    // clear the same keys so a discard truly empties the composer on reopen.
+    const keys = messageDraftKeys(user?.userId, composeBodyMessageId);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(keys.body);
+        window.localStorage.removeItem(keys.improveInstruction);
+      } catch (error) {
+        console.warn('Failed to clear compose body draft:', error);
+      }
+    }
+    onClose();
+  }, [clearDraftFields, user?.userId, composeBodyMessageId, onClose]);
+
+  const uploadAttachments = async (
+    attachments: AttachedFile[],
+  ): Promise<UploadedAttachment[]> => {
+    const valid = attachments.filter((a) => a.file);
+    return Promise.all(
+      valid.map(async (attachment) => {
+        const file = attachment.file;
+        if (!file) throw new Error('missing file');
+        const uploadUrl = await generateUploadUrl({});
+        const result = await fetch(uploadUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': file.type || 'application/octet-stream' },
+          body: file,
+        });
+        if (!result.ok) throw new Error('upload failed');
+        const { storageId } = await result.json();
+        if (typeof storageId !== 'string') throw new Error('upload failed');
+        return {
+          storageId: toId<'_storage'>(storageId),
+          fileName: file.name,
+          contentType: file.type,
+          size: file.size,
+        };
+      }),
+    );
+  };
+
+  const handleSend = async (message: string, attachments?: AttachedFile[]) => {
+    if (!contactId || !integrationName || !subject.trim()) return;
+
+    let uploaded: UploadedAttachment[] | undefined;
+    if (attachments && attachments.length > 0) {
+      try {
+        uploaded = await uploadAttachments(attachments);
+      } catch (error) {
+        console.error('Error uploading attachments:', error);
+        toast({ title: t('compose.uploadFailed'), variant: 'destructive' });
+        return;
+      }
+    }
+
+    try {
+      const result = await composeEmail({
+        organizationId,
+        contactId: toId<'contacts'>(contactId),
+        integrationName,
+        subject: subject.trim(),
+        content: message,
+        ...(dynamicSender && effectiveSender ? { from: effectiveSender } : {}),
+        ...(uploaded?.length ? { attachments: uploaded } : {}),
+      });
+      toast({ title: t('compose.sent'), variant: 'success' });
+      // MessageEditor clears its own body draft on a successful send; clear the
+      // field drafts here so a sent email never reappears as a draft.
+      clearDraftFields();
+      onSent(result.conversationId);
+    } catch (error) {
+      // Re-throw so MessageEditor keeps the draft and shows its own error toast.
+      console.error('Failed to compose email:', error);
+      throw error;
+    }
+  };
+
+  return (
+    <>
+      <Stack gap={0} className="relative min-h-0 flex-1">
+        <Stack gap={0} className="min-h-0 flex-1 overflow-y-auto">
+          <div className="border-border bg-background sticky top-0 z-20 border-b p-4 sm:px-6 sm:py-4">
+            <Row justify="between" align="center" gap={2}>
+              <Stack gap={0} className="min-w-0">
+                <Text variant="label" className="truncate">
+                  {t('compose.title')}
+                </Text>
+                <Text variant="muted" className="truncate text-xs">
+                  {t('compose.description')}
+                </Text>
+              </Stack>
+              <Row gap={1} className="shrink-0">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Trash2Icon}
+                  onClick={() => setConfirmDiscardOpen(true)}
+                >
+                  {t('compose.discard')}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onClose}
+                  aria-label={tCommon('aria.close')}
+                >
+                  <XIcon className="size-4" />
+                </Button>
+              </Row>
+            </Row>
+          </div>
+
+          <div className="mx-auto w-full max-w-3xl px-4 pt-4 sm:px-6">
+            <Stack gap={4}>
+              <ContactRecipientPicker
+                organizationId={organizationId}
+                value={contactId || null}
+                onChange={setContactId}
+              />
+
+              {integrationsLoading ? null : !hasEmailIntegration ? (
+                <Text variant="muted">{t('compose.noEmailIntegration')}</Text>
+              ) : (
+                <>
+                  {emailIntegrations.length > 1 && (
+                    <SearchableSelect
+                      label={t('compose.inboxLabel')}
+                      required
+                      value={integrationName || null}
+                      onValueChange={handleInboxChange}
+                      options={emailIntegrations.map((i) => ({
+                        value: i.slug,
+                        label: i.title,
+                        description: i.fromAddress,
+                      }))}
+                      placeholder={t('compose.inboxPlaceholder')}
+                      aria-label={t('compose.inboxLabel')}
+                    />
+                  )}
+
+                  {selectedIntegration &&
+                    (dynamicSender ? (
+                      <Input
+                        label={t('compose.fromLabel')}
+                        required
+                        type="email"
+                        value={senderInputValue}
+                        onChange={(event) =>
+                          setSenderAddress(event.target.value)
+                        }
+                        description={t('compose.fromDomainHint', {
+                          domain: senderDomain,
+                        })}
+                        errorMessage={
+                          senderAddress.trim() !== '' && !senderValid
+                            ? t('compose.fromInvalid', { domain: senderDomain })
+                            : undefined
+                        }
+                        placeholder={`you@${senderDomain}`}
+                        aria-label={t('compose.fromLabel')}
+                      />
+                    ) : (
+                      <Text variant="muted">
+                        {t('compose.from', {
+                          from:
+                            selectedIntegration.fromAddress ??
+                            selectedIntegration.title,
+                        })}
+                      </Text>
+                    ))}
+                </>
+              )}
+
+              <Input
+                label={t('compose.subject')}
+                required
+                value={subject}
+                onChange={(event) => setSubject(event.target.value)}
+                placeholder={t('compose.subjectPlaceholder')}
+              />
+            </Stack>
+          </div>
+        </Stack>
+
+        <PanelFooter className="px-4 py-3">
+          <div className="mx-auto w-full max-w-3xl">
+            <MessageEditor
+              onSave={handleSend}
+              placeholder={t('compose.bodyPlaceholder')}
+              organizationId={organizationId}
+              messageId={composeBodyMessageId}
+              disabled={!canSend}
+            />
+            {hasEmailIntegration && !canSend && (
+              <Text variant="muted" className="mt-2 text-xs">
+                {t('compose.fillRequired')}
+              </Text>
+            )}
+          </div>
+        </PanelFooter>
+      </Stack>
+
+      {confirmDiscardOpen && (
+        <ConfirmDialog
+          open
+          onOpenChange={(next) => {
+            if (!next) setConfirmDiscardOpen(false);
+          }}
+          variant="destructive"
+          title={t('compose.discardConfirm.title')}
+          description={t('compose.discardConfirm.description')}
+          confirmText={t('compose.discard')}
+          onConfirm={discardDraft}
+        />
+      )}
+    </>
+  );
+}

--- a/services/platform/app/features/conversations/components/contact-recipient-picker.tsx
+++ b/services/platform/app/features/conversations/components/contact-recipient-picker.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from '@/app/components/ui/forms/searchable-select';
+import { useContacts } from '@/app/features/contacts/hooks/queries';
+import { useT } from '@/lib/i18n/client';
+
+/** Placeholder email a contact record carries when it has no real address. */
+const UNKNOWN_CONTACT_EMAIL = 'unknown@example.com';
+
+interface ContactRecipientPickerProps {
+  organizationId: string;
+  /** Selected contact id, or null. */
+  value: string | null;
+  onChange: (contactId: string) => void;
+  disabled?: boolean;
+  error?: boolean;
+}
+
+/**
+ * Recipient picker for the compose dialog — the same {@link SearchableSelect}
+ * that backs the assignee/model/agent selectors, fed by the org's contacts.
+ * Only contacts with a real email address are offered (a contact without one
+ * can't be emailed — mirrors the reply path's `customer_email_not_found` guard).
+ */
+export function ContactRecipientPicker({
+  organizationId,
+  value,
+  onChange,
+  disabled,
+  error,
+}: ContactRecipientPickerProps) {
+  const { t } = useT('conversations');
+  const { contacts, isLoading } = useContacts(organizationId);
+
+  const options = useMemo<SearchableSelectOption[]>(
+    () =>
+      contacts
+        .filter((c) => c.email && c.email !== UNKNOWN_CONTACT_EMAIL)
+        .map((c) => {
+          const name = c.name?.trim();
+          return {
+            value: c._id,
+            label: name || c.email || c._id,
+            description: name ? c.email : undefined,
+          };
+        }),
+    [contacts],
+  );
+
+  return (
+    <SearchableSelect
+      label={t('compose.to')}
+      required
+      value={value}
+      onValueChange={onChange}
+      options={options}
+      disabled={disabled}
+      error={error}
+      placeholder={t('compose.toPlaceholder')}
+      searchPlaceholder={t('compose.searchContacts')}
+      emptyText={
+        isLoading ? t('compose.contactsLoading') : t('compose.noContacts')
+      }
+      aria-label={t('compose.to')}
+    />
+  );
+}

--- a/services/platform/app/features/conversations/components/conversations-navigation.tsx
+++ b/services/platform/app/features/conversations/components/conversations-navigation.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import {
   TabNavigation,
   type TabNavigationItem,
@@ -11,6 +13,8 @@ import { useApproxConversationCountByStatus } from '../hooks/queries';
 
 interface ConversationsNavigationProps {
   organizationId: string;
+  /** Trailing action pinned to the right of the tab row (e.g. Compose). */
+  action?: ReactNode;
 }
 
 const STATUSES = ['open', 'closed', 'spam', 'archived'] as const;
@@ -25,6 +29,7 @@ function CountBadge({ count }: { count: number }) {
 
 export function ConversationsNavigation({
   organizationId,
+  action,
 }: ConversationsNavigationProps) {
   const { t } = useT('conversations');
 
@@ -51,5 +56,9 @@ export function ConversationsNavigation({
     };
   });
 
-  return <TabNavigation items={navigationItems} standalone={false} prefetch />;
+  return (
+    <TabNavigation items={navigationItems} standalone={false} prefetch>
+      {action}
+    </TabNavigation>
+  );
 }

--- a/services/platform/app/features/conversations/components/conversations.tsx
+++ b/services/platform/app/features/conversations/components/conversations.tsx
@@ -30,6 +30,7 @@ import { useBulkActions } from '../hooks/use-bulk-actions';
 import { useConversationSelection } from '../hooks/use-conversation-selection';
 import type { Conversation } from '../types';
 import { BulkSendDialog } from './bulk-send-dialog';
+import { ComposeEmailPane } from './compose-email-pane';
 import { ConversationListPanel } from './conversation-list-panel';
 import { ConversationListToolbar } from './conversation-list-toolbar';
 import { ConversationPanel } from './conversation-panel';
@@ -63,6 +64,10 @@ interface ConversationsProps {
   /** Server-side provider filter (the route owns the URL state). The control
    *  renders only when at least one option exists. */
   channelFilter?: ChannelFilter;
+  /** Compose mode — render the compose pane in the reading pane (URL: `?compose`). */
+  composing?: boolean;
+  /** Contact to seed the composer with (URL: `?composeContact`). */
+  composeContact?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +116,8 @@ export function Conversations({
   conversationCount,
   totalConversationCount,
   channelFilter,
+  composing = false,
+  composeContact,
 }: ConversationsProps) {
   const navigate = useNavigate();
 
@@ -242,12 +249,43 @@ export function Conversations({
     setSelectedConversationId(conversation.id);
   };
 
+  const closeCompose = useCallback(() => {
+    void navigate({
+      to: '/dashboard/$id/conversations/$status',
+      params: { id: organizationId, status: status ?? 'open' },
+      search: (prev) => ({
+        ...prev,
+        compose: undefined,
+        composeContact: undefined,
+      }),
+      replace: true,
+    });
+  }, [navigate, organizationId, status]);
+
+  const handleComposeSent = useCallback(
+    (conversationId: string) => {
+      setSelectedConversationId(conversationId);
+      void navigate({
+        to: '/dashboard/$id/conversations/$status',
+        params: { id: organizationId, status: status ?? 'open' },
+        search: (prev) => ({
+          ...prev,
+          conversation: conversationId,
+          compose: undefined,
+          composeContact: undefined,
+        }),
+      });
+    },
+    [navigate, organizationId, status],
+  );
+
   return (
     <>
       <ConversationListPanel
-        // On mobile the activate CTA owns the screen (reading pane below), so
-        // hide the empty list there; on desktop it sits beside the CTA.
-        hidden={!!selectedConversationId || isActivateEmpty}
+        // On mobile the activate CTA / a selected thread / compose owns the
+        // screen (reading pane below), so hide the empty list there; on desktop
+        // it sits beside them.
+        hidden={!!selectedConversationId || isActivateEmpty || composing}
         overlay={
           isBulkProcessing ? (
             <LoadingOverlay message={tConversations('updating')} />
@@ -493,12 +531,22 @@ export function Conversations({
       <div
         className={cn(
           'flex-1 min-w-0',
-          // Show the reading pane on mobile when there's a selection OR when
-          // it's hosting the activate CTA (the empty list is hidden there).
-          selectedConversationId || isActivateEmpty ? 'flex' : 'hidden md:flex',
+          // Show the reading pane on mobile when composing, when there's a
+          // selection, OR when it's hosting the activate CTA (the empty list is
+          // hidden there).
+          selectedConversationId || isActivateEmpty || composing
+            ? 'flex'
+            : 'hidden md:flex',
         )}
       >
-        {isActivateEmpty ? (
+        {composing ? (
+          <ComposeEmailPane
+            organizationId={organizationId}
+            initialContactId={composeContact}
+            onSent={handleComposeSent}
+            onClose={closeCompose}
+          />
+        ) : isActivateEmpty ? (
           <ConversationsEmptyState />
         ) : (
           <ConversationPanel

--- a/services/platform/app/features/conversations/components/message-editor.tsx
+++ b/services/platform/app/features/conversations/components/message-editor.tsx
@@ -28,7 +28,11 @@ import { useImproveMessage } from '../hooks/actions';
 import { EditorActionBar } from './message-editor/editor-action-bar';
 import { FileAttachmentsList } from './message-editor/file-attachments-list';
 import { ImproveMode } from './message-editor/improve-mode';
-import type { AttachedFile, MessageEditorProps } from './message-editor/types';
+import {
+  type AttachedFile,
+  type MessageEditorProps,
+  messageDraftKeys,
+} from './message-editor/types';
 import { MessageImprovementDialog } from './message-improvement-dialog';
 
 function markdownToHtml(md: string): string {
@@ -72,20 +76,13 @@ function MilkdownEditorInner({
   const { mutateAsync: improveMessage } = useImproveMessage();
 
   const editorPlaceholder = placeholder || tConversations('messagePlaceholder');
-  const draftPrefix = user?.userId
-    ? `conversation-${user.userId}`
-    : 'conversation';
+  const draftKeys = messageDraftKeys(user?.userId, messageId);
   const [message, setMessage, clearMessage] = usePersistedState(
-    messageId ? `${draftPrefix}-${messageId}` : `${draftPrefix}-new`,
+    draftKeys.body,
     pendingMessage?.content || '',
   );
   const [improveInstruction, setImproveInstruction, clearImproveInstruction] =
-    usePersistedState(
-      messageId
-        ? `${draftPrefix}-${messageId}-improve-instruction`
-        : `${draftPrefix}-new-improve-instruction`,
-      '',
-    );
+    usePersistedState(draftKeys.improveInstruction, '');
 
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
   const [isImproveMode, setIsImproveMode] = useState(false);

--- a/services/platform/app/features/conversations/components/message-editor/types.test.ts
+++ b/services/platform/app/features/conversations/components/message-editor/types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { messageDraftKeys } from './types';
+
+// The key format is a compatibility contract: it must match the format the
+// editor used inline before extraction (so existing drafts aren't orphaned),
+// and the compose pane's Discard relies on producing the SAME keys the editor
+// persists under.
+describe('messageDraftKeys', () => {
+  it('keys a per-user draft by messageId', () => {
+    expect(messageDraftKeys('u1', 'm1')).toEqual({
+      body: 'conversation-u1-m1',
+      improveInstruction: 'conversation-u1-m1-improve-instruction',
+    });
+  });
+
+  it('falls back to a shared "new" slot when messageId is absent', () => {
+    expect(messageDraftKeys('u1', undefined)).toEqual({
+      body: 'conversation-u1-new',
+      improveInstruction: 'conversation-u1-new-improve-instruction',
+    });
+  });
+
+  it('drops the user segment when signed out', () => {
+    expect(messageDraftKeys(undefined, 'm1')).toEqual({
+      body: 'conversation-m1',
+      improveInstruction: 'conversation-m1-improve-instruction',
+    });
+  });
+});

--- a/services/platform/app/features/conversations/components/message-editor/types.tsx
+++ b/services/platform/app/features/conversations/components/message-editor/types.tsx
@@ -24,6 +24,22 @@ export interface MessageEditorProps {
   organizationId: string;
 }
 
+/**
+ * localStorage keys the `MessageEditor` persists its draft under, per user +
+ * `messageId` (falling back to a shared `new` slot). Exported as the single
+ * source of truth so a caller that owns the composer's lifecycle (e.g. the
+ * compose pane) can clear the same body/instruction drafts it can't reach
+ * through the editor's internal state.
+ */
+export function messageDraftKeys(
+  userId: string | undefined,
+  messageId: string | undefined,
+): { body: string; improveInstruction: string } {
+  const prefix = userId ? `conversation-${userId}` : 'conversation';
+  const base = `${prefix}-${messageId ?? 'new'}`;
+  return { body: base, improveInstruction: `${base}-improve-instruction` };
+}
+
 const FILE_TYPE_ICONS = {
   image: { Icon: ImageIcon, colorClass: 'text-blue-500' },
   video: { Icon: VideoIcon, colorClass: 'text-purple-500' },

--- a/services/platform/app/features/conversations/hooks/mutations.ts
+++ b/services/platform/app/features/conversations/hooks/mutations.ts
@@ -35,6 +35,12 @@ export function useSendMessageViaIntegration() {
   );
 }
 
+export function useComposeEmailConversation() {
+  return useConvexMutation(
+    api.conversations.mutations.composeEmailConversation,
+  );
+}
+
 export function useCloseConversation() {
   return useConvexMutation(api.conversations.mutations.closeConversation);
 }

--- a/services/platform/app/features/conversations/hooks/queries.ts
+++ b/services/platform/app/features/conversations/hooks/queries.ts
@@ -1,9 +1,18 @@
+import { useMemo } from 'react';
+
+import { useInboxAvailability } from '@/app/features/automations/builtin-views/registry';
+import { useRequiredIntegrations } from '@/app/features/automations/hooks/use-required-integrations';
 import { useCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { api } from '@/convex/_generated/api';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import type { ConvexItemOf } from '@/lib/types/convex-helpers';
+
+import {
+  type EmailIntegrationOption,
+  resolvedEmailOption,
+} from '../lib/email-integrations';
 
 export type Conversation = ConvexItemOf<
   typeof api.conversations.queries.listConversations
@@ -54,6 +63,53 @@ export function useApproxConversationCountByStatus(
       status,
     },
   );
+}
+
+/**
+ * The inboxes the compose dialog can send through — exactly the Inbox's own
+ * connected providers, so compose can never disagree with the page it lives on
+ * (reaching the Inbox already requires an installed email automation whose
+ * provider is connected). Derived from the installed inbox automations'
+ * `requiredIntegrations[0]` (the provider, as the channel filter reads it),
+ * resolved through {@link useRequiredIntegrations} — which merges the file
+ * config (title, type, connectionConfig) with the credential and reports the
+ * authoritative `connected` (`isActive && status === 'active'`) status.
+ */
+export function useEmailIntegrations(organizationId: string): {
+  emailIntegrations: EmailIntegrationOption[];
+  isLoading: boolean;
+} {
+  const { inboxAutomations, isLoading: inboxLoading } =
+    useInboxAvailability(organizationId);
+
+  const providerSlugs = useMemo(
+    () => [
+      ...new Set(
+        inboxAutomations
+          .map((automation) => automation.requiredIntegrations[0])
+          .filter((slug): slug is string => Boolean(slug)),
+      ),
+    ],
+    [inboxAutomations],
+  );
+
+  const { required, isLoading: requiredLoading } = useRequiredIntegrations(
+    organizationId,
+    providerSlugs,
+  );
+
+  const emailIntegrations = useMemo(
+    () =>
+      required
+        .filter((r) => r.connected)
+        .map((r) => resolvedEmailOption(r.slug, r.integration)),
+    [required],
+  );
+
+  return {
+    emailIntegrations,
+    isLoading: inboxLoading || requiredLoading,
+  };
 }
 
 export function useConversationWithMessages(conversationId: string | null) {

--- a/services/platform/app/features/conversations/lib/email-integrations.test.ts
+++ b/services/platform/app/features/conversations/lib/email-integrations.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  emailDomain,
+  isSenderAddressValid,
+  resolvedEmailOption,
+  supportsDynamicSender,
+} from './email-integrations';
+
+describe('resolvedEmailOption', () => {
+  it('reads slug, title, type and fromAddress from a resolved integration', () => {
+    expect(
+      resolvedEmailOption('imap_smtp', {
+        title: 'Company Mailbox',
+        type: 'imap_smtp',
+        connectionConfig: { fromAddress: 'support@acme.test' },
+      }),
+    ).toEqual({
+      slug: 'imap_smtp',
+      title: 'Company Mailbox',
+      type: 'imap_smtp',
+      fromAddress: 'support@acme.test',
+    });
+  });
+
+  it('falls back to the slug / empty type when fields are missing', () => {
+    expect(resolvedEmailOption('outlook', {})).toEqual({
+      slug: 'outlook',
+      title: 'outlook',
+      type: '',
+      fromAddress: undefined,
+    });
+    expect(resolvedEmailOption('gmail', null)).toEqual({
+      slug: 'gmail',
+      title: 'gmail',
+      type: '',
+      fromAddress: undefined,
+    });
+  });
+
+  it('ignores a blank configured fromAddress', () => {
+    expect(
+      resolvedEmailOption('imap_smtp', {
+        type: 'imap_smtp',
+        connectionConfig: { fromAddress: '   ' },
+      }).fromAddress,
+    ).toBeUndefined();
+  });
+});
+
+describe('emailDomain', () => {
+  it('returns the lowercased domain', () => {
+    expect(emailDomain('Jane@Acme.TEST')).toBe('acme.test');
+  });
+  it('returns empty for an address without a domain', () => {
+    expect(emailDomain('nope')).toBe('');
+  });
+});
+
+describe('supportsDynamicSender', () => {
+  it('is true for imap_smtp with a known verified domain', () => {
+    expect(
+      supportsDynamicSender({
+        slug: 'imap_smtp',
+        title: 'Mailbox',
+        type: 'imap_smtp',
+        fromAddress: 'support@acme.test',
+      }),
+    ).toBe(true);
+  });
+  it('is false for a fixed-sender provider (outlook)', () => {
+    expect(
+      supportsDynamicSender({
+        slug: 'outlook',
+        title: 'Outlook',
+        type: 'rest_api',
+        fromAddress: 'ops@acme.test',
+      }),
+    ).toBe(false);
+  });
+  it('is false for imap_smtp without a known domain', () => {
+    expect(
+      supportsDynamicSender({
+        slug: 'imap_smtp',
+        title: 'Mailbox',
+        type: 'imap_smtp',
+      }),
+    ).toBe(false);
+    expect(supportsDynamicSender(null)).toBe(false);
+  });
+});
+
+describe('isSenderAddressValid', () => {
+  it('accepts any local part on the verified domain (case-insensitive)', () => {
+    expect(isSenderAddressValid('sales@acme.test', 'acme.test')).toBe(true);
+    expect(isSenderAddressValid('Sales@ACME.test', 'acme.test')).toBe(true);
+  });
+  it('rejects a different domain, empty local part, or whitespace', () => {
+    expect(isSenderAddressValid('sales@evil.test', 'acme.test')).toBe(false);
+    expect(isSenderAddressValid('@acme.test', 'acme.test')).toBe(false);
+    expect(isSenderAddressValid('sales @acme.test', 'acme.test')).toBe(false);
+    expect(isSenderAddressValid('', 'acme.test')).toBe(false);
+    expect(isSenderAddressValid('sales', 'acme.test')).toBe(false);
+  });
+});

--- a/services/platform/app/features/conversations/lib/email-integrations.ts
+++ b/services/platform/app/features/conversations/lib/email-integrations.ts
@@ -1,0 +1,94 @@
+/**
+ * Sender/inbox helpers for the compose dialog.
+ *
+ * Compose sends through the org's connected inbox providers — the SAME set the
+ * Inbox's channel filter derives (installed inbox automations' required
+ * integrations, resolved to active credentials via `useRequiredIntegrations`).
+ * These pure helpers shape a resolved integration into a sender option and
+ * validate a dynamic sender address, kept React-free so they're unit-testable
+ * without rendering.
+ */
+
+/** A connected, email-capable inbox the compose dialog can send through. */
+export interface EmailIntegrationOption {
+  /** Integration slug — passed to the backend as `integrationName`. */
+  slug: string;
+  /** Human title for the picker (e.g. "Outlook"). */
+  title: string;
+  /** Integration kind (`imap_smtp` | `rest_api` | …) — drives sender editability. */
+  type: string;
+  /** Configured send address, when the integration exposes one (imap_smtp). */
+  fromAddress?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Shape a resolved inbox integration (the merged file-config + credential object
+ * from `useRequiredIntegrations`) into a sender option. `slug` is passed
+ * explicitly — it is the stable key the backend expects as `integrationName`.
+ */
+export function resolvedEmailOption(
+  slug: string,
+  integration: unknown,
+): EmailIntegrationOption {
+  const rec = isRecord(integration) ? integration : {};
+  const connectionConfig = rec.connectionConfig;
+  const fromAddress =
+    isRecord(connectionConfig) &&
+    typeof connectionConfig.fromAddress === 'string' &&
+    connectionConfig.fromAddress.trim().length > 0
+      ? connectionConfig.fromAddress.trim()
+      : undefined;
+  return {
+    slug,
+    title:
+      typeof rec.title === 'string' && rec.title.trim().length > 0
+        ? rec.title
+        : slug,
+    type: typeof rec.type === 'string' ? rec.type : '',
+    fromAddress,
+  };
+}
+
+/**
+ * Whether the sender address is user-choosable for this integration. True only
+ * for imap_smtp over a domain-verified SMTP provider (Resend), where any address
+ * on the verified domain is valid — and only when we know that domain (a
+ * configured `fromAddress`). gmail/outlook send from the fixed OAuth account, so
+ * Tale can't override their sender.
+ */
+export function supportsDynamicSender(
+  integration: EmailIntegrationOption | null | undefined,
+): boolean {
+  return (
+    integration?.type === 'imap_smtp' &&
+    typeof integration.fromAddress === 'string' &&
+    emailDomain(integration.fromAddress) !== ''
+  );
+}
+
+/** Lowercased domain part of an email address, or '' when it has none. */
+export function emailDomain(address: string): string {
+  const at = address.lastIndexOf('@');
+  return at === -1 ? '' : address.slice(at + 1).toLowerCase();
+}
+
+/**
+ * A candidate sender is valid when it is `localpart@domain` on the given
+ * verified `domain`, with a non-empty local part and no whitespace. Mirrors the
+ * server-side domain-equality guard (`resolveReplyFrom`), so the UI blocks a
+ * mismatch the backend would otherwise silently drop back to the configured From.
+ */
+export function isSenderAddressValid(
+  candidate: string,
+  domain: string,
+): boolean {
+  const trimmed = candidate.trim();
+  if (trimmed === '' || /\s/.test(trimmed)) return false;
+  const at = trimmed.lastIndexOf('@');
+  if (at <= 0) return false;
+  return emailDomain(trimmed) === domain.toLowerCase();
+}

--- a/services/platform/app/routes/dashboard/$id/conversations.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations.tsx
@@ -6,8 +6,10 @@ import {
   Link,
   Outlet,
   redirect,
+  useNavigate,
+  useParams,
 } from '@tanstack/react-router';
-import { Inbox } from 'lucide-react';
+import { Inbox, SquarePen } from 'lucide-react';
 
 import {
   AdaptiveHeaderRoot,
@@ -58,6 +60,12 @@ function ConversationsLayout() {
   // link into an org without one lands on a friendly pointer to the
   // Automations catalog instead of an inbox that can never fill.
   const { isLoading, hasInbox } = useInboxAvailability(organizationId);
+  const navigate = useNavigate();
+  // The active status tab lives on the child route; read it (strict: false) so
+  // Compose opens the pane on whichever tab the user is viewing.
+  const params = useParams({ strict: false });
+  const currentStatus =
+    typeof params.status === 'string' ? params.status : 'open';
 
   if (isLoading || !hasInbox) {
     return (
@@ -109,7 +117,30 @@ function ConversationsLayout() {
           <AdaptiveHeaderRoot standalone={false}>
             <AdaptiveHeaderTitle>{t('title')}</AdaptiveHeaderTitle>
           </AdaptiveHeaderRoot>
-          <ConversationsNavigation organizationId={organizationId} />
+          <ConversationsNavigation
+            organizationId={organizationId}
+            action={
+              <Button
+                size="sm"
+                variant="secondary"
+                icon={SquarePen}
+                onClick={() =>
+                  void navigate({
+                    to: '/dashboard/$id/conversations/$status',
+                    params: { id: organizationId, status: currentStatus },
+                    search: (prev) => ({
+                      ...prev,
+                      compose: 'new',
+                      composeContact: undefined,
+                      conversation: undefined,
+                    }),
+                  })
+                }
+              >
+                {t('compose.compose')}
+              </Button>
+            }
+          />
         </>
       }
     >

--- a/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
@@ -37,6 +37,10 @@ const searchSchema = z.object({
   conversation: z.string().optional(),
   /** Channel filter: an inbox provider's integration slug (e.g. `gmail`). */
   channel: z.string().optional(),
+  /** Compose mode: any value opens the compose pane in the reading pane. */
+  compose: z.string().optional(),
+  /** Contact id to seed the composer with (from a contact-row "Email" action). */
+  composeContact: z.string().optional(),
 });
 
 export const Route = createFileRoute('/dashboard/$id/conversations/$status')({
@@ -112,7 +116,8 @@ function useChannelOptions(
 
 function ConversationsStatusPage() {
   const { id: organizationId, status } = Route.useParams();
-  const { search, conversation, channel } = Route.useSearch();
+  const { search, conversation, channel, compose, composeContact } =
+    Route.useSearch();
   const navigate = useNavigate();
 
   const mappedStatus =
@@ -171,6 +176,8 @@ function ConversationsStatusPage() {
         value: channel,
         onChange: handleChannelChange,
       }}
+      composing={compose !== undefined}
+      composeContact={composeContact}
     />
   );
 }

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -300,6 +300,7 @@ import type * as conversations_bulk_reopen_conversations from "../conversations/
 import type * as conversations_bulk_spam_conversations from "../conversations/bulk_spam_conversations.js";
 import type * as conversations_bulk_unarchive_conversations from "../conversations/bulk_unarchive_conversations.js";
 import type * as conversations_close_conversation from "../conversations/close_conversation.js";
+import type * as conversations_compose_email_conversation from "../conversations/compose_email_conversation.js";
 import type * as conversations_count_unread from "../conversations/count_unread.js";
 import type * as conversations_create_conversation from "../conversations/create_conversation.js";
 import type * as conversations_create_conversation_public from "../conversations/create_conversation_public.js";
@@ -2061,6 +2062,7 @@ declare const fullApi: ApiFromModules<{
   "conversations/bulk_spam_conversations": typeof conversations_bulk_spam_conversations;
   "conversations/bulk_unarchive_conversations": typeof conversations_bulk_unarchive_conversations;
   "conversations/close_conversation": typeof conversations_close_conversation;
+  "conversations/compose_email_conversation": typeof conversations_compose_email_conversation;
   "conversations/count_unread": typeof conversations_count_unread;
   "conversations/create_conversation": typeof conversations_create_conversation;
   "conversations/create_conversation_public": typeof conversations_create_conversation_public;

--- a/services/platform/convex/conversations/compose_email_conversation.test.ts
+++ b/services/platform/convex/conversations/compose_email_conversation.test.ts
@@ -1,0 +1,243 @@
+// Server-side compose derivation — drives the REAL `mutationWithRLS` wrapper,
+// the internal `createConversation` mutation and the real send helper through
+// convex-test. Fake timers keep the scheduled outbound send action (a 'use
+// node' integration call) from executing: the assertion boundary is the created
+// conversation + queued message row + the scheduled job's args. Mirrors
+// reply_to_conversation.test.ts.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { api } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root (this file is at
+// convex/conversations/), mirroring reply_to_conversation.test.ts.
+const TEST_DIR_FROM_CONVEX_ROOT = 'conversations';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_conv_compose';
+const OTHER_ORG = 'org_conv_compose_other';
+const EDITOR = 'user_compose_editor';
+const OUTSIDER = 'user_compose_outsider';
+type T = TestConvex<typeof schema>;
+
+// Seed the local member mirror so the org-membership gate resolves on its hot
+// path and never falls back to the (test-unavailable) Better Auth component.
+async function seedMember(
+  t: T,
+  userId: string,
+  organizationId: string,
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      memberId: `m_${userId}`,
+      userId,
+      organizationId,
+      role: 'editor',
+      createdAt: 0,
+    });
+  });
+}
+
+async function seedContact(
+  t: T,
+  organizationId: string,
+  email: string | undefined,
+): Promise<Id<'contacts'>> {
+  return t.run((ctx) =>
+    ctx.db.insert('contacts', {
+      organizationId,
+      name: 'Jane Doe',
+      ...(email !== undefined ? { email } : {}),
+      source: 'api_import',
+    }),
+  );
+}
+
+async function allConversations(t: T) {
+  return t.run((ctx) => ctx.db.query('conversations').collect());
+}
+
+describe('composeEmailConversation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates an outbound email conversation to the contact and delegates delivery to the send path', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, EDITOR, ORG);
+    const contactId = await seedContact(t, ORG, 'jane@acme.test');
+
+    const { conversationId, messageId } = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.conversations.mutations.composeEmailConversation, {
+        organizationId: ORG,
+        contactId,
+        integrationName: 'outlook',
+        subject: 'Project kickoff',
+        content: '<p>Hello there</p>',
+      });
+
+    const conversation = await t.run((ctx) => ctx.db.get(conversationId));
+    expect(conversation).toMatchObject({
+      organizationId: ORG,
+      contactId,
+      channel: 'email',
+      direction: 'outbound',
+      integrationName: 'outlook',
+      subject: 'Project kickoff',
+      status: 'open',
+    });
+
+    const message = await t.run((ctx) => ctx.db.get(messageId));
+    expect(message).toMatchObject({
+      organizationId: ORG,
+      conversationId,
+      channel: 'email',
+      direction: 'outbound',
+      deliveryState: 'queued',
+      content: '<p>Hello there</p>',
+    });
+    expect(message?.metadata).toMatchObject({
+      to: ['jane@acme.test'],
+      subject: 'Project kickoff',
+      integrationName: 'outlook',
+    });
+
+    // Delivery delegated to the existing integration action. A fresh compose has
+    // no inbound to derive a reply-from, so `from` is omitted entirely and the
+    // send action falls back to the integration's configured From.
+    const scheduled = await t.run((ctx) =>
+      ctx.db.system.query('_scheduled_functions').collect(),
+    );
+    const sendJobs = scheduled.filter((job) =>
+      job.name.includes('sendMessageViaIntegrationAction'),
+    );
+    expect(sendJobs).toHaveLength(1);
+    expect(sendJobs[0].args[0]).toMatchObject({
+      integrationName: 'outlook',
+      to: ['jane@acme.test'],
+      subject: 'Project kickoff',
+      body: '<p>Hello there</p>',
+      contentType: 'HTML',
+    });
+    expect(sendJobs[0].args[0]).not.toHaveProperty('from');
+
+    const stored = await t.run((ctx) => ctx.db.get(conversationId));
+    expect(typeof stored?.lastMessageAt).toBe('number');
+  });
+
+  it('sends from a chosen sender (dynamic-sender) and stamps it on the thread', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, EDITOR, ORG);
+    const contactId = await seedContact(t, ORG, 'jane@acme.test');
+
+    const { conversationId } = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.conversations.mutations.composeEmailConversation, {
+        organizationId: ORG,
+        contactId,
+        integrationName: 'imap_smtp',
+        subject: 'Project kickoff',
+        content: '<p>Hello there</p>',
+        from: 'sales@acme.test',
+      });
+
+    // Stamped on the conversation (our side of the thread) so replies reuse it.
+    const conversation = await t.run((ctx) => ctx.db.get(conversationId));
+    expect(conversation?.metadata).toMatchObject({
+      to: [{ address: 'sales@acme.test' }],
+    });
+
+    // The send action receives it as `from` (its resolveReplyFrom then guards it
+    // against the integration's verified domain).
+    const scheduled = await t.run((ctx) =>
+      ctx.db.system.query('_scheduled_functions').collect(),
+    );
+    const sendJobs = scheduled.filter((job) =>
+      job.name.includes('sendMessageViaIntegrationAction'),
+    );
+    expect(sendJobs).toHaveLength(1);
+    expect(sendJobs[0].args[0]).toMatchObject({
+      to: ['jane@acme.test'],
+      from: 'sales@acme.test',
+    });
+  });
+
+  it('throws when the contact has no email and creates no conversation', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, EDITOR, ORG);
+    const contactId = await seedContact(t, ORG, undefined);
+
+    const error: unknown = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.conversations.mutations.composeEmailConversation, {
+        organizationId: ORG,
+        contactId,
+        integrationName: 'outlook',
+        subject: 'Project kickoff',
+        content: 'Hello',
+      })
+      .catch((e: unknown) => e);
+
+    expect(String(error)).toContain('contact_email_not_found');
+    expect(await allConversations(t)).toHaveLength(0);
+  });
+
+  it('throws when the subject is blank and creates no conversation', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, EDITOR, ORG);
+    const contactId = await seedContact(t, ORG, 'jane@acme.test');
+
+    const error: unknown = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.conversations.mutations.composeEmailConversation, {
+        organizationId: ORG,
+        contactId,
+        integrationName: 'outlook',
+        subject: '   ',
+        content: 'Hello',
+      })
+      .catch((e: unknown) => e);
+
+    expect(String(error)).toContain('compose_subject_required');
+    expect(await allConversations(t)).toHaveLength(0);
+  });
+
+  it('denies a member of another organization (RLS)', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, OUTSIDER, OTHER_ORG);
+    const contactId = await seedContact(t, ORG, 'jane@acme.test');
+
+    await expect(
+      t
+        .withIdentity({ subject: OUTSIDER })
+        .mutation(api.conversations.mutations.composeEmailConversation, {
+          organizationId: ORG,
+          contactId,
+          integrationName: 'outlook',
+          subject: 'Project kickoff',
+          content: 'Hello',
+        }),
+    ).rejects.toThrow();
+    expect(await allConversations(t)).toHaveLength(0);
+  });
+});

--- a/services/platform/convex/conversations/compose_email_conversation.ts
+++ b/services/platform/convex/conversations/compose_email_conversation.ts
@@ -1,0 +1,138 @@
+/**
+ * Start a brand-new outbound email conversation to a contact.
+ *
+ * The counterpart to `reply_to_conversation`: rather than deriving the recipient
+ * and integration from an existing conversation, compose takes an explicit
+ * `contactId` (recipient) and `integrationName` (the inbox to send through),
+ * creates a fresh outbound conversation, then delegates the send itself to the
+ * shared `sendMessageViaIntegration` path — threading, from-resolution, audit
+ * and delivery all live there, so replies and compose share one send spine.
+ *
+ * Two deliberate choices:
+ * - The conversation is created through the INTERNAL `createConversation`
+ *   mutation, not the helper directly. `createConversation` writes its audit row
+ *   via `AuditLogHelpers.logSuccess`, and under `mutationWithRLS` that write is
+ *   denied for every role by the `auditLogChainGenesis` sentinel (#1972).
+ *   Running it via `ctx.runMutation` executes it on a raw (non-RLS) ctx, in the
+ *   same transaction — the same escape hatch `emitAuditSuccess` uses. The send
+ *   itself stays on the user ctx so its audit records the real actor.
+ * - The sender is carried on the conversation's `metadata.to` — the address on
+ *   OUR side of the thread, which `sendMessageViaIntegration` reads via
+ *   `inboundRecipientAddress` to derive the send From (and which every later
+ *   reply reuses). When the caller passes `from` — the dynamic-sender case
+ *   (imap_smtp over a domain-verified SMTP provider, where any address on the
+ *   verified domain is a valid sender) — we stamp it there, so the first send
+ *   AND replies go out as that address, still domain-guarded by `resolveReplyFrom`
+ *   in the send action. When `from` is omitted, `metadata.to` stays unset and the
+ *   send falls back to the integration's configured From (see `reply_from.ts`).
+ */
+
+import { ConvexError } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { splitHtmlText } from './reply_to_conversation';
+import { sendMessageViaIntegration } from './send_message_via_integration';
+
+/** Placeholder email a contact record carries when it has no real address. */
+const UNKNOWN_CONTACT_EMAIL = 'unknown@example.com';
+
+export interface ComposeEmailConversationArgs {
+  organizationId: string;
+  contactId: Id<'contacts'>;
+  integrationName: string;
+  subject: string;
+  content: string;
+  /**
+   * Sender address for the thread (dynamic-sender / imap_smtp only). Any address
+   * on the integration's verified domain; the send action's `resolveReplyFrom`
+   * guard silently falls back to the configured From if the domain doesn't match.
+   * Omit to send from the integration's configured From.
+   */
+  from?: string;
+  attachments?: Array<{
+    storageId: Id<'_storage'>;
+    fileName: string;
+    contentType: string;
+    size: number;
+  }>;
+}
+
+export interface ComposeEmailConversationResult {
+  conversationId: Id<'conversations'>;
+  messageId: Id<'conversationMessages'>;
+}
+
+export async function composeEmailConversation(
+  ctx: MutationCtx,
+  args: ComposeEmailConversationArgs,
+): Promise<ComposeEmailConversationResult> {
+  const subject = args.subject.trim();
+  if (!subject) {
+    throw new ConvexError({
+      code: 'compose_subject_required',
+      message: 'A subject is required to start an email',
+    });
+  }
+
+  // Recipient is always an existing contact (contacts-only compose). Resolve it
+  // before creating anything so a bad recipient never leaves an empty thread.
+  const contact = await ctx.db.get(args.contactId);
+  if (!contact) {
+    throw new ConvexError({
+      code: 'contact_not_found',
+      message: 'Contact not found',
+    });
+  }
+
+  if (contact.organizationId !== args.organizationId) {
+    throw new ConvexError({
+      code: 'contact_org_mismatch',
+      message: 'Contact does not belong to organization',
+    });
+  }
+
+  const recipientEmail = contact.email;
+  if (!recipientEmail || recipientEmail === UNKNOWN_CONTACT_EMAIL) {
+    throw new ConvexError({
+      code: 'contact_email_not_found',
+      message: 'Contact has no email address to send to',
+    });
+  }
+
+  // Create the outbound conversation on a raw ctx (see file header re: #1972).
+  // A chosen sender is stamped into `metadata.to` (our side of the thread) so
+  // both this send and later replies resolve to it via `inboundRecipientAddress`.
+  const chosenFrom = args.from?.trim();
+  const { conversationId } = await ctx.runMutation(
+    internal.conversations.internal_mutations.createConversation,
+    {
+      organizationId: args.organizationId,
+      contactId: args.contactId,
+      subject,
+      status: 'open',
+      channel: 'email',
+      direction: 'outbound',
+      integrationName: args.integrationName,
+      ...(chosenFrom ? { metadata: { to: [{ address: chosenFrom }] } } : {}),
+    },
+  );
+
+  const { html, text } = splitHtmlText(args.content);
+
+  return {
+    conversationId,
+    messageId: await sendMessageViaIntegration(ctx, {
+      conversationId,
+      organizationId: args.organizationId,
+      integrationName: args.integrationName,
+      content: args.content,
+      to: [recipientEmail],
+      subject,
+      html,
+      text,
+      ...(args.attachments?.length ? { attachments: args.attachments } : {}),
+    }),
+  };
+}

--- a/services/platform/convex/conversations/internal_mutations.ts
+++ b/services/platform/convex/conversations/internal_mutations.ts
@@ -23,6 +23,7 @@ export const createConversation = internalMutation({
     type: v.optional(v.string()),
     channel: v.optional(v.string()),
     direction: v.optional(v.union(v.literal('inbound'), v.literal('outbound'))),
+    integrationName: v.optional(v.string()),
     metadata: v.optional(jsonRecordValidator),
   },
   returns: v.object({

--- a/services/platform/convex/conversations/mutations.ts
+++ b/services/platform/convex/conversations/mutations.ts
@@ -3,6 +3,7 @@ import { ConvexError, v } from 'convex/values';
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { internal } from '../_generated/api';
 import { mutationWithRLS } from '../lib/rls';
+import { composeEmailConversation as composeEmailConversationHelper } from './compose_email_conversation';
 import * as ConversationsHelpers from './helpers';
 import {
   bulkReplyToConversations as bulkReplyToConversationsHelper,
@@ -97,6 +98,34 @@ export const replyToConversation = mutationWithRLS({
   returns: v.id('conversationMessages'),
   handler: async (ctx, args) => {
     return await replyToConversationHelper(ctx, args);
+  },
+});
+
+export const composeEmailConversation = mutationWithRLS({
+  args: {
+    organizationId: v.string(),
+    contactId: v.id('contacts'),
+    integrationName: v.string(),
+    subject: v.string(),
+    content: v.string(),
+    from: v.optional(v.string()),
+    attachments: v.optional(
+      v.array(
+        v.object({
+          storageId: v.id('_storage'),
+          fileName: v.string(),
+          contentType: v.string(),
+          size: v.number(),
+        }),
+      ),
+    ),
+  },
+  returns: v.object({
+    conversationId: v.id('conversations'),
+    messageId: v.id('conversationMessages'),
+  }),
+  handler: async (ctx, args) => {
+    return await composeEmailConversationHelper(ctx, args);
   },
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1954,6 +1954,35 @@
       "messagePlaceholder": "Antwort eingeben...",
       "send": "Senden"
     },
+    "compose": {
+      "compose": "Verfassen",
+      "newEmail": "Neue E-Mail",
+      "title": "Neue E-Mail",
+      "description": "Beginne eine neue E-Mail-Konversation mit einem Kontakt.",
+      "to": "An",
+      "toPlaceholder": "Kontakt auswählen",
+      "searchContacts": "Kontakte durchsuchen",
+      "contactsLoading": "Kontakte werden geladen…",
+      "noContacts": "Noch keine Kontakte mit E-Mail-Adresse",
+      "inboxLabel": "Postfach",
+      "inboxPlaceholder": "Postfach auswählen",
+      "fromLabel": "Absender",
+      "fromDomainHint": "Beliebige Adresse unter {domain}",
+      "fromInvalid": "Gib eine Adresse unter {domain} ein",
+      "from": "Absender: {from}",
+      "noEmailIntegration": "Verbinde eine E-Mail-Integration, um E-Mails zu senden.",
+      "subject": "Betreff",
+      "subjectPlaceholder": "Worum geht es?",
+      "bodyPlaceholder": "Schreib deine Nachricht…",
+      "fillRequired": "Wähle einen Kontakt, ein Postfach und einen Betreff, um zu senden.",
+      "discard": "Verwerfen",
+      "discardConfirm": {
+        "title": "Entwurf verwerfen?",
+        "description": "Du verwirfst diesen E-Mail-Entwurf endgültig. Das lässt sich nicht rückgängig machen."
+      },
+      "sent": "E-Mail gesendet",
+      "uploadFailed": "Anhang konnte nicht hochgeladen werden"
+    },
     "updating": "Konversationen werden aktualisiert...",
     "bulk": {
       "sendMessages": "Nachrichten senden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1954,6 +1954,35 @@
       "messagePlaceholder": "Type your reply...",
       "send": "Send"
     },
+    "compose": {
+      "compose": "Compose",
+      "newEmail": "New email",
+      "title": "New email",
+      "description": "Start a new email conversation with a contact.",
+      "to": "To",
+      "toPlaceholder": "Select a contact",
+      "searchContacts": "Search contacts",
+      "contactsLoading": "Loading contacts…",
+      "noContacts": "No contacts with an email address yet",
+      "inboxLabel": "Inbox",
+      "inboxPlaceholder": "Select an inbox",
+      "fromLabel": "From",
+      "fromDomainHint": "Any address at {domain}",
+      "fromInvalid": "Enter an address at {domain}",
+      "from": "From: {from}",
+      "noEmailIntegration": "Connect an email integration to send email.",
+      "subject": "Subject",
+      "subjectPlaceholder": "What's this about?",
+      "bodyPlaceholder": "Write your message…",
+      "fillRequired": "Choose a contact, an inbox, and a subject to send.",
+      "discard": "Discard",
+      "discardConfirm": {
+        "title": "Discard draft?",
+        "description": "This draft email will be permanently discarded. This can't be undone."
+      },
+      "sent": "Email sent",
+      "uploadFailed": "Failed to upload attachment"
+    },
     "updating": "Updating conversations...",
     "bulk": {
       "sendMessages": "Send messages",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1955,6 +1955,35 @@
       "messagePlaceholder": "Saisis ta réponse...",
       "send": "Envoyer"
     },
+    "compose": {
+      "compose": "Rédiger",
+      "newEmail": "Nouvel e-mail",
+      "title": "Nouvel e-mail",
+      "description": "Démarre une nouvelle conversation par e-mail avec un contact.",
+      "to": "À",
+      "toPlaceholder": "Sélectionne un contact",
+      "searchContacts": "Rechercher des contacts",
+      "contactsLoading": "Chargement des contacts…",
+      "noContacts": "Aucun contact avec une adresse e-mail pour l'instant",
+      "inboxLabel": "Boîte",
+      "inboxPlaceholder": "Sélectionne une boîte",
+      "fromLabel": "Expéditeur",
+      "fromDomainHint": "N'importe quelle adresse sur {domain}",
+      "fromInvalid": "Saisis une adresse sur {domain}",
+      "from": "Expéditeur : {from}",
+      "noEmailIntegration": "Connecte une intégration e-mail pour envoyer des e-mails.",
+      "subject": "Objet",
+      "subjectPlaceholder": "De quoi s'agit-il ?",
+      "bodyPlaceholder": "Écris ton message…",
+      "fillRequired": "Choisis un contact, une boîte et un objet pour envoyer.",
+      "discard": "Supprimer",
+      "discardConfirm": {
+        "title": "Supprimer le brouillon ?",
+        "description": "Ce brouillon d'e-mail sera définitivement supprimé. Cette action est irréversible."
+      },
+      "sent": "E-mail envoyé",
+      "uploadFailed": "Échec de l'envoi de la pièce jointe"
+    },
     "updating": "Mise à jour des conversations...",
     "bulk": {
       "sendMessages": "Envoyer les messages",


### PR DESCRIPTION
## Summary

Adds the ability to compose a brand-new outbound email from the Inbox, with the recipient chosen from Contacts. The inbox was previously reply-only. Compose reuses the existing send path and renders in the reading pane (not a modal), matching the conversation UI.

## Changes

- **Backend** — `composeEmailConversation` mutation (+ helper): creates a fresh outbound conversation and delegates to `sendMessageViaIntegration`, so replies and compose share one send path. Adds the missing `integrationName` arg to the internal `createConversation`. No schema change.
- **Sender** — the chosen sender is stored on `conversation.metadata.to`, so the first send and every later reply resolve to it via the existing domain-guarded reply-from. For `imap_smtp` the sender is editable across the verified domain; gmail/outlook stay on the OAuth account.
- **UI** — compose renders in the reading pane: contact picker, inbox + sender fields, subject, and the reply composer. Entry points are URL-driven (`?compose` / `?composeContact`): a Compose button on the conversations tab row and an Email action on a contact row.
- **Drafts** — recipient, inbox, sender, subject, and body persist per user + org; restore on reopen, seed from a contact row, clear on send, and can be discarded behind a confirmation.
- **i18n** — en / de / fr strings under `conversations.compose.*`.

## Tests

Backend mutation 5/5 (happy path, org mismatch, missing/placeholder email, blank subject, RLS, custom sender); `email-integrations` 10/10; `messageDraftKeys` 3/3; `message-editor` 5/5. Typecheck, lint, format, and the i18n parity/usage/pronoun suite pass.

## Notes

- Scope: single recipient, contacts-only. cc/bcc, multiple recipients, and a From display-name are follow-ups.
- Manual QA of the rendered pane against a live email integration is still pending.
- Docs ("Start a new email") to follow.
