### PR TITLE
feat(platform): sibling breadcrumb switchers for automations & projects

### DIFF
--- a/services/platform/app/features/automations/components/automation-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/automations/components/automation-breadcrumb-switcher.test.tsx
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import type { AutomationSummary } from '../hooks/use-automations';
+import type { AutomationInstallState } from '../hooks/use-install-state';
+import { AutomationBreadcrumbSwitcher } from './automation-breadcrumb-switcher';
+
+const mockNavigate = vi.fn();
+const mockLocation = {
+  search: { tab: 'configuration' } as Record<string, unknown>,
+};
+const mockAbility = { can: vi.fn(() => true) };
+
+let automationsFixture: AutomationSummary[] = [];
+let installBySlugFixture = new Map<string, AutomationInstallState>();
+
+vi.mock('../hooks/use-automations', () => ({
+  useAutomations: () => ({
+    automations: automationsFixture,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../hooks/use-install-state', () => ({
+  useAutomationInstallStates: () => ({
+    bySlug: installBySlugFixture,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/app/hooks/use-ability', () => ({
+  useAbility: () => mockAbility,
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
+}));
+
+function summary(
+  partial: Pick<AutomationSummary, 'slug' | 'name'> &
+    Partial<AutomationSummary>,
+): AutomationSummary {
+  return {
+    description: '',
+    scope: 'org',
+    kind: 'automation',
+    workflows: [],
+    agents: [],
+    skills: [],
+    functions: [],
+    requiredIntegrations: [],
+    views: [],
+    ...partial,
+  };
+}
+
+function installed(slug: string): AutomationInstallState {
+  return {
+    automationSlug: slug,
+    status: 'active',
+    installedAt: 1,
+    blockedIntegrations: [],
+  };
+}
+
+describe('AutomationBreadcrumbSwitcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAbility.can.mockReturnValue(true);
+    mockLocation.search = { tab: 'configuration' };
+    automationsFixture = [
+      summary({
+        slug: 'vat-return-desk',
+        name: 'VAT return desk',
+        workflows: ['vat'],
+      }),
+      summary({
+        slug: 'gmail/sync-emails',
+        name: 'Gmail sync',
+        workflows: ['sync'],
+      }),
+      summary({
+        slug: 'inbox-only',
+        name: 'Inbox only',
+        workflows: [],
+      }),
+      summary({
+        slug: 'not-installed-yet',
+        name: 'Not installed yet',
+      }),
+      summary({
+        slug: 'email/inbox',
+        name: 'Email inbox',
+        kind: 'bundle',
+        members: ['gmail/sync-emails'],
+      }),
+    ];
+    installBySlugFixture = new Map([
+      ['vat-return-desk', installed('vat-return-desk')],
+      ['gmail/sync-emails', installed('gmail/sync-emails')],
+      ['inbox-only', installed('inbox-only')],
+    ]);
+  });
+
+  it('lists only installed automations (no catalog-only or bundles)', async () => {
+    const { user } = render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch automation, current: vat return desk/i,
+      }),
+    );
+
+    expect(
+      screen.getByRole('menuitem', { name: 'VAT return desk' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Gmail sync' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Not installed yet' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Email inbox' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps a portable ?tab= when switching', async () => {
+    const { user } = render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch automation, current: vat return desk/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Gmail sync' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/org-1/automations/gmail__sync-emails',
+      search: { tab: 'configuration' },
+    });
+  });
+
+  it('drops ?tab=editor when the target has no workflow tabs', async () => {
+    mockLocation.search = { tab: 'editor' };
+    const { user } = render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch automation, current: vat return desk/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Inbox only' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/org-1/automations/inbox-only',
+      search: {},
+    });
+  });
+
+  it('keeps project-scoped navigation when projectId is set', async () => {
+    const { user } = render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+        projectId="proj-1"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch automation, current: vat return desk/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Gmail sync' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/org-1/projects/proj-1/automations/gmail__sync-emails',
+      search: { tab: 'configuration' },
+    });
+  });
+
+  it('does not navigate when the current automation is chosen again', async () => {
+    const { user } = render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch automation, current: vat return desk/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'VAT return desk' }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('renders a plain name when nothing is installed', () => {
+    automationsFixture = [];
+    installBySlugFixture = new Map();
+    render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /switch automation/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('VAT return desk')).toBeInTheDocument();
+  });
+
+  it('passes an axe audit with the menu open', async () => {
+    const { user, container } = render(
+      <AutomationBreadcrumbSwitcher
+        organizationId="org-1"
+        automationSlug="vat-return-desk"
+        displayName="VAT return desk"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch automation, current: vat return desk/i,
+      }),
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/automations/components/automation-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/automations/components/automation-breadcrumb-switcher.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
+import { useLocale } from '@tale/ui/i18n/locale-provider';
+import { useLocation, useNavigate } from '@tanstack/react-router';
+import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { useAbility } from '@/app/hooks/use-ability';
+import { useT } from '@/lib/i18n/client';
+import { resolveAutomationLocale } from '@/lib/shared/utils/resolve-automation-locale';
+import { cn } from '@/lib/utils/cn';
+
+import { useAutomations } from '../hooks/use-automations';
+import { useAutomationInstallStates } from '../hooks/use-install-state';
+import {
+  automationInstalledTabValues,
+  automationSwitchLocation,
+} from '../lib/automation-switch-path';
+
+/**
+ * Breadcrumb leaf for an automation detail page: the current name opens a
+ * dropdown of INSTALLED sibling automations (same membership as the hub's
+ * Installed tab — install row present, no bundles). Portable `?tab=` values
+ * (Configuration, Integrations, shared workflow tabs when both sides have
+ * them) are kept; a tab the target does not expose is dropped so the page
+ * lands on its own default instead of a missing Editor/Triggers surface.
+ */
+export function AutomationBreadcrumbSwitcher({
+  organizationId,
+  automationSlug,
+  displayName,
+  projectId,
+}: {
+  organizationId: string;
+  automationSlug: string;
+  displayName: string;
+  /** When set, switches stay on the project-scoped automation route. */
+  projectId?: string;
+}) {
+  const { t } = useT('automations');
+  const { locale } = useLocale();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const ability = useAbility();
+  const isDeveloper = ability.can('read', 'developerSettings');
+  const { automations } = useAutomations(organizationId);
+  const { bySlug: installBySlug } = useAutomationInstallStates(organizationId);
+
+  const siblings = useMemo(
+    () =>
+      automations
+        .filter(
+          (automation) =>
+            automation.kind !== 'bundle' &&
+            installBySlug.get(automation.slug) != null,
+        )
+        .map((automation) => ({
+          slug: automation.slug,
+          name: resolveAutomationLocale(automation, locale).name,
+          automation,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name, locale)),
+    [automations, installBySlug, locale],
+  );
+
+  const items = useMemo<DropdownMenuGroup[]>(
+    () => [
+      siblings.map((sibling) => ({
+        type: 'item' as const,
+        label: sibling.name,
+        selected: sibling.slug === automationSlug,
+        onClick: () => {
+          if (sibling.slug === automationSlug) return;
+          const next = automationSwitchLocation({
+            organizationId,
+            toSlug: sibling.slug,
+            projectId,
+            search: location.search as Record<string, unknown>,
+            targetTabValues: automationInstalledTabValues(
+              sibling.automation,
+              isDeveloper,
+            ),
+          });
+          void navigate({ to: next.pathname, search: next.search });
+        },
+      })),
+    ],
+    [
+      siblings,
+      automationSlug,
+      organizationId,
+      projectId,
+      navigate,
+      location.search,
+      isDeveloper,
+    ],
+  );
+
+  if (siblings.length === 0) {
+    return <>{displayName}</>;
+  }
+
+  return (
+    <DropdownMenu
+      align="start"
+      items={items}
+      trigger={
+        <button
+          type="button"
+          aria-label={t('switcher.ariaLabel', { name: displayName })}
+          className={cn(
+            'inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm',
+            'hover:text-muted-foreground transition-colors',
+            'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+          )}
+        >
+          <span className="min-w-0 truncate">{displayName}</span>
+          <ChevronDown
+            className="text-muted-foreground size-4 shrink-0"
+            aria-hidden="true"
+          />
+        </button>
+      }
+    />
+  );
+}

--- a/services/platform/app/features/automations/components/automation-detail-shell.tsx
+++ b/services/platform/app/features/automations/components/automation-detail-shell.tsx
@@ -28,8 +28,12 @@ import {
 } from '@/app/components/ui/navigation/tab-navigation';
 import { useT } from '@/lib/i18n/client';
 
+import { AutomationBreadcrumbSwitcher } from './automation-breadcrumb-switcher';
+
 export function AutomationDetailShell({
   organizationId,
+  automationSlug,
+  projectId,
   displayName,
   isLoading = false,
   tabs,
@@ -37,6 +41,10 @@ export function AutomationDetailShell({
   children,
 }: {
   organizationId: string;
+  /** Current automation slug — enables the sibling switcher on the leaf. */
+  automationSlug?: string;
+  /** When set, the switcher keeps navigation on the project-scoped route. */
+  projectId?: string;
   /** Localized automation name for the breadcrumb leaf; absent while loading. */
   displayName?: string;
   isLoading?: boolean;
@@ -82,7 +90,16 @@ export function AutomationDetailShell({
                   label={t('title')}
                   className="contents"
                 >
-                  {displayName ?? (
+                  {displayName && automationSlug ? (
+                    <AutomationBreadcrumbSwitcher
+                      organizationId={organizationId}
+                      automationSlug={automationSlug}
+                      displayName={displayName}
+                      projectId={projectId}
+                    />
+                  ) : displayName ? (
+                    displayName
+                  ) : (
                     <SkeletonBox>
                       <span className="inline-block h-4 w-32 align-middle" />
                     </SkeletonBox>

--- a/services/platform/app/features/automations/components/automation-page.tsx
+++ b/services/platform/app/features/automations/components/automation-page.tsx
@@ -657,6 +657,8 @@ function InstalledAutomationBody({
         <ActiveEditorProvider>
           <AutomationDetailShell
             organizationId={organizationId}
+            automationSlug={automationSlug}
+            projectId={projectId}
             displayName={display.name}
             tabs={navItems}
             tabsChildren={
@@ -1032,6 +1034,8 @@ export function AutomationPage({
     return (
       <AutomationDetailShell
         organizationId={organizationId}
+        automationSlug={automationSlug}
+        projectId={projectId}
         displayName={automationSlug}
       >
         <ContentArea>
@@ -1053,6 +1057,8 @@ export function AutomationPage({
   const shell = (children: React.ReactNode) => (
     <AutomationDetailShell
       organizationId={organizationId}
+      automationSlug={automationSlug}
+      projectId={projectId}
       displayName={displayName}
     >
       <ContentArea gap={6}>{children}</ContentArea>

--- a/services/platform/app/features/automations/lib/automation-switch-path.test.ts
+++ b/services/platform/app/features/automations/lib/automation-switch-path.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  automationInstalledTabValues,
+  automationSwitchLocation,
+} from './automation-switch-path';
+
+describe('automationInstalledTabValues', () => {
+  it('always includes integrations and configuration', () => {
+    const tabs = automationInstalledTabValues(
+      { scope: 'org', workflows: [], views: [] },
+      true,
+    );
+    expect(tabs.has('integrations')).toBe(true);
+    expect(tabs.has('configuration')).toBe(true);
+    expect(tabs.has('editor')).toBe(false);
+  });
+
+  it('adds workflow tabs for a developer when a workflow exists', () => {
+    const tabs = automationInstalledTabValues(
+      { scope: 'org', workflows: ['notify'], views: [] },
+      true,
+    );
+    expect(tabs.has('editor')).toBe(true);
+    expect(tabs.has('executions')).toBe(true);
+    expect(tabs.has('triggers')).toBe(true);
+    expect(tabs.has('environment')).toBe(true);
+  });
+
+  it('omits workflow tabs when the caller is not a developer', () => {
+    const tabs = automationInstalledTabValues(
+      { scope: 'org', workflows: ['notify'], views: [] },
+      false,
+    );
+    expect(tabs.has('editor')).toBe(false);
+    expect(tabs.has('triggers')).toBe(false);
+  });
+
+  it('includes org-scoped view ids and skips them on project scope', () => {
+    const views = [{ id: 'inbox', data: {} }] as never;
+    expect(
+      automationInstalledTabValues(
+        { scope: 'org', workflows: [], views },
+        false,
+      ).has('inbox'),
+    ).toBe(true);
+    expect(
+      automationInstalledTabValues(
+        { scope: 'project', workflows: [], views },
+        false,
+      ).has('inbox'),
+    ).toBe(false);
+  });
+});
+
+describe('automationSwitchLocation', () => {
+  const org = 'org-1';
+  const withWorkflowTabs = new Set([
+    'editor',
+    'executions',
+    'triggers',
+    'environment',
+    'integrations',
+    'configuration',
+  ]);
+  const withoutWorkflowTabs = new Set(['integrations', 'configuration']);
+
+  it('keeps ?tab= when the target exposes it', () => {
+    expect(
+      automationSwitchLocation({
+        organizationId: org,
+        toSlug: 'gmail/sync-emails',
+        search: { tab: 'configuration' },
+        targetTabValues: withoutWorkflowTabs,
+      }),
+    ).toEqual({
+      pathname: `/dashboard/${org}/automations/gmail__sync-emails`,
+      search: { tab: 'configuration' },
+    });
+  });
+
+  it('drops ?tab=editor when the target has no editor', () => {
+    expect(
+      automationSwitchLocation({
+        organizationId: org,
+        toSlug: 'inbox-only',
+        search: { tab: 'editor' },
+        targetTabValues: withoutWorkflowTabs,
+      }),
+    ).toEqual({
+      pathname: `/dashboard/${org}/automations/inbox-only`,
+      search: {},
+    });
+  });
+
+  it('keeps editor when the target has workflow tabs', () => {
+    expect(
+      automationSwitchLocation({
+        organizationId: org,
+        toSlug: 'other',
+        search: { tab: 'editor' },
+        targetTabValues: withWorkflowTabs,
+      }).search,
+    ).toEqual({ tab: 'editor' });
+  });
+
+  it('builds the project-scoped root path', () => {
+    expect(
+      automationSwitchLocation({
+        organizationId: org,
+        toSlug: 'other',
+        projectId: 'proj-1',
+        search: {},
+        targetTabValues: withWorkflowTabs,
+      }).pathname,
+    ).toBe(`/dashboard/${org}/projects/proj-1/automations/other`);
+  });
+});

--- a/services/platform/app/features/automations/lib/automation-switch-path.ts
+++ b/services/platform/app/features/automations/lib/automation-switch-path.ts
@@ -1,0 +1,84 @@
+import { automationSlugToParam } from '@/lib/shared/schemas/automations';
+
+import { viewRouteId } from '../components/automation-view-body';
+import type { AutomationSummary } from '../hooks/use-automations';
+import { isAutomationViewErrorStub } from '../hooks/use-automations';
+
+/** Reserved automation-page tab values — must stay in sync with `automation-page.tsx`. */
+const RESERVED_TAB_VALUES = [
+  'editor',
+  'executions',
+  'configuration',
+  'triggers',
+  'integrations',
+  'environment',
+] as const;
+
+/**
+ * Tab values the installed automation page would render for this automation —
+ * the same gating as `InstalledAutomationBody` (developer + workflow →
+ * Editor/Executions/Triggers/Environment; Integrations + Configuration always;
+ * org-scoped bundled views as extra tabs). Used by the breadcrumb switcher so
+ * a carried `?tab=` is kept only when the target actually exposes it.
+ */
+export function automationInstalledTabValues(
+  automation: Pick<AutomationSummary, 'scope' | 'workflows' | 'views'>,
+  isDeveloper: boolean,
+): Set<string> {
+  const workflowSlug = automation.workflows[0];
+  const showDevTabs = isDeveloper && workflowSlug !== undefined;
+  const used = new Set<string>(RESERVED_TAB_VALUES);
+  const tabs = new Set<string>(['integrations', 'configuration']);
+  if (showDevTabs) {
+    tabs.add('editor');
+    tabs.add('executions');
+    tabs.add('triggers');
+    tabs.add('environment');
+  }
+  if (automation.scope !== 'project') {
+    automation.views.forEach((view, index) => {
+      const raw = isAutomationViewErrorStub(view)
+        ? view.id
+        : viewRouteId(view, index);
+      let value = raw;
+      while (used.has(value)) value = `view-${value}`;
+      used.add(value);
+      tabs.add(value);
+    });
+  }
+  return tabs;
+}
+
+/**
+ * Path + search for an automation breadcrumb switch.
+ *
+ * Always the target automation's detail root (never `/runs/…` — run ids are
+ * not portable). `?tab=` is kept only when {@link targetTabValues} includes
+ * it; otherwise the search is cleared so the page picks its own default —
+ * avoiding a missing Editor/Triggers/… surface on automations without a
+ * workflow (or when the operator isn't a developer).
+ */
+export function automationSwitchLocation({
+  organizationId,
+  toSlug,
+  projectId,
+  search,
+  targetTabValues,
+}: {
+  organizationId: string;
+  toSlug: string;
+  projectId?: string;
+  search: Record<string, unknown>;
+  targetTabValues: ReadonlySet<string>;
+}): { pathname: string; search: Record<string, unknown> } {
+  const toParam = automationSlugToParam(toSlug);
+  const pathname =
+    projectId !== undefined
+      ? `/dashboard/${organizationId}/projects/${projectId}/automations/${toParam}`
+      : `/dashboard/${organizationId}/automations/${toParam}`;
+  const tab = search.tab;
+  return {
+    pathname,
+    search: typeof tab === 'string' && targetTabValues.has(tab) ? { tab } : {},
+  };
+}

--- a/services/platform/app/features/projects/components/project-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/projects/components/project-breadcrumb-switcher.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import { ProjectBreadcrumbSwitcher } from './project-breadcrumb-switcher';
+
+const mockNavigate = vi.fn();
+const mockLocation = {
+  pathname: '/dashboard/org-1/projects/proj-getting-started/files',
+  search: {} as Record<string, unknown>,
+};
+
+type ProjectRow = {
+  _id: Id<'projects'>;
+  name: string;
+};
+
+let projectsFixture: ProjectRow[] = [];
+
+vi.mock('../hooks/queries', () => ({
+  useProjects: () => ({ projects: projectsFixture, isLoading: false }),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
+}));
+
+const CURRENT_ID = 'proj-getting-started' as Id<'projects'>;
+const OTHER_ID = 'proj-acme' as Id<'projects'>;
+
+describe('ProjectBreadcrumbSwitcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation.pathname =
+      '/dashboard/org-1/projects/proj-getting-started/files';
+    mockLocation.search = {};
+    projectsFixture = [
+      { _id: CURRENT_ID, name: 'Getting started' },
+      { _id: OTHER_ID, name: 'Acme AG' },
+    ];
+  });
+
+  it('opens a menu of sibling projects from the current name', async () => {
+    const { user } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: getting started/i,
+      }),
+    );
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Getting started' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Acme AG' }),
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to the selected project while keeping the current sub-page', async () => {
+    const { user } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: getting started/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Acme AG' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/org-1/projects/proj-acme/files',
+      search: {},
+    });
+  });
+
+  it('does not navigate when the current project is chosen again', async () => {
+    const { user } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: getting started/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Getting started' }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('renders a plain name when the project list is empty', () => {
+    projectsFixture = [];
+    render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /switch project/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Getting started')).toBeInTheDocument();
+  });
+
+  it('passes an axe audit with the menu open', async () => {
+    const { user, container } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: getting started/i,
+      }),
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/projects/components/project-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/projects/components/project-breadcrumb-switcher.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
+import { useLocation, useNavigate } from '@tanstack/react-router';
+import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import { useProjects } from '../hooks/queries';
+import { projectSwitchPathname } from '../lib/project-switch-path';
+
+/**
+ * Breadcrumb leaf for a project detail page: the current project name opens a
+ * dropdown of sibling projects so the operator can jump between them without
+ * returning to the Projects list. Portable tabs (files, tasks, …) stay put;
+ * bound-view / nested-automation paths reset to the overview.
+ */
+export function ProjectBreadcrumbSwitcher({
+  organizationId,
+  projectId,
+  projectName,
+}: {
+  organizationId: string;
+  projectId: Id<'projects'>;
+  projectName: string;
+}) {
+  const { t } = useT('projects');
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { projects } = useProjects(organizationId);
+
+  const items = useMemo<DropdownMenuGroup[]>(
+    () => [
+      projects.map((project) => ({
+        type: 'item' as const,
+        label: project.name,
+        selected: project._id === projectId,
+        onClick: () => {
+          if (project._id === projectId) return;
+          const to = projectSwitchPathname(
+            location.pathname,
+            organizationId,
+            projectId,
+            project._id,
+          );
+          void navigate({ to, search: location.search });
+        },
+      })),
+    ],
+    [
+      projects,
+      projectId,
+      organizationId,
+      navigate,
+      location.pathname,
+      location.search,
+    ],
+  );
+
+  // Nothing to switch to yet (list still empty / loading) — keep the plain
+  // name so the h1 leaf stays readable without a dead chevron.
+  if (projects.length === 0) {
+    return <>{projectName}</>;
+  }
+
+  return (
+    <DropdownMenu
+      align="start"
+      items={items}
+      trigger={
+        <button
+          type="button"
+          aria-label={t('switcher.ariaLabel', { name: projectName })}
+          className={cn(
+            'inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm',
+            'hover:text-muted-foreground transition-colors',
+            'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+          )}
+        >
+          <span className="min-w-0 truncate">{projectName}</span>
+          <ChevronDown
+            className="text-muted-foreground size-4 shrink-0"
+            aria-hidden="true"
+          />
+        </button>
+      }
+    />
+  );
+}

--- a/services/platform/app/features/projects/lib/project-switch-path.test.ts
+++ b/services/platform/app/features/projects/lib/project-switch-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectSwitchPathname } from './project-switch-path';
+
+describe('projectSwitchPathname', () => {
+  const org = 'org-1';
+  const from = 'proj-a';
+  const to = 'proj-b';
+
+  it('preserves portable tabs and task sub-views', () => {
+    expect(
+      projectSwitchPathname(
+        `/dashboard/${org}/projects/${from}/files`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/projects/${to}/files`);
+    expect(
+      projectSwitchPathname(
+        `/dashboard/${org}/projects/${from}/tasks/board`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/projects/${to}/tasks/board`);
+  });
+
+  it('resets bound views and nested automation details to the overview', () => {
+    expect(
+      projectSwitchPathname(
+        `/dashboard/${org}/projects/${from}/views/vat__desk/inbox`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/projects/${to}`);
+    expect(
+      projectSwitchPathname(
+        `/dashboard/${org}/projects/${from}/automations/vat__desk`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/projects/${to}`);
+  });
+
+  it('stays on the overview when already there', () => {
+    expect(
+      projectSwitchPathname(
+        `/dashboard/${org}/projects/${from}`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/projects/${to}`);
+  });
+});

--- a/services/platform/app/features/projects/lib/project-switch-path.ts
+++ b/services/platform/app/features/projects/lib/project-switch-path.ts
@@ -1,0 +1,44 @@
+/**
+ * Where a project breadcrumb switch should land when jumping between projects.
+ *
+ * Core collaboration / management tabs exist on every project and are preserved
+ * (including task sub-views like `/tasks/board`). Bound-view and nested
+ * automation detail paths are project-specific — those reset to the project
+ * overview so the operator never dead-ends on a missing view or automation.
+ */
+
+const PORTABLE_PROJECT_SEGMENTS = new Set([
+  'threads',
+  'discussions',
+  'tasks',
+  'metrics',
+  'instructions',
+  'files',
+  'agents',
+  'secrets',
+  'settings',
+]);
+
+/**
+ * `@param pathname` the current location pathname
+ * `@param organizationId` active org id
+ * `@param fromProjectId` project currently open
+ * `@param toProjectId` project to open
+ */
+export function projectSwitchPathname(
+  pathname: string,
+  organizationId: string,
+  fromProjectId: string,
+  toProjectId: string,
+): string {
+  const prefix = `/dashboard/${organizationId}/projects/${fromProjectId}`;
+  const targetRoot = `/dashboard/${organizationId}/projects/${toProjectId}`;
+  if (pathname !== prefix && !pathname.startsWith(`${prefix}/`)) {
+    return targetRoot;
+  }
+  const rest = pathname.slice(prefix.length);
+  if (rest === '' || rest === '/') return targetRoot;
+  const firstSegment = rest.slice(1).split('/')[0] ?? '';
+  if (!PORTABLE_PROJECT_SEGMENTS.has(firstSegment)) return targetRoot;
+  return `${targetRoot}${rest}`;
+}

--- a/services/platform/app/routes/dashboard/$id/automations/$automationSlug/runs/$executionId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$automationSlug/runs/$executionId.tsx
@@ -36,6 +36,7 @@ function AutomationRunDetail() {
     >
       <AutomationDetailShell
         organizationId={organizationId}
+        automationSlug={automationSlug}
         displayName={automationSlug}
       >
         <ContentArea>

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
@@ -27,6 +27,7 @@ import {
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
 import { useProjectViewTabs } from '@/app/features/automations/hooks/use-project-view-tabs';
+import { ProjectBreadcrumbSwitcher } from '@/app/features/projects/components/project-breadcrumb-switcher';
 import { useProject } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
 import { api } from '@/convex/_generated/api';
@@ -221,7 +222,11 @@ function ProjectDetailLayout() {
                     className="contents"
                   >
                     {project ? (
-                      project.name
+                      <ProjectBreadcrumbSwitcher
+                        organizationId={organizationId}
+                        projectId={asProjectId(projectId)}
+                        projectName={project.name}
+                      />
                     ) : (
                       <SkeletonBox>
                         <span className="inline-block h-4 w-32 align-middle" />

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/automations/$automationSlug/runs/$executionId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/automations/$automationSlug/runs/$executionId.tsx
@@ -45,6 +45,8 @@ function ProjectAutomationRunDetail() {
     >
       <AutomationDetailShell
         organizationId={organizationId}
+        automationSlug={automationSlug}
+        projectId={projectId}
         displayName={automationSlug}
       >
         <ContentArea>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -991,6 +991,9 @@
       "drop": "Dateien hierher ziehen, oder",
       "deleteFile": "{name} löschen",
       "folderDeleted": "Der Ordner dieses Quartals wurde gelöscht. Legen Sie ihn in Wissen neu an oder entfernen Sie diese Abrechnung."
+    },
+    "switcher": {
+      "ariaLabel": "Automatisierung wechseln, aktuell: {name}"
     }
   },
   "changelog": {
@@ -8270,6 +8273,9 @@
       "emptyDescription": "Installiere eine Projekt-Automatisierung im Automatisierungen-Hub und füge dieses Projekt hinzu.",
       "emptyCta": "Automatisierungen öffnen",
       "statusBroken": "Reparatur nötig"
+    },
+    "switcher": {
+      "ariaLabel": "Projekt wechseln, aktuell: {name}"
     }
   },
   "webdav": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -991,6 +991,9 @@
       "drop": "Drop files here, or",
       "deleteFile": "Delete {name}",
       "folderDeleted": "This quarter’s folder was deleted. Recreate it in Knowledge, or remove this return."
+    },
+    "switcher": {
+      "ariaLabel": "Switch automation, current: {name}"
     }
   },
   "changelog": {
@@ -5559,6 +5562,9 @@
       "emptyDescription": "Install a project automation from the Automations hub, then add this project.",
       "emptyCta": "Browse Automations",
       "statusBroken": "Needs repair"
+    },
+    "switcher": {
+      "ariaLabel": "Switch project, current: {name}"
     }
   },
   "pwa": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -991,6 +991,9 @@
       "drop": "Déposez les fichiers ici, ou",
       "deleteFile": "Supprimer {name}",
       "folderDeleted": "Le dossier de ce trimestre a été supprimé. Recréez-le dans Connaissances ou supprimez ce décompte."
+    },
+    "switcher": {
+      "ariaLabel": "Changer d'automatisation, actuelle : {name}"
     }
   },
   "changelog": {
@@ -8270,6 +8273,9 @@
       "emptyDescription": "Installe une automatisation projet depuis le hub Automatisations, puis ajoute ce projet.",
       "emptyCta": "Parcourir les automatisations",
       "statusBroken": "À réparer"
+    },
+    "switcher": {
+      "ariaLabel": "Changer de projet, actuel : {name}"
     }
   },
   "webdav": {


### PR DESCRIPTION
## What
On an automation or project **detail page**, the breadcrumb leaf becomes a **dropdown of sibling items** and switches between them in place. New `lib/*-switch-path` helpers compute the destination while preserving a portable `?tab=` and staying project-scoped when a `projectId` is present. When there's nothing to switch to, the leaf falls back to plain text.

## Scope
- New: `automation-breadcrumb-switcher` + `project-breadcrumb-switcher` (+ tests) and their `lib/*-switch-path` helpers (+ tests).
- Wiring: `automation-detail-shell` / `automation-page` + 3 detail routes (additive props only).
- i18n: `automations.switcher.ariaLabel` + `projects.switcher.ariaLabel` (en/de/fr).

## Test
- 23 tests green across both switchers + both path helpers (incl. an axe a11y check), client project. typecheck · oxlint (type-aware) · oxfmt clean.