### PR TITLE
feat(platform): collapse mobile composer's agent + model pickers into one

### DIFF
--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -27,6 +27,7 @@ import {
   AUTO_AGENT_SLUG,
   DEFAULT_CHAT_AGENT_SLUG,
 } from '@/lib/shared/constants/agents';
+import { cn } from '@/lib/utils/cn';
 
 import { useChatLayout } from '../context/chat-layout-context';
 import { useChatAgents, type ChatAgent } from '../hooks/queries';
@@ -46,12 +47,16 @@ interface AgentSelectorProps {
    *  their agent (sandbox session, --resume transcript), so the selector
    *  locks on them instead of offering a switch. */
   threadId?: string;
+  /** Render the trigger full-width with its chevron right-aligned — used in the
+   *  mobile combined assistant+model panel, where each row fills the panel. */
+  fullWidth?: boolean;
 }
 
 export const AgentSelector = memo(function AgentSelector({
   organizationId,
   projectId,
   threadId,
+  fullWidth = false,
 }: AgentSelectorProps) {
   const { t } = useT('chat');
   const { t: tComposer } = useT('composer');
@@ -238,7 +243,10 @@ export const AgentSelector = memo(function AgentSelector({
       <Tooltip content={t('agentSelector.lockedExternal')} side="top">
         <Button
           type="button"
-          className="cursor-not-allowed gap-1.5 sm:min-w-32"
+          className={cn(
+            'cursor-not-allowed gap-1.5',
+            fullWidth ? 'w-full' : 'sm:min-w-32',
+          )}
           variant="ghost"
           size="sm"
           aria-disabled="true"
@@ -246,9 +254,15 @@ export const AgentSelector = memo(function AgentSelector({
             agent: lockedAgent.displayName,
           })}
         >
-          <Bot className="size-3.5" aria-hidden="true" />
-          <span>{lockedAgent.displayName}</span>
-          <Box className="text-muted-foreground size-3" aria-hidden="true" />
+          <Bot className="size-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{lockedAgent.displayName}</span>
+          <Box
+            className={cn(
+              'text-muted-foreground size-3',
+              fullWidth && 'ml-auto',
+            )}
+            aria-hidden="true"
+          />
         </Button>
       </Tooltip>
     );
@@ -265,7 +279,9 @@ export const AgentSelector = memo(function AgentSelector({
       side="top"
       sideOffset={8}
       contentClassName="w-[28rem] max-w-[calc(100vw-2rem)]"
-      tooltip={t('agentSelector.label')}
+      // No hover tooltip in the mobile combined panel (touch has no hover, and
+      // the panel already frames it).
+      tooltip={fullWidth ? undefined : t('agentSelector.label')}
       tooltipSide="top"
       searchPlaceholder={t('agentSelector.searchPlaceholder')}
       emptyText={t('agentSelector.noResults')}
@@ -280,26 +296,32 @@ export const AgentSelector = memo(function AgentSelector({
         // send/mic cluster.
         <Button
           type="button"
-          className="gap-1.5 sm:min-w-32"
+          className={cn('gap-1.5', fullWidth ? 'w-full' : 'sm:min-w-32')}
           variant="ghost"
           size="sm"
           aria-label={t('agentSelector.label')}
           disabled={isAgentLoading}
         >
-          <Bot className="size-3.5" aria-hidden="true" />
+          <Bot className="size-3.5 shrink-0" aria-hidden="true" />
           <Skeletonize
             loading={isAgentLoading}
             label={t('agentSelector.label')}
           >
             <SkeletonBox>
               <span
-                className={hasNoAgents ? 'text-muted-foreground' : undefined}
+                className={cn(
+                  'truncate',
+                  hasNoAgents && 'text-muted-foreground',
+                )}
               >
                 {currentLabel}
               </span>
             </SkeletonBox>
           </Skeletonize>
-          <ChevronDown className="size-3" aria-hidden="true" />
+          <ChevronDown
+            className={cn('size-3 shrink-0', fullWidth && 'ml-auto')}
+            aria-hidden="true"
+          />
         </Button>
       }
       footer={

--- a/services/platform/app/features/chat/components/assistant-model-selector.test.tsx
+++ b/services/platform/app/features/chat/components/assistant-model-selector.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import enMessages from '../../../../messages/en.json';
+import { AssistantModelSelector } from './assistant-model-selector';
+
+// The two pickers are heavy (Convex-backed); stub them — this component's job
+// is to collapse them behind one button and reveal both on demand.
+vi.mock('./agent-selector', () => ({
+  AgentSelector: () => <div data-testid="agent-selector-stub" />,
+}));
+vi.mock('./model-selector', () => ({
+  ModelSelector: () => <div data-testid="model-selector-stub" />,
+}));
+vi.mock('../hooks/use-effective-agent', () => ({
+  useEffectiveAgent: () => ({ agent: null, isLoading: false }),
+}));
+vi.mock('../context/chat-layout-context', () => ({
+  useChatLayout: () => ({ selectedModelOverrides: {} }),
+}));
+
+describe('AssistantModelSelector', () => {
+  it('collapses to one button and reveals both pickers on demand', async () => {
+    const { user } = render(<AssistantModelSelector organizationId="org-1" />);
+
+    // Collapsed: a single control; neither picker is mounted yet.
+    const trigger = screen.getByRole('button', {
+      name: enMessages.chat.assistantModelSelector.label,
+    });
+    expect(screen.queryByTestId('agent-selector-stub')).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    // Opened: one labelled group holding BOTH pickers (agent + model).
+    const group = await screen.findByRole('group', {
+      name: enMessages.chat.assistantModelSelector.label,
+    });
+    expect(group).toContainElement(screen.getByTestId('agent-selector-stub'));
+    expect(group).toContainElement(screen.getByTestId('model-selector-stub'));
+  });
+});

--- a/services/platform/app/features/chat/components/assistant-model-selector.tsx
+++ b/services/platform/app/features/chat/components/assistant-model-selector.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { Button } from '@tale/ui/button';
+import { Bot, ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import { useEffectiveAgent } from '../hooks/use-effective-agent';
+import { AgentSelector } from './agent-selector';
+import { ModelSelector } from './model-selector';
+
+interface AssistantModelSelectorProps {
+  organizationId: string;
+  /** Project the chat belongs to, if any (restricts agents/models). */
+  projectId?: string;
+  /** Current thread, if one exists. */
+  threadId?: string;
+}
+
+/**
+ * The mobile-only combined agent + model control. The cramped mobile row can't
+ * fit two pickers, so this collapses them behind one compact button: it shows
+ * only the current assistant (the model — often a long id — lives in the panel,
+ * not the toolbar), and opening it stacks the two real pickers so drilling into
+ * either keeps everything (search, per-model details, footers, all states).
+ * Desktop is unaffected — it renders the two pickers directly (see ChatInput).
+ */
+export function AssistantModelSelector({
+  organizationId,
+  projectId,
+  threadId,
+}: AssistantModelSelectorProps) {
+  const { t } = useT('chat');
+  const [open, setOpen] = useState(false);
+
+  // Collapsed label: just the resolved assistant (kept short); the model is a
+  // row in the panel, so it never widens the toolbar.
+  const { agent } = useEffectiveAgent(organizationId);
+  const agentLabel = agent?.displayName ?? t('agentSelector.defaultAgent');
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="max-w-[9rem] min-w-0 gap-1.5"
+          aria-label={t('assistantModelSelector.label')}
+        >
+          <Bot className="size-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{agentLabel}</span>
+          <ChevronDown className="size-3 shrink-0" aria-hidden="true" />
+        </Button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="start"
+          side="top"
+          sideOffset={8}
+          // Don't pull focus onto the first picker trigger on open — that
+          // focus reads as a hover to its Radix tooltip and flashes "Select
+          // agent" over the panel.
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          // The rows drill into the real pickers, whose lists portal to the
+          // body; keep this panel open while the user works inside one of them.
+          onInteractOutside={(e) => {
+            const target = e.detail.originalEvent.target;
+            if (
+              target instanceof Element &&
+              target.closest('[role="listbox"],[role="combobox"]')
+            ) {
+              e.preventDefault();
+            }
+          }}
+          onFocusOutside={(e) => {
+            const target = e.detail.originalEvent.target;
+            if (
+              target instanceof Element &&
+              target.closest('[role="listbox"],[role="combobox"]')
+            ) {
+              e.preventDefault();
+            }
+          }}
+          className={cn(
+            'ring-border bg-popover text-popover-foreground dark:bg-muted data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 z-50 w-fit min-w-[11rem] max-w-[calc(100vw-2rem)] rounded-lg p-1 shadow-md ring-1 outline-none',
+          )}
+        >
+          {/* Two stacked pickers — their Bot / Cpu icons name each dimension,
+              so no extra row labels are needed. `fullWidth` fills each row and
+              right-aligns its chevron (icon + name stay left). */}
+          <div
+            role="group"
+            aria-label={t('assistantModelSelector.label')}
+            className="flex flex-col gap-0.5"
+          >
+            <AgentSelector
+              organizationId={organizationId}
+              projectId={projectId}
+              threadId={threadId}
+              fullWidth
+            />
+            <ModelSelector
+              organizationId={organizationId}
+              projectId={projectId}
+              threadId={threadId}
+              fullWidth
+            />
+          </div>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/services/platform/app/features/chat/components/chat-input-agent-toolbar.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input-agent-toolbar.test.tsx
@@ -1,14 +1,17 @@
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { render, screen } from '@/tests/utils/render';
 
 import { ChatInput } from './chat-input';
 
-// #2488 regression: the agent/model/sandbox cluster used gap={1}, which left
-// the read-only "Default model" label visually flush against the Sandbox badge
-// when ExternalAgentModeToggle is hidden. Stub the heavy children so we can
-// assert the cluster's layout gap in isolation.
+// Toggled per test: desktop keeps the two separate pickers; mobile collapses
+// them into one combined control.
+const { mobileState } = vi.hoisted(() => ({ mobileState: { value: false } }));
+vi.mock('@/app/hooks/use-is-mobile', () => ({
+  useIsMobile: () => mobileState.value,
+}));
+
 vi.mock('../context/chat-layout-context', () => ({
   useChatLayout: () => ({ quotedText: null, setQuotedText: vi.fn() }),
 }));
@@ -46,11 +49,16 @@ vi.mock('@/app/components/ui/forms/file-upload', () => ({
     Overlay: () => null,
   },
 }));
+// Stub the pickers + combined control so we can assert the toolbar's layout
+// (each has its own unit test for behaviour).
 vi.mock('./agent-selector', () => ({
   AgentSelector: () => <div data-testid="agent-selector-stub" />,
 }));
 vi.mock('./model-selector', () => ({
   ModelSelector: () => <div data-testid="model-selector-stub" />,
+}));
+vi.mock('./assistant-model-selector', () => ({
+  AssistantModelSelector: () => <div data-testid="assistant-model-stub" />,
 }));
 vi.mock('./external-agent-mode-toggle', () => ({
   ExternalAgentModeToggle: () => null,
@@ -65,8 +73,12 @@ vi.mock('./voice-mode-toggle', () => ({
   VoiceModeToggle: () => null,
 }));
 
-describe('ChatInput agent toolbar spacing', () => {
-  it('uses gap-2 between agent, model, and sandbox controls (#2488)', () => {
+describe('ChatInput agent toolbar', () => {
+  beforeEach(() => {
+    mobileState.value = false;
+  });
+
+  function renderToolbar() {
     render(
       <ChatInput
         organizationId="org-1"
@@ -81,12 +93,29 @@ describe('ChatInput agent toolbar spacing', () => {
         variant="full"
       />,
     );
+  }
 
-    const agentStub = screen.getByTestId('agent-selector-stub');
-    const cluster = agentStub.parentElement;
-
+  it('desktop: keeps the two separate pickers, gap-2 from the sandbox control (#2488)', () => {
+    renderToolbar();
+    // #2488: the read-only "Default model" label must not sit flush against the
+    // Sandbox badge when ExternalAgentModeToggle is hidden.
+    const agent = screen.getByTestId('agent-selector-stub');
+    const cluster = agent.parentElement;
     expect(cluster).toHaveClass('gap-2');
     expect(cluster).toContainElement(screen.getByTestId('model-selector-stub'));
     expect(cluster).toContainElement(screen.getByTestId('sandbox-stub'));
+    // Desktop is untouched — no combined control.
+    expect(
+      screen.queryByTestId('assistant-model-stub'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('mobile: collapses the two pickers into one combined control', () => {
+    mobileState.value = true;
+    renderToolbar();
+    expect(screen.getByTestId('assistant-model-stub')).toBeInTheDocument();
+    // The two separate pickers are not rendered on the cramped mobile row.
+    expect(screen.queryByTestId('agent-selector-stub')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('model-selector-stub')).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -17,6 +17,7 @@ import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { DataNoticeFooter } from '@/app/features/governance/components/data-notice-footer';
 import { useUploadPolicy } from '@/app/features/settings/governance/hooks/queries';
+import { useIsMobile } from '@/app/hooks/use-is-mobile';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import type { BlobRef } from '@/convex/lib/storage/blob_ref';
@@ -47,6 +48,7 @@ import { normalizeCopiedText } from '../utils/normalize-copied-text';
 import { AgentSelector } from './agent-selector';
 import { useArenaModeOptional } from './arena/arena-mode-context';
 import { ArenaModelSelector } from './arena/arena-model-selector';
+import { AssistantModelSelector } from './assistant-model-selector';
 import { AttachmentTray } from './chat-input/attachment-tray';
 import { toBcp47 } from './chat-input/locale-defaults';
 import {
@@ -325,6 +327,9 @@ export function ChatInput({
   const { i18n } = useTranslation();
   const arenaContext = useArenaModeOptional();
   const isArenaMode = arenaContext?.isArenaMode ?? false;
+  // Collapse the agent + model pickers into one control only on the cramped
+  // mobile row; desktop keeps the two separate pickers unchanged.
+  const isComposerMobile = useIsMobile();
 
   const speechLang = toBcp47(i18n.language) ?? 'en-US';
   const policyLimits = useUploadPolicy(organizationId);
@@ -1433,16 +1438,29 @@ export function ChatInput({
                   <ArenaModelSelector organizationId={organizationId} />
                 ) : (
                   <HStack gap={2} align="center">
-                    <AgentSelector
-                      organizationId={organizationId}
-                      projectId={projectId}
-                      threadId={threadId}
-                    />
-                    <ModelSelector
-                      organizationId={organizationId}
-                      projectId={projectId}
-                      threadId={threadId}
-                    />
+                    {/* Desktop is unchanged — two separate pickers, which work
+                        well with the room. Only the cramped mobile row collapses
+                        them into one combined control. */}
+                    {isComposerMobile ? (
+                      <AssistantModelSelector
+                        organizationId={organizationId}
+                        projectId={projectId}
+                        threadId={threadId}
+                      />
+                    ) : (
+                      <>
+                        <AgentSelector
+                          organizationId={organizationId}
+                          projectId={projectId}
+                          threadId={threadId}
+                        />
+                        <ModelSelector
+                          organizationId={organizationId}
+                          projectId={projectId}
+                          threadId={threadId}
+                        />
+                      </>
+                    )}
                     <ExternalAgentModeToggle
                       threadId={threadId}
                       organizationId={organizationId}

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -43,6 +43,7 @@ import {
   resolveModelLocale,
   resolveProviderLocale,
 } from '@/lib/shared/utils/resolve-provider-locale';
+import { cn } from '@/lib/utils/cn';
 
 import { useChatLayout } from '../context/chat-layout-context';
 import { useChatAgents } from '../hooks/queries';
@@ -62,6 +63,9 @@ interface ModelSelectorProps {
    *  model list and overrides must follow the thread's agent — not the global
    *  per-user picker state another thread may have changed. */
   threadId?: string;
+  /** Render the trigger full-width with its chevron right-aligned — used in the
+   *  mobile combined assistant+model panel, where each row fills the panel. */
+  fullWidth?: boolean;
 }
 
 function getModelShortName(modelId: string): string {
@@ -73,6 +77,7 @@ export const ModelSelector = memo(function ModelSelector({
   organizationId,
   projectId,
   threadId,
+  fullWidth = false,
 }: ModelSelectorProps) {
   const { t } = useT('chat');
   const { agent: effectiveAgent } = useEffectiveAgent(organizationId);
@@ -453,19 +458,22 @@ export const ModelSelector = memo(function ModelSelector({
     return (
       <Button
         type="button"
-        className="gap-1.5"
+        className={cn('gap-1.5', fullWidth && 'w-full')}
         size="sm"
         variant="ghost"
         aria-label={t('modelSelector.label')}
         disabled
       >
-        <Cpu className="size-3.5" aria-hidden="true" />
+        <Cpu className="size-3.5 shrink-0" aria-hidden="true" />
         <Skeletonize loading label={t('modelSelector.label')}>
           <SkeletonBox>
-            <span>{t('modelSelector.auto')}</span>
+            <span className="truncate">{t('modelSelector.auto')}</span>
           </SkeletonBox>
         </Skeletonize>
-        <ChevronDown className="size-3" aria-hidden="true" />
+        <ChevronDown
+          className={cn('size-3 shrink-0', fullWidth && 'ml-auto')}
+          aria-hidden="true"
+        />
       </Button>
     );
   }
@@ -500,7 +508,7 @@ export const ModelSelector = memo(function ModelSelector({
           side="top"
           sideOffset={8}
           contentClassName="w-[22rem]"
-          tooltip={t('modelSelector.label')}
+          tooltip={fullWidth ? undefined : t('modelSelector.label')}
           tooltipSide="top"
           searchPlaceholder={t('modelSelector.searchPlaceholder')}
           emptyText={t('modelSelector.noResults')}
@@ -715,7 +723,7 @@ export const ModelSelector = memo(function ModelSelector({
       side="top"
       sideOffset={8}
       contentClassName="w-[28rem] max-w-[calc(100vw-2rem)]"
-      tooltip={t('modelSelector.label')}
+      tooltip={fullWidth ? undefined : t('modelSelector.label')}
       tooltipSide="top"
       searchPlaceholder={t('modelSelector.searchPlaceholder')}
       emptyText={t('modelSelector.noResults')}
@@ -737,14 +745,17 @@ export const ModelSelector = memo(function ModelSelector({
       trigger={
         <Button
           type="button"
-          className="gap-1.5"
+          className={cn('gap-1.5', fullWidth && 'w-full')}
           variant="ghost"
           size="sm"
           aria-label={t('modelSelector.label')}
         >
-          <Cpu className="size-3.5" aria-hidden="true" />
-          <span>{currentLabel}</span>
-          <ChevronDown className="size-3" aria-hidden="true" />
+          <Cpu className="size-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{currentLabel}</span>
+          <ChevronDown
+            className={cn('size-3 shrink-0', fullWidth && 'ml-auto')}
+            aria-hidden="true"
+          />
         </Button>
       }
     />

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1799,6 +1799,9 @@
       "PROJECT_FORBIDDEN": "Du hast keinen Zugriff auf das Projekt dieser Konversation.",
       "PROJECT_NOT_FOUND": "Das Projekt dieser Konversation existiert nicht mehr.",
       "PROJECT_ORG_MISMATCH": "Das Projekt dieser Konversation gehört zu einer anderen Organisation."
+    },
+    "assistantModelSelector": {
+      "label": "Assistent und Modell"
     }
   },
   "common": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1799,6 +1799,9 @@
       "PROJECT_FORBIDDEN": "You don't have access to this conversation's project.",
       "PROJECT_NOT_FOUND": "This conversation's project no longer exists.",
       "PROJECT_ORG_MISMATCH": "This conversation's project belongs to a different organization."
+    },
+    "assistantModelSelector": {
+      "label": "Assistant and model"
     }
   },
   "common": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1799,6 +1799,9 @@
       "PROJECT_FORBIDDEN": "Tu n'as pas accès au projet de cette conversation.",
       "PROJECT_NOT_FOUND": "Le projet de cette conversation n'existe plus.",
       "PROJECT_ORG_MISMATCH": "Le projet de cette conversation appartient à une autre organisation."
+    },
+    "assistantModelSelector": {
+      "label": "Assistant et modèle"
     }
   },
   "common": {


### PR DESCRIPTION
## What
On a phone the composer's two separate **Agent** and **Model** pickers consumed scarce toolbar width. Below `md` they now collapse behind a single **"Assistant and model"** button that opens a popover stacking the real `AgentSelector` + `ModelSelector` full-width; desktop keeps the two inline (unchanged). The selectors gain an opt-in `fullWidth` trigger for the stacked layout.

## Scope
- New: `assistant-model-selector.tsx` (+ test).
- `chat-input.tsx` chooses the combined control on mobile; `agent-selector`/`model-selector` gain `fullWidth?`.
- i18n: `chat.assistantModelSelector.label` (en/de/fr).

## Test
- `assistant-model-selector.test.tsx` (collapses to one labelled button, reveals both pickers) + updated `chat-input-agent-toolbar.test.tsx` (desktop two / mobile one) — green (client). typecheck · oxlint · oxfmt clean.