### PR TITLE
feat(platform): tale-vision — image analysis for run_code sandbox code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,10 @@ TALE_AUDIT_SIGNING_KEY=4f8c2a9e7b1d6035e4a8c2f9d7b3061a5e8c4f2a9d7b30615e4c8a2f9
 # SANDBOX_LLM_GATEWAY_ADMIN_USERNAME=admin
 # SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD=
 
+# Per-session spend cap (cents) for the vision-only virtual key minted for chat
+# run_code sessions (the in-sandbox `tale-vision` CLI). Default 200 = $2.
+# RUN_CODE_VISION_BUDGET_CENTS=200
+
 # ============================================================================
 # OPTIONAL: Restart controller (one-click "Apply & restart")
 # ============================================================================

--- a/services/platform/convex/agent_tools/run_code_tool.ts
+++ b/services/platform/convex/agent_tools/run_code_tool.ts
@@ -314,6 +314,8 @@ MULTI-STEP: repeated run_code calls (no steps array); the sandbox session persis
 
 PATHS: \`/user/code/\` your file_write scripts (what \`entryPath\` runs) · \`/user/output/\` deliverables — ONLY files written here are harvested back into the workspace and canvas (incl. prior runs' outputs) · \`/user/uploads/\` the user's files.
 
+VISION: \`tale-vision <image-paths...> [--question "..."]\` analyzes images with the org's vision model (NDJSON line per image; results cached for the turn, so re-runs are free). For large batches raise timeoutMs (max 300000) and chunk across run_code calls.
+
 LIMITS: 1 GB memory · ≤16 harvested files/run.
 
 Results embed terminal output (stdout capped 4 KB; stderr on failure) and a \`sandboxState\` manifest (files per dir with \`fileId\`) — read it first: never regenerate an output already listed; hand a \`fileId\` to \`image\` (analyze) or \`document_write\`.`,

