### PR TITLE
feat(platform): duplicate an integration into a second instance

### DIFF
--- a/docs/de/platform/admin/integrations.md
+++ b/docs/de/platform/admin/integrations.md
@@ -48,6 +48,12 @@ Beide Hebel werden zur Anfrage-Zeit erzwungen, nicht zur Installations-Zeit — 
 
 Klick auf die Zeile, dann auf **Trennen**. Eine getrennte Integration hört sofort auf zu authentifizieren; Agents und Workflows, die von ihr abhängen, melden beim nächsten Aufruf einen Konfigurationsfehler. Die Zeile bleibt mit einem Getrennt-Badge in der Liste, damit der Audit-Pfad überlebt. Erneutes Verbinden geht den Anmelde-Fluss von Grund auf neu.
 
+## Zwei Instanzen derselben Integration betreiben
+
+Manche Integrationen braucht man mehrfach — zwei Postfächer, zwei Datenbanken, zwei API-Mandanten. Öffne die Integration und wähle **Duplizieren** (auch im ⋯-Menü der Zeile), um eine zweite Instanz anzulegen. Tale kopiert die Konfiguration der Integration unter einem neuen Namen (`Support-Postfach (2)`), lässt die Anmeldedaten für dich frei und klont jede an das Original gebundene Automatisierung, damit die Kopie ihre eigene Synchronisation und ihren eigenen Posteingang bekommt.
+
+Die Kopie startet getrennt und bleibt ruhig — bis du ihre Anmeldedaten einträgst und verbindest, läuft kein geplanter Durchlauf. Ein unkonfiguriertes Duplikat erzeugt also nie fehlschlagende Durchläufe. Duplizieren wird nur dort angeboten, wo eine zweite Instanz tatsächlich funktionieren kann: OAuth-Integrationen (Gmail, Outlook, Slack) und GitHub sind beim Anbieter an ihre exakte Identität gebunden und lassen sich deshalb nicht duplizieren.
+
 ## Slack-Bot und Benachrichtigungen
 
 Slack ist zweigerichtet. Über den Agent, der Slack aufruft (Nachrichten posten, Kanäle lesen), hinaus kann die Organisation Leute aus Slack heraus mit einem Agent sprechen lassen und System-Events in einen Kanal pushen. Beides wird auf der verbundenen Slack-Zeile konfiguriert, und beides nutzt dieselbe OAuth-Anmeldung — keine zweite Verbindung.

--- a/docs/en/platform/admin/integrations.md
+++ b/docs/en/platform/admin/integrations.md
@@ -48,6 +48,12 @@ Both levers are enforced at request time, not at install time — changing a lev
 
 Click the row, then **Disconnect**. A disconnected integration stops authenticating immediately; agents and workflows that depend on it surface a configuration error on the next call. The row stays in the list with a disconnected badge so the audit trail survives. Reconnecting walks the credential flow again from scratch.
 
