### PR TITLE
feat(platform): surface the conversation's real From address

### DIFF
--- a/builtin-configs/integrations/outlook/config.json
+++ b/builtin-configs/integrations/outlook/config.json
@@ -16,7 +16,8 @@
       "Mail.Send",
       "Calendars.Read",
       "Calendars.ReadWrite",
-      "Contacts.Read"
+      "Contacts.Read",
+      "User.Read"
     ]
   },
   "operations": [

--- a/services/platform/app/components/ui/forms/input.tsx
+++ b/services/platform/app/components/ui/forms/input.tsx
@@ -51,6 +51,13 @@ type BaseProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> &
     isInvalid?: boolean;
     label?: string;
     description?: ReactNode;
+    /**
+     * A fixed, non-editable addon rendered INSIDE the field's border, right after
+     * the value (e.g. a locked email domain `@acme.com`). The value input is
+     * transparent and content-sized so the two read as one string, and the border
+     * + focus ring live on the wrapper. Not combined with `passwordToggle`.
+     */
+    suffix?: ReactNode;
     /** Optional hover/focus tooltip on the label (the deeper "why/format"). */
     labelInfo?: ReactNode;
     required?: boolean;
@@ -72,6 +79,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
       isInvalid,
       label,
       description,
+      suffix,
       labelInfo,
       required,
       wrapperClassName,
@@ -232,6 +240,73 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
               className="text-destructive flex items-center gap-1.5 text-sm"
             >
               <XCircle className="size-4" aria-hidden="true" />
+              {errorMessage}
+            </p>
+          )}
+          {description && (
+            <Description id={descriptionId}>{description}</Description>
+          )}
+        </div>
+      );
+    }
+
+    if (suffix) {
+      return (
+        <div className={cn('flex flex-col gap-1.5', wrapperClassName)}>
+          {label && (
+            <Label
+              htmlFor={id}
+              required={required}
+              error={hasError}
+              info={labelInfo}
+            >
+              {label}
+            </Label>
+          )}
+          {/* The border + focus ring live on the wrapper; the input is
+              transparent and content-sized so the value and the fixed suffix
+              read as one contiguous string. Clicking anywhere in the box
+              focuses the field — the inner input owns the semantics. */}
+          {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions -- focus-forwarding wrapper; the child input is the interactive control */}
+          <div
+            className={cn(
+              'flex h-9 w-full items-center rounded-lg border border-transparent bg-input px-3 py-2 text-base ring-1 ring-[color:var(--color-border-input)] ring-offset-background transition-[border-color,box-shadow] duration-150 focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2',
+              showInvalid && 'border-destructive focus-within:ring-destructive',
+              showShake && 'animate-shake',
+              className,
+            )}
+            onMouseDown={(e) => {
+              if (!(e.target instanceof HTMLInputElement)) {
+                e.preventDefault();
+                e.currentTarget.querySelector('input')?.focus();
+              }
+            }}
+          >
+            <input
+              id={id}
+              type={inputType}
+              {...sensitiveAttrs}
+              className="placeholder:text-muted-foreground [field-sizing:content] min-w-0 border-0 bg-transparent p-0 text-base outline-none focus-visible:ring-0 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              ref={ref}
+              required={required}
+              aria-invalid={showInvalid || undefined}
+              aria-describedby={describedBy}
+              aria-errormessage={hasError ? errorId : undefined}
+              {...props}
+              style={{ ...style, ...securityStyle }}
+            />
+            <span className="text-muted-foreground shrink-0 select-none">
+              {suffix}
+            </span>
+          </div>
+          {errorMessage && (
+            <p
+              id={errorId}
+              role="alert"
+              aria-live="polite"
+              className="text-destructive flex items-center gap-1.5 text-sm"
+            >
+              <Info className="size-4" aria-hidden="true" />
               {errorMessage}
             </p>
           )}

--- a/services/platform/app/features/conversations/components/compose-email-pane.tsx
+++ b/services/platform/app/features/conversations/components/compose-email-pane.tsx
@@ -52,6 +52,16 @@ const MessageEditor = lazyComponent(
   },
 );
 
+/**
+ * Build the full sender from an edited local part + the inbox's fixed domain.
+ * Strips anything from an '@' on (defends against a pasted full address); an
+ * empty local part yields '' so the sender falls back to the inbox default.
+ */
+function senderFromLocalPart(localPart: string, domain: string): string {
+  const clean = localPart.replace(/@.*/, '').trim();
+  return clean ? `${clean}@${domain}` : '';
+}
+
 export interface ComposeEmailPaneProps {
   organizationId: string;
   /** Seed the recipient (e.g. arriving from a contact row). */
@@ -183,6 +193,9 @@ export function ComposeEmailPane({
   // back cleanly without an effect that could clobber a restored override.
   const senderDefault = selectedIntegration?.fromAddress ?? '';
   const senderInputValue = senderAddress || senderDefault;
+  // Only the local part is editable; the domain is fixed to the inbox's and
+  // shown as a badge, so the address can never leave the verified domain.
+  const senderLocalPart = senderInputValue.replace(/@.*/, '');
   const effectiveSender = senderAddress.trim() || senderDefault;
   const dynamicSender = supportsDynamicSender(selectedIntegration);
   const senderDomain = senderDefault ? emailDomain(senderDefault) : '';
@@ -395,28 +408,27 @@ export function ComposeEmailPane({
                       <Input
                         label={t('compose.fromLabel')}
                         required
-                        type="email"
-                        value={senderInputValue}
+                        value={senderLocalPart}
                         onChange={(event) =>
-                          setSenderAddress(event.target.value)
+                          setSenderAddress(
+                            senderFromLocalPart(
+                              event.target.value,
+                              senderDomain,
+                            ),
+                          )
                         }
+                        suffix={`@${senderDomain}`}
                         description={t('compose.fromDomainHint', {
                           domain: senderDomain,
                         })}
-                        errorMessage={
-                          senderAddress.trim() !== '' && !senderValid
-                            ? t('compose.fromInvalid', { domain: senderDomain })
-                            : undefined
-                        }
-                        placeholder={`you@${senderDomain}`}
-                        aria-label={t('compose.fromLabel')}
+                        placeholder={t('compose.fromLocalPlaceholder')}
                       />
                     ) : (
                       <Text variant="muted">
                         {t('compose.from', {
-                          from:
-                            selectedIntegration.fromAddress ??
-                            selectedIntegration.title,
+                          from: selectedIntegration.fromAddress
+                            ? `${selectedIntegration.title} <${selectedIntegration.fromAddress}>`
+                            : selectedIntegration.title,
                         })}
                       </Text>
                     ))}

--- a/services/platform/app/features/conversations/components/conversation-header.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-header.test.tsx
@@ -30,6 +30,12 @@ vi.mock('./conversation-assignee-picker', () => ({
   ConversationAssigneePicker: () => null,
 }));
 
+// The From-source line reads email integrations via a Convex query; stub it so
+// the header renders without a live Convex client.
+vi.mock('../hooks/queries', () => ({
+  useEmailIntegrations: () => ({ emailIntegrations: [], isLoading: false }),
+}));
+
 vi.mock('../hooks/mutations', () => ({
   useCloseConversation: () => ({ mutate: vi.fn(), isPending: false }),
   useReopenConversation: () => ({ mutate: vi.fn(), isPending: false }),

--- a/services/platform/app/features/conversations/components/conversation-header.tsx
+++ b/services/platform/app/features/conversations/components/conversation-header.tsx
@@ -7,6 +7,7 @@ import { Text } from '@tale/ui/text';
 import {
   ArrowLeft,
   Ellipsis,
+  Mail,
   MessageSquare,
   MessageSquareOff,
   ShieldX,
@@ -14,6 +15,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
+import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { ContactInfoPopover } from '@/app/features/contacts/components/contact-info-popover';
 import {
   useContactById,
@@ -21,14 +23,20 @@ import {
 } from '@/app/features/contacts/hooks/queries';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { toast } from '@/app/hooks/use-toast';
+import {
+  inboundRecipientAddress,
+  resolveReplyFrom,
+} from '@/convex/conversations/reply_from';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
+import { isRecord } from '@/lib/utils/type-utils';
 
 import {
   useCloseConversation,
   useMarkAsSpam,
   useReopenConversation,
 } from '../hooks/mutations';
+import { useEmailIntegrations } from '../hooks/queries';
 import type { ConversationWithMessages } from '../types';
 import { ConversationAssigneePicker } from './conversation-assignee-picker';
 import { DotIcon } from './dot-icon';
@@ -54,6 +62,23 @@ export function ConversationHeader({
   const [isContactInfoOpen, setIsContactInfoOpen] = useState(false);
   const pendingContactInfo = useRef(false);
   const { formatRelative } = useFormatDate();
+
+  // The org's actual "From" on THIS thread — the address the contact wrote to
+  // (or the chosen compose sender, both captured in `metadata.to`), domain-
+  // guarded against the inbox default. Reuses the send path's reply-from logic
+  // so what's shown matches what a reply actually goes out as, not the
+  // mailbox's generic default. Falls back to the inbox default, then nothing.
+  const { emailIntegrations } = useEmailIntegrations(organizationId);
+  const inbox = conversation.integrationName
+    ? emailIntegrations.find((i) => i.slug === conversation.integrationName)
+    : undefined;
+  const inboundTo = inboundRecipientAddress(
+    isRecord(conversation.metadata) ? conversation.metadata : undefined,
+  );
+  const conversationFrom = inbox?.fromAddress
+    ? resolveReplyFrom(inboundTo, inbox.fromAddress)
+    : (inboundTo ?? inbox?.fromAddress);
+  const inboxLabel = inbox?.title;
 
   const { mutate: closeConversation, isPending: isClosing } =
     useCloseConversation();
@@ -290,6 +315,22 @@ export function ConversationHeader({
               <>
                 <DotIcon className="mx-0.5 shrink-0" />
                 <span>{lastMessageTime}</span>
+              </>
+            )}
+            {conversationFrom && (
+              <>
+                <DotIcon className="mx-0.5 shrink-0" />
+                <Tooltip content={inboxLabel ?? conversationFrom}>
+                  <span
+                    className="inline-flex min-w-0 items-center gap-1"
+                    aria-label={t('header.inboxSource', {
+                      inbox: conversationFrom,
+                    })}
+                  >
+                    <Mail className="size-3 shrink-0" aria-hidden="true" />
+                    <span className="truncate">{conversationFrom}</span>
+                  </span>
+                </Tooltip>
               </>
             )}
           </Row>

--- a/services/platform/convex/integrations/oauth2_token_exchange.ts
+++ b/services/platform/convex/integrations/oauth2_token_exchange.ts
@@ -47,6 +47,56 @@ interface TokenResponse {
   };
 }
 
+/**
+ * Best-effort fetch of the connected account's send address, so compose + the
+ * conversation header can show the exact From for OAuth mailboxes. Gmail's
+ * `users.getProfile` needs only the already-granted `gmail.readonly` scope;
+ * Outlook's `/me` needs `User.Read`. Returns null on any failure — the caller
+ * treats the address as optional and never fails the connection over it.
+ */
+async function fetchOAuthAccountEmail(
+  slug: string,
+  accessToken: string,
+): Promise<string | null> {
+  const init = {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(10_000),
+  };
+  try {
+    if (slug === 'gmail') {
+      const res = await fetch(
+        'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+        init,
+      );
+      if (!res.ok) {
+        console.warn(`[OAuth2] gmail profile fetch failed: ${res.status}`);
+        return null;
+      }
+      const body = await fetchJson<{ emailAddress?: string }>(res);
+      return typeof body.emailAddress === 'string' ? body.emailAddress : null;
+    }
+    if (slug === 'outlook') {
+      const res = await fetch('https://graph.microsoft.com/v1.0/me', init);
+      if (!res.ok) {
+        console.warn(`[OAuth2] outlook /me fetch failed: ${res.status}`);
+        return null;
+      }
+      const body = await fetchJson<{
+        mail?: string | null;
+        userPrincipalName?: string;
+      }>(res);
+      return body.mail ?? body.userPrincipalName ?? null;
+    }
+    return null;
+  } catch (error) {
+    console.warn(
+      `[OAuth2] account-email capture failed for ${slug} (non-fatal):`,
+      error,
+    );
+    return null;
+  }
+}
+
 export const handleOAuth2Callback = internalAction({
   args: {
     credentialId: v.id('integrationCredentials'),
@@ -198,6 +248,32 @@ export const handleOAuth2Callback = internalAction({
         errorMessage: undefined,
       },
     );
+
+    // Best-effort: capture the connected account's send address for OAuth
+    // mailboxes (gmail/outlook) so compose + the conversation header can show
+    // the exact From. Runs AFTER activation, so a failure here leaves a healthy
+    // connection — the address is optional and fills in on the next reconnect.
+    if (credential.slug === 'gmail' || credential.slug === 'outlook') {
+      const accountEmail = await fetchOAuthAccountEmail(
+        credential.slug,
+        tokens.access_token,
+      );
+      if (accountEmail) {
+        await ctx.runMutation(
+          internal.integrations.credential_mutations.updateCredentialsInternal,
+          {
+            credentialId: args.credentialId,
+            connectionConfig: {
+              ...credential.connectionConfig,
+              fromAddress: accountEmail,
+            },
+          },
+        );
+        debugLog(
+          `Captured ${credential.slug} account email for credential ${args.credentialId}`,
+        );
+      }
+    }
 
     debugLog(
       `OAuth2 token exchange successful for credential ${args.credentialId}`,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2088,7 +2088,7 @@
       "inboxPlaceholder": "Postfach auswählen",
       "fromLabel": "Absender",
       "fromDomainHint": "Beliebige Adresse unter {domain}",
-      "fromInvalid": "Gib eine Adresse unter {domain} ein",
+      "fromLocalPlaceholder": "support",
       "from": "Absender: {from}",
       "noEmailIntegration": "Verbinde eine E-Mail-Integration, um E-Mails zu senden.",
       "subject": "Betreff",
@@ -2151,6 +2151,7 @@
       "noMembers": "Keine Mitglieder gefunden",
       "unassign": "Zuweisung aufheben",
       "assignError": "Zuständigkeit konnte nicht aktualisiert werden",
+      "inboxSource": "Postfach: {inbox}",
       "toast": {
         "closed": "Konversation wurde geschlossen.",
         "closeFailed": "Beim Schließen der Konversation ist ein unerwarteter Fehler aufgetreten.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2088,7 +2088,7 @@
       "inboxPlaceholder": "Select an inbox",
       "fromLabel": "From",
       "fromDomainHint": "Any address at {domain}",
-      "fromInvalid": "Enter an address at {domain}",
+      "fromLocalPlaceholder": "support",
       "from": "From: {from}",
       "noEmailIntegration": "Connect an email integration to send email.",
       "subject": "Subject",
@@ -2151,6 +2151,7 @@
       "noMembers": "No members found",
       "unassign": "Unassign",
       "assignError": "Couldn't update the assignee",
+      "inboxSource": "Inbox: {inbox}",
       "toast": {
         "closed": "Conversation has been closed successfully.",
         "closeFailed": "An unexpected error occurred while closing the conversation.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2088,7 +2088,7 @@
       "inboxPlaceholder": "Sélectionne une boîte",
       "fromLabel": "Expéditeur",
       "fromDomainHint": "N'importe quelle adresse sur {domain}",
-      "fromInvalid": "Saisis une adresse sur {domain}",
+      "fromLocalPlaceholder": "support",
       "from": "Expéditeur : {from}",
       "noEmailIntegration": "Connecte une intégration e-mail pour envoyer des e-mails.",
       "subject": "Objet",
@@ -2151,6 +2151,7 @@
       "noMembers": "Aucun membre trouvé",
       "unassign": "Retirer l'attribution",
       "assignError": "Impossible de mettre à jour le responsable",
+      "inboxSource": "Boîte de réception : {inbox}",
       "toast": {
         "closed": "La conversation a été fermée avec succès.",
         "closeFailed": "Une erreur inattendue s'est produite lors de la fermeture de la conversation.",


### PR DESCRIPTION
## What

Show the actual send address of a conversation instead of a generic provider label, and let SMTP senders edit the local part of the From address.

- **OAuth mailboxes (Gmail/Outlook):** on connect, capture the connected account's email via the provider profile API and show it as `Provider <address>` in compose. Adds the Microsoft Graph `User.Read` scope required to read the Outlook address.
- **SMTP:** the compose From field edits **only** the local part; the verified domain is fixed and rendered as a badge, so the sender can never leave the verified domain.
- **Header:** shows the thread's true From — the address the contact wrote to, or the chosen compose sender — reusing the existing reply-from resolution so it matches what a reply actually sends as.
- **`Input`:** adds an optional `suffix` affix (used for the domain badge).

The account-email capture is **best-effort and non-fatal**: if the provider API is unreachable or unauthorized, the connection stays healthy and the From gracefully falls back to the provider name.

## Definition of done

- [x] **Green gate** — typecheck, oxfmt, oxlint all pass locally
- [x] **Security** — SAST clean; the profile fetch uses a bearer token with a 10s timeout and treats any non-OK response as "no address"
- [ ] **Tests** — N/A: best-effort capture (network) + UI; the header From reuses the already-tested `resolveReplyFrom`. Verified live instead (see Observed)
- [x] **Migration** — N/A: no data-model or config-schema change (an added scope value to an existing integration config)
- [x] **Locales** — `fromLocalPlaceholder` + `inboxSource` added to en/de/fr
- [x] **Docs** — N/A: refines an existing display; no new user-configurable surface
- [x] **Accessibility** — From field keeps its label; the header From has an `aria-label` and a tooltip
- [x] **Observed** — verified live: a reconnected Gmail mailbox now shows its exact address in compose (the fix that surfaced a disabled Gmail API on the customer's project)

## Note for operators

Existing **Outlook** connections must re-authorize once to grant the new `User.Read` scope before their address is captured; until then Outlook compose falls back to the provider name (no breakage).