### PR TITLE
feat(cli): pin tale update to the current release line

### DIFF
--- a/docs/de/self-hosted/operate/upgrades.md
+++ b/docs/de/self-hosted/operate/upgrades.md
@@ -28,11 +28,13 @@ Zwei Dinge sind es wert, zuerst zu bestätigen:
 
 `tale update` aktualisiert das CLI-Binary und synct dann deine Projektdateien auf die Templates dieser Version. Es fasst die laufenden Container **nicht** an — das ist der Job von `tale deploy`. Scheitert der Datei-Sync, rollt das CLI sein eigenes Binary auf die Version zurück, auf der dein Workspace war, sodass Binary und `tale.json` nie auseinanderdriften.
 
+Ohne Argumente zielt das Kommando auf das neueste Release **innerhalb deiner aktuellen x.y-Release-Linie** — eine 0.3.x-Instanz bewegt sich auf das neueste 0.3.x. Releases auf einer neueren Linie können breaking Changes tragen, deshalb überquert `tale update` diese Grenze nie von selbst: Existiert eine neuere Linie, sagt es das und bleibt stehen. Der Linienwechsel ist ein bewusster Schritt — lies zuerst die Release-Notes der neuen Linie und nagle die Zielversion dann mit `--version` fest.
+
 ```bash
-# Bewege das CLI und die Projektdateien auf das letzte Release
+# Bewege das CLI und die Projektdateien auf das neueste Release der aktuellen x.y-Linie
 tale update
 
-# Eine bestimmte Version festnageln (erlaubt Downgrades — siehe Zurückrollen)
+# Eine bestimmte Version festnageln — der einzige Weg, die Linie zu wechseln (erlaubt Downgrades — siehe Zurückrollen)
 tale update --version 0.10.2
 
 # Versions-Wechsel und Datei-Sync vorab ansehen, ohne etwas anzufassen

--- a/docs/en/self-hosted/operate/upgrades.md
+++ b/docs/en/self-hosted/operate/upgrades.md
@@ -28,11 +28,13 @@ If the upgrade crosses a major version (1.x → 2.x), read the migration notes e
 
 `tale update` updates the CLI binary and then syncs your project files to that version's templates. It does **not** touch the running containers — that is `tale deploy`'s job. If the file sync fails, the CLI rolls its own binary back to the version your workspace was on, so the binary and `tale.json` never drift apart.
 
+Run bare, the command targets the newest release **in your current x.y release line** — a 0.3.x instance moves to the newest 0.3.x. Releases on a newer line can be breaking, so `tale update` never crosses that boundary on its own: when a newer line exists it says so and stays put. Moving lines is a deliberate step — read the release notes for the new line first, then pin it with `--version`.
+
 ```bash
-# Move the CLI + project files to the latest release
+# Move the CLI + project files to the newest release in the current x.y line
 tale update
 
-# Pin a specific version (allows downgrades — see Rolling back)
+# Pin a specific version — the only way to change lines; allows downgrades (see Rolling back)
 tale update --version 0.10.2
 
 # Preview the version change and file sync without touching anything

--- a/docs/fr/self-hosted/operate/upgrades.md
+++ b/docs/fr/self-hosted/operate/upgrades.md
@@ -28,11 +28,13 @@ Si la montée de version traverse une version majeure (1.x → 2.x), lis les not
 
 `tale update` met à jour le binaire CLI, puis synchronise tes fichiers projet sur les templates de cette version. Il ne **touche pas** aux conteneurs en marche — c'est le boulot de `tale deploy`. Si la synchro des fichiers échoue, la CLI fait reculer son propre binaire à la version sur laquelle ton workspace était, pour que le binaire et `tale.json` ne dérivent jamais l'un de l'autre.
 
