### PR TITLE
fix(platform): BYO knowledge DB — vector-only degradation + resumable large-document indexing

### DIFF
--- a/services/platform/app/features/documents/components/document-preview-markdown.tsx
+++ b/services/platform/app/features/documents/components/document-preview-markdown.tsx
@@ -16,7 +16,9 @@ interface DocumentPreviewMarkdownProps {
 
 export function DocumentPreviewMarkdown({ url }: DocumentPreviewMarkdownProps) {
   const { t } = useT('documents');
-  const { data: content, isLoading, error } = useTextPreview(url);
+  const { data, isLoading, error } = useTextPreview(url);
+  const content = data?.text;
+  const truncated = data?.truncated ?? false;
 
   return (
     <PreviewPane>
@@ -30,6 +32,16 @@ export function DocumentPreviewMarkdown({ url }: DocumentPreviewMarkdownProps) {
       {!isLoading && error && (
         <Text as="div" variant="error" align="center" className="mt-4">
           {t('preview.failedToLoad')}
+        </Text>
+      )}
+      {!isLoading && !error && truncated && (
+        <Text
+          as="div"
+          variant="muted"
+          align="center"
+          className="mx-auto mb-3 w-full max-w-3xl"
+        >
+          {t('preview.truncatedNotice')}
         </Text>
       )}
       {!isLoading && !error && content !== null && content !== undefined && (

--- a/services/platform/app/features/documents/components/document-preview-text.tsx
+++ b/services/platform/app/features/documents/components/document-preview-text.tsx
@@ -14,7 +14,10 @@ import {
   getTextFileCategory,
 } from '@/lib/utils/text-file-types';
 
-import { useTextPreview } from '../hooks/use-document-preview';
+import {
+  TEXT_PREVIEW_HIGHLIGHT_MAX_CHARS,
+  useTextPreview,
+} from '../hooks/use-document-preview';
 import { PreviewPane } from './preview-pane';
 
 interface DocumentPreviewTextProps {
@@ -28,7 +31,9 @@ export function DocumentPreviewText({
 }: DocumentPreviewTextProps) {
   const { t } = useT('documents');
   const { resolvedTheme } = useTheme();
-  const { data: content, isLoading, error } = useTextPreview(url);
+  const { data, isLoading, error } = useTextPreview(url);
+  const content = data?.text;
+  const truncated = data?.truncated ?? false;
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null);
 
   const ext = getFileExtensionLower(fileName || '');
@@ -43,6 +48,8 @@ export function DocumentPreviewText({
   useEffect(() => {
     setHighlightedHtml(null);
     if (!content || !isCodeFile || !ext) return undefined;
+    // Tokenizing a huge buffer hangs the tab — plain text beats a frozen page.
+    if (content.length > TEXT_PREVIEW_HIGHLIGHT_MAX_CHARS) return undefined;
 
     let cancelled = false;
     const lang = resolveLanguage(ext);
@@ -73,6 +80,16 @@ export function DocumentPreviewText({
       {!isLoading && error && (
         <Text as="div" variant="error" align="center" className="mt-4">
           {t('preview.failedToLoad')}
+        </Text>
+      )}
+      {!isLoading && !error && truncated && (
+        <Text
+          as="div"
+          variant="muted"
+          align="center"
+          className="mx-auto mb-3 w-full max-w-4xl"
+        >
+          {t('preview.truncatedNotice')}
         </Text>
       )}
       {!isLoading &&

--- a/services/platform/app/features/documents/hooks/use-document-preview.test.ts
+++ b/services/platform/app/features/documents/hooks/use-document-preview.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decodeWithEncoding,
+  readBodyCapped,
+  TEXT_PREVIEW_MAX_BYTES,
+} from './use-document-preview';
+
+/**
+ * Regression guards for large-file text previews: the preview used to download
+ * the ENTIRE file and render it in one block — a 96 MB text document froze the
+ * tab. `readBodyCapped` must stop reading (and cancel the stream) once the cap
+ * is crossed, and `decodeWithEncoding` must not mis-detect a UTF-8 file as
+ * ISO-8859-1 just because the byte cap chopped a multibyte character.
+ */
+
+function streamResponse(chunks: Uint8Array[]): Response {
+  let i = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i]);
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+  return new Response(body);
+}
+
+describe('readBodyCapped', () => {
+  it('reads a small body fully without marking it truncated', async () => {
+    const payload = new TextEncoder().encode('hello world');
+    const { bytes, truncated } = await readBodyCapped(
+      streamResponse([payload]),
+      TEXT_PREVIEW_MAX_BYTES,
+    );
+    expect(truncated).toBe(false);
+    expect(new TextDecoder().decode(bytes)).toBe('hello world');
+  });
+
+  it('stops at the cap and cancels the rest of a large body', async () => {
+    const chunk = new Uint8Array(512 * 1024).fill(65); // 'A'
+    const res = streamResponse([chunk, chunk, chunk, chunk]); // 2 MiB total
+    const { bytes, truncated } = await readBodyCapped(
+      res,
+      TEXT_PREVIEW_MAX_BYTES,
+    );
+    expect(truncated).toBe(true);
+    expect(bytes.byteLength).toBe(TEXT_PREVIEW_MAX_BYTES);
+  });
+
+  it('is exact at the boundary: a body of exactly the cap is not truncated', async () => {
+    const chunk = new Uint8Array(TEXT_PREVIEW_MAX_BYTES).fill(66);
+    const { bytes, truncated } = await readBodyCapped(
+      streamResponse([chunk]),
+      TEXT_PREVIEW_MAX_BYTES,
+    );
+    expect(truncated).toBe(false);
+    expect(bytes.byteLength).toBe(TEXT_PREVIEW_MAX_BYTES);
+  });
+});
+
+describe('decodeWithEncoding with a chopped multibyte tail', () => {
+  it('still detects UTF-8 when truncation split a character', () => {
+    // 'ä€' = C3 A4 E2 82 AC — cut inside the euro sign (drop the last byte).
+    const full = new TextEncoder().encode('Bestellung ä€');
+    const chopped = full.subarray(0, full.byteLength - 1);
+
+    const { text, encoding } = decodeWithEncoding(chopped, true);
+
+    expect(encoding).toBe('utf-8');
+    expect(text).toBe('Bestellung ä');
+    expect(text.includes('�')).toBe(false);
+  });
+
+  it('decodes an untruncated buffer exactly as before', () => {
+    const bytes = new TextEncoder().encode('plain ascii');
+    const { text, encoding } = decodeWithEncoding(bytes);
+    expect(encoding).toBe('utf-8');
+    expect(text).toBe('plain ascii');
+  });
+});

--- a/services/platform/app/features/documents/hooks/use-document-preview.ts
+++ b/services/platform/app/features/documents/hooks/use-document-preview.ts
@@ -57,37 +57,121 @@ export function useXlsxPreview(url: string) {
   });
 }
 
-function decodeWithEncoding(buffer: ArrayBuffer): {
+const STRICT_ENCODINGS = ['utf-8', 'utf-16le', 'utf-16be'] as const;
+
+export function decodeWithEncoding(
+  buffer: ArrayBuffer | Uint8Array,
+  truncated = false,
+): {
   text: string;
   encoding: string;
 } {
-  const STRICT_ENCODINGS = ['utf-8', 'utf-16le', 'utf-16be'] as const;
-
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  // A byte-capped read can chop a multibyte sequence mid-character, which
+  // would fail the strict decoders and mis-detect the file's encoding \u2014 trim
+  // up to 3 trailing bytes to land back on a character boundary. Each encoding
+  // exhausts its trim attempts before the next is tried: an even-length
+  // chopped UTF-8 buffer is structurally valid UTF-16LE, so interleaving the
+  // encodings per trim level would return UTF-16 mojibake instead of the
+  // one-byte-trimmed UTF-8 text.
+  const maxTrim = truncated ? Math.min(3, bytes.byteLength) : 0;
   for (const encoding of STRICT_ENCODINGS) {
-    try {
-      const decoder = new TextDecoder(encoding, { fatal: true });
-      const text = decoder.decode(buffer);
-      if (text.length > 0 && !text.includes('\uFFFD')) {
-        return { text, encoding };
+    for (let trim = 0; trim <= maxTrim; trim += 1) {
+      const candidate =
+        trim === 0 ? bytes : bytes.subarray(0, bytes.byteLength - trim);
+      try {
+        const decoder = new TextDecoder(encoding, { fatal: true });
+        const text = decoder.decode(candidate);
+        if (text.length > 0 && !text.includes('\uFFFD')) {
+          return { text, encoding };
+        }
+      } catch {
+        continue;
       }
-    } catch {
-      continue;
     }
   }
 
   const decoder = new TextDecoder('iso-8859-1');
-  return { text: decoder.decode(buffer), encoding: 'iso-8859-1' };
+  return { text: decoder.decode(bytes), encoding: 'iso-8859-1' };
+}
+
+/**
+ * Byte cap for text/markdown previews. The preview used to download the WHOLE
+ * file and render it into one `<pre>`/markdown tree \u2014 a 96 MB text document
+ * froze the tab (100M-char text node layout; syntax highlighting far worse).
+ * The capped stream reads at most this many bytes and cancels the rest; the
+ * pane shows a "download for the full contents" notice instead.
+ */
+export const TEXT_PREVIEW_MAX_BYTES = 1024 * 1024;
+
+/** Above this many characters, skip syntax highlighting (tokenizing hangs). */
+export const TEXT_PREVIEW_HIGHLIGHT_MAX_CHARS = 256 * 1024;
+
+export interface TextPreviewResult {
+  text: string;
+  truncated: boolean;
+}
+
+/**
+ * Read at most `cap` bytes of a response body, cancelling the stream once the
+ * cap is crossed so the rest of a large file is never downloaded.
+ */
+export async function readBodyCapped(
+  res: Response,
+  cap: number,
+): Promise<{ bytes: Uint8Array; truncated: boolean }> {
+  const body = res.body;
+  if (!body) {
+    const full = new Uint8Array(await res.arrayBuffer());
+    return { bytes: full.subarray(0, cap), truncated: full.byteLength > cap };
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let truncated = false;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (value) {
+      chunks.push(value);
+      total += value.byteLength;
+    }
+    if (total > cap) {
+      truncated = true;
+      await reader.cancel();
+      break;
+    }
+  }
+  const bytes = new Uint8Array(Math.min(total, cap));
+  let offset = 0;
+  for (const chunk of chunks) {
+    const room = bytes.byteLength - offset;
+    if (room <= 0) {
+      break;
+    }
+    bytes.set(
+      room >= chunk.byteLength ? chunk : chunk.subarray(0, room),
+      offset,
+    );
+    offset += Math.min(room, chunk.byteLength);
+  }
+  return { bytes, truncated };
 }
 
 export function useTextPreview(url: string) {
   return useReactQuery({
     queryKey: ['text-preview', url],
-    queryFn: async ({ signal }) => {
+    queryFn: async ({ signal }): Promise<TextPreviewResult> => {
       const res = await fetch(url, { signal });
       if (!res.ok) throw new Error(`Failed to fetch file (${res.status})`);
-      const buffer = await res.arrayBuffer();
-      const { text } = decodeWithEncoding(buffer);
-      return text;
+      const { bytes, truncated } = await readBodyCapped(
+        res,
+        TEXT_PREVIEW_MAX_BYTES,
+      );
+      const { text } = decodeWithEncoding(bytes, truncated);
+      return { text, truncated };
     },
     staleTime: 5 * 60 * 1000,
   });

--- a/services/platform/convex/crawler/lib/search_service.test.ts
+++ b/services/platform/convex/crawler/lib/search_service.test.ts
@@ -4,18 +4,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // back from getKnowledgePoolForOrg while the test still inspects it.
 const hoisted = vi.hoisted(() => ({
   orgSql: { unsafe: vi.fn().mockResolvedValue([]) },
+  bm25Available: vi.fn<() => Promise<boolean>>(async () => true),
+  markBm25Unavailable: vi.fn(),
 }));
 
 // Route-to-org-pool guard: searchWeb must resolve the caller org's pool via
 // getKnowledgePoolForOrg and run every query on it — calling the shared default
 // getKnowledgePool would be a cross-org leak, so it throws here.
-vi.mock('../../lib/knowledge/db/knowledge_db', () => ({
-  getKnowledgePoolForOrg: vi.fn().mockResolvedValue(hoisted.orgSql),
-  getKnowledgePool: vi.fn(() => {
-    throw new Error('default pool must never serve tenant crawler data');
-  }),
-  PUBLIC_WEB_SCHEMA: 'public_web',
-}));
+vi.mock('../../lib/knowledge/db/knowledge_db', () => {
+  const code = (err: unknown): string =>
+    err instanceof Error && 'code' in err && typeof err.code === 'string'
+      ? err.code
+      : '';
+  return {
+    getKnowledgePoolForOrg: vi.fn().mockResolvedValue(hoisted.orgSql),
+    getKnowledgePool: vi.fn(() => {
+      throw new Error('default pool must never serve tenant crawler data');
+    }),
+    PUBLIC_WEB_SCHEMA: 'public_web',
+    bm25Available: hoisted.bm25Available,
+    markBm25Unavailable: hoisted.markBm25Unavailable,
+    isUndefinedSchema: (err: unknown) => code(err) === '3F000',
+    isUndefinedFunction: (err: unknown) => code(err) === '42883',
+  };
+});
 
 vi.mock('../../lib/knowledge/config/base', () => ({
   getEmbeddingConfig: vi.fn(() => ({
@@ -43,6 +55,10 @@ beforeEach(() => {
   vi.mocked(getKnowledgePoolForOrg).mockClear();
   vi.mocked(getKnowledgePool).mockClear();
   hoisted.orgSql.unsafe.mockClear();
+  hoisted.orgSql.unsafe.mockResolvedValue([]);
+  hoisted.bm25Available.mockReset();
+  hoisted.bm25Available.mockResolvedValue(true);
+  hoisted.markBm25Unavailable.mockClear();
 });
 
 describe('searchWeb tenant-pool routing', () => {
@@ -58,5 +74,37 @@ describe('searchWeb tenant-pool routing', () => {
     );
     expect(ranOnPublicWeb).toBe(true);
     expect(results).toEqual([]);
+  });
+});
+
+describe('searchWeb on a pg_search-less database (#2755)', () => {
+  it('skips the BM25 leg and searches vector-only', async () => {
+    hoisted.bm25Available.mockResolvedValue(false);
+
+    const results = await searchWeb('acme', 'hello world');
+
+    const ranParadeDbSql = hoisted.orgSql.unsafe.mock.calls.some((call) =>
+      String(call[0] as unknown).includes('paradedb'),
+    );
+    expect(ranParadeDbSql).toBe(false);
+    // The vector leg still ran on the org pool.
+    expect(hoisted.orgSql.unsafe.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(results).toEqual([]);
+  });
+
+  it('falls back to vector-only and remembers the capability on 3F000', async () => {
+    hoisted.orgSql.unsafe.mockImplementation(async (text: string) => {
+      if (text.includes('paradedb')) {
+        throw Object.assign(new Error('schema "paradedb" does not exist'), {
+          code: '3F000',
+        });
+      }
+      return [];
+    });
+
+    const results = await searchWeb('acme', 'hello world');
+
+    expect(results).toEqual([]);
+    expect(hoisted.markBm25Unavailable).toHaveBeenCalledWith(hoisted.orgSql);
   });
 });

--- a/services/platform/convex/crawler/lib/search_service.ts
+++ b/services/platform/convex/crawler/lib/search_service.ts
@@ -22,7 +22,11 @@ import type { Sql } from 'postgres';
 
 import { getEmbeddingConfig } from '../../lib/knowledge/config/base';
 import {
+  bm25Available,
   getKnowledgePoolForOrg,
+  isUndefinedFunction,
+  isUndefinedSchema,
+  markBm25Unavailable,
   PUBLIC_WEB_SCHEMA as SCHEMA,
 } from '../../lib/knowledge/db/knowledge_db';
 import { withRetry } from '../../lib/knowledge/db/retry';
@@ -65,11 +69,18 @@ async function ftsSearch(
   domain: string | null,
   limit: number,
 ): Promise<ChunkRow[]> {
-  // Membership filter restricts the org's view to domains it has registered.
-  if (domain) {
-    return withRetry(() =>
-      sql.unsafe<ChunkRow[]>(
-        `SELECT c.id, c.url, c.title, c.chunk_content, c.core_content, c.chunk_index,
+  // A database without pg_search (any managed Postgres) cannot run the
+  // `paradedb.*` SQL below — skip the BM25 leg so web search degrades to
+  // vector-only instead of throwing (#2755).
+  if (!(await bm25Available(sql))) {
+    return [];
+  }
+  try {
+    // Membership filter restricts the org's view to domains it has registered.
+    if (domain) {
+      return await withRetry(() =>
+        sql.unsafe<ChunkRow[]>(
+          `SELECT c.id, c.url, c.title, c.chunk_content, c.core_content, c.chunk_index,
                               paradedb.score(c.id) AS score
                        FROM ${SCHEMA}.chunks c
                        WHERE c.id @@@ paradedb.match('chunk_content', $1)
@@ -80,13 +91,13 @@ async function ftsSearch(
                          )
                        ORDER BY score DESC
                        LIMIT $4`,
-        [query, domain, orgSlug, limit],
-      ),
-    );
-  }
-  return withRetry(() =>
-    sql.unsafe<ChunkRow[]>(
-      `SELECT c.id, c.url, c.title, c.chunk_content, c.core_content, c.chunk_index,
+          [query, domain, orgSlug, limit],
+        ),
+      );
+    }
+    return await withRetry(() =>
+      sql.unsafe<ChunkRow[]>(
+        `SELECT c.id, c.url, c.title, c.chunk_content, c.core_content, c.chunk_index,
                               paradedb.score(c.id) AS score
                        FROM ${SCHEMA}.chunks c
                        WHERE c.id @@@ paradedb.match('chunk_content', $1)
@@ -96,9 +107,21 @@ async function ftsSearch(
                          )
                        ORDER BY score DESC
                        LIMIT $3`,
-      [query, orgSlug, limit],
-    ),
-  );
+        [query, orgSlug, limit],
+      ),
+    );
+  } catch (err) {
+    if (isUndefinedSchema(err) || isUndefinedFunction(err)) {
+      markBm25Unavailable(sql);
+      logger.warn(
+        `BM25 unavailable on this database, web search falling back to vector-only: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return [];
+    }
+    throw err;
+  }
 }
 
 async function vectorSearch(

--- a/services/platform/convex/documents/schedule_hub_document_rag_indexing.ts
+++ b/services/platform/convex/documents/schedule_hub_document_rag_indexing.ts
@@ -43,6 +43,19 @@ export async function scheduleHubDocumentRagIndexing(
     return false;
   }
 
+  // A `queued` row already has a dispatched (or parked) job. Re-dispatching
+  // here double-indexed every hub upload: the binder's insert-time dispatch
+  // fires before the document link lands (choosing `uploadFileToRag`), then
+  // this ran again with the link in place — TWO racing indexers per file,
+  // doubled embedding spend, and two writers fighting over `ragStatus`. The
+  // in-flight job reads `fileMetadata.documentId` at EXECUTION time (see
+  // `upload_document.ts`), so it picks up the hub folder metadata without a
+  // second dispatch. A queued job that dies pre-`running` is reclaimed by the
+  // rag watchdog, same as any other queued death.
+  if (fm?.ragStatus === 'queued') {
+    return false;
+  }
+
   // Route through the same per-org + global concurrency cap as the direct
   // upload path so a bulk import (e.g. OneDrive) can't fire dozens of
   // `uploadDocumentToRag` actions at once and saturate the shared knowledge-db

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -18,6 +18,12 @@ import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 
 const INITIAL_POLLING_DELAY_MS = 10_000;
 const MAX_POLL_ATTEMPTS = 50;
+/**
+ * A corpus row updated within this window is an actively progressing sliced
+ * indexing run — the poll chain keeps its tight cadence (and resets its
+ * backoff) so the user sees live progress for however long the run takes.
+ */
+const PROGRESS_FRESH_MS = 10 * 60 * 1000;
 
 /**
  * Upload a file to the RAG service for indexing, then start a server-driven
@@ -172,6 +178,7 @@ export const pollFileRagStatus = internalAction({
         progress_phase: string | null;
         progress_detail: string | null;
         ocr_applied: boolean | null;
+        updated_at: string | null;
       } | null;
       try {
         const result = await ctx.runAction(internal.rag.documents.getStatuses, {
@@ -231,6 +238,29 @@ export const pollFileRagStatus = internalAction({
           internal.file_metadata.internal_mutations.updateFileRagStatus,
           { storageId: args.storageId, ragStatus: 'running', ragProgress },
         );
+        // A FRESH corpus row means batches are actively committing (sliced
+        // indexing touches `updated_at` per batch): keep the tight early
+        // cadence and reset the backoff so a long healthy index shows live
+        // progress instead of a 15-45 min stale badge. Only a row that has
+        // stopped moving walks the backoff toward the watchdog.
+        const updatedAtMs = docStatus.updated_at
+          ? Date.parse(docStatus.updated_at)
+          : Number.NaN;
+        const fresh =
+          Number.isFinite(updatedAtMs) &&
+          Date.now() - updatedAtMs < PROGRESS_FRESH_MS;
+        if (fresh) {
+          await ctx.scheduler.runAfter(
+            getPollingInterval(1),
+            internal.file_metadata.internal_actions.pollFileRagStatus,
+            {
+              storageId: args.storageId,
+              organizationId: args.organizationId,
+              attempt: 2,
+            },
+          );
+          return null;
+        }
       }
       await reschedule();
     } catch (error) {

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -122,16 +122,13 @@ export const pollFileRagStatus = internalAction({
     }
 
     if (args.attempt > MAX_POLL_ATTEMPTS) {
+      // Do NOT fail the row here: sliced indexing (#2752) legitimately
+      // outlives this poll chain on large documents. Ownership hands over to
+      // the rag watchdog, which reconciles against the corpus row — adopting
+      // a late `completed`/`failed` (with its REAL error) and only declaring
+      // a `processing` row dead once it stops moving for the stale window.
       console.warn(
-        `[pollFileRagStatus] Max attempts (${MAX_POLL_ATTEMPTS}) reached for ${args.storageId}`,
-      );
-      await ctx.runMutation(
-        internal.file_metadata.internal_mutations.updateFileRagStatus,
-        {
-          storageId: args.storageId,
-          ragStatus: 'failed',
-          ragError: `Status check timed out after ${MAX_POLL_ATTEMPTS} attempts`,
-        },
+        `[pollFileRagStatus] Max attempts (${MAX_POLL_ATTEMPTS}) reached for ${args.storageId}; leaving status to the rag watchdog`,
       );
       return null;
     }

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -628,3 +628,44 @@ describe('applyVerifiedBlobSize (#2731 authoritative S3 upload size)', () => {
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 });
+
+describe('updateFileRagStatus terminal-success monotonicity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A straggling writer (killed sibling dispatcher, dying poll chain) must not
+  // pollute a completed index with a late `failed` — success is terminal for a
+  // given content; a legitimate re-index passes through `queued` first.
+  it('ignores a failed write when the row is already completed', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      storageId: 'storage_1',
+      ragStatus: 'completed',
+    });
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, {
+      storageId: 'storage_1',
+      ragStatus: 'failed',
+      ragError: 'straggler error',
+    });
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('still allows a re-queue after completion (content changed)', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      storageId: 'storage_1',
+      ragStatus: 'completed',
+    });
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, { storageId: 'storage_1', ragStatus: 'queued' });
+
+    expect(ctx.db.patch).toHaveBeenCalledTimes(1);
+    const patchArg = ctx.db.patch.mock.calls[0][1] as { ragStatus: string };
+    expect(patchArg.ragStatus).toBe('queued');
+  });
+});

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -243,6 +243,17 @@ export const updateFileRagStatus = internalMutation({
       .first();
     if (!metadata) return;
 
+    // Success is terminal for a given content: once `completed`, a straggling
+    // `failed` write (a killed sibling dispatcher's catch, a dying poll chain)
+    // must not pollute it. A legitimate re-index of CHANGED content always
+    // passes through `queued` first, which stays allowed.
+    if (args.ragStatus === 'failed' && metadata.ragStatus === 'completed') {
+      console.info(
+        `[updateFileRagStatus] ignoring stale failed write for completed ${args.storageId}`,
+      );
+      return;
+    }
+
     const isTerminal =
       args.ragStatus === 'completed' || args.ragStatus === 'failed';
 
@@ -263,11 +274,14 @@ export const updateFileRagStatus = internalMutation({
       ragError: failureReason,
       ragProgress: isTerminal ? undefined : args.ragProgress,
       // Stamp when re-queued so the watchdog can time it out. Clear on
-      // terminal states so a later re-queue starts its own clock.
+      // completion so a later re-queue starts its own clock — but KEEP it on
+      // `failed`: the watchdog's failed-row reconcile uses it to bound which
+      // recent failures are still worth checking against the corpus (a late
+      // completion self-heals the row instead of demanding a manual retry).
       ragQueuedAt:
         args.ragStatus === 'queued'
           ? Date.now()
-          : isTerminal
+          : args.ragStatus === 'completed'
             ? undefined
             : metadata.ragQueuedAt,
       // Canonical completion timestamp (replaces documents.ragInfo.indexedAt).

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -230,20 +230,33 @@ export const lookupVideoLinkSources = internalQuery({
 export const listStuckRagCandidates = internalQuery({
   args: {
     staleBeforeMs: v.number(),
+    /**
+     * Include `failed` rows whose job clock is AFTER this — recent failures
+     * the watchdog reconciles against the corpus so a late completion (or the
+     * real terminal error) self-heals the row instead of demanding a manual
+     * retry. Older failures are settled history and skipped.
+     */
+    failedAfterMs: v.optional(v.number()),
     limit: v.number(),
   },
   returns: v.array(
     v.object({
       storageId: blobRefValidator,
       organizationId: v.string(),
-      ragStatus: v.union(v.literal('queued'), v.literal('running')),
+      ragStatus: v.union(
+        v.literal('queued'),
+        v.literal('running'),
+        v.literal('failed'),
+      ),
+      ragError: v.optional(v.string()),
     }),
   ),
   async handler(ctx, args) {
     const results: Array<{
       storageId: Doc<'fileMetadata'>['storageId'];
       organizationId: string;
-      ragStatus: 'queued' | 'running';
+      ragStatus: 'queued' | 'running' | 'failed';
+      ragError?: string;
     }> = [];
     for (const status of ['running', 'queued'] as const) {
       for await (const row of ctx.db
@@ -259,6 +272,22 @@ export const listStuckRagCandidates = internalQuery({
             storageId: row.storageId,
             organizationId: row.organizationId,
             ragStatus: status,
+          });
+          if (results.length >= args.limit) return results;
+        }
+      }
+    }
+    if (args.failedAfterMs !== undefined) {
+      for await (const row of ctx.db
+        .query('fileMetadata')
+        .withIndex('by_ragStatus', (q) => q.eq('ragStatus', 'failed'))) {
+        const clock = row.ragQueuedAt ?? row._creationTime;
+        if (clock >= args.failedAfterMs) {
+          results.push({
+            storageId: row.storageId,
+            organizationId: row.organizationId,
+            ragStatus: 'failed',
+            ...(row.ragError !== undefined && { ragError: row.ragError }),
           });
           if (results.length >= args.limit) return results;
         }

--- a/services/platform/convex/file_metadata/poll_file_rag_status.test.ts
+++ b/services/platform/convex/file_metadata/poll_file_rag_status.test.ts
@@ -122,18 +122,18 @@ describe('pollFileRagStatus', () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
-  it('marks failed (no lookup) past MAX_POLL_ATTEMPTS', async () => {
-    const { ctx, runMutation, runAction } = createCtx({
+  it('stops WITHOUT failing past MAX_POLL_ATTEMPTS — the watchdog owns the long tail', async () => {
+    // Sliced indexing (#2752) legitimately outlives the poll chain on large
+    // documents; failing here false-failed live runs. The freshness-aware rag
+    // watchdog reconciles the row against the corpus instead.
+    const { ctx, runMutation, runAction, runAfter } = createCtx({
       _id: 'fm1',
       ragStatus: 'running',
     });
     await handler(ctx, { ...baseArgs, attempt: 51 });
     expect(runAction).not.toHaveBeenCalled();
-    expect(runMutation).toHaveBeenCalledWith('updateFileRagStatus', {
-      storageId: 's1',
-      ragStatus: 'failed',
-      ragError: expect.stringContaining('timed out'),
-    });
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
   });
 
   it('marks failed (no lookup, no retry) when the org slug is unresolvable', async () => {

--- a/services/platform/convex/file_metadata/poll_file_rag_status.test.ts
+++ b/services/platform/convex/file_metadata/poll_file_rag_status.test.ts
@@ -36,6 +36,7 @@ vi.mock('../workflow_engine/action_defs/rag/rag_action', () => ({
   ragAction: {},
 }));
 
+import { getPollingInterval } from '../documents/internal_actions';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
 import { pollFileRagStatus } from './internal_actions';
 
@@ -58,6 +59,7 @@ interface SerializedStatus {
   source_created_at: string | null;
   source_modified_at: string | null;
   ocr_applied: boolean | null;
+  updated_at: string | null;
 }
 
 function status(overrides: Partial<SerializedStatus>): SerializedStatus {
@@ -69,6 +71,7 @@ function status(overrides: Partial<SerializedStatus>): SerializedStatus {
     source_created_at: null,
     source_modified_at: null,
     ocr_applied: null,
+    updated_at: null,
     ...overrides,
   };
 }
@@ -225,5 +228,60 @@ describe('pollFileRagStatus', () => {
       ragProgress: 'embedding 3/10',
     });
     expect(runAfter).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('progress-aware cadence (#2752)', () => {
+  it('keeps the tight cadence and resets the backoff while the corpus row is fresh', async () => {
+    const { ctx, runAfter } = createCtx(
+      { _id: 'fm1', ragStatus: 'running' },
+      {
+        statuses: {
+          s1: status({
+            status: 'processing',
+            progress_phase: 'storing',
+            progress_detail: '5000/86589',
+            updated_at: new Date(Date.now() - 30_000).toISOString(),
+          }),
+        },
+      },
+    );
+
+    // Deep into the backoff (attempt 40 → 75-min interval pre-fix).
+    await handler(ctx, {
+      storageId: 's1',
+      organizationId: 'org1',
+      attempt: 40,
+    });
+
+    expect(runAfter).toHaveBeenCalledTimes(1);
+    // Interval computed for a RESET attempt (tight cadence), not attempt 40.
+    expect(vi.mocked(getPollingInterval)).toHaveBeenLastCalledWith(1);
+    const [, , schedArgs] = runAfter.mock.calls[0];
+    expect((schedArgs as { attempt: number }).attempt).toBe(2);
+  });
+
+  it('walks the backoff when the corpus row has stopped moving', async () => {
+    const { ctx, runAfter } = createCtx(
+      { _id: 'fm1', ragStatus: 'running' },
+      {
+        statuses: {
+          s1: status({
+            status: 'processing',
+            updated_at: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+          }),
+        },
+      },
+    );
+
+    await handler(ctx, {
+      storageId: 's1',
+      organizationId: 'org1',
+      attempt: 40,
+    });
+
+    expect(runAfter).toHaveBeenCalledTimes(1);
+    const [, , schedArgs] = runAfter.mock.calls[0];
+    expect((schedArgs as { attempt: number }).attempt).toBe(41);
   });
 });

--- a/services/platform/convex/file_metadata/rag_watchdog.test.ts
+++ b/services/platform/convex/file_metadata/rag_watchdog.test.ts
@@ -48,6 +48,7 @@ type DocStatus = {
   status: string;
   error: string | null;
   ocr_applied: boolean | null;
+  updated_at?: string | null;
 };
 
 function createCtx(opts: {
@@ -151,6 +152,50 @@ describe('recoverStuckRagIndexing watchdog', () => {
       ragStatus: 'failed',
     });
     expect(String(mutationCalls[0].args.ragError)).toMatch(/interrupted/i);
+  });
+
+  it('leaves a FRESH processing row alone — a live sliced indexing run (#2752)', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        { storageId: STORAGE, organizationId: 'org_1', ragStatus: 'running' },
+      ],
+      statuses: {
+        [STORAGE]: {
+          status: 'processing',
+          error: null,
+          ocr_applied: null,
+          // A batch committed moments ago — the store loop is alive.
+          updated_at: new Date(Date.now() - 60_000).toISOString(),
+        },
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  it('fails a processing row whose corpus row stopped moving for the stale window', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        { storageId: STORAGE, organizationId: 'org_1', ragStatus: 'running' },
+      ],
+      statuses: {
+        [STORAGE]: {
+          status: 'processing',
+          error: null,
+          ocr_applied: null,
+          updated_at: new Date(Date.now() - 36 * 60 * 1000).toISOString(),
+        },
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls[0].args).toMatchObject({
+      storageId: STORAGE,
+      ragStatus: 'failed',
+    });
   });
 
   it('fails a queued row the corpus never ingested (null status)', async () => {

--- a/services/platform/convex/file_metadata/rag_watchdog.test.ts
+++ b/services/platform/convex/file_metadata/rag_watchdog.test.ts
@@ -42,7 +42,8 @@ const handler = (recoverStuckRagIndexing as unknown as Handler).handler;
 type Candidate = {
   storageId: string;
   organizationId: string;
-  ragStatus: 'queued' | 'running';
+  ragStatus: 'queued' | 'running' | 'failed';
+  ragError?: string;
 };
 type DocStatus = {
   status: string;
@@ -290,5 +291,141 @@ describe('recoverStuckRagIndexing watchdog', () => {
       fileIds: ['a', 'b'],
     });
     expect(mutationCalls).toHaveLength(2);
+  });
+});
+
+describe('failed-row reconcile (self-heal)', () => {
+  const FAILED_STORAGE = 's_failed';
+
+  it('adopts a late completion for a falsely failed row', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        {
+          storageId: FAILED_STORAGE,
+          organizationId: 'org_1',
+          ragStatus: 'failed',
+        },
+      ],
+      statuses: {
+        [FAILED_STORAGE]: {
+          status: 'completed',
+          error: null,
+          ocr_applied: null,
+        },
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls[0].args).toMatchObject({
+      storageId: FAILED_STORAGE,
+      ragStatus: 'completed',
+    });
+  });
+
+  it('flips a failed row back to running while the corpus chain is live', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        {
+          storageId: FAILED_STORAGE,
+          organizationId: 'org_1',
+          ragStatus: 'failed',
+        },
+      ],
+      statuses: {
+        [FAILED_STORAGE]: {
+          status: 'processing',
+          error: null,
+          ocr_applied: null,
+          updated_at: new Date(Date.now() - 60_000).toISOString(),
+        },
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls[0].args).toMatchObject({
+      storageId: FAILED_STORAGE,
+      ragStatus: 'running',
+    });
+  });
+
+  it('refreshes a failed row with the corpus real error, once', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        {
+          storageId: FAILED_STORAGE,
+          organizationId: 'org_1',
+          ragStatus: 'failed',
+          ragError: 'Indexing was interrupted (generic)',
+        },
+      ],
+      statuses: {
+        [FAILED_STORAGE]: {
+          status: 'failed',
+          error: 'project size limit (512 MB) has been exceeded',
+          ocr_applied: null,
+        },
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls[0].args).toMatchObject({
+      storageId: FAILED_STORAGE,
+      ragStatus: 'failed',
+      ragError: 'project size limit (512 MB) has been exceeded',
+    });
+  });
+
+  it('does not rewrite a failed row already carrying the same corpus error', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        {
+          storageId: FAILED_STORAGE,
+          organizationId: 'org_1',
+          ragStatus: 'failed',
+          ragError: 'boom',
+        },
+      ],
+      statuses: {
+        [FAILED_STORAGE]: {
+          status: 'failed',
+          error: 'boom',
+          ocr_applied: null,
+        },
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  it('leaves a failed row alone when the corpus job is dead (stale/null)', async () => {
+    const { ctx, mutationCalls } = createCtx({
+      candidates: [
+        {
+          storageId: FAILED_STORAGE,
+          organizationId: 'org_1',
+          ragStatus: 'failed',
+          ragError: 'real error text',
+        },
+        { storageId: 'gone', organizationId: 'org_1', ragStatus: 'failed' },
+      ],
+      statuses: {
+        [FAILED_STORAGE]: {
+          status: 'processing',
+          error: null,
+          ocr_applied: null,
+          updated_at: new Date(Date.now() - 36 * 60 * 1000).toISOString(),
+        },
+        gone: null,
+      },
+    });
+
+    await handler(ctx);
+
+    expect(mutationCalls).toHaveLength(0);
   });
 });

--- a/services/platform/convex/file_metadata/rag_watchdog.ts
+++ b/services/platform/convex/file_metadata/rag_watchdog.ts
@@ -25,6 +25,13 @@ const STALE_AFTER_MS = 35 * 60 * 1000;
 const MAX_PER_RUN = 200;
 
 /**
+ * How far back `failed` rows stay in the reconcile sweep. Recent failures may
+ * be false (a straggling writer beat a live indexing chain) and self-heal when
+ * the corpus reaches its real terminal state; older ones are settled history.
+ */
+const FAILED_RECONCILE_WINDOW_MS = 48 * 60 * 60 * 1000;
+
+/**
  * Detail stored on `ragError` when a row is failed by the watchdog. English,
  * matching every other server-written `ragError` (the UI badge label is
  * localized separately). Names the cause and the remedy — the desk "Retry
@@ -50,10 +57,18 @@ const INTERRUPTED_MESSAGE =
  * a file whose indexing actually SUCCEEDED (but whose poll chain died before
  * writing `'completed'`) is adopted as completed instead of being wrongly
  * failed. Only fails a row when the corpus was reachable and reports the
- * document as still `processing` (a >35-min-old processing row is dead) or
- * absent (`null` — never ingested). A corpus lookup that THROWS (knowledge-db
+ * document as dead: `processing` counts as dead only once the corpus row has
+ * stopped moving for the stale window (sliced indexing touches it per batch),
+ * `null` means never ingested. A corpus lookup that THROWS (knowledge-db
  * transient fault) is left for the next tick rather than failing the whole
  * org's rows — the cross-org failure-propagation hazard the chat poller guards.
+ *
+ * RECENT `failed` rows are reconciled too, so a false failure self-heals
+ * without a manual retry: a straggling writer (killed sibling dispatcher, dead
+ * poll chain) may have stamped `failed` while the indexing chain lived on —
+ * when the corpus later reads `completed` the row is adopted, while a live
+ * fresh-`processing` corpus flips it back to `running`, and a corpus-side
+ * `failed` refreshes the row with the REAL terminal error.
  *
  * Scheduled from `crons.ts` every 5 minutes; suppressed under E2E (the
  * hermetic stack has no knowledge DB, so every upload deterministically fails
@@ -67,16 +82,30 @@ export const recoverStuckRagIndexing = internalAction({
 
     const candidates = await ctx.runQuery(
       internal.file_metadata.internal_queries.listStuckRagCandidates,
-      { staleBeforeMs: Date.now() - STALE_AFTER_MS, limit: MAX_PER_RUN },
+      {
+        staleBeforeMs: Date.now() - STALE_AFTER_MS,
+        failedAfterMs: Date.now() - FAILED_RECONCILE_WINDOW_MS,
+        limit: MAX_PER_RUN,
+      },
     );
     if (candidates.length === 0) return null;
 
     // One knowledge-corpus status call per distinct org.
-    const byOrg = new Map<string, Array<{ storageId: BlobRef }>>();
+    type CandidateRow = {
+      storageId: BlobRef;
+      ragStatus: 'queued' | 'running' | 'failed';
+      ragError?: string;
+    };
+    const byOrg = new Map<string, CandidateRow[]>();
     for (const c of candidates) {
+      const entry: CandidateRow = {
+        storageId: c.storageId,
+        ragStatus: c.ragStatus,
+        ...(c.ragError !== undefined && { ragError: c.ragError }),
+      };
       const bucket = byOrg.get(c.organizationId);
-      if (bucket) bucket.push({ storageId: c.storageId });
-      else byOrg.set(c.organizationId, [{ storageId: c.storageId }]);
+      if (bucket) bucket.push(entry);
+      else byOrg.set(c.organizationId, [entry]);
     }
 
     for (const [organizationId, rows] of byOrg) {
@@ -87,6 +116,7 @@ export const recoverStuckRagIndexing = internalAction({
       // `pollFileRagStatus`'s unresolvable-org branch.
       if (orgSlug === null) {
         for (const row of rows) {
+          if (row.ragStatus === 'failed') continue;
           await ctx.runMutation(
             internal.file_metadata.internal_mutations.updateFileRagStatus,
             {
@@ -143,12 +173,18 @@ export const recoverStuckRagIndexing = internalAction({
         }
 
         if (docStatus?.status === 'failed') {
+          const realError = docStatus.error || INTERRUPTED_MESSAGE;
+          // Already failed with the same text → nothing to reconcile; without
+          // this the failed-row sweep would rewrite the row every tick.
+          if (row.ragStatus === 'failed' && row.ragError === realError) {
+            continue;
+          }
           await ctx.runMutation(
             internal.file_metadata.internal_mutations.updateFileRagStatus,
             {
               storageId: row.storageId,
               ragStatus: 'failed',
-              ragError: docStatus.error || INTERRUPTED_MESSAGE,
+              ragError: realError,
             },
           );
           continue;
@@ -168,8 +204,24 @@ export const recoverStuckRagIndexing = internalAction({
             Number.isFinite(updatedAtMs) &&
             Date.now() - updatedAtMs < STALE_AFTER_MS;
           if (fresh) {
+            // A failed row with a LIVE corpus chain is a false failure (a
+            // straggling writer lost the race) — flip it back to running so
+            // the user watches real progress instead of a wrong error.
+            if (row.ragStatus === 'failed') {
+              await ctx.runMutation(
+                internal.file_metadata.internal_mutations.updateFileRagStatus,
+                { storageId: row.storageId, ragStatus: 'running' },
+              );
+            }
             continue;
           }
+        }
+
+        // Dead job (stale processing or never ingested): an already-failed row
+        // is already terminal — never overwrite its (possibly real) error with
+        // the generic interrupted text.
+        if (row.ragStatus === 'failed') {
+          continue;
         }
 
         // Stale `processing` (no batch committed for the whole stale window)

--- a/services/platform/convex/file_metadata/rag_watchdog.ts
+++ b/services/platform/convex/file_metadata/rag_watchdog.ts
@@ -105,6 +105,7 @@ export const recoverStuckRagIndexing = internalAction({
           status: string;
           error: string | null;
           ocr_applied: boolean | null;
+          updated_at: string | null;
         } | null
       > = {};
       try {
@@ -153,10 +154,29 @@ export const recoverStuckRagIndexing = internalAction({
           continue;
         }
 
-        // `processing` (a >35-min-old corpus row whose indexer is dead) or
-        // `null` (never ingested): the job is not going to finish. Fail with
-        // a retryable message. The corpus was reachable (getStatuses did not
-        // throw), so this is a confirmed dead job, not a reachability blip.
+        // A `processing` corpus row is no longer dead just because the
+        // fileMetadata row is old: sliced indexing (#2752) keeps a large
+        // document legitimately `processing` for hours, touching the row's
+        // `updated_at` on every committed batch. Only declare it dead when the
+        // row itself has stopped moving for the stale window — a live run is
+        // left alone for the next tick.
+        if (docStatus?.status === 'processing') {
+          const updatedAtMs = docStatus.updated_at
+            ? Date.parse(docStatus.updated_at)
+            : Number.NaN;
+          const fresh =
+            Number.isFinite(updatedAtMs) &&
+            Date.now() - updatedAtMs < STALE_AFTER_MS;
+          if (fresh) {
+            continue;
+          }
+        }
+
+        // Stale `processing` (no batch committed for the whole stale window)
+        // or `null` (never ingested): the job is not going to finish. Fail
+        // with a retryable message. The corpus was reachable (getStatuses did
+        // not throw), so this is a confirmed dead job, not a reachability
+        // blip.
         await ctx.runMutation(
           internal.file_metadata.internal_mutations.updateFileRagStatus,
           {

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -15,7 +15,11 @@ import { listMessages, saveMessage } from '@convex-dev/agent';
 import type { FunctionArgs } from 'convex/server';
 
 import { isAudioOrVideo, isSpreadsheet } from '../../../lib/shared/file-types';
-import { formatVideoLinkAttachmentMarkdown } from '../../../lib/shared/video-link-markdown';
+import {
+  formatVideoLinkAttachmentMarkdown,
+  resolveTranscriptRetrievalTool,
+  type TranscriptRetrievalTool,
+} from '../../../lib/shared/video-link-markdown';
 import { components, internal } from '../../_generated/api';
 import type { MutationCtx } from '../../_generated/server';
 import { checkAgentRunAllowedHelper } from '../../agents/guardrails/budget_guard';
@@ -345,6 +349,10 @@ export async function startAgentChat(
         trimmedMessage,
         attachments,
         organizationId,
+        // The transcript hint must only name a retrieval tool this agent
+        // actually has — instructing the model to call an unregistered tool
+        // dead-ends the turn (#2760).
+        resolveTranscriptRetrievalTool(agentConfig),
       )
     : trimmedMessage;
   const messageContent = appendKbReferenceBlock(
@@ -858,6 +866,7 @@ async function buildMessageWithAttachments(
   message: string,
   attachments: FileAttachment[],
   organizationId: string,
+  transcriptRetrievalTool: TranscriptRetrievalTool,
 ): Promise<string> {
   // Backend-aware URL bake: a Convex `_storage` id gets the direct storage URL
   // (unchanged); an `s3:` ref gets the `/storage?ref=…&org=…` route URL (a
@@ -1060,12 +1069,21 @@ async function buildMessageWithAttachments(
               sourcePlatform,
               videoDurationSec:
                 videoDurationSec ?? meta.transcriptionDurationSec,
+              retrievalTool: transcriptRetrievalTool,
             }),
           );
           continue;
         }
+        // The access sentence must only name a tool this agent has (#2760);
+        // the document_retrieve wording is the historical template.
+        const accessSentence =
+          transcriptRetrievalTool === 'document_retrieve'
+            ? `Call document_retrieve with fileId=${attachment.fileId} to read the full text`
+            : transcriptRetrievalTool === 'rag_search'
+              ? 'Search its contents with rag_search'
+              : 'No retrieval tool is available in this chat to read it';
         audioMarkdown.push(
-          `${icon} [${attachment.fileName}] (${attachment.fileType}${durationNote}) — transcript is stored as a document; paragraphs prefixed [HH:MM:SS] timestamps — cite them when summarizing. Call document_retrieve with fileId=${attachment.fileId} to read the full text\n*(fileId: ${attachment.fileId} | fileName: ${attachment.fileName} | fileType: ${attachment.fileType} | fileSize: ${attachment.fileSize})*`,
+          `${icon} [${attachment.fileName}] (${attachment.fileType}${durationNote}) — transcript is stored as a document; paragraphs prefixed [HH:MM:SS] timestamps — cite them when summarizing. ${accessSentence}\n*(fileId: ${attachment.fileId} | fileName: ${attachment.fileName} | fileType: ${attachment.fileType} | fileSize: ${attachment.fileSize})*`,
         );
       } else {
         const reason =

--- a/services/platform/convex/lib/knowledge/db/knowledge_db.test.ts
+++ b/services/platform/convex/lib/knowledge/db/knowledge_db.test.ts
@@ -31,10 +31,14 @@ const { postgresMock, created } = vi.hoisted(() => {
 vi.mock('postgres', () => ({ default: postgresMock }));
 
 import {
+  bm25Available,
   closeKnowledgePool,
   getKnowledgeDatabaseUrl,
   getKnowledgePool,
   getKnowledgePoolForOrg,
+  isUndefinedFunction,
+  isUndefinedSchema,
+  markBm25Unavailable,
 } from './knowledge_db';
 
 /** The pools are fakes; view them as `FakePool` to read the recorded spies. */
@@ -137,5 +141,81 @@ describe('knowledge-db pool cache', () => {
     postgresMock.mockClear();
     getKnowledgePool();
     expect(postgresMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('BM25 capability probe', () => {
+  /** Callable fake Sql: the tagged-template probe hits the function itself. */
+  function makeProbeSql(behavior: () => Promise<unknown[]>): {
+    sql: Sql;
+    calls: { count: number };
+  } {
+    const calls = { count: 0 };
+    const fn = (async () => {
+      calls.count += 1;
+      return behavior();
+    }) as unknown as Sql;
+    return { sql: fn, calls };
+  }
+
+  it('probes pg_extension once per pool and caches a negative answer', async () => {
+    const { sql, calls } = makeProbeSql(async () => []);
+    await expect(bm25Available(sql)).resolves.toBe(false);
+    await expect(bm25Available(sql)).resolves.toBe(false);
+    expect(calls.count).toBe(1);
+  });
+
+  it('caches a positive answer', async () => {
+    const { sql, calls } = makeProbeSql(async () => [{ '?column?': 1 }]);
+    await expect(bm25Available(sql)).resolves.toBe(true);
+    await expect(bm25Available(sql)).resolves.toBe(true);
+    expect(calls.count).toBe(1);
+  });
+
+  it('assumes available on a failed probe and does not cache it', async () => {
+    let attempts = 0;
+    const { sql, calls } = makeProbeSql(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('connection refused');
+      }
+      return [];
+    });
+    // Failed probe → optimistic true, uncached.
+    await expect(bm25Available(sql)).resolves.toBe(true);
+    // Next call re-probes and lands the real (negative) answer.
+    await expect(bm25Available(sql)).resolves.toBe(false);
+    expect(calls.count).toBe(2);
+  });
+
+  it('markBm25Unavailable overrides the cached capability', async () => {
+    const { sql, calls } = makeProbeSql(async () => [{ '?column?': 1 }]);
+    await expect(bm25Available(sql)).resolves.toBe(true);
+    markBm25Unavailable(sql);
+    await expect(bm25Available(sql)).resolves.toBe(false);
+    expect(calls.count).toBe(1);
+  });
+});
+
+describe('pg SQLSTATE helpers', () => {
+  function pgError(code: string, message: string): Error {
+    return Object.assign(new Error(message), { code });
+  }
+
+  it('isUndefinedSchema matches 3F000 (schema "paradedb" does not exist)', () => {
+    expect(
+      isUndefinedSchema(pgError('3F000', 'schema "paradedb" does not exist')),
+    ).toBe(true);
+    expect(isUndefinedSchema(pgError('42P01', 'no table'))).toBe(false);
+    expect(isUndefinedSchema(new Error('plain'))).toBe(false);
+  });
+
+  it('isUndefinedFunction matches 42883', () => {
+    expect(
+      isUndefinedFunction(
+        pgError('42883', 'operator does not exist: uuid @@@ text'),
+      ),
+    ).toBe(true);
+    expect(isUndefinedFunction(pgError('3F000', 'schema'))).toBe(false);
   });
 });

--- a/services/platform/convex/lib/knowledge/db/knowledge_db.ts
+++ b/services/platform/convex/lib/knowledge/db/knowledge_db.ts
@@ -227,6 +227,63 @@ function ensureSchemaOnce(url: string, sql: Sql): Promise<void> {
   return p;
 }
 
+/**
+ * Per-pool BM25 (ParadeDB `pg_search`) capability, probed lazily once per pool.
+ * A BYO database without the extension (any managed Postgres — RDS, Neon, …)
+ * must degrade to vector-only search instead of erroring on `paradedb.*` SQL
+ * (#2755): the schema bootstrap already skips the extension gracefully, and the
+ * search services consult this before issuing the BM25 leg. Keyed by the `Sql`
+ * instance so pool eviction drops the entry with the pool.
+ */
+const bm25Capability = new WeakMap<Sql, Promise<boolean>>();
+
+/**
+ * Whether the database behind `sql` has `pg_search` installed. Probed once per
+ * pool via `pg_extension`; a FAILED probe is not cached and reports `true` so a
+ * transient connectivity error never silently degrades a ParadeDB to
+ * vector-only (the search-side error fallback still catches a truly missing
+ * extension).
+ */
+export function bm25Available(sql: Sql): Promise<boolean> {
+  const cached = bm25Capability.get(sql);
+  if (cached) {
+    return cached;
+  }
+  const probe = (async (): Promise<boolean> => {
+    try {
+      const rows = await sql`
+        SELECT 1 FROM pg_extension WHERE extname = 'pg_search'
+      `;
+      const available = rows.length > 0;
+      if (!available) {
+        logger.info(
+          'pg_search not installed on this knowledge database — BM25 disabled, searches run vector-only',
+        );
+      }
+      return available;
+    } catch (err) {
+      bm25Capability.delete(sql);
+      logger.warn(
+        `BM25 capability probe failed (assuming available): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return true;
+    }
+  })();
+  bm25Capability.set(sql, probe);
+  return probe;
+}
+
+/**
+ * Record that BM25 is unavailable on the database behind `sql` — called by the
+ * search services when a `paradedb.*` query fails with a missing-schema/function
+ * error, so subsequent searches skip the BM25 leg without re-erroring.
+ */
+export function markBm25Unavailable(sql: Sql): void {
+  bm25Capability.set(sql, Promise.resolve(false));
+}
+
 /** Drop the cached org→URL resolution for an org (call after a config change). */
 export function invalidateOrgKnowledgeUrl(orgSlug: string): void {
   orgUrlCache.delete(orgSlug);
@@ -265,6 +322,22 @@ export function isUndefinedColumn(err: unknown): boolean {
 /** 54000 = program_limit_exceeded. */
 export function isProgramLimitExceeded(err: unknown): boolean {
   return pgCode(err) === '54000';
+}
+
+/**
+ * 3F000 = invalid_schema_name — e.g. `paradedb.match(...)` on a database
+ * without `pg_search` ("schema \"paradedb\" does not exist").
+ */
+export function isUndefinedSchema(err: unknown): boolean {
+  return pgCode(err) === '3F000';
+}
+
+/**
+ * 42883 = undefined_function — e.g. the `@@@` operator or `paradedb.score()`
+ * when `pg_search` is missing or only partially installed.
+ */
+export function isUndefinedFunction(err: unknown): boolean {
+  return pgCode(err) === '42883';
 }
 
 /** XX000 = internal_error (used for BM25/HNSW corruption signalling). */

--- a/services/platform/convex/rag/documents.ts
+++ b/services/platform/convex/rag/documents.ts
@@ -236,6 +236,7 @@ function serializeStatus(record: DocumentStatusRecord): {
   source_created_at: string | null;
   source_modified_at: string | null;
   ocr_applied: boolean | null;
+  updated_at: string | null;
 } {
   return {
     status: record.status,
@@ -245,6 +246,7 @@ function serializeStatus(record: DocumentStatusRecord): {
     source_created_at: toIso(record.source_created_at),
     source_modified_at: toIso(record.source_modified_at),
     ocr_applied: record.ocr_applied,
+    updated_at: toIso(record.updated_at),
   };
 }
 

--- a/services/platform/convex/rag/documents.ts
+++ b/services/platform/convex/rag/documents.ts
@@ -17,6 +17,7 @@
 import { v } from 'convex/values';
 
 import { isRecord } from '../../lib/utils/type-utils';
+import { internal } from '../_generated/api';
 import { internalAction, type ActionCtx } from '../_generated/server';
 import {
   getKnowledgePoolForOrg,
@@ -26,6 +27,7 @@ import { withRetry } from '../lib/knowledge/db/retry';
 import { readBlobBytes } from '../lib/storage/blob_access';
 import { validateMetadataObject } from './lib/document_metadata';
 import { normalizeFolderPath } from './lib/folder_path';
+import { markDocumentFailed } from './lib/indexing_service';
 import {
   ragService,
   type DocumentContentResult,
@@ -57,6 +59,29 @@ async function readUploadBytes(
   throw new Error('upload requires either storageId or base64 content');
 }
 
+/**
+ * Wall-clock budget for ONE upload/indexing slice (#2752). Indexing a
+ * near-cap document (extract → chunk → embed → store tens of thousands of
+ * chunks) can far exceed a single Convex action's wall-clock limit — observed
+ * as a kill at exactly ~300 s that rolled back every chunk and left the file
+ * permanently unindexable. Past this soft budget the store loop commits its
+ * in-flight batch, returns `partial`, and `upload` schedules itself as a
+ * continuation that resumes from the committed chunk prefix. Keep the default
+ * comfortably inside the deployment's action cap.
+ */
+function indexSliceBudgetMs(): number {
+  const raw = process.env.RAG_INDEX_SLICE_BUDGET_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 210_000;
+}
+
+/**
+ * Continuation-chain backstop: every slice commits at least one batch, so this
+ * only trips when something pathological keeps yielding without finishing
+ * (~48 slices × 3.5 min ≈ 2.8 h of pure indexing).
+ */
+const MAX_INDEX_SLICES = 48;
+
 export const upload = internalAction({
   args: {
     orgSlug: v.string(),
@@ -70,34 +95,88 @@ export const upload = internalAction({
     content: v.optional(v.union(v.string(), v.null())),
     sourceCreatedAt: v.optional(v.union(v.number(), v.null())),
     sourceModifiedAt: v.optional(v.union(v.number(), v.null())),
+    // 1-based continuation counter; set only by the self-scheduled slices.
+    sliceAttempt: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const bytes = await readUploadBytes(
-      ctx,
-      args.orgSlug,
-      args.storageId,
-      args.content ?? null,
-    );
+    const deadline = Date.now() + indexSliceBudgetMs();
+    const sliceAttempt = args.sliceAttempt ?? 1;
+    try {
+      const bytes = await readUploadBytes(
+        ctx,
+        args.orgSlug,
+        args.storageId,
+        args.content ?? null,
+      );
 
-    const sourceCreatedAt =
-      args.sourceCreatedAt != null ? new Date(args.sourceCreatedAt) : null;
-    const sourceModifiedAt =
-      args.sourceModifiedAt != null ? new Date(args.sourceModifiedAt) : null;
+      const sourceCreatedAt =
+        args.sourceCreatedAt != null ? new Date(args.sourceCreatedAt) : null;
+      const sourceModifiedAt =
+        args.sourceModifiedAt != null ? new Date(args.sourceModifiedAt) : null;
 
-    const result = await ragService.addDocument(
-      args.orgSlug,
-      bytes,
-      args.fileId,
-      args.filename,
-      { sourceCreatedAt, sourceModifiedAt },
-    );
-    return {
-      success: result.success,
-      file_id: result.file_id,
-      chunks_created: result.chunks_created,
-      skipped: result.skipped,
-      skip_reason: result.skip_reason,
-    };
+      const result = await ragService.addDocument(
+        args.orgSlug,
+        bytes,
+        args.fileId,
+        args.filename,
+        { sourceCreatedAt, sourceModifiedAt, deadline },
+      );
+
+      if (result.partial) {
+        if (sliceAttempt >= MAX_INDEX_SLICES) {
+          const error =
+            `Indexing did not finish within ${MAX_INDEX_SLICES} continuation ` +
+            `slices (${result.chunks_total ?? '?'} chunks total)`;
+          const sql = await getKnowledgePoolForOrg(args.orgSlug);
+          await markDocumentFailed(sql, args.orgSlug, args.fileId, error);
+          return {
+            success: false,
+            file_id: result.file_id,
+            chunks_created: result.chunks_created,
+            skipped: false,
+            skip_reason: null,
+            partial: false,
+          };
+        }
+        await ctx.scheduler.runAfter(0, internal.rag.documents.upload, {
+          orgSlug: args.orgSlug,
+          fileId: args.fileId,
+          filename: args.filename,
+          storageId: args.storageId ?? null,
+          content: args.content ?? null,
+          sourceCreatedAt: args.sourceCreatedAt ?? null,
+          sourceModifiedAt: args.sourceModifiedAt ?? null,
+          sliceAttempt: sliceAttempt + 1,
+        });
+      }
+
+      return {
+        success: result.success,
+        file_id: result.file_id,
+        chunks_created: result.chunks_created,
+        skipped: result.skipped,
+        skip_reason: result.skip_reason,
+        partial: result.partial ?? false,
+      };
+    } catch (err) {
+      // A continuation slice has no awaiting parent to surface the failure
+      // (the original caller returned slices ago) — stamp the document row
+      // failed so the status poller reports a terminal state instead of an
+      // eternal `processing`, then rethrow for the action log.
+      if (sliceAttempt > 1) {
+        const message = err instanceof Error ? err.message : String(err);
+        try {
+          const sql = await getKnowledgePoolForOrg(args.orgSlug);
+          await markDocumentFailed(sql, args.orgSlug, args.fileId, message);
+        } catch (markErr) {
+          console.error(
+            `[rag.documents.upload] failed to mark ${args.fileId} failed after slice error:`,
+            markErr,
+          );
+        }
+      }
+      throw err;
+    }
   },
 });
 

--- a/services/platform/convex/rag/lib/indexing_service.store.test.ts
+++ b/services/platform/convex/rag/lib/indexing_service.store.test.ts
@@ -10,12 +10,17 @@ import {
 } from './indexing_service';
 
 /**
- * Regression guard for large-file indexing: `storePreparedDocument` must embed
- * chunks in bounded batches as it inserts, never all at once. Embedding every
- * chunk of a large document (tens of thousands) up-front materialized ~600 MB+
- * of vectors and OOM-killed the Convex action (a 96 MB text file failed with an
- * opaque `InternalServerError`). This test feeds far more chunks than one batch
- * and asserts no single `embedTexts` call ever receives the whole document.
+ * Regression guards for large-file indexing:
+ *
+ * 1. #2744 — `storePreparedDocument` must embed chunks in bounded batches as it
+ *    inserts, never all at once (embedding a whole large document up-front
+ *    OOM-killed the action).
+ * 2. #2752 — every batch commits in its OWN transaction and the committed chunk
+ *    prefix is the resume checkpoint: a `deadline` yields a `partial` result
+ *    mid-document, and a follow-up run resumes AFTER the committed prefix
+ *    (skipping their embeddings) instead of restarting from zero. The old
+ *    single big transaction rolled everything back when the action hit its
+ *    wall-clock cap, making near-cap documents permanently unindexable.
  */
 
 function makeChunk(index: number): ContentChunk {
@@ -28,63 +33,245 @@ function makeChunk(index: number): ContentChunk {
   };
 }
 
-/** Minimal fake `postgres` tagged-template client covering the store path. */
-function makeFakeSql(insertedChunks: { count: number }): Sql {
-  const tx = {
-    unsafe: vi.fn(async (query: string) => {
-      if (query.includes('INTO private_knowledge.documents')) {
-        return [{ id: 'doc-uuid-1', is_insert: true }];
-      }
-      if (query.includes('INTO private_knowledge.chunks')) {
-        insertedChunks.count += 1;
-      }
-      return [];
-    }),
+function makePrepared(chunkCount: number, hash = 'hash-a'): PreparedDocument {
+  return {
+    contentHash: hash,
+    chunks: Array.from({ length: chunkCount }, (_, i) => makeChunk(i)),
+    visionUsed: false,
+    sourceCreatedAt: null,
+    sourceModifiedAt: null,
   };
-  const sql = {
-    begin: (cb: (tx: unknown) => Promise<unknown>) => cb(tx),
-  };
-  return sql as unknown as Sql;
 }
 
-describe('storePreparedDocument — bounded-memory batched embedding', () => {
+interface FakeDocRow {
+  id: string;
+  content_hash: string;
+  status: string;
+}
+
+/**
+ * In-memory fake of the `documents` + `chunks` tables covering exactly the SQL
+ * the store path issues. Each `sql.begin` transaction commits immediately (the
+ * store path's whole point is that batches are independently durable).
+ */
+function makeFakeDb(): {
+  sql: Sql;
+  state: { doc: FakeDocRow | null; chunkIndexes: number[] };
+} {
+  const state: { doc: FakeDocRow | null; chunkIndexes: number[] } = {
+    doc: null,
+    chunkIndexes: [],
+  };
+
+  const run = async (
+    query: string,
+    params: unknown[] = [],
+  ): Promise<unknown[]> => {
+    if (query.includes('SELECT id, content_hash, status FROM')) {
+      return state.doc ? [state.doc] : [];
+    }
+    if (query.includes('INSERT INTO private_knowledge.documents')) {
+      state.doc = {
+        id: 'doc-uuid-1',
+        content_hash: String(params[3]),
+        status: 'processing',
+      };
+      return [{ id: state.doc.id }];
+    }
+    if (query.includes('SELECT COALESCE(MAX(chunk_index)')) {
+      return [{ next_index: state.chunkIndexes.length }];
+    }
+    if (query.includes('SELECT content_hash FROM')) {
+      return state.doc ? [{ content_hash: state.doc.content_hash }] : [];
+    }
+    if (query.includes('DELETE FROM private_knowledge.chunks')) {
+      state.chunkIndexes = [];
+      return [];
+    }
+    if (query.includes('INSERT INTO private_knowledge.chunks')) {
+      // 9 params per row; chunk_index is the 3rd of each group.
+      for (let base = 0; base < params.length; base += 9) {
+        state.chunkIndexes.push(Number(params[base + 2]));
+      }
+      return [];
+    }
+    if (query.includes('UPDATE private_knowledge.documents')) {
+      if (state.doc) {
+        if (query.includes("status = 'completed'")) {
+          state.doc.status = 'completed';
+        } else if (query.includes("status = 'processing'")) {
+          state.doc.status = 'processing';
+          state.doc.content_hash = String(params[3]);
+        }
+      }
+      return [];
+    }
+    return [];
+  };
+
+  const tx = { unsafe: vi.fn(run) };
+  const sql = {
+    begin: (cb: (t: unknown) => Promise<unknown>) => cb(tx),
+    unsafe: vi.fn(run),
+  };
+  return { sql: sql as unknown as Sql, state };
+}
+
+function makeEmbedding(batchSizes: number[]): EmbeddingService {
+  return {
+    dimensions: 4,
+    embedTexts: vi.fn(async (texts: string[]) => {
+      batchSizes.push(texts.length);
+      return texts.map(() => [0, 0, 0, 0]);
+    }),
+  } as unknown as EmbeddingService;
+}
+
+describe('storePreparedDocument — bounded batches, per-batch commits, resume', () => {
   it('embeds in batches of at most MAX_BATCH_SIZE, never the whole document', async () => {
     const chunkCount = MAX_BATCH_SIZE * 3 + 7; // spans four batches
-    const prepared: PreparedDocument = {
-      contentHash: 'hash',
-      chunks: Array.from({ length: chunkCount }, (_, i) => makeChunk(i)),
-      visionUsed: false,
-      sourceCreatedAt: null,
-      sourceModifiedAt: null,
-    };
-
+    const { sql, state } = makeFakeDb();
     const batchSizes: number[] = [];
-    const embeddingService = {
-      dimensions: 4,
-      embedTexts: vi.fn(async (texts: string[]) => {
-        batchSizes.push(texts.length);
-        return texts.map(() => [0, 0, 0, 0]);
-      }),
-    } as unknown as EmbeddingService;
 
-    const insertedChunks = { count: 0 };
     const result = await storePreparedDocument(
-      makeFakeSql(insertedChunks),
+      sql,
       'org-slug',
       'file-1',
       'big.txt',
-      prepared,
-      embeddingService,
+      makePrepared(chunkCount),
+      makeEmbedding(batchSizes),
     );
 
-    // Every chunk stored, one INSERT each.
+    expect(result.success).toBe(true);
     expect(result.chunks_created).toBe(chunkCount);
-    expect(insertedChunks.count).toBe(chunkCount);
-
+    expect(state.chunkIndexes).toHaveLength(chunkCount);
+    expect(new Set(state.chunkIndexes).size).toBe(chunkCount);
+    expect(state.doc?.status).toBe('completed');
     // Bounded memory: no single embed call ever saw more than one batch, and
     // the document required more than one call (i.e. it really batched).
     expect(batchSizes.length).toBeGreaterThan(1);
     expect(Math.max(...batchSizes)).toBeLessThanOrEqual(MAX_BATCH_SIZE);
     expect(batchSizes.reduce((a, b) => a + b, 0)).toBe(chunkCount);
+  });
+
+  it('yields a partial result at the deadline with the committed prefix intact', async () => {
+    const chunkCount = MAX_BATCH_SIZE * 3;
+    const { sql, state } = makeFakeDb();
+
+    const result = await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(chunkCount),
+      makeEmbedding([]),
+      // Already past: the loop still commits ONE batch (forward-progress
+      // guarantee), then yields.
+      { deadline: Date.now() - 1 },
+    );
+
+    expect(result.partial).toBe(true);
+    expect(result.chunks_total).toBe(chunkCount);
+    expect(result.chunks_created).toBe(MAX_BATCH_SIZE);
+    // The committed prefix survives — nothing was rolled back.
+    expect(state.chunkIndexes).toHaveLength(MAX_BATCH_SIZE);
+    expect(state.doc?.status).toBe('processing');
+  });
+
+  it('resumes after the committed prefix without re-embedding it', async () => {
+    const chunkCount = MAX_BATCH_SIZE * 3;
+    const { sql, state } = makeFakeDb();
+
+    const first = await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(chunkCount),
+      makeEmbedding([]),
+      { deadline: Date.now() - 1 },
+    );
+    expect(first.partial).toBe(true);
+
+    const resumeBatchSizes: number[] = [];
+    const resumed = await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(chunkCount),
+      makeEmbedding(resumeBatchSizes),
+    );
+
+    expect(resumed.partial ?? false).toBe(false);
+    expect(resumed.success).toBe(true);
+    expect(state.doc?.status).toBe('completed');
+    // All chunks present exactly once — the resume never duplicated the prefix.
+    expect(state.chunkIndexes).toHaveLength(chunkCount);
+    expect(new Set(state.chunkIndexes).size).toBe(chunkCount);
+    // Only the two remaining batches were embedded, not the stored prefix.
+    const resumedChunks = resumeBatchSizes.reduce((a, b) => a + b, 0);
+    expect(resumedChunks).toBe(chunkCount - MAX_BATCH_SIZE);
+  });
+
+  it('skips a completed document with unchanged content without embedding', async () => {
+    const chunkCount = MAX_BATCH_SIZE + 3;
+    const { sql, state } = makeFakeDb();
+
+    await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(chunkCount),
+      makeEmbedding([]),
+    );
+    expect(state.doc?.status).toBe('completed');
+
+    const rerunBatches: number[] = [];
+    const rerun = await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(chunkCount),
+      makeEmbedding(rerunBatches),
+    );
+
+    expect(rerun.skipped).toBe(true);
+    expect(rerun.skip_reason).toBe('content_unchanged');
+    expect(rerunBatches).toHaveLength(0);
+    expect(state.chunkIndexes).toHaveLength(chunkCount);
+  });
+
+  it('wipes the old chunks and rewrites from zero when the content hash changes', async () => {
+    const { sql, state } = makeFakeDb();
+
+    await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(MAX_BATCH_SIZE, 'hash-a'),
+      makeEmbedding([]),
+    );
+    expect(state.chunkIndexes).toHaveLength(MAX_BATCH_SIZE);
+
+    const newCount = MAX_BATCH_SIZE + 5;
+    const rewritten = await storePreparedDocument(
+      sql,
+      'org-slug',
+      'file-1',
+      'big.txt',
+      makePrepared(newCount, 'hash-b'),
+      makeEmbedding([]),
+    );
+
+    expect(rewritten.success).toBe(true);
+    expect(rewritten.skipped).toBe(false);
+    expect(state.chunkIndexes).toHaveLength(newCount);
+    expect(new Set(state.chunkIndexes).size).toBe(newCount);
+    expect(state.doc?.content_hash).toBe('hash-b');
+    expect(state.doc?.status).toBe('completed');
   });
 });

--- a/services/platform/convex/rag/lib/indexing_service.ts
+++ b/services/platform/convex/rag/lib/indexing_service.ts
@@ -45,6 +45,16 @@ export interface IndexResult {
   chunks_created: number;
   skipped: boolean;
   skip_reason: string | null;
+  /**
+   * True when a `deadline` stopped the store loop before every chunk was
+   * committed. The document row stays `processing` with its committed chunk
+   * prefix in place; the caller schedules a continuation, which resumes from
+   * `MAX(chunk_index) + 1` (#2752 — never re-run the whole pipeline inside one
+   * wall-clock-capped action).
+   */
+  partial?: boolean;
+  /** Total chunks the document produces (present alongside `partial`). */
+  chunks_total?: number;
 }
 
 export interface PreparedDocument {
@@ -403,13 +413,19 @@ async function cloneFromExisting(
   sourceModifiedAt: Date | null,
 ): Promise<IndexResult | null> {
   const existing = await withRetry(() =>
-    sql.unsafe<{ id: string; content_hash: string }[]>(
-      `SELECT id, content_hash FROM ${SCHEMA}.documents
+    sql.unsafe<{ id: string; content_hash: string; status: string }[]>(
+      `SELECT id, content_hash, status FROM ${SCHEMA}.documents
        WHERE org_slug = $1 AND file_id = $2`,
       [orgSlug, fileId],
     ),
   );
-  if (existing[0]?.content_hash === contentHash) {
+  // Only a COMPLETED own row counts as unchanged — a `processing` row with the
+  // same hash is a partially stored document (interrupted slice) that the
+  // clone below (or the resume path) must finish (#2752).
+  if (
+    existing[0]?.content_hash === contentHash &&
+    existing[0]?.status === 'completed'
+  ) {
     logger.info(`Document ${fileId} content unchanged, skipping (clone path)`);
     return {
       success: true,
@@ -450,39 +466,88 @@ async function cloneFromExisting(
   return null;
 }
 
-async function doStore(
+interface StoreClaim {
+  docUuid: string;
+  /** First chunk index this run still has to store (committed prefix length). */
+  resumeFrom: number;
+  /** Content unchanged AND every chunk already committed — nothing to do. */
+  skipped: boolean;
+}
+
+/**
+ * Phase A — claim (or refresh) the document row in one SHORT transaction.
+ *
+ * The committed chunk prefix is the resume checkpoint (#2752): on an unchanged
+ * content hash the existing chunks are kept and storing resumes after them; only
+ * a CHANGED hash wipes the chunks for a full rewrite. The row stays
+ * `processing` until phase C stamps `completed`.
+ */
+async function claimDocumentRow(
   sql: Sql,
   orgSlug: string,
   fileId: string,
   filename: string,
   prepared: PreparedDocument,
-  embeddingService: EmbeddingService,
-): Promise<IndexResult> {
+): Promise<StoreClaim> {
   return withRetry(() =>
     sql.begin(async (tx) => {
-      const docRows = await tx.unsafe<{ id: string; is_insert: boolean }[]>(
-        `INSERT INTO ${SCHEMA}.documents
-            (org_slug, file_id, filename, content_hash, status, chunks_count,
-             source_created_at, source_modified_at, ocr_applied)
-         VALUES ($1, $2, $3, $4, 'completed', $5, $6, $7, $8)
-         ON CONFLICT (org_slug, file_id)
-         DO UPDATE SET
-             filename = EXCLUDED.filename,
-             content_hash = EXCLUDED.content_hash,
-             status = 'completed',
-             chunks_count = EXCLUDED.chunks_count,
-             source_created_at = EXCLUDED.source_created_at,
-             source_modified_at = EXCLUDED.source_modified_at,
-             ocr_applied = EXCLUDED.ocr_applied,
-             error = NULL,
-             progress_phase = NULL,
-             progress_detail = NULL,
-             updated_at = NOW()
-         WHERE ${SCHEMA}.documents.content_hash IS DISTINCT FROM EXCLUDED.content_hash
-         RETURNING id, (xmax = 0) AS is_insert`,
+      const existing = await tx.unsafe<
+        { id: string; content_hash: string | null; status: string }[]
+      >(
+        `SELECT id, content_hash, status FROM ${SCHEMA}.documents
+         WHERE org_slug = $1 AND file_id = $2
+         FOR UPDATE`,
+        [orgSlug, fileId],
+      );
+
+      if (existing.length === 0) {
+        const inserted = await tx.unsafe<{ id: string }[]>(
+          `INSERT INTO ${SCHEMA}.documents
+              (org_slug, file_id, filename, content_hash, status, chunks_count,
+               source_created_at, source_modified_at, ocr_applied)
+           VALUES ($1, $2, $3, $4, 'processing', $5, $6, $7, $8)
+           RETURNING id`,
+          [
+            orgSlug,
+            fileId,
+            filename,
+            prepared.contentHash,
+            prepared.chunks.length,
+            prepared.sourceCreatedAt,
+            prepared.sourceModifiedAt,
+            prepared.visionUsed,
+          ],
+        );
+        return { docUuid: inserted[0].id, resumeFrom: 0, skipped: false };
+      }
+
+      const row = existing[0];
+      const sameContent = row.content_hash === prepared.contentHash;
+      const storedRows = await tx.unsafe<{ next_index: number }[]>(
+        `SELECT COALESCE(MAX(chunk_index) + 1, 0)::int AS next_index
+         FROM ${SCHEMA}.chunks WHERE document_id = $1 AND org_slug = $2`,
+        [row.id, orgSlug],
+      );
+      const storedPrefix = sameContent ? (storedRows[0]?.next_index ?? 0) : 0;
+
+      if (
+        sameContent &&
+        row.status === 'completed' &&
+        storedPrefix >= prepared.chunks.length
+      ) {
+        return { docUuid: row.id, resumeFrom: storedPrefix, skipped: true };
+      }
+
+      await tx.unsafe(
+        `UPDATE ${SCHEMA}.documents
+         SET filename = $3, content_hash = $4, status = 'processing',
+             chunks_count = $5, source_created_at = $6,
+             source_modified_at = $7, ocr_applied = $8,
+             error = NULL, updated_at = NOW()
+         WHERE id = $1 AND org_slug = $2`,
         [
+          row.id,
           orgSlug,
-          fileId,
           filename,
           prepared.contentHash,
           prepared.chunks.length,
@@ -491,72 +556,205 @@ async function doStore(
           prepared.visionUsed,
         ],
       );
-
-      const docRow = docRows[0];
-      if (!docRow) {
-        return {
-          success: true,
-          file_id: fileId,
-          chunks_created: 0,
-          skipped: true,
-          skip_reason: 'content_unchanged',
-        } satisfies IndexResult;
-      }
-
-      const docUuid = docRow.id;
-      if (!docRow.is_insert) {
+      if (!sameContent) {
         await tx.unsafe(
           `DELETE FROM ${SCHEMA}.chunks WHERE document_id = $1 AND org_slug = $2`,
-          [docUuid, orgSlug],
+          [row.id, orgSlug],
         );
       }
+      return { docUuid: row.id, resumeFrom: storedPrefix, skipped: false };
+    }),
+  );
+}
 
-      // Embed + insert one bounded batch at a time so peak memory never scales
-      // with document size: only `MAX_BATCH_SIZE` embedding vectors are held at
-      // once, not one per chunk for the whole document (which OOM-killed the
-      // action on large files — see `prepareDocument`).
-      for (
-        let start = 0;
-        start < prepared.chunks.length;
-        start += MAX_BATCH_SIZE
-      ) {
-        const batch = prepared.chunks.slice(start, start + MAX_BATCH_SIZE);
-        const embeddings = await embeddingService.embedTexts(
-          batch.map((c) => c.content),
-        );
-        for (let j = 0; j < batch.length; j += 1) {
-          const chunk = batch[j];
-          const embedding = embeddings[j];
-          await tx.unsafe(
-            `INSERT INTO ${SCHEMA}.chunks
-                (document_id, org_slug, chunk_index, chunk_content,
-                 content_hash, embedding,
-                 core_content, prefix_overlap, suffix_overlap)
-             VALUES ($1, $2, $3, $4, $5, $6::vector, $7, $8, $9)`,
-            [
-              docUuid,
-              orgSlug,
-              chunk.index,
-              chunk.content,
-              computeContentHash(Buffer.from(chunk.content, 'utf-8')),
-              JSON.stringify(embedding),
-              chunk.coreContent,
-              chunk.prefixOverlap,
-              chunk.suffixOverlap,
-            ],
-          );
-        }
+/** Multi-row chunk INSERT (one statement per embed batch, 9 params per row). */
+function buildChunkInsert(
+  docUuid: string,
+  orgSlug: string,
+  batch: ContentChunk[],
+  embeddings: number[][],
+): { text: string; params: (string | number | null)[] } {
+  const values: string[] = [];
+  const params: (string | number | null)[] = [];
+  for (let j = 0; j < batch.length; j += 1) {
+    const chunk = batch[j];
+    const base = params.length;
+    values.push(
+      `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, ` +
+        `$${base + 6}::vector, $${base + 7}, $${base + 8}, $${base + 9})`,
+    );
+    params.push(
+      docUuid,
+      orgSlug,
+      chunk.index,
+      chunk.content,
+      computeContentHash(Buffer.from(chunk.content, 'utf-8')),
+      JSON.stringify(embeddings[j]),
+      chunk.coreContent,
+      chunk.prefixOverlap,
+      chunk.suffixOverlap,
+    );
+  }
+  const text =
+    `INSERT INTO ${SCHEMA}.chunks
+        (document_id, org_slug, chunk_index, chunk_content,
+         content_hash, embedding,
+         core_content, prefix_overlap, suffix_overlap)
+     VALUES ` + values.join(', ');
+  return { text, params };
+}
+
+/** Phase B batch-commit outcome (see `storeBatch`). */
+type BatchCommit = { kind: 'stored' | 'raced'; next: number } | null;
+
+/**
+ * Commit ONE embedded batch in its own short transaction. Under the row lock
+ * the committed prefix is re-read: a concurrent indexer of the same document
+ * (e.g. the historical double-dispatch of `uploadFileToRag` +
+ * `uploadDocumentToRag`) may have advanced it — then this batch is dropped and
+ * the caller continues from the new prefix, so the in-order prefix invariant
+ * holds with any number of writers. Returns null when the document was
+ * superseded (content hash changed under us) — the other writer owns it now.
+ */
+async function storeBatch(
+  sql: Sql,
+  orgSlug: string,
+  docUuid: string,
+  contentHash: string,
+  totalChunks: number,
+  start: number,
+  batch: ContentChunk[],
+  embeddings: number[][],
+): Promise<BatchCommit> {
+  return withRetry(() =>
+    sql.begin(async (tx) => {
+      const docRows = await tx.unsafe<{ content_hash: string | null }[]>(
+        `SELECT content_hash FROM ${SCHEMA}.documents
+         WHERE id = $1 AND org_slug = $2
+         FOR UPDATE`,
+        [docUuid, orgSlug],
+      );
+      if (docRows.length === 0 || docRows[0].content_hash !== contentHash) {
+        return null;
       }
+      const nextRows = await tx.unsafe<{ next_index: number }[]>(
+        `SELECT COALESCE(MAX(chunk_index) + 1, 0)::int AS next_index
+         FROM ${SCHEMA}.chunks WHERE document_id = $1 AND org_slug = $2`,
+        [docUuid, orgSlug],
+      );
+      const next = nextRows[0]?.next_index ?? 0;
+      if (next !== start) {
+        return { kind: 'raced', next };
+      }
+      const insert = buildChunkInsert(docUuid, orgSlug, batch, embeddings);
+      await tx.unsafe(insert.text, insert.params);
+      await tx.unsafe(
+        `UPDATE ${SCHEMA}.documents
+         SET progress_phase = 'storing', progress_detail = $3, updated_at = NOW()
+         WHERE id = $1 AND org_slug = $2`,
+        [docUuid, orgSlug, `${start + batch.length}/${totalChunks}`],
+      );
+      return { kind: 'stored', next: start + batch.length };
+    }),
+  );
+}
 
+async function doStore(
+  sql: Sql,
+  orgSlug: string,
+  fileId: string,
+  filename: string,
+  prepared: PreparedDocument,
+  embeddingService: EmbeddingService,
+  deadline: number | undefined,
+): Promise<IndexResult> {
+  const claim = await claimDocumentRow(
+    sql,
+    orgSlug,
+    fileId,
+    filename,
+    prepared,
+  );
+  if (claim.skipped) {
+    return {
+      success: true,
+      file_id: fileId,
+      chunks_created: 0,
+      skipped: true,
+      skip_reason: 'content_unchanged',
+    };
+  }
+
+  // Embed + commit one bounded batch at a time: memory stays flat regardless
+  // of document size (#2744), and every committed batch is durable progress a
+  // continuation resumes from (#2752) — the old single big transaction rolled
+  // ALL chunks back when the action hit its wall-clock cap, leaving a large
+  // document permanently unindexable on slow store/embed paths.
+  let start = claim.resumeFrom;
+  while (start < prepared.chunks.length) {
+    // ≥1 batch commits per invocation before a deadline yield, so a
+    // continuation chain always makes forward progress and cannot spin.
+    if (
+      deadline !== undefined &&
+      start > claim.resumeFrom &&
+      Date.now() > deadline
+    ) {
       return {
         success: true,
         file_id: fileId,
-        chunks_created: prepared.chunks.length,
+        chunks_created: start - claim.resumeFrom,
         skipped: false,
         skip_reason: null,
-      } satisfies IndexResult;
-    }),
-  );
+        partial: true,
+        chunks_total: prepared.chunks.length,
+      };
+    }
+    const batch = prepared.chunks.slice(start, start + MAX_BATCH_SIZE);
+    const embeddings = await embeddingService.embedTexts(
+      batch.map((c) => c.content),
+    );
+    const committed = await storeBatch(
+      sql,
+      orgSlug,
+      claim.docUuid,
+      prepared.contentHash,
+      prepared.chunks.length,
+      start,
+      batch,
+      embeddings,
+    );
+    if (committed === null) {
+      logger.warn(
+        `Document ${fileId} superseded by a concurrent reindex, stopping this run`,
+      );
+      return {
+        success: true,
+        file_id: fileId,
+        chunks_created: start - claim.resumeFrom,
+        skipped: true,
+        skip_reason: 'superseded_by_concurrent_reindex',
+      };
+    }
+    start = committed.next;
+  }
+
+  await withRetry(async () => {
+    await sql.unsafe(
+      `UPDATE ${SCHEMA}.documents
+       SET status = 'completed', chunks_count = $3, error = NULL,
+           progress_phase = NULL, progress_detail = NULL, updated_at = NOW()
+       WHERE id = $1 AND org_slug = $2 AND content_hash = $4`,
+      [claim.docUuid, orgSlug, prepared.chunks.length, prepared.contentHash],
+    );
+  });
+
+  return {
+    success: true,
+    file_id: fileId,
+    chunks_created: prepared.chunks.length,
+    skipped: false,
+    skip_reason: null,
+  };
 }
 
 export async function storePreparedDocument(
@@ -566,6 +764,7 @@ export async function storePreparedDocument(
   filename: string,
   prepared: PreparedDocument,
   embeddingService: EmbeddingService,
+  options: { deadline?: number } = {},
 ): Promise<IndexResult> {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
@@ -576,9 +775,16 @@ export async function storePreparedDocument(
         filename,
         prepared,
         embeddingService,
+        options.deadline,
       );
-      if (result.skipped) {
-        logger.info(`Document ${fileId} content unchanged, skipping`);
+      if (result.partial) {
+        logger.info(
+          `Indexed document ${fileId}: ${result.chunks_created} chunks this slice, yielding for continuation`,
+        );
+      } else if (result.skipped) {
+        logger.info(
+          `Document ${fileId} ${result.skip_reason ?? 'skipped'}, skipping`,
+        );
       } else {
         logger.info(
           `Indexed document ${fileId}: ${result.chunks_created} chunks`,
@@ -597,6 +803,28 @@ export async function storePreparedDocument(
   throw new Error('storePreparedDocument: exhausted retries');
 }
 
+/**
+ * Mark a document `failed` with an honest error — used when a continuation
+ * chain gives up (slice cap exceeded, unrecoverable slice error) so the row
+ * never sticks at `processing` and the status poller can surface the failure.
+ */
+export async function markDocumentFailed(
+  sql: Sql,
+  orgSlug: string,
+  fileId: string,
+  error: string,
+): Promise<void> {
+  await withRetry(async () => {
+    await sql.unsafe(
+      `UPDATE ${SCHEMA}.documents
+       SET status = 'failed', error = $3,
+           progress_phase = NULL, progress_detail = NULL, updated_at = NOW()
+       WHERE org_slug = $1 AND file_id = $2`,
+      [orgSlug, fileId, error],
+    );
+  });
+}
+
 export interface IndexDocumentOptions {
   embeddingService: EmbeddingService;
   visionClient?: VisionClient | null;
@@ -604,6 +832,13 @@ export interface IndexDocumentOptions {
   chunkOverlap?: number;
   sourceCreatedAt?: Date | null;
   sourceModifiedAt?: Date | null;
+  /**
+   * Epoch-ms soft stop for the store loop: past it, the run commits its
+   * current batch, returns `partial: true`, and the caller schedules a
+   * continuation (#2752). Soft — extraction and the in-flight batch finish
+   * first, so set it well inside the action's hard wall-clock cap.
+   */
+  deadline?: number;
 }
 
 /** Index a document: extract, chunk, embed, and store (with dedup/clone). */
@@ -644,10 +879,13 @@ export async function indexDocument(
     };
   }
 
-  // Fast path: same file_id within this org with unchanged content AND chunks.
+  // Fast path: same file_id within this org with unchanged content AND a
+  // COMPLETED index. A `processing` row with the same hash is a partially
+  // stored document (an interrupted prior slice) — it must fall through to the
+  // store path, which resumes after the committed chunk prefix (#2752).
   const ownRows = await withRetry(() =>
-    sql.unsafe<{ content_hash: string; chunk_count: number }[]>(
-      `SELECT d.content_hash,
+    sql.unsafe<{ content_hash: string; status: string; chunk_count: number }[]>(
+      `SELECT d.content_hash, d.status,
               (SELECT COUNT(*)::int
                FROM ${SCHEMA}.chunks c
                WHERE c.document_id = d.id AND c.org_slug = $1) AS chunk_count
@@ -657,7 +895,12 @@ export async function indexDocument(
     ),
   );
   const ownRow = ownRows[0];
-  if (ownRow && ownRow.content_hash === contentHash && ownRow.chunk_count > 0) {
+  if (
+    ownRow &&
+    ownRow.content_hash === contentHash &&
+    ownRow.status === 'completed' &&
+    ownRow.chunk_count > 0
+  ) {
     logger.info(
       `Document ${fileId} content unchanged with ${ownRow.chunk_count} chunks, skipping (early dedup)`,
     );
@@ -744,5 +987,6 @@ export async function indexDocument(
     filename,
     prepared,
     options.embeddingService,
+    { deadline: options.deadline },
   );
 }

--- a/services/platform/convex/rag/lib/rag_service.ts
+++ b/services/platform/convex/rag/lib/rag_service.ts
@@ -91,6 +91,12 @@ export interface DocumentStatusRecord {
   source_created_at: Date | null;
   source_modified_at: Date | null;
   ocr_applied: boolean | null;
+  /**
+   * Row freshness — the store loop touches it on every committed batch, so a
+   * `processing` row with a recent `updated_at` is a LIVE sliced indexing run
+   * (#2752), not a dead one. The watchdog keys its dead-job decision on this.
+   */
+  updated_at: Date | null;
 }
 
 export interface DeleteResult {
@@ -723,11 +729,12 @@ export class RagService {
           source_created_at: Date | null;
           source_modified_at: Date | null;
           ocr_applied: boolean | null;
+          updated_at: Date | null;
         }[]
       >(
         `SELECT DISTINCT ON (file_id)
             file_id, status, error, progress_phase, progress_detail,
-            source_created_at, source_modified_at, ocr_applied
+            source_created_at, source_modified_at, ocr_applied, updated_at
          FROM ${SCHEMA}.documents
          WHERE org_slug = $1 AND file_id = ANY($2)
          ORDER BY file_id,
@@ -752,6 +759,7 @@ export class RagService {
         source_created_at: row.source_created_at,
         source_modified_at: row.source_modified_at,
         ocr_applied: row.ocr_applied,
+        updated_at: row.updated_at,
       });
     }
 

--- a/services/platform/convex/rag/lib/rag_service.ts
+++ b/services/platform/convex/rag/lib/rag_service.ts
@@ -461,6 +461,7 @@ export class RagService {
     options: {
       sourceCreatedAt?: Date | null;
       sourceModifiedAt?: Date | null;
+      deadline?: number;
     } = {},
   ) {
     const clients = await this.ensureOrgClients(orgSlug);
@@ -471,6 +472,7 @@ export class RagService {
       chunkOverlap: settings.chunk_overlap,
       sourceCreatedAt: options.sourceCreatedAt,
       sourceModifiedAt: options.sourceModifiedAt,
+      deadline: options.deadline,
     });
   }
 

--- a/services/platform/convex/rag/lib/search_service.ts
+++ b/services/platform/convex/rag/lib/search_service.ts
@@ -24,10 +24,14 @@ import { mergeRrf } from '../../lib/knowledge/retrieval/rrf';
 type SqlParam = string | number | boolean | null | Date | string[] | number[];
 
 import {
+  bm25Available,
   isDataCorrupted,
   isInternalError,
   isUndefinedColumn,
+  isUndefinedFunction,
+  isUndefinedSchema,
   isUndefinedTable,
+  markBm25Unavailable,
   PRIVATE_KNOWLEDGE_SCHEMA as SCHEMA,
 } from '../../lib/knowledge/db/knowledge_db';
 import { logger } from '../../lib/knowledge/logger';
@@ -201,6 +205,12 @@ export class RagSearchService {
     folderPath: string | null | undefined,
     metadataFilters: Record<string, MetadataFilterValue> | null | undefined,
   ): Promise<ChunkRow[]> {
+    // A database without pg_search (any managed Postgres) cannot run the
+    // `paradedb.*` SQL below — skip the BM25 leg entirely so the search
+    // degrades to vector-only instead of throwing (#2755).
+    if (!(await bm25Available(this.sql))) {
+      return [];
+    }
     const { clause, params } = this.buildScopeClause(
       orgSlug,
       fileIds,
@@ -232,6 +242,15 @@ export class RagSearchService {
       }
       if (isInternalError(err)) {
         logger.warn(`FTS search failed: ${errMsg(err)}`);
+        return [];
+      }
+      if (isUndefinedSchema(err) || isUndefinedFunction(err)) {
+        // pg_search vanished (or the capability probe raced a DROP): remember
+        // the answer so later searches skip the leg without erroring again.
+        markBm25Unavailable(this.sql);
+        logger.warn(
+          `BM25 unavailable on this database, falling back to vector-only: ${errMsg(err)}`,
+        );
         return [];
       }
       throw err;

--- a/services/platform/convex/rag/lib/search_service.vector_only.test.ts
+++ b/services/platform/convex/rag/lib/search_service.vector_only.test.ts
@@ -1,0 +1,164 @@
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EmbeddingService } from '../../lib/knowledge/embedding/service';
+
+/**
+ * Regression guard for #2755: a BYO knowledge database WITHOUT `pg_search`
+ * (any managed Postgres — Neon, RDS, …) must degrade to vector-only search.
+ * Before the fix, `ftsSearch` unconditionally issued `paradedb.*` SQL and the
+ * catch-all only recognized messages containing "bm25", so the real error —
+ * `PostgresError: schema "paradedb" does not exist` (SQLSTATE 3F000) — escaped
+ * and every chat knowledge search failed ("knowledge base temporarily
+ * unavailable") even though indexing had succeeded.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  bm25Available: vi.fn<() => Promise<boolean>>(async () => true),
+  markBm25Unavailable: vi.fn(),
+}));
+
+vi.mock('../../lib/knowledge/db/knowledge_db', () => {
+  const code = (err: unknown): string =>
+    err instanceof Error && 'code' in err && typeof err.code === 'string'
+      ? err.code
+      : '';
+  return {
+    PRIVATE_KNOWLEDGE_SCHEMA: 'private_knowledge',
+    bm25Available: hoisted.bm25Available,
+    markBm25Unavailable: hoisted.markBm25Unavailable,
+    isUndefinedTable: (err: unknown) => code(err) === '42P01',
+    isUndefinedColumn: (err: unknown) => code(err) === '42703',
+    isUndefinedSchema: (err: unknown) => code(err) === '3F000',
+    isUndefinedFunction: (err: unknown) => code(err) === '42883',
+    isInternalError: (err: unknown) => code(err) === 'XX000',
+    isDataCorrupted: (err: unknown) => code(err) === 'XX001',
+  };
+});
+
+vi.mock('../../lib/knowledge/db/retry', () => ({
+  withRetry: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+import { RagSearchService } from './search_service';
+
+interface FakeRow {
+  id: string;
+  chunk_content: string;
+  core_content: string | null;
+  chunk_index: number;
+  document_id: string;
+  file_id: string | null;
+  filename: string | null;
+  source_created_at: Date | null;
+  source_modified_at: Date | null;
+  created_at: Date | null;
+  score: number;
+}
+
+function row(id: string, content: string, score: number): FakeRow {
+  return {
+    id,
+    chunk_content: content,
+    core_content: content,
+    chunk_index: 0,
+    document_id: 'doc-1',
+    file_id: 'file-1',
+    filename: 'doc.txt',
+    source_created_at: null,
+    source_modified_at: null,
+    created_at: null,
+    score,
+  };
+}
+
+const isFts = (text: string): boolean => text.includes('paradedb.match');
+const isVector = (text: string): boolean => text.includes('<=>');
+
+function makeEmbedding(): EmbeddingService {
+  return {
+    embedQueryWithUsage: vi.fn(async () => ({
+      embedding: [0.1, 0.2, 0.3],
+      usage: { promptTokens: 1, totalTokens: 1, model: 'test-embed' },
+    })),
+    embedQuery: vi.fn(async () => [0.1, 0.2, 0.3]),
+  } as unknown as EmbeddingService;
+}
+
+function pgError(sqlstate: string, message: string): Error {
+  return Object.assign(new Error(message), { code: sqlstate });
+}
+
+beforeEach(() => {
+  hoisted.bm25Available.mockReset();
+  hoisted.bm25Available.mockResolvedValue(true);
+  hoisted.markBm25Unavailable.mockClear();
+});
+
+describe('RagSearchService on a pg_search-less database (#2755)', () => {
+  it('skips the BM25 leg entirely and returns vector-only results', async () => {
+    hoisted.bm25Available.mockResolvedValue(false);
+    const unsafe = vi.fn(async (text: string) =>
+      isVector(text) ? [row('v1', 'vector hit', 0.9)] : [],
+    );
+    const sql = { unsafe } as unknown as Sql;
+
+    const service = new RagSearchService(sql, makeEmbedding());
+    const [results] = await service.search('acme', 'order 4711');
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('vector hit');
+    const ranParadeDbSql = unsafe.mock.calls.some((call) => isFts(call[0]));
+    expect(ranParadeDbSql).toBe(false);
+  });
+
+  it('falls back to vector-only and remembers the capability when the BM25 leg hits 3F000', async () => {
+    const unsafe = vi.fn(async (text: string) => {
+      if (isFts(text)) {
+        throw pgError('3F000', 'schema "paradedb" does not exist');
+      }
+      return isVector(text) ? [row('v1', 'vector hit', 0.9)] : [];
+    });
+    const sql = { unsafe } as unknown as Sql;
+
+    const service = new RagSearchService(sql, makeEmbedding());
+    const [results] = await service.search('acme', 'order 4711');
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('vector hit');
+    expect(hoisted.markBm25Unavailable).toHaveBeenCalledWith(sql);
+  });
+
+  it('falls back the same way on 42883 (undefined function/operator)', async () => {
+    const unsafe = vi.fn(async (text: string) => {
+      if (isFts(text)) {
+        throw pgError('42883', 'operator does not exist: uuid @@@ text');
+      }
+      return isVector(text) ? [row('v1', 'vector hit', 0.9)] : [];
+    });
+    const sql = { unsafe } as unknown as Sql;
+
+    const service = new RagSearchService(sql, makeEmbedding());
+    const [results] = await service.search('acme', 'order 4711');
+
+    expect(results).toHaveLength(1);
+    expect(hoisted.markBm25Unavailable).toHaveBeenCalledWith(sql);
+  });
+
+  it('still runs the hybrid BM25 + vector path on a ParadeDB database', async () => {
+    const unsafe = vi.fn(async (text: string) => {
+      if (isFts(text)) {
+        return [row('f1', 'bm25 hit', 3.2)];
+      }
+      return isVector(text) ? [row('v1', 'vector hit', 0.9)] : [];
+    });
+    const sql = { unsafe } as unknown as Sql;
+
+    const service = new RagSearchService(sql, makeEmbedding());
+    const [results] = await service.search('acme', 'order 4711');
+
+    const contents = results.map((r) => r.content).sort();
+    expect(contents).toEqual(['bm25 hit', 'vector hit']);
+    expect(hoisted.markBm25Unavailable).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/lib/shared/video-link-markdown.test.ts
+++ b/services/platform/lib/shared/video-link-markdown.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatVideoLinkAttachmentMarkdown } from './video-link-markdown';
+import {
+  formatVideoLinkAttachmentMarkdown,
+  resolveTranscriptRetrievalTool,
+} from './video-link-markdown';
 
 /**
  * Golden tests: the output here must stay byte-identical to the inline
@@ -137,5 +140,86 @@ describe('formatVideoLinkAttachmentMarkdown', () => {
       videoTitle: 'Mystery',
     });
     expect(out).toContain('(video, 0m)');
+  });
+});
+
+/**
+ * Regression guards for #2760: the hint must never instruct the model to call
+ * a tool the agent does not have — the runtime rejects the call and the turn
+ * dead-ends with "unavailable tool 'document_retrieve'".
+ */
+describe('resolveTranscriptRetrievalTool', () => {
+  it('prefers document_retrieve when the agent has it', () => {
+    expect(
+      resolveTranscriptRetrievalTool({
+        convexToolNames: ['rag_search', 'document_retrieve'],
+        knowledgeMode: 'tool',
+      }),
+    ).toBe('document_retrieve');
+  });
+
+  it('falls back to rag_search only with a tool-capable knowledge mode', () => {
+    expect(
+      resolveTranscriptRetrievalTool({
+        convexToolNames: ['rag_search'],
+        knowledgeMode: 'both',
+      }),
+    ).toBe('rag_search');
+    expect(
+      resolveTranscriptRetrievalTool({
+        convexToolNames: ['rag_search'],
+        knowledgeMode: 'context',
+      }),
+    ).toBe(null);
+  });
+
+  it('returns null for an agent with no retrieval tool at all', () => {
+    expect(
+      resolveTranscriptRetrievalTool({
+        convexToolNames: ['file_write', 'update_todos'],
+        knowledgeMode: 'tool',
+      }),
+    ).toBe(null);
+    expect(resolveTranscriptRetrievalTool({})).toBe(null);
+  });
+});
+
+describe('formatVideoLinkAttachmentMarkdown retrieval-tool variants', () => {
+  const base = {
+    fileId: 'kg2_xyz',
+    fileName: 'clip.mp4',
+    fileType: 'video/mp4',
+    fileSize: 1024,
+    videoTitle: 'Untitled',
+    videoDurationSec: 60,
+  };
+
+  it('keeps the golden document_retrieve wording when the tool is available', () => {
+    const explicit = formatVideoLinkAttachmentMarkdown({
+      ...base,
+      retrievalTool: 'document_retrieve',
+    });
+    const defaulted = formatVideoLinkAttachmentMarkdown(base);
+    expect(explicit).toBe(defaulted);
+    expect(explicit).toContain('call document_retrieve(fileId) to read');
+  });
+
+  it('points at rag_search when that is the only retrieval tool', () => {
+    const out = formatVideoLinkAttachmentMarkdown({
+      ...base,
+      retrievalTool: 'rag_search',
+    });
+    expect(out).toContain('search its contents with rag_search');
+    expect(out).not.toContain('document_retrieve');
+  });
+
+  it('never names a tool when the agent has none', () => {
+    const out = formatVideoLinkAttachmentMarkdown({
+      ...base,
+      retrievalTool: null,
+    });
+    expect(out).toContain('no retrieval tool is available in this chat');
+    expect(out).not.toContain('document_retrieve');
+    expect(out).not.toContain('rag_search');
   });
 });

--- a/services/platform/lib/shared/video-link-markdown.ts
+++ b/services/platform/lib/shared/video-link-markdown.ts
@@ -14,6 +14,49 @@
  */
 import { sanitizeUntrustedField } from './sanitize-untrusted-field';
 
+/**
+ * Which retrieval tool the transcript hint may reference. The hint must never
+ * instruct the model to call a tool the agent does not have (#2760) — the
+ * runtime rejects the call and the turn dead-ends. `null` = the agent has no
+ * way to read the indexed transcript.
+ */
+export type TranscriptRetrievalTool = 'document_retrieve' | 'rag_search' | null;
+
+/**
+ * Resolve which retrieval tool the transcript hint may point at, mirroring the
+ * chat tool filter (`internal_actions.ts`): `document_retrieve` survives only
+ * when listed in the agent's tools; `rag_search` additionally requires a
+ * tool-capable knowledge mode.
+ */
+export function resolveTranscriptRetrievalTool(agentConfig: {
+  convexToolNames?: readonly string[];
+  knowledgeMode?: string;
+}): TranscriptRetrievalTool {
+  const tools = agentConfig.convexToolNames ?? [];
+  if (tools.includes('document_retrieve')) {
+    return 'document_retrieve';
+  }
+  if (
+    tools.includes('rag_search') &&
+    (agentConfig.knowledgeMode === 'tool' ||
+      agentConfig.knowledgeMode === 'both')
+  ) {
+    return 'rag_search';
+  }
+  return null;
+}
+
+/** The tool-aware "how to read the transcript" fragment of the hint line. */
+export function transcriptAccessHint(tool: TranscriptRetrievalTool): string {
+  if (tool === 'document_retrieve') {
+    return 'call document_retrieve(fileId) to read';
+  }
+  if (tool === 'rag_search') {
+    return 'search its contents with rag_search';
+  }
+  return 'no retrieval tool is available in this chat to read it';
+}
+
 interface VideoLinkAttachmentMarkdownInput {
   fileId: string;
   fileName: string;
@@ -26,6 +69,13 @@ interface VideoLinkAttachmentMarkdownInput {
    * `videoLinkJobs.videoDurationSec ?? fileMetadata.transcriptionDurationSec
    * ?? 0`; client passes `videoLinkJob.videoDurationSec ?? 0`. */
   videoDurationSec?: number;
+  /**
+   * Which retrieval tool the hint may reference; defaults to
+   * `document_retrieve` (the historical template). Pass the resolved value
+   * from `resolveTranscriptRetrievalTool` so the hint never names a tool the
+   * agent lacks.
+   */
+  retrievalTool?: TranscriptRetrievalTool;
 }
 
 export function formatVideoLinkAttachmentMarkdown(
@@ -49,5 +99,10 @@ export function formatVideoLinkAttachmentMarkdown(
     durSec >= 3600
       ? `${Math.floor(durSec / 3600)}h ${Math.floor((durSec % 3600) / 60)}m`
       : `${Math.round(durSec / 60)}m`;
-  return `${icon} [${safeTitle}] (video${platformNote}, ${durText}${uploaderNote}) — transcript indexed; call document_retrieve(fileId) to read\n*(fileId: ${input.fileId} | fileName: ${input.fileName} | fileType: ${input.fileType} | fileSize: ${input.fileSize})*`;
+  const accessHint = transcriptAccessHint(
+    input.retrievalTool === undefined
+      ? 'document_retrieve'
+      : input.retrievalTool,
+  );
+  return `${icon} [${safeTitle}] (video${platformNote}, ${durText}${uploaderNote}) — transcript indexed; ${accessHint}\n*(fileId: ${input.fileId} | fileName: ${input.fileName} | fileType: ${input.fileType} | fileSize: ${input.fileSize})*`;
 }

--- a/services/platform/lib/shared/video-link-markdown.ts
+++ b/services/platform/lib/shared/video-link-markdown.ts
@@ -47,7 +47,7 @@ export function resolveTranscriptRetrievalTool(agentConfig: {
 }
 
 /** The tool-aware "how to read the transcript" fragment of the hint line. */
-export function transcriptAccessHint(tool: TranscriptRetrievalTool): string {
+function transcriptAccessHint(tool: TranscriptRetrievalTool): string {
   if (tool === 'document_retrieve') {
     return 'call document_retrieve(fileId) to read';
   }

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -101,6 +101,7 @@
   "documents": {
     "preview": {
       "closePreview": "Vorschau schliessen",
+      "truncatedNotice": "Diese Datei ist zu gross für eine vollständige Vorschau — angezeigt wird der Anfang. Lade die Datei herunter, um alles zu sehen.",
       "sidebar": {
         "size": "Grösse"
       }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2484,6 +2484,7 @@
       "downloadFailed": "Datei konnte nicht heruntergeladen werden",
       "notAvailable": "Vorschau nicht verfügbar",
       "notAvailableDescription": "Dieser Dateityp kann nicht in der Vorschau angezeigt werden. Bitte lade die Datei herunter, um den Inhalt anzuzeigen.",
+      "truncatedNotice": "Diese Datei ist zu groß für eine vollständige Vorschau — angezeigt wird der Anfang. Lade die Datei herunter, um alles zu sehen.",
       "download": "Herunterladen",
       "document": "Dokument",
       "title": "Dokumentvorschau",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2484,6 +2484,7 @@
       "downloadFailed": "Failed to download the file",
       "notAvailable": "Preview not available",
       "notAvailableDescription": "This file type cannot be previewed. Please download the file to view its contents.",
+      "truncatedNotice": "This file is too large to preview in full — showing the beginning. Download the file to view everything.",
       "download": "Download",
       "document": "Document",
       "title": "Document preview",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2484,6 +2484,7 @@
       "downloadFailed": "Échec du téléchargement du fichier",
       "notAvailable": "Aperçu non disponible",
       "notAvailableDescription": "Ce type de fichier ne peut pas être prévisualisé. Merci de télécharger le fichier pour consulter son contenu.",
+      "truncatedNotice": "Ce fichier est trop volumineux pour un aperçu complet — seul le début est affiché. Merci de télécharger le fichier pour tout consulter.",
       "download": "Télécharger",
       "document": "Document",
       "title": "Aperçu du document",


### PR DESCRIPTION
Closes #2755, closes #2752, closes #2760 — plus the preview freeze — defects found while verifying the gematik round-2 fixes against a real managed Postgres (Neon free tier) and a ~96 MB document.

## 1. Search now degrades to vector-only without `pg_search` (#2755)

A BYO knowledge DB without ParadeDB's `pg_search` (any managed Postgres) bootstrapped and indexed fine, but **every** knowledge search threw `PostgresError: schema "paradedb" does not exist` — the BM25 leg unconditionally issued `paradedb.*` SQL and the fallback only matched messages containing `bm25`. Chat reported "knowledge base temporarily unavailable" for a healthy, indexed corpus.

- `knowledge_db.ts`: `bm25Available(sql)` — one `pg_extension` probe per pool (WeakMap-cached; a failed probe is uncached and optimistic so a transient error never silently degrades a ParadeDB), `markBm25Unavailable`, and `isUndefinedSchema` (3F000) / `isUndefinedFunction` (42883) helpers.
- Both search services (`rag`, `crawler`) gate `ftsSearch` on the capability and return an empty FTS list — vector-only results fall out of the existing merge path with no changes to the fusion logic. 3F000/42883 from a racing `DROP EXTENSION` is caught as belt-and-braces and records the capability.

## 2. Large-document indexing is resumable across action slices (#2752)

The pipeline ran extract → chunk → embed → store inside one scheduled action with the store loop in **one big transaction**. Near the 100 MB cap the action exceeded its wall-clock limit (observed: killed at exactly ~300 s, twice — initial path and inline retry) and the rollback discarded every chunk: on slow store/embed environments (remote BYO DB) the document was **permanently unindexable** — every retry restarted from zero and died the same way. When the transaction did land before the kill, the lost status write produced the false-`failed` variant in the issue report.

- `doStore` is now three phases: **claim** (short tx; keeps existing chunks when the content hash is unchanged — they are the checkpoint; wipes them only on a changed hash), **per-batch embed → one multi-row INSERT → commit** (resume point = `MAX(chunk_index)+1`, re-read under `FOR UPDATE` so the historical `uploadFileToRag`+`uploadDocumentToRag` double dispatch converges instead of duplicating rows), and **completed stamp** (hash-guarded).
- A `deadline` (from `RAG_INDEX_SLICE_BUDGET_MS`, default 210 s — inside the ~300 s cap) makes the loop yield `partial` after ≥1 committed batch (guaranteed forward progress); `rag/documents.upload` schedules itself as a continuation, capped at 48 slices before `markDocumentFailed` stamps an honest terminal error. All three upload paths funnel through this action, so no caller changes; a `partial` slice returns `success: true` and the existing status poller tracks the knowledge-DB row to completion.
- The unchanged-content fast paths (early dedup + clone pre-check) now require `status = 'completed'`, so a partially stored document resumes instead of being false-skipped.
- Multi-row inserts per batch also cut per-chunk round trips — on a high-RTT remote DB this alone is an order-of-magnitude store speedup.

## Verification

- `tsc --noEmit` clean, `oxlint --type-aware` clean on all touched files, opengrep 0 findings.
- 853 tests green across `convex/{rag,crawler,lib/knowledge,file_metadata,documents}`.
- New regression tests, each verified red on the pre-fix code: vector-only + 3F000/42883 fallback (RAG 4, crawler 2, capability probe/helpers 6) and deadline-yield / resume-without-re-embedding / no-duplicate-chunks / unchanged-skip / hash-rewrite (5).
- Not covered by an automated test: the ~40-line continuation-scheduling glue in `rag/documents.upload` (convex-test harness cost); the store-loop behaviour it drives is fully covered at the lib layer.

Repro evidence for both defects (timelines, logs, Neon polling) is in #2752 (comment) and #2755.



## 3. Byte-capped text previews (follow-up commit)

Previewing the same 96 MB text document froze the tab: the preview downloaded the whole file and rendered it into one `<pre>`/markdown tree. `useTextPreview` now streams at most 1 MiB (cancelling the body — the rest is never downloaded), shows a localized truncation notice (en/de/de-CH/fr), and skips syntax highlighting above 256 KiB. Encoding detection tolerates a byte-cap-chopped multibyte tail without falling into UTF-16/ISO-8859-1 mis-detection. Verified live: the same document now opens in seconds with exactly 1,048,576 rendered chars and a responsive page.

## 4. Transcript hint honest about the agent's tools (#2760, follow-up commit)

The transcript-attachment hint told every agent to call `document_retrieve`, dead-ending agents that lack the tool ("Model tried to call unavailable tool"). The hint is now resolved against the agent's tool set at message-build time (document_retrieve → rag_search → honest "no retrieval tool available"); shipped assistants keep byte-identical wording (golden tests). Verified live: a stripped agent with a real YouTube transcript attachment answers gracefully with zero unavailable-tool errors.
