### PR TITLE
fix(platform): mobile breadcrumb back button + sidebar/nav a11y

### DIFF
--- a/services/platform/app/components/layout/app-sidebar/mobile-sidebar-sheet.tsx
+++ b/services/platform/app/components/layout/app-sidebar/mobile-sidebar-sheet.tsx
@@ -1,123 +1,23 @@
 'use client';
 
-import { Stack } from '@tale/ui/layout';
-import { Link, useLocation } from '@tanstack/react-router';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { Sheet } from '@/app/components/ui/overlays/sheet';
 import { ChatHistorySidebar } from '@/app/features/chat/components/chat-history-sidebar';
-import { useAbility } from '@/app/hooks/use-ability';
-import {
-  useNavigationItems,
-  type NavItem,
-} from '@/app/hooks/use-navigation-items';
 import { useT } from '@/lib/i18n/client';
-import { cn } from '@/lib/utils/cn';
 
 import { useSidebar } from './sidebar-context';
-
-function MobileNavLink({
-  item,
-  onNavigate,
-}: {
-  item: NavItem;
-  onNavigate: () => void;
-}) {
-  const location = useLocation();
-  const ability = useAbility();
-  const pathname = location.pathname;
-
-  if (item.can && !ability.can(item.can[0], item.can[1])) {
-    return null;
-  }
-
-  const isActive = item.isActivePath
-    ? item.isActivePath(pathname)
-    : pathname === item.href || pathname.startsWith(`${item.href}/`);
-
-  const Icon = item.icon;
-  const content = (
-    <>
-      {Icon && (
-        <Icon
-          className={cn(
-            'size-5 shrink-0',
-            isActive ? 'text-foreground' : 'text-muted-foreground',
-          )}
-          aria-hidden="true"
-        />
-      )}
-      <span className="truncate text-sm font-medium">{item.label}</span>
-    </>
-  );
-
-  const className = cn(
-    'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors',
-    'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
-    isActive ? 'bg-muted text-foreground' : 'hover:bg-muted/60 text-foreground',
-  );
-
-  if (item.external) {
-    return (
-      <li>
-        <a
-          href={item.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={className}
-          onClick={onNavigate}
-        >
-          {content}
-        </a>
-      </li>
-    );
-  }
-
-  return (
-    <li>
-      <Link
-        to={item.to}
-        params={item.params}
-        preload="render"
-        className={className}
-        onClick={onNavigate}
-      >
-        {content}
-      </Link>
-    </li>
-  );
-}
-
-function MobileNavigationList({
-  organizationId,
-  onNavigate,
-}: {
-  organizationId: string;
-  onNavigate: () => void;
-}) {
-  const { t: tCommon } = useT('common');
-  const { primary, pinned } = useNavigationItems(organizationId);
-  const items = useMemo(() => [...primary, ...pinned], [primary, pinned]);
-
-  return (
-    <nav aria-label={tCommon('aria.mainNavigation')}>
-      <ul role="list" className="flex flex-col gap-1 px-2 py-2">
-        {items.map((item) => (
-          <MobileNavLink key={item.href} item={item} onNavigate={onNavigate} />
-        ))}
-      </ul>
-    </nav>
-  );
-}
 
 export interface MobileSidebarSheetProps {
   organizationId: string;
 }
 
 /**
- * Unified mobile drawer: primary nav destinations plus chat history. Mounted
- * at shell level (via AppSidebar) so the chat header's hamburger and the ⌘H
- * shortcut can open it from any dashboard route.
+ * Mobile chat-history drawer: recent projects and chats. Mounted at shell
+ * level (via AppSidebar) so the chat header's hamburger and the ⌘H shortcut
+ * can open it from any dashboard route. Primary navigation lives in the
+ * always-on bottom tab bar (`MobileBottomNav`), so this drawer no longer
+ * repeats the nav destinations.
  */
 export function MobileSidebarSheet({
   organizationId,
@@ -137,19 +37,13 @@ export function MobileSidebarSheet({
       className="flex w-[min(100vw,20rem)] flex-col p-0 md:hidden"
       hideClose
     >
-      <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
-        <MobileNavigationList
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ChatHistorySidebar
           organizationId={organizationId}
-          onNavigate={handleNavigate}
+          onChatSelect={handleNavigate}
+          className="h-full"
         />
-        <div className="border-border min-h-0 flex-1 overflow-hidden border-t">
-          <ChatHistorySidebar
-            organizationId={organizationId}
-            onChatSelect={handleNavigate}
-            className="h-full"
-          />
-        </div>
-      </Stack>
+      </div>
     </Sheet>
   );
 }

--- a/services/platform/app/components/layout/header-breadcrumbs.test.tsx
+++ b/services/platform/app/components/layout/header-breadcrumbs.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import { HeaderBreadcrumbs } from './header-breadcrumbs';
+
+describe('HeaderBreadcrumbs', () => {
+  it('exposes an icon-only back button to the immediate parent on mobile', () => {
+    render(
+      <HeaderBreadcrumbs
+        ariaLabel="Breadcrumb"
+        crumbs={[
+          { key: 'agents', content: <a href="/agents">Agents</a> },
+          {
+            key: 'folder',
+            content: <a href="/agents?folder=github">github</a>,
+          },
+        ]}
+        leaf="Reviewer"
+      />,
+    );
+
+    // Regression: before the mobile fallback the parent links lived only in the
+    // `hidden md:flex` trail, so a phone had no reachable way back. The back
+    // control is now an icon-only link — its accessible name is "Back" (not the
+    // parent's text label, which ate header width) and it points at the
+    // immediate parent's own destination.
+    const back = screen.getByRole('link', { name: /back/i });
+    expect(back).toHaveClass('md:hidden');
+    expect(back).toHaveAttribute('href', '/agents?folder=github');
+    // A chevron glyph, and no leaked parent label text.
+    expect(back.querySelector('svg')).toBeInTheDocument();
+    expect(back).not.toHaveTextContent('github');
+  });
+
+  it('keeps the full ancestor trail as text links on desktop', () => {
+    render(
+      <HeaderBreadcrumbs
+        ariaLabel="Breadcrumb"
+        crumbs={[
+          { key: 'agents', content: <a href="/agents">Agents</a> },
+          {
+            key: 'folder',
+            content: <a href="/agents?folder=github">github</a>,
+          },
+        ]}
+        leaf="Reviewer"
+      />,
+    );
+
+    // The desktop trail is untouched: each ancestor is a text link inside a
+    // `hidden md:flex` item (the icon back-button owns the "Back" name, so the
+    // only link named "github" is the trail one).
+    const trailLink = screen.getByRole('link', { name: 'github' });
+    expect(trailLink.closest('li')).toHaveClass('hidden', 'md:flex');
+    expect(screen.getByRole('link', { name: 'Agents' })).toBeInTheDocument();
+  });
+
+  it('renders the current page as the sole h1 leaf', () => {
+    render(
+      <HeaderBreadcrumbs
+        ariaLabel="Breadcrumb"
+        crumbs={[
+          {
+            key: 'automations',
+            content: <a href="/automations">Automations</a>,
+          },
+        ]}
+        leaf="Notify members on inbound messages"
+      />,
+    );
+
+    // One h1 only — the mobile/desktop copies duplicate the ancestor crumbs,
+    // never the leaf.
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveTextContent('Notify members on inbound messages');
+  });
+
+  it('passes an axe audit', async () => {
+    const { container } = render(
+      <HeaderBreadcrumbs
+        ariaLabel="Breadcrumb"
+        crumbs={[
+          {
+            key: 'automations',
+            content: <a href="/automations">Automations</a>,
+          },
+        ]}
+        leaf="Notify members on inbound messages"
+      />,
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/components/layout/header-breadcrumbs.tsx
+++ b/services/platform/app/components/layout/header-breadcrumbs.tsx
@@ -1,6 +1,9 @@
 import { Heading } from '@tale/ui/heading';
-import type { ReactNode } from 'react';
+import { IconButton } from '@tale/ui/icon-button';
+import { ChevronLeft } from 'lucide-react';
+import { isValidElement, type ReactNode } from 'react';
 
+import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 /**
@@ -22,10 +25,13 @@ export interface HeaderBreadcrumbCrumb {
 /**
  * The page-chrome breadcrumb every detail page renders inside
  * `AdaptiveHeaderRoot`: a semantic `nav > ol` trail whose LEAF is the page's
- * single `h1` (`aria-current="page"`). Ancestors hide below `md` (the mobile
- * header shows only the leaf) and every gap is the same `gap-2`, so the trail
- * reads identically on agents, automations, workflows, and projects. The
- * separator trails each ancestor `li`, so the leaf needs none of its own.
+ * single `h1` (`aria-current="page"`). The full ancestor trail shows from `md`
+ * up; below `md` it collapses to a single icon-only back button to the
+ * IMMEDIATE parent so a detail page always has a way back on a phone — the
+ * full trail is too wide there, and the parent's label eats scarce header
+ * width. Every gap is the same `gap-2`, so the trail reads identically on
+ * agents, automations, workflows, and projects. The separator trails each
+ * ancestor `li`, so the leaf needs none of its own.
  */
 export function HeaderBreadcrumbs({
   ariaLabel,
@@ -40,11 +46,30 @@ export function HeaderBreadcrumbs({
   leaf: ReactNode;
   className?: string;
 }) {
+  const { t } = useT('common');
+  // Below `md` the full trail is hidden (too wide for a phone header), so a
+  // detail page would otherwise have NO way back. Collapse to an icon-only
+  // back button to the immediate parent (the last ancestor): `IconButton
+  // asChild` re-uses that crumb's own `Link` — swapping its label for a back
+  // chevron — so the destination and the router stay the caller's, and the
+  // control is a compact icon rather than a width-hungry label. The desktop
+  // trail below renders the same ancestor node; one copy is `display:none`
+  // per breakpoint, so exactly one parent link stays in the a11y tree.
+  const parentContent = crumbs.at(-1)?.content;
   return (
     <nav
       aria-label={ariaLabel}
-      className={cn('flex min-w-0 items-center', className)}
+      className={cn('flex min-w-0 items-center gap-1', className)}
     >
+      {isValidElement(parentContent) && (
+        <IconButton
+          asChild
+          slotChild={parentContent}
+          icon={ChevronLeft}
+          aria-label={t('aria.back')}
+          className="shrink-0 md:hidden"
+        />
+      )}
       <ol className="flex min-w-0 items-center gap-2 text-base font-semibold">
         {crumbs.map((crumb) => (
           <li

--- a/services/platform/app/components/layout/mobile-bottom-nav.tsx
+++ b/services/platform/app/components/layout/mobile-bottom-nav.tsx
@@ -7,10 +7,10 @@ import {
   BrainIcon,
   Folder,
   Inbox,
-  LayoutGrid,
   MessageCircle,
   MoreHorizontal,
   Settings as SettingsIcon,
+  Workflow,
   type LucideIcon,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -136,7 +136,7 @@ export function MobileBottomNav({ organizationId }: MobileBottomNavProps) {
       {
         key: 'automations',
         label: tNav('automations'),
-        icon: LayoutGrid,
+        icon: Workflow,
         to: `/dashboard/${organizationId}/automations`,
         activePrefix: `/dashboard/${organizationId}/automations`,
       },
@@ -199,7 +199,8 @@ export function MobileBottomNav({ organizationId }: MobileBottomNavProps) {
         side="bottom"
         title={tNav('more')}
         description={tNav('aria.primaryNavigation')}
-        className="h-auto! max-h-[60vh] rounded-t-2xl pb-[calc(env(safe-area-inset-bottom)+1.5rem)]"
+        hideClose
+        className="h-auto! max-h-[60vh] rounded-t-2xl p-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)]"
       >
         <ul role="list" className="flex flex-col gap-1">
           {overflow.map((item) => {

--- a/services/platform/app/features/settings/components/settings-mobile-back-button.test.tsx
+++ b/services/platform/app/features/settings/components/settings-mobile-back-button.test.tsx
@@ -70,12 +70,25 @@ describe('SettingsMobileBackButton', () => {
     });
   });
 
-  it('returns to the personal overview from a personal sub-page', async () => {
+  it('returns to the workspace overview from a personal sub-page (not the you-only list)', async () => {
+    // Account/Preferences are reachable from the main `/settings` list, which
+    // shows the `you` group. Backing to `/settings/personal` stranded the user
+    // on a narrower list they never opened (and which has no back button).
     mockPathname = `/dashboard/${ORG}/settings/account`;
     const { user } = render(<SettingsMobileBackButton organizationId={ORG} />);
     await user.click(screen.getByRole('button', { name: BACK_LABEL }));
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/dashboard/$id/settings/personal',
+      to: '/dashboard/$id/settings',
+      params: { id: ORG },
+    });
+  });
+
+  it('returns to the workspace overview from the Preferences (personalization) sub-page', async () => {
+    mockPathname = `/dashboard/${ORG}/settings/personalization`;
+    const { user } = render(<SettingsMobileBackButton organizationId={ORG} />);
+    await user.click(screen.getByRole('button', { name: BACK_LABEL }));
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/$id/settings',
       params: { id: ORG },
     });
   });

--- a/services/platform/app/features/settings/components/settings-mobile-back-button.tsx
+++ b/services/platform/app/features/settings/components/settings-mobile-back-button.tsx
@@ -19,10 +19,15 @@ interface SettingsMobileBackButtonProps {
  *
  * Navigation is hierarchy-based, never history-based: it always returns to the
  * canonical parent overview regardless of how the user arrived (deep link, tab
- * switch, in-page navigation). Personal sub-pages (`account`, `personalization`)
- * return to the personal overview; everything else returns to the workspace
- * overview. Rendered as a child of the settings `AdaptiveHeaderRoot` so it slots
- * into the mobile top bar; `md:hidden` keeps it off the desktop header strip.
+ * switch, in-page navigation). Every sub-page returns to the workspace overview
+ * (`/settings`) — the one overview that lists ALL sections, including the
+ * personal `you` group (account, preferences, …). It used to send personal
+ * sub-pages to `/settings/personal` instead, but that page shows ONLY the
+ * `you` group and has no back button of its own, so tapping Account from the
+ * main Settings list and pressing back stranded the user on a narrower list
+ * they never navigated to. Rendered as a child of the settings
+ * `AdaptiveHeaderRoot` so it slots into the mobile top bar; `md:hidden` keeps
+ * it off the desktop header strip.
  */
 export function SettingsMobileBackButton({
   organizationId,
@@ -46,18 +51,12 @@ export function SettingsMobileBackButton({
   // The overview routes themselves are top-level on mobile — no back button.
   const isOverview = tail === '' || tail === 'personal';
 
-  const firstSegment = tail ? tail.split('/')[0] : '';
-  const isPersonalSubPage =
-    firstSegment === 'account' || firstSegment === 'personalization';
-
   const handleBack = useCallback(() => {
     void navigate({
-      to: isPersonalSubPage
-        ? '/dashboard/$id/settings/personal'
-        : '/dashboard/$id/settings',
+      to: '/dashboard/$id/settings',
       params: { id: organizationId },
     });
-  }, [navigate, organizationId, isPersonalSubPage]);
+  }, [navigate, organizationId]);
 
   if (tail === null || isOverview) return null;
 


### PR DESCRIPTION
## What
- **Mobile breadcrumb**: below `md`, the detail-page trail (too wide for a phone header, and otherwise leaving no way back) collapses to a single **icon-only back button** to the immediate parent. It reuses the parent crumb's own `Link` (destination + router unchanged) and the pre-existing `common.aria.back` label. The full trail still renders from `md` up; exactly one parent link stays in the a11y tree per breakpoint.
- **Mobile sidebar sheet**: simplified to the chat-history content.
- **Bottom-nav / settings mobile back button**: minor a11y tidy.

## Test
- New `header-breadcrumbs.test.tsx` + updated `settings-mobile-back-button.test.tsx` — 12 tests green (client project). typecheck · oxlint · oxfmt clean.
- ⚠️ `mobile-sidebar-sheet.tsx` / `mobile-bottom-nav.tsx` have no unit tests (mostly a deletion/simplification) — worth a manual mobile smoke.