### PR TITLE
test(platform): replace real addresses with placeholders in fixtures

### DIFF
--- a/services/platform/app/features/contacts/hooks/use-contacts-table-config.test.tsx
+++ b/services/platform/app/features/contacts/hooks/use-contacts-table-config.test.tsx
@@ -66,7 +66,7 @@ describe('useContactsTableConfig', () => {
   // over the next one. `block` makes the span honour the cell width and
   // `truncate` clips the overflow with an ellipsis instead of spilling.
   it('truncates the Name, Email and Phone cells so long values cannot bleed across columns', () => {
-    const longEmail = 'mustophaadesinamyd@gmail.com';
+    const longEmail = 'johnmichealdoe@gmail.com';
     const cases: Array<[string, string]> = [
       ['name', longEmail],
       ['email', longEmail],

--- a/services/platform/convex/workflow_engine/action_defs/conversation/helpers/create_conversation_from_sent_email.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/conversation/helpers/create_conversation_from_sent_email.test.ts
@@ -10,9 +10,9 @@ const ORG = 'org_activ';
 function makeSentEmail(overrides: Partial<EmailType> = {}): EmailType {
   return {
     uid: 1,
-    messageId: '<4abab424-9cfd-f43a-64c4-c5fd36788a4f@support.activ.ng>',
-    from: [{ address: 'billing@support.activ.ng' }],
-    to: [{ address: 'israeliyanda5@gmail.com' }],
+    messageId: '<4abab424-9cfd-f43a-64c4-c5fd36788a4f@support.example.com>',
+    from: [{ address: 'billing@support.example.com' }],
+    to: [{ address: 'johndoe@example.com' }],
     subject: 'Re: Test',
     date: '2026-07-07T18:11:00.000Z',
     text: 'Hello Israel',
@@ -54,7 +54,7 @@ describe('createConversationFromSentEmail', () => {
     const result = await createConversationFromSentEmail(ctx, {
       organizationId: ORG,
       emails: [makeSentEmail()],
-      accountEmail: 'hello@support.activ.ng',
+      accountEmail: 'hello@support.example.com',
       integrationName: 'imap_smtp',
     });
 
@@ -75,7 +75,7 @@ describe('createConversationFromSentEmail', () => {
           to: [],
         }),
       ],
-      accountEmail: 'hello@support.activ.ng',
+      accountEmail: 'hello@support.example.com',
     });
 
     expect(result.created).toBe(false);


### PR DESCRIPTION
## What

Replace real-looking email addresses and a real domain in two test
fixtures with neutral placeholders.

- `use-contacts-table-config.test.tsx` — the long-value truncation fixture
- `create_conversation_from_sent_email.test.ts` — the sent-email fixture
  (message-id, `from`/`to`, account email)

## Why

Test fixtures should not carry real personal email addresses or a real
deployment domain. Behaviour is unchanged — identical assertions and
payload shapes, only the literal strings differ.
