### PR TITLE
feat(platform): delete an unconnected duplicate instance

### DIFF
--- a/docs/de/platform/admin/integrations.md
+++ b/docs/de/platform/admin/integrations.md
@@ -54,6 +54,8 @@ Manche Integrationen braucht man mehrfach — zwei Postfächer, zwei Datenbanken
 
 Die Kopie startet getrennt und bleibt ruhig — bis du ihre Anmeldedaten einträgst und verbindest, läuft kein geplanter Durchlauf. Ein unkonfiguriertes Duplikat erzeugt also nie fehlschlagende Durchläufe. Duplizieren wird nur dort angeboten, wo eine zweite Instanz tatsächlich funktionieren kann: OAuth-Integrationen (Gmail, Outlook, Slack) und GitHub sind beim Anbieter an ihre exakte Identität gebunden und lassen sich deshalb nicht duplizieren.
 
+Ein Duplikat ist vollständig entfernbar. Solange es getrennt ist, bietet sein Panel **Löschen** an — das entfernt die Instanz, ihre Anmeldedaten und die für sie geklonten Automatisierungen. Mitgelieferte Integrationen bieten nie Löschen an: sie lassen sich nur trennen, damit die Vorlage für die nächste Verbindung erhalten bleibt.
+
 ## Slack-Bot und Benachrichtigungen
 
 Slack ist zweigerichtet. Über den Agent, der Slack aufruft (Nachrichten posten, Kanäle lesen), hinaus kann die Organisation Leute aus Slack heraus mit einem Agent sprechen lassen und System-Events in einen Kanal pushen. Beides wird auf der verbundenen Slack-Zeile konfiguriert, und beides nutzt dieselbe OAuth-Anmeldung — keine zweite Verbindung.

--- a/docs/en/platform/admin/integrations.md
+++ b/docs/en/platform/admin/integrations.md
@@ -54,6 +54,8 @@ Some integrations are needed more than once — two mailboxes, two databases, tw
 
 The copy starts disconnected and stays idle — no scheduled run fires until you enter its credentials and connect it, so an unconfigured duplicate never generates failing runs. Duplicate is offered only where a second instance can actually work: OAuth integrations (Gmail, Outlook, Slack) and GitHub are bound to their exact identity at the provider, so they cannot be duplicated.
 
+A duplicate is fully removable. While it is disconnected, its panel offers **Delete**, which removes the instance, its credential, and the automations that were cloned for it. Built-in integrations never offer Delete — they can only be disconnected, so the template survives for the next connection.
+
 ## Slack bot and notifications
 
 Slack is two-directional. Beyond the agent calling Slack (posting messages, reading channels), the org can let people talk to an agent from inside Slack and have system events pushed to a channel. Both are configured on the connected Slack row, and both ride the single OAuth credential — no second connection.

--- a/docs/fr/platform/admin/integrations.md
+++ b/docs/fr/platform/admin/integrations.md
@@ -54,6 +54,8 @@ Certaines intégrations servent plusieurs fois — deux boîtes mail, deux bases
 
 La copie démarre déconnectée et reste au repos : aucune exécution planifiée ne se déclenche avant que tu saisisses ses identifiants et la connectes, donc un doublon non configuré ne produit jamais d’exécutions en échec. Dupliquer n’est proposé que là où une seconde instance peut réellement fonctionner : les intégrations OAuth (Gmail, Outlook, Slack) et GitHub sont liées à leur identité exacte chez le fournisseur et ne peuvent donc pas être dupliquées.
 
+Un doublon se retire entièrement. Tant qu’il est déconnecté, son panneau propose **Supprimer**, ce qui retire l’instance, son identifiant et les automatisations clonées pour elle. Les intégrations livrées ne proposent jamais Supprimer : elles ne peuvent qu’être déconnectées, pour que le modèle survive à la prochaine connexion.
+
 ## Bot Slack et notifications
 
 Slack est bidirectionnel. Au-delà de l’agent qui appelle Slack (poster des messages, lire des canaux), l’org peut laisser des personnes parler à un agent depuis Slack et pousser des événements système dans un canal. Les deux se configurent sur la ligne Slack connectée, et les deux utilisent le même identifiant OAuth — pas de seconde connexion.

