### PR TITLE
fix(platform): skip covering-gate checks in container catalog validation

### DIFF
--- a/services/platform/convex/lib/config_store/validate_builtin_catalog.ts
+++ b/services/platform/convex/lib/config_store/validate_builtin_catalog.ts
@@ -43,7 +43,9 @@ export const validateBuiltinCatalog = internalAction({
       return { ok: false, issueCount: 0, filesValidated: 0 };
     }
 
-    const registryIssues = checkValidatorRegistryComplete();
+    const registryIssues = checkValidatorRegistryComplete({
+      checkCoveringGates: false,
+    });
     const { issues: catalogIssues, filesValidated } = validateConfigDir(
       builtinDir,
       'catalog',

--- a/services/platform/lib/shared/config/catalog_validator.test.ts
+++ b/services/platform/lib/shared/config/catalog_validator.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression for #2675 — runtime container images have no vitest sources, so
+ * `validateBuiltinCatalog` must skip repo-relative covering-gate existence
+ * checks while CI/build gates keep them enabled.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const AUTOMATIONS_GATE_FRAGMENTS = [
+  'builtin_apps.test.ts',
+  'fixture_bundle_drift.test.ts',
+] as const;
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: (path: Parameters<typeof actual.existsSync>[0]) => {
+      const p = String(path);
+      if (AUTOMATIONS_GATE_FRAGMENTS.some((fragment) => p.includes(fragment))) {
+        return false;
+      }
+      return actual.existsSync(path);
+    },
+  };
+});
+
+import { checkValidatorRegistryComplete } from './catalog_validator';
+
+describe('checkValidatorRegistryComplete covering gates', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports missing gate files when checkCoveringGates is true (default)', () => {
+    const issues = checkValidatorRegistryComplete();
+    expect(issues.some((issue) => issue.startsWith('automations:'))).toBe(true);
+  });
+
+  it('skips gate file checks when checkCoveringGates is false', () => {
+    const issues = checkValidatorRegistryComplete({
+      checkCoveringGates: false,
+    });
+    expect(issues).toEqual([]);
+  });
+});

--- a/services/platform/lib/shared/config/catalog_validator.ts
+++ b/services/platform/lib/shared/config/catalog_validator.ts
@@ -539,13 +539,24 @@ export function validateConfigDir(
   return { issues, filesValidated };
 }
 
+interface CheckValidatorRegistryCompleteOptions {
+  /** When false, skip repo-relative existence checks for externally-gated
+   *  domains (e.g. `automations`). Domain↔validator mapping checks still run.
+   *  Runtime container images have no vitest sources — callers there pass
+   *  `false`; CI/build gates keep the default `true`. */
+  checkCoveringGates?: boolean;
+}
+
 /**
  * The registry drift guard: every `CONFIG_DOMAINS` entry must declare a
  * validator, every validator must map back to a registered domain, and every
  * externally-gated domain's covering test files must still exist. Returns one
  * human-readable issue per problem; empty = the registry is complete.
  */
-export function checkValidatorRegistryComplete(): string[] {
+export function checkValidatorRegistryComplete(
+  options: CheckValidatorRegistryCompleteOptions = {},
+): string[] {
+  const { checkCoveringGates = true } = options;
   const issues: string[] = [];
 
   for (const domain of CONFIG_DOMAINS) {
@@ -566,6 +577,8 @@ export function checkValidatorRegistryComplete(): string[] {
       );
     }
   }
+
+  if (!checkCoveringGates) return issues;
 
   for (const [name, validator] of Object.entries(DOMAIN_VALIDATORS)) {
     if (validator.kind !== 'external-gate') continue;


### PR DESCRIPTION
## Summary
- Add optional `checkCoveringGates` parameter to `checkValidatorRegistryComplete` (default `true`) so callers can skip repo-relative existence checks for externally-gated domains like `automations`.
- Call `checkValidatorRegistryComplete({ checkCoveringGates: false })` from the runtime `validateBuiltinCatalog` action — container images ship no vitest sources, so covering-gate paths always appeared missing.
- Add regression test proving `checkCoveringGates: false` skips automations gate file checks while the default still reports them.

Fixes #2675

## Test plan
- [x] `bun run --filter @tale/platform test -- catalog_validator builtin_configs_validation`
- [ ] Post-deploy `validateBuiltinCatalog` in a container no longer logs automations covering-gate false positives