### PR TITLE
chore(platform): freeze 0.3.6 version-checkpoint fixtures

### DIFF
--- a/services/platform/convex/migrations/testing/versions/index.json
+++ b/services/platform/convex/migrations/testing/versions/index.json
@@ -528,5 +528,10 @@
     "dbSchema": "561dd9501088a6d81af5dc3c",
     "configSchema": "54ec00088862116e46ff81b5",
     "scaffold": "2d3f81aaf21f85dd75afe849"
+  },
+  "0.3.6": {
+    "dbSchema": "561dd9501088a6d81af5dc3c",
+    "configSchema": "54ec00088862116e46ff81b5",
+    "scaffold": "2d3f81aaf21f85dd75afe849"
   }
 }


### PR DESCRIPTION
## Summary
- Freeze `0.3.6` migration version-checkpoint fixtures from the `v0.3.6` tag (`dump-version-schemas.ts --tag v0.3.6`).
- Reuses existing blob fingerprints (same as `0.3.5`); only `index.json` gains the `0.3.6` key. Historical `0.3.5` fixtures unchanged.

## Test plan
- [x] Blob integrity: 107 versions, 0 missing
- [x] Index adds only `0.3.6`; `0.3.5` fingerprints unchanged
- [ ] CI green on this PR