### PR TITLE
feat(platform): reconnect an integration without re-entering credentials

### DIFF
--- a/docs/de/platform/admin/integrations.md
+++ b/docs/de/platform/admin/integrations.md
@@ -46,7 +46,11 @@ Beide Hebel werden zur Anfrage-Zeit erzwungen, nicht zur Installations-Zeit — 
 
 ## Eine Integration widerrufen
 
-Klick auf die Zeile, dann auf **Trennen**. Eine getrennte Integration hört sofort auf zu authentifizieren; Agents und Workflows, die von ihr abhängen, melden beim nächsten Aufruf einen Konfigurationsfehler. Die Zeile bleibt mit einem Getrennt-Badge in der Liste, damit der Audit-Pfad überlebt. Erneutes Verbinden geht den Anmelde-Fluss von Grund auf neu.
+Klick auf die Zeile, dann auf **Trennen**. Eine getrennte Integration hört sofort auf zu authentifizieren; Agents und Workflows, die von ihr abhängen, melden beim nächsten Aufruf einen Konfigurationsfehler. Die Zeile bleibt mit einem Getrennt-Badge in der Liste, damit der Audit-Pfad überlebt.
+
+Beim Trennen bleibt die gespeicherte Anmeldung erhalten, deshalb bietet die Zeile **Neu verbinden** an — ein Klick, kein erneutes Eintippen. Tale prüft die gespeicherten Anmeldedaten zuerst und markiert die Integration nur dann als verbunden, wenn sie noch funktionieren; wurde das Passwort oder der Schlüssel in der Zwischenzeit geändert, scheitert die Prüfung und die Zeile bleibt getrennt — eine veraltete Anmeldung sieht also nie gesund aus. Über **Andere Anmeldedaten verwenden** trägst du stattdessen eine neue Anmeldung ein. OAuth-Integrationen verbinden sich über den Zustimmungsdialog des Anbieters neu, denn eine widerrufene Freigabe lässt sich nur durch erneutes Autorisieren wiederherstellen. Beim Neuverbinden werden außerdem die beim Trennen deaktivierten Agents wieder aktiv und die an die Integration gebundenen Automatisierungen laufen weiter.
+
+**Verbindung entfernen** geht weiter als Trennen: die gespeicherte Anmeldung wird vollständig gelöscht. Die Vorlage der Integration bleibt im Katalog, du kannst sie also später erneut mit neuen Anmeldedaten verbinden.
 
 ## Zwei Instanzen derselben Integration betreiben
 

--- a/docs/en/platform/admin/integrations.md
+++ b/docs/en/platform/admin/integrations.md
@@ -46,7 +46,11 @@ Both levers are enforced at request time, not at install time — changing a lev
 
 ## Revoking an integration
 
-Click the row, then **Disconnect**. A disconnected integration stops authenticating immediately; agents and workflows that depend on it surface a configuration error on the next call. The row stays in the list with a disconnected badge so the audit trail survives. Reconnecting walks the credential flow again from scratch.
+Click the row, then **Disconnect**. A disconnected integration stops authenticating immediately; agents and workflows that depend on it surface a configuration error on the next call. The row stays in the list with a disconnected badge so the audit trail survives.
+
+Disconnecting keeps the stored login, so the row offers **Reconnect** — one click, no re-typing. Tale tests the saved credential first and only marks the integration connected if it still works; if the password or key changed while it was down, the test fails and the row stays disconnected, so a stale login never looks healthy. Use **Use different credentials** to enter a new login instead. OAuth integrations reconnect through the provider's consent screen, since a revoked grant can only be restored by authorizing again. Reconnecting also restores the agents the disconnect disabled and resumes the automations bound to the integration.
+
+**Remove connection** goes further than Disconnect: it deletes the stored login entirely. The integration template stays in the catalog, so you can connect it again later by entering credentials.
 
 ## Running two of the same integration
 

--- a/docs/fr/platform/admin/integrations.md
+++ b/docs/fr/platform/admin/integrations.md
@@ -46,7 +46,11 @@ Les deux leviers sont appliqués à la requête, pas à l’installation — cha
 
 ## Révoquer une intégration
 
