### PR TITLE
feat(platform): send-then-wait for processing media

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -92,7 +92,14 @@ interface ChatInputProps extends Omit<
     message: string,
     attachments?: FileAttachment[],
     kbReferences?: KbMention[],
+    options?: { deferForMedia?: boolean },
   ) => void;
+  /**
+   * Disables the send-then-wait deferral (arena mode: the send fans out to
+   * two threads and deferral there is an explicit follow-up) — processing
+   * media falls back to blocking the send button as before.
+   */
+  mediaDeferDisabled?: boolean;
   onStopGenerating?: () => void;
   isLoading?: boolean;
   /**
@@ -292,6 +299,7 @@ export function ChatInput({
   videoLinkJobs = [],
   isProcessingVideo = false,
   hasFailedVideoJobs = false,
+  mediaDeferDisabled = false,
   ingestVideoUrlsFromText,
   cancelVideoJob,
   retryVideoJob,
@@ -349,21 +357,34 @@ export function ChatInput({
   const { pending: pasteIngestPending, ingest: ingestVideoUrls } =
     useVideoUrlIngest(ingestVideoUrlsFromText, organizationId, i18n.language);
 
-  // Single source of truth for the media-processing states that block send.
-  // `mediaBlockReason` names the active one (precedence order) for the send-
-  // button tooltip; `mediaBlocksSend` is the OR consumed by the send-gate and
-  // the disabled state. `pasteIngestPending` (blocks send, no tooltip) and
-  // `sendBlocked` (carries its own reason string) stay separate.
-  const mediaBlockReason: MediaBlockReason | null = isTranscribing
-    ? 'transcribing'
-    : isProcessingVideo
-      ? 'processingVideo'
-      : hasFailedVideoJobs
-        ? 'failedVideo'
-        : hasFailedAudioJobs
-          ? 'failedAudio'
+  // Send-then-wait: processing media no longer blocks Send — the send parks
+  // as a waiting_media queue row and the readiness watcher starts the turn
+  // when everything is ready. Deferral is unavailable in two cases, which
+  // keep the old blocking behaviour: arena (`mediaDeferDisabled`) and a send
+  // carrying `@`-mention KB references (the deferred path doesn't transport
+  // those). Failed media ALWAYS blocks — the user retries/removes in place.
+  // Raw prop read (kbMentionsEnabled derives later): a non-empty mentions
+  // list only exists when the feature is on.
+  const kbRefsPinned = (kbMentions?.length ?? 0) > 0;
+  const mediaDeferUnavailable = mediaDeferDisabled || kbRefsPinned;
+  // `mediaBlockReason` names the active blocker (precedence order) for the
+  // send-button tooltip; `mediaBlocksSend` is the OR consumed by the
+  // send-gate and the disabled state. `pasteIngestPending` (blocks send, no
+  // tooltip) and `sendBlocked` (carries its own reason string) stay separate.
+  const mediaBlockReason: MediaBlockReason | null = hasFailedVideoJobs
+    ? 'failedVideo'
+    : hasFailedAudioJobs
+      ? 'failedAudio'
+      : mediaDeferUnavailable && isTranscribing
+        ? 'transcribing'
+        : mediaDeferUnavailable && isProcessingVideo
+          ? 'processingVideo'
           : null;
   const mediaBlocksSend = mediaBlockReason !== null;
+  // What the current composer state would defer on at send time.
+  const deferForMedia =
+    !mediaDeferUnavailable &&
+    (isIndexing || isTranscribing || isProcessingVideo);
   const [previewImage, setPreviewImage] = useState<{
     src: string;
     alt: string;
@@ -758,7 +779,7 @@ export function ChatInput({
       (queueSend && (!value.trim() || attachments.length > 0)) ||
       disabled ||
       isUploading ||
-      isIndexing ||
+      (mediaDeferUnavailable && isIndexing) ||
       mediaBlocksSend ||
       pasteIngestPending ||
       sendBlocked
@@ -803,7 +824,13 @@ export function ChatInput({
         : undefined;
     setMentionTrigger(null);
 
-    onSendMessage(messageToSend, attachmentsToSend, kbRefsToSend);
+    if (deferForMedia) {
+      onSendMessage(messageToSend, attachmentsToSend, kbRefsToSend, {
+        deferForMedia: true,
+      });
+    } else {
+      onSendMessage(messageToSend, attachmentsToSend, kbRefsToSend);
+    }
   };
 
   const imageAttachments = useMemo(
@@ -1466,7 +1493,7 @@ export function ChatInput({
                     : (!value.trim() && attachments.length === 0) ||
                       inputDisabled ||
                       isUploading ||
-                      isIndexing ||
+                      (mediaDeferUnavailable && isIndexing) ||
                       mediaBlocksSend ||
                       pasteIngestPending ||
                       sendBlocked;

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -877,6 +877,7 @@ export function ChatInterface({
     message: string,
     sentAttachments?: FileAttachment[],
     kbReferences?: KbMention[],
+    options?: { deferForMedia?: boolean },
   ) => {
     // Queue mode: a turn is running on this external-agent thread — enqueue
     // instead of dispatching. Text-only (ChatInput blocks attachment sends in
@@ -951,12 +952,19 @@ export function ChatInterface({
     // `clearInputValue()` — without this, the chip lingers in the
     // composer for the 50-200 ms `bindCompletedJobsToMessage` round-trip
     // and the user reads it as "the input box doesn't clear quickly".
-    const videoLinkSnapshot = videoLinkJobs.filter(
-      (j) =>
-        j.displayStatus === 'completed' &&
-        j.messageBoundAt === undefined &&
-        j.lifecycleStatus !== 'trashed' &&
-        j.storageId !== undefined,
+    // Deferred sends (media still processing) carry EVERY sendable chip —
+    // in-flight jobs included, the enqueue mutation claims them; direct
+    // sends keep the completed-only predicate.
+    const videoLinkSnapshot = videoLinkJobs.filter((j) =>
+      options?.deferForMedia === true
+        ? j.messageBoundAt === undefined &&
+          j.lifecycleStatus !== 'trashed' &&
+          j.displayStatus !== 'skipped' &&
+          j.displayStatus !== 'failed'
+        : j.displayStatus === 'completed' &&
+          j.messageBoundAt === undefined &&
+          j.lifecycleStatus !== 'trashed' &&
+          j.storageId !== undefined,
     );
     const snapshotJobIds = videoLinkSnapshot.map((j) => j.jobId);
     if (snapshotJobIds.length > 0) {
@@ -993,6 +1001,7 @@ export function ChatInterface({
         finalAttachments,
         videoLinkSnapshot,
         kbReferences,
+        options,
       );
     } catch (err) {
       // Restore the draft so the user can retry or edit. The chip
@@ -1465,7 +1474,7 @@ export function ChatInterface({
         ) : threadStatusPending ? null : (
           <FileUpload.Root>
             <div className="px-3">
-              {isExternalAgentThread && dataThreadId && (
+              {dataThreadId && (
                 <QueuedMessageTray
                   threadId={dataThreadId}
                   organizationId={organizationId}
@@ -1502,6 +1511,7 @@ export function ChatInterface({
                 }
                 isLoading={isLoading}
                 queueModeActive={queueModeActive}
+                mediaDeferDisabled={isArenaMode}
                 disabled={hasNoAgents || hasActiveApproval || missingKeyBlocked}
                 disabledReason={
                   hasNoAgents

--- a/services/platform/app/features/chat/components/embedded-chat.tsx
+++ b/services/platform/app/features/chat/components/embedded-chat.tsx
@@ -171,6 +171,10 @@ function EmbeddedChatContent({
         removeAttachment={removeAttachment}
         clearAttachments={clearAttachments}
         isIndexing={isIndexing}
+        // Embedded surfaces keep the pre-deferral blocking UX: their send
+        // path (use-embedded-chat) has no waiting_media route yet, so an
+        // allowed-but-deferred click would be a silent no-op here.
+        mediaDeferDisabled
         indexingStatuses={indexingStatuses}
         isTranscribing={isTranscribing}
         transcriptionStatuses={transcriptionStatuses}

--- a/services/platform/app/features/chat/components/queued-message-tray.tsx
+++ b/services/platform/app/features/chat/components/queued-message-tray.tsx
@@ -14,6 +14,10 @@ import { cn } from '@/lib/utils/cn';
 
 import { useDeleteQueuedMessage } from '../hooks/mutations';
 import { useSessionProgress } from '../hooks/queries';
+import {
+  WaitingMediaDetails,
+  type WaitingMediaAttachment,
+} from './waiting-media-details';
 
 /** An optimistic entry for a message whose enqueue mutation is still in
  * flight — rendered exactly like a 'queued' row so the send never appears to
@@ -28,6 +32,10 @@ interface TrayEntry {
   queueId?: Id<'chatMessageQueue'>;
   text: string;
   status: 'waiting_media' | 'queued' | 'claimed' | 'delivered';
+  /** Media-wait rows: what the send waits on, for the live progress strip
+   * (`WaitingMediaDetails`) under the text line. */
+  attachments?: readonly WaitingMediaAttachment[];
+  videoJobIds?: readonly Id<'videoLinkJobs'>[];
   /** Entry left the waiting set (picked or removed) — kept briefly with a
    * fade-out so a fast pick reads as a deliberate move into the transcript,
    * not a flash. */
@@ -80,6 +88,12 @@ export function QueuedMessageTray({
               queueId: r.queueId,
               text: r.text,
               status: r.status,
+              ...(r.attachments !== undefined && {
+                attachments: r.attachments,
+              }),
+              ...(r.videoJobIds !== undefined && {
+                videoJobIds: r.videoJobIds,
+              }),
             },
           ]
         : [],
