### PR TITLE
fix(platform): make prompt dialogs full-width on mobile

### DIFF
--- a/services/platform/app/features/prompts/components/prompt-history-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-history-dialog.tsx
@@ -242,7 +242,9 @@ export function PromptHistoryDialog({
         onOpenChange={onOpenChange}
         title={dialogTitle}
         description={dialogDescription}
-        className="w-[95vw] max-w-[720px]"
+        // Width is desktop-only: unprefixed w/max-w override the shared Dialog
+        // mobile bottom-sheet (`w-full max-w-full`) and leave side gaps.
+        className="md:w-[95vw] md:max-w-[720px]"
       >
         {comparingVersion && history ? (
           <PromptCompareView

--- a/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
@@ -319,7 +319,9 @@ function PromptLibraryDialogContent({
         onOpenChange={onOpenChange}
         title={t('library.title')}
         description={t('library.description')}
-        className="w-[95vw] max-w-[680px]"
+        // Width is desktop-only: unprefixed w/max-w override the shared Dialog
+        // mobile bottom-sheet (`w-full max-w-full`) and leave side gaps.
+        className="md:w-[95vw] md:max-w-[680px]"
       >
         <Stack>
           <Tabs


### PR DESCRIPTION
## What & why

`PromptHistoryDialog` and `PromptLibraryDialog` passed an **unprefixed** `w-[95vw]` / `max-w-*` to the
shared `Dialog`. On phones that overrode the Dialog's mobile bottom-sheet sizing (`w-full max-w-full`)
and left side gaps. Gate the desktop width override behind `md:` so the mobile sheet stays full-width
while desktop keeps its capped width.

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 14/14
  (prompt-history-dialog, prompt-library-dialog).
- [x] **Tests** — existing dialog specs pass unchanged (content/behaviour untouched).
- [N/A] **Migration / Locales / Docs** — CSS-only responsive fix; no data, string, or doc change.
- [x] **Accessibility** — dialog role/labelling unchanged; full-width improves the mobile target.
- [x] **Observed** — class-level change; specs assert the dialogs still render their content.
