### PR TITLE
docs: disable GitHub Code Quality (false positives)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,6 +53,12 @@ faster format/lint/typecheck/test subset while iterating.
 - **ENVIRONMENT_FALLBACK warning**: the platform build may print an
   `ENVIRONMENT_FALLBACK` error. It is a Convex-specific warning and does not prevent
   successful builds.
+- **GitHub Code Quality is disabled**: the `github-code-quality` default setup was
+  turned off (Settings → Security → Code quality, or
+  `PATCH /repos/.../code-quality/setup` with `state: not-configured`). It reported
+  persistent false positives on this repo (e.g. Convex `"use node"` as an unknown
+  directive). Keep it off; lint and SAST stay with oxlint and Opengrep
+  (`bun run check` / `bun run lint:sast`).
 
 ## Reporting bugs & ideas
 


### PR DESCRIPTION
## Summary

- Disabled GitHub Code Quality default setup on `tale-project/tale` (`state: not-configured`) — the `github-code-quality` bot was flooding PRs with false positives (notably Convex `"use node"` as an “Unknown directive”).
- Documented the decision under Known issues in `.github/CONTRIBUTING.md` so it is not re-enabled; lint/SAST stay with oxlint and Opengrep.

## Checklist

- [x] `bun run check` passes (format, lint, typecheck, all tests). — **N/A**: docs-only CONTRIBUTING note; no product code.
- [x] `bun run lint:sast` passes (Opengrep) — **N/A**: no source paths touched.
- [x] Translations updated in `services/platform/messages/{en,de,fr}.json` — **N/A**.
- [x] Docs updated in `docs/{en,de,fr}/` for any user-visible change — **N/A** (contributor note only).
- [x] `README.md` / `README.de.md` / `README.fr.md` updated — **N/A**.

## Test plan

- [x] `GET /repos/tale-project/tale/code-quality/setup` returns `"state":"not-configured"` (applied via API before this PR).
- [ ] Confirm new PRs no longer get `github-code-quality[bot]` review comments.
- [ ] Spot-check Settings → Security → Code quality shows disabled.