### PR TITLE
fix(platform): resolve automation manifest i18n in the catalog grid

### DIFF
--- a/services/platform/app/features/automations/components/automations-grid.test.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.test.tsx
@@ -23,15 +23,25 @@ import { AutomationsGrid, type AutomationsGridProps } from './automations-grid';
  * automation navigates to its automation page. Every card also carries a ⋯ menu.
  */
 
-const { useAutomationsMock, useAutomationCatalogMock } = vi.hoisted(() => ({
-  useAutomationsMock: vi.fn(),
-  useAutomationCatalogMock: vi.fn(),
-}));
+const { useAutomationsMock, useAutomationCatalogMock, localeMock } = vi.hoisted(
+  () => ({
+    useAutomationsMock: vi.fn(),
+    useAutomationCatalogMock: vi.fn(),
+    localeMock: vi.fn(),
+  }),
+);
 
 vi.mock('../hooks/use-automations', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../hooks/use-automations')>()),
   useAutomations: useAutomationsMock,
   useAutomationCatalog: useAutomationCatalogMock,
+}));
+
+// The grid resolves every manifest name/description through the active locale
+// (the `use-automations` i18n contract) — settable per test, `en` by default.
+vi.mock('@tale/ui/i18n/locale-provider', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tale/ui/i18n/locale-provider')>()),
+  useLocale: () => localeMock(),
 }));
 
 // Install-state map, settable per test: empty ⇒ every card renders the
@@ -144,6 +154,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   installMock.mockResolvedValue(undefined);
   mockInstallStates = new Map();
