### PR TITLE
fix(platform): name agent-type radiogroup for screen readers

### DIFF
--- a/services/platform/app/components/ui/forms/radio-group.test.tsx
+++ b/services/platform/app/components/ui/forms/radio-group.test.tsx
@@ -185,6 +185,22 @@ describe('RadioGroup', () => {
       expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-labelledby');
     });
 
+    it('uses external aria-labelledby when label prop is absent', () => {
+      render(
+        <>
+          <span id="external-label">External label</span>
+          <RadioGroup
+            aria-labelledby="external-label"
+            options={[{ value: 'a', label: 'A' }]}
+          />
+        </>,
+      );
+      expect(screen.getByRole('radiogroup')).toHaveAttribute(
+        'aria-labelledby',
+        'external-label',
+      );
+    });
+
     it('sets aria-describedby when description is provided', () => {
       render(
         <RadioGroup

--- a/services/platform/app/components/ui/forms/radio-group.tsx
+++ b/services/platform/app/components/ui/forms/radio-group.tsx
@@ -46,6 +46,8 @@ export const RadioGroup = forwardRef<
       options,
       columns = 1,
       children,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
       ...props
     },
     ref,
@@ -73,8 +75,8 @@ export const RadioGroup = forwardRef<
           {...props}
           ref={ref}
           required={required}
-          aria-labelledby={label ? `${id}-label` : undefined}
-          aria-describedby={description ? descriptionId : undefined}
+          aria-labelledby={label ? `${id}-label` : ariaLabelledBy}
+          aria-describedby={description ? descriptionId : ariaDescribedBy}
         >
           {options
             ? options.map((option) => (

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/general-tab-agent-type-a11y.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/general-tab-agent-type-a11y.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// Regression coverage for #2682: the agent-type RadioGroup lived under a
+// PageSection heading but had no accessible name — screen readers could not
+// discover which fieldset the three type options belonged to.
+
+const { mockUseParams } = vi.hoisted(() => ({
+  mockUseParams: () => ({ id: 'org-1', agentId: 'agent-1' }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    useParams: mockUseParams,
+    ...config,
+  }),
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <a href="/">{children}</a>
+  ),
+}));
+
+vi.mock('@/app/features/agents/hooks/mutations', () => ({
+  useUpdateAgentBindings: () => ({ mutateAsync: vi.fn() }),
+  useUpdateAgentSharing: () => ({ mutateAsync: vi.fn() }),
+  useTranslateAgentFields: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/app/features/agents/hooks/queries', () => ({
+  useAgentBinding: () => ({ data: null }),
+}));
+
+vi.mock('@/app/features/organization/hooks/queries', () => ({
+  useOrganization: () => ({ data: null }),
+}));
+
+vi.mock('@/app/hooks/use-team-filter', () => ({
+  useTeamFilter: () => ({ teams: [] }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { AgentConfigProvider } from '@/app/features/agents/hooks/use-agent-config-context';
+
+import { Route } from './index';
+
+// The router-mock above replaces `createFileRoute` so `Route` is the plain
+// config object (component included); the real Route type doesn't expose it.
+const GeneralTab = (Route as unknown as { component: () => React.ReactElement })
+  .component;
+
+function renderGeneralTab() {
+  return render(
+    <AgentConfigProvider
+      agentName="agent-1"
+      initialConfig={{ supportedModels: [] }}
+    >
+      <GeneralTab />
+    </AgentConfigProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GeneralTab agent-type radiogroup a11y (#2682)', () => {
+  it('names the agent-type radiogroup from the section heading', () => {
+    renderGeneralTab();
+    expect(
+      screen.getByRole('radiogroup', { name: 'Agent type' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { Link } from '@tanstack/react-router';
 import { Info } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
@@ -57,14 +57,16 @@ function InfoTooltipLabel({
   info,
   moreInfoLabel,
   className,
+  id,
 }: {
   label: string;
   info: ReactNode;
   moreInfoLabel: string;
   className?: string;
+  id?: string;
 }) {
   return (
-    <span className={cn('inline-flex items-center gap-1', className)}>
+    <span id={id} className={cn('inline-flex items-center gap-1', className)}>
       {label}
       <Tooltip content={info}>
         <button
@@ -80,6 +82,7 @@ function InfoTooltipLabel({
 }
 
 function GeneralTab() {
+  const agentTypeLabelId = useId();
   const { t } = useT('settings');
   const { t: tCommon } = useT('common');
   const { id: organizationId, agentId: agentSlug } = Route.useParams();
@@ -510,6 +513,7 @@ function GeneralTab() {
       <PageSection
         title={
           <InfoTooltipLabel
+            id={agentTypeLabelId}
             label={t('agents.form.agentType.sectionTitle')}
             info={agentTypeInfo}
             moreInfoLabel={tCommon('aria.moreInfo')}
@@ -519,6 +523,7 @@ function GeneralTab() {
       >
         <FormSection>
           <RadioGroup
+            aria-labelledby={agentTypeLabelId}
             value={primaryBehavior}
             onValueChange={handleTypeSelect}
             options={agentTypeOptions}


### PR DESCRIPTION
## Summary
- Wire the General tab **Agent type** section heading to its `RadioGroup` via `aria-labelledby`
- Extend `RadioGroup` to honour external `aria-labelledby` / `aria-describedby` when the built-in `label` / `description` props are absent
- Add unit and General-tab regression tests so the radiogroup exposes the accessible name "Agent type"

## Test plan
- [x] `cd services/platform && bunx vitest --run --config vitest.ui.config.ts general-tab-agent-type-a11y radio-group.test`
- [ ] VoiceOver / NVDA: General tab → Agent type group is announced with its section label

Fixes #2682