### PR TITLE
test(platform): self-provision the yt-dlp toolchain for the live test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,39 +96,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Install yt-dlp + deno + ffmpeg + the bgutil plugin BEFORE the test run so
-      # the live YouTube ingestion test (convex/video_links/ytdlp_live.test.ts)
-      # runs as part of the normal `turbo run test` below — it is just another
-      # test, gated behind YOUTUBE_LIVE_TEST so it only fires here (where the
-      # binaries + provider exist) and skips in every other environment.
+      # NOTE: yt-dlp + deno + ffmpeg + the bgutil plugin are NO LONGER installed
+      # here. The live YouTube ingestion test (convex/video_links/ytdlp_live.test.ts)
+      # now SELF-PROVISIONS them via `ensureVideoToolchain()` in a `beforeAll`
+      # (see convex/video_links/ytdlp_toolchain.ts), downloading whatever the
+      # host is missing into a per-user cache. That makes the exact same test
+      # runnable on a laptop, not just on CI — the bespoke install step is gone.
       #
-      # Why it lives on CI: GitHub runners are DATACENTER IPs — the exact
-      # environment where YouTube's "confirm you're not a bot" wall appears — so
-      # a green run proves the shipped anti-bot stack (the bgutil PO-token
-      # provider service above + tuned player clients) actually gets past the
-      # wall and pulls a transcript, not just that it works from a residential
-      # laptop. The three tools are baked into the convex image
-      # (services/convex/Dockerfile); we install the same ones into the PATH
-      # runYtdlp pins (/usr/local/bin:/usr/bin:/bin).
-      - name: Install yt-dlp + deno + ffmpeg + bgutil plugin (for the live YT test)
-        run: |
-          set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y ffmpeg unzip
-          sudo curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp" -o /usr/local/bin/yt-dlp
-          sudo chmod 0755 /usr/local/bin/yt-dlp
-          curl -fsSL "https://github.com/denoland/deno/releases/latest/download/deno-x86_64-unknown-linux-gnu.zip" -o /tmp/deno.zip
-          sudo unzip -o /tmp/deno.zip -d /usr/local/bin && sudo chmod 0755 /usr/local/bin/deno
-          mkdir -p /tmp/yt-dlp-plugins
-          curl -fsSL "https://github.com/Brainicism/bgutil-ytdlp-pot-provider/releases/download/1.3.1/bgutil-ytdlp-pot-provider.zip" -o /tmp/bgutil.zip
-          unzip -o /tmp/bgutil.zip -d /tmp/yt-dlp-plugins
+      # We STILL run it here because GitHub runners are DATACENTER IPs — the exact
+      # environment where YouTube's "confirm you're not a bot" wall appears — so a
+      # green run proves the shipped anti-bot stack (the bgutil PO-token provider
+      # service above + tuned player clients) actually gets past the wall and
+      # pulls a transcript, not just that it works from a residential laptop.
 
       - name: Run tests
         # YOUTUBE_LIVE_TEST enables the live ingest test within the normal suite;
-        # the three vars are declared on the `test` task in turbo.json so turbo
-        # keys its cache on them (else a cached result would skip the live test).
+        # it + VIDEO_INGEST_POT_PROVIDER_URL are declared on the `test` task in
+        # turbo.json so turbo keys its cache on them (else a cached result would
+        # skip the live test). VIDEO_INGEST_YTDLP_PLUGIN_DIRS is intentionally
+        # NOT set — the toolchain helper points it at the self-provisioned plugin
+        # cache at runtime.
         env:
           YOUTUBE_LIVE_TEST: '1'
-          VIDEO_INGEST_YTDLP_PLUGIN_DIRS: /tmp/yt-dlp-plugins
           VIDEO_INGEST_POT_PROVIDER_URL: http://127.0.0.1:4416
         run: bunx turbo run test
 

--- a/services/platform/convex/video_links/ytdlp.test.ts
+++ b/services/platform/convex/video_links/ytdlp.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildAntiBotFlags,
+  buildSpawnPath,
   classifyYtDlpStderr,
   cookiesFlagsFromEnv,
