### PR TITLE
feat(platform): guide failed RAG indexing to the embedding settings

### DIFF
--- a/services/platform/app/features/documents/components/document-preview-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.tsx
@@ -154,6 +154,7 @@ function DetailsSidebar({
                 status={doc?.ragStatus}
                 indexedAt={doc?.ragIndexedAt}
                 error={doc?.ragError}
+                errorCode={doc?.ragErrorCode}
                 documentId={doc?.id}
               />
             </SkeletonBox>

--- a/services/platform/app/features/documents/components/embedding-settings-action.tsx
+++ b/services/platform/app/features/documents/components/embedding-settings-action.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { LinkButton } from '@tale/ui/button';
+import { Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import { Settings } from 'lucide-react';
+
+import { useAbility } from '@/app/hooks/use-ability';
+import { useOrganizationId } from '@/app/hooks/use-organization-id';
+import { useT } from '@/lib/i18n/client';
+
+/**
+ * Guidance block for the failed-indexing dialog when the cause is the
+ * organization having no embedding model configured
+ * (`ragErrorCode === RAG_ERROR_EMBEDDING_NOT_CONFIGURED`): names the fix and
+ * deep-links Settings → Data residency for members who can open org settings
+ * (the same `orgSettings` gate the route itself uses), or points everyone else
+ * at an admin. Mirrors the chat error's `ProviderKeyErrorAction`.
+ */
+export function EmbeddingNotConfiguredGuidance() {
+  const { t } = useT('documents');
+  const organizationId = useOrganizationId();
+  const canOpenOrgSettings = useAbility().can('read', 'orgSettings');
+
+  return (
+    <Stack gap={2} className="mt-3">
+      <Text>{t('rag.dialog.failed.embeddingNotConfigured.hint')}</Text>
+      {canOpenOrgSettings && organizationId ? (
+        <LinkButton
+          variant="secondary"
+          size="sm"
+          icon={Settings}
+          href="/dashboard/$id/settings/data-residency"
+          params={{ id: organizationId }}
+          className="w-fit gap-1.5"
+        >
+          {t('rag.dialog.failed.embeddingNotConfigured.configureCta')}
+        </LinkButton>
+      ) : (
+        <Text variant="muted">
+          {t('rag.dialog.failed.embeddingNotConfigured.askAdmin')}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/services/platform/app/features/documents/components/rag-status-badge.test.tsx
+++ b/services/platform/app/features/documents/components/rag-status-badge.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { fireEvent, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
@@ -20,12 +21,32 @@ vi.mock('@/lib/i18n/client', () => ({
   }),
 }));
 
+type MockLinkProps = React.ComponentProps<'a'> & {
+  to?: string;
+  params?: Record<string, string>;
+  preload?: string | false;
+};
+
 vi.mock('@tanstack/react-router', () => ({
   useParams: () => ({ id: 'test-org-id' }),
+  Link: React.forwardRef<HTMLAnchorElement, MockLinkProps>(function Link(
+    { to, params: _params, preload: _preload, children, ...rest },
+    ref,
+  ) {
+    return (
+      <a ref={ref} href={to} {...rest}>
+        {children}
+      </a>
+    );
+  }),
+}));
+
+const { canMock } = vi.hoisted(() => ({
+  canMock: vi.fn((_action: string, _subject: string) => true),
 }));
 
 vi.mock('@/app/hooks/use-ability', () => ({
-  useAbility: () => ({ can: () => true }),
+  useAbility: () => ({ can: canMock }),
 }));
 
 vi.mock('@/app/hooks/use-toast', () => ({
@@ -141,6 +162,94 @@ describe('RagStatusBadge', () => {
       expect(screen.getByRole('dialog')).toHaveAccessibleDescription(
         'documents.rag.dialog.unsupported.description',
       );
+    });
+  });
+
+  // A failure caused by the org having no embedding model is fixable in
+  // Settings → Data residency, so the failed dialog must guide there instead
+  // of dead-ending on the raw error prose.
+  describe('embedding-not-configured guidance', () => {
+    afterEach(() => {
+      canMock.mockImplementation(() => true);
+    });
+
+    const openFailedDialog = () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'documents.rag.dialog.failed.title',
+        }),
+      );
+    };
+
+    it('deep-links the embedding settings for members who can open org settings', () => {
+      render(
+        <RagStatusBadge
+          status="failed"
+          error='Organization "test" has no embedding model configured…'
+          errorCode="embedding_not_configured"
+          documentId="doc-1"
+        />,
+      );
+      openFailedDialog();
+      expect(
+        screen.getByText(
+          'documents.rag.dialog.failed.embeddingNotConfigured.hint',
+        ),
+      ).toBeInTheDocument();
+      const link = screen.getByRole('link', {
+        name: 'documents.rag.dialog.failed.embeddingNotConfigured.configureCta',
+      });
+      expect(link).toHaveAttribute(
+        'href',
+        '/dashboard/$id/settings/data-residency',
+      );
+    });
+
+    it('points members without org-settings access at an admin instead', () => {
+      canMock.mockImplementation(
+        (_action: string, subject: string) => subject !== 'orgSettings',
+      );
+      render(
+        <RagStatusBadge
+          status="failed"
+          error='Organization "test" has no embedding model configured…'
+          errorCode="embedding_not_configured"
+          documentId="doc-1"
+        />,
+      );
+      openFailedDialog();
+      expect(
+        screen.getByText(
+          'documents.rag.dialog.failed.embeddingNotConfigured.askAdmin',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('renders no guidance for failures without the code', () => {
+      render(
+        <RagStatusBadge status="failed" error="boom" documentId="doc-1" />,
+      );
+      openFailedDialog();
+      expect(
+        screen.queryByText(
+          'documents.rag.dialog.failed.embeddingNotConfigured.hint',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('passes axe audit with the guidance shown', async () => {
+      render(
+        <RagStatusBadge
+          status="failed"
+          error="no embedding model"
+          errorCode="embedding_not_configured"
+          documentId="doc-1"
+        />,
+      );
+      openFailedDialog();
+      // The dialog is portaled outside the render container.
+      await checkAccessibility(document.body);
     });
   });
 });

--- a/services/platform/app/features/documents/components/rag-status-badge.tsx
+++ b/services/platform/app/features/documents/components/rag-status-badge.tsx
@@ -10,11 +10,13 @@ import { ViewDialog } from '@/app/components/ui/dialog/view-dialog';
 import { useAbility } from '@/app/hooks/use-ability';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { toast } from '@/app/hooks/use-toast';
+import { RAG_ERROR_EMBEDDING_NOT_CONFIGURED } from '@/convex/knowledge/rag_error_codes';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 import type { RagStatus } from '@/types/documents';
 
 import { useRetryRagIndexing } from '../hooks/actions';
+import { EmbeddingNotConfiguredGuidance } from './embedding-settings-action';
 
 interface RagStatusBadgeProps {
   status: RagStatus | undefined;
@@ -22,6 +24,8 @@ interface RagStatusBadgeProps {
   indexedAt?: number;
   /** Error message (for failed status) */
   error?: string;
+  /** Machine-readable failure cause (convex/knowledge/rag_error_codes) */
+  errorCode?: string;
   /** Document ID (required for retry functionality) */
   documentId?: string;
 }
@@ -42,6 +46,7 @@ export function RagStatusBadge({
   status,
   indexedAt,
   error,
+  errorCode,
   documentId,
 }: RagStatusBadgeProps) {
   const { t } = useT('documents');
@@ -200,6 +205,9 @@ export function RagStatusBadge({
             <pre className="bg-muted max-h-[200px] overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
               {error || t('rag.dialog.failed.unknownError')}
             </pre>
+            {errorCode === RAG_ERROR_EMBEDDING_NOT_CONFIGURED && (
+              <EmbeddingNotConfiguredGuidance />
+            )}
           </div>
         </ViewDialog>
         {retryButton}

--- a/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
@@ -198,6 +198,7 @@ export function useDocumentsTableConfig({
                 status={row.original.ragStatus}
                 indexedAt={row.original.ragIndexedAt}
                 error={row.original.ragError}
+                errorCode={row.original.ragErrorCode}
                 documentId={row.original.id}
               />
               {row.original.ragStatus === 'completed' &&

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-view-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-view-dialog.tsx
@@ -56,6 +56,7 @@ export function ViewKnowledgeEntryDialog({
             status={entry.ragStatus}
             indexedAt={entry.ragIndexedAt}
             error={entry.ragError}
+            errorCode={entry.ragErrorCode}
             documentId={entry.documentId ? String(entry.documentId) : undefined}
           />
         ),

--- a/services/platform/app/features/knowledge-entries/hooks/use-knowledge-entries-table-config.tsx
+++ b/services/platform/app/features/knowledge-entries/hooks/use-knowledge-entries-table-config.tsx
@@ -89,6 +89,7 @@ export function useKnowledgeEntriesTableConfig(): KnowledgeEntriesTableConfig {
             status={row.original.ragStatus}
             indexedAt={row.original.ragIndexedAt}
             error={row.original.ragError}
+            errorCode={row.original.ragErrorCode}
             documentId={
               row.original.documentId
                 ? String(row.original.documentId)

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -413,6 +413,7 @@ import type * as knowledge_file_actions from "../knowledge/file_actions.js";
 import type * as knowledge_indexing from "../knowledge/indexing.js";
 import type * as knowledge_ingest_file from "../knowledge/ingest_file.js";
 import type * as knowledge_pool from "../knowledge/pool.js";
+import type * as knowledge_rag_error_codes from "../knowledge/rag_error_codes.js";
 import type * as knowledge_recommendations from "../knowledge/recommendations.js";
 import type * as knowledge_rest_api from "../knowledge/rest_api.js";
 import type * as knowledge_search from "../knowledge/search.js";
@@ -1299,6 +1300,7 @@ declare const fullApi: ApiFromModules<{
   "knowledge/indexing": typeof knowledge_indexing;
   "knowledge/ingest_file": typeof knowledge_ingest_file;
   "knowledge/pool": typeof knowledge_pool;
+  "knowledge/rag_error_codes": typeof knowledge_rag_error_codes;
   "knowledge/recommendations": typeof knowledge_recommendations;
   "knowledge/rest_api": typeof knowledge_rest_api;
   "knowledge/search": typeof knowledge_search;

--- a/services/platform/convex/documents/get_document_rag_projection.ts
+++ b/services/platform/convex/documents/get_document_rag_projection.ts
@@ -20,6 +20,8 @@ export interface DocumentRagProjection {
   status?: 'queued' | 'running' | 'completed' | 'failed' | 'unsupported';
   indexedAt?: number;
   error?: string;
+  /** Machine-readable cause for guidable failures (knowledge/rag_error_codes). */
+  errorCode?: string;
   indexed: boolean;
 }
 
@@ -33,6 +35,7 @@ function projectFromFileMetadata(
     status: fm.ragStatus,
     indexedAt: fm.ragIndexedAt,
     error: fm.ragError,
+    errorCode: fm.ragErrorCode,
     indexed: fm.ragStatus === 'completed',
   };
 }

--- a/services/platform/convex/documents/schedule_hub_document_rag_indexing.ts
+++ b/services/platform/convex/documents/schedule_hub_document_rag_indexing.ts
@@ -67,6 +67,7 @@ export async function scheduleHubDocumentRagIndexing(
     await ctx.db.patch(fm._id, {
       ragStatus: 'queued',
       ragError: undefined,
+      ragErrorCode: undefined,
       ragProgress: undefined,
       ragParked: undefined,
       ragQueuedAt: Date.now(),

--- a/services/platform/convex/documents/transform_to_document_item.ts
+++ b/services/platform/convex/documents/transform_to_document_item.ts
@@ -125,6 +125,7 @@ export function transformToDocumentItem(
     ragStatus: ragProjection?.status,
     ragIndexedAt: ragProjection?.indexedAt,
     ragError: ragProjection?.error,
+    ragErrorCode: ragProjection?.errorCode,
     scannedPagesDetected: document.scannedPagesDetected,
     ocrApplied: document.ocrApplied,
     teamId: document.teamId ?? null,

--- a/services/platform/convex/documents/validators.ts
+++ b/services/platform/convex/documents/validators.ts
@@ -64,6 +64,7 @@ export const documentItemValidator = v.object({
   ragStatus: v.optional(ragStatusValidator),
   ragIndexedAt: v.optional(v.number()),
   ragError: v.optional(v.string()),
+  ragErrorCode: v.optional(v.string()),
   scannedPagesDetected: v.optional(v.number()),
   ocrApplied: v.optional(v.boolean()),
   teamId: v.optional(v.union(v.string(), v.null())),

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -512,6 +512,77 @@ describe('updateFileRagStatus ragError default (empty-failure guard)', () => {
   });
 });
 
+// `ragErrorCode` lives and dies with `ragError`: only a failed write may carry
+// it (it drives the failed dialog's guidance), and every other write — or a
+// failed write for a NEW cause without a code — must clear what a previous
+// failure left, so stale guidance never pins itself to fresh prose.
+describe('updateFileRagStatus ragErrorCode lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function failedRowCtx() {
+    // A row that already failed once with a guidable cause.
+    return createMockCtx({
+      _id: 'fm_1',
+      storageId: 'storage_1',
+      ragStatus: 'running',
+      ragErrorCode: 'embedding_not_configured',
+      ragQueuedAt: 1,
+    });
+  }
+
+  it('persists the code on a failed write that carries one', async () => {
+    const { ctx } = failedRowCtx();
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, {
+      storageId: 'storage_1',
+      ragStatus: 'failed',
+      ragError: 'Organization "acme" has no embedding model configured…',
+      ragErrorCode: 'embedding_not_configured',
+    });
+
+    const patchArg = ctx.db.patch.mock.calls[0][1] as {
+      ragErrorCode: string | undefined;
+    };
+    expect(patchArg.ragErrorCode).toBe('embedding_not_configured');
+  });
+
+  it('clears a stale code when a failed write names a new cause without one', async () => {
+    const { ctx } = failedRowCtx();
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, {
+      storageId: 'storage_1',
+      ragStatus: 'failed',
+      ragError: 'pool exhausted',
+    });
+
+    const patchArg = ctx.db.patch.mock.calls[0][1] as {
+      ragErrorCode: string | undefined;
+    };
+    expect('ragErrorCode' in patchArg).toBe(true);
+    expect(patchArg.ragErrorCode).toBeUndefined();
+  });
+
+  it('clears the code on a non-failed transition', async () => {
+    const { ctx } = failedRowCtx();
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, {
+      storageId: 'storage_1',
+      ragStatus: 'completed',
+      ragErrorCode: 'embedding_not_configured',
+    });
+
+    const patchArg = ctx.db.patch.mock.calls[0][1] as {
+      ragErrorCode: string | undefined;
+    };
+    expect(patchArg.ragErrorCode).toBeUndefined();
+  });
+});
+
 describe('ensureFileMetadataForDocument', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -98,11 +98,13 @@ export const saveFileMetadata = internalMutation({
       if (needsRagRetry) {
         patchData.ragStatus = 'queued';
         patchData.ragError = undefined;
+        patchData.ragErrorCode = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = now;
       } else if (shouldIndex && !scheduleRag) {
         patchData.ragStatus = 'queued';
         patchData.ragError = undefined;
+        patchData.ragErrorCode = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = now;
       } else if (isUnsupported && existing.ragStatus !== 'unsupported') {
@@ -111,6 +113,7 @@ export const saveFileMetadata = internalMutation({
         // button that can never succeed — forever).
         patchData.ragStatus = 'unsupported';
         patchData.ragError = undefined;
+        patchData.ragErrorCode = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = undefined;
       }
@@ -242,6 +245,8 @@ export const updateFileRagStatus = internalMutation({
       v.literal('unsupported'),
     ),
     ragError: v.optional(v.string()),
+    // Machine-readable cause for guidable failures (knowledge/rag_error_codes).
+    ragErrorCode: v.optional(v.string()),
     ragProgress: v.optional(v.string()),
     ocrApplied: v.optional(v.boolean()),
   },
@@ -286,6 +291,11 @@ export const updateFileRagStatus = internalMutation({
     await ctx.db.patch(metadata._id, {
       ragStatus: args.ragStatus,
       ragError: failureReason,
+      // Lives and dies with `ragError`: only a failed write may carry a code,
+      // and a failed write WITHOUT one clears whatever a previous failure left
+      // (the new prose describes a new cause — a stale code would pin the old
+      // guidance to it).
+      ragErrorCode: args.ragStatus === 'failed' ? args.ragErrorCode : undefined,
       ragProgress: isTerminal ? undefined : args.ragProgress,
       // Stamp when re-queued so the watchdog can time it out. Clear on
       // completion so a later re-queue starts its own clock — but KEEP it on

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -162,6 +162,7 @@ export const saveFileMetadata = mutation({
       if (needsRagRetry) {
         patchData.ragStatus = 'queued';
         patchData.ragError = undefined;
+        patchData.ragErrorCode = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = now;
       }
@@ -176,6 +177,7 @@ export const saveFileMetadata = mutation({
       ) {
         patchData.ragStatus = undefined;
         patchData.ragError = undefined;
+        patchData.ragErrorCode = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = undefined;
       }

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -47,6 +47,11 @@ export const fileMetadataTable = defineTable({
     ),
   ),
   ragError: v.optional(v.string()),
+  // Stable machine-readable cause set alongside `ragError` when the failure is
+  // one the UI can guide the user out of (values in knowledge/rag_error_codes).
+  // Open string like `source`, so a new cause needs no schema change. Only ever
+  // present on a 'failed' row; cleared with `ragError` on every transition.
+  ragErrorCode: v.optional(v.string()),
   ragProgress: v.optional(v.string()),
   // Timestamp (ms) when ragStatus was last set to 'queued'. Used by the
   // poll-timeout watchdog to give up on uploads that never reached RAG

--- a/services/platform/convex/knowledge/ingest_file.test.ts
+++ b/services/platform/convex/knowledge/ingest_file.test.ts
@@ -184,7 +184,12 @@ describe('indexFileBlob — outcome → status', () => {
 
     await indexFileBlob(ctx, ARGS);
 
-    expect(statusWrites.at(-1)).toMatchObject({ ragStatus: 'failed' });
+    expect(statusWrites.at(-1)).toMatchObject({
+      ragStatus: 'failed',
+      // The stable code (pinned: it lives on persisted rows) drives the
+      // failed dialog's deep link to the embedding settings.
+      ragErrorCode: 'embedding_not_configured',
+    });
     expect(String(statusWrites.at(-1)?.ragError)).toMatch(
       /no embedding model/i,
     );
@@ -217,6 +222,8 @@ describe('indexFileBlob — outcome → status', () => {
 
     expect(statusWrites.at(-1)).toMatchObject({ ragStatus: 'failed' });
     expect(String(statusWrites.at(-1)?.ragError)).toContain('pool exhausted');
+    // Only the guidable embedding-config failure carries a code.
+    expect(statusWrites.at(-1)?.ragErrorCode).toBeUndefined();
   });
 
   it('fails when the organization is unresolvable', async () => {

--- a/services/platform/convex/knowledge/ingest_file.ts
+++ b/services/platform/convex/knowledge/ingest_file.ts
@@ -53,6 +53,7 @@ import {
   PRIVATE_KNOWLEDGE_SCHEMA,
   resolveOrgUrl,
 } from './pool';
+import { RAG_ERROR_EMBEDDING_NOT_CONFIGURED } from './rag_error_codes';
 
 /** Slices committed per invocation before the continuation reschedules —
  * bounds one run well under the Convex action ceiling while still moving
@@ -251,10 +252,10 @@ export async function indexFileBlob(
       },
     );
   } catch (error) {
-    const reason =
-      error instanceof EmbeddingNotConfigured
-        ? error.message
-        : `Indexing failed: ${sanitizeError(error, ERROR_EXCERPT)}`;
+    const notConfigured = error instanceof EmbeddingNotConfigured;
+    const reason = notConfigured
+      ? error.message
+      : `Indexing failed: ${sanitizeError(error, ERROR_EXCERPT)}`;
     console.error(
       `[indexFileBlob] indexing failed for ${String(storageId)}:`,
       error instanceof Error ? error.message : error,
@@ -263,6 +264,11 @@ export async function indexFileBlob(
       await writeStatus(ctx, storageId, {
         ragStatus: 'failed',
         ragError: reason,
+        // The stable code lets the failed-indexing dialog deep-link the fix
+        // (Settings → Data residency) instead of dead-ending on prose.
+        ...(notConfigured
+          ? { ragErrorCode: RAG_ERROR_EMBEDDING_NOT_CONFIGURED }
+          : {}),
       });
     } catch (statusError) {
       console.error(

--- a/services/platform/convex/knowledge/rag_error_codes.ts
+++ b/services/platform/convex/knowledge/rag_error_codes.ts
@@ -1,0 +1,13 @@
+/**
+ * Stable machine-readable causes for `fileMetadata.ragError`, persisted next to
+ * the prose so surfaces can attach guidance (deep links, role-aware hints)
+ * without sniffing English message text that is free to change.
+ *
+ * Deliberately dependency-free: the client imports these literals too (the
+ * failed-indexing dialog), and the modules that raise the errors are
+ * `'use node'` server code it must never pull in.
+ */
+
+/** The organization has no embedding model configured (`EmbeddingNotConfigured`)
+ * — fixed under Settings → Data residency → Embedding model. */
+export const RAG_ERROR_EMBEDDING_NOT_CONFIGURED = 'embedding_not_configured';

--- a/services/platform/convex/knowledge_entries/queries.ts
+++ b/services/platform/convex/knowledge_entries/queries.ts
@@ -24,6 +24,7 @@ export interface KnowledgeEntryItem extends Doc<'knowledgeEntries'> {
   ragStatus?: DocumentRagProjection['status'] | 'not_indexed';
   ragIndexedAt?: number;
   ragError?: string;
+  ragErrorCode?: string;
 }
 
 async function projectEntries(
@@ -51,6 +52,7 @@ async function projectEntries(
       ragStatus: rag?.status ?? 'not_indexed',
       ragIndexedAt: rag?.indexedAt,
       ragError: rag?.error,
+      ragErrorCode: rag?.errorCode,
     };
   });
 }

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -2310,6 +2310,13 @@ documents:
         description: Das Dokument konnte nicht für die RAG-Suche indexiert werden.
         errorDetails: 'Fehlerdetails:'
         unknownError: Unbekannter Fehler aufgetreten
+        embeddingNotConfigured:
+          hint: Die Indexierung braucht ein Embedding-Modell. Für diese
+            Organisation ist noch keines konfiguriert.
+          configureCta: Embedding-Modell konfigurieren
+          askAdmin:
+            Bitte einen Admin deiner Organisation, eines einzurichten, und
+            starte die Indexierung danach neu.
       unsupported:
         title: Format nicht unterstützt
         description:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -2228,6 +2228,12 @@ documents:
         description: The document could not be indexed for RAG search.
         errorDetails: 'Error details:'
         unknownError: Unknown error occurred
+        embeddingNotConfigured:
+          hint:
+            Knowledge indexing needs an embedding model, and this organization
+            doesn't have one configured yet.
+          configureCta: Configure embedding model
+          askAdmin: Ask an organization admin to configure one, then retry indexing.
       unsupported:
         title: Format not supported
         description:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -2327,6 +2327,14 @@ documents:
         description: Le document n'a pas pu être indexé pour la recherche RAG.
         errorDetails: "Détails de l'erreur :"
         unknownError: Erreur inconnue survenue
+        embeddingNotConfigured:
+          hint:
+            L'indexation a besoin d'un modèle d'embedding. Cette organisation
+            n'en a pas encore configuré.
+          configureCta: Configurer le modèle d'embedding
+          askAdmin:
+            Demande à un administrateur de ton organisation d'en configurer
+            un, puis relance l'indexation.
       unsupported:
         title: Format non pris en charge
         description:

--- a/services/platform/types/documents.ts
+++ b/services/platform/types/documents.ts
@@ -37,6 +37,8 @@ export interface DocumentItem {
   ragIndexedAt?: number;
   /** Error message (for failed status) */
   ragError?: string;
+  /** Machine-readable failure cause (values in convex/knowledge/rag_error_codes) */
+  ragErrorCode?: string;
   /** Number of scanned pages detected in the document */
   scannedPagesDetected?: number;
   /** Whether OCR was applied during RAG indexing */


### PR DESCRIPTION
## What

When a document fails to index because the organization has no embedding model configured, the "Indexing failed" dialog dead-ended on the raw English error prose. It now renders localized guidance under the error details:

- members who can open org settings get a **Configure embedding model** deep link to **Settings → Data residency** (where the one-click embedding recommendation already lives),
- everyone else gets an ask-an-admin hint.

Knowledge entries reuse the same badge/dialog, so that surface is covered too.

## How

- `fileMetadata.ragErrorCode` — a stable machine-readable cause persisted next to `ragError`, so the UI attaches guidance without sniffing English message text. Open string (like `source`); the one value today is `embedding_not_configured`, stamped by `indexFileBlob` when `EmbeddingNotConfigured` is raised. Schema growth is data-safe (`migrations:check` green, no migration).
- The code lives and dies with `ragError`: `updateFileRagStatus` persists it only on `failed` and clears it on every other transition — a failed write naming a new cause without a code also clears the stale one, and every re-queue/clear path (`saveFileMetadata`, hub re-index, non-indexable re-upload) clears it alongside `ragError`. The watchdog and poll paths all go through the same choke, so they inherit the clearing.
- Plumbed through the RAG projection → document item validator → documents/knowledge-entries queries → `RagStatusBadge` (new `errorCode` prop, all four call sites).
- `EmbeddingNotConfiguredGuidance` mirrors the chat error's `ProviderKeyErrorAction`: `LinkButton` deep link gated on the same `orgSettings` ability the data-residency route uses, ask-an-admin text otherwise.
- The constant lives in a dependency-free `convex/knowledge/rag_error_codes.ts` because the client imports it and `knowledge/embedding.ts` is `'use node'`.
- Locales: en/de/fr in the same change (de-CH needs no override — no ß, no divergent vocabulary).

Existing failed rows predate the code and show no guidance until their next (re-)failure stamps it — retrying an unconfigured org re-fails in milliseconds and picks it up, and retrying after configuring succeeds anyway, so no backfill.

## Tests

- `updateFileRagStatus` lifecycle: persists on failed, clears on non-failed, clears stale code when a new cause carries none.
- `indexFileBlob`: stamps the code for `EmbeddingNotConfigured`, leaves it off other failures.
- `RagStatusBadge`: deep link for org-settings holders (href asserted), ask-admin fallback, no guidance without the code, axe audit on the open dialog.

Verified live on the dev stack: legacy failed row shows no guidance → Retry re-fails with the code → dialog shows hint + CTA → CTA lands on Data residency with the embedding recommendation visible.

Full platform suite green (74k server tests, i18n suites, `migrations:check`). Three client-project tests in `app/features/settings/` (settings-rail axe, data-residency stored-values) time out flakily **under full-suite parallel load only** — different victims each run, all pass in isolation, none touched by this change.