### PR TITLE
fix(platform): let Canvas infer viewer kind for user uploads

### DIFF
--- a/services/platform/app/features/workspace/components/file-viewer-router.tsx
+++ b/services/platform/app/features/workspace/components/file-viewer-router.tsx
@@ -8,12 +8,9 @@ import { Text } from '@tale/ui/text';
 import { memo, useEffect, useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
-import {
-  getFileExtensionLower,
-  isTextBasedFile,
-} from '@/lib/utils/text-file-types';
 
 import { useThreadFileContent } from '../hooks/use-thread-file-content';
+import { resolveFileViewerKind } from '../lib/resolve-file-viewer-kind';
 import { AttachmentViewer } from '../viewers/attachment-viewer';
 import { CodeFileViewer } from '../viewers/code-file-viewer';
 import { ImageViewer } from '../viewers/image-viewer';
@@ -33,52 +30,6 @@ interface FileViewerRouterProps {
    * a "Writing…" placeholder until the file lands.
    */
   liveEncoding?: 'utf-8' | 'base64';
-}
-
-type RenderKind =
-  | 'image'
-  | 'attachment'
-  | 'html'
-  | 'svg'
-  | 'mermaid'
-  | 'markdown'
-  | 'code';
-
-const IMAGE_EXTS = new Set([
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'webp',
-  'bmp',
-  'ico',
-  'avif',
-]);
-
-function resolveKind(
-  hint: string | undefined,
-  path: string,
-  contentType: string | undefined,
-): RenderKind {
-  if (
-    hint === 'image' ||
-    hint === 'attachment' ||
-    hint === 'html' ||
-    hint === 'svg' ||
-    hint === 'mermaid' ||
-    hint === 'markdown' ||
-    hint === 'code'
-  ) {
-    return hint;
-  }
-  const ext = getFileExtensionLower(path);
-  if (IMAGE_EXTS.has(ext) || contentType?.startsWith('image/')) return 'image';
-  if (ext === 'html' || ext === 'htm') return 'html';
-  if (ext === 'svg') return 'svg';
-  if (ext === 'mmd' || ext === 'mermaid') return 'mermaid';
-  if (ext === 'md' || ext === 'mdx' || ext === 'markdown') return 'markdown';
-  if (!isTextBasedFile(path, contentType)) return 'attachment';
-  return 'code';
 }
 
 function FileViewerRouterComponent({
@@ -161,7 +112,7 @@ function FileViewerRouterComponent({
         </Stack>
       );
     }
-    const kind = resolveKind(undefined, path, undefined);
+    const kind = resolveFileViewerKind(undefined, path, undefined);
     const text = renderContent ?? '';
     if (
       kind === 'html' ||
@@ -192,7 +143,11 @@ function FileViewerRouterComponent({
     );
   }
 
-  const kind = resolveKind(result.renderHint, path, result.contentType);
+  const kind = resolveFileViewerKind(
+    result.renderHint,
+    path,
+    result.contentType,
+  );
 
   if (result.status === 'error' && result.error === 'too_large' && result.url) {
     return (

--- a/services/platform/app/features/workspace/lib/resolve-file-viewer-kind.test.ts
+++ b/services/platform/app/features/workspace/lib/resolve-file-viewer-kind.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveFileViewerKind } from './resolve-file-viewer-kind';
+
+describe('resolveFileViewerKind', () => {
+  it('infers markdown for uploaded paths when renderHint is unset', () => {
+    expect(
+      resolveFileViewerKind(
+        undefined,
+        '/user/uploads/notes.md',
+        'text/markdown',
+      ),
+    ).toBe('markdown');
+  });
+
+  it('infers code for text uploads when renderHint is unset', () => {
+    expect(
+      resolveFileViewerKind(
+        undefined,
+        '/user/uploads/script.py',
+        'text/x-python',
+      ),
+    ).toBe('code');
+  });
+
+  it('forces download-only when renderHint is attachment', () => {
+    expect(
+      resolveFileViewerKind(
+        'attachment',
+        '/user/uploads/notes.md',
+        'text/markdown',
+      ),
+    ).toBe('attachment');
+  });
+
+  it('keeps image hint for image uploads', () => {
+    expect(
+      resolveFileViewerKind('image', '/user/uploads/photo.png', 'image/png'),
+    ).toBe('image');
+  });
+});

--- a/services/platform/app/features/workspace/lib/resolve-file-viewer-kind.ts
+++ b/services/platform/app/features/workspace/lib/resolve-file-viewer-kind.ts
@@ -1,0 +1,55 @@
+import {
+  getFileExtensionLower,
+  isTextBasedFile,
+} from '@/lib/utils/text-file-types';
+
+export type FileViewerRenderKind =
+  | 'image'
+  | 'attachment'
+  | 'html'
+  | 'svg'
+  | 'mermaid'
+  | 'markdown'
+  | 'code';
+
+const IMAGE_EXTS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'bmp',
+  'ico',
+  'avif',
+]);
+
+/**
+ * Pick the Canvas viewer for a workspace file. A server `renderHint`, when
+ * present, wins; otherwise infer from path extension and content type (the
+ * path user uploads take when `renderHint` is omitted).
+ */
+export function resolveFileViewerKind(
+  hint: string | undefined,
+  path: string,
+  contentType: string | undefined,
+): FileViewerRenderKind {
+  if (
+    hint === 'image' ||
+    hint === 'attachment' ||
+    hint === 'html' ||
+    hint === 'svg' ||
+    hint === 'mermaid' ||
+    hint === 'markdown' ||
+    hint === 'code'
+  ) {
+    return hint;
+  }
+  const ext = getFileExtensionLower(path);
+  if (IMAGE_EXTS.has(ext) || contentType?.startsWith('image/')) return 'image';
+  if (ext === 'html' || ext === 'htm') return 'html';
+  if (ext === 'svg') return 'svg';
+  if (ext === 'mmd' || ext === 'mermaid') return 'mermaid';
+  if (ext === 'md' || ext === 'mdx' || ext === 'markdown') return 'markdown';
+  if (!isTextBasedFile(path, contentType)) return 'attachment';
+  return 'code';
+}

--- a/services/platform/convex/lib/attachments/workspace_uploads.ts
+++ b/services/platform/convex/lib/attachments/workspace_uploads.ts
@@ -136,9 +136,9 @@ export async function fileAttachmentsIntoWorkspace(
               contentType,
               sha256,
               source: 'user_upload' as const,
-              renderHint: contentType.startsWith('image/')
-                ? ('image' as const)
-                : ('attachment' as const),
+              ...(contentType.startsWith('image/')
+                ? { renderHint: 'image' as const }
+                : {}),
             },
           );
           filed += 1;

--- a/services/platform/convex/thread_files/internal_mutations.ts
+++ b/services/platform/convex/thread_files/internal_mutations.ts
@@ -111,7 +111,14 @@ export const upsertThreadFile = internalMutation({
         updatedAt: now,
       };
       if (args.sha256 !== undefined) patch.sha256 = args.sha256;
-      if (args.renderHint !== undefined) patch.renderHint = args.renderHint;
+      if (args.source === 'user_upload') {
+        // User uploads infer viewer kind client-side from the path when
+        // `renderHint` is unset. Always patch so a re-upload clears a stale
+        // `'attachment'` hint from older server versions (#2677).
+        patch.renderHint = args.renderHint;
+      } else if (args.renderHint !== undefined) {
+        patch.renderHint = args.renderHint;
+      }
       await ctx.db.patch(existing._id, patch);
       return { id: existing._id, replaced: true, unchanged: false };
     }


### PR DESCRIPTION
Fixes #2677

## Summary
- Stop hardcoding `renderHint: 'attachment'` for non-image user uploads in `workspace_uploads.ts`
- Only set `renderHint: 'image'` for image uploads; let the Canvas viewer infer markdown/code/html/etc. from path and content type (same as agent-written files)
- Clear stale `attachment` hints when a user re-uploads the same path
- Extract `resolveFileViewerKind` with regression tests documenting inference vs forced attachment

## Test plan
- [x] `bun run test:ui -- resolve-file-viewer-kind.test.ts`
- [x] `bun run test -- workspace_uploads.test.ts`
- [ ] Manual: attach a `.md` file in chat, open Canvas — Source/Preview with rendered markdown

## Definition of done
- [x] Green gate — targeted tests pass
- [x] Security gate — N/A
- [x] Tests — unit tests for viewer kind inference
- [x] Migration — N/A (optional field behavior only)
- [x] Locales — N/A
- [x] Docs — N/A (restores documented behavior)
- [x] Accessibility — N/A
- [x] Sweep — user_upload filing + viewer router + upsert replace path
- [x] Observed — unit tests cover inference regression
- [x] Commits — single atomic commit off main