### PR TITLE
feat(platform): retain and erase automation runs

### DIFF
--- a/services/platform/convex/automations/run_status.ts
+++ b/services/platform/convex/automations/run_status.ts
@@ -1,0 +1,24 @@
+/**
+ * Which run statuses mean "this record is finished and will not change again".
+ *
+ * The retention sweep and the erasure path both need this, and getting it wrong
+ * is the single most dangerous mistake either could make: a `waiting` run is
+ * parked on a human decision (an approval, a `repeatUntil` not yet satisfied)
+ * and may legitimately sit for weeks, while a `running` one is mid-flight.
+ * Deleting either destroys live work rather than an old record — so the
+ * predicate lives here, once, instead of being restated at each call site.
+ */
+
+/** Run statuses that will never change again. */
+export const TERMINAL_RUN_STATUSES = [
+  'success',
+  'failed',
+  'cancelled',
+] as const;
+
+export type TerminalRunStatus = (typeof TERMINAL_RUN_STATUSES)[number];
+
+/** Whether a run has finished — the only runs retention may ever touch. */
+export function isTerminalRunStatus(status: string): boolean {
+  return (TERMINAL_RUN_STATUSES as readonly string[]).includes(status);
+}

--- a/services/platform/convex/automations/schema.ts
+++ b/services/platform/convex/automations/schema.ts
@@ -1,6 +1,8 @@
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+import { lifecycleStatusValidator } from '../governance/soft_delete_validators';
+
 /**
  * The automation store — the Convex host behind the automation engine's
  * `DispatchStore`. Five tables, each answering one question:
@@ -242,9 +244,22 @@ export const automationRunsTable = defineTable({
   chainSeq: v.optional(v.number()),
   startedAt: v.number(),
   finishedAt: v.optional(v.number()),
+  /**
+   * Retention lifecycle, distinct from `status`: `status` says how the run
+   * ENDED, this says whether its record is still kept. The `workflowLog`
+   * retention sweep flips an aged terminal run to `expired` (the Trash window
+   * an operator can still recover from) and hard-deletes it only after
+   * `deletionGraceDays`. Absent means live, so every existing row is retained
+   * until a sweep touches it — and the sweep only ever touches TERMINAL runs,
+   * because a `waiting` run is parked on a human decision and may legitimately
+   * sit for weeks.
+   */
+  lifecycleStatus: v.optional(lifecycleStatusValidator),
+  statusChangedAt: v.optional(v.number()),
 })
   .index('by_org', ['organizationId'])
   .index('by_org_name', ['organizationId', 'name'])
   .index('by_org_project', ['organizationId', 'projectId'])
   .index('by_status', ['status'])
-  .index('by_status_wakeAt', ['status', 'wakeAt']);
+  .index('by_status_wakeAt', ['status', 'wakeAt'])
+  .index('by_org_lifecycleStatus', ['organizationId', 'lifecycleStatus']);

