### PR TITLE
fix(platform): video-link geoblock classification + chip error details

### DIFF
--- a/services/platform/app/features/chat/components/video-link-chip.test.tsx
+++ b/services/platform/app/features/chat/components/video-link-chip.test.tsx
@@ -62,6 +62,21 @@ describe('VideoLinkChip', () => {
       await checkAccessibility(container);
     });
 
+    it('passes axe audit in failed state with technical details', async () => {
+      const { container } = render(
+        <VideoLinkChip
+          job={makeJob({
+            displayStatus: 'failed',
+            errorReasonCode: 'transient',
+            errorMessage: 'ERROR: something went wrong upstream',
+          })}
+          onCancel={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+      );
+      await checkAccessibility(container);
+    });
+
     it('passes axe audit in retrying state with attempt token', async () => {
       const { container } = render(
         <VideoLinkChip
@@ -126,6 +141,41 @@ describe('VideoLinkChip', () => {
       );
       const buttons = getAllByRole('button');
       expect(buttons.length).toBe(1);
+    });
+
+    it('reveals the sanitized failure detail behind a disclosure when present', () => {
+      const { container } = render(
+        <VideoLinkChip
+          job={makeJob({
+            displayStatus: 'failed',
+            errorReasonCode: 'transient',
+            errorMessage:
+              'ERROR: [youtube] h7LDFVd8DSk: The uploader has not made this video available in your country',
+          })}
+          onCancel={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+      );
+      const details = container.querySelector('details');
+      expect(details).not.toBeNull();
+      expect(details?.querySelector('summary')).not.toBeNull();
+      expect(details?.textContent).toContain(
+        'The uploader has not made this video available in your country',
+      );
+    });
+
+    it('renders no disclosure when the failed job has no errorMessage', () => {
+      const { container } = render(
+        <VideoLinkChip
+          job={makeJob({
+            displayStatus: 'failed',
+            errorReasonCode: 'transient',
+          })}
+          onCancel={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+      );
+      expect(container.querySelector('details')).toBeNull();
     });
 
     it('sets aria-busy=true while processing and false on terminal states', () => {

--- a/services/platform/app/features/chat/components/video-link-chip.tsx
+++ b/services/platform/app/features/chat/components/video-link-chip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CollapsibleDetails } from '@tale/ui/collapsible-details';
 import { Stack } from '@tale/ui/layout';
 import { AlertCircle, Loader2, RotateCcw, X } from 'lucide-react';
 
@@ -173,6 +174,18 @@ export function VideoLinkChip({
           )}
           <span className="truncate">{statusText}</span>
         </span>
+        {/* Verbatim failure detail — safe to show: scrubbed server-side by
+            sanitizeStderr and capped at 500 chars before it reaches the row. */}
+        {isFailed && job.errorMessage && (
+          <CollapsibleDetails
+            variant="compact"
+            summary={tChat('errorDetailsSummary')}
+          >
+            <p className="text-muted-foreground mt-1 font-mono text-xs break-all whitespace-pre-wrap opacity-70">
+              {job.errorMessage}
+            </p>
+          </CollapsibleDetails>
+        )}
       </Stack>
       {isFailed && (
         <button

--- a/services/platform/convex/video_links/ytdlp.test.ts
+++ b/services/platform/convex/video_links/ytdlp.test.ts
@@ -46,6 +46,24 @@ describe('classifyYtDlpStderr', () => {
     );
   });
 
+  it('classifies geo-blocks across yt-dlp phrasings', () => {
+    // Verbatim stderr from a real CH/LI-restricted video: "not" and
+    // "available" are non-contiguous here, which the old pattern missed.
+    expect(
+      classifyYtDlpStderr(
+        'ERROR: [youtube] h7LDFVd8DSk: The uploader has not made this video available in your country\n' +
+          'This video is available in Switzerland, Liechtenstein.\n' +
+          'You might want to use a VPN or a proxy server (with --proxy) to workaround.\n',
+      ),
+    ).toBe('geoblocked');
+    expect(
+      classifyYtDlpStderr('ERROR: This video is not available in your country'),
+    ).toBe('geoblocked');
+    expect(
+      classifyYtDlpStderr('The video is not available in your region'),
+    ).toBe('geoblocked');
+  });
+
   it('falls back to transient for anything unrecognized', () => {
     expect(classifyYtDlpStderr('some unexpected network blip')).toBe(
       'transient',

--- a/services/platform/convex/video_links/ytdlp.ts
+++ b/services/platform/convex/video_links/ytdlp.ts
@@ -544,8 +544,11 @@ export function classifyYtDlpStderr(stderr: string): YtDlpErrorReason {
     return 'memberOnly';
   }
   if (
-    s.includes('not available in your country') ||
-    s.includes('not available in your region') ||
+    // Matched loosely ("available in your …", not "not available in your …")
+    // because yt-dlp phrasings vary: e.g. "The uploader has not made this
+    // video available in your country" separates "not" from "available".
+    s.includes('available in your country') ||
+    s.includes('available in your region') ||
     s.includes('geo')
   ) {
     return 'geoblocked';


### PR DESCRIPTION
## Problem

Demo incident (2026-07-19 ~23:43 UTC): a user pasted a YouTube video restricted to Switzerland/Liechtenstein. yt-dlp reported

> ERROR: [youtube] h7LDFVd8DSk: The uploader has not made this video available in your country
> This video is available in Switzerland, Liechtenstein.
> You might want to use a VPN or a proxy server (with --proxy) to workaround.

`classifyYtDlpStderr` only matches the contiguous substrings `not available in your country` / `not available in your region` / `geo` — this phrasing separates "not" from "available", so the failure fell through to `transient`: a permanent geo-block burned the full 30/60/120 s retry ladder (~4 min) and the chip showed a misleading "Temporary issue — try again" that invites more futile retries. Correctly classified, `geoblocked` is in `NEVER_RETRY` and has an accurate localized label.

Second defect: the job row's `errorMessage` (sanitizeStderr-scrubbed yt-dlp output — in this incident it named the exact cause *and* the fix) is already projected to the client chip payload but never rendered; users only ever saw the coded label. (The ingest pipeline catches every failure, so nothing reaches GlitchTip either — observability is a separate track, not in this PR.)

## Changes

- **Classifier**: widen the geoblock patterns to `available in your country` / `available in your region` (subsumes the old phrasings; branch order unchanged — bot-wall/rate-limit/private still win first). Regression test feeds the verbatim incident stderr plus both legacy phrasings.
- **Chip**: a failed video-link chip with a non-empty `errorMessage` now renders it behind a collapsed "Technical details" disclosure — same `CollapsibleDetails` pattern as `chat-error-display.tsx`, reusing the already-localized `chat.errorDetailsSummary`. Zero new i18n keys; hidden when no detail was captured.

## Verification

- vitest: `ytdlp.test.ts` 38/38 (regression case red→green), `video-link-chip.test.tsx` 11/11 incl. an axe audit with the disclosure present.
- Live dev-stack drive (throwaway org, real yt-dlp): pasted a bogus video URL → `unavailable` fast-fail → disclosure renders with the verbatim stderr, opens via keyboard Enter, verified in light + dark.
- `bun run check` green except pre-existing/unrelated local failures: `observatory.test.ts` headers grade (same pre-existing local failure documented in #2815; main CI `Test` is green) and Slack/SCIM convexTest timeouts under full parallel load (pass in isolation).

## Release notes

No migration, no env, no locale changes. Behavior: geo-blocked videos fail fast with the correct label instead of retrying; failed chips expose the sanitized error text on demand.

Out of scope (tracked separately): GlitchTip visibility for caught ingest failures (log-stream forwarding design pending), retry affordance shown for never-retryable codes.

## Definition of done

- [x] Green gate — format / lint / typecheck / tests (documented local flakes above)
- [x] Regression test locks the classifier fix
- [x] UI observed live in both themes, keyboard reachable, axe-clean
- [x] No locale/docs ripple (no new keys; docs don't enumerate per-code labels)