### PR TITLE
fix(platform): advance agent live timeline on tool-only activity

### DIFF
--- a/services/platform/app/features/automations/components/automation-canvas.browser.test.tsx
+++ b/services/platform/app/features/automations/components/automation-canvas.browser.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/tests/utils/render';
+
+import { buildGraph } from '../lib/graph';
+import { AutomationCanvas } from './automation-canvas';
+
+/**
+ * REAL Chromium (project `browser`): the run dialog's canvas must frame the
+ * step in flight. jsdom has no layout, so React Flow's pane measures nothing
+ * there and every viewport command is a silent no-op — the exact condition
+ * this canvas used to mistake for success. Only a real browser can witness
+ * the framing.
+ *
+ * Regression: the follow effect waited on `useNodesInitialized` (false in a
+ * real browser long after the graph is on screen, because these nodes carry a
+ * fixed box instead of a measured one) and recorded a followed step as framed
+ * even when React Flow had dropped the pan or later grew its pane under it.
+ * The viewport then kept its identity transform while the whole-graph fit
+ * stayed switched off — nodes off-frame, an apparently empty strip, the
+ * running step nowhere in sight.
+ */
+
+const PANE_HEIGHT = 600;
+const PANE_WIDTH = 800;
+
+beforeAll(() => {
+  // The canvas sizes its frame with Tailwind classes and this tier loads no
+  // app stylesheet, so the pane would collapse to zero height and React Flow
+  // would centre against its built-in default instead of what is on screen.
+  // In the app the dialog's own column gives the frame this height.
+  const style = document.createElement('style');
+  // `!important`: the React Flow stylesheet sizes the pane to 100% of a frame
+  // that has no height here, and Vite may inject it after this rule.
+  style.textContent = `.react-flow { height: ${String(PANE_HEIGHT)}px !important; width: ${String(PANE_WIDTH)}px !important; }`;
+  document.head.append(style);
+});
+
+const graph = buildGraph({
+  name: 'order-report',
+  nodes: [
+    { id: 'first', type: 'transform', input: { expr: '1 + 1' } },
+    {
+      id: 'second',
+      type: 'transform',
+      input: { expr: '{{ nodes.first.output }}' },
+    },
+    {
+      id: 'third',
+      type: 'transform',
+      input: { expr: '{{ nodes.second.output }}' },
+    },
+  ],
+});
+
+/** Far apart, so a viewport framing one node cannot accidentally show another. */
+const positions = {
+  first: { x: 0, y: 0 },
+  second: { x: 0, y: 1200 },
+  third: { x: 0, y: 2400 },
+};
+
+// This tier registers no global cleanup, and a left-over canvas from an
+// earlier case would be the one a document-wide query measures.
+afterEach(cleanup);
+
+/** The pane and one node box, measured inside THIS render's container. */
+function boxes(
+  container: HTMLElement,
+  nodeId: string,
+): { pane: DOMRect; node: DOMRect } | null {
+  const pane = container.querySelector('.react-flow');
+  const node = container.querySelector(
+    `.react-flow__node[data-id="${nodeId}"]`,
+  );
+  if (!pane || !node) return null;
+  return {
+    pane: pane.getBoundingClientRect(),
+    node: node.getBoundingClientRect(),
+  };
+}
+
+/** How far a node's own centre sits from the pane's, in screen pixels. */
+function centreOffset(container: HTMLElement, nodeId: string): number {
+  const measured = boxes(container, nodeId);
+  if (measured === null) return Number.POSITIVE_INFINITY;
+  const { pane, node } = measured;
+  return Math.hypot(
+    node.left + node.width / 2 - (pane.left + pane.width / 2),
+    node.top + node.height / 2 - (pane.top + pane.height / 2),
+  );
+}
+
+function canvas(props: {
+  followNodeId: string;
+  visibleNodeIds?: ReadonlySet<string>;
+}) {
+  return (
+    <AutomationCanvas
+      graph={graph}
+      positions={positions}
+      selectedNodeId={props.followNodeId}
+      onSelectNode={vi.fn()}
+      inspectorId="inspector"
+      followNodeId={props.followNodeId}
+      onReturnToFollow={vi.fn()}
+      {...(props.visibleNodeIds !== undefined
+        ? { visibleNodeIds: props.visibleNodeIds }
+        : {})}
+    />
+  );
+}
+
+describe('AutomationCanvas — following the run', () => {
+  it('centres the viewport on the followed step', async () => {
+    const { container } = render(canvas({ followNodeId: 'second' }));
+
+    // Within a few pixels of dead centre: the pan is animated, so allow the
+    // last frame's rounding but nothing near a node's own height.
+    await waitFor(() => {
+      expect(centreOffset(container, 'second')).toBeLessThan(8);
+    });
+  });
+
+  it('re-centres when the run advances to the next step', async () => {
+    const { container, rerender } = render(canvas({ followNodeId: 'second' }));
+    await waitFor(() => {
+      expect(centreOffset(container, 'second')).toBeLessThan(8);
+    });
+
+    rerender(canvas({ followNodeId: 'third' }));
+
+    await waitFor(() => {
+      expect(centreOffset(container, 'third')).toBeLessThan(8);
+    });
+  });
+
+  it('frames the drawn path when the followed step is not drawable', async () => {
+    // The cursor sits outside the visible set, so the follow has no box to aim
+    // at. The whole-graph fit is off while following, so without the fallback
+    // fit the viewport would stay parked on nothing.
+    const { container } = render(
+      canvas({ followNodeId: 'third', visibleNodeIds: new Set(['first']) }),
+    );
+
+    await waitFor(() => {
+      const measured = boxes(container, 'first');
+      expect(measured).not.toBeNull();
+      expect(measured?.node.top).toBeGreaterThanOrEqual(
+        (measured?.pane.top ?? 0) - 1,
+      );
+      expect(measured?.node.bottom).toBeLessThanOrEqual(
+        (measured?.pane.bottom ?? 0) + 1,
+      );
+    });
+  });
+});

--- a/services/platform/app/features/automations/components/automation-canvas.tsx
+++ b/services/platform/app/features/automations/components/automation-canvas.tsx
@@ -8,8 +8,8 @@ import {
   Panel,
   Position,
   ReactFlowProvider,
-  useNodesInitialized,
   useReactFlow,
+  useStore,
   type Edge,
   type Node,
 } from '@xyflow/react';
@@ -19,6 +19,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type CSSProperties,
 } from 'react';
 
