### PR TITLE
feat(platform): float mobile page actions in a bottom dock

### DIFF
--- a/services/platform/app/components/layout/content-area.test.tsx
+++ b/services/platform/app/components/layout/content-area.test.tsx
@@ -1,9 +1,12 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
 
 import { ContentArea } from './content-area';
+
+const DOCK_END_PAD =
+  'pb-[calc(var(--content-area-pb)+var(--mobile-floating-actions-pad,0px))]';
 
 describe('ContentArea', () => {
   describe('accessibility', () => {
@@ -24,5 +27,35 @@ describe('ContentArea', () => {
       );
       await checkAccessibility(container);
     });
+  });
+
+  it('keeps floating-dock end clearance even when className sets py-*', () => {
+    const { container } = render(
+      <ContentArea className="mx-auto max-w-3xl px-4 py-4">
+        <p>Agent tab</p>
+      </ContentArea>,
+    );
+    expect(container.firstElementChild).toHaveClass(DOCK_END_PAD);
+  });
+
+  it('sets the page variant content-area pb token', () => {
+    const { container } = render(
+      <ContentArea>
+        <p>Page content</p>
+      </ContentArea>,
+    );
+    expect(container.firstElementChild).toHaveClass(
+      '[--content-area-pb:1.5rem]',
+    );
+    expect(container.firstElementChild).toHaveClass(DOCK_END_PAD);
+  });
+
+  it('sets the narrow variant content-area pb token', () => {
+    const { container } = render(
+      <ContentArea variant="narrow">
+        <p>Narrow content</p>
+      </ContentArea>,
+    );
+    expect(container.firstElementChild).toHaveClass('[--content-area-pb:1rem]');
   });
 });

--- a/services/platform/app/components/layout/content-area.tsx
+++ b/services/platform/app/components/layout/content-area.tsx
@@ -5,26 +5,39 @@ import { forwardRef, type HTMLAttributes } from 'react';
 
 import { cn } from '@/lib/utils/cn';
 
-const contentAreaVariants = cva('flex min-w-0 w-full flex-col', {
-  variants: {
-    variant: {
-      page: 'px-4 py-6',
-      narrow: 'mx-auto max-w-[544px] px-4 py-4',
-      panel: 'px-6 py-4',
+/**
+ * Applied LAST in `cn()` so call-site `py-*` / `pb-*` cannot drop dock
+ * clearance (agent tabs pass `className="… py-4"` which would otherwise
+ * replace the variant bottom padding and hide `--mobile-floating-actions-pad`).
+ *
+ * Base size comes from `--content-area-pb` set per variant.
+ */
+const FLOATING_DOCK_END_PAD =
+  'pb-[calc(var(--content-area-pb)+var(--mobile-floating-actions-pad,0px))]';
+
+const contentAreaVariants = cva(
+  'flex min-w-0 w-full flex-col [--content-area-pb:1.5rem]',
+  {
+    variants: {
+      variant: {
+        page: 'px-4 pt-6 [--content-area-pb:1.5rem]',
+        narrow: 'mx-auto max-w-[544px] px-4 pt-4 [--content-area-pb:1rem]',
+        panel: 'px-6 pt-4 [--content-area-pb:1rem]',
+      },
+      gap: {
+        3: 'gap-3',
+        4: 'gap-4',
+        5: 'gap-5',
+        6: 'gap-6',
+        8: 'gap-8',
+      },
     },
-    gap: {
-      3: 'gap-3',
-      4: 'gap-4',
-      5: 'gap-5',
-      6: 'gap-6',
-      8: 'gap-8',
+    defaultVariants: {
+      variant: 'page',
+      gap: 6,
     },
   },
-  defaultVariants: {
-    variant: 'page',
-    gap: 6,
-  },
-});
+);
 
 interface ContentAreaProps
   extends
@@ -35,7 +48,11 @@ export const ContentArea = forwardRef<HTMLDivElement, ContentAreaProps>(
   ({ variant, gap, className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn(contentAreaVariants({ variant, gap }), className)}
+      className={cn(
+        contentAreaVariants({ variant, gap }),
+        className,
+        FLOATING_DOCK_END_PAD,
+      )}
       {...props}
     />
   ),

--- a/services/platform/app/components/layout/mobile-floating-actions.test.tsx
+++ b/services/platform/app/components/layout/mobile-floating-actions.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { render, screen, waitFor } from '@/tests/utils/render';
+
+import {
+  MOBILE_FLOATING_ACTIONS_PAD,
+  MOBILE_FLOATING_ACTIONS_PAD_VAR,
+  MobileFloatingActions,
+} from './mobile-floating-actions';
+
+afterEach(() => {
+  document.documentElement.style.removeProperty(
+    MOBILE_FLOATING_ACTIONS_PAD_VAR,
+  );
+  document.documentElement.removeAttribute('data-floating-actions-pad-count');
+});
+
+describe('MobileFloatingActions', () => {
+  it('portals a content-width dock to body, bottom-right above the bottom nav', async () => {
+    render(
+      <MobileFloatingActions>
+        <button type="button">Save</button>
+      </MobileFloatingActions>,
+    );
+
+    const save = await screen.findByRole('button', { name: 'Save' });
+    const outer = save.closest('.fixed');
+    expect(outer).not.toBeNull();
+    expect(outer).toHaveClass('fixed', 'right-4', 'w-fit', 'md:hidden');
+    expect(outer?.className).toContain(
+      'bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]',
+    );
+    expect(outer?.className).not.toContain('left-1/2');
+    expect(document.body.contains(outer)).toBe(true);
+
+    const inner = outer?.firstElementChild;
+    expect(inner).toHaveClass('w-fit', 'rounded-xl', 'border', 'shadow-md');
+
+    await waitFor(() => {
+      expect(outer).not.toHaveClass('hidden');
+    });
+  });
+
+  it('sets page bottom-pad while visible and clears it when empty', async () => {
+    const { rerender } = render(
+      <MobileFloatingActions>
+        <button type="button">Save</button>
+      </MobileFloatingActions>,
+    );
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue(
+          MOBILE_FLOATING_ACTIONS_PAD_VAR,
+        ),
+      ).toBe(MOBILE_FLOATING_ACTIONS_PAD);
+    });
+
+    function EmptySlot() {
+      return null;
+    }
+    rerender(
+      <MobileFloatingActions>
+        <EmptySlot />
+      </MobileFloatingActions>,
+    );
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue(
+          MOBILE_FLOATING_ACTIONS_PAD_VAR,
+        ),
+      ).toBe('');
+    });
+  });
+
+  it('hides the dock when children render nothing', async () => {
+    function EmptySlot() {
+      return null;
+    }
+
+    render(
+      <MobileFloatingActions>
+        <EmptySlot />
+      </MobileFloatingActions>,
+    );
+
+    await waitFor(() => {
+      const dock = document.body.querySelector('.fixed.w-fit');
+      expect(dock).not.toBeNull();
+      expect(dock).toHaveClass('hidden');
+      expect(dock).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('renders nothing before mount (SSR-safe)', async () => {
+    const { container } = render(
+      <div data-testid="host">
+        <MobileFloatingActions>
+          <button type="button">Discard</button>
+        </MobileFloatingActions>
+      </div>,
+    );
+    expect(
+      container.querySelector('[data-testid="host"]')?.children,
+    ).toHaveLength(0);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Discard' }),
+      ).toBeInTheDocument();
+      expect(
+        container
+          .querySelector('[data-testid="host"]')
+          ?.contains(screen.getByRole('button', { name: 'Discard' })),
+      ).toBe(false);
+    });
+  });
+});

