### PR TITLE
feat(web): task-board and sandbox demos, DemoShell a11y

### DIFF
--- a/design/web.md
+++ b/design/web.md
@@ -96,11 +96,13 @@ and follow one contract:
   (Agents / Knowledge / Automations / Projects / Settings) use `AdaptiveHeaderTitle` (page title
   only). Pass `title` for list pages. Reference captures in
   `services/docs/public/images/platform/`. The frame is a labelled `role="img"` window (localized
-  one-sentence `aria-label`, everything inside `aria-hidden`) with a **fixed aspect ratio**
+  one-sentence `aria-label`; decorative DOM under `aria-hidden` + `inert`; `data-nosnippet` so
+  crawlers don't lift demo copy into snippets) with a **fixed aspect ratio**
   (CLS 0). Elevation uses `shadow-demo` / `shadow-demo-hero`. Demos sit on `DemoStage`
   (atmospheric wash — never a photo). Demo _content_ must match product idioms (chat bubbles,
   RoutingStepRow, SourceCards, composer toolbar, Agents/Documents tables, workflow-step cards,
-  Executions table, in-chat approval cards) — not fictional hub diagrams. Give mobile a taller
+  Executions table, in-chat approval cards, project task boards, sandbox Files /
+  Live panes) — not fictional hub diagrams. Give mobile a taller
   ratio than desktop; size wells against **German**.
 - **Text primitives, not the markdown engine.** `demo-typing-text` / `demo-stream-text` reuse the
   globals.css `.stream-reveal`/`.animate-cursor-blink` primitives. Never pull `IncrementalMarkdown`

