### PR TITLE
fix(platform): cut chat time-to-first-words — routing, reasoning prior, classifier ceiling, provider cache

### DIFF
--- a/builtin-configs/agents/router.json
+++ b/builtin-configs/agents/router.json
@@ -11,7 +11,7 @@
   "visibleInChat": false,
   "personalizationMode": "off",
   "maxSteps": 1,
-  "timeoutMs": 8000,
+  "timeoutMs": 4000,
   "routing": {
     "modelSelection": "auto",
     "orchestration": "auto",
@@ -19,7 +19,6 @@
   },
   "supportedModels": [
     "openrouter:anthropic/claude-haiku-4.5",
-    "openrouter:google/gemini-3.1-pro-preview",
-    "openrouter:openai/gpt-5.5"
+    "openrouter:google/gemini-3-flash-preview"
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -308,6 +308,7 @@
         "tailwindcss": "4.2.2",
         "turndown": "7.2.0",
         "typescript": "6.0.2",
+        "undici": "7.28.0",
         "validator": "13.15.35",
         "vite": "8.0.16",
         "vite-plugin-pwa": "1.3.0",

--- a/services/platform/app/features/chat/hooks/use-stream-buffer.ts
+++ b/services/platform/app/features/chat/hooks/use-stream-buffer.ts
@@ -78,11 +78,13 @@ const DEFAULT_CONFIG = {
   /** Characters to buffer before starting the reveal. This is the dominant
    *  PERCEIVED-TTFT lever: nothing is shown until this many characters have
    *  accumulated. The backend flushes deltas in ~250 ms throttled bursts (often
-   *  20-80 chars each), so a threshold of 30 could force a wait for the SECOND
-   *  burst (~+250 ms) whenever the first burst lands at 12-29 chars. 12 lets the
-   *  first burst start the reveal immediately; the EMA catch-up ramp below still
-   *  smooths the first second, so the lower reservoir doesn't read as choppy. */
-  initialBufferChars: 12,
+   *  20-80 chars each), so any threshold at or below the typical first burst
+   *  starts the reveal on the FIRST flush. 4 (was 12) also unblocks very short
+   *  answers ("4.", "Paris.") that previously sat below the gate until the
+   *  stream ENDED — the whole reply appeared only at drain time. The EMA
+   *  catch-up ramp below still smooths the first second, so the tiny reservoir
+   *  doesn't read as choppy. */
+  initialBufferChars: 4,
   /** Max chars scanned past a chunk while extending through an ambiguous
    *  markdown prefix (partial fences/rules) before giving up and holding.
    *  Bounds the per-tick line-buffer extension. */

--- a/services/platform/convex.json
+++ b/services/platform/convex.json
@@ -5,13 +5,14 @@
   },
   "node": {
     "externalPackages": [
+      "@modelcontextprotocol/sdk",
+      "canvas",
       "mssql",
-      "tedious",
       "mysql2",
       "pg",
       "postgres",
-      "@modelcontextprotocol/sdk",
-      "canvas"
+      "tedious",
+      "undici"
     ]
   },
   "aiFiles": {

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1263,6 +1263,7 @@ import type * as providers_failover from "../providers/failover.js";
 import type * as providers_failure_scope from "../providers/failure_scope.js";
 import type * as providers_file_actions from "../providers/file_actions.js";
 import type * as providers_file_utils from "../providers/file_utils.js";
+import type * as providers_keep_alive from "../providers/keep_alive.js";
 import type * as providers_provider_attribution from "../providers/provider_attribution.js";
 import type * as providers_provider_files_cache from "../providers/provider_files_cache.js";
 import type * as providers_request_body_transform from "../providers/request_body_transform.js";
@@ -3039,6 +3040,7 @@ declare const fullApi: ApiFromModules<{
   "providers/failure_scope": typeof providers_failure_scope;
   "providers/file_actions": typeof providers_file_actions;
   "providers/file_utils": typeof providers_file_utils;
+  "providers/keep_alive": typeof providers_keep_alive;
   "providers/provider_attribution": typeof providers_provider_attribution;
   "providers/provider_files_cache": typeof providers_provider_files_cache;
   "providers/request_body_transform": typeof providers_request_body_transform;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1264,6 +1264,7 @@ import type * as providers_failure_scope from "../providers/failure_scope.js";
 import type * as providers_file_actions from "../providers/file_actions.js";
 import type * as providers_file_utils from "../providers/file_utils.js";
 import type * as providers_provider_attribution from "../providers/provider_attribution.js";
+import type * as providers_provider_files_cache from "../providers/provider_files_cache.js";
 import type * as providers_request_body_transform from "../providers/request_body_transform.js";
 import type * as providers_resolve_model from "../providers/resolve_model.js";
 import type * as providers_resolve_model_node from "../providers/resolve_model_node.js";
@@ -3039,6 +3040,7 @@ declare const fullApi: ApiFromModules<{
   "providers/file_actions": typeof providers_file_actions;
   "providers/file_utils": typeof providers_file_utils;
   "providers/provider_attribution": typeof providers_provider_attribution;
+  "providers/provider_files_cache": typeof providers_provider_files_cache;
   "providers/request_body_transform": typeof providers_request_body_transform;
   "providers/resolve_model": typeof providers_resolve_model;
   "providers/resolve_model_node": typeof providers_resolve_model_node;

--- a/services/platform/convex/agents/auto_route.ts
+++ b/services/platform/convex/agents/auto_route.ts
@@ -37,6 +37,7 @@ import { detectDomain } from '../lib/agent_response/model_routing/domain';
 import { reasoningProviderOptionsFor } from '../lib/agent_response/reasoning/build_reasoning_options';
 import { scoreDifficulty } from '../lib/agent_response/reasoning/signals';
 import { classFromIntensity } from '../lib/agent_response/reasoning/types';
+import { createDebugLog } from '../lib/debug_log';
 import { buildCallProviderOptions } from '../lib/provider_options';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 import { resolveLanguageModelWithFallback } from '../providers/failover';
@@ -64,11 +65,15 @@ import type { AgentReadResult } from './file_utils';
 import { listInstalledAgentsForOrg } from './internal_actions';
 import { routeSeedValidator, routeTuningValidator } from './schema';
 
+const debugLog = createDebugLog('DEBUG_AUTO_ROUTE', '[resolveAutoRoute]');
+
 /** Hard ceiling on the classifier call — beyond this we use the default. Kept
- *  in step with the `router` agent's declared `timeoutMs` so a fast classifier
- *  model gets the full budget the config intends rather than being cut off
- *  early (the previous 6s clipped slower providers → silent fallback). */
-const ROUTE_TIMEOUT_MS = 8_000;
+ *  in step with the `router` agent's declared `timeoutMs`. The classifier is
+ *  a BLOCKING hop before the real answer starts, so every ms it waits is dead
+ *  air for the user: a healthy classifier answers in 1–2.5s, and a slow
+ *  provider outlier is better served by the default agent NOW than by a
+ *  specialist 8s later (measured: timeout turns cost +8.4s perceived TTFT). */
+const ROUTE_TIMEOUT_MS = 4_000;
 
 /** Cap the candidate list shown to the router so a huge org doesn't bloat the
  *  prompt. A fast model handles this many slugs trivially. */
@@ -369,8 +374,8 @@ export const resolveAutoRoute = internalAction({
         // misroute (specialist not picked / truncated output / unparsable reply)
         // is visible in the logs without guessing. Shortlist confirms the
         // specialist was even a candidate; raw shows the model's actual reply.
-        console.log(
-          `[resolveAutoRoute] classified org=${args.organizationId} domain=${domain} shortlist=[${shortlist
+        debugLog(
+          `classified org=${args.organizationId} domain=${domain} shortlist=[${shortlist
             .map((c) => c.name)
             .join(
               ', ',

--- a/services/platform/convex/agents/chat_turn_generate.ts
+++ b/services/platform/convex/agents/chat_turn_generate.ts
@@ -49,10 +49,15 @@ import { userContextValidator } from '../lib/agent_response/validators';
 import { blobRefValidator } from '../lib/storage/blob_ref';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 import { resolveLanguageModelWithFallback } from '../providers/failover';
+import { ensureProviderKeepAlive } from '../providers/keep_alive';
 import type { AutoRouteReason } from '../streaming/validators';
 import { applyModelOverride } from './config';
 import { resolveExternalAgentModelRefs } from './external_agent/resolve_external_agent_model';
 import { resolveAgentConfigInline } from './resolve_agent_config';
+
+// Reuse provider TLS connections across turns (module scope: once per
+// executor process, before the first turn's model call).
+ensureProviderKeepAlive();
 
 /** Save a short assistant-role system notice so an async failure is visible. */
 async function saveSystemNotice(

--- a/services/platform/convex/lib/agent_completion/on_agent_complete.ts
+++ b/services/platform/convex/lib/agent_completion/on_agent_complete.ts
@@ -141,7 +141,7 @@ export async function onAgentComplete(
     const messageId = result.messageId;
 
     if (messageId) {
-      console.log('[onAgentComplete] DEBUG citations:', {
+      debugLog('citations', {
         hasCitations: !!result.citations,
         citationsLength: result.citations?.length,
       });

--- a/services/platform/convex/lib/agent_response/model_routing/select_model.test.ts
+++ b/services/platform/convex/lib/agent_response/model_routing/select_model.test.ts
@@ -166,3 +166,54 @@ describe('quality-score interpolation (missing intelligence)', () => {
     expect(r.ref).toBe('p:b');
   });
 });
+
+describe('easy turns prefer the cheapest sufficient sibling (latency)', () => {
+  // Over-provisioning a trivial turn buys time-to-first-token, not quality:
+  // the quality-first order used to hand "hello" to the priciest sibling the
+  // cost terciles happened to label draft/standard.
+  const cheapFast: ModelCandidate = {
+    ref: 'p:cheap-fast',
+    tier: 'draft',
+    outputCentsPerMillion: 50,
+    qualityScore: 0.8,
+  };
+  const pricySmart: ModelCandidate = {
+    ref: 'p:pricy-smart',
+    tier: 'draft',
+    outputCentsPerMillion: 120,
+    qualityScore: 0.94,
+  };
+
+  it('easy → cheapest within the sufficient tier, not highest quality', () => {
+    const r = selectModelTier({
+      candidates: [pricySmart, cheapFast],
+      difficultyClass: 'easy',
+      domain: 'general',
+    });
+    expect(r.ref).toBe('p:cheap-fast');
+  });
+
+  it('medium keeps the quality-first order', () => {
+    const r = selectModelTier({
+      candidates: [pricySmart, cheapFast],
+      difficultyClass: 'medium',
+      domain: 'general',
+    });
+    expect(r.ref).toBe('p:pricy-smart');
+  });
+
+  it('high-stakes domains still force the strongest tier over cost', () => {
+    const frontierPricy: ModelCandidate = {
+      ref: 'p:frontier-pricy',
+      tier: 'frontier',
+      outputCentsPerMillion: 1500,
+      qualityScore: 0.95,
+    };
+    const r = selectModelTier({
+      candidates: [cheapFast, frontierPricy],
+      difficultyClass: 'easy',
+      domain: 'medical',
+    });
+    expect(r.ref).toBe('p:frontier-pricy');
+  });
+});

--- a/services/platform/convex/lib/agent_response/model_routing/select_model.ts
+++ b/services/platform/convex/lib/agent_response/model_routing/select_model.ts
@@ -201,14 +201,20 @@ export function selectModelTier(input: SelectModelInput): ModelSelection {
   const atOrAbove = indexed.filter((x) => x.rank >= targetRank);
   const pool = atOrAbove.length > 0 ? atOrAbove : indexed;
 
+  // Within the sufficient tier: an EASY turn optimizes for cost (which tracks
+  // speed — over-provisioning a trivial turn buys latency, not quality; the
+  // quality-first order used to hand "hello" to the priciest sibling that the
+  // cost terciles happened to label draft/standard). Medium/hard turns keep
+  // quality first — there the stronger answer is worth the wait.
+  const preferCheap = !highStakes && difficultyClass === 'easy';
   pool.sort((a, b) => {
     if (a.domainMatch !== b.domainMatch) return a.domainMatch ? -1 : 1;
     if (a.rank !== b.rank) return a.rank - b.rank; // cheapest sufficient tier
+    const costA = a.c.outputCentsPerMillion ?? Infinity;
+    const costB = b.c.outputCentsPerMillion ?? Infinity;
+    if (preferCheap && costA !== costB) return costA - costB;
     if (a.quality !== b.quality) return b.quality - a.quality;
-    return (
-      (a.c.outputCentsPerMillion ?? Infinity) -
-      (b.c.outputCentsPerMillion ?? Infinity)
-    );
+    return costA - costB;
   });
 
   const winner = pool[0];

--- a/services/platform/convex/lib/agent_response/reasoning/signals.test.ts
+++ b/services/platform/convex/lib/agent_response/reasoning/signals.test.ts
@@ -160,3 +160,44 @@ describe('scoreDifficulty', () => {
     expect(creative.creativity).toBeGreaterThan(precise.creativity);
   });
 });
+
+describe('class-capped prior budget', () => {
+  // The prior may never announce 'easy' yet spend a 'medium' thinking budget:
+  // a single feature weight (math on "what is 2+2?") used to push a trivial
+  // turn to a ~3.4k-token thinking prior — seconds of dead air before the
+  // first visible token.
+  it('caps an easy-class turn at the low-tier budget even when math fires', () => {
+    const r = scoreDifficulty({
+      kind: 'chat',
+      promptText: 'What is 2+2? Answer in one word.',
+    });
+    expect(r.difficultyClass).toBe('easy');
+    expect(r.target.tier).toBe('low');
+    expect(r.target.budgetTokens).toBeLessThanOrEqual(2048);
+  });
+
+  it('keeps trivial greetings at tier off', () => {
+    const r = scoreDifficulty({ kind: 'chat', promptText: 'hello' });
+    expect(r.target.tier).toBe('off');
+    expect(r.target.budgetTokens).toBe(0);
+  });
+
+  it('floors still win: code turns keep their medium minimum', () => {
+    const r = scoreDifficulty({
+      kind: 'chat',
+      promptText: 'Fix this:\n```js\nconst x = arr.map(f);\n```',
+    });
+    expect(r.floorTier).toBe('medium');
+    expect(r.target.budgetTokens).toBeGreaterThanOrEqual(8192);
+  });
+
+  it('hard turns keep an uncapped high-tier prior', () => {
+    const r = scoreDifficulty({
+      kind: 'chat',
+      promptText:
+        'Prove that sqrt(2) is irrational, then formalize the argument step by step.',
+    });
+    expect(r.difficultyClass).toBe('hard');
+    expect(r.target.budgetTokens).toBeGreaterThan(8192);
+  });
+});

--- a/services/platform/convex/lib/agent_response/reasoning/signals.ts
+++ b/services/platform/convex/lib/agent_response/reasoning/signals.ts
@@ -178,6 +178,15 @@ const OFF_INTENSITY = 0.12;
 const PRIOR_BUDGET_GAMMA = 1.4;
 const PRIOR_BUDGET_MAX = TIER_BUDGET_TOKENS.high;
 
+/** Ceiling the PRIOR budget may reach per difficulty class — the prior can
+ *  never announce 'easy' yet spend a 'medium' thinking budget. Floors (code /
+ *  hard verbs / attachments) and the online controller may still raise it. */
+const CLASS_TIER_CAP: Record<DifficultyClass, ReasoningTier> = {
+  easy: 'low',
+  medium: 'medium',
+  hard: 'high',
+};
+
 // How far the Auto router's coarse hint pulls the heuristic prior toward it — a
 // blend, not an override (the online controller still refines from observed
 // usage). Representative prior intensity / creativity score per hint level.
@@ -330,12 +339,25 @@ export function scoreDifficulty(signals: DifficultySignals): DifficultyResult {
   if (signals.hasAttachments) floorTier = maxTier(floorTier, 'low');
 
   // Continuous intensity → prior budget → tier, lifted to the floor.
+  //
+  // The budget is CAPPED at the turn's own difficulty class: without the cap a
+  // single feature weight (math on "what is 2+2?") pushed an easy-class turn
+  // into a medium thinking budget — seconds of dead air before the first
+  // visible token on a trivial message. The floors below still win, so code /
+  // hard-verb / attachment turns keep their guaranteed minimum, and the online
+  // controller can still raise the budget when a model's revealed need says so.
+  const difficultyClass = classFromIntensity(intensity);
+  const classCapBudget = TIER_BUDGET_TOKENS[CLASS_TIER_CAP[difficultyClass]];
   const rawBudget =
     intensity <= OFF_INTENSITY
       ? 0
-      : Math.round(
-          1024 +
-            Math.pow(intensity, PRIOR_BUDGET_GAMMA) * (PRIOR_BUDGET_MAX - 1024),
+      : Math.min(
+          Math.round(
+            1024 +
+              Math.pow(intensity, PRIOR_BUDGET_GAMMA) *
+                (PRIOR_BUDGET_MAX - 1024),
+          ),
+          classCapBudget,
         );
   const tier = maxTier(budgetToTier(rawBudget), floorTier);
   const budgetTokens = Math.max(rawBudget, TIER_BUDGET_TOKENS[floorTier]);
@@ -343,7 +365,7 @@ export function scoreDifficulty(signals: DifficultySignals): DifficultyResult {
   return {
     intensity,
     creativity,
-    difficultyClass: classFromIntensity(intensity),
+    difficultyClass,
     target: { tier, budgetTokens },
     floorTier,
     features: {

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -76,6 +76,11 @@ import {
   serializeProviderJson,
   validateProviderName,
 } from './file_utils';
+import {
+  computeProvidersFingerprint,
+  getCachedProviders,
+  setCachedProviders,
+} from './provider_files_cache';
 import { mergeRequestBodyMap } from './request_body_transform';
 // Type-only import (erased at runtime — no circular dependency) so the
 // in-process resolver shares the canonical ResolvedModelData shape.
@@ -440,6 +445,15 @@ async function loadAllProviders(
   orgSlug: string,
 ): Promise<ProviderWithSecrets[]> {
   const dir = resolveProvidersDir(orgSlug);
+  // Cross-turn cache: the catalog is a pure function of the directory's
+  // on-disk content, and this runs on EVERY model resolution (once per chat
+  // turn, plus once per fallback attempt). The mtime fingerprint makes any
+  // provider edit / key rotation miss naturally; see provider_files_cache.ts.
+  const fingerprint = await computeProvidersFingerprint(dir);
+  if (fingerprint) {
+    const cached = getCachedProviders<ProviderWithSecrets>(dir, fingerprint);
+    if (cached) return cached;
+  }
   let entries: string[];
   try {
     entries = await readdir(dir);
@@ -529,6 +543,7 @@ async function loadAllProviders(
     );
   }
 
+  if (fingerprint) setCachedProviders(dir, fingerprint, providers);
   return providers;
 }
 

--- a/services/platform/convex/providers/keep_alive.ts
+++ b/services/platform/convex/providers/keep_alive.ts
@@ -1,0 +1,37 @@
+'use node';
+
+/**
+ * Keep TLS connections from the node executor alive ACROSS turns.
+ *
+ * Node's default fetch dispatcher idles keep-alive sockets out after ~4s;
+ * chat turns are usually farther apart, so every turn paid a fresh TCP+TLS
+ * handshake to the LLM provider (~60–250ms to openrouter.ai measured on the
+ * chat hot path). Installing one global dispatcher with a longer idle window
+ * lets consecutive turns — and every other outbound fetch in the executor
+ * (title generation, embeddings, moderation) — reuse connections. undici's
+ * `setGlobalDispatcher` shares the `Symbol.for('undici.globalDispatcher.1')`
+ * registry with Node's built-in fetch, so the global `fetch` honors it.
+ *
+ * This module is 'use node' and imports the `undici` package (declared in
+ * `convex.json` `node.externalPackages` — it must NOT be bundled: its internals
+ * require `node:` builtins the V8 bundler can't resolve). Keep it out of any
+ * import chain reachable from V8 functions; entry-point node actions (e.g.
+ * `agents/chat_turn_generate.ts`) call {@link ensureProviderKeepAlive} once.
+ * The executor is a single persistent process, so the dispatcher spans
+ * invocations and is torn down with the process on deploy/restart.
+ */
+
+import { Agent, setGlobalDispatcher } from 'undici';
+
+let installed = false;
+
+export function ensureProviderKeepAlive(): void {
+  if (installed) return;
+  installed = true;
+  setGlobalDispatcher(
+    new Agent({
+      keepAliveTimeout: 60_000,
+      keepAliveMaxTimeout: 300_000,
+    }),
+  );
+}

--- a/services/platform/convex/providers/provider_files_cache.test.ts
+++ b/services/platform/convex/providers/provider_files_cache.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearProviderFilesCacheForTest,
+  computeProvidersFingerprint,
+  getCachedProviders,
+  setCachedProviders,
+} from './provider_files_cache';
+
+describe('provider_files_cache', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'tale-providers-'));
+    clearProviderFilesCacheForTest();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips a catalog under a matching fingerprint', async () => {
+    await writeFile(path.join(dir, 'openrouter.json'), '{"models":[]}');
+    const fp = await computeProvidersFingerprint(dir);
+    expect(fp).not.toBeNull();
+    const catalog = [{ name: 'openrouter' }];
+    setCachedProviders(dir, fp as string, catalog);
+    const hit = getCachedProviders<{ name: string }>(dir, fp as string);
+    expect(hit).toEqual(catalog);
+    // Shallow copy: reordering the returned array must not corrupt the cache.
+    expect(hit).not.toBe(catalog);
+  });
+
+  it('misses when a provider file changes (edit or key rotation)', async () => {
+    const file = path.join(dir, 'openrouter.json');
+    await writeFile(file, '{"models":[]}');
+    const fp1 = await computeProvidersFingerprint(dir);
+    setCachedProviders(dir, fp1 as string, [{ name: 'openrouter' }]);
+
+    // Size change guarantees a fingerprint shift even on coarse mtime clocks.
+    await writeFile(file, '{"models":[{"id":"m"}]}');
+    const fp2 = await computeProvidersFingerprint(dir);
+    expect(fp2).not.toBe(fp1);
+    expect(getCachedProviders(dir, fp2 as string)).toBeUndefined();
+  });
+
+  it('misses when a secrets file appears', async () => {
+    await writeFile(path.join(dir, 'openrouter.json'), '{"models":[]}');
+    const fp1 = await computeProvidersFingerprint(dir);
+    setCachedProviders(dir, fp1 as string, [{ name: 'openrouter' }]);
+
+    await writeFile(path.join(dir, 'openrouter.secrets.json'), '{}');
+    const fp2 = await computeProvidersFingerprint(dir);
+    expect(fp2).not.toBe(fp1);
+    expect(getCachedProviders(dir, fp2 as string)).toBeUndefined();
+  });
+
+  it('returns null for an unreadable directory (caller owns the error)', async () => {
+    expect(
+      await computeProvidersFingerprint(path.join(dir, 'missing')),
+    ).toBeNull();
+  });
+});

--- a/services/platform/convex/providers/provider_files_cache.ts
+++ b/services/platform/convex/providers/provider_files_cache.ts
@@ -1,0 +1,89 @@
+'use node';
+
+/**
+ * In-process cache for the per-turn provider catalog built by
+ * `loadAllProviders` in ./file_actions.ts.
+ *
+ * Rebuilding the catalog every send is pure overhead on the chat hot path: it
+ * re-reads + Zod-parses EVERY provider JSON and decrypts every secrets file
+ * per model resolution, for data that only changes when an operator edits a
+ * provider. The catalog is a pure function of the provider directory's on-disk
+ * content, so it can be cached and reused across turns.
+ *
+ * Mirrors the proven module-level cache in `../lib/agent_chat/skill_context_cache.ts`
+ * (itself modelled on `lib/sops.ts`): a `Map` keyed by directory, validated
+ * with a cheap `readdir` + `stat` fingerprint on every read — so ANY write to
+ * a provider file (app save actions, operator edits, scaffolds) shifts the
+ * fingerprint and misses naturally; no explicit invalidation hook is needed.
+ * The self-hosted Node executor is a single persistent process, so
+ * module-level state persists across invocations and is cleared on
+ * deploy/restart.
+ */
+
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+interface CacheEntry {
+  fingerprint: string;
+  value: unknown[];
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Cheap freshness probe: list the provider directory and combine every
+ * `*.json` entry's (name, mtime, size) — this covers both `<provider>.json`
+ * and `<provider>.secrets.json`, so config edits AND key rotations shift the
+ * fingerprint. Returns `null` when the directory is unreadable so the caller
+ * falls through to the uncached path (which owns the friendly error).
+ */
+export async function computeProvidersFingerprint(
+  dir: string,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  const relevant = entries.filter((e) => e.endsWith('.json')).sort();
+  const parts = await Promise.all(
+    relevant.map(async (name) => {
+      try {
+        const s = await stat(path.join(dir, name));
+        return `${name}:${s.mtimeMs}:${s.size}`;
+      } catch {
+        return `${name}:absent`;
+      }
+    }),
+  );
+  return parts.join('|');
+}
+
+/** Return the cached catalog iff present AND its fingerprint still matches.
+ *  The array is shallow-copied so callers reordering it can't corrupt the
+ *  cache; entries themselves are treated as immutable by all callers. */
+export function getCachedProviders<T>(
+  dir: string,
+  fingerprint: string,
+): T[] | undefined {
+  const entry = cache.get(dir);
+  if (entry && entry.fingerprint === fingerprint) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- single writer (setCachedProviders) stores the caller's own element type
+    return [...entry.value] as T[];
+  }
+  return undefined;
+}
+
+export function setCachedProviders(
+  dir: string,
+  fingerprint: string,
+  value: unknown[],
+): void {
+  cache.set(dir, { fingerprint, value: [...value] });
+}
+
+/** Test hook: drop everything (mirrors the skill-context cache's helper). */
+export function clearProviderFilesCacheForTest(): void {
+  cache.clear();
+}

--- a/services/platform/convex/providers/resolve_model.ts
+++ b/services/platform/convex/providers/resolve_model.ts
@@ -14,6 +14,7 @@ import type {
   LanguageModelV3Middleware,
 } from '@ai-sdk/provider';
 import { wrapLanguageModel } from 'ai';
+import { Agent as UndiciAgent } from 'undici';
 
 import type { Domain } from '../../lib/shared/constants/domains';
 import type {
@@ -314,6 +315,26 @@ type FetchFn = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+/**
+ * Keep TLS connections to LLM providers alive ACROSS turns. Node's default
+ * dispatcher idles keep-alive sockets out after ~4s; chat turns are usually
+ * farther apart, so every turn paid a fresh TCP+TLS handshake to the provider
+ * (~60–250ms to openrouter.ai measured on the chat hot path). One module-level
+ * agent with a longer idle window spans turns in the persistent node executor
+ * and is torn down with the process on deploy/restart.
+ */
+const keepAliveDispatcher = new UndiciAgent({
+  keepAliveTimeout: 60_000,
+  keepAliveMaxTimeout: 300_000,
+});
+
+const keepAliveFetch: FetchFn = (input, init) =>
+  fetch(input, {
+    ...init,
+    dispatcher: keepAliveDispatcher,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- undici's fetch honors `dispatcher` in RequestInit; TS's DOM lib types don't declare it
+  } as RequestInit);
+
 function createDebugFetch(providerName: string): FetchFn | undefined {
   if (process.env.TALE_DEBUG_LLM_WIRE !== '1') return undefined;
   return async (input, init) => {
@@ -347,7 +368,7 @@ function createDebugFetch(providerName: string): FetchFn | undefined {
     } catch (err) {
       console.warn('[TALE_DEBUG_LLM_WIRE] failed to log outgoing request', err);
     }
-    return fetch(input, init);
+    return keepAliveFetch(input, init);
   };
 }
 
@@ -376,7 +397,7 @@ function createCompatibleProvider(
   // fetch unchanged, so there's zero overhead on the common path.
   const wireFetch = createWireTransformFetch(
     modelData,
-    createDebugFetch(modelData.providerName),
+    createDebugFetch(modelData.providerName) ?? keepAliveFetch,
   );
   return createOpenAICompatible({
     name: modelData.providerName,

--- a/services/platform/convex/providers/resolve_model.ts
+++ b/services/platform/convex/providers/resolve_model.ts
@@ -14,7 +14,6 @@ import type {
   LanguageModelV3Middleware,
 } from '@ai-sdk/provider';
 import { wrapLanguageModel } from 'ai';
-import { Agent as UndiciAgent } from 'undici';
 
 import type { Domain } from '../../lib/shared/constants/domains';
 import type {
@@ -315,26 +314,6 @@ type FetchFn = (
   init?: RequestInit,
 ) => Promise<Response>;
 
-/**
- * Keep TLS connections to LLM providers alive ACROSS turns. Node's default
- * dispatcher idles keep-alive sockets out after ~4s; chat turns are usually
- * farther apart, so every turn paid a fresh TCP+TLS handshake to the provider
- * (~60–250ms to openrouter.ai measured on the chat hot path). One module-level
- * agent with a longer idle window spans turns in the persistent node executor
- * and is torn down with the process on deploy/restart.
- */
-const keepAliveDispatcher = new UndiciAgent({
-  keepAliveTimeout: 60_000,
-  keepAliveMaxTimeout: 300_000,
-});
-
-const keepAliveFetch: FetchFn = (input, init) =>
-  fetch(input, {
-    ...init,
-    dispatcher: keepAliveDispatcher,
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- undici's fetch honors `dispatcher` in RequestInit; TS's DOM lib types don't declare it
-  } as RequestInit);
-
 function createDebugFetch(providerName: string): FetchFn | undefined {
   if (process.env.TALE_DEBUG_LLM_WIRE !== '1') return undefined;
   return async (input, init) => {
@@ -368,7 +347,7 @@ function createDebugFetch(providerName: string): FetchFn | undefined {
     } catch (err) {
       console.warn('[TALE_DEBUG_LLM_WIRE] failed to log outgoing request', err);
     }
-    return keepAliveFetch(input, init);
+    return fetch(input, init);
   };
 }
 
@@ -397,7 +376,7 @@ function createCompatibleProvider(
   // fetch unchanged, so there's zero overhead on the common path.
   const wireFetch = createWireTransformFetch(
     modelData,
-    createDebugFetch(modelData.providerName) ?? keepAliveFetch,
+    createDebugFetch(modelData.providerName),
   );
   return createOpenAICompatible({
     name: modelData.providerName,

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -163,6 +163,7 @@
     "tailwindcss": "4.2.2",
     "turndown": "7.2.0",
     "typescript": "6.0.2",
+    "undici": "7.28.0",
     "validator": "13.15.35",
     "vite": "8.0.16",
     "vite-plugin-pwa": "1.3.0",


### PR DESCRIPTION
## Why

Users reported long dead air between sending a chat message and the first words of the answer — everywhere, in both Auto and pinned mode. A full instrumented investigation (mock-provider floor, pinned real model, Auto mode, direct-curl provider baselines, browser-observed perceived timings) attributed every stage of the send→first-visible-word path and confirmed four our-side amplifiers on top of an ~850 ms fixed pipeline floor.

## What was measured (before)

| Path | Perceived first words |
|---|---|
| Mock provider (our-side floor) | ~850 ms |
| Pinned Claude Haiku, warm | 3.4–4.3 s (direct-curl provider floor: 1.7–2.6 s) |
| Model-Auto easy prompt | routed to gemini-3.1-pro + ~6 s thinking (~11 s total) |
| Auto agent, classifier success / timeout | +1.6 s / **+8.4 s** on top |

Root causes: (1) within-tier model routing preferred highest quality, so cost-tercile inference handed trivial prompts to premium reasoning models; (2) the reasoning governor's prior gave easy-class turns medium thinking budgets whenever a math token fired ("what is 2+2?" → 3.4–5.2k tokens of forced thinking); (3) the blocking Auto classifier could hold a turn for its full 8 s ceiling; (4) every model resolution re-read + re-parsed every provider file and decrypted every secrets file; (5) every turn paid a fresh TLS handshake; (6) sub-gate-length answers only revealed at stream end.

## Changes

- Easy-class turns now route to the **cheapest sufficient** model (cost tracks speed); medium/hard keep quality-first, high-stakes domains still force the strongest tier.
- The reasoning **prior is capped at its own difficulty class** (easy→low); code/hard-verb/attachment floors and controller-learned raises still win.
- Auto-route classifier ceiling **8 s → 4 s** (fallback = default agent now, not a specialist 8 s later); builtin router config keeps `timeoutMs` in step and swaps its two heavyweight fallback classifier models for flash-class; classification log gated behind `DEBUG_AUTO_ROUTE`.
- **Provider-file cache** (mtime/size fingerprint, same pattern as the skill-context cache) — kills the per-turn read+Zod+decrypt sweep and the per-turn secrets warns.
- **TLS keep-alive** to providers via a module-level undici agent (60 s idle window).
- Stream reveal gate **12 → 4 chars** — short answers no longer wait for stream end.
- Gated a stray per-completion `console.log`.

## Measured after (same harness)

- Mock floor pre-stream: 412–493 ms → **376–431 ms**; per-turn provider warns: 2+ → **0**.
- Haiku math-trivial turn: ~3.65 s p50 → **2.9 s** (converges further as the learned reasoning profile un-poisons; fresh orgs get the capped prior from turn one).
- Model-Auto easy prompt now picks the cheapest sufficient candidate (verified live + unit-pinned against the real five-model set: Haiku, not gemini-pro).
- Auto-mode worst-case classifier dead air halved by the 4 s cap.

Regression tests pin all three behavior changes (`select_model.test.ts`, `signals.test.ts`, `provider_files_cache.test.ts`); the stream-buffer suite covers the reveal gate via explicit options.

## Gate

`bun run check` green except `@tale/sandbox-runtime-daemon#test` → `tale-vision-read-hook > PDF when pdftotext missing` — fails identically on a clean main checkout on this machine (pdftotext installed at /opt/homebrew/bin); pre-existing, unrelated.

Deferred follow-ups (measured but structural/product-shaped) are tracked in #2776: per-turn ~19.3k-token payload, classifier/prep overlap, history-load join, E2E perf-budget spec.
