### PR TITLE
refactor(platform): UI polish for tool-selector, prompts, save-prompt

### DIFF
--- a/services/platform/app/components/ui/forms/checkbox.tsx
+++ b/services/platform/app/components/ui/forms/checkbox.tsx
@@ -87,7 +87,7 @@ const CheckboxBase = React.forwardRef<
       return (
         <div className="flex items-start gap-2">
           <div className="mt-0.5">{checkbox}</div>
-          <div className="flex flex-col gap-0.5">
+          <div className="flex flex-col gap-1">
             {label && (
               <Label
                 htmlFor={id}

--- a/services/platform/app/features/agents/components/tool-selector.tsx
+++ b/services/platform/app/features/agents/components/tool-selector.tsx
@@ -26,11 +26,12 @@ import {
   Wrench,
   type LucideIcon,
 } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { CheckboxGroup } from '@/app/components/ui/forms/checkbox-group';
 import { FormSection } from '@/app/components/ui/forms/form-section';
+import { Label } from '@/app/components/ui/forms/label';
 import { MultiSelect } from '@/app/components/ui/forms/multi-select';
 import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { useAutomationDisplay } from '@/app/features/automations/hooks/use-automation-text';
@@ -321,19 +322,20 @@ export function ToolSelector({
                   />
                 </Card>
               ) : (
-                <div className="grid items-start gap-4 md:grid-cols-2">
+                <div className="columns-1 gap-x-4 md:columns-2">
                   {displayCategories.map(([category, toolNames]) => (
-                    <ToolCategoryCard
-                      key={category}
-                      category={category}
-                      toolNames={toolNames}
-                      selectedSet={selectedSet}
-                      isLoading={isLoading}
-                      onCategoryChange={handleCategoryChange}
-                      toolDescription={toolDescription}
-                      t={t}
-                      tTools={tTools}
-                    />
+                    <div key={category} className="mb-4 break-inside-avoid">
+                      <ToolCategoryCard
+                        category={category}
+                        toolNames={toolNames}
+                        selectedSet={selectedSet}
+                        isLoading={isLoading}
+                        onCategoryChange={handleCategoryChange}
+                        toolDescription={toolDescription}
+                        t={t}
+                        tTools={tTools}
+                      />
+                    </div>
                   ))}
                 </div>
               )}
@@ -368,6 +370,7 @@ function ToolCategoryCard({
 }) {
   const label = t(`agents.tools.categories.${category}`);
   const Icon = CATEGORY_ICONS[category] ?? Wrench;
+  const categoryCheckboxId = useId();
 
   const enabledValues = isLoading
     ? []
@@ -379,19 +382,15 @@ function ToolCategoryCard({
 
   return (
     <Card padding="md">
-      <Stack gap={3}>
-        <Row gap={2} align="center" justify="between">
-          <Row gap={2} align="center" className="min-w-0">
-            <Icon
-              className="text-muted-foreground size-4 shrink-0"
-              aria-hidden="true"
-            />
-            {/* Parent checkbox: the category label doubles as enable-all for
-                the tools this card currently SHOWS — under an active search
-                filter it only ever toggles the visible rows, never hidden
-                ones. */}
+      <Stack gap={4}>
+        {/* Checkbox-first header so the enable-all control shares a column
+            with the tool rows below. Icon sits in the label (aria-hidden)
+            rather than before the box — that was crowding the title and
+            shifting the header checkbox right of the children. */}
+        <Row gap={3} align="start" justify="between">
+          <div className="flex min-w-0 flex-1 items-start gap-2">
             <Checkbox
-              label={label}
+              id={categoryCheckboxId}
               checked={
                 allSelected ? true : someSelected ? 'indeterminate' : false
               }
@@ -402,8 +401,19 @@ function ToolCategoryCard({
                 )
               }
               disabled={isLoading}
+              className="mt-0.5"
             />
-          </Row>
+            <Label
+              htmlFor={categoryCheckboxId}
+              className="flex min-w-0 cursor-pointer items-center gap-2 leading-5"
+            >
+              <Icon
+                className="text-muted-foreground size-4 shrink-0"
+                aria-hidden="true"
+              />
+              <span className="truncate">{label}</span>
+            </Label>
+          </div>
           <Badge
             aria-label={t('agents.tools.enabledCountLabel', {
               enabled,
@@ -415,6 +425,7 @@ function ToolCategoryCard({
         </Row>
         <CheckboxGroup
           columns={1}
+          className="gap-3 [&>div]:gap-3"
           options={toolNames.map((name) => ({
             value: name,
             label: isLoading ? 'Tool name' : toolDisplayName(tTools, name),

--- a/services/platform/app/features/chat/components/save-prompt-menu.test.tsx
+++ b/services/platform/app/features/chat/components/save-prompt-menu.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { SavePromptMenu } from './save-prompt-menu';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        promptLibrary: 'Prompt library',
+        savePromptDraft: 'Save prompt draft',
+        savePromptMenu: 'Save prompt',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('SavePromptMenu', () => {
+  it('shows a book icon when the composer is empty (opens library)', () => {
+    // Empty composer → one-click Prompt library. The trigger must read as the
+    // destination (BookOpen), not a save/bookmark affordance.
+    render(
+      <SavePromptMenu
+        onSavePromptDraft={vi.fn()}
+        onOpenPromptLibrary={vi.fn()}
+        canSavePromptDraft={false}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Prompt library' });
+    expect(button.querySelector('.lucide-book-open')).toBeTruthy();
+    expect(button.querySelector('.lucide-bookmark')).toBeNull();
+  });
+
+  it('shows a bookmark icon when the composer has content (save menu)', () => {
+    render(
+      <SavePromptMenu
+        onSavePromptDraft={vi.fn()}
+        onOpenPromptLibrary={vi.fn()}
+        canSavePromptDraft={true}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Save prompt' });
+    expect(button.querySelector('.lucide-bookmark')).toBeTruthy();
+    expect(button.querySelector('.lucide-book-open')).toBeNull();
+  });
+});

--- a/services/platform/app/features/chat/components/save-prompt-menu.tsx
+++ b/services/platform/app/features/chat/components/save-prompt-menu.tsx
@@ -22,7 +22,8 @@ export function SavePromptMenu({
   const { t: tChat } = useT('chat');
 
   // With an empty composer there's nothing to save as a draft, so the only
-  // useful action is the prompt library. Skip the menu and open it directly.
+  // useful action is the prompt library. Skip the menu and open it directly —
+  // BookOpen matches the destination (same icon as the library menu item).
   if (!canSavePromptDraft) {
     return (
       <Button
@@ -35,7 +36,7 @@ export function SavePromptMenu({
         onClick={onOpenPromptLibrary}
         className="focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-inset"
       >
-        <Bookmark className="size-4" aria-hidden="true" />
+        <BookOpen className="size-4" aria-hidden="true" />
       </Button>
     );
   }

--- a/services/platform/app/features/prompts/components/prompt-list-row.test.tsx
+++ b/services/platform/app/features/prompts/components/prompt-list-row.test.tsx
@@ -102,7 +102,7 @@ describe('PromptListRow', () => {
     expect(onUse).toHaveBeenCalledWith(prompt);
   });
 
-  it('exposes the more-actions button with translated aria-label', () => {
+  it('exposes a dense more-actions icon button with translated aria-label', () => {
     render(
       <PromptListRow
         prompt={prompt}
@@ -113,9 +113,13 @@ describe('PromptListRow', () => {
         isLast={false}
       />,
     );
-    expect(
-      screen.getByRole('button', { name: 'prompts.actions.more' }),
-    ).toBeInTheDocument();
+    const more = screen.getByRole('button', {
+      name: 'prompts.actions.more',
+    });
+    expect(more).toBeInTheDocument();
+    // icon-sm (size-8) — not the old size-11 touch override that dominated the row
+    expect(more.className).toMatch(/\bsize-8\b/);
+    expect(more.className).not.toMatch(/\bsize-11\b/);
   });
 
   // Regression test for #1475: tags and the assigned team must be shown.

--- a/services/platform/app/features/prompts/components/prompt-list-row.tsx
+++ b/services/platform/app/features/prompts/components/prompt-list-row.tsx
@@ -189,8 +189,7 @@ export function PromptListRow({
             trigger={
               <Button
                 variant="ghost"
-                size="icon"
-                className="size-11"
+                size="icon-sm"
                 aria-label={t('actions.more')}
               >
                 <MoreHorizontal className="size-4" />


### PR DESCRIPTION
## Summary

Small UI-polish across the tool selector, prompt library, and the chat save-prompt button.

## Changes

- **Tool selector** — category cards flow in CSS columns (masonry) instead of a fixed two-column grid, and the category header is checkbox-first: the enable-all `Checkbox` pairs with an explicit `Label` (`htmlFor` + `useId`) so it aligns with the tool rows and the icon no longer crowds the title.
- **Checkbox** — label column gap `0.5 → 1`.
- **Prompt list row** — denser more-actions button (`size-11` → `icon-sm`).
- **Save-prompt button** — the empty-composer state opens the prompt library, so it shows `BookOpen` (the library's icon) instead of `Bookmark`.

## Tests

`tool-selector`, `prompt-list-row`, and `save-prompt-menu` suites pass (16 tests); typecheck, lint, and format are clean. No new strings, schema, or boundaries.

Manual QA of the rendered UI is still pending.