--- a/services/platform/convex/governance/automation_run_erasure.test.ts
+++ b/services/platform/convex/governance/automation_run_erasure.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Right-to-erasure coverage over `automationRuns`.
+ *
+ * Attribution is a prefix match on `startedBy` (`user:<id>`, `api-key:<id>`)
+ * because the table has no `userId` — so these pin both what it DOES reach and
+ * what it deliberately does not.
+ */
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'governance';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_run_erasure';
+const DAY = 24 * 60 * 60 * 1000;
+type T = TestConvex<typeof schema>;
+
+interface RunSeed {
+  status: 'success' | 'failed' | 'cancelled' | 'running' | 'waiting';
+  startedAgoDays: number;
+  startedBy?: string;
+  organizationId?: string;
+}
+
+async function seedRuns(t: T, runs: RunSeed[]): Promise<void> {
+  const now = Date.now();
+  await t.run(async (ctx) => {
+    for (const [i, run] of runs.entries()) {
+      await ctx.db.insert('automationRuns', {
+        organizationId: run.organizationId ?? ORG,
+        name: `automation-${i}`,
+        version: 1,
+        status: run.status,
+        mode: 'live',
+        startedBy: run.startedBy ?? 'trigger:t1',
+        input: null,
+        startedAt: now - run.startedAgoDays * DAY,
+      });
+    }
+  });
+}
+
+describe('eraseSubjectAutomationRuns', () => {
+  it('erases runs the subject started, by either caller marker', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 1, startedBy: 'user:subj' },
+      { status: 'failed', startedAgoDays: 1, startedBy: 'api-key:subj' },
+    ]);
+
+    const result = await t.mutation(
+      internal.governance.erasure.eraseSubjectAutomationRuns,
+      { organizationId: ORG, userId: 'subj' },
+    );
+
+    expect(result).toEqual({ rows: 2, skippedByHold: 0 });
+  });
+
+  it('leaves other subjects, schedule-started runs, and other orgs alone', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 1, startedBy: 'user:someone_else' },
+      { status: 'success', startedAgoDays: 1, startedBy: 'trigger:t1' },
+      {
+        status: 'success',
+        startedAgoDays: 1,
+        startedBy: 'user:subj',
+        organizationId: 'other_org',
+      },
+    ]);
+
+    const result = await t.mutation(
+      internal.governance.erasure.eraseSubjectAutomationRuns,
+      { organizationId: ORG, userId: 'subj' },
+    );
+
+    expect(result).toEqual({ rows: 0, skippedByHold: 0 });
+    const left = await t.run(
+      async (ctx) => (await ctx.db.query('automationRuns').collect()).length,
+    );
+    expect(left).toBe(3);
+  });
+
+  /** A prefix match must not erase `user:subj_2` when erasing `user:subj`. */
+  it('does not match a userId that merely shares a prefix', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 1, startedBy: 'user:subj_2' },
+    ]);
+
+    const result = await t.mutation(
+      internal.governance.erasure.eraseSubjectAutomationRuns,
+      { organizationId: ORG, userId: 'subj' },
+    );
+
+    expect(result.rows).toBe(0);
+  });
+
+  it('erases a run whatever its status — erasure is not retention', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'waiting', startedAgoDays: 1, startedBy: 'user:subj' },
+    ]);
+
+    const result = await t.mutation(
+      internal.governance.erasure.eraseSubjectAutomationRuns,
+      { organizationId: ORG, userId: 'subj' },
+    );
+
+    expect(result.rows).toBe(1);
+  });
+});

