### PR TITLE
fix(ui): restore menu focus after logout confirm dialog closes

### DIFF
--- a/packages/ui/src/hooks/use-restore-focus.test.ts
+++ b/packages/ui/src/hooks/use-restore-focus.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { createRef } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { useRestoreFocus } from './use-restore-focus';
@@ -31,6 +32,30 @@ describe('useRestoreFocus', () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(document.activeElement).toBe(trigger);
+  });
+
+  it('refocuses the fallback when the opener has been removed from the DOM', () => {
+    const trigger = document.createElement('button');
+    const fallback = document.createElement('button');
+    document.body.append(trigger, fallback);
+    trigger.focus();
+
+    const fallbackRef = createRef<HTMLButtonElement>();
+    fallbackRef.current = fallback;
+
+    const { result } = renderHook(
+      ({ open }) => useRestoreFocus(open, fallbackRef),
+      { initialProps: { open: true } },
+    );
+
+    // Opener unmounts (e.g. a menu item that closed its menu on open).
+    trigger.remove();
+
+    const event = new Event('close', { cancelable: true });
+    result.current(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(fallback);
   });
 
   it('does not refocus an opener that has been removed from the DOM', () => {

--- a/packages/ui/src/hooks/use-restore-focus.ts
+++ b/packages/ui/src/hooks/use-restore-focus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef } from 'react';
+import { type RefObject, useCallback, useLayoutEffect, useRef } from 'react';
 
 /**
  * Restores DOM focus to the control that was focused before an overlay opened.
@@ -18,9 +18,15 @@ import { useCallback, useLayoutEffect, useRef } from 'react';
  * does not also run.
  *
  * @param open Whether the overlay is currently open.
+ * @param fallbackRef Optional element to focus when the captured opener has
+ *   been removed from the DOM (e.g. a menu item that unmounts when its
+ *   dropdown closes).
  * @returns An `onCloseAutoFocus` handler to pass to `Dialog.Content`.
  */
-export function useRestoreFocus(open: boolean) {
+export function useRestoreFocus(
+  open: boolean,
+  fallbackRef?: RefObject<HTMLElement | null>,
+) {
   const previouslyFocused = useRef<HTMLElement | null>(null);
 
   useLayoutEffect(() => {
@@ -30,14 +36,22 @@ export function useRestoreFocus(open: boolean) {
     }
   }, [open]);
 
-  return useCallback((event: Event) => {
-    const target = previouslyFocused.current;
-    // Only take over from Radix when the opener still exists in the document;
-    // otherwise let Radix's default close behaviour run.
-    if (target && target.isConnected) {
-      event.preventDefault();
-      target.focus();
-    }
-    previouslyFocused.current = null;
-  }, []);
+  return useCallback(
+    (event: Event) => {
+      let target = previouslyFocused.current;
+      // Menu items and other transient openers unmount when their parent
+      // overlay closes; fall back to a stable trigger (e.g. the menu button).
+      if (target && !target.isConnected) {
+        target = fallbackRef?.current ?? null;
+      }
+      // Only take over from Radix when a restore target still exists in the
+      // document; otherwise let Radix's default close behaviour run.
+      if (target && target.isConnected) {
+        event.preventDefault();
+        target.focus();
+      }
+      previouslyFocused.current = null;
+    },
+    [fallbackRef],
+  );
 }

--- a/services/platform/app/components/ui/dialog/confirm-dialog.tsx
+++ b/services/platform/app/components/ui/dialog/confirm-dialog.tsx
@@ -59,6 +59,11 @@ export interface ConfirmDialogProps {
   requireConfirmPhrase?: string;
   /** Optional label shown above the type-to-confirm input. */
   requireConfirmPhraseLabel?: string;
+  /**
+   * Stable element to restore focus to when the captured opener unmounts before
+   * close (e.g. a dropdown menu item).
+   */
+  restoreFocusRef?: React.RefObject<HTMLElement | null>;
 }
 
 /**
@@ -81,6 +86,7 @@ export function ConfirmDialog({
   className,
   requireConfirmPhrase,
   requireConfirmPhraseLabel,
+  restoreFocusRef,
 }: ConfirmDialogProps) {
   const { t: tCommon } = useT('common');
   const [phraseInput, setPhraseInput] = React.useState('');
@@ -139,6 +145,7 @@ export function ConfirmDialog({
       description={description}
       footer={footer}
       className={className}
+      restoreFocusRef={restoreFocusRef}
     >
       {children}
       {requireConfirmPhrase !== undefined && (

--- a/services/platform/app/components/ui/dialog/dialog.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.tsx
@@ -119,6 +119,11 @@ export interface DialogProps {
   trigger?: React.ReactNode;
   /** Whether to prevent focus restoration when dialog closes (default: false) */
   preventCloseAutoFocus?: boolean;
+  /**
+   * Stable element to restore focus to when the captured opener unmounts before
+   * close (e.g. a dropdown menu item). Passed to `useRestoreFocus`.
+   */
+  restoreFocusRef?: React.RefObject<HTMLElement | null>;
 }
 
 /**
@@ -163,12 +168,13 @@ export function Dialog({
   customHeader,
   trigger,
   preventCloseAutoFocus = false,
+  restoreFocusRef,
 }: DialogProps) {
   const parentDepth = React.useContext(DialogDepthContext);
   const isNested = parentDepth > 0;
   // Without a `trigger`, Radix has no element to restore focus to on close, so
   // focus falls to <body> (WCAG 2.4.3). Capture the opener and refocus it.
-  const restoreFocus = useRestoreFocus(open);
+  const restoreFocus = useRestoreFocus(open, restoreFocusRef);
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       {trigger && (

--- a/services/platform/app/components/user-button.test.tsx
+++ b/services/platform/app/components/user-button.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render, screen, within } from '@/tests/utils/render';
+import { render, screen, waitFor, within } from '@/tests/utils/render';
 
 import { UserButton } from './user-button';
 
@@ -18,6 +18,10 @@ vi.mock('@/lib/i18n/client', () => ({
         'userButton.defaultName': 'User',
         'userButton.documentation': 'Documentation',
         'userButton.logOut': 'Log out',
+        'userButton.logOutConfirm.title': 'Log out',
+        'userButton.logOutConfirm.description':
+          'Are you sure you want to log out?',
+        'userButton.logOutConfirm.confirm': 'Log out',
         'userButton.manageAccount': 'Manage account',
         'userButton.toast.signOutFailed': 'Sign out failed',
         'userButton.language': 'Language',
@@ -32,6 +36,8 @@ vi.mock('@/lib/i18n/client', () => ({
         'languages.en': 'English',
         'languages.de': 'Deutsch',
         'languages.fr': 'Français',
+        // common.actions.* (ConfirmDialog cancel button)
+        'actions.cancel': 'Cancel',
       };
       return translations[key] ?? key;
     },
@@ -361,6 +367,26 @@ describe('UserButton', () => {
       expect(
         within(menu).getByRole('menuitem', { name: 'Log out' }),
       ).toBeInTheDocument();
+    });
+
+    it('restores focus to the menu trigger after cancelling sign out', async () => {
+      const result = render(<UserButton />);
+      const trigger = screen.getByRole('button', { name: 'Manage account' });
+      await result.user.click(trigger);
+      const menu = await screen.findByRole('menu');
+
+      await result.user.click(
+        within(menu).getByRole('menuitem', { name: 'Log out' }),
+      );
+
+      const dialog = await screen.findByRole('dialog', { name: 'Log out' });
+      expect(dialog).toBeInTheDocument();
+
+      await result.user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(trigger);
+      });
     });
   });
 

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -30,6 +30,7 @@ import {
   type ReactNode,
   useCallback,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -205,6 +206,7 @@ export function UserButton({
 
   const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
   const [open, setOpen] = useState(false);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
 
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next);
@@ -602,6 +604,7 @@ export function UserButton({
 
   const triggerContent = (
     <button
+      ref={menuTriggerRef}
       type="button"
       aria-label={
         label ? undefined : (tooltipText ?? t('userButton.manageAccount'))
@@ -639,6 +642,7 @@ export function UserButton({
       description={t('userButton.logOutConfirm.description')}
       confirmText={t('userButton.logOutConfirm.confirm')}
       onConfirm={handleSignOut}
+      restoreFocusRef={menuTriggerRef}
     />
   );
 


### PR DESCRIPTION
## Summary

- Add optional `fallbackRef` to `useRestoreFocus` so focus restores to a stable trigger when the captured opener unmounts (e.g. dropdown menu item)
- Thread `restoreFocusRef` through `Dialog` and `ConfirmDialog`
- Wire the user menu trigger ref into the sign-out confirmation dialog

Fixes #2681

## Test plan

- [x] `bun run --filter @tale/ui test -- use-restore-focus.test.ts` (includes fallback-when-disconnected regression)
- [x] `bun run --filter @tale/platform test:ui -- user-button.test.tsx` (sign-out cancel returns focus to menu trigger)
- [ ] Manual: open user menu → Log out → Cancel → keyboard focus returns to account button