### PR TITLE
refactor(platform): remove retired From template agent create item

### DIFF
--- a/services/platform/app/components/catalog/use-catalog-sync.tsx
+++ b/services/platform/app/components/catalog/use-catalog-sync.tsx
@@ -79,7 +79,7 @@ export function useCatalogSync({
   )
     ? {
         // Named after what it touches ("Update built-in agents"), not the
-        // mechanism — "catalog" means nothing next to Blank / From template.
+        // mechanism — "catalog" means nothing next to Blank / Upload.
         label: t(`button.${domain}`),
         icon: RefreshCw,
         onClick: () => setConfirmOpen(true),

--- a/services/platform/app/features/agents/components/agents-action-menu.tsx
+++ b/services/platform/app/features/agents/components/agents-action-menu.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useNavigate } from '@tanstack/react-router';
-import { LayoutTemplate, Plus, Upload } from 'lucide-react';
+import { Plus, Upload } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import {
@@ -40,7 +39,6 @@ export function AgentsActionMenu({
   const setCreateOpen = onCreateOpenChange ?? setInternalCreateOpen;
   const [uploadOpen, setUploadOpen] = useState(false);
   const { t } = useT('settings');
-  const navigate = useNavigate();
   const { mutateAsync: saveAgent } = useSaveAgent();
   const { mutateAsync: installAgent } = useInstallCatalogAgent();
   const { agents } = useListAgents(organizationId);
@@ -57,26 +55,13 @@ export function AgentsActionMenu({
         onClick: () => setCreateOpen(true),
       },
       {
-        // The standalone agent-template catalog was retired — agents are
-        // installed by automations now — so this item now browses the
-        // Automations catalog instead (same retarget as the chat agent
-        // selector's footer button).
-        label: t('agents.createMenu.fromTemplate'),
-        icon: LayoutTemplate,
-        onClick: () =>
-          void navigate({
-            to: '/dashboard/$id/automations',
-            params: { id: organizationId },
-          }),
-      },
-      {
         label: t('agents.uploadDialog.menuItem'),
         icon: Upload,
         onClick: () => setUploadOpen(true),
       },
       ...(extraMenuItems ?? []),
     ],
-    [t, setCreateOpen, navigate, organizationId, extraMenuItems],
+    [t, setCreateOpen, extraMenuItems],
   );
 
   return (

--- a/services/platform/app/routes/dashboard/$id/agents/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/index.tsx
@@ -15,7 +15,7 @@ const searchSchema = z.object({
 // The agent roster — the org's list of installed agents. Agents are now
 // installed exclusively through automations or the create/upload menu below
 // (the standalone Catalog tab was folded in here — "Update from catalog"
-// lives in the same action menu as Blank / From template / Upload).
+// lives in the same action menu as Blank / Upload).
 export const Route = createFileRoute('/dashboard/$id/agents/')({
   head: () => ({
     meta: seo('agents'),

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5561,8 +5561,7 @@
       "tableCaption": "Installierte Agents",
       "createAgent": "Agent erstellen",
       "createMenu": {
-        "blank": "Leer",
-        "fromTemplate": "Aus Vorlage"
+        "blank": "Leer"
       },
       "searchAgent": "Agents suchen",
       "columns": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5857,8 +5857,7 @@
       "tableCaption": "Installed agents",
       "createAgent": "Create agent",
       "createMenu": {
-        "blank": "Blank",
-        "fromTemplate": "From template"
+        "blank": "Blank"
       },
       "searchAgent": "Search agents",
       "columns": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5561,8 +5561,7 @@
       "tableCaption": "Agents installés",
       "createAgent": "Créer un agent",
       "createMenu": {
-        "blank": "Vierge",
-        "fromTemplate": "À partir d'un modèle"
+        "blank": "Vierge"
       },
       "searchAgent": "Rechercher des agents",
       "columns": {

--- a/services/platform/tests/e2e/specs/agents.spec.ts
+++ b/services/platform/tests/e2e/specs/agents.spec.ts
@@ -68,7 +68,7 @@ test('creates a custom agent then deletes it', async ({ page, org }) => {
   });
 
   // "Create agent" is a dropdown trigger; its "Blank" item opens the create
-  // dialog (siblings: "From template", "Upload file").
+  // dialog (sibling: "Upload file").
   await page
     .getByRole('button', { name: t('settings.agents.createAgent') })
     .click();


### PR DESCRIPTION
## What

Remove the **From template** item from the agent create menu, leaving
**Blank** and **Upload**.

## Why

The standalone agent-template catalog was retired — agents are installed
through automations now — so this item only redirected to the Automations
page. Keeping it in the create menu implied a template flow that no longer
exists, so it is misleading rather than useful.

## Scope

- `agents-action-menu.tsx` — drop the item and its now-unused `navigate`
  wiring
- `agents.createMenu.fromTemplate` removed from `en` / `de` / `fr`
- comment in `agents/index.tsx` + `use-catalog-sync.tsx` and the
  `agents.spec.ts` e2e updated to describe the two-item menu
