### PR TITLE
fix(platform): grow editor Save/Discard hit area to 44px (#1980)

### DIFF
--- a/services/platform/app/components/ui/editor/editor-actions.test.tsx
+++ b/services/platform/app/components/ui/editor/editor-actions.test.tsx
@@ -39,12 +39,14 @@ beforeEach(() => {
 });
 
 describe('EditorActions — mobile touch targets (#1980)', () => {
-  it('grows the Save and Discard buttons to 44px on mobile', () => {
+  it('extends the Save and Discard hit areas to 44px on mobile without growing the visual box', () => {
     render(<EditorActions controller={makeController()} />);
     for (const name of ['actions.discard', 'actions.save']) {
       expect(screen.getByRole('button', { name })).toHaveClass(
-        'max-sm:min-h-11',
-        'max-sm:min-w-11',
+        'relative',
+        'max-sm:after:absolute',
+        'max-sm:after:-inset-1.5',
+        "max-sm:after:content-['']",
       );
     }
   });

--- a/services/platform/app/components/ui/editor/editor-actions.tsx
+++ b/services/platform/app/components/ui/editor/editor-actions.tsx
@@ -169,9 +169,10 @@ export function EditorActions({
         collapseLabel
         // The `sm` size is 32px tall and, once the label collapses to an icon
         // below the `sm` breakpoint, narrower than the 44px WCAG 2.5.5 touch
-        // target. Grow the hit area to 44×44px on mobile only; the dense
-        // desktop size is kept from `sm` up (WCAG 2.5.5 / #1980).
-        className="max-sm:min-h-11 max-sm:min-w-11"
+        // target. Keep the visual box at 32px (matching the adjacent History
+        // button) and extend the tappable area to ≥44px via an invisible
+        // pseudo-element overlay on mobile only (WCAG 2.5.5 / #1980).
+        className="relative max-sm:after:absolute max-sm:after:-inset-1.5 max-sm:after:content-['']"
         disabled={discardDisabled}
         aria-disabled={discardDisabled ? 'true' : undefined}
       >
@@ -181,7 +182,7 @@ export function EditorActions({
         type={formId ? 'submit' : 'button'}
         size="sm"
         form={formId}
-        className="max-sm:min-h-11 max-sm:min-w-11"
+        className="relative max-sm:after:absolute max-sm:after:-inset-1.5 max-sm:after:content-['']"
         onClick={formId ? undefined : () => void runSave()}
         disabled={saveDisabled}
         aria-busy={controller.isSaving ? 'true' : undefined}


### PR DESCRIPTION
## What
The block-editor **Save** and **Discard** actions presented a sub-minimum touch target. They now meet the **WCAG 2.5.5 (AA)** 44×44 CSS-px target size via an invisible pseudo-element overlay that enlarges the pointer/touch hit area **without changing the visual button size** — replacing the prior `min-h-11 / min-w-11` sizing.

## Scope
- `app/components/ui/editor/editor-actions.tsx` + its test.
- No behavior change beyond the enlarged hit area; visual layout unchanged.

## Test
- `editor-actions.test.tsx` updated and green (client/jsdom project).
- typecheck · oxlint (type-aware) · oxfmt all clean.