### PR TITLE
fix(platform): align section actions, status chips, and chart chrome

### DIFF
--- a/packages/ui/src/components/data-display/chart-card.test.tsx
+++ b/packages/ui/src/components/data-display/chart-card.test.tsx
@@ -37,6 +37,20 @@ describe('ChartCard', () => {
       expect(screen.queryByText('chart body')).not.toBeInTheDocument();
     });
 
+    it('omits the in-card title when the parent owns the section heading', () => {
+      render(
+        <ChartCard isEmpty emptyTitle="No data yet">
+          <div>chart body</div>
+        </ChartCard>,
+      );
+      // EmptyState still has a heading; the card chrome itself has none.
+      expect(
+        screen.getByRole('heading', { name: 'No data yet' }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByRole('heading')).toHaveLength(1);
+      expect(screen.queryByText('chart body')).not.toBeInTheDocument();
+    });
+
     it('renders an info tooltip trigger when given a tooltip', () => {
       render(
         <ChartCard title="Trend" tooltip="What this shows">

--- a/packages/ui/src/components/data-display/chart-card.tsx
+++ b/packages/ui/src/components/data-display/chart-card.tsx
@@ -13,8 +13,12 @@ import {
 } from '../overlays/tooltip';
 
 interface ChartCardProps {
-  /** Chart title. */
-  title: string;
+  /**
+   * Chart title. Omit when the parent already owns the section heading
+   * (e.g. a metrics page `MetricsSection`) so the label sits outside the card
+   * like sibling tables.
+   */
+  title?: string;
   /** Optional explainer shown via an info tooltip next to the title. */
   tooltip?: string;
   /** Right-aligned header controls, e.g. a period or metric selector. */
@@ -36,11 +40,14 @@ interface ChartCardProps {
 }
 
 /**
- * The unified chart container: a bordered card with a title + optional info
+ * The unified chart container: a bordered card with an optional title + info
  * tooltip, an optional toolbar (period/metric controls), a fixed-height body
  * that swaps between a loading placeholder, an empty state, and the chart, and
  * an optional legend below. Replaces the per-feature `ChartCard` /
  * `ChartCardHeader` reimplementations.
+ *
+ * Fill matches metrics `DataTable` frames (border only, no `bg-card`) so a
+ * chart beside titled table sections doesn't read as a different surface.
  */
 export function ChartCard({
   title,
@@ -56,35 +63,41 @@ export function ChartCard({
   bodyClassName = 'h-60',
   className,
 }: ChartCardProps) {
+  const showHeader = Boolean(title || tooltip || toolbar);
+
   return (
     <div
       className={cn(
-        'border-border bg-card flex h-full flex-col gap-4 rounded-lg border p-5',
+        'border-border flex h-full flex-col gap-4 rounded-lg border p-5',
         className,
       )}
     >
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <h3 className="text-foreground truncate text-sm font-semibold">
-            {title}
-          </h3>
-          {tooltip ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger
-                  type="button"
-                  aria-label={tooltip}
-                  className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex size-6 shrink-0 items-center justify-center rounded focus-visible:ring-2 focus-visible:outline-none"
-                >
-                  <Info className="size-4" aria-hidden />
-                </TooltipTrigger>
-                <TooltipContent side="top">{tooltip}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : null}
+      {showHeader ? (
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
+            {title ? (
+              <h3 className="text-foreground truncate text-sm font-semibold">
+                {title}
+              </h3>
+            ) : null}
+            {tooltip ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={tooltip}
+                    className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex size-6 shrink-0 items-center justify-center rounded focus-visible:ring-2 focus-visible:outline-none"
+                  >
+                    <Info className="size-4" aria-hidden />
+                  </TooltipTrigger>
+                  <TooltipContent side="top">{tooltip}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : null}
+          </div>
+          {toolbar ? <div className="shrink-0">{toolbar}</div> : null}
         </div>
-        {toolbar ? <div className="shrink-0">{toolbar}</div> : null}
-      </div>
+      ) : null}
 
       <div className={cn('w-full', bodyClassName)}>
         {loading ? (

--- a/services/platform/app/components/metrics/metrics-layout.tsx
+++ b/services/platform/app/components/metrics/metrics-layout.tsx
@@ -44,7 +44,7 @@ export function MetricsLayout({
 }: MetricsLayoutProps) {
   return (
     <Stack gap={6} className={className}>
-      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div className="flex shrink-0 flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="flex flex-col gap-1">
           <Tag className="text-foreground text-base font-semibold">{title}</Tag>
           {description ? <Text variant="caption">{description}</Text> : null}

--- a/services/platform/app/components/metrics/metrics-section.tsx
+++ b/services/platform/app/components/metrics/metrics-section.tsx
@@ -17,11 +17,9 @@ interface MetricsSectionProps {
 }
 
 /**
- * The shared titled section for metrics bodies (top-N tables, arena summary…):
- * one h3 heading style + the standard `gap-3` rhythm, replacing the hand-rolled
- * header row every table used to carry. Charts keep their own chrome
- * (`ChartCard` owns its title); everything else on a metrics page sits in one
- * of these.
+ * The shared titled section for metrics bodies (charts, top-N tables, arena
+ * summary…): one h3 heading style + the standard `gap-3` rhythm. Section titles
+ * sit outside the bordered frame so charts and tables share the same chrome.
  */
 export function MetricsSection({
   title,

--- a/services/platform/app/components/ui/editor/dirty-blocker-provider.test.tsx
+++ b/services/platform/app/components/ui/editor/dirty-blocker-provider.test.tsx
@@ -1,13 +1,8 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-
-const toastMock = vi.fn();
-vi.mock('@/app/hooks/use-toast', () => ({
-  toast: (...args: unknown[]) => toastMock(...args),
-}));
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: (ns: string) => ({
@@ -64,7 +59,6 @@ beforeEach(() => {
   blockerState.proceed = vi.fn();
   blockerState.reset = vi.fn();
   capturedBlockerOpts = undefined;
-  toastMock.mockClear();
 });
 
 describe('DirtyBlockerProvider', () => {
@@ -114,63 +108,14 @@ describe('DirtyBlockerProvider', () => {
     expect(capturedBlockerOpts?.enableBeforeUnload()).toBe(true);
   });
 
-  it('offers Save & Leave when every dirty source registered a save, and runs it before proceeding', async () => {
-    const user = userEvent.setup();
-    const save = vi.fn().mockResolvedValue(undefined);
+  it('offers Keep editing and Discard & Leave only', () => {
     blockerState.status = 'blocked';
     render(
       <DirtyBlockerProvider>
-        <Source dirty options={{ save }} />
-      </DirtyBlockerProvider>,
-    );
-
-    const saveButton = screen.getByRole('button', {
-      name: 'common.unsavedChanges.saveAndLeave',
-    });
-    await user.click(saveButton);
-
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
-    expect(blockerState.proceed).toHaveBeenCalledTimes(1);
-    expect(toastMock).not.toHaveBeenCalled();
-  });
-
-  it('keeps the user on the page (reset + toast) when Save & Leave fails', async () => {
-    const user = userEvent.setup();
-    const save = vi.fn().mockRejectedValue(new Error('boom'));
-    blockerState.status = 'blocked';
-    render(
-      <DirtyBlockerProvider>
-        <Source dirty options={{ save }} />
-      </DirtyBlockerProvider>,
-    );
-
-    await user.click(
-      screen.getByRole('button', {
-        name: 'common.unsavedChanges.saveAndLeave',
-      }),
-    );
-
-    await waitFor(() => expect(blockerState.reset).toHaveBeenCalled());
-    expect(blockerState.proceed).not.toHaveBeenCalled();
-    expect(toastMock).toHaveBeenCalledWith(
-      expect.objectContaining({ variant: 'destructive' }),
-    );
-  });
-
-  it('degrades to Stay/Discard when a dirty source has no save path', () => {
-    blockerState.status = 'blocked';
-    render(
-      <DirtyBlockerProvider>
-        <Source dirty options={{ save: vi.fn() }} />
         <Source dirty />
       </DirtyBlockerProvider>,
     );
 
-    expect(
-      screen.queryByRole('button', {
-        name: 'common.unsavedChanges.saveAndLeave',
-      }),
-    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'common.unsavedChanges.stay' }),
     ).toBeInTheDocument();
@@ -179,5 +124,27 @@ describe('DirtyBlockerProvider', () => {
         name: 'common.unsavedChanges.discardAndLeave',
       }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'common.unsavedChanges.saveAndLeave',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('proceeds on Discard & Leave', async () => {
+    const user = userEvent.setup();
+    blockerState.status = 'blocked';
+    render(
+      <DirtyBlockerProvider>
+        <Source dirty />
+      </DirtyBlockerProvider>,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'common.unsavedChanges.discardAndLeave',
+      }),
+    );
+    expect(blockerState.proceed).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/platform/app/components/ui/editor/dirty-blocker-provider.tsx
+++ b/services/platform/app/components/ui/editor/dirty-blocker-provider.tsx
@@ -13,7 +13,6 @@ import {
 } from 'react';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
-import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
 import { DirtySourceContext, type DirtySourceEntry } from './use-dirty-source';
@@ -54,27 +53,14 @@ function isWithinScope(scopePath: string, pathname: string): boolean {
 
 interface DirtyBlockerProviderProps {
   children: ReactNode;
-  /**
-   * When supplied, the navigation dialog renders a third "Save & Leave"
-   * button that awaits this callback before proceeding. A failed save
-   * keeps the user on the page and surfaces a destructive toast.
-   * Pages with section-scoped saves (e.g. governance) omit it so the
-   * dialog stays a two-button choice. Without it, "Save & Leave" is still
-   * offered whenever EVERY dirty source registered its own `save`.
-   */
-  onSaveAll?: () => Promise<void>;
 }
 
-export function DirtyBlockerProvider({
-  children,
-  onSaveAll,
-}: DirtyBlockerProviderProps) {
+export function DirtyBlockerProvider({ children }: DirtyBlockerProviderProps) {
   const { t } = useT('common');
   const [sources, setSources] = useState<Map<string, DirtySourceEntry>>(
     () => new Map(),
   );
   const bypassRef = useRef(false);
-  const [isSavingLeave, setIsSavingLeave] = useState(false);
 
   const anyDirty = useMemo(
     () => Array.from(sources.values()).some((entry) => entry.dirty),
@@ -87,8 +73,7 @@ export function DirtyBlockerProvider({
       if (
         existing &&
         existing.dirty === entry.dirty &&
-        existing.scopePath === entry.scopePath &&
-        existing.save === entry.save
+        existing.scopePath === entry.scopePath
       ) {
         return prev;
       }
@@ -159,51 +144,6 @@ export function DirtyBlockerProvider({
     blocker.proceed?.();
   }, [blocker]);
 
-  // "Save & Leave" is available when the page supplied a save-all, or when
-  // every DIRTY source registered its own save path (an invalid draft
-  // deliberately registers none, so the dialog degrades to Stay/Discard).
-  const dirtyEntries = useMemo(
-    () => Array.from(sources.values()).filter((entry) => entry.dirty),
-    [sources],
-  );
-  const canSaveAndLeave =
-    onSaveAll !== undefined ||
-    (dirtyEntries.length > 0 &&
-      dirtyEntries.every((entry) => entry.save !== undefined));
-
-  const handleSaveAndLeave = useCallback(async () => {
-    setIsSavingLeave(true);
-    try {
-      if (onSaveAll) {
-        await onSaveAll();
-      } else {
-        // Sequential (not parallel) so a failure stops before later saves
-        // commit — the surviving dirty flags keep the remaining edits armed.
-        for (const entry of sourcesRef.current.values()) {
-          if (entry.dirty && entry.save) await entry.save();
-        }
-      }
-      // Mirror discard: clear the registry so an in-flight re-evaluation of
-      // `shouldBlockFn` can't re-prompt while the saved sources' effects are
-      // still catching up.
-      setSources((prev) => (prev.size === 0 ? prev : new Map()));
-      blocker.proceed?.();
-    } catch (err) {
-      blocker.reset?.();
-      toast({
-        title: t('actions.save'),
-        description: err instanceof Error ? err.message : String(err),
-        variant: 'destructive',
-      });
-    } finally {
-      setIsSavingLeave(false);
-    }
-  }, [blocker, onSaveAll, t]);
-
-  const description = canSaveAndLeave
-    ? t('unsavedChanges.descriptionThreeButton')
-    : t('unsavedChanges.descriptionTwoButton');
-
   return (
     <DirtyBlockerControlContext.Provider value={control}>
       <DirtySourceContext.Provider value={sourceRegistry}>
@@ -214,14 +154,14 @@ export function DirtyBlockerProvider({
             if (!open) handleStay();
           }}
           title={t('unsavedChanges.title')}
-          description={description}
+          description={t('unsavedChanges.description')}
           footer={
             <>
               <Button
                 type="button"
                 variant="secondary"
                 onClick={handleStay}
-                disabled={isSavingLeave}
+                autoFocus
               >
                 {t('unsavedChanges.stay')}
               </Button>
@@ -229,21 +169,9 @@ export function DirtyBlockerProvider({
                 type="button"
                 variant="destructive"
                 onClick={handleDiscardAndLeave}
-                disabled={isSavingLeave}
               >
                 {t('unsavedChanges.discardAndLeave')}
               </Button>
-              {canSaveAndLeave && (
-                <Button
-                  type="button"
-                  variant="primary"
-                  onClick={() => void handleSaveAndLeave()}
-                  isLoading={isSavingLeave}
-                  autoFocus
-                >
-                  {t('unsavedChanges.saveAndLeave')}
-                </Button>
-              )}
             </>
           }
         />

--- a/services/platform/app/components/ui/editor/use-dirty-source.test.tsx
+++ b/services/platform/app/components/ui/editor/use-dirty-source.test.tsx
@@ -65,48 +65,22 @@ describe('useRegisterDirtySource', () => {
     expect(register).not.toHaveBeenLastCalledWith(id, { dirty: false });
   });
 
-  it('registers scopePath and a save wrapper that reaches the latest closure', async () => {
+  it('registers scopePath when provided', () => {
     const register = vi.fn();
     const registry = { register, unregister: vi.fn() };
-    const firstSave = vi.fn().mockResolvedValue(undefined);
-    const secondSave = vi.fn().mockResolvedValue(undefined);
 
-    const { rerender } = render(
+    render(
       <Harness
         registry={registry}
         dirty
-        options={{ scopePath: '/dashboard/org/agents/a', save: firstSave }}
+        options={{ scopePath: '/dashboard/org/agents/a' }}
       />,
     );
-    const [id, entry] = register.mock.calls.at(-1) ?? [];
-    expect(entry).toMatchObject({
+    const [, entry] = register.mock.calls.at(-1) ?? [];
+    expect(entry).toEqual({
       dirty: true,
       scopePath: '/dashboard/org/agents/a',
     });
-    expect(typeof entry.save).toBe('function');
-
-    // A re-render swapping only the save callback must not re-register, yet
-    // the ALREADY-registered wrapper must call the NEW closure — the provider
-    // invokes it at dialog-click time, potentially renders later.
-    rerender(
-      <Harness
-        registry={registry}
-        dirty
-        options={{ scopePath: '/dashboard/org/agents/a', save: secondSave }}
-      />,
-    );
-    await entry.save();
-    expect(firstSave).not.toHaveBeenCalled();
-    expect(secondSave).toHaveBeenCalledTimes(1);
-    expect(register.mock.calls.at(-1)?.[0]).toBe(id);
-  });
-
-  it('registers no save when the caller omits one (invalid draft)', () => {
-    const register = vi.fn();
-    const registry = { register, unregister: vi.fn() };
-    render(<Harness registry={registry} dirty options={{ scopePath: '/x' }} />);
-    const [, entry] = register.mock.calls.at(-1) ?? [];
-    expect(entry.save).toBeUndefined();
   });
 
   it('no-ops without a provider (does not throw)', () => {

--- a/services/platform/app/components/ui/editor/use-dirty-source.ts
+++ b/services/platform/app/components/ui/editor/use-dirty-source.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useEffect, useId, useRef } from 'react';
+import { createContext, useContext, useEffect, useId } from 'react';
 
 /** One registered dirty-state source, as the blocker provider sees it. */
 export interface DirtySourceEntry {
@@ -13,12 +13,6 @@ export interface DirtySourceEntry {
    * Omit for sources whose edits die with any navigation (the default).
    */
   scopePath?: string;
-  /**
-   * Persist this source's pending edits. When EVERY dirty source provides
-   * one, the navigation dialog offers "Save & Leave". Register it only while
-   * a save can actually succeed (e.g. the draft is valid).
-   */
-  save?: () => Promise<void>;
 }
 
 interface DirtySourceRegistry {
@@ -34,8 +28,6 @@ export const DirtySourceContext = createContext<DirtySourceRegistry | null>(
 export interface DirtySourceOptions {
   /** See {@link DirtySourceEntry.scopePath}. */
   scopePath?: string;
-  /** See {@link DirtySourceEntry.save}. */
-  save?: () => Promise<void>;
 }
 
 /**
@@ -53,14 +45,6 @@ export function useRegisterDirtySource(
 ): void {
   const ctx = useContext(DirtySourceContext);
   const id = useId();
-
-  // The provider invokes `save` at dialog-click time; route it through a ref
-  // so re-renders that only change the callback's identity (fresh closures
-  // every render in most editors) don't churn the registry, while the click
-  // still reaches the LATEST closure.
-  const saveRef = useRef(options?.save);
-  saveRef.current = options?.save;
-  const hasSave = options?.save !== undefined;
   const scopePath = options?.scopePath;
 
   useEffect(() => {
@@ -77,13 +61,8 @@ export function useRegisterDirtySource(
     ctx.register(id, {
       dirty: isDirty,
       ...(scopePath !== undefined && { scopePath }),
-      ...(hasSave && {
-        save: async () => {
-          await saveRef.current?.();
-        },
-      }),
     });
-  }, [ctx, id, isDirty, scopePath, hasSave]);
+  }, [ctx, id, isDirty, scopePath]);
 
   useEffect(
     () => () => {

--- a/services/platform/app/components/ui/editor/use-form-editor.ts
+++ b/services/platform/app/components/ui/editor/use-form-editor.ts
@@ -215,11 +215,9 @@ export function useFormEditor<T extends FieldValues>({
 
   const isValid = schema ? form.formState.isValid : true;
 
-  // Register with the page-level DirtyBlockerProvider. A valid draft also
-  // registers its save path so the navigation dialog can offer "Save & Leave"
-  // (#2572); an invalid one registers none — that save could only fail — and
-  // the dialog degrades to Stay/Discard.
-  useRegisterDirtySource(isDirty, isValid ? { save: doSave } : undefined);
+  // Register with the page-level DirtyBlockerProvider so navigation away
+  // prompts before discarding unsaved edits.
+  useRegisterDirtySource(isDirty);
 
   const submit = useCallback(
     (e?: { preventDefault: () => void }) => {

--- a/services/platform/app/components/ui/editor/use-json-config-editor.ts
+++ b/services/platform/app/components/ui/editor/use-json-config-editor.ts
@@ -196,12 +196,9 @@ export function useJsonConfigEditor<T>({
     return schema.safeParse(config).success;
   }, [schema, config]);
 
-  // Register with the page-level DirtyBlockerProvider, including the save
-  // path so the navigation dialog can offer "Save & Leave" (#2572). A valid
-  // draft registers `save`; an invalid one registers none — that save could
-  // only fail — and the dialog degrades to Stay/Discard, same as
-  // `useFormEditor`.
-  useRegisterDirtySource(isDirty, isValid ? { save: doSave } : undefined);
+  // Register with the page-level DirtyBlockerProvider so navigation away
+  // prompts before discarding unsaved edits.
+  useRegisterDirtySource(isDirty);
 
   return {
     config,

--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -334,13 +334,8 @@ export function AgentNavigation({
   // dialog fires on navigation away from the agent editor. The config state
   // lives in `AgentConfigProvider` ABOVE the tab routes, so switching tabs
   // inside `basePath` loses nothing — scope the blocker to leaving the agent
-  // (#2572). A valid draft also registers its save path so the dialog can
-  // offer "Save & Leave"; an invalid one deliberately doesn't (that save is
-  // guaranteed to fail server-side).
-  useRegisterDirtySource(isDirty, {
-    scopePath: basePath,
-    ...(isValid && { save: doSave }),
-  });
+  // (#2572).
+  useRegisterDirtySource(isDirty, { scopePath: basePath });
 
   const handleLoadHistory = useCallback(async () => {
     setIsLoadingHistory(true);

--- a/services/platform/app/features/analytics/usage/usage-trend-chart.tsx
+++ b/services/platform/app/features/analytics/usage/usage-trend-chart.tsx
@@ -3,12 +3,14 @@
 import { ChartCard } from '@tale/ui/chart-card';
 import { ChartLegend } from '@tale/ui/chart-legend';
 import { CHART_COLORS } from '@tale/ui/chart-theme';
+import { BarChart3 } from 'lucide-react';
 
 import {
   seriesToLegend,
   TrendBarChart,
   type ChartSeries,
 } from '@/app/components/metrics/charts';
+import { MetricsSection } from '@/app/components/metrics/metrics-section';
 import { useFormatNumber } from '@/app/hooks/use-format-number';
 import { useT } from '@/lib/i18n/client';
 
@@ -107,25 +109,29 @@ export function UsageTrendChart({
     return formatNumber(value);
   };
 
+  // Same anatomy as Top Voice Models / Per-User Usage: section title outside
+  // the bordered frame, card chrome without an inner title or different fill.
   return (
-    <ChartCard
-      title={t(`usage.metric.${metric}`)}
-      isEmpty={!hasData}
-      emptyTitle={t('usage.empty.title')}
-      emptyDescription={t('usage.empty.description')}
-      legend={
-        metric === 'tokens' ? (
-          <ChartLegend items={seriesToLegend(chartSeries)} />
-        ) : undefined
-      }
-    >
-      <TrendBarChart
-        data={data}
-        series={chartSeries}
-        xKey="label"
-        yTickFormatter={formatYTick}
-        valueFormatter={valueFormatter}
-      />
-    </ChartCard>
+    <MetricsSection title={t(`usage.metric.${metric}`)}>
+      <ChartCard
+        isEmpty={!hasData}
+        emptyIcon={BarChart3}
+        emptyTitle={t('usage.empty.title')}
+        emptyDescription={t('usage.empty.description')}
+        legend={
+          metric === 'tokens' ? (
+            <ChartLegend items={seriesToLegend(chartSeries)} />
+          ) : undefined
+        }
+      >
+        <TrendBarChart
+          data={data}
+          series={chartSeries}
+          xKey="label"
+          yTickFormatter={formatYTick}
+          valueFormatter={valueFormatter}
+        />
+      </ChartCard>
+    </MetricsSection>
   );
 }

--- a/services/platform/app/features/automations/components/automation-page.tsx
+++ b/services/platform/app/features/automations/components/automation-page.tsx
@@ -1036,6 +1036,7 @@ export function AutomationPage({
       >
         <ContentArea>
           <EmptyState
+            icon={LayoutGrid}
             title={t('notFound.title')}
             description={t('notFound.description')}
           />

--- a/services/platform/app/features/automations/components/automation-workflow-editor-tab.tsx
+++ b/services/platform/app/features/automations/components/automation-workflow-editor-tab.tsx
@@ -16,6 +16,7 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
  * `useWorkflowEditorView` persists the choice in a cookie shared across every
  * workflow, layered under an optional `?view=` URL override.
  */
+import { Workflow } from 'lucide-react';
 import { Fragment, lazy, useCallback, useMemo, type ReactNode } from 'react';
 
 import { SuspenseBoundary } from '@/app/components/error-boundaries/core/suspense-boundary';
@@ -268,6 +269,7 @@ export function AutomationWorkflowEditorTab({
   if (!config) {
     return (
       <EmptyState
+        icon={Workflow}
         title={t('editor.notFoundTitle')}
         description={t('editor.notFoundDescription')}
       />

--- a/services/platform/app/features/automations/registry/connected/collection.tsx
+++ b/services/platform/app/features/automations/registry/connected/collection.tsx
@@ -599,6 +599,7 @@ function CollectionBody({
           }
         : {})}
       emptyState={{
+        icon: ListChecks,
         title: emptyState?.titleKey ?? t('binding.empty'),
         description: emptyState?.descriptionKey,
       }}

--- a/services/platform/app/features/automations/registry/connected/external-list.tsx
+++ b/services/platform/app/features/automations/registry/connected/external-list.tsx
@@ -32,7 +32,7 @@
 import { Button } from '@tale/ui/button';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { Text } from '@tale/ui/text';
-import { CircleDot } from 'lucide-react';
+import { CircleDot, Inbox } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
@@ -245,7 +245,7 @@ export function ExternalList({
             data={visibleRows}
             getRowId={getRowId}
             isLoading={searching}
-            emptyState={{ title: t('binding.empty') }}
+            emptyState={{ icon: Inbox, title: t('binding.empty') }}
             {...(paginated && {
               infiniteScroll: {
                 hasMore: hasNextPage,

--- a/services/platform/app/features/projects/components/project-agents-tab.tsx
+++ b/services/platform/app/features/projects/components/project-agents-tab.tsx
@@ -35,6 +35,7 @@ import {
   type ProjectModeRadioValue,
 } from './project-mode-radio';
 import {
+  ProjectSlugListAdd,
   ProjectSlugListEditor,
   type SlugOption,
 } from './project-slug-list-editor';
@@ -254,6 +255,15 @@ export function ProjectAgentsTab({
       <StickySectionHeader
         title={t('agents.agentsHeading')}
         description={t('agents.sectionDescription')}
+        action={
+          <ProjectSlugListAdd
+            value={config.agentList}
+            onChange={(next) => editor.updateConfig({ agentList: next })}
+            options={agentOptions}
+            addLabel={t('agents.addAgent')}
+            disabled={fieldsDisabled}
+          />
+        }
       />
 
       <FormSection>
@@ -269,7 +279,6 @@ export function ProjectAgentsTab({
           value={config.agentList}
           onChange={(next) => editor.updateConfig({ agentList: next })}
           options={agentOptions}
-          addLabel={t('agents.addAgent')}
           mode={config.agentMode}
           disabled={fieldsDisabled}
         />
@@ -279,6 +288,15 @@ export function ProjectAgentsTab({
         title={t('agents.modelsHeading')}
         gap={6}
         className="mt-8 border-t pt-8"
+        action={
+          <ProjectSlugListAdd
+            value={config.modelList}
+            onChange={(next) => editor.updateConfig({ modelList: next })}
+            options={modelOptions}
+            addLabel={t('agents.addModel')}
+            disabled={fieldsDisabled}
+          />
+        }
       >
         <FormSection>
           <ProjectModeRadio
@@ -293,7 +311,6 @@ export function ProjectAgentsTab({
             value={config.modelList}
             onChange={(next) => editor.updateConfig({ modelList: next })}
             options={modelOptions}
-            addLabel={t('agents.addModel')}
             mode={config.modelMode}
             disabled={fieldsDisabled}
           />

--- a/services/platform/app/features/projects/components/project-files-tab.tsx
+++ b/services/platform/app/features/projects/components/project-files-tab.tsx
@@ -687,11 +687,8 @@ export function ProjectFilesTab({
       <StickySectionHeader
         title={t('files.title')}
         description={t('files.emptyDescription')}
-      />
-
-      <FormSection>
-        {canEdit ? (
-          <HStack gap={2} align="center" justify="end">
+        action={
+          canEdit ? (
             <Button
               variant="secondary"
               size="sm"
@@ -701,9 +698,11 @@ export function ProjectFilesTab({
               <FolderPlus className="size-4" aria-hidden="true" />
               {tDocuments('folder.newFolder')}
             </Button>
-          </HStack>
-        ) : null}
+          ) : undefined
+        }
+      />
 
+      <FormSection>
         {!isEmpty ? (
           <ul
             ref={treeRef}

--- a/services/platform/app/features/projects/components/project-slug-list-editor.test.tsx
+++ b/services/platform/app/features/projects/components/project-slug-list-editor.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@/tests/utils/render';
 
 import {
+  ProjectSlugListAdd,
   ProjectSlugListEditor,
   type SlugOption,
 } from './project-slug-list-editor';
@@ -20,15 +21,14 @@ const OPTIONS: SlugOption[] = [
   },
 ];
 
-describe('ProjectSlugListEditor', () => {
-  it('keeps the ghost add button as the popover trigger when open', async () => {
+describe('ProjectSlugListAdd', () => {
+  it('keeps the add button as the popover trigger when open', async () => {
     const { user } = render(
-      <ProjectSlugListEditor
+      <ProjectSlugListAdd
         value={[]}
         onChange={vi.fn()}
         options={OPTIONS}
         addLabel="Add agent"
-        mode="recommended"
       />,
     );
 
@@ -48,12 +48,11 @@ describe('ProjectSlugListEditor', () => {
   it('appends the selected slug and closes the picker', async () => {
     const onChange = vi.fn();
     const { user } = render(
-      <ProjectSlugListEditor
+      <ProjectSlugListAdd
         value={[]}
         onChange={onChange}
         options={OPTIONS}
         addLabel="Add agent"
-        mode="recommended"
       />,
     );
 
@@ -67,17 +66,45 @@ describe('ProjectSlugListEditor', () => {
 
   it('hides the add control when every option is already selected', () => {
     render(
-      <ProjectSlugListEditor
+      <ProjectSlugListAdd
         value={['assistant', 'coder']}
         onChange={vi.fn()}
         options={OPTIONS}
         addLabel="Add agent"
-        mode="recommended"
       />,
     );
 
     expect(
       screen.queryByRole('button', { name: 'Add agent' }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('ProjectSlugListEditor', () => {
+  it('renders ordered rows for the current value', () => {
+    render(
+      <ProjectSlugListEditor
+        value={['coder', 'assistant']}
+        onChange={vi.fn()}
+        options={OPTIONS}
+        mode="recommended"
+      />,
+    );
+
+    expect(screen.getByText('Coder')).toBeInTheDocument();
+    expect(screen.getByText('Assistant')).toBeInTheDocument();
+  });
+
+  it('shows the lockout banner when restricted and empty', () => {
+    render(
+      <ProjectSlugListEditor
+        value={[]}
+        onChange={vi.fn()}
+        options={OPTIONS}
+        mode="restricted"
+      />,
+    );
+
+    expect(screen.getByText(/lockout|empty|restricted/i)).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/projects/components/project-slug-list-editor.tsx
+++ b/services/platform/app/features/projects/components/project-slug-list-editor.tsx
@@ -22,6 +22,70 @@ export interface SlugOption extends SearchableSelectOption {
   description?: string;
 }
 
+interface ProjectSlugListAddProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  options: ReadonlyArray<SlugOption>;
+  addLabel: string;
+  disabled?: boolean;
+}
+
+/**
+ * Header-side "Add agent/model" control. Lives next to the section title so
+ * empty lists don't leave a lone CTA under the mode radios.
+ */
+export function ProjectSlugListAdd({
+  value,
+  onChange,
+  options,
+  addLabel,
+  disabled,
+}: ProjectSlugListAddProps) {
+  const { t: tCommon } = useT('common');
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const selectedSet = useMemo(() => new Set(value), [value]);
+  const remainingOptions = useMemo(
+    () =>
+      pruneEmptyAgentSections(
+        options.filter((opt) => !selectedSet.has(opt.value)),
+      ),
+    [options, selectedSet],
+  );
+
+  const handleAdd = useCallback(
+    (slug: string) => {
+      if (selectedSet.has(slug)) return;
+      onChange([...value, slug]);
+      setPickerOpen(false);
+    },
+    [selectedSet, value, onChange],
+  );
+
+  if (disabled || remainingOptions.length === 0) return null;
+
+  return (
+    <SearchableSelect
+      value={null}
+      onValueChange={handleAdd}
+      options={remainingOptions}
+      open={pickerOpen}
+      onOpenChange={setPickerOpen}
+      align="end"
+      contentClassName="w-[28rem] max-w-[calc(100vw-2rem)]"
+      searchPlaceholder={tCommon('search.placeholder')}
+      emptyText={tCommon('search.noResults')}
+      aria-label={addLabel}
+      trigger={
+        <Button type="button" variant="secondary" size="sm" className="gap-2">
+          <Plus className="size-4" aria-hidden="true" />
+          {addLabel}
+        </Button>
+      }
+    />
+  );
+}
+
 interface ProjectSlugListEditorProps {
   /** Slugs currently selected, in defined order. */
   value: string[];
@@ -29,14 +93,12 @@ interface ProjectSlugListEditorProps {
   onChange: (next: string[]) => void;
   /** Full catalog of selectable items. */
   options: ReadonlyArray<SlugOption>;
-  /** Label for the "Add" button. */
-  addLabel: string;
   /**
    * When `restricted`, an empty list is a lockout — render a destructive
    * banner. When `recommended`, an empty list is fine (nothing is pinned).
    */
   mode: 'recommended' | 'restricted';
-  /** Disable adds/removes (e.g. while a mutation is in flight). */
+  /** Disable removes/reorders (e.g. while a mutation is in flight). */
   disabled?: boolean;
 }
 
@@ -47,27 +109,19 @@ interface SlugRow extends ReorderItem {
 }
 
 /**
- * Ordered list editor for project slug lists, modelled on the
- * `ReorderList` component used in agents settings. Selected items are
- * rendered as draggable rows with up/down arrows + remove buttons; the
- * "Add" button opens a searchable picker that appends to the end.
- *
- * Used by [project-agents-tab.tsx] to drive `recommendedAgentSlugs`,
- * `allowedAgentSlugs`, `recommendedModels`, and `allowedModels`. The
- * caller controls the option label shape (agents pass agent slugs;
- * models pass `<provider>:<id>` refs).
+ * Ordered list editor for project slug lists. Selected items are draggable
+ * rows with up/down + remove. Adding is owned by {@link ProjectSlugListAdd}
+ * in the section header (same pattern as Files → New folder).
  */
 export function ProjectSlugListEditor({
   value,
   onChange,
   options,
-  addLabel,
   mode,
   disabled,
 }: ProjectSlugListEditorProps) {
   const { t } = useT('projects');
   const { t: tCommon } = useT('common');
-  const [pickerOpen, setPickerOpen] = useState(false);
 
   // Optimistic local order. The parent's `value` lags behind by a Convex
   // roundtrip, so driving the list straight from it would make framer-motion
@@ -96,16 +150,6 @@ export function ProjectSlugListEditor({
     [onChange],
   );
 
-  const selectedSet = useMemo(() => new Set(localValue), [localValue]);
-
-  const remainingOptions = useMemo(
-    () =>
-      pruneEmptyAgentSections(
-        options.filter((opt) => !selectedSet.has(opt.value)),
-      ),
-    [options, selectedSet],
-  );
-
   const optionByValue = useMemo(() => {
     const map = new Map<string, SlugOption>();
     for (const opt of options) map.set(opt.value, opt);
@@ -113,13 +157,8 @@ export function ProjectSlugListEditor({
   }, [options]);
 
   // Framer Motion's `Reorder.Group` / `Reorder.Item` tracks items by
-  // reference identity. If we recreated every SlugRow object on each
-  // render, adding a new item would make every existing row look "new"
-  // to Framer Motion — triggering a full set of layout animations and
-  // visually skewing the list (and any sibling Reorder.Group sharing the
-  // page). Cache rows in a ref-backed map keyed by slug so existing rows
-  // keep their object reference unless their visible content actually
-  // changed.
+  // reference identity. Cache rows in a ref-backed map keyed by slug so
+  // existing rows keep their object reference unless content changed.
   const rowsByIdRef = useRef(new Map<string, SlugRow>());
   const rows = useMemo<SlugRow[]>(() => {
     const result: SlugRow[] = [];
@@ -146,9 +185,6 @@ export function ProjectSlugListEditor({
         result.push(fresh);
       }
     }
-    // GC dropped slugs so the cache doesn't grow unbounded. Build a
-    // disposable array of keys-to-delete instead of spreading the
-    // iterator (oxlint flags spread-over-iterables on the hot path).
     const toDelete: string[] = [];
     for (const cachedId of rowsByIdRef.current.keys()) {
       if (!liveIds.has(cachedId)) toDelete.push(cachedId);
@@ -191,16 +227,9 @@ export function ProjectSlugListEditor({
     [localValue, commit],
   );
 
-  const handleAdd = useCallback(
-    (slug: string) => {
-      if (selectedSet.has(slug)) return;
-      commit([...localValue, slug]);
-      setPickerOpen(false);
-    },
-    [selectedSet, localValue, commit],
-  );
-
   const isLockedOut = mode === 'restricted' && localValue.length === 0;
+
+  if (rows.length === 0 && !isLockedOut) return null;
 
   return (
     <Stack gap={3}>
@@ -217,11 +246,6 @@ export function ProjectSlugListEditor({
           dragHandleLabel={tCommon('drag')}
           removeLabel={tCommon('remove')}
           renderItem={({ item }) => (
-            // Label-only inside the row. Long descriptions (e.g. agent
-            // bios) used to be inlined with `shrink-0` and overflowed —
-            // they're still discoverable in the searchable picker when
-            // adding, and we surface them as a `title` tooltip here for
-            // power users who want to recall the context on hover.
             <Row
               gap={2}
               align="baseline"
@@ -251,27 +275,6 @@ export function ProjectSlugListEditor({
             {t('editor.slugEditorEmptyLockout')}
           </Text>
         </div>
-      ) : null}
-
-      {!disabled && remainingOptions.length > 0 ? (
-        <SearchableSelect
-          value={null}
-          onValueChange={handleAdd}
-          options={remainingOptions}
-          open={pickerOpen}
-          onOpenChange={setPickerOpen}
-          align="start"
-          contentClassName="w-[28rem] max-w-[calc(100vw-2rem)]"
-          searchPlaceholder={tCommon('search.placeholder')}
-          emptyText={tCommon('search.noResults')}
-          aria-label={addLabel}
-          trigger={
-            <Button type="button" variant="ghost">
-              <Plus className="size-4" aria-hidden="true" />
-              {addLabel}
-            </Button>
-          }
-        />
       ) : null}
     </Stack>
   );

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
@@ -1149,22 +1149,25 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
           </SettingsSection>
 
           {/* SCIM stays inline (its own generate/regenerate/disable lifecycle,
-              independent of the SSO config Save). */}
+              independent of the SSO config Save). Status sits in `action` so it
+              scans next to the title — same placement as deployment Built-in. */}
           <SettingsSection
             className="border-border border-t pt-8"
             title={t('integrations.enterpriseSso.scim.section')}
             description={t('integrations.enterpriseSso.scim.help')}
-          >
-            <Stack gap={4} className={FIELD_COLUMN}>
-              {config?.scim.enabled ? (
+            action={
+              config?.scim.enabled ? (
                 <Badge variant="green" dot>
                   {t('integrations.enterpriseSso.scim.enabled')}
                 </Badge>
               ) : (
-                <Badge variant="outline">
+                <Badge variant="slate" dot>
                   {t('integrations.enterpriseSso.scim.disabled')}
                 </Badge>
-              )}
+              )
+            }
+          >
+            <Stack gap={4} className={FIELD_COLUMN}>
               {scimToken ? (
                 <Stack gap={2}>
                   <Text variant="muted" className="text-sm">

--- a/services/platform/app/features/settings/governance/components/guardrails-overview.tsx
+++ b/services/platform/app/features/settings/governance/components/guardrails-overview.tsx
@@ -363,6 +363,7 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
         // chrome. EmptyState itself is borderless by design.
         <div className="border-border overflow-hidden rounded-lg border">
           <EmptyState
+            icon={Shield}
             title={t('guardrailsOverview.recentEvents.empty.title')}
             description={t('guardrailsOverview.recentEvents.empty.description')}
           />

--- a/services/platform/app/features/settings/governance/components/trash-page.tsx
+++ b/services/platform/app/features/settings/governance/components/trash-page.tsx
@@ -15,7 +15,7 @@ import {
   TableRow,
 } from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
-import { Undo2 } from 'lucide-react';
+import { Trash2, Undo2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
@@ -239,6 +239,7 @@ export function TrashPage({ organizationId }: Props) {
         <Skeletonize loading={loading} label={t('trash.title', 'Trash')}>
           {!loading && rows.length === 0 ? (
             <EmptyState
+              icon={Trash2}
               title={t('trash.emptyTitle', 'Trash is empty')}
               description={t(
                 'trash.empty',

--- a/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
@@ -137,6 +137,21 @@ describe('IntegrationPanel — disconnect loading state', () => {
     vi.mocked(useIntegrationManage).mockImplementation(useManageMock as never);
   });
 
+  it('titles the sheet with the integration name, not a generic mode label', () => {
+    vi.mocked(useIntegrationManage).mockImplementation(
+      () =>
+        ({
+          ...baseManage,
+          isActive: false,
+        }) as never,
+    );
+    renderPanel();
+    // Connect flow used to say "Add integration" — that hid which product
+    // you were connecting after opening from a named catalog card.
+    expect(screen.getByText('Shopify')).toBeInTheDocument();
+    expect(screen.queryByText('Add integration')).not.toBeInTheDocument();
+  });
+
   it('shows the dialog loading state and keeps it open until the disconnect resolves', async () => {
     renderPanel();
 

--- a/services/platform/app/features/settings/integrations/components/integration-panel.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.tsx
@@ -111,9 +111,10 @@ export function IntegrationPanel({
 
   const isDetailsMode = manage.isActive ?? false;
 
-  const panelTitle = isDetailsMode
-    ? t('integrations.panel.integrationDetails')
-    : t('integrations.panel.addIntegration');
+  // Sheet title is the integration's identity (same name as the catalog card),
+  // not the generic mode label — "Add integration" / "Integration details"
+  // don't answer "which one am I connecting?" when the panel opens.
+  const panelTitle = integration.title;
 
   return (
     <Sheet

--- a/services/platform/app/features/settings/mcp-servers/components/mcp-servers.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-servers.tsx
@@ -120,7 +120,10 @@ export function McpServers({
     : null;
 
   return (
-    <Stack gap={0} className="pb-8">
+    // Fill the settings pane so EmptyState (flex-1 + justify-center) sits in
+    // the middle of the area below the section header — same fix as
+    // Integrations / Automations.
+    <Stack gap={0} className="min-h-0 flex-1 pb-8">
       {serverList.length > 0 ? (
         <Grid cols={1} md={2} lg={3}>
           {serverList.map((server) => (
@@ -138,6 +141,7 @@ export function McpServers({
           icon={Server}
           title={t('emptyTitle')}
           description={t('emptyDescription')}
+          className="min-h-0"
         />
       )}
 

--- a/services/platform/app/features/skills/components/skill-bindings-select.tsx
+++ b/services/platform/app/features/skills/components/skill-bindings-select.tsx
@@ -12,10 +12,6 @@ import { useT } from '@/lib/i18n/client';
 
 import { useListSkills } from '../hooks/queries';
 import { toSkillRows } from '../lib/skill-rows';
-import {
-  resolveSkillLoadErrorPresentation,
-  skillLoadErrorSummaryKey,
-} from '../utils/skill-load-error';
 
 export interface SkillBindingsMode {
   selected: string[];
@@ -79,19 +75,9 @@ export function SkillBindingsSelect({
       filteredSkills.map((skill) => {
         const hasError = Boolean(skill.status);
         const errorDescription = hasError
-          ? (() => {
-              const presentation = resolveSkillLoadErrorPresentation(
-                skill.status,
-                skill.message,
-              );
-              const key = skillLoadErrorSummaryKey(presentation);
-              return presentation.line != null
-                ? t(key, {
-                    line: presentation.line,
-                    defaultValue: 'YAML syntax error (line {line})',
-                  })
-                : t(key, { defaultValue: 'Failed to read SKILL.md' });
-            })()
+          ? t('skills.columns.loadError', {
+              defaultValue: 'Failed to read SKILL.md',
+            })
           : undefined;
         return {
           value: skill.slug,

--- a/services/platform/app/features/skills/components/skills-catalog.test.tsx
+++ b/services/platform/app/features/skills/components/skills-catalog.test.tsx
@@ -84,7 +84,8 @@ const SKILLS = [
   {
     slug: 'broken-skill',
     status: 'corrupted',
-    message: 'SKILL.md could not be parsed',
+    message:
+      'YAML parse error: Nested mappings are not allowed in compact mappings at line 2, column 14: description: broken',
   },
 ] as SkillListEntry[];
 
@@ -112,9 +113,10 @@ describe('SkillsCatalog', () => {
 
   it('badges a broken row and shows its read-error message', () => {
     render(<SkillsCatalog organizationId="org-1" />);
+    // Short generic badge; specific failure lives in the description.
     expect(screen.getByText('Failed to read SKILL.md')).toBeInTheDocument();
     expect(
-      screen.getByText('SKILL.md could not be parsed'),
+      screen.getByText(/YAML parse error: Nested mappings are not allowed/),
     ).toBeInTheDocument();
   });
 

--- a/services/platform/app/features/skills/components/skills-catalog.tsx
+++ b/services/platform/app/features/skills/components/skills-catalog.tsx
@@ -300,8 +300,8 @@ export function SkillsCatalog({
                 </CatalogCardIcon>
               }
               title={row.name}
-              // A broken row's description is its backend read-error message —
-              // the badge already carries the localized "failed to read" state.
+              // Badge stays short and generic; the description carries the
+              // specific failure (YAML parse, missing frontmatter, etc.).
               description={row.status ? row.message : row.description}
               badge={
                 row.status ? (

--- a/services/platform/app/features/skills/utils/skill-load-error.test.ts
+++ b/services/platform/app/features/skills/utils/skill-load-error.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   resolveSkillLoadErrorPresentation,
   skillLoadErrorDetailTitleKey,
-  skillLoadErrorSummaryKey,
 } from './skill-load-error';
 
 describe('resolveSkillLoadErrorPresentation', () => {
@@ -40,17 +39,6 @@ describe('resolveSkillLoadErrorPresentation', () => {
         'YAML frontmatter is not closed by a `---` line',
       ),
     ).toEqual({ kind: 'unclosed_frontmatter' });
-  });
-});
-
-describe('skillLoadErrorSummaryKey', () => {
-  it('uses the line-specific key when a line is known', () => {
-    expect(
-      skillLoadErrorSummaryKey({ kind: 'yaml_syntax', line: 2, column: 14 }),
-    ).toBe('skills.loadError.yamlSyntaxLine');
-    expect(skillLoadErrorSummaryKey({ kind: 'yaml_syntax' })).toBe(
-      'skills.loadError.yamlSyntax',
-    );
   });
 });
 

--- a/services/platform/app/features/skills/utils/skill-load-error.ts
+++ b/services/platform/app/features/skills/utils/skill-load-error.ts
@@ -62,28 +62,6 @@ export function resolveSkillLoadErrorPresentation(
   return { kind: 'generic' };
 }
 
-export function skillLoadErrorSummaryKey(
-  presentation: SkillLoadErrorPresentation,
-): string {
-  if (presentation.kind === 'yaml_syntax' && presentation.line != null) {
-    return 'skills.loadError.yamlSyntaxLine';
-  }
-  return SUMMARY_KEYS[presentation.kind];
-}
-
-const SUMMARY_KEYS: Record<SkillLoadErrorKind, string> = {
-  yaml_syntax: 'skills.loadError.yamlSyntax',
-  missing_frontmatter: 'skills.loadError.missingFrontmatter',
-  unclosed_frontmatter: 'skills.loadError.unclosedFrontmatter',
-  frontmatter_too_large: 'skills.loadError.frontmatterTooLarge',
-  invalid_frontmatter: 'skills.loadError.invalidFrontmatter',
-  empty_frontmatter: 'skills.loadError.emptyFrontmatter',
-  not_found: 'skills.loadError.notFound',
-  symlink: 'skills.loadError.symlink',
-  inaccessible: 'skills.loadError.inaccessible',
-  generic: 'skills.loadError.generic',
-};
-
 export function skillLoadErrorDetailTitleKey(
   presentation: SkillLoadErrorPresentation,
 ): string {

--- a/services/platform/app/routes/dashboard/$id/settings/api/mcp.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/api/mcp.tsx
@@ -33,11 +33,15 @@ function ApiMcpPage() {
   // Access is gated by the parent `api` route layout. Section title (not a
   // page title) — the settings rail already names the page; the former
   // header action moves into the section header.
+  // `fitToContainer` + section `flex-1` so EmptyState (flex-1 +
+  // justify-center) sits in the middle of the pane below the section
+  // header — same height chain as Integrations.
   return (
-    <SettingsPage>
+    <SettingsPage fitToContainer>
       <SettingsSection
         title={tNav('mcp')}
         description={tMcp('description')}
+        className="min-h-0 flex-1"
         action={
           <Button onClick={() => setAddDialogOpen(true)}>
             <Plus className="mr-2 size-4" />

--- a/services/platform/app/routes/dashboard/$id/settings/metrics/projects.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/metrics/projects.tsx
@@ -97,13 +97,16 @@ function ProjectsMetricsRoute() {
     />
   );
 
-  return (
-    // `fullWidth`: `ProjectMetricsPage` lays its charts out on a two-column
-    // grid designed for the full pane, wider than the `max-w-3xl` standard
-    // settings measure (#2567).
-    <SettingsPage fullWidth>
-      <Skeletonize loading={projectsLoading}>
-        {selectedProjectId ? (
+  // `fullWidth`: `ProjectMetricsPage` lays its charts out on a two-column
+  // grid designed for the full pane, wider than the `max-w-3xl` standard
+  // settings measure (#2567). Empty path also uses `fitToContainer` so
+  // EmptyState can vertically center in the remaining pane (Integrations
+  // pattern); the selected-project path stays content-sized so charts
+  // scroll with the outer settings scroller.
+  if (selectedProjectId) {
+    return (
+      <SettingsPage fullWidth>
+        <Skeletonize loading={projectsLoading}>
           <ProjectMetricsPage
             as="h3"
             toolbarStart={projectPicker}
@@ -111,20 +114,31 @@ function ProjectsMetricsRoute() {
             periodDays={periodDays}
             onChangePeriod={handleChangePeriod}
           />
-        ) : (
-          <MetricsLayout
-            as="h3"
-            title={tTasks('metrics.title')}
-            description={tTasks('metrics.description')}
-            toolbar={projectPicker}
-          >
-            <EmptyState
-              icon={BarChart3}
-              title={t('projects.emptyTitle')}
-              description={t('projects.emptyDescription')}
-            />
-          </MetricsLayout>
-        )}
+        </Skeletonize>
+      </SettingsPage>
+    );
+  }
+
+  return (
+    <SettingsPage fullWidth fitToContainer>
+      <Skeletonize
+        loading={projectsLoading}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <MetricsLayout
+          as="h3"
+          title={tTasks('metrics.title')}
+          description={tTasks('metrics.description')}
+          toolbar={projectPicker}
+          className="min-h-0 flex-1"
+        >
+          <EmptyState
+            icon={BarChart3}
+            title={t('projects.emptyTitle')}
+            description={t('projects.emptyDescription')}
+            className="min-h-0"
+          />
+        </MetricsLayout>
       </Skeletonize>
     </SettingsPage>
   );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1860,11 +1860,9 @@
     },
     "unsavedChanges": {
       "title": "Ungespeicherte Änderungen",
-      "descriptionTwoButton": "Du hast ungespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.",
-      "descriptionThreeButton": "Du hast ungespeicherte Änderungen. Speichere sie, bevor du gehst, oder verwirf sie.",
-      "stay": "Bleiben",
-      "discardAndLeave": "Verwerfen & Gehen",
-      "saveAndLeave": "Speichern & Gehen"
+      "description": "Du hast ungespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.",
+      "stay": "Weiter bearbeiten",
+      "discardAndLeave": "Verwerfen & Gehen"
     },
     "editor": {
       "fixHighlightedFields": "Bitte korrigiere die hervorgehobenen Felder und versuche es erneut.",
@@ -5573,7 +5571,7 @@
         "title": "Ungespeicherte Änderungen",
         "description": "Du hast ungespeicherte Änderungen. Möchtest du wirklich die Seite verlassen? Deine Änderungen gehen verloren.",
         "leave": "Verlassen",
-        "stay": "Bleiben"
+        "stay": "Weiter bearbeiten"
       },
       "navigation": {
         "general": "Allgemein",
@@ -8112,7 +8110,7 @@
       "agentsHeading": "Agenten",
       "modelsHeading": "Modelle",
       "integrationsHeading": "Integrationen",
-      "sectionDescription": "Lege fest, welche Agenten und Modelle in diesem Projekt auftauchen. Die Liste unten bestimmt die Reihenfolge, die Mitglieder sehen; der Modus darunter entscheidet, ob der Rest verfügbar bleibt oder nicht.",
+      "sectionDescription": "Lege fest, welche Agenten und Modelle Mitglieder in diesem Projekt nutzen können.",
       "modeRecommended": "Empfohlen",
       "modeRecommendedDescription": "Pinne die Einträge unten oben an. Der Rest bleibt verfügbar.",
       "modeRestricted": "Eingeschränkt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1860,11 +1860,9 @@
     },
     "unsavedChanges": {
       "title": "Unsaved changes",
-      "descriptionTwoButton": "You have unsaved changes. Leaving now will discard them.",
-      "descriptionThreeButton": "You have unsaved changes. Save them before leaving, or discard and leave.",
-      "stay": "Stay",
-      "discardAndLeave": "Discard & Leave",
-      "saveAndLeave": "Save & Leave"
+      "description": "You have unsaved changes. Leaving now will discard them.",
+      "stay": "Keep editing",
+      "discardAndLeave": "Discard & Leave"
     },
     "editor": {
       "fixHighlightedFields": "Fix the highlighted fields and try again.",
@@ -5399,7 +5397,7 @@
       "agentsHeading": "Agents",
       "modelsHeading": "Models",
       "integrationsHeading": "Integrations",
-      "sectionDescription": "Curate which agents and models appear in this project. The list below is the order members see them; the mode below picks whether the rest stay available or not.",
+      "sectionDescription": "Choose which agents and models members can use in this project.",
       "modeRecommended": "Recommended",
       "modeRecommendedDescription": "Pin the items below to the top. Others remain available.",
       "modeRestricted": "Restricted",
@@ -5864,7 +5862,7 @@
         "title": "Unsaved changes",
         "description": "You have unsaved changes. Are you sure you want to leave? Your changes will be lost.",
         "leave": "Leave",
-        "stay": "Stay"
+        "stay": "Keep editing"
       },
       "navigation": {
         "general": "General",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1860,11 +1860,9 @@
     },
     "unsavedChanges": {
       "title": "Modifications non enregistrées",
-      "descriptionTwoButton": "Tu as des modifications non enregistrées. Quitter maintenant les fera disparaître.",
-      "descriptionThreeButton": "Tu as des modifications non enregistrées. Enregistre-les avant de partir, ou abandonne-les.",
-      "stay": "Rester",
-      "discardAndLeave": "Abandonner & Quitter",
-      "saveAndLeave": "Enregistrer & Quitter"
+      "description": "Tu as des modifications non enregistrées. Quitter maintenant les fera disparaître.",
+      "stay": "Continuer à modifier",
+      "discardAndLeave": "Abandonner & Quitter"
     },
     "editor": {
       "fixHighlightedFields": "Corrige les champs surlignés et réessaie.",
@@ -5573,7 +5571,7 @@
         "title": "Modifications non enregistrées",
         "description": "Tu as des modifications non enregistrées. Es-tu sûr de vouloir quitter ? Tes modifications seront perdues.",
         "leave": "Quitter",
-        "stay": "Rester"
+        "stay": "Continuer à modifier"
       },
       "navigation": {
         "general": "Général",
@@ -8112,7 +8110,7 @@
       "agentsHeading": "Agents",
       "modelsHeading": "Modèles",
       "integrationsHeading": "Intégrations",
-      "sectionDescription": "Choisis quels agents et modèles apparaissent dans ce projet. La liste ci-dessous fixe l'ordre que les membres voient ; le mode plus bas choisit si le reste reste accessible ou non.",
+      "sectionDescription": "Choisis quels agents et modèles les membres peuvent utiliser dans ce projet.",
       "modeRecommended": "Recommandés",
       "modeRecommendedDescription": "Épingle les éléments ci-dessous en haut. Les autres restent disponibles.",
       "modeRestricted": "Restreints",


### PR DESCRIPTION
## Summary
- Section CTAs and status chips move into the header action slot (New folder, Add agent/model, SCIM Enabled/Disabled). Empty sections were leaving orphaned buttons under the body; the header is where the next step should sit when there’s nothing in the list yet.
- Usage trend chart uses the same chrome as the tables below it (title outside, border-only frame, empty-state icon). ChartCard’s inner title + different fill made Tokens look like a separate surface on the same page.
- Integration side panel titles use the product name (e.g. Confluence) instead of “Add integration,” so the open panel matches the card you clicked.
- Shorten the project Agents blurb — Recommended/Restricted already explain order vs availability.
- Unsaved-leave dialog is Stay / Discard only — save stays on the page Save control, not a second path inside the blocker.

## Test plan
- [ ] Integrations → Confluence panel header shows **Confluence**
- [ ] Usage Metrics → trend title/empty icon/frame match Top Voice Models / Per-User Usage
- [ ] Project Files → **New folder** on the header row with **Files**
- [ ] Project Agents → **Add agent** / **Add model** in headers; shorter description
- [ ] SCIM → compact Enabled/Disabled badge in section header
- [ ] Dirty editor leave → Stay / Discard only