--- a/services/platform/app/components/layout/mobile-floating-actions.tsx
+++ b/services/platform/app/components/layout/mobile-floating-actions.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/lib/utils/cn';
+
+interface MobileFloatingActionsProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/** CSS custom property consumed by `PageLayout` for bottom scroll clearance. */
+export const MOBILE_FLOATING_ACTIONS_PAD_VAR = '--mobile-floating-actions-pad';
+
+/**
+ * Clears the floating dock (≈3rem) plus a gap so page content can scroll
+ * past it. Applied only while a dock with real actions is visible.
+ */
+export const MOBILE_FLOATING_ACTIONS_PAD = '4.5rem';
+
+const PAD_COUNT_ATTR = 'data-floating-actions-pad-count';
+
+function nodeHasContent(node: HTMLElement): boolean {
+  return (
+    node.childElementCount > 0 || (node.textContent?.trim().length ?? 0) > 0
+  );
+}
+
+function acquirePagePad(): void {
+  const root = document.documentElement;
+  const next = Number(root.getAttribute(PAD_COUNT_ATTR) ?? '0') + 1;
+  root.setAttribute(PAD_COUNT_ATTR, String(next));
+  root.style.setProperty(
+    MOBILE_FLOATING_ACTIONS_PAD_VAR,
+    MOBILE_FLOATING_ACTIONS_PAD,
+  );
+}
+
+function releasePagePad(): void {
+  const root = document.documentElement;
+  const next = Number(root.getAttribute(PAD_COUNT_ATTR) ?? '1') - 1;
+  if (next <= 0) {
+    root.removeAttribute(PAD_COUNT_ATTR);
+    root.style.removeProperty(MOBILE_FLOATING_ACTIONS_PAD_VAR);
+  } else {
+    root.setAttribute(PAD_COUNT_ATTR, String(next));
+  }
+}
+
+/**
+ * Content-width floating dock for page actions on `< md`. Portaled to
+ * `document.body` so `position: fixed` is viewport-relative — callers often
+ * live under `StickyHeader` (`backdrop-blur`), which would otherwise trap
+ * fixed descendants and pin the dock behind the header.
+ *
+ * Sits bottom-right above the in-flow `MobileBottomNav`. Hidden when children
+ * render nothing (slot components still pass a truthy element to the parent).
+ * While visible, sets `--mobile-floating-actions-pad` so `PageLayout` adds
+ * bottom scroll clearance and the dock does not cover page actions.
+ * Callers must single-mount (gate with `useIsMobile`) — never render the same
+ * actions both here and in a desktop header/tab slot.
+ */
+export function MobileFloatingActions({
+  children,
+  className,
+}: MobileFloatingActionsProps) {
+  const [mounted, setMounted] = useState(false);
+  const [hasContent, setHasContent] = useState(false);
+  const innerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return undefined;
+    const node = innerRef.current;
+    if (!node) return undefined;
+
+    const update = () => setHasContent(nodeHasContent(node));
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(node, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    return () => observer.disconnect();
+  }, [mounted, children]);
+
+  useEffect(() => {
+    if (!hasContent) return undefined;
+    acquirePagePad();
+    return () => releasePagePad();
+  }, [hasContent]);
+
+  if (!mounted || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className={cn(
+        'pointer-events-none fixed right-4 z-40 w-fit md:hidden',
+        'bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]',
+        !hasContent && 'hidden',
+        className,
+      )}
+      aria-hidden={!hasContent}
+    >
+      <div
+        ref={innerRef}
+        className="border-border bg-background pointer-events-auto flex w-fit items-center gap-2 rounded-xl border px-3 py-2 shadow-md"
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/services/platform/app/components/layout/page-layout.test.tsx
+++ b/services/platform/app/components/layout/page-layout.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
@@ -31,5 +31,16 @@ describe('PageLayout', () => {
       );
       await checkAccessibility(container);
     });
+  });
+
+  it('does not apply floating-actions pad on the layout shell', () => {
+    const { container } = render(
+      <PageLayout>
+        <p>Page content</p>
+      </PageLayout>,
+    );
+    expect(container.firstElementChild?.className ?? '').not.toContain(
+      '--mobile-floating-actions-pad',
+    );
   });
 });