@@ -158,50 +172,66 @@ export function QueuedMessageTray({
                 ? t('queue.status.deliversNow')
                 : t('queue.status.queued');
         const queueId = entry.queueId;
+        const showMediaDetails =
+          !entry.ghost &&
+          entry.status === 'waiting_media' &&
+          ((entry.attachments?.length ?? 0) > 0 ||
+            (entry.videoJobIds?.length ?? 0) > 0);
         return (
           <li
             key={entry.key}
             className={cn(
-              'border-border bg-muted/40 text-foreground flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm',
+              'border-border bg-muted/40 text-foreground flex flex-col gap-1.5 rounded-lg border px-3 py-1.5 text-sm',
               'animate-in fade-in-0 slide-in-from-bottom-1 transition-opacity duration-300',
               entry.ghost && 'opacity-0',
             )}
           >
-            <Clock
-              className="text-muted-foreground size-3.5 shrink-0"
-              aria-hidden="true"
-            />
-            <span className="min-w-0 flex-1 truncate">{entry.text}</span>
-            <span className="text-muted-foreground shrink-0 text-xs italic">
-              {statusText}
-            </span>
-            {!entry.ghost &&
-              (entry.status === 'queued' || entry.status === 'waiting_media') &&
-              queueId && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-6 shrink-0"
-                  aria-label={t('queue.tray.remove')}
-                  onClick={() =>
-                    deleteQueued(
-                      { queueId },
-                      {
-                        onError: (err: unknown) => {
-                          console.warn('[queue-tray] delete failed', err);
-                          toast({
-                            title: t('queue.tray.removeFailed'),
-                            variant: 'destructive',
-                          });
+            <div className="flex items-center gap-2">
+              <Clock
+                className="text-muted-foreground size-3.5 shrink-0"
+                aria-hidden="true"
+              />
+              <span className="min-w-0 flex-1 truncate">{entry.text}</span>
+              <span className="text-muted-foreground shrink-0 text-xs italic">
+                {statusText}
+              </span>
+              {!entry.ghost &&
+                (entry.status === 'queued' ||
+                  entry.status === 'waiting_media') &&
+                queueId && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 shrink-0"
+                    aria-label={t('queue.tray.remove')}
+                    onClick={() =>
+                      deleteQueued(
+                        { queueId },
+                        {
+                          onError: (err: unknown) => {
+                            console.warn('[queue-tray] delete failed', err);
+                            toast({
+                              title: t('queue.tray.removeFailed'),
+                              variant: 'destructive',
+                            });
+                          },
                         },
-                      },
-                    )
-                  }
-                >
-                  <X className="size-3.5" aria-hidden="true" />
-                </Button>
-              )}
+                      )
+                    }
+                  >
+                    <X className="size-3.5" aria-hidden="true" />
+                  </Button>
+                )}
+            </div>
+            {showMediaDetails && (
+              <WaitingMediaDetails
+                threadId={threadId}
+                organizationId={organizationId}
+                attachments={entry.attachments}
+                videoJobIds={entry.videoJobIds}
+              />
+            )}
           </li>
         );
       })}

