### PR TITLE
feat(platform): unify per-chat context menu across header and sidebar

### DIFF
--- a/packages/ui/src/components/overlays/dropdown-menu.test.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.test.tsx
@@ -1,11 +1,72 @@
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render, act } from '@/tests/utils/render';
+import { render, act, screen } from '@/tests/utils/render';
 
 import { DropdownMenu } from './dropdown-menu';
 
 describe('DropdownMenu', () => {
+  describe('keepOpen items (in-place drill-down)', () => {
+    it('activate via keyboard and keep the menu open', async () => {
+      // Drill-down menus (e.g. chat "Move to project") swap the panel's
+      // contents on `keepOpen`; the handler must run on keyboard activation,
+      // not just pointer, or the item is unreachable for keyboard users.
+      const onDrill = vi.fn();
+      const { user } = render(
+        <DropdownMenu
+          open
+          onOpenChange={vi.fn()}
+          trigger={<button>Open Menu</button>}
+          items={[
+            [
+              {
+                type: 'item',
+                label: 'Move to project',
+                keepOpen: true,
+                onClick: onDrill,
+              },
+              { type: 'item', label: 'Pin', onClick: vi.fn() },
+            ],
+          ]}
+        />,
+      );
+
+      const item = screen.getByRole('menuitem', { name: 'Move to project' });
+      item.focus();
+      await user.keyboard('{Enter}');
+
+      expect(onDrill).toHaveBeenCalledTimes(1);
+      // Stayed open (keepOpen): a sibling item is still mounted.
+      expect(screen.getByRole('menuitem', { name: 'Pin' })).toBeInTheDocument();
+    });
+
+    it('fire exactly once on pointer click (no double-fire)', async () => {
+      const onDrill = vi.fn();
+      const { user } = render(
+        <DropdownMenu
+          open
+          onOpenChange={vi.fn()}
+          trigger={<button>Open Menu</button>}
+          items={[
+            [
+              {
+                type: 'item',
+                label: 'Move to project',
+                keepOpen: true,
+                onClick: onDrill,
+              },
+            ],
+          ]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('menuitem', { name: 'Move to project' }),
+      );
+      expect(onDrill).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit with trigger visible', async () => {
       const { container } = render(

--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -271,8 +271,20 @@ function renderItem(item: DropdownMenuItem, key: number) {
             item.destructive && 'text-destructive focus:text-destructive',
             item.className,
           )}
-          onClick={item.onClick}
-          onSelect={item.keepOpen ? (e) => e.preventDefault() : undefined}
+          // `keepOpen` items swap the panel's contents in place, so run the
+          // handler on `onSelect` — which fires for BOTH pointer and keyboard
+          // activation — and preventDefault to keep the menu open. Routing
+          // through `onClick` (pointer-only) would make the item unreachable by
+          // keyboard; wiring both would double-fire on click.
+          onClick={item.keepOpen ? undefined : item.onClick}
+          onSelect={
+            item.keepOpen
+              ? (e) => {
+                  e.preventDefault();
+                  item.onClick?.();
+                }
+              : undefined
+          }
           disabled={item.disabled}
         >
           {Icon && <Icon />}

--- a/services/platform/app/features/chat/components/chat-actions.test.tsx
+++ b/services/platform/app/features/chat/components/chat-actions.test.tsx
@@ -1,0 +1,262 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import enMessages from '../../../../messages/en.json';
+import { ChatActions } from './chat-actions';
+
+// ── Spies for the thread + project mutations the menu drives ────────────────
+const {
+  moveMutate,
+  deleteMutate,
+  archiveMutate,
+  unarchiveMutate,
+  pinMutate,
+  projectsState,
+  createDialog,
+} = vi.hoisted(() => ({
+  moveMutate: vi.fn(),
+  deleteMutate: vi.fn(),
+  archiveMutate: vi.fn(),
+  unarchiveMutate: vi.fn(),
+  pinMutate: vi.fn(),
+  projectsState: {
+    projects: [
+      { _id: 'p1', name: 'Investing', icon: 'DollarSign', color: 'green' },
+      { _id: 'p2', name: 'Business', icon: 'Folder', color: 'gray' },
+      { _id: 'p3', name: 'Homework', icon: 'GraduationCap', color: 'blue' },
+    ] as Array<{ _id: string; name: string; icon: string; color: string }>,
+  },
+  createDialog: { onCreated: null as ((id: string) => void) | null },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useDeleteThread: () => ({ mutate: deleteMutate, isPending: false }),
+  useArchiveThread: () => ({ mutate: archiveMutate }),
+  useUnarchiveThread: () => ({ mutate: unarchiveMutate }),
+  useSetThreadPinned: () => ({ mutate: pinMutate }),
+}));
+
+vi.mock('@/app/features/projects/hooks/mutations', () => ({
+  useMoveThreadToProject: () => ({ mutate: moveMutate }),
+}));
+
+vi.mock('@/app/features/projects/hooks/queries', () => ({
+  useProjects: () => projectsState,
+}));
+
+vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
+  useLegalHoldByTarget: () => ({ data: null }),
+}));
+
+// The create-project dialog pulls in a form + Convex; stub it to a marker and
+// capture its `onCreated` so we can assert the "create → move" hand-off.
+vi.mock('@/app/features/projects/components/project-create-dialog', () => ({
+  ProjectCreateDialog: ({
+    open,
+    onCreated,
+  }: {
+    open: boolean;
+    onCreated?: (id: string) => void;
+  }) => {
+    createDialog.onCreated = onCreated ?? null;
+    return open ? <div data-testid="create-project-dialog" /> : null;
+  },
+}));
+
+// Delete confirmation → a plain confirm button while open.
+vi.mock('@/app/components/ui/dialog/delete-dialog', () => ({
+  DeleteDialog: ({ open, onDelete }: { open: boolean; onDelete: () => void }) =>
+    open ? (
+      <button type="button" onClick={onDelete}>
+        confirm-delete
+      </button>
+    ) : null,
+}));
+
+// Stand in for the Radix dropdown (portals are flaky in jsdom): the trigger
+// plus one button per action item; a `sub` entry renders its label as a marker
+// span and its nested items inline, so the Move-to-project submenu is drivable.
+interface MenuItemStub {
+  type: string;
+  label: ReactNode;
+  content?: ReactNode;
+  disabled?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+  items?: MenuItemStub[][];
+}
+function StubMenuItems({ items }: { items: MenuItemStub[] }) {
+  return (
+    <>
+      {items.map((item, i) => {
+        if (item.type === 'item') {
+          return (
+            // oxlint-disable-next-line react/no-array-index-key
+            <button
+              key={i}
+              type="button"
+              disabled={item.disabled}
+              data-selected={item.selected ? 'true' : undefined}
+              onClick={item.onClick}
+            >
+              {item.label}
+            </button>
+          );
+        }
+        if (item.type === 'sub') {
+          return (
+            // oxlint-disable-next-line react/no-array-index-key
+            <div key={i}>
+              <span>
+                {`sub:${typeof item.label === 'string' ? item.label : ''}`}
+              </span>
+              <StubMenuItems items={(item.items ?? []).flat()} />
+            </div>
+          );
+        }
+        if (item.type === 'label') {
+          // oxlint-disable-next-line react/no-array-index-key
+          return <span key={i}>{item.content}</span>;
+        }
+        return null;
+      })}
+    </>
+  );
+}
+vi.mock('@tale/ui/dropdown-menu', () => ({
+  DropdownMenu: ({
+    trigger,
+    items,
+  }: {
+    trigger: ReactNode;
+    items: MenuItemStub[][];
+  }) => (
+    <div>
+      {trigger}
+      <StubMenuItems items={items.flat()} />
+    </div>
+  ),
+}));
+
+const CHAT = { id: 'chat-1', title: 'Quarterly plan' };
+
+function renderActions(props?: Partial<Parameters<typeof ChatActions>[0]>) {
+  return render(
+    <ChatActions
+      chat={CHAT}
+      organizationId="org-1"
+      currentChatId="chat-1"
+      projectId="p2"
+      {...props}
+    />,
+  );
+}
+
+describe('ChatActions — Move to project', () => {
+  beforeEach(() => {
+    moveMutate.mockClear();
+    deleteMutate.mockClear();
+    pinMutate.mockClear();
+    createDialog.onCreated = null;
+  });
+
+  // "Move to project" drills down in place; open it before asserting the list.
+  async function openMoveView(user: ReturnType<typeof renderActions>['user']) {
+    await user.click(screen.getByText(enMessages.projects.picker.title));
+  }
+
+  it('lists every project after opening "Move to project"', async () => {
+    const { user } = renderActions();
+    // Not shown until the drill-down is opened (no lateral flyout).
+    expect(screen.queryByText('Homework')).not.toBeInTheDocument();
+    await openMoveView(user);
+    expect(screen.getByText('Investing')).toBeInTheDocument();
+    expect(screen.getByText('Business')).toBeInTheDocument();
+    expect(screen.getByText('Homework')).toBeInTheDocument();
+  });
+
+  it('disables the current project (you cannot move a chat onto itself)', async () => {
+    const { user } = renderActions({ projectId: 'p2' });
+    await openMoveView(user);
+    // p2 = Business is the current project.
+    expect(screen.getByText('Business').closest('button')).toBeDisabled();
+    expect(screen.getByText('Investing').closest('button')).toBeEnabled();
+  });
+
+  it('moves the chat when a project row is chosen', async () => {
+    const { user } = renderActions({ projectId: 'p2' });
+    await openMoveView(user);
+    // Click the row's label; the event bubbles to the (enabled) row button.
+    await user.click(screen.getByText('Homework'));
+    expect(moveMutate).toHaveBeenCalledWith(
+      { threadId: 'chat-1', projectId: 'p3' },
+      expect.anything(),
+    );
+  });
+
+  it('opens the create dialog from "New project" and moves on creation', async () => {
+    const { user } = renderActions();
+    await openMoveView(user);
+    await user.click(screen.getByText(enMessages.chat.newProject));
+    expect(screen.getByTestId('create-project-dialog')).toBeInTheDocument();
+
+    // The dialog reports the new id; the menu moves the chat into it.
+    createDialog.onCreated?.('p-new');
+    expect(moveMutate).toHaveBeenCalledWith(
+      { threadId: 'chat-1', projectId: 'p-new' },
+      expect.anything(),
+    );
+  });
+
+  it('removes the chat from its project (projectId: null)', async () => {
+    const { user } = renderActions({ projectId: 'p2' });
+    await openMoveView(user);
+    await user.click(screen.getByText(enMessages.chat.removeFromProject));
+    expect(moveMutate).toHaveBeenCalledWith(
+      { threadId: 'chat-1', projectId: null },
+      expect.anything(),
+    );
+  });
+
+  it('offers "New project" with an empty-state note when there are no projects', async () => {
+    projectsState.projects = [];
+    try {
+      const { user } = renderActions({ projectId: undefined });
+      await openMoveView(user);
+      expect(screen.getByText(enMessages.chat.newProject)).toBeInTheDocument();
+      expect(
+        screen.getByText(enMessages.projects.picker.empty),
+      ).toBeInTheDocument();
+    } finally {
+      projectsState.projects = [
+        { _id: 'p1', name: 'Investing', icon: 'DollarSign', color: 'green' },
+        { _id: 'p2', name: 'Business', icon: 'Folder', color: 'gray' },
+        { _id: 'p3', name: 'Homework', icon: 'GraduationCap', color: 'blue' },
+      ];
+    }
+  });
+
+  it('hides "Remove from project" when the chat is not in a project', async () => {
+    const { user } = renderActions({ projectId: undefined });
+    await openMoveView(user);
+    expect(
+      screen.queryByText(enMessages.chat.removeFromProject),
+    ).not.toBeInTheDocument();
+  });
+
+  it('deletes via the confirmation dialog', async () => {
+    const { user } = renderActions();
+    await user.click(screen.getByText(enMessages.common.actions.delete));
+    await user.click(screen.getByText('confirm-delete'));
+    expect(deleteMutate).toHaveBeenCalledWith(
+      { threadId: 'chat-1' },
+      expect.anything(),
+    );
+  });
+});

--- a/services/platform/app/features/chat/components/chat-actions.tsx
+++ b/services/platform/app/features/chat/components/chat-actions.tsx
@@ -1,33 +1,12 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
-import { Text } from '@tale/ui/text';
-import { useNavigate } from '@tanstack/react-router';
-import {
-  Archive,
-  ArchiveRestore,
-  FolderMinus,
-  MoreHorizontal,
-  Pencil,
-  Pin,
-  PinOff,
-  Trash2,
-} from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { DropdownMenu } from '@tale/ui/dropdown-menu';
+import { MoreHorizontal } from 'lucide-react';
 
-import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
-import { useMoveThreadToProject } from '@/app/features/projects/hooks/mutations';
-import { useLegalHoldByTarget } from '@/app/features/settings/governance/hooks/queries';
-import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
-import {
-  useArchiveThread,
-  useDeleteThread,
-  useSetThreadPinned,
-  useUnarchiveThread,
-} from '../hooks/mutations';
+import { useChatContextMenu } from '../hooks/use-chat-context-menu';
 
 interface ChatActionsProps {
   chat: {
@@ -39,12 +18,16 @@ interface ChatActionsProps {
   onRename?: () => void;
   isArchived?: boolean;
   isPinned?: boolean;
-  /** The project this chat currently belongs to, if any. When set, the menu
-   * offers "Remove from project" (chats are otherwise only added to a project
-   * by dragging onto a folder). */
+  /** The project this chat currently belongs to, if any — the "Move to
+   * project" submenu marks it as current and offers "Remove from project". */
   projectId?: string;
 }
 
+/**
+ * The per-chat "…" menu shown on each sidebar chat row. A thin trigger over the
+ * shared {@link useChatContextMenu} (Pin · Rename · Move to project · Archive ·
+ * Delete), so the sidebar and the chat header stay in lockstep.
+ */
 export function ChatActions({
   chat,
   currentChatId,
@@ -54,251 +37,24 @@ export function ChatActions({
   isPinned = false,
   projectId,
 }: ChatActionsProps) {
-  const navigate = useNavigate();
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const { toast } = useToast();
-
-  const { t: tCommon } = useT('common');
   const { t: tChat } = useT('chat');
-  const { t: tGovernance } = useT('governance');
 
-  // Read-only consultation so archive/delete can show "blocked by legal
-  // hold". The query is reactive: a hold placed via the panel (which is
-  // the only entry point for placing holds since the User+Org refactor)
-  // automatically disables these actions. Cascade-includes user-custodian
-  // hits via the thread author.
-  const { data: hold } = useLegalHoldByTarget({
+  const { items, dialogs, onMenuOpenChange } = useChatContextMenu({
+    chat,
     organizationId,
-    targetType: 'thread',
-    targetId: chat.id,
-  });
-  const isHeld = hold !== null && hold !== undefined;
-
-  const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread();
-  const { mutate: archiveThread } = useArchiveThread();
-  const { mutate: unarchiveThread } = useUnarchiveThread();
-  const { mutate: setThreadPinned } = useSetThreadPinned();
-  const { mutate: moveThreadToProject } = useMoveThreadToProject();
-
-  const handleRemoveFromProject = useCallback(() => {
-    moveThreadToProject(
-      { threadId: chat.id, projectId: null },
-      {
-        onError: (error: unknown) => {
-          console.error('Failed to remove chat from project:', error);
-          toast({
-            title: tChat('removeFromProjectFailed'),
-            variant: 'destructive',
-          });
-        },
-      },
-    );
-  }, [chat.id, moveThreadToProject, toast, tChat]);
-
-  const handleDelete = useCallback(() => {
-    deleteThread(
-      { threadId: chat.id },
-      {
-        onSuccess: () => {
-          setIsDeleteDialogOpen(false);
-
-          if (currentChatId === chat.id) {
-            void navigate({
-              to: '/dashboard/$id/chat',
-              params: { id: organizationId },
-            });
-          }
-        },
-        onError: (error) => {
-          console.error('Failed to delete chat:', error);
-          toast({
-            title: tChat('deleteFailed'),
-            variant: 'destructive',
-          });
-        },
-      },
-    );
-  }, [
-    chat.id,
+    placement: 'sidebar',
     currentChatId,
-    organizationId,
-    deleteThread,
-    navigate,
-    toast,
-    tChat,
-  ]);
-
-  const handleArchive = useCallback(() => {
-    archiveThread(
-      { threadId: chat.id },
-      {
-        onSuccess: () => {
-          if (currentChatId === chat.id) {
-            void navigate({
-              to: '/dashboard/$id/chat',
-              params: { id: organizationId },
-            });
-          }
-          toast({
-            title: tChat('archiveSuccess'),
-          });
-        },
-        onError: (error) => {
-          console.error('Failed to archive chat:', error);
-          toast({
-            title: tChat('archiveFailed'),
-            variant: 'destructive',
-          });
-        },
-      },
-    );
-  }, [
-    chat.id,
-    currentChatId,
-    organizationId,
-    archiveThread,
-    navigate,
-    toast,
-    tChat,
-  ]);
-
-  const handleUnarchive = useCallback(() => {
-    unarchiveThread(
-      { threadId: chat.id },
-      {
-        onSuccess: () => {
-          toast({
-            title: tChat('unarchiveSuccess'),
-          });
-        },
-        onError: (error) => {
-          console.error('Failed to unarchive chat:', error);
-          toast({
-            title: tChat('unarchiveFailed'),
-            variant: 'destructive',
-          });
-        },
-      },
-    );
-  }, [chat.id, unarchiveThread, toast, tChat]);
-
-  const handleTogglePin = useCallback(() => {
-    setThreadPinned(
-      { threadId: chat.id, pinned: !isPinned },
-      {
-        onError: (error) => {
-          console.error('Failed to update pin:', error);
-          toast({ title: tChat('pinFailed'), variant: 'destructive' });
-        },
-      },
-    );
-  }, [chat.id, isPinned, setThreadPinned, toast, tChat]);
-
-  const menuItems = useMemo<DropdownMenuGroup[]>(() => {
-    // Surface the legal-hold reason as a leading label so disabled
-    // archive/delete items aren't unexplained (the tooltip the old icon
-    // row carried is unavailable inside a menu).
-    const heldNotice: DropdownMenuGroup | null = isHeld
-      ? [
-          {
-            type: 'label' as const,
-            content: tGovernance('legalHold.badges.blockedByHold'),
-          },
-        ]
-      : null;
-
-    if (isArchived) {
-      return [
-        ...(heldNotice ? [heldNotice] : []),
-        [
-          {
-            type: 'item' as const,
-            label: tChat('unarchive'),
-            icon: ArchiveRestore,
-            disabled: isHeld,
-            onClick: handleUnarchive,
-          },
-        ],
-        [
-          {
-            type: 'item' as const,
-            label: tCommon('actions.delete'),
-            icon: Trash2,
-            destructive: true,
-            disabled: isHeld,
-            onClick: () => setIsDeleteDialogOpen(true),
-          },
-        ],
-      ];
-    }
-
-    return [
-      ...(heldNotice ? [heldNotice] : []),
-      [
-        {
-          type: 'item' as const,
-          label: isPinned ? tChat('unpinChat') : tChat('pinChat'),
-          icon: isPinned ? PinOff : Pin,
-          onClick: handleTogglePin,
-        },
-        ...(onRename
-          ? [
-              {
-                type: 'item' as const,
-                label: tCommon('actions.rename'),
-                icon: Pencil,
-                onClick: onRename,
-              },
-            ]
-          : []),
-        ...(projectId
-          ? [
-              {
-                type: 'item' as const,
-                label: tChat('removeFromProject'),
-                icon: FolderMinus,
-                onClick: handleRemoveFromProject,
-              },
-            ]
-          : []),
-        {
-          type: 'item' as const,
-          label: tChat('archive'),
-          icon: Archive,
-          disabled: isHeld,
-          onClick: handleArchive,
-        },
-      ],
-      [
-        {
-          type: 'item' as const,
-          label: tCommon('actions.delete'),
-          icon: Trash2,
-          destructive: true,
-          disabled: isHeld,
-          onClick: () => setIsDeleteDialogOpen(true),
-        },
-      ],
-    ];
-  }, [
-    isArchived,
     isPinned,
-    isHeld,
-    onRename,
+    isArchived,
     projectId,
-    handleTogglePin,
-    handleArchive,
-    handleUnarchive,
-    handleRemoveFromProject,
-    tChat,
-    tCommon,
-    tGovernance,
-  ]);
+    onRename,
+  });
 
   return (
     <>
       <DropdownMenu
         align="end"
+        onOpenChange={onMenuOpenChange}
         trigger={
           <Button
             variant="ghost"
@@ -309,43 +65,10 @@ export function ChatActions({
             <MoreHorizontal className="size-4" />
           </Button>
         }
-        items={menuItems}
+        items={items}
       />
 
-      <DeleteDialog
-        open={isDeleteDialogOpen}
-        onOpenChange={setIsDeleteDialogOpen}
-        title={tChat('deleteChat')}
-        description={
-          <>
-            {(() => {
-              const parts = tChat('deleteConfirmation', {
-                title: '\x00',
-              }).split('\x00');
-              if (parts.length < 2) {
-                return tChat('deleteConfirmation', { title: chat.title });
-              }
-              return (
-                <>
-                  {parts[0]}
-                  <Text as="span" variant="body" className="font-semibold">
-                    {chat.title}
-                  </Text>
-                  {parts[1]}
-                </>
-              );
-            })()}
-            <br />
-            <br />
-            <Text as="span" variant="muted">
-              {tChat('deletePermanentMessage')}
-            </Text>
-          </>
-        }
-        deleteText={tChat('deleteChat')}
-        isDeleting={isDeleting}
-        onDelete={handleDelete}
-      />
+      {dialogs}
     </>
   );
 }

--- a/services/platform/app/features/chat/components/chat-header.test.tsx
+++ b/services/platform/app/features/chat/components/chat-header.test.tsx
@@ -4,22 +4,37 @@ import { checkAccessibility } from '@/tests/utils/a11y';
 import { render, screen } from '@/tests/utils/render';
 
 import enMessages from '../../../../messages/en.json';
+import type { UseChatContextMenuOptions } from '../hooks/use-chat-context-menu';
 import { ChatHeader } from './chat-header';
+
+interface HeaderMeta {
+  title: string | null;
+  pinnedAt: number | null;
+  projectId: string | null;
+  status: string;
+}
 
 // The sidebar owns search/drawer state; the chat layout owns the sub-panel
 // visibility. The header only calls into them.
-const { sidebarState, chatLayoutState } = vi.hoisted(() => ({
-  sidebarState: {
-    isMobileSheetOpen: false,
-    setMobileSheetOpen: vi.fn(),
-    isSearchOpen: false,
-    setSearchOpen: vi.fn(),
-  },
-  chatLayoutState: {
-    isHistoryPanelOpen: true,
-    toggleHistoryPanel: vi.fn(),
-  },
-}));
+const { sidebarState, chatLayoutState, panelState, metaState, lastMenuOpts } =
+  vi.hoisted(() => ({
+    sidebarState: {
+      isMobileSheetOpen: false,
+      setMobileSheetOpen: vi.fn(),
+      isSearchOpen: false,
+      setSearchOpen: vi.fn(),
+    },
+    chatLayoutState: {
+      isHistoryPanelOpen: true,
+      toggleHistoryPanel: vi.fn(),
+    },
+    panelState: {
+      openPane: vi.fn(),
+      visiblePanes: [] as Array<{ id: string }>,
+    },
+    metaState: { value: null as HeaderMeta | null },
+    lastMenuOpts: { value: null as UseChatContextMenuOptions | null },
+  }));
 
 vi.mock('@/app/components/layout/app-sidebar/sidebar-context', () => ({
   useSidebar: () => sidebarState,
@@ -27,6 +42,23 @@ vi.mock('@/app/components/layout/app-sidebar/sidebar-context', () => ({
 
 vi.mock('../context/chat-layout-context', () => ({
   useChatLayout: () => chatLayoutState,
+}));
+
+vi.mock('./chat-panel/chat-panel-context', () => ({
+  useChatPanel: () => panelState,
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useThreadHeaderMeta: () => metaState.value,
+}));
+
+// The menu itself is exercised in chat-actions.test.tsx (real hook). Here we
+// only assert the header wires it correctly — capture the options it passes.
+vi.mock('../hooks/use-chat-context-menu', () => ({
+  useChatContextMenu: (opts: UseChatContextMenuOptions) => {
+    lastMenuOpts.value = opts;
+    return { items: [], dialogs: null, onMenuOpenChange: vi.fn() };
+  },
 }));
 
 vi.mock('@/app/components/layout/adaptive-header', () => ({
@@ -44,9 +76,10 @@ vi.mock('@/app/components/layout/adaptive-header', () => ({
 }));
 
 // The per-thread dialogs pull in Convex; the header only needs their mount
-// points to exist.
+// points to exist. Export renders a marker while open so "Export" is drivable.
 vi.mock('./export-chat-dialog', () => ({
-  ExportChatDialog: () => null,
+  ExportChatDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="export-dialog" /> : null,
 }));
 vi.mock('./share-chat-dialog', () => ({
   ShareChatDialog: () => null,
@@ -59,6 +92,10 @@ describe('ChatHeader', () => {
     sidebarState.isMobileSheetOpen = false;
     chatLayoutState.toggleHistoryPanel.mockClear();
     chatLayoutState.isHistoryPanelOpen = true;
+    panelState.openPane.mockClear();
+    panelState.visiblePanes = [];
+    metaState.value = null;
+    lastMenuOpts.value = null;
   });
 
   it('without a thread: only the panel toggle, no per-thread actions', () => {
@@ -101,6 +138,43 @@ describe('ChatHeader', () => {
     const { user } = render(<ChatHeader organizationId="org-1" />);
     await user.click(screen.getByLabelText(enMessages.chat.searchChat));
     expect(sidebarState.setSearchOpen).toHaveBeenCalledWith(true);
+  });
+
+  describe('menu wiring', () => {
+    it('passes the active thread + its meta to the menu', () => {
+      metaState.value = {
+        title: 'Quarterly plan',
+        pinnedAt: 123,
+        projectId: 'p1',
+        status: 'active',
+      };
+      render(<ChatHeader organizationId="org-1" threadId="thread-1" />);
+      const opts = lastMenuOpts.value;
+      expect(opts?.placement).toBe('header');
+      expect(opts?.chat).toEqual({ id: 'thread-1', title: 'Quarterly plan' });
+      expect(opts?.currentChatId).toBe('thread-1');
+      expect(opts?.isPinned).toBe(true);
+      expect(opts?.projectId).toBe('p1');
+    });
+
+    it('offers "View files" only when the canvas pane has content', () => {
+      panelState.visiblePanes = [{ id: 'canvas' }];
+      render(<ChatHeader organizationId="org-1" threadId="thread-1" />);
+      expect(lastMenuOpts.value?.viewFiles?.visible).toBe(true);
+    });
+
+    it('hides "View files" when the chat has no files', () => {
+      panelState.visiblePanes = [];
+      render(<ChatHeader organizationId="org-1" threadId="thread-1" />);
+      expect(lastMenuOpts.value?.viewFiles?.visible).toBe(false);
+    });
+
+    it('"View files" opens the canvas pane', () => {
+      panelState.visiblePanes = [{ id: 'canvas' }];
+      render(<ChatHeader organizationId="org-1" threadId="thread-1" />);
+      lastMenuOpts.value?.viewFiles?.onSelect();
+      expect(panelState.openPane).toHaveBeenCalledWith('canvas');
+    });
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/features/chat/components/chat-header.tsx
+++ b/services/platform/app/features/chat/components/chat-header.tsx
@@ -1,18 +1,17 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
+import { DropdownMenu } from '@tale/ui/dropdown-menu';
 import { Row } from '@tale/ui/layout';
 import {
   MessagesSquare,
-  Download,
   Ellipsis,
   PanelLeftClose,
   PanelLeftOpen,
   Search,
   Share,
 } from 'lucide-react';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 
 import { AdaptiveHeaderRoot } from '@/app/components/layout/adaptive-header';
 import { useSidebar } from '@/app/components/layout/app-sidebar/sidebar-context';
@@ -20,6 +19,9 @@ import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 import { useChatLayout } from '../context/chat-layout-context';
+import { useThreadHeaderMeta } from '../hooks/queries';
+import { useChatContextMenu } from '../hooks/use-chat-context-menu';
+import { useChatPanel } from './chat-panel/chat-panel-context';
 import { ExportChatDialog } from './export-chat-dialog';
 import { ShareChatDialog } from './share-chat-dialog';
 
@@ -34,6 +36,10 @@ interface ChatHeaderProps {
  * and the per-thread actions (Share + overflow) join it while a thread is
  * open. The mobile bar keeps its hamburger + search buttons, wired to the
  * shared sidebar state (drawer + palette).
+ *
+ * The overflow "…" is the same menu the sidebar chat rows carry (built by
+ * {@link useChatContextMenu}) — View files · Move to project · Pin · Archive ·
+ * Export · Delete — so header and sidebar never drift apart.
  */
 export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
   const { isMobileSheetOpen, setMobileSheetOpen, setSearchOpen } = useSidebar();
@@ -43,21 +49,31 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
 
   const { t: tChat } = useT('chat');
 
-  // The per-thread voice toggle moved to the composer (next to dictation),
-  // so the header dropdown now only carries the export action.
-  const headerMenuItems = useMemo<DropdownMenuGroup[]>(
-    () => [
-      [
-        {
-          type: 'item' as const,
-          label: tChat('export.button'),
-          icon: Download,
-          onClick: () => setIsExportDialogOpen(true),
-        },
-      ],
-    ],
-    [tChat],
-  );
+  const { openPane, visiblePanes } = useChatPanel();
+  const meta = useThreadHeaderMeta(threadId, organizationId);
+  // The canvas pane registers a descriptor only when the thread has files
+  // (branch-aware, including live writes), so this is exactly when
+  // `openPane('canvas')` will stick — gate "View files" on it.
+  const canvasHasFiles = visiblePanes.some((pane) => pane.id === 'canvas');
+
+  const {
+    items: menuItems,
+    dialogs: menuDialogs,
+    onMenuOpenChange,
+  } = useChatContextMenu({
+    chat: { id: threadId ?? '', title: meta?.title ?? '' },
+    organizationId,
+    placement: 'header',
+    currentChatId: threadId,
+    isPinned: meta?.pinnedAt != null,
+    isArchived: meta?.status === 'archived',
+    projectId: meta?.projectId ?? undefined,
+    viewFiles: {
+      visible: canvasHasFiles,
+      onSelect: () => openPane('canvas'),
+    },
+    onExport: () => setIsExportDialogOpen(true),
+  });
 
   const baseIconClasses = 'size-5 text-muted-foreground p-0.25';
 
@@ -115,7 +131,8 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
                     <Ellipsis className={baseIconClasses} />
                   </Button>
                 }
-                items={headerMenuItems}
+                items={menuItems}
+                onOpenChange={onMenuOpenChange}
                 align="end"
               />
             </>
@@ -169,7 +186,8 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
                     <Ellipsis className={baseIconClasses} />
                   </Button>
                 }
-                items={headerMenuItems}
+                items={menuItems}
+                onOpenChange={onMenuOpenChange}
                 align="end"
               />
             </>
@@ -179,6 +197,7 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
 
       {threadId && (
         <>
+          {menuDialogs}
           <ExportChatDialog
             open={isExportDialogOpen}
             onOpenChange={setIsExportDialogOpen}

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -402,6 +402,21 @@ export function useThreadSandboxState(threadId: string | null | undefined) {
   };
 }
 
+/**
+ * Lightweight thread metadata for the chat header's overflow menu (title, pin
+ * state, current project, lifecycle status). Kept off the hot `getThreadMeta`.
+ */
+export function useThreadHeaderMeta(
+  threadId: string | null | undefined,
+  organizationId: string,
+) {
+  const { data } = useConvexQuery(
+    api.threads.queries.getThreadHeaderMeta,
+    threadId && organizationId ? { threadId, organizationId } : 'skip',
+  );
+  return data ?? null;
+}
+
 export function useActiveApprovals(organizationId: string) {
   const { data, isLoading } = useConvexQuery(
     api.approvals.queries.listActiveApprovalsByOrganization,

--- a/services/platform/app/features/chat/hooks/use-chat-context-menu.tsx
+++ b/services/platform/app/features/chat/hooks/use-chat-context-menu.tsx
@@ -1,0 +1,445 @@
+'use client';
+
+import {
+  type DropdownMenuGroup,
+  type DropdownMenuItem,
+} from '@tale/ui/dropdown-menu';
+import { Text } from '@tale/ui/text';
+import { useNavigate } from '@tanstack/react-router';
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Files,
+  FolderInput,
+  FolderMinus,
+  FolderPlus,
+  Pencil,
+  Pin,
+  PinOff,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+
+import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
+import { ProjectAvatar } from '@/app/features/projects/components/project-avatar';
+import { ProjectCreateDialog } from '@/app/features/projects/components/project-create-dialog';
+import { useMoveThreadToProject } from '@/app/features/projects/hooks/mutations';
+import { useProjects } from '@/app/features/projects/hooks/queries';
+import { useLegalHoldByTarget } from '@/app/features/settings/governance/hooks/queries';
+import { useToast } from '@/app/hooks/use-toast';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import {
+  useArchiveThread,
+  useDeleteThread,
+  useSetThreadPinned,
+  useUnarchiveThread,
+} from './mutations';
+
+export interface UseChatContextMenuOptions {
+  chat: { id: string; title: string };
+  organizationId: string;
+  /**
+   * `'header'` — the active-thread overflow menu next to Share (View files +
+   * Export are wired by the header via `viewFiles`/`onExport`).
+   * `'sidebar'` — a chat-row menu (inline Rename via `onRename`).
+   */
+  placement: 'header' | 'sidebar';
+  /** The currently-open thread; used to route away after delete/archive. */
+  currentChatId?: string;
+  isPinned?: boolean;
+  isArchived?: boolean;
+  /** The project this chat currently belongs to, if any. */
+  projectId?: string;
+  /** Inline rename entry (sidebar rows only). */
+  onRename?: () => void;
+  /** "View files in chat" (header only) — shown only when `visible`. */
+  viewFiles?: { visible: boolean; onSelect: () => void };
+  /** "Export" entry (header only). */
+  onExport?: () => void;
+}
+
+/**
+ * The single source of truth for the per-chat context menu, shared by the chat
+ * header overflow menu and the sidebar chat-row menu. Owns the pin / archive /
+ * delete / move-to-project handlers and the Delete + "New project" dialogs, and
+ * assembles the menu groups for the given `placement`. Returns `items` (feed to
+ * `<DropdownMenu items=… />`) and `dialogs` (render once alongside the trigger).
+ */
+export function useChatContextMenu({
+  chat,
+  organizationId,
+  placement,
+  currentChatId,
+  isPinned = false,
+  isArchived = false,
+  projectId,
+  onRename,
+  viewFiles,
+  onExport,
+}: UseChatContextMenuOptions): {
+  items: DropdownMenuGroup[];
+  dialogs: ReactNode;
+  /** Wire to the menu's `onOpenChange` so the drill-down resets on close. */
+  onMenuOpenChange: (open: boolean) => void;
+} {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
+  // "Move to project" drills DOWN in place (swaps this panel's contents) rather
+  // than flying out sideways — a lateral submenu has no room in the left-docked
+  // / mobile sidebar and spills off-screen.
+  const [inMoveView, setInMoveView] = useState(false);
+
+  const { t: tCommon } = useT('common');
+  const { t: tChat } = useT('chat');
+  const { t: tGovernance } = useT('governance');
+  const { t: tProjects } = useT('projects');
+
+  // Read-only consultation so archive/delete can show "blocked by legal hold".
+  // Reactive: a hold placed via the governance panel disables these actions.
+  const { data: hold } = useLegalHoldByTarget({
+    organizationId,
+    targetType: 'thread',
+    targetId: chat.id,
+  });
+  const isHeld = hold !== null && hold !== undefined;
+
+  const { projects } = useProjects(organizationId);
+
+  const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread();
+  const { mutate: archiveThread } = useArchiveThread();
+  const { mutate: unarchiveThread } = useUnarchiveThread();
+  const { mutate: setThreadPinned } = useSetThreadPinned();
+  const { mutate: moveThreadToProject } = useMoveThreadToProject();
+
+  const goToChatRoot = useCallback(() => {
+    if (currentChatId === chat.id) {
+      void navigate({
+        to: '/dashboard/$id/chat',
+        params: { id: organizationId },
+      });
+    }
+  }, [chat.id, currentChatId, organizationId, navigate]);
+
+  const handleDelete = useCallback(() => {
+    deleteThread(
+      { threadId: chat.id },
+      {
+        onSuccess: () => {
+          setIsDeleteDialogOpen(false);
+          goToChatRoot();
+        },
+        onError: (error) => {
+          console.error('Failed to delete chat:', error);
+          toast({ title: tChat('deleteFailed'), variant: 'destructive' });
+        },
+      },
+    );
+  }, [chat.id, deleteThread, goToChatRoot, toast, tChat]);
+
+  const handleArchive = useCallback(() => {
+    archiveThread(
+      { threadId: chat.id },
+      {
+        onSuccess: () => {
+          goToChatRoot();
+          toast({ title: tChat('archiveSuccess') });
+        },
+        onError: (error) => {
+          console.error('Failed to archive chat:', error);
+          toast({ title: tChat('archiveFailed'), variant: 'destructive' });
+        },
+      },
+    );
+  }, [chat.id, archiveThread, goToChatRoot, toast, tChat]);
+
+  const handleUnarchive = useCallback(() => {
+    unarchiveThread(
+      { threadId: chat.id },
+      {
+        onSuccess: () => toast({ title: tChat('unarchiveSuccess') }),
+        onError: (error) => {
+          console.error('Failed to unarchive chat:', error);
+          toast({ title: tChat('unarchiveFailed'), variant: 'destructive' });
+        },
+      },
+    );
+  }, [chat.id, unarchiveThread, toast, tChat]);
+
+  const handleTogglePin = useCallback(() => {
+    setThreadPinned(
+      { threadId: chat.id, pinned: !isPinned },
+      {
+        onError: (error) => {
+          console.error('Failed to update pin:', error);
+          toast({ title: tChat('pinFailed'), variant: 'destructive' });
+        },
+      },
+    );
+  }, [chat.id, isPinned, setThreadPinned, toast, tChat]);
+
+  const handleMoveToProject = useCallback(
+    (targetProjectId: Id<'projects'>) => {
+      moveThreadToProject(
+        { threadId: chat.id, projectId: targetProjectId },
+        {
+          onSuccess: () => toast({ title: tProjects('composer.moveSuccess') }),
+          onError: (error: unknown) => {
+            console.error('Failed to move chat to project:', error);
+            toast({
+              title: tProjects('composer.moveError'),
+              variant: 'destructive',
+            });
+          },
+        },
+      );
+    },
+    [chat.id, moveThreadToProject, toast, tProjects],
+  );
+
+  const handleRemoveFromProject = useCallback(() => {
+    moveThreadToProject(
+      { threadId: chat.id, projectId: null },
+      {
+        onError: (error: unknown) => {
+          console.error('Failed to remove chat from project:', error);
+          toast({
+            title: tChat('removeFromProjectFailed'),
+            variant: 'destructive',
+          });
+        },
+      },
+    );
+  }, [chat.id, moveThreadToProject, toast, tChat]);
+
+  const items = useMemo<DropdownMenuGroup[]>(() => {
+    const heldNotice: DropdownMenuGroup | null = isHeld
+      ? [
+          {
+            type: 'label' as const,
+            content: tGovernance('legalHold.badges.blockedByHold'),
+          },
+        ]
+      : null;
+
+    const deleteItem: DropdownMenuItem = {
+      type: 'item',
+      label: tCommon('actions.delete'),
+      icon: Trash2,
+      destructive: true,
+      disabled: isHeld,
+      onClick: () => setIsDeleteDialogOpen(true),
+    };
+
+    if (isArchived) {
+      return [
+        ...(heldNotice ? [heldNotice] : []),
+        [
+          {
+            type: 'item' as const,
+            label: tChat('unarchive'),
+            icon: ArchiveRestore,
+            disabled: isHeld,
+            onClick: handleUnarchive,
+          },
+        ],
+        [deleteItem],
+      ];
+    }
+
+    // Drilled INTO the move view: a Back row, then New project + the project
+    // list, then Remove — all in this same anchored panel, so nothing spills.
+    if (inMoveView) {
+      const projectRows: DropdownMenuItem[] =
+        projects.length > 0
+          ? projects.map((project) => {
+              const isCurrent = project._id === projectId;
+              return {
+                type: 'item' as const,
+                label: (
+                  <span className="flex min-w-0 items-center gap-2">
+                    <ProjectAvatar
+                      name={project.name}
+                      icon={project.icon}
+                      color={project.color}
+                      size={16}
+                      variant="plain"
+                    />
+                    <span className="truncate">{project.name}</span>
+                  </span>
+                ),
+                disabled: isCurrent,
+                selected: isCurrent,
+                onClick: isCurrent
+                  ? undefined
+                  : () => handleMoveToProject(project._id),
+              };
+            })
+          : [{ type: 'label' as const, content: tProjects('picker.empty') }];
+
+      return [
+        [
+          {
+            type: 'item' as const,
+            label: tProjects('picker.title'),
+            icon: ChevronLeft,
+            keepOpen: true,
+            onClick: () => setInMoveView(false),
+          },
+        ],
+        [
+          {
+            type: 'item' as const,
+            label: tChat('newProject'),
+            icon: FolderPlus,
+            onClick: () => setIsCreateProjectOpen(true),
+          },
+          ...projectRows,
+        ],
+        ...(projectId
+          ? [
+              [
+                {
+                  type: 'item' as const,
+                  label: tChat('removeFromProject'),
+                  icon: FolderMinus,
+                  onClick: handleRemoveFromProject,
+                },
+              ],
+            ]
+          : []),
+      ];
+    }
+
+    const primary: DropdownMenuItem[] = [];
+    if (placement === 'header' && viewFiles?.visible) {
+      primary.push({
+        type: 'item',
+        label: tChat('viewFiles'),
+        icon: Files,
+        onClick: viewFiles.onSelect,
+      });
+    }
+    // Enters the drill-down (see `inMoveView`). `keepOpen` swaps the panel in
+    // place instead of closing; the chevron signals the drill-in.
+    primary.push({
+      type: 'item',
+      label: tProjects('picker.title'),
+      icon: FolderInput,
+      trailing: <ChevronRight className="size-4" />,
+      keepOpen: true,
+      onClick: () => setInMoveView(true),
+    });
+    primary.push({
+      type: 'item',
+      label: isPinned ? tChat('unpinChat') : tChat('pinChat'),
+      icon: isPinned ? PinOff : Pin,
+      onClick: handleTogglePin,
+    });
+    if (onRename) {
+      primary.push({
+        type: 'item',
+        label: tCommon('actions.rename'),
+        icon: Pencil,
+        onClick: onRename,
+      });
+    }
+    primary.push({
+      type: 'item',
+      label: tChat('archive'),
+      icon: Archive,
+      disabled: isHeld,
+      onClick: handleArchive,
+    });
+    if (placement === 'header' && onExport) {
+      primary.push({
+        type: 'item',
+        label: tChat('export.button'),
+        icon: Download,
+        onClick: onExport,
+      });
+    }
+
+    return [...(heldNotice ? [heldNotice] : []), primary, [deleteItem]];
+  }, [
+    placement,
+    isArchived,
+    isHeld,
+    isPinned,
+    projectId,
+    projects,
+    inMoveView,
+    onRename,
+    onExport,
+    viewFiles,
+    handleTogglePin,
+    handleArchive,
+    handleUnarchive,
+    handleMoveToProject,
+    handleRemoveFromProject,
+    tChat,
+    tCommon,
+    tGovernance,
+    tProjects,
+  ]);
+
+  const dialogs = (
+    <>
+      <DeleteDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title={tChat('deleteChat')}
+        description={
+          <>
+            {(() => {
+              const parts = tChat('deleteConfirmation', {
+                title: '\x00',
+              }).split('\x00');
+              if (parts.length < 2) {
+                return tChat('deleteConfirmation', { title: chat.title });
+              }
+              return (
+                <>
+                  {parts[0]}
+                  <Text as="span" variant="body" className="font-semibold">
+                    {chat.title}
+                  </Text>
+                  {parts[1]}
+                </>
+              );
+            })()}
+            <br />
+            <br />
+            <Text as="span" variant="muted">
+              {tChat('deletePermanentMessage')}
+            </Text>
+          </>
+        }
+        deleteText={tChat('deleteChat')}
+        isDeleting={isDeleting}
+        onDelete={handleDelete}
+      />
+
+      <ProjectCreateDialog
+        open={isCreateProjectOpen}
+        onOpenChange={setIsCreateProjectOpen}
+        organizationId={organizationId}
+        navigateOnCreate={false}
+        onCreated={handleMoveToProject}
+      />
+    </>
+  );
+
+  const onMenuOpenChange = useCallback((open: boolean) => {
+    // Always reopen at the root list, never mid-drill-down.
+    if (!open) setInMoveView(false);
+  }, []);
+
+  return { items, dialogs, onMenuOpenChange };
+}

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -21,6 +21,7 @@ import {
   isHiddenFromChatHistory,
   listThreads as listThreadsHelper,
 } from './list_threads';
+import { threadStatusValidator } from './validators';
 
 export const listThreads = query({
   args: {
@@ -281,6 +282,43 @@ export const getThreadProject = query({
     );
     if (!metadata) return null;
     return { projectId: metadata.projectId ?? null };
+  },
+});
+
+/**
+ * Lightweight per-thread metadata for the chat header's overflow menu: the
+ * title (delete-confirmation copy), pin state, current project, and lifecycle
+ * status (so the menu shows Archive vs Unarchive). Deliberately separate from
+ * the hot `getThreadMeta` so adding menu fields doesn't ripple its many
+ * readers. Behind a single `canAccessThread` check; null when inaccessible.
+ */
+export const getThreadHeaderMeta = query({
+  args: { threadId: v.string(), organizationId: v.string() },
+  returns: v.union(
+    v.null(),
+    v.object({
+      title: v.union(v.string(), v.null()),
+      pinnedAt: v.union(v.number(), v.null()),
+      projectId: v.union(v.id('projects'), v.null()),
+      status: threadStatusValidator,
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return null;
+    const metadata = await canAccessThread(
+      ctx,
+      args.threadId,
+      authUser,
+      args.organizationId,
+    );
+    if (!metadata) return null;
+    return {
+      title: metadata.title ?? null,
+      pinnedAt: metadata.pinnedAt ?? null,
+      projectId: metadata.projectId ?? null,
+      status: metadata.status,
+    };
   },
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1805,7 +1805,8 @@
     },
     "assistantModelSelector": {
       "label": "Assistent und Modell"
-    }
+    },
+    "viewFiles": "Dateien im Chat anzeigen"
   },
   "common": {
     "optional": "optional",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1805,7 +1805,8 @@
     },
     "assistantModelSelector": {
       "label": "Assistant and model"
-    }
+    },
+    "viewFiles": "View files in chat"
   },
   "common": {
     "optional": "optional",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1805,7 +1805,8 @@
     },
     "assistantModelSelector": {
       "label": "Assistant et modèle"
-    }
+    },
+    "viewFiles": "Afficher les fichiers du chat"
   },
   "common": {
     "optional": "facultatif",


### PR DESCRIPTION
## What
The per-chat menu was split — the sidebar row had the full set, the header overflow carried only **Export**. Both now render one shared `use-chat-context-menu` hook (parameterized by `placement`), reaching **parity**: View files · Move to project · Pin · Archive · Export · Delete. Adds an **in-place "Move to project"** drill-down (with a New-project → move hand-off). A new `getThreadHeaderMeta` query backs the header's pin/project state.

## Cross-package
- `@tale/ui` `dropdown-menu` gains `keepOpen` items that fire on `onSelect` (keyboard **and** pointer) instead of pointer-only `onClick` — required for the in-place panel swap. `use-chat-context-menu` is its only consumer today; the non-`keepOpen` path is byte-identical, so existing menus are unaffected.

## Test
- `chat-actions.test.tsx` (drives the real hook: list/move/new-project/remove/delete) + updated `chat-header.test.tsx` (wiring, View-files visibility) — 18 tests green (client). `dropdown-menu.test.tsx` — 4 green (`@tale/ui` unit). Both packages: typecheck · oxlint (type-aware) · oxfmt clean.