### PR TITLE
refactor(platform): responsive workflow minimap and panel borders

### DIFF
--- a/services/platform/app/features/workflows/components/workflow-ai-chat-panel.tsx
+++ b/services/platform/app/features/workflows/components/workflow-ai-chat-panel.tsx
@@ -63,7 +63,7 @@ export function WorkflowAIChatPanel({
       aria-label={t('sidePanel.aiAssistant')}
       style={{ '--panel-width': `${width}px` }}
       className={cn(
-        'bg-background border-border flex min-h-0 w-(--panel-width) flex-col overflow-hidden border-l shadow-lg max-md:absolute max-md:inset-0 max-md:z-20 max-md:w-full max-md:shadow-none',
+        'bg-background border-border flex min-h-0 w-(--panel-width) flex-col overflow-hidden md:border-l shadow-lg max-md:absolute max-md:inset-0 max-md:z-20 max-md:w-full max-md:shadow-none',
         overlay
           ? 'absolute top-0 right-0 bottom-0 z-20'
           : 'relative flex-[0_0_auto] shadow-none',

--- a/services/platform/app/features/workflows/components/workflow-minimap-dimensions.test.ts
+++ b/services/platform/app/features/workflows/components/workflow-minimap-dimensions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeMinimapDimensions } from './workflow-minimap-dimensions';
+
+describe('computeMinimapDimensions', () => {
+  it('sizes a compact MiniMap on a phone-width canvas', () => {
+    expect(computeMinimapDimensions(375, 600)).toEqual({
+      width: 68,
+      height: 109,
+    });
+  });
+
+  it('sizes a compact MiniMap on a chat-squeezed desktop canvas', () => {
+    expect(computeMinimapDimensions(400, 512)).toEqual({
+      width: 72,
+      height: 92,
+    });
+  });
+
+  it('sizes proportionally on a wide canvas', () => {
+    const dims = computeMinimapDimensions(900, 600);
+    expect(dims).toEqual({ width: 162, height: 108 });
+  });
+
+  it('caps height below the old 200px max on a tall over-threshold canvas', () => {
+    const dims = computeMinimapDimensions(500, 900);
+    expect(dims).toEqual({ width: 90, height: 160 });
+  });
+
+  it('returns null for zero-sized containers', () => {
+    expect(computeMinimapDimensions(0, 600)).toBeNull();
+    expect(computeMinimapDimensions(600, 0)).toBeNull();
+  });
+});

--- a/services/platform/app/features/workflows/components/workflow-minimap-dimensions.ts
+++ b/services/platform/app/features/workflows/components/workflow-minimap-dimensions.ts
@@ -1,0 +1,47 @@
+/**
+ * Container-relative MiniMap size for the workflow canvas.
+ *
+ * Sized from the canvas container (not the window) so a chat-squeezed or
+ * phone-width canvas does not keep a desktop-sized MiniMap. Returns `null`
+ * only when the container has not been measured yet (non-positive size).
+ */
+
+const MINIMAP_WIDTH_RATIO = 0.18;
+const MINIMAP_MIN_WIDTH = 64;
+const MINIMAP_MAX_WIDTH = 192;
+const MINIMAP_MIN_HEIGHT = 64;
+const MINIMAP_MAX_HEIGHT = 160;
+const MINIMAP_HEIGHT_RATIO = 0.28;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export type MinimapDimensions = { width: number; height: number };
+
+export function computeMinimapDimensions(
+  containerWidth: number,
+  containerHeight: number,
+): MinimapDimensions | null {
+  if (containerWidth <= 0 || containerHeight <= 0) {
+    return null;
+  }
+
+  const width = clamp(
+    Math.round(containerWidth * MINIMAP_WIDTH_RATIO),
+    MINIMAP_MIN_WIDTH,
+    MINIMAP_MAX_WIDTH,
+  );
+  const aspectRatio = containerWidth / containerHeight;
+  const heightCap = Math.min(
+    MINIMAP_MAX_HEIGHT,
+    Math.round(containerHeight * MINIMAP_HEIGHT_RATIO),
+  );
+  const height = clamp(
+    Math.round(width / aspectRatio),
+    MINIMAP_MIN_HEIGHT,
+    heightCap,
+  );
+
+  return { width, height };
+}

--- a/services/platform/app/features/workflows/components/workflow-sidepanel.tsx
+++ b/services/platform/app/features/workflows/components/workflow-sidepanel.tsx
@@ -241,7 +241,7 @@ export function WorkflowSidePanel({
       style={{ '--panel-width': `${width}px` }}
       as="aside"
       gap={0}
-      className="bg-background border-border relative min-h-0 w-(--panel-width) flex-[0_0_auto] overflow-hidden border-l max-md:absolute max-md:inset-0 max-md:z-10 max-md:w-full"
+      className="bg-background border-border relative min-h-0 w-(--panel-width) flex-[0_0_auto] overflow-hidden max-md:absolute max-md:inset-0 max-md:z-10 max-md:w-full md:border-l"
     >
       {/* Resize handle */}
       <div

--- a/services/platform/app/features/workflows/components/workflow-steps.tsx
+++ b/services/platform/app/features/workflows/components/workflow-steps.tsx
@@ -34,6 +34,10 @@ import { WorkflowCallbacksProvider } from './workflow-callbacks-context';
 import { WorkflowEdge } from './workflow-edge';
 import { WorkflowGroupNode } from './workflow-group-node';
 import { WorkflowLoopContainer } from './workflow-loop-container';
+import {
+  computeMinimapDimensions,
+  type MinimapDimensions,
+} from './workflow-minimap-dimensions';
 import { WorkflowStep } from './workflow-step';
 
 interface WorkflowStepsProps {
@@ -147,10 +151,8 @@ function WorkflowStepsInner({
   });
 
   const [showActivityBanner, setShowActivityBanner] = useState(true);
-  const [minimapDimensions, setMinimapDimensions] = useState({
-    width: 192,
-    height: 128,
-  });
+  const [minimapDimensions, setMinimapDimensions] =
+    useState<MinimapDimensions | null>(null);
 
   const { fitView, getViewport } = useReactFlow();
 
@@ -174,23 +176,13 @@ function WorkflowStepsInner({
     const container = containerRef.current;
     if (!container) return undefined;
 
-    const MINIMAP_BASE_WIDTH = 144;
-    const MINIMAP_MAX_WIDTH = 192;
     const WIDTH_CHANGE_THRESHOLD = 50;
 
     const handleContainerResize = () => {
       const { width, height } = container.getBoundingClientRect();
       if (width === 0 || height === 0) return;
 
-      const aspectRatio = width / height;
-      const isMobile = window.innerWidth < 768;
-      const baseWidth = isMobile ? MINIMAP_BASE_WIDTH : MINIMAP_MAX_WIDTH;
-      const calculatedHeight = Math.round(baseWidth / aspectRatio);
-
-      setMinimapDimensions({
-        width: baseWidth,
-        height: Math.max(80, Math.min(calculatedHeight, 200)),
-      });
+      setMinimapDimensions(computeMinimapDimensions(width, height));
 
       // Skip the first measurement: ReactFlow's own `fitView` prop already
       // centers the initial graph (instantly). Firing another fitView here on
@@ -337,19 +329,23 @@ function WorkflowStepsInner({
             nodesFocusable
             edgesFocusable
             multiSelectionKeyCode={['Meta', 'Ctrl']}
-            minimapProps={{
-              className:
-                'border-border overflow-hidden rounded-lg border shadow-sm',
-              style: {
-                width: minimapDimensions.width,
-                height: minimapDimensions.height,
-              },
-              nodeStrokeColor: minimapNodeStrokeColor,
-              nodeStrokeWidth: 3,
-              pannable: true,
-              zoomable: true,
-              inversePan: false,
-            }}
+            minimapProps={
+              minimapDimensions
+                ? {
+                    className:
+                      'border-border overflow-hidden rounded-lg border shadow-sm',
+                    style: {
+                      width: minimapDimensions.width,
+                      height: minimapDimensions.height,
+                    },
+                    nodeStrokeColor: minimapNodeStrokeColor,
+                    nodeStrokeWidth: 3,
+                    pannable: true,
+                    zoomable: true,
+                    inversePan: false,
+                  }
+                : undefined
+            }
             backgroundProps={{
               variant: BackgroundVariant.Dots,
               gap: 20,


### PR DESCRIPTION
## What & why

Two workflow-canvas responsiveness fixes.

- **Minimap sizes to its container.** The MiniMap was sized from `window.innerWidth` (a binary
  mobile/desktop check), so a chat-squeezed or embedded canvas kept a desktop-sized minimap. Sizing
  is extracted into a pure, unit-tested `computeMinimapDimensions` that scales from the canvas
  container's own box (clamped width/height ratios); the minimap renders only once the container has
  been measured.
- **No stray panel hairline on phones.** The workflow side panel and AI chat panel are full-width
  below `md`; their permanent left border read as a hairline against the viewport. Gated to
  `md:border-l`.

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 9/9
  (workflow-minimap-dimensions, workflow-steps).
- [x] **Tests** — new unit spec for `computeMinimapDimensions` (ratios, clamps, unmeasured → null);
  existing workflow-steps spec still green.
- [N/A] **Migration / Locales / Docs** — no data, string, or documented behaviour change.
- [N/A] **Accessibility** — the MiniMap is a decorative canvas control; border is cosmetic.
- [x] **Observed** — pure-function spec covers the sizing math; border change is class-level.

Two atomic commits: the minimap refactor and the border fix.
