### PR TITLE
feat(platform): adapt inbox navigation and header on mobile

### DIFF
--- a/services/platform/app/features/conversations/components/compose-email-pane.tsx
+++ b/services/platform/app/features/conversations/components/compose-email-pane.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { Center, Row, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { Loader2Icon, Trash2Icon, XIcon } from 'lucide-react';
+import { Loader2Icon, Trash2Icon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PanelFooter } from '@/app/components/layout/panel-footer';
@@ -102,7 +102,6 @@ export function ComposeEmailPane({
   onClose,
 }: ComposeEmailPaneProps) {
   const { t } = useT('conversations');
-  const { t: tCommon } = useT('common');
   const { user } = useAuth();
   const { emailIntegrations, isLoading: integrationsLoading } =
     useEmailIntegrations(organizationId);
@@ -337,14 +336,6 @@ export function ComposeEmailPane({
                   onClick={() => setConfirmDiscardOpen(true)}
                 >
                   {t('compose.discard')}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onClose}
-                  aria-label={tCommon('aria.close')}
-                >
-                  <XIcon className="size-4" />
                 </Button>
               </Row>
             </Row>

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+vi.mock('@/app/hooks/use-current-member-context', () => ({
+  useCurrentMemberContext: () => ({
+    data: { role: 'admin' },
+  }),
+}));
+
+vi.mock('@/app/features/settings/organization/hooks/queries', () => ({
+  useMembers: () => ({
+    members: [
+      {
+        userId: 'user-1',
+        displayName: 'Ada Lovelace',
+        email: 'ada@example.com',
+      },
+    ],
+  }),
+}));
+
+vi.mock('@/app/features/settings/teams/hooks/queries', () => ({
+  useOrgTeams: () => ({
+    teams: [{ id: 'team-1', name: 'Support' }],
+  }),
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useAssignConversation: () => ({ mutate: vi.fn() }),
+  useAssignConversationTeam: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+vi.mock('@/app/features/tasks/components/assignee-avatar', () => ({
+  AssigneeAvatar: ({
+    name,
+    assigneeId,
+  }: {
+    name?: string;
+    assigneeId?: string;
+  }) => <span data-testid={`avatar-${assigneeId}`}>{name ?? assigneeId}</span>,
+}));
+
+vi.mock('@/app/components/ui/forms/searchable-select', () => ({
+  SearchableSelect: ({ trigger }: { trigger: React.ReactNode }) => (
+    <div data-testid="assign-select">{trigger}</div>
+  ),
+}));
+
+import { ConversationAssigneePicker } from './conversation-assignee-picker';
+
+function makeConversation(
+  overrides: {
+    assigneeUserId?: string;
+    assigneeTeamId?: string;
+  } = {},
+) {
+  return {
+    _id: 'conv-1',
+    id: 'conv-1',
+    organizationId: 'org-1',
+    ...overrides,
+  } as Parameters<typeof ConversationAssigneePicker>[0]['conversation'];
+}
+
+describe('ConversationAssigneePicker', () => {
+  it('shows a dual stack when both team and person are assigned (mobile keeps both)', () => {
+    render(
+      <ConversationAssigneePicker
+        conversation={makeConversation({
+          assigneeUserId: 'user-1',
+          assigneeTeamId: 'team-1',
+        })}
+        organizationId="org-1"
+      />,
+    );
+
+    // Mobile stack encodes both dimensions — do not drop team when person is set.
+    const stack = screen.getByTestId('assign-dual-stack');
+    expect(stack).toHaveClass('md:hidden');
+    expect(stack.querySelector('svg')).toBeInTheDocument();
+    expect(
+      stack.querySelector('[data-testid="avatar-user-1"]'),
+    ).toBeInTheDocument();
+
+    // Desktop still lists both labelled chips.
+    expect(screen.getByText('Support')).toBeInTheDocument();
+    expect(screen.getAllByText('Ada Lovelace').length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it('shows only the team glyph when only the team queue is set', () => {
+    render(
+      <ConversationAssigneePicker
+        conversation={makeConversation({ assigneeTeamId: 'team-1' })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(screen.queryByTestId('assign-dual-stack')).not.toBeInTheDocument();
+    expect(screen.getByText('Support')).toBeInTheDocument();
+  });
+
+  it('shows only the person avatar when only a person is assigned', () => {
+    render(
+      <ConversationAssigneePicker
+        conversation={makeConversation({ assigneeUserId: 'user-1' })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(screen.queryByTestId('assign-dual-stack')).not.toBeInTheDocument();
+    expect(screen.getByTestId('avatar-user-1')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@tale/ui/button';
 import { Check, UserPlus, Users } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import {
   SearchableSelect,
@@ -69,41 +69,85 @@ export function ConversationAssigneePicker({
   const team = teams.find((tm) => tm.id === assigneeTeamId);
   const teamName = team?.name;
 
-  // Trigger chips — the team queue and/or the individual owner, or a bare
-  // "Assign" affordance when neither is set.
-  const teamChip = assigneeTeamId ? (
-    <span className="flex items-center gap-1.5">
-      <Users className="text-muted-foreground size-4 shrink-0" />
-      <span className="max-w-[8rem] truncate text-sm">
-        {teamName ?? t('header.assignedTeam')}
-      </span>
-    </span>
-  ) : null;
-  const personChip = assigneeUserId ? (
-    <span className="flex items-center gap-1.5">
-      <AssigneeAvatar
-        assigneeType="user"
-        assigneeId={assigneeUserId}
-        name={assigneeName}
-        size="sm"
-      />
-      <span className="max-w-[8rem] truncate text-sm">
-        {assigneeName ?? t('header.assignee')}
-      </span>
-    </span>
-  ) : null;
-  const chips =
-    teamChip || personChip ? (
-      <span className="flex items-center gap-2">
-        {teamChip}
-        {personChip}
-      </span>
-    ) : (
+  // Trigger content for the assign control.
+  //
+  // Two independent dimensions (team queue + person claimer) can both be set —
+  // shared-inbox model. Labels are desktop-only; mobile stays icon-only but
+  // must still show BOTH dimensions when both are set (stacked pair), never
+  // drop one. Icons stay size-5 / avatar `md` for a usable hit target with the
+  // square trigger below.
+  const bothAssigned = Boolean(assigneeTeamId && assigneeUserId);
+
+  let chips: ReactNode;
+  if (bothAssigned && assigneeUserId) {
+    chips = (
+      <>
+        <span
+          data-testid="assign-dual-stack"
+          className="relative inline-flex size-7 items-center justify-center md:hidden"
+          aria-hidden="true"
+        >
+          <Users className="text-muted-foreground absolute top-0.5 left-0 size-4" />
+          <AssigneeAvatar
+            assigneeType="user"
+            assigneeId={assigneeUserId}
+            name={assigneeName}
+            size="sm"
+            className="border-background relative ml-2.5 border-2"
+          />
+        </span>
+        <span className="hidden items-center gap-2 md:flex">
+          <span className="flex items-center gap-1.5">
+            <Users className="text-muted-foreground size-5 shrink-0" />
+            <span className="max-w-[8rem] truncate text-sm">
+              {teamName ?? t('header.assignedTeam')}
+            </span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <AssigneeAvatar
+              assigneeType="user"
+              assigneeId={assigneeUserId}
+              name={assigneeName}
+              size="md"
+            />
+            <span className="max-w-[8rem] truncate text-sm">
+              {assigneeName ?? t('header.assignee')}
+            </span>
+          </span>
+        </span>
+      </>
+    );
+  } else if (assigneeTeamId) {
+    chips = (
       <span className="flex items-center gap-1.5">
-        <UserPlus className="text-muted-foreground size-4 shrink-0" />
-        <span className="text-sm">{t('header.assign')}</span>
+        <Users className="text-muted-foreground size-5 shrink-0" />
+        <span className="hidden max-w-[8rem] truncate text-sm md:inline">
+          {teamName ?? t('header.assignedTeam')}
+        </span>
       </span>
     );
+  } else if (assigneeUserId) {
+    chips = (
+      <span className="flex items-center gap-1.5">
+        <AssigneeAvatar
+          assigneeType="user"
+          assigneeId={assigneeUserId}
+          name={assigneeName}
+          size="md"
+        />
+        <span className="hidden max-w-[8rem] truncate text-sm md:inline">
+          {assigneeName ?? t('header.assignee')}
+        </span>
+      </span>
+    );
+  } else {
+    chips = (
+      <span className="flex items-center gap-1.5">
+        <UserPlus className="text-muted-foreground size-5 shrink-0" />
+        <span className="hidden text-sm md:inline">{t('header.assign')}</span>
+      </span>
+    );
+  }
 
   // Compose a read-out of the current assignment for the trigger's aria-label.
   const parts: string[] = [];
@@ -207,7 +251,9 @@ export function ConversationAssigneePicker({
         <Button
           variant="ghost"
           size="sm"
-          className="gap-2"
+          // Mobile is icon-only: use a square ≥32px hit target. Desktop grows
+          // with the label (`md:w-auto md:px-3`).
+          className="size-8 shrink-0 gap-2 p-0 md:h-8 md:w-auto md:px-3"
           aria-label={assignedLabel}
         >
           {chips}

--- a/services/platform/app/features/conversations/components/conversation-header.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-header.test.tsx
@@ -164,7 +164,7 @@ describe('ConversationHeader', () => {
     expect(screen.getByText('Project proposal feedback')).toBeInTheDocument();
   });
 
-  it('falls back to email when contact name is missing', () => {
+  it('falls back to email when contact name is missing without duplicating it on the meta line', () => {
     render(
       <ConversationHeader
         conversation={makeConversation({
@@ -181,23 +181,28 @@ describe('ConversationHeader', () => {
       />,
     );
 
-    const nameElements = screen.getAllByText('sarah@company.com');
-    expect(nameElements.length).toBeGreaterThanOrEqual(1);
+    // Primary shows the email; the meta line must not repeat it (that doubled
+    // the string on phone widths and forced the timestamp to wrap mid-phrase).
+    expect(screen.getAllByText('sarah@company.com')).toHaveLength(1);
+    expect(screen.getByText('2 min ago')).toHaveClass('whitespace-nowrap');
   });
 
-  it('renders back button on mobile when onBack is provided', () => {
+  it('keeps the contact email on the meta line for desktop widths only', () => {
     render(
       <ConversationHeader
         conversation={makeConversation()}
         organizationId="org-1"
-        onBack={vi.fn()}
       />,
     );
 
-    expect(screen.getByLabelText('Back')).toBeInTheDocument();
+    expect(screen.getByText('Sarah Johnson')).toBeInTheDocument();
+    const email = screen.getByText('sarah@company.com');
+    expect(email).toBeInTheDocument();
+    // Mobile hides the sender email (contact info already has it); md+ keeps it.
+    expect(email).toHaveClass('hidden', 'md:inline');
   });
 
-  it('does not render back button when onBack is not provided', () => {
+  it('does not render a back control (back lives in the page header)', () => {
     render(
       <ConversationHeader
         conversation={makeConversation()}

--- a/services/platform/app/features/conversations/components/conversation-header.tsx
+++ b/services/platform/app/features/conversations/components/conversation-header.tsx
@@ -5,7 +5,6 @@ import { DropdownMenu, type DropdownMenuItem } from '@tale/ui/dropdown-menu';
 import { Row, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import {
-  ArrowLeft,
   Ellipsis,
   Mail,
   MessageSquare,
@@ -46,7 +45,6 @@ interface ConversationHeaderProps {
   organizationId: string;
   onResolve?: () => void;
   onReopen?: () => void;
-  onBack?: () => void;
 }
 
 export function ConversationHeader({
@@ -54,10 +52,8 @@ export function ConversationHeader({
   organizationId,
   onResolve,
   onReopen,
-  onBack,
 }: ConversationHeaderProps) {
   const { t } = useT('conversations');
-  const { t: tCommon } = useT('common');
   const { contact } = conversation;
   const [isContactInfoOpen, setIsContactInfoOpen] = useState(false);
   const pendingContactInfo = useRef(false);
@@ -234,27 +230,19 @@ export function ConversationHeader({
     ? formatRelative(new Date(conversation.last_message_at))
     : null;
 
+  // Primary line prefers a display name; when the contact has none, it already
+  // shows the email — repeating it on the meta line is noise and eats width.
+  const primaryLabel = contact.name || contact.email;
+  const showEmailInMeta = Boolean(contact.name && contact.email);
+
   return (
     <Stack gap={3} className="border-border border-b p-4 sm:px-6 sm:py-4">
-      {/* Back button - visible only on mobile */}
-      {onBack && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="shrink-0 md:hidden"
-          onClick={onBack}
-          title={tCommon('actions.back')}
-        >
-          <ArrowLeft className="size-5" />
-        </Button>
-      )}
-
       {/* Subject Row */}
-      <Row justify="between">
+      <Row justify="between" gap={2} className="min-w-0">
         <Text className="min-w-0 truncate text-base font-semibold tracking-tight">
           {conversation.subject || conversation.title}
         </Text>
-        <Row gap={1} className="shrink-0">
+        <Row gap={2} className="shrink-0 items-center">
           <ConversationAssigneePicker
             conversation={conversation}
             organizationId={organizationId}
@@ -264,10 +252,10 @@ export function ConversationHeader({
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-7"
+                className="size-8 shrink-0"
                 aria-label={t('header.moreActions')}
               >
-                <Ellipsis className="text-muted-foreground size-4" />
+                <Ellipsis className="text-muted-foreground size-5" />
               </Button>
             }
             items={[moreMenuItems]}
@@ -278,7 +266,7 @@ export function ConversationHeader({
       </Row>
 
       {/* Sender Row */}
-      <div className="flex items-center gap-2.5">
+      <div className="flex min-w-0 items-center gap-2.5">
         <ContactInfoPopover
           contact={contactData}
           open={isContactInfoOpen}
@@ -298,28 +286,38 @@ export function ConversationHeader({
         <div className="flex min-w-0 flex-col gap-px">
           <button
             type="button"
-            className="cursor-pointer text-left text-[13px] font-semibold tracking-tight hover:underline"
+            className="cursor-pointer truncate text-left text-[13px] font-semibold tracking-tight hover:underline"
             onClick={() => setIsContactInfoOpen(true)}
           >
-            {contact.name || contact.email}
+            {primaryLabel}
           </button>
-          <Row gap={0} className="text-muted-foreground text-xs tracking-tight">
-            <button
-              type="button"
-              className="cursor-pointer hover:underline"
-              onClick={() => setIsContactInfoOpen(true)}
-            >
-              {contact.email}
-            </button>
+          <div className="text-muted-foreground flex min-w-0 items-center text-xs tracking-tight">
+            {showEmailInMeta && (
+              <button
+                type="button"
+                className="hidden min-w-0 cursor-pointer truncate hover:underline md:inline"
+                onClick={() => setIsContactInfoOpen(true)}
+              >
+                {contact.email}
+              </button>
+            )}
             {lastMessageTime && (
               <>
-                <DotIcon className="mx-0.5 shrink-0" />
-                <span>{lastMessageTime}</span>
+                {showEmailInMeta && (
+                  <DotIcon className="mx-0.5 hidden shrink-0 md:inline" />
+                )}
+                <span className="shrink-0 whitespace-nowrap">
+                  {lastMessageTime}
+                </span>
               </>
             )}
             {conversationFrom && (
               <>
-                <DotIcon className="mx-0.5 shrink-0" />
+                {lastMessageTime ? (
+                  <DotIcon className="mx-0.5 shrink-0" />
+                ) : showEmailInMeta ? (
+                  <DotIcon className="mx-0.5 hidden shrink-0 md:inline" />
+                ) : null}
                 <Tooltip content={inboxLabel ?? conversationFrom}>
                   <span
                     className="inline-flex min-w-0 items-center gap-1"
@@ -333,7 +331,7 @@ export function ConversationHeader({
                 </Tooltip>
               </>
             )}
-          </Row>
+          </div>
         </div>
       </div>
     </Stack>

--- a/services/platform/app/features/conversations/components/conversation-panel.tsx
+++ b/services/platform/app/features/conversations/components/conversation-panel.tsx
@@ -467,9 +467,6 @@ export function ConversationPanel({
                 onReopen={() => {
                   onSelectedConversationChange(null);
                 }}
-                onBack={() => {
-                  onSelectedConversationChange(null);
-                }}
               />
             ) : (
               <Stack

--- a/services/platform/app/features/conversations/components/conversations.tsx
+++ b/services/platform/app/features/conversations/components/conversations.tsx
@@ -125,11 +125,32 @@ export function Conversations({
     initialConversationId ?? null,
   );
 
+  // Selection is mirrored in `?conversation=` so the mobile header back button
+  // (remounted in `AdaptiveHeaderSlot` outside this tree) can read it.
   useEffect(() => {
-    if (initialConversationId) {
-      setSelectedConversationId(initialConversationId);
-    }
+    setSelectedConversationId(initialConversationId ?? null);
   }, [initialConversationId]);
+
+  const handleSelectedConversationChange = useCallback(
+    (id: string | null) => {
+      setSelectedConversationId(id);
+      void navigate({
+        to: '/dashboard/$id/conversations/$status',
+        params: { id: organizationId, status: status ?? 'open' },
+        search: (prev) => ({
+          ...prev,
+          conversation: id ?? undefined,
+          // Leaving compose for a thread (desktop list still visible) must
+          // drop the compose params or the reading pane stays on New email.
+          ...(id != null
+            ? { compose: undefined, composeContact: undefined }
+            : {}),
+        }),
+        replace: true,
+      });
+    },
+    [navigate, organizationId, status],
+  );
 
   // `searchQuery` is the single source of truth for the filter. It is seeded
   // once from the `?search=` URL param; thereafter the URL is kept in sync from
@@ -212,8 +233,8 @@ export function Conversations({
 
   const onBulkComplete = useCallback(() => {
     clearSelection();
-    setSelectedConversationId(null);
-  }, [clearSelection]);
+    handleSelectedConversationChange(null);
+  }, [clearSelection, handleSelectedConversationChange]);
 
   const {
     isBulkProcessing,
@@ -246,7 +267,7 @@ export function Conversations({
   const skeletonRows = Math.min(conversationCount ?? 12, 12);
 
   const handleConversationSelect = (conversation: Conversation) => {
-    setSelectedConversationId(conversation.id);
+    handleSelectedConversationChange(conversation.id);
   };
 
   const closeCompose = useCallback(() => {
@@ -264,7 +285,6 @@ export function Conversations({
 
   const handleComposeSent = useCallback(
     (conversationId: string) => {
-      setSelectedConversationId(conversationId);
       void navigate({
         to: '/dashboard/$id/conversations/$status',
         params: { id: organizationId, status: status ?? 'open' },
@@ -551,7 +571,7 @@ export function Conversations({
         ) : (
           <ConversationPanel
             selectedConversationId={selectedConversationId}
-            onSelectedConversationChange={setSelectedConversationId}
+            onSelectedConversationChange={handleSelectedConversationChange}
             status={status}
             forceLoading={isLoading}
           />

--- a/services/platform/app/features/conversations/components/inbox-mobile-back-button.test.tsx
+++ b/services/platform/app/features/conversations/components/inbox-mobile-back-button.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+const ORG = 'test-org';
+const BACK_LABEL = 'common.aria.back';
+
+let mockSearch: {
+  conversation?: string;
+  compose?: string;
+  composeContact?: string;
+} = {};
+let mockParams: { id?: string; status?: string } = {
+  id: ORG,
+  status: 'open',
+};
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => mockNavigate,
+  useParams: () => mockParams,
+  useSearch: () => mockSearch,
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({ t: (key: string) => `${ns}.${key}` }),
+}));
+
+import { InboxMobileBackButton } from './inbox-mobile-back-button';
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockSearch = {};
+  mockParams = { id: ORG, status: 'open' };
+});
+
+describe('InboxMobileBackButton', () => {
+  it('renders nothing on the list (no conversation or compose)', () => {
+    render(<InboxMobileBackButton />);
+    expect(screen.queryByRole('button', { name: BACK_LABEL })).toBeNull();
+  });
+
+  it('clears the conversation search param on back', async () => {
+    mockSearch = { conversation: 'conv-1' };
+    const { user } = render(<InboxMobileBackButton />);
+
+    const back = screen.getByRole('button', { name: BACK_LABEL });
+    expect(back).toHaveClass('md:hidden');
+    await user.click(back);
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/$id/conversations/$status',
+      params: { id: ORG, status: 'open' },
+      search: expect.any(Function),
+      replace: true,
+    });
+    const searchUpdater = mockNavigate.mock.calls[0]?.[0]?.search as (prev: {
+      conversation?: string;
+      compose?: string;
+      composeContact?: string;
+    }) => {
+      conversation?: string;
+      compose?: string;
+      composeContact?: string;
+    };
+    expect(searchUpdater({ conversation: 'conv-1' })).toEqual({
+      conversation: undefined,
+      compose: undefined,
+      composeContact: undefined,
+    });
+  });
+
+  it('shows while composing and clears compose params on back', async () => {
+    mockSearch = { compose: 'new', composeContact: 'contact-1' };
+    const { user } = render(<InboxMobileBackButton />);
+
+    await user.click(screen.getByRole('button', { name: BACK_LABEL }));
+
+    const searchUpdater = mockNavigate.mock.calls[0]?.[0]?.search as (prev: {
+      conversation?: string;
+      compose?: string;
+      composeContact?: string;
+    }) => {
+      conversation?: string;
+      compose?: string;
+      composeContact?: string;
+    };
+    expect(
+      searchUpdater({
+        compose: 'new',
+        composeContact: 'contact-1',
+      }),
+    ).toEqual({
+      conversation: undefined,
+      compose: undefined,
+      composeContact: undefined,
+    });
+  });
+
+  it('passes the accessibility audit when visible', async () => {
+    mockSearch = { compose: 'new' };
+    const { container } = render(<InboxMobileBackButton />);
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/conversations/components/inbox-mobile-back-button.tsx
+++ b/services/platform/app/features/conversations/components/inbox-mobile-back-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { IconButton } from '@tale/ui/icon-button';
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import { ArrowLeft } from 'lucide-react';
+import { useCallback } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+
+/**
+ * Compact mobile-only back control for the Inbox page chrome — sits left of
+ * the Inbox title in `AdaptiveHeaderRoot` while a conversation or the compose
+ * pane is open (`?conversation=` / `?compose=`). Self-contained (reads the URL)
+ * so it still works when `AdaptiveHeaderSlot` remounts the header outside the
+ * conversations tree. Uses the dense `sm` icon square so the glyph reads as
+ * part of the title cluster rather than a padded toolbar button.
+ */
+export function InboxMobileBackButton() {
+  const { t } = useT('common');
+  const navigate = useNavigate();
+  const params = useParams({ strict: false }) as {
+    id?: string;
+    status?: string;
+  };
+  const search = useSearch({ strict: false }) as {
+    conversation?: unknown;
+    compose?: unknown;
+  };
+  const conversationId =
+    typeof search.conversation === 'string' ? search.conversation : undefined;
+  const isComposing = search.compose !== undefined;
+  const showBack = Boolean(conversationId || isComposing);
+
+  const handleBack = useCallback(() => {
+    if (!params.id) return;
+    void navigate({
+      to: '/dashboard/$id/conversations/$status',
+      params: { id: params.id, status: params.status ?? 'open' },
+      search: (prev) => ({
+        ...prev,
+        conversation: undefined,
+        compose: undefined,
+        composeContact: undefined,
+      }),
+      replace: true,
+    });
+  }, [navigate, params.id, params.status]);
+
+  if (!showBack || !params.id) return null;
+
+  return (
+    <IconButton
+      icon={ArrowLeft}
+      iconSize={5}
+      size="sm"
+      aria-label={t('aria.back')}
+      onClick={handleBack}
+      className="-ml-1.5 shrink-0 md:hidden"
+    />
+  );
+}

--- a/services/platform/app/routes/dashboard/$id/conversations.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations.test.tsx
@@ -82,9 +82,12 @@ vi.mock('@/app/components/layout/adaptive-header', () => ({
 vi.mock(
   '@/app/features/conversations/components/conversations-navigation',
   () => ({
-    ConversationsNavigation: () => (
-      <div data-testid="conversations-navigation" />
-    ),
+    ConversationsNavigation: ({
+      action,
+    }: {
+      organizationId: string;
+      action?: React.ReactNode;
+    }) => <div data-testid="conversations-navigation">{action}</div>,
   }),
 );
 
@@ -219,6 +222,23 @@ describe('ConversationsLayout', () => {
 
     // One-shot: the stash is cleared so a later visit doesn't reopen it again.
     expect(window.localStorage.getItem(pendingComposeKey)).toBeNull();
+  });
+
+  it('shows the Compose action when the inbox list is open', () => {
+    mockInboxAvailability = { isLoading: false, hasInbox: true };
+    render(<ConversationsLayout />);
+
+    expect(screen.getByRole('button', { name: 'Compose' })).toBeInTheDocument();
+  });
+
+  it('hides the Compose action while composing', () => {
+    mockInboxAvailability = { isLoading: false, hasInbox: true };
+    mockSearch = { compose: 'new' };
+    render(<ConversationsLayout />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Compose' }),
+    ).not.toBeInTheDocument();
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/routes/dashboard/$id/conversations.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations.tsx
@@ -21,6 +21,7 @@ import { ContentWrapper } from '@/app/components/layout/content-wrapper';
 import { PageLayout } from '@/app/components/layout/page-layout';
 import { useInboxAvailability } from '@/app/features/automations/builtin-views/registry';
 import { ConversationsNavigation } from '@/app/features/conversations/components/conversations-navigation';
+import { InboxMobileBackButton } from '@/app/features/conversations/components/inbox-mobile-back-button';
 import { useComposeContactName } from '@/app/features/conversations/hooks/queries';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
@@ -218,31 +219,34 @@ function ConversationsLayout() {
       className="overflow-hidden"
       header={
         <>
-          <AdaptiveHeaderRoot standalone={false}>
+          <AdaptiveHeaderRoot standalone={false} className="gap-1">
+            <InboxMobileBackButton />
             <AdaptiveHeaderTitle>{t('title')}</AdaptiveHeaderTitle>
           </AdaptiveHeaderRoot>
           <ConversationsNavigation
             organizationId={organizationId}
             action={
-              <Button
-                size="sm"
-                variant="secondary"
-                icon={SquarePen}
-                onClick={() =>
-                  void navigate({
-                    to: '/dashboard/$id/conversations/$status',
-                    params: { id: organizationId, status: currentStatus },
-                    search: (prev) => ({
-                      ...prev,
-                      compose: 'new',
-                      composeContact: undefined,
-                      conversation: undefined,
-                    }),
-                  })
-                }
-              >
-                {t('compose.compose')}
-              </Button>
+              composeParam === undefined ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon={SquarePen}
+                  onClick={() =>
+                    void navigate({
+                      to: '/dashboard/$id/conversations/$status',
+                      params: { id: organizationId, status: currentStatus },
+                      search: (prev) => ({
+                        ...prev,
+                        compose: 'new',
+                        composeContact: undefined,
+                        conversation: undefined,
+                      }),
+                    })
+                  }
+                >
+                  {t('compose.compose')}
+                </Button>
+              ) : undefined
             }
           />
         </>


### PR DESCRIPTION
## What & why

On mobile the conversation reading pane filled the screen with no way back to the list, and the
header crowded at narrow widths. This adapts the inbox + conversation-header surface for phones.

- **Back control → page chrome.** `InboxMobileBackButton` (new) sits left of the Inbox title in the
  page header and reads the `?conversation=` / `?compose=` URL params, so it still works when the
  header remounts outside the conversations tree. `ConversationHeader` no longer owns an `onBack`.
- **URL-driven selection.** The open conversation is mirrored into `?conversation=`; the Compose
  action is hidden while composing.
- **Responsive header.** The contact email renders on the meta line at `md+` only (it doubled the
  primary label and forced the timestamp to wrap on phones); the assignee trigger collapses to a
  square icon-only control below `md`, still showing **both** team and person when both are set.
- **Cleanup.** Removed the redundant compose **X** close — Discard already closes the pane.

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 26/26
  (inbox-mobile-back-button, conversation-header, conversation-assignee-picker, conversations route).
- [x] **Tests** — new specs for the back button and assignee picker; header/route specs updated for
  the moved back control, the md-only email, and Compose gating.
- [x] **Accessibility** — back button keeps `aria.back` and is keyboard reachable; assignee trigger
  keeps its composed `aria-label` and a ≥32px hit target on mobile.
- [N/A] **Migration / Locales** — no data or new string (existing keys reused).
- [N/A] **Docs** — no user-facing doc surface changed.
- [x] **Observed** — specs assert rendered placement/classes and the URL-param gating.
