### PR TITLE
fix(platform): accept unlabelled finish reasons with substantive text

### DIFF
--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -1622,7 +1622,9 @@ export async function generateAgentResponse(
       // is an EXPECTED capacity stop on tool-heavy turns and continues
       // neutrally for up to MAX_STEP_CAP_CONTINUES rounds; provider anomalies
       // ('length', 'unknown', DeepSeek stop-with-empty-text) retry ONCE with
-      // the [RESPONSE_INTERRUPTED] marker, as before.
+      // the [RESPONSE_INTERRUPTED] marker, as before. An unlabelled finish
+      // ('other'/'unknown'/undefined) with substantive final text is accepted
+      // as complete — no retry (see UNLABELLED_FINISH_REASONS).
       let stepCapRounds = 0;
       for (;;) {
         const continueCheck = shouldRetryGeneration(

--- a/services/platform/convex/lib/agent_response/retry_policy.ts
+++ b/services/platform/convex/lib/agent_response/retry_policy.ts
@@ -128,7 +128,9 @@ export const MAX_STEP_CAP_CONTINUES = 3;
  *   rounds.
  * - 'anomaly': the provider ended the generation abnormally ('length',
  *   'unknown', `undefined`, or DeepSeek's 'stop' with empty text after tool
- *   calls) — retried ONCE with the [RESPONSE_INTERRUPTED] marker.
+ *   calls) — retried ONCE with the [RESPONSE_INTERRUPTED] marker. An
+ *   unlabelled finish ('other'/'unknown'/`undefined`) with substantive final
+ *   text is NOT an anomaly — see {@link UNLABELLED_FINISH_REASONS}.
  */
 export type ContinueKind = 'step-cap' | 'anomaly';
 
@@ -138,6 +140,17 @@ export interface ContinueAttempts {
   /** Step-cap continuation rounds already run this turn. */
   stepCapRounds: number;
 }
+
+/**
+ * Finish reasons that say the provider never labelled how the generation
+ * ended — they carry NO signal that the text is incomplete. The
+ * openai-compatible adapter reports 'other' for a stream where no chunk had a
+ * mappable `finish_reason` (its streaming initial value; some OpenRouter
+ * upstreams omit the field entirely) and for any nonstandard string;
+ * 'unknown' / `undefined` are the same situation on other adapters. Distinct
+ * from 'length', which is a positive truncation signal and stays retryable.
+ */
+const UNLABELLED_FINISH_REASONS = new Set(['other', 'unknown']);
 
 /**
  * Determine whether the generation result should be continued, and in which
@@ -151,6 +164,11 @@ export interface ContinueAttempts {
  *
  * Special case: `finishReason === "stop"` with empty text after tool calls
  * (known DeepSeek edge case) still triggers an anomaly retry.
+ *
+ * Mirror special case: an unlabelled finish (see
+ * {@link UNLABELLED_FINISH_REASONS}) with substantive final text is accepted
+ * as complete — retrying a finished answer regenerates it from scratch
+ * (duplicate content, doubled token spend) behind a spurious ⚠ retry marker.
  */
 export function shouldRetryGeneration(
   finishReason: string | undefined,
@@ -190,6 +208,12 @@ export function shouldRetryGeneration(
       };
     }
     return { retry: false, reason: 'non-retryable-finish-reason' };
+  }
+
+  const unlabelled =
+    !finishReason || UNLABELLED_FINISH_REASONS.has(finishReason);
+  if (unlabelled && !!text?.trim() && !needsToolResultRetry(text, steps)) {
+    return { retry: false, reason: 'unlabelled-finish-with-substantive-text' };
   }
 
   return {

--- a/services/platform/convex/lib/agent_response/should_retry_generation.test.ts
+++ b/services/platform/convex/lib/agent_response/should_retry_generation.test.ts
@@ -95,8 +95,8 @@ describe('shouldRetryGeneration', () => {
       });
     });
 
