### PR TITLE
fix(platform): cascade an integration reconnect to agents and schedules

### DIFF
--- a/services/platform/convex/automations/install_mutations.ts
+++ b/services/platform/convex/automations/install_mutations.ts
@@ -246,6 +246,31 @@ export const listAutomationInstallationsInternal = internalQuery({
   },
 });
 
+/**
+ * Automation slugs whose install row lists `integrationSlug` in its
+ * `requiredIntegrations` — the automations BOUND to a given integration in this
+ * org. Drives "Duplicate integration": each bound automation is cloned + rebound
+ * to the duplicate's new slug. Single `by_org` scan + in-memory filter (the set
+ * per org is small); `requiredIntegrations` is already denormalized on the row.
+ */
+export const listInstallationsRequiringIntegrationInternal = internalQuery({
+  args: { organizationId: v.string(), integrationSlug: v.string() },
+  returns: v.array(v.object({ automationSlug: v.string() })),
+  handler: async (ctx, args): Promise<Array<{ automationSlug: string }>> => {
+    const out: Array<{ automationSlug: string }> = [];
+    for await (const row of ctx.db
+      .query('automationInstallations')
+      .withIndex('by_org', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      if (row.requiredIntegrations.includes(args.integrationSlug)) {
+        out.push({ automationSlug: row.automationSlug });
+      }
+    }
+    return out;
+  },
+});
+
 export const getAutomationInstallationInternal = internalQuery({
   args: { organizationId: v.string(), automationSlug: v.string() },
   returns: v.union(v.any(), v.null()),

--- a/services/platform/convex/integrations/cascade.ts
+++ b/services/platform/convex/integrations/cascade.ts
@@ -1,23 +1,35 @@
 'use node';
 
 /**
- * Integration → agents cascade coordinator. When an integration is
- * disconnected, every agent that HARD-requires it
- * (`metadata.requires.integrations`) is disabled. On reconnect, only what the
+ * Integration → agents + schedules cascade coordinator, run on either edge of a
+ * credential's connected state. Scheduled from `credential_mutations.ts` (V8
+ * mutations can't call a `'use node'` action directly).
+ *
+ * On `disable`, every agent that HARD-requires the integration
+ * (`metadata.requires.integrations`) is disabled. On `enable`, only what the
  * cascade disabled is restored — a user's explicit disable is never
- * resurrected. Scheduled from `credential_mutations.ts` on credential status
- * changes (V8 mutations can't call a `'use node'` action directly).
+ * resurrected — and the schedules of the automations BOUND to the integration
+ * are reconciled from their manifests. That reconcile is what lets an
+ * automation be installed against a not-yet-connected integration WITHOUT a
+ * cron: rather than firing a doomed run every tick until an operator supplies
+ * the login, it gets its schedule the moment the integration first connects.
+ * For everything already running it is a heal, and it is pause-preserving —
+ * `reconcileAutomationSchedules` converges an existing row's variables/timezone
+ * and never touches its `isActive`, so a schedule an operator paused stays
+ * paused across a disconnect/reconnect cycle.
  */
 
 import { v } from 'convex/values';
 
 import { getString, isRecord } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
-import { internalAction } from '../_generated/server';
+import { type ActionCtx, internalAction } from '../_generated/server';
 import {
   invalidateAgentListCache,
   listAgentsForOrg,
 } from '../agents/internal_actions';
+import { syncAutomationSchedules } from '../automations/install_actions';
+import { readAutomationBundleManifest } from '../automations/install_fs';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 
 /** Agents that HARD-require `slug` via metadata.requires.integrations. */
@@ -43,14 +55,58 @@ async function requiringAgentSlugs(
   return out;
 }
 
+/**
+ * Reconcile the schedules of every automation bound to `slug` from its manifest.
+ * Best-effort per automation: a bundle whose source no longer resolves is logged
+ * and skipped rather than failing the whole cascade (the agent half has already
+ * run, and a reconnect must not half-apply).
+ */
+async function reconcileBoundSchedules(
+  ctx: ActionCtx,
+  organizationId: string,
+  orgSlug: string,
+  slug: string,
+): Promise<number> {
+  const bound = await ctx.runQuery(
+    internal.automations.install_mutations
+      .listInstallationsRequiringIntegrationInternal,
+    { organizationId, integrationSlug: slug },
+  );
+  let reconciled = 0;
+  for (const { automationSlug } of bound) {
+    try {
+      const manifest = await readAutomationBundleManifest(
+        orgSlug,
+        automationSlug,
+      );
+      await syncAutomationSchedules(
+        ctx,
+        organizationId,
+        automationSlug,
+        manifest,
+      );
+      reconciled += 1;
+    } catch (error) {
+      console.error(
+        `[IntegrationCascade] schedule reconcile for automation "${automationSlug}" failed:`,
+        error,
+      );
+    }
+  }
+  return reconciled;
+}
+
 export const cascadeIntegration = internalAction({
   args: {
     organizationId: v.string(),
     slug: v.string(),
     mode: v.union(v.literal('disable'), v.literal('enable')),
   },
-  returns: v.object({ agents: v.number() }),
-  handler: async (ctx, args): Promise<{ agents: number }> => {
+  returns: v.object({ agents: v.number(), schedules: v.number() }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ agents: number; schedules: number }> => {
     const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
 
     // Agents that hard-require this integration.
@@ -72,13 +128,28 @@ export const cascadeIntegration = internalAction({
       }
     }
 
+    // Only the reconnect edge provisions schedules. Disconnect deliberately
+    // leaves them alone: a cron whose integration is down fails visibly, and
+    // silently deactivating rows here would need a "who paused this" marker to
+    // avoid resurrecting an operator's own pause on the way back up.
+    const schedules =
+      args.mode === 'enable'
+        ? await reconcileBoundSchedules(
+            ctx,
+            args.organizationId,
+            orgSlug,
+            args.slug,
+          )
+        : 0;
+
     invalidateAgentListCache(orgSlug);
     console.log('[IntegrationCascade]', {
       org: args.organizationId,
       slug: args.slug,
       mode: args.mode,
       agents: agentSlugs.length,
+      schedules,
     });
-    return { agents: agentSlugs.length };
+    return { agents: agentSlugs.length, schedules };
   },
 });

--- a/services/platform/convex/integrations/credential_mutations.test.ts
+++ b/services/platform/convex/integrations/credential_mutations.test.ts
@@ -44,7 +44,7 @@ vi.mock('./slack_installations', () => ({
   deleteSlackInstallationsForCredential: vi.fn().mockResolvedValue(undefined),
 }));
 
-const { updateCredentials, deleteCredentials } =
+const { updateCredentials, updateCredentialsInternal, deleteCredentials } =
   await import('./credential_mutations');
 
 type MutationConfig = {
@@ -52,18 +52,22 @@ type MutationConfig = {
 };
 
 const updateHandler = (updateCredentials as unknown as MutationConfig).handler;
+const updateInternalHandler = (
+  updateCredentialsInternal as unknown as MutationConfig
+).handler;
 const deleteHandler = (deleteCredentials as unknown as MutationConfig).handler;
 
-function createMockCtx() {
+function createMockCtx(
+  cred: Record<string, unknown> = { status: 'active', isActive: true },
+) {
   return {
     db: {
       get: vi.fn().mockResolvedValue({
         _id: 'cred-1',
         organizationId: 'org-123',
         slug: 'slack',
-        status: 'active',
-        isActive: true,
         authMethod: 'apiKey',
+        ...cred,
       }),
       patch: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
@@ -71,6 +75,18 @@ function createMockCtx() {
     storage: { delete: vi.fn().mockResolvedValue(undefined) },
     scheduler: { runAfter: vi.fn().mockResolvedValue(undefined) },
   };
+}
+
+/** The cascade mode scheduled by a handler, or null when none was scheduled. */
+function scheduledCascadeMode(
+  ctx: ReturnType<typeof createMockCtx>,
+): string | null {
+  const call = ctx.scheduler.runAfter.mock.calls.find(
+    (args: unknown[]) => args[1] === 'cascadeIntegration',
+  );
+  if (!call) return null;
+  const payload = call[2] as { mode: string };
+  return payload.mode;
 }
 
 describe('credential mutations capability gate', () => {
@@ -151,6 +167,74 @@ describe('credential mutations capability gate', () => {
       );
 
       expect(ctx.db.patch).toHaveBeenCalled();
+    });
+  });
+
+  // The cascade re-enables agents a disconnect disabled AND provisions the
+  // schedules of the automations bound to the integration. It must fire on BOTH
+  // connected-state edges — reconnect used to schedule nothing, which left the
+  // `enable` half of cascade.ts unreachable.
+  describe('connected-state cascade', () => {
+    it('cascades disable when a connected credential is deactivated', async () => {
+      asDeveloper();
+      const ctx = createMockCtx({ status: 'active', isActive: true });
+
+      await updateHandler(
+        ctx as never,
+        {
+          credentialId: 'cred-1',
+          isActive: false,
+          status: 'inactive',
+        } as never,
+      );
+
+      expect(scheduledCascadeMode(ctx)).toBe('disable');
+    });
+
+    it('cascades enable when a disconnected credential is reactivated', async () => {
+      asDeveloper();
+      const ctx = createMockCtx({ status: 'inactive', isActive: false });
+
+      await updateHandler(
+        ctx as never,
+        { credentialId: 'cred-1', isActive: true, status: 'active' } as never,
+      );
+
+      expect(scheduledCascadeMode(ctx)).toBe('enable');
+    });
+
+    it('schedules nothing when the connected state does not change', async () => {
+      asDeveloper();
+      const ctx = createMockCtx({ status: 'active', isActive: true });
+
+      await updateHandler(
+        ctx as never,
+        { credentialId: 'cred-1', errorMessage: 'transient' } as never,
+      );
+
+      expect(scheduledCascadeMode(ctx)).toBeNull();
+    });
+
+    it('cascades enable from the internal mutation (the OAuth2 exchange path)', async () => {
+      const ctx = createMockCtx({ status: 'inactive', isActive: false });
+
+      await updateInternalHandler(
+        ctx as never,
+        { credentialId: 'cred-1', isActive: true, status: 'active' } as never,
+      );
+
+      expect(scheduledCascadeMode(ctx)).toBe('enable');
+    });
+
+    it('does not cascade on an internal token refresh of a live credential', async () => {
+      const ctx = createMockCtx({ status: 'active', isActive: true });
+
+      await updateInternalHandler(
+        ctx as never,
+        { credentialId: 'cred-1', status: 'active', isActive: true } as never,
+      );
+
+      expect(scheduledCascadeMode(ctx)).toBeNull();
     });
   });
 });

--- a/services/platform/convex/integrations/credential_mutations.ts
+++ b/services/platform/convex/integrations/credential_mutations.ts
@@ -25,20 +25,39 @@ import {
 } from './validators';
 
 /**
- * Disconnecting an integration cascade-disables agents that hard-require it.
- * Scheduled (not awaited) because the cascade coordinator is a `'use node'`
- * action a V8 mutation cannot call directly.
+ * Disconnecting an integration cascade-disables agents that hard-require it;
+ * reconnecting restores them and (re)provisions the schedules of the automations
+ * bound to it. Scheduled (not awaited) because the cascade coordinator is a
+ * `'use node'` action a V8 mutation cannot call directly.
  */
-function scheduleCascadeDisable(
+function scheduleCascade(
   ctx: MutationCtx,
   organizationId: string,
   slug: string,
+  mode: 'disable' | 'enable',
 ): Promise<unknown> {
   return ctx.scheduler.runAfter(
     0,
     internal.integrations.cascade.cascadeIntegration,
-    { organizationId, slug, mode: 'disable' },
+    { organizationId, slug, mode },
   );
+}
+
+/**
+ * Whether this patch flips the credential's connected state, and which way.
+ * `null` when the transition is a no-op (a plain credential edit, a re-save of
+ * an already-connected integration) — the cascade only runs on a real edge.
+ */
+function connectedTransition(
+  cred: { isActive: boolean; status: string },
+  updates: { isActive?: boolean; status?: string },
+): 'disable' | 'enable' | null {
+  const wasActive = cred.isActive && cred.status === 'active';
+  const nowActive =
+    (updates.isActive ?? cred.isActive) &&
+    (updates.status ?? cred.status) === 'active';
+  if (wasActive === nowActive) return null;
+  return nowActive ? 'enable' : 'disable';
 }
 
 export const createCredentials = internalMutation({
@@ -136,14 +155,12 @@ export const updateCredentials = mutation({
     if (clearSmtpAuth) cleanUpdates.smtpAuth = undefined;
     await ctx.db.patch(credentialId, cleanUpdates);
 
-    // Cascade on the disconnect transition: disable any agents that
-    // hard-require this integration.
-    const wasActive = cred.isActive && cred.status === 'active';
-    const nowActive =
-      (updates.isActive ?? cred.isActive) &&
-      (updates.status ?? cred.status) === 'active';
-    if (!nowActive && wasActive) {
-      await scheduleCascadeDisable(ctx, cred.organizationId, cred.slug);
+    // Cascade on either connected-state edge: disconnect disables the agents
+    // that hard-require this integration, reconnect restores them and revives
+    // the bound automations' schedules.
+    const transition = connectedTransition(cred, updates);
+    if (transition) {
+      await scheduleCascade(ctx, cred.organizationId, cred.slug, transition);
     }
 
     await AuditLogHelpers.logSuccess(ctx, {
@@ -179,6 +196,7 @@ export const updateCredentialsInternal = internalMutation({
   args: updateCredentialsArgs,
   handler: async (ctx, args) => {
     const { credentialId, clearSmtpAuth, ...updates } = args;
+    const cred = await ctx.db.get(credentialId);
     const cleanUpdates = Object.fromEntries(
       Object.entries(updates).filter(([_, value]) => value !== undefined),
     );
@@ -186,6 +204,17 @@ export const updateCredentialsInternal = internalMutation({
     // mailbox login when the separate SMTP provider is turned off.
     if (clearSmtpAuth) cleanUpdates.smtpAuth = undefined;
     await ctx.db.patch(credentialId, cleanUpdates);
+
+    // Same connected-state cascade the user-facing mutation runs: the OAuth2
+    // token exchange completes a (re)connection here, and a failed refresh
+    // parks the credential in `error`. Edge-gated, so a plain token refresh
+    // (active → active) is a no-op.
+    if (cred) {
+      const transition = connectedTransition(cred, updates);
+      if (transition) {
+        await scheduleCascade(ctx, cred.organizationId, cred.slug, transition);
+      }
+    }
   },
 });
 
@@ -221,7 +250,7 @@ export const deleteCredentials = mutation({
     await ctx.db.delete(args.credentialId);
 
     // Disconnecting the integration: cascade-disable its hard-requiring agents.
-    await scheduleCascadeDisable(ctx, cred.organizationId, cred.slug);
+    await scheduleCascade(ctx, cred.organizationId, cred.slug, 'disable');
 
     await AuditLogHelpers.logSuccess(ctx, {
       auditCtx: {


### PR DESCRIPTION
## Problem

The integration cascade only ran on the **disconnect** edge, which made the `enable` half of `cascade.ts` unreachable. `reEnableIfCascadeDisabled` was written to restore exactly the agents a disconnect disabled — and nothing ever called it. Reconnecting an integration left every hard-requiring agent disabled until someone re-enabled it by hand.

There was also no path for an automation to acquire its cron *after* install. `reconcileAutomationSchedules` runs at install time only, so an automation installed against an integration that is not connected yet either gets a schedule that fires failing runs immediately, or gets none and never recovers.

## Change

- Fire the cascade on **either** edge of the credential's connected state, gated on a real edge — a plain credential edit or an OAuth token refresh (`active -> active`) stays a no-op.
- Cascade from `updateCredentialsInternal` too. The OAuth2 token exchange completes a (re)connection there, and a failed refresh parks the credential in `error`, which is a disconnect edge.
- On the **enable** edge, reconcile the schedules of the automations bound to the integration. For an already-running install this is a heal; for one installed without a cron it is how the cron arrives.

Disconnect deliberately does **not** deactivate schedules: a cron whose integration is down fails visibly, and silently parking rows would need a "who paused this" marker to avoid resurrecting an operator's own pause on the way back up.

## Pause-preserving

`reconcileAutomationSchedules` converges an existing row's `variables`/`timezone` and never touches its `isActive`, so a schedule an operator paused stays paused across a disconnect/reconnect cycle.

## Tests

`credential_mutations.test.ts` covers all four transitions plus both internal-mutation paths:

- deactivating a connected credential cascades `disable`
- reactivating a disconnected credential cascades `enable` (fails before this change — nothing was scheduled)
- no connected-state change schedules nothing
- the internal mutation cascades `enable` on the OAuth2 exchange path
- an internal token refresh of a live credential does not cascade

Gate: `tsc` clean, `oxlint --type-aware` 0/0, `oxfmt --check` clean, 27 tests pass.