--- a/services/platform/app/features/chat/components/queued-message-tray.tsx
+++ b/services/platform/app/features/chat/components/queued-message-tray.tsx
@@ -27,7 +27,7 @@ interface TrayEntry {
   key: string;
   queueId?: Id<'chatMessageQueue'>;
   text: string;
-  status: 'queued' | 'claimed' | 'delivered';
+  status: 'waiting_media' | 'queued' | 'claimed' | 'delivered';
   /** Entry left the waiting set (picked or removed) — kept briefly with a
    * fade-out so a fast pick reads as a deliberate move into the transcript,
    * not a flash. */
@@ -71,7 +71,9 @@ export function QueuedMessageTray({
   // drained into the next turn; their bubbles are saved, so they leave too.
   const live = useMemo<TrayEntry[]>(() => {
     const fromServer = (rows ?? []).flatMap<TrayEntry>((r) =>
-      r.status === 'queued' || r.status === 'delivered'
+      r.status === 'queued' ||
+      r.status === 'delivered' ||
+      r.status === 'waiting_media'
         ? [
             {
               key: r.queueId,
@@ -148,11 +150,13 @@ export function QueuedMessageTray({
       {entries.map((entry) => {
         const statusText = entry.ghost
           ? t('queue.status.consumed')
-          : entry.status === 'delivered'
-            ? t('queue.status.delivered')
-            : agentLingering
-              ? t('queue.status.deliversNow')
-              : t('queue.status.queued');
+          : entry.status === 'waiting_media'
+            ? t('queue.status.waitingMedia')
+            : entry.status === 'delivered'
+              ? t('queue.status.delivered')
+              : agentLingering
+                ? t('queue.status.deliversNow')
+                : t('queue.status.queued');
         const queueId = entry.queueId;
         return (
           <li
@@ -171,31 +175,33 @@ export function QueuedMessageTray({
             <span className="text-muted-foreground shrink-0 text-xs italic">
               {statusText}
             </span>
-            {!entry.ghost && entry.status === 'queued' && queueId && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-6 shrink-0"
-                aria-label={t('queue.tray.remove')}
-                onClick={() =>
-                  deleteQueued(
-                    { queueId },
-                    {
-                      onError: (err: unknown) => {
-                        console.warn('[queue-tray] delete failed', err);
-                        toast({
-                          title: t('queue.tray.removeFailed'),
-                          variant: 'destructive',
-                        });
+            {!entry.ghost &&
+              (entry.status === 'queued' || entry.status === 'waiting_media') &&
+              queueId && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-6 shrink-0"
+                  aria-label={t('queue.tray.remove')}
+                  onClick={() =>
+                    deleteQueued(
+                      { queueId },
+                      {
+                        onError: (err: unknown) => {
+                          console.warn('[queue-tray] delete failed', err);
+                          toast({
+                            title: t('queue.tray.removeFailed'),
+                            variant: 'destructive',
+                          });
+                        },
                       },
-                    },
-                  )
-                }
-              >
-                <X className="size-3.5" aria-hidden="true" />
-              </Button>
-            )}
+                    )
+                  }
+                >
+                  <X className="size-3.5" aria-hidden="true" />
+                </Button>
+              )}
           </li>
         );
       })}

--- a/services/platform/app/features/chat/components/steer-status.tsx
+++ b/services/platform/app/features/chat/components/steer-status.tsx
@@ -53,9 +53,13 @@ export function SteerStatusProvider({
     const map = new Map<string, SteerStatus>();
     if (rows) {
       // Persist-at-pick: the transcript bubble's id is `savedMessageId`
-      // (created at the pick); legacy rows carry it as `messageId`. A waiting
-      // deferred row has no bubble yet — the queue tray renders it instead.
-      for (const r of rows) map.set(r.savedMessageId ?? r.messageId, r.status);
+      // (created at the pick); legacy rows carry it as `messageId`.
+      for (const r of rows) {
+        // A media-wait row has no bubble by definition (the pipeline saves
+        // its message only at start) — the queue tray renders it instead.
+        if (r.status === 'waiting_media') continue;
+        map.set(r.savedMessageId ?? r.messageId, r.status);
+      }
     }
     return map;
   }, [rows]);

--- a/services/platform/app/features/chat/components/video-link-chip.tsx
+++ b/services/platform/app/features/chat/components/video-link-chip.tsx
@@ -10,8 +10,15 @@ import type { VideoLinkJob } from '../hooks/use-chat-video-links';
 
 interface VideoLinkChipProps {
   job: VideoLinkJob;
-  onCancel: () => void;
+  /** Omit to hide the chip's own remove button — the queue tray does this
+   * because its row already carries the whole-message cancel; two ✕ with
+   * different scopes on one line read as duplicates. */
+  onCancel?: () => void;
   onRetry: () => void;
+  /** Drop the chip's own card chrome (border/background/rounding) —
+   * for hosts that already draw a card around it (the queue tray's
+   * waiting row), where a card-in-card reads as clutter. */
+  flat?: boolean;
 }
 
 const PROCESSING_STATUSES: ReadonlySet<string> = new Set([
@@ -40,7 +47,12 @@ const PROCESSING_STATUSES: ReadonlySet<string> = new Set([
  * Tap targets are ≥44pt and the cancel/retry buttons are visible on
  * touch devices (not hover-gated) per the mobile B6 review.
  */
-export function VideoLinkChip({ job, onCancel, onRetry }: VideoLinkChipProps) {
+export function VideoLinkChip({
+  job,
+  onCancel,
+  onRetry,
+  flat = false,
+}: VideoLinkChipProps) {
   const { t: tChat } = useT('chat');
 
   const isProcessing = PROCESSING_STATUSES.has(job.displayStatus);
@@ -89,10 +101,15 @@ export function VideoLinkChip({ job, onCancel, onRetry }: VideoLinkChipProps) {
         // `message-bubble.tsx`'s user-bubble width — same breakpoint
         // prevents a sm-lg-viewport bounce where the chip is wider than
         // the bubble that replaces it on send.
-        'group/chip flex max-w-full items-center gap-2 rounded-2xl border px-3 py-1.5 text-sm lg:max-w-md',
+        'group/chip flex max-w-full items-center gap-2 text-sm lg:max-w-md',
+        !flat && 'rounded-2xl border px-3 py-1.5',
         isFailed
-          ? 'border-destructive/40 bg-destructive/5 text-destructive'
-          : 'border-border bg-muted/40 text-foreground',
+          ? flat
+            ? 'text-destructive'
+            : 'border-destructive/40 bg-destructive/5 text-destructive'
+          : flat
+            ? 'text-foreground'
+            : 'border-border bg-muted/40 text-foreground',
       )}
     >
       <span aria-hidden="true" className="shrink-0 text-base leading-none">
@@ -167,14 +184,16 @@ export function VideoLinkChip({ job, onCancel, onRetry }: VideoLinkChipProps) {
           <RotateCcw className="size-4" />
         </button>
       )}
-      <button
-        type="button"
-        onClick={onCancel}
-        aria-label={tChat('videoLink.actions.removeLink')}
-        className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex size-11 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
-      >
-        <X className="size-4" />
-      </button>
+      {onCancel && (
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label={tChat('videoLink.actions.removeLink')}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex size-11 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <X className="size-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/services/platform/app/features/chat/components/waiting-media-details.tsx
+++ b/services/platform/app/features/chat/components/waiting-media-details.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { HStack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import { FileText } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+
+import { useChatVideoLinks } from '../hooks/use-chat-video-links';
+import type { FileAttachment } from '../hooks/use-convex-file-upload';
+import { useFileIndexingStatus } from '../hooks/use-file-indexing-status';
+import { useFileTranscriptionStatus } from '../hooks/use-file-transcription-status';
+import { AttachmentStatusLabel } from './chat-input/attachment-status-label';
+import { VideoLinkChip } from './video-link-chip';
+
+export interface WaitingMediaAttachment {
+  fileId: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+}
+
+/**
+ * The live progress strip under a `waiting_media` queue-tray row — the same
+ * detail the composer showed before the send, so parking the message never
+ * loses "Fetching captions…" / "Transcribing…" / indexing state or the
+ * retry affordance.
+ *
+ * Video jobs render the REAL `VideoLinkChip` in its flat form (matched from
+ * the thread's job subscription by the row's claimed ids — the composer
+ * hook filters bound rows out, so this reads the raw query). The row's ✕ is
+ * the only cancel and it cancels the media processing too
+ * (`cancelDeferredJobs`). File attachments reuse the composer's
+ * status-label with the same indexing/transcription subscriptions.
+ */
+export function WaitingMediaDetails({
+  threadId,
+  organizationId,
+  attachments,
+  videoJobIds,
+}: {
+  threadId: string;
+  organizationId: string;
+  attachments?: readonly WaitingMediaAttachment[];
+  videoJobIds?: readonly Id<'videoLinkJobs'>[];
+}) {
+  const { data: jobRows } = useConvexQuery(
+    api.video_links.queries.listForThread,
+    videoJobIds && videoJobIds.length > 0
+      ? { threadId, organizationId }
+      : 'skip',
+  );
+  // Callback only — the hook's own `jobs` list filters bound rows, which is
+  // exactly what these rows are. Convex dedupes the doubled subscription.
+  const { retryJob } = useChatVideoLinks({
+    threadId,
+    organizationId,
+  });
+
+  const jobs = useMemo(() => {
+    if (!jobRows || !videoJobIds || videoJobIds.length === 0) return [];
+    const wanted = new Set<string>(videoJobIds);
+    // A cancelled (skipped) job is excluded from the send at start — its
+    // chip retires from the strip the same moment.
+    return jobRows.filter(
+      (j) => wanted.has(j.jobId) && j.displayStatus !== 'skipped',
+    );
+  }, [jobRows, videoJobIds]);
+
+  const fileAttachments = useMemo(
+    () =>
+      (attachments ?? []).filter(
+        (a) => !a.fileType.startsWith('image/'),
+      ) as unknown as FileAttachment[], // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- row attachments carry the same {fileId,fileName,fileType,fileSize} shape; fileId is the branded BlobRef string the queries accept.
+    [attachments],
+  );
+  const { statusMap: indexingStatuses } = useFileIndexingStatus(
+    fileAttachments,
+    organizationId,
+  );
+  const { statusMap: transcriptionStatuses } = useFileTranscriptionStatus(
+    fileAttachments,
+    organizationId,
+  );
+
+  if (jobs.length === 0 && fileAttachments.length === 0) return null;
+
+  // Everything renders FLAT — the tray row is the card; a second border
+  // inside it reads as clutter (card-in-card). The row's ✕ is the single
+  // cancel affordance and it cancels the media processing too, so chips
+  // carry no onCancel; retry stays because it acts on the failed job in
+  // place.
+  return (
+    <HStack gap={3} align="center" className="min-w-0 flex-wrap pl-5">
+      {jobs.map((job) => (
+        <VideoLinkChip
+          key={job.jobId}
+          job={job}
+          flat
+          onRetry={() => void retryJob(job.jobId)}
+        />
+      ))}
+      {fileAttachments.map((attachment) => (
+        <HStack
+          key={attachment.fileId}
+          gap={2}
+          align="center"
+          className="min-w-0"
+        >
+          <FileText
+            className="text-muted-foreground size-3.5 shrink-0"
+            aria-hidden="true"
+          />
+          <Text as="span" variant="caption" className="max-w-40 truncate">
+            {attachment.fileName}
+          </Text>
+          <AttachmentStatusLabel
+            attachment={attachment}
+            indexingStatuses={indexingStatuses}
+            transcriptionStatuses={transcriptionStatuses}
+          />
+        </HStack>
+      ))}
+    </HStack>
+  );
+}

--- a/services/platform/app/features/chat/components/waiting-media-details.tsx
+++ b/services/platform/app/features/chat/components/waiting-media-details.tsx
@@ -70,11 +70,19 @@ export function WaitingMediaDetails({
     );
   }, [jobRows, videoJobIds]);
 
+  // Reconstruct FileAttachment objects rather than asserting the row shape —
+  // the queue only stores the four fields the status hooks need, and a cast
+  // trips `no-unsafe-type-assertion` (FileAttachment is narrower via optionals).
   const fileAttachments = useMemo(
-    () =>
-      (attachments ?? []).filter(
-        (a) => !a.fileType.startsWith('image/'),
-      ) as unknown as FileAttachment[], // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- row attachments carry the same {fileId,fileName,fileType,fileSize} shape; fileId is the branded BlobRef string the queries accept.
+    (): FileAttachment[] =>
+      (attachments ?? [])
+        .filter((a) => !a.fileType.startsWith('image/'))
+        .map((a) => ({
+          fileId: a.fileId,
+          fileName: a.fileName,
+          fileType: a.fileType,
+          fileSize: a.fileSize,
+        })),
     [attachments],
   );
   const { statusMap: indexingStatuses } = useFileIndexingStatus(

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -170,6 +170,16 @@ function buildThreadTitle(message: string): string {
   return message.length > 50 ? message.slice(0, 50) + '...' : message;
 }
 
+export interface SendMessageOptions {
+  /**
+   * Composer saw media still processing at click time (RAG-indexing files,
+   * running transcriptions, in-flight video jobs). The send parks as a
+   * `waiting_media` queue row (convex/threads/media_send.ts) instead of
+   * dispatching; the readiness watcher starts the turn server-side.
+   */
+  deferForMedia?: boolean;
+}
+
 interface ArenaParams {
   isArenaMode: boolean;
   modelA: string | null;
@@ -325,6 +335,7 @@ export function useSendMessage({
       attachments?: FileAttachment[],
       videoLinkSnapshot?: VideoLinkJob[],
       kbReferences?: KbMention[],
+      options?: SendMessageOptions,
     ) => {
       if (sendingRef.current) return;
 
@@ -437,15 +448,52 @@ export function useSendMessage({
       const pastedTokensToStrip: string[] = [];
       const snapshotJobIds: Array<Id<'videoLinkJobs'>> = [];
       const boundJobIdsLocal: Array<Id<'videoLinkJobs'>> = [];
+
+      const currentArena = arenaRef.current;
+      const modelA = currentArena?.modelA;
+      const modelB = currentArena?.modelB;
+      const isArena = currentArena?.isArenaMode && modelA && modelB;
+
+      // Send-then-wait: media was still processing at click time — the
+      // composer flags pending files (options), and a not-yet-completed
+      // video job in the snapshot flags itself. Such a send parks as a
+      // `waiting_media` queue row (convex/threads/media_send.ts) instead of
+      // dispatching; the readiness watcher starts the turn server-side.
+      // Arena keeps the old completed-only behaviour (its send fans out to
+      // two threads; deferral there is an explicit follow-up).
+      const deferForMedia =
+        !isArena &&
+        (options?.deferForMedia === true ||
+          (videoLinkSnapshot?.some(
+            (j) =>
+              j.messageBoundAt === undefined &&
+              j.lifecycleStatus !== 'trashed' &&
+              j.displayStatus !== 'completed' &&
+              j.displayStatus !== 'failed' &&
+              j.displayStatus !== 'skipped',
+          ) ??
+            false));
+
       if (videoLinkSnapshot && videoLinkSnapshot.length > 0) {
         for (const job of videoLinkSnapshot) {
           // Re-assert the bind predicate to defend against a stale
           // snapshot (a chip status flipping between the click-handler
           // read and this point). Server bind would also skip these
           // rows, so optimistic and persisted stay aligned.
-          if (job.displayStatus !== 'completed') continue;
           if (job.messageBoundAt !== undefined) continue;
           if (job.lifecycleStatus === 'trashed') continue;
+          if (deferForMedia) {
+            // Deferred path: the enqueue mutation claims the jobs and the
+            // turn start builds their payloads — collect ids + strip every
+            // pasted token now (completed AND in-flight), push no payloads
+            // (the server would double them otherwise).
+            if (job.displayStatus === 'skipped') continue;
+            if (job.displayStatus === 'failed') continue;
+            snapshotJobIds.push(job.jobId);
+            pastedTokensToStrip.push(job.pastedToken);
+            continue;
+          }
+          if (job.displayStatus !== 'completed') continue;
           if (!job.storageId) continue;
           // fileType sentinel matches the bind mutation's output —
           // `isAudioOrVideo` in start_agent_chat.ts picks the video icon
@@ -464,11 +512,6 @@ export function useSendMessage({
           boundJobIdsLocal.push(job.jobId);
         }
       }
-
-      const currentArena = arenaRef.current;
-      const modelA = currentArena?.modelA;
-      const modelB = currentArena?.modelB;
-      const isArena = currentArena?.isArenaMode && modelA && modelB;
 
       // Arena compares two models on ONE chosen agent, so it can't run in
       // "Auto" mode — it needs an explicit selection. Fail fast before any
@@ -565,6 +608,59 @@ export function useSendMessage({
             }`,
           );
         }
+      }
+
+      // --- Send-then-wait (media still processing) -----------------------
+      // Park the send as a waiting_media queue row and return: the thread
+      // exists (created here for welcome-page sends), the composer clears,
+      // and the QUEUE TRAY is the visible representation — no optimistic
+      // bubble (the pipeline saves the real user message when the readiness
+      // watcher starts the turn). KB references never reach this branch —
+      // the composer blocks the @-mention + processing-media combination.
+      if (deferForMedia) {
+        try {
+          let ensuredThreadId = threadId;
+          if (!ensuredThreadId) {
+            const title = buildThreadTitle(messageToSend);
+            ensuredThreadId = await createThread({
+              organizationId,
+              title,
+              chatType: 'general',
+              teamId,
+            });
+            setPendingThreadId(ensuredThreadId);
+            const navThreadId = ensuredThreadId;
+            startTransition(() => {
+              void navigate({
+                to: '/dashboard/$id/chat/$threadId',
+                params: { id: organizationId, threadId: navThreadId },
+              });
+            });
+          }
+          await convexClient.mutation(api.threads.media_send.enqueueMediaSend, {
+            threadId: ensuredThreadId,
+            organizationId,
+            message: messageToSend,
+            agentSlug: agentSlugToSend,
+            modelId: modelId || undefined,
+            ...(mutationAttachments.length > 0 && {
+              attachments: mutationAttachments,
+            }),
+            ...(snapshotJobIds.length > 0 && { videoJobIds: snapshotJobIds }),
+          });
+        } catch (err) {
+          // Same rollback contract as a failed dispatch: chips + KB pins
+          // return, the caller (chat-interface) restores the typed draft.
+          if (unmarkJobsSent && snapshotJobIds.length > 0) {
+            unmarkJobsSent(snapshotJobIds);
+          }
+          rollbackKbMentions();
+          toast({ title: t('toast.sendFailed'), variant: 'destructive' });
+          sendingRef.current = false;
+          throw err instanceof Error ? err : new Error(String(err));
+        }
+        sendingRef.current = false;
+        return;
       }
 
       // Show optimistic message AFTER precheck so it reflects any mask

--- a/services/platform/app/features/workflows/components/workflow-assistant.tsx
+++ b/services/platform/app/features/workflows/components/workflow-assistant.tsx
@@ -132,6 +132,10 @@ function WorkflowAssistantContent({
         indexingStatuses={indexingStatuses}
         isTranscribing={isTranscribing}
         transcriptionStatuses={transcriptionStatuses}
+        // The assistant's send path (useAssistantChat) has no waiting_media
+        // route yet — keep the pre-deferral blocking UX so an allowed click
+        // is never a silent no-op.
+        mediaDeferDisabled
       />
     </Stack>
   );

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1405,6 +1405,7 @@ import type * as threads_internal_mutations from "../threads/internal_mutations.
 import type * as threads_internal_queries from "../threads/internal_queries.js";
 import type * as threads_list_archived_threads from "../threads/list_archived_threads.js";
 import type * as threads_list_threads from "../threads/list_threads.js";
+import type * as threads_media_send from "../threads/media_send.js";
 import type * as threads_message_queue from "../threads/message_queue.js";
 import type * as threads_mutations from "../threads/mutations.js";
 import type * as threads_queries from "../threads/queries.js";
@@ -1463,6 +1464,7 @@ import type * as users_types from "../users/types.js";
 import type * as users_update_user_name from "../users/update_user_name.js";
 import type * as users_update_user_password from "../users/update_user_password.js";
 import type * as users_validators from "../users/validators.js";
+import type * as video_links_bind_for_send from "../video_links/bind_for_send.js";
 import type * as video_links_captions_parser from "../video_links/captions_parser.js";
 import type * as video_links_clone_transcript from "../video_links/clone_transcript.js";
 import type * as video_links_donor from "../video_links/donor.js";
@@ -3193,6 +3195,7 @@ declare const fullApi: ApiFromModules<{
   "threads/internal_queries": typeof threads_internal_queries;
   "threads/list_archived_threads": typeof threads_list_archived_threads;
   "threads/list_threads": typeof threads_list_threads;
+  "threads/media_send": typeof threads_media_send;
   "threads/message_queue": typeof threads_message_queue;
   "threads/mutations": typeof threads_mutations;
   "threads/queries": typeof threads_queries;
@@ -3251,6 +3254,7 @@ declare const fullApi: ApiFromModules<{
   "users/update_user_name": typeof users_update_user_name;
   "users/update_user_password": typeof users_update_user_password;
   "users/validators": typeof users_validators;
+  "video_links/bind_for_send": typeof video_links_bind_for_send;
   "video_links/captions_parser": typeof video_links_captions_parser;
   "video_links/clone_transcript": typeof video_links_clone_transcript;
   "video_links/donor": typeof video_links_donor;

--- a/services/platform/convex/migrations/config.snapshot.json
+++ b/services/platform/convex/migrations/config.snapshot.json
@@ -100388,6 +100388,44 @@
       ],
       "type": "object"
     },
+    "governance.conversationAccessConfigSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "restrictAssigned": {
+          "type": "boolean"
+        }
+      },
+      "required": ["restrictAssigned"],
+      "type": "object"
+    },
+    "governance.conversationRoutingConfigSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "format": "email",
+                "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                "type": "string"
+              },
+              "teamId": {
+                "type": "string"
+              },
+              "userId": {
+                "type": "string"
+              }
+            },
+            "required": ["address"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["rules"],
+      "type": "object"
+    },
     "governance.dataNoticeConfigSchema": {
       "additionalProperties": false,
       "properties": {
@@ -101711,6 +101749,46 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "object_storage.objectStorageConnectionFileSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "bucket": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "endpoint": {
+          "format": "uri",
+          "type": "string"
+        },
+        "forcePathStyle": {
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "region": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": ["region", "forcePathStyle", "bucket"],
+      "type": "object"
+    },
+    "object_storage.objectStorageConnectionSecretsSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "accessKeyId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "secretAccessKey": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": ["accessKeyId", "secretAccessKey"],
       "type": "object"
     },
     "organizations.memberRoleSchema": {

--- a/services/platform/convex/migrations/schema.snapshot.json
+++ b/services/platform/convex/migrations/schema.snapshot.json
@@ -2736,6 +2736,50 @@
         },
         "optional": false
       },
+      "attachments": {
+        "ft": {
+          "type": "array",
+          "value": {
+            "type": "object",
+            "value": {
+              "fileId": {
+                "fieldType": {
+                  "type": "union",
+                  "value": [
+                    {
+                      "tableName": "_storage",
+                      "type": "id"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "optional": false
+              },
+              "fileName": {
+                "fieldType": {
+                  "type": "string"
+                },
+                "optional": false
+              },
+              "fileSize": {
+                "fieldType": {
+                  "type": "number"
+                },
+                "optional": false
+              },
+              "fileType": {
+                "fieldType": {
+                  "type": "string"
+                },
+                "optional": false
+              }
+            }
+          }
+        },
+        "optional": true
+      },
       "claimedAt": {
         "ft": {
           "type": "number"
@@ -2818,6 +2862,10 @@
           "value": [
             {
               "type": "literal",
+              "value": "waiting_media"
+            },
+            {
+              "type": "literal",
               "value": "queued"
             },
             {
@@ -2865,6 +2913,22 @@
           "type": "string"
         },
         "optional": false
+      },
+      "videoJobIds": {
+        "ft": {
+          "type": "array",
+          "value": {
+            "tableName": "videoLinkJobs",
+            "type": "id"
+          }
+        },
+        "optional": true
+      },
+      "waitingSince": {
+        "ft": {
+          "type": "number"
+        },
+        "optional": true
       }
     },
     "configCache": {
@@ -6254,6 +6318,12 @@
         },
         "optional": false
       },
+      "organizationId": {
+        "ft": {
+          "type": "string"
+        },
+        "optional": true
+      },
       "outputTokens": {
         "ft": {
           "type": "number"
@@ -7440,6 +7510,14 @@
             {
               "type": "literal",
               "value": "sandbox_quota"
+            },
+            {
+              "type": "literal",
+              "value": "conversation_access"
+            },
+            {
+              "type": "literal",
+              "value": "conversation_routing"
             }
           ]
         },
@@ -12552,6 +12630,15 @@
       "title": {
         "ft": {
           "type": "string"
+        },
+        "optional": true
+      },
+      "unlockedToolGroups": {
+        "ft": {
+          "type": "array",
+          "value": {
+            "type": "string"
+          }
         },
         "optional": true
       },

--- a/services/platform/convex/threads/media_send.test.ts
+++ b/services/platform/convex/threads/media_send.test.ts
@@ -1,0 +1,355 @@
+// Send-then-wait: readiness matrix + watcher lifecycle + deferred-bind
+// helpers. The turn START itself (startMediaTurn) goes through the
+// persistent-streaming component, which convex-test cannot register — that
+// path mirrors startQueuedTurn line-for-line and is covered by typecheck +
+// review (see threads/media_send.ts docblock).
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+import {
+  bindJobsForDeferredSend,
+  buildBoundJobAttachments,
+  unbindDeferredJobs,
+} from '../video_links/bind_for_send';
+import { isMediaSendReady } from './media_send';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'threads';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+type T = TestConvex<typeof schema>;
+
+const ORG = 'org_media_send';
+const THREAD = 'thread_media_1';
+const USER = 'user_sender';
+
+async function seedVideoJob(
+  t: T,
+  overrides: {
+    status?:
+      | 'queued'
+      | 'fetching_captions'
+      | 'transcribing_handoff'
+      | 'completed'
+      | 'failed'
+      | 'skipped';
+    withMeta?: 'completed' | 'running';
+    threadId?: string | undefined;
+    uploadedBy?: string;
+    messageBoundAt?: number;
+  } = {},
+): Promise<Id<'videoLinkJobs'>> {
+  return t.run(async (ctx) => {
+    let fileMetadataId: Id<'fileMetadata'> | undefined;
+    if (overrides.withMeta) {
+      fileMetadataId = await ctx.db.insert('fileMetadata', {
+        organizationId: ORG,
+        storageId: `s3:${ORG}/job-blob-${Math.floor(Math.random() * 1e9)}`,
+        source: 'video_link',
+        fileName: 'Video.txt',
+        contentType: 'text/plain; charset=utf-8',
+        size: 42,
+        transcript: 'Hello transcript.',
+        transcriptionStatus: overrides.withMeta,
+      });
+    }
+    return ctx.db.insert('videoLinkJobs', {
+      organizationId: ORG,
+      ...(overrides.threadId !== undefined && {
+        threadId: overrides.threadId,
+      }),
+      uploadedBy: overrides.uploadedBy ?? USER,
+      sourceUrl: 'https://www.youtube.com/watch?v=abc',
+      sourceUrlHash: 'hash_media_send',
+      sourcePlatform: 'youtube',
+      pastedToken: 'https://www.youtube.com/watch?v=abc',
+      status: overrides.status ?? 'completed',
+      statusChangedAt: Date.now(),
+      lifecycleStatus: 'active',
+      videoTitle: 'Video',
+      ...(overrides.messageBoundAt !== undefined && {
+        messageBoundAt: overrides.messageBoundAt,
+      }),
+      ...(fileMetadataId !== undefined && { fileMetadataId }),
+      ...(fileMetadataId !== undefined && {
+        storageId: `s3:${ORG}/job-storage`,
+      }),
+    });
+  });
+}
+
+async function seedWaitingRow(
+  t: T,
+  fields: {
+    videoJobIds?: Id<'videoLinkJobs'>[];
+    attachments?: Array<{
+      fileId: string;
+      fileName: string;
+      fileType: string;
+      fileSize: number;
+    }>;
+    status?: 'waiting_media' | 'queued';
+  } = {},
+): Promise<Id<'chatMessageQueue'>> {
+  return t.run(async (ctx) =>
+    ctx.db.insert('chatMessageQueue', {
+      organizationId: ORG,
+      threadId: THREAD,
+      userId: USER,
+      userEmail: 'sender@example.com',
+      userName: 'Sender',
+      agentSlug: 'assistant',
+      messageId: 'row-1',
+      deferredPersist: true,
+      text: 'Summarize this video',
+      status: fields.status ?? 'waiting_media',
+      createdAt: Date.now(),
+      waitingSince: Date.now(),
+      ...(fields.videoJobIds !== undefined && {
+        videoJobIds: fields.videoJobIds,
+      }),
+      ...(fields.attachments !== undefined && {
+        attachments: fields.attachments,
+      }),
+    }),
+  );
+}
+
+async function seedDocMeta(
+  t: T,
+  storageId: string,
+  ragStatus: 'queued' | 'running' | 'completed' | 'failed' | undefined,
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('fileMetadata', {
+      organizationId: ORG,
+      storageId,
+      fileName: 'report.pdf',
+      contentType: 'application/pdf',
+      size: 1000,
+      ...(ragStatus !== undefined && { ragStatus }),
+    });
+  });
+}
+
+function readiness(t: T, rowId: Id<'chatMessageQueue'>): Promise<boolean> {
+  return t.run(async (ctx) => {
+    const row = await ctx.db.get(rowId);
+    if (!row) throw new Error('row missing');
+    return isMediaSendReady(ctx, row);
+  });
+}
+
+describe('isMediaSendReady', () => {
+  it('is ready when every video job completed', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedVideoJob(t, { status: 'completed' });
+    const rowId = await seedWaitingRow(t, { videoJobIds: [jobId] });
+    expect(await readiness(t, rowId)).toBe(true);
+  });
+
+  it('waits on an in-flight video job', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedVideoJob(t, { status: 'fetching_captions' });
+    const rowId = await seedWaitingRow(t, { videoJobIds: [jobId] });
+    expect(await readiness(t, rowId)).toBe(false);
+  });
+
+  it('holds on a failed video job (user action required)', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedVideoJob(t, { status: 'failed' });
+    const rowId = await seedWaitingRow(t, { videoJobIds: [jobId] });
+    expect(await readiness(t, rowId)).toBe(false);
+  });
+
+  it('excludes cancelled jobs and erased jobs', async () => {
+    const t = convexTest(schema, modules);
+    const skippedId = await seedVideoJob(t, { status: 'skipped' });
+    const erasedId = await seedVideoJob(t, { status: 'completed' });
+    await t.run(async (ctx) => ctx.db.delete(erasedId));
+    const rowId = await seedWaitingRow(t, {
+      videoJobIds: [skippedId, erasedId],
+    });
+    expect(await readiness(t, rowId)).toBe(true);
+  });
+
+  it('treats Whisper handoff with a completed transcript as ready', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedVideoJob(t, {
+      status: 'transcribing_handoff',
+      withMeta: 'completed',
+    });
+    const rowId = await seedWaitingRow(t, { videoJobIds: [jobId] });
+    expect(await readiness(t, rowId)).toBe(true);
+  });
+
+  it('waits on a doc attachment while RAG indexing is active, proceeds on terminal', async () => {
+    const t = convexTest(schema, modules);
+    const doc = {
+      fileId: `s3:${ORG}/doc-1`,
+      fileName: 'report.pdf',
+      fileType: 'application/pdf',
+      fileSize: 1000,
+    };
+    await seedDocMeta(t, doc.fileId, 'running');
+    const rowId = await seedWaitingRow(t, { attachments: [doc] });
+    expect(await readiness(t, rowId)).toBe(false);
+
+    const t2 = convexTest(schema, modules);
+    await seedDocMeta(t2, doc.fileId, 'failed');
+    const rowId2 = await seedWaitingRow(t2, { attachments: [doc] });
+    expect(await readiness(t2, rowId2)).toBe(true);
+  });
+
+  it('never gates on images or unknown files', async () => {
+    const t = convexTest(schema, modules);
+    const rowId = await seedWaitingRow(t, {
+      attachments: [
+        {
+          fileId: `s3:${ORG}/img-1`,
+          fileName: 'pic.png',
+          fileType: 'image/png',
+          fileSize: 10,
+        },
+        {
+          fileId: `s3:${ORG}/no-meta`,
+          fileName: 'stray.bin',
+          fileType: 'application/octet-stream',
+          fileSize: 10,
+        },
+      ],
+    });
+    expect(await readiness(t, rowId)).toBe(true);
+  });
+});
+
+describe('checkMediaSendReadiness (non-start paths)', () => {
+  it('reschedules (row intact) while media is pending', async () => {
+    const t = convexTest(schema, modules);
+    const jobId = await seedVideoJob(t, { status: 'fetching_captions' });
+    const rowId = await seedWaitingRow(t, { videoJobIds: [jobId] });
+    await t.run(async (ctx) => {
+      await ctx.db.insert('threadMetadata', {
+        threadId: THREAD,
+        userId: USER,
+        chatType: 'general',
+        status: 'active',
+        createdAt: Date.now(),
+        organizationId: ORG,
+      });
+    });
+
+    await t.mutation(internal.threads.media_send.checkMediaSendReadiness, {
+      queueId: rowId,
+    });
+
+    const row = await t.run(async (ctx) => ctx.db.get(rowId));
+    expect(row?.status).toBe('waiting_media');
+  });
+
+  it('drops an orphaned row when the thread is gone', async () => {
+    const t = convexTest(schema, modules);
+    const rowId = await seedWaitingRow(t);
+
+    await t.mutation(internal.threads.media_send.checkMediaSendReadiness, {
+      queueId: rowId,
+    });
+
+    const row = await t.run(async (ctx) => ctx.db.get(rowId));
+    expect(row).toBeNull();
+  });
+
+  it('no-ops on a row that already left waiting_media', async () => {
+    const t = convexTest(schema, modules);
+    const rowId = await seedWaitingRow(t, { status: 'queued' });
+
+    await t.mutation(internal.threads.media_send.checkMediaSendReadiness, {
+      queueId: rowId,
+    });
+
+    const row = await t.run(async (ctx) => ctx.db.get(rowId));
+    expect(row?.status).toBe('queued');
+  });
+});
+
+describe('deferred bind helpers', () => {
+  it('claims unbound own jobs, stamping threadId on welcome-page rows', async () => {
+    const t = convexTest(schema, modules);
+    const preThread = await seedVideoJob(t, {
+      status: 'fetching_captions',
+      threadId: undefined,
+    });
+    const foreign = await seedVideoJob(t, { uploadedBy: 'someone_else' });
+    const alreadyBound = await seedVideoJob(t, { messageBoundAt: 123 });
+
+    const claimed = await t.run(async (ctx) =>
+      bindJobsForDeferredSend(ctx, {
+        jobIds: [preThread, foreign, alreadyBound],
+        userId: USER,
+        threadId: THREAD,
+        organizationId: ORG,
+      }),
+    );
+
+    expect(claimed).toEqual([preThread]);
+    const job = await t.run(async (ctx) => ctx.db.get(preThread));
+    expect(job?.threadId).toBe(THREAD);
+    expect(job?.messageBoundAt).toBeDefined();
+  });
+
+  it('unbind releases only the owner rows', async () => {
+    const t = convexTest(schema, modules);
+    const own = await seedVideoJob(t, { messageBoundAt: 123 });
+    const foreign = await seedVideoJob(t, {
+      uploadedBy: 'someone_else',
+      messageBoundAt: 456,
+    });
+
+    await t.run(async (ctx) => unbindDeferredJobs(ctx, [own, foreign], USER));
+
+    const ownRow = await t.run(async (ctx) => ctx.db.get(own));
+    const foreignRow = await t.run(async (ctx) => ctx.db.get(foreign));
+    expect(ownRow?.messageBoundAt).toBeUndefined();
+    expect(foreignRow?.messageBoundAt).toBe(456);
+  });
+
+  it('builds payloads only for transcript-ready jobs', async () => {
+    const t = convexTest(schema, modules);
+    const ready = await seedVideoJob(t, {
+      status: 'completed',
+      withMeta: 'completed',
+    });
+    const whisperReady = await seedVideoJob(t, {
+      status: 'transcribing_handoff',
+      withMeta: 'completed',
+    });
+    const pending = await seedVideoJob(t, { status: 'fetching_captions' });
+
+    const payloads = await t.run(async (ctx) =>
+      buildBoundJobAttachments(ctx, [ready, whisperReady, pending]),
+    );
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({
+      fileName: 'Video',
+      fileType: 'video/mp4',
+      fileSize: 42,
+    });
+  });
+});

--- a/services/platform/convex/threads/media_send.test.ts
+++ b/services/platform/convex/threads/media_send.test.ts
@@ -13,7 +13,7 @@ import schema from '../schema';
 import {
   bindJobsForDeferredSend,
   buildBoundJobAttachments,
-  unbindDeferredJobs,
+  cancelDeferredJobs,
 } from '../video_links/bind_for_send';
 import { isMediaSendReady } from './media_send';
 
@@ -313,19 +313,24 @@ describe('deferred bind helpers', () => {
     expect(job?.messageBoundAt).toBeDefined();
   });
 
-  it('unbind releases only the owner rows', async () => {
+  it('row deletion cancels only the owner jobs (skipped + unbound)', async () => {
     const t = convexTest(schema, modules);
-    const own = await seedVideoJob(t, { messageBoundAt: 123 });
+    const own = await seedVideoJob(t, {
+      status: 'fetching_captions',
+      messageBoundAt: 123,
+    });
     const foreign = await seedVideoJob(t, {
       uploadedBy: 'someone_else',
       messageBoundAt: 456,
     });
 
-    await t.run(async (ctx) => unbindDeferredJobs(ctx, [own, foreign], USER));
+    await t.run(async (ctx) => cancelDeferredJobs(ctx, [own, foreign], USER));
 
     const ownRow = await t.run(async (ctx) => ctx.db.get(own));
     const foreignRow = await t.run(async (ctx) => ctx.db.get(foreign));
+    expect(ownRow?.status).toBe('skipped');
     expect(ownRow?.messageBoundAt).toBeUndefined();
+    expect(foreignRow?.status).toBe('completed');
     expect(foreignRow?.messageBoundAt).toBe(456);
   });
 

--- a/services/platform/convex/threads/media_send.ts
+++ b/services/platform/convex/threads/media_send.ts
@@ -1,0 +1,320 @@
+import { ConvexError, v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import type { Doc } from '../_generated/dataModel';
+import {
+  internalMutation,
+  mutation,
+  type MutationCtx,
+} from '../_generated/server';
+import { validateChatAttachmentCaps } from '../agents/chat_turn';
+import { isDrainingNow } from '../control/drain';
+import { canAccessThread } from '../lib/rls/auth/can_access_thread';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { blobRefValidator } from '../lib/storage/blob_ref';
+import { persistentStreaming } from '../streaming/helpers';
+import {
+  bindJobsForDeferredSend,
+  buildBoundJobAttachments,
+} from '../video_links/bind_for_send';
+import { MAX_QUEUED_PER_THREAD } from './message_queue';
+
+/**
+ * Send-then-wait for media ("thread-first"): Send is allowed while video
+ * ingest / transcription / RAG indexing still runs. The send parks as a
+ * `chatMessageQueue` row with `status='waiting_media'`; the readiness
+ * watcher below starts the agent turn server-side (under the row's stored
+ * identity — same posture as the text queue's `startQueuedTurn`) the moment
+ * every tracked medium is terminal-ready and the thread is idle.
+ *
+ * Waiting rows never enter the text-queue drain paths (those filter exact
+ * statuses); a started row is `claimed` under its turn's streamId, so the
+ * existing `settleQueueOnTurnEnd` retires it at the boundary.
+ *
+ * Readiness matrix (see the plan note; PR #2808 changed it):
+ *  - video job: transcript captured (`completed`, or Whisper-handoff with a
+ *    completed fileMetadata). RAG is NOT awaited — `document_retrieve`
+ *    serves the row transcript while indexing runs.
+ *  - A/V upload: `transcriptionStatus` terminal; `failed`/`skipped` proceed
+ *    degraded (the agent reports it) — only pending/running wait.
+ *  - doc upload: `ragStatus` out of `queued|running` (extraction lives
+ *    inside indexing, so content is unreadable before terminal).
+ *  - image: never gated.
+ *  - video job `failed`: user action required — the row keeps waiting while
+ *    the tray shows the failed chip's retry; deleting the row unbinds the
+ *    chips back into the composer.
+ */
+
+const READY_POLL_MS = 3_000;
+const SLOW_POLL_MS = 15_000;
+/** After two minutes of waiting, back the poll off — long Whisper runs and
+ * failed-chip stalls should not burn a mutation every 3s for hours. */
+const SLOW_AFTER_MS = 2 * 60_000;
+const DRAIN_REQUEUE_DELAY_MS = 5_000;
+
+const attachmentValidator = v.object({
+  fileId: blobRefValidator,
+  fileName: v.string(),
+  fileType: v.string(),
+  fileSize: v.number(),
+});
+
+export const enqueueMediaSend = mutation({
+  args: {
+    threadId: v.string(),
+    organizationId: v.string(),
+    /** Typed text, already stripped of video pastedTokens client-side. May
+     * be empty for attachment-only sends. */
+    message: v.string(),
+    agentSlug: v.string(),
+    modelId: v.optional(v.string()),
+    /** Committed uploads (bytes in storage — composer still gates on
+     * isUploading). */
+    attachments: v.optional(v.array(attachmentValidator)),
+    /** Unbound video-link jobs in any state. */
+    videoJobIds: v.optional(v.array(v.id('videoLinkJobs'))),
+  },
+  returns: v.object({ queueId: v.id('chatMessageQueue') }),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) {
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
+    }
+    const meta = await canAccessThread(
+      ctx,
+      args.threadId,
+      authUser,
+      args.organizationId,
+    );
+    if (!meta || meta.userId !== authUser.userId) {
+      throw new ConvexError({
+        code: 'THREAD_NOT_FOUND',
+        message: 'Thread not found',
+      });
+    }
+
+    const trimmed = args.message.trim();
+    const mediaCount =
+      (args.attachments?.length ?? 0) + (args.videoJobIds?.length ?? 0);
+    if (!trimmed && mediaCount === 0) {
+      throw new ConvexError({ code: 'EMPTY_MESSAGE' });
+    }
+    validateChatAttachmentCaps(args.attachments);
+
+    // Shared per-thread cap with the text queue: waiting + queued rows
+    // together stay bounded.
+    let pendingCount = 0;
+    for (const status of ['waiting_media', 'queued'] as const) {
+      const rows = await ctx.db
+        .query('chatMessageQueue')
+        .withIndex('by_threadId_status', (q) =>
+          q.eq('threadId', args.threadId).eq('status', status),
+        )
+        .collect();
+      pendingCount += rows.length;
+    }
+    if (pendingCount >= MAX_QUEUED_PER_THREAD) {
+      throw new ConvexError({ code: 'QUEUE_FULL' });
+    }
+
+    const claimed = await bindJobsForDeferredSend(ctx, {
+      jobIds: args.videoJobIds ?? [],
+      userId: authUser.userId,
+      threadId: args.threadId,
+      organizationId: args.organizationId,
+    });
+
+    const now = Date.now();
+    const rowId = await ctx.db.insert('chatMessageQueue', {
+      organizationId: args.organizationId,
+      threadId: args.threadId,
+      userId: authUser.userId,
+      userEmail: authUser.email ?? '',
+      userName: authUser.name ?? '',
+      agentSlug: args.agentSlug,
+      ...(args.modelId !== undefined && { modelId: args.modelId }),
+      messageId: '',
+      deferredPersist: true,
+      text: trimmed,
+      status: 'waiting_media' as const,
+      createdAt: now,
+      waitingSince: now,
+      ...(args.attachments !== undefined &&
+        args.attachments.length > 0 && { attachments: args.attachments }),
+      ...(claimed.length > 0 && { videoJobIds: claimed }),
+    });
+    await ctx.db.patch(rowId, { messageId: String(rowId) });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.threads.media_send.checkMediaSendReadiness,
+      { queueId: rowId },
+    );
+
+    return { queueId: rowId };
+  },
+});
+
+/** Readiness per the matrix in the module doc. Exported for tests. */
+export async function isMediaSendReady(
+  ctx: MutationCtx,
+  row: Doc<'chatMessageQueue'>,
+): Promise<boolean> {
+  for (const jobId of row.videoJobIds ?? []) {
+    const job = await ctx.db.get(jobId);
+    if (!job) continue; // erased — proceed without it
+    if (job.status === 'completed') continue;
+    if (job.status === 'skipped') continue; // cancelled — excluded at start
+    if (job.status === 'failed') return false; // user action (retry/delete)
+    if (job.status === 'transcribing_handoff' && job.fileMetadataId) {
+      const meta = await ctx.db.get(job.fileMetadataId);
+      if (meta?.transcriptionStatus === 'completed') continue;
+      if (
+        meta?.transcriptionStatus === 'failed' ||
+        meta?.transcriptionStatus === 'skipped'
+      ) {
+        return false; // Whisper failed — same user-action posture as 'failed'
+      }
+    }
+    return false; // any other non-terminal phase
+  }
+
+  for (const attachment of row.attachments ?? []) {
+    if (attachment.fileType.startsWith('image/')) continue;
+    const meta = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', attachment.fileId))
+      .first();
+    if (!meta) continue; // no pipeline record — nothing to wait on
+    const isAv =
+      attachment.fileType.startsWith('audio/') ||
+      attachment.fileType.startsWith('video/');
+    if (isAv || meta.transcriptionStatus !== undefined) {
+      // Terminal transcription is enough — document_retrieve serves the row
+      // transcript while RAG indexing runs (PR #2808). failed/skipped
+      // proceed degraded; only an active pipeline waits.
+      if (
+        meta.transcriptionStatus === 'queued' ||
+        meta.transcriptionStatus === 'running'
+      ) {
+        return false;
+      }
+      continue;
+    }
+    // Document: content is only readable once indexing leaves the active
+    // states (extraction happens inside the RAG pipeline).
+    if (meta.ragStatus === 'queued' || meta.ragStatus === 'running') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export const checkMediaSendReadiness = internalMutation({
+  args: { queueId: v.id('chatMessageQueue') },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const row = await ctx.db.get(args.queueId);
+    // Deleted (user abandoned) or already started — the watcher chain ends.
+    if (!row || row.status !== 'waiting_media') return null;
+
+    const meta = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', row.threadId))
+      .first();
+    if (!meta) {
+      // Thread erased while waiting — the row is an orphan. Jobs follow
+      // their own erasure cascade; just drop the row.
+      await ctx.db.delete(row._id);
+      return null;
+    }
+
+    const reschedule = async (delayMs: number) => {
+      await ctx.scheduler.runAfter(
+        delayMs,
+        internal.threads.media_send.checkMediaSendReadiness,
+        { queueId: args.queueId },
+      );
+    };
+
+    const ready = await isMediaSendReady(ctx, row);
+    if (!ready) {
+      const age = Date.now() - (row.waitingSince ?? row.createdAt);
+      await reschedule(age > SLOW_AFTER_MS ? SLOW_POLL_MS : READY_POLL_MS);
+      return null;
+    }
+    if (await isDrainingNow(ctx)) {
+      await reschedule(DRAIN_REQUEUE_DELAY_MS);
+      return null;
+    }
+    if (meta.generationStatus === 'generating') {
+      // A turn is running — the media send starts at its own readiness, not
+      // the text-queue boundary, so just try again shortly.
+      await reschedule(READY_POLL_MS);
+      return null;
+    }
+
+    await startMediaTurn(ctx, meta, row);
+    return null;
+  },
+});
+
+/**
+ * Mirror of `startQueuedTurn` for ONE waiting row, with two deliberate
+ * differences: attachments are forwarded (row snapshot + payloads of the
+ * bound video jobs), and there is NO `queuedPromptMessageId` — the
+ * generation pipeline saves the user message itself, so the bubble carries
+ * the attachment cards exactly like a direct send.
+ */
+async function startMediaTurn(
+  ctx: MutationCtx,
+  meta: Doc<'threadMetadata'>,
+  row: Doc<'chatMessageQueue'>,
+): Promise<void> {
+  const videoPayloads = await buildBoundJobAttachments(
+    ctx,
+    row.videoJobIds ?? [],
+  );
+  const attachments = [...(row.attachments ?? []), ...videoPayloads];
+
+  const streamId = await persistentStreaming.createStream(ctx);
+  const now = Date.now();
+  await ctx.db.patch(row._id, {
+    status: 'claimed' as const,
+    claimedByStreamId: streamId,
+    claimedAt: now,
+  });
+  await ctx.db.patch(meta._id, {
+    generationStatus: 'generating' as const,
+    streamId,
+    generationStartTime: now,
+    generationHeartbeatAt: undefined,
+    updatedAt: now,
+    lastReplyAt: now,
+    liveRoute: undefined,
+    cancelledAt: undefined,
+    cancelledMessageId: undefined,
+  });
+
+  await ctx.scheduler.runAfter(
+    0,
+    internal.agents.chat_turn_generate.runChatTurnGeneration,
+    {
+      agentSlug: row.agentSlug,
+      organizationId: row.organizationId,
+      message: row.text,
+      threadId: meta.threadId,
+      streamId,
+      userId: row.userId,
+      userEmail: row.userEmail,
+      userName: row.userName,
+      requestStartMs: now,
+      ...(row.modelId !== undefined && { modelId: row.modelId }),
+      ...(attachments.length > 0 && { attachments }),
+      // External-thread agent lock parity with startQueuedTurn: the thread's
+      // stored agent wins over stale per-user picker state.
+      ...(meta.agentSlug !== undefined && { priorAgentSlug: meta.agentSlug }),
+    },
+  );
+}

--- a/services/platform/convex/threads/media_send.ts
+++ b/services/platform/convex/threads/media_send.ts
@@ -41,8 +41,8 @@ import { MAX_QUEUED_PER_THREAD } from './message_queue';
  *    inside indexing, so content is unreadable before terminal).
  *  - image: never gated.
  *  - video job `failed`: user action required — the row keeps waiting while
- *    the tray shows the failed chip's retry; deleting the row unbinds the
- *    chips back into the composer.
+ *    the tray shows the failed chip's retry; deleting the row cancels the
+ *    jobs outright (skipped + cleanup — no composer residue).
  */
 
 const READY_POLL_MS = 3_000;

--- a/services/platform/convex/threads/message_queue.ts
+++ b/services/platform/convex/threads/message_queue.ts
@@ -14,7 +14,7 @@ import { isDrainingNow } from '../control/drain';
 import { canAccessThread } from '../lib/rls/auth/can_access_thread';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { persistentStreaming } from '../streaming/helpers';
-import { unbindDeferredJobs } from '../video_links/bind_for_send';
+import { cancelDeferredJobs } from '../video_links/bind_for_send';
 
 /**
  * While a deploy drain is active, queued messages must NOT start a new
@@ -616,11 +616,12 @@ export const deleteQueuedMessage = mutation({
     if (row.status !== 'queued' && row.status !== 'waiting_media') {
       return { deleted: false };
     }
-    // Abandoning a media-wait releases its bound video jobs: the unbound
-    // chips reappear in the composer (retry/remove flows take over) and the
-    // readiness watcher's next tick sees the row gone and stops.
+    // Abandoning a media-wait cancels its media too — the user dismissed
+    // the whole message, so its videos stop processing (skipped + cleanup)
+    // instead of reappearing in the composer as residue. The readiness
+    // watcher's next tick sees the row gone and stops.
     if (row.status === 'waiting_media' && row.videoJobIds !== undefined) {
-      await unbindDeferredJobs(ctx, row.videoJobIds, row.userId);
+      await cancelDeferredJobs(ctx, row.videoJobIds, row.userId);
     }
     // Persist-at-pick rows have no transcript copy while queued — only legacy
     // rows (saved at enqueue, in flight across the deploy) carry one.

--- a/services/platform/convex/threads/message_queue.ts
+++ b/services/platform/convex/threads/message_queue.ts
@@ -687,16 +687,31 @@ export const listQueuedMessages = query({
     // Send order: the strip renders these in the order the user typed them.
     // The index is keyed on (threadId, status), so the collect is unordered.
     rows.sort((a, b) => a.createdAt - b.createdAt);
-    return rows.map((r) => ({
-      queueId: r._id,
-      messageId: r.messageId,
-      savedMessageId: r.deferredPersist ? r.savedMessageId : r.messageId,
-      text: r.text,
-      status: r.status,
-      createdAt: r.createdAt,
-      ...(r.attachments !== undefined && { attachments: r.attachments }),
-      ...(r.videoJobIds !== undefined && { videoJobIds: r.videoJobIds }),
-      ...(r.waitingSince !== undefined && { waitingSince: r.waitingSince }),
-    }));
+    // Optional media-wait fields assigned after the base object — a
+    // conditional spread inside `.map` trips `oxc/no-map-spread`.
+    return rows.map((r) => {
+      const entry: {
+        queueId: typeof r._id;
+        messageId: string;
+        savedMessageId: string | undefined;
+        text: string;
+        status: typeof r.status;
+        createdAt: number;
+        attachments?: typeof r.attachments;
+        videoJobIds?: typeof r.videoJobIds;
+        waitingSince?: number;
+      } = {
+        queueId: r._id,
+        messageId: r.messageId,
+        savedMessageId: r.deferredPersist ? r.savedMessageId : r.messageId,
+        text: r.text,
+        status: r.status,
+        createdAt: r.createdAt,
+      };
+      if (r.attachments !== undefined) entry.attachments = r.attachments;
+      if (r.videoJobIds !== undefined) entry.videoJobIds = r.videoJobIds;
+      if (r.waitingSince !== undefined) entry.waitingSince = r.waitingSince;
+      return entry;
+    });
   },
 });

--- a/services/platform/convex/threads/message_queue.ts
+++ b/services/platform/convex/threads/message_queue.ts
@@ -14,6 +14,7 @@ import { isDrainingNow } from '../control/drain';
 import { canAccessThread } from '../lib/rls/auth/can_access_thread';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { persistentStreaming } from '../streaming/helpers';
+import { unbindDeferredJobs } from '../video_links/bind_for_send';
 
 /**
  * While a deploy drain is active, queued messages must NOT start a new
@@ -612,8 +613,14 @@ export const deleteQueuedMessage = mutation({
       return { deleted: false };
     }
     // claimed/delivered/consumed are already (being) handed to the agent.
-    if (row.status !== 'queued') {
+    if (row.status !== 'queued' && row.status !== 'waiting_media') {
       return { deleted: false };
+    }
+    // Abandoning a media-wait releases its bound video jobs: the unbound
+    // chips reappear in the composer (retry/remove flows take over) and the
+    // readiness watcher's next tick sees the row gone and stops.
+    if (row.status === 'waiting_media' && row.videoJobIds !== undefined) {
+      await unbindDeferredJobs(ctx, row.videoJobIds, row.userId);
     }
     // Persist-at-pick rows have no transcript copy while queued — only legacy
     // rows (saved at enqueue, in flight across the deploy) carry one.
@@ -639,12 +646,27 @@ export const listQueuedMessages = query({
       savedMessageId: v.optional(v.string()),
       text: v.string(),
       status: v.union(
+        v.literal('waiting_media'),
         v.literal('queued'),
         v.literal('claimed'),
         v.literal('delivered'),
         v.literal('consumed'),
       ),
       createdAt: v.number(),
+      /** Media-wait rows only: what the send is waiting on, so the tray can
+       * render the live chip/file status alongside the parked text. */
+      attachments: v.optional(
+        v.array(
+          v.object({
+            fileId: v.string(),
+            fileName: v.string(),
+            fileType: v.string(),
+            fileSize: v.number(),
+          }),
+        ),
+      ),
+      videoJobIds: v.optional(v.array(v.id('videoLinkJobs'))),
+      waitingSince: v.optional(v.number()),
     }),
   ),
   handler: async (ctx, args) => {
@@ -672,6 +694,9 @@ export const listQueuedMessages = query({
       text: r.text,
       status: r.status,
       createdAt: r.createdAt,
+      ...(r.attachments !== undefined && { attachments: r.attachments }),
+      ...(r.videoJobIds !== undefined && { videoJobIds: r.videoJobIds }),
+      ...(r.waitingSince !== undefined && { waitingSince: r.waitingSince }),
     }));
   },
 });

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -471,7 +471,8 @@ export const chatMessageQueueTable = defineTable({
   /** Video-link jobs bound to this waiting send at enqueue (messageBoundAt
    * stamped so the composer releases the chips and no other send can bind
    * them). Their attachment payloads are built at start, when the jobs are
-   * terminal. Deleting the row unbinds them back into the composer. */
+   * terminal. Deleting the row CANCELS them (skipped + cleanup) — the user
+   * dismissed the whole message, so its media stops processing too. */
   videoJobIds: v.optional(v.array(v.id('videoLinkJobs'))),
   /** When the row entered waiting_media — watcher observability. */
   waitingSince: v.optional(v.number()),

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -1,6 +1,7 @@
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+import { blobRefValidator } from '../lib/storage/blob_ref';
 import { autoRouteReasonValidator } from '../streaming/validators';
 import { chatTypeValidator, threadStatusValidator } from './validators';
 
@@ -430,6 +431,11 @@ export const chatMessageQueueTable = defineTable({
   /** Exact content; drain prompt + steer payload source. */
   text: v.string(),
   status: v.union(
+    // Send-then-wait: parked until every tracked medium below is
+    // terminal-ready, then started as its OWN turn by the readiness
+    // watcher (threads/media_send.ts) — never enters the text drain
+    // paths (they filter exact statuses and never see this literal).
+    v.literal('waiting_media'),
     v.literal('queued'),
     v.literal('claimed'),
     v.literal('delivered'),
@@ -447,6 +453,28 @@ export const chatMessageQueueTable = defineTable({
   createdAt: v.number(),
   claimedAt: v.optional(v.number()),
   deliveredAt: v.optional(v.number()),
+
+  // --- media-wait facet (status='waiting_media' rows only) ---------------
+  /** Committed upload attachments snapshot (bytes already in storage — the
+   * composer still gates on isUploading). Forwarded verbatim to
+   * runChatTurnGeneration at start. */
+  attachments: v.optional(
+    v.array(
+      v.object({
+        fileId: blobRefValidator,
+        fileName: v.string(),
+        fileType: v.string(),
+        fileSize: v.number(),
+      }),
+    ),
+  ),
+  /** Video-link jobs bound to this waiting send at enqueue (messageBoundAt
+   * stamped so the composer releases the chips and no other send can bind
+   * them). Their attachment payloads are built at start, when the jobs are
+   * terminal. Deleting the row unbinds them back into the composer. */
+  videoJobIds: v.optional(v.array(v.id('videoLinkJobs'))),
+  /** When the row entered waiting_media — watcher observability. */
+  waitingSince: v.optional(v.number()),
 })
   .index('by_threadId_status', ['threadId', 'status'])
   .index('by_organizationId', ['organizationId']);

--- a/services/platform/convex/video_links/bind_for_send.ts
+++ b/services/platform/convex/video_links/bind_for_send.ts
@@ -1,0 +1,106 @@
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+
+/**
+ * Video-job binding for the send-then-wait path (threads/media_send.ts).
+ *
+ * A deferred media send claims its video jobs at ENQUEUE — non-terminal jobs
+ * included, that is the point — by stamping `messageBoundAt` (+ `threadId`
+ * for welcome-page rows). The stamp is what releases the chips from the
+ * composer (`useChatVideoLinks` filters bound rows) and keeps
+ * `bindCompletedJobsToMessage` from double-binding them into another send.
+ * The attachment payloads are built later, at turn START, when the jobs are
+ * terminal; deleting the waiting row unbinds so the chips reappear in the
+ * composer and the existing retry/remove flows take over.
+ *
+ * Sibling of `bindCompletedJobsToMessage` (mutations.ts) — that one scans a
+ * thread for completed-only jobs at direct-send time; these helpers work an
+ * explicit id list for a stored user with no auth context.
+ */
+
+export interface BoundJobAttachment {
+  fileId: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+}
+
+/** Enqueue-time claim. Skips anything not claimable (foreign, bound,
+ * cancelled, trashed); returns the ids actually claimed. */
+export async function bindJobsForDeferredSend(
+  ctx: MutationCtx,
+  args: {
+    jobIds: readonly Id<'videoLinkJobs'>[];
+    userId: string;
+    threadId: string;
+    organizationId: string;
+  },
+): Promise<Id<'videoLinkJobs'>[]> {
+  const now = Date.now();
+  const claimed: Id<'videoLinkJobs'>[] = [];
+  for (const jobId of args.jobIds) {
+    const job = await ctx.db.get(jobId);
+    if (!job) continue;
+    if (job.organizationId !== args.organizationId) continue;
+    if (job.uploadedBy !== args.userId) continue;
+    if (job.messageBoundAt !== undefined) continue;
+    if (job.status === 'skipped') continue;
+    if (job.lifecycleStatus === 'trashed') continue;
+    await ctx.db.patch(jobId, {
+      ...(job.threadId === undefined && { threadId: args.threadId }),
+      messageBoundAt: now,
+    });
+    claimed.push(jobId);
+  }
+  return claimed;
+}
+
+/**
+ * Start-time payloads — the same shape `bindCompletedJobsToMessage` puts on
+ * a direct send's attachments (fileType keeps the 'video/mp4' routing
+ * sentinel; see that mutation). Jobs without a completed transcript by now
+ * (failed, cancelled, erased) are excluded — the turn proceeds without them.
+ */
+export async function buildBoundJobAttachments(
+  ctx: MutationCtx,
+  jobIds: readonly Id<'videoLinkJobs'>[],
+): Promise<BoundJobAttachment[]> {
+  const out: BoundJobAttachment[] = [];
+  for (const jobId of jobIds) {
+    const job = await ctx.db.get(jobId);
+    if (!job || !job.storageId || !job.fileMetadataId) continue;
+    const meta = await ctx.db.get(job.fileMetadataId);
+    if (!meta) continue;
+    // Captions/clone branch ends 'completed'; the Whisper branch stays
+    // 'transcribing_handoff' with completion recorded on the fileMetadata
+    // row — mirror bindCompletedJobsToMessage's projection.
+    const transcriptReady =
+      job.status === 'completed' ||
+      (job.status === 'transcribing_handoff' &&
+        meta.transcriptionStatus === 'completed');
+    if (!transcriptReady) continue;
+    out.push({
+      fileId: job.storageId,
+      fileName: job.videoTitle ?? 'Video link',
+      fileType: 'video/mp4',
+      fileSize: meta.size,
+    });
+  }
+  return out;
+}
+
+/** Delete-time release: clear `messageBoundAt` on the row owner's jobs so
+ * the unbound chips reappear in the composer. */
+export async function unbindDeferredJobs(
+  ctx: MutationCtx,
+  jobIds: readonly Id<'videoLinkJobs'>[],
+  userId: string,
+): Promise<void> {
+  for (const jobId of jobIds) {
+    const job = await ctx.db.get(jobId);
+    if (!job) continue;
+    if (job.uploadedBy !== userId) continue;
+    if (job.messageBoundAt === undefined) continue;
+    await ctx.db.patch(jobId, { messageBoundAt: undefined });
+  }
+}

--- a/services/platform/convex/video_links/bind_for_send.ts
+++ b/services/platform/convex/video_links/bind_for_send.ts
@@ -1,3 +1,4 @@
+import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 
@@ -89,18 +90,56 @@ export async function buildBoundJobAttachments(
   return out;
 }
 
-/** Delete-time release: clear `messageBoundAt` on the row owner's jobs so
- * the unbound chips reappear in the composer. */
-export async function unbindDeferredJobs(
+/**
+ * Delete-time cascade: cancelling a waiting send cancels its media too —
+ * the user dismissed the whole message, so the videos must not keep
+ * processing (nor reappear in the composer as residue). Mirrors
+ * `cancelVideoLink`'s semantics for an explicit id list: flip to
+ * 'skipped', propagate the Whisper early-exit, schedule the cleanup
+ * action. The unbind (`messageBoundAt: undefined`) happens in the same
+ * patch — `cleanupCancelledVideoLink` refuses message-bound rows, and
+ * these are only bound to a row that no longer exists.
+ */
+export async function cancelDeferredJobs(
   ctx: MutationCtx,
   jobIds: readonly Id<'videoLinkJobs'>[],
   userId: string,
 ): Promise<void> {
+  const now = Date.now();
   for (const jobId of jobIds) {
     const job = await ctx.db.get(jobId);
     if (!job) continue;
     if (job.uploadedBy !== userId) continue;
-    if (job.messageBoundAt === undefined) continue;
-    await ctx.db.patch(jobId, { messageBoundAt: undefined });
+    if (job.status === 'skipped') {
+      if (job.messageBoundAt !== undefined) {
+        await ctx.db.patch(jobId, { messageBoundAt: undefined });
+      }
+      continue;
+    }
+    await ctx.db.patch(jobId, {
+      messageBoundAt: undefined,
+      status: 'skipped',
+      statusChangedAt: now,
+    });
+    // Whisper-handoff in flight: also skip the fileMetadata transcription
+    // so transcribe_audio's early-exit fires (mirror cancelVideoLink).
+    if (
+      job.fileMetadataId &&
+      job.storageId &&
+      job.status === 'transcribing_handoff'
+    ) {
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileTranscription,
+        {
+          storageId: job.storageId,
+          transcriptionStatus: 'skipped',
+        },
+      );
+    }
+    await ctx.scheduler.runAfter(
+      0,
+      internal.video_links.internal_mutations.cleanupCancelledVideoLink,
+      { jobId },
+    );
   }
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1234,6 +1234,7 @@
       "full": "Die Nachrichten-Warteschlange ist voll",
       "status": {
         "queued": "Eingereiht — wird nach dem aktuellen Schritt übernommen",
+        "waitingMedia": "Wartet auf die Anhänge — wird automatisch gesendet, sobald alles bereit ist",
         "delivered": "Übermittelt — warte auf die Antwort des Agenten",
         "deliversNow": "Wird gerade zugestellt",
         "consumed": "Übernommen"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1234,6 +1234,7 @@
       "full": "Message queue is full",
       "status": {
         "queued": "Queued — will be picked up after the current step",
+        "waitingMedia": "Waiting for attachments to finish processing — sends automatically",
         "delivered": "Delivered — waiting for the agent to respond",
         "deliversNow": "Delivering now",
         "consumed": "Picked up"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1234,6 +1234,7 @@
       "full": "La file d'attente des messages est pleine",
       "status": {
         "queued": "En file d'attente — sera pris en compte après l'étape en cours",
+        "waitingMedia": "En attente des pièces jointes — envoi automatique dès que tout est prêt",
         "delivered": "Transmis — en attente de la réponse de l'agent",
         "deliversNow": "Transmission en cours",
         "consumed": "Pris en compte"


### PR DESCRIPTION
## Problem

The composer blocked Send until video ingest / transcription / RAG indexing finished. On a new chat that also delayed thread creation, pinning the user to the welcome page — the exact complaint behind the send-block reports: you can't hand the task off and go do something else.

## Change (reviewed plan: `send_then_wait_media` — revised to extend `chatMessageQueue` instead of adding a `deferredMediaSends` table)

**Backend**
- `chatMessageQueue` grows a `waiting_media` status + optional `attachments` / `videoJobIds` / `waitingSince` (data-safe growth: snapshots refreshed, no migration; invisible to every text-drain path, which filter exact statuses).
- New `threads/media_send.ts`: `enqueueMediaSend` (parks the send; claims video jobs at enqueue via `video_links/bind_for_send.ts` so chips leave the composer and can't double-bind) + `checkMediaSendReadiness`, a self-rescheduling watcher (3s → 15s backoff) that starts the turn server-side under the row's stored identity — the exact `startQueuedTurn` posture — once media is terminal-ready and the thread idle. The media turn starts alone with NO `queuedPromptMessageId`, so the pipeline saves the user bubble with its attachment cards exactly like a direct send; `settleQueueOnTurnEnd` retires the claimed row.
- Readiness leans on #2808: video/audio wait for the transcript only (RAG not awaited — `document_retrieve` serves the row transcript); docs wait for `ragStatus` to leave `queued|running`; images never gate; a failed video job holds the row.
- `deleteQueuedMessage` accepts `waiting_media` and unbinds the jobs — the chips reappear in the composer for the existing retry/remove flows.

**Client**
- `chat-input`: processing media no longer blocks Send; the click routes with `{deferForMedia}`. Failed media still blocks; `isUploading` + `pasteIngestPending` still gate (send-during-byte-upload is out of scope); arena, embedded chat, and the workflow assistant pass `mediaDeferDisabled` (their send paths have no waiting route — an allowed click must never be a silent no-op).
- `use-send-message`: deferred sends create the thread first (welcome path navigates), strip ALL pasted video tokens, then `enqueueMediaSend` — no optimistic bubble; the queue tray is the visible representation.
- Queue tray renders `waiting_media` rows ("Waiting for attachments to finish processing — sends automatically", en/de/fr) with remove; tray now mounts for all threads.

## Verification

- **Live browser E2E on the dev stack (twice)**: typed a message, uploaded a fixture (288 KB, then 1.5 MB), clicked Send while the chip showed "Indexing..." (button enabled — previously disabled) → thread created + navigated instantly, composer cleared, tray showed the waiting row with remove; when indexing finished (~6 min for the 1.5 MB run) the turn auto-started server-side with zero interaction, the user bubble carried the attachment card, and the agent's reply quoted the file's actual header line verbatim. Screenshots captured.
- Suites: `media_send` 13 (readiness matrix, watcher non-start paths, bind/unbind helpers), threads 255, chat-input 128, use-send-message, tray, i18n parity 24, migrations chain+versions 357 — all green. `migrations:check`, tsc, oxlint, staged SAST clean.
- Honest gaps: `startMediaTurn` itself isn't convex-testable (persistent-streaming component) — it mirrors `startQueuedTurn` line-for-line and is covered by the live E2E above; `enqueueMediaSend` glue likewise (betterAuth) — covered live.

## Definition of done

- [x] Green gate — tsc, oxlint, targeted vitest suites, migrations:check + chain/versions suites
- [x] Security gate — staged SAST clean; enqueue re-validates thread access + caps server-side; watcher start uses the queue's established stored-identity posture
- [x] Tests — readiness matrix + watcher lifecycle + bind helpers + existing suites
- [x] Migration — N/A: data-safe schema growth (optional fields + widened union), snapshots refreshed
- [x] Locales — new tray string in en/de/fr; parity + voice checks green
- [x] Docs — N/A: no docs page covers composer gating; plan file updated as the design record
- [x] Accessibility — tray reuses the existing labelled list semantics; no new interactive patterns
- [x] Sweep — all five ChatInput consumers audited (embedded + workflow assistant pinned to blocking; discussions/shared-view pass no media props); steer-status map excludes waiting rows
- [x] Observed — live two-run browser E2E incl. the waiting tray and the zero-interaction auto-start
- [x] Commits — single atomic conventional commit, branched off main

## UX iteration (Larry's review): live progress + cancel cascade on waiting rows

- **`WaitingMediaDetails`** strip under each `waiting_media` tray row: the real `VideoLinkChip` per bound job in a new **flat** form (the row is the card — card-in-card read as clutter), live "Fetching captions… / Transcribing…" progress and the retry affordance, plus file attachments with the composer's own indexing/transcription status labels.
- **Single cancel, cascading**: the chip's own ✕ is hidden in the tray (`onCancel` now optional); the row's ✕ is the one cancel and it cancels the media too — `cancelDeferredJobs` flips the jobs to skipped (+ Whisper early-exit + cleanup, mirroring `cancelVideoLink`) instead of unbinding chips back into the composer as residue.
- Verified live with a real Vimeo video: send-while-fetching → parked row with live chip progress → auto-started turn summarizing the actual video content.