### PR TITLE
feat(platform): probe the node-action lane on the status page

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1323,6 +1323,8 @@ import type * as skills_file_utils from "../skills/file_utils.js";
 import type * as skills_get_skill_audit_history from "../skills/get_skill_audit_history.js";
 import type * as skills_upload_mutations from "../skills/upload_mutations.js";
 import type * as sso_providers_validators from "../sso_providers/validators.js";
+import type * as status_node_ping from "../status/node_ping.js";
+import type * as status_node_ping_queries from "../status/node_ping_queries.js";
 import type * as streaming_helpers from "../streaming/helpers.js";
 import type * as streaming_http_actions from "../streaming/http_actions.js";
 import type * as streaming_internal_mutations from "../streaming/internal_mutations.js";
@@ -3103,6 +3105,8 @@ declare const fullApi: ApiFromModules<{
   "skills/get_skill_audit_history": typeof skills_get_skill_audit_history;
   "skills/upload_mutations": typeof skills_upload_mutations;
   "sso_providers/validators": typeof sso_providers_validators;
+  "status/node_ping": typeof status_node_ping;
+  "status/node_ping_queries": typeof status_node_ping_queries;
   "streaming/helpers": typeof streaming_helpers;
   "streaming/http_actions": typeof streaming_http_actions;
   "streaming/internal_mutations": typeof streaming_internal_mutations;

--- a/services/platform/convex/status/node_ping.ts
+++ b/services/platform/convex/status/node_ping.ts
@@ -1,0 +1,30 @@
+'use node';
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import { internalAction } from '../_generated/server';
+
+/**
+ * Liveness probe for the NODE-action lane.
+ *
+ * Self-hosted Convex runs `'use node'` actions in a separate node executor
+ * whose syscalls (`ctx.runQuery` & co.) are HTTP callbacks to the backend.
+ * That channel can wedge independently of everything the existing `/version`
+ * probe sees — observed on demo v0.3.8 (2026-07-18): every node action failed
+ * with "fetch failed" for hours while V8 queries and the HTTP-actions site
+ * kept working and the status page said "operational".
+ *
+ * The platform's status prober invokes this through the admin-key
+ * ConvexHttpClient channel (same as WebDAV), so no new public HTTP surface is
+ * exposed. Executing this action at all proves the executor spawns; the inner
+ * `runQuery` round-trip proves the callback channel — the part that actually
+ * broke.
+ */
+export const ping = internalAction({
+  args: {},
+  returns: v.string(),
+  handler: async (ctx): Promise<string> => {
+    return await ctx.runQuery(internal.status.node_ping_queries.ok, {});
+  },
+});

--- a/services/platform/convex/status/node_ping_queries.ts
+++ b/services/platform/convex/status/node_ping_queries.ts
@@ -1,0 +1,16 @@
+import { v } from 'convex/values';
+
+import { internalQuery } from '../_generated/server';
+
+/**
+ * Trivial V8 query the node-lane ping round-trips through. The VALUE is the
+ * round-trip itself: a `'use node'` action's `ctx.runQuery` is an HTTP
+ * callback from the node executor to the backend, and that channel is
+ * exactly what a wedged executor breaks ("fetch failed" from every node
+ * action) while V8 execution and external HTTP stay healthy.
+ */
+export const ok = internalQuery({
+  args: {},
+  returns: v.string(),
+  handler: async () => 'ok',
+});

--- a/services/platform/status-probe.test.ts
+++ b/services/platform/status-probe.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   _resetStatusProbeCache,
+  _setNodeLaneProbeForTests,
   buildStatusFeed,
   type ComponentResult,
   probeServices,
@@ -32,8 +33,15 @@ function allOperationalFeedComponents(): StatusFeedComponent[] {
   return [{ id: 'convex', status: 'operational' }];
 }
 
+beforeEach(() => {
+  // The node-lane probe self-activates on ADMIN_KEY; a developer shell that
+  // exports one must not change which components these tests see.
+  vi.stubEnv('ADMIN_KEY', '');
+});
+
 afterEach(() => {
   _resetStatusProbeCache();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -144,6 +152,42 @@ describe('probeServices', () => {
     const [ra, rb, rc] = await Promise.all([a, b, c]);
     expect(ra).toBe(rb);
     expect(rb).toBe(rc);
+  });
+});
+
+describe('node-action lane probe', () => {
+  test('appears as a second component and keeps operational when up', async () => {
+    _setNodeLaneProbeForTests(() => Promise.resolve(true));
+    const doFetch = vi.fn(() => Promise.resolve(okResponse()));
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.components.map((c) => c.id)).toEqual([
+      'convex',
+      'convexNodeActions',
+    ]);
+    expect(result.overall).toBe('operational');
+    // The node lane rides the admin client, not fetch — the single fetch is
+    // still the /version liveness probe.
+    expect(doFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('a wedged node lane degrades the status while V8 liveness stays green', async () => {
+    // The demo v0.3.8 incident shape: /version answered 200 while every
+    // 'use node' action died with "fetch failed" — the page must say
+    // degraded, not operational.
+    _setNodeLaneProbeForTests(() => Promise.resolve(false));
+    const doFetch = vi.fn(() => Promise.resolve(okResponse()));
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.overall).toBe('degraded');
+    expect(
+      result.components.find((c) => c.id === 'convexNodeActions')?.up,
+    ).toBe(false);
+    expect(result.components.find((c) => c.id === 'convex')?.up).toBe(true);
+  });
+
+  test('absent without an ADMIN_KEY or override — dev keeps one component', async () => {
+    const doFetch = vi.fn(() => Promise.resolve(okResponse()));
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.components.map((c) => c.id)).toEqual(['convex']);
   });
 });
 
@@ -300,6 +344,23 @@ describe('renderStatusPage', () => {
   test('uses French status words for fr locale', () => {
     expect(renderStatusPage(baseFeed, 'fr-FR')).toContain('>Opérationnel<');
     expect(renderStatusPage(outageFeed, 'fr-FR')).toContain('>Indisponible<');
+  });
+
+  test('renders the background-processing row when the node lane is down', () => {
+    const degraded: StatusFeed = {
+      status: 'degraded',
+      components: [
+        { id: 'convex', status: 'operational' },
+        { id: 'convexNodeActions', status: 'outage' },
+      ],
+      checkedAt: baseFeed.checkedAt,
+    };
+    const html = renderStatusPage(degraded, '');
+    expect(html).toContain('Partial degradation');
+    expect(html).toContain('Background processing');
+    expect(html).toContain('>Unavailable<');
+    // Still no stack names on the public surface.
+    expect(html).not.toContain('Convex');
   });
 
   test('marks status dots aria-hidden so screen readers rely on the text label', () => {

--- a/services/platform/status-probe.ts
+++ b/services/platform/status-probe.ts
@@ -11,21 +11,30 @@
  * the public response or this process's memory.
  */
 
+import { ConvexHttpClient } from 'convex/browser';
+import { anyApi } from 'convex/server';
+
 const CACHE_TTL_MS = 5000;
 const PROBE_TIMEOUT_MS = 2000;
+// Node-action probes spawn a node executor on a cold path — give them more
+// headroom than a plain HTTP liveness fetch before calling the lane down.
+const NODE_PROBE_TIMEOUT_MS = 8000;
 
 // Default to loopback so `bun run dev` works without env overrides; docker
 // compose sets CONVEX_URL to the in-network DNS name (convex), which takes
 // precedence. Knowledge-base (RAG) and web/document (crawler) work now runs
 // IN-PROCESS inside the Convex backend — there are no separate rag/crawler
-// HTTP services to probe, so Convex liveness is the single backend signal.
+// HTTP services to probe, so Convex liveness is the single backend signal
+// for V8 execution; the node-action lane gets its own probe below.
 const CONVEX_URL = process.env.CONVEX_URL || 'http://127.0.0.1:3210';
 
 export type OverallStatus = 'operational' | 'degraded' | 'outage';
-// One backend today (the Convex application, which subsumes RAG + crawler).
-// The wider vocabulary is kept so a future per-subsystem probe can re-add ids
-// without breaking consumers.
-export type ComponentId = 'convex';
+// Two facets of the one backend: `convex` is V8/HTTP liveness (the
+// `/version` fetch), `convexNodeActions` is the `'use node'` executor lane —
+// which can wedge on its own. Observed on demo v0.3.8 (2026-07-18): every
+// node action failed with "fetch failed" for hours after an upgrade restart
+// while `/version` stayed green and this page said "operational".
+export type ComponentId = 'convex' | 'convexNodeActions';
 
 // Binary today because each probe is just `fetch.ok`. The wider
 // `OverallStatus` vocabulary leaves room for a future `'degraded'`
@@ -56,18 +65,99 @@ export interface StatusFeed {
 
 interface Probe {
   id: ComponentId;
-  url: string;
+  run: (doFetch: typeof fetch) => Promise<boolean>;
+}
+
+let cache: { at: number; result: StatusResult } | null = null;
+let inflight: Promise<StatusResult> | null = null;
+
+// ---------------------------------------------------------------------------
+// Node-action lane probe
+//
+// Rides the same admin-key ConvexHttpClient channel WebDAV uses
+// (`lib/webdav/ctx.ts`), so no new public HTTP surface is exposed — the
+// convex `/ping` route is internet-reachable through Caddy, and an
+// unauthenticated endpoint that spawns a node process per hit would be an
+// abuse lever. Skipped entirely (component absent) when ADMIN_KEY is unset,
+// e.g. plain `bun run dev` without the entrypoint-provisioned key.
+// ---------------------------------------------------------------------------
+
+type NodeLaneProbe = () => Promise<boolean>;
+
+let nodeLaneProbeOverride: NodeLaneProbe | null = null;
+let adminClient: ConvexHttpClient | null = null;
+
+function getAdminClient(adminKey: string): ConvexHttpClient {
+  if (!adminClient) {
+    const client = new ConvexHttpClient(CONVEX_URL);
+    // setAdminAuth is @internal in convex types but present at runtime —
+    // the established pattern (lib/webdav/ctx.ts, reset-owner.ts).
+    // oxlint-disable-next-line no-unsafe-type-assertion
+    const setAdminAuth = Reflect.get(client, 'setAdminAuth') as (
+      token: string,
+    ) => void;
+    setAdminAuth.call(client, adminKey);
+    adminClient = client;
+  }
+  return adminClient;
+}
+
+async function probeNodeLane(adminKey: string): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      getAdminClient(adminKey).action(anyApi.status.node_ping.ping, {}),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('node-lane probe timed out')),
+          NODE_PROBE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    return result === 'ok';
+  } catch (err) {
+    // Cadence is bounded by the probe cache, so this cannot spam. No
+    // upstream string reaches the public response — only this log.
+    console.warn(
+      '[status-probe] node-action lane probe failed:',
+      err instanceof Error ? err.message : String(err),
+    );
+    return false;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/** Test-only: replace (or clear) the node-lane probe implementation. */
+export function _setNodeLaneProbeForTests(probe: NodeLaneProbe | null): void {
+  nodeLaneProbeOverride = probe;
+}
+
+async function probeUrl(url: string, doFetch: typeof fetch): Promise<boolean> {
+  return probeOne(url, doFetch);
 }
 
 // Convex has no `/health`; `/version` is the established liveness probe
 // (already used by services/platform/docker-entrypoint.sh and the Convex
 // container's own healthcheck). Body is plain text — do NOT call .json().
-const PROBES: readonly Probe[] = [
-  { id: 'convex', url: `${CONVEX_URL}/version` },
-];
-
-let cache: { at: number; result: StatusResult } | null = null;
-let inflight: Promise<StatusResult> | null = null;
+// Assembled per round (not module-level) so the node-lane component appears
+// exactly when a probe implementation is available.
+function buildProbes(): Probe[] {
+  const probes: Probe[] = [
+    { id: 'convex', run: (f) => probeUrl(`${CONVEX_URL}/version`, f) },
+  ];
+  const adminKey = process.env.ADMIN_KEY;
+  if (nodeLaneProbeOverride) {
+    const override = nodeLaneProbeOverride;
+    probes.push({ id: 'convexNodeActions', run: () => override() });
+  } else if (adminKey) {
+    probes.push({
+      id: 'convexNodeActions',
+      run: () => probeNodeLane(adminKey),
+    });
+  }
+  return probes;
+}
 
 async function probeOne(url: string, doFetch: typeof fetch): Promise<boolean> {
   try {
@@ -88,8 +178,9 @@ async function probeOne(url: string, doFetch: typeof fetch): Promise<boolean> {
 }
 
 async function runProbes(doFetch: typeof fetch): Promise<StatusResult> {
-  const ups = await Promise.all(PROBES.map((p) => probeOne(p.url, doFetch)));
-  const components: ComponentResult[] = PROBES.map((p, i) => ({
+  const probes = buildProbes();
+  const ups = await Promise.all(probes.map((p) => p.run(doFetch)));
+  const components: ComponentResult[] = probes.map((p, i) => ({
     id: p.id,
     up: ups[i] ?? false,
   }));
@@ -138,6 +229,8 @@ export async function probeServices(
 export function _resetStatusProbeCache(): void {
   cache = null;
   inflight = null;
+  nodeLaneProbeOverride = null;
+  adminClient = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,6 +284,7 @@ const STRINGS = {
     statusDown: 'Unavailable',
     components: {
       convex: 'Application',
+      convexNodeActions: 'Background processing',
     },
   },
   de: {
@@ -204,6 +298,7 @@ const STRINGS = {
     statusDown: 'Nicht verfügbar',
     components: {
       convex: 'Anwendung',
+      convexNodeActions: 'Hintergrundverarbeitung',
     },
   },
   fr: {
@@ -217,6 +312,7 @@ const STRINGS = {
     statusDown: 'Indisponible',
     components: {
       convex: 'Application',
+      convexNodeActions: 'Traitements en arrière-plan',
     },
   },
 } as const;


### PR DESCRIPTION
## The incident this makes visible (demo, 2026-07-18)

After the v0.3.8 upgrade restart (~09:45Z), **every `'use node'` action on demo failed with `Uncaught Error: fetch failed`** — uploads, branding reads, provider/agent/automation listings, `generateBlobUpload` — for ~3.5 hours, until a manual convex-container restart at ~13:19Z healed it instantly. GlitchTip: 6+ issue groups, all firstSeen 09:45, ~900 events.

**Why it happened:** `git log v0.3.7..v0.3.8` contains only three pure-platform commits — zero changes to the convex service, entrypoints, or deploy orchestration. The same upgrade procedure ran clean for v0.3.7 five hours earlier. So this wasn't a release regression but an **upgrade-restart race** that left the node executor's backend-callback channel wedged: node actions run in a separate executor whose syscalls (`ctx.runQuery` etc.) are HTTP callbacks to the backend, and that channel died while V8 execution and the HTTP-actions site stayed healthy (same class as the #2631 dev-side observations of deploy pushes breaking the node-action runtime).

**Why nobody could see it:** `/status` probes only `${CONVEX_URL}/version` — V8/HTTP liveness. The page said **"operational"** for the entire outage.

## Change

A second status component, **"Background processing"** (`convexNodeActions`):

- `convex/status/node_ping.ts` — internal `'use node'` action whose handler round-trips an internal V8 query. Executing it proves the executor spawns; the inner `runQuery` proves the callback channel — the exact part that broke.
- The platform prober invokes it over the **admin-key ConvexHttpClient channel** WebDAV already uses — no new public HTTP surface (`/ping` is internet-reachable through Caddy, and an unauthenticated endpoint that spawns a node process per hit would be an abuse lever). Without `ADMIN_KEY` (plain `bun run dev`), the component is simply absent.
- A wedged lane now renders **"Partial degradation"** on `/status` (labels in en/de/fr, no stack names) and flips `/status.json` to `degraded` for keyword monitors. Probe cadence stays bounded by the existing 5 s single-flight cache; the node probe gets an 8 s timeout for cold spawns.

## Verification

- `bun run check` green; `status-probe.test.ts` 30/30 — including the incident-shaped regression test ("`/version` 200 while the node lane is down → degraded, not operational"), which the old code fails.
- The E2E that surfaced all of this now passes end-to-end on demo v0.3.8 after the restart: 59.7 MB browser upload → presigned PUT into the org's R2 bucket (62,593,142 bytes verified) → indexed on the org's Neon knowledge DB (vector-only) → chat Q&A answers the planted facts with the document cited.