### PR TITLE
refactor(platform): back arrow for mobile page-header control

### DIFF
--- a/services/platform/app/components/layout/header-breadcrumbs.tsx
+++ b/services/platform/app/components/layout/header-breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@tale/ui/heading';
 import { IconButton } from '@tale/ui/icon-button';
-import { ChevronLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { isValidElement, type ReactNode } from 'react';
 
 import { useT } from '@/lib/i18n/client';
@@ -51,7 +51,7 @@ export function HeaderBreadcrumbs({
   // detail page would otherwise have NO way back. Collapse to an icon-only
   // back button to the immediate parent (the last ancestor): `IconButton
   // asChild` re-uses that crumb's own `Link` — swapping its label for a back
-  // chevron — so the destination and the router stay the caller's, and the
+  // arrow — so the destination and the router stay the caller's, and the
   // control is a compact icon rather than a width-hungry label. The desktop
   // trail below renders the same ancestor node; one copy is `display:none`
   // per breakpoint, so exactly one parent link stays in the a11y tree.
@@ -65,9 +65,11 @@ export function HeaderBreadcrumbs({
         <IconButton
           asChild
           slotChild={parentContent}
-          icon={ChevronLeft}
+          icon={ArrowLeft}
+          iconSize={5}
+          size="sm"
           aria-label={t('aria.back')}
-          className="shrink-0 md:hidden"
+          className="-ml-1.5 shrink-0 md:hidden"
         />
       )}
       <ol className="flex min-w-0 items-center gap-2 text-base font-semibold">

--- a/services/platform/app/features/settings/components/settings-mobile-back-button.tsx
+++ b/services/platform/app/features/settings/components/settings-mobile-back-button.tsx
@@ -2,7 +2,7 @@
 
 import { IconButton } from '@tale/ui/icon-button';
 import { useLocation, useNavigate } from '@tanstack/react-router';
-import { ChevronLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
@@ -12,7 +12,7 @@ interface SettingsMobileBackButtonProps {
 }
 
 /**
- * Mobile-only back chevron for settings *sub-pages*. On mobile the settings rail
+ * Mobile-only back arrow for settings *sub-pages*. On mobile the settings rail
  * is hidden and the dedicated overview routes (`/settings`, `/settings/personal`)
  * drive navigation, so a sub-page (e.g. `/settings/branding`) needs an explicit
  * way back to its overview list.
@@ -27,7 +27,8 @@ interface SettingsMobileBackButtonProps {
  * main Settings list and pressing back stranded the user on a narrower list
  * they never navigated to. Rendered as a child of the settings
  * `AdaptiveHeaderRoot` so it slots into the mobile top bar; `md:hidden` keeps
- * it off the desktop header strip.
+ * it off the desktop header strip. Uses the dense `sm` icon square so the
+ * glyph sits with the title rather than a padded toolbar button.
  */
 export function SettingsMobileBackButton({
   organizationId,
@@ -62,10 +63,12 @@ export function SettingsMobileBackButton({
 
   return (
     <IconButton
-      icon={ChevronLeft}
+      icon={ArrowLeft}
+      iconSize={5}
+      size="sm"
       aria-label={t('aria.back')}
       onClick={handleBack}
-      className="md:hidden"
+      className="-ml-1.5 md:hidden"
     />
   );
 }


### PR DESCRIPTION
## What & why

The mobile-only "back to parent" controls used a `ChevronLeft`. Switch both to `ArrowLeft` at the
denser `sm` icon square (`iconSize={5}`, `-ml-1.5`) so the glyph sits with the page title rather than
as a padded toolbar button — and so the back affordance is consistent across the breadcrumb header
and the settings sub-page header. Behaviour and the accessible label are unchanged.

- `app/components/layout/header-breadcrumbs.tsx`
- `app/features/settings/components/settings-mobile-back-button.tsx`

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 12/12
  (header-breadcrumbs, settings-mobile-back-button).
- [x] **Tests** — existing specs for both controls pass unchanged (label/behaviour preserved).
- [x] **Accessibility** — same `aria.back` label; still `md:hidden`; icon bumped to `size-5` for a
  comfortable target.
- [N/A] **Migration / Locales** — no data or string change.
- [N/A] **Docs** — icon-only visual swap; no user-facing behaviour change.
- [x] **Observed** — specs assert each control renders with its label; the swap is class-level.
