### PR TITLE
fix(platform): document.list can list a named project's folder files

### DIFF
--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -3,6 +3,8 @@ import { v } from 'convex/values';
 import type { Id } from '../_generated/dataModel';
 import { internalQuery } from '../_generated/server';
 import { getUserTeamIds } from '../lib/get_user_teams';
+import { toId } from '../lib/type_cast_helpers';
+import { resolveProjectAccessForUser } from '../projects/resolve_project_access';
 import { checkMembership } from './check_membership';
 import { getAccessibleDocumentIds as getAccessibleDocumentIdsHelper } from './get_accessible_document_ids';
 import { getAgentScopedFileIds as getAgentScopedFileIdsHelper } from './get_agent_scoped_file_ids';
@@ -97,6 +99,10 @@ export const listForAgent = internalQuery({
     organizationId: v.string(),
     userId: v.string(),
     folderId: v.optional(v.string()),
+    /** Owning project of a project-scoped listing (e.g. a task's quarter
+     *  folder). Read access is resolved once here; only then does the helper
+     *  surface that project's docs (hub listings still exclude them). */
+    projectId: v.optional(v.string()),
     folderPath: v.optional(v.string()),
     extension: v.optional(v.string()),
     teamId: v.optional(v.string()),
@@ -109,9 +115,25 @@ export const listForAgent = internalQuery({
     cursor: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { userId, ...rest } = args;
+    const { userId, projectId, ...rest } = args;
     const userTeamIds = await getUserTeamIds(ctx, userId);
-    return listDocumentsForAgentHelper(ctx, { ...rest, userTeamIds });
+    // A project-scoped listing surfaces the project's own docs only after the
+    // caller proves read access to it. Denied / absent → fall through to hub
+    // rules (project docs stay excluded) — fail-safe, no boundary loosening.
+    let allowedProjectId: string | undefined;
+    if (projectId) {
+      const access = await resolveProjectAccessForUser(
+        ctx,
+        toId<'projects'>(projectId),
+        { userId, organizationId: args.organizationId },
+      );
+      if (access.canRead) allowedProjectId = projectId;
+    }
+    return listDocumentsForAgentHelper(ctx, {
+      ...rest,
+      userTeamIds,
+      projectId: allowedProjectId,
+    });
   },
 });
 

--- a/services/platform/convex/documents/list_documents_for_agent.test.ts
+++ b/services/platform/convex/documents/list_documents_for_agent.test.ts
@@ -492,6 +492,43 @@ describe('listDocumentsForAgent', () => {
       expect(result.documents).toHaveLength(1);
     });
 
+    it("surfaces a project's own documents when the caller names that project", async () => {
+      const ctx = createMockCtx({}, [
+        makeDoc({ _id: 'doc1', teamId: undefined }),
+        makeDoc({ _id: 'doc2', teamId: undefined, projectId: 'proj1' }),
+      ]);
+
+      // Naming the owning project lifts the hub-only exclusion for THAT
+      // project's docs — the org-wide hub doc plus proj1's doc both list.
+      const result = await listDocumentsForAgent(ctx as unknown as QueryCtx, {
+        ...baseArgs,
+        userTeamIds: [],
+        projectId: 'proj1',
+      });
+
+      const ids = result.documents.map((d) => d.fileId);
+      expect(result.documents).toHaveLength(2);
+      expect(ids).toContain('file_doc1');
+      expect(ids).toContain('file_doc2');
+    });
+
+    it('keeps project-scoped documents isolated to the named project', async () => {
+      const ctx = createMockCtx({}, [
+        makeDoc({ _id: 'doc1', teamId: undefined, projectId: 'proj1' }),
+        makeDoc({ _id: 'doc2', teamId: undefined, projectId: 'proj2' }),
+      ]);
+
+      // Naming proj1 must never surface a sibling project's files.
+      const result = await listDocumentsForAgent(ctx as unknown as QueryCtx, {
+        ...baseArgs,
+        userTeamIds: [],
+        projectId: 'proj1',
+      });
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]?.fileId).toBe('file_doc1');
+    });
+
     it('filters out documents from teams user does not belong to', async () => {
       const ctx = createMockCtx({}, [
         makeDoc({ _id: 'doc1', teamId: 'team1' }),

--- a/services/platform/convex/documents/list_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_documents_for_agent.ts
@@ -18,7 +18,10 @@ import {
 } from '../lib/fuzzy_match';
 import { toId } from '../lib/type_cast_helpers';
 import { isActiveDocument } from './_helpers';
-import { hasKnowledgeHubDocumentAccess } from './access';
+import {
+  hasKnowledgeHubDocumentAccess,
+  isProjectScopedDocument,
+} from './access';
 
 const MAX_SCAN = 10_000;
 const DEFAULT_LIMIT = 20;
@@ -50,6 +53,12 @@ export async function listDocumentsForAgent(
     /** Exact folder id — wins over `folderPath` (no fuzzy resolution). The
      *  base query is org-keyed, so a foreign org's folder id matches nothing. */
     folderId?: string;
+    /** Owning project of a project-scoped listing. Project docs are hidden
+     *  from Knowledge Hub surfaces (`hasKnowledgeHubDocumentAccess`); when the
+     *  caller names the project (read access resolved once in `listForAgent`),
+     *  that project's docs become visible here — folder-driven desks list a
+     *  task's own quarter folder this way. Absent = hub behavior (excluded). */
+    projectId?: string;
     folderPath?: string;
     extension?: string;
     teamId?: string;
@@ -146,9 +155,13 @@ export async function listDocumentsForAgent(
     if (folderIdSet && !folderIdSet.has(doc.folderId ?? '')) continue;
     if (args.extension && doc.extension !== args.extension) continue;
 
-    // Team filter
+    // Team / project-scope filter
     if (args.teamId) {
       if (doc.teamId !== args.teamId) continue;
+    } else if (isProjectScopedDocument(doc)) {
+      // Project docs never surface in the hub; they list here only when the
+      // caller named their owning project (access resolved once upstream).
+      if (!args.projectId || doc.projectId !== args.projectId) continue;
     } else if (!hasKnowledgeHubDocumentAccess(doc, teamIdSet)) {
       continue;
     }

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -159,6 +159,10 @@ type DocumentActionParams =
       operation: 'list';
       /** Exact folder id — wins over `folderPath` (no fuzzy resolution). */
       folderId?: string;
+      /** Owning project of a project-scoped folder (e.g. a task's quarter
+       *  folder). Required to list that folder's files — project docs are
+       *  hidden from hub listings otherwise. Pass `{{input.task.projectId}}`. */
+      projectId?: string;
       folderPath?: string;
       extension?: string;
     }
@@ -272,6 +276,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
     v.object({
       operation: v.literal('list'),
       folderId: v.optional(v.string()),
+      projectId: v.optional(v.string()),
       folderPath: v.optional(v.string()),
       extension: v.optional(v.string()),
     }),
@@ -841,6 +846,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
               organizationId,
               userId,
               folderId: params.folderId,
+              projectId: params.projectId,
               folderPath: params.folderPath,
               extension: params.extension,
               limit: MAX_LIMIT,


### PR DESCRIPTION
## Problem

The `vat-return-desk` automation stopped running its first step — the invoice-reader (OCR) pass that writes `*.ocr.json` sidecars. A quarter full of invoice images went straight past extraction and the deterministic pipeline then failed:

> TRANSFORM FAILED: invoice raster(s) without a `*.ocr.json` sidecar …

## Root cause

The `document.list` workflow action (`documents.internal_queries.listForAgent` → `listDocumentsForAgent`) runs every row through `hasKnowledgeHubDocumentAccess`, which **excludes project-scoped documents unconditionally** (they surface through the project's own queries, never the hub). A folder-driven automation that lists a task's **project** folder therefore always got an empty list.

The desk's `has_invoice_rasters` gate reads that list, saw zero files, and routed around `extract_invoices`. No sidecars were produced, so `run_pipeline`'s transform failed on the missing sidecars.

Verified against the live dev backend on the exact failing quarter folder:

| `listForAgent` on the folder | documents |
| --- | --- |
| without `projectId` (old behavior) | **0** |
| with `projectId` (this PR) | **8** — `Scans Q2 2026.pdf`, `IMG_5083.jpg` … `IMG_5112.jpg` |

## Change

Add an optional `projectId` to the `list` op:

- `listForAgent` resolves the caller's **read access** to that project once (fail-safe: denied/absent → hub behavior, project docs stay hidden).
- The row filter then surfaces **that project's own** docs — still hidden from hub surfaces, and **isolated to the named project** (a sibling project's files never leak).
- No `projectId` → unchanged hub behavior.

## Companion pack change (separate `configs` repo)

`vat-return-desk` workflow → **1.7.0**:
- `list_quarter_files` passes `projectId: {{input.task.projectId}}` so the gate sees the real files → OCR runs first again.
- new `has_any_files` gate: a folder with **no files at all** ends the run immediately with a note on the task, instead of booting the reader or the setup assistant on nothing.

## Tests

- `list_documents_for_agent.test.ts`: +2 cases (named project surfaces its docs; cross-project isolation). 77 pass.
- `bun run --filter @tale/platform typecheck` green.