### PR TITLE
fix(platform): unblock local Convex push (linkedom canvas) + data-safe reset advice

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -479,6 +479,7 @@
   "patchedDependencies": {
     "convex-helpers@0.1.114": "patches/convex-helpers@0.1.114.patch",
     "@convex-dev/agent@0.6.1": "patches/@convex-dev%2Fagent@0.6.1.patch",
+    "linkedom@0.18.13": "patches/linkedom@0.18.13.patch",
   },
   "overrides": {
     "@xmldom/xmldom": "0.8.13",

--- a/docs/en/develop/contributor-setup.md
+++ b/docs/en/develop/contributor-setup.md
@@ -78,7 +78,21 @@ Set `TALE_DEV_SKIP_CONVEX_MAINTENANCE=1` to opt out of prune/snapshot cleanup (t
 
 ## Resetting local Convex dev data
 
-Last resort only — wipes **all** local Convex dev data: every table in the local SQLite file, every upload in `convex_local_storage/files/`, and every function bundle. Org config on disk and `.env.local` are untouched.
+Last resort only — `bun run setup:clean` wipes **all** local Convex dev data: every table in the local SQLite file, every upload in `convex_local_storage/files/`, and every function bundle. Org config on disk and `.env.local` are untouched.
+
+**Keep your data across the reset.** Even when the integrity gate fires (a live module bundle is missing), the backend itself still starts — so you can export your data first and restore it afterwards, and the reset then loses nothing:
+
+```bash
+# 1. Start the backend (this bypasses the `bun run dev` integrity gate), then
+#    export in a second terminal:
+bun run --filter @tale/platform convex:dev
+cd services/platform && npx convex export --path convex-backup.zip
+
+# 2. Reset (guarded — see below), bootstrap a fresh deployment, then restore:
+bun run setup:clean            # type: delete local convex
+bun run dev                    # wait for the READY banner
+cd services/platform && npx convex import --replace-all convex-backup.zip
+```
 
 `bun run setup:clean` is guarded on purpose (coding agents must not run it unless you explicitly asked):
 
@@ -86,7 +100,7 @@ Last resort only — wipes **all** local Convex dev data: every table in the loc
 2. When prompted, type the exact phrase `delete local convex` (a bare `y` is rejected).
 3. Non-interactive runs (CI) require `TALE_CONFIRM_DESTROY_LOCAL_CONVEX=delete-local-convex` — never set that in agent shells.
 
-Try automatic maintenance and a normal `bun run dev` first. Only run `bun run setup:clean` when you accept losing local conversations, uploads, and other anonymous-deployment state.
+Try automatic maintenance and a normal `bun run dev` first. If you must reset, **export first** (above) to keep your data — only skip the export when you truly don't need the local conversations, uploads, and other anonymous-deployment state.
 
 ## Hybrid mode against a containerised Convex
 

--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
   "packageManager": "bun@1.3.10",
   "patchedDependencies": {
     "convex-helpers@0.1.114": "patches/convex-helpers@0.1.114.patch",
-    "@convex-dev/agent@0.6.1": "patches/@convex-dev%2Fagent@0.6.1.patch"
+    "@convex-dev/agent@0.6.1": "patches/@convex-dev%2Fagent@0.6.1.patch",
+    "linkedom@0.18.13": "patches/linkedom@0.18.13.patch"
   },
   "scarfSettings": {
     "enabled": false

--- a/patches/linkedom@0.18.13.patch
+++ b/patches/linkedom@0.18.13.patch
@@ -1,0 +1,13 @@
+diff --git a/commonjs/canvas.cjs b/commonjs/canvas.cjs
+index 76ea9db4f5a8c08b70813b0beb80aa6a1dced5b4..f8e18f9a964f895764bfbc8db8fbd2f6f171769e 100644
+--- a/commonjs/canvas.cjs
++++ b/commonjs/canvas.cjs
+@@ -1,7 +1,3 @@
+ /* c8 ignore start */
+-try {
+-  module.exports = require('canvas');
+-} catch (fallback) {
+-  module.exports = require('./canvas-shim.cjs');
+-}
++module.exports = require('./canvas-shim.cjs');
+ /* c8 ignore stop */

--- a/services/platform/scripts/convex-local-maintenance.test.ts
+++ b/services/platform/scripts/convex-local-maintenance.test.ts
@@ -184,6 +184,9 @@ describe('applyConvexLocalMaintenance', () => {
     expect(result.integrityError).toContain('module storage is incomplete');
     expect(result.integrityError).toContain('live');
     expect(formatModuleIntegrityError(['live'])).toContain('setup:clean');
+    // The advice must preserve data — point at export/import, not a bare wipe.
+    expect(formatModuleIntegrityError(['live'])).toContain('convex export');
+    expect(formatModuleIntegrityError(['live'])).toContain('convex import');
   });
 
   it('sets integrityError after prune if a live blob disappeared', () => {

--- a/services/platform/scripts/convex-local-maintenance.ts
+++ b/services/platform/scripts/convex-local-maintenance.ts
@@ -171,9 +171,16 @@ export function formatModuleIntegrityError(missing: readonly string[]): string {
     `Local Convex module storage is incomplete: ${missing.length} live ` +
     `function-bundle blob(s) referenced by the deployment are missing on disk` +
     (sample ? ` (e.g. ${sample}${more})` : '') +
-    '. Automatic prune cannot repair this. Stop other Convex processes, then ' +
-    'run `bun run setup:clean` (type `delete local convex`) and `bun run dev` ' +
-    'to bootstrap a fresh deployment.'
+    '. Automatic prune cannot repair this — the bundle bytes are gone, so the ' +
+    'deployment must be rebuilt. To rebuild WITHOUT losing local data, export ' +
+    'it first (the backend still starts): run ' +
+    '`bun run --filter @tale/platform convex:dev` (this bypasses the check) ' +
+    'and, in another terminal, `cd services/platform && npx convex export ' +
+    '--path convex-backup.zip`. Then reset and restore: `bun run setup:clean` ' +
+    '(type `delete local convex`), `bun run dev`, then `cd services/platform && ' +
+    'npx convex import --replace-all convex-backup.zip`. See contributor-setup ' +
+    '(resetting local Convex dev data). Running setup:clean without exporting ' +
+    'first permanently discards every local table, upload, and function.'
   );
 }
 


### PR DESCRIPTION
Two independent fixes for the local Convex dev experience, both surfaced while diagnosing a corrupt local deployment.

## 1. linkedom pulls native `canvas` into crawler node actions

`linkedom` (the crawler's HTML parser, `convex/crawler/helpers/parse_html.ts`) statically imports the classic `canvas` package via its `HTMLCanvasElement` support. esbuild therefore bundles `canvas/build/Release/canvas.node` into every `'use node'` crawler action, and a local `convex dev` push fails:

> ✘ No loader is configured for ".node" files: node_modules/canvas/build/Release/canvas.node

`canvas` is in `convex.json` `externalPackages`, but Convex only externalizes a package whose resolved path matches `services/platform/node_modules/<pkg>` — which fails for the root-hoisted transitive `linkedom → canvas` in the bun-workspace layout. CI and Docker use a flat `node_modules` where it resolves, so this only breaks local dev after a fresh install.

**Fix:** patch `linkedom`'s `commonjs/canvas.cjs` to load its own pure-JS `canvas-shim.cjs` directly instead of `try(require('canvas'))/catch(shim)`. The crawler never renders a canvas, so behaviour is unchanged and no native binary is bundled.

## 2. Module-integrity failure told developers to throw away their data

When a live function-bundle blob is missing on disk, the integrity gate stopped `bun run dev` with advice to run `setup:clean` and "bootstrap a fresh deployment" — which silently discards every local table, upload, and function, and never mentioned the data was recoverable.

The backend still starts with a missing bundle, so the data can be exported and re-imported around the reset. The error message and the `contributor-setup` reset section now point at the data-preserving path:

```
bun run --filter @tale/platform convex:dev        # start backend (bypasses the gate)
cd services/platform && npx convex export --path convex-backup.zip
bun run setup:clean                               # then reset
bun run dev
cd services/platform && npx convex import --replace-all convex-backup.zip
```

A unit assertion locks the message to naming `convex export` and `convex import`.

**Follow-up:** the de/fr `contributor-setup` translations still describe the old wipe-only flow and should be updated to match.
