### PR TITLE
feat(docs): produce-video doctrine for the deepened series

### DIFF
--- a/.agents/skills/produce-video/SKILL.md
+++ b/.agents/skills/produce-video/SKILL.md
@@ -23,13 +23,18 @@ any asset under `services/docs/public/videos/**`, a `<Video>` embed on a docs pa
   choreography. The narration is the spine: scene budgets derive from its measured audio, so a
   script change re-plans the timeline and re-records the take. (Why: pacing edits after recording
   cost a full re-record anyway — do the cheap iteration on paper.)
-- **Narration is docs prose, spoken.** Docs voice per locale (write-translations: du/tu, no
-  bureaucratic German, no marketed French), written natively — never translated word for word.
-  Spoken UI vocabulary matches the shipped catalog (`Wissen`, `Connaissances`). Words a locale's
-  voice mis-reads (the brand, product terms) get a respelling in the pipeline's per-locale
-  pronunciation map — spoken text only, captions keep the real spelling. ElevenLabs audio
-  tags sparingly; punctuation and ellipses carry pacing. Claims must be true of the product —
-  narration ships in three languages and gets quoted back.
+- **Narration is a colleague showing you, spoken.** Contractions, short spoken sentences, action +
+  reason in the same breath, every real choice names a rejected alternative, one pitfall beat and
+  one verify beat per episode, closers recap what the viewer DID — never aphorisms (register rules
+  - banned-pattern list: [`STORYBOARD.md`](STORYBOARD.md)). Written natively per locale
+    (write-translations: du/tu, no bureaucratic German, no marketed French) — never translated word
+    for word. Spoken UI vocabulary matches the shipped catalog (`Wissen`, `Connaissances`). Words a
+    locale's voice mis-reads (the brand, product terms) get a respelling in the pipeline's
+    per-locale pronunciation map — spoken text only, captions keep the real spelling. ElevenLabs
+    audio tags sparingly; punctuation and ellipses carry pacing. A `wholeTakeLocales` locale bills
+    the episode as ONE request — its joined spoken script stays ≤4,500 chars (`--stage check`
+    guards the 5,000-char cap). Claims must be true of the product — narration ships in three
+    languages and gets quoted back.
 - **Rehearse free before you bill or record.** `--stage check` (instant: spec ↔ choreography ↔
   mock-reply pairing), `--stage plan` (instant: the timeline table from estimates), then a
   `--mock-tts` take (silence-narrated, auto-composed as a draft into `.state/`) prove the
@@ -82,6 +87,12 @@ await cursor.click(pickerDoc); // the viewer hears it, then sees it
 - [ ] **`bun run --filter @tale/docs test` green** — the videos contract plus the docs suite.
 - [ ] **Shared org left as seeded** — cleanup ran; `docs:screenshots --skip-seed --only chat-thread-reply` still captures pixel-equivalent.
 - [ ] **Docs pages updated in all three locales** (episode page + any embeds) per write-docs.
+- [ ] **Every task block does real work on camera** — click/type/submit/create; a hover-only
+      block is context, not a task (the in-depth arc, STORYBOARD.md).
+- [ ] **Pitfall + verify beats present** — one real failure shown and diagnosed; the outcome
+      proven on a different surface.
+- [ ] **Table read passed the banned-pattern list in every locale** (STORYBOARD.md register), and
+      `--stage check` is green — no whole-take budget or register warnings left standing.
 
 ## Companion files
 

--- a/.agents/skills/produce-video/STORYBOARD.md
+++ b/.agents/skills/produce-video/STORYBOARD.md
@@ -47,21 +47,80 @@ How an episode is authored — read alongside the worked example,
   Every surface a scene touches belongs in the episode's `warmup`.
 - **Calm is a feature.** The grounding beat in Episode 1 is eighteen seconds on one unmoving
   answer — stillness directs attention to the voice. Do not fill every second with motion.