+  ffmpegLocationFlags,
   impersonateFlagsFromEnv,
   pluginDirFlagsFromEnv,
   proxyFlagsFromEnv,
@@ -284,5 +286,46 @@ describe('pluginDirFlagsFromEnv', () => {
     expect(
       pluginDirFlagsFromEnv({ VIDEO_INGEST_YTDLP_PLUGIN_DIRS: '/x' }, true),
     ).toEqual(['--plugin-dirs', '/x']);
+  });
+});
+
+describe('buildSpawnPath', () => {
+  it('pins the production PATH when unset', () => {
+    expect(buildSpawnPath({})).toBe('/usr/local/bin:/usr/bin:/bin');
+  });
+
+  it('prepends VIDEO_INGEST_BIN_DIR when set', () => {
+    expect(buildSpawnPath({ VIDEO_INGEST_BIN_DIR: '/cache/bin' })).toBe(
+      '/cache/bin:/usr/local/bin:/usr/bin:/bin',
+    );
+  });
+
+  it('ignores a blank override', () => {
+    expect(buildSpawnPath({ VIDEO_INGEST_BIN_DIR: '   ' })).toBe(
+      '/usr/local/bin:/usr/bin:/bin',
+    );
+  });
+});
+
+describe('ffmpegLocationFlags', () => {
+  it('defaults to the baked /usr/bin/ffmpeg', () => {
+    expect(ffmpegLocationFlags({})).toEqual([
+      '--ffmpeg-location',
+      '/usr/bin/ffmpeg',
+    ]);
+  });
+
+  it('honours VIDEO_INGEST_FFMPEG_LOCATION', () => {
+    expect(
+      ffmpegLocationFlags({
+        VIDEO_INGEST_FFMPEG_LOCATION: '/opt/homebrew/bin/ffmpeg',
+      }),
+    ).toEqual(['--ffmpeg-location', '/opt/homebrew/bin/ffmpeg']);
+  });
+
+  it('falls back to the default for a blank override', () => {
+    expect(ffmpegLocationFlags({ VIDEO_INGEST_FFMPEG_LOCATION: '  ' })).toEqual(
+      ['--ffmpeg-location', '/usr/bin/ffmpeg'],
+    );
   });
 });

--- a/services/platform/convex/video_links/ytdlp.ts
+++ b/services/platform/convex/video_links/ytdlp.ts
@@ -72,12 +72,54 @@ const BASE_FLAGS: ReadonlyArray<string> = [
   '--restrict-filenames',
   '--downloader',
   'native',
-  '--ffmpeg-location',
-  '/usr/bin/ffmpeg',
+  // NOTE: `--ffmpeg-location` used to live here, hard-pinned to
+  // `/usr/bin/ffmpeg`. It moved OUT into the per-invocation
+  // `ffmpegLocationFlags(env)` so the LIVE ingest test can point yt-dlp at a
+  // self-provisioned ffmpeg (e.g. Homebrew's) discovered AFTER this array is
+  // module-cached. The production default is byte-for-byte unchanged.
   // NOTE: the `youtube:player_client=…` extractor-arg moved out of BASE_FLAGS
   // into `buildAntiBotFlags` so it can be tuned per deployment (and combined
   // with a PO token / provider) via env without editing this cached set.
 ];
