### PR TITLE
fix(platform): show locked notice on locked discussion composer

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input.test.tsx
@@ -434,3 +434,38 @@ describe('ChatInput disabled composer (missing API key)', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+const LOCKED_DISCUSSION_MESSAGE = 'This discussion is locked';
+
+function renderLockedComposer() {
+  return render(
+    <ChatInput
+      organizationId="org-1"
+      value=""
+      onChange={vi.fn()}
+      onSendMessage={vi.fn()}
+      attachments={[]}
+      uploadingFiles={[]}
+      uploadFiles={vi.fn()}
+      removeAttachment={vi.fn()}
+      clearAttachments={vi.fn(() => [])}
+      variant="assistant"
+      disabled
+      disabledReason="locked"
+      disabledMessage={LOCKED_DISCUSSION_MESSAGE}
+    />,
+  );
+}
+
+// #2680: locked discussions reused chat's archived disabled copy.
+describe('ChatInput disabled composer (locked discussion)', () => {
+  it('shows the caller-supplied locked message instead of the archived copy', () => {
+    renderLockedComposer();
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
+    expect(screen.getByText(LOCKED_DISCUSSION_MESSAGE)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/this chat is archived/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -103,13 +103,18 @@ interface ChatInputProps extends Omit<
    */
   queueModeActive?: boolean;
   disabled?: boolean;
-  disabledReason?: 'no-agents' | 'pending-approval' | 'archived' | 'no-api-key';
+  disabledReason?:
+    | 'no-agents'
+    | 'pending-approval'
+    | 'archived'
+    | 'locked'
+    | 'no-api-key';
   /**
    * Reason text for `disabledReason === 'no-api-key'` — distinguishes the
    * specific-model vs org-wide missing-key wording (`modelSelector.noApiKey`
-   * vs `modelSelector.noProviderKey`, chosen by the caller). The other
-   * `disabledReason`s carry a fixed, non-interpolated string, so they don't
-   * need this.
+   * vs `modelSelector.noProviderKey`, chosen by the caller). Also used for
+   * `disabledReason === 'locked'` so callers can supply domain-specific copy
+   * (e.g. discussions) instead of the chat archived string.
    */
   disabledMessage?: string;
   placeholder?: string;
@@ -1335,11 +1340,13 @@ export function ChatInput({
                 <Text as="div" variant="muted">
                   {disabledReason === 'archived'
                     ? tChat('archivedDisabled')
-                    : disabledReason === 'pending-approval'
-                      ? tChat('pendingApprovalDisabled')
-                      : disabledReason === 'no-api-key'
-                        ? (disabledMessage ?? tChat('modelSelector.noApiKey'))
-                        : tChat('noAgentsAvailable')}
+                    : disabledReason === 'locked'
+                      ? disabledMessage
+                      : disabledReason === 'pending-approval'
+                        ? tChat('pendingApprovalDisabled')
+                        : disabledReason === 'no-api-key'
+                          ? (disabledMessage ?? tChat('modelSelector.noApiKey'))
+                          : tChat('noAgentsAvailable')}
                 </Text>
                 {/* Missing API key is a setup blocker with an actionable fix
                     (unlike no-agents/pending-approval/archived, which are

--- a/services/platform/app/features/discussions/components/discussion-thread-view.test.tsx
+++ b/services/platform/app/features/discussions/components/discussion-thread-view.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string) => `${ns}.${key}`,
+  }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children?: ReactNode }) => <a href="#">{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+vi.mock('../../chat/hooks/use-convex-file-upload', () => ({
+  useConvexFileUpload: () => ({
+    attachments: [],
+    uploadingFiles: [],
+    uploadFiles: vi.fn(),
+    removeAttachment: vi.fn(),
+    clearAttachments: vi.fn(),
+  }),
+}));
+
+vi.mock('../../chat/hooks/use-message-processing', () => ({
+  useMessageProcessing: () => ({ messages: [] }),
+}));
+
+vi.mock('../../tasks/hooks/use-actor-directory', () => ({
+  useActorDirectory: () => ({
+    resolveActor: () => null,
+    currentUserId: 'user-1',
+  }),
+}));
+
+vi.mock('../../tasks/lib/mention-actor-options', () => ({
+  useMentionActorOptions: () => [],
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  usePostReply: () => ({ mutateAsync: vi.fn() }),
+  useSetDiscussionStatus: () => ({ mutateAsync: vi.fn() }),
+  useCreateTaskFromDiscussion: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useDiscussion: () => ({
+    data: {
+      title: 'Design review',
+      discussionStatus: 'locked',
+      discussionCategory: null,
+      linkedTaskId: null,
+    },
+  }),
+}));
+
+const chatInputSpy = vi.fn();
+vi.mock('../../chat/components/chat-input', () => ({
+  ChatInput: (props: {
+    disabled?: boolean;
+    disabledReason?: string;
+    disabledMessage?: string;
+  }) => {
+    chatInputSpy(props);
+    return <div data-testid="chat-input" />;
+  },
+}));
+
+vi.mock('../../chat/components/message-bubble', () => ({
+  MessageBubble: () => null,
+}));
+
+import { DiscussionThreadView } from './discussion-thread-view';
+
+describe('DiscussionThreadView', () => {
+  it('passes the discussions locked copy to ChatInput when locked (#2680)', () => {
+    render(
+      <DiscussionThreadView
+        organizationId="org-1"
+        projectId={'project-1' as never}
+        threadId="thread-1"
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(chatInputSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disabled: true,
+        disabledReason: 'locked',
+        disabledMessage: 'discussions.reply.lockedPlaceholder',
+      }),
+    );
+  });
+});

--- a/services/platform/app/features/discussions/components/discussion-thread-view.tsx
+++ b/services/platform/app/features/discussions/components/discussion-thread-view.tsx
@@ -332,7 +332,10 @@ export function DiscussionThreadView({
               onSendMessage={handleSend}
               isLoading={isSending}
               disabled={isLocked}
-              disabledReason={isLocked ? 'archived' : undefined}
+              disabledReason={isLocked ? 'locked' : undefined}
+              disabledMessage={
+                isLocked ? t('reply.lockedPlaceholder') : undefined
+              }
               organizationId={organizationId}
               threadId={threadId}
               projectId={String(projectId)}


### PR DESCRIPTION
Fixes #2680

## Summary
- Add `'locked'` to `ChatInput`'s `disabledReason` union
- Locked discussions pass `disabledMessage={t('reply.lockedPlaceholder')}` instead of reusing `'archived'` (which showed chat's "This chat is archived…" copy)
- Existing `reply.lockedPlaceholder` strings in en/de/fr are used — no new locale keys

## Test plan
- [x] `bun run test:ui -- chat-input.test.tsx discussion-thread-view.test.tsx`
- [ ] Manual: lock a discussion — composer overlay shows "This discussion is locked", not archived chat copy

## Definition of done
- [x] Green gate — targeted UI tests pass
- [x] Security gate — N/A
- [x] Tests — ChatInput + DiscussionThreadView regression tests
- [x] Migration — N/A
- [x] Locales — uses existing discussions strings (en/de/fr)
- [x] Docs — N/A
- [x] Accessibility — correct disabled reason text for screen readers
- [x] Sweep — discussion thread view only caller of locked reason
- [x] Observed — unit tests assert locked copy vs archived
- [x] Commits — single atomic commit off main