+- **Cold-open on the end state.** End the warmup on the episode's OUTCOME surface (the finished
+  run journal, the built agent, the connected integration) so the title card reveals over it —
+  the opening narration promises the concrete result the viewer will have produced by the outro.
+- **Locale-resolved UI text is DATA, never a literal anchor.** Catalog card names (each
+  automation.json's `i18n` block), the builtin agent's display name, and any other
+  manifest-translated string get a per-locale map in `scenes.ts` (see `CATALOG_CARD_NAME` in
+  `ep5-automations/scenes.ts`) — an English `getByText` fails the de/fr take, or worse, silently
+  passes on an i18n regression. Chrome anchors keep using `rt.t()`/href literals.
+
+## The in-depth arc
+
+An episode is a guide, not a tour: the viewer DOES something real and can repeat it afterwards.
+The arc, mapped onto the scene grammar (14–19 scenes, 5–6 minutes; ep1 stays the short trailer):
+
+| Block            | Scenes   | Chapter card    | What it does                                                                                      |
+| ---------------- | -------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| Cold open        | `title`  | —               | Card over the end-state surface; the voice promises the concrete outcome.                         |
+| Context          | 1–2      | first card      | Where we are, what already exists in this workspace, the job to be done.                          |
+| Task blocks ×2–4 | 2–5 each | one per block   | The real work: do → name why this choice (and the rejected alternative) → observe the result.     |
+| Pitfall          | 1–2      | "When it fails" | A real failure or classic mistake shown, diagnosed, and fixed or located — never moralized about. |
+| Verify           | 1        | optional        | Prove the outcome on a DIFFERENT surface (journal row, audit entry, cited answer, updated table). |
+| Recap            | 1        | —               | The verbs the viewer just did + the docs page by name.                                            |
+| Outro            | `outro`  | —               | The next episode's concrete promise; `tailMs ≥ 3600`.                                             |
+
+**Every task block contains a real interaction** — click, type, submit, create. A block that only
+navigates and hovers is context, not a task; an episode of only context is the old series. Longer
+scenes breathe via `minMs` floors — the cursor works unhurried while the voice pauses.
 
 ## Writing the narration
 
+The register is **a competent colleague showing you at your desk** — not an essayist. Checkable
+rules, enforced by the table read (and the objective ones by `--stage check`):
+
+- **Spoken language.** Contractions wherever a person would use them ("let's", "here's",
+  "you'll"). Sentences average ≤16 words. If you wouldn't say it across a desk, cut it.
+- **Action + reason in the same breath.** Name what's being clicked/typed and why, together: "We
+  pick Member, because most people never need more." Never a claim without its on-screen evidence
+  in the same scene.
+- **Decisions name the rejected alternative.** At every real choice (role, model, scope, trigger):
+  "X, because…; Y would also work when…". At least one per task block.
+- **Numbers over adjectives.** "340 of 380 URLs", "shown once — copy it now"; never "powerful",
+  "seamless".
+- **One metaphor per episode, max** — and only if the UI shows it. **One series callback per
+  episode, max.**
+- **Closers recap actions.** What the viewer DID (verbs), the docs page by name, the next
+  episode's promise. Aphorisms are banned:
+
+| Banned pattern                          | It sounded like                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------- |
+| Aphorism closer "X is not Y; it is Z"   | "Trust is not a feeling; it is a record."                                 |
+| Wiring/machinery/doors/gates lexicon    | "hier ist die Verdrahtung", "the machinery itself", "walks the doors"     |
+| Personified abstractions                | "a whole capability lights up", "budgets that turn amber"                 |
+| Chiasmus / parallelism for its own sake | "Connect boldly — because each door was built to be opened deliberately." |
+| Presenter flourishes                    | "Now the centerpiece.", "And the heavy machinery:"                        |
+| Zero-contraction register               | "Let us start where your team will spend most of its time"                |
+| Words nobody says aloud                 | "attributable", "consequential action", "eingehegt", "exigibles"          |
+
 Draft the whole episode in English first and read it aloud — cut anything you stumble over. Then
 write each other locale NATIVELY against the same scene outline (write-translations voice files),
-checking spoken UI vocabulary against the shipped catalog. In German, never OPEN a sentence with
-the brand — the pronunciation respelling is stable mid-sentence and unstable sentence-initially.
-Keep scenes between one and three sentences (~8–20 s of speech); the 5,000-character ElevenLabs request cap is far above any sane
-scene. End the episode by naming what the next one covers — the series is a serial.
+checking spoken UI vocabulary against the shipped catalog; the banned list applies per locale
+(a native German aphorism dies the same death as a calqued one). In German, never OPEN a sentence
+with the brand — the pronunciation respelling is stable mid-sentence and unstable
+sentence-initially. Keep scenes between one and three sentences (~8–20 s of speech). **Whole-take
+budget:** a locale in `wholeTakeLocales` bills the episode as ONE ElevenLabs request (hard cap
+5,000 chars) — keep the JOINED spoken script ≤4,500 chars (~700 EN words; read the spoken-chars
+line of `--stage plan`); over budget, tighten the script or flip that locale to per-scene BEFORE
+any tts. End the episode by naming what the next one covers — the series is a serial.
 
 ## Adding an episode, in order
 
 1. Scaffold the pair: `bun run gen` → `video-episode` (spec + choreography skeleton with the
-   series voices and the warmup contract).
-2. Storyboard on paper: scenes, surfaces, the one wow moment, where the AI-literacy beat lands.
+   series voices, the arc scene stubs, and the warmup contract).
+2. Storyboard on paper against the arc: the outcome, the 2–4 task blocks, the pitfall, the verify
+   surface, where the chapter cards land.
 3. Write `episode.ts` narration (en first, then de/fr natively) + any new mock replies
    (`lib/mocks/overrides/docs-replies.ts`) and demo-content the surfaces need (seeder, not takes).
    `--stage check` and `--stage plan` are instant — run them as you go.

