### PR TITLE
feat(platform): warn task comment composer while a run executes

### DIFF
--- a/services/platform/app/features/automations/registry/connected/subject-run.test.tsx
+++ b/services/platform/app/features/automations/registry/connected/subject-run.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SubjectRun } from './subject-run';
+
+// i18n → echo `<ns>.<key>`.
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string) => `${ns}.${key}`,
+  }),
+}));
+
+vi.mock('../../runtime/automation-runtime', () => ({
+  useAutomationRuntime: () => ({ organizationId: 'org_1' }),
+}));
+
+vi.mock('./subject-input-panel', () => ({
+  SubjectInputPanel: () => null,
+}));
+
+// The operator run view is out of scope — it only has to mount the
+// `beforeDetails` slot, where the comment thread lives.
+vi.mock('@/app/features/operator/components/embedded-run', () => ({
+  EmbeddedRun: ({ beforeDetails }: { beforeDetails?: ReactNode }) => (
+    <div data-testid="embedded-run">{beforeDetails}</div>
+  ),
+}));
+
+// The shared comments surface — stubbed to capture the props this seam hands it.
+const taskCommentsCalls: Record<string, unknown>[] = [];
+vi.mock('@/app/features/tasks/components/task-comments', () => ({
+  TaskComments: (props: Record<string, unknown>) => {
+    taskCommentsCalls.push(props);
+    return <div data-testid="task-comments" />;
+  },
+}));
+
+vi.mock('@/app/features/tasks/hooks/queries', () => ({
+  useTask: () => ({
+    task: { _id: 'task_1', organizationId: 'org_1', projectId: 'proj_1' },
+    canComment: true,
+  }),
+  useTaskDiscussion: () => ({ comments: [] }),
+}));
+
+vi.mock('@/app/hooks/use-current-member-context', () => ({
+  useCurrentMemberContext: () => ({
+    data: { userId: 'user_1', isAdmin: false },
+  }),
+}));
+
+// The subject's latest run — tests flip the status per case.
+let latestRunReturn: { data: unknown; isLoading: boolean } = {
+  data: null,
+  isLoading: false,
+};
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => latestRunReturn,
+}));
+
+afterEach(() => {
+  taskCommentsCalls.length = 0;
+  latestRunReturn = { data: null, isLoading: false };
+});
+
+const runWithStatus = (status: string) => ({
+  data: { executionId: 'exec_1', status, startedAt: 1 },
+  isLoading: false,
+});
+
+describe('SubjectRun comment composer hint', () => {
+  it("warns at the composer while the subject's latest run is active", () => {
+    latestRunReturn = runWithStatus('running');
+
+    render(<SubjectRun subjectType="task" subjectId="task_1" />);
+
+    expect(taskCommentsCalls).toHaveLength(1);
+    expect(taskCommentsCalls[0]).toMatchObject({
+      taskId: 'task_1',
+      composerHint: 'automations.detail.commentsDuringRun',
+    });
+  });
+
+  it('passes no hint once the run settled', () => {
+    latestRunReturn = runWithStatus('completed');
+
+    render(<SubjectRun subjectType="task" subjectId="task_1" />);
+
+    expect(taskCommentsCalls).toHaveLength(1);
+    expect(taskCommentsCalls[0]?.composerHint).toBeUndefined();
+  });
+
+  it('passes no hint when the subject has no run yet', () => {
+    render(<SubjectRun subjectType="task" subjectId="task_1" />);
+
+    // Without a run to embed, the thread still renders after the placeholder.
+    expect(screen.getByText('automations.runs.none')).toBeInTheDocument();
+    expect(taskCommentsCalls).toHaveLength(1);
+    expect(taskCommentsCalls[0]?.composerHint).toBeUndefined();
+  });
+});

--- a/services/platform/app/features/automations/registry/connected/subject-run.tsx
+++ b/services/platform/app/features/automations/registry/connected/subject-run.tsx
@@ -29,11 +29,20 @@ import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context'
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
+import { isActiveExecutionStatus } from '@/lib/shared/platform/run_capacity';
 
 import { useAutomationRuntime } from '../../runtime/automation-runtime';
 import { SubjectInputPanel } from './subject-input-panel';
 