--- a/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
@@ -322,3 +322,32 @@ describe('IntegrationPanel — duplicate action', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('IntegrationPanel — delete a disconnected removable instance', () => {
+  it('offers Delete on the disconnected footer and opens the confirm dialog', () => {
+    const setConfirmDelete = vi.fn();
+    vi.mocked(useIntegrationManage).mockImplementation(
+      () =>
+        ({
+          ...baseManage,
+          isActive: false,
+          isRemovable: true,
+          confirmDelete: false,
+          setConfirmDelete,
+          handleDeleteInstance: vi.fn(),
+        }) as never,
+    );
+    render(
+      <IntegrationPanel
+        open
+        onOpenChange={vi.fn()}
+        integration={integration}
+        organizationId="org-1"
+      />,
+    );
+    const sheet = screen.getByTestId('sheet');
+    // A disconnected duplicate is deletable even though it was never connected.
+    fireEvent.click(within(sheet).getByRole('button', { name: 'Delete' }));
+    expect(setConfirmDelete).toHaveBeenCalledWith(true);
+  });
+});

--- a/services/platform/app/features/settings/integrations/components/integration-panel.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.tsx
@@ -307,11 +307,27 @@ export function IntegrationPanel({
               variant="destructive"
             >
               <Trash2 className="mr-2 size-3.5" />
-              {t('integrations.panel.deleteIntegration')}
+              {manage.isRemovable
+                ? tCommon('actions.delete')
+                : t('integrations.panel.deleteIntegration')}
             </Button>
           </HStack>
         ) : (
-          <HStack justify="end" align="center">
+          <HStack
+            justify={manage.isRemovable ? 'between' : 'end'}
+            align="center"
+          >
+            {manage.isRemovable ? (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => manage.setConfirmDelete(true)}
+                disabled={manage.busy}
+              >
+                <Trash2 className="mr-2 size-3.5" />
+                {tCommon('actions.delete')}
+              </Button>
+            ) : null}
             <Button
               onClick={
                 manage.selectedAuthMethod === 'oauth2' &&
@@ -380,11 +396,23 @@ export function IntegrationPanel({
       <DeleteDialog
         open={manage.confirmDelete}
         onOpenChange={manage.setConfirmDelete}
-        title={t('integrations.panel.deleteConfirmTitle')}
-        description={t('integrations.panel.deleteConfirmDescription')}
+        title={
+          manage.isRemovable
+            ? t('integrations.panel.deleteInstanceConfirmTitle')
+            : t('integrations.panel.deleteConfirmTitle')
+        }
+        description={
+          manage.isRemovable
+            ? t('integrations.panel.deleteInstanceConfirmDescription')
+            : t('integrations.panel.deleteConfirmDescription')
+        }
         preview={{ primary: panelTitle, secondary: identity }}
         isDeleting={manage.busy}
-        onDelete={manage.handleUninstall}
+        onDelete={
+          manage.isRemovable
+            ? manage.handleDeleteInstance
+            : manage.handleUninstall
+        }
       />
     </Sheet>
   );

--- a/services/platform/app/features/settings/integrations/components/integrations.tsx
+++ b/services/platform/app/features/settings/integrations/components/integrations.tsx
@@ -40,6 +40,8 @@ export interface IntegrationListItem {
   /** Whether the "Duplicate" action is offered — false for OAuth / slug-bound
    *  integrations (see isDuplicableIntegration); projected by listIntegrations. */
   duplicable: boolean;
+  /** True for a user-created duplicate instance — fully deletable, not a builtin. */
+  removable?: boolean;
   operationCount: number;
   hash: string;
   [key: string]: unknown;

--- a/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
@@ -59,6 +59,8 @@ export type Integration = Record<string, unknown> & {
   authMethod?: string;
   supportedAuthMethods?: string[];
   isActive?: boolean;
+  /** True for a user-created duplicate instance — fully deletable, not a builtin. */
+  removable?: boolean;
   iconUrl?: string | null;
   oauth2Config?: {
     authorizationUrl?: string;
@@ -224,12 +226,19 @@ export function useIntegrationManage(
   const uninstallFn = useAction(
     api.integrations.file_actions.uninstallIntegration,
   );
+  const deleteInstanceFn = useAction(
+    api.integrations.file_actions.deleteIntegrationInstance,
+  );
   const installFn = useAction(api.integrations.file_actions.installIntegration);
   const { mutateAsync: generateUploadUrl } = useGenerateUploadUrl();
   const { mutateAsync: generateOAuth2Url } = useGenerateIntegrationOAuth2Url();
   const { mutateAsync: saveOAuth2Credentials } = useSaveOAuth2Credentials();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Drives the DeleteDialog's loading state (via `busy`) so a delete/uninstall
+  // shows "Deleting…" and holds the dialog open until it resolves — mirroring
+  // the disconnect confirm, so a destructive action never looks like a no-op.
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const hasOAuth2Config = !!integration.oauth2Config;
 
@@ -372,7 +381,12 @@ export function useIntegrationManage(
     }
   }, []);
 
-  const busy = isSubmitting || isTesting || isSavingOAuth2 || isApplyingUpdate;
+  const busy =
+    isSubmitting ||
+    isTesting ||
+    isSavingOAuth2 ||
+    isApplyingUpdate ||
+    isDeleting;
 
   const busyRef = useRef(false);
   busyRef.current = busy;
@@ -964,6 +978,7 @@ export function useIntegrationManage(
     !!integration.oauth2Config?.clientId || oauth2SavedOptimistic;
 
   const handleUninstall = useCallback(async () => {
+    setIsDeleting(true);
     try {
       await uninstallFn({
         slug: integration.name ?? '',
@@ -986,9 +1001,50 @@ export function useIntegrationManage(
         variant: 'destructive',
       });
     } finally {
+      setIsDeleting(false);
       setConfirmDelete(false);
     }
   }, [uninstallFn, integration, organizationId, onOpenChange, t, queryClient]);
+
+  // Fully delete a user-created duplicate instance (config dir + credential +
+  // rebound automations) — unlike `handleUninstall`, which only removes the
+  // credential. Available while the instance is disconnected.
+  const isRemovable = integration.removable === true;
+  const handleDeleteInstance = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await deleteInstanceFn({
+        slug: integration.name ?? '',
+        organizationId,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['config', 'integrations'],
+      });
+      toast({
+        title: t('integrations.manageDialog.deleted'),
+        description: t('integrations.manageDialog.deletedDescription', {
+          name: integration.title,
+        }),
+      });
+      onOpenChange(false);
+    } catch (error) {
+      toast({
+        title: t('integrations.manageDialog.deleteFailed'),
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDeleting(false);
+      setConfirmDelete(false);
+    }
+  }, [
+    deleteInstanceFn,
+    integration,
+    organizationId,
+    onOpenChange,
+    t,
+    queryClient,
+  ]);
 
   const operationCount =
     (integration.connector?.operations?.length ??
@@ -1059,6 +1115,8 @@ export function useIntegrationManage(
     confirmDelete,
     setConfirmDelete,
     handleUninstall,
+    isRemovable,
+    handleDeleteInstance,
 
     maskValue,
   };

--- a/services/platform/convex/integrations/file_actions.test.ts
+++ b/services/platform/convex/integrations/file_actions.test.ts
@@ -1,3 +1,5 @@
+import { rm } from 'node:fs/promises';
+
 import { ConvexError } from 'convex/values';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -107,6 +109,7 @@ const {
   saveIntegrationConfig,
   writeIntegrationFiles,
   duplicateIntegration,
+  deleteIntegrationInstance,
 } = await import('./file_actions');
 
 type ActionConfig = {
@@ -122,6 +125,9 @@ const writeFilesHandler = (writeIntegrationFiles as unknown as ActionConfig)
   .handler;
 const duplicateHandler = (duplicateIntegration as unknown as ActionConfig)
   .handler;
+const deleteInstanceHandler = (
+  deleteIntegrationInstance as unknown as ActionConfig
+).handler;
 
 function createMockCtx() {
   return {
@@ -356,6 +362,70 @@ describe('duplicateIntegration', () => {
         newIntegrationSlug: 'imap_smtp-2',
         installedBy: 'a@b.com',
       }),
+    );
+  });
+});
+
+describe('deleteIntegrationInstance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireDeveloperSettingsAccessById.mockResolvedValue({
+      orgId: 'org-123',
+      orgSlug: 'default',
+      userId: 'user-1',
+      email: 'a@b.com',
+      member: { _id: 'm-1', role: 'developer' },
+    });
+    mockCleanupReboundAutomations.mockResolvedValue(undefined);
+  });
+
+  it('rejects a plain member before any teardown', async () => {
+    mockRequireDeveloperSettingsAccessById.mockRejectedValue(FORBIDDEN);
+    const ctx = createMockCtx();
+    await expect(
+      deleteInstanceHandler(
+        ctx as never,
+        { organizationId: 'org-123', slug: 'imap_smtp-2' } as never,
+      ),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN_DEVELOPER_SETTINGS' } });
+    expect(mockCleanupReboundAutomations).not.toHaveBeenCalled();
+  });
+
+  it('refuses to delete a built-in template (disconnect only)', async () => {
+    // `imap_smtp` has no `-<n>` suffix → a builtin per the mock.
+    const ctx = createMockCtx();
+    await expect(
+      deleteInstanceHandler(
+        ctx as never,
+        { organizationId: 'org-123', slug: 'imap_smtp' } as never,
+      ),
+    ).rejects.toThrow(/built-in template/i);
+    expect(mockCleanupReboundAutomations).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(vi.mocked(rm)).not.toHaveBeenCalled();
+  });
+
+  it('fully deletes a non-builtin instance even if never connected: automations, credential, dir', async () => {
+    // `imap_smtp-2` ends in `-2` → a non-builtin instance per the mock.
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({ _id: 'cred-2' }); // getBySlugInternal
+
+    const result = await deleteInstanceHandler(
+      ctx as never,
+      { organizationId: 'org-123', slug: 'imap_smtp-2' } as never,
+    );
+
+    expect(result).toEqual({ deleted: true });
+    expect(mockCleanupReboundAutomations).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ integrationSlug: 'imap_smtp-2' }),
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith('deleteCredentialsInternal', {
+      credentialId: 'cred-2',
+    });
+    expect(vi.mocked(rm)).toHaveBeenCalledWith(
+      '/data/integrations/default/imap_smtp-2',
+      { recursive: true, force: true },
     );
   });
 });