--- a/services/web/app/components/blocks/demos/connect-agents.tsx
+++ b/services/web/app/components/blocks/demos/connect-agents.tsx
@@ -39,6 +39,7 @@ export function ConnectAgents({
   const inView = useInView(ref, { once: true, margin: '-15%' });
   const beat = useDemoTimeline({ beats: BEATS, start: inView });
   const reduceMotion = useReducedMotion();
+  const ready = beat >= BEAT.done;
 
   return (
     <div ref={ref}>
@@ -87,12 +88,12 @@ export function ConnectAgents({
                       <span
                         className={cn(
                           'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium',
-                          beat >= BEAT.done
+                          ready
                             ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
                             : 'bg-surface-site-inset text-fg-muted',
                         )}
                       >
-                        {beat >= BEAT.done ? (
+                        {ready ? (
                           <span className="size-1.5 rounded-full bg-emerald-500" />
                         ) : null}
                         {t('demos.connect.statusReady')}

--- a/services/web/app/components/blocks/demos/content/agents-demos.tsx
+++ b/services/web/app/components/blocks/demos/content/agents-demos.tsx
@@ -3,13 +3,13 @@ import { ConnectAgents } from '@/app/components/blocks/demos/connect-agents';
 import {
   useAgentsScenario,
   useAutomationScenario,
-  useChatScenario,
   useKnowledgeScenario,
   useProjectsScenario,
+  useSandboxScenario,
 } from '@/app/components/blocks/demos/demo-scenarios';
-import { HeroOrchestration } from '@/app/components/blocks/demos/hero-orchestration';
 import { KnowledgePool } from '@/app/components/blocks/demos/knowledge-pool';
 import { ProjectsBoard } from '@/app/components/blocks/demos/projects-board';
+import { SandboxWorkspace } from '@/app/components/blocks/demos/sandbox-workspace';
 
 export function AgentsHeroDemo() {
   const scenario = useAgentsScenario('platformAgents');
@@ -32,6 +32,6 @@ export function AgentsTourAutomationsDemo() {
 }
 
 export function AgentsTourChatDemo() {
-  const scenario = useChatScenario('platformAgents');
-  return <HeroOrchestration scenario={scenario} elevation="default" />;
+  const scenario = useSandboxScenario('platformAgents');
+  return <SandboxWorkspace scenario={scenario} />;
 }

--- a/services/web/app/components/blocks/demos/content/projects-demos.tsx
+++ b/services/web/app/components/blocks/demos/content/projects-demos.tsx
@@ -1,15 +1,15 @@
-import { AutomationRun } from '@/app/components/blocks/demos/automation-run';
 import {
-  useAutomationScenario,
   useChatScenario,
   useGovernScenario,
   useKnowledgeScenario,
   useProjectsScenario,
+  useTaskBoardScenario,
 } from '@/app/components/blocks/demos/demo-scenarios';
 import { GovernGate } from '@/app/components/blocks/demos/govern-gate';
 import { HeroOrchestration } from '@/app/components/blocks/demos/hero-orchestration';
 import { KnowledgePool } from '@/app/components/blocks/demos/knowledge-pool';
 import { ProjectsBoard } from '@/app/components/blocks/demos/projects-board';
+import { TaskBoard } from '@/app/components/blocks/demos/task-board';
 
 export function ProjectsHeroDemo() {
   const scenario = useProjectsScenario('platformProjects');
@@ -17,8 +17,8 @@ export function ProjectsHeroDemo() {
 }
 
 export function ProjectsTourTasksDemo() {
-  const scenario = useAutomationScenario('platformProjects');
-  return <AutomationRun scenario={scenario} />;
+  const scenario = useTaskBoardScenario('platformProjects');
+  return <TaskBoard scenario={scenario} />;
 }
 
 export function ProjectsTourChatDemo() {

--- a/services/web/app/components/blocks/demos/demo-scenarios.ts
+++ b/services/web/app/components/blocks/demos/demo-scenarios.ts
@@ -222,3 +222,90 @@ export function useProjectsScenario(
     })),
   };
 }
+
+/**
+ * Fixed board layout (4 lanes × fixed card slots) — mirrors
+ * `BOARD_TASK_STATUSES` lanes Todo → Done from
+ * `services/platform/app/features/tasks/lib/display.ts` (backlog/cancelled
+ * omitted so the marketing frame stays dense).
+ */
+export interface TaskBoardCard {
+  id: string;
+  title: string;
+  assignee: string;
+}
+
+export interface TaskBoardScenario {
+  label: string;
+  /** Cards in To do (2), In progress (1), In review (1), Done (1). */
+  todo: readonly [TaskBoardCard, TaskBoardCard];
+  inProgress: TaskBoardCard;
+  inReview: TaskBoardCard;
+  done: TaskBoardCard;
+}
+
+export function useTaskBoardScenario(
+  ns: Namespace = 'home',
+  prefix = 'demos.tasks',
+): TaskBoardScenario {
+  const { t } = useT(ns);
+  const card = (n: number): TaskBoardCard => ({
+    id: t(`${prefix}.id${n}`),
+    title: t(`${prefix}.title${n}`),
+    assignee: t(`${prefix}.assignee${n}`),
+  });
+  return {
+    label: t(`${prefix}.label`),
+    todo: [card(1), card(2)],
+    inProgress: card(3),
+    inReview: card(4),
+    done: card(5),
+  };
+}
+
+/**
+ * Sandbox chat + Files / Live side pane — vocabulary from
+ * `workspace-files-pane.tsx` and `live-browser-pane.tsx` (no platform imports).
+ */
+export interface SandboxScenario {
+  label: string;
+  prompt: string;
+  agent: string;
+  model: string;
+  reply: string;
+  /** File-tree entries under the workspace root (fixed count). */
+  files: readonly [string, string, string, string];
+  activeFile: string;
+  codeLines: readonly [string, string, string, string];
+  browserUrl: string;
+  browserTitle: string;
+}
+
+export function useSandboxScenario(
+  ns: Namespace = 'home',
+  prefix = 'demos.sandbox',
+): SandboxScenario {
+  const { t } = useT(ns);
+  return {
+    label: t(`${prefix}.label`),
+    prompt: t(`${prefix}.prompt`),
+    agent: t(`${prefix}.agent`),
+    model: t(`${prefix}.model`),
+    reply: t(`${prefix}.reply`),
+    files: [
+      t(`${prefix}.file1`),
+      t(`${prefix}.file2`),
+      t(`${prefix}.file3`),
+      t(`${prefix}.file4`),
+    ],
+    activeFile: t(`${prefix}.activeFile`),
+    codeLines: [
+      t(`${prefix}.code1`),
+      t(`${prefix}.code2`),
+      t(`${prefix}.code3`),
+      t(`${prefix}.code4`),
+    ],
+    browserUrl: t(`${prefix}.browserUrl`),
+    browserTitle: t(`${prefix}.browserTitle`),
+  };
+}

--- a/services/web/app/components/blocks/demos/demo-shell.test.tsx
+++ b/services/web/app/components/blocks/demos/demo-shell.test.tsx
@@ -1,0 +1,34 @@
+import { AppShell } from '@tale/ui/app-shell';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { i18n } from '@/lib/i18n/i18n';
+
+import { DemoShell } from './demo-shell';
+
+describe('DemoShell a11y / SEO contract', () => {
+  it('exposes one labelled image and hides decorative DOM from AT + snippets', () => {
+    const label =
+      'Animated demo: a labelled product illustration for assistive tech.';
+    render(
+      <AppShell i18n={i18n}>
+        <DemoShell label={label} activeNav="chat">
+          <p>Scenario copy that must not be page text</p>
+        </DemoShell>
+      </AppShell>,
+    );
+
+    const illustration = screen.getByRole('img', { name: label });
+    expect(illustration.tagName).toBe('FIGURE');
+    expect(illustration.getAttribute('data-nosnippet')).not.toBeNull();
+
+    // Visible to querySelector (DOM still paints the mock) but not as
+    // readable page content — aria-hidden + inert on the decorative payload.
+    const payload = illustration.querySelector('[aria-hidden="true"]');
+    expect(payload).not.toBeNull();
+    expect(payload?.hasAttribute('inert')).toBe(true);
+    expect(payload?.textContent).toContain(
+      'Scenario copy that must not be page text',
+    );
+  });
+});

--- a/services/web/app/components/blocks/demos/demo-shell.tsx
+++ b/services/web/app/components/blocks/demos/demo-shell.tsx
@@ -91,8 +91,11 @@ interface DemoShellProps {
 /**
  * 1:1 frame of the Tale app around every product demo — browser chrome,
  * icon nav rail, and the correct page header for the active nav.
- * Header + content share the same `surface-site` as the nav rail (product
- * `bg-background` idiom) — no raised strip under the title.
+ *
+ * Treated as a single illustration for a11y + SEO: `role="img"` with a
+ * one-sentence `aria-label`, decorative DOM under `aria-hidden` + `inert`
+ * (not read as page text / not focusable), and `data-nosnippet` so crawlers
+ * don't lift demo copy into search snippets.
  */
 export function DemoShell({
   label,
@@ -110,6 +113,7 @@ export function DemoShell({
     <figure
       role="img"
       aria-label={label}
+      data-nosnippet=""
       className={cn(
         'border-border-base/70 bg-surface-site m-0 flex w-full flex-col overflow-hidden rounded-2xl border',
         'ring-1 ring-black/[0.03] dark:ring-white/[0.04]',
@@ -117,94 +121,98 @@ export function DemoShell({
         className,
       )}
     >
-      {/* Browser chrome — marketing frame; the real app is a web deployment. */}
+      {/* Decorative payload — never page copy for AT or snippets. */}
       <div
-        aria-hidden
-        className="border-border-base/60 bg-surface-site-inset/70 relative flex h-9 shrink-0 items-center border-b px-3 md:h-10 md:px-3.5"
+        aria-hidden="true"
+        inert
+        className="flex min-h-0 min-w-0 flex-1 flex-col"
       >
-        <span className="flex items-center gap-1.5">
-          <span className="bg-demo-traffic-close size-2.5 rounded-full" />
-          <span className="bg-demo-traffic-min size-2.5 rounded-full" />
-          <span className="bg-demo-traffic-max size-2.5 rounded-full" />
-        </span>
-        <span className="border-border-base/60 bg-surface-site text-fg-muted absolute left-1/2 flex max-w-[min(72%,22rem)] -translate-x-1/2 items-center gap-1.5 rounded-full border px-3 py-0.5 text-[11px]">
-          <Lock className="size-3 shrink-0 opacity-70" strokeWidth={1.75} />
-          <span className="truncate font-medium tracking-tight">
-            {DEMO_ORIGIN}
+        {/* Browser chrome — marketing frame; the real app is a web deployment. */}
+        <div className="border-border-base/60 bg-surface-site-inset/70 relative flex h-9 shrink-0 items-center border-b px-3 md:h-10 md:px-3.5">
+          <span className="flex items-center gap-1.5">
+            <span className="bg-demo-traffic-close size-2.5 rounded-full" />
+            <span className="bg-demo-traffic-min size-2.5 rounded-full" />
+            <span className="bg-demo-traffic-max size-2.5 rounded-full" />
           </span>
-        </span>
-      </div>
-
-      <div aria-hidden className="flex min-h-0 min-w-0 flex-1">
-        <div className="border-border-base/60 bg-surface-site flex w-11 shrink-0 flex-col items-center border-r md:w-14">
-          <span className="flex shrink-0 items-center justify-center py-2.5 md:py-3">
-            <TaleLogo
-              wordmark={false}
-              className="text-fg-base size-4 md:size-5"
-            />
-          </span>
-          <span className="mx-0.5 flex min-h-0 flex-1 flex-col items-center justify-start gap-0.5 py-1 md:gap-1 md:py-2">
-            {NAV_ICONS.map((Icon, index) => {
-              const active = index === activeIndex;
-              return (
-                <span
-                  key={index}
-                  className={cn(
-                    'flex shrink-0 items-center justify-center rounded-lg p-1.5 md:p-2',
-                    active
-                      ? 'bg-surface-site-inset text-fg-base'
-                      : 'text-fg-muted',
-                  )}
-                >
-                  <Icon
-                    className="size-4 shrink-0 md:size-5"
-                    strokeWidth={active ? 2 : 1.75}
-                  />
-                </span>
-              );
-            })}
-          </span>
-          <span className="text-fg-muted flex shrink-0 flex-col items-center gap-1 py-2 md:gap-2 md:py-3">
-            <span className="relative flex items-center justify-center rounded-lg p-1.5 md:p-2">
-              <Bell className="size-4 md:size-5" strokeWidth={1.75} />
-              <span className="bg-brand-base absolute top-1.5 right-1.5 size-1.5 rounded-full md:top-2 md:right-2" />
-            </span>
-            <span className="bg-surface-site-inset text-fg-muted ring-border-base/50 flex size-6 items-center justify-center rounded-full ring-1 md:size-7">
-              <CircleUser className="size-3.5 md:size-4" strokeWidth={1.75} />
+          <span className="border-border-base/60 bg-surface-site text-fg-muted absolute left-1/2 flex max-w-[min(72%,22rem)] -translate-x-1/2 items-center gap-1.5 rounded-full border px-3 py-0.5 text-[11px]">
+            <Lock className="size-3 shrink-0 opacity-70" strokeWidth={1.75} />
+            <span className="truncate font-medium tracking-tight">
+              {DEMO_ORIGIN}
             </span>
           </span>
         </div>
 
-        {/* Main pane — same surface as the nav rail (product bg-background). */}
-        <div className="bg-surface-site flex min-w-0 flex-1 flex-col">
-          {usePageHeader ? (
-            <div className="border-border-base/60 bg-surface-site flex h-11 shrink-0 items-center border-b px-3 md:h-13 md:px-4">
-              <span className="text-fg-base truncate text-sm font-semibold tracking-tight md:text-base">
-                {title}
+        <div className="flex min-h-0 min-w-0 flex-1">
+          <div className="border-border-base/60 bg-surface-site flex w-11 shrink-0 flex-col items-center border-r md:w-14">
+            <span className="flex shrink-0 items-center justify-center py-2.5 md:py-3">
+              <TaleLogo
+                wordmark={false}
+                className="text-fg-base size-4 md:size-5"
+              />
+            </span>
+            <span className="mx-0.5 flex min-h-0 flex-1 flex-col items-center justify-start gap-0.5 py-1 md:gap-1 md:py-2">
+              {NAV_ICONS.map((Icon, index) => {
+                const active = index === activeIndex;
+                return (
+                  <span
+                    key={index}
+                    className={cn(
+                      'flex shrink-0 items-center justify-center rounded-lg p-1.5 md:p-2',
+                      active
+                        ? 'bg-surface-site-inset text-fg-base'
+                        : 'text-fg-muted',
+                    )}
+                  >
+                    <Icon
+                      className="size-4 shrink-0 md:size-5"
+                      strokeWidth={active ? 2 : 1.75}
+                    />
+                  </span>
+                );
+              })}
+            </span>
+            <span className="text-fg-muted flex shrink-0 flex-col items-center gap-1 py-2 md:gap-2 md:py-3">
+              <span className="relative flex items-center justify-center rounded-lg p-1.5 md:p-2">
+                <Bell className="size-4 md:size-5" strokeWidth={1.75} />
+                <span className="bg-brand-base absolute top-1.5 right-1.5 size-1.5 rounded-full md:top-2 md:right-2" />
               </span>
-            </div>
-          ) : (
-            <div className="border-border-base/60 bg-surface-site flex h-11 shrink-0 items-center gap-0.5 border-b px-2.5 md:h-13 md:gap-1 md:px-3">
-              <span className="text-fg-muted flex size-8 items-center justify-center rounded-lg">
-                <MessagesSquare className="size-4" strokeWidth={1.75} />
+              <span className="bg-surface-site-inset text-fg-muted ring-border-base/50 flex size-6 items-center justify-center rounded-full ring-1 md:size-7">
+                <CircleUser className="size-3.5 md:size-4" strokeWidth={1.75} />
               </span>
-              <span className="text-fg-muted flex size-8 items-center justify-center rounded-lg">
-                <Search className="size-4" strokeWidth={1.75} />
-              </span>
-              <span className="flex-1" />
-              <span className="text-fg-muted ml-auto flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium">
-                <Share className="size-4" strokeWidth={1.75} />
-                <span className="hidden sm:inline">
-                  {t('demos.chrome.share')}
+            </span>
+          </div>
+
+          {/* Main pane — same surface as the nav rail (product bg-background). */}
+          <div className="bg-surface-site flex min-w-0 flex-1 flex-col">
+            {usePageHeader ? (
+              <div className="border-border-base/60 bg-surface-site flex h-11 shrink-0 items-center border-b px-3 md:h-13 md:px-4">
+                <span className="text-fg-base truncate text-sm font-semibold tracking-tight md:text-base">
+                  {title}
                 </span>
-              </span>
-              <span className="text-fg-muted flex size-8 items-center justify-center rounded-lg">
-                <Ellipsis className="size-4" strokeWidth={1.75} />
-              </span>
+              </div>
+            ) : (
+              <div className="border-border-base/60 bg-surface-site flex h-11 shrink-0 items-center gap-0.5 border-b px-2.5 md:h-13 md:gap-1 md:px-3">
+                <span className="text-fg-muted flex size-8 items-center justify-center rounded-lg">
+                  <MessagesSquare className="size-4" strokeWidth={1.75} />
+                </span>
+                <span className="text-fg-muted flex size-8 items-center justify-center rounded-lg">
+                  <Search className="size-4" strokeWidth={1.75} />
+                </span>
+                <span className="flex-1" />
+                <span className="text-fg-muted ml-auto flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium">
+                  <Share className="size-4" strokeWidth={1.75} />
+                  <span className="hidden sm:inline">
+                    {t('demos.chrome.share')}
+                  </span>
+                </span>
+                <span className="text-fg-muted flex size-8 items-center justify-center rounded-lg">
+                  <Ellipsis className="size-4" strokeWidth={1.75} />
+                </span>
+              </div>
+            )}
+            <div className="bg-surface-site min-h-0 flex-1 overflow-hidden">
+              {children}
             </div>
-          )}
-          <div className="bg-surface-site min-h-0 flex-1 overflow-hidden">
-            {children}
           </div>
         </div>
       </div>

--- a/services/web/app/components/blocks/demos/knowledge-pool.tsx
+++ b/services/web/app/components/blocks/demos/knowledge-pool.tsx
@@ -93,6 +93,8 @@ export function KnowledgePool({
             <div className="flex flex-col">
               {scene.rows.map((row, index) => {
                 const Icon = TYPE_ICON[row.type];
+                const indexed = beat >= BEAT.done;
+                const indexing = beat >= BEAT.indexing && !indexed;
                 return beat >= BEAT.row1 + index ? (
                   <motion.div
                     key={row.name}
@@ -118,15 +120,15 @@ export function KnowledgePool({
                     <span className="flex justify-end">
                       <span
                         className={cn(
-                          'inline-flex rounded-md px-1.5 py-0.5 text-[10px] font-medium',
-                          beat >= BEAT.done
+                          'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium',
+                          indexed
                             ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
-                            : beat >= BEAT.indexing
+                            : indexing
                               ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
                               : 'bg-surface-site-inset text-fg-muted',
                         )}
                       >
-                        {beat >= BEAT.done
+                        {indexed
                           ? t('demos.knowledge.statusIndexed')
                           : t('demos.knowledge.statusIndexing')}
                       </span>

--- a/services/web/app/components/blocks/demos/sandbox-workspace.tsx
+++ b/services/web/app/components/blocks/demos/sandbox-workspace.tsx
@@ -1,0 +1,265 @@
+import { cn } from '@tale/ui/cn';
+import { motion, useInView, useReducedMotion } from 'framer-motion';
+import {
+  ChevronRight,
+  FileCode2,
+  FolderOpen,
+  Globe,
+  MonitorPlay,
+} from 'lucide-react';
+import { useRef } from 'react';
+
+import {
+  type SandboxScenario,
+  useSandboxScenario,
+} from '@/app/components/blocks/demos/demo-scenarios';
+import { DemoShell } from '@/app/components/blocks/demos/demo-shell';
+import { useDemoTimeline } from '@/app/components/blocks/demos/use-demo-timeline';
+import { useT } from '@/lib/i18n/client';
+
+const easeOut = [0.22, 1, 0.36, 1] as const;
+
+const BEATS = [0, 400, 900, 1400, 2000, 2600, 3200] as const;
+const BEAT = {
+  frame: 0,
+  prompt: 1,
+  pane: 2,
+  files: 3,
+  code: 4,
+  live: 5,
+  reply: 6,
+} as const;
+
+/**
+ * D9 — Sandbox agent workspace: chat thread + Files / Live side pane.
+ * Vocabulary from `workspace-files-pane.tsx` (explorer + preview) and
+ * `live-browser-pane.tsx` (screencast chrome) — static faux frames only,
+ * never a real VNC stream.
+ */
+export function SandboxWorkspace({
+  scenario,
+}: {
+  /** Story override — defaults to the homepage Claude Code sandbox scene. */
+  scenario?: SandboxScenario;
+}) {
+  const { t } = useT('home');
+  const homeScenario = useSandboxScenario();
+  const scene = scenario ?? homeScenario;
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, margin: '-15%' });
+  const beat = useDemoTimeline({ beats: BEATS, start: inView });
+  const reduceMotion = useReducedMotion();
+  const showLive = beat >= BEAT.live;
+
+  const pop = (delay = 0) => ({
+    initial: reduceMotion ? false : { opacity: 0, y: 6 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: 0.3, ease: easeOut, delay },
+  });
+
+  return (
+    <div ref={ref}>
+      <DemoShell
+        label={scene.label}
+        activeNav="chat"
+        className="mx-auto aspect-[7/10] max-w-4xl sm:aspect-[16/10]"
+      >
+        <div className="flex h-full min-h-0">
+          <div className="border-border-base flex min-w-0 flex-[0.95] flex-col border-r">
+            <div className="flex min-h-0 flex-1 flex-col justify-start gap-2.5 px-3 py-3 sm:gap-3 sm:px-4 sm:py-3.5">
+              {beat >= BEAT.prompt ? (
+                <motion.div {...pop()} className="flex flex-col items-end">
+                  <div className="bg-surface-site-inset text-fg-base max-w-[92%] rounded-2xl px-3 py-2 text-xs sm:max-w-xs sm:text-[13px]">
+                    {scene.prompt}
+                  </div>
+                </motion.div>
+              ) : null}
+
+              {beat >= BEAT.reply ? (
+                <motion.div
+                  {...pop()}
+                  className="flex flex-col items-start gap-1.5"
+                >
+                  <p className="text-fg-subtle flex items-center gap-1.5 text-[10px] sm:text-[11px]">
+                    <span className="text-fg-base font-medium">
+                      {scene.agent}
+                    </span>
+                    <span aria-hidden>·</span>
+                    <span>{scene.model}</span>
+                  </p>
+                  <p className="text-fg-base text-xs leading-snug sm:text-[13px]">
+                    {scene.reply}
+                  </p>
+                </motion.div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            {beat >= BEAT.pane ? (
+              <motion.div {...pop()} className="flex h-full min-h-0 flex-col">
+                <div
+                  role="presentation"
+                  className="border-border-base flex shrink-0 gap-0.5 border-b px-1.5 pt-1.5"
+                >
+                  <PaneTab
+                    active={!showLive}
+                    icon={FolderOpen}
+                    label={t('demos.sandbox.filesTab')}
+                  />
+                  <PaneTab
+                    active={showLive}
+                    icon={MonitorPlay}
+                    label={t('demos.sandbox.liveTab')}
+                  />
+                </div>
+
+                <div className="relative min-h-0 flex-1 overflow-hidden">
+                  <div
+                    className={cn(
+                      'flex h-full min-h-0',
+                      showLive && 'flex-col sm:flex-row',
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        'flex min-h-0',
+                        showLive
+                          ? 'border-border-base/70 max-h-[38%] shrink-0 border-b sm:max-h-none sm:w-[36%] sm:flex-col sm:border-r sm:border-b-0'
+                          : 'min-w-0 flex-1',
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          'border-border-base/70 flex shrink-0 flex-col gap-0.5 px-1.5 py-2',
+                          showLive ? 'w-full' : 'w-[42%] border-r',
+                        )}
+                      >
+                        <p className="text-fg-subtle mb-1 truncate px-1 text-[9px] font-medium tracking-wide uppercase">
+                          {t('demos.sandbox.treeRoot')}
+                        </p>
+                        {beat >= BEAT.files
+                          ? scene.files.map((name, index) => {
+                              const active = name === scene.activeFile;
+                              return (
+                                <motion.div
+                                  key={name}
+                                  {...pop(index * 0.04)}
+                                  className={cn(
+                                    'flex items-center gap-1 rounded px-1 py-0.5 text-[10px] md:text-[11px]',
+                                    active
+                                      ? 'bg-surface-site-inset text-fg-base font-medium'
+                                      : 'text-fg-muted',
+                                  )}
+                                >
+                                  {active ? (
+                                    <ChevronRight
+                                      aria-hidden
+                                      className="size-2.5 shrink-0"
+                                    />
+                                  ) : (
+                                    <span className="size-2.5 shrink-0" />
+                                  )}
+                                  <FileCode2
+                                    aria-hidden
+                                    className="size-3 shrink-0"
+                                    strokeWidth={1.75}
+                                  />
+                                  <span className="truncate">{name}</span>
+                                </motion.div>
+                              );
+                            })
+                          : null}
+                      </div>
+                      {!showLive ? (
+                        <div className="bg-surface-site-inset/40 flex min-w-0 flex-1 flex-col px-2 py-2 md:px-3">
+                          <p className="text-fg-subtle mb-1.5 truncate text-[10px] font-medium">
+                            {scene.activeFile}
+                          </p>
+                          {beat >= BEAT.code ? (
+                            <motion.pre
+                              {...pop()}
+                              className="text-fg-muted overflow-hidden font-mono text-[9px] leading-relaxed md:text-[10px]"
+                            >
+                              {scene.codeLines.map((line, i) => (
+                                <div key={i} className="flex gap-2">
+                                  <span className="text-fg-subtle/70 w-3 shrink-0 text-right tabular-nums select-none">
+                                    {i + 1}
+                                  </span>
+                                  <span className="text-fg-base truncate">
+                                    {line}
+                                  </span>
+                                </div>
+                              ))}
+                            </motion.pre>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+
+                    {showLive ? (
+                      <motion.div
+                        {...pop()}
+                        className="flex min-h-0 min-w-0 flex-1 flex-col p-2 md:p-2.5"
+                      >
+                        <div className="border-border-base bg-surface-site-raised flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border">
+                          <div className="border-border-base flex items-center gap-1.5 border-b px-2 py-1.5">
+                            <Globe
+                              aria-hidden
+                              className="text-fg-muted size-3 shrink-0"
+                              strokeWidth={1.75}
+                            />
+                            <span className="text-fg-muted truncate font-mono text-[10px] md:text-[11px]">
+                              {scene.browserUrl}
+                            </span>
+                          </div>
+                          <div className="from-surface-site-inset to-surface-site-raised relative flex min-h-0 flex-1 flex-col items-center justify-center bg-gradient-to-b px-3">
+                            <MonitorPlay
+                              aria-hidden
+                              className="text-fg-subtle mb-2 size-6 md:size-7"
+                              strokeWidth={1.5}
+                            />
+                            <p className="text-fg-base text-center text-[11px] font-medium md:text-xs">
+                              {scene.browserTitle}
+                            </p>
+                            <p className="text-fg-subtle mt-1 text-center text-[10px]">
+                              {t('demos.sandbox.liveHint')}
+                            </p>
+                          </div>
+                        </div>
+                      </motion.div>
+                    ) : null}
+                  </div>
+                </div>
+              </motion.div>
+            ) : null}
+          </div>
+        </div>
+      </DemoShell>
+    </div>
+  );
+}
+
+function PaneTab({
+  active,
+  icon: Icon,
+  label,
+}: {
+  active: boolean;
+  icon: typeof FolderOpen;
+  label: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-t-md px-2 py-1 text-[10px] font-medium md:text-[11px]',
+        active
+          ? 'bg-surface-site text-fg-base border-border-base border border-b-transparent'
+          : 'text-fg-muted',
+      )}
+    >
+      <Icon aria-hidden className="size-3" strokeWidth={1.75} />
+      {label}
+    </span>
+  );
+}

--- a/services/web/app/components/blocks/demos/task-board.tsx
+++ b/services/web/app/components/blocks/demos/task-board.tsx
@@ -1,0 +1,176 @@
+import { cn } from '@tale/ui/cn';
+import { motion, useInView, useReducedMotion } from 'framer-motion';
+import { Bot } from 'lucide-react';
+import { useRef, type ReactNode } from 'react';
+
+import {
+  type TaskBoardCard,
+  type TaskBoardScenario,
+  useTaskBoardScenario,
+} from '@/app/components/blocks/demos/demo-scenarios';
+import { DemoShell } from '@/app/components/blocks/demos/demo-shell';
+import { useDemoTimeline } from '@/app/components/blocks/demos/use-demo-timeline';
+import { useT } from '@/lib/i18n/client';
+
+const easeOut = [0.22, 1, 0.36, 1] as const;
+
+const BEATS = [0, 300, 700, 1100, 1500, 1900, 2400] as const;
+const BEAT = {
+  frame: 0,
+  columns: 1,
+  todo: 2,
+  inProgress: 3,
+  inReview: 4,
+  done: 5,
+  working: 6,
+} as const;
+
+/**
+ * D8 — Projects task board (kanban). Mirrors `KanbanBoard` /
+ * `BoardColumn` / `TaskCard` idioms: status lanes, identifier + title cards,
+ * agent assignee row. Product also has Backlog + Cancelled — omitted here so
+ * the fixed marketing frame stays readable (see `BOARD_TASK_STATUSES`).
+ */
+export function TaskBoard({
+  scenario,
+}: {
+  /** Story override — defaults to the homepage relaunch board. */
+  scenario?: TaskBoardScenario;
+}) {
+  const { t } = useT('home');
+  const homeScenario = useTaskBoardScenario();
+  const scene = scenario ?? homeScenario;
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, margin: '-15%' });
+  const beat = useDemoTimeline({ beats: BEATS, start: inView });
+  const reduceMotion = useReducedMotion();
+
+  const columns: readonly {
+    key: string;
+    label: string;
+    cards: readonly TaskBoardCard[];
+    showAt: number;
+    working?: boolean;
+  }[] = [
+    {
+      key: 'todo',
+      label: t('demos.tasks.colTodo'),
+      cards: scene.todo,
+      showAt: BEAT.todo,
+    },
+    {
+      key: 'in_progress',
+      label: t('demos.tasks.colInProgress'),
+      cards: [scene.inProgress],
+      showAt: BEAT.inProgress,
+      working: true,
+    },
+    {
+      key: 'in_review',
+      label: t('demos.tasks.colInReview'),
+      cards: [scene.inReview],
+      showAt: BEAT.inReview,
+    },
+    {
+      key: 'done',
+      label: t('demos.tasks.colDone'),
+      cards: [scene.done],
+      showAt: BEAT.done,
+    },
+  ];
+
+  return (
+    <div ref={ref}>
+      <DemoShell
+        label={scene.label}
+        title={t('demos.tasks.windowTitle')}
+        activeNav="projects"
+        className="mx-auto aspect-[7/10] max-w-4xl sm:aspect-[16/10]"
+      >
+        <div className="flex h-full flex-col gap-3 p-3 md:gap-4 md:p-4">
+          {beat >= BEAT.columns ? (
+            <motion.div
+              initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.35, ease: easeOut }}
+              className="flex min-h-0 flex-1 gap-2 overflow-hidden md:gap-3"
+            >
+              {columns.map((column) => {
+                const working = Boolean(column.working) && beat >= BEAT.working;
+                return (
+                  <section
+                    key={column.key}
+                    className="bg-surface-site-inset/60 flex min-w-0 flex-1 flex-col rounded-lg"
+                  >
+                    <header className="flex items-center justify-between gap-1 px-2 py-1.5 md:px-2.5 md:py-2">
+                      <span className="text-fg-base truncate text-[10px] font-medium tracking-wide uppercase md:text-[11px]">
+                        {column.label}
+                      </span>
+                      <span className="text-fg-subtle text-[10px] tabular-nums md:text-[11px]">
+                        {column.cards.length}
+                      </span>
+                    </header>
+                    <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden px-1.5 pb-2 md:gap-2 md:px-2">
+                      {beat >= column.showAt ? (
+                        column.cards.map((card, index) => (
+                          <motion.article
+                            key={card.id}
+                            initial={
+                              reduceMotion ? false : { opacity: 0, y: 6 }
+                            }
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{
+                              duration: 0.3,
+                              ease: easeOut,
+                              delay: reduceMotion ? 0 : index * 0.05,
+                            }}
+                            className={cn(
+                              'border-border-base bg-surface-site-raised rounded-md border p-2 shadow-sm md:p-2.5',
+                              working && 'ring-border-strong ring-1',
+                            )}
+                          >
+                            <div className="flex items-start justify-between gap-1">
+                              <p className="text-fg-subtle text-[10px] font-medium tracking-wide tabular-nums">
+                                {card.id}
+                              </p>
+                              {working ? (
+                                <span className="bg-surface-site-inset text-fg-muted shrink-0 rounded px-1 py-0.5 text-[9px] font-medium tracking-wide uppercase">
+                                  {t('demos.tasks.working')}
+                                </span>
+                              ) : null}
+                            </div>
+                            <p className="text-fg-base mt-0.5 line-clamp-2 text-[11px] leading-snug font-medium md:text-xs">
+                              {card.title}
+                            </p>
+                            <p className="text-fg-muted mt-1.5 flex min-w-0 items-center gap-1 text-[10px] md:text-[11px]">
+                              <Bot
+                                aria-hidden
+                                className="size-3 shrink-0"
+                                strokeWidth={1.75}
+                              />
+                              <span className="truncate">{card.assignee}</span>
+                            </p>
+                          </motion.article>
+                        ))
+                      ) : (
+                        <EmptyLane />
+                      )}
+                    </div>
+                  </section>
+                );
+              })}
+            </motion.div>
+          ) : null}
+        </div>
+      </DemoShell>
+    </div>
+  );
+}
+
+function EmptyLane(): ReactNode {
+  return (
+    <div className="border-border-base/80 text-fg-subtle m-0.5 flex flex-1 items-center justify-center rounded-lg border border-dashed px-2 py-4 text-[10px]">
+      ···
+    </div>
+  );
+}

--- a/services/web/app/components/blocks/demos/tour-demos.stories.tsx
+++ b/services/web/app/components/blocks/demos/tour-demos.stories.tsx
@@ -34,6 +34,8 @@ import { GovernGate } from './govern-gate';
 import { HeroOrchestration } from './hero-orchestration';
 import { KnowledgePool } from './knowledge-pool';
 import { ProjectsBoard } from './projects-board';
+import { SandboxWorkspace } from './sandbox-workspace';
+import { TaskBoard } from './task-board';
 
 const meta = {
   title: 'Blocks/Demos/TourDemos',
@@ -61,6 +63,8 @@ export const Automation: Story = { render: () => <AutomationRun /> };
 export const Govern: Story = { render: () => <GovernGate /> };
 export const Arena: Story = { render: () => <ChatArena /> };
 export const Projects: Story = { render: () => <ProjectsBoard /> };
+export const Tasks: Story = { render: () => <TaskBoard /> };
+export const Sandbox: Story = { render: () => <SandboxWorkspace /> };
 
 export const ConnectOnStage: Story = {
   name: 'Connect (on DemoStage)',
@@ -180,6 +184,12 @@ export const ReducedMotionEndState: Story = {
       </DemoStage>
       <DemoStage>
         <ProjectsBoard />
+      </DemoStage>
+      <DemoStage>
+        <TaskBoard />
+      </DemoStage>
+      <DemoStage>
+        <SandboxWorkspace />
       </DemoStage>
     </div>
   ),

--- a/services/web/app/components/blocks/feature/feature.stories.tsx
+++ b/services/web/app/components/blocks/feature/feature.stories.tsx
@@ -34,7 +34,7 @@ export const Hero: Story = {
     <FeatureHero
       eyebrow="Platform"
       title="What are agents in Tale?"
-      description="Dock Claude Code, Codex, Cursor, and Gemini beside in-product agents — one orchestrator, shared knowledge, approvals on the way out."
+      description="Dock Claude Code, Codex, Hermes, and OpenClaw beside in-product agents — one orchestrator, shared knowledge, approvals on the way out."
       showCtas
     />
   ),

--- a/services/web/app/components/marketing/marketing.stories.tsx
+++ b/services/web/app/components/marketing/marketing.stories.tsx
@@ -62,7 +62,7 @@ export const Cards: Story = {
             <MarketingCard
               to="/platform/agents"
               title="Agents"
-              description="Orchestrate Claude Code, Codex, Cursor, and Gemini."
+              description="Orchestrate Claude Code, Codex, Hermes, and OpenClaw."
             />
           </li>
           <li className="bg-surface-site-raised">

--- a/services/web/app/pages/platform/agents-page.tsx
+++ b/services/web/app/pages/platform/agents-page.tsx
@@ -12,7 +12,7 @@ import { usePlatformTour } from '@/app/pages/platform/use-platform-tour';
 export function AgentsPage() {
   const content = useFeaturePageContent('agents', 'platformAgents');
   // Agent-flavored scenes: a library scoped to one agent, a workflow that
-  // calls an agent as its LLM step, and a delegation moment in chat.
+  // calls an agent as its LLM step, and a sandbox Files / Live browser pane.
   const tour = usePlatformTour('platformAgents', [
     { id: 'projects', demo: <AgentsTourProjectsDemo /> },
     { id: 'knowledge', demo: <AgentsTourKnowledgeDemo /> },

--- a/services/web/app/pages/platform/projects-page.tsx
+++ b/services/web/app/pages/platform/projects-page.tsx
@@ -11,9 +11,9 @@ import { usePlatformTour } from '@/app/pages/platform/use-platform-tour';
 
 export function ProjectsPage() {
   const content = useFeaturePageContent('projects', 'platformProjects');
-  // The hero shows the workspace roster; the tour assigns a board task to an
-  // agent, resumes a project chat with its context, opens the project files,
-  // and holds the outbound step behind a review gate.
+  // The hero shows the workspace roster; the tour shows the task board with
+  // an agent on a card, resumes a project chat with its context, opens the
+  // project files, and holds the outbound step behind a review gate.
   const tour = usePlatformTour('platformProjects', [
     { id: 'tasks', demo: <ProjectsTourTasksDemo /> },
     { id: 'chat', demo: <ProjectsTourChatDemo /> },

--- a/services/web/lib/seo/build.ts
+++ b/services/web/lib/seo/build.ts
@@ -63,7 +63,7 @@ export const WEB_SITE_DESCRIPTION =
  * aligned with visible homepage / pricing / security copy — no ratings.
  */
 export const WEB_LLMS_PAGES_INTRO = [
-  'Tale is a self-hosted orchestrator for AI agents. Connect Claude Code, Codex, Cursor, Gemini, and in-product agents; pool org knowledge with citations; run automations with approvals; govern spend and audit every action.',
+  'Tale is a self-hosted orchestrator for AI agents. Connect Claude Code, Codex, Hermes, OpenClaw, and in-product agents; pool org knowledge with citations; run automations with approvals; govern spend and audit every action.',
   'Publisher: Ruler GmbH, Seestrasse 4, 3700 Spiez, Switzerland (VAT CHE-186.532.610). License: MIT (Community free to self-host). Enterprise: CHF 12 / EUR 14 per user/month (two months free on yearly billing). Certifications: ISO 27001, SOC 2 Type II.',
   'Deploy on your infrastructure (Docker/Linux), including air-gapped environments. Documentation: https://tale.dev/docs/llms.txt — source: https://github.com/tale-project/tale',
 ].join('\n\n');

--- a/services/web/messages/de.json
+++ b/services/web/messages/de.json
@@ -27,10 +27,10 @@
     },
     "platformAgents": {
       "title": "Was sind Agents in Tale?",
-      "description": "Tale-Agents kombinieren Anweisungen, Wissen, Tools und ein Modell. Verbinde Claude Code, Codex, Cursor und Gemini unter einem Orchestrator, den du hostest."
+      "description": "Tale-Agents kombinieren Anweisungen, Wissen, Tools und ein Modell. Verbinde Claude Code, Codex, Hermes und OpenClaw unter einem Orchestrator, den du hostest."
     },
     "platformChat": {
-      "title": "Was ist Chat in Tale?",
+      "title": "Chats in Tale",
       "description": "Tale Chat ist der Alltagseinstieg: Agent wählen, Nachricht senden, gestreamte Antwort lesen — mit Zitaten, Tool-Aufrufen, Arena-Modus und Freigaben im Chat."
     },
     "platformAutomations": {
@@ -74,10 +74,10 @@
       },
       "agents": {
         "label": "Agents",
-        "description": "Claude Code, Codex, Cursor und Gemini orchestrieren."
+        "description": "Claude Code, Codex, Hermes und OpenClaw orchestrieren."
       },
       "chat": {
-        "label": "Chat",
+        "label": "Chats",
         "description": "Alltag-KI mit Zitationen, Tools und Arena."
       },
       "projects": {
@@ -153,7 +153,7 @@
   "home": {
     "hero": {
       "title": "Orchestriere jeden KI-Agent auf deinem Stack",
-      "subtitle": "Verbinde Claude Code, Codex, Cursor und die übrigen Agents deines Teams. Bündle ihr Wissen, delegiere echte Arbeit — auf Infrastruktur, die du betreibst.",
+      "subtitle": "Verbinde Claude Code, Codex, Hermes, OpenClaw und die übrigen Agents deines Teams. Bündle ihr Wissen, delegiere echte Arbeit — auf Infrastruktur, die du betreibst.",
       "ctaPrimary": "Demo anfragen",
       "ctaSecondary": "Kontakt aufnehmen"
     },
@@ -179,7 +179,7 @@
         "inputPlaceholder": "Frag einfach…"
       },
       "connect": {
-        "label": "Animierte Demo: Die Agents-Liste zeigt Claude Code, Codex, Cursor, Support-Agent und Gemini als installierte Zeilen mit Modell-Chips.",
+        "label": "Animierte Demo: Die Agents-Liste zeigt Claude Code, Codex, Hermes, Support-Agent und OpenClaw als installierte Zeilen mit Modell-Chips.",
         "windowTitle": "Agents",
         "searchPlaceholder": "Agents suchen…",
         "addLabel": "Agents",
@@ -189,14 +189,14 @@
         "statusReady": "Bereit",
         "agent1": "Claude Code",
         "agent2": "Codex",
-        "agent3": "Cursor",
+        "agent3": "Hermes",
         "agent4": "Support-Agent",
-        "agent5": "Gemini",
+        "agent5": "OpenClaw",
         "model1": "Claude Opus",
         "model2": "GPT-5.5",
-        "model3": "Composer",
+        "model3": "Claude Sonnet",
         "model4": "Claude Sonnet",
-        "model5": "Gemini 2.5"
+        "model5": "Claude Opus"
       },
       "knowledge": {
         "label": "Animierte Demo: Die Wissens-Dokumententabelle indexiert ein PDF, eine Website, einen Produktkatalog und ein Runbook und zeigt Index-Status-Badges.",
@@ -299,6 +299,52 @@
         "members2": "14",
         "members3": "5",
         "members4": "11"
+      },
+      "tasks": {
+        "windowTitle": "Tasks",
+        "colTodo": "To do",
+        "colInProgress": "In progress",
+        "colInReview": "In review",
+        "colDone": "Done",
+        "working": "Arbeitet",
+        "id1": "WEB-14",
+        "id2": "WEB-15",
+        "id3": "WEB-12",
+        "id4": "WEB-11",
+        "id5": "WEB-9",
+        "label": "Animierte Demo: Das Projekt-Task-Board zeigt die Spalten To do, In progress, In review und Done — ein Agent bearbeitet eine Karte in In progress.",
+        "title1": "/docs-Redirects mappen",
+        "assignee1": "Nicht zugewiesen",
+        "title2": "Pricing-Seiten-Copy entwerfen",
+        "assignee2": "Mira",
+        "title3": "Migrationsleitfaden schreiben",
+        "assignee3": "Relaunch Agent",
+        "title4": "Staging-Checkliste prüfen",
+        "assignee4": "Relaunch Agent",
+        "title5": "Brand-Tokens shippen",
+        "assignee5": "Design Agent"
+      },
+      "sandbox": {
+        "filesTab": "Files",
+        "liveTab": "Live",
+        "treeRoot": "workspace",
+        "liveHint": "Live-Browseransicht",
+        "label": "Animierte Demo: Ein Sandbox-Agent-Chat öffnet den Files-Bereich an einer Python-CLI und wechselt dann zur Live-Browseransicht der laufenden App.",
+        "prompt": "Baue eine kleine Python-CLI und öffne sie im Browser, damit ich durchklicken kann.",
+        "agent": "Claude Code",
+        "model": "Claude Opus",
+        "reply": "cli.py und eine lokale Vorschau sind da — Files zeigt den Tree; Live streamt den Browser.",
+        "file1": "cli.py",
+        "file2": "pyproject.toml",
+        "file3": "tests/test_cli.py",
+        "file4": "README.md",
+        "activeFile": "cli.py",
+        "code1": "import click",
+        "code2": "@click.command()",
+        "code3": "def main():",
+        "code4": "    click.echo(\"ready\")",
+        "browserUrl": "http://127.0.0.1:5173",
+        "browserTitle": "CLI-Vorschau · localhost"
       }
     },
     "tour": {
@@ -307,7 +353,7 @@
       "connect": {
         "eyebrow": "Agents & Integrationen",
         "title": "Bring die Agents mit,\ndenen du schon vertraust",
-        "description": "Claude Code, Codex, Cursor, Gemini — plus Slack, GitHub, Outlook und der Rest deines Stacks. Nichts wird ersetzt; alles wird koordiniert."
+        "description": "Claude Code, Codex, Hermes, OpenClaw — plus Slack, GitHub, Outlook und der Rest deines Stacks. Nichts wird ersetzt; alles wird koordiniert."
       },
       "pool": {
         "eyebrow": "Wissen",
@@ -360,7 +406,7 @@
     },
     "agents": {
       "title": "Funktioniert mit den Agents, die du nutzt",
-      "subtitle": "Docke Claude Code, Codex, Cursor, Gemini, Hermes, OpenClaw, Pi und OpenCode unter einem Orchestrator an, den du hostest."
+      "subtitle": "Docke Claude Code, Codex, Hermes, OpenClaw, Pi und OpenCode unter einem Orchestrator an, den du hostest."
     },
     "compliance": {
       "eyebrow": "SICHERHEIT",
@@ -758,7 +804,7 @@
   "platformAgents": {
     "eyebrow": "Agents",
     "title": "Was sind Agents in Tale?",
-    "description": "Ein Tale Agent ist die Vier-Knopf-Kombination aus Anweisungen, Wissen, Tools und Modell. Redakteure bauen sie einmal; das Team nutzt sie in Chat, Automations und Projekten — inklusive externer Agents wie Claude Code, Codex, Cursor und Gemini.",
+    "description": "Ein Tale Agent ist die Vier-Knopf-Kombination aus Anweisungen, Wissen, Tools und Modell. Redakteure bauen sie einmal; das Team nutzt sie in Chat, Automations und Projekten — inklusive externer Agents wie Claude Code, Codex, Hermes und OpenClaw.",
     "capabilities": {
       "heading": "Was können Agents?",
       "description": "Was eine Agent-Definition dem ganzen Team gibt — und was sie einem nackten Modell voraushat.",
@@ -770,7 +816,7 @@
         },
         {
           "title": "Externe Agents docken an",
-          "body": "Verbinde Claude Code, Codex, Cursor und Gemini, damit Arbeit an den Agent geroutet wird, der schon in deinem Stack lebt.",
+          "body": "Verbinde Claude Code, Codex, Hermes und OpenClaw, damit Arbeit an den Agent geroutet wird, der schon in deinem Stack lebt.",
           "docsLabel": "Externe Agents"
         },
         {
@@ -798,8 +844,8 @@
           "a": "Ein Tale Agent kombiniert Anweisungen, Wissen, Tools und Modell zu einer wiederverwendbaren Einheit, die Mitglieder in Chat und Automations nutzen."
         },
         {
-          "q": "Kann Tale Claude Code und Cursor orchestrieren?",
-          "a": "Ja. Tale verbindet externe Agents wie Claude Code, Codex, Cursor und Gemini, damit dein Team Arbeit über einen Orchestrator routet."
+          "q": "Kann Tale Claude Code und Hermes orchestrieren?",
+          "a": "Ja. Tale verbindet externe Agents wie Claude Code, Codex, Hermes und OpenClaw, damit dein Team Arbeit über einen Orchestrator routet."
         },
         {
           "q": "Wann nutze ich einen Agent statt eines Workflows?",
@@ -857,9 +903,9 @@
         },
         {
           "id": "chat",
-          "eyebrow": "Chat",
-          "title": "Mit Agents in\nAlltags-Threads sprechen",
-          "description": "Wähle einen Agent in Chat, sende eine Nachricht und sieh eine belegte Antwort mit Zitaten streamen."
+          "eyebrow": "Sandbox",
+          "title": "Dem Agent in Files\nund Live zusehen",
+          "description": "Externe Agents arbeiten in einer Sandbox — brows den Workspace-Tree, öffne die Datei, die sie gerade geschrieben haben, und schau im Live-Browser zu, wie sie das Ergebnis durchklicken."
         }
       ]
     },
@@ -893,20 +939,6 @@
         "runTone3": "running",
         "duration3": "0,8s"
       },
-      "hero": {
-        "label": "Animierte Demo: Ein Thread, der beim Support-Agent begann, wird an den Docs-Agent delegiert — der antwortet mit der Offline-Install-Checkliste und zwei zitierten Quellen.",
-        "prompt": "Der Basel-Pilot braucht unsere Offline-Install-Checkliste bis Freitag — was schicken wir?",
-        "routedTitle": "An Docs-Agent delegiert",
-        "routedDetail": "Vom Support-Agent übergeben — der Verlauf bleibt erhalten.",
-        "reply1": "Schick den Air-Gap-Install-Guide, Version 2.3 oder neuer.",
-        "reply2": "Er deckt die Offline-Modell-Registry und die Lizenz-Aktivierung ab.",
-        "reply3": "Häng das Hardware-Sizing für den 40-Nutzer-Piloten an —",
-        "reply4": "und markiere, dass das DNS-freie Setup das Appliance-Image braucht.",
-        "citation1": "airgap-install.pdf",
-        "citation2": "Pilot-Anforderungen",
-        "composerAgentRouted": "Docs-Agent",
-        "composerModel": "Claude Opus"
-      },
       "connect": {
         "label": "Animierte Demo: Die Agents-Liste dieser Seite — Support-Agent, Docs-Agent, Release-Agent, Research-Agent und Pilot-Agent, jeweils mit Modell.",
         "agent1": "Support-Agent",
@@ -934,6 +966,24 @@
         "project4": "Release-Zug",
         "agents4": "3 Agents",
         "members4": "7"
+      },
+      "sandbox": {
+        "label": "Animierte Demo: Hermes bearbeitet install_offline.py im Files-Bereich, dann zeigt der Live-Browser die Air-Gap-Install-Checkliste.",
+        "prompt": "Fixe das Offline-Install-Skript und zeig mir die Checkliste im Live-Browser.",
+        "agent": "Hermes",
+        "model": "Claude Sonnet",
+        "reply": "Registry-Pfad gefixt — Files hat den Diff; Live ist auf der Checkliste.",
+        "file1": "install_offline.py",
+        "file2": "registry.json",
+        "file3": "docs/checklist.md",
+        "file4": "Dockerfile",
+        "activeFile": "install_offline.py",
+        "code1": "def resolve_registry(path):",
+        "code2": "    root = Path(path).expanduser()",
+        "code3": "    if not root.exists():",
+        "code4": "        raise SystemExit(\"missing registry\")",
+        "browserUrl": "http://127.0.0.1:8787/checklist",
+        "browserTitle": "Air-Gap-Install-Checkliste"
       }
     }
   },
@@ -1115,8 +1165,8 @@
     }
   },
   "platformChat": {
-    "eyebrow": "Chat",
-    "title": "Was ist Chat in Tale?",
+    "eyebrow": "Chats",
+    "title": "Chats in Tale",
     "description": "Chat ist der Alltagseinstieg: Agent wählen (oder keinen), tippen, und eine Antwort streamt mit Zitationen, Tool-Aufrufen und optionalen Arena-Vergleichen — die Oberfläche, in die jedes andere Plattform-Modul einmündet.",
     "capabilities": {
       "heading": "Was umfasst Chat?",
@@ -1483,7 +1533,7 @@
           "id": "agents",
           "eyebrow": "Agents",
           "title": "Jeder Agent,\nein Roster",
-          "description": "Claude Code, Codex, Cursor, Gemini — angedockt neben In-Product-Agents, damit Arbeit zum Tool geht, das dein Team schon nutzt."
+          "description": "Claude Code, Codex, Hermes, OpenClaw — angedockt neben In-Product-Agents, damit Arbeit zum Tool geht, das dein Team schon nutzt."
         },
         {
           "id": "knowledge",
@@ -1534,7 +1584,7 @@
         },
         {
           "q": "Wo fange ich an?",
-          "a": "Öffne Chat für eine belegte Antwort, oder Agents, um Claude Code, Codex, Cursor und Gemini unter einem Orchestrator anzudocken."
+          "a": "Öffne Chat für eine belegte Antwort, oder Agents, um Claude Code, Codex, Hermes und OpenClaw unter einem Orchestrator anzudocken."
         }
       ]
     },
@@ -1939,24 +1989,6 @@
         "agents4": "1 Agent",
         "members4": "6"
       },
-      "automation": {
-        "label": "Animierte Demo: Eine einem Agent zugewiesene Board-Aufgabe durchläuft den Task-Ops-Loop und endet in einer Review-Anfrage.",
-        "trigger": "Aufgabe an Agent zugewiesen",
-        "llm": "Migrationsleitfaden entwerfen",
-        "condition": "Checkliste bestanden?",
-        "branchYes": "Ja",
-        "action": "Review anfordern",
-        "actionAlt": "An Owner eskalieren",
-        "run1": "#214",
-        "runTone1": "done",
-        "duration1": "48s",
-        "run2": "#215",
-        "runTone2": "pending",
-        "duration2": "—",
-        "run3": "#216",
-        "runTone3": "running",
-        "duration3": "12s"
-      },
       "hero": {
         "label": "Animierte Demo: Ein Projekt-Chat setzt den Website-Relaunch mit den Anweisungen und Dateien des Projekts als Kontext fort; der Agent antwortet mit Zitaten.",
         "prompt": "Was fehlt noch, bevor der Relaunch live geht?",
@@ -1990,6 +2022,24 @@
         "audit2": "Pricing-Seite veröffentlicht",
         "audit3": "Aufgabe #212 auf dem Board geschlossen",
         "budgetValue": "CHF 120 / 400"
+      },
+      "tasks": {
+        "label": "Animierte Demo: Das Website-Relaunch-Board — der Relaunch Agent arbeitet an WEB-12 (Migrationsleitfaden) in In progress, während WEB-11 in In review wartet.",
+        "id1": "WEB-14",
+        "title1": "/docs-Redirect-Map fertigstellen",
+        "assignee1": "Nicht zugewiesen",
+        "id2": "WEB-15",
+        "title2": "Pricing-Hero-Copy neu schreiben",
+        "assignee2": "Mira",
+        "id3": "WEB-12",
+        "title3": "Migrationsleitfaden für den Relaunch entwerfen",
+        "assignee3": "Relaunch Agent",
+        "id4": "WEB-11",
+        "title4": "Staging-Checkliste freigeben",
+        "assignee4": "Relaunch Agent",
+        "id5": "WEB-9",
+        "title5": "Brand-Token-Set veröffentlichen",
+        "assignee5": "Design Agent"
       }
     }
   },

--- a/services/web/messages/en.json
+++ b/services/web/messages/en.json
@@ -27,10 +27,10 @@
     },
     "platformAgents": {
       "title": "What are agents in Tale?",
-      "description": "Tale agents combine instructions, knowledge, tools, and a model. Connect Claude Code, Codex, Cursor, and Gemini under one orchestrator you host."
+      "description": "Tale agents combine instructions, knowledge, tools, and a model. Connect Claude Code, Codex, Hermes, and OpenClaw under one orchestrator you host."
     },
     "platformChat": {
-      "title": "What is Chat in Tale?",
+      "title": "Chats in Tale",
       "description": "Tale Chat is the everyday entry point: pick an agent, send a message, and read a streamed reply with citations, tool calls, Arena mode, and in-chat approvals."
     },
     "platformAutomations": {
@@ -74,10 +74,10 @@
       },
       "agents": {
         "label": "Agents",
-        "description": "Orchestrate Claude Code, Codex, Cursor, and Gemini."
+        "description": "Orchestrate Claude Code, Codex, Hermes, and OpenClaw."
       },
       "chat": {
-        "label": "Chat",
+        "label": "Chats",
         "description": "Everyday AI with citations, tools, and Arena."
       },
       "projects": {
@@ -153,7 +153,7 @@
   "home": {
     "hero": {
       "title": "Orchestrate every AI agent on your stack",
-      "subtitle": "Connect Claude Code, Codex, Cursor, and the rest of your team's agents. Pool their knowledge, delegate real work — on infrastructure you run.",
+      "subtitle": "Connect Claude Code, Codex, Hermes, OpenClaw, and the rest of your team's agents. Pool their knowledge, delegate real work — on infrastructure you run.",
       "ctaPrimary": "Request a demo",
       "ctaSecondary": "Contact us"
     },
@@ -179,7 +179,7 @@
         "inputPlaceholder": "Ask anything…"
       },
       "connect": {
-        "label": "Animated demo: the Agents list shows Claude Code, Codex, Cursor, Support Agent, and Gemini as installed rows with model chips.",
+        "label": "Animated demo: the Agents list shows Claude Code, Codex, Hermes, Support Agent, and OpenClaw as installed rows with model chips.",
         "windowTitle": "Agents",
         "searchPlaceholder": "Search agents…",
         "addLabel": "Agents",
@@ -189,14 +189,14 @@
         "statusReady": "Ready",
         "agent1": "Claude Code",
         "agent2": "Codex",
-        "agent3": "Cursor",
+        "agent3": "Hermes",
         "agent4": "Support Agent",
-        "agent5": "Gemini",
+        "agent5": "OpenClaw",
         "model1": "Claude Opus",
         "model2": "GPT-5.5",
-        "model3": "Composer",
+        "model3": "Claude Sonnet",
         "model4": "Claude Sonnet",
-        "model5": "Gemini 2.5"
+        "model5": "Claude Opus"
       },
       "knowledge": {
         "label": "Animated demo: the Knowledge documents table indexes a PDF, a website, a product catalog, and a runbook, then shows indexed status badges.",
@@ -299,6 +299,52 @@
         "members2": "14",
         "members3": "5",
         "members4": "11"
+      },
+      "tasks": {
+        "windowTitle": "Tasks",
+        "colTodo": "To do",
+        "colInProgress": "In progress",
+        "colInReview": "In review",
+        "colDone": "Done",
+        "working": "Working",
+        "label": "Animated demo: the project task board shows To do, In progress, In review, and Done lanes — an agent works a card in In progress.",
+        "id1": "WEB-14",
+        "title1": "Map /docs redirects",
+        "assignee1": "Unassigned",
+        "id2": "WEB-15",
+        "title2": "Draft pricing page copy",
+        "assignee2": "Mira",
+        "id3": "WEB-12",
+        "title3": "Write migration guide",
+        "assignee3": "Relaunch Agent",
+        "id4": "WEB-11",
+        "title4": "Review staging checklist",
+        "assignee4": "Relaunch Agent",
+        "id5": "WEB-9",
+        "title5": "Ship brand tokens",
+        "assignee5": "Design Agent"
+      },
+      "sandbox": {
+        "filesTab": "Files",
+        "liveTab": "Live",
+        "treeRoot": "workspace",
+        "liveHint": "Live browser view",
+        "label": "Animated demo: a sandbox agent chat opens the Files pane on a Python CLI, then switches to the Live browser view of the running app.",
+        "prompt": "Scaffold a small Python CLI and open it in the browser so I can click through.",
+        "agent": "Claude Code",
+        "model": "Claude Opus",
+        "reply": "Created cli.py and a local preview — Files shows the tree; Live streams the browser.",
+        "file1": "cli.py",
+        "file2": "pyproject.toml",
+        "file3": "tests/test_cli.py",
+        "file4": "README.md",
+        "activeFile": "cli.py",
+        "code1": "import click",
+        "code2": "@click.command()",
+        "code3": "def main():",
+        "code4": "    click.echo(\"ready\")",
+        "browserUrl": "http://127.0.0.1:5173",
+        "browserTitle": "CLI preview · localhost"
       }
     },
     "tour": {
@@ -307,7 +353,7 @@
       "connect": {
         "eyebrow": "Agents & integrations",
         "title": "Bring the agents\nyou already trust",
-        "description": "Claude Code, Codex, Cursor, Gemini — plus Slack, GitHub, Outlook, and the rest of your stack. Nothing gets replaced; everything gets coordinated."
+        "description": "Claude Code, Codex, Hermes, OpenClaw — plus Slack, GitHub, Outlook, and the rest of your stack. Nothing gets replaced; everything gets coordinated."
       },
       "pool": {
         "eyebrow": "Knowledge",
@@ -360,7 +406,7 @@
     },
     "agents": {
       "title": "Works with the agents you run",
-      "subtitle": "Dock Claude Code, Codex, Cursor, Gemini, Hermes, OpenClaw, Pi, and OpenCode under one orchestrator you host."
+      "subtitle": "Dock Claude Code, Codex, Hermes, OpenClaw, Pi, and OpenCode under one orchestrator you host."
     },
     "compliance": {
       "eyebrow": "SECURITY",
@@ -768,7 +814,7 @@
           "id": "agents",
           "eyebrow": "Agents",
           "title": "Every agent,\none roster",
-          "description": "Claude Code, Codex, Cursor, Gemini — docked beside in-product agents so work routes to the tool your team already runs."
+          "description": "Claude Code, Codex, Hermes, OpenClaw — docked beside in-product agents so work routes to the tool your team already runs."
         },
         {
           "id": "knowledge",
@@ -819,7 +865,7 @@
         },
         {
           "q": "Where should I start?",
-          "a": "Open Chat to try a grounded reply, or Agents to dock Claude Code, Codex, Cursor, and Gemini under one orchestrator."
+          "a": "Open Chat to try a grounded reply, or Agents to dock Claude Code, Codex, Hermes, and OpenClaw under one orchestrator."
         }
       ]
     },
@@ -922,7 +968,7 @@
   "platformAgents": {
     "eyebrow": "Agents",
     "title": "What are agents in Tale?",
-    "description": "A Tale agent is the four-knob combination of instructions, knowledge, tools, and a model. Editors build them once; the team runs them in chat, automations, and projects — including external agents like Claude Code, Codex, Cursor, and Gemini.",
+    "description": "A Tale agent is the four-knob combination of instructions, knowledge, tools, and a model. Editors build them once; the team runs them in chat, automations, and projects — including external agents like Claude Code, Codex, Hermes, and OpenClaw.",
     "capabilities": {
       "heading": "What can agents do?",
       "description": "What one agent definition gives the whole team — and what it adds beyond a bare model.",
@@ -934,7 +980,7 @@
         },
         {
           "title": "External agents dock in",
-          "body": "Connect Claude Code, Codex, Cursor, and Gemini so work routes to the agent that already lives in your stack.",
+          "body": "Connect Claude Code, Codex, Hermes, and OpenClaw so work routes to the agent that already lives in your stack.",
           "docsLabel": "External agents"
         },
         {
@@ -962,8 +1008,8 @@
           "a": "A Tale agent combines instructions, knowledge, tools, and a model into one reusable unit that Members run in chat and automations."
         },
         {
-          "q": "Can Tale orchestrate Claude Code and Cursor?",
-          "a": "Yes. Tale connects external agents such as Claude Code, Codex, Cursor, and Gemini so your team routes work through one orchestrator."
+          "q": "Can Tale orchestrate Claude Code and Hermes?",
+          "a": "Yes. Tale connects external agents such as Claude Code, Codex, Hermes, and OpenClaw so your team routes work through one orchestrator."
         },
         {
           "q": "When should I use an agent instead of a workflow?",
@@ -1021,9 +1067,9 @@
         },
         {
           "id": "chat",
-          "eyebrow": "Chat",
-          "title": "Hand threads between\nspecialists mid-flight",
-          "description": "When a conversation leaves one agent's domain, delegation passes it on — transcript, citations, and tools intact."
+          "eyebrow": "Sandbox",
+          "title": "Watch the agent\nin Files and Live",
+          "description": "External agents work in a sandbox — browse the workspace tree, open the file they just wrote, and watch the live browser as they click through the result."
         }
       ]
     },
@@ -1057,20 +1103,6 @@
         "runTone3": "running",
         "duration3": "0.8s"
       },
-      "hero": {
-        "label": "Animated demo: a thread that started with the Support Agent is delegated to the Docs Agent, which answers with the offline install checklist and two cited sources.",
-        "prompt": "The Basel pilot needs our offline install checklist before Friday — what do we send?",
-        "routedTitle": "Delegated to Docs Agent",
-        "routedDetail": "Handed off by Support Agent — transcript intact.",
-        "reply1": "Send the air-gapped install guide, v2.3 or later.",
-        "reply2": "It covers the offline model registry and license activation.",
-        "reply3": "Attach the hardware sizing sheet for their 40-user pilot,",
-        "reply4": "and flag that DNS-free setup needs the appliance image.",
-        "citation1": "airgap-install.pdf",
-        "citation2": "Pilot requirements",
-        "composerAgentRouted": "Docs Agent",
-        "composerModel": "Claude Opus"
-      },
       "connect": {
         "label": "Animated demo: the Agents list for this page — Support Agent, Docs Agent, Release Agent, Research Agent, and Pilot Agent, each with its model.",
         "agent1": "Support Agent",
@@ -1098,12 +1130,30 @@
         "project4": "Release train",
         "agents4": "3 agents",
         "members4": "7"
+      },
+      "sandbox": {
+        "label": "Animated demo: Hermes edits install_offline.py in the Files pane, then the Live browser shows the air-gapped install checklist.",
+        "prompt": "Fix the offline install script and show me the checklist page in the live browser.",
+        "agent": "Hermes",
+        "model": "Claude Sonnet",
+        "reply": "Patched the registry path — Files has the diff; Live is on the checklist.",
+        "file1": "install_offline.py",
+        "file2": "registry.json",
+        "file3": "docs/checklist.md",
+        "file4": "Dockerfile",
+        "activeFile": "install_offline.py",
+        "code1": "def resolve_registry(path):",
+        "code2": "    root = Path(path).expanduser()",
+        "code3": "    if not root.exists():",
+        "code4": "        raise SystemExit(\"missing registry\")",
+        "browserUrl": "http://127.0.0.1:8787/checklist",
+        "browserTitle": "Air-gapped install checklist"
       }
     }
   },
   "platformChat": {
-    "eyebrow": "Chat",
-    "title": "What is Chat in Tale?",
+    "eyebrow": "Chats",
+    "title": "Chats in Tale",
     "description": "Chat is the everyday entry point: pick an agent (or none), type, and a reply streams back with citations, tool calls, and optional Arena comparisons — the surface every other platform module feeds.",
     "capabilities": {
       "heading": "What does Chat include?",
@@ -1755,24 +1805,6 @@
         "agents4": "1 agent",
         "members4": "6"
       },
-      "automation": {
-        "label": "Animated demo: a board task assigned to an agent runs the task-ops loop and ends in a review request.",
-        "trigger": "Task assigned to agent",
-        "llm": "Draft migration guide",
-        "condition": "Checklist passed?",
-        "branchYes": "Yes",
-        "action": "Request review",
-        "actionAlt": "Escalate to owner",
-        "run1": "#214",
-        "runTone1": "done",
-        "duration1": "48s",
-        "run2": "#215",
-        "runTone2": "pending",
-        "duration2": "—",
-        "run3": "#216",
-        "runTone3": "running",
-        "duration3": "12s"
-      },
       "hero": {
         "label": "Animated demo: a project chat resumes the website relaunch with the project's instructions and files as context; the agent answers with citations.",
         "prompt": "What's left before the relaunch goes live?",
@@ -1806,6 +1838,24 @@
         "audit2": "Pricing page published",
         "audit3": "Task #212 closed on the board",
         "budgetValue": "CHF 120 / 400"
+      },
+      "tasks": {
+        "label": "Animated demo: the Website relaunch board — Relaunch Agent works WEB-12 (migration guide) in In progress while WEB-11 waits in In review.",
+        "id1": "WEB-14",
+        "title1": "Finish /docs redirect map",
+        "assignee1": "Unassigned",
+        "id2": "WEB-15",
+        "title2": "Rewrite pricing hero copy",
+        "assignee2": "Mira",
+        "id3": "WEB-12",
+        "title3": "Draft migration guide for relaunch",
+        "assignee3": "Relaunch Agent",
+        "id4": "WEB-11",
+        "title4": "Sign off staging checklist",
+        "assignee4": "Relaunch Agent",
+        "id5": "WEB-9",
+        "title5": "Publish brand token set",
+        "assignee5": "Design Agent"
       }
     }
   },

--- a/services/web/messages/fr.json
+++ b/services/web/messages/fr.json
@@ -27,10 +27,10 @@
     },
     "platformAgents": {
       "title": "Que sont les agents dans Tale ?",
-      "description": "Les agents Tale combinent instructions, connaissances, outils et modèle. Connecte Claude Code, Codex, Cursor et Gemini sous un orchestrateur que tu héberges."
+      "description": "Les agents Tale combinent instructions, connaissances, outils et modèle. Connecte Claude Code, Codex, Hermes et OpenClaw sous un orchestrateur que tu héberges."
     },
     "platformChat": {
-      "title": "Qu’est-ce que Chat dans Tale ?",
+      "title": "Chats dans Tale",
       "description": "Tale Chat, l’entrée du quotidien : choisis un agent, envoie un message, lis la réponse — citations, appels d’outils, Arena et approbations dans le fil."
     },
     "platformAutomations": {
@@ -74,10 +74,10 @@
       },
       "agents": {
         "label": "Agents",
-        "description": "Orchestrer Claude Code, Codex, Cursor et Gemini."
+        "description": "Orchestrer Claude Code, Codex, Hermes et OpenClaw."
       },
       "chat": {
-        "label": "Chat",
+        "label": "Chats",
         "description": "IA du quotidien avec citations, outils et Arena."
       },
       "projects": {
@@ -153,7 +153,7 @@
   "home": {
     "hero": {
       "title": "Orchestre chaque agent IA de ta stack",
-      "subtitle": "Connecte Claude Code, Codex, Cursor et les autres agents de ton équipe. Mets leur savoir en commun, délègue du vrai travail — sur une infrastructure que tu fais tourner.",
+      "subtitle": "Connecte Claude Code, Codex, Hermes, OpenClaw et les autres agents de ton équipe. Mets leur savoir en commun, délègue du vrai travail — sur une infrastructure que tu fais tourner.",
       "ctaPrimary": "Demander une démo",
       "ctaSecondary": "Nous contacter"
     },
@@ -179,7 +179,7 @@
         "inputPlaceholder": "Pose ta question…"
       },
       "connect": {
-        "label": "Démo animée : la liste Agents montre Claude Code, Codex, Cursor, Agent Support et Gemini comme lignes installées avec des chips de modèle.",
+        "label": "Démo animée : la liste Agents montre Claude Code, Codex, Hermes, Agent Support et OpenClaw comme lignes installées avec des chips de modèle.",
         "windowTitle": "Agents",
         "searchPlaceholder": "Rechercher des agents…",
         "addLabel": "Agents",
@@ -189,14 +189,14 @@
         "statusReady": "Prêt",
         "agent1": "Claude Code",
         "agent2": "Codex",
-        "agent3": "Cursor",
+        "agent3": "Hermes",
         "agent4": "Agent Support",
-        "agent5": "Gemini",
+        "agent5": "OpenClaw",
         "model1": "Claude Opus",
         "model2": "GPT-5.5",
-        "model3": "Composer",
+        "model3": "Claude Sonnet",
         "model4": "Claude Sonnet",
-        "model5": "Gemini 2.5"
+        "model5": "Claude Opus"
       },
       "knowledge": {
         "label": "Démo animée : la table Documents de la base de connaissances indexe un PDF, un site, un catalogue produits et un runbook, puis affiche les badges d’indexation.",
@@ -299,6 +299,52 @@
         "members2": "14",
         "members3": "5",
         "members4": "11"
+      },
+      "tasks": {
+        "windowTitle": "Tasks",
+        "colTodo": "To do",
+        "colInProgress": "In progress",
+        "colInReview": "In review",
+        "colDone": "Done",
+        "working": "En cours",
+        "label": "Démo animée : le tableau de tâches du projet montre les colonnes To do, In progress, In review et Done — un agent travaille une carte dans In progress.",
+        "id1": "WEB-14",
+        "title1": "Cartographier les redirections /docs",
+        "assignee1": "Non assigné",
+        "id2": "WEB-15",
+        "title2": "Rédiger le texte de la page pricing",
+        "assignee2": "Mira",
+        "id3": "WEB-12",
+        "title3": "Rédiger le guide de migration",
+        "assignee3": "Relaunch Agent",
+        "id4": "WEB-11",
+        "title4": "Relire la checklist staging",
+        "assignee4": "Relaunch Agent",
+        "id5": "WEB-9",
+        "title5": "Livrer les tokens de marque",
+        "assignee5": "Design Agent"
+      },
+      "sandbox": {
+        "filesTab": "Files",
+        "liveTab": "Live",
+        "treeRoot": "workspace",
+        "liveHint": "Vue navigateur live",
+        "label": "Démo animée : un chat d’agent sandbox ouvre le volet Files sur une CLI Python, puis passe à la vue Live du navigateur de l’app en cours.",
+        "prompt": "Scaffold une petite CLI Python et ouvre-la dans le navigateur pour que je puisse cliquer.",
+        "agent": "Claude Code",
+        "model": "Claude Opus",
+        "reply": "cli.py et un aperçu local sont prêts — Files montre l’arbre ; Live streame le navigateur.",
+        "file1": "cli.py",
+        "file2": "pyproject.toml",
+        "file3": "tests/test_cli.py",
+        "file4": "README.md",
+        "activeFile": "cli.py",
+        "code1": "import click",
+        "code2": "@click.command()",
+        "code3": "def main():",
+        "code4": "    click.echo(\"ready\")",
+        "browserUrl": "http://127.0.0.1:5173",
+        "browserTitle": "Aperçu CLI · localhost"
       }
     },
     "tour": {
@@ -307,7 +353,7 @@
       "connect": {
         "eyebrow": "Agents & intégrations",
         "title": "Amène les agents\nque tu utilises déjà",
-        "description": "Claude Code, Codex, Cursor, Gemini — plus Slack, GitHub, Outlook et le reste de ta stack. Rien n’est remplacé ; tout est coordonné."
+        "description": "Claude Code, Codex, Hermes, OpenClaw — plus Slack, GitHub, Outlook et le reste de ta stack. Rien n’est remplacé ; tout est coordonné."
       },
       "pool": {
         "eyebrow": "Connaissances",
@@ -360,7 +406,7 @@
     },
     "agents": {
       "title": "Fonctionne avec les agents que tu utilises",
-      "subtitle": "Accroche Claude Code, Codex, Cursor, Gemini, Hermes, OpenClaw, Pi et OpenCode sous un orchestrateur que tu héberges."
+      "subtitle": "Accroche Claude Code, Codex, Hermes, OpenClaw, Pi et OpenCode sous un orchestrateur que tu héberges."
     },
     "compliance": {
       "eyebrow": "SÉCURITÉ",
@@ -758,7 +804,7 @@
   "platformAgents": {
     "eyebrow": "Agents",
     "title": "Que sont les agents dans Tale ?",
-    "description": "Un agent Tale est la combinaison à quatre boutons d’instructions, connaissances, outils et modèle. Les éditeurs les construisent une fois ; l’équipe les exécute dans Chat, automations et projets — y compris des agents externes comme Claude Code, Codex, Cursor et Gemini.",
+    "description": "Un agent Tale est la combinaison à quatre boutons d’instructions, connaissances, outils et modèle. Les éditeurs les construisent une fois ; l’équipe les exécute dans Chat, automations et projets — y compris des agents externes comme Claude Code, Codex, Hermes et OpenClaw.",
     "capabilities": {
       "heading": "Que peuvent faire les agents ?",
       "description": "Ce qu’une définition d’agent donne à toute l’équipe — et ce qu’elle ajoute par rapport à un modèle nu.",
@@ -770,7 +816,7 @@
         },
         {
           "title": "Les agents externes s’accostent",
-          "body": "Connecte Claude Code, Codex, Cursor et Gemini pour router le travail vers l’agent qui vit déjà dans ta stack.",
+          "body": "Connecte Claude Code, Codex, Hermes et OpenClaw pour router le travail vers l’agent qui vit déjà dans ta stack.",
           "docsLabel": "Agents externes"
         },
         {
@@ -798,8 +844,8 @@
           "a": "Un agent Tale combine instructions, connaissances, outils et modèle en une unité réutilisable que les membres exécutent dans Chat et automations."
         },
         {
-          "q": "Tale peut-il orchestrer Claude Code et Cursor ?",
-          "a": "Oui. Tale connecte des agents externes comme Claude Code, Codex, Cursor et Gemini pour que ton équipe route le travail via un orchestrateur."
+          "q": "Tale peut-il orchestrer Claude Code et Hermes ?",
+          "a": "Oui. Tale connecte des agents externes comme Claude Code, Codex, Hermes et OpenClaw pour que ton équipe route le travail via un orchestrateur."
         },
         {
           "q": "Quand utiliser un agent plutôt qu’un workflow ?",
@@ -857,9 +903,9 @@
         },
         {
           "id": "chat",
-          "eyebrow": "Chat",
-          "title": "Parle aux agents\ndans les fils du quotidien",
-          "description": "Choisis un agent dans Chat, envoie un message, et vois une réponse fondée arriver en streaming avec citations."
+          "eyebrow": "Sandbox",
+          "title": "Regarde l’agent\ndans Files et Live",
+          "description": "Les agents externes travaillent dans un sandbox — parcours l’arbre du workspace, ouvre le fichier qu’ils viennent d’écrire, et suis le navigateur live pendant qu’ils cliquent dans le résultat."
         }
       ]
     },
@@ -893,20 +939,6 @@
         "runTone3": "running",
         "duration3": "0,8 s"
       },
-      "hero": {
-        "label": "Démo animée : un fil commencé avec l’agent Support est délégué à l’agent Docs, qui répond avec la checklist d’installation hors ligne et deux sources citées.",
-        "prompt": "Le pilote de Bâle veut notre checklist d’installation hors ligne avant vendredi — on envoie quoi ?",
-        "routedTitle": "Délégué à Agent Docs",
-        "routedDetail": "Transmis par l’agent Support — historique intact.",
-        "reply1": "Envoie le guide d’installation air-gapped, version 2.3 ou plus.",
-        "reply2": "Il couvre le registre de modèles hors ligne et l’activation de licence.",
-        "reply3": "Joins la fiche de dimensionnement matériel pour leur pilote à 40 utilisateurs,",
-        "reply4": "et signale que l’installation sans DNS demande l’image appliance.",
-        "citation1": "install-airgap.pdf",
-        "citation2": "Exigences du pilote",
-        "composerAgentRouted": "Agent Docs",
-        "composerModel": "Claude Opus"
-      },
       "connect": {
         "label": "Démo animée : la liste Agents de cette page — agent Support, agent Docs, agent Release, agent Recherche et agent Pilote, chacun avec son modèle.",
         "agent1": "Agent Support",
@@ -934,6 +966,24 @@
         "project4": "Train de release",
         "agents4": "3 agents",
         "members4": "7"
+      },
+      "sandbox": {
+        "label": "Démo animée : Hermes édite install_offline.py dans le volet Files, puis le navigateur Live montre la checklist d’install air-gap.",
+        "prompt": "Corrige le script d’install offline et montre-moi la checklist dans le navigateur live.",
+        "agent": "Hermes",
+        "model": "Claude Sonnet",
+        "reply": "Chemin du registry corrigé — Files a le diff ; Live est sur la checklist.",
+        "file1": "install_offline.py",
+        "file2": "registry.json",
+        "file3": "docs/checklist.md",
+        "file4": "Dockerfile",
+        "activeFile": "install_offline.py",
+        "code1": "def resolve_registry(path):",
+        "code2": "    root = Path(path).expanduser()",
+        "code3": "    if not root.exists():",
+        "code4": "        raise SystemExit(\"missing registry\")",
+        "browserUrl": "http://127.0.0.1:8787/checklist",
+        "browserTitle": "Checklist d’install air-gap"
       }
     }
   },
@@ -1115,8 +1165,8 @@
     }
   },
   "platformChat": {
-    "eyebrow": "Chat",
-    "title": "Qu’est-ce que Chat dans Tale ?",
+    "eyebrow": "Chats",
+    "title": "Chats dans Tale",
     "description": "Chat est le point d’entrée quotidien : choisis un agent (ou aucun), tape, et une réponse arrive en streaming avec citations, appels d’outils et comparaisons Arena optionnelles — la surface dans laquelle chaque autre module plateforme alimente.",
     "capabilities": {
       "heading": "Que comprend Chat ?",
@@ -1483,7 +1533,7 @@
           "id": "agents",
           "eyebrow": "Agents",
           "title": "Chaque agent,\nun seul roster",
-          "description": "Claude Code, Codex, Cursor, Gemini — accrochés à côté des agents produit pour router le travail vers l’outil que ton équipe utilise déjà."
+          "description": "Claude Code, Codex, Hermes, OpenClaw — accrochés à côté des agents produit pour router le travail vers l’outil que ton équipe utilise déjà."
         },
         {
           "id": "knowledge",
@@ -1534,7 +1584,7 @@
         },
         {
           "q": "Par où commencer ?",
-          "a": "Ouvre Chat pour une réponse fondée, ou Agents pour accrocher Claude Code, Codex, Cursor et Gemini sous un seul orchestrateur."
+          "a": "Ouvre Chat pour une réponse fondée, ou Agents pour accrocher Claude Code, Codex, Hermes et OpenClaw sous un seul orchestrateur."
         }
       ]
     },
@@ -1939,24 +1989,6 @@
         "agents4": "1 agent",
         "members4": "6"
       },
-      "automation": {
-        "label": "Démo animée : une tâche du tableau assignée à un agent traverse la boucle task-ops et se termine par une demande de revue.",
-        "trigger": "Tâche assignée à l’agent",
-        "llm": "Rédiger le guide de migration",
-        "condition": "Checklist validée ?",
-        "branchYes": "Oui",
-        "action": "Demander une revue",
-        "actionAlt": "Escalader au responsable",
-        "run1": "#214",
-        "runTone1": "done",
-        "duration1": "48s",
-        "run2": "#215",
-        "runTone2": "pending",
-        "duration2": "—",
-        "run3": "#216",
-        "runTone3": "running",
-        "duration3": "12s"
-      },
       "hero": {
         "label": "Démo animée : un chat de projet reprend la refonte du site avec les instructions et fichiers du projet en contexte ; l’agent répond avec des citations.",
         "prompt": "Que reste-t-il avant la mise en ligne de la refonte ?",
@@ -1990,6 +2022,24 @@
         "audit2": "Page tarifs publiée",
         "audit3": "Tâche #212 fermée sur le tableau",
         "budgetValue": "CHF 120 / 400"
+      },
+      "tasks": {
+        "label": "Démo animée : le board Website relaunch — Relaunch Agent travaille WEB-12 (guide de migration) dans In progress pendant que WEB-11 attend dans In review.",
+        "id1": "WEB-14",
+        "title1": "Finir la carte de redirections /docs",
+        "assignee1": "Non assigné",
+        "id2": "WEB-15",
+        "title2": "Réécrire le hero de la page pricing",
+        "assignee2": "Mira",
+        "id3": "WEB-12",
+        "title3": "Rédiger le guide de migration du relaunch",
+        "assignee3": "Relaunch Agent",
+        "id4": "WEB-11",
+        "title4": "Valider la checklist staging",
+        "assignee4": "Relaunch Agent",
+        "id5": "WEB-9",
+        "title5": "Publier le set de tokens de marque",
+        "assignee5": "Design Agent"
       }
     }
   },

--- a/services/web/tests/e2e/specs/home-demos.spec.ts
+++ b/services/web/tests/e2e/specs/home-demos.spec.ts
@@ -184,7 +184,7 @@ test.describe('feature page demo scenarios', () => {
     );
   });
 
-  test('agents page shows its own roster and delegates a thread', async ({
+  test('agents page shows its own roster and a sandbox Files/Live pane', async ({
     page,
   }) => {
     await page.goto('/platform/agents');
@@ -204,14 +204,17 @@ test.describe('feature page demo scenarios', () => {
       t('platformAgents.demos.projects.project1'),
     );
 
-    const chat = page.getByRole('img', {
-      name: t('platformAgents.demos.hero.label'),
+    const sandbox = page.getByRole('img', {
+      name: t('platformAgents.demos.sandbox.label'),
     });
-    await chat.scrollIntoViewIfNeeded();
-    await expect(chat).toContainText(
-      t('platformAgents.demos.hero.routedTitle'),
+    await sandbox.scrollIntoViewIfNeeded();
+    await expect(sandbox).toContainText(
+      t('platformAgents.demos.sandbox.browserTitle'),
     );
-    await expect(chat).toContainText(t('platformAgents.demos.hero.citation2'));
+    await expect(sandbox).toContainText(
+      t('platformAgents.demos.sandbox.activeFile'),
+    );
+    await expect(sandbox).not.toContainText(t('home.demos.sandbox.prompt'));
   });
 
   test('governance page holds a knowledge write for approval', async ({
@@ -360,13 +363,12 @@ test.describe('feature page demo scenarios', () => {
     await expect(hero).not.toContainText(t('home.demos.projects.project1'));
 
     const tasks = page.getByRole('img', {
-      name: t('platformProjects.demos.automation.label'),
+      name: t('platformProjects.demos.tasks.label'),
     });
     await tasks.scrollIntoViewIfNeeded();
-    await expect(tasks).toContainText(
-      t('platformProjects.demos.automation.trigger'),
-    );
-    await expect(tasks).not.toContainText(t('home.demos.automation.trigger'));
+    await expect(tasks).toContainText(t('platformProjects.demos.tasks.id3'));
+    await expect(tasks).toContainText(t('platformProjects.demos.tasks.title3'));
+    await expect(tasks).not.toContainText(t('home.demos.tasks.title3'));
 
     const chat = page.getByRole('img', {
       name: t('platformProjects.demos.hero.label'),


### PR DESCRIPTION
## Summary
- Add **TaskBoard** and **SandboxWorkspace** marketing demos; wire them into the Projects tasks tour and Agents chat tour.
- Feature **Hermes / OpenClaw** in agent-list marketing copy (replacing Cursor / Gemini in those lists).
- Rename nav **Chat → Chats**; page/SEO heading **Chats in Tale**.
- Treat **DemoShell** as an illustration for a11y/SEO (`role="img"`, `aria-hidden` + `inert`, `data-nosnippet`) with a unit contract test.

## Test plan
- [x] `bun run --filter @tale/web test app/components/blocks/demos/demo-shell.test.tsx`
- [ ] Spot-check `/`, `/platform/projects`, `/platform/agents` locally (demos animate; reduced-motion end states)
- [ ] Confirm nav shows **Chats** and Chat page H1 is **Chats in Tale** (en / de / fr)
- [ ] CI: format, lint, typecheck, web e2e `home-demos.spec.ts`

## Definition of done
- [x] Locales — en / de / fr updated for new demo chrome/scenarios, nav, titles
- [x] Docs — `design/web.md` DemoShell contract updated
- [x] Accessibility — DemoShell illustration contract (+ unit test)
- [x] Tests — demo-shell unit; e2e assertions updated for new demos
- [x] Migration — N/A
- [ ] Green gate — full `bun run check` deferred to CI
- [x] Sweep — agent-list copy + demo wiring sites updated
- [x] Commits — conventional, branched off main


Made with [Cursor](https://cursor.com)