### PR TITLE
feat(platform): searchable breadcrumb switchers and mobile parent

### DIFF
--- a/services/platform/app/components/layout/header-breadcrumbs.test.tsx
+++ b/services/platform/app/components/layout/header-breadcrumbs.test.tsx
@@ -34,6 +34,53 @@ describe('HeaderBreadcrumbs', () => {
     expect(back).not.toHaveTextContent('github');
   });
 
+  it('keeps all ancestor crumbs desktop-only by default', () => {
+    render(
+      <HeaderBreadcrumbs
+        ariaLabel="Breadcrumb"
+        crumbs={[
+          { key: 'agents', content: <a href="/agents">Agents</a> },
+          {
+            key: 'folder',
+            content: <a href="/agents?folder=github">github</a>,
+          },
+        ]}
+        leaf="Reviewer"
+      />,
+    );
+
+    for (const name of ['Agents', 'github'] as const) {
+      const trailLink = screen.getByRole('link', { name });
+      expect(trailLink.closest('li')).toHaveClass('hidden', 'md:flex');
+    }
+  });
+
+  it('shows the immediate parent in the trail on mobile when opted in', () => {
+    render(
+      <HeaderBreadcrumbs
+        ariaLabel="Breadcrumb"
+        showImmediateParentOnMobile
+        crumbs={[
+          { key: 'agents', content: <a href="/agents">Agents</a> },
+          {
+            key: 'folder',
+            content: <a href="/agents?folder=github">github</a>,
+          },
+        ]}
+        leaf="Reviewer"
+      />,
+    );
+
+    // Agent file-based detail: mobile title is `[parent] / [leaf]`. Only the
+    // last ancestor stays visible below `md`; earlier crumbs stay desktop-only.
+    const parentLink = screen.getByRole('link', { name: 'github' });
+    expect(parentLink.closest('li')).toHaveClass('flex');
+    expect(parentLink.closest('li')).not.toHaveClass('hidden');
+
+    const agentsLink = screen.getByRole('link', { name: 'Agents' });
+    expect(agentsLink.closest('li')).toHaveClass('hidden', 'md:flex');
+  });
+
   it('keeps the full ancestor trail as text links on desktop', () => {
     render(
       <HeaderBreadcrumbs

--- a/services/platform/app/components/layout/header-breadcrumbs.tsx
+++ b/services/platform/app/components/layout/header-breadcrumbs.tsx
@@ -29,15 +29,17 @@ export interface HeaderBreadcrumbCrumb {
  * up; below `md` it collapses to a single icon-only back button to the
  * IMMEDIATE parent so a detail page always has a way back on a phone — the
  * full trail is too wide there, and the parent's label eats scarce header
- * width. Every gap is the same `gap-2`, so the trail reads identically on
- * agents, automations, workflows, and projects. The separator trails each
- * ancestor `li`, so the leaf needs none of its own.
+ * width (unless {@link showImmediateParentOnMobile} opts in to
+ * `[parent] / [leaf]`). Every gap is the same `gap-2`, so the trail reads
+ * identically on agents, automations, workflows, and projects. The separator
+ * trails each ancestor `li`, so the leaf needs none of its own.
  */
 export function HeaderBreadcrumbs({
   ariaLabel,
   crumbs,
   leaf,
   className,
+  showImmediateParentOnMobile = false,
 }: {
   ariaLabel: string;
   crumbs: readonly HeaderBreadcrumbCrumb[];
@@ -45,6 +47,12 @@ export function HeaderBreadcrumbs({
    *  loading names in `Skeletonize` at the call site. */
   leaf: ReactNode;
   className?: string;
+  /**
+   * When true, keep the last ancestor visible below `md` so the title reads
+   * `[parent] / [leaf]` (agent file-based detail pages). Default keeps all
+   * ancestor crumbs desktop-only.
+   */
+  showImmediateParentOnMobile?: boolean;
 }) {
   const { t } = useT('common');
   // Below `md` the full trail is hidden (too wide for a phone header), so a
@@ -54,7 +62,9 @@ export function HeaderBreadcrumbs({
   // arrow — so the destination and the router stay the caller's, and the
   // control is a compact icon rather than a width-hungry label. The desktop
   // trail below renders the same ancestor node; one copy is `display:none`
-  // per breakpoint, so exactly one parent link stays in the a11y tree.
+  // per breakpoint, so exactly one parent link stays in the a11y tree —
+  // unless `showImmediateParentOnMobile`, which keeps the last trail crumb
+  // visible alongside the back control (same destination, different names).
   const parentContent = crumbs.at(-1)?.content;
   return (
     <nav
@@ -73,17 +83,24 @@ export function HeaderBreadcrumbs({
         />
       )}
       <ol className="flex min-w-0 items-center gap-2 text-base font-semibold">
-        {crumbs.map((crumb) => (
-          <li
-            key={crumb.key}
-            className="hidden shrink-0 items-center gap-2 md:flex"
-          >
-            {crumb.content}
-            <span className="text-muted-foreground" aria-hidden="true">
-              /
-            </span>
-          </li>
-        ))}
+        {crumbs.map((crumb, i) => {
+          const isImmediateParent = i === crumbs.length - 1;
+          const showOnMobile = showImmediateParentOnMobile && isImmediateParent;
+          return (
+            <li
+              key={crumb.key}
+              className={cn(
+                'shrink-0 items-center gap-2',
+                showOnMobile ? 'flex' : 'hidden md:flex',
+              )}
+            >
+              {crumb.content}
+              <span className="text-muted-foreground" aria-hidden="true">
+                /
+              </span>
+            </li>
+          );
+        })}
         <li className="flex min-w-0 items-center">
           <Heading level={1} size="base" truncate aria-current="page">
             {leaf}

--- a/services/platform/app/components/ui/forms/searchable-select.test.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.test.tsx
@@ -100,12 +100,39 @@ describe('SearchableSelect', () => {
       expect(screen.getByText('No results')).toBeInTheDocument();
     });
 
+    it('uses text-base on the search input so mobile browsers do not zoom on focus', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      const input = screen.getByRole('combobox');
+      // iOS Safari zooms focused inputs under 16px; text-base is 1rem (16px).
+      expect(input.className).toContain('text-base');
+    });
+
     it('renders footer when provided', async () => {
       const { user } = renderSelect({
         footer: <button type="button">Add item</button>,
       });
       await user.click(screen.getByText('Open select'));
       expect(screen.getByText('Add item')).toBeInTheDocument();
+    });
+
+    it('renders a title above the search field when provided', async () => {
+      const { user } = renderSelect({ title: 'Switch fruit' });
+      await user.click(screen.getByText('Open select'));
+      expect(screen.getByText('Switch fruit')).toBeInTheDocument();
+    });
+
+    it('marks the selected option with a leading accent in switcher variant', async () => {
+      const { user } = renderSelect({
+        value: 'apple',
+        variant: 'switcher',
+        title: 'Switch fruit',
+      });
+      await user.click(screen.getByText('Open select'));
+      const appleOption = screen.getByRole('option', { name: /Apple/i });
+      expect(appleOption.getAttribute('aria-selected')).toBe('true');
+      expect(appleOption.className).toContain('bg-muted/60');
+      expect(appleOption.querySelector('span.bg-blue-600')).toBeInTheDocument();
     });
   });
 

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -121,6 +121,22 @@ export interface SearchableSelectProps {
    * @default false
    */
   modal?: boolean;
+  /**
+   * Optional heading above the search field (e.g. "Switch agent"). Used by
+   * breadcrumb entity switchers; ignored when empty.
+   */
+  title?: ReactNode;
+  /**
+   * Visual packing for the popover.
+   *   - `'default'`: catalog picker (agents, models) — search strip, trailing
+   *     check, rounded option rows.
+   *   - `'switcher'`: breadcrumb entity switcher — titled panel, bordered
+   *     search, limited list height, selected row with leading check + left
+   *     accent bar.
+   *
+   * @default 'default'
+   */
+  variant?: 'default' | 'switcher';
 }
 
 // Radix Popover — unlike Radix Select — does NOT auto-size its content to the
@@ -193,7 +209,10 @@ function SearchableSelectBase({
   tooltip,
   tooltipSide = 'top',
   modal = false,
+  title,
+  variant = 'default',
 }: SearchableSelectProps) {
+  const isSwitcher = variant === 'switcher';
   const instanceId = useId();
   const listboxId = `${instanceId}-listbox`;
   const optionId = (index: number) => `${instanceId}-option-${index}`;
@@ -410,37 +429,77 @@ function SearchableSelectBase({
           align={align}
           side={side}
           sideOffset={sideOffset}
-          className={cn(CONTENT_CLASSES, contentClassName)}
+          className={cn(
+            CONTENT_CLASSES,
+            isSwitcher && 'overflow-hidden',
+            contentClassName,
+          )}
           onOpenAutoFocus={(e) => {
             e.preventDefault();
             searchRef.current?.focus();
             initializeHighlight();
           }}
         >
-          <div className="border-border flex items-center gap-2 border-b p-3">
-            <Search
-              className="text-muted-foreground size-3.5 shrink-0"
-              aria-hidden="true"
-            />
-            <input
-              ref={searchRef}
-              type="text"
-              role="combobox"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={searchPlaceholder}
-              className="placeholder:text-muted-foreground flex-1 bg-transparent text-base outline-none"
-              aria-expanded={isOpen}
-              aria-controls={listboxId}
-              aria-activedescendant={
-                filteredOptions.length > 0
-                  ? optionId(highlightedIndex)
-                  : undefined
-              }
-              aria-autocomplete="list"
-              aria-label={searchPlaceholder}
-            />
+          <div
+            className={cn(
+              isSwitcher
+                ? 'border-border flex flex-col border-b'
+                : 'border-border flex items-center gap-2 border-b p-3',
+            )}
+          >
+            {title != null && title !== '' && (
+              <div
+                className={cn(
+                  'text-foreground text-sm font-semibold',
+                  // More inset from the panel edge than the search row below.
+                  isSwitcher && 'px-4 pt-3 pb-2',
+                )}
+              >
+                {title}
+              </div>
+            )}
+            <div
+              className={cn(
+                // Tighter inset from the panel edge than the title above.
+                isSwitcher && 'px-2 pb-2',
+                isSwitcher && (title == null || title === '') && 'pt-2',
+              )}
+            >
+              <div
+                className={cn(
+                  'flex items-center gap-2',
+                  isSwitcher
+                    ? 'border-border bg-[color:var(--color-bg-base)] focus-within:border-[color:var(--color-accent-base)] focus-within:ring-[color:var(--color-accent-base)]/30 rounded-md border px-2.5 py-1.5 focus-within:ring-2'
+                    : undefined,
+                )}
+              >
+                <Search
+                  className="text-muted-foreground size-3.5 shrink-0"
+                  aria-hidden="true"
+                />
+                <input
+                  ref={searchRef}
+                  type="text"
+                  role="combobox"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={searchPlaceholder}
+                  // text-base (≥16px) prevents iOS focus-zoom; md:text-sm keeps
+                  // the compact desktop density.
+                  className="placeholder:text-muted-foreground flex-1 bg-transparent text-base outline-none md:text-sm"
+                  aria-expanded={isOpen}
+                  aria-controls={listboxId}
+                  aria-activedescendant={
+                    filteredOptions.length > 0
+                      ? optionId(highlightedIndex)
+                      : undefined
+                  }
+                  aria-autocomplete="list"
+                  aria-label={searchPlaceholder}
+                />
+              </div>
+            </div>
           </div>
 
           <div
@@ -448,7 +507,12 @@ function SearchableSelectBase({
             id={listboxId}
             role="listbox"
             aria-label={ariaLabel}
-            className="max-h-[20rem] overflow-y-auto p-1"
+            className={cn(
+              'overflow-y-auto',
+              // Switcher stays compact so a long sibling list doesn't fill the
+              // viewport; catalog pickers keep the taller default.
+              isSwitcher ? 'max-h-60' : 'max-h-[20rem] p-1',
+            )}
           >
             {filteredOptions.map((option, index) => (
               <SearchableSelectOptionItem
@@ -463,6 +527,7 @@ function SearchableSelectBase({
                 showRadio={showRadio}
                 descriptionMode={descriptionMode}
                 action={optionAction?.(option)}
+                variant={variant}
               />
             ))}
 
@@ -533,6 +598,7 @@ function SearchableSelectOptionItem({
   showRadio,
   descriptionMode = 'inline',
   action,
+  variant = 'default',
 }: {
   option: SearchableSelectOption;
   index: number;
@@ -544,7 +610,10 @@ function SearchableSelectOptionItem({
   showRadio?: boolean;
   descriptionMode?: 'inline' | 'tooltip';
   action?: ReactNode;
+  variant?: 'default' | 'switcher';
 }) {
+  const isSwitcher = variant === 'switcher';
+
   if (option.isSectionHeader) {
     return (
       <div
@@ -571,6 +640,9 @@ function SearchableSelectOptionItem({
       ? option.description
       : null;
 
+  const leadingCheck = isSwitcher && !showRadio;
+  const trailingCheck = !isSwitcher && !showRadio && isSelected;
+
   const row = (
     // oxlint-disable-next-line jsx-a11y/click-events-have-key-events -- keyboard handled via aria-activedescendant
     <div
@@ -583,12 +655,22 @@ function SearchableSelectOptionItem({
       onClick={() => !option.disabled && onSelect(option.value)}
       onMouseEnter={() => onMouseEnter(index)}
       className={cn(
-        'group/option flex w-full cursor-default gap-2 rounded-md p-2 text-left text-sm transition-colors',
+        'group/option relative flex w-full cursor-default gap-2 text-left text-sm transition-colors',
+        isSwitcher
+          ? 'border-border rounded-none border-b px-3 py-2 last:border-b-0'
+          : 'rounded-md p-2',
         showInlineDescription ? 'items-start' : 'items-center',
-        isHighlighted && 'bg-accent',
+        isSwitcher && isSelected && 'bg-muted/60',
+        isHighlighted && !(isSwitcher && isSelected) && 'bg-accent',
         option.disabled && 'pointer-events-none opacity-50',
       )}
     >
+      {isSwitcher && isSelected && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-0.5 bg-blue-600"
+        />
+      )}
       {showRadio && (
         // Outer wrapper matches the first label-row height (~24px, driven by
         // the optional badge's line-height + py) and centers the 16px radio
@@ -614,6 +696,18 @@ function SearchableSelectOptionItem({
           </span>
         </span>
       )}
+      {leadingCheck && (
+        <span
+          aria-hidden="true"
+          className="flex size-4 shrink-0 items-center justify-center"
+        >
+          {isSelected ? (
+            <Check className="size-4 text-blue-600" />
+          ) : (
+            <span className="size-4" />
+          )}
+        </span>
+      )}
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <Text as="span" variant="label">
@@ -632,7 +726,7 @@ function SearchableSelectOptionItem({
           </Text>
         )}
       </div>
-      {!showRadio && isSelected && (
+      {trailingCheck && (
         <Check className="text-primary size-4 shrink-0" aria-hidden="true" />
       )}
       {action}

--- a/services/platform/app/features/agents/components/agent-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/agents/components/agent-breadcrumb-switcher.test.tsx
@@ -12,9 +12,11 @@ const mockLocation = {
 };
 
 let agentsFixture: unknown[] = [];
+let installsFixture: { agentSlug: string; enabled: boolean }[] = [];
 
 vi.mock('@/app/features/agents/hooks/queries', () => ({
   useListAgents: () => ({ agents: agentsFixture, isLoading: false }),
+  useAgentInstallations: () => ({ data: installsFixture, isLoading: false }),
 }));
 
 vi.mock('@tanstack/react-router', async (importOriginal) => ({
@@ -46,6 +48,11 @@ describe('AgentBreadcrumbSwitcher', () => {
         uiConfigurable: true,
       },
     ];
+    // Both fixtures are installed + enabled unless a test overrides this.
+    installsFixture = [
+      { agentSlug: 'issue-triager', enabled: true },
+      { agentSlug: 'coder', enabled: true },
+    ];
   });
 
   it('opens a menu of sibling agents from the current name', async () => {
@@ -64,9 +71,9 @@ describe('AgentBreadcrumbSwitcher', () => {
     );
 
     expect(
-      screen.getByRole('menuitem', { name: 'Issue triager' }),
+      screen.getByRole('option', { name: 'Issue triager' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('menuitem', { name: 'Coder' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Coder' })).toBeInTheDocument();
   });
 
   it('navigates to the selected agent while keeping the current tab', async () => {
@@ -83,7 +90,7 @@ describe('AgentBreadcrumbSwitcher', () => {
         name: /switch agent, current: issue triager/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Coder' }));
+    await user.click(screen.getByRole('option', { name: 'Coder' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/dashboard/org-1/agents/coder/instructions',
@@ -105,7 +112,7 @@ describe('AgentBreadcrumbSwitcher', () => {
         name: /switch agent, current: issue triager/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Issue triager' }));
+    await user.click(screen.getByRole('option', { name: 'Issue triager' }));
 
     expect(mockNavigate).not.toHaveBeenCalled();
   });
@@ -124,6 +131,73 @@ describe('AgentBreadcrumbSwitcher', () => {
       screen.queryByRole('button', { name: /switch agent/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByText('Issue triager')).toBeInTheDocument();
+  });
+
+  it('offers only installed agents, not the raw on-disk catalog', async () => {
+    // On disk: three agents. `legal-counsel` is an un-installed (e.g. retired)
+    // catalog file with no install record — it must not be a switch target.
+    agentsFixture = [
+      {
+        name: 'issue-triager',
+        displayName: 'Issue triager',
+        uiConfigurable: true,
+      },
+      { name: 'coder', displayName: 'Coder', uiConfigurable: true },
+      {
+        name: 'legal-counsel',
+        displayName: 'Legal Counsel',
+        uiConfigurable: true,
+      },
+    ];
+    installsFixture = [
+      { agentSlug: 'issue-triager', enabled: true },
+      { agentSlug: 'coder', enabled: true },
+      // legal-counsel intentionally has no install record.
+    ];
+
+    const { user } = render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch agent, current: issue triager/i,
+      }),
+    );
+
+    expect(screen.getByRole('option', { name: 'Coder' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'Legal Counsel' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('excludes installed-but-disabled agents', async () => {
+    installsFixture = [
+      { agentSlug: 'issue-triager', enabled: true },
+      { agentSlug: 'coder', enabled: false },
+    ];
+
+    const { user } = render(
+      <AgentBreadcrumbSwitcher
+        organizationId="org-1"
+        agentId="issue-triager"
+        displayName="Issue triager"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch agent, current: issue triager/i,
+      }),
+    );
+
+    expect(
+      screen.queryByRole('option', { name: 'Coder' }),
+    ).not.toBeInTheDocument();
   });
 
   it('passes an axe audit with the menu open', async () => {

--- a/services/platform/app/features/agents/components/agent-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/agents/components/agent-breadcrumb-switcher.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { ChevronDown } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { useListAgents } from '@/app/features/agents/hooks/queries';
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from '@/app/components/ui/forms/searchable-select';
+import {
+  useAgentInstallations,
+  useListAgents,
+} from '@/app/features/agents/hooks/queries';
 import { toConfigurableAgent } from '@/app/features/agents/utils/agent-list-item';
 import { useT } from '@/lib/i18n/client';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
@@ -16,9 +22,9 @@ import { agentSwitchPathname } from '../lib/agent-switch-path';
 
 /**
  * Breadcrumb leaf for an agent detail page: the current display name opens a
- * dropdown of sibling agents so the operator can jump between them without
- * returning to the Agents list. Portable editor tabs (instructions, tools, …)
- * stay put.
+ * searchable switcher of sibling agents so the operator can jump between them
+ * without returning to the Agents list. Portable editor tabs (instructions,
+ * tools, …) stay put.
  */
 export function AgentBreadcrumbSwitcher({
   organizationId,
@@ -34,56 +40,60 @@ export function AgentBreadcrumbSwitcher({
   const navigate = useNavigate();
   const location = useLocation();
   const { agents: rawAgents } = useListAgents(organizationId);
+  const installs = useAgentInstallations(organizationId);
 
-  const siblings = useMemo(() => {
-    const rows = [];
+  const options = useMemo<SearchableSelectOption[]>(() => {
+    // Offer only INSTALLED + enabled agents as switch targets — the same gate
+    // the Agents list applies (see `agents-table.tsx`). The on-disk catalog
+    // `useListAgents` returns also carries un-installed and retired agents,
+    // which must not appear here.
+    const enabledSlugs = new Set<string>();
+    const states = installs.data as
+      | ReadonlyArray<{ agentSlug: string; enabled: boolean }>
+      | undefined;
+    for (const s of states ?? []) {
+      if (s.enabled) enabledSlugs.add(s.agentSlug);
+    }
+
+    const rows: SearchableSelectOption[] = [];
     for (const raw of rawAgents ?? []) {
       const agent = toConfigurableAgent(raw);
       if (!agent) continue;
+      // `agent.name` is the slug; install state keys on `agentSlug`.
+      if (!enabledSlugs.has(agent.name)) continue;
       rows.push({
-        name: agent.name,
+        value: agent.name,
         label: resolveAgentLocale(agent, locale).displayName || agent.name,
       });
     }
     return rows.sort((a, b) => a.label.localeCompare(b.label, locale));
-  }, [rawAgents, locale]);
+  }, [rawAgents, installs.data, locale]);
 
-  const items = useMemo<DropdownMenuGroup[]>(
-    () => [
-      siblings.map((sibling) => ({
-        type: 'item' as const,
-        label: sibling.label,
-        selected: sibling.name === agentId,
-        onClick: () => {
-          if (sibling.name === agentId) return;
-          const to = agentSwitchPathname(
-            location.pathname,
-            organizationId,
-            agentId,
-            sibling.name,
-          );
-          void navigate({ to, search: location.search });
-        },
-      })),
-    ],
-    [
-      siblings,
-      agentId,
-      organizationId,
-      navigate,
-      location.pathname,
-      location.search,
-    ],
-  );
-
-  if (siblings.length === 0) {
+  if (options.length === 0) {
     return <>{displayName}</>;
   }
 
   return (
-    <DropdownMenu
+    <SearchableSelect
+      variant="switcher"
       align="start"
-      items={items}
+      contentClassName="min-w-64"
+      value={agentId}
+      options={options}
+      title={t('agents.switcher.title')}
+      searchPlaceholder={t('agents.switcher.searchPlaceholder')}
+      emptyText={t('agents.switcher.empty')}
+      aria-label={t('agents.switcher.ariaLabel', { name: displayName })}
+      onValueChange={(nextId) => {
+        if (nextId === agentId) return;
+        const to = agentSwitchPathname(
+          location.pathname,
+          organizationId,
+          agentId,
+          nextId,
+        );
+        void navigate({ to, search: location.search });
+      }}
       trigger={
         <button
           type="button"

--- a/services/platform/app/features/automations/components/automation-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/automations/components/automation-breadcrumb-switcher.test.tsx
@@ -122,16 +122,16 @@ describe('AutomationBreadcrumbSwitcher', () => {
     );
 
     expect(
-      screen.getByRole('menuitem', { name: 'VAT return desk' }),
+      screen.getByRole('option', { name: 'VAT return desk' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('menuitem', { name: 'Gmail sync' }),
+      screen.getByRole('option', { name: 'Gmail sync' }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('menuitem', { name: 'Not installed yet' }),
+      screen.queryByRole('option', { name: 'Not installed yet' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('menuitem', { name: 'Email inbox' }),
+      screen.queryByRole('option', { name: 'Email inbox' }),
     ).not.toBeInTheDocument();
   });
 
@@ -149,7 +149,7 @@ describe('AutomationBreadcrumbSwitcher', () => {
         name: /switch automation, current: vat return desk/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Gmail sync' }));
+    await user.click(screen.getByRole('option', { name: 'Gmail sync' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/dashboard/org-1/automations/gmail__sync-emails',
@@ -172,7 +172,7 @@ describe('AutomationBreadcrumbSwitcher', () => {
         name: /switch automation, current: vat return desk/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Inbox only' }));
+    await user.click(screen.getByRole('option', { name: 'Inbox only' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/dashboard/org-1/automations/inbox-only',
@@ -195,7 +195,7 @@ describe('AutomationBreadcrumbSwitcher', () => {
         name: /switch automation, current: vat return desk/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Gmail sync' }));
+    await user.click(screen.getByRole('option', { name: 'Gmail sync' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/dashboard/org-1/projects/proj-1/automations/gmail__sync-emails',
@@ -217,7 +217,7 @@ describe('AutomationBreadcrumbSwitcher', () => {
         name: /switch automation, current: vat return desk/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'VAT return desk' }));
+    await user.click(screen.getByRole('option', { name: 'VAT return desk' }));
 
     expect(mockNavigate).not.toHaveBeenCalled();
   });

--- a/services/platform/app/features/automations/components/automation-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/automations/components/automation-breadcrumb-switcher.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { ChevronDown } from 'lucide-react';
 import { useMemo } from 'react';
 
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from '@/app/components/ui/forms/searchable-select';
 import { useAbility } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { resolveAutomationLocale } from '@/lib/shared/utils/resolve-automation-locale';
@@ -20,10 +23,10 @@ import {
 
 /**
  * Breadcrumb leaf for an automation detail page: the current name opens a
- * dropdown of INSTALLED sibling automations (same membership as the hub's
- * Installed tab — install row present, no bundles). Portable `?tab=` values
- * (Configuration, Integrations, shared workflow tabs when both sides have
- * them) are kept; a tab the target does not expose is dropped so the page
+ * searchable switcher of INSTALLED sibling automations (same membership as the
+ * hub's Installed tab — install row present, no bundles). Portable `?tab=`
+ * values (Configuration, Integrations, shared workflow tabs when both sides
+ * have them) are kept; a tab the target does not expose is dropped so the page
  * lands on its own default instead of a missing Editor/Triggers surface.
  */
 export function AutomationBreadcrumbSwitcher({
@@ -64,47 +67,51 @@ export function AutomationBreadcrumbSwitcher({
     [automations, installBySlug, locale],
   );
 
-  const items = useMemo<DropdownMenuGroup[]>(
-    () => [
+  const options = useMemo<SearchableSelectOption[]>(
+    () =>
       siblings.map((sibling) => ({
-        type: 'item' as const,
+        value: sibling.slug,
         label: sibling.name,
-        selected: sibling.slug === automationSlug,
-        onClick: () => {
-          if (sibling.slug === automationSlug) return;
-          const next = automationSwitchLocation({
-            organizationId,
-            toSlug: sibling.slug,
-            projectId,
-            search: location.search as Record<string, unknown>,
-            targetTabValues: automationInstalledTabValues(
-              sibling.automation,
-              isDeveloper,
-            ),
-          });
-          void navigate({ to: next.pathname, search: next.search });
-        },
       })),
-    ],
-    [
-      siblings,
-      automationSlug,
-      organizationId,
-      projectId,
-      navigate,
-      location.search,
-      isDeveloper,
-    ],
+    [siblings],
   );
 
-  if (siblings.length === 0) {
+  const siblingBySlug = useMemo(
+    () => new Map(siblings.map((sibling) => [sibling.slug, sibling])),
+    [siblings],
+  );
+
+  if (options.length === 0) {
     return <>{displayName}</>;
   }
 
   return (
-    <DropdownMenu
+    <SearchableSelect
+      variant="switcher"
       align="start"
-      items={items}
+      contentClassName="min-w-64"
+      value={automationSlug}
+      options={options}
+      title={t('switcher.title')}
+      searchPlaceholder={t('switcher.searchPlaceholder')}
+      emptyText={t('switcher.empty')}
+      aria-label={t('switcher.ariaLabel', { name: displayName })}
+      onValueChange={(nextSlug) => {
+        if (nextSlug === automationSlug) return;
+        const sibling = siblingBySlug.get(nextSlug);
+        if (!sibling) return;
+        const next = automationSwitchLocation({
+          organizationId,
+          toSlug: sibling.slug,
+          projectId,
+          search: location.search as Record<string, unknown>,
+          targetTabValues: automationInstalledTabValues(
+            sibling.automation,
+            isDeveloper,
+          ),
+        });
+        void navigate({ to: next.pathname, search: next.search });
+      }}
       trigger={
         <button
           type="button"

--- a/services/platform/app/features/projects/components/project-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/projects/components/project-breadcrumb-switcher.test.tsx
@@ -60,11 +60,9 @@ describe('ProjectBreadcrumbSwitcher', () => {
     );
 
     expect(
-      screen.getByRole('menuitem', { name: 'Getting started' }),
+      screen.getByRole('option', { name: 'Getting started' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('menuitem', { name: 'Acme AG' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Acme AG' })).toBeInTheDocument();
   });
 
   it('navigates to the selected project while keeping the current sub-page', async () => {
@@ -81,7 +79,7 @@ describe('ProjectBreadcrumbSwitcher', () => {
         name: /switch project, current: getting started/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Acme AG' }));
+    await user.click(screen.getByRole('option', { name: 'Acme AG' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/dashboard/org-1/projects/proj-acme/files',
@@ -103,7 +101,7 @@ describe('ProjectBreadcrumbSwitcher', () => {
         name: /switch project, current: getting started/i,
       }),
     );
-    await user.click(screen.getByRole('menuitem', { name: 'Getting started' }));
+    await user.click(screen.getByRole('option', { name: 'Getting started' }));
 
     expect(mockNavigate).not.toHaveBeenCalled();
   });

--- a/services/platform/app/features/projects/components/project-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/projects/components/project-breadcrumb-switcher.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { ChevronDown } from 'lucide-react';
 import { useMemo } from 'react';
 
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from '@/app/components/ui/forms/searchable-select';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -14,9 +17,9 @@ import { projectSwitchPathname } from '../lib/project-switch-path';
 
 /**
  * Breadcrumb leaf for a project detail page: the current project name opens a
- * dropdown of sibling projects so the operator can jump between them without
- * returning to the Projects list. Portable tabs (files, tasks, …) stay put;
- * bound-view / nested-automation paths reset to the overview.
+ * searchable switcher of sibling projects so the operator can jump between them
+ * without returning to the Projects list. Portable tabs (files, tasks, …) stay
+ * put; bound-view / nested-automation paths reset to the overview.
  */
 export function ProjectBreadcrumbSwitcher({
   organizationId,
@@ -32,44 +35,42 @@ export function ProjectBreadcrumbSwitcher({
   const location = useLocation();
   const { projects } = useProjects(organizationId);
 
-  const items = useMemo<DropdownMenuGroup[]>(
-    () => [
+  const options = useMemo<SearchableSelectOption[]>(
+    () =>
       projects.map((project) => ({
-        type: 'item' as const,
+        value: project._id,
         label: project.name,
-        selected: project._id === projectId,
-        onClick: () => {
-          if (project._id === projectId) return;
-          const to = projectSwitchPathname(
-            location.pathname,
-            organizationId,
-            projectId,
-            project._id,
-          );
-          void navigate({ to, search: location.search });
-        },
       })),
-    ],
-    [
-      projects,
-      projectId,
-      organizationId,
-      navigate,
-      location.pathname,
-      location.search,
-    ],
+    [projects],
   );
 
   // Nothing to switch to yet (list still empty / loading) — keep the plain
   // name so the h1 leaf stays readable without a dead chevron.
-  if (projects.length === 0) {
+  if (options.length === 0) {
     return <>{projectName}</>;
   }
 
   return (
-    <DropdownMenu
+    <SearchableSelect
+      variant="switcher"
       align="start"
-      items={items}
+      contentClassName="min-w-64"
+      value={projectId}
+      options={options}
+      title={t('switcher.title')}
+      searchPlaceholder={t('switcher.searchPlaceholder')}
+      emptyText={t('switcher.empty')}
+      aria-label={t('switcher.ariaLabel', { name: projectName })}
+      onValueChange={(nextId) => {
+        if (nextId === projectId) return;
+        const to = projectSwitchPathname(
+          location.pathname,
+          organizationId,
+          projectId,
+          nextId,
+        );
+        void navigate({ to, search: location.search });
+      }}
       trigger={
         <button
           type="button"

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -133,6 +133,7 @@ function AgentDetailLayout() {
     <AdaptiveHeaderRoot standalone={false} className="gap-2">
       <HeaderBreadcrumbs
         ariaLabel={tCommon('aria.breadcrumb')}
+        showImmediateParentOnMobile
         crumbs={[
           {
             key: 'agents',

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -995,6 +995,9 @@
       "folderDeleted": "Der Ordner dieses Quartals wurde gelöscht. Legen Sie ihn in Wissen neu an oder entfernen Sie diese Abrechnung."
     },
     "switcher": {
+      "title": "Automatisierung wechseln",
+      "searchPlaceholder": "Automatisierungen suchen",
+      "empty": "Keine Automatisierung gefunden",
       "ariaLabel": "Automatisierung wechseln, aktuell: {name}"
     }
   },
@@ -5585,6 +5588,9 @@
       "agentSaved": "Agent gespeichert",
       "agentSaveFailed": "Agent konnte nicht gespeichert werden",
       "switcher": {
+        "title": "Agent wechseln",
+        "searchPlaceholder": "Agenten suchen",
+        "empty": "Kein Agent gefunden",
         "ariaLabel": "Agent wechseln, aktuell: {name}"
       },
       "validation": {
@@ -8302,6 +8308,9 @@
       "statusBroken": "Reparatur nötig"
     },
     "switcher": {
+      "title": "Projekt wechseln",
+      "searchPlaceholder": "Projekte suchen",
+      "empty": "Kein Projekt gefunden",
       "ariaLabel": "Projekt wechseln, aktuell: {name}"
     }
   },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -995,6 +995,9 @@
       "folderDeleted": "This quarter’s folder was deleted. Recreate it in Knowledge, or remove this return."
     },
     "switcher": {
+      "title": "Switch automation",
+      "searchPlaceholder": "Search automations",
+      "empty": "No automations match",
       "ariaLabel": "Switch automation, current: {name}"
     }
   },
@@ -5584,6 +5587,9 @@
       "statusBroken": "Needs repair"
     },
     "switcher": {
+      "title": "Switch project",
+      "searchPlaceholder": "Search projects",
+      "empty": "No projects match",
       "ariaLabel": "Switch project, current: {name}"
     }
   },
@@ -5881,6 +5887,9 @@
       "agentSaved": "Agent saved",
       "agentSaveFailed": "Failed to save agent",
       "switcher": {
+        "title": "Switch agent",
+        "searchPlaceholder": "Search agents",
+        "empty": "No agents match",
         "ariaLabel": "Switch agent, current: {name}"
       },
       "validation": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -995,6 +995,9 @@
       "folderDeleted": "Le dossier de ce trimestre a été supprimé. Recréez-le dans Connaissances ou supprimez ce décompte."
     },
     "switcher": {
+      "title": "Changer d'automatisation",
+      "searchPlaceholder": "Rechercher des automatisations",
+      "empty": "Aucune automatisation ne correspond",
       "ariaLabel": "Changer d'automatisation, actuelle : {name}"
     }
   },
@@ -5585,6 +5588,9 @@
       "agentSaved": "Agent enregistré",
       "agentSaveFailed": "Échec de l'enregistrement de l'agent",
       "switcher": {
+        "title": "Changer d'agent",
+        "searchPlaceholder": "Rechercher des agents",
+        "empty": "Aucun agent ne correspond",
         "ariaLabel": "Changer d'agent, actuel : {name}"
       },
       "validation": {
@@ -8302,6 +8308,9 @@
       "statusBroken": "À réparer"
     },
     "switcher": {
+      "title": "Changer de projet",
+      "searchPlaceholder": "Rechercher des projets",
+      "empty": "Aucun projet ne correspond",
       "ariaLabel": "Changer de projet, actuel : {name}"
     }
   },


### PR DESCRIPTION
## What

Two related improvements to header breadcrumb navigation, one commit each.

### Searchable breadcrumb switchers

The agent, automation, and project breadcrumb switchers now use
`SearchableSelect` with a new `variant="switcher"` (titled panel, bordered
search field, leading check + left accent bar on the current row, capped
list height) instead of a plain dropdown, so long sibling lists become
searchable.

- New `title` prop and `variant: 'default' | 'switcher'` on `SearchableSelect`
- The agent switcher now offers only **installed + enabled** agents — the
  same gate the Agents list applies — rather than the full on-disk catalog
- `switcher.title` / `searchPlaceholder` / `empty` added to `en` / `de` / `fr`

### Mobile breadcrumb parent

New `showImmediateParentOnMobile` prop on `HeaderBreadcrumbs` keeps the last
ancestor visible below `md`, so an agent detail page reads `[parent] / [leaf]`
on a phone instead of collapsing to only the back button.

## Tests

Unit tests cover both: the switcher option list + variant rendering, and the
`showImmediateParentOnMobile` breakpoint behaviour (default vs opted-in).