-Clique la ligne, puis **Déconnecter**. Une intégration déconnectée arrête d’authentifier immédiatement ; les agents et workflows qui en dépendent font remonter une erreur de configuration au prochain appel. La ligne reste dans la liste avec un badge déconnecté pour que la piste d’audit survive. Reconnecter parcourt le flux d’identifiants de zéro.
+Clique la ligne, puis **Déconnecter**. Une intégration déconnectée arrête d’authentifier immédiatement ; les agents et workflows qui en dépendent font remonter une erreur de configuration au prochain appel. La ligne reste dans la liste avec un badge déconnecté pour que la piste d’audit survive.
+
+Déconnecter conserve l’identifiant enregistré : la ligne propose donc **Reconnecter** — un clic, rien à retaper. Tale teste d’abord l’identifiant enregistré et ne marque l’intégration comme connectée que s’il fonctionne toujours ; si le mot de passe ou la clé a changé entre-temps, le test échoue et la ligne reste déconnectée — un identifiant périmé n’a donc jamais l’air sain. **Utiliser d’autres identifiants** permet d’en saisir un nouveau à la place. Les intégrations OAuth se reconnectent via l’écran de consentement du fournisseur, car une autorisation révoquée ne se rétablit qu’en autorisant à nouveau. Reconnecter réactive aussi les agents que la déconnexion avait désactivés et relance les automatisations liées à l’intégration.
+
+**Retirer la connexion** va plus loin que Déconnecter : l’identifiant enregistré est supprimé. Le modèle de l’intégration reste au catalogue, tu peux donc la reconnecter plus tard en saisissant de nouveaux identifiants.
 
 ## Faire tourner deux fois la même intégration
 

--- a/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
@@ -351,3 +351,76 @@ describe('IntegrationPanel — delete a disconnected removable instance', () => 
     expect(setConfirmDelete).toHaveBeenCalledWith(true);
   });
 });