+## Running two of the same integration
+
+Some integrations are needed more than once — two mailboxes, two databases, two API tenants. Open the integration and choose **Duplicate** (also in the row's ⋯ menu) to create a second instance. Tale copies the integration's configuration under a new name (`Support mailbox (2)`), leaves its credential blank for you to fill in, and clones any automation bound to the original so the copy gets its own sync and its own inbox thread.
+
+The copy starts disconnected and stays idle — no scheduled run fires until you enter its credentials and connect it, so an unconfigured duplicate never generates failing runs. Duplicate is offered only where a second instance can actually work: OAuth integrations (Gmail, Outlook, Slack) and GitHub are bound to their exact identity at the provider, so they cannot be duplicated.
+
 ## Slack bot and notifications
 
 Slack is two-directional. Beyond the agent calling Slack (posting messages, reading channels), the org can let people talk to an agent from inside Slack and have system events pushed to a channel. Both are configured on the connected Slack row, and both ride the single OAuth credential — no second connection.

--- a/docs/fr/platform/admin/integrations.md
+++ b/docs/fr/platform/admin/integrations.md
@@ -48,6 +48,12 @@ Les deux leviers sont appliqués à la requête, pas à l’installation — cha
 
 Clique la ligne, puis **Déconnecter**. Une intégration déconnectée arrête d’authentifier immédiatement ; les agents et workflows qui en dépendent font remonter une erreur de configuration au prochain appel. La ligne reste dans la liste avec un badge déconnecté pour que la piste d’audit survive. Reconnecter parcourt le flux d’identifiants de zéro.
 
+## Faire tourner deux fois la même intégration
+
+Certaines intégrations servent plusieurs fois — deux boîtes mail, deux bases de données, deux locataires d’API. Ouvre l’intégration et choisis **Dupliquer** (également dans le menu ⋯ de la ligne) pour créer une seconde instance. Tale copie la configuration de l’intégration sous un nouveau nom (`Boîte support (2)`), laisse son identifiant vide pour que tu le renseignes, et clone toute automatisation liée à l’originale afin que la copie ait sa propre synchronisation et son propre fil de réception.
+
+La copie démarre déconnectée et reste au repos : aucune exécution planifiée ne se déclenche avant que tu saisisses ses identifiants et la connectes, donc un doublon non configuré ne produit jamais d’exécutions en échec. Dupliquer n’est proposé que là où une seconde instance peut réellement fonctionner : les intégrations OAuth (Gmail, Outlook, Slack) et GitHub sont liées à leur identité exacte chez le fournisseur et ne peuvent donc pas être dupliquées.
+
 ## Bot Slack et notifications
 
 Slack est bidirectionnel. Au-delà de l’agent qui appelle Slack (poster des messages, lire des canaux), l’org peut laisser des personnes parler à un agent depuis Slack et pousser des événements système dans un canal. Les deux se configurent sur la ligne Slack connectée, et les deux utilisent le même identifiant OAuth — pas de seconde connexion.

--- a/services/platform/app/features/settings/integrations/components/integration-card.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-card.test.tsx
@@ -131,6 +131,40 @@ describe('IntegrationCard', () => {
     expect(screen.getByRole('button', { name: 'Shopify' })).toBeDisabled();
   });
 
+  it('offers a Duplicate action in the ⋯ menu that fires onDuplicate', async () => {
+    const user = userEvent.setup();
+    const onDuplicate = vi.fn();
+    render(
+      <IntegrationCard
+        title="Shopify"
+        description="Sync products."
+        onClick={vi.fn()}
+        onDuplicate={onDuplicate}
+      />,
+    );
+    // The ⋯ trigger's accessible name is the (mocked) menuLabel key.
+    await user.click(
+      screen.getByRole('button', { name: 'integrations.menuLabel' }),
+    );
+    await user.click(await screen.findByText('actions.duplicate'));
+    expect(onDuplicate).toHaveBeenCalledOnce();
+  });
+
+  it('hides the Duplicate action when onDuplicate is not provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <IntegrationCard
+        title="Shopify"
+        description="Sync products."
+        onClick={vi.fn()}
+      />,
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'integrations.menuLabel' }),
+    );
+    expect(screen.queryByText('actions.duplicate')).not.toBeInTheDocument();
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(

--- a/services/platform/app/features/settings/integrations/components/integration-card.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge } from '@tale/ui/badge';
-import { Download, Eye, Puzzle, type LucideIcon } from 'lucide-react';
+import { Copy, Download, Eye, Puzzle, type LucideIcon } from 'lucide-react';
 
 import {
   CatalogCard,
@@ -28,6 +28,8 @@ interface IntegrationCardProps {
   onClick?: () => void;
   /** Download this integration's files as a zip (fills the ⋯ Export action). */
   onExport?: () => void;
+  /** Clone this integration under a new slug (fills the ⋯ Duplicate action). */
+  onDuplicate?: () => void;
 }
 
 export function IntegrationCard({
@@ -41,6 +43,7 @@ export function IntegrationCard({
   icon: Icon = Puzzle,
   onClick,
   onExport,
+  onDuplicate,
 }: IntegrationCardProps) {
   const { t } = useT('settings');
   const { t: tCommon } = useT('common');
@@ -102,6 +105,16 @@ export function IntegrationCard({
                       label: tCommon('actions.export'),
                       icon: Download,
                       onClick: onExport,
+                    } satisfies EntityRowAction,
+                  ]
+                : []),
+              ...(onDuplicate
+                ? [
+                    {
+                      key: 'duplicate',
+                      label: tCommon('actions.duplicate'),
+                      icon: Copy,
+                      onClick: onDuplicate,
                     } satisfies EntityRowAction,
                   ]
                 : []),

--- a/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
@@ -276,3 +276,49 @@ describe('IntegrationPanel — confirm dialogs name the instance', () => {
     expect(within(dialog).getByText('support@acme.test')).toBeInTheDocument();
   });
 });
+
+describe('IntegrationPanel — duplicate action', () => {
+  beforeEach(() => {
+    // A connected integration renders the details-mode footer.
+    vi.mocked(useIntegrationManage).mockImplementation(
+      () => baseManage as never,
+    );
+  });
+
+  it('renders a Duplicate button that fires onDuplicate', () => {
+    const onDuplicate = vi.fn();
+    render(
+      <IntegrationPanel
+        open
+        onOpenChange={vi.fn()}
+        integration={integration}
+        organizationId="org-1"
+        onDuplicate={onDuplicate}
+      />,
+    );
+    // With 1–2 secondary actions the footer renders inline buttons (no ⋯ menu).
+    const sheet = screen.getByTestId('sheet');
+    fireEvent.click(within(sheet).getByRole('button', { name: 'Duplicate' }));
+    expect(onDuplicate).toHaveBeenCalledOnce();
+  });
+
+  it('omits the Duplicate button when onDuplicate is not provided', () => {
+    render(
+      <IntegrationPanel
+        open
+        onOpenChange={vi.fn()}
+        integration={integration}
+        organizationId="org-1"
+        onExport={vi.fn()}
+      />,
+    );
+    const sheet = screen.getByTestId('sheet');
+    // Export renders as an inline button; Duplicate does not.
+    expect(
+      within(sheet).getByRole('button', { name: 'Export' }),
+    ).toBeInTheDocument();
+    expect(
+      within(sheet).queryByRole('button', { name: 'Duplicate' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/settings/integrations/components/integration-panel.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.tsx
@@ -5,7 +5,7 @@ import { IconButton } from '@tale/ui/icon-button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useAction } from 'convex/react';
-import { Download, Loader2, Trash2, X } from 'lucide-react';
+import { Copy, Download, Loader2, Trash2, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -35,6 +35,10 @@ interface IntegrationPanelProps {
   onExport?: () => void;
   /** Parent-owned export in-flight state, reflected on the Export button. */
   isExporting?: boolean;
+  /** Clone this integration under a new slug (footer Duplicate action). */
+  onDuplicate?: () => void;
+  /** Parent-owned duplicate in-flight state, reflected on the Duplicate button. */
+  isDuplicating?: boolean;
 }
 
 export function IntegrationPanel({
@@ -44,6 +48,8 @@ export function IntegrationPanel({
   organizationId,
   onExport,
   isExporting,
+  onDuplicate,
+  isDuplicating,
 }: IntegrationPanelProps) {
   const { t } = useT('settings');
   const { t: tCommon } = useT('common');
@@ -132,20 +138,35 @@ export function IntegrationPanel({
       ? integration.connectionConfig.apiEndpoint
       : undefined);
 
-  // Footer secondary actions. Rendered inline: a popup for one item is more
-  // friction than it saves.
-  const secondaryActions = onExport
-    ? [
-        {
-          key: 'export',
-          label: tCommon('actions.export'),
-          icon: Download,
-          onClick: onExport,
-          disabled: manage.busy || isExporting,
-          loading: isExporting ?? false,
-        },
-      ]
-    : [];
+  // Footer secondary actions (Export, Duplicate) — at most two, so they render
+  // inline. A popup for one or two items is more friction than it saves; if a
+  // third ever lands, collapse them then.
+  const secondaryActions = [
+    ...(onExport
+      ? [
+          {
+            key: 'export',
+            label: tCommon('actions.export'),
+            icon: Download,
+            onClick: onExport,
+            disabled: manage.busy || isExporting,
+            loading: isExporting ?? false,
+          },
+        ]
+      : []),
+    ...(onDuplicate
+      ? [
+          {
+            key: 'duplicate',
+            label: tCommon('actions.duplicate'),
+            icon: Copy,
+            onClick: onDuplicate,
+            disabled: manage.busy || isDuplicating,
+            loading: isDuplicating ?? false,
+          },
+        ]
+      : []),
+  ];
 
   return (
     <Sheet

--- a/services/platform/app/features/settings/integrations/components/integrations.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integrations.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -18,7 +18,9 @@ vi.mock('@/app/components/ui/data-display/image', () => ({
 }));
 
 vi.mock('./integration-panel', () => ({
-  IntegrationPanel: () => <div data-testid="integration-panel" />,
+  IntegrationPanel: ({ integration }: { integration: { title?: string } }) => (
+    <div data-testid="integration-panel">{integration?.title}</div>
+  ),
 }));
 
 vi.mock('./integration-upload/integration-upload-dialog', () => ({
@@ -28,6 +30,11 @@ vi.mock('./integration-upload/integration-upload-dialog', () => ({
 // The export action wires a Convex hook (no ConvexProvider mounts here).
 vi.mock('../hooks/use-export-integration', () => ({
   useExportIntegration: () => ({ mutateAsync: vi.fn() }),
+}));
+
+const mockDuplicateAsync = vi.fn();
+vi.mock('../hooks/use-duplicate-integration', () => ({
+  useDuplicateIntegration: () => ({ mutateAsync: mockDuplicateAsync }),
 }));
 
 afterEach(() => {
@@ -44,6 +51,7 @@ function makeIntegration(
     title: 'Test Integration',
     description: 'A test integration',
     authMethod: 'bearer_token',
+    duplicable: true,
     operationCount: 5,
     hash: 'abc123',
     ...overrides,
@@ -167,6 +175,60 @@ describe('Integrations', () => {
 
     await user.click(screen.getByText('integrations.tabs.connected'));
     expect(onTabChange).toHaveBeenCalledWith('connected');
+  });
+
+  it('duplicating switches to the all tab and opens the new instance once it appears', async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+    mockDuplicateAsync.mockResolvedValue({
+      newSlug: 'imap_smtp-2',
+      credentialId: 'c1',
+      reboundAutomations: [],
+    });
+    const source = makeIntegration({
+      slug: 'imap_smtp',
+      title: 'IMAP / SMTP Mailbox',
+      duplicable: true,
+    });
+    const { rerender } = render(
+      <Integrations
+        {...defaultProps}
+        onTabChange={onTabChange}
+        integrations={[source]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'integrations.menuLabel' }),
+    );
+    await user.click(await screen.findByText('actions.duplicate'));
+
+    // Duplicate fires, then switches to the "all" tab (the new instance is
+    // inactive, so it would be hidden on Connected).
+    await waitFor(() => {
+      expect(mockDuplicateAsync).toHaveBeenCalledWith({
+        organizationId: 'org-1',
+        slug: 'imap_smtp',
+      });
+      expect(onTabChange).toHaveBeenCalledWith('all');
+    });
+
+    // The new instance arrives on the refetch → its panel opens automatically.
+    const duplicate = makeIntegration({
+      slug: 'imap_smtp-2',
+      title: 'IMAP / SMTP Mailbox (2)',
+      duplicable: true,
+    });
+    rerender(
+      <Integrations
+        {...defaultProps}
+        onTabChange={onTabChange}
+        integrations={[source, duplicate]}
+      />,
+    );
+    expect(await screen.findByTestId('integration-panel')).toHaveTextContent(
+      'IMAP / SMTP Mailbox (2)',
+    );
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/features/settings/integrations/components/integrations.tsx
+++ b/services/platform/app/features/settings/integrations/components/integrations.tsx
@@ -4,7 +4,7 @@ import { Button } from '@tale/ui/button';
 import { EmptyState } from '@tale/ui/empty-state';
 import { Stack } from '@tale/ui/layout';
 import { Skeletonize } from '@tale/ui/skeleton-context';
-import { Search, Unplug } from 'lucide-react';
+import { Loader2, Search, Unplug } from 'lucide-react';
 import {
   useCallback,
   useEffect,
@@ -22,6 +22,7 @@ import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { downloadBase64File } from '@/lib/utils/download';
 
+import { useDuplicateIntegration } from '../hooks/use-duplicate-integration';
 import { useExportIntegration } from '../hooks/use-export-integration';
 import { IntegrationCard } from './integration-card';
 import { IntegrationPanel } from './integration-panel';
@@ -36,6 +37,9 @@ export interface IntegrationListItem {
   labels?: string[];
   type?: 'rest_api' | 'sql';
   authMethod: string;
+  /** Whether the "Duplicate" action is offered — false for OAuth / slug-bound
+   *  integrations (see isDuplicableIntegration); projected by listIntegrations. */
+  duplicable: boolean;
   operationCount: number;
   hash: string;
   [key: string]: unknown;
@@ -114,6 +118,63 @@ export function Integrations({
       }
     },
     [exportingSlug, exportIntegration, organizationId, t],
+  );
+
+  const { mutateAsync: duplicateIntegration } = useDuplicateIntegration();
+  const [duplicatingSlug, setDuplicatingSlug] = useState<string | null>(null);
+  // After a duplicate resolves, open the new instance's panel once the
+  // refetched list contains it (mirrors the `initialSlug` deep-link effect) so
+  // the user lands on its credentials form instead of a dead-end grid.
+  const [pendingOpenSlug, setPendingOpenSlug] = useState<string | null>(null);
+  const handleDuplicate = useCallback(
+    async (item: IntegrationListItem) => {
+      if (duplicatingSlug) return;
+      setDuplicatingSlug(item.slug);
+      // Duplicating is a multi-step server action (clone config → mint an
+      // inactive credential → rebind bundled automations), and the ⋯ menu that
+      // launched it has already closed — so surface progress as a loading toast
+      // that the success/error toast then replaces (the store keeps one toast).
+      toast({
+        title: (
+          <span className="inline-flex items-center gap-2">
+            {t('integrations.duplicate.pending', {
+              name: item.title,
+              defaultValue: 'Creating a copy of {name}…',
+            })}
+            <Loader2 className="size-4 animate-spin" />
+          </span>
+        ),
+        duration: 60_000,
+      });
+      try {
+        const result = await duplicateIntegration({
+          organizationId,
+          slug: item.slug,
+        });
+        toast({
+          variant: 'success',
+          title: t('integrations.duplicate.success', {
+            name: item.title,
+            defaultValue: 'Created a copy of {name}',
+          }),
+        });
+        // The new instance is inactive, so it only shows on the "all" tab —
+        // switch there and open it so Duplicate never dead-ends on Connected.
+        onTabChange('all');
+        setPendingOpenSlug(result.newSlug);
+      } catch (error) {
+        console.error(error);
+        toast({
+          title: t('integrations.duplicate.failed', {
+            defaultValue: 'Failed to duplicate integration',
+          }),
+          variant: 'destructive',
+        });
+      } finally {
+        setDuplicatingSlug(null);
+      }
+    },
+    [duplicatingSlug, duplicateIntegration, onTabChange, organizationId, t],
   );
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -199,6 +260,16 @@ export function Integrations({
     onInitialSlugConsumed?.();
   }, [initialSlug, integrations, onInitialSlugConsumed]);
 
+  // Open a freshly duplicated instance once the invalidated list refetches and
+  // includes it — then clear the pending slug so it opens exactly once.
+  useEffect(() => {
+    if (!pendingOpenSlug) return;
+    const match = integrations.find((i) => i.slug === pendingOpenSlug);
+    if (!match) return;
+    setManagingIntegration(match);
+    setPendingOpenSlug(null);
+  }, [pendingOpenSlug, integrations]);
+
   return (
     // Fill the settings pane so EmptyState (flex-1 + justify-center) sits in
     // the middle of the area below the tabs/search — same fix as Automations.
@@ -240,6 +311,11 @@ export function Integrations({
               }
               onClick={() => handleCardClick(integration)}
               onExport={() => void handleExport(integration)}
+              onDuplicate={
+                integration.duplicable
+                  ? () => void handleDuplicate(integration)
+                  : undefined
+              }
             />
           ))}
         </CatalogGrid>
@@ -263,6 +339,12 @@ export function Integrations({
           organizationId={organizationId}
           onExport={() => void handleExport(managingIntegration)}
           isExporting={exportingSlug === managingIntegration.slug}
+          onDuplicate={
+            managingIntegration.duplicable
+              ? () => void handleDuplicate(managingIntegration)
+              : undefined
+          }
+          isDuplicating={duplicatingSlug === managingIntegration.slug}
         />
       )}
     </Stack>

--- a/services/platform/app/features/settings/integrations/hooks/mutations.ts
+++ b/services/platform/app/features/settings/integrations/hooks/mutations.ts
@@ -5,7 +5,7 @@ import { useCallback } from 'react';
 import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
 import { api } from '@/convex/_generated/api';
 
-function useInvalidateIntegrations() {
+export function useInvalidateIntegrations() {
   const queryClient = useQueryClient();
   return () =>
     queryClient.invalidateQueries({ queryKey: ['config', 'integrations'] });

--- a/services/platform/app/features/settings/integrations/hooks/use-duplicate-integration.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-duplicate-integration.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+
+import { useConvexAction } from '@/app/hooks/use-convex-action';
+import { api } from '@/convex/_generated/api';
+
+import { useInvalidateIntegrations } from './mutations';
+
+/**
+ * Duplicate an integration under a new, unique slug — clones its config +
+ * inactive credential and rebinds any bundled sync automation to the new slug —
+ * then refresh the integrations list so the new instance's card appears.
+ */
+export function useDuplicateIntegration() {
+  const { mutateAsync: duplicate } = useConvexAction(
+    api.integrations.file_actions.duplicateIntegration,
+  );
+  const invalidate = useInvalidateIntegrations();
+
+  const mutateAsync = useCallback(
+    async (...args: Parameters<typeof duplicate>) => {
+      const result = await duplicate(...args);
+      void invalidate();
+      return result;
+    },
+    [duplicate, invalidate],
+  );
+
+  return { mutateAsync };
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -243,6 +243,7 @@ import type * as auth from "../auth.js";
 import type * as automations_agent_readiness from "../automations/agent_readiness.js";
 import type * as automations_automation_workflow_slugs from "../automations/automation_workflow_slugs.js";
 import type * as automations_bundle_parse from "../automations/bundle_parse.js";
+import type * as automations_duplicate_rebind from "../automations/duplicate_rebind.js";
 import type * as automations_file_actions from "../automations/file_actions.js";
 import type * as automations_file_utils from "../automations/file_utils.js";
 import type * as automations_install_actions from "../automations/install_actions.js";
@@ -252,6 +253,7 @@ import type * as automations_install_mutations from "../automations/install_muta
 import type * as automations_install_preflight from "../automations/install_preflight.js";
 import type * as automations_install_queries from "../automations/install_queries.js";
 import type * as automations_provision_defaults from "../automations/provision_defaults.js";
+import type * as automations_rebind_manifest from "../automations/rebind_manifest.js";
 import type * as automations_schedule_readiness from "../automations/schedule_readiness.js";
 import type * as automations_schedule_variables from "../automations/schedule_variables.js";
 import type * as automations_upload_actions from "../automations/upload_actions.js";
@@ -2042,6 +2044,7 @@ declare const fullApi: ApiFromModules<{
   "automations/agent_readiness": typeof automations_agent_readiness;
   "automations/automation_workflow_slugs": typeof automations_automation_workflow_slugs;
   "automations/bundle_parse": typeof automations_bundle_parse;
+  "automations/duplicate_rebind": typeof automations_duplicate_rebind;
   "automations/file_actions": typeof automations_file_actions;
   "automations/file_utils": typeof automations_file_utils;
   "automations/install_actions": typeof automations_install_actions;
@@ -2051,6 +2054,7 @@ declare const fullApi: ApiFromModules<{
   "automations/install_preflight": typeof automations_install_preflight;
   "automations/install_queries": typeof automations_install_queries;
   "automations/provision_defaults": typeof automations_provision_defaults;
+  "automations/rebind_manifest": typeof automations_rebind_manifest;
   "automations/schedule_readiness": typeof automations_schedule_readiness;
   "automations/schedule_variables": typeof automations_schedule_variables;
   "automations/upload_actions": typeof automations_upload_actions;

--- a/services/platform/convex/automations/duplicate_rebind.test.ts
+++ b/services/platform/convex/automations/duplicate_rebind.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `rebindBundledAutomations` clones every automation bound to an integration onto
+ * a duplicate's new slug. Two properties matter beyond the manifest rewrite
+ * (pinned separately in rebind_manifest.test.ts):
+ *
+ *  1. the clone installs with NO cron — a duplicate's credential is blank until
+ *     an operator fills it in, and a schedule provisioned now would fire a
+ *     guaranteed-failing run on every tick until then (forever, if the duplicate
+ *     is abandoned). The integration's reconnect cascade provisions it on first
+ *     successful connect instead;
+ *  2. a bundle dir written but not installed is swept on failure — the teardown
+ *     finds automations by INSTALL ROW, so an uninstalled dir would be invisible
+ *     to it and left behind.
+ *
+ * The filesystem and the automation-dir resolvers are mocked; the real manifest
+ * is read off disk so the schema re-validation step runs against real data.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const IMAP_MANIFEST = path.join(
+  REPO_ROOT,
+  'builtin-configs/automations/imap-smtp/sync-emails/automation.json',
+);
+const MANIFEST_JSON = readFileSync(IMAP_MANIFEST, 'utf-8');
+
+const mockRm = vi.fn().mockResolvedValue(undefined);
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readdir: vi.fn().mockResolvedValue([]),
+  readFile: vi.fn().mockResolvedValue(MANIFEST_JSON),
+  rm: (...args: unknown[]) => mockRm(...args),
+}));
+
+vi.mock('../_generated/api', () => ({
+  internal: {
+    automations: {
+      install_mutations: {
+        listInstallationsRequiringIntegrationInternal: 'listBound',
+        listAutomationInstallationsInternal: 'listInstalled',
+      },
+      install_actions: { installAutomationInternal: 'install' },
+    },
+  },
+}));
+
+vi.mock('./file_utils', () => ({
+  listAutomationSlugs: vi.fn().mockResolvedValue([]),
+  resolveAutomationDir: (orgSlug: string, slug: string) =>
+    `/cfg/${orgSlug}/automations/${slug}`,
+  resolveAutomationsDir: (orgSlug: string) => `/cfg/${orgSlug}/automations`,
+  resolveCatalogAutomationsDir: () => '/builtin/automations',
+}));
+
+vi.mock('./install_fs', () => ({
+  resolveAutomationBundleSourceDir: vi
+    .fn()
+    .mockResolvedValue('/builtin/automations/imap-smtp/sync-emails'),
+}));
+
+vi.mock('../lib/file_io', () => ({
+  atomicWrite: vi.fn().mockResolvedValue(undefined),
+  atomicWriteBuffer: vi.fn().mockResolvedValue(undefined),
+  errnoCode: () => undefined,
+  readFileBufferSafe: vi.fn().mockResolvedValue(null),
+}));
+
+const { rebindBundledAutomations } = await import('./duplicate_rebind');
+
+const ARGS = {
+  organizationId: 'org-1',
+  orgSlug: 'acme',
+  sourceIntegrationSlug: 'imap_smtp',
+  newIntegrationSlug: 'imap_smtp-2',
+  installedBy: 'a@b.com',
+};
+
+function createCtx(installImpl?: () => Promise<unknown>) {
+  const runAction = installImpl
+    ? vi.fn().mockImplementation(installImpl)
+    : vi.fn().mockResolvedValue({ ok: true });
+  return {
+    runQuery: vi.fn().mockImplementation((ref: string) => {
+      if (ref === 'listBound') {
+        return Promise.resolve([{ automationSlug: 'imap-smtp/sync-emails' }]);
+      }
+      return Promise.resolve([]);
+    }),
+    runAction,
+  };
+}
+
+describe('rebindBundledAutomations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRm.mockResolvedValue(undefined);
+  });
+
+  it('installs the rebound clone with no cron until the instance connects', async () => {
+    const ctx = createCtx();
+
+    const rebound = await rebindBundledAutomations(ctx as never, ARGS);
+
+    expect(rebound).toEqual([
+      {
+        sourceSlug: 'imap-smtp/sync-emails',
+        newSlug: 'imap-smtp/sync-emails-2',
+      },
+    ]);
+    expect(ctx.runAction).toHaveBeenCalledWith('install', {
+      organizationId: 'org-1',
+      automationSlug: 'imap-smtp/sync-emails-2',
+      installedBy: 'a@b.com',
+      skipSchedules: true,
+    });
+  });
+
+  it('sweeps the written bundle dir when the install throws', async () => {
+    const ctx = createCtx(() => Promise.reject(new Error('install failed')));
+
+    await expect(rebindBundledAutomations(ctx as never, ARGS)).rejects.toThrow(
+      'install failed',
+    );
+
+    expect(mockRm).toHaveBeenCalledWith(
+      '/cfg/acme/automations/imap-smtp/sync-emails-2',
+      { recursive: true, force: true },
+    );
+  });
+
+  it('is a no-op for an integration with no bound automations', async () => {
+    const ctx = createCtx();
+    ctx.runQuery.mockResolvedValue([]);
+
+    expect(await rebindBundledAutomations(ctx as never, ARGS)).toEqual([]);
+    expect(ctx.runAction).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/automations/duplicate_rebind.ts
+++ b/services/platform/convex/automations/duplicate_rebind.ts
@@ -1,0 +1,289 @@
+'use node';
+
+/**
+ * The "Duplicate integration" automation-rebind sub-routine. When an integration
+ * is duplicated under a new slug, every automation BOUND to the source
+ * integration is cloned into the org under a fresh automation slug with all its
+ * integration references rewritten to the new slug (see
+ * {@link rebindManifestIntegration}), so the duplicate gets its own sync + its
+ * own inbox. General to any integration with a bundled automation; a no-op for
+ * integrations without one (REST / SQL). The reverse — {@link
+ * cleanupReboundAutomations} — powers the duplicate action's failure teardown.
+ */
+
+import { mkdir, readdir, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  AUTOMATION_MANIFEST_FILENAME,
+  automationManifestSchema,
+  isValidAutomationSlug,
+} from '../../lib/shared/schemas/automations';
+import { zodErrorMessage } from '../../lib/shared/schemas/format-error';
+import { isRecord } from '../../lib/utils/type-utils';
+import { internal } from '../_generated/api';
+import type { ActionCtx } from '../_generated/server';
+import { deriveNextSlug } from '../integrations/file_utils';
+import {
+  atomicWrite,
+  atomicWriteBuffer,
+  errnoCode,
+  readFileBufferSafe,
+} from '../lib/file_io';
+import {
+  listAutomationSlugs,
+  resolveAutomationDir,
+  resolveAutomationsDir,
+  resolveCatalogAutomationsDir,
+} from './file_utils';
+import { resolveAutomationBundleSourceDir } from './install_fs';
+import { rebindManifestIntegration } from './rebind_manifest';
+
+/** Skip guards mirroring the automation install copy (dotfiles + secrets). */
+function skipBundleEntry(name: string): boolean {
+  return name.startsWith('.') || name.endsWith('.secrets.json');
+}
+
+/**
+ * Copy a source automation bundle tree into `destDir`, writing the rebound
+ * `automation.json` at the root and every other file (icon.svg, and any
+ * agents/ views/ scripts/ a richer bundle carries) verbatim. Mirrors the
+ * install copy's dotfile/secret/symlink skips so the same guards apply.
+ */
+async function copyBundleWithReboundManifest(
+  sourceDir: string,
+  destDir: string,
+  reboundManifest: Record<string, unknown>,
+): Promise<void> {
+  const walk = async (
+    src: string,
+    dst: string,
+    isRoot: boolean,
+  ): Promise<void> => {
+    await mkdir(dst, { recursive: true });
+    const entries = await readdir(src, { withFileTypes: true });
+    for (const entry of entries) {
+      if (skipBundleEntry(entry.name) || entry.isSymbolicLink()) continue;
+      const srcPath = path.join(src, entry.name);
+      const dstPath = path.join(dst, entry.name);
+      if (entry.isDirectory()) {
+        await walk(srcPath, dstPath, false);
+      } else if (entry.isFile()) {
+        if (isRoot && entry.name === AUTOMATION_MANIFEST_FILENAME) {
+          await atomicWrite(
+            dstPath,
+            `${JSON.stringify(reboundManifest, null, 2)}\n`,
+          );
+        } else {
+          const buf = await readFileBufferSafe(srcPath);
+          if (buf) await atomicWriteBuffer(dstPath, buf);
+        }
+      }
+    }
+  };
+  await walk(sourceDir, destDir, true);
+}
+
+/**
+ * Clone + rebind every automation bound to `sourceIntegrationSlug` onto
+ * `newIntegrationSlug`, installing each under a fresh automation slug. Returns
+ * the source→new automation slug pairs (empty when the integration has no
+ * bundled automation).
+ */
+export async function rebindBundledAutomations(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    orgSlug: string;
+    sourceIntegrationSlug: string;
+    newIntegrationSlug: string;
+    installedBy: string;
+  },
+): Promise<Array<{ sourceSlug: string; newSlug: string }>> {
+  const {
+    organizationId,
+    orgSlug,
+    sourceIntegrationSlug,
+    newIntegrationSlug,
+    installedBy,
+  } = args;
+
+  // (a) Discover installed automations bound to the source integration.
+  const bound = await ctx.runQuery(
+    internal.automations.install_mutations
+      .listInstallationsRequiringIntegrationInternal,
+    { organizationId, integrationSlug: sourceIntegrationSlug },
+  );
+  if (bound.length === 0) return [];
+
+  // Collision universe for the new automation slug: org-dir slugs, install-row
+  // slugs, AND builtin-catalog slugs — the last is essential, since
+  // `resolveAutomationBundleSourceDir` resolves the builtin first and would
+  // shadow our org-dir copy on a catalog collision.
+  const takenAutomationSlugs = new Set<string>([
+    ...(await listAutomationSlugs(
+      resolveAutomationsDir(orgSlug),
+      'dup-integration',
+    )),
+    ...(await listAutomationSlugs(
+      resolveCatalogAutomationsDir(),
+      'dup-integration',
+    )),
+    ...(await ctx.runQuery(
+      internal.automations.install_mutations
+        .listAutomationInstallationsInternal,
+      { organizationId },
+    )),
+  ]);
+
+  const rebound: Array<{ sourceSlug: string; newSlug: string }> = [];
+  // Bundle dirs written but not yet installed. `cleanupReboundAutomations`
+  // finds automations by INSTALL ROW, so a dir whose install threw would
+  // otherwise be invisible to the teardown and left littering the org's
+  // automations dir. Tracked here and swept on the way out.
+  const uninstalledDirs: string[] = [];
+  try {
+    for (const { automationSlug: sourceAutomationSlug } of bound) {
+      // (b) Read the source manifest (builtin catalog for a first-party
+      // automation, else the org's own copy — resolveAutomationBundleSourceDir).
+      const sourceDir = await resolveAutomationBundleSourceDir(
+        orgSlug,
+        sourceAutomationSlug,
+      );
+      const rawManifest: unknown = JSON.parse(
+        await readFile(
+          path.join(sourceDir, AUTOMATION_MANIFEST_FILENAME),
+          'utf-8',
+        ),
+      );
+      if (!isRecord(rawManifest)) {
+        throw new Error(
+          `Automation "${sourceAutomationSlug}" manifest is not a JSON object`,
+        );
+      }
+
+      // (c) Rewrite integration refs, then sanity-check the result still parses.
+      const reboundManifest = rebindManifestIntegration(
+        rawManifest,
+        sourceIntegrationSlug,
+        newIntegrationSlug,
+      );
+      const parsed = automationManifestSchema.safeParse(reboundManifest);
+      if (!parsed.success) {
+        throw new Error(
+          zodErrorMessage(
+            `Rebound automation "${sourceAutomationSlug}" is invalid`,
+            parsed.error,
+          ),
+        );
+      }
+
+      // (d) Derive a fresh, non-colliding automation slug and reserve it so two
+      // bound automations in one duplicate can't collide.
+      const newAutomationSlug = deriveNextSlug(
+        sourceAutomationSlug,
+        takenAutomationSlugs,
+      );
+      if (!isValidAutomationSlug(newAutomationSlug)) {
+        throw new Error(
+          `Derived automation slug is invalid: ${newAutomationSlug}`,
+        );
+      }
+      takenAutomationSlugs.add(newAutomationSlug);
+
+      // (e) Write the rebound bundle into the org dir.
+      const newDir = resolveAutomationDir(orgSlug, newAutomationSlug);
+      uninstalledDirs.push(newDir);
+      await copyBundleWithReboundManifest(sourceDir, newDir, reboundManifest);
+
+      // (f) Install in place. The new slug is absent from the catalog, so it
+      // resolves to the org dir (the self-copy is skipped); ensureOrgResources
+      // registers the inline workflow and writes the install row
+      // (requiredIntegrations = [newIntegrationSlug]).
+      //
+      // NO schedule yet: the duplicate's credential is blank until an operator
+      // enters this instance's login, and a cron provisioned now would fire a
+      // guaranteed-failing run on every tick until then — forever, if the
+      // duplicate is abandoned. The integration's reconnect cascade
+      // (`integrations/cascade.ts`) reconciles the schedule from this manifest the
+      // moment the instance first connects.
+      await ctx.runAction(
+        internal.automations.install_actions.installAutomationInternal,
+        {
+          organizationId,
+          automationSlug: newAutomationSlug,
+          installedBy,
+          skipSchedules: true,
+        },
+      );
+
+      // Installed — the install row now makes it findable by the teardown.
+      uninstalledDirs.pop();
+      rebound.push({
+        sourceSlug: sourceAutomationSlug,
+        newSlug: newAutomationSlug,
+      });
+    }
+  } catch (error) {
+    // Sweep any bundle dir written without a matching install row, so a failed
+    // duplicate leaves nothing behind for the teardown to miss.
+    for (const dir of uninstalledDirs) {
+      await rm(dir, { recursive: true, force: true }).catch(
+        (rmError: unknown) => {
+          console.error(
+            `[duplicateIntegration] failed to remove uninstalled rebound bundle "${dir}":`,
+            rmError,
+          );
+        },
+      );
+    }
+    throw error;
+  }
+
+  return rebound;
+}
+
+/**
+ * Reverse {@link rebindBundledAutomations} for the duplicate action's failure
+ * teardown: uninstall + remove every automation whose install row is bound to
+ * `integrationSlug` (the DUPLICATE's new slug). Best-effort — logs and continues
+ * past any single failure so the rest of the cleanup still runs. Finds whatever
+ * was installed regardless of where a mid-rebind failure stopped.
+ */
+export async function cleanupReboundAutomations(
+  ctx: ActionCtx,
+  args: { organizationId: string; orgSlug: string; integrationSlug: string },
+): Promise<void> {
+  const { organizationId, orgSlug, integrationSlug } = args;
+  const rebound = await ctx.runQuery(
+    internal.automations.install_mutations
+      .listInstallationsRequiringIntegrationInternal,
+    { organizationId, integrationSlug },
+  );
+  for (const { automationSlug } of rebound) {
+    try {
+      await ctx.runAction(
+        internal.automations.install_actions.uninstallAutomationInternal,
+        { organizationId, automationSlug },
+      );
+    } catch (error) {
+      console.error(
+        `[duplicateIntegration] failed to uninstall rebound automation "${automationSlug}":`,
+        error,
+      );
+    }
+    // Uninstall leaves the org-dir bundle in place (a private/org-dir automation
+    // is never removed by uninstall), so drop the dir explicitly.
+    await rm(resolveAutomationDir(orgSlug, automationSlug), {
+      recursive: true,
+      force: true,
+    }).catch((error: unknown) => {
+      if (errnoCode(error) !== 'ENOENT') {
+        console.error(
+          `[duplicateIntegration] failed to remove rebound automation dir "${automationSlug}":`,
+          error,
+        );
+      }
+    });
+  }
+}

--- a/services/platform/convex/automations/install_actions.ts
+++ b/services/platform/convex/automations/install_actions.ts
@@ -315,6 +315,15 @@ export async function ensureOrgResources(
   organizationId: string,
   automationSlug: string,
   install: InstallContext,
+  /**
+   * Skip schedule provisioning. For an automation installed against an
+   * integration that is not connected yet (a fresh duplicate's blank
+   * credential), a cron created now would fire a doomed run on every tick until
+   * an operator fills the login in. The integration's reconnect cascade
+   * (`integrations/cascade.ts`) reconciles the schedule the moment it first
+   * connects, so skipping here defers the cron rather than dropping it.
+   */
+  skipSchedules = false,
 ): Promise<{ workflows: number; agents: number; resources: number }> {
   const { orgSlug, installedBy, manifest } = install;
   const record: {
@@ -381,7 +390,14 @@ export async function ensureOrgResources(
   // project for a project automation (re-seeding each existing binding's schedules on
   // reinstall). A newly added binding's schedules are created by `installAutomation`
   // after the bind, when the binding is visible.
-  await syncAutomationSchedules(ctx, organizationId, automationSlug, manifest);
+  if (!skipSchedules) {
+    await syncAutomationSchedules(
+      ctx,
+      organizationId,
+      automationSlug,
+      manifest,
+    );
+  }
 
   return {
     workflows: workflow ? 1 : 0,
@@ -595,6 +611,14 @@ export const installAutomationInternal = internalAction({
     organizationId: v.string(),
     automationSlug: v.string(),
     installedBy: v.string(),
+    /**
+     * Install without provisioning the automation's cron triggers. Set by the
+     * "Duplicate integration" rebind: the duplicate's credential is blank until
+     * an operator fills it in, and a schedule created now would fire a failing
+     * run every tick in the meantime. The integration's reconnect cascade
+     * provisions it on first successful connect.
+     */
+    skipSchedules: v.optional(v.boolean()),
   },
   returns: v.object({
     ok: v.boolean(),
@@ -627,6 +651,7 @@ export const installAutomationInternal = internalAction({
       args.organizationId,
       args.automationSlug,
       install,
+      args.skipSchedules ?? false,
     );
     return { ok: true, ...counts };
   },

--- a/services/platform/convex/automations/rebind_manifest.test.ts
+++ b/services/platform/convex/automations/rebind_manifest.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { rebindManifestIntegration } from './rebind_manifest';
+
+/**
+ * `rebindManifestIntegration` is the pure core of "Duplicate integration": it
+ * rewrites an automation manifest's integration-slug references onto a new slug
+ * and NOTHING else. Pin it against the real shipped imap sync-emails bundle so a
+ * regression that over-rewrites (a template string, a display name) or
+ * under-rewrites (misses a binding field) is caught loudly.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const IMAP_MANIFEST = path.join(
+  REPO_ROOT,
+  'builtin-configs/automations/imap-smtp/sync-emails/automation.json',
+);
+
+function loadImapManifest(): Record<string, unknown> {
+  return JSON.parse(readFileSync(IMAP_MANIFEST, 'utf-8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+/** Count exact quoted JSON tokens (so `"imap_smtp"` never matches inside `"imap_smtp-2"`). */
+function countToken(value: unknown, token: string): number {
+  const re = new RegExp(`"${token.replace(/[-]/g, '\\$&')}"`, 'g');
+  return (JSON.stringify(value).match(re) ?? []).length;
+}
+
+describe('rebindManifestIntegration', () => {
+  it('rewrites exactly the 10 imap_smtp slug references to the new slug', () => {
+    const source = loadImapManifest();
+    const result = rebindManifestIntegration(
+      source,
+      'imap_smtp',
+      'imap_smtp-2',
+    );
+
+    // The imap bundle names the integration in exactly 10 places.
+    expect(countToken(result, 'imap_smtp-2')).toBe(10);
+    // …and none of the original slug survives.
+    expect(countToken(result, 'imap_smtp')).toBe(0);
+  });
+
+  it('rewrites each binding field by its exact role', () => {
+    const result = rebindManifestIntegration(
+      loadImapManifest(),
+      'imap_smtp',
+      'imap_smtp-2',
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test navigates known manifest shape
+    const m = result as {
+      requires: { integrations: string[] };
+      workflow: {
+        requires: { integrations: Array<{ name: string }> };
+        steps: Array<{
+          stepSlug: string;
+          config?: { type?: string; parameters?: Record<string, unknown> };
+        }>;
+      };
+    };
+
+    // Manifest-level requires (drives requiredIntegrations + inbox channel).
+    expect(m.requires.integrations).toEqual(['imap_smtp-2']);
+    // Workflow-level requires ({name, operations}).
+    expect(m.workflow.requires.integrations[0].name).toBe('imap_smtp-2');
+
+    const byStep = new Map(m.workflow.steps.map((s) => [s.stepSlug, s]));
+    // integration-type steps → parameters.name
+    for (const slug of [
+      'fetch_new_emails',
+      'fetch_latest_emails',
+      'fetch_new_sent_emails',
+      'fetch_latest_sent_emails',
+    ]) {
+      expect(byStep.get(slug)?.config?.parameters?.name).toBe('imap_smtp-2');
+    }
+    // conversation-type steps → parameters.integrationName
+    for (const slug of [
+      'query_latest_inbound_message',
+      'insert_emails_to_conversation',
+      'query_latest_outbound_message',
+      'insert_sent_emails_to_conversation',
+    ]) {
+      expect(byStep.get(slug)?.config?.parameters?.integrationName).toBe(
+        'imap_smtp-2',
+      );
+    }
+  });
+
+  it('leaves display names, operations, and template strings untouched', () => {
+    const source = loadImapManifest();
+    const result = rebindManifestIntegration(
+      source,
+      'imap_smtp',
+      'imap_smtp-2',
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test navigates known manifest shape
+    const m = result as {
+      name: string;
+      workflow: {
+        steps: Array<{
+          name: string;
+          config?: { parameters?: Record<string, unknown> };
+        }>;
+      };
+    };
+
+    // Manifest + step display names are unchanged.
+    expect(m.name).toBe('Sync emails via SMTP/IMAP');
+    const fetchNew = m.workflow.steps.find(
+      (s) => s.name === 'Fetch New Emails (Incremental)',
+    );
+    expect(fetchNew).toBeDefined();
+    // The `operation` and `{{steps…}}` template params on that step survive.
+    expect(fetchNew?.config?.parameters?.operation).toBe('list_messages');
+    const params = fetchNew?.config?.parameters as {
+      params?: { since?: string };
+    };
+    expect(params.params?.since).toContain('{{steps.');
+  });
+
+  it('is a no-op when the source slug is not referenced', () => {
+    const source = loadImapManifest();
+    const result = rebindManifestIntegration(source, 'not_present', 'whatever');
+    expect(result).toEqual(source);
+  });
+
+  it('does not mutate the input manifest', () => {
+    const source = loadImapManifest();
+    const snapshot = JSON.stringify(source);
+    rebindManifestIntegration(source, 'imap_smtp', 'imap_smtp-2');
+    expect(JSON.stringify(source)).toBe(snapshot);
+  });
+});

--- a/services/platform/convex/automations/rebind_manifest.ts
+++ b/services/platform/convex/automations/rebind_manifest.ts
@@ -1,0 +1,82 @@
+/**
+ * Rebind an automation manifest from one integration slug to another — the pure
+ * core of "Duplicate integration". Rewrites ONLY the fields that name the
+ * integration by slug, and ONLY where the value exactly equals `fromSlug`:
+ *
+ *   - `requires.integrations[]` (slug strings) — drives the install row's
+ *     `requiredIntegrations` and, for an inbox automation, the channel binding;
+ *   - `integrations[]` (the "provides" display array, when present);
+ *   - `workflow.requires.integrations[].name`;
+ *   - each `workflow.steps[].config.parameters.name` on an `integration`-type
+ *     step (the runtime resolves the integration by `name`);
+ *   - each `workflow.steps[].config.parameters.integrationName` on a
+ *     `conversation`-type step (resolved by `integrationName`).
+ *
+ * Everything else — template strings (`{{steps…}}`), operations, step display
+ * names, other integrations in a multi-integration automation, the
+ * `builtinViews` opt-in — is left byte-for-byte intact. Operates on the raw
+ * parsed JSON (a deep clone), so no manifest field is ever dropped by a schema
+ * round-trip. Pure and dependency-free for direct unit testing.
+ */
+
+import { isRecord } from '../../lib/utils/type-utils';
+
+type JsonObject = Record<string, unknown>;
+
+function asObject(value: unknown): JsonObject | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+export function rebindManifestIntegration(
+  manifest: JsonObject,
+  fromSlug: string,
+  toSlug: string,
+): JsonObject {
+  // Deep clone via JSON round-trip: the manifest is pure JSON, so this is a
+  // faithful copy and keeps the rewrite from mutating the caller's object.
+  const clone: unknown = JSON.parse(JSON.stringify(manifest));
+  const next: JsonObject = isRecord(clone) ? clone : {};
+  const swap = (value: unknown): unknown =>
+    value === fromSlug ? toSlug : value;
+
+  // 1. requires.integrations : string[]
+  const requires = asObject(next.requires);
+  if (requires && Array.isArray(requires.integrations)) {
+    requires.integrations = requires.integrations.map(swap);
+  }
+
+  // 2. integrations : string[]  (the "provides" display array)
+  if (Array.isArray(next.integrations)) {
+    next.integrations = next.integrations.map(swap);
+  }
+
+  const workflow = asObject(next.workflow);
+
+  // 3. workflow.requires.integrations : { name, ... }[]
+  const workflowRequires = workflow && asObject(workflow.requires);
+  if (workflowRequires && Array.isArray(workflowRequires.integrations)) {
+    for (const dep of workflowRequires.integrations) {
+      const entry = asObject(dep);
+      if (entry && entry.name === fromSlug) entry.name = toSlug;
+    }
+  }
+
+  // 4. workflow.steps[].config.parameters.{name|integrationName}
+  const steps = workflow && Array.isArray(workflow.steps) ? workflow.steps : [];
+  for (const rawStep of steps) {
+    const config = asObject(asObject(rawStep)?.config);
+    const params = config && asObject(config.parameters);
+    if (!config || !params) continue;
+    // Integration-type steps name the integration via `name`; conversation-type
+    // steps via `integrationName`. Gate on `config.type` + exact-slug match so a
+    // step display `name` (or any other field) is never touched.
+    if (config.type === 'integration' && params.name === fromSlug) {
+      params.name = toSlug;
+    }
+    if (config.type === 'conversation' && params.integrationName === fromSlug) {
+      params.integrationName = toSlug;
+    }
+  }
+
+  return next;
+}

--- a/services/platform/convex/integrations/file_actions.test.ts
+++ b/services/platform/convex/integrations/file_actions.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('node:fs/promises', () => ({
   readdir: vi.fn().mockResolvedValue([]),
   mkdir: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('node:path', async () => {
@@ -36,13 +37,26 @@ vi.mock('../_generated/api', () => ({
 }));
 
 const mockAtomicWrite = vi.fn();
+const mockAtomicWriteBuffer = vi.fn();
 const mockReadFileSafe = vi.fn();
+const mockReadFileBufferSafe = vi.fn();
 const mockReadJsonFile = vi.fn();
 vi.mock('../lib/file_io', () => ({
   atomicWrite: (...args: unknown[]) => mockAtomicWrite(...args),
+  atomicWriteBuffer: (...args: unknown[]) => mockAtomicWriteBuffer(...args),
   readFileSafe: (...args: unknown[]) => mockReadFileSafe(...args),
+  readFileBufferSafe: (...args: unknown[]) => mockReadFileBufferSafe(...args),
   readJsonFile: (...args: unknown[]) => mockReadJsonFile(...args),
   sha256: () => 'mock-hash',
+}));
+
+const mockRebindBundledAutomations = vi.fn();
+const mockCleanupReboundAutomations = vi.fn();
+vi.mock('../automations/duplicate_rebind', () => ({
+  rebindBundledAutomations: (...args: unknown[]) =>
+    mockRebindBundledAutomations(...args),
+  cleanupReboundAutomations: (...args: unknown[]) =>
+    mockCleanupReboundAutomations(...args),
 }));
 
 // The capability gate lives in providers/auth (a `'use node'` helper that issues
@@ -67,10 +81,19 @@ vi.mock('./file_utils', async () => {
     ...actual,
     resolveConfigPath: (orgSlug: string, slug: string) =>
       `/data/integrations/${orgSlug}/${slug}/config.json`,
+    resolveConnectorPath: (orgSlug: string, slug: string) =>
+      `/data/integrations/${orgSlug}/${slug}/connector.ts`,
+    resolveIconPath: (orgSlug: string, slug: string) =>
+      `/data/integrations/${orgSlug}/${slug}/icon.svg`,
     resolveIntegrationDir: (orgSlug: string, slug: string) =>
       `/data/integrations/${orgSlug}/${slug}`,
+    resolveIntegrationsDir: (orgSlug: string) =>
+      `/data/integrations/${orgSlug}`,
     parseIntegrationJson: (s: string) => JSON.parse(s),
     serializeIntegrationJson: (c: unknown) => JSON.stringify(c),
+    // Stand-in for the catalog check: a duplicate ends in `-<n>`; everything
+    // else (bare slugs) is treated as a seeded builtin.
+    isBuiltinIntegrationSlug: (slug: string) => !/-\d+$/.test(slug),
   };
 });
 
@@ -83,6 +106,7 @@ const {
   uninstallIntegration,
   saveIntegrationConfig,
   writeIntegrationFiles,
+  duplicateIntegration,
 } = await import('./file_actions');
 
 type ActionConfig = {
@@ -95,6 +119,8 @@ const uninstallHandler = (uninstallIntegration as unknown as ActionConfig)
 const saveConfigHandler = (saveIntegrationConfig as unknown as ActionConfig)
   .handler;
 const writeFilesHandler = (writeIntegrationFiles as unknown as ActionConfig)
+  .handler;
+const duplicateHandler = (duplicateIntegration as unknown as ActionConfig)
   .handler;
 
 function createMockCtx() {
@@ -222,5 +248,114 @@ describe('integrations/file_actions capability gates', () => {
       });
       expect(mockAtomicWrite).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('duplicateIntegration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireDeveloperSettingsAccessById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      member: { _id: 'm-1', role: 'developer' },
+    });
+    mockReadFileSafe.mockResolvedValue(null);
+    mockReadFileBufferSafe.mockResolvedValue(null);
+    mockRebindBundledAutomations.mockResolvedValue([]);
+  });
+
+  it('rejects a plain member before any file or credential write', async () => {
+    mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+    const ctx = createMockCtx();
+    await expect(
+      duplicateHandler(
+        ctx as never,
+        { organizationId: 'org-123', slug: 'imap_smtp' } as never,
+      ),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' } });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(mockRebindBundledAutomations).not.toHaveBeenCalled();
+  });
+
+  it('refuses to duplicate an OAuth integration', async () => {
+    mockReadJsonFile.mockResolvedValue({
+      ok: true,
+      data: { title: 'Gmail', authMethod: 'oauth2' },
+      hash: 'h',
+    });
+    const ctx = createMockCtx();
+    await expect(
+      duplicateHandler(
+        ctx as never,
+        { organizationId: 'org-123', slug: 'gmail' } as never,
+      ),
+    ).rejects.toThrow(/cannot be duplicated/i);
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(mockRebindBundledAutomations).not.toHaveBeenCalled();
+  });
+
+  it('refuses to duplicate github (slug-bound) even though it is not OAuth', async () => {
+    mockReadJsonFile.mockResolvedValue({
+      ok: true,
+      data: { title: 'GitHub', authMethod: 'bearer_token' },
+      hash: 'h',
+    });
+    const ctx = createMockCtx();
+    await expect(
+      duplicateHandler(
+        ctx as never,
+        { organizationId: 'org-123', slug: 'github' } as never,
+      ),
+    ).rejects.toThrow(/cannot be duplicated/i);
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('clones a safe integration to the next slug with a suffixed title and rebinds its automations', async () => {
+    mockReadJsonFile.mockResolvedValue({
+      ok: true,
+      data: { title: 'IMAP / SMTP Mailbox', authMethod: 'basic_auth' },
+      hash: 'h',
+    });
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue([]); // no existing credential rows
+    ctx.runMutation.mockResolvedValue('cred-2'); // createCredentials → id
+
+    const result = await duplicateHandler(
+      ctx as never,
+      { organizationId: 'org-123', slug: 'imap_smtp' } as never,
+    );
+
+    expect(result).toMatchObject({
+      newSlug: 'imap_smtp-2',
+      credentialId: 'cred-2',
+      reboundAutomations: [],
+    });
+    // Inactive, blank credential under the derived slug.
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'createCredentials',
+      expect.objectContaining({
+        organizationId: 'org-123',
+        slug: 'imap_smtp-2',
+        status: 'inactive',
+        isActive: false,
+        authMethod: 'basic_auth',
+      }),
+    );
+    // Config written under the new slug with a distinguishing "(2)" title.
+    expect(mockAtomicWrite).toHaveBeenCalledWith(
+      '/data/integrations/default/imap_smtp-2/config.json',
+      expect.stringContaining('IMAP / SMTP Mailbox (2)'),
+    );
+    // Bundled automations rebound onto the new slug.
+    expect(mockRebindBundledAutomations).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        sourceIntegrationSlug: 'imap_smtp',
+        newIntegrationSlug: 'imap_smtp-2',
+        installedBy: 'a@b.com',
+      }),
+    );
   });
 });

--- a/services/platform/convex/integrations/file_actions.ts
+++ b/services/platform/convex/integrations/file_actions.ts
@@ -8,19 +8,27 @@
  * Supports compare-and-swap via expectedHash to prevent lost updates.
  */
 
-import { readdir } from 'node:fs/promises';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import { v } from 'convex/values';
 import JSZip from 'jszip';
 
-import type { IntegrationJsonConfig } from '../../lib/shared/schemas/integrations';
+import {
+  isDuplicableIntegration,
+  type IntegrationJsonConfig,
+} from '../../lib/shared/schemas/integrations';
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
-import { action, internalAction } from '../_generated/server';
+import { type ActionCtx, action, internalAction } from '../_generated/server';
+import {
+  cleanupReboundAutomations,
+  rebindBundledAutomations,
+} from '../automations/duplicate_rebind';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
 import {
   atomicWrite,
+  atomicWriteBuffer,
   readFileBufferSafe,
   readFileSafe,
   readJsonFile,
@@ -29,6 +37,8 @@ import {
 import { requireDeveloperSettingsAccessById } from '../providers/auth';
 import type { IntegrationReadResult } from './file_utils';
 import {
+  deriveNextSlug,
+  isBuiltinIntegrationSlug,
   MAX_FILE_SIZE_BYTES,
   parseIntegrationJson,
   resolveConfigPath,
@@ -161,6 +171,14 @@ export const listIntegrations = action({
 
           const entry: Record<string, unknown> = {
             slug,
+            // Only a base builtin template spawns instances; an instance
+            // (a duplicate like imap_smtp-2) is a leaf — not itself duplicable.
+            duplicable:
+              isBuiltinIntegrationSlug(slug) &&
+              isDuplicableIntegration({
+                slug,
+                authMethod: result.config.authMethod,
+              }),
             title: result.config.title,
             description: result.config.description,
             labels: result.config.labels,
@@ -446,7 +464,6 @@ export const writeIntegrationFiles = action({
     const configContent = serializeIntegrationJson(config);
     const integrationDir = resolveIntegrationDir(orgSlug, args.slug);
 
-    const { mkdir } = await import('node:fs/promises');
     await mkdir(integrationDir, { recursive: true });
 
     await atomicWrite(path.join(integrationDir, 'config.json'), configContent);
@@ -522,6 +539,208 @@ export const exportIntegration = action({
       filename: `${args.slug}.zip`,
       dataBase64,
     };
+  },
+});
+
+/**
+ * Best-effort teardown for a failed {@link duplicateIntegration}, in reverse of
+ * creation order: remove any rebound automations, delete the credential, then
+ * remove the integration dir — so a retry re-derives the same slug from a clean
+ * slate. Never throws (each step is logged); the caller rethrows the original
+ * error.
+ */
+async function cleanupDuplicatedIntegration(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    orgSlug: string;
+    newSlug: string;
+    newDir: string;
+    credentialId: Id<'integrationCredentials'> | null;
+  },
+): Promise<void> {
+  const { organizationId, orgSlug, newSlug, newDir, credentialId } = args;
+  await cleanupReboundAutomations(ctx, {
+    organizationId,
+    orgSlug,
+    integrationSlug: newSlug,
+  }).catch((error: unknown) => {
+    console.error(
+      `[duplicateIntegration] rebound-automation cleanup for "${newSlug}" failed:`,
+      error,
+    );
+  });
+  if (credentialId) {
+    await ctx
+      .runMutation(
+        internal.integrations.credential_mutations.deleteCredentialsInternal,
+        { credentialId },
+      )
+      .catch((error: unknown) => {
+        console.error(
+          `[duplicateIntegration] credential cleanup for "${newSlug}" failed:`,
+          error,
+        );
+      });
+  }
+  await rm(newDir, { recursive: true, force: true }).catch((error: unknown) => {
+    console.error(
+      `[duplicateIntegration] dir cleanup for "${newSlug}" failed:`,
+      error,
+    );
+  });
+}
+
+/**
+ * Duplicate an integration under a new, unique slug: clone its config dir
+ * (config.json + optional connector.ts + icon.svg) with a distinguishing
+ * "<title> (N)" title, create an inactive/blank credential, and rebind any
+ * bundled sync automation to the new slug so the copy gets its own sync + inbox.
+ * General to any duplication-safe integration ({@link isDuplicableIntegration});
+ * the automation rebind is a no-op for integrations without a bundled one
+ * (REST / SQL). Gated on the same `developerSettings` capability as the other
+ * integration writes.
+ *
+ * Multi-step (files + DB rows + automation install) with no cross-boundary
+ * transaction, so on any failure it best-effort tears down in reverse order and
+ * rethrows — a retry then re-derives the same slug from a clean slate.
+ */
+export const duplicateIntegration = action({
+  args: {
+    organizationId: v.string(),
+    slug: v.string(),
+  },
+  returns: v.object({
+    newSlug: v.string(),
+    credentialId: v.id('integrationCredentials'),
+    reboundAutomations: v.array(
+      v.object({ sourceSlug: v.string(), newSlug: v.string() }),
+    ),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    newSlug: string;
+    credentialId: Id<'integrationCredentials'>;
+    reboundAutomations: Array<{ sourceSlug: string; newSlug: string }>;
+  }> => {
+    if (!validateIntegrationSlug(args.slug)) {
+      throw new Error(`Invalid integration slug: ${args.slug}`);
+    }
+    const { orgSlug, userId, email } = await requireDeveloperSettingsAccessById(
+      ctx,
+      args.organizationId,
+    );
+    const installedBy = email ? email : userId;
+
+    const source = await readIntegrationConfigFile(orgSlug, args.slug);
+    if (!source.ok) {
+      throw new Error(`Cannot duplicate integration: ${source.message}`);
+    }
+    // Server-side duplicability guard behind the UI gate: OAuth / slug-bound
+    // integrations can't be safely cloned under a new slug.
+    if (
+      !isDuplicableIntegration({
+        slug: args.slug,
+        authMethod: source.config.authMethod,
+      })
+    ) {
+      throw new Error(
+        `Integration "${args.slug}" cannot be duplicated (OAuth or provider-bound).`,
+      );
+    }
+    // Duplicate the base template, not an instance — a duplicate is a leaf.
+    if (!isBuiltinIntegrationSlug(args.slug)) {
+      throw new Error(
+        `Integration "${args.slug}" is already an instance; duplicate the base integration instead.`,
+      );
+    }
+
+    const connectorCode = await readConnectorCode(orgSlug, args.slug);
+    const iconBuf = await readFileBufferSafe(
+      resolveIconPath(orgSlug, args.slug),
+    );
+
+    // Derive a unique new slug across on-disk dirs AND credential rows.
+    const dirNames = await readdir(resolveIntegrationsDir(orgSlug)).catch(
+      () => [] as string[],
+    );
+    const credentials = (await ctx.runQuery(
+      internal.integrations.credential_queries.listInternal,
+      { organizationId: args.organizationId },
+    )) as Array<{ slug: string }>;
+    const newSlug = deriveNextSlug(args.slug, [
+      ...dirNames.filter(
+        (e) => !e.startsWith('.') && validateIntegrationSlug(e),
+      ),
+      ...credentials.map((c) => c.slug),
+    ]);
+    if (!validateIntegrationSlug(newSlug)) {
+      throw new Error(`Derived integration slug is invalid: ${newSlug}`);
+    }
+    // deriveNextSlug always appends `-<n>`; that trailing number distinguishes
+    // the copy's title so the two show apart in the inbox channel picker.
+    const suffix = newSlug.slice(newSlug.lastIndexOf('-') + 1);
+
+    const newDir = resolveIntegrationDir(orgSlug, newSlug);
+    let credentialId: Id<'integrationCredentials'> | null = null;
+    try {
+      await mkdir(newDir, { recursive: true });
+      const dupConfig: IntegrationJsonConfig = {
+        ...source.config,
+        title: `${source.config.title} (${suffix})`,
+      };
+      await atomicWrite(
+        resolveConfigPath(orgSlug, newSlug),
+        serializeIntegrationJson(dupConfig),
+      );
+      if (connectorCode) {
+        await atomicWrite(
+          resolveConnectorPath(orgSlug, newSlug),
+          connectorCode,
+        );
+      }
+      // writeIntegrationFiles omits the icon; copy it byte-for-byte here.
+      if (iconBuf) {
+        await atomicWriteBuffer(resolveIconPath(orgSlug, newSlug), iconBuf);
+      }
+
+      // Inactive, blank credential — NO secrets, NO connectionConfig (the blank
+      // config-file templates ride along in the copied config.json; the
+      // operator fills in this instance's login).
+      credentialId = await ctx.runMutation(
+        internal.integrations.credential_mutations.createCredentials,
+        {
+          organizationId: args.organizationId,
+          slug: newSlug,
+          status: 'inactive',
+          isActive: false,
+          authMethod: source.config.authMethod,
+          supportedAuthMethods: source.config.supportedAuthMethods,
+          capabilities: source.config.capabilities,
+        },
+      );
+
+      const reboundAutomations = await rebindBundledAutomations(ctx, {
+        organizationId: args.organizationId,
+        orgSlug,
+        sourceIntegrationSlug: args.slug,
+        newIntegrationSlug: newSlug,
+        installedBy,
+      });
+
+      return { newSlug, credentialId, reboundAutomations };
+    } catch (error) {
+      await cleanupDuplicatedIntegration(ctx, {
+        organizationId: args.organizationId,
+        orgSlug,
+        newSlug,
+        newDir,
+        credentialId,
+      });
+      throw error;
+    }
   },
 });
 

--- a/services/platform/convex/integrations/file_utils.test.ts
+++ b/services/platform/convex/integrations/file_utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveNextSlug, validateIntegrationSlug } from './file_utils';
+
+describe('deriveNextSlug', () => {
+  it('appends -2 to a base with no numeric suffix', () => {
+    expect(deriveNextSlug('imap_smtp', [])).toBe('imap_smtp-2');
+  });
+
+  it('skips slugs already taken', () => {
+    expect(deriveNextSlug('imap_smtp', ['imap_smtp-2', 'imap_smtp-3'])).toBe(
+      'imap_smtp-4',
+    );
+  });
+
+  it('increments an existing numeric suffix instead of stacking (-2-2)', () => {
+    expect(deriveNextSlug('imap_smtp-2', [])).toBe('imap_smtp-3');
+    expect(deriveNextSlug('imap_smtp-2', ['imap_smtp-3'])).toBe('imap_smtp-4');
+  });
+
+  it('suffixes only the last segment of a kebab automation slug path', () => {
+    expect(deriveNextSlug('imap-smtp/sync-emails', [])).toBe(
+      'imap-smtp/sync-emails-2',
+    );
+    expect(deriveNextSlug('imap-smtp/sync-emails-2', [])).toBe(
+      'imap-smtp/sync-emails-3',
+    );
+  });
+
+  it('always returns a slug distinct from the base', () => {
+    expect(deriveNextSlug('x-5', ['x-6'])).toBe('x-7');
+  });
+
+  it('produces a valid integration slug for the imap case', () => {
+    expect(validateIntegrationSlug(deriveNextSlug('imap_smtp', []))).toBe(true);
+  });
+});

--- a/services/platform/convex/integrations/file_utils.ts
+++ b/services/platform/convex/integrations/file_utils.ts
@@ -7,6 +7,7 @@
  * No Convex dependencies — these can be used in any Node.js context.
  */
 
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { zodErrorMessage } from '../../lib/shared/schemas/format-error';
@@ -49,6 +50,55 @@ export type IntegrationReadResult =
 export function validateIntegrationSlug(slug: string): boolean {
   if (slug.length > MAX_SLUG_LENGTH) return false;
   return INTEGRATION_SLUG_REGEX.test(slug);
+}
+
+/**
+ * Compute the next free `<stem>-<n>` slug given a `base` slug and the set of
+ * already-taken slugs. Used to mint a fresh, non-colliding slug when
+ * duplicating an integration (`imap_smtp` → `imap_smtp-2`) or its bundled
+ * automation (`imap-smtp/sync-emails` → `imap-smtp/sync-emails-2`).
+ *
+ * A base that already ends in `-<n>` is re-normalized so `imap_smtp-2` yields
+ * `imap_smtp-3`, never `imap_smtp-2-2`. Appending `-<n>` only mutates a kebab
+ * path's final segment, so the same helper serves both the flat integration
+ * slug space and the `/`-separated automation slug space. The returned slug is
+ * always distinct from `base`; the caller re-validates it against the relevant
+ * domain regex (length / shape).
+ */
+export function deriveNextSlug(
+  base: string,
+  existing: Iterable<string>,
+): string {
+  const taken = new Set(existing);
+  const match = /^(.*)-(\d+)$/.exec(base);
+  const stem = match ? match[1] : base;
+  let n = match ? Number(match[2]) + 1 : 2;
+  let candidate = `${stem}-${n}`;
+  while (taken.has(candidate)) {
+    n += 1;
+    candidate = `${stem}-${n}`;
+  }
+  return candidate;
+}
+
+const BUILTIN_DIR_ENV = 'TALE_CONFIG_BUILTIN_DIR';
+
+/**
+ * Whether `slug` names a first-party integration in the built-in catalog
+ * (`<TALE_CONFIG_BUILTIN_DIR>/integrations/<slug>/config.json`). A builtin is a
+ * seeded template that must only be disconnected, never fully deleted (that
+ * would take the shared template dir with it). A NON-builtin — a duplicate like
+ * `imap_smtp-2`, or an uploaded connector — is an org-owned instance whose dir
+ * is safe to delete. Independent of connection state: a never-connected
+ * duplicate is just as deletable as one that was connected then disconnected.
+ * Fails SAFE — an unset catalog env ⇒ treat as builtin (deletion refused).
+ */
+export function isBuiltinIntegrationSlug(slug: string): boolean {
+  const catalogRoot = process.env[BUILTIN_DIR_ENV];
+  if (!catalogRoot) return true;
+  return existsSync(
+    path.join(catalogRoot, 'integrations', slug, 'config.json'),
+  );
 }
 
 /**

--- a/services/platform/lib/shared/schemas/integrations.test.ts
+++ b/services/platform/lib/shared/schemas/integrations.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { integrationJsonSchema } from './integrations';
+import { integrationJsonSchema, isDuplicableIntegration } from './integrations';
 
 /**
  * Every integration `config.json` in `builtin-configs/integrations/` ships as
@@ -62,4 +62,32 @@ describe('builtin-configs/integrations/*/config.json invariants', () => {
       });
     });
   }
+});
+
+describe('isDuplicableIntegration', () => {
+  it('allows non-OAuth, type/capability-driven integrations', () => {
+    expect(
+      isDuplicableIntegration({ slug: 'imap_smtp', authMethod: 'basic_auth' }),
+    ).toBe(true);
+    expect(
+      isDuplicableIntegration({ slug: 'tavily', authMethod: 'api_key' }),
+    ).toBe(true);
+    expect(
+      isDuplicableIntegration({ slug: 'discord', authMethod: 'bearer_token' }),
+    ).toBe(true);
+  });
+
+  it('blocks OAuth integrations (gmail / outlook / slack) — slug-bound registration', () => {
+    for (const slug of ['gmail', 'outlook', 'slack']) {
+      expect(isDuplicableIntegration({ slug, authMethod: 'oauth2' })).toBe(
+        false,
+      );
+    }
+  });
+
+  it('blocks github even though it is bearer_token (sandbox git auth keys on the slug)', () => {
+    expect(
+      isDuplicableIntegration({ slug: 'github', authMethod: 'bearer_token' }),
+    ).toBe(false);
+  });
 });

--- a/services/platform/lib/shared/schemas/integrations.ts
+++ b/services/platform/lib/shared/schemas/integrations.ts
@@ -106,3 +106,29 @@ export const integrationJsonSchema = z.object({
 });
 
 export type IntegrationJsonConfig = z.infer<typeof integrationJsonSchema>;
+
+/**
+ * Whether an integration instance can be safely duplicated (cloned under a new
+ * slug). The single source of truth for the "Duplicate" gate — used both to
+ * project `duplicable` onto the integration list and to guard the
+ * `duplicateIntegration` action server-side.
+ *
+ * Duplication is safe for integrations whose runtime behaviour keys on `type`
+ * or on the dynamic slug, but NOT for ones with provider-side registration or
+ * runtime slug-equality branches bound to the literal slug — a copy under a new
+ * slug would silently fail to authenticate or route:
+ *   - `oauth2` auth (gmail, outlook, slack): OAuth redirect URIs, provider
+ *     client registration, and inbound routing are bound to the exact slug.
+ *   - `github`: sandbox git auth keys on `slug === 'github'`
+ *     (convex/node_only/sandbox/session_credentials.ts), so a `github-2` copy
+ *     loses its git credentials. It authenticates via `bearer_token`, not
+ *     `oauth2`, so it needs the explicit slug exclusion.
+ * imap_smtp and generic REST / SQL are clean (only `type ===` branches, and
+ * `type` rides along in the copied config.json).
+ */
+export function isDuplicableIntegration(input: {
+  slug: string;
+  authMethod: string;
+}): boolean {
+  return input.authMethod !== 'oauth2' && input.slug !== 'github';
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6451,6 +6451,11 @@
       "export": {
         "failed": "Integration konnte nicht exportiert werden"
       },
+      "duplicate": {
+        "failed": "Integration konnte nicht dupliziert werden",
+        "pending": "Kopie von {name} wird erstellt…",
+        "success": "Kopie von {name} erstellt"
+      },
       "viewDetails": "Details anzeigen",
       "menuLabel": "{name} verwalten"
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6750,6 +6750,11 @@
       "export": {
         "failed": "Failed to export integration"
       },
+      "duplicate": {
+        "failed": "Failed to duplicate integration",
+        "pending": "Creating a copy of {name}…",
+        "success": "Created a copy of {name}"
+      },
       "viewDetails": "View details",
       "menuLabel": "Manage {name}"
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6451,6 +6451,11 @@
       "export": {
         "failed": "Échec de l'export de l'intégration"
       },
+      "duplicate": {
+        "failed": "Échec de la duplication de l'intégration",
+        "pending": "Création d'une copie de {name}…",
+        "success": "Copie de {name} créée"
+      },
       "viewDetails": "Voir les détails",
       "menuLabel": "Gérer {name}"
     },


### PR DESCRIPTION
> **Stacked** on #2869 (which is stacked on #2865). Review the top commit; the base will collapse as the parents merge.

## Why

Some integrations are needed more than once — two mailboxes, two databases, two API tenants. The data model already supported it: an instance is identified by **slug**, and everything downstream (credentials, conversations, automation bindings) keys off that slug. What was missing was a way to mint the second one.

## Change

A **Duplicate** action in the card's ⋯ menu and the panel footer. It:

1. clones the config dir (`config.json` + `connector.ts` + `icon.svg`) under a fresh slug from `deriveNextSlug` (`imap_smtp` → `imap_smtp-2`);
2. titles it `<title> (N)` so the two are distinguishable in the inbox channel picker;
3. mints a blank, inactive credential — no secrets copied;
4. clones every automation bound to the source onto the new slug, so the copy gets its own sync and its own inbox.

After it resolves, the list switches to the **all** tab and opens the new instance's panel, so Duplicate never dead-ends on a Connected tab that an inactive instance isn't on.

## The rebind

`rebindManifestIntegration` is pure and rewrites **only** the manifest fields that name an integration by slug, and only where the value *exactly* equals the source slug:

- `requires.integrations[]`, the `integrations[]` provides array
- `workflow.requires.integrations[].name`
- `parameters.name` on `integration`-type steps, `parameters.integrationName` on `conversation`-type steps (gated on `config.type`, so a step's display `name` is never touched)

Everything else — template strings, operations, step display names, other integrations in a multi-integration automation — is byte-for-byte intact, and the result is re-validated against `automationManifestSchema` before it is written. Pinned in `rebind_manifest.test.ts` against the real shipped imap `sync-emails` bundle: exactly 10 references rewritten, nothing else.

## No cron until connected

The clone installs with `skipSchedules: true`. Its credential is blank until an operator supplies the login, so a schedule provisioned at duplicate time would fire a guaranteed-failing run **every tick** until then — forever, if the duplicate is abandoned. The reconnect cascade from #2865 provisions the schedule on first successful connect instead.

## The gate

`authMethod !== 'oauth2' && slug !== 'github'`, enforced twice — as the projected `duplicable` flag driving the UI, and server-side in the action:

- **oauth2** (gmail, outlook, slack): redirect URIs, provider client registration and inbound routing are bound to the exact slug.
- **github**: sandbox git auth keys on `slug === 'github'` (`node_only/sandbox/session_credentials.ts`). It authenticates via `bearer_token`, not `oauth2`, so it needs the explicit exclusion.

imap_smtp and generic REST / SQL only branch on `type`, which rides along in the copied `config.json`. Only a base template duplicates — an instance is a leaf, so you get `-2`, `-3` from the original rather than `-2-2`.

## Failure handling

Duplicating spans files, DB rows and an automation install with no cross-boundary transaction. Any failure tears down in reverse creation order (rebound automations → credential → config dir) and rethrows, so a retry re-derives the same slug from a clean slate. Bundle dirs written without a matching install row are swept explicitly — the teardown finds automations *by install row* and would otherwise leave them behind.

## Tests

- `rebind_manifest.test.ts` — the rewrite vs the real manifest (over- and under-rewrite both caught)
- `duplicate_rebind.test.ts` — installs with no cron, sweeps an uninstalled bundle dir on failure, no-ops with no bound automations
- `file_utils.test.ts` — `deriveNextSlug` including re-normalizing an already-suffixed base
- `integrations.test.ts` (schemas) — the duplicability predicate
- `file_actions.test.ts` — rejects a plain member before any write, refuses OAuth, refuses github, and the happy path (slug, suffixed title, rebind)
- UI — Duplicate renders and fires from card + panel, omitted when not duplicable, and the post-duplicate tab switch + panel open

471 tests pass across the integrations UI, convex integrations/automations, schema and i18n suites. Gate: `tsc` clean, `oxlint --type-aware` 0/0, `oxfmt --check` clean, `migrations:check` OK (no schema change), docs suite 194 pass.

Docs updated in en/de/fr. Not covered here: an interactive click-through against a live org — it mutates real config dirs and installs automations, so it needs a deliberate run.