-    it('retries for finishReason "unknown"', () => {
-      const result = shouldRetryGeneration('unknown', 'Some text', [], FRESH);
+    it('retries for finishReason "unknown" with no output', () => {
+      const result = shouldRetryGeneration('unknown', '', [], FRESH);
       expect(result).toEqual({
         retry: true,
         reason: 'finish-reason-unknown',
@@ -113,11 +113,117 @@ describe('shouldRetryGeneration', () => {
       });
     });
 
-    it('retries for undefined finishReason', () => {
-      const result = shouldRetryGeneration(undefined, 'Text', [], FRESH);
+    it('retries for undefined finishReason with no output', () => {
+      const result = shouldRetryGeneration(undefined, '', [], FRESH);
       expect(result).toEqual({
         retry: true,
         reason: 'finish-reason-undefined',
+        kind: 'anomaly',
+      });
+    });
+  });
+
+  describe('unlabelled finish with substantive text is accepted', () => {
+    // Regression: an OpenRouter upstream streamed a COMPLETE answer but never
+    // sent a `finish_reason`, so the openai-compatible adapter reported
+    // 'other' (its streaming default). That says nothing about the text being
+    // incomplete — retrying regenerated the whole answer behind a ⚠ retry
+    // badge, duplicating the content and re-burning the full prompt.
+    it('does not retry "other" when the final step has substantive text', () => {
+      // Mirror of the incident: tool-call step, then a text-only final step.
+      const steps = [
+        makeStep({ toolCalls: [{ toolName: 'document_retrieve' }], text: '' }),
+        makeStep({ text: 'A complete multi-paragraph interpretation.' }),
+      ];
+      const result = shouldRetryGeneration(
+        'other',
+        'A complete multi-paragraph interpretation.',
+        steps,
+        FRESH,
+      );
+      expect(result).toEqual({
+        retry: false,
+        reason: 'unlabelled-finish-with-substantive-text',
+      });
+    });
+
+    it('does not retry "other" with text and no steps', () => {
+      const result = shouldRetryGeneration(
+        'other',
+        'Direct answer.',
+        [],
+        FRESH,
+      );
+      expect(result).toEqual({
+        retry: false,
+        reason: 'unlabelled-finish-with-substantive-text',
+      });
+    });
+
+    it('does not retry "unknown" with text', () => {
+      const result = shouldRetryGeneration('unknown', 'Some text', [], FRESH);
+      expect(result).toEqual({
+        retry: false,
+        reason: 'unlabelled-finish-with-substantive-text',
+      });
+    });
+
+    it('does not retry undefined finishReason with text', () => {
+      const result = shouldRetryGeneration(undefined, 'Text', [], FRESH);
+      expect(result).toEqual({
+        retry: false,
+        reason: 'unlabelled-finish-with-substantive-text',
+      });
+    });
+
+    it('still retries "other" when text is only a pre-tool preamble', () => {
+      const steps = [
+        makeStep({
+          toolCalls: [{ toolName: 'search' }],
+          text: 'Let me check...',
+        }),
+      ];
+      const result = shouldRetryGeneration(
+        'other',
+        'Let me check...',
+        steps,
+        FRESH,
+      );
+      expect(result).toEqual({
+        retry: true,
+        reason: 'finish-reason-other',
+        kind: 'anomaly',
+      });
+    });
+
+    it('still retries "other" when the follow-up after tools is empty', () => {
+      const steps = [
+        makeStep({ toolCalls: [{ toolName: 'search' }], text: 'Checking...' }),
+        makeStep({ text: '' }),
+      ];
+      const result = shouldRetryGeneration(
+        'other',
+        'Checking...',
+        steps,
+        FRESH,
+      );
+      expect(result).toEqual({
+        retry: true,
+        reason: 'finish-reason-other',
+        kind: 'anomaly',
+      });
+    });
+
+    it('still retries "length" with substantive text (real truncation)', () => {
+      const result = shouldRetryGeneration(
+        'length',
+        'A long but cut-off answ',
+        [],
+        FRESH,
+      );
+      expect(result).toEqual({
+        retry: true,
+        reason: 'finish-reason-length',
         kind: 'anomaly',
       });
     });


### PR DESCRIPTION
## Summary

Chat turns auto-retried — and visibly re-answered — whenever the provider stream never carried a standard `finish_reason`: the openai-compatible adapter reports its streaming default `'other'`, and `shouldRetryGeneration` classified every such finish as an anomaly without looking at the text. Observed on a deepseek-v4-flash thread routed through OpenRouter: a complete answer got `[RESPONSE_INTERRUPTED] Retry succeeded`, the retry re-answered from scratch (second `document_retrieve` call, ~19k prompt tokens re-spent) and the content rendered three times behind a ⚠ badge. The retried generation ended `'other'` too — only the one-shot `anomalyRetried` fuse stopped a loop.

Fix: an unlabelled finish (`'other'`/`'unknown'`/`undefined`) with substantive final text (`!needsToolResultRetry`) is accepted as complete — the mirror of the existing DeepSeek `'stop'`-with-empty-text special case. `'length'` (a real truncation signal) and empty or preamble-only text keep the single anomaly retry. Post-loop `[GENERATION_INCOMPLETE]`/`[STEP_LIMIT_REACHED]` notices only fire on empty/preamble text, so accepted turns end clean with no warning.

## Checklist

- [x] `bun run check` passes (format, lint, typecheck, all tests) — platform suite 76913 passed; the 7 local failures are environmental and absent from CI: 5 sweep git-ignored `.history/` editor artifacts under `builtin-configs/agents/`, 1 (`run-code-policy.test.tsx`) is a 10s timeout under full-suite load that passes in isolation in 2s.
- [x] `bun run lint:sast` passes (Opengrep) — 0 findings on the changed files (pre-commit scan).
- [x] Translations — N/A: no user-visible string; the new `reason` value is internal debug/telemetry only.
- [x] Docs — N/A: internal retry classification; no user-facing behaviour to document beyond removing a spurious retry badge.
- [x] `README` — N/A: nothing user-configurable changed.

## Test plan

- `cd services/platform && bun run test -- run convex/lib/agent_response/should_retry_generation.test.ts` — 42/42. The new `unlabelled finish with substantive text` block mirrors the incident (tool step → text-only final step, `finishReason: 'other'`) and pins the boundaries: empty text, preamble-only text, and `'length'` still retry. Red→green was observed: the 4 new accept cases fail on the previous policy.
- Full `agent_response` suite: 300/300; `typecheck` and `oxlint --type-aware` clean.
- The live incident is not deterministically reproducible (transient OpenRouter upstream omitting `finish_reason`; 5 direct replications on 3 upstreams all sent `stop`), so the regression test drives the exact recorded inputs from the affected thread instead.