### PR TITLE
feat(platform): scope task assignees & mentions to project access

### DIFF
--- a/services/platform/app/features/tasks/components/assignee-picker.test.tsx
+++ b/services/platform/app/features/tasks/components/assignee-picker.test.tsx
@@ -42,10 +42,12 @@ let mockDirectoryAgents: AssignableAgent[] = mockAgents.filter(
 );
 
 vi.mock('../hooks/use-actor-directory', () => ({
-  useActorDirectory: () => ({
-    members: [
+  useAssignableActors: () => ({
+    assignableMembers: [
       { type: 'user', id: 'user-1', name: 'Alex', email: 'alex@example.com' },
     ],
+    assignableAgents: mockDirectoryAgents,
+    // The unfiltered directory list is still returned for current-value display.
     agents: mockDirectoryAgents,
     currentUserId: 'user-1',
     resolveActor: () => ({

--- a/services/platform/app/features/tasks/components/assignee-picker.tsx
+++ b/services/platform/app/features/tasks/components/assignee-picker.tsx
@@ -13,10 +13,11 @@ import {
   type SearchableSelectOption,
 } from '@/app/components/ui/forms/searchable-select';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { looksLikeCodeTask } from '@/lib/shared/agents/display-category';
 
-import { useActorDirectory } from '../hooks/use-actor-directory';
+import { useAssignableActors } from '../hooks/use-actor-directory';
 import type { TaskActorType } from '../lib/display';
 import { AssigneeAvatar } from './assignee-avatar';
 
@@ -45,7 +46,7 @@ export function AssigneePicker({
   afterTrigger,
 }: {
   organizationId: string;
-  projectId?: string;
+  projectId?: Id<'projects'>;
   assigneeType?: TaskActorType;
   assigneeId?: string;
   onAssign: (type: TaskActorType, id: string) => void;
@@ -62,10 +63,13 @@ export function AssigneePicker({
 }) {
   const { t } = useT('tasks');
   const { t: tCommon } = useT('common');
-  const { members, agents, currentUserId, resolveActor } = useActorDirectory(
-    organizationId,
-    projectId,
-  );
+  const {
+    assignableMembers,
+    assignableAgents,
+    agents,
+    currentUserId,
+    resolveActor,
+  } = useAssignableActors(organizationId, projectId);
   const [open, setOpen] = useState(false);
 
   const resolved =
@@ -119,16 +123,16 @@ export function AssigneePicker({
   );
 
   const platformAgents = useMemo(
-    () => agents.filter((a) => a.displayCategory === 'agent'),
-    [agents],
+    () => assignableAgents.filter((a) => a.displayCategory === 'agent'),
+    [assignableAgents],
   );
   const codingAgents = useMemo(
-    () => agents.filter((a) => a.displayCategory === 'coding-agent'),
-    [agents],
+    () => assignableAgents.filter((a) => a.displayCategory === 'coding-agent'),
+    [assignableAgents],
   );
 
   const options = useMemo<SearchableSelectOption[]>(() => {
-    const sortedMembers = [...members].sort((a, b) =>
+    const sortedMembers = [...assignableMembers].sort((a, b) =>
       a.id === currentUserId ? -1 : b.id === currentUserId ? 1 : 0,
     );
     const memberOptions: SearchableSelectOption[] = sortedMembers.map((m) => ({
@@ -174,7 +178,7 @@ export function AssigneePicker({
 
     return [...memberOptions, ...agentSections];
   }, [
-    members,
+    assignableMembers,
     platformAgents,
     codingAgents,
     currentUserId,

--- a/services/platform/app/features/tasks/components/kanban-board.test.tsx
+++ b/services/platform/app/features/tasks/components/kanban-board.test.tsx
@@ -20,6 +20,13 @@ vi.mock('../hooks/use-actor-directory', () => ({
     currentUserId: null,
     resolveActor: () => null,
   }),
+  useAssignableActors: () => ({
+    assignableMembers: [],
+    assignableAgents: [],
+    agents: [],
+    currentUserId: null,
+    resolveActor: () => null,
+  }),
 }));
 
 function makeTask(

--- a/services/platform/app/features/tasks/components/tasks-list.test.tsx
+++ b/services/platform/app/features/tasks/components/tasks-list.test.tsx
@@ -20,6 +20,13 @@ vi.mock('../hooks/use-actor-directory', () => ({
     currentUserId: null,
     resolveActor: () => null,
   }),
+  useAssignableActors: () => ({
+    assignableMembers: [],
+    assignableAgents: [],
+    agents: [],
+    currentUserId: null,
+    resolveActor: () => null,
+  }),
 }));
 
 function makeTask(

--- a/services/platform/app/features/tasks/hooks/use-actor-directory.test.ts
+++ b/services/platform/app/features/tasks/hooks/use-actor-directory.test.ts
@@ -2,6 +2,8 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { Id } from '@/convex/_generated/dataModel';
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ i18n: { language: 'en' } }),
 }));
@@ -10,8 +12,31 @@ vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({ t: (key: string) => key }),
 }));
 
+interface MockMember {
+  userId: string;
+  displayName?: string;
+  email?: string;
+  role: string;
+}
+let mockMembers: MockMember[] = [];
 vi.mock('@/app/features/settings/organization/hooks/queries', () => ({
-  useMembers: () => ({ members: [] }),
+  useMembers: () => ({ members: mockMembers }),
+}));
+
+let mockProject: {
+  agentMode?: string;
+  allowedAgentSlugs?: string[];
+  recommendedAgentSlugs?: string[];
+} | null = null;
+vi.mock('@/app/features/projects/hooks/queries', () => ({
+  useProject: () => ({ project: mockProject }),
+}));
+
+let mockScope: { data: { orgWide: boolean; userIds: string[] } | undefined } = {
+  data: undefined,
+};
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => mockScope,
 }));
 
 vi.mock('@/app/hooks/use-current-member-context', () => ({
@@ -46,7 +71,10 @@ vi.mock('@/app/features/agents/hooks/queries', () => ({
 }));
 
 // Import after mocks are set up (mirrors use-effective-agent.test.ts).
-const { useActorDirectory } = await import('./use-actor-directory');
+const { useActorDirectory, useAssignableActors } =
+  await import('./use-actor-directory');
+
+const PROJECT_ID = 'proj-1' as Id<'projects'>;
 
 describe('useActorDirectory — agent liveness filter (#2603)', () => {
   it('excludes an agent with no install row (never installed) from the assignable list', () => {
@@ -123,5 +151,86 @@ describe('useActorDirectory — resolveActor for a non-live agent (#2609)', () =
       name: 'ghost-agent',
       isAgent: true,
     });
+  });
+});
+
+describe('useAssignableActors — project-scoped candidates', () => {
+  it('drops disabled members even for an org-wide project', () => {
+    mockMembers = [
+      { userId: 'u1', displayName: 'One', role: 'member' },
+      { userId: 'u2', displayName: 'Two', role: 'disabled' },
+    ];
+    mockAgents = [];
+    mockInstalls = { data: [], isLoading: false };
+    mockProject = null;
+    mockScope = { data: { orgWide: true, userIds: [] } };
+
+    const { result } = renderHook(() =>
+      useAssignableActors('org-1', PROJECT_ID),
+    );
+    expect(result.current.assignableMembers.map((m) => m.id)).toEqual(['u1']);
+  });
+
+  it('filters members to the accessible set for a team-scoped project', () => {
+    mockMembers = [
+      { userId: 'u1', displayName: 'One', role: 'member' },
+      { userId: 'u2', displayName: 'Two', role: 'member' },
+      { userId: 'u3', displayName: 'Three', role: 'member' },
+    ];
+    mockAgents = [];
+    mockInstalls = { data: [], isLoading: false };
+    mockProject = null;
+    mockScope = { data: { orgWide: false, userIds: ['u1', 'u3'] } };
+
+    const { result } = renderHook(() =>
+      useAssignableActors('org-1', PROJECT_ID),
+    );
+    expect(result.current.assignableMembers.map((m) => m.id).sort()).toEqual([
+      'u1',
+      'u3',
+    ]);
+  });
+
+  it('falls back to org-wide (minus disabled) while the access query loads', () => {
+    mockMembers = [
+      { userId: 'u1', displayName: 'One', role: 'member' },
+      { userId: 'u2', displayName: 'Two', role: 'disabled' },
+    ];
+    mockAgents = [];
+    mockInstalls = { data: [], isLoading: false };
+    mockProject = null;
+    mockScope = { data: undefined }; // still loading
+
+    const { result } = renderHook(() =>
+      useAssignableActors('org-1', PROJECT_ID),
+    );
+    expect(result.current.assignableMembers.map((m) => m.id)).toEqual(['u1']);
+  });
+
+  it('restricts agents to the project allow-list, leaving the display list whole', () => {
+    mockMembers = [];
+    mockAgents = [
+      { name: 'scout', displayName: 'Scout' },
+      { name: 'intruder', displayName: 'Intruder' },
+    ];
+    mockInstalls = {
+      data: [
+        { agentSlug: 'scout', enabled: true },
+        { agentSlug: 'intruder', enabled: true },
+      ],
+      isLoading: false,
+    };
+    mockProject = { agentMode: 'restricted', allowedAgentSlugs: ['scout'] };
+    mockScope = { data: { orgWide: true, userIds: [] } };
+
+    const { result } = renderHook(() =>
+      useAssignableActors('org-1', PROJECT_ID),
+    );
+    expect(result.current.assignableAgents.map((a) => a.id)).toEqual(['scout']);
+    // The unfiltered directory still exposes both agents for display.
+    expect(result.current.agents.map((a) => a.id).sort()).toEqual([
+      'intruder',
+      'scout',
+    ]);
   });
 });

--- a/services/platform/app/features/tasks/hooks/use-actor-directory.ts
+++ b/services/platform/app/features/tasks/hooks/use-actor-directory.ts
@@ -6,9 +6,13 @@ import {
   useListAgents,
 } from '@/app/features/agents/hooks/queries';
 import { toConfigurableAgent } from '@/app/features/agents/utils/agent-list-item';
+import { useProject } from '@/app/features/projects/hooks/queries';
 import { useMembers } from '@/app/features/settings/organization/hooks/queries';
 import { useListWorkflows } from '@/app/features/workflows/hooks/file-queries';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import {
   getAgentDisplayCategory,
@@ -42,6 +46,8 @@ export interface AssignableActor {
   id: string;
   name: string;
   email?: string;
+  /** Org role (members only) — lets the assignable filter drop disabled users. */
+  role?: string;
 }
 
 export interface AssignableAgent extends AssignableActor {
@@ -81,6 +87,7 @@ export function useActorDirectory(organizationId: string, projectId?: string) {
         id: m.userId,
         name: m.displayName || m.email || m.userId,
         email: m.email,
+        role: m.role,
       })),
     [members],
   );
@@ -261,8 +268,56 @@ export function useActorDirectory(organizationId: string, projectId?: string) {
     members: memberList,
     agents: agentList,
     currentUserId: me?.userId,
-    // `projectId` is accepted for forward-compat (scoping agents to a project)
-    // but the current directory is org-wide.
+    // `useActorDirectory` stays org-wide — it also resolves *historical* actors
+    // (comment authors, a current assignee who has since lost access), which a
+    // project filter would regress to raw ids. The project-scoped candidate
+    // lists for authoring live in `useAssignableActors` below.
     projectId,
   };
+}
+
+/**
+ * The assignee picker and `@`-mention autocomplete build their candidate lists
+ * from this: {@link useActorDirectory} narrowed to who can actually access the
+ * project. Members outside the project's team(s) are dropped, agents the project
+ * doesn't permit are dropped, and disabled members are always excluded. The
+ * unfiltered `members` / `agents` / `resolveActor` are still returned (spread
+ * from the directory) for *display* of historical/current actors.
+ *
+ * With no `projectId` the lists degrade to org-wide (all non-disabled members,
+ * all agents) — there is no project to scope to. While the access query is in
+ * flight, members fall back to org-wide; the backend guard is the real gate.
+ */
+export function useAssignableActors(
+  organizationId: string,
+  projectId?: Id<'projects'>,
+) {
+  const directory = useActorDirectory(organizationId, projectId);
+  const { members, agents } = directory;
+  const { project } = useProject(projectId);
+  const scope = useConvexQuery(
+    api.projects.queries.listAccessibleUserIds,
+    projectId ? { organizationId, projectId } : 'skip',
+  );
+
+  const assignableMembers = useMemo<AssignableActor[]>(() => {
+    const nonDisabled = members.filter((m) => m.role !== 'disabled');
+    if (!projectId || !scope.data || scope.data.orgWide) return nonDisabled;
+    const ids = new Set(scope.data.userIds);
+    return nonDisabled.filter((m) => ids.has(m.id));
+  }, [members, projectId, scope.data]);
+
+  const assignableAgents = useMemo<AssignableAgent[]>(() => {
+    if (project?.agentMode === 'restricted') {
+      const allowed = new Set(project.allowedAgentSlugs ?? []);
+      return agents.filter((a) => allowed.has(a.id));
+    }
+    // 'all' / unset: every agent, recommended ones first.
+    const recommended = new Set(project?.recommendedAgentSlugs ?? []);
+    return [...agents].sort(
+      (a, b) => Number(recommended.has(b.id)) - Number(recommended.has(a.id)),
+    );
+  }, [agents, project]);
+
+  return { ...directory, assignableMembers, assignableAgents };
 }

--- a/services/platform/app/features/tasks/lib/mention-actor-options.ts
+++ b/services/platform/app/features/tasks/lib/mention-actor-options.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 
-import { useProject } from '@/app/features/projects/hooks/queries';
 import type { Id } from '@/convex/_generated/dataModel';
 
-import { useActorDirectory } from '../hooks/use-actor-directory';
+import { useAssignableActors } from '../hooks/use-actor-directory';
 import { memberInsertHandle } from './mention-handles';
 
 export const MAX_MENTION_OPTIONS = 8;
@@ -33,15 +32,12 @@ export function useMentionActorOptions(
   organizationId: string,
   projectId: Id<'projects'>,
 ): MentionActorOption[] {
-  const { members, agents, currentUserId } = useActorDirectory(
-    organizationId,
-    projectId,
-  );
-  const { project } = useProject(projectId);
+  const { assignableMembers, assignableAgents, currentUserId } =
+    useAssignableActors(organizationId, projectId);
 
   return useMemo(() => {
     const options: MentionActorOption[] = [];
-    for (const member of members) {
+    for (const member of assignableMembers) {
       // You never need to @mention yourself — leave the current user out.
       if (member.id === currentUserId) continue;
       const handle = memberInsertHandle(member);
@@ -55,16 +51,7 @@ export function useMentionActorOptions(
         });
       }
     }
-    const restricted = project?.agentMode === 'restricted';
-    const allowed = new Set(project?.allowedAgentSlugs ?? []);
-    const recommended = new Set(project?.recommendedAgentSlugs ?? []);
-    const mentionableAgents = restricted
-      ? agents.filter((a) => allowed.has(a.id))
-      : [...agents].sort(
-          (a, b) =>
-            Number(recommended.has(b.id)) - Number(recommended.has(a.id)),
-        );
-    for (const agent of mentionableAgents) {
+    for (const agent of assignableAgents) {
       options.push({
         type: 'agent',
         id: agent.id,
@@ -73,7 +60,7 @@ export function useMentionActorOptions(
       });
     }
     return options;
-  }, [members, agents, project, currentUserId]);
+  }, [assignableMembers, assignableAgents, currentUserId]);
 }
 
 export function filterMentionActorOptions(

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1242,6 +1242,7 @@ import type * as products_upsert_product_translation from "../products/upsert_pr
 import type * as products_validate_product_name from "../products/validate_product_name.js";
 import type * as products_validators from "../products/validators.js";
 import type * as projects_access from "../projects/access.js";
+import type * as projects_accessible_members from "../projects/accessible_members.js";
 import type * as projects_audit_actions from "../projects/audit_actions.js";
 import type * as projects_internal_queries from "../projects/internal_queries.js";
 import type * as projects_mutations from "../projects/mutations.js";
@@ -3032,6 +3033,7 @@ declare const fullApi: ApiFromModules<{
   "products/validate_product_name": typeof products_validate_product_name;
   "products/validators": typeof products_validators;
   "projects/access": typeof projects_access;
+  "projects/accessible_members": typeof projects_accessible_members;
   "projects/audit_actions": typeof projects_audit_actions;
   "projects/internal_queries": typeof projects_internal_queries;
   "projects/mutations": typeof projects_mutations;

--- a/services/platform/convex/projects/access.ts
+++ b/services/platform/convex/projects/access.ts
@@ -118,3 +118,17 @@ export function checkProjectAccess(
   const canEdit = EDITOR_ROLES.has(userRole);
   return { canRead: true, canEdit, canAdminister: false };
 }
+
+/**
+ * Whether a specific agent may be assigned or run in a project. A project in
+ * `agentMode: 'restricted'` only permits its `allowedAgentSlugs`; any other mode
+ * ('all' / unset) permits every org agent. Liveness (installed + enabled) is a
+ * separate gate (`assertAgentAssigneeLive`).
+ */
+export function isAgentAllowedByProject(
+  project: { agentMode?: string; allowedAgentSlugs?: string[] },
+  agentSlug: string,
+): boolean {
+  if (project.agentMode !== 'restricted') return true;
+  return (project.allowedAgentSlugs ?? []).includes(agentSlug);
+}

--- a/services/platform/convex/projects/accessible_members.test.ts
+++ b/services/platform/convex/projects/accessible_members.test.ts
@@ -1,0 +1,387 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import type { Doc, Id } from '../_generated/dataModel';
+import schema from '../schema';
+import { getProjectAccessibleUserIds } from './accessible_members';
+import {
+  assertAgentAssigneeAllowedByProject,
+  assertHumanAssigneeAccess,
+} from './resolve_project_access';
+
+// convex-test module map keyed relative to the convex/ root (this file is at
+// convex/projects/), mirroring queries.test.ts.
+const TEST_DIR_FROM_CONVEX_ROOT = 'projects';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_access';
+const OTHER_ORG = 'org_other';
+const TEAM_A = 'team_a';
+const TEAM_B = 'team_b';
+
+const ADMIN = 'u_admin';
+const MEMBER_A = 'u_member_a';
+const MEMBER_B = 'u_member_b';
+const OUTSIDER = 'u_outsider';
+const DISABLED_A = 'u_disabled_a';
+const BOTH_TEAMS = 'u_both';
+
+type T = TestConvex<typeof schema>;
+
+function dataOf(err: unknown): Record<string, unknown> | undefined {
+  if (err === null || typeof err !== 'object' || !('data' in err))
+    return undefined;
+  let data: unknown = (err as { data: unknown }).data;
+  for (let i = 0; i < 3 && typeof data === 'string'; i++) {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+  return typeof data === 'object' && data !== null
+    ? (data as Record<string, unknown>)
+    : undefined;
+}
+function codeOf(err: unknown): string | undefined {
+  const c = dataOf(err)?.code;
+  return typeof c === 'string' ? c : undefined;
+}
+async function catchCode(
+  fn: () => Promise<unknown>,
+): Promise<string | undefined> {
+  try {
+    await fn();
+  } catch (err) {
+    return codeOf(err);
+  }
+  return undefined;
+}
+
+async function seedMember(
+  t: T,
+  userId: string,
+  role = 'member',
+  organizationId = ORG,
+): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert('memberMirror', {
+      memberId: `m_${userId}_${organizationId}`,
+      userId,
+      organizationId,
+      role,
+      createdAt: 0,
+    }),
+  );
+}
+
+async function seedTeam(t: T, userId: string, teamId: string): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert('teamMemberMirror', {
+      teamMemberId: `tm_${userId}_${teamId}`,
+      userId,
+      teamId,
+      createdAt: 0,
+    }),
+  );
+}
+
+async function seedProject(
+  t: T,
+  args: {
+    organizationId?: string;
+    teamId?: string;
+    sharedWithTeamIds?: string[];
+  } = {},
+): Promise<Id<'projects'>> {
+  return t.run((ctx) =>
+    ctx.db.insert('projects', {
+      organizationId: args.organizationId ?? ORG,
+      name: 'Project',
+      teamId: args.teamId,
+      sharedWithTeamIds: args.sharedWithTeamIds,
+      createdBy: 'u_creator',
+      createdAt: 0,
+      updatedAt: 0,
+    }),
+  );
+}
+
+function getProjectDoc(
+  t: T,
+  projectId: Id<'projects'>,
+): Promise<Doc<'projects'>> {
+  return t.run(async (ctx) => {
+    const p = await ctx.db.get(projectId);
+    if (!p) throw new Error('project missing');
+    return p;
+  });
+}
+
+/** Seed the standard org roster used by most cases. */
+async function seedRoster(t: T): Promise<void> {
+  await seedMember(t, ADMIN, 'admin');
+  await seedMember(t, MEMBER_A);
+  await seedMember(t, MEMBER_B);
+  await seedMember(t, OUTSIDER);
+  await seedMember(t, DISABLED_A, 'disabled');
+  await seedTeam(t, MEMBER_A, TEAM_A);
+  await seedTeam(t, MEMBER_B, TEAM_B);
+  await seedTeam(t, DISABLED_A, TEAM_A);
+}
+
+/**
+ * Run the helper in a txn, returning a Convex-serializable value — a `Set`
+ * cannot cross the `t.run` boundary. `null` = org-wide.
+ */
+function accessibleIds(
+  t: T,
+  projectId: Id<'projects'>,
+): Promise<string[] | null> {
+  return t.run(async (ctx) => {
+    const project = await ctx.db.get(projectId);
+    if (!project) throw new Error('project missing');
+    const set = await getProjectAccessibleUserIds(ctx, project);
+    return set === null ? null : [...set];
+  });
+}
+
+describe('getProjectAccessibleUserIds', () => {
+  it('returns null for an org-wide project (no team restriction)', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t); // no teamId → org-wide
+    expect(await accessibleIds(t, projectId)).toBeNull();
+  });
+
+  it('returns team members ∪ admins, excluding disabled and other teams', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+
+    const ids = await accessibleIds(t, projectId);
+    expect(ids).not.toBeNull();
+    expect([...(ids ?? [])].sort()).toEqual([ADMIN, MEMBER_A].sort());
+    // Disabled team member, other-team member, and teamless member are absent.
+    expect(ids).not.toContain(DISABLED_A);
+    expect(ids).not.toContain(MEMBER_B);
+    expect(ids).not.toContain(OUTSIDER);
+  });
+
+  it('de-dupes a user who is on both the owning and a shared team', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    await seedMember(t, BOTH_TEAMS);
+    await seedTeam(t, BOTH_TEAMS, TEAM_A);
+    await seedTeam(t, BOTH_TEAMS, TEAM_B);
+    const projectId = await seedProject(t, {
+      teamId: TEAM_A,
+      sharedWithTeamIds: [TEAM_B],
+    });
+
+    const ids = (await accessibleIds(t, projectId)) ?? [];
+    expect(ids.filter((id) => id === BOTH_TEAMS)).toHaveLength(1);
+    expect([...ids].sort()).toEqual(
+      [ADMIN, MEMBER_A, MEMBER_B, BOTH_TEAMS].sort(),
+    );
+  });
+
+  it('excludes a stale team-mirror row for a user no longer in the org', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, ADMIN, 'admin');
+    await seedTeam(t, 'u_ghost', TEAM_A); // team row but no memberMirror
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+
+    const ids = await accessibleIds(t, projectId);
+    expect(ids).not.toContain('u_ghost');
+    expect(ids).toEqual([ADMIN]);
+  });
+});
+
+describe('listAccessibleUserIds query', () => {
+  it('returns the accessible set for a team member calling on a team project', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+
+    const res = await t
+      .withIdentity({ subject: MEMBER_A })
+      .query(api.projects.queries.listAccessibleUserIds, {
+        organizationId: ORG,
+        projectId,
+      });
+    expect(res.orgWide).toBe(false);
+    expect([...res.userIds].sort()).toEqual([ADMIN, MEMBER_A].sort());
+  });
+
+  it('flags org-wide projects so the client shows every member', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t); // org-wide
+
+    const res = await t
+      .withIdentity({ subject: MEMBER_A })
+      .query(api.projects.queries.listAccessibleUserIds, {
+        organizationId: ORG,
+        projectId,
+      });
+    expect(res).toEqual({ orgWide: true, userIds: [] });
+  });
+
+  it('fails closed to empty when the caller cannot read the project', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+
+    // OUTSIDER is an org member but on no team → no access to the team project.
+    const res = await t
+      .withIdentity({ subject: OUTSIDER })
+      .query(api.projects.queries.listAccessibleUserIds, {
+        organizationId: ORG,
+        projectId,
+      });
+    expect(res).toEqual({ orgWide: false, userIds: [] });
+  });
+
+  it('fails closed for a project outside the active org', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, {
+      organizationId: OTHER_ORG,
+      teamId: TEAM_A,
+    });
+
+    const res = await t
+      .withIdentity({ subject: MEMBER_A })
+      .query(api.projects.queries.listAccessibleUserIds, {
+        organizationId: ORG,
+        projectId,
+      });
+    expect(res).toEqual({ orgWide: false, userIds: [] });
+  });
+});
+
+describe('assertHumanAssigneeAccess', () => {
+  it('allows self-assignment regardless of team access', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+    const project = await getProjectDoc(t, projectId);
+
+    const code = await catchCode(() =>
+      t.run((ctx) =>
+        assertHumanAssigneeAccess(ctx, {
+          project,
+          organizationId: ORG,
+          assigneeId: OUTSIDER,
+          callerId: OUTSIDER,
+        }),
+      ),
+    );
+    expect(code).toBeUndefined();
+  });
+
+  it('allows an assignee on the project team', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+    const project = await getProjectDoc(t, projectId);
+
+    const code = await catchCode(() =>
+      t.run((ctx) =>
+        assertHumanAssigneeAccess(ctx, {
+          project,
+          organizationId: ORG,
+          assigneeId: MEMBER_A,
+          callerId: ADMIN,
+        }),
+      ),
+    );
+    expect(code).toBeUndefined();
+  });
+
+  it('rejects an assignee outside the project team', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t, { teamId: TEAM_A });
+    const project = await getProjectDoc(t, projectId);
+
+    const code = await catchCode(() =>
+      t.run((ctx) =>
+        assertHumanAssigneeAccess(ctx, {
+          project,
+          organizationId: ORG,
+          assigneeId: MEMBER_B,
+          callerId: ADMIN,
+        }),
+      ),
+    );
+    expect(code).toBe('ASSIGNEE_NO_PROJECT_ACCESS');
+  });
+
+  it('allows any member on an org-wide project', async () => {
+    const t = convexTest(schema, modules);
+    await seedRoster(t);
+    const projectId = await seedProject(t); // org-wide
+    const project = await getProjectDoc(t, projectId);
+
+    const code = await catchCode(() =>
+      t.run((ctx) =>
+        assertHumanAssigneeAccess(ctx, {
+          project,
+          organizationId: ORG,
+          assigneeId: OUTSIDER,
+          callerId: ADMIN,
+        }),
+      ),
+    );
+    expect(code).toBeUndefined();
+  });
+});
+
+describe('assertAgentAssigneeAllowedByProject', () => {
+  it('permits any agent in a non-restricted project', () => {
+    expect(() =>
+      assertAgentAssigneeAllowedByProject({ agentMode: 'all' }, 'anything'),
+    ).not.toThrow();
+    expect(() =>
+      assertAgentAssigneeAllowedByProject({}, 'anything'),
+    ).not.toThrow();
+  });
+
+  it('permits an allow-listed agent in a restricted project', () => {
+    expect(() =>
+      assertAgentAssigneeAllowedByProject(
+        { agentMode: 'restricted', allowedAgentSlugs: ['scout'] },
+        'scout',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a non-allowed agent in a restricted project', () => {
+    let code: string | undefined;
+    try {
+      assertAgentAssigneeAllowedByProject(
+        { agentMode: 'restricted', allowedAgentSlugs: ['scout'] },
+        'intruder',
+      );
+    } catch (err) {
+      code = codeOf(err);
+    }
+    expect(code).toBe('AGENT_NOT_ALLOWED_IN_PROJECT');
+  });
+});

--- a/services/platform/convex/projects/accessible_members.ts
+++ b/services/platform/convex/projects/accessible_members.ts
@@ -1,0 +1,62 @@
+/**
+ * Reverse of `hasProjectAccess`: enumerate the user IDs that CAN access a
+ * project, so an assignee picker / `@`-mention directory never offers a user who
+ * cannot see the project (`use-actor-directory`, `tasks/directory.ts`).
+ *
+ * Reads the local membership mirrors (`memberMirror`, `teamMemberMirror`) — the
+ * same source `getUserTeamIds` / `hasProjectAccess` resolve against — so the
+ * reverse set and the forward gate always agree. Tenant-safe: team IDs come from
+ * the org-scoped project, and every returned userId must appear in that org's
+ * `memberMirror`.
+ */
+
+import type { Doc } from '../_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+import { ADMIN_ROLES, getProjectTeamIds } from './access';
+
+/**
+ * The set of user IDs with access to `project`, or `null` when the project is
+ * org-wide (no team restriction) — callers treat `null` as "every non-disabled
+ * member". For a team-scoped project the set is exactly the users for whom
+ * `hasProjectAccess(project, theirTeams, theirRole)` is true: org admins/owners
+ * (always) ∪ members of the project's team(s), minus `disabled` and stale
+ * (no-longer-in-org) rows.
+ */
+export async function getProjectAccessibleUserIds(
+  ctx: QueryCtx | MutationCtx,
+  project: Doc<'projects'>,
+): Promise<Set<string> | null> {
+  const teamIds = getProjectTeamIds(project);
+  if (teamIds.length === 0) return null; // org-wide
+
+  // One pass over the org's members: role lookup + the admin/owner set (admins
+  // always have access regardless of team). This also lets us drop stale
+  // teamMemberMirror rows for users who have since left the org.
+  const roleByUserId = new Map<string, string>();
+  for await (const row of ctx.db
+    .query('memberMirror')
+    .withIndex('by_organizationId', (q) =>
+      q.eq('organizationId', project.organizationId),
+    )) {
+    roleByUserId.set(row.userId, row.role);
+  }
+
+  const accessible = new Set<string>();
+  for (const [userId, role] of roleByUserId) {
+    if (ADMIN_ROLES.has(role)) accessible.add(userId);
+  }
+
+  for (const teamId of teamIds) {
+    for await (const row of ctx.db
+      .query('teamMemberMirror')
+      .withIndex('by_teamId', (q) => q.eq('teamId', teamId))) {
+      const role = roleByUserId.get(row.userId);
+      // Skip users no longer in the org (stale mirror row) and disabled users —
+      // both fail `hasProjectAccess`.
+      if (role === undefined || role === 'disabled') continue;
+      accessible.add(row.userId);
+    }
+  }
+
+  return accessible;
+}

--- a/services/platform/convex/projects/queries.ts
+++ b/services/platform/convex/projects/queries.ts
@@ -23,6 +23,7 @@ import {
   hasProjectAccess,
   isOrgWideProject,
 } from './access';
+import { getProjectAccessibleUserIds } from './accessible_members';
 import {
   projectIntegrationsModeValidator,
   projectKnowledgeModeValidator,
@@ -153,6 +154,36 @@ export const listProjects = query({
     }
 
     return visible;
+  },
+});
+
+/**
+ * The user IDs that can be ASSIGNED work in a project — i.e. those who can
+ * access it. Powers the task assignee picker + `@`-mention autocomplete so they
+ * never offer a user who cannot see the project (see `use-actor-directory`).
+ *
+ * `orgWide: true` (with empty `userIds`) means no team restriction — the client
+ * shows every non-disabled member. Otherwise `userIds` is the exact accessible
+ * set (admins/owners ∪ the project's team members). Fails closed to
+ * `{ orgWide: false, userIds: [] }` when the project isn't in the active org or
+ * the caller can't read it.
+ */
+export const listAccessibleUserIds = query({
+  args: { organizationId: v.string(), projectId: v.id('projects') },
+  returns: v.object({ orgWide: v.boolean(), userIds: v.array(v.string()) }),
+  handler: async (ctx, args) => {
+    const project = await ctx.db.get(args.projectId);
+    if (!project || !isActiveOrg(project.organizationId, args.organizationId)) {
+      return { orgWide: false, userIds: [] };
+    }
+    const auth = await getAuthContext(ctx, args.organizationId);
+    if (!hasProjectAccess(project, auth.teamIds, auth.role)) {
+      return { orgWide: false, userIds: [] };
+    }
+    const set = await getProjectAccessibleUserIds(ctx, project);
+    return set === null
+      ? { orgWide: true, userIds: [] }
+      : { orgWide: false, userIds: [...set] };
   },
 });
 

--- a/services/platform/convex/projects/resolve_project_access.ts
+++ b/services/platform/convex/projects/resolve_project_access.ts
@@ -5,17 +5,51 @@
  * role, team ids — and fails CLOSED (no access) on any resolution error.
  */
 
-import type { Id } from '../_generated/dataModel';
+import { ConvexError } from 'convex/values';
+
+import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
 import { getUserTeamIds } from '../lib/get_user_teams';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
-import { checkProjectAccess, type ProjectAccessResult } from './access';
+import {
+  checkProjectAccess,
+  hasProjectAccess,
+  isAgentAllowedByProject,
+  type ProjectAccessResult,
+} from './access';
 
 export const NO_PROJECT_ACCESS: ProjectAccessResult = {
   canRead: false,
   canEdit: false,
   canAdminister: false,
 };
+
+/**
+ * Resolve a user's org role + team IDs, or `null` when that can't be proven
+ * (user removed mid-request, auth mirror miss). Shared by the project-access
+ * resolvers below; fails CLOSED so a resolution error never leaks access.
+ */
+export async function resolveUserAccessContext(
+  ctx: QueryCtx | MutationCtx,
+  organizationId: string,
+  userId: string,
+): Promise<{ role: string; teamIds: string[] } | null> {
+  try {
+    const member = await getOrganizationMember(ctx, organizationId, {
+      userId,
+      email: undefined,
+      name: undefined,
+    });
+    const teamIds = await getUserTeamIds(ctx, member.userId);
+    return { role: member.role, teamIds };
+  } catch (err) {
+    console.warn(
+      '[projects/resolve_project_access] user access context resolve failed',
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
 
 /**
  * Resolve the caller's access matrix on a project by id.
@@ -34,22 +68,55 @@ export async function resolveProjectAccessForUser(
   if (!project || project.organizationId !== args.organizationId) {
     return NO_PROJECT_ACCESS;
   }
+  const context = await resolveUserAccessContext(
+    ctx,
+    args.organizationId,
+    args.userId,
+  );
+  if (!context) return NO_PROJECT_ACCESS;
+  return checkProjectAccess(project, context.teamIds, context.role);
+}
 
-  try {
-    const member = await getOrganizationMember(ctx, args.organizationId, {
-      userId: args.userId,
-      email: undefined,
-      name: undefined,
-    });
-    const userTeamIds = await getUserTeamIds(ctx, member.userId);
-    return checkProjectAccess(project, userTeamIds, member.role);
-  } catch (err) {
-    // Membership resolution failing (user removed mid-request, auth mirror
-    // miss) means no provable access — deny rather than leak.
-    console.warn(
-      '[projects/resolve_project_access] membership resolve failed',
-      err instanceof Error ? err.message : err,
-    );
-    return NO_PROJECT_ACCESS;
+/**
+ * Guard a HUMAN task assignee: they must be able to read the project they'd be
+ * assigned work in. Self-assignment is always allowed — the caller already
+ * passed the project's write gate. Throws `ASSIGNEE_NO_PROJECT_ACCESS`.
+ */
+export async function assertHumanAssigneeAccess(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    project: Doc<'projects'>;
+    organizationId: string;
+    assigneeId: string;
+    callerId: string;
+  },
+): Promise<void> {
+  if (args.assigneeId === args.callerId) return;
+  const context = await resolveUserAccessContext(
+    ctx,
+    args.organizationId,
+    args.assigneeId,
+  );
+  if (
+    context &&
+    hasProjectAccess(args.project, context.teamIds, context.role)
+  ) {
+    return;
+  }
+  throw new ConvexError({ code: 'ASSIGNEE_NO_PROJECT_ACCESS' });
+}
+
+/**
+ * Guard an AGENT task assignee against the project's agent restriction: a
+ * `restricted`-mode project only permits its `allowedAgentSlugs`. Throws
+ * `AGENT_NOT_ALLOWED_IN_PROJECT`. (Liveness is a separate gate,
+ * `assertAgentAssigneeLive`.)
+ */
+export function assertAgentAssigneeAllowedByProject(
+  project: Pick<Doc<'projects'>, 'agentMode' | 'allowedAgentSlugs'>,
+  agentSlug: string,
+): void {
+  if (!isAgentAllowedByProject(project, agentSlug)) {
+    throw new ConvexError({ code: 'AGENT_NOT_ALLOWED_IN_PROJECT' });
   }
 }

--- a/services/platform/convex/tasks/access.ts
+++ b/services/platform/convex/tasks/access.ts
@@ -10,6 +10,7 @@ export {
   checkProjectAccess,
   getProjectTeamIds,
   hasProjectAccess,
+  isAgentAllowedByProject,
   isOrgWideProject,
   type ProjectAccessResult,
 } from '../projects/access';

--- a/services/platform/convex/tasks/directory.ts
+++ b/services/platform/convex/tasks/directory.ts
@@ -17,6 +17,7 @@
 import type { Doc } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
 import { listByOrganizationHandler } from '../members/queries';
+import { getProjectAccessibleUserIds } from '../projects/accessible_members';
 import type { MentionDirectoryEntry } from './mentions';
 
 /** Derive candidate `@handle`s for a member from email + display name. */
@@ -62,7 +63,12 @@ export async function buildMentionDirectory(
     const members = await listByOrganizationHandler(ctx, {
       organizationId: args.organizationId,
     });
+    // Only members who can access the project are mentionable — matches the
+    // assignee picker's scoping (`use-actor-directory`). `null` = org-wide.
+    const accessible = await getProjectAccessibleUserIds(ctx, args.project);
     for (const member of members) {
+      if (member.role === 'disabled') continue;
+      if (accessible && !accessible.has(member.userId)) continue;
       entries.push({
         type: 'user',
         id: member.userId,

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -36,9 +36,20 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import {
+  assertAgentAssigneeAllowedByProject,
+  assertHumanAssigneeAccess,
+  resolveUserAccessContext,
+} from '../projects/resolve_project_access';
 import { cascadeDeleteThreadChildren } from '../threads/cascade_helpers';
 import { emitEvent } from '../workflows/triggers/emit_event';
-import { canClaimTask, checkProjectAccess, normalizeAssignee } from './access';
+import {
+  canClaimTask,
+  checkProjectAccess,
+  hasProjectAccess,
+  isAgentAllowedByProject,
+  normalizeAssignee,
+} from './access';
 import {
   cleanupRemovedAttachments,
   validateTaskAttachments,
@@ -346,6 +357,16 @@ export const createTask = mutation({
       assigneeId: args.assigneeId,
     });
     await assertAgentAssigneeLive(ctx, args.organizationId, assignee);
+    if (assignee?.assigneeType === 'user') {
+      await assertHumanAssigneeAccess(ctx, {
+        project,
+        organizationId: args.organizationId,
+        assigneeId: assignee.assigneeId,
+        callerId: auth.userId,
+      });
+    } else if (assignee?.assigneeType === 'agent') {
+      assertAgentAssigneeAllowedByProject(project, assignee.assigneeId);
+    }
 
     if (args.parentTaskId) {
       const parent = await loadTaskOrThrow(ctx, args.parentTaskId);
@@ -710,6 +731,16 @@ export const assignTask = mutation({
       assigneeId: args.assigneeId,
     });
     await assertAgentAssigneeLive(ctx, task.organizationId, assignee);
+    if (assignee?.assigneeType === 'user') {
+      await assertHumanAssigneeAccess(ctx, {
+        project,
+        organizationId: task.organizationId,
+        assigneeId: assignee.assigneeId,
+        callerId: auth.userId,
+      });
+    } else if (assignee?.assigneeType === 'agent') {
+      assertAgentAssigneeAllowedByProject(project, assignee.assigneeId);
+    }
     const previousAssigneeId = task.assigneeId ?? null;
 
     await ctx.db.patch(args.taskId, {
@@ -1521,6 +1552,13 @@ export const bulkUpdateTasks = mutation({
     const now = Date.now();
     const projectAccessCache = new Map<string, boolean>();
     const authCache = new Map<string, AuthContext | null>();
+    // The assignee is constant across the batch; cache its resolved access
+    // context per org and the resulting allow/deny per project.
+    const assigneeCtxByOrg = new Map<
+      string,
+      { role: string; teamIds: string[] } | null
+    >();
+    const assigneeAllowedByProject = new Map<string, boolean>();
 
     for (const taskId of args.taskIds) {
       const task = await ctx.db.get(taskId);
@@ -1601,6 +1639,46 @@ export const bulkUpdateTasks = mutation({
         (task.assigneeId ?? null) !== (assignee?.assigneeId ?? null);
       if (args.clearAssignee || assignee) {
         if (assignee) {
+          // Per-project assignee gate. Access is per-project, so skip a task
+          // whose project the assignee can't take rather than aborting the
+          // whole batch (mirrors the `canEdit` skip above). Reuses the
+          // `projectKey` computed for the canEdit gate earlier this iteration.
+          let allowed = assigneeAllowedByProject.get(projectKey);
+          if (allowed === undefined) {
+            const assigneeProject = await ctx.db.get(task.projectId);
+            if (!assigneeProject) {
+              allowed = false;
+            } else if (assignee.assigneeType === 'agent') {
+              allowed = isAgentAllowedByProject(
+                assigneeProject,
+                assignee.assigneeId,
+              );
+            } else if (assignee.assigneeId === auth.userId) {
+              allowed = true; // self-assign is always safe
+            } else {
+              let assigneeCtx = assigneeCtxByOrg.get(task.organizationId);
+              if (assigneeCtx === undefined) {
+                assigneeCtx = await resolveUserAccessContext(
+                  ctx,
+                  task.organizationId,
+                  assignee.assigneeId,
+                );
+                assigneeCtxByOrg.set(task.organizationId, assigneeCtx);
+              }
+              allowed =
+                assigneeCtx !== null &&
+                hasProjectAccess(
+                  assigneeProject,
+                  assigneeCtx.teamIds,
+                  assigneeCtx.role,
+                );
+            }
+            assigneeAllowedByProject.set(projectKey, allowed);
+          }
+          if (!allowed) {
+            skipped += 1;
+            continue;
+          }
           await assertAgentAssigneeLive(ctx, task.organizationId, assignee);
         }
         patch.assigneeType = assignee?.assigneeType;


### PR DESCRIPTION
## What & why

Task assignment and `@`-mentions previously listed **every** org member and every enabled agent, ignoring a project's team-scope. A project scoped to a team is only readable by that team (plus org admins/owners), so a task could be assigned to — or mention — someone (or an agent) who cannot even see the project.

Assignable people and agents are now exactly those with access to the task's project, enforced in the UI **and** the backend.

## Changes

**Backend**

- `projects/accessible_members.ts` (new) — `getProjectAccessibleUserIds`: reverse team fan-out (`teamMemberMirror.by_teamId`) ∪ org admins/owners, minus disabled and stale rows; `null` = org-wide. Reuses `getProjectTeamIds` + `ADMIN_ROLES`.
- `projects/resolve_project_access.ts` — `assertHumanAssigneeAccess` (self-assignment exempt; throws `ASSIGNEE_NO_PROJECT_ACCESS`) and `assertAgentAssigneeAllowedByProject` (throws `AGENT_NOT_ALLOWED_IN_PROJECT`); extracted a shared `resolveUserAccessContext`.
- `projects/queries.ts` — `listAccessibleUserIds` query (`{ orgWide, userIds }`, fails closed when the caller can't read the project).
- `tasks/directory.ts` — `buildMentionDirectory` filters members to the accessible set.
- `tasks/mutations.ts` — guards in `createTask`, `assignTask`, and `bulkUpdateTasks` (bulk skips per-project instead of aborting; self-assignment always allowed).

**Frontend**

- `use-actor-directory.ts` — new `useAssignableActors` returns project-filtered `assignableMembers` / `assignableAgents`; `members` / `agents` / `resolveActor` stay org-wide so historical and current actors still resolve by name.
- `assignee-picker.tsx` + `mention-actor-options.ts` consume the scoped lists (the latter's duplicated agent-gating is now centralized).

## Behaviour notes

- **Org-wide projects** (no team) still show every member — minus disabled.
- A **currently-assigned** user who later loses access still renders by name and keeps the assignment; they simply aren't re-selectable.
- **Agents** now respect the project's `agentMode` / `allowedAgentSlugs` in the picker, matching the backend `@`-mention directory.

## Verification

- New tests: `accessible_members.test.ts` (15 — helper / query / assertions covering disabled, stale rows, de-dupe, cross-org fail-closed, self-assign, agent gate) + 4 `useAssignableActors` hook cases.
- Regression: 1041 server tests (projects / tasks / documents / folders / agents) and 85 tasks + discussions UI tests pass; typecheck, oxlint, and oxfmt are clean.

## Definition of done

- [x] **Green gate** — typecheck / oxlint / oxfmt clean; targeted + regression tests pass locally
- [x] **Security** — access resolved via existing membership mirrors; args validated (`v.id`, `v.string`); no string-built SQL/shell (SAST runs in CI)
- [x] **Tests** — happy path + edges (disabled / stale / org-wide) + errors (no access, agent not allowed)
- [x] **Migration** — N/A: reads existing indexed tables, no schema change
- [x] **Locales** — N/A: no new user-facing strings (rejections surface via the existing mutation error toast)
- [x] **Docs** — N/A: no user-configurable surface changed
- [x] **Accessibility** — N/A: no new UI elements; picker structure unchanged
- [x] **Sweep** — task assignee + the shared task/discussion `@`-mention directory covered; conversations are org-scoped, not project-scoped → out of scope
- [x] **Observed** — behaviour exercised by the tests above against a real convex-test DB and jsdom render
- [x] **Commits** — atomic, conventional, branched off `main`
