### PR TITLE
fix(platform): invalidate agents list cache after agent save

### DIFF
--- a/services/platform/app/features/agents/components/agent-navigation.test.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
@@ -46,6 +46,17 @@ vi.mock('@/app/hooks/use-convex-action', () => ({
   useConvexAction: () => ({ mutateAsync: vi.fn() }),
 }));
 
+const saveAgentMock = vi.fn();
+const restoreAgentMock = vi.fn();
+const snapshotMock = vi.fn();
+vi.mock('../hooks/mutations', () => ({
+  // Regression: Save/restore must go through these hooks so the agents list
+  // cache (chat ModelSelector / supportedModels) is invalidated after edit.
+  useSaveAgent: () => ({ mutateAsync: saveAgentMock }),
+  useRestoreFromHistory: () => ({ mutateAsync: restoreAgentMock }),
+  useSnapshotToHistory: () => ({ mutateAsync: snapshotMock }),
+}));
+
 vi.mock('@/app/hooks/use-format-date', () => ({
   useFormatDate: () => ({
     formatDate: (date: Date) => date.toISOString(),
@@ -86,6 +97,7 @@ vi.mock('../../organization/hooks/queries', () => ({
 // component reads.
 const agentConfigState = {
   config: {} as Record<string, unknown>,
+  initialConfig: {} as Record<string, unknown>,
   isDirty: false,
   isSaving: false,
   resetConfig: vi.fn(),
@@ -102,7 +114,7 @@ vi.mock('./history-diff-dialog', () => ({
 }));
 
 import { screen } from '@testing-library/react';
-import { expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
 
 import { AgentNavigation } from './agent-navigation';
 
@@ -113,6 +125,17 @@ const VALID_CONFIG = {
 };
 
 describe('AgentNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveAgentMock.mockResolvedValue({ hash: 'h' });
+    restoreAgentMock.mockResolvedValue({ hash: 'h' });
+    snapshotMock.mockResolvedValue(undefined);
+    agentConfigState.initialConfig = { ...VALID_CONFIG };
+    agentConfigState.config = { ...VALID_CONFIG };
+    agentConfigState.isDirty = false;
+    agentConfigState.isSaving = false;
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       agentConfigState.config = {};
@@ -159,6 +182,38 @@ describe('AgentNavigation', () => {
       expect(
         screen.getByRole('button', { name: 'common.actions.save' }),
       ).toBeEnabled();
+    });
+  });
+
+  describe('list cache invalidation after save', () => {
+    it('saves via useSaveAgent so chat picks up new supportedModels', async () => {
+      const user = userEvent.setup();
+      const onSaved = vi.fn();
+      const withNewModel = {
+        ...VALID_CONFIG,
+        supportedModels: ['openai:gpt-4o', 'anthropic:claude-sonnet-4'],
+      };
+      agentConfigState.config = withNewModel;
+      agentConfigState.isDirty = true;
+
+      render(
+        <AgentNavigation
+          organizationId="test-org"
+          agentId="test-agent"
+          onSaved={onSaved}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'common.actions.save' }),
+      );
+
+      expect(saveAgentMock).toHaveBeenCalledWith({
+        organizationId: 'test-org',
+        agentName: 'test-agent',
+        config: withNewModel,
+      });
+      expect(onSaved).toHaveBeenCalled();
     });
   });
 });

--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -29,6 +29,11 @@ import { normalizeAgentConfig } from '@/lib/shared/utils/normalize-agent-config'
 import { changedKeys } from '@/lib/utils/structural-equal';
 
 import { useOrganization } from '../../organization/hooks/queries';
+import {
+  useRestoreFromHistory,
+  useSaveAgent,
+  useSnapshotToHistory,
+} from '../hooks/mutations';
 import { useAgentConfig } from '../hooks/use-agent-config-context';
 import { useAgentValidation } from '../hooks/use-agent-validation';
 import { HistoryDiffDialog } from './history-diff-dialog';
@@ -137,19 +142,19 @@ export function AgentNavigation({
   const { data: organization } = useOrganization(organizationId);
   const orgDefaultLocale = getOrganizationDefaultLocale(organization?.metadata);
 
-  const snapshotAction = useConvexAction(
-    api.agents.file_actions.snapshotToHistory,
-  );
-  const saveAction = useConvexAction(api.agents.file_actions.saveAgent);
+  // Use the shared mutation hooks so a successful save/restore invalidates
+  // `['config','agents',organizationId]` — chat's ModelSelector reads
+  // supportedModels from that cached list (`staleTime: Infinity`), and the
+  // raw action path left it stale after Instructions edits.
+  const snapshotAction = useSnapshotToHistory();
+  const saveAction = useSaveAgent();
   const listHistoryAction = useConvexAction(
     api.agents.file_actions.listHistory,
   );
   const readHistoryAction = useConvexAction(
     api.agents.file_actions.readHistoryEntry,
   );
-  const restoreAction = useConvexAction(
-    api.agents.file_actions.restoreFromHistory,
-  );
+  const restoreAction = useRestoreFromHistory();
 
   const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>([]);
   const [, setIsLoadingHistory] = useState(false);


### PR DESCRIPTION
## Summary
- Agent Instructions Save/restore now uses `useSaveAgent` / `useRestoreFromHistory`, which invalidate the cached `listAgents` query chat’s ModelSelector reads (`staleTime: Infinity`).
- Fixes new `supportedModels` not appearing in the chat model picker until a hard refresh.
- Adds a regression test that Save goes through the invalidating hook.

## Test plan
- [x] `bun run --filter @tale/platform test:ui -- app/features/agents/components/agent-navigation.test.tsx`
- [ ] Add a model on agent Instructions → Save → return to chat → select that agent → new model appears without refresh
- [ ] Restore a history entry that changes models → chat list updates

## Definition of done
- [x] **Green gate** — targeted UI tests green (full `check` not re-run for this one-liner hook swap)
- [x] **Security gate** — N/A (no boundary / auth change; pre-commit opengrep clean)
- [x] **Tests** — regression covers Save via `useSaveAgent`
- [x] **Migration** — N/A
- [x] **Locales** — N/A (no user-visible strings)
- [x] **Docs** — N/A
- [x] **Accessibility** — N/A (no UI structure change)
- [x] **Sweep** — create dialog / action menu already used `useSaveAgent`; navigation was the missing caller; restore path included
- [ ] **Observed** — unit test observed; browser repro left for reviewer / follow-up
- [x] **Commits** — one conventional commit on `cursor/invalidate-agents-list-on-save`