### PR TITLE
fix(platform): polish empty states, settings alignment, and chat key banner

### DIFF
--- a/packages/ui/src/components/feedback/empty-state.tsx
+++ b/packages/ui/src/components/feedback/empty-state.tsx
@@ -39,7 +39,10 @@ export function EmptyState({
       )}
     >
       {Icon && (
-        <Icon className="text-muted-foreground mb-4 size-5" aria-hidden />
+        // 24px matches the platform empty-state spec (Conversations, Documents
+        // search, etc.). size-5 (20px) read as a muted ornament next to the
+        // title once these states are vertically centered in a full pane.
+        <Icon className="text-muted-foreground mb-4 size-6" aria-hidden />
       )}
       <Heading level={headingLevel} size="sm">
         {title}

--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -154,6 +154,24 @@ describe('DataTable loading states', () => {
 
       expect(screen.getByText('Nothing here')).toBeInTheDocument();
     });
+
+    it('does not force a column-size minWidth that would scroll an empty table', () => {
+      const { container } = render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={0}
+          emptyState={{ title: 'No items found' }}
+        />,
+      );
+
+      const table = container.querySelector('table');
+      expect(table).not.toBeNull();
+      // Content-based floor is for data/skeleton only — empty stays at 100% so
+      // Sandboxes (and other wide-column settings tables) don't show a lonely
+      // horizontal scrollbar under the empty state.
+      expect(table).toHaveStyle({ minWidth: '100%' });
+    });
   });
 
   describe('filtered-empty state (active filters + no data)', () => {

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -720,7 +720,15 @@ export function DataTable<TData, TValue = unknown>({
         // `max(100%, …)` so the table still fills a wide container (preserving
         // the primitive's `min-w-full`) while gaining a content-based floor that
         // forces horizontal scroll on narrow viewports instead of squashing.
-        style={{ minWidth: `max(100%, ${tableMinWidth})` }}
+        // Initial empty (no headers, no rows) must NOT inherit the column-size
+        // floor — otherwise a 7-column table (~1050px default) scrolls
+        // horizontally inside a max-w-3xl settings pane with nothing to reveal.
+        style={{
+          minWidth:
+            tableBodyState === 'empty' || tableBodyState === 'idle-empty'
+              ? '100%'
+              : `max(100%, ${tableMinWidth})`,
+        }}
       >
         {caption && <TableCaption className="sr-only">{caption}</TableCaption>}
         {/* Hide column headers on the initial empty state — an empty grid with
@@ -959,14 +967,13 @@ export function DataTable<TData, TValue = unknown>({
               </TableRow>
             ))
           ) : tableBodyState === 'empty' ? (
-            // Initial empty state — no data and no filters active. The cell
-            // wraps the empty state in a viewport-sized, sticky container so
-            // it stays centered even when the table overflows horizontally
-            // (common on narrow viewports where many columns push the table
-            // wider than the scroll viewport).
+            // Initial empty state — no data and no filters active. Table
+            // minWidth is 100% in this state (no column-size floor), so a
+            // plain `w-full` keeps the empty copy inside the bordered frame
+            // without a phantom horizontal scrollbar.
             <TableRow data-no-hover>
               <TableCell colSpan={colSpan} className="p-0">
-                <div className="sticky left-0 w-screen max-w-full p-4">
+                <div className="w-full p-4">
                   <DataTableEmptyState
                     icon={emptyState?.icon}
                     title={emptyState?.title ?? ''}
@@ -978,7 +985,10 @@ export function DataTable<TData, TValue = unknown>({
               </TableCell>
             </TableRow>
           ) : tableBodyState === 'filtered-empty' ? (
-            // Filtered empty state — filters applied but no matching rows
+            // Filtered empty state — filters applied but no matching rows.
+            // Headers stay visible and the table may still be wider than the
+            // viewport, so stick the empty copy to the left edge of the
+            // scrollport (not the full table width).
             <TableRow data-no-hover>
               <TableCell colSpan={colSpan} className="p-0">
                 <div className="sticky left-0 w-screen max-w-full p-4">

--- a/services/platform/app/features/automations/components/automations-grid.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.tsx
@@ -677,17 +677,21 @@ export function AutomationsGrid({
   }
 
   if (!hasAutomations) {
+    // EmptyState already uses flex-1 + justify-center; the page stack must
+    // fill the pane (see automations/index) so the copy sits in the middle
+    // of the area below the Installed/All tabs — not pinned under the header.
     return (
       <EmptyState
         icon={LayoutGrid}
         title={t('empty.title')}
         description={t('empty.description')}
+        className="min-h-0"
       />
     );
   }
 
   return (
-    <Stack gap={4}>
+    <Stack gap={4} className="min-h-0 flex-1">
       <CatalogToolbar
         search={{
           value: searchQuery,
@@ -702,6 +706,7 @@ export function AutomationsGrid({
             icon={LayoutGrid}
             title={t('noResults.title')}
             description={t('noResults.description')}
+            className="min-h-0"
           />
         ) : (
           // The Installed tab with nothing installed yet — the All tab sits
@@ -710,6 +715,7 @@ export function AutomationsGrid({
             icon={LayoutGrid}
             title={t('empty.title')}
             description={t('empty.description')}
+            className="min-h-0"
           />
         )
       ) : hasFolders ? (

--- a/services/platform/app/features/chat/components/chat-input.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input.test.tsx
@@ -410,6 +410,20 @@ describe('ChatInput disabled composer (missing API key)', () => {
     expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
   });
 
+  it('hides textarea glyphs when a draft sits under the disabled overlay', () => {
+    // Regression: a conversation-starter fill (or restored draft) left real
+    // text in the disabled textarea while the absolute "No API key…" overlay
+    // painted on top — the two stacked and read as garbled overlap.
+    renderDisabledForMissingApiKey({
+      value: 'Help me write a clear, professional email',
+    });
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toBeDisabled();
+    expect(textarea).toHaveClass('text-transparent');
+    expect(screen.getByText(NO_API_KEY_MESSAGE)).toBeInTheDocument();
+  });
+
   it('shows the actionable Settings link for an admin', () => {
     mockCan.mockReturnValue(true);
     renderDisabledForMissingApiKey();

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -1284,7 +1284,15 @@ export function ChatInput({
               onCompositionEnd={() => {
                 isComposingRef.current = false;
               }}
-              className="text-foreground placeholder:text-muted-foreground relative min-h-[72px] resize-none border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:min-h-[100px]"
+              className={cn(
+                'text-foreground placeholder:text-muted-foreground relative min-h-[72px] resize-none border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:min-h-[100px]',
+                // The disabled-reason overlay is `absolute top-0` over this
+                // textarea. A conversation-starter click (or a restored draft)
+                // can still leave glyphs in `value` while `disabled` — without
+                // this, those glyphs stack under the "No API key…" copy and
+                // read as a garbled double-print.
+                disabled && 'text-transparent caret-transparent',
+              )}
               disabled={inputDisabled}
               placeholder=""
               aria-labelledby={textareaLabelId}

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -1313,7 +1313,14 @@ export function ChatInterface({
                 isAgentLoading={isAgentLoading}
                 agentName={effectiveAgent?.displayName}
                 conversationStarters={effectiveAgent?.conversationStarters}
-                onSuggestionClick={setInputValue}
+                onSuggestionClick={(starter) => {
+                  // Starters fill the composer; when the composer is hard-
+                  // disabled for a missing API key the fill would sit under
+                  // the absolute reason overlay and double-print. Skip until
+                  // a key exists (the Open-provider-settings CTA is the path).
+                  if (missingKeyBlocked) return;
+                  setInputValue(starter);
+                }}
               />
             )}
 

--- a/services/platform/app/features/settings/branding/components/branding-settings.tsx
+++ b/services/platform/app/features/settings/branding/components/branding-settings.tsx
@@ -56,7 +56,7 @@ function BrandingSettingsView({
   }, []);
 
   return (
-    <SettingsPage fitToContainer>
+    <SettingsPage fitToContainer fullWidth>
       <SettingsSection
         title={tNav('branding')}
         description={tSettings('menu.branding.description')}
@@ -64,7 +64,9 @@ function BrandingSettingsView({
       >
         {/* `justify-center` centers the fixed-width form on small screens where
             the preview is hidden; it's inert on lg where the flex-1 preview fills
-            the row. */}
+            the row. `fullWidth` above drops the default max-w-3xl cap — otherwise
+            form (max-w-sm) + preview share ~768px and the mock dashboard
+            squashes into a ~300px strip. */}
         <Row gap={6} align="stretch" justify="center" className="flex-1">
           <BrandingForm
             organizationId={organizationId}

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
@@ -217,7 +217,10 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
             disabled={!canEdit || editor.isLoading}
             className="contents"
           >
-            <Stack gap={6} className="max-w-2xl">
+            {/* Full section width (not max-w-2xl): Discard/Save and fields
+                share the right edge with section header toggles on Security
+                & Monitoring. */}
+            <Stack gap={6}>
               {enabled && (
                 <Stack gap={4}>
                   <div>
@@ -227,6 +230,7 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
                       min={1}
                       max={50}
                       step={1}
+                      wrapperClassName="max-w-xs"
                       errorMessage={errors.maxAttempts?.message}
                       {...register('maxAttempts', { valueAsNumber: true })}
                     />

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -184,7 +184,10 @@ export function PasswordPolicyEditor({
             disabled={!canEdit || editor.isLoading}
             className="contents"
           >
-            <Stack gap={6} className="max-w-2xl">
+            {/* Full section width (not max-w-2xl): Discard/Save share the
+                section right edge with sibling Security & Monitoring actions.
+                Short numeric fields stay max-w-xs so they don't stretch. */}
+            <Stack gap={6}>
               <Stack gap={4}>
                 <div>
                   <Input
@@ -193,6 +196,7 @@ export function PasswordPolicyEditor({
                     min={6}
                     max={128}
                     step={1}
+                    wrapperClassName="max-w-xs"
                     errorMessage={errors.minLength?.message}
                     {...register('minLength', { valueAsNumber: true })}
                   />
@@ -248,6 +252,7 @@ export function PasswordPolicyEditor({
                       min={1}
                       max={3650}
                       step={1}
+                      wrapperClassName="max-w-xs"
                       errorMessage={errors.rotationDays?.message}
                       {...register('rotationDays', { valueAsNumber: true })}
                     />

--- a/services/platform/app/features/settings/governance/components/sandbox-quota-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/sandbox-quota-editor.tsx
@@ -129,7 +129,9 @@ export function SandboxQuotaEditor({
             disabled={!canEdit || editor.isLoading}
             className="contents"
           >
-            <Stack gap={6} className="max-w-2xl">
+            {/* Full section width (not max-w-2xl): Discard/Save must share
+                the section right edge with sibling Policies & limits actions. */}
+            <Stack gap={6}>
               <div>
                 <Input
                   label={t('sandboxQuota.maxSessions')}
@@ -137,6 +139,7 @@ export function SandboxQuotaEditor({
                   min={1}
                   max={500}
                   step={1}
+                  wrapperClassName="max-w-xs"
                   errorMessage={errors.maxSessionsPerOrg?.message}
                   {...register('maxSessionsPerOrg', { valueAsNumber: true })}
                 />

--- a/services/platform/app/features/settings/governance/components/session-idle-timeout-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/session-idle-timeout-editor.tsx
@@ -164,7 +164,9 @@ export function SessionIdleTimeoutEditor({
             disabled={!canEdit || editor.isLoading}
             className="contents"
           >
-            <Stack gap={6} className="max-w-2xl">
+            {/* Full section width (not max-w-2xl): Discard/Save share the
+                section toggle's right edge. Minutes field stays max-w-xs. */}
+            <Stack gap={6}>
               {enabled && (
                 <div>
                   <Input
@@ -173,6 +175,7 @@ export function SessionIdleTimeoutEditor({
                     min={SESSION_IDLE_TIMEOUT_MIN_MINUTES}
                     max={SESSION_IDLE_TIMEOUT_MAX_MINUTES}
                     step={1}
+                    wrapperClassName="max-w-xs"
                     errorMessage={errors.idleTimeoutMinutes?.message}
                     {...register('idleTimeoutMinutes', { valueAsNumber: true })}
                   />

--- a/services/platform/app/features/settings/governance/components/system-prompt-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/system-prompt-editor.test.tsx
@@ -61,6 +61,22 @@ describe('SystemPromptEditor', () => {
       render(<SystemPromptEditor organizationId="org-1" />);
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
+
+    it('spans the full settings section so Discard/Save share the Add-rule edge', () => {
+      // Regression: a max-w-2xl wrap left the textareas and action cluster
+      // narrower than Default Models (+ Add rule) on the same Content & models
+      // page, so the right edges didn't line up.
+      setLoaded();
+      const { container } = render(
+        <SystemPromptEditor organizationId="org-1" />,
+      );
+      const form = container.querySelector('form');
+      expect(form).not.toBeNull();
+      expect(form?.querySelector('.max-w-2xl')).toBeNull();
+      expect(
+        screen.getByRole('button', { name: /discard/i }).closest('.ml-auto'),
+      ).not.toBeNull();
+    });
   });
 
   describe('loading state (skeletonized)', () => {

--- a/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
@@ -127,7 +127,10 @@ export function SystemPromptEditor({
       >
         <form id={FORM_ID} onSubmit={editor.submit}>
           <fieldset disabled={editor.isLoading} className="contents">
-            <Stack gap={6} className="max-w-2xl">
+            {/* Full section width (not max-w-2xl): sits above Default Models
+                on Content & models, so the textareas and the Discard/Save
+                cluster must share the same right edge as "+ Add rule". */}
+            <Stack gap={6}>
               <FormSection
                 label={t('systemPrompt.prefixLabel')}
                 description={t('systemPrompt.prefixDescription')}

--- a/services/platform/app/features/settings/governance/components/two-factor-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/two-factor-policy-editor.tsx
@@ -169,7 +169,9 @@ export function TwoFactorPolicyEditor({
           />
         }
       >
-        <Stack gap={6} className="max-w-2xl">
+        {/* Full section width (not max-w-2xl): matches header toggle edge.
+            Short numeric grace field stays max-w-xs. */}
+        <Stack gap={6}>
           {!enforced && (
             <Text variant="muted" className="text-sm">
               {t('twoFactorPolicy.policyDisabledHint')}
@@ -196,6 +198,7 @@ export function TwoFactorPolicyEditor({
                 min={0}
                 max={30}
                 step={1}
+                wrapperClassName="max-w-xs"
               />
               <Text variant="muted" className="text-xs">
                 {t('twoFactorPolicy.gracePeriodDaysHint')}

--- a/services/platform/app/features/settings/governance/components/upload-policy-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/upload-policy-editor.test.tsx
@@ -83,6 +83,18 @@ describe('UploadPolicyEditor', () => {
       render(<UploadPolicyEditor organizationId="org-1" />);
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
+
+    it('spans the full settings section so Discard/Save share the Edit edge', () => {
+      // Regression: max-w-2xl left the form + action cluster narrower than
+      // Retention's Edit on the same Policies & limits page.
+      setLoaded();
+      const { container } = render(
+        <UploadPolicyEditor organizationId="org-1" />,
+      );
+      const form = container.querySelector('form');
+      expect(form).not.toBeNull();
+      expect(form?.querySelector('.max-w-2xl')).toBeNull();
+    });
   });
 
   describe('loading state (skeletonized)', () => {

--- a/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
@@ -251,7 +251,10 @@ export function UploadPolicyEditor({
               disabled={!canManage || editor.isLoading}
               className="contents"
             >
-              <Stack gap={6} className="max-w-2xl">
+              {/* Full section width (not max-w-2xl): Discard/Save must share
+                  the right edge with the section action toggle and sibling
+                  sections (e.g. Retention Edit) on Policies & limits. */}
+              <Stack gap={6}>
                 <Stack gap={4}>
                   <Grid md={2}>
                     <Input

--- a/services/platform/app/features/settings/integrations/components/integrations.tsx
+++ b/services/platform/app/features/settings/integrations/components/integrations.tsx
@@ -156,6 +156,7 @@ export function Integrations({
           icon={Search}
           title={t('integrations.noResults.title')}
           description={t('integrations.noResults.description')}
+          className="min-h-0"
         />
       );
     }
@@ -165,6 +166,7 @@ export function Integrations({
           icon={Unplug}
           title={t('integrations.empty.connectedTitle')}
           description={t('integrations.empty.connectedDescription')}
+          className="min-h-0"
         />
       );
     }
@@ -186,9 +188,11 @@ export function Integrations({
   }, [initialSlug, integrations, onInitialSlugConsumed]);
 
   return (
-    <Stack gap={0} className="pb-8">
+    // Fill the settings pane so EmptyState (flex-1 + justify-center) sits in
+    // the middle of the area below the tabs/search — same fix as Automations.
+    <Stack gap={0} className="min-h-0 flex-1 pb-8">
       <CatalogToolbar
-        className="mb-4"
+        className="mb-4 shrink-0"
         tabs={{ items: tabItems, value: tab, onValueChange: onTabChange }}
         search={{
           value: searchQuery,

--- a/services/platform/app/routes/dashboard/$id/automations/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/index.tsx
@@ -51,7 +51,7 @@ function AutomationsIndexPage() {
   });
 
   return (
-    <Stack gap={6} className="p-4">
+    <Stack gap={6} className="min-h-0 flex-1 p-4">
       <AutomationsGrid
         organizationId={organizationId}
         tab={tab ?? DEFAULT_AUTOMATIONS_TAB}

--- a/services/platform/app/routes/dashboard/$id/settings/integrations.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/integrations.tsx
@@ -167,10 +167,11 @@ function IntegrationsPage() {
   };
 
   return (
-    <SettingsPage>
+    <SettingsPage fitToContainer>
       <SettingsSection
         title={tNav('integrations')}
         description={tSettings('integrations.pageSubtitle')}
+        className="min-h-0 flex-1"
       >
         <Integrations
           organizationId={organizationId}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -884,6 +884,50 @@
     "integrationsTab": {
       "emptyTitle": "Keine Integrationen erforderlich",
       "emptyDescription": "Diese Automation läuft ohne verbundene Integration."
+    },
+    "metrics": {
+      "link": "Metriken anzeigen",
+      "title": "Workflow-Metriken",
+      "description": "Nutzungs- und Leistungskennzahlen über alle Automatisierungen.",
+      "cappedNotice": "Es werden die letzten 5.000 Ausführungen in diesem Zeitraum angezeigt. Ältere Ausführungen sind nicht in diesen Summen enthalten.",
+      "period": {
+        "last7Days": "Letzte 7 Tage",
+        "last30Days": "Letzte 30 Tage",
+        "last90Days": "Letzte 90 Tage",
+        "label": "Zeitraum"
+      },
+      "cards": {
+        "totalRuns": "Ausführungen gesamt",
+        "successRate": "Erfolgsquote",
+        "avgDuration": "Ø Dauer",
+        "failedRuns": "Fehlgeschlagen"
+      },
+      "chart": {
+        "trendTitle": "Ausführungen im Zeitverlauf",
+        "trendTooltip": "Anzahl der Workflow-Ausführungen im gewählten Zeitraum",
+        "statusTitle": "Statusverteilung",
+        "statusTooltip": "Verteilung der Workflow-Ergebnisse",
+        "totalLabel": "Gesamt",
+        "noData": "Keine Daten",
+        "noDataDescription": "Führe einen Workflow aus, um die Verteilung zu sehen",
+        "completed": "Abgeschlossen",
+        "failed": "Fehlgeschlagen",
+        "running": "Läuft",
+        "pending": "Ausstehend"
+      },
+      "table": {
+        "title": "Top-Workflows",
+        "workflow": "Workflow",
+        "runs": "Ausführungen",
+        "successRate": "Erfolgsquote",
+        "avgDuration": "Ø Dauer",
+        "failed": "Fehlgeschlagen",
+        "lastRun": "Letzte Ausführung"
+      },
+      "empty": {
+        "title": "Keine Workflow-Ausführungen",
+        "description": "Im gewählten Zeitraum wurden keine Workflows ausgeführt."
+      }
     }
   },
   "changelog": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -884,6 +884,50 @@
     "integrationsTab": {
       "emptyTitle": "No integrations required",
       "emptyDescription": "This automation runs without any connected integration."
+    },
+    "metrics": {
+      "link": "Metrics",
+      "title": "Automation Metrics",
+      "description": "Usage and performance KPIs across your automations.",
+      "cappedNotice": "Showing the most recent 5,000 runs in this window. Older runs in this period are not included in these totals.",
+      "period": {
+        "last7Days": "Last 7 days",
+        "last30Days": "Last 30 days",
+        "last90Days": "Last 90 days",
+        "label": "Period"
+      },
+      "cards": {
+        "totalRuns": "Total runs",
+        "successRate": "Success rate",
+        "avgDuration": "Avg duration",
+        "failedRuns": "Failed runs"
+      },
+      "chart": {
+        "trendTitle": "Runs over time",
+        "trendTooltip": "Number of workflow executions over the selected time period",
+        "statusTitle": "Status breakdown",
+        "statusTooltip": "Distribution of workflow run outcomes",
+        "totalLabel": "Total runs",
+        "noData": "No data",
+        "noDataDescription": "Run a workflow to see breakdown",
+        "completed": "Completed",
+        "failed": "Failed",
+        "running": "Running",
+        "pending": "Pending"
+      },
+      "table": {
+        "title": "Top workflows",
+        "workflow": "Workflow",
+        "runs": "Runs",
+        "successRate": "Success rate",
+        "avgDuration": "Avg duration",
+        "failed": "Failed",
+        "lastRun": "Last run"
+      },
+      "empty": {
+        "title": "No workflow runs",
+        "description": "No workflows have run in the selected period."
+      }
     }
   },
   "changelog": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -885,6 +885,50 @@
     "integrationsTab": {
       "emptyTitle": "Aucune intégration requise",
       "emptyDescription": "Cette automatisation fonctionne sans intégration connectée."
+    },
+    "metrics": {
+      "link": "Voir les métriques",
+      "title": "Métriques des workflows",
+      "description": "Indicateurs d'utilisation et de performance de tes automatisations.",
+      "cappedNotice": "Affichage des 5 000 exécutions les plus récentes sur cette période. Les exécutions plus anciennes ne sont pas incluses dans ces totaux.",
+      "period": {
+        "last7Days": "7 derniers jours",
+        "last30Days": "30 derniers jours",
+        "last90Days": "90 derniers jours",
+        "label": "Période"
+      },
+      "cards": {
+        "totalRuns": "Exécutions totales",
+        "successRate": "Taux de réussite",
+        "avgDuration": "Durée moyenne",
+        "failedRuns": "Échecs"
+      },
+      "chart": {
+        "trendTitle": "Exécutions dans le temps",
+        "trendTooltip": "Nombre d'exécutions de workflows sur la période sélectionnée",
+        "statusTitle": "Répartition par statut",
+        "statusTooltip": "Distribution des résultats d'exécution des workflows",
+        "totalLabel": "Total",
+        "noData": "Aucune donnée",
+        "noDataDescription": "Exécute un workflow pour voir la répartition",
+        "completed": "Terminées",
+        "failed": "Échouées",
+        "running": "En cours",
+        "pending": "En attente"
+      },
+      "table": {
+        "title": "Top workflows",
+        "workflow": "Workflow",
+        "runs": "Exécutions",
+        "successRate": "Taux de réussite",
+        "avgDuration": "Durée moyenne",
+        "failed": "Échecs",
+        "lastRun": "Dernière exécution"
+      },
+      "empty": {
+        "title": "Aucune exécution",
+        "description": "Aucun workflow n'a été exécuté sur la période sélectionnée."
+      }
     }
   },
   "changelog": {


### PR DESCRIPTION
## Summary
- Restore missing `automations.metrics` locale strings (en/de/fr) so Metrics no longer shows raw i18n keys
- Stop empty DataTables from forcing a horizontal scrollbar; center Automations/Integrations empty states and bump shared empty-state icon to 24px
- Drop `max-w-2xl` on governance form clusters so Discard/Save align with section actions; give Branding `fullWidth` so the live preview isn’t squashed
- Keep the missing-API-key composer overlay from stacking over conversation-starter/draft text

## Test plan
- [ ] Settings → Metrics → Automations: labels read as real copy (not `metrics.cards.*` keys)
- [ ] Settings → Sandboxes (empty): bordered empty state has no horizontal scrollbar
- [ ] Automations / Settings → Integrations empty: empty copy is vertically centered; icon reads at 24px
- [ ] Governance Content & models / Policies & limits / Security & Monitoring: Discard/Save line up with section header actions; short number fields stay compact
- [ ] Settings → Branding (lg+): preview mock is usable width, not a narrow portrait strip
- [ ] Chat with no provider key: only the API-key message + Open provider settings shows (no overlapped starter text); clicking a starter does nothing until a key exists


Made with [Cursor](https://cursor.com)