### PR TITLE
feat(platform): outcome slots and resolve agent i18n display names

### DIFF
--- a/services/platform/app/features/automations/hooks/use-automation-agent-readiness.ts
+++ b/services/platform/app/features/automations/hooks/use-automation-agent-readiness.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { useMemo } from 'react';
 
 import { useActionQuery } from '@/app/hooks/use-action-query';
@@ -99,10 +100,15 @@ export function useAutomationAgentReadiness(
   isLoading: boolean;
   refetch: () => void;
 } {
+  const { locale } = useLocale();
   const q = useActionQuery(
-    ['automations', 'agent-readiness', organizationId, automationSlug],
+    ['automations', 'agent-readiness', organizationId, automationSlug, locale],
     api.automations.agent_readiness.getAutomationAgentReadiness,
-    { organizationId, automationSlug: automationSlug },
+    {
+      organizationId,
+      automationSlug: automationSlug,
+      locale,
+    },
     { enabled: enabled && organizationId !== '' && automationSlug !== '' },
   );
 

--- a/services/platform/app/features/automations/registry/connected/agent-list.tsx
+++ b/services/platform/app/features/automations/registry/connected/agent-list.tsx
@@ -13,6 +13,7 @@
 import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { Card } from '@tale/ui/card';
+import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { HStack, VStack } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Text } from '@tale/ui/text';
@@ -95,6 +96,7 @@ function AuthModeToggle({
 
 export function AgentList({ title, agents, roles }: AgentListProps) {
   const { t } = useT('automations');
+  const { locale } = useLocale();
   const { automationSlug } = useAutomationRuntime();
   const list = useBoundAction(
     'agents/file_actions:listAutomationAgents',
@@ -167,6 +169,7 @@ export function AgentList({ title, agents, roles }: AgentListProps) {
         const result = await listRef.current.dispatch({
           organizationId: '$orgId',
           automationSlug,
+          locale,
         });
         const all = Array.isArray(result) ? result.filter(isRecord) : [];
         // The action already scopes to this automation's agents; `agents` is only an
@@ -191,7 +194,7 @@ export function AgentList({ title, agents, roles }: AgentListProps) {
     return () => {
       cancelled = true;
     };
-  }, [agents, automationSlug]);
+  }, [agents, automationSlug, locale]);
 
   const roleOf = (slug: string): string | undefined => {
     if (!roles) return undefined;

--- a/services/platform/app/features/operator/components/outcome-strip.test.tsx
+++ b/services/platform/app/features/operator/components/outcome-strip.test.tsx
@@ -169,15 +169,112 @@ describe('OutcomeStrip', () => {
     expect(screen.queryAllByText('Done')).toHaveLength(0);
   });
 
-  it('keeps an Outcome placeholder while the run is in flight and files are not ready', () => {
+  it('promises a muted slot per upcoming outcome step while the run is in flight', () => {
     render(
       <OutcomeStrip
         projection={projection({
           status: 'running',
           steps: [
             {
-              stepSlug: 'publish_return',
-              name: 'File return.xml',
+              stepSlug: 'publish_a',
+              name: 'File artifact A into the folder',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'upcoming',
+              params: { surface: 'outcome' },
+              promisedTitle: 'a.xml',
+            },
+            {
+              stepSlug: 'publish_b',
+              name: 'File artifact B overview',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'upcoming',
+              params: { surface: 'outcome' },
+              promisedTitle: 'b.md',
+            },
+            {
+              stepSlug: 'publish_c',
+              name: 'File artifact C',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'upcoming',
+              params: { surface: 'outcome' },
+              promisedTitle: 'c.csv',
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('Outcome')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Working — results will appear here.'),
+    ).toBeNull();
+    expect(screen.getByText('a.xml')).toBeInTheDocument();
+    expect(screen.getByText('b.md')).toBeInTheDocument();
+    expect(screen.getByText('c.csv')).toBeInTheDocument();
+    expect(screen.getByText('Not ready yet.')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('promises outcome slots when publish steps were skipped after the run parked for input', () => {
+    // A completed run can leave earlier outcome steps `skipped` (routed around)
+    // while the desk still waits on operator input for a follow-up pass.
+    render(
+      <OutcomeStrip
+        projection={projection({
+          status: 'completed',
+          steps: [
+            {
+              stepSlug: 'publish_a',
+              name: 'File artifact A into the folder',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'skipped',
+              params: { surface: 'outcome' },
+              promisedTitle: 'a.xml',
+            },
+            {
+              stepSlug: 'publish_b',
+              name: 'File artifact B overview',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'skipped',
+              params: { surface: 'outcome' },
+              promisedTitle: 'b.md',
+            },
+            {
+              stepSlug: 'publish_c',
+              name: 'File artifact C',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'skipped',
+              params: { surface: 'outcome' },
+              promisedTitle: 'c.csv',
+            },
+          ],
+        })}
+      />,
+    );
+    expect(
+      screen.queryByText(
+        'No results yet — they will appear here once a run produces them.',
+      ),
+    ).toBeNull();
+    expect(screen.getByText('a.xml')).toBeInTheDocument();
+    expect(screen.getByText('b.md')).toBeInTheDocument();
+    expect(screen.getByText('c.csv')).toBeInTheDocument();
+  });
+
+  it('falls back to the step name when no promisedTitle was authored', () => {
+    render(
+      <OutcomeStrip
+        projection={projection({
+          status: 'running',
+          steps: [
+            {
+              stepSlug: 'publish_summary',
+              name: 'Publish the summary artifact',
               stepType: 'action',
               render: 'artifact',
               partState: 'upcoming',
@@ -187,10 +284,46 @@ describe('OutcomeStrip', () => {
         })}
       />,
     );
-    expect(screen.getByText('Outcome')).toBeInTheDocument();
     expect(
-      screen.getByText('Working — results will appear here.'),
+      screen.getByText('Publish the summary artifact'),
     ).toBeInTheDocument();
+  });
+
+  it('keeps ready artifacts next to still-pending outcome slots', () => {
+    render(
+      <OutcomeStrip
+        projection={projection({
+          status: 'running',
+          steps: [
+            {
+              stepSlug: 'publish_a',
+              name: 'File artifact A into the folder',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'output_available',
+              params: { surface: 'outcome' },
+              output: {
+                title: 'a.xml',
+                documentId: 'd1',
+                fileId: 'f1',
+                action: 'created',
+              },
+            },
+            {
+              stepSlug: 'publish_b',
+              name: 'File artifact B overview',
+              stepType: 'action',
+              render: 'artifact',
+              partState: 'upcoming',
+              params: { surface: 'outcome' },
+              promisedTitle: 'b.md',
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'a.xml' })).toBeInTheDocument();
+    expect(screen.getByText('b.md')).toBeInTheDocument();
   });
 
   it('keeps the Outcome lane as an empty-state placeholder when a settled run produced no files', () => {
@@ -214,6 +347,8 @@ describe('OutcomeStrip', () => {
     // A settled run with an outcome-annotated step but no files/errors renders
     // the Outcome section as a stable placeholder rather than vanishing.
     expect(screen.getByText('Outcome')).toBeInTheDocument();
+    expect(screen.queryByText('File return.xml')).toBeNull();
+    expect(screen.queryByText('Not ready yet.')).toBeNull();
     expect(
       screen.getByText(
         'No results yet — they will appear here once a run produces them.',

--- a/services/platform/app/features/operator/components/outcome-strip.tsx
+++ b/services/platform/app/features/operator/components/outcome-strip.tsx
@@ -2,20 +2,24 @@
 
 /**
  * Outcome strip — promotes steps annotated `ui.params.surface: "outcome"` into
- * a first-class, always-expanded section (peer of Input). Document artifacts
- * open via `DocumentPreviewDialog` (preview first, download from the dialog) —
+ * a first-class, always-expanded section (peer of Input). While a run is in
+ * flight, every outcome step is a promised slot (muted name + pulse); once a
+ * step lands, that row becomes the openable artifact. Document artifacts open
+ * via `DocumentPreviewDialog` (preview first, download from the dialog) —
  * same path as Documents / Project files. Non-document files with a resolved
  * storage URL keep a direct link as a fallback.
  */
 import { Card } from '@tale/ui/card';
 import { Row, VStack } from '@tale/ui/layout';
+import { StatusIndicator } from '@tale/ui/status-indicator';
 import { Text } from '@tale/ui/text';
 import { PackageCheck } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import { MarkdownContent } from '@/app/features/chat/components/message-bubble/markdown-renderer';
 import { DocumentPreviewDialog } from '@/app/features/documents/components/document-preview-dialog';
 import { useT } from '@/lib/i18n/client';
+import type { PartState } from '@/lib/shared/platform/part_state';
 import { resolveSurface } from '@/lib/shared/platform/render_kinds';
 
 import { parseDocumentArtifact } from '../lib/document-artifact';
@@ -31,6 +35,44 @@ function outcomeSteps(projection: OperatorProjection): StepProjection[] {
 function stepTitle(step: StepProjection): string {
   const doc = parseDocumentArtifact(step.output);
   return doc?.title ?? step.name;
+}
+
+/** Pending/skipped Outcome row label — pack-authored title when present. */
+function slotLabel(step: StepProjection): string {
+  return step.promisedTitle ?? step.name;
+}
+
+/** Step is actively working — show a slot even if projection status lagged. */
+const ACTIVE_PENDING_STATES = new Set<PartState>([
+  'running',
+  'loading',
+  'queued_capacity',
+  'waiting_external',
+  'waiting_human',
+]);
+
+/**
+ * Promised deliverable rows. `skipped` always counts: a run can complete (or
+ * park for operator input) after routing around earlier outcome steps — the
+ * spine marks those `skipped`, but the Outcome lane still names what a later
+ * successful pass will file. `upcoming` / `empty` only while the run is alive
+ * (settled leftovers keep the empty copy).
+ */
+function isPendingSlot(step: StepProjection, runInFlight: boolean): boolean {
+  if (
+    step.partState === 'output_available' ||
+    step.partState === 'output_error'
+  ) {
+    return false;
+  }
+  if (ACTIVE_PENDING_STATES.has(step.partState)) return true;
+  if (step.partState === 'skipped') return true;
+  if (!runInFlight) return false;
+  return step.partState === 'upcoming' || step.partState === 'empty';
+}
+
+function slotShouldPulse(step: StepProjection, runInFlight: boolean): boolean {
+  return runInFlight || ACTIVE_PENDING_STATES.has(step.partState);
 }
 
 type PreviewTarget = {
@@ -49,39 +91,31 @@ type OutcomeEntry =
     }
   | { kind: 'href'; key: string; name: string; url: string };
 
-function entriesForReadySteps(ready: StepProjection[]): {
+function entriesForReadyStep(step: StepProjection): {
   entries: OutcomeEntry[];
-  textOnly: StepProjection[];
+  textOnly: boolean;
 } {
   const entries: OutcomeEntry[] = [];
-  const covered = new Set<string>();
-
-  for (const step of ready) {
-    const doc = parseDocumentArtifact(step.output);
-    if (doc) {
-      covered.add(step.stepSlug);
-      entries.push({
-        kind: 'preview',
-        key: step.stepSlug,
-        name: doc.title,
-        documentId: doc.documentId,
-        fileId: doc.fileId,
-      });
-      continue;
-    }
-    for (const file of step.files ?? []) {
-      covered.add(step.stepSlug);
-      entries.push({
-        kind: 'href',
-        key: `${step.stepSlug}:${file.url}`,
-        name: file.name,
-        url: file.url,
-      });
-    }
+  const doc = parseDocumentArtifact(step.output);
+  if (doc) {
+    entries.push({
+      kind: 'preview',
+      key: step.stepSlug,
+      name: doc.title,
+      documentId: doc.documentId,
+      fileId: doc.fileId,
+    });
+    return { entries, textOnly: false };
   }
-
-  const textOnly = ready.filter((step) => !covered.has(step.stepSlug));
-  return { entries, textOnly };
+  for (const file of step.files ?? []) {
+    entries.push({
+      kind: 'href',
+      key: `${step.stepSlug}:${file.url}`,
+      name: file.name,
+      url: file.url,
+    });
+  }
+  return { entries, textOnly: entries.length === 0 };
 }
 
 const openClassName =
@@ -98,38 +132,101 @@ export function OutcomeStrip({
   // No pack annotation → omit entirely (not an empty card).
   if (steps.length === 0) return null;
 
-  const errors = steps.filter((s) => s.partState === 'output_error');
-  const ready = steps.filter((s) => s.partState === 'output_available');
-  const pending = steps.filter(
-    (s) =>
-      s.partState === 'running' ||
-      s.partState === 'loading' ||
-      s.partState === 'queued_capacity' ||
-      s.partState === 'waiting_external' ||
-      s.partState === 'waiting_human',
-  );
-  // Publish steps often stay `upcoming` until late in the run — still reserve
-  // the Outcome lane while the execution is in flight so operators know where
-  // files will land.
   const runInFlight =
     projection.status === 'running' || projection.status === 'pending';
-  const awaitingFiles =
-    ready.length === 0 &&
-    errors.length === 0 &&
-    (pending.length > 0 || runInFlight);
-  // A settled run with no outcome files/errors keeps the Outcome lane too — it
-  // renders an empty-state placeholder rather than vanishing, so the section is
-  // a stable peer of Input whether or not this run produced anything yet.
-  const noOutputYet = ready.length === 0 && errors.length === 0;
 
-  const { entries, textOnly } = entriesForReadySteps(ready);
+  const rows: ReactNode[] = [];
+  let hasReadyOrError = false;
+  let hasPendingSlot = false;
+
+  for (const step of steps) {
+    if (step.partState === 'output_error') {
+      hasReadyOrError = true;
+      rows.push(
+        <li key={step.stepSlug}>
+          <Text variant="muted" className="text-destructive">
+            {step.node?.error ??
+              t('outcome.failed', {
+                defaultValue: 'This step failed.',
+              })}
+          </Text>
+        </li>,
+      );
+      continue;
+    }
+
+    if (step.partState === 'output_available') {
+      hasReadyOrError = true;
+      const { entries, textOnly } = entriesForReadyStep(step);
+      for (const entry of entries) {
+        rows.push(
+          <li key={entry.key}>
+            {entry.kind === 'preview' ? (
+              <button
+                type="button"
+                className={`${openClassName} border-none bg-transparent p-0 text-left`}
+                onClick={() =>
+                  setPreview({
+                    documentId: entry.documentId,
+                    fileId: entry.fileId,
+                    fileName: entry.name,
+                  })
+                }
+              >
+                {entry.name}
+              </button>
+            ) : (
+              <a
+                href={entry.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={openClassName}
+              >
+                {entry.name}
+              </a>
+            )}
+          </li>,
+        );
+      }
+      if (textOnly) {
+        const summary = pickString(asRecord(step.output), 'summary');
+        rows.push(
+          <li key={step.stepSlug}>
+            {typeof summary === 'string' && summary.trim() !== '' ? (
+              <MarkdownContent content={summary} />
+            ) : (
+              <Text as="span" className="font-medium">
+                {stepTitle(step)}
+              </Text>
+            )}
+          </li>,
+        );
+      }
+      continue;
+    }
+
+    if (isPendingSlot(step, runInFlight)) {
+      hasPendingSlot = true;
+      const pulse = slotShouldPulse(step, runInFlight);
+      rows.push(
+        <li key={step.stepSlug}>
+          <StatusIndicator variant="neutral" pulse={pulse} size="sm">
+            {slotLabel(step)}
+          </StatusIndicator>
+        </li>,
+      );
+    }
+  }
+
+  const showSettledEmpty =
+    !hasReadyOrError && !hasPendingSlot && rows.length === 0;
 
   return (
     // Same chrome as automation BlockFrame / Input — always expanded, never
     // nested under a "Workflow run" disclosure.
     <Card asChild padding="none" shadow="sm">
       <section>
-        <Row gap={3} align="start" justify="between" className="p-5 pb-3">
+        <Row gap={3} align="center" justify="between" className="p-5 pb-3">
           <div className="flex min-w-0 items-center gap-2.5">
             <Row
               gap={0}
@@ -142,78 +239,32 @@ export function OutcomeStrip({
               {t('section.outcome', { defaultValue: 'Outcome' })}
             </Text>
           </div>
+          {hasPendingSlot && (
+            <Text variant="muted" className="shrink-0 text-sm">
+              {t('outcome.pendingHint', {
+                defaultValue: 'Not ready yet.',
+              })}
+            </Text>
+          )}
         </Row>
         <VStack gap={3} className="px-5 pb-5">
-          {noOutputYet && (
+          {showSettledEmpty && (
             <Text variant="muted">
-              {awaitingFiles
-                ? t('outcome.inProgress', {
-                    defaultValue: 'Working — results will appear here.',
-                  })
-                : t('outcome.empty', {
-                    defaultValue:
-                      'No results yet — they will appear here once a run produces them.',
-                  })}
+              {t('outcome.empty', {
+                defaultValue:
+                  'No results yet — they will appear here once a run produces them.',
+              })}
             </Text>
           )}
 
-          {errors.map((step) => (
-            <Text
-              key={step.stepSlug}
-              variant="muted"
-              className="text-destructive"
+          {rows.length > 0 && (
+            <ul
+              className="flex flex-col gap-2"
+              role={hasPendingSlot ? 'status' : undefined}
             >
-              {step.node?.error ??
-                t('outcome.failed', {
-                  defaultValue: 'This step failed.',
-                })}
-            </Text>
-          ))}
-
-          {entries.length > 0 && (
-            <ul className="flex flex-col gap-2">
-              {entries.map((entry) => (
-                <li key={entry.key}>
-                  {entry.kind === 'preview' ? (
-                    <button
-                      type="button"
-                      className={`${openClassName} border-none bg-transparent p-0 text-left`}
-                      onClick={() =>
-                        setPreview({
-                          documentId: entry.documentId,
-                          fileId: entry.fileId,
-                          fileName: entry.name,
-                        })
-                      }
-                    >
-                      {entry.name}
-                    </button>
-                  ) : (
-                    <a
-                      href={entry.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={openClassName}
-                    >
-                      {entry.name}
-                    </a>
-                  )}
-                </li>
-              ))}
+              {rows}
             </ul>
           )}
-
-          {textOnly.map((step) => {
-            const summary = pickString(asRecord(step.output), 'summary');
-            if (typeof summary === 'string' && summary.trim() !== '') {
-              return <MarkdownContent key={step.stepSlug} content={summary} />;
-            }
-            return (
-              <Text key={step.stepSlug} as="span" className="font-medium">
-                {stepTitle(step)}
-              </Text>
-            );
-          })}
         </VStack>
 
         <DocumentPreviewDialog

--- a/services/platform/app/features/operator/hooks/use-execution-projection.ts
+++ b/services/platform/app/features/operator/hooks/use-execution-projection.ts
@@ -46,6 +46,19 @@ interface DefinitionStep {
   /** The step's own inline i18n (`workflowStepI18nSchema`) — resolved via
    * `resolveWorkflowStepText`; when present it wins over `ui.labelKey`. */
   i18n?: WorkflowStepI18n;
+  /** Literal document-action `parameters.title` (no template) when authored. */
+  promisedTitle?: string;
+}
+
+/** Prefer a concrete file name for Outcome slots; skip templated titles. */
+function parsePromisedTitle(rawConfig: unknown): string | undefined {
+  if (!isRecord(rawConfig) || rawConfig.type !== 'document') return undefined;
+  if (!isRecord(rawConfig.parameters)) return undefined;
+  const title = rawConfig.parameters.title;
+  if (typeof title !== 'string') return undefined;
+  const trimmed = title.trim();
+  if (trimmed === '' || trimmed.includes('{{')) return undefined;
+  return trimmed;
 }
 
 function parseParams(
@@ -115,6 +128,8 @@ function parseDefinitionSteps(config: unknown): DefinitionStep[] {
     if (typeof raw.role === 'string') step.role = raw.role;
     const i18n = parseStepI18n(raw.i18n);
     if (i18n !== undefined) step.i18n = i18n;
+    const promisedTitle = parsePromisedTitle(raw.config);
+    if (promisedTitle !== undefined) step.promisedTitle = promisedTitle;
     out.push(step);
   }
   return out;
@@ -259,6 +274,9 @@ function projectStep(
   }
   if (step.ui?.params !== undefined) projection.params = step.ui.params;
   if (step.role !== undefined) projection.role = step.role;
+  if (step.promisedTitle !== undefined) {
+    projection.promisedTitle = step.promisedTitle;
+  }
   if (node !== undefined) projection.node = node;
   if (opts.liveParts !== undefined && opts.liveParts.length > 0) {
     projection.liveParts = opts.liveParts;

--- a/services/platform/app/features/operator/types.ts
+++ b/services/platform/app/features/operator/types.ts
@@ -68,6 +68,12 @@ export interface StepProjection {
   node?: ExecutionNodeState;
   /** Parsed `node.outputPreview` JSON, when present and parseable. */
   output?: unknown;
+  /**
+   * Literal artifact name from a document-action definition
+   * (`config.parameters.title` with no `{{…}}` template) — Outcome pending /
+   * skipped slots prefer this over the long step name when the pack authored one.
+   */
+  promisedTitle?: string;
 }
 
 /**

--- a/services/platform/convex/agents/config.test.ts
+++ b/services/platform/convex/agents/config.test.ts
@@ -38,6 +38,21 @@ describe('resolveAgentDisplay (Auto-router candidate descriptions)', () => {
     ]);
   });
 
+  it('resolves a pack-style Setup Assistant name from i18n.en only', () => {
+    // Mirrors vat-return-desk/setup-assistant.json — displayName lives only
+    // under i18n; Configuration must not fall back to the file slug.
+    const r = resolveAgentDisplay({
+      ...baseConfig,
+      i18n: {
+        en: {
+          displayName: 'Setup Assistant',
+          description: 'Creates and repairs a client setup.',
+        },
+      },
+    });
+    expect(r.displayName).toBe('Setup Assistant');
+  });
+
   it('prefers the requested locale, falling back to en then top level', () => {
     expect(resolveAgentDisplay(i18nOnly, 'de').description).toBe(
       'Übersetzt Dokumente, Text und Bilder zwischen Sprachen.',

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -46,6 +46,7 @@ import {
 } from '../lib/file_io';
 import { stripNulls } from '../lib/strip_nulls';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
+import { resolveAgentDisplay } from './config';
 import type { AgentJsonConfig, AgentReadResult } from './file_utils';
 import {
   MAX_FILE_SIZE_BYTES,
@@ -374,6 +375,8 @@ export const listAutomationAgents = action({
   args: {
     organizationId: v.string(),
     automationSlug: v.string(),
+    /** UI locale — resolves `i18n.<locale>.displayName` (and description). */
+    locale: v.optional(v.string()),
   },
   returns: v.any(),
   handler: async (ctx, args) => {
@@ -404,11 +407,15 @@ export const listAutomationAgents = action({
         if (!validateAgentName(slug)) return null;
         const result = await readAgentFile(orgSlug, slug);
         if (result.ok) {
+          // Pack agents often keep displayName/description only under `i18n`
+          // (no top-level fields) — resolve them the same way the agent
+          // catalog and router do, or Configuration falls back to the slug.
+          const display = resolveAgentDisplay(result.config, args.locale);
           return {
             name: slug,
             shortName,
-            displayName: result.config.displayName,
-            description: result.config.description,
+            displayName: display.displayName ?? shortName,
+            description: display.description,
             visibleInChat: result.config.visibleInChat,
             primaryBehavior: result.config.primaryBehavior,
             agentKind: result.config.agentKind,
@@ -417,7 +424,7 @@ export const listAutomationAgents = action({
             toolNames: result.config.toolNames,
             integrationBindings: result.config.integrationBindings,
             roleRestriction: result.config.roleRestriction,
-            conversationStarters: result.config.conversationStarters,
+            conversationStarters: display.conversationStarters,
             composerMode: result.config.composerMode,
             isRouter: result.config.isRouter,
             uiConfigurable: result.config.uiConfigurable,

--- a/services/platform/convex/automations/agent_readiness.ts
+++ b/services/platform/convex/automations/agent_readiness.ts
@@ -61,7 +61,12 @@ interface AutomationAgentRow {
 }
 
 export const getAutomationAgentReadiness = action({
-  args: { organizationId: v.string(), automationSlug: v.string() },
+  args: {
+    organizationId: v.string(),
+    automationSlug: v.string(),
+    /** UI locale for resolving pack-agent `i18n` display names. */
+    locale: v.optional(v.string()),
+  },
   returns: v.any(),
   handler: async (ctx, args): Promise<unknown> => {
     await requireOrgMembershipById(ctx, args.organizationId);
@@ -72,6 +77,7 @@ export const getAutomationAgentReadiness = action({
       {
         organizationId: args.organizationId,
         automationSlug: args.automationSlug,
+        ...(args.locale !== undefined && { locale: args.locale }),
       },
     )) as AutomationAgentRow[];
     // Skip malformed-config rows (they carry `status`/`message`, not agent fields).

--- a/services/platform/convex/task_metrics/agent_run_dedup.test.ts
+++ b/services/platform/convex/task_metrics/agent_run_dedup.test.ts
@@ -149,18 +149,18 @@ describe('startTaskAgentRun dedup (park-reentry counter-leak fix)', () => {
       projectId,
       wfExecutionId,
       stepSlug: 'extract_invoices',
-      agentSlug: 'vat-return-desk/invoice-extract',
+      agentSlug: 'vat-return-desk/invoice-reader',
     });
     // A counter the first entry already bumped — the re-acquire must NOT bump it.
     await seedCounter(t, 'org', 1);
-    await seedCounter(t, 'agent:vat-return-desk/invoice-extract', 1);
+    await seedCounter(t, 'agent:vat-return-desk/invoice-reader', 1);
 
     const res = await t.mutation(
       internal.task_metrics.internal_mutations.startTaskAgentRun,
       {
         organizationId: ORG,
         taskId,
-        agentSlug: 'vat-return-desk/invoice-extract',
+        agentSlug: 'vat-return-desk/invoice-reader',
         trigger: 'manual',
         wfExecutionId,
         stepSlug: 'extract_invoices',
@@ -172,7 +172,7 @@ describe('startTaskAgentRun dedup (park-reentry counter-leak fix)', () => {
     expect(res.runId).toBe(existing); // same row, not a duplicate
     expect(await runsFor(t, wfExecutionId)).toHaveLength(1);
     expect(await counter(t, 'org')).toBe(1); // unchanged
-    expect(await counter(t, 'agent:vat-return-desk/invoice-extract')).toBe(1);
+    expect(await counter(t, 'agent:vat-return-desk/invoice-reader')).toBe(1);
   });
 
   it('does NOT dedup a different step of the same execution (distinct logical run)', async () => {

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -42,7 +42,6 @@
       "runDetails": "Laufdetails"
     },
     "outcome": {
-      "inProgress": "Arbeitet — Ergebnisse erscheinen hier.",
       "pendingHint": "Noch nicht fertig.",
       "failed": "Dieser Schritt ist fehlgeschlagen.",
       "empty": "Noch keine Ergebnisse — sie erscheinen hier, sobald ein Lauf welche erzeugt."

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -43,6 +43,7 @@
     },
     "outcome": {
       "inProgress": "Arbeitet — Ergebnisse erscheinen hier.",
+      "pendingHint": "Noch nicht fertig.",
       "failed": "Dieser Schritt ist fehlgeschlagen.",
       "empty": "Noch keine Ergebnisse — sie erscheinen hier, sobald ein Lauf welche erzeugt."
     },

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -50,6 +50,7 @@
     },
     "outcome": {
       "inProgress": "Arbeitet — Ergebnisse erscheinen hier.",
+      "pendingHint": "Noch nicht fertig.",
       "failed": "Dieser Schritt ist fehlgeschlagen.",
       "empty": "Noch keine Ergebnisse — sie erscheinen hier, sobald ein Lauf welche erzeugt."
     },

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -49,7 +49,6 @@
       "runDetails": "Laufdetails"
     },
     "outcome": {
-      "inProgress": "Arbeitet — Ergebnisse erscheinen hier.",
       "pendingHint": "Noch nicht fertig.",
       "failed": "Dieser Schritt ist fehlgeschlagen.",
       "empty": "Noch keine Ergebnisse — sie erscheinen hier, sobald ein Lauf welche erzeugt."

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -44,7 +44,6 @@
       "runDetails": "Run details"
     },
     "outcome": {
-      "inProgress": "Working — results will appear here.",
       "pendingHint": "Not ready yet.",
       "failed": "This step failed.",
       "empty": "No results yet — they will appear here once a run produces them."

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -45,6 +45,7 @@
     },
     "outcome": {
       "inProgress": "Working — results will appear here.",
+      "pendingHint": "Not ready yet.",
       "failed": "This step failed.",
       "empty": "No results yet — they will appear here once a run produces them."
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -49,7 +49,6 @@
       "runDetails": "Détails de l'exécution"
     },
     "outcome": {
-      "inProgress": "En cours — les résultats apparaîtront ici.",
       "pendingHint": "Pas encore prêts.",
       "failed": "Cette étape a échoué.",
       "empty": "Pas encore de résultats — ils apparaîtront ici dès qu’un passage en produit."

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -50,6 +50,7 @@
     },
     "outcome": {
       "inProgress": "En cours — les résultats apparaîtront ici.",
+      "pendingHint": "Pas encore prêts.",
       "failed": "Cette étape a échoué.",
       "empty": "Pas encore de résultats — ils apparaîtront ici dès qu’un passage en produit."
     },


### PR DESCRIPTION
## Summary
- Operator **Outcome** strip lists promised deliverable slots while steps are pending or skipped (with a short pending hint), then swaps in the real previews when ready.
- Automation agent lists / readiness resolve pack `i18n.<locale>.displayName` (and description) so Configuration shows names like Setup Assistant instead of the slug.
- Tests updated for the vat-return-desk agent slug rename (`invoice-reader`).

## Test plan
- [x] `vitest` outcome-strip (client) + agents/config + agent_run_dedup (server)
- [ ] Hard-refresh Configuration → agents show Setup Assistant / Invoice Reader for the current locale
- [ ] Run a VAT desk (or any multi-outcome automation) → Outcome shows named slots while working / after needs_input skip
- [ ] Confirm pulse only while a run is in flight (settled skipped slots stay muted, no pulse)

## Definition of done
- [x] Green gate — focused format + unit tests observed green (full monorepo `check` left to CI)
- [x] Security gate — opengrep on commit clean
- [x] Tests — outcome-strip + config displayName + dedup slug
- [x] Migration — N/A
- [x] Locales — `operator.outcome.pendingHint` in en/de/fr/de-CH
- [x] Docs — N/A (operator UX polish)
- [x] Accessibility — slots reuse existing Outcome structure; pending labels remain text
- [x] Sweep — readiness locale threaded through list + hook; wizards still optional-locale (defaults via resolve)
- [x] Observed — unit tests green; earlier browser check covered slots + display names
- [x] Commits — one conventional commit on `cursor/outcome-slots-and-agent-display`