+
+// ---------------------------------------------------------------------------
+// Spawn PATH + ffmpeg location — resolved from `process.env` on EVERY spawn so
+// the LIVE ingest test (`ytdlp_live.test.ts`) can inject a self-provisioned
+// toolchain (see `ytdlp_toolchain.ts`) AFTER this module is imported + cached.
+// Both keep the production defaults byte-for-byte, so an unset environment (the
+// baked convex image) behaves exactly as before.
+// ---------------------------------------------------------------------------
+
+/**
+ * PATH for the yt-dlp/ffmpeg child. Production pins the minimal set the
+ * Dockerfile installs into (`/usr/local/bin:/usr/bin:/bin`) — deliberately NOT
+ * `process.env.PATH`, so a dev host's shell PATH can't leak arbitrary binaries
+ * into the sandboxed child. `VIDEO_INGEST_BIN_DIR`, when set, is PREPENDED so a
+ * self-provisioned yt-dlp + deno (downloaded outside the pinned dirs, e.g. into
+ * a per-user cache) is found first. Read per-spawn — never baked into a cache —
+ * so the live test can set it after module load.
+ */
+export function buildSpawnPath(env: NodeJS.ProcessEnv): string {
+  const base = '/usr/local/bin:/usr/bin:/bin';
+  const extra = env.VIDEO_INGEST_BIN_DIR?.trim();
+  return extra ? `${extra}:${base}` : base;
+}
+
+/**
+ * `--ffmpeg-location` for yt-dlp's post-processing (subtitle convert + audio
+ * extract). Passed EXPLICITLY rather than resolved via PATH, so it works even
+ * when ffmpeg lives outside the pinned spawn PATH — e.g. Homebrew's
+ * `/opt/homebrew/bin/ffmpeg` on a dev laptop. Defaults to the Dockerfile's
+ * `/usr/bin/ffmpeg`; `VIDEO_INGEST_FFMPEG_LOCATION` overrides with an absolute
+ * path. Built per-invocation (NOT in the cached `BASE_FLAGS`) so the live test
+ * can point it at a self-provisioned ffmpeg after module load.
+ */
+export function ffmpegLocationFlags(env: NodeJS.ProcessEnv): string[] {
+  return [
+    '--ffmpeg-location',
+    env.VIDEO_INGEST_FFMPEG_LOCATION?.trim() || '/usr/bin/ffmpeg',
+  ];
+}
 
 // Flags whose support depends on the installed yt-dlp version. Probed
 // once via `yt-dlp --help` at first invocation and cached for the