--- a/.claude/skills/produce-video/SKILL.md
+++ b/.claude/skills/produce-video/SKILL.md
@@ -23,13 +23,18 @@ any asset under `services/docs/public/videos/**`, a `<Video>` embed on a docs pa
   choreography. The narration is the spine: scene budgets derive from its measured audio, so a
   script change re-plans the timeline and re-records the take. (Why: pacing edits after recording
   cost a full re-record anyway — do the cheap iteration on paper.)
-- **Narration is docs prose, spoken.** Docs voice per locale (write-translations: du/tu, no
-  bureaucratic German, no marketed French), written natively — never translated word for word.
-  Spoken UI vocabulary matches the shipped catalog (`Wissen`, `Connaissances`). Words a locale's
-  voice mis-reads (the brand, product terms) get a respelling in the pipeline's per-locale
-  pronunciation map — spoken text only, captions keep the real spelling. ElevenLabs audio
-  tags sparingly; punctuation and ellipses carry pacing. Claims must be true of the product —
-  narration ships in three languages and gets quoted back.
+- **Narration is a colleague showing you, spoken.** Contractions, short spoken sentences, action +
+  reason in the same breath, every real choice names a rejected alternative, one pitfall beat and
+  one verify beat per episode, closers recap what the viewer DID — never aphorisms (register rules
+  - banned-pattern list: [`STORYBOARD.md`](STORYBOARD.md)). Written natively per locale
+    (write-translations: du/tu, no bureaucratic German, no marketed French) — never translated word
+    for word. Spoken UI vocabulary matches the shipped catalog (`Wissen`, `Connaissances`). Words a
+    locale's voice mis-reads (the brand, product terms) get a respelling in the pipeline's
+    per-locale pronunciation map — spoken text only, captions keep the real spelling. ElevenLabs
+    audio tags sparingly; punctuation and ellipses carry pacing. A `wholeTakeLocales` locale bills
+    the episode as ONE request — its joined spoken script stays ≤4,500 chars (`--stage check`
+    guards the 5,000-char cap). Claims must be true of the product — narration ships in three
+    languages and gets quoted back.
 - **Rehearse free before you bill or record.** `--stage check` (instant: spec ↔ choreography ↔
   mock-reply pairing), `--stage plan` (instant: the timeline table from estimates), then a
   `--mock-tts` take (silence-narrated, auto-composed as a draft into `.state/`) prove the
@@ -82,6 +87,12 @@ await cursor.click(pickerDoc); // the viewer hears it, then sees it
 - [ ] **`bun run --filter @tale/docs test` green** — the videos contract plus the docs suite.
 - [ ] **Shared org left as seeded** — cleanup ran; `docs:screenshots --skip-seed --only chat-thread-reply` still captures pixel-equivalent.
 - [ ] **Docs pages updated in all three locales** (episode page + any embeds) per write-docs.
+- [ ] **Every task block does real work on camera** — click/type/submit/create; a hover-only
+      block is context, not a task (the in-depth arc, STORYBOARD.md).
+- [ ] **Pitfall + verify beats present** — one real failure shown and diagnosed; the outcome
+      proven on a different surface.
+- [ ] **Table read passed the banned-pattern list in every locale** (STORYBOARD.md register), and
+      `--stage check` is green — no whole-take budget or register warnings left standing.
 
 ## Companion files
 

--- a/.claude/skills/produce-video/STORYBOARD.md
+++ b/.claude/skills/produce-video/STORYBOARD.md
@@ -47,21 +47,80 @@ How an episode is authored — read alongside the worked example,
   Every surface a scene touches belongs in the episode's `warmup`.
 - **Calm is a feature.** The grounding beat in Episode 1 is eighteen seconds on one unmoving
   answer — stillness directs attention to the voice. Do not fill every second with motion.
