### PR TITLE
fix(platform): bound the log an automation run stores

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -47,6 +47,7 @@ import type * as audit_logs_validators from "../audit_logs/validators.js";
 import type * as audit_logs_verify_integrity from "../audit_logs/verify_integrity.js";
 import type * as auth from "../auth.js";
 import type * as automations_agent_host from "../automations/agent_host.js";
+import type * as automations_bound_run_payload from "../automations/bound_run_payload.js";
 import type * as automations_catalog from "../automations/catalog.js";
 import type * as automations_checkpoints from "../automations/checkpoints.js";
 import type * as automations_cron from "../automations/cron.js";
@@ -937,6 +938,7 @@ declare const fullApi: ApiFromModules<{
   "audit_logs/verify_integrity": typeof audit_logs_verify_integrity;
   auth: typeof auth;
   "automations/agent_host": typeof automations_agent_host;
+  "automations/bound_run_payload": typeof automations_bound_run_payload;
   "automations/catalog": typeof automations_catalog;
   "automations/checkpoints": typeof automations_checkpoints;
   "automations/cron": typeof automations_cron;

--- a/services/platform/convex/automations/bound_run_payload.test.ts
+++ b/services/platform/convex/automations/bound_run_payload.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NodeTrace } from '../../lib/engine/core/types';
+import {
+  boundCheckpointTrace,
+  boundNodeTrace,
+  boundRunTrace,
+  MAX_RUN_DETAIL_CHARS,
+  MAX_TRACE_FIELD_CHARS,
+  truncateRunDetail,
+} from './bound_run_payload';
+import type { NodeCheckpoint } from './checkpoints';
+
+const entry = (over: Partial<NodeTrace> = {}): NodeTrace => ({
+  node: 'fetch',
+  type: 'imap-smtp.list_messages',
+  status: 'ok',
+  ...over,
+});
+
+describe('truncateRunDetail', () => {
+  it('leaves a normal failure reason untouched', () => {
+    const detail = 'IMAP host is not configured.';
+    expect(truncateRunDetail(detail)).toBe(detail);
+  });
+
+  it('passes undefined through so an absent detail stays absent', () => {
+    expect(truncateRunDetail(undefined)).toBeUndefined();
+  });
+
+  it('caps a 66 KB engine-interpolated reason inside the limit', () => {
+    // execute/index.ts:357 interpolates JSON.stringify(resolved) into the message.
+    const detail = `resolved input does not match the schema. Resolved input was: ${'{"body":"…"},'.repeat(6000)}`;
+    expect(detail.length).toBeGreaterThan(66_000);
+
+    const result = truncateRunDetail(detail);
+
+    // Hard bound: the marker is budgeted INSIDE the cap, not appended on top.
+    expect(result.length).toBe(MAX_RUN_DETAIL_CHARS);
+    expect(result).toContain(`truncated from ${detail.length} characters`);
+  });
+
+  it('re-capping an already-capped detail is a no-op', () => {
+    const once = truncateRunDetail('x'.repeat(50_000));
+    expect(truncateRunDetail(once)).toBe(once);
+  });
+});
+
+describe('boundNodeTrace', () => {
+  it('keeps a small input and output as they are', () => {
+    const t = entry({ input: { limit: 25 }, output: { count: 2 } });
+    expect(boundNodeTrace(t)).toEqual(t);
+  });
+
+  it('preserves the identity fields', () => {
+    const bounded = boundNodeTrace(entry({ ms: 12, note: 'skipped' }));
+    expect(bounded.node).toBe('fetch');
+    expect(bounded.type).toBe('imap-smtp.list_messages');
+    expect(bounded.status).toBe('ok');
+    expect(bounded.ms).toBe(12);
+    expect(bounded.note).toBe('skipped');
+  });
+
+  it('replaces an output past the hard ceiling with a marker naming the size', () => {
+    // A github.get_pull_request_diff forEach output: many large diffs.
+    const output = Array.from({ length: 40 }, (_, i) => ({
+      pull: i,
+      diff: 'x'.repeat(3000),
+    }));
+
+    const bounded = boundNodeTrace(entry({ output }));
+
+    expect(JSON.stringify(bounded.output).length).toBeLessThan(
+      MAX_TRACE_FIELD_CHARS,
+    );
+    expect(bounded.output).toMatchObject({ __truncated: true });
+  });
+
+  it('shape-bounds a large-but-tolerable value instead of dropping it', () => {
+    const bounded = boundNodeTrace(
+      entry({ input: { body: 'y'.repeat(9000) } }),
+    );
+
+    // Kept as a string with a count marker — not replaced wholesale.
+    const input = bounded.input as { body: string };
+    expect(typeof input.body).toBe('string');
+    expect(input.body).toContain('chars)');
+  });
+
+  it('caps a per-node error string', () => {
+    const bounded = boundNodeTrace(entry({ error: 'e'.repeat(80_000) }));
+    expect(bounded.error?.length).toBe(MAX_RUN_DETAIL_CHARS);
+  });
+
+  it('leaves an absent input/output absent rather than adding keys', () => {
+    const bounded = boundNodeTrace(entry());
+    expect('input' in bounded).toBe(false);
+    expect('output' in bounded).toBe(false);
+  });
+});
+
+describe('boundRunTrace', () => {
+  it('bounds every entry and preserves execution order', () => {
+    const trace = [
+      entry({ node: 'a', output: { ok: 1 } }),
+      entry({ node: 'b', output: 'z'.repeat(200_000) }),
+      entry({ node: 'c' }),
+    ];
+
+    const bounded = boundRunTrace(trace);
+
+    expect(bounded.map((e) => e.node)).toEqual(['a', 'b', 'c']);
+    expect(JSON.stringify(bounded).length).toBeLessThan(
+      3 * MAX_TRACE_FIELD_CHARS,
+    );
+  });
+});
+
+describe('boundCheckpointTrace', () => {
+  /**
+   * The load-bearing guarantee: `outputsFrom()` builds the executor's scope
+   * from `checkpoint.output`, so bounding it would change execution, not the
+   * log. And `effects` is the audit trail of real side effects.
+   */
+  it('never touches the checkpoint output — it feeds the executor scope', () => {
+    const output = {
+      messages: Array.from({ length: 500 }, (_, i) => ({
+        id: i,
+        body: 'b'.repeat(2000),
+      })),
+    };
+    const checkpoint: NodeCheckpoint = {
+      status: 'ok',
+      output,
+      trace: entry({ output }),
+      effects: [],
+    };
+
+    const bounded = boundCheckpointTrace(checkpoint);
+
+    expect(bounded.output).toBe(output);
+  });
+
+  it('never touches effects — that is the side-effect audit trail', () => {
+    const effects = [
+      {
+        node: 'send',
+        connector: 'imap-smtp',
+        input: { text: 'q'.repeat(60_000) },
+      },
+    ];
+    const checkpoint: NodeCheckpoint = {
+      status: 'ok',
+      output: null,
+      trace: entry(),
+      effects,
+    };
+
+    expect(boundCheckpointTrace(checkpoint).effects).toBe(effects);
+  });
+
+  it('does bound the nested trace', () => {
+    const checkpoint: NodeCheckpoint = {
+      status: 'ok',
+      output: null,
+      trace: entry({ output: 'w'.repeat(200_000) }),
+      effects: [],
+    };
+
+    const bounded = boundCheckpointTrace(checkpoint);
+
+    // A single oversized STRING is shape-bounded — kept, with a count marker —
+    // rather than replaced wholesale. The `__truncated` marker is reserved for
+    // values shape bounding cannot get under the ceiling (many large items).
+    expect(typeof bounded.trace.output).toBe('string');
+    expect(bounded.trace.output as string).toContain('(+195904 chars)');
+    expect(JSON.stringify(bounded.trace.output).length).toBeLessThan(
+      MAX_TRACE_FIELD_CHARS,
+    );
+  });
+});

