### PR TITLE
feat(platform): agent-detail breadcrumb switcher and history label

### DIFF
--- a/services/platform/app/features/agents/components/agent-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/agents/components/agent-breadcrumb-switcher.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import { AgentBreadcrumbSwitcher } from './agent-breadcrumb-switcher';
+
+const mockNavigate = vi.fn();
+const mockLocation = {
+  pathname: '/dashboard/org-1/agents/issue-triager/instructions',
+  search: {} as Record<string, unknown>,
+};
+
+let agentsFixture: unknown[] = [];
+
+vi.mock('@/app/features/agents/hooks/queries', () => ({
+  useListAgents: () => ({ agents: agentsFixture, isLoading: false }),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
+}));
+
+vi.mock('@tale/ui/i18n/locale-provider', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tale/ui/i18n/locale-provider')>()),
+  useLocale: () => ({ locale: 'en' }),
+}));
+
+describe('AgentBreadcrumbSwitcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation.pathname =
+      '/dashboard/org-1/agents/issue-triager/instructions';
+    mockLocation.search = {};
+    agentsFixture = [
+      {
+        name: 'issue-triager',
+        displayName: 'Issue triager',
+        uiConfigurable: true,
+      },
+      {
+        name: 'coder',
+        displayName: 'Coder',
+        uiConfigurable: true,
+      },
+    ];
+  });
+
+  it('opens a menu of sibling agents from the current name', async () => {
+    const { user } = render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch agent, current: issue triager/i,
+      }),
+    );
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Issue triager' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Coder' })).toBeInTheDocument();
+  });
+
+  it('navigates to the selected agent while keeping the current tab', async () => {
+    const { user } = render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch agent, current: issue triager/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Coder' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard/org-1/agents/coder/instructions',
+      search: {},
+    });
+  });
+
+  it('does not navigate when the current agent is chosen again', async () => {
+    const { user } = render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch agent, current: issue triager/i,
+      }),
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Issue triager' }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('renders a plain name when the agent list is empty', () => {
+    agentsFixture = [];
+    render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /switch agent/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Issue triager')).toBeInTheDocument();
+  });
+
+  it('passes an axe audit with the menu open', async () => {
+    const { user, container } = render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch agent, current: issue triager/i,
+      }),
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/agents/components/agent-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/agents/components/agent-breadcrumb-switcher.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
+import { useLocale } from '@tale/ui/i18n/locale-provider';
+import { useLocation, useNavigate } from '@tanstack/react-router';
+import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { useListAgents } from '@/app/features/agents/hooks/queries';
+import { toConfigurableAgent } from '@/app/features/agents/utils/agent-list-item';
+import { useT } from '@/lib/i18n/client';
+import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
+import { cn } from '@/lib/utils/cn';
+
+import { agentSwitchPathname } from '../lib/agent-switch-path';
+
+/**
+ * Breadcrumb leaf for an agent detail page: the current display name opens a
+ * dropdown of sibling agents so the operator can jump between them without
+ * returning to the Agents list. Portable editor tabs (instructions, tools, …)
+ * stay put.
+ */
+export function AgentBreadcrumbSwitcher({
+  organizationId,
+  agentId,
+  displayName,
+}: {
+  organizationId: string;
+  agentId: string;
+  displayName: string;
+}) {
+  const { t } = useT('settings');
+  const { locale } = useLocale();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { agents: rawAgents } = useListAgents(organizationId);
+
+  const siblings = useMemo(() => {
+    const rows = [];
+    for (const raw of rawAgents ?? []) {
+      const agent = toConfigurableAgent(raw);
+      if (!agent) continue;
+      rows.push({
+        name: agent.name,
+        label: resolveAgentLocale(agent, locale).displayName || agent.name,
+      });
+    }
+    return rows.sort((a, b) => a.label.localeCompare(b.label, locale));
+  }, [rawAgents, locale]);
+
+  const items = useMemo<DropdownMenuGroup[]>(
+    () => [
+      siblings.map((sibling) => ({
+        type: 'item' as const,
+        label: sibling.label,
+        selected: sibling.name === agentId,
+        onClick: () => {
+          if (sibling.name === agentId) return;
+          const to = agentSwitchPathname(
+            location.pathname,
+            organizationId,
+            agentId,
+            sibling.name,
+          );
+          void navigate({ to, search: location.search });
+        },
+      })),
+    ],
+    [
+      siblings,
+      agentId,
+      organizationId,
+      navigate,
+      location.pathname,
+      location.search,
+    ],
+  );
+
+  if (siblings.length === 0) {
+    return <>{displayName}</>;
+  }
+
+  return (
+    <DropdownMenu
+      align="start"
+      items={items}
+      trigger={
+        <button
+          type="button"
+          aria-label={t('agents.switcher.ariaLabel', { name: displayName })}
+          className={cn(
+            'inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm',
+            'hover:text-muted-foreground transition-colors',
+            'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+          )}
+        >
+          <span className="min-w-0 truncate">{displayName}</span>
+          <ChevronDown
+            className="text-muted-foreground size-4 shrink-0"
+            aria-hidden="true"
+          />
+        </button>
+      }
+    />
+  );
+}

--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -439,8 +439,15 @@ export function AgentNavigation({
   ]);
 
   const historyMenuItems = useMemo(() => {
+    const labelGroup = [
+      {
+        type: 'label' as const,
+        content: t('agents.history.menuLabel'),
+      },
+    ];
     if (historyEntries.length === 0) {
       return [
+        labelGroup,
         [
           {
             type: 'item' as const,
@@ -451,6 +458,7 @@ export function AgentNavigation({
       ];
     }
     return [
+      labelGroup,
       historyEntries.map<DropdownMenuItem>((entry) => ({
         type: 'item',
         label: formatDate(new Date(entry.date), 'long'),
@@ -487,7 +495,7 @@ export function AgentNavigation({
               }
               items={historyMenuItems}
               align="end"
-              contentClassName="w-64"
+              contentClassName="w-52"
               onOpenChange={(open) => {
                 if (open) void handleLoadHistory();
               }}

--- a/services/platform/app/features/agents/lib/agent-switch-path.test.ts
+++ b/services/platform/app/features/agents/lib/agent-switch-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentSwitchPathname } from './agent-switch-path';
+
+describe('agentSwitchPathname', () => {
+  const org = 'org-1';
+  const from = 'issue-triager';
+  const to = 'coder';
+
+  it('preserves portable editor tabs', () => {
+    expect(
+      agentSwitchPathname(
+        `/dashboard/${org}/agents/${from}/instructions`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/agents/${to}/instructions`);
+    expect(
+      agentSwitchPathname(
+        `/dashboard/${org}/agents/${from}/conversation-starters`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/agents/${to}/conversation-starters`);
+  });
+
+  it('resets unknown nested paths to the agent overview', () => {
+    expect(
+      agentSwitchPathname(
+        `/dashboard/${org}/agents/${from}/something-else`,
+        org,
+        from,
+        to,
+      ),
+    ).toBe(`/dashboard/${org}/agents/${to}`);
+  });
+
+  it('stays on the overview when already there', () => {
+    expect(
+      agentSwitchPathname(`/dashboard/${org}/agents/${from}`, org, from, to),
+    ).toBe(`/dashboard/${org}/agents/${to}`);
+  });
+
+  it('encodes composite agent slugs', () => {
+    const fromComposite = 'vat-desk/coordinator';
+    const toComposite = 'vat-desk/researcher';
+    expect(
+      agentSwitchPathname(
+        `/dashboard/${org}/agents/${encodeURIComponent(fromComposite)}/tools`,
+        org,
+        fromComposite,
+        toComposite,
+      ),
+    ).toBe(`/dashboard/${org}/agents/${encodeURIComponent(toComposite)}/tools`);
+  });
+});

--- a/services/platform/app/features/agents/lib/agent-switch-path.ts
+++ b/services/platform/app/features/agents/lib/agent-switch-path.ts
@@ -1,0 +1,56 @@
+/**
+ * Where an agent breadcrumb switch should land when jumping between agents.
+ *
+ * Editor tabs exist on every agent and are preserved. Anything else under the
+ * agent id (future nested routes) resets to the agent overview.
+ */
+
+const PORTABLE_AGENT_SEGMENTS = new Set([
+  'instructions',
+  'tools',
+  'skills',
+  'knowledge',
+  'conversation-starters',
+  'webhook',
+  'environment',
+]);
+
+/**
+ * `@param pathname` the current location pathname
+ * `@param organizationId` active org id
+ * `@param fromAgentId` agent currently open (decoded route param)
+ * `@param toAgentId` agent to open (decoded slug / name)
+ */
+export function agentSwitchPathname(
+  pathname: string,
+  organizationId: string,
+  fromAgentId: string,
+  toAgentId: string,
+): string {
+  const fromEnc = encodeURIComponent(fromAgentId);
+  const toEnc = encodeURIComponent(toAgentId);
+  const prefix = `/dashboard/${organizationId}/agents/${fromEnc}`;
+  const targetRoot = `/dashboard/${organizationId}/agents/${toEnc}`;
+  if (pathname !== prefix && !pathname.startsWith(`${prefix}/`)) {
+    // Path may carry a raw (decoded) agent id when the slug has no reserved
+    // characters — accept that form too so the switch still preserves tabs.
+    const rawPrefix = `/dashboard/${organizationId}/agents/${fromAgentId}`;
+    if (pathname === rawPrefix || pathname.startsWith(`${rawPrefix}/`)) {
+      return switchRest(pathname, rawPrefix, targetRoot);
+    }
+    return targetRoot;
+  }
+  return switchRest(pathname, prefix, targetRoot);
+}
+
+function switchRest(
+  pathname: string,
+  prefix: string,
+  targetRoot: string,
+): string {
+  const rest = pathname.slice(prefix.length);
+  if (rest === '' || rest === '/') return targetRoot;
+  const firstSegment = rest.slice(1).split('/')[0] ?? '';
+  if (!PORTABLE_AGENT_SEGMENTS.has(firstSegment)) return targetRoot;
+  return `${targetRoot}${rest}`;
+}

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.breadcrumb.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.breadcrumb.test.tsx
@@ -95,6 +95,15 @@ vi.mock('@/app/features/agents/components/agent-navigation', () => ({
   AgentNavigation: () => null,
 }));
 
+// The breadcrumb leaf switcher pulls in the router (`useNavigate`) and locale
+// context; this test only covers the trail typography, so stub it to the plain
+// display name — its own behaviour is covered in agent-breadcrumb-switcher.test.
+vi.mock('@/app/features/agents/components/agent-breadcrumb-switcher', () => ({
+  AgentBreadcrumbSwitcher: ({ displayName }: { displayName: string }) => (
+    <>{displayName}</>
+  ),
+}));
+
 import { AdaptiveHeaderProvider } from '@/app/components/layout/adaptive-header';
 
 import { Route } from './$agentId';

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -19,6 +19,7 @@ import {
   TabNavigation,
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
+import { AgentBreadcrumbSwitcher } from '@/app/features/agents/components/agent-breadcrumb-switcher';
 import { AgentNavigation } from '@/app/features/agents/components/agent-navigation';
 import {
   useListAgents,
@@ -172,7 +173,13 @@ function AgentDetailLayout() {
             className="contents"
           >
             <SkeletonBox>
-              {resolvedDisplayName || (
+              {resolvedDisplayName ? (
+                <AgentBreadcrumbSwitcher
+                  organizationId={organizationId}
+                  agentId={agentId}
+                  displayName={resolvedDisplayName}
+                />
+              ) : (
                 <span className="inline-block h-4 w-32 align-middle" />
               )}
             </SkeletonBox>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5584,6 +5584,9 @@
       "agentNotFound": "Agent nicht gefunden oder Du hast keinen Zugriff.",
       "agentSaved": "Agent gespeichert",
       "agentSaveFailed": "Agent konnte nicht gespeichert werden",
+      "switcher": {
+        "ariaLabel": "Agent wechseln, aktuell: {name}"
+      },
       "validation": {
         "displayNameRequired": "Gib einen Anzeigenamen ein.",
         "systemInstructionsRequired": "Gib Systemanweisungen ein.",
@@ -5611,6 +5614,7 @@
       },
       "history": {
         "empty": "Keine Verlaufseinträge",
+        "menuLabel": "Versionsverlauf",
         "diffTitle": "Änderungen vergleichen",
         "diffDescription": "Unterschiede prüfen, bevor der Snapshot vom {date} wiederhergestellt wird",
         "noDifferences": "Keine Unterschiede gefunden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5880,6 +5880,9 @@
       "agentNotFound": "Agent not found or you don't have access.",
       "agentSaved": "Agent saved",
       "agentSaveFailed": "Failed to save agent",
+      "switcher": {
+        "ariaLabel": "Switch agent, current: {name}"
+      },
       "validation": {
         "displayNameRequired": "Enter a display name.",
         "systemInstructionsRequired": "Enter system instructions.",
@@ -5907,6 +5910,7 @@
       },
       "history": {
         "empty": "No history entries",
+        "menuLabel": "Version history",
         "diffTitle": "Compare changes",
         "diffDescription": "Review differences before restoring snapshot from {date}",
         "noDifferences": "No differences found",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5584,6 +5584,9 @@
       "agentNotFound": "Agent introuvable ou tu n'as pas accès.",
       "agentSaved": "Agent enregistré",
       "agentSaveFailed": "Échec de l'enregistrement de l'agent",
+      "switcher": {
+        "ariaLabel": "Changer d'agent, actuel : {name}"
+      },
       "validation": {
         "displayNameRequired": "Saisis un nom d'affichage.",
         "systemInstructionsRequired": "Saisis des instructions système.",
@@ -5611,6 +5614,7 @@
       },
       "history": {
         "empty": "Aucune entrée d'historique",
+        "menuLabel": "Historique des versions",
         "diffTitle": "Comparer les modifications",
         "diffDescription": "Examine les différences avant de restaurer l'instantané du {date}",
         "noDifferences": "Aucune différence trouvée",


### PR DESCRIPTION
## What & why

Two small, related enhancements to the agent detail page.

- **Breadcrumb switcher.** The breadcrumb leaf (the agent's display name) was static text. It is now
  a dropdown of sibling agents (`AgentBreadcrumbSwitcher`) so an operator can jump between agents
  without returning to the roster. Portable editor tabs (instructions, tools, skills, …) are
  preserved across the switch via `agentSwitchPathname`; any other sub-path resets to the agent
  overview. Falls back to plain text when there are no siblings.
- **History menu label.** The version-history dropdown now carries a "Version history" heading and a
  tighter width, so the bare date list reads as a titled menu.

`agent-switch-path.ts` is a pure, unit-tested helper (the tab-preservation logic).

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 13/13
  (agent-switch-path, agent-breadcrumb-switcher, agent-navigation).
- [x] **Tests** — new specs for the switcher and the path helper (portable tab preserved, raw-slug
  form, non-portable/nested reset, no-sibling fallback); the agent-navigation spec covers the menu.
- [x] **Locales** — `agents.switcher.ariaLabel` + `agents.history.menuLabel` added to en/de/fr.
- [x] **Accessibility** — switcher trigger has an `aria-label` (current agent), keyboard reachable,
  visible focus ring; items are real menu items.
- [N/A] **Migration** — no data/config change.
- [N/A] **Docs** — the "Browse agents" copy/doc is a separate PR.
- [x] **Observed** — specs assert dropdown items, the selection navigation target, and the fallback.
