### PR TITLE
fix(platform): unblock org BYO object-storage browser delivery

### DIFF
--- a/docs/de/self-hosted/configuration/data-residency.md
+++ b/docs/de/self-hosted/configuration/data-residency.md
@@ -61,6 +61,8 @@ Anders als der deployment-weite S3-Schalter oben ist dieser Weg **nicht** nur f�
 
 Org-Admins verwalten auch diese Verbindung unter **Einstellungen > Datenresidenz der Organisation**; der dortige Verbindungstest führt einen echten Hochladen-Lesen-Löschen-Durchlauf gegen den Bucket aus, bevor du dich festlegst. Wie bei der Wissens-Verbindung bleiben die JSON-Dateien die Quelle der Wahrheit.
 
+> **Erlaube den Origin der App in der CORS-Policy des Buckets.** Uploads und Downloads laufen über vorsignierte URLs direkt zwischen Browser und Bucket, der Bucket muss Cross-Origin-Anfragen von der URL deines Deployments also akzeptieren — erlaube diesen Origin mit den Methoden `GET`, `PUT` und `HEAD` sowie allen Request-Headern (Cloudflare R2: **Settings > CORS Policy** des Buckets; AWS S3 und MinIO: die CORS-Konfiguration des Buckets). Der Verbindungstest in der App läuft auf dem Server, nicht im Browser — eine fehlende CORS-Policy zeigt sich deshalb erst später, als fehlgeschlagener Upload.
+
 ### Vorhandene Dateien in den Bucket verschieben
 
 Den Bucket zu verbinden leitet nur **neue** Uploads um; die Blobs, die vor der Verbindung geschrieben wurden, bleiben in Convex' `_storage` und funktionieren weiter über die gemischten Referenzen oben. Um auch diese Historie auf deine eigene Infrastruktur zu holen — der eigentliche Sinn der Datenresidenz — führe den **Blob-Backfill** aus: eine Operator-Aktion, die jeden vorhandenen Blob in den Bucket der Org kopiert, prüft, dass er Byte für Byte identisch zurückkommt, jede referenzierende Zeile umschreibt und die Convex-Kopie löscht.

--- a/docs/en/self-hosted/configuration/data-residency.md
+++ b/docs/en/self-hosted/configuration/data-residency.md
@@ -61,6 +61,8 @@ Unlike the deployment-wide S3 switch above, this path is **not** greenfield-only
 
 Org admins can manage this connection from **Settings > Organization data residency** too; its connection test performs a real upload/read/delete round-trip against the bucket before you commit. As with the knowledge connection, the JSON files remain the source of truth.
 
+> **Allow the app's origin in the bucket's CORS policy.** Uploads and downloads run directly between the browser and the bucket via presigned URLs, so the bucket must accept cross-origin requests from your deployment's URL — allow that origin with the methods `GET`, `PUT`, and `HEAD` and all request headers (Cloudflare R2: the bucket's **Settings > CORS Policy**; AWS S3 and MinIO: the bucket's CORS configuration). The in-app connection test runs from the server, not the browser, so a missing CORS policy surfaces only later, as a failed upload.
+
 ### Moving pre-existing files into the bucket
 
 Connecting the bucket only reroutes **new** uploads; the blobs written before you connected it stay in Convex's `_storage` and keep working through the mixed references above. To bring that history onto your own infrastructure as well — the whole point of data residency — run the **blob backfill**: an operator action that copies each pre-existing blob into the org's bucket, verifies it round-trips byte-for-byte, rewrites every row that references it, and deletes the Convex copy.

--- a/docs/fr/self-hosted/configuration/data-residency.md
+++ b/docs/fr/self-hosted/configuration/data-residency.md
@@ -61,6 +61,8 @@ Contrairement au basculement S3 au niveau du déploiement ci-dessus, ce chemin n
 
 Les admins d'org gèrent aussi cette connexion dans **Paramètres > Résidence des données de l'organisation** ; son test de connexion effectue un aller-retour réel écriture-lecture-suppression contre le bucket avant que tu t'engages. Comme pour la connexion des connaissances, les fichiers JSON restent la source de vérité.
 
+> **Autorise l'origine de l'app dans la politique CORS du bucket.** Les téléversements et les téléchargements passent directement du navigateur au bucket via des URL présignées : le bucket doit donc accepter les requêtes cross-origin depuis l'URL de ton déploiement — autorise cette origine avec les méthodes `GET`, `PUT` et `HEAD` et tous les en-têtes de requête (Cloudflare R2 : **Settings > CORS Policy** du bucket ; AWS S3 et MinIO : la configuration CORS du bucket). Le test de connexion dans l'app s'exécute côté serveur, pas dans le navigateur — une politique CORS manquante ne se montre donc que plus tard, sous la forme d'un téléversement échoué.
+
 ### Déplacer les fichiers pré-existants dans le bucket
 
 Connecter le bucket ne réachemine que les **nouveaux** téléversements ; les blobs écrits avant la connexion restent dans le `_storage` de Convex et continuent de fonctionner via les références mixtes ci-dessus. Pour amener aussi cet historique sur ta propre infrastructure — tout l'intérêt de la résidence des données — lance le **backfill de blobs** : une action d'opérateur qui copie chaque blob pré-existant dans le bucket de l'org, vérifie qu'il revient identique octet pour octet, réécrit chaque ligne qui le référence et supprime la copie Convex.

--- a/services/platform/app/features/settings/org-data-residency/components/org-data-residency-settings.test.tsx
+++ b/services/platform/app/features/settings/org-data-residency/components/org-data-residency-settings.test.tsx
@@ -378,6 +378,26 @@ describe('OrgDataResidencySettings', () => {
     expect(call).not.toHaveProperty('secretAccessKey');
   });
 