--- a/services/platform/convex/automations/bound_run_payload.ts
+++ b/services/platform/convex/automations/bound_run_payload.ts
@@ -1,0 +1,130 @@
+/**
+ * Bound the DESCRIPTIVE parts of an `automationRuns` row before they are
+ * stored.
+ *
+ * Why: a run document carries no size limit of any kind, and Convex refuses a
+ * document over ~1 MiB — so an oversized run does not merely bloat the table,
+ * its write FAILS and the run dies (possibly without even recording why). On
+ * top of that the row is patched once per completed node and Convex retains
+ * every revision, so each stored byte is paid for many times over. The retired
+ * `wfExecutions` had an escape valve for this (payloads over 400 KB were
+ * offloaded to file storage); the rewrite did not carry one over.
+ *
+ * **What is bounded, and what deliberately is not.** Only fields nothing reads
+ * back are safe to shorten:
+ *
+ *  - `trace` / `checkpoint.trace` — pure diagnostics. Bounded.
+ *  - `detail` — the operator-facing failure reason. Capped.
+ *  - `checkpoint.output` — **NEVER**. `outputsFrom()` builds the executor's
+ *    scope from it, so a later node reading `{{ nodes.x.output }}` would see a
+ *    truncation marker instead of its data: that changes execution, not the log.
+ *  - the run's `output` — **NEVER**. Returned to API callers.
+ *  - `effects` — **NEVER**. The audit trail of real side effects (message sent,
+ *    record written, model called); truncating it weakens auditability.
+ *
+ * This is why the change bounds the run log rather than the run: the functional
+ * payload still needs the storage-offload valve the old engine had, which is a
+ * larger change than this one.
+ *
+ * **Bound exactly once, at first write.** {@link boundJson} is deliberately not
+ * idempotent — a second pass re-cuts its own marker and reports a smaller loss
+ * than really occurred. So bound a value as it first enters the row and never
+ * re-bound one read back out: `recordCheckpoint` bounds only the incoming
+ * entry, never the already-stored `checkpoints.nodes` it merges into.
+ *
+ * No governance surface: nothing here deletes a row or drops a side effect, so
+ * it needs no retention policy, legal-hold check, or operator opt-in — unlike
+ * the retention sweep, which is off by default and therefore cannot be what
+ * keeps a default install bounded.
+ */
+
+import type { NodeTrace } from '../../lib/engine/core/types';
+import { boundJson } from '../../lib/shared/utils/bound-json';
+import type { NodeCheckpoint } from './checkpoints';
+
+/**
+ * Shape limits for a trace entry's `input`/`output`. Generous next to the chat
+ * tool loop's 400 characters: a person debugging a failed run needs the real
+ * value and the real stack, not the gist.
+ */
+const TRACE_LIMITS = {
+  maxString: 4096,
+  maxItems: 50,
+  maxDepth: 10,
+} as const;
+
+/**
+ * Hard ceiling per trace field AFTER shape bounding. Shape limits alone cannot
+ * bound a total (fifty 4 KB strings is still 200 KB), so anything past this is
+ * replaced wholesale by {@link truncatedMarker} — that is what makes the bound a
+ * guarantee rather than a tendency.
+ */
+export const MAX_TRACE_FIELD_CHARS = 32 * 1024;
+
+/** Characters of `detail` kept, marker included. */
+export const MAX_RUN_DETAIL_CHARS = 4096;
+
+/** Stand-in for a value too large to keep, naming what was dropped. */
+function truncatedMarker(chars: number): Record<string, unknown> {
+  return {
+    __truncated: true,
+    chars,
+    note: 'value exceeded the run-trace ceiling and was not stored',
+  };
+}
+
+/** Shape-bound a trace field, then enforce the hard ceiling. */
+function boundTraceField(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  const shaped = boundJson(value, TRACE_LIMITS);
+  const chars = JSON.stringify(shaped)?.length ?? 0;
+  return chars <= MAX_TRACE_FIELD_CHARS ? shaped : truncatedMarker(chars);
+}
+
+/**
+ * Cap `detail` to {@link MAX_RUN_DETAIL_CHARS} **including** the marker, so the
+ * bound holds and re-capping an already-capped value is a no-op. The engine
+ * interpolates whole resolved inputs into some error messages
+ * (`execute/index.ts` :357, :95), which is how a 66 KB failure reason happens.
+ */
+export function truncateRunDetail(detail: string): string;
+export function truncateRunDetail(detail: undefined): undefined;
+export function truncateRunDetail(
+  detail: string | undefined,
+): string | undefined;
+export function truncateRunDetail(
+  detail: string | undefined,
+): string | undefined {
+  if (detail === undefined) return undefined;
+  if (detail.length <= MAX_RUN_DETAIL_CHARS) return detail;
+  // The marker names only the original length, so its width does not depend on
+  // how much is kept (which would be circular).
+  const marker = `\n… [truncated from ${detail.length} characters]`;
+  return `${detail.slice(0, MAX_RUN_DETAIL_CHARS - marker.length)}${marker}`;
+}
+
+/** Bound one trace entry's descriptive fields, leaving its identity intact. */
+export function boundNodeTrace(entry: NodeTrace): NodeTrace {
+  const bounded: NodeTrace = { ...entry };
+  if (entry.input !== undefined) bounded.input = boundTraceField(entry.input);
+  if (entry.output !== undefined)
+    bounded.output = boundTraceField(entry.output);
+  if (entry.error !== undefined) bounded.error = truncateRunDetail(entry.error);
+  return bounded;
+}
+
+/** Bound a whole run trace, in place-order. */
+export function boundRunTrace(trace: readonly NodeTrace[]): NodeTrace[] {
+  return trace.map(boundNodeTrace);
+}
+
+/**
+ * Bound a checkpoint's `trace` ONLY. `output` and `effects` are passed through
+ * untouched — see the header: one feeds the executor's scope, the other is the
+ * audit trail.
+ */
+export function boundCheckpointTrace(
+  checkpoint: NodeCheckpoint,
+): NodeCheckpoint {
+  return { ...checkpoint, trace: boundNodeTrace(checkpoint.trace) };
+}

