### PR TITLE
fix(platform): schedule Whisper for video-link audio handoff

### DIFF
--- a/packages/ui/src/server/byte-range.ts
+++ b/packages/ui/src/server/byte-range.ts
@@ -12,7 +12,7 @@
  * unit-tested under the node vitest runtime.
  */
 
-export interface ByteRange {
+interface ByteRange {
   /** First byte position, inclusive. */
   start: number;
   /** Last byte position, inclusive (≤ size - 1). */

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -42,7 +42,15 @@ vi.mock('./rag_dispatch', () => ({
 vi.mock('../_generated/api', () => ({
   internal: {
     governance: { retention_cleanup: { runRetentionCleanup: 'mock' } },
-    file_metadata: { internal_actions: { uploadFileToRag: 'mock' } },
+    file_metadata: {
+      internal_actions: {
+        uploadFileToRag: 'mock',
+        extractFileMetadata: 'extract_mock',
+      },
+      transcribe_audio: {
+        transcribeAudio: 'transcribeAudio_mock',
+      },
+    },
   },
 }));
 
@@ -183,6 +191,43 @@ describe('saveFileMetadata (internal)', () => {
       0,
       'mock',
       expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
+  // Regression: video-link handoff stores audio/mpeg. `resolveFileType`
+  // intentionally returns '' for audio MIME, so classifying isAudio from
+  // that output skipped Whisper and stamped ragStatus=unsupported — chip
+  // stuck on Transcribing….
+  it('queues Whisper for audio/mpeg video-link handoff (not unsupported)', async () => {
+    const { ctx } = createMockCtx(null);
+    const handler = await getSaveHandler();
+
+    await handler(ctx, {
+      ...baseArgs,
+      fileName: 'This Chinese Luxury SUV has so much aura 😌.mp3',
+      contentType: 'audio/mpeg',
+      size: 3_049_437,
+      source: 'video_link',
+      uploadedBy: 'user_1',
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      'fileMetadata',
+      expect.objectContaining({
+        contentType: 'audio/mpeg',
+        source: 'video_link',
+        transcriptionStatus: 'queued',
+        ragStatus: undefined,
+      }),
+    );
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      'transcribeAudio_mock',
+      expect.objectContaining({
+        storageId: 'storage_1',
+        contentType: 'audio/mpeg',
+        organizationId: 'org_1',
+      }),
     );
   });
 

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 
 import {
+  isAudioOrVideo,
   isRagIndexableFile,
   resolveFileType,
 } from '../../lib/shared/file-types';
@@ -47,13 +48,17 @@ export const saveFileMetadata = internalMutation({
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
 
+    // Route Whisper from the caller-supplied MIME, not `resolveFileType`.
+    // That helper intentionally never returns audio/*|video/* (media is
+    // byte-classified elsewhere), so using its output here made every
+    // video-link handoff look non-audio: no transcriptionStatus, no
+    // transcribeAudio schedule, ragStatus=unsupported — chip stuck on
+    // Transcribing…. Align with the public `mutations.saveFileMetadata`.
+    const isAudio = isAudioOrVideo(args.contentType);
     const resolvedContentType = resolveFileType(
       args.fileName,
       args.contentType,
     );
-    const isAudio =
-      resolvedContentType.startsWith('audio/') ||
-      resolvedContentType.startsWith('video/');
     const shouldIndex =
       !isAudio && isRagIndexableFile(args.fileName, resolvedContentType);
     // No extractor exists for this format and it isn't routed through the


### PR DESCRIPTION
## Summary
- Video-link ingest was stuck on **Transcribing…** because internal `saveFileMetadata` classified `isAudio` from `resolveFileType()`, which intentionally never returns `audio/*`/`video/*`.
- Handoff rows got no `transcriptionStatus`, no `transcribeAudio` schedule, and `ragStatus: unsupported`.
- Fix: use `isAudioOrVideo(args.contentType)` (aligned with public `mutations.saveFileMetadata`) and add a regression test for `audio/mpeg` + `source: video_link`.

## Test plan
- [x] `bun run --filter @tale/platform test -- convex/file_metadata/internal_mutations.test.ts` (28 passed)
- [ ] Deploy to demo; re-paste a YouTube short (existing stuck jobs do not auto-retry)
- [ ] Confirm `fileMetadata.transcriptionStatus` goes `queued` → `running` → `completed` and chip reaches Ready