### PR TITLE
docs: link live MDN Observatory scans in the hardening pages

### DIFF
--- a/docs/de/self-hosted/operate/security/hardening.md
+++ b/docs/de/self-hosted/operate/security/hardening.md
@@ -82,9 +82,17 @@ Jede HTML-Antwort trägt einen strengen Satz an Sicherheitsheadern, und der Satz
 Gegen die eigene Bereitstellung prüfen:
 
 - `curl -sI https://<dein-host>/ | grep -iE 'content-security|strict-transport|x-frame|x-content-type|referrer-policy|permissions-policy|cross-origin'`
-- Den Host auf [securityheaders.com](https://securityheaders.com) oder im [MDN HTTP Observatory](https://developer.mozilla.org/en-US/observatory) scannen.
+- Den Host auf [securityheaders.com](https://securityheaders.com) oder im [MDN HTTP Observatory](https://developer.mozilla.org/de/observatory) scannen.
 
-Cross-Origin-Isolation (COOP/CORP) ist auf der Plattform-App bewusst deaktiviert, weil sie OAuth-Anmelde-Popups öffnet und für Branding-Assets von einem zweiten Host erreichbar sein kann; die Content-Seiten, die keines von beidem tun, aktivieren sie. HSTS wird nur ausgegeben, wenn `SITE_URL` `https://` ist.
+<!--
+  The MDN Observatory UI is only localized in some languages. When adding a new
+  docs language, check whether developer.mozilla.org/<lang>/observatory exists
+  and fall back to the en-US analyze links if it does not.
+-->
+
+Die öffentliche Demo ist die Live-Referenz dafür, was eine korrekte Bereitstellung meldet: Der [Observatory-Scan von demo.tale.dev](https://developer.mozilla.org/de/observatory/analyze?host=demo.tale.dev) stand am 15.07.2026 bei A+ — Score 115/100, alle zehn Tests bestanden. Der einzige Header, der im Report als nicht implementiert steht — `Cross-Origin-Resource-Policy` — kostet keine Punkte und ist die bewusste Ausnahme direkt darunter.
+
+Cross-Origin-Isolation (COOP/CORP) bleibt auf der Plattform-App bewusst aus: `Cross-Origin-Opener-Policy: same-origin` würde die Fenster-Referenz kappen, über die ein OAuth-Anmelde-Popup die fertige Anmeldung an die App zurückmeldet, und `Cross-Origin-Resource-Policy` würde Branding-Assets blockieren, die von einem zweiten Host geladen werden. Die Content-Seiten, die beides nicht tun, aktivieren beide Header. HSTS wird nur ausgegeben, wenn `SITE_URL` `https://` ist.
 
 ## Wo das hingehört
 

--- a/docs/en/self-hosted/operate/security/hardening.md
+++ b/docs/en/self-hosted/operate/security/hardening.md
@@ -84,7 +84,15 @@ Verify it against your own deployment:
 - `curl -sI https://<your-host>/ | grep -iE 'content-security|strict-transport|x-frame|x-content-type|referrer-policy|permissions-policy|cross-origin'`
 - Scan the host on [securityheaders.com](https://securityheaders.com) or the [MDN HTTP Observatory](https://developer.mozilla.org/en-US/observatory).
 
-Cross-origin isolation (COOP/CORP) is deliberately left off on the platform app because it opens OAuth sign-in popups and can be reached from a second host for branding assets; the content sites, which do neither, enable it. HSTS is emitted only when `SITE_URL` is `https://`.
+<!--
+  The MDN Observatory UI is only localized in some languages. When adding a new
+  docs language, check whether developer.mozilla.org/<lang>/observatory exists
+  and fall back to the en-US analyze links if it does not.
+-->
+
+The public demo is the live reference for what a correct deployment reports: the [Observatory scan of demo.tale.dev](https://developer.mozilla.org/en-US/observatory/analyze?host=demo.tale.dev) came back A+ on 15 July 2026 — score 115/100, all ten tests passed. The one header the report lists as not implemented, `Cross-Origin-Resource-Policy`, costs no points; it is the deliberate exception described below.
+
+Cross-origin isolation (COOP/CORP) is deliberately left off on the platform app: `Cross-Origin-Opener-Policy: same-origin` would sever the live window handle an OAuth sign-in popup uses to hand the finished sign-in back to the app, and `Cross-Origin-Resource-Policy` would block branding assets loaded from a second host. The content sites, which do neither, enable both. HSTS is emitted only when `SITE_URL` is `https://`.
 
 ## Where this fits
 

--- a/docs/fr/self-hosted/operate/security/hardening.md
+++ b/docs/fr/self-hosted/operate/security/hardening.md
@@ -82,9 +82,17 @@ Chaque réponse HTML porte un ensemble strict d'en-têtes de sécurité, et cet 
 Vérifie-le sur ton propre déploiement :
 
 - `curl -sI https://<ton-hôte>/ | grep -iE 'content-security|strict-transport|x-frame|x-content-type|referrer-policy|permissions-policy|cross-origin'`
-- Analyse l'hôte sur [securityheaders.com](https://securityheaders.com) ou le [MDN HTTP Observatory](https://developer.mozilla.org/en-US/observatory).
+- Analyse l'hôte sur [securityheaders.com](https://securityheaders.com) ou le [MDN HTTP Observatory](https://developer.mozilla.org/fr/observatory).
 
-L'isolation cross-origin (COOP/CORP) est volontairement désactivée sur l'app de la plateforme parce qu'elle ouvre des popups de connexion OAuth et peut être atteinte depuis un second hôte pour les ressources de marque ; les sites de contenu, qui ne font ni l'un ni l'autre, l'activent. HSTS n'est émis que lorsque `SITE_URL` est `https://`.
+<!--
+  The MDN Observatory UI is only localized in some languages. When adding a new
+  docs language, check whether developer.mozilla.org/<lang>/observatory exists
+  and fall back to the en-US analyze links if it does not.
+-->
+
+La démo publique est la référence en direct de ce qu’un déploiement correct rapporte : le [scan Observatory de demo.tale.dev](https://developer.mozilla.org/fr/observatory/analyze?host=demo.tale.dev) affichait A+ le 15/07/2026 — score 115/100, dix tests sur dix réussis. Le seul en-tête que le rapport liste comme non implémenté, `Cross-Origin-Resource-Policy`, ne coûte aucun point ; c’est l’exception délibérée décrite juste en dessous.
+
+L’isolation cross-origin (COOP/CORP) reste volontairement désactivée sur l’app de la plateforme : `Cross-Origin-Opener-Policy: same-origin` couperait la référence de fenêtre par laquelle un popup de connexion OAuth renvoie l’authentification terminée à l’app, et `Cross-Origin-Resource-Policy` bloquerait les ressources de marque chargées depuis un second hôte. Les sites de contenu, qui ne font ni l’un ni l’autre, activent les deux. HSTS n’est émis que lorsque `SITE_URL` est `https://`.
 
 ## Où cela s'inscrit
 


### PR DESCRIPTION
## Summary

Verified Tale's live domains on the MDN HTTP Observatory (fresh API scans, 2026-07-15, algorithm v5) and linked the live scan into the hardening docs:

- `demo.tale.dev` — **A+ (115/100, 10/10 tests)**. The one header the report lists as not implemented is `Cross-Origin-Resource-Policy` at zero penalty — the documented platform exception (an OAuth sign-in popup needs a live window handle; branding assets load from a second host).
- `tale.dev` — B+ (80): the live deployment predates #2720 — it still serves `script-src 'self' 'unsafe-inline'` and no Permissions-Policy/COOP/CORP. At HEAD, `services/web` and `services/docs` pin inline scripts via `withScriptHashes` (`packages/ui/src/server/security-headers.ts`), so the next deploy resolves this; no repo change needed.
- `status.tale.dev` — B (75): the status page is hosted by OpenStatus (third party); the headers are theirs (`unsafe-inline` CSP, missing `X-Content-Type-Options` and `Referrer-Policy`). Not fixable from this repo, and outside the self-hosted trust boundary the hardening page covers.

Docs changes, `docs/{en,de,fr}/self-hosted/operate/security/hardening.md` (HTTP security headers section):

- Direct Observatory analyze links for the demo deployment, localized per docs language (`en-US`/`de`/`fr` MDN locales); the generic Observatory link in de/fr is localized too.
- Scan date + grade recorded: A+, score 115/100, all ten tests passed, 15 July 2026.
- The COOP/CORP paragraph now names what enabling those headers would break (severed OAuth popup window handle, blocked cross-host branding assets).
- An HTML comment for future authors: check `developer.mozilla.org/<lang>/observatory` exists before localizing the link for a new docs language, and fall back to `en-US` if it does not (the MDN Observatory UI is only localized in some languages).

## Verification

- Scans fetched via `POST /api/v2/scan` + `GET /api/v2/analyze` on `observatory-api.mdn.mozilla.net`; per-test results cross-checked against `curl -sI` response headers of each host.
- MDN `de` and `fr` Observatory URLs (including the analyze deep links) verified live, HTTP 200.
- `bun run --filter @tale/docs test` green (29 files, 189 tests — includes the locale parity/outline and i18n docs checks).
- `bun run --filter @tale/docs build` + `test:prerender` green (8/8); the prerendered HTML of all three pages carries the localized links, and the maintainer comment is stripped from the rendered output.

## Done checklist

- [x] Green gate — `@tale/docs` structural suite, build, prerender suite
- [x] Security gate — N/A: docs prose only, no code boundary touched
- [x] Tests — N/A: content change, carried by the docs structural suite
- [x] Migration — N/A: no data model or config schema touched
- [x] Locales — en/de/fr updated in the same change, de/fr authored natively (du/tu, NBSP + typographic apostrophes in FR)
- [x] Docs — this change is docs
- [x] Accessibility — N/A: prose and descriptive text links through the existing renderer
- [x] Sweep — the Observatory is referenced only in these three pages (repo-wide grep)
- [x] Observed — real API scans, live MDN URL checks, rendered dist HTML inspected
- [x] Commits — atomic, conventional, branched off latest main