### PR TITLE
fix(platform): shrink batch size for messageMetadata org backfill

### DIFF
--- a/services/platform/convex/migrations/versions/v0_3_7/01_backfill_message_metadata_org_id/migration.ts
+++ b/services/platform/convex/migrations/versions/v0_3_7/01_backfill_message_metadata_org_id/migration.ts
@@ -52,6 +52,13 @@ export const migration = defineDbMigration({
   subjects: { tables: ['messageMetadata', 'threadMetadata'] },
   table: 'messageMetadata',
 
+  // messageMetadata rows are heavy — contextWindow is capped at 500K chars
+  // (message_metadata/internal_mutations.ts) plus reasoning + tool I/O — so the
+  // default 100 rows/txn reads past Convex's 16 MiB per-transaction read limit.
+  // Page in small batches; this backfill is one-time and resumable, so the extra
+  // transactions cost nothing.
+  batchSize: 8,
+
   // IDEMPOTENT per-row forward transform: a replayed, already-stamped row is a
   // no-op (the runner replays the crash batch on resume).
   async up(ctx, doc) {


### PR DESCRIPTION
## What

`v0_3_7/01_backfill_message_metadata_org_id` paginates `messageMetadata` at the default 100 rows per transaction. Those rows are heavy — `contextWindow` alone is capped at 500K chars, plus `reasoning` and tool I/O — so a single batch reads past Convex's 16 MiB per-transaction read limit and `applyUp` fails mid-run (hit on a private deploy running `make migrate-up`).

## Change

Set `batchSize: 8` on the migration spec so each transaction reads well under the limit. The runner already honours `migration.batchSize` (`runner.ts:127` → `.paginate({ numItems })`); nothing else changes. Per-row behaviour, idempotency, and reversibility are untouched — the backfill stays resumable, so re-running `make migrate-up` completes across more, smaller transactions and skips already-stamped rows.

## Note

No new migration version: `batchSize` is a runtime pagination knob, not part of the migration identity/ledger, so the registry and chain/corpus guards are unaffected.