### PR TITLE
fix(platform): match asset hashes of 8+ chars, not exactly 8

### DIFF
--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -35,6 +35,7 @@ describe('cacheControlForStaticPath', () => {
     ['/assets/vendor-radix-C-BNZUpZ.js', IMMUTABLE], // hash contains '-'
     ['/assets/vendor-katex-_Zecxha_.css', IMMUTABLE], // hash contains '_'
     ['/assets/vendor-katex-DUoGyCxW.js.map', IMMUTABLE], // sourcemap
+    ['/assets/queries-LIOgKzLg2.js', IMMUTABLE], // 9-char hash (Rollup collision-extended)
   ])('caches %s immutably', (pathname, expected) => {
     expect(cacheControlForStaticPath(pathname)).toBe(expected);
   });

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -292,19 +292,21 @@ const moduleDir = dirname(fileURLToPath(import.meta.url));
 const distDir = join(moduleDir, 'dist');
 const distSeoDir = join(moduleDir, 'dist-seo');
 
-// Content-hashed bundler output — `assets/<name>-<8-char hash>.js|css` (+ its
-// `.map`) — is content-addressed: a given filename never maps to different
-// bytes across builds (Vite's default hashing; the deploy publishes a fresh
-// tree and never reuses a name), so it is safe to cache forever as immutable.
-// Everything else served from `dist/` has a stable name that CAN change across
-// deploys — `index.html`, `sw.js`, `manifest.webmanifest`, favicons, the
-// un-hashed `public/assets/*` images, and version-pinned `/canvas-libs/*` — so
-// those must revalidate. Scoping to `/assets/` + the `.js|.css` extension keeps
-// the un-hashed images (svg/png) and `/canvas-libs/*` out of the immutable
-// bucket; the hash pattern is belt-and-suspenders. Fail-safe: an unmatched
-// hashed file merely loses the optimization (revalidates), never serves stale
-// bytes — so a future Vite hash-length change degrades gracefully.
-const IMMUTABLE_ASSET = /^\/assets\/.+-[A-Za-z0-9_-]{8}\.(?:js|css)(?:\.map)?$/;
+// Content-hashed bundler output — `assets/<name>-<hash>.js|css` (+ its `.map`) —
+// is content-addressed: a given filename never maps to different bytes across
+// builds (Vite's default hashing; the deploy publishes a fresh tree and never
+// reuses a name), so it is safe to cache forever as immutable. Everything else
+// served from `dist/` has a stable name that CAN change across deploys —
+// `index.html`, `sw.js`, `manifest.webmanifest`, favicons, the un-hashed
+// `public/assets/*` images, and version-pinned `/canvas-libs/*` — so those must
+// revalidate. Scoping to `/assets/` + the `.js|.css` extension keeps the
+// un-hashed images (svg/png) and `/canvas-libs/*` out of the immutable bucket;
+// the hash pattern is belt-and-suspenders. `{8,}` (not `{8}`) because Rollup
+// extends a hash past its usual 8 chars to break collisions between same-named
+// chunks (e.g. several `queries-*.js`). Fail-safe: an unmatched hashed file
+// merely loses the optimization (revalidates), never serves stale bytes.
+const IMMUTABLE_ASSET =
+  /^\/assets\/.+-[A-Za-z0-9_-]{8,}\.(?:js|css)(?:\.map)?$/;
 export function cacheControlForStaticPath(pathname: string): string {
   return IMMUTABLE_ASSET.test(pathname)
     ? 'public, max-age=31536000, immutable'


### PR DESCRIPTION
## Problem

Follow-up to the static-asset caching fix (#2843). That rule marks content-hashed chunks `immutable` by matching `-[A-Za-z0-9_-]{8}\.(?:js|css)` — **exactly 8** hash chars. Rollup lengthens a hash past 8 chars to disambiguate same-named chunks, so a post-deploy HAR showed `/assets/queries-LIOgKzLg2.js` (9-char hash, one of six `queries-*.js`) falling to `no-cache` and being re-downloaded on every visit. Fail-safe (never stale), but it leaves collision-extended chunks uncached — and that grows as chunks are added.

## Fix

Widen the pattern `{8}` → `{8,}` (8-or-more). Handles any hash length; only `.js|.css` under `/assets/` match, so un-hashed public images (svg/png) and version-pinned `/canvas-libs/*` are still excluded. Fail-safe unchanged.

## Verification

- `bun run --filter @tale/platform test server.test.ts` → green (57), incl. a new 9-char case (`/assets/queries-LIOgKzLg2.js` → immutable) that fails on `{8}`, passes on `{8,}`.
- `bun run --filter @tale/platform typecheck` clean; `oxfmt --check` + `oxlint` clean.

Verified against the post-deploy HAR: the caching fix works (repeat visit ~243s → ~9.9s; 152/153 hashed assets from cache); this closes the last 9-char-hash gap.
