### PR TITLE
docs(platform): genericize VAT-flavored comments in task plumbing

### DIFF
--- a/services/platform/app/features/tasks/components/task-input-files.tsx
+++ b/services/platform/app/features/tasks/components/task-input-files.tsx
@@ -49,7 +49,7 @@ import { FileOpenButton } from './file-open-button';
 
 /**
  * Names listed before the "+N more" toggle. A few, deliberately: every file owns
- * a line, and a quarter's folder runs to two dozen, so a preview that showed
+ * a line, and a busy folder runs to two dozen, so a preview that showed
  * eight pushed the deliverables below the fold to list working material.
  */
 const MAX_LISTED = 5;

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -321,7 +321,7 @@ function matchesNaming(naming: string, value: string): boolean {
 }
 
 /**
- * The one-field template create: the subject's natural key (e.g. a quarter
+ * The one-field template create: the subject's natural key (e.g. a period
  * folder name) is the only input — the contract derives the title, provisions
  * the bound input folder, and stamps the automation as owner. The run itself
  * starts later, through the status choreography.
@@ -628,7 +628,7 @@ function CreateTaskBody({
   const { t } = useT('tasks');
   const { t: tCommon } = useT('common');
   const createTask = useCreateTask();
-  // Subject templates ("new quarter"): contracts with `create.enabled` offer
+  // Subject templates: contracts with `create.enabled` offer one chip each;
   // a one-field create beside the blank form.
   const templates = useTaskSubjectTemplates(organizationId, projectId);
   const [templateSlug, setTemplateSlug] = useState<string | null>(null);

--- a/services/platform/app/features/tasks/lib/folder-files.ts
+++ b/services/platform/app/features/tasks/lib/folder-files.ts
@@ -4,7 +4,7 @@
  * An automation-owned task bound to a folder reads its input from that folder
  * AND writes into it (`document.create`), so the folder holds the operator's
  * uploads, the run's working material and the run's deliverables side by side.
- * One flat list is what made a quarter with three deliverables read as 27 input
+ * One flat list is what made a folder with three deliverables read as 27 input
  * files.
  *
  * ONE rule splits it: the promoted set is the Outcome, the rest is Files.
@@ -34,8 +34,8 @@ export function isProducedByRun(file: FolderFileLike): boolean {
 
 /**
  * Does a declared deliverable name this file? Exact match unless the pattern
- * carries `*`/`?`, so a name whose run derives it (`return-2026Q1.xml`) can be
- * declared as `return-*.xml`. Everything else in the pattern is literal — a
+ * carries `*`/`?`, so a name whose run derives it (`report-2026-03.xml`) can be
+ * declared as `report-*.xml`. Everything else in the pattern is literal — a
  * dot in a file name must not read as "any character".
  */
 export function matchesPattern(name: string, pattern: string): boolean {
@@ -64,7 +64,7 @@ export interface OutcomeSlot<T> {
  * first.
  *
  * The zone shows a few names and hides the tail behind "+N more", so which few
- * decides whether it is useful. A quarter's folder holds a handful of uploaded
+ * decides whether it is useful. A bound folder holds a handful of uploaded
  * documents and one derived artifact per document, all newer — in raw folder
  * order the preview is therefore nothing but `.ocr.json` sidecars, while the
  * questions a reader has about the INPUT zone ("did my upload land? what is

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -290,7 +290,7 @@ async function collectFolderFacts(
       continue; // orphaned: folder deleted or not in this project.
     }
     existingFolders.add(folderId);
-    // A small bounded page is enough to answer "any active file?" — quarter
+    // A small bounded page is enough to answer "any active file?" — subject
     // folders hold at most a handful; a trashed doc must not count, so the
     // active check runs in JS (`lifecycleStatus`), not a fragile arg-filter.
     const docs = await ctx.db
@@ -466,7 +466,7 @@ export const listTasksByProjectPaginated = query({
     );
     // Stamp, per the task's external FOLDER, two signals a folder-driven view
     // gates row actions on: `folderExists` (the bound folder is still there —
-    // a deleted quarter leaves an orphaned return the desk marks and lets you
+    // a deleted folder leaves an orphaned subject the desk marks and lets you
     // remove) and `hasFiles` (it holds ≥1 active file — hide Start until
     // documents are uploaded).
     const { existingFolders, foldersWithFiles } = await collectFolderFacts(

--- a/services/platform/lib/shared/schemas/automation_presentation.ts
+++ b/services/platform/lib/shared/schemas/automation_presentation.ts
@@ -2,9 +2,9 @@
  * How an automation NAMES ITSELF to people — the display half of a pack
  * manifest, versioned with the document so every surface reads the same thing.
  *
- * The slug is addressing, not a label: `vat-return-desk` is how the store,
- * the run log and the pack directory refer to the automation, and showing it in
- * a dialog title or a task panel leaks that addressing at the reader. Packs
+ * The slug is addressing, not a label: `payroll-desk` is how the store, the
+ * run log and the pack directory refer to the automation, and showing it in a
+ * dialog title or a task panel leaks that addressing at the reader. Packs
  * already declare a real name and its translations (`automation.yml`: `name`,
  * `description`, `icon`, `labels`, `i18n.<locale>`), which the install used to
  * drop on the floor; this is the shape that carries it through.

--- a/services/platform/lib/shared/schemas/automation_settings.ts
+++ b/services/platform/lib/shared/schemas/automation_settings.ts
@@ -76,7 +76,7 @@ export const settingsFieldSchema = z
      * client-side validation (`boolean` stores 'true'/'false'). */
     type: z.enum(['text', 'number', 'boolean', 'select']),
     required: z.boolean().optional(),
-    /** Anchored regex a `text` value must match (e.g. a VAT-number shape). */
+    /** Anchored regex a `text` value must match (e.g. an identifier shape). */
     pattern: z.string().max(500).optional(),
     /** Prefill when the file carries no value yet, in string form. */
     default: z.string().max(500).optional(),

--- a/services/platform/lib/shared/schemas/task_contract.ts
+++ b/services/platform/lib/shared/schemas/task_contract.ts
@@ -14,7 +14,7 @@
 import { z } from 'zod/v4';
 
 /** Localizable strings of the create-flow's single input field (the
- *  subject's natural key, e.g. the quarter folder name). */
+ *  subject's natural key, e.g. a period folder name). */
 const taskSubjectFieldTextSchema = z.object({
   label: z.string().optional(),
   placeholder: z.string().optional(),
@@ -35,14 +35,14 @@ export const taskSubjectContractSchema = z.object({
     .object({
       kind: z.literal('folder'),
       /** Anchored regex the folder name must match at template-create time
-       *  (e.g. "^\\d{4}Q[1-4]$" for VAT quarters). */
+       *  (e.g. "^\\d{4}Q[1-4]$" for period folders). */
       naming: z.string().optional(),
       /** Sibling setup folder resolved into `externalUrl` on create (the
        *  desks' binding convention; create fails closed when missing). */
       setupFolderName: z.string().optional(),
     })
     .optional(),
-  /** Board-side template creation ("New quarter" from the task board). */
+  /** Board-side template creation (one chip per `create.enabled` contract). */
   create: z
     .object({
       enabled: z.boolean(),


### PR DESCRIPTION
The shared task/automation plumbing still carried VAT-desk examples in its comments and schema docstrings — "a quarter's folder", `return-2026Q1.xml`, a VAT-number regex — even though the surfaces are generic. Neutral examples (period folders, `report-*.xml`, an identifier shape) keep them honest for every desk built on the same contract.

Comment/docstring-only: no runtime strings, no behavior change.