### PR TITLE
fix(platform): give uploads a response deadline after the last byte

### DIFF
--- a/services/platform/app/features/documents/components/upload-file-row.test.tsx
+++ b/services/platform/app/features/documents/components/upload-file-row.test.tsx
@@ -80,6 +80,25 @@ describe('UploadFileRow', () => {
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
+  it('shows an indeterminate confirming state once all bytes are sent', () => {
+    render(
+      <UploadFileRow
+        {...baseProps}
+        status="finalizing"
+        bytesLoaded={1_200_000}
+        bytesTotal={1_200_000}
+      />,
+    );
+
+    // No frozen "100%" — the copy says what's actually happening.
+    expect(screen.getByText('Confirming upload…')).toBeInTheDocument();
+    expect(screen.queryByText('100%')).not.toBeInTheDocument();
+    // The bar is indeterminate: present, labelled, but with no value.
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAccessibleName('Confirming upload of test-document.pdf');
+    expect(bar).not.toHaveAttribute('aria-valuenow');
+  });
+
   it('shows check icon for completed files', () => {
     render(<UploadFileRow {...baseProps} status="completed" />);
 
@@ -122,6 +141,18 @@ describe('UploadFileRow', () => {
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<UploadFileRow {...baseProps} />);
+      await checkAccessibility(container);
+    });
+
+    it('passes axe audit in the indeterminate confirming state', async () => {
+      const { container } = render(
+        <UploadFileRow
+          {...baseProps}
+          status="finalizing"
+          bytesLoaded={1_200_000}
+          bytesTotal={1_200_000}
+        />,
+      );
       await checkAccessibility(container);
     });
   });

--- a/services/platform/app/features/documents/components/upload-file-row.tsx
+++ b/services/platform/app/features/documents/components/upload-file-row.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Row } from '@tale/ui/layout';
-import { CircleAlert, CircleCheck, RotateCw, X } from 'lucide-react';
+import { CircleAlert, CircleCheck, Loader2, RotateCw, X } from 'lucide-react';
 import { memo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
@@ -73,6 +73,10 @@ export const UploadFileRow = memo(function UploadFileRow({
   const isFailed = status === 'failed';
   const isCompleted = status === 'completed';
   const isUploading = status === 'uploading';
+  // Bytes all sent, waiting for the store/records — byte progress is over,
+  // so the bar goes indeterminate and the copy says "confirming" instead of
+  // freezing at 100 % (which reads as "stuck" during a slow-uplink drain).
+  const isFinalizing = status === 'finalizing';
   const isPending = status === 'pending';
 
   return (
@@ -145,6 +149,16 @@ export const UploadFileRow = memo(function UploadFileRow({
           </span>
         )}
 
+        {isFinalizing && (
+          <span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-blue-600">
+            <Loader2
+              className="size-3 motion-safe:animate-spin"
+              aria-hidden="true"
+            />
+            {t('upload.confirming')}
+          </span>
+        )}
+
         {isFailed && onRetry && (
           <button
             type="button"
@@ -168,7 +182,8 @@ export const UploadFileRow = memo(function UploadFileRow({
         )}
       </Row>
 
-      {/* Progress bar (only for uploading) */}
+      {/* Progress bar: determinate while bytes flow, indeterminate while
+          confirming (no aria-valuenow — there is no meaningful value). */}
       {isUploading && (
         <div
           role="progressbar"
@@ -182,6 +197,15 @@ export const UploadFileRow = memo(function UploadFileRow({
             className="h-full rounded-full bg-gradient-to-b from-blue-600 to-blue-400 transition-all duration-300 ease-out"
             style={{ width: `${percentage}%` }}
           />
+        </div>
+      )}
+      {isFinalizing && (
+        <div
+          role="progressbar"
+          aria-label={t('upload.confirmingFileNamed', { fileName })}
+          className="bg-muted h-1 w-full overflow-hidden rounded-full"
+        >
+          <div className="h-full w-full rounded-full bg-gradient-to-b from-blue-600 to-blue-400 motion-safe:animate-pulse" />
         </div>
       )}
 

--- a/services/platform/app/features/documents/hooks/mutations.ts
+++ b/services/platform/app/features/documents/hooks/mutations.ts
@@ -77,6 +77,19 @@ interface UploadOptions {
 // possible until a page reload.
 const UPLOAD_STALL_TIMEOUT_MS = 60_000;
 
+// Separate, deliberately generous deadline for everything AFTER the last byte
+// has been handed to the network stack. `progress` reports bytes written into
+// local/OS buffers, not bytes the store has acknowledged — so on a slow uplink
+// the bar sits at 100 % while buffers drain for minutes, then the store
+// commits the object and responds; no progress event ever fires again in that
+// window. Timing THAT phase with the 60 s inactivity window discarded an
+// otherwise-complete transfer (observed live: a 59.7 MB presigned PUT to R2
+// at ~90 KB/s reached 100 % and was aborted a minute later). Buffered bytes
+// are bounded by socket/proxy buffers (single-digit MB), so ten minutes
+// covers the worst realistic drain + server commit without reintroducing the
+// stuck-latch problem this watchdog exists to prevent.
+const UPLOAD_RESPONSE_DEADLINE_MS = 10 * 60_000;
+
 // Ceiling for the Convex upload mutations (`generateUploadUrl`,
 // `createDocumentFromUpload`). These are normally sub-second; if one never
 // settles (a wedged websocket) the per-file loop would hang forever with the
@@ -84,7 +97,7 @@ const UPLOAD_STALL_TIMEOUT_MS = 60_000;
 // hung call fails the file and releases the loop instead of wedging the dialog.
 const MUTATION_TIMEOUT_MS = 120_000;
 
-function uploadWithProgress(
+export function uploadWithProgress(
   url: string,
   file: File,
   contentType: string,
@@ -100,30 +113,41 @@ function uploadWithProgress(
     xhr.open(method, url);
     xhr.setRequestHeader('Content-Type', contentType);
 
-    // No-progress watchdog: (re)armed on every progress tick; if it ever
-    // fires, the transfer has stalled — abort so the promise settles.
+    // Two-phase watchdog: while bytes are flowing, (re)arm the short
+    // inactivity window on every progress tick; once the upload phase is
+    // over (`xhr.upload` 'load'), no further progress events exist by
+    // design, so switch to the long response deadline instead of letting
+    // the inactivity window kill a healthy request. Either timer firing
+    // aborts so the promise settles and the dialog latch releases.
     let stalled = false;
-    let stallTimer: ReturnType<typeof setTimeout> | undefined;
-    const clearStall = () => {
-      if (stallTimer !== undefined) clearTimeout(stallTimer);
+    let uploadPhaseDone = false;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const clearWatchdog = () => {
+      if (watchdog !== undefined) clearTimeout(watchdog);
     };
-    const armStall = () => {
-      clearStall();
-      stallTimer = setTimeout(() => {
+    const armWatchdog = (ms: number) => {
+      clearWatchdog();
+      watchdog = setTimeout(() => {
         stalled = true;
         xhr.abort();
-      }, UPLOAD_STALL_TIMEOUT_MS);
+      }, ms);
     };
 
     xhr.upload.addEventListener('progress', (e) => {
-      armStall();
+      // A late progress tick after the upload phase ended must not re-arm
+      // the short window over the response deadline.
+      if (!uploadPhaseDone) armWatchdog(UPLOAD_STALL_TIMEOUT_MS);
       if (e.lengthComputable) {
         onProgress(e.loaded, e.total);
       }
     });
+    xhr.upload.addEventListener('load', () => {
+      uploadPhaseDone = true;
+      armWatchdog(UPLOAD_RESPONSE_DEADLINE_MS);
+    });
 
     xhr.addEventListener('load', () => {
-      clearStall();
+      clearWatchdog();
       if (xhr.status >= 200 && xhr.status < 300) {
         if (method === 'PUT') {
           // S3 PUT returns an empty body (ETag header only); the ref is bound
@@ -142,11 +166,11 @@ function uploadWithProgress(
     });
 
     xhr.addEventListener('error', () => {
-      clearStall();
+      clearWatchdog();
       reject(new Error('Upload failed: network error'));
     });
     xhr.addEventListener('abort', () => {
-      clearStall();
+      clearWatchdog();
       reject(
         stalled
           ? new UploadTimeoutError('Upload stalled')
@@ -156,7 +180,7 @@ function uploadWithProgress(
 
     signal?.addEventListener('abort', () => xhr.abort(), { once: true });
 
-    armStall();
+    armWatchdog(UPLOAD_STALL_TIMEOUT_MS);
     xhr.send(file);
   });
 }

--- a/services/platform/app/features/documents/hooks/mutations.ts
+++ b/services/platform/app/features/documents/hooks/mutations.ts
@@ -26,7 +26,16 @@ import { UploadTimeoutError, withDeadline } from '../lib/upload-deadline';
 // Types
 // ---------------------------------------------------------------------------
 
-export type FileUploadStatus = 'pending' | 'uploading' | 'completed' | 'failed';
+export type FileUploadStatus =
+  | 'pending'
+  | 'uploading'
+  // All bytes handed to the network stack; waiting for the store to commit
+  // and the document records to bind. Progress is indeterminate here — on a
+  // slow uplink this phase runs for minutes with no byte progress to show,
+  // and a bar frozen at 100 % reads as "stuck" (see UPLOAD_RESPONSE_DEADLINE_MS).
+  | 'finalizing'
+  | 'completed'
+  | 'failed';
 
 export interface TrackedFile {
   id: string;
@@ -107,6 +116,10 @@ export function uploadWithProgress(
   method: 'POST' | 'PUT',
   signal: AbortSignal | undefined,
   onProgress: (loaded: number, total: number) => void,
+  // Fires once when the upload phase ends (all bytes handed off) and the
+  // response wait begins — the caller flips the row into its indeterminate
+  // "confirming" state so a full bar never sits frozen at 100 %.
+  onUploadPhaseDone?: () => void,
 ): Promise<{ storageId?: string }> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -144,6 +157,7 @@ export function uploadWithProgress(
     xhr.upload.addEventListener('load', () => {
       uploadPhaseDone = true;
       armWatchdog(UPLOAD_RESPONSE_DEADLINE_MS);
+      onUploadPhaseDone?.();
     });
 
     xhr.addEventListener('load', () => {
@@ -285,6 +299,12 @@ export function useDocumentUpload(options: UploadOptions) {
               bytesLoaded: loaded,
               bytesTotal: total,
             });
+          },
+          () => {
+            // Bytes are all out the door; the store hasn't answered yet and
+            // the document records aren't bound. Show "confirming", not a
+            // dead 100 % bar — on a slow uplink this phase runs for minutes.
+            updateFileStatus(fileId, { status: 'finalizing' });
           },
         );
         // Bind the S3 ref (known up front from the handoff) or the Convex id

--- a/services/platform/app/features/documents/hooks/upload-with-progress.test.ts
+++ b/services/platform/app/features/documents/hooks/upload-with-progress.test.ts
@@ -69,7 +69,7 @@ class FakeXhr {
   }
 }
 
-function startUpload() {
+function startUpload(onUploadPhaseDone?: () => void) {
   const file = new File(['x'], 'big.pdf', { type: 'application/pdf' });
   const promise = uploadWithProgress(
     'https://acc.r2.cloudflarestorage.com/bucket/key',
@@ -78,6 +78,7 @@ function startUpload() {
     'PUT',
     undefined,
     () => {},
+    onUploadPhaseDone,
   );
   // Swallow later assertions' rejections so an aborting test can inspect the
   // promise without an unhandled-rejection warning.
@@ -96,6 +97,17 @@ afterEach(() => {
 });
 
 describe('uploadWithProgress two-phase watchdog', () => {
+  it('reports the end of the upload phase so the UI can show "confirming"', async () => {
+    const onUploadPhaseDone = vi.fn();
+    const { promise, xhr } = startUpload(onUploadPhaseDone);
+    xhr.emitProgress(100_000, 100_000);
+    expect(onUploadPhaseDone).not.toHaveBeenCalled();
+    xhr.emitUploadDone();
+    expect(onUploadPhaseDone).toHaveBeenCalledTimes(1);
+    xhr.emitResponse(200);
+    await expect(promise).resolves.toEqual({});
+  });
+
   it('still aborts a transfer with no progress for the stall window', async () => {
     const { promise, xhr } = startUpload();
     xhr.emitProgress(1_000, 100_000);

--- a/services/platform/app/features/documents/hooks/upload-with-progress.test.ts
+++ b/services/platform/app/features/documents/hooks/upload-with-progress.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UploadTimeoutError } from '../lib/upload-deadline';
+
+vi.mock('@/app/hooks/use-convex-mutation', () => ({
+  useConvexMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock('@/app/hooks/use-convex-action', () => ({
+  useConvexAction: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock('@/convex/_generated/api', () => ({ api: {} }));
+
+import { uploadWithProgress } from './mutations';
+
+/**
+ * Minimal scripted XMLHttpRequest double. Tests drive the upload lifecycle by
+ * emitting the exact events the browser would (`upload.progress`,
+ * `upload.load`, response `load`) and advancing fake timers between them.
+ */
+class FakeXhr {
+  static current: FakeXhr | null = null;
+
+  upload = { listeners: new Map<string, (e: unknown) => void>() } as {
+    listeners: Map<string, (e: unknown) => void>;
+    addEventListener?: unknown;
+  };
+
+  private listeners = new Map<string, () => void>();
+  status = 0;
+  responseText = '';
+  statusText = '';
+  aborted = false;
+
+  constructor() {
+    FakeXhr.current = this;
+    this.upload.addEventListener = (type: string, fn: (e: unknown) => void) => {
+      this.upload.listeners.set(type, fn);
+    };
+  }
+
+  open(): void {}
+  setRequestHeader(): void {}
+  send(): void {}
+
+  addEventListener(type: string, fn: () => void): void {
+    this.listeners.set(type, fn);
+  }
+
+  abort(): void {
+    this.aborted = true;
+    this.listeners.get('abort')?.();
+  }
+
+  emitProgress(loaded: number, total: number): void {
+    this.upload.listeners.get('progress')?.({
+      lengthComputable: true,
+      loaded,
+      total,
+    });
+  }
+
+  emitUploadDone(): void {
+    this.upload.listeners.get('load')?.({});
+  }
+
+  emitResponse(status: number): void {
+    this.status = status;
+    this.listeners.get('load')?.();
+  }
+}
+
+function startUpload() {
+  const file = new File(['x'], 'big.pdf', { type: 'application/pdf' });
+  const promise = uploadWithProgress(
+    'https://acc.r2.cloudflarestorage.com/bucket/key',
+    file,
+    'application/pdf',
+    'PUT',
+    undefined,
+    () => {},
+  );
+  // Swallow later assertions' rejections so an aborting test can inspect the
+  // promise without an unhandled-rejection warning.
+  promise.catch(() => {});
+  return { promise, xhr: FakeXhr.current as unknown as FakeXhr };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('XMLHttpRequest', FakeXhr);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('uploadWithProgress two-phase watchdog', () => {
+  it('still aborts a transfer with no progress for the stall window', async () => {
+    const { promise, xhr } = startUpload();
+    xhr.emitProgress(1_000, 100_000);
+    vi.advanceTimersByTime(60_001);
+    expect(xhr.aborted).toBe(true);
+    await expect(promise).rejects.toBeInstanceOf(UploadTimeoutError);
+  });
+
+  it('does NOT abort while waiting for the store response after the last byte', async () => {
+    const { promise, xhr } = startUpload();
+    xhr.emitProgress(100_000, 100_000);
+    xhr.emitUploadDone();
+
+    // The regression: on a slow uplink the buffers drain for minutes after
+    // the bar reads 100 % and no further progress event ever fires. The old
+    // 60 s inactivity window killed the request right here.
+    vi.advanceTimersByTime(5 * 60_000);
+    expect(xhr.aborted).toBe(false);
+
+    xhr.emitResponse(200);
+    await expect(promise).resolves.toEqual({});
+  });
+
+  it('aborts when even the response deadline passes with no answer', async () => {
+    const { promise, xhr } = startUpload();
+    xhr.emitProgress(100_000, 100_000);
+    xhr.emitUploadDone();
+    vi.advanceTimersByTime(10 * 60_000 + 1);
+    expect(xhr.aborted).toBe(true);
+    await expect(promise).rejects.toBeInstanceOf(UploadTimeoutError);
+  });
+
+  it('a late progress tick cannot shrink the response deadline back to 60s', async () => {
+    const { promise, xhr } = startUpload();
+    xhr.emitUploadDone();
+    // Browsers may deliver a final buffered progress event after upload.load.
+    xhr.emitProgress(100_000, 100_000);
+    vi.advanceTimersByTime(2 * 60_000);
+    expect(xhr.aborted).toBe(false);
+    xhr.emitResponse(200);
+    await expect(promise).resolves.toEqual({});
+  });
+});

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -828,6 +828,7 @@ import type * as lib_helpers_audit_hash from "../lib/helpers/audit_hash.js";
 import type * as lib_helpers_build_audit_context from "../lib/helpers/build_audit_context.js";
 import type * as lib_helpers_count_items_in_org from "../lib/helpers/count_items_in_org.js";
 import type * as lib_helpers_has_records_in_org from "../lib/helpers/has_records_in_org.js";
+import type * as lib_helpers_id_shape from "../lib/helpers/id_shape.js";
 import type * as lib_helpers_org_slug from "../lib/helpers/org_slug.js";
 import type * as lib_helpers_pii_hash from "../lib/helpers/pii_hash.js";
 import type * as lib_helpers_public_storage_url from "../lib/helpers/public_storage_url.js";
@@ -2603,6 +2604,7 @@ declare const fullApi: ApiFromModules<{
   "lib/helpers/build_audit_context": typeof lib_helpers_build_audit_context;
   "lib/helpers/count_items_in_org": typeof lib_helpers_count_items_in_org;
   "lib/helpers/has_records_in_org": typeof lib_helpers_has_records_in_org;
+  "lib/helpers/id_shape": typeof lib_helpers_id_shape;
   "lib/helpers/org_slug": typeof lib_helpers_org_slug;
   "lib/helpers/pii_hash": typeof lib_helpers_pii_hash;
   "lib/helpers/public_storage_url": typeof lib_helpers_public_storage_url;

--- a/services/platform/lib/shared/utils/example-agents-normalized.test.ts
+++ b/services/platform/lib/shared/utils/example-agents-normalized.test.ts
@@ -26,9 +26,13 @@ const EXAMPLES_DIR = path.resolve(
 describe('builtin-configs/agents/*.json invariants', () => {
   // Recursive: agents moved to a tree layout (chat/, github/), and
   // a non-recursive listing silently shrank this gate to router.json only.
+  // Hidden directories are skipped: editor tooling drops stale copies into
+  // e.g. `.history/`, and those must not fail (or pass!) a gate about the
+  // configs that actually ship.
   const files = readdirSync(EXAMPLES_DIR, { recursive: true })
     .map(String)
     .filter((f) => f.endsWith('.json'))
+    .filter((f) => !f.split(path.sep).some((seg) => seg.startsWith('.')))
     .sort();
 
   it('discovered the agent tree, not just the domain root', () => {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2521,6 +2521,8 @@
       "fromMicrosoft365": "Von Microsoft 365",
       "uploadInProgress": "Upload läuft",
       "uploadingFileNamed": "{fileName} wird hochgeladen",
+      "confirming": "Bestätige Upload…",
+      "confirmingFileNamed": "Upload von {fileName} wird bestätigt",
       "failedFileName": "{fileName} — Fehlgeschlagen",
       "pleaseWaitForUpload": "Bitte warte, bis der aktuelle Upload abgeschlossen ist",
       "noFilesSelected": "Keine Dateien ausgewählt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2521,6 +2521,8 @@
       "fromMicrosoft365": "From Microsoft 365",
       "uploadInProgress": "Upload in progress",
       "uploadingFileNamed": "Uploading {fileName}",
+      "confirming": "Confirming upload…",
+      "confirmingFileNamed": "Confirming upload of {fileName}",
       "failedFileName": "{fileName} — Failed",
       "pleaseWaitForUpload": "Please wait for the current upload to complete",
       "noFilesSelected": "No files selected",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2521,6 +2521,8 @@
       "fromMicrosoft365": "Depuis Microsoft 365",
       "uploadInProgress": "Téléversement en cours",
       "uploadingFileNamed": "Téléversement de {fileName}",
+      "confirming": "Confirmation du téléversement…",
+      "confirmingFileNamed": "Confirmation du téléversement de {fileName}",
       "failedFileName": "{fileName} — Échec",
       "pleaseWaitForUpload": "Merci de patienter jusqu'à la fin du téléversement en cours",
       "noFilesSelected": "Aucun fichier sélectionné",


### PR DESCRIPTION
## Found by the post-v0.3.7 re-run of the org data-residency E2E

v0.3.7's CSP fix (#2778) works — the presigned PUT to the org's R2 bucket now leaves the browser and streams for the full 59.7 MB. But the upload then dies at the finish line, twice, deterministically:

1. Progress reaches **100 %** after ~13 min at ~90 KB/s.
2. ~60 s later the client itself aborts (`net::ERR_ABORTED`), shows "**Upload timed out. Check your connection and try again.**", and the bucket stays empty.

## Root cause

`uploadWithProgress` (documents upload hook) arms a 60 s **no-progress stall watchdog** on every `progress` tick — the right design for the transfer phase, and its comment explicitly says a fixed overall timeout would kill slow large uploads. The blind spot: `xhr.upload`'s `progress` reports bytes handed to **local/OS buffers**, not bytes the store acknowledged. On a slow uplink the bar reads 100 % while buffers keep draining for minutes, and **no progress event ever fires again** — the watchdog then kills a healthy request in its response-wait phase and the entire multi-minute transfer is discarded.

## Fix

Two-phase watchdog: keep the 60 s inactivity window while bytes are flowing; on `xhr.upload` `'load'` (upload phase over) switch to a deliberately generous **10-minute response deadline**. A truly wedged request still settles and releases the dialog latch; a slow-uplink upload no longer gets executed at 100 %. A late buffered `progress` tick after `upload.load` can no longer shrink the deadline back to 60 s.

## Verification

- `bun run check` green.
- New `upload-with-progress.test.ts` drives a scripted XHR double through all four paths (mid-transfer stall still aborts; response-wait survives 5 min; response deadline still aborts at 10 min; late progress tick can't re-arm the short window). The "does NOT abort while waiting" case fails on the old code — and failed live on demo v0.3.7 twice.
- Final E2E leg (upload lands in R2 → indexing on the org's Neon KDB → chat retrieval with citation) re-runs on demo once this ships in a release.

Sweep note: the chat attachment hook uses plain `fetch` (no watchdog — unaffected); `use-agent-file-upload.ts` has a progress XHR with **no** watchdog at all (pre-existing, opposite gap: a wedged upload hangs the latch forever; left untouched here as out of scope).