@@ -296,7 +338,9 @@ function resolveSupportedFlags(): Promise<string[]> {
     const child = spawn(YTDLP_BIN, ['--help'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
-        PATH: '/usr/local/bin:/usr/bin:/bin',
+        // Prepends `VIDEO_INGEST_BIN_DIR` when set (see `buildSpawnPath`) so
+        // the probe hits the same yt-dlp the live test self-provisioned.
+        PATH: buildSpawnPath(process.env),
         HOME: tmpdir(),
         LANG: 'C.UTF-8',
       },
@@ -510,19 +554,32 @@ async function runYtdlp(
     // action is hard-killed — the wrapper Node process terminates but
     // ffmpeg continues to its natural exit, leaving disk/CPU usage that
     // the entrypoint's 60-min tmpdir sweep can only partially reclaim.
-    const proc = spawn(YTDLP_BIN, [...commonFlags, ...antiBotFlags, ...args], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      cwd: jobDir,
-      detached: true,
-      // env stripped to the minimum yt-dlp + ffmpeg need. NEVER pass
-      // process.env — Convex secrets (SOPS_AGE_KEY, db creds, provider
-      // tokens) would land in the child's environment.
-      env: {
-        PATH: '/usr/local/bin:/usr/bin:/bin',
-        HOME: jobDir,
-        LANG: 'C.UTF-8',
+    // `ffmpegLocationFlags` is merged in per-invocation (read from
+    // `process.env`, NOT the cached `commonFlags`) so the live test's
+    // self-provisioned ffmpeg path takes effect after module load.
+    const proc = spawn(
+      YTDLP_BIN,
+      [
+        ...commonFlags,
+        ...ffmpegLocationFlags(process.env),
+        ...antiBotFlags,
+        ...args,
+      ],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: jobDir,
+        detached: true,
+        // env stripped to the minimum yt-dlp + ffmpeg need. NEVER pass
+        // process.env — Convex secrets (SOPS_AGE_KEY, db creds, provider
+        // tokens) would land in the child's environment. `buildSpawnPath`
+        // keeps the pinned production PATH unless `VIDEO_INGEST_BIN_DIR` is set.
+        env: {
+          PATH: buildSpawnPath(process.env),
+          HOME: jobDir,
+          LANG: 'C.UTF-8',
+        },
       },
-    });
+    );
     let stdout = '';
     let stderr = '';
     // Cap accumulated output to prevent OOM on chatty errors. yt-dlp

--- a/services/platform/convex/video_links/ytdlp_live.test.ts
+++ b/services/platform/convex/video_links/ytdlp_live.test.ts
@@ -5,23 +5,31 @@
  * we get past YouTube's bot wall and pull a non-empty transcript.
  *
  * Gated behind `YOUTUBE_LIVE_TEST=1` so it is SKIPPED in the ordinary unit
- * suite (which has no `yt-dlp`) and RUN only by the dedicated
- * `.github/workflows/youtube-ingest.yml` job. That job runs on GitHub's
- * datacenter IPs — i.e. the exact environment where YouTube's "confirm you're
- * not a bot" wall appears — so a green run there is the real proof that
- * ingestion works from a server, not just from a residential laptop.
+ * suite and RUN only where the toolchain + a suitable egress exist: the `Unit`
+ * job in `.github/workflows/test.yml` (which sets the flag + a bgutil PO-token
+ * provider) and any developer who opts in locally. GitHub runners are DATACENTER
+ * IPs — the exact environment where YouTube's "confirm you're not a bot" wall
+ * appears — so a green CI run is the real proof that ingestion works from a
+ * server, not just from a residential laptop.
  *
- * Requires `yt-dlp`, `deno` (JS-challenge solver), and `ffmpeg` (subtitle
- * conversion) on PATH — the workflow installs them.
+ * SELF-PROVISIONING: `yt-dlp`, `deno` (JS-challenge solver), `ffmpeg` (subtitle
+ * conversion), and the bgutil PO-token plugin are NO LONGER installed by a
+ * workflow step. The `beforeAll` below calls `ensureVideoToolchain()` to
+ * download/resolve them into a per-user cache and points `ytdlp.ts` at them via
+ * `VIDEO_INGEST_BIN_DIR` / `VIDEO_INGEST_FFMPEG_LOCATION` /
+ * `VIDEO_INGEST_YTDLP_PLUGIN_DIRS` — so the very same test runs on a bare CI
+ * runner and on a laptop. It stays gated behind `YOUTUBE_LIVE_TEST=1`; the
+ * provisioning + network calls never fire in the normal suite.
  */
 import { readFile } from 'node:fs/promises';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { ytdlpJson, ytdlpWriteSubs, type YtDlpMetadata } from './ytdlp';
+import { ensureVideoToolchain } from './ytdlp_toolchain';
 
 const LIVE = process.env.YOUTUBE_LIVE_TEST === '1';
 
@@ -54,6 +62,18 @@ function captionLangs(meta: YtDlpMetadata): string[] {
 describe.skipIf(!LIVE)(
   'yt-dlp live YouTube ingestion (datacenter-IP anti-bot)',
   () => {
+    // Download/resolve the yt-dlp + deno + ffmpeg + bgutil toolchain and point
+    // `ytdlp.ts` at it. Lives inside the gated `describe` so it NEVER runs (nor
+    // touches the network) in the ordinary suite. Generous timeout: a cold cache
+    // downloads two binaries and may `brew install ffmpeg` on a fresh laptop.
+    beforeAll(async () => {
+      const tc = await ensureVideoToolchain();
+      process.env.VIDEO_INGEST_BIN_DIR = tc.binDir;
+      process.env.VIDEO_INGEST_FFMPEG_LOCATION = tc.ffmpegLocation;
+      // `||=`: honour an explicit plugin dir (e.g. the CI baked path) if set.
+      process.env.VIDEO_INGEST_YTDLP_PLUGIN_DIRS ||= tc.pluginDir;
+    }, 600_000);
+
     it('fetches video metadata past the bot wall', async () => {
       const jobDir = await mkdtemp(join(tmpdir(), 'ytlive-meta-'));
       const meta = await withRetries(() =>

--- a/services/platform/convex/video_links/ytdlp_toolchain.ts
+++ b/services/platform/convex/video_links/ytdlp_toolchain.ts
@@ -1,0 +1,277 @@
+'use node';
+
+/**
+ * Self-provisioning toolchain for the LIVE YouTube-ingest test
+ * (`ytdlp_live.test.ts`). Production bakes yt-dlp + deno + ffmpeg + the bgutil
+ * PO-token plugin into the convex image (`services/convex/Dockerfile`); this
+ * module reproduces that set ON DEMAND so the live test runs on a bare laptop
+ * or CI runner without a bespoke install step.
+ *
+ * What it guarantees — downloading only what's missing into a per-user cache
+ * (`~/.cache/tale-video-toolchain/`, override `TALE_VIDEO_TOOLCHAIN_DIR`):
+ *   - yt-dlp: platform standalone binary → `bin/yt-dlp`. Skipped when yt-dlp is
+ *     already on a pinned system PATH dir (`/usr/local/bin`|`/usr/bin`), i.e.
+ *     the production image, where `runYtdlp` finds it with no override.
+ *   - deno: yt-dlp's JS-challenge runtime (n-signature solver, yt-dlp ≥
+ *     2025.11) → `bin/deno`. Same skip rule.
+ *   - ffmpeg: SYSTEM-FIRST — resolved via `which` over the FULL inherited PATH
+ *     (so Homebrew's `/opt/homebrew/bin` counts), installed via brew/apt only
+ *     when absent. Returned as an absolute path because yt-dlp receives it
+ *     through `--ffmpeg-location`, which is PATH-independent.
+ *   - bgutil: PO-token-provider plugin → `plugins/`. Cheap; only exercised when
+ *     a provider URL is reachable (datacenter IPs), so a residential host that
+ *     never calls it can't be broken by a partial plugin.
+ *
+ * The caller (`ytdlp_live.test.ts`'s `beforeAll`) feeds the returned dirs to
+ * `ytdlp.ts` via `VIDEO_INGEST_BIN_DIR` (prepended to the sandboxed spawn PATH),
+ * `VIDEO_INGEST_FFMPEG_LOCATION`, and `VIDEO_INGEST_YTDLP_PLUGIN_DIRS`.
+ *
+ * `'use node'`: this file lives under `convex/` (so the convex bundler analyses
+ * it) and uses `node:child_process`/`node:fs` — the same runtime pin as
+ * `ytdlp.ts`. It is imported only by the gated live test, never by a deployed
+ * Convex function.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import { arch, homedir, platform } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Directories the yt-dlp/ffmpeg spawn PATH is pinned to in production
+ * (`ytdlp.ts:buildSpawnPath`). A binary already present in one of these needs
+ * no download — the sandboxed child finds it without `VIDEO_INGEST_BIN_DIR`.
+ */
+const PINNED_SYSTEM_BIN_DIRS = ['/usr/local/bin', '/usr/bin'] as const;
+
+/**
+ * bgutil PO-token provider plugin version. Pinned to match the `bgutil` service
+ * container in `.github/workflows/test.yml` and the Dockerfile's baked copy —
+ * plugin and provider must agree on the protocol version.
+ */
+const BGUTIL_POT_VERSION = '1.3.1';
+
+interface VideoToolchain {
+  /**
+   * `bin/` holding the (possibly downloaded) yt-dlp + deno. Prepended to the
+   * sandboxed spawn PATH via `VIDEO_INGEST_BIN_DIR`.
+   */
+  binDir: string;
+  /** Absolute ffmpeg path — passed via `--ffmpeg-location`, so PATH-independent. */
+  ffmpegLocation: string;
+  /** `plugins/` holding the bgutil plugin — set as `VIDEO_INGEST_YTDLP_PLUGIN_DIRS`. */
+  pluginDir: string;
+}
+
+// Memoized module-level promise: `provisionToolchain` runs at most once per
+// process, and its on-disk cache makes repeated processes (test files, reruns)
+// cheap too. A rejection is intentionally cached — a broken host fails fast and
+// identically rather than re-attempting slow downloads on every call.
+let cachedToolchain: Promise<VideoToolchain> | null = null;
+
+/**
+ * Ensure yt-dlp + deno + ffmpeg + the bgutil plugin are available for the live
+ * ingest test, downloading whatever is missing. Idempotent (every step no-ops
+ * when its output already exists) and memoized.
+ */
+export async function ensureVideoToolchain(): Promise<VideoToolchain> {
+  cachedToolchain ??= provisionToolchain();
+  return cachedToolchain;
+}
+
+async function provisionToolchain(): Promise<VideoToolchain> {
+  const cacheDir =
+    process.env.TALE_VIDEO_TOOLCHAIN_DIR?.trim() ||
+    join(homedir(), '.cache', 'tale-video-toolchain');
+  const binDir = join(cacheDir, 'bin');
+  const pluginDir = join(cacheDir, 'plugins');
+  await fs.mkdir(binDir, { recursive: true });
+  await fs.mkdir(pluginDir, { recursive: true });
+
+  await ensureYtdlp(binDir);
+  await ensureDeno(binDir);
+  const ffmpegLocation = await ensureFfmpeg();
+  await ensureBgutilPlugin(pluginDir);
+
+  return { binDir, ffmpegLocation, pluginDir };
+}
+
+/**
+ * True when `bin` already sits on a pinned production PATH dir, so the
+ * sandboxed child resolves it with no `VIDEO_INGEST_BIN_DIR` override.
+ */
+function isOnPinnedSystemPath(bin: string): boolean {
+  return PINNED_SYSTEM_BIN_DIRS.some((dir) => existsSync(join(dir, bin)));
+}
+
+/** yt-dlp standalone-build asset name for this host (yt-dlp's own naming). */
+function ytdlpAsset(): string {
+  const p = platform();
+  const a = arch();
+  // The macOS build is a universal binary (arm64 + x64), so arch is irrelevant.
+  if (p === 'darwin') return 'yt-dlp_macos';
+  if (p === 'linux' && a === 'x64') return 'yt-dlp_linux';
+  if (p === 'linux' && a === 'arm64') return 'yt-dlp_linux_aarch64';
+  throw new Error(`[video-toolchain] no yt-dlp standalone build for ${p}/${a}`);
+}
+
+async function ensureYtdlp(binDir: string): Promise<void> {
+  const cached = join(binDir, 'yt-dlp');
+  if (isOnPinnedSystemPath('yt-dlp') || existsSync(cached)) return;
+  console.info('[video-toolchain] downloading yt-dlp…');
+  await downloadTo(
+    `https://github.com/yt-dlp/yt-dlp/releases/latest/download/${ytdlpAsset()}`,
+    cached,
+  );
+  await fs.chmod(cached, 0o755);
+}
+
+/** Deno release triple for this host (deno's own release naming). */
+function denoTriple(): string {
+  const p = platform();
+  const a = arch();
+  if (p === 'darwin' && a === 'arm64') return 'aarch64-apple-darwin';
+  if (p === 'darwin' && a === 'x64') return 'x86_64-apple-darwin';
+  if (p === 'linux' && a === 'x64') return 'x86_64-unknown-linux-gnu';
+  if (p === 'linux' && a === 'arm64') return 'aarch64-unknown-linux-gnu';
+  throw new Error(`[video-toolchain] no deno build for ${p}/${a}`);
+}
+
+async function ensureDeno(binDir: string): Promise<void> {
+  const cached = join(binDir, 'deno');
+  if (isOnPinnedSystemPath('deno') || existsSync(cached)) return;
+  console.info('[video-toolchain] downloading deno…');
+  // The deno release ships a single `deno` binary inside a zip.
+  const zip = join(binDir, 'deno.zip');
+  await downloadTo(
+    `https://github.com/denoland/deno/releases/latest/download/deno-${denoTriple()}.zip`,
+    zip,
+  );
+  await unzipInto(zip, binDir);
+  await fs.rm(zip, { force: true });
+  await fs.chmod(cached, 0o755);
+}
+
+/**
+ * Resolve an absolute ffmpeg path (system-first). ffmpeg is passed to yt-dlp via
+ * `--ffmpeg-location`, so it need NOT sit on the pinned spawn PATH — a Homebrew
+ * `/opt/homebrew/bin/ffmpeg` is fine. If absent, install it with the platform
+ * package manager (brew on macOS, apt on Debian/Ubuntu, best-effort) and
+ * re-resolve. Throws a clear, actionable error if it still can't be found.
+ */
+async function ensureFfmpeg(): Promise<string> {
+  const found = await which('ffmpeg');
+  if (found) return found;
+
+  if (platform() === 'darwin' && (await which('brew'))) {
+    console.info('[video-toolchain] installing ffmpeg via Homebrew…');
+    await run('brew', ['install', 'ffmpeg']);
+  } else if (platform() === 'linux' && (await which('apt-get'))) {
+    console.info('[video-toolchain] installing ffmpeg via apt-get…');
+    // Best-effort: the runner may lack sudo or network. A failure just surfaces
+    // as the "still missing" error below, with full context for the operator.
+    try {
+      await run('sudo', ['apt-get', 'install', '-y', 'ffmpeg']);
+    } catch (err) {
+      console.warn(
+        '[video-toolchain] apt-get install ffmpeg failed (best-effort):',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  const reResolved = await which('ffmpeg');
+  if (!reResolved) {
+    throw new Error(
+      '[video-toolchain] ffmpeg not found and could not be auto-installed. ' +
+        'Install it manually (macOS: `brew install ffmpeg`; Debian/Ubuntu: ' +
+        '`apt-get install ffmpeg`) and re-run.',
+    );
+  }
+  return reResolved;
+}
+
+/**
+ * Download + unzip the bgutil PO-token-provider plugin into `pluginDir`. The zip
+ * expands to a `yt_dlp_plugins/` namespace package that yt-dlp auto-loads from
+ * `--plugin-dirs`; its presence is the idempotency guard.
+ */
+async function ensureBgutilPlugin(pluginDir: string): Promise<void> {
+  if (existsSync(join(pluginDir, 'yt_dlp_plugins'))) return;
+  console.info('[video-toolchain] downloading bgutil yt-dlp plugin…');
+  const zip = join(pluginDir, 'bgutil-ytdlp-pot-provider.zip');
+  await downloadTo(
+    `https://github.com/Brainicism/bgutil-ytdlp-pot-provider/releases/download/${BGUTIL_POT_VERSION}/bgutil-ytdlp-pot-provider.zip`,
+    zip,
+  );
+  await unzipInto(zip, pluginDir);
+  await fs.rm(zip, { force: true });
+}
+
+/**
+ * Stream a URL to `dest`. `fetch` follows redirects, so the GitHub
+ * `releases/latest/download/…` shape (302 → CDN) works directly. The whole body
+ * is buffered in memory — every asset here is well under ~50 MB.
+ */
+async function downloadTo(url: string, dest: string): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `[video-toolchain] download failed (${res.status} ${res.statusText}): ${url}`,
+    );
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  await fs.writeFile(dest, bytes);
+}
+
+/**
+ * Unzip `zip` into `destDir` via the system `unzip` (present on macOS and the
+ * GitHub Ubuntu runner). `-o` overwrites so a re-run over a warm cache never
+ * blocks on a prompt; `-q` keeps the test output quiet.
+ */
+async function unzipInto(zip: string, destDir: string): Promise<void> {
+  await run('unzip', ['-o', '-q', zip, '-d', destDir]);
+}
+
+/**
+ * Resolve `bin` to an absolute path via the system `which`, searching the FULL
+ * inherited PATH (unlike the sandboxed yt-dlp spawn) so a Homebrew/apt ffmpeg is
+ * discoverable. Returns null when not found — never throws.
+ */
+async function which(bin: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn('which', [bin], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let out = '';
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+    });
+    // ENOENT (no `which` binary) or any spawn error → treat as "not found".
+    child.on('error', () => resolve(null));
+    child.on('close', (code) => {
+      const first = out.trim().split('\n')[0]?.trim();
+      resolve(code === 0 && first ? first : null);
+    });
+  });
+}
+
+/**
+ * Spawn `cmd` and resolve on exit 0, rejecting otherwise. stdout/stderr are
+ * inherited so a slow `brew install` streams progress into the test output.
+ */
+async function run(cmd: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'] });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(
+            `[video-toolchain] '${cmd} ${args.join(' ')}' exited ${code}`,
+          ),
+        );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The LIVE YouTube-ingest test (`convex/video_links/ytdlp_live.test.ts`) needed `yt-dlp`, `deno`, `ffmpeg`, and the bgutil PO-token plugin installed by a bespoke step in `.github/workflows/test.yml`. That meant it only ran on CI — a developer could never run it on a laptop.

## Change

- **New `convex/video_links/ytdlp_toolchain.ts`** — a memoized, idempotent `ensureVideoToolchain()` that downloads whatever the host is missing into a per-user cache (`~/.cache/tale-video-toolchain/`, override `TALE_VIDEO_TOOLCHAIN_DIR`):
  - yt-dlp + deno platform standalone builds → `bin/` (skipped when already on the pinned system PATH, i.e. the baked convex image).
  - ffmpeg **system-first** — resolved via `which` over the full PATH (so Homebrew's `/opt/homebrew/bin` counts), installed via brew/apt only if absent; returned as an absolute path (passed through `--ffmpeg-location`, so PATH-independent).
  - bgutil PO-token plugin → `plugins/`.
- **`ytdlp.ts` (backward-compatible)** — the spawn PATH and `--ffmpeg-location` are now read from `process.env` on every spawn: `buildSpawnPath()` prepends `VIDEO_INGEST_BIN_DIR` to the pinned `/usr/local/bin:/usr/bin:/bin`, and `ffmpegLocationFlags()` replaces the hard-coded `--ffmpeg-location` that lived in the module-cached `BASE_FLAGS`. **Defaults are byte-for-byte unchanged**, so the baked convex image is unaffected.
- **`ytdlp_live.test.ts`** — a `beforeAll` (inside the `YOUTUBE_LIVE_TEST` gate) provisions the toolchain and points `ytdlp.ts` at it; stale `youtube-ingest.yml` comment refreshed.
- **`.github/workflows/test.yml`** — the install step is gone; the bgutil service container and `YOUTUBE_LIVE_TEST` / `VIDEO_INGEST_POT_PROVIDER_URL` env stay. `VIDEO_INGEST_YTDLP_PLUGIN_DIRS` is dropped (the helper sets it at runtime).

## Proof (local, macOS arm64, residential IP)

`YOUTUBE_LIVE_TEST=1 bun run --filter @tale/platform test -- ytdlp_live`

- **Cold cache**: downloaded yt-dlp 2026.07.04 + deno 2.9.2 + the bgutil plugin, `brew install`ed ffmpeg 8.1.2, then **2/2 tests passed** (real metadata + a non-empty transcript) in 90.8s.
- **Warm cache**: no re-download / re-install (idempotent) — **2/2 passed** in 66.5s.

Gate: `typecheck` ✓ · `lint` (0 warnings / 0 errors) ✓ · `oxfmt --check` ✓ · `ytdlp.test.ts` **33/33** ✓ (added coverage for `buildSpawnPath` + `ffmpegLocationFlags`).

## Note

`VIDEO_INGEST_BIN_DIR` / `VIDEO_INGEST_FFMPEG_LOCATION` / `TALE_VIDEO_TOOLCHAIN_DIR` are internal test-provisioning hooks with production-unchanged defaults, so they are intentionally not surfaced in `.env.example` / operator docs.