+
+describe('IntegrationPanel — disconnected with a saved login', () => {
+  it('shows Reconnect + the saved identity instead of a blank form', () => {
+    const handleReconnect = vi.fn();
+    vi.mocked(useIntegrationManage).mockImplementation(
+      () => ({ ...baseManage, isActive: false, handleReconnect }) as never,
+    );
+    render(
+      <IntegrationPanel
+        open
+        onOpenChange={vi.fn()}
+        integration={
+          {
+            ...integration,
+            isActive: false,
+            basicAuth: { username: 'hello@support.example.com' },
+          } as Parameters<typeof IntegrationPanel>[0]['integration']
+        }
+        organizationId="org-1"
+      />,
+    );
+    const sheet = screen.getByTestId('sheet');
+    // The retained login is shown, not hidden behind a blank re-entry form.
+    expect(
+      within(sheet).getByText('hello@support.example.com'),
+    ).toBeInTheDocument();
+    // One-click Reconnect, not a "Connect" that implies re-entering everything.
+    fireEvent.click(within(sheet).getByRole('button', { name: 'Reconnect' }));
+    expect(handleReconnect).toHaveBeenCalledOnce();
+    expect(
+      within(sheet).queryByRole('button', { name: 'Connect' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reconnects an OAuth2 integration via the authorize round-trip, not a flag flip', () => {
+    // A grant revoked at the provider can't be revived by re-activating a stored
+    // token, so Reconnect must route to reauthorize for oauth2 — the same branch
+    // the Connect button takes.
+    const handleReconnect = vi.fn();
+    const handleReauthorize = vi.fn();
+    vi.mocked(useIntegrationManage).mockImplementation(
+      () =>
+        ({
+          ...baseManage,
+          isActive: false,
+          selectedAuthMethod: 'oauth2',
+          hasOAuth2Config: true,
+          hasOAuth2Credentials: true,
+          handleReconnect,
+          handleReauthorize,
+        }) as never,
+    );
+    render(
+      <IntegrationPanel
+        open
+        onOpenChange={vi.fn()}
+        integration={
+          {
+            ...integration,
+            isActive: false,
+            authMethod: 'oauth2',
+            oauth2Auth: { accessTokenEncrypted: 'x' },
+          } as Parameters<typeof IntegrationPanel>[0]['integration']
+        }
+        organizationId="org-1"
+      />,
+    );
+    const sheet = screen.getByTestId('sheet');
+    fireEvent.click(within(sheet).getByRole('button', { name: 'Reconnect' }));
+    expect(handleReauthorize).toHaveBeenCalledOnce();
+    expect(handleReconnect).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/settings/integrations/components/integration-panel.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { BorderedSection } from '@tale/ui/bordered-section';
 import { Button } from '@tale/ui/button';
 import { IconButton } from '@tale/ui/icon-button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useAction } from 'convex/react';
-import { Copy, Download, Loader2, Trash2, X } from 'lucide-react';
+import { Copy, Download, Loader2, Plug, Trash2, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -138,6 +139,27 @@ export function IntegrationPanel({
       ? integration.connectionConfig.apiEndpoint
       : undefined);
 
+  // A disconnected integration that still has stored credentials shows a
+  // "saved login" view (identity + one-click Reconnect) instead of a blank
+  // form; re-entering is opt-in via "use different credentials". A
+  // never-connected instance (a fresh duplicate) has no stored login → form.
+  const hasSavedLogin = Boolean(
+    integration.basicAuth?.username ||
+    integration.apiKeyAuth ||
+    integration.oauth2Auth,
+  );
+  const [editingCredentials, setEditingCredentials] = useState(false);
+  const showSavedLogin = hasSavedLogin && !editingCredentials;
+
+  // This integration connects by the OAuth2 authorize round-trip rather than by
+  // testing stored credentials. Shared by Connect AND Reconnect so both agree:
+  // a grant revoked at the provider can't be revived by flipping a flag, so
+  // reconnect must re-authorize, not re-activate.
+  const connectViaOAuth2 =
+    manage.selectedAuthMethod === 'oauth2' &&
+    manage.hasOAuth2Config &&
+    manage.hasOAuth2Credentials;
+
   // Footer secondary actions (Export, Duplicate) — at most two, so they render
   // inline. A popup for one or two items is more friction than it saves; if a
   // third ever lands, collapse them then.
@@ -263,6 +285,28 @@ export function IntegrationPanel({
                 />
               )}
             </Stack>
+          ) : showSavedLogin ? (
+            <Stack gap={3}>
+              <BorderedSection>
+                <Text variant="label">
+                  {t('integrations.manageDialog.authentication')}
+                </Text>
+                <Text variant="muted" className="text-sm">
+                  {t('integrations.panel.savedLoginHint')}
+                </Text>
+                {identity ? <Text variant="code">{identity}</Text> : null}
+              </BorderedSection>
+              <HStack justify="end" align="center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setEditingCredentials(true)}
+                  disabled={manage.busy}
+                >
+                  {t('integrations.panel.useDifferentCredentials')}
+                </Button>
+              </HStack>
+            </Stack>
           ) : (
             <IntegrationCredentialsFormConnected
               integration={integration}
@@ -328,48 +372,55 @@ export function IntegrationPanel({
                 {tCommon('actions.delete')}
               </Button>
             ) : null}
-            <Button
-              onClick={
-                manage.selectedAuthMethod === 'oauth2' &&
-                manage.hasOAuth2Config &&
-                manage.hasOAuth2Credentials
-                  ? manage.handleReauthorize
-                  : manage.handleTestConnection
-              }
-              disabled={
-                manage.busy ||
-                (manage.selectedAuthMethod === 'oauth2' &&
-                manage.hasOAuth2Config &&
-                manage.hasOAuth2Credentials
-                  ? false
-                  : !manage.hasChanges)
-              }
-              disabledReason={
-                !manage.busy &&
-                !(
-                  manage.selectedAuthMethod === 'oauth2' &&
-                  manage.hasOAuth2Config &&
-                  manage.hasOAuth2Credentials
-                ) &&
-                !manage.hasChanges
-                  ? manage.selectedAuthMethod === 'oauth2' &&
-                    manage.hasOAuth2Config
-                    ? t('integrations.panel.saveCredentialsThenConnect')
-                    : t('integrations.panel.enterCredentialsToConnect')
-                  : undefined
-              }
-            >
-              {manage.isTesting || manage.isSavingOAuth2 ? (
-                <>
+            {showSavedLogin ? (
+              <Button
+                type="button"
+                onClick={
+                  connectViaOAuth2
+                    ? manage.handleReauthorize
+                    : () => void manage.handleReconnect()
+                }
+                disabled={manage.busy}
+              >
+                {manage.isSubmitting || manage.isSavingOAuth2 ? (
                   <Loader2 className="mr-2 size-4 animate-spin" />
-                  {t('integrations.manageDialog.connecting')}
-                </>
-              ) : (
-                t('integrations.panel.connectName', {
-                  name: integration.title,
-                })
-              )}
-            </Button>
+                ) : (
+                  <Plug className="mr-2 size-4" />
+                )}
+                {t('integrations.panel.reconnect')}
+              </Button>
+            ) : (
+              <Button
+                onClick={
+                  connectViaOAuth2
+                    ? manage.handleReauthorize
+                    : manage.handleTestConnection
+                }
+                disabled={
+                  manage.busy || (connectViaOAuth2 ? false : !manage.hasChanges)
+                }
+                disabledReason={
+                  !manage.busy && !connectViaOAuth2 && !manage.hasChanges
+                    ? manage.selectedAuthMethod === 'oauth2' &&
+                      manage.hasOAuth2Config
+                      ? t('integrations.panel.saveCredentialsThenConnect')
+                      : t('integrations.panel.enterCredentialsToConnect')
+                    : undefined
+                }
+              >
+                {manage.isTesting || manage.isSavingOAuth2 ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    {t('integrations.manageDialog.connecting')}
+                  </>
+                ) : (
+                  <>
+                    <Plug className="mr-2 size-4" />
+                    {t('integrations.panel.connect')}
+                  </>
+                )}
+              </Button>
+            )}
           </HStack>
         )}
       </div>

--- a/services/platform/app/features/settings/integrations/hooks/use-integration-manage-reconnect.test.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-integration-manage-reconnect.test.ts
@@ -1,0 +1,120 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `handleReconnect` reactivates a disconnected integration from its RETAINED
+ * credentials. It must TEST before it activates: a credential can rot while
+ * disconnected (the mailbox password changed, the API key was rotated), and
+ * activating on faith would flip the badge to Connected while every sync fails
+ * silently — the worst failure mode here, because nothing surfaces it.
+ */
+
+const mockTestConnection = vi.fn();
+const mockUpdateCredentials = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('convex/react', () => ({ useAction: () => vi.fn() }));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: { integrations: { file_actions: {} } },
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('./actions', () => ({
+  useTestIntegration: () => ({
+    mutateAsync: mockTestConnection,
+    isPending: false,
+  }),
+  useGenerateIntegrationOAuth2Url: () => ({ mutateAsync: vi.fn() }),
+  useSaveOAuth2Credentials: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('./mutations', () => ({
+  useUpdateCredentials: () => ({ mutateAsync: mockUpdateCredentials }),
+  useGenerateUploadUrl: () => ({ mutateAsync: vi.fn() }),
+}));
+
+const { useIntegrationManage } = await import('./use-integration-manage');
+
+const integration = {
+  _id: 'cred-1',
+  title: 'Support mailbox',
+  name: 'imap_smtp-2',
+  organizationId: 'org-1',
+  authMethod: 'basic_auth',
+  isActive: false,
+  basicAuth: { username: 'hello@support.example.com' },
+} as Parameters<typeof useIntegrationManage>[0];
+
+function renderManage() {
+  return renderHook(() =>
+    useIntegrationManage(integration, vi.fn(), true, 'org-1'),
+  );
+}
+
+describe('useIntegrationManage — handleReconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('activates the credential once the retained login tests clean', async () => {
+    mockTestConnection.mockResolvedValue({ success: true });
+    const { result } = renderManage();
+
+    await act(async () => {
+      await result.current.handleReconnect();
+    });
+
+    expect(mockTestConnection).toHaveBeenCalledWith({ credentialId: 'cred-1' });
+    expect(mockUpdateCredentials).toHaveBeenCalledWith({
+      credentialId: 'cred-1',
+      isActive: true,
+      status: 'active',
+    });
+  });
+
+  it('does NOT activate when the retained login no longer works', async () => {
+    mockTestConnection.mockResolvedValue({
+      success: false,
+      message: 'Invalid credentials',
+    });
+    const { result } = renderManage();
+
+    await act(async () => {
+      await result.current.handleReconnect();
+    });
+
+    expect(mockUpdateCredentials).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        description: 'Invalid credentials',
+      }),
+    );
+  });
+
+  it('does NOT activate when the test itself throws', async () => {
+    mockTestConnection.mockRejectedValue(new Error('network down'));
+    const { result } = renderManage();
+
+    await act(async () => {
+      await result.current.handleReconnect();
+    });
+
+    expect(mockUpdateCredentials).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' }),
+    );
+  });
+});

--- a/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
@@ -855,6 +855,46 @@ export function useIntegrationManage(
     }
   }, [updateCredentials, integration, t]);
 
