### PR TITLE
fix(platform): stop pdfjs toBase64 shim poisoning JWE encrypt

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -808,6 +808,7 @@ import type * as lib_create_agent_config from "../lib/create_agent_config.js";
 import type * as lib_crypto_base64_to_bytes from "../lib/crypto/base64_to_bytes.js";
 import type * as lib_crypto_base64_url_to_buffer from "../lib/crypto/base64_url_to_buffer.js";
 import type * as lib_crypto_decrypt_string from "../lib/crypto/decrypt_string.js";
+import type * as lib_crypto_disarm_broken_to_base64_shim from "../lib/crypto/disarm_broken_to_base64_shim.js";
 import type * as lib_crypto_encrypt_string from "../lib/crypto/encrypt_string.js";
 import type * as lib_crypto_get_secret_key from "../lib/crypto/get_secret_key.js";
 import type * as lib_crypto_hex_to_bytes from "../lib/crypto/hex_to_bytes.js";
@@ -2578,6 +2579,7 @@ declare const fullApi: ApiFromModules<{
   "lib/crypto/base64_to_bytes": typeof lib_crypto_base64_to_bytes;
   "lib/crypto/base64_url_to_buffer": typeof lib_crypto_base64_url_to_buffer;
   "lib/crypto/decrypt_string": typeof lib_crypto_decrypt_string;
+  "lib/crypto/disarm_broken_to_base64_shim": typeof lib_crypto_disarm_broken_to_base64_shim;
   "lib/crypto/encrypt_string": typeof lib_crypto_encrypt_string;
   "lib/crypto/get_secret_key": typeof lib_crypto_get_secret_key;
   "lib/crypto/hex_to_bytes": typeof lib_crypto_hex_to_bytes;

--- a/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.test.ts
+++ b/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.test.ts
@@ -5,6 +5,7 @@ import { disarmBrokenToBase64Shim } from './disarm_broken_to_base64_shim';
 
 describe('disarmBrokenToBase64Shim', () => {
   it('removes an options-blind toBase64 so jose emits base64url JWE', async () => {
+    // oxlint-disable-next-line no-extend-native -- test installs a deliberate poison shim
     Object.defineProperty(Uint8Array.prototype, 'toBase64', {
       value: function (this: Uint8Array) {
         return Buffer.from(
@@ -28,6 +29,7 @@ describe('disarmBrokenToBase64Shim', () => {
   });
 
   it('leaves a correct toBase64 alone', () => {
+    // oxlint-disable-next-line no-extend-native -- test installs a correct options-aware shim
     Object.defineProperty(Uint8Array.prototype, 'toBase64', {
       value: function (
         this: Uint8Array,

--- a/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.test.ts
+++ b/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.test.ts
@@ -1,0 +1,53 @@
+import { CompactEncrypt } from 'jose';
+import { describe, expect, it } from 'vitest';
+
+import { disarmBrokenToBase64Shim } from './disarm_broken_to_base64_shim';
+
+describe('disarmBrokenToBase64Shim', () => {
+  it('removes an options-blind toBase64 so jose emits base64url JWE', async () => {
+    Object.defineProperty(Uint8Array.prototype, 'toBase64', {
+      value: function (this: Uint8Array) {
+        return Buffer.from(
+          this.buffer,
+          this.byteOffset,
+          this.byteLength,
+        ).toString('base64');
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    disarmBrokenToBase64Shim();
+    expect(typeof Uint8Array.prototype.toBase64).toBe('undefined');
+
+    const key = new Uint8Array(32).fill(3);
+    const jwe = await new CompactEncrypt(new TextEncoder().encode('tok'))
+      .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+      .encrypt(key);
+    expect(jwe).not.toMatch(/[+=/]/);
+  });
+
+  it('leaves a correct toBase64 alone', () => {
+    Object.defineProperty(Uint8Array.prototype, 'toBase64', {
+      value: function (
+        this: Uint8Array,
+        options?: { alphabet?: 'base64' | 'base64url'; omitPadding?: boolean },
+      ) {
+        const encoding =
+          options?.alphabet === 'base64url' ? 'base64url' : 'base64';
+        let out = Buffer.from(
+          this.buffer,
+          this.byteOffset,
+          this.byteLength,
+        ).toString(encoding);
+        if (options?.omitPadding) out = out.replace(/=+$/, '');
+        return out;
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    disarmBrokenToBase64Shim();
+    expect(typeof Uint8Array.prototype.toBase64).toBe('function');
+  });
+});

--- a/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.ts
+++ b/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.ts
@@ -1,0 +1,26 @@
+/**
+ * jose 6 prefers `Uint8Array.prototype.toBase64` when present and passes
+ * `{ alphabet: 'base64url', omitPadding: true }`. A process-global shim that
+ * ignores those options (the pdfjs Node polyfill regression) makes
+ * CompactEncrypt emit std-base64 JWE that compactDecrypt rejects.
+ *
+ * Drop a broken shim so jose falls back to encodeBase64 + url rewrite.
+ * Correct native / options-aware shims are left alone.
+ */
+export function disarmBrokenToBase64Shim(): void {
+  if (typeof Uint8Array.prototype.toBase64 !== 'function') return;
+  try {
+    const probe = new Uint8Array([0xff, 0xfe, 0xfd, 0x00, 0x01]);
+    const out = (
+      Uint8Array.prototype.toBase64 as (options?: {
+        alphabet?: 'base64' | 'base64url';
+        omitPadding?: boolean;
+      }) => string
+    ).call(probe, { alphabet: 'base64url', omitPadding: true });
+    if (!/[+=/]/.test(out)) return;
+  } catch {
+    // Treat a throwing shim as broken too.
+  }
+  // oxlint-disable-next-line no-extend-native -- removing a poison prototype shim so jose can use its safe fallback
+  Reflect.deleteProperty(Uint8Array.prototype, 'toBase64');
+}

--- a/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.ts
+++ b/services/platform/convex/lib/crypto/disarm_broken_to_base64_shim.ts
@@ -8,16 +8,14 @@
  * Correct native / options-aware shims are left alone.
  */
 export function disarmBrokenToBase64Shim(): void {
-  if (typeof Uint8Array.prototype.toBase64 !== 'function') return;
+  const toBase64 = Reflect.get(Uint8Array.prototype, 'toBase64');
+  if (typeof toBase64 !== 'function') return;
   try {
     const probe = new Uint8Array([0xff, 0xfe, 0xfd, 0x00, 0x01]);
-    const out = (
-      Uint8Array.prototype.toBase64 as (options?: {
-        alphabet?: 'base64' | 'base64url';
-        omitPadding?: boolean;
-      }) => string
-    ).call(probe, { alphabet: 'base64url', omitPadding: true });
-    if (!/[+=/]/.test(out)) return;
+    const out = Reflect.apply(toBase64, probe, [
+      { alphabet: 'base64url', omitPadding: true },
+    ]);
+    if (typeof out === 'string' && !/[+=/]/.test(out)) return;
   } catch {
     // Treat a throwing shim as broken too.
   }

--- a/services/platform/convex/lib/crypto/encrypt_string.ts
+++ b/services/platform/convex/lib/crypto/encrypt_string.ts
@@ -1,5 +1,6 @@
 import { CompactEncrypt } from 'jose';
 
+import { disarmBrokenToBase64Shim } from './disarm_broken_to_base64_shim';
 import { getSecretKey } from './get_secret_key';
 
 /**
@@ -8,11 +9,11 @@ import { getSecretKey } from './get_secret_key';
 export async function encryptString(plaintext: string): Promise<string> {
   if (!plaintext) throw new Error('Cannot encrypt empty or null data');
 
+  disarmBrokenToBase64Shim();
+
   const secret = getSecretKey();
   const encoder = new TextEncoder();
-  const jwe = await new CompactEncrypt(encoder.encode(plaintext))
+  return await new CompactEncrypt(encoder.encode(plaintext))
     .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
     .encrypt(secret);
-
-  return jwe; // compact JWE string
 }

--- a/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.test.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.test.ts
@@ -7,6 +7,7 @@ const PROBE = new Uint8Array([0xff, 0xfe, 0xfd, 0x00, 0x01]);
 
 /** The options-blind shim that poisoned Convex Node workers after #2414. */
 function installBrokenToBase64Shim(): void {
+  // oxlint-disable-next-line no-extend-native -- test installs a deliberate poison shim
   Object.defineProperty(Uint8Array.prototype, 'toBase64', {
     value: function (this: Uint8Array) {
       return Buffer.from(

--- a/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.test.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.test.ts
@@ -1,0 +1,62 @@
+import { CompactEncrypt, compactDecrypt } from 'jose';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { installPdfjsDomGlobals } from './pdfjs_dom_polyfill';
+
+const PROBE = new Uint8Array([0xff, 0xfe, 0xfd, 0x00, 0x01]);
+
+/** The options-blind shim that poisoned Convex Node workers after #2414. */
+function installBrokenToBase64Shim(): void {
+  Object.defineProperty(Uint8Array.prototype, 'toBase64', {
+    value: function (this: Uint8Array) {
+      return Buffer.from(
+        this.buffer,
+        this.byteOffset,
+        this.byteLength,
+      ).toString('base64');
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  // Leave a correct shim (or native) so later suites aren't poisoned.
+  installPdfjsDomGlobals();
+});
+
+describe('installPdfjsDomGlobals base64 codecs', () => {
+  it('honors alphabet: base64url and omitPadding', () => {
+    installBrokenToBase64Shim();
+    expect(
+      PROBE.toBase64({ alphabet: 'base64url', omitPadding: true }),
+    ).toMatch(/[+=/]/);
+
+    installPdfjsDomGlobals();
+
+    const url = PROBE.toBase64({ alphabet: 'base64url', omitPadding: true });
+    expect(url).not.toMatch(/[+=/]/);
+    expect(url).toBe(Buffer.from(PROBE).toString('base64url'));
+
+    const std = PROBE.toBase64({ alphabet: 'base64' });
+    expect(std).toBe(Buffer.from(PROBE).toString('base64'));
+  });
+
+  it('replaces a poison toBase64 so jose CompactEncrypt stays base64url', async () => {
+    installBrokenToBase64Shim();
+    installPdfjsDomGlobals();
+
+    const key = new Uint8Array(32).fill(7);
+    const jwe = await new CompactEncrypt(
+      new TextEncoder().encode('integration-secret'),
+    )
+      .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+      .encrypt(key);
+
+    expect(jwe).not.toMatch(/[+=/]/);
+    expect(jwe.split('.')[0]?.length).toBe(39);
+
+    const { plaintext } = await compactDecrypt(jwe, key);
+    expect(new TextDecoder().decode(plaintext)).toBe('integration-secret');
+  });
+});

--- a/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
@@ -298,13 +298,14 @@ function fromBase64Shim(
 }
 
 function toBase64IgnoresBase64urlAlphabet(): boolean {
-  if (typeof Uint8Array.prototype.toBase64 !== 'function') return false;
+  const toBase64 = Reflect.get(Uint8Array.prototype, 'toBase64');
+  if (typeof toBase64 !== 'function') return false;
   try {
     const probe = new Uint8Array([0xff, 0xfe, 0xfd, 0x00, 0x01]);
-    const out = (
-      Uint8Array.prototype.toBase64 as (options?: ToBase64Options) => string
-    ).call(probe, { alphabet: 'base64url', omitPadding: true });
-    return /[+=/]/.test(out);
+    const out = Reflect.apply(toBase64, probe, [
+      { alphabet: 'base64url', omitPadding: true },
+    ]);
+    return typeof out !== 'string' || /[+=/]/.test(out);
   } catch {
     return true;
   }

--- a/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
@@ -257,24 +257,60 @@ class Path2DPolyfill {
 
 let installed = false;
 
-/**
- * Idempotently install the globals pdfjs needs, BEFORE pdfjs is imported.
- * Only fills gaps so a real browser/runtime global (or @napi-rs/canvas, if it
- * ever does load) still wins.
- *
- * Besides the DOM globals, pdfjs 5.x's modern build calls ES2025 APIs
- * unconditionally — `Promise.try` in its message handler, the `Uint8Array`
- * base64 codecs on font/signature paths — which Node 22 (V8 12.4) doesn't
- * ship. Fill those too; removable once the runtime moves to Node ≥24.
- */
-export function installPdfjsDomGlobals(): void {
-  if (installed) return;
-  installed = true;
-  const g = globalThis as Record<string, unknown>;
-  g.DOMMatrix ??= DOMMatrixPolyfill;
-  g.ImageData ??= ImageDataPolyfill;
-  g.Path2D ??= Path2DPolyfill;
+type Base64Alphabet = 'base64' | 'base64url';
 
+type ToBase64Options = {
+  alphabet?: Base64Alphabet;
+  omitPadding?: boolean;
+};
+
+type FromBase64Options = {
+  alphabet?: Base64Alphabet;
+};
+
+/**
+ * ES2025 `Uint8Array` base64 codecs — Node 22 lacks them; pdfjs 5.x calls them
+ * unconditionally. jose's CompactEncrypt also prefers `toBase64` when present
+ * and passes `{ alphabet: 'base64url', omitPadding: true }`. A shim that
+ * ignores those options poisons every later encrypt in the same Node worker
+ * (integration credentials, OAuth tokens, …) with std-base64 JWE that
+ * `compactDecrypt` rejects.
+ */
+function toBase64Shim(this: Uint8Array, options?: ToBase64Options): string {
+  const encoding: BufferEncoding =
+    options?.alphabet === 'base64url' ? 'base64url' : 'base64';
+  let out = Buffer.from(this.buffer, this.byteOffset, this.byteLength).toString(
+    encoding,
+  );
+  // Node's `base64url` codec already omits padding; std `base64` does not.
+  if (options?.omitPadding) out = out.replace(/=+$/, '');
+  return out;
+}
+
+function fromBase64Shim(
+  base64: string,
+  options?: FromBase64Options,
+): Uint8Array {
+  const encoding: BufferEncoding =
+    options?.alphabet === 'base64url' ? 'base64url' : 'base64';
+  // Copy the Buffer view — never wrap buf.buffer (shared allocation pool).
+  return new Uint8Array(Buffer.from(base64, encoding));
+}
+
+function toBase64IgnoresBase64urlAlphabet(): boolean {
+  if (typeof Uint8Array.prototype.toBase64 !== 'function') return false;
+  try {
+    const probe = new Uint8Array([0xff, 0xfe, 0xfd, 0x00, 0x01]);
+    const out = (
+      Uint8Array.prototype.toBase64 as (options?: ToBase64Options) => string
+    ).call(probe, { alphabet: 'base64url', omitPadding: true });
+    return /[+=/]/.test(out);
+  } catch {
+    return true;
+  }
+}
+
+function ensureEs2025Shims(): void {
   // The lib.esnext types declare these, so `typeof` guards compile cleanly;
   // Object.defineProperty sidesteps matching the full declared signatures
   // (options bags, overloads) that the simple fills don't implement.
@@ -286,30 +322,62 @@ export function installPdfjsDomGlobals(): void {
       configurable: true,
     });
   }
-  if (typeof Uint8Array.fromBase64 !== 'function') {
+
+  // Install when missing, or replace a process-global poison shim that
+  // ignores `alphabet` (regression: always-`base64` loop). Native Node ≥24
+  // / Bun implementations honor options and win the probe below.
+  const needBase64Codecs =
+    typeof Uint8Array.fromBase64 !== 'function' ||
+    typeof Uint8Array.prototype.toBase64 !== 'function' ||
+    toBase64IgnoresBase64urlAlphabet();
+  if (needBase64Codecs) {
     Object.defineProperty(Uint8Array, 'fromBase64', {
-      value: (s: string) => new Uint8Array(Buffer.from(s, 'base64')),
+      value: fromBase64Shim,
+      writable: true,
+      configurable: true,
+    });
+    // oxlint-disable-next-line no-extend-native -- deliberate spec-shaped polyfill of an ES2025 method Node 22 lacks; guarded so a correct native implementation wins
+    Object.defineProperty(Uint8Array.prototype, 'toBase64', {
+      value: toBase64Shim,
       writable: true,
       configurable: true,
     });
   }
-  for (const [name, encoding] of [
-    ['toBase64', 'base64'],
-    ['toHex', 'hex'],
-  ] as const) {
-    if (typeof Uint8Array.prototype[name] !== 'function') {
-      // oxlint-disable-next-line no-extend-native -- deliberate spec-shaped polyfill of an ES2025 method Node 22 lacks; guarded so a real runtime implementation wins
-      Object.defineProperty(Uint8Array.prototype, name, {
-        value: function (this: Uint8Array) {
-          return Buffer.from(
-            this.buffer,
-            this.byteOffset,
-            this.byteLength,
-          ).toString(encoding);
-        },
-        writable: true,
-        configurable: true,
-      });
-    }
+  if (typeof Uint8Array.prototype.toHex !== 'function') {
+    // oxlint-disable-next-line no-extend-native -- deliberate spec-shaped polyfill of an ES2025 method Node 22 lacks; guarded so a real runtime implementation wins
+    Object.defineProperty(Uint8Array.prototype, 'toHex', {
+      value: function (this: Uint8Array) {
+        return Buffer.from(
+          this.buffer,
+          this.byteOffset,
+          this.byteLength,
+        ).toString('hex');
+      },
+      writable: true,
+      configurable: true,
+    });
   }
+}
+
+/**
+ * Idempotently install the globals pdfjs needs, BEFORE pdfjs is imported.
+ * Only fills gaps so a real browser/runtime global (or @napi-rs/canvas, if it
+ * ever does load) still wins.
+ *
+ * Besides the DOM globals, pdfjs 5.x's modern build calls ES2025 APIs
+ * unconditionally — `Promise.try` in its message handler, the `Uint8Array`
+ * base64 codecs on font/signature paths — which Node 22 (V8 12.4) doesn't
+ * ship. Fill those too; removable once the runtime moves to Node ≥24.
+ *
+ * ES2025 shims re-run on every call so a hot reload can replace a previously
+ * installed options-blind `toBase64` without restarting the Node worker.
+ */
+export function installPdfjsDomGlobals(): void {
+  ensureEs2025Shims();
+  if (installed) return;
+  installed = true;
+  const g = globalThis as Record<string, unknown>;
+  g.DOMMatrix ??= DOMMatrixPolyfill;
+  g.ImageData ??= ImageDataPolyfill;
+  g.Path2D ??= Path2DPolyfill;
 }


### PR DESCRIPTION
## Summary
- Restore options-aware `Uint8Array.prototype.toBase64` / `fromBase64` in the Node pdfjs DOM polyfill (it had ignored `alphabet: 'base64url'`, so jose `CompactEncrypt` wrote std-base64 JWEs).
- Disarm a broken process-global `toBase64` shim before `encryptString` so integration Connect / credential saves stay decryptable even on a poisoned Convex Node worker.
- Add regression tests for the polyfill and the disarm helper.

## Test plan
- [x] `bun run --filter @tale/platform test -- pdfjs_dom_polyfill.test.ts disarm_broken_to_base64_shim.test.ts pdf.test.ts`
- [x] UI: Settings → Integrations → GitHub Disconnect → Connect with PAT → Connection successful; stored `keyEncrypted` is base64url and decrypts
- [ ] CI green on this PR

## Definition of done
- [x] Tests — polyfill + disarm regressions
- [x] Observed — UI Connect write path verified
- [ ] Green gate — full `bun run check` not re-run on this push; targeted tests passed
- N/A Migration / Locales / Docs / Accessibility — crypto/polyfill only, no user-facing strings or schema