### PR TITLE
fix(platform): place product toasts at the outer top-right

### DIFF
--- a/services/platform/app/components/ui/feedback/toaster.test.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.test.tsx
@@ -37,15 +37,13 @@ describe('Toaster', () => {
     expect(viewport?.textContent).toContain('Update available');
   });
 
-  // Regression (#1986): the viewport must clear the top header band, not sit
-  // flush against the top edge. A right-anchored Sheet's header lands in the
-  // top-right corner — the same spot as the toast — so a flush toast covered
-  // the panel title. The `4rem` top padding drops the first toast below that
-  // header band.
-  it('offsets the viewport below the top header band', () => {
+  // Regression (#2803): product toasts belong at the outer top-right, with the
+  // same outer gutter as the side edges and only the safe-area inset added on
+  // top.
+  it('anchors the viewport at the outer top-right gutter', () => {
     render(<Toaster />);
 
     const viewport = document.body.querySelector('ol');
-    expect(viewport?.className).toContain('pt-[calc(4rem+var(--safe-top))]');
+    expect(viewport?.className).toContain('pt-[calc(0.75rem+var(--safe-top))]');
   });
 });

--- a/services/platform/app/components/ui/feedback/toaster.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.tsx
@@ -128,17 +128,12 @@ export function Toaster() {
                 // toast Root re-enables `pointer-events-auto`, so toasts stay
                 // interactive (close / swipe) while the gaps click through.
                 //
-                // `pt-[calc(4rem+…)]` drops the first toast below the top header
-                // band instead of flush against the top edge. The desktop app
-                // header (`h-13`) sits top-left, but a right-anchored Sheet's
-                // header lands top-right — the same corner as the viewport — so a
-                // toast at the very top covered the panel title (issue #1986).
-                // 4rem = the `h-13` header (3.25rem) + the prior 0.75rem gap, and
-                // it also clears a Sheet's taller ~3.5rem header. The offset is
-                // padding INSIDE the `top-0`/`max-h-screen` box, so the stack
-                // still fits the viewport and the cleared strip stays
-                // `pointer-events-none` (controls under it remain clickable).
-                'pointer-events-none fixed z-100 flex max-h-screen w-auto max-w-sm min-w-[18.75rem] flex-col p-3 pt-[calc(4rem+var(--safe-top))] pr-[calc(0.75rem+var(--safe-right))] pl-[calc(0.75rem+var(--safe-left))]',
+                // Product toasts live at the OUTER top-right of the viewport,
+                // safe-area aware but not dropped into the app/sheet header band.
+                // The viewport already portals to <body> at z-100 above sheets
+                // and dialogs, so clickability does not rely on an inward offset.
+                // Keep the same 0.75rem outer gutter on every edge.
+                'pointer-events-none fixed z-100 flex max-h-screen w-auto max-w-sm min-w-[18.75rem] flex-col p-3 pt-[calc(0.75rem+var(--safe-top))] pr-[calc(0.75rem+var(--safe-right))] pl-[calc(0.75rem+var(--safe-left))]',
                 viewportPositionClasses[position],
               )}
             />,


### PR DESCRIPTION
## Summary
- Product toasts (including changelog “update available”) now sit at the **outer top-right**, using `0.75rem` + safe-area padding instead of the old `4rem` header-clearing offset that pushed them into the mid-header band ([#2803](https://github.com/tale-project/tale/issues/2803)).
- Body portal + `z-100` unchanged so toasts still paint above sheets/dialogs.
- Auth `top-center` toasts left as an intentional exception.

## Test plan
- [x] `toaster.test.tsx` asserts `pt-[calc(0.75rem+var(--safe-top))]`
- [ ] Dashboard: trigger changelog “update available” — toast at outer top-right
- [ ] Open a settings sheet; fire a save toast — still clickable above chrome
- [ ] Spot-check auth login toast still top-center

## Definition of done
- [x] Green gate — focused toaster tests
- [x] Tests — regression for viewport padding class
- [x] Migration — N/A
- [x] Locales — N/A (no new strings)
- [x] Docs — N/A
- [x] Accessibility — N/A (placement only)
- [x] Sweep — toaster viewport only; auth top-center left alone
- [ ] Observed — visual spot-check pending in browser
- [x] Commits — one focused fix on a branch off `main`


Made with [Cursor](https://cursor.com)