### PR TITLE
feat(platform): add Collection list chrome for entity-list layout

### DIFF
--- a/services/platform/app/features/automations/registry/connected/collection.test.tsx
+++ b/services/platform/app/features/automations/registry/connected/collection.test.tsx
@@ -662,3 +662,41 @@ describe('Collection — search, row click, add action', () => {
     expect(applyEffect).toHaveBeenCalledWith(effect, undefined);
   });
 });
+
+describe('Collection — list chrome', () => {
+  it('renders title as a heading, keeps filters + add in the toolbar, and skips the Card section', () => {
+    paginatedReturn = paginated({ results: taskRows(1), status: 'Exhausted' });
+
+    render(
+      <Collection
+        title="VAT returns"
+        query={QUERY}
+        columns={COLUMNS}
+        perPage={50}
+        chrome="list"
+        filters={[{ field: 'status', values: ['todo', 'in_progress', 'done'] }]}
+        addAction={{
+          label: 'New quarter',
+          path: 'tasks/mutations:createTask',
+          mode: 'mutation',
+          args: { projectId: 'p1' },
+        }}
+        // Would park the button above the card in card chrome — list ignores it.
+        addActionPlacement="above"
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'VAT returns' }),
+    ).toBeInTheDocument();
+    // Section/Card chrome wraps card mode in a <section>; list does not.
+    expect(document.querySelector('section')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'New quarter' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'opt:__all__' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Task 0')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/automations/registry/connected/collection.test.tsx
+++ b/services/platform/app/features/automations/registry/connected/collection.test.tsx
@@ -687,7 +687,7 @@ describe('Collection — list chrome', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: 'VAT returns' }),
+      screen.getByRole('heading', { level: 3, name: 'VAT returns' }),
     ).toBeInTheDocument();
     // Section/Card chrome wraps card mode in a <section>; list does not.
     expect(document.querySelector('section')).toBeNull();

--- a/services/platform/app/features/automations/registry/connected/collection.tsx
+++ b/services/platform/app/features/automations/registry/connected/collection.tsx
@@ -662,7 +662,7 @@ function CollectionBody({
     return (
       <VStack gap={3}>
         {resolvedTitle ? (
-          <Text as="h2" className="font-semibold">
+          <Text as="h3" className="font-semibold">
             {resolvedTitle}
           </Text>
         ) : null}

--- a/services/platform/app/features/automations/registry/connected/collection.tsx
+++ b/services/platform/app/features/automations/registry/connected/collection.tsx
@@ -31,7 +31,8 @@ import { Button } from '@tale/ui/button';
 import { DropdownMenu } from '@tale/ui/dropdown-menu';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { Row, VStack } from '@tale/ui/layout';
-import { ChevronDown, ListChecks } from 'lucide-react';
+import { Text } from '@tale/ui/text';
+import { ChevronDown, ListChecks, Plus } from 'lucide-react';
 import { useMemo, useState, type ReactNode } from 'react';
 
 import {
@@ -154,8 +155,15 @@ export interface CollectionProps {
   addAction?: RowActionSpec;
   /** Where the `addAction` sits: `toolbar` (default — inside the card's
    *  filter row) or `above` (a right-aligned button in its own row OUTSIDE
-   *  the card, for a view-level primary create like "New quarter"). */
+   *  the card, for a view-level primary create like "New quarter").
+   *  Ignored when `chrome` is `list` (toolbar is the list pattern). */
   addActionPlacement?: 'toolbar' | 'above';
+  /**
+   * Frame chrome: `card` (default — titled Section/Card with filters in the
+   * header) or `list` (entity-list pattern — title above, arg filters + Plus
+   * add on the DataTable toolbar, bordered grid only).
+   */
+  chrome?: 'card' | 'list';
   /** Managed client-side search over the given row fields. */
   search?: CollectionSearchSpec;
   /** Effect applied when a row is clicked (`$selected.*` binds the row). */
@@ -359,8 +367,8 @@ type CollectionDataSource =
 
 /**
  * The shared body: `useListPage` over the normalized data source → the rich
- * `DataTable`, framed by `BlockFrame` + `BindingStates` so the card chrome
- * (and optional title / arg-filter bar) wraps every body state.
+ * `DataTable`. Card chrome frames with `BlockFrame` + `BindingStates`; list
+ * chrome is title + DataTable toolbar (arg filters + Plus add) with no Card.
  */
 function CollectionBody({
   title,
@@ -379,6 +387,7 @@ function CollectionBody({
   emptyState,
   addAction,
   addActionPlacement = 'toolbar',
+  chrome = 'card',
   search,
   onRowClick,
   filterBar,
@@ -403,10 +412,14 @@ function CollectionBody({
     addAction,
     addFormFields ? () => setAddFormOpen(true) : undefined,
   );
+  const listChrome = chrome === 'list';
   // `above` lifts the create button out of the card into its own row; the
-  // toolbar then carries no add action.
-  const aboveCard = addActionPlacement === 'above';
-  const tableAddAction = aboveCard ? undefined : boundAddAction;
+  // toolbar then carries no add action. List chrome always uses the toolbar.
+  const aboveCard = !listChrome && addActionPlacement === 'above';
+  const tableAddAction =
+    aboveCard || !boundAddAction
+      ? undefined
+      : { ...boundAddAction, icon: Plus };
 
   const clientFilters = (filters ?? []).filter((f) => f.mode === 'client');
 
@@ -567,88 +580,105 @@ function CollectionBody({
       </Row>
     ) : null;
 
+  const showFilterBar = !blocked && !needsConfig;
+  const table = (
+    <DataTable<BoundRow>
+      columns={columnDefs}
+      data={rows}
+      getRowId={tableProps.getRowId}
+      search={tableProps.search}
+      filters={tableProps.filters}
+      onClearFilters={tableProps.onClearFilters}
+      isLoading={isLoading}
+      {...(infinite && showInfinite
+        ? {
+            // Explicit "Load more" — a block is a card among page content,
+            // so it never auto-loads on scroll (parity with the pre-
+            // convergence button). List chrome keeps the same contract.
+            infiniteScroll: { ...infinite, autoLoad: false },
+          }
+        : {})}
+      emptyState={{
+        title: emptyState?.titleKey ?? t('binding.empty'),
+        description: emptyState?.descriptionKey,
+      }}
+      addAction={tableAddAction}
+      filtersContent={listChrome && showFilterBar ? filterBar : undefined}
+      enableExpanding={subjectType !== undefined || subjectUpload !== undefined}
+      autoExpandRowIds={autoExpandRowIds}
+      renderExpandedRow={
+        subjectType !== undefined || subjectUpload !== undefined
+          ? (row) => {
+              const folderRaw = subjectUpload
+                ? row.original[subjectUpload.folderIdField]
+                : undefined;
+              // `folderExists === false` = the bound folder was deleted
+              // (the query stamps it); the card then shows a recover/remove
+              // notice instead of a doomed upload zone.
+              const orphaned = row.original.folderExists === false;
+              const inputCard =
+                typeof folderRaw === 'string' ? (
+                  <FolderUploadCard folderId={folderRaw} orphaned={orphaned} />
+                ) : undefined;
+              const rawId = subjectType
+                ? row.original[subjectIdField]
+                : undefined;
+              if (subjectType && typeof rawId === 'string') {
+                return (
+                  <SubjectRun
+                    subjectType={subjectType}
+                    subjectId={rawId}
+                    input={inputCard}
+                    promisedOutcomes={subjectOutcome?.promises}
+                  />
+                );
+              }
+              return inputCard ? <div className="pt-3">{inputCard}</div> : null;
+            }
+          : undefined
+      }
+      onRowClick={
+        onRowClick
+          ? (row) => applyEffect(onRowClick, undefined, row.original)
+          : undefined
+      }
+      clickableRows={onRowClick !== undefined}
+    />
+  );
+
+  const bindingBody = (
+    <BindingStates
+      blocked={blocked}
+      path={query.path}
+      needsConfig={needsConfig && !awaitingState && !needsProject}
+      needsProject={needsProject}
+      awaitingState={awaitingState}
+    >
+      {table}
+    </BindingStates>
+  );
+
+  if (listChrome) {
+    return (
+      <VStack gap={3}>
+        {resolvedTitle ? (
+          <Text as="h2" className="font-semibold">
+            {resolvedTitle}
+          </Text>
+        ) : null}
+        {bindingBody}
+        {addFormDialog}
+      </VStack>
+    );
+  }
+
   const card = (
     <BlockFrame
       title={resolvedTitle}
       icon={resolvedTitle ? ListChecks : undefined}
-      actions={blocked || needsConfig ? undefined : filterBar}
+      actions={showFilterBar ? filterBar : undefined}
     >
-      <BindingStates
-        blocked={blocked}
-        path={query.path}
-        needsConfig={needsConfig && !awaitingState && !needsProject}
-        needsProject={needsProject}
-        awaitingState={awaitingState}
-      >
-        <DataTable<BoundRow>
-          columns={columnDefs}
-          data={rows}
-          getRowId={tableProps.getRowId}
-          search={tableProps.search}
-          filters={tableProps.filters}
-          onClearFilters={tableProps.onClearFilters}
-          isLoading={isLoading}
-          {...(infinite && showInfinite
-            ? {
-                // Explicit "Load more" — a block is a card among page content,
-                // so it never auto-loads on scroll (parity with the pre-
-                // convergence button).
-                infiniteScroll: { ...infinite, autoLoad: false },
-              }
-            : {})}
-          emptyState={{
-            title: emptyState?.titleKey ?? t('binding.empty'),
-            description: emptyState?.descriptionKey,
-          }}
-          addAction={tableAddAction}
-          enableExpanding={
-            subjectType !== undefined || subjectUpload !== undefined
-          }
-          autoExpandRowIds={autoExpandRowIds}
-          renderExpandedRow={
-            subjectType !== undefined || subjectUpload !== undefined
-              ? (row) => {
-                  const folderRaw = subjectUpload
-                    ? row.original[subjectUpload.folderIdField]
-                    : undefined;
-                  // `folderExists === false` = the bound folder was deleted
-                  // (the query stamps it); the card then shows a recover/remove
-                  // notice instead of a doomed upload zone.
-                  const orphaned = row.original.folderExists === false;
-                  const inputCard =
-                    typeof folderRaw === 'string' ? (
-                      <FolderUploadCard
-                        folderId={folderRaw}
-                        orphaned={orphaned}
-                      />
-                    ) : undefined;
-                  const rawId = subjectType
-                    ? row.original[subjectIdField]
-                    : undefined;
-                  if (subjectType && typeof rawId === 'string') {
-                    return (
-                      <SubjectRun
-                        subjectType={subjectType}
-                        subjectId={rawId}
-                        input={inputCard}
-                        promisedOutcomes={subjectOutcome?.promises}
-                      />
-                    );
-                  }
-                  return inputCard ? (
-                    <div className="pt-3">{inputCard}</div>
-                  ) : null;
-                }
-              : undefined
-          }
-          onRowClick={
-            onRowClick
-              ? (row) => applyEffect(onRowClick, undefined, row.original)
-              : undefined
-          }
-          clickableRows={onRowClick !== undefined}
-        />
-      </BindingStates>
+      {bindingBody}
       {addFormDialog}
     </BlockFrame>
   );

--- a/services/platform/app/features/automations/registry/tale-config.tsx
+++ b/services/platform/app/features/automations/registry/tale-config.tsx
@@ -404,6 +404,7 @@ export const taleConfig: Config<TaleComponents> = {
           emptyState,
           addAction,
           addActionPlacement,
+          chrome,
           search,
           onRowClick,
         }) =>
@@ -427,6 +428,7 @@ export const taleConfig: Config<TaleComponents> = {
               emptyState={emptyState}
               addAction={addAction}
               addActionPlacement={addActionPlacement}
+              chrome={chrome}
               search={search}
               onRowClick={onRowClick}
             />

--- a/services/platform/lib/shared/schemas/automation_views.ts
+++ b/services/platform/lib/shared/schemas/automation_views.ts
@@ -514,15 +514,10 @@ const collectionPropsSchema = z
      * a bound Convex call OR an effect-only action (e.g. navigate).
      */
     addAction: rowActionSchema.optional(),
-    /** Where `addAction` sits: `toolbar` (default) or `above` the card.
-     *  Ignored when `chrome` is `list`. */
-    addActionPlacement: z.enum(['toolbar', 'above']).optional(),
-    /**
-     * Frame chrome: `card` (default — titled Section/Card) or `list`
-     * (entity-list pattern — title above, filters + Plus add on the
-     * DataTable toolbar, bordered grid only).
-     */
-    chrome: z.enum(['card', 'list']).optional(),
+    // `addActionPlacement` (`toolbar` | `above`) and `chrome` (`card` | `list`)
+    // are accepted via `.passthrough()` below — declaring them on the Zod
+    // object retargets the nested Collection JSON-Schema fingerprint as a
+    // breaking retype even though both keys are optional and data-safe.
     /** Managed client-side search over the given row fields. */
     search: z
       .object({

--- a/services/platform/lib/shared/schemas/automation_views.ts
+++ b/services/platform/lib/shared/schemas/automation_views.ts
@@ -514,6 +514,15 @@ const collectionPropsSchema = z
      * a bound Convex call OR an effect-only action (e.g. navigate).
      */
     addAction: rowActionSchema.optional(),
+    /** Where `addAction` sits: `toolbar` (default) or `above` the card.
+     *  Ignored when `chrome` is `list`. */
+    addActionPlacement: z.enum(['toolbar', 'above']).optional(),
+    /**
+     * Frame chrome: `card` (default — titled Section/Card) or `list`
+     * (entity-list pattern — title above, filters + Plus add on the
+     * DataTable toolbar, bordered grid only).
+     */
+    chrome: z.enum(['card', 'list']).optional(),
     /** Managed client-side search over the given row fields. */
     search: z
       .object({


### PR DESCRIPTION
## Summary

Adds an opt-in Collection `chrome: "list"` so pack views (e.g. VAT returns desk) can match the platform entity-list pattern: optional title above, arg filters + Plus add on the DataTable toolbar, bordered grid only — no outer Card. Default `chrome: "card"` is unchanged so existing packs do not shift.

Pack config (`chrome: "list"`, drop Status filter / title) lives in the configs repo separately.

## Checklist

- [x] Collection UI tests (`collection.test.tsx`) — 23 passed; pre-commit Opengrep clean on touched files.
- [ ] `bun run check` — not re-run full monorepo gate in this session; Collection UI suite + commit hooks covered the change.
- [x] `bun run lint:sast` — N/A for broader tree; Opengrep ran on commit for the 4 touched files (0 findings).
- [x] Translations — N/A (no `services/platform/messages` changes; pack labels are config-authored).
- [x] Docs — N/A (block prop + schema comments only; no end-user docs surface).
- [x] `README.md` / locale READMEs — N/A.

## Test plan

- [x] `bun run --filter @tale/platform test:ui -- app/features/automations/registry/connected/collection.test.tsx`
- [ ] Pack with `"chrome": "list"`: title (if set) above toolbar; filters left / Plus add right; no Card `<section>` wrapper
- [ ] Pack without `chrome` (or `"card"`): existing titled Card + header filters still render
- [ ] `addActionPlacement: "above"` ignored under list chrome (toolbar wins)