### PR TITLE
feat(platform): serve transcript directly while RAG index is pending

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -1311,7 +1311,9 @@ export function ChatInterface({
               // md:pt-19 = the floating glass top bar (52px) + the list's own
               // 24px breathing room: at rest content clears the bar; once
               // scrolled it slides beneath the blur (the scroller spans the
-              // full column height behind the overlay).
+              // full column height behind the overlay). Send-snap / response
+              // slack read this padding-top as their top inset so a just-sent
+              // bubble stays fully visible under the glass, not at 16px.
               'flex flex-col overflow-y-visible p-4 sm:p-6 md:pt-19',
               showWelcome && 'flex-1 justify-center',
             )}

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -25,7 +25,7 @@ import { useBranchContext } from '../context/branch-context';
 import type { ChatItem } from '../hooks/use-merged-chat-items';
 import { usePersonalizationActiveForThread } from '../hooks/use-personalization-active';
 import { VoiceOutputProvider } from '../hooks/voice-output-context';
-import { TOP_INSET } from '../scroll-constants';
+import { resolveTopInset } from '../scroll-constants';
 import type { RouteReason } from '../utils/route-reason';
 import { hasThoughtSteps } from '../utils/thought-predicates';
 import { ApprovalCardRenderer } from './approval-card-renderer';
@@ -78,8 +78,9 @@ function useVirtualizedMessagesFlag(): boolean {
   return enabled;
 }
 
-// TOP_INSET imported from ../scroll-constants — shared with use-chat-scroll
-// so the slack formula and the send-snap target always agree.
+// resolveTopInset imported from ../scroll-constants — shared with
+// use-chat-scroll so the slack formula and the send-snap target always agree
+// (both read the content wrapper's padding-top).
 
 /**
  * Native "virtualization-lite": history messages (everything before the
@@ -97,7 +98,7 @@ const HISTORY_CONTENT_VISIBILITY =
 /**
  * Pure slack formula: how tall the response area must be so that scrolling
  * to the bottom positions the last user message at the viewport top (with
- * TOP_INSET breathing room). Matches assistant-ui's ViewportSlack pattern.
+ * the live top inset). Matches assistant-ui's ViewportSlack pattern.
  * A user message taller than the viewport naturally yields 0 — its top still
  * anchors at the viewport top via the send-snap scroll target.
  * Exported for unit testing.
@@ -140,13 +141,18 @@ function computeResponseMinHeight(
   const padBottom = contentWrapper
     ? parseFloat(getComputedStyle(contentWrapper).paddingBottom) || 0
     : 0;
+  // padding-top is the clearance for the floating glass header on md+
+  // (`md:pt-19`); must match use-chat-scroll's send-snap inset.
+  const padTop = contentWrapper
+    ? parseFloat(getComputedStyle(contentWrapper).paddingTop) || 0
+    : 0;
 
   return computeSlackPx({
     viewportH: container.clientHeight,
     userMsgH,
     gap,
     padBottom,
-    topInset: TOP_INSET,
+    topInset: resolveTopInset(padTop),
   });
 }
 

--- a/services/platform/app/features/chat/hooks/use-chat-scroll.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-scroll.ts
@@ -11,7 +11,7 @@ import {
 import { useAutoScroll } from '@/app/hooks/use-auto-scroll';
 import { usePrefersReducedMotion } from '@/app/hooks/use-prefers-reduced-motion';
 
-import { TOP_INSET } from '../scroll-constants';
+import { resolveTopInset } from '../scroll-constants';
 
 interface UseChatScrollParams {
   /** URL thread id — drives the thread-open scroll (restore or bottom). */
