### PR TITLE
fix(platform): verify S3 upload size server-side against the product cap (#2731)

### DIFF
--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -459,3 +459,79 @@ describe('ensureFileMetadataForDocument', () => {
     expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 });
+
+async function getApplyVerifiedBlobSizeHandler() {
+  const { applyVerifiedBlobSize } = await import('./internal_mutations');
+  return (applyVerifiedBlobSize as unknown as { handler: Function }).handler;
+}
+
+describe('applyVerifiedBlobSize (#2731 authoritative S3 upload size)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const CAP = 100 * 1024 * 1024;
+
+  it('corrects the stored size within the cap, leaving status untouched', async () => {
+    // Client declared 1 KB; the real object is 5 MB (still under the cap).
+    const existing = {
+      _id: 'fm1',
+      storageId: 's3:testorg/uuid',
+      size: 1024,
+      ragStatus: 'queued',
+    };
+    const { ctx } = createMockCtx(existing);
+    const handler = await getApplyVerifiedBlobSizeHandler();
+
+    await handler(ctx, {
+      storageId: 's3:testorg/uuid',
+      size: 5 * 1024 * 1024,
+      overCap: false,
+      limitBytes: CAP,
+    });
+
+    // usedBytes rides on fileMetadata.size, so it is now honest (5 MB, not 1 KB).
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm1', { size: 5 * 1024 * 1024 });
+  });
+
+  it('rejects an over-cap object: corrects size AND fails the row', async () => {
+    // Client declared 1 KB; the real object is 200 MB (over the 100 MB cap).
+    const existing = {
+      _id: 'fm1',
+      storageId: 's3:testorg/uuid',
+      size: 1024,
+      ragStatus: 'queued',
+    };
+    const { ctx } = createMockCtx(existing);
+    const handler = await getApplyVerifiedBlobSizeHandler();
+    const realSize = 200 * 1024 * 1024;
+
+    await handler(ctx, {
+      storageId: 's3:testorg/uuid',
+      size: realSize,
+      overCap: true,
+      limitBytes: CAP,
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      'fm1',
+      expect.objectContaining({ size: realSize, ragStatus: 'failed' }),
+    );
+    const patchArg = ctx.db.patch.mock.calls[0][1] as { ragError: string };
+    expect(patchArg.ragError).toContain('100 MB limit');
+  });
+
+  it('no-ops when the row is already gone', async () => {
+    const { ctx } = createMockCtx(null);
+    const handler = await getApplyVerifiedBlobSizeHandler();
+
+    await handler(ctx, {
+      storageId: 's3:testorg/uuid',
+      size: 1,
+      overCap: false,
+      limitBytes: CAP,
+    });
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -12,7 +12,11 @@ import {
   RateLimitExceededError,
   checkOrganizationRateLimit,
 } from '../lib/rate_limiter/helpers';
-import { blobRefValidator, convexStorageId } from '../lib/storage/blob_ref';
+import {
+  blobRefValidator,
+  convexStorageId,
+  isS3Ref,
+} from '../lib/storage/blob_ref';
 import { maybeDispatchRagIndexing, promoteQueuedRagJobs } from './rag_dispatch';
 import { sourceFromProvider } from './source_from_provider';
 
@@ -185,6 +189,19 @@ export const saveFileMetadata = internalMutation({
       },
     );
 
+    // An `s3:` blob was uploaded by a presigned PUT (no Content-Length gate),
+    // so verify its real size server-side and reject/correct past the cap.
+    if (isS3Ref(args.storageId)) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.files.blob_actions.verifyS3BlobSize,
+        {
+          storageId: String(args.storageId),
+          organizationId: args.organizationId,
+        },
+      );
+    }
+
     try {
       await checkOrganizationRateLimit(
         ctx,
@@ -272,6 +289,45 @@ export const updateFileRagStatus = internalMutation({
         });
       }
     }
+  },
+});
+
+/**
+ * Record the authoritative byte size of an `s3:`-backed blob (from a server
+ * HEAD), correcting the row that was created with the client-declared size — a
+ * presigned PUT enforces no Content-Length. When the real size is over the
+ * product cap, mark the row `ragStatus: 'failed'` with a size error so the user
+ * sees why (the blob itself is deleted by the caller). The corrected `size`
+ * flows into `computeUserUploadVolumeBytes` so volume accounting is honest;
+ * per the existing quota model a failed row counts until the user deletes it.
+ */
+export const applyVerifiedBlobSize = internalMutation({
+  args: {
+    storageId: blobRefValidator,
+    size: v.number(),
+    overCap: v.boolean(),
+    limitBytes: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const metadata = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
+      .first();
+    if (!metadata) return null;
+
+    const overCapPatch = args.overCap
+      ? {
+          ragStatus: 'failed' as const,
+          ragError: `File exceeds the ${Math.round(
+            args.limitBytes / (1024 * 1024),
+          )} MB limit`,
+          ragQueuedAt: undefined,
+          ragProgress: undefined,
+        }
+      : {};
+    await ctx.db.patch(metadata._id, { size: args.size, ...overCapPatch });
+    return null;
   },
 });
 

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -13,7 +13,7 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
-import { blobRefValidator } from '../lib/storage/blob_ref';
+import { blobRefValidator, isS3Ref } from '../lib/storage/blob_ref';
 import { maybeDispatchRagIndexing } from './rag_dispatch';
 
 export const saveFileMetadata = mutation({
@@ -252,6 +252,19 @@ export const saveFileMetadata = mutation({
         organizationId: args.organizationId,
       },
     );
+
+    // An `s3:` blob was uploaded by a presigned PUT (no Content-Length gate),
+    // so verify its real size server-side and reject/correct past the cap.
+    if (isS3Ref(args.storageId)) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.files.blob_actions.verifyS3BlobSize,
+        {
+          storageId: String(args.storageId),
+          organizationId: args.organizationId,
+        },
+      );
+    }
 
     try {
       await checkOrganizationRateLimit(

--- a/services/platform/convex/files/blob_actions.ts
+++ b/services/platform/convex/files/blob_actions.ts
@@ -13,6 +13,8 @@
 
 import { v } from 'convex/values';
 
+import { DOCUMENT_MAX_FILE_SIZE } from '../../lib/shared/file-types';
+import { internal } from '../_generated/api';
 import { action, internalAction } from '../_generated/server';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
@@ -21,8 +23,10 @@ import {
   deleteBlob,
   generateBlobUpload as generateBlobUploadHandoff,
   getBlobUrl,
+  isS3Ref,
   putBlob,
   readBlobBytes,
+  s3BlobSize,
 } from '../lib/storage/blob_access';
 
 export interface BlobUploadHandoff {
@@ -201,6 +205,66 @@ export const deleteOrgBlobs = internalAction({
           err: err instanceof Error ? err.message : String(err),
         });
       }
+    }
+    return null;
+  },
+});
+
+/**
+ * Verify an `s3:` upload's REAL size against the product cap and correct the
+ * row the binder created from the client-declared size. A presigned PUT
+ * enforces no Content-Length, so a member could declare 1 KB and PUT gigabytes,
+ * bypassing `DOCUMENT_MAX_FILE_SIZE` + the volume quota. Scheduled (best-effort)
+ * from the binders right after an `s3:` ref is bound. HEAD the object → write
+ * the authoritative size (so `computeUserUploadVolumeBytes` is honest); if it
+ * is over the cap, mark the row failed AND delete the oversize object from the
+ * org's bucket. No-op for Convex refs (their size is authoritative at bind) and
+ * for a missing object (never-uploaded / already-reclaimed).
+ */
+export const verifyS3BlobSize = internalAction({
+  args: {
+    storageId: v.string(),
+    organizationId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    if (!isS3Ref(args.storageId)) return null;
+    const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+    if (orgSlug === null) {
+      console.warn(
+        `[verifyS3BlobSize] org ${args.organizationId} unresolvable; cannot verify ${args.storageId}`,
+      );
+      return null;
+    }
+    let size: number | null;
+    try {
+      size = await s3BlobSize(orgSlug, args.storageId);
+    } catch (err) {
+      // A HEAD failure must not wedge the upload — log and leave the
+      // client-declared size in place (the upload policy already gated on it).
+      console.warn('[verifyS3BlobSize] HEAD failed', {
+        ref: args.storageId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+    if (size === null) return null;
+
+    const overCap = size > DOCUMENT_MAX_FILE_SIZE;
+    await ctx.runMutation(
+      internal.file_metadata.internal_mutations.applyVerifiedBlobSize,
+      {
+        storageId: args.storageId,
+        size,
+        overCap,
+        limitBytes: DOCUMENT_MAX_FILE_SIZE,
+      },
+    );
+    if (overCap) {
+      await deleteBlob(ctx, orgSlug, args.storageId);
+      console.warn(
+        `[verifyS3BlobSize] rejected oversize s3 upload ${args.storageId}: ${size} > ${DOCUMENT_MAX_FILE_SIZE} bytes; row failed, object deleted`,
+      );
     }
     return null;
   },

--- a/services/platform/convex/lib/storage/blob_access.ts
+++ b/services/platform/convex/lib/storage/blob_access.ts
@@ -37,6 +37,7 @@ import {
   resolveOrgObjectStore,
   s3DeleteObject,
   s3GetObjectBytes,
+  s3HeadObject,
   s3PresignGetUrl,
   s3PresignPutUrl,
   s3PutObject,
@@ -84,6 +85,24 @@ export async function readBlobBytes(
   }
   const store = await requireS3(orgSlug, parsed.key);
   return await s3GetObjectBytes(store, parsed.key);
+}
+
+/**
+ * The authoritative byte size of an S3-backed blob (a server HEAD), or `null`
+ * for a Convex ref (its size is authoritative at bind time via the `_storage`
+ * system row) or a missing object. Namespace-guarded via `requireS3`, so an
+ * org can only probe keys in its own namespace. Used to verify an `s3:` upload
+ * against the product cap — a presigned PUT enforces no Content-Length.
+ */
+export async function s3BlobSize(
+  orgSlug: string,
+  ref: BlobRef,
+): Promise<number | null> {
+  const parsed = parseBlobRef(ref);
+  if (parsed.backend !== 's3') return null;
+  const store = await requireS3(orgSlug, parsed.key);
+  const head = await s3HeadObject(store, parsed.key);
+  return head?.size ?? null;
 }
 
 /**

--- a/services/platform/convex/lib/storage/object_store.integration.test.ts
+++ b/services/platform/convex/lib/storage/object_store.integration.test.ts
@@ -24,6 +24,7 @@ import {
   resolveOrgObjectStore,
   s3DeleteObject,
   s3GetObjectBytes,
+  s3HeadObject,
   s3PresignGetUrl,
   s3PutObject,
   buildObjectKey,
@@ -120,6 +121,22 @@ describe.skipIf(!RUN)('per-org S3 object store (MinIO round-trip)', () => {
     // `<prefix?>/<orgSlug>/<uuid>` — with no prefix configured the key starts
     // at the org segment, so match `testorg/` at start OR after a prefix slash.
     expect(buildObjectKey(store, ORG)).toMatch(new RegExp(`(^|/)${ORG}/`));
+  });
+
+  it('HEAD reports the AUTHORITATIVE byte size (not any client claim)', async () => {
+    // The anti-spoof crux of #2731: a presigned PUT enforces no Content-Length,
+    // so the client-declared size can't be trusted — HEAD reads the real length
+    // the store recorded. A 3 MiB object HEADs as exactly 3 MiB regardless of
+    // what the uploader declared, so `size > DOCUMENT_MAX_FILE_SIZE` on THIS
+    // value is a truthful cap check.
+    const key = buildObjectKey(store, ORG);
+    const realSize = 3 * 1024 * 1024;
+    await s3PutObject(store, key, new Uint8Array(realSize), 'application/pdf');
+    const head = await s3HeadObject(store, key);
+    expect(head?.size).toBe(realSize);
+    await s3DeleteObject(store, key);
+    // A missing object HEADs as null (never-uploaded / already-reclaimed).
+    expect(await s3HeadObject(store, key)).toBeNull();
   });
 
   it('blob access refuses a key outside the org namespace (tenant isolation)', async () => {

--- a/services/platform/convex/lib/storage/object_store.ts
+++ b/services/platform/convex/lib/storage/object_store.ts
@@ -249,6 +249,31 @@ export async function s3GetObjectBytes(
   return new Uint8Array(await res.arrayBuffer());
 }
 
+/**
+ * HEAD an object → its size in bytes (the authoritative server-side length).
+ * Used to verify an `s3:` upload's real size against the product cap — a
+ * presigned PUT enforces no Content-Length, so the client-declared size can't
+ * be trusted. Returns `null` when the object is missing (404).
+ */
+export async function s3HeadObject(
+  store: S3ObjectStore,
+  key: string,
+): Promise<{ size: number } | null> {
+  const res = await store.client.fetch(objectUrl(store, key), {
+    method: 'HEAD',
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`S3 HEAD ${key} failed: ${res.status}`);
+  }
+  const len = res.headers.get('content-length');
+  const size = len === null ? NaN : Number(len);
+  if (!Number.isFinite(size)) {
+    throw new Error(`S3 HEAD ${key} returned no usable content-length`);
+  }
+  return { size };
+}
+
 /** DELETE an object. S3 DELETE is idempotent (204 whether or not it existed). */
 export async function s3DeleteObject(
   store: S3ObjectStore,


### PR DESCRIPTION
Closes #2731. A presigned S3 PUT enforces no Content-Length, so for a BYO-S3 org the cap + volume quota rode on the **client-declared** `fileSize` — a member could declare 1 KB and PUT gigabytes.

## Fix
- `s3HeadObject` (object_store) + a namespace-guarded `s3BlobSize` (blob_access) read the **authoritative** server-side length.
- `verifyS3BlobSize` (node action) is scheduled from the two **client-upload** binders (`saveFileMetadata` public + internal) for `s3:` refs only. It HEADs the object, writes the real size (so `computeUserUploadVolumeBytes` — which sums `fileMetadata.size` — is honest), and when over `DOCUMENT_MAX_FILE_SIZE` marks the row `ragStatus: failed` (with a size error) **and deletes the oversize object** from the org's bucket.
- No-op for Convex refs (size is authoritative at bind) and for server-side imports via `linkDocumentToFile` (the server controls the bytes). A HEAD failure is logged, never wedges the upload.

## Acceptance criteria
- [x] An S3 upload whose real size exceeds the cap is rejected server-side (row failed, object deleted) regardless of declared `fileSize`.
- [x] `usedBytes` reflects the authoritative object size (the row's `size` is corrected).
- [x] Regression tests: `s3HeadObject` byte-exactness + missing→null vs **real MinIO**; `applyVerifiedBlobSize` corrects-within-cap / fails-over-cap / no-ops.

Gates: typecheck 0 (fresh codegen) · lint 0 · touched suites green · SAST 0. Consistent with the existing quota model (failed rows count until the user deletes them).