+  // Reactivate a disconnected integration using its RETAINED credentials — the
+  // one-click inverse of handleDisconnect, no re-entry needed.
+  //
+  // TESTS FIRST, then activates. A credential can rot while disconnected (the
+  // mailbox password changed, the API key was rotated), and activating on faith
+  // would flip the badge to Connected while every sync fails silently — the
+  // same success gate `handleTestConnection` applies to the Connect path.
+  // OAuth2 reconnect is NOT this handler: a revoked grant needs the authorize
+  // round-trip (`handleReauthorize`), which the panel routes to instead.
+  const handleReconnect = useCallback(async () => {
+    setIsSubmitting(true);
+    try {
+      const result = await testConnection({
+        credentialId: toId<'integrationCredentials'>(integration._id),
+      });
+      if (!result.success) {
+        toast({
+          title: t('integrations.toast.reconnectFailed'),
+          description: result.message ?? t('integrations.connectionTestFailed'),
+          variant: 'destructive',
+        });
+        return;
+      }
+      await updateCredentials({
+        credentialId: toId<'integrationCredentials'>(integration._id),
+        isActive: true,
+        status: 'active',
+      });
+      setOptimisticActive(true);
+    } catch (error) {
+      toast({
+        title: t('integrations.toast.reconnectFailed'),
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [testConnection, updateCredentials, integration, t]);
+
   const handleSaveOAuth2Only = useCallback(async () => {
     if (
       !oauth2Fields.authorizationUrl.trim() ||
@@ -1071,6 +1111,7 @@ export function useIntegrationManage(
     setTestResult,
     handleTestConnection,
     handleDisconnect,
+    handleReconnect,
     handleReauthorize,
     prepareOAuth2Url,
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6152,7 +6152,8 @@
       },
       "toast": {
         "disconnected": "Getrennt",
-        "disconnectFailed": "Trennung fehlgeschlagen"
+        "disconnectFailed": "Trennung fehlgeschlagen",
+        "reconnectFailed": "Neuverbindung fehlgeschlagen"
       },
       "connectionSuccessful": "Verbindung",
       "connectionTestFailed": "Verbindungstest fehlgeschlagen",
@@ -6268,6 +6269,10 @@
         "newCodeLines": "{count} Codezeilen"
       },
       "panel": {
+        "connect": "Verbinden",
+        "reconnect": "Neu verbinden",
+        "savedLoginHint": "Du bist getrennt – deine gespeicherten Zugangsdaten bleiben erhalten. Verbinde neu oder verwende andere Zugangsdaten.",
+        "useDifferentCredentials": "Andere Zugangsdaten verwenden",
         "connectName": "{name} verbinden",
         "saveCredentialsThenConnect": "Speichere oben die Zugangsdaten, dann verbinde.",
         "enterCredentialsToConnect": "Gib Zugangsdaten ein, um zu verbinden.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6451,7 +6451,8 @@
       },
       "toast": {
         "disconnected": "Disconnected",
-        "disconnectFailed": "Disconnect failed"
+        "disconnectFailed": "Disconnect failed",
+        "reconnectFailed": "Reconnect failed"
       },
       "connectionSuccessful": "Connection successful",
       "connectionTestFailed": "Connection test failed",
@@ -6567,6 +6568,10 @@
         "newCodeLines": "{count} lines of code"
       },
       "panel": {
+        "connect": "Connect",
+        "reconnect": "Reconnect",
+        "savedLoginHint": "You're disconnected — your saved login is kept. Reconnect, or use different credentials.",
+        "useDifferentCredentials": "Use different credentials",
         "connectName": "Connect {name}",
         "saveCredentialsThenConnect": "Save credentials above, then connect.",
         "enterCredentialsToConnect": "Enter credentials to connect.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6152,7 +6152,8 @@
       },
       "toast": {
         "disconnected": "Déconnectée",
-        "disconnectFailed": "Échec de la déconnexion"
+        "disconnectFailed": "Échec de la déconnexion",
+        "reconnectFailed": "Échec de la reconnexion"
       },
       "connectionSuccessful": "Connexion réussie",
       "connectionTestFailed": "Échec du test de connexion",
@@ -6268,6 +6269,10 @@
         "newCodeLines": "{count} lignes de code"
       },
       "panel": {
+        "connect": "Connecter",
+        "reconnect": "Reconnecter",
+        "savedLoginHint": "Tu es déconnecté — tes identifiants enregistrés sont conservés. Reconnecte-toi ou utilise d'autres identifiants.",
+        "useDifferentCredentials": "Utiliser d'autres identifiants",
         "connectName": "Connecter {name}",
         "saveCredentialsThenConnect": "Enregistre les identifiants ci-dessus, puis connecte.",
         "enterCredentialsToConnect": "Saisis des identifiants pour connecter.",

--- a/services/platform/tests/e2e/specs/integrations.spec.ts
+++ b/services/platform/tests/e2e/specs/integrations.spec.ts
@@ -40,15 +40,14 @@ function integrationCard(page: Page, title: string) {
   return page.getByRole('button', { name: title, exact: true });
 }
 
-function connectButton(page: Page, title: string) {
-  // `connectName` is "Connect {name}"; the e2e i18n resolver does not
-  // interpolate, so substitute the (config-derived) title ourselves.
-  const label = t('settings.integrations.panel.connectName').replace(
-    '{name}',
-    title,
-  );
+function connectButton(page: Page) {
+  // The settings panel's primary action is a bare "Connect" — the sheet is
+  // already titled with the integration name, so the button doesn't repeat it.
   return page
-    .getByRole('button', { name: label, exact: true })
+    .getByRole('button', {
+      name: t('settings.integrations.panel.connect'),
+      exact: true,
+    })
     .filter({ visible: true });
 }
 
@@ -109,7 +108,7 @@ async function connectAndVerify(
   await expect(field).toBeVisible({ timeout: TIMEOUT.VISIBLE });
   await field.fill(opts.token);
 
-  const connect = connectButton(page, opts.title);
+  const connect = connectButton(page);
   await expect(connect).toBeEnabled({ timeout: TIMEOUT.VISIBLE });
   await connect.click();
 


### PR DESCRIPTION
> **Stacked** on #2871 → #2870 → #2869 → #2865. Review the top commit.

## Problem

A disconnected integration keeps its stored credentials — but there was no way to use them. The panel showed a blank credentials form, and the Connect button was **disabled** until something changed (`!hasChanges`). So reconnecting meant re-typing a password Tale already had. The docs described exactly that: *"Reconnecting walks the credential flow again from scratch."*

## Change

**A saved-login view** when credentials are stored: the identity that distinguishes this instance, plus a one-click **Reconnect**. Re-entering is opt-in via **Use different credentials**. A never-connected instance (a fresh duplicate) has no stored login, so it still gets the form.

**Reconnect tests before it activates.** A credential can rot while disconnected — the mailbox password changed, the API key was rotated. Activating on faith would flip the badge to Connected while every sync failed silently, which is the one failure mode nothing else surfaces. On a failed test the instance stays disconnected and the reason is toasted. This is the same success gate `handleTestConnection` already applies to the Connect path.

**OAuth2 doesn't reconnect by flag flip.** A grant revoked at the provider can only be restored by authorizing again, so Reconnect routes to `handleReauthorize` there. That branch is now derived once as `connectViaOAuth2` and shared with the Connect button, which previously spelled the same three-term condition out three times (onClick, disabled, disabledReason).

**"Connect" instead of "Connect {name}."** The sheet is already titled with the integration name; repeating it made the button the widest element in the footer.

## Tests

`use-integration-manage-reconnect.test.ts` (new) pins the gate at the hook level:

- activates once the retained login tests clean
- does **not** activate when the login no longer works, and toasts the reason
- does **not** activate when the test itself throws

`integration-panel.test.tsx` — the saved identity + Reconnect render instead of a blank form (and no "Connect" button), and an OAuth2 instance routes Reconnect to reauthorize rather than `handleReconnect`.

164 tests pass across the integrations UI + i18n suites. Gate: `tsc` clean, `oxlint --type-aware` 0/0, `oxfmt --check` clean, docs suite 194 pass.

## Docs

The "Revoking an integration" section's claim that reconnecting starts from scratch is now false — replaced in en/de/fr with what actually happens, including the test-before-connect behaviour and the OAuth exception.