### PR TITLE
docs: fix agent create name rules and drop webhook publish gate

### DIFF
--- a/docs/de/platform/agents/create.md
+++ b/docs/de/platform/agents/create.md
@@ -16,9 +16,9 @@ Stell sicher, dass zwei Dinge stehen:
 
 ## Schritt 1 — Den Agent erstellen
 
-Öffne **Agenten** in der Seitenleiste und klicke auf **Agent erstellen**, dann wähle **Leer** (das Menü bietet auch **Aus Vorlage** und **Datei hochladen** für den Import von Agent-JSON). Der Dialog fragt nach vier Dingen: einem **Name** — der eindeutigen Id für Links und die API, die du später nicht ändern kannst; füge ein `/` ein, um den Agent in einem Ordner abzulegen, z. B. `marketing/seo-writer` —, einem **Anzeigename**, den Teamkollegen im Chat sehen, einer **Beschreibung** und der **Modell**-Liste. Das erste Modell ist der Standard, der Rest sind Fallbacks; zieh zum Umsortieren oder ergänze jederzeit weitere. Klicke auf **Weiter**, und der Editor öffnet sich auf dem Tab **Allgemein**.
+Öffne **Agenten** in der Seitenleiste und klicke auf **Agent erstellen**, dann wähle **Leer** (das Menü bietet auch **Aus Vorlage** und **Datei hochladen** für den Import von Agent-JSON). Der Dialog fragt nach vier Dingen: einem **Name** — der eindeutigen Id für Links und die API, die du später nicht ändern kannst; nutze nur Kleinbuchstaben, Zahlen, Bindestriche und Unterstriche, z. B. `seo-writer` —, einem **Anzeigename**, den Teamkollegen im Chat sehen, einer **Beschreibung** und der **Modell**-Liste. Das erste Modell ist der Standard, der Rest sind Fallbacks; zieh zum Umsortieren oder ergänze jederzeit weitere. Klicke auf **Weiter**, und der Editor öffnet sich auf dem Tab **Allgemein**.
 
-<Frame caption="Die Agentenliste — Agent erstellen sitzt oben rechts; die Ordnerzeilen entstehen aus Slugs mit einem /-Präfix.">
+<Frame caption="Die Agentenliste — Agent erstellen sitzt oben rechts.">
 
 ![Die Agentenliste mit ausgeklapptem chat-Ordner, die die Zeilen Assistant und Automation Assistant mit ihren Standardmodellen und Tool-Anzahlen zeigt.](/images/platform/agents-list-expanded.webp)
 

--- a/docs/de/platform/agents/webhook-triggers.md
+++ b/docs/de/platform/agents/webhook-triggers.md
@@ -17,12 +17,6 @@ Diese Seite deckt nur die Webhook-Oberfläche pro Agent ab. Für eingehende Trig
 
 Öffne den Agent, wechsle zu **Webhook** und klicke auf **Webhook erstellen**. Der Dialog zeigt die neue URL genau einmal — sichere sie, denn das in der URL eingebettete Token wirkt als Zugangsnachweis. Es gibt keinen separaten API-Schlüssel und keine Kopfzeile: wer die URL hält, kann mit dem Agent chatten, also behandle sie wie ein Geheimnis.
 
-<Note>
-
-Webhooks verlangen einen veröffentlichten Agent — ein unveröffentlichter zeigt den Hinweis **Veröffentliche diesen Agent, um Webhook-Zugriff zu aktivieren**, bis du ihn veröffentlichst.
-
-</Note>
-
 ## Aufrufen
 
 POSTe einen JSON-Body mit einem `message`-Feld; die Antwort ist die Antwort des Agents:

--- a/docs/en/platform/agents/create.md
+++ b/docs/en/platform/agents/create.md
@@ -16,9 +16,9 @@ Make sure two things are in place:
 
 ## Step 1 — Create the agent
 
-Open **Agents** in the sidebar and click **Create agent**, then pick **Blank** (the menu also offers **From template** and **Upload file** for importing agent JSON). The dialog asks for four things: a **Name** — the unique id used in links and the API, which you can't change later; add a `/` to file the agent in a folder, e.g. `marketing/seo-writer` — a **Display name** teammates see in chat, a **Description**, and the **Model** list. The first model is the default and the rest are fallbacks; drag to reorder or add more anytime. Click **Continue** and the editor opens on the **General** tab.
+Open **Agents** in the sidebar and click **Create agent**, then pick **Blank** (the menu also offers **From template** and **Upload file** for importing agent JSON). The dialog asks for four things: a **Name** — the unique id used in links and the API, which you can't change later — use lowercase letters, numbers, hyphens, and underscores only, e.g. `seo-writer` — a **Display name** teammates see in chat, a **Description**, and the **Model** list. The first model is the default and the rest are fallbacks; drag to reorder or add more anytime. Click **Continue** and the editor opens on the **General** tab.
 
