### PR TITLE
fix(platform): defer Sheet side border to sm+ for mobile full-bleed

### DIFF
--- a/services/platform/app/components/ui/overlays/sheet.test.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.test.tsx
@@ -8,6 +8,33 @@ import { Sheet } from './sheet';
 const MISSING_DESCRIPTION_WARNING = 'Missing `Description`';
 
 describe('Sheet', () => {
+  describe('full-bleed mobile edge borders', () => {
+    // Below `sm` the panel is `w-full`; a permanent side border reads as a
+    // hairline against the viewport. Borders apply from `sm` up where the
+    // panel is inset.
+    it('defers the left border on a right sheet to sm+', () => {
+      render(
+        <Sheet open onOpenChange={vi.fn()} title="Sheet Title" side="right">
+          <p>Sheet content</p>
+        </Sheet>,
+      );
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveClass('sm:border-l');
+      expect(dialog).not.toHaveClass('border-l');
+    });
+
+    it('defers the right border on a left sheet to sm+', () => {
+      render(
+        <Sheet open onOpenChange={vi.fn()} title="Sheet Title" side="left">
+          <p>Sheet content</p>
+        </Sheet>,
+      );
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveClass('sm:border-r');
+      expect(dialog).not.toHaveClass('border-r');
+    });
+  });
+
   describe('accessibility', () => {
     it('marks the content as a modal dialog (aria-modal)', () => {
       render(

--- a/services/platform/app/components/ui/overlays/sheet.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.tsx
@@ -48,9 +48,11 @@ const sheetVariants = cva(
         top: 'inset-x-0 top-0 h-full sm:h-auto border-b pt-[calc(1.5rem+var(--safe-top))] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
         bottom:
           'inset-x-0 bottom-0 h-full sm:h-auto border-t pb-[calc(1.5rem+var(--safe-bottom))] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        left: 'inset-y-0 left-0 h-full w-full sm:w-3/4 border-r pt-[calc(1.5rem+var(--safe-top))] pb-[calc(1.5rem+var(--safe-bottom))] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        // Side borders only from `sm` up — below that the panel is `w-full` and
+        // an edge border against the viewport reads as a stray hairline.
+        left: 'inset-y-0 left-0 h-full w-full sm:w-3/4 sm:border-r pt-[calc(1.5rem+var(--safe-top))] pb-[calc(1.5rem+var(--safe-bottom))] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
         right:
-          'inset-y-0 right-0 h-full w-full sm:w-3/4 border-l pt-[calc(1.5rem+var(--safe-top))] pb-[calc(1.5rem+var(--safe-bottom))] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+          'inset-y-0 right-0 h-full w-full sm:w-3/4 sm:border-l pt-[calc(1.5rem+var(--safe-top))] pb-[calc(1.5rem+var(--safe-bottom))] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
       },
       size: {
         sm: '',


### PR DESCRIPTION
## What & why

Below the `sm` breakpoint the `Sheet` panel is `w-full`; its permanent left/right edge border read
as a stray hairline against the viewport. Move the side borders to `sm:border-l` / `sm:border-r` so
they apply only from `sm` up, where the panel is inset. (Same full-bleed-border idea as the workflow
panels, on the shared `Sheet` primitive.)

## Definition of done

- [x] **Green gate** — `oxfmt --check` clean; `@tale/platform typecheck` clean; vitest 7/7 (sheet).
- [x] **Tests** — new "full-bleed mobile edge borders" specs assert the border is `sm:`-gated on both
  left and right sheets.
- [N/A] **Migration / Locales / Docs** — CSS-only responsive fix.
- [x] **Accessibility** — dialog role/labelling unchanged; purely cosmetic border.
- [x] **Observed** — specs assert the rendered `sm:border-*` classes.