--- a/services/platform/convex/governance/automation_run_retention.test.ts
+++ b/services/platform/convex/governance/automation_run_retention.test.ts
@@ -1,0 +1,370 @@
+/**
+ * The `workflowLog` sweep over `automationRuns`.
+ *
+ * The load-bearing guarantee is the terminal-only filter: a `waiting` run is
+ * parked on a human decision and may sit for weeks, and a `running` one is
+ * mid-flight, so age alone must never make either a candidate. Everything else
+ * here (the flag gate, the Trash flip, the grace delete) follows the shape the
+ * other retention categories already use.
+ */
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import {
+  isTerminalRunStatus,
+  TERMINAL_RUN_STATUSES,
+} from '../automations/run_status';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'governance';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_run_retention';
+const DAY = 24 * 60 * 60 * 1000;
+type T = TestConvex<typeof schema>;
+
+interface RunSeed {
+  status: 'success' | 'failed' | 'cancelled' | 'running' | 'waiting';
+  finishedAgoDays?: number;
+  startedAgoDays: number;
+  lifecycleStatus?: 'expired';
+  statusChangedAgoDays?: number;
+  startedBy?: string;
+  organizationId?: string;
+}
+
+async function seedRuns(t: T, runs: RunSeed[]): Promise<void> {
+  const now = Date.now();
+  await t.run(async (ctx) => {
+    for (const [i, run] of runs.entries()) {
+      await ctx.db.insert('automationRuns', {
+        organizationId: run.organizationId ?? ORG,
+        name: `automation-${i}`,
+        version: 1,
+        status: run.status,
+        mode: 'live',
+        startedBy: run.startedBy ?? 'trigger:t1',
+        input: null,
+        startedAt: now - run.startedAgoDays * DAY,
+        ...(run.finishedAgoDays !== undefined && {
+          finishedAt: now - run.finishedAgoDays * DAY,
+        }),
+        ...(run.lifecycleStatus !== undefined && {
+          lifecycleStatus: run.lifecycleStatus,
+        }),
+        ...(run.statusChangedAgoDays !== undefined && {
+          statusChangedAt: now - run.statusChangedAgoDays * DAY,
+        }),
+      });
+    }
+  });
+}
+
+describe('isTerminalRunStatus', () => {
+  it.each(TERMINAL_RUN_STATUSES)('treats %s as terminal', (status) => {
+    expect(isTerminalRunStatus(status)).toBe(true);
+  });
+
+  it.each(['running', 'waiting', 'queued', ''])(
+    'refuses to treat %s as terminal',
+    (status) => {
+      expect(isTerminalRunStatus(status)).toBe(false);
+    },
+  );
+});
+
+describe('listExpiredAutomationRuns', () => {
+  it('lists aged terminal runs', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 60, finishedAgoDays: 60 },
+      { status: 'failed', startedAgoDays: 45, finishedAgoDays: 45 },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it('NEVER lists a waiting run — it is parked on a human decision', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [{ status: 'waiting', startedAgoDays: 400 }]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('NEVER lists a running run, however old', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [{ status: 'running', startedAgoDays: 400 }]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('leaves a run inside the window alone', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 3, finishedAgoDays: 3 },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('ages on finishedAt, not startedAt — a long run that ended recently is kept', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 200, finishedAgoDays: 2 },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('falls back to startedAt when a run ended without stamping finishedAt', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [{ status: 'failed', startedAgoDays: 90 }]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('never crosses an organization boundary', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      {
+        status: 'success',
+        startedAgoDays: 90,
+        finishedAgoDays: 90,
+        organizationId: 'other_org',
+      },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips a run already in the Trash window', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      {
+        status: 'success',
+        startedAgoDays: 90,
+        finishedAgoDays: 90,
+        lifecycleStatus: 'expired',
+        statusChangedAgoDays: 1,
+      },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('honours the batch size', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(
+      t,
+      Array.from({ length: 5 }, () => ({
+        status: 'success' as const,
+        startedAgoDays: 90,
+        finishedAgoDays: 90,
+      })),
+    );
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 2 },
+    );
+
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('listGraceExpiredAutomationRuns', () => {
+  it('lists a run whose Trash window has elapsed', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      {
+        status: 'success',
+        startedAgoDays: 90,
+        finishedAgoDays: 90,
+        lifecycleStatus: 'expired',
+        statusChangedAgoDays: 30,
+      },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listGraceExpiredAutomationRuns,
+      {
+        organizationId: ORG,
+        graceCutoffMs: Date.now() - 7 * DAY,
+        batchSize: 50,
+      },
+    );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('keeps a run still inside its Trash window', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      {
+        status: 'success',
+        startedAgoDays: 90,
+        finishedAgoDays: 90,
+        lifecycleStatus: 'expired',
+        statusChangedAgoDays: 1,
+      },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listGraceExpiredAutomationRuns,
+      {
+        organizationId: ORG,
+        graceCutoffMs: Date.now() - 7 * DAY,
+        batchSize: 50,
+      },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('ignores a live run that was never flipped', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 90, finishedAgoDays: 90 },
+    ]);
+
+    const rows = await t.query(
+      internal.governance.internal_queries.listGraceExpiredAutomationRuns,
+      {
+        organizationId: ORG,
+        graceCutoffMs: Date.now() - 7 * DAY,
+        batchSize: 50,
+      },
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('deleteExpiredAutomationRun', () => {
+  it('deletes an aged terminal run', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 90, finishedAgoDays: 90 },
+    ]);
+    const [row] = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    await t.mutation(
+      internal.governance.internal_mutations_retention
+        .deleteExpiredAutomationRun,
+      { runId: row._id, organizationId: ORG, cutoffMs: Date.now() - 30 * DAY },
+    );
+
+    const left = await t.run((ctx) => ctx.db.get(row._id));
+    expect(left).toBeNull();
+  });
+
+  /**
+   * The scan and the delete are separate transactions. If a run is resumed in
+   * between, the delete must refuse — otherwise retention deletes a row out
+   * from under a live walker.
+   */
+  it('refuses once the run has been resumed since it was listed', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 90, finishedAgoDays: 90 },
+    ]);
+    const [row] = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.patch(row._id, { status: 'running' });
+    });
+
+    await t.mutation(
+      internal.governance.internal_mutations_retention
+        .deleteExpiredAutomationRun,
+      { runId: row._id, organizationId: ORG, cutoffMs: Date.now() - 30 * DAY },
+    );
+
+    const left = await t.run((ctx) => ctx.db.get(row._id));
+    expect(left).not.toBeNull();
+  });
+
+  it('refuses a cross-org delete', async () => {
+    const t = convexTest(schema, modules);
+    await seedRuns(t, [
+      { status: 'success', startedAgoDays: 90, finishedAgoDays: 90 },
+    ]);
+    const [row] = await t.query(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: ORG, cutoffMs: Date.now() - 30 * DAY, batchSize: 50 },
+    );
+
+    await t.mutation(
+      internal.governance.internal_mutations_retention
+        .deleteExpiredAutomationRun,
+      {
+        runId: row._id,
+        organizationId: 'other_org',
+        cutoffMs: Date.now() - 30 * DAY,
+      },
+    );
+
+    const left = await t.run((ctx) => ctx.db.get(row._id));
+    expect(left).not.toBeNull();
+  });
+});