-<Frame caption="The agents list — Create agent sits top right; the folder rows come from slugs with a / prefix.">
+<Frame caption="The agents list — Create agent sits top right.">
 
 ![The agents list with the chat folder expanded, showing the Assistant and Automation Assistant rows with their default models and tool counts.](/images/platform/agents-list-expanded.webp)
 

--- a/docs/en/platform/agents/webhook-triggers.md
+++ b/docs/en/platform/agents/webhook-triggers.md
@@ -17,12 +17,6 @@ This page covers the per-agent webhook surface only. For inbound triggers that r
 
 Open the agent, switch to **Webhooks**, and click **Create webhook**. The dialog shows the new URL once — save it, because the token embedded in the URL acts as the authentication credential. There is no separate API key or header: anyone holding the URL can chat with the agent, so treat it like a secret.
 
-<Note>
-
-Webhooks require a published agent — an unpublished one shows **Publish this agent to enable webhook access** until you publish it.
-
-</Note>
-
 ## Call it
 
 POST a JSON body with a `message` field; the response is the agent's reply:

--- a/docs/fr/platform/agents/create.md
+++ b/docs/fr/platform/agents/create.md
@@ -16,9 +16,9 @@ Vérifie que deux choses sont en place :
 
 ## Étape 1 — Créer l’agent
 
-Ouvre **Agents** dans la barre latérale et clique sur **Créer un agent**, puis choisis **Vierge** (le menu propose aussi **À partir d'un modèle** et **Téléverser un fichier** pour importer du JSON d’agent). Le dialogue demande quatre choses : un **Nom** — l’identifiant unique utilisé dans les liens et l’API, que tu ne peux plus changer ensuite ; ajoute un `/` pour ranger l’agent dans un dossier, par exemple `marketing/seo-writer` — un **Nom d'affichage** que tes coéquipiers voient dans le chat, une **Description**, et la liste **Modèle**. Le premier modèle est celui par défaut et les suivants sont des fallbacks ; glisse pour réordonner ou ajoutes-en d’autres à tout moment. Clique sur **Continuer** et l’éditeur s’ouvre sur l’onglet **Général**.
+Ouvre **Agents** dans la barre latérale et clique sur **Créer un agent**, puis choisis **Vierge** (le menu propose aussi **À partir d'un modèle** et **Téléverser un fichier** pour importer du JSON d’agent). Le dialogue demande quatre choses : un **Nom** — l’identifiant unique utilisé dans les liens et l’API, que tu ne peux plus changer ensuite ; utilise uniquement des lettres minuscules, des chiffres, des tirets et des underscores, par exemple `seo-writer` — un **Nom d'affichage** que tes coéquipiers voient dans le chat, une **Description**, et la liste **Modèle**. Le premier modèle est celui par défaut et les suivants sont des fallbacks ; glisse pour réordonner ou ajoutes-en d’autres à tout moment. Clique sur **Continuer** et l’éditeur s’ouvre sur l’onglet **Général**.
 
-<Frame caption="La liste des agents — Créer un agent se trouve en haut à droite ; les lignes de dossier viennent des slugs préfixés par un /.">
+<Frame caption="La liste des agents — Créer un agent se trouve en haut à droite.">
 
 ![La liste des agents avec le dossier chat déplié, montrant les lignes Assistant et Automation Assistant avec leurs modèles par défaut et le nombre d’outils.](/images/platform/agents-list-expanded.webp)
 

--- a/docs/fr/platform/agents/webhook-triggers.md
+++ b/docs/fr/platform/agents/webhook-triggers.md
@@ -17,12 +17,6 @@ Cette page couvre la seule surface webhook par agent. Pour les déclencheurs ent
 
 Ouvre l’agent, passe à **Webhooks** et clique sur **Créer un webhook**. Le dialogue montre la nouvelle URL une seule fois — mets-la de côté, parce que le token embarqué dans l’URL fait office d’identifiant d’authentification. Il n’y a ni clé API séparée ni en-tête : quiconque détient l’URL peut chatter avec l’agent, donc traite-la comme un secret.
 
-<Note>
-
-Les webhooks demandent un agent publié — un agent non publié affiche **Publie cet agent pour activer l'accès par webhook** jusqu’à sa publication.
-
-</Note>
-
 ## L’appeler
 
 Envoie un POST avec un corps JSON portant un champ `message` ; la réponse est celle de l’agent :


### PR DESCRIPTION
## Summary

- **Fixes #2683** — Update `platform/agents/create.md` (en/de/fr) to document valid agent name slugs (`seo-writer` style) and remove the obsolete `/` folder instruction that the create dialog rejects.
- **Fixes #2684** — Remove the outdated published-agent `<Note>` from `platform/agents/webhook-triggers.md` (en/de/fr); webhooks no longer require publishing.

## Test plan

- [x] `bun run --filter @tale/docs test` — 188 tests passed
- [x] Swept en/de/fr for both pages