+  it('explains the bucket CORS requirement next to the storage form', () => {
+    setStorageFixture({
+      configured: true,
+      region: 'auto',
+      endpoint: 'https://acc.r2.cloudflarestorage.com',
+      forcePathStyle: true,
+      bucket: 'org-blobs',
+      hasCredentials: true,
+    });
+
+    render(<OrgDataResidencySettings organizationId="org-1" />);
+
+    // Browser-direct presigned PUT/GET needs a CORS policy on the org's
+    // bucket, and the server-side probe cannot detect a missing one — the
+    // panel has to say so, with the exact origin to allow.
+    expect(
+      screen.getByText(/must accept cross-origin \(CORS\) requests from/),
+    ).toBeInTheDocument();
+  });
+
   it('keeps the bucket probe disabled with blank fields when NO keys are stored', () => {
     setStorageFixture({
       configured: true,

--- a/services/platform/app/features/settings/org-data-residency/components/org-data-residency-settings.tsx
+++ b/services/platform/app/features/settings/org-data-residency/components/org-data-residency-settings.tsx
@@ -720,6 +720,11 @@ function StorageSection({
                   okLabel={t('orgDataResidency.storage.verified')}
                 />
               </HStack>
+              <Alert
+                description={t('orgDataResidency.storage.corsNote', {
+                  origin: window.location.origin,
+                })}
+              />
               <p className="text-muted-foreground text-xs">
                 {t('orgDataResidency.storage.note')}
               </p>

--- a/services/platform/convex/agent_tools/documents/document_retrieve_tool.test.ts
+++ b/services/platform/convex/agent_tools/documents/document_retrieve_tool.test.ts
@@ -6,7 +6,9 @@ import { documentRetrieveArgs } from './document_retrieve_tool';
 import { retrieveDocument } from './helpers/retrieve_document';
 
 const FILE_ID = 'file-storage-123';
-const ORG_ID = 'org1';
+// Production-shaped document id so orgSlugFromId's syntactic gate lets the
+// mocked runQuery answer through (short fixtures like 'org1' are rejected).
+const ORG_ID = 'jn7e5agwkrztazsh38bq0zt73n87e20w';
 const USER_ID = 'user1';
 const ORG_SLUG = 'org-1';
 

--- a/services/platform/convex/betterAuth/trusted_headers/get_user_by_id.ts
+++ b/services/platform/convex/betterAuth/trusted_headers/get_user_by_id.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../lib/utils/type-utils';
 import { components } from '../../_generated/api';
 import type { QueryCtx } from '../../_generated/server';
+import { looksLikeConvexDocumentId } from '../../lib/helpers/id_shape';
 
 export interface BetterAuthUser {
   _id: string;
@@ -26,6 +27,11 @@ export async function getUserById(
   ctx: QueryCtx,
   userId: string,
 ): Promise<BetterAuthUser | null> {
+  // Sentinels ('system'), slugs, and emails cannot be document ids; passing
+  // one into the component's `_id` filter throws INSIDE the component (an
+  // uncaught component-query error in the logs) before any caller's catch.
+  // They can only ever mean "no such user" — answer that here.
+  if (!looksLikeConvexDocumentId(userId)) return null;
   const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
     model: 'user',
     paginationOpts: {

--- a/services/platform/convex/crawler/index_pages.ts
+++ b/services/platform/convex/crawler/index_pages.ts
@@ -123,7 +123,15 @@ export const discoverUrls = internalAction({
         ? { ctx, organizationId: args.organizationId }
         : undefined,
     });
-    const inserted = await saveDiscoveredUrls(sql, args.domain, discovered);
+    // Threading the org slug lets the store self-heal the `websites` parent
+    // row (+ membership) on a pool this org switched to mid-flight — see
+    // `ensureWebsiteRow`.
+    const inserted = await saveDiscoveredUrls(
+      sql,
+      args.domain,
+      discovered,
+      args.orgSlug,
+    );
     return {
       domain: args.domain,
       urls: discovered,

--- a/services/platform/convex/crawler/lib/indexing_service.ts
+++ b/services/platform/convex/crawler/lib/indexing_service.ts
@@ -34,7 +34,7 @@ import {
   extractParagraphHashes,
   filterBoilerplateParagraphs,
 } from './paragraph_dedup';
-import { reindexChunks } from './website_store';
+import { ensureWebsiteRow, reindexChunks } from './website_store';
 
 const INDEXING_CONCURRENCY = 5;
 const _EXECUTEMANY_BATCH_SIZE = 25;
@@ -130,6 +130,10 @@ export async function indexPage(
 
   // --- Hash update + page count query + skip check (transactional + retried) ---
   const { pageCounts, existing } = await transactWithRetry(sql, async (tx) => {
+    // A crawl chain that crossed an org's pool switch (BYO database turned
+    // on/off mid-scan) lands on a pool without the `websites` parent row —
+    // self-heal it so the URL insert below can't die on the domain FK.
+    await ensureWebsiteRow(tx, domain, orgSlug);
     await tx.unsafe(
       `INSERT INTO ${SCHEMA}.website_urls (domain, url, status, discovered_at)
                    VALUES ($1, $2, 'active', NOW())

--- a/services/platform/convex/crawler/lib/website_store.test.ts
+++ b/services/platform/convex/crawler/lib/website_store.test.ts
@@ -2,8 +2,11 @@ import type { Sql } from 'postgres';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  DEFAULT_SCAN_INTERVAL_SECONDS,
+  ensureWebsiteRow,
   getWebsite,
   orgHasMembership,
+  saveDiscoveredUrls,
   updateScanStatus,
 } from './website_store';
 
@@ -52,5 +55,68 @@ describe('website_store tenant-pool routing', () => {
     expect(await getWebsite(sql, 'missing.example')).toBeNull();
     expect(unsafe).toHaveBeenCalledTimes(1);
     expect(String(unsafe.mock.calls[0][0])).toContain('public_web.websites');
+  });
+});
+
+/**
+ * Background crawl chains resolve their pool per action, so a chain that
+ * crosses an org's bring-your-own-database switch continues on a pool that
+ * never saw `registerWebsite` — its `website_urls` writes died on
+ * `website_urls_domain_fkey` (observed once on demo v0.3.6 one minute after
+ * switching an org's knowledge DB to a fresh Neon instance). The parent row
+ * must be ensured inside the same transaction as the URL insert.
+ */
+describe('ensureWebsiteRow self-heal', () => {
+  it('upserts the websites parent and the org membership idempotently', async () => {
+    const { sql, unsafe } = makeFakeSql();
+
+    await ensureWebsiteRow(sql, 'docs.example', 'acme');
+
+    expect(unsafe).toHaveBeenCalledTimes(2);
+    const [websitesSql, websitesParams] = unsafe.mock.calls[0];
+    expect(String(websitesSql)).toContain('INSERT INTO public_web.websites');
+    expect(String(websitesSql)).toContain('ON CONFLICT (domain) DO NOTHING');
+    expect(websitesParams).toEqual([
+      'docs.example',
+      DEFAULT_SCAN_INTERVAL_SECONDS,
+    ]);
+    const [membershipSql, membershipParams] = unsafe.mock.calls[1];
+    expect(String(membershipSql)).toContain(
+      'INSERT INTO public_web.website_org_memberships',
+    );
+    expect(membershipParams).toEqual(['docs.example', 'acme']);
+  });
+
+  it('skips the membership insert when no org slug is in hand', async () => {
+    const { sql, unsafe } = makeFakeSql();
+    await ensureWebsiteRow(sql, 'docs.example');
+    expect(unsafe).toHaveBeenCalledTimes(1);
+    expect(String(unsafe.mock.calls[0][0])).toContain('public_web.websites');
+  });
+
+  it('saveDiscoveredUrls ensures the parent before any URL insert', async () => {
+    const unsafe = vi.fn().mockResolvedValue([{ count: '0' }]);
+    const tx = { unsafe } as unknown as Sql;
+    const sql = {
+      begin: (cb: (tx: Sql) => Promise<number>) => cb(tx),
+    } as unknown as Sql;
+
+    await saveDiscoveredUrls(
+      sql,
+      'docs.example',
+      [{ url: 'https://x/1' }],
+      'acme',
+    );
+
+    const statements = unsafe.mock.calls.map((c) => String(c[0]));
+    const parentIdx = statements.findIndex((s) =>
+      s.includes('INSERT INTO public_web.websites'),
+    );
+    const urlIdx = statements.findIndex((s) =>
+      s.includes('INSERT INTO public_web.website_urls'),
+    );
+    expect(parentIdx).toBeGreaterThanOrEqual(0);
+    expect(urlIdx).toBeGreaterThanOrEqual(0);
+    expect(parentIdx).toBeLessThan(urlIdx);
   });
 });

--- a/services/platform/convex/crawler/lib/website_store.ts
+++ b/services/platform/convex/crawler/lib/website_store.ts
@@ -88,17 +88,60 @@ export interface DiscoveredUrl {
   url: string;
 }
 
+/** Scan cadence a website row gets when nothing chose one explicitly (6h) —
+ *  shared by user-initiated registration and the background self-heal. */
+export const DEFAULT_SCAN_INTERVAL_SECONDS = 21600;
+
+/**
+ * Idempotently make sure the `websites` parent row (and, when the caller
+ * carries one, the org's membership row) exists on THIS pool before a
+ * `website_urls` write.
+ *
+ * Background crawl chains resolve their org's knowledge pool per action, so a
+ * chain that started before an org switched to (or away from) a bring-your-own
+ * database continues on a pool that never saw `registerWebsite` — its
+ * `website_urls` insert then dies on `website_urls_domain_fkey` and the scan
+ * wedges until someone re-registers the domain by hand. Ensuring the parent at
+ * the write site makes any pool switch self-heal on the next crawl instead.
+ *
+ * `registerWebsite` stays the semantic owner of user-initiated registration
+ * (interval choice, `first_membership` signal); this helper only backfills the
+ * minimal rows a write needs, preserving any existing row untouched.
+ */
+export async function ensureWebsiteRow(
+  tx: Pick<Sql, 'unsafe'>,
+  domain: string,
+  orgSlug?: string,
+): Promise<void> {
+  await tx.unsafe(
+    `INSERT INTO ${SCHEMA}.websites (domain, scan_interval, created_at, updated_at)
+               VALUES ($1, $2, NOW(), NOW())
+               ON CONFLICT (domain) DO NOTHING`,
+    [domain, DEFAULT_SCAN_INTERVAL_SECONDS],
+  );
+  if (orgSlug) {
+    await tx.unsafe(
+      `INSERT INTO ${SCHEMA}.website_org_memberships (domain, org_slug)
+                 VALUES ($1, $2)
+                 ON CONFLICT DO NOTHING`,
+      [domain, orgSlug],
+    );
+  }
+}
+
 /** Save discovered URLs. Returns number of newly inserted URLs (excludes dupes). */
 export async function saveDiscoveredUrls(
   sql: Sql,
   domain: string,
   urls: DiscoveredUrl[],
+  orgSlug?: string,
 ): Promise<number> {
   if (urls.length === 0) {
     return 0;
   }
   return withRetry(() =>
     sql.begin(async (tx) => {
+      await ensureWebsiteRow(tx, domain, orgSlug);
       const before = await tx.unsafe<{ count: string }[]>(
         `SELECT COUNT(*) FROM ${SCHEMA}.website_urls WHERE domain = $1`,
         [domain],
@@ -640,7 +683,7 @@ export interface RegisterWebsiteResult {
 export async function registerWebsite(
   sql: Sql,
   domain: string,
-  scanInterval = 21600,
+  scanInterval = DEFAULT_SCAN_INTERVAL_SECONDS,
   orgSlug?: string,
 ): Promise<RegisterWebsiteResult> {
   if (!orgSlug) {

--- a/services/platform/convex/lib/helpers/id_shape.test.ts
+++ b/services/platform/convex/lib/helpers/id_shape.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { looksLikeConvexDocumentId } from './id_shape';
+
+describe('looksLikeConvexDocumentId', () => {
+  it('accepts real document-id shapes', () => {
+    // A production Better Auth organization id (32 chars, base-32).
+    expect(looksLikeConvexDocumentId('jn7e5agwkrztazsh38bq0zt73n87e20w')).toBe(
+      true,
+    );
+    expect(looksLikeConvexDocumentId('kd72m0v4d3sa8gh2plq9x1c5znb0e4tf')).toBe(
+      true,
+    );
+  });
+
+  it('rejects the sentinels and non-id strings that throw inside db.get', () => {
+    // The 'system' actor sentinel — the observed "Invalid ID length 6" spam.
+    expect(looksLikeConvexDocumentId('system')).toBe(false);
+    expect(looksLikeConvexDocumentId('')).toBe(false);
+    expect(looksLikeConvexDocumentId('larry-test')).toBe(false);
+    expect(looksLikeConvexDocumentId('user@example.com')).toBe(false);
+    expect(looksLikeConvexDocumentId('ABCDEFGHIJKLMNOPQRSTUVWXYZ012345')).toBe(
+      false,
+    );
+  });
+});

--- a/services/platform/convex/lib/helpers/id_shape.test.ts
+++ b/services/platform/convex/lib/helpers/id_shape.test.ts
@@ -13,6 +13,14 @@ describe('looksLikeConvexDocumentId', () => {
     );
   });
 
+  it('accepts convex-test synthetic document ids', () => {
+    // convex-test allocates ids as `<counter>;<tableName>`; these are real
+    // document ids in the in-process backend and must not be short-circuited.
+    expect(looksLikeConvexDocumentId('10000;organization')).toBe(true);
+    expect(looksLikeConvexDocumentId('1;user')).toBe(true);
+    expect(looksLikeConvexDocumentId('42;member')).toBe(true);
+  });
+
   it('rejects the sentinels and non-id strings that throw inside db.get', () => {
     // The 'system' actor sentinel — the observed "Invalid ID length 6" spam.
     expect(looksLikeConvexDocumentId('system')).toBe(false);
@@ -22,5 +30,8 @@ describe('looksLikeConvexDocumentId', () => {
     expect(looksLikeConvexDocumentId('ABCDEFGHIJKLMNOPQRSTUVWXYZ012345')).toBe(
       false,
     );
+    // Short alphanumeric fixtures used in mocked unit tests — not document ids.
+    expect(looksLikeConvexDocumentId('org1')).toBe(false);
+    expect(looksLikeConvexDocumentId('org_abc')).toBe(false);
   });
 });

--- a/services/platform/convex/lib/helpers/id_shape.ts
+++ b/services/platform/convex/lib/helpers/id_shape.ts
@@ -11,11 +11,17 @@
  * `'system'`, a slug, or an email in an id-typed field therefore turns into
  * permanent error spam instead of a clean "not found".
  *
- * Convex document ids are lowercase base-32 strings around 32 characters. The
- * accepted range here is deliberately generous so a future id-length change
- * cannot reject real ids, while still excluding every realistic sentinel,
- * slug (dashes), or email (`@`, dots).
+ * Two shapes are accepted:
+ * - Production Convex document ids: lowercase base-32, roughly 32 characters.
+ *   The length band is deliberately generous so a future id-length change
+ *   cannot reject real ids, while still excluding every realistic sentinel,
+ *   slug (dashes), or email (`@`, dots).
+ * - `convex-test` synthetic ids: `<digits>;<tableName>` (e.g.
+ *   `10000;organization`). These are real document ids in the in-process
+ *   test backend and must reach `db.get` the same way production ids do.
  */
 export function looksLikeConvexDocumentId(value: string): boolean {
-  return /^[0-9a-z]{20,64}$/.test(value);
+  return (
+    /^[0-9a-z]{20,64}$/.test(value) || /^\d+;[a-zA-Z][a-zA-Z0-9_]*$/.test(value)
+  );
 }

--- a/services/platform/convex/lib/helpers/id_shape.ts
+++ b/services/platform/convex/lib/helpers/id_shape.ts
@@ -1,0 +1,21 @@
+/**
+ * Syntactic pre-check for values about to cross into a component lookup by
+ * `_id`.
+ *
+ * The betterAuth component's adapter runs `db.get(value)` for `_id` filters,
+ * and `db.get` THROWS (`Unable to decode ID`) on any string that cannot be a
+ * document id. A thrown component query is recorded as an uncaught server
+ * error even when the platform-side caller catches the rejection — and to the
+ * caller it looks TRANSIENT (it is not an `OrgSlugUnresolvableError`-style
+ * terminal miss), so cron reconcilers retry it forever. A sentinel like
+ * `'system'`, a slug, or an email in an id-typed field therefore turns into
+ * permanent error spam instead of a clean "not found".
+ *
+ * Convex document ids are lowercase base-32 strings around 32 characters. The
+ * accepted range here is deliberately generous so a future id-length change
+ * cannot reject real ids, while still excluding every realistic sentinel,
+ * slug (dashes), or email (`@`, dots).
+ */
+export function looksLikeConvexDocumentId(value: string): boolean {
+  return /^[0-9a-z]{20,64}$/.test(value);
+}

--- a/services/platform/convex/lib/helpers/org_slug.test.ts
+++ b/services/platform/convex/lib/helpers/org_slug.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { orgSlugFromIdOrNull, orgSlugFromId } from './org_slug';
+
+/**
+ * The lookup must answer "no such org" for values that cannot BE document ids
+ * WITHOUT crossing into the betterAuth component: the component's `db.get`
+ * throws on them, which (a) logs an uncaught component-query error on every
+ * caller cadence — observed as 5-minutely GlitchTip spam from a cron
+ * reconciler resolving a `'system'`-style sentinel — and (b) looks transient
+ * to `orgSlugFromIdOrNull`, so the caller retries forever instead of folding
+ * to `null` once.
+ */
+describe('org slug lookup with non-id values', () => {
+  it('folds a sentinel to null without a component round-trip', async () => {
+    const runQuery = vi.fn();
+    const result = await orgSlugFromIdOrNull({ runQuery }, 'system');
+    expect(result).toBeNull();
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('throws the terminal OrgSlugUnresolvableError from the strict variant', async () => {
+    const runQuery = vi.fn();
+    await expect(orgSlugFromId({ runQuery }, 'not-an-id')).rejects.toThrow(
+      /no organization row found/,
+    );
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('still resolves a real-shaped id through the component', async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValue({ slug: 'test', name: 'larry-test' });
+    const result = await orgSlugFromIdOrNull(
+      { runQuery },
+      'jn7e5agwkrztazsh38bq0zt73n87e20w',
+    );
+    expect(result).toBe('test');
+    expect(runQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/convex/lib/helpers/org_slug.ts
+++ b/services/platform/convex/lib/helpers/org_slug.ts
@@ -9,6 +9,7 @@
 
 import { getString, isRecord } from '../../../lib/utils/type-utils';
 import { components } from '../../_generated/api';
+import { looksLikeConvexDocumentId } from './id_shape';
 
 // Loose ctx shape so all of: Convex ActionCtx, ToolCtx, query/mutation
 // ctxs can pass through. The runQuery signature on the real Convex
@@ -94,6 +95,14 @@ export async function orgIdentityFromId(
   ctx: CtxWithRunQuery,
   organizationId: string,
 ): Promise<OrgIdentity> {
+  // A value that cannot BE a document id (a sentinel like 'system', a slug,
+  // an email) would throw INSIDE the betterAuth component — logged there as
+  // an uncaught error on every caller cadence, and non-terminal to
+  // `orgSlugFromIdOrNull`, so cron reconcilers would retry it forever.
+  // Treat it as the permanent miss it is.
+  if (!looksLikeConvexDocumentId(organizationId)) {
+    throw new OrgSlugUnresolvableError(organizationId, 'no_row');
+  }
   const row = await ctx.runQuery(components.betterAuth.adapter.findOne, {
     model: 'organization',
     where: [{ field: '_id', value: organizationId, operator: 'eq' }],

--- a/services/platform/convex/organizations/resolve_org_slug.test.ts
+++ b/services/platform/convex/organizations/resolve_org_slug.test.ts
@@ -12,23 +12,28 @@ function makeCtx(findOneResult: unknown) {
   };
 }
 
+// Production-shaped document id so orgSlugFromId's syntactic gate lets the
+// mocked runQuery answer through (short fixtures like 'org_abc' are rejected).
+const ORG_ID = 'jn7e5agwkrztazsh38bq0zt73n87e20w';
+const MISSING_ORG_ID = 'kd72m0v4d3sa8gh2plq9x1c5znb0e4tf';
+
 describe('resolveOrgSlug', () => {
   it('returns the slug for an existing organization', async () => {
-    const ctx = makeCtx({ _id: 'org_abc', slug: 'acme' });
-    await expect(resolveOrgSlug(ctx as never, 'org_abc')).resolves.toBe('acme');
+    const ctx = makeCtx({ _id: ORG_ID, slug: 'acme' });
+    await expect(resolveOrgSlug(ctx as never, ORG_ID)).resolves.toBe('acme');
   });
 
   it('throws when the organization is not found', async () => {
     const ctx = makeCtx(null);
-    await expect(resolveOrgSlug(ctx as never, 'org_missing')).rejects.toThrow(
-      /no organization row found for id .*org_missing/,
+    await expect(resolveOrgSlug(ctx as never, MISSING_ORG_ID)).rejects.toThrow(
+      /no organization row found for id .*kd72m0v4d3sa8gh2plq9x1c5znb0e4tf/,
     );
   });
 
   it('throws when the organization row is missing a slug field', async () => {
-    const ctx = makeCtx({ _id: 'org_abc' });
-    await expect(resolveOrgSlug(ctx as never, 'org_abc')).rejects.toThrow(
-      /organization .*org_abc.* has no slug/,
+    const ctx = makeCtx({ _id: ORG_ID });
+    await expect(resolveOrgSlug(ctx as never, ORG_ID)).rejects.toThrow(
+      /organization .*jn7e5agwkrztazsh38bq0zt73n87e20w.* has no slug/,
     );
   });
 });

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.test.ts
@@ -13,13 +13,17 @@ import { uploadFile } from './upload_file_direct';
 
 const uploadFileMock = vi.mocked(uploadFile);
 
+// Production-shaped document id so orgSlugFromId's syntactic gate lets the
+// mocked runQuery answer through (short fixtures like 'org-1' are rejected).
+const ORG_ID = 'jn7e5agwkrztazsh38bq0zt73n87e20w';
+
 const DEFAULT_METADATA = {
   fileName: 'document.pdf',
   contentType: 'application/pdf',
-  organizationId: 'org-1',
+  organizationId: ORG_ID,
 };
 
-const DEFAULT_ORG_ROW = { _id: 'org-1', slug: 'default' };
+const DEFAULT_ORG_ROW = { _id: ORG_ID, slug: 'default' };
 
 /**
  * `uploadDocument` no longer downloads the file into a Blob — the in-process
@@ -88,7 +92,7 @@ describe('uploadDocument', () => {
       fileName: 'contract.docx',
       contentType:
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      organizationId: 'org-1',
+      organizationId: ORG_ID,
     });
 
     await uploadDocument(ctx as never, FILE_ID);
@@ -105,7 +109,7 @@ describe('uploadDocument', () => {
       fileName: 'contract.docx',
       contentType:
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      organizationId: 'org-1',
+      organizationId: ORG_ID,
     });
 
     await uploadDocument(ctx as never, FILE_ID, {
@@ -123,7 +127,7 @@ describe('uploadDocument', () => {
     const ctx = createCtx({
       fileName: 'report',
       contentType: 'application/pdf',
-      organizationId: 'org-1',
+      organizationId: ORG_ID,
     });
 
     await uploadDocument(ctx as never, FILE_ID);

--- a/services/platform/lib/org-storage-origins.test.ts
+++ b/services/platform/lib/org-storage-origins.test.ts
@@ -1,0 +1,189 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  collectOrgObjectStorageOrigins,
+  createOrgObjectStorageOriginsProvider,
+  originsForConnection,
+} from './org-storage-origins';
+
+const tempDirs: string[] = [];
+
+function makeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'org-storage-origins-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeOrgConnection(
+  configDir: string,
+  orgSlug: string,
+  content: string,
+): void {
+  const domainDir = join(configDir, orgSlug, 'object-storage');
+  mkdirSync(domainDir, { recursive: true });
+  writeFileSync(join(domainDir, 'connection.json'), content);
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('originsForConnection', () => {
+  test('uses the endpoint origin when an endpoint is set (MinIO/R2)', () => {
+    expect(
+      originsForConnection({
+        endpoint: 'https://acc.r2.cloudflarestorage.com',
+        bucket: 'blobs',
+        region: 'auto',
+      }),
+    ).toEqual(['https://acc.r2.cloudflarestorage.com']);
+  });
+
+  test('strips path and port details down to the origin', () => {
+    expect(
+      originsForConnection({ endpoint: 'http://minio.internal:9100/extra' }),
+    ).toEqual(['http://minio.internal:9100']);
+  });
+
+  test('derives both AWS addressing styles when no endpoint is set', () => {
+    expect(
+      originsForConnection({ bucket: 'my-blobs', region: 'eu-central-1' }),
+    ).toEqual([
+      'https://my-blobs.s3.eu-central-1.amazonaws.com',
+      'https://s3.eu-central-1.amazonaws.com',
+    ]);
+  });
+
+  test('returns nothing for an unparsable endpoint, with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(originsForConnection({ endpoint: 'not a url' })).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  test('rejects bucket/region values outside the S3 alphabet (header-injection guard)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(
+      originsForConnection({ bucket: 'x.com; script-src *', region: 'auto' }),
+    ).toEqual([]);
+    expect(
+      originsForConnection({ bucket: 'ok-bucket', region: 'evil *' }),
+    ).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('collectOrgObjectStorageOrigins', () => {
+  test('collects, dedupes and sorts origins across orgs', () => {
+    const dir = makeConfigDir();
+    writeOrgConnection(
+      dir,
+      'org-a',
+      JSON.stringify({
+        region: 'auto',
+        endpoint: 'https://acc.r2.cloudflarestorage.com',
+        bucket: 'a-blobs',
+        forcePathStyle: true,
+      }),
+    );
+    writeOrgConnection(
+      dir,
+      'org-b',
+      JSON.stringify({
+        region: 'auto',
+        endpoint: 'https://acc.r2.cloudflarestorage.com',
+        bucket: 'b-blobs',
+        forcePathStyle: true,
+      }),
+    );
+    writeOrgConnection(
+      dir,
+      'org-c',
+      JSON.stringify({
+        region: 'us-east-1',
+        bucket: 'c-blobs',
+        forcePathStyle: false,
+      }),
+    );
+    expect(collectOrgObjectStorageOrigins(dir)).toEqual([
+      'https://acc.r2.cloudflarestorage.com',
+      'https://c-blobs.s3.us-east-1.amazonaws.com',
+      'https://s3.us-east-1.amazonaws.com',
+    ]);
+  });
+
+  test('ignores orgs without an object-storage config, silently', () => {
+    const dir = makeConfigDir();
+    mkdirSync(join(dir, 'org-without-storage', 'branding'), {
+      recursive: true,
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(collectOrgObjectStorageOrigins(dir)).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('skips malformed JSON with a warning instead of throwing', () => {
+    const dir = makeConfigDir();
+    writeOrgConnection(dir, 'org-broken', '{not json');
+    writeOrgConnection(
+      dir,
+      'org-ok',
+      JSON.stringify({
+        region: 'auto',
+        endpoint: 'https://acc.r2.cloudflarestorage.com',
+        bucket: 'blobs',
+      }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(collectOrgObjectStorageOrigins(dir)).toEqual([
+      'https://acc.r2.cloudflarestorage.com',
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns [] for an unreadable config dir, with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(
+      collectOrgObjectStorageOrigins(join(tmpdir(), 'does-not-exist-xyz')),
+    ).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('createOrgObjectStorageOriginsProvider', () => {
+  test('always returns [] without a config dir', () => {
+    expect(createOrgObjectStorageOriginsProvider(null)()).toEqual([]);
+    expect(createOrgObjectStorageOriginsProvider(undefined)()).toEqual([]);
+  });
+
+  test('serves cached origins inside the TTL and rescans after it', () => {
+    vi.useFakeTimers();
+    const dir = makeConfigDir();
+    const provider = createOrgObjectStorageOriginsProvider(dir, 5000);
+    expect(provider()).toEqual([]);
+
+    // A save landing inside the TTL is not visible yet…
+    writeOrgConnection(
+      dir,
+      'org-a',
+      JSON.stringify({
+        region: 'auto',
+        endpoint: 'https://acc.r2.cloudflarestorage.com',
+        bucket: 'blobs',
+      }),
+    );
+    expect(provider()).toEqual([]);
+
+    // …but is after the TTL elapses.
+    vi.advanceTimersByTime(5001);
+    expect(provider()).toEqual(['https://acc.r2.cloudflarestorage.com']);
+    vi.useRealTimers();
+  });
+});

--- a/services/platform/lib/org-storage-origins.ts
+++ b/services/platform/lib/org-storage-origins.ts
@@ -31,6 +31,11 @@ interface OriginExtractionInput {
   region?: unknown;
 }
 
+/** True iff `err` is a Node ErrnoException with the given code. */
+function isErrnoCode(err: unknown, code: string): boolean {
+  return err instanceof Error && 'code' in err && err.code === code;
+}
+
 /**
  * Derive the browser-facing origin(s) for one org's connection file content.
  * With an explicit endpoint (MinIO/R2/Wasabi) the origin is the endpoint's.
@@ -107,7 +112,7 @@ export function collectOrgObjectStorageOrigins(configDir: string): string[] {
     } catch (err) {
       // Almost every org has no object-storage config — only warn on
       // anything other than the file simply not existing.
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      if (!isErrnoCode(err, 'ENOENT')) {
         console.warn(`[org-storage-origins] cannot read ${file}`, err);
       }
       continue;

--- a/services/platform/lib/org-storage-origins.ts
+++ b/services/platform/lib/org-storage-origins.ts
@@ -1,0 +1,159 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  OBJECT_STORAGE_CONFIG_DOMAIN,
+  OBJECT_STORAGE_CONNECTION_KEY,
+} from './shared/schemas/object_storage';
+
+/**
+ * Origins the browser must be allowed to reach for per-org bring-your-own
+ * object storage (`<TALE_CONFIG_DIR>/<orgSlug>/object-storage/connection.json`).
+ *
+ * With an org bucket configured, `files/blob_actions.generateBlobUpload` hands
+ * the browser a presigned PUT addressed at the org's EXTERNAL endpoint, and the
+ * `/storage` httpAction 302-redirects document GETs to presigned URLs on that
+ * same endpoint — so the SPA's CSP (`connect-src` for fetch/XHR, `img-src` /
+ * `media-src` for redirected media loads) must include those origins or the
+ * browser kills the transfer before it leaves the page. The rest of the CSP
+ * stays strict; see the policy comment in `server.ts`.
+ *
+ * Extraction is deliberately LOOSE (no schema validation): the authoritative
+ * validation happens in Convex at write time, and a platform container running
+ * one release behind the config writer must still emit the origin rather than
+ * strict-parse-fail into a broken upload. Unreadable or malformed files are
+ * skipped with a warning — never thrown.
+ */
+
+interface OriginExtractionInput {
+  endpoint?: unknown;
+  bucket?: unknown;
+  region?: unknown;
+}
+
+/**
+ * Derive the browser-facing origin(s) for one org's connection file content.
+ * With an explicit endpoint (MinIO/R2/Wasabi) the origin is the endpoint's.
+ * Without one (AWS S3 proper) the presigned URL lands on the regional AWS
+ * host — virtual-hosted (`<bucket>.s3.<region>.amazonaws.com`) by default,
+ * path-style (`s3.<region>.amazonaws.com`) under `forcePathStyle` — so both
+ * are returned rather than mirroring the SDK's style choice here.
+ */
+export function originsForConnection(conn: OriginExtractionInput): string[] {
+  if (typeof conn.endpoint === 'string' && conn.endpoint.length > 0) {
+    try {
+      return [new URL(conn.endpoint).origin];
+    } catch (err) {
+      console.warn(
+        '[org-storage-origins] unparsable endpoint URL; skipping',
+        { endpoint: conn.endpoint },
+        err,
+      );
+      return [];
+    }
+  }
+  if (typeof conn.bucket === 'string' && typeof conn.region === 'string') {
+    // These two values are interpolated into a response HEADER — restrict
+    // them to the S3 bucket-name / region alphabets so a hostile config
+    // value (a `;`, whitespace, `*`) can never smuggle extra CSP sources
+    // or directives. The endpoint branch above is immune (URL.origin).
+    if (
+      !/^[a-z0-9.-]{3,63}$/.test(conn.bucket) ||
+      !/^[a-z0-9-]{1,32}$/.test(conn.region)
+    ) {
+      console.warn(
+        '[org-storage-origins] bucket/region outside the S3 alphabet; skipping',
+        { bucket: conn.bucket, region: conn.region },
+      );
+      return [];
+    }
+    return [
+      `https://${conn.bucket}.s3.${conn.region}.amazonaws.com`,
+      `https://s3.${conn.region}.amazonaws.com`,
+    ];
+  }
+  return [];
+}
+
+/**
+ * Scan every org's `object-storage/connection.json` under `configDir` and
+ * return the deduplicated, sorted set of storage origins. Missing files and
+ * unreadable JSON are skipped (warned, never thrown) — a broken org config
+ * must not take the security headers down with it.
+ */
+export function collectOrgObjectStorageOrigins(configDir: string): string[] {
+  const origins = new Set<string>();
+  let entries;
+  try {
+    entries = readdirSync(configDir, { withFileTypes: true });
+  } catch (err) {
+    console.warn(
+      `[org-storage-origins] cannot read config dir ${configDir}`,
+      err,
+    );
+    return [];
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const file = join(
+      configDir,
+      entry.name,
+      OBJECT_STORAGE_CONFIG_DOMAIN,
+      `${OBJECT_STORAGE_CONNECTION_KEY}.json`,
+    );
+    let raw: string;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch (err) {
+      // Almost every org has no object-storage config — only warn on
+      // anything other than the file simply not existing.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`[org-storage-origins] cannot read ${file}`, err);
+      }
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      console.warn(`[org-storage-origins] invalid JSON in ${file}`, err);
+      continue;
+    }
+    if (typeof parsed !== 'object' || parsed === null) continue;
+    for (const origin of originsForConnection(
+      parsed as OriginExtractionInput,
+    )) {
+      origins.add(origin);
+    }
+  }
+  return [...origins].sort();
+}
+
+/**
+ * TTL-cached provider around `collectOrgObjectStorageOrigins`, called on every
+ * response by the security-header middleware. The scan is a handful of file
+ * reads, but per-response would still be wasteful — and org storage configs
+ * change rarely (an admin saving the data-residency panel). A short TTL keeps
+ * the window between "panel saved" and "CSP carries the new origin" small
+ * without wiring into the config watcher (whose lifecycle is gated by the
+ * optional TALE_FILE_EVENTS flag, which security headers must not depend on).
+ *
+ * A `null`/absent config dir (e.g. unit tests, split deployments without the
+ * mount) yields a provider that always returns `[]`.
+ */
+export function createOrgObjectStorageOriginsProvider(
+  configDir: string | null | undefined,
+  ttlMs = 5000,
+): () => readonly string[] {
+  if (!configDir) return () => [];
+  let cached: readonly string[] = [];
+  let lastScanAt = -Infinity;
+  return () => {
+    const now = Date.now();
+    if (now - lastScanAt >= ttlMs) {
+      cached = collectOrgObjectStorageOrigins(configDir);
+      lastScanAt = now;
+    }
+    return cached;
+  };
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7196,6 +7196,7 @@
         "prefixHint": "Optionaler Namensraum im Bucket; leer legt Objekte direkt im Bucket ab.",
         "credentialsHint": "Nur Schreiben — gespeicherte Schlüssel werden nie angezeigt. Gib beide Schlüssel ein oder lass beide leer, um die gespeicherten Schlüssel zu testen.",
         "verified": "Bucket geprüft (Hochladen, Lesen, Löschen)",
+        "corsNote": "Uploads und Downloads laufen direkt zwischen Browser und deinem Bucket. Der Bucket muss deshalb Cross-Origin-Anfragen (CORS) von {origin} akzeptieren — erlaube diesen Origin mit den Methoden GET, PUT und HEAD sowie allen Request-Headern. Der Verbindungstest läuft auf dem Server und kann das nicht prüfen.",
         "note": "Ohne Verbindung liegen die Dateien dieser Organisation im eingebauten Speicher des Deployments, pro Organisation isoliert. Mit Verbindung landen neue Uploads im oben angegebenen Bucket; zuvor gespeicherte Dateien bleiben lesbar, wo sie sind.",
         "saved": "Gespeichert — neue Uploads dieser Organisation landen in deinem Bucket.",
         "cleared": "Verbindung entfernt — neue Uploads landen wieder im eingebauten Speicher des Deployments. Dateien in deinem Bucket bleiben dort, sind für Tale aber erst wieder verfügbar, wenn du die Verbindung erneut einrichtest.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7487,6 +7487,7 @@
         "prefixHint": "Optional namespace inside the bucket; blank stores objects at the bucket root.",
         "credentialsHint": "Write-only — stored keys are never shown. Enter both keys, or leave both blank to test the stored keys.",
         "verified": "Bucket verified (upload, read, delete)",
+        "corsNote": "Uploads and downloads run directly between the browser and your bucket, so the bucket must accept cross-origin (CORS) requests from {origin} — allow that origin with the GET, PUT and HEAD methods and all request headers. The connection test runs on the server and cannot check this.",
         "note": "Off, this organization's files live in the deployment's built-in storage, isolated per organization. On, new uploads go to the bucket above; files stored before the switch stay readable where they are.",
         "saved": "Saved — this organization's new uploads go to your bucket.",
         "cleared": "Connection removed — new uploads go back to the deployment's built-in storage. Files already in your bucket stay there but are unavailable to Tale until you reconnect it.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7196,6 +7196,7 @@
         "prefixHint": "Espace de noms optionnel dans le bucket ; vide, les objets sont stockés à la racine.",
         "credentialsHint": "Écriture seule — les clés stockées ne sont jamais affichées. Saisis les deux clés, ou laisse-les vides pour tester les clés enregistrées.",
         "verified": "Bucket vérifié (écriture, lecture, suppression)",
+        "corsNote": "Les téléversements et les téléchargements passent directement du navigateur à ton bucket : le bucket doit donc accepter les requêtes cross-origin (CORS) depuis {origin} — autorise cette origine avec les méthodes GET, PUT et HEAD et tous les en-têtes de requête. Le test de connexion s'exécute côté serveur et ne peut pas le vérifier.",
         "note": "Désactivé, les fichiers de cette organisation restent dans le stockage intégré du déploiement, isolés par organisation. Activé, les nouveaux téléversements vont dans le bucket ci-dessus ; les fichiers stockés avant le changement restent lisibles là où ils sont.",
         "saved": "Enregistré — les nouveaux téléversements de cette organisation vont dans ton bucket.",
         "cleared": "Connexion supprimée — les nouveaux téléversements retournent dans le stockage intégré du déploiement. Les fichiers déjà dans ton bucket y restent, mais Tale ne peut plus les lire tant que tu ne rétablis pas la connexion.",

--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -184,6 +184,54 @@ describe('security headers', () => {
     // Same-origin assets are covered by `'self'`; no extra origin is emitted.
     expect(csp).toContain("font-src 'self' data:");
   });
+
+  // Org BYO object storage hands the browser presigned PUT/GET URLs on the
+  // org's EXTERNAL endpoint (files/blob_actions.generateBlobUpload, the
+  // /storage 302 lane), so those origins must be allow-listed or every
+  // browser-direct upload dies as `net::ERR_BLOCKED_BY_CSP` — the exact
+  // failure observed on demo v0.3.6 with a Cloudflare R2 bucket configured.
+  test('org BYO storage origins join connect-src, img-src and media-src', async () => {
+    const app = createApp(baseEnv, {
+      orgStorageOrigins: () => ['https://acc.r2.cloudflarestorage.com'],
+    });
+    const res = await app.fetch(new Request('http://localhost/api/health'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    const directive = (name: string) =>
+      csp
+        .split(';')
+        .map((d) => d.trim())
+        .find((d) => d.startsWith(name)) ?? '';
+    expect(directive('connect-src')).toContain(
+      'https://acc.r2.cloudflarestorage.com',
+    );
+    expect(directive('img-src')).toContain(
+      'https://acc.r2.cloudflarestorage.com',
+    );
+    expect(directive('media-src')).toContain(
+      'https://acc.r2.cloudflarestorage.com',
+    );
+    // The storage origin must not leak into execution or framing directives.
+    expect(directive('script-src')).not.toContain('r2.cloudflarestorage.com');
+    expect(directive('frame-src')).not.toContain('r2.cloudflarestorage.com');
+    expect(directive('default-src')).toBe("default-src 'self'");
+  });
+
+  test('a data-residency save reaches the CSP without a restart', async () => {
+    let origins: readonly string[] = [];
+    const app = createApp(baseEnv, { orgStorageOrigins: () => origins });
+
+    const before = await app.fetch(new Request('http://localhost/api/health'));
+    expect(before.headers.get('content-security-policy')).not.toContain(
+      'r2.cloudflarestorage.com',
+    );
+
+    // The org admin saves an external bucket; the provider now reports it.
+    origins = ['https://acc.r2.cloudflarestorage.com'];
+    const after = await app.fetch(new Request('http://localhost/api/health'));
+    expect(after.headers.get('content-security-policy')).toContain(
+      "connect-src 'self' https://acc.r2.cloudflarestorage.com",
+    );
+  });
 });
 
 describe('POST /canvas-preview', () => {

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -12,6 +12,7 @@ import {
   wrapCanvasPreviewHtml,
 } from './lib/canvas-preview-shell';
 import { createConfigWatcher } from './lib/config-watcher';
+import { createOrgObjectStorageOriginsProvider } from './lib/org-storage-origins';
 import {
   createScreencastRelayHandler,
   type ScreencastWsData,
@@ -103,6 +104,15 @@ if (fileEventsEnabled && configDir && existsSync(configDir)) {
   });
   console.log(`Config file watcher active: ${configDir}`);
 }
+
+// Live view of the org BYO object-storage endpoint origins the CSP must
+// allow (see the security-headers comment block below). Deliberately NOT
+// gated by TALE_FILE_EVENTS — security headers must not depend on the SSE
+// feature flag; the provider is a no-op returning `[]` when the config dir
+// isn't mounted.
+const defaultOrgStorageOrigins = createOrgObjectStorageOriginsProvider(
+  configDir ?? null,
+);
 
 /**
  * Resolve the org slugs the current session is allowed to receive
@@ -411,11 +421,24 @@ function getEnvConfig(): EnvConfig {
 //     transfer (lawful basis, DPA, transparency notice are operator's
 //     responsibility). Most operators should leave it empty and rely on
 //     the libraries vendored under `public/canvas-libs/` instead.
+//   - Org bring-your-own object storage: endpoint origins read from
+//     `<TALE_CONFIG_DIR>/<orgSlug>/object-storage/connection.json` are
+//     appended to connect-src (browser-direct presigned PUT uploads +
+//     fetch-based downloads) and img-src / media-src (the `/storage`
+//     route 302s media to presigned GETs on the same endpoint). These are
+//     org-admin-configured storage backends holding the org's OWN data —
+//     the org, not a third party, is the controller — so they don't fall
+//     under the CDN prohibition above. Sourced live from config (see
+//     `lib/org-storage-origins.ts`), never from env.
 //
-// All Convex traffic — including storage uploads via `generateUploadUrl()`
-// and storage downloads — flows same-origin through Caddy (`/ws_api`,
-// `/api/storage/*`), so `'self'` covers it without needing any
-// `*.convex.cloud` / `*.convex.site` entries. SITE_URL hostname determines
+// All OTHER Convex traffic — including deployment-default storage uploads
+// via `generateUploadUrl()` and storage downloads — flows same-origin
+// through Caddy (`/ws_api`, `/api/storage/*`), so `'self'` covers it
+// without needing any `*.convex.cloud` / `*.convex.site` entries. The one
+// exception is the org BYO object-storage lane above: `generateBlobUpload`
+// hands the browser a presigned PUT addressed directly at the org's
+// endpoint, deliberately bypassing the platform so multi-hundred-MB blobs
+// never transit (or OOM) the server. SITE_URL hostname determines
 // whether HSTS is emitted (only when the deployment is HTTPS).
 // ---------------------------------------------------------------------------
 
@@ -452,7 +475,10 @@ function siteOriginFromUrl(siteUrl: string | undefined): string | null {
   }
 }
 
-function buildContentSecurityPolicy(env: EnvConfig) {
+function buildContentSecurityPolicy(
+  env: EnvConfig,
+  orgStorageOrigins: readonly string[] = [],
+) {
   const sentryOrigin = sentryOriginFromDsn(env.SENTRY_DSN);
   const sentry = sentryOrigin ? [sentryOrigin] : [];
   const figmaMcp = isLoopbackSite(env) ? ['https://mcp.figma.com'] : [];
@@ -476,9 +502,9 @@ function buildContentSecurityPolicy(env: EnvConfig) {
       ...figmaMcp,
     ],
     styleSrc: ["'self'", "'unsafe-inline'"],
-    imgSrc: ["'self'", 'data:', 'blob:', ...branding],
+    imgSrc: ["'self'", 'data:', 'blob:', ...branding, ...orgStorageOrigins],
     fontSrc: ["'self'", 'data:', ...branding],
-    connectSrc: ["'self'", ...sentry],
+    connectSrc: ["'self'", ...sentry, ...orgStorageOrigins],
     workerSrc: ["'self'", 'blob:'],
     frameSrc: ["'self'"],
     frameAncestors: ["'none'"],
@@ -486,8 +512,10 @@ function buildContentSecurityPolicy(env: EnvConfig) {
     formAction: ["'self'"],
     objectSrc: ["'none'"],
     // TTS playback streams audio from same-origin `/http_api/api/tts-audio`
-    // via `<audio>.src`, so `'self'` is required.
-    mediaSrc: ["'self'"],
+    // via `<audio>.src`, so `'self'` is required. Org BYO storage origins
+    // are included because `/storage` 302s audio/video attachments to
+    // presigned GETs on the org's endpoint.
+    mediaSrc: ["'self'", ...orgStorageOrigins],
   };
 }
 
@@ -507,41 +535,69 @@ function isLoopbackSite(env: EnvConfig): boolean {
   }
 }
 
-export function createApp(env: EnvConfig = getEnvConfig()): Hono {
+export interface CreateAppOptions {
+  /**
+   * Test seam for the org BYO object-storage origins fed into the CSP.
+   * Production uses the TTL-cached `TALE_CONFIG_DIR` scan.
+   */
+  orgStorageOrigins?: () => readonly string[];
+}
+
+export function createApp(
+  env: EnvConfig = getEnvConfig(),
+  opts: CreateAppOptions = {},
+): Hono {
   const app = new Hono();
 
-  const secure = secureHeaders({
-    contentSecurityPolicy: buildContentSecurityPolicy(env),
-    // 180 days. No `includeSubDomains`, no `preload` — self-deployed
-    // operators run on varied domains and don't own preload submission.
-    strictTransportSecurity: isHttpsSite(env) ? 'max-age=15552000' : false,
-    xContentTypeOptions: 'nosniff',
-    xFrameOptions: 'DENY',
-    referrerPolicy: 'strict-origin-when-cross-origin',
-    permissionsPolicy: {
-      camera: [],
-      microphone: ['self'],
-      // Active features: location-request approval card uses geolocation;
-      // copy-to-clipboard hook is wired into many UI surfaces; live-browser
-      // human takeover reads the host clipboard (`navigator.clipboard.readText`)
-      // to bridge a paste into the remote session — both need same-origin grants.
-      geolocation: ['self'],
-      clipboardWrite: ['self'],
-      clipboardRead: ['self'],
-      usb: [],
-      payment: [],
-      bluetooth: [],
-      midi: [],
-      hid: [],
-      serial: [],
-    },
-    // Defaults that would interfere with same-origin embeds and OAuth
-    // popups; we explicitly lean on CSP `frame-ancestors` and
-    // `frame-src` instead.
-    crossOriginEmbedderPolicy: false,
-    crossOriginOpenerPolicy: false,
-    crossOriginResourcePolicy: false,
-  });
+  const makeSecure = (storageOrigins: readonly string[]) =>
+    secureHeaders({
+      contentSecurityPolicy: buildContentSecurityPolicy(env, storageOrigins),
+      // 180 days. No `includeSubDomains`, no `preload` — self-deployed
+      // operators run on varied domains and don't own preload submission.
+      strictTransportSecurity: isHttpsSite(env) ? 'max-age=15552000' : false,
+      xContentTypeOptions: 'nosniff',
+      xFrameOptions: 'DENY',
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      permissionsPolicy: {
+        camera: [],
+        microphone: ['self'],
+        // Active features: location-request approval card uses geolocation;
+        // copy-to-clipboard hook is wired into many UI surfaces; live-browser
+        // human takeover reads the host clipboard (`navigator.clipboard.readText`)
+        // to bridge a paste into the remote session — both need same-origin grants.
+        geolocation: ['self'],
+        clipboardWrite: ['self'],
+        clipboardRead: ['self'],
+        usb: [],
+        payment: [],
+        bluetooth: [],
+        midi: [],
+        hid: [],
+        serial: [],
+      },
+      // Defaults that would interfere with same-origin embeds and OAuth
+      // popups; we explicitly lean on CSP `frame-ancestors` and
+      // `frame-src` instead.
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+      crossOriginResourcePolicy: false,
+    });
+  // Org BYO storage endpoints are runtime config (the org data-residency
+  // panel writes them, no restart involved), so the CSP has to follow
+  // without a process restart: re-check the (TTL-cached) origin set per
+  // request and rebuild the middleware only when it actually changed.
+  const orgStorageOrigins = opts.orgStorageOrigins ?? defaultOrgStorageOrigins;
+  let secureOriginsKey: string | null = null;
+  let secure = makeSecure([]);
+  const currentSecure = () => {
+    const origins = orgStorageOrigins();
+    const key = origins.join(' ');
+    if (key !== secureOriginsKey) {
+      secureOriginsKey = key;
+      secure = makeSecure(origins);
+    }
+    return secure;
+  };
   // WebDAV-specific narrow variant: CSP is dropped (DAV bodies are raw
   // blobs / XML, not HTML — CSP rewrites would confuse clients like
   // Finder and rclone), but HSTS, X-Frame-Options, X-Content-Type-Options,
@@ -570,7 +626,7 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
     if (c.req.path === '/canvas-preview') return next();
     if (c.req.path.startsWith('/dav/') || c.req.path === '/dav')
       return secureForDav(c, next);
-    return secure(c, next);
+    return currentSecure()(c, next);
   });
 
   app.post('/canvas-preview', async (c) => {


### PR DESCRIPTION
## Context

Live E2E of **org data residency** on demo.tale.dev v0.3.6 (org `larry-test`, fresh admin account), pointing the org at a **Cloudflare R2 bucket** and a **Neon Postgres** knowledge DB. Config went green end-to-end (both probes OK, saves applied, stored-secret re-test OK) — then the first real 59.7 MB browser upload failed instantly. Everything found on the way is fixed in this one branch.

## Fix 1 — platform CSP blocked every browser-direct S3 transfer

`generateBlobUpload` (S3 branch) hands the browser a **presigned PUT addressed at the org's external endpoint**, and the `/storage` route 302s GETs to the same origin — but `buildContentSecurityPolicy` built `connect-src 'self' <sentry>` once at boot. Chromium killed the PUT as `ERR_BLOCKED_BY_CSP` before it left the page (`[FAILED] csp` in the network log; header captured on demo). The panel's Test connection is a **server-side** probe, so configuration looked perfectly healthy until the first real upload.

Fix: `lib/org-storage-origins.ts` scans `<TALE_CONFIG_DIR>/<org>/object-storage/connection.json` (the config dir is already mounted read-only on the platform container) with a 5 s TTL cache; the origins join `connect-src`, `img-src` and `media-src`, and the memoized `secureHeaders` middleware rebuilds only when the origin set changes — a panel save reaches the CSP without a restart. Endpoint-less AWS configs derive both addressing-style origins; bucket/region values are gated to the S3 alphabet so config values can never smuggle CSP sources into a response header.

## Fix 2 — nobody said the bucket needs a CORS policy

R2/MinIO buckets ship with **no CORS policy**, browser-direct transfers need one, and no surface said so (the server-side probe can't detect it). The storage panel now shows the requirement inline with the exact origin to allow + methods (GET/PUT/HEAD), in en/de/de-CH-inherited/fr, and the self-hosted data-residency docs (en/de/fr) document it next to the walkthrough.

## Fix 3 — crawler wedged on a knowledge-pool switch (GlitchTip 7464816)

One minute after switching the org's knowledge DB to the fresh Neon instance, `crawler/index_pages:discoverUrls` died on `website_urls_domain_fkey`: crawl chains resolve the org pool per action, so a chain crossing the switch lands on a database that never saw `registerWebsite` (verified: `public_web.websites` empty on the Neon side). `ensureWebsiteRow` now idempotently backfills the parent + membership rows inside the same transaction as the URL writes (discovery + page-indexing paths), so any pool switch self-heals on the next crawl.

## Fix 4 — 5-minutely betterAuth error spam (GlitchTip 7454355/7454356, pre-existing)

308 events since 2026-07-17: `adapter:findOne` throwing `Unable to decode ID: Invalid ID length 6`. The betterAuth adapter runs `db.get` for `_id` filters, which **throws inside the component** on any non-id value (a `'system'`-class sentinel, length 6) — logged as an uncaught component error on every cron tick, and shaped like a *transient* failure to `orgSlugFromIdOrNull`, so the caller retried forever instead of folding to a miss once. Both shared lookup seams (`orgIdentityFromId`, `getUserById`) now short-circuit values that cannot be document ids into their terminal-miss answers without crossing into the component. Expected effect: the spam stops after this release — worth confirming in GlitchTip.

## Verification

- `bun run check` green (format, lint, typecheck, all tests).
- New regression tests: CSP origins in the right directives + no-restart pickup (`server.test.ts`), scanner/TTL/injection-guard (`lib/org-storage-origins.test.ts`), panel CORS note (`org-data-residency-settings.test.tsx`), ensure-parent ordering (`website_store.test.ts`), non-id short-circuits (`org_slug.test.ts`, `id_shape.test.ts`).
- Bucket CORS verified live against R2 (OPTIONS preflight from the demo origin → 204 + correct `Access-Control-Allow-*`).
- Post-release plan: re-run the 59.7 MB upload on demo through the real path (no bypasses), verify the blob lands in the R2 bucket, chunks land in the Neon corpus, and chat Q&A retrieves the planted facts with a citation.