### PR TITLE
fix(platform): table empty-state icons + design UX notes

### DIFF
--- a/design/sources/agents-models-ux-gaps.md
+++ b/design/sources/agents-models-ux-gaps.md
@@ -1,0 +1,114 @@
+# Agents & Models — UX Gaps
+
+A working list of friction points in how Tale surfaces agents, their capabilities, and the models that back them. Ordered by impact, not by effort.
+
+## Top three (start here)
+
+### 1. "Auto" model selection is opaque
+
+Chat agents default to **Auto** mode and silently pick a model. The user never sees which one ran. When a response is bad, they can't tell whether it's the model, the agent, or the prompt.
+
+**Fix idea:** show the actual model name on each AI message — a small "via deepseek-v4-flash" chip below the bubble, optionally clickable to reveal "Auto picked this because cost / latency / context length."
+
+### 2. Capabilities aren't scannable or persistent
+
+The agent picker shows real descriptions today — "Image Creator generates and edits images from text prompts using FLUX, Imagen, or Nano Banana," "Researcher: live planning, web search via Tavily, cited sources," etc. That covers more than I initially gave it credit for.
+
+What's still missing:
+
+- **Only visible at picker time.** Once you've selected an agent and are in the conversation, you can't see its tools anymore. Forget whether Researcher has web access? You have to re-open the picker to check.
+- **Prose, not structured flags.** Descriptions read well but aren't scannable. Comparing two agents means reading two paragraphs. A visual capability strip (`📡 Web · 📄 Docs · 🖼 Vision`) lets users diff agents at a glance.
+- **Inconsistent depth.** Descriptions are admin-authored, so quality varies. "Automation Assistant — creates and manages automation workflows" is vague compared to Image Creator's specific model list. Structured capability flags would be uniform regardless of who wrote the agent.
+
+**Fix idea:** keep the existing descriptions in the picker, but also surface a structured capability strip on the agent row (in the picker) and a small persistent indicator on the active-agent chip during chat (clickable to reveal full details).
+
+### 3. No cross-agent suggestion when you hit a wall
+
+Ask Assistant for an image, it politely declines. There's no _"looks like you want an image — try the Image Creator agent"_ link. High-impact discoverability moment, zero built today.
+
+**Fix idea:** when an agent refuses a task that another agent can do, surface a one-line suggestion + "Switch agent" button under the refusal.
+
+---
+
+## Why models don't show up (the original question)
+
+When the user switches agents and the model dropdown changes silently, three things are happening invisibly:
+
+1. The new agent has a different `supportedModels` allowlist
+2. Models must match the agent's capability tag (`chat` vs `image-generation`)
+3. Governance policies (`model_access`) filter further
+
+When the result is zero models, the UI just shows **"No models available"** with a red triangle. That single string covers four very different situations:
+
+- No providers configured at all
+- Providers exist but none offer the required capability (e.g. no image-gen provider for Image Creator)
+- All models blocked by governance
+- Tag mismatch (dev-only)
+
+**Fix idea — reason-aware empty state.** Branch on the actual cause:
+
+- _No providers:_ "No models available — connect a provider in Settings → Providers."
+- _Capability mismatch:_ "Image Creator needs image-generation models. None of your configured providers offer them — try adding Vercel Gateway or OpenRouter."
+- _Blocked by governance:_ "None of this agent's models are approved by your organization. Ask an admin to update the model access policy."
+
+Each one points to a different next action; the current single string forces guessing.
+
+**Related:** when switching agents drops the user's previous selection, say so. Currently it changes without notice. A toast like _"Switched to FLUX 2 Pro — Image Creator doesn't use Claude Opus"_ would convert silent loss into noticed swap.
+
+---
+
+## The rest of the gap list
+
+### 4. Quantization variants are jargon
+
+The picker shows "GLM 5.1 (fp8)" vs "GLM 5.1 (fp4)". Most users don't know what this means. Either explain (hover tooltip: _"fp8 = higher quality, slower; fp4 = faster, cheaper"_) or hide variants behind a developer toggle.
+
+### 5. No model count at agent-picker time
+
+You pick an agent and _then_ discover whether it has 17 models, 4 models, or zero. Showing "Researcher · 17 models" / "Image Creator · 0 (admin blocked)" on the agent row sets expectations before the click.
+
+### 6. No agent discovery surface
+
+Outside the settings page, agents aren't browseable. New users don't learn what exists. A first-run agent picker with descriptions and example use cases would help.
+
+### 7. No model history per message
+
+After a long chat you can't see which model produced which response. Critical for trust, retrospection, and debugging "why was that answer worse." Subtle "via {model}" footer per AI message solves it.
+
+### 8. No graceful model degradation
+
+If FLUX 2 Pro is rate-limited or down, the user probably sees a generic "something went wrong." There's no built-in fallback ("FLUX 2 Pro hit rate limit — try FLUX Kontext Pro?") or auto-switch notice.
+
+### 9. Agent switching mid-conversation is ambiguous
+
+Unclear whether context carries over and whether the change is signaled visibly. A divider in the message stream ("Switched to Image Creator") would make it traceable.
+
+### 10. No agent personality preview
+
+Agents that differ in tone (Sales vs Researcher vs Assistant) look identical at the picker. One-line excerpts or example outputs would set expectations.
+
+### 11. Costs are invisible
+
+Some models cost meaningfully more per call. No preview before send, no running total, no "you've used $X this month." For paying teams, this is a glaring miss.
+
+### 12. End users can't tweak agents
+
+Only admins can create/edit. Power users with a niche need (different instructions, fewer tools) have no path. A "duplicate this agent and modify" affordance would unlock a lot.
+
+---
+
+## Framing for the design exploration
+
+The unifying principle behind most of these:
+
+> **Agents define a curated model space. The model picker is the result, not a generic chooser.**
+
+Once that framing lands — through reason-aware empty states (#3-style), capability strips (#2), and visible model attribution (#1) — most of the "why is my model gone" / "what does this agent do" confusion evaporates.
+
+The exploration in `untitled.pen` should focus on three small frames showing this principle in practice:
+
+1. Reason-aware empty state (the "no models available" rewrite)
+2. AI message bubble with the "via {model}" attribution chip (#1)
+3. Agent row with capability strip and model count (#2 + #5)
+
+Three frames, same design language, demonstrating the explicit-relationship pattern.

--- a/design/sources/session-ux-changes.md
+++ b/design/sources/session-ux-changes.md
@@ -1,0 +1,73 @@
+# Session notes — UX changes
+
+Quick log of what changed and why. Pair with [`agents-models-ux-gaps.md`](agents-models-ux-gaps.md) for the gap inventory.
+
+## Notifications
+
+Moved the bell out of the user dropdown and into the sidebar — notifications are a primary surface, burying them in a user menu makes them undiscoverable.
+
+Rewrote the row pattern: dropped the chevron-expand, the duplicate severity dot (people kept reading it as an unread indicator), and the hidden "Mark as read" button. The whole row is now clickable to mark read. Same pattern as Gmail, Linear, GitHub.
+
+New empty states: "You're all caught up" on the Unread tab, "No notifications yet" on All — with icons. Empty states are a positive design moment, not just absence of content.
+
+Popover background switched to `bg-card` so light mode is white (matching the rest of the app's dropdowns).
+
+Unread dot recolored `sky-500` → `blue-500`. `sky-500` (#0ea5e9) reads as teal/cyan, not "unread blue" — `blue-500` (#3b82f6) is the unambiguous notification blue and clears the 3:1 non-text contrast bar in both themes.
+
+## Data tables
+
+Named the entity in row-count footers across 9+ tables. "Showing all 7 agents" instead of "No more items to load" — the old copy described the loading mechanism, users care about the data.
+
+Search input bumped from 256px → 288px and fixed an internal `max-w-70` that was leaving a phantom gap before adjacent buttons. Footer copy left-aligned with `px-3` to match cell padding.
+
+Empty-state rows no longer respond to hover. The shared `TableBody` paints row hover via `[&_tr:not([data-no-hover]):hover]:bg-muted/50`; four governance editors (budget, model-access, feature-flags, default-model) were suppressing it with a per-row `hover:bg-transparent`, which loses the CSS specificity fight and highlights anyway. Switched them to `data-no-hover`. Hover means "this row is actionable" — an empty placeholder has nothing to act on, so highlighting it is noise. Real data rows still hover normally.
+
+## Destructive contrast (dark mode)
+
+`--destructive` does double duty: it's the error _text_ color and the _fill_ for destructive buttons/badges. In dark mode the token is lightened (toward red-400) so red error text stays legible on the dark surface — but that same light red, used as a button fill behind white text, drops to ~2.75:1 and fails WCAG AA (4.5:1). Light mode was also borderline (~3.7:1).
+
+Fix: point the four white-text-on-red _fills_ at a fixed `red-600` (`hover:red-700`) instead of the theme token — `button.tsx` destructive variant (fixes Delete-all-chats and every destructive button app-wide), the notification bell count badge, the mobile tab-bar badge, and the chat-history "new response" badge. `red-600` (#dc2626) clears AA against white in both themes. Red-on-neutral _error text_ keeps using the token untouched (it's ~7:1 and fine). White text constrains the fill to roughly red-600 darkness, so the same red is used in both themes deliberately — anything lighter fails the white-text contrast.
+
+## Dropdown menus
+
+Radio dots → checkmarks. Radios imply "select pending submit" but menus commit on click — wrong affordance. macOS, VS Code, Notion all use checkmarks. Submenu background flipped from `bg-muted` (grey) to `bg-card` to match the parent menu. Added a `keepOpen` flag for menu items that swap content in place.
+
+## Settings
+
+Dropped the redundant "Two-factor authentication is not yet enabled" line — the "Enable" button alone conveys state. Kept the org-enforced variant since "you must do this" is real context.
+
+Branding panel borders were invisible because `border-input` paints with the input _fill_ color (white in light, near-black in dark) — switched to `border-border`. Lightened the heavy v4 `shadow-sm` to `shadow-xs`.
+
+## Profile name save bug
+
+`getCurrentUser` was reading from the JWT identity, which doesn't refresh on profile updates. So edits saved correctly to the DB but the form re-read the stale JWT name and "reverted" on screen. Now reads from the user table directly. One extra query per profile read — fine for this path.
+
+## Agent picker
+
+Capability icons (🌐 Web, 📄 Docs, 💻 Code, 🖼 Image, 🔌 Integrations) under each agent's description — scannable structured layer on top of the admin-authored prose. Descriptions vary in quality by agent author; icons are uniform.
+
+Layout fix: icons originally sat in the right rail and competed with the selection checkmark; moved them into a new `meta` slot below the description. "Requires Tavily" warning moved to the same row, opposite the icons. Free side benefit: descriptions stopped wrapping. Background → `bg-card`.
+
+## Model picker
+
+Same pattern as the agent picker: dropped the radio, moved capability tag icons from the right rail to the `meta` slot, switched to `bg-card`.
+
+Added hover tooltips on the provider badge ("Routed via Openrouter") and quantization badges (fp8 = "Higher quality, slower" / fp4 = "Faster, cheaper" etc.). This is option 1 from gap #4. **Option 2 (hide variants behind a developer toggle) is the better long-term fix** — most users have no reason to pick between fp8 and fp4 of the same model, that's a cost-vs-quality decision configuration shouldn't surface in the runtime picker. Tooltips are the band-aid.
+
+## AI disclaimer
+
+Hid the "AI can make mistakes—verify responses and do not share sensitive data." footer on the empty/new-chat homepage. It still appears in active chats (gated on `threadId`).
+
+Why: the empty homepage is a _welcoming_ moment — the prompt is asking the user what they want to do, the composer is inviting them to start. A disclaimer underneath that says "be careful" before they've typed a word disclaims a thing that hasn't happened, and works against the inviting tone. The risk the disclaimer mitigates only exists once the AI starts generating, so that's the moment it earns its place — small, persistent, at the bottom of the active chat. Legally, this also matches how Swiss revFADP and the EU AI Act treat disclosure: required at the _point of interaction_, not pre-engagement.
+
+Caveat documented for whoever owns compliance at Tale: if there's a contractual or vertical-industry reason it must stay on the homepage (regulated customers, enterprise contracts), revert. Otherwise this matches the industry default.
+
+## Still open
+
+From [agents-models-ux-gaps.md](agents-models-ux-gaps.md):
+
+- "Auto" model attribution chip on AI messages (#1)
+- Persistent capability indicator during chat — not just at picker time (#2)
+- Cross-agent suggestion when the wrong agent is picked (#3)
+- Reason-aware "No models available" empty state
+- Quantization variants behind a developer toggle (the real fix for #4)

--- a/services/platform/app/features/settings/audit-logs/components/audit-log-table.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-log-table.tsx
@@ -3,6 +3,7 @@
 import { Grid, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { UsePaginatedQueryResult } from 'convex/react';
+import { ScrollText } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
@@ -162,6 +163,7 @@ export function AuditLogTable({
         caption={copy.tableCaption}
         stickyLayout={stickyLayout}
         emptyState={{
+          icon: ScrollText,
           title: copy.emptyTitle,
           description: copy.emptyDescription,
         }}

--- a/services/platform/app/features/settings/audit-logs/components/block-counters-table.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/block-counters-table.tsx
@@ -3,6 +3,7 @@
 import { Row } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { ColumnDef } from '@tanstack/react-table';
+import { ShieldOff } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
@@ -110,6 +111,7 @@ export function BlockCountersTable({
       caption={t('logs.blockCounters.tableCaption')}
       isLoading={isLoading}
       emptyState={{
+        icon: ShieldOff,
         title: t('logs.blockCounters.emptyTitle'),
         description: t('logs.blockCounters.empty'),
       }}

--- a/services/platform/app/features/settings/governance/components/rules-table-empty-state.tsx
+++ b/services/platform/app/features/settings/governance/components/rules-table-empty-state.tsx
@@ -23,14 +23,14 @@ export function RulesTableEmptyState({
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center gap-3 px-5 py-10 text-center',
+        'flex flex-col items-center justify-center px-5 py-10 text-center',
         className,
       )}
     >
-      {Icon && <Icon className="text-muted-foreground size-8" />}
+      {Icon && <Icon className="text-muted-foreground mb-4 size-8" />}
       <p className="text-foreground text-sm font-medium">{title}</p>
       {description && (
-        <p className="text-muted-foreground text-sm">{description}</p>
+        <p className="text-muted-foreground mt-1 text-sm">{description}</p>
       )}
     </div>
   );

--- a/services/platform/app/features/settings/governance/data-subject-requests/requests-list-section.tsx
+++ b/services/platform/app/features/settings/governance/data-subject-requests/requests-list-section.tsx
@@ -229,6 +229,7 @@ export function RequestsListSection({
             },
           }}
           emptyState={{
+            icon: FileText,
             title: t('dataSubjectRequests.sections.requestsList.empty.title'),
             description: t(
               'dataSubjectRequests.sections.requestsList.empty.description',

--- a/services/platform/app/features/settings/governance/legal-hold/active-holds-section.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/active-holds-section.tsx
@@ -212,6 +212,7 @@ export function ActiveHoldsSection({
           approxRowCount={rows?.length}
           getRowId={(row) => row._id}
           emptyState={{
+            icon: Lock,
             title: t('legalHold.sections.activeHolds.empty.title'),
             description: t('legalHold.sections.activeHolds.empty.description'),
           }}

--- a/services/platform/app/features/settings/governance/legal-hold/matters-section.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/matters-section.tsx
@@ -161,6 +161,7 @@ export function MattersSection({ organizationId }: MattersSectionProps) {
           approxRowCount={matters?.length}
           getRowId={(row) => String(row._id)}
           emptyState={{
+            icon: Archive,
             title: t('legalHold.sections.matters.empty.title'),
             description: t('legalHold.sections.matters.empty.description'),
           }}

--- a/services/platform/app/features/settings/governance/legal-hold/release-history-section.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/release-history-section.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@tale/ui/badge';
 import { Row, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { ColumnDef } from '@tanstack/react-table';
+import { History } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
@@ -194,6 +195,7 @@ export function ReleaseHistorySection({
           },
         }}
         emptyState={{
+          icon: History,
           title: t('legalHold.sections.history.empty.title'),
           description: t('legalHold.sections.history.empty.description'),
         }}

--- a/services/platform/app/features/settings/governance/legal-hold/release-requests-section.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/release-requests-section.tsx
@@ -5,7 +5,7 @@ import { IconButton } from '@tale/ui/icon-button';
 import { Row, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { ColumnDef } from '@tanstack/react-table';
-import { Check, X } from 'lucide-react';
+import { Check, Inbox, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
@@ -208,6 +208,7 @@ export function ReleaseRequestsSection({
               approxRowCount={pending.data?.length}
               getRowId={(row) => row._id}
               emptyState={{
+                icon: Inbox,
                 title: t('legalHold.sections.releaseRequests.empty.title'),
                 description: t(
                   'legalHold.sections.releaseRequests.empty.description',
@@ -227,6 +228,7 @@ export function ReleaseRequestsSection({
               approxRowCount={approved.data?.length}
               getRowId={(row) => row._id}
               emptyState={{
+                icon: Inbox,
                 title: t('legalHold.sections.releaseRequests.empty.title'),
                 description: t(
                   'legalHold.sections.releaseRequests.empty.description',

--- a/services/platform/app/features/settings/sandboxes/sandboxes-settings.tsx
+++ b/services/platform/app/features/settings/sandboxes/sandboxes-settings.tsx
@@ -2,7 +2,7 @@ import { Badge } from '@tale/ui/badge';
 import { Row, Stack } from '@tale/ui/layout';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { FunctionReturnType } from 'convex/server';
-import { Pin, PinOff, Square, Trash2 } from 'lucide-react';
+import { Box, Pin, PinOff, Square, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
@@ -270,6 +270,7 @@ export function SandboxesSettings({ organizationId }: SandboxesSettingsProps) {
         approxRowCount={data?.length}
         getRowId={(row) => row.sessionId}
         emptyState={{
+          icon: Box,
           title: t('empty.title'),
           description: t('empty.description'),
         }}

--- a/services/platform/app/features/workflows/executions/executions-table.tsx
+++ b/services/platform/app/features/workflows/executions/executions-table.tsx
@@ -518,6 +518,7 @@ export function ExecutionsTable({
         presets: ['today', 'last7Days', 'last30Days', 'allTime'],
       }}
       emptyState={{
+        icon: Workflow,
         title: tCommon('search.noResults'),
         description: tCommon('search.tryAdjusting'),
       }}


### PR DESCRIPTION
## Summary
- Add icons to settings/governance/sandbox/executions table empty states for clearer empty UI
- Add design source notes for agents/models and session UX gaps
- Rebased onto current `main` (hub polish commit was already landed upstream; local example org dumps and screenshots were left out of this PR)

## Test plan
- [ ] Open settings tables with no rows (audit logs, block counters, governance rules, DSAR, legal hold sections, sandboxes) and confirm empty states show icons
- [ ] Open automations/workflows executions empty state and confirm icon renders
- [ ] Spot-check `design/sources/agents-models-ux-gaps.md` and `design/sources/session-ux-changes.md` render as expected


Made with [Cursor](https://cursor.com)