### PR TITLE
perf(platform): skip CSP/nonce middleware for hashed assets

### DIFF
--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -264,6 +264,20 @@ describe('security headers', () => {
       "connect-src 'self' https://acc.r2.cloudflarestorage.com",
     );
   });
+
+  test('content-hashed assets bypass the CSP/nonce middleware', async () => {
+    const app = createApp(baseEnv);
+    // A content-hashed asset path skips secureHeaders (no per-request CSP +
+    // crypto nonce), so its response carries no CSP — while a normal path still
+    // does (control). Independent of whether the file exists on disk.
+    const asset = await app.fetch(
+      new Request('http://localhost/assets/vendor-katex-DUoGyCxW.js'),
+    );
+    expect(asset.headers.get('content-security-policy')).toBeNull();
+
+    const normal = await app.fetch(new Request('http://localhost/api/health'));
+    expect(normal.headers.get('content-security-policy')).not.toBeNull();
+  });
 });
 
 describe('POST /canvas-preview', () => {

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -669,6 +669,12 @@ export function createApp(
     if (c.req.path === '/canvas-preview') return next();
     if (c.req.path.startsWith('/dav/') || c.req.path === '/dav')
       return secureForDav(c, next);
+    // Content-hashed JS/CSS chunks are static and never use the nonce'd CSP, so
+    // skip the per-request CSP + crypto-nonce build for them — a cold load's
+    // ~150-asset burst would otherwise pay it on the single event loop. The
+    // static file handler re-adds the one header that matters for a script
+    // response, `X-Content-Type-Options: nosniff`.
+    if (IMMUTABLE_ASSET.test(c.req.path)) return next();
     return currentSecure()(c, next);
   });
 
@@ -913,10 +919,16 @@ export function createApp(
       if (filePath.startsWith(distDir)) {
         const file = Bun.file(filePath);
         if (await file.exists()) {
-          // Bun infers Content-Type from the file extension; we only add the
-          // caching directive (immutable for content-hashed chunks).
+          // Bun infers Content-Type from the file extension; we add the caching
+          // directive plus `nosniff`. Content-hashed assets skip the security-
+          // headers middleware above, so we re-assert the one header that
+          // matters for a script/style byte stream here (harmless duplicate for
+          // the other static files, which also get it from that middleware).
           return new Response(file, {
-            headers: { 'Cache-Control': cacheControlForStaticPath(pathname) },
+            headers: {
+              'Cache-Control': cacheControlForStaticPath(pathname),
+              'X-Content-Type-Options': 'nosniff',
+            },
           });
         }
       }


### PR DESCRIPTION
## Problem

Follow-up to the caching fix (#2843): repeat visits are now fast, but the *first* (cold) visit is still slow. Part of that is self-inflicted — on a cold load the ~150 content-hashed JS/CSS chunks each pass through the global `secureHeaders` middleware, which builds a full CSP string and a **fresh crypto nonce per request**, on the single Bun event loop. A static script/style byte stream never uses that nonce'd CSP, so it's wasted work paid ~150× during the burst. (Confirmed: on `main`, a request to `/assets/vendor-katex-….js` comes back with `content-security-policy: default-src 'self'; script-src 'nonce-…'`.)

## Change

Bypass `secureHeaders` for content-hashed `/assets/*` in the `app.use('*')` guard — mirroring the existing `/canvas-preview` and `/dav/*` bypasses — and re-assert `X-Content-Type-Options: nosniff` on the static-file response (the one header that matters for a script/style stream; CSP/X-Frame/Referrer are document-level). Uses the same `IMMUTABLE_ASSET` pattern as the cache rule, so only hashed JS/CSS bypass; un-hashed images under `/assets/` still get the full middleware.

## Verification

- `bun run --filter @tale/platform test server.test.ts` → green (57), incl. a new test asserting a hashed-asset response carries **no** CSP while `/api/health` still does. Verified it **fails on `main`** (asset gets the full CSP) and passes here.
- `typecheck` clean; `oxfmt --check` + `oxlint` clean.

## Honest caveat — this is measure-after

I can't prove from the HAR alone that this middleware is *the* cold-load bottleneck (the box's raw bandwidth and Caddy's on-the-fly gzip/zstd are also candidates). It's a correct optimization regardless (don't build a per-request nonce for static bytes). Next step: deploy, capture a fresh **cold** HAR, and measure first-load TTFB/throughput. If it's not enough, the documented escalation is moving `/assets/*` to Caddy `file_server` (bigger infra change; see #2842).