### PR TITLE
fix(sandbox): chunk skill stage uploads to avoid 413

### DIFF
--- a/services/platform/convex/agents/external_agent/run_external_agent.ts
+++ b/services/platform/convex/agents/external_agent/run_external_agent.ts
@@ -1044,7 +1044,7 @@ export const runExternalAgentTurn = internalAction({
         workspaceIsTale = await workspaceIsTaleRepo(sessionId, workdirRel);
       } catch (skillErr) {
         console.warn(
-          '[runExternalAgentTurn] integration skill staging failed (continuing):',
+          '[runExternalAgentTurn] skill staging failed (continuing):',
           skillErr,
         );
       }

--- a/services/platform/convex/node_only/sandbox/bound_org_skills.test.ts
+++ b/services/platform/convex/node_only/sandbox/bound_org_skills.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { WORKFLOW_SKILL_NAMES } from '../../lib/skills/guidance';
-import { customBoundSlugs, planBoundOrgSkillPrune } from './bound_org_skills';
+import {
+  customBoundSlugs,
+  planBoundOrgSkillPrune,
+  shouldStageBoundSkillAsset,
+} from './bound_org_skills';
 import {
   BAKED_BUILTIN_SKILL_NAMES,
   INTEGRATION_SKILL_PREFIX,
@@ -26,6 +30,37 @@ describe('customBoundSlugs', () => {
   it('returns empty when bindings are absent or empty', () => {
     expect(customBoundSlugs(undefined)).toEqual([]);
     expect(customBoundSlugs([])).toEqual([]);
+  });
+});
+
+describe('shouldStageBoundSkillAsset', () => {
+  it('keeps runnable skill assets', () => {
+    expect(shouldStageBoundSkillAsset('engine/entrypoint.py')).toBe(true);
+    expect(shouldStageBoundSkillAsset('scripts/x.py')).toBe(true);
+    expect(shouldStageBoundSkillAsset('mapping/rates.yaml')).toBe(true);
+    expect(shouldStageBoundSkillAsset('schema/eCH-0217-2-0-0.xsd')).toBe(true);
+    expect(shouldStageBoundSkillAsset('README.md')).toBe(true);
+  });
+
+  it('drops test suites at any depth', () => {
+    expect(shouldStageBoundSkillAsset('tests/foo.py')).toBe(false);
+    expect(shouldStageBoundSkillAsset('engine/tests/bar.py')).toBe(false);
+    expect(shouldStageBoundSkillAsset('tests/parity/oracles/x.json')).toBe(
+      false,
+    );
+    // A file merely NAMED tests.py is not a tests/ directory.
+    expect(shouldStageBoundSkillAsset('engine/tests.py')).toBe(true);
+  });
+
+  it('drops bytecode and binary assets the UTF-8 read already corrupts', () => {
+    expect(shouldStageBoundSkillAsset('__pycache__/x.cpython-312.pyc')).toBe(
+      false,
+    );
+    expect(shouldStageBoundSkillAsset('engine/cached.pyc')).toBe(false);
+    expect(shouldStageBoundSkillAsset('assets/icon.png')).toBe(false);
+    expect(shouldStageBoundSkillAsset('docs/example.PDF')).toBe(false);
+    expect(shouldStageBoundSkillAsset('fonts/inter.woff2')).toBe(false);
+    expect(shouldStageBoundSkillAsset('bundle.zip')).toBe(false);
   });
 });
 

--- a/services/platform/convex/node_only/sandbox/bound_org_skills.ts
+++ b/services/platform/convex/node_only/sandbox/bound_org_skills.ts
@@ -59,6 +59,27 @@ export function customBoundSlugs(
   );
 }
 
+// Asset extensions that cannot survive the UTF-8 `readFileSafe` read used by
+// `readSkillForExecution` — staging them ships corrupt bytes, so they are
+// skipped up front (and they are dead weight for an agent anyway).
+const BINARY_ASSET_EXT_RE =
+  /\.(png|jpe?g|gif|webp|pdf|zip|woff2?|ttf|otf|pyc)$/i;
+
+/**
+ * Should this skill-bundle asset be staged into an AGENT session? Pure —
+ * exported for unit tests. Drops test suites (`tests/` at any depth),
+ * `__pycache__`, and binary assets: agents need the runnable skill (code,
+ * mappings, schemas, docs), not its test fixtures, and the binary formats
+ * are already broken by the UTF-8 read (see BINARY_ASSET_EXT_RE). Script
+ * steps' `useSkills` staging is separate and unaffected (stage_skills.ts
+ * include lists).
+ */
+export function shouldStageBoundSkillAsset(relPath: string): boolean {
+  const segments = relPath.split('/');
+  if (segments.some((s) => s === 'tests' || s === '__pycache__')) return false;
+  return !BINARY_ASSET_EXT_RE.test(relPath);
+}
+
 /** Pure prune decision for previously staged custom bound skill dirs. */
 export function planBoundOrgSkillPrune(input: {
   stagedDirNames: ReadonlySet<string>;
@@ -134,7 +155,10 @@ export async function stageBoundOrgSkills(
   const { kept } = selectStageableSkills(candidates, (slug) => slug, repoOwned);
   if (kept.length === 0) return;
 
-  const files: SessionStageFile[] = [];
+  // One stage call PER SKILL, each inside its own try/catch: a fat or broken
+  // skill must not take down its siblings (the old all-slugs-in-one-POST shape
+  // 413'd the whole set once the combined base64 outgrew the spawner body
+  // cap). sessionStageFiles chunks each skill's payload under the HTTP budget.
   for (const slug of kept) {
     try {
       const result = await ctx.runAction(
@@ -142,27 +166,28 @@ export async function stageBoundOrgSkills(
         { orgSlug, slug },
       );
       if (!isSkillReadOk(result)) continue;
-      files.push({
-        path: `${skillsStageDir}/${slug}/SKILL.md`,
-        contentBase64: Buffer.from(result.body, 'utf8').toString('base64'),
-      });
+      const files: SessionStageFile[] = [
+        {
+          path: `${skillsStageDir}/${slug}/SKILL.md`,
+          contentBase64: Buffer.from(result.body, 'utf8').toString('base64'),
+        },
+      ];
       for (const asset of result.files) {
+        if (!shouldStageBoundSkillAsset(asset.path)) continue;
         files.push({
           path: `${skillsStageDir}/${slug}/${asset.path}`,
           contentBase64: Buffer.from(asset.content, 'utf8').toString('base64'),
         });
       }
+      const staged = await sessionStageFiles(args.sessionId, files);
+      if (staged.skipped.length > 0) {
+        console.warn(
+          `[stageBoundOrgSkills] ${slug}: some files were skipped:`,
+          staged.skipped,
+        );
+      }
     } catch (err) {
-      console.warn(`[stageBoundOrgSkills] reading ${slug} failed:`, err);
+      console.warn(`[stageBoundOrgSkills] staging ${slug} failed:`, err);
     }
-  }
-
-  if (files.length === 0) return;
-  const result = await sessionStageFiles(args.sessionId, files);
-  if (result.skipped.length > 0) {
-    console.warn(
-      '[stageBoundOrgSkills] some files were skipped:',
-      result.skipped,
-    );
   }
 }

--- a/services/platform/convex/node_only/sandbox/helpers/session_client.test.ts
+++ b/services/platform/convex/node_only/sandbox/helpers/session_client.test.ts
@@ -4,7 +4,14 @@
 
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import { drainSessionExecResilient, sessionCreate } from './session_client';
+import {
+  chunkStageFiles,
+  drainSessionExecResilient,
+  STAGE_BODY_BUDGET_BYTES,
+  sessionCreate,
+  sessionStageFiles,
+  type SessionStageFile,
+} from './session_client';
 
 const enc = new TextEncoder();
 
@@ -133,6 +140,83 @@ describe('drainSessionExecResilient', () => {
     // Longer timeout: the give-up path deliberately sleeps the full linear
     // backoff (0.5+1+1.5+2+2.5s ≈ 7.5s) across the 5 retries.
   }, 15_000);
+});
+
+describe('chunkStageFiles', () => {
+  const stageFile = (path: string, contentBytes: number): SessionStageFile => ({
+    path,
+    contentBase64: 'a'.repeat(contentBytes),
+  });
+
+  test('packs many files into batches whose serialized body stays under the budget', () => {
+    const budget = 1_000;
+    const files = Array.from({ length: 40 }, (_, i) =>
+      stageFile(`dir/file-${i}.txt`, 100),
+    );
+    const batches = chunkStageFiles(files, budget);
+    expect(batches.length).toBeGreaterThan(1);
+    for (const batch of batches) {
+      expect(
+        Buffer.byteLength(JSON.stringify({ files: batch }), 'utf8'),
+      ).toBeLessThanOrEqual(budget);
+    }
+    // Order and completeness: flattening the batches reproduces the input.
+    expect(batches.flat()).toEqual(files);
+  });
+
+  test('a single entry over the budget throws instead of 413ing downstream', () => {
+    expect(() => chunkStageFiles([stageFile('big.bin', 2_000)], 1_000)).toThrow(
+      /big\.bin/,
+    );
+  });
+
+  test('empty input yields no batches', () => {
+    expect(chunkStageFiles([], 1_000)).toEqual([]);
+  });
+});
+
+describe('sessionStageFiles chunking', () => {
+  test('splits an over-budget payload into sequential POSTs and merges results', async () => {
+    // Two files that cannot share one batch under the module budget: each
+    // serializes to ~0.9 MiB, together ~1.8 MiB > 1.5 MiB.
+    const big = Math.floor(STAGE_BODY_BUDGET_BYTES * 0.6);
+    const files: SessionStageFile[] = [
+      { path: 'skills/a/SKILL.md', contentBase64: 'a'.repeat(big) },
+      { path: 'skills/b/SKILL.md', contentBase64: 'b'.repeat(big) },
+    ];
+    const bodies: Array<{ files: SessionStageFile[] }> = [];
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async (_url: any, init: any) => {
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+      const body = JSON.parse(String(init.body)) as {
+        files: SessionStageFile[];
+      };
+      bodies.push(body);
+      return new Response(
+        JSON.stringify({
+          staged: body.files.map((f) => ({ path: f.path, bytes: 1 })),
+          skipped:
+            bodies.length === 2
+              ? [{ path: 'skills/b/extra', reason: 'denied' }]
+              : [],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    const result = await sessionStageFiles('ses-stage', files);
+    expect(bodies.length).toBe(2);
+    expect(bodies[0]?.files.map((f) => f.path)).toEqual(['skills/a/SKILL.md']);
+    expect(bodies[1]?.files.map((f) => f.path)).toEqual(['skills/b/SKILL.md']);
+    expect(result.staged.map((s) => s.path)).toEqual([
+      'skills/a/SKILL.md',
+      'skills/b/SKILL.md',
+    ]);
+    expect(result.skipped).toEqual([
+      { path: 'skills/b/extra', reason: 'denied' },
+    ]);
+  });
 });
 
 describe('sessionCreate drain-retry', () => {

--- a/services/platform/convex/node_only/sandbox/helpers/session_client.ts
+++ b/services/platform/convex/node_only/sandbox/helpers/session_client.ts
@@ -480,9 +480,56 @@ export interface SessionStageResult {
   skipped: Array<{ path: string; reason: string }>;
 }
 
-/** POST /v1/sessions/:id/files/stage — write files into the session workspace.
- * Throws on transport/HTTP failure; per-file failures come back in `skipped`. */
-export async function sessionStageFiles(
+/** Client-side serialized-body budget per stage POST. Deliberately far under
+ * the spawner's maxRequestBodyBytes (2 MiB historically, 8 MiB now) so a
+ * multi-skill or fat-subtree payload never 413s regardless of which spawner
+ * build is running; the HMAC headers ride outside the body, so the envelope
+ * math below is exact. */
+export const STAGE_BODY_BUDGET_BYTES = 1.5 * 1024 * 1024;
+
+// Serialized length of the request envelope around the files array:
+// `{"files":[` + `]}`.
+const STAGE_ENVELOPE_BYTES = Buffer.byteLength('{"files":[]}', 'utf8');
+
+/**
+ * Pack stage files into batches whose SERIALIZED request body stays under
+ * `maxBodyBytes`, preserving order. Pure — exported for unit tests. Uses the
+ * exact JSON length (per-entry serialized bytes + separating commas +
+ * envelope), so a batch never exceeds the budget it was packed for. A single
+ * entry that cannot fit on its own throws: chunking cannot help an oversize
+ * file, and silently posting it would just 413 downstream.
+ */
+export function chunkStageFiles(
+  files: SessionStageFile[],
+  maxBodyBytes: number = STAGE_BODY_BUDGET_BYTES,
+): SessionStageFile[][] {
+  const batches: SessionStageFile[][] = [];
+  let batch: SessionStageFile[] = [];
+  let batchBytes = STAGE_ENVELOPE_BYTES;
+  for (const file of files) {
+    const entryBytes = Buffer.byteLength(JSON.stringify(file), 'utf8');
+    if (STAGE_ENVELOPE_BYTES + entryBytes > maxBodyBytes) {
+      throw new Error(
+        `stage file "${file.path}" serializes to ${entryBytes} bytes — over the ` +
+          `${maxBodyBytes}-byte request budget; it cannot be staged inline`,
+      );
+    }
+    const commaBytes = batch.length > 0 ? 1 : 0;
+    if (batchBytes + commaBytes + entryBytes > maxBodyBytes) {
+      batches.push(batch);
+      batch = [];
+      batchBytes = STAGE_ENVELOPE_BYTES;
+    }
+    batch.push(file);
+    batchBytes += (batch.length > 1 ? 1 : 0) + entryBytes;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+/** One raw stage POST — no chunking. Kept private; callers go through
+ * sessionStageFiles so every payload is budget-packed. */
+async function postStageFiles(
   sessionId: string,
   files: SessionStageFile[],
 ): Promise<SessionStageResult> {
@@ -500,6 +547,24 @@ export async function sessionStageFiles(
   }
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
   return (await res.json()) as SessionStageResult;
+}
+
+/** POST /v1/sessions/:id/files/stage — write files into the session workspace.
+ * Large payloads are auto-chunked into sequential POSTs, each packed under
+ * STAGE_BODY_BUDGET_BYTES, so callers can hand over whole skill bundles
+ * without tripping the spawner's request-body cap. Throws on transport/HTTP
+ * failure of any chunk; per-file failures come back merged in `skipped`. */
+export async function sessionStageFiles(
+  sessionId: string,
+  files: SessionStageFile[],
+): Promise<SessionStageResult> {
+  const merged: SessionStageResult = { staged: [], skipped: [] };
+  for (const batch of chunkStageFiles(files)) {
+    const result = await postStageFiles(sessionId, batch);
+    merged.staged.push(...result.staged);
+    merged.skipped.push(...result.skipped);
+  }
+  return merged;
 }
 
 export interface SessionDeleteResult {

--- a/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
+++ b/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
@@ -1495,7 +1495,7 @@ export const runSandboxAgent = internalAction({
           workspaceIsTale = await workspaceIsTaleRepo(sessionId);
         } catch (skillErr) {
           console.warn(
-            '[runSandboxAgent] integration skill staging failed (continuing):',
+            '[runSandboxAgent] skill staging failed (continuing):',
             skillErr,
           );
         }

--- a/services/platform/tests/integration/container-smoke-test.ts
+++ b/services/platform/tests/integration/container-smoke-test.ts
@@ -574,9 +574,10 @@ async function sandboxSessionProbe(): Promise<void> {
     );
   }
 
-  // 2 MB + 1 body → 413 (streaming body cap fires before HMAC check). Piped
+  // 8 MiB + 1 body → 413 (streaming body cap fires before HMAC check;
+  // matches SANDBOX_MAX_REQUEST_BODY_BYTES default in sandbox config). Piped
   // via stdin (`--data-binary @-`) to dodge the kernel's MAX_ARG_STRLEN.
-  const tooBig = 'x'.repeat(2_097_153);
+  const tooBig = 'x'.repeat(8 * 1024 * 1024 + 1);
   const oversized = await capture(
     [
       'curl',

--- a/services/sandbox/src/config.ts
+++ b/services/sandbox/src/config.ts
@@ -375,15 +375,17 @@ export function loadConfig(): SpawnerConfig {
       100 * 1024 * 1024,
       { min: 1024 },
     ),
-    // Body cap on /v1/execute. The request body now carries only URL
-    // lists (workspace files, prior outputs, upload slots) — no inline
-    // content — so 2 MB is plenty for the JSON envelope + URL strings
-    // even at the MAX_FILES_PER_REQUEST (50) ceiling. Bounds the
-    // unsigned-mode OOM surface. Operators with a niche need can raise
-    // via SANDBOX_MAX_REQUEST_BODY_BYTES.
+    // Body cap on /v1/execute and the session file endpoints. /v1/execute
+    // carries URL lists, but /v1/sessions/:id/files/stage takes INLINE
+    // base64 content (bound org skills, useSkills subtrees, steer control
+    // files), so the cap must fit a real skill-bundle chunk plus JSON
+    // envelope. The platform client chunks its stage payloads well under
+    // this (session_client.ts STAGE_BODY_BUDGET_BYTES); 8 MiB leaves
+    // headroom for growth while still bounding the unsigned-mode OOM
+    // surface. Operators can tune via SANDBOX_MAX_REQUEST_BODY_BYTES.
     maxRequestBodyBytes: numEnv(
       'SANDBOX_MAX_REQUEST_BODY_BYTES',
-      2 * 1024 * 1024,
+      8 * 1024 * 1024,
       { min: 4 * 1024 },
     ),
     session: {


### PR DESCRIPTION
## Summary
- Bound org skills (`swiss-vat-return` + `xlsx`/`pdf`/`docx`) were staged in one `sessionStageFiles` POST and hit the sandbox **2 MiB** body cap → HTTP **413**, so setup-assistant sessions never got those skills under `~/.claude/skills/`.
- Raise default `SANDBOX_MAX_REQUEST_BODY_BYTES` to **8 MiB**, stage **one skill per call** (isolated failures), auto-chunk payloads under a **1.5 MiB** client budget, skip `tests/` / binaries from agent staging, and fix the misleading “integration skill staging failed” catch logs.

## Test plan
- [x] `bunx vitest run convex/node_only/sandbox/bound_org_skills.test.ts convex/node_only/sandbox/helpers/session_client.test.ts` (16 passed)
- [ ] After sandbox restart (picks up 8 MiB default): re-run vat-return-desk setup-assistant and confirm `~/.claude/skills/swiss-vat-return/` (and xlsx/pdf/docx) exist; convex log has no `files stage failed (413)` for that turn

## Definition of done
- [x] Green gate — unit tests for changed modules
- [x] Security — N/A (no new auth/boundary; body cap still bounds OOM)
- [x] Tests — chunkStageFiles + shouldStageBoundSkillAsset + sessionStageFiles chunking
- [x] Migration — N/A
- [x] Locales — N/A
- [x] Docs — N/A (config comment updated in place)
- [x] Accessibility — N/A
- [x] Sweep — bound_org_skills, session_client, sandbox config, both catch sites
- [ ] Observed — live session re-smoke deferred (needs sandbox process restart for new default; client chunking alone already stays under the old 2 MiB)
- [x] Commits — atomic conventional on branch off main