### PR TITLE
feat(docs): video-pipeline authoring loop — check, doctor, mock rehearsal, draft compose, A/V verification

### DIFF
--- a/.agents/skills/produce-video/SKILL.md
+++ b/.agents/skills/produce-video/SKILL.md
@@ -30,10 +30,18 @@ any asset under `services/docs/public/videos/**`, a `<Video>` embed on a docs pa
   pronunciation map — spoken text only, captions keep the real spelling. ElevenLabs audio
   tags sparingly; punctuation and ellipses carry pacing. Claims must be true of the product —
   narration ships in three languages and gets quoted back.
+- **Rehearse free before you bill or record.** `--stage check` (instant: spec ↔ choreography ↔
+  mock-reply pairing), `--stage plan` (instant: the timeline table from estimates), then a
+  `--mock-tts` take (silence-narrated, auto-composed as a draft into `.state/`) prove the
+  structure, the locators, and the budgets at zero cost. Only then synthesize real narration and
+  record the real take. (Why: every failure mode caught by check/plan/mock costs seconds there and
+  minutes-to-euros later; the same validation runs in `bun run check` via the episode gate.)
 - **TTS bills per character — respect the cache.** `--stage tts` is cache-first
   (`.state/tts-cache/`); an unchanged scene is free, an edited one re-bills all its locales.
   Batch script edits, then regenerate once. Voice ids are pinned per locale in the episode spec;
-  audition with `--audition` before changing one (a voice change re-records every locale).
+  audition with `--audition` before changing one (a voice change re-records every locale). The
+  cache key shape is test-pinned (`lib/tts-cache-key.test.ts`) — changing it re-bills the entire
+  back catalog.
 - **Choreography waits on state, never on time — `cue()` is the one exception.** Target elements
   by role + `localeT` label or by href/data literal (seeded content stays English in every
   locale; per-locale DISPLAY NAMES like the builtin agent are data — map them). Scope pickers to
@@ -41,9 +49,11 @@ any asset under `services/docs/public/videos/**`, a `<Video>` embed on a docs pa
   fix with a per-scene `minMs`/`leadInMs` in the spec, never by letting it slide. (enforced by the
   recorder + compose drift gate, ±100 ms)
 - **Takes are additive-only against the shared org.** Recording reuses the docs-screenshots
