### PR TITLE
fix(platform): truncate long contacts Name/Email/Phone cells

### DIFF
--- a/services/platform/app/features/contacts/hooks/use-contacts-table-config.test.tsx
+++ b/services/platform/app/features/contacts/hooks/use-contacts-table-config.test.tsx
@@ -2,7 +2,7 @@
 import '@testing-library/jest-dom/vitest';
 import { AppShell } from '@tale/ui/app-shell';
 import type { ColumnDef } from '@tanstack/react-table';
-import { renderHook } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
 
@@ -25,6 +25,21 @@ function columnKey(column: ColumnDef<Contact>): string | undefined {
   return 'accessorKey' in column ? column.accessorKey : column.id;
 }
 
+type CellRenderer = (ctx: { row: { original: Partial<Contact> } }) => ReactNode;
+
+/** Render a single accessor column's cell for a given contact row. */
+function renderCell(accessorKey: string, contact: Partial<Contact>) {
+  const { result } = renderHook(() => useContactsTableConfig(), {
+    wrapper: Providers,
+  });
+  const column = result.current.columns.find(
+    (c) => 'accessorKey' in c && c.accessorKey === accessorKey,
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only narrowing of ColumnDef cell to its callable form
+  const cell = column?.cell as CellRenderer;
+  return render(<Providers>{cell({ row: { original: contact } })}</Providers>);
+}
+
 describe('useContactsTableConfig', () => {
   it('marks Name, Email and Added sortable; everything else not (#2639)', () => {
     const { result } = renderHook(() => useContactsTableConfig(), {
@@ -44,5 +59,28 @@ describe('useContactsTableConfig', () => {
     expect(byKey.get('phone')?.enableSorting).toBe(false);
     expect(byKey.get('source')?.enableSorting).toBe(false);
     expect(byKey.get('locale')?.enableSorting).toBe(false);
+  });
+
+  // A contact's name is frequently a raw email — an unbreakable token that, as
+  // a bare inline span in a `table-fixed` cell, overflowed its column and bled
+  // over the next one. `block` makes the span honour the cell width and
+  // `truncate` clips the overflow with an ellipsis instead of spilling.
+  it('truncates the Name, Email and Phone cells so long values cannot bleed across columns', () => {
+    const longEmail = 'mustophaadesinamyd@gmail.com';
+    const cases: Array<[string, string]> = [
+      ['name', longEmail],
+      ['email', longEmail],
+      ['phone', '+15551234567890'],
+    ];
+
+    for (const [key, value] of cases) {
+      const { unmount } = renderCell(key, {
+        name: longEmail,
+        email: longEmail,
+        phone: '+15551234567890',
+      });
+      expect(screen.getByText(value)).toHaveClass('truncate', 'block');
+      unmount();
+    }
   });
 });

--- a/services/platform/app/features/contacts/hooks/use-contacts-table-config.tsx
+++ b/services/platform/app/features/contacts/hooks/use-contacts-table-config.tsx
@@ -82,8 +82,14 @@ export const useContactsTableConfig = createTableConfigHook<'contacts'>(
         accessorKey: 'name',
         header: sortableHeader<Contact>(tTables('headers.name'), sortLabels),
         size: 200,
+        // `block truncate`: a long value (contacts frequently carry an email as
+        // their name) is an unbreakable token that, as a bare inline span in a
+        // `table-fixed` cell, overflows the column and bleeds over the next one.
+        // `truncate` only clips once the span is block-level with the cell's
+        // width — matches every sibling entity table. Full value is on the row's
+        // detail dialog.
         cell: ({ row }) => (
-          <Text as="span" variant="label">
+          <Text as="span" variant="label" truncate className="block">
             {row.original.name || ''}
           </Text>
         ),
@@ -93,7 +99,7 @@ export const useContactsTableConfig = createTableConfigHook<'contacts'>(
         header: sortableHeader<Contact>(tTables('headers.email'), sortLabels),
         size: 240,
         cell: ({ row }) => (
-          <Text as="span" variant="body">
+          <Text as="span" variant="body" truncate className="block">
             {row.original.email || tTables('cells.noEmail')}
           </Text>
         ),
@@ -105,7 +111,7 @@ export const useContactsTableConfig = createTableConfigHook<'contacts'>(
         size: 160,
         enableSorting: false,
         cell: ({ row }) => (
-          <Text as="span" variant="body">
+          <Text as="span" variant="body" truncate className="block">
             {row.original.phone || ''}
           </Text>
         ),


### PR DESCRIPTION
## What
In the fixed-layout contacts table, long values (a raw email used as a name, long phone numbers) bled across into the neighbouring column. The **Name / Email / Phone** cell renderers now clip overflow with an ellipsis inside the column width (`Text` `truncate` prop + `block`).

## Scope
- `app/features/contacts/hooks/use-contacts-table-config.tsx` + its test. CSS-class only; no data/behavior change.

## Note
- Touches the same file that in-flight `feat/2618-switch` (merge Customers & Vendors → Contacts, #2618) rewrites — **merge-order/rebase care** needed if both land.

## Test
- `use-contacts-table-config.test.tsx` asserts the three cells carry `truncate`+`block`; green (client project). typecheck · oxlint · oxfmt clean.