+  localeMock.mockReturnValue({ locale: 'en', setLocale: vi.fn() });
 });
 
 describe('AutomationsGrid catalog/installed union (#1979)', () => {
@@ -575,6 +586,137 @@ describe('AutomationsGrid tabs + badges', () => {
     expect(screen.getByText('A discoverable automation.')).not.toContainElement(
       labels,
     );
+  });
+});
+
+// #2806-series: the catalog card must render through the manifest's inline
+// `i18n` block (the `use-automations` contract — "never the literals
+// directly"). The de/fr docs videos shipped with English card titles because
+// the grid was the one automation surface reading the literals.
+describe('AutomationsGrid manifest i18n (the automation translates itself)', () => {
+  const triageAutomation = () =>
+    automationSummary({
+      slug: 'projects/tasks/triage-unassigned',
+      name: 'Triage unassigned tasks',
+      description: 'Scores new tasks and routes them.',
+      i18n: {
+        de: {
+          name: 'Unzugewiesene Aufgaben sichten',
+          description: 'Bewertet neue Aufgaben und leitet sie weiter.',
+        },
+      },
+    });
+
+  it('renders the resolved name, description, and aria-label for the active locale', async () => {
+    localeMock.mockReturnValue({ locale: 'de', setLocale: vi.fn() });
+    useAutomationsMock.mockReturnValue({
+      automations: [],
+      isLoading: false,
+      error: null,
+    });
+    useAutomationCatalogMock.mockReturnValue({
+      automations: [triageAutomation()],
+      isLoading: false,
+      error: null,
+    });
+
+    renderAllTab(<AutomationsGrid organizationId="org_1" />);
+
+    expect(
+      screen.getByText('Unzugewiesene Aufgaben sichten'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Bewertet neue Aufgaben und leitet sie weiter.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Triage unassigned tasks'),
+    ).not.toBeInTheDocument();
+    // The whole-card button carries the RESOLVED accessible name.
+    expect(
+      screen.getByRole('button', { name: 'Unzugewiesene Aufgaben sichten' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts the grid by the resolved names, not the literals', async () => {
+    localeMock.mockReturnValue({ locale: 'de', setLocale: vi.fn() });
+    useAutomationsMock.mockReturnValue({
+      automations: [],
+      isLoading: false,
+      error: null,
+    });
+    useAutomationCatalogMock.mockReturnValue({
+      automations: [
+        // EN order: Archive < Sync — the DE names invert it.
+        automationSummary({
+          slug: 'archive-mailbox',
+          name: 'Archive mailbox',
+          i18n: { de: { name: 'Postfach archivieren' } },
+        }),
+        automationSummary({
+          slug: 'sync-tasks',
+          name: 'Sync tasks',
+          i18n: { de: { name: 'Aufgaben synchronisieren' } },
+        }),
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderAllTab(<AutomationsGrid organizationId="org_1" />);
+
+    expect(
+      screen
+        .getAllByText(/Postfach archivieren|Aufgaben synchronisieren/)
+        .map((el) => el.textContent),
+    ).toStrictEqual(['Aufgaben synchronisieren', 'Postfach archivieren']);
+  });
+
+  it('matches search against the resolved text, not the hidden literals', async () => {
+    localeMock.mockReturnValue({ locale: 'de', setLocale: vi.fn() });
+    useAutomationsMock.mockReturnValue({
+      automations: [],
+      isLoading: false,
+      error: null,
+    });
+    useAutomationCatalogMock.mockReturnValue({
+      automations: [triageAutomation()],
+      isLoading: false,
+      error: null,
+    });
+
+    const { user } = renderAllTab(<AutomationsGrid organizationId="org_1" />);
+    const search = screen.getByRole('textbox');
+
+    await user.type(search, 'sichten');
+    expect(
+      screen.getByText('Unzugewiesene Aufgaben sichten'),
+    ).toBeInTheDocument();
+
+    // The English literal is not on the card — searching it finds nothing.
+    await user.clear(search);
+    await user.type(search, 'unassigned');
+    expect(
+      screen.queryByText('Unzugewiesene Aufgaben sichten'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('falls back to the manifest literals without an i18n block', async () => {
+    localeMock.mockReturnValue({ locale: 'de', setLocale: vi.fn() });
+    useAutomationsMock.mockReturnValue({
+      automations: [],
+      isLoading: false,
+      error: null,
+    });
+    useAutomationCatalogMock.mockReturnValue({
+      automations: [automationSummary()],
+      isLoading: false,
+      error: null,
+    });
+
+    renderAllTab(<AutomationsGrid organizationId="org_1" />);
+
+    expect(screen.getByText('Sample Automation')).toBeInTheDocument();
+    expect(screen.getByText('A discoverable automation.')).toBeInTheDocument();
   });
 });
 

--- a/services/platform/app/features/automations/components/automations-grid.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.tsx
@@ -13,6 +13,7 @@
  * `TabNavigation` (`AutomationsNavigation`) — not a toolbar pill strip. */
 import { Badge } from '@tale/ui/badge';
 import { EmptyState } from '@tale/ui/empty-state';
+import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { Stack } from '@tale/ui/layout';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { useNavigate } from '@tanstack/react-router';
@@ -54,9 +55,11 @@ import {
 } from '@/app/components/ui/entity/entity-row-actions';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
+import { resolveAutomationLocale } from '@/lib/shared/utils/resolve-automation-locale';
 import { downloadBase64File } from '@/lib/utils/download';
 
 import { notifyOnInstallFailure } from '../hooks/install-failure-toast';
+import { useAutomationDisplay } from '../hooks/use-automation-text';
 import {
   type AutomationSummary,
   useAutomationCatalog,
@@ -129,13 +132,6 @@ function BundleInstallStateBadge({
   return <Badge variant="green">{t('install.installed')}</Badge>;
 }
 
-/** Search matches an automation's name or description. */
-function automationHaystack(
-  automation: AutomationSummary,
-): ReadonlyArray<string | undefined> {
-  return [automation.name, automation.description];
-}
-
 /**
  * The section an automation groups under: the top-level segment of its manifest
  * `folder` ('' = ungrouped → the trailing "General" section).
@@ -182,10 +178,11 @@ function NotInstalledMenu({
   onInstall: () => void;
 }) {
   const { t } = useT('automations');
+  const display = useAutomationDisplay()(automation);
   const { action: deleteAction, dialog: deleteDialog } =
     useAutomationDeleteAction({
       automationSlug: automation.slug,
-      automationName: automation.name,
+      automationName: display.name,
       organizationId,
     });
   const { mutateAsync: exportAutomation } = useExportAutomation();
@@ -229,7 +226,7 @@ function NotInstalledMenu({
     <>
       <EntityRowActions
         actions={actions}
-        ariaLabel={t('install.menuLabel', { name: automation.name })}
+        ariaLabel={t('install.menuLabel', { name: display.name })}
         disabled={isPending}
       />
       {isCustom && deleteDialog}
@@ -255,6 +252,7 @@ function InstalledBundleMenu({
   onReinstall: () => void;
 }) {
   const { t } = useT('automations');
+  const display = useAutomationDisplay()(bundle);
   const { uninstallBundle } = useAutomationInstallActions(organizationId);
   const { mutateAsync: exportAutomation } = useExportAutomation();
   const dialogs = useEntityRowDialogs(['uninstallBundle']);
@@ -325,7 +323,7 @@ function InstalledBundleMenu({
     <>
       <EntityRowActions
         actions={actions}
-        ariaLabel={t('install.menuLabel', { name: bundle.name })}
+        ariaLabel={t('install.menuLabel', { name: display.name })}
         disabled={busy}
       />
       <DeleteDialog
@@ -335,7 +333,7 @@ function InstalledBundleMenu({
         description={t('install.uninstallBundleDescription', {
           count: memberCount,
         })}
-        preview={{ primary: bundle.name }}
+        preview={{ primary: display.name }}
         warning={t('install.uninstallWarning')}
         deleteText={t('install.uninstallBundle')}
         isDeleting={busy}
@@ -376,6 +374,7 @@ export function AutomationsGrid({
   toolbarAction,
 }: AutomationsGridProps) {
   const { t } = useT('automations');
+  const { locale } = useLocale();
   const navigate = useNavigate();
   // The catalog shows the UNION of the org's installed automations and the built-in
   // catalog, keyed by slug. An installed entry wins (it carries the full
@@ -387,16 +386,42 @@ export function AutomationsGrid({
   const { automations: catalog, isLoading: catalogLoading } =
     useAutomationCatalog(organizationId);
   const isLoading = installedLoading || catalogLoading;
-  const automations = useMemo(() => {
+  const unionAutomations = useMemo(() => {
     const unionBySlug = new Map<string, AutomationSummary>();
     for (const automation of catalog)
       unionBySlug.set(automation.slug, automation);
     for (const automation of installed)
       unionBySlug.set(automation.slug, automation);
-    return Array.from(unionBySlug.values()).sort((a, b) =>
-      a.name.localeCompare(b.name),
-    );
+    return Array.from(unionBySlug.values());
   }, [installed, catalog]);
+  // Manifest i18n (`AutomationSummary.i18n`) resolved ONCE per union entry —
+  // sort, search, and every rendered name/description read this map, so a card
+  // can never show a literal the manifest translates (the `use-automations`
+  // contract). The pure resolver rather than `useAutomationDisplay`: the hook
+  // returns a fresh closure per render, which would defeat this memo and every
+  // array derived from it.
+  const displayBySlug = useMemo(() => {
+    const map = new Map<string, { name: string; description: string }>();
+    for (const automation of unionAutomations) {
+      map.set(automation.slug, resolveAutomationLocale(automation, locale));
+    }
+    return map;
+  }, [unionAutomations, locale]);
+  const displayFor = useCallback(
+    (automation: AutomationSummary) =>
+      displayBySlug.get(automation.slug) ?? {
+        name: automation.name,
+        description: automation.description,
+      },
+    [displayBySlug],
+  );
+  const automations = useMemo(
+    () =>
+      [...unionAutomations].sort((a, b) =>
+        displayFor(a).name.localeCompare(displayFor(b).name, locale),
+      ),
+    [unionAutomations, displayFor, locale],
+  );
   // member slug → its owning bundle summary — installed members card under
   // Installed with an extra "Uninstall bundle" action.
   const bundleByMember = useMemo(() => {
@@ -460,6 +485,15 @@ export function AutomationsGrid({
           // members never card here.
           automations.filter((automation) => automation.hidden !== true),
     [automations, tab, bySlug],
+  );
+  // Search matches the card as RENDERED — the locale-resolved name and
+  // description (`useCatalogSearch` needs a referentially stable haystack fn).
+  const automationHaystack = useCallback(
+    (automation: AutomationSummary): ReadonlyArray<string | undefined> => {
+      const display = displayFor(automation);
+      return [display.name, display.description];
+    },
+    [displayFor],
   );
   const filteredAutomations = useCatalogSearch(
     tabbedAutomations,
@@ -546,6 +580,7 @@ export function AutomationsGrid({
       isBundle &&
       deriveBundleInstallStatus(automation.members ?? [], bySlug) !==
         'not-installed';
+    const display = displayFor(automation);
     const icon = (
       <CatalogCardIcon>
         <AutomationIcon
@@ -576,7 +611,9 @@ export function AutomationsGrid({
           ) : owningBundle ? (
             <AutomationMarker
               icon={Package}
-              label={t('bundle.partOf', { name: owningBundle.name })}
+              label={t('bundle.partOf', {
+                name: displayFor(owningBundle).name,
+              })}
             >
               {icon}
             </AutomationMarker>
@@ -588,8 +625,8 @@ export function AutomationsGrid({
             icon
           )
         }
-        title={automation.name}
-        description={automation.description}
+        title={display.name}
+        description={display.description}
         badge={
           isBundle ? (
             <BundleInstallStateBadge
@@ -620,7 +657,7 @@ export function AutomationsGrid({
               })
             : setPanelAutomation(automation)
         }
-        ariaLabel={automation.name}
+        ariaLabel={display.name}
         menu={
           bundleInstalled ? (
             <InstalledBundleMenu
@@ -631,7 +668,7 @@ export function AutomationsGrid({
           ) : isInstalled ? (
             <AutomationLifecycleActions
               automationSlug={automation.slug}
-              automationName={automation.name}
+              automationName={display.name}
               organizationId={organizationId}
               context="org"
               scope={automation.scope}
@@ -735,7 +772,7 @@ export function AutomationsGrid({
           }}
           organizationId={organizationId}
           automationSlug={wizardAutomation.slug}
-          automationName={wizardAutomation.name}
+          automationName={displayFor(wizardAutomation).name}
           scope={wizardAutomation.scope}
           requiredIntegrations={wizardAutomation.requiredIntegrations}
         />
@@ -748,7 +785,7 @@ export function AutomationsGrid({
           }}
           organizationId={organizationId}
           bundleSlug={wizardBundle.slug}
-          bundleName={wizardBundle.name}
+          bundleName={displayFor(wizardBundle).name}
           scope={wizardBundle.scope}
         />
       )}


### PR DESCRIPTION
## Problem

The Automations catalog grid rendered manifest literals directly — card title/description (`automations-grid.tsx:591-592`), aria-labels, ⋯-menu labels, the sort comparator, and the search haystack all read `automation.name`/`.description` instead of resolving the manifest's per-locale `i18n` block. This violated the documented contract on `AutomationSummary.i18n` (`use-automations.ts`: *render through `useAutomationDisplay` … never the literals directly*).

All 27 builtin automations ship complete de/fr translations, and every other automation surface (panel, page, configuration, agent catalog) resolves them — so a de/fr user saw an English card title, clicked it, and landed on a page showing the German name. This is also why the de/fr docs tutorial videos show English automation titles on camera (found during the video-series re-production).

## Fix

- Resolve every union entry once through `resolveAutomationLocale`, memoized on `[union, locale]` (the `useAutomationDisplay` closure is per-render and would defeat the derived sort/search memos — noted in a comment).
- Sort by the resolved names with locale collation.
- Search matches the card as rendered (resolved name + description), via a referentially stable `useCallback` haystack per the `useCatalogSearch` contract.
- `NotInstalledMenu` / `InstalledBundleMenu` resolve via `useAutomationDisplay` like the sibling surfaces (menu aria-labels, delete-dialog preview, delete action name).
- Wizard + lifecycle display-name props and the "Part of <bundle>" marker use the resolved names.

EN output is unchanged — the resolver falls back to the literals when no `i18n` block exists.

## Tests

New `AutomationsGrid manifest i18n` describe (settable `useLocale` mock, the established pattern): resolved name/description/aria-label in `de`, resolved-name sort order (en/de orders invert), search hit on the German substring + miss on the hidden English literal, and literal fallback without an `i18n` block. `bunx vitest --run --config vitest.ui.config.ts automations-grid`: 28/28 green; platform typecheck + oxlint green.