### PR TITLE
perf(platform): cache hashed assets, revalidate index.html

### DIFF
--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { wrapCanvasPreviewHtml } from './lib/canvas-preview-shell';
 import {
   authorizeScreencast,
+  cacheControlForStaticPath,
   createApp,
   SCREENCAST_ROUTE_RE,
   shouldDeliverSseEvent,
@@ -21,6 +22,37 @@ const baseEnv = {
   TALE_VERSION: undefined,
   CANVAS_PREVIEW_CSP_EXTRA_ORIGINS: [] as readonly string[],
 };
+
+describe('cacheControlForStaticPath', () => {
+  const IMMUTABLE = 'public, max-age=31536000, immutable';
+  const REVALIDATE = 'no-cache';
+
+  test.each([
+    // Content-hashed bundler output under /assets/ — a filename never maps to
+    // different bytes, so it is safe to cache forever.
+    ['/assets/vendor-katex-DUoGyCxW.js', IMMUTABLE],
+    ['/assets/index-D6U9bzSy.css', IMMUTABLE],
+    ['/assets/vendor-radix-C-BNZUpZ.js', IMMUTABLE], // hash contains '-'
+    ['/assets/vendor-katex-_Zecxha_.css', IMMUTABLE], // hash contains '_'
+    ['/assets/vendor-katex-DUoGyCxW.js.map', IMMUTABLE], // sourcemap
+  ])('caches %s immutably', (pathname, expected) => {
+    expect(cacheControlForStaticPath(pathname)).toBe(expected);
+  });
+
+  test.each([
+    // Stable-named files that can change across deploys must revalidate.
+    ['/index.html', REVALIDATE],
+    ['/sw.js', REVALIDATE],
+    ['/manifest.webmanifest', REVALIDATE],
+    ['/favicon.ico', REVALIDATE],
+    ['/assets/pwa-192x192.png', REVALIDATE], // un-hashed public image in assets/
+    ['/assets/logo-white.svg', REVALIDATE],
+    ['/assets/apple-touch-icon-180x180.png', REVALIDATE], // digits, not a hash
+    ['/canvas-libs/d3/7.8.5/d3.min.js', REVALIDATE], // version-pinned, outside assets/
+  ])('revalidates %s', (pathname, expected) => {
+    expect(cacheControlForStaticPath(pathname)).toBe(expected);
+  });
+});
 
 describe('security headers', () => {
   test('every standard header is present on /api/health', async () => {

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -291,6 +291,25 @@ const port = process.env.PORT || 3000;
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 const distDir = join(moduleDir, 'dist');
 const distSeoDir = join(moduleDir, 'dist-seo');
+
+// Content-hashed bundler output — `assets/<name>-<8-char hash>.js|css` (+ its
+// `.map`) — is content-addressed: a given filename never maps to different
+// bytes across builds (Vite's default hashing; the deploy publishes a fresh
+// tree and never reuses a name), so it is safe to cache forever as immutable.
+// Everything else served from `dist/` has a stable name that CAN change across
+// deploys — `index.html`, `sw.js`, `manifest.webmanifest`, favicons, the
+// un-hashed `public/assets/*` images, and version-pinned `/canvas-libs/*` — so
+// those must revalidate. Scoping to `/assets/` + the `.js|.css` extension keeps
+// the un-hashed images (svg/png) and `/canvas-libs/*` out of the immutable
+// bucket; the hash pattern is belt-and-suspenders. Fail-safe: an unmatched
+// hashed file merely loses the optimization (revalidates), never serves stale
+// bytes — so a future Vite hash-length change degrades gracefully.
+const IMMUTABLE_ASSET = /^\/assets\/.+-[A-Za-z0-9_-]{8}\.(?:js|css)(?:\.map)?$/;
+export function cacheControlForStaticPath(pathname: string): string {
+  return IMMUTABLE_ASSET.test(pathname)
+    ? 'public, max-age=31536000, immutable'
+    : 'no-cache';
+}
 // Branding is per-org: images live at
 // `${TALE_CONFIG_DIR}/<orgSlug>/branding/images/<filename>`. The org slug is a
 // path segment in the request (`/branding/images/:orgSlug/:filename`) and is
@@ -894,7 +913,11 @@ export function createApp(
       if (filePath.startsWith(distDir)) {
         const file = Bun.file(filePath);
         if (await file.exists()) {
-          return new Response(file);
+          // Bun infers Content-Type from the file extension; we only add the
+          // caching directive (immutable for content-hashed chunks).
+          return new Response(file, {
+            headers: { 'Cache-Control': cacheControlForStaticPath(pathname) },
+          });
         }
       }
     }
@@ -964,9 +987,12 @@ export function createApp(
     return new Response(html, {
       headers: {
         'Content-Type': 'text/html',
-        // In dev, never let the browser reuse a cached shell — a live-reload
-        // must fetch the freshly-published index.html (new chunk hashes).
-        ...(DEV_HOT_RELOAD ? { 'Cache-Control': 'no-store' } : {}),
+        // Never cache the SPA shell without revalidation: it embeds the
+        // content-hashed chunk filenames, which change on every deploy, so a
+        // heuristically-cached shell would reference deleted chunks. In dev a
+        // live-reload must fetch the freshly-published index.html, and
+        // `no-store` additionally blocks any reuse of a stale shell.
+        'Cache-Control': DEV_HOT_RELOAD ? 'no-store' : 'no-cache',
       },
     });
   });


### PR DESCRIPTION
## What & why

Built JS/CSS were served with **no `Cache-Control`**, so browsers re-downloaded the entire ~870 KB bundle on every visit. The service worker deliberately does **not** cache JS/CSS/HTML (navigations are `NetworkOnly`), so HTTP headers are the *only* caching layer for the bundle — and it was absent. A HAR of the dashboard showed all 142 content-hashed chunks re-fetched on each load.

## Change

- Content-hashed bundler output under `/assets/` (`*-<hash>.js|css` and their `.map`) → `Cache-Control: public, max-age=31536000, immutable`. Safe because filenames are content-addressed and never reused for different bytes.
- `index.html` and other stable-named files (`sw.js`, `manifest.webmanifest`, favicons, un-hashed public images, `/canvas-libs/*`) → `no-cache`, so a deploy's new chunk hashes are always picked up. This also fixes a latent staleness bug: prod `index.html` previously had **no** cache header.
- New pure, exported helper `cacheControlForStaticPath()`, applied at the SPA static-file handler in `server.ts`.

## Detection safety

Scoped to `/assets/` + `.js|.css` + the 8-char content-hash pattern (which tolerates `-`/`_` in hashes). Un-hashed public images (svg/png) and version-pinned `/canvas-libs/*` never match → they revalidate. Fail-safe by design: an unmatched hashed file only loses the optimization, it never serves stale bytes.

## Verification

- `bun run --filter @tale/platform test` → full suite green (**77,103 passed**), including **13 new** table-driven helper cases (hashed js/css/map incl. dash/underscore hashes; images, `sw.js`, manifest, `/canvas-libs/*`, index.html → revalidate).
- `oxfmt --check` and `oxlint` clean on the changed files.
- Typecheck: this change adds **zero delta** — the only error (`automations-grid.tsx:728`, a TanStack Router search-param type) reproduces identically on pristine `origin/main` and is already red on `main`'s CI, unrelated to this change.

## Follow-up

The *first uncached* load is still gated by single-origin throughput (~3.6 KB/s, up to 20 s TTFB, no CDN) — tracked in #2842 (Caddy `file_server`/`dist` export + origin investigation). A third-party CDN stays out of scope (same-origin/air-gap CSP policy).