### PR TITLE
feat(platform): 100MB workspace files + streamed S3 sandbox staging

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -501,6 +501,7 @@ import type * as file_metadata_transcription_request from "../file_metadata/tran
 import type * as files_blob_actions from "../files/blob_actions.js";
 import type * as files_mutations from "../files/mutations.js";
 import type * as files_queries from "../files/queries.js";
+import type * as files_sandbox_blob_http from "../files/sandbox_blob_http.js";
 import type * as folders_access from "../folders/access.js";
 import type * as folders_cleanup_empty_ancestors from "../folders/cleanup_empty_ancestors.js";
 import type * as folders_find_folder_by_path from "../folders/find_folder_by_path.js";
@@ -932,6 +933,7 @@ import type * as lib_storage_blob_delete from "../lib/storage/blob_delete.js";
 import type * as lib_storage_blob_read_any from "../lib/storage/blob_read_any.js";
 import type * as lib_storage_blob_ref from "../lib/storage/blob_ref.js";
 import type * as lib_storage_object_store from "../lib/storage/object_store.js";
+import type * as lib_storage_sandbox_stage_token from "../lib/storage/sandbox_stage_token.js";
 import type * as lib_strip_nulls from "../lib/strip_nulls.js";
 import type * as lib_summarization_auto_summarize from "../lib/summarization/auto_summarize.js";
 import type * as lib_summarization_index from "../lib/summarization/index.js";
@@ -1107,6 +1109,7 @@ import type * as node_only_sandbox_api_error_detection from "../node_only/sandbo
 import type * as node_only_sandbox_bound_org_skills from "../node_only/sandbox/bound_org_skills.js";
 import type * as node_only_sandbox_browser_view from "../node_only/sandbox/browser_view.js";
 import type * as node_only_sandbox_helpers_session_client from "../node_only/sandbox/helpers/session_client.js";
+import type * as node_only_sandbox_helpers_stage_url from "../node_only/sandbox/helpers/stage_url.js";
 import type * as node_only_sandbox_integration_skills from "../node_only/sandbox/integration_skills.js";
 import type * as node_only_sandbox_internal_actions from "../node_only/sandbox/internal_actions.js";
 import type * as node_only_sandbox_llm_gateway_admin from "../node_only/sandbox/llm_gateway_admin.js";