@@ -47,9 +48,9 @@ import {
 const NODE_WIDTH = 300;
 const NODE_HEIGHT = 116;
 
-/** First-sight zoom when the canvas follows a run's cursor: close enough to
- * read the box, wide enough for its neighbours to peek in. */
-const FOLLOW_ZOOM = 0.85;
+/** First-sight zoom when the canvas follows a run's cursor: the step in flight
+ * reads at full size, with its neighbours peeking in at the edges. */
+const FOLLOW_ZOOM = 1;
 
 /** React Flow requires a stable node-type map; an inline object remounts every
  * node on each render. */
@@ -118,8 +119,18 @@ function CanvasInner({
   size = 'default',
 }: AutomationCanvasProps) {
   const { t } = useT('automations');
-  const { setCenter, getZoom } = useReactFlow();
-  const nodesInitialized = useNodesInitialized();
+  const { setCenter, getZoom, fitView } = useReactFlow();
+  // React Flow's own readiness: `onInit` fires once the pane is mounted and
+  // its zoom behaviour is live, which is the moment viewport commands start
+  // landing instead of being dropped.
+  const [flowReady, setFlowReady] = useState(false);
+  // The pane React Flow measured, straight from its store. `useNodesInitialized`
+  // is NOT the signal to wait for here — this canvas gives every node a fixed
+  // box and centers from that constant, and the hook stays false in a real
+  // browser long after the graph is on screen (measured against it, the follow
+  // simply never ran).
+  const paneWidth = useStore((state) => state.width);
+  const paneHeight = useStore((state) => state.height);
 
   const incomingByNode = useMemo(() => {
     const grouped = new Map<string, typeof graph.edges>();
@@ -248,23 +259,66 @@ function CanvasInner({
     [centerOnNode, getZoom],
   );
 
-  // Follow the run: recenter ONLY when the followed id changes — every other
-  // re-render (live-query ticks re-project the run constantly) must leave the
-  // viewport alone, or the canvas would snap back mid-pan under the reader.
+  // Where the followed box actually sits. Keyed by POSITION, not just id: auto
+  // layout resolves asynchronously, so the first sight of a followed node is
+  // usually at a placeholder position that moves once ELK answers — a
+  // recenter keyed on the id alone would frame that placeholder and then hold
+  // the viewport over empty canvas forever.
+  const followPosition = useMemo(() => {
+    if (followNodeId == null) return null;
+    return (
+      visibleNodes.find((candidate) => candidate.id === followNodeId)
+        ?.position ?? null
+    );
+  }, [followNodeId, visibleNodes]);
+
+  // Follow the run: recenter when the followed step CHANGES, when its box
+  // moves, or when the pane it is framed in resizes — and on nothing else, so
+  // the live-query ticks that re-project the run constantly leave the viewport
+  // alone rather than snapping it back mid-pan under the reader.
   const followedRef = useRef<string | null>(null);
+  const fellBackToFitRef = useRef(false);
   useEffect(() => {
-    if (!nodesInitialized || followNodeId == null) return;
-    if (followedRef.current === followNodeId) return;
+    // React Flow drops viewport commands until its pane is mounted, and the
+    // drop is SILENT — without this gate the first follow is swallowed, the
+    // step is recorded as framed, and the canvas keeps its identity transform
+    // (nodes off-frame, an apparently empty strip).
+    if (!flowReady || paneWidth === 0 || paneHeight === 0) return;
+    if (followNodeId == null) return;
+    if (followPosition === null) {
+      // The cursor's box is not drawable — it fell outside the visible set. The
+      // whole-graph fit is off while following, so fit the drawn path once
+      // rather than leaving the viewport parked on nothing.
+      if (visibleNodes.length > 0 && !fellBackToFitRef.current) {
+        fellBackToFitRef.current = true;
+        void fitView({ padding: 0.2, duration: 0 });
+      }
+      return;
+    }
+    // The pane's size belongs in the key: React Flow centers against the size
+    // it has measured SO FAR, and this canvas grows into its column after
+    // mount — a framing computed against the pre-growth pane leaves the step
+    // half a pane off centre for the rest of the run.
+    const followKey = `${followNodeId}@${String(followPosition.x)},${String(followPosition.y)}#${String(paneWidth)}x${String(paneHeight)}`;
+    if (followedRef.current === followKey) return;
     const first = followedRef.current === null;
-    const centered = centerOnNode(
+    centerOnNode(
       followNodeId,
       first ? FOLLOW_ZOOM : getZoom(),
       first ? 0 : 200,
     );
-    // Not centered yet = the box has no laid-out position so far; leave the
-    // ref untouched and the next layout pass retries.
-    if (centered) followedRef.current = followNodeId;
-  }, [nodesInitialized, followNodeId, centerOnNode, getZoom]);
+    followedRef.current = followKey;
+  }, [
+    flowReady,
+    paneWidth,
+    paneHeight,
+    followNodeId,
+    followPosition,
+    visibleNodes.length,
+    centerOnNode,
+    fitView,
+    getZoom,
+  ]);
 
   const canvasContext = useMemo<CanvasNodeContextValue>(
     () => ({
@@ -339,6 +393,7 @@ function CanvasInner({
           // the whole-graph initial fit would only flash a different framing
           // for it to override.
           fitView={followNodeId == null}
+          onInit={() => setFlowReady(true)}
           backgroundProps={{ gap: 16 }}
         >
           {followNodeId != null &&

--- a/services/platform/app/features/automations/components/run-ask-card.test.tsx
+++ b/services/platform/app/features/automations/components/run-ask-card.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { render, screen } from '@/tests/utils/render';
+
+import { RunAskCard } from './run-ask-card';
+
+// The answer mutation, observable: the card must record the answer AFTER the
+// timeline mirror (post-then-resume, so the resumed agent can already read
+// the thread) and must refuse an empty submission outright.
+const { mutateAsync } = vi.hoisted(() => ({
+  mutateAsync: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../hooks/mutations', () => ({
+  useAnswerHumanAsk: () => ({ mutateAsync }),
+}));
+
+const ask = {
+  askId: 'ask-1' as Id<'automationHumanAsks'>,
+  question: 'RE-2026-0120: which amount governs — 1850.00 or 1580.00?',
+};
+
+describe('RunAskCard', () => {
+  it('shows the question and submits the answer, mirror first', async () => {
+    const calls: string[] = [];
+    mutateAsync.mockImplementation(() => {
+      calls.push('answer');
+      return Promise.resolve(null);
+    });
+    const onAnswerPosted = vi.fn((_answer: string) => {
+      calls.push('mirror');
+      return Promise.resolve();
+    });
+    render(
+      <RunAskCard
+        organizationId="org-1"
+        ask={ask}
+        onAnswerPosted={onAnswerPosted}
+      />,
+    );
+    expect(screen.getByTestId('run-ask-question')).toHaveTextContent(
+      'which amount governs',
+    );
+
+    fireEvent.change(screen.getByLabelText(/your answer/i), {
+      target: { value: 'The invoice copy: 1580.00 net.' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /send answer & resume/i }),
+    );
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        organizationId: 'org-1',
+        askId: ask.askId,
+        answer: 'The invoice copy: 1580.00 net.',
+      });
+    });
+    expect(onAnswerPosted).toHaveBeenCalledWith(
+      'The invoice copy: 1580.00 net.',
+    );
+    expect(calls).toEqual(['mirror', 'answer']);
+  });
+
+  it('keeps the submit disabled while the answer is blank', () => {
+    render(<RunAskCard organizationId="org-1" ask={ask} />);
+    expect(
+      screen.getByRole('button', { name: /send answer & resume/i }),
+    ).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/your answer/i), {
+      target: { value: '   ' },
+    });
+    expect(
+      screen.getByRole('button', { name: /send answer & resume/i }),
+    ).toBeDisabled();
+  });
+});

--- a/services/platform/app/features/automations/components/run-ask-card.tsx
+++ b/services/platform/app/features/automations/components/run-ask-card.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { Alert } from '@tale/ui/alert';
+import { Button } from '@tale/ui/button';
+import { Text } from '@tale/ui/text';
+import { Textarea } from '@tale/ui/textarea';
+import { MessageCircleQuestion } from 'lucide-react';
+import { useId, useState } from 'react';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import { useAnswerHumanAsk } from '../hooks/mutations';
+import { automationErrorMessage } from '../lib/errors';
+
+/** The pending-ask shape `getPendingAskForRun` returns — the caller queries
+ * it (the panel also drives its state line from it) and hands it in. */
+export interface RunPendingAsk {
+  askId: Id<'automationHumanAsks'>;
+  question: string;
+}
+
+/**
+ * The answer surface of a run whose agent asked a question and parked: the
+ * question, one answer box, one submit. Submitting records the answer and
+ * resumes the SAME agent conversation — the card clears reactively when the
+ * pending ask flips to answered. `onAnswerPosted` lets the task panel mirror
+ * the answer onto the task timeline as the member's own comment BEFORE the
+ * resume kicks (post-then-run, so the resumed agent can already read it).
+ */
+export function RunAskCard({
+  organizationId,
+  ask,
+  onAnswerPosted,
+}: {
+  organizationId: string;
+  ask: RunPendingAsk;
+  onAnswerPosted?: (answer: string) => Promise<void>;
+}) {
+  const { t } = useT('automations');
+  const answerAsk = useAnswerHumanAsk();
+  const inputId = useId();
+  const [answer, setAnswer] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  const submit = async () => {
+    const text = answer.trim();
+    if (text === '') return;
+    setBusy(true);
+    setRefusal(null);
+    try {
+      // Timeline first, resume second — a mirror that fails must not block
+      // the answer, so it only warns.
+      if (onAnswerPosted !== undefined) {
+        await onAnswerPosted(text).catch((error: unknown) => {
+          console.warn('[automations] answer comment mirror failed:', error);
+        });
+      }
+      await answerAsk.mutateAsync({
+        organizationId,
+        askId: ask.askId,
+        answer: text,
+      });
+    } catch (error) {
+      setRefusal(automationErrorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="border-primary/40 bg-primary/[0.03] flex flex-col gap-3 rounded-lg border p-4">
+      <div className="flex items-start gap-2">
+        <MessageCircleQuestion
+          className="text-primary mt-0.5 size-4 shrink-0"
+          aria-hidden
+        />
+        <div className="flex min-w-0 flex-col gap-1">
+          <Text as="p" className="text-sm font-medium">
+            {t('runs.ask.title')}
+          </Text>
+          <Text
+            as="p"
+            className="text-sm whitespace-pre-wrap"
+            data-testid="run-ask-question"
+          >
+            {ask.question}
+          </Text>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor={inputId} className="sr-only">
+          {t('runs.ask.answerLabel')}
+        </label>
+        <Textarea
+          id={inputId}
+          value={answer}
+          onChange={(event) => setAnswer(event.target.value)}
+          placeholder={t('runs.ask.placeholder')}
+          rows={3}
+          disabled={busy}
+          className="bg-background"
+        />
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            isLoading={busy}
+            disabled={answer.trim() === ''}
+            onClick={() => void submit()}
+          >
+            {t('runs.ask.submit')}
+          </Button>
+        </div>
+      </div>
+      {refusal !== null && (
+        <Alert variant="destructive" description={refusal} />
+      )}
+    </div>
+  );
+}

--- a/services/platform/app/features/automations/components/run-detail.tsx
+++ b/services/platform/app/features/automations/components/run-detail.tsx
@@ -21,6 +21,7 @@ import {
   useAutomation,
   useAutomationRun,
   useNodeTypeCatalog,
+  useRunPendingAsk,
 } from '../hooks/queries';
 import { readDocument, readPositions } from '../lib/document';
 import { automationErrorMessage } from '../lib/errors';
@@ -36,6 +37,7 @@ import { AutomationCanvas } from './automation-canvas';
 import { EffectList } from './effect-list';
 import { NodeInspector } from './node-inspector';
 import { approvalIdFromDetail, RunApprovalCard } from './run-approval-card';
+import { RunAskCard } from './run-ask-card';
 import { RunBadge } from './run-status-badge';
 
 /**
@@ -65,6 +67,8 @@ export function RunDetail({
 
   const runQuery = useAutomationRun(organizationId, runId);
   const run = runQuery.data ?? null;
+  const pendingAskQuery = useRunPendingAsk(organizationId, runId);
+  const pendingAsk = pendingAskQuery.data ?? null;
   const versionQuery = useAutomation(
     organizationId,
     automationSlug,
@@ -175,6 +179,9 @@ export function RunDetail({
 
       {refusal !== null && (
         <Alert variant="destructive" description={refusal} />
+      )}
+      {pendingAsk !== null && (
+        <RunAskCard organizationId={organizationId} ask={pendingAsk} />
       )}
       {(() => {
         // A live run parked on a write approval carries `approval:<id>` as

--- a/services/platform/app/features/automations/hooks/mutations.ts
+++ b/services/platform/app/features/automations/hooks/mutations.ts
@@ -40,6 +40,14 @@ export function useResolveRunApproval() {
   });
 }
 
+/** Answer a run's pending `ask_human` question — records the answer and
+ * resumes the parked agent conversation. */
+export function useAnswerHumanAsk() {
+  return useConvexMutation(api.automations.human_asks.answerAsk, {
+    errorToast: false,
+  });
+}
+
 /** Start a run — `mock` performs no IO, `live` may reach the outside world. */
 export function useStartAutomationRun() {
   return useConvexMutation(api.automations.mutations.startRun, {

--- a/services/platform/app/features/automations/hooks/queries.ts
+++ b/services/platform/app/features/automations/hooks/queries.ts
@@ -94,6 +94,18 @@ export function useRunApproval(
   );
 }
 
+/** The live question a run's agent parked on (`ask_human`), null when nothing
+ * waits on a person. Reactive: answering flips it to null everywhere. */
+export function useRunPendingAsk(
+  organizationId: string,
+  runId: Id<'automationRuns'> | undefined,
+) {
+  return useConvexQuery(
+    api.automations.human_asks.getPendingAskForRun,
+    runId === undefined ? 'skip' : { organizationId, runId },
+  );
+}
+
 /** The projects one automation is bound to — empty means org-level. */
 export function useAutomationProjects(organizationId: string, name: string) {
   return useConvexQuery(api.automations.queries.listAutomationProjects, {

--- a/services/platform/app/features/tasks/components/task-subject-panel.tsx
+++ b/services/platform/app/features/tasks/components/task-subject-panel.tsx
@@ -164,18 +164,23 @@ function TaskRunDetailsDialog({
                 onReturnToFollow={() => setSelectedNodeId(null)}
                 size="fill"
               />
-              <Stack
-                as="section"
-                gap={2}
-                className="shrink-0 md:min-h-0 md:overflow-y-auto"
-              >
-                <Text as="h3" variant="label">
+              {/* The actions list is the left column's second scroller. It must
+                  be allowed to SHRINK below its content (`min-h-0` + no
+                  `shrink-0`) — a flex item that keeps its content height
+                  overflows the dialog's clipped box instead of scrolling, which
+                  silently cut every action past the fold. The heading stays put
+                  and only the list scrolls. Mobile keeps the whole dialog as
+                  the one scroller. */}
+              <Stack as="section" gap={2} className="md:min-h-0 md:flex-1">
+                <Text as="h3" variant="label" className="shrink-0">
                   {t('run.effectsTitle')}
                 </Text>
-                <EffectList
-                  effects={projection.effects}
-                  emptyMessage={t('run.noEffectsYet')}
-                />
+                <div className="md:min-h-0 md:flex-1 md:overflow-y-auto">
+                  <EffectList
+                    effects={projection.effects}
+                    emptyMessage={t('run.noEffectsYet')}
+                  />
+                </div>
               </Stack>
             </div>
             <Stack

--- a/services/platform/app/features/tasks/components/task-subject-panel.tsx
+++ b/services/platform/app/features/tasks/components/task-subject-panel.tsx
@@ -21,10 +21,12 @@ import {
   RunApprovalCard,
   approvalIdFromDetail,
 } from '@/app/features/automations/components/run-approval-card';
+import { RunAskCard } from '@/app/features/automations/components/run-ask-card';
 import { RunStepDetail } from '@/app/features/automations/components/run-step-detail';
 import {
   useAutomation,
   useAutomationRun,
+  useRunPendingAsk,
 } from '@/app/features/automations/hooks/queries';
 import {
   readDocument,
@@ -293,6 +295,10 @@ export function TaskSubjectPanel({
     taskId: task._id,
   });
   const run = runQuery.data ?? null;
+  // The live run's parked question, if its agent asked one — the panel's
+  // whole story flips to "answer this" while it is pending.
+  const pendingAskQuery = useRunPendingAsk(organizationId, run?.runId);
+  const pendingAsk = pendingAskQuery.data ?? null;
 
   // `hasFiles` exactly as the choreography computes it: only a folder-input
   // contract with a bound folder ever reads true.
@@ -458,7 +464,9 @@ export function TaskSubjectPanel({
 
   const stateLine =
     state.kind === 'running'
-      ? t('run.working', { name: displayName })
+      ? pendingAsk !== null
+        ? t('run.waitingAnswer', { name: displayName })
+        : t('run.working', { name: displayName })
       : state.kind === 'review'
         ? t('subject.review', { name: displayName })
         : state.kind === 'ready'
@@ -516,7 +524,7 @@ export function TaskSubjectPanel({
       )}
 
       <Row gap={2} align="center">
-        {state.kind === 'running' && (
+        {state.kind === 'running' && pendingAsk === null && (
           <Loader2
             className="text-muted-foreground size-4 shrink-0 animate-spin"
             aria-hidden
@@ -526,6 +534,18 @@ export function TaskSubjectPanel({
           {stateLine}
         </Text>
       </Row>
+
+      {pendingAsk !== null && (
+        <RunAskCard
+          organizationId={organizationId}
+          ask={pendingAsk}
+          // The member's answer lands on the task timeline as THEIR comment
+          // before the resume kicks, so the thread shows who decided what.
+          onAnswerPosted={async (answer) => {
+            await addComment.mutateAsync({ taskId: task._id, body: answer });
+          }}
+        />
+      )}
 
       {canEdit && (
         <Row gap={2} wrap className="mt-1">

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -51,6 +51,7 @@ import type * as automations_bound_run_payload from "../automations/bound_run_pa
 import type * as automations_catalog from "../automations/catalog.js";
 import type * as automations_checkpoints from "../automations/checkpoints.js";
 import type * as automations_cron from "../automations/cron.js";
+import type * as automations_human_asks from "../automations/human_asks.js";
 import type * as automations_liveness from "../automations/liveness.js";
 import type * as automations_llm_call from "../automations/llm_call.js";
 import type * as automations_mutations from "../automations/mutations.js";
@@ -754,6 +755,7 @@ import type * as sandbox_session_naming from "../sandbox/session_naming.js";
 import type * as sandbox_session_queries from "../sandbox/session_queries.js";
 import type * as sandbox_session_queries_public from "../sandbox/session_queries_public.js";
 import type * as sandbox_sessions_schema from "../sandbox/sessions_schema.js";
+import type * as sandbox_tool_names from "../sandbox/tool_names.js";
 import type * as sandbox_tools_http from "../sandbox/tools_http.js";
 import type * as sandbox_user_env from "../sandbox/user_env.js";
 import type * as sandbox_user_env_actions from "../sandbox/user_env_actions.js";
@@ -942,6 +944,7 @@ declare const fullApi: ApiFromModules<{
   "automations/catalog": typeof automations_catalog;
   "automations/checkpoints": typeof automations_checkpoints;
   "automations/cron": typeof automations_cron;
+  "automations/human_asks": typeof automations_human_asks;
   "automations/liveness": typeof automations_liveness;
   "automations/llm_call": typeof automations_llm_call;
   "automations/mutations": typeof automations_mutations;
@@ -1645,6 +1648,7 @@ declare const fullApi: ApiFromModules<{
   "sandbox/session_queries": typeof sandbox_session_queries;
   "sandbox/session_queries_public": typeof sandbox_session_queries_public;
   "sandbox/sessions_schema": typeof sandbox_sessions_schema;
+  "sandbox/tool_names": typeof sandbox_tool_names;
   "sandbox/tools_http": typeof sandbox_tools_http;
   "sandbox/user_env": typeof sandbox_user_env;
   "sandbox/user_env_actions": typeof sandbox_user_env_actions;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -60,6 +60,7 @@ import type * as automations_poke from "../automations/poke.js";
 import type * as automations_queries from "../automations/queries.js";
 import type * as automations_recover_agent_turns from "../automations/recover_agent_turns.js";
 import type * as automations_rest_api from "../automations/rest_api.js";
+import type * as automations_run_status from "../automations/run_status.js";
 import type * as automations_script_host from "../automations/script_host.js";
 import type * as automations_stepper from "../automations/stepper.js";
 import type * as automations_store from "../automations/store.js";
@@ -953,6 +954,7 @@ declare const fullApi: ApiFromModules<{
   "automations/queries": typeof automations_queries;
   "automations/recover_agent_turns": typeof automations_recover_agent_turns;
   "automations/rest_api": typeof automations_rest_api;
+  "automations/run_status": typeof automations_run_status;
   "automations/script_host": typeof automations_script_host;
   "automations/stepper": typeof automations_stepper;
   "automations/store": typeof automations_store;

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -59,6 +59,7 @@ import {
   sessionIdForWorkflowExecution,
   workflowExecutionOwnerId,
 } from '../sandbox/session_naming';
+import { ASK_HUMAN_TOOL } from '../sandbox/tool_names';
 import type { AgentTurnFile, AgentTurnResult } from './checkpoints';
 import { resolveServingTarget } from './llm_call';
 
@@ -122,6 +123,88 @@ export interface AutomationAgentHost {
 }
 
 const DEFAULT_HARNESS = 'claude-code';
+
+/** An `automationHumanAsks` row as the host consumes it — the internal reads
+ * return it untyped (`v.any()`), so every consumer narrows through here. */
+interface AskRow {
+  _id: Id<'automationHumanAsks'>;
+  runId: string;
+  nodeId: string;
+  execId: string;
+  question: string;
+  expiresAt: number;
+  status: string;
+  agentSessionId?: string;
+  answer?: string;
+}
+
+function readAskRow(value: unknown): AskRow | null {
+  if (value === null || typeof value !== 'object') return null;
+  const record: Record<string, unknown> = { ...value };
+  if (
+    typeof record._id !== 'string' ||
+    typeof record.runId !== 'string' ||
+    typeof record.nodeId !== 'string' ||
+    typeof record.execId !== 'string' ||
+    typeof record.question !== 'string' ||
+    typeof record.expiresAt !== 'number' ||
+    typeof record.status !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the row came from the automationHumanAsks table read
+    _id: record._id as Id<'automationHumanAsks'>,
+    runId: record.runId,
+    nodeId: record.nodeId,
+    execId: record.execId,
+    question: record.question,
+    expiresAt: record.expiresAt,
+    status: record.status,
+    ...(typeof record.agentSessionId === 'string'
+      ? { agentSessionId: record.agentSessionId }
+      : {}),
+    ...(typeof record.answer === 'string' ? { answer: record.answer } : {}),
+  };
+}
+
+/** The extra margin the parked cursor's deadline gets past the ask's expiry,
+ * so the poll-side expiry settle always wins over the stepper's generic
+ * time-limit cut (whose message would blame the agent, not the silence). */
+const ASK_DEADLINE_MARGIN_MS = 60 * 60 * 1000;
+
+/** Best-effort close of a turn's pending ask on the cancel paths — an
+ * unanswerable card must not keep soliciting an answer. */
+async function closePendingAskForExec(
+  ctx: ActionCtx,
+  sessionId: string,
+  execId: string,
+): Promise<void> {
+  const ask = readAskRow(
+    await ctx.runQuery(internal.automations.human_asks.getPendingAskForExec, {
+      sessionId,
+      execId,
+    }),
+  );
+  if (ask === null) return;
+  await ctx
+    .runMutation(internal.automations.human_asks.closeAsk, {
+      askId: ask._id,
+      status: 'cancelled',
+    })
+    .catch((err) => console.warn('[agent-host] ask close failed:', err));
+}
+
+/** The instructions line that makes the tool discoverable — the shim only
+ * advertises generic `workspace_tool`, so the turn is told the name. */
+const ASK_HUMAN_GUIDANCE =
+  "When you hit a decision or fact ONLY the run's human operator can " +
+  `provide, call the "${ASK_HUMAN_TOOL}" workspace tool (via workspace_tool) ` +
+  'with one complete, self-contained question (you may bundle several), ' +
+  'then say you are waiting and END YOUR TURN. You will be resumed with the ' +
+  'answer as your next message. Never guess, never invent placeholder ' +
+  'values for such facts, and never ask about things you can determine ' +
+  'yourself from the staged files.';
 
 /** The real agent door for one run's organization. */
 export function automationAgentHost(
@@ -220,12 +303,46 @@ export function automationAgentHost(
       );
       const agent = state?.cursor?.agent;
       if (agent === undefined || agent.execId !== execId) return null;
-      return agent.result ?? null;
+      if (agent.result !== undefined) return agent.result;
+      // A turn parked on an ask waits for a person, not for the sandbox — but
+      // not forever. Past the ask's own expiry, the turn settles as errored
+      // and the manifest decides what an unanswered question means.
+      const ask = readAskRow(
+        await ctx.runQuery(
+          internal.automations.human_asks.getPendingAskForExec,
+          { sessionId: agent.sessionId, execId },
+        ),
+      );
+      if (ask !== null && Date.now() > ask.expiresAt) {
+        await ctx.runMutation(internal.automations.human_asks.closeAsk, {
+          askId: ask._id,
+          status: 'expired',
+        });
+        await ctx.runMutation(
+          internal.automations.mutations.recordAgentTurnSettled,
+          {
+            organizationId,
+            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the stepper only holds ids it was invoked with
+            runId: runId as never,
+            nodeId: ask.nodeId,
+            execId,
+            result: {
+              errored: true,
+              reason:
+                'the agent asked the operator a question and nobody answered within 7 days',
+              text: '',
+              files: [],
+            },
+          },
+        );
+      }
+      return null;
     },
     cancel: async ({ sessionId, execId }) => {
       await sessionCancelExec(sessionId, execId).catch((err) =>
         console.warn('[agent-host] exec cancel failed:', err),
       );
+      await closePendingAskForExec(ctx, sessionId, execId);
       await releaseTurnKey(ctx, {
         organizationId,
         sessionId,
@@ -667,6 +784,10 @@ export const startWorkflowAgentTurn = internalAction({
             allowedModels: [args.gatewayModel],
             connectorGrants: [...(args.request.connectors ?? [])],
             budgetCents,
+            // The one workspace tool an automation turn holds: ask the run's
+            // operator. The org-data READ tools stay chat-lane only — a run
+            // has no turn user to scope them to.
+            toolGrants: [ASK_HUMAN_TOOL],
           },
           expiresAt: args.deadlineAt,
         },
@@ -699,10 +820,10 @@ export const startWorkflowAgentTurn = internalAction({
               ].join('\n'),
             ]
           : []),
+        ASK_HUMAN_GUIDANCE,
         "Write every file you produce to /user/output/ — files there are collected when your turn ends and become this step's output.",
       ].join('\n\n');
 
-      const connectors = args.request.connectors ?? [];
       const exec = buildExternalTurnExec({
         harness: args.harness,
         gatewayModel: args.gatewayModel,
@@ -710,9 +831,9 @@ export const startWorkflowAgentTurn = internalAction({
         instructions,
         prompt: args.request.prompt,
         execId: args.execId,
-        ...(connectors.length > 0
-          ? { bridgeUrl: connectorsBridgeUrlForSessions() }
-          : {}),
+        // Always mounted: `ask_human` rides the bridge, so every automation
+        // turn gets the shim even when the node declares no connectors.
+        bridgeUrl: connectorsBridgeUrlForSessions(),
         ...(visionRef !== null
           ? {
               vision: {
@@ -785,6 +906,7 @@ export const driveWorkflowAgentTurn = internalAction({
         // Already gone — the reap is best-effort.
         console.warn('[agent-host] orphan exec reap failed (already gone?)');
       });
+      await closePendingAskForExec(ctx, args.sessionId, args.execId);
       await releaseTurnKey(ctx, {
         organizationId: args.organizationId,
         sessionId: args.sessionId,
@@ -833,6 +955,244 @@ export const driveWorkflowAgentTurn = internalAction({
     return null;
   },
 });
+
+/**
+ * A member answered a parked ask: resume the SAME harness conversation on a
+ * fresh exec whose first message is the answer. Everything upstream of the
+ * node keeps its checkpoints; the session keeps its files; the conversation
+ * keeps its context (`--resume`). Guarded end-to-end — a stale answer (run
+ * moved on, cancelled, superseded) retargets nothing and starts nothing.
+ */
+export const resumeWorkflowAgentTurnWithAnswer = internalAction({
+  args: {
+    organizationId: v.string(),
+    askId: v.id('automationHumanAsks'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const ask = readAskRow(
+      await ctx.runQuery(internal.automations.human_asks.getAskForResume, {
+        askId: args.askId,
+        organizationId: args.organizationId,
+      }),
+    );
+    if (ask === null || ask.status !== 'answered' || ask.answer === undefined) {
+      console.warn('[agent-host] answered-ask resume: ask not resumable');
+      return null;
+    }
+    const askRunId = ask.runId;
+    const state = await ctx.runQuery(
+      internal.automations.queries.readAgentCursor,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the ask row carries the durable run id
+      { organizationId: args.organizationId, runId: askRunId as never },
+    );
+    const agent = state?.cursor?.agent;
+    const live =
+      state !== null &&
+      (state.status === 'waiting' ||
+        state.status === 'running' ||
+        state.status === 'queued') &&
+      state.cursor?.node === ask.nodeId &&
+      agent?.execId === ask.execId &&
+      agent.result === undefined;
+    if (!live || agent === undefined) {
+      console.warn(
+        '[agent-host] answered-ask resume: the run moved on — answer recorded, nothing to resume',
+      );
+      return null;
+    }
+
+    const request = readWorkflowAgentRequest(agent.input);
+    const sessionId = agent.sessionId;
+    const execId = randomUUID();
+    const deadlineAt = Date.now() + agentWorkTurnDeadlineMs();
+    // Serving is re-resolved, not replayed from the cursor: the wait can span
+    // days and the org's provider config may have moved — the key, the token
+    // scope, and the exec must name the SAME model either way.
+    const keys: TurnKeys = {
+      organizationId: args.organizationId,
+      runId: askRunId,
+      nodeId: ask.nodeId,
+      execId,
+      sessionId,
+      harness: agent.harness,
+      providerSlug: agent.providerSlug,
+      gatewayModel: agent.gatewayModel,
+      deadlineAt,
+    };
+    try {
+      // The wait may have outlived the container (idle reaper stops and
+      // preserves) — the session volume holds the workspace AND the harness's
+      // own conversation state, so an adopt-or-recreate brings both back.
+      await ensureWorkflowSession(ctx, args.organizationId, askRunId);
+
+      const target = await resolveServingTarget(
+        ctx,
+        args.organizationId,
+        request.model,
+      );
+      const routing = resolveGatewayRouting(
+        target.providerSlug,
+        target.modelId,
+      );
+      keys.providerSlug = target.providerSlug;
+      keys.gatewayModel = routing.gatewayModel;
+      const vision = await resolveTurnVisionModel(
+        ctx,
+        args.organizationId,
+        target,
+      );
+      const budgetCents = workflowAgentBudgetCents();
+      const key = await provisionSessionGatewayKey(ctx, {
+        organizationId: args.organizationId,
+        sessionId,
+        allowedModels: [
+          { providerSlug: target.providerSlug, modelId: target.modelId },
+          ...(vision !== null
+            ? [{ providerSlug: vision.providerSlug, modelId: vision.modelId }]
+            : []),
+        ],
+        budgetCents,
+      });
+      await ctx.runMutation(
+        internal.sandbox.session_mutations.insertSessionToken,
+        {
+          organizationId: args.organizationId,
+          sessionId,
+          tokenHash: key.keyHash,
+          llmGatewayKeyId: key.keyId,
+          scope: {
+            agentKind: agent.harness,
+            allowedModels: [routing.gatewayModel],
+            connectorGrants: [...(request.connectors ?? [])],
+            budgetCents,
+            toolGrants: [ASK_HUMAN_TOOL],
+          },
+          expiresAt: deadlineAt,
+        },
+      );
+      // Cursor first, op row second, exec last — the same
+      // row-exists-before-the-slow-part ordering as the kick, so a death
+      // between any two steps leaves a state the watchdog/poll can settle.
+      const retarget = await ctx.runMutation(
+        internal.automations.human_asks.retargetAgentCursor,
+        {
+          organizationId: args.organizationId,
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the ask row carries the durable run id
+          runId: askRunId as never,
+          nodeId: ask.nodeId,
+          fromExecId: ask.execId,
+          toExecId: execId,
+          deadlineAt,
+        },
+      );
+      if (!retarget.retargeted) {
+        console.warn(
+          '[agent-host] answered-ask resume: cursor retarget lost the race — leaving the run as-is',
+        );
+        return null;
+      }
+      await ctx.runMutation(
+        internal.sandbox.session_mutations.upsertSessionOp,
+        {
+          organizationId: args.organizationId,
+          sessionId,
+          execId,
+          kind: 'workflow-agent',
+          status: 'running',
+          modelRef: `${keys.providerSlug}/${keys.gatewayModel}`,
+          deadlineMs: deadlineAt,
+          heartbeatAt: Date.now(),
+          mintedKeyId: key.keyId,
+        },
+      );
+
+      const instructions = [
+        ...(request.system !== undefined && request.system !== ''
+          ? [request.system]
+          : []),
+        ASK_HUMAN_GUIDANCE,
+        "Write every file you produce to /user/output/ — files there are collected when your turn ends and become this step's output.",
+      ].join('\n\n');
+      const prompt = [
+        'The operator answered your question:',
+        '',
+        ask.answer,
+        '',
+        'Continue the task from where you left off, applying this answer. Ask again only if a genuinely NEW operator-only decision comes up.',
+      ].join('\n');
+      const exec = buildExternalTurnExec({
+        harness: agent.harness,
+        gatewayModel: keys.gatewayModel,
+        serving: { kind: 'gateway', token: key.token },
+        instructions,
+        prompt,
+        execId,
+        bridgeUrl: connectorsBridgeUrlForSessions(),
+        ...(ask.agentSessionId !== undefined
+          ? { resume: ask.agentSessionId }
+          : {}),
+        ...(vision !== null
+          ? {
+              vision: {
+                model: resolveGatewayRouting(
+                  vision.providerSlug,
+                  vision.modelId,
+                ).gatewayModel,
+              },
+            }
+          : {}),
+      });
+      if (ask.agentSessionId === undefined) {
+        // The asking turn ended without a resume handle (a harness that never
+        // reported one). The answer still reaches the agent — as a fresh
+        // conversation over the same workspace — so warn rather than fail.
+        console.warn(
+          '[agent-host] answered-ask resume without a harness session handle — starting fresh over the preserved workspace',
+        );
+      }
+
+      const progress = liveProgressSink(ctx, keys);
+      const window = await drainHarnessWindow({
+        sessionId,
+        execId,
+        harness: agent.harness,
+        start: exec,
+        onText: progress.onText,
+        onTimeline: progress.onTimeline,
+      });
+      await progress.flush();
+      await continueOrSettle(ctx, keys, window);
+    } catch (err) {
+      console.error('[agent-host] answered-ask resume failed:', err);
+      await settleWorkflowAgentTurn(ctx, keys, {
+        errored: true,
+        reason: `the agent turn could not resume after the answer: ${err instanceof Error ? err.message : String(err)}`,
+        text: '',
+        files: [],
+      });
+    }
+    return null;
+  },
+});
+
+/** Narrow the cursor's recorded request (stored as plain JSON) back to the
+ * fields the resume needs. Absent fields degrade, never throw — the resume
+ * must work for any request the kick accepted. */
+function readWorkflowAgentRequest(input: Record<string, unknown>): {
+  model: string;
+  system?: string;
+  connectors?: string[];
+} {
+  return {
+    model: typeof input.model === 'string' ? input.model : '',
+    ...(typeof input.system === 'string' ? { system: input.system } : {}),
+    ...(Array.isArray(input.connectors) &&
+    input.connectors.every((slug) => typeof slug === 'string')
+      ? { connectors: input.connectors }
+      : {}),
+  };
+}
 
 interface TurnKeys {
   organizationId: string;
@@ -957,6 +1317,58 @@ async function continueOrSettle(
     );
   const { errored, crashReason } = classifyHarnessEnd(window);
   const ended = window.ended;
+
+  // A clean turn end with a question on the table is not a settle — it is the
+  // WAIT. The node stays parked on its cursor (no result), the key is
+  // released (this turn is over; the answered resume mints its own), and the
+  // run sits `waiting` until a person answers or the ask expires. A CRASHED
+  // turn never waits: its question dies with it and the error settles as
+  // usual.
+  const pendingAsk = readAskRow(
+    await ctx.runQuery(internal.automations.human_asks.getPendingAskForExec, {
+      sessionId: args.sessionId,
+      execId: args.execId,
+    }),
+  );
+  if (pendingAsk !== null && !errored) {
+    await ctx.runMutation(internal.automations.human_asks.recordAskParked, {
+      askId: pendingAsk._id,
+      ...(ended?.sessionId !== undefined
+        ? { agentSessionId: ended.sessionId }
+        : {}),
+    });
+    // The stepper's generic time-limit cut must not fire while the turn
+    // legitimately waits — the ask's own expiry (enforced by the poll) is the
+    // clock now, and the margin keeps its message the one the operator sees.
+    await ctx.runMutation(internal.automations.human_asks.retargetAgentCursor, {
+      organizationId: args.organizationId,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from the turn's own args
+      runId: args.runId as never,
+      nodeId: args.nodeId,
+      fromExecId: args.execId,
+      deadlineAt: pendingAsk.expiresAt + ASK_DEADLINE_MARGIN_MS,
+    });
+    await releaseTurnKey(ctx, {
+      organizationId: args.organizationId,
+      sessionId: args.sessionId,
+      execId: args.execId,
+      status: 'completed',
+      agentResultStatus: 'awaiting_human',
+      ...(window.execResult?.exitCode != null
+        ? { exitCode: window.execResult.exitCode }
+        : {}),
+    });
+    return;
+  }
+  if (pendingAsk !== null) {
+    // Crashed with a question pending: the ask cannot be answered into a dead
+    // conversation — close it so the panel stops offering it.
+    await ctx.runMutation(internal.automations.human_asks.closeAsk, {
+      askId: pendingAsk._id,
+      status: 'cancelled',
+    });
+  }
+
   const text =
     ended?.finalText !== undefined && ended.finalText !== ''
       ? ended.finalText

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -725,13 +725,16 @@ export const startWorkflowAgentTurn = internalAction({
           : {}),
       });
 
+      const progress = liveProgressSink(ctx, args);
       const window = await drainHarnessWindow({
         sessionId: args.sessionId,
         execId: args.execId,
         harness: args.harness,
         start: exec,
-        ...liveProgressSink(ctx, args),
+        onText: progress.onText,
+        onTimeline: progress.onTimeline,
       });
+      await progress.flush();
       await continueOrSettle(ctx, args, window);
     } catch (err) {
       console.error('[agent-host] turn start failed:', err);
@@ -804,16 +807,19 @@ export const driveWorkflowAgentTurn = internalAction({
       return null;
     }
 
+    const progress = liveProgressSink(ctx, args);
     let window;
     try {
       window = await drainHarnessWindow({
         sessionId: args.sessionId,
         execId: args.execId,
         harness: args.harness,
-        ...liveProgressSink(ctx, args),
+        onText: progress.onText,
+        onTimeline: progress.onTimeline,
       });
     } catch (err) {
       console.error('[agent-host] drive window threw:', err);
+      await progress.flush();
       await settleWorkflowAgentTurn(ctx, args, {
         errored: true,
         reason: 'the agent turn stopped unexpectedly',
@@ -822,6 +828,7 @@ export const driveWorkflowAgentTurn = internalAction({
       });
       return null;
     }
+    await progress.flush();
     await continueOrSettle(ctx, args, window);
     return null;
   },
@@ -854,28 +861,39 @@ function liveProgressSink(
 ): {
   onText: (text: string) => void;
   onTimeline: (parts: HarnessTimelinePart[]) => void;
+  /** Await the writes queued so far — the settle path calls this before its
+   * own op writes, so a late live flush cannot land after (and shrink) the
+   * final transcript snapshot. */
+  flush: () => Promise<void>;
 } {
+  // Serialized like the chat lane's stream chain: each write carries the full
+  // state-so-far, so in-order landing is what keeps the tail monotonic.
+  let chain: Promise<void> = Promise.resolve();
   const write = (patch: {
     progressText?: string;
     liveTimeline?: HarnessTimelinePart[];
   }) => {
-    void ctx
-      .runMutation(internal.sandbox.session_mutations.upsertSessionOp, {
-        organizationId: args.organizationId,
-        sessionId: args.sessionId,
-        execId: args.execId,
-        kind: 'workflow-agent',
-        status: 'running',
-        lastEventAt: Date.now(),
-        ...patch,
-      })
-      .catch((err) =>
-        console.warn('[agent-host] live progress write failed:', err),
-      );
+    chain = chain.then(() =>
+      ctx
+        .runMutation(internal.sandbox.session_mutations.upsertSessionOp, {
+          organizationId: args.organizationId,
+          sessionId: args.sessionId,
+          execId: args.execId,
+          kind: 'workflow-agent',
+          status: 'running',
+          lastEventAt: Date.now(),
+          ...patch,
+        })
+        .then(() => undefined)
+        .catch((err) =>
+          console.warn('[agent-host] live progress write failed:', err),
+        ),
+    );
   };
   return {
     onText: (text) => write({ progressText: text }),
     onTimeline: (liveTimeline) => write({ liveTimeline }),
+    flush: () => chain,
   };
 }
 

--- a/services/platform/convex/automations/human_asks.test.ts
+++ b/services/platform/convex/automations/human_asks.test.ts
@@ -1,0 +1,371 @@
+/**
+ * The ask-a-human lifecycle behind `ask_human` — the data layer the bridge,
+ * the agent host, and the answer card all trust. What these pin: the ask can
+ * only ever attach to the run its SESSION proves (nothing client-supplied
+ * picks the run, the node, or the exec), a second question folds instead of
+ * multiplying cards, the public surfaces are membership-gated and go quiet on
+ * dead runs, and the cursor retarget refuses everything but the exact parked
+ * turn it was issued for.
+ */
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api, internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import { sessionIdForWorkflowExecution } from '../sandbox/session_naming';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'automations';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+type T = TestConvex<typeof schema>;
+
+const ORG = 'org_asks';
+const OTHER_ORG = 'org_asks_other';
+const MEMBER = 'u_asker';
+const EXEC = 'exec-ask-1';
+const NODE = 'repair_setup';
+
+async function seedMember(t: T, organizationId: string): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      memberId: `m_${MEMBER}_${organizationId}`,
+      userId: MEMBER,
+      organizationId,
+      role: 'editor',
+      createdAt: 0,
+    });
+  });
+}
+
+/** A live run parked on its agent node, with the session row that proves it. */
+async function seedParkedRun(
+  t: T,
+  overrides: {
+    status?: 'waiting' | 'success';
+    cursor?: boolean;
+    taskId?: string;
+  } = {},
+): Promise<{ runId: Id<'automationRuns'>; sessionId: string }> {
+  const runId = await t.run(async (ctx) =>
+    ctx.db.insert('automationRuns', {
+      organizationId: ORG,
+      name: 'vat-return-desk',
+      version: 1,
+      status: overrides.status ?? 'waiting',
+      mode: 'live',
+      startedBy: `user:${MEMBER}`,
+      input:
+        overrides.taskId !== undefined
+          ? { task: { id: overrides.taskId } }
+          : {},
+      startedAt: 0,
+      checkpoints: {
+        nodes: {},
+        executions: 1,
+        ...(overrides.cursor === false
+          ? {}
+          : {
+              cursor: {
+                node: NODE,
+                index: 0,
+                passes: 0,
+                outs: [],
+                agent: {
+                  execId: EXEC,
+                  sessionId: sessionIdForWorkflowExecution('placeholder'),
+                  deadlineAt: 9_999_999,
+                  providerSlug: 'openrouter',
+                  gatewayModel: 'z-ai/glm-5.2',
+                  harness: 'claude-code',
+                  input: { model: 'glm', prompt: 'fix it' },
+                },
+              },
+            }),
+      },
+    }),
+  );
+  const sessionId = sessionIdForWorkflowExecution(String(runId));
+  await t.run(async (ctx) => {
+    await ctx.db.insert('sandboxSessions', {
+      organizationId: ORG,
+      sessionId,
+      profile: 'agent',
+      status: 'active',
+      ownerType: 'workflow_run',
+      ownerId: `${String(runId)}:@workflow`,
+      createdBy: 'system:automation',
+      createdAt: 0,
+      expiresAt: 9_999_999,
+    });
+  });
+  return { runId, sessionId };
+}
+
+function createAsk(t: T, sessionId: string, question: string, org = ORG) {
+  return t.mutation(internal.automations.human_asks.createAskForExec, {
+    organizationId: org,
+    sessionId,
+    question,
+  });
+}
+
+/** A real task row, so the run input's `task.id` normalizes. */
+async function seedTask(t: T): Promise<Id<'tasks'>> {
+  return t.run(async (ctx) => {
+    const projectId = await ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'VAT desk',
+      createdBy: MEMBER,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    return await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      projectId,
+      title: 'VAT return 2026Q1',
+      status: 'in_progress',
+      rank: 'a0',
+      createdBy: MEMBER,
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+  });
+}
+
+describe('createAskForExec', () => {
+  it('attaches the question to the run the session proves, exec and node from the cursor', async () => {
+    const t = convexTest(schema, modules);
+    const taskId = await seedTask(t);
+    const { runId, sessionId } = await seedParkedRun(t, {
+      taskId: String(taskId),
+    });
+
+    const created = await createAsk(t, sessionId, 'Which amount governs?');
+
+    expect(created).toMatchObject({
+      question: 'Which amount governs?',
+      folded: false,
+      taskId,
+    });
+    if ('refused' in created) throw new Error('unexpected refusal');
+    const row = await t.run((ctx) => ctx.db.get(created.askId));
+    expect(row).toMatchObject({
+      organizationId: ORG,
+      runId,
+      nodeId: NODE,
+      execId: EXEC,
+      status: 'pending',
+    });
+    expect(row?.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('treats a garbage task reference as "no task" instead of failing the ask', async () => {
+    const t = convexTest(schema, modules);
+    const { sessionId } = await seedParkedRun(t, { taskId: 'not-a-task-id' });
+
+    const created = await createAsk(t, sessionId, 'Still works?');
+
+    if ('refused' in created) throw new Error('unexpected refusal');
+    expect(created.taskId).toBeUndefined();
+  });
+
+  it('folds a second question into the pending row instead of a second card', async () => {
+    const t = convexTest(schema, modules);
+    const { sessionId } = await seedParkedRun(t);
+
+    const first = await createAsk(t, sessionId, 'Question one?');
+    const second = await createAsk(t, sessionId, 'Question two?');
+
+    if ('refused' in first || 'refused' in second) {
+      throw new Error('unexpected refusal');
+    }
+    expect(second.folded).toBe(true);
+    expect(second.askId).toBe(first.askId);
+    const row = await t.run((ctx) => ctx.db.get(first.askId));
+    expect(row?.question).toBe('Question one?\n\nQuestion two?');
+  });
+
+  it('refuses an unknown session, a finished run, and a run with no live turn', async () => {
+    const t = convexTest(schema, modules);
+    expect(await createAsk(t, 'ses-unknown', 'Anyone?')).toHaveProperty(
+      'refused',
+    );
+
+    const finished = await seedParkedRun(t, { status: 'success' });
+    expect(await createAsk(t, finished.sessionId, 'Too late?')).toHaveProperty(
+      'refused',
+    );
+
+    const cursorless = await seedParkedRun(t, { cursor: false });
+    expect(await createAsk(t, cursorless.sessionId, 'No turn?')).toHaveProperty(
+      'refused',
+    );
+  });
+
+  it('refuses a caller naming another organization than the session’s', async () => {
+    const t = convexTest(schema, modules);
+    const { sessionId } = await seedParkedRun(t);
+    expect(
+      await createAsk(t, sessionId, 'Cross-org?', OTHER_ORG),
+    ).toHaveProperty('refused');
+  });
+});
+
+describe('answerAsk + getPendingAskForRun', () => {
+  it('lets a member answer once; the pending card clears reactively', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, ORG);
+    const { runId, sessionId } = await seedParkedRun(t);
+    const created = await createAsk(t, sessionId, 'Which amount governs?');
+    if ('refused' in created) throw new Error('unexpected refusal');
+
+    const asMember = t.withIdentity({ subject: MEMBER });
+    const pending = await asMember.query(
+      api.automations.human_asks.getPendingAskForRun,
+      { organizationId: ORG, runId },
+    );
+    expect(pending).toMatchObject({
+      askId: created.askId,
+      nodeId: NODE,
+      question: 'Which amount governs?',
+    });
+
+    await asMember.mutation(api.automations.human_asks.answerAsk, {
+      organizationId: ORG,
+      askId: created.askId,
+      answer: 'The invoice copy: 1580.00 net.',
+    });
+
+    const row = await t.run((ctx) => ctx.db.get(created.askId));
+    expect(row).toMatchObject({
+      status: 'answered',
+      answer: 'The invoice copy: 1580.00 net.',
+      answeredBy: MEMBER,
+    });
+    expect(
+      await asMember.query(api.automations.human_asks.getPendingAskForRun, {
+        organizationId: ORG,
+        runId,
+      }),
+    ).toBeNull();
+
+    // Answered means answered — a second submission is refused.
+    await expect(
+      asMember.mutation(api.automations.human_asks.answerAsk, {
+        organizationId: ORG,
+        askId: created.askId,
+        answer: 'Changed my mind.',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('shows nothing to a non-member and nothing on a dead run', async () => {
+    const t = convexTest(schema, modules);
+    const { runId, sessionId } = await seedParkedRun(t);
+    const created = await createAsk(t, sessionId, 'Secret?');
+    if ('refused' in created) throw new Error('unexpected refusal');
+
+    // Identity present, but no membership in ORG.
+    expect(
+      await t
+        .withIdentity({ subject: 'u_outsider' })
+        .query(api.automations.human_asks.getPendingAskForRun, {
+          organizationId: ORG,
+          runId,
+        }),
+    ).toBeNull();
+
+    await seedMember(t, ORG);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(runId, { status: 'cancelled' });
+    });
+    expect(
+      await t
+        .withIdentity({ subject: MEMBER })
+        .query(api.automations.human_asks.getPendingAskForRun, {
+          organizationId: ORG,
+          runId,
+        }),
+    ).toBeNull();
+  });
+});
+
+describe('retargetAgentCursor + closeAsk', () => {
+  it('moves the parked cursor onto the resumed exec, guarded by the old one', async () => {
+    const t = convexTest(schema, modules);
+    const { runId } = await seedParkedRun(t);
+
+    const wrong = await t.mutation(
+      internal.automations.human_asks.retargetAgentCursor,
+      {
+        organizationId: ORG,
+        runId,
+        nodeId: NODE,
+        fromExecId: 'exec-stale',
+        toExecId: 'exec-new',
+      },
+    );
+    expect(wrong.retargeted).toBe(false);
+
+    const right = await t.mutation(
+      internal.automations.human_asks.retargetAgentCursor,
+      {
+        organizationId: ORG,
+        runId,
+        nodeId: NODE,
+        fromExecId: EXEC,
+        toExecId: 'exec-new',
+        deadlineAt: 123_456_789,
+      },
+    );
+    expect(right.retargeted).toBe(true);
+    const run = await t.run((ctx) => ctx.db.get(runId));
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- seeded above in this exact shape
+    const checkpoints = run?.checkpoints as {
+      cursor: { agent: { execId: string; deadlineAt: number } };
+    };
+    expect(checkpoints.cursor.agent.execId).toBe('exec-new');
+    expect(checkpoints.cursor.agent.deadlineAt).toBe(123_456_789);
+  });
+
+  it('closes only pending asks', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, ORG);
+    const { sessionId } = await seedParkedRun(t);
+    const created = await createAsk(t, sessionId, 'Still there?');
+    if ('refused' in created) throw new Error('unexpected refusal');
+
+    await t.mutation(internal.automations.human_asks.closeAsk, {
+      askId: created.askId,
+      status: 'expired',
+    });
+    expect((await t.run((ctx) => ctx.db.get(created.askId)))?.status).toBe(
+      'expired',
+    );
+
+    // Terminal rows stay put — a late cancel cannot overwrite the expiry.
+    await t.mutation(internal.automations.human_asks.closeAsk, {
+      askId: created.askId,
+      status: 'cancelled',
+    });
+    expect((await t.run((ctx) => ctx.db.get(created.askId)))?.status).toBe(
+      'expired',
+    );
+  });
+});

--- a/services/platform/convex/automations/human_asks.ts
+++ b/services/platform/convex/automations/human_asks.ts
@@ -1,0 +1,399 @@
+/**
+ * The ask-a-human loop of an automation `agent` node.
+ *
+ * An agent turn that hits a decision only a person can make calls the
+ * sandbox bridge's `ask_human` tool and ends its turn. The host then parks
+ * the node on the ask instead of settling it (`agent_host`), the run stays
+ * `waiting`, and the question surfaces on the task panel and the run views.
+ * A member's answer resumes the SAME harness conversation on a fresh exec —
+ * nothing upstream re-runs, no side effect repeats. Unanswered past
+ * `expiresAt`, the host settles the turn as errored and the manifest decides
+ * what "no answer" means.
+ *
+ * Tenant isolation: every row carries `organizationId`; the public surface
+ * proves membership and reads through the run's own organization.
+ */
+
+import { ConvexError, v } from 'convex/values';
+
+import { isRecord } from '../../lib/utils/type-utils';
+import { internal } from '../_generated/api';
+import type { Doc, Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from '../_generated/server';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { readCheckpoints } from './checkpoints';
+
+/** How long a question waits for a person before the turn settles as
+ * unanswered. A parked run is a database row — the wait costs nothing — but
+ * an ask nobody will ever answer must not hold a task open forever. */
+export const HUMAN_ASK_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** One answer per turn: a second `ask_human` call while one is pending folds
+ * into the same row, so the panel shows ONE card and one submission answers
+ * everything the agent queued up. */
+const QUESTION_JOINER = '\n\n';
+
+/** Cap a stored question/answer — these render on cards and mirror into task
+ * comments, not a log store. */
+const TEXT_MAX = 8_000;
+
+function cleanText(raw: string, label: string): string {
+  const text = raw.trim();
+  if (text === '') {
+    throw new ConvexError({
+      code: 'HUMAN_ASK_INVALID',
+      message: `${label} must not be empty`,
+    });
+  }
+  return text.length <= TEXT_MAX ? text : `${text.slice(0, TEXT_MAX)}…`;
+}
+
+/** The run's task subject, when the manifest gave it one (`input.task.id`) —
+ * where the question/answer mirror lands. The run input is manifest-shaped
+ * (`v.any()`), so the id normalizes instead of being trusted: garbage means
+ * "no task", never a failed ask. */
+function taskIdOfRun(
+  db: QueryCtx['db'],
+  run: Doc<'automationRuns'>,
+): Id<'tasks'> | undefined {
+  const input: unknown = run.input;
+  if (!isRecord(input) || !isRecord(input.task)) return undefined;
+  const raw = input.task.id;
+  if (typeof raw !== 'string' || raw === '') return undefined;
+  return db.normalizeId('tasks', raw) ?? undefined;
+}
+
+async function pendingAskForExec(
+  ctx: { db: QueryCtx['db'] },
+  sessionId: string,
+  execId: string,
+): Promise<Doc<'automationHumanAsks'> | null> {
+  for await (const ask of ctx.db
+    .query('automationHumanAsks')
+    .withIndex('by_session_exec', (q) =>
+      q.eq('sessionId', sessionId).eq('execId', execId),
+    )) {
+    if (ask.status === 'pending') return ask;
+  }
+  return null;
+}
+
+/**
+ * Register one question from a live agent turn. The caller is the sandbox
+ * bridge dispatch, which knows only the session token's (org, sessionId) —
+ * the run, its LIVE exec, the node, and the task are all derived here from
+ * the run's own cursor, so nothing client-supplied can attach a question to
+ * a turn it does not own.
+ */
+export const createAskForExec = internalMutation({
+  args: {
+    organizationId: v.string(),
+    sessionId: v.string(),
+    question: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      askId: v.id('automationHumanAsks'),
+      taskId: v.optional(v.id('tasks')),
+      question: v.string(),
+      folded: v.boolean(),
+    }),
+    v.object({ refused: v.string() }),
+  ),
+  handler: async (ctx, args) => {
+    const question = cleanText(args.question, 'question');
+    const session = await ctx.db
+      .query('sandboxSessions')
+      .withIndex('by_sessionId', (q) => q.eq('sessionId', args.sessionId))
+      .first();
+    if (
+      session === null ||
+      session.organizationId !== args.organizationId ||
+      session.ownerType !== 'workflow_run'
+    ) {
+      return { refused: 'this session is not an automation run session' };
+    }
+    // `workflowExecutionOwnerId(runId)` = `${runId}:@workflow`.
+    const runIdRaw = session.ownerId.split(':')[0] ?? '';
+    const run = await ctx.db
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- derived from the session's owner key; a foreign id fails the org check below
+      .get(runIdRaw as Id<'automationRuns'>)
+      .catch(() => null);
+    if (run === null || run.organizationId !== args.organizationId) {
+      return { refused: 'the automation run behind this session is gone' };
+    }
+    if (
+      run.status !== 'waiting' &&
+      run.status !== 'running' &&
+      run.status !== 'queued'
+    ) {
+      return { refused: 'the automation run has already finished' };
+    }
+    const cursor = readCheckpoints(run.checkpoints).cursor;
+    if (cursor?.agent === undefined || cursor.agent.result !== undefined) {
+      return { refused: 'the run has no live agent turn right now' };
+    }
+    const execId = cursor.agent.execId;
+
+    const existing = await pendingAskForExec(ctx, args.sessionId, execId);
+    if (existing !== null) {
+      const merged = cleanText(
+        `${existing.question}${QUESTION_JOINER}${question}`,
+        'question',
+      );
+      await ctx.db.patch(existing._id, { question: merged });
+      return {
+        askId: existing._id,
+        ...(existing.taskId !== undefined ? { taskId: existing.taskId } : {}),
+        question,
+        folded: true,
+      };
+    }
+
+    const taskId = taskIdOfRun(ctx.db, run);
+    const askId = await ctx.db.insert('automationHumanAsks', {
+      organizationId: args.organizationId,
+      runId: run._id,
+      nodeId: cursor.node,
+      sessionId: args.sessionId,
+      execId,
+      question,
+      status: 'pending',
+      expiresAt: Date.now() + HUMAN_ASK_TTL_MS,
+      ...(taskId !== undefined ? { taskId } : {}),
+      createdAt: Date.now(),
+    });
+    return {
+      askId,
+      ...(taskId !== undefined ? { taskId } : {}),
+      question,
+      folded: false,
+    };
+  },
+});
+
+/** Stamp the harness resume handle when the asking turn ends — what the
+ * answered resume passes as `--resume` so the conversation continues. */
+export const recordAskParked = internalMutation({
+  args: {
+    askId: v.id('automationHumanAsks'),
+    agentSessionId: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const ask = await ctx.db.get(args.askId);
+    if (ask === null || ask.status !== 'pending') return null;
+    if (args.agentSessionId !== undefined) {
+      await ctx.db.patch(args.askId, { agentSessionId: args.agentSessionId });
+    }
+    return null;
+  },
+});
+
+/** The pending ask of one turn, read by the host's settle path to decide
+ * park-for-answer over settle. */
+export const getPendingAskForExec = internalQuery({
+  args: { sessionId: v.string(), execId: v.string() },
+  returns: v.union(v.any(), v.null()),
+  handler: async (ctx, args) =>
+    pendingAskForExec(ctx, args.sessionId, args.execId),
+});
+
+/** Full row for the resume action (already answered) — internal, org carried
+ * for the same mixed-up-caller refusal the other internal reads use. */
+export const getAskForResume = internalQuery({
+  args: { askId: v.id('automationHumanAsks'), organizationId: v.string() },
+  returns: v.union(v.any(), v.null()),
+  handler: async (ctx, args) => {
+    const ask = await ctx.db.get(args.askId);
+    if (ask === null || ask.organizationId !== args.organizationId) return null;
+    return ask;
+  },
+});
+
+/** Terminal states the host stamps: `expired` when nobody answered in time,
+ * `cancelled` when the turn ended in a crash or the run was cut. */
+export const closeAsk = internalMutation({
+  args: {
+    askId: v.id('automationHumanAsks'),
+    status: v.union(v.literal('expired'), v.literal('cancelled')),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const ask = await ctx.db.get(args.askId);
+    if (ask === null || ask.status !== 'pending') return null;
+    await ctx.db.patch(args.askId, { status: args.status });
+    return null;
+  },
+});
+
+/**
+ * A member answers. Records the answer and hands the turn back to the agent
+ * host, which resumes the SAME harness conversation with the answer as its
+ * next message. The task-comment mirror of the answer is the CALLER's job
+ * (the panel posts it as the member's own comment first, so the timeline
+ * shows who answered) — this mutation owns only the resume contract.
+ */
+export const answerAsk = mutation({
+  args: {
+    organizationId: v.string(),
+    askId: v.id('automationHumanAsks'),
+    answer: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new ConvexError({ code: 'UNAUTHORIZED' });
+    await getOrganizationMember(ctx, args.organizationId, authUser);
+    const ask = await ctx.db.get(args.askId);
+    if (ask === null || ask.organizationId !== args.organizationId) {
+      throw new ConvexError({ code: 'HUMAN_ASK_NOT_FOUND' });
+    }
+    if (ask.status !== 'pending') {
+      throw new ConvexError({ code: 'HUMAN_ASK_NOT_PENDING' });
+    }
+    if (Date.now() > ask.expiresAt) {
+      throw new ConvexError({ code: 'HUMAN_ASK_EXPIRED' });
+    }
+    const answer = cleanText(args.answer, 'answer');
+    await ctx.db.patch(args.askId, {
+      status: 'answered',
+      answer,
+      answeredBy: authUser.userId,
+      answeredAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(
+      0,
+      internal.automations.agent_host.resumeWorkflowAgentTurnWithAnswer,
+      { organizationId: args.organizationId, askId: args.askId },
+    );
+    return null;
+  },
+});
+
+const pendingAskShape = v.object({
+  askId: v.id('automationHumanAsks'),
+  runId: v.id('automationRuns'),
+  nodeId: v.string(),
+  question: v.string(),
+  createdAt: v.number(),
+  expiresAt: v.number(),
+  taskId: v.optional(v.id('tasks')),
+});
+
+/** The live question of one run, for the run dialog and the task panel —
+ * membership-gated like every public automation read. Null when nothing is
+ * waiting on a person. */
+export const getPendingAskForRun = query({
+  args: { organizationId: v.string(), runId: v.id('automationRuns') },
+  returns: v.union(pendingAskShape, v.null()),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return null;
+    try {
+      await getOrganizationMember(ctx, args.organizationId, authUser);
+    } catch {
+      // Non-member reads resolve to "nothing pending", mirroring the other
+      // run-view queries: the panel degrades instead of erroring.
+      console.warn('[human-asks] non-member pending-ask read refused');
+      return null;
+    }
+    const run = await ctx.db.get(args.runId);
+    if (run === null || run.organizationId !== args.organizationId) {
+      return null;
+    }
+    // A dead run's question is unanswerable — the resume guard would refuse
+    // anyway, so the card never offers it.
+    if (
+      run.status !== 'waiting' &&
+      run.status !== 'running' &&
+      run.status !== 'queued'
+    ) {
+      return null;
+    }
+    for await (const ask of ctx.db
+      .query('automationHumanAsks')
+      .withIndex('by_run_status', (q) =>
+        q.eq('runId', args.runId).eq('status', 'pending'),
+      )) {
+      if (Date.now() > ask.expiresAt) continue; // expiry is stamped lazily
+      return {
+        askId: ask._id,
+        runId: ask.runId,
+        nodeId: ask.nodeId,
+        question: ask.question,
+        createdAt: ask.createdAt,
+        expiresAt: ask.expiresAt,
+        ...(ask.taskId !== undefined ? { taskId: ask.taskId } : {}),
+      };
+    }
+    return null;
+  },
+});
+
+/**
+ * Move the run's parked agent cursor onto a new exec (the answered resume)
+ * and/or a new deadline (the ask's own expiry while waiting). Guarded exactly
+ * like `recordAgentTurnSettled`: the run must still be live, parked on this
+ * node, on the expected exec, with no result — a stale resume retargets
+ * nothing.
+ */
+export const retargetAgentCursor = internalMutation({
+  args: {
+    organizationId: v.string(),
+    runId: v.id('automationRuns'),
+    nodeId: v.string(),
+    fromExecId: v.string(),
+    toExecId: v.optional(v.string()),
+    deadlineAt: v.optional(v.number()),
+  },
+  returns: v.object({ retargeted: v.boolean() }),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.runId);
+    if (!row || row.organizationId !== args.organizationId) {
+      return { retargeted: false };
+    }
+    if (
+      row.status !== 'waiting' &&
+      row.status !== 'running' &&
+      row.status !== 'queued'
+    ) {
+      return { retargeted: false };
+    }
+    const checkpoints = readCheckpoints(row.checkpoints);
+    const cursor = checkpoints.cursor;
+    if (
+      cursor === undefined ||
+      cursor.node !== args.nodeId ||
+      cursor.agent === undefined ||
+      cursor.agent.execId !== args.fromExecId ||
+      cursor.agent.result !== undefined
+    ) {
+      return { retargeted: false };
+    }
+    await ctx.db.patch(args.runId, {
+      checkpoints: {
+        nodes: checkpoints.nodes,
+        cursor: {
+          ...cursor,
+          agent: {
+            ...cursor.agent,
+            ...(args.toExecId !== undefined ? { execId: args.toExecId } : {}),
+            ...(args.deadlineAt !== undefined
+              ? { deadlineAt: args.deadlineAt }
+              : {}),
+          },
+        },
+        executions: checkpoints.executions,
+      },
+    });
+    return { retargeted: true };
+  },
+});

--- a/services/platform/convex/automations/schema.ts
+++ b/services/platform/convex/automations/schema.ts
@@ -263,3 +263,42 @@ export const automationRunsTable = defineTable({
   .index('by_status', ['status'])
   .index('by_status_wakeAt', ['status', 'wakeAt'])
   .index('by_org_lifecycleStatus', ['organizationId', 'lifecycleStatus']);
+
+/**
+ * One question an agent turn asked a human (`ask_human`), and its answer. The
+ * asking run parks (`waiting`, `agent:<nodeId>`) with its turn ended; the
+ * answer resumes the SAME harness conversation (`agentSessionId`) on a fresh
+ * exec, so nothing upstream re-runs. The question and answer are mirrored
+ * onto the task timeline when the run has a task subject, but THIS row is the
+ * contract — a run without a task parks and resumes exactly the same way.
+ */
+export const automationHumanAsksTable = defineTable({
+  organizationId: v.string(),
+  runId: v.id('automationRuns'),
+  nodeId: v.string(),
+  /** The asking turn: the run's sandbox session + the exec that asked. */
+  sessionId: v.string(),
+  execId: v.string(),
+  /** Harness conversation handle captured at the asking turn's end — what the
+   * resumed exec passes as `--resume` so the agent keeps its context. */
+  agentSessionId: v.optional(v.string()),
+  question: v.string(),
+  status: v.union(
+    v.literal('pending'),
+    v.literal('answered'),
+    v.literal('expired'),
+    v.literal('cancelled'),
+  ),
+  /** Unanswered past this instant, the turn settles as errored (the manifest
+   * decides what "no answer" means — comment, todo, escalation). */
+  expiresAt: v.number(),
+  answer: v.optional(v.string()),
+  answeredBy: v.optional(v.string()),
+  answeredAt: v.optional(v.number()),
+  /** The task whose timeline mirrors the question, when the run has one. */
+  taskId: v.optional(v.id('tasks')),
+  createdAt: v.number(),
+})
+  .index('by_org', ['organizationId'])
+  .index('by_run_status', ['runId', 'status'])
+  .index('by_session_exec', ['sessionId', 'execId']);

--- a/services/platform/convex/chat/external_turn_drain.test.ts
+++ b/services/platform/convex/chat/external_turn_drain.test.ts
@@ -30,8 +30,11 @@ vi.mock('../node_only/sandbox/llm_gateway_admin', () => ({
 import { getFunctionName } from 'convex/server';
 
 import { internal } from '../_generated/api';
+import type { HarnessTimelinePart } from './external_turn_shared';
 import {
   drainExternalTurnWindow,
+  drainHarnessWindow,
+  STREAM_TEXT_THROTTLE_MS,
   TURN_ENDED_EXIT_GRACE_MS,
 } from './external_turn_shared';
 
@@ -80,6 +83,38 @@ const RESULT_LINE = `${JSON.stringify({
   result: 'Hello! How can I help?',
   is_error: false,
   duration_ms: 2900,
+})}\n`;
+
+/** A tool call with no assistant text around it — the shape of a tool-heavy
+ * stretch (reading files, running commands) where the agent says nothing. */
+const TOOL_USE_LINE = `${JSON.stringify({
+  type: 'assistant',
+  message: {
+    id: 'msg_t1',
+    model: 'z-ai/glm-5.2',
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_1',
+        name: 'Bash',
+        input: { command: 'ls /user/workspace/input' },
+      },
+    ],
+  },
+})}\n`;
+
+const TOOL_RESULT_LINE = `${JSON.stringify({
+  type: 'user',
+  message: {
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: 'INV-1.pdf',
+        is_error: false,
+      },
+    ],
+  },
 })}\n`;
 
 type DrainCallbacks = { onStdout?: (text: string) => void };
@@ -198,5 +233,103 @@ describe('drainExternalTurnWindow — turn-ended cut + mid-window streaming', ()
     // own — a leaked timer would abort a signal nothing listens to, but more
     // importantly it would keep the action's event loop dirty.
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+// Regression for the frozen run log: the automation lane passes BOTH sinks,
+// and the timeline used to ride the text guard — so a tool-heavy stretch
+// (which emits no assistant text) wrote nothing to the op row, the run dialog
+// sat on "starting up in the sandbox…", and the whole backlog flooded in at
+// once with the agent's next text block. The timeline must advance on tool
+// activity alone.
+describe('drainHarnessWindow — live timeline on tool-only activity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('emits the timeline for tool activity before any assistant text exists', async () => {
+    const onText = vi.fn<(text: string) => void>();
+    const onTimeline = vi.fn<(parts: HarnessTimelinePart[]) => void>();
+    mockDrain.mockImplementation(
+      (
+        _sessionId: unknown,
+        _body: unknown,
+        _signal: unknown,
+        callbacks: DrainCallbacks,
+      ) => {
+        callbacks.onStdout?.(TOOL_USE_LINE);
+        return Promise.resolve(TERMINAL);
+      },
+    );
+
+    const window = await drainHarnessWindow({
+      sessionId: 'session_1',
+      execId: 'exec_1',
+      harness: 'claude-code',
+      onText,
+      onTimeline,
+    });
+
+    expect(window.kind).toBe('terminal');
+    expect(onText).not.toHaveBeenCalled();
+    expect(onTimeline).toHaveBeenCalledTimes(1);
+    expect(onTimeline.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({
+        type: 'tool-Bash',
+        state: 'input-available',
+        toolCallId: 'toolu_1',
+      }),
+    ]);
+  });
+
+  it('keeps advancing the timeline between text blocks (tool results alone)', async () => {
+    const onText = vi.fn<(text: string) => void>();
+    const onTimeline = vi.fn<(parts: HarnessTimelinePart[]) => void>();
+    let emit: ((chunk: string) => void) | undefined;
+    let finish: (() => void) | undefined;
+    mockDrain.mockImplementation(
+      (
+        _sessionId: unknown,
+        _body: unknown,
+        _signal: unknown,
+        callbacks: DrainCallbacks,
+      ) => {
+        emit = callbacks.onStdout;
+        return new Promise((resolve) => {
+          finish = () => resolve(TERMINAL);
+        });
+      },
+    );
+
+    const windowPromise = drainHarnessWindow({
+      sessionId: 'session_1',
+      execId: 'exec_1',
+      harness: 'claude-code',
+      onText,
+      onTimeline,
+    });
+    emit?.(TEXT_LINE);
+    expect(onText).toHaveBeenCalledTimes(1);
+    expect(onTimeline).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(STREAM_TEXT_THROTTLE_MS + 50);
+    emit?.(TOOL_USE_LINE + TOOL_RESULT_LINE);
+
+    // No new text arrived — the tool transcript must still move.
+    expect(onText).toHaveBeenCalledTimes(1);
+    expect(onTimeline).toHaveBeenCalledTimes(2);
+    expect(onTimeline.mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({ type: 'text' }),
+      expect.objectContaining({
+        type: 'tool-Bash',
+        state: 'output-available',
+        toolCallId: 'toolu_1',
+      }),
+    ]);
+
+    finish?.();
+    await expect(windowPromise).resolves.toMatchObject({ kind: 'terminal' });
   });
 });

--- a/services/platform/convex/chat/external_turn_shared.ts
+++ b/services/platform/convex/chat/external_turn_shared.ts
@@ -766,20 +766,31 @@ export async function drainHarnessWindow(args: {
   let turnEndedGrace: ReturnType<typeof setTimeout> | undefined;
 
   let lastNotifiedText = '';
+  let lastNotifiedEventCount = 0;
   let lastNotifyAt = 0;
   const notifyTextSoFar = () => {
     if (args.onText === undefined && args.onTimeline === undefined) return;
     const now = Date.now();
     if (now - lastNotifyAt < STREAM_TEXT_THROTTLE_MS) return;
+    // The text notifies only when non-empty and changed; the transcript
+    // advances on tool activity even when no new text arrived (a tool-heavy
+    // stretch emits none), so the timeline tracks parsed events instead of
+    // riding the text guard — behind it, a run's live log stalls until the
+    // agent's next text block and then floods the whole backlog at once.
     const text = textFromEvents(events);
-    // The transcript advances on tool activity even when no new text arrived,
-    // so the timeline gets its own emptiness check.
-    const timelineOnly = args.onText === undefined;
-    if (!timelineOnly && (text === '' || text === lastNotifiedText)) return;
+    const textAdvanced = text !== '' && text !== lastNotifiedText;
+    const timelineAdvanced =
+      args.onTimeline !== undefined && events.length > lastNotifiedEventCount;
+    if (!textAdvanced && !timelineAdvanced) return;
     lastNotifyAt = now;
-    lastNotifiedText = text;
-    if (text !== '') args.onText?.(text);
-    args.onTimeline?.(timelineFromEvents(events));
+    if (textAdvanced) {
+      lastNotifiedText = text;
+      args.onText?.(text);
+    }
+    if (timelineAdvanced) {
+      lastNotifiedEventCount = events.length;
+      args.onTimeline?.(timelineFromEvents(events));
+    }
   };
 
   const onStdout = (chunk: string) => {

--- a/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
@@ -28,6 +28,7 @@ import { internalAction, type ActionCtx } from '../../_generated/server';
 import { searchKnowledge } from '../../knowledge/search';
 import { orgSlugFromId } from '../../lib/helpers/org_slug';
 import type { AgentReadSubject } from '../../lib/rls/helpers/agent_read_access';
+import { ASK_HUMAN_TOOL } from '../../sandbox/tool_names';
 
 /**
  * The read-only workspace tools a managed external turn is granted by default.
@@ -65,6 +66,14 @@ const TOOL_READ_SUBJECT: Record<WorkspaceReadTool, AgentReadSubject> = {
 
 /** Human-facing one-liners the status listing relays to the model. */
 const TOOL_DESCRIPTIONS: Record<string, string> = {
+  [ASK_HUMAN_TOOL]:
+    'Ask the human operator of this automation run a question only they can ' +
+    'answer (a business decision, a fact not in the files). Args: {question: ' +
+    'string} — a COMPLETE, self-contained question (name the document, date, ' +
+    'amount). You may bundle several questions in one call. After a ' +
+    'successful call, say you are waiting for the operator and END YOUR TURN ' +
+    '— you will be resumed with the answer. Do not call it repeatedly for ' +
+    'the same question.',
   rag_search:
     "Search the organization's knowledge base; returns the most relevant " +
     'passages with their text. Args: {query: string, limit?: number}.',
@@ -117,7 +126,9 @@ export const dispatchWorkspaceTool = internalAction({
   args: {
     organizationId: v.string(),
     sessionId: v.string(),
-    userId: v.string(),
+    /** The turn's user — absent on an automation run's token, whose only
+     * grantable tool (`ask_human`) needs none. */
+    userId: v.optional(v.string()),
     tool: v.string(),
     callArgs: v.any(),
   },
@@ -149,7 +160,8 @@ async function runWorkspaceTool(
   ctx: ActionCtx,
   args: {
     organizationId: string;
-    userId: string;
+    sessionId: string;
+    userId?: string;
     tool: string;
     callArgs: unknown;
   },
@@ -160,6 +172,17 @@ async function runWorkspaceTool(
   // requested name to still be a plain string.
   const requestedTool: string = args.tool;
 
+  // Not an org-data read: no turn user required (an automation run carries
+  // none), no role matrix — the ask attaches to the run the SESSION proves,
+  // and the answer side has its own membership gate.
+  if (args.tool === ASK_HUMAN_TOOL) {
+    return await runAskHuman(ctx, {
+      organizationId: args.organizationId,
+      sessionId: args.sessionId,
+      callArgs,
+    });
+  }
+
   if (!isWorkspaceReadTool(args.tool)) {
     return {
       status: 'invalid_args',
@@ -169,6 +192,22 @@ async function runWorkspaceTool(
     };
   }
 
+  // An external-turn token always carries the turn's user for the READ tools;
+  // without one the read cannot be access-scoped, so it cannot run.
+  if (args.userId === undefined) {
+    return {
+      status: 'unavailable',
+      blockers: [
+        {
+          code: 'no_user_context',
+          guidance:
+            'This session token carries no user context, so workspace reads cannot run from it.',
+        },
+      ],
+    };
+  }
+  const userId = args.userId;
+
   // The session token names the user this turn runs as; whether that user may
   // still READ is re-resolved per dispatch from the same membership + role
   // matrix the user-side RLS queries consult. A revoked or downgraded member
@@ -176,7 +215,7 @@ async function runWorkspaceTool(
   const subject = TOOL_READ_SUBJECT[args.tool];
   const access = await ctx.runQuery(
     internal.sandbox.workspace_access.resolveWorkspaceReadAccess,
-    { organizationId: args.organizationId, userId: args.userId, subject },
+    { organizationId: args.organizationId, userId, subject },
   );
   if (!access.allowed) {
     return {
@@ -243,7 +282,7 @@ async function runWorkspaceTool(
       internal.documents.internal_queries.listForAgent,
       {
         organizationId: args.organizationId,
-        userId: args.userId,
+        userId,
         ...(typeof callArgs.fileName === 'string'
           ? { fileName: callArgs.fileName }
           : {}),
@@ -326,6 +365,80 @@ async function runWorkspaceTool(
   return {
     status: 'error',
     message: `Workspace tool "${requestedTool}" has no handler.`,
+  };
+}
+
+/**
+ * `ask_human`: register a question for the run's operator. The session names
+ * the run (verified server-side against its live agent cursor); the question
+ * mirrors onto the task timeline when the run has a task subject. The tool
+ * result tells the model to END ITS TURN — the host parks the node on the
+ * pending ask and resumes this same conversation once someone answers.
+ */
+async function runAskHuman(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    sessionId: string;
+    callArgs: Record<string, unknown>;
+  },
+): Promise<ToolResult> {
+  const question =
+    typeof args.callArgs.question === 'string'
+      ? args.callArgs.question.trim()
+      : '';
+  if (question === '') {
+    return {
+      status: 'invalid_args',
+      message:
+        'ask_human needs a non-empty "question" string — a complete, ' +
+        'self-contained question the operator can answer without seeing ' +
+        'your session.',
+    };
+  }
+  const created = await ctx.runMutation(
+    internal.automations.human_asks.createAskForExec,
+    {
+      organizationId: args.organizationId,
+      sessionId: args.sessionId,
+      question,
+    },
+  );
+  if ('refused' in created) {
+    return {
+      status: 'unavailable',
+      blockers: [
+        {
+          code: 'no_live_run',
+          guidance: `The question could not be registered: ${created.refused}. Finish the task with what you have and note the open question in your summary.`,
+        },
+      ],
+    };
+  }
+  // Timeline mirror — the operator may live in the task view; a failed mirror
+  // never fails the ask (the panel card is the primary surface).
+  if (created.taskId !== undefined) {
+    await ctx
+      .runMutation(internal.tasks.internal_mutations.agentAddComment, {
+        organizationId: args.organizationId,
+        actorId: 'workflow',
+        taskId: created.taskId,
+        body: `[automated] 🙋 **Question for you** — the agent working on this task is waiting for your answer:\n\n> ${question.replaceAll('\n', '\n> ')}\n\nAnswer it from this task's assistant panel — the run resumes automatically once you submit.`,
+      })
+      .catch((err: unknown) =>
+        console.warn('[workspace-tools] ask_human comment mirror failed:', err),
+      );
+  }
+  return {
+    status: 'ok',
+    output: {
+      registered: true,
+      questionId: String(created.askId),
+      guidance:
+        'The operator has been asked. Now say briefly that you are waiting ' +
+        'for their answer and END YOUR TURN — you will be resumed with the ' +
+        'answer as your next message. Do not poll, do not repeat the call.',
+    },
   };
 }
 

--- a/services/platform/convex/sandbox/tool_names.ts
+++ b/services/platform/convex/sandbox/tool_names.ts
@@ -1,0 +1,14 @@
+/**
+ * Workspace-tool names shared across runtimes. The dispatch bridge that
+ * implements them is `'use node'`; the HTTP face that gates them is not — a
+ * name both sides compare against therefore lives here, importable from
+ * either.
+ */
+
+/**
+ * The ask-a-human tool of an automation agent turn: registers a question for
+ * the run's operator, then the agent ends its turn and is resumed with the
+ * answer. Granted ONLY on the workflow-agent lane — a chat turn's user is
+ * already present, so asking "a human" there is just asking the chat.
+ */
+export const ASK_HUMAN_TOOL = 'ask_human';

--- a/services/platform/convex/sandbox/tools_http.ts
+++ b/services/platform/convex/sandbox/tools_http.ts
@@ -69,27 +69,15 @@ export const toolsExecuteHandler = httpAction(async (ctx, request) => {
       ],
     });
   }
-  // An external-turn token always carries the turn's user; without one the read
-  // cannot be access-scoped, so it cannot run.
-  if (auth.userId === undefined) {
-    return json(200, {
-      status: 'unavailable',
-      blockers: [
-        {
-          code: 'no_user_context',
-          guidance:
-            'This session token carries no user context, so workspace tools cannot run from it.',
-        },
-      ],
-    });
-  }
-
+  // Whether a tool needs the turn's user is per-tool: the org-data READS
+  // refuse without one inside the dispatch, while `ask_human` (an automation
+  // run's tool — its token carries no user) runs on the session alone.
   const result: unknown = await ctx.runAction(
     internal.node_only.sandbox.workspace_tools_bridge.dispatchWorkspaceTool,
     {
       organizationId: auth.organizationId,
       sessionId: auth.sessionId,
-      userId: auth.userId,
+      ...(auth.userId !== undefined ? { userId: auth.userId } : {}),
       tool,
       callArgs,
     },

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -24,6 +24,7 @@ import {
 } from './audit_logs/schema';
 import {
   automationDeploymentsTable,
+  automationHumanAsksTable,
   automationProjectBindingsTable,
   automationRunsTable,
   automationsTable,
@@ -155,6 +156,7 @@ export default defineSchema({
   automationTriggers: automationTriggersTable,
   automationRuns: automationRunsTable,
   automationUploadIntents: automationUploadIntentsTable,
+  automationHumanAsks: automationHumanAsksTable,
   // Chat storage. `generations` is split out because it is the only hot-written
   // row during a turn — keeping it out of `threads` means a streaming turn does
   // not rewrite a row every thread list reads. `memories` are pending until a

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -862,6 +862,11 @@ automations:
       input: Der Schritt würde aufrufen mit
       approve: Freigeben
       reject: Ablehnen
+    ask:
+      title: Der Agent braucht deine Antwort, um weiterzumachen
+      answerLabel: Deine Antwort
+      placeholder: Schreib deine Antwort — Freitext genügt.
+      submit: Antwort senden & fortsetzen
     title: Läufe
     heading: 'Lauf von {automation}'
     empty: Diese Automatisierung ist noch nicht gelaufen.
@@ -6945,6 +6950,7 @@ tasks:
     cancelled: Der Lauf wurde abgebrochen.
     missingInput: Lege zuerst die Eingabedateien ab — unter Dateien ist bei dieser Aufgabe noch nichts.
     working: '{name} arbeitet an dieser Aufgabe.'
+    waitingAnswer: '{name} hat eine Frage und wartet — sobald du unten antwortest, geht es weiter.'
     details: Details
     currentStep: Aktueller Schritt
     stepNotReached: Der Lauf hat diesen Schritt nicht erreicht.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -823,6 +823,11 @@ automations:
       input: The step would call with
       approve: Approve
       reject: Reject
+    ask:
+      title: The agent needs your answer to continue
+      answerLabel: Your answer
+      placeholder: Type your answer — plain text is fine.
+      submit: Send answer & resume
     title: Runs
     heading: 'Run of {automation}'
     empty: This automation has not run yet.
@@ -7026,6 +7031,7 @@ tasks:
     cancelled: The run was cancelled.
     missingInput: Add the input files first — this task's Files list is still empty.
     working: '{name} is working on this task.'
+    waitingAnswer: '{name} paused with a question — it continues as soon as you answer below.'
     details: Details
     currentStep: Current step
     stepNotReached: The run has not reached this step.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -860,6 +860,11 @@ automations:
       input: "L'étape appellerait avec"
       approve: Approuver
       reject: Rejeter
+    ask:
+      title: "L'agent a besoin de ta réponse pour continuer"
+      answerLabel: Ta réponse
+      placeholder: Écris ta réponse — du texte simple suffit.
+      submit: Envoyer la réponse & reprendre
     title: Exécutions
     heading: 'Exécution de {automation}'
     empty: Cette automatisation ne s’est encore jamais exécutée.
@@ -7040,6 +7045,7 @@ tasks:
     cancelled: "L'exécution a été annulée."
     missingInput: "Dépose d'abord les fichiers d'entrée — la liste Fichiers de cette tâche est encore vide."
     working: '{name} travaille sur cette tâche.'
+    waitingAnswer: '{name} attend ta réponse à une question — dès que tu réponds ci-dessous, ça reprend.'
     details: Détails
     currentStep: Étape en cours
     stepNotReached: "L'exécution n'a pas atteint cette étape."


### PR DESCRIPTION
## Problem

An automation run's agent-node dialog sat on "The agent is starting up in the sandbox…" for minutes while the turn was in fact running, then the whole log backlog flooded in at once. Observed live on a Swiss VAT return desk run.

Root cause: `drainHarnessWindow`'s throttled notifier gated the `onTimeline` flush behind the text guard (`text === '' || text unchanged → return`) whenever `onText` was also passed — exactly the automation agent lane's sink shape. A tool-heavy stretch (reading files, running commands) emits no assistant text, so the op row's `liveTimeline` got zero writes; the log only advanced in bursts on each new text block.

## Fix

- `external_turn_shared.ts`: the timeline advances on parsed-event count, independent of the text guard (same 250ms throttle). The chat lane passes `onText` only and keeps its exact behavior.
- `agent_host.ts`: `liveProgressSink` writes are serialized on a promise chain (the chat lane's stream-chain pattern) and flushed before `continueOrSettle`, so a late live flush cannot land after — and shrink — the final transcript snapshot. The existing running-after-terminal guard in `upsertSessionOp` already covers the status field; this covers payload ordering.

The task-agent lane passes no sinks and has no live-log query surface (`kind: 'task-agent'` ops are only read by the watchdog) — left untouched.

## Verification

- Two regression tests in `external_turn_drain.test.ts`: tool-only activity emits the timeline before any assistant text exists; tool results alone keep advancing it between text blocks.
- `chat` + `automations` + `sandbox` server suites: 570 passed. `tsc` and `oxlint` clean.
- Live-verified on a running VAT desk run: the current agent node's first tool row rendered with no text present, and the log grew 2 → 19 rows in ~2 minutes, chronological and pinned to bottom.

---

## Also on this branch (grew per review): the run canvas fix and the ask-a-human loop

### fix: keep the run canvas on the step in flight (`d080edaf`)

The progress dialog's canvas never framed the running step: the follow effect gated on `useNodesInitialized` (false forever in a real browser for fixed-box nodes) and recorded a step as framed even when React Flow silently dropped the pan or later grew its pane. Now gated on `onInit` + the measured pane, keyed on `<id>@<x>,<y>#<paneW>x<paneH>` so the framing re-asserts after auto-layout and pane growth, with a one-shot `fitView` fallback when the cursor is not drawable. Default follow zoom 0.85 → 1. "Actions performed" was `shrink-0` and overflowed the dialog's clipped box instead of scrolling — now a real scroller. New real-Chromium test tier for the canvas (`automation-canvas.browser.test.tsx`, 3 tests) — jsdom cannot witness a viewport.

### feat: let automation agents ask the operator and resume (`18bc0991`)

An agent turn that hits an operator-only decision calls the `ask_human` workspace tool (bridge-dispatched; granted only on the workflow-agent lane — chat keeps its read-only set), then ends its turn. The host parks the node instead of settling: the run sits `waiting`, the question mirrors onto the task timeline and renders as an answer card on the task panel and run views, and the member's answer resumes the **same harness conversation** (`--resume`) on a fresh exec — nothing upstream re-runs, no side effect repeats, and the resumed turn may ask again (rounds unbounded by design). Unanswered asks expire after 7 days and settle the turn as errored, leaving "what silence means" to the manifest.

- `automationHumanAsks` table + lifecycle (`convex/automations/human_asks.ts`): the ask derives run/node/exec from the session's owner key and the run's own cursor — nothing client-supplied picks the target; a second question folds into the pending card; answer mutation is membership-gated; queries go quiet on dead runs. Schema gate: data-safe growth, no migration.
- Park/resume in `agent_host.ts`: pending ask on a clean turn end ⇒ record the harness resume handle, extend the parked cursor's deadline past the ask expiry, release the key (`awaiting_human`), don't settle; the answer schedules `resumeWorkflowAgentTurnWithAnswer`, which re-resolves serving (config may move during a days-long wait), mints a fresh key, retargets the cursor to a new exec, and rides the normal drive chain. Crashed turns cancel their ask and settle as before.
- UI: `RunAskCard` in the task subject panel (state line: "paused with a question", answer posted as the member's own comment before the resume) and in the run detail view. Strings in en/de/fr.
- Tests: 9 convex-test lifecycle/isolation tests, 2 card tests; all touched suites green (579 server / 227 client / i18n 48).

**Verified live end to end** on a probe automation: `ask_human` registered the question → run `waiting`, card shown → answered "SWORDFISH" → same conversation resumed → agent wrote `/user/output/answer.txt` (harvested into the run output) → run `success`.

Field note for local stacks: two earlier probe rounds failed with a silently tool-less harness — the local `tale-sandbox-runtime:latest` predated the integrations→connectors rename and lacked `tale-connectors-mcp`. If MCP tools seem absent in a sandbox turn, rebuild the runtime image (`SANDBOX_RUNTIME_FORCE_BUILD=1 bun scripts/ensure-sandbox-runtime-image.ts`) and reap the old session containers.

Follow-ups deliberately out of this PR: desk manifest/prompt migration to prefer `ask_human` over encoded holds (config pack), end-user docs for the answer card, and the long-wait phase 2 (end-turn + single-node re-run for waits past the turn deadline is already covered by the resume path; no further machinery needed).
