### PR TITLE
fix(platform): make captioned-video transcripts retrievable by the agent

### DIFF
--- a/services/platform/convex/video_links/internal_mutations.ts
+++ b/services/platform/convex/video_links/internal_mutations.ts
@@ -277,7 +277,15 @@ export const insertSyntheticFileMetadata = internalMutation({
       transcriptionStatus: 'completed',
       transcriptionDurationSec: args.videoDurationSec,
       // RAG indexing happens via the scheduled uploadFileToRag below.
+      // Set BOTH statuses: `transcriptRagStatus` drives the composer chip
+      // (use-file-transcription-status.ts), while the CANONICAL `ragStatus` is
+      // what `pollFileRagStatus` advances and `document_retrieve` gates on. The
+      // audio path (transcribe_audio.ts) already writes both; the captions path
+      // must too, or the poller short-circuits on an undefined `ragStatus`
+      // (internal_actions.ts:117) and the agent can never retrieve the
+      // transcript ("still being indexed" forever), even though it is indexed.
       transcriptRagStatus: 'queued',
+      ragStatus: 'queued',
       // Provenance fields (sourceUrl/sourcePlatform/videoTitle/uploader/
       // duration) are NOT written here — `start_agent_chat.ts` JOINs
       // videoLinkJobs by storageId for live state.

--- a/services/platform/convex/video_links/synthetic_file_metadata.test.ts
+++ b/services/platform/convex/video_links/synthetic_file_metadata.test.ts
@@ -1,0 +1,98 @@
+// Regression: the captions-branch synthetic fileMetadata must carry the
+// CANONICAL `ragStatus`, not only the chip-facing `transcriptRagStatus`.
+// `pollFileRagStatus` short-circuits when `ragStatus` is undefined
+// (file_metadata/internal_actions.ts) and `document_retrieve` gates on
+// `ragStatus === 'completed'` — so omitting it left every captioned video
+// transcript permanently "still being indexed" to the agent even though the
+// transcript was indexed and searchable. The audio branch already writes both.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it, vi } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+// The synthetic-insert bail path (job erased) reaches a backend-aware blob
+// delete; the happy path here never hits it, but the module pulls the node
+// seam transitively, so stub it to keep the V8 test bundle clean.
+vi.mock('../lib/storage/blob_delete', () => ({
+  deleteBlobInMutation: vi.fn(async () => undefined),
+  deleteOrgBlobInMutation: vi.fn(async () => undefined),
+  scheduleS3BlobDeletes: vi.fn(async () => undefined),
+}));
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'video_links';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+type T = TestConvex<typeof schema>;
+
+const ORG = 'org_video_test';
+
+async function seedJob(t: T): Promise<Id<'videoLinkJobs'>> {
+  return t.run(async (ctx) =>
+    ctx.db.insert('videoLinkJobs', {
+      organizationId: ORG,
+      uploadedBy: 'user_1',
+      sourceUrl: 'https://www.youtube.com/watch?v=abc123',
+      sourceUrlHash: 'hash_abc123',
+      sourcePlatform: 'youtube',
+      pastedToken: 'https://www.youtube.com/watch?v=abc123',
+      status: 'indexing',
+      statusChangedAt: Date.now(),
+      lifecycleStatus: 'active',
+    }),
+  );
+}
+
+describe('insertSyntheticFileMetadata — captions branch RAG status', () => {
+  it('sets the canonical ragStatus (queued), not only transcriptRagStatus', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedJob(t);
+
+    await t.mutation(
+      internal.video_links.internal_mutations.insertSyntheticFileMetadata,
+      {
+        jobId,
+        storageId: 's3:org_video_test/00000000-0000-0000-0000-000000000000',
+        transcript: 'Hello world transcript.',
+        fileSize: 42,
+        videoTitle: 'Test Video',
+        videoDurationSec: 12,
+        sourceUrl: 'https://www.youtube.com/watch?v=abc123',
+        sourcePlatform: 'youtube',
+        transcriptSource: 'captions_human',
+        captionLang: 'en',
+        organizationId: ORG,
+        uploadedBy: 'user_1',
+      },
+    );
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query('fileMetadata')
+        .filter((q) => q.eq(q.field('organizationId'), ORG))
+        .first(),
+    );
+
+    expect(row).not.toBeNull();
+    // The fix: the retrieval gate reads ragStatus; it must be seeded so the
+    // poller advances it to 'completed'.
+    expect(row?.ragStatus).toBe('queued');
+    // And the chip-facing status stays set too.
+    expect(row?.transcriptRagStatus).toBe('queued');
+  });
+});


### PR DESCRIPTION
## What

The captions branch of YouTube/video ingestion never made its transcript retrievable by the chat agent.

`insertSyntheticFileMetadata` (the captions path) wrote only `transcriptRagStatus` — the field that drives the composer chip — and never the **canonical** `ragStatus`. But:

- `pollFileRagStatus` short-circuits when `ragStatus` is `undefined` (it treats that as "not RAG-queued"), so it never advances the row.
- `document_retrieve` gates on `ragStatus === 'completed'`.

So for any video with captions, the transcript was fetched, stored, and fully indexed into the knowledge DB — but the agent's `document_retrieve` gate never opened. It reported **"the transcript is still being indexed"** forever. The audio/Whisper branch (`transcribe_audio.ts`) already sets both statuses, so only the captions path was affected.

Fix: seed `ragStatus: 'queued'` alongside `transcriptRagStatus` in the synthetic row, so the poller advances it to `completed` and retrieval works.

## Verification
Reproduced and fixed live on a full local stack with a real OpenRouter provider:
- **Normal** video (captions) — transcript fetched verbatim; retrieval works after the fix.
- **Short** (`[Music]` captions) + **Gemma** — retrieved and correctly reported "music, no spoken words."
- **Audio-only** (no captions → Whisper) + **Qwen** — retrieved and quoted the lyrics.

Regression test `synthetic_file_metadata.test.ts` asserts the captions branch seeds the canonical `ragStatus`.

> Note: local/self-hosted video ingestion also needs the yt-dlp/ffmpeg toolchain wired into the Convex deployment env (`VIDEO_INGEST_BIN_DIR`, `VIDEO_INGEST_FFMPEG_LOCATION`) — production bakes the binaries into the image, but the dev orchestrator does not set these. That is a separate setup gap and will be tracked/fixed separately.
