### PR TITLE
feat(platform): immediate loading feedback for desk row Start

### DIFF
--- a/services/platform/app/features/automations/registry/connected/bound-button.test.tsx
+++ b/services/platform/app/features/automations/registry/connected/bound-button.test.tsx
@@ -20,8 +20,10 @@ vi.mock('@/lib/i18n/client', () => ({
   }),
 }));
 
+// Mutable so a test can flip the dispatch into its in-flight state.
+let boundActionPending = false;
 vi.mock('../../hooks/use-bound-action', () => ({
-  useBoundAction: () => ({ dispatch: vi.fn(), isPending: false }),
+  useBoundAction: () => ({ dispatch: vi.fn(), isPending: boundActionPending }),
 }));
 
 vi.mock('../../runtime/action-effects', () => ({
@@ -94,5 +96,29 @@ describe('action label i18n (pack `i18n.<locale>` overrides)', () => {
     expect(
       screen.getByRole('button', { name: 'Open Knowledge' }),
     ).toBeInTheDocument();
+  });
+});
+
+describe('in-flight feedback', () => {
+  it('shows a busy spinner (not just a dim button) while dispatch is pending', () => {
+    // A slow server otherwise leaves "Start" looking inert after the click.
+    boundActionPending = true;
+    try {
+      render(
+        <BoundButton
+          action={{
+            label: 'Start',
+            path: 'tasks/public_actions:startTaskWorkflow',
+            mode: 'action',
+          }}
+          item={{ _id: 't1' }}
+        />,
+      );
+      const button = screen.getByRole('button', { name: 'Start' });
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+    } finally {
+      boundActionPending = false;
+    }
   });
 });

--- a/services/platform/app/features/automations/registry/connected/bound-button.tsx
+++ b/services/platform/app/features/automations/registry/connected/bound-button.tsx
@@ -268,7 +268,7 @@ function DispatchBoundButton({
       <Button
         size={size}
         variant={action.variant ?? 'secondary'}
-        disabled={isPending}
+        isLoading={isPending}
         onClick={() => {
           if (action.confirm) {
             setConfirmOpen(true);

--- a/services/platform/app/features/automations/registry/connected/subject-awaiting-input-actions.test.tsx
+++ b/services/platform/app/features/automations/registry/connected/subject-awaiting-input-actions.test.tsx
@@ -8,7 +8,7 @@ import { SubjectAwaitingInputActions } from './subject-awaiting-input-actions';
 // Drive the indicator query by hand.
 let indicator:
   | {
-      state: 'parked' | 'failed' | 'awaiting_input' | null;
+      state: 'parked' | 'failed' | 'awaiting_input' | 'starting' | null;
       failedExecutionId: string | null;
     }
   | undefined;
@@ -37,6 +37,14 @@ describe('SubjectAwaitingInputActions', () => {
     // A "Start" here would re-run WITHOUT the awaited answer; the row itself
     // expands (chevron / row click) to the question and the answer panel.
     indicator = { state: 'awaiting_input', failedExecutionId: null };
+    const { container } = renderGate();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('suppresses the cluster while the run is starting', () => {
+    // The run was just kicked off but the task status hasn't flipped yet —
+    // re-offering Start would only bounce off the duplicate-run guard.
+    indicator = { state: 'starting', failedExecutionId: null };
     const { container } = renderGate();
     expect(container).toBeEmptyDOMElement();
   });

--- a/services/platform/app/features/automations/registry/connected/subject-awaiting-input-actions.tsx
+++ b/services/platform/app/features/automations/registry/connected/subject-awaiting-input-actions.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 /**
- * Actions-cell gate for a subject whose latest run parked awaiting operator
- * input. The config-driven cluster (e.g. a "Start" bound action) would re-run
- * the automation WITHOUT the answer it is waiting for, so on such rows the
- * actions cell simply goes quiet: the row expands like any other (chevron /
- * row click) to the question and the inline answer panel
- * (`SubjectInputPanel`), and the "Needs your input" chip carries the
- * guidance. Every other run state renders the cluster unchanged.
+ * Actions-cell gate for a subject whose latest run makes the config-driven
+ * cluster wrong to offer:
+ *   - parked awaiting operator input — a "Start" bound action would re-run
+ *     the automation WITHOUT the answer it is waiting for; the row expands
+ *     like any other (chevron / row click) to the question and the inline
+ *     answer panel (`SubjectInputPanel`), and the "Needs your input" chip
+ *     carries the guidance;
+ *   - starting — the run was just kicked off but the subject's status hasn't
+ *     flipped yet, so the cluster would still offer Start; a second click
+ *     only bounces off the duplicate-run guard, and the "Starting…" chip
+ *     already explains the state.
+ * On such rows the actions cell simply goes quiet. Every other run state
+ * renders the cluster unchanged.
  *
  * Reads the same tiny per-row indicator query as the status chip and the
  * re-run action (Convex dedupes the identical subscription), so it adds no
@@ -34,6 +40,8 @@ export function SubjectAwaitingInputActions({
     api.workflow_executions.queries.getSubjectRunIndicator,
     { organizationId, subjectType, subjectId },
   );
-  if (data?.state === 'awaiting_input') return null;
+  if (data?.state === 'awaiting_input' || data?.state === 'starting') {
+    return null;
+  }
   return <>{cluster}</>;
 }

--- a/services/platform/app/features/automations/registry/connected/subject-run-status-chip.test.tsx
+++ b/services/platform/app/features/automations/registry/connected/subject-run-status-chip.test.tsx
@@ -7,7 +7,10 @@ import { SubjectRunStatusChip } from './subject-run-status-chip';
 
 // Drive the indicator query by hand; echo i18n keys so assertions read clearly.
 let indicator:
-  | { state: 'parked' | 'failed' | null; failedExecutionId: string | null }
+  | {
+      state: 'parked' | 'failed' | 'starting' | null;
+      failedExecutionId: string | null;
+    }
   | undefined;
 vi.mock('@/app/hooks/use-convex-query', () => ({
   useConvexQuery: () => ({ data: indicator }),
@@ -45,6 +48,13 @@ describe('SubjectRunStatusChip', () => {
     indicator = { state: 'parked', failedExecutionId: null };
     renderChip();
     expect(screen.getByText('runs.queuedForCapacity')).toBeInTheDocument();
+    expect(screen.queryByText('in_progress')).not.toBeInTheDocument();
+  });
+
+  it('swaps in the "Starting…" badge while a fresh run is picking up', () => {
+    indicator = { state: 'starting', failedExecutionId: null };
+    renderChip();
+    expect(screen.getByText('runs.starting')).toBeInTheDocument();
     expect(screen.queryByText('in_progress')).not.toBeInTheDocument();
   });
 

--- a/services/platform/app/features/automations/registry/connected/subject-run-status-chip.tsx
+++ b/services/platform/app/features/automations/registry/connected/subject-run-status-chip.tsx
@@ -8,7 +8,11 @@
  *     capacity" (the run view's queued step badge);
  *   - ended in failure → destructive "Failed" (the run view's errored step
  *     badge) — so a crashed automation reads as "Failed" instead of a
- *     misleading, frozen "in_progress".
+ *     misleading, frozen "in_progress";
+ *   - parked awaiting an operator's answer → blue "Needs your input";
+ *   - kicked off but not yet reflected in the task's own status (the window
+ *     between Start and the workflow's ack step) → blue "Starting…" — so
+ *     pressing Start visibly reacts instead of sitting on a stale "Backlog".
  * The subject's own lifecycle/kanban status is never changed — only the display
  * swaps, so a parked or failed row reads as one coherent state instead of a
  * contradictory pair. Owns the status cell via Collection's `rowAccessory`,
@@ -64,6 +68,13 @@ export function SubjectRunStatusChip({
     return (
       <Badge variant="blue" dot title={t('runs.awaitingInputHint')}>
         {t('runs.awaitingInput')}
+      </Badge>
+    );
+  }
+  if (data?.state === 'starting') {
+    return (
+      <Badge variant="blue" dot title={t('runs.startingHint')}>
+        {t('runs.starting')}
       </Badge>
     );
   }

--- a/services/platform/app/features/operator/components/rerun-button.tsx
+++ b/services/platform/app/features/operator/components/rerun-button.tsx
@@ -52,7 +52,11 @@ export function RerunButton({
   };
 
   return (
-    <Button variant="secondary" disabled={isPending} onClick={() => void run()}>
+    <Button
+      variant="secondary"
+      isLoading={isPending}
+      onClick={() => void run()}
+    >
       {t('rerun.button')}
     </Button>
   );

--- a/services/platform/convex/workflow_executions/queries.ts
+++ b/services/platform/convex/workflow_executions/queries.ts
@@ -1,7 +1,10 @@
 import { paginationOptsValidator } from 'convex/server';
 import { v } from 'convex/values';
 
-import { deriveRunIndicator } from '../../lib/shared/platform/run_capacity';
+import {
+  deriveRunIndicator,
+  isActiveExecutionStatus,
+} from '../../lib/shared/platform/run_capacity';
 import * as ApprovalsHelpers from '../approvals/helpers';
 import { queryWithRLS } from '../lib/rls';
 import { TERMINAL_STATUSES } from '../tasks/helpers';
@@ -104,12 +107,13 @@ export const getLatestExecutionForSubject = queryWithRLS({
 
 /**
  * The ambient run indicator for a subject's row, derived from the subject's
- * latest run (see `deriveRunIndicator`): `state` is `'parked' | 'failed' | null`
- * and, when failed, `failedExecutionId` carries that run's id so the row can
- * offer a one-click re-run (`rerunExecution`). A tiny value (not the full run
- * summary) so a list can show a per-row chip + retry without subscribing each
- * visible row to the heavy execution summary: Convex pushes an update only when
- * the indicator flips, not on every ~4s poll of a running execution.
+ * latest run (see `deriveRunIndicator`): `state` is
+ * `'parked' | 'failed' | 'awaiting_input' | 'starting' | null` and, when
+ * failed, `failedExecutionId` carries that run's id so the row can offer a
+ * one-click re-run (`rerunExecution`). A tiny value (not the full run summary)
+ * so a list can show a per-row chip + retry without subscribing each visible
+ * row to the heavy execution summary: Convex pushes an update only when the
+ * indicator flips, not on every ~4s poll of a running execution.
  *
  * A RESOLVED subject returns `null`: a task already done/cancelled keeps showing
  * its real terminal status, never a stale "Failed" chip or a Re-run offer for a
@@ -126,6 +130,7 @@ export const getSubjectRunIndicator = queryWithRLS({
       v.literal('parked'),
       v.literal('failed'),
       v.literal('awaiting_input'),
+      v.literal('starting'),
       v.null(),
     ),
     failedExecutionId: v.union(v.id('wfExecutions'), v.null()),
@@ -136,15 +141,15 @@ export const getSubjectRunIndicator = queryWithRLS({
     // overriding it with a "Failed" chip (or offering a Re-run) for an old run.
     // RLS wraps the wfExecutions query below; `ctx.db.get` bypasses it, so match
     // the org explicitly.
+    let taskStatus: string | undefined;
     if (args.subjectType === 'task') {
       const taskId = ctx.db.normalizeId('tasks', args.subjectId);
       const task = taskId ? await ctx.db.get(taskId) : null;
-      if (
-        task &&
-        task.organizationId === args.organizationId &&
-        TERMINAL_STATUSES.has(task.status)
-      ) {
-        return { state: null, failedExecutionId: null };
+      if (task && task.organizationId === args.organizationId) {
+        if (TERMINAL_STATUSES.has(task.status)) {
+          return { state: null, failedExecutionId: null };
+        }
+        taskStatus = task.status;
       }
     }
     const row = await ctx.db
@@ -157,7 +162,7 @@ export const getSubjectRunIndicator = queryWithRLS({
       )
       .order('desc')
       .first();
-    let state: 'parked' | 'failed' | 'awaiting_input' | null =
+    let state: 'parked' | 'failed' | 'awaiting_input' | 'starting' | null =
       deriveRunIndicator(row);
     // A run that ended by asking the operator for a decision leaves a pending
     // human-input / review approval keyed to that execution — surface it as
@@ -179,6 +184,21 @@ export const getSubjectRunIndicator = queryWithRLS({
       ) {
         state = 'awaiting_input';
       }
+    }
+    // A run is active but the task's own status doesn't show it yet — the
+    // window between the desk's Start and the workflow's ack step flipping the
+    // task to in_progress (engine pickup can take seconds). Surface it as
+    // "starting" so the row visibly reacts to Start instead of sitting on a
+    // stale Backlog badge. Task-only: only a task's own status can prove the
+    // run state would otherwise be invisible.
+    if (
+      state === null &&
+      row &&
+      isActiveExecutionStatus(row.status) &&
+      taskStatus !== undefined &&
+      taskStatus !== 'in_progress'
+    ) {
+      state = 'starting';
     }
     return {
       state,

--- a/services/platform/convex/workflow_executions/subject_run_indicator.test.ts
+++ b/services/platform/convex/workflow_executions/subject_run_indicator.test.ts
@@ -111,6 +111,29 @@ async function seedFailedRun(
   );
 }
 
+/** A just-kicked-off run: active (`pending`), not parked on capacity. */
+async function seedPendingRun(
+  t: T,
+  taskId: Id<'tasks'>,
+  opts?: { awaitingCapacityStepSlug?: string },
+): Promise<Id<'wfExecutions'>> {
+  return await t.run((ctx) =>
+    ctx.db.insert('wfExecutions', {
+      organizationId: ORG,
+      wfDefinitionId: 'issue-desk/desk-process',
+      status: 'pending',
+      currentStepSlug: '',
+      startedAt: 0,
+      updatedAt: 0,
+      subjectType: 'task',
+      subjectId: taskId,
+      ...(opts?.awaitingCapacityStepSlug !== undefined && {
+        awaitingCapacityStepSlug: opts.awaitingCapacityStepSlug,
+      }),
+    }),
+  );
+}
+
 describe('getSubjectRunIndicator terminal-subject suppression', () => {
   it('surfaces Failed (+ the run id) for a NON-terminal task whose latest run failed', async () => {
     const t = newT();
@@ -128,6 +151,64 @@ describe('getSubjectRunIndicator terminal-subject suppression', () => {
       });
 
     expect(res).toEqual({ state: 'failed', failedExecutionId: execId });
+  });
+
+  it('surfaces Starting for an active run whose task status has not flipped yet', async () => {
+    // The window between the desk's Start and the workflow's ack step: the run
+    // exists (pending) but the task still reads backlog — the row must react.
+    const t = newT();
+    await seedMember(t);
+    const project = await seedProject(t);
+    const taskId = await seedTask(t, project, 'o/r#3', 'open');
+    await seedPendingRun(t, taskId);
+
+    const res = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow_executions.queries.getSubjectRunIndicator, {
+        organizationId: ORG,
+        subjectType: 'task',
+        subjectId: taskId,
+      });
+
+    expect(res).toEqual({ state: 'starting', failedExecutionId: null });
+  });
+
+  it('suppresses Starting once the task itself reads in_progress', async () => {
+    const t = newT();
+    await seedMember(t);
+    const project = await seedProject(t);
+    const taskId = await seedTask(t, project, 'o/r#4', 'open');
+    await seedPendingRun(t, taskId);
+    await t.run((ctx) => ctx.db.patch(taskId, { status: 'in_progress' }));
+
+    const res = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow_executions.queries.getSubjectRunIndicator, {
+        organizationId: ORG,
+        subjectType: 'task',
+        subjectId: taskId,
+      });
+
+    // The task's own badge already shows the activity — nothing to surface.
+    expect(res).toEqual({ state: null, failedExecutionId: null });
+  });
+
+  it('keeps parked-on-capacity ahead of Starting for an active queued run', async () => {
+    const t = newT();
+    await seedMember(t);
+    const project = await seedProject(t);
+    const taskId = await seedTask(t, project, 'o/r#5', 'open');
+    await seedPendingRun(t, taskId, { awaitingCapacityStepSlug: 'run' });
+
+    const res = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow_executions.queries.getSubjectRunIndicator, {
+        organizationId: ORG,
+        subjectType: 'task',
+        subjectId: taskId,
+      });
+
+    expect(res).toEqual({ state: 'parked', failedExecutionId: null });
   });
 
   it('suppresses the failed-run indicator once the task is done', async () => {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -905,6 +905,8 @@
       "failedHint": "Der letzte automatische Lauf wurde mit einem Fehler abgebrochen. Öffne die Aufgabe, um zu sehen, welcher Schritt fehlgeschlagen ist, und starte ihn neu.",
       "awaitingInput": "Deine Eingabe nötig",
       "awaitingInputHint": "Angehalten — der Desk hat dir eine Frage gestellt. Klappe die Zeile auf, antworte und dann „Senden & fortfahren“.",
+      "starting": "Startet …",
+      "startingHint": "Der Lauf wurde gestartet und legt gleich los.",
       "input": {
         "heading": "Wir brauchen deine Eingabe, um fortzufahren",
         "placeholder": "Gib deine Antwort ein …",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -905,6 +905,8 @@
       "failedHint": "The last automated run stopped on an error. Open the task to see which step failed, then re-run it.",
       "awaitingInput": "Needs your input",
       "awaitingInputHint": "Parked — the desk asked you a question. Expand the row, answer, then Submit & continue.",
+      "starting": "Starting…",
+      "startingHint": "The run was kicked off and picks up in a moment.",
       "input": {
         "heading": "We need your input to continue",
         "placeholder": "Type your answer…",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -905,6 +905,8 @@
       "failedHint": "La dernière exécution automatique s'est arrêtée sur une erreur. Ouvrez la tâche pour voir quelle étape a échoué, puis relancez-la.",
       "awaitingInput": "Réponse requise",
       "awaitingInputHint": "En attente — le desk t’a posé une question. Déplie la ligne, réponds, puis « Envoyer et continuer ».",
+      "starting": "Démarrage…",
+      "startingHint": "L’exécution vient d’être lancée et démarre dans un instant.",
       "input": {
         "heading": "Nous avons besoin de ta réponse pour continuer",
         "placeholder": "Saisis ta réponse…",


### PR DESCRIPTION
## Problem

Clicking **Start** on a desk return row gives no visible feedback when the server is slow: the button only sets `disabled` while the Convex action runs, and after the action resolves the row keeps its stale *Backlog* badge (next to a still-enabled Start) until the workflow's ack step flips the task to `in_progress`. The click reads as ignored, sometimes for seconds.

## Change

Two dead windows, one change each:

1. **Click → action resolves** — `DispatchBoundButton` and `RerunButton` now pass `isLoading={isPending}`, so the Button primitive's spinner (+ `aria-busy`) appears the moment the click lands.
2. **Action resolves → ack flips the task** — `getSubjectRunIndicator` gains a `starting` state: the latest run is active but the task's own status doesn't show it yet. Task subjects only — only there is the contradiction provable; `parked` / `failed` / `awaiting_input` keep precedence. The status chip renders a blue **"Starting…"** badge and the actions-cell gate goes quiet, so a second click can't bounce off the duplicate-run guard.

The execution row is committed before the action resolves, so the chip takes over right as the button spinner ends — observed live: **52 ms** spinner → **1919 ms** action resolved → **1983 ms** Start hidden + "Starting…" → ack → "In progress" + Cancel.

## Verification

- Unit: bound-button spinner (`aria-busy` + disabled while pending), convex indicator suite (starting / suppressed once `in_progress` / parked precedence), chip renders "Starting…", actions gate hides the cluster — all green.
- i18n parity suite green (en/de/fr keys added).
- Live: full flow driven in a dev org (install desk → New quarter → upload → Start → Starting… → In progress; Cancel → Cancelled + Start again).

## Definition of done

- [x] Green gate — format / oxlint (type-aware) / tsc / touched vitest suites pass locally
- [x] Security gate — `bun run lint:sast` clean (0 findings)
- [x] Tests — new cases for the spinner, the `starting` derivation (incl. precedence + suppression), chip, and gate
- [x] Migration — N/A: query return shape only, no persisted schema/config change
- [x] Locales — `runs.starting(+Hint)` in en/de/fr; de-CH sparse override N/A (no ß in the German strings)
- [x] Docs — N/A: run-chip states aren't enumerated in user docs
- [x] Accessibility — spinner sets `aria-busy`; chip reuses the existing Badge+title pattern
- [x] Sweep — all three indicator consumers handled (chip, rerun action, awaiting-input gate); board-card inherits the chip; add-action path unchanged (its form dialog already shows `isSubmitting`)
- [x] Observed — real UI timeline above, plus the cancel/restart loop
- [x] Commits — two atomic conventional commits off `main`