+- **Cold-open on the end state.** End the warmup on the episode's OUTCOME surface (the finished
+  run journal, the built agent, the connected integration) so the title card reveals over it —
+  the opening narration promises the concrete result the viewer will have produced by the outro.
+- **Locale-resolved UI text is DATA, never a literal anchor.** Catalog card names (each
+  automation.json's `i18n` block), the builtin agent's display name, and any other
+  manifest-translated string get a per-locale map in `scenes.ts` (see `CATALOG_CARD_NAME` in
+  `ep5-automations/scenes.ts`) — an English `getByText` fails the de/fr take, or worse, silently
+  passes on an i18n regression. Chrome anchors keep using `rt.t()`/href literals.
+
+## The in-depth arc
+
+An episode is a guide, not a tour: the viewer DOES something real and can repeat it afterwards.
+The arc, mapped onto the scene grammar (14–19 scenes, 5–6 minutes; ep1 stays the short trailer):
+
+| Block            | Scenes   | Chapter card    | What it does                                                                                      |
+| ---------------- | -------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| Cold open        | `title`  | —               | Card over the end-state surface; the voice promises the concrete outcome.                         |
+| Context          | 1–2      | first card      | Where we are, what already exists in this workspace, the job to be done.                          |
+| Task blocks ×2–4 | 2–5 each | one per block   | The real work: do → name why this choice (and the rejected alternative) → observe the result.     |
+| Pitfall          | 1–2      | "When it fails" | A real failure or classic mistake shown, diagnosed, and fixed or located — never moralized about. |
+| Verify           | 1        | optional        | Prove the outcome on a DIFFERENT surface (journal row, audit entry, cited answer, updated table). |
+| Recap            | 1        | —               | The verbs the viewer just did + the docs page by name.                                            |
+| Outro            | `outro`  | —               | The next episode's concrete promise; `tailMs ≥ 3600`.                                             |
+
+**Every task block contains a real interaction** — click, type, submit, create. A block that only
+navigates and hovers is context, not a task; an episode of only context is the old series. Longer
+scenes breathe via `minMs` floors — the cursor works unhurried while the voice pauses.
 
 ## Writing the narration
 
+The register is **a competent colleague showing you at your desk** — not an essayist. Checkable
+rules, enforced by the table read (and the objective ones by `--stage check`):
+
+- **Spoken language.** Contractions wherever a person would use them ("let's", "here's",
+  "you'll"). Sentences average ≤16 words. If you wouldn't say it across a desk, cut it.
+- **Action + reason in the same breath.** Name what's being clicked/typed and why, together: "We
+  pick Member, because most people never need more." Never a claim without its on-screen evidence
+  in the same scene.
+- **Decisions name the rejected alternative.** At every real choice (role, model, scope, trigger):
+  "X, because…; Y would also work when…". At least one per task block.
+- **Numbers over adjectives.** "340 of 380 URLs", "shown once — copy it now"; never "powerful",
+  "seamless".
+- **One metaphor per episode, max** — and only if the UI shows it. **One series callback per
+  episode, max.**
+- **Closers recap actions.** What the viewer DID (verbs), the docs page by name, the next
+  episode's promise. Aphorisms are banned:
+
+| Banned pattern                          | It sounded like                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------- |
+| Aphorism closer "X is not Y; it is Z"   | "Trust is not a feeling; it is a record."                                 |
+| Wiring/machinery/doors/gates lexicon    | "hier ist die Verdrahtung", "the machinery itself", "walks the doors"     |
+| Personified abstractions                | "a whole capability lights up", "budgets that turn amber"                 |
+| Chiasmus / parallelism for its own sake | "Connect boldly — because each door was built to be opened deliberately." |
+| Presenter flourishes                    | "Now the centerpiece.", "And the heavy machinery:"                        |
+| Zero-contraction register               | "Let us start where your team will spend most of its time"                |
+| Words nobody says aloud                 | "attributable", "consequential action", "eingehegt", "exigibles"          |
+
 Draft the whole episode in English first and read it aloud — cut anything you stumble over. Then
 write each other locale NATIVELY against the same scene outline (write-translations voice files),
-checking spoken UI vocabulary against the shipped catalog. In German, never OPEN a sentence with
-the brand — the pronunciation respelling is stable mid-sentence and unstable sentence-initially.
-Keep scenes between one and three sentences (~8–20 s of speech); the 5,000-character ElevenLabs request cap is far above any sane
-scene. End the episode by naming what the next one covers — the series is a serial.
+checking spoken UI vocabulary against the shipped catalog; the banned list applies per locale
+(a native German aphorism dies the same death as a calqued one). In German, never OPEN a sentence
+with the brand — the pronunciation respelling is stable mid-sentence and unstable
+sentence-initially. Keep scenes between one and three sentences (~8–20 s of speech). **Whole-take
+budget:** a locale in `wholeTakeLocales` bills the episode as ONE ElevenLabs request (hard cap
+5,000 chars) — keep the JOINED spoken script ≤4,500 chars (~700 EN words; read the spoken-chars
+line of `--stage plan`); over budget, tighten the script or flip that locale to per-scene BEFORE
+any tts. End the episode by naming what the next one covers — the series is a serial.
 
 ## Adding an episode, in order
 
 1. Scaffold the pair: `bun run gen` → `video-episode` (spec + choreography skeleton with the
-   series voices and the warmup contract).
-2. Storyboard on paper: scenes, surfaces, the one wow moment, where the AI-literacy beat lands.
+   series voices, the arc scene stubs, and the warmup contract).
+2. Storyboard on paper against the arc: the outcome, the 2–4 task blocks, the pitfall, the verify
+   surface, where the chapter cards land.
 3. Write `episode.ts` narration (en first, then de/fr natively) + any new mock replies
    (`lib/mocks/overrides/docs-replies.ts`) and demo-content the surfaces need (seeder, not takes).
    `--stage check` and `--stage plan` are instant — run them as you go.

