### PR TITLE
test(platform): fix automations-grid labels assertion for quiet tone

### DIFF
--- a/services/platform/app/features/automations/components/automations-grid.test.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.test.tsx
@@ -566,11 +566,15 @@ describe('AutomationsGrid tabs + badges', () => {
 
     renderAllTab(<AutomationsGrid organizationId="org_1" />);
 
-    const label = screen.getByText('GitHub');
-    expect(label).toBeInTheDocument();
-    // Invalid-nesting regression: the label chips must not render inside the
-    // description <p>.
-    expect(label.closest('p')).toBeNull();
+    // Quiet tone renders the labels as one muted "A · B" line in the card's
+    // meta row (see CatalogLabels) — a node of its own.
+    const labels = screen.getByText('GitHub · Email');
+    expect(labels).toBeInTheDocument();
+    // Regression guard: the labels must never be concatenated into the
+    // description paragraph.
+    expect(screen.getByText('A discoverable automation.')).not.toContainElement(
+      labels,
+    );
   });
 });
 


### PR DESCRIPTION
## What

`main`'s UI test suite is red: `automations-grid.test.tsx › "moves manifest labels into the meta row (never inside the description)"` fails on every PR built off current `main`.

## Why

#2762 changed catalog cards' `CatalogLabels` **quiet** tone to render labels as one muted `A · B` line inside a `<p>` (the intended "labels don't compete with the title" design). The test — added back in #2414 — was left asserting:

- `screen.getByText('GitHub')` (exact match), which can't match the joined `GitHub · Email` text, and
- `label.closest('p') === null`, which is now false because quiet labels render in their own `<p>`.

The component behaves as designed; the test was simply not updated alongside the redesign.

## Fix

Test-only. Assert the joined `GitHub · Email` line renders in the card's meta row and is **not** concatenated into the description paragraph — preserving the original "labels never inside the description" intent, against the current rendering.

## Testing

`test:ui automations-grid` → **24/24 pass**; `oxfmt` clean.
