### PR TITLE
refactor(platform): reroute chat browse button to agents roster

### DIFF
--- a/docs/de/platform/chat/agents-in-chat.md
+++ b/docs/de/platform/chat/agents-in-chat.md
@@ -5,15 +5,15 @@ description: Wie der Agent-Picker im Chat funktioniert — welche Agents erschei
 
 Einen Agent im Chat zu wählen ist der Unterschied zwischen einer Frage an den generischen Assistenten und einer Frage an etwas, das die Org für eine Domäne geformt hat. Der Agent-Picker ist das meistgenutzte Bedienelement im Chat; welche Agents erscheinen, wann ein Agent gesetzt bleibt und was beim Wechsel mitten im Chat passiert, ist das Thema dieser Seite.
 
-<Frame caption="Der geöffnete Agent-Picker über dem Chat — Auto, die installierten Agents und der Katalog-Shortcut.">
+<Frame caption="Der geöffnete Agent-Picker über dem Chat — Auto, die installierten Agents und der Shortcut Agenten ansehen.">
 
-![Der über dem Chat geöffnete Agent-Picker zeigt ein Suchfeld, einen Auto-Eintrag, den ausgewählten Assistenten, einen Eintrag namens Automation Assistant und einen Knopf Automatisierungen durchsuchen.](/images/platform/chat-agent-picker.webp)
+![Der über dem Chat geöffnete Agent-Picker zeigt ein Suchfeld, einen Auto-Eintrag, den ausgewählten Assistenten, einen Eintrag namens Automation Assistant und einen Knopf Agenten ansehen.](/images/platform/chat-agent-picker.webp)
 
 </Frame>
 
 ## Der Agent-Picker
 
-Klick auf den Agent-Chip am Chat (sein zugänglicher Name ist **Agent auswählen**), und der Picker öffnet mit **Agents suchen** obenauf. Die Liste zeigt **Auto** — Tale routet jede Nachricht an den Agent, der am besten passt — gefolgt von jedem Agent, auf den du Zugriff hast und der als **Im Chat sichtbar** markiert ist; Coding-Agenten bekommen einen eigenen Abschnitt **Coding-Agenten**, sobald welche sichtbar sind. Agents ohne diesen Schalter existieren in der Org, tauchen hier aber nie auf, was die Liste kurz hält. **Automatisierungen durchsuchen** unten führt zum [Automatisierungen-Katalog](/de/platform/automations/catalog) — neue Agents kommen als Teil einer Automatisierung an, die du installierst.
+Klick auf den Agent-Chip am Chat (sein zugänglicher Name ist **Agent auswählen**), und der Picker öffnet mit **Agents suchen** obenauf. Die Liste zeigt **Auto** — Tale routet jede Nachricht an den Agent, der am besten passt — gefolgt von jedem Agent, auf den du Zugriff hast und der als **Im Chat sichtbar** markiert ist; Coding-Agenten bekommen einen eigenen Abschnitt **Coding-Agenten**, sobald welche sichtbar sind. Agents ohne diesen Schalter existieren in der Org, tauchen hier aber nie auf, was die Liste kurz hält. **Agenten ansehen** unten führt zur [Agenten-Liste](/de/platform/agents/create) — dort legst du Agents an, lädst sie hoch oder verwaltest sie.
 
 ## „Im Chat sichtbar"
 

--- a/docs/en/platform/chat/agents-in-chat.md
+++ b/docs/en/platform/chat/agents-in-chat.md
@@ -5,15 +5,15 @@ description: How the agents picker works in Chat — which agents appear, what "
 
 Picking an agent in Chat is the difference between asking a generic Assistant and asking something the org has shaped for a domain. The agents picker is the most-used control in the chat; the rules behind which agent appears, when an agent persists, and what happens when you switch mid-chat are the subject of this page.
 
-<Frame caption="The agent picker open over the chat — Auto, the installed agents, and the Catalog shortcut.">
+<Frame caption="The agent picker open over the chat — Auto, the installed agents, and the Browse agents shortcut.">
 
-![The agent picker open above the chat input, showing a search field, an Auto entry, the selected Assistant, an Automation Assistant entry, and a Browse automations button.](/images/platform/chat-agent-picker.webp)
+![The agent picker open above the chat input, showing a search field, an Auto entry, the selected Assistant, an Automation Assistant entry, and a Browse agents button.](/images/platform/chat-agent-picker.webp)
 
 </Frame>
 
 ## The agents picker
 