--- a/services/platform/convex/automations/mutations.ts
+++ b/services/platform/convex/automations/mutations.ts
@@ -23,7 +23,11 @@
 
 import { ConvexError, v } from 'convex/values';
 
-import type { Automation, RunResult } from '../../lib/engine/core/types';
+import type {
+  Automation,
+  NodeTrace,
+  RunResult,
+} from '../../lib/engine/core/types';
 import { defineAbilityFor } from '../../lib/permissions/ability';
 import { automationPresentationSchema } from '../../lib/shared/schemas/automation_presentation';
 import { automationSettingsSchema } from '../../lib/shared/schemas/automation_settings';
@@ -36,6 +40,11 @@ import { internalMutation, mutation } from '../_generated/server';
 import { requireOrgAdminOrDeveloper } from '../lib/auth/require_org_admin_or_developer';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import {
+  boundCheckpointTrace,
+  boundRunTrace,
+  truncateRunDetail,
+} from './bound_run_payload';
 import type { NodeCheckpoint, NodeCursor } from './checkpoints';
 import { readCheckpoints } from './checkpoints';
 import { RUN_CLAIM_PROMISE_MS } from './liveness';
@@ -964,9 +973,16 @@ export const recordProgress = internalMutation({
     const checkpoint = args.checkpoint as NodeCheckpoint | undefined;
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- same
     const cursor = args.cursor as NodeCursor | undefined;
+    // Bound the INCOMING entry only. The entries already in
+    // `checkpoints.nodes` were bounded when they were first written, and
+    // `boundJson` is not idempotent — re-bounding them on every subsequent node
+    // would re-cut their markers and understate what was dropped.
     const nodes =
       args.nodeId !== undefined && checkpoint !== undefined
-        ? { ...checkpoints.nodes, [args.nodeId]: checkpoint }
+        ? {
+            ...checkpoints.nodes,
+            [args.nodeId]: boundCheckpointTrace(checkpoint),
+          }
         : checkpoints.nodes;
     await ctx.db.patch(args.runId, {
       checkpoints: {
@@ -1016,7 +1032,7 @@ export const suspendRun = internalMutation({
     const seq = (row.chainSeq ?? 0) + 1;
     await ctx.db.patch(args.runId, {
       status: 'waiting',
-      detail: args.detail,
+      detail: truncateRunDetail(args.detail),
       checkpoints: {
         nodes: checkpoints.nodes,
         ...(cursor !== undefined && cursor !== null && { cursor }),
@@ -1180,15 +1196,20 @@ export const finishRun = internalMutation({
       return { status: row.status };
     }
     const checkpoints = readCheckpoints(row.checkpoints);
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the walker owns the trace shape; the row stores it as JSON
+    const trace = (args.trace ?? []) as NodeTrace[];
     await ctx.db.patch(args.runId, {
       status: args.status,
       ...(args.output !== undefined && { output: args.output }),
-      trace: args.trace,
+      // The trace is freshly assembled by the walker, so this is its FIRST
+      // write — bound it here. `effects` is deliberately untouched: it is the
+      // audit trail of real side effects.
+      trace: boundRunTrace(trace),
       effects: args.effects,
       // A finishing detail (a failure message) replaces; finishing WITHOUT
       // one clears whatever wait detail is still on the row — a completed
       // run must not keep advertising the approval it once parked on.
-      detail: args.detail,
+      detail: truncateRunDetail(args.detail),
       checkpoints: { nodes: checkpoints.nodes, executions: args.executions },
       // A terminal row makes no promise.
       wakeAt: undefined,

--- a/services/platform/convex/automations/store.ts
+++ b/services/platform/convex/automations/store.ts
@@ -32,6 +32,7 @@ import type { Automation, RunResult } from '../../lib/engine/core/types';
 import { internal } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
 import type { ActionCtx, MutationCtx, QueryCtx } from '../_generated/server';
+import { boundRunTrace, truncateRunDetail } from './bound_run_payload';
 
 /** Who a write is attributed to — a user id, or a system marker for a write
  * the platform performs on its own behalf. */
@@ -555,10 +556,13 @@ export function automationStore(
         startedBy: actor,
         input: null,
         ...(result.output !== undefined && { output: result.output }),
-        trace: result.trace,
+        // First (and only) write of this run's log — bound the diagnostics
+        // here. `output` and `effects` are left whole: one is returned to the
+        // caller, the other is the side-effect audit trail.
+        trace: boundRunTrace(result.trace),
         effects: result.effects,
         ...(result.error?.message !== undefined && {
-          detail: result.error.message,
+          detail: truncateRunDetail(result.error.message),
         }),
         startedAt: now,
         finishedAt: now,

--- a/services/platform/lib/chat/context.ts
+++ b/services/platform/lib/chat/context.ts
@@ -38,6 +38,7 @@
  */
 
 import { UNTRUSTED_CONTENT_SYSTEM_PROMPT } from '../../convex/lib/untrusted_content';
+import { boundJson } from '../shared/utils/bound-json';
 import { narrowBcp47 } from '../shared/utils/narrow-bcp47';
 import { pickField } from '../shared/utils/pick-field';
 import { MAX_HISTORY_BUDGET_TOKENS } from './budget';
@@ -254,29 +255,15 @@ const TOOL_RESULT_MAX_DEPTH = 8;
  * user's words is not).
  */
 export function boundToolResult(value: unknown, depth = 0): unknown {
-  if (depth > TOOL_RESULT_MAX_DEPTH) return '…';
-  if (typeof value === 'string') {
-    return value.length > TOOL_RESULT_MAX_STRING
-      ? `${value.slice(0, TOOL_RESULT_MAX_STRING)}…(+${value.length - TOOL_RESULT_MAX_STRING} chars)`
-      : value;
-  }
-  if (Array.isArray(value)) {
-    const items = value
-      .slice(0, TOOL_RESULT_MAX_ITEMS)
-      .map((item) => boundToolResult(item, depth + 1));
-    if (value.length > TOOL_RESULT_MAX_ITEMS) {
-      items.push(`…(+${value.length - TOOL_RESULT_MAX_ITEMS} more items)`);
-    }
-    return items;
-  }
-  if (value !== null && typeof value === 'object') {
-    const out: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      out[key] = boundToolResult(entry, depth + 1);
-    }
-    return out;
-  }
-  return value;
+  return boundJson(
+    value,
+    {
+      maxString: TOOL_RESULT_MAX_STRING,
+      maxItems: TOOL_RESULT_MAX_ITEMS,
+      maxDepth: TOOL_RESULT_MAX_DEPTH,
+    },
+    depth,
+  );
 }
 
 /** Apply the tool-result bound to a message's parts, leaving every other

--- a/services/platform/lib/shared/utils/bound-json.test.ts
+++ b/services/platform/lib/shared/utils/bound-json.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { boundJson, type BoundJsonLimits } from './bound-json';
+
+/**
+ * These lock the algorithm that was previously inlined in the chat tool loop
+ * (`boundToolResult`) and is now shared with the automations run log. It had no
+ * tests before the extraction, so the marker text and the pass-through cases
+ * are pinned here — the chat window sizing depends on both.
+ */
+
+const LIMITS: BoundJsonLimits = {
+  maxString: 10,
+  maxItems: 3,
+  maxDepth: 2,
+};
+
+describe('boundJson', () => {
+  it('leaves a short string untouched', () => {
+    expect(boundJson('short', LIMITS)).toBe('short');
+  });
+
+  it('leaves a string exactly at the limit untouched', () => {
+    expect(boundJson('0123456789', LIMITS)).toBe('0123456789');
+  });
+
+  it('cuts a long string and reports the dropped character count', () => {
+    expect(boundJson('0123456789abcde', LIMITS)).toBe('0123456789…(+5 chars)');
+  });
+
+  it('caps an array and reports the dropped item count', () => {
+    expect(boundJson([1, 2, 3, 4, 5], LIMITS)).toEqual([
+      1,
+      2,
+      3,
+      '…(+2 more items)',
+    ]);
+  });
+
+  it('leaves an array exactly at the limit uncapped', () => {
+    expect(boundJson([1, 2, 3], LIMITS)).toEqual([1, 2, 3]);
+  });
+
+  it('walks nested objects and bounds their strings', () => {
+    expect(boundJson({ a: { b: '0123456789abc' } }, LIMITS)).toEqual({
+      a: { b: '0123456789…(+3 chars)' },
+    });
+  });
+
+  it('elides a subtree past the depth limit', () => {
+    // depth 0 = root object, 1 = a, 2 = b, 3 = c -> elided
+    expect(boundJson({ a: { b: { c: { d: 'deep' } } } }, LIMITS)).toEqual({
+      a: { b: { c: '…' } },
+    });
+  });
+
+  it('preserves null and undefined rather than turning them into markers', () => {
+    expect(boundJson(null, LIMITS)).toBeNull();
+    expect(boundJson(undefined, LIMITS)).toBeUndefined();
+    expect(boundJson({ a: null }, LIMITS)).toEqual({ a: null });
+  });
+
+  it('passes non-string primitives through untouched', () => {
+    expect(boundJson(42, LIMITS)).toBe(42);
+    expect(boundJson(true, LIMITS)).toBe(true);
+  });
+
+  /**
+   * NOT idempotent, and the second pass MISREPORTS the loss: the marker itself
+   * is long enough to be re-cut, so `+90 chars` becomes `+12 chars` and the
+   * reader is told a smaller value was dropped than really was. Pinned here as
+   * a hazard, not an aspiration — callers must bound a value exactly once, at
+   * the point it first enters storage, and never re-bound a value read back
+   * out. `boundCheckpointTrace` relies on this.
+   */
+  it('is NOT idempotent — re-bounding re-cuts the marker and misreports the count', () => {
+    const once = boundJson({ big: 'x'.repeat(100) }, LIMITS);
+    expect(once).toEqual({ big: 'xxxxxxxxxx…(+90 chars)' });
+
+    const twice = boundJson(once, LIMITS);
+    expect(twice).toEqual({ big: 'xxxxxxxxxx…(+12 chars)' });
+    expect(twice).not.toEqual(once);
+  });
+});

--- a/services/platform/lib/shared/utils/bound-json.ts
+++ b/services/platform/lib/shared/utils/bound-json.ts
@@ -1,0 +1,63 @@
+/**
+ * Deep-truncate an arbitrary JSON value so one verbose payload cannot flood
+ * whatever is about to store or send it: long strings are cut with a count
+ * marker, arrays are capped with a count marker, and nesting past the depth
+ * limit is elided.
+ *
+ * Two callers with genuinely different budgets share this one algorithm rather
+ * than keeping a copy each:
+ *
+ *  - the chat tool loop, fitting a tool result into a context window
+ *    (hundreds of characters — the model only needs the gist);
+ *  - the automations run log, bounding a run's diagnostic trace
+ *    (tens of kilobytes — a human debugging a failure needs the real stack).
+ *
+ * **Only ever apply this to data that is purely descriptive.** Truncating a
+ * value that something later READS BACK changes behaviour instead of just
+ * shortening a log — in the automations engine a node's checkpoint `output`
+ * feeds the executor's scope on resume, so it must never be bounded.
+ */
+
+export interface BoundJsonLimits {
+  /** Characters kept per string before the count marker. */
+  readonly maxString: number;
+  /** Array entries kept before the count marker. */
+  readonly maxItems: number;
+  /** Nesting levels walked before the subtree is elided. */
+  readonly maxDepth: number;
+}
+
+/**
+ * Bound `value` to `limits`. Primitives other than strings pass through
+ * untouched; `undefined` and `null` are preserved so an absent field stays
+ * absent rather than becoming a marker.
+ */
+export function boundJson(
+  value: unknown,
+  limits: BoundJsonLimits,
+  depth = 0,
+): unknown {
+  if (depth > limits.maxDepth) return '…';
+  if (typeof value === 'string') {
+    return value.length > limits.maxString
+      ? `${value.slice(0, limits.maxString)}…(+${value.length - limits.maxString} chars)`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, limits.maxItems)
+      .map((item) => boundJson(item, limits, depth + 1));
+    if (value.length > limits.maxItems) {
+      items.push(`…(+${value.length - limits.maxItems} more items)`);
+    }
+    return items;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = boundJson(entry, limits, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}


### PR DESCRIPTION
An `automationRuns` row carries no size limit of any kind, and Convex refuses a
document over ~1 MiB. So an oversized run does not merely bloat the table — its
write **fails and the run dies**, possibly without recording why. The row is
also patched once per completed node and every revision is retained, so each
stored byte is paid for many times over.

The retired `wfExecutions` had an escape valve for this: payloads over 400 KB
were offloaded to file storage (`SIZE_THRESHOLD`, commented "accounts for ~2x
Convex serialization overhead under 1MB limit"). The rewrite did not carry one
over, and `input` / `output` / `checkpoints` / `trace` / `effects` are all bare
`v.any()` stored inline.

## What is bounded

- `trace` and `checkpoint.trace` — shape-bounded (long strings cut with a count
  marker, arrays capped, deep nesting elided), then held under a hard per-field
  ceiling. Shape limits alone cannot bound a total, so the ceiling is what makes
  this a guarantee rather than a tendency.
- `detail` — capped with the marker budgeted *inside* the cap, so the bound
  holds and re-capping is a no-op. The engine interpolates whole resolved inputs
  into some error messages (`execute/index.ts` :357, :95), which is how a 66 KB
  failure reason happens.

## What is deliberately left whole

Shortening any of these would change behaviour rather than shorten a log:

| field | why |
| --- | --- |
| `checkpoint.output` | `outputsFrom()` builds the executor's scope from it — a later node reading `{{ nodes.x.output }}` would see a truncation marker |
| the run's `output` | returned to API callers |
| `effects` | the audit trail of real side effects (message sent, record written, model called) |
| `cursor.agent.result` | read back on resume to produce the node's output |

## Bound once, never re-bound

`boundJson` is not idempotent: a second pass re-cuts its own marker and reports
a *smaller* loss than really occurred. So each value is bounded as it first
enters the row — `recordProgress` bounds only the incoming checkpoint, never the
already-stored entries it merges into. A test pins that hazard.

## Reuse

`lib/chat/context.ts` already had this algorithm as `boundToolResult`, whose own
comment says it mirrors the automations engine's window discipline. Rather than
keep a second copy, the first commit lifts it to
`lib/shared/utils/bound-json.ts` with the limits parameterised; chat passes its
existing constants, so its behaviour is unchanged. It had no tests before; the
shared helper has them now, including the marker text chat's window sizing
depends on.

## Scope

This bounds the run **log**, not the run. A genuinely large functional payload
still sits inline, so it reduces the document-limit risk without removing it —
removing it needs the storage-offload valve, which is a larger change.

No governance surface: nothing here deletes a row or drops a side effect, so it
needs no retention policy, legal-hold check, or operator opt-in. Retention for
finished runs and right-to-erasure coverage are a separate, governance-owned
change.

## Verification

`bun run --filter @tale/platform` — 204 automations tests, 146 chat tests,
typecheck 0, lint 0 (type-aware), `oxfmt --check` clean, `migrations:check` OK
(no schema change).
