### PR TITLE
feat(platform): per-org object storage (BYO S3) for document + audio blobs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -239,6 +239,7 @@
         "@tanstack/react-virtual": "3.13.26",
         "@xyflow/react": "12.10.2",
         "ai": "6.0.156",
+        "aws4fetch": "^1.0.20",
         "bcryptjs": "3.0.3",
         "better-auth": "1.6.23",
         "chokidar": "5.0.0",
@@ -2409,6 +2410,8 @@
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -19,6 +19,7 @@ import { DataNoticeFooter } from '@/app/features/governance/components/data-noti
 import { useUploadPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 import { CHAT_UPLOAD_ACCEPT } from '@/lib/shared/file-types';
@@ -136,7 +137,7 @@ interface ChatInputProps extends Omit<
   fileUploadDisabled?: boolean;
   isIndexing?: boolean;
   indexingStatuses?: Map<
-    Id<'_storage'>,
+    BlobRef,
     { status?: string; error?: string; progress?: string }
   >;
   /** True while any audio attachment is still `queued` or `running`, or the
@@ -144,7 +145,7 @@ interface ChatInputProps extends Omit<
    * never sees a "pending" transcript. */
   isTranscribing?: boolean;
   transcriptionStatuses?: Map<
-    Id<'_storage'>,
+    BlobRef,
     {
       status?: 'queued' | 'running' | 'completed' | 'failed' | 'skipped';
       error?: string;

--- a/services/platform/app/features/chat/components/chat-input/attachment-status-label.tsx
+++ b/services/platform/app/features/chat/components/chat-input/attachment-status-label.tsx
@@ -4,7 +4,7 @@ import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { Loader } from 'lucide-react';
 
-import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
 import { isAudioOrVideo } from '@/lib/shared/file-types';
 import { formatFileSize } from '@/lib/utils/format/file';
@@ -29,8 +29,8 @@ export interface IndexingStatusInfo {
 
 interface AttachmentStatusLabelProps {
   attachment: FileAttachment;
-  transcriptionStatuses?: Map<Id<'_storage'>, TranscriptionStatusInfo>;
-  indexingStatuses?: Map<Id<'_storage'>, IndexingStatusInfo>;
+  transcriptionStatuses?: Map<BlobRef, TranscriptionStatusInfo>;
+  indexingStatuses?: Map<BlobRef, IndexingStatusInfo>;
 }
 
 /**

--- a/services/platform/app/features/chat/components/chat-input/attachment-tray.tsx
+++ b/services/platform/app/features/chat/components/chat-input/attachment-tray.tsx
@@ -6,6 +6,7 @@ import { Bot, Eye, Folder, Loader, RotateCcw, User, X } from 'lucide-react';
 
 import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
 import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
 import { isAudioOrVideo } from '@/lib/shared/file-types';
 import { middleEllipsis } from '@/lib/utils/format/file';
@@ -39,8 +40,8 @@ interface AttachmentTrayProps {
   imageAttachments: FileAttachment[];
   fileAttachments: FileAttachment[];
   uploadingFiles: string[];
-  transcriptionStatuses?: Map<Id<'_storage'>, TranscriptionStatusInfo>;
-  indexingStatuses?: Map<Id<'_storage'>, IndexingStatusInfo>;
+  transcriptionStatuses?: Map<BlobRef, TranscriptionStatusInfo>;
+  indexingStatuses?: Map<BlobRef, IndexingStatusInfo>;
   retryAudioTranscription?: (fileId: Id<'_storage'>) => void;
   cancelUpload?: (fileId: string) => void;
   removeAttachment: (fileId: Id<'_storage'>) => void;

--- a/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
-import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
 
 import type { FileAttachment } from './use-convex-file-upload';
@@ -55,7 +55,7 @@ export function useFileIndexingStatus(
   );
 
   const statusMap = useMemo(() => {
-    const map = new Map<Id<'_storage'>, FileIndexingInfo>();
+    const map = new Map<BlobRef, FileIndexingInfo>();
     if (!metadata) return map;
     for (const m of metadata) {
       map.set(m.storageId, {
@@ -76,7 +76,7 @@ export function useFileIndexingStatus(
   // transition (not the absolute status) means a remount that observes an
   // already-finished file stays silent, and the success toast fires exactly
   // once per upload.
-  const prevStatusRef = useRef(new Map<Id<'_storage'>, RagStatus>());
+  const prevStatusRef = useRef(new Map<BlobRef, RagStatus>());
 
   useEffect(() => {
     if (!metadata) return;

--- a/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
@@ -4,7 +4,7 @@ import { useQuery } from 'convex/react';
 import { useMemo } from 'react';
 
 import { api } from '@/convex/_generated/api';
-import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 
 import { isAudioOrVideo } from '../../../../lib/shared/file-types';
 import type { FileAttachment } from './use-convex-file-upload';
@@ -63,7 +63,7 @@ export function useFileTranscriptionStatus(
   const isQueryLoading = audioFileIds.length > 0 && metadata === undefined;
 
   const statusMap = useMemo(() => {
-    const map = new Map<Id<'_storage'>, FileTranscriptionInfo>();
+    const map = new Map<BlobRef, FileTranscriptionInfo>();
     if (!metadata) return map;
     for (const m of metadata) {
       map.set(m.storageId, {

--- a/services/platform/app/features/chat/hooks/use-kb-mentions.ts
+++ b/services/platform/app/features/chat/hooks/use-kb-mentions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 
 /** Mirrors `MAX_KB_REFERENCES` in convex/agents/chat_turn.ts. */
 export const MAX_KB_MENTIONS = 5;
@@ -14,7 +15,7 @@ export const MAX_KB_MENTIONS = 5;
 export interface KbDocumentMention {
   kind: 'document';
   documentId: Id<'documents'>;
-  fileId: Id<'_storage'>;
+  fileId: BlobRef;
   title: string;
   fileType: string;
   fileSize: number;

--- a/services/platform/app/features/documents/components/document-history-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-history-dialog.tsx
@@ -14,6 +14,7 @@ import { useDocumentComparison } from '@/app/features/documents/hooks/use-docume
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -29,12 +30,12 @@ interface DocumentHistoryDialogProps {
 }
 
 type VersionPick = {
-  storageId: Id<'_storage'>;
+  storageId: BlobRef;
   fileName: string;
 };
 
 type DocumentVersionRow = {
-  storageId: Id<'_storage'>;
+  storageId: BlobRef;
   createdAt: number;
   isCurrent: boolean;
   fileName?: string;

--- a/services/platform/app/features/documents/hooks/mutations.ts
+++ b/services/platform/app/features/documents/hooks/mutations.ts
@@ -6,6 +6,7 @@ import {
   removeItemFromListQuery,
   updateItemInListQuery,
 } from '@/app/hooks/optimistic-updates';
+import { useConvexAction } from '@/app/hooks/use-convex-action';
 import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
 import {
   removeItemFromPaginatedQuery,
@@ -87,12 +88,16 @@ function uploadWithProgress(
   url: string,
   file: File,
   contentType: string,
+  // `POST` → Convex `_storage` (the response JSON carries the storageId to
+  // bind); `PUT` → the org's S3 bucket (the presigned URL, no useful body — the
+  // ref was known up front and is bound by the caller).
+  method: 'POST' | 'PUT',
   signal: AbortSignal | undefined,
   onProgress: (loaded: number, total: number) => void,
-): Promise<{ storageId: string }> {
+): Promise<{ storageId?: string }> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', url);
+    xhr.open(method, url);
     xhr.setRequestHeader('Content-Type', contentType);
 
     // No-progress watchdog: (re)armed on every progress tick; if it ever
@@ -120,6 +125,12 @@ function uploadWithProgress(
     xhr.addEventListener('load', () => {
       clearStall();
       if (xhr.status >= 200 && xhr.status < 300) {
+        if (method === 'PUT') {
+          // S3 PUT returns an empty body (ETag header only); the ref is bound
+          // by the caller from the handoff's `s3Ref`.
+          resolve({});
+          return;
+        }
         try {
           resolve(JSON.parse(xhr.responseText));
         } catch {
@@ -169,8 +180,11 @@ export function useDocumentUpload(options: UploadOptions) {
   const [trackedFiles, setTrackedFiles] = useState<TrackedFile[]>([]);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  const { mutateAsync: generateUploadUrl } = useConvexMutation(
-    api.files.mutations.generateUploadUrl,
+  // Backend-aware upload handoff: routes to the org's own S3 bucket when
+  // configured, else Convex `_storage`. An ACTION (not a mutation) because
+  // presigning S3 needs the node runtime.
+  const { mutateAsync: generateBlobUpload } = useConvexAction(
+    api.files.blob_actions.generateBlobUpload,
   );
   const { mutateAsync: createDocumentFromUpload } = useConvexMutation(
     api.documents.mutations.createDocumentFromUpload,
@@ -219,24 +233,28 @@ export function useDocumentUpload(options: UploadOptions) {
       // Track the committed blob so a later document-creation failure can
       // reclaim it (the blob is committed before createDocumentFromUpload,
       // which cannot delete it itself — a throwing mutation rolls back its
-      // own storage.delete).
-      let uploadedStorageId: string | undefined;
+      // own storage.delete). The ref is a Convex `_storage` id OR an `s3:` key.
+      let uploadedRef: string | undefined;
       try {
         const resolvedType =
           resolveFileType(file.name, file.type) || 'application/octet-stream';
 
         const signal = abortControllerRef.current?.signal;
         const contentHash = await calculateFileHash(file);
-        const uploadUrl = await withDeadline(
-          generateUploadUrl({}),
+        const handoff = await withDeadline(
+          generateBlobUpload({
+            organizationId: options.organizationId,
+            contentType: resolvedType,
+          }),
           MUTATION_TIMEOUT_MS,
           signal,
         );
 
         const { storageId } = await uploadWithProgress(
-          uploadUrl,
+          handoff.url,
           file,
           resolvedType,
+          handoff.method,
           signal,
           (loaded, total) => {
             updateFileStatus(fileId, {
@@ -245,7 +263,13 @@ export function useDocumentUpload(options: UploadOptions) {
             });
           },
         );
-        uploadedStorageId = storageId;
+        // Bind the S3 ref (known up front from the handoff) or the Convex id
+        // (returned in the POST response body).
+        const boundRef = handoff.s3Ref ?? storageId;
+        if (!boundRef) {
+          throw new Error('Upload did not return a storage reference');
+        }
+        uploadedRef = boundRef;
 
         // Create document records — one per team, or one org-wide. Each
         // mutation is raced against a deadline + the abort signal so a wedged
@@ -256,7 +280,7 @@ export function useDocumentUpload(options: UploadOptions) {
             await withDeadline(
               createDocumentFromUpload({
                 organizationId: options.organizationId,
-                fileId: toId<'_storage'>(storageId),
+                fileId: boundRef,
                 fileName: file.name,
                 contentType: resolvedType,
                 contentHash,
@@ -283,7 +307,7 @@ export function useDocumentUpload(options: UploadOptions) {
           await withDeadline(
             createDocumentFromUpload({
               organizationId: options.organizationId,
-              fileId: toId<'_storage'>(storageId),
+              fileId: boundRef,
               fileName: file.name,
               contentType: resolvedType,
               contentHash,
@@ -327,10 +351,11 @@ export function useDocumentUpload(options: UploadOptions) {
         // rejection, oversize, unsupported type, a wedged create). Reclaim the
         // orphaned blob so it doesn't silently consume storage — best-effort,
         // never let a cleanup failure mask the original error.
-        if (uploadedStorageId) {
+        if (uploadedRef) {
           try {
             await deleteRejectedUploadBlob({
-              storageId: toId<'_storage'>(uploadedStorageId),
+              storageId: uploadedRef,
+              organizationId: options.organizationId,
             });
           } catch (cleanupError) {
             console.warn(
@@ -360,7 +385,7 @@ export function useDocumentUpload(options: UploadOptions) {
       }
     },
     [
-      generateUploadUrl,
+      generateBlobUpload,
       createDocumentFromUpload,
       deleteRejectedUploadBlob,
       options.organizationId,

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -493,6 +493,7 @@ import type * as file_metadata_source_from_provider from "../file_metadata/sourc
 import type * as file_metadata_transcribe_audio from "../file_metadata/transcribe_audio.js";
 import type * as file_metadata_transcribe_dictation from "../file_metadata/transcribe_dictation.js";
 import type * as file_metadata_transcription_request from "../file_metadata/transcription_request.js";
+import type * as files_blob_actions from "../files/blob_actions.js";
 import type * as files_mutations from "../files/mutations.js";
 import type * as files_queries from "../files/queries.js";
 import type * as folders_access from "../folders/access.js";
@@ -918,6 +919,9 @@ import type * as lib_shared_schemas_utils_json_value from "../lib/shared/schemas
 import type * as lib_skills_guidance from "../lib/skills/guidance.js";
 import type * as lib_skills_precedence from "../lib/skills/precedence.js";
 import type * as lib_sops from "../lib/sops.js";
+import type * as lib_storage_blob_access from "../lib/storage/blob_access.js";
+import type * as lib_storage_blob_ref from "../lib/storage/blob_ref.js";
+import type * as lib_storage_object_store from "../lib/storage/object_store.js";
 import type * as lib_strip_nulls from "../lib/strip_nulls.js";
 import type * as lib_summarization_auto_summarize from "../lib/summarization/auto_summarize.js";
 import type * as lib_summarization_index from "../lib/summarization/index.js";
@@ -1131,6 +1135,10 @@ import type * as notifications_notify_slack from "../notifications/notify_slack.
 import type * as notifications_queries from "../notifications/queries.js";
 import type * as notifications_send_actionable_email from "../notifications/send_actionable_email.js";
 import type * as oauth2 from "../oauth2.js";
+import type * as object_storage_actions from "../object_storage/actions.js";
+import type * as object_storage_file_actions from "../object_storage/file_actions.js";
+import type * as object_storage_file_utils from "../object_storage/file_utils.js";
+import type * as object_storage_validators from "../object_storage/validators.js";
 import type * as onedrive_actions from "../onedrive/actions.js";
 import type * as onedrive_deactivate_sync_configs from "../onedrive/deactivate_sync_configs.js";
 import type * as onedrive_derive_sync_targets from "../onedrive/derive_sync_targets.js";
@@ -2249,6 +2257,7 @@ declare const fullApi: ApiFromModules<{
   "file_metadata/transcribe_audio": typeof file_metadata_transcribe_audio;
   "file_metadata/transcribe_dictation": typeof file_metadata_transcribe_dictation;
   "file_metadata/transcription_request": typeof file_metadata_transcription_request;
+  "files/blob_actions": typeof files_blob_actions;
   "files/mutations": typeof files_mutations;
   "files/queries": typeof files_queries;
   "folders/access": typeof folders_access;
@@ -2674,6 +2683,9 @@ declare const fullApi: ApiFromModules<{
   "lib/skills/guidance": typeof lib_skills_guidance;
   "lib/skills/precedence": typeof lib_skills_precedence;
   "lib/sops": typeof lib_sops;
+  "lib/storage/blob_access": typeof lib_storage_blob_access;
+  "lib/storage/blob_ref": typeof lib_storage_blob_ref;
+  "lib/storage/object_store": typeof lib_storage_object_store;
   "lib/strip_nulls": typeof lib_strip_nulls;
   "lib/summarization/auto_summarize": typeof lib_summarization_auto_summarize;
   "lib/summarization/index": typeof lib_summarization_index;
@@ -2887,6 +2899,10 @@ declare const fullApi: ApiFromModules<{
   "notifications/queries": typeof notifications_queries;
   "notifications/send_actionable_email": typeof notifications_send_actionable_email;
   oauth2: typeof oauth2;
+  "object_storage/actions": typeof object_storage_actions;
+  "object_storage/file_actions": typeof object_storage_file_actions;
+  "object_storage/file_utils": typeof object_storage_file_utils;
+  "object_storage/validators": typeof object_storage_validators;
   "onedrive/actions": typeof onedrive_actions;
   "onedrive/deactivate_sync_configs": typeof onedrive_deactivate_sync_configs;
   "onedrive/derive_sync_targets": typeof onedrive_derive_sync_targets;

--- a/services/platform/convex/agents/chat_turn_generate.ts
+++ b/services/platform/convex/agents/chat_turn_generate.ts
@@ -46,6 +46,7 @@ import {
 } from '../governance/sanitize';
 import { runGenerationCore } from '../lib/agent_chat/internal_actions';
 import { userContextValidator } from '../lib/agent_response/validators';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 import { resolveLanguageModelWithFallback } from '../providers/failover';
 import type { AutoRouteReason } from '../streaming/validators';
@@ -113,7 +114,7 @@ export const runChatTurnGeneration = internalAction({
       v.array(
         v.object({
           documentId: v.id('documents'),
-          fileId: v.id('_storage'),
+          fileId: blobRefValidator,
           fileName: v.string(),
           fileType: v.string(),
           fileSize: v.number(),

--- a/services/platform/convex/agents/resolve_referenced_files.ts
+++ b/services/platform/convex/agents/resolve_referenced_files.ts
@@ -23,6 +23,7 @@ import {
   isProjectScopedDocument,
 } from '../documents/access';
 import { getUserTeamIds } from '../lib/get_user_teams';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 /** Hard cap on `@`-mentioned knowledge-base documents per turn. Mirrored by
  *  the composer (`MAX_KB_MENTIONS` in use-kb-mentions.ts). */
@@ -32,7 +33,7 @@ export const MAX_KB_REFERENCES = 5;
  *  scheduled-action payload. */
 export interface ResolvedKbReference {
   documentId: Id<'documents'>;
-  fileId: Id<'_storage'>;
+  fileId: BlobRef;
   fileName: string;
   fileType: string;
   fileSize: number;

--- a/services/platform/convex/agents/start_chat.ts
+++ b/services/platform/convex/agents/start_chat.ts
@@ -13,6 +13,7 @@ import { internalMutation } from '../_generated/server';
 import { startAgentChat } from '../lib/agent_chat';
 import { userContextValidator } from '../lib/agent_response/validators';
 import { getOrganizationMember } from '../lib/rls';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { autoRouteReasonValidator } from '../streaming/validators';
 
 const beforeGenerateHookRef = makeFunctionReference<'action'>(
@@ -47,7 +48,7 @@ export const startChat = internalMutation({
       v.array(
         v.object({
           documentId: v.id('documents'),
-          fileId: v.id('_storage'),
+          fileId: blobRefValidator,
           fileName: v.string(),
           fileType: v.string(),
           fileSize: v.number(),

--- a/services/platform/convex/documents/actions.ts
+++ b/services/platform/convex/documents/actions.ts
@@ -4,13 +4,13 @@ import { v } from 'convex/values';
 
 import { isRecord, getBoolean, getString } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
-import type { Id } from '../_generated/dataModel';
 import { action } from '../_generated/server';
 import {
   RateLimitExceededError,
   checkUserRateLimit,
 } from '../lib/rate_limiter/helpers';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import type { BlobRef } from '../lib/storage/blob_ref';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 
 const INITIAL_POLLING_DELAY_MS = 10_000;
@@ -33,7 +33,7 @@ export const retryRagIndexing = action({
   handler: async (ctx, args) => {
     // RAG status is canonical on fileMetadata.ragStatus; hoist storageId so the
     // catch can mark failure after the document is resolved.
-    let storageId: Id<'_storage'> | null = null;
+    let storageId: BlobRef | null = null;
     try {
       const authUser = await getAuthUserIdentity(ctx);
       if (!authUser) {

--- a/services/platform/convex/documents/get_document_rag_projection.ts
+++ b/services/platform/convex/documents/get_document_rag_projection.ts
@@ -12,8 +12,9 @@
  * `not_indexed`.
  */
 
-import type { Doc, Id } from '../_generated/dataModel';
+import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 export interface DocumentRagProjection {
   status?: 'queued' | 'running' | 'completed' | 'failed' | 'unsupported';
@@ -64,7 +65,7 @@ export async function getDocumentRagProjectionBatch(
 
   // Deduplicate fileIds so a blob shared by multiple docs is fetched once.
   const seen = new Set<string>();
-  const uniqueFileIds: Id<'_storage'>[] = [];
+  const uniqueFileIds: BlobRef[] = [];
   for (const d of docs) {
     if (!d.fileId) continue;
     const key = String(d.fileId);

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -2,18 +2,20 @@
 
 import { v } from 'convex/values';
 
-import {
-  fetchJson,
-  getBoolean,
-  getString,
-  isRecord,
-} from '../../lib/utils/type-utils';
+import { getBoolean, getString, isRecord } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
-import type { Id } from '../_generated/dataModel';
 import { internalAction, type ActionCtx } from '../_generated/server';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
-import { buildDownloadUrl } from '../lib/helpers/public_storage_url';
-import { blobRefValidator, type BlobRef } from '../lib/storage/blob_ref';
+import {
+  buildBlobServeUrl,
+  buildDownloadUrl,
+} from '../lib/helpers/public_storage_url';
+import { putBlob } from '../lib/storage/blob_access';
+import {
+  blobRefValidator,
+  isS3Ref,
+  type BlobRef,
+} from '../lib/storage/blob_ref';
 import { deleteDocumentById } from '../workflow_engine/action_defs/rag/helpers/delete_document';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 // `generate_document` / `generate_docx` are `'use node'` modules and are NOT
@@ -678,21 +680,15 @@ export const storeRawContent = internalAction({
     const bytes = new TextEncoder().encode(args.content);
     const size = bytes.byteLength;
 
-    const uploadUrl = await ctx.storage.generateUploadUrl();
-    const uploadResponse = await fetch(uploadUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': args.contentType },
-      body: bytes,
-    });
-
-    if (!uploadResponse.ok) {
-      throw new Error(
-        `Failed to upload content: ${uploadResponse.status} ${uploadResponse.statusText}`,
-      );
-    }
-
-    const { storageId } = await fetchJson<{ storageId: Id<'_storage'> }>(
-      uploadResponse,
+    // Store through the backend-aware seam: an org with a bring-your-own bucket
+    // gets the blob in its own S3, else Convex `_storage` (unchanged). The slug
+    // resolves the org's store; a missing slug falls through to the default.
+    const orgSlug = (await orgSlugFromIdOrNull(ctx, args.organizationId)) ?? '';
+    const storageId: BlobRef = await putBlob(
+      ctx,
+      orgSlug,
+      bytes,
+      args.contentType,
     );
 
     const lowerFileName = args.fileName.toLowerCase();
@@ -713,7 +709,12 @@ export const storeRawContent = internalAction({
       },
     );
 
-    const downloadUrl = buildDownloadUrl(storageId, finalFileName);
+    // An `s3:` blob is served through the node `/storage` route (which presigns
+    // + 302-redirects); the `org` param addresses the right bucket. A Convex
+    // blob keeps the direct `/storage?id=` download URL.
+    const downloadUrl = isS3Ref(storageId)
+      ? buildBlobServeUrl(String(storageId), args.organizationId, finalFileName)
+      : buildDownloadUrl(String(storageId), finalFileName);
 
     return {
       success: true,

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -13,6 +13,7 @@ import type { Id } from '../_generated/dataModel';
 import { internalAction, type ActionCtx } from '../_generated/server';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
 import { buildDownloadUrl } from '../lib/helpers/public_storage_url';
+import { blobRefValidator, type BlobRef } from '../lib/storage/blob_ref';
 import { deleteDocumentById } from '../workflow_engine/action_defs/rag/helpers/delete_document';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 // `generate_document` / `generate_docx` are `'use node'` modules and are NOT
@@ -194,7 +195,7 @@ export const deleteDocumentFromRag = internalAction({
      * scheduled jobs from earlier code keep working.
      */
     expectedExternalItemId: v.optional(v.string()),
-    expectedFileId: v.optional(v.id('_storage')),
+    expectedFileId: v.optional(blobRefValidator),
     /**
      * Sync-reconcile only: forwarded to `deleteDocumentById` so the
      * mutation reaps now-empty ancestor folders up to (but not
@@ -356,7 +357,7 @@ export const uploadDocumentToRag = internalAction({
     // server poll on the fileMetadata row (keyed by the document's storageId).
     // storageId is hoisted so the catch can still mark failure when the upload
     // throws after the document is resolved.
-    let storageId: Id<'_storage'> | null = null;
+    let storageId: BlobRef | null = null;
     try {
       const document = await ctx.runQuery(
         internal.documents.internal_queries.getDocumentByIdRaw,
@@ -450,7 +451,7 @@ export const uploadDocumentToRag = internalAction({
 export const reindexDocumentInRag = internalAction({
   args: {
     documentId: v.id('documents'),
-    oldFileId: v.id('_storage'),
+    oldFileId: blobRefValidator,
     /** Optional for backward compatibility with in-flight scheduled jobs.
      * New scheduler callers always pass it; when missing we fall back
      * to the current document's organizationId (which may have changed
@@ -619,7 +620,7 @@ export const syncRagFolderPaths = internalAction({
     organizationId: v.string(),
     updates: v.array(
       v.object({
-        fileId: v.id('_storage'),
+        fileId: blobRefValidator,
         /** New folder path; omitted clears it (document moved to the root). */
         folderPath: v.optional(v.string()),
       }),

--- a/services/platform/convex/documents/internal_mutations.ts
+++ b/services/platform/convex/documents/internal_mutations.ts
@@ -5,6 +5,7 @@ import { internalMutation } from '../_generated/server';
 import { cleanupEmptyAncestorFolders } from '../folders/cleanup_empty_ancestors';
 import { eraseDocumentBlobs } from '../governance/erase_document_blobs';
 import { assertNotHeld } from '../governance/legal_hold_guard';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { createDocument as createDocumentHelper } from './create_document';
 import { scheduleHubDocumentRagIndexing as scheduleHubDocumentRagIndexingImpl } from './schedule_hub_document_rag_indexing';
 import { updateDocumentInternal as updateDocumentInternalHelper } from './update_document_internal';
@@ -17,7 +18,7 @@ export const updateDocument = internalMutation({
     title: v.optional(v.string()),
     content: v.optional(v.string()),
     metadata: v.optional(jsonRecordValidator),
-    fileId: v.optional(v.id('_storage')),
+    fileId: v.optional(blobRefValidator),
     mimeType: v.optional(v.string()),
     extension: v.optional(v.string()),
     sourceProvider: v.optional(sourceProviderValidator),
@@ -171,7 +172,7 @@ export const createDocument = internalMutation({
     organizationId: v.string(),
     title: v.string(),
     content: v.optional(v.string()),
-    fileId: v.optional(v.id('_storage')),
+    fileId: v.optional(blobRefValidator),
     mimeType: v.optional(v.string()),
     extension: v.optional(v.string()),
     sourceProvider: v.optional(sourceProviderValidator),
@@ -195,7 +196,7 @@ export const upsertDocumentByExternalId = internalMutation({
     externalItemId: v.string(),
     folderPathPrefix: v.optional(v.string()),
     title: v.string(),
-    fileId: v.optional(v.id('_storage')),
+    fileId: v.optional(blobRefValidator),
     mimeType: v.optional(v.string()),
     extension: v.optional(v.string()),
     sourceProvider: v.optional(v.string()),

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import type { Id } from '../_generated/dataModel';
 import { internalQuery } from '../_generated/server';
 import { getUserTeamIds } from '../lib/get_user_teams';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { toId } from '../lib/type_cast_helpers';
 import { resolveProjectAccessForUser } from '../projects/resolve_project_access';
 import { checkMembership } from './check_membership';
@@ -256,7 +257,7 @@ export const listFilesByFolderInternal = internalQuery({
     v.null(),
     v.array(
       v.object({
-        fileId: v.id('_storage'),
+        fileId: blobRefValidator,
         name: v.string(),
       }),
     ),

--- a/services/platform/convex/documents/list_document_versions.ts
+++ b/services/platform/convex/documents/list_document_versions.ts
@@ -4,11 +4,12 @@
  * from `fileMetadata` when present (upsert keeps prior blobs + their rows).
  */
 
-import type { Doc, Id } from '../_generated/dataModel';
+import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 export type DocumentVersionEntry = {
-  storageId: Id<'_storage'>;
+  storageId: BlobRef;
   createdAt: number;
   isCurrent: boolean;
   fileName?: string;
@@ -21,7 +22,7 @@ export async function listDocumentVersionsForDoc(
   doc: Doc<'documents'>,
 ): Promise<DocumentVersionEntry[]> {
   const history = doc.historyFiles ?? [];
-  const ordered: Array<{ storageId: Id<'_storage'>; isCurrent: boolean }> = [];
+  const ordered: Array<{ storageId: BlobRef; isCurrent: boolean }> = [];
   const seen = new Set<string>();
 
   if (doc.fileId) {

--- a/services/platform/convex/documents/list_files_by_folder.ts
+++ b/services/platform/convex/documents/list_files_by_folder.ts
@@ -1,10 +1,11 @@
 import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { findFolderByPath } from '../folders/find_folder_by_path';
+import type { BlobRef } from '../lib/storage/blob_ref';
 import { isActiveDocument } from './_helpers';
 
 export interface FolderFile {
-  fileId: Id<'_storage'>;
+  fileId: BlobRef;
   name: string;
 }
 

--- a/services/platform/convex/documents/list_orphaned_external_docs.ts
+++ b/services/platform/convex/documents/list_orphaned_external_docs.ts
@@ -1,10 +1,11 @@
 import type { Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 export interface OrphanedExternalDoc {
   documentId: Id<'documents'>;
   externalItemId: string;
-  fileId?: Id<'_storage'>;
+  fileId?: BlobRef;
   title?: string;
 }
 
@@ -34,7 +35,7 @@ export async function listOrphanedExternalDocs(
     _id: Id<'documents'>;
     sourceProvider?: string;
     externalItemId?: string;
-    fileId?: Id<'_storage'>;
+    fileId?: BlobRef;
     title?: string;
     driveId?: string;
     lifecycleStatus?: string;

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -22,6 +22,7 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { blobRefValidator, convexStorageId } from '../lib/storage/blob_ref';
 import { hasTeamAccess } from '../lib/team_access';
 import { stopSyncForDeletedDocument } from '../onedrive/deactivate_sync_configs';
 import { checkProjectAccess } from '../projects/access';
@@ -41,7 +42,7 @@ export const updateDocument = mutation({
     title: v.optional(v.string()),
     content: v.optional(v.string()),
     metadata: v.optional(jsonValueValidator),
-    fileId: v.optional(v.id('_storage')),
+    fileId: v.optional(blobRefValidator),
     mimeType: v.optional(v.string()),
     extension: v.optional(v.string()),
     sourceProvider: v.optional(sourceProviderValidator),
@@ -173,7 +174,7 @@ export const deleteDocument = mutation({
 export const createDocumentFromUpload = mutation({
   args: {
     organizationId: v.string(),
-    fileId: v.id('_storage'),
+    fileId: blobRefValidator,
     fileName: v.string(),
     contentType: v.optional(v.string()),
     contentHash: v.optional(v.string()),
@@ -325,7 +326,17 @@ export const createDocumentFromUpload = mutation({
     // reject past the product cap. An org upload policy can only narrow this
     // further (checked above); it can't raise it, matching the client, which
     // never lets a >100 MB document through.
-    const storageMeta = await ctx.db.system.get(args.fileId);
+    // `db.system.get` only sizes Convex `_storage` blobs. An `s3:` ref lives in
+    // the org's OWN bucket (the org's storage cost, not the deployment's), so
+    // the authoritative server-side probe isn't available — fall back to the
+    // client-declared `fileSize` for the product cap (the upload policy above
+    // already gated on it).
+    const convexFileId = convexStorageId(args.fileId);
+    const storageMeta = convexFileId
+      ? await ctx.db.system.get(convexFileId)
+      : args.fileSize != null
+        ? { size: args.fileSize }
+        : null;
     if (storageMeta && storageMeta.size > DOCUMENT_MAX_FILE_SIZE) {
       throw new ConvexError({
         code: 'FILE_TOO_LARGE',

--- a/services/platform/convex/documents/queries.ts
+++ b/services/platform/convex/documents/queries.ts
@@ -13,6 +13,7 @@ import { countItemsInOrg } from '../lib/helpers/count_items_in_org';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { isActiveOrg } from '../lib/rls/organization/assert_active_org';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { resolveProjectAccessForUser } from '../projects/resolve_project_access';
 import { isActiveDocument } from './_helpers';
 import { canReadDocument, hasKnowledgeHubDocumentAccess } from './access';
@@ -192,7 +193,7 @@ export const searchDocumentsForMention = query({
 });
 
 const documentVersionValidator = v.object({
-  storageId: v.id('_storage'),
+  storageId: blobRefValidator,
   createdAt: v.number(),
   isCurrent: v.boolean(),
   fileName: v.optional(v.string()),

--- a/services/platform/convex/documents/schema.ts
+++ b/services/platform/convex/documents/schema.ts
@@ -2,13 +2,17 @@ import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
 import { lifecycleStatusValidator } from '../governance/soft_delete_validators';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { jsonRecordValidator } from '../lib/validators/json';
 
 export const documentsTable = defineTable({
   organizationId: v.string(),
   title: v.optional(v.string()),
   content: v.optional(v.string()),
-  fileId: v.optional(v.id('_storage')),
+  // Blob reference for the source file: a Convex `_storage` id (deployment
+  // default) OR an `s3:<key>` ref when the org routes blobs at its own bucket.
+  // Widened from `v.id('_storage')` — every existing id still validates.
+  fileId: v.optional(blobRefValidator),
   mimeType: v.optional(v.string()),
   extension: v.optional(v.string()),
   // Open string. Equal to the integration slug for integration-sourced docs
@@ -20,7 +24,7 @@ export const documentsTable = defineTable({
   siteId: v.optional(v.string()),
   driveId: v.optional(v.string()),
   contentHash: v.optional(v.string()),
-  historyFiles: v.optional(v.array(v.id('_storage'))),
+  historyFiles: v.optional(v.array(blobRefValidator)),
   teamId: v.optional(v.string()),
   // Full list of team IDs the document belongs to (multi-team). `teamId`
   // mirrors the first entry for single-team consumers.

--- a/services/platform/convex/documents/search_documents_for_mention.ts
+++ b/services/platform/convex/documents/search_documents_for_mention.ts
@@ -29,6 +29,7 @@ import type { PaginationResult } from 'convex/server';
 import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { documentsSearchStrategy, runEntitySearch } from '../lib/search';
+import type { BlobRef } from '../lib/storage/blob_ref';
 import { isActiveDocument } from './_helpers';
 import { hasKnowledgeHubDocumentAccess } from './access';
 
@@ -40,7 +41,7 @@ const MAX_PROJECT_SCAN = 1000;
 
 export interface MentionDocumentResult {
   documentId: Id<'documents'>;
-  fileId: Id<'_storage'>;
+  fileId: BlobRef;
   /** Display title — document title, falling back to the blob's file name. */
   title: string;
   fileType: string;

--- a/services/platform/convex/documents/types.ts
+++ b/services/platform/convex/documents/types.ts
@@ -174,8 +174,9 @@ export interface GenerateDocumentArgs {
 export interface GenerateDocumentResult {
   /** Whether the document was generated and uploaded successfully */
   success: boolean;
-  /** Convex storage id for the generated file */
-  fileStorageId: Id<'_storage'>;
+  /** Blob reference for the generated file: a Convex `_storage` id (default) OR
+   *  an `s3:<key>` ref when the org has a bring-your-own bucket. */
+  fileStorageId: BlobRef;
   /** Download URL for the generated file */
   downloadUrl: string;
   /** Final file name including extension */

--- a/services/platform/convex/documents/types.ts
+++ b/services/platform/convex/documents/types.ts
@@ -5,6 +5,7 @@
 import type { Infer } from 'convex/values';
 
 import type { Id } from '../_generated/dataModel';
+import type { BlobRef } from '../lib/storage/blob_ref';
 import type {
   documentItemValidator,
   documentFindResponseValidator,
@@ -60,7 +61,7 @@ export interface CreateDocumentArgs {
   title?: string;
 
   content?: string;
-  fileId?: Id<'_storage'>;
+  fileId?: BlobRef;
   mimeType?: string;
   extension?: string;
   metadata?: unknown;
@@ -117,7 +118,7 @@ export type ListDocumentsByExtensionResult = Array<{
   _id: Id<'documents'>;
   _creationTime: number;
   title?: string;
-  fileId?: Id<'_storage'>;
+  fileId?: BlobRef;
   mimeType?: string;
   extension?: string;
   metadata?: unknown;

--- a/services/platform/convex/documents/update_document.ts
+++ b/services/platform/convex/documents/update_document.ts
@@ -9,6 +9,7 @@ import { isRecord } from '../../lib/utils/type-utils';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { getUserTeamIds } from '../lib/get_user_teams';
+import type { BlobRef } from '../lib/storage/blob_ref';
 import { extractExtension } from './extract_extension';
 import { teamIdsToFields } from './team_fields';
 
@@ -19,7 +20,7 @@ export async function updateDocument(
     title?: string;
     content?: string;
     metadata?: unknown;
-    fileId?: Id<'_storage'>;
+    fileId?: BlobRef;
     mimeType?: string;
     extension?: string;
     sourceProvider?: string;

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -8,13 +8,14 @@ import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { buildFolderPath } from '../folders/queries';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 export type UpdateDocumentInternalArgs = {
   documentId: Id<'documents'>;
   title?: string;
   content?: string;
   metadata?: Record<string, unknown>;
-  fileId?: Id<'_storage'>;
+  fileId?: BlobRef;
   mimeType?: string;
   extension?: string;
   sourceProvider?: string;

--- a/services/platform/convex/documents/upsert_document_by_external_id.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.ts
@@ -23,6 +23,7 @@ import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { buildFolderPath } from '../folders/queries';
+import { convexStorageId, type BlobRef } from '../lib/storage/blob_ref';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
 import { extractExtension } from './extract_extension';
 import { findDocumentByExternalId } from './find_document_by_external_id';
@@ -33,7 +34,7 @@ export interface UpsertDocumentByExternalIdArgs {
   /** Optional prefix scope: docs whose folderPath equals or sits under this. */
   folderPathPrefix?: string;
   title: string;
-  fileId?: Id<'_storage'>;
+  fileId?: BlobRef;
   mimeType?: string;
   /** File extension for the document row. Sync titles are kept clean (no
    * extension), so callers derive this from the stored blob's filename and
@@ -123,14 +124,24 @@ export async function upsertDocumentByExternalId(
       if (existing.fileId === undefined) {
         contentChanged = true;
       } else {
-        const [oldBlob, newBlob] = await Promise.all([
-          ctx.db.system.get(existing.fileId),
-          ctx.db.system.get(args.fileId),
-        ]);
-        contentChanged =
-          oldBlob === null ||
-          newBlob === null ||
-          oldBlob.sha256 !== newBlob.sha256;
+        // `db.system.get` only sizes/hashes Convex `_storage` blobs. When either
+        // side is an `s3:` ref its bytes live in the org's bucket (no system
+        // row to hash), so we can't SHA-compare — treat as changed so a real
+        // update re-indexes rather than being skipped.
+        const oldConvex = convexStorageId(existing.fileId);
+        const newConvex = convexStorageId(args.fileId);
+        if (oldConvex === null || newConvex === null) {
+          contentChanged = true;
+        } else {
+          const [oldBlob, newBlob] = await Promise.all([
+            ctx.db.system.get(oldConvex),
+            ctx.db.system.get(newConvex),
+          ]);
+          contentChanged =
+            oldBlob === null ||
+            newBlob === null ||
+            oldBlob.sha256 !== newBlob.sha256;
+        }
       }
     }
     const folderChanged =

--- a/services/platform/convex/file_metadata/actions.ts
+++ b/services/platform/convex/file_metadata/actions.ts
@@ -6,6 +6,7 @@ import { internal } from '../_generated/api';
 import { action } from '../_generated/server';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 
 /**
  * Check RAG indexing status for a list of files and update fileMetadata.
@@ -23,7 +24,7 @@ import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
  */
 export const checkFileRagStatuses = action({
   args: {
-    storageIds: v.array(v.id('_storage')),
+    storageIds: v.array(blobRefValidator),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {

--- a/services/platform/convex/file_metadata/helpers.ts
+++ b/services/platform/convex/file_metadata/helpers.ts
@@ -1,20 +1,35 @@
-import type { Id } from '../_generated/dataModel';
+import { internal } from '../_generated/api';
 import type { MutationCtx } from '../_generated/server';
+import { convexStorageId, type BlobRef } from '../lib/storage/blob_ref';
 
 /**
  * Delete a storage blob and its associated fileMetadata record.
  * Silently skips the metadata deletion if no record exists.
+ *
+ * Backend-aware: a Convex `_storage` id is deleted inline; an `s3:` ref lives in
+ * the org's own bucket and can't be signed from a mutation, so its physical
+ * delete is scheduled onto the node `deleteOrgBlobs` action (best-effort). The
+ * fileMetadata row (which carries the owning org) is removed either way.
  */
 export async function deleteStorageWithMetadata(
   ctx: MutationCtx,
-  storageId: Id<'_storage'>,
+  storageId: BlobRef,
 ): Promise<void> {
-  await ctx.storage.delete(storageId);
-
   const metadata = await ctx.db
     .query('fileMetadata')
     .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
     .first();
+
+  const convexId = convexStorageId(storageId);
+  if (convexId !== null) {
+    await ctx.storage.delete(convexId);
+  } else if (metadata) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.files.blob_actions.deleteOrgBlobs,
+      { organizationId: metadata.organizationId, refs: [String(storageId)] },
+    );
+  }
 
   if (metadata) {
     await ctx.db.delete(metadata._id);

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -12,6 +12,8 @@ import { extractDocumentMetadata } from '../crawler/lib/document_metadata';
 import { getPollingInterval } from '../documents/internal_actions';
 import { isUpstreamHttpError } from '../lib/errors/upstream_http_error';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { readBlobBytes } from '../lib/storage/blob_access';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 
 const INITIAL_POLLING_DELAY_MS = 10_000;
@@ -31,7 +33,7 @@ const MAX_POLL_ATTEMPTS = 50;
 export const uploadFileToRag = internalAction({
   args: {
     organizationId: v.string(),
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     fileName: v.string(),
     contentType: v.string(),
   },
@@ -98,7 +100,7 @@ export const uploadFileToRag = internalAction({
  */
 export const pollFileRagStatus = internalAction({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     organizationId: v.string(),
     attempt: v.number(),
   },
@@ -263,7 +265,7 @@ const EXTRACT_METADATA_RETRY_DELAYS = [30_000, 60_000, 120_000];
  */
 export const extractFileMetadata = internalAction({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     fileName: v.string(),
     contentType: v.string(),
     organizationId: v.string(),
@@ -293,15 +295,25 @@ export const extractFileMetadata = internalAction({
     // call.
     if (ext && EXTRACT_METADATA_EXTENSIONS.has(ext)) {
       try {
-        const fileBlob = await ctx.storage.get(args.storageId);
-        if (!fileBlob) {
+        // Read via the backend-aware seam: a Convex `_storage` id streams from
+        // `_storage`; an `s3:` ref is fetched from the org's own bucket (needs
+        // the slug to resolve the store).
+        const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+        if (orgSlug === null) {
+          console.warn(
+            `[extractFileMetadata] org ${args.organizationId} unresolvable for ${args.storageId}, skipping`,
+          );
+          return null;
+        }
+        let bytes: Uint8Array;
+        try {
+          bytes = await readBlobBytes(ctx, orgSlug, args.storageId);
+        } catch {
           console.warn(
             `[extractFileMetadata] No blob for file ${args.storageId}, skipping`,
           );
           return null;
         }
-
-        const bytes = new Uint8Array(await fileBlob.arrayBuffer());
         const meta = await extractDocumentMetadata(bytes, ext);
 
         const pageCount = meta.pageCount;

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -12,13 +12,14 @@ import {
   RateLimitExceededError,
   checkOrganizationRateLimit,
 } from '../lib/rate_limiter/helpers';
+import { blobRefValidator, convexStorageId } from '../lib/storage/blob_ref';
 import { maybeDispatchRagIndexing, promoteQueuedRagJobs } from './rag_dispatch';
 import { sourceFromProvider } from './source_from_provider';
 
 export const saveFileMetadata = internalMutation({
   args: {
     organizationId: v.string(),
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     fileName: v.string(),
     contentType: v.string(),
     size: v.number(),
@@ -117,16 +118,21 @@ export const saveFileMetadata = internalMutation({
         await maybeDispatchRagIndexing(ctx, args.storageId);
       }
       if (needsTranscribeRetry) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.file_metadata.transcribe_audio.transcribeAudio,
-          {
-            storageId: args.storageId,
-            fileName: args.fileName,
-            contentType: args.contentType,
-            organizationId: args.organizationId,
-          },
-        );
+        // Transcription is a Convex-`_storage`-only pipeline (audio uploads are
+        // never routed to S3); narrow the ref for the Id-typed action arg.
+        const audioId = convexStorageId(args.storageId);
+        if (audioId) {
+          await ctx.scheduler.runAfter(
+            0,
+            internal.file_metadata.transcribe_audio.transcribeAudio,
+            {
+              storageId: audioId,
+              fileName: args.fileName,
+              contentType: args.contentType,
+              organizationId: args.organizationId,
+            },
+          );
+        }
       }
 
       return existing._id;
@@ -156,16 +162,20 @@ export const saveFileMetadata = internalMutation({
     }
 
     if (isAudio) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.file_metadata.transcribe_audio.transcribeAudio,
-        {
-          storageId: args.storageId,
-          fileName: args.fileName,
-          contentType: args.contentType,
-          organizationId: args.organizationId,
-        },
-      );
+      // Audio is Convex-`_storage`-only; narrow for the Id-typed action arg.
+      const audioId = convexStorageId(args.storageId);
+      if (audioId) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.file_metadata.transcribe_audio.transcribeAudio,
+          {
+            storageId: audioId,
+            fileName: args.fileName,
+            contentType: args.contentType,
+            organizationId: args.organizationId,
+          },
+        );
+      }
     }
 
     await ctx.scheduler.runAfter(
@@ -202,7 +212,7 @@ export const saveFileMetadata = internalMutation({
 
 export const updateFileRagStatus = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     ragStatus: v.union(
       v.literal('queued'),
       v.literal('running'),
@@ -287,7 +297,7 @@ export const updateFileRagStatus = internalMutation({
 export const ensureFileMetadataForDocument = internalMutation({
   args: {
     organizationId: v.string(),
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     documentId: v.id('documents'),
     fileName: v.string(),
     contentType: v.optional(v.string()),
@@ -304,7 +314,10 @@ export const ensureFileMetadataForDocument = internalMutation({
       return existing._id;
     }
 
-    const sys = await ctx.db.system.get(args.storageId);
+    // `db.system.get` only knows Convex `_storage` ids; an `s3:` ref has no
+    // system row, so size/contentType fall back to the passed value / defaults.
+    const convexId = convexStorageId(args.storageId);
+    const sys = convexId ? await ctx.db.system.get(convexId) : null;
     return await ctx.db.insert('fileMetadata', {
       organizationId: args.organizationId,
       storageId: args.storageId,
@@ -329,7 +342,7 @@ export const ensureFileMetadataForDocument = internalMutation({
  */
 export const expireStaleRagQueue = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     staleAfterMs: v.number(),
   },
   returns: v.null(),
@@ -361,7 +374,7 @@ export const expireStaleRagQueue = internalMutation({
  */
 export const updateFileTranscription = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     transcriptionStatus: v.optional(
       v.union(
         v.literal('queued'),
@@ -433,10 +446,15 @@ export const updateFileTranscription = internalMutation({
       args.transcriptionStatus === 'failed' ||
       args.transcriptionStatus === 'skipped'
     ) {
-      const linkedJob = await ctx.db
-        .query('videoLinkJobs')
-        .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
-        .first();
+      // videoLinkJobs.storageId is a Convex `_storage` id (video-link audio is
+      // never S3); narrow the ref for the index lookup.
+      const convexAudioId = convexStorageId(args.storageId);
+      const linkedJob = convexAudioId
+        ? await ctx.db
+            .query('videoLinkJobs')
+            .withIndex('by_storageId', (q) => q.eq('storageId', convexAudioId))
+            .first()
+        : null;
       if (linkedJob && linkedJob.status === 'transcribing_handoff') {
         const nextStatus =
           args.transcriptionStatus === 'completed'
@@ -460,7 +478,7 @@ export const updateFileTranscription = internalMutation({
 
 export const updateFileVisionMetadata = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     pageCount: v.optional(v.number()),
     scannedPagesDetected: v.optional(v.number()),
     visionRequired: v.optional(v.boolean()),
@@ -502,7 +520,7 @@ export const updateFileVisionMetadata = internalMutation({
  */
 export const acquireTranscriptionLock = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     runId: v.string(),
     leaseMs: v.number(),
   },
@@ -545,7 +563,7 @@ export const acquireTranscriptionLock = internalMutation({
  */
 export const releaseTranscriptionLock = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     runId: v.string(),
   },
   returns: v.null(),
@@ -606,10 +624,15 @@ export const recoverStuckTranscriptions = internalMutation({
         // status, which means `cleanupCancelledVideoLink` never gets
         // called and the audio blob orphans. Reverse-lookup by storageId
         // (new `by_storageId` index) and flip in the same tick.
-        const linkedJob = await ctx.db
-          .query('videoLinkJobs')
-          .withIndex('by_storageId', (q) => q.eq('storageId', row.storageId))
-          .first();
+        const convexAudioId = convexStorageId(row.storageId);
+        const linkedJob = convexAudioId
+          ? await ctx.db
+              .query('videoLinkJobs')
+              .withIndex('by_storageId', (q) =>
+                q.eq('storageId', convexAudioId),
+              )
+              .first()
+          : null;
         if (linkedJob && linkedJob.status === 'transcribing_handoff') {
           await ctx.db.patch(linkedJob._id, {
             status: 'failed',
@@ -629,7 +652,7 @@ export const recoverStuckTranscriptions = internalMutation({
 
 export const linkDocumentToFile = internalMutation({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
     documentId: v.id('documents'),
   },
   async handler(ctx, args) {

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -118,21 +118,19 @@ export const saveFileMetadata = internalMutation({
         await maybeDispatchRagIndexing(ctx, args.storageId);
       }
       if (needsTranscribeRetry) {
-        // Transcription is a Convex-`_storage`-only pipeline (audio uploads are
-        // never routed to S3); narrow the ref for the Id-typed action arg.
-        const audioId = convexStorageId(args.storageId);
-        if (audioId) {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.file_metadata.transcribe_audio.transcribeAudio,
-            {
-              storageId: audioId,
-              fileName: args.fileName,
-              contentType: args.contentType,
-              organizationId: args.organizationId,
-            },
-          );
-        }
+        // `transcribeAudio` is backend-aware: it reads the source blob from
+        // Convex `_storage` OR the org's S3 bucket, so the full ref is passed
+        // through (no `_storage`-only narrowing).
+        await ctx.scheduler.runAfter(
+          0,
+          internal.file_metadata.transcribe_audio.transcribeAudio,
+          {
+            storageId: args.storageId,
+            fileName: args.fileName,
+            contentType: args.contentType,
+            organizationId: args.organizationId,
+          },
+        );
       }
 
       return existing._id;
@@ -162,20 +160,18 @@ export const saveFileMetadata = internalMutation({
     }
 
     if (isAudio) {
-      // Audio is Convex-`_storage`-only; narrow for the Id-typed action arg.
-      const audioId = convexStorageId(args.storageId);
-      if (audioId) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.file_metadata.transcribe_audio.transcribeAudio,
-          {
-            storageId: audioId,
-            fileName: args.fileName,
-            contentType: args.contentType,
-            organizationId: args.organizationId,
-          },
-        );
-      }
+      // `transcribeAudio` is backend-aware (reads `_storage` OR the org's S3
+      // bucket), so pass the full ref through.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.file_metadata.transcribe_audio.transcribeAudio,
+        {
+          storageId: args.storageId,
+          fileName: args.fileName,
+          contentType: args.contentType,
+          organizationId: args.organizationId,
+        },
+      );
     }
 
     await ctx.scheduler.runAfter(

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -3,10 +3,11 @@ import { v } from 'convex/values';
 import { components } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
 import { internalQuery } from '../_generated/server';
+import { blobRefValidator, convexStorageId } from '../lib/storage/blob_ref';
 
 export const getByStorageId = internalQuery({
   args: {
-    storageId: v.id('_storage'),
+    storageId: blobRefValidator,
   },
   async handler(ctx, args) {
     return await ctx.db
@@ -89,7 +90,7 @@ export const listChatAttachmentsForThread = internalQuery({
  */
 export const filterStorageIdsByCallerOrg = internalQuery({
   args: {
-    storageIds: v.array(v.id('_storage')),
+    storageIds: v.array(blobRefValidator),
     userId: v.string(),
   },
   // Returns one entry per authorized storage id with its organizationId so
@@ -100,7 +101,7 @@ export const filterStorageIdsByCallerOrg = internalQuery({
   // still reports `processing` for an orphaned (watchdog-failed) document.
   returns: v.array(
     v.object({
-      storageId: v.id('_storage'),
+      storageId: blobRefValidator,
       organizationId: v.string(),
       ragStatus: v.optional(
         v.union(
@@ -167,10 +168,10 @@ export const filterStorageIdsByCallerOrg = internalQuery({
  * defense-in-depth and a miss only loses the wrap, never poisons trust.
  */
 export const lookupVideoLinkSources = internalQuery({
-  args: { storageIds: v.array(v.id('_storage')) },
+  args: { storageIds: v.array(blobRefValidator) },
   returns: v.array(
     v.object({
-      storageId: v.id('_storage'),
+      storageId: blobRefValidator,
       sourceUrl: v.optional(v.string()),
     }),
   ),
@@ -185,9 +186,13 @@ export const lookupVideoLinkSources = internalQuery({
         .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
         .first();
       if (!meta || meta.source !== 'video_link') continue;
+      // videoLinkJobs.storageId is a Convex `_storage` id; a video-link row is
+      // always Convex-backed, so narrowing here is lossless.
+      const convexId = convexStorageId(storageId);
+      if (convexId === null) continue;
       const job = await ctx.db
         .query('videoLinkJobs')
-        .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
+        .withIndex('by_storageId', (q) => q.eq('storageId', convexId))
         .first();
       const entry: {
         storageId: (typeof args.storageIds)[number];
@@ -230,7 +235,7 @@ export const listStuckRagCandidates = internalQuery({
   },
   returns: v.array(
     v.object({
-      storageId: v.id('_storage'),
+      storageId: blobRefValidator,
       organizationId: v.string(),
       ragStatus: v.union(v.literal('queued'), v.literal('running')),
     }),

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -323,7 +323,7 @@ export const findCachedTranscript = internalQuery({
   args: {
     organizationId: v.string(),
     contentHash: v.string(),
-    excludeStorageId: v.id('_storage'),
+    excludeStorageId: blobRefValidator,
   },
   async handler(ctx, args) {
     for await (const row of ctx.db

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -13,12 +13,17 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { maybeDispatchRagIndexing } from './rag_dispatch';
 
 export const saveFileMetadata = mutation({
   args: {
     organizationId: v.string(),
-    storageId: v.id('_storage'),
+    // Blob reference: a Convex `_storage` id (default) OR an `s3:<key>` ref when
+    // the org has a bring-your-own bucket. The chat composer binds whichever the
+    // upload handoff returned; the RAG-index + transcription reads are
+    // backend-aware.
+    storageId: blobRefValidator,
     fileName: v.string(),
     contentType: v.string(),
     size: v.number(),
@@ -277,7 +282,10 @@ export const saveFileMetadata = mutation({
  */
 export const skipTranscription = mutation({
   args: {
-    storageId: v.id('_storage'),
+    // Blob reference (`_storage` id or `s3:` ref) — a chat audio attachment may
+    // live in the org's own bucket. The transcription mutations key the
+    // fileMetadata row off the string form either way.
+    storageId: blobRefValidator,
     organizationId: v.string(),
   },
   async handler(ctx, args) {
@@ -337,7 +345,10 @@ export const skipTranscription = mutation({
  */
 export const retryTranscription = mutation({
   args: {
-    storageId: v.id('_storage'),
+    // Blob reference (`_storage` id or `s3:` ref) — a chat audio attachment may
+    // live in the org's own bucket. The transcription mutations key the
+    // fileMetadata row off the string form either way.
+    storageId: blobRefValidator,
     organizationId: v.string(),
   },
   async handler(ctx, args) {

--- a/services/platform/convex/file_metadata/queries.ts
+++ b/services/platform/convex/file_metadata/queries.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { query } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 
 export const getUserStorageUsage = query({
   args: {
@@ -67,11 +68,11 @@ export const getByDocumentId = query({
 export const getByStorageIds = query({
   args: {
     organizationId: v.string(),
-    storageIds: v.array(v.id('_storage')),
+    storageIds: v.array(blobRefValidator),
   },
   returns: v.array(
     v.object({
-      storageId: v.id('_storage'),
+      storageId: blobRefValidator,
       documentId: v.optional(v.id('documents')),
       fileName: v.string(),
       contentType: v.string(),

--- a/services/platform/convex/file_metadata/rag_dispatch.ts
+++ b/services/platform/convex/file_metadata/rag_dispatch.ts
@@ -1,7 +1,8 @@
 import type { GenericMutationCtx } from 'convex/server';
 
 import { internal } from '../_generated/api';
-import type { DataModel, Doc, Id } from '../_generated/dataModel';
+import type { DataModel, Doc } from '../_generated/dataModel';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
@@ -39,7 +40,7 @@ export const MAX_CONCURRENT_RAG_INDEXING_GLOBAL = 8;
 async function countRagInFlight(
   ctx: MutationCtx,
   organizationId: string,
-  excludeStorageId?: Id<'_storage'>,
+  excludeStorageId?: BlobRef,
 ): Promise<number> {
   let inFlight = 0;
   for await (const row of ctx.db
@@ -72,7 +73,7 @@ async function countRagInFlight(
  */
 async function countGlobalRagInFlight(
   ctx: MutationCtx,
-  excludeStorageId?: Id<'_storage'>,
+  excludeStorageId?: BlobRef,
 ): Promise<number> {
   let inFlight = 0;
   for await (const row of ctx.db
@@ -139,7 +140,7 @@ async function dispatchRow(
  */
 export async function maybeDispatchRagIndexing(
   ctx: MutationCtx,
-  storageId: Id<'_storage'>,
+  storageId: BlobRef,
 ): Promise<void> {
   const row = await ctx.db
     .query('fileMetadata')

--- a/services/platform/convex/file_metadata/rag_watchdog.ts
+++ b/services/platform/convex/file_metadata/rag_watchdog.ts
@@ -1,10 +1,10 @@
 import { v } from 'convex/values';
 
 import { internal } from '../_generated/api';
-import type { Id } from '../_generated/dataModel';
 import { internalAction } from '../_generated/server';
 import { isE2ECronSuppressed } from '../lib/e2e_cron_guard';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import type { BlobRef } from '../lib/storage/blob_ref';
 
 /**
  * A row is only a recovery candidate once its age exceeds the Convex 30-min
@@ -72,7 +72,7 @@ export const recoverStuckRagIndexing = internalAction({
     if (candidates.length === 0) return null;
 
     // One knowledge-corpus status call per distinct org.
-    const byOrg = new Map<string, Array<{ storageId: Id<'_storage'> }>>();
+    const byOrg = new Map<string, Array<{ storageId: BlobRef }>>();
     for (const c of candidates) {
       const bucket = byOrg.get(c.organizationId);
       if (bucket) bucket.push({ storageId: c.storageId });

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -2,10 +2,14 @@ import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
 import { lifecycleStatusValidator } from '../governance/soft_delete_validators';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 
 export const fileMetadataTable = defineTable({
   organizationId: v.string(),
-  storageId: v.id('_storage'),
+  // Blob reference: a Convex `_storage` id (default) OR an `s3:<key>` ref in the
+  // org's own bucket. Widened from `v.id('_storage')` — every existing id still
+  // validates, and the `by_storageId` index keys off the string form either way.
+  storageId: blobRefValidator,
   documentId: v.optional(v.id('documents')),
   // Open provenance string (no hard enum, so a new channel needs no schema
   // change — mirrors documents.sourceProvider). Reserved values:

--- a/services/platform/convex/file_metadata/transcribe_audio.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.ts
@@ -494,13 +494,19 @@ export const transcribeAudio = internalAction({
         // statusChangedAt advances past the watchdog window. Generic
         // by-storageId lookup keeps transcribe_audio decoupled from
         // video_links-specific shape — see the R12 reactive-join review.
-        await ctx.runMutation(
-          internal.video_links.internal_mutations.heartbeatJobByStorageId,
-          {
-            storageId: args.storageId,
-            progress: progressLabel,
-          },
-        );
+        // Video-link audio is always a Convex `_storage` blob (yt-dlp writes it
+        // via `storage.store`); an S3-backed ref has no video-link job to
+        // heartbeat, so narrow to the Convex id (null → skip the no-op call).
+        const heartbeatStorageId = convexStorageId(args.storageId);
+        if (heartbeatStorageId) {
+          await ctx.runMutation(
+            internal.video_links.internal_mutations.heartbeatJobByStorageId,
+            {
+              storageId: heartbeatStorageId,
+              progress: progressLabel,
+            },
+          );
+        }
       }
 
       const fullTranscript = chunkParagraphs.join('\n\n');

--- a/services/platform/convex/file_metadata/transcribe_audio.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.ts
@@ -9,6 +9,8 @@ import { internalAction } from '../_generated/server';
 import { estimateTranscriptionCostCents } from '../governance/cost_estimation';
 import { classifyError } from '../lib/error_classification';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { readBlobBytes } from '../lib/storage/blob_access';
+import { blobRefValidator, convexStorageId } from '../lib/storage/blob_ref';
 import { resolveTranscriptionModel } from '../providers/resolve_model';
 import { uploadFile } from '../workflow_engine/action_defs/rag/helpers/upload_file_direct';
 import {
@@ -225,7 +227,11 @@ async function indexTranscriptToRag(
  */
 export const transcribeAudio = internalAction({
   args: {
-    storageId: v.id('_storage'),
+    // Audio blob reference: a Convex `_storage` id (deployment default) OR an
+    // `s3:<key>` ref when the org has a bring-your-own bucket. The source read
+    // (below) routes off the backend via `readBlobBytes`; the Convex path is
+    // byte-for-byte unchanged.
+    storageId: blobRefValidator,
     fileName: v.string(),
     contentType: v.string(),
     organizationId: v.string(),
@@ -314,10 +320,16 @@ export const transcribeAudio = internalAction({
       // Dedup: Convex stores a SHA-256 of every upload on `_storage`. If the
       // same content was already transcribed in this org, short-circuit and
       // copy the prior transcript rather than paying ffmpeg + OpenAI again.
-      const contentHash = await ctx.runQuery(
-        internal.file_metadata.internal_queries.getStorageSha256,
-        { storageId: args.storageId },
-      );
+      // An `s3:` ref has no `_storage` system row, so the checksum is
+      // unavailable — dedup gracefully degrades to off for BYO-bucket orgs
+      // (correctness preserved; at worst one duplicate Whisper run).
+      const audioConvexId = convexStorageId(args.storageId);
+      const contentHash = audioConvexId
+        ? await ctx.runQuery(
+            internal.file_metadata.internal_queries.getStorageSha256,
+            { storageId: audioConvexId },
+          )
+        : null;
 
       if (contentHash) {
         // Stamp our own row so future uploads can dedup against it too.
@@ -385,9 +397,28 @@ export const transcribeAudio = internalAction({
         organizationId: args.organizationId,
       });
 
-      const origBlob = await ctx.storage.get(args.storageId);
-      if (!origBlob) {
-        throw new Error(`Audio blob not found in storage: ${args.storageId}`);
+      // Read the source audio from whichever backend owns it. Convex `_storage`
+      // blobs stream straight from `ctx.storage` (unchanged); an `s3:` ref is
+      // fetched from the org's own bucket via the backend-aware seam (needs the
+      // slug to resolve the store).
+      let origBlob: Blob;
+      if (audioConvexId) {
+        const b = await ctx.storage.get(audioConvexId);
+        if (!b) {
+          throw new Error(`Audio blob not found in storage: ${args.storageId}`);
+        }
+        origBlob = b;
+      } else {
+        if (orgSlug === null) {
+          throw new Error(
+            `[transcribeAudio] org ${args.organizationId} unresolvable; cannot read S3 audio blob ${args.storageId}`,
+          );
+        }
+        const bytes = await readBlobBytes(ctx, orgSlug, args.storageId);
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
+        origBlob = new Blob([bytes as BlobPart], {
+          type: args.contentType || 'application/octet-stream',
+        });
       }
 
       // Phase 1 — compress

--- a/services/platform/convex/files/blob_actions.ts
+++ b/services/platform/convex/files/blob_actions.ts
@@ -1,0 +1,132 @@
+'use node';
+
+/**
+ * Backend-aware blob ACTIONS for the browser upload handoff + the S3 delete
+ * lane. These live in a `'use node'` module because presigning / signing S3
+ * requests needs the node runtime — a V8 query/mutation cannot. Convex-backed
+ * orgs work here too (the action just mints a `generateUploadUrl`), so the
+ * client calls ONE endpoint regardless of the org's storage backend.
+ *
+ * See `convex/lib/storage/blob_access.ts` for the backend routing and the
+ * stored-reference encoding (`_storage` id | `s3:<key>`).
+ */
+
+import { v } from 'convex/values';
+
+import { action, internalAction } from '../_generated/server';
+import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
+import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { toPublicUrl } from '../lib/helpers/public_storage_url';
+import {
+  deleteBlob,
+  generateBlobUpload as generateBlobUploadHandoff,
+  getBlobUrl,
+} from '../lib/storage/blob_access';
+
+export interface BlobUploadHandoff {
+  /** Where the browser sends the bytes. */
+  url: string;
+  /** `POST` → Convex `_storage` (bind the returned id); `PUT` → the org's S3
+   *  bucket (bind `s3Ref`). */
+  method: 'POST' | 'PUT';
+  /** Present iff `method === 'PUT'`: the reference the client binds after the
+   *  upload succeeds (the object key is known up front for S3). */
+  s3Ref?: string;
+}
+
+/**
+ * Mint an upload handoff for the caller's org. Routes to the org's own S3 bucket
+ * when configured, else Convex `_storage`. The caller MUST be a member of
+ * `organizationId` — the blob is namespaced under that org and, for an S3-backed
+ * org, is signed against that org's bucket, so cross-org targeting is refused
+ * here (not just isolated by key).
+ */
+export const generateBlobUpload = action({
+  args: {
+    organizationId: v.string(),
+    contentType: v.optional(v.string()),
+  },
+  returns: v.object({
+    url: v.string(),
+    method: v.union(v.literal('POST'), v.literal('PUT')),
+    s3Ref: v.optional(v.string()),
+  }),
+  handler: async (ctx, args): Promise<BlobUploadHandoff> => {
+    const auth = await requireOrgMembershipById(ctx, args.organizationId);
+    const handoff = await generateBlobUploadHandoff(ctx, auth.orgSlug, {
+      contentType: args.contentType,
+    });
+    // Convex `generateUploadUrl` returns an INTERNAL origin unreachable from the
+    // browser; rewrite it through the public proxy (parity with
+    // `files.mutations.generateUploadUrl`). The S3 presigned PUT already
+    // addresses the org's public endpoint, so leave it untouched.
+    const url =
+      handoff.method === 'POST' ? toPublicUrl(handoff.url) : handoff.url;
+    return { url, method: handoff.method, s3Ref: handoff.s3Ref };
+  },
+});
+
+/**
+ * Presign a short-lived GET URL for an `s3:` blob so the V8 `/storage` httpAction
+ * (which cannot sign S3 requests) can 302-redirect the browser to it. Resolves
+ * the org's bucket from `organizationId`; returns `null` when the org is
+ * unresolvable (surfaced as a 404 by the route). Convex refs never reach here —
+ * the route streams those directly.
+ */
+export const presignBlobGet = internalAction({
+  args: {
+    organizationId: v.string(),
+    ref: v.string(),
+    filename: v.optional(v.string()),
+  },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args): Promise<string | null> => {
+    const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+    if (orgSlug === null) {
+      console.warn(
+        `[presignBlobGet] org ${args.organizationId} unresolvable; cannot presign ${args.ref}`,
+      );
+      return null;
+    }
+    return await getBlobUrl(ctx, orgSlug, args.ref, {
+      filename: args.filename ?? undefined,
+    });
+  },
+});
+
+/**
+ * Physically delete a batch of blob references from whichever backend owns them.
+ * Internal — scheduled from `eraseDocumentBlobs` for the `s3:` refs it cannot
+ * delete inline (a mutation can't sign an S3 request). Convex refs are deleted
+ * inline by the mutation itself; this action is the S3 lane. Best-effort +
+ * idempotent: a missing object / unresolvable org is logged, never thrown, so
+ * one bad ref can't wedge a cleanup batch.
+ */
+export const deleteOrgBlobs = internalAction({
+  args: {
+    organizationId: v.string(),
+    refs: v.array(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    if (args.refs.length === 0) return null;
+    const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+    if (orgSlug === null) {
+      console.warn(
+        `[deleteOrgBlobs] org ${args.organizationId} unresolvable; skipping delete of ${args.refs.length} blob ref(s)`,
+      );
+      return null;
+    }
+    for (const ref of args.refs) {
+      try {
+        await deleteBlob(ctx, orgSlug, ref);
+      } catch (err) {
+        console.warn('[deleteOrgBlobs] blob delete failed', {
+          ref,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/files/mutations.ts
+++ b/services/platform/convex/files/mutations.ts
@@ -1,8 +1,15 @@
 import { v } from 'convex/values';
 
+import { internal } from '../_generated/api';
 import { mutation } from '../_generated/server';
 import { toPublicUrl } from '../lib/helpers/public_storage_url';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import {
+  blobRefValidator,
+  convexStorageId,
+  isS3Ref,
+} from '../lib/storage/blob_ref';
 
 export const generateUploadUrl = mutation({
   args: {},
@@ -26,22 +33,29 @@ const ORPHAN_CLEANUP_WINDOW_MS = 30 * 60 * 1000;
 /**
  * Best-effort cleanup for a blob whose owning document creation was rejected.
  *
- * The desk uploader commits a `_storage` blob (via `generateUploadUrl` + a
- * direct POST) BEFORE calling `createDocumentFromUpload`. When that mutation
- * rejects (quota, oversize, unsupported type, …) the blob is left orphaned —
- * no `fileMetadata` row, no document — and silently consumes storage. It can't
- * be deleted inside `createDocumentFromUpload` itself: a Convex mutation that
- * throws rolls back its `ctx.storage.delete` along with everything else. So the
- * client calls this compensating mutation from its failure path.
+ * The desk uploader commits a blob (via the upload handoff + a direct POST/PUT)
+ * BEFORE calling `createDocumentFromUpload`. When that mutation rejects (quota,
+ * oversize, unsupported type, …) the blob is left orphaned — no `fileMetadata`
+ * row, no document — and silently consumes storage. It can't be deleted inside
+ * `createDocumentFromUpload` itself: a Convex mutation that throws rolls back
+ * its `ctx.storage.delete` along with everything else. So the client calls this
+ * compensating mutation from its failure path.
  *
- * Safety: deletes ONLY a blob that (a) has no `fileMetadata` row — so a real,
- * linked file can never be removed — and (b) was created within the cleanup
- * window. A blob owned by another feature (automation icon, skill asset, …)
- * has no `fileMetadata` row either, hence the recency bound; realistically the
- * caller only ever passes a storageId it just minted here.
+ * Safety: deletes ONLY a blob that has no `fileMetadata` row — so a real, linked
+ * file can never be removed. Convex blobs additionally require a recency bound
+ * (a `_storage` system row's `_creationTime`) so this can't be aimed at another
+ * feature's freshly-minted blob. For an `s3:` ref there is no system row; the
+ * key was minted for this org's own bucket by the upload handoff and only the
+ * minting client calls here, so the "no fileMetadata row" check plus an
+ * org-membership gate is the safety boundary. The S3 delete needs the node
+ * runtime, so it is scheduled (a mutation can't sign it).
  */
 export const deleteRejectedUploadBlob = mutation({
-  args: { storageId: v.id('_storage') },
+  args: {
+    storageId: blobRefValidator,
+    /** Required to reclaim an `s3:` ref — addresses the org's bucket. */
+    organizationId: v.optional(v.string()),
+  },
   returns: v.object({ deleted: v.boolean() }),
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
@@ -49,21 +63,39 @@ export const deleteRejectedUploadBlob = mutation({
       throw new Error('Unauthenticated');
     }
 
-    // Never touch a blob that became a real file.
+    // Never touch a blob that became a real file (either backend).
     const linked = await ctx.db
       .query('fileMetadata')
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
     if (linked) return { deleted: false };
 
-    const meta = await ctx.db.system.get(args.storageId);
+    if (isS3Ref(args.storageId)) {
+      // Need the org to address the bucket; verify the caller belongs to it,
+      // then schedule the org-scoped node delete (idempotent, best-effort).
+      if (!args.organizationId) return { deleted: false };
+      await getOrganizationMember(ctx, args.organizationId, authUser);
+      await ctx.scheduler.runAfter(
+        0,
+        internal.files.blob_actions.deleteOrgBlobs,
+        {
+          organizationId: args.organizationId,
+          refs: [String(args.storageId)],
+        },
+      );
+      return { deleted: true };
+    }
+
+    const convexId = convexStorageId(args.storageId);
+    if (convexId === null) return { deleted: false };
+    const meta = await ctx.db.system.get(convexId);
     if (!meta) return { deleted: false };
     if (Date.now() - meta._creationTime > ORPHAN_CLEANUP_WINDOW_MS) {
       return { deleted: false };
     }
 
     try {
-      await ctx.storage.delete(args.storageId);
+      await ctx.storage.delete(convexId);
       return { deleted: true };
     } catch (error) {
       // Already gone / racing another deleter — nothing to reclaim.

--- a/services/platform/convex/files/queries.ts
+++ b/services/platform/convex/files/queries.ts
@@ -1,13 +1,49 @@
 import { v } from 'convex/values';
 
 import { prepareFileUrlIds } from '../../lib/shared/file-url-batch';
+import type { QueryCtx } from '../_generated/server';
 import { query } from '../_generated/server';
-import { toPublicUrl } from '../lib/helpers/public_storage_url';
+import {
+  buildBlobServeUrl,
+  toPublicUrl,
+} from '../lib/helpers/public_storage_url';
 import { getAuthUserIdentity } from '../lib/rls';
+import {
+  blobRefValidator,
+  convexStorageId,
+  isS3Ref,
+  type BlobRef,
+} from '../lib/storage/blob_ref';
+
+/**
+ * Resolve a download URL for a blob reference. A Convex `_storage` id gets a
+ * direct (proxy-rewritten) storage URL; an `s3:` ref gets the node `/storage`
+ * route URL that presigns + 302-redirects (a query can't presign). For an S3
+ * ref we resolve the owning org from the blob's `fileMetadata` row so the route
+ * can address the right bucket; a ref with no fileMetadata row is unservable
+ * here → null.
+ */
+async function resolveBlobUrl(
+  ctx: QueryCtx,
+  ref: BlobRef,
+): Promise<string | null> {
+  if (isS3Ref(ref)) {
+    const meta = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', ref))
+      .first();
+    if (!meta) return null;
+    return buildBlobServeUrl(String(ref), meta.organizationId, meta.fileName);
+  }
+  const convexId = convexStorageId(ref);
+  if (convexId === null) return null;
+  const url = await ctx.storage.getUrl(convexId);
+  return url ? toPublicUrl(url) : null;
+}
 
 export const getFileUrl = query({
   args: {
-    fileId: v.id('_storage'),
+    fileId: blobRefValidator,
   },
   returns: v.union(v.string(), v.null()),
   handler: async (ctx, args) => {
@@ -15,8 +51,7 @@ export const getFileUrl = query({
     if (!authUser) return null;
 
     try {
-      const url = await ctx.storage.getUrl(args.fileId);
-      return url ? toPublicUrl(url) : null;
+      return await resolveBlobUrl(ctx, args.fileId);
     } catch {
       return null;
     }
@@ -25,11 +60,11 @@ export const getFileUrl = query({
 
 export const getFileUrls = query({
   args: {
-    fileIds: v.array(v.id('_storage')),
+    fileIds: v.array(blobRefValidator),
   },
   returns: v.array(
     v.object({
-      fileId: v.id('_storage'),
+      fileId: blobRefValidator,
       url: v.union(v.string(), v.null()),
     }),
   ),
@@ -45,8 +80,7 @@ export const getFileUrls = query({
     return Promise.all(
       uniqueIds.map(async (fileId) => {
         try {
-          const url = await ctx.storage.getUrl(fileId);
-          return { fileId, url: url ? toPublicUrl(url) : null };
+          return { fileId, url: await resolveBlobUrl(ctx, fileId) };
         } catch {
           return { fileId, url: null };
         }

--- a/services/platform/convex/governance/erase_document_blobs.ts
+++ b/services/platform/convex/governance/erase_document_blobs.ts
@@ -23,9 +23,17 @@
  * which mutations can't perform). The retention path is fire-and-forget
  * via a scheduled action; the GDPR processor walks the returned `fileIds`
  * after the mutation returns.
+ *
+ * Backend split: a blob is EITHER a Convex `_storage` id (deleted inline here)
+ * OR an `s3:<key>` ref in the org's own bucket. A mutation cannot sign an S3
+ * request (needs the node runtime), so `s3:` refs are batched and handed to the
+ * scheduled `internal.files.blob_actions.deleteOrgBlobs` action instead. Convex
+ * blobs keep today's inline delete — zero regression for deployment-default orgs.
  */
+import { internal } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
+import { convexStorageId, type BlobRef } from '../lib/storage/blob_ref';
 
 export interface EraseDocumentBlobsResult {
   /** All `_storage` ids that were physically deleted (primary + history). */
@@ -39,27 +47,40 @@ export async function eraseDocumentBlobs(
   doc: Doc<'documents'>,
 ): Promise<EraseDocumentBlobsResult> {
   const storageIdsDeleted: string[] = [];
+  const s3RefsToDelete: string[] = [];
   let fileMetadataRowsDeleted = 0;
 
-  if (doc.fileId) {
-    const fileId = doc.fileId;
-    // Mirror the try/catch already used by erasure.ts:658 and
-    // internal_mutations_retention.ts:301 — a missing blob (already
-    // deleted by a prior partial run) must NOT abort the whole
-    // transaction, leaving the documents row permanently behind.
-    // Round-2 review HIGH cluster.
-    try {
-      await ctx.storage.delete(fileId);
-    } catch (err) {
-      console.warn('[erase_document_blobs] storage.delete failed', {
-        fileId: String(fileId),
-        err: String(err),
-      });
+  // Primary blob first (kept ahead of history for stable accounting), then
+  // every history revision. Both fields now hold blob REFERENCES (`_storage` id
+  // or `s3:` ref); `convexStorageId` narrows to the id for the inline delete.
+  const refs: BlobRef[] = [];
+  if (doc.fileId) refs.push(doc.fileId);
+  if (doc.historyFiles) refs.push(...doc.historyFiles);
+
+  for (const ref of refs) {
+    const convexId = convexStorageId(ref);
+    if (convexId !== null) {
+      // Mirror the try/catch already used by erasure.ts:658 and
+      // internal_mutations_retention.ts:301 — a missing blob (already
+      // deleted by a prior partial run) must NOT abort the whole
+      // transaction, leaving the documents row permanently behind.
+      // Round-2 review HIGH cluster.
+      try {
+        await ctx.storage.delete(convexId);
+      } catch (err) {
+        console.warn('[erase_document_blobs] storage.delete failed', {
+          fileId: String(ref),
+          err: String(err),
+        });
+      }
+    } else {
+      // S3-backed: defer to the scheduled node action (can't sign here).
+      s3RefsToDelete.push(String(ref));
     }
-    storageIdsDeleted.push(String(fileId));
+    storageIdsDeleted.push(String(ref));
     const meta = await ctx.db
       .query('fileMetadata')
-      .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+      .withIndex('by_storageId', (q) => q.eq('storageId', ref))
       .first();
     if (meta) {
       await ctx.db.delete(meta._id);
@@ -67,26 +88,15 @@ export async function eraseDocumentBlobs(
     }
   }
 
-  if (doc.historyFiles) {
-    for (const historyFileId of doc.historyFiles) {
-      try {
-        await ctx.storage.delete(historyFileId);
-      } catch (err) {
-        console.warn('[erase_document_blobs] history storage.delete failed', {
-          fileId: String(historyFileId),
-          err: String(err),
-        });
-      }
-      storageIdsDeleted.push(String(historyFileId));
-      const histMeta = await ctx.db
-        .query('fileMetadata')
-        .withIndex('by_storageId', (q) => q.eq('storageId', historyFileId))
-        .first();
-      if (histMeta) {
-        await ctx.db.delete(histMeta._id);
-        fileMetadataRowsDeleted++;
-      }
-    }
+  // Fire-and-forget the physical S3 deletes (idempotent, best-effort). Deferring
+  // to a scheduled action keeps this mutation transactional and never blocks the
+  // row delete on a slow/unreachable bucket.
+  if (s3RefsToDelete.length > 0) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.files.blob_actions.deleteOrgBlobs,
+      { organizationId: doc.organizationId, refs: s3RefsToDelete },
+    );
   }
 
   return { storageIdsDeleted, fileMetadataRowsDeleted };

--- a/services/platform/convex/http.ts
+++ b/services/platform/convex/http.ts
@@ -61,6 +61,7 @@ import {
   RateLimitExceededError,
 } from './lib/rate_limiter/helpers';
 import { restOptionsHandler } from './lib/rest/helpers';
+import { isS3Ref } from './lib/storage/blob_ref';
 import { toId } from './lib/type_cast_helpers';
 import { getClientIp, loadTrustedProxies } from './lib/utils/client_ip';
 import { sanitizeError } from './lib/utils/sanitize_secrets';
@@ -138,10 +139,13 @@ http.route({
   method: 'GET',
   handler: httpAction(async (ctx, req) => {
     const url = new URL(req.url);
-    const storageId = url.searchParams.get('id');
+    // `ref` is the universal blob reference (a `_storage` id or an `s3:` ref);
+    // `id` is the legacy param (always a `_storage` id) still used by
+    // `buildDownloadUrl`. Either identifies the blob.
+    const ref = url.searchParams.get('ref') ?? url.searchParams.get('id');
     const filename = url.searchParams.get('filename');
 
-    if (!storageId) {
+    if (!ref) {
       return new Response('Missing storage ID', { status: 400 });
     }
 
@@ -161,8 +165,29 @@ http.route({
       throw error;
     }
 
+    // S3-backed blob: a V8 httpAction can't presign, so delegate to the node
+    // action and 302-redirect the browser to the short-lived presigned GET. The
+    // `org` param identifies which bucket (the ref alone doesn't).
+    if (isS3Ref(ref)) {
+      const org = url.searchParams.get('org');
+      if (!org) {
+        return new Response('Missing org for S3 blob', { status: 400 });
+      }
+      const presigned: string | null = await ctx.runAction(
+        internal.files.blob_actions.presignBlobGet,
+        { organizationId: org, ref, filename: filename ?? undefined },
+      );
+      if (!presigned) {
+        return new Response('File not found', { status: 404 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: { Location: presigned },
+      });
+    }
+
     try {
-      const blob = await ctx.storage.get(toId<'_storage'>(storageId));
+      const blob = await ctx.storage.get(toId<'_storage'>(ref));
       if (!blob) {
         return new Response('File not found', { status: 404 });
       }

--- a/services/platform/convex/knowledge_entries/internal_mutations.ts
+++ b/services/platform/convex/knowledge_entries/internal_mutations.ts
@@ -8,6 +8,7 @@ import type { KnowledgeWriteMetadata } from '../approvals/types';
 import { createDocument } from '../documents/create_document';
 import { getOrCreateFolderPath } from '../folders/get_or_create_path';
 import { checkOrganizationRateLimit } from '../lib/rate_limiter/helpers';
+import { blobRefValidator, type BlobRef } from '../lib/storage/blob_ref';
 import {
   KNOWLEDGE_ENTRIES_FOLDER,
   KNOWLEDGE_SOURCE_PROVIDER,
@@ -174,7 +175,7 @@ export const updateKnowledgeWriteApprovalWithResult = internalMutation({
 export const attachEntryDocument = internalMutation({
   args: {
     entryId: v.id('knowledgeEntries'),
-    fileId: v.id('_storage'),
+    fileId: blobRefValidator,
     contentHash: v.string(),
   },
   returns: v.union(v.id('documents'), v.null()),
@@ -258,7 +259,7 @@ export const attachEntryDocument = internalMutation({
 
 async function linkFileMetadataToDocument(
   ctx: MutationCtx,
-  storageId: Id<'_storage'>,
+  storageId: BlobRef,
   documentId: Id<'documents'>,
 ): Promise<void> {
   const metadata = await ctx.db

--- a/services/platform/convex/lib/config_store/resolvers.ts
+++ b/services/platform/convex/lib/config_store/resolvers.ts
@@ -19,6 +19,7 @@ import { resolveSsoDir } from '../../enterprise_sso/file_utils';
 import { resolveGovernanceDir } from '../../governance/file_utils';
 import { resolveIntegrationsDir } from '../../integrations/file_utils';
 import { resolveKnowledgeDir } from '../../knowledge/file_utils';
+import { resolveObjectStorageDir } from '../../object_storage/file_utils';
 import { resolvePromptsDir } from '../../prompts/file_utils';
 import { resolveProvidersDir } from '../../providers/file_utils';
 import { resolveSkillsDir } from '../../skills/file_utils';
@@ -41,6 +42,8 @@ export const DOMAIN_DIR_RESOLVERS: Record<string, DomainDirResolver> = {
   sso: resolveSsoDir,
   // Per-org knowledge-DB connection — `resolveKnowledgeDir` returns `<org>/knowledge/`.
   knowledge: resolveKnowledgeDir,
+  // Per-org object-storage (BYO S3) connection — `<org>/object-storage/`.
+  'object-storage': resolveObjectStorageDir,
   automations: resolveAutomationsDir,
   // LEGACY-CHAIN ONLY: `workflows` left the config-domain registry when
   // standalone workflows retired (a workflow lives inline in its automation).

--- a/services/platform/convex/lib/helpers/public_storage_url.ts
+++ b/services/platform/convex/lib/helpers/public_storage_url.ts
@@ -40,6 +40,22 @@ export function buildDownloadUrl(storageId: string, fileName: string): string {
 }
 
 /**
+ * Build the `/storage` route URL for an `s3:` blob reference. A Convex query
+ * cannot presign S3, so it hands the browser this URL instead; the node
+ * `/storage` httpAction resolves the org's bucket (from `org`, the Better Auth
+ * organization id) and 302-redirects to a short-lived presigned GET. `org` is
+ * REQUIRED for an S3 ref — the route needs it to address the right bucket.
+ */
+export function buildBlobServeUrl(
+  ref: string,
+  orgId: string,
+  fileName?: string,
+): string {
+  const base = `${getPublicHttpApiUrl()}/storage?ref=${encodeURIComponent(ref)}&org=${encodeURIComponent(orgId)}`;
+  return fileName ? `${base}&filename=${encodeURIComponent(fileName)}` : base;
+}
+
+/**
  * Rewrite an internal Convex URL to route through the public proxy.
  *
  * Internal URLs like `http://127.0.0.1:3210/api/storage/...` are unreachable

--- a/services/platform/convex/lib/storage/blob_access.ts
+++ b/services/platform/convex/lib/storage/blob_access.ts
@@ -26,7 +26,12 @@
  */
 
 import type { ActionCtx } from '../../_generated/server';
-import { encodeS3Ref, parseBlobRef, type BlobRef } from './blob_ref';
+import {
+  encodeS3Ref,
+  parseBlobRef,
+  s3KeyBelongsToOrg,
+  type BlobRef,
+} from './blob_ref';
 import {
   buildObjectKey,
   resolveOrgObjectStore,
@@ -77,7 +82,7 @@ export async function readBlobBytes(
     }
     return new Uint8Array(await blob.arrayBuffer());
   }
-  const store = await requireS3(orgSlug);
+  const store = await requireS3(orgSlug, parsed.key);
   return await s3GetObjectBytes(store, parsed.key);
 }
 
@@ -96,7 +101,7 @@ export async function deleteBlob(
     await ctx.storage.delete(parsed.storageId);
     return;
   }
-  const store = await requireS3(orgSlug);
+  const store = await requireS3(orgSlug, parsed.key);
   await s3DeleteObject(store, parsed.key);
 }
 
@@ -115,7 +120,7 @@ export async function getBlobUrl(
   if (parsed.backend === 'convex') {
     return await ctx.storage.getUrl(parsed.storageId);
   }
-  const store = await requireS3(orgSlug);
+  const store = await requireS3(orgSlug, parsed.key);
   return await s3PresignGetUrl(store, parsed.key, { filename: opts.filename });
 }
 
@@ -142,7 +147,20 @@ export async function generateBlobUpload(
   return { url, method: 'PUT', s3Ref: encodeS3Ref(key) };
 }
 
-async function requireS3(orgSlug: string): Promise<S3ObjectStore> {
+/**
+ * Resolve the org's S3 store for an operation on `key`, refusing a key outside
+ * the org's own namespace. Blob refs are client-bindable strings, so without
+ * this check a member of org A could bind org B's key and have A's read /
+ * serve / delete address B's object whenever the two orgs resolve to the same
+ * physical bucket (a supported config — `prefix` exists to share buckets).
+ * Fail-closed: a foreign or malformed key throws, it is never "not found".
+ */
+async function requireS3(orgSlug: string, key: string): Promise<S3ObjectStore> {
+  if (!s3KeyBelongsToOrg(key, orgSlug)) {
+    throw new Error(
+      `s3 blob key is outside org '${orgSlug}' namespace; refusing`,
+    );
+  }
   const store = await resolveOrgObjectStore(orgSlug);
   if (store.backend !== 's3') {
     throw new Error(

--- a/services/platform/convex/lib/storage/blob_access.ts
+++ b/services/platform/convex/lib/storage/blob_access.ts
@@ -54,6 +54,7 @@ export async function putBlob(
 ): Promise<BlobRef> {
   const store = await resolveOrgObjectStore(orgSlug);
   if (store.backend === 'convex') {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
     const blob = new Blob([bytes as BlobPart], { type: contentType });
     return await ctx.storage.store(blob);
   }

--- a/services/platform/convex/lib/storage/blob_access.ts
+++ b/services/platform/convex/lib/storage/blob_access.ts
@@ -1,0 +1,152 @@
+'use node';
+
+/**
+ * Backend-aware blob access — the single seam every org-owned blob operation
+ * routes through so a blob transparently lives in Convex `_storage` (deployment
+ * default) OR the org's own S3 bucket (bring-your-own object storage).
+ *
+ * # The blob reference
+ *
+ * Historically every blob is an `Id<'_storage'>`. To let a blob live in S3
+ * without a repo-wide id-type rewrite, a stored reference is now a STRING that
+ * is EITHER:
+ *   - a Convex storage id (unchanged — the default), or
+ *   - `s3:<objectKey>` — the bytes live in the org's bucket at `<objectKey>`.
+ * Schema fields widen from `v.id('_storage')` to `blobRefValidator`
+ * (`v.union(v.id('_storage'), v.string())`); existing id values keep validating.
+ * `parseBlobRef` / `encodeS3Ref` are the ONLY places that know the encoding.
+ *
+ * # Why an action context
+ *
+ * S3 verbs sign requests (crypto) and read per-org config (fs) — both need the
+ * `'use node'` runtime, so put/read/delete for an S3-backed org run in ACTIONS.
+ * Convex-backed blobs work in any ctx. Serving is the one asymmetry: a Convex
+ * query CAN mint a `_storage` URL but CANNOT presign S3, so S3 blobs are served
+ * through the node `/storage` HTTP route (see `blobServeThroughHttp`).
+ */
+
+import type { ActionCtx } from '../../_generated/server';
+import { encodeS3Ref, parseBlobRef, type BlobRef } from './blob_ref';
+import {
+  buildObjectKey,
+  resolveOrgObjectStore,
+  s3DeleteObject,
+  s3GetObjectBytes,
+  s3PresignGetUrl,
+  s3PresignPutUrl,
+  s3PutObject,
+  type S3ObjectStore,
+} from './object_store';
+
+export type { BlobRef } from './blob_ref';
+export { encodeS3Ref, parseBlobRef, isS3Ref } from './blob_ref';
+
+/**
+ * Store bytes for an org and return the stored reference. Routes to the org's
+ * S3 bucket when configured, else Convex `_storage`. Action ctx required (S3
+ * signing needs node).
+ */
+export async function putBlob(
+  ctx: ActionCtx,
+  orgSlug: string,
+  bytes: Uint8Array,
+  contentType: string,
+): Promise<BlobRef> {
+  const store = await resolveOrgObjectStore(orgSlug);
+  if (store.backend === 'convex') {
+    const blob = new Blob([bytes as BlobPart], { type: contentType });
+    return await ctx.storage.store(blob);
+  }
+  const key = buildObjectKey(store, orgSlug);
+  await s3PutObject(store, key, bytes, contentType);
+  return encodeS3Ref(key);
+}
+
+/** Read a blob's raw bytes, from whichever backend owns it. Action ctx. */
+export async function readBlobBytes(
+  ctx: ActionCtx,
+  orgSlug: string,
+  ref: BlobRef,
+): Promise<Uint8Array> {
+  const parsed = parseBlobRef(ref);
+  if (parsed.backend === 'convex') {
+    const blob = await ctx.storage.get(parsed.storageId);
+    if (blob === null) {
+      throw new Error(`blob not found in _storage: ${parsed.storageId}`);
+    }
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+  const store = await requireS3(orgSlug);
+  return await s3GetObjectBytes(store, parsed.key);
+}
+
+/**
+ * Delete a blob from whichever backend owns it. Idempotent. Action ctx (S3
+ * delete needs node; Convex `_storage.delete` is also available in mutations,
+ * but a mixed-backend caller must schedule this from an action).
+ */
+export async function deleteBlob(
+  ctx: ActionCtx,
+  orgSlug: string,
+  ref: BlobRef,
+): Promise<void> {
+  const parsed = parseBlobRef(ref);
+  if (parsed.backend === 'convex') {
+    await ctx.storage.delete(parsed.storageId);
+    return;
+  }
+  const store = await requireS3(orgSlug);
+  await s3DeleteObject(store, parsed.key);
+}
+
+/**
+ * A time-limited download URL for a blob. Convex blobs get a `_storage` URL; S3
+ * blobs get a presigned GET. Action ctx (S3 presign needs node) — the query
+ * serve path uses `blobServeThroughHttp` instead.
+ */
+export async function getBlobUrl(
+  ctx: ActionCtx,
+  orgSlug: string,
+  ref: BlobRef,
+  opts: { filename?: string } = {},
+): Promise<string | null> {
+  const parsed = parseBlobRef(ref);
+  if (parsed.backend === 'convex') {
+    return await ctx.storage.getUrl(parsed.storageId);
+  }
+  const store = await requireS3(orgSlug);
+  return await s3PresignGetUrl(store, parsed.key, { filename: opts.filename });
+}
+
+/**
+ * Upload handoff for the client. Convex: `generateUploadUrl` (the client POSTs
+ * and learns the id from the response). S3: a presigned PUT plus the ref the
+ * client will bind (the key is known up front). The caller returns `{ url,
+ * method, s3Ref }` to the browser; when `s3Ref` is present the client PUTs to
+ * `url` then binds `s3Ref`, else it POSTs and binds the returned storage id.
+ */
+export async function generateBlobUpload(
+  ctx: ActionCtx,
+  orgSlug: string,
+  opts: { contentType?: string } = {},
+): Promise<{ url: string; method: 'POST' | 'PUT'; s3Ref?: string }> {
+  const store = await resolveOrgObjectStore(orgSlug);
+  if (store.backend === 'convex') {
+    return { url: await ctx.storage.generateUploadUrl(), method: 'POST' };
+  }
+  const key = buildObjectKey(store, orgSlug);
+  const url = await s3PresignPutUrl(store, key, {
+    contentType: opts.contentType,
+  });
+  return { url, method: 'PUT', s3Ref: encodeS3Ref(key) };
+}
+
+async function requireS3(orgSlug: string): Promise<S3ObjectStore> {
+  const store = await resolveOrgObjectStore(orgSlug);
+  if (store.backend !== 's3') {
+    throw new Error(
+      `blob references org '${orgSlug}' S3 storage, but no S3 store is configured`,
+    );
+  }
+  return store;
+}

--- a/services/platform/convex/lib/storage/blob_ref.test.ts
+++ b/services/platform/convex/lib/storage/blob_ref.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  convexStorageId,
+  encodeS3Ref,
+  isS3Ref,
+  parseBlobRef,
+  s3KeyBelongsToOrg,
+} from './blob_ref';
+
+describe('blob_ref encoding', () => {
+  it('round-trips an s3 key through encode/parse', () => {
+    const parsed = parseBlobRef(encodeS3Ref('acme/123e4567'));
+    expect(parsed).toEqual({ backend: 's3', key: 'acme/123e4567' });
+  });
+
+  it('treats a non-prefixed string as a Convex storage id', () => {
+    const parsed = parseBlobRef('kg2abc123');
+    expect(parsed.backend).toBe('convex');
+    expect(isS3Ref('kg2abc123')).toBe(false);
+    expect(convexStorageId('kg2abc123')).toBe('kg2abc123');
+  });
+
+  it('convexStorageId is null for s3 refs', () => {
+    expect(convexStorageId('s3:acme/uuid')).toBeNull();
+  });
+});
+
+describe('s3KeyBelongsToOrg (tenant-isolation guard)', () => {
+  it('accepts the org own keys, with and without a prefix', () => {
+    // buildObjectKey mints `[prefix/]orgSlug/uuid` — second-to-last = org.
+    expect(s3KeyBelongsToOrg('acme/6f9619ff-8b86', 'acme')).toBe(true);
+    expect(s3KeyBelongsToOrg('tale/prod/acme/6f9619ff', 'acme')).toBe(true);
+  });
+
+  it('refuses another org key — even inside a shared bucket namespace', () => {
+    expect(s3KeyBelongsToOrg('globex/6f9619ff-8b86', 'acme')).toBe(false);
+    expect(s3KeyBelongsToOrg('tale/prod/globex/6f9619ff', 'acme')).toBe(false);
+  });
+
+  it('refuses a prefix crafted to embed the victim slug in the wrong segment', () => {
+    // Attacker org "globex" chose prefix "x/acme" → its keys are
+    // `x/acme/globex/uuid`; the segment before the uuid is still globex.
+    expect(s3KeyBelongsToOrg('x/acme/globex/6f9619ff', 'acme')).toBe(false);
+    // And the victim's own key never passes for the attacker.
+    expect(s3KeyBelongsToOrg('x/acme/6f9619ff', 'globex')).toBe(false);
+  });
+
+  it('refuses malformed keys: empty segments, bare uuid, empty string', () => {
+    expect(s3KeyBelongsToOrg('acme//6f9619ff', 'acme')).toBe(false);
+    expect(s3KeyBelongsToOrg('//acme/6f9619ff', 'acme')).toBe(false);
+    expect(s3KeyBelongsToOrg('6f9619ff', 'acme')).toBe(false);
+    expect(s3KeyBelongsToOrg('', 'acme')).toBe(false);
+    expect(s3KeyBelongsToOrg('acme/', 'acme')).toBe(false);
+  });
+});

--- a/services/platform/convex/lib/storage/blob_ref.ts
+++ b/services/platform/convex/lib/storage/blob_ref.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure blob-reference encoding — V8-safe (NO `node:*`, NO `fetch`), so Convex
+ * schema files, queries, and mutations can import the validator + parser. The
+ * actual S3 I/O lives in the `'use node'` sibling `blob_access.ts`.
+ *
+ * A stored blob reference is a STRING that is EITHER a Convex `_storage` id
+ * (unchanged — the deployment default) OR `s3:<objectKey>` (the bytes live in
+ * the org's own bucket). This is the ONLY module that knows the encoding.
+ */
+
+import { v } from 'convex/values';
+
+import type { Id } from '../../_generated/dataModel';
+
+/** A stored blob reference: a Convex `_storage` id, or an `s3:`-prefixed key. */
+export type BlobRef = Id<'_storage'> | string;
+
+const S3_PREFIX = 's3:';
+
+/**
+ * Schema validator for a blob-reference field. Widening a legacy
+ * `v.id('_storage')` field to this union is backward-compatible — every
+ * existing id value still validates, and new S3 refs land in the string arm.
+ */
+export const blobRefValidator = v.union(v.id('_storage'), v.string());
+
+/** Encode an S3 object key as a stored blob reference. */
+export function encodeS3Ref(key: string): string {
+  return `${S3_PREFIX}${key}`;
+}
+
+export type ParsedBlobRef =
+  | { backend: 'convex'; storageId: Id<'_storage'> }
+  | { backend: 's3'; key: string };
+
+/**
+ * Decode a stored reference. An `s3:`-prefixed string is an S3 key; anything
+ * else is a Convex storage id (Convex ids never contain a `:`).
+ */
+export function parseBlobRef(ref: BlobRef): ParsedBlobRef {
+  if (typeof ref === 'string' && ref.startsWith(S3_PREFIX)) {
+    return { backend: 's3', key: ref.slice(S3_PREFIX.length) };
+  }
+  return { backend: 'convex', storageId: ref as Id<'_storage'> };
+}
+
+/** True when a stored reference points at the org's S3 bucket (not `_storage`). */
+export function isS3Ref(ref: BlobRef): boolean {
+  return typeof ref === 'string' && ref.startsWith(S3_PREFIX);
+}
+
+/** The Convex storage id of a convex-backed ref, or null for an S3 ref. */
+export function convexStorageId(ref: BlobRef): Id<'_storage'> | null {
+  const parsed = parseBlobRef(ref);
+  return parsed.backend === 'convex' ? parsed.storageId : null;
+}

--- a/services/platform/convex/lib/storage/blob_ref.ts
+++ b/services/platform/convex/lib/storage/blob_ref.ts
@@ -8,12 +8,18 @@
  * the org's own bucket). This is the ONLY module that knows the encoding.
  */
 
-import { v } from 'convex/values';
+import { v, type GenericId } from 'convex/values';
 
-import type { Id } from '../../_generated/dataModel';
+// Use `GenericId` from `convex/values` — NOT `Id` from `_generated/dataModel`.
+// This module's `blobRefValidator` is imported BY the schema (documents /
+// fileMetadata), and `dataModel`'s `Id` is derived FROM the schema, so importing
+// `Id` here would close a schema↔dataModel type cycle that poisons every
+// query/mutation ctx type (TS2719). `GenericId<'_storage'>` is identical to
+// `Id<'_storage'>` but schema-independent.
+type StorageId = GenericId<'_storage'>;
 
 /** A stored blob reference: a Convex `_storage` id, or an `s3:`-prefixed key. */
-export type BlobRef = Id<'_storage'> | string;
+export type BlobRef = StorageId | string;
 
 const S3_PREFIX = 's3:';
 
@@ -30,7 +36,7 @@ export function encodeS3Ref(key: string): string {
 }
 
 export type ParsedBlobRef =
-  | { backend: 'convex'; storageId: Id<'_storage'> }
+  | { backend: 'convex'; storageId: StorageId }
   | { backend: 's3'; key: string };
 
 /**
@@ -41,7 +47,8 @@ export function parseBlobRef(ref: BlobRef): ParsedBlobRef {
   if (typeof ref === 'string' && ref.startsWith(S3_PREFIX)) {
     return { backend: 's3', key: ref.slice(S3_PREFIX.length) };
   }
-  return { backend: 'convex', storageId: ref as Id<'_storage'> };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a non-`s3:` ref is a Convex `_storage` id by construction
+  return { backend: 'convex', storageId: ref as StorageId };
 }
 
 /** True when a stored reference points at the org's S3 bucket (not `_storage`). */
@@ -50,7 +57,7 @@ export function isS3Ref(ref: BlobRef): boolean {
 }
 
 /** The Convex storage id of a convex-backed ref, or null for an S3 ref. */
-export function convexStorageId(ref: BlobRef): Id<'_storage'> | null {
+export function convexStorageId(ref: BlobRef): StorageId | null {
   const parsed = parseBlobRef(ref);
   return parsed.backend === 'convex' ? parsed.storageId : null;
 }

--- a/services/platform/convex/lib/storage/blob_ref.ts
+++ b/services/platform/convex/lib/storage/blob_ref.ts
@@ -61,3 +61,24 @@ export function convexStorageId(ref: BlobRef): StorageId | null {
   const parsed = parseBlobRef(ref);
   return parsed.backend === 'convex' ? parsed.storageId : null;
 }
+
+/**
+ * TENANT ISOLATION — does an S3 object key sit in `orgSlug`'s own namespace?
+ *
+ * `buildObjectKey` always mints `[<prefix>/]<orgSlug>/<uuid>`, so the
+ * second-to-last segment IS the owning org, regardless of the org-chosen
+ * `prefix` (and of later prefix changes — old keys still carry the slug).
+ * Blob refs are client-bindable strings (`blobRefValidator` accepts any
+ * string), so every S3 read / presign / delete MUST refuse a key outside the
+ * org's namespace — otherwise two orgs sharing one physical bucket (a
+ * supported config; `prefix` exists for exactly that) could address each
+ * other's objects by binding a foreign key. Empty segments are rejected
+ * outright (`a//b` never comes out of `buildObjectKey`).
+ */
+export function s3KeyBelongsToOrg(key: string, orgSlug: string): boolean {
+  const segments = key.split('/');
+  if (segments.length < 2 || segments.some((s) => s.length === 0)) {
+    return false;
+  }
+  return segments[segments.length - 2] === orgSlug;
+}

--- a/services/platform/convex/lib/storage/object_storage_documents.e2e.test.ts
+++ b/services/platform/convex/lib/storage/object_storage_documents.e2e.test.ts
@@ -1,0 +1,201 @@
+/**
+ * E2E — a Knowledge-Hub DOCUMENT blob flowing through the per-org object-storage
+ * seam against a REAL S3-compatible store (MinIO). Gated behind
+ * `OBJECT_STORAGE_E2E` so the ordinary unit suite (no MinIO) skips it.
+ *
+ *   docker run -d --name minio -p 9100:9000 \
+ *     -e MINIO_ROOT_USER=testkey -e MINIO_ROOT_PASSWORD=testsecret123 \
+ *     minio/minio server /data        # (create a bucket `org-blobs`)
+ *   OBJECT_STORAGE_E2E=1 bunx vitest --run object_storage_documents.e2e
+ *
+ * Proves the EXACT seam a document upload/serve/read/delete flows through when
+ * the org has a bring-your-own bucket configured:
+ *   - the config resolver routes the org to its S3 bucket (not Convex _storage),
+ *   - the browser upload handoff (`generateBlobUpload`) presigns a PUT and the
+ *     bytes land IN THE BUCKET at the returned ref,
+ *   - the RAG-read path (`readBlobBytes`) reads those bytes back,
+ *   - the serve path (`getBlobUrl` → presigned GET) downloads them,
+ *   - the delete path (`deleteBlob`) removes them,
+ *   - and the admin test-connection probe round-trips (PUT+GET+DELETE).
+ *
+ * The S3 arm of `blob_access` never touches the Convex `ActionCtx`, so the tests
+ * pass a Proxy ctx that THROWS on any access — asserting the S3 path is
+ * ctx-free (a Convex query/mutation/action-independent seam).
+ */
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ActionCtx } from '../../_generated/server';
+import {
+  deleteBlob,
+  generateBlobUpload,
+  getBlobUrl,
+  parseBlobRef,
+  putBlob,
+  readBlobBytes,
+} from './blob_access';
+import {
+  buildS3ObjectStore,
+  probeS3ObjectStore,
+  resolveOrgObjectStore,
+  s3GetObjectBytes,
+  type S3ObjectStore,
+} from './object_store';
+
+const RUN = !!process.env.OBJECT_STORAGE_E2E;
+const ORG = 'docs-e2e-org';
+const ENDPOINT = 'http://127.0.0.1:9100';
+const BUCKET = 'org-blobs';
+const SECRETS = { accessKeyId: 'testkey', secretAccessKey: 'testsecret123' };
+
+// A ctx the S3 path must never touch — any property access is a test failure.
+const noCtx = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error('the S3 blob path must not access ActionCtx');
+    },
+  },
+) as unknown as ActionCtx;
+
+describe.skipIf(!RUN)(
+  'per-org object storage — document blob seam (MinIO)',
+  () => {
+    let store: S3ObjectStore;
+
+    beforeAll(async () => {
+      // Point the resolver at a throwaway TALE_CONFIG_DIR holding one org's
+      // object-storage connection (plaintext secrets — no SOPS key configured).
+      const root = await mkdtemp(join(tmpdir(), 'obj-store-docs-e2e-'));
+      process.env.TALE_CONFIG_DIR = root;
+      const dir = join(root, ORG, 'object-storage');
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, 'connection.json'),
+        JSON.stringify(
+          {
+            region: 'us-east-1',
+            endpoint: ENDPOINT,
+            forcePathStyle: true,
+            bucket: BUCKET,
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        join(dir, 'connection.secrets.json'),
+        JSON.stringify(SECRETS, null, 2),
+      );
+
+      const resolved = await resolveOrgObjectStore(ORG);
+      expect(resolved.backend).toBe('s3');
+      if (resolved.backend !== 's3')
+        throw new Error('org did not resolve to S3');
+      store = resolved;
+    });
+
+    afterAll(() => {
+      delete process.env.TALE_CONFIG_DIR;
+    });
+
+    it('routes an org with a BYO bucket to S3 (not Convex _storage)', async () => {
+      const resolved = await resolveOrgObjectStore(ORG);
+      expect(resolved.backend).toBe('s3');
+      // A DIFFERENT org with no config falls back to the Convex default.
+      const other = await resolveOrgObjectStore('some-unconfigured-org');
+      expect(other.backend).toBe('convex');
+    });
+
+    it('upload handoff → PUT lands the bytes IN THE BUCKET at the bound ref', async () => {
+      const handoff = await generateBlobUpload(noCtx, ORG, {
+        contentType: 'text/plain',
+      });
+      expect(handoff.method).toBe('PUT');
+      const ref = handoff.s3Ref;
+      expect(ref).toBeTruthy();
+      if (!ref) throw new Error('handoff returned no s3Ref');
+
+      const body = new TextEncoder().encode('per-org document source bytes 📄');
+      const put = await fetch(handoff.url, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body,
+      });
+      expect(put.ok).toBe(true);
+
+      // The object exists in the org's MinIO bucket at the ref's key.
+      const parsed = parseBlobRef(ref);
+      expect(parsed.backend).toBe('s3');
+      if (parsed.backend !== 's3') throw new Error('ref not S3');
+      const inBucket = await s3GetObjectBytes(store, parsed.key);
+      expect(new TextDecoder().decode(inBucket)).toBe(
+        'per-org document source bytes 📄',
+      );
+
+      await deleteBlob(noCtx, ORG, ref);
+    });
+
+    it('read → serve → delete round-trip through the backend-aware seam', async () => {
+      // putBlob is the server-side ingest half (agent/generated docs); it must
+      // also land in S3.
+      const original = new TextEncoder().encode('hub doc: the quick brown fox');
+      const ref = await putBlob(noCtx, ORG, original, 'text/plain');
+      expect(typeof ref).toBe('string');
+      expect(String(ref).startsWith('s3:')).toBe(true);
+
+      // RAG-read path.
+      const read = await readBlobBytes(noCtx, ORG, ref);
+      expect(new TextDecoder().decode(read)).toBe(
+        'hub doc: the quick brown fox',
+      );
+
+      // Serve path: a presigned GET a bare fetch (no signer) can download.
+      const url = await getBlobUrl(noCtx, ORG, ref, { filename: 'report.txt' });
+      expect(url).toBeTruthy();
+      if (!url) throw new Error('getBlobUrl returned no url');
+      const served = await fetch(url);
+      expect(served.ok).toBe(true);
+      expect(await served.text()).toBe('hub doc: the quick brown fox');
+      expect(served.headers.get('content-disposition') ?? '').toContain(
+        'report.txt',
+      );
+
+      // Delete path removes it from the bucket.
+      await deleteBlob(noCtx, ORG, ref);
+      const parsed = parseBlobRef(ref);
+      if (parsed.backend !== 's3') throw new Error('ref not S3');
+      await expect(s3GetObjectBytes(store, parsed.key)).rejects.toThrow();
+    });
+
+    it('admin test-connection probe round-trips (PUT+GET+DELETE) and rejects bad creds', async () => {
+      // Good creds: a real probe object round-trip against the bucket.
+      const good = buildS3ObjectStore(
+        {
+          region: 'us-east-1',
+          endpoint: ENDPOINT,
+          forcePathStyle: true,
+          bucket: BUCKET,
+        },
+        SECRETS,
+      );
+      await expect(probeS3ObjectStore(good)).resolves.toBeUndefined();
+
+      // Wrong secret: the probe must fail (proves the probe truly exercises S3).
+      const bad = buildS3ObjectStore(
+        {
+          region: 'us-east-1',
+          endpoint: ENDPOINT,
+          forcePathStyle: true,
+          bucket: BUCKET,
+        },
+        { accessKeyId: 'testkey', secretAccessKey: 'wrong-secret' },
+      );
+      await expect(probeS3ObjectStore(bad)).rejects.toThrow();
+    });
+  },
+);

--- a/services/platform/convex/lib/storage/object_storage_producers.e2e.test.ts
+++ b/services/platform/convex/lib/storage/object_storage_producers.e2e.test.ts
@@ -1,0 +1,223 @@
+/**
+ * E2E — the REMAINING org-owned blob producers (beyond Knowledge-Hub documents)
+ * flowing through the per-org object-storage seam against a REAL S3-compatible
+ * store (MinIO). Gated behind `OBJECT_STORAGE_E2E` so the ordinary unit suite
+ * (no MinIO) skips it.
+ *
+ *   docker run -d --name minio -p 9100:9000 \
+ *     -e MINIO_ROOT_USER=testkey -e MINIO_ROOT_PASSWORD=testsecret123 \
+ *     minio/minio server /data        # (create a bucket `org-blobs`)
+ *   OBJECT_STORAGE_E2E=1 bunx vitest --run object_storage_producers.e2e
+ *
+ * Each case exercises the EXACT seam calls its producer makes and asserts the
+ * object is PHYSICALLY present in the org's bucket (ListObjectsV2), not merely
+ * that a ref came back:
+ *   - CHAT ATTACHMENT: the browser upload handoff (`generateBlobUpload`) presigns
+ *     a PUT, the bytes land in the bucket, the attachment READ (`readBlobBytes`,
+ *     used by the inline-image / parse / sandbox-staging paths) reads them back,
+ *     the download URL (`getBlobUrl`) serves them, and delete removes them.
+ *   - AUDIO BLOB: the server-side ingest store (`putBlob`, as video-link
+ *     transcription does) lands the audio in the bucket, `readBlobBytes` (the
+ *     `transcribeAudio` source read) reads it, and delete removes it.
+ *   - SERVER-GENERATED DOCUMENT: `putBlob` (as `storeRawContent` now does) lands
+ *     the blob, `readBlobBytes` (the RAG index read) reads it, delete removes it.
+ *
+ * The S3 arm of `blob_access` never touches the Convex `ActionCtx`, so the tests
+ * pass a Proxy ctx that THROWS on any access — asserting the S3 path is ctx-free.
+ */
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ActionCtx } from '../../_generated/server';
+import {
+  deleteBlob,
+  generateBlobUpload,
+  getBlobUrl,
+  parseBlobRef,
+  putBlob,
+  readBlobBytes,
+} from './blob_access';
+import {
+  resolveOrgObjectStore,
+  s3ListObjectKeys,
+  type S3ObjectStore,
+} from './object_store';
+
+const RUN = !!process.env.OBJECT_STORAGE_E2E;
+const ORG = 'producers-e2e-org';
+const ENDPOINT = 'http://127.0.0.1:9100';
+const BUCKET = 'org-blobs';
+const SECRETS = { accessKeyId: 'testkey', secretAccessKey: 'testsecret123' };
+
+// A ctx the S3 path must never touch — any property access is a test failure.
+const noCtx = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error('the S3 blob path must not access ActionCtx');
+    },
+  },
+) as unknown as ActionCtx;
+
+/** True iff an object with exactly `key` is physically present in the bucket. */
+async function objectExists(
+  store: S3ObjectStore,
+  key: string,
+): Promise<boolean> {
+  const keys = await s3ListObjectKeys(store, key);
+  return keys.includes(key);
+}
+
+describe.skipIf(!RUN)(
+  'per-org object storage — remaining producers (MinIO)',
+  () => {
+    let store: S3ObjectStore;
+
+    beforeAll(async () => {
+      // Point the resolver at a throwaway TALE_CONFIG_DIR holding one org's
+      // object-storage connection (plaintext secrets — no SOPS key configured).
+      const root = await mkdtemp(join(tmpdir(), 'obj-store-producers-e2e-'));
+      process.env.TALE_CONFIG_DIR = root;
+      const dir = join(root, ORG, 'object-storage');
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, 'connection.json'),
+        JSON.stringify(
+          {
+            region: 'us-east-1',
+            endpoint: ENDPOINT,
+            forcePathStyle: true,
+            bucket: BUCKET,
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        join(dir, 'connection.secrets.json'),
+        JSON.stringify(SECRETS, null, 2),
+      );
+
+      const resolved = await resolveOrgObjectStore(ORG);
+      expect(resolved.backend).toBe('s3');
+      if (resolved.backend !== 's3')
+        throw new Error('org did not resolve to S3');
+      store = resolved;
+    });
+
+    afterAll(() => {
+      delete process.env.TALE_CONFIG_DIR;
+    });
+
+    it('CHAT ATTACHMENT: upload handoff → PUT lands IN THE BUCKET, reads/serves/deletes', async () => {
+      // The composer calls `generateBlobUpload` and PUTs the bytes (an image
+      // here — the highest-volume chat attachment type).
+      const handoff = await generateBlobUpload(noCtx, ORG, {
+        contentType: 'image/png',
+      });
+      expect(handoff.method).toBe('PUT');
+      const ref = handoff.s3Ref;
+      expect(ref).toBeTruthy();
+      if (!ref) throw new Error('handoff returned no s3Ref');
+
+      const body = new TextEncoder().encode('PNG\x00 chat attachment bytes 🖼️');
+      const put = await fetch(handoff.url, {
+        method: 'PUT',
+        headers: { 'content-type': 'image/png' },
+        body,
+      });
+      expect(put.ok).toBe(true);
+
+      const parsed = parseBlobRef(ref);
+      expect(parsed.backend).toBe('s3');
+      if (parsed.backend !== 's3') throw new Error('ref not S3');
+
+      // Physically present in the org's bucket.
+      expect(await objectExists(store, parsed.key)).toBe(true);
+
+      // Attachment READ path (inline image / parse / sandbox staging).
+      const read = await readBlobBytes(noCtx, ORG, ref);
+      expect(new TextDecoder().decode(read)).toBe(
+        'PNG\x00 chat attachment bytes 🖼️',
+      );
+
+      // Download/serve path: a presigned GET a bare fetch (no signer) downloads.
+      const url = await getBlobUrl(noCtx, ORG, ref, { filename: 'photo.png' });
+      expect(url).toBeTruthy();
+      if (!url) throw new Error('getBlobUrl returned no url');
+      const served = await fetch(url);
+      expect(served.ok).toBe(true);
+      expect(await served.text()).toBe('PNG\x00 chat attachment bytes 🖼️');
+
+      // Delete removes it from the bucket.
+      await deleteBlob(noCtx, ORG, ref);
+      expect(await objectExists(store, parsed.key)).toBe(false);
+    });
+
+    it('AUDIO BLOB: server ingest store → IN THE BUCKET → transcribe read → serve → delete', async () => {
+      // Mirrors the video-link ingest store + the `transcribeAudio` source read.
+      const audio = new TextEncoder().encode('OggS fake audio payload for e2e');
+      const ref = await putBlob(noCtx, ORG, audio, 'audio/ogg');
+      expect(typeof ref).toBe('string');
+      expect(String(ref).startsWith('s3:')).toBe(true);
+
+      const parsed = parseBlobRef(ref);
+      if (parsed.backend !== 's3') throw new Error('ref not S3');
+      expect(await objectExists(store, parsed.key)).toBe(true);
+
+      // `transcribeAudio` reads the source bytes via `readBlobBytes`.
+      const read = await readBlobBytes(noCtx, ORG, ref);
+      expect(new TextDecoder().decode(read)).toBe(
+        'OggS fake audio payload for e2e',
+      );
+
+      // Served for download (fileMetadata `getFileUrl` s3 branch).
+      const url = await getBlobUrl(noCtx, ORG, ref, { filename: 'clip.ogg' });
+      expect(url).toBeTruthy();
+      if (!url) throw new Error('getBlobUrl returned no url');
+      const served = await fetch(url);
+      expect(served.ok).toBe(true);
+      expect(await served.text()).toBe('OggS fake audio payload for e2e');
+
+      await deleteBlob(noCtx, ORG, ref);
+      expect(await objectExists(store, parsed.key)).toBe(false);
+    });
+
+    it('SERVER-GENERATED DOCUMENT: storeRawContent putBlob → IN THE BUCKET → read → delete', async () => {
+      // Mirrors `storeRawContent` (agent-generated + knowledge-entry docs).
+      const doc = new TextEncoder().encode('# Generated report\n\nbody text');
+      const ref = await putBlob(noCtx, ORG, doc, 'text/markdown');
+      expect(String(ref).startsWith('s3:')).toBe(true);
+
+      const parsed = parseBlobRef(ref);
+      if (parsed.backend !== 's3') throw new Error('ref not S3');
+      expect(await objectExists(store, parsed.key)).toBe(true);
+
+      const read = await readBlobBytes(noCtx, ORG, ref);
+      expect(new TextDecoder().decode(read)).toBe(
+        '# Generated report\n\nbody text',
+      );
+
+      await deleteBlob(noCtx, ORG, ref);
+      expect(await objectExists(store, parsed.key)).toBe(false);
+    });
+
+    it('every producer namespaces its object under the org slug in the bucket', async () => {
+      // Tenant isolation: the object key carries the org slug segment.
+      const ref = await putBlob(
+        noCtx,
+        ORG,
+        new Uint8Array([1, 2, 3]),
+        'application/octet-stream',
+      );
+      const parsed = parseBlobRef(ref);
+      if (parsed.backend !== 's3') throw new Error('ref not S3');
+      expect(parsed.key.split('/')).toContain(ORG);
+      await deleteBlob(noCtx, ORG, ref);
+    });
+  },
+);

--- a/services/platform/convex/lib/storage/object_store.integration.test.ts
+++ b/services/platform/convex/lib/storage/object_store.integration.test.ts
@@ -121,4 +121,31 @@ describe.skipIf(!RUN)('per-org S3 object store (MinIO round-trip)', () => {
     // at the org segment, so match `testorg/` at start OR after a prefix slash.
     expect(buildObjectKey(store, ORG)).toMatch(new RegExp(`(^|/)${ORG}/`));
   });
+
+  it('blob access refuses a key outside the org namespace (tenant isolation)', async () => {
+    // Plant a real object under a DIFFERENT org's namespace in the SAME
+    // bucket (the shared-bucket scenario `prefix` exists for), then prove the
+    // org-scoped seam refuses to read / presign / delete it even though the
+    // raw store could. Guards the client-bindable-ref hole: binding another
+    // org's `s3:` key must fail closed at every access path.
+    const foreignKey = 'other-org/6f9619ff-feed-beef';
+    await s3PutObject(
+      store,
+      foreignKey,
+      new TextEncoder().encode('foreign bytes'),
+      'text/plain',
+    );
+    const { readBlobBytes, getBlobUrl, deleteBlob } =
+      await import('./blob_access');
+    const fakeCtx = {} as Parameters<typeof readBlobBytes>[0];
+    const ref = `s3:${foreignKey}`;
+    await expect(readBlobBytes(fakeCtx, ORG, ref)).rejects.toThrow(/namespace/);
+    await expect(getBlobUrl(fakeCtx, ORG, ref)).rejects.toThrow(/namespace/);
+    await expect(deleteBlob(fakeCtx, ORG, ref)).rejects.toThrow(/namespace/);
+    // The object is untouched (refusal happened before any store call) — the
+    // OWNING org's namespace check passes and can still read it.
+    const raw = await s3GetObjectBytes(store, foreignKey);
+    expect(new TextDecoder().decode(raw)).toBe('foreign bytes');
+    await s3DeleteObject(store, foreignKey);
+  });
 });

--- a/services/platform/convex/lib/storage/object_store.integration.test.ts
+++ b/services/platform/convex/lib/storage/object_store.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test — the per-org S3 object-store verbs against a REAL
+ * S3-compatible store (MinIO). Gated behind `OBJECT_STORAGE_INTEGRATION=1` so
+ * the ordinary unit suite (no MinIO) skips it. Run it with:
+ *
+ *   docker run -d --name minio -p 9100:9000 \
+ *     -e MINIO_ROOT_USER=testkey -e MINIO_ROOT_PASSWORD=testsecret123 \
+ *     minio/minio server /data
+ *   # (create a bucket `org-blobs`)
+ *   OBJECT_STORAGE_INTEGRATION=1 bunx vitest --run object_store.integration
+ *
+ * Proves the whole seam an org's blobs flow through: the per-org config resolver
+ * routes to the bucket, and PUT / GET / presigned-GET / DELETE round-trip on the
+ * wire format the browser and RAG pipeline depend on.
+ */
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  resolveOrgObjectStore,
+  s3DeleteObject,
+  s3GetObjectBytes,
+  s3PresignGetUrl,
+  s3PutObject,
+  buildObjectKey,
+  type S3ObjectStore,
+} from './object_store';
+
+const RUN = process.env.OBJECT_STORAGE_INTEGRATION === '1';
+const ORG = 'testorg';
+
+describe.skipIf(!RUN)('per-org S3 object store (MinIO round-trip)', () => {
+  let store: S3ObjectStore;
+
+  beforeAll(async () => {
+    // Point the config resolver at a throwaway TALE_CONFIG_DIR holding one org's
+    // object-storage connection (plaintext secrets — no SOPS key configured).
+    const root = await mkdtemp(join(tmpdir(), 'obj-store-it-'));
+    process.env.TALE_CONFIG_DIR = root;
+    const dir = join(root, ORG, 'object-storage');
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'connection.json'),
+      JSON.stringify(
+        {
+          region: 'us-east-1',
+          endpoint: 'http://127.0.0.1:9100',
+          forcePathStyle: true,
+          bucket: 'org-blobs',
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      join(dir, 'connection.secrets.json'),
+      JSON.stringify(
+        { accessKeyId: 'testkey', secretAccessKey: 'testsecret123' },
+        null,
+        2,
+      ),
+    );
+    const resolved = await resolveOrgObjectStore(ORG);
+    if (resolved.backend !== 's3') {
+      throw new Error('expected the org to resolve to an S3 store');
+    }
+    store = resolved;
+  });
+
+  afterAll(() => {
+    delete process.env.TALE_CONFIG_DIR;
+  });
+
+  it('PUT then GET round-trips the exact bytes', async () => {
+    const key = buildObjectKey(store, ORG);
+    const body = new TextEncoder().encode('hello per-org object storage 🌍');
+    await s3PutObject(store, key, body, 'text/plain; charset=utf-8');
+    const got = await s3GetObjectBytes(store, key);
+    expect(new TextDecoder().decode(got)).toBe(
+      'hello per-org object storage 🌍',
+    );
+    await s3DeleteObject(store, key);
+  });
+
+  it('presigns a working GET URL a plain fetch can download', async () => {
+    const key = buildObjectKey(store, ORG);
+    await s3PutObject(
+      store,
+      key,
+      new TextEncoder().encode('presign me'),
+      'text/plain',
+    );
+    const url = await s3PresignGetUrl(store, key, {
+      filename: 'download.txt',
+    });
+    // A bare fetch (no signer) must succeed purely on the query signature.
+    const res = await fetch(url);
+    expect(res.ok).toBe(true);
+    expect(await res.text()).toBe('presign me');
+    expect(res.headers.get('content-disposition') ?? '').toContain(
+      'download.txt',
+    );
+    await s3DeleteObject(store, key);
+  });
+
+  it('DELETE is idempotent (deleting a missing key does not throw)', async () => {
+    const key = buildObjectKey(store, ORG);
+    await s3PutObject(store, key, new TextEncoder().encode('x'), 'text/plain');
+    await s3DeleteObject(store, key);
+    await expect(s3DeleteObject(store, key)).resolves.toBeUndefined();
+    // GET on the deleted key must now fail.
+    await expect(s3GetObjectBytes(store, key)).rejects.toThrow();
+  });
+
+  it('the object key is namespaced under the org slug', () => {
+    // `<prefix?>/<orgSlug>/<uuid>` — with no prefix configured the key starts
+    // at the org segment, so match `testorg/` at start OR after a prefix slash.
+    expect(buildObjectKey(store, ORG)).toMatch(new RegExp(`(^|/)${ORG}/`));
+  });
+});

--- a/services/platform/convex/lib/storage/object_store.ts
+++ b/services/platform/convex/lib/storage/object_store.ts
@@ -1,0 +1,248 @@
+'use node';
+
+/**
+ * Per-organization object-store resolution + S3 verbs.
+ *
+ * The SINGLE per-org routing entry point for file blobs, the object-storage
+ * analogue of `getKnowledgePoolForOrg` for the RAG corpus. `resolveOrgObjectStore
+ * (orgSlug)` returns either the deployment default (Convex `_storage` — today's
+ * behaviour, zero regression) or, when the org has configured
+ * `<org>/object-storage/connection.json`, an S3 backend addressing the org's own
+ * bucket. Callers that hold an `ActionCtx` use `blob_access.ts`, which routes
+ * `ctx.storage.*` vs. these S3 verbs off the resolved backend; this module owns
+ * only the resolution + the raw S3 requests.
+ *
+ * S3 requests are signed with `aws4fetch` (a few-KB SigV4 signer) rather than
+ * `@aws-sdk/client-s3` — the AWS SDK is large and would risk the Convex module
+ * push-size cap. Works against any S3-compatible store (AWS S3, MinIO, R2,
+ * Wasabi) via `endpoint` + `forcePathStyle`.
+ *
+ * TENANT ISOLATION: the store is keyed strictly by `orgSlug`; a per-org bucket is
+ * NEVER addressed for another org. Resolution is fail-closed — a present but
+ * broken per-org config throws rather than silently using the shared default.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { AwsClient } from 'aws4fetch';
+
+import {
+  readOrgObjectStorageConnection,
+  type ObjectStorageConnectionFile,
+} from '../../object_storage/file_utils';
+
+/** Deployment default: blobs live in Convex `_storage` (per-org logical scope). */
+export interface ConvexObjectStore {
+  backend: 'convex';
+}
+
+/** Per-org bring-your-own S3-compatible bucket (physical isolation). */
+export interface S3ObjectStore {
+  backend: 's3';
+  client: AwsClient;
+  config: ObjectStorageConnectionFile;
+}
+
+export type ResolvedObjectStore = ConvexObjectStore | S3ObjectStore;
+
+const CONVEX_STORE: ConvexObjectStore = { backend: 'convex' };
+
+// Short-TTL resolution cache, mirroring `knowledge_db.ts` ORG_URL_TTL_MS: a
+// config change (admin edits the org's bucket) takes effect within the TTL
+// without a restart, and the hot path avoids a disk read + SOPS decrypt per blob.
+const ORG_STORE_TTL_MS = 15_000;
+interface CacheEntry {
+  store: ResolvedObjectStore;
+  expires: number;
+}
+const orgStoreCache = new Map<string, CacheEntry>();
+
+/**
+ * Resolve an org's object store: its own S3 bucket when
+ * `<org>/object-storage/connection.json` is configured, else the deployment
+ * default (Convex `_storage`). Cached with a short TTL. Throws (fail-closed) if a
+ * present per-org config is invalid or its credentials can't be decrypted.
+ */
+export async function resolveOrgObjectStore(
+  orgSlug: string,
+): Promise<ResolvedObjectStore> {
+  const now = Date.now();
+  const cached = orgStoreCache.get(orgSlug);
+  if (cached && cached.expires > now) {
+    return cached.store;
+  }
+  const resolved = await readOrgObjectStorageConnection(orgSlug);
+  let store: ResolvedObjectStore;
+  if (resolved === null) {
+    store = CONVEX_STORE;
+  } else {
+    store = {
+      backend: 's3',
+      client: new AwsClient({
+        accessKeyId: resolved.secrets.accessKeyId,
+        secretAccessKey: resolved.secrets.secretAccessKey,
+        region: resolved.connection.region,
+        service: 's3',
+      }),
+      config: resolved.connection,
+    };
+    console.info(`Resolved per-org S3 object store for org '${orgSlug}'`);
+  }
+  orgStoreCache.set(orgSlug, { store, expires: now + ORG_STORE_TTL_MS });
+  return store;
+}
+
+/** Drop the cached store resolution for an org (call after a config change). */
+export function invalidateOrgObjectStore(orgSlug: string): void {
+  orgStoreCache.delete(orgSlug);
+}
+
+/**
+ * Build the S3 object URL for a key, honouring path-style (MinIO/R2) vs.
+ * virtual-host (AWS) addressing. The key is percent-encoded per path segment
+ * (S3 keys may contain `/`, which stays a separator).
+ */
+function objectUrl(store: S3ObjectStore, key: string): string {
+  const encodedKey = key
+    .split('/')
+    .map((seg) => encodeURIComponent(seg))
+    .join('/');
+  const { bucket, endpoint, forcePathStyle, region } = store.config;
+  if (endpoint) {
+    const base = endpoint.replace(/\/+$/, '');
+    if (forcePathStyle) {
+      return `${base}/${encodeURIComponent(bucket)}/${encodedKey}`;
+    }
+    const u = new URL(base);
+    return `${u.protocol}//${bucket}.${u.host}/${encodedKey}`;
+  }
+  return `https://${bucket}.s3.${region}.amazonaws.com/${encodedKey}`;
+}
+
+/**
+ * Namespaced object key for an org's blob. `<prefix>/<orgSlug>/<uuid>` — the
+ * `orgSlug` segment keeps blobs legible/auditable inside a bucket even though a
+ * per-org bucket is already dedicated; `prefix` is the org-chosen namespace.
+ */
+export function buildObjectKey(store: S3ObjectStore, orgSlug: string): string {
+  const prefix = store.config.prefix?.replace(/^\/+|\/+$/g, '');
+  const parts = [prefix, orgSlug, randomUUID()].filter(
+    (p): p is string => Boolean(p) && p!.length > 0,
+  );
+  return parts.join('/');
+}
+
+/** PUT bytes to the org's bucket. Throws on a non-2xx response. */
+export async function s3PutObject(
+  store: S3ObjectStore,
+  key: string,
+  body: Uint8Array,
+  contentType: string,
+): Promise<void> {
+  const res = await store.client.fetch(objectUrl(store, key), {
+    method: 'PUT',
+    // aws4fetch hashes the Uint8Array body for SigV4 (it checks `byteLength`);
+    // the cast is only to bridge TS 5.7's `Uint8Array<ArrayBufferLike>` vs the
+    // DOM `BufferSource` shape — it is a valid `BodyInit` at runtime.
+    body: body as BodyInit,
+    headers: { 'content-type': contentType },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `S3 PUT ${key} failed: ${res.status} ${await safeErrorBody(res)}`,
+    );
+  }
+}
+
+/** GET the raw bytes of an object. Throws on a non-2xx response. */
+export async function s3GetObjectBytes(
+  store: S3ObjectStore,
+  key: string,
+): Promise<Uint8Array> {
+  const res = await store.client.fetch(objectUrl(store, key), {
+    method: 'GET',
+  });
+  if (!res.ok) {
+    throw new Error(
+      `S3 GET ${key} failed: ${res.status} ${await safeErrorBody(res)}`,
+    );
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+/** DELETE an object. S3 DELETE is idempotent (204 whether or not it existed). */
+export async function s3DeleteObject(
+  store: S3ObjectStore,
+  key: string,
+): Promise<void> {
+  const res = await store.client.fetch(objectUrl(store, key), {
+    method: 'DELETE',
+  });
+  // 204 (deleted) and 404 (already gone) are both success for our purposes.
+  if (!res.ok && res.status !== 404) {
+    throw new Error(
+      `S3 DELETE ${key} failed: ${res.status} ${await safeErrorBody(res)}`,
+    );
+  }
+}
+
+/** Default presigned-URL lifetime (seconds) — long enough for a browser fetch. */
+const DEFAULT_PRESIGN_TTL_SEC = 15 * 60;
+
+/**
+ * Presign a time-limited GET URL for the browser to download the object
+ * directly from the store (no proxy through the platform). `filename` sets a
+ * `Content-Disposition: attachment` so the download names the file.
+ */
+export async function s3PresignGetUrl(
+  store: S3ObjectStore,
+  key: string,
+  opts: { filename?: string; expiresInSec?: number } = {},
+): Promise<string> {
+  const url = new URL(objectUrl(store, key));
+  url.searchParams.set(
+    'X-Amz-Expires',
+    String(opts.expiresInSec ?? DEFAULT_PRESIGN_TTL_SEC),
+  );
+  if (opts.filename) {
+    url.searchParams.set(
+      'response-content-disposition',
+      `attachment; filename="${opts.filename.replace(/"/g, '')}"`,
+    );
+  }
+  const signed = await store.client.sign(url.toString(), {
+    method: 'GET',
+    aws: { signQuery: true },
+  });
+  return signed.url;
+}
+
+/**
+ * Presign a time-limited PUT URL for the browser to upload a blob directly to
+ * the org's bucket — the S3 analogue of `ctx.storage.generateUploadUrl()`.
+ */
+export async function s3PresignPutUrl(
+  store: S3ObjectStore,
+  key: string,
+  opts: { contentType?: string; expiresInSec?: number } = {},
+): Promise<string> {
+  const url = new URL(objectUrl(store, key));
+  url.searchParams.set(
+    'X-Amz-Expires',
+    String(opts.expiresInSec ?? DEFAULT_PRESIGN_TTL_SEC),
+  );
+  const signed = await store.client.sign(url.toString(), {
+    method: 'PUT',
+    aws: { signQuery: true },
+  });
+  return signed.url;
+}
+
+/** Read a short slice of an error response body for diagnostics (never throws). */
+async function safeErrorBody(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 300);
+  } catch {
+    return '(unreadable body)';
+  }
+}

--- a/services/platform/convex/lib/storage/object_store.ts
+++ b/services/platform/convex/lib/storage/object_store.ts
@@ -284,9 +284,14 @@ export async function s3PresignGetUrl(
     String(opts.expiresInSec ?? DEFAULT_PRESIGN_TTL_SEC),
   );
   if (opts.filename) {
+    // The store reflects this param as a response header — strip quotes AND
+    // control chars (CR/LF/NUL…) so a hostile filename can't splice into the
+    // Content-Disposition header (mirrors the `/storage` route's sanitizer).
+    // oxlint-disable-next-line no-control-regex -- stripping control chars is the point
+    const safeName = opts.filename.replace(/["\u0000-\u001f\u007f]/g, '');
     url.searchParams.set(
       'response-content-disposition',
-      `attachment; filename="${opts.filename.replace(/"/g, '')}"`,
+      `attachment; filename="${safeName}"`,
     );
   }
   const signed = await store.client.sign(url.toString(), {

--- a/services/platform/convex/lib/storage/object_store.ts
+++ b/services/platform/convex/lib/storage/object_store.ts
@@ -29,6 +29,7 @@ import { AwsClient } from 'aws4fetch';
 import {
   readOrgObjectStorageConnection,
   type ObjectStorageConnectionFile,
+  type ObjectStorageConnectionSecrets,
 } from '../../object_storage/file_utils';
 
 /** Deployment default: blobs live in Convex `_storage` (per-org logical scope). */
@@ -76,20 +77,54 @@ export async function resolveOrgObjectStore(
   if (resolved === null) {
     store = CONVEX_STORE;
   } else {
-    store = {
-      backend: 's3',
-      client: new AwsClient({
-        accessKeyId: resolved.secrets.accessKeyId,
-        secretAccessKey: resolved.secrets.secretAccessKey,
-        region: resolved.connection.region,
-        service: 's3',
-      }),
-      config: resolved.connection,
-    };
+    store = buildS3ObjectStore(resolved.connection, resolved.secrets);
     console.info(`Resolved per-org S3 object store for org '${orgSlug}'`);
   }
   orgStoreCache.set(orgSlug, { store, expires: now + ORG_STORE_TTL_MS });
   return store;
+}
+
+/**
+ * Build an `S3ObjectStore` from a connection + credentials WITHOUT touching disk
+ * — the shared constructor for both `resolveOrgObjectStore` (which reads the
+ * org's config) and the admin test-connection probe (which validates values
+ * from the form before they are ever persisted).
+ */
+export function buildS3ObjectStore(
+  connection: ObjectStorageConnectionFile,
+  secrets: ObjectStorageConnectionSecrets,
+): S3ObjectStore {
+  return {
+    backend: 's3',
+    client: new AwsClient({
+      accessKeyId: secrets.accessKeyId,
+      secretAccessKey: secrets.secretAccessKey,
+      region: connection.region,
+      service: 's3',
+    }),
+    config: connection,
+  };
+}
+
+/**
+ * Round-trip a throwaway probe object (PUT → GET → DELETE) against the store to
+ * prove the credentials AND the bucket are usable before the admin saves the
+ * config. Throws on any step failure (surfaced to the admin as the test result);
+ * always attempts the cleanup DELETE even when the GET assertion fails.
+ */
+export async function probeS3ObjectStore(store: S3ObjectStore): Promise<void> {
+  const key = buildObjectKey(store, '__tale_probe__');
+  const expected = `tale-object-storage-probe ${new Date().toISOString()}`;
+  const body = new TextEncoder().encode(expected);
+  await s3PutObject(store, key, body, 'text/plain; charset=utf-8');
+  try {
+    const got = await s3GetObjectBytes(store, key);
+    if (new TextDecoder().decode(got) !== expected) {
+      throw new Error('probe object read back with unexpected content');
+    }
+  } finally {
+    await s3DeleteObject(store, key);
+  }
 }
 
 /** Drop the cached store resolution for an org (call after a config change). */
@@ -127,7 +162,7 @@ export function objectUrl(store: S3ObjectStore, key: string): string {
 export function buildObjectKey(store: S3ObjectStore, orgSlug: string): string {
   const prefix = store.config.prefix?.replace(/^\/+|\/+$/g, '');
   const parts = [prefix, orgSlug, randomUUID()].filter(
-    (p): p is string => Boolean(p) && p!.length > 0,
+    (p): p is string => typeof p === 'string' && p.length > 0,
   );
   return parts.join('/');
 }
@@ -144,6 +179,7 @@ export async function s3PutObject(
     // aws4fetch hashes the Uint8Array body for SigV4 (it checks `byteLength`);
     // the cast is only to bridge TS 5.7's `Uint8Array<ArrayBufferLike>` vs the
     // DOM `BufferSource` shape — it is a valid `BodyInit` at runtime.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- valid BodyInit at runtime (see above)
     body: body as BodyInit,
     headers: { 'content-type': contentType },
   });

--- a/services/platform/convex/lib/storage/object_store.ts
+++ b/services/platform/convex/lib/storage/object_store.ts
@@ -155,6 +155,49 @@ export function objectUrl(store: S3ObjectStore, key: string): string {
 }
 
 /**
+ * List the object keys physically present in the store under an optional
+ * `prefix` (S3 ListObjectsV2). Diagnostic/verification helper — proves a blob is
+ * really in the bucket rather than trusting a returned ref. Handles the (rare)
+ * multi-page case by following the continuation token.
+ */
+export async function s3ListObjectKeys(
+  store: S3ObjectStore,
+  prefix?: string,
+): Promise<string[]> {
+  // `objectUrl(store, '')` yields the bucket base with a trailing slash; strip
+  // it so the list query targets the bucket, not a phantom empty-key object.
+  const bucketBase = objectUrl(store, '').replace(/\/+$/, '');
+  const keys: string[] = [];
+  let continuationToken: string | undefined;
+  do {
+    const url = new URL(bucketBase);
+    url.searchParams.set('list-type', '2');
+    if (prefix) url.searchParams.set('prefix', prefix);
+    if (continuationToken)
+      url.searchParams.set('continuation-token', continuationToken);
+    const res = await store.client.fetch(url.toString(), { method: 'GET' });
+    if (!res.ok) {
+      throw new Error(
+        `S3 LIST failed: ${res.status} ${await safeErrorBody(res)}`,
+      );
+    }
+    const xml = await res.text();
+    for (const m of xml.matchAll(/<Key>([^<]*)<\/Key>/g)) {
+      keys.push(
+        m[1]
+          .replaceAll('&amp;', '&')
+          .replaceAll('&lt;', '<')
+          .replaceAll('&gt;', '>'),
+      );
+    }
+    const tokenMatch =
+      /<NextContinuationToken>([^<]*)<\/NextContinuationToken>/.exec(xml);
+    continuationToken = tokenMatch ? tokenMatch[1] : undefined;
+  } while (continuationToken);
+  return keys;
+}
+
+/**
  * Namespaced object key for an org's blob. `<prefix>/<orgSlug>/<uuid>` — the
  * `orgSlug` segment keeps blobs legible/auditable inside a bucket even though a
  * per-org bucket is already dedicated; `prefix` is the org-chosen namespace.

--- a/services/platform/convex/lib/storage/object_store.ts
+++ b/services/platform/convex/lib/storage/object_store.ts
@@ -102,7 +102,7 @@ export function invalidateOrgObjectStore(orgSlug: string): void {
  * virtual-host (AWS) addressing. The key is percent-encoded per path segment
  * (S3 keys may contain `/`, which stays a separator).
  */
-function objectUrl(store: S3ObjectStore, key: string): string {
+export function objectUrl(store: S3ObjectStore, key: string): string {
   const encodedKey = key
     .split('/')
     .map((seg) => encodeURIComponent(seg))

--- a/services/platform/convex/object_storage/actions.ts
+++ b/services/platform/convex/object_storage/actions.ts
@@ -1,0 +1,189 @@
+import { ConvexError, v } from 'convex/values';
+
+import { defineAbilityFor } from '../../lib/permissions/ability';
+import { zodErrorMessage } from '../../lib/shared/schemas/format-error';
+import { objectStorageConnectionFileSchema } from '../../lib/shared/schemas/object_storage';
+import { internal } from '../_generated/api';
+import { action, type ActionCtx } from '../_generated/server';
+import {
+  requireOrgMembershipById,
+  type OrgMembershipAuth,
+} from '../lib/auth/require_org_membership';
+import {
+  objectStorageConnectionArgs,
+  type ObjectStorageConnectionView,
+  type ObjectStorageProbeResult,
+} from './validators';
+
+/**
+ * Admin-gated public actions for the per-org "bring your own object storage"
+ * bucket connection. Each authenticates the caller as an org admin, then
+ * delegates the filesystem write / probe to the `'use node'` `file_actions.ts`
+ * (kept separate so the generated api types don't collapse to `any`). The
+ * connection lives in per-org JSON files — no DB row carries it. Mirrors the
+ * per-org knowledge-DB admin actions.
+ */
+
+/** Gate to an org admin/owner (the `orgSettings` write capability). */
+async function requireObjectStorageAdmin(
+  ctx: ActionCtx,
+  organizationId: string,
+): Promise<OrgMembershipAuth> {
+  const auth = await requireOrgMembershipById(ctx, organizationId);
+  if (defineAbilityFor(auth.member.role).cannot('write', 'orgSettings')) {
+    throw new ConvexError({
+      code: 'ORG_FORBIDDEN',
+      message: `Role "${auth.member.role}" cannot manage the object-storage connection.`,
+    });
+  }
+  return auth;
+}
+
+/** Read the org's object-storage connection (masked — no credentials returned). */
+export const getObjectStorageConnection = action({
+  args: { organizationId: v.string() },
+  returns: v.object({
+    configured: v.boolean(),
+    region: v.optional(v.string()),
+    endpoint: v.optional(v.string()),
+    forcePathStyle: v.optional(v.boolean()),
+    bucket: v.optional(v.string()),
+    prefix: v.optional(v.string()),
+    hasCredentials: v.optional(v.boolean()),
+  }),
+  handler: async (ctx, args): Promise<ObjectStorageConnectionView> => {
+    const auth = await requireObjectStorageAdmin(ctx, args.organizationId);
+    return ctx.runAction(internal.object_storage.file_actions.readConnection, {
+      orgSlug: auth.orgSlug,
+    });
+  },
+});
+
+/**
+ * Save (or update) the org's object-storage connection. Credentials are
+ * required the first time the connection is configured; on a later edit they
+ * may be omitted (leaving the stored sidecar untouched) so the bucket/region
+ * can change without re-entering the keys.
+ */
+export const saveObjectStorageConnection = action({
+  args: {
+    organizationId: v.string(),
+    ...objectStorageConnectionArgs,
+    accessKeyId: v.optional(v.string()),
+    secretAccessKey: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const auth = await requireObjectStorageAdmin(ctx, args.organizationId);
+    const parsed = objectStorageConnectionFileSchema.safeParse({
+      region: args.region,
+      endpoint: args.endpoint,
+      forcePathStyle: args.forcePathStyle ?? false,
+      bucket: args.bucket,
+      prefix: args.prefix,
+    });
+    if (!parsed.success) {
+      throw new ConvexError({
+        code: 'INVALID_CONNECTION',
+        message: zodErrorMessage(
+          'Invalid object-storage connection',
+          parsed.error,
+        ),
+      });
+    }
+
+    const hasKey = !!args.accessKeyId && args.accessKeyId.length > 0;
+    const hasSecret = !!args.secretAccessKey && args.secretAccessKey.length > 0;
+    if (hasKey !== hasSecret) {
+      throw new ConvexError({
+        code: 'INVALID_CREDENTIALS',
+        message:
+          'Both accessKeyId and secretAccessKey must be provided together.',
+      });
+    }
+    if (!hasKey) {
+      // No credentials in this request — only valid when a sidecar already
+      // exists (an edit of the bucket/region). A first-time configure needs
+      // them (S3 has no passwordless mode).
+      const existing: ObjectStorageConnectionView = await ctx.runAction(
+        internal.object_storage.file_actions.readConnection,
+        { orgSlug: auth.orgSlug },
+      );
+      if (!existing.hasCredentials) {
+        throw new ConvexError({
+          code: 'CREDENTIALS_REQUIRED',
+          message:
+            'accessKeyId and secretAccessKey are required to configure object storage.',
+        });
+      }
+    }
+
+    await ctx.runAction(internal.object_storage.file_actions.writeConnection, {
+      orgSlug: auth.orgSlug,
+      region: parsed.data.region,
+      endpoint: parsed.data.endpoint,
+      forcePathStyle: parsed.data.forcePathStyle,
+      bucket: parsed.data.bucket,
+      prefix: parsed.data.prefix,
+      accessKeyId: hasKey ? args.accessKeyId : undefined,
+      secretAccessKey: hasSecret ? args.secretAccessKey : undefined,
+    });
+    return null;
+  },
+});
+
+/** Remove the org's object-storage connection (revert to Convex `_storage`). */
+export const deleteObjectStorageConnection = action({
+  args: { organizationId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const auth = await requireObjectStorageAdmin(ctx, args.organizationId);
+    await ctx.runAction(internal.object_storage.file_actions.deleteConnection, {
+      orgSlug: auth.orgSlug,
+    });
+    return null;
+  },
+});
+
+/**
+ * Probe a candidate bucket before saving — a real PUT+GET+DELETE round-trip
+ * that proves the credentials AND the bucket work. Tests the values in the
+ * form; credentials are required (there is no passwordless S3).
+ */
+export const testObjectStorageConnection = action({
+  args: {
+    organizationId: v.string(),
+    ...objectStorageConnectionArgs,
+    accessKeyId: v.string(),
+    secretAccessKey: v.string(),
+  },
+  returns: v.any(),
+  handler: async (ctx, args): Promise<ObjectStorageProbeResult> => {
+    await requireObjectStorageAdmin(ctx, args.organizationId);
+    const parsed = objectStorageConnectionFileSchema.safeParse({
+      region: args.region,
+      endpoint: args.endpoint,
+      forcePathStyle: args.forcePathStyle ?? false,
+      bucket: args.bucket,
+      prefix: args.prefix,
+    });
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: zodErrorMessage(
+          'Invalid object-storage connection',
+          parsed.error,
+        ),
+      };
+    }
+    return ctx.runAction(internal.object_storage.file_actions.probeConnection, {
+      region: parsed.data.region,
+      endpoint: parsed.data.endpoint,
+      forcePathStyle: parsed.data.forcePathStyle,
+      bucket: parsed.data.bucket,
+      prefix: parsed.data.prefix,
+      accessKeyId: args.accessKeyId,
+      secretAccessKey: args.secretAccessKey,
+    });
+  },
+});

--- a/services/platform/convex/object_storage/file_actions.ts
+++ b/services/platform/convex/object_storage/file_actions.ts
@@ -1,0 +1,241 @@
+'use node';
+
+/**
+ * Internal `'use node'` file writers + S3 probe for the per-org object-storage
+ * connection. Kept in a SEPARATE file from the public `actions.ts` that calls
+ * them via `internal.*` so the generated api types don't collapse to `any` (the
+ * Convex self-referential-api-type trap); every handler carries an explicit
+ * `Promise<…>` return annotation for the same reason.
+ *
+ * Mirrors `knowledge/file_actions.ts`. The connection lives in per-org JSON
+ * files — no DB row carries it. The credentials sidecar is SOPS-encrypted when a
+ * SOPS age key is configured, plaintext otherwise (same hybrid model as
+ * `providers`/`knowledge`).
+ */
+
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { v } from 'convex/values';
+
+import { internalAction } from '../_generated/server';
+import {
+  atomicWrite,
+  atomicWriteSecret,
+  generateHistoryTimestamp,
+  pruneHistory,
+  readFileSafe,
+  removeDirSafe,
+  removeFileSafe,
+} from '../lib/file_io';
+import {
+  encryptJsonWithSops,
+  hasSopsKey,
+  invalidateSecretsCache,
+} from '../lib/sops';
+import {
+  buildS3ObjectStore,
+  invalidateOrgObjectStore,
+  probeS3ObjectStore,
+} from '../lib/storage/object_store';
+import { checkProviderHostPolicy } from '../providers/file_actions';
+import {
+  parseObjectStorageConnectionJson,
+  resolveObjectStorageConnectionFilePath,
+  resolveObjectStorageConnectionSecretsFilePath,
+  resolveObjectStorageHistoryDir,
+  serializeObjectStorageConnectionJson,
+  serializeObjectStorageSecretsJson,
+  type ObjectStorageConnectionFile,
+} from './file_utils';
+import {
+  objectStorageConnectionArgs,
+  type ObjectStorageConnectionView,
+  type ObjectStorageProbeResult,
+} from './validators';
+
+const MAX_HISTORY_ENTRIES = 20;
+
+/** SSRF-gate an optional S3 endpoint (AWS proper has none — nothing to gate). */
+function gateEndpoint(endpoint: string | undefined): void {
+  if (endpoint) {
+    checkProviderHostPolicy(endpoint);
+  }
+}
+
+/** Assemble a validated connection object from the flat action args. */
+function connectionFromArgs(args: {
+  region: string;
+  endpoint?: string;
+  forcePathStyle?: boolean;
+  bucket: string;
+  prefix?: string;
+}): ObjectStorageConnectionFile {
+  return {
+    region: args.region,
+    endpoint: args.endpoint,
+    forcePathStyle: args.forcePathStyle ?? false,
+    bucket: args.bucket,
+    prefix: args.prefix,
+  };
+}
+
+/** Snapshot the current connection.json into `.history/` before overwrite. */
+async function snapshotHistory(
+  orgSlug: string,
+  currentContent: string,
+): Promise<void> {
+  const historyDir = resolveObjectStorageHistoryDir(orgSlug);
+  await mkdir(historyDir, { recursive: true });
+  await atomicWrite(
+    path.join(historyDir, `${generateHistoryTimestamp()}.json`),
+    currentContent,
+  );
+  await pruneHistory(historyDir, MAX_HISTORY_ENTRIES);
+}
+
+/**
+ * Write (or update) the org's `connection.json` and, when a credential pair is
+ * supplied, its SOPS secret sidecar.
+ *
+ * Credential semantics: BOTH `accessKeyId` and `secretAccessKey` present (and
+ * non-empty) sets/replaces the sidecar; both absent leaves any existing sidecar
+ * untouched (so the bucket/region can be edited without re-entering the keys).
+ * S3 has no passwordless mode, so removing the sidecar is not offered here —
+ * dropping the whole config (`deleteConnection`) is the way to revert.
+ */
+export const writeConnection = internalAction({
+  args: {
+    orgSlug: v.string(),
+    ...objectStorageConnectionArgs,
+    accessKeyId: v.optional(v.string()),
+    secretAccessKey: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (_ctx, args): Promise<null> => {
+    gateEndpoint(args.endpoint);
+    // Re-validate through the shared schema (defence in depth) before disk.
+    const connection = connectionFromArgs(args);
+    const filePath = resolveObjectStorageConnectionFilePath(args.orgSlug);
+    const serialized = serializeObjectStorageConnectionJson(connection);
+
+    const currentContent = await readFileSafe(filePath);
+    if (currentContent) {
+      await snapshotHistory(args.orgSlug, currentContent);
+    }
+    await atomicWrite(filePath, serialized);
+
+    // Both keys present (non-empty) sets/replaces the sidecar; the locals let TS
+    // narrow away `undefined` without a non-null assertion.
+    const accessKeyId = args.accessKeyId;
+    const secretAccessKey = args.secretAccessKey;
+    if (accessKeyId && secretAccessKey) {
+      const secretsPath = resolveObjectStorageConnectionSecretsFilePath(
+        args.orgSlug,
+      );
+      const plaintext = serializeObjectStorageSecretsJson({
+        accessKeyId,
+        secretAccessKey,
+      });
+      const content = hasSopsKey() ? encryptJsonWithSops(plaintext) : plaintext;
+      await atomicWriteSecret(secretsPath, content);
+      invalidateSecretsCache(secretsPath);
+    }
+
+    invalidateOrgObjectStore(args.orgSlug);
+    return null;
+  },
+});
+
+/**
+ * Read the org's connection config for the admin view. Never returns the
+ * credentials — only whether they are configured.
+ */
+export const readConnection = internalAction({
+  args: { orgSlug: v.string() },
+  returns: v.object({
+    configured: v.boolean(),
+    region: v.optional(v.string()),
+    endpoint: v.optional(v.string()),
+    forcePathStyle: v.optional(v.boolean()),
+    bucket: v.optional(v.string()),
+    prefix: v.optional(v.string()),
+    hasCredentials: v.optional(v.boolean()),
+  }),
+  handler: async (_ctx, args): Promise<ObjectStorageConnectionView> => {
+    const configRaw = await readFileSafe(
+      resolveObjectStorageConnectionFilePath(args.orgSlug),
+    );
+    if (configRaw === null) {
+      return { configured: false };
+    }
+    const connection = parseObjectStorageConnectionJson(configRaw);
+    return {
+      configured: true,
+      region: connection.region,
+      endpoint: connection.endpoint,
+      forcePathStyle: connection.forcePathStyle,
+      bucket: connection.bucket,
+      prefix: connection.prefix,
+      hasCredentials: await objectStorageCredentialsConfigured(args.orgSlug),
+    };
+  },
+});
+
+/** True when a credentials sidecar exists (whether or not decryptable now). */
+async function objectStorageCredentialsConfigured(
+  orgSlug: string,
+): Promise<boolean> {
+  const raw = await readFileSafe(
+    resolveObjectStorageConnectionSecretsFilePath(orgSlug),
+  );
+  return raw !== null && raw.trim().length > 0;
+}
+
+/** Remove the org's connection config + secrets + history (revert to default). */
+export const deleteConnection = internalAction({
+  args: { orgSlug: v.string() },
+  returns: v.null(),
+  handler: async (_ctx, args): Promise<null> => {
+    const secretsPath = resolveObjectStorageConnectionSecretsFilePath(
+      args.orgSlug,
+    );
+    await removeFileSafe(resolveObjectStorageConnectionFilePath(args.orgSlug));
+    await removeFileSafe(secretsPath);
+    await removeDirSafe(resolveObjectStorageHistoryDir(args.orgSlug));
+    invalidateSecretsCache(secretsPath);
+    invalidateOrgObjectStore(args.orgSlug);
+    return null;
+  },
+});
+
+/**
+ * Probe a candidate bucket + credentials with a REAL round-trip: SSRF-gate the
+ * endpoint, then PUT → GET → DELETE a throwaway object. Proves the store is
+ * usable before the admin commits to it. Never throws — a failure is reported as
+ * `{ ok: false, error }` for the admin form.
+ */
+export const probeConnection = internalAction({
+  args: {
+    ...objectStorageConnectionArgs,
+    accessKeyId: v.string(),
+    secretAccessKey: v.string(),
+  },
+  returns: v.any(),
+  handler: async (_ctx, args): Promise<ObjectStorageProbeResult> => {
+    try {
+      gateEndpoint(args.endpoint);
+      const store = buildS3ObjectStore(connectionFromArgs(args), {
+        accessKeyId: args.accessKeyId,
+        secretAccessKey: args.secretAccessKey,
+      });
+      await probeS3ObjectStore(store);
+      return { ok: true };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+});

--- a/services/platform/convex/object_storage/file_utils.ts
+++ b/services/platform/convex/object_storage/file_utils.ts
@@ -1,0 +1,196 @@
+'use node';
+
+/**
+ * Per-organization object-storage config file utilities.
+ *
+ * Pure path + (de)serialization + resolution helpers for the `object-storage`
+ * config domain (admin-on-demand, one file per org, no builtin catalog). On
+ * disk, mirroring `knowledge`/`providers`/`sso`:
+ *   {TALE_CONFIG_DIR}/<orgSlug>/object-storage/connection.json          (config)
+ *   {TALE_CONFIG_DIR}/<orgSlug>/object-storage/connection.secrets.json  (SOPS)
+ *
+ * The connection is read by the object-store resolver (`lib/storage/
+ * object_store.ts`, `'use node'`) to route an org's blobs at its own S3 bucket.
+ * The admin read/save/delete actions mirror `knowledge/file_actions.ts`.
+ */
+
+import path from 'node:path';
+
+import { zodErrorMessage } from '../../lib/shared/schemas/format-error';
+import {
+  OBJECT_STORAGE_CONFIG_DOMAIN,
+  OBJECT_STORAGE_CONNECTION_KEY,
+  objectStorageConnectionFileSchema,
+  objectStorageConnectionSecretsSchema,
+  type ObjectStorageConnectionFile,
+  type ObjectStorageConnectionSecrets,
+} from '../../lib/shared/schemas/object_storage';
+import {
+  errnoCode,
+  getConfigRoot,
+  readFileSafe,
+  safeJoinWithinDir,
+  validateOrgSlug,
+} from '../lib/file_io';
+import { decryptSecretsFile } from '../lib/sops';
+
+export type { ObjectStorageConnectionFile, ObjectStorageConnectionSecrets };
+export { OBJECT_STORAGE_CONFIG_DOMAIN, OBJECT_STORAGE_CONNECTION_KEY };
+
+export const MAX_FILE_SIZE_BYTES = 64 * 1024; // 64 KB
+
+/** `<orgSlug>/object-storage/` — the org's object-storage config directory. */
+export function resolveObjectStorageDir(orgSlug: string): string {
+  if (!validateOrgSlug(orgSlug)) {
+    throw new Error(`Invalid org slug: ${orgSlug}`);
+  }
+  return path.join(
+    getConfigRoot(OBJECT_STORAGE_CONFIG_DOMAIN),
+    orgSlug,
+    OBJECT_STORAGE_CONFIG_DOMAIN,
+  );
+}
+
+/** `<orgSlug>/object-storage/connection.json` — non-secret bucket config. */
+export function resolveObjectStorageConnectionFilePath(
+  orgSlug: string,
+): string {
+  return safeJoinWithinDir(
+    resolveObjectStorageDir(orgSlug),
+    `${OBJECT_STORAGE_CONNECTION_KEY}.json`,
+  );
+}
+
+/** `<orgSlug>/object-storage/connection.secrets.json` — SOPS credentials. */
+export function resolveObjectStorageConnectionSecretsFilePath(
+  orgSlug: string,
+): string {
+  return safeJoinWithinDir(
+    resolveObjectStorageDir(orgSlug),
+    `${OBJECT_STORAGE_CONNECTION_KEY}.secrets.json`,
+  );
+}
+
+/** `<orgSlug>/object-storage/.history/connection` — config history snapshots. */
+export function resolveObjectStorageHistoryDir(orgSlug: string): string {
+  return safeJoinWithinDir(
+    safeJoinWithinDir(resolveObjectStorageDir(orgSlug), '.history'),
+    OBJECT_STORAGE_CONNECTION_KEY,
+  );
+}
+
+/** Serialize the bucket config to its canonical on-disk form. */
+export function serializeObjectStorageConnectionJson(
+  config: ObjectStorageConnectionFile,
+): string {
+  return (
+    JSON.stringify(objectStorageConnectionFileSchema.parse(config), null, 2) +
+    '\n'
+  );
+}
+
+/** Parse + validate `connection.json`. Throws on invalid input. */
+export function parseObjectStorageConnectionJson(
+  content: string,
+): ObjectStorageConnectionFile {
+  const parsed: unknown = JSON.parse(content);
+  const result = objectStorageConnectionFileSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      zodErrorMessage('Invalid object-storage connection config', result.error),
+    );
+  }
+  return result.data;
+}
+
+/** Serialize the credentials sidecar. */
+export function serializeObjectStorageSecretsJson(
+  secrets: ObjectStorageConnectionSecrets,
+): string {
+  return (
+    JSON.stringify(
+      objectStorageConnectionSecretsSchema.parse(secrets),
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+/** Parse + validate `connection.secrets.json`. Throws on invalid input. */
+export function parseObjectStorageSecretsJson(
+  content: string,
+): ObjectStorageConnectionSecrets {
+  const parsed: unknown = JSON.parse(content);
+  const result = objectStorageConnectionSecretsSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      zodErrorMessage('Invalid object-storage secrets file', result.error),
+    );
+  }
+  return result.data;
+}
+
+export interface ResolvedObjectStorageConnection {
+  connection: ObjectStorageConnectionFile;
+  secrets: ObjectStorageConnectionSecrets;
+}
+
+/**
+ * Read + resolve an org's object-storage connection.
+ *
+ * Returns `null` when the org has NO `connection.json` — the caller then uses
+ * the deployment default (Convex `_storage`). Returns the bucket config +
+ * decrypted credentials when present.
+ *
+ * FAIL-CLOSED: throws when `connection.json` is present but invalid, or when the
+ * credentials sidecar is missing/undecryptable. Never falls back to the shared
+ * default store for a misconfigured per-org bucket — mis-routing a tenant's
+ * blobs into the shared store is worse than erroring.
+ */
+export async function readOrgObjectStorageConnection(
+  orgSlug: string,
+): Promise<ResolvedObjectStorageConnection | null> {
+  const configRaw = await readFileSafe(
+    resolveObjectStorageConnectionFilePath(orgSlug),
+  );
+  if (configRaw === null) {
+    return null;
+  }
+  const connection = parseObjectStorageConnectionJson(configRaw);
+  const secrets = await readObjectStorageSecrets(orgSlug);
+  return { connection, secrets };
+}
+
+/**
+ * Read + decrypt the org's S3 credentials from the SOPS sidecar. A present
+ * `connection.json` REQUIRES credentials (S3 has no passwordless mode), so an
+ * absent/undecryptable sidecar throws — fail closed rather than sign requests
+ * with no key.
+ */
+async function readObjectStorageSecrets(
+  orgSlug: string,
+): Promise<ObjectStorageConnectionSecrets> {
+  const secretsPath = resolveObjectStorageConnectionSecretsFilePath(orgSlug);
+  let raw: Record<string, unknown>;
+  try {
+    raw = await decryptSecretsFile(secretsPath);
+  } catch (err) {
+    if (errnoCode(err) === 'ENOENT') {
+      throw new Error(
+        `object-storage credentials missing for org '${orgSlug}': ` +
+          `${OBJECT_STORAGE_CONNECTION_KEY}.secrets.json not found`,
+      );
+    }
+    throw err;
+  }
+  const parsed = objectStorageConnectionSecretsSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      zodErrorMessage(
+        `Invalid object-storage credentials for org '${orgSlug}'`,
+        parsed.error,
+      ),
+    );
+  }
+  return parsed.data;
+}

--- a/services/platform/convex/object_storage/file_utils.ts
+++ b/services/platform/convex/object_storage/file_utils.ts
@@ -179,6 +179,7 @@ async function readObjectStorageSecrets(
       throw new Error(
         `object-storage credentials missing for org '${orgSlug}': ` +
           `${OBJECT_STORAGE_CONNECTION_KEY}.secrets.json not found`,
+        { cause: err },
       );
     }
     throw err;

--- a/services/platform/convex/object_storage/validators.ts
+++ b/services/platform/convex/object_storage/validators.ts
@@ -1,0 +1,34 @@
+import { v } from 'convex/values';
+
+/**
+ * Shared arg + view shapes for the per-org object-storage connection admin
+ * actions. V8-safe (only `convex/values` + types) so both the public
+ * `actions.ts` and the `'use node'` `file_actions.ts` can import them.
+ */
+
+/** Non-secret bucket-coordinate args (mirrors the `connection.json` schema). */
+export const objectStorageConnectionArgs = {
+  region: v.string(),
+  endpoint: v.optional(v.string()),
+  forcePathStyle: v.optional(v.boolean()),
+  bucket: v.string(),
+  prefix: v.optional(v.string()),
+} as const;
+
+/** Masked admin view of a saved connection — never carries the credentials. */
+export interface ObjectStorageConnectionView {
+  configured: boolean;
+  region?: string;
+  endpoint?: string;
+  forcePathStyle?: boolean;
+  bucket?: string;
+  prefix?: string;
+  /** Whether an encrypted credentials sidecar is present (never the values). */
+  hasCredentials?: boolean;
+}
+
+/** Result of a test-connection probe (real PUT+GET+DELETE round-trip). */
+export interface ObjectStorageProbeResult {
+  ok: boolean;
+  error?: string;
+}

--- a/services/platform/convex/projects/queries.ts
+++ b/services/platform/convex/projects/queries.ts
@@ -15,6 +15,7 @@ import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { isActiveOrg } from '../lib/rls/organization/assert_active_org';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { listByOrganizationHandler } from '../members/queries';
 import { isHiddenFromChatHistory } from '../threads/list_threads';
 import {
@@ -287,7 +288,7 @@ export const listProjectDocuments = query({
       _id: v.id('documents'),
       _creationTime: v.number(),
       title: v.optional(v.string()),
-      fileId: v.optional(v.id('_storage')),
+      fileId: v.optional(blobRefValidator),
       mimeType: v.optional(v.string()),
       extension: v.optional(v.string()),
       folderId: v.optional(v.id('folders')),

--- a/services/platform/convex/rag/documents.ts
+++ b/services/platform/convex/rag/documents.ts
@@ -17,13 +17,13 @@
 import { v } from 'convex/values';
 
 import { isRecord } from '../../lib/utils/type-utils';
-import { internalAction } from '../_generated/server';
+import { internalAction, type ActionCtx } from '../_generated/server';
 import {
   getKnowledgePoolForOrg,
   PRIVATE_KNOWLEDGE_SCHEMA as SCHEMA,
 } from '../lib/knowledge/db/knowledge_db';
 import { withRetry } from '../lib/knowledge/db/retry';
-import { toId } from '../lib/type_cast_helpers';
+import { readBlobBytes } from '../lib/storage/blob_access';
 import { validateMetadataObject } from './lib/document_metadata';
 import { normalizeFolderPath } from './lib/folder_path';
 import {
@@ -37,15 +37,19 @@ function toIso(value: Date | null | undefined): string | null {
   return value ? value.toISOString() : null;
 }
 
-/** Resolve upload bytes from a storage id (preferred) or inline base64. */
-async function resolveUploadBytes(
-  // The caller passes a Convex `_storage` id for the uploaded file. The bytes
-  // are read here so the ported indexing pipeline gets a `Uint8Array`.
-  storageBlob: Blob | null,
+/**
+ * Resolve upload bytes from a stored blob reference (a Convex `_storage` id OR
+ * an `s3:<key>` ref — `readBlobBytes` routes to the org's backend) or, when the
+ * caller already holds the bytes, from inline base64.
+ */
+async function readUploadBytes(
+  ctx: ActionCtx,
+  orgSlug: string,
+  ref: string | null | undefined,
   base64Content: string | null,
 ): Promise<Uint8Array> {
-  if (storageBlob) {
-    return new Uint8Array(await storageBlob.arrayBuffer());
+  if (ref != null && ref !== '') {
+    return await readBlobBytes(ctx, orgSlug, ref);
   }
   if (base64Content != null) {
     return new Uint8Array(Buffer.from(base64Content, 'base64'));
@@ -58,20 +62,22 @@ export const upload = internalAction({
     orgSlug: v.string(),
     fileId: v.string(),
     filename: v.string(),
-    // TODO(rewire): the caller passes a Convex `_storage` id for the uploaded
-    // file; the bytes are read here via `ctx.storage.get`. `content` is an
-    // alternative inline base64 path for callers that already hold the bytes.
+    // A stored blob reference for the uploaded file: a Convex `_storage` id OR
+    // an `s3:<key>` ref (the bytes are read via `readBlobBytes`, which routes to
+    // the org's backend). `content` is an alternative inline base64 path for
+    // callers that already hold the bytes.
     storageId: v.optional(v.union(v.string(), v.null())),
     content: v.optional(v.union(v.string(), v.null())),
     sourceCreatedAt: v.optional(v.union(v.number(), v.null())),
     sourceModifiedAt: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
-    const storageBlob =
-      args.storageId != null && args.storageId !== ''
-        ? await ctx.storage.get(toId<'_storage'>(args.storageId))
-        : null;
-    const bytes = await resolveUploadBytes(storageBlob, args.content ?? null);
+    const bytes = await readUploadBytes(
+      ctx,
+      args.orgSlug,
+      args.storageId,
+      args.content ?? null,
+    );
 
     const sourceCreatedAt =
       args.sourceCreatedAt != null ? new Date(args.sourceCreatedAt) : null;
@@ -231,21 +237,16 @@ export const compareFiles = internalAction({
     maxChanges: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
-    const baseBlob =
-      args.baseStorageId != null && args.baseStorageId !== ''
-        ? await ctx.storage.get(toId<'_storage'>(args.baseStorageId))
-        : null;
-    const comparisonBlob =
-      args.comparisonStorageId != null && args.comparisonStorageId !== ''
-        ? await ctx.storage.get(toId<'_storage'>(args.comparisonStorageId))
-        : null;
-
-    const baseBytes = await resolveUploadBytes(
-      baseBlob,
+    const baseBytes = await readUploadBytes(
+      ctx,
+      args.orgSlug,
+      args.baseStorageId,
       args.baseContent ?? null,
     );
-    const comparisonBytes = await resolveUploadBytes(
-      comparisonBlob,
+    const comparisonBytes = await readUploadBytes(
+      ctx,
+      args.orgSlug,
+      args.comparisonStorageId,
       args.comparisonContent ?? null,
     );
 

--- a/services/platform/convex/webdav/tree_mutations.ts
+++ b/services/platform/convex/webdav/tree_mutations.ts
@@ -12,6 +12,7 @@ import { extractExtension } from '../documents/extract_extension';
 import { findFolderByPath } from '../folders/find_folder_by_path';
 import { MAX_FOLDER_DEPTH } from '../folders/mutations';
 import { buildFolderPath } from '../folders/queries';
+import { convexStorageId, type BlobRef } from '../lib/storage/blob_ref';
 import {
   budgetTake,
   chargeReadBudget,
@@ -460,7 +461,7 @@ export const moveResource = internalMutation({
       // external-sync reconcile (which matches on folderPath / folderPathPrefix)
       // mis-matches the relocated subtree and re-creates duplicates.
       const ragFolderPathUpdates: Array<{
-        fileId: Id<'_storage'>;
+        fileId: BlobRef;
         folderPath?: string;
       }> = [];
       await fixupMovedFolderDescendants(
@@ -884,7 +885,7 @@ async function fixupMovedFolderDescendants(
   depth: number,
   budget: ReadBudget,
   ragFolderPathUpdates: Array<{
-    fileId: Id<'_storage'>;
+    fileId: BlobRef;
     folderPath?: string;
   }>,
 ): Promise<void> {
@@ -935,7 +936,7 @@ async function fixupMovedFolderDescendants(
 async function purgeOldBlob(
   ctx: MutationCtx,
   organizationId: string,
-  oldFileId: Id<'_storage'>,
+  oldFileId: BlobRef,
 ): Promise<void> {
   // Refcount guard. COPY shares the source doc's storageId (createDocument is
   // called with fileId: src.fileId — Convex _storage is content-addressed), so
@@ -980,9 +981,20 @@ async function purgeOldBlob(
       documentId: undefined,
     });
   }
-  try {
-    await ctx.storage.delete(oldFileId);
-  } catch (err) {
-    console.warn('[webdav] purgeOldBlob storage.delete failed', err);
+  const convexId = convexStorageId(oldFileId);
+  if (convexId !== null) {
+    try {
+      await ctx.storage.delete(convexId);
+    } catch (err) {
+      console.warn('[webdav] purgeOldBlob storage.delete failed', err);
+    }
+  } else {
+    // S3-backed old blob: a mutation can't sign an S3 delete, so schedule the
+    // org-scoped node action (best-effort, idempotent).
+    await ctx.scheduler.runAfter(
+      0,
+      internal.files.blob_actions.deleteOrgBlobs,
+      { organizationId, refs: [String(oldFileId)] },
+    );
   }
 }

--- a/services/platform/lib/shared/config/catalog_validator.ts
+++ b/services/platform/lib/shared/config/catalog_validator.ts
@@ -55,6 +55,10 @@ import {
   knowledgeConnectionFileSchema,
   knowledgeConnectionSecretsSchema,
 } from '../schemas/knowledge';
+import {
+  objectStorageConnectionFileSchema,
+  objectStorageConnectionSecretsSchema,
+} from '../schemas/object_storage';
 import { promptJsonSchema } from '../schemas/prompts';
 import {
   providerJsonSchema,
@@ -297,6 +301,23 @@ function validateKnowledgeDir(dir: string, relPrefix: string): WalkResult {
   );
 }
 
+function validateObjectStorageDir(dir: string, relPrefix: string): WalkResult {
+  return walkFlat(
+    dir,
+    relPrefix,
+    (base, rel, out) => {
+      out.issues.push(
+        `${rel}: only connection.json lives in the object-storage domain`,
+      );
+      return undefined;
+    },
+    {
+      secretsSchema: objectStorageConnectionSecretsSchema,
+      specialFiles: { 'connection.json': objectStorageConnectionFileSchema },
+    },
+  );
+}
+
 function validateGovernanceDir(dir: string): WalkResult {
   return walkFlat(
     dir,
@@ -423,6 +444,10 @@ const DOMAIN_VALIDATORS: Record<string, DomainValidator> = {
   knowledge: {
     kind: 'walk',
     validateDir: (dir) => validateKnowledgeDir(dir, ''),
+  },
+  'object-storage': {
+    kind: 'walk',
+    validateDir: (dir) => validateObjectStorageDir(dir, ''),
   },
   automations: {
     kind: 'external-gate',

--- a/services/platform/lib/shared/config/registry.ts
+++ b/services/platform/lib/shared/config/registry.ts
@@ -43,6 +43,7 @@ import {
   policyTypeToFileBase,
 } from '../schemas/governance';
 import { KNOWLEDGE_CONFIG_DOMAIN } from '../schemas/knowledge';
+import { OBJECT_STORAGE_CONFIG_DOMAIN } from '../schemas/object_storage';
 
 /**
  * On-disk shape of a domain's catalog/data dir:
@@ -314,6 +315,19 @@ export const CONFIG_DOMAINS: readonly ConfigDomain[] = [
   // deployment-default knowledge pool (zero regression).
   {
     name: KNOWLEDGE_CONFIG_DOMAIN, // 'knowledge'
+    layout: 'single-file',
+    readContext: 'node-direct',
+    dataModel: 'config',
+  },
+  // Per-org "bring your own object storage" for file blobs. Same shape as
+  // `knowledge`: admin-on-demand (no `scaffoldKind`, no builtin default), read
+  // NODE-DIRECT by the `'use node'` object-store resolver from
+  // `<org>/object-storage/connection.json`, so it is NOT mirrored into
+  // `configCache` (no `v8Sync`/`watcher`; the resolver re-reads on a short TTL).
+  // Absent ⇒ the org's blobs stay on the deployment-default Convex `_storage`
+  // (zero regression).
+  {
+    name: OBJECT_STORAGE_CONFIG_DOMAIN, // 'object-storage'
     layout: 'single-file',
     readContext: 'node-direct',
     dataModel: 'config',

--- a/services/platform/lib/shared/schemas/object_storage.ts
+++ b/services/platform/lib/shared/schemas/object_storage.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod/v4';
+
+/**
+ * Per-organization "bring your own object storage" for file blobs.
+ *
+ * An org may route ALL of its uploaded blobs — Knowledge-Hub documents, chat
+ * attachments, audio, TTS, video-link media, thread/workspace files, agent
+ * knowledge, task/email attachments, generated images — at its OWN
+ * S3-compatible bucket (AWS S3, MinIO, Cloudflare R2, Wasabi, …) instead of the
+ * deployment's Convex `_storage`. Combined with the per-org knowledge Postgres
+ * (`knowledge/connection.json`), this puts EVERY layer of an org's data — source
+ * blobs, extracted text, chunks, embeddings — physically in the org's own
+ * infrastructure. Absent this config, the org's blobs stay on the deployment
+ * default (Convex `_storage`), scoped per-org logically (today's behaviour, zero
+ * regression).
+ *
+ * TENANT ISOLATION: a per-org bucket is dedicated to one org and MUST NEVER be
+ * addressed for another org — the resolver keys strictly by orgSlug, never a
+ * client-supplied value. See AGENTS.md → "Tenant isolation".
+ *
+ * File-based config domain like `knowledge`/`sso`: admin-created on demand, one
+ * file per org, no builtin catalog. On disk (mirrors `knowledge`):
+ *   {TALE_CONFIG_DIR}/<orgSlug>/object-storage/connection.json          (config)
+ *   {TALE_CONFIG_DIR}/<orgSlug>/object-storage/connection.secrets.json  (SOPS)
+ *
+ * The bucket SHAPE reuses the S3 fields the deployment-wide
+ * `dataStores.convexStorage` already uses (region/endpoint/forcePathStyle) — a
+ * single bucket rather than Convex's five, since one org owns the whole bucket.
+ * Credentials (`accessKeyId`/`secretAccessKey`) live ONLY in the SOPS-encrypted
+ * secrets sidecar, exactly like `providers/*.secrets.json`.
+ */
+
+export const OBJECT_STORAGE_CONFIG_DOMAIN = 'object-storage';
+export const OBJECT_STORAGE_CONNECTION_KEY = 'connection';
+
+/**
+ * `connection.json` — the org's S3-compatible bucket coordinates. Reuses the
+ * `dataStores.convexStorage` S3 shape (region + optional endpoint +
+ * forcePathStyle), narrowed to ONE bucket the org owns.
+ */
+export const objectStorageConnectionFileSchema = z
+  .object({
+    region: z.string().min(1),
+    /**
+     * S3-compatible endpoint (MinIO/R2/Wasabi). Omit for AWS S3 proper.
+     * Restricted to http(s):// — `.url()` alone also admits
+     * file:/javascript:/ftp:, and the SSRF host gate only checks the hostname,
+     * so a non-http scheme with a public host would otherwise reach the signer.
+     * Mirrors `convexStorageSchema` in deployment.ts.
+     */
+    endpoint: z
+      .string()
+      .url()
+      .refine((u) => {
+        try {
+          const p = new URL(u).protocol;
+          return p === 'https:' || p === 'http:';
+        } catch {
+          return false;
+        }
+      }, 'Endpoint must be http(s)://')
+      .optional(),
+    /** Path-style addressing (`endpoint/bucket/key`) — required by MinIO and
+     * most non-AWS stores; AWS S3 uses virtual-host style (the default). */
+    forcePathStyle: z.boolean().default(false),
+    bucket: z.string().min(1),
+    /**
+     * Optional key prefix inside the bucket. Lets an org share one bucket
+     * across, say, staging/prod, or namespace Tale's blobs beside other data.
+     * Empty ⇒ blobs live at the bucket root. Never used for cross-org scoping
+     * (a per-org bucket is already dedicated); purely an org-chosen namespace.
+     */
+    prefix: z.string().optional(),
+  })
+  .strict();
+export type ObjectStorageConnectionFile = z.infer<
+  typeof objectStorageConnectionFileSchema
+>;
+
+/**
+ * `connection.secrets.json` — the S3 credentials sidecar. SOPS-encrypted at
+ * rest when a SOPS age key is configured; plaintext JSON otherwise (same hybrid
+ * model as `providers`/`knowledge`). Both keys are required together — an
+ * S3-compatible store always needs a key pair (there is no passwordless
+ * equivalent to Postgres peer auth here).
+ */
+export const objectStorageConnectionSecretsSchema = z
+  .object({
+    accessKeyId: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+  })
+  .strict();
+export type ObjectStorageConnectionSecrets = z.infer<
+  typeof objectStorageConnectionSecretsSchema
+>;

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -94,6 +94,7 @@
     "@tanstack/react-virtual": "3.13.26",
     "@xyflow/react": "12.10.2",
     "ai": "6.0.156",
+    "aws4fetch": "^1.0.20",
     "bcryptjs": "3.0.3",
     "better-auth": "1.6.23",
     "chokidar": "5.0.0",


### PR DESCRIPTION
Closes the reviewer's isolation gap: an org can now store its **source blobs in its own S3 bucket**, not just its vectors — so every knowledge layer (source files, extracted text, embeddings) can live in the org's own infrastructure. Backward-compatible: orgs without a bucket stay on Convex `_storage`, byte-for-byte unchanged.

## What's here (all proven against real MinIO — objects physically LISTed in the bucket)
- **`object-storage` config domain** + per-org S3 resolver (`aws4fetch`, fail-closed, cached) — mirrors the BYO knowledge-DB pattern. Set via `<org>/object-storage/connection.json` + SOPS-encrypted credentials.
- **Backend-aware blob seam** (`blob_ref` / `blob_access`): a stored ref is a `_storage` id OR `s3:<key>`, so no repo-wide id-type rewrite. Widened blob-ref fields are superset-safe.
- **Admin config + test-connection action** (real PUT/GET/DELETE probe before saving).
- **Producers routed end-to-end** (upload → read → serve → delete): Knowledge-Hub **documents** (+ history), **audio transcription** reads, and **server-generated documents** (agent output + materialized knowledge entries). Serve for S3 goes through the `/storage` route as a 302-to-presigned-GET (a V8 query can't presign).

## Gates
`typecheck` 0 · `lint` 0 · `migrations:check` OK (data-safe widened unions, no migration needed) · ripple-area server tests green · gated MinIO E2E green (documents + producers, object LISTed in bucket).

## Deliberately follow-up (correctness over coverage — each is safe as-is)
Remaining blob producers stay on Convex `_storage` (safe) or have only their field widened (superset-safe), never half-wired: **chat-attachment client cutover** (needs ~6 read consumers made backend-aware + a delete fix), **video-link store** (coupled `by_storageId` sites), **TTS** (its serve is designed to avoid replayable URLs → needs byte-streaming, not a 302), and imports/tasks/image-gen/workflow staging. Also follow-up: the **BYO-org blob data migration** (move existing `_storage` blobs into the bucket on switch) and the **cloud management UI** for the config.

Note: a prior in-branch attempt widened tts/video/task fields without routing their consumers (compiled only against a stale `api.d.ts`); that was dropped here and the routed producers' consumer params widened cleanly instead.