-Click the agent chip on the chat (its accessible name is **Select agent**) and the picker opens with **Search agents** at the top. The list shows **Auto** — Tale routes each message to the best-fitting agent — followed by every agent you have access to that is marked **Visible in chat**; coding agents get their own **Coding agents** section when any are visible. Agents without that toggle exist in the org but never surface here, which keeps the list short. **Browse automations** at the bottom leads to the [Automations catalog](/platform/automations/catalog) — new agents arrive as part of an automation you install.
+Click the agent chip on the chat (its accessible name is **Select agent**) and the picker opens with **Search agents** at the top. The list shows **Auto** — Tale routes each message to the best-fitting agent — followed by every agent you have access to that is marked **Visible in chat**; coding agents get their own **Coding agents** section when any are visible. Agents without that toggle exist in the org but never surface here, which keeps the list short. **Browse agents** at the bottom leads to the [agents list](/platform/agents/create) — create, upload, or manage agents there.
 
 ## "Visible in chat"
 

--- a/docs/fr/platform/chat/agents-in-chat.md
+++ b/docs/fr/platform/chat/agents-in-chat.md
@@ -5,15 +5,15 @@ description: Comment fonctionne le sélecteur d’agents dans le Chat — quels 
 
 Choisir un agent dans le Chat fait la différence entre interroger un Assistant générique et interroger quelque chose que l’organisation a façonné pour un domaine. Le sélecteur d’agents est le contrôle le plus utilisé du chat ; les règles qui décident quel agent apparaît, quand un agent persiste, et ce qui se passe quand tu changes en cours de chat font l’objet de cette page.
 
-<Frame caption="Le sélecteur d’agents ouvert au-dessus du chat — Auto, les agents installés et le raccourci Catalogue.">
+<Frame caption="Le sélecteur d’agents ouvert au-dessus du chat — Auto, les agents installés et le raccourci Parcourir les agents.">
 
-![Le sélecteur d’agents ouvert au-dessus du chat, montrant un champ de recherche, une entrée Auto, l’Assistant sélectionné, une entrée Assistant d’automatisation et un bouton Parcourir les automatisations.](/images/platform/chat-agent-picker.webp)
+![Le sélecteur d’agents ouvert au-dessus du chat, montrant un champ de recherche, une entrée Auto, l’Assistant sélectionné, une entrée Assistant d’automatisation et un bouton Parcourir les agents.](/images/platform/chat-agent-picker.webp)
 
 </Frame>
 
 ## Le sélecteur d’agents
 
-Clique sur la puce d’agent du chat (son nom accessible est **Sélectionner un agent**) et le sélecteur s’ouvre avec **Rechercher des agents** en haut. La liste montre **Auto** — Tale route chaque message vers l’agent qui colle le mieux — suivi de chaque agent auquel tu as accès et qui est marqué **Visible dans le chat** ; les agents de code ont leur propre section **Agents de code** dès que l’un d’eux est visible. Les agents sans cette bascule existent dans l’organisation mais ne montent jamais ici, ce qui garde la liste courte. **Parcourir les automatisations**, en bas, mène au [catalogue des automatisations](/fr/platform/automations/catalog) — les nouveaux agents arrivent au sein d’une automatisation que tu installes.
+Clique sur la puce d’agent du chat (son nom accessible est **Sélectionner un agent**) et le sélecteur s’ouvre avec **Rechercher des agents** en haut. La liste montre **Auto** — Tale route chaque message vers l’agent qui colle le mieux — suivi de chaque agent auquel tu as accès et qui est marqué **Visible dans le chat** ; les agents de code ont leur propre section **Agents de code** dès que l’un d’eux est visible. Les agents sans cette bascule existent dans l’organisation mais ne montent jamais ici, ce qui garde la liste courte. **Parcourir les agents**, en bas, mène à la [liste des agents](/fr/platform/agents/create) — crée, charge ou gère les agents depuis là.
 
 ## « Visible dans le chat »
 

--- a/services/platform/app/features/chat/components/agent-selector.test.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/lib/i18n/client', () => ({
         'agentSelector.auto': 'Auto',
         'agentSelector.autoDescription':
           'Auto picks the best agent per message.',
-        'agentSelector.browseAutomations': 'Browse automations',
+        'agentSelector.browseAgents': 'Browse agents',
         'agentSelector.sectionAgents': 'Agents',
         'agentSelector.sectionCodingAgents': 'Coding agents',
         'agentSelector.sectionImageAgents': 'Image agents',
