### PR TITLE
fix(platform): keep automations catalog bottom padding in scroll flow

### DIFF
--- a/services/platform/app/features/automations/components/automations-grid.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.tsx
@@ -727,8 +727,11 @@ export function AutomationsGrid({
     );
   }
 
+  // `grow`, not `flex-1`: content-sized when the grid overflows (so the
+  // page stack's bottom padding stays in the scrolled flow) while still
+  // filling the pane so the no-results empty state below centers.
   return (
-    <Stack gap={4} className="min-h-0 flex-1">
+    <Stack gap={4} className="grow">
       <CatalogToolbar
         search={{
           value: searchQuery,

--- a/services/platform/app/routes/dashboard/$id/automations/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/index.tsx
@@ -50,8 +50,13 @@ function AutomationsIndexPage() {
     onSynced: () => invalidateAutomations(organizationId),
   });
 
+  // `grow` (basis auto), NOT `flex-1` (basis 0): the page scrolls in
+  // PageLayout, and a basis-0 box is capped at pane height, clipping the
+  // p-4 bottom padding at the scroll boundary once the catalog overflows
+  // (see the same note in settings-page.tsx). `grow` still fills the pane
+  // when content is short, so the empty state stays centered (#2704).
   return (
-    <Stack gap={6} className="min-h-0 flex-1 p-4">
+    <Stack gap={6} className="grow p-4">
       <AutomationsGrid
         organizationId={organizationId}
         tab={tab ?? DEFAULT_AUTOMATIONS_TAB}


### PR DESCRIPTION
## Problem

On `/dashboard/$id/automations`, scrolling the catalog to the end leaves the last card row flush against the bottom viewport edge — no breathing room (reported with screenshot).

## Root cause

`PageLayout` is the page's scroll container. #2704 wrapped the index content in `Stack className="min-h-0 flex-1 p-4"` to center the empty state — but `flex-1` (basis 0) + `min-h-0` caps the box at pane height, so once the catalog overflows, the cards flow *past* the box's `padding-bottom` and the `p-4` bottom gap is clipped at the scroll boundary. This is the exact failure mode already documented in `settings-page.tsx`. The inner `Stack min-h-0 flex-1` in `AutomationsGrid` had the same cap.

## Change

Both stacks: `min-h-0 flex-1` → `grow` (grow 1, basis auto, automatic min-height). The box is now max(content, pane): content-sized when the grid overflows — padding stays in the scrolled flow — while still filling the pane when content is short, so the empty states remain centered (the reason #2704 added `flex-1`).

## Verification

- E2E in a real browser (`bun dev` stack): scrolled `?tab=all` to the end — gap below the last card is now exactly **16px** (was 0, card flush with viewport edge).
- No-results empty state (garbage search) still renders vertically centered in the content pane; Installed tab renders clean with space below.
- `visual-aspect-analyzer` on the page: **score 100, zero defects**, no unintended `affected` elements (451 discovered).
- Format, oxlint (type-aware), platform typecheck, and `automations-grid` component tests (28/28) all green.
- Swept for the same pattern elsewhere: knowledge pages use `DataTable stickyLayout` (own scroll container), so the automations index was the only affected site.