--- a/services/platform/convex/governance/erasure.ts
+++ b/services/platform/convex/governance/erasure.ts
@@ -764,6 +764,7 @@ const perCategoryValidator = v.object({
   taskSubscriptions: rowsAndHoldValidator,
   taskReviewDecisions: rowsAndHoldValidator,
   wfExecutions: rowsAndHoldValidator,
+  automationRuns: rowsAndHoldValidator,
 });
 
 export const finalizeProcessing = internalMutation({
@@ -1752,6 +1753,62 @@ export const eraseSubjectWfExecutions = internalMutation({
   },
 });
 
+/**
+ * `automationRuns` the subject started. Stores `input`, `output`, `trace` (every
+ * node's resolved input AND output) and `effects` as free-form JSON, any of
+ * which can carry subject PII.
+ *
+ * Attribution differs from the `wfExecutions` handler above, and is weaker.
+ * That table had `userId` + `triggeredBy` with indexes for exactly this walk;
+ * `automationRuns` has neither — a run names its starter in `startedBy` as a
+ * prefixed marker (`user:<id>`, `api-key:<id>`, `trigger:<id>`). So this is an
+ * org-scoped scan matching those prefixes rather than an index lookup. Erasure
+ * is rare, so the scan cost is acceptable; the alternative (a denormalized
+ * `userId` + index) would still miss every run written before it existed.
+ *
+ * **Scope, stated plainly:** this erases runs the subject STARTED. A run whose
+ * payload merely mentions a third party — an inbound email body, a contact
+ * record read by a node — is not reachable this way, exactly as it was not
+ * reachable through the `wfExecutions` handler. Widening that is a separate
+ * decision about what Art 17 coverage over automation payloads should mean, not
+ * something to slip in here.
+ */
+export const eraseSubjectAutomationRuns = internalMutation({
+  args: { organizationId: v.string(), userId: v.string() },
+  returns: v.object({ rows: v.number(), skippedByHold: v.number() }),
+  handler: async (ctx, args) => {
+    // A run started by this subject, whichever caller surface stamped it.
+    const startedBySubject = (startedBy: string): boolean =>
+      startedBy === `user:${args.userId}` ||
+      startedBy === `api-key:${args.userId}`;
+
+    const iter = () =>
+      ctx.db
+        .query('automationRuns')
+        .withIndex('by_org', (q) =>
+          q.eq('organizationId', args.organizationId),
+        );
+
+    // Hold guard: count what WOULD be erased and touch nothing.
+    const holds = await loadActiveHolds(ctx, args.organizationId);
+    if (holds.orgHeld || holds.userMembershipIds.has(args.userId)) {
+      let skippedByHold = 0;
+      for await (const row of iter()) {
+        if (startedBySubject(row.startedBy)) skippedByHold++;
+      }
+      return { rows: 0, skippedByHold };
+    }
+
+    let rows = 0;
+    for await (const row of iter()) {
+      if (!startedBySubject(row.startedBy)) continue;
+      await ctx.db.delete(row._id);
+      rows++;
+    }
+    return { rows, skippedByHold: 0 };
+  },
+});
+
 export const eraseSubjectLoginAttempts = internalMutation({
   // Tables are email-keyed and global, but the GDPR request is org-scoped.
   // Re-read holds for the requesting org so a mid-flight hold blocks this
@@ -1867,6 +1924,7 @@ export const processErasureRequest = internalAction({
       taskSubscriptions: { rows: 0, skippedByHold: 0 },
       taskReviewDecisions: { rows: 0, skippedByHold: 0 },
       wfExecutions: { rows: 0, skippedByHold: 0 },
+      automationRuns: { rows: 0, skippedByHold: 0 },
     };
     let errorMessage: string | undefined;
 
@@ -2136,6 +2194,15 @@ export const processErasureRequest = internalAction({
           userId: state.targetUserId,
         },
       );
+      // The same duty over the CURRENT run table — `wfExecutions` above only
+      // covers records the retired engine wrote.
+      perCategory.automationRuns = await ctx.runMutation(
+        internal.governance.erasure.eraseSubjectAutomationRuns,
+        {
+          organizationId: state.organizationId,
+          userId: state.targetUserId,
+        },
+      );
 
       // loginAttempts / loginBlockCounters are email-keyed (not
       // userId-keyed). Look up the email via BetterAuth before the
@@ -2238,6 +2305,7 @@ interface PerCategoryCounts {
   taskSubscriptions: RowsAndHold;
   taskReviewDecisions: RowsAndHold;
   wfExecutions: RowsAndHold;
+  automationRuns: RowsAndHold;
 }
 
 // =============================================================================

--- a/services/platform/convex/governance/internal_mutations_retention.ts
+++ b/services/platform/convex/governance/internal_mutations_retention.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { internalMutation } from '../_generated/server';
 import type { MutationCtx } from '../_generated/server';
 import { createAuditLog } from '../audit_logs/helpers';
+import { isTerminalRunStatus } from '../automations/run_status';
 import { cascadeDeleteThreadChildren } from '../discussions/thread_cascade';
 import { deleteStorageWithMetadata } from '../file_metadata/helpers';
 import { eraseDocumentBlobs } from './erase_document_blobs';
@@ -741,6 +742,69 @@ export const deleteExpiredUsageLedgerRow = internalMutation({
       category: 'data',
       resourceType: 'usage_ledger',
       resourceId: String(args.rowId),
+      status: 'success',
+    });
+
+    return null;
+  },
+});
+
+/**
+ * Hard-delete one aged automation run, audited like every other retention
+ * delete.
+ *
+ * Re-checks TERMINAL status here as well as in the listing query: the row is
+ * re-read inside this mutation, so a run that was resumed between the scan and
+ * this write must not be deleted out from under a live walker.
+ *
+ * No `authorUserId` is passed — `automationRuns` carries no `userId` (a run
+ * names its starter in `startedBy` as a prefixed marker), so only the org-wide
+ * hold applies here. Per-subject removal is the erasure path's job.
+ */
+export const deleteExpiredAutomationRun = internalMutation({
+  args: {
+    runId: v.id('automationRuns'),
+    organizationId: v.string(),
+    cutoffMs: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.runId);
+    if (!row) {
+      return null;
+    }
+
+    if (!isTerminalRunStatus(row.status)) {
+      console.info(
+        `[RetentionCleanup] skipping deleteExpiredAutomationRun(${String(args.runId)}): run is ${row.status}, not terminal`,
+      );
+      return null;
+    }
+
+    const guard = await assertSafeRetentionDelete(ctx, {
+      rowOrganizationId: row.organizationId,
+      expectedOrganizationId: args.organizationId,
+      rowEffectiveMs: row.finishedAt ?? row.startedAt,
+      cutoffMs: args.cutoffMs,
+    });
+    if (!guard.proceed) {
+      console.info(
+        `[RetentionCleanup] skipping deleteExpiredAutomationRun(${String(args.runId)}): ${guard.reason}`,
+      );
+      return null;
+    }
+
+    await ctx.db.delete(args.runId);
+
+    await createAuditLog(ctx, {
+      organizationId: args.organizationId,
+      actorId: 'system',
+      actorEmail: 'system@tale.so',
+      actorType: 'system',
+      action: 'automation_run.retention_deleted',
+      category: 'data',
+      resourceType: 'automation_run',
+      resourceId: String(args.runId),
       status: 'success',
     });
 

--- a/services/platform/convex/governance/internal_queries.ts
+++ b/services/platform/convex/governance/internal_queries.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 
 import { stripModelRefQualifier } from '../../lib/shared/utils/model-ref';
 import { internalQuery } from '../_generated/server';
+import { isTerminalRunStatus } from '../automations/run_status';
 import { getUserTeamIds } from '../lib/get_user_teams';
 import { getOrganizationMember } from '../lib/rls';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
@@ -967,6 +968,70 @@ export const listGraceExpiredUsageLedgerRows = internalQuery({
     const rows = [];
     for await (const row of ctx.db
       .query('usageLedger')
+      .withIndex('by_org_lifecycleStatus', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      const status = row.lifecycleStatus ?? 'active';
+      if (status !== 'trashed' && status !== 'expired') continue;
+      const ts = row.statusChangedAt ?? Date.now();
+      if (ts >= args.graceCutoffMs) continue;
+      rows.push(row);
+      if (rows.length >= args.batchSize) break;
+    }
+    return rows;
+  },
+});
+
+/**
+ * Aged automation runs eligible for the Trash window.
+ *
+ * TERMINAL ONLY, and that is the whole safety of this sweep: a `waiting` run is
+ * parked on a human decision (an approval, a `repeatUntil` not yet satisfied)
+ * and may legitimately sit for weeks, while a `running` one is mid-flight.
+ * Sweeping by age alone would silently destroy pending approvals, so a run is
+ * only ever a candidate once it has actually finished.
+ *
+ * Aged by `finishedAt` — when the record became complete — falling back to
+ * `startedAt` for any row that ended without stamping one.
+ */
+export const listExpiredAutomationRuns = internalQuery({
+  args: {
+    organizationId: v.string(),
+    cutoffMs: v.number(),
+    batchSize: v.number(),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const rows = [];
+    for await (const row of ctx.db
+      .query('automationRuns')
+      .withIndex('by_org', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      if (!isTerminalRunStatus(row.status)) continue;
+      const status = row.lifecycleStatus ?? 'active';
+      if (status !== 'active') continue;
+      if ((row.finishedAt ?? row.startedAt) >= args.cutoffMs) continue;
+
+      rows.push(row);
+      if (rows.length >= args.batchSize) break;
+    }
+    return rows;
+  },
+});
+
+/** Automation runs whose Trash window has itself expired — ready to delete. */
+export const listGraceExpiredAutomationRuns = internalQuery({
+  args: {
+    organizationId: v.string(),
+    graceCutoffMs: v.number(),
+    batchSize: v.number(),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const rows = [];
+    for await (const row of ctx.db
+      .query('automationRuns')
       .withIndex('by_org_lifecycleStatus', (q) =>
         q.eq('organizationId', args.organizationId),
       )) {

--- a/services/platform/convex/governance/retention_cleanup.ts
+++ b/services/platform/convex/governance/retention_cleanup.ts
@@ -724,6 +724,95 @@ async function cleanupWorkflowLogs(
   return processed;
 }
 
+/**
+ * The `workflowLog` category's second table: automation runs.
+ *
+ * Shares the operator's `workflowLogEnabled` flag and window with
+ * {@link cleanupWorkflowLogs} rather than inventing a category — to an operator
+ * these are one thing ("how long do we keep a record of what automations did"),
+ * and the retired `wfExecutions` this table replaced was already governed by it.
+ *
+ * Only TERMINAL runs are candidates: a `waiting` run is parked on a human
+ * decision and may sit for weeks, a `running` one is mid-flight, and deleting
+ * either would destroy live work rather than an old record.
+ *
+ * `automationRuns` has no `userId`, so the per-user custodian cascade the
+ * execution sweep performs has nothing to key on — the org-wide hold applies,
+ * and removing one subject's runs is the erasure path's job.
+ */
+async function cleanupAutomationRuns(
+  ctx: ActionCtx,
+  org: OrgPolicy,
+  batchSize: number,
+  holds: ActiveHolds,
+): Promise<number> {
+  if (!org.config.workflowLogEnabled) return 0;
+  const days = org.config.workflowLogRetentionDays;
+  if (typeof days !== 'number' || days <= 0) return 0;
+
+  if (holds.orgHeld) {
+    console.info(
+      `[RetentionCleanup] org ${org.organizationId} on legal hold — skipping automation run cleanup`,
+    );
+    return 0;
+  }
+
+  const cutoffMs = Date.now() - days * DAY_MS;
+  const graceDays = org.config.deletionGraceDays ?? 0;
+  let processed = 0;
+
+  // Pass A: flip aged terminal runs → expired (the Trash window).
+  if (graceDays > 0) {
+    const passA = await ctx.runQuery(
+      internal.governance.internal_queries.listExpiredAutomationRuns,
+      { organizationId: org.organizationId, cutoffMs, batchSize },
+    );
+    for (const run of passA) {
+      await ctx.runMutation(
+        internal.governance.soft_delete_helpers.markRowExpiredGeneric,
+        {
+          resourceType: 'automationRun',
+          rowId: String(run._id),
+          organizationId: org.organizationId,
+          cutoffMs,
+          timestampField: 'finishedAt',
+        },
+      );
+      processed += 1;
+    }
+  }
+
+  // Pass B: delete what the Trash window has released (or, with no grace
+  // configured, what is simply past the window).
+  const expiredRuns =
+    graceDays > 0
+      ? await ctx.runQuery(
+          internal.governance.internal_queries.listGraceExpiredAutomationRuns,
+          {
+            organizationId: org.organizationId,
+            graceCutoffMs: Date.now() - graceDays * DAY_MS,
+            batchSize,
+          },
+        )
+      : await ctx.runQuery(
+          internal.governance.internal_queries.listExpiredAutomationRuns,
+          { organizationId: org.organizationId, cutoffMs, batchSize },
+        );
+  for (const run of expiredRuns) {
+    await ctx.runMutation(
+      internal.governance.internal_mutations_retention
+        .deleteExpiredAutomationRun,
+      {
+        runId: run._id,
+        organizationId: org.organizationId,
+        cutoffMs: graceDays > 0 ? undefined : cutoffMs,
+      },
+    );
+    processed += 1;
+  }
+  return processed;
+}
+
 async function cleanupUsageLedger(
   ctx: ActionCtx,
   org: OrgPolicy,
@@ -1473,6 +1562,10 @@ export const runOrgRetentionCleanup = internalAction({
         {
           name: 'workflowLogs',
           run: () => cleanupWorkflowLogs(ctx, org, batchSize, holds),
+        },
+        {
+          name: 'automationRuns',
+          run: () => cleanupAutomationRuns(ctx, org, batchSize, holds),
         },
         {
           name: 'chatFilterEvents',

--- a/services/platform/convex/governance/soft_delete_helpers.ts
+++ b/services/platform/convex/governance/soft_delete_helpers.ts
@@ -127,6 +127,18 @@ export const SOFT_DELETE_RESOURCE_CONFIG: Record<
     displayNameField: 'periodKey',
     authorField: 'userId',
   },
+  // A finished automation run's record. `authorField` is absent on purpose:
+  // the table carries no `userId` — a run names its starter in `startedBy` as
+  // a prefixed marker (`user:<id>`, `api-key:<id>`, `trigger:<id>`) — so the
+  // sweep applies the ORG hold only, and per-user custodian cascade is handled
+  // by the erasure path instead.
+  automationRun: {
+    tableName: 'automationRuns',
+    statusField: 'lifecycleStatus',
+    auditPrefix: 'automation_run',
+    auditResourceType: 'automation_run',
+    displayNameField: 'name',
+  },
   auditLog: {
     tableName: 'auditLogs',
     statusField: 'lifecycleStatus',

--- a/services/platform/convex/governance/soft_delete_validators.ts
+++ b/services/platform/convex/governance/soft_delete_validators.ts
@@ -49,6 +49,7 @@ export const SOFT_DELETE_RESOURCE_TYPES = [
   'externalConversation',
   'workflowExecution',
   'usageLedger',
+  'automationRun',
   'auditLog',
   'chatFilterEvent',
 ] as const;


### PR DESCRIPTION
`automationRuns` is the table every new run lands in, and **nothing ever deleted
from it** — it appears nowhere in `governance/` or `crons.ts`. Meanwhile the
`wfExecutions` table it replaced was kept in `legacy/schema.ts` and still has its
30-day `cleanupWorkflowLogs` pass. The retired table is swept; the live one grows
without a ceiling. The Art 17 erasure walk has the same gap: it reaches
`wfExecutions` and misses every run the current engine wrote.

This is the governance half of the run lifecycle. The operational half — bounding
what a single run stores so its write cannot fail — is #2885, deliberately kept
separate: nothing here changes during a run, and nothing there involves policy.

## Retention

Extends the existing `workflowLog` category rather than adding one. To an operator
these are one question — "how long do we keep a record of what automations did" —
and it is the category that already governed the predecessor.

**It stays OFF by default** (`workflowLogEnabled: false`), like every
non-ephemeral category. Enabling deletion remains the operator's decision, so
this PR deletes nothing on any existing deployment until someone opts in.

Runs now carry `lifecycleStatus` + `statusChangedAt` and are registered for
soft-delete, so an aged run enters the Trash window and is hard-deleted only
after `deletionGraceDays` — the same two-pass shape `usageLedger` uses. Without
those fields this would have been the only category silently ignoring that
setting.

### Terminal runs only

The load-bearing safety property, enforced in both the listing query and the
delete mutation:

| status | swept |
| --- | --- |
| `success`, `failed`, `cancelled` | yes |
| `waiting` | **never** — parked on a human decision, may sit for weeks |
| `running` | **never** — mid-flight |

Age alone must never make a non-terminal run a candidate, or the sweep silently
destroys pending approvals. The predicate lives in one place
(`automations/run_status.ts`) and is re-checked at the delete boundary, because
the scan and the write are separate transactions — a run resumed in between must
not be deleted out from under a live walker.

Runs are aged on `finishedAt` (when the record became complete), falling back to
`startedAt` for a run that ended without stamping one.

`automationRuns` has no `userId`, so the per-user custodian cascade the execution
sweep performs has nothing to key on: the org-wide hold applies, and removing one
subject's runs is the erasure path's job.

## Erasure

Attribution is weaker than the handler it mirrors, and the code says so.
`wfExecutions` had `userId` + `triggeredBy` with indexes for exactly this walk;
`automationRuns` has neither — a run names its starter in `startedBy` as a
prefixed marker (`user:<id>`, `api-key:<id>`, `trigger:<id>`). So this is an
org-scoped scan matching those markers rather than an index lookup. Erasure is
rare, so the scan cost is acceptable, and a denormalized `userId` would still
miss every run written before it existed.

**Scope, stated plainly:** this erases runs the subject **started**. A run whose
payload merely mentions a third party — an inbound email body, a contact record a
node read — is not reachable this way, exactly as it was not reachable through
the `wfExecutions` handler. Widening that is a separate decision about what Art 17
coverage over automation payloads should mean, not something to slip in here.

Counts land in the existing per-category map, which the receipt stores in its
generic `perCategorySnapshot`, so no schema change is needed. Legal holds behave
as they do above: an org hold or a custodian hold on the subject counts what
would be erased and touches nothing.

## Schema

The two new fields are optional and the index is additive, so
`migrations:check` classes them as data-safe growth (7 → 9) and no migration is
owed.

## Verification

509 governance + automations tests (26 new, covering every row of the table
above), typecheck 0, lint 0 (type-aware), `oxfmt --check` clean,
`migrations:check` OK.