-function TaskExpandComments({ taskId }: { taskId: string }) {
+function TaskExpandComments({
+  taskId,
+  runActive,
+}: {
+  taskId: string;
+  /** The subject's latest run is still executing — comments posted now won't
+   *  reach it (runs read the timeline when they start), so warn at the composer. */
+  runActive: boolean;
+}) {
   const { t } = useT('automations');
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- subjectId for subjectType=task is a tasks id
   const id = taskId as Id<'tasks'>;
@@ -61,6 +70,7 @@ function TaskExpandComments({ taskId }: { taskId: string }) {
           isAdmin={me?.isAdmin}
           showHeading={false}
           order="desc"
+          composerHint={runActive ? t('detail.commentsDuringRun') : undefined}
         />
       </div>
     </CollapsibleDetails>
@@ -85,7 +95,10 @@ export function SubjectRun({
   // The comment thread outranks the process machinery for an operator, so it
   // slots in ABOVE the collapsed "Run details" (below the Outcome). Without a
   // run to embed, it simply follows the placeholder.
-  const comments = isTask ? <TaskExpandComments taskId={subjectId} /> : null;
+  const runActive = data != null && isActiveExecutionStatus(data.status);
+  const comments = isTask ? (
+    <TaskExpandComments taskId={subjectId} runActive={runActive} />
+  ) : null;
 
   const runBody = (() => {
     if (isLoading && data === undefined) return <SkeletonText lines={4} />;

--- a/services/platform/app/features/automations/runtime/resource-detail.test.tsx
+++ b/services/platform/app/features/automations/runtime/resource-detail.test.tsx
@@ -125,6 +125,16 @@ vi.mock('@/app/hooks/use-current-member-context', () => ({
   }),
 }));
 
+// The comments section subscribes to the subject's latest run to warn the
+// composer while it is active; tests flip the status per case.
+let latestRunReturn: { data: unknown; isLoading: boolean } = {
+  data: null,
+  isLoading: false,
+};
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => latestRunReturn,
+}));
+
 // The chat section is gated on the automation's cast — the runtime context
 // supplies `roles`; tests flip it to cover mapped and unmapped automations.
 let runtimeRoles: Record<string, string> | undefined = {
@@ -204,6 +214,7 @@ afterEach(() => {
   taskCommentsCalls.length = 0;
   useTaskCalls.length = 0;
   runtimeRoles = { implementer: 'desk/helper' };
+  latestRunReturn = { data: null, isLoading: false };
 });
 
 describe('ResourceDetail — task subject composition', () => {
@@ -301,6 +312,32 @@ describe('ResourceDetail — task subject composition', () => {
     openDetail({ subjectType: 'task', id: 'task123' });
 
     expect(screen.getByText('automations.binding.empty')).toBeInTheDocument();
+  });
+
+  it('warns at the comment composer while the subject run is active', () => {
+    activityReturn = bound({ data: [] });
+    latestRunReturn = {
+      data: { executionId: 'exec1', status: 'running', startedAt: 1 },
+      isLoading: false,
+    };
+
+    openDetail({ subjectType: 'task', id: 'task123' });
+
+    expect(taskCommentsCalls[0]).toMatchObject({
+      composerHint: 'automations.detail.commentsDuringRun',
+    });
+  });
+
+  it('passes no composer hint once the run settled', () => {
+    activityReturn = bound({ data: [] });
+    latestRunReturn = {
+      data: { executionId: 'exec1', status: 'completed', startedAt: 1 },
+      isLoading: false,
+    };
+
+    openDetail({ subjectType: 'task', id: 'task123' });
+
+    expect(taskCommentsCalls[0]?.composerHint).toBeUndefined();
   });
 });
 

--- a/services/platform/app/features/automations/runtime/resource-detail.tsx
+++ b/services/platform/app/features/automations/runtime/resource-detail.tsx
@@ -37,10 +37,13 @@ import {
   useState,
 } from 'react';
 
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { useFormatDate } from '@/app/hooks/use-format-date';
+import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
+import { isActiveExecutionStatus } from '@/lib/shared/platform/run_capacity';
 import { isRecord } from '@/lib/utils/type-utils';
 
 import { TaskComments } from '../../tasks/components/task-comments';
@@ -183,10 +186,20 @@ function TaskActivitySection({
  * direct-API precedent rather than the bundle capability allowlist.
  */
 function TaskCommentsSection({ taskId }: { taskId: string }) {
+  const { t } = useT('automations');
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a task subject's target.id is a tasks Convex id (openDetail contract)
   const id = taskId as Id<'tasks'>;
   const { task, canComment } = useTask(id);
   const { data: me } = useCurrentMemberContext(task?.organizationId);
+  // Same subscription the sibling SubjectRun holds (Convex dedupes identical
+  // query+args) — while that run is active, warn at the composer that it
+  // won't see comments posted now (runs read the timeline when they start).
+  const { organizationId } = useAutomationRuntime();
+  const { data: run } = useConvexQuery(
+    api.workflow_executions.queries.getLatestExecutionForSubject,
+    { organizationId, subjectType: 'task', subjectId: taskId },
+  );
+  const runActive = run != null && isActiveExecutionStatus(run.status);
   if (!task) return null;
   return (
     <TaskComments
@@ -196,6 +209,7 @@ function TaskCommentsSection({ taskId }: { taskId: string }) {
       canComment={canComment}
       currentUserId={me?.userId}
       isAdmin={me?.isAdmin}
+      composerHint={runActive ? t('detail.commentsDuringRun') : undefined}
     />
   );
 }
@@ -300,10 +314,10 @@ export function ResourceDetailProvider({
   const { t } = useT('automations');
   const [target, setTarget] = useState<ResourceDetailTarget | null>(null);
   const open = useCallback((next: ResourceDetailTarget) => setTarget(next), []);
-  const api = useMemo<ResourceDetailApi>(() => ({ open }), [open]);
+  const detailApi = useMemo<ResourceDetailApi>(() => ({ open }), [open]);
 
   return (
-    <ResourceDetailContext.Provider value={api}>
+    <ResourceDetailContext.Provider value={detailApi}>
       {children}
       <ResponsiveDialog
         open={target !== null}

--- a/services/platform/app/features/tasks/components/task-comments.test.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.test.tsx
@@ -14,8 +14,17 @@ vi.mock('./mention-text', () => ({
 }));
 
 vi.mock('./mention-textarea', () => ({
-  MentionTextarea: (props: { value: string; placeholder?: string }) => (
-    <textarea placeholder={props.placeholder} value={props.value} readOnly />
+  MentionTextarea: (props: {
+    value: string;
+    placeholder?: string;
+    'aria-describedby'?: string;
+  }) => (
+    <textarea
+      placeholder={props.placeholder}
+      value={props.value}
+      aria-describedby={props['aria-describedby']}
+      readOnly
+    />
   ),
 }));
 
@@ -209,5 +218,44 @@ describe('TaskComments composer position', () => {
       />,
     );
     expect(composerVsList(container)).toBe('composer-first');
+  });
+});
+
+describe('TaskComments composer hint', () => {
+  it('renders the hint and wires it as the textarea description', () => {
+    localeState.locale = 'en';
+    const { container } = render(
+      <TaskComments
+        taskId={'task_1' as never}
+        organizationId="org_1"
+        projectId={'project_1' as never}
+        canComment
+        composerHint="A run is in progress."
+      />,
+    );
+    expect(screen.getByText('A run is in progress.')).toHaveAttribute(
+      'id',
+      'new-comment-hint',
+    );
+    expect(container.querySelector('textarea')).toHaveAttribute(
+      'aria-describedby',
+      'new-comment-hint',
+    );
+  });
+
+  it('omits the hint and the aria wiring when not provided', () => {
+    localeState.locale = 'en';
+    const { container } = render(
+      <TaskComments
+        taskId={'task_1' as never}
+        organizationId="org_1"
+        projectId={'project_1' as never}
+        canComment
+      />,
+    );
+    expect(container.querySelector('#new-comment-hint')).toBeNull();
+    expect(container.querySelector('textarea')).not.toHaveAttribute(
+      'aria-describedby',
+    );
   });
 });

--- a/services/platform/app/features/tasks/components/task-comments.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.tsx
@@ -68,6 +68,7 @@ export function TaskComments({
   isAdmin,
   showHeading = true,
   order = 'asc',
+  composerHint,
 }: {
   taskId: Id<'tasks'>;
   organizationId: string;
@@ -81,6 +82,9 @@ export function TaskComments({
    *  first — for log-like surfaces (a desk run's timeline) where the latest
    *  automated comment carries the actionable state. */
   order?: 'asc' | 'desc';
+  /** Contextual note under the composer (also the textarea's accessible
+   *  description) — e.g. "a run is in progress and won't see new comments". */
+  composerHint?: string;
 }) {
   const { t } = useT('tasks');
   const { t: tCommon } = useT('common');
@@ -270,7 +274,13 @@ export function TaskComments({
           onValueChange={setDraft}
           onKeyDown={onModEnter(() => void submitNew())}
           placeholder={t('actions.comment')}
+          aria-describedby={composerHint ? 'new-comment-hint' : undefined}
         />
+        {composerHint && (
+          <Text as="p" id="new-comment-hint" variant="caption">
+            {composerHint}
+          </Text>
+        )}
         <MentionTriggerChips
           organizationId={organizationId}
           target={{ taskId }}

--- a/services/platform/lib/shared/platform/run_capacity.ts
+++ b/services/platform/lib/shared/platform/run_capacity.ts
@@ -16,7 +16,17 @@ export function isParkedOnCapacity(
 ): boolean {
   if (!execution) return false;
   if (execution.awaitingCapacityStepSlug === undefined) return false;
-  return execution.status === 'running' || execution.status === 'pending';
+  return isActiveExecutionStatus(execution.status);
+}
+
+/**
+ * An execution that is still doing work — scheduled (`pending`) or `running`.
+ * The one definition of "active" shared by the capacity indicator above and
+ * the UI surfaces that change behaviour while a subject's run is in flight
+ * (e.g. the task comment composer's "this run won't see new comments" hint).
+ */
+export function isActiveExecutionStatus(status: string): boolean {
+  return status === 'running' || status === 'pending';
 }
 
 /**

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -755,6 +755,7 @@
       "input": "Eingabe",
       "more": "Details",
       "comments": "Kommentare",
+      "commentsDuringRun": "Ein Lauf ist gerade aktiv und sieht neue Kommentare nicht. Schreib Feedback, auf das die Automatisierung reagieren soll, erst nach Ende des Laufs.",
       "discuss": "Diskussion",
       "externalRef": "Externe Referenz",
       "subjectFolder": "Ordner",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -755,6 +755,7 @@
       "input": "Input",
       "more": "Details",
       "comments": "Comments",
+      "commentsDuringRun": "A run is in progress and won't see new comments. For feedback the automation should act on, comment after the run finishes.",
       "discuss": "Discussion",
       "externalRef": "External reference",
       "subjectFolder": "Folder",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -756,6 +756,7 @@
       "input": "Entrée",
       "more": "Détails",
       "comments": "Commentaires",
+      "commentsDuringRun": "Une exécution est en cours et ne verra pas les nouveaux commentaires. Pour un retour que l'automatisation doit traiter, commente après la fin de l'exécution.",
       "discuss": "Discussion",
       "externalRef": "Référence externe",
       "subjectFolder": "Dossier",


### PR DESCRIPTION
## Summary

While a task subject's latest workflow run is active (`pending`/`running`), the automations comment surfaces now show a hint under the comment composer telling the operator that the running automation won't see comments posted now (runs read the task timeline when they start — on the VAT desk, a run's closing anchor even skips past mid-run comments). Previously the only signal was buried in automated comments after the fact, exactly too late for the operator who comments right after Start.

- `TaskComments` gains an optional `composerHint` prop — rendered under the textarea and wired as its `aria-describedby`.
- Both automations surfaces pass it while the subject's latest run is active: the desk expand row (`SubjectRun` → `TaskExpandComments`) and the resource-detail dialog (`TaskCommentsSection`, same `getLatestExecutionForSubject` subscription its sibling `SubjectRun` already holds — Convex dedupes).
- Active-ness = new shared `isActiveExecutionStatus` in `run_capacity.ts` (adopted by `isParkedOnCapacity` too, so the definition stays single).
- i18n: `automations.detail.commentsDuringRun` in en/de/fr; de-CH inherits from de via the sparse-override pattern.
- The tasks-board `task-modal` shares `TaskComments` but is deliberately NOT wired — run-reading semantics are automation-specific; possible follow-up.

Companion change (separate repo): tale-project/workflows `55f925d` gives the VAT desk an onboarding narrative for a fresh client's first run and routes machine repairs straight back to the pipeline.

## Definition of done

- [x] Green gate — tsc, oxlint on touched files, vitest: touched files 20/20, tasks+automations suites 53 files / 361 tests, run_capacity 8/8, i18n parity 47/47
- [x] Security gate — opengrep pre-commit scan: 0 findings
- [x] Tests — hint renders + aria wiring + absent-when-unset (task-comments); passthrough on running / settled / no-run (subject-run, resource-detail)
- [x] Migration — N/A (no data-model or config-schema change)
- [x] Locales — en/de/fr added; de-CH sparse override by design (parity suite green)
- [x] Docs — N/A (internal UI affordance; no docs page covers the composer)
- [x] Accessibility — real text node, `aria-describedby` on the textarea, house `Text` caption tokens
- [x] Sweep — all `TaskComments` call sites walked: two automations surfaces wired, task-modal ruled out above
- [x] Observed — rendered DOM asserted in component tests (hint text, aria attribute, absence); not yet watched on a live desk run — will confirm on the next dev-stack run
- [x] Commits — single atomic conventional commit, branch off main