--- a/services/platform/tests/docs-videos/episodes/ep1-welcome/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep1-welcome/scenes.ts
@@ -32,6 +32,14 @@ const ASSISTANT_NAME = {
 /** The hidden autoInstall triage automation (see docs-screenshots manifest). */
 const TRIAGE_AUTOMATION_PATH = 'projects__tasks__triage-unassigned';
 
+/** Catalog card name — locale-resolved DATA like the assistant's display
+ * name: the grid renders automation.json's `i18n` block per locale. */
+const RESOLVE_ISSUES_CARD_NAME = {
+  en: 'Resolve GitHub issues',
+  de: 'GitHub-Issues lösen',
+  fr: 'Résoudre les issues GitHub',
+} as const;
+
 /** A primary-rail link, located by target URL — immune to locale. */
 function rail(rt: SceneRuntime, path: string) {
   return rt.page
@@ -260,7 +268,9 @@ export const SCENES: readonly SceneChoreography[] = [
       await allTab.waitFor({ state: 'visible', timeout: 30_000 });
       await cue(2.0);
       await cursor.click(allTab);
-      const card = page.getByText('Resolve GitHub issues').first();
+      const card = page
+        .getByText(RESOLVE_ISSUES_CARD_NAME[rt.ctx.locale])
+        .first();
       await card.waitFor({ state: 'visible', timeout: 15_000 });
       await cue(5.5);
       await cursor.hover(card);

--- a/services/platform/tests/docs-videos/episodes/ep5-automations/scenes.ts
+++ b/services/platform/tests/docs-videos/episodes/ep5-automations/scenes.ts
@@ -22,6 +22,29 @@ const APPROVAL_FIELD_LABEL = {
   fr: 'Derniers ajustements',
 } as const;
 
+/** Catalog card names are locale-resolved DATA: the grid renders each
+ * automation.json's `i18n` block, so anchors must speak the take's locale —
+ * an English anchor fails every de/fr take (and before the grid fix, it
+ * silently PASSED on the untranslated cards). Values quote the manifests
+ * (fixtures config/default + builtin triage-unassigned). */
+const CATALOG_CARD_NAME = {
+  resolveGithubIssues: {
+    en: 'Resolve GitHub issues',
+    de: 'GitHub-Issues lösen',
+    fr: 'Résoudre les issues GitHub',
+  },
+  syncGmailEmails: {
+    en: 'Sync Gmail emails',
+    de: 'Gmail-E-Mails synchronisieren',
+    fr: 'Synchroniser les e-mails Gmail',
+  },
+  triageUnassigned: {
+    en: 'Triage unassigned tasks',
+    de: 'Unzugewiesene Aufgaben sichten',
+    fr: 'Trier les tâches non assignées',
+  },
+} as const;
+
 function rail(rt: SceneRuntime, path: string) {
   return rt.page
     .locator(`nav a[href="/dashboard/${rt.ctx.orgId}${path}"]`)
@@ -92,12 +115,18 @@ export const SCENES: readonly SceneChoreography[] = [
       await allTab.waitFor({ state: 'visible', timeout: 30_000 });
       await cue(3.0);
       await cursor.click(allTab);
-      const github = page.getByText('Resolve GitHub issues').first();
+      const github = page
+        .getByText(CATALOG_CARD_NAME.resolveGithubIssues[rt.ctx.locale])
+        .first();
       await github.waitFor({ state: 'visible', timeout: 15_000 });
       await cue(6.5);
       await cursor.hover(github);
       await cue(10.0);
-      await cursor.hover(page.getByText('Sync Gmail emails').first());
+      await cursor.hover(
+        page
+          .getByText(CATALOG_CARD_NAME.syncGmailEmails[rt.ctx.locale])
+          .first(),
+      );
     },
   },
   {
@@ -113,7 +142,9 @@ export const SCENES: readonly SceneChoreography[] = [
       await cue(2.6);
       await cursor.click(installedTab);
       const triage = page
-        .getByRole('button', { name: /Triage unassigned tasks/ })
+        .getByRole('button', {
+          name: CATALOG_CARD_NAME.triageUnassigned[ctx.locale],
+        })
         .first();
       await triage.waitFor({ state: 'visible', timeout: 15_000 });
       await cue(6.4);

--- a/services/platform/tests/docs-videos/lib/validate.ts
+++ b/services/platform/tests/docs-videos/lib/validate.ts
@@ -20,9 +20,51 @@ import type { EpisodeSpec } from './episode';
 import { LOCALES } from './episode';
 import type { ChoreographyModule } from './episodes';
 import { DEFAULT_TAIL_MS } from './timeline';
+import { toSpokenText } from './tts-text';
 
 /** The compose bookend: 1.5 s fade-out that must land inside the outro. */
 const FADE_OUT_ROOM_MS = 2000;
+
+/**
+ * A whole-take locale synthesizes the episode as ONE ElevenLabs request, and
+ * the API hard-caps a request at 5,000 characters. Error with headroom so the
+ * tts stage can never 400 mid-batch; warn on approach so the script gets
+ * tightened (or the locale flipped to per-scene) before billing.
+ */
+const WHOLE_TAKE_MAX_CHARS = 4800;
+const WHOLE_TAKE_WARN_CHARS = 4500;
+
+/** The in-depth series band (produce-video STORYBOARD.md): 600–700 EN words
+ * play 5–6 minutes at ~145 wpm; the bounds catch a tour-length or
+ * over-stuffed script early. Warning only — episode length is judgment. */
+const EN_WORDS_MIN = 450;
+const EN_WORDS_MAX = 750;
+
+/** Register smells the narration doctrine bans outright (STORYBOARD.md
+ * "Writing the narration") — warnings, never errors: voice stays a human
+ * call, the lint only flags the patterns that always read as essay prose. */
+const BANNED_NARRATION_PATTERNS: ReadonlyArray<{
+  readonly pattern: RegExp;
+  readonly hint: string;
+}> = [
+  {
+    pattern:
+      /\b(?:is|are) not (?:an? )?[^.;—]{1,40}[;—]\s*(?:it(?:'s| is)|they(?:'re| are))\b/iu,
+    hint: 'aphorism template ("X is not Y — it is Z") — say the concrete thing instead',
+  },
+  {
+    pattern: /\b(?:wiring|Verdrahtung|câblage)\b/iu,
+    hint: 'wiring metaphor — name the actual mechanism',
+  },
+  {
+    pattern: /\b(?:machinery|Maschinerie|machinerie)\b/iu,
+    hint: 'machinery metaphor — name the actual surface or setting',
+  },
+  {
+    pattern: /\bblast radius\b/iu,
+    hint: 'jargon nobody says aloud — describe what the role can actually touch',
+  },
+];
 
 export interface ValidationFinding {
   readonly severity: 'error' | 'warning';
@@ -115,6 +157,68 @@ export function validateEpisodeSpec(episode: EpisodeSpec): ValidationFinding[] {
       `${episode.id}/${outro.id}`,
       `last scene tailMs ${outro.tailMs ?? DEFAULT_TAIL_MS}ms < ${FADE_OUT_ROOM_MS}ms — the 1.5s fade-out will clip it`,
     );
+  }
+
+  if (!episode.diagnostic) {
+    // Whole-take budget: the joined spoken script (exactly as the tts stage
+    // joins it — respelled, trimmed, silent scenes dropped, '\n\n' seams)
+    // must clear the single-request cap with headroom.
+    for (const locale of episode.wholeTakeLocales ?? []) {
+      if (!completeLocales.includes(locale)) continue;
+      const joined = episode.scenes
+        .map((scene) =>
+          toSpokenText(scene.narration[locale] ?? '', locale).trim(),
+        )
+        .filter(Boolean)
+        .join('\n\n');
+      if (joined.length > WHOLE_TAKE_MAX_CHARS) {
+        error(
+          episode.id,
+          `${locale} whole-take script is ${joined.length} spoken chars — over the ` +
+            `${WHOLE_TAKE_MAX_CHARS} budget (ElevenLabs caps one request at 5,000): ` +
+            `tighten the script or drop ${locale} from wholeTakeLocales`,
+        );
+      } else if (joined.length > WHOLE_TAKE_WARN_CHARS) {
+        warning(
+          episode.id,
+          `${locale} whole-take script is ${joined.length} spoken chars — ` +
+            `approaching the ${WHOLE_TAKE_MAX_CHARS} budget; tighten before billing`,
+        );
+      }
+    }
+
+    // The in-depth band — EN carries the series pacing (de/fr are written
+    // natively against the same outline and inherit its shape).
+    if (completeLocales.includes('en')) {
+      const words = episode.scenes
+        .map((scene) => scene.narration.en ?? '')
+        .join(' ')
+        .split(/\s+/u)
+        .filter(Boolean).length;
+      if (words < EN_WORDS_MIN || words > EN_WORDS_MAX) {
+        warning(
+          episode.id,
+          `EN narration is ${words} words — outside the ${EN_WORDS_MIN}–${EN_WORDS_MAX} ` +
+            `in-depth band (~5–6 min at ~145 wpm; produce-video STORYBOARD.md)`,
+        );
+      }
+    }
+
+    // Banned register — the patterns that always read as essay prose.
+    for (const scene of episode.scenes) {
+      for (const locale of LOCALES) {
+        const narration = scene.narration[locale];
+        if (!narration) continue;
+        for (const { pattern, hint } of BANNED_NARRATION_PATTERNS) {
+          if (pattern.test(narration)) {
+            warning(
+              `${episode.id}/${scene.id}`,
+              `${locale} narration: ${hint}`,
+            );
+          }
+        }
+      }
+    }
   }
 
   // A hero prompt that pairs with no DOCS_REPLIES match clause streams the

--- a/tools/plop/templates/video-episode/episode.ts.hbs
+++ b/tools/plop/templates/video-episode/episode.ts.hbs
@@ -2,10 +2,14 @@
  * {{episodeLabel}} — "{{titleEn}}". TODO: one line on what the episode
  * teaches and the thread that carries it.
  *
- * Narration doctrine (produce-video skill): docs voice, written natively per
- * locale — never translated word for word (write-translations). Storyboard
- * FIRST (.agents/skills/produce-video/STORYBOARD.md), then a table read,
- * then choreography. Scene ids join episode.ts ↔ scenes.ts — validate with
+ * Narration doctrine (produce-video skill): a competent colleague showing
+ * you at your desk — contractions, short spoken sentences, action + reason
+ * in the same breath, every real choice names a rejected alternative, one
+ * pitfall beat + one verify beat per episode, closers recap what the viewer
+ * DID (never aphorisms). Written natively per locale — never translated
+ * word for word (write-translations). Storyboard FIRST
+ * (.agents/skills/produce-video/STORYBOARD.md), then a table read, then
+ * choreography. Scene ids join episode.ts ↔ scenes.ts — validate with
  * `bun run docs:videos -- --episode {{id}} --stage check`.
  */
 
@@ -31,8 +35,12 @@ export const {{constName}}: EpisodeSpec = {
     de: 'rKiu7lQ4c5P3az3745s3',
     fr: 'QbsdzCokdlo98elkq4Pc',
   },
-  /** One whole-episode generation per locale — consistent delivery. */
-  wholeTakeLocales: ['en', 'de', 'fr'],
+  /** EN ships as ONE whole-take generation (consistent delivery) and its
+   * JOINED spoken script must stay ≤4,500 chars (~700 words) — `--stage
+   * check` guards the 5,000-char ElevenLabs request cap. de/fr synthesize
+   * per-scene: no episode-level cap, and a single-scene edit re-bills only
+   * that scene. */
+  wholeTakeLocales: ['en'],
   // Typing a live chat prompt on camera? Add heroPromptByLocale and pair
   // every locale with a DOCS_REPLIES match clause (lib/mocks/overrides/
   // docs-replies.ts) — `--stage check` enforces the pairing.
@@ -41,15 +49,57 @@ export const {{constName}}: EpisodeSpec = {
       id: 'title',
       leadInMs: 1200,
       narration: {
-        en: 'TODO — the opening line the title card plays under.',
+        en: 'TODO — cold open over the END-STATE surface: promise the concrete outcome the viewer will have produced by the outro.',
         de: 'TODO',
         fr: 'TODO',
       },
     },
     {
-      id: 'first-scene',
+      // Context: where we are, what already exists here, the job to be done.
+      id: 'context',
       narration: {
-        en: 'TODO — write the story before the choreography.',
+        en: 'TODO',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+    {
+      // Task block 1 of 2–4. Every block contains a REAL interaction
+      // (click/type/submit — never hover-only): do it, say why this choice
+      // over the rejected alternative, observe the result on screen.
+      id: 'task-1',
+      narration: {
+        en: 'TODO',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+    {
+      // Pitfall: a real failure or classic mistake shown and diagnosed —
+      // chapter card "When it fails" (chapterByLocale on this scene).
+      id: 'pitfall',
+      narration: {
+        en: 'TODO',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+    {
+      // Verify: prove the outcome on a DIFFERENT surface (journal row,
+      // audit entry, cited answer, updated table).
+      id: 'verify',
+      narration: {
+        en: 'TODO',
+        de: 'TODO',
+        fr: 'TODO',
+      },
+    },
+    {
+      // Recap: the verbs the viewer just did + the docs page by name +
+      // what the next episode covers.
+      id: 'recap',
+      narration: {
+        en: 'TODO',
         de: 'TODO',
         fr: 'TODO',
       },

--- a/tools/plop/templates/video-episode/scenes.ts.hbs
+++ b/tools/plop/templates/video-episode/scenes.ts.hbs
@@ -56,7 +56,7 @@ export const SCENES: readonly SceneChoreography[] = [
     },
   },
   {
-    id: 'first-scene',
+    id: 'context',
     run: async (rt) => {
       const { page, cursor, cue } = rt;
       // Unveiling the settled app IS the transition from the title card.
@@ -67,6 +67,32 @@ export const SCENES: readonly SceneChoreography[] = [
       // TODO: the scene's beats, each landing with the narration:
       //   await cue(3.2);
       //   await cursor.click(page.getByRole('link', { name: rt.t('…') }));
+    },
+  },
+  {
+    // Task blocks do the REAL work on camera; register anything created
+    // on `rt.ctx.cleanup` the moment it exists.
+    id: 'task-1',
+    run: async (_rt) => {
+      // TODO
+    },
+  },
+  {
+    id: 'pitfall',
+    run: async (_rt) => {
+      // TODO: show the failure, then the diagnosis path.
+    },
+  },
+  {
+    id: 'verify',
+    run: async (_rt) => {
+      // TODO: prove the outcome on a different surface.
+    },
+  },
+  {
+    id: 'recap',
+    run: async (_rt) => {
+      // TODO: usually the surface at rest; cursor hides here.
     },
   },
   {


### PR DESCRIPTION
Part of the video-series re-production (pilot lands separately). This PR carries the content standard the rewrites build to, plus the pipeline guards that make its objective parts checkable.

## What's here

- **STORYBOARD.md** — the in-depth arc (cold open on the end-state surface → context → 2–4 task blocks each with a REAL interaction → a pitfall shown and diagnosed → the outcome verified on a different surface → recap → outro) and the new narration register ("a competent colleague showing you at your desk"): contractions, action + reason in one breath, decisions name the rejected alternative, numbers over adjectives — with a **banned-pattern table built from the shipped lines** ("Trust is not a feeling; it is a record", "hier ist die Verdrahtung", …). Also replaces the stale claim that the 5,000-char ElevenLabs cap "is far above any sane scene": for `wholeTakeLocales` it binds per EPISODE.
- **SKILL.md** — narration rule rewritten to the register; 3 new ship-checklist boxes (real interaction per task block · pitfall + verify beats · table read passed the banned list). Mirrors regenerated via `bun run skills:sync`.
- **lib/validate.ts** — new guards in the always-on episode gate: ERROR when a whole-take locale's joined spoken script exceeds 4,800 chars (an over-cap request would 400 mid-batch), WARN >4,500; WARN when EN is outside the 450–750-word depth band; WARN on the banned-register patterns. **Warnings never fail a gate** — voice judgment stays human; verified live: the 9 not-yet-rewritten episodes print warnings and exit 0.
- **gen:episode templates** — `wholeTakeLocales` corrected to `['en']` (what all 10 shipped episodes actually use; de/fr synthesize per-scene so a single-scene edit re-bills one scene, and deepened de/fr scripts would straddle the whole-take cap), arc scene skeleton (context/task-1/pitfall/verify/recap), register header comment. Spec/choreography stub ids kept in parity.
- **ep5 + ep1 scenes.ts** — catalog-card anchors move from English literals (`getByText('Resolve GitHub issues')`) to per-locale maps quoting the manifests' `i18n` blocks. With #2806 merged, the English anchors would fail every de/fr take; before it they silently passed on the untranslated cards — this is the masking trap that hid the bug.

## Verification

- `bunx vitest --run --project server tests/docs-videos/lib/episodes.test.ts` — green (2/2).
- `bun run docs:videos -- --episode ep5-automations,ep9-governance,ep8-people --stage check` — register + depth warnings print for the old scripts, exit 0.
- Platform typecheck + `bun run skills:check` green.

Depends conceptually on #2806 (grid i18n) for any future de/fr take of ep1/ep5 — no build-time dependency.