### PR TITLE
feat(platform): link the assignee picker to auto-assign settings

### DIFF
--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
@@ -47,9 +47,45 @@ vi.mock('@/app/features/tasks/components/assignee-avatar', () => ({
   }) => <span data-testid={`avatar-${assigneeId}`}>{name ?? assigneeId}</span>,
 }));
 
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    hash,
+    params,
+    onClick,
+    className,
+  }: {
+    children: React.ReactNode;
+    to: string;
+    hash?: string;
+    params?: { id: string };
+    onClick?: () => void;
+    className?: string;
+  }) => (
+    <a
+      href={`${to}${hash ? `#${hash}` : ''}`}
+      data-org={params?.id}
+      className={className}
+      onClick={onClick}
+    >
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock('@/app/components/ui/forms/searchable-select', () => ({
-  SearchableSelect: ({ trigger }: { trigger: React.ReactNode }) => (
-    <div data-testid="assign-select">{trigger}</div>
+  SearchableSelect: ({
+    trigger,
+    footer,
+  }: {
+    trigger: React.ReactNode;
+    footer?: React.ReactNode;
+  }) => (
+    <div data-testid="assign-select">
+      {trigger}
+      {footer ? <div data-testid="assign-footer">{footer}</div> : null}
+    </div>
   ),
 }));
 
@@ -118,5 +154,38 @@ describe('ConversationAssigneePicker', () => {
 
     expect(screen.queryByTestId('assign-dual-stack')).not.toBeInTheDocument();
     expect(screen.getByTestId('avatar-user-1')).toBeInTheDocument();
+  });
+
+  it('always shows Auto assign linking to conversation routing settings', () => {
+    render(
+      <ConversationAssigneePicker
+        conversation={makeConversation()}
+        organizationId="org-1"
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /auto assign/i });
+    expect(link).toHaveAttribute(
+      'href',
+      '/dashboard/$id/settings/governance/policies-limits#conversation-routing',
+    );
+    expect(link).toHaveAttribute('data-org', 'org-1');
+  });
+
+  it('shows Unassign and Auto assign together when a person is assigned', () => {
+    render(
+      <ConversationAssigneePicker
+        conversation={makeConversation({ assigneeUserId: 'user-1' })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(screen.getByTestId('assign-footer')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /unassign/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /auto assign/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { Check, UserPlus, Users } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { Check, Settings, UserPlus, Users } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
 import {
@@ -284,30 +285,38 @@ export function ConversationAssigneePicker({
         return null;
       }}
       footer={
-        assigneeUserId || assigneeTeamId ? (
-          <div className="flex flex-col">
-            {assigneeUserId && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start"
-                onClick={() => handleValueChange(UNASSIGN_USER)}
-              >
-                {t('header.unassign')}
-              </Button>
-            )}
-            {assigneeTeamId && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start"
-                onClick={() => handleValueChange(UNASSIGN_TEAM)}
-              >
-                {t('header.unassignTeam')}
-              </Button>
-            )}
-          </div>
-        ) : undefined
+        <div className="flex flex-col">
+          {assigneeUserId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start"
+              onClick={() => handleValueChange(UNASSIGN_USER)}
+            >
+              {t('header.unassign')}
+            </Button>
+          )}
+          {assigneeTeamId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start"
+              onClick={() => handleValueChange(UNASSIGN_TEAM)}
+            >
+              {t('header.unassignTeam')}
+            </Button>
+          )}
+          <Link
+            to="/dashboard/$id/settings/governance/policies-limits"
+            params={{ id: organizationId }}
+            hash="conversation-routing"
+            className="hover:bg-muted flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-sm"
+            onClick={() => setOpen(false)}
+          >
+            <Settings className="size-4 shrink-0" aria-hidden="true" />
+            {t('header.autoAssignSettings')}
+          </Link>
+        </div>
       }
     />
   );

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
@@ -437,6 +437,7 @@ export function ConversationRoutingPolicyEditor({
   return (
     <Skeletonize loading={loading} label={t('conversationRouting.title')}>
       <SettingsSection
+        id="conversation-routing"
         title={t('conversationRouting.title')}
         description={t('conversationRouting.description')}
         action={

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2241,7 +2241,8 @@
       "peopleSection": "Personen",
       "teamsSection": "Team",
       "assignSearchAll": "Personen und Teams suchen",
-      "noAssignees": "Keine Personen oder Teams gefunden"
+      "noAssignees": "Keine Personen oder Teams gefunden",
+      "autoAssignSettings": "Automatisch zuweisen"
     },
     "editor": {
       "noContent": "Kein Inhalt zum Verbessern",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2241,7 +2241,8 @@
       "peopleSection": "People",
       "teamsSection": "Team",
       "assignSearchAll": "Search people and teams",
-      "noAssignees": "No people or teams found"
+      "noAssignees": "No people or teams found",
+      "autoAssignSettings": "Auto assign"
     },
     "editor": {
       "noContent": "No content to improve",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2241,7 +2241,8 @@
       "peopleSection": "Personnes",
       "teamsSection": "Équipe",
       "assignSearchAll": "Rechercher des personnes et des équipes",
-      "noAssignees": "Aucune personne ou équipe trouvée"
+      "noAssignees": "Aucune personne ou équipe trouvée",
+      "autoAssignSettings": "Assignation auto"
     },
     "editor": {
       "noContent": "Aucun contenu à améliorer",


### PR DESCRIPTION
## Why

The conversation assignee picker is exactly where someone notices that this routing should be automatic — and there was no way to get from there to the policy that does it. You had to already know it lives under Governance > Policies & limits.

## Change

An **Auto assign** link in the picker's footer, anchored at the conversation-routing section so the page opens on the right control instead of the top of a nine-editor page.

The footer previously rendered only when something was assigned (it held the two unassign actions). It now always renders, with the unassign rows staying conditional inside it.

`ConversationRoutingPolicyEditor`'s `SettingsSection` gets an `id` so the hash resolves — `SettingsSection` already spreads its rest props onto the `<section>`, so no component change was needed.

## Access

The picker is already admin-only: non-admins hit the early return at `conversation-assignee-picker.tsx:161` and get read-only assignment chips, never this footer. `isAdmin` is `role === 'admin' || 'owner'`, which is exactly the set granted `read orgSettings` — the capability gating the Governance rail entry — so the link never points somewhere the viewer can't follow.

## Tests

`conversation-assignee-picker.test.tsx` covers the link's presence and target, that it closes the picker on click, and that the unassign rows still render conditionally. Swept the governance + conversations suites (52 files, 451 tests) — all pass. i18n suites pass with the new `conversations.header.autoAssignSettings` key in en/de/fr.

Gate: `tsc` clean, `oxlint --type-aware` 0/0, `oxfmt --check` clean.