### PR TITLE
fix(platform): scope automations 'Browse all' navigate to its route

### DIFF
--- a/services/platform/app/features/automations/components/automations-grid.test.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.test.tsx
@@ -520,6 +520,8 @@ describe('AutomationsGrid tabs + badges', () => {
       screen.getByRole('button', { name: 'Browse all automations' }),
     );
     expect(navigateMock).toHaveBeenCalledWith({
+      to: '/dashboard/$id/automations',
+      params: { id: 'org_1' },
       search: expect.any(Function),
     });
     const searchFn = navigateMock.mock.calls[0][0].search as (prev: {

--- a/services/platform/app/features/automations/components/automations-grid.tsx
+++ b/services/platform/app/features/automations/components/automations-grid.tsx
@@ -725,6 +725,8 @@ export function AutomationsGrid({
         variant="secondary"
         onClick={() =>
           void navigate({
+            to: '/dashboard/$id/automations',
+            params: { id: organizationId },
             search: (prev) => ({ ...prev, tab: 'all' }),
           })
         }


### PR DESCRIPTION
## Problem

The automations empty-state **Browse all** button (added in #2841) called `navigate({ search: (prev) => ({ ...prev, tab: 'all' }) })` with no `to`. With no target route, TanStack Router resolves the destination search params to `never`, so the updater's return isn't assignable — `tsc` failed at `automations-grid.tsx:728` (TS2322). This made the platform **Type check** job red on `main`.

## Fix

Pass the explicit route + params, matching the established sibling pattern (the products/contacts/websites catalog tables) and this file's own other navigations:

```ts
navigate({
  to: '/dashboard/$id/automations',
  params: { id: organizationId },
  search: (prev) => ({ ...prev, tab: 'all' }),
})
```

The grid mounts on exactly one route (`/dashboard/$id/automations/`), whose `validateSearch` owns `?tab=`, so the target is unambiguous. Runtime behaviour is unchanged (a relative `search`-only navigate already worked at runtime) — this is a type-correctness fix that unblocks CI's Type check.

## Verification

- **Type check green**: `bun run --filter @tale/platform typecheck` now exits 0 — this was the only error.
- **Regression**: the existing browse-all test now asserts `to` + `params`; verified it **fails on the old code** (navigate called without them) and **passes on the new**. `--project client` suite: 28/28 pass.
- Format + lint clean on the changed files.

Independent of #2843.