@@ -2291,6 +2294,7 @@ declare const fullApi: ApiFromModules<{
   "files/blob_actions": typeof files_blob_actions;
   "files/mutations": typeof files_mutations;
   "files/queries": typeof files_queries;
+  "files/sandbox_blob_http": typeof files_sandbox_blob_http;
   "folders/access": typeof folders_access;
   "folders/cleanup_empty_ancestors": typeof folders_cleanup_empty_ancestors;
   "folders/find_folder_by_path": typeof folders_find_folder_by_path;
@@ -2722,6 +2726,7 @@ declare const fullApi: ApiFromModules<{
   "lib/storage/blob_read_any": typeof lib_storage_blob_read_any;
   "lib/storage/blob_ref": typeof lib_storage_blob_ref;
   "lib/storage/object_store": typeof lib_storage_object_store;
+  "lib/storage/sandbox_stage_token": typeof lib_storage_sandbox_stage_token;
   "lib/strip_nulls": typeof lib_strip_nulls;
   "lib/summarization/auto_summarize": typeof lib_summarization_auto_summarize;
   "lib/summarization/index": typeof lib_summarization_index;
@@ -2897,6 +2902,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/bound_org_skills": typeof node_only_sandbox_bound_org_skills;
   "node_only/sandbox/browser_view": typeof node_only_sandbox_browser_view;
   "node_only/sandbox/helpers/session_client": typeof node_only_sandbox_helpers_session_client;
+  "node_only/sandbox/helpers/stage_url": typeof node_only_sandbox_helpers_stage_url;
   "node_only/sandbox/integration_skills": typeof node_only_sandbox_integration_skills;
   "node_only/sandbox/internal_actions": typeof node_only_sandbox_internal_actions;
   "node_only/sandbox/llm_gateway_admin": typeof node_only_sandbox_llm_gateway_admin;

--- a/services/platform/convex/agent_tools/files/file_edit_tool.ts
+++ b/services/platform/convex/agent_tools/files/file_edit_tool.ts
@@ -92,7 +92,7 @@ export const fileEditTool: ToolDefinition = {
 
 USE THIS over \`file_write\` for small changes to a file you already wrote — the rest stays byte-identical; far cheaper than re-emitting it. Use \`file_write\` instead when the file does not exist yet (\`file_edit\` errors \`NOT_FOUND\`; only \`file_write\` creates files), when you're rewriting most of it anyway, or for binary files (\`file_edit\` only handles text).
 
-QUOTAS: same as \`file_write\` — ≤ 10 MB per file, ≤ 100 MB per workspace.
+QUOTAS: same workspace as \`file_write\` — ≤ 100 MB per file, ≤ 100 files and ≤ 1 GB per workspace.
 
 Every result includes \`sandboxState\` — the current workspace manifest. Trust it over memory.`,
     inputSchema: fileEditArgs,

--- a/services/platform/convex/agent_tools/files/file_write_tool.ts
+++ b/services/platform/convex/agent_tools/files/file_write_tool.ts
@@ -73,7 +73,7 @@ USE FOR: final deliverables → \`/user/output/report.md\` (write directly; no s
 
 Inside a \`run_code\` script the same rule applies: deliverables must be saved to \`/user/output/\` — files left in the cwd or \`/tmp\` are discarded when the container exits. Rewrite a skill example's bare \`output.xlsx\` as \`/user/output/output.xlsx\`.
 
-QUOTAS: ≤ 10 MB per file; ≤ 100 files and ≤ 100 MB per workspace.
+QUOTAS: ≤ 10 MB content per file_write call; workspace ≤ 100 files and ≤ 1 GB total (≤ 100 MB per file — user uploads and run outputs may be larger than one file_write can emit).
 
 Every result includes \`sandboxState\` — the current workspace manifest. Trust it over memory: a file listed there already exists, don't recreate it.
 

--- a/services/platform/convex/agent_tools/run_code_tool.test.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.test.ts
@@ -326,6 +326,46 @@ describe('formatRunCodeResultMessage', () => {
     expect(msg).toContain('````\na\n```\nb\n````');
   });
 
+  it('surfaces staging skips so the model knows what scripts cannot read', () => {
+    const msg = formatRunCodeResultMessage({
+      ...baseRun,
+      stdoutPreview: 'ran fine\n',
+      stagingSkipped: [
+        {
+          path: '/user/uploads/big.bin',
+          reason:
+            '30.0 MB org-bucket file exceeds the 1.0 MB inline staging cap',
+        },
+      ],
+    });
+    expect(msg).toContain('NOT staged into the sandbox');
+    expect(msg).toContain('/user/uploads/big.bin');
+    expect(msg).toContain('inline staging cap');
+  });
+
+  it('surfaces harvest skips on success AND failure', () => {
+    const ok = formatRunCodeResultMessage({
+      ...baseRun,
+      stdoutPreview: 'wrote it\n',
+      harvestSkipped: [
+        {
+          path: '/user/output/huge.zip',
+          reason: '25.0 MB exceeds the 20.0 MB per-file harvest cap',
+        },
+      ],
+    });
+    expect(ok).toContain('Output files NOT harvested');
+    expect(ok).toContain('/user/output/huge.zip');
+
+    const failed = formatRunCodeResultMessage({
+      ...baseRun,
+      status: 'failed',
+      exitCode: 1,
+      harvestSkipped: [{ path: '/user/output/huge.zip', reason: 'x' }],
+    });
+    expect(failed).toContain('Output files NOT harvested');
+  });
+
   it('reports an install-only success without the harvest lecture', () => {
     const msg = formatRunCodeResultMessage(
       { ...baseRun, stdoutPreview: 'Successfully installed pandas-2.2.1\n' },

--- a/services/platform/convex/agent_tools/run_code_tool.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.ts
@@ -238,6 +238,8 @@ export function formatRunCodeResultMessage(
     stderrPreview: string;
     durationMs: number;
     files: Array<{ path: string }>;
+    stagingSkipped?: Array<{ path: string; reason: string }>;
+    harvestSkipped?: Array<{ path: string; reason: string }>;
   },
   opts?: { installOnly?: boolean; packageCount?: number },
 ): string {
@@ -271,6 +273,22 @@ export function formatRunCodeResultMessage(
   if (!success && stderr.length > 0) {
     const fence = fenceFor(stderr);
     blocks.push(`stderr:\n${fence}\n${stderr}\n${fence}`);
+  }
+  // Ground truth about files the run could NOT see or return — without this
+  // the model reads an empty dir or a missing deliverable as its own bug.
+  if (run.stagingSkipped !== undefined && run.stagingSkipped.length > 0) {
+    blocks.push(
+      `⚠ NOT staged into the sandbox (scripts cannot read these):\n${run.stagingSkipped
+        .map((s) => `- ${s.path} — ${s.reason}`)
+        .join('\n')}`,
+    );
+  }
+  if (run.harvestSkipped !== undefined && run.harvestSkipped.length > 0) {
+    blocks.push(
+      `⚠ Output files NOT harvested back into the workspace:\n${run.harvestSkipped
+        .map((s) => `- ${s.path} — ${s.reason}`)
+        .join('\n')}`,
+    );
   }
   // Backstop for language mismatches the pre-flight heuristic let through:
   // bash choking on Python source has this one unmistakable signature.
@@ -485,6 +503,8 @@ Results embed terminal output (stdout capped 4 KB; stderr on failure) and a \`sa
           size: number;
           contentType: string;
         }>;
+        stagingSkipped?: Array<{ path: string; reason: string }>;
+        harvestSkipped?: Array<{ path: string; reason: string }>;
         executionId: string;
       };
 
@@ -550,6 +570,12 @@ Results embed terminal output (stdout capped 4 KB; stderr on failure) and a \`sa
         runStderrPreview: run.stderrPreview,
         durationMs: run.durationMs,
         files: run.files,
+        ...(run.stagingSkipped !== undefined && {
+          stagingSkipped: run.stagingSkipped,
+        }),
+        ...(run.harvestSkipped !== undefined && {
+          harvestSkipped: run.harvestSkipped,
+        }),
         sandboxState,
         message: messageWithState,
       };

--- a/services/platform/convex/files/blob_actions.ts
+++ b/services/platform/convex/files/blob_actions.ts
@@ -139,7 +139,7 @@ export const presignBlobGet = internalAction({
  * V8 workflow engine) use to write org-owned blobs: they cannot import the
  * `'use node'` seam themselves, so they hop through this action. Bounded by
  * Convex's function-argument ceiling — callers own keeping their payloads
- * small (thread files are ≤ 10 MB by THREAD_FILE_MAX_BYTES). Falls back to
+ * small (the lane V8 file tools emit ≤ 10 MB per write). Falls back to
  * Convex `_storage` when the org is unresolvable (never fails a write over
  * blob routing).
  */

--- a/services/platform/convex/files/sandbox_blob_http.ts
+++ b/services/platform/convex/files/sandbox_blob_http.ts
@@ -1,0 +1,106 @@
+/**
+ * `/api/sandbox-blob` — stream an org-bucket (`s3:`) blob to a sandbox
+ * session container.
+ *
+ * Session containers sit on the SSRF-locked sandbox net: they can reach the
+ * Convex http-actions origin via the `convex` alias but have no route to an
+ * org's S3/R2 endpoint, and a presigned bucket URL is a bearer credential
+ * that must never enter an untrusted container. The staging path therefore
+ * hands the in-container daemon THIS route instead: it verifies a short-lived
+ * HMAC stage token (see lib/storage/sandbox_stage_token.ts), presigns
+ * server-side — `presignBlobGet` re-checks the key sits in the token org's
+ * namespace — and passes the upstream body through as a stream (no buffering;
+ * a workspace file can be 100 MB).
+ *
+ * No IP rate limit on purpose: the token gate is strictly stronger (unforgeable,
+ * single-blob, minutes-lived), and an IP bucket would throttle a legitimate
+ * 100-file staging burst from the one sandbox-relay address.
+ */
+
+import { internal } from '../_generated/api';
+import { httpAction } from '../_generated/server';
+import { isS3Ref } from '../lib/storage/blob_ref';
+import { verifyStageToken } from '../lib/storage/sandbox_stage_token';
+
+export const sandboxBlobServeHandler = httpAction(async (ctx, req) => {
+  const url = new URL(req.url);
+  const token = url.searchParams.get('token');
+  if (!token) {
+    return new Response('Missing token', { status: 400 });
+  }
+
+  const verdict = await verifyStageToken(token);
+  if (!verdict.ok) {
+    if (verdict.reason === 'unconfigured') {
+      // The deployment carries no HMAC root — it also could not have SIGNED
+      // a token, so a request landing here is a config gap, not an attack.
+      console.warn(
+        '[sandbox-blob] refused: no WEBDAV_APP_PASSWORD_HMAC_KEY to verify with',
+      );
+      return new Response('Stage tokens unavailable', { status: 503 });
+    }
+    // malformed / bad_signature / expired all collapse to one status — a
+    // forger learns nothing about which check tripped.
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const { ref, org } = verdict.payload;
+  // `_storage` blobs stage via their own `ctx.storage.getUrl` capability
+  // URLs; this route exists solely for the bucket lane.
+  if (!isS3Ref(ref)) {
+    return new Response('Unsupported ref', { status: 400 });
+  }
+
+  // Fail closed as 404 (mirrors `/storage`): presign throws for a key outside
+  // the org's namespace and for an org with no object storage configured —
+  // neither should leak whether the object exists.
+  let presigned: string | null;
+  try {
+    presigned = await ctx.runAction(
+      internal.files.blob_actions.presignBlobGet,
+      {
+        organizationId: org,
+        ref,
+      },
+    );
+  } catch (error) {
+    console.warn(
+      `[sandbox-blob] presign refused for org ${org}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    presigned = null;
+  }
+  if (!presigned) {
+    return new Response('File not found', { status: 404 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(presigned);
+  } catch (error) {
+    console.warn(
+      `[sandbox-blob] upstream fetch failed for org ${org}:`,
+      error instanceof Error ? error.message : String(error),
+    );
+    return new Response('Upstream fetch failed', { status: 502 });
+  }
+  if (!upstream.ok || upstream.body === null) {
+    console.warn(
+      `[sandbox-blob] upstream returned ${upstream.status} for org ${org}`,
+    );
+    return new Response('Upstream fetch failed', { status: 502 });
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type':
+      upstream.headers.get('content-type') ?? 'application/octet-stream',
+  };
+  // Forward the declared length when the bucket provides it — the daemon's
+  // cheap over-cap rejection reads it before streaming a byte.
+  const contentLength = upstream.headers.get('content-length');
+  if (contentLength !== null) {
+    headers['Content-Length'] = contentLength;
+  }
+  return new Response(upstream.body, { status: 200, headers });
+});

--- a/services/platform/convex/http.ts
+++ b/services/platform/convex/http.ts
@@ -49,6 +49,7 @@ import {
   samlLoginHandler,
   samlAcsHandler,
 } from './enterprise_sso/http_handlers';
+import { sandboxBlobServeHandler } from './files/sandbox_blob_http';
 import { imageProxyHandler } from './images/http_actions';
 import {
   executeIntegrationHandler,
@@ -303,6 +304,15 @@ http.route({
   path: '/api/image-proxy',
   method: 'GET',
   handler: imageProxyHandler,
+});
+
+// Sandbox staging lane for org-bucket blobs — HMAC-token-gated, streams the
+// bytes through so the SSRF-locked session container never sees a bucket
+// credential. See files/sandbox_blob_http.ts.
+http.route({
+  path: '/api/sandbox-blob',
+  method: 'GET',
+  handler: sandboxBlobServeHandler,
 });
 
 /**

--- a/services/platform/convex/lib/attachments/workspace_uploads.test.ts
+++ b/services/platform/convex/lib/attachments/workspace_uploads.test.ts
@@ -3,9 +3,13 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { DOCUMENT_MAX_FILE_SIZE } from '../../../lib/shared/file-types';
 import type { Id } from '../../_generated/dataModel';
 import { MAX_ATTACHMENTS_PER_TURN } from '../../agents/external_agent/attachment_files';
-import { THREAD_FILE_MAX_BYTES } from '../../thread_files/schema';
+import {
+  THREAD_FILE_MAX_BYTES,
+  THREAD_WORKSPACE_MAX_BYTES,
+} from '../../thread_files/schema';
 import type { FileAttachment } from './types';
 import { buildWorkspaceUploadPlan } from './workspace_uploads';
 
@@ -49,6 +53,25 @@ describe('buildWorkspaceUploadPlan', () => {
     ]);
     expect(plan.planned.map((p) => p.path)).toEqual(['/user/uploads/ok.bin']);
     expect(plan.skipped).toEqual([{ name: 'huge.bin', reason: 'too_large' }]);
+  });
+
+  // Regression for the 30MB-log bug: a cap below the upload cap silently
+  // withheld legitimately uploaded files from the sandbox. Every file the
+  // upload gate accepts must also pass the workspace filing gate.
+  it('files anything the upload cap accepts', () => {
+    expect(THREAD_FILE_MAX_BYTES).toBeGreaterThanOrEqual(
+      DOCUMENT_MAX_FILE_SIZE,
+    );
+    expect(THREAD_WORKSPACE_MAX_BYTES).toBeGreaterThanOrEqual(
+      THREAD_FILE_MAX_BYTES,
+    );
+    const plan = buildWorkspaceUploadPlan([
+      att('upload-cap.bin', DOCUMENT_MAX_FILE_SIZE),
+    ]);
+    expect(plan.planned.map((p) => p.path)).toEqual([
+      '/user/uploads/upload-cap.bin',
+    ]);
+    expect(plan.skipped).toEqual([]);
   });
 
   it('caps the batch at the per-turn attachment limit', () => {

--- a/services/platform/convex/lib/attachments/workspace_uploads.ts
+++ b/services/platform/convex/lib/attachments/workspace_uploads.ts
@@ -112,109 +112,124 @@ export async function fileAttachmentsIntoWorkspace(
     planned.length > 0
       ? await orgSlugFromIdOrNull(ctx, args.organizationId)
       : null;
-  await Promise.all(
-    planned.map(async ({ attachment, path }) => {
-      try {
-        let bytes: Uint8Array;
-        const convexId = convexStorageId(attachment.fileId);
-        if (convexId !== null) {
-          const blob = await ctx.storage.get(convexId);
-          if (blob === null) {
-            failed += 1;
-            console.warn(
-              `[workspace_uploads] attachment blob missing for ${path} (${attachment.fileId})`,
-            );
-            return;
-          }
-          bytes = new Uint8Array(await blob.arrayBuffer());
-        } else {
-          if (orgSlug === null) {
-            failed += 1;
-            console.warn(
-              `[workspace_uploads] org unresolvable; cannot read S3 attachment for ${path}`,
-            );
-            return;
-          }
-          bytes = await readBlobBytes(ctx, orgSlug, attachment.fileId);
-        }
-        const sha256 = await sha256Hex(bytes);
-        const contentType =
-          attachment.fileType.trim().length > 0
-            ? attachment.fileType
-            : 'application/octet-stream';
-        // Re-send of unchanged bytes (regenerate, duplicate upload): skip
-        // before copying so no orphan blob is ever stored.
-        const existing = await ctx.runQuery(
-          internal.thread_files.internal_queries.getThreadFileByPath,
-          { threadId: args.workspaceThreadId, path },
-        );
-        if (
-          existing !== null &&
-          existing.sha256 === sha256 &&
-          existing.source === 'user_upload'
-        ) {
-          unchanged += 1;
+  const fileOne = async ({
+    attachment,
+    path,
+  }: WorkspaceUploadPlan['planned'][number]): Promise<void> => {
+    try {
+      let bytes: Uint8Array;
+      const convexId = convexStorageId(attachment.fileId);
+      if (convexId !== null) {
+        const blob = await ctx.storage.get(convexId);
+        if (blob === null) {
+          failed += 1;
+          console.warn(
+            `[workspace_uploads] attachment blob missing for ${path} (${attachment.fileId})`,
+          );
           return;
         }
-        // Backend-aware copy: the org's own bucket when configured, else
-        // Convex `_storage` (putBlob routes; a null slug forces `_storage`).
-        let copyId: BlobRef;
-        if (orgSlug !== null) {
-          copyId = await putBlob(ctx, orgSlug, bytes, contentType);
-        } else {
-          const ab = new ArrayBuffer(bytes.byteLength);
-          new Uint8Array(ab).set(bytes);
-          copyId = await ctx.storage.store(
-            new Blob([ab], { type: contentType }),
+        bytes = new Uint8Array(await blob.arrayBuffer());
+      } else {
+        if (orgSlug === null) {
+          failed += 1;
+          console.warn(
+            `[workspace_uploads] org unresolvable; cannot read S3 attachment for ${path}`,
           );
+          return;
         }
-        try {
-          await ctx.runMutation(
-            internal.thread_files.internal_mutations.upsertThreadFile,
-            {
-              organizationId: args.organizationId,
-              threadId: args.workspaceThreadId,
-              path,
-              storageId: copyId,
-              size: bytes.byteLength,
-              contentType,
-              sha256,
-              source: 'user_upload' as const,
-              // Only images carry a hint. Anything else stays unhinted so the
-              // viewer's inference decides — stamping 'attachment' here made
-              // every non-image upload permanently download-only, unlike the
-              // agent-written twin of the same file (#2677).
-              ...(contentType.startsWith('image/')
-                ? { renderHint: 'image' as const }
-                : {}),
-            },
-          );
-          filed += 1;
-        } catch (err) {
-          // Quota/validation rejection — reap the now-orphaned copy blob.
-          try {
-            const copyConvexId = convexStorageId(copyId);
-            if (copyConvexId !== null) {
-              await ctx.storage.delete(copyConvexId);
-            } else if (orgSlug !== null) {
-              await deleteBlob(ctx, orgSlug, copyId);
-            }
-          } catch (delErr) {
-            console.warn(
-              '[workspace_uploads] orphan copy cleanup failed:',
-              delErr,
-            );
-          }
-          throw err;
-        }
-      } catch (err) {
-        failed += 1;
-        console.warn(
-          `[workspace_uploads] filing ${path} failed (attachment still readable via chat):`,
-          err,
-        );
+        bytes = await readBlobBytes(ctx, orgSlug, attachment.fileId);
       }
-    }),
+      const sha256 = await sha256Hex(bytes);
+      const contentType =
+        attachment.fileType.trim().length > 0
+          ? attachment.fileType
+          : 'application/octet-stream';
+      // Re-send of unchanged bytes (regenerate, duplicate upload): skip
+      // before copying so no orphan blob is ever stored.
+      const existing = await ctx.runQuery(
+        internal.thread_files.internal_queries.getThreadFileByPath,
+        { threadId: args.workspaceThreadId, path },
+      );
+      if (
+        existing !== null &&
+        existing.sha256 === sha256 &&
+        existing.source === 'user_upload'
+      ) {
+        unchanged += 1;
+        return;
+      }
+      // Backend-aware copy: the org's own bucket when configured, else
+      // Convex `_storage` (putBlob routes; a null slug forces `_storage`).
+      let copyId: BlobRef;
+      if (orgSlug !== null) {
+        copyId = await putBlob(ctx, orgSlug, bytes, contentType);
+      } else {
+        const ab = new ArrayBuffer(bytes.byteLength);
+        new Uint8Array(ab).set(bytes);
+        copyId = await ctx.storage.store(new Blob([ab], { type: contentType }));
+      }
+      try {
+        await ctx.runMutation(
+          internal.thread_files.internal_mutations.upsertThreadFile,
+          {
+            organizationId: args.organizationId,
+            threadId: args.workspaceThreadId,
+            path,
+            storageId: copyId,
+            size: bytes.byteLength,
+            contentType,
+            sha256,
+            source: 'user_upload' as const,
+            // Only images carry a hint. Anything else stays unhinted so the
+            // viewer's inference decides — stamping 'attachment' here made
+            // every non-image upload permanently download-only, unlike the
+            // agent-written twin of the same file (#2677).
+            ...(contentType.startsWith('image/')
+              ? { renderHint: 'image' as const }
+              : {}),
+          },
+        );
+        filed += 1;
+      } catch (err) {
+        // Quota/validation rejection — reap the now-orphaned copy blob.
+        try {
+          const copyConvexId = convexStorageId(copyId);
+          if (copyConvexId !== null) {
+            await ctx.storage.delete(copyConvexId);
+          } else if (orgSlug !== null) {
+            await deleteBlob(ctx, orgSlug, copyId);
+          }
+        } catch (delErr) {
+          console.warn(
+            '[workspace_uploads] orphan copy cleanup failed:',
+            delErr,
+          );
+        }
+        throw err;
+      }
+    } catch (err) {
+      failed += 1;
+      console.warn(
+        `[workspace_uploads] filing ${path} failed (attachment still readable via chat):`,
+        err,
+      );
+    }
+  };
+  // Each copy holds the whole file in memory (read + sha256 + backend copy),
+  // so with the per-file cap at 100 MB an all-concurrent batch of 20 could
+  // transiently need gigabytes. Small files keep the concurrent lane (the
+  // pre-raise worst case every deployment already absorbed); large ones run
+  // one at a time.
+  const LARGE_COPY_THRESHOLD_BYTES = 10 * 1024 * 1024;
+  const smallPlanned = planned.filter(
+    (p) => p.attachment.fileSize <= LARGE_COPY_THRESHOLD_BYTES,
   );
+  const largePlanned = planned.filter(
+    (p) => p.attachment.fileSize > LARGE_COPY_THRESHOLD_BYTES,
+  );
+  await Promise.all(smallPlanned.map(fileOne));
+  for (const p of largePlanned) {
+    await fileOne(p);
+  }
   return { filed, unchanged, skipped: skipped.length + failed };
 }

--- a/services/platform/convex/lib/storage/sandbox_stage_token.test.ts
+++ b/services/platform/convex/lib/storage/sandbox_stage_token.test.ts
@@ -62,7 +62,16 @@ describe('signStageToken / verifyStageToken', () => {
   it('rejects a tampered signature and malformed tokens', async () => {
     vi.stubEnv(KEY_ENV, KEY);
     const token = (await signStageToken({ ref: REF, org: ORG })) ?? '';
-    const flipped = token.slice(0, -1) + (token.endsWith('A') ? 'B' : 'A');
+    // Flip a mid-signature base64url char — the trailing char of a 32-byte
+    // HMAC encoding only carries padding bits, so A↔B there often leaves the
+    // decoded bytes unchanged and the token still verifies.
+    const [version, payloadB64, sigB64 = ''] = token.split('.');
+    const mid = Math.floor(sigB64.length / 2);
+    const flippedSig =
+      sigB64.slice(0, mid) +
+      (sigB64[mid] === 'A' ? 'B' : 'A') +
+      sigB64.slice(mid + 1);
+    const flipped = `${version}.${payloadB64}.${flippedSig}`;
     expect((await verifyStageToken(flipped)).ok).toBe(false);
     expect(await verifyStageToken('')).toEqual({
       ok: false,

--- a/services/platform/convex/lib/storage/sandbox_stage_token.test.ts
+++ b/services/platform/convex/lib/storage/sandbox_stage_token.test.ts
@@ -1,0 +1,133 @@
+// Stage-token contract: sign/verify round-trip, tamper + expiry + key-absence
+// rejection, and the sandbox-reachable URL builder. Pure Web-Crypto — the env
+// is the only seam, stubbed per test.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildSandboxBlobStageUrl,
+  STAGE_TOKEN_TTL_MS,
+  signStageToken,
+  stageTokenSigningAvailable,
+  verifyStageToken,
+} from './sandbox_stage_token';
+
+const KEY_ENV = 'WEBDAV_APP_PASSWORD_HMAC_KEY';
+const KEY = 'ab'.repeat(32); // 64 hex chars
+const OTHER_KEY = 'cd'.repeat(32);
+const REF = 's3:org-abc/files/big.bin';
+const ORG = 'org-abc';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('signStageToken / verifyStageToken', () => {
+  it('round-trips ref, org, and expiry', async () => {
+    vi.stubEnv(KEY_ENV, KEY);
+    const now = 1_700_000_000_000;
+    const token = await signStageToken({ ref: REF, org: ORG }, now);
+    expect(token).not.toBeNull();
+    const verdict = await verifyStageToken(token ?? '', now + 1);
+    expect(verdict).toEqual({
+      ok: true,
+      payload: { ref: REF, org: ORG, exp: now + STAGE_TOKEN_TTL_MS },
+    });
+  });
+
+  it('rejects an expired token', async () => {
+    vi.stubEnv(KEY_ENV, KEY);
+    const now = 1_700_000_000_000;
+    const token = (await signStageToken({ ref: REF, org: ORG }, now)) ?? '';
+    const verdict = await verifyStageToken(token, now + STAGE_TOKEN_TTL_MS);
+    expect(verdict).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('rejects a payload swap (signature no longer matches)', async () => {
+    vi.stubEnv(KEY_ENV, KEY);
+    const token = (await signStageToken({ ref: REF, org: ORG })) ?? '';
+    const [version, , sig] = token.split('.');
+    const forged = Buffer.from(
+      JSON.stringify({ ref: 's3:victim/secret.bin', org: 'victim', exp: 9e15 }),
+      'utf8',
+    )
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const verdict = await verifyStageToken(`${version}.${forged}.${sig}`);
+    expect(verdict).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a tampered signature and malformed tokens', async () => {
+    vi.stubEnv(KEY_ENV, KEY);
+    const token = (await signStageToken({ ref: REF, org: ORG })) ?? '';
+    const flipped = token.slice(0, -1) + (token.endsWith('A') ? 'B' : 'A');
+    expect((await verifyStageToken(flipped)).ok).toBe(false);
+    expect(await verifyStageToken('')).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
+    expect(await verifyStageToken('v1.only-two')).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
+    expect(await verifyStageToken('v2.a.b')).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
+  });
+
+  it('rejects a token minted under a different key', async () => {
+    vi.stubEnv(KEY_ENV, OTHER_KEY);
+    const token = (await signStageToken({ ref: REF, org: ORG })) ?? '';
+    vi.stubEnv(KEY_ENV, KEY);
+    const verdict = await verifyStageToken(token);
+    expect(verdict).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('refuses to sign or verify without a usable HMAC root', async () => {
+    vi.stubEnv(KEY_ENV, '');
+    expect(stageTokenSigningAvailable()).toBe(false);
+    expect(await signStageToken({ ref: REF, org: ORG })).toBeNull();
+    expect(await verifyStageToken('v1.a.b')).toEqual({
+      ok: false,
+      reason: 'unconfigured',
+    });
+    // A too-short root is as good as none — refuse rather than sign weakly.
+    vi.stubEnv(KEY_ENV, 'ab'.repeat(8));
+    expect(stageTokenSigningAvailable()).toBe(false);
+    expect(await signStageToken({ ref: REF, org: ORG })).toBeNull();
+  });
+});
+
+describe('buildSandboxBlobStageUrl', () => {
+  it('builds a token URL on the sandbox-visible http-actions origin', async () => {
+    vi.stubEnv(KEY_ENV, KEY);
+    vi.stubEnv('SANDBOX_HTTP_API_BASE_URL', 'http://convex-test:9999/');
+    const url = await buildSandboxBlobStageUrl(REF, ORG);
+    expect(url).not.toBeNull();
+    const parsed = new URL(url ?? '');
+    expect(parsed.origin).toBe('http://convex-test:9999');
+    expect(parsed.pathname).toBe('/api/sandbox-blob');
+    const verdict = await verifyStageToken(
+      parsed.searchParams.get('token') ?? '',
+    );
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.payload.ref).toBe(REF);
+      expect(verdict.payload.org).toBe(ORG);
+    }
+  });
+
+  it('defaults to the convex:3211 alias', async () => {
+    vi.stubEnv(KEY_ENV, KEY);
+    const url = await buildSandboxBlobStageUrl(REF, ORG);
+    expect(url ?? '').toMatch(/^http:\/\/convex:3211\/api\/sandbox-blob\?/);
+  });
+
+  it('returns null when the deployment cannot sign', async () => {
+    vi.stubEnv(KEY_ENV, '');
+    expect(await buildSandboxBlobStageUrl(REF, ORG)).toBeNull();
+  });
+});

--- a/services/platform/convex/lib/storage/sandbox_stage_token.ts
+++ b/services/platform/convex/lib/storage/sandbox_stage_token.ts
@@ -1,0 +1,201 @@
+/**
+ * Signed capability tokens for staging org-bucket (`s3:`) blobs into sandbox
+ * sessions.
+ *
+ * A session container can only reach Convex through the sandbox-net `convex`
+ * alias — it has no route to an org's S3/R2 endpoint, and a presigned bucket
+ * URL is a bearer credential that must never enter an untrusted container.
+ * So `s3:` workspace files are staged via the `/api/sandbox-blob` httpAction
+ * (reachable at `SANDBOX_HTTP_API_BASE_URL`), which verifies one of these
+ * tokens, presigns server-side, and streams the bytes through.
+ *
+ * Token: `v1.<b64url(payload)>.<b64url(hmac)>` where payload is
+ * `{ref, org, exp}` and the signature is HMAC-SHA256 over `v1.<b64url(payload)>`
+ * with a purpose-derived subkey, so a token grants exactly one blob in one
+ * org's bucket for a few minutes — nothing else, and nothing if it leaks
+ * after expiry.
+ *
+ * Key: derived from the deployment HMAC root `WEBDAV_APP_PASSWORD_HMAC_KEY`
+ * (itself derived from INSTANCE_SECRET at boot — see lib/webdav/hmac-key.ts;
+ * despite the WebDAV-scoped name it is the deployment-wide HMAC secret every
+ * install already carries, and reusing it means zero new env plumbing). The
+ * subkey is sha256("<root>:sandbox-blob-stage:v1"), so a compromise of one
+ * domain's derived key never crosses into the other.
+ *
+ * Pure Web-Crypto — usable from both the Convex isolate (the httpAction
+ * verifier) and node actions (the session-exec signer).
+ */
+
+const TOKEN_VERSION = 'v1';
+const KEY_DERIVATION_CONTEXT = 'sandbox-blob-stage:v1';
+/** Staging URLs are consumed by the daemon within the same exec call; 10
+ * minutes absorbs a slow multi-hundred-MB stage without leaving a long-lived
+ * bearer lying around in spawner logs. */
+export const STAGE_TOKEN_TTL_MS = 10 * 60 * 1000;
+
+export interface StageTokenPayload {
+  /** Blob reference — an `s3:<key>` ref (the `_storage` lane has its own
+   * capability URLs via `ctx.storage.getUrl`). */
+  ref: string;
+  /** Better Auth organization id owning the bucket — the presign step
+   * re-checks the key belongs to this org's namespace. */
+  org: string;
+  /** Expiry, epoch ms. */
+  exp: number;
+}
+
+function b64urlEncode(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlDecode(s: string): Uint8Array | null {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/');
+  try {
+    const bin = atob(padded);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function utf8(s: string): Uint8Array<ArrayBuffer> {
+  const encoded = new TextEncoder().encode(s);
+  const buf = new ArrayBuffer(encoded.byteLength);
+  new Uint8Array(buf).set(encoded);
+  return new Uint8Array(buf);
+}
+
+/** Constant-time comparison — a plain `===` on the signature would leak a
+ * byte-position oracle to a forger timing the route. */
+function timingSafeEqualBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  return diff === 0;
+}
+
+/** The deployment HMAC root this module derives its subkey from. `null` when
+ * the deployment carries no HMAC root (minimal dev setups) — signing callers
+ * fall back to the bounded inline-staging lane, the verifier refuses. */
+function hmacRoot(): string | null {
+  const raw = process.env.WEBDAV_APP_PASSWORD_HMAC_KEY;
+  if (!raw || raw.length < 64) return null;
+  return raw;
+}
+
+export function stageTokenSigningAvailable(): boolean {
+  return hmacRoot() !== null;
+}
+
+async function deriveKey(root: string): Promise<CryptoKey> {
+  const keyBytes = await crypto.subtle.digest(
+    'SHA-256',
+    utf8(`${root}:${KEY_DERIVATION_CONTEXT}`),
+  );
+  return crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+async function signMessage(root: string, message: string): Promise<Uint8Array> {
+  const key = await deriveKey(root);
+  const sig = await crypto.subtle.sign('HMAC', key, utf8(message));
+  return new Uint8Array(sig);
+}
+
+/** Mint a stage token for one blob. Returns `null` when the deployment has no
+ * HMAC root to sign with. `now` is injectable for tests. */
+export async function signStageToken(
+  payload: { ref: string; org: string },
+  now: number = Date.now(),
+): Promise<string | null> {
+  const root = hmacRoot();
+  if (root === null) return null;
+  const full: StageTokenPayload = {
+    ref: payload.ref,
+    org: payload.org,
+    exp: now + STAGE_TOKEN_TTL_MS,
+  };
+  const payloadB64 = b64urlEncode(utf8(JSON.stringify(full)));
+  const message = `${TOKEN_VERSION}.${payloadB64}`;
+  const sig = await signMessage(root, message);
+  return `${message}.${b64urlEncode(sig)}`;
+}
+
+export type StageTokenVerdict =
+  | { ok: true; payload: StageTokenPayload }
+  | {
+      ok: false;
+      reason: 'unconfigured' | 'malformed' | 'bad_signature' | 'expired';
+    };
+
+/** Verify a stage token. Signature is checked BEFORE expiry so the two
+ * failure modes are indistinguishable in timing to a forger. */
+export async function verifyStageToken(
+  token: string,
+  now: number = Date.now(),
+): Promise<StageTokenVerdict> {
+  const root = hmacRoot();
+  if (root === null) return { ok: false, reason: 'unconfigured' };
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[0] !== TOKEN_VERSION) {
+    return { ok: false, reason: 'malformed' };
+  }
+  const [, payloadB64, sigB64] = parts;
+  const sigBytes = b64urlDecode(sigB64 ?? '');
+  if (sigBytes === null) return { ok: false, reason: 'malformed' };
+  const expected = await signMessage(root, `${TOKEN_VERSION}.${payloadB64}`);
+  if (!timingSafeEqualBytes(sigBytes, expected)) {
+    return { ok: false, reason: 'bad_signature' };
+  }
+  const payloadBytes = b64urlDecode(payloadB64 ?? '');
+  if (payloadBytes === null) return { ok: false, reason: 'malformed' };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(payloadBytes));
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as { ref?: unknown }).ref !== 'string' ||
+    typeof (parsed as { org?: unknown }).org !== 'string' ||
+    typeof (parsed as { exp?: unknown }).exp !== 'number'
+  ) {
+    return { ok: false, reason: 'malformed' };
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shape validated field-by-field above
+  const payload = parsed as StageTokenPayload;
+  if (payload.exp <= now) return { ok: false, reason: 'expired' };
+  return { ok: true, payload };
+}
+
+/**
+ * Build the sandbox-reachable staging URL for an `s3:` blob: the
+ * `/api/sandbox-blob` httpAction on the Convex http-actions origin as seen
+ * from INSIDE the sandbox network (`convex:3211` by default — in prod the
+ * convex container is dual-homed onto the sandbox net; in dev the
+ * `convex-relay` socat bridges it to the host-run backend; override with
+ * SANDBOX_HTTP_API_BASE_URL for non-standard topologies). Returns `null`
+ * when no HMAC root is configured.
+ */
+export async function buildSandboxBlobStageUrl(
+  ref: string,
+  organizationId: string,
+): Promise<string | null> {
+  const token = await signStageToken({ ref, org: organizationId });
+  if (token === null) return null;
+  const base = (
+    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://convex:3211'
+  ).replace(/\/$/, '');
+  return `${base}/api/sandbox-blob?token=${encodeURIComponent(token)}`;
+}

--- a/services/platform/convex/node_only/sandbox/helpers/stage_url.ts
+++ b/services/platform/convex/node_only/sandbox/helpers/stage_url.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve a blob reference to a URL the in-container runnerd daemon can fetch
+ * over the sandbox-net `convex` alias — the ONE way any workspace/input blob
+ * gets staged into a session by URL:
+ *
+ * - Convex `_storage` id → its capability URL, origin-rewritten to the alias.
+ * - Org-bucket `s3:` ref → the token-gated `/api/sandbox-blob` stream route
+ *   (the sandbox net has no route to the bucket, and a presigned bucket URL
+ *   must never enter the container).
+ *
+ * Returns `null` when the blob cannot be staged by URL: the `_storage` bytes
+ * are gone, or the deployment has no HMAC root to sign a stage token with.
+ * Callers own the skip-vs-fail policy (chat run_code additionally keeps a
+ * bounded inline-base64 fallback lane — see session_exec.ts).
+ */
+
+import type { ActionCtx } from '../../../_generated/server';
+import { toSandboxStorageUrl } from '../../../lib/helpers/public_storage_url';
+import { convexStorageId } from '../../../lib/storage/blob_ref';
+import { buildSandboxBlobStageUrl } from '../../../lib/storage/sandbox_stage_token';
+
+export async function stageUrlForBlobRef(
+  ctx: Pick<ActionCtx, 'storage'>,
+  ref: string,
+  organizationId: string,
+): Promise<string | null> {
+  const cid = convexStorageId(ref);
+  if (cid !== null) {
+    const raw = await ctx.storage.getUrl(cid);
+    return raw === null ? null : toSandboxStorageUrl(raw);
+  }
+  return buildSandboxBlobStageUrl(ref, organizationId);
+}

--- a/services/platform/convex/node_only/sandbox/session_exec.test.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.test.ts
@@ -1,27 +1,51 @@
 // Inline-snippet staging contract (pure functions), the executeCodeInSession
-// arg mutex, and runStepsInSession's install semantics — pip/npm exit codes
+// arg mutex, runStepsInSession's install semantics — pip/npm exit codes
 // must fail the run (INSTALL_FAILED) and installs get their own floored
-// budget. The session wire is mocked at the session_client boundary, the same
-// seam the crawler render tests use.
+// budget — plus the workspace staging plan's lane routing and the harvest's
+// per-file skip semantics. The session wire is mocked at the session_client
+// boundary, the same seam the crawler render tests use.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ActionCtx } from '../../_generated/server';
 
 const drainSessionExecResilient = vi.fn();
+const sessionListFiles = vi.fn();
+const sessionReadFile = vi.fn();
 
 vi.mock('./helpers/session_client', () => ({
   drainSessionExecResilient: (...args: unknown[]) =>
     drainSessionExecResilient(...args),
   sessionDeleteFiles: vi.fn(),
-  sessionListFiles: vi.fn().mockResolvedValue([]),
-  sessionReadFile: vi.fn(),
+  sessionListFiles: (...args: unknown[]) => sessionListFiles(...args),
+  sessionReadFile: (...args: unknown[]) => sessionReadFile(...args),
   sessionStageFiles: vi.fn(),
+}));
+
+const readBlobBytes = vi.fn();
+const putBlob = vi.fn();
+const deleteBlob = vi.fn();
+
+vi.mock('../../lib/storage/blob_access', () => ({
+  readBlobBytes: (...args: unknown[]) => readBlobBytes(...args),
+  putBlob: (...args: unknown[]) => putBlob(...args),
+  deleteBlob: (...args: unknown[]) => deleteBlob(...args),
+}));
+
+const orgSlugFromIdOrNull = vi.fn();
+
+vi.mock('../../lib/helpers/org_slug', () => ({
+  orgSlugFromIdOrNull: (...args: unknown[]) => orgSlugFromIdOrNull(...args),
 }));
 
 import {
   execInputsError,
   inlineStagePath,
+  planWorkspaceStaging,
+  runAndHarvestInSession,
   runStepsInSession,
   stagePathOf,
+  type WorkspaceStageRow,
 } from './session_exec';
 
 describe('inlineStagePath', () => {
@@ -241,5 +265,272 @@ describe('runStepsInSession — install semantics', () => {
       packagesByLang: { python: ['pandas'] },
     });
     expect(run.stdout).toBe('report written\n');
+  });
+});
+
+const HMAC_ENV = 'WEBDAV_APP_PASSWORD_HMAC_KEY';
+const ORG = 'org-1';
+
+function stageRow(over: Partial<WorkspaceStageRow>): WorkspaceStageRow {
+  return {
+    organizationId: ORG,
+    path: '/user/uploads/a.txt',
+    storageId: 'kg-convex-id',
+    size: 5,
+    source: 'user_upload',
+    ...over,
+  };
+}
+
+function stagingCtx(getUrl: (id: string) => Promise<string | null>) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- only `storage.getUrl` is exercised by the plan
+  return { storage: { getUrl } } as unknown as ActionCtx;
+}
+
+describe('planWorkspaceStaging — lane routing', () => {
+  beforeEach(() => {
+    readBlobBytes.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('stages a _storage blob by its alias-rewritten capability URL', async () => {
+    const ctx = stagingCtx(async () => 'http://127.0.0.1:3210/api/storage/u1');
+    const plan = await planWorkspaceStaging(ctx, [stageRow({})], {
+      organizationId: ORG,
+      includeRunOutputs: true,
+      stageOrgSlug: 'acme',
+    });
+    expect(plan.toStage).toEqual([
+      { path: 'uploads/a.txt', url: 'http://convex:3210/api/storage/u1' },
+    ]);
+    expect(plan.stagingSkipped).toEqual([]);
+  });
+
+  it('reports a purged _storage blob instead of dropping it silently', async () => {
+    const ctx = stagingCtx(async () => null);
+    const plan = await planWorkspaceStaging(ctx, [stageRow({})], {
+      organizationId: ORG,
+      includeRunOutputs: true,
+      stageOrgSlug: 'acme',
+    });
+    expect(plan.toStage).toEqual([]);
+    expect(plan.stagingSkipped).toEqual([
+      { path: '/user/uploads/a.txt', reason: 'stored bytes are missing' },
+    ]);
+  });
+
+  it('stages an org-bucket blob via the token-gated stream route', async () => {
+    vi.stubEnv(HMAC_ENV, 'ab'.repeat(32));
+    const ctx = stagingCtx(async () => {
+      throw new Error('getUrl must not be called for an s3 ref');
+    });
+    const plan = await planWorkspaceStaging(
+      ctx,
+      [
+        stageRow({
+          path: '/user/uploads/big.bin',
+          storageId: 's3:acme/big-object',
+          size: 30 * 1024 * 1024,
+        }),
+      ],
+      { organizationId: ORG, includeRunOutputs: true, stageOrgSlug: 'acme' },
+    );
+    expect(plan.stagingSkipped).toEqual([]);
+    expect(plan.toStage).toHaveLength(1);
+    expect(plan.toStage[0].path).toBe('uploads/big.bin');
+    expect(plan.toStage[0].url).toMatch(
+      /^http:\/\/convex:3211\/api\/sandbox-blob\?token=/,
+    );
+  });
+
+  it('falls back to bounded inline base64 when no stage-token key exists', async () => {
+    vi.stubEnv(HMAC_ENV, '');
+    readBlobBytes.mockResolvedValue(new TextEncoder().encode('hello'));
+    const ctx = stagingCtx(async () => null);
+    const plan = await planWorkspaceStaging(
+      ctx,
+      [
+        stageRow({
+          path: '/user/uploads/small.bin',
+          storageId: 's3:acme/small-object',
+          size: 5,
+        }),
+        stageRow({
+          path: '/user/uploads/big.bin',
+          storageId: 's3:acme/big-object',
+          size: 2 * 1024 * 1024,
+        }),
+      ],
+      { organizationId: ORG, includeRunOutputs: true, stageOrgSlug: 'acme' },
+    );
+    expect(plan.toStage).toEqual([
+      {
+        path: 'uploads/small.bin',
+        contentBase64: Buffer.from('hello').toString('base64'),
+      },
+    ]);
+    expect(plan.stagingSkipped).toHaveLength(1);
+    expect(plan.stagingSkipped[0].path).toBe('/user/uploads/big.bin');
+    expect(plan.stagingSkipped[0].reason).toContain('inline staging cap');
+  });
+
+  it('reports unresolvable orgs and failed bucket reads as skips', async () => {
+    vi.stubEnv(HMAC_ENV, '');
+    readBlobBytes.mockRejectedValue(new Error('bucket down'));
+    const ctx = stagingCtx(async () => null);
+    const noSlug = await planWorkspaceStaging(
+      ctx,
+      [stageRow({ storageId: 's3:acme/x', size: 5 })],
+      { organizationId: ORG, includeRunOutputs: true, stageOrgSlug: null },
+    );
+    expect(noSlug.stagingSkipped[0].reason).toContain('unresolvable');
+    const readFail = await planWorkspaceStaging(
+      ctx,
+      [stageRow({ storageId: 's3:acme/x', size: 5 })],
+      { organizationId: ORG, includeRunOutputs: true, stageOrgSlug: 'acme' },
+    );
+    expect(readFail.stagingSkipped[0].reason).toContain(
+      'reading the org-bucket bytes failed',
+    );
+  });
+
+  it('filters cross-org rows and warm-session run_outputs entirely', async () => {
+    const ctx = stagingCtx(async () => 'http://127.0.0.1:3210/api/storage/u1');
+    const plan = await planWorkspaceStaging(
+      ctx,
+      [
+        stageRow({ organizationId: 'someone-else' }),
+        stageRow({ path: '/user/output/old.txt', source: 'run_output' }),
+        stageRow({ path: '/user/code/gen.py', source: 'agent_write' }),
+      ],
+      { organizationId: ORG, includeRunOutputs: false, stageOrgSlug: 'acme' },
+    );
+    expect(plan.toStage.map((f) => f.path)).toEqual(['code/gen.py']);
+    expect(plan.stagingSkipped).toEqual([]);
+  });
+});
+
+function harvestCtx(over: {
+  runQuery?: ReturnType<typeof vi.fn>;
+  runMutation?: ReturnType<typeof vi.fn>;
+  store?: ReturnType<typeof vi.fn>;
+  storageDelete?: ReturnType<typeof vi.fn>;
+}) {
+  const ctx = {
+    runQuery: over.runQuery ?? vi.fn().mockResolvedValue(null),
+    runMutation:
+      over.runMutation ??
+      vi.fn().mockResolvedValue({ id: 'row', replaced: false }),
+    storage: {
+      store: over.store ?? vi.fn().mockResolvedValue('kg-stored'),
+      delete: over.storageDelete ?? vi.fn(),
+    },
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- harvest touches only these ctx members
+  return ctx as unknown as ActionCtx;
+}
+
+function outputEntry(name: string, size = 5) {
+  return { name, type: 'file' as const, size, mtimeMs: 0 };
+}
+
+function textBytes(s: string): { bytes: ArrayBuffer; contentType: string } {
+  const encoded = new TextEncoder().encode(s);
+  const buf = new ArrayBuffer(encoded.byteLength);
+  new Uint8Array(buf).set(encoded);
+  return { bytes: buf, contentType: 'text/plain' };
+}
+
+describe('runAndHarvestInSession — per-file harvest skips', () => {
+  beforeEach(() => {
+    drainSessionExecResilient.mockReset();
+    drainSessionExecResilient.mockResolvedValue(execResult());
+    sessionListFiles.mockReset();
+    sessionReadFile.mockReset();
+    orgSlugFromIdOrNull.mockReset();
+    orgSlugFromIdOrNull.mockResolvedValue(null);
+  });
+
+  const runArgs = {
+    organizationId: ORG,
+    workspaceThreadId: 'thread-1',
+    sessionId: 'sid',
+    stepPaths: ['/user/code/a.py'],
+  };
+
+  it('skips an over-cap output without reading it and keeps the run green', async () => {
+    sessionListFiles.mockResolvedValue([
+      outputEntry('big.bin', 25 * 1024 * 1024),
+      outputEntry('ok.txt'),
+    ]);
+    sessionReadFile.mockResolvedValue(textBytes('hello'));
+    const ctx = harvestCtx({});
+    const run = await runAndHarvestInSession(ctx, runArgs);
+    expect(run.status).toBe('completed');
+    expect(run.files.map((f) => f.path)).toEqual(['/user/output/ok.txt']);
+    expect(run.harvestSkipped).toHaveLength(1);
+    expect(run.harvestSkipped?.[0].path).toBe('/user/output/big.bin');
+    expect(run.harvestSkipped?.[0].reason).toContain('20.0 MB');
+    // The oversize file was never pulled across the wire.
+    expect(sessionReadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns a workspace-quota rejection into a skip + blob reap, not a run failure', async () => {
+    sessionListFiles.mockResolvedValue([
+      outputEntry('a.txt'),
+      outputEntry('b.txt'),
+    ]);
+    sessionReadFile
+      .mockResolvedValueOnce(textBytes('content-a'))
+      .mockResolvedValueOnce(textBytes('content-b'));
+    const store = vi
+      .fn()
+      .mockResolvedValueOnce('kg-a')
+      .mockResolvedValueOnce('kg-b');
+    const runMutation = vi.fn(
+      async (_ref: unknown, mutArgs: Record<string, unknown>) => {
+        if (mutArgs.path === '/user/output/a.txt') {
+          throw new Error('Workspace would exceed the byte cap.');
+        }
+        return { id: 'row', replaced: false };
+      },
+    );
+    const storageDelete = vi.fn();
+    const ctx = harvestCtx({ store, runMutation, storageDelete });
+    const run = await runAndHarvestInSession(ctx, runArgs);
+    expect(run.status).toBe('completed');
+    expect(run.files.map((f) => f.path)).toEqual(['/user/output/b.txt']);
+    expect(run.harvestSkipped).toHaveLength(1);
+    expect(run.harvestSkipped?.[0].path).toBe('/user/output/a.txt');
+    expect(run.harvestSkipped?.[0].reason).toContain(
+      'not saved to the workspace',
+    );
+    // The orphaned copy of a.txt was reaped; b.txt's blob stayed.
+    expect(storageDelete).toHaveBeenCalledWith('kg-a');
+    expect(storageDelete).not.toHaveBeenCalledWith('kg-b');
+  });
+
+  it('reports files beyond the per-run cap and unreadable files', async () => {
+    const many = Array.from({ length: 18 }, (_, i) => outputEntry(`f${i}.txt`));
+    sessionListFiles.mockResolvedValue(many);
+    sessionReadFile.mockImplementation(async (_sid: string, path: string) =>
+      path === '/user/output/f3.txt' ? null : textBytes('x'),
+    );
+    const ctx = harvestCtx({});
+    const run = await runAndHarvestInSession(ctx, runArgs);
+    expect(run.status).toBe('completed');
+    // The 16-slot cap counts HARVESTED files: f3's read failure frees a slot,
+    // so 16 of the remaining 17 land and the last (f17) reports the cap.
+    expect(run.files).toHaveLength(16);
+    expect(run.harvestSkipped).toHaveLength(2);
+    expect(
+      run.harvestSkipped?.find((s) => s.path === '/user/output/f3.txt')?.reason,
+    ).toContain('read from sandbox failed');
+    expect(
+      run.harvestSkipped?.find((s) => s.path === '/user/output/f17.txt')
+        ?.reason,
+    ).toContain('per-run harvest cap');
   });
 });

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -32,8 +32,13 @@ import {
 } from '../../agent_tools/files/_shared';
 import { orgSlugFromIdOrNull } from '../../lib/helpers/org_slug';
 import { toSandboxStorageUrl } from '../../lib/helpers/public_storage_url';
-import { putBlob, readBlobBytes } from '../../lib/storage/blob_access';
+import {
+  deleteBlob,
+  putBlob,
+  readBlobBytes,
+} from '../../lib/storage/blob_access';
 import { convexStorageId, type BlobRef } from '../../lib/storage/blob_ref';
+import { buildSandboxBlobStageUrl } from '../../lib/storage/sandbox_stage_token';
 import {
   drainSessionExecResilient,
   sessionDeleteFiles,
@@ -44,6 +49,22 @@ import {
 
 const SANDBOX_MAX_OUTPUT_FILES_PER_RUN = 16;
 const OUTPUT_DIR = '/user/output';
+
+/** Read-back ceiling per harvested output file — mirror of the runnerd
+ * daemon's FILE_READ_MAX_BYTES (services/sandbox-runtime/daemon/src/main.ts);
+ * keep the two in sync. Checked against the listing size BEFORE reading so an
+ * oversize output is reported as skipped instead of surfacing as an opaque
+ * read failure. */
+const HARVEST_READ_MAX_BYTES = 20 * 1024 * 1024;
+
+/** Inline-staging ceiling for the no-stage-token fallback lane — mirror of
+ * the runnerd daemon's INLINE_MAX_BYTES (1 MB decoded; its base64 form also
+ * has to fit the 1.5 MB per-request stage budget in session_client). */
+const INLINE_STAGE_MAX_BYTES = 1 * 1024 * 1024;
+
+function formatMb(n: number): string {
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 /** Hidden staging area for inline `run_code` snippets, under the executable
  * `/user/code` surface but never a threadFile — so it is invisible to
@@ -95,6 +116,15 @@ export interface SessionExecResultShape {
     size: number;
     contentType: string;
   }>;
+  /** Workspace files that could NOT be staged into the container (org-bucket
+   * blob over the inline cap on a deployment without stage tokens, a missing
+   * blob, a daemon-side refusal). The run still executes — scripts just don't
+   * see these paths; surfaced on the run_code result so the model knows. */
+  stagingSkipped?: Array<{ path: string; reason: string }>;
+  /** `/user/output` files that could NOT be harvested back (over the
+   * read-back cap, rejected by the workspace quota, storage failure). The
+   * run itself still succeeds; surfaced on the run_code result. */
+  harvestSkipped?: Array<{ path: string; reason: string }>;
 }
 
 function interpreterCommand(absPath: string): string[] | null {
@@ -236,6 +266,110 @@ export async function runStepsInSession(
   };
 }
 
+export interface WorkspaceStageRow {
+  organizationId: string;
+  path: string;
+  storageId: BlobRef;
+  size: number;
+  source: 'user_upload' | 'agent_write' | 'run_output';
+}
+
+/**
+ * Decide how each workspace row reaches the container — exported for unit
+ * tests; {@link executeCodeInSession} is the sole production caller.
+ *
+ * Both primary lanes are URL fetches by the in-container daemon over the
+ * sandbox-reachable `convex` alias (capped at its 100 MB FETCH_MAX_BYTES): a
+ * Convex `_storage` blob by its capability URL, an org-bucket `s3:` blob via
+ * the token-gated `/api/sandbox-blob` stream route (the sandbox net has no
+ * route to the org's S3 endpoint, and a presigned bucket URL must never enter
+ * the container). Deployments without an HMAC root to sign stage tokens fall
+ * back to inline base64, bounded by the daemon's 1 MB inline cap. Whatever
+ * cannot be staged lands in `stagingSkipped` and is surfaced on the run
+ * result — the model must never be left guessing why a listed workspace file
+ * is absent.
+ */
+export async function planWorkspaceStaging(
+  ctx: ActionCtx,
+  rows: WorkspaceStageRow[],
+  opts: {
+    organizationId: string;
+    /** Fresh session ⇒ true: re-stage prior `run_output` files too; a warm
+     * session already has them on disk. */
+    includeRunOutputs: boolean;
+    stageOrgSlug: string | null;
+  },
+): Promise<{
+  toStage: Array<{ path: string; url?: string; contentBase64?: string }>;
+  stagingSkipped: Array<{ path: string; reason: string }>;
+}> {
+  const toStage: Array<{ path: string; url?: string; contentBase64?: string }> =
+    [];
+  const stagingSkipped: Array<{ path: string; reason: string }> = [];
+  for (const r of rows) {
+    if (r.organizationId !== opts.organizationId) continue;
+    if (r.source === 'run_output' && !opts.includeRunOutputs) continue;
+    const rowConvexId = convexStorageId(r.storageId);
+    if (rowConvexId !== null) {
+      const raw = await ctx.storage.getUrl(rowConvexId);
+      if (raw === null) {
+        stagingSkipped.push({
+          path: r.path,
+          reason: 'stored bytes are missing',
+        });
+        continue;
+      }
+      toStage.push({
+        path: stagePathOf(r.path),
+        url: toSandboxStorageUrl(raw),
+      });
+      continue;
+    }
+    const stageUrl = await buildSandboxBlobStageUrl(
+      String(r.storageId),
+      opts.organizationId,
+    );
+    if (stageUrl !== null) {
+      toStage.push({ path: stagePathOf(r.path), url: stageUrl });
+      continue;
+    }
+    // No HMAC root to sign a stage token with — legacy inline lane.
+    if (opts.stageOrgSlug === null) {
+      stagingSkipped.push({
+        path: r.path,
+        reason: 'organization unresolvable for its storage bucket',
+      });
+      continue;
+    }
+    if (r.size > INLINE_STAGE_MAX_BYTES) {
+      stagingSkipped.push({
+        path: r.path,
+        reason: `${formatMb(r.size)} org-bucket file exceeds the ${formatMb(
+          INLINE_STAGE_MAX_BYTES,
+        )} inline staging cap (no stage-token key configured on this deployment)`,
+      });
+      continue;
+    }
+    try {
+      const bytes = await readBlobBytes(ctx, opts.stageOrgSlug, r.storageId);
+      toStage.push({
+        path: stagePathOf(r.path),
+        contentBase64: Buffer.from(bytes).toString('base64'),
+      });
+    } catch (err) {
+      console.warn(
+        `[session_exec] S3 thread-file read failed for ${r.path}:`,
+        err instanceof Error ? err.message : err,
+      );
+      stagingSkipped.push({
+        path: r.path,
+        reason: 'reading the org-bucket bytes failed',
+      });
+    }
+  }
+  return { toStage, stagingSkipped };
+}
+
 /**
  * Session-exec + threadFiles harvest: run `stepPaths` via {@link
  * runStepsInSession}, then harvest top-level `/user/output` — storing only
@@ -279,22 +413,48 @@ export async function runAndHarvestInSession(
   // Harvest top-level /user/output, upserting only new/changed files (sha256).
   // Install-only runs skip it — an install can't produce deliverables, and the
   // sha256 dedupe would re-read every existing output file for nothing.
+  // A file that CANNOT come back (over the read cap, workspace quota, storage
+  // hiccup) is recorded in `harvestSkipped` and never fails the run — the
+  // script did its work; losing the whole result over one oversize deliverable
+  // punished exactly the successful case.
   const files: Array<{
     path: string;
     storageId: string;
     size: number;
     contentType: string;
   }> = [];
+  const harvestSkipped: Array<{ path: string; reason: string }> = [];
   const entries =
     args.stepPaths.length === 0
       ? []
       : ((await sessionListFiles(sessionId, OUTPUT_DIR)) ?? []);
   for (const e of entries) {
     if (e.type !== 'file') continue;
-    if (files.length >= SANDBOX_MAX_OUTPUT_FILES_PER_RUN) break;
     const absPath = `${OUTPUT_DIR}/${e.name}`;
+    if (files.length >= SANDBOX_MAX_OUTPUT_FILES_PER_RUN) {
+      harvestSkipped.push({
+        path: absPath,
+        reason: `over the ${SANDBOX_MAX_OUTPUT_FILES_PER_RUN}-file per-run harvest cap`,
+      });
+      continue;
+    }
+    if (e.size > HARVEST_READ_MAX_BYTES) {
+      harvestSkipped.push({
+        path: absPath,
+        reason: `${formatMb(e.size)} exceeds the ${formatMb(
+          HARVEST_READ_MAX_BYTES,
+        )} per-file harvest cap — split the output or have the user download it another way`,
+      });
+      continue;
+    }
     const read = await sessionReadFile(sessionId, absPath);
-    if (read === null) continue;
+    if (read === null) {
+      harvestSkipped.push({
+        path: absPath,
+        reason: 'read from sandbox failed',
+      });
+      continue;
+    }
     const buf = Buffer.from(read.bytes);
     const sha256 = createHash('sha256').update(buf).digest('hex');
     const existing = await ctx.runQuery(
@@ -317,28 +477,52 @@ export async function runAndHarvestInSession(
     const ab = new ArrayBuffer(buf.byteLength);
     new Uint8Array(ab).set(buf);
     const harvestBytes = new Uint8Array(ab);
-    let storageId: BlobRef;
-    if (orgSlug !== null) {
-      storageId = await putBlob(ctx, orgSlug, harvestBytes, contentType);
-    } else {
-      storageId = await ctx.storage.store(
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
-        new Blob([harvestBytes as BlobPart], { type: contentType }),
+    let storageId: BlobRef | null = null;
+    try {
+      if (orgSlug !== null) {
+        storageId = await putBlob(ctx, orgSlug, harvestBytes, contentType);
+      } else {
+        storageId = await ctx.storage.store(
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
+          new Blob([harvestBytes as BlobPart], { type: contentType }),
+        );
+      }
+      await ctx.runMutation(
+        internal.thread_files.internal_mutations.upsertThreadFile,
+        {
+          organizationId,
+          threadId: workspaceThreadId,
+          path: absPath,
+          storageId,
+          size: buf.byteLength,
+          contentType,
+          sha256,
+          source: 'run_output' as const,
+        },
       );
-    }
-    await ctx.runMutation(
-      internal.thread_files.internal_mutations.upsertThreadFile,
-      {
-        organizationId,
-        threadId: workspaceThreadId,
+    } catch (err) {
+      // Quota/validation rejection after the blob copy — reap the orphan
+      // (mirrors workspace_uploads' filing reap).
+      if (storageId !== null) {
+        try {
+          const copyConvexId = convexStorageId(storageId);
+          if (copyConvexId !== null) {
+            await ctx.storage.delete(copyConvexId);
+          } else if (orgSlug !== null) {
+            await deleteBlob(ctx, orgSlug, storageId);
+          }
+        } catch (delErr) {
+          console.warn('[session_exec] harvest orphan cleanup failed:', delErr);
+        }
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[session_exec] harvest skipped ${absPath}: ${message}`);
+      harvestSkipped.push({
         path: absPath,
-        storageId,
-        size: buf.byteLength,
-        contentType,
-        sha256,
-        source: 'run_output' as const,
-      },
-    );
+        reason: `not saved to the workspace: ${message}`,
+      });
+      continue;
+    }
     // A fileMetadata row per harvested blob (was a documented follow-up): a
     // follow-up consumer of the storage id — e.g. a workflow `document.create`
     // filing a produced artifact — resolves name/type through fileMetadata and
@@ -380,6 +564,7 @@ export async function runAndHarvestInSession(
     stderrPreview: run.stderr.slice(0, 4096),
     durationMs: Date.now() - startedAt,
     files,
+    ...(harvestSkipped.length > 0 && { harvestSkipped }),
   };
 }
 
@@ -455,6 +640,12 @@ export const executeCodeInSession = internalAction({
         contentType: v.string(),
       }),
     ),
+    stagingSkipped: v.optional(
+      v.array(v.object({ path: v.string(), reason: v.string() })),
+    ),
+    harvestSkipped: v.optional(
+      v.array(v.object({ path: v.string(), reason: v.string() })),
+    ),
   }),
   handler: async (ctx, args): Promise<SessionExecResultShape> => {
     const inputsError = execInputsError(args);
@@ -471,57 +662,25 @@ export const executeCodeInSession = internalAction({
     // Stage inputs. On a fresh session, reconstruct the whole workspace from
     // threadFiles; on a warm/resumed one, only re-stage the mutable inputs
     // (scripts/uploads) — prior `run_output` files persist in the workspace.
-    //
-    // Backend split: a Convex `_storage` blob is staged by URL (the
-    // in-container daemon fetches it over the sandbox-reachable `convex`
-    // alias). An `s3:` blob CANNOT be fetched from the sandbox — the
-    // `--internal` sandbox net has no route to the org's S3 endpoint — so its
-    // bytes are read here (node) and staged inline as base64 (bounded by the
-    // 10 MB THREAD_FILE_MAX_BYTES cap on every workspace file).
+    // Lane routing (storage-backend split, inline fallback, skip surfacing)
+    // lives in `planWorkspaceStaging` above.
     const rows = await ctx.runQuery(
       internal.thread_files.internal_queries.listThreadFiles,
       { threadId: args.threadId },
     );
     const stageOrgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
-    const toStage: {
-      path: string;
-      url?: string;
-      contentBase64?: string;
-    }[] = [];
-    for (const r of rows as Array<{
-      organizationId: string;
-      path: string;
-      storageId: BlobRef;
-      source: 'user_upload' | 'agent_write' | 'run_output';
-    }>) {
-      if (r.organizationId !== args.organizationId) continue;
-      if (r.source === 'run_output' && !created) continue;
-      const rowConvexId = convexStorageId(r.storageId);
-      if (rowConvexId !== null) {
-        const raw = await ctx.storage.getUrl(rowConvexId);
-        if (raw === null) continue;
-        toStage.push({
-          path: stagePathOf(r.path),
-          url: toSandboxStorageUrl(raw),
-        });
-        continue;
-      }
-      if (stageOrgSlug === null) continue;
-      try {
-        const bytes = await readBlobBytes(ctx, stageOrgSlug, r.storageId);
-        toStage.push({
-          path: stagePathOf(r.path),
-          contentBase64: Buffer.from(bytes).toString('base64'),
-        });
-      } catch (err) {
-        console.warn(
-          `[session_exec] S3 thread-file read failed for ${r.path}:`,
-          err instanceof Error ? err.message : err,
-        );
-      }
-    }
+    const { toStage, stagingSkipped } = await planWorkspaceStaging(
+      ctx,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- listThreadFiles codegen rows
+      rows as WorkspaceStageRow[],
+      {
+        organizationId: args.organizationId,
+        includeRunOutputs: created,
+        stageOrgSlug,
+      },
+    );
     if (toStage.length > 0) {
-      await sessionStageFiles(
+      const stageResult = await sessionStageFiles(
         sessionId,
         toStage.map((f) =>
           f.url !== undefined
@@ -529,6 +688,14 @@ export const executeCodeInSession = internalAction({
             : { path: f.path, contentBase64: f.contentBase64 ?? '' },
         ),
       );
+      // Daemon-side refusals (unsafe path, fetch failure, over the fetch cap)
+      // were previously discarded — carry them into the surfaced skips.
+      for (const s of stageResult.skipped) {
+        console.warn(
+          `[session_exec] daemon refused to stage ${s.path}: ${s.reason}`,
+        );
+        stagingSkipped.push({ path: `/user/${s.path}`, reason: s.reason });
+      }
     }
 
     // Inline mode: stage the snippet as a hidden one-shot script and run it
@@ -557,7 +724,7 @@ export const executeCodeInSession = internalAction({
     }
 
     try {
-      return await runAndHarvestInSession(ctx, {
+      const result = await runAndHarvestInSession(ctx, {
         organizationId: args.organizationId,
         workspaceThreadId: args.threadId,
         sessionId,
@@ -567,6 +734,7 @@ export const executeCodeInSession = internalAction({
         }),
         ...(args.timeoutMs !== undefined && { timeoutMs: args.timeoutMs }),
       });
+      return stagingSkipped.length > 0 ? { ...result, stagingSkipped } : result;
     } finally {
       if (inlinePath !== undefined) {
         await sessionDeleteFiles(sessionId, [inlinePath]).catch(

--- a/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
+++ b/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
@@ -95,6 +95,7 @@ import {
   sessionReadFile,
   sessionStageFiles,
 } from './helpers/session_client';
+import { stageUrlForBlobRef } from './helpers/stage_url';
 import {
   reconcileBuiltinSkills,
   stageIntegrationSkills,
@@ -534,11 +535,17 @@ export async function folderStageFiles(
   const dir = as.replace(/\/+$/, '');
   const staged: SessionStageFile[] = [];
   for (const file of files) {
-    const raw = await ctx.storage.getUrl(toId<'_storage'>(file.fileId));
-    if (!raw) continue; // blob purged under a live row — skip, don't fail
+    // Blob-aware: a BYO-bucket org's documents carry `s3:` refs, which stage
+    // via the token-gated stream route instead of a `_storage` capability URL.
+    const url = await stageUrlForBlobRef(
+      ctx,
+      String(file.fileId),
+      organizationId,
+    );
+    if (url === null) continue; // blob purged under a live row — skip, don't fail
     staged.push({
       path: `${pathPrefix}${dir}/${file.name}`,
-      url: toSandboxStorageUrl(raw),
+      url,
     });
   }
   return staged;
@@ -692,13 +699,17 @@ export const runSandboxScript = internalAction({
             url: await storeAsUrl(input.from.content),
           });
         } else if ('fileId' in input.from) {
-          const raw = await ctx.storage.getUrl(
-            toId<'_storage'>(input.from.fileId),
+          const url = await stageUrlForBlobRef(
+            ctx,
+            input.from.fileId,
+            args.organizationId,
           );
-          if (!raw) return fail(`input file not found: ${input.from.fileId}`);
+          if (url === null) {
+            return fail(`input file not found: ${input.from.fileId}`);
+          }
           stageInputs.push({
             path: `uploads/${input.as}`,
-            url: toSandboxStorageUrl(raw),
+            url,
           });
         } else {
           const staged = await folderStageFiles(
@@ -1669,11 +1680,15 @@ export const runSandboxAgent = internalAction({
               contentBase64: Buffer.from(input.from.content).toString('base64'),
             });
           } else if ('fileId' in input.from) {
-            const raw = await ctx.storage.getUrl(
-              toId<'_storage'>(input.from.fileId),
+            const url = await stageUrlForBlobRef(
+              ctx,
+              input.from.fileId,
+              args.organizationId,
             );
-            if (!raw) return fail(`input file not found: ${input.from.fileId}`);
-            stageFiles.push({ path: input.as, url: toSandboxStorageUrl(raw) });
+            if (url === null) {
+              return fail(`input file not found: ${input.from.fileId}`);
+            }
+            stageFiles.push({ path: input.as, url });
           } else {
             const staged = await folderStageFiles(
               ctx,

--- a/services/platform/convex/thread_files/schema.ts
+++ b/services/platform/convex/thread_files/schema.ts
@@ -1,6 +1,7 @@
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+import { DOCUMENT_MAX_FILE_SIZE } from '../../lib/shared/file-types';
 import { blobRefValidator } from '../lib/storage/blob_ref';
 
 /**
@@ -78,6 +79,13 @@ export const threadFilesTable = defineTable({
  * client validation lives in the tool description so the LLM can self-correct
  * before the round-trip.
  */
-export const THREAD_FILE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB per file
+/**
+ * Per-file cap ≡ the chat/document upload cap: anything a user can upload can
+ * be filed into the workspace and staged into the sandbox (the container-side
+ * URL-fetch cap is sized to match — `FETCH_MAX_BYTES` in the runnerd daemon).
+ * Do not diverge the two: a workspace cap below the upload cap silently
+ * withholds legitimately uploaded files from `run_code` (the 30MB-log bug).
+ */
+export const THREAD_FILE_MAX_BYTES = DOCUMENT_MAX_FILE_SIZE; // 100 MB per file
 export const THREAD_WORKSPACE_MAX_FILES = 100;
-export const THREAD_WORKSPACE_MAX_BYTES = 100 * 1024 * 1024; // 100 MB total
+export const THREAD_WORKSPACE_MAX_BYTES = 1024 * 1024 * 1024; // 1 GB total

--- a/services/platform/convex/threads/snapshot_thread_files.test.ts
+++ b/services/platform/convex/threads/snapshot_thread_files.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  THREAD_FILE_MAX_BYTES,
+  THREAD_WORKSPACE_MAX_BYTES,
+} from '../thread_files/schema';
+
 vi.mock('../_generated/server', () => ({
   internalAction: ({ handler }: { handler: Function }) => handler,
 }));
@@ -187,16 +192,22 @@ describe('snapshotThreadFiles', () => {
     expect(upserts).toHaveLength(100);
   });
 
-  it('skips files that would exceed the 100 MB workspace byte cap', async () => {
-    const big = 60 * 1024 * 1024; // 60 MB each → second one overflows 100 MB
+  it('skips files that would exceed the workspace byte cap', async () => {
+    // Enough max-size files to overflow the byte budget by exactly one —
+    // derived from the constants so a cap raise can't silently retarget this
+    // at the file-count branch instead.
+    const fits = Math.floor(THREAD_WORKSPACE_MAX_BYTES / THREAD_FILE_MAX_BYTES);
     const { ctx } = makeCtx({
-      sourceFiles: [
-        fileRow({ path: 'big1', storageId: 's1', size: big }),
-        fileRow({ path: 'big2', storageId: 's2', size: big }),
-      ],
+      sourceFiles: Array.from({ length: fits + 1 }, (_, i) =>
+        fileRow({
+          path: `big${i}`,
+          storageId: `s${i}`,
+          size: THREAD_FILE_MAX_BYTES,
+        }),
+      ),
     });
     const out = await run(ctx, baseArgs);
-    expect(out.copied).toBe(1);
+    expect(out.copied).toBe(fits);
     expect(out.skipped).toBe(1);
   });
 

--- a/services/platform/tests/manual/scripts/e2e-sandbox-large-files.ts
+++ b/services/platform/tests/manual/scripts/e2e-sandbox-large-files.ts
@@ -1,0 +1,608 @@
+/**
+ * Live-stack e2e for large files across the sandbox boundary:
+ * the 100 MB workspace caps (per-file = upload cap), the token-gated
+ * `/api/sandbox-blob` streaming lane for BYO-S3 orgs, and the per-file
+ * staging/harvest skip surfacing.
+ *
+ * Prerequisites: platform dev stack (`bun dev`) + sandbox spawner running on
+ * loopback; docker available for the optional MinIO (BYO-S3) phase.
+ *
+ *   bun services/platform/tests/manual/scripts/e2e-sandbox-large-files.ts
+ *   SKIP_S3=1 bun …  # skip the MinIO phase
+ *
+ * Phases:
+ *  A. Browser (fresh user + org): chat with a 30 MB text attachment →
+ *     the workspace filing that used to silently skip anything over 10 MB.
+ *  B. Backend: the threadFiles row exists with the full 30 MB size.
+ *  C. Sandbox: executeCodeInSession reads the staged upload (`wc`) — the
+ *     staging lane that used to be impossible over the 1.5 MB stage budget.
+ *  D. Harvest: a 15 MB output is harvested (old cap: hard failure), a 25 MB
+ *     output is reported in `harvestSkipped` (old cap: silent loss).
+ *  E. Route security: missing/garbage/expired/foreign tokens are refused.
+ *  F. BYO-S3 (MinIO): the org's blobs route to its own bucket and a >1 MB
+ *     upload still reaches the sandbox — through the streaming route, since
+ *     the container has no path to the bucket.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium, type Browser, type Page } from '@playwright/test';
+
+import { createOrgViaWizard, uniqueCredentials } from '../../e2e/helpers/auth';
+import {
+  composer,
+  fillComposer,
+  sendButton,
+  stopButton,
+} from '../../e2e/helpers/chat';
+import { BASE_URL, TIMEOUT } from '../../e2e/helpers/env';
+
+const PLATFORM_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+const REPO_ROOT = path.resolve(PLATFORM_ROOT, '../..');
+const HTTP_API = process.env.VITE_CONVEX_SITE_URL ?? 'http://127.0.0.1:3211';
+const MINIO_NAME = 'tale-e2e-minio';
+const MINIO_PORT = 19100;
+
+// Repo-root `.env.local` pins CONVEX_DEPLOYMENT to a DIFFERENT anonymous
+// deployment (`anonymous-agent`); when this script is launched from the repo
+// root, bun auto-loads it into process.env and every convex CLI child would
+// target the wrong backend. Drop it — the CLI then resolves the platform
+// deployment from `services/platform/.env.local` via its cwd.
+const CLI_ENV: NodeJS.ProcessEnv = { ...process.env };
+delete CLI_ENV.CONVEX_DEPLOYMENT;
+
+const results: Array<{ id: string; ok: boolean; detail: string }> = [];
+function record(id: string, ok: boolean, detail: string): void {
+  results.push({ id, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${id} — ${detail}`);
+}
+
+function convexRun(fn: string, args: unknown, timeoutMs = 240_000): unknown {
+  const proc = spawnSync('bunx', ['convex', 'run', fn, JSON.stringify(args)], {
+    cwd: PLATFORM_ROOT,
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    env: CLI_ENV,
+  });
+  if (proc.status !== 0) {
+    throw new Error(
+      `convex run ${fn} failed (${proc.status}): ${proc.stderr.slice(0, 800)}`,
+    );
+  }
+  const out = proc.stdout.trim();
+  if (out.length === 0) return null;
+  const jsonStart = out.search(/[[{"]/);
+  return JSON.parse(jsonStart >= 0 ? out.slice(jsonStart) : out);
+}
+
+/** Deployment env var via the CLI (`convex env get`). */
+function convexEnvGet(name: string): string | null {
+  const proc = spawnSync('bunx', ['convex', 'env', 'get', name], {
+    cwd: PLATFORM_ROOT,
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: CLI_ENV,
+  });
+  if (proc.status !== 0) return null;
+  const value = proc.stdout.trim();
+  return value.length > 0 ? value : null;
+}
+
+/**
+ * Org slug + creator user id from the Better Auth component's `organization`
+ * table (`metadata.creatorId`); there is no root-app query for either, and the
+ * one-off query API cannot cross into components — the CLI's component data
+ * dump is the sanctioned admin read.
+ */
+function orgMetaFromComponent(orgId: string): {
+  slug: string;
+  ownerUserId: string;
+} {
+  const proc = spawnSync(
+    'bunx',
+    [
+      'convex',
+      'data',
+      '--component',
+      'betterAuth',
+      'organization',
+      '--order',
+      'desc',
+      '--limit',
+      '100',
+    ],
+    { cwd: PLATFORM_ROOT, encoding: 'utf8', timeout: 60_000, env: CLI_ENV },
+  );
+  if (proc.status !== 0) {
+    throw new Error(`convex data failed: ${proc.stderr.slice(0, 300)}`);
+  }
+  const line = proc.stdout.split('\n').find((l) => l.includes(orgId));
+  if (!line)
+    throw new Error(`org ${orgId} not in component organization table`);
+  const cols = line.split('|').map((c) => c.trim().replace(/^"|"$/g, ''));
+  const slug = cols[cols.length - 1];
+  const creator = /creatorId\\":\\"([A-Za-z0-9]+)/.exec(line)?.[1];
+  if (!slug || !creator) {
+    throw new Error(`could not parse slug/creator from: ${line}`);
+  }
+  return { slug, ownerUserId: creator };
+}
+
+/** Deterministic text file of exactly `lines` newline-terminated 114-byte
+ * lines (275,592 lines ≈ 30 MB — comfortably over both the old 10 MB
+ * workspace cap and the 1.5 MB stage-request budget). */
+function writeLogFile(filePath: string, lines: number): number {
+  const chunk: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    chunk.push(
+      `2026-07-20T00:00:00Z [INFO] svc-${i % 7} request_id=${String(i).padStart(8, '0')} handled path=/api/v1/resource status=200`.padEnd(
+        113,
+        '.',
+      ),
+    );
+  }
+  const body = `${chunk.join('\n')}\n`;
+  writeFileSync(filePath, body);
+  return Buffer.byteLength(body);
+}
+
+async function attachAndSend(
+  page: Page,
+  orgId: string,
+  filePath: string,
+  fileName: string,
+  message: string,
+): Promise<string> {
+  await page.goto(`${BASE_URL}/dashboard/${orgId}/chat`);
+  await composer(page).waitFor({
+    state: 'visible',
+    timeout: TIMEOUT.FIRST_PAINT,
+  });
+  await page.locator('input[type="file"]').first().setInputFiles(filePath);
+  // The chip (with the full name in `title`) renders once the upload lands —
+  // a 30 MB body takes a moment on loopback.
+  await page
+    .locator(`[title="${fileName}"]`)
+    .first()
+    .waitFor({ state: 'visible', timeout: 120_000 });
+  await fillComposer(page, message);
+  await sendButton(page).click();
+  await page.waitForURL(/\/chat\/([A-Za-z0-9]{16,})(?:[/?#]|$)/, {
+    timeout: TIMEOUT.NAV,
+  });
+  const threadId = /\/chat\/([A-Za-z0-9]{16,})/.exec(page.url())?.[1];
+  if (!threadId) throw new Error(`no thread id in ${page.url()}`);
+  // Wait for the turn to settle (Stop → gone). Generation may legitimately
+  // take a while on a live model; the filing we assert on happens BEFORE the
+  // model call, so a model hiccup must not fail the script here.
+  try {
+    await stopButton(page).waitFor({ state: 'hidden', timeout: 240_000 });
+  } catch {
+    console.warn(
+      'turn still running after 240s — continuing (filing is pre-generation)',
+    );
+  }
+  return threadId;
+}
+
+interface ThreadFileRow {
+  path: string;
+  size: number;
+  contentType: string;
+  source: string;
+  storageId: string;
+}
+
+function listThreadFiles(threadId: string): ThreadFileRow[] {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- admin CLI JSON
+  return convexRun('thread_files/internal_queries:listThreadFiles', {
+    threadId,
+  }) as ThreadFileRow[];
+}
+
+/**
+ * Poll for a workspace row: attachment filing runs inside the generation
+ * action, which starts a routing/fallback dance AFTER the send — the Send⇄Stop
+ * toggle can flap through model retries long before the filing lands, so a
+ * single-shot read right after the UI settles races it.
+ */
+async function waitForThreadFile(
+  threadId: string,
+  filePath: string,
+  timeoutMs = 180_000,
+): Promise<ThreadFileRow | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const row = listThreadFiles(threadId).find((r) => r.path === filePath);
+    if (row !== undefined) return row;
+    if (Date.now() > deadline) return undefined;
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+}
+
+interface ExecResult {
+  status: string;
+  exitCode: number | null;
+  stdoutPreview: string;
+  stderrPreview: string;
+  files: Array<{ path: string; size: number }>;
+  stagingSkipped?: Array<{ path: string; reason: string }>;
+  harvestSkipped?: Array<{ path: string; reason: string }>;
+}
+
+function execInSession(
+  organizationId: string,
+  threadId: string,
+  userId: string,
+  code: string,
+  language: 'bash' | 'python' = 'bash',
+  timeoutMs = 120_000,
+): ExecResult {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- admin CLI JSON
+  return convexRun(
+    'node_only/sandbox/session_exec:executeCodeInSession',
+    {
+      organizationId,
+      threadId,
+      uploadedBy: userId,
+      stepPaths: [],
+      inlineCode: { content: code, language },
+      timeoutMs,
+    },
+    360_000,
+  ) as ExecResult;
+}
+
+async function main(): Promise<void> {
+  const thirtyMb = path.join('/tmp', 'e2e-30mb-app.log');
+  const LINES_30MB = 275_592;
+  const bytes30 = writeLogFile(thirtyMb, LINES_30MB);
+  console.log(`30MB fixture: ${bytes30} bytes, ${LINES_30MB} lines`);
+
+  const browser: Browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    baseURL: BASE_URL,
+    locale: 'en-US',
+  });
+  const page = await context.newPage();
+
+  // ---- Phase A: fresh org, 30 MB chat attachment -------------------------
+  // Sign up from the PAGE context (browser fetch): under bun, playwright's
+  // APIRequestContext crashes parsing Set-Cookie (its node:http shim reports
+  // the request path as the response URL), and the browser jar is where the
+  // session cookie must land anyway for the wizard that follows.
+  const creds = uniqueCredentials('sandbox-large');
+  await page.goto(`${BASE_URL}/`);
+  const signUp = await page.evaluate(
+    async (args: { email: string; password: string }) => {
+      const res = await fetch('/api/auth/sign-up/email', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: args.email,
+          email: args.email,
+          password: args.password,
+        }),
+        credentials: 'include',
+      });
+      return { status: res.status, body: (await res.text()).slice(0, 300) };
+    },
+    { email: creds.email, password: creds.password },
+  );
+  if (signUp.status >= 400) {
+    throw new Error(`sign-up failed: ${signUp.status} ${signUp.body}`);
+  }
+  const orgId = await createOrgViaWizard(page);
+  console.log(`org: ${orgId}  user: ${creds.email}`);
+  // The org slug (MinIO config dir) + creator user id (executeCodeInSession's
+  // uploadedBy provenance).
+  const orgMeta = orgMetaFromComponent(orgId);
+  console.log(`slug: ${orgMeta.slug}  owner: ${orgMeta.ownerUserId}`);
+
+  const threadId = await attachAndSend(
+    page,
+    orgId,
+    thirtyMb,
+    'e2e-30mb-app.log',
+    'Use run_code to count the exact number of lines in the attached log file.',
+  );
+  console.log(`thread: ${threadId}`);
+
+  // ---- Phase B: workspace filing at the new cap --------------------------
+  const upload = await waitForThreadFile(
+    threadId,
+    '/user/uploads/e2e-30mb-app.log',
+  );
+  record(
+    'B1 filing-30mb',
+    upload !== undefined &&
+      upload.size === bytes30 &&
+      upload.source === 'user_upload',
+    upload
+      ? `filed ${upload.size} bytes as ${upload.path} (${upload.storageId.startsWith('s3:') ? 's3' : '_storage'})`
+      : 'row did not appear within 180s',
+  );
+
+  // ---- Phase C: staging + read inside the sandbox ------------------------
+  const wc = execInSession(
+    orgId,
+    threadId,
+    orgMeta.ownerUserId,
+    'wc -l -c /user/uploads/e2e-30mb-app.log',
+  );
+  const wcOk =
+    wc.status === 'completed' &&
+    wc.stdoutPreview.includes(String(LINES_30MB)) &&
+    wc.stdoutPreview.includes(String(bytes30)) &&
+    (wc.stagingSkipped === undefined || wc.stagingSkipped.length === 0);
+  record(
+    'C1 sandbox-reads-30mb',
+    wcOk,
+    `status=${wc.status} stdout="${wc.stdoutPreview.trim()}" stagingSkipped=${JSON.stringify(wc.stagingSkipped ?? [])}`,
+  );
+
+  // ---- Phase D: harvest — 15 MB in, 25 MB skipped with a reason ----------
+  const harvest = execInSession(
+    orgId,
+    threadId,
+    orgMeta.ownerUserId,
+    [
+      'import os',
+      "open('/user/output/mid-15mb.bin','wb').write(os.urandom(15*1024*1024))",
+      "open('/user/output/huge-25mb.bin','wb').write(os.urandom(25*1024*1024))",
+      "print('outputs written')",
+    ].join('\n'),
+    'python',
+  );
+  const midHarvested = harvest.files.some(
+    (f) =>
+      f.path === '/user/output/mid-15mb.bin' && f.size === 15 * 1024 * 1024,
+  );
+  const hugeSkip = (harvest.harvestSkipped ?? []).find(
+    (s) => s.path === '/user/output/huge-25mb.bin',
+  );
+  record(
+    'D1 harvest-15mb',
+    harvest.status === 'completed' && midHarvested,
+    `status=${harvest.status} files=${JSON.stringify(harvest.files.map((f) => `${f.path}:${f.size}`))}`,
+  );
+  record(
+    'D2 harvest-skip-25mb',
+    hugeSkip !== undefined && hugeSkip.reason.includes('20.0 MB'),
+    `harvestSkipped=${JSON.stringify(harvest.harvestSkipped ?? [])}`,
+  );
+
+  // ---- Phase E: stream-route token gate ----------------------------------
+  const noToken = await fetch(`${HTTP_API}/api/sandbox-blob`);
+  record('E1 route-no-token', noToken.status === 400, `HTTP ${noToken.status}`);
+  const garbage = await fetch(
+    `${HTTP_API}/api/sandbox-blob?token=v1.aaaa.bbbb`,
+  );
+  record(
+    'E2 route-garbage-token',
+    garbage.status === 403,
+    `HTTP ${garbage.status}`,
+  );
+  {
+    // Real signatures: mint with the deployment's own HMAC root.
+    const hmacKey = convexEnvGet('WEBDAV_APP_PASSWORD_HMAC_KEY');
+    if (hmacKey) {
+      process.env.WEBDAV_APP_PASSWORD_HMAC_KEY = hmacKey;
+      const { signStageToken } =
+        await import('../../../convex/lib/storage/sandbox_stage_token');
+      const expired = await signStageToken(
+        { ref: 's3:whatever/x', org: orgId },
+        Date.now() - 11 * 60 * 1000,
+      );
+      const expiredRes = await fetch(
+        `${HTTP_API}/api/sandbox-blob?token=${encodeURIComponent(expired ?? '')}`,
+      );
+      record(
+        'E3 route-expired-token',
+        expiredRes.status === 403,
+        `HTTP ${expiredRes.status}`,
+      );
+      const foreign = await signStageToken({
+        ref: 's3:not-this-org/nothing',
+        org: orgId,
+      });
+      const foreignRes = await fetch(
+        `${HTTP_API}/api/sandbox-blob?token=${encodeURIComponent(foreign ?? '')}`,
+      );
+      // Valid signature, but the org has no bucket / the key is outside its
+      // namespace → fail-closed 404, never a stream.
+      record(
+        'E4 route-foreign-ref',
+        foreignRes.status === 404,
+        `HTTP ${foreignRes.status}`,
+      );
+    } else {
+      record(
+        'E3 route-expired-token',
+        false,
+        'could not read HMAC root from deployment env',
+      );
+    }
+  }
+
+  // ---- Phase F: BYO-S3 org via MinIO -------------------------------------
+  if (process.env.SKIP_S3 === '1') {
+    console.log('SKIP_S3=1 — skipping the MinIO phase');
+  } else {
+    spawnSync('docker', ['rm', '-f', MINIO_NAME], { encoding: 'utf8' });
+    const boot = spawnSync(
+      'docker',
+      [
+        'run',
+        '-d',
+        '--name',
+        MINIO_NAME,
+        '-p',
+        `${MINIO_PORT}:9000`,
+        '-e',
+        'MINIO_ROOT_USER=minioadmin',
+        '-e',
+        'MINIO_ROOT_PASSWORD=minioadmin',
+        'minio/minio',
+        'server',
+        '/data',
+      ],
+      { encoding: 'utf8' },
+    );
+    if (boot.status !== 0) {
+      record('F0 minio-boot', false, boot.stderr.slice(0, 300));
+    } else {
+      // Bucket = top-level dir on the FS backend; wait for readiness first.
+      for (let i = 0; i < 30; i++) {
+        const ping = spawnSync(
+          'curl',
+          [
+            '-s',
+            '-o',
+            '/dev/null',
+            '-w',
+            '%{http_code}',
+            `http://127.0.0.1:${MINIO_PORT}/minio/health/ready`,
+          ],
+          { encoding: 'utf8' },
+        );
+        if (ping.stdout.trim() === '200') break;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      spawnSync(
+        'docker',
+        ['exec', MINIO_NAME, 'mkdir', '-p', '/data/tale-e2e'],
+        { encoding: 'utf8' },
+      );
+
+      // Point the fresh org's blob routing at its own bucket (file-based org
+      // config — written directly, as an operator would). The root that
+      // matters is the BACKEND's TALE_CONFIG_DIR (deployment env), not this
+      // script's — the two diverge on dev machines.
+      const configRoot =
+        convexEnvGet('TALE_CONFIG_DIR') ??
+        process.env.TALE_CONFIG_DIR ??
+        path.join(REPO_ROOT, '.tale-config');
+      const cfgDir = path.join(configRoot, orgMeta.slug, 'object-storage');
+      mkdirSync(cfgDir, { recursive: true });
+      writeFileSync(
+        path.join(cfgDir, 'connection.json'),
+        JSON.stringify(
+          {
+            region: 'us-east-1',
+            endpoint: `http://127.0.0.1:${MINIO_PORT}`,
+            forcePathStyle: true,
+            bucket: 'tale-e2e',
+          },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(
+        path.join(cfgDir, 'connection.secrets.json'),
+        JSON.stringify(
+          { accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin' },
+          null,
+          2,
+        ),
+      );
+      console.log(`org object-storage config written: ${cfgDir}`);
+      // The blob-routing resolver caches per-org store decisions for 15s
+      // (ORG_STORE_TTL_MS) and this org was already resolved to `_storage`
+      // during phase A — outlive that entry before uploading.
+      await new Promise((r) => setTimeout(r, 16_000));
+
+      // A fresh 5 MB upload in a NEW thread now routes: upload → MinIO,
+      // filing copy → MinIO (s3 ref), staging → /api/sandbox-blob stream.
+      const fiveMb = path.join('/tmp', 'e2e-5mb-s3.log');
+      const LINES_5MB = 51_200;
+      const bytes5 = writeLogFile(fiveMb, LINES_5MB);
+      const s3ThreadId = await attachAndSend(
+        page,
+        orgId,
+        fiveMb,
+        'e2e-5mb-s3.log',
+        'Use run_code to count the exact number of lines in the attached log file.',
+      );
+      console.log(`s3 thread: ${s3ThreadId}`);
+
+      const s3upload = await waitForThreadFile(
+        s3ThreadId,
+        '/user/uploads/e2e-5mb-s3.log',
+      );
+      record(
+        'F1 s3-filing-5mb',
+        s3upload !== undefined &&
+          s3upload.size === bytes5 &&
+          s3upload.storageId.startsWith('s3:'),
+        s3upload
+          ? `filed as ${s3upload.storageId.slice(0, 24)}… size=${s3upload.size}`
+          : 'row did not appear within 180s',
+      );
+
+      const s3wc = execInSession(
+        orgId,
+        s3ThreadId,
+        orgMeta.ownerUserId,
+        'wc -l -c /user/uploads/e2e-5mb-s3.log',
+      );
+      const s3ok =
+        s3wc.status === 'completed' &&
+        s3wc.stdoutPreview.includes(String(LINES_5MB)) &&
+        s3wc.stdoutPreview.includes(String(bytes5)) &&
+        (s3wc.stagingSkipped === undefined || s3wc.stagingSkipped.length === 0);
+      record(
+        'F2 s3-sandbox-reads-5mb',
+        s3ok,
+        `status=${s3wc.status} stdout="${s3wc.stdoutPreview.trim()}" stagingSkipped=${JSON.stringify(s3wc.stagingSkipped ?? [])}`,
+      );
+
+      // Physical evidence the org's blobs really live in ITS bucket: the
+      // MinIO FS backend materializes each object under /data/<bucket>/.
+      const bucketLs = spawnSync(
+        'docker',
+        [
+          'exec',
+          MINIO_NAME,
+          'sh',
+          '-c',
+          'find /data/tale-e2e -type d -name "*.log" -o -type d -name "xl.meta" | head; ls /data/tale-e2e/ | head -20',
+        ],
+        { encoding: 'utf8' },
+      );
+      const bucketEntries = bucketLs.stdout.trim();
+      record(
+        'F3 s3-bucket-has-objects',
+        bucketLs.status === 0 && bucketEntries.length > 0,
+        `bucket contents: ${bucketEntries.split('\n').slice(0, 5).join(' | ') || '(empty)'}`,
+      );
+
+      // Teardown: the MinIO container is per-run scratch.
+      spawnSync('docker', ['rm', '-f', MINIO_NAME], { encoding: 'utf8' });
+    }
+  }
+
+  await browser.close();
+
+  console.log('\n===== SUMMARY =====');
+  for (const r of results) {
+    console.log(`${r.ok ? 'PASS' : 'FAIL'}  ${r.id} — ${r.detail}`);
+  }
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length > 0) {
+    console.error(`\n${failed.length} check(s) FAILED`);
+    process.exit(1);
+  }
+  console.log('\nAll checks passed.');
+}
+
+main().catch((err: unknown) => {
+  console.error('e2e script crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

A 30 MB chat attachment never reached the sandbox: `run_code` reported `sandboxState.uploads: []` and the model flailed (tried `urlopen` inside the container, read empty paths). Root cause: the workspace per-file cap (`THREAD_FILE_MAX_BYTES`, 10 MB) sat below the chat upload cap (`DOCUMENT_MAX_FILE_SIZE`, 100 MB), and `buildWorkspaceUploadPlan` skipped oversize attachments with only a server-side `console.warn` — invisible to the model and the user.

Two adjacent defects surfaced during the fix:

- **BYO-S3/R2 orgs**: workspace files staged as inline base64, capped ~1 MB by the 1.5 MB stage-request budget — and one larger file made `chunkStageFiles` **throw, failing the whole `run_code` call**. Workflow folder/`fileId` inputs were additionally hard-cast to `_storage` ids (broken for bucket orgs).
- **Harvest**: a 10–20 MB `/user/output` file failed the entire run via the upsert cap; >20 MB vanished silently.

## Changes

- **Caps**: `THREAD_FILE_MAX_BYTES := DOCUMENT_MAX_FILE_SIZE` (100 MB, single anchor — invariant test locks per-file cap ≥ upload cap), workspace total 100 MB → 1 GB. Filing copies >10 MB attachments sequentially to bound node-executor memory.
- **Signed streaming lane for bucket orgs**: new `/api/sandbox-blob` httpAction — verifies a short-TTL HMAC stage token (`{ref, org, exp}`, subkey of the deployment HMAC root, **zero new env**), presigns server-side (`s3KeyBelongsToOrg` tenant gate), and streams the bytes through. The container fetches it over the existing `convex:3211` alias (daemon fetch cap is already 100 MB); bucket credentials/presigned URLs never enter the container. No-HMAC deployments keep the inline lane, now skip-guarded instead of throwing.
- **Skips are surfaced**: `stagingSkipped` / `harvestSkipped` on the exec result and in the `run_code` message (`⚠ NOT staged into the sandbox: <path> — <reason>`); daemon-side staging refusals were previously discarded.
- **Harvest**: per-file skip + orphan-blob reap instead of run failure; >20 MB outputs short-circuit from the listing size with an explicit reason (read-back cap unchanged at 20 MB by decision).
- **Workflow staging sweep**: folder/`fileId` inputs route through the shared blob-aware `stageUrlForBlobRef`.
- **Live E2E playbook**: `tests/manual/scripts/e2e-sandbox-large-files.ts`.

## Verification

Live E2E (fresh browser-driven org on the dev stack + sandbox), 11/11:

| Check | Result |
|---|---|
| 30 MB attachment filed (31,417,488 B) → sandbox `wc` reads exactly 275,592 lines, no skips | PASS |
| 15 MB output harvested / 25 MB output skipped with surfaced 20 MB-cap reason | PASS |
| Token gate: missing 400 · forged 403 · expired 403 · valid-sig foreign ref 404 | PASS |
| MinIO org: upload files as `s3:` ref → stream-staged → `wc` exact → objects physically in bucket | PASS |

Unit: 62+ tests across token tamper/expiry/key-swap, all six staging lanes, three harvest-skip classes, message formatting, filing plan + cap invariant. `bun run check` green except three pre-existing/unrelated local failures: `observatory.test.ts` (headers grade, untouched since #1936, zero import overlap) and two agent-config prefetch tests (10 s timeouts under full parallel load; pass 2/2 in isolation).

## Release notes

No migration (constants + a new route; no schema shape change), no new env vars, no sandbox image rebuild (runnerd's fetch cap was already 100 MB). Prod reaches `convex:3211` from the sandbox net today (integrations bridge path).

## Definition of done

- [x] Green gate — format / lint / typecheck / tests (3 pre-existing/unrelated local failures documented above)
- [x] Security gate — `bun run lint:sast` 0 findings incl. new files; token route: HMAC + TTL + tenant-scoped presign, constant-time compare
- [x] Tests — happy path + edges + errors (unit + live E2E)
- [x] Migration — N/A: constants only, no schema/data change (`migrations:check` green)
- [x] Locales — N/A: no user-visible UI strings (tool/result text is English-only by design)
- [x] Docs — N/A: no user-facing docs describe the 10 MB cap; behavior is internal tool plumbing
- [x] Accessibility — N/A: no UI
- [x] Sweep — all cap consumers + staging call sites enumerated and updated (workflow exec included); harvest read-back mirror constant documented against daemon `FILE_READ_MAX_BYTES`
- [x] Observed — live E2E above, plus route curls on the running backend
- [x] Commits — atomic conventional ×3, branched off main

## Reviewer focus

`sandbox_stage_token.ts` (crypto: domain-separated subkey of `WEBDAV_APP_PASSWORD_HMAC_KEY`, b64url HMAC-SHA256, timing-safe compare) and `sandbox_blob_http.ts` (no IP rate limit **on purpose** — token gate is strictly stronger and an IP bucket would throttle legitimate 100-file staging bursts; fail-closed 404 on presign refusal). Known small gaps left out deliberately: workflow script-step results don't forward `harvestSkipped` yet; filing-layer `too_many` skips still only log.