--- a/services/platform/convex/node_only/sandbox/thread_session.test.ts
+++ b/services/platform/convex/node_only/sandbox/thread_session.test.ts
@@ -1,0 +1,213 @@
+// armVisionLane contract: mints a vision-only gateway key for a chat run_code
+// session and injects the TALE_* env triplet — best-effort (never throws into
+// session creation), token row inserted BEFORE the env patch so teardown can
+// always revoke. Gateway + session wire mocked at the same seams as
+// session_exec.test.ts.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ActionCtx } from '../../_generated/server';
+
+const sessionEnvPatch = vi.fn();
+
+vi.mock('./helpers/session_client', () => ({
+  sessionCreate: vi.fn(),
+  sessionDestroy: vi.fn(),
+  sessionEnvPatch: (...args: unknown[]) => sessionEnvPatch(...args),
+  sessionIsAlive: vi.fn(),
+}));
+
+const applyGatewayConfig = vi.fn();
+const hashVirtualKey = vi.fn();
+const mintVirtualKey = vi.fn();
+const provisionProviders = vi.fn();
+const resolveGatewayRoutingFromRef = vi.fn();
+
+vi.mock('./llm_gateway_admin', () => ({
+  applyGatewayConfig: (...args: unknown[]) => applyGatewayConfig(...args),
+  hashVirtualKey: (...args: unknown[]) => hashVirtualKey(...args),
+  mintVirtualKey: (...args: unknown[]) => mintVirtualKey(...args),
+  provisionProviders: (...args: unknown[]) => provisionProviders(...args),
+  resolveGatewayRoutingFromRef: (...args: unknown[]) =>
+    resolveGatewayRoutingFromRef(...args),
+}));
+
+const resolveLanguageModel = vi.fn();
+
+vi.mock('../../providers/resolve_model', () => ({
+  resolveLanguageModel: (...args: unknown[]) => resolveLanguageModel(...args),
+}));
+
+const loadOrgGatewayProviders = vi.fn();
+
+vi.mock('../../providers/file_actions', () => ({
+  loadOrgGatewayProviders: (...args: unknown[]) =>
+    loadOrgGatewayProviders(...args),
+}));
+
+import { armVisionLane } from './thread_session';
+
+const ARGS = {
+  organizationId: 'org_1',
+  threadId: 'thr_1',
+  sessionId: 'thr-thr_1',
+};
+
+const makeCtx = () => {
+  const runMutation = vi.fn().mockResolvedValue('row_1');
+  const ctx = { runMutation } as unknown as ActionCtx;
+  return { ctx, runMutation };
+};
+
+const armHappyMocks = () => {
+  resolveLanguageModel.mockResolvedValue({
+    modelData: { providerName: 'openrouter', modelId: 'qwen-vl-max' },
+  });
+  resolveGatewayRoutingFromRef.mockReturnValue({
+    gatewayProvider: 'openrouter',
+    gatewayModel: 'openrouter/qwen-vl-max',
+  });
+  loadOrgGatewayProviders.mockResolvedValue([{ name: 'openrouter' }]);
+  provisionProviders.mockResolvedValue(undefined);
+  applyGatewayConfig.mockResolvedValue(undefined);
+  mintVirtualKey.mockResolvedValue({ key: 'sk-bf-test-key', keyId: 'vk_1' });
+  hashVirtualKey.mockReturnValue('hash-of-key');
+  sessionEnvPatch.mockResolvedValue([]);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('armVisionLane', () => {
+  it('mints a vision-only key, inserts the token row, then patches env', async () => {
+    armHappyMocks();
+    const { ctx, runMutation } = makeCtx();
+
+    await armVisionLane(ctx, ARGS);
+
+    // Provisioning ran before the mint (mint fails closed without it).
+    expect(provisionProviders).toHaveBeenCalledWith('org_1', [
+      { name: 'openrouter' },
+    ]);
+    expect(applyGatewayConfig).toHaveBeenCalledTimes(1);
+
+    // The key allows exactly the resolved vision ref, on the small budget.
+    expect(mintVirtualKey).toHaveBeenCalledTimes(1);
+    const mintArgs = mintVirtualKey.mock.calls[0]?.[0] as {
+      budgetCents: number;
+      allowedModels: string[];
+      organizationId: string;
+      sessionId: string;
+    };
+    expect(mintArgs.budgetCents).toBe(200);
+    expect(mintArgs.allowedModels).toHaveLength(1);
+    expect(mintArgs.organizationId).toBe('org_1');
+    expect(mintArgs.sessionId).toBe('thr-thr_1');
+
+    // Token row: hash only, gateway key id for teardown revoke, scoped shape.
+    // (Which mutation the ref points at is typechecked; Convex api refs are
+    // per-access proxies, so identity assertions are meaningless here.)
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    const [, mutationArgs] = runMutation.mock.calls[0] as [
+      unknown,
+      {
+        organizationId: string;
+        sessionId: string;
+        tokenHash: string;
+        llmGatewayKeyId: string;
+        scope: {
+          agentKind: string;
+          allowedModels: string[];
+          integrationGrants: string[];
+          toolGrants: string[];
+          budgetCents: number;
+          threadId: string;
+        };
+        expiresAt: number;
+      },
+    ];
+    expect(mutationArgs.tokenHash).toBe('hash-of-key');
+    expect(mutationArgs.llmGatewayKeyId).toBe('vk_1');
+    expect(mutationArgs.scope.agentKind).toBe('run_code_vision');
+    expect(mutationArgs.scope.allowedModels).toEqual(mintArgs.allowedModels);
+    expect(mutationArgs.scope.integrationGrants).toEqual([]);
+    expect(mutationArgs.scope.toolGrants).toEqual([]);
+    expect(mutationArgs.scope.budgetCents).toBe(200);
+    expect(mutationArgs.scope.threadId).toBe('thr_1');
+    expect(mutationArgs.expiresAt).toBeGreaterThan(Date.now());
+
+    // Env triplet lands in the session store; the row insert came FIRST so a
+    // crash between the two can never leave an untracked live key.
+    expect(sessionEnvPatch).toHaveBeenCalledWith('thr-thr_1', {
+      set: {
+        TALE_GATEWAY_URL: 'http://sandbox-llm-gateway:8080',
+        TALE_GATEWAY_TOKEN: 'sk-bf-test-key',
+        TALE_VISION_MODEL: 'openrouter/qwen-vl-max',
+      },
+    });
+    const insertOrder = runMutation.mock.invocationCallOrder[0] ?? Infinity;
+    const patchOrder = sessionEnvPatch.mock.invocationCallOrder[0] ?? 0;
+    expect(insertOrder).toBeLessThan(patchOrder);
+  });
+
+  it('skips provisioning when the org has no gateway providers', async () => {
+    armHappyMocks();
+    loadOrgGatewayProviders.mockResolvedValue([]);
+    const { ctx } = makeCtx();
+
+    await armVisionLane(ctx, ARGS);
+
+    expect(provisionProviders).not.toHaveBeenCalled();
+    expect(applyGatewayConfig).toHaveBeenCalledTimes(1);
+    expect(mintVirtualKey).toHaveBeenCalledTimes(1);
+    expect(sessionEnvPatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('no vision-tagged model → skips silently (no mint, no patch, no throw)', async () => {
+    armHappyMocks();
+    resolveLanguageModel.mockRejectedValue(
+      new Error('no model with tag vision'),
+    );
+    const { ctx, runMutation } = makeCtx();
+
+    await expect(armVisionLane(ctx, ARGS)).resolves.toBeUndefined();
+
+    expect(mintVirtualKey).not.toHaveBeenCalled();
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(sessionEnvPatch).not.toHaveBeenCalled();
+  });
+
+  it('mint failure → no token row, no env patch, no throw', async () => {
+    armHappyMocks();
+    mintVirtualKey.mockRejectedValue(new Error('gateway 503'));
+    const { ctx, runMutation } = makeCtx();
+
+    await expect(armVisionLane(ctx, ARGS)).resolves.toBeUndefined();
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(sessionEnvPatch).not.toHaveBeenCalled();
+  });
+
+  it('env patch failure → no throw; the row exists so teardown still revokes', async () => {
+    armHappyMocks();
+    sessionEnvPatch.mockRejectedValue(new Error('spawner 502'));
+    const { ctx, runMutation } = makeCtx();
+
+    await expect(armVisionLane(ctx, ARGS)).resolves.toBeUndefined();
+
+    expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it('gateway auth-posture failure → skips the lane (never a fail-open key)', async () => {
+    armHappyMocks();
+    applyGatewayConfig.mockRejectedValue(new Error('config PUT failed'));
+    const { ctx, runMutation } = makeCtx();
+
+    await expect(armVisionLane(ctx, ARGS)).resolves.toBeUndefined();
+
+    expect(mintVirtualKey).not.toHaveBeenCalled();
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(sessionEnvPatch).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/node_only/sandbox/thread_session.ts
+++ b/services/platform/convex/node_only/sandbox/thread_session.ts
@@ -21,20 +21,142 @@
 
 import { v } from 'convex/values';
 
+import { formatModelRef } from '../../../lib/shared/utils/model-ref';
 import { internal } from '../../_generated/api';
+import type { ActionCtx } from '../../_generated/server';
 import { internalAction } from '../../_generated/server';
+import { loadOrgGatewayProviders } from '../../providers/file_actions';
+import { resolveLanguageModel } from '../../providers/resolve_model';
 import { sessionIdForThread } from '../../sandbox/session_naming';
 import {
   sessionCreate,
   sessionDestroy,
+  sessionEnvPatch,
   sessionIsAlive,
 } from './helpers/session_client';
+import {
+  applyGatewayConfig,
+  hashVirtualKey,
+  mintVirtualKey,
+  provisionProviders,
+  resolveGatewayRoutingFromRef,
+} from './llm_gateway_admin';
 
 const OWNER_TYPE = 'thread';
 // run_code is untrusted user code — keep the hardened one-shot posture
 // (uid 65534). (A long-lived `run_code` profile that also drops the
 // cumulative-CPU ulimit is a follow-up on the sandbox side.)
 const PROFILE = 'default' as const;
+
+// Vision lane (tale-vision CLI in run_code execs): per-session gateway key
+// budget + TTL. Small on purpose — vision-only, one turn's worth of images.
+const VISION_BUDGET_CENTS = (() => {
+  const parsed = Number(process.env.RUN_CODE_VISION_BUDGET_CENTS ?? '200');
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 200;
+})();
+const VISION_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
+// Always the sandbox-network alias (hardcoded in the runtime NO_PROXY); kept
+// separate from SANDBOX_LLM_GATEWAY_URL so host-run convex doesn't leak a
+// host-only URL into the container (same split as run_external_agent.ts).
+const VISION_GATEWAY_URL =
+  process.env.EXTERNAL_AGENT_GATEWAY_URL ?? 'http://sandbox-llm-gateway:8080';
+
+/**
+ * Arm the vision lane on a freshly (re)created thread session: mint a gateway
+ * virtual key scoped to ONLY the org's vision-tagged model and patch
+ * `TALE_GATEWAY_URL`/`TALE_GATEWAY_TOKEN`/`TALE_VISION_MODEL` into the
+ * session env store, so the baked `tale-vision` CLI works from run_code
+ * execs.
+ *
+ * Best-effort BY DESIGN — a posture difference from the external-agent path,
+ * where a gateway-auth failure fails the turn (fail-closed): here vision is a
+ * convenience capability, so ANY failure (no vision-tagged model, gateway
+ * down, provisioning error) logs, and the session comes up without vision —
+ * the CLI then exits 2 with an actionable message. Ordering matters: the
+ * token row is inserted BEFORE the env patch so a crash can never leave an
+ * injected-but-untracked key; turn-end teardown revokes every token row of
+ * the session (session_teardown.ts) including stale ones from mid-turn
+ * recreates. A reaped container always needs a fresh mint — the plaintext key
+ * exists only in the container's in-memory env store, never on the platform.
+ */
+export async function armVisionLane(
+  ctx: ActionCtx,
+  args: { organizationId: string; threadId: string; sessionId: string },
+): Promise<void> {
+  const started = Date.now();
+  try {
+    // Throws when the org has no vision-tagged model → graceful skip.
+    const vision = await resolveLanguageModel(ctx, {
+      tag: 'vision',
+      organizationId: args.organizationId,
+    });
+    const visionModelRef = formatModelRef({
+      providerName: vision.modelData.providerName,
+      modelId: vision.modelData.modelId,
+    });
+    const gatewayModel =
+      resolveGatewayRoutingFromRef(visionModelRef).gatewayModel;
+
+    // Chat sessions never provision the gateway otherwise. mintVirtualKey
+    // fails closed on a missing provider key, so a provisioning failure
+    // surfaces as a skipped lane, never an over-permissive key (same layering
+    // as run_external_agent.ts).
+    const gatewayProviders = await loadOrgGatewayProviders(
+      ctx,
+      args.organizationId,
+    );
+    if (gatewayProviders.length > 0) {
+      await provisionProviders(args.organizationId, gatewayProviders);
+    }
+    await applyGatewayConfig();
+
+    const minted = await mintVirtualKey({
+      budgetCents: VISION_BUDGET_CENTS,
+      allowedModels: [visionModelRef],
+      organizationId: args.organizationId,
+      sessionId: args.sessionId,
+    });
+    await ctx.runMutation(
+      internal.sandbox.session_mutations.insertSessionToken,
+      {
+        organizationId: args.organizationId,
+        sessionId: args.sessionId,
+        tokenHash: hashVirtualKey(minted.key),
+        llmGatewayKeyId: minted.keyId,
+        scope: {
+          agentKind: 'run_code_vision',
+          allowedModels: [visionModelRef],
+          integrationGrants: [],
+          toolGrants: [],
+          budgetCents: VISION_BUDGET_CENTS,
+          threadId: args.threadId,
+        },
+        expiresAt: Date.now() + VISION_TOKEN_TTL_MS,
+      },
+    );
+    const denied = await sessionEnvPatch(args.sessionId, {
+      set: {
+        TALE_GATEWAY_URL: VISION_GATEWAY_URL,
+        TALE_GATEWAY_TOKEN: minted.key,
+        TALE_VISION_MODEL: gatewayModel,
+      },
+    });
+    if (denied.length > 0) {
+      console.warn(
+        `[thread_session] vision env names denied by runnerd:`,
+        denied,
+      );
+    }
+    console.log(
+      `[thread_session] vision lane armed for ${args.sessionId} in ${Date.now() - started}ms (model ${gatewayModel})`,
+    );
+  } catch (err) {
+    console.warn(
+      `[thread_session] vision lane not armed for ${args.sessionId} after ${Date.now() - started}ms (run_code continues without tale-vision):`,
+      err,
+    );
+  }
+}
 
 /**
  * Ensure the thread's session exists and is live; create or resume it.
@@ -76,6 +198,11 @@ export const ensureThreadSession = internalAction({
         internal.sandbox.session_mutations.resumeStoppedSession,
         { organizationId: args.organizationId, sessionId },
       );
+      await armVisionLane(ctx, {
+        organizationId: args.organizationId,
+        threadId: args.threadId,
+        sessionId,
+      });
       return { sessionId, created: false };
     }
 
@@ -111,6 +238,11 @@ export const ensureThreadSession = internalAction({
     await ctx.runMutation(internal.sandbox.session_mutations.setSessionStatus, {
       rowId,
       status: 'active',
+    });
+    await armVisionLane(ctx, {
+      organizationId: args.organizationId,
+      threadId: args.threadId,
+      sessionId,
     });
     return { sessionId, created: true };
   },

--- a/services/platform/tests/integration/container-sandbox-runtime-test.ts
+++ b/services/platform/tests/integration/container-sandbox-runtime-test.ts
@@ -105,6 +105,30 @@ await assertContains('node present', 65534, 'v', 'node --version');
 await assertOk('uv present', 65534, 'command -v uv');
 // bun + bunx — many JS/TS projects (Tale included) use them.
 await assertOk('bun present', 65534, 'command -v bun && command -v bunx');
+// Batch vision CLI — chat run_code execs run at this uid.
+await assertOk(
+  'tale-vision present',
+  65534,
+  'test -x /usr/local/bin/tale-vision',
+);
+await assertOk(
+  'tale-vision venv imports Pillow under -E',
+  65534,
+  '/opt/tale-vision/bin/python -E -c "import PIL"',
+);
+// The shim must neutralize the per-exec user PYTHONPATH (entrypoint.sh
+// prepends /user/.runtime/deps/python) or a user-installed fake PIL could
+// shadow the venv's.
+await assertOk(
+  'tale-vision shim runs python -E -s',
+  65534,
+  "grep -q ' -E -s ' /usr/local/bin/tale-vision",
+);
+await assertOk(
+  'venv PIL immune to PYTHONPATH shadowing',
+  65534,
+  `mkdir -p /workspace/fake/PIL && printf 'raise RuntimeError("shadowed")\\n' > /workspace/fake/PIL/__init__.py && PYTHONPATH=/workspace/fake /opt/tale-vision/bin/python -E -c 'import PIL; assert "tale-vision" in PIL.__file__, PIL.__file__'`,
+);
 
 console.log('');
 console.log('--- agent session role (uid 10001) ---');
@@ -354,6 +378,12 @@ print("OPENCLAW_WRAPPER_FLAGS_OK")
 }
 await assertOk('agent on PATH', 10001, 'command -v agent');
 await assertOk('agent --version runs', 10001, 'agent --version');
+// Coding agents (session role) shell out to the same vision CLI.
+await assertOk(
+  'tale-vision usable at agent uid',
+  10001,
+  'test -x /usr/local/bin/tale-vision && /opt/tale-vision/bin/python -E -c "import PIL"',
+);
 // HOME on the workspace volume must be writable for agent state.
 await assertOk(
   'HOME writable for agent state',
@@ -558,6 +588,101 @@ console.log(
   } finally {
     if (cid) await ok(['docker', 'rm', '-f', cid]);
   }
+}
+
+console.log('');
+console.log('--- tale-vision analyzes against a stub gateway ---');
+// End-to-end inside the image at the run_code uid: stub Anthropic-Messages
+// server (429 first, then 200), 3000×1500 noise PNG → assert downscale
+// (payload < original, longest edge ≤ --max-edge), NDJSON shape, retry, and
+// the per-turn cache short-circuiting the second run. No real model/key.
+{
+  const functional = `
+import base64, json, os, subprocess, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+state = {"count": 0}
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        state["count"] += 1
+        if self.headers.get("authorization") != "Bearer sk-bf-test":
+            self.send_response(401); self.end_headers(); return
+        n = int(self.headers.get("content-length", 0))
+        body = json.loads(self.rfile.read(n))
+        img = body["messages"][0]["content"][0]["source"]["data"]
+        with open("/workspace/sent.bin", "wb") as f:
+            f.write(base64.b64decode(img))
+        if state["count"] == 1:
+            self.send_response(429); self.end_headers(); return
+        payload = json.dumps(
+            {"content": [{"type": "text", "text": f"OK#{state['count']}"}]}
+        ).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass
+
+srv = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+port = srv.server_address[1]
+
+vp = "/opt/tale-vision/bin/python"
+subprocess.run(
+    [vp, "-E", "-c",
+     "import os; from PIL import Image; "
+     "Image.frombytes('RGB', (3000, 1500), os.urandom(3000*1500*3))"
+     ".save('/workspace/big.png')"],
+    check=True,
+)
+env = dict(
+    os.environ,
+    TALE_GATEWAY_URL=f"http://127.0.0.1:{port}",
+    TALE_GATEWAY_TOKEN="sk-bf-test",
+    TALE_VISION_MODEL="stub-vision",
+    TMPDIR="/workspace",
+)
+
+r1 = subprocess.run(
+    ["tale-vision", "/workspace/big.png", "--max-edge", "2000"],
+    capture_output=True, text=True, env=env,
+)
+assert r1.returncode == 0, f"first run failed: {r1.stderr[:300]}"
+line1 = json.loads(r1.stdout.strip().splitlines()[-1])
+assert line1["ok"] and line1["cached"] is False and line1["text"] == "OK#2", line1
+assert state["count"] == 2, state  # 429 → retried → 200
+
+sent = os.path.getsize("/workspace/sent.bin")
+orig = os.path.getsize("/workspace/big.png")
+assert 0 < sent < orig, (sent, orig)
+edge = subprocess.run(
+    [vp, "-E", "-c",
+     "from PIL import Image; print(max(Image.open('/workspace/sent.bin').size))"],
+    capture_output=True, text=True, check=True,
+).stdout.strip()
+assert int(edge) <= 2000, edge
+
+r2 = subprocess.run(
+    ["tale-vision", "/workspace/big.png", "--max-edge", "2000"],
+    capture_output=True, text=True, env=env,
+)
+line2 = json.loads(r2.stdout.strip().splitlines()[-1])
+assert r2.returncode == 0 and line2["cached"] is True, (r2.returncode, line2)
+assert line2["text"] == "OK#2", line2
+assert state["count"] == 2, state  # cache hit → no new gateway call
+
+print("TALE_VISION_FUNCTIONAL_OK")
+`;
+  await assertContains(
+    'tale-vision downscale/retry/cache against a stub gateway',
+    65534,
+    'TALE_VISION_FUNCTIONAL_OK',
+    `python3 - <<'PYEOF'\n${functional}\nPYEOF`,
+  );
 }
 
 console.log('');

--- a/services/sandbox-llm-gateway/README.md
+++ b/services/sandbox-llm-gateway/README.md
@@ -1,10 +1,10 @@
 # @tale/sandbox-llm-gateway
 
-The sandbox LLM gateway ([maximhq/bifrost](https://github.com/maximhq/bifrost) core). The single path from an in-sandbox coding agent (Claude Code / OpenCode) to an LLM.
+The sandbox LLM gateway ([maximhq/bifrost](https://github.com/maximhq/bifrost) core). The single path from in-sandbox code to an LLM — coding agents (Claude Code / OpenCode), and the `tale-vision` CLI that chat `run_code` execs use for image analysis.
 
 ## Overview
 
-Raw provider API keys live ONLY here and in the platform. The sandbox holds a session-scoped `sk-bf-*` virtual key (budget + model allowlist), revoked at session destroy. The platform is the source of truth for providers/models; it provisions the gateway via the management API on session create (`convex/node_only/sandbox/llm_gateway_admin.ts`).
+Raw provider API keys live ONLY here and in the platform. The sandbox holds a session-scoped `sk-bf-*` virtual key (budget + model allowlist), revoked at session destroy. The platform is the source of truth for providers/models; it provisions the gateway via the management API on session create (`convex/node_only/sandbox/llm_gateway_admin.ts`). Chat run_code sessions mint a narrower key still: vision-model-only, small budget (`armVisionLane`, `convex/node_only/sandbox/thread_session.ts`).
 
 Dual-homed onto two Docker networks:
 

--- a/services/sandbox-runtime/Dockerfile
+++ b/services/sandbox-runtime/Dockerfile
@@ -34,6 +34,7 @@ ARG PI_CODING_AGENT_VERSION=0.80.3
 ARG OPENCLAW_VERSION=2026.6.11
 ARG PLAYWRIGHT_MCP_VERSION=0.0.41
 ARG GH_VERSION=2.62.0
+ARG PILLOW_VERSION=12.3.0
 ARG TARGETARCH
 
 # Runtime additions — fontconfig + DejaVu so Pillow/matplotlib render text,
@@ -434,6 +435,18 @@ COPY services/sandbox-runtime/tale-integrations-mcp /usr/local/bin/tale-integrat
 COPY services/sandbox-runtime/tale-vision-transcribe /usr/local/bin/tale-vision-transcribe
 COPY services/sandbox-runtime/tale-vision-read-hook /usr/local/bin/tale-vision-read-hook
 
+# Batch vision CLI for in-sandbox code (`run_code` scripts and coding agents):
+# analyzes images via the platform LLM gateway with the session virtual key —
+# same no-provider-key-in-container lane as tale-vision-transcribe (which stays
+# the single-image Read-hook polyfill). Pillow lives in a dedicated venv and
+# the shim runs `python -E -s` so the per-exec user deps that entrypoint.sh
+# prepends onto PYTHONPATH (/user/.runtime/deps/python) can never shadow PIL.
+RUN python3 -m venv /opt/tale-vision \
+    && /opt/tale-vision/bin/pip install --no-cache-dir "Pillow==${PILLOW_VERSION}" \
+    && printf '#!/bin/sh\nexec /opt/tale-vision/bin/python -E -s /opt/tale-vision/cli.py "$@"\n' \
+       > /usr/local/bin/tale-vision
+COPY services/sandbox-runtime/tale-vision /opt/tale-vision/cli.py
+
 # Human-control MCP bridge: a dependency-free stdio MCP server exposing
 # request_human_control({reason}). The agent calls it to hand the live browser
 # to a human (CAPTCHA/login/2FA); the platform observes the tool_use, parks the
@@ -445,6 +458,7 @@ COPY services/sandbox-runtime/entrypoint.sh /entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh /entrypoint.sh /usr/local/bin/tale-git-credential \
       /usr/local/bin/tale-playwright-mcp /usr/local/bin/tale-integrations-mcp \
       /usr/local/bin/tale-vision-transcribe /usr/local/bin/tale-vision-read-hook \
+      /usr/local/bin/tale-vision \
       /usr/local/bin/tale-human-control-mcp \
       /usr/local/bin/tale-steer-hook \
       /usr/local/bin/tale-plan-gate

--- a/services/sandbox-runtime/daemon/src/tale-vision.test.ts
+++ b/services/sandbox-runtime/daemon/src/tale-vision.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const CLI = resolve(import.meta.dir, '../../tale-vision');
+
+// Host-run guards: the baked venv always has python3+Pillow; on dev hosts the
+// suite needs python3 (all tests) and Pillow (downscale test only) — the
+// container conformance test covers the full matrix unconditionally.
+const hasPython = spawnSync('python3', ['-V']).status === 0;
+const hasPil =
+  hasPython && spawnSync('python3', ['-c', 'import PIL']).status === 0;
+const pyTest = hasPython ? test : test.skip;
+const pilTest = hasPil ? test : test.skip;
+
+// Canonical 1×1 transparent PNG — decodes under Pillow and sniffs without it.
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64',
+);
+
+interface StubRequest {
+  authorization: string | null;
+  anthropicVersion: string | null;
+  model: unknown;
+  imageBytes: number;
+  mediaType: unknown;
+}
+
+// Assertion-free traversal of the unknown request body (satisfies both the
+// strict tsconfig and the no-unsafe-type-assertion lint rule).
+const pick = (value: unknown, key: string): unknown => {
+  if (typeof value !== 'object' || value === null) return undefined;
+  return Object.entries(value).find(([k]) => k === key)?.[1];
+};
+const head = (value: unknown): unknown =>
+  Array.isArray(value) ? value[0] : undefined;
+
+/** Anthropic-Messages-shaped stub gateway; `failFirst` 429s the first call.
+ * The CLI must be spawned ASYNC (Bun.spawn): a spawnSync would block this
+ * process's event loop and the stub could never answer. */
+const startStub = (opts: { failFirst?: boolean } = {}) => {
+  const requests: StubRequest[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const body: unknown = await req.json();
+      const source = pick(
+        head(pick(head(pick(body, 'messages')), 'content')),
+        'source',
+      );
+      const data = pick(source, 'data');
+      requests.push({
+        authorization: req.headers.get('authorization'),
+        anthropicVersion: req.headers.get('anthropic-version'),
+        model: pick(body, 'model'),
+        imageBytes: Buffer.from(typeof data === 'string' ? data : '', 'base64')
+          .length,
+        mediaType: pick(source, 'media_type'),
+      });
+      if (opts.failFirst && requests.length === 1) {
+        return new Response('rate limited', { status: 429 });
+      }
+      return Response.json({
+        content: [{ type: 'text', text: `STUB ANALYSIS #${requests.length}` }],
+      });
+    },
+  });
+  return { server, requests, url: `http://127.0.0.1:${server.port}` };
+};
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = realpathSync(mkdtempSync(`${tmpdir()}/tale-vision-`));
+});
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+const runCli = async (
+  args: string[],
+  env: Record<string, string>,
+  input?: Buffer,
+) => {
+  const cleanEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) cleanEnv[key] = value;
+  }
+  const proc = Bun.spawn({
+    cmd: ['python3', CLI, ...args],
+    env: {
+      ...cleanEnv,
+      TALE_GATEWAY_URL: '',
+      TALE_GATEWAY_TOKEN: '',
+      TALE_VISION_MODEL: '',
+      // Cache falls back to $TMPDIR/tale-vision (no /user on hosts); pin it
+      // into the per-test dir so cache tests are isolated.
+      TMPDIR: workDir,
+      ...env,
+    },
+    stdin: input ? new Uint8Array(input) : 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, status] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { status, stdout, stderr };
+};
+
+const gatewayEnv = (url: string) => ({
+  TALE_GATEWAY_URL: url,
+  TALE_GATEWAY_TOKEN: 'sk-bf-test',
+  TALE_VISION_MODEL: 'stub-vision',
+});
+
+const ndjson = (stdout: string) =>
+  stdout
+    .trim()
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+
+describe('tale-vision', () => {
+  pyTest(
+    'missing env → exit 2 with actionable message, no output',
+    async () => {
+      const png = join(workDir, 'a.png');
+      writeFileSync(png, TINY_PNG);
+      const { status, stdout, stderr } = await runCli([png], {});
+      expect(status).toBe(2);
+      expect(stdout.trim()).toBe('');
+      expect(stderr).toContain('not configured');
+      expect(stderr).toContain('TALE_VISION_MODEL');
+    },
+  );
+
+  pyTest('happy path: NDJSON line with gateway contract headers', async () => {
+    const { server, requests, url } = startStub();
+    try {
+      const png = join(workDir, 'a.png');
+      writeFileSync(png, TINY_PNG);
+      const { status, stdout } = await runCli([png], gatewayEnv(url));
+      expect(status).toBe(0);
+      const lines = ndjson(stdout);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        path: png,
+        ok: true,
+        text: 'STUB ANALYSIS #1',
+        cached: false,
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.authorization).toBe('Bearer sk-bf-test');
+      expect(requests[0]?.anthropicVersion).toBe('2023-06-01');
+      expect(requests[0]?.model).toBe('stub-vision');
+      expect(requests[0]?.mediaType).toBe('image/png');
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  pyTest(
+    'continue-on-error: unreadable input fails its line only, exit 1',
+    async () => {
+      const { server, url } = startStub();
+      try {
+        const png = join(workDir, 'a.png');
+        writeFileSync(png, TINY_PNG);
+        const missing = join(workDir, 'nope.png');
+        const { status, stdout } = await runCli(
+          [png, missing],
+          gatewayEnv(url),
+        );
+        expect(status).toBe(1);
+        const lines = ndjson(stdout);
+        expect(lines).toHaveLength(2);
+        const good = lines.find((l) => l.path === png);
+        const bad = lines.find((l) => l.path === missing);
+        expect(good).toMatchObject({ ok: true, text: 'STUB ANALYSIS #1' });
+        expect(bad?.ok).toBe(false);
+        expect(String(bad?.error)).toContain('could not read input');
+      } finally {
+        void server.stop(true);
+      }
+    },
+  );
+
+  pyTest(
+    'cache: second run answers from cache without a gateway call',
+    async () => {
+      const { server, requests, url } = startStub();
+      try {
+        const png = join(workDir, 'a.png');
+        writeFileSync(png, TINY_PNG);
+        const first = await runCli([png], gatewayEnv(url));
+        expect(first.status).toBe(0);
+        expect(ndjson(first.stdout)[0]).toMatchObject({ cached: false });
+
+        const second = await runCli([png], gatewayEnv(url));
+        expect(second.status).toBe(0);
+        expect(ndjson(second.stdout)[0]).toMatchObject({
+          ok: true,
+          text: 'STUB ANALYSIS #1',
+          cached: true,
+        });
+        expect(requests).toHaveLength(1);
+      } finally {
+        void server.stop(true);
+      }
+    },
+  );
+
+  pyTest('retry: 429 then 200 succeeds with two gateway calls', async () => {
+    const { server, requests, url } = startStub({ failFirst: true });
+    try {
+      const png = join(workDir, 'a.png');
+      writeFileSync(png, TINY_PNG);
+      const { status, stdout } = await runCli([png], gatewayEnv(url));
+      expect(status).toBe(0);
+      expect(ndjson(stdout)[0]).toMatchObject({
+        ok: true,
+        text: 'STUB ANALYSIS #2',
+      });
+      expect(requests).toHaveLength(2);
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  pyTest("stdin: '-' analyzes bytes from stdin", async () => {
+    const { server, requests, url } = startStub();
+    try {
+      const { status, stdout } = await runCli(['-'], gatewayEnv(url), TINY_PNG);
+      expect(status).toBe(0);
+      expect(ndjson(stdout)[0]).toMatchObject({
+        path: '-',
+        ok: true,
+        text: 'STUB ANALYSIS #1',
+      });
+      expect(requests).toHaveLength(1);
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  pilTest(
+    'downscale: oversized PNG is shrunk before upload',
+    async () => {
+      const { server, requests, url } = startStub();
+      try {
+        const big = join(workDir, 'big.png');
+        const gen = spawnSync(
+          'python3',
+          [
+            '-c',
+            `import os; from PIL import Image; Image.frombytes('RGB', (3000, 1500), os.urandom(3000*1500*3)).save(${JSON.stringify(big)})`,
+          ],
+          { encoding: 'utf8' },
+        );
+        expect(gen.status).toBe(0);
+
+        const { status, stdout } = await runCli(
+          [big, '--max-edge', '2000'],
+          gatewayEnv(url),
+        );
+        expect(status).toBe(0);
+        expect(ndjson(stdout)[0]).toMatchObject({ ok: true });
+        expect(requests).toHaveLength(1);
+        const sent = requests[0]?.imageBytes ?? 0;
+        expect(sent).toBeGreaterThan(0);
+        // 3000×1500 noise → 2000×1000: the re-encoded payload must be far
+        // smaller than the original file (dimension proof lives in the
+        // container test, which decodes the payload with the venv's Pillow).
+        const original = Bun.file(big).size;
+        expect(sent).toBeLessThan(original);
+      } finally {
+        void server.stop(true);
+      }
+    },
+    20000,
+  );
+});

--- a/services/sandbox-runtime/tale-vision
+++ b/services/sandbox-runtime/tale-vision
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""tale-vision — batch image analysis for in-sandbox code, via the platform
+LLM gateway.
+
+Analyzes images with the org's vision model THROUGH THE PLATFORM GATEWAY, so
+no raw provider key ever enters the container — the same lane as
+`tale-vision-transcribe` (which stays the single-image Read-hook polyfill;
+this CLI is the batch/code-facing superset).
+
+  tale-vision <image-path>... [--question "..."]   one NDJSON line per input
+  tale-vision - < image.png                        read one image from stdin
+
+Env contract (injected by the platform when the org has a vision model):
+  TALE_GATEWAY_URL    gateway root, e.g. http://sandbox-llm-gateway:8080
+  TALE_GATEWAY_TOKEN  session virtual key (sent as Bearer)
+  TALE_VISION_MODEL   gateway model id (`--model` overrides)
+
+Behaviour:
+  * Downscales before upload (longest edge `--max-edge`, default 2000):
+    vision models downsample anyway, so this is model-lossless and cuts the
+    payload by orders of magnitude for screenshots. Re-encoding is
+    deterministic (fixed params, no timestamps) so cache keys are stable.
+  * Caches results per (processed bytes, question, model) under
+    /user/.cache/tale-vision — re-running after a run_code timeout is free
+    for already-analyzed images within the turn.
+  * Bounded concurrency, per-image timeout, retry with backoff on 429/5xx,
+    continue-on-error per image; each NDJSON line is flushed immediately so
+    partial output survives an exec timeout.
+  * Animated inputs: first frame only.
+
+Output: one JSON object per line —
+  {"path": ..., "ok": true,  "text": ..., "cached": true|false}
+  {"path": ..., "ok": false, "error": ...}
+
+Exit codes: 0 all inputs ok · 1 any input failed · 2 usage/config error.
+"""
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import random
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+ANTHROPIC_VERSION = "2023-06-01"
+MAX_TOKENS = 1024
+# The gateway lives on the sandbox-internal docker network — never route it
+# through an egress proxy, whatever HTTP(S)_PROXY says (Node's fetch in
+# tale-vision-transcribe ignores proxy env for the same reason).
+_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+RETRY_ATTEMPTS = 3
+RETRY_BASE_S = 0.5
+# Keep the original bytes verbatim when already small enough; re-encoded
+# JPEGs step q85→q75→q65 until they fit. Anything the encoder cannot get
+# under the hard cap is refused per-image (the gateway/model would anyway).
+PASSTHROUGH_MAX_BYTES = 1_572_864  # 1.5 MiB
+HARD_PAYLOAD_MAX_BYTES = 4 * 1024 * 1024
+JPEG_QUALITIES = (85, 75, 65)
+
+DEFAULT_PROMPT = (
+    "Describe this image and extract its text and any structured fields "
+    "verbatim. Preserve numbers, dates, and identifiers exactly."
+)
+
+MEDIA_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+_pil_modules = None
+_pil_checked = False
+
+
+def _pil():
+    """Lazy PIL import: the baked venv always has Pillow; host test runs may
+    not, in which case images pass through un-downscaled (size-guarded)."""
+    global _pil_modules, _pil_checked
+    if not _pil_checked:
+        _pil_checked = True
+        try:
+            from PIL import Image, ImageOps  # noqa: PLC0415
+
+            _pil_modules = (Image, ImageOps)
+        except ImportError:
+            _pil_modules = None
+    return _pil_modules
+
+
+def sniff_media_type(data):
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+class ImageError(Exception):
+    """Per-image failure (bad input, oversize, gateway error) — the batch
+    continues; the message becomes the NDJSON `error` field."""
+
+
+def prepare_image(data, max_edge):
+    """Return (payload_bytes, media_type), downscaled/re-encoded when needed.
+
+    Deterministic: same input bytes + same max_edge → same output bytes
+    (fixed resample/quality, no metadata added), so the cache key is stable
+    across re-runs.
+    """
+    if len(data) == 0:
+        raise ImageError("empty input")
+    pil = _pil()
+    if pil is None:
+        media = sniff_media_type(data)
+        if media is None:
+            raise ImageError("unrecognized image format (expected PNG/JPEG/WebP/GIF)")
+        if len(data) > HARD_PAYLOAD_MAX_BYTES:
+            raise ImageError(
+                f"image is {len(data)} bytes > {HARD_PAYLOAD_MAX_BYTES} and Pillow "
+                "is unavailable to downscale it — provide a smaller image"
+            )
+        return data, media
+
+    image_mod, imageops_mod = pil
+    try:
+        img = image_mod.open(io.BytesIO(data))
+        img.load()
+    except Exception as err:
+        raise ImageError(f"could not decode image: {err}") from err
+
+    original_format = (img.format or "").upper()
+    img = imageops_mod.exif_transpose(img)
+    needs_resize = max(img.size) > max_edge
+
+    # Small enough and already in a wire format the model accepts → send the
+    # original bytes verbatim (best fidelity, cheapest, trivially stable key).
+    if (
+        not needs_resize
+        and len(data) <= PASSTHROUGH_MAX_BYTES
+        and original_format in ("PNG", "JPEG", "WEBP", "GIF")
+    ):
+        return data, f"image/{'jpeg' if original_format == 'JPEG' else original_format.lower()}"
+
+    if needs_resize:
+        scale = max_edge / max(img.size)
+        new_size = (
+            max(1, round(img.size[0] * scale)),
+            max(1, round(img.size[1] * scale)),
+        )
+        img = img.resize(new_size, image_mod.Resampling.LANCZOS)
+
+    # PNG stays PNG when that stays small (UI screenshots: text legibility over
+    # size); everything else — or a fat PNG — goes lossy JPEG, stepping the
+    # quality down until it fits.
+    if original_format == "PNG":
+        buf = io.BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        if buf.tell() <= PASSTHROUGH_MAX_BYTES:
+            return buf.getvalue(), "image/png"
+
+    if img.mode in ("RGBA", "LA", "P", "PA"):
+        rgba = img.convert("RGBA")
+        flat = image_mod.new("RGB", rgba.size, (255, 255, 255))
+        flat.paste(rgba, mask=rgba.split()[-1])
+        img = flat
+    elif img.mode != "RGB":
+        img = img.convert("RGB")
+    for quality in JPEG_QUALITIES:
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=quality)
+        if buf.tell() <= PASSTHROUGH_MAX_BYTES:
+            return buf.getvalue(), "image/jpeg"
+    if buf.tell() <= HARD_PAYLOAD_MAX_BYTES:
+        return buf.getvalue(), "image/jpeg"
+    raise ImageError(
+        f"image still {buf.tell()} bytes after downscaling to edge {max_edge} "
+        f"and JPEG q{JPEG_QUALITIES[-1]} — try a smaller --max-edge"
+    )
+
+
+def cache_dir():
+    for candidate in (
+        "/user/.cache/tale-vision",
+        os.path.join(tempfile.gettempdir(), "tale-vision"),
+    ):
+        try:
+            os.makedirs(candidate, exist_ok=True)
+            if os.access(candidate, os.W_OK):
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def cache_key(payload, question, model):
+    h = hashlib.sha256()
+    h.update(payload)
+    h.update(b"\x00")
+    h.update(question.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(model.encode("utf-8"))
+    return h.hexdigest()
+
+
+def cache_get(directory, key):
+    if directory is None:
+        return None
+    try:
+        with open(os.path.join(directory, f"{key}.json"), encoding="utf-8") as f:
+            entry = json.load(f)
+        text = entry.get("text")
+        return text if isinstance(text, str) else None
+    except (OSError, ValueError):
+        return None
+
+
+def cache_put(directory, key, text):
+    if directory is None:
+        return
+    path = os.path.join(directory, f"{key}.json")
+    try:
+        tmp = f"{path}.{os.getpid()}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"text": text}, f)
+        os.replace(tmp, path)
+    except OSError as err:
+        print(f"tale-vision: cache write failed: {err}", file=sys.stderr)
+
+
+def call_gateway(cfg, payload, media_type, question, deadline):
+    """POST the Anthropic Messages request; retry 429/5xx/transient network
+    errors with jittered backoff, all bounded by the per-image deadline."""
+    body = json.dumps(
+        {
+            "model": cfg["model"],
+            "max_tokens": MAX_TOKENS,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": base64.b64encode(payload).decode("ascii"),
+                            },
+                        },
+                        {"type": "text", "text": question},
+                    ],
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+    last_error = "unknown error"
+    for attempt in range(RETRY_ATTEMPTS):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ImageError(f"timed out ({last_error})")
+        req = urllib.request.Request(
+            f"{cfg['url']}/anthropic/v1/messages",
+            data=body,
+            headers={
+                "content-type": "application/json",
+                "authorization": f"Bearer {cfg['token']}",
+                "anthropic-version": ANTHROPIC_VERSION,
+            },
+            method="POST",
+        )
+        retryable = False
+        try:
+            with _OPENER.open(req, timeout=remaining) as res:
+                raw = res.read().decode("utf-8", "replace")
+            parsed = json.loads(raw)
+            blocks = parsed.get("content")
+            text = "\n".join(
+                b.get("text", "")
+                for b in blocks
+                if isinstance(b, dict) and b.get("type") == "text"
+            ).strip() if isinstance(blocks, list) else ""
+            return text or "(vision model returned no text)"
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode("utf-8", "replace")[:500]
+            last_error = f"vision model call failed (status {err.code}): {detail}"
+            retryable = err.code == 429 or 500 <= err.code < 600
+        except urllib.error.URLError as err:
+            last_error = f"vision gateway request failed: {err.reason}"
+            retryable = True
+        except (TimeoutError, json.JSONDecodeError, OSError) as err:
+            last_error = f"vision gateway request failed: {err}"
+            retryable = True
+        if not retryable or attempt == RETRY_ATTEMPTS - 1:
+            raise ImageError(last_error)
+        backoff = RETRY_BASE_S * (2**attempt) + random.uniform(0, 0.25)
+        time.sleep(min(backoff, max(0.0, deadline - time.monotonic())))
+    raise ImageError(last_error)
+
+
+def analyze_one(cfg, label, data):
+    payload, media_type = prepare_image(data, cfg["max_edge"])
+    key = cache_key(payload, cfg["question"], cfg["model"])
+    cached = cache_get(cfg["cache_dir"], key)
+    if cached is not None:
+        return {"path": label, "ok": True, "text": cached, "cached": True}
+    deadline = time.monotonic() + cfg["timeout"]
+    text = call_gateway(cfg, payload, media_type, cfg["question"], deadline)
+    cache_put(cfg["cache_dir"], key, text)
+    return {"path": label, "ok": True, "text": text, "cached": False}
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog="tale-vision",
+        description="Analyze images with the org's vision model via the "
+        "platform LLM gateway. Prints one NDJSON line per input. Animated "
+        "inputs: first frame only.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        metavar="path",
+        help="image files (PNG/JPEG/WebP/GIF); '-' reads one image from stdin",
+    )
+    parser.add_argument(
+        "--question",
+        default=DEFAULT_PROMPT,
+        help="what to ask about each image (default: describe + extract text)",
+    )
+    parser.add_argument(
+        "--max-edge",
+        type=int,
+        default=2000,
+        help="downscale so the longest edge is at most this (default 2000)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=3,
+        help="images analyzed in parallel (default 3)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60,
+        help="per-image seconds incl. retries (default 60)",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="override TALE_VISION_MODEL",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    url = (os.environ.get("TALE_GATEWAY_URL") or "").rstrip("/")
+    token = os.environ.get("TALE_GATEWAY_TOKEN") or ""
+    model = args.model or os.environ.get("TALE_VISION_MODEL") or ""
+    if not url or not token or not model:
+        print(
+            "tale-vision: the vision lane is not configured for this session "
+            "(missing TALE_GATEWAY_URL / TALE_GATEWAY_TOKEN / TALE_VISION_MODEL) "
+            "— no vision model is available here.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.paths.count("-") > 1:
+        print("tale-vision: '-' (stdin) may be given only once", file=sys.stderr)
+        return 2
+    if args.max_edge < 1 or args.concurrency < 1 or args.timeout <= 0:
+        print(
+            "tale-vision: --max-edge/--concurrency/--timeout must be positive",
+            file=sys.stderr,
+        )
+        return 2
+
+    cfg = {
+        "url": url,
+        "token": token,
+        "model": model,
+        "question": args.question,
+        "max_edge": args.max_edge,
+        "timeout": args.timeout,
+        "cache_dir": cache_dir(),
+    }
+
+    stdout_lock = threading.Lock()
+    any_failed = False
+
+    def emit(line):
+        with stdout_lock:
+            print(json.dumps(line, ensure_ascii=False), flush=True)
+
+    def run(label):
+        if label == "-":
+            data = sys.stdin.buffer.read()
+        else:
+            with open(label, "rb") as f:
+                data = f.read()
+        return analyze_one(cfg, label, data)
+
+    with ThreadPoolExecutor(max_workers=min(args.concurrency, len(args.paths))) as pool:
+        futures = {pool.submit(run, label): label for label in args.paths}
+        for future in as_completed(futures):
+            label = futures[future]
+            try:
+                emit(future.result())
+            except ImageError as err:
+                any_failed = True
+                emit({"path": label, "ok": False, "error": str(err)})
+            except OSError as err:
+                any_failed = True
+                emit({"path": label, "ok": False, "error": f"could not read input: {err}"})
+
+    return 1 if any_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/services/sandbox/docs/run-code-persistent-sessions.md
+++ b/services/sandbox/docs/run-code-persistent-sessions.md
@@ -93,6 +93,20 @@ session STOPPED (workspace preserved) → next turn resumes it
 - **Create hook:** first `run_code` of a turn. `run_code_tool.ts` already has
   `threadId` in `ctx`; it ensures/reuses the `thr-<threadId>` session and
   dispatches the exec into it instead of `spawnerExecute`.
+- **Vision lane (on create AND resume-after-reap):** right after
+  `sessionCreate`/`resumeStoppedSession`, `armVisionLane`
+  (`node_only/sandbox/thread_session.ts`) best-effort mints a gateway virtual
+  key scoped to ONLY the org's vision-tagged model
+  (`RUN_CODE_VISION_BUDGET_CENTS`, default 200¢/session), inserts its
+  `sandboxSessionTokens` row (with `llmGatewayKeyId`, so the normal teardown
+  revoke covers it), then patches
+  `TALE_GATEWAY_URL`/`TALE_GATEWAY_TOKEN`/`TALE_VISION_MODEL` into the session
+  env store — the contract the baked `tale-vision` CLI reads from run_code
+  execs. Any failure logs and the session comes up without vision (the CLI
+  exits 2 with an actionable message). A reaped-then-recreated container
+  always re-mints: the plaintext key exists only in the container's in-memory
+  env store; the superseded row stays budget-capped until teardown revokes
+  every row of the session.
 - **Stop hook:** `clearGenerationStatus` (`threads/internal_mutations.ts:427`)
   is the one place every terminal path converges (normal completion, user
   cancel, 35-min stale-recovery). It's a _mutation_, so it **schedules** an
@@ -297,6 +311,11 @@ required, though it remains a possible future cleanup.
   stop-schedule call in `clearGenerationStatus` / `cancel_generation` /
   `recover_stuck_chat_turns`, `file_write` live-stage, a `run_code` resource
   profile, and thread-delete → `destroySession`.
+- **Vision lane:** `armVisionLane` in `thread_session.ts` (mint + token row +
+  env patch, best-effort), the baked `tale-vision` CLI + its Pillow venv in
+  the runtime image, and one VISION line in the `run_code` tool description.
+  Teardown/revoke paths unchanged — the token row's `llmGatewayKeyId` rides
+  the existing `revokeTokensForSession` sweep.
 - **Unchanged (the compat win):** Canvas, file cards, `file_read`/`file_list`,
   `threadFiles` schema, all read `threadFiles` as before.
 - **Reused as-is:** `session_client` (create/exec/attach/stop/destroy/stage/


### PR DESCRIPTION
## Problem

Chat `run_code` lets the agent process user files in the sandbox with code, but code cannot *see* images — screenshots, scanned documents, matplotlib output. External coding agents already have an in-sandbox vision lane (`tale-vision-transcribe` through the LLM gateway with the session virtual key); chat run_code sessions had none.

## Design (agreed with Larry)

Reuse the existing gateway lane — no new platform HTTP surface, no fileId requirement:

- **`tale-vision` CLI** (baked into the runtime image, Python + Pillow in an isolated `/opt/tale-vision` venv, shim runs `python -E -s` so per-exec user deps can never shadow PIL): batch paths or stdin, `--question`, bounded concurrency, per-image timeout, 429/5xx retry with backoff, continue-on-error, NDJSON flushed per line. Deterministic client-side downscale (longest edge 2000; PNG kept when small, else JPEG q85→q75→q65) — model-lossless, cuts payloads by orders of magnitude.
- **Per-turn cache** keyed `sha256(processed bytes + question + model)` in the session workspace: a run_code timeout (hard cap 5 min/call) becomes a soft chunk boundary — re-running the same loop resumes free. Live measurement: 6061ms → 556ms.
- **`armVisionLane`** (`thread_session.ts`): on session create/recreate, mint a VK scoped to ONLY the org's vision-tagged model (deny-by-default allowlist, budget `RUN_CODE_VISION_BUDGET_CENTS` default 200¢, bound to the org's provider key), insert the `sandboxSessionTokens` row **before** the env patch (a crash can never leave an untracked live key), then patch `TALE_GATEWAY_URL/TOKEN` + `TALE_VISION_MODEL` into the runnerd env store. Best-effort: any failure logs and the session comes up without vision. Turn-end teardown revokes via the existing `revokeTokensForSession` + `revokeVirtualKey` sweep — zero new revoke machinery, zero schema changes, no migration.
- `tale-vision-transcribe`/`tale-vision-read-hook` untouched (frozen Read-hook polyfill contract); external agents get the new CLI for free (same env contract). Workflow code-steps: follow-up.

## Verification

- **Unit:** `daemon/src/tale-vision.test.ts` — 7/7 against a stub gateway (env-missing exit 2, NDJSON, continue-on-error, cache-hit with zero second call, 429→200 retry, stdin, downscale). `thread_session.test.ts` — 6/6 (mint scope/budget, insert-before-patch ordering, no-vision-model / mint-failure / patch-failure / gateway-config-failure postures).
- **Image conformance:** `bun run docker:test:sandbox-runtime` — **45/45**, incl. new checks (CLI at both uids, venv PIL under `-E`, PYTHONPATH-shadow guard, in-container functional test: stub gateway, 3000×1500 noise PNG → payload < original & longest edge ≤ 2000, 429 retry, cache short-circuit).
- **Live browser E2E on the dev stack:** uploaded a generated 2400×1200 invoice PNG, asked the agent to run `tale-vision` twice via run_code. First run `ok:true, cached:false` (6061ms) with every field read verbatim (RE-2026-0718, CHF 1250.00, 8.1%, CHF 1351.25); second run `cached:true` (556ms), byte-identical. The turn ran on **deepseek-v4-flash (text-only)** after an unrelated gemini region failover — a text-only chat model gained working vision through the sandbox CLI, which is exactly the point. Post-turn, the gateway VK list contains no `thr-*` key → teardown revoke confirmed.
- `bun run check`: all suites tied to this change green. Three unrelated failures exist on this dev machine: `slack/http_actions` + `scim/http_actions` (60s starvation timeouts under full parallel load; pass in isolation) and `observatory.test.ts` (B+ vs A+ — env-dependent: passes on a clean worktree of the same commit without the dev `.env.local`/org config; CSP-origins class, #2778).