--- a/services/platform/convex/integrations/file_actions.ts
+++ b/services/platform/convex/integrations/file_actions.ts
@@ -179,6 +179,11 @@ export const listIntegrations = action({
                 slug,
                 authMethod: result.config.authMethod,
               }),
+            // A non-builtin instance (a duplicate like imap_smtp-2, or an
+            // uploaded connector) — its org-owned dir is fully deletable, unlike
+            // a seeded builtin template (which is only disconnected). Independent
+            // of connection state (a never-connected duplicate is deletable).
+            removable: !isBuiltinIntegrationSlug(slug),
             title: result.config.title,
             description: result.config.description,
             labels: result.config.labels,
@@ -741,6 +746,61 @@ export const duplicateIntegration = action({
       });
       throw error;
     }
+  },
+});
+
+/**
+ * Fully delete a DUPLICATED integration instance: remove its rebound automations,
+ * its credential, and its config dir — the inverse of `duplicateIntegration`,
+ * available while the instance is disconnected. Only a user-created duplicate
+ * (marked `metadata.duplicatedFrom`) may be deleted this way; a builtin template
+ * is refused (disconnect keeps the seeded template). Gated on the same
+ * `developerSettings` capability as the other integration writes.
+ */
+export const deleteIntegrationInstance = action({
+  args: { organizationId: v.string(), slug: v.string() },
+  returns: v.object({ deleted: v.boolean() }),
+  handler: async (ctx, args): Promise<{ deleted: boolean }> => {
+    if (!validateIntegrationSlug(args.slug)) {
+      throw new Error(`Invalid integration slug: ${args.slug}`);
+    }
+    const { orgSlug } = await requireDeveloperSettingsAccessById(
+      ctx,
+      args.organizationId,
+    );
+    // Safety: never fully delete a builtin template — that would take the seeded
+    // template dir with it. A non-builtin instance (a duplicate or an uploaded
+    // connector) is org-owned and deletable whether or not it was ever
+    // connected; a builtin is only disconnected.
+    if (isBuiltinIntegrationSlug(args.slug)) {
+      throw new Error(
+        `Integration "${args.slug}" is a built-in template; disconnect it instead of deleting.`,
+      );
+    }
+
+    // Reverse the instance footprint, in creation-reverse order: rebound
+    // automations, then the credential, then the config dir.
+    await cleanupReboundAutomations(ctx, {
+      organizationId: args.organizationId,
+      orgSlug,
+      integrationSlug: args.slug,
+    });
+    const existing = await ctx.runQuery(
+      internal.integrations.credential_queries.getBySlugInternal,
+      { organizationId: args.organizationId, slug: args.slug },
+    );
+    if (existing) {
+      await ctx.runMutation(
+        internal.integrations.credential_mutations.deleteCredentialsInternal,
+        { credentialId: existing._id },
+      );
+    }
+    await rm(resolveIntegrationDir(orgSlug, args.slug), {
+      recursive: true,
+      force: true,
+    });
+
+    return { deleted: true };
   },
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6273,9 +6273,11 @@
         "enterCredentialsToConnect": "Gib Zugangsdaten ein, um zu verbinden.",
         "disconnectConfirmTitle": "Integration trennen",
         "disconnectConfirmDescription": "Möchtest du diese Integration wirklich trennen? Du kannst sie später erneut verbinden.",
-        "deleteConfirmTitle": "Integration löschen",
-        "deleteConfirmDescription": "Möchtest du diese Integration wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
-        "deleteIntegration": "Integration löschen"
+        "deleteConfirmTitle": "Verbindung entfernen",
+        "deleteConfirmDescription": "Damit werden die gespeicherten Zugangsdaten entfernt und die Integration getrennt. Die Vorlage bleibt erhalten – zum erneuten Verbinden gibst du die Zugangsdaten wieder ein.",
+        "deleteInstanceConfirmTitle": "Diese Instanz löschen",
+        "deleteInstanceConfirmDescription": "Damit werden diese Integration und alle dafür eingerichteten Automatisierungen dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "deleteIntegration": "Verbindung entfernen"
       },
       "authMethods": {
         "api_key": "API-Schlüssel",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6572,9 +6572,11 @@
         "enterCredentialsToConnect": "Enter credentials to connect.",
         "disconnectConfirmTitle": "Disconnect integration",
         "disconnectConfirmDescription": "Are you sure you want to disconnect this integration? You can reconnect it later.",
-        "deleteConfirmTitle": "Delete integration",
-        "deleteConfirmDescription": "Are you sure you want to delete this integration? This action cannot be undone.",
-        "deleteIntegration": "Delete integration"
+        "deleteConfirmTitle": "Remove connection",
+        "deleteConfirmDescription": "This removes the stored login and disconnects this integration. The template stays, so you can reconnect by entering credentials again.",
+        "deleteInstanceConfirmTitle": "Delete this instance",
+        "deleteInstanceConfirmDescription": "This permanently deletes this integration and any automations set up for it. This can't be undone.",
+        "deleteIntegration": "Remove connection"
       },
       "authMethods": {
         "api_key": "API key",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6273,9 +6273,11 @@
         "enterCredentialsToConnect": "Saisis des identifiants pour connecter.",
         "disconnectConfirmTitle": "Déconnecter l'intégration",
         "disconnectConfirmDescription": "Es-tu sûr de vouloir déconnecter cette intégration ? Tu pourras la reconnecter ultérieurement.",
-        "deleteConfirmTitle": "Supprimer l'intégration",
-        "deleteConfirmDescription": "Es-tu sûr de vouloir supprimer cette intégration ? Cette action est irréversible.",
-        "deleteIntegration": "Supprimer l'intégration"
+        "deleteConfirmTitle": "Supprimer la connexion",
+        "deleteConfirmDescription": "Cela supprime les identifiants enregistrés et déconnecte l'intégration. Le modèle est conservé — pour te reconnecter, saisis à nouveau tes identifiants.",
+        "deleteInstanceConfirmTitle": "Supprimer cette instance",
+        "deleteInstanceConfirmDescription": "Cela supprime définitivement cette intégration et toutes les automatisations configurées pour elle. Cette action est irréversible.",
+        "deleteIntegration": "Supprimer la connexion"
       },
       "authMethods": {
         "api_key": "Clé API",


### PR DESCRIPTION
> **Stacked** on #2870 → #2869 → #2865. Review the top commit.

## Why

#2870 can create instances with no way to remove one. The panel's only destructive action removes the stored credential and leaves the config dir and the cloned automations behind, so an unwanted copy stays in the list forever with its automations installed. **Do not release #2870 without this** — create-without-delete is a one-way door.

## Change

`deleteIntegrationInstance` — the inverse of duplicate. In reverse creation order it uninstalls the automations bound to the instance, deletes its credential, and removes its config dir.

It **refuses a built-in template** outright: deleting one would take the seeded template dir with it, so a builtin is only ever disconnected. Deletability is independent of connection state — a duplicate that was never connected is just as removable as one that was connected and then disconnected, which matters because an unconfigured duplicate is exactly the one you want to get rid of.

## Copy

The panel routes its delete confirm by instance kind, so the two outcomes read differently instead of sharing one vague warning:

| | Title | What it says |
|---|---|---|
| builtin | Remove connection | the stored login is removed, the template stays, you can reconnect |
| instance | Delete this instance | the integration and its automations are permanently gone |

The builtin action is renamed **Remove connection** — the old "Delete integration" implied the template disappeared too, which was never true.

A removable instance also gets Delete in its **disconnected** footer, so an unconfigured duplicate can be removed without connecting it first.

`isDeleting` now feeds `busy`, so both teardowns hold the dialog open in its loading state until they resolve rather than looking like a no-op.

## Tests

`file_actions.test.ts` — rejects a plain member before any teardown, refuses a built-in template (disconnect only), and fully deletes a non-builtin instance that was never connected (automations + credential + dir). UI — Delete appears in the disconnected footer for a removable instance and opens the confirm.

447 tests pass across the integrations UI, convex integrations/automations and i18n suites. Gate: `tsc` clean, `oxlint --type-aware` 0/0, `oxfmt --check` clean, docs suite 194 pass. Docs updated in en/de/fr.

## Known gap

No audit-log entry. This matches its siblings (`installIntegration`/`uninstallIntegration` don't audit either), but it is a genuinely irreversible action, so auditing it is worth a follow-up — the repo already has the path (`emitAuditSuccess` / internal `createAuditLog`).