### PR TITLE
fix(platform): prevent mobile input zoom on focus

### DIFF
--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -13,6 +13,14 @@ describe('Input', () => {
       expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument();
     });
 
+    it('uses text-base so mobile browsers do not zoom on focus', () => {
+      render(<Input placeholder="Enter text" />);
+      // iOS Safari zooms focused inputs under 16px; text-base is 1rem (16px).
+      expect(screen.getByPlaceholderText('Enter text').className).toContain(
+        'text-base',
+      );
+    });
+
     it('renders with label', () => {
       render(<Input label="Email" />);
       expect(

--- a/services/platform/app/components/ui/forms/json-input.tsx
+++ b/services/platform/app/components/ui/forms/json-input.tsx
@@ -171,7 +171,6 @@ interface JsonTextEditorProps {
   textValue: string;
   disabled: boolean;
   rows: number;
-  fontSize: number;
   inputId: string;
   describedBy: string | undefined;
   placeholder: string;
@@ -183,7 +182,6 @@ function JsonTextEditor({
   textValue,
   disabled,
   rows,
-  fontSize,
   inputId,
   describedBy,
   placeholder,
@@ -204,7 +202,9 @@ function JsonTextEditor({
       id={inputId}
       aria-describedby={describedBy}
       className={cn(
-        'w-full resize-none border-0 bg-transparent p-3 text-xs focus:outline-none focus:ring-0 min-h-[12.5rem] overflow-y-auto',
+        // text-base (≥16px) on mobile prevents iOS focus-zoom; md:text-xs keeps
+        // the dense monospace editor on desktop.
+        'w-full resize-none border-0 bg-transparent p-3 text-base focus:outline-none focus:ring-0 min-h-[12.5rem] overflow-y-auto md:text-xs',
         'font-mono leading-relaxed',
         'placeholder:text-muted-foreground',
         theme === 'dark'
@@ -214,7 +214,6 @@ function JsonTextEditor({
       style={{
         fontFamily:
           'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-        fontSize: `${fontSize}px`,
         lineHeight: '1.4',
       }}
       placeholder={placeholder}
@@ -299,7 +298,7 @@ function JsonInputBase({
   required,
   className,
   rows = 4,
-  fontSize = 12,
+  fontSize = 16,
   id,
   placeholder = JSON.stringify({ key: 'value' }, null, 2),
 }: JsonInputProps) {
@@ -499,7 +498,6 @@ function JsonInputBase({
             textValue={textValue}
             disabled={disabled}
             rows={rows}
-            fontSize={fontSize}
             inputId={resolvedId}
             describedBy={describedBy}
             placeholder={placeholder}

--- a/services/platform/app/components/ui/forms/textarea.test.tsx
+++ b/services/platform/app/components/ui/forms/textarea.test.tsx
@@ -12,6 +12,14 @@ describe('Textarea', () => {
       expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument();
     });
 
+    it('uses text-base so mobile browsers do not zoom on focus', () => {
+      render(<Textarea placeholder="Enter text" />);
+      // iOS Safari zooms focused textareas under 16px; text-base is 1rem (16px).
+      expect(screen.getByPlaceholderText('Enter text').className).toContain(
+        'text-base',
+      );
+    });
+
     it('renders with label', () => {
       render(<Textarea label="Description" />);
       expect(

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -1036,7 +1036,7 @@ function ChatRow({ chat }: { chat: ChatItem }) {
           }}
           onBlur={() => ctx.onInputBlur(chat._id, draft)}
           aria-label={t('history.renameChat')}
-          className="ring-primary focus-visible:ring-primary min-w-0 flex-1 rounded-sm bg-transparent px-1 text-[13px] leading-snug ring-1 outline-none focus-visible:ring-2"
+          className="ring-primary focus-visible:ring-primary min-w-0 flex-1 rounded-sm bg-transparent px-1 text-base leading-snug ring-1 outline-none focus-visible:ring-2 md:text-[13px]"
         />
       ) : (
         <>

--- a/services/platform/app/features/chat/components/edit-message-dialog.tsx
+++ b/services/platform/app/features/chat/components/edit-message-dialog.tsx
@@ -109,7 +109,7 @@ function EditMessageDialogContent({
         }}
         onKeyDown={handleKeyDown}
         disabled={isSubmitting}
-        className="border-border bg-background text-foreground max-h-[50vh] min-h-[4rem] w-full resize-none rounded-lg border p-3 text-sm leading-6 focus:outline-none disabled:opacity-50"
+        className="border-border bg-background text-foreground max-h-[50vh] min-h-[4rem] w-full resize-none rounded-lg border p-3 text-base leading-6 focus:outline-none disabled:opacity-50 md:text-sm"
         rows={3}
       />
     </Dialog>

--- a/services/platform/app/features/chat/components/human-input-fields.tsx
+++ b/services/platform/app/features/chat/components/human-input-fields.tsx
@@ -71,7 +71,7 @@ function HumanInputFieldsComponent({
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
               updateField(field.label, e.target.value)
             }
-            className="min-h-[80px] text-sm"
+            className="min-h-[80px] text-base md:text-sm"
             disabled={disabled}
           />
         );

--- a/services/platform/app/features/chat/components/human-input-request-card.tsx
+++ b/services/platform/app/features/chat/components/human-input-request-card.tsx
@@ -577,7 +577,7 @@ function HumanInputRequestCardComponent({
                   }
                   placeholder={t('pushbackPlaceholder')}
                   aria-label={t('pushback')}
-                  className="min-h-[80px] text-sm"
+                  className="min-h-[80px] text-base md:text-sm"
                   disabled={isSubmitting}
                   autoFocus
                 />

--- a/services/platform/app/features/chat/components/inline-edit-input.tsx
+++ b/services/platform/app/features/chat/components/inline-edit-input.tsx
@@ -75,7 +75,7 @@ export function InlineEditInput({
         onKeyDown={handleKeyDown}
         disabled={isSubmitting}
         aria-label={tChat('editMessage')}
-        className="text-foreground min-h-[2.5rem] w-full resize-none bg-transparent text-sm leading-6 focus:outline-none disabled:opacity-50"
+        className="text-foreground min-h-[2.5rem] w-full resize-none bg-transparent text-base leading-6 focus:outline-none disabled:opacity-50 md:text-sm"
         rows={1}
       />
       <Row gap={2} justify="end">

--- a/services/platform/app/features/chat/components/integration-approval-card.tsx
+++ b/services/platform/app/features/chat/components/integration-approval-card.tsx
@@ -305,7 +305,7 @@ function IntegrationApprovalCardComponent({
                   setFeedbackText(e.target.value)
                 }
                 placeholder={t('feedbackPlaceholder')}
-                className="min-h-[60px] text-sm"
+                className="min-h-[60px] text-base md:text-sm"
                 disabled={isProcessing}
                 autoFocus
               />

--- a/services/platform/app/features/chat/components/message-feedback.tsx
+++ b/services/platform/app/features/chat/components/message-feedback.tsx
@@ -173,7 +173,7 @@ export function MessageFeedback({
             onChange={(e) => setComment(e.target.value)}
             onKeyDown={handleCommentKeyDown}
             placeholder={t('feedback.commentPlaceholder')}
-            className="border-border bg-muted text-foreground placeholder:text-muted-foreground min-h-[60px] w-full resize-none rounded-lg border px-3 py-2 text-sm focus:ring-1 focus:ring-offset-0 focus:outline-none"
+            className="border-border bg-muted text-foreground placeholder:text-muted-foreground min-h-[60px] w-full resize-none rounded-lg border px-3 py-2 text-base focus:ring-1 focus:ring-offset-0 focus:outline-none md:text-sm"
             aria-label={t('feedback.commentPlaceholder')}
           />
           <Row gap={2} align="stretch">

--- a/services/platform/app/features/chat/components/message-info-dialog.tsx
+++ b/services/platform/app/features/chat/components/message-info-dialog.tsx
@@ -234,7 +234,7 @@ function DirectTtftProbe({
           onChange={(e) => setMessage(e.target.value)}
           placeholder="Replays this turn's user message (editable)"
           rows={2}
-          className="bg-muted w-full rounded px-2 py-1 text-sm"
+          className="bg-muted w-full rounded px-2 py-1 text-base md:text-sm"
         />
         <label className="flex items-center gap-2 text-sm">
           <input

--- a/services/platform/app/features/chat/components/sandbox-chip.tsx
+++ b/services/platform/app/features/chat/components/sandbox-chip.tsx
@@ -355,7 +355,7 @@ export function SandboxChip({
                       setError(null);
                     }}
                     placeholder={t('workdir.placeholder')}
-                    className="h-8 font-mono text-xs"
+                    className="h-8 font-mono text-base md:text-xs"
                     autoComplete="off"
                     spellCheck={false}
                   />

--- a/services/platform/app/features/chat/components/workflow-run-approval-card.tsx
+++ b/services/platform/app/features/chat/components/workflow-run-approval-card.tsx
@@ -692,7 +692,7 @@ function WorkflowHumanInputSection({
             }
             placeholder={t('pushbackPlaceholder')}
             aria-label={t('pushback')}
-            className="min-h-[80px] text-sm"
+            className="min-h-[80px] text-base md:text-sm"
             disabled={isSubmitting}
             autoFocus
           />

--- a/services/platform/app/features/contacts/components/contact-import-form.tsx
+++ b/services/platform/app/features/contacts/components/contact-import-form.tsx
@@ -79,7 +79,7 @@ export function ContactImportForm({ hideTabs, mode }: ContactImportFormProps) {
             placeholder={
               'contact@example.com,John Doe\ncontact2@example.com,Jane Smith,en\ncontact3@example.com,,zh'
             }
-            className="min-h-[200px] font-mono text-sm"
+            className="min-h-[200px] font-mono text-base md:text-sm"
             errorMessage={
               typeof errors.contacts?.message === 'string'
                 ? errors.contacts.message

--- a/services/platform/app/features/documents/components/document-preview-pdf.tsx
+++ b/services/platform/app/features/documents/components/document-preview-pdf.tsx
@@ -559,7 +559,7 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
             max={Math.max(1, state.totalPages)}
             value={state.pageNum}
             onChange={onPageInputChange}
-            className="bg-background w-10 appearance-none rounded-md py-1 text-center text-sm ring-1 ring-white/20 focus:ring-white/40 focus:outline-none"
+            className="bg-background w-12 appearance-none rounded-md py-1 text-center text-base ring-1 ring-white/20 focus:ring-white/40 focus:outline-none md:w-10 md:text-sm"
           />
           <div>/</div>
           <div className="w-4 text-center text-sm tabular-nums">

--- a/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
@@ -374,7 +374,7 @@ function PromptFormDialogContent({
           value={content}
           onChange={(e) => setContent(e.target.value)}
           placeholder={t('form.contentPlaceholder')}
-          className="min-h-[120px] font-mono text-sm"
+          className="min-h-[120px] font-mono text-base md:text-sm"
           required
           aria-required
           aria-label={t('form.contentLabel')}

--- a/services/platform/app/features/prompts/components/save-prompt-dialog.tsx
+++ b/services/platform/app/features/prompts/components/save-prompt-dialog.tsx
@@ -207,7 +207,7 @@ function SavePromptDialogContent({
         <Textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
-          className="min-h-[120px] text-sm"
+          className="min-h-[120px] text-base md:text-sm"
           required
           aria-required
           aria-label={t('form.contentLabel')}

--- a/services/platform/app/features/settings/branding/components/color-picker-input.tsx
+++ b/services/platform/app/features/settings/branding/components/color-picker-input.tsx
@@ -103,7 +103,7 @@ export function ColorPickerInput({
           onChange={handleTextChange}
           maxLength={8}
           placeholder="6366F1"
-          className="text-foreground placeholder:text-muted-foreground w-[4.5rem] border-none bg-transparent text-sm leading-5 font-normal outline-none"
+          className="text-foreground placeholder:text-muted-foreground w-[4.5rem] border-none bg-transparent text-base leading-5 font-normal outline-none md:text-sm"
           aria-label={t('branding.hexValueAria', { label })}
         />
       </Row>

--- a/services/platform/app/features/settings/governance/components/chat-filter-config.tsx
+++ b/services/platform/app/features/settings/governance/components/chat-filter-config.tsx
@@ -618,7 +618,7 @@ function CategoryEditForm({
               <Textarea
                 value={wordsText}
                 rows={14}
-                className="font-mono text-xs"
+                className="font-mono text-base md:text-xs"
                 onChange={(e) => setWordsText(e.target.value)}
                 placeholder={t('contentSafety.wordsPlaceholder')}
               />

--- a/services/platform/app/features/settings/governance/components/moderation-custom-json-path-section.tsx
+++ b/services/platform/app/features/settings/governance/components/moderation-custom-json-path-section.tsx
@@ -131,7 +131,7 @@ export function CustomJsonPathSection({
             {t('moderationProvider.pathStepDescription')}
           </p>
           <Input
-            className="mt-1.5 font-mono text-sm"
+            className="mt-1.5 font-mono text-base md:text-sm"
             value={draft.customCategoriesPath}
             onChange={(e) => onChange({ customCategoriesPath: e.target.value })}
             placeholder={sample.categoriesPath}
@@ -172,7 +172,7 @@ export function CustomJsonPathSection({
               {t('moderationProvider.flaggedPathDescription')}
             </p>
             <Input
-              className="mt-1.5 font-mono text-sm"
+              className="mt-1.5 font-mono text-base md:text-sm"
               value={draft.customFlaggedPath}
               onChange={(e) => onChange({ customFlaggedPath: e.target.value })}
               placeholder="$.results[0].flagged"

--- a/services/platform/app/features/settings/governance/components/moderation-endpoint-edit-dialog.tsx
+++ b/services/platform/app/features/settings/governance/components/moderation-endpoint-edit-dialog.tsx
@@ -165,7 +165,7 @@ export function EndpointEditDialog({
           <Textarea
             value={draft.requestTemplate}
             rows={6}
-            className="font-mono text-xs"
+            className="font-mono text-base md:text-xs"
             onChange={(e) =>
               setDraft({ ...draft, requestTemplate: e.target.value })
             }

--- a/services/platform/app/features/settings/governance/components/pii/pii-config-preview.tsx
+++ b/services/platform/app/features/settings/governance/components/pii/pii-config-preview.tsx
@@ -118,7 +118,7 @@ export function PiiConfigPreview({
           onChange={(e) => setInput(e.target.value)}
           rows={4}
           aria-label={tPiiConfigPanel('inputTitle')}
-          className="w-full rounded-md border border-[color:var(--color-border-base)] bg-[color:var(--color-bg-base)] p-3 font-sans text-sm leading-relaxed text-[color:var(--color-fg-base)] focus:ring-2 focus:ring-[color:var(--color-accent-base)]/30 focus:outline-none"
+          className="w-full rounded-md border border-[color:var(--color-border-base)] bg-[color:var(--color-bg-base)] p-3 font-sans text-base leading-relaxed text-[color:var(--color-fg-base)] focus:ring-2 focus:ring-[color:var(--color-accent-base)]/30 focus:outline-none md:text-sm"
         />
       </Stage>
 
@@ -282,7 +282,7 @@ function TokenizeStages({
           onChange={(e) => setAiResponseOverride(e.target.value)}
           rows={5}
           aria-label={tPiiConfigPanel('aiTitle')}
-          className="w-full rounded-md border border-[color:var(--color-border-base)] bg-[color:var(--color-bg-base)] p-3 font-mono text-sm leading-relaxed text-[color:var(--color-fg-base)] focus:ring-2 focus:ring-[color:var(--color-accent-base)]/30 focus:outline-none"
+          className="w-full rounded-md border border-[color:var(--color-border-base)] bg-[color:var(--color-bg-base)] p-3 font-mono text-base leading-relaxed text-[color:var(--color-fg-base)] focus:ring-2 focus:ring-[color:var(--color-accent-base)]/30 focus:outline-none md:text-sm"
         />
       </Stage>
 

--- a/services/platform/app/features/settings/providers/components/provider-options-editor.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-options-editor.tsx
@@ -435,7 +435,7 @@ function ProviderOptionsEditorSheet({
               disabled={inFlight}
               placeholder={PROVIDER_OPTIONS_PLACEHOLDER}
               errorMessage={validation.ok ? undefined : validation.error}
-              className="font-mono text-xs"
+              className="font-mono text-base md:text-xs"
             />
             <Text className="text-muted-foreground text-[12px]">
               {exampleLabel}
@@ -512,7 +512,6 @@ export function ModelProviderOptionsField({
         onChange={onChange}
         schema={providerOptionsClientSchema}
         rows={6}
-        fontSize={12}
       />
       <CollapsibleGuide label={copy.guideLabel} content={copy.helpText} />
     </Stack>
@@ -541,7 +540,6 @@ export function ModelRequestBodyMapField({
         schema={requestBodyMapClientSchema}
         placeholder={REQUEST_BODY_MAP_PLACEHOLDER}
         rows={5}
-        fontSize={12}
       />
       <CollapsibleGuide label={copy.guideLabel} content={copy.helpText} />
     </Stack>

--- a/services/platform/app/features/skills/components/skill-detail-panel.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-panel.tsx
@@ -428,7 +428,7 @@ export function SkillDetailPanel({
                       onChange={(e) => setEditBody(e.target.value)}
                       rows={18}
                       disabled={isSaving}
-                      className="font-mono text-sm"
+                      className="font-mono text-base md:text-sm"
                     />
                   </Stack>
                 </Stack>

--- a/services/platform/app/features/tasks/components/label-editor.tsx
+++ b/services/platform/app/features/tasks/components/label-editor.tsx
@@ -191,7 +191,7 @@ export function LabelEditor({
                     setHighlighted(0);
                   }}
                   onKeyDown={onSearchKeyDown}
-                  className="placeholder:text-muted-foreground flex-1 bg-transparent text-sm outline-none"
+                  className="placeholder:text-muted-foreground flex-1 bg-transparent text-base outline-none md:text-sm"
                 />
               </Row>
               <div

--- a/services/platform/app/features/workflows/components/workflow-specification.tsx
+++ b/services/platform/app/features/workflows/components/workflow-specification.tsx
@@ -367,7 +367,7 @@ export function WorkflowSpecification({
         className={cn(
           'border-input bg-background text-foreground placeholder:text-muted-foreground',
           'focus-visible:ring-ring min-h-64 w-full flex-1 resize-none rounded-lg border',
-          'p-4 pb-16 font-mono text-sm leading-relaxed focus-visible:ring-2 focus-visible:outline-none',
+          'p-4 pb-16 font-mono text-base leading-relaxed focus-visible:ring-2 focus-visible:outline-none md:text-sm',
           !specificationValidation.isValid &&
             'border-destructive focus-visible:ring-destructive',
         )}

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -564,7 +564,7 @@ function InstructionsTab() {
             onChange={(e) => writeOverride(e.target.value)}
             required
             rows={8}
-            className="font-mono text-sm"
+            className="font-mono text-base md:text-sm"
             errorMessage={fieldErrors.systemInstructions}
           />
         </Stack>


### PR DESCRIPTION
## What

Raise the font size of text inputs and textareas to `text-base` (16px) on
mobile, dropping back to the previous compact size from `md` up
(`md:text-sm` / `md:text-xs`). Applied to the base `Input`, `Textarea`, and
`JsonInput` components and ~24 call sites — chat composers and feedback
fields, settings/governance editors, prompt/skill/workflow editors, the
document viewer page control, contact import, and the branding hex field.

## Why

iOS Safari auto-zooms the viewport whenever a focused input renders below
16px, leaving the page zoomed and misaligned after the field is tapped.
Rendering at 16px on small screens suppresses the zoom; desktop density is
untouched via the `md:` overrides.

## Tests

Adds regression tests to `Input` and `Textarea` asserting `text-base` is
present, so the guard can't silently regress.