@@ -153,7 +153,8 @@ export function clearSavedThreadScrollTops() {
  *                       per tick, so late-resolving history heights converge
  *                       on the true position.
  *  - 'bottom'        → the live bottom.
- *  - 'last-user-top' → the last user message's top at TOP_INSET (send/edit
+ *  - 'last-user-top' → the last user message's top at the live top inset
+ *                       (content padding-top / TOP_INSET fallback — send/edit
  *                       snap, thread first-open). Re-resolved per tick
  *                       against the live element, so response-slack
  *                       corrections and late-settling content keep the
@@ -278,9 +279,10 @@ export interface ChatScroll {
   showScrollButton: boolean;
   /**
    * Force-snap signal: scrolls the just-sent user message to the viewport
-   * top (TOP_INSET) on the next content settle, REGARDLESS of whether the
-   * user had scrolled away. This is the ONLY thing that scrolls the chat
-   * besides explicit user actions — AI generation growth never does.
+   * top (content padding-top inset) on the next content settle, REGARDLESS
+   * of whether the user had scrolled away. This is the ONLY thing that
+   * scrolls the chat besides explicit user actions — AI generation growth
+   * never does.
    *
    *  - `true`  → INSTANT snap (the FIRST message of a chat — it must render
    *    at its position without any visible scrolling).
@@ -435,6 +437,12 @@ export function useChatScroll({
       );
     };
 
+    // Match response-slack: content padding-top clears the floating glass
+    // header on md+ (`md:pt-19`). A hardcoded TOP_INSET alone lands short
+    // bubbles under the blur.
+    const getTopInset = (): number =>
+      resolveTopInset(parseFloat(getComputedStyle(content).paddingTop) || 0);
+
     const resolveHoldTarget = (hold: ScrollHold): number =>
       resolveSnapTargetTop({
         kind: hold.kind,
@@ -443,7 +451,7 @@ export function useChatScroll({
         clientHeight: container.clientHeight,
         lastUserTop:
           hold.kind === 'last-user-top' ? getLastUserTop() : undefined,
-        topInset: TOP_INSET,
+        topInset: getTopInset(),
       });
 
     const applyHold = (hold: ScrollHold) => {
@@ -684,12 +692,16 @@ export function useChatScroll({
           c.getBoundingClientRect().top +
           c.scrollTop
         : undefined;
+    const contentEl = contentRef.current;
+    const topInset = resolveTopInset(
+      contentEl ? parseFloat(getComputedStyle(contentEl).paddingTop) || 0 : 0,
+    );
     const decision = resolveThreadOpenTarget({
       savedTop,
       scrollHeight: c.scrollHeight,
       clientHeight: c.clientHeight,
       lastUserTop,
-      topInset: TOP_INSET,
+      topInset,
     });
     // Keep the RAW saved top in a position hold (not the clamped first
     // target): content below the estimate-based fold grows as real heights
@@ -713,6 +725,7 @@ export function useChatScroll({
     threadId,
     messagesLength,
     containerRef,
+    contentRef,
     lastUserMessageRef,
     beginHold,
     reseedScrollTrackers,

--- a/services/platform/app/features/chat/hooks/use-chat-video-links.retry-toast.test.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-video-links.retry-toast.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { ConvexError } from 'convex/values';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toast } from '@/app/hooks/use-toast';
+import type { Id } from '@/convex/_generated/dataModel';
+
+import { useChatVideoLinks } from './use-chat-video-links';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the silent retry click.
+//
+// `retryVideoLink` refuses retries with structured ConvexError codes — the
+// 15-minute bot-detection/rate-limit cooldown (`retryCooldown`), budget and
+// in-flight caps — and the chip's onRetry discards the returned promise.
+// `retryJob` used to await the mutation with no catch, so the refusal became
+// an unhandled rejection: the user clicked retry on a bot-walled video and
+// nothing visibly happened, while the `videoLink.errors.retryCooldown` copy
+// sat unreachable in the locale files. `retryJob` now surfaces the refusal
+// through the same toast contract as `ingestUrlsFromText`.
+// ---------------------------------------------------------------------------
+
+// The hook calls useMutation three times in fixed order (ingest, cancel,
+// retry — see use-chat-video-links.ts). A cycling dispatcher keeps the
+// mapping stable across re-renders.
+const mutationFns = [vi.fn(), vi.fn(), vi.fn()];
+let mutationCallIdx = 0;
+const retryFn = mutationFns[2];
+
+vi.mock('convex/react', () => ({
+  useQuery: vi.fn(() => undefined),
+  useMutation: vi.fn(() => mutationFns[mutationCallIdx++ % 3]),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+const toastMock = vi.mocked(toast);
+
+const JOB_ID = 'job-1' as Id<'videoLinkJobs'>;
+
+function renderRetryJob() {
+  const { result } = renderHook(() =>
+    useChatVideoLinks({ threadId: undefined, organizationId: 'org-1' }),
+  );
+  return result.current.retryJob;
+}
+
+describe('useChatVideoLinks retryJob error surfacing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('toasts the mapped copy when the mutation refuses with a structured code', async () => {
+    retryFn.mockRejectedValueOnce(
+      new ConvexError({
+        code: 'retryCooldown',
+        message: 'wait a few minutes',
+      }),
+    );
+    const retryJob = renderRetryJob();
+
+    // Must resolve, not reject — the chip's onRetry discards the promise,
+    // so a rethrow would be an unhandled rejection again.
+    await expect(retryJob(JOB_ID)).resolves.toBeUndefined();
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(toastMock).toHaveBeenCalledWith({
+      title: 'videoLink.toast.retryFailedTitle',
+      description: 'videoLink.errors.retryCooldown',
+      variant: 'destructive',
+    });
+  });
+
+  it('falls back to the generic copy on an unstructured error', async () => {
+    retryFn.mockRejectedValueOnce(new Error('network blip'));
+    const retryJob = renderRetryJob();
+
+    await expect(retryJob(JOB_ID)).resolves.toBeUndefined();
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: 'videoLink.toast.retryFailedTitle',
+      description: 'videoLink.errors.generic',
+      variant: 'destructive',
+    });
+  });
+
+  it('stays silent when the retry succeeds', async () => {
+    retryFn.mockResolvedValueOnce(undefined);
+    const retryJob = renderRetryJob();
+
+    await retryJob(JOB_ID);
+
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(retryFn).toHaveBeenCalledWith({ jobId: JOB_ID });
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-chat-video-links.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-video-links.ts
@@ -61,6 +61,21 @@ const NON_TERMINAL: ReadonlySet<string> = new Set([
   'indexing',
 ]);
 
+/**
+ * Structured `code` off a ConvexError rejection, when present. Video-link
+ * mutations reject with codes that map 1:1 to `videoLink.errors.*` keys
+ * (retryCooldown, budgetExceeded, inFlightCap, …); unstructured errors
+ * return undefined so callers fall back to the generic copy.
+ */
+function convexErrorCode(err: unknown): string | undefined {
+  return err instanceof ConvexError &&
+    typeof err.data === 'object' &&
+    err.data !== null &&
+    'code' in err.data
+    ? String(err.data.code)
+    : undefined;
+}
+
 export interface UseChatVideoLinksResult {
   jobs: VideoLinkJob[];
   isAnyProcessing: boolean;
@@ -229,19 +244,9 @@ export function useChatVideoLinks(args: {
           });
           ingested += 1;
         } catch (err) {
-          // Surface the rejection to the user. ConvexError carries a
-          // structured `code` that maps 1:1 to `videoLink.errors.*` keys;
-          // unstructured errors fall back to the generic copy.
-          // After the `instanceof ConvexError`, type-check, and
-          // `'code' in err.data` narrowings, TS already knows
-          // `err.data.code: unknown` — no cast required.
-          const code =
-            err instanceof ConvexError &&
-            typeof err.data === 'object' &&
-            err.data !== null &&
-            'code' in err.data
-              ? String(err.data.code)
-              : undefined;
+          // Surface the rejection to the user; unstructured errors fall
+          // back to the generic copy.
+          const code = convexErrorCode(err);
           toast({
             title: tChat('videoLink.toast.ingestFailedTitle'),
             description: tChat(
@@ -294,9 +299,31 @@ export function useChatVideoLinks(args: {
 
   const retryJob = useCallback(
     async (jobId: Id<'videoLinkJobs'>) => {
-      await retryMutation({ jobId });
+      try {
+        await retryMutation({ jobId });
+      } catch (err) {
+        // The mutation refuses retries with structured codes — the 15-min
+        // bot-detection/rate-limit cooldown (`retryCooldown`), budget and
+        // in-flight caps — and the chip's onRetry discards the returned
+        // promise, so without this catch the refusal is an unhandled
+        // rejection and the click reads as dead. Same surfacing contract
+        // as `ingestUrlsFromText`; nothing upstream reacts to the retry
+        // outcome, so don't rethrow.
+        const code = convexErrorCode(err);
+        toast({
+          title: tChat('videoLink.toast.retryFailedTitle'),
+          description: tChat(
+            code ? `videoLink.errors.${code}` : 'videoLink.errors.generic',
+          ),
+          variant: 'destructive',
+        });
+        console.error(
+          '[useChatVideoLinks] retry failed:',
+          err instanceof Error ? err.message : err,
+        );
+      }
     },
-    [retryMutation],
+    [retryMutation, tChat],
   );
 
   return {

--- a/services/platform/app/features/chat/scroll-constants.test.ts
+++ b/services/platform/app/features/chat/scroll-constants.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTopInset, TOP_INSET } from './scroll-constants';
+
+describe('resolveTopInset', () => {
+  it('falls back to TOP_INSET when padding is not yet measurable', () => {
+    expect(resolveTopInset(0)).toBe(TOP_INSET);
+    expect(resolveTopInset(Number.NaN)).toBe(TOP_INSET);
+  });
+
+  it('uses mobile content padding as the snap inset', () => {
+    // `p-4` / `sm:p-6` — ordinary breathing room, no floating header.
+    expect(resolveTopInset(16)).toBe(16);
+    expect(resolveTopInset(24)).toBe(24);
+  });
+
+  it('clears the floating glass header via desktop content padding', () => {
+    // Regression lock for #2805: send-snap used to hardcode TOP_INSET=16
+    // against a full-height scroller under an absolute h-18 glass bar, so
+    // short user bubbles landed half-hidden. Desktop content uses
+    // `md:pt-19` (~76px) so slack and snap stay below the blur.
+    expect(resolveTopInset(76)).toBe(76);
+    expect(resolveTopInset(76)).toBeGreaterThan(TOP_INSET);
+  });
+});

--- a/services/platform/app/features/chat/scroll-constants.ts
+++ b/services/platform/app/features/chat/scroll-constants.ts
@@ -1,7 +1,18 @@
 /**
- * Vertical inset (px) between the viewport top and the anchored last user
- * message. Shared by the response-slack min-height computation
- * (chat-messages) and the send-snap scroll target (use-chat-scroll) so the
- * slack formula and the scroll destination always agree.
+ * Fallback vertical inset (px) between the viewport top and the anchored last
+ * user message when the content wrapper's padding-top isn't measurable yet.
+ * Prefer {@link resolveTopInset} with the live padding so slack and send-snap
+ * stay in sync with the CSS that clears the floating glass header (`md:pt-19`).
  */
 export const TOP_INSET = 16;
+
+/**
+ * Live top inset for send-snap and response-area slack. The content wrapper's
+ * padding-top is the single source of truth: on desktop `md:pt-19` (~76px)
+ * clears the absolute frosted header; on smaller breakpoints `p-4` / `sm:p-6`
+ * is ordinary breathing room. Falling back to {@link TOP_INSET} covers the
+ * brief window before layout styles resolve.
+ */
+export function resolveTopInset(padTopPx: number): number {
+  return padTopPx > 0 ? padTopPx : TOP_INSET;
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -54,6 +54,7 @@ import type * as agent_tools_documents_helpers_fetch_document_comparison from ".
 import type * as agent_tools_documents_helpers_fetch_document_content from "../agent_tools/documents/helpers/fetch_document_content.js";
 import type * as agent_tools_documents_helpers_list_documents from "../agent_tools/documents/helpers/list_documents.js";
 import type * as agent_tools_documents_helpers_retrieve_document from "../agent_tools/documents/helpers/retrieve_document.js";
+import type * as agent_tools_documents_helpers_transcript_content from "../agent_tools/documents/helpers/transcript_content.js";
 import type * as agent_tools_documents_internal_actions from "../agent_tools/documents/internal_actions.js";
 import type * as agent_tools_documents_internal_mutations from "../agent_tools/documents/internal_mutations.js";
 import type * as agent_tools_files__shared from "../agent_tools/files/_shared.js";
@@ -1836,6 +1837,7 @@ declare const fullApi: ApiFromModules<{
   "agent_tools/documents/helpers/fetch_document_content": typeof agent_tools_documents_helpers_fetch_document_content;
   "agent_tools/documents/helpers/list_documents": typeof agent_tools_documents_helpers_list_documents;
   "agent_tools/documents/helpers/retrieve_document": typeof agent_tools_documents_helpers_retrieve_document;
+  "agent_tools/documents/helpers/transcript_content": typeof agent_tools_documents_helpers_transcript_content;
   "agent_tools/documents/internal_actions": typeof agent_tools_documents_internal_actions;
   "agent_tools/documents/internal_mutations": typeof agent_tools_documents_internal_mutations;
   "agent_tools/files/_shared": typeof agent_tools_files__shared;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -773,6 +773,7 @@ import type * as lib_attachments_format_markdown from "../lib/attachments/format
 import type * as lib_attachments_index from "../lib/attachments/index.js";
 import type * as lib_attachments_process_attachments from "../lib/attachments/process_attachments.js";
 import type * as lib_attachments_register_files from "../lib/attachments/register_files.js";
+import type * as lib_attachments_resolve_transcript_identity from "../lib/attachments/resolve_transcript_identity.js";
 import type * as lib_attachments_types from "../lib/attachments/types.js";
 import type * as lib_attachments_workspace_uploads from "../lib/attachments/workspace_uploads.js";
 import type * as lib_auth_e2e_harness from "../lib/auth/e2e_harness.js";
@@ -2556,6 +2557,7 @@ declare const fullApi: ApiFromModules<{
   "lib/attachments/index": typeof lib_attachments_index;
   "lib/attachments/process_attachments": typeof lib_attachments_process_attachments;
   "lib/attachments/register_files": typeof lib_attachments_register_files;
+  "lib/attachments/resolve_transcript_identity": typeof lib_attachments_resolve_transcript_identity;
   "lib/attachments/types": typeof lib_attachments_types;
   "lib/attachments/workspace_uploads": typeof lib_attachments_workspace_uploads;
   "lib/auth/e2e_harness": typeof lib_auth_e2e_harness;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1462,6 +1462,8 @@ import type * as users_update_user_name from "../users/update_user_name.js";
 import type * as users_update_user_password from "../users/update_user_password.js";
 import type * as users_validators from "../users/validators.js";
 import type * as video_links_captions_parser from "../video_links/captions_parser.js";
+import type * as video_links_clone_transcript from "../video_links/clone_transcript.js";
+import type * as video_links_donor from "../video_links/donor.js";
 import type * as video_links_ingest_video_link from "../video_links/ingest_video_link.js";
 import type * as video_links_internal_mutations from "../video_links/internal_mutations.js";
 import type * as video_links_internal_queries from "../video_links/internal_queries.js";
@@ -3246,6 +3248,8 @@ declare const fullApi: ApiFromModules<{
   "users/update_user_password": typeof users_update_user_password;
   "users/validators": typeof users_validators;
   "video_links/captions_parser": typeof video_links_captions_parser;
+  "video_links/clone_transcript": typeof video_links_clone_transcript;
+  "video_links/donor": typeof video_links_donor;
   "video_links/ingest_video_link": typeof video_links_ingest_video_link;
   "video_links/internal_mutations": typeof video_links_internal_mutations;
   "video_links/internal_queries": typeof video_links_internal_queries;

--- a/services/platform/convex/agent_tools/documents/document_retrieve_tool.test.ts
+++ b/services/platform/convex/agent_tools/documents/document_retrieve_tool.test.ts
@@ -460,6 +460,164 @@ describe('retrieveDocument helper', () => {
   });
 });
 
+describe('transcript fallback (RAG index not ready)', () => {
+  const TRANSCRIPT = 'Source: https://youtu.be/abc\n\n[00:00:01] hello world';
+
+  /** Chat-attachment `fileMetadata` row carrying a completed transcript —
+   * the shape `insertSyntheticFileMetadata` (video captions) and
+   * `transcribe_audio` (Whisper) write before RAG indexing finishes. */
+  function transcriptRow(overrides?: Record<string, unknown>) {
+    return {
+      organizationId: ORG_ID,
+      storageId: 'chat-upload-1',
+      fileName: 'My Video.txt',
+      transcript: TRANSCRIPT,
+      transcriptionStatus: 'completed',
+      ragStatus: 'queued',
+      ...overrides,
+    };
+  }
+
+  it('serves the stored transcript while indexing is pending, without hitting RAG', async () => {
+    ({ ctx, runAction } = createCtx({
+      queryResults: [
+        null, // findDocumentByFileId — no hub row
+        transcriptRow(), // getByStorageId — transcript ready, index queued
+        [], // lookupVideoLinkSources
+      ],
+      ragResult: createRagResult(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    const result = await retrieveDocument(ctx, { fileId: 'chat-upload-1' });
+
+    expect(result.content).toBe(TRANSCRIPT);
+    expect(result.name).toBe('My Video.txt');
+    expect(result.chunkRange).toEqual({ start: 1, end: 1 });
+    expect(result.totalChunks).toBe(1);
+    expect(result.note).toMatch(/still in progress/);
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
+  it('rescues ragStatus=failed when a transcript exists, noting the failure', async () => {
+    ({ ctx, runAction } = createCtx({
+      queryResults: [
+        null,
+        transcriptRow({ ragStatus: 'failed', ragError: 'embedder down' }),
+        [],
+      ],
+      ragResult: createRagResult(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    const result = await retrieveDocument(ctx, { fileId: 'chat-upload-1' });
+
+    expect(result.content).toBe(TRANSCRIPT);
+    expect(result.note).toMatch(/indexing failed/i);
+    expect(result.note).toContain('embedder down');
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
+  it('wraps video-sourced fallback content as untrusted', async () => {
+    ({ ctx } = createCtx({
+      queryResults: [
+        null,
+        transcriptRow(),
+        [{ sourceUrl: 'https://youtu.be/abc' }], // lookupVideoLinkSources
+      ],
+      ragResult: createRagResult(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    const result = await retrieveDocument(ctx, { fileId: 'chat-upload-1' });
+
+    expect(result.content).toContain(
+      '<untrusted_source tool="document_retrieve" url="https://youtu.be/abc">',
+    );
+    expect(result.content).toContain(TRANSCRIPT);
+    expect(result.content.trimEnd()).toMatch(/<\/untrusted_source>$/);
+  });
+
+  it('paginates the transcript with the same chunk protocol', async () => {
+    const longTranscript =
+      'a'.repeat(2048) + 'b'.repeat(2048) + 'c'.repeat(500);
+    ({ ctx } = createCtx({
+      queryResults: [null, transcriptRow({ transcript: longTranscript }), []],
+      ragResult: createRagResult(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    const result = await retrieveDocument(ctx, {
+      fileId: 'chat-upload-1',
+      chunkStart: 2,
+      chunkEnd: 2,
+    });
+
+    expect(result.content).toBe('b'.repeat(2048));
+    expect(result.chunkRange).toEqual({ start: 2, end: 2 });
+    expect(result.totalChunks).toBe(3);
+  });
+
+  it('keeps the indexing error when transcription has not completed', async () => {
+    ({ ctx } = createCtx({
+      queryResults: [null, transcriptRow({ transcriptionStatus: 'running' })],
+      ragResult: createRagResult(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    await expect(
+      retrieveDocument(ctx, { fileId: 'chat-upload-1' }),
+    ).rejects.toThrow('still being indexed');
+  });
+
+  it('keeps the failed error when no transcript exists', async () => {
+    ({ ctx } = createCtx({
+      queryResults: [
+        null,
+        transcriptRow({
+          transcript: '',
+          ragStatus: 'failed',
+          ragError: 'crawler timeout',
+        }),
+      ],
+      ragResult: createRagResult(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    await expect(
+      retrieveDocument(ctx, { fileId: 'chat-upload-1' }),
+    ).rejects.toThrow('RAG indexing failed');
+  });
+
+  it('leaves the note unset on the normal RAG path', async () => {
+    ({ ctx } = createCtx({
+      queryResults: [
+        null,
+        {
+          organizationId: ORG_ID,
+          storageId: 'chat-upload-1',
+          ragStatus: 'completed',
+        },
+        { slug: ORG_SLUG },
+        [],
+      ],
+      ragResult: createRagResult({ file_id: 'chat-upload-1' }),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    }));
+
+    const result = await retrieveDocument(ctx, { fileId: 'chat-upload-1' });
+
+    expect(result.note).toBeUndefined();
+  });
+});
+
 describe('documentRetrieveArgs schema validation', () => {
   it('accepts valid fileId only', () => {
     const result = documentRetrieveArgs.parse({ fileId: 'abc123' });

--- a/services/platform/convex/agent_tools/documents/document_retrieve_tool.ts
+++ b/services/platform/convex/agent_tools/documents/document_retrieve_tool.ts
@@ -65,7 +65,7 @@ NOT FOR: searching across documents → rag_search; listing/browsing the knowled
 
 PAGINATION: the response carries chunkRange {start, end} (1-indexed), totalChunks, and truncated (content capped at ~50K chars). First call: omit chunkStart/chunkEnd. Need more? Call again with chunkStart = chunkRange.end + 1. Max 100 chunks per call.
 
-INDEXING ERRORS: "still being indexed" → the chat attachment hasn't finished RAG indexing; wait briefly and retry once before reporting to the user. "RAG indexing failed" → the file cannot be retrieved; tell the user and stop, do not retry.`,
+INDEXING: video/audio transcripts are returned even while search indexing is pending or failed — a "note" field on the result says so; the text is complete, but rag_search may not cover that file yet. For other attachments: "still being indexed" → the chat attachment hasn't finished RAG indexing; wait briefly and retry once before reporting to the user. "RAG indexing failed" → the file cannot be retrieved; tell the user and stop, do not retry.`,
     inputSchema: documentRetrieveArgs,
     execute: async (ctx, args): Promise<DocumentRetrieveResult> => {
       return retrieveDocument(ctx, args);

--- a/services/platform/convex/agent_tools/documents/helpers/fetch_document_content.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/fetch_document_content.ts
@@ -1,7 +1,7 @@
 import { internal } from '../../../_generated/api';
 import type { ActionCtx } from '../../../_generated/server';
 
-const MAX_CONTENT_CHARS = 50_000;
+export const MAX_CONTENT_CHARS = 50_000;
 
 export interface DocumentContentResult {
   fileId: string;

--- a/services/platform/convex/agent_tools/documents/helpers/retrieve_document.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/retrieve_document.ts
@@ -12,12 +12,20 @@ import {
   fetchDocumentContent,
   type DocumentContentResult,
 } from './fetch_document_content';
+import { buildTranscriptContentResult } from './transcript_content';
 
 const debugLog = createDebugLog('DEBUG_AGENT_TOOLS', '[AgentTools]');
 
 export type RetrieveDocumentArgs = z.infer<typeof documentRetrieveArgs>;
 
-export type DocumentRetrieveResult = DocumentContentResult;
+export type DocumentRetrieveResult = DocumentContentResult & {
+  /**
+   * Present when the content was served directly from the stored transcript
+   * because RAG indexing is still pending or has failed. Tells the model the
+   * text is complete but `rag_search` may not cover this file yet.
+   */
+  note?: string;
+};
 
 export async function retrieveDocument(
   ctx: ToolCtx,
@@ -45,6 +53,10 @@ export async function retrieveDocument(
     internal.documents.internal_queries.findDocumentByFileId,
     { organizationId, fileId: args.fileId },
   );
+
+  // Set when the row's RAG index isn't ready but the content is already
+  // readable from the row itself (transcript-backed chat attachments).
+  let directResult: DocumentRetrieveResult | null = null;
 
   if (document) {
     // Project files pass when this chat's verified project scope covers the
@@ -85,28 +97,68 @@ export async function retrieveDocument(
       );
     }
 
-    if (fileMetadata.ragStatus === 'failed') {
-      throw new Error(
-        `RAG indexing failed for file "${args.fileId}": ` +
-          `${fileMetadata.ragError ?? 'unknown error'}. ` +
-          'Cannot retrieve content.',
-      );
-    }
-
     if (fileMetadata.ragStatus !== 'completed') {
-      const status = fileMetadata.ragStatus ?? 'pending';
-      throw new Error(
-        `File "${args.fileId}" is still being indexed (status: ${status}). ` +
-          'Try again shortly.',
-      );
+      // Transcript-backed rows (video-link captions, audio Whisper) carry
+      // the full text on the row before indexing even starts — the RAG
+      // index is derived from that same text. Serve the source directly
+      // instead of failing on a derived index that lags (queued/running)
+      // or died (failed): unlike plain uploads, the composer unblocks the
+      // moment the transcript lands, so this window is user-reachable.
+      const transcript =
+        fileMetadata.transcriptionStatus === 'completed' &&
+        typeof fileMetadata.transcript === 'string' &&
+        fileMetadata.transcript.length > 0
+          ? fileMetadata.transcript
+          : null;
+
+      if (transcript !== null) {
+        const note =
+          fileMetadata.ragStatus === 'failed'
+            ? 'Search indexing failed for this file' +
+              (fileMetadata.ragError ? ` (${fileMetadata.ragError})` : '') +
+              '. The content in this result was read directly from the ' +
+              'stored transcript — it is the complete text, but rag_search ' +
+              'cannot find this file.'
+            : 'Search indexing is still in progress for this file. The ' +
+              'content in this result was read directly from the stored ' +
+              'transcript — it is the complete text, but rag_search may ' +
+              'not find this file yet.';
+        directResult = {
+          ...buildTranscriptContentResult({
+            fileId: args.fileId,
+            fileName: fileMetadata.fileName,
+            transcript,
+            chunkStart: args.chunkStart,
+            chunkEnd: args.chunkEnd,
+          }),
+          note,
+        };
+      } else if (fileMetadata.ragStatus === 'failed') {
+        throw new Error(
+          `RAG indexing failed for file "${args.fileId}": ` +
+            `${fileMetadata.ragError ?? 'unknown error'}. ` +
+            'Cannot retrieve content.',
+        );
+      } else {
+        const status = fileMetadata.ragStatus ?? 'pending';
+        throw new Error(
+          `File "${args.fileId}" is still being indexed (status: ${status}). ` +
+            'Try again shortly.',
+        );
+      }
     }
   }
 
-  const orgSlug = await orgSlugFromId(ctx, organizationId);
-  const result = await fetchDocumentContent(ctx, orgSlug, args.fileId, {
-    chunkStart: args.chunkStart,
-    chunkEnd: args.chunkEnd,
-  });
+  let result: DocumentRetrieveResult;
+  if (directResult !== null) {
+    result = directResult;
+  } else {
+    const orgSlug = await orgSlugFromId(ctx, organizationId);
+    result = await fetchDocumentContent(ctx, orgSlug, args.fileId, {
+      chunkStart: args.chunkStart,
+      chunkEnd: args.chunkEnd,
+    });
+  }
 
   // Prompt-injection defense: transcripts/captions reaching the agent via
   // this tool originate from attacker-controlled video metadata (uploader,
@@ -131,6 +183,7 @@ export async function retrieveDocument(
     totalChars: result.totalChars,
     truncated: result.truncated,
     wrappedAsUntrusted: videoSources.length > 0,
+    servedFromTranscript: directResult !== null,
   });
 
   return result;

--- a/services/platform/convex/agent_tools/documents/helpers/transcript_content.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/transcript_content.ts
@@ -1,0 +1,84 @@
+import {
+  MAX_CONTENT_CHARS,
+  type DocumentContentResult,
+} from './fetch_document_content';
+
+/**
+ * Direct-transcript content window for `document_retrieve`.
+ *
+ * Used when a chat attachment's RAG indexing hasn't completed (queued /
+ * running / failed) but the `fileMetadata` row already carries the full
+ * transcript — video-link captions (`insertSyntheticFileMetadata`) and audio
+ * Whisper runs (`transcribe_audio`) both write it before indexing starts.
+ * The RAG index is derived from that same text, so serving the source is
+ * strictly fresher than waiting for the derived copy.
+ *
+ * Mirrors the RAG read contract (`rag_service.getDocumentContent` +
+ * `fetchDocumentContent`) so pagination behaves identically on both paths:
+ * 1-indexed chunk windows, `chunkEnd` defaulting to
+ * `chunkStart + MAX_CHUNK_WINDOW - 1`, an out-of-range start returning empty
+ * content with `chunkRange {0,0}`, `totalChars` counting the selected window
+ * before the cap, and the 50K content cap with `truncated`.
+ */
+
+/**
+ * Mirrors the RAG default `chunk_size` (rag/lib/config.ts) so fallback pages
+ * have familiar granularity. Boundaries need NOT match the real chunker —
+ * chunk numbering is per-response, and the model never mixes windows across
+ * the index-completion moment within one call.
+ */
+const FALLBACK_CHUNK_CHARS = 2048;
+/** Mirrors `MAX_CHUNK_WINDOW` in rag/lib/rag_service.ts. */
+const MAX_CHUNK_WINDOW = 200;
+
+export interface TranscriptContentArgs {
+  fileId: string;
+  fileName: string;
+  transcript: string;
+  chunkStart?: number;
+  chunkEnd?: number;
+}
+
+export function buildTranscriptContentResult(
+  args: TranscriptContentArgs,
+): DocumentContentResult {
+  const totalChunks = Math.max(
+    1,
+    Math.ceil(args.transcript.length / FALLBACK_CHUNK_CHARS),
+  );
+  const start = args.chunkStart ?? 1;
+  const end = Math.min(
+    args.chunkEnd ?? start + MAX_CHUNK_WINDOW - 1,
+    totalChunks,
+  );
+
+  if (start > totalChunks) {
+    return {
+      fileId: args.fileId,
+      name: args.fileName,
+      content: '',
+      chunkRange: { start: 0, end: 0 },
+      totalChunks,
+      truncated: false,
+      totalChars: 0,
+    };
+  }
+
+  // Windows are contiguous, non-overlapping slices, so one `slice` over the
+  // [start, end] range reconstructs the exact text of those chunks.
+  const rawContent = args.transcript.slice(
+    (start - 1) * FALLBACK_CHUNK_CHARS,
+    end * FALLBACK_CHUNK_CHARS,
+  );
+  const truncated = rawContent.length > MAX_CONTENT_CHARS;
+
+  return {
+    fileId: args.fileId,
+    name: args.fileName,
+    content: truncated ? rawContent.slice(0, MAX_CONTENT_CHARS) : rawContent,
+    chunkRange: { start, end },
+    totalChunks,
+    truncated,
+    totalChars: rawContent.length,
+  };
+}

--- a/services/platform/convex/agent_tools/documents/transcript_content.test.ts
+++ b/services/platform/convex/agent_tools/documents/transcript_content.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTranscriptContentResult } from './helpers/transcript_content';
+
+/** Mirrors FALLBACK_CHUNK_CHARS in helpers/transcript_content.ts — the test
+ * pins the window width because chunk numbers are part of the tool's
+ * pagination contract with the model. */
+const CHUNK = 2048;
+
+const BASE = { fileId: 'file-1', fileName: 'Video.txt' };
+
+describe('buildTranscriptContentResult', () => {
+  it('returns a short transcript as a single chunk', () => {
+    const result = buildTranscriptContentResult({
+      ...BASE,
+      transcript: 'hello world',
+    });
+
+    expect(result).toEqual({
+      fileId: 'file-1',
+      name: 'Video.txt',
+      content: 'hello world',
+      chunkRange: { start: 1, end: 1 },
+      totalChunks: 1,
+      truncated: false,
+      totalChars: 11,
+    });
+  });
+
+  it('treats an exactly chunk-sized transcript as one chunk', () => {
+    const result = buildTranscriptContentResult({
+      ...BASE,
+      transcript: 'x'.repeat(CHUNK),
+    });
+
+    expect(result.totalChunks).toBe(1);
+    expect(result.chunkRange).toEqual({ start: 1, end: 1 });
+    expect(result.content).toHaveLength(CHUNK);
+  });
+
+  it('splits into contiguous windows and returns all of them by default', () => {
+    const transcript = 'a'.repeat(CHUNK) + 'b'.repeat(CHUNK) + 'c'.repeat(500);
+    const result = buildTranscriptContentResult({ ...BASE, transcript });
+
+    expect(result.totalChunks).toBe(3);
+    expect(result.chunkRange).toEqual({ start: 1, end: 3 });
+    expect(result.content).toBe(transcript);
+    expect(result.totalChars).toBe(transcript.length);
+  });
+
+  it('selects the requested chunk window exactly', () => {
+    const transcript = 'a'.repeat(CHUNK) + 'b'.repeat(CHUNK) + 'c'.repeat(500);
+    const result = buildTranscriptContentResult({
+      ...BASE,
+      transcript,
+      chunkStart: 2,
+      chunkEnd: 2,
+    });
+
+    expect(result.content).toBe('b'.repeat(CHUNK));
+    expect(result.chunkRange).toEqual({ start: 2, end: 2 });
+    expect(result.totalChunks).toBe(3);
+    expect(result.totalChars).toBe(CHUNK);
+  });
+
+  it('clamps chunkEnd to the last chunk', () => {
+    const transcript = 'a'.repeat(CHUNK) + 'b'.repeat(100);
+    const result = buildTranscriptContentResult({
+      ...BASE,
+      transcript,
+      chunkStart: 2,
+      chunkEnd: 50,
+    });
+
+    expect(result.chunkRange).toEqual({ start: 2, end: 2 });
+    expect(result.content).toBe('b'.repeat(100));
+  });
+
+  it('returns the RAG empty-window shape when chunkStart is out of range', () => {
+    const result = buildTranscriptContentResult({
+      ...BASE,
+      transcript: 'short',
+      chunkStart: 5,
+    });
+
+    expect(result).toEqual({
+      fileId: 'file-1',
+      name: 'Video.txt',
+      content: '',
+      chunkRange: { start: 0, end: 0 },
+      totalChunks: 1,
+      truncated: false,
+      totalChars: 0,
+    });
+  });
+
+  it('caps returned content at 50K chars and flags truncation', () => {
+    const transcript = 'x'.repeat(60_000);
+    const result = buildTranscriptContentResult({ ...BASE, transcript });
+
+    expect(result.truncated).toBe(true);
+    expect(result.content).toHaveLength(50_000);
+    expect(result.totalChars).toBe(60_000);
+  });
+
+  it('does not truncate at exactly 50K chars', () => {
+    const transcript = 'x'.repeat(50_000);
+    const result = buildTranscriptContentResult({ ...BASE, transcript });
+
+    expect(result.truncated).toBe(false);
+    expect(result.content).toHaveLength(50_000);
+  });
+});

--- a/services/platform/convex/agents/external_agent/run_external_agent.ts
+++ b/services/platform/convex/agents/external_agent/run_external_agent.ts
@@ -47,6 +47,7 @@ import {
 import { components, internal } from '../../_generated/api';
 import type { ActionCtx } from '../../_generated/server';
 import { internalAction } from '../../_generated/server';
+import { resolveTranscriptAttachmentIdentities } from '../../lib/attachments/resolve_transcript_identity';
 import { createDebugLog } from '../../lib/debug_log';
 import { orgSlugFromIdOrNull } from '../../lib/helpers/org_slug';
 import { toSandboxStorageUrl } from '../../lib/helpers/public_storage_url';
@@ -263,7 +264,16 @@ async function stageChatAttachments(
     orgSlug: string | null;
   },
 ): Promise<{ prompt: string; additionalDirs: string[] }> {
-  const plan = buildAttachmentStagePlan(opts.promptMessageId, opts.attachments);
+  // Video-link transcripts arrive under their display identity (the
+  // 'video/mp4' routing sentinel + extension-less title) while the blob is
+  // transcript text — restore the real fileName/contentType so the staged
+  // file AND the preamble line the agent reads are honest (see
+  // resolve_transcript_identity.ts).
+  const attachments = await resolveTranscriptAttachmentIdentities(
+    ctx,
+    opts.attachments,
+  );
+  const plan = buildAttachmentStagePlan(opts.promptMessageId, attachments);
   const entries: {
     path: string;
     url?: string;

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -5,6 +5,13 @@ import type { Doc } from '../_generated/dataModel';
 import { internalQuery } from '../_generated/server';
 import { blobRefValidator } from '../lib/storage/blob_ref';
 
+export const getById = internalQuery({
+  args: { fileMetadataId: v.id('fileMetadata') },
+  async handler(ctx, args) {
+    return await ctx.db.get(args.fileMetadataId);
+  },
+});
+
 export const getByStorageId = internalQuery({
   args: {
     storageId: blobRefValidator,

--- a/services/platform/convex/lib/attachments/resolve_transcript_identity.test.ts
+++ b/services/platform/convex/lib/attachments/resolve_transcript_identity.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAttachmentStagePlan } from '../../agents/external_agent/attachment_files';
+import {
+  applyTranscriptIdentity,
+  resolveTranscriptAttachmentIdentities,
+} from './resolve_transcript_identity';
+import { buildWorkspaceUploadPlan } from './workspace_uploads';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the mislabelled video-link transcript on disk.
+//
+// `bindCompletedJobsToMessage` stamps transcript attachments with the
+// 'video/mp4' routing sentinel and the extension-less video title, while the
+// blob is transcript text. The workspace filer and the external-agent stager
+// copied those display fields verbatim, so /user/uploads carried e.g.
+// "It Broke?" · video/mp4 · 1.8 KB whose bytes were UTF-8 text — unreadable
+// in the Canvas preview and a lie in the agent's preamble. The resolver
+// restores the synthetic fileMetadata row's real identity
+// (`"<title>.txt"`, text/plain) at the staging boundary.
+// ---------------------------------------------------------------------------
+
+const TRANSCRIPT_ATTACHMENT = {
+  fileId: 'storage-1',
+  fileName: 'It Broke?',
+  fileType: 'video/mp4',
+  fileSize: 1_800,
+};
+
+const VIDEO_LINK_META = {
+  source: 'video_link',
+  fileName: 'It Broke?.txt',
+  contentType: 'text/plain; charset=utf-8',
+};
+
+describe('applyTranscriptIdentity', () => {
+  it('restores the fileMetadata identity for video_link rows', () => {
+    const resolved = applyTranscriptIdentity(
+      TRANSCRIPT_ATTACHMENT,
+      VIDEO_LINK_META,
+    );
+
+    expect(resolved).toEqual({
+      fileId: 'storage-1',
+      fileName: 'It Broke?.txt',
+      fileType: 'text/plain; charset=utf-8',
+      fileSize: 1_800,
+    });
+  });
+
+  it('keeps regular uploads untouched', () => {
+    const upload = {
+      fileId: 'storage-2',
+      fileName: 'report.pdf',
+      fileType: 'application/pdf',
+      fileSize: 5_000,
+    };
+
+    expect(
+      applyTranscriptIdentity(upload, {
+        source: 'user_upload',
+        fileName: 'report.pdf',
+        contentType: 'application/pdf',
+      }),
+    ).toBe(upload);
+    expect(applyTranscriptIdentity(upload, null)).toBe(upload);
+  });
+
+  it('lands the transcript as a .txt in the workspace upload plan', () => {
+    const { planned } = buildWorkspaceUploadPlan([
+      applyTranscriptIdentity(TRANSCRIPT_ATTACHMENT, VIDEO_LINK_META),
+    ]);
+
+    expect(planned).toHaveLength(1);
+    expect(planned[0].path).toBe('/user/uploads/It Broke?.txt');
+    expect(planned[0].attachment.fileType).toBe('text/plain; charset=utf-8');
+  });
+
+  it('lands the transcript as a .txt in the external-agent stage plan', () => {
+    const plan = buildAttachmentStagePlan('msg-1', [
+      applyTranscriptIdentity(TRANSCRIPT_ATTACHMENT, VIDEO_LINK_META),
+    ]);
+
+    expect(plan.planned).toHaveLength(1);
+    expect(plan.planned[0].absPath).toBe('/user/uploads/msg-1/It Broke?.txt');
+    // The preamble prints this fileType — the agent must read "text/plain",
+    // not be told it has an mp4.
+    expect(plan.planned[0].fileType).toBe('text/plain; charset=utf-8');
+  });
+});
+
+describe('resolveTranscriptAttachmentIdentities', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves video_link rows and passes others through', async () => {
+    const upload = {
+      fileId: 'storage-2',
+      fileName: 'report.pdf',
+      fileType: 'application/pdf',
+      fileSize: 5_000,
+    };
+    const runQuery = vi.fn().mockImplementation((_ref, args) => {
+      if (args.storageId === 'storage-1') {
+        return Promise.resolve(VIDEO_LINK_META);
+      }
+      return Promise.resolve({
+        source: 'user_upload',
+        fileName: 'report.pdf',
+        contentType: 'application/pdf',
+      });
+    });
+
+    const resolved = await resolveTranscriptAttachmentIdentities(
+      { runQuery } as never,
+      [TRANSCRIPT_ATTACHMENT, upload],
+    );
+
+    expect(resolved[0].fileName).toBe('It Broke?.txt');
+    expect(resolved[0].fileType).toBe('text/plain; charset=utf-8');
+    expect(resolved[1]).toBe(upload);
+  });
+
+  it('fails open on a lookup error, keeping the display identity', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const runQuery = vi.fn().mockRejectedValue(new Error('db hiccup'));
+
+    const resolved = await resolveTranscriptAttachmentIdentities(
+      { runQuery } as never,
+      [TRANSCRIPT_ATTACHMENT],
+    );
+
+    expect(resolved[0]).toBe(TRANSCRIPT_ATTACHMENT);
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/lib/attachments/resolve_transcript_identity.ts
+++ b/services/platform/convex/lib/attachments/resolve_transcript_identity.ts
@@ -1,0 +1,70 @@
+import { internal } from '../../_generated/api';
+import type { ActionCtx } from '../../_generated/server';
+
+/**
+ * Video-link transcript attachments travel through chat messages under a
+ * DISPLAY identity: `bindCompletedJobsToMessage` stamps `fileType:
+ * 'video/mp4'` (the isAudioOrVideo routing sentinel that keeps the bubble's
+ * video card and the document_retrieve hint working) and the extension-less
+ * video title as `fileName` — while the underlying blob is the transcript
+ * TEXT. Any consumer that materializes the blob as a real file (the chat
+ * workspace's /user/uploads, external-agent staging) must restore the true
+ * identity from the synthetic fileMetadata row (`fileName: "<title>.txt"`,
+ * `contentType: text/plain`) or it ships a text file labelled as an mp4 —
+ * unreadable in the Canvas preview and a lie in the agent's file listing.
+ */
+
+interface AttachmentIdentity {
+  fileId: string;
+  fileName: string;
+  fileType: string;
+}
+
+type TranscriptMeta = {
+  source?: string;
+  fileName: string;
+  contentType: string;
+} | null;
+
+/**
+ * Pure mapping: video-link rows adopt the fileMetadata identity; everything
+ * else (regular uploads, audio, unknown rows) passes through untouched.
+ */
+export function applyTranscriptIdentity<T extends AttachmentIdentity>(
+  attachment: T,
+  meta: TranscriptMeta,
+): T {
+  if (!meta || meta.source !== 'video_link') return attachment;
+  return {
+    ...attachment,
+    fileName: meta.fileName,
+    fileType: meta.contentType,
+  };
+}
+
+/**
+ * Resolve each attachment's on-disk identity via its fileMetadata row.
+ * Fail-open: a lookup error keeps the display identity — staging is
+ * best-effort and must never fail the turn.
+ */
+export async function resolveTranscriptAttachmentIdentities<
+  T extends AttachmentIdentity,
+>(ctx: Pick<ActionCtx, 'runQuery'>, attachments: readonly T[]): Promise<T[]> {
+  return Promise.all(
+    attachments.map(async (attachment) => {
+      try {
+        const meta = await ctx.runQuery(
+          internal.file_metadata.internal_queries.getByStorageId,
+          { storageId: attachment.fileId },
+        );
+        return applyTranscriptIdentity(attachment, meta);
+      } catch (err) {
+        console.warn(
+          `[attachments] identity lookup failed for ${attachment.fileId}; keeping display identity:`,
+          err instanceof Error ? err.message : err,
+        );
+        return attachment;
+      }
+    }),
+  );
+}

--- a/services/platform/convex/lib/attachments/workspace_uploads.ts
+++ b/services/platform/convex/lib/attachments/workspace_uploads.ts
@@ -34,6 +34,7 @@ import { THREAD_FILE_MAX_BYTES } from '../../thread_files/schema';
 import { orgSlugFromIdOrNull } from '../helpers/org_slug';
 import { deleteBlob, putBlob, readBlobBytes } from '../storage/blob_access';
 import { convexStorageId, type BlobRef } from '../storage/blob_ref';
+import { resolveTranscriptAttachmentIdentities } from './resolve_transcript_identity';
 import type { FileAttachment } from './types';
 
 const UPLOADS_PATH_PREFIX = '/user/uploads';
@@ -88,7 +89,15 @@ export async function fileAttachmentsIntoWorkspace(
     attachments: readonly FileAttachment[];
   },
 ): Promise<{ filed: number; unchanged: number; skipped: number }> {
-  const { planned, skipped } = buildWorkspaceUploadPlan(args.attachments);
+  // Video-link transcripts arrive under their display identity (the
+  // 'video/mp4' routing sentinel + extension-less title) while the blob is
+  // transcript text — restore the real fileName/contentType before anything
+  // lands on disk (see resolve_transcript_identity.ts).
+  const attachments = await resolveTranscriptAttachmentIdentities(
+    ctx,
+    args.attachments,
+  );
+  const { planned, skipped } = buildWorkspaceUploadPlan(attachments);
   for (const s of skipped) {
     console.warn(
       `[workspace_uploads] not filing "${s.name}" into /user/uploads: ${s.reason}`,

--- a/services/platform/convex/video_links/clone_transcript.ts
+++ b/services/platform/convex/video_links/clone_transcript.ts
@@ -1,0 +1,115 @@
+'use node';
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import { internalAction } from '../_generated/server';
+import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { putBlob } from '../lib/storage/blob_access';
+import type { BlobRef } from '../lib/storage/blob_ref';
+
+/**
+ * Materialize a donor transcript for a freshly-inserted clone job:
+ * store the donor's transcript text as this job's own blob (backend-aware
+ * — a BYO-bucket org's copy lands in its own bucket) and finalize via
+ * `finalizeClonedTranscript`. No yt-dlp, no Whisper — this is the
+ * zero-re-parse path behind org-wide video-link reuse.
+ *
+ * Scheduled by `ingestVideoUrl` when `findReusableTranscriptDonor` hits.
+ * The job sits at status='indexing' while this runs (watchdog window
+ * 5 min); every exit either completes the job, degrades it to the full
+ * pipeline, or CAS-fails it — never leaves it stuck.
+ */
+export const cloneTranscriptFromDonor = internalAction({
+  args: {
+    jobId: v.id('videoLinkJobs'),
+    donorFileMetadataId: v.id('fileMetadata'),
+    organizationId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    try {
+      const donor = await ctx.runQuery(
+        internal.file_metadata.internal_queries.getById,
+        { fileMetadataId: args.donorFileMetadataId },
+      );
+
+      if (
+        !donor ||
+        donor.organizationId !== args.organizationId ||
+        donor.transcriptionStatus !== 'completed' ||
+        typeof donor.transcript !== 'string' ||
+        donor.transcript.length === 0
+      ) {
+        // Donor vanished (GC/erasure) between lookup and clone — degrade
+        // to the full pipeline instead of failing the chip: reset to
+        // 'queued' (the orchestrator CAS-expects it) and hand over.
+        const reset = await ctx.runMutation(
+          internal.video_links.internal_mutations.updateJob,
+          {
+            jobId: args.jobId,
+            status: 'queued',
+            expectedStatus: 'indexing',
+          },
+        );
+        if (reset === 'ok') {
+          await ctx.scheduler.runAfter(
+            0,
+            internal.video_links.ingest_video_link.ingestVideoLink,
+            { jobId: args.jobId },
+          );
+        }
+        return null;
+      }
+
+      const bytes = new TextEncoder().encode(donor.transcript);
+      const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+      let storageId: BlobRef;
+      if (orgSlug !== null) {
+        storageId = await putBlob(
+          ctx,
+          orgSlug,
+          bytes,
+          'text/plain; charset=utf-8',
+        );
+      } else {
+        // Unresolvable slug → Convex `_storage` fallback, mirroring the
+        // workspace filer's posture (never break the flow over routing).
+        const ab = new ArrayBuffer(bytes.byteLength);
+        new Uint8Array(ab).set(bytes);
+        storageId = await ctx.storage.store(
+          new Blob([ab], { type: 'text/plain; charset=utf-8' }),
+        );
+      }
+
+      await ctx.runMutation(
+        internal.video_links.internal_mutations.finalizeClonedTranscript,
+        {
+          jobId: args.jobId,
+          storageId,
+          organizationId: args.organizationId,
+          transcript: donor.transcript,
+          fileName: donor.fileName,
+          fileSize: bytes.byteLength,
+          ...(donor.transcriptionDurationSec !== undefined && {
+            transcriptionDurationSec: donor.transcriptionDurationSec,
+          }),
+        },
+      );
+    } catch (err) {
+      console.error(
+        `[cloneTranscriptFromDonor] clone failed for job ${args.jobId}:`,
+        err instanceof Error ? err.message : err,
+      );
+      // CAS keeps a concurrent cancel's 'skipped' from being stomped.
+      await ctx.runMutation(internal.video_links.internal_mutations.updateJob, {
+        jobId: args.jobId,
+        status: 'failed',
+        expectedStatus: 'indexing',
+        errorReasonCode: 'transient',
+        errorMessage: 'Transcript clone failed — retry to re-fetch',
+      });
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/video_links/donor.ts
+++ b/services/platform/convex/video_links/donor.ts
@@ -1,0 +1,67 @@
+import type { Doc } from '../_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+
+/**
+ * Donor lookup for transcript reuse: the same URL pasted anywhere in the
+ * SAME organization (any thread, any user) within this window attaches a
+ * clone of the existing transcript instead of re-running yt-dlp. Never
+ * crosses organizations — the index prefix is the tenant boundary.
+ *
+ * Why donors exist at all: a cancelled completed chip keeps its
+ * fileMetadata row (cleanupCancelledVideoLink deletes only the blob and
+ * only-non-completed rows), and message-bound rows keep everything — so
+ * the transcript TEXT survives on the row in both the remove→re-add and
+ * the already-sent case.
+ */
+
+/** Captions drift over time (creators edit, auto-captions regenerate) —
+ * a stale transcript quietly diverging from the video is worse than one
+ * fresh re-fetch per month. */
+export const TRANSCRIPT_REUSE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Rows examined per lookup. The (org, hash) key rarely accumulates more
+ * than a handful of rows; the cap bounds the mutation's read set when a
+ * URL was spam-pasted hundreds of times. */
+const DONOR_SCAN_LIMIT = 20;
+
+export interface TranscriptDonor {
+  job: Doc<'videoLinkJobs'>;
+  meta: Doc<'fileMetadata'>;
+}
+
+/**
+ * Newest reusable transcript for (org, normalized-URL hash), or null.
+ * Reusable = the linked fileMetadata row still exists, is not trashed,
+ * finished transcription, and carries the transcript text (blob presence
+ * is NOT required — cancel deletes the blob but keeps the row).
+ */
+export async function findReusableTranscriptDonor(
+  ctx: QueryCtx | MutationCtx,
+  organizationId: string,
+  sourceUrlHash: string,
+  now: number,
+): Promise<TranscriptDonor | null> {
+  let scanned = 0;
+  for await (const job of ctx.db
+    .query('videoLinkJobs')
+    .withIndex('by_organizationId_and_sourceUrlHash', (q) =>
+      q.eq('organizationId', organizationId).eq('sourceUrlHash', sourceUrlHash),
+    )
+    .order('desc')) {
+    scanned += 1;
+    if (scanned > DONOR_SCAN_LIMIT) break;
+    // Descending _creationTime: every row past this point is older still.
+    if (now - job._creationTime > TRANSCRIPT_REUSE_MAX_AGE_MS) break;
+    if (job.lifecycleStatus === 'trashed') continue;
+    if (!job.fileMetadataId) continue;
+    const meta = await ctx.db.get(job.fileMetadataId);
+    if (!meta) continue;
+    if (meta.lifecycleStatus === 'trashed') continue;
+    if (meta.transcriptionStatus !== 'completed') continue;
+    if (typeof meta.transcript !== 'string' || meta.transcript.length === 0) {
+      continue;
+    }
+    return { job, meta };
+  }
+  return null;
+}

--- a/services/platform/convex/video_links/donor_reuse.test.ts
+++ b/services/platform/convex/video_links/donor_reuse.test.ts
@@ -1,0 +1,268 @@
+// Org-wide transcript reuse: a URL already transcribed in the org (any
+// thread, any user, ≤30 days) is attached by cloning the donor row instead
+// of re-running yt-dlp. These tests cover the two server pieces: the donor
+// lookup (`findReusableTranscriptDonor`) — including the remove→re-add case
+// where the cancelled chip's fileMetadata row survives as the donor — and
+// the clone finalizer (`finalizeClonedTranscript`), including its
+// cancel-race guard and the verbatim-transcript contract (the donor text
+// already carries the provenance header; re-prepending would double it).
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it, vi } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import { deleteOrgBlobInMutation } from '../lib/storage/blob_delete';
+import schema from '../schema';
+import {
+  findReusableTranscriptDonor,
+  TRANSCRIPT_REUSE_MAX_AGE_MS,
+} from './donor';
+
+vi.mock('../lib/storage/blob_delete', () => ({
+  deleteBlobInMutation: vi.fn(async () => undefined),
+  deleteOrgBlobInMutation: vi.fn(async () => undefined),
+  scheduleS3BlobDeletes: vi.fn(async () => undefined),
+}));
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'video_links';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+type T = TestConvex<typeof schema>;
+
+const ORG = 'org_donor_test';
+const HASH = 'hash_donor_1';
+const TRANSCRIPT =
+  'Source: https://www.youtube.com/watch?v=abc\nPlatform: youtube\n\nHello transcript.';
+
+interface SeedOverrides {
+  org?: string;
+  jobStatus?: 'completed' | 'skipped' | 'failed';
+  jobLifecycle?: 'active' | 'trashed';
+  metaLifecycle?: 'active' | 'trashed';
+  metaTranscript?: string;
+  metaStatus?: 'completed' | 'running';
+}
+
+async function seedDonorPair(
+  t: T,
+  overrides: SeedOverrides = {},
+): Promise<{ jobId: Id<'videoLinkJobs'>; metaId: Id<'fileMetadata'> }> {
+  return t.run(async (ctx) => {
+    const org = overrides.org ?? ORG;
+    const metaId = await ctx.db.insert('fileMetadata', {
+      organizationId: org,
+      storageId: `s3:${org}/donor-blob`,
+      source: 'video_link',
+      fileName: 'Test Video.txt',
+      contentType: 'text/plain; charset=utf-8',
+      size: TRANSCRIPT.length,
+      uploadedBy: 'user_donor',
+      transcript: overrides.metaTranscript ?? TRANSCRIPT,
+      transcriptionStatus: overrides.metaStatus ?? 'completed',
+      transcriptRagStatus: 'completed',
+      ragStatus: 'completed',
+      lifecycleStatus: overrides.metaLifecycle ?? 'active',
+      statusChangedAt: Date.now(),
+    });
+    const jobId = await ctx.db.insert('videoLinkJobs', {
+      organizationId: org,
+      uploadedBy: 'user_donor',
+      sourceUrl: 'https://www.youtube.com/watch?v=abc',
+      sourceUrlHash: HASH,
+      sourcePlatform: 'youtube',
+      pastedToken: 'https://www.youtube.com/watch?v=abc',
+      status: overrides.jobStatus ?? 'completed',
+      statusChangedAt: Date.now(),
+      lifecycleStatus: overrides.jobLifecycle ?? 'active',
+      fileMetadataId: metaId,
+      storageId: `s3:${org}/donor-blob`,
+      videoTitle: 'Test Video',
+    });
+    return { jobId, metaId };
+  });
+}
+
+function findDonor(t: T, org = ORG, now = Date.now()) {
+  return t.run(async (ctx) => findReusableTranscriptDonor(ctx, org, HASH, now));
+}
+
+describe('findReusableTranscriptDonor', () => {
+  it('finds the completed donor for (org, hash)', async () => {
+    const t = convexTest(schema, modules);
+    const { metaId } = await seedDonorPair(t);
+
+    const donor = await findDonor(t);
+
+    expect(donor).not.toBeNull();
+    expect(donor?.meta._id).toBe(metaId);
+    expect(donor?.meta.transcript).toBe(TRANSCRIPT);
+  });
+
+  it('finds a donor whose chip was removed (skipped job, surviving row)', async () => {
+    // The remove→re-add case: cancel flips the job to skipped and deletes
+    // the blob, but the completed fileMetadata row (with transcript text)
+    // survives — it must qualify as a donor.
+    const t = convexTest(schema, modules);
+    const { metaId } = await seedDonorPair(t, { jobStatus: 'skipped' });
+
+    const donor = await findDonor(t);
+
+    expect(donor?.meta._id).toBe(metaId);
+  });
+
+  it('ignores donors without a completed transcript', async () => {
+    const t = convexTest(schema, modules);
+    await seedDonorPair(t, { metaStatus: 'running' });
+    expect(await findDonor(t)).toBeNull();
+
+    const t2 = convexTest(schema, modules);
+    await seedDonorPair(t2, { metaTranscript: '' });
+    expect(await findDonor(t2)).toBeNull();
+  });
+
+  it('ignores donors older than the reuse window', async () => {
+    const t = convexTest(schema, modules);
+    await seedDonorPair(t);
+
+    const farFuture = Date.now() + TRANSCRIPT_REUSE_MAX_AGE_MS + 60_000;
+    expect(await findDonor(t, ORG, farFuture)).toBeNull();
+  });
+
+  it('never crosses organizations', async () => {
+    const t = convexTest(schema, modules);
+    await seedDonorPair(t);
+
+    expect(await findDonor(t, 'org_other')).toBeNull();
+  });
+
+  it('skips trashed rows', async () => {
+    const t = convexTest(schema, modules);
+    await seedDonorPair(t, { jobLifecycle: 'trashed' });
+    expect(await findDonor(t)).toBeNull();
+
+    const t2 = convexTest(schema, modules);
+    await seedDonorPair(t2, { metaLifecycle: 'trashed' });
+    expect(await findDonor(t2)).toBeNull();
+  });
+
+  it('returns the newest qualifying donor', async () => {
+    const t = convexTest(schema, modules);
+    await seedDonorPair(t, { metaTranscript: `${TRANSCRIPT} v1` });
+    const { metaId: newerMetaId } = await seedDonorPair(t, {
+      metaTranscript: `${TRANSCRIPT} v2`,
+    });
+
+    const donor = await findDonor(t);
+
+    expect(donor?.meta._id).toBe(newerMetaId);
+  });
+});
+
+async function seedCloneJob(
+  t: T,
+  status: 'indexing' | 'skipped',
+): Promise<Id<'videoLinkJobs'>> {
+  return t.run(async (ctx) =>
+    ctx.db.insert('videoLinkJobs', {
+      organizationId: ORG,
+      threadId: 'thread_clone_1',
+      uploadedBy: 'user_repaster',
+      sourceUrl: 'https://www.youtube.com/watch?v=abc',
+      sourceUrlHash: HASH,
+      sourcePlatform: 'youtube',
+      pastedToken: 'youtube.com/watch?v=abc',
+      status,
+      statusChangedAt: Date.now(),
+      lifecycleStatus: 'active',
+      videoTitle: 'Test Video',
+    }),
+  );
+}
+
+describe('finalizeClonedTranscript', () => {
+  it('lands the verbatim transcript and completes the job', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedCloneJob(t, 'indexing');
+
+    const fileMetadataId = await t.mutation(
+      internal.video_links.internal_mutations.finalizeClonedTranscript,
+      {
+        jobId,
+        storageId: `s3:${ORG}/clone-blob`,
+        organizationId: ORG,
+        transcript: TRANSCRIPT,
+        fileName: 'Test Video.txt',
+        fileSize: TRANSCRIPT.length,
+        transcriptionDurationSec: 12,
+      },
+    );
+
+    expect(fileMetadataId).not.toBeNull();
+    const row = await t.run(async (ctx) =>
+      ctx.db.get(fileMetadataId as Id<'fileMetadata'>),
+    );
+    // Verbatim — the donor text already carries the provenance header;
+    // a doubled header here means the finalizer re-prepended it.
+    expect(row?.transcript).toBe(TRANSCRIPT);
+    expect(row?.source).toBe('video_link');
+    expect(row?.contentType).toBe('text/plain; charset=utf-8');
+    expect(row?.ragStatus).toBe('queued');
+    expect(row?.transcriptRagStatus).toBe('queued');
+    expect(row?.transcriptionStatus).toBe('completed');
+    expect(row?.threadId).toBe('thread_clone_1');
+    expect(row?.uploadedBy).toBe('user_repaster');
+
+    const job = await t.run(async (ctx) => ctx.db.get(jobId));
+    expect(job?.status).toBe('completed');
+    expect(job?.fileMetadataId).toBe(fileMetadataId);
+    expect(job?.storageId).toBe(`s3:${ORG}/clone-blob`);
+  });
+
+  it('bails and reaps the blob when cancel raced the clone', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedCloneJob(t, 'skipped');
+
+    const result = await t.mutation(
+      internal.video_links.internal_mutations.finalizeClonedTranscript,
+      {
+        jobId,
+        storageId: `s3:${ORG}/orphan-blob`,
+        organizationId: ORG,
+        transcript: TRANSCRIPT,
+        fileName: 'Test Video.txt',
+        fileSize: TRANSCRIPT.length,
+      },
+    );
+
+    expect(result).toBeNull();
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query('fileMetadata')
+        .filter((q) => q.eq(q.field('organizationId'), ORG))
+        .collect(),
+    );
+    expect(rows).toHaveLength(0);
+    const job = await t.run(async (ctx) => ctx.db.get(jobId));
+    expect(job?.status).toBe('skipped');
+    expect(vi.mocked(deleteOrgBlobInMutation)).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      `s3:${ORG}/orphan-blob`,
+      'video_links.finalizeClonedTranscript',
+    );
+  });
+});

--- a/services/platform/convex/video_links/internal_mutations.ts
+++ b/services/platform/convex/video_links/internal_mutations.ts
@@ -320,6 +320,92 @@ export const insertSyntheticFileMetadata = internalMutation({
 });
 
 /**
+ * Donor-clone finalizer — sibling of `insertSyntheticFileMetadata` above,
+ * with two deliberate differences:
+ *   1. The transcript is stored VERBATIM: the donor text already carries
+ *      the provenance header (Source/Platform/Fetched/Method) from its
+ *      original ingest; re-prepending would double it and lie about the
+ *      fetch date.
+ *   2. The job patch is CAS-gated on status='indexing' — the clone action
+ *      runs async after `ingestVideoUrl` inserted the row, so a cancel
+ *      (or GC) can land in between; on a miss the stored blob is reaped
+ *      and no fileMetadata row is created.
+ */
+export const finalizeClonedTranscript = internalMutation({
+  args: {
+    jobId: v.id('videoLinkJobs'),
+    // Blob reference (`_storage` id or `s3:` ref) already stored by the
+    // clone action.
+    storageId: blobRefValidator,
+    organizationId: v.string(),
+    transcript: v.string(),
+    fileName: v.string(),
+    fileSize: v.number(),
+    transcriptionDurationSec: v.optional(v.number()),
+  },
+  returns: v.union(v.id('fileMetadata'), v.null()),
+  async handler(ctx, args) {
+    const job = await ctx.db.get(args.jobId);
+    if (!job || job.status !== 'indexing') {
+      // Cancel/GC raced the clone — reap the orphan blob and bail.
+      await deleteOrgBlobInMutation(
+        ctx,
+        args.organizationId,
+        args.storageId,
+        'video_links.finalizeClonedTranscript',
+      );
+      return null;
+    }
+
+    const fileMetadataId = await ctx.db.insert('fileMetadata', {
+      organizationId: job.organizationId,
+      storageId: args.storageId,
+      source: 'video_link',
+      fileName: args.fileName,
+      contentType: 'text/plain; charset=utf-8',
+      size: args.fileSize,
+      uploadedBy: job.uploadedBy,
+      ...(job.threadId !== undefined && { threadId: job.threadId }),
+      transcript: args.transcript,
+      transcriptionStatus: 'completed',
+      ...(args.transcriptionDurationSec !== undefined && {
+        transcriptionDurationSec: args.transcriptionDurationSec,
+      }),
+      // Same dual-status contract as insertSyntheticFileMetadata: the
+      // chip reads transcriptRagStatus, the retrieval gate reads the
+      // canonical ragStatus. RAG re-indexes the clone cheaply — its
+      // content-hash dedup (findExistingByHash → cloneFromExisting)
+      // recognizes the donor's identical bytes.
+      transcriptRagStatus: 'queued',
+      ragStatus: 'queued',
+      lifecycleStatus: 'active',
+      statusChangedAt: Date.now(),
+    });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.file_metadata.internal_actions.uploadFileToRag,
+      {
+        organizationId: job.organizationId,
+        storageId: args.storageId,
+        fileName: args.fileName,
+        contentType: 'text/plain; charset=utf-8',
+      },
+    );
+
+    await ctx.db.patch(args.jobId, {
+      fileMetadataId,
+      storageId: args.storageId,
+      status: 'completed',
+      statusChangedAt: Date.now(),
+      progress: undefined,
+    });
+
+    return fileMetadataId;
+  },
+});
+
+/**
  * Cancellation/retry cleanup. Runs as a separate scheduled action so the
  * cancel mutation returns instantly and the user-visible chip flips
  * before the storage/RAG deletes complete (which can take seconds).

--- a/services/platform/convex/video_links/mutations.ts
+++ b/services/platform/convex/video_links/mutations.ts
@@ -16,6 +16,7 @@ import { checkOrganizationRateLimit } from '../lib/rate_limiter/helpers';
 import { assertThreadAccess } from '../lib/rls/auth/can_access_thread';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { findReusableTranscriptDonor } from './donor';
 
 /** Per-org cap on in-flight video-link jobs. Prevents one org from soaking
  * all 32 Node-action slots with concurrent yt-dlp/Whisper work. */
@@ -224,6 +225,97 @@ export const ingestVideoUrl = mutation({
         await ctx.db.patch(existing._id, { pastedToken: args.pastedToken });
       }
       return existing._id;
+    }
+
+    // Transcript reuse: the same URL already transcribed anywhere in this
+    // org (any thread, any user, ≤30 days — see donor.ts) attaches a clone
+    // of the existing transcript instead of re-running yt-dlp. This is
+    // what makes remove→re-add instant (and immune to bot-wall re-fetch
+    // failures), and collapses org-wide duplicate pastes to one fetch.
+    // Placed BEFORE the in-flight cap on purpose: a clone consumes no
+    // yt-dlp/Whisper slot, so it must not be starved by (or count against
+    // admission to) the org's three fetch slots.
+    const donor = await findReusableTranscriptDonor(
+      ctx,
+      args.organizationId,
+      sourceUrlHash,
+      now,
+    );
+    if (donor) {
+      const jobId = await ctx.db.insert('videoLinkJobs', {
+        organizationId: args.organizationId,
+        ...(args.threadId !== undefined && { threadId: args.threadId }),
+        uploadedBy: userId,
+        sourceUrl: args.url,
+        sourceUrlHash,
+        sourcePlatform: serverPlatform,
+        pastedToken: args.pastedToken,
+        // 'indexing' (not 'completed') until the clone action lands the
+        // fileMetadata row — the chip shows the existing "Indexing…"
+        // label and the watchdog's 5-min 'indexing' window covers a
+        // wedged clone.
+        status: 'indexing',
+        statusChangedAt: now,
+        attempts: 0,
+        lifecycleStatus: 'active',
+        // Video metadata rides over from the donor job so the chip and
+        // the message-time provenance join render identically to a
+        // fresh ingest.
+        ...(donor.job.videoTitle !== undefined && {
+          videoTitle: donor.job.videoTitle,
+        }),
+        ...(donor.job.videoUploader !== undefined && {
+          videoUploader: donor.job.videoUploader,
+        }),
+        ...(donor.job.videoDurationSec !== undefined && {
+          videoDurationSec: donor.job.videoDurationSec,
+        }),
+        ...(donor.job.videoLanguage !== undefined && {
+          videoLanguage: donor.job.videoLanguage,
+        }),
+        ...(donor.job.videoChapters !== undefined && {
+          videoChapters: donor.job.videoChapters,
+        }),
+        ...(donor.job.transcriptSource !== undefined && {
+          transcriptSource: donor.job.transcriptSource,
+        }),
+        ...(donor.job.captionTrackKind !== undefined && {
+          captionTrackKind: donor.job.captionTrackKind,
+        }),
+        ...(donor.job.captionLang !== undefined && {
+          captionLang: donor.job.captionLang,
+        }),
+      });
+
+      await ctx.scheduler.runAfter(
+        0,
+        internal.video_links.clone_transcript.cloneTranscriptFromDonor,
+        {
+          jobId,
+          donorFileMetadataId: donor.meta._id,
+          organizationId: args.organizationId,
+        },
+      );
+
+      await createAuditLog(ctx, {
+        organizationId: args.organizationId,
+        actorId: userId,
+        actorType: 'user',
+        action: 'video_link.ingest',
+        category: 'data',
+        resourceType: 'video_link_job',
+        resourceId: String(jobId),
+        status: 'success',
+        metadata: {
+          sourcePlatform: serverPlatform,
+          sourceUrlHash,
+          reusedTranscript: true,
+          donorJobId: String(donor.job._id),
+          ...(args.threadId !== undefined && { threadId: args.threadId }),
+        },
+      });
+
+      return jobId;
     }
 
     // Per-org in-flight concurrency cap. Cheap index-scoped iteration —

--- a/services/platform/lib/shared/video-url.test.ts
+++ b/services/platform/lib/shared/video-url.test.ts
@@ -272,9 +272,84 @@ describe('extractVideoUrls', () => {
     expect(out).toHaveLength(2);
   });
 
-  it('rejects http:// URLs', () => {
+  it('upgrades http:// to https:// for allowlisted video hosts', () => {
     const out = extractVideoUrls('http://youtu.be/abc');
-    expect(out).toHaveLength(0);
+    expect(out).toHaveLength(1);
+    expect(out[0].url).toBe('https://youtu.be/abc');
+    // pastedToken keeps the original spelling so the send-time literal
+    // strip still finds it in the textarea.
+    expect(out[0].pastedToken).toBe('http://youtu.be/abc');
+  });
+
+  it('still rejects http:// URLs from non-video hosts', () => {
+    expect(extractVideoUrls('http://example.com/article')).toHaveLength(0);
+  });
+
+  it('chips a protocol-less youtube watch URL', () => {
+    const out = extractVideoUrls(
+      'try for example: youtube.com/watch?v=dQw4w9WgXcQ without protocol',
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].url).toBe('https://youtube.com/watch?v=dQw4w9WgXcQ');
+    expect(out[0].platform).toBe('youtube');
+    expect(out[0].pastedToken).toBe('youtube.com/watch?v=dQw4w9WgXcQ');
+  });
+
+  it('chips www. and short-host bare forms', () => {
+    expect(extractVideoUrls('www.youtube.com/watch?v=abc')[0]?.url).toBe(
+      'https://www.youtube.com/watch?v=abc',
+    );
+    expect(extractVideoUrls('youtu.be/abc')[0]?.url).toBe(
+      'https://youtu.be/abc',
+    );
+    expect(extractVideoUrls('see vimeo.com/12345 today')[0]?.platform).toBe(
+      'vimeo',
+    );
+  });
+
+  it('never chips bare tokens from non-video hosts', () => {
+    expect(
+      extractVideoUrls('see example.com/article and docs.python.org/3/library'),
+    ).toHaveLength(0);
+  });
+
+  it('requires a path on bare tokens (homepage never chips)', () => {
+    expect(extractVideoUrls('I like youtube.com a lot')).toHaveLength(0);
+    expect(extractVideoUrls('youtube.com/ maybe')).toHaveLength(0);
+  });
+
+  it('does not double-match the host inside a full URL', () => {
+    const out = extractVideoUrls('https://youtu.be/abc');
+    expect(out).toHaveLength(1);
+    expect(out[0].pastedToken).toBe('https://youtu.be/abc');
+  });
+
+  it('dedups the bare and https forms of the same video to one chip', () => {
+    const out = extractVideoUrls('https://youtu.be/abc and youtu.be/abc');
+    expect(out).toHaveLength(1);
+    expect(out[0].pastedToken).toBe('https://youtu.be/abc');
+  });
+
+  it('ignores bare tokens inside code blocks', () => {
+    expect(extractVideoUrls('run `youtu.be/abc` locally')).toHaveLength(0);
+  });
+
+  it('strips trailing punctuation on bare tokens, keeping pastedToken as-is', () => {
+    const out = extractVideoUrls('watch youtube.com/watch?v=abc.');
+    expect(out).toHaveLength(1);
+    expect(out[0].url).toBe('https://youtube.com/watch?v=abc');
+    expect(out[0].pastedToken).toBe('youtube.com/watch?v=abc.');
+  });
+
+  it('keeps first-occurrence order across mixed protocol forms', () => {
+    const out = extractVideoUrls(
+      'youtu.be/first then https://youtu.be/second then http://youtu.be/third',
+    );
+    expect(out.map((u) => u.url)).toEqual([
+      'https://youtu.be/first',
+      'https://youtu.be/second',
+      'https://youtu.be/third',
+    ]);
   });
 
   it('rejects URLs that fail isSafeVideoUrl', () => {

--- a/services/platform/lib/shared/video-url.ts
+++ b/services/platform/lib/shared/video-url.ts
@@ -25,6 +25,13 @@
  * "This site isn't supported" chip for every non-video paste. The
  * server's `ingestVideoUrl` mutation still accepts any https URL —
  * the allowlist lives in the chat-input flow, not the ingest contract.
+ *
+ * Protocol repair: pastes of ALLOWLISTED hosts without a scheme
+ * (`youtube.com/watch?v=…`) or with `http://` are upgraded to https
+ * before validation — users paste address-bar fragments constantly and
+ * every supported platform is HSTS-only, so the upgrade recovers clear
+ * intent without ever fetching over http. Non-allowlisted bare/http
+ * tokens still die at the platform gate and stay plain text.
  */
 
 interface ExtractedVideoUrl {
@@ -233,6 +240,58 @@ function stripTrailingNoise(token: string): string {
 }
 
 const URL_RE = /\bhttps:\/\/[^\s<>"'`]+/gi;
+/**
+ * `http://` form of a video link. Upgraded to https before the safety
+ * pipeline — we never fetch over http; every supported platform is
+ * HSTS-only. Non-allowlisted http links still die at the platform gate,
+ * so the https-only ingest policy is unchanged.
+ */
+const HTTP_URL_RE = /\bhttp:\/\/[^\s<>"'`]+/gi;
+/**
+ * Protocol-less form (`youtube.com/watch?v=…`, `www.youtu.be/x`). Host +
+ * MANDATORY non-empty path — a bare `youtube.com` homepage never chips.
+ * The boundary group excludes `/`, `:`, and `@`, so hosts inside a full
+ * URL (`https://youtube.com/…`) or an email never double-match. This
+ * regex is deliberately generic about hosts: the closed `detectPlatform`
+ * allowlist downstream is the single decision point, so ordinary prose
+ * domains (`example.com/docs`) are dropped there, never chipped.
+ */
+const BARE_URL_RE =
+  /(?:^|[\s<>("'[])((?:[a-z0-9-]+\.)+[a-z]{2,}\/[^\s<>"'`]+)/gi;
+
+/** A URL-shaped token found in pasted text: the exact original substring
+ * plus the https form to validate/ingest, positioned for first-occurrence
+ * ordering across the three scan passes. */
+interface UrlCandidate {
+  original: string;
+  url: string;
+  index: number;
+}
+
+function collectUrlCandidates(text: string): UrlCandidate[] {
+  const candidates: UrlCandidate[] = [];
+  for (const m of text.matchAll(URL_RE)) {
+    candidates.push({ original: m[0], url: m[0], index: m.index ?? 0 });
+  }
+  for (const m of text.matchAll(HTTP_URL_RE)) {
+    candidates.push({
+      original: m[0],
+      url: `https://${m[0].slice('http://'.length)}`,
+      index: m.index ?? 0,
+    });
+  }
+  for (const m of text.matchAll(BARE_URL_RE)) {
+    const token = m[1];
+    candidates.push({
+      original: token,
+      url: `https://${token}`,
+      // `m.index` points at the boundary char; anchor on the token itself
+      // so cross-pass ordering compares like with like.
+      index: (m.index ?? 0) + m[0].length - token.length,
+    });
+  }
+  return candidates.sort((a, b) => a.index - b.index);
+}
 
 /**
  * Extract up to `maxUrls` deduped, sanitized video URLs from free text.
@@ -240,12 +299,15 @@ const URL_RE = /\bhttps:\/\/[^\s<>"'`]+/gi;
  * Algorithm:
  *  1. Strip fenced/inline code blocks (preserves blockquotes — those are
  *     legitimate forwarding, not quotation).
- *  2. Regex-match `\bhttps:\/\/[^\s<>"'`]+`.
- *  3. Per match, strip trailing punctuation + markdown emphasis (captures
- *     the cleaned URL but ALSO records the ORIGINAL substring as
+ *  2. Collect candidates in three passes — `https://` as-is, `http://`
+ *     upgraded to https, and protocol-less host/path tokens with https
+ *     prepended — sorted by text position (first occurrence wins).
+ *  3. Per candidate, strip trailing punctuation + markdown emphasis
+ *     (captures the cleaned URL but ALSO records the ORIGINAL substring as
  *     `pastedToken` for later literal-replace stripping at send time).
  *  4. Drop entries that fail `isSafeVideoUrl` or `isPlaylistUrl`.
- *  5. Dedup post-normalize (`normalizeUrlForHash`); first occurrence wins.
+ *  5. Dedup post-normalize (`normalizeUrlForHash`) — the https and bare
+ *     forms of the same video collapse to one chip.
  *  6. Cap to `maxUrls` (default 3) — pastes of 100 URLs are an abuse vector.
  */
 export function extractVideoUrls(
@@ -257,17 +319,17 @@ export function extractVideoUrls(
   const out: ExtractedVideoUrl[] = [];
   const seen = new Set<string>();
 
-  for (const match of cleaned.matchAll(URL_RE)) {
+  for (const candidate of collectUrlCandidates(cleaned)) {
     if (out.length >= maxUrls) break;
-    const original = match[0];
-    const cleanedUrl = stripTrailingNoise(original);
+    const cleanedUrl = stripTrailingNoise(candidate.url);
     if (cleanedUrl.length === 0) continue;
     if (!isSafeVideoUrl(cleanedUrl)) continue;
     if (isPlaylistUrl(cleanedUrl)) continue;
     const platform = detectPlatform(cleanedUrl);
     // Closed allowlist: skip anything that isn't a recognized video host.
     // Prevents the chat composer from spawning a yt-dlp job (and red
-    // "site isn't supported" chip) for ordinary links like GitHub URLs.
+    // "site isn't supported" chip) for ordinary links like GitHub URLs —
+    // and keeps the http/bare passes from widening what can chip.
     if (platform === 'generic') continue;
     const dedupKey = normalizeUrlForHash(cleanedUrl);
     if (seen.has(dedupKey)) continue;
@@ -275,9 +337,10 @@ export function extractVideoUrls(
     out.push({
       url: cleanedUrl,
       // pastedToken preserves the original text-as-pasted (including any
-      // stripped trailing punctuation) so use-send-message.ts can do a
-      // literal String.replace on the textarea content.
-      pastedToken: original,
+      // stripped trailing punctuation and the original protocol-less /
+      // http:// spelling) so use-send-message.ts can do a literal
+      // String.replace on the textarea content.
+      pastedToken: candidate.original,
       platform,
     });
   }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1364,6 +1364,7 @@
       },
       "toast": {
         "ingestFailedTitle": "Video konnte nicht hinzugefügt werden",
+        "retryFailedTitle": "Erneuter Versuch fehlgeschlagen",
         "bindFailedDescription": "Video-Transkript konnte nicht angehängt werden — bitte erneut versuchen"
       }
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1383,6 +1383,7 @@
       },
       "toast": {
         "ingestFailedTitle": "Couldn't add this video",
+        "retryFailedTitle": "Couldn't retry this video",
         "bindFailedDescription": "Couldn't attach the video transcript — please retry"
       }
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1364,6 +1364,7 @@
       },
       "toast": {
         "ingestFailedTitle": "Impossible d'ajouter cette vidéo",
+        "retryFailedTitle": "Impossible de réessayer cette vidéo",
         "bindFailedDescription": "Impossible de joindre la transcription vidéo — réessaie"
       }
     },


### PR DESCRIPTION
## Problem

Pasting a video link flips the chip to **Ready** the moment the transcript is captured (`insertSyntheticFileMetadata` writes `transcript` + `transcriptionStatus: 'completed'` + `ragStatus: 'queued'` and marks the job completed in the same mutation) — but RAG indexing continues async, with a 10s-minimum status-poll lag plus embedding time. Asking "summarize this video" right after Ready made `document_retrieve` throw **"still being indexed — try again shortly"**, and a `ragStatus='failed'` row was permanently unreadable even though the full transcript sits on the row.

Transcript-backed rows are the only class where this gap is user-reachable: plain uploads block send via `isIndexing` until indexing completes, video/audio chips unblock at transcript-capture.

## Change

- **New `helpers/transcript_content.ts`** — pure `buildTranscriptContentResult`: slices the stored transcript into 2048-char windows (mirrors RAG `chunk_size`), with full pagination-contract parity to the RAG read path (`chunkStart`/`chunkEnd` defaults, `MAX_CHUNK_WINDOW`, out-of-range → empty `{0,0}` shape, 50K cap + `truncated`).
- **`helpers/retrieve_document.ts`** — chat-attachment branch: when `ragStatus !== 'completed'` and `transcriptionStatus === 'completed'` with a non-empty `transcript`, serve the row transcript instead of throwing; `ragStatus='failed'` rows are rescued the same way. A `note` field tells the model the text is complete but `rag_search` may not cover the file yet. The fallback result flows through the same `wrapUntrusted` exit as the RAG path (prompt-injection defense preserved). Rows without a transcript keep the exact existing errors.
- **`document_retrieve_tool.ts`** — INDEXING paragraph of the tool description updated for the new semantics.

Not covered on purpose: on-demand extraction for binary uploads (duplicates the pipeline's most expensive stage, incl. billed OCR, per paginated call — and their send path already waits for indexing). The universal alternative — reordering the indexing pipeline to store chunk text before embedding — is a separate project (touches the #2752 sliced-indexing resume invariant).

## Verification

- 128 vitest green across `agent_tools/documents/` (15 new: 8 pure-helper cases + 7 fallback/tool cases incl. untrusted-wrap, failed-rescue, pagination, and unchanged-error paths); `tsc --noEmit` and oxlint clean; staged SAST 0 findings.
- Producer-side field contract (`transcript`+`transcriptionStatus`+`ragStatus` written together) already guarded by `synthetic_file_metadata.test.ts`.
- **Not verified live:** a real YouTube paste E2E (local yt-dlp bot-wall flakiness). The unit tests exercise the real `retrieveDocument` + `buildTranscriptContentResult` + `wrapUntrusted` with only DB/RAG calls mocked.

## Definition of done

- [x] Green gate — oxfmt (hook), oxlint, tsc, vitest (touched workspace) green locally
- [x] Security gate — staged opengrep SAST clean; no new boundary (tool input stays zod-validated)
- [x] Tests — happy path + edges (pagination, truncation, out-of-range) + error paths (no-transcript rows unchanged)
- [x] Migration — N/A: no schema or config-domain change
- [x] Locales — N/A: agent-facing English strings only (house convention for tool text)
- [x] Docs — N/A: no docs page references this tool's behavior; tool description updated in place
- [x] Accessibility — N/A: no UI
- [x] Sweep — workflow `document_action` ruled out (stays RAG-only); hub-document path untouched; builtin-configs reference the tool by name only; `api.d.ts` codegen committed
- [x] Observed — behavior proven at unit level with real helper/tool code; live video E2E honestly not run (see Verification)
- [x] Commits — single atomic conventional commit, branched off main

---

## Follow-up in this PR: silent video-chip retry click (fix)

Clicking retry on a failed video chip did visibly nothing when the backend refused the retry. `retryVideoLink` throws structured `ConvexError` codes — the 15-min bot-detection/rate-limit cooldown (`retryCooldown`), `budgetExceeded`, `inFlightCap` — but `retryJob` (`use-chat-video-links.ts`) awaited the mutation with no catch and the chip's `onRetry` `void`s the promise, so the refusal was an unhandled rejection. The `videoLink.errors.retryCooldown` copy existed in every locale but was unreachable.

- `retryJob` now surfaces refusals through the same toast contract as `ingestUrlsFromText` (code → `videoLink.errors.*`, generic fallback); shared `convexErrorCode` helper extracted.
- New `videoLink.toast.retryFailedTitle` in **en/de/fr** (de-CH stays a sparse override); i18n parity + centralized voice checks green.
- Regression test `use-chat-video-links.retry-toast.test.ts` — watched red on the old hook (2/3 fail: rejection, no toast), green on the new (3/3).

## Follow-up 2 in this PR: transcript staged on disk as a fake mp4 (fix)

The message attachment for a video-link transcript deliberately carries a display identity — `fileType: 'video/mp4'` (the `isAudioOrVideo` routing sentinel) and the extension-less video title — while the blob is transcript text. Both file-materializing consumers copied it verbatim: the workspace filer (`/user/uploads` in chat + Canvas showed `It Broke?` · 1.8 KB · video/mp4, download-only) and the external-agent stager (whose preamble told the model it had an mp4).

- New shared `resolve_transcript_identity.ts`: restores the synthetic `fileMetadata` row's real identity (`"<title>.txt"`, `text/plain`) for `source === 'video_link'` rows, fail-open; wired into `workspace_uploads.ts` and `run_external_agent.ts` staging.
- Display consumers (bubble video card, `document_retrieve` hint) intentionally keep the sentinel.
- 6 new tests incl. plan-level regressions (`/user/uploads/It Broke?.txt` + text/plain on both staging paths).

## Follow-ups 3+4 in this PR: protocol-less video links + org-wide transcript reuse

**Protocol-less / http URLs now chip** (`lib/shared/video-url.ts`): candidates are collected in three position-sorted passes — `https://` as-is, `http://` upgraded, and bare `youtube.com/watch?v=…` tokens with https prepended — all funneled through the same safety pipeline and the closed `detectPlatform` allowlist, so non-video hosts still never chip and nothing is ever fetched over http. Bare tokens require a non-empty path; `pastedToken` keeps the original spelling so send-time stripping works. 53 extractor tests green.

**Re-pasted URLs reuse the org's existing transcript** (`video_links/donor.ts`, `clone_transcript.ts`, ingest rework): after the same-composer dedup misses, `ingestVideoUrl` looks up a donor by `(organizationId, sourceUrlHash)` — newest row ≤30 days whose `fileMetadata` still carries a completed transcript (a cancelled chip's row survives; bound rows keep everything). On a hit the new job clones the transcript verbatim as its own blob + synthetic row (RAG content-hash dedup clones the embeddings) and completes in ~1s with **zero yt-dlp** — covering remove→re-add, cross-thread, and cross-user pastes, org-scoped only. Cancel-vs-clone races are CAS-guarded with orphan-blob reaping; a vanished donor degrades to the full pipeline; the watchdog's existing 5-min `indexing` window backstops a wedged clone. No schema change; audit logs record `reusedTranscript` + `donorJobId`. 9 new convex-test cases (donor lookup incl. the skipped-job case + finalizer happy path & cancel race); `ingestVideoUrl` glue itself is not convex-testable (betterAuth) — verified by typecheck + review.