+Lancée sans argument, la commande vise la release la plus récente **de ta ligne x.y actuelle** — une instance 0.3.x bouge vers la 0.3.x la plus récente. Les releases d'une ligne plus récente peuvent porter des changements breaking, donc la commande ne franchit jamais cette frontière d'elle-même : quand une ligne plus récente existe, elle le dit et reste en place. Changer de ligne est un pas délibéré — lis d'abord les notes de version de la nouvelle ligne, puis fixe la version cible avec `--version`.
+
 ```bash
-# Bouge la CLI et les fichiers projet à la dernière release
+# Bouge la CLI et les fichiers projet à la release la plus récente de la ligne x.y actuelle
 tale update
 
-# Fixe une version précise (autorise les downgrades — voir Rollback)
+# Fixe une version précise — le seul moyen de changer de ligne (autorise les downgrades — voir Rollback)
 tale update --version 0.10.2
 
 # Aperçu du changement de version et de la synchro des fichiers sans rien toucher

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -118,16 +118,19 @@ binary first, then syncs the project files to that version's templates. It does
 **not** roll the containers — run `tale deploy` afterwards for that. If the file
 sync fails, the CLI is rolled back to the workspace's previous version so the
 binary and `tale.json` never drift apart. With no `--version`, targets the
-latest release.
+latest release **in the current x.y release line** (a 0.3.x CLI moves to the
+newest 0.3.x). Line upgrades (e.g. 0.3.x → 0.4.0) can be breaking, so they
+never happen implicitly: when a newer line exists the command says so and
+stays put; move lines deliberately with `--version`.
 
 The CLI also self-aligns to the instance version on every command, so you rarely
 run `tale update` except to deliberately move versions.
 
-| Option                | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| `-v, --version <ver>` | Update to this exact version instead of latest (allows downgrade) |
-| `-f, --force`         | Force re-sync of locally modified project files                   |
-| `--dry-run`           | Preview the version change and file sync without modifying        |
+| Option                | Description                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| `-v, --version <ver>` | Update to this exact version instead of the in-line latest (allows downgrade and line changes) |
+| `-f, --force`         | Force re-sync of locally modified project files                                                |
+| `--dry-run`           | Preview the version change and file sync without modifying                                     |
 
 ### `tale status`
 

--- a/tools/cli/src/commands/update/index.ts
+++ b/tools/cli/src/commands/update/index.ts
@@ -7,11 +7,11 @@ export function createUpdateCommand(): Command {
   return (
     new Command('update')
       .description(
-        'Update this Tale instance: move the CLI to a new version and sync project files (run `tale deploy` afterwards to roll the containers)',
+        'Update this Tale instance: move the CLI to a new version within its current x.y release line and sync project files (run `tale deploy` afterwards to roll the containers)',
       )
       .option(
         '-v, --version <version>',
-        'update to this exact version (e.g. 0.9.0) instead of the latest release; allows downgrades',
+        'update to this exact version (e.g. 0.9.0) instead of the latest release in the current x.y line; required to change release lines; allows downgrades',
       )
       .option(
         '-f, --force',

--- a/tools/cli/src/lib/actions/run-update.test.ts
+++ b/tools/cli/src/lib/actions/run-update.test.ts
@@ -12,6 +12,7 @@ function resolved(version: string): ResolvedRelease {
   return {
     release: { tag: `v${version}`, version, assetNames: ['tale_macos'] },
     skipped: [],
+    newerLine: null,
   };
 }
 
@@ -106,5 +107,18 @@ describe('runUpdate', () => {
 
     expect(resolveRelease).toHaveBeenCalledWith({ version: '0.7.0' });
     expect(deps.installBinary).toHaveBeenCalledTimes(1);
+  });
+
+  test('newer release line available: still targets the in-line release', async () => {
+    const resolveRelease = mock(async () => ({
+      ...resolved('0.8.1'),
+      newerLine: '0.9.0',
+    }));
+    const deps = makeDeps({ resolveRelease });
+    await runUpdate({}, deps);
+
+    expect(deps.installBinary).toHaveBeenCalledWith(
+      expect.objectContaining({ version: '0.8.1' }),
+    );
   });
 });

--- a/tools/cli/src/lib/actions/run-update.ts
+++ b/tools/cli/src/lib/actions/run-update.ts
@@ -146,7 +146,7 @@ export async function runUpdate(
   const projectDir = deps.requireProject();
   const prev = await deps.readWorkspaceVersion(projectDir);
 
-  const { release, skipped } = await deps.resolveRelease({
+  const { release, skipped, newerLine } = await deps.resolveRelease({
     version: opts.version,
   });
   const target = release.version;
@@ -170,6 +170,14 @@ export async function runUpdate(
     logger.warn(
       `Skipping ${skipped.map((t) => t.replace(/^v/, '')).join(', ')} — ` +
         `binary not yet uploaded. Re-run 'tale update' later to pick them up.`,
+    );
+  }
+  if (!opts.version && newerLine !== null) {
+    logger.warn(
+      `A newer release line is available: v${newerLine}. 'tale update' stays ` +
+        `within your current line, and line upgrades can be breaking — review ` +
+        `the release notes and the upgrade docs, then run ` +
+        `'tale update --version ${newerLine}' to move explicitly.`,
     );
   }
   if (opts.version && !isDev && comparison < 0) {

--- a/tools/cli/src/lib/version/self-update.test.ts
+++ b/tools/cli/src/lib/version/self-update.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+
+import { type ReleaseInfo, selectRelease } from './self-update';
+
+const ASSET = 'tale_linux';
+
+function release(version: string, assets: string[] = [ASSET]): ReleaseInfo {
+  return { tag: `v${version}`, version, assetNames: assets };
+}
+
+describe('selectRelease', () => {
+  test('pinned: picks the highest release in the anchor line, not the newest overall', () => {
+    const { best, newerLine } = selectRelease(
+      [
+        release('0.4.1'),
+        release('0.4.0'),
+        release('0.3.12'),
+        release('0.3.11'),
+      ],
+      ASSET,
+      '0.3.11',
+    );
+    expect(best?.version).toBe('0.3.12');
+    expect(newerLine).toBe('0.4.1');
+  });
+
+  test('pinned: lines below the anchor never count as newer', () => {
+    const { best, newerLine } = selectRelease(
+      [release('0.3.12'), release('0.2.9')],
+      ASSET,
+      '0.3.11',
+    );
+    expect(best?.version).toBe('0.3.12');
+    expect(newerLine).toBeNull();
+  });
+
+  test('pinned: a major bump counts as a newer line', () => {
+    const { best, newerLine } = selectRelease(
+      [release('1.0.0'), release('0.9.3')],
+      ASSET,
+      '0.9.2',
+    );
+    expect(best?.version).toBe('0.9.3');
+    expect(newerLine).toBe('1.0.0');
+  });
+
+  test('pinned: skipped lists only same-line releases missing the binary', () => {
+    const { best, skipped } = selectRelease(
+      [
+        release('0.4.0', []),
+        release('0.3.14', []),
+        release('0.3.13', []),
+        release('0.3.12'),
+      ],
+      ASSET,
+      '0.3.11',
+    );
+    expect(best?.version).toBe('0.3.12');
+    expect(skipped).toEqual(['v0.3.14', 'v0.3.13']);
+  });
+
+  test('pinned: no release in the line → best is null, newer line still reported', () => {
+    const { best, newerLine } = selectRelease(
+      [release('0.4.0')],
+      ASSET,
+      '0.3.11',
+    );
+    expect(best).toBeNull();
+    expect(newerLine).toBe('0.4.0');
+  });
+
+  test('unpinned (dev build): picks the newest release across lines', () => {
+    const { best, newerLine } = selectRelease(
+      [release('0.4.0'), release('0.3.12')],
+      ASSET,
+      null,
+    );
+    expect(best?.version).toBe('0.4.0');
+    expect(newerLine).toBeNull();
+  });
+
+  test('unpinned: binary-less newer versions are skipped across lines', () => {
+    const { best, skipped } = selectRelease(
+      [release('0.4.0', []), release('0.3.12')],
+      ASSET,
+      null,
+    );
+    expect(best?.version).toBe('0.3.12');
+    expect(skipped).toEqual(['v0.4.0']);
+  });
+
+  test('a release without this platform binary is never picked', () => {
+    const { best } = selectRelease(
+      [release('0.3.12', ['tale_windows.exe']), release('0.3.11')],
+      ASSET,
+      '0.3.10',
+    );
+    expect(best?.version).toBe('0.3.11');
+  });
+});

--- a/tools/cli/src/lib/version/self-update.ts
+++ b/tools/cli/src/lib/version/self-update.ts
@@ -3,7 +3,11 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
 import pkg from '../../../package.json';
-import { compareVersions, extractVersion } from '../../utils/compare-versions';
+import {
+  compareVersions,
+  extractVersion,
+  sameMinor,
+} from '../../utils/compare-versions';
 import * as logger from '../../utils/logger';
 
 /**
@@ -38,11 +42,21 @@ export interface ReleaseInfo {
 export interface ResolvedRelease {
   release: ReleaseInfo;
   /**
-   * Tags newer than `release` that lack the binary for this platform — i.e.
-   * a newer version exists but its binary hasn't been uploaded yet. Empty
-   * when a specific version was requested. Newest-first.
+   * Tags newer than `release` within the same release line that lack the
+   * binary for this platform — i.e. a newer version exists but its binary
+   * hasn't been uploaded yet. Empty when a specific version was requested.
+   * Newest-first.
    */
   skipped: string[];
+  /**
+   * Highest released version on a line above the current one (different
+   * `major.minor`) when the lookup was line-pinned and one exists. Line
+   * upgrades can be breaking, so `tale update` never targets this
+   * automatically — it is surfaced so the operator can move explicitly with
+   * `--version`. Null when a specific version was requested, on dev builds,
+   * or when the current line is the newest.
+   */
+  newerLine: string | null;
 }
 
 /**
@@ -85,10 +99,14 @@ function parseRelease(data: Record<string, unknown>): ReleaseInfo | null {
   return { tag, version, assetNames };
 }
 
-async function fetchLatestReadyRelease(
-  asset: string,
-): Promise<ResolvedRelease> {
-  const url = `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=15`;
+const RELEASES_PAGE_SIZE = 100;
+/** Upper bound on paging through /releases — 300 releases ≈ years of history. */
+const RELEASES_MAX_PAGES = 3;
+
+async function fetchReleasesPage(
+  page: number,
+): Promise<Record<string, unknown>[]> {
+  const url = `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${RELEASES_PAGE_SIZE}&page=${page}`;
   const response = await fetch(url, {
     headers: {
       ...getAuthHeaders(),
@@ -115,44 +133,69 @@ async function fetchLatestReadyRelease(
   }
 
   const entries = (await response.json()) as Record<string, unknown>[];
-  if (!Array.isArray(entries) || entries.length === 0) {
-    throw new Error(
-      'No releases found. If this is a private repo, set GITHUB_TOKEN.',
-    );
-  }
+  return Array.isArray(entries) ? entries : [];
+}
 
-  // Parse all non-draft, non-prerelease releases (cap at 10)
-  const candidates: ReleaseInfo[] = [];
-  for (const entry of entries) {
-    if (entry.draft || entry.prerelease) continue;
-    const release = parseRelease(entry);
-    if (release) candidates.push(release);
-    if (candidates.length >= 10) break;
-  }
+/** Human label for `anchor`'s release line: `0.3.11` → `0.3.x`. */
+function lineLabel(anchor: string): string {
+  const version = extractVersion(anchor);
+  if (!version) return anchor;
+  const [major, minor] = version.split('-')[0].split('.');
+  return `${major}.${minor}.x`;
+}
 
-  // Find the highest-versioned release that has the required binary asset
+/**
+ * Pick the release to install from the fetched list: the highest-versioned
+ * candidate that carries this platform's binary, restricted to `lineAnchor`'s
+ * release line (same `major.minor`) unless the anchor is null.
+ *
+ * `skipped` lists same-line versions above the pick whose binary is missing,
+ * newest first. `newerLine` reports the highest version on a line above the
+ * anchor's, if any — informational, never targeted.
+ *
+ * Exported for tests; production goes through {@link resolveRelease}.
+ */
+export function selectRelease(
+  candidates: ReleaseInfo[],
+  asset: string,
+  lineAnchor: string | null,
+): {
+  best: ReleaseInfo | null;
+  skipped: string[];
+  newerLine: string | null;
+} {
+  const inLine = (version: string) =>
+    lineAnchor === null || sameMinor(version, lineAnchor);
+
   let best: ReleaseInfo | null = null;
-  const skipped: string[] = [];
+  let newerLine: string | null = null;
 
   for (const candidate of candidates) {
-    if (candidate.assetNames.includes(asset)) {
-      if (!best || compareVersions(candidate.version, best.version) > 0) {
-        best = candidate;
+    if (!inLine(candidate.version)) {
+      if (
+        lineAnchor !== null &&
+        compareVersions(candidate.version, lineAnchor) > 0 &&
+        (newerLine === null ||
+          compareVersions(candidate.version, newerLine) > 0)
+      ) {
+        newerLine = candidate.version;
       }
+      continue;
+    }
+    if (!candidate.assetNames.includes(asset)) continue;
+    if (!best || compareVersions(candidate.version, best.version) > 0) {
+      best = candidate;
     }
   }
 
-  if (!best) {
-    throw new Error(
-      `No recent release includes the ${asset} binary. ` +
-        `Check https://github.com/${GITHUB_REPO}/releases for details.`,
-    );
-  }
-
-  // Collect versions newer than the best ready release but lacking the binary
-  for (const candidate of candidates) {
-    if (compareVersions(candidate.version, best.version) > 0) {
-      skipped.push(candidate.tag);
+  // Collect same-line versions newer than the pick but lacking the binary
+  const skipped: string[] = [];
+  if (best) {
+    for (const candidate of candidates) {
+      if (!inLine(candidate.version)) continue;
+      if (compareVersions(candidate.version, best.version) > 0) {
+        skipped.push(candidate.tag);
+      }
     }
   }
 
@@ -163,7 +206,73 @@ async function fetchLatestReadyRelease(
     return compareVersions(vb, va);
   });
 
-  return { release: best, skipped };
+  return { best, skipped, newerLine };
+}
+
+async function fetchLatestReadyRelease(
+  asset: string,
+  lineAnchor: string | null,
+): Promise<ResolvedRelease> {
+  const candidates: ReleaseInfo[] = [];
+  let sawAnyRelease = false;
+
+  // Page until the pinned line yields an installable release — once newer
+  // lines accumulate releases, the current line's latest falls off the
+  // first page.
+  for (let page = 1; page <= RELEASES_MAX_PAGES; page++) {
+    let entries: Record<string, unknown>[];
+    try {
+      entries = await fetchReleasesPage(page);
+    } catch (err) {
+      if (page === 1) throw err;
+      // Later pages are best-effort: select from what already loaded.
+      logger.debug(
+        `stopping release pagination at page ${page}: ${String(err)}`,
+      );
+      break;
+    }
+    if (entries.length > 0) sawAnyRelease = true;
+
+    for (const entry of entries) {
+      if (entry.draft || entry.prerelease) continue;
+      const release = parseRelease(entry);
+      if (release) candidates.push(release);
+    }
+
+    const { best } = selectRelease(candidates, asset, lineAnchor);
+    if (best || entries.length < RELEASES_PAGE_SIZE) break;
+  }
+
+  if (!sawAnyRelease) {
+    throw new Error(
+      'No releases found. If this is a private repo, set GITHUB_TOKEN.',
+    );
+  }
+
+  const { best, skipped, newerLine } = selectRelease(
+    candidates,
+    asset,
+    lineAnchor,
+  );
+
+  if (!best) {
+    const base =
+      lineAnchor === null
+        ? `No recent release includes the ${asset} binary.`
+        : `No ${lineLabel(lineAnchor)} release includes the ${asset} binary.`;
+    const lineHint =
+      lineAnchor !== null && newerLine !== null
+        ? ` A newer release line exists (v${newerLine}) — 'tale update' stays ` +
+          `within ${lineLabel(lineAnchor)}; move lines explicitly with ` +
+          `'tale update --version ${newerLine}'.`
+        : '';
+    throw new Error(
+      `${base}${lineHint} ` +
+        `Check https://github.com/${GITHUB_REPO}/releases for details.`,
+    );
+  }
+
+  return { release: best, skipped, newerLine };
 }
 
 async function fetchReleaseByTag(
@@ -228,7 +337,13 @@ export function getBinaryPath(): string {
 
 /**
  * Resolve the release to install: a specific version when `version` is set,
- * otherwise the latest release whose platform binary is uploaded.
+ * otherwise the latest release — within the running binary's release line
+ * (same `major.minor`) — whose platform binary is uploaded.
+ *
+ * Line upgrades (e.g. 0.3.x → 0.4.0) can be breaking, so they never happen
+ * implicitly: moving lines requires an explicit `version`. Dev builds carry
+ * a placeholder version with no released line and keep resolving the
+ * absolute latest.
  */
 export async function resolveRelease(opts: {
   version?: string;
@@ -236,9 +351,10 @@ export async function resolveRelease(opts: {
   const asset = getAssetName();
   if (opts.version) {
     const release = await fetchReleaseByTag(asset, normalizeTag(opts.version));
-    return { release, skipped: [] };
+    return { release, skipped: [], newerLine: null };
   }
-  return fetchLatestReadyRelease(asset);
+  const lineAnchor = isDevBuild() ? null : pkg.version;
+  return fetchLatestReadyRelease(asset, lineAnchor);
 }
 
 function formatBytes(bytes: number): string {


### PR DESCRIPTION
## Why

0.4.0 ships as a breaking, fresh-deploy-only release with no 0.3 → 0.4 migration (#2857). Today `tale update` without `--version` targets the highest non-prerelease release that has a platform binary — so the moment v0.4.0 becomes a normal GitHub release, every 0.3.x CLI in the wild auto-jumps on `tale update`: binary, project files, and `tale.json` all move to 0.4, and only the deploy guard in the 0.4 binary stops the damage after the fact. This change has to ship in a 0.3.12 release **before** v0.4.0 goes public.

## What

- `tale update` without `--version` resolves the newest release **within the running binary's `major.minor` line** (via the existing `sameMinor()`); changing lines requires an explicit `tale update --version X`.
- When a newer line exists, resolution returns it as `newerLine` and `tale update` warns with the exact command to move — it never targets it. Dry-run shows the same notice.
- Release lookup pages through `/releases` (`per_page=100`, up to 3 pages). The repo already has 100+ releases, so the old single 15-entry page stops seeing a pinned line once newer lines accumulate — today an old 0.2-line CLI already cannot see 0.2.99 in that window.
- Dev builds (`-dev` placeholder version, no released line) keep resolving the absolute latest.
- The `skipped` list ("binary not yet uploaded") is now same-line only; cross-line availability is the separate notice.
- Help text, `tools/cli/README.md`, and `docs/{en,de,fr}/self-hosted/operate/upgrades.md` updated to match.

## Verification

- New `selectRelease` unit tests (line pick, newer-line detection, major bump, skipped scoping, no-in-line error hint, unpinned/dev) plus a run-update case; CLI suite 305 pass, tsc + oxlint clean; @tale/docs 194 pass.
- Live-data check against the real release list: anchor `0.2.50` → best `0.2.99` + newerLine `0.3.11` (the exact cross-line scenario, replayed on real history); anchor `0.3.4` → `0.3.11`, no newerLine; unpinned → `0.3.11`.

## Release sequencing

1. Land here, sync to `release/0.3`, ship as **v0.3.12**; release notes say "update your CLI to ≥0.3.12 first".
2. Publish the first v0.4.0 as a GitHub **prerelease** for a transition window — CLI resolution and `install-cli.sh` (`releases/latest`) both skip prereleases, so not-yet-updated 0.3 CLIs keep resolving 0.3.x.
3. Residual risk once 0.4.0 goes GA: CLIs ≤ 0.3.11 that never updated still jump lines; their data stays protected by the 0.4 deploy guard and the docker-entrypoint backstop.

Note: #2857 touches the same `run-update.ts` region (BREAKING_BASELINE downgrade warning, legacy-volume module removal) — whichever lands second gets a small, trivially resolvable conflict.