### PR TITLE
perf(platform): chat TTFT follow-ups — classifier overlap, history preload, payload slim, perf guard

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -828,6 +828,7 @@ import type * as lib_helpers_audit_hash from "../lib/helpers/audit_hash.js";
 import type * as lib_helpers_build_audit_context from "../lib/helpers/build_audit_context.js";
 import type * as lib_helpers_count_items_in_org from "../lib/helpers/count_items_in_org.js";
 import type * as lib_helpers_has_records_in_org from "../lib/helpers/has_records_in_org.js";
+import type * as lib_helpers_id_shape from "../lib/helpers/id_shape.js";
 import type * as lib_helpers_org_slug from "../lib/helpers/org_slug.js";
 import type * as lib_helpers_pii_hash from "../lib/helpers/pii_hash.js";
 import type * as lib_helpers_public_storage_url from "../lib/helpers/public_storage_url.js";
@@ -2605,6 +2606,7 @@ declare const fullApi: ApiFromModules<{
   "lib/helpers/build_audit_context": typeof lib_helpers_build_audit_context;
   "lib/helpers/count_items_in_org": typeof lib_helpers_count_items_in_org;
   "lib/helpers/has_records_in_org": typeof lib_helpers_has_records_in_org;
+  "lib/helpers/id_shape": typeof lib_helpers_id_shape;
   "lib/helpers/org_slug": typeof lib_helpers_org_slug;
   "lib/helpers/pii_hash": typeof lib_helpers_pii_hash;
   "lib/helpers/public_storage_url": typeof lib_helpers_public_storage_url;

--- a/services/platform/convex/agent_tools/contacts/contact_read_tool.ts
+++ b/services/platform/convex/agent_tools/contacts/contact_read_tool.ts
@@ -75,50 +75,16 @@ export const contactReadTool: ToolDefinition = {
   name: 'contact_read',
   availability: 'any',
   tool: createTool({
-    description: `Contact data read tool for retrieving contact information from the INTERNAL CRM database.
+    description: `Read contacts from the INTERNAL CRM database (people/organizations you correspond with: customers, leads, vendors).
 
-Contacts are the people and organizations you correspond with — customers, leads, vendors/suppliers, and other counterparts — kept in one internal directory.
-
-SCOPE LIMITATION:
-This tool ONLY accesses the internal CRM contact database.
-DO NOT use this tool for data from external systems - check [INTEGRATIONS] context and delegate to the integration agent instead.
-Example: Hotel guests, e-commerce customers, external system records are NOT in this database.
+INTERNAL ONLY: external-system records (hotel guests, e-commerce customers, …) are NOT here — check [INTEGRATIONS] context and delegate to the integration agent instead.
 
 OPERATIONS:
-• 'get_by_id': Fetch a single contact by their Convex ID. Use when you have a specific contact ID.
-• 'get_by_email': Fetch a single contact by their email address within the organization.
-• 'list': Paginate through all contacts for the organization. Use for browsing, searching, or bulk operations.
-• 'count': Count total contacts for the organization.
-  NOTE: If data volume is too large (cannot be counted within 3 pagination requests), returns a message indicating the data is too large to count.
+• 'get_by_id' (Convex ID) · 'get_by_email' · 'list' (paginated browse/search) · 'count' (may report "too large" past 3 pages).
 
-AVAILABLE FIELDS (select only what you need):
-System fields:
-• _id: Convex document ID (Id<"contacts">)
-• _creationTime: Document creation timestamp (number)
-• organizationId: Organization ID (string)
+FIELDS (pass 'fields' — select only what you need): _id, _creationTime, organizationId, name (recommended), email (recommended), phone, externalId, source, locale, address {street, city, state, country, postalCode}, tags, notes, metadata (CAN BE VERY LARGE — avoid unless needed; may hold custom attributes imported from external systems).
 
-Core contact fields:
-• name: Contact name (string, optional) - RECOMMENDED
-• email: Contact email (string, optional) - RECOMMENDED
-• phone: Contact phone number (string, optional)
-• externalId: External system ID (string or number, optional)
-• source: Data source - 'manual_import' | 'file_upload' | 'shopify' | ... (string)
-• locale: Contact locale/language preference (string, optional)
-• address: Contact address object with street, city, state, country, postalCode (optional)
-• tags: Free-form labels for the contact (string[], optional)
-• notes: Free-form notes about the contact (string, optional)
-
-Large/complex fields (use sparingly):
-• metadata: Additional metadata (object, optional) - CAN BE VERY LARGE
-
-BEST PRACTICES:
-• Always specify 'fields' to minimize response size and improve performance.
-• Avoid 'metadata' unless specifically needed - it can be very large.
-• Use 'list' with pagination (cursor) for large contact bases instead of fetching all at once.
-• Default numItems is 200; reduce if selecting many fields or heavy fields.
-• If hasMore is true, continue calling with the returned cursor to fetch all contacts.
-• Use 'count' to get total contact count. If data is too large, the response will indicate this.
-• If you need contact information not found in standard fields, check the 'metadata' field - it may contain additional custom attributes imported from external systems.`,
+USAGE: default numItems 200 (reduce for many/heavy fields); while hasMore, continue with the returned cursor.`,
     inputSchema: contactReadArgs,
     execute: async (
       ctx: ToolCtx,

--- a/services/platform/convex/agent_tools/documents/document_find_tool.ts
+++ b/services/platform/convex/agent_tools/documents/document_find_tool.ts
@@ -87,39 +87,15 @@ export const documentFindTool: ToolDefinition = {
   availability: 'any',
   sandboxBridge: true,
   tool: createTool({
-    description: `Find and filter documents in the knowledge base.
+    description: `Find and filter documents in the knowledge base — by folder, extension, team, date range, or fuzzy file name; count matches via totalCount; paginate large sets.
 
-USE THIS TOOL TO:
-• Find documents in a specific folder
-• Filter by file type (extension), team, or date range
-• Search documents by file name (fuzzy match)
-• Count documents matching criteria (check totalCount in response)
-• Paginate through large result sets
+NOT FOR: semantic/content search → rag_search; reading indexed content → document_retrieve with the fileId; extracting data from uploaded files → pdf, docx, text, excel, image, or pptx tools with the fileId.
 
-DO NOT USE THIS TOOL FOR:
-• Semantic/content search — use rag_search instead
-• Reading indexed document content — use document_retrieve with the file ID (fileId) instead
-• Extracting data from uploaded files — use pdf, docx, text, excel, image, or pptx tools with the file ID (fileId) instead
+RESPONSE: documents [{fileId, title, extension, folderPath, teamId, createdAt (Unix ms UTC), sizeBytes}] — fileId works with document_retrieve, the extraction tools, and any tool operating on stored files. totalCount is null when the scan limit was reached (count unknown — NOT zero results). If warning is present, results may be incomplete — narrow your filters before continuing.
 
-RESPONSE FIELDS:
-• documents: Array of {fileId, title, extension, folderPath, teamId, createdAt (Unix ms UTC), sizeBytes}
-  - fileId: The file ID. Use with document_retrieve, file extraction tools (pdf, docx, txt, excel, image, pptx), and any tool that operates on stored files.
-• totalCount: Total matching documents (number), or null if the scan limit was reached and the true count is unknown — this does NOT mean zero results.
-• hasMore: Whether more results are available
-• cursor: Pass to next call to get the next page
-• warning: null normally. If present, results may be incomplete — follow the guidance in the message.
+PAGINATION: first call omits cursor; while hasMore is true, pass back the returned cursor.
 
-PAGINATION:
-1. First call: omit cursor
-2. If hasMore is true, call again with the returned cursor value
-3. Repeat until hasMore is false
-
-TIPS:
-• Combine filters to narrow results (e.g., folderPath + extension + dateFrom)
-• For large document sets, always provide at least one filter (folderPath, extension, teamId, or date range) to ensure complete results
-• If warning is present in the response, narrow your filters before continuing
-• Default sort is newest first (createdAt desc)
-• Dates are interpreted as UTC`,
+TIPS: combine filters; for large document sets always provide at least one filter (folderPath, extension, teamId, or date range) to ensure complete results.`,
     inputSchema: documentFindArgs,
     execute: async (ctx, args): Promise<DocumentFindResult> => {
       return listDocuments(ctx, args);

--- a/services/platform/convex/agent_tools/documents/document_retrieve_tool.ts
+++ b/services/platform/convex/agent_tools/documents/document_retrieve_tool.ts
@@ -59,41 +59,13 @@ export const documentRetrieveTool = {
   availability: 'any' as const,
   sandboxBridge: true as const,
   tool: createTool({
-    description: `Retrieve document content by file ID. Works for both knowledge-base documents (found via document_find) and files the user uploaded directly in this chat — both are indexed and readable through this tool.
+    description: `Retrieve document content by file ID — knowledge-base documents (fileId from document_find) and chat attachments the user uploaded (ID surfaced alongside the upload); both are indexed and readable here. Returns the text in original order — preferred over the pdf/docx/text extractors when you need the complete document, not just an excerpt.
 
-USE THIS TOOL TO:
-• Read the full or partial content of a specific document
-• Paginate through large documents using chunk ranges
-• Follow up after document_find to read a knowledge-base document's content
-• Read the full text of a chat attachment in original order (preferred over pdf/docx/text extractors when you need the complete document, not just an excerpt)
+NOT FOR: searching across documents → rag_search; listing/browsing the knowledge base → document_find; extracting structured data or images → pdf, docx, text, excel, image, or pptx tools.
 
-DO NOT USE THIS TOOL FOR:
-• Searching across documents — use rag_search instead
-• Listing or browsing knowledge-base documents — use document_find instead
-• Extracting structured data or images from a file — use pdf, docx, text, excel, image, or pptx tools
+PAGINATION: the response carries chunkRange {start, end} (1-indexed), totalChunks, and truncated (content capped at ~50K chars). First call: omit chunkStart/chunkEnd. Need more? Call again with chunkStart = chunkRange.end + 1. Max 100 chunks per call.
 
-RESPONSE FIELDS:
-• fileId: The file ID
-• name: Document title
-• content: The retrieved text content
-• chunkRange: { start, end } — actual chunk range returned (1-indexed)
-• totalChunks: Total chunks in the document
-• truncated: Whether content was truncated to fit the ~50K char limit
-• totalChars: Total character count of the requested chunk range (before truncation)
-
-PAGINATION (for large documents):
-1. First call: omit chunkStart and chunkEnd to get the first chunks
-2. Check totalChunks and chunkRange in the response
-3. If you need more, call again with chunkStart set to chunkRange.end + 1
-4. Max 100 chunks per call
-
-INDEXING STATE:
-• If the tool errors with "still being indexed", the chat attachment hasn't finished RAG indexing yet — wait briefly and retry once before reporting to the user
-• If the tool errors with "RAG indexing failed", the file cannot be retrieved; tell the user and stop, do not retry
-
-TIPS:
-• Get file IDs from document_find (knowledge base) or the user's chat attachment (the ID surfaced alongside the upload)
-• For semantic search across documents, use rag_search instead`,
+INDEXING ERRORS: "still being indexed" → the chat attachment hasn't finished RAG indexing; wait briefly and retry once before reporting to the user. "RAG indexing failed" → the file cannot be retrieved; tell the user and stop, do not retry.`,
     inputSchema: documentRetrieveArgs,
     execute: async (ctx, args): Promise<DocumentRetrieveResult> => {
       return retrieveDocument(ctx, args);

--- a/services/platform/convex/agent_tools/documents/document_write_tool.ts
+++ b/services/platform/convex/agent_tools/documents/document_write_tool.ts
@@ -55,30 +55,11 @@ export const documentWriteTool = {
   tool: createTool({
     description: `Save one or more files to the documents hub. Requires user approval — an approval card will be created. When telling the user the card is ready, do not reference its position (no "above" / "below") — just say the approval card has been created.
 
-USE THIS TOOL TO:
-• Save generated files (text, docx, pdf, excel, pptx) to the documents hub
-• Save multiple files at once in a single batch
-• Organize files into folders in the documents hub
+USE WHEN the user wants generated files (text, docx, pdf, excel, pptx) kept in the documents hub — "save to [folder]", "store in [folder]".
 
-WHEN TO USE THIS TOOL:
-• User says "save to [folder]", "store in [folder]", "download to [folder]", "put it in [folder]"
-• User wants to keep generated files in the documents hub
-• User specifies a folder/directory for file organization
+NOT FOR: generating files (use the text, docx, pdf, excel, or pptx tools first), searching (rag_search / document_find), or reading (document_retrieve).
 
-DO NOT USE THIS TOOL FOR:
-• Generating files — use text, docx, pdf, excel, or pptx tools first
-• Searching documents — use rag_search or document_find
-• Reading documents — use document_retrieve
-
-WORKFLOW:
-1. First generate file(s) using text (generate), docx (generate), pdf (generate), etc.
-2. Collect the fileStorageId from each tool result
-3. Call document_write with all fileStorageIds in the files array
-4. A single approval card will appear for the user to review and approve all files at once
-
-PARAMETERS:
-• files: REQUIRED — array of { fileId, title? } objects. fileId is the fileStorageId from a file generation tool. title optionally overrides the document title.
-• folderPath: Optional — target folder path (e.g. "reports/2026"). Created automatically if it doesn't exist. Applied to all files.`,
+WORKFLOW: generate the file(s) → collect each tool result's fileStorageId → call document_write once with all of them in the files array (fileId = fileStorageId; title optionally overrides) → a single approval card covers the whole batch.`,
     inputSchema: documentWriteArgs,
     execute: async (
       ctx: ToolCtx,

--- a/services/platform/convex/agent_tools/files/file_edit_tool.ts
+++ b/services/platform/convex/agent_tools/files/file_edit_tool.ts
@@ -88,27 +88,13 @@ export const fileEditTool: ToolDefinition = {
   name: 'file_edit' as const,
   availability: 'any' as const,
   tool: createTool({
-    description: `**file_edit** — apply a targeted search-replace edit to an existing workspace file.
+    description: `**file_edit** — targeted search-replace in an existing workspace file: replaces \`old_string\` with \`new_string\`. The match is **literal** (whitespace and indentation included) — no regex, no wildcards. \`old_string\` must occur exactly once (else \`OLD_STRING_NOT_UNIQUE\` — widen the context or set \`replace_all\`). The edit is atomic (same file identity, new blob).
 
-USE THIS INSTEAD OF \`file_write\` WHEN:
-- You're changing a small region of a file you already wrote (a function body, a single line, a renamed identifier) — \`file_edit\` is dramatically cheaper than re-emitting the whole file.
-- You're iterating on code you just generated and want to keep the rest of the file byte-identical.
-
-USE \`file_write\` INSTEAD WHEN:
-- The file does not exist yet (\`file_edit\` errors with \`NOT_FOUND\` — only \`file_write\` creates files).
-- You're rewriting most of the file anyway.
-- The file is binary (images, PDFs, archives, Office docs — \`file_edit\` only handles text).
-
-HOW IT WORKS:
-- The tool finds the exact substring \`old_string\` in the file and replaces it with \`new_string\`.
-- \`old_string\` must match **literally**, including whitespace and indentation. No regex, no wildcards.
-- By default \`old_string\` must occur exactly once. If it appears multiple times the tool errors with \`OLD_STRING_NOT_UNIQUE\` and tells you how many matches it found — either widen \`old_string\` with more surrounding context, or pass \`replace_all: true\`.
-- \`new_string\` can be empty to delete \`old_string\`.
-- The edit is atomic: the file's row keeps its identity, the old storage blob is dropped, the new one takes its place.
+USE THIS over \`file_write\` for small changes to a file you already wrote — the rest stays byte-identical; far cheaper than re-emitting it. Use \`file_write\` instead when the file does not exist yet (\`file_edit\` errors \`NOT_FOUND\`; only \`file_write\` creates files), when you're rewriting most of it anyway, or for binary files (\`file_edit\` only handles text).
 
 QUOTAS: same as \`file_write\` — ≤ 10 MB per file, ≤ 100 MB per workspace.
 
-Every result (success or failure) includes \`sandboxState\` — the current workspace manifest. Trust it over memory.`,
+Every result includes \`sandboxState\` — the current workspace manifest. Trust it over memory.`,
     inputSchema: fileEditArgs,
     execute: async (ctx: ToolCtx, args: FileEditArgs) => {
       const { organizationId, threadId } = ctx;

--- a/services/platform/convex/agent_tools/files/file_write_tool.ts
+++ b/services/platform/convex/agent_tools/files/file_write_tool.ts
@@ -67,28 +67,17 @@ export const fileWriteTool: ToolDefinition = {
   name: 'file_write' as const,
   availability: 'any' as const,
   tool: createTool({
-    description: `**file_write** — create or replace a file in the current thread's workspace.
+    description: `**file_write** — create or atomically replace one workspace file per call.
 
-Writes one file at a time. If a file already exists at \`path\` it is replaced atomically; otherwise a new entry is created.
+USE FOR: final deliverables → \`/user/output/report.md\` (write directly; no script detour); code to execute → \`file_write\` then \`run_code({entryPath: "/user/code/gen.py"})\` (\`/user/code/\` is the only executable location); intermediate data for a later \`run_code\`.
 
-USE THIS TO:
-- Save a final deliverable the user should see or download (\`/user/output/report.md\`, \`/user/output/landing.html\`, …)
-- Stage code you're about to execute (\`file_write({path: "/user/code/gen.py", ...})\` then \`run_code({entryPath: "/user/code/gen.py"})\`)
-- Materialize intermediate data the next \`run_code\` call should read
+Inside a \`run_code\` script the same rule applies: deliverables must be saved to \`/user/output/\` — files left in the cwd or \`/tmp\` are discarded when the container exits. Rewrite a skill example's bare \`output.xlsx\` as \`/user/output/output.xlsx\`.
 
-WHERE TO WRITE:
-- \`/user/output/\` — deliverables (reports, exports, rendered pages). Write them here directly; no script detour needed.
-- \`/user/code/\` — scripts + working files; this is the \`run_code\` cwd and the only executable location.
-- Inside a \`run_code\` script, the same rule applies: a deliverable the script produces must be saved to \`/user/output/\` — files left in the cwd or \`/tmp\` are discarded when the container exits. If a skill's example saves to a bare relative path like \`output.xlsx\`, rewrite it as \`/user/output/output.xlsx\`.
+QUOTAS: ≤ 10 MB per file; ≤ 100 files and ≤ 100 MB per workspace.
 
-QUOTAS:
-- ≤ 10 MB per file
-- ≤ 100 files per workspace
-- ≤ 100 MB per workspace (aggregate)
+Every result includes \`sandboxState\` — the current workspace manifest. Trust it over memory: a file listed there already exists, don't recreate it.
 
-Every result (success or failure) includes \`sandboxState\` — the current workspace manifest. Trust it over memory: a file listed there already exists, don't recreate it.
-
-The canvas (right pane) renders workspace files by extension automatically — \`.html\` opens in a sandboxed iframe, \`.svg\` renders inline, \`.md\` as markdown, \`.py\`/\`.ts\`/\`.json\` as syntax-highlighted code, image extensions inline, others as a download chip.`,
+The canvas renders workspace files by extension (\`.html\` sandboxed iframe, \`.svg\` inline, \`.md\` markdown, code highlighted, images inline, others a download chip).`,
     inputSchema: fileWriteArgs,
     execute: async (ctx: ToolCtx, args: FileWriteArgs) => {
       const { organizationId, threadId } = ctx;

--- a/services/platform/convex/agent_tools/location/request_user_location_tool.ts
+++ b/services/platform/convex/agent_tools/location/request_user_location_tool.ts
@@ -28,17 +28,7 @@ export const requestUserLocationTool = {
   // primary-only: Same primary-turn card/resume model as request_human_input.
   availability: 'primary-only' as const,
   tool: createTool({
-    description: `**DIRECTLY call this tool** to request the user's geographic location.
-
-**WHEN TO USE:**
-• When you need to know where the user is located (e.g., weather, nearby places, local time, regional recommendations)
-• When the user asks a location-dependent question but hasn't provided their location
-
-**HOW IT WORKS:**
-• An approval card appears asking the user to share their browser location
-• The user can approve (shares city-level location) or deny
-• You will receive a city-level address (e.g., "Hangzhou, Zhejiang, China") — never raw coordinates
-• If denied, you will be informed and should proceed without location data
+    description: `**DIRECTLY call this tool** when you need the user's location and they haven't shared it. An approval card requests their browser location: approve → city-level address only (never raw coordinates); deny → proceed without location data.
 
 **AFTER CALLING - CRITICAL:**
 • You MUST STOP and produce your final response immediately

--- a/services/platform/convex/agent_tools/products/product_read_tool.ts
+++ b/services/platform/convex/agent_tools/products/product_read_tool.ts
@@ -81,36 +81,14 @@ export const productReadTool: ToolDefinition = {
   name: 'product_read',
   availability: 'any',
   tool: createTool({
-    description: `Product catalog read tool for retrieving product information from the INTERNAL product database.
-
-SCOPE LIMITATION:
-This tool ONLY accesses the internal product catalog.
-DO NOT use this tool for products from external e-commerce systems - check [INTEGRATIONS] context and delegate to the integration agent instead.
+    description: `Read products from the INTERNAL catalog. External e-commerce products are NOT here — check [INTEGRATIONS] context and delegate to the integration agent instead.
 
 OPERATIONS:
-• 'list': Browse/search the catalog. Returns ONLY: _id, name, description, status, stock (fixed fields).
-  Supports filters: status (active/inactive/draft/archived), minStock (minimum stock level).
-  Use this to find products, then use 'get_by_id' to get full details.
-• 'get_by_id': Fetch one or more products by ID. Supports batch queries (pass multiple IDs).
-  Use 'fields' parameter to select which fields to return.
-• 'count': Count total products. Supports filters: status, minStock.
-  NOTE: If data volume is too large (cannot be counted within 3 pagination requests), returns a message indicating the data is too large to count.
+• 'list': browse/search; returns fixed fields (_id, name, description, status, stock); filters: status (active/inactive/draft/archived), minStock.
+• 'get_by_id': one or more IDs (batch in ONE call); pass 'fields' to select from _id, name, description, price, currency, status, category, imageUrl, stock, tags, externalId, lastUpdated, translations/metadata (HEAVY — avoid unless needed).
+• 'count': with optional status/minStock filters (may report "too large" past 3 pages).
 
-WORKFLOW:
-1. Use 'list' to browse/search products (returns: _id, name, description, status, stock)
-2. Use 'get_by_id' with the IDs you need to fetch full product details
-3. Use 'count' to get total product count (with optional filters)
-
-AVAILABLE FIELDS FOR get_by_id (select only what you need):
-• _id, name, description, price, currency, status, category, imageUrl, stock, tags, externalId, lastUpdated
-• translations, metadata (HEAVY - avoid unless specifically needed)
-
-BEST PRACTICES:
-• Use 'list' for browsing, 'get_by_id' for details - this minimizes token usage
-• Use status and minStock filters to narrow down results
-• Batch multiple product IDs in a single 'get_by_id' call instead of multiple calls
-• Specify 'fields' in get_by_id to minimize response size
-• Use 'count' with filters to get counts for specific subsets of products`,
+WORKFLOW: 'list' to find → 'get_by_id' (with 'fields') for details → 'count' for totals.`,
     inputSchema: productReadArgs,
     execute: async (
       ctx: ToolCtx,

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -194,47 +194,19 @@ export const ragSearchTool = {
   availability: 'any' as const,
   sandboxBridge: true as const,
   tool: createTool({
-    description: `Knowledge base tool for searching, retrieving, and listing indexed documents.
+    description: `Knowledge base: search, retrieve, and list indexed documents.
 
 OPERATIONS:
-• 'search': Search the knowledge base for relevant document excerpts using hybrid search (BM25 + vector similarity). Returns numbered excerpts with relevance scores.
-• 'retrieve': Retrieve document content by file ID in paginated chunks (default 10 chunks per call). Use chunkStart/chunkEnd to paginate. Returns chunk range and totalChunks so you can fetch more. Use this to read uploaded files (PDF, DOCX, PPTX, TXT, XLSX, etc.).
-• 'list_indexed': List documents indexed in the Document Hub (does NOT include files uploaded in chat). Returns file names, file IDs, and modification dates.
+• 'search': hybrid search (BM25 + vector) over the knowledge base; returns scored excerpts. Use for KB lookups (policies, docs, stored content) or when exact field values are unknown.
+• 'retrieve': read a document by file ID in paginated chunks (default 10/call; chunkStart/chunkEnd to page; returns totalChunks). Use to read uploaded files (PDF, DOCX, XLSX, …).
+• 'list_indexed': list Document Hub documents (name, fileId, sourceModifiedAt; paginated via cursor — pass the returned cursor verbatim). Chat-uploaded files are NOT listed; their file IDs are already in the conversation.
 
-WHEN TO USE 'search':
-• Knowledge base lookups: policies, procedures, documentation
-• Questions about stored documents and content
-• Finding information when you don't know exact field values
+RULES:
+• If the user's message contains file IDs, search with 'fileIds' FIRST; on no relevant results retry without.
+• Folder-scoped asks ("search the contracts folder"): pass 'folderPath' (matches the folder + all subfolders); retry without it if nothing relevant.
+• When a user uploads a file to read/summarize/analyze → 'retrieve' it (or 'search' with a query for targeted lookup in large files).
 
-SEARCH STRATEGY — file ID priority:
-When the user's message contains file IDs (e.g. from uploaded attachments), ALWAYS pass those IDs in the 'fileIds' parameter first to search within those specific files. If that returns no relevant results, retry WITHOUT fileIds to perform a broader knowledge base search. This ensures uploaded/referenced files are prioritized while still falling back to the full knowledge base when needed.
-
-SEARCH SCOPING — folder filter:
-When the user asks to search within a specific folder ("search the contracts folder", "only look in Reports/2024"), pass 'folderPath'. It matches that Document Hub folder and all of its subfolders. If the folder-scoped search returns nothing relevant, retry without folderPath.
-
-WHEN TO USE 'retrieve':
-• Reading content of a specific uploaded file (paginated, 10 chunks per call by default)
-• When a user uploads a file and asks you to read, summarize, or analyze it
-• For large documents, retrieve returns the first page — use chunkStart/chunkEnd to read more, or use 'search' with a query for targeted lookup
-
-WHEN TO USE 'list_indexed':
-• See which documents are in the Document Hub (org/team knowledge base)
-• Get file IDs for use with the search or retrieve operations
-• Check when documents were last modified
-• NOTE: This only lists Document Hub files. Files uploaded in chat are NOT included — their file IDs are already in the conversation context.
-
-WHEN NOT TO USE:
-• "How many contacts?" → Use contact_read with operation='count'
-• "List all products" → Use product_read with operation='list'
-• "Look up a contact by email" → Use contact_read with operation='get_by_email'
-• For counting/listing/filtering structured data, use database tools instead
-• Browsing all documents (not just indexed) → Use document_find instead
-
-RESPONSE (list_indexed):
-• documents: Array of {fileId, name, sourceModifiedAt}
-• totalCount: Total matching documents (null if scan limit reached)
-• hasMore: Whether more results are available
-• cursor: Opaque pagination cursor. Pass the exact value to the next call to fetch the next page. Do not fabricate values.`,
+NOT for structured data: counts/lists/filters of contacts or products → contact_read / product_read / database tools; browsing ALL documents (not just indexed) → document_find.`,
     inputSchema: ragToolArgs,
     execute: async (ctx: ToolCtx, args) => {
       if (args.operation === 'list_indexed') {

--- a/services/platform/convex/agent_tools/run_code_tool.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.ts
@@ -286,24 +286,17 @@ export const runCodeTool: ToolDefinition = {
   name: 'run_code' as const,
   availability: 'any' as const,
   tool: createTool({
-    description: `**run_code** — execute code in the thread's sandbox (Python 3, Node as ESM, bash). Pick a \`mode\`:
+    description: `**run_code** — execute code in the thread's sandbox (Python 3, Node as ESM, bash). Modes: \`inline\` (code + language) — a snippet run directly, like a shell: one-off commands, quick computations, sandbox inspection; not stored (re-runnable work → "script") · \`script\` (entryPath) — a \`file_write\`-staged workspace script; extension picks the interpreter · \`install\` — packages only (big installs / a separate checkpoint).
 
-- \`{"mode": "inline", "code": "ls -la /user/output", "language": "bash"}\` — run a snippet directly, like a shell. For one-off commands, quick computations, sandbox inspection. The snippet is not stored — for anything worth re-running or editing, use mode "script".
-- \`{"mode": "script", "entryPath": "/user/code/gen.py"}\` — run a workspace script. \`file_write\` it first; the extension picks the interpreter (.py / .js / .cjs / .mjs / .sh).
-- \`{"mode": "install", "packages": {"python": ["pandas"]}}\` — install packages without running code (use for big installs or a separate install checkpoint).
+PACKAGES: declare them in \`packages\` (works in every mode; the org policy gates them). Do NOT install ad-hoc from inline code — \`pip install x\` / \`npm install -g y\` are rejected with PREFER_PACKAGES (\`pip install -r\` and project-local \`npm install\` remain fine).
 
-PACKAGES: declare pip specs in \`packages.python\`, npm specs in \`packages.node\` — available on every mode; they install before the code runs and persist for later run_code calls in this turn. The org policy gates them. Do NOT install ad-hoc from inline code — \`pip install x\` / \`npm install -g y\` snippets are rejected with PREFER_PACKAGES (\`pip install -r\` and project-local \`npm install\` remain fine).
+MULTI-STEP: repeated run_code calls (no steps array); the sandbox session persists within the turn.
 
-MULTI-STEP: call run_code repeatedly — the sandbox session persists within the turn (installed packages, files under \`/user/output/\`). There is no steps array.
+PATHS: \`/user/code/\` your file_write scripts (what \`entryPath\` runs) · \`/user/output/\` deliverables — ONLY files written here are harvested back into the workspace and canvas (incl. prior runs' outputs) · \`/user/uploads/\` the user's files.
 
-PATHS (pre-populated from the thread workspace):
-- \`/user/code/\`    — scripts you authored via \`file_write\` (what \`entryPath\` runs);
-- \`/user/output/\`  — deliverables: ONLY files written here are harvested back into the workspace and canvas; previous runs' outputs also live here;
-- \`/user/uploads/\` — files the user uploaded into the thread.
+LIMITS: 1 GB memory · ≤16 harvested files/run.
 
-LIMITS: default 30s per run (\`timeoutMs\`, max 300s); declared package installs get their own budget (up to 5 min); 1 GB memory; max 16 harvested output files per run.
-
-Every result message embeds the run's terminal output (stdout inline, capped at 4 KB; stderr too on failure) plus a **\`sandboxState\`** manifest — the current files under each dir, each with its \`fileId\`. Read it before acting: don't regenerate an output already listed there, and hand a file's \`fileId\` to the \`image\` (analyze) or \`document_write\` tool.`,
+Results embed terminal output (stdout capped 4 KB; stderr on failure) and a \`sandboxState\` manifest (files per dir with \`fileId\`) — read it first: never regenerate an output already listed; hand a \`fileId\` to \`image\` (analyze) or \`document_write\`.`,
     // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag -- the match is prose in this LLM tool-description string, not rendered HTML
     inputSchema: runCodeArgs,
     execute: async (ctx: ToolCtx, args: RunCodeArgs) => {

--- a/services/platform/convex/agent_tools/run_code_tool.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.ts
@@ -288,6 +288,8 @@ export const runCodeTool: ToolDefinition = {
   tool: createTool({
     description: `**run_code** — execute code in the thread's sandbox (Python 3, Node as ESM, bash). Modes: \`inline\` (code + language) — a snippet run directly, like a shell: one-off commands, quick computations, sandbox inspection; not stored (re-runnable work → "script") · \`script\` (entryPath) — a \`file_write\`-staged workspace script; extension picks the interpreter · \`install\` — packages only (big installs / a separate checkpoint).
 
+EXAMPLES: {"mode": "inline", "language": "python", "code": "print(1+1)"} · {"mode": "script", "entryPath": "/user/code/gen.py"} · {"mode": "install", "packages": ["pandas"]}
+
 PACKAGES: declare them in \`packages\` (works in every mode; the org policy gates them). Do NOT install ad-hoc from inline code — \`pip install x\` / \`npm install -g y\` are rejected with PREFER_PACKAGES (\`pip install -r\` and project-local \`npm install\` remain fine).
 
 MULTI-STEP: repeated run_code calls (no steps array); the sandbox session persists within the turn.

--- a/services/platform/convex/agent_tools/spawn_agent/create_spawn_agent_tool.ts
+++ b/services/platform/convex/agent_tools/spawn_agent/create_spawn_agent_tool.ts
@@ -247,17 +247,13 @@ export function createSpawnAgentTool(deps: SpawnAgentDeps) {
     // primary-only: jobs must not spawn jobs (recursion guard, design §6.1).
     availability: 'primary-only' as const,
     tool: createTool({
-      description: `Spawn a focused worker agent for ONE well-scoped task and get its result back. The worker runs non-interactively with EXACTLY the capabilities you grant it (a subset of your own, plus baseline workspace READ access), and its progress is shown to the user as a live job card.
-
-**When to use:** a sub-task that benefits from isolation — open-ended research, bulk extraction, drafting a long document — where a focused context beats doing it inline. For quick answers, just act yourself.
+      description: `Spawn a focused worker agent for ONE well-scoped task and get its result back. Non-interactive; runs with EXACTLY the capabilities you grant (a subset of your own + always-on workspace READ); progress shows as a live job card. Use when isolation helps (research, bulk extraction, long drafts); else act yourself.
 
 **Contract:**
-• You author the worker's task instructions; the platform adds its operating rules. Grant the SMALLEST tool set that can do the job.
-• The worker cannot talk to the user. If its result says it needs user input, ask the user yourself (request_human_input) — ask each question at most ONCE; never re-ask something the user already answered.
-• Out-of-grant requests are silently dropped — the result includes what was narrowed so you can adapt (e.g. a missing integration → tell the user to connect it, or do that part yourself).
-• If the job fails or is cut off, its partial progress is visible to the user; summarize honestly and continue yourself if you can.
-• The worker shares YOUR thread workspace and can ALWAYS read it: \`file_read\` and \`file_list\` are granted automatically (don't list them), and \`file_list\` resolves a workspace path to the \`fileId\` other tools take (e.g. \`image\` — grant it when the job must analyze workspace images). Tools that WRITE the workspace (file_write, file_edit, file_delete, run_code) are granted only when you list them.
-• When you grant a write-side workspace tool, the result carries \`sandboxState\` — the workspace after the job. Files listed there ALREADY EXIST (the user sees them on the canvas): reference them by path, NEVER rewrite them from the worker's text reply.
+• Grant the SMALLEST tool set that can do the job.
+• The worker cannot talk to the user — relay questions via request_human_input; ask each question at most ONCE; never re-ask something the user already answered.
+• Narrowed grants are reported back — adapt (connect the missing integration via the user, or do it yourself). On failure/cutoff partial progress stays visible; summarize honestly and continue yourself if you can.
+• The worker reads YOUR thread workspace (\`file_list\` maps paths to \`fileId\`s — grant \`image\` for workspace-image analysis). Write tools (file_write, file_edit, file_delete, run_code) apply only if listed; the result then carries \`sandboxState\` (the post-job workspace). Files listed there ALREADY EXIST (the user sees them on the canvas): reference them by path, NEVER rewrite them from the worker's text reply.
 
 **Grantable tools:** ${grantableToolLines(deps)}
 **Grantable methodologies:**

--- a/services/platform/convex/agent_tools/web/web_tool.ts
+++ b/services/platform/convex/agent_tools/web/web_tool.ts
@@ -68,17 +68,11 @@ export const webTool: ToolDefinition = {
   tool: createTool({
     description: `Access web content in two modes:
 
-**fetch**: Fetch and extract content from any public URL. Supports web pages, PDFs, DOCX, PPTX, and images (PNG, JPG, GIF, WebP, etc.). Use the \`query\` parameter as an extraction instruction to guide what content to focus on.
+**fetch**: extract content from any public URL — web pages, PDFs, DOCX, PPTX, images. Use \`query\` as an extraction instruction to guide what to focus on.
 
-**search**: Search through websites that have been added to the organization's knowledge base. Only content from indexed knowledge base websites is searchable — this does NOT search the open internet. If the website you need isn't indexed, use fetch mode with a direct URL instead, or suggest the user add the website to their knowledge base.
+**search**: semantic search over websites added to the organization's knowledge base. Only indexed knowledge-base websites — this does NOT search the open internet. If the site you need isn't indexed, use fetch with a direct URL, or suggest the user add it to their knowledge base.
 
-IMPORTANT: Always cite the source URL for every piece of information you present from the results.
-
-EXAMPLES:
-- { mode: "fetch", url: "https://example.com/report.pdf", query: "Summarize the key findings" }
-- { mode: "fetch", url: "https://example.com/pricing" }
-- { mode: "search", query: "shipping policy" }
-- { mode: "search", query: "workflow patterns", domain: "docs.convex.dev" }`,
+IMPORTANT: Always cite the source URL for every piece of information you present from the results.`,
     inputSchema: webToolArgs,
     execute: async (ctx: ToolCtx, args) => {
       if (args.mode === 'fetch') {

--- a/services/platform/convex/agents/chat_turn_generate.ts
+++ b/services/platform/convex/agents/chat_turn_generate.ts
@@ -32,7 +32,10 @@ import {
   resolveProductAgentKind,
   type ProductAgentSlug,
 } from '../../lib/agent-adapters/events';
-import { AUTO_AGENT_SLUG } from '../../lib/shared/constants/agents';
+import {
+  AUTO_AGENT_SLUG,
+  DEFAULT_CHAT_AGENT_SLUG,
+} from '../../lib/shared/constants/agents';
 import type {
   ResponseReasoningSeed,
   ResponseStyleAdvice,
@@ -180,6 +183,28 @@ export const runChatTurnGeneration = internalAction({
       //    agent that no longer resolves (uninstalled/renamed) falls through
       //    to the client selection.
       const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
+      // Kick the guardrails snapshot immediately: it depends only on the org,
+      // so it loads while the (Auto) classifier and the agent config resolve
+      // below instead of serially after them. Awaited in the Promise.all
+      // further down.
+      const guardrailsPromise = loadGuardrailsSnapshot(
+        ctx,
+        args.organizationId,
+      );
+      const governanceQuery = (supportedModels: string[]) =>
+        ctx.runQuery(
+          internal.governance.internal_queries.resolveGenerationGovernance,
+          {
+            organizationId: args.organizationId,
+            userId: args.userId,
+            userEmail: args.userEmail,
+            userName: args.userName,
+            supportedModels: supportedModels.map(stripModelRefQualifier),
+            ...(args.modelId
+              ? { explicitModelId: stripModelRefQualifier(args.modelId) }
+              : {}),
+          },
+        );
       let lockedConfigResult:
         | Awaited<ReturnType<typeof resolveAgentConfigInline>>
         | undefined;
@@ -220,6 +245,32 @@ export const runChatTurnGeneration = internalAction({
       // suffix; `routeSeed` seeds the reasoning governor's prior.
       let routeStyle: ResponseStyleAdvice | undefined;
       let routeSeed: ResponseReasoningSeed | undefined;
+      // Speculative default-agent prep (Auto only): the classifier's full
+      // LLM round-trip is dead air before the answer can start, and the route
+      // lands on the default chat agent in the common case (fallback, cached
+      // default, general asks). Resolve the default agent's config + its
+      // governance NOW, concurrently with the classifier; a specialist route
+      // below simply redoes both (a cheap disk read + one query) and the
+      // speculation is discarded.
+      const speculativePrep =
+        !lockedConfigResult && args.agentSlug === AUTO_AGENT_SLUG
+          ? (async () => {
+              const cfg = await resolveAgentConfigInline(ctx, {
+                orgSlug,
+                agentSlug: DEFAULT_CHAT_AGENT_SLUG,
+                organizationId: args.organizationId,
+                modelId: args.modelId,
+              });
+              const gov = await governanceQuery(cfg.supportedModels);
+              return { cfg, gov };
+            })().catch((err: unknown) => {
+              console.warn(
+                '[runChatTurnGeneration] speculative default-agent prep failed (resolving after route):',
+                err instanceof Error ? err.message : err,
+              );
+              return undefined;
+            })
+          : undefined;
       if (!lockedConfigResult && args.agentSlug === AUTO_AGENT_SLUG) {
         const allowedAgentSlugs = args.projectId
           ? await ctx.runQuery(
@@ -280,8 +331,15 @@ export const runChatTurnGeneration = internalAction({
       //    (member + teamIds fetched once) instead of the former two/three
       //    (resolveDefaultModel + getAccessibleModels + checkModelAccess each
       //    re-fetching membership).
+      // Cash in the speculation when the route landed on the default agent;
+      // any other slug (specialist route, pinned agent, lock) resolves fresh.
+      const speculative =
+        speculativePrep && resolvedAgentSlug === DEFAULT_CHAT_AGENT_SLUG
+          ? await speculativePrep
+          : undefined;
       const configResult =
         lockedConfigResult ??
+        speculative?.cfg ??
         (await resolveAgentConfigInline(ctx, {
           orgSlug,
           agentSlug: resolvedAgentSlug,
@@ -340,22 +398,8 @@ export const runChatTurnGeneration = internalAction({
       }
 
       const [guardrails, governance] = await Promise.all([
-        loadGuardrailsSnapshot(ctx, args.organizationId),
-        ctx.runQuery(
-          internal.governance.internal_queries.resolveGenerationGovernance,
-          {
-            organizationId: args.organizationId,
-            userId: args.userId,
-            userEmail: args.userEmail,
-            userName: args.userName,
-            supportedModels: configResult.supportedModels.map(
-              stripModelRefQualifier,
-            ),
-            ...(args.modelId
-              ? { explicitModelId: stripModelRefQualifier(args.modelId) }
-              : {}),
-          },
-        ),
+        guardrailsPromise,
+        speculative?.gov ?? governanceQuery(configResult.supportedModels),
       ]);
 
       // 4. Governance default model (implicit path only).

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -58,6 +58,7 @@ import {
 import { onAgentComplete } from '../agent_completion';
 import {
   buildStructuredContext,
+  loadStructuredHistory,
   AGENT_CONTEXT_CONFIGS,
   RECOVERY_TIMEOUT_MS,
   estimateTokens,
@@ -747,6 +748,68 @@ export async function generateAgentResponse(
         }
       })();
 
+    // History budget + the paginated history load, hoisted ABOVE the context
+    // Promise.all: the load depends only on the thread, the token budget, and
+    // the compaction boundary (threadMetadata.contextSummary) — never on the
+    // RAG / web / personalization legs — so it runs concurrently with them
+    // instead of serially after (on long threads the sequential page loop was
+    // pure added TTFT). The builder consumes it via `preloadedHistory`.
+    const agentConfig = AGENT_CONTEXT_CONFIGS[agentType];
+    const governanceMaxContext =
+      config.maxContextTokens ?? args.maxContextTokens;
+    // History budget scales with the model's real context window (capped), so a
+    // long chat actually fills the window and auto-compaction can kick in at
+    // ~90%. Never dips below the per-agent default; governance still caps it.
+    // An unknown context window falls back to a sensible default inside
+    // `resolveContextBudget`.
+    const effectiveMaxHistoryTokens = resolveContextBudget({
+      contextWindow: modelContextWindow,
+      governanceMaxContext:
+        governanceMaxContext != null &&
+        Number.isFinite(governanceMaxContext) &&
+        governanceMaxContext > 0
+          ? governanceMaxContext
+          : undefined,
+      agentDefault: agentConfig.maxHistoryTokens,
+    });
+    debugLog('History budget resolved', {
+      modelContextWindow,
+      governanceLimit: governanceMaxContext,
+      agentDefault: agentConfig.maxHistoryTokens,
+      effective: effectiveMaxHistoryTokens,
+    });
+    // Adaptive Reasoning Governor (Layer C) state — also the source of the
+    // compaction summary that bounds the history load. Shared with the context
+    // Promise.all below (awaiting a promise twice is safe).
+    const threadMetadataPromise = ctx
+      .runQuery(internal.threads.internal_queries.getThreadMetadata, {
+        threadId,
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          '[reasoning] getThreadMetadata failed; using cold-start prior',
+          err instanceof Error ? err.message : err,
+        );
+        return null;
+      });
+    const historyPromise = threadMetadataPromise.then((meta) =>
+      loadStructuredHistory(
+        ctx,
+        threadId,
+        effectiveMaxHistoryTokens,
+        meta?.contextSummary?.coversThroughOrder,
+      ),
+    );
+    // Observe an early rejection so it can never surface as an unhandled
+    // rejection while the context Promise.all is still running; the real
+    // await at context build below still throws the original error.
+    void historyPromise.catch((err: unknown) =>
+      console.warn(
+        '[generate_response] history preload failed (surfaces at context build):',
+        err instanceof Error ? err.message : err,
+      ),
+    );
+
     // Call beforeContext hook if provided
     let hookData: BeforeContextResult | undefined;
     if (hooks?.beforeContext) {
@@ -777,20 +840,10 @@ export async function generateAgentResponse(
           tokens: 0,
         }),
       projectInstructionsPromise,
-      // Adaptive Reasoning Governor (Layer C): fetch the thread's learned
-      // reasoning state alongside the other context queries so it adds no
-      // serial latency. Degrades to the cold-start prior if the lookup fails.
-      ctx
-        .runQuery(internal.threads.internal_queries.getThreadMetadata, {
-          threadId,
-        })
-        .catch((err: unknown) => {
-          console.warn(
-            '[reasoning] getThreadMetadata failed; using cold-start prior',
-            err instanceof Error ? err.message : err,
-          );
-          return null;
-        }),
+      // Adaptive Reasoning Governor (Layer C): the thread's learned reasoning
+      // state — the same promise the history preload above chained from, so
+      // it adds no serial latency and is fetched exactly once.
+      threadMetadataPromise,
       // Inherited cross-thread profile (per org + model) for warm-starting a
       // fresh thread. Also parallel, also best-effort.
       organizationId
@@ -853,41 +906,12 @@ export async function generateAgentResponse(
       });
     }
 
-    // Build structured context (history, RAG, web)
+    // Build structured context (history, RAG, web). The history itself was
+    // preloaded concurrently with the Promise.all above, so `contextBuildMs`
+    // now measures only the RESIDUAL wait (history slower than the other
+    // legs) plus the pure string assembly.
     // Note: promptMessage is NOT included - it's passed via `prompt` parameter
-    const agentConfig = AGENT_CONTEXT_CONFIGS[agentType];
-    const governanceMaxContext =
-      config.maxContextTokens ?? args.maxContextTokens;
-    // History budget scales with the model's real context window (capped), so a
-    // long chat actually fills the window and auto-compaction can kick in at
-    // ~90%. Never dips below the per-agent default; governance still caps it.
-    // An unknown context window falls back to a sensible default inside
-    // `resolveContextBudget`.
-    const historyBudget = resolveContextBudget({
-      contextWindow: modelContextWindow,
-      governanceMaxContext:
-        governanceMaxContext != null &&
-        Number.isFinite(governanceMaxContext) &&
-        governanceMaxContext > 0
-          ? governanceMaxContext
-          : undefined,
-      agentDefault: agentConfig.maxHistoryTokens,
-    });
-    const effectiveMaxHistoryTokens = historyBudget;
-
-    debugLog('History budget resolved', {
-      modelContextWindow,
-      governanceLimit: governanceMaxContext,
-      agentDefault: agentConfig.maxHistoryTokens,
-      effective: effectiveMaxHistoryTokens,
-    });
-
     const contextBuildStart = Date.now();
-    // Artifacts module removed — workspace context is now discoverable via the
-    // `file_list` tool, so there is no artifacts block to build. This was a
-    // no-op async shim (always resolved to '') awaited on the critical path
-    // right before context build; `buildStructuredContext` treats an absent
-    // artifactsContext identically (gated by `if (artifactsContext)`).
     structuredThreadContext = await buildStructuredContext({
       ctx,
       threadId,
@@ -899,6 +923,7 @@ export async function generateAgentResponse(
       artifactsContext: undefined,
       promptMessageId,
       contextSummary,
+      preloadedHistory: await historyPromise,
     });
     const contextBuildMs = Date.now() - contextBuildStart;
 
@@ -2508,7 +2533,7 @@ export async function generateAgentResponse(
                 0,
                 internal.lib.context_management.compaction.summarize
                   .compactThreadHistory,
-                { threadId, organizationId, budget: historyBudget },
+                { threadId, organizationId, budget: effectiveMaxHistoryTokens },
               )
               .then(() => undefined)
               .catch((compactErr: unknown) =>

--- a/services/platform/convex/lib/agent_response/generate_response_error_handling.test.ts
+++ b/services/platform/convex/lib/agent_response/generate_response_error_handling.test.ts
@@ -61,6 +61,11 @@ vi.mock('../agent_completion', () => ({
 const mockBuildStructuredContext = vi.fn();
 vi.mock('../context_management', () => ({
   buildStructuredContext: mockBuildStructuredContext,
+  loadStructuredHistory: vi.fn().mockResolvedValue({
+    messages: [],
+    toolMessageAges: new Map(),
+    approvals: [],
+  }),
   AGENT_CONTEXT_CONFIGS: {
     chat: {
       maxHistoryTokens: 25_000,

--- a/services/platform/convex/lib/context_management/index.ts
+++ b/services/platform/convex/lib/context_management/index.ts
@@ -85,8 +85,10 @@ export {
 // Structured context builder (for collapsible <details> formatted context)
 export {
   buildStructuredContext,
+  loadStructuredHistory,
   type BuildStructuredContextParams,
   type StructuredContextResult,
+  type StructuredHistoryBundle,
 } from './structured_context_builder';
 
 // Message formatters

--- a/services/platform/convex/lib/context_management/structured_context_builder.ts
+++ b/services/platform/convex/lib/context_management/structured_context_builder.ts
@@ -137,6 +137,47 @@ export interface BuildStructuredContextParams {
    *  by `text` instead of being loaded verbatim, and `text` is injected as an
    *  "earlier conversation, condensed" block ahead of the recent turns. */
   contextSummary?: { text: string; coversThroughOrder: number };
+  /** Pre-loaded history (from {@link loadStructuredHistory}): lets the caller
+   *  start the paginated message load CONCURRENTLY with other context work
+   *  (RAG, personalization) instead of serially after it — the load depends
+   *  only on the thread, the token budget, and the summary boundary, never on
+   *  those other legs. When absent the builder loads internally (retry and
+   *  recovery paths keep that). */
+  preloadedHistory?: StructuredHistoryBundle;
+}
+
+/** History bundle produced by {@link loadStructuredHistory} and consumed via
+ *  `preloadedHistory` — the load half of `buildStructuredContext`, split out
+ *  so it can overlap the context `Promise.all` on the hot path. */
+export interface StructuredHistoryBundle {
+  messages: MessageDoc[];
+  toolMessageAges: Map<string, ToolOutputAge>;
+  approvals: ApprovalItem[] | null;
+}
+
+/**
+ * Load message history and approvals in parallel (independent queries).
+ * Messages already folded into the rolling summary are excluded so they
+ * aren't double-counted against the budget (the summary stands in).
+ */
+export async function loadStructuredHistory(
+  ctx: ActionCtx,
+  threadId: string,
+  maxHistoryTokens: number,
+  summarizedThroughOrder?: number,
+): Promise<StructuredHistoryBundle> {
+  const [{ messages, toolMessageAges }, approvals] = await Promise.all([
+    loadPrioritizedMessages(
+      ctx,
+      threadId,
+      maxHistoryTokens,
+      summarizedThroughOrder,
+    ),
+    ctx.runQuery(internal.approvals.internal_queries.getApprovalsForThread, {
+      threadId,
+    }),
+  ]);
+  return { messages, toolMessageAges, approvals };
 }
 
 /**
@@ -160,20 +201,14 @@ export async function buildStructuredContext(
     contextSummary,
   } = params;
 
-  // Load message history and approvals in parallel (independent queries).
-  // Messages already folded into the rolling summary are excluded here so they
-  // aren't double-counted against the budget (the summary stands in).
-  const [{ messages, toolMessageAges }, approvals] = await Promise.all([
-    loadPrioritizedMessages(
+  const { messages, toolMessageAges, approvals } =
+    params.preloadedHistory ??
+    (await loadStructuredHistory(
       ctx,
       threadId,
       maxHistoryTokens,
       contextSummary?.coversThroughOrder,
-    ),
-    ctx.runQuery(internal.approvals.internal_queries.getApprovalsForThread, {
-      threadId,
-    }),
-  ]);
+    ));
 
   const contextParts: string[] = [];
 

--- a/services/platform/convex/lib/prompts/registry/__snapshots__/render.test.ts.snap
+++ b/services/platform/convex/lib/prompts/registry/__snapshots__/render.test.ts.snap
@@ -33,47 +33,15 @@ exports[`cache-critical prompt snapshots > system.structured_response 1`] = `
 STRUCTURED RESPONSES (Optional)
 ====================
 
-For SUBSTANTIAL responses only (multi-paragraph answers, research results, detailed explanations),
-you MAY use these markers to structure your response. Do NOT use markers for short answers,
-simple confirmations, or brief replies.
+For SUBSTANTIAL responses only (multi-paragraph answers, research results, detailed explanations) you MAY structure the reply with these markers — each alone on its own line, in this order. Never use them for short answers, simple confirmations, or brief replies (1-2 paragraphs stay plain).
 
-Available markers (EACH ON ITS OWN LINE with no other text, in this order):
+[[CONCLUSION]] — 1-2 sentence direct answer or summary, shown prominently. Must come first if markers are used.
+[[KEY_POINTS]] — bullet list of the most important findings or facts.
+[[DETAILS]] — extended explanation, context, or supporting details; shown in a collapsible section.
+[[QUESTIONS]] — clarifying questions the user must answer before you proceed (numbered or bulleted list).
+[[NEXT_STEPS]] — 2-4 short follow-up topics, rendered as clickable buttons the user sends as their own message. STRICT FORMAT: one plain-text item per line, under 60 characters, NO numbering, NO bullets, NO markdown, NO preamble line ("Compare Q3 vs Q4 revenue" — never "1. Compare…", "- Analyze…", "**Deep dive**…", or a full sentence of preamble). Questions belong in [[QUESTIONS]], not here. MUST be the LAST section — no text after its items.
 
-[[CONCLUSION]]
-A 1-2 sentence direct answer or summary. Shown prominently to the user.
-
-[[KEY_POINTS]]
-A bullet list of the most important findings or facts.
-
-[[DETAILS]]
-Extended explanation, context, or supporting details. Shown in a collapsible section.
-
-[[QUESTIONS]]
-Clarifying questions you need the user to answer before proceeding.
-Use this when you need more information from the user. Write as a numbered or bulleted list.
-
-[[NEXT_STEPS]]
-2-4 short follow-up topics. These become clickable buttons in the UI that the user sends as their own message.
-STRICT FORMAT — one plain-text item per line, NO numbering, NO bullets, NO markdown, NO preamble lines.
-Each item MUST be under 60 characters. Be concise — these are button labels, not sentences.
-Good: Compare Q3 vs Q4 revenue
-Good: Analyze competitor pricing strategy
-Bad: 1. Compare Q3 vs Q4 revenue (no numbering)
-Bad: - Analyze competitor pricing (no bullets)
-Bad: **Deep dive** into pricing (no markdown)
-Bad: Tell me:
-1. What pricing... (no preamble + sub-list)
-Bad: Based on the research already conducted, here are the six recommended perspectives (way too long)
-Do NOT put questions here — use [[QUESTIONS]] instead.
-[[NEXT_STEPS]] MUST be the LAST section. Do NOT add any text after the follow-up items.
-
-Rules:
-- Markers are OPTIONAL. Only use them when the response is long enough to benefit from structure.
-- [[CONCLUSION]] must come first if you use markers.
-- Not all markers are required. Use only the ones that fit the content.
-- Each marker must appear alone on its own line. Do NOT put other text on the same line as a marker.
-- Do NOT use markers inside code blocks.
-- For short responses (1-2 paragraphs), just respond normally without any markers."
+Rules: markers are optional and none is required — use only the ones that fit; never put other text on a marker's line; never use markers inside code blocks."
 `;
 
 exports[`cache-critical prompt snapshots > system.untrusted_content 1`] = `

--- a/services/platform/convex/lib/prompts/registry/entries/system.ts
+++ b/services/platform/convex/lib/prompts/registry/entries/system.ts
@@ -50,44 +50,13 @@ export const structuredResponseEntry: PromptEntry = {
 STRUCTURED RESPONSES (Optional)
 ====================
 
-For SUBSTANTIAL responses only (multi-paragraph answers, research results, detailed explanations),
-you MAY use these markers to structure your response. Do NOT use markers for short answers,
-simple confirmations, or brief replies.
+For SUBSTANTIAL responses only (multi-paragraph answers, research results, detailed explanations) you MAY structure the reply with these markers — each alone on its own line, in this order. Never use them for short answers, simple confirmations, or brief replies (1-2 paragraphs stay plain).
 
-Available markers (EACH ON ITS OWN LINE with no other text, in this order):
+[[CONCLUSION]] — 1-2 sentence direct answer or summary, shown prominently. Must come first if markers are used.
+[[KEY_POINTS]] — bullet list of the most important findings or facts.
+[[DETAILS]] — extended explanation, context, or supporting details; shown in a collapsible section.
+[[QUESTIONS]] — clarifying questions the user must answer before you proceed (numbered or bulleted list).
+[[NEXT_STEPS]] — 2-4 short follow-up topics, rendered as clickable buttons the user sends as their own message. STRICT FORMAT: one plain-text item per line, under 60 characters, NO numbering, NO bullets, NO markdown, NO preamble line ("Compare Q3 vs Q4 revenue" — never "1. Compare…", "- Analyze…", "**Deep dive**…", or a full sentence of preamble). Questions belong in [[QUESTIONS]], not here. MUST be the LAST section — no text after its items.
 
-[[CONCLUSION]]
-A 1-2 sentence direct answer or summary. Shown prominently to the user.
-
-[[KEY_POINTS]]
-A bullet list of the most important findings or facts.
-
-[[DETAILS]]
-Extended explanation, context, or supporting details. Shown in a collapsible section.
-
-[[QUESTIONS]]
-Clarifying questions you need the user to answer before proceeding.
-Use this when you need more information from the user. Write as a numbered or bulleted list.
-
-[[NEXT_STEPS]]
-2-4 short follow-up topics. These become clickable buttons in the UI that the user sends as their own message.
-STRICT FORMAT — one plain-text item per line, NO numbering, NO bullets, NO markdown, NO preamble lines.
-Each item MUST be under 60 characters. Be concise — these are button labels, not sentences.
-Good: Compare Q3 vs Q4 revenue
-Good: Analyze competitor pricing strategy
-Bad: 1. Compare Q3 vs Q4 revenue (no numbering)
-Bad: - Analyze competitor pricing (no bullets)
-Bad: **Deep dive** into pricing (no markdown)
-Bad: Tell me:\n1. What pricing... (no preamble + sub-list)
-Bad: Based on the research already conducted, here are the six recommended perspectives (way too long)
-Do NOT put questions here — use [[QUESTIONS]] instead.
-[[NEXT_STEPS]] MUST be the LAST section. Do NOT add any text after the follow-up items.
-
-Rules:
-- Markers are OPTIONAL. Only use them when the response is long enough to benefit from structure.
-- [[CONCLUSION]] must come first if you use markers.
-- Not all markers are required. Use only the ones that fit the content.
-- Each marker must appear alone on its own line. Do NOT put other text on the same line as a marker.
-- Do NOT use markers inside code blocks.
-- For short responses (1-2 paragraphs), just respond normally without any markers.`,
+Rules: markers are optional and none is required — use only the ones that fit; never put other text on a marker's line; never use markers inside code blocks.`,
 };

--- a/services/platform/tests/e2e/specs/chat-ttft.spec.ts
+++ b/services/platform/tests/e2e/specs/chat-ttft.spec.ts
@@ -1,0 +1,80 @@
+import { CANNED_REPLY } from '../../../lib/mocks/overrides/canned';
+import {
+  assistantMessages,
+  deleteThreadById,
+  fillComposer,
+  sendButton,
+  sendNewThreadMessage,
+} from '../helpers/chat';
+import { TIMEOUT, isMockLlmMode } from '../helpers/env';
+import { test, expect } from '../helpers/fixtures';
+
+/**
+ * Chat time-to-first-words budget (mock stack only).
+ *
+ * The mock provider answers instantly, so click→reply wall time here is pure
+ * platform pipeline: mutation → scheduled node action → config/guardrails →
+ * streamText → delta flush → reactive render. The 2026-07 TTFT investigation
+ * (#2776, PR #2777) measured this floor at ~0.8–1.0s locally; the regression
+ * class this spec guards against — a serial classifier hop on pinned turns,
+ * forced thinking, a de-parallelized pipeline — costs MULTIPLE seconds, so
+ * the bands sit generously above CI-runner noise and far below any real
+ * regression. The first turn (navigation + thread creation) is a warm-up and
+ * is not timed; the three follow-ups are timed from the send CLICK to the
+ * reply becoming visible.
+ *
+ * Budget anchored to `sla-targets.ts` `dialog_ttft` (~1s mean in production):
+ * median of three warm turns < 3.5s, worst single turn < 8s.
+ */
+
+test.skip(!isMockLlmMode(), 'perf budget is only deterministic under the mock');
+
+const MEDIAN_BUDGET_MS = 3_500;
+const WORST_BUDGET_MS = 8_000;
+
+const chatUrl = (organizationId: string) => `/dashboard/${organizationId}/chat`;
+
+test('three warm mock turns stay inside the first-words budget', async ({
+  page,
+  org,
+}) => {
+  const { organizationId } = org;
+  await page.goto(chatUrl(organizationId));
+
+  const salt = Date.now().toString(36);
+
+  // Untimed warm-up: creates the thread (navigation-heavy) and absorbs any
+  // cold module import after a fresh push.
+  const threadId = await sendNewThreadMessage(page, `ttft warmup ${salt}`);
+  await expect(
+    assistantMessages(page).nth(0).getByText(CANNED_REPLY),
+  ).toBeVisible({ timeout: TIMEOUT.REPLY });
+
+  const durations: number[] = [];
+  for (let turn = 1; turn <= 3; turn++) {
+    const message = `ttft probe ${salt} turn ${turn}`;
+    await fillComposer(page, message);
+    await expect(sendButton(page)).toBeEnabled();
+    const before = Date.now();
+    await sendButton(page).click();
+    await expect(
+      assistantMessages(page).nth(turn).getByText(CANNED_REPLY),
+    ).toBeVisible({ timeout: TIMEOUT.REPLY });
+    durations.push(Date.now() - before);
+  }
+
+  const sorted = [...durations].sort((a, b) => a - b);
+  const median = sorted[1];
+  const worst = sorted[2];
+
+  expect(
+    median,
+    `median first-words ${median}ms over budget (turns: ${durations.join(', ')}ms)`,
+  ).toBeLessThan(MEDIAN_BUDGET_MS);
+  expect(
+    worst,
+    `worst first-words ${worst}ms over budget (turns: ${durations.join(', ')}ms)`,
+  ).toBeLessThan(WORST_BUDGET_MS);
+
+  await deleteThreadById(page, threadId);
+});


### PR DESCRIPTION
## Why

Second wave of the chat time-to-first-words work: the four items deferred from the investigation PR (#2777) into #2776. All measured live on the same harness (mock-provider floor = pure pipeline; fresh-thread pinned-Haiku probe for payload; Auto turn for routing).

## Changes

1. **Auto classifier overlap** — the guardrails snapshot starts immediately for every mode, and under Auto the default chat agent's config + governance resolve speculatively during the classifier's LLM round-trip; a specialist route redoes them at the old serial cost. Verified live: a novel Auto turn classified → default agent through the speculative path, `timeFromSendMs` 3,098 ms vs 4,256 ms for the equivalent baseline turn.
2. **History preload** — `buildStructuredContext`'s paginated message load (sequential 100/page) now runs concurrently with the RAG/web/personalization fan-out via a `loadStructuredHistory` split, chained off the shared threadMetadata query. Retry/recovery paths keep the internal load.
3. **Payload slim** — twelve tool descriptions + the structured-responses appendix compressed to ~half; every operation, parameter rule, scope limit, redirect, and emphatic guard preserved (rules duplicated in `inputSchema.describe()` texts were the main cut). **Measured: 19,147 → 16,496 input tokens (−13.8%)** on the fresh-thread probe. The remaining distance to the issue's aspirational <10k needs lazy/conditional tool registration and an agent-instruction diet — product-shaped calls, explicitly out of scope here.
4. **Perf-budget guard** — `chat-ttft.spec.ts` (mock stack): three warm turns, median < 3.5 s, worst < 8 s; bands sit far above CI-runner noise and far below the multi-second regression class the investigation fixed.

## Verification

- Mock pipeline floor unchanged after 1+2: 861/901 ms perceived first-words (baseline 780–990 ms band).
- Live Haiku fresh-thread probe: payload −2.7k tokens; Auto turn routes correctly (`classified`, speculative prep cashed in).
- 753 server tests + prompts snapshot suite + UI suite green; `bun run check` green except the pre-existing machine-local `pdftotext` failure in `@tale/sandbox-runtime-daemon` (fails identically on clean main).

Closes #2776.