-  workspace; the only mutation a take may leave is nothing — the wow thread is cleaned up even on
-  abort. Demo-content changes go through `../docs-screenshots/demo-content.ts` and the paired
-  `lib/mocks/overrides/docs-replies.ts` (the typed prompt must contain its reply's match clause).
+  workspace; the only mutation a take may leave is nothing — anything a scene creates on camera
+  registers on `ctx.cleanup` (thread, knowledge entry, agent, task) the moment it exists, and the
+  recorder sweeps it even on abort. Demo-content changes go through
+  `../docs-screenshots/demo-content.ts` and the paired `lib/mocks/overrides/docs-replies.ts` (the
+  typed prompt must contain its reply's match clause — `--stage check` enforces the pairing).
 - **The shipped set is indivisible.** An episode ships `<id>.<locale>.{mp4,vtt,webp}` for ALL
   three locales, declared in `public/videos/manifest.json`, embedded via `<Video>` (src + poster +
   captions + lang) on pages whose locale matches. (enforced by `services/docs/tests/videos.test.ts`)
@@ -61,10 +71,13 @@ await cursor.click(pickerDoc); // the viewer hears it, then sees it
 ## Before an episode ships — tick every box, or N/A with a reason
 
 - [ ] **Watched end-to-end at 1×, every locale** — not skimmed frames: cursor motion, stream
-      pacing, scene transitions, the fade-out.
+      pacing, scene transitions, the fade-out. The per-scene review sheet
+      (`.state/review/<id>.<locale>/index.html`, written by every compose) is the triage aid, not
+      the watch-through.
 - [ ] **Listened, every locale** — pronunciation (brand names!), pace, no synthesis artifacts;
       spot-check with an STT round-trip when unsure.
-- [ ] **Compose drift gate green** (±100 ms every scene) and no overrun waivers.
+- [ ] **Compose gates green** — drift (±100 ms every scene), the automatic A/V verification
+      (duration + speech coverage; never ship on `--no-verify`), and no overrun waivers.
 - [ ] **Captions open correctly** on the rendered docs page in each locale; timing follows the voice.
 - [ ] **`bun run --filter @tale/docs test` green** — the videos contract plus the docs suite.
 - [ ] **Shared org left as seeded** — cleanup ran; `docs:screenshots --skip-seed --only chat-thread-reply` still captures pixel-equivalent.

--- a/.agents/skills/produce-video/STORYBOARD.md
+++ b/.agents/skills/produce-video/STORYBOARD.md
@@ -59,10 +59,14 @@ scene. End the episode by naming what the next one covers — the series is a se
 
 ## Adding an episode, in order
 
-1. Storyboard on paper: scenes, surfaces, the one wow moment, where the AI-literacy beat lands.
-2. Write `episode.ts` narration (en first, then de/fr natively) + any new mock replies
+1. Scaffold the pair: `bun run gen` → `video-episode` (spec + choreography skeleton with the
+   series voices and the warmup contract).
+2. Storyboard on paper: scenes, surfaces, the one wow moment, where the AI-literacy beat lands.
+3. Write `episode.ts` narration (en first, then de/fr natively) + any new mock replies
    (`lib/mocks/overrides/docs-replies.ts`) and demo-content the surfaces need (seeder, not takes).
-3. `--stage tts` once per locale; listen to two or three scenes before recording anything.
-4. Write `scenes.ts`; rehearse the risky interactions standalone before a full take.
-5. Record + compose per locale; run the SKILL.md ship checklist; embed on the docs pages
+   `--stage check` and `--stage plan` are instant — run them as you go.
+4. Write `scenes.ts`; rehearse the whole take free with `--mock-tts` (silence narration, draft
+   compose, review sheet) until the choreography fits every budget.
+5. `--stage tts` once per locale; listen to two or three scenes before recording anything.
+6. Record + compose per locale; run the SKILL.md ship checklist; embed on the docs pages
    (episode page + index row + any overview embeds) in all three locales.

--- a/.claude/skills/produce-video/SKILL.md
+++ b/.claude/skills/produce-video/SKILL.md
@@ -30,10 +30,18 @@ any asset under `services/docs/public/videos/**`, a `<Video>` embed on a docs pa
   pronunciation map — spoken text only, captions keep the real spelling. ElevenLabs audio
   tags sparingly; punctuation and ellipses carry pacing. Claims must be true of the product —
   narration ships in three languages and gets quoted back.
+- **Rehearse free before you bill or record.** `--stage check` (instant: spec ↔ choreography ↔
+  mock-reply pairing), `--stage plan` (instant: the timeline table from estimates), then a
+  `--mock-tts` take (silence-narrated, auto-composed as a draft into `.state/`) prove the
+  structure, the locators, and the budgets at zero cost. Only then synthesize real narration and
+  record the real take. (Why: every failure mode caught by check/plan/mock costs seconds there and
+  minutes-to-euros later; the same validation runs in `bun run check` via the episode gate.)
 - **TTS bills per character — respect the cache.** `--stage tts` is cache-first
   (`.state/tts-cache/`); an unchanged scene is free, an edited one re-bills all its locales.
   Batch script edits, then regenerate once. Voice ids are pinned per locale in the episode spec;
-  audition with `--audition` before changing one (a voice change re-records every locale).
+  audition with `--audition` before changing one (a voice change re-records every locale). The
+  cache key shape is test-pinned (`lib/tts-cache-key.test.ts`) — changing it re-bills the entire
+  back catalog.
 - **Choreography waits on state, never on time — `cue()` is the one exception.** Target elements
   by role + `localeT` label or by href/data literal (seeded content stays English in every
   locale; per-locale DISPLAY NAMES like the builtin agent are data — map them). Scope pickers to
@@ -41,9 +49,11 @@ any asset under `services/docs/public/videos/**`, a `<Video>` embed on a docs pa
   fix with a per-scene `minMs`/`leadInMs` in the spec, never by letting it slide. (enforced by the
   recorder + compose drift gate, ±100 ms)
 - **Takes are additive-only against the shared org.** Recording reuses the docs-screenshots
-  workspace; the only mutation a take may leave is nothing — the wow thread is cleaned up even on
-  abort. Demo-content changes go through `../docs-screenshots/demo-content.ts` and the paired
-  `lib/mocks/overrides/docs-replies.ts` (the typed prompt must contain its reply's match clause).
+  workspace; the only mutation a take may leave is nothing — anything a scene creates on camera
+  registers on `ctx.cleanup` (thread, knowledge entry, agent, task) the moment it exists, and the
+  recorder sweeps it even on abort. Demo-content changes go through
+  `../docs-screenshots/demo-content.ts` and the paired `lib/mocks/overrides/docs-replies.ts` (the
+  typed prompt must contain its reply's match clause — `--stage check` enforces the pairing).
 - **The shipped set is indivisible.** An episode ships `<id>.<locale>.{mp4,vtt,webp}` for ALL
   three locales, declared in `public/videos/manifest.json`, embedded via `<Video>` (src + poster +
   captions + lang) on pages whose locale matches. (enforced by `services/docs/tests/videos.test.ts`)
@@ -61,10 +71,13 @@ await cursor.click(pickerDoc); // the viewer hears it, then sees it
 ## Before an episode ships — tick every box, or N/A with a reason
 
 - [ ] **Watched end-to-end at 1×, every locale** — not skimmed frames: cursor motion, stream
-      pacing, scene transitions, the fade-out.
+      pacing, scene transitions, the fade-out. The per-scene review sheet
+      (`.state/review/<id>.<locale>/index.html`, written by every compose) is the triage aid, not
+      the watch-through.
 - [ ] **Listened, every locale** — pronunciation (brand names!), pace, no synthesis artifacts;
       spot-check with an STT round-trip when unsure.
-- [ ] **Compose drift gate green** (±100 ms every scene) and no overrun waivers.
+- [ ] **Compose gates green** — drift (±100 ms every scene), the automatic A/V verification
+      (duration + speech coverage; never ship on `--no-verify`), and no overrun waivers.
 - [ ] **Captions open correctly** on the rendered docs page in each locale; timing follows the voice.
 - [ ] **`bun run --filter @tale/docs test` green** — the videos contract plus the docs suite.
 - [ ] **Shared org left as seeded** — cleanup ran; `docs:screenshots --skip-seed --only chat-thread-reply` still captures pixel-equivalent.

--- a/.claude/skills/produce-video/STORYBOARD.md
+++ b/.claude/skills/produce-video/STORYBOARD.md
@@ -59,10 +59,14 @@ scene. End the episode by naming what the next one covers — the series is a se
 
 ## Adding an episode, in order
 
-1. Storyboard on paper: scenes, surfaces, the one wow moment, where the AI-literacy beat lands.
-2. Write `episode.ts` narration (en first, then de/fr natively) + any new mock replies
+1. Scaffold the pair: `bun run gen` → `video-episode` (spec + choreography skeleton with the
+   series voices and the warmup contract).
+2. Storyboard on paper: scenes, surfaces, the one wow moment, where the AI-literacy beat lands.
+3. Write `episode.ts` narration (en first, then de/fr natively) + any new mock replies
    (`lib/mocks/overrides/docs-replies.ts`) and demo-content the surfaces need (seeder, not takes).
-3. `--stage tts` once per locale; listen to two or three scenes before recording anything.
-4. Write `scenes.ts`; rehearse the risky interactions standalone before a full take.
-5. Record + compose per locale; run the SKILL.md ship checklist; embed on the docs pages
+   `--stage check` and `--stage plan` are instant — run them as you go.
+4. Write `scenes.ts`; rehearse the whole take free with `--mock-tts` (silence narration, draft
+   compose, review sheet) until the choreography fits every budget.
+5. `--stage tts` once per locale; listen to two or three scenes before recording anything.
+6. Record + compose per locale; run the SKILL.md ship checklist; embed on the docs pages
    (episode page + index row + any overview embeds) in all three locales.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Safety and architecture invariants — they hold even where no linter covers the
 - **Accessibility is WCAG 2.1 AA** — real HTML, keyboard reachable, visible focus, labelled controls, AA contrast.
 - **Commits** follow `.commitlintrc.json` (atomic, imperative, ≤72-char header); branch off `main`, never commit to it. **Never add `Co-Authored-By` or "Generated with Claude Code" / any attribution line** — `.husky/commit-msg` strips Cursor/Claude attribution trailers before commitlint runs.
 - **A change is rarely one file** — sweep the concept's blast radius (`search-codebase`): a user-visible string → every locale (+ docs); a new UI element → label + a11y + docs + tests; an env var / flag / API field → docs + `.env.example` + the READMEs. The guards catch the big ones — run them.
-- **Scaffold a new part** (service / package / tool / skill / migration) from a template (`bun run gen …`), never hand-rolled — so it carries the standard configs and test layout.
+- **Scaffold a new part** (service / package / tool / skill / migration / video episode) from a template (`bun run gen …`), never hand-rolled — so it carries the standard configs and test layout.
 - **Instructions are docs too** — change a path, command, or pattern a skill or this file documents, and update it in the same change (`bun run skills:check` guards the skill set).
 
 ## Skills and guides index

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -79,8 +79,10 @@ export default {
         'tests/docs-screenshots/capture.ts',
         // Same shape: the docs video producer behind the root `docs:videos`
         // script (source of every services/docs/public/videos/ asset). Episode
-        // choreographies load via a dynamic template import the graph can't see.
+        // specs and choreographies are auto-discovered via dynamic imports
+        // (lib/episodes.ts) the graph can't see.
         'tests/docs-videos/produce.ts',
+        'tests/docs-videos/episodes/*/episode.ts',
         'tests/docs-videos/episodes/*/scenes.ts',
         // Hand-run locale-org bootstrap (`bun tests/docs-videos/seed-locale-orgs.ts`).
         'tests/docs-videos/seed-locale-orgs.ts',

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gen:tool": "bun run gen tool",
     "gen:skill": "bun run gen skill",
     "gen:migration": "bun run gen migration",
+    "gen:episode": "bun run gen video-episode",
     "generate:icons": "bun scripts/generate-integration-icons.ts",
     "prepare": "bunx husky"
   },

--- a/plopfile.ts
+++ b/plopfile.ts
@@ -5,6 +5,7 @@ import { registerPackage } from './tools/plop/generators/package';
 import { registerService } from './tools/plop/generators/service';
 import { registerSkill } from './tools/plop/generators/skill';
 import { registerTool } from './tools/plop/generators/tool';
+import { registerVideoEpisode } from './tools/plop/generators/video-episode';
 import { registerHelpers } from './tools/plop/helpers';
 
 export default function (plop: NodePlopAPI): void {
@@ -14,4 +15,5 @@ export default function (plop: NodePlopAPI): void {
   registerTool(plop);
   registerSkill(plop);
   registerMigration(plop);
+  registerVideoEpisode(plop);
 }

--- a/services/platform/lib/mocks/overrides/docs-replies.test.ts
+++ b/services/platform/lib/mocks/overrides/docs-replies.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { DOCS_REPLIES, matchDocsReply } from './docs-replies';
+
+describe('DOCS_REPLIES invariants', () => {
+  it('match clauses are lowercase — matching lowercases the message, so a cased clause can never fire', () => {
+    const cased = DOCS_REPLIES.filter(
+      (reply) => reply.match !== reply.match.toLowerCase(),
+    ).map((reply) => reply.match);
+    expect(cased).toEqual([]);
+  });
+
+  it('match clauses are unique — a duplicate silently shadows its successor', () => {
+    const seen = new Set<string>();
+    const duplicates = DOCS_REPLIES.map((reply) => reply.match).filter(
+      (match) => (seen.has(match) ? true : (seen.add(match), false)),
+    );
+    expect(duplicates).toEqual([]);
+  });
+
+  it('pausing tool turns carry intro content — an empty generation trips the model-fallback banner (#2767)', () => {
+    const offenders = DOCS_REPLIES.filter(
+      (reply) =>
+        reply.tool?.name === 'request_human_input' && !reply.toolIntro?.trim(),
+    ).map((reply) => reply.match);
+    expect(offenders).toEqual([]);
+  });
+
+  it('matches case-insensitively and rides the tool along', () => {
+    const matched = matchDocsReply(
+      'What did customers say about ONBOARDING LAST QUARTER?',
+    );
+    expect(matched?.reply).toBeTruthy();
+  });
+});

--- a/services/platform/tests/docs-videos/README.md
+++ b/services/platform/tests/docs-videos/README.md
@@ -4,7 +4,29 @@ Every video under `services/docs/public/videos/` is produced by this pipeline fr
 episode spec — no hand-recorded video ever ships. The production discipline lives in the
 [`produce-video`](../../../../.agents/skills/produce-video/SKILL.md) skill; the docs-side gate in
 `services/docs/tests/videos.test.ts`; the shared demo workspace in
-[`../docs-screenshots/`](../docs-screenshots/README.md).
+[`../docs-screenshots/`](../docs-screenshots/README.md). `bun run docs:videos -- --help` is the
+authoritative flag reference.
+
+## The authoring loop — cheap first, expensive last
+
+Each step catches what the next one would waste time (or money) discovering:
+
+```bash
+bun run gen                                                # scaffold: pick "video-episode"
+# … storyboard + narration (STORYBOARD.md in the skill) …
+bun run docs:videos -- --episode <id> --stage check        # instant: spec ↔ scenes ↔ mock replies
+bun run docs:videos -- --episode <id> --stage plan         # instant: timeline table from estimates
+bun run docs:videos -- --episode <id> --mock-tts           # free rehearsal: silence-narrated take,
+                                                           #   auto-composed as a draft in .state/out/
+bun run docs:videos -- --episode <id> --locale all --stage tts      # bills characters (cache-first)
+bun run docs:videos -- --episode <id> --locale all                  # the real takes
+open services/platform/tests/docs-videos/.state/review/<id>.<locale>/index.html   # per-scene evidence
+```
+
+`--stage check` also runs automatically before every take, `--doctor`'s preflight before every
+record, and an A/V verification (duration + per-scene speech coverage) after every compose — the
+classic failure modes (drifted scene ids, unpaired hero prompts, expired auth, a silent track) fail
+in seconds with the fix command attached, not minutes into a take.
 
 ## Runbook — clean checkout → one episode in three locales
 
@@ -28,26 +50,31 @@ bunx playwright install chromium
 bun run docs:screenshots                                        # en org (idempotent)
 bun services/platform/tests/docs-videos/seed-locale-orgs.ts     # de+fr orgs (idempotent)
 
-# 4. Produce (from the REPO ROOT — stages are separable)
-bun run docs:videos -- --episode ep1-welcome --locale en,de,fr             # all stages
-bun run docs:videos -- --episode ep1-welcome --locale de --stage tts       # narration only (bills characters — cache-first)
-bun run docs:videos -- --episode ep1-welcome --locale de --stage record    # needs the stack
-bun run docs:videos -- --episode ep1-welcome --locale de --stage compose   # ffmpeg only
-bun run docs:videos -- --list                                              # episodes + narration readiness
-bun run docs:videos -- --audition                                          # voice candidates → .state/audition/
+# 4. Verify the environment, then produce (from the REPO ROOT)
+bun run docs:videos -- --doctor                                 # every prerequisite, with fixes
+bun run docs:videos -- --episode ep1-welcome --locale all       # tts → record → compose
 
-# 5. Verify
+# 5. Verify the result
 bun run --filter @tale/docs test              # videos contract + the docs suite
 bun run --filter @tale/docs dev               # watch the page on :3002
-bun run docs:videos -- --episode spike-sync --locale en   # pipeline self-test (diagnostic, no docs output)
+bun run docs:videos -- --episode spike-sync --mock-tts   # pipeline self-test — zero prerequisites
 ```
+
+Stages are separable (`--stage tts|record|compose`): TTS bills per character (cache-first),
+recording needs the running stack, compose needs only ffmpeg. Batch runs take lists and `all`
+(`--episode all --locale all`) and finish with a per-unit summary instead of dying on the first
+failure.
 
 ## How it works
 
 1. **TTS** (`lib/tts.ts`) — per scene and locale, ElevenLabs `eleven_v3` (fallback
-   `eleven_multilingual_v2`) synthesizes the narration from `episodes/<id>/episode.ts`. Cache-first
-   under `.state/tts-cache/` keyed by content hash: an unchanged scene never re-bills. Output: the
-   audio plan `.state/tts/<episode>.<locale>.json` (mp3 paths + measured durations).
+   `eleven_multilingual_v2`) synthesizes the narration from `episodes/<id>/episode.ts`; whole-take
+   locales get ONE generation sliced by character timestamps (consistent delivery). Cache-first
+   under `.state/tts-cache/` keyed by content hash: an unchanged scene never re-bills (the key
+   shape is pinned by `lib/tts-cache-key.test.ts` — a drifted key would re-bill the back catalog).
+   `--mock-tts` (`lib/tts-mock.ts`) swaps in estimated-length silence for free rehearsal; such
+   plans are marked `estimated` and can only compose as drafts. Output: the audio plan
+   `.state/tts/<episode>.<locale>.json` (mp3 paths + durations).
 2. **Record** (`lib/recorder.ts`) — the timeline is PLANNED from the audio durations
    (`lib/timeline.ts`); the runner paces scene starts to that plan and a CDP screencast captures
    every compositor frame with its timestamp into `.state/frames/`. The injected overlay
@@ -56,26 +83,44 @@ bun run docs:videos -- --episode spike-sync --locale en   # pipeline self-test (
    The take is ONE SPA session: the app boots and every surface warms BEFORE the screencast
    (`warmup` in scenes.ts, ending settled on the opening route), the title/outro cards are in-app
    overlays (`lib/cards.ts`), and deep route changes go through `spaNavigate` (pushState +
-   popstate) — a full page load re-boots the app on camera and no warm-up can hide it.
+   popstate) — a full page load re-boots the app on camera and no warm-up can hide it. Anything a
+   scene creates on camera registers on `ctx.cleanup` (`lib/cleanup.ts`); the recorder sweeps it
+   off camera in a finally, even when the take aborts.
 3. **Compose** (`lib/compose.ts`) — the drift gate (every actual scene start within ±100 ms of
    plan), then ffmpeg: frames → 30 fps H.264 1080p with fade bookends, narration placed at the
    planned offsets, loudness-normalized; WebVTT captions from the scripts (`lib/vtt.ts`); a poster
    from the title card; `public/videos/manifest.json` upserted diff-quiet (`lib/video-manifest.ts`).
+   After the encode, `lib/verify.ts` asserts the composed duration matches the plan and that
+   audible speech covers every narrated window (silencedetect) — a silent track or global offset
+   fails loudly (`--no-verify` opts out). Every compose writes a per-scene thumbnail review sheet
+   to `.state/review/<episode>.<locale>/index.html`. `--draft` encodes 720p/veryfast into
+   `.state/out/` and skips poster + manifest — the fast look-adjust loop.
+
+Cross-cutting: `lib/validate.ts` is the static gate (`--stage check` + the always-on vitest test
+`lib/episodes.test.ts`); `lib/doctor.ts` the environment preflight; `lib/episodes.ts` discovers
+episodes from the filesystem (`episodes/<id>/episode.ts`, id = directory name — nothing to
+register).
 
 ## The shared-workspace contract
 
 Recording runs against the SAME "Northlight Labs" org the screenshot pipeline seeds — never a
-divergent second workspace. A take is **additive-only**: the one chat thread the wow scene creates
-is deleted off camera afterwards, even when the take aborts (`cleanupWowThread`). Never seed from
-here; content changes belong in `../docs-screenshots/demo-content.ts` (+ the paired mock replies in
-`lib/mocks/overrides/docs-replies.ts` — the video prompts pair with `heroPromptByLocale`).
+divergent second workspace. A take is **additive-only**: whatever a scene creates on camera it
+registers on `ctx.cleanup` (thread, knowledge entry, agent, task), and the recorder deletes it off
+camera afterwards, even when the take aborts. Never seed from here; content changes belong in
+`../docs-screenshots/demo-content.ts` (+ the paired mock replies in
+`lib/mocks/overrides/docs-replies.ts` — the video prompts pair with `heroPromptByLocale`, enforced
+by `--stage check`).
 
 ## Gotchas
 
 - **Ports :3000/:4141 must be owned by the Mode-A stack** (same trap as docs-screenshots), and the
   runner requires the docs-screenshots `.state/` bootstrap — it never mints its own org.
+  `--doctor` verifies both.
+- **`docs:videos` is a ROOT script** — from inside a workspace directory bun reports
+  "Script not found"; run it from the repo root.
 - **The gateway process env carries the stream pace** — restarting it drops
-  `TALE_MOCK_STREAM_PACE_MS`; set it again or streamed answers race past the camera.
+  `TALE_MOCK_STREAM_PACE_MS`; set it again or streamed answers race past the camera (the doctor
+  reminds you; it cannot see another process's env).
 - **Locale-dependent display names are data, not chrome** — the builtin assistant is `Assistent` in
   the German UI (`ASSISTANT_NAME` in `episodes/ep1-welcome/scenes.ts`); UI chrome resolves through
   `localeT`, seeded content literals (file names, task titles) are locale-invariant.
@@ -95,9 +140,13 @@ here; content changes belong in `../docs-screenshots/demo-content.ts` (+ the pai
   content a scene shows needs all three language versions AND, for anything triage-triggered, its
   `DOCS_TRIAGE_SCORES` pairing. UI chrome still localizes itself — only DATA needs the locale orgs.
 - **Expired auth = re-run `bun run docs:screenshots`** (its bootstrap signs back in and rewrites
-  `.state/` correctly). NEVER hand-write org.json — an emptied threads/projects map makes the next
+  `.state/` correctly; the doctor's "demo auth" check catches the stale state before a take films
+  the login page). NEVER hand-write org.json — an emptied threads/projects map makes the next
   seed run re-create content it cannot see.
 - **"Sounded fine in analysis" ≠ plays in a browser** — ffmpeg decodes what real players refuse
   (the 96 kHz-AAC-from-loudnorm bug played as silence everywhere but in ffmpeg). The compose gate
   asserts ≤48 kHz; for an end-to-end check, play the docs page and read
   `video.webkitAudioDecodedByteCount` — zero after playback means no decodable audio.
+- **Estimates are rehearsal-only** — `--mock-tts`/`--stage plan` character-count durations run
+  ~10–15 % short of real ElevenLabs delivery; real narration re-plans the timeline and every cue
+  lands differently. That is why estimated plans refuse to compose outside `.state/`.

--- a/services/platform/tests/docs-videos/episodes/ep1-welcome/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep1-welcome/scenes.ts
@@ -168,7 +168,7 @@ export const SCENES: readonly SceneChoreography[] = [
       await cursor.click(sendButton(rt));
       await page.waitForURL(THREAD_URL, { timeout: 20_000 });
       const threadId = THREAD_URL.exec(page.url())?.[1];
-      if (threadId) ctx.notes.set('wowThreadId', threadId);
+      if (threadId) ctx.cleanup.thread(threadId);
     },
   },
   {

--- a/services/platform/tests/docs-videos/episodes/ep10-developers/episode.ts
+++ b/services/platform/tests/docs-videos/episodes/ep10-developers/episode.ts
@@ -30,7 +30,6 @@ export const EP10_DEVELOPERS: EpisodeSpec = {
     de: 'rKiu7lQ4c5P3az3745s3',
     fr: 'QbsdzCokdlo98elkq4Pc',
   },
-  heroPromptByLocale: { en: 'unused', de: 'unused', fr: 'unused' },
   scenes: [
     {
       id: 'title',

--- a/services/platform/tests/docs-videos/episodes/ep2-chat/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep2-chat/scenes.ts
@@ -1,7 +1,7 @@
 /**
  * Episode 2 choreography — one surface (chat), four on-camera prompts, four
  * created threads. Every thread the take creates is registered under the
- * `cleanupThreadIds` note and deleted off camera by the recorder's cleanup,
+ * cleanup registry (`ctx.cleanup.thread`) and deleted off camera,
  * even when the take aborts. Same rules of the road as Episode 1: rail links
  * by href, UI chrome via the locale catalog, seeded content via
  * `videoContentFor`, readiness on state — `cue()` is the only clock.
@@ -52,19 +52,10 @@ function sendButton(rt: SceneRuntime) {
 
 const THREAD_URL = /\/chat\/([A-Za-z0-9]{16,})(?:[/?#]|$)/;
 
-/** Register a thread for the recorder's off-camera cleanup (multi-thread). */
-function registerThreadForCleanup(ctx: SceneContext, threadId: string): void {
-  const existing = ctx.notes.get('cleanupThreadIds');
-  ctx.notes.set(
-    'cleanupThreadIds',
-    existing ? `${existing},${threadId}` : threadId,
-  );
-}
-
-/** Capture the thread id from the current URL and register it. */
+/** Capture the thread id from the current URL and register its cleanup. */
 function registerCurrentThread(rt: SceneRuntime): void {
   const threadId = THREAD_URL.exec(rt.page.url())?.[1];
-  if (threadId) registerThreadForCleanup(rt.ctx, threadId);
+  if (threadId) rt.ctx.cleanup.thread(threadId);
 }
 
 /**
@@ -135,7 +126,7 @@ export async function warmup(
   await page.keyboard.press('Enter');
   await page.waitForURL(THREAD_URL, { timeout: 20_000 });
   const warmThread = THREAD_URL.exec(page.url())?.[1];
-  if (warmThread) registerThreadForCleanup(ctx, warmThread);
+  if (warmThread) ctx.cleanup.thread(warmThread);
   await page
     .getByText(CANVAS_BRIEF_HEADING[ctx.locale])
     .first()

--- a/services/platform/tests/docs-videos/episodes/ep2-chat/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep2-chat/scenes.ts
@@ -11,7 +11,6 @@ import { videoContentFor } from '../../lib/locale-content';
 import {
   spaNavigate,
   type SceneChoreography,
-  type SceneContext,
   type SceneRuntime,
 } from '../../lib/scene';
 import {

--- a/services/platform/tests/docs-videos/episodes/ep3-knowledge/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep3-knowledge/scenes.ts
@@ -1,8 +1,8 @@
 /**
  * Episode 3 choreography — the knowledge library, surface by surface. The
- * one on-camera mutation (the knowledge entry) is registered under the
- * `cleanupEntryTopics` note and deleted off camera by the recorder; the wow
- * thread rides the `cleanupThreadIds` contract from Episode 2. Knowledge
+ * one on-camera mutation (the knowledge entry) is registered on the
+ * cleanup registry and deleted off camera by the recorder; the wow
+ * thread rides the same contract (`ctx.cleanup.thread`). Knowledge
  * sub-pages are deep links (`spaNavigate` under 'cut' chapter veils); the
  * documents and agents hops are real rail clicks.
  */
@@ -41,14 +41,6 @@ function sendButton(rt: SceneRuntime) {
 }
 
 const THREAD_URL = /\/chat\/([A-Za-z0-9]{16,})(?:[/?#]|$)/;
-
-function registerThreadForCleanup(ctx: SceneContext, threadId: string): void {
-  const existing = ctx.notes.get('cleanupThreadIds');
-  ctx.notes.set(
-    'cleanupThreadIds',
-    existing ? `${existing},${threadId}` : threadId,
-  );
-}
 
 /** Every route the take renders, warmed before the screencast. */
 export async function warmup(
@@ -196,13 +188,7 @@ export const SCENES: readonly SceneChoreography[] = [
         dialog.getByRole('button', { name: rt.t('common.actions.save') }),
       );
       await dialog.waitFor({ state: 'hidden', timeout: 15_000 });
-      const existing = ctx.notes.get('cleanupEntryTopics');
-      ctx.notes.set(
-        'cleanupEntryTopics',
-        existing
-          ? `${existing},${ENTRY_TOPIC[ctx.locale]}`
-          : ENTRY_TOPIC[ctx.locale],
-      );
+      ctx.cleanup.knowledgeEntry(ENTRY_TOPIC[ctx.locale]);
       await page
         .getByText(ENTRY_TOPIC[ctx.locale])
         .first()
@@ -306,7 +292,7 @@ export const SCENES: readonly SceneChoreography[] = [
       await cursor.click(sendButton(rt));
       await page.waitForURL(THREAD_URL, { timeout: 20_000 });
       const threadId = THREAD_URL.exec(page.url())?.[1];
-      if (threadId) registerThreadForCleanup(ctx, threadId);
+      if (threadId) ctx.cleanup.thread(threadId);
       await sendButton(rt).waitFor({ state: 'visible', timeout: 30_000 });
       await cue(11.5);
       const source = page

--- a/services/platform/tests/docs-videos/episodes/ep3-knowledge/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep3-knowledge/scenes.ts
@@ -11,7 +11,6 @@ import { videoContentFor } from '../../lib/locale-content';
 import {
   spaNavigate,
   type SceneChoreography,
-  type SceneContext,
   type SceneRuntime,
 } from '../../lib/scene';
 import { ENTRY_CONTENT, ENTRY_TOPIC } from './episode';

--- a/services/platform/tests/docs-videos/episodes/ep4-agent/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep4-agent/scenes.ts
@@ -2,8 +2,8 @@
  * Episode 4 choreography — an agent built on camera. The warmup creates and
  * deletes a throwaway agent so every editor chunk is compiled BEFORE the
  * screencast (the real creation must land on a warm editor). The on-camera
- * agent + its test thread are removed off camera via the `cleanupAgentNames`
- * and `cleanupThreadIds` notes — registered the moment they exist, so an
+ * agent + its test thread are removed off camera via the cleanup registry
+ * (`ctx.cleanup.agent` / `.thread`) — registered the moment they exist, so an
  * aborted take still cleans up.
  */
 
@@ -32,11 +32,6 @@ function sendButton(rt: SceneRuntime) {
 }
 
 const THREAD_URL = /\/chat\/([A-Za-z0-9]{16,})(?:[/?#]|$)/;
-
-function registerNote(ctx: SceneContext, key: string, value: string): void {
-  const existing = ctx.notes.get(key);
-  ctx.notes.set(key, existing ? `${existing},${value}` : value);
-}
 
 /** The agent editor's section navigation, scoped by its aria name. */
 function editorNav(rt: SceneRuntime) {
@@ -193,7 +188,7 @@ export const SCENES: readonly SceneChoreography[] = [
       );
       await page.keyboard.type(AGENT_DISPLAY_NAME[ctx.locale], { delay: 48 });
       // Registered the moment it will exist — an aborted take still cleans.
-      registerNote(ctx, 'cleanupAgentNames', AGENT_DISPLAY_NAME[ctx.locale]);
+      ctx.cleanup.agent(AGENT_DISPLAY_NAME[ctx.locale]);
       await cue(10.4);
       await cursor.click(
         page.getByRole('button', {
@@ -334,7 +329,7 @@ export const SCENES: readonly SceneChoreography[] = [
       await cursor.click(sendButton(rt));
       await page.waitForURL(THREAD_URL, { timeout: 20_000 });
       const threadId = THREAD_URL.exec(page.url())?.[1];
-      if (threadId) registerNote(ctx, 'cleanupThreadIds', threadId);
+      if (threadId) ctx.cleanup.thread(threadId);
       await sendButton(rt).waitFor({ state: 'visible', timeout: 30_000 });
     },
   },

--- a/services/platform/tests/docs-videos/episodes/ep4-agent/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep4-agent/scenes.ts
@@ -7,11 +7,7 @@
  * aborted take still cleans up.
  */
 
-import {
-  type SceneChoreography,
-  type SceneContext,
-  type SceneRuntime,
-} from '../../lib/scene';
+import { type SceneChoreography, type SceneRuntime } from '../../lib/scene';
 import { AGENT_DISPLAY_NAME, AGENT_INSTRUCTIONS, AGENT_SLUG } from './episode';
 
 function rail(rt: SceneRuntime, path: string) {

--- a/services/platform/tests/docs-videos/episodes/ep5-automations/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep5-automations/scenes.ts
@@ -8,7 +8,6 @@
 import {
   spaNavigate,
   type SceneChoreography,
-  type SceneContext,
   type SceneRuntime,
 } from '../../lib/scene';
 import { APPROVAL_FIELD_TEXT } from './episode';

--- a/services/platform/tests/docs-videos/episodes/ep5-automations/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep5-automations/scenes.ts
@@ -42,14 +42,6 @@ function sendButton(rt: SceneRuntime) {
 
 const THREAD_URL = /\/chat\/([A-Za-z0-9]{16,})(?:[/?#]|$)/;
 
-function registerThreadForCleanup(ctx: SceneContext, threadId: string): void {
-  const existing = ctx.notes.get('cleanupThreadIds');
-  ctx.notes.set(
-    'cleanupThreadIds',
-    existing ? `${existing},${threadId}` : threadId,
-  );
-}
-
 export async function warmup(
   page: import('@playwright/test').Page,
   ctx: import('../../lib/scene').SceneContext,
@@ -197,7 +189,7 @@ export const SCENES: readonly SceneChoreography[] = [
       await cursor.click(sendButton(rt));
       await page.waitForURL(THREAD_URL, { timeout: 20_000 });
       const threadId = THREAD_URL.exec(page.url())?.[1];
-      if (threadId) registerThreadForCleanup(ctx, threadId);
+      if (threadId) ctx.cleanup.thread(threadId);
       // The pending card carries the draft; wait on its field label.
       const field = page
         .getByRole('textbox', { name: APPROVAL_FIELD_LABEL[ctx.locale] })

--- a/services/platform/tests/docs-videos/episodes/ep6-projects/episode.ts
+++ b/services/platform/tests/docs-videos/episodes/ep6-projects/episode.ts
@@ -45,11 +45,6 @@ export const EP6_PROJECTS: EpisodeSpec = {
     fr: 'QbsdzCokdlo98elkq4Pc',
   },
   /** Unused on camera (no chat scene); kept for the spec contract. */
-  heroPromptByLocale: {
-    en: 'Draft the launch announcement post',
-    de: 'Launch-Ankündigung entwerfen',
-    fr: 'Rédiger l’annonce de lancement',
-  },
   scenes: [
     {
       id: 'title',

--- a/services/platform/tests/docs-videos/episodes/ep6-projects/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep6-projects/scenes.ts
@@ -2,7 +2,7 @@
  * Episode 6 choreography — the relaunch project deep dive with one live
  * centerpiece: a task created on camera, scored by the triage automation,
  * and visibly taken by the agent. The task is archived off camera
- * (`cleanupTaskTitles` + `cleanupTaskBoardUrl`); nothing else mutates.
+ * (`ctx.cleanup.task`); nothing else mutates.
  */
 
 import { videoContentFor } from '../../lib/locale-content';
@@ -171,9 +171,8 @@ export const SCENES: readonly SceneChoreography[] = [
       });
       await createButton.waitFor({ state: 'visible', timeout: 30_000 });
       // Register cleanup BEFORE creating — an abort still archives.
-      ctx.notes.set('cleanupTaskTitles', CAMERA_TASK_TITLE[ctx.locale]);
-      ctx.notes.set(
-        'cleanupTaskBoardUrl',
+      ctx.cleanup.task(
+        CAMERA_TASK_TITLE[ctx.locale],
         `/dashboard/${ctx.orgId}/projects/${relaunchId(ctx)}/tasks/board`,
       );
       await cue(2.6);

--- a/services/platform/tests/docs-videos/episodes/ep7-integrations/episode.ts
+++ b/services/platform/tests/docs-videos/episodes/ep7-integrations/episode.ts
@@ -34,11 +34,6 @@ export const EP7_INTEGRATIONS: EpisodeSpec = {
     fr: 'QbsdzCokdlo98elkq4Pc',
   },
   /** No live chat ask in this episode. */
-  heroPromptByLocale: {
-    en: 'unused',
-    de: 'unused',
-    fr: 'unused',
-  },
   scenes: [
     {
       id: 'title',

--- a/services/platform/tests/docs-videos/episodes/ep8-people/episode.ts
+++ b/services/platform/tests/docs-videos/episodes/ep8-people/episode.ts
@@ -31,7 +31,6 @@ export const EP8_PEOPLE: EpisodeSpec = {
     de: 'rKiu7lQ4c5P3az3745s3',
     fr: 'QbsdzCokdlo98elkq4Pc',
   },
-  heroPromptByLocale: { en: 'unused', de: 'unused', fr: 'unused' },
   scenes: [
     {
       id: 'title',

--- a/services/platform/tests/docs-videos/episodes/ep9-governance/episode.ts
+++ b/services/platform/tests/docs-videos/episodes/ep9-governance/episode.ts
@@ -29,7 +29,6 @@ export const EP9_GOVERNANCE: EpisodeSpec = {
     de: 'rKiu7lQ4c5P3az3745s3',
     fr: 'QbsdzCokdlo98elkq4Pc',
   },
-  heroPromptByLocale: { en: 'unused', de: 'unused', fr: 'unused' },
   scenes: [
     {
       id: 'title',

--- a/services/platform/tests/docs-videos/episodes/spike-sync/episode.ts
+++ b/services/platform/tests/docs-videos/episodes/spike-sync/episode.ts
@@ -35,7 +35,6 @@ export const SPIKE_SYNC: EpisodeSpec = {
   },
   needsKnowledgeDb: false,
   voices: EP1_WELCOME.voices,
-  heroPromptByLocale: { en: '', de: '', fr: '' },
   scenes: [
     {
       id: 'title',

--- a/services/platform/tests/docs-videos/lib/audio-plan.ts
+++ b/services/platform/tests/docs-videos/lib/audio-plan.ts
@@ -20,6 +20,12 @@ export interface AudioPlan {
   readonly locale: Locale;
   readonly voiceId: string;
   readonly model: string;
+  /**
+   * True when the plan carries `--mock-tts` rehearsal silence with ESTIMATED
+   * durations. Compose refuses to ship an estimated plan into the docs tree
+   * — real narration re-plans the timeline, so every cue lands differently.
+   */
+  readonly estimated?: boolean;
   readonly scenes: readonly AudioPlanScene[];
 }
 

--- a/services/platform/tests/docs-videos/lib/cards.ts
+++ b/services/platform/tests/docs-videos/lib/cards.ts
@@ -14,10 +14,10 @@ import path from 'node:path';
 
 import type { Page } from '@playwright/test';
 
-const HERE = path.dirname(new URL(import.meta.url).pathname);
-const REPO_ROOT = path.resolve(HERE, '../../../../..');
+import { DOCS_PUBLIC_DIR } from './paths';
+
 const LOGO_SVG = readFileSync(
-  path.join(REPO_ROOT, 'services/docs/public/images/logo-text-white.svg'),
+  path.join(DOCS_PUBLIC_DIR, 'images/logo-text-white.svg'),
   'utf8',
 );
 

--- a/services/platform/tests/docs-videos/lib/cleanup.ts
+++ b/services/platform/tests/docs-videos/lib/cleanup.ts
@@ -1,0 +1,278 @@
+/**
+ * The take's additive-only contract, as an API. Anything a scene creates ON
+ * CAMERA is registered here the moment it exists — so even an aborted take
+ * leaves the demo org exactly as seeded (a leftover wow thread once ambushed
+ * the next take's picker locator). The recorder runs `runCleanup` in a
+ * finally block, off camera, in its own en-locale context (the e2e chat
+ * helpers resolve labels from the en catalog).
+ *
+ * Registered values are per-locale DATA literals (thread ids, entry topics,
+ * agent display names, task titles) — the en-locale cleanup context finds
+ * them regardless of the take locale. Every deletion is best-effort with a
+ * warning: a cleanup failure must never mask the take's own error.
+ */
+
+import path from 'node:path';
+
+import type { Browser, Page } from '@playwright/test';
+
+import { BASE_URL } from '../../e2e/helpers/env';
+import { SCREENSHOTS_STATE_DIR } from './paths';
+
+/** What one take may leave behind; scenes register, the recorder sweeps. */
+export class CleanupRegistry {
+  private readonly threadIds = new Set<string>();
+  private readonly entryTopics = new Set<string>();
+  private readonly agentNames = new Set<string>();
+  private readonly taskTitles = new Set<string>();
+  private taskBoardUrl = '';
+
+  /** A chat thread created on camera, by id (from the thread URL). */
+  thread(id: string): void {
+    if (id.trim()) this.threadIds.add(id.trim());
+  }
+
+  /** A knowledge entry created on camera, by its topic literal. */
+  knowledgeEntry(topic: string): void {
+    if (topic.trim()) this.entryTopics.add(topic.trim());
+  }
+
+  /** An agent created on camera, by display name (shown in the list row). */
+  agent(name: string): void {
+    if (name.trim()) this.agentNames.add(name.trim());
+  }
+
+  /** A task created on camera — archived on the board it was created on. */
+  task(title: string, boardUrl: string): void {
+    if (!title.trim()) return;
+    this.taskTitles.add(title.trim());
+    if (boardUrl.trim()) this.taskBoardUrl = boardUrl.trim();
+  }
+
+  get isEmpty(): boolean {
+    return (
+      this.threadIds.size === 0 &&
+      this.entryTopics.size === 0 &&
+      this.agentNames.size === 0 &&
+      this.taskTitles.size === 0
+    );
+  }
+
+  snapshot(): {
+    readonly threadIds: readonly string[];
+    readonly entryTopics: readonly string[];
+    readonly agentNames: readonly string[];
+    readonly taskTitles: readonly string[];
+    readonly taskBoardUrl: string;
+  } {
+    return {
+      threadIds: [...this.threadIds],
+      entryTopics: [...this.entryTopics],
+      agentNames: [...this.agentNames],
+      taskTitles: [...this.taskTitles],
+      taskBoardUrl: this.taskBoardUrl,
+    };
+  }
+}
+
+async function deleteThreads(
+  page: Page,
+  orgId: string,
+  threadIds: readonly string[],
+): Promise<void> {
+  if (threadIds.length === 0) return;
+  await page.goto(`/dashboard/${orgId}/chat`, {
+    waitUntil: 'domcontentloaded',
+  });
+  const { deleteThreadById, ensureHistorySidebarOpen } =
+    await import('../../e2e/helpers/chat');
+  // Thread rows render only inside the history drawer — open it before any
+  // existence check, or every row reads as "gone".
+  await ensureHistorySidebarOpen(page);
+  for (const id of threadIds) {
+    // The app deletes some registered threads itself (an Arena branch on
+    // exit) — skip rows that are already gone instead of timing out.
+    // `isVisible()` never waits — use a bounded waitFor so a still-loading
+    // list cannot read as "already gone".
+    const row = page.locator(`[data-thread-id="${id}"]`).first();
+    const present = await row
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!present) {
+      console.log(`  · thread ${id} already gone`);
+      continue;
+    }
+    try {
+      await deleteThreadById(page, id);
+      console.log(`  ✓ cleaned up thread ${id}`);
+    } catch (error) {
+      console.warn(
+        `  ! could not delete thread ${id} — remove it by hand:`,
+        error,
+      );
+    }
+  }
+}
+
+async function deleteKnowledgeEntries(
+  page: Page,
+  orgId: string,
+  topics: readonly string[],
+): Promise<void> {
+  for (const topic of topics) {
+    try {
+      await page.goto(`/dashboard/${orgId}/knowledge-entries`, {
+        waitUntil: 'domcontentloaded',
+      });
+      // Wait for the list to resolve before judging the row's absence.
+      await page
+        .getByRole('button', { name: 'Add entry' })
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      const row = page.getByRole('row').filter({ hasText: topic }).first();
+      const present = await row
+        .waitFor({ state: 'visible', timeout: 8_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!present) {
+        console.log(`  · entry "${topic}" already gone`);
+        continue;
+      }
+      // Row menu → Delete → confirm (the dialog's button shares the label).
+      await row.getByRole('button', { name: 'Open menu' }).click();
+      await page.getByRole('menuitem', { name: 'Delete' }).click();
+      const dialog = page.getByRole('dialog', {
+        name: 'Delete knowledge entry',
+      });
+      await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await dialog.waitFor({ state: 'hidden', timeout: 15_000 });
+      console.log(`  ✓ cleaned up knowledge entry "${topic}"`);
+    } catch (error) {
+      console.warn(
+        `  ! could not delete entry "${topic}" — remove it by hand:`,
+        error,
+      );
+    }
+  }
+}
+
+async function deleteAgents(
+  page: Page,
+  orgId: string,
+  names: readonly string[],
+): Promise<void> {
+  for (const name of names) {
+    try {
+      await page.goto(`/dashboard/${orgId}/agents`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page
+        .getByRole('button', { name: 'Create agent' })
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      const row = page.getByRole('row').filter({ hasText: name }).first();
+      const present = await row
+        .waitFor({ state: 'visible', timeout: 8_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!present) {
+        console.log(`  · agent "${name}" already gone`);
+        continue;
+      }
+      await row.getByRole('button', { name: 'Open menu' }).click();
+      await page.getByRole('menuitem', { name: 'Delete', exact: true }).click();
+      await page
+        .getByRole('button', { name: 'Delete agent', exact: true })
+        .click();
+      await row.waitFor({ state: 'hidden', timeout: 15_000 });
+      console.log(`  ✓ cleaned up agent "${name}"`);
+    } catch (error) {
+      console.warn(
+        `  ! could not delete agent "${name}" — remove it by hand:`,
+        error,
+      );
+    }
+  }
+}
+
+async function archiveTasks(
+  page: Page,
+  titles: readonly string[],
+  boardUrl: string,
+): Promise<void> {
+  if (!boardUrl) return;
+  for (const title of titles) {
+    try {
+      await page.goto(boardUrl, { waitUntil: 'domcontentloaded' });
+      const card = page.getByText(title).first();
+      const present = await card
+        .waitFor({ state: 'visible', timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!present) {
+        console.log(`  · task "${title}" already gone`);
+        continue;
+      }
+      await card.click();
+      const dialog = page.getByRole('dialog').last();
+      await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+      // Archive lives directly in the dialog, or under its ⋯ menu.
+      const direct = dialog.getByRole('button', { name: 'Archive' }).first();
+      if (await direct.isVisible().catch(() => false)) {
+        await direct.click();
+      } else {
+        await dialog
+          .getByRole('button', { name: 'More actions' })
+          .first()
+          .click();
+        await page.getByRole('menuitem', { name: 'Archive' }).first().click();
+      }
+      const confirm = page.getByRole('dialog', { name: 'Archive task?' });
+      await confirm.waitFor({ state: 'visible', timeout: 10_000 });
+      await confirm.getByRole('button', { name: 'Archive' }).click();
+      await confirm.waitFor({ state: 'hidden', timeout: 10_000 });
+      console.log(`  ✓ archived task "${title}"`);
+    } catch (error) {
+      console.warn(
+        `  ! could not archive task "${title}" — archive it by hand:`,
+        error,
+      );
+    }
+  }
+}
+
+/**
+ * Sweep everything the registry recorded, in its own en-locale context.
+ * Called from the recorder's finally — even when the take aborted.
+ */
+export async function runCleanup(
+  browser: Browser,
+  orgId: string,
+  registry: CleanupRegistry,
+): Promise<void> {
+  if (registry.isEmpty) return;
+  const { threadIds, entryTopics, agentNames, taskTitles, taskBoardUrl } =
+    registry.snapshot();
+  const context = await browser.newContext({
+    baseURL: BASE_URL,
+    storageState: path.join(SCREENSHOTS_STATE_DIR, 'auth.json'),
+    viewport: { width: 1920, height: 1080 },
+    locale: 'en-US',
+    timezoneId: 'UTC',
+    serviceWorkers: 'block',
+  });
+  try {
+    await context.addInitScript(() => {
+      window.localStorage.setItem('user-locale', 'en');
+    });
+    const page = await context.newPage();
+    await deleteThreads(page, orgId, threadIds);
+    await deleteKnowledgeEntries(page, orgId, entryTopics);
+    await deleteAgents(page, orgId, agentNames);
+    await archiveTasks(page, taskTitles, taskBoardUrl);
+  } catch (error) {
+    console.warn('  ! cleanup context failed — check the org by hand:', error);
+  } finally {
+    await context.close();
+  }
+}

--- a/services/platform/tests/docs-videos/lib/cli.test.ts
+++ b/services/platform/tests/docs-videos/lib/cli.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { CliUsageError, parseCliArgs, STAGES } from './cli';
+
+describe('docs:videos CLI parsing', () => {
+  it('defaults to ep1-welcome / en / all stages with verification on', () => {
+    const options = parseCliArgs([]);
+    expect(options.episodes).toEqual(['ep1-welcome']);
+    expect(options.locales).toEqual(['en']);
+    expect(options.stage).toBe('all');
+    expect(options.verify).toBe(true);
+    expect(options.mockTts).toBe(false);
+    expect(options.draft).toBe(false);
+  });
+
+  it('parses comma lists and the all shorthands', () => {
+    const options = parseCliArgs([
+      '--episode',
+      'ep2-chat,ep3-knowledge',
+      '--locale',
+      'de,fr',
+    ]);
+    expect(options.episodes).toEqual(['ep2-chat', 'ep3-knowledge']);
+    expect(options.locales).toEqual(['de', 'fr']);
+    expect(parseCliArgs(['--episode', 'all']).episodes).toBe('all');
+    expect(parseCliArgs(['--locale', 'all']).locales).toEqual([
+      'en',
+      'de',
+      'fr',
+    ]);
+  });
+
+  it('accepts every documented stage and rejects unknown ones', () => {
+    for (const stage of STAGES) {
+      expect(parseCliArgs(['--stage', stage]).stage).toBe(stage);
+    }
+    expect(() => parseCliArgs(['--stage', 'render'])).toThrow(CliUsageError);
+  });
+
+  it('parses the mode flags', () => {
+    const options = parseCliArgs(['--mock-tts', '--draft', '--no-verify']);
+    expect(options.mockTts).toBe(true);
+    expect(options.draft).toBe(true);
+    expect(options.verify).toBe(false);
+    expect(parseCliArgs(['--doctor']).doctor).toBe(true);
+    expect(parseCliArgs(['-h']).help).toBe(true);
+  });
+
+  it('rejects unknown arguments, locales, and dangling values', () => {
+    expect(() => parseCliArgs(['--frames'])).toThrow(CliUsageError);
+    expect(() => parseCliArgs(['--locale', 'es'])).toThrow(/Unknown locale/);
+    expect(() => parseCliArgs(['--episode'])).toThrow(/needs a value/);
+  });
+});

--- a/services/platform/tests/docs-videos/lib/cli.ts
+++ b/services/platform/tests/docs-videos/lib/cli.ts
@@ -1,0 +1,173 @@
+/**
+ * Argument parsing for `bun run docs:videos` — pure and unit-tested, so the
+ * CLI contract can't silently drift. `produce.ts` owns dispatch; this module
+ * owns the vocabulary and the help text.
+ */
+
+import { LOCALES, type Locale } from './episode';
+
+export const STAGES = [
+  'check',
+  'plan',
+  'tts',
+  'record',
+  'compose',
+  'all',
+] as const;
+export type Stage = (typeof STAGES)[number];
+
+export interface CliOptions {
+  /** Episode ids, or 'all' (every shippable episode, diagnostics excluded). */
+  readonly episodes: readonly string[] | 'all';
+  readonly locales: readonly Locale[];
+  readonly stage: Stage;
+  readonly list: boolean;
+  readonly audition: boolean;
+  readonly help: boolean;
+  /** Rehearsal narration: estimated-length silence instead of ElevenLabs. */
+  readonly mockTts: boolean;
+  /** Fast low-res compose into `.state/out/` — never the docs tree. */
+  readonly draft: boolean;
+  /** Post-compose A/V verification (`--no-verify` opts out). */
+  readonly verify: boolean;
+  /** Environment preflight: stack, auth, orgs, tools — with fix commands. */
+  readonly doctor: boolean;
+}
+
+const DEFAULTS: CliOptions = {
+  episodes: ['ep1-welcome'],
+  locales: ['en'],
+  stage: 'all',
+  list: false,
+  audition: false,
+  help: false,
+  mockTts: false,
+  draft: false,
+  verify: true,
+  doctor: false,
+};
+
+export class CliUsageError extends Error {}
+
+function parseList(flag: string, raw: string | undefined): string[] {
+  const values = (raw ?? '')
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
+  if (values.length === 0) {
+    throw new CliUsageError(`${flag} needs a value (see --help)`);
+  }
+  return values;
+}
+
+export function parseCliArgs(argv: readonly string[]): CliOptions {
+  const options = { ...DEFAULTS } as {
+    -readonly [K in keyof CliOptions]: CliOptions[K];
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--list':
+        options.list = true;
+        break;
+      case '--audition':
+        options.audition = true;
+        break;
+      case '--doctor':
+        options.doctor = true;
+        break;
+      case '--mock-tts':
+        options.mockTts = true;
+        break;
+      case '--draft':
+        options.draft = true;
+        break;
+      case '--no-verify':
+        options.verify = false;
+        break;
+      case '--episode': {
+        const values = parseList('--episode', argv[++i]);
+        options.episodes = values.includes('all') ? 'all' : values;
+        break;
+      }
+      case '--locale': {
+        const values = parseList('--locale', argv[++i]);
+        if (values.includes('all')) {
+          options.locales = [...LOCALES];
+          break;
+        }
+        const invalid = values.filter(
+          (value) => !LOCALES.includes(value as Locale),
+        );
+        if (invalid.length > 0) {
+          throw new CliUsageError(
+            `Unknown locale(s): ${invalid.join(', ')} (valid: ${LOCALES.join(', ')}, all)`,
+          );
+        }
+        options.locales = values as Locale[];
+        break;
+      }
+      case '--stage': {
+        const value = argv[++i] ?? '';
+        if (!STAGES.includes(value as Stage)) {
+          throw new CliUsageError(
+            `Unknown stage "${value}" (valid: ${STAGES.join(', ')})`,
+          );
+        }
+        options.stage = value as Stage;
+        break;
+      }
+      default:
+        throw new CliUsageError(`Unknown argument: ${arg} (see --help)`);
+    }
+  }
+  return options;
+}
+
+export function helpText(): string {
+  return `docs:videos — produce the docs tutorial videos from episode specs
+
+Usage
+  bun run docs:videos -- [flags]
+
+Selection
+  --episode <ids|all>   Episode id(s), comma-separated, or "all" (every
+                        shippable episode; diagnostics stay opt-in by id).
+                        Default: ep1-welcome
+  --locale <l,l|all>    ${LOCALES.join(', ')} or "all". Default: en
+
+Stages (--stage <name>, default: all = tts → record → compose)
+  check     Static validation only: spec ↔ choreography parity, locale
+            consistency, hero-prompt ↔ mock-reply pairing. No side effects.
+  plan      Print the planned timeline (measured narration when TTS ran,
+            estimates otherwise). No side effects.
+  tts       Synthesize narration (ElevenLabs, cache-first — bills characters).
+  record    Drive the browser take (needs the Mode-A stack; see README).
+  compose   ffmpeg assembly + captions + poster + manifest + verification.
+
+Modes
+  --mock-tts    Estimated-length silent narration instead of ElevenLabs —
+                rehearse choreography with zero billing. Compose refuses to
+                ship an estimated plan into the docs tree (use --draft).
+  --draft       Compose fast + small into .state/out/ for review; skips the
+                manifest, poster and docs assets entirely.
+  --no-verify   Skip the post-compose A/V verification gate.
+
+Utilities
+  --list        Episodes, narration readiness, TTS/plan status.
+  --doctor      Preflight the environment (stack, auth, orgs, tools) and
+                print the exact fix command for anything broken.
+  --audition    Voice candidates → .state/audition/.
+  --help, -h    This text.
+
+Examples
+  bun run docs:videos -- --episode ep2-chat --locale all
+  bun run docs:videos -- --episode ep3-knowledge --locale de --stage tts
+  bun run docs:videos -- --episode spike-sync --mock-tts --draft
+  bun run docs:videos -- --episode all --locale all --stage check
+`;
+}

--- a/services/platform/tests/docs-videos/lib/compose.ts
+++ b/services/platform/tests/docs-videos/lib/compose.ts
@@ -43,7 +43,7 @@ const DRAFT_HEIGHT = 720;
 /** Ten minutes of encode budget — episodes are minutes long, 4K input. */
 const ENCODE_TIMEOUT_MS = 10 * 60 * 1000;
 
-export interface ComposeOptions {
+interface ComposeOptions {
   /**
    * Fast low-res encode into `.state/out/` for review — never touches the
    * docs tree, the poster, or the manifest.

--- a/services/platform/tests/docs-videos/lib/compose.ts
+++ b/services/platform/tests/docs-videos/lib/compose.ts
@@ -29,14 +29,29 @@ import {
 } from './ffmpeg';
 import { DOCS_PUBLIC_DIR } from './paths';
 import { framesDir, timelinePath, type RecordedTimeline } from './recorder';
+import { writeReviewSheet } from './review';
 import { driftReport, driftViolations, MAX_DRIFT_MS } from './timeline';
+import { verifyComposedEpisode } from './verify';
 import { upsertVideoManifest, type VideoManifestEntry } from './video-manifest';
 
 const FPS = 30;
 const OUT_WIDTH = 1920;
 const OUT_HEIGHT = 1080;
+/** Draft encodes trade fidelity for loop speed: 720p, fast preset. */
+const DRAFT_WIDTH = 1280;
+const DRAFT_HEIGHT = 720;
 /** Ten minutes of encode budget — episodes are minutes long, 4K input. */
 const ENCODE_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface ComposeOptions {
+  /**
+   * Fast low-res encode into `.state/out/` for review — never touches the
+   * docs tree, the poster, or the manifest.
+   */
+  readonly draft?: boolean;
+  /** Post-encode A/V verification (duration + speech coverage). Default on. */
+  readonly verify?: boolean;
+}
 
 interface FramesLog {
   readonly frames: readonly { file: string; tMs: number }[];
@@ -85,8 +100,19 @@ export async function runComposeStage(
   episode: EpisodeSpec,
   locale: Locale,
   stateDir: string,
+  options: ComposeOptions = {},
 ): Promise<void> {
+  const draft = options.draft ?? false;
   const audioPlan = readAudioPlan(stateDir, episode.id, locale);
+  // Estimated (mock) narration re-plans differently from the real audio —
+  // it must never reach the docs tree. Draft and diagnostic output stays
+  // in `.state/`, so rehearsal takes remain fully composable.
+  if (audioPlan.estimated && !draft && !episode.diagnostic) {
+    throw new Error(
+      `${episode.id}/${locale}: the audio plan is --mock-tts rehearsal silence — ` +
+        `compose with --draft, or run --stage tts (real narration) and re-record first.`,
+    );
+  }
   const tlPath = timelinePath(stateDir, episode.id, locale);
   if (!existsSync(tlPath)) {
     throw new Error(`No recording at ${tlPath} — run --stage record first.`);
@@ -97,19 +123,30 @@ export async function runComposeStage(
     readFileSync(path.join(dir, 'frames.json'), 'utf8'),
   ) as FramesLog;
 
-  console.log(`Compose ${episode.id}/${locale}: drift gate…`);
+  console.log(
+    `Compose ${episode.id}/${locale}${draft ? ' (draft)' : ''}: drift gate…`,
+  );
   assertDrift(recorded);
 
   const totalMs = recorded.planned.totalMs;
   const concatPath = path.join(dir, 'frames.txt');
   writeFileSync(concatPath, buildConcatList(framesLog.frames, totalMs));
 
-  const outDir = episode.diagnostic
-    ? path.join(stateDir, 'out')
-    : path.join(DOCS_PUBLIC_DIR, 'videos', locale, episode.section, episode.id);
+  const outDir =
+    draft || episode.diagnostic
+      ? path.join(stateDir, 'out')
+      : path.join(
+          DOCS_PUBLIC_DIR,
+          'videos',
+          locale,
+          episode.section,
+          episode.id,
+        );
   mkdirSync(outDir, { recursive: true });
-  const baseName = `${episode.id}.${locale}`;
+  const baseName = `${episode.id}.${locale}${draft ? '.draft' : ''}`;
   const mp4Path = path.join(outDir, `${baseName}.mp4`);
+  const outWidth = draft ? DRAFT_WIDTH : OUT_WIDTH;
+  const outHeight = draft ? DRAFT_HEIGHT : OUT_HEIGHT;
 
   // Narrated scenes → audio inputs placed at their planned offsets.
   const narrated = recorded.planned.scenes
@@ -128,7 +165,7 @@ export async function runComposeStage(
   // outro scene's tail carries the room the fade-out needs (episode spec).
   const fadeOutStartSec = Math.max(totalMs / 1000 - 1.5, 0);
   const filters: string[] = [
-    `[0:v]fps=${FPS},scale=${OUT_WIDTH}:${OUT_HEIGHT}:flags=lanczos,format=yuv420p,` +
+    `[0:v]fps=${FPS},scale=${outWidth}:${outHeight}:flags=lanczos,format=yuv420p,` +
       `fade=t=in:st=0:d=0.5,fade=t=out:st=${fadeOutStartSec.toFixed(3)}:d=1.5[v]`,
   ];
   const audioLabels: string[] = [];
@@ -167,9 +204,9 @@ export async function runComposeStage(
       '-c:v',
       'libx264',
       '-preset',
-      'medium',
+      draft ? 'veryfast' : 'medium',
       '-crf',
-      '20',
+      draft ? '30' : '20',
       '-maxrate',
       '3M',
       '-bufsize',
@@ -196,32 +233,37 @@ export async function runComposeStage(
   const vttPath = path.join(outDir, `${baseName}.vtt`);
   writeFileSync(vttPath, buildVtt(cues));
 
-  // Poster: the fully revealed title card (mid-title-scene frame).
-  const titleScene = recorded.planned.scenes[0];
-  const posterAtSec = titleScene
-    ? (titleScene.startMs + titleScene.budgetMs * 0.6) / 1000
-    : 1;
-  const posterPngPath = path.join(dir, 'poster.png');
-  await runFfmpeg(
-    ffmpegBin(),
-    [
-      '-y',
-      '-ss',
-      posterAtSec.toFixed(3),
-      '-i',
-      mp4Path,
-      '-frames:v',
-      '1',
-      posterPngPath,
-    ],
-    60_000,
-  );
-  const poster = await encodeWebp(
-    readFileSync(posterPngPath),
-    `${baseName} poster`,
-  );
-  const posterPath = path.join(outDir, `${baseName}.webp`);
-  writeFileSync(posterPath, poster.bytes);
+  // Poster: the fully revealed title card (mid-title-scene frame). Drafts
+  // skip it — nothing in the review loop needs a webp.
+  let poster: Awaited<ReturnType<typeof encodeWebp>> | null = null;
+  let posterPath = '';
+  if (!draft) {
+    const titleScene = recorded.planned.scenes[0];
+    const posterAtSec = titleScene
+      ? (titleScene.startMs + titleScene.budgetMs * 0.6) / 1000
+      : 1;
+    const posterPngPath = path.join(dir, 'poster.png');
+    await runFfmpeg(
+      ffmpegBin(),
+      [
+        '-y',
+        '-ss',
+        posterAtSec.toFixed(3),
+        '-i',
+        mp4Path,
+        '-frames:v',
+        '1',
+        posterPngPath,
+      ],
+      60_000,
+    );
+    poster = await encodeWebp(
+      readFileSync(posterPngPath),
+      `${baseName} poster`,
+    );
+    posterPath = path.join(outDir, `${baseName}.webp`);
+    writeFileSync(posterPath, poster.bytes);
+  }
 
   const mp4DurationMs = await probeDurationMs(mp4Path);
   // Playback-compatibility gate: ffmpeg happily DECODES exotic tracks its own
@@ -240,13 +282,46 @@ export async function runComposeStage(
       );
     }
   }
-  const mp4SizeMb = (readFileSync(mp4Path).byteLength / 1024 / 1024).toFixed(1);
-  console.log(
-    `  ✓ ${baseName}.mp4 — ${(mp4DurationMs / 1000).toFixed(1)}s, ${mp4SizeMb} MB, ` +
-      `${cues.length} caption cues, poster ${poster.width}×${poster.height} q${poster.quality}`,
-  );
+  // Automated watch-check: composed duration vs plan + audible speech over
+  // every narrated window — a silent track or a global offset never ships
+  // (nor survives a draft loop) unheard.
+  if (options.verify ?? true) {
+    const issues = await verifyComposedEpisode(mp4Path, recorded, audioPlan, {
+      audioIsSilent: audioPlan.estimated ?? false,
+    });
+    if (issues.length > 0) {
+      throw new Error(
+        `A/V verification failed for ${baseName}.mp4:\n` +
+          issues
+            .map((issue) => `  ✗ ${issue.where} — ${issue.detail}`)
+            .join('\n') +
+          `\n(--no-verify skips the gate; a silent or desynced cut must never ship.)`,
+      );
+    }
+    console.log(
+      `  ✓ verified — duration on plan${audioPlan.estimated ? '' : ', every narration window audible'}`,
+    );
+  }
 
-  if (!episode.diagnostic) {
+  const mp4SizeMb = readFileSync(mp4Path).byteLength / 1024 / 1024;
+  const sheetPath = await writeReviewSheet({
+    episode,
+    locale,
+    mp4Path,
+    recorded,
+    audioPlan,
+    stateDir,
+    draft,
+    durationMs: mp4DurationMs,
+    sizeMb: mp4SizeMb,
+  });
+  console.log(
+    `  ✓ ${baseName}.mp4 — ${(mp4DurationMs / 1000).toFixed(1)}s, ${mp4SizeMb.toFixed(1)} MB, ` +
+      `${cues.length} caption cues${poster ? `, poster ${poster.width}×${poster.height} q${poster.quality}` : ''}`,
+  );
+  console.log(`  ✓ review sheet → ${sheetPath}`);
+
+  if (!draft && !episode.diagnostic) {
     const relative = (file: string) =>
       path.relative(DOCS_PUBLIC_DIR, file).split(path.sep).join('/');
     const entries: VideoManifestEntry[] = [
@@ -266,14 +341,18 @@ export async function runComposeStage(
         kind: 'captions',
         durationSec: Math.round(mp4DurationMs / 100) / 10,
       },
-      {
-        file: relative(posterPath),
-        episode: episode.id,
-        locale,
-        kind: 'poster',
-        width: poster.width,
-        height: poster.height,
-      },
+      ...(poster
+        ? [
+            {
+              file: relative(posterPath),
+              episode: episode.id,
+              locale,
+              kind: 'poster',
+              width: poster.width,
+              height: poster.height,
+            } satisfies VideoManifestEntry,
+          ]
+        : []),
     ];
     upsertVideoManifest(DOCS_PUBLIC_DIR, entries);
     console.log(`  ✓ manifest updated (${entries.length} entries)`);

--- a/services/platform/tests/docs-videos/lib/compose.ts
+++ b/services/platform/tests/docs-videos/lib/compose.ts
@@ -27,13 +27,10 @@ import {
   probeDurationMs,
   runFfmpeg,
 } from './ffmpeg';
+import { DOCS_PUBLIC_DIR } from './paths';
 import { framesDir, timelinePath, type RecordedTimeline } from './recorder';
 import { driftReport, driftViolations, MAX_DRIFT_MS } from './timeline';
 import { upsertVideoManifest, type VideoManifestEntry } from './video-manifest';
-
-const HERE = path.dirname(new URL(import.meta.url).pathname);
-const REPO_ROOT = path.resolve(HERE, '../../../../..');
-const DOCS_PUBLIC = path.join(REPO_ROOT, 'services/docs/public');
 
 const FPS = 30;
 const OUT_WIDTH = 1920;
@@ -109,7 +106,7 @@ export async function runComposeStage(
 
   const outDir = episode.diagnostic
     ? path.join(stateDir, 'out')
-    : path.join(DOCS_PUBLIC, 'videos', locale, episode.section, episode.id);
+    : path.join(DOCS_PUBLIC_DIR, 'videos', locale, episode.section, episode.id);
   mkdirSync(outDir, { recursive: true });
   const baseName = `${episode.id}.${locale}`;
   const mp4Path = path.join(outDir, `${baseName}.mp4`);
@@ -251,7 +248,7 @@ export async function runComposeStage(
 
   if (!episode.diagnostic) {
     const relative = (file: string) =>
-      path.relative(DOCS_PUBLIC, file).split(path.sep).join('/');
+      path.relative(DOCS_PUBLIC_DIR, file).split(path.sep).join('/');
     const entries: VideoManifestEntry[] = [
       {
         file: relative(mp4Path),
@@ -278,7 +275,7 @@ export async function runComposeStage(
         height: poster.height,
       },
     ];
-    upsertVideoManifest(DOCS_PUBLIC, entries);
+    upsertVideoManifest(DOCS_PUBLIC_DIR, entries);
     console.log(`  ✓ manifest updated (${entries.length} entries)`);
   }
 }

--- a/services/platform/tests/docs-videos/lib/dev-env.ts
+++ b/services/platform/tests/docs-videos/lib/dev-env.ts
@@ -12,8 +12,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-const HERE = path.dirname(new URL(import.meta.url).pathname);
-const REPO_ROOT = path.resolve(HERE, '../../../../..');
+import { REPO_ROOT } from './paths';
 
 export function loadDevEnv(): void {
   const file = path.join(REPO_ROOT, '.env.dev');

--- a/services/platform/tests/docs-videos/lib/doctor.ts
+++ b/services/platform/tests/docs-videos/lib/doctor.ts
@@ -1,0 +1,418 @@
+/**
+ * Environment preflight for the video pipeline — every prerequisite a stage
+ * needs, probed in seconds, each failure carrying the EXACT fix command.
+ * Exists because the expensive failures all look the same: a take dies ten
+ * minutes in on something `--doctor` would have named up front (expired
+ * auth → the recorder sees the login page; a restarted gateway → streams
+ * race past the camera; a missing locale org → the de take throws mid-way).
+ *
+ * Two entry points: `--doctor` prints the full report; the record stage runs
+ * the record-relevant subset automatically and aborts on hard failures
+ * before a single frame is captured.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { BASE_URL } from '../../e2e/helpers/env';
+import type { EpisodeSpec, Locale } from './episode';
+import { ffmpegBin } from './ffmpeg';
+import { REPO_ROOT, SCREENSHOTS_STATE_DIR, STATE_DIR } from './paths';
+
+export type DoctorStatus = 'ok' | 'warn' | 'fail';
+
+export interface DoctorCheck {
+  readonly name: string;
+  readonly status: DoctorStatus;
+  readonly detail: string;
+  /** The exact command that fixes a warn/fail, when one exists. */
+  readonly fix?: string;
+}
+
+export interface DoctorScope {
+  /** Selected episodes — decides org/locale/knowledge-DB applicability. */
+  readonly episodes: readonly EpisodeSpec[];
+  readonly locales: readonly Locale[];
+  readonly needsTts: boolean;
+  readonly needsRecord: boolean;
+  readonly needsCompose: boolean;
+  /** Mock narration needs no ElevenLabs key. */
+  readonly mockTts: boolean;
+}
+
+const GATEWAY_URL = 'http://localhost:4141';
+/** The RAG backend the Indexed badges need on camera (docs demo container). */
+const KNOWLEDGE_DB = { host: 'localhost', port: 5544 } as const;
+const MOCK_STREAM_PACE_HINT =
+  'TALE_MOCK_STREAM_PACE_MS=35 must be set ON THE GATEWAY PROCESS (a restart drops it) — not verifiable from here, check its env';
+
+function run(
+  bin: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ ok: boolean; output: string }> {
+  return new Promise((resolve) => {
+    const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let output = '';
+    proc.stdout.on('data', (d: Buffer) => {
+      output += d.toString();
+    });
+    proc.stderr.on('data', (d: Buffer) => {
+      output += d.toString();
+    });
+    const killer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      resolve({ ok: false, output: `timed out after ${timeoutMs}ms` });
+    }, timeoutMs);
+    proc.on('error', (error) => {
+      clearTimeout(killer);
+      resolve({ ok: false, output: String(error) });
+    });
+    proc.on('close', (code) => {
+      clearTimeout(killer);
+      resolve({ ok: code === 0, output });
+    });
+  });
+}
+
+/** Any HTTP status is a live listener; only transport errors mean "down". */
+async function probeHttp(url: string): Promise<'listening' | 'down'> {
+  try {
+    await fetch(url, { signal: AbortSignal.timeout(3000) });
+    return 'listening';
+  } catch (error) {
+    console.warn(`  · ${url} probe: ${String(error)}`);
+    return 'down';
+  }
+}
+
+/** Cookie header from a Playwright storageState file, localhost-scoped. */
+function cookieHeaderFromStorageState(authPath: string): string | null {
+  try {
+    const state = JSON.parse(readFileSync(authPath, 'utf8')) as {
+      cookies?: { name: string; value: string; domain: string }[];
+    };
+    const cookies = (state.cookies ?? []).filter((cookie) =>
+      cookie.domain.includes('localhost'),
+    );
+    if (cookies.length === 0) return null;
+    return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
+  } catch (error) {
+    console.warn(`unreadable storage state at ${authPath}:`, error);
+    return null;
+  }
+}
+
+async function checkBinaries(): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  const ffmpeg = ffmpegBin();
+  const ffprobe =
+    process.env.VIDEO_INGEST_FFMPEG_LOCATION !== undefined
+      ? path.join(path.dirname(ffmpeg), 'ffprobe')
+      : 'ffprobe';
+  for (const bin of [ffmpeg, ffprobe]) {
+    const result = await run(bin, ['-version'], 10_000);
+    checks.push(
+      result.ok
+        ? {
+            name: bin,
+            status: 'ok',
+            detail: result.output.split('\n')[0] ?? 'runnable',
+          }
+        : {
+            name: bin,
+            status: 'fail',
+            detail: 'not runnable',
+            fix: 'brew install ffmpeg   # or set VIDEO_INGEST_FFMPEG_LOCATION',
+          },
+    );
+  }
+  return checks;
+}
+
+async function checkChromium(): Promise<DoctorCheck> {
+  try {
+    const { chromium } = await import('@playwright/test');
+    const executable = chromium.executablePath();
+    if (executable && existsSync(executable)) {
+      return { name: 'chromium', status: 'ok', detail: executable };
+    }
+    return {
+      name: 'chromium',
+      status: 'fail',
+      detail: 'Playwright Chromium is not installed',
+      fix: 'bunx playwright install chromium',
+    };
+  } catch (error) {
+    return {
+      name: 'chromium',
+      status: 'fail',
+      detail: String(error),
+      fix: 'bunx playwright install chromium',
+    };
+  }
+}
+
+function checkElevenLabsKey(mockTts: boolean): DoctorCheck {
+  if (process.env.ELEVENLABS_API_KEY) {
+    return {
+      name: 'ELEVENLABS_API_KEY',
+      status: 'ok',
+      detail: 'set (via env or the repo-root .env.dev)',
+    };
+  }
+  return {
+    name: 'ELEVENLABS_API_KEY',
+    status: mockTts ? 'warn' : 'fail',
+    detail: mockTts
+      ? 'not set — fine for --mock-tts, required for real narration'
+      : 'not set — the tts stage bills through this key',
+    fix: `echo 'ELEVENLABS_API_KEY=…' >> ${path.join(REPO_ROOT, '.env.dev')}   # gitignored dev-tooling secrets`,
+  };
+}
+
+async function checkAppAndGateway(): Promise<DoctorCheck[]> {
+  const [app, gateway] = await Promise.all([
+    probeHttp(BASE_URL),
+    probeHttp(`${GATEWAY_URL}/v1/models`),
+  ]);
+  return [
+    app === 'listening'
+      ? { name: `app ${BASE_URL}`, status: 'ok', detail: 'listening' }
+      : {
+          name: `app ${BASE_URL}`,
+          status: 'fail',
+          detail: 'not reachable — the Mode-A stack is down',
+          fix: 'bring up the docs-demo stack: services/platform/tests/docs-screenshots/README.md',
+        },
+    gateway === 'listening'
+      ? {
+          name: `mock gateway ${GATEWAY_URL}`,
+          status: 'ok',
+          detail: `listening — ${MOCK_STREAM_PACE_HINT}`,
+        }
+      : {
+          name: `mock gateway ${GATEWAY_URL}`,
+          status: 'fail',
+          detail: 'not reachable — recording streams need the mock gateway',
+          fix: 'bring up the docs-demo stack: services/platform/tests/docs-screenshots/README.md',
+        },
+  ];
+}
+
+/**
+ * The expired-auth trap: a stale storageState records the LOGIN PAGE, not
+ * the workspace. Probe the session endpoint with the saved cookies — a null
+ * session means re-bootstrap, never hand-edit `.state/`.
+ */
+async function checkAuthFreshness(): Promise<DoctorCheck> {
+  const authPath = path.join(SCREENSHOTS_STATE_DIR, 'auth.json');
+  if (!existsSync(authPath)) {
+    return {
+      name: 'demo auth',
+      status: 'fail',
+      detail: `no storage state at ${authPath}`,
+      fix: 'bun run docs:screenshots   # bootstraps + signs in the demo owner',
+    };
+  }
+  const cookieHeader = cookieHeaderFromStorageState(authPath);
+  if (!cookieHeader) {
+    return {
+      name: 'demo auth',
+      status: 'fail',
+      detail: 'storage state carries no localhost cookies',
+      fix: 'bun run docs:screenshots',
+    };
+  }
+  try {
+    const response = await fetch(`${BASE_URL}/api/auth/get-session`, {
+      headers: { cookie: cookieHeader },
+      signal: AbortSignal.timeout(4000),
+    });
+    if (response.status === 401) {
+      return {
+        name: 'demo auth',
+        status: 'fail',
+        detail:
+          'session rejected (401) — the recorder would film the login page',
+        fix: 'bun run docs:screenshots',
+      };
+    }
+    if (!response.ok) {
+      return {
+        name: 'demo auth',
+        status: 'warn',
+        detail: `session endpoint answered ${response.status} — could not verify freshness`,
+      };
+    }
+    const session = (await response.json()) as unknown;
+    const alive =
+      session !== null &&
+      typeof session === 'object' &&
+      ('user' in session || 'session' in session) &&
+      Boolean(
+        (session as { user?: unknown; session?: unknown }).user ??
+        (session as { user?: unknown; session?: unknown }).session,
+      );
+    return alive
+      ? { name: 'demo auth', status: 'ok', detail: 'session is live' }
+      : {
+          name: 'demo auth',
+          status: 'fail',
+          detail: 'session expired — the recorder would film the login page',
+          fix: 'bun run docs:screenshots',
+        };
+  } catch (error) {
+    return {
+      name: 'demo auth',
+      status: 'warn',
+      detail: `could not probe the session endpoint (${String(error)})`,
+    };
+  }
+}
+
+function checkOrgs(
+  episodes: readonly EpisodeSpec[],
+  locales: readonly Locale[],
+): DoctorCheck[] {
+  if (episodes.every((episode) => episode.diagnostic)) return [];
+  const checks: DoctorCheck[] = [];
+  if (locales.includes('en')) {
+    const orgPath = path.join(SCREENSHOTS_STATE_DIR, 'org.json');
+    checks.push(
+      existsSync(orgPath)
+        ? { name: 'en demo org', status: 'ok', detail: orgPath }
+        : {
+            name: 'en demo org',
+            status: 'fail',
+            detail: `no org state at ${orgPath}`,
+            fix: 'bun run docs:screenshots',
+          },
+    );
+  }
+  const localeLocales = locales.filter((locale) => locale !== 'en');
+  if (localeLocales.length > 0) {
+    const localeOrgsPath = path.join(STATE_DIR, 'locale-orgs.json');
+    const present = existsSync(localeOrgsPath)
+      ? (JSON.parse(readFileSync(localeOrgsPath, 'utf8')) as Partial<
+          Record<Locale, unknown>
+        >)
+      : {};
+    for (const locale of localeLocales) {
+      checks.push(
+        present[locale]
+          ? { name: `${locale} demo org`, status: 'ok', detail: 'seeded' }
+          : {
+              name: `${locale} demo org`,
+              status: 'fail',
+              detail: `no ${locale} org in ${localeOrgsPath}`,
+              fix: `bun services/platform/tests/docs-videos/seed-locale-orgs.ts --locale ${locale}`,
+            },
+      );
+    }
+  }
+  return checks;
+}
+
+async function checkKnowledgeDb(
+  episodes: readonly EpisodeSpec[],
+): Promise<DoctorCheck | null> {
+  if (!episodes.some((episode) => episode.needsKnowledgeDb)) return null;
+  const { createConnection } = await import('node:net');
+  const reachable = await new Promise<boolean>((resolve) => {
+    const socket = createConnection({
+      host: KNOWLEDGE_DB.host,
+      port: KNOWLEDGE_DB.port,
+      timeout: 1500,
+    });
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once('error', () => resolve(false));
+  });
+  return reachable
+    ? {
+        name: `knowledge db :${KNOWLEDGE_DB.port}`,
+        status: 'ok',
+        detail: 'reachable — Indexed badges will render',
+      }
+    : {
+        name: `knowledge db :${KNOWLEDGE_DB.port}`,
+        status: 'fail',
+        detail:
+          'unreachable — a selected episode shows Indexed badges on camera',
+        fix: 'docker start tale-docs-knowledge-db',
+      };
+}
+
+/** Frames are heavy (a 3-minute take ≈ 3–5 GB of JPEG) — warn early. */
+async function checkDiskSpace(): Promise<DoctorCheck | null> {
+  // `.state/` may not exist yet on a fresh clone — fall back to its parent.
+  const probe = existsSync(STATE_DIR) ? STATE_DIR : path.dirname(STATE_DIR);
+  const result = await run('df', ['-Pk', probe], 5000);
+  if (!result.ok) return null;
+  const dataLine = result.output.trim().split('\n').at(-1) ?? '';
+  const availableKb = Number(dataLine.split(/\s+/)[3]);
+  if (!Number.isFinite(availableKb)) return null;
+  const availableGb = availableKb / 1024 / 1024;
+  return availableGb >= 8
+    ? {
+        name: 'disk space',
+        status: 'ok',
+        detail: `${availableGb.toFixed(0)} GB free for frames`,
+      }
+    : {
+        name: 'disk space',
+        status: 'warn',
+        detail: `${availableGb.toFixed(1)} GB free — a take writes 3–5 GB of frames`,
+        fix: `rm -rf ${path.join(STATE_DIR, 'frames')}   # disposable`,
+      };
+}
+
+export async function runDoctor(scope: DoctorScope): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  checks.push(...(await checkBinaries()));
+  if (scope.needsTts) checks.push(checkElevenLabsKey(scope.mockTts));
+  if (scope.needsRecord) {
+    checks.push(await checkChromium());
+    const recordsRealOrg = !scope.episodes.every(
+      (episode) => episode.diagnostic,
+    );
+    if (recordsRealOrg) {
+      checks.push(...(await checkAppAndGateway()));
+      checks.push(await checkAuthFreshness());
+      checks.push(...checkOrgs(scope.episodes, scope.locales));
+      const knowledgeDb = await checkKnowledgeDb(scope.episodes);
+      if (knowledgeDb) checks.push(knowledgeDb);
+    }
+    const disk = await checkDiskSpace();
+    if (disk) checks.push(disk);
+  }
+  return checks;
+}
+
+export function doctorHasFailures(checks: readonly DoctorCheck[]): boolean {
+  return checks.some((check) => check.status === 'fail');
+}
+
+export function formatDoctorReport(checks: readonly DoctorCheck[]): string {
+  const icon: Record<DoctorStatus, string> = {
+    ok: '✓',
+    warn: '⚠',
+    fail: '✗',
+  };
+  return checks
+    .map((check) => {
+      const line = `  ${icon[check.status]} ${check.name} — ${check.detail}`;
+      return check.fix && check.status !== 'ok'
+        ? `${line}\n      fix: ${check.fix}`
+        : line;
+    })
+    .join('\n');
+}

--- a/services/platform/tests/docs-videos/lib/doctor.ts
+++ b/services/platform/tests/docs-videos/lib/doctor.ts
@@ -81,8 +81,8 @@ async function probeHttp(url: string): Promise<'listening' | 'down'> {
   try {
     await fetch(url, { signal: AbortSignal.timeout(3000) });
     return 'listening';
-  } catch (error) {
-    console.warn(`  · ${url} probe: ${String(error)}`);
+  } catch {
+    // Transport failure IS the diagnostic result — reported as 'down'.
     return 'down';
   }
 }

--- a/services/platform/tests/docs-videos/lib/doctor.ts
+++ b/services/platform/tests/docs-videos/lib/doctor.ts
@@ -20,9 +20,9 @@ import type { EpisodeSpec, Locale } from './episode';
 import { ffmpegBin } from './ffmpeg';
 import { REPO_ROOT, SCREENSHOTS_STATE_DIR, STATE_DIR } from './paths';
 
-export type DoctorStatus = 'ok' | 'warn' | 'fail';
+type DoctorStatus = 'ok' | 'warn' | 'fail';
 
-export interface DoctorCheck {
+interface DoctorCheck {
   readonly name: string;
   readonly status: DoctorStatus;
   readonly detail: string;
@@ -30,7 +30,7 @@ export interface DoctorCheck {
   readonly fix?: string;
 }
 
-export interface DoctorScope {
+interface DoctorScope {
   /** Selected episodes — decides org/locale/knowledge-DB applicability. */
   readonly episodes: readonly EpisodeSpec[];
   readonly locales: readonly Locale[];

--- a/services/platform/tests/docs-videos/lib/episode.ts
+++ b/services/platform/tests/docs-videos/lib/episode.ts
@@ -61,8 +61,13 @@ export interface EpisodeSpec {
    * scripts next change.
    */
   readonly wholeTakeLocales?: readonly Locale[];
-  /** The question typed live in the chat wow scene, per locale. */
-  readonly heroPromptByLocale: Record<Locale, string>;
+  /**
+   * The question typed live in the chat wow scene, per locale — omit when
+   * the episode has no live-typed chat scene. A non-empty prompt MUST
+   * contain a `DOCS_REPLIES` match clause (validated by `--stage check`),
+   * or the take streams the visibly synthetic e2e canned reply.
+   */
+  readonly heroPromptByLocale?: Record<Locale, string>;
   readonly scenes: readonly SceneSpec[];
 }
 

--- a/services/platform/tests/docs-videos/lib/episodes.test.ts
+++ b/services/platform/tests/docs-videos/lib/episodes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadChoreography, loadEpisodes } from './episodes';
+import {
+  formatFindings,
+  validateChoreography,
+  validateEpisodeSpec,
+  type ValidationFinding,
+} from './validate';
+
+/**
+ * The always-on episode gate: every episode the registry discovers must pass
+ * static validation — spec ↔ choreography id parity, locale consistency,
+ * hero-prompt ↔ DOCS_REPLIES pairing, warmup presence. This is the same
+ * validation `--stage check` runs; here it fails `bun run check` the moment
+ * an episode drifts, instead of minutes into a take.
+ */
+describe('episode registry gate', () => {
+  it('discovers the full series in natural order', async () => {
+    const ids = (await loadEpisodes()).map((episode) => episode.id);
+    expect(ids).toContain('ep1-welcome');
+    expect(ids).toContain('spike-sync');
+    expect(ids.length).toBeGreaterThanOrEqual(11);
+    expect(ids.indexOf('ep2-chat')).toBeLessThan(
+      ids.indexOf('ep10-developers'),
+    );
+  });
+
+  it('every episode passes static validation (spec + choreography)', async () => {
+    const errors: ValidationFinding[] = [];
+    for (const episode of await loadEpisodes()) {
+      const findings = [
+        ...validateEpisodeSpec(episode),
+        ...validateChoreography(episode, await loadChoreography(episode.id)),
+      ];
+      errors.push(...findings.filter((f) => f.severity === 'error'));
+      const warnings = findings.filter((f) => f.severity === 'warning');
+      if (warnings.length > 0) {
+        console.warn(`${episode.id}:\n${formatFindings(warnings)}`);
+      }
+    }
+    expect(
+      errors.map((finding) => `${finding.where}: ${finding.detail}`),
+    ).toEqual([]);
+  });
+});

--- a/services/platform/tests/docs-videos/lib/episodes.ts
+++ b/services/platform/tests/docs-videos/lib/episodes.ts
@@ -33,7 +33,8 @@ export async function loadChoreography(
 }
 
 /** `ep2-…` before `ep10-…` — numeric-aware, deterministic across machines. */
-const naturalOrder = new Intl.Collator('en', { numeric: true }).compare;
+const collator = new Intl.Collator('en', { numeric: true });
+const naturalOrder = (a: string, b: string): number => collator.compare(a, b);
 
 function isEpisodeSpec(value: unknown): value is EpisodeSpec {
   if (typeof value !== 'object' || value === null) return false;

--- a/services/platform/tests/docs-videos/lib/episodes.ts
+++ b/services/platform/tests/docs-videos/lib/episodes.ts
@@ -79,15 +79,3 @@ export async function loadEpisodes(): Promise<readonly EpisodeSpec[]> {
   cache = episodes;
   return episodes;
 }
-
-/** One episode by id, or throw naming the known ids. */
-export async function findEpisode(id: string): Promise<EpisodeSpec> {
-  const episodes = await loadEpisodes();
-  const episode = episodes.find((e) => e.id === id);
-  if (!episode) {
-    throw new Error(
-      `Unknown episode "${id}". Known: ${episodes.map((e) => e.id).join(', ')}`,
-    );
-  }
-  return episode;
-}

--- a/services/platform/tests/docs-videos/lib/episodes.ts
+++ b/services/platform/tests/docs-videos/lib/episodes.ts
@@ -12,6 +12,25 @@ import path from 'node:path';
 
 import type { EpisodeSpec } from './episode';
 import { EPISODES_DIR } from './paths';
+import type { SceneChoreography, SceneContext } from './scene';
+
+export interface ChoreographyModule {
+  readonly SCENES: readonly SceneChoreography[];
+  /** Optional pre-screencast lap over every surface the take visits. */
+  readonly warmup?: (
+    page: import('@playwright/test').Page,
+    ctx: SceneContext,
+  ) => Promise<void>;
+}
+
+/** The paired `scenes.ts` of one episode (choreography side of the spec). */
+export async function loadChoreography(
+  episodeId: string,
+): Promise<ChoreographyModule> {
+  return (await import(
+    path.join(EPISODES_DIR, episodeId, 'scenes.ts')
+  )) as ChoreographyModule;
+}
 
 /** `ep2-…` before `ep10-…` — numeric-aware, deterministic across machines. */
 const naturalOrder = new Intl.Collator('en', { numeric: true }).compare;

--- a/services/platform/tests/docs-videos/lib/episodes.ts
+++ b/services/platform/tests/docs-videos/lib/episodes.ts
@@ -1,0 +1,73 @@
+/**
+ * Episode registry by filesystem convention: every `episodes/<id>/episode.ts`
+ * that exports an `EpisodeSpec` is registered automatically — there is no
+ * manual import list to forget when adding an episode. The spec's `id` must
+ * equal its directory name (it already keys the TTS cache, timeline and
+ * output paths), and discovery fails loudly on any directory that doesn't
+ * export a recognizable spec.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import type { EpisodeSpec } from './episode';
+import { EPISODES_DIR } from './paths';
+
+/** `ep2-…` before `ep10-…` — numeric-aware, deterministic across machines. */
+const naturalOrder = new Intl.Collator('en', { numeric: true }).compare;
+
+function isEpisodeSpec(value: unknown): value is EpisodeSpec {
+  if (typeof value !== 'object' || value === null) return false;
+  const spec = value as Partial<EpisodeSpec>;
+  return (
+    typeof spec.id === 'string' &&
+    Array.isArray(spec.scenes) &&
+    typeof spec.voices === 'object'
+  );
+}
+
+let cache: readonly EpisodeSpec[] | null = null;
+
+/** All episodes, discovered from `episodes/<id>/episode.ts`, natural order. */
+export async function loadEpisodes(): Promise<readonly EpisodeSpec[]> {
+  if (cache) return cache;
+  const directories = readdirSync(EPISODES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(path.join(EPISODES_DIR, name, 'episode.ts')))
+    .sort(naturalOrder);
+  const episodes: EpisodeSpec[] = [];
+  for (const directory of directories) {
+    const module = (await import(
+      path.join(EPISODES_DIR, directory, 'episode.ts')
+    )) as Record<string, unknown>;
+    const spec = Object.values(module).find(isEpisodeSpec);
+    if (!spec) {
+      throw new Error(
+        `episodes/${directory}/episode.ts exports no EpisodeSpec — export a ` +
+          `const with id/scenes/voices (see episodes/ep1-welcome/episode.ts).`,
+      );
+    }
+    if (spec.id !== directory) {
+      throw new Error(
+        `episodes/${directory}: spec id "${spec.id}" must equal the directory ` +
+          `name — the id keys the TTS cache, timeline and output paths.`,
+      );
+    }
+    episodes.push(spec);
+  }
+  cache = episodes;
+  return episodes;
+}
+
+/** One episode by id, or throw naming the known ids. */
+export async function findEpisode(id: string): Promise<EpisodeSpec> {
+  const episodes = await loadEpisodes();
+  const episode = episodes.find((e) => e.id === id);
+  if (!episode) {
+    throw new Error(
+      `Unknown episode "${id}". Known: ${episodes.map((e) => e.id).join(', ')}`,
+    );
+  }
+  return episode;
+}

--- a/services/platform/tests/docs-videos/lib/estimate.ts
+++ b/services/platform/tests/docs-videos/lib/estimate.ts
@@ -1,0 +1,33 @@
+/**
+ * Rough narration-length estimation for REHEARSAL runs (`--mock-tts`,
+ * `--stage plan` before any TTS exists). Calibrated against the shipped
+ * ep1 narration (~15.5 chars/sec at ElevenLabs' tutorial pace); good enough
+ * to plan a timeline and rehearse choreography, never good enough to ship —
+ * estimated audio plans are refused outside `.state/` by the compose stage.
+ *
+ * Pure module — no fs, no network.
+ */
+
+import { stripAudioTags } from './vtt';
+
+/** Average speech rate: milliseconds per spoken character. */
+const MS_PER_CHAR = 64;
+/** Breathing room the voice takes at each sentence boundary. */
+const MS_PER_SENTENCE_BREAK = 220;
+/** Onset latency baked into every generated clip. */
+const BASE_MS = 240;
+
+/**
+ * Estimate how long a narration text will take to speak, in milliseconds.
+ * Returns 0 for a silent scene (empty or tags-only text).
+ */
+export function estimateSpeechMs(text: string): number {
+  const clean = stripAudioTags(text);
+  if (!clean) return 0;
+  const sentenceBreaks = (clean.match(/[.!?…]+(?:\s|$)/g) ?? []).length;
+  return Math.round(
+    BASE_MS +
+      clean.length * MS_PER_CHAR +
+      sentenceBreaks * MS_PER_SENTENCE_BREAK,
+  );
+}

--- a/services/platform/tests/docs-videos/lib/format.ts
+++ b/services/platform/tests/docs-videos/lib/format.ts
@@ -1,0 +1,10 @@
+/** Console/HTML display helpers shared by the plan view and review sheet. */
+
+/** `m:ss.d` — video-position clock, tenth-of-a-second precision. */
+export function formatClock(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const tenths = Math.floor((ms % 1000) / 100);
+  return `${minutes}:${String(seconds).padStart(2, '0')}.${tenths}`;
+}

--- a/services/platform/tests/docs-videos/lib/paths.ts
+++ b/services/platform/tests/docs-videos/lib/paths.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical filesystem anchors for the docs video pipeline. Every module
+ * derives its locations from here — the "where are we" math lives in exactly
+ * one place instead of per-file `../../../..` chains.
+ */
+
+import path from 'node:path';
+
+const LIB_DIR = path.dirname(new URL(import.meta.url).pathname);
+
+/** `services/platform/tests/docs-videos/` — the pipeline root. */
+export const PIPELINE_DIR = path.resolve(LIB_DIR, '..');
+
+/** Episode specs + choreography, one directory per episode id. */
+export const EPISODES_DIR = path.join(PIPELINE_DIR, 'episodes');
+
+/**
+ * Disposable, gitignored working state: TTS cache, audio plans, frames,
+ * drafts, review sheets. Only `tts-cache/` is worth keeping (it bills).
+ */
+export const STATE_DIR = path.join(PIPELINE_DIR, '.state');
+
+export const REPO_ROOT = path.resolve(PIPELINE_DIR, '../../../..');
+
+/** Where produced episodes ship: `services/docs/public/`. */
+export const DOCS_PUBLIC_DIR = path.join(REPO_ROOT, 'services/docs/public');
+
+/**
+ * The docs-screenshots bootstrap state the recorder reuses (auth.json +
+ * org.json) — the video pipeline never mints its own demo org.
+ */
+export const SCREENSHOTS_STATE_DIR = path.resolve(
+  PIPELINE_DIR,
+  '..',
+  'docs-screenshots',
+  '.state',
+);

--- a/services/platform/tests/docs-videos/lib/paths.ts
+++ b/services/platform/tests/docs-videos/lib/paths.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 const LIB_DIR = path.dirname(new URL(import.meta.url).pathname);
 
 /** `services/platform/tests/docs-videos/` — the pipeline root. */
-export const PIPELINE_DIR = path.resolve(LIB_DIR, '..');
+const PIPELINE_DIR = path.resolve(LIB_DIR, '..');
 
 /** Episode specs + choreography, one directory per episode id. */
 export const EPISODES_DIR = path.join(PIPELINE_DIR, 'episodes');

--- a/services/platform/tests/docs-videos/lib/recorder.ts
+++ b/services/platform/tests/docs-videos/lib/recorder.ts
@@ -24,11 +24,12 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 
-import { chromium, type Browser, type CDPSession } from '@playwright/test';
+import { chromium, type CDPSession } from '@playwright/test';
 
 import { BASE_URL } from '../../e2e/helpers/env';
 import { readAudioPlan } from './audio-plan';
 import { installVideoCards } from './cards';
+import { CleanupRegistry, runCleanup } from './cleanup';
 import { Cursor } from './cursor';
 import type { EpisodeSpec, Locale } from './episode';
 import { loadChoreography } from './episodes';
@@ -158,239 +159,6 @@ function sleepUntil(deadlineMs: number, nowMs: () => number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, wait));
 }
 
-/**
- * Delete every thread the take created — the take must leave the demo org
- * exactly as seeded. Scenes register ids under the `wowThreadId` note (the
- * Episode 1 contract, one thread) and/or a comma-separated `cleanupThreadIds`
- * note (any number). Runs in its own en-locale context because the e2e chat
- * helpers resolve labels from the en catalog. Best-effort per thread: a
- * failure here must never mask the take's own error.
- */
-async function cleanupWowThread(
-  browser: Browser,
-  ctx: SceneContext,
-): Promise<void> {
-  const ids = [
-    ...new Set(
-      [
-        ctx.notes.get('wowThreadId'),
-        ...(ctx.notes.get('cleanupThreadIds')?.split(',') ?? []),
-      ]
-        .map((id) => id?.trim())
-        .filter((id): id is string => Boolean(id)),
-    ),
-  ];
-  // Knowledge entries a take creates ON CAMERA (Episode 3's `entries`
-  // scene), registered by topic — topics are per-locale DATA literals, so
-  // the en-locale cleanup context finds them regardless of the take locale.
-  const entryTopics = [
-    ...new Set(
-      (ctx.notes.get('cleanupEntryTopics')?.split(',') ?? [])
-        .map((topic) => topic.trim())
-        .filter(Boolean),
-    ),
-  ];
-  // Agents a take creates ON CAMERA (Episode 4's create scene), registered
-  // by display name — the agents list row carries it in every locale.
-  const agentNames = [
-    ...new Set(
-      (ctx.notes.get('cleanupAgentNames')?.split(',') ?? [])
-        .map((name) => name.trim())
-        .filter(Boolean),
-    ),
-  ];
-  // Tasks a take creates ON CAMERA (Episode 6), archived by title on the
-  // board the scene registered under `cleanupTaskBoardUrl`.
-  const taskTitles = [
-    ...new Set(
-      (ctx.notes.get('cleanupTaskTitles')?.split(',') ?? [])
-        .map((title) => title.trim())
-        .filter(Boolean),
-    ),
-  ];
-  const taskBoardUrl = ctx.notes.get('cleanupTaskBoardUrl') ?? '';
-  if (
-    ids.length === 0 &&
-    entryTopics.length === 0 &&
-    agentNames.length === 0 &&
-    taskTitles.length === 0
-  )
-    return;
-  const cleanupContext = await browser.newContext({
-    baseURL: BASE_URL,
-    storageState: path.join(SCREENSHOTS_STATE_DIR, 'auth.json'),
-    viewport: VIEWPORT,
-    locale: 'en-US',
-    timezoneId: 'UTC',
-    serviceWorkers: 'block',
-  });
-  try {
-    await cleanupContext.addInitScript(() => {
-      window.localStorage.setItem('user-locale', 'en');
-    });
-    const cleanupPage = await cleanupContext.newPage();
-    await cleanupPage.goto(`/dashboard/${ctx.orgId}/chat`, {
-      waitUntil: 'domcontentloaded',
-    });
-    const { deleteThreadById, ensureHistorySidebarOpen } =
-      await import('../../e2e/helpers/chat');
-    // Thread rows render only inside the history drawer — open it before
-    // any existence check, or every row reads as "gone".
-    await ensureHistorySidebarOpen(cleanupPage);
-    for (const id of ids) {
-      // The app deletes some registered threads itself (an Arena branch on
-      // exit) — skip rows that are already gone instead of timing out.
-      // `isVisible()` never waits — use a bounded waitFor so a still-loading
-      // list cannot read as "already gone".
-      const row = cleanupPage.locator(`[data-thread-id="${id}"]`).first();
-      const present = await row
-        .waitFor({ state: 'visible', timeout: 5_000 })
-        .then(() => true)
-        .catch(() => false);
-      if (!present) {
-        console.log(`  · thread ${id} already gone`);
-        continue;
-      }
-      try {
-        await deleteThreadById(cleanupPage, id);
-        console.log(`  ✓ cleaned up thread ${id}`);
-      } catch (error) {
-        console.warn(
-          `  ! could not delete thread ${id} — remove it by hand:`,
-          error,
-        );
-      }
-    }
-    for (const topic of entryTopics) {
-      try {
-        await cleanupPage.goto(`/dashboard/${ctx.orgId}/knowledge-entries`, {
-          waitUntil: 'domcontentloaded',
-        });
-        // Wait for the list to resolve before judging the row's absence.
-        await cleanupPage
-          .getByRole('button', { name: 'Add entry' })
-          .waitFor({ state: 'visible', timeout: 15_000 });
-        const row = cleanupPage
-          .getByRole('row')
-          .filter({ hasText: topic })
-          .first();
-        const present = await row
-          .waitFor({ state: 'visible', timeout: 8_000 })
-          .then(() => true)
-          .catch(() => false);
-        if (!present) {
-          console.log(`  · entry "${topic}" already gone`);
-          continue;
-        }
-        // Row menu → Delete → confirm (the dialog's button shares the label).
-        await row.getByRole('button', { name: 'Open menu' }).click();
-        await cleanupPage.getByRole('menuitem', { name: 'Delete' }).click();
-        const dialog = cleanupPage.getByRole('dialog', {
-          name: 'Delete knowledge entry',
-        });
-        await dialog.waitFor({ state: 'visible', timeout: 15_000 });
-        await dialog.getByRole('button', { name: 'Delete' }).click();
-        await dialog.waitFor({ state: 'hidden', timeout: 15_000 });
-        console.log(`  ✓ cleaned up knowledge entry "${topic}"`);
-      } catch (error) {
-        console.warn(
-          `  ! could not delete entry "${topic}" — remove it by hand:`,
-          error,
-        );
-      }
-    }
-    for (const name of agentNames) {
-      try {
-        await cleanupPage.goto(`/dashboard/${ctx.orgId}/agents`, {
-          waitUntil: 'domcontentloaded',
-        });
-        await cleanupPage
-          .getByRole('button', { name: 'Create agent' })
-          .waitFor({ state: 'visible', timeout: 15_000 });
-        const row = cleanupPage
-          .getByRole('row')
-          .filter({ hasText: name })
-          .first();
-        const present = await row
-          .waitFor({ state: 'visible', timeout: 8_000 })
-          .then(() => true)
-          .catch(() => false);
-        if (!present) {
-          console.log(`  · agent "${name}" already gone`);
-          continue;
-        }
-        await row.getByRole('button', { name: 'Open menu' }).click();
-        await cleanupPage
-          .getByRole('menuitem', { name: 'Delete', exact: true })
-          .click();
-        await cleanupPage
-          .getByRole('button', { name: 'Delete agent', exact: true })
-          .click();
-        await row.waitFor({ state: 'hidden', timeout: 15_000 });
-        console.log(`  ✓ cleaned up agent "${name}"`);
-      } catch (error) {
-        console.warn(
-          `  ! could not delete agent "${name}" — remove it by hand:`,
-          error,
-        );
-      }
-    }
-    for (const title of taskTitles) {
-      if (!taskBoardUrl) break;
-      try {
-        await cleanupPage.goto(taskBoardUrl, {
-          waitUntil: 'domcontentloaded',
-        });
-        const card = cleanupPage.getByText(title).first();
-        const present = await card
-          .waitFor({ state: 'visible', timeout: 15_000 })
-          .then(() => true)
-          .catch(() => false);
-        if (!present) {
-          console.log(`  · task "${title}" already gone`);
-          continue;
-        }
-        await card.click();
-        const dialog = cleanupPage.getByRole('dialog').last();
-        await dialog.waitFor({ state: 'visible', timeout: 15_000 });
-        // Archive lives directly in the dialog, or under its ⋯ menu.
-        const direct = dialog.getByRole('button', { name: 'Archive' }).first();
-        if (await direct.isVisible().catch(() => false)) {
-          await direct.click();
-        } else {
-          await dialog
-            .getByRole('button', { name: 'More actions' })
-            .first()
-            .click();
-          await cleanupPage
-            .getByRole('menuitem', { name: 'Archive' })
-            .first()
-            .click();
-        }
-        const confirm = cleanupPage.getByRole('dialog', {
-          name: 'Archive task?',
-        });
-        await confirm.waitFor({ state: 'visible', timeout: 10_000 });
-        await confirm.getByRole('button', { name: 'Archive' }).click();
-        await confirm.waitFor({ state: 'hidden', timeout: 10_000 });
-        console.log(`  ✓ archived task "${title}"`);
-      } catch (error) {
-        console.warn(
-          `  ! could not archive task "${title}" — archive it by hand:`,
-          error,
-        );
-      }
-    }
-  } catch (error) {
-    console.warn(
-      '  ! thread cleanup context failed — check the org by hand:',
-      error,
-    );
-  } finally {
-    await cleanupContext.close();
-  }
-}
-
 export async function runRecordStage(
   episode: EpisodeSpec,
   locale: Locale,
@@ -462,7 +230,7 @@ export async function runRecordStage(
       locale,
       heroPrompt: episode.heroPromptByLocale?.[locale] ?? '',
       projects: new Map(Object.entries(orgState.projects)),
-      notes: new Map(),
+      cleanup: new CleanupRegistry(),
     };
 
     // The take is ONE SPA session — no full page load ever happens on
@@ -547,7 +315,7 @@ export async function runRecordStage(
         console.warn('stopScreencast failed:', error);
       });
       await context.close();
-      await cleanupWowThread(browser, ctx);
+      await runCleanup(browser, ctx.orgId, ctx.cleanup);
     }
 
     const recorded: RecordedTimeline = {

--- a/services/platform/tests/docs-videos/lib/recorder.ts
+++ b/services/platform/tests/docs-videos/lib/recorder.ts
@@ -31,13 +31,10 @@ import { readAudioPlan } from './audio-plan';
 import { installVideoCards } from './cards';
 import { Cursor } from './cursor';
 import type { EpisodeSpec, Locale } from './episode';
+import { loadChoreography } from './episodes';
 import { contextLocale, localeT } from './i18n';
 import { SCREENSHOTS_STATE_DIR, STATE_DIR } from './paths';
-import {
-  choreographyFor,
-  type SceneChoreography,
-  type SceneContext,
-} from './scene';
+import { choreographyFor, type SceneContext } from './scene';
 import { planTimeline, type PlannedTimeline } from './timeline';
 
 const HERE = path.dirname(new URL(import.meta.url).pathname);
@@ -106,23 +103,6 @@ function readOrgState(episode: EpisodeSpec, locale: Locale): OrgState {
     );
   }
   return state;
-}
-
-interface ChoreographyModule {
-  readonly SCENES: readonly SceneChoreography[];
-  /** Optional pre-screencast lap over every surface the take visits. */
-  readonly warmup?: (
-    page: import('@playwright/test').Page,
-    ctx: SceneContext,
-  ) => Promise<void>;
-}
-
-async function loadChoreography(
-  episodeId: string,
-): Promise<ChoreographyModule> {
-  return (await import(
-    `../episodes/${episodeId}/scenes`
-  )) as ChoreographyModule;
 }
 
 interface FrameLogEntry {
@@ -480,7 +460,7 @@ export async function runRecordStage(
     const ctx: SceneContext = {
       orgId: orgState.orgId,
       locale,
-      heroPrompt: episode.heroPromptByLocale[locale],
+      heroPrompt: episode.heroPromptByLocale?.[locale] ?? '',
       projects: new Map(Object.entries(orgState.projects)),
       notes: new Map(),
     };

--- a/services/platform/tests/docs-videos/lib/recorder.ts
+++ b/services/platform/tests/docs-videos/lib/recorder.ts
@@ -32,6 +32,7 @@ import { installVideoCards } from './cards';
 import { Cursor } from './cursor';
 import type { EpisodeSpec, Locale } from './episode';
 import { contextLocale, localeT } from './i18n';
+import { SCREENSHOTS_STATE_DIR, STATE_DIR } from './paths';
 import {
   choreographyFor,
   type SceneChoreography,
@@ -40,13 +41,6 @@ import {
 import { planTimeline, type PlannedTimeline } from './timeline';
 
 const HERE = path.dirname(new URL(import.meta.url).pathname);
-const SCREENSHOTS_STATE = path.join(
-  HERE,
-  '..',
-  '..',
-  'docs-screenshots',
-  '.state',
-);
 
 const VIEWPORT = { width: 1920, height: 1080 } as const;
 const DPR = 2;
@@ -85,7 +79,7 @@ function readOrgState(episode: EpisodeSpec, locale: Locale): OrgState {
   // en records against the shared docs-screenshots org; de/fr against their
   // own natively-seeded orgs (native task titles, documents, entries).
   if (locale === 'en') {
-    const orgStatePath = path.join(SCREENSHOTS_STATE, 'org.json');
+    const orgStatePath = path.join(SCREENSHOTS_STATE_DIR, 'org.json');
     if (!existsSync(orgStatePath)) {
       throw new Error(
         `No demo workspace at ${orgStatePath} — run \`bun run docs:screenshots\` once ` +
@@ -95,7 +89,7 @@ function readOrgState(episode: EpisodeSpec, locale: Locale): OrgState {
     const state = JSON.parse(readFileSync(orgStatePath, 'utf8')) as OrgState;
     return { orgId: state.orgId, projects: state.projects ?? {} };
   }
-  const localeOrgsPath = path.join(HERE, '..', '.state', 'locale-orgs.json');
+  const localeOrgsPath = path.join(STATE_DIR, 'locale-orgs.json');
   if (!existsSync(localeOrgsPath)) {
     throw new Error(
       `No locale orgs at ${localeOrgsPath} — run ` +
@@ -244,7 +238,7 @@ async function cleanupWowThread(
     return;
   const cleanupContext = await browser.newContext({
     baseURL: BASE_URL,
-    storageState: path.join(SCREENSHOTS_STATE, 'auth.json'),
+    storageState: path.join(SCREENSHOTS_STATE_DIR, 'auth.json'),
     viewport: VIEWPORT,
     locale: 'en-US',
     timezoneId: 'UTC',
@@ -461,8 +455,8 @@ export async function runRecordStage(
   try {
     const context = await browser.newContext({
       baseURL: BASE_URL,
-      ...(existsSync(path.join(SCREENSHOTS_STATE, 'auth.json'))
-        ? { storageState: path.join(SCREENSHOTS_STATE, 'auth.json') }
+      ...(existsSync(path.join(SCREENSHOTS_STATE_DIR, 'auth.json'))
+        ? { storageState: path.join(SCREENSHOTS_STATE_DIR, 'auth.json') }
         : {}),
       viewport: VIEWPORT,
       deviceScaleFactor: DPR,

--- a/services/platform/tests/docs-videos/lib/review.ts
+++ b/services/platform/tests/docs-videos/lib/review.ts
@@ -14,6 +14,7 @@ import type { AudioPlan } from './audio-plan';
 import type { EpisodeSpec, Locale } from './episode';
 import { narrationFor } from './episode';
 import { ffmpegBin, runFfmpeg } from './ffmpeg';
+import { formatClock } from './format';
 import type { RecordedTimeline } from './recorder';
 import { stripAudioTags } from './vtt';
 
@@ -27,13 +28,6 @@ interface ReviewSheetInput {
   readonly draft: boolean;
   readonly durationMs: number;
   readonly sizeMb: number;
-}
-
-function formatClock(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, '0')}.${String(Math.round((ms % 1000) / 100))}`;
 }
 
 function escapeHtml(text: string): string {

--- a/services/platform/tests/docs-videos/lib/review.ts
+++ b/services/platform/tests/docs-videos/lib/review.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-take review sheet: one static HTML page under `.state/review/` with
+ * two thumbnails per scene (entry + mid-narration), the planned vs actual
+ * timing, and the narration text — so the human QA pass starts from
+ * evidence instead of scrubbing three locales end-to-end blind. The sheet
+ * never replaces the final watch-through; it makes the fast iteration loop
+ * (draft → look → adjust) cheap.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import type { AudioPlan } from './audio-plan';
+import type { EpisodeSpec, Locale } from './episode';
+import { narrationFor } from './episode';
+import { ffmpegBin, runFfmpeg } from './ffmpeg';
+import type { RecordedTimeline } from './recorder';
+import { stripAudioTags } from './vtt';
+
+interface ReviewSheetInput {
+  readonly episode: EpisodeSpec;
+  readonly locale: Locale;
+  readonly mp4Path: string;
+  readonly recorded: RecordedTimeline;
+  readonly audioPlan: AudioPlan;
+  readonly stateDir: string;
+  readonly draft: boolean;
+  readonly durationMs: number;
+  readonly sizeMb: number;
+}
+
+function formatClock(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}.${String(Math.round((ms % 1000) / 100))}`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+async function extractThumb(
+  mp4Path: string,
+  atMs: number,
+  outPath: string,
+): Promise<void> {
+  await runFfmpeg(
+    ffmpegBin(),
+    [
+      '-y',
+      '-ss',
+      (Math.max(0, atMs) / 1000).toFixed(3),
+      '-i',
+      mp4Path,
+      '-frames:v',
+      '1',
+      '-vf',
+      'scale=480:-2',
+      '-q:v',
+      '3',
+      outPath,
+    ],
+    60_000,
+  );
+}
+
+/** Write the sheet and its thumbnails; returns the index.html path. */
+export async function writeReviewSheet(
+  input: ReviewSheetInput,
+): Promise<string> {
+  const { episode, locale, recorded, audioPlan } = input;
+  const dir = path.join(input.stateDir, 'review', `${episode.id}.${locale}`);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+
+  const maxThumbMs = Math.max(0, input.durationMs - 150);
+  const rows: string[] = [];
+  for (const scene of recorded.planned.scenes) {
+    const audio = audioPlan.scenes.find((s) => s.id === scene.id);
+    const narrationMs = audio?.durationMs ?? 0;
+    const spec = episode.scenes.find((s) => s.id === scene.id);
+    const entryAtMs = Math.min(
+      scene.startMs + Math.min(600, scene.budgetMs * 0.2),
+      maxThumbMs,
+    );
+    const midAtMs = Math.min(
+      narrationMs > 0
+        ? scene.narrationStartMs + narrationMs * 0.5
+        : scene.startMs + scene.budgetMs * 0.7,
+      maxThumbMs,
+    );
+    const entryThumb = `${scene.id}-entry.jpg`;
+    const midThumb = `${scene.id}-mid.jpg`;
+    await extractThumb(input.mp4Path, entryAtMs, path.join(dir, entryThumb));
+    await extractThumb(input.mp4Path, midAtMs, path.join(dir, midThumb));
+
+    const actualMs = recorded.actualStartsMs[scene.id];
+    const driftMs = actualMs === undefined ? null : actualMs - scene.startMs;
+    const narration = spec
+      ? stripAudioTags(narrationFor(episode, scene.id, locale))
+      : '';
+    const chapter = spec?.chapterByLocale?.[locale];
+    rows.push(`<tr>
+      <td class="id">${escapeHtml(scene.id)}${chapter ? `<span class="chapter">${escapeHtml(chapter)}${spec?.chapterTransition === 'cut' ? ' · cut' : ''}</span>` : ''}</td>
+      <td class="num">${formatClock(scene.startMs)}</td>
+      <td class="num">${(scene.budgetMs / 1000).toFixed(1)}s</td>
+      <td class="num">${narrationMs > 0 ? `${(narrationMs / 1000).toFixed(1)}s` : '—'}</td>
+      <td class="num">${driftMs === null ? '—' : `${driftMs > 0 ? '+' : ''}${driftMs}ms`}</td>
+      <td><img src="${entryThumb}" alt="${escapeHtml(scene.id)} at scene start" loading="lazy"></td>
+      <td><img src="${midThumb}" alt="${escapeHtml(scene.id)} mid narration" loading="lazy"></td>
+      <td class="narration">${escapeHtml(narration) || '<em>silent</em>'}</td>
+    </tr>`);
+  }
+
+  const title = `${episode.id} · ${locale}${input.draft ? ' · DRAFT' : ''}`;
+  const html = `<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>${escapeHtml(title)} — review sheet</title>
+<style>
+  body { font: 14px/1.45 system-ui, sans-serif; background: #0b0e14; color: #e2e8f0; margin: 24px; }
+  h1 { font-size: 18px; font-weight: 600; }
+  .meta { color: #93a4bd; margin-bottom: 16px; }
+  .draft { color: #f59e0b; font-weight: 700; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border-bottom: 1px solid #1e293b; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { color: #93a4bd; font-weight: 600; position: sticky; top: 0; background: #0b0e14; }
+  td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
+  td.id { font-weight: 600; white-space: nowrap; }
+  .chapter { display: block; color: #60a5fa; font-size: 12px; font-weight: 500; }
+  img { width: 240px; border-radius: 6px; display: block; }
+  td.narration { color: #cbd5e1; max-width: 420px; }
+</style>
+<h1>${escapeHtml(title)}${input.draft ? ' <span class="draft">draft encode — not for shipping</span>' : ''}</h1>
+<p class="meta">${(input.durationMs / 1000).toFixed(1)}s · ${input.sizeMb.toFixed(1)} MB · ${recorded.planned.scenes.length} scenes · ${escapeHtml(path.basename(input.mp4Path))}${audioPlan.estimated ? ' · <span class="draft">estimated (mock) narration</span>' : ''}</p>
+<table>
+  <tr><th>scene</th><th>start</th><th>budget</th><th>narration</th><th>drift</th><th>scene start</th><th>mid narration</th><th>script</th></tr>
+  ${rows.join('\n')}
+</table>
+</html>
+`;
+  const indexPath = path.join(dir, 'index.html');
+  writeFileSync(indexPath, html);
+  return indexPath;
+}

--- a/services/platform/tests/docs-videos/lib/scene.ts
+++ b/services/platform/tests/docs-videos/lib/scene.ts
@@ -19,6 +19,7 @@
 
 import type { Page } from '@playwright/test';
 
+import type { CleanupRegistry } from './cleanup';
 import type { Cursor } from './cursor';
 import type { Locale } from './episode';
 
@@ -56,11 +57,11 @@ export interface SceneContext {
   /** Seeded project ids by project name (docs-screenshots org state). */
   readonly projects: ReadonlyMap<string, string>;
   /**
-   * Scene-to-recorder side channel — e.g. the wow scene stores the thread id
-   * it created under `wowThreadId` so the recorder can delete it (off camera)
-   * after the take.
+   * The additive-only contract: register anything the scene creates ON
+   * CAMERA the moment it exists (thread, knowledge entry, agent, task) —
+   * the recorder sweeps it off camera after the take, even on abort.
    */
-  readonly notes: Map<string, string>;
+  readonly cleanup: CleanupRegistry;
 }
 
 export interface SceneRuntime {

--- a/services/platform/tests/docs-videos/lib/tts-cache-key.test.ts
+++ b/services/platform/tests/docs-videos/lib/tts-cache-key.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { sceneCacheKey, wholeEpisodeCacheKey } from './tts';
+
+/**
+ * Characterization lock on the TTS cache keys. The digests below were
+ * computed from the shipped implementation on 2026-07-18; if any assertion
+ * here fails, the change under review REKEYS the ElevenLabs cache — every
+ * already-paid-for narration in `.state/tts-cache/` goes stale and the next
+ * `--stage tts` re-bills the entire back catalog. That is practically never
+ * an acceptable side effect; revert the key-shape change instead of updating
+ * these values. (Deliberate rekeying — a new voice-settings epoch — must
+ * update the digests in the same change, with the re-billing called out.)
+ */
+describe('tts cache keys', () => {
+  it('pins the per-scene key for the v3 shape (no neighbour context)', () => {
+    expect(
+      sceneCacheKey('eleven_v3', { voiceId: 'VOICE_A', text: 'Hello world.' }),
+    ).toBe('60a4359c0bb0cd7742a296afb07efa776e2d7690d4c9831da5b52ae9417e2f25');
+  });
+
+  it('pins the per-scene key with previous/next context (v2 fallback)', () => {
+    expect(
+      sceneCacheKey('eleven_multilingual_v2', {
+        voiceId: 'VOICE_A',
+        text: 'Hello world.',
+        previousText: 'Before.',
+        nextText: 'After.',
+      }),
+    ).toBe('ee55237dcc99d57029190c76a917800c9dd8d768f58d76abff1e750b5880600b');
+  });
+
+  it('pins the whole-episode key', () => {
+    expect(
+      wholeEpisodeCacheKey('eleven_v3', 'VOICE_A', 'Scene one.\n\nScene two.'),
+    ).toBe('42e17d19fdc1b40190f2c9a22e1ac9b84560b28569e87b63b4ced0259481cc24');
+  });
+
+  it('keys ignore absent-vs-empty neighbour context (same bytes)', () => {
+    expect(sceneCacheKey('eleven_v3', { voiceId: 'V', text: 'T' })).toBe(
+      sceneCacheKey('eleven_v3', {
+        voiceId: 'V',
+        text: 'T',
+        previousText: '',
+        nextText: '',
+      }),
+    );
+  });
+});

--- a/services/platform/tests/docs-videos/lib/tts-mock.ts
+++ b/services/platform/tests/docs-videos/lib/tts-mock.ts
@@ -1,0 +1,55 @@
+/**
+ * Mock narration for REHEARSAL takes (`--mock-tts`): estimated-length
+ * silence instead of ElevenLabs — so choreography, timeline fit, and the
+ * whole record→compose machinery can be exercised with zero billing, no API
+ * key, and no network. The resulting audio plan is marked `estimated`; the
+ * compose stage refuses to ship it anywhere but `.state/` (drafts and
+ * diagnostics), because estimated durations place every cue slightly off.
+ */
+
+import { existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { estimateSpeechMs } from './estimate';
+import { ffmpegBin, runFfmpeg } from './ffmpeg';
+
+interface MockNarrationResult {
+  readonly mp3Path: string;
+  readonly durationMs: number;
+  readonly cached: boolean;
+}
+
+/**
+ * One silent mp3 of the text's estimated speaking length, cache-first.
+ * Silence is content-free, so the cache keys on duration alone.
+ */
+export async function synthesizeMockNarration(
+  text: string,
+  stateDir: string,
+): Promise<MockNarrationResult> {
+  const durationMs = estimateSpeechMs(text);
+  if (durationMs <= 0) return { mp3Path: '', durationMs: 0, cached: true };
+  const dir = path.join(stateDir, 'tts-mock');
+  const mp3Path = path.join(dir, `silence-${durationMs}ms.mp3`);
+  if (existsSync(mp3Path)) return { mp3Path, durationMs, cached: true };
+  mkdirSync(dir, { recursive: true });
+  await runFfmpeg(
+    ffmpegBin(),
+    [
+      '-y',
+      '-f',
+      'lavfi',
+      '-i',
+      'anullsrc=r=44100:cl=mono',
+      '-t',
+      (durationMs / 1000).toFixed(3),
+      '-c:a',
+      'libmp3lame',
+      '-q:a',
+      '9',
+      mp3Path,
+    ],
+    60_000,
+  );
+  return { mp3Path, durationMs, cached: false };
+}

--- a/services/platform/tests/docs-videos/lib/tts.ts
+++ b/services/platform/tests/docs-videos/lib/tts.ts
@@ -17,7 +17,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { probeDurationMs } from './ffmpeg';
+import { ffmpegBin, probeDurationMs, runFfmpeg } from './ffmpeg';
 
 const API_BASE = 'https://api.elevenlabs.io';
 const PREFERRED_MODEL = 'eleven_v3';
@@ -94,7 +94,16 @@ interface CacheSidecar {
   readonly characters: number;
 }
 
-function cacheKey(model: string, request: SynthesisRequest): string {
+/**
+ * Cache key of one per-scene generation. BYTE-STABLE CONTRACT: the JSON
+ * field set, order, and constant values must never change — every cached
+ * mp3 under `.state/tts-cache/` is keyed by this, and a drifted key
+ * re-bills the entire back catalog (pinned by tts-cache-key.test.ts).
+ */
+export function sceneCacheKey(
+  model: string,
+  request: SynthesisRequest,
+): string {
   return createHash('sha256')
     .update(
       JSON.stringify({
@@ -161,7 +170,7 @@ export async function synthesize(
     model === PREFERRED_MODEL
       ? { text: request.text, voiceId: request.voiceId }
       : request;
-  const key = cacheKey(model, effective);
+  const key = sceneCacheKey(model, effective);
   const cacheDir = path.join(stateDir, 'tts-cache');
   const mp3Path = path.join(cacheDir, `${key}.mp3`);
   const sidecarPath = path.join(cacheDir, `${key}.json`);
@@ -227,6 +236,30 @@ const SLICE_LEAD_SEC = 0.08;
 const SLICE_TAIL_SEC = 0.15;
 
 /**
+ * Cache key of one whole-episode generation. Same byte-stability contract
+ * as `sceneCacheKey` (pinned by tts-cache-key.test.ts).
+ */
+export function wholeEpisodeCacheKey(
+  model: string,
+  voiceId: string,
+  joined: string,
+): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        kind: 'whole-episode-v1',
+        model,
+        voiceId,
+        joined,
+        settings: VOICE_SETTINGS,
+        seed: SEED,
+        format: OUTPUT_FORMAT,
+      }),
+    )
+    .digest('hex');
+}
+
+/**
  * Synthesize a whole episode's narration as ONE generation and slice it into
  * per-scene mp3s via the character-timestamp alignment. One generation means
  * one consistent delivery — per-scene generations audibly drift in tone
@@ -243,19 +276,7 @@ export async function synthesizeEpisodeWhole(
   const model = await resolveTtsModel();
   const spoken = texts.map((t) => t.trim());
   const joined = spoken.filter(Boolean).join('\n\n');
-  const key = createHash('sha256')
-    .update(
-      JSON.stringify({
-        kind: 'whole-episode-v1',
-        model,
-        voiceId,
-        joined,
-        settings: VOICE_SETTINGS,
-        seed: SEED,
-        format: OUTPUT_FORMAT,
-      }),
-    )
-    .digest('hex');
+  const key = wholeEpisodeCacheKey(model, voiceId, joined);
   const cacheDir = path.join(stateDir, 'tts-cache');
   const wholePath = path.join(cacheDir, `${key}.whole.mp3`);
   const sidecarPath = path.join(cacheDir, `${key}.whole.json`);
@@ -326,8 +347,6 @@ export async function synthesizeEpisodeWhole(
     ] ?? 0;
 
   // Locate each scene's character span inside `joined` and cut around it.
-  const { runFfmpeg: run } = await import('./ffmpeg');
-  const { ffmpegBin: bin } = await import('./ffmpeg');
   const slices: EpisodeSliceResult[] = [];
   const sidecarSlices: { file: string; durationMs: number }[] = [];
   let cursor = 0;
@@ -355,8 +374,8 @@ export async function synthesizeEpisodeWhole(
     previousEndSec = endSec;
     const file = `${key}.scene-${index}.mp3`;
     const slicePath = path.join(cacheDir, file);
-    await run(
-      bin(),
+    await runFfmpeg(
+      ffmpegBin(),
       [
         '-y',
         '-i',

--- a/services/platform/tests/docs-videos/lib/validate.ts
+++ b/services/platform/tests/docs-videos/lib/validate.ts
@@ -1,0 +1,188 @@
+/**
+ * Static validation of episode specs and their choreography — everything
+ * that can be proven WITHOUT a stack, a key, or a take. The type system
+ * already guards the typed shapes; this catches the cross-file and
+ * cross-system drift it cannot see:
+ *
+ *  - episode.ts ↔ scenes.ts scene-id parity (the join key of the pipeline),
+ *  - per-locale narration consistency (a locale is all scenes or none),
+ *  - hero prompts pairing with a `DOCS_REPLIES` match clause (an unpaired
+ *    prompt streams the visibly synthetic e2e canned reply on camera),
+ *  - the outro's room for the compose fade-out.
+ *
+ * Runs as `--stage check`, automatically before tts/record/compose, and as
+ * the always-on vitest gate (`episodes.test.ts`) so drift fails `bun run
+ * check` long before a take burns minutes discovering it.
+ */
+
+import { DOCS_REPLIES } from '../../../lib/mocks/overrides/docs-replies';
+import type { EpisodeSpec } from './episode';
+import { LOCALES } from './episode';
+import type { ChoreographyModule } from './episodes';
+import { DEFAULT_TAIL_MS } from './timeline';
+
+/** The compose bookend: 1.5 s fade-out that must land inside the outro. */
+const FADE_OUT_ROOM_MS = 2000;
+
+export interface ValidationFinding {
+  readonly severity: 'error' | 'warning';
+  /** `episode-id` or `episode-id/scene-id`. */
+  readonly where: string;
+  readonly detail: string;
+}
+
+function listPreview(values: readonly string[], max = 5): string {
+  const preview = values.slice(0, max).join(', ');
+  return values.length > max
+    ? `${preview}, … (${values.length} total)`
+    : preview;
+}
+
+export function validateEpisodeSpec(episode: EpisodeSpec): ValidationFinding[] {
+  const findings: ValidationFinding[] = [];
+  const error = (where: string, detail: string) =>
+    findings.push({ severity: 'error', where, detail });
+  const warning = (where: string, detail: string) =>
+    findings.push({ severity: 'warning', where, detail });
+
+  if (episode.scenes.length === 0) {
+    error(episode.id, 'has no scenes');
+    return findings;
+  }
+
+  // Scene ids are the pipeline's join key — unique and non-empty.
+  const seen = new Set<string>();
+  for (const scene of episode.scenes) {
+    if (!scene.id.trim()) error(episode.id, 'a scene has an empty id');
+    if (seen.has(scene.id)) {
+      error(`${episode.id}/${scene.id}`, 'duplicate scene id');
+    }
+    seen.add(scene.id);
+    if (
+      (scene.leadInMs ?? 0) < 0 ||
+      (scene.tailMs ?? 0) < 0 ||
+      (scene.minMs ?? 0) < 0
+    ) {
+      error(`${episode.id}/${scene.id}`, 'negative timing override');
+    }
+    if (scene.chapterTransition && !scene.chapterByLocale) {
+      error(
+        `${episode.id}/${scene.id}`,
+        'chapterTransition without chapterByLocale — the transition has no card to play',
+      );
+    }
+  }
+
+  // A locale is authored for ALL scenes or NONE — a partial locale records
+  // a take with silent holes. (Explicit '' is a deliberate silent scene.)
+  const completeLocales = LOCALES.filter((locale) =>
+    episode.scenes.every((scene) => scene.narration[locale] !== undefined),
+  );
+  for (const locale of LOCALES) {
+    if (completeLocales.includes(locale)) continue;
+    const present = episode.scenes.filter(
+      (scene) => scene.narration[locale] !== undefined,
+    );
+    if (present.length === 0) continue; // not started — fine mid-authoring
+    const missing = episode.scenes
+      .filter((scene) => scene.narration[locale] === undefined)
+      .map((scene) => scene.id);
+    error(
+      episode.id,
+      `${locale} narration covers ${present.length}/${episode.scenes.length} scenes — missing: ${listPreview(missing)}`,
+    );
+  }
+  if (completeLocales.length === 0) {
+    error(episode.id, 'no locale has complete narration');
+  }
+
+  for (const locale of LOCALES) {
+    if (!episode.voices[locale]?.trim()) {
+      error(episode.id, `no ${locale} voice id`);
+    }
+  }
+
+  // The compose stage fades out over the last 1.5 s — the outro needs room,
+  // or the ending is audibly/visually clipped. (Diagnostic output never
+  // ships, so a clipped probe tail is fine.)
+  const outro = episode.scenes.at(-1);
+  if (
+    !episode.diagnostic &&
+    outro &&
+    (outro.tailMs ?? DEFAULT_TAIL_MS) < FADE_OUT_ROOM_MS
+  ) {
+    warning(
+      `${episode.id}/${outro.id}`,
+      `last scene tailMs ${outro.tailMs ?? DEFAULT_TAIL_MS}ms < ${FADE_OUT_ROOM_MS}ms — the 1.5s fade-out will clip it`,
+    );
+  }
+
+  // A hero prompt that pairs with no DOCS_REPLIES match clause streams the
+  // visibly synthetic e2e canned reply on camera (the #1 wow-scene failure).
+  if (!episode.diagnostic) {
+    for (const locale of LOCALES) {
+      const prompt = episode.heroPromptByLocale?.[locale];
+      if (!prompt) continue;
+      const paired = DOCS_REPLIES.some((reply) =>
+        prompt.toLowerCase().includes(reply.match),
+      );
+      if (!paired) {
+        error(
+          episode.id,
+          `${locale} hero prompt pairs with no DOCS_REPLIES match clause — ` +
+            `add/adjust the entry in lib/mocks/overrides/docs-replies.ts ` +
+            `(the take would stream the canned e2e reply)`,
+        );
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function validateChoreography(
+  episode: EpisodeSpec,
+  module: ChoreographyModule,
+): ValidationFinding[] {
+  const findings: ValidationFinding[] = [];
+  const error = (where: string, detail: string) =>
+    findings.push({ severity: 'error', where, detail });
+
+  const specIds = new Set(episode.scenes.map((scene) => scene.id));
+  const choreoIds = new Set<string>();
+  for (const scene of module.SCENES) {
+    if (choreoIds.has(scene.id)) {
+      error(`${episode.id}/${scene.id}`, 'duplicate choreography id');
+    }
+    choreoIds.add(scene.id);
+    if (!specIds.has(scene.id)) {
+      error(
+        `${episode.id}/${scene.id}`,
+        'choreography for a scene episode.ts does not declare',
+      );
+    }
+  }
+  for (const id of specIds) {
+    if (!choreoIds.has(id)) {
+      error(`${episode.id}/${id}`, 'scene has no choreography in scenes.ts');
+    }
+  }
+  if (!episode.diagnostic && typeof module.warmup !== 'function') {
+    error(
+      episode.id,
+      'scenes.ts exports no warmup — every surface the take visits must be ' +
+        'compiled and warmed before the screencast starts',
+    );
+  }
+  return findings;
+}
+
+/** Console rendering: one aligned line per finding. */
+export function formatFindings(findings: readonly ValidationFinding[]): string {
+  return findings
+    .map(
+      (finding) =>
+        `  ${finding.severity === 'error' ? '✗' : '⚠'} ${finding.where} — ${finding.detail}`,
+    )
+    .join('\n');
+}

--- a/services/platform/tests/docs-videos/lib/verify.test.ts
+++ b/services/platform/tests/docs-videos/lib/verify.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSpeechIntervals, verifySpeechCoverage } from './verify';
+
+const STDERR_SAMPLE = `
+[silencedetect @ 0x600] silence_start: 0
+[silencedetect @ 0x600] silence_end: 1.7 | silence_duration: 1.7
+[silencedetect @ 0x600] silence_start: 9.2
+[silencedetect @ 0x600] silence_end: 10.4 | silence_duration: 1.2
+[silencedetect @ 0x600] silence_start: 18.05
+`;
+
+describe('parseSpeechIntervals', () => {
+  it('inverts silences into speech over the track, closing a trailing open silence', () => {
+    expect(parseSpeechIntervals(STDERR_SAMPLE, 20_000)).toEqual([
+      { startMs: 1700, endMs: 9200 },
+      { startMs: 10_400, endMs: 18_050 },
+    ]);
+  });
+
+  it('treats a track with no detected silence as fully audible', () => {
+    expect(parseSpeechIntervals('', 5000)).toEqual([
+      { startMs: 0, endMs: 5000 },
+    ]);
+  });
+});
+
+describe('verifySpeechCoverage', () => {
+  const speech = [{ startMs: 1700, endMs: 9200 }];
+
+  it('passes a well-covered narration window', () => {
+    expect(
+      verifySpeechCoverage(
+        [{ id: 'intro', startMs: 1500, durationMs: 7000 }],
+        speech,
+      ),
+    ).toEqual([]);
+  });
+
+  it('flags a silent narration window', () => {
+    const issues = verifySpeechCoverage(
+      [{ id: 'lost-scene', startMs: 12_000, durationMs: 4000 }],
+      speech,
+    );
+    expect(issues).toHaveLength(2); // silent window + early-speech offset
+    expect(issues[0]?.where).toBe('lost-scene');
+    expect(issues[0]?.detail).toContain('0% audible');
+  });
+
+  it('flags speech well before the first narration (global offset)', () => {
+    const issues = verifySpeechCoverage(
+      [{ id: 'title', startMs: 5000, durationMs: 4000 }],
+      [{ startMs: 500, endMs: 9000 }],
+    );
+    expect(issues.some((issue) => issue.where === 'lead-in')).toBe(true);
+  });
+});

--- a/services/platform/tests/docs-videos/lib/verify.ts
+++ b/services/platform/tests/docs-videos/lib/verify.ts
@@ -1,0 +1,183 @@
+/**
+ * Post-compose A/V verification — the automatable half of the "watch it
+ * end-to-end" QA gate. What the spike-sync probe proves by hand, this proves
+ * on every compose:
+ *
+ *  1. the container's duration matches the planned timeline,
+ *  2. audible speech actually covers each narrated window (silencedetect →
+ *     speech intervals → per-scene coverage), so a silent track, a missing
+ *     scene, or a global audio offset can never ship unheard,
+ *  3. no speech plays before the first narration is due (offset bugs).
+ *
+ * The interval math is pure and unit-tested; only `verifyComposedEpisode`
+ * touches ffmpeg. Coverage thresholds are deliberately generous — loudnorm
+ * dynamics and intra-narration pauses eat real coverage; the gate hunts
+ * broken tracks, not prosody.
+ */
+
+import type { AudioPlan } from './audio-plan';
+import { ffmpegBin, probeDurationMs, runFfmpeg } from './ffmpeg';
+import type { RecordedTimeline } from './recorder';
+
+/** silencedetect noise floor / minimum silence length. */
+const SILENCE_ARGS = 'silencedetect=n=-35dB:d=0.35';
+/** A narrated window must be at least this fraction audible. */
+const MIN_SPEECH_COVERAGE = 0.55;
+/** Slack before the first narration where speech may already exist. */
+const EARLY_SPEECH_SLACK_MS = 700;
+/** Composed duration may differ from the plan by at most this much. */
+const MAX_DURATION_DELTA_MS = 800;
+
+export interface SpeechInterval {
+  readonly startMs: number;
+  readonly endMs: number;
+}
+
+export interface VerifyIssue {
+  readonly where: string;
+  readonly detail: string;
+}
+
+/**
+ * Parse ffmpeg `silencedetect` stderr into SPEECH intervals over
+ * `[0, totalMs]` (the inverse of the reported silences).
+ */
+export function parseSpeechIntervals(
+  ffmpegStderr: string,
+  totalMs: number,
+): SpeechInterval[] {
+  const silences: { startMs: number; endMs: number }[] = [];
+  let openStartMs: number | null = null;
+  for (const match of ffmpegStderr.matchAll(
+    /silence_(start|end):\s*(-?[\d.]+)/g,
+  )) {
+    const kind = match[1];
+    const atMs = Math.max(0, Math.round(Number(match[2]) * 1000));
+    if (kind === 'start') {
+      openStartMs = atMs;
+    } else if (openStartMs !== null) {
+      silences.push({ startMs: openStartMs, endMs: atMs });
+      openStartMs = null;
+    }
+  }
+  // A silence still open at EOF runs to the end of the track.
+  if (openStartMs !== null) {
+    silences.push({ startMs: openStartMs, endMs: totalMs });
+  }
+
+  const speech: SpeechInterval[] = [];
+  let cursor = 0;
+  for (const silence of silences) {
+    if (silence.startMs > cursor) {
+      speech.push({ startMs: cursor, endMs: silence.startMs });
+    }
+    cursor = Math.max(cursor, silence.endMs);
+  }
+  if (cursor < totalMs) speech.push({ startMs: cursor, endMs: totalMs });
+  return speech;
+}
+
+function overlapMs(
+  interval: SpeechInterval,
+  startMs: number,
+  endMs: number,
+): number {
+  return Math.max(
+    0,
+    Math.min(interval.endMs, endMs) - Math.max(interval.startMs, startMs),
+  );
+}
+
+interface NarratedWindow {
+  readonly id: string;
+  readonly startMs: number;
+  readonly durationMs: number;
+}
+
+/** Pure coverage check: every narrated window ≥ threshold audible. */
+export function verifySpeechCoverage(
+  windows: readonly NarratedWindow[],
+  speech: readonly SpeechInterval[],
+): VerifyIssue[] {
+  const issues: VerifyIssue[] = [];
+  for (const window of windows) {
+    const audible = speech.reduce(
+      (sum, interval) =>
+        sum +
+        overlapMs(interval, window.startMs, window.startMs + window.durationMs),
+      0,
+    );
+    const coverage = window.durationMs > 0 ? audible / window.durationMs : 1;
+    if (coverage < MIN_SPEECH_COVERAGE) {
+      issues.push({
+        where: window.id,
+        detail:
+          `narration window ${window.startMs}–${window.startMs + window.durationMs}ms is only ` +
+          `${Math.round(coverage * 100)}% audible (need ≥${Math.round(MIN_SPEECH_COVERAGE * 100)}%) — ` +
+          `silent/missing narration or A/V offset`,
+      });
+    }
+  }
+  const firstNarrationMs = windows[0]?.startMs;
+  if (firstNarrationMs !== undefined) {
+    const early = speech.find(
+      (interval) => interval.startMs < firstNarrationMs - EARLY_SPEECH_SLACK_MS,
+    );
+    if (early) {
+      issues.push({
+        where: 'lead-in',
+        detail: `speech at ${early.startMs}ms but the first narration is planned at ${firstNarrationMs}ms — global audio offset`,
+      });
+    }
+  }
+  return issues;
+}
+
+interface VerifyOptions {
+  /** `--mock-tts` plans carry silence — coverage would always fail. */
+  readonly audioIsSilent: boolean;
+}
+
+/**
+ * Run the full verification against a composed mp4. Returns issues instead
+ * of throwing so the compose stage can aggregate and report them all.
+ */
+export async function verifyComposedEpisode(
+  mp4Path: string,
+  recorded: RecordedTimeline,
+  audioPlan: AudioPlan,
+  options: VerifyOptions,
+): Promise<VerifyIssue[]> {
+  const issues: VerifyIssue[] = [];
+  const plannedMs = recorded.planned.totalMs;
+  const actualMs = await probeDurationMs(mp4Path);
+  if (Math.abs(actualMs - plannedMs) > MAX_DURATION_DELTA_MS) {
+    issues.push({
+      where: 'duration',
+      detail: `composed ${actualMs}ms vs planned ${plannedMs}ms (|Δ| > ${MAX_DURATION_DELTA_MS}ms)`,
+    });
+  }
+  if (options.audioIsSilent) return issues;
+
+  const windows: NarratedWindow[] = recorded.planned.scenes.flatMap((scene) => {
+    const audio = audioPlan.scenes.find((s) => s.id === scene.id);
+    if (!audio || audio.durationMs <= 0) return [];
+    return [
+      {
+        id: scene.id,
+        startMs: scene.narrationStartMs,
+        durationMs: audio.durationMs,
+      },
+    ];
+  });
+  if (windows.length === 0) return issues;
+
+  const { stderr } = await runFfmpeg(
+    ffmpegBin(),
+    ['-i', mp4Path, '-map', '0:a:0', '-af', SILENCE_ARGS, '-f', 'null', '-'],
+    120_000,
+  );
+  const speech = parseSpeechIntervals(stderr, actualMs || plannedMs);
+  issues.push(...verifySpeechCoverage(windows, speech));
+  return issues;
+}

--- a/services/platform/tests/docs-videos/lib/verify.ts
+++ b/services/platform/tests/docs-videos/lib/verify.ts
@@ -28,12 +28,12 @@ const EARLY_SPEECH_SLACK_MS = 700;
 /** Composed duration may differ from the plan by at most this much. */
 const MAX_DURATION_DELTA_MS = 800;
 
-export interface SpeechInterval {
+interface SpeechInterval {
   readonly startMs: number;
   readonly endMs: number;
 }
 
-export interface VerifyIssue {
+interface VerifyIssue {
   readonly where: string;
   readonly detail: string;
 }

--- a/services/platform/tests/docs-videos/produce.ts
+++ b/services/platform/tests/docs-videos/produce.ts
@@ -2,148 +2,164 @@
  * Docs tutorial-video producer. Every committed video under
  * `services/docs/public/videos/` is produced by this script from a declarative
  * episode spec (`episodes/<id>/episode.ts`) — no hand-recorded video ever
- * ships (the doctrine lives in the `produce-video` skill).
+ * ships (the doctrine lives in the `produce-video` skill, the runbook in
+ * README.md, `--help` in lib/cli.ts).
  *
- *   bun run docs:videos                                   # ep1, en, all stages
- *   bun run docs:videos -- --episode ep1-welcome --locale en,de,fr
- *   bun run docs:videos -- --stage tts                    # narration only
- *   bun run docs:videos -- --stage record                 # needs the Mode-A stack
- *   bun run docs:videos -- --stage compose                # ffmpeg assembly only
- *   bun run docs:videos -- --list                         # enumerate episodes
- *   bun run docs:videos -- --audition                     # voice candidates → .state/audition/
- *
- * Stages are separable on purpose: TTS bills per character (cache-first,
- * `lib/tts.ts`), recording needs the running docs-demo stack (same runbook as
- * docs:screenshots — see README.md), compose needs only ffmpeg. The narration
- * audio plan produced by `tts` (`.state/tts/<episode>.<locale>.json`) is the
- * contract the other two stages build on.
+ * Stages are separable on purpose: `check` and `plan` are free and instant,
+ * `tts` bills per character (cache-first, `lib/tts.ts` — or `--mock-tts`
+ * rehearsal silence for zero-cost iteration), `record` needs the running
+ * docs-demo stack (preflighted by `lib/doctor.ts`), `compose` needs only
+ * ffmpeg (`--draft` for the fast review loop). The narration audio plan
+ * written by `tts` (`.state/tts/<episode>.<locale>.json`) is the contract
+ * the other stages build on.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { EP1_WELCOME } from './episodes/ep1-welcome/episode';
-import { EP2_CHAT } from './episodes/ep2-chat/episode';
-import { EP3_KNOWLEDGE } from './episodes/ep3-knowledge/episode';
-import { EP4_AGENT } from './episodes/ep4-agent/episode';
-import { EP5_AUTOMATIONS } from './episodes/ep5-automations/episode';
-import { EP6_PROJECTS } from './episodes/ep6-projects/episode';
-import { EP7_INTEGRATIONS } from './episodes/ep7-integrations/episode';
-import { EP8_PEOPLE } from './episodes/ep8-people/episode';
-import { EP9_GOVERNANCE } from './episodes/ep9-governance/episode';
-import { EP10_DEVELOPERS } from './episodes/ep10-developers/episode';
-import { SPIKE_SYNC } from './episodes/spike-sync/episode';
 import { audioPlanPath, type AudioPlan } from './lib/audio-plan';
+import {
+  CliUsageError,
+  helpText,
+  parseCliArgs,
+  type CliOptions,
+} from './lib/cli';
 import { loadDevEnv } from './lib/dev-env';
+import { doctorHasFailures, formatDoctorReport, runDoctor } from './lib/doctor';
 import {
   LOCALES,
   narrationFor,
   type EpisodeSpec,
   type Locale,
 } from './lib/episode';
+import { loadChoreography, loadEpisodes } from './lib/episodes';
+import { estimateSpeechMs } from './lib/estimate';
 import { ensureFfmpegAvailable } from './lib/ffmpeg';
+import { formatClock } from './lib/format';
+import { STATE_DIR } from './lib/paths';
+import { planTimeline } from './lib/timeline';
 import {
   elevenLabsApiKey,
   resolveTtsModel,
   synthesize,
   synthesizeEpisodeWhole,
 } from './lib/tts';
+import { synthesizeMockNarration } from './lib/tts-mock';
 import { toSpokenText } from './lib/tts-text';
+import {
+  formatFindings,
+  validateChoreography,
+  validateEpisodeSpec,
+  type ValidationFinding,
+} from './lib/validate';
 
 // Dev-tooling secrets live in the repo-root `.env.dev` (never the platform's
 // own env files) — load them before anything reads process.env.
 loadDevEnv();
 
-const EPISODES: readonly EpisodeSpec[] = [
-  EP1_WELCOME,
-  EP2_CHAT,
-  EP3_KNOWLEDGE,
-  EP4_AGENT,
-  EP5_AUTOMATIONS,
-  EP6_PROJECTS,
-  EP7_INTEGRATIONS,
-  EP8_PEOPLE,
-  EP9_GOVERNANCE,
-  EP10_DEVELOPERS,
-  SPIKE_SYNC,
-];
-
-const HERE = path.dirname(new URL(import.meta.url).pathname);
-export const STATE_DIR = path.join(HERE, '.state');
-
-type Stage = 'tts' | 'record' | 'compose' | 'all';
-
-interface CliArgs {
-  episode: string;
-  locales: Locale[];
-  stage: Stage;
-  list: boolean;
-  audition: boolean;
+/**
+ * Static validation, printed. `withChoreography: false` while a script is
+ * still narration-only (the storyboard-first workflow TTSes before scenes.ts
+ * exists); record/compose always validate both sides.
+ */
+async function runCheckStage(
+  episode: EpisodeSpec,
+  withChoreography: boolean,
+): Promise<boolean> {
+  const findings: ValidationFinding[] = [...validateEpisodeSpec(episode)];
+  if (withChoreography) {
+    try {
+      findings.push(
+        ...validateChoreography(episode, await loadChoreography(episode.id)),
+      );
+    } catch (error) {
+      findings.push({
+        severity: 'error',
+        where: episode.id,
+        detail: `scenes.ts failed to load: ${String(error)}`,
+      });
+    }
+  }
+  if (findings.length > 0) console.log(formatFindings(findings));
+  const errors = findings.filter((finding) => finding.severity === 'error');
+  if (errors.length === 0 && findings.length === 0) {
+    console.log(`  ✓ ${episode.id} — spec and choreography are consistent`);
+  }
+  return errors.length === 0;
 }
 
-function parseArgs(argv: string[]): CliArgs {
-  const args: CliArgs = {
-    episode: 'ep1-welcome',
-    locales: ['en'],
-    stage: 'all',
-    list: false,
-    audition: false,
-  };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === '--list') args.list = true;
-    else if (arg === '--audition') args.audition = true;
-    else if (arg === '--episode') args.episode = argv[++i] ?? '';
-    else if (arg === '--stage') args.stage = (argv[++i] ?? 'all') as Stage;
-    else if (arg === '--locale') {
-      const requested = (argv[++i] ?? '').split(',').filter(Boolean);
-      const invalid = requested.filter((l) => !LOCALES.includes(l as Locale));
-      if (invalid.length > 0) {
-        throw new Error(
-          `Unknown locale(s): ${invalid.join(', ')} (valid: ${LOCALES.join(', ')})`,
-        );
-      }
-      args.locales = requested as Locale[];
-    } else throw new Error(`Unknown argument: ${arg}`);
-  }
-  if (!['tts', 'record', 'compose', 'all'].includes(args.stage)) {
-    throw new Error(`Unknown stage: ${args.stage}`);
-  }
-  return args;
+/** The spoken (respelled) narration per scene — the TTS/plan input. */
+function spokenTexts(episode: EpisodeSpec, locale: Locale): string[] {
+  return episode.scenes.map((scene) =>
+    toSpokenText(narrationFor(episode, scene.id, locale), locale),
+  );
 }
 
-function findEpisode(id: string): EpisodeSpec {
-  const episode = EPISODES.find((e) => e.id === id);
-  if (!episode) {
-    throw new Error(
-      `Unknown episode "${id}". Known: ${EPISODES.map((e) => e.id).join(', ')}`,
-    );
-  }
-  return episode;
+function writeAudioPlan(plan: AudioPlan): void {
+  const planPath = audioPlanPath(STATE_DIR, plan.episodeId, plan.locale);
+  mkdirSync(path.dirname(planPath), { recursive: true });
+  writeFileSync(planPath, `${JSON.stringify(plan, null, 2)}\n`);
 }
 
 /**
- * Synthesize every scene's narration for one locale, cache-first, passing
- * neighbouring scene texts as previous/next context so prosody flows across
- * cuts. Writes the audio plan JSON.
+ * Synthesize every scene's narration for one locale and write the audio
+ * plan. Three sources, one plan shape: `--mock-tts` estimated silence
+ * (free), a whole-episode generation sliced by character timestamps
+ * (consistent delivery), or per-scene generations with neighbour context.
  */
 async function runTtsStage(
   episode: EpisodeSpec,
   locale: Locale,
+  mockTts: boolean,
 ): Promise<void> {
   const voiceId = episode.voices[locale];
-  const model = await resolveTtsModel();
-  // The synthesizer gets the SPOKEN respelling (brand pronunciation etc.);
-  // captions and the episode spec keep the written form.
-  const texts = episode.scenes.map((scene) =>
-    toSpokenText(narrationFor(episode, scene.id, locale), locale),
-  );
+  const texts = spokenTexts(episode, locale);
   const planScenes: AudioPlan['scenes'][number][] = [];
   let billed = 0;
   let cachedCount = 0;
-  if (episode.wholeTakeLocales?.includes(locale)) {
+  let model: string;
+
+  const logScene = (
+    sceneId: string,
+    entry: { durationMs: number; cached: boolean },
+    flavour: 'mock' | 'whole' | 'scene',
+  ) => {
+    if (entry.durationMs <= 0) {
+      console.log(`  ∅ ${locale}/${sceneId} — silent`);
+      return;
+    }
+    const glyph = flavour === 'mock' ? '≈' : entry.cached ? '≡' : '♪';
+    const suffix = [
+      flavour === 'mock' ? 'estimated silence' : null,
+      flavour === 'whole' ? 'whole take' : null,
+      entry.cached && flavour !== 'mock' ? 'cached' : null,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    console.log(
+      `  ${glyph} ${locale}/${sceneId} — ${(entry.durationMs / 1000).toFixed(1)}s${suffix ? ` (${suffix})` : ''}`,
+    );
+  };
+
+  if (mockTts) {
+    model = 'mock-silence';
+    for (const [index, scene] of episode.scenes.entries()) {
+      const result = await synthesizeMockNarration(
+        texts[index] ?? '',
+        STATE_DIR,
+      );
+      if (result.cached && result.durationMs > 0) cachedCount += 1;
+      planScenes.push({
+        id: scene.id,
+        mp3Path: result.mp3Path,
+        durationMs: result.durationMs,
+      });
+      logScene(scene.id, result, 'mock');
+    }
+  } else if (episode.wholeTakeLocales?.includes(locale)) {
     // One generation for the whole episode → consistent delivery; sliced
     // into per-scene mp3s by character timestamps.
+    model = await resolveTtsModel();
     const whole = await synthesizeEpisodeWhole(texts, voiceId, STATE_DIR);
     billed = whole.billedCharacters;
     for (const [index, scene] of episode.scenes.entries()) {
@@ -159,78 +175,124 @@ async function runTtsStage(
         mp3Path: slice.mp3Path,
         durationMs: slice.durationMs,
       });
-      console.log(
-        `  ${slice.cached ? '≡' : '♪'} ${locale}/${scene.id} — ${(slice.durationMs / 1000).toFixed(1)}s (whole take${slice.cached ? ', cached' : ''})`,
+      logScene(scene.id, slice, 'whole');
+    }
+  } else {
+    model = await resolveTtsModel();
+    for (const [index, scene] of episode.scenes.entries()) {
+      const text = texts[index] ?? '';
+      if (!text.trim()) {
+        // Deliberately silent scene — nothing to synthesize.
+        planScenes.push({ id: scene.id, mp3Path: '', durationMs: 0 });
+        console.log(`  ∅ ${locale}/${scene.id} — silent`);
+        continue;
+      }
+      const result = await synthesize(
+        {
+          text,
+          voiceId,
+          previousText: texts[index - 1],
+          nextText: texts[index + 1],
+        },
+        STATE_DIR,
       );
+      billed += result.characters;
+      if (result.cached) cachedCount += 1;
+      planScenes.push({
+        id: scene.id,
+        mp3Path: result.mp3Path,
+        durationMs: result.durationMs,
+      });
+      logScene(scene.id, result, 'scene');
     }
-    const wholePlan: AudioPlan = {
-      episodeId: episode.id,
-      locale,
-      voiceId,
-      model,
-      scenes: planScenes,
-    };
-    mkdirSync(path.dirname(audioPlanPath(STATE_DIR, episode.id, locale)), {
-      recursive: true,
-    });
-    writeFileSync(
-      audioPlanPath(STATE_DIR, episode.id, locale),
-      `${JSON.stringify(wholePlan, null, 2)}\n`,
-    );
-    const wholeTotal = planScenes.reduce((sum, s) => sum + s.durationMs, 0);
-    console.log(
-      `TTS ${episode.id}/${locale}: ${planScenes.length} scenes, ${(wholeTotal / 1000).toFixed(1)}s narration (single take), ` +
-        `${billed} characters billed.`,
-    );
-    return;
   }
-  for (const [index, scene] of episode.scenes.entries()) {
-    const text = texts[index] ?? '';
-    if (!text.trim()) {
-      // Deliberately silent scene — nothing to synthesize.
-      planScenes.push({ id: scene.id, mp3Path: '', durationMs: 0 });
-      console.log(`  ∅ ${locale}/${scene.id} — silent`);
-      continue;
-    }
-    const result = await synthesize(
-      {
-        text,
-        voiceId,
-        previousText: texts[index - 1],
-        nextText: texts[index + 1],
-      },
-      STATE_DIR,
-    );
-    billed += result.characters;
-    if (result.cached) cachedCount += 1;
-    planScenes.push({
-      id: scene.id,
-      mp3Path: result.mp3Path,
-      durationMs: result.durationMs,
-    });
-    console.log(
-      `  ${result.cached ? '≡' : '♪'} ${locale}/${scene.id} — ${(result.durationMs / 1000).toFixed(1)}s${result.cached ? ' (cached)' : ''}`,
-    );
-  }
-  const plan: AudioPlan = {
+
+  writeAudioPlan({
     episodeId: episode.id,
     locale,
     voiceId,
     model,
+    ...(mockTts ? { estimated: true } : {}),
     scenes: planScenes,
-  };
-  mkdirSync(path.dirname(audioPlanPath(STATE_DIR, episode.id, locale)), {
-    recursive: true,
   });
-  writeFileSync(
-    audioPlanPath(STATE_DIR, episode.id, locale),
-    `${JSON.stringify(plan, null, 2)}\n`,
-  );
-  const total = planScenes.reduce((sum, s) => sum + s.durationMs, 0);
+  const totalMs = planScenes.reduce((sum, scene) => sum + scene.durationMs, 0);
   console.log(
-    `TTS ${episode.id}/${locale}: ${planScenes.length} scenes, ${(total / 1000).toFixed(1)}s narration, ` +
-      `${cachedCount} cached, ${billed} characters billed.`,
+    `TTS ${episode.id}/${locale}: ${planScenes.length} scenes, ` +
+      `${(totalMs / 1000).toFixed(1)}s narration, ${cachedCount} cached, ` +
+      `${billed} characters billed${mockTts ? ' (mock — estimates only)' : ''}.`,
   );
+}
+
+/**
+ * Print the planned timeline — measured narration when an audio plan
+ * exists, estimates otherwise. Free, instant, zero side effects: the
+ * pacing-design tool for script iteration.
+ */
+function runPlanStage(episode: EpisodeSpec, locale: Locale): void {
+  const planPath = audioPlanPath(STATE_DIR, episode.id, locale);
+  const audioPlan = existsSync(planPath)
+    ? (JSON.parse(readFileSync(planPath, 'utf8')) as AudioPlan)
+    : null;
+  const texts = spokenTexts(episode, locale);
+  const timeline = planTimeline(
+    episode.scenes.map((scene, index) => ({
+      id: scene.id,
+      audioDurationMs:
+        audioPlan?.scenes.find((s) => s.id === scene.id)?.durationMs ??
+        estimateSpeechMs(texts[index] ?? ''),
+      leadInMs: scene.leadInMs,
+      tailMs: scene.tailMs,
+      minMs: scene.minMs,
+    })),
+  );
+  const source = audioPlan
+    ? audioPlan.estimated
+      ? 'mock audio plan (estimated durations)'
+      : `measured audio plan (${audioPlan.model})`
+    : 'no audio plan — character-count estimates';
+  console.log(`Plan ${episode.id}/${locale} — ${source}`);
+  console.log('  start    budget  narration  scene');
+  for (const [index, planned] of timeline.scenes.entries()) {
+    const spec = episode.scenes[index];
+    const audioMs =
+      audioPlan?.scenes.find((s) => s.id === planned.id)?.durationMs ??
+      estimateSpeechMs(texts[index] ?? '');
+    const chapter = spec?.chapterByLocale?.[locale];
+    console.log(
+      `  ${formatClock(planned.startMs).padStart(7)}  ${`${(planned.budgetMs / 1000).toFixed(1)}s`.padStart(6)}  ${
+        audioMs > 0
+          ? `${(audioMs / 1000).toFixed(1)}s`.padStart(9)
+          : '        —'
+      }  ${planned.id}${chapter ? `  [${chapter}${spec?.chapterTransition === 'cut' ? ' · cut' : ''}]` : ''}`,
+    );
+  }
+  const characters = texts.join('').length;
+  console.log(
+    `  = ${formatClock(timeline.totalMs)} planned total, ${characters} spoken characters`,
+  );
+}
+
+interface UnitResult {
+  readonly episode: string;
+  readonly locale: Locale;
+  readonly ok: boolean;
+  readonly detail: string;
+}
+
+async function runList(): Promise<void> {
+  for (const episode of await loadEpisodes()) {
+    const narrationReady = LOCALES.filter((locale) =>
+      episode.scenes.every((scene) => scene.narration[locale] !== undefined),
+    );
+    const ttsReady = LOCALES.filter((locale) =>
+      existsSync(audioPlanPath(STATE_DIR, episode.id, locale)),
+    );
+    console.log(
+      `${episode.id}  [${episode.section}]${episode.diagnostic ? ' (diagnostic)' : ''}  ` +
+        `${episode.scenes.length} scenes, narration: ${narrationReady.join(', ') || '—'}, ` +
+        `tts plans: ${ttsReady.join(', ') || '—'}`,
+    );
+  }
 }
 
 /** Voice-audition candidates; samples double as future cache warmup. */
@@ -292,41 +354,181 @@ async function runAudition(): Promise<void> {
   );
 }
 
+async function resolveSelection(
+  options: CliOptions,
+): Promise<readonly EpisodeSpec[]> {
+  const episodes = await loadEpisodes();
+  if (options.episodes === 'all') {
+    // Diagnostics exercise the pipeline itself — they stay opt-in by id.
+    return episodes.filter((episode) => !episode.diagnostic);
+  }
+  return Promise.all(
+    options.episodes.map(async (id) => {
+      const episode = episodes.find((e) => e.id === id);
+      if (!episode) {
+        throw new CliUsageError(
+          `Unknown episode "${id}". Known: ${episodes.map((e) => e.id).join(', ')}`,
+        );
+      }
+      return episode;
+    }),
+  );
+}
+
 async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
-  if (args.list) {
-    for (const episode of EPISODES) {
-      const locales = LOCALES.filter((l) =>
-        episode.scenes.every((s) => s.narration[l]),
-      );
-      console.log(
-        `${episode.id}  [${episode.section}]  ${episode.scenes.length} scenes, narration ready: ${locales.join(', ') || '—'}`,
-      );
+  let options: CliOptions;
+  try {
+    options = parseCliArgs(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof CliUsageError) {
+      console.error(`docs:videos: ${error.message}`);
+      process.exitCode = 1;
+      return;
     }
+    throw error;
+  }
+  if (options.help) {
+    console.log(helpText());
     return;
   }
-
-  await ensureFfmpegAvailable();
-  elevenLabsApiKey();
-
-  if (args.audition) {
+  if (options.list) {
+    await runList();
+    return;
+  }
+  if (options.audition) {
+    await ensureFfmpegAvailable();
+    elevenLabsApiKey();
     await runAudition();
     return;
   }
 
-  const episode = findEpisode(args.episode);
-  for (const locale of args.locales) {
-    if (args.stage === 'tts' || args.stage === 'all') {
-      await runTtsStage(episode, locale);
+  const selection = await resolveSelection(options);
+  const stages: readonly ('check' | 'plan' | 'tts' | 'record' | 'compose')[] =
+    options.stage === 'all' ? ['tts', 'record', 'compose'] : [options.stage];
+  const needsTts = stages.includes('tts');
+  const needsRecord = stages.includes('record');
+  const needsCompose = stages.includes('compose');
+
+  // Fail on missing prerequisites in seconds, not minutes into a take —
+  // doctor first (it REPORTS missing pieces; the hard gates below throw).
+  if (options.doctor || needsRecord) {
+    const checks = await runDoctor({
+      episodes: selection,
+      locales: options.locales,
+      needsTts,
+      needsRecord: needsRecord || options.doctor,
+      needsCompose,
+      mockTts: options.mockTts,
+    });
+    console.log(`Doctor:\n${formatDoctorReport(checks)}`);
+    if (doctorHasFailures(checks)) {
+      if (options.doctor) {
+        process.exitCode = 1;
+        return;
+      }
+      throw new Error(
+        'preflight failed — fix the ✗ items above (or run --doctor after).',
+      );
     }
-    if (args.stage === 'record' || args.stage === 'all') {
-      const { runRecordStage } = await import('./lib/recorder');
-      await runRecordStage(episode, locale, STATE_DIR);
+    if (options.doctor) return;
+  }
+  if (needsTts || needsCompose) await ensureFfmpegAvailable();
+  if (needsTts && !options.mockTts) elevenLabsApiKey();
+
+  const results: UnitResult[] = [];
+  for (const episode of selection) {
+    // Structural drift fails here, before any stage burns time on it. The
+    // tts stage validates the spec only — narration is authored (and
+    // synthesized) before choreography exists.
+    const checkOk = await runCheckStage(
+      episode,
+      options.stage === 'check' || needsRecord || needsCompose,
+    );
+    if (!checkOk || options.stage === 'check') {
+      for (const locale of options.locales) {
+        results.push({
+          episode: episode.id,
+          locale,
+          ok: checkOk,
+          detail: checkOk ? 'check' : 'check failed',
+        });
+      }
+      continue;
     }
-    if (args.stage === 'compose' || args.stage === 'all') {
-      const { runComposeStage } = await import('./lib/compose');
-      await runComposeStage(episode, locale, STATE_DIR);
+
+    for (const locale of options.locales) {
+      try {
+        if (options.stage === 'plan') {
+          runPlanStage(episode, locale);
+          results.push({
+            episode: episode.id,
+            locale,
+            ok: true,
+            detail: 'plan',
+          });
+          continue;
+        }
+        if (needsTts) await runTtsStage(episode, locale, options.mockTts);
+        if (needsRecord) {
+          const { runRecordStage } = await import('./lib/recorder');
+          await runRecordStage(episode, locale, STATE_DIR);
+        }
+        if (needsCompose) {
+          const { runComposeStage } = await import('./lib/compose');
+          const planPath = audioPlanPath(STATE_DIR, episode.id, locale);
+          const estimatedPlan =
+            existsSync(planPath) &&
+            ((JSON.parse(readFileSync(planPath, 'utf8')) as AudioPlan)
+              .estimated ??
+              false);
+          // A rehearsal (mock) plan auto-composes as a draft — the guard in
+          // compose would otherwise reject it at the end of a long take.
+          const draft = options.draft || (estimatedPlan && !episode.diagnostic);
+          if (draft && !options.draft) {
+            console.log(
+              '  · estimated narration → composing as draft (.state/out)',
+            );
+          }
+          await runComposeStage(episode, locale, STATE_DIR, {
+            draft,
+            verify: options.verify,
+          });
+        }
+        results.push({
+          episode: episode.id,
+          locale,
+          ok: true,
+          detail: stages.join('+'),
+        });
+      } catch (error) {
+        console.error(`✗ ${episode.id}/${locale}:`, error);
+        results.push({
+          episode: episode.id,
+          locale,
+          ok: false,
+          detail:
+            String(error instanceof Error ? error.message : error).split(
+              '\n',
+            )[0] ?? 'failed',
+        });
+      }
     }
+  }
+
+  const failed = results.filter((result) => !result.ok);
+  if (results.length > 1) {
+    console.log('\nSummary:');
+    for (const result of results) {
+      console.log(
+        `  ${result.ok ? '✓' : '✗'} ${result.episode}/${result.locale} — ${result.detail}`,
+      );
+    }
+  }
+  if (failed.length > 0) {
+    console.error(
+      `\n${failed.length}/${results.length} unit(s) failed — see above.`,
+    );
+    process.exitCode = 1;
   }
 }
 

--- a/services/platform/tests/docs-videos/seed-locale-orgs.ts
+++ b/services/platform/tests/docs-videos/seed-locale-orgs.ts
@@ -27,17 +27,10 @@ import { BASE_URL, TIMEOUT } from '../e2e/helpers/env';
 import { t } from '../e2e/helpers/i18n';
 import type { Locale } from './lib/episode';
 import { videoContentFor } from './lib/locale-content';
+import { SCREENSHOTS_STATE_DIR, STATE_DIR } from './lib/paths';
 
-const HERE = path.dirname(new URL(import.meta.url).pathname);
-const STATE_DIR = path.join(HERE, '.state');
 const LOCALE_ORGS = path.join(STATE_DIR, 'locale-orgs.json');
-const SCREENSHOTS_AUTH = path.join(
-  HERE,
-  '..',
-  'docs-screenshots',
-  '.state',
-  'auth.json',
-);
+const SCREENSHOTS_AUTH = path.join(SCREENSHOTS_STATE_DIR, 'auth.json');
 const TRIAGE_PATH = 'projects__tasks__triage-unassigned';
 
 /** The org names are workspace fiction — native per locale, and distinct so

--- a/tools/plop/README.md
+++ b/tools/plop/README.md
@@ -19,6 +19,8 @@ bun run gen:package    # packages/<name> — kind: react | typescript
 bun run gen:service    # services/<name> — kind: react | docker
 bun run gen:tool       # tools/<name>    — kind: typescript | shell
 bun run gen:skill      # .agents/skills/<name> or builtin-configs/skills/<name> — docs (SKILL.md + README)
+bun run gen:migration  # services/platform/convex/migrations/versions/<v>/<nn>_<slug> — kind: db | node | component | reference
+bun run gen:episode    # services/platform/tests/docs-videos/episodes/<id> — spec + choreography skeleton
 ```
 
 Each generator prompts for a **kind** (the skill generator for a **category**)
@@ -26,8 +28,8 @@ and scaffolds from the matching `templates/<category>/<kind>/` directory.
 
 ## Layout
 
-- `generators/` — one generator per category (`package`, `service`, `tool`, `skill`),
-  each selecting a variant via a `kind` prompt
+- `generators/` — one generator per category (`package`, `service`, `tool`, `skill`,
+  `migration`, `video-episode`), most selecting a variant via a `kind` prompt
 - `templates/<category>/<kind>/` — Handlebars (`.hbs`) and static templates
   rendered by the generators
 - `helpers/` — shared Handlebars helpers registered with Plop

--- a/tools/plop/generators/video-episode.ts
+++ b/tools/plop/generators/video-episode.ts
@@ -1,0 +1,107 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { ActionType, NodePlopAPI } from 'plop';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const templateDir = path.resolve(here, '../templates/video-episode');
+const repoRoot = path.resolve(here, '../../..');
+const episodesRoot = path.join(
+  repoRoot,
+  'services/platform/tests/docs-videos/episodes',
+);
+
+const ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+interface Answers {
+  id: string;
+  titleEn: string;
+  episodeLabel: string;
+  needsKnowledgeDb: boolean;
+}
+
+function nextSteps(id: string, dest: string): string {
+  return (
+    `\nScaffolded ${dest}.\n\n` +
+    `Next steps (the produce-video skill owns the discipline):\n` +
+    `  1. storyboard first — .agents/skills/produce-video/STORYBOARD.md;\n` +
+    `     narration for ALL scenes in en, de, fr (write-translations voice),\n` +
+    `     then a table read before any choreography\n` +
+    `  2. a live-typed chat prompt? pair heroPromptByLocale with a match\n` +
+    `     clause in services/platform/lib/mocks/overrides/docs-replies.ts\n` +
+    `  3. bun run docs:videos -- --episode ${id} --stage check\n` +
+    `  4. bun run docs:videos -- --episode ${id} --stage plan   # pacing\n` +
+    `  5. rehearse free of billing: bun run docs:videos -- --episode ${id} --mock-tts\n` +
+    `  6. real narration + take: bun run docs:videos -- --episode ${id} --locale all\n` +
+    `  7. embed the mp4+vtt+poster set on the docs pages (write-docs) and\n` +
+    `     tick the produce-video ship checklist before committing assets`
+  );
+}
+
+export function registerVideoEpisode(plop: NodePlopAPI): void {
+  plop.setGenerator('video-episode', {
+    description:
+      'Docs tutorial-video episode (services/platform/tests/docs-videos/episodes) — spec + choreography skeleton',
+    prompts: [
+      {
+        type: 'input',
+        name: 'id',
+        message: 'Episode id (kebab-case, e.g. ep11-billing):',
+        validate: (value: string) => {
+          if (!ID_RE.test(value)) return 'Use lowercase kebab-case';
+          if (existsSync(path.join(episodesRoot, value))) {
+            return `episodes/${value} already exists`;
+          }
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'titleEn',
+        message: 'English title (title card, e.g. "Billing and plans"):',
+        validate: (value: string) =>
+          value.trim().length > 0 || 'The title card needs a title',
+      },
+      {
+        type: 'input',
+        name: 'episodeLabel',
+        message: 'Card eyebrow (e.g. "Episode 11"):',
+        default: (answers: Partial<Answers>) => {
+          const digits = /^ep(\d+)/.exec(answers.id ?? '')?.[1];
+          return digits ? `Episode ${digits}` : 'Episode';
+        },
+      },
+      {
+        type: 'confirm',
+        name: 'needsKnowledgeDb',
+        message: 'Does a scene show Indexed badges (needs the RAG container)?',
+        default: false,
+      },
+    ],
+    actions: (data) => {
+      const answers = data as Answers;
+      const dest = `services/platform/tests/docs-videos/episodes/${answers.id}`;
+      const templateData = {
+        ...answers,
+        constName: answers.id.toUpperCase().replaceAll('-', '_'),
+      };
+      const actions: ActionType[] = [
+        {
+          type: 'add',
+          path: `${dest}/episode.ts`,
+          templateFile: `${templateDir}/episode.ts.hbs`,
+          data: templateData,
+        },
+        {
+          type: 'add',
+          path: `${dest}/scenes.ts`,
+          templateFile: `${templateDir}/scenes.ts.hbs`,
+          data: templateData,
+        },
+      ];
+      actions.push(() => nextSteps(answers.id, dest));
+      return actions;
+    },
+  });
+}

--- a/tools/plop/templates/video-episode/episode.ts.hbs
+++ b/tools/plop/templates/video-episode/episode.ts.hbs
@@ -1,0 +1,69 @@
+/**
+ * {{episodeLabel}} — "{{titleEn}}". TODO: one line on what the episode
+ * teaches and the thread that carries it.
+ *
+ * Narration doctrine (produce-video skill): docs voice, written natively per
+ * locale — never translated word for word (write-translations). Storyboard
+ * FIRST (.agents/skills/produce-video/STORYBOARD.md), then a table read,
+ * then choreography. Scene ids join episode.ts ↔ scenes.ts — validate with
+ * `bun run docs:videos -- --episode {{id}} --stage check`.
+ */
+
+import type { EpisodeSpec } from '../../lib/episode';
+
+export const {{constName}}: EpisodeSpec = {
+  id: '{{id}}',
+  section: 'tutorials',
+  titleByLocale: {
+    en: '{{titleEn}}',
+    de: 'TODO — native German title',
+    fr: 'TODO — native French title',
+  },
+  episodeLabelByLocale: {
+    en: '{{episodeLabel}}',
+    de: '{{episodeLabel}}',
+    fr: '{{episodeLabel}}',
+  },
+  needsKnowledgeDb: {{needsKnowledgeDb}},
+  /** The series voices, pinned 2026-07-16 (audition history in ep1). */
+  voices: {
+    en: 'WZlYpi1yf6zJhNWXih74',
+    de: 'rKiu7lQ4c5P3az3745s3',
+    fr: 'QbsdzCokdlo98elkq4Pc',
+  },
+  /** One whole-episode generation per locale — consistent delivery. */
+  wholeTakeLocales: ['en', 'de', 'fr'],
+  // Typing a live chat prompt on camera? Add heroPromptByLocale and pair
+  // every locale with a DOCS_REPLIES match clause (lib/mocks/overrides/
+  // docs-replies.ts) — `--stage check` enforces the pairing.
+  scenes: [
+    {
+      id: 'title',
+      leadInMs: 1200,
+      narration: {
+        en: 'TODO — the opening line the title card plays under.',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+    {
+      id: 'first-scene',
+      narration: {
+        en: 'TODO — write the story before the choreography.',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+    {
+      id: 'outro',
+      // Post-narration room: the card holds ~2s, then the compose fade-out
+      // (1.5s) completes inside it — the ending must never feel cut off.
+      tailMs: 3600,
+      narration: {
+        en: 'TODO — the closing line over the outro card.',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+  ],
+} as const;

--- a/tools/plop/templates/video-episode/scenes.ts.hbs
+++ b/tools/plop/templates/video-episode/scenes.ts.hbs
@@ -1,0 +1,79 @@
+/**
+ * {{episodeLabel}} choreography. Scene ids pair 1:1 with episode.ts. Rules
+ * of the road (produce-video skill):
+ *
+ *  - wait on state (locators), never on time — `cue(sec)` is the ONE
+ *    exception: it waits until that second of the running narration so
+ *    actions land with the voice.
+ *  - target by role + the locale catalog (`rt.t('…')`) or by href/data
+ *    literal — the same scene records under en, de AND fr.
+ *  - never `page.goto` inside a scene (it re-boots the SPA on camera);
+ *    rail clicks and `spaNavigate` are the only route changes.
+ *  - anything created ON CAMERA registers on `ctx.cleanup` the moment it
+ *    exists — an aborted take still leaves the org as seeded.
+ *
+ * Rehearse free of billing:
+ *   bun run docs:videos -- --episode {{id}} --mock-tts
+ */
+
+import type { SceneChoreography, SceneContext } from '../../lib/scene';
+
+/**
+ * Visited by the recorder BEFORE the screencast starts: on a dev server the
+ * first visit to a route compiles its chunks and fetches cold data —
+ * seconds of skeleton that must never be on camera. Mirror EVERY surface
+ * the scenes touch, then end settled on the opening route (the recorder
+ * covers it with the title card and starts the screencast).
+ */
+export async function warmup(
+  page: import('@playwright/test').Page,
+  ctx: SceneContext,
+): Promise<void> {
+  const routes = [
+    `/dashboard/${ctx.orgId}/chat`,
+    // TODO: every route a scene visits.
+  ];
+  for (const route of routes) {
+    await page.goto(route, { waitUntil: 'load' });
+    await page
+      .waitForLoadState('networkidle', { timeout: 8_000 })
+      .catch(() => {
+        console.warn(`warmup: ${route} never reached networkidle — continuing`);
+      });
+    await page.waitForTimeout(250);
+  }
+  await page
+    .getByRole('textbox')
+    .first()
+    .waitFor({ state: 'visible', timeout: 15_000 });
+}
+
+export const SCENES: readonly SceneChoreography[] = [
+  {
+    id: 'title',
+    run: async ({ page }) => {
+      await page.evaluate(() => window.__taleVideoCard?.reveal());
+    },
+  },
+  {
+    id: 'first-scene',
+    run: async (rt) => {
+      const { page, cursor, cue } = rt;
+      // Unveiling the settled app IS the transition from the title card.
+      await page.evaluate(() => window.__taleVideoCard?.fadeOutAndRemove(700));
+      await cursor.place(1450, 700);
+      await cue(1.0);
+      await cursor.show();
+      // TODO: the scene's beats, each landing with the narration:
+      //   await cue(3.2);
+      //   await cursor.click(page.getByRole('link', { name: rt.t('…') }));
+    },
+  },
+  {
+    id: 'outro',
+    run: async ({ page, cursor }) => {
+      await cursor.hide();
+      await page.evaluate(() => window.__taleVideoCard?.showOutro());
+    },
+  },
+];


### PR DESCRIPTION
## What

The docs tutorial-video pipeline (`services/platform/tests/docs-videos/`) gets a full authoring loop around the existing tts→record→compose core, so every classic failure mode fails in seconds with a fix attached instead of minutes (or euros) into a take. **No shipped video asset changes** — `services/docs/` is untouched, TTS cache keys are byte-stable (test-pinned), and the real-compose encode settings are unchanged.

### New capabilities

- **`--stage check`** — static validation: episode.ts ↔ scenes.ts scene-id parity, per-locale narration consistency, hero-prompt ↔ `DOCS_REPLIES` pairing, warmup presence, outro fade room. Also runs automatically before takes, and as an always-on vitest gate (`lib/episodes.test.ts`) so episode drift fails `bun run check`. It immediately caught the `'unused'` hero-prompt sentinels — `heroPromptByLocale` is now optional and dropped where no scene types it.
- **`--stage plan`** — instant timeline table (measured narration when TTS ran, character-count estimates otherwise; estimates run ~10–15 % short of real delivery).
- **`--doctor`** + automatic record preflight — ffmpeg/ffprobe, Chromium, ElevenLabs key, app + mock-gateway ports, **demo-auth session freshness** (the expired-storageState → films-the-login-page trap), per-locale demo orgs, knowledge DB when an episode needs it, disk space; every failure prints the exact fix command.
- **`--mock-tts`** — estimated-length silent narration (ffmpeg `anullsrc`): rehearse choreography/budgets/locators with zero billing, no key, no network. Estimated plans are marked and refuse to compose outside `.state/` (auto-drafted).
- **`--draft`** — 720p/veryfast compose into `.state/out/`, no poster/manifest — the fast look-adjust loop.
- **A/V verification after every compose** — composed duration vs plan, plus silencedetect speech-coverage over every narrated window: a silent track, missing scene audio, or a global offset now fails the compose (`--no-verify` opts out). Pure interval math unit-tested.
- **Review sheets** — every compose writes `.state/review/<ep>.<locale>/index.html` with two thumbnails per scene + planned/actual timing + script, so the human QA pass starts from evidence.
- **`bun run gen:episode`** — plop scaffold for `episodes/<id>/{episode.ts,scenes.ts}` with the series voices, warmup contract, and card scenes; passes its own `check`/`plan` as generated.
- **CLI** — `--help`, `--episode all`/comma lists, `--locale all`, per-unit continue-on-error with an end summary for series batches; parser unit-tested (`lib/cli.ts`).

### Structure

- Episode auto-discovery (`lib/episodes.ts`; spec id must equal its directory) replaces the manual import registry; `lib/paths.ts` replaces four per-file `../../..` chains.
- `ctx.cleanup` (typed `CleanupRegistry`: thread/knowledgeEntry/agent/task) replaces the stringly comma-joined `notes` keys and the `registerNote` helper copy-pasted across four episodes; the 230-line cleanup block moves out of `recorder.ts` into `lib/cleanup.ts` unchanged in behaviour. A typo'd key can no longer silently skip cleanup.
- The recorder's pacing/screencast core is untouched (diff-verified: imports/ctx/cleanup only).
- `DOCS_REPLIES` gains invariant tests (lowercase + unique match clauses; `toolIntro` on pausing tool turns — #2767 regression lock). TTS cache-key shapes are characterization-locked (`lib/tts-cache-key.test.ts`) — a drifted key would re-bill the entire narration back catalog.
- README rewritten around the cheap-first loop; `produce-video` skill + STORYBOARD updated (rehearse-before-you-bill rule, registry contract, verification ship gate); skills mirrors resynced.

## Verification

- Full offline pipeline proven on the `spike-sync` diagnostic (no stack, no key): mock tts → record (**0–1 ms drift**, ~1820 frames) → compose → verification → review sheet; title card, cue-timed red flip, and cursor click all visually confirmed from the sheet thumbnails.
- `--doctor` exercised against the down stack: every missing prerequisite named with its fix, exit 1.
- Platform server vitest project: **904 files / 9723 tests passed**; docs suite 194 passed; turbo lint+typecheck across 21 workspaces green; opengrep SAST 0 findings; `format:check` green; `skills:check` green.
- Scaffolder exercised end-to-end (`ep99-probe` created, validated via check+plan, removed).
- Not exercised here: a real-org record/TTS run (needs the Mode-A stack + ElevenLabs key; recreating videos was explicitly out of scope). The recorder core is unchanged and covered by the offline take.