--- a/services/platform/app/components/layout/page-layout.tsx
+++ b/services/platform/app/components/layout/page-layout.tsx
@@ -33,6 +33,11 @@ export function PageLayout({
       // `scrollbar-gutter: stable` reserves the vertical scrollbar's space so
       // that filtering a list (which can add/remove the scrollbar as the row
       // count changes) doesn't shift the page horizontally.
+      //
+      // Floating-dock end clearance lives on scrollable *content* (`ContentArea`,
+      // inbox list) via `--mobile-floating-actions-pad` — not here. Padding on
+      // this flex shell clips `overflow-hidden` pages and misses `flex-1 min-h-0`
+      // outlets.
       className={cn(
         'flex min-h-0 flex-1 flex-col overflow-auto [scrollbar-gutter:stable]',
         className,

--- a/services/platform/app/components/ui/editor/editor-actions.tsx
+++ b/services/platform/app/components/ui/editor/editor-actions.tsx
@@ -151,11 +151,7 @@ export function EditorActions({
 
   return (
     <div
-      className={cn(
-        'ml-auto sticky right-0 z-10 flex items-center gap-2 bg-background/95 pl-3',
-        'before:pointer-events-none before:absolute before:-left-6 before:top-0 before:h-full before:w-6 before:bg-gradient-to-r before:from-transparent before:to-background/95',
-        className,
-      )}
+      className={cn('flex items-center gap-2', className)}
       aria-live="polite"
     >
       {history}

--- a/services/platform/app/components/ui/navigation/tab-navigation.test.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.test.tsx
@@ -38,11 +38,19 @@ vi.mock('@/app/hooks/use-resize-observer', () => ({
   useResizeObserver: vi.fn(),
 }));
 
+const isMobileState = { value: false };
+vi.mock('@/app/hooks/use-is-mobile', () => ({
+  useIsMobile: () => isMobileState.value,
+}));
+
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({ t: (key: string) => key }),
 }));
 
 describe('TabNavigation', () => {
+  beforeEach(() => {
+    isMobileState.value = false;
+  });
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(
@@ -251,6 +259,21 @@ describe('TabNavigation', () => {
       ).toBeInTheDocument();
     });
 
+    it('contains the absolute measure row so it cannot widen PageLayout', () => {
+      // Regression: the invisible width-twin row is position:absolute and
+      // wider than the viewport. Without overflow-x-hidden on the <nav>, it
+      // inflates an ancestor `overflow-auto` scrollport and a horizontal
+      // swipe shifts the whole project shell — even when page content fits.
+      render(
+        <TabNavigation
+          ariaLabel="Project navigation"
+          items={items}
+          overflow="menu"
+        />,
+      );
+      expect(screen.getByRole('navigation')).toHaveClass('overflow-x-hidden');
+    });
+
     it('renders every tab inline (no More trigger) when the row fits', () => {
       // Two tabs: 120 + 16 + 120 = 256 ≤ 300 — nothing to fold.
       render(
@@ -264,6 +287,45 @@ describe('TabNavigation', () => {
       expect(
         screen.queryByRole('button', { name: 'aria.moreTabs' }),
       ).toBeNull();
+    });
+  });
+
+  describe('trailing children placement', () => {
+    const items = [
+      { label: 'General', href: '/dashboard/test-org/settings' },
+      { label: 'Branding', href: '/dashboard/test-org/settings/branding' },
+    ];
+
+    it('keeps children in the desktop trailing slot', () => {
+      isMobileState.value = false;
+      const { container } = render(
+        <TabNavigation ariaLabel="Settings navigation" items={items}>
+          <button type="button">Save</button>
+        </TabNavigation>,
+      );
+      const nav = screen.getByRole('navigation', {
+        name: 'Settings navigation',
+      });
+      expect(nav).toContainElement(
+        screen.getByRole('button', { name: 'Save' }),
+      );
+      expect(container.querySelector('.fixed.w-fit')).toBeNull();
+    });
+
+    it('moves children into the floating dock on mobile', async () => {
+      isMobileState.value = true;
+      render(
+        <TabNavigation ariaLabel="Settings navigation" items={items}>
+          <button type="button">Save</button>
+        </TabNavigation>,
+      );
+      const nav = screen.getByRole('navigation', {
+        name: 'Settings navigation',
+      });
+      const save = await screen.findByRole('button', { name: 'Save' });
+      expect(nav).not.toContainElement(save);
+      expect(save.closest('.fixed')).toHaveClass('right-4', 'w-fit');
+      expect(document.body.contains(save)).toBe(true);
     });
   });
 });

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -14,7 +14,9 @@ import {
 } from 'react';
 
 import { useBrandingContext } from '@/app/components/branding/branding-provider';
+import { MobileFloatingActions } from '@/app/components/layout/mobile-floating-actions';
 import { useAbility } from '@/app/hooks/use-ability';
+import { useIsMobile } from '@/app/hooks/use-is-mobile';
 import { useResizeObserver } from '@/app/hooks/use-resize-observer';
 import { useT } from '@/lib/i18n/client';
 import { type AppAction, type AppSubject } from '@/lib/permissions/ability';
@@ -107,6 +109,10 @@ export function TabNavigation({
   const ability = useAbility();
   const { accentColor } = useBrandingContext();
   const { t: tCommon } = useT('common');
+  // On `< md`, trailing actions move to a floating dock so they no longer
+  // pin over the scrolling tabs. Desktop keeps the trailing slot. Single
+  // mount either way — never render Save twice.
+  const isMobile = useIsMobile();
   // The horizontally-scrolling tab list. Kept separate from the outer <nav> so
   // the trailing button group can sit outside the scroll area and stay pinned
   // to the right while only the tabs scroll. All measurement/scroll logic reads
@@ -455,180 +461,192 @@ export function TabNavigation({
     );
 
   return (
-    <nav
-      ref={navRef}
-      className={cn(
-        // A single fixed height for EVERY tab strip — list and detail alike.
-        // `min-h-13` (52px) clamps both a bare tab row and one carrying the
-        // taller `h-8` editor actions (Save/Discard/History) to the same height,
-        // which plain `py-3` can't do (the taller content would win). It also
-        // matches the breadcrumb header (`h-13`). `page-action-header` mirrors
-        // this so moving between tabbed and non-tabbed pages doesn't bounce.
-        'relative border-b border-border min-h-13 flex items-stretch shrink-0',
-        standalone && 'bg-background z-10',
-        className,
-      )}
-      aria-label={ariaLabel}
-    >
-      <div
-        ref={scrollRef}
-        className="scrollbar-hide relative flex min-w-0 flex-1 items-center gap-4 overflow-x-auto px-4"
+    <>
+      <nav
+        ref={navRef}
+        className={cn(
+          // A single fixed height for EVERY tab strip — list and detail alike.
+          // `min-h-13` (52px) clamps both a bare tab row and one carrying the
+          // taller `h-8` editor actions (Save/Discard/History) to the same height,
+          // which plain `py-3` can't do (the taller content would win). It also
+          // matches the breadcrumb header (`h-13`). `page-action-header` mirrors
+          // this so moving between tabbed and non-tabbed pages doesn't bounce.
+          //
+          // `overflow-x-hidden` contains the absolute `overflow="menu"` measure
+          // row. That twin is `invisible` but still contributes to ancestor
+          // scrollable overflow; without this, PageLayout (`overflow-auto`)
+          // gains a phantom horizontal scrollbar and a trackpad swipe shifts
+          // the whole project shell sideways even though page content fits.
+          'relative overflow-x-hidden border-b border-border min-h-13 flex items-stretch shrink-0',
+          standalone && 'bg-background z-10',
+          className,
+        )}
+        aria-label={ariaLabel}
       >
-        {visibleItems.map((item, index) => {
-          const isActive = isPathActive(item);
-          const [path, queryString] = item.href.split('?');
-          const hrefSearch = queryString
-            ? Object.fromEntries(new URLSearchParams(queryString))
-            : undefined;
-          const isItemDirty =
-            dirtyKeys !== undefined &&
-            (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false);
+        <div
+          ref={scrollRef}
+          className="scrollbar-hide relative flex min-w-0 flex-1 items-center gap-4 overflow-x-auto px-4"
+        >
+          {visibleItems.map((item, index) => {
+            const isActive = isPathActive(item);
+            const [path, queryString] = item.href.split('?');
+            const hrefSearch = queryString
+              ? Object.fromEntries(new URLSearchParams(queryString))
+              : undefined;
+            const isItemDirty =
+              dirtyKeys !== undefined &&
+              (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false);
 
-          return (
-            <Link
-              // Search-param tab strips share one pathname across items, so
-              // the href alone is not unique — the label disambiguates.
-              key={`${item.href}|${item.label}`}
-              ref={(el) => {
-                itemRefs.current[index] = el;
-              }}
-              to={path}
-              search={item.search ?? hrefSearch}
-              preload={prefetch ? 'render' : false}
-              aria-current={isActive ? 'page' : undefined}
-              className={cn(
-                'relative flex h-full shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm py-1 text-sm font-medium transition-colors outline-none focus-visible:outline-none',
-                isActive
-                  ? 'text-foreground'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              {isItemDirty && (
-                <>
-                  <span
-                    aria-hidden="true"
-                    className="inline-block size-1.5 rounded-full bg-amber-500"
-                  />
-                  {/* The dot alone is decorative (aria-hidden) — this is its
-                      text twin, so screen-reader users still hear that the
-                      tab carries unsaved changes. The trailing `{' '}`
-                      keeps it a separate word from the label that follows
-                      (adjacent JSX text nodes concatenate with no space). */}
-                  <span className="sr-only">
-                    {tCommon('aria.unsavedChanges')}
-                  </span>{' '}
-                </>
-              )}
-              {item.label}
-              {item.trailing}
-            </Link>
-          );
-        })}
-        {overflowItems.length > 0 && (
-          <DropdownMenu
-            align="end"
-            items={overflowMenuItems}
-            trigger={
-              <button
-                ref={moreTriggerRef}
-                type="button"
-                aria-label={tCommon('aria.moreTabs')}
+            return (
+              <Link
+                // Search-param tab strips share one pathname across items, so
+                // the href alone is not unique — the label disambiguates.
+                key={`${item.href}|${item.label}`}
+                ref={(el) => {
+                  itemRefs.current[index] = el;
+                }}
+                to={path}
+                search={item.search ?? hrefSearch}
+                preload={prefetch ? 'render' : false}
+                aria-current={isActive ? 'page' : undefined}
                 className={cn(
-                  'relative flex h-full shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-sm py-1 text-sm font-medium transition-colors outline-none focus-visible:outline-none',
-                  activeInOverflow
+                  'relative flex h-full shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm py-1 text-sm font-medium transition-colors outline-none focus-visible:outline-none',
+                  isActive
                     ? 'text-foreground'
                     : 'text-muted-foreground hover:text-foreground',
                 )}
               >
-                {overflowHasDirty && (
+                {isItemDirty && (
                   <>
                     <span
                       aria-hidden="true"
                       className="inline-block size-1.5 rounded-full bg-amber-500"
                     />
+                    {/* The dot alone is decorative (aria-hidden) — this is its
+                      text twin, so screen-reader users still hear that the
+                      tab carries unsaved changes. The trailing `{' '}`
+                      keeps it a separate word from the label that follows
+                      (adjacent JSX text nodes concatenate with no space). */}
                     <span className="sr-only">
                       {tCommon('aria.unsavedChanges')}
                     </span>{' '}
                   </>
                 )}
-                {tCommon('moreTabs')}
-                <ChevronDown aria-hidden="true" className="size-4" />
-              </button>
-            }
-          />
-        )}
-      </div>
+                {item.label}
+                {item.trailing}
+              </Link>
+            );
+          })}
+          {overflowItems.length > 0 && (
+            <DropdownMenu
+              align="end"
+              items={overflowMenuItems}
+              trigger={
+                <button
+                  ref={moreTriggerRef}
+                  type="button"
+                  aria-label={tCommon('aria.moreTabs')}
+                  className={cn(
+                    'relative flex h-full shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-sm py-1 text-sm font-medium transition-colors outline-none focus-visible:outline-none',
+                    activeInOverflow
+                      ? 'text-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {overflowHasDirty && (
+                    <>
+                      <span
+                        aria-hidden="true"
+                        className="inline-block size-1.5 rounded-full bg-amber-500"
+                      />
+                      <span className="sr-only">
+                        {tCommon('aria.unsavedChanges')}
+                      </span>{' '}
+                    </>
+                  )}
+                  {tCommon('moreTabs')}
+                  <ChevronDown aria-hidden="true" className="size-4" />
+                </button>
+              }
+            />
+          )}
+        </div>
 
-      {/* Width twin of every tab (+ the More trigger, last) for the `menu`
+        {/* Width twin of every tab (+ the More trigger, last) for the `menu`
           overflow clamp. Clamped-away tabs unmount from the real row, so this
           hidden copy is the only place their widths stay measurable. Same
           typography/gap classes as the live row so the twin widths hold. */}
-      {isMenuOverflow && (
-        <div
-          ref={measureRowRef}
-          aria-hidden="true"
-          className="pointer-events-none invisible absolute top-0 left-0 flex items-center gap-4 whitespace-nowrap"
-        >
-          {accessibleItems.map((item) => (
-            <span
-              key={`${item.href}|${item.label}`}
-              className="flex items-center gap-1.5 py-1 text-sm font-medium"
-            >
-              {dirtyKeys !== undefined &&
-                (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false) && (
-                  <span className="inline-block size-1.5 rounded-full" />
-                )}
-              {item.label}
-              {item.trailing}
+        {isMenuOverflow && (
+          <div
+            ref={measureRowRef}
+            aria-hidden="true"
+            className="pointer-events-none invisible absolute top-0 left-0 flex items-center gap-4 whitespace-nowrap"
+          >
+            {accessibleItems.map((item) => (
+              <span
+                key={`${item.href}|${item.label}`}
+                className="flex items-center gap-1.5 py-1 text-sm font-medium"
+              >
+                {dirtyKeys !== undefined &&
+                  (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false) && (
+                    <span className="inline-block size-1.5 rounded-full" />
+                  )}
+                {item.label}
+                {item.trailing}
+              </span>
+            ))}
+            <span className="flex items-center gap-1 py-1 text-sm font-medium">
+              {tCommon('moreTabs')}
+              <ChevronDown className="size-4" />
             </span>
-          ))}
-          <span className="flex items-center gap-1 py-1 text-sm font-medium">
-            {tCommon('moreTabs')}
-            <ChevronDown className="size-4" />
-          </span>
-        </div>
-      )}
+          </div>
+        )}
 
-      {/* Animated active indicator. Rendered as a child of the <nav> rather than
+        {/* Animated active indicator. Rendered as a child of the <nav> rather than
           the scroll container so it can sit flush on the nav's bottom border:
           the scroll container is `overflow-x: auto` (which forces `overflow-y`
           to clip too), so a child anchored to `bottom-0` there floats above the
           border by the nav's bottom padding. Its position is measured in JS
           relative to the nav and re-synced on scroll. */}
-      {activeIndex !== -1 && (
-        <div
-          ref={indicatorRef}
-          aria-hidden="true"
-          className={cn(
-            'pointer-events-none absolute bottom-0 h-0.5',
-            !accentColor && 'bg-foreground',
-            shouldAnimate &&
-              'transition-all duration-200 ease-out motion-reduce:transition-none',
-          )}
-          style={{
-            width: `${indicatorStyle.width}px`,
-            left: `${indicatorStyle.left}px`,
-            backgroundColor: accentColor || undefined,
-          }}
-        />
-      )}
+        {activeIndex !== -1 && (
+          <div
+            ref={indicatorRef}
+            aria-hidden="true"
+            className={cn(
+              'pointer-events-none absolute bottom-0 h-0.5',
+              !accentColor && 'bg-foreground',
+              shouldAnimate &&
+                'transition-all duration-200 ease-out motion-reduce:transition-none',
+            )}
+            style={{
+              width: `${indicatorStyle.width}px`,
+              left: `${indicatorStyle.left}px`,
+              backgroundColor: accentColor || undefined,
+            }}
+          />
+        )}
 
-      {/* Trailing action group — pinned to the right, outside the scroll area,
-          so it stays in view while the tabs scroll under it. The left shadow +
-          background fade make the scrolling tabs visibly slide beneath it —
-          shown ONLY when the strip actually overflows, else it reads as a stray
-          shadow floating beside the buttons on a wide viewport. */}
-      {children && (
-        <div
-          className={cn(
-            'bg-background relative z-[1] flex shrink-0 items-center gap-2 self-stretch pr-4 pl-3',
-            isScrollable &&
-              'shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.18)] dark:shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.6)]',
-          )}
-        >
-          {children}
-        </div>
+        {/* Trailing action group — desktop only. Pinned to the right, outside the
+          scroll area, so it stays in view while the tabs scroll under it. The
+          left shadow + background fade make the scrolling tabs visibly slide
+          beneath it — shown ONLY when the strip actually overflows, else it
+          reads as a stray shadow floating beside the buttons on a wide
+          viewport. On mobile, the same children float above the bottom nav. */}
+        {children && !isMobile && (
+          <div
+            className={cn(
+              'bg-background relative z-[1] flex shrink-0 items-center gap-2 self-stretch pr-4 pl-3',
+              isScrollable &&
+                'shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.18)] dark:shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.6)]',
+            )}
+          >
+            {children}
+          </div>
+        )}
+      </nav>
+      {children && isMobile && (
+        <MobileFloatingActions>{children}</MobileFloatingActions>
       )}
-    </nav>
+    </>
   );
 }

--- a/services/platform/app/features/agents/components/agent-tab-content.tsx
+++ b/services/platform/app/features/agents/components/agent-tab-content.tsx
@@ -13,7 +13,7 @@ import { ContentArea } from '@/app/components/layout/content-area';
  */
 export function AgentTabContent({ children }: { children: ReactNode }) {
   return (
-    <ContentArea gap={6} className="mx-auto max-w-3xl px-4 py-4">
+    <ContentArea gap={6} className="mx-auto max-w-3xl px-4 pt-4">
       {children}
     </ContentArea>
   );

--- a/services/platform/app/features/automations/components/automation-page.tsx
+++ b/services/platform/app/features/automations/components/automation-page.tsx
@@ -327,6 +327,7 @@ function ReadinessSection({
  */
 function AutomationEditorActionsSlot({ trailing }: { trailing: ReactNode }) {
   const controller = useActiveEditor();
+  if (!controller && !trailing) return null;
   if (!controller) {
     return (
       <Row gap={2} className="ml-auto">

--- a/services/platform/app/features/conversations/components/conversation-list-panel.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-list-panel.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+import { ConversationListPanel } from './conversation-list-panel';
+
+describe('ConversationListPanel', () => {
+  it('reserves floating-dock clearance on the list scroller', () => {
+    const { container } = render(
+      <ConversationListPanel>
+        <p>Conversation</p>
+      </ConversationListPanel>,
+    );
+    const scroller = container.querySelector('.overflow-y-auto');
+    expect(scroller).toHaveClass(
+      'pb-[length:var(--mobile-floating-actions-pad,0px)]',
+    );
+  });
+});

--- a/services/platform/app/features/conversations/components/conversation-list-panel.tsx
+++ b/services/platform/app/features/conversations/components/conversation-list-panel.tsx
@@ -21,7 +21,10 @@ export function ConversationListPanel({
         hidden ? 'hidden md:flex' : 'flex',
       )}
     >
-      <Stack gap={0} className="min-h-0 flex-1 overflow-y-auto">
+      <Stack
+        gap={0}
+        className="min-h-0 flex-1 overflow-y-auto pb-[length:var(--mobile-floating-actions-pad,0px)]"
+      >
         {children}
       </Stack>
       {overlay}

--- a/services/platform/app/features/settings/governance/components/system-prompt-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/system-prompt-editor.test.tsx
@@ -73,8 +73,13 @@ describe('SystemPromptEditor', () => {
       const form = container.querySelector('form');
       expect(form).not.toBeNull();
       expect(form?.querySelector('.max-w-2xl')).toBeNull();
+      // The cluster is right-aligned by its `HStack justify="end"` wrapper
+      // (EditorActions no longer carries its own `ml-auto`), so Save/Discard
+      // still sit at the section's right edge — level with Add rule.
       expect(
-        screen.getByRole('button', { name: /discard/i }).closest('.ml-auto'),
+        screen
+          .getByRole('button', { name: /discard/i })
+          .closest('.justify-end'),
       ).not.toBeNull();
     });
   });

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -111,7 +111,7 @@ function AgentDetailLayout() {
   if (!isLoading && (loadFailed || !agentConfig)) {
     return (
       <PageLayout>
-        <ContentArea className="mx-auto max-w-3xl px-4 py-6">
+        <ContentArea className="mx-auto max-w-3xl px-4 pt-6">
           <Text variant="muted">{t('agents.agentNotFound')}</Text>
         </ContentArea>
       </PageLayout>
@@ -255,7 +255,7 @@ function AgentDetailLayout() {
       >
         <Skeletonize loading label={t('agents.title')}>
           {/* Same width as the loaded tabs (#2567) so the swap doesn't jump. */}
-          <ContentArea className="mx-auto max-w-3xl px-4 py-4">
+          <ContentArea className="mx-auto max-w-3xl px-4 pt-4">
             <Stack gap={6}>
               <Stack gap={1}>
                 <SkeletonText lines={1} />

--- a/services/platform/app/routes/dashboard/$id/settings.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings.tsx
@@ -7,6 +7,7 @@ import {
   AdaptiveHeaderTitle,
 } from '@/app/components/layout/adaptive-header';
 import { ContentArea } from '@/app/components/layout/content-area';
+import { MobileFloatingActions } from '@/app/components/layout/mobile-floating-actions';
 import { PageLayout } from '@/app/components/layout/page-layout';
 import {
   ActiveEditorProvider,
@@ -21,6 +22,7 @@ import {
   useSettingsHeaderActions,
   type SettingsHeaderAction,
 } from '@/app/features/settings/components/settings-secondary-action-context';
+import { useIsMobile } from '@/app/hooks/use-is-mobile';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { seo } from '@/lib/utils/seo';
@@ -60,7 +62,11 @@ function SettingsLayout() {
           <PageLayout
             organizationId={organizationId}
             header={
-              <AdaptiveHeaderRoot showBorder standalone={false}>
+              <AdaptiveHeaderRoot
+                showBorder
+                standalone={false}
+                className="gap-1"
+              >
                 <SettingsMobileBackButton organizationId={organizationId} />
                 <AdaptiveHeaderTitle>{headerTitle}</AdaptiveHeaderTitle>
                 <SettingsEditorActionsSlot />
@@ -108,15 +114,18 @@ function HeaderActionButton({ action }: { action: SettingsHeaderAction }) {
  * Renders the unified Save/Discard cluster (from `useActiveEditor`) plus any
  * page-specific buttons registered via `useRegisterSettingsSecondaryAction`.
  * Data residency uses the latter exclusively: [Save] [Apply & restart].
+ * Desktop only — mobile uses `SettingsMobileActionBar` (single mount).
  */
 function SettingsEditorActionsSlot() {
   const controller = useActiveEditor();
   const actions = useSettingsHeaderActions();
+  const isMobile = useIsMobile();
 
+  if (isMobile) return null;
   if (!controller && actions.length === 0) return null;
 
   return (
-    <div className="ml-auto hidden items-center gap-2 md:flex">
+    <div className="ml-auto flex items-center gap-2">
       {controller && (
         <EditorActions controller={controller} entityKind="settings" />
       )}
@@ -128,22 +137,25 @@ function SettingsEditorActionsSlot() {
 }
 
 /**
- * Mobile-only bar — mirrors `SettingsEditorActionsSlot` for small screens.
+ * Mobile-only floating dock — mirrors `SettingsEditorActionsSlot` for small
+ * screens so Save/Discard no longer sit under the header and crowd the page.
  */
 function SettingsMobileActionBar() {
   const controller = useActiveEditor();
   const actions = useSettingsHeaderActions();
+  const isMobile = useIsMobile();
 
+  if (!isMobile) return null;
   if (!controller && actions.length === 0) return null;
 
   return (
-    <div className="border-border flex items-center justify-end gap-2 border-b px-4 py-2 md:hidden">
+    <MobileFloatingActions>
       {controller && (
         <EditorActions controller={controller} entityKind="settings" />
       )}
       {actions.map((action) => (
         <HeaderActionButton key={action.label} action={action} />
       ))}
-    </div>
+    </MobileFloatingActions>
   );
 }

--- a/services/platform/tests/e2e/specs/responsive.spec.ts
+++ b/services/platform/tests/e2e/specs/responsive.spec.ts
@@ -13,11 +13,12 @@ import { t } from '../helpers/i18n';
  *
  * The app's responsive split is the Tailwind `md` breakpoint (768px): desktop
  * chrome is `hidden md:flex` (side rail, settings desktop Save slot); mobile
- * chrome is `md:hidden` (the in-flow `BottomTabBar`, the settings mobile Save
- * bar). There is NO hamburger drawer — primary nav is the bottom tab bar, and a
- * trailing "More" tab opens a bottom `Sheet` (Radix dialog named "More") with
- * the overflow destinations. The settings test makes a throwaway dirty edit to
- * reveal the mobile Save bar, then reloads to discard it (nothing persists).
+ * chrome is `md:hidden` (the in-flow `BottomTabBar`, the content-width floating
+ * Save dock above it). There is NO hamburger drawer — primary nav is the bottom
+ * tab bar, and a trailing "More" tab opens a bottom `Sheet` (Radix dialog named
+ * "More") with the overflow destinations. The settings test makes a throwaway
+ * dirty edit to reveal the floating Save, then reloads to discard it (nothing
+ * persists).
  */
 
 // Phone viewport — OVERRIDES the project's Desktop Chrome viewport for this file
@@ -25,10 +26,8 @@ import { t } from '../helpers/i18n';
 test.use({ viewport: { width: 390, height: 844 } });
 
 /**
- * The settings Save cluster renders TWICE (mobile bar `md:hidden`, desktop slot
- * `hidden md:flex`), both mounting only once an editor is dirty. At `< md` the
- * only one that can be visible is the mobile bar, so the visible-filtered Save
- * button is unambiguously the mobile variant.
+ * Settings mounts Save once via `useIsMobile`: the floating dock on `< md`, the
+ * header slot on `md+`. At phone width the visible Save is the floating dock.
  */
 function visibleSaveButton(page: Page) {
   return page
@@ -80,7 +79,7 @@ test.describe('responsive / mobile layout', () => {
     await expect(moreSheet).toBeHidden({ timeout: TIMEOUT.VISIBLE });
   });
 
-  test('settings: the mobile Save bar is the visible Save cluster', async ({
+  test('settings: the floating Save dock is the visible Save cluster', async ({
     page,
     org,
   }) => {
@@ -105,23 +104,19 @@ test.describe('responsive / mobile layout', () => {
     await expect(nameField).toBeVisible({ timeout: TIMEOUT.FIRST_PAINT });
     await expect(nameField).toBeEnabled();
 
-    // The Save cluster is always mounted (`EditorActions` renders whenever an
-    // editor is registered); it's just *disabled* until the editor is dirty. At
-    // `< md` only the mobile bar is in the a11y tree — the desktop cluster is
-    // `hidden md:flex` (display:none, excluded) — so exactly one Save button
-    // exists, and while clean it's the visible-but-disabled mobile variant.
+    // Save mounts once (`useIsMobile` gates floating vs header). While clean
+    // it's the visible-but-disabled floating dock above the bottom tab bar.
     const save = visibleSaveButton(page);
     await expect(save).toHaveCount(1, { timeout: TIMEOUT.VISIBLE });
     await expect(save).toBeVisible();
     await expect(save).toBeDisabled();
 
-    // A throwaway dirty edit enables the mobile Save. NOTHING is saved.
+    // A throwaway dirty edit enables the floating Save. NOTHING is saved.
     const originalName = await nameField.inputValue();
     await nameField.fill(`${originalName} (responsive-probe)`);
     await expect(save).toBeEnabled({ timeout: TIMEOUT.VISIBLE });
 
-    // Still exactly one Save button at `< md` (desktop cluster stays
-    // display:none, so it never enters the accessibility tree).
+    // Still exactly one Save button at `< md` (header slot is unmounted).
     await expect(
       page.getByRole('button', { name: t('common.actions.save'), exact: true }),
     ).toHaveCount(1);

--- a/services/platform/tests/manual/responsive.md
+++ b/services/platform/tests/manual/responsive.md
@@ -1,20 +1,22 @@
 # Responsive — Manual Test Plan (cross-cutting)
 
 > **Purpose**: Verify the app adapts across viewports — the mobile in-flow
-> bottom tab bar, the **More** overflow sheet, the mobile Save cluster, and that
-> no key surface overflows horizontally at phone width. This is a cross-cutting
-> guide: it re-walks surfaces other guides own (chat, a DataTable page, a
-> settings form) at a narrow viewport rather than testing a single feature.
+> bottom tab bar, the **More** overflow sheet, the mobile floating Save
+> cluster, and that no key surface overflows horizontally at phone width. This
+> is a cross-cutting guide: it re-walks surfaces other guides own (chat, a
+> DataTable page, a settings form) at a narrow viewport rather than testing a
+> single feature.
 
 ## Scope & routes
 
 The responsive split is the Tailwind **`md` breakpoint (768 px)**. Desktop chrome
 is `hidden md:flex` (the side rail, the desktop Save slot); mobile chrome is
-`md:hidden` (the in-flow `BottomTabBar`, the mobile Save bar). **`< md` (≤ 767 px)
-is the mobile layout; ≥ 768 px is the full desktop layout** — at exactly 768 px
-the desktop chrome is already active (there is no separate "tablet" layout). There
-is **no hamburger drawer**: primary nav is the bottom tab bar, and a trailing
-**More** tab opens a bottom `Sheet` with the overflow destinations.
+`md:hidden` (the in-flow `BottomTabBar`, the content-width floating Save dock
+bottom-right above it). **`< md` (≤ 767 px) is the mobile layout; ≥ 768 px is the full
+desktop layout** — at exactly 768 px the desktop chrome is already active
+(there is no separate "tablet" layout). There is **no hamburger drawer**:
+primary nav is the bottom tab bar, and a trailing **More** tab opens a bottom
+`Sheet` with the overflow destinations.
 
 Test at three widths — **390×844** (mobile, matches `responsive.spec.ts`),
 **767×1024** (just below the breakpoint — still mobile), **1280×800** (desktop).
@@ -26,7 +28,7 @@ Drive the width with the Playwright MCP `browser_resize` (or a context `viewport
 | Projects (primary tab)                | `/dashboard/{org}/projects`                         |
 | Agents (primary tab, gated)           | `/dashboard/{org}/agents`                           |
 | Knowledge / Documents (More overflow) | `/dashboard/{org}/documents`                        |
-| Settings → Account (Save bar + More)  | `/dashboard/{org}/settings/account`                 |
+| Settings → Account (floating Save)    | `/dashboard/{org}/settings/account`                 |
 | Contacts (DataTable page)             | `/dashboard/{org}/contacts`                         |
 | Products (DataTable page)             | `/dashboard/{org}/products`                         |
 | Discussions (project tab)             | `/dashboard/{org}/projects/{projectId}/discussions` |
@@ -34,9 +36,10 @@ Drive the width with the Playwright MCP `browser_resize` (or a context `viewport
 ## Prerequisites
 
 Bring the stack up and sign in per [SETUP.md](SETUP.md). Any seeded org works
-(read-only for nav/overflow/no-overflow checks). The mobile Save-bar case (F3)
-makes a **throwaway dirty edit and discards it via reload** — nothing persists —
-so a shared org is safe; mint your own only if you want to keep a write.
+(read-only for nav/overflow/no-overflow checks). The mobile floating-Save case
+(F3) makes a **throwaway dirty edit and discards it via reload** — nothing
+persists — so a shared org is safe; mint your own only if you want to keep a
+write.
 
 > **Agent note**: set the viewport to **390×844** _before_ the first `goto`, so
 > the shell mounts at mobile width. The mobile primary-nav landmark is the
@@ -50,33 +53,33 @@ so a shared org is safe; mint your own only if you want to keep a write.
 
 ## Automated coverage
 
-| Case(s)          | Status         | e2e spec                                                                               |
-| ---------------- | -------------- | -------------------------------------------------------------------------------------- |
-| F1, F2           | ✅ automated   | `responsive.spec.ts` (app-shell: rail hidden, tab bar + More sheet)                    |
-| F3               | ✅ automated   | `responsive.spec.ts` (mobile Save bar: 1 visible Save, dirty→enabled, reload-discard)  |
-| F4               | 🔶 partial     | `responsive.spec.ts` (chat input renders + enabled at mobile; **no send / no attach**) |
-| F5               | 🔶 partial     | `responsive.spec.ts` (contacts list usable at mobile; **no row/stack assertions**)     |
-| F6, F7           | ⛔ manual-only | —                                                                                      |
-| F8, F9           | ⛔ manual-only | — (F8 needs one discussion created; F9 needs canvas content, mode B)                   |
-| B1–B3, A1–A3, P1 | ⛔ manual-only | —                                                                                      |
+| Case(s)          | Status         | e2e spec                                                                                 |
+| ---------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| F1, F2           | ✅ automated   | `responsive.spec.ts` (app-shell: rail hidden, tab bar + More sheet)                      |
+| F3               | ✅ automated   | `responsive.spec.ts` (floating Save dock: 1 visible Save, dirty→enabled, reload-discard) |
+| F4               | 🔶 partial     | `responsive.spec.ts` (chat input renders + enabled at mobile; **no send / no attach**)   |
+| F5               | 🔶 partial     | `responsive.spec.ts` (contacts list usable at mobile; **no row/stack assertions**)       |
+| F6, F7           | ⛔ manual-only | —                                                                                        |
+| F8, F9           | ⛔ manual-only | — (F8 needs one discussion created; F9 needs canvas content, mode B)                     |
+| B1–B3, A1–A3, P1 | ⛔ manual-only | —                                                                                        |
 
 Legend: ✅ fully automated · 🔶 partially automated · ⛔ manual-only (no spec).
 `responsive.spec.ts` runs the worker owner at viewport `390×844` and has 4 tests
-(app shell, Save bar, chat input, contacts list).
+(app shell, floating Save, chat input, contacts list).
 
 ## Functional tests
 
-| ID  | Test            | Steps (route + control)                                                                                                                              | Expected (verifiable)                                                                                                                                                                                                                                                                                                  |
-| --- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| F1  | Bottom tab bar  | At 390 px, open `/dashboard/{org}/chat`                                                                                                              | The `navigation` "Primary navigation" (`navigation.aria.primaryNavigation`) is **visible**; the "Main navigation" rail (`common.aria.mainNavigation`) is **hidden**. The bar shows tabs **Projects** (`projects.title`), **Chat** (`navigation.chat`), **Agents** (`navigation.agents`), **More** (`navigation.more`). |
-| F2  | More sheet      | Tap **More** (`navigation.more`) in the bottom bar                                                                                                   | A `dialog` named **More** (`navigation.more`) opens with buttons **Knowledge** (`navigation.knowledge`), **Settings** (`navigation.userSettings`). Pressing **Escape** hides the dialog. Tapping an item navigates and closes the sheet.                                                                               |
-| F3  | Mobile Save bar | At 390 px, open `/dashboard/{org}/settings/account`; edit **Display name** (`settings.account.profile.name`)                                         | Exactly **one** visible **Save** button (`common.actions.save`) exists (the mobile bar; the desktop slot is `display:none`). It is **disabled while clean**, becomes **enabled after the edit**. Reload → the field rehydrates to the **original value** (the probe edit did not persist).                             |
-| F4  | Chat input      | At 390 px, open `/dashboard/{org}/chat`                                                                                                              | The chat input textbox **Message input** (`chat.aria.chatInput`) is **visible and enabled**. (Optional manual extension: type `hello`, click **Send message** (`chat.send`), assert it re-enables; attach a file via the chat input.)                                                                                  |
-| F5  | DataTable page  | At 390 px, open `/dashboard/{org}/contacts`                                                                                                          | The page settles into either the **Import contacts** button (`contacts.importMenu.importContacts`) **or** the empty state **No contacts yet** (`emptyStates.contacts.title`) — both prove the table chrome rendered. No action is clipped off-screen.                                                                  |
-| F6  | Dialog / sheet  | At 390 px, open a create dialog (e.g. **New project** on `/dashboard/{org}/projects`)                                                                | The dialog/sheet renders within the viewport; its primary action button is visible and reachable without horizontal scroll.                                                                                                                                                                                            |
-| F7  | No overflow     | At 390 px, on chat, settings/account, and contacts, read `documentElement.scrollWidth`                                                               | `scrollWidth === clientWidth` (== 390) on each page — no horizontal scrollbar, nothing off-canvas.                                                                                                                                                                                                                     |
-| F8  | Discussions     | Mode A, needs one discussion created: at 390×844, open `/dashboard/{org}/projects/{projectId}/discussions` and tap the discussion to open its thread | The reply box with the placeholder **"Reply… use @ to mention a teammate or agent"** (`discussions.reply.placeholder`) is **visible and enabled**; `document.documentElement.scrollWidth === clientWidth` (no horizontal overflow).                                                                                    |
-| F9  | Workspace panel | Mode B — canvas content needed: at 390×844, open a chat thread that produced canvas files → tap **Open canvas** (`chat.canvas.stripOpen`)            | The **Canvas** panel (`chat.canvas.title`) opens **within the viewport** with a reachable close/back control; no horizontal overflow. Presentation at `< md` is unverified — **record whether it presents as a sheet or a split view** (check live).                                                                   |
+| ID  | Test            | Steps (route + control)                                                                                                                              | Expected (verifiable)                                                                                                                                                                                                                                                                                                                               |
+| --- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | Bottom tab bar  | At 390 px, open `/dashboard/{org}/chat`                                                                                                              | The `navigation` "Primary navigation" (`navigation.aria.primaryNavigation`) is **visible**; the "Main navigation" rail (`common.aria.mainNavigation`) is **hidden**. The bar shows tabs **Projects** (`projects.title`), **Chat** (`navigation.chat`), **Agents** (`navigation.agents`), **More** (`navigation.more`).                              |
+| F2  | More sheet      | Tap **More** (`navigation.more`) in the bottom bar                                                                                                   | A `dialog` named **More** (`navigation.more`) opens with buttons **Knowledge** (`navigation.knowledge`), **Settings** (`navigation.userSettings`). Pressing **Escape** hides the dialog. Tapping an item navigates and closes the sheet.                                                                                                            |
+| F3  | Floating Save   | At 390 px, open `/dashboard/{org}/settings/account`; edit **Display name** (`settings.account.profile.name`)                                         | Exactly **one** visible **Save** button (`common.actions.save`) exists (the content-width floating dock bottom-right above the bottom tab bar; the desktop header slot is unmounted). It is **disabled while clean**, becomes **enabled after the edit**. Reload → the field rehydrates to the **original value** (the probe edit did not persist). |
+| F4  | Chat input      | At 390 px, open `/dashboard/{org}/chat`                                                                                                              | The chat input textbox **Message input** (`chat.aria.chatInput`) is **visible and enabled**. (Optional manual extension: type `hello`, click **Send message** (`chat.send`), assert it re-enables; attach a file via the chat input.)                                                                                                               |
+| F5  | DataTable page  | At 390 px, open `/dashboard/{org}/contacts`                                                                                                          | The page settles into either the **Import contacts** button (`contacts.importMenu.importContacts`) **or** the empty state **No contacts yet** (`emptyStates.contacts.title`) — both prove the table chrome rendered. No action is clipped off-screen.                                                                                               |
+| F6  | Dialog / sheet  | At 390 px, open a create dialog (e.g. **New project** on `/dashboard/{org}/projects`)                                                                | The dialog/sheet renders within the viewport; its primary action button is visible and reachable without horizontal scroll.                                                                                                                                                                                                                         |
+| F7  | No overflow     | At 390 px, on chat, settings/account, and contacts, read `documentElement.scrollWidth`                                                               | `scrollWidth === clientWidth` (== 390) on each page — no horizontal scrollbar, nothing off-canvas.                                                                                                                                                                                                                                                  |
+| F8  | Discussions     | Mode A, needs one discussion created: at 390×844, open `/dashboard/{org}/projects/{projectId}/discussions` and tap the discussion to open its thread | The reply box with the placeholder **"Reply… use @ to mention a teammate or agent"** (`discussions.reply.placeholder`) is **visible and enabled**; `document.documentElement.scrollWidth === clientWidth` (no horizontal overflow).                                                                                                                 |
+| F9  | Workspace panel | Mode B — canvas content needed: at 390×844, open a chat thread that produced canvas files → tap **Open canvas** (`chat.canvas.stripOpen`)            | The **Canvas** panel (`chat.canvas.title`) opens **within the viewport** with a reachable close/back control; no horizontal overflow. Presentation at `< md` is unverified — **record whether it presents as a sheet or a split view** (check live).                                                                                                |
 
 ## Boundary & error tests
 


### PR DESCRIPTION
## What & why

On phones (`< md`), trailing page actions previously pinned over the scrolling tab strip
(project/settings tabs) or stacked under the page header and crowded content. This introduces a
single mobile **floating-actions dock** and routes those actions through it.

- **`MobileFloatingActions`** (new) — a content-width dock portaled to `<body>` so `position:fixed`
  is viewport-relative even under a `backdrop-blur` header, sitting bottom-right above the bottom tab
  bar. Hidden when its slot renders nothing.
- **Settings Save/Discard** and **`TabNavigation` trailing children** now mount once via `useIsMobile`:
  the desktop trailing slot on `md+`, the dock on `< md` — never both.
- **Scroll clearance** via a ref-counted `--mobile-floating-actions-pad` var: `ContentArea` appends
  the bottom-pad class last so a caller's `py-*`/`pb-*` can't drop it; `PageLayout` keeps padding on
  scrollable content, not the shell; the inbox list consumes the same var.
- **Bonus fix:** `TabNavigation`'s absolute overflow-measure row is now contained with
  `overflow-x-hidden`, killing a phantom horizontal scrollbar that let a trackpad swipe shift the
  whole shell sideways even when page content fit.

Agent-tab `ContentArea` call sites switch `py-*` → `pt-*` so the dock clearance isn't overridden.

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; targeted vitest 23/23
  (content-area, page-layout, mobile-floating-actions, tab-navigation, conversation-list-panel).
- [x] **Tests** — new specs for the dock, the pad token, tab-strip mobile/desktop placement, and the
  `overflow-x-hidden` guard.
- [x] **Accessibility** — dock is `aria-hidden` when empty; actions keep their own labels; single
  mount avoids duplicate controls in the a11y tree.
- [x] **Docs** — `tests/manual/responsive.md` + `responsive.spec.ts` retargeted from the old "mobile
  Save bar" to the floating Save dock.
- [N/A] **Migration** — no data-model/config change.
- [N/A] **Locales** — no user-visible strings added.
- [~] **Observed** — unit specs assert rendered classes/placement. Playwright `responsive.spec.ts` is
  updated but not run locally (heavy/flaky); CI exercises it.
