### PR TITLE
fix(platform): keep section headers out of searchable-select filtering

### DIFF
--- a/services/platform/app/components/ui/forms/searchable-select.test.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.test.tsx
@@ -190,6 +190,78 @@ describe('SearchableSelect', () => {
     });
   });
 
+  describe('section headers during search', () => {
+    // Mirrors assignee pickers: "Team" contains "a" so a naive label filter
+    // would keep an empty Team header when only a person matches.
+    const sectionedOptions: SearchableSelectOption[] = [
+      {
+        value: '__people_header__',
+        label: 'People',
+        isSectionHeader: true,
+      },
+      { value: 'user:israel', label: 'Israel Iyanda' },
+      // No "a"/"i" so person-only and both-type queries stay precise.
+      { value: 'user:bob', label: 'Bob' },
+      {
+        value: '__team_header__',
+        label: 'Team',
+        isSectionHeader: true,
+      },
+      { value: 'team:eng', label: 'Engineering' },
+      // No "a"/"i" — "Team" itself contains "a" and must not keep an empty section.
+      { value: 'team:support', label: 'Support' },
+    ];
+
+    function renderSectioned() {
+      return renderSelect({ options: sectionedOptions });
+    }
+
+    it('keeps People header and drops empty Team when only a person matches', async () => {
+      const { user } = renderSectioned();
+      await user.click(screen.getByText('Open select'));
+      await user.type(screen.getByRole('combobox'), 'a');
+      // "Team".includes("a") must NOT keep an empty Team header.
+      expect(screen.getByText('People')).toBeInTheDocument();
+      expect(screen.queryByText('Team')).not.toBeInTheDocument();
+      const opts = screen.getAllByRole('option');
+      expect(opts).toHaveLength(1);
+      expect(opts[0]).toHaveTextContent('Israel Iyanda');
+    });
+
+    it('keeps Team header and drops People when only a team matches', async () => {
+      const { user } = renderSectioned();
+      await user.click(screen.getByText('Open select'));
+      await user.type(screen.getByRole('combobox'), 'eng');
+      expect(screen.queryByText('People')).not.toBeInTheDocument();
+      expect(screen.getByText('Team')).toBeInTheDocument();
+      const opts = screen.getAllByRole('option');
+      expect(opts).toHaveLength(1);
+      expect(opts[0]).toHaveTextContent('Engineering');
+    });
+
+    it('keeps both headers when people and teams match', async () => {
+      const { user } = renderSectioned();
+      await user.click(screen.getByText('Open select'));
+      // "i" matches Israel + Engineering; neither header label contains "i".
+      await user.type(screen.getByRole('combobox'), 'i');
+      expect(screen.getByText('People')).toBeInTheDocument();
+      expect(screen.getByText('Team')).toBeInTheDocument();
+      const opts = screen.getAllByRole('option');
+      expect(opts).toHaveLength(2);
+      expect(opts[0]).toHaveTextContent('Israel Iyanda');
+      expect(opts[1]).toHaveTextContent('Engineering');
+    });
+
+    it('shows empty state when no section has matches', async () => {
+      const { user } = renderSectioned();
+      await user.click(screen.getByText('Open select'));
+      await user.type(screen.getByRole('combobox'), 'zzzzz');
+      expect(screen.queryByText('People')).not.toBeInTheDocument();
+      expect(screen.queryByText('Team')).not.toBeInTheDocument();
+      expect(screen.getByText('No results')).toBeInTheDocument();
+    });
+  });
+
   describe('keyboard navigation', () => {
     it('moves highlight down with ArrowDown', async () => {
       const { user } = renderSelect();

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -156,6 +156,45 @@ function defaultFilterFn(option: SearchableSelectOption, query: string) {
   );
 }
 
+/**
+ * Filter a flat option list while preserving section structure: never match
+ * headers against the query; keep a header only when its section has ≥1
+ * matching item. Leading unsectioned items filter normally.
+ */
+function filterOptionsWithSections(
+  options: ReadonlyArray<SearchableSelectOption>,
+  query: string,
+  filter: (option: SearchableSelectOption, query: string) => boolean,
+): SearchableSelectOption[] {
+  const result: SearchableSelectOption[] = [];
+  let i = 0;
+  while (i < options.length) {
+    const current = options[i];
+    if (!current) {
+      i++;
+      continue;
+    }
+    if (current.isSectionHeader) {
+      const header = current;
+      i++;
+      const matched: SearchableSelectOption[] = [];
+      while (i < options.length && !options[i]?.isSectionHeader) {
+        const item = options[i];
+        if (item && filter(item, query)) matched.push(item);
+        i++;
+      }
+      if (matched.length > 0) {
+        result.push(header, ...matched);
+      }
+      continue;
+    }
+    // Unsectioned leading (or mid-list) item — filter on its own.
+    if (filter(current, query)) result.push(current);
+    i++;
+  }
+  return result;
+}
+
 function findNextEnabledIndex(
   options: ReadonlyArray<SearchableSelectOption>,
   current: number,
@@ -268,7 +307,7 @@ function SearchableSelectBase({
 
   const filteredOptions = useMemo(() => {
     if (!search) return options;
-    return options.filter((o) => filter(o, search));
+    return filterOptionsWithSections(options, search, filter);
   }, [options, search, filter]);
 
   const initializeHighlight = useCallback(() => {


### PR DESCRIPTION
## Problem

`SearchableSelect` filtered its flat option list item-by-item, which treated section headers as ordinary options. Two ways that goes wrong:

- a header is **dropped** when its own label doesn't match the query, so matching items render with no heading above them;
- a header is **kept** when its label happens to match the query, stranded above an empty section.

Searching the conversation assignee picker for a person's name shows both: the "People" heading disappears from above the results, and a bare "Team" header can survive with nothing under it.

## Change

Filter section-aware: never match a header against the query, and keep a header only when its own section has at least one matching item. Leading or mid-list unsectioned items still filter on their own, so unsectioned lists behave exactly as before.

## Tests

`searchable-select.test.tsx` covers a header kept with its matching items, a header dropped when its section has no match, a header whose label matches the query but whose section is empty, and unsectioned items filtering normally. 41 tests pass.

Swept the consumers: conversations + tasks suites (36 files, 159 tests) pass. Gate: `tsc` clean, `oxlint --type-aware` 0/0, `oxfmt --check` clean.