@@ -240,13 +240,13 @@ describe('AgentSelector', () => {
     expect(trigger).toHaveClass('sm:min-w-32');
   });
 
-  it('shows the "Browse automations" button when user has write permission', async () => {
+  it('shows the "Browse agents" button when user has write permission', async () => {
     const { user } = render(<AgentSelector organizationId="org-1" />);
 
     const trigger = screen.getByLabelText('Select agent');
     await user.click(trigger);
 
-    expect(screen.getByText('Browse automations')).toBeInTheDocument();
+    expect(screen.getByText('Browse agents')).toBeInTheDocument();
   });
 
   it('groups platform and coding agents under section headers', async () => {
@@ -273,7 +273,7 @@ describe('AgentSelector', () => {
     expect(screen.getByText('Software Developer')).toBeInTheDocument();
   });
 
-  it('hides the "Browse automations" button when user lacks write permission', async () => {
+  it('hides the "Browse agents" button when user lacks write permission', async () => {
     mockCanWrite = false;
 
     const { user } = render(<AgentSelector organizationId="org-1" />);
@@ -281,7 +281,7 @@ describe('AgentSelector', () => {
     const trigger = screen.getByLabelText('Select agent');
     await user.click(trigger);
 
-    expect(screen.queryByText('Browse automations')).not.toBeInTheDocument();
+    expect(screen.queryByText('Browse agents')).not.toBeInTheDocument();
   });
 
   it('shows a "view agent details" link on each agent row (not Auto) for managers', async () => {
@@ -327,17 +327,17 @@ describe('AgentSelector', () => {
     expect(mockSetSelectedAgent).not.toHaveBeenCalled();
   });
 
-  it('navigates to the automations catalog when "Browse automations" is clicked', async () => {
+  it('navigates to the agents roster when "Browse agents" is clicked', async () => {
     const { user } = render(<AgentSelector organizationId="org-1" />);
 
     const trigger = screen.getByLabelText('Select agent');
     await user.click(trigger);
 
-    const addButton = screen.getByText('Browse automations');
+    const addButton = screen.getByText('Browse agents');
     await user.click(addButton);
 
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/dashboard/$id/automations',
+      to: '/dashboard/$id/agents',
       params: { id: 'org-1' },
     });
   });

--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -189,13 +189,14 @@ export const AgentSelector = memo(function AgentSelector({
     [allAgents, readiness, navigate, organizationId, setSelectedAgent],
   );
 
-  // The footer "Browse automations" button sends the user to the Automations
-  // catalog — agents are installed via automations now, so that's the
-  // browse-and-install surface — rather than a bare create-agent dialog.
+  // The footer "Browse agents" button sends the user to the agents roster —
+  // create, upload, and manage live there (same surface as the @-mention
+  // empty action). Automations remain the install path for packaged agents,
+  // reachable from the roster's create menu.
   const handleAddAgentClick = useCallback(() => {
     setOpen(false);
     void navigate({
-      to: '/dashboard/$id/automations',
+      to: '/dashboard/$id/agents',
       params: { id: organizationId },
     });
   }, [navigate, organizationId]);
@@ -203,7 +204,7 @@ export const AgentSelector = memo(function AgentSelector({
   // Right-side action per row: a link to that agent's detail page, mirroring
   // the model selector's provider link. Skipped for the "Auto" pseudo-option
   // (no agent to view) and only shown to users who can manage agents — the
-  // detail page is the same `agents` write gate as the "Browse automations"
+  // detail page is the same `agents` write gate as the "Browse agents"
   // footer button.
   const renderOptionAction = useCallback(
     (option: SearchableSelectOption): ReactNode => {
@@ -332,7 +333,7 @@ export const AgentSelector = memo(function AgentSelector({
             icon={LayoutGrid}
             onClick={handleAddAgentClick}
           >
-            {t('agentSelector.browseAutomations')}
+            {t('agentSelector.browseAgents')}
           </Button>
         ) : undefined
       }

--- a/services/platform/app/features/chat/components/chat-input.test.tsx
+++ b/services/platform/app/features/chat/components/chat-input.test.tsx
@@ -477,12 +477,12 @@ describe('ChatInput disabled composer (no agents)', () => {
     expect(screen.queryByText(/publish/i)).not.toBeInTheDocument();
   });
 
-  it('shows Browse automations for an admin who can install agents', () => {
+  it('shows Browse agents for an admin who can install agents', () => {
     mockCan.mockReturnValue(true);
     renderDisabledForNoAgents();
 
     expect(
-      screen.getByRole('link', { name: 'Browse automations' }),
+      screen.getByRole('link', { name: 'Browse agents' }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/ask an admin/i)).not.toBeInTheDocument();
   });
@@ -497,7 +497,7 @@ describe('ChatInput disabled composer (no agents)', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'Browse automations' }),
+      screen.queryByRole('link', { name: 'Browse agents' }),
     ).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/chat/components/no-agents-action.tsx
+++ b/services/platform/app/features/chat/components/no-agents-action.tsx
@@ -8,8 +8,8 @@ import { useT } from '@/lib/i18n/client';
 
 /**
  * Inline next-step for the no-agents composer block. Writers get a deep link
- * to Automations (where agents are installed now); Members get an ask-admin
- * hint — they cannot open Agents or Automations themselves.
+ * to the agents roster (create / upload / manage); Members get an ask-admin
+ * hint — they cannot open Agents themselves.
  */
 export function NoAgentsErrorAction({
   organizationId,
@@ -32,11 +32,11 @@ export function NoAgentsErrorAction({
       variant="secondary"
       size="sm"
       icon={LayoutGrid}
-      href="/dashboard/$id/automations"
+      href="/dashboard/$id/agents"
       params={{ id: organizationId }}
       className="w-fit gap-1.5"
     >
-      {t('agentSelector.browseAutomations')}
+      {t('agentSelector.browseAgents')}
     </LinkButton>
   );
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1173,7 +1173,7 @@
       "noResults": "Keine Agents gefunden",
       "lockedExternal": "Dieser Chat läuft in einer Sandbox und behält seinen Coding-Agent — starte einen neuen Chat, um einen anderen zu verwenden.",
       "lockedExternalLabel": "Agent: {{agent}} (für diesen Sandbox-Chat festgelegt)",
-      "browseAutomations": "Automatisierungen durchsuchen",
+      "browseAgents": "Agenten ansehen",
       "sectionAgents": "Agenten",
       "sectionCodingAgents": "Coding-Agenten",
       "sectionImageAgents": "Bild"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1173,7 +1173,7 @@
       "noResults": "No agents found",
       "lockedExternal": "This chat runs in a sandbox and keeps its coding agent — start a new chat to use a different one.",
       "lockedExternalLabel": "Agent: {{agent}} (pinned for this sandbox chat)",
-      "browseAutomations": "Browse automations",
+      "browseAgents": "Browse agents",
       "sectionAgents": "Agents",
       "sectionCodingAgents": "Coding agents",
       "sectionImageAgents": "Image agents"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1173,7 +1173,7 @@
       "noResults": "Aucun agent trouvé",
       "lockedExternal": "Ce chat s'exécute dans un bac à sable et garde son agent de code — démarre un nouveau chat pour en utiliser un autre.",
       "lockedExternalLabel": "Agent : {{agent}} (fixé pour ce chat sandbox)",
-      "browseAutomations": "Parcourir les automatisations",
+      "browseAgents": "Parcourir les agents",
       "sectionAgents": "Agents",
       "sectionCodingAgents": "Agents de code",
       "sectionImageAgents": "Image"


### PR DESCRIPTION
## What & why

The chat agent picker's footer button and the no-agents empty state linked to the **Automations
catalog**, framed as "Browse automations" — a leftover from when agents only arrived via automation
installs. Agents now have a first-class roster (create / upload / manage), so both entry points now
read **"Browse agents"** and route to `/dashboard/$id/agents`.

- `agent-selector.tsx`, `no-agents-action.tsx` — label + navigation target.
- `agentSelector.browseAutomations` → `browseAgents` in en/de/fr (the unrelated
  `conversations.activate.browseAutomations` key is left untouched).
- `docs/{en,de,fr}/platform/chat/agents-in-chat.md` — copy, the link (now `/platform/agents/create`),
  and the screenshot alt text.

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 35/35
  (agent-selector, chat-input).
- [x] **Tests** — specs updated to assert the new label and the `/dashboard/$id/agents` navigation
  target for both write-permitted and member cases.
- [x] **Locales** — key renamed in all three locales.
- [x] **Docs** — agents-in-chat page updated; the new link target `/platform/agents/create` verified
  present in en/de/fr.
- [N/A] **Migration / Accessibility** — no data change; the button keeps its role/label.
- [x] **Observed** — specs assert label + navigate() args; docs link target existence checked.
