### PR TITLE
feat(platform): crawl documents, URL lists, and JS-rendered pages

### DIFF
--- a/docs/de/platform/knowledge/crawling.md
+++ b/docs/de/platform/knowledge/crawling.md
@@ -3,9 +3,9 @@ title: Crawling
 description: Wie Tale eine Website in Wissen verwandelt — Domain registrieren, URLs über die Sitemap entdecken, geplante Re-Scans und die Ansicht der indexierten Seiten.
 ---
 
-Eine Website ist die Form der Wissensdatenbank für „eine öffentliche Seite, die der Agent kennen soll“. Du gibst Tale eine Domain und ein Scan-Intervall; der Crawler entdeckt URLs, holt Seiten, extrahiert den Hauptinhalt, chunked und bettet den Text ein und serviert die Chunks zur Antwortzeit genauso wie bei Dokumenten. Diese Seite geht durch, was du zwischen dem Hinzufügen einer Domain und den ersten Agenten-Zitaten ihrer Seiten siehst.
+Eine Website ist die Form der Wissensdatenbank für „eine öffentliche Seite, die der Agent kennen soll“. Du gibst Tale eine Domain und ein Scan-Intervall; der Crawler entdeckt URLs, holt Seiten, extrahiert den Hauptinhalt, chunked und bettet den Text ein und serviert die Chunks zur Antwortzeit genauso wie bei Dokumenten. Brauchst du gezielte Seiten statt einer ganzen Website, übergibst du stattdessen eine URL-Liste — dieselbe Pipeline läuft dann genau über die Seiten, die du nennst. Diese Seite geht durch, was du zwischen dem Hinzufügen einer Domain und den ersten Agenten-Zitaten ihrer Seiten siehst.
 
-<Frame caption="Eine Website hinzufügen — Domain plus Scan-Intervall ist das ganze Formular.">
+<Frame caption="Eine Website hinzufügen — im Modus „Gesamte Website“ ist Domain plus Scan-Intervall das ganze Formular.">
 
 ![Der Dialog Website hinzufügen auf dem Websites-Tab, der nach einer Domain und einem Scan-Intervall fragt, das standardmäßig auf alle sechs Stunden steht.](/images/platform/websites-add-dialog.webp)
 
@@ -13,7 +13,7 @@ Eine Website ist die Form der Wissensdatenbank für „eine öffentliche Seite, 
 
 ## Eine Website hinzufügen
 
-Öffne **Wissen > Websites** und klicke auf **Website hinzufügen**. Der Dialog hat zwei Felder: **Domain** (zum Beispiel `example.com`) und **Scan-Intervall** — jede Stunde, alle 6 Stunden (der Standard), alle 12 Stunden, täglich, alle 5 Tage, alle 7 Tage oder alle 30 Tage. Tale normalisiert die Domain — `https://`, `www.` und Schrägstriche am Ende sind verkraftbar — und weist alles ab, was sich nicht als Hostname lesen lässt. Klicke auf **Speichern**; der Scheduler nimmt neue Websites beim nächsten Takt auf, der erste Scan startet also binnen Sekunden.
+Öffne **Wissen > Websites** und klicke auf **Website hinzufügen**. Der **Quellentyp** entscheidet, was die Quelle abdeckt: **Gesamte Website** — der Standard — crawlt alles, was sich auf der Domain entdecken lässt, **URL-Liste** indexiert genau die Seiten, die du einfügst (dazu der nächste Abschnitt). Im Modus Gesamte Website hat der Dialog zwei Felder: **Domain** (zum Beispiel `example.com`) und **Scan-Intervall** — jede Stunde, alle 6 Stunden (der Standard), alle 12 Stunden, täglich, alle 5 Tage, alle 7 Tage oder alle 30 Tage. Tale normalisiert die Domain — `https://`, `www.` und Schrägstriche am Ende sind verkraftbar — und weist alles ab, was sich nicht als Hostname lesen lässt. Klicke auf **Speichern**; der Scheduler nimmt neue Websites beim nächsten Takt auf, der erste Scan startet also binnen Sekunden.
 
 <Note>
 
@@ -21,20 +21,26 @@ Es gibt kein Auth-Feld und keine Include/Exclude-Pfadliste — der Crawler sieht
 
 </Note>
 
+## Eine URL-Liste hinzufügen
+
+Stelle den **Quellentyp** auf **URL-Liste**, wenn du bestimmte Seiten willst statt einer ganzen Website — hier ein Bericht, da eine Preisseite, dazu eine Handvoll PDFs. Füge unter **URLs** eine URL pro Zeile ein; nur diese Seiten werden geholt und indexiert, Links darüber hinaus folgt der Crawler nicht. Die Zeilen dürfen mehrere Websites mischen: Der Dialog gruppiert sie zu einer Quelle pro Website, aus einem Einfügen über drei Domains werden also drei Zeilen. Fügst du für eine Website, die schon eine Liste hat, erneut URLs ein, landen die neuen in der bestehenden Quelle — nichts fällt weg, und das Scan-Intervall wechselt auf deine neue Wahl. Listen scannen im selben Takt wie ganze Websites; ihre Zeilen tragen in der Tabelle das Badge **URL-Liste**.
+
 ## Wie URLs entdeckt werden
 
 Der Crawler versucht zuerst den kooperativen Weg. Er löst die Startseite auf und geht jede Sitemap durch, die die Website veröffentlicht — `sitemap.xml`, Sitemap-Indizes, gezippte und in der robots-Datei deklarierte Sitemaps — und sammelt so die URL-Liste, die die Website selbst pflegt. Websites mit gesunder Sitemap bekommen vollständige Abdeckung ohne Raten.
 
 Fehlt die Sitemap, ist sie kaputt oder leer, fällt der Crawler auf einen Breitensuche-Linklauf von der Startseite zurück: nur Links innerhalb der Domain, externe und Social-Links fallen weg, Navigations- und Footer-Chrome wird vor der Extraktion entfernt. Der Fallback deckt Websites ohne Sitemap ab, erreicht aber nie die Vollständigkeit einer gepflegten Sitemap.
 
+Nicht nur Seiten zählen. Verlinkte Dokumente — PDF- und Office-Dateien (`docx`, `xlsx`, `pptx`, `odt`) — werden wie Seiten geholt und indexiert, egal ob der Crawler sie auf einer Website findet oder du sie direkt in einer URL-Liste aufführst. Bilder und gescannte Dokumente ohne eingebetteten Text werden übersprungen: Der Scan merkt sich, dass er nachgesehen hat, und speichert nichts.
+
 ## Der Scan-Zeitplan
 
-Das Intervall entscheidet, wie oft URLs neu entdeckt und Seiten neu geholt werden. Jeder Scan ist inkrementell: Unveränderte Seiten werden übersprungen, geänderte neu extrahiert und neu eingebettet, neue Seiten kommen dazu, entfernte fliegen aus dem Index. Agenten, die auf die Website zeigen, sehen den neuen Inhalt beim nächsten Abruf — einen separaten Veröffentlichungsschritt gibt es nicht.
+Das Intervall entscheidet, wie oft URLs neu entdeckt und Seiten neu geholt werden. Jeder Scan ist inkrementell: Unveränderte Seiten werden übersprungen, geänderte neu extrahiert und neu eingebettet, neue Seiten kommen dazu, entfernte fliegen aus dem Index. URL-Listen folgen demselben Takt mit festem Bestand — die gelisteten Seiten werden nach Zeitplan neu geholt, Neues wird nicht entdeckt. Agenten, die auf die Website zeigen, sehen den neuen Inhalt beim nächsten Abruf — einen separaten Veröffentlichungsschritt gibt es nicht.
 
 ## Die Tabelle lesen
 
-Jede Zeile zeigt die Domain, ihren **Status** — **Inaktiv** zwischen Scans, **Wird gescannt** im Flug, **Aktiv** nach einem erfolgreichen Scan, **Fehler**, wenn der letzte Scan fehlschlug, **Lösche…** während der Entfernung —, den Prozentwert **Indexiert** (Hover zeigt gecrawlte von insgesamt gefundenen Seiten), die letzte **Gescannt**-Zeit und das **Intervall**. Öffne eine Zeile für den entdeckten Titel und die Beschreibung der Website; klicke auf **Seiten anzeigen** für die Seitenliste — jede indexierte URL mit Wortzahl, Chunk-Zahl und letzter Crawl-Zeit, plus ein Suchfeld, das über die indexierten Chunks läuft und damit der schnellste Weg ist zu prüfen, was ein Agent wirklich abrufen würde.
+Jede Zeile zeigt die Domain (Quellen vom Typ URL-Liste tragen daneben das Badge **URL-Liste**), ihren **Status** — **Inaktiv** zwischen Scans, **Wird gescannt** im Flug, **Aktiv** nach einem erfolgreichen Scan, **Fehler**, wenn der letzte Scan fehlschlug, **Lösche…** während der Entfernung —, den Prozentwert **Indexiert** (Hover zeigt gecrawlte von insgesamt gefundenen Seiten), die letzte **Gescannt**-Zeit und das **Intervall**. Öffne eine Zeile für den entdeckten Titel und die Beschreibung der Website; klicke auf **Seiten anzeigen** für die Seitenliste — jede indexierte URL mit Wortzahl, Chunk-Zahl und letzter Crawl-Zeit, plus ein Suchfeld, das über die indexierten Chunks läuft und damit der schnellste Weg ist zu prüfen, was ein Agent wirklich abrufen würde.
 
 ## Wo das hingehört
 
-Crawling ist der günstige Weg, eine öffentliche Website in den Agenten-Kontext zu holen: eine Domain, ein Takt, und der Rest ist das Problem des Crawlers. Der Preis ist die Grenze des anonymen Besuchers — private Inhalte brauchen [Dokumente](/de/platform/knowledge/documents) oder eine Connector. Wie die Website-Zeilen neben Kontakte, Produkten und Lieferanten stehen, liest du in [Strukturierte Daten](/de/platform/knowledge/structured-data).
+Crawling ist der günstige Weg, eine öffentliche Website in den Agenten-Kontext zu holen: eine Domain — oder eine handverlesene URL-Liste —, ein Takt, und der Rest ist das Problem des Crawlers. Der Preis ist die Grenze des anonymen Besuchers — private Inhalte brauchen [Dokumente](/de/platform/knowledge/documents) oder eine Connector. Wie die Website-Zeilen neben Kontakte, Produkten und Lieferanten stehen, liest du in [Strukturierte Daten](/de/platform/knowledge/structured-data).

--- a/docs/en/platform/knowledge/crawling.md
+++ b/docs/en/platform/knowledge/crawling.md
@@ -3,9 +3,9 @@ title: Crawling
 description: How Tale turns a website into knowledge — domain registration, sitemap-driven URL discovery, scheduled re-scans, and the indexed-pages view.
 ---
 
-A Website is the knowledge base's shape for "a public site the agent should know about". You hand Tale a domain and a scan interval; the crawler discovers URLs, fetches pages, extracts the main content, chunks and embeds the text, and serves the chunks back at reply time the same way it does for Documents. This page walks what you see between adding a domain and agents citing its pages.
+A Website is the knowledge base's shape for "a public site the agent should know about". You hand Tale a domain and a scan interval; the crawler discovers URLs, fetches pages, extracts the main content, chunks and embeds the text, and serves the chunks back at reply time the same way it does for Documents. When you need specific pages rather than a whole site, hand it a URL list instead — the same pipeline runs on exactly the pages you name. This page walks what you see between adding a domain and agents citing its pages.
 
-<Frame caption="Adding a website — domain plus scan interval is the whole form.">
+<Frame caption="Adding a website — in Whole website mode, domain plus scan interval is the whole form.">
 
 ![The Add website dialog on the Websites tab, asking for a domain and a scan interval that defaults to every six hours.](/images/platform/websites-add-dialog.webp)
 
@@ -13,7 +13,7 @@ A Website is the knowledge base's shape for "a public site the agent should know
 
 ## Adding a website
 
-Open **Knowledge > Websites** and click **Add website**. The dialog has two fields: **Domain** (for example `example.com`) and **Scan interval** — every 1 hour, 6 hours (the default), 12 hours, 1 day, 5 days, 7 days, or 30 days. Tale normalises the domain — `https://`, `www.`, and trailing slashes are tolerated — and rejects anything that does not parse as a hostname. Click **Save**; the scheduler picks new websites up on its next tick, so the first scan starts within seconds.
+Open **Knowledge > Websites** and click **Add website**. **Source type** decides what the source covers: **Whole website** — the default — crawls everything it can discover on the domain, **URL list** indexes exactly the pages you paste (the next section). In Whole website mode the dialog has two fields: **Domain** (for example `example.com`) and **Scan interval** — every 1 hour, 6 hours (the default), 12 hours, 1 day, 5 days, 7 days, or 30 days. Tale normalises the domain — `https://`, `www.`, and trailing slashes are tolerated — and rejects anything that does not parse as a hostname. Click **Save**; the scheduler picks new websites up on its next tick, so the first scan starts within seconds.
 
 <Note>
 
@@ -21,20 +21,26 @@ There is no auth field and no include/exclude path list — the crawler sees exa
 
 </Note>
 
+## Adding a URL list
+
+Switch **Source type** to **URL list** when you want specific pages, not a whole site — a report here, a pricing page there, a handful of PDFs. Paste one URL per line into **URLs**; only those pages are fetched and indexed, and the crawler follows no links beyond them. The lines may span several websites: the dialog groups them into one source per website, so a paste covering three domains creates three rows. Pasting another list for a website that already has one adds the new URLs to the existing source — nothing is dropped, and the scan interval moves to whatever you picked. Lists re-scan on the same cadence as whole websites; their rows carry a **URL list** badge in the table.
+
 ## How URLs are discovered
 
 The crawler tries the cooperative path first. It resolves the homepage and walks every sitemap the site publishes — `sitemap.xml`, sitemap indexes, gzipped and robots-declared sitemaps — collecting the URL list the site itself maintains. Sites with a healthy sitemap get complete coverage with no guessing.
 
 When the sitemap is missing, broken, or empty, the crawler falls back to a breadth-first link walk from the homepage: in-domain links only, external and social links dropped, navigation and footer chrome stripped before extraction. The fallback covers sitemap-less sites, but it cannot match a well-maintained sitemap for completeness.
 
+Pages are not the only content that counts. Linked documents — PDF and Office files (`docx`, `xlsx`, `pptx`, `odt`) — are fetched and indexed like pages, whether the crawler finds them linked on a website or you list them directly in a URL list. Images and scanned documents without embedded text are skipped: the scan remembers it looked and stores nothing.
+
 ## The scan schedule
 
-The interval decides how often URLs are re-discovered and pages re-fetched. Each scan is incremental: unchanged pages are skipped, changed pages are re-extracted and re-embedded, new pages are added, removed pages are dropped from the index. Agents pointed at the website see the new content on the next retrieval — there is no separate publish step.
+The interval decides how often URLs are re-discovered and pages re-fetched. Each scan is incremental: unchanged pages are skipped, changed pages are re-extracted and re-embedded, new pages are added, removed pages are dropped from the index. URL lists follow the same cadence with a fixed set — the listed pages are re-fetched on schedule, nothing new is discovered. Agents pointed at the website see the new content on the next retrieval — there is no separate publish step.
 
 ## Reading the table
 
-Each row shows the domain, its **Status** — **Idle** between scans, **Scanning** in flight, **Active** after a successful scan, **Error** when the last scan failed, **Deleting** during removal — the **Indexed** percentage (hover for crawled-of-total page counts), the last **Scanned** time, and the **Interval**. Open a row for the site's discovered title and description; click **View pages** for the page list — every indexed URL with its word count, chunk count, and last-crawled time, plus a search box that runs over the indexed chunks, which is the quickest way to check what an agent would actually retrieve.
+Each row shows the domain (URL-list sources carry a **URL list** badge beside it), its **Status** — **Idle** between scans, **Scanning** in flight, **Active** after a successful scan, **Error** when the last scan failed, **Deleting** during removal — the **Indexed** percentage (hover for crawled-of-total page counts), the last **Scanned** time, and the **Interval**. Open a row for the site's discovered title and description; click **View pages** for the page list — every indexed URL with its word count, chunk count, and last-crawled time, plus a search box that runs over the indexed chunks, which is the quickest way to check what an agent would actually retrieve.
 
 ## Where this fits
 
-Crawling is the cheap way to bring a public site into agent context: a domain, a cadence, and the rest is the crawler's problem. The trade-off is the anonymous-visitor boundary — private content needs [Documents](/platform/knowledge/documents) or an connector. For how the Website rows sit beside Contacts, Products, and Vendors, read [Structured data](/platform/knowledge/structured-data).
+Crawling is the cheap way to bring a public site into agent context: a domain — or a hand-picked URL list — a cadence, and the rest is the crawler's problem. The trade-off is the anonymous-visitor boundary — private content needs [Documents](/platform/knowledge/documents) or an connector. For how the Website rows sit beside Contacts, Products, and Vendors, read [Structured data](/platform/knowledge/structured-data).

--- a/docs/fr/platform/knowledge/crawling.md
+++ b/docs/fr/platform/knowledge/crawling.md
@@ -3,9 +3,9 @@ title: Exploration de sites web
 description: Comment Tale transforme un site web en connaissances — enregistrement du domaine, découverte des URL par sitemap, ré-analyses planifiées et vue des pages indexées.
 ---
 
-Un site web est la forme que prend, dans la base de connaissances, « un site public que l’agent doit connaître ». Tu confies à Tale un domaine et un intervalle d’analyse ; le crawler découvre les URL, va chercher les pages, extrait le contenu principal, découpe le texte et calcule ses embeddings, puis sert les fragments au moment de répondre, exactement comme pour les Documents. Cette page parcourt ce que tu vois entre l’ajout d’un domaine et les citations de ses pages par les agents.
+Un site web est la forme que prend, dans la base de connaissances, « un site public que l’agent doit connaître ». Tu confies à Tale un domaine et un intervalle d’analyse ; le crawler découvre les URL, va chercher les pages, extrait le contenu principal, découpe le texte et calcule ses embeddings, puis sert les fragments au moment de répondre, exactement comme pour les Documents. Quand tu veux des pages précises plutôt qu’un site entier, confie-lui une liste d’URL — le même pipeline tourne alors exactement sur les pages que tu nommes. Cette page parcourt ce que tu vois entre l’ajout d’un domaine et les citations de ses pages par les agents.
 
-<Frame caption="Ajouter un site web — un domaine plus un intervalle d’analyse, et le formulaire est complet.">
+<Frame caption="Ajouter un site web — en mode « Site web entier », un domaine plus un intervalle d’analyse, et le formulaire est complet.">
 
 ![La boîte de dialogue Ajouter un site web de l’onglet Sites web, demandant un domaine et un intervalle d’analyse réglé par défaut sur toutes les 6 heures.](/images/platform/websites-add-dialog.webp)
 
@@ -13,7 +13,7 @@ Un site web est la forme que prend, dans la base de connaissances, « un site pu
 
 ## Ajouter un site web
 
-Ouvre **Connaissances > Sites web** et clique sur **Ajouter un site web**. La boîte de dialogue a deux champs : **Domaine** (par exemple `example.com`) et **Intervalle d'analyse** — toutes les heures, toutes les 6 heures (le réglage par défaut), toutes les 12 heures, tous les jours, tous les 5, 7 ou 30 jours. Tale normalise le domaine — `https://`, `www.` et les barres obliques finales sont tolérés — et rejette tout ce qui ne se lit pas comme un nom d’hôte. Clique sur **Enregistrer** ; le planificateur ramasse les nouveaux sites à son prochain passage, la première analyse démarre donc en quelques secondes.
+Ouvre **Connaissances > Sites web** et clique sur **Ajouter un site web**. Le **Type de source** décide de ce que couvre la source : **Site web entier** — le réglage par défaut — explore tout ce qui se découvre sur le domaine, **Liste d'URL** indexe exactement les pages que tu colles (la section suivante y revient). En mode Site web entier, la boîte de dialogue a deux champs : **Domaine** (par exemple `example.com`) et **Intervalle d'analyse** — toutes les heures, toutes les 6 heures (le réglage par défaut), toutes les 12 heures, tous les jours, tous les 5, 7 ou 30 jours. Tale normalise le domaine — `https://`, `www.` et les barres obliques finales sont tolérés — et rejette tout ce qui ne se lit pas comme un nom d’hôte. Clique sur **Enregistrer** ; le planificateur ramasse les nouveaux sites à son prochain passage, la première analyse démarre donc en quelques secondes.
 
 <Note>
 
@@ -21,20 +21,26 @@ Il n’y a ni champ d’authentification ni liste de chemins à inclure ou exclu
 
 </Note>
 
+## Ajouter une liste d’URL
+
+Passe le **Type de source** sur **Liste d'URL** quand tu veux des pages précises, pas un site entier — un rapport ici, une page de tarifs là, quelques PDF. Colle une URL par ligne dans le champ **URL** ; seules ces pages sont chargées et indexées, le crawler ne suit aucun lien au-delà. Les lignes peuvent mélanger plusieurs sites web : la boîte de dialogue les regroupe en une source par site web, un collage qui couvre trois domaines crée donc trois lignes. Recoller une liste pour un site qui en a déjà une ajoute les nouvelles URL à la source existante — rien ne se perd, et l’intervalle d’analyse passe à ton nouveau choix. Les listes se ré-analysent à la même cadence que les sites entiers ; leurs lignes portent le badge **Liste d'URL** dans la table.
+
 ## Comment les URL sont découvertes
 
 Le crawler tente d’abord la voie coopérative. Il résout la page d’accueil et parcourt chaque sitemap que le site publie — `sitemap.xml`, index de sitemaps, sitemaps compressés ou déclarés dans le robots.txt — pour collecter la liste d’URL que le site entretient lui-même. Les sites au sitemap sain obtiennent une couverture complète, sans rien deviner.
 
 Quand le sitemap manque, est cassé ou vide, le crawler se rabat sur un parcours de liens en largeur depuis la page d’accueil : liens du domaine uniquement, liens externes et sociaux écartés, navigation et pied de page retirés avant l’extraction. Ce repli couvre les sites sans sitemap, mais il ne peut pas égaler la complétude d’un sitemap bien tenu.
 
+Les pages ne sont pas le seul contenu qui compte. Les documents liés — PDF et fichiers Office (`docx`, `xlsx`, `pptx`, `odt`) — sont chargés et indexés comme des pages, que le crawler les trouve sur un site ou que tu les listes directement dans une liste d’URL. Les images et les documents numérisés sans texte intégré sont ignorés : l’analyse note qu’elle a regardé et n’enregistre rien.
+
 ## Le planning d’analyse
 
-L’intervalle décide de la fréquence à laquelle les URL sont redécouvertes et les pages rechargées. Chaque analyse est incrémentale : les pages inchangées sont sautées, les pages modifiées sont réextraites et réindexées, les nouvelles pages sont ajoutées, les pages disparues sont retirées de l’index. Les agents pointés sur le site voient le nouveau contenu dès la récupération suivante — il n’y a pas d’étape de publication séparée.
+L’intervalle décide de la fréquence à laquelle les URL sont redécouvertes et les pages rechargées. Chaque analyse est incrémentale : les pages inchangées sont sautées, les pages modifiées sont réextraites et réindexées, les nouvelles pages sont ajoutées, les pages disparues sont retirées de l’index. Une liste d’URL suit la même cadence avec un ensemble fixe — les pages listées sont rechargées selon le planning, rien de nouveau n’est découvert. Les agents pointés sur le site voient le nouveau contenu dès la récupération suivante — il n’y a pas d’étape de publication séparée.
 
 ## Lire la table
 
-Chaque ligne montre le domaine, son **Statut** — **Inactif** entre deux analyses, **En cours d'analyse** en vol, **Actif** après une analyse réussie, **Erreur** quand la dernière analyse a échoué, **Suppression en cours** pendant le retrait — le pourcentage **Indexé** (survole-le pour le compte de pages explorées sur le total), l’heure de dernière analyse dans **Analysé** et l’**Intervalle**. Ouvre une ligne pour le titre et la description découverts du site ; clique sur **Voir les pages** pour la liste des pages — chaque URL indexée avec son nombre de mots, son nombre de fragments et sa dernière exploration, plus un champ de recherche qui interroge les fragments indexés : le moyen le plus rapide de vérifier ce qu’un agent récupérerait réellement.
+Chaque ligne montre le domaine (les sources de type liste d’URL portent à côté le badge **Liste d'URL**), son **Statut** — **Inactif** entre deux analyses, **En cours d'analyse** en vol, **Actif** après une analyse réussie, **Erreur** quand la dernière analyse a échoué, **Suppression en cours** pendant le retrait — le pourcentage **Indexé** (survole-le pour le compte de pages explorées sur le total), l’heure de dernière analyse dans **Analysé** et l’**Intervalle**. Ouvre une ligne pour le titre et la description découverts du site ; clique sur **Voir les pages** pour la liste des pages — chaque URL indexée avec son nombre de mots, son nombre de fragments et sa dernière exploration, plus un champ de recherche qui interroge les fragments indexés : le moyen le plus rapide de vérifier ce qu’un agent récupérerait réellement.
 
 ## Où cela s’inscrit
 
-L’exploration est le moyen économique d’amener un site public dans le contexte des agents : un domaine, une cadence, et le reste est l’affaire du crawler. La contrepartie est la frontière du visiteur anonyme — le contenu privé passe par [Documents](/fr/platform/knowledge/documents) ou une connector. Pour la place des lignes Sites web à côté des Contacts, Produits et Fournisseurs, lis [Données structurées](/fr/platform/knowledge/structured-data).
+L’exploration est le moyen économique d’amener un site public dans le contexte des agents : un domaine — ou une liste d’URL choisie à la main — une cadence, et le reste est l’affaire du crawler. La contrepartie est la frontière du visiteur anonyme — le contenu privé passe par [Documents](/fr/platform/knowledge/documents) ou une connector. Pour la place des lignes Sites web à côté des Contacts, Produits et Fournisseurs, lis [Données structurées](/fr/platform/knowledge/structured-data).

--- a/services/db/migrations/knowledge-db/private_knowledge/00000000000001_knowledge_private_baseline.sql
+++ b/services/db/migrations/knowledge-db/private_knowledge/00000000000001_knowledge_private_baseline.sql
@@ -54,6 +54,12 @@ CREATE TABLE IF NOT EXISTS private_knowledge.documents (
 -- migration fails with "column does not exist" on exactly the deployments that
 -- most need it. Every column is nullable or carries a constant default, so
 -- adding it to a populated table is a metadata-only change.
+--
+-- AND it must ship as a new numbered migration as well (see
+-- 00000000000003_knowledge_private_converge_columns.sql): this file's version
+-- is already recorded on every migrated database, and an applied migration
+-- never runs again — an edit here alone reaches only databases created after
+-- the edit.
 ALTER TABLE private_knowledge.documents
     ADD COLUMN IF NOT EXISTS error              TEXT,
     ADD COLUMN IF NOT EXISTS org_slug           TEXT        NOT NULL DEFAULT 'default',

--- a/services/db/migrations/knowledge-db/private_knowledge/00000000000003_knowledge_private_converge_columns.sql
+++ b/services/db/migrations/knowledge-db/private_knowledge/00000000000003_knowledge_private_converge_columns.sql
@@ -1,0 +1,44 @@
+-- migrate:up
+--
+-- Re-states the private_knowledge column convergence under its own version.
+--
+-- The baseline converges columns onto tables an earlier release created — but
+-- a migration file is applied ONCE. A database that recorded the baseline's
+-- version before a column was added to that file never runs the file again, so
+-- editing an already-applied migration silently loses the edit on exactly the
+-- databases that need it. `context_header` was added to the baseline that way:
+-- every corpus provisioned before the edit is missing the column, and every
+-- chunk INSERT on it fails with "column context_header does not exist".
+--
+-- Hence this file: the baseline's complete convergence set again, as a NEW
+-- version, so every database — bundled (dbmate at container start) or
+-- bring-your-own (the platform bootstrap) — actually applies it. Pure
+-- ADD COLUMN IF NOT EXISTS with constant defaults: metadata-only, idempotent,
+-- safe on any vintage, a no-op where the baseline already ran in full.
+--
+-- The rule this file exists to encode: a column added to the baseline must
+-- ALSO ship as a new numbered migration.
+
+ALTER TABLE private_knowledge.documents
+    ADD COLUMN IF NOT EXISTS error              TEXT,
+    ADD COLUMN IF NOT EXISTS org_slug           TEXT        NOT NULL DEFAULT 'default',
+    ADD COLUMN IF NOT EXISTS progress_phase     TEXT,
+    ADD COLUMN IF NOT EXISTS progress_detail    TEXT,
+    ADD COLUMN IF NOT EXISTS source_created_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS source_modified_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS ocr_applied        BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS folder_path        TEXT,
+    ADD COLUMN IF NOT EXISTS metadata           JSONB       NOT NULL DEFAULT '{}';
+
+ALTER TABLE private_knowledge.chunks
+    ADD COLUMN IF NOT EXISTS org_slug       TEXT NOT NULL DEFAULT 'default',
+    ADD COLUMN IF NOT EXISTS context_header TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS core_content   TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS prefix_overlap TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS suffix_overlap TEXT NOT NULL DEFAULT '';
+
+-- migrate:down
+-- Deliberately empty, like the baseline: on a database that only now receives
+-- these columns they may immediately hold data, and dropping them would
+-- destroy reassembly and tenancy information. Remove a column with an
+-- explicit, reviewed migration instead.

--- a/services/db/migrations/knowledge-db/public_web/00000000000002_knowledge_web_baseline.sql
+++ b/services/db/migrations/knowledge-db/public_web/00000000000002_knowledge_web_baseline.sql
@@ -120,6 +120,11 @@ CREATE TABLE IF NOT EXISTS public_web.chunks (
     FOREIGN KEY (domain, url) REFERENCES public_web.website_urls(domain, url) ON DELETE CASCADE
 );
 
+-- Convergence for databases an earlier release created — which a column added
+-- here alone never reaches, because this file's version is already recorded
+-- there and an applied migration never runs again. A new column must ALSO ship
+-- as a new numbered migration (see
+-- 00000000000004_knowledge_web_converge_columns.sql).
 ALTER TABLE public_web.chunks
     ADD COLUMN IF NOT EXISTS context_header TEXT NOT NULL DEFAULT '',
     ADD COLUMN IF NOT EXISTS core_content   TEXT NOT NULL DEFAULT '',

--- a/services/db/migrations/knowledge-db/public_web/00000000000004_knowledge_web_converge_columns.sql
+++ b/services/db/migrations/knowledge-db/public_web/00000000000004_knowledge_web_converge_columns.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+--
+-- Re-states the public_web column convergence under its own version — the same
+-- reason as 00000000000003 in private_knowledge: a migration file is applied
+-- ONCE, so a column added to the already-applied baseline (as `context_header`
+-- was) never reaches a database that migrated before the edit, and every chunk
+-- INSERT there fails with "column context_header does not exist". Pure
+-- ADD COLUMN IF NOT EXISTS: metadata-only, idempotent, a no-op where the
+-- baseline already ran in full.
+
+ALTER TABLE public_web.chunks
+    ADD COLUMN IF NOT EXISTS context_header TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS core_content   TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS prefix_overlap TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS suffix_overlap TEXT NOT NULL DEFAULT '';
+
+-- migrate:down
+-- Deliberately empty, like the baseline: on a database that only now receives
+-- these columns they may immediately hold data, and dropping them would
+-- destroy reassembly information. Remove a column with an explicit, reviewed
+-- migration instead.

--- a/services/db/migrations/knowledge-db/public_web/00000000000005_url_list_sources.sql
+++ b/services/db/migrations/knowledge-db/public_web/00000000000005_url_list_sources.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+--
+-- URL-list sources: a websites row may now be a curated list of URLs instead
+-- of a crawled site. `kind` discriminates — 'site' discovers pages via
+-- robots/sitemaps/links as before, 'list' fetches exactly the URLs an
+-- operator registered. `website_urls.listed` marks rows that came from an
+-- operator's list rather than discovery; on a 'site' row they act as extra
+-- seeds. Kind only ever widens ('list' -> 'site'): registering the full site
+-- upgrades the row, registering a list on a crawled site merely adds seeds.
+-- Additive and idempotent — a no-op wherever it already ran in full.
+
+ALTER TABLE public_web.websites
+    ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'site';
+
+ALTER TABLE public_web.websites
+    DROP CONSTRAINT IF EXISTS websites_kind_check;
+ALTER TABLE public_web.websites
+    ADD CONSTRAINT websites_kind_check CHECK (kind IN ('site', 'list'));
+
+ALTER TABLE public_web.website_urls
+    ADD COLUMN IF NOT EXISTS listed BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- migrate:down
+-- Deliberately empty, like the baseline: `kind` and `listed` hold operator
+-- intent the moment they exist, and dropping them would collapse curated
+-- lists back into crawled sites. Remove with an explicit, reviewed migration
+-- instead.

--- a/services/platform/app/features/websites/components/website-add-dialog.test.tsx
+++ b/services/platform/app/features/websites/components/website-add-dialog.test.tsx
@@ -16,10 +16,16 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
 }));
 
 // Controllable mutate so a test can drive its onError callback. The dialog uses
-// the callback form `mutate(args, { onSuccess, onError })`.
+// the callback form `mutate(args, { onSuccess, onError })` for site mode and
+// awaits `mutateAsync(args)` once per domain group in URL-list mode.
 const createWebsiteMock = vi.fn();
+const createWebsiteAsyncMock = vi.fn();
 vi.mock('../hooks/mutations', () => ({
-  useCreateWebsite: () => ({ mutate: createWebsiteMock, isPending: false }),
+  useCreateWebsite: () => ({
+    mutate: createWebsiteMock,
+    mutateAsync: createWebsiteAsyncMock,
+    isPending: false,
+  }),
 }));
 
 import { AddWebsiteDialog } from './website-add-dialog';
@@ -146,6 +152,100 @@ describe('AddWebsiteDialog', () => {
           }),
         ),
       );
+    });
+  });
+
+  describe('URL list mode', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('groups pasted URLs into one create call per website, folding www', async () => {
+      createWebsiteAsyncMock.mockResolvedValue('site-id');
+      const onClose = vi.fn();
+      const { user } = render(
+        <AddWebsiteDialog
+          isOpen={true}
+          onClose={onClose}
+          organizationId="test-org-id"
+        />,
+      );
+
+      await user.click(screen.getByRole('radio', { name: 'URL list' }));
+      const textarea = screen.getByLabelText('URLs');
+      await user.type(
+        textarea,
+        'https://www.fedlex.admin.ch/eli/cc/2009/615/de{enter}' +
+          'https://fedlex.admin.ch/eli/cc/2009/828/de{enter}' +
+          'https://www.bazg.admin.ch/dam/52_15.pdf',
+      );
+
+      const submit = document.querySelector(
+        'button[type="submit"]',
+      ) as HTMLButtonElement;
+      await waitFor(() => expect(submit).toBeEnabled());
+      await user.click(submit);
+
+      await waitFor(() =>
+        expect(createWebsiteAsyncMock).toHaveBeenCalledTimes(2),
+      );
+      expect(createWebsiteAsyncMock).toHaveBeenCalledWith({
+        organizationId: 'test-org-id',
+        domain: 'fedlex.admin.ch',
+        scanInterval: '6h',
+        urls: [
+          'https://www.fedlex.admin.ch/eli/cc/2009/615/de',
+          'https://fedlex.admin.ch/eli/cc/2009/828/de',
+        ],
+      });
+      expect(createWebsiteAsyncMock).toHaveBeenCalledWith({
+        organizationId: 'test-org-id',
+        domain: 'bazg.admin.ch',
+        scanInterval: '6h',
+        urls: ['https://www.bazg.admin.ch/dam/52_15.pdf'],
+      });
+      await waitFor(() =>
+        expect(toast).toHaveBeenCalledWith(
+          expect.objectContaining({ variant: 'success' }),
+        ),
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('rejects an unparseable line with a field error and no calls', async () => {
+      const { user } = render(
+        <AddWebsiteDialog
+          isOpen={true}
+          onClose={vi.fn()}
+          organizationId="test-org-id"
+        />,
+      );
+
+      await user.click(screen.getByRole('radio', { name: 'URL list' }));
+      await user.type(screen.getByLabelText('URLs'), 'not a url at all');
+      const submit = document.querySelector(
+        'button[type="submit"]',
+      ) as HTMLButtonElement;
+      await user.click(submit);
+
+      await waitFor(() =>
+        expect(
+          screen.getByText('This line is not a valid URL: not a url at all'),
+        ).toBeInTheDocument(),
+      );
+      expect(createWebsiteAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it('passes axe audit in list mode', async () => {
+      const { container, user } = render(
+        <AddWebsiteDialog
+          isOpen={true}
+          onClose={vi.fn()}
+          organizationId="test-org-id"
+        />,
+      );
+      await user.click(screen.getByRole('radio', { name: 'URL list' }));
+      await checkAccessibility(container);
     });
   });
 });

--- a/services/platform/app/features/websites/components/website-add-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-add-dialog.tsx
@@ -6,7 +6,9 @@ import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { RadioGroup } from '@/app/components/ui/forms/radio-group';
 import { Select } from '@/app/components/ui/forms/select';
+import { Textarea } from '@/app/components/ui/forms/textarea';
 import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -15,7 +17,9 @@ import { convexErrorCode } from '@/lib/utils/convex-error';
 import { useCreateWebsite } from '../hooks/mutations';
 
 type FormData = {
+  mode: 'site' | 'list';
   domain: string;
+  urls: string;
   scanInterval: string;
 };
 
@@ -25,39 +29,117 @@ interface AddWebsiteDialogProps {
   organizationId: string;
 }
 
+function ensureScheme(value: string): string {
+  return value.startsWith('http://') || value.startsWith('https://')
+    ? value
+    : `https://${value}`;
+}
+
+function isValidDomainInput(value: string): boolean {
+  try {
+    const parsed = new URL(ensureScheme(value));
+    return !!parsed.hostname && parsed.hostname.includes('.');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Split a pasted URL list into one group per website. The backend registers
+ * one source per domain, so lines are grouped by hostname with the `www.`
+ * prefix folded away (the crawler treats www/apex as one site).
+ */
+function parseUrlList(raw: string): {
+  groups: Map<string, string[]>;
+  invalid: string[];
+} {
+  const groups = new Map<string, string[]>();
+  const invalid: string[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let parsed: URL;
+    try {
+      parsed = new URL(ensureScheme(trimmed));
+    } catch {
+      invalid.push(trimmed);
+      continue;
+    }
+    if (
+      (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') ||
+      !parsed.hostname.includes('.')
+    ) {
+      invalid.push(trimmed);
+      continue;
+    }
+    const host = parsed.hostname.toLowerCase();
+    const key = host.startsWith('www.') ? host.slice(4) : host;
+    const bucket = groups.get(key) ?? [];
+    bucket.push(parsed.toString());
+    groups.set(key, bucket);
+  }
+  return { groups, invalid };
+}
+
 export function AddWebsiteDialog({
   isOpen,
   onClose,
   organizationId,
 }: AddWebsiteDialogProps) {
   const { t: tWebsites } = useT('websites');
-  const { mutate: createWebsite, isPending: isLoading } = useCreateWebsite();
+  const {
+    mutate: createWebsite,
+    mutateAsync: createWebsiteAsync,
+    isPending,
+  } = useCreateWebsite();
 
   const formSchema = useMemo(
     () =>
-      z.object({
-        domain: z
-          .string()
-          .min(1, tWebsites('validation.domainRequired'))
-          .refine(
-            (val) => {
-              try {
-                const url =
-                  val.startsWith('http://') || val.startsWith('https://')
-                    ? val
-                    : `https://${val}`;
-                const parsed = new URL(url);
-                return !!parsed.hostname && parsed.hostname.includes('.');
-              } catch {
-                return false;
-              }
-            },
-            { message: tWebsites('validation.validDomain') },
-          ),
-        scanInterval: z
-          .string()
-          .min(1, tWebsites('validation.scanIntervalRequired')),
-      }),
+      z
+        .object({
+          mode: z.enum(['site', 'list']),
+          domain: z.string(),
+          urls: z.string(),
+          scanInterval: z
+            .string()
+            .min(1, tWebsites('validation.scanIntervalRequired')),
+        })
+        .superRefine((data, ctx) => {
+          if (data.mode === 'site') {
+            if (data.domain.trim().length === 0) {
+              ctx.addIssue({
+                code: 'custom',
+                path: ['domain'],
+                message: tWebsites('validation.domainRequired'),
+              });
+            } else if (!isValidDomainInput(data.domain)) {
+              ctx.addIssue({
+                code: 'custom',
+                path: ['domain'],
+                message: tWebsites('validation.validDomain'),
+              });
+            }
+            return;
+          }
+          const { groups, invalid } = parseUrlList(data.urls);
+          if (invalid.length > 0) {
+            ctx.addIssue({
+              code: 'custom',
+              path: ['urls'],
+              message: tWebsites('validation.urlListInvalid', {
+                line: invalid[0],
+              }),
+            });
+            return;
+          }
+          if (groups.size === 0) {
+            ctx.addIssue({
+              code: 'custom',
+              path: ['urls'],
+              message: tWebsites('validation.urlListRequired'),
+            });
+          }
+        }),
     [tWebsites],
   );
 
@@ -74,21 +156,25 @@ export function AddWebsiteDialog({
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isSubmitting },
     reset,
     setValue,
     watch,
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      mode: 'site',
       domain: '',
+      urls: '',
       scanInterval: '6h',
     },
   });
 
+  const mode = watch('mode');
   const scanInterval = watch('scanInterval');
+  const isLoading = isPending || isSubmitting;
 
-  const onSubmit = (data: FormData) => {
+  const submitSite = (data: FormData) => {
     createWebsite(
       {
         organizationId,
@@ -119,6 +205,51 @@ export function AddWebsiteDialog({
     );
   };
 
+  const submitList = async (data: FormData) => {
+    const { groups } = parseUrlList(data.urls);
+    const failed: string[] = [];
+    let urlCount = 0;
+    // One source per domain, registered sequentially. Re-registering merges
+    // server-side, so retrying after a partial failure is idempotent.
+    for (const [domain, urls] of groups) {
+      try {
+        await createWebsiteAsync({
+          organizationId,
+          domain,
+          scanInterval: data.scanInterval,
+          urls,
+        });
+        urlCount += urls.length;
+      } catch (error) {
+        console.error(`Failed to add URL list for ${domain}:`, error);
+        failed.push(domain);
+      }
+    }
+    if (failed.length > 0) {
+      toast({
+        title: tWebsites('toast.addListPartial', {
+          domains: failed.join(', '),
+        }),
+        variant: 'destructive',
+      });
+      return;
+    }
+    toast({
+      title: tWebsites('toast.addListSuccess', { count: urlCount }),
+      variant: 'success',
+    });
+    reset();
+    onClose();
+  };
+
+  const onSubmit = async (data: FormData) => {
+    if (data.mode === 'site') {
+      submitSite(data);
+      return;
+    }
+    await submitList(data);
+  };
+
   const handleClose = () => {
     reset();
     onClose();
@@ -133,15 +264,45 @@ export function AddWebsiteDialog({
       isSubmitting={isLoading}
       onSubmit={handleSubmit(onSubmit)}
     >
-      <Input
-        id="domain"
-        type="text"
-        label={tWebsites('domain')}
-        placeholder={tWebsites('urlPlaceholder')}
-        {...register('domain')}
+      <RadioGroup
+        id="mode"
+        label={tWebsites('addMode.label')}
+        value={mode}
+        onValueChange={(value) =>
+          setValue('mode', value === 'list' ? 'list' : 'site', {
+            shouldDirty: true,
+          })
+        }
+        options={[
+          { value: 'site', label: tWebsites('addMode.site') },
+          { value: 'list', label: tWebsites('addMode.list') },
+        ]}
+        columns={2}
         disabled={isLoading}
-        errorMessage={errors.domain?.message}
       />
+
+      {mode === 'site' ? (
+        <Input
+          id="domain"
+          type="text"
+          label={tWebsites('domain')}
+          placeholder={tWebsites('urlPlaceholder')}
+          {...register('domain')}
+          disabled={isLoading}
+          errorMessage={errors.domain?.message}
+        />
+      ) : (
+        <Textarea
+          id="urls"
+          label={tWebsites('urlList')}
+          placeholder={tWebsites('urlListPlaceholder')}
+          description={tWebsites('urlListHint')}
+          rows={6}
+          {...register('urls')}
+          disabled={isLoading}
+          errorMessage={errors.urls?.message}
+        />
+      )}
 
       <Select
         value={scanInterval}

--- a/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
+++ b/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
@@ -43,6 +43,11 @@ export const useWebsitesTableConfig = createTableConfigHook<'websites'>(
           <Text as="span" variant="label" truncate>
             {row.original.domain}
           </Text>
+          {row.original.kind === 'list' && (
+            <Badge variant="outline" className="shrink-0">
+              {tEntity('kindList')}
+            </Badge>
+          )}
         </HStack>
       ),
     },

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -620,6 +620,7 @@ import type * as node_only_sandbox_helpers_stage_url from "../node_only/sandbox/
 import type * as node_only_sandbox_internal_actions from "../node_only/sandbox/internal_actions.js";
 import type * as node_only_sandbox_llm_gateway_admin from "../node_only/sandbox/llm_gateway_admin.js";
 import type * as node_only_sandbox_quiet_idle from "../node_only/sandbox/quiet_idle.js";
+import type * as node_only_sandbox_render_fetch from "../node_only/sandbox/render_fetch.js";
 import type * as node_only_sandbox_resume_rotation from "../node_only/sandbox/resume_rotation.js";
 import type * as node_only_sandbox_session_admin_actions from "../node_only/sandbox/session_admin_actions.js";
 import type * as node_only_sandbox_session_credentials from "../node_only/sandbox/session_credentials.js";
@@ -1514,6 +1515,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/internal_actions": typeof node_only_sandbox_internal_actions;
   "node_only/sandbox/llm_gateway_admin": typeof node_only_sandbox_llm_gateway_admin;
   "node_only/sandbox/quiet_idle": typeof node_only_sandbox_quiet_idle;
+  "node_only/sandbox/render_fetch": typeof node_only_sandbox_render_fetch;
   "node_only/sandbox/resume_rotation": typeof node_only_sandbox_resume_rotation;
   "node_only/sandbox/session_admin_actions": typeof node_only_sandbox_session_admin_actions;
   "node_only/sandbox/session_credentials": typeof node_only_sandbox_session_credentials;

--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -545,6 +545,49 @@ describe('rag_fetch', () => {
     expect(second.nextOffset).toBeUndefined();
   });
 
+  it('serves an exact range through offset + limit, reporting the next offset', async () => {
+    const text = 'x'.repeat(1000) + 'MATCH' + 'y'.repeat(1000);
+    fetchDocumentByFileIdMock.mockResolvedValueOnce({
+      fileId: 'file_range',
+      filename: 'range.txt',
+      folderPath: null,
+      modifiedAt: null,
+      text,
+    });
+    const executor = await makeExecutor(createCtx().ctx);
+
+    const result = await executor.execute({
+      id: 'call_1',
+      name: 'rag_fetch',
+      input: { ref: 'file_range', offset: 1000, limit: 5 },
+    });
+    expect(result.status).toBe('ok');
+    expect(result.content).toBe('MATCH');
+    expect(result.offset).toBe(1000);
+    expect(result.nextOffset).toBe(1005);
+    expect(result.totalChars).toBe(2005);
+  });
+
+  it('clamps an oversized limit to the window maximum', async () => {
+    fetchDocumentByFileIdMock.mockResolvedValueOnce({
+      fileId: 'file_cap',
+      filename: 'cap.txt',
+      folderPath: null,
+      modifiedAt: null,
+      text: 'z'.repeat(30_000),
+    });
+    const executor = await makeExecutor(createCtx().ctx);
+
+    const result = await executor.execute({
+      id: 'call_1',
+      name: 'rag_fetch',
+      input: { ref: 'file_cap', limit: 999_999 },
+    });
+    expect(result.status).toBe('ok');
+    expect(result.content).toHaveLength(20_000);
+    expect(result.nextOffset).toBe(20_000);
+  });
+
   it('needs a ref', async () => {
     const executor = await makeExecutor(createCtx().ctx);
     await expect(

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -208,6 +208,9 @@ export function createChatToolExecutor(
     readonly ref?: string;
     readonly url?: string;
     readonly snippet?: string;
+    /** Char position of the match within the ref's full text — a rag_fetch
+     * starting offset that lands on the match instead of the start. */
+    readonly offset?: number;
     readonly data?: Record<string, unknown>;
   }
 
@@ -259,6 +262,7 @@ export function createChatToolExecutor(
             ref: hit.source.ref,
             ...(hit.source.url ? { url: hit.source.url } : {}),
             snippet: clip(hit.text, SNIPPET_CHARS),
+            ...(hit.offset !== undefined ? { offset: hit.offset } : {}),
           });
         }
         sources.documents = knowledge.hits.some((h) => h.corpus === 'documents')
@@ -409,12 +413,18 @@ export function createChatToolExecutor(
       typeof args.offset === 'number' && args.offset > 0
         ? Math.floor(args.offset)
         : 0;
+    // An explicit range: `limit` caps the returned window below the default,
+    // so the model can read exactly the region a search hit points at.
+    const limit =
+      typeof args.limit === 'number' && args.limit > 0
+        ? Math.min(Math.floor(args.limit), FETCH_WINDOW_CHARS)
+        : FETCH_WINDOW_CHARS;
 
     const window = (
       text: string,
     ): { content: string; totalChars: number; nextOffset?: number } => {
-      const slice = text.slice(offset, offset + FETCH_WINDOW_CHARS);
-      const nextOffset = offset + FETCH_WINDOW_CHARS;
+      const slice = text.slice(offset, offset + limit);
+      const nextOffset = offset + limit;
       return {
         content: slice,
         totalChars: text.length,

--- a/services/platform/convex/knowledge/corpus.test.ts
+++ b/services/platform/convex/knowledge/corpus.test.ts
@@ -237,6 +237,7 @@ describe('rows become hits', () => {
         title: 'Handbook',
         url: null,
         modified_at: new Date('2026-01-02T03:04:05Z'),
+        hit_offset: null,
         score: 0.87,
       },
     ]);
@@ -257,5 +258,28 @@ describe('rows become hits', () => {
       },
       score: 0.87,
     });
+  });
+
+  it('maps the hit offset through when the corpus can establish it', async () => {
+    // SUM(length(...)) reaches JS as text; a NULL position stays absent so
+    // the model falls back to reading from the start.
+    const { sql } = recorder([
+      {
+        id: '7',
+        chunk_content: 'Art. 10 Steuerpflicht…',
+        chunk_index: 5,
+        ref: 'https://a.ch/law',
+        title: 'Law',
+        url: 'https://a.ch/law',
+        modified_at: null,
+        hit_offset: '12480',
+        score: 0.9,
+      },
+    ]);
+    const hits = await new DocumentCorpusReader(sql, 'acme').dense({
+      ...LEG,
+      embedding: EMBEDDING,
+    });
+    expect(hits[0]?.offset).toBe(12480);
   });
 });

--- a/services/platform/convex/knowledge/corpus.ts
+++ b/services/platform/convex/knowledge/corpus.ts
@@ -63,6 +63,9 @@ interface CorpusRow {
   title: string | null;
   url: string | null;
   modified_at: Date | null;
+  /** Char position of the chunk within the ref's fetchable text, cast to
+   * text (SUM is bigint); NULL when it cannot be established. */
+  hit_offset: string | null;
   score: number;
 }
 
@@ -91,6 +94,10 @@ export class DocumentCorpusReader implements CorpusReader {
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
+             (SELECT COALESCE(SUM(length(c2.core_content)), 0)
+                FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
+               WHERE c2.org_slug = c.org_slug AND c2.document_id = c.document_id
+                 AND c2.chunk_index < c.chunk_index)::text AS hit_offset,
              paradedb.score(c.id) AS score
       FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c
       JOIN ${PRIVATE_KNOWLEDGE_SCHEMA}.documents d
@@ -117,6 +124,10 @@ export class DocumentCorpusReader implements CorpusReader {
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
+             (SELECT COALESCE(SUM(length(c2.core_content)), 0)
+                FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
+               WHERE c2.org_slug = c.org_slug AND c2.document_id = c.document_id
+                 AND c2.chunk_index < c.chunk_index)::text AS hit_offset,
              1 - (c.embedding <=> $1::vector) AS score
       FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c
       JOIN ${PRIVATE_KNOWLEDGE_SCHEMA}.documents d
@@ -208,6 +219,10 @@ export class WebCorpusReader implements CorpusReader {
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
              u.last_crawled_at AS modified_at,
+             CASE WHEN c.core_content <> ''
+                   AND position(c.core_content IN u.content) > 0
+                  THEN (position(c.core_content IN u.content) - 1)::text
+                  ELSE NULL END AS hit_offset,
              paradedb.score(c.id) AS score
       FROM ${PUBLIC_WEB_SCHEMA}.chunks c
       JOIN ${PUBLIC_WEB_SCHEMA}.website_org_memberships m
@@ -232,6 +247,10 @@ export class WebCorpusReader implements CorpusReader {
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
              u.last_crawled_at AS modified_at,
+             CASE WHEN c.core_content <> ''
+                   AND position(c.core_content IN u.content) > 0
+                  THEN (position(c.core_content IN u.content) - 1)::text
+                  ELSE NULL END AS hit_offset,
              1 - (c.embedding <=> $1::vector) AS score
       FROM ${PUBLIC_WEB_SCHEMA}.chunks c
       JOIN ${PUBLIC_WEB_SCHEMA}.website_org_memberships m
@@ -324,6 +343,9 @@ function toHits(
       // read on its own still says which document and section it came from.
       text: row.chunk_content,
       chunkIndex: row.chunk_index,
+      ...(row.hit_offset !== null && row.hit_offset !== undefined
+        ? { offset: Number(row.hit_offset) }
+        : {}),
       source: {
         ref: row.ref,
         title: row.title,

--- a/services/platform/convex/knowledge/crawl.ts
+++ b/services/platform/convex/knowledge/crawl.ts
@@ -138,11 +138,13 @@ export async function fetchWebsiteInfoFromCorpus(
       description: string | null;
       status: string;
       last_scanned_at: Date | null;
+      error: string | null;
       page_count: string;
       crawled_count: string;
     }>
   >(
     `SELECT w.domain, w.title, w.description, w.status, w.last_scanned_at,
+            w.error,
             (SELECT count(*) FROM ${PUBLIC_WEB_SCHEMA}.website_urls u
               WHERE u.domain = w.domain AND u.status <> 'deleted')::text AS page_count,
             (SELECT count(*) FROM ${PUBLIC_WEB_SCHEMA}.website_urls u
@@ -166,6 +168,7 @@ export async function fetchWebsiteInfoFromCorpus(
     last_scanned_at: row.last_scanned_at
       ? row.last_scanned_at.toISOString()
       : null,
+    error: row.error,
   };
 }
 

--- a/services/platform/convex/knowledge/crawl.ts
+++ b/services/platform/convex/knowledge/crawl.ts
@@ -25,6 +25,10 @@ import type {
   CrawlerWebsiteInfo,
 } from '../websites/types';
 
+/** How many URLs one scan tracks per domain: discovery stops admitting here,
+ * and a longer operator list is truncated (logged, never silent). */
+export const MAX_URLS_PER_DOMAIN = 200;
+
 /** Corpus → Convex status vocabulary. The corpus distinguishes `completed`
  * (a finished scan) from `active`; the websites row treats both as a healthy
  * scanned site. */
@@ -54,9 +58,48 @@ export async function registerDomain(
   domain: string,
   scanIntervalSeconds: number,
 ): Promise<void> {
+  // `kind = 'site'` on conflict too: kind only ever WIDENS — a domain some
+  // org tracked as a URL list becomes a crawled site the moment any org
+  // registers the site proper (its listed URLs stay as extra seeds).
   await sql.unsafe(
-    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval)
+    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval, kind)
+     VALUES ($1, $2, 'site')
+     ON CONFLICT (domain)
+     DO UPDATE SET scan_interval = EXCLUDED.scan_interval, kind = 'site',
+                   updated_at = NOW()`,
+    [domain, scanIntervalSeconds],
+  );
+  await sql.unsafe(
+    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships (domain, org_slug)
      VALUES ($1, $2)
+     ON CONFLICT (domain, org_slug) DO NOTHING`,
+    [domain, orgSlug],
+  );
+}
+
+/**
+ * Register a curated URL list for an organization. The listed rows in
+ * `website_urls` ARE the list — there is no separate list table. Idempotent
+ * and merging: re-registering adds new URLs and re-marks existing ones as
+ * listed. On a domain some org already crawls as a site, the row's kind
+ * stays 'site' ('list' never narrows) and the URLs become extra seeds.
+ */
+export async function registerUrlList(
+  sql: Sql,
+  orgSlug: string,
+  domain: string,
+  urls: readonly string[],
+  scanIntervalSeconds: number,
+): Promise<void> {
+  const admitted = urls.slice(0, MAX_URLS_PER_DOMAIN);
+  if (admitted.length < urls.length) {
+    console.warn(
+      `[crawl] ${domain}: URL list truncated to the ${MAX_URLS_PER_DOMAIN}-URL cap (${urls.length} given)`,
+    );
+  }
+  await sql.unsafe(
+    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval, kind)
+     VALUES ($1, $2, 'list')
      ON CONFLICT (domain)
      DO UPDATE SET scan_interval = EXCLUDED.scan_interval, updated_at = NOW()`,
     [domain, scanIntervalSeconds],
@@ -67,6 +110,14 @@ export async function registerDomain(
      ON CONFLICT (domain, org_slug) DO NOTHING`,
     [domain, orgSlug],
   );
+  for (const url of admitted) {
+    await sql.unsafe(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_urls (domain, url, status, discovered_at, listed)
+       VALUES ($1, $2, 'discovered', NOW(), TRUE)
+       ON CONFLICT (domain, url) DO UPDATE SET listed = TRUE`,
+      [domain, url],
+    );
+  }
 }
 
 /** Update the scan cadence on the domain row. */
@@ -134,6 +185,7 @@ export async function fetchWebsiteInfoFromCorpus(
   const rows = await sql.unsafe<
     Array<{
       domain: string;
+      kind: string;
       title: string | null;
       description: string | null;
       status: string;
@@ -143,7 +195,7 @@ export async function fetchWebsiteInfoFromCorpus(
       crawled_count: string;
     }>
   >(
-    `SELECT w.domain, w.title, w.description, w.status, w.last_scanned_at,
+    `SELECT w.domain, w.kind, w.title, w.description, w.status, w.last_scanned_at,
             w.error,
             (SELECT count(*) FROM ${PUBLIC_WEB_SCHEMA}.website_urls u
               WHERE u.domain = w.domain AND u.status <> 'deleted')::text AS page_count,
@@ -160,6 +212,7 @@ export async function fetchWebsiteInfoFromCorpus(
   if (!row) return null;
   return {
     domain: row.domain,
+    kind: row.kind === 'list' ? 'list' : 'site',
     title: row.title,
     description: row.description,
     page_count: Number(row.page_count),

--- a/services/platform/convex/knowledge/crawl_action.ts
+++ b/services/platform/convex/knowledge/crawl_action.ts
@@ -1,10 +1,19 @@
 'use node';
 
 /**
- * The website crawl engine: discover a domain's pages, fetch them politely,
- * strip cross-page boilerplate, and index the text into the `public_web`
- * corpus — chunks (embedded with the organization's model when one is
- * configured) plus the full page text `rag_fetch` serves back.
+ * The website crawl engine: discover a domain's pages (or take an operator's
+ * URL list verbatim), fetch them politely, strip cross-page boilerplate, and
+ * index the text into the `public_web` corpus — chunks (embedded with the
+ * organization's model when one is configured) plus the full page text
+ * `rag_fetch` serves back.
+ *
+ * Every fetch dispatches on the response content type, never a heuristic:
+ * documents (pdf/docx/xlsx/pptx/odt) and plain text are extracted
+ * in-process; HTML is rendered in batches by a sandboxed browser
+ * (`renderUrlsInSandbox`) so JS-rendered sites yield their real content.
+ * The in-process probe stays the authority on page lifecycle — status
+ * codes, deletes, size caps, SSRF guards — and content-hash comparison is
+ * the only change detection.
  *
  * A scan is a CONTINUATION CHAIN, not one long action: a Convex node action
  * is hard-killed near ten minutes without running its catch, so each link
@@ -25,6 +34,8 @@ import type { Sql } from 'postgres';
 
 import { chunkDocument } from '../../lib/knowledge/chunking';
 import {
+  classifyContentType,
+  documentNameForUrl,
   extractLinks,
   isDisallowed,
   isSitemapIndex,
@@ -41,8 +52,15 @@ import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
-import { safeFetch, SafeFetchError } from '../lib/http/safe_fetch';
+import {
+  safeFetch,
+  safeFetchBinary,
+  SafeFetchError,
+} from '../lib/http/safe_fetch';
+import { extractText } from '../lib/knowledge/extraction/router';
+import { renderUrlsInSandbox } from '../node_only/sandbox/render_fetch';
 import { readOrgEmbeddingConfig } from './connection';
+import { MAX_URLS_PER_DOMAIN } from './crawl';
 import { pinDimensions } from './dimensions';
 import { Embedder, embedderForOrg, EmbeddingNotConfigured } from './embedding';
 import { getKnowledgePoolForOrg, resolveOrgUrl } from './pool';
@@ -65,9 +83,22 @@ const PAGE_MAX_BYTES = 2 * 1024 * 1024;
 const SITEMAP_MAX_BYTES = 8 * 1024 * 1024;
 const ROBOTS_MAX_BYTES = 256 * 1024;
 
-/** How many URLs one scan will track per domain. Sites larger than this are
- * crawled up to the cap and the truncation is logged, not silent. */
-const MAX_URLS_PER_DOMAIN = 200;
+/** Content fetch budgets. Documents run far fatter and slower than HTML
+ * pages (a consolidated legal handbook PDF is megabytes), so the page fetch
+ * gets its own timeout and cap. */
+const PAGE_FETCH_TIMEOUT_MS = 30_000;
+const DOCUMENT_MAX_BYTES = 25 * 1024 * 1024;
+
+/** Render lane budgets. HTML pages are rendered in a sandboxed browser in
+ * batches; the node action's hard kill sits near ten minutes, so a link
+ * stops opening render sessions once its remaining window could no longer
+ * fit a session create + exec + harvest. */
+const ACTION_HARD_WALL_MS = 540_000;
+const RENDER_BATCH_SIZE = 10;
+const RENDER_MIN_WINDOW_MS = 120_000;
+const RENDER_EXEC_MAX_MS = 240_000;
+const RENDER_HARVEST_MARGIN_MS = 30_000;
+
 /** Sitemap fetches per discovery (indexes recurse one level). */
 const MAX_SITEMAP_FETCHES = 10;
 /** When sitemaps yield fewer URLs than this, fall back to link-walking. */
@@ -125,27 +156,107 @@ export const scanWebsite = internalAction({
     const sql = await getKnowledgePoolForOrg(args.orgSlug);
 
     try {
+      const kind = await domainKind(sql, args.domain);
       if (continuation === 0) {
         const claimed = await claimScan(sql, args.domain);
         if (!claimed) {
           console.log(`[crawl] ${args.domain}: scan already running, skipping`);
           return null;
         }
-        await discoverAndRecordUrls(sql, args.domain);
+        // A URL list has no discovery: its operator-listed rows ARE the
+        // frontier, and robots.txt does not govern explicitly requested
+        // pages (the same stance web_fetch takes).
+        if (kind === 'site') {
+          await discoverAndRecordUrls(sql, args.domain);
+        }
       }
 
-      // Fetch AND index page by page, all inside the budget window. A page is
-      // indexed the moment it changes — so a killed action loses at most one
-      // page's work, and the next link re-indexes it (unchanged text with no
-      // chunks counts as changed).
-      const deadline = Date.now() + SCAN_BUDGET_MS;
+      // Fetch AND index page by page inside the budget window; HTML pages
+      // queue for a sandboxed render batch and settle when it flushes. A
+      // page is indexed the moment it changes — a killed action loses at
+      // most one batch's work, and rows a flush never settled stay due for
+      // the next link (unchanged text with no chunks counts as changed).
+      const linkStartedAt = Date.now();
+      const deadline = linkStartedAt + SCAN_BUDGET_MS;
+      const hardWall = linkStartedAt + ACTION_HARD_WALL_MS;
       const indexer = new PageIndexer(ctx, sql, identity);
+      const renderQueue: DuePage[] = [];
+      let renderBatchCounter = 0;
+
+      const flushRenderBatch = async (): Promise<void> => {
+        if (renderQueue.length === 0) return;
+        const window = hardWall - Date.now();
+        if (window < RENDER_MIN_WINDOW_MS) {
+          // Too close to the action's kill point to open a session — drop
+          // the queue UNMARKED so the next continuation link retries it.
+          renderQueue.length = 0;
+          return;
+        }
+        const batch = renderQueue.splice(0);
+        renderBatchCounter += 1;
+        // Infra failures (quota, session create, transport) THROW into the
+        // scan's error path: rows stay untouched, the status is visible,
+        // and the next interval retries. Only per-URL render outcomes are
+        // charged to the page's fail_count.
+        const results = await renderUrlsInSandbox(ctx, {
+          organizationId: args.organizationId,
+          urls: batch.map((page) => page.url),
+          batchKey: `${args.domain}:${scanStartedAt}:${continuation}:${renderBatchCounter}`,
+          execTimeoutMs: Math.min(
+            RENDER_EXEC_MAX_MS,
+            window - RENDER_HARVEST_MARGIN_MS,
+          ),
+        });
+        for (const page of batch) {
+          const outcome = results.get(page.url) ?? {
+            kind: 'not_attempted' as const,
+          };
+          if (outcome.kind === 'not_attempted') continue;
+          if (outcome.kind === 'failed') {
+            console.warn(
+              `[crawl] ${page.url}: render failed: ${outcome.reason}`,
+            );
+            await recordPageFailure(sql, args.domain, page.url);
+            continue;
+          }
+          const stored = await storePageText(
+            sql,
+            args.domain,
+            page,
+            htmlTitle(outcome.html),
+            htmlToText(outcome.html),
+          );
+          if (stored === 'changed') await indexer.indexPage(page.url);
+          if (kind === 'site') {
+            await admitRenderedLinks(
+              sql,
+              args.domain,
+              outcome.html,
+              outcome.finalUrl,
+            );
+          }
+        }
+      };
+
       while (Date.now() < deadline) {
-        const page = await nextDuePage(sql, args.domain, scanStartedAt);
-        if (!page) break;
-        const outcome = await fetchAndStorePage(sql, args.domain, page);
-        if (outcome === 'changed') await indexer.indexPage(page.url);
-        await sleep(FETCH_DELAY_MS);
+        const pages = await nextDuePages(
+          sql,
+          args.domain,
+          scanStartedAt,
+          RENDER_BATCH_SIZE,
+        );
+        if (pages.length === 0) break;
+        for (const page of pages) {
+          if (Date.now() >= deadline) break;
+          const outcome = await fetchAndStorePage(sql, args.domain, page);
+          if (outcome === 'render') renderQueue.push(page);
+          else if (outcome === 'changed') await indexer.indexPage(page.url);
+          await sleep(FETCH_DELAY_MS);
+          if (renderQueue.length >= RENDER_BATCH_SIZE) await flushRenderBatch();
+        }
+        // Settle the partial batch BEFORE re-querying the frontier — the
+        // queued rows are unmarked and would come straight back.
+        await flushRenderBatch();
       }
       await indexer.finish();
 
@@ -258,6 +369,17 @@ export const scanDueWebsites = internalAction({
     return null;
   },
 });
+
+/** What this domain row is: a crawled site (pages discovered) or a curated
+ * URL list (exactly the listed rows are fetched). Rows that predate the
+ * distinction read as 'site'. */
+async function domainKind(sql: Sql, domain: string): Promise<'site' | 'list'> {
+  const rows = await sql.unsafe<{ kind: string }[]>(
+    `SELECT kind FROM ${PUBLIC_WEB_SCHEMA}.websites WHERE domain = $1`,
+    [domain],
+  );
+  return rows[0]?.kind === 'list' ? 'list' : 'site';
+}
 
 /** Take the corpus-side claim on a domain, or report that another scan holds
  * it. A claim older than {@link STUCK_SCAN_TAKEOVER} belongs to a crashed
@@ -409,8 +531,6 @@ async function discoverAndRecordUrls(sql: Sql, domain: string): Promise<void> {
 
 interface DuePage {
   readonly url: string;
-  readonly etag: string | null;
-  readonly last_modified: string | null;
   readonly content_hash: string | null;
 }
 
@@ -418,21 +538,23 @@ const DUE_PAGE_PREDICATE = `
       domain = $1 AND status <> 'deleted' AND fail_count < ${MAX_FETCH_FAILURES}
       AND (last_crawled_at IS NULL OR last_crawled_at < $2::timestamptz)`;
 
-/** The next URL this scan has not visited yet (never-crawled first). */
-async function nextDuePage(
+/** The next URLs this scan has not visited yet (never-crawled first). The
+ * batch size matches the render batch, so one claim's HTML pages fill at
+ * most one render session. */
+async function nextDuePages(
   sql: Sql,
   domain: string,
   scanStartedAt: string,
-): Promise<DuePage | null> {
-  const rows = await sql.unsafe<DuePage[]>(
-    `SELECT url, etag, last_modified, content_hash
+  limit: number,
+): Promise<DuePage[]> {
+  return await sql.unsafe<DuePage[]>(
+    `SELECT url, content_hash
        FROM ${PUBLIC_WEB_SCHEMA}.website_urls
       WHERE ${DUE_PAGE_PREDICATE}
       ORDER BY last_crawled_at ASC NULLS FIRST, url ASC
-      LIMIT 1`,
-    [domain, scanStartedAt],
+      LIMIT $3`,
+    [domain, scanStartedAt, limit],
   );
-  return rows[0] ?? null;
 }
 
 async function countDuePages(
@@ -448,12 +570,17 @@ async function countDuePages(
   return Number(rows[0]?.n ?? 0);
 }
 
-type FetchOutcome = 'changed' | 'unchanged' | 'failed';
+type FetchOutcome = 'changed' | 'unchanged' | 'failed' | 'render';
 
 /**
- * Fetch one page (conditionally when the last crawl stored a validator) and
- * store its text, title, and paragraph hashes. Reports whether the content
- * changed — only changed pages are re-chunked and re-embedded.
+ * Probe one page and dispatch on its content type: binaries and plain text
+ * are extracted and stored in-process; HTML reports `render` (body
+ * discarded, row left unmarked) so the caller batches it through the
+ * sandboxed browser. The probe is the sole authority on page LIFECYCLE —
+ * status codes, deletes, size caps, and the SSRF guard for every byte
+ * download. Change detection is the stored content hash alone: a 304 on an
+ * SPA shell proves nothing about rendered content, so no conditional
+ * validators are sent.
  */
 async function fetchAndStorePage(
   sql: Sql,
@@ -461,16 +588,12 @@ async function fetchAndStorePage(
   page: DuePage,
 ): Promise<FetchOutcome> {
   const hosts = siteHosts(domain);
-  const conditional: Record<string, string> = { accept: 'text/html' };
-  if (page.etag) conditional['if-none-match'] = page.etag;
-  if (page.last_modified) conditional['if-modified-since'] = page.last_modified;
 
   let response;
   try {
-    response = await safeFetch(page.url, {
-      headers: conditional,
-      timeoutMs: PAGE_TIMEOUT_MS,
-      maxResponseBytes: PAGE_MAX_BYTES,
+    response = await safeFetchBinary(page.url, {
+      timeoutMs: PAGE_FETCH_TIMEOUT_MS,
+      maxResponseBytes: DOCUMENT_MAX_BYTES,
       allowedHosts: [...hosts],
     });
   } catch (error) {
@@ -483,15 +606,6 @@ async function fetchAndStorePage(
     return 'failed';
   }
 
-  if (response.status === 304) {
-    await sql.unsafe(
-      `UPDATE ${PUBLIC_WEB_SCHEMA}.website_urls
-          SET last_crawled_at = NOW(), fail_count = 0
-        WHERE domain = $1 AND url = $2`,
-      [domain, page.url],
-    );
-    return 'unchanged';
-  }
   if (response.status === 404 || response.status === 410) {
     // The page is gone — drop it from the index. Discovery being partial
     // (BFS depth, the URL cap) means absence from a scan proves nothing,
@@ -520,43 +634,74 @@ async function fetchAndStorePage(
     return 'failed';
   }
   const contentType = response.headers.get('content-type') ?? '';
-  if (contentType !== '' && !/text\/html|text\/plain|xhtml/.test(contentType)) {
-    // Not a text page (an image, a feed, a download) — remember we looked so
-    // the scan moves on, but store nothing.
-    await sql.unsafe(
-      `UPDATE ${PUBLIC_WEB_SCHEMA}.website_urls
-          SET last_crawled_at = NOW(), fail_count = 0
-        WHERE domain = $1 AND url = $2`,
-      [domain, page.url],
-    );
+  const dispatch = classifyContentType(contentType);
+  if (dispatch.kind === 'skip') {
+    // Not something this lane can turn into text (an image, a feed, a
+    // binary download) — remember we looked so the scan moves on, but
+    // store nothing.
+    await markPageVisited(sql, domain, page.url);
     return 'unchanged';
   }
+  if (dispatch.kind === 'html') {
+    // Content comes from the rendered DOM, not this probe body — the page
+    // joins the render batch and its row stays unmarked until the batch
+    // settles it.
+    return 'render';
+  }
+  const bytes = new Uint8Array(await response.body.arrayBuffer());
 
-  const title = htmlTitle(response.body);
-  const text = htmlToText(response.body);
+  let title: string | null;
+  let text: string;
+  if (dispatch.kind === 'text') {
+    title = null;
+    text = new TextDecoder().decode(bytes);
+  } else {
+    const name = documentNameForUrl(page.url, dispatch.extension);
+    try {
+      // The crawl lane carries no vision arm; extractors degrade on their
+      // own (scanned PDF pages come back empty instead of failing).
+      const [extracted] = await extractText(bytes, name, {
+        visionClient: null,
+        processImages: false,
+      });
+      text = extracted;
+    } catch (error) {
+      console.warn(
+        `[crawl] ${page.url}: extraction failed for ${name}:`,
+        error instanceof Error ? error.message : error,
+      );
+      await markPageVisited(sql, domain, page.url);
+      return 'unchanged';
+    }
+    title = name;
+  }
+  return await storePageText(sql, domain, page, title, text);
+}
+
+/**
+ * Store one page's extracted text, title, and paragraph hashes; report
+ * whether the content changed. Only changed pages are re-chunked and
+ * re-embedded — and a page whose text is unchanged but whose chunks are
+ * missing (an earlier scan died between fetch and index) counts as changed.
+ */
+async function storePageText(
+  sql: Sql,
+  domain: string,
+  page: DuePage,
+  title: string | null,
+  text: string,
+): Promise<'changed' | 'unchanged'> {
   const contentHash = computeContentHash(text);
   const wordCount = text.split(/\s+/).filter((word) => word.length > 0).length;
-  const etag = response.headers.get('etag');
-  const lastModified = response.headers.get('last-modified');
 
   const unchanged = page.content_hash === contentHash;
   await sql.begin(async (tx) => {
     await tx.unsafe(
       `UPDATE ${PUBLIC_WEB_SCHEMA}.website_urls
           SET content = $3, title = $4, content_hash = $5, word_count = $6,
-              status = 'active', last_crawled_at = NOW(), fail_count = 0,
-              etag = $7, last_modified = $8
+              status = 'active', last_crawled_at = NOW(), fail_count = 0
         WHERE domain = $1 AND url = $2`,
-      [
-        domain,
-        page.url,
-        text,
-        title,
-        contentHash,
-        wordCount,
-        etag,
-        lastModified,
-      ],
+      [domain, page.url, text, title, contentHash, wordCount],
     );
     await tx.unsafe(
       `DELETE FROM ${PUBLIC_WEB_SCHEMA}.page_paragraph_hashes
@@ -579,8 +724,6 @@ async function fetchAndStorePage(
   });
 
   if (unchanged) {
-    // Same text as last scan — but if its chunks are missing (an earlier
-    // scan died between fetching and indexing), index it anyway.
     const chunkRows = await sql.unsafe<{ ok: number }[]>(
       `SELECT 1 AS ok FROM ${PUBLIC_WEB_SCHEMA}.chunks
         WHERE domain = $1 AND url = $2 LIMIT 1`,
@@ -589,6 +732,61 @@ async function fetchAndStorePage(
     return chunkRows.length > 0 ? 'unchanged' : 'changed';
   }
   return 'changed';
+}
+
+/**
+ * Admit same-site links found in a rendered page (site kind only) so SPA
+ * sites — whose anchors exist only after JS runs — still grow the frontier.
+ * Honours the host and asset-suffix rules and the per-domain cap; robots
+ * disallow rules apply at discovery time only (accepted residue until a
+ * robots-sensitive JS site matters). Freshly admitted rows have no
+ * `last_crawled_at`, so the running scan picks them up.
+ */
+async function admitRenderedLinks(
+  sql: Sql,
+  domain: string,
+  html: string,
+  baseUrl: string,
+): Promise<void> {
+  const hosts = siteHosts(domain);
+  const countRows = await sql.unsafe<{ n: string }[]>(
+    `SELECT count(*)::text AS n FROM ${PUBLIC_WEB_SCHEMA}.website_urls
+      WHERE domain = $1 AND status <> 'deleted'`,
+    [domain],
+  );
+  let tracked = Number(countRows[0]?.n ?? 0);
+  for (const href of extractLinks(html)) {
+    if (tracked >= MAX_URLS_PER_DOMAIN) {
+      console.warn(
+        `[crawl] ${domain}: URL cap of ${MAX_URLS_PER_DOMAIN} reached during rendered-link admission`,
+      );
+      return;
+    }
+    const normalized = normalizeCandidateUrl(href, baseUrl, hosts);
+    if (!normalized) continue;
+    const inserted = await sql.unsafe<{ url: string }[]>(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_urls (domain, url, status, discovered_at)
+       VALUES ($1, $2, 'discovered', NOW())
+       ON CONFLICT (domain, url) DO NOTHING
+       RETURNING url`,
+      [domain, normalized],
+    );
+    if (inserted.length > 0) tracked += 1;
+  }
+}
+
+/** Remember that the scan looked at a URL without storing content for it. */
+async function markPageVisited(
+  sql: Sql,
+  domain: string,
+  url: string,
+): Promise<void> {
+  await sql.unsafe(
+    `UPDATE ${PUBLIC_WEB_SCHEMA}.website_urls
+        SET last_crawled_at = NOW(), fail_count = 0
+      WHERE domain = $1 AND url = $2`,
+    [domain, url],
+  );
 }
 
 async function recordPageFailure(

--- a/services/platform/convex/knowledge/crawl_ops.ts
+++ b/services/platform/convex/knowledge/crawl_ops.ts
@@ -29,6 +29,7 @@ import {
   listPageChunks,
   listWebsitePages,
   registerDomain,
+  registerUrlList,
   searchDomainContent,
   setScanInterval,
 } from './crawl';
@@ -50,6 +51,27 @@ export const registerDomainOp = internalAction({
       sql,
       args.orgSlug,
       args.domain,
+      args.scanIntervalSeconds,
+    );
+    return null;
+  },
+});
+
+export const registerUrlListOp = internalAction({
+  args: {
+    orgSlug: v.string(),
+    domain: v.string(),
+    urls: v.array(v.string()),
+    scanIntervalSeconds: v.number(),
+  },
+  returns: v.null(),
+  handler: async (_ctx, args): Promise<null> => {
+    const sql = await getKnowledgePoolForOrg(args.orgSlug);
+    await registerUrlList(
+      sql,
+      args.orgSlug,
+      args.domain,
+      args.urls,
       args.scanIntervalSeconds,
     );
     return null;

--- a/services/platform/convex/knowledge/ddl.test.ts
+++ b/services/platform/convex/knowledge/ddl.test.ts
@@ -105,6 +105,22 @@ describe('the real migrations are what gets applied', () => {
     }
   });
 
+  it('carries the url-list source columns outside the public_web baseline', () => {
+    // Same regression class as the chunk-context convergence: these columns
+    // postdate the applied baseline, so they must arrive in their own
+    // migration or an already-migrated database never receives them.
+    delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
+    const later = corpusMigrations()
+      .filter((m) => m.schema === 'public_web')
+      .slice(1);
+    expect(
+      later.some((m) => m.sql.includes('ADD COLUMN IF NOT EXISTS kind')),
+    ).toBe(true);
+    expect(
+      later.some((m) => m.sql.includes('ADD COLUMN IF NOT EXISTS listed')),
+    ).toBe(true);
+  });
+
   it('never applies a down migration', () => {
     // Applying whatever follows the down marker to a populated corpus would be
     // a loaded gun; the bootstrap only ever runs the up half.

--- a/services/platform/convex/knowledge/ddl.test.ts
+++ b/services/platform/convex/knowledge/ddl.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   applyCorpusSchema,
-  corpusSchemaSql,
+  corpusMigrations,
   findMigrationsDir,
   upSection,
 } from './ddl';
@@ -37,14 +37,31 @@ describe('the real migrations are what gets applied', () => {
     expect(findMigrationsDir()).not.toBeNull();
   });
 
-  it('reads one statement block per corpus', () => {
+  it('reads the baseline and the converging migration of each corpus', () => {
     delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
-    expect(corpusSchemaSql().length).toBeGreaterThanOrEqual(2);
+    const migrations = corpusMigrations();
+    for (const schema of ['private_knowledge', 'public_web']) {
+      expect(
+        migrations.filter((m) => m.schema === schema).length,
+      ).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('keys every file on the numeric version dbmate ledgers use', () => {
+    delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
+    const versions = corpusMigrations().map((m) => m.version);
+    for (const version of versions) {
+      expect(version).toMatch(/^\d+$/);
+    }
+    // Ledger identity: within a schema a version can be recorded only once.
+    expect(new Set(versions).size).toBe(versions.length);
   });
 
   it('declares both corpora and their chunk tables', () => {
     delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
-    const all = corpusSchemaSql().join('\n');
+    const all = corpusMigrations()
+      .map((m) => m.sql)
+      .join('\n');
     expect(all).toContain('CREATE SCHEMA IF NOT EXISTS private_knowledge');
     expect(all).toContain('CREATE SCHEMA IF NOT EXISTS public_web');
     expect(all).toContain('private_knowledge.chunks');
@@ -55,7 +72,9 @@ describe('the real migrations are what gets applied', () => {
     // If a migration ever loses one of these, retrieval breaks in a way that
     // looks like bad search results rather than like a missing column.
     delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
-    const all = corpusSchemaSql().join('\n');
+    const all = corpusMigrations()
+      .map((m) => m.sql)
+      .join('\n');
     for (const column of [
       'context_header',
       'core_content',
@@ -68,13 +87,31 @@ describe('the real migrations are what gets applied', () => {
     }
   });
 
+  it('converges the chunk context columns outside the baseline too', () => {
+    // The regression this guards: `context_header` was added to the
+    // already-applied baseline, which a ledgered database never re-runs, so
+    // every chunk INSERT failed with "column does not exist". Each corpus must
+    // carry the convergence in a migration that is NOT its first (baseline)
+    // version.
+    delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
+    const migrations = corpusMigrations();
+    for (const schema of ['private_knowledge', 'public_web']) {
+      const later = migrations.filter((m) => m.schema === schema).slice(1);
+      expect(
+        later.some((m) =>
+          m.sql.includes('ADD COLUMN IF NOT EXISTS context_header'),
+        ),
+      ).toBe(true);
+    }
+  });
+
   it('never applies a down migration', () => {
     // Applying whatever follows the down marker to a populated corpus would be
     // a loaded gun; the bootstrap only ever runs the up half.
     delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
-    for (const statement of corpusSchemaSql()) {
-      expect(statement).not.toContain('migrate:down');
-      expect(statement).not.toMatch(/DROP SCHEMA(?!\s+.*--)/i);
+    for (const migration of corpusMigrations()) {
+      expect(migration.sql).not.toContain('migrate:down');
+      expect(migration.sql).not.toMatch(/DROP SCHEMA(?!\s+.*--)/i);
     }
   });
 
@@ -92,11 +129,37 @@ describe('the real migrations are what gets applied', () => {
       }
       process.env.KNOWLEDGE_MIGRATIONS_DIR = dir;
       expect(findMigrationsDir()).toBe(dir);
-      const statements = corpusSchemaSql();
-      expect(statements).toEqual([
-        'CREATE SCHEMA IF NOT EXISTS private_knowledge;',
-        'CREATE SCHEMA IF NOT EXISTS public_web;',
+      expect(corpusMigrations()).toEqual([
+        {
+          schema: 'private_knowledge',
+          version: '001',
+          name: '001_test.sql',
+          sql: 'CREATE SCHEMA IF NOT EXISTS private_knowledge;',
+        },
+        {
+          schema: 'public_web',
+          version: '001',
+          name: '001_test.sql',
+          sql: 'CREATE SCHEMA IF NOT EXISTS public_web;',
+        },
       ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a file it cannot ledger rather than guessing', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'knowledge-ddl-'));
+    try {
+      for (const schema of ['private_knowledge', 'public_web']) {
+        mkdirSync(path.join(dir, schema), { recursive: true });
+        writeFileSync(
+          path.join(dir, schema, 'unversioned.sql'),
+          '-- migrate:up\nSELECT 1;\n',
+        );
+      }
+      process.env.KNOWLEDGE_MIGRATIONS_DIR = dir;
+      expect(() => corpusMigrations()).toThrow(/numeric version/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -123,22 +186,105 @@ describe('reading one migration file', () => {
   });
 });
 
-describe('applyCorpusSchema — operator-prepared databases', () => {
-  it('skips preparation when both corpora already carry their tables', async () => {
-    const executed: string[] = [];
+describe('applyCorpusSchema — version-aware application', () => {
+  /** A Sql facade that answers the ledger reads from `recorded` and records
+   * everything executed. */
+  function fakeSql(recorded: Record<string, string[]>) {
+    const executed: { statement: string; params?: unknown[] }[] = [];
     const sql = {
-      unsafe: async (statement: string) => {
-        executed.push(statement);
+      unsafe: async (statement: string, params?: unknown[]) => {
+        executed.push({ statement, params });
+        for (const [schema, versions] of Object.entries(recorded)) {
+          if (
+            statement.includes(
+              `SELECT version FROM ${schema}.schema_migrations`,
+            )
+          ) {
+            return versions.map((version) => ({ version }));
+          }
+        }
         if (statement.includes('information_schema.tables')) {
           return [{ n: '3' }];
         }
-        throw new Error('nothing else should run');
+        return [];
       },
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal Sql facade for the probe path
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal Sql facade for the ledger protocol
     } as unknown as Parameters<typeof applyCorpusSchema>[0];
+    return { sql, executed };
+  }
+
+  function versionsBySchema() {
+    delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
+    const migrations = corpusMigrations();
+    const of = (schema: string) =>
+      migrations.filter((m) => m.schema === schema).map((m) => m.version);
+    return {
+      privateVersions: of('private_knowledge'),
+      publicVersions: of('public_web'),
+    };
+  }
+
+  function insertedVersions(
+    executed: { statement: string; params?: unknown[] }[],
+  ) {
+    return executed
+      .filter(({ statement }) => statement.includes('INSERT INTO'))
+      .map(({ params }) => params?.[0]);
+  }
+
+  it('applies and records only what a ledgered database is missing', async () => {
+    // The bundled database's ledgers know the baselines; everything after them
+    // — the converging migrations a later release added — must be applied.
+    const { privateVersions, publicVersions } = versionsBySchema();
+    const { sql, executed } = fakeSql({
+      private_knowledge: privateVersions.slice(0, 1),
+      public_web: publicVersions.slice(0, 1),
+    });
 
     await applyCorpusSchema(sql);
 
-    expect(executed).toHaveLength(1);
+    const expected = [...privateVersions.slice(1), ...publicVersions.slice(1)];
+    expect(insertedVersions(executed)).toEqual(expected);
+    // The baselines themselves must not have been re-applied.
+    expect(
+      executed.some(({ statement }) =>
+        statement.includes(
+          'CREATE TABLE IF NOT EXISTS private_knowledge.documents',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('applies nothing beyond the ledger protocol when up to date', async () => {
+    const { privateVersions, publicVersions } = versionsBySchema();
+    const { sql, executed } = fakeSql({
+      private_knowledge: privateVersions,
+      public_web: publicVersions,
+    });
+
+    await applyCorpusSchema(sql);
+
+    expect(insertedVersions(executed)).toEqual([]);
+    expect(
+      executed.some(({ statement }) => statement.includes('ADD COLUMN')),
+    ).toBe(false);
+  });
+
+  it('re-applies everything on a database bootstrapped before the ledger existed', async () => {
+    // The old bootstrap recorded nothing. Every file re-applies — safe because
+    // the migrations are idempotent — and the ledger is written so the next
+    // run is cheap.
+    const { privateVersions, publicVersions } = versionsBySchema();
+    const { sql, executed } = fakeSql({
+      private_knowledge: [],
+      public_web: [],
+    });
+
+    await applyCorpusSchema(sql);
+
+    expect(insertedVersions(executed)).toEqual([
+      ...privateVersions,
+      ...publicVersions,
+    ]);
   });
 });

--- a/services/platform/convex/knowledge/ddl.ts
+++ b/services/platform/convex/knowledge/ddl.ts
@@ -1,21 +1,30 @@
 'use node';
 
 /**
- * Creating the corpus schema on an organization's own database — by applying
+ * Preparing the corpus schema on an organization's own database — by applying
  * the SAME migrations the bundled database uses, never a copy of them.
  *
  * The corpus tables are declared exactly once, in
  * `services/db/migrations/knowledge-db/<schema>/*.sql`. The bundled
  * knowledge database gets them from dbmate at container start; an
- * organization's own database starts empty and gets them from here, reading the
- * very same files. There is deliberately no TypeScript that declares a corpus
- * table: the schema was once written out in three places, and the copies drifted
- * until a deploy failed on a column one of them had never heard of.
+ * organization's own database gets them from here, reading the very same
+ * files. There is deliberately no TypeScript that declares a corpus table: the
+ * schema was once written out in three places, and the copies drifted until a
+ * deploy failed on a column one of them had never heard of.
  *
- * Each migration file contains a `-- migrate:up` section and a `-- migrate:down`
- * section. Only the up section is applied, in filename order, and the statements
- * are written to be idempotent, so a bootstrap that is interrupted or repeated
- * converges rather than failing.
+ * Application is version-aware, with dbmate's own semantics and ledger: each
+ * schema tracks its applied versions in `<schema>.schema_migrations`, and only
+ * files whose version is not recorded are applied, in filename order, then
+ * recorded. That is what lets a database that was bootstrapped on an earlier
+ * release receive a migration added later — skipping everything whenever the
+ * tables already existed (as this module once did) is how `context_header`
+ * went missing on every pre-existing corpus and broke chunk writes.
+ *
+ * A database bootstrapped before this ledger existed has tables but no
+ * recorded versions; every file then applies again, which is safe because the
+ * migrations are written to be idempotent — a bootstrap that is interrupted or
+ * repeated converges rather than failing. Only each file's `-- migrate:up`
+ * section is ever applied.
  *
  * Where the files are found, in order:
  *   1. `KNOWLEDGE_MIGRATIONS_DIR` — the same variable the database container
@@ -24,10 +33,10 @@
  *      module — how it works in development and in tests.
  *
  * A deployment whose image ships neither gets an ACTIONABLE refusal telling the
- * operator to apply the migrations to their database themselves. That is the
- * right failure: silently running a hand-written approximation of the schema
- * would put an organization's documents into tables that do not match what
- * every other deployment has.
+ * operator to apply the migrations to their database themselves — unless the
+ * corpus tables already exist, in which case the database container (or the
+ * operator) owns migration application and this module must not turn that
+ * arrangement into a dead end.
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -48,8 +57,22 @@ const CORPUS_SCHEMAS = [PRIVATE_KNOWLEDGE_SCHEMA, PUBLIC_WEB_SCHEMA] as const;
 const UP_MARKER = '-- migrate:up';
 const DOWN_MARKER = '-- migrate:down';
 
+const MISSING_MIGRATIONS_REMEDY =
+  'The knowledge corpus migrations are not available in this deployment, so a new database cannot be prepared automatically. Apply services/db/migrations/knowledge-db/ to the database yourself, or set KNOWLEDGE_MIGRATIONS_DIR to where they are.';
+
+/** One migration file: where it applies, its ledger identity, and its up SQL. */
+export interface CorpusMigration {
+  schema: (typeof CORPUS_SCHEMAS)[number];
+  /** dbmate's version: the filename's digits before the first underscore. */
+  version: string;
+  /** The filename, for logs. */
+  name: string;
+  /** The `-- migrate:up` section, the only part that is ever applied. */
+  sql: string;
+}
+
 /** Cached per directory: the files do not change while the process runs. */
-const cachedSql = new Map<string, readonly string[]>();
+const cachedMigrations = new Map<string, readonly CorpusMigration[]>();
 
 /** Where the migrations live, or `null` when this deployment does not ship
  * them. */
@@ -75,22 +98,21 @@ export function findMigrationsDir(): string | null {
 }
 
 /**
- * The up-migration statements for both corpora, in application order.
+ * Every corpus migration, in application order: schema by schema, files in
+ * filename order within each.
  *
  * Throws when the migrations are not available, naming what the operator has to
  * do instead.
  */
-export function corpusSchemaSql(): readonly string[] {
+export function corpusMigrations(): readonly CorpusMigration[] {
   const dir = findMigrationsDir();
   if (dir === null) {
-    throw new Error(
-      'The knowledge corpus migrations are not available in this deployment, so a new database cannot be prepared automatically. Apply services/db/migrations/knowledge-db/ to the database yourself, or set KNOWLEDGE_MIGRATIONS_DIR to where they are.',
-    );
+    throw new Error(MISSING_MIGRATIONS_REMEDY);
   }
-  const cached = cachedSql.get(dir);
+  const cached = cachedMigrations.get(dir);
   if (cached) return cached;
 
-  const statements: string[] = [];
+  const migrations: CorpusMigration[] = [];
   for (const schema of CORPUS_SCHEMAS) {
     const schemaDir = path.join(dir, schema);
     if (!existsSync(schemaDir)) {
@@ -107,19 +129,28 @@ export function corpusSchemaSql(): readonly string[] {
       );
     }
     for (const file of files) {
-      statements.push(
-        upSection(readFileSync(path.join(schemaDir, file), 'utf8')),
-      );
+      const version = file.split('_')[0] ?? '';
+      if (!/^\d+$/.test(version)) {
+        throw new Error(
+          `The knowledge corpus migration "${schema}/${file}" has no numeric version prefix; dbmate and this bootstrap both key the applied-migrations ledger on it.`,
+        );
+      }
+      migrations.push({
+        schema,
+        version,
+        name: file,
+        sql: upSection(readFileSync(path.join(schemaDir, file), 'utf8')),
+      });
     }
   }
-  cachedSql.set(dir, statements);
-  return statements;
+  cachedMigrations.set(dir, migrations);
+  return migrations;
 }
 
 /** True when both corpora's core tables already exist — the database was
- * prepared (by an earlier bootstrap, or by the operator applying the
+ * prepared by an earlier bootstrap, or by the operator applying the
  * migrations by hand, which is exactly the remedy the missing-migrations
- * error names). */
+ * error names. */
 async function corpusSchemaPresent(sql: Sql): Promise<boolean> {
   const rows = await sql.unsafe<{ n: string }[]>(
     `SELECT count(*)::text AS n
@@ -133,8 +164,26 @@ async function corpusSchemaPresent(sql: Sql): Promise<boolean> {
   return rows[0]?.n === '3';
 }
 
+/** The versions a schema has already applied, per its dbmate ledger — created
+ * here when absent, in dbmate's own shape, so either applier can pick up where
+ * the other left off. */
+async function appliedVersions(
+  sql: Sql,
+  schema: (typeof CORPUS_SCHEMAS)[number],
+): Promise<Set<string>> {
+  await sql.unsafe(`CREATE SCHEMA IF NOT EXISTS ${schema}`);
+  await sql.unsafe(
+    `CREATE TABLE IF NOT EXISTS ${schema}.schema_migrations (version VARCHAR PRIMARY KEY)`,
+  );
+  const rows = await sql.unsafe<{ version: string }[]>(
+    `SELECT version FROM ${schema}.schema_migrations`,
+  );
+  return new Set(rows.map((row) => row.version));
+}
+
 /**
- * Create the corpus schema on a database that does not have it yet.
+ * Bring a database's corpus schema up to date: apply every migration its
+ * per-schema ledger has not recorded, then record it.
  *
  * Idempotent, and applied as a whole per file so a partially applied file
  * cannot leave a table without its indexes. A database that already carries
@@ -143,26 +192,46 @@ async function corpusSchemaPresent(sql: Sql): Promise<boolean> {
  * "apply the migrations yourself" remedy into a dead end.
  */
 export async function applyCorpusSchema(sql: Sql): Promise<void> {
-  if (await corpusSchemaPresent(sql)) {
+  if (findMigrationsDir() === null) {
+    if (await corpusSchemaPresent(sql)) {
+      logger.info(
+        'the knowledge corpus tables are present and this deployment ships no migration files; applying pending migrations stays the job of the database container',
+      );
+      return;
+    }
+    throw new Error(MISSING_MIGRATIONS_REMEDY);
+  }
+
+  const migrations = corpusMigrations();
+  let appliedCount = 0;
+  for (const schema of CORPUS_SCHEMAS) {
+    const applied = await appliedVersions(sql, schema);
+    for (const migration of migrations) {
+      if (migration.schema !== schema) continue;
+      if (applied.has(migration.version)) continue;
+      logger.info(
+        `applying knowledge corpus migration ${schema}/${migration.name}`,
+      );
+      await sql.unsafe(migration.sql);
+      await sql.unsafe(
+        `INSERT INTO ${schema}.schema_migrations (version) VALUES ($1)
+         ON CONFLICT (version) DO NOTHING`,
+        [migration.version],
+      );
+      appliedCount += 1;
+    }
+  }
+  if (appliedCount > 0) {
     logger.info(
-      'the knowledge corpus schema is already present; nothing to prepare',
+      `the knowledge corpus schema is ready (${appliedCount} migration${appliedCount === 1 ? '' : 's'} applied)`,
     );
-    return;
   }
-  const statements = corpusSchemaSql();
-  logger.info(
-    'preparing the knowledge corpus schema on a database that has not been used before',
-  );
-  for (const statement of statements) {
-    await sql.unsafe(statement);
-  }
-  logger.info('the knowledge corpus schema is ready');
 }
 
 /**
  * The `migrate:up` half of a dbmate migration.
  *
- * The down half must never run during a bootstrap — for these baselines it is
+ * The down half must never run during a bootstrap — for these files it is
  * intentionally empty, but applying whatever follows the marker would be a
  * loaded gun pointed at a corpus.
  */

--- a/services/platform/convex/node_only/sandbox/render_fetch.test.ts
+++ b/services/platform/convex/node_only/sandbox/render_fetch.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseRenderResults } from './render_fetch';
+
+/**
+ * The worker↔engine protocol, pinned: what the crawl engine does with a page
+ * hinges on this mapping — `ok` stores content, `failed` charges the page's
+ * fail_count, `not_attempted` leaves the row due for the next link. A
+ * malformed record must never look like a success.
+ */
+
+const URLS = ['https://a.ch/x', 'https://a.ch/y'] as const;
+
+describe('parseRenderResults', () => {
+  it('maps rendered pages, failures, and untouched URLs', () => {
+    const results = parseRenderResults(
+      {
+        pages: [
+          {
+            url: 'https://a.ch/x',
+            attempted: true,
+            status: 200,
+            finalUrl: 'https://a.ch/x2',
+            html: '<html>ok</html>',
+          },
+          { url: 'https://a.ch/y', attempted: true, error: 'nav timeout' },
+        ],
+      },
+      URLS,
+    );
+    expect(results.get('https://a.ch/x')).toEqual({
+      kind: 'ok',
+      status: 200,
+      finalUrl: 'https://a.ch/x2',
+      html: '<html>ok</html>',
+    });
+    expect(results.get('https://a.ch/y')).toEqual({
+      kind: 'failed',
+      reason: 'nav timeout',
+    });
+  });
+
+  it('treats a URL the worker never reached as not attempted', () => {
+    const results = parseRenderResults(
+      { pages: [{ url: 'https://a.ch/x', attempted: false }] },
+      URLS,
+    );
+    expect(results.get('https://a.ch/x')).toEqual({ kind: 'not_attempted' });
+    expect(results.get('https://a.ch/y')).toEqual({ kind: 'not_attempted' });
+  });
+
+  it('never turns a malformed record into a success', () => {
+    const results = parseRenderResults(
+      {
+        pages: [
+          // Attempted but no html and no error: failed with a stock reason.
+          { url: 'https://a.ch/x', attempted: true, status: 200 },
+          // Unknown URL and junk entries: ignored.
+          { url: 'https://other.ch/z', attempted: true, html: '<p>' },
+          null,
+          'garbage',
+        ],
+      },
+      URLS,
+    );
+    expect(results.get('https://a.ch/x')).toEqual({
+      kind: 'failed',
+      reason: 'render produced no content',
+    });
+    expect(results.get('https://a.ch/y')).toEqual({ kind: 'not_attempted' });
+    expect(results.size).toBe(2);
+  });
+
+  it('survives a payload that is not an object at all', () => {
+    for (const payload of [null, 42, 'nope', { pages: 'nope' }]) {
+      const results = parseRenderResults(payload, URLS);
+      expect(results.get('https://a.ch/x')).toEqual({ kind: 'not_attempted' });
+    }
+  });
+});

--- a/services/platform/convex/node_only/sandbox/render_fetch.ts
+++ b/services/platform/convex/node_only/sandbox/render_fetch.ts
@@ -1,0 +1,407 @@
+'use node';
+
+/**
+ * The crawler's render lane: fetch a batch of HTML pages through a headless
+ * browser inside an ephemeral sandbox session, so JS-rendered sites (SPA
+ * shells) yield their real content. This finishes wiring the `render`
+ * session lane the platform already scaffolds (`sessionIdForRender`,
+ * `ownerType: 'render'` with its own org quota).
+ *
+ * Division of labour with the crawl engine: the engine's plain probe GET
+ * remains the authority on page LIFECYCLE (2xx/404/deletes, size caps,
+ * content-type dispatch, SSRF guards for every byte download) — the render
+ * worker only turns an already-probed HTML page into its rendered DOM.
+ * Binaries never enter the sandbox.
+ *
+ * Failure semantics are two-tier by design:
+ *  - Infra failures (quota, session create, exec transport, no output file)
+ *    THROW — the caller fails the whole scan visibly and retries next
+ *    interval; per-page `fail_count` is never charged for a down sandbox.
+ *  - Per-URL render outcomes (nav timeout, blocked redirect, oversized DOM)
+ *    come back as `failed` and are charged to that page alone.
+ *
+ * One session per batch, destroyed in `finally` — a session never spans
+ * loop iterations or scan continuation links.
+ */
+
+import { z } from 'zod';
+
+import { internal } from '../../_generated/api';
+import type { ActionCtx } from '../../_generated/server';
+import { sessionIdForRender } from '../../sandbox/session_naming';
+import {
+  sessionCreate,
+  sessionDestroy,
+  sessionReadFile,
+  sessionStageFiles,
+} from './helpers/session_client';
+import { runStepsInSession } from './session_exec';
+
+/** Per-page navigation budget inside the worker. */
+const RENDER_PAGE_TIMEOUT_MS = 20_000;
+/** How long the worker waits for network-idle after DOMContentLoaded. */
+const RENDER_IDLE_TIMEOUT_MS = 5_000;
+/** The worker stops STARTING pages this far before the exec hard kill, so
+ * it always exits cleanly with its partial results on disk. */
+const WORKER_EXIT_MARGIN_MS = 20_000;
+/** Rendered-DOM caps: per page, and total per batch — `sessionReadFile`
+ * serves at most 20MB, so the output file must stay safely under it. */
+const RENDER_MAX_HTML_BYTES = 6 * 1024 * 1024;
+const RENDER_MAX_TOTAL_BYTES = 15 * 1024 * 1024;
+
+export type RenderPageOutcome =
+  | { kind: 'ok'; status: number; finalUrl: string; html: string }
+  | { kind: 'failed'; reason: string }
+  | { kind: 'not_attempted' };
+
+export interface RenderBatchArgs {
+  organizationId: string;
+  urls: readonly string[];
+  /** Unique per batch — feeds the session id AND the per-owner slot, so
+   * concurrent batches (different domains, same org) never collide. */
+  batchKey: string;
+  /** Wall-clock budget for the sandbox exec, already clamped by the caller
+   * against its own action deadline. */
+  execTimeoutMs: number;
+}
+
+/** The worker's output file is a boundary: validate, never trust. Records
+ * that fail the schema are ignored (their URL stays `not_attempted`). */
+const renderRecordSchema = z.object({
+  url: z.string(),
+  attempted: z.boolean().optional(),
+  status: z.number().optional(),
+  finalUrl: z.string().optional(),
+  html: z.string().optional(),
+  error: z.string().optional(),
+});
+const renderPayloadSchema = z.object({ pages: z.array(z.unknown()) });
+
+/**
+ * Map the worker's output file onto per-URL outcomes. A URL the worker never
+ * reached (or a malformed record) is `not_attempted` — the row stays due and
+ * the next continuation link retries it.
+ */
+export function parseRenderResults(
+  payload: unknown,
+  urls: readonly string[],
+): Map<string, RenderPageOutcome> {
+  const byUrl = new Map<string, RenderPageOutcome>();
+  for (const url of urls) byUrl.set(url, { kind: 'not_attempted' });
+  const parsed = renderPayloadSchema.safeParse(payload);
+  if (!parsed.success) return byUrl;
+  for (const entry of parsed.data.pages) {
+    const record = renderRecordSchema.safeParse(entry);
+    if (!record.success) continue;
+    const { url, attempted, status, finalUrl, html, error } = record.data;
+    if (!byUrl.has(url) || attempted !== true) continue;
+    if (html !== undefined && status !== undefined) {
+      byUrl.set(url, {
+        kind: 'ok',
+        status,
+        finalUrl: finalUrl ?? url,
+        html,
+      });
+      continue;
+    }
+    byUrl.set(url, {
+      kind: 'failed',
+      reason:
+        error !== undefined && error.length > 0
+          ? error
+          : 'render produced no content',
+    });
+  }
+  return byUrl;
+}
+
+/**
+ * Render one batch of URLs in a throwaway sandbox session and return the
+ * per-URL outcomes. Throws on any infrastructure failure (see module doc).
+ */
+export async function renderUrlsInSandbox(
+  ctx: ActionCtx,
+  args: RenderBatchArgs,
+): Promise<Map<string, RenderPageOutcome>> {
+  const sessionId = sessionIdForRender(args.batchKey);
+  const rowId = await ctx.runMutation(
+    internal.sandbox.session_mutations.reserveSessionSlotAndInsert,
+    {
+      organizationId: args.organizationId,
+      sessionId,
+      profile: 'default',
+      ownerType: 'render',
+      ownerId: sessionId,
+      createdBy: 'system:crawler',
+    },
+  );
+
+  let created = false;
+  try {
+    try {
+      await sessionCreate({
+        sessionId,
+        organizationId: args.organizationId,
+        profile: 'default',
+      });
+      created = true;
+    } catch (error) {
+      // Roll the reserved row out of the way so the freed slot wakes any
+      // parked waiter and a retry is not blocked by the per-owner cap.
+      await ctx.runMutation(
+        internal.sandbox.session_mutations.setSessionStatus,
+        {
+          rowId,
+          status: 'failed',
+        },
+      );
+      throw error;
+    }
+    await ctx.runMutation(internal.sandbox.session_mutations.setSessionStatus, {
+      rowId,
+      status: 'active',
+    });
+
+    const workerInput = {
+      urls: args.urls,
+      perPageTimeoutMs: RENDER_PAGE_TIMEOUT_MS,
+      idleTimeoutMs: RENDER_IDLE_TIMEOUT_MS,
+      softBudgetMs: Math.max(
+        30_000,
+        args.execTimeoutMs - WORKER_EXIT_MARGIN_MS,
+      ),
+      maxHtmlBytes: RENDER_MAX_HTML_BYTES,
+      maxTotalBytes: RENDER_MAX_TOTAL_BYTES,
+    };
+    await sessionStageFiles(sessionId, [
+      {
+        path: 'code/render.mjs',
+        contentBase64: Buffer.from(RENDER_WORKER_SOURCE, 'utf8').toString(
+          'base64',
+        ),
+      },
+      {
+        path: 'code/urls.json',
+        contentBase64: Buffer.from(
+          JSON.stringify(workerInput),
+          'utf8',
+        ).toString('base64'),
+      },
+    ]);
+
+    const run = await runStepsInSession(sessionId, {
+      stepPaths: ['/user/code/render.mjs'],
+      timeoutMs: args.execTimeoutMs,
+    });
+    // The worker rewrites its output after every page, so even a hard-killed
+    // exec leaves partial results behind; only a MISSING file is an infra
+    // failure worth failing the scan over.
+    const file = await sessionReadFile(sessionId, '/user/output/pages.json');
+    if (!file) {
+      const detail = [
+        `status ${run.status}`,
+        run.errorMessage ?? '',
+        run.stderr.slice(-400),
+      ]
+        .filter((part) => part.length > 0)
+        .join(' — ');
+      throw new Error(`render worker produced no output (${detail})`);
+    }
+    const payload: unknown = JSON.parse(new TextDecoder().decode(file.bytes));
+    return parseRenderResults(payload, args.urls);
+  } finally {
+    if (created) {
+      try {
+        await sessionDestroy(sessionId);
+      } catch (error) {
+        console.warn(
+          `[render] session ${sessionId} destroy failed (teardown cron will reap it):`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+    try {
+      await ctx.runMutation(
+        internal.sandbox.session_mutations.markSessionRowDestroyed,
+        { organizationId: args.organizationId, sessionId },
+      );
+    } catch (error) {
+      console.warn(
+        `[render] session ${sessionId} row flip failed:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+}
+
+/**
+ * The worker staged into the sandbox. Plain node ESM (`.mjs` — the step
+ * runner has no TS interpreter). Resolves playwright from the paths the
+ * sandbox image bakes and verifies at build time; launches Chromium with the
+ * egress proxy passed EXPLICITLY (Chromium ignores proxy env vars, and the
+ * sandbox bridge is internal-only — without `--proxy-server` every
+ * navigation dies). Re-validates hostnames because the engine-side SSRF
+ * guard does not travel into the sandbox: single-label hosts (docker service
+ * aliases like `convex`) and private/link-local IP literals are refused, on
+ * the original URL and again on the post-redirect landing host.
+ */
+const RENDER_WORKER_SOURCE = `
+import { createRequire } from 'node:module';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+
+const requireModule = createRequire(import.meta.url);
+const PLAYWRIGHT_CANDIDATES = [
+  '/opt/agents/lib/node_modules/@playwright/mcp/node_modules/playwright-core',
+  '/opt/agents/skills/visual-aspect-analyzer/node_modules/playwright',
+  'playwright-core',
+  'playwright',
+];
+
+function loadChromium() {
+  const failures = [];
+  for (const candidate of PLAYWRIGHT_CANDIDATES) {
+    try {
+      const mod = requireModule(candidate);
+      if (mod && mod.chromium) return mod.chromium;
+      failures.push(candidate + ': no chromium export');
+    } catch (error) {
+      failures.push(candidate + ': ' + (error && error.message ? error.message : String(error)));
+    }
+  }
+  throw new Error('playwright is not resolvable in this sandbox image: ' + failures.join(' | '));
+}
+
+function isBlockedHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  if (host === '' || !host.includes('.')) return true;
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host.endsWith('.local') || host.endsWith('.internal')) return true;
+  const ipv4 = /^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$/.exec(host);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+    return false;
+  }
+  if (host.includes(':')) return true;
+  return false;
+}
+
+const input = JSON.parse(readFileSync('/user/code/urls.json', 'utf8'));
+const urls = Array.isArray(input.urls) ? input.urls : [];
+const perPageTimeoutMs = input.perPageTimeoutMs || 20000;
+const idleTimeoutMs = input.idleTimeoutMs || 5000;
+const softBudgetMs = input.softBudgetMs || 180000;
+const maxHtmlBytes = input.maxHtmlBytes || 6291456;
+const maxTotalBytes = input.maxTotalBytes || 15728640;
+
+const startedAt = Date.now();
+const records = new Map();
+for (const url of urls) records.set(url, { url, attempted: false });
+mkdirSync('/user/output', { recursive: true });
+function flush() {
+  writeFileSync(
+    '/user/output/pages.json',
+    JSON.stringify({ pages: Array.from(records.values()) }),
+  );
+}
+flush();
+
+const chromium = loadChromium();
+const proxyServer =
+  process.env.HTTPS_PROXY || process.env.https_proxy ||
+  process.env.HTTP_PROXY || process.env.http_proxy;
+const launchOptions = { headless: true };
+if (proxyServer) {
+  launchOptions.proxy = { server: proxyServer };
+  const bypass = process.env.NO_PROXY || process.env.no_proxy;
+  if (bypass) launchOptions.proxy.bypass = bypass;
+}
+
+const browser = await chromium.launch(launchOptions);
+let totalBytes = 0;
+try {
+  const context = await browser.newContext();
+  for (const url of urls) {
+    if (Date.now() - startedAt > softBudgetMs) break;
+    if (totalBytes > maxTotalBytes) break;
+    const record = records.get(url);
+    record.attempted = true;
+    let hostname = '';
+    try {
+      hostname = new URL(url).hostname;
+    } catch {
+      record.error = 'unparseable URL';
+      flush();
+      continue;
+    }
+    if (isBlockedHost(hostname)) {
+      record.error = 'blocked host';
+      flush();
+      continue;
+    }
+    const page = await context.newPage();
+    try {
+      const response = await page.goto(url, {
+        timeout: perPageTimeoutMs,
+        waitUntil: 'domcontentloaded',
+      });
+      await page
+        .waitForLoadState('networkidle', { timeout: idleTimeoutMs })
+        .catch(() => {});
+      // SPAs go network-quiet between boot and their data fetch, so idle
+      // alone captures the shell. Wait until the rendered TEXT stops
+      // growing: stable across two samples (or the cap) is the document.
+      const settleDeadline = Date.now() + Math.min(perPageTimeoutMs, 15000);
+      let previousLength = -1;
+      let stableSamples = 0;
+      while (Date.now() < settleDeadline && stableSamples < 2) {
+        const length = await page
+          .evaluate('document.body ? document.body.innerText.length : 0')
+          .catch(() => 0);
+        if (length === previousLength && length > 0) stableSamples += 1;
+        else stableSamples = 0;
+        previousLength = length;
+        if (stableSamples < 2) {
+          await new Promise((resolve) => setTimeout(resolve, 1500));
+        }
+      }
+      const finalUrl = page.url();
+      let finalHost = '';
+      try {
+        finalHost = new URL(finalUrl).hostname;
+      } catch {
+        finalHost = '';
+      }
+      const status = response ? response.status() : 0;
+      if (finalHost === '' || isBlockedHost(finalHost)) {
+        record.error = 'redirected to a blocked host';
+      } else if (status < 200 || status >= 300) {
+        record.status = status;
+        record.error = 'HTTP ' + status + ' at render time';
+      } else {
+        const html = await page.content();
+        if (html.length > maxHtmlBytes) {
+          record.error = 'rendered HTML exceeds the per-page bound';
+        } else {
+          record.status = status;
+          record.finalUrl = finalUrl;
+          record.html = html;
+          totalBytes += html.length;
+        }
+      }
+    } catch (error) {
+      record.error = (error && error.message ? String(error.message) : 'navigation failed').slice(0, 500);
+    } finally {
+      await page.close().catch(() => {});
+    }
+    flush();
+  }
+} finally {
+  await browser.close().catch(() => {});
+}
+flush();
+`;

--- a/services/platform/convex/websites/actions.ts
+++ b/services/platform/convex/websites/actions.ts
@@ -1,5 +1,6 @@
 import { ConvexError, v } from 'convex/values';
 
+import { normalizeListedUrl, siteHosts } from '../../lib/knowledge/crawl-parse';
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { ActionCtx } from '../_generated/server';
@@ -67,6 +68,9 @@ export const createWebsite = action({
     // Runtime validation happens at the internal mutation chokepoint
     // (`provisionWebsite`), which every write path funnels through.
     scanInterval: v.string(),
+    // Present = a curated URL list on this domain instead of a whole-site
+    // crawl. Every entry must live on the domain (or its www/apex sibling).
+    urls: v.optional(v.array(v.string())),
   },
   returns: v.id('websites'),
   handler: async (ctx, args): Promise<Id<'websites'>> => {
@@ -88,18 +92,61 @@ export const createWebsite = action({
     );
 
     const domain = toWebsiteDomain(args.domain);
+    const isList = args.urls !== undefined && args.urls.length > 0;
 
-    const websiteId = await ctx.runMutation(
-      internal.websites.internal_mutations.provisionWebsite,
-      {
-        organizationId: args.organizationId,
-        domain: args.domain,
-        title: args.title,
-        description: args.description,
+    // Boundary validation for list entries: parseable, http(s), and on this
+    // domain. The client splits a multi-domain paste into one call per
+    // domain, so a foreign-host entry here is a caller bug, not user input
+    // to soften.
+    let listedUrls: string[] | undefined;
+    if (isList && args.urls) {
+      const hosts = siteHosts(domain);
+      const normalized = new Set<string>();
+      for (const entry of args.urls) {
+        const url = normalizeListedUrl(entry, hosts);
+        if (!url) {
+          throw new ConvexError({
+            code: 'WEBSITE_INVALID_LIST_URL',
+            url: entry,
+            domain,
+          });
+        }
+        normalized.add(url);
+      }
+      listedUrls = [...normalized];
+    }
+
+    let websiteId: Id<'websites'>;
+    const existing = isList
+      ? await ctx.runQuery(
+          internal.websites.internal_queries.getWebsiteByDomain,
+          { organizationId: args.organizationId, domain },
+        )
+      : null;
+    if (existing) {
+      // Same-org re-registration of a list MERGES: the corpus upsert adds
+      // the new URLs, the row just refreshes its cadence. Site mode keeps
+      // the duplicate guard in `createWebsite` (#2056).
+      await ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
+        websiteId: existing._id,
         scanInterval: args.scanInterval,
         status: 'scanning',
-      },
-    );
+      });
+      websiteId = existing._id;
+    } else {
+      websiteId = await ctx.runMutation(
+        internal.websites.internal_mutations.provisionWebsite,
+        {
+          organizationId: args.organizationId,
+          domain: args.domain,
+          kind: isList ? 'list' : undefined,
+          title: args.title,
+          description: args.description,
+          scanInterval: args.scanInterval,
+          status: 'scanning',
+        },
+      );
+    }
 
     // Register with crawler asynchronously — don't block the UI
     await ctx.scheduler.runAfter(
@@ -110,6 +157,7 @@ export const createWebsite = action({
         domain,
         scanInterval: args.scanInterval,
         organizationId: args.organizationId,
+        urls: listedUrls,
       },
     );
 

--- a/services/platform/convex/websites/create_website.test.ts
+++ b/services/platform/convex/websites/create_website.test.ts
@@ -51,6 +51,35 @@ function codeOf(err: unknown): string | undefined {
   return typeof candidate === 'string' ? candidate : undefined;
 }
 
+describe('URL-list provisioning', () => {
+  it('stores kind on list rows and leaves site rows without one', async () => {
+    const t = convexTest(schema, modules);
+    const listId = await t.mutation(
+      internal.websites.internal_mutations.provisionWebsite,
+      {
+        organizationId: ORG,
+        domain: 'fedlex.admin.ch',
+        kind: 'list',
+        scanInterval: '6h',
+        status: 'scanning',
+      },
+    );
+    const siteId = await t.mutation(
+      internal.websites.internal_mutations.provisionWebsite,
+      {
+        organizationId: ORG,
+        domain: 'example.org',
+        scanInterval: '6h',
+        status: 'scanning',
+      },
+    );
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(listId))?.kind).toBe('list');
+      expect((await ctx.db.get(siteId))?.kind).toBeUndefined();
+    });
+  });
+});
+
 describe('createWebsite duplicate guard (#2056)', () => {
   // Regression: the duplicate-domain rejection must carry a structured
   // ConvexError code. A raw `Error` is redacted to "Server Error" in prod, so

--- a/services/platform/convex/websites/create_website.ts
+++ b/services/platform/convex/websites/create_website.ts
@@ -11,6 +11,7 @@ import type { MutationCtx } from '../_generated/server';
 export interface CreateWebsiteArgs {
   organizationId: string;
   domain: string; // Accepts full URL (preferred) or bare domain
+  kind?: 'site' | 'list';
   title?: string;
   description?: string;
   scanInterval: string; // e.g., '60m' | '6h' | '12h' | '1d' | '5d' | '7d' | '30d'

--- a/services/platform/convex/websites/internal_actions.ts
+++ b/services/platform/convex/websites/internal_actions.ts
@@ -58,6 +58,32 @@ export async function registerDomainWithCrawler(
   });
 }
 
+/**
+ * Register a curated URL list in the organization's `public_web` corpus and
+ * start its first scan immediately. The listed URLs are the whole frontier —
+ * no discovery runs for a list.
+ */
+export async function registerUrlListWithCrawler(
+  ctx: ActionCtx,
+  orgSlug: string,
+  domain: string,
+  urls: readonly string[],
+  scanInterval: string,
+  organizationId: string,
+): Promise<void> {
+  await ctx.runAction(internal.knowledge.crawl_ops.registerUrlListOp, {
+    orgSlug,
+    domain,
+    urls: [...urls],
+    scanIntervalSeconds: scanIntervalToSeconds(scanInterval),
+  });
+  await ctx.scheduler.runAfter(0, internal.knowledge.crawl_action.scanWebsite, {
+    domain,
+    orgSlug,
+    organizationId,
+  });
+}
+
 export async function updateCrawlerScanInterval(
   ctx: ActionCtx,
   orgSlug: string,
@@ -259,17 +285,31 @@ export const registerAndSync = internalAction({
     domain: v.string(),
     scanInterval: v.string(),
     organizationId: v.string(),
+    // Present = register a curated URL list instead of a whole-site crawl.
+    urls: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args): Promise<void> => {
     const orgSlug = await orgSlugFromId(ctx, args.organizationId);
+    const isList = args.urls !== undefined && args.urls.length > 0;
     try {
-      await registerDomainWithCrawler(
-        ctx,
-        orgSlug,
-        args.domain,
-        args.scanInterval,
-        args.organizationId,
-      );
+      if (isList && args.urls) {
+        await registerUrlListWithCrawler(
+          ctx,
+          orgSlug,
+          args.domain,
+          args.urls,
+          args.scanInterval,
+          args.organizationId,
+        );
+      } else {
+        await registerDomainWithCrawler(
+          ctx,
+          orgSlug,
+          args.domain,
+          args.scanInterval,
+          args.organizationId,
+        );
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(
@@ -284,16 +324,19 @@ export const registerAndSync = internalAction({
       return;
     }
 
-    // Async: fetch homepage title & description (non-blocking, independent of scan)
-    await ctx.scheduler.runAfter(
-      0,
-      internal.websites.internal_actions.fetchAndPatchHomepage,
-      {
-        websiteId: args.websiteId,
-        domain: args.domain,
-        organizationId: args.organizationId,
-      },
-    );
+    // Async: fetch homepage title & description (non-blocking, independent
+    // of scan). Not for lists — their homepage is not part of the list.
+    if (!isList) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.websites.internal_actions.fetchAndPatchHomepage,
+        {
+          websiteId: args.websiteId,
+          domain: args.domain,
+          organizationId: args.organizationId,
+        },
+      );
+    }
 
     // Schedule a delayed sync to pick up scan results
     await ctx.scheduler.runAfter(
@@ -377,6 +420,7 @@ export const syncSingleWebsite = internalAction({
           {
             websiteId: args.websiteId,
             status: info.status,
+            kind: info.kind,
             pageCount: info.page_count,
             crawledPageCount: info.crawled_count,
             title: info.title ?? undefined,

--- a/services/platform/convex/websites/internal_actions.ts
+++ b/services/platform/convex/websites/internal_actions.ts
@@ -203,7 +203,10 @@ export const syncWebsiteStatuses = internalAction({
               metadata: {
                 ...website.metadata,
                 lastStatusSyncAt: now,
-                lastSyncError: undefined,
+                // See syncSingleWebsite: null clears through the metadata
+                // merge; undefined would not survive serialization.
+                lastSyncError:
+                  websiteInfo.status === 'error' ? websiteInfo.error : null,
               },
               status: websiteInfo.status,
               pageCount: websiteInfo.page_count,
@@ -383,7 +386,11 @@ export const syncSingleWebsite = internalAction({
               : undefined,
             metadata: {
               ...website.metadata,
-              lastSyncError: undefined,
+              // The crawler's own failure reason rides along with an error
+              // status. Cleared with null, never undefined: undefined is
+              // dropped in serialization, so the metadata merge downstream
+              // would keep the stale message.
+              lastSyncError: info.status === 'error' ? info.error : null,
               lastStatusSyncAt: syncTimestamp,
             },
           },

--- a/services/platform/convex/websites/internal_mutations.ts
+++ b/services/platform/convex/websites/internal_mutations.ts
@@ -6,6 +6,7 @@ import * as WebsitesHelpers from './helpers';
 import {
   isValidScanInterval,
   SCAN_INTERVAL_VALUES,
+  websiteKindValidator,
   websiteStatusValidator,
 } from './validators';
 
@@ -28,6 +29,7 @@ export const provisionWebsite = internalMutation({
   args: {
     organizationId: v.string(),
     domain: v.string(),
+    kind: v.optional(websiteKindValidator),
     title: v.optional(v.string()),
     description: v.optional(v.string()),
     scanInterval: v.string(),
@@ -54,6 +56,7 @@ export const patchWebsite = internalMutation({
   args: {
     websiteId: v.id('websites'),
     domain: v.optional(v.string()),
+    kind: v.optional(websiteKindValidator),
     title: v.optional(v.string()),
     description: v.optional(v.string()),
     scanInterval: v.optional(v.string()),

--- a/services/platform/convex/websites/rest_api.ts
+++ b/services/platform/convex/websites/rest_api.ts
@@ -12,6 +12,7 @@
  *   POST   /api/v1/websites/:id/search  — Search content
  */
 
+import { normalizeListedUrl, siteHosts } from '../../lib/knowledge/crawl-parse';
 import { internal } from '../_generated/api';
 import {
   extractPathParts,
@@ -66,17 +67,65 @@ export const createWebsite = withRestAuth('rest:api', async (rc, request) => {
 
   const domain = toWebsiteDomain(body.domain);
 
-  const websiteId = await rc.ctx.runMutation(
-    internal.websites.internal_mutations.provisionWebsite,
-    {
-      organizationId: rc.org.organizationId,
-      domain,
-      title: body.title,
-      description: body.description,
-      scanInterval: body.scanInterval,
-      status: 'scanning',
-    },
-  );
+  // Optional `urls` = a curated URL list on this domain instead of a
+  // whole-site crawl. Mirrors `actions.createWebsite`: entries must be
+  // http(s) URLs on the domain (or its www/apex sibling), and re-posting a
+  // list for a domain this org already tracks MERGES the URLs.
+  const rawUrls: unknown = body.urls;
+  const listEntries: unknown[] = Array.isArray(rawUrls) ? rawUrls : [];
+  const isList = listEntries.length > 0;
+  let listedUrls: string[] | undefined;
+  if (isList) {
+    const hosts = siteHosts(domain);
+    const normalized = new Set<string>();
+    for (const entry of listEntries) {
+      const candidate = typeof entry === 'string' ? entry : null;
+      const url =
+        candidate === null ? null : normalizeListedUrl(candidate, hosts);
+      if (!url) {
+        return jsonError(
+          `Invalid list URL (must be http(s) on ${domain}): ${String(entry)}`,
+          400,
+        );
+      }
+      normalized.add(url);
+    }
+    listedUrls = [...normalized];
+  }
+
+  const existing = isList
+    ? await rc.ctx.runQuery(
+        internal.websites.internal_queries.getWebsiteByDomain,
+        { organizationId: rc.org.organizationId, domain },
+      )
+    : null;
+
+  let websiteId;
+  if (existing) {
+    await rc.ctx.runMutation(
+      internal.websites.internal_mutations.patchWebsite,
+      {
+        websiteId: existing._id,
+        scanInterval: body.scanInterval,
+        status: 'scanning',
+        callerOrgId: rc.org.organizationId,
+      },
+    );
+    websiteId = existing._id;
+  } else {
+    websiteId = await rc.ctx.runMutation(
+      internal.websites.internal_mutations.provisionWebsite,
+      {
+        organizationId: rc.org.organizationId,
+        domain,
+        kind: isList ? 'list' : undefined,
+        title: body.title,
+        description: body.description,
+        scanInterval: body.scanInterval,
+        status: 'scanning',
+      },
+    );
+  }
 
   // Register with crawler and schedule follow-up sync.
   // Fire-and-forget via the scheduler — matches `actions.createWebsite`
@@ -92,6 +141,7 @@ export const createWebsite = withRestAuth('rest:api', async (rc, request) => {
       domain,
       scanInterval: body.scanInterval,
       organizationId: rc.org.organizationId,
+      urls: listedUrls,
     },
   );
 

--- a/services/platform/convex/websites/schema.ts
+++ b/services/platform/convex/websites/schema.ts
@@ -6,6 +6,8 @@ import { jsonRecordValidator } from '../lib/validators/json';
 export const websitesTable = defineTable({
   organizationId: v.string(),
   domain: v.string(),
+  // 'site' = crawled whole, 'list' = curated URL list; absent reads as 'site'.
+  kind: v.optional(v.union(v.literal('site'), v.literal('list'))),
   title: v.optional(v.string()),
   description: v.optional(v.string()),
   scanInterval: v.string(),

--- a/services/platform/convex/websites/types.ts
+++ b/services/platform/convex/websites/types.ts
@@ -5,13 +5,18 @@
 import type { Infer } from 'convex/values';
 
 import type { Id } from '../_generated/dataModel';
-import type { websiteStatusValidator, websiteValidator } from './validators';
+import type {
+  websiteKindValidator,
+  websiteStatusValidator,
+  websiteValidator,
+} from './validators';
 
 // =============================================================================
 // INFERRED TYPES (from validators)
 // =============================================================================
 
 export type WebsiteStatus = Infer<typeof websiteStatusValidator>;
+export type WebsiteKind = Infer<typeof websiteKindValidator>;
 export type Website = Infer<typeof websiteValidator>;
 
 // =============================================================================
@@ -27,6 +32,7 @@ export interface GetWebsitesResult {
     _creationTime: number;
     organizationId: string;
     domain: string;
+    kind?: WebsiteKind;
     title?: string;
     description?: string;
     scanInterval: string;
@@ -81,6 +87,7 @@ export interface CrawlerPage {
 
 export interface CrawlerWebsiteInfo {
   domain: string;
+  kind: WebsiteKind;
   title: string | null;
   description: string | null;
   page_count: number;

--- a/services/platform/convex/websites/types.ts
+++ b/services/platform/convex/websites/types.ts
@@ -87,6 +87,9 @@ export interface CrawlerWebsiteInfo {
   crawled_count: number;
   status: WebsiteStatus;
   last_scanned_at: string | null;
+  /** Why the last scan failed — set with status 'error', cleared on the next
+   * scan start. */
+  error: string | null;
 }
 
 export interface CrawlerPagesResponse {

--- a/services/platform/convex/websites/update_website.ts
+++ b/services/platform/convex/websites/update_website.ts
@@ -11,6 +11,7 @@ import { ensureUrl } from './create_website';
 export interface UpdateWebsiteArgs {
   websiteId: Id<'websites'>;
   domain?: string;
+  kind?: 'site' | 'list';
   title?: string;
   description?: string;
   scanInterval?: string;

--- a/services/platform/convex/websites/validators.ts
+++ b/services/platform/convex/websites/validators.ts
@@ -14,6 +14,14 @@ export const websiteStatusValidator = v.union(
   v.literal('deleting'),
 );
 
+/** What a websites row IS: a crawled site (pages discovered via
+ * robots/sitemaps/links) or a curated list of URLs fetched verbatim. Absent
+ * on rows that predate the distinction — read absent as 'site'. */
+export const websiteKindValidator = v.union(
+  v.literal('site'),
+  v.literal('list'),
+);
+
 /**
  * The allowed scan-interval cadences. This is the single source of truth for
  * every write path (REST, the agent write tool, and the Convex actions) —
@@ -44,6 +52,7 @@ export const websiteValidator = v.object({
   _creationTime: v.number(),
   organizationId: v.string(),
   domain: v.string(),
+  kind: v.optional(websiteKindValidator),
   title: v.optional(v.string()),
   description: v.optional(v.string()),
   scanInterval: v.string(),

--- a/services/platform/lib/chat/tools.ts
+++ b/services/platform/lib/chat/tools.ts
@@ -113,8 +113,17 @@ const RAG_FETCH_SCHEMA = object(
       type: 'integer',
       minimum: 0,
       description:
-        'Character offset to continue reading a long document from — use the ' +
-        '"nextOffset" a truncated result reports.',
+        'Character offset to start reading from: a rag_search hit’s ' +
+        '"offset" to land on the match, or the "nextOffset" a truncated ' +
+        'result reports to continue.',
+    },
+    limit: {
+      type: 'integer',
+      minimum: 1,
+      maximum: 20_000,
+      description:
+        'How many characters to return (default and maximum 20000). With ' +
+        '"offset" this selects an exact content range.',
     },
   },
   ['ref'],
@@ -136,11 +145,15 @@ const CHAT_TOOL_DESCRIPTIONS: Record<ChatToolName, string> = {
   rag_search:
     "Search the organization's knowledge: documents, knowledge entries, " +
     'crawled website pages, products, and contacts. Returns ranked results ' +
-    'with a ref you can pass to rag_fetch for the full content.',
+    'with a ref you can pass to rag_fetch for the full content; document ' +
+    'and page hits also carry the match’s character "offset" — start ' +
+    'rag_fetch there to read around the match.',
   rag_fetch:
     'Load the full text of one piece of org content: a document (by the ' +
     'file id a rag_search result carries) or a crawled website page (by its ' +
-    'URL).',
+    'URL). Reads a window of up to 20000 characters; "offset" and "limit" ' +
+    'select an exact range, and a truncated result reports the "nextOffset" ' +
+    'to continue from.',
   web_fetch:
     'Fetch a public web page by URL and read it as text. Only for pages ' +
     "outside the organization's knowledge — content already crawled into " +

--- a/services/platform/lib/i18n/keys-dynamic.yml
+++ b/services/platform/lib/i18n/keys-dynamic.yml
@@ -60,6 +60,11 @@ entries:
   - 'products.searchPlaceholder'
   - 'websites.searchPlaceholder'
 
+  # `tEntity('kindList')` in use-websites-table-config.tsx (the URL-list badge)
+  # goes through the same `createTableConfigHook` runtime `entityNamespace`, so
+  # the scanner can't tie the literal back to the `websites` namespace either.
+  - 'websites.kindList'
+
   # Sortable-column header state announced to assistive tech (#2639):
   # `t.common('aria.sortAscending' | 'aria.sortDescending' | 'aria.sortAvailable')`
   # in app/features/contacts/hooks/use-contacts-table-config.tsx reads `t.common`

--- a/services/platform/lib/knowledge/crawl-parse.test.ts
+++ b/services/platform/lib/knowledge/crawl-parse.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  classifyContentType,
+  documentNameForUrl,
   extractLinks,
+  normalizeListedUrl,
   isDisallowed,
   isSitemapIndex,
   metaDescription,
@@ -136,6 +139,107 @@ describe('normalizeCandidateUrl', () => {
     expect(
       normalizeCandidateUrl('/logo.svg', 'https://www.example.com/', hosts),
     ).toBeNull();
+  });
+
+  it('admits extractable documents but drops legacy Office formats', () => {
+    expect(
+      normalizeCandidateUrl(
+        '/reports/annual.pdf',
+        'https://www.example.com/',
+        hosts,
+      ),
+    ).toBe('https://www.example.com/reports/annual.pdf');
+    expect(
+      normalizeCandidateUrl('/notes.docx', 'https://www.example.com/', hosts),
+    ).toBe('https://www.example.com/notes.docx');
+    expect(
+      normalizeCandidateUrl('/notes.doc', 'https://www.example.com/', hosts),
+    ).toBeNull();
+    expect(
+      normalizeCandidateUrl('/sheet.xls', 'https://www.example.com/', hosts),
+    ).toBeNull();
+  });
+});
+
+describe('normalizeListedUrl', () => {
+  const hosts = siteHosts('www.fedlex.admin.ch');
+
+  it('keeps entries discovery would suffix-filter — the list is explicit', () => {
+    expect(
+      normalizeListedUrl('https://www.fedlex.admin.ch/notes.doc', hosts),
+    ).toBe('https://www.fedlex.admin.ch/notes.doc');
+  });
+
+  it('rejects foreign hosts and non-http schemes', () => {
+    expect(normalizeListedUrl('https://other.ch/a', hosts)).toBeNull();
+    expect(normalizeListedUrl('ftp://www.fedlex.admin.ch/a', hosts)).toBeNull();
+  });
+
+  it('trims, upgrades plaintext http, and drops fragments', () => {
+    expect(
+      normalizeListedUrl(
+        '  http://fedlex.admin.ch/eli/cc/2009/615/de#art5 ',
+        hosts,
+      ),
+    ).toBe('https://fedlex.admin.ch/eli/cc/2009/615/de');
+  });
+});
+
+describe('classifyContentType', () => {
+  it('routes html and text types, ignoring charset parameters', () => {
+    expect(classifyContentType('text/html; charset=utf-8')).toEqual({
+      kind: 'html',
+    });
+    expect(classifyContentType('application/xhtml+xml')).toEqual({
+      kind: 'html',
+    });
+    expect(classifyContentType('text/plain')).toEqual({ kind: 'text' });
+  });
+
+  it('treats a missing header as a text page, the pre-dispatch behavior', () => {
+    expect(classifyContentType('')).toEqual({ kind: 'html' });
+  });
+
+  it('maps document mime types to the extension the router keys on', () => {
+    expect(classifyContentType('application/pdf')).toEqual({
+      kind: 'document',
+      extension: '.pdf',
+    });
+    expect(
+      classifyContentType(
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      ),
+    ).toEqual({ kind: 'document', extension: '.docx' });
+  });
+
+  it('skips everything the lane cannot turn into text', () => {
+    expect(classifyContentType('image/png')).toEqual({ kind: 'skip' });
+    expect(classifyContentType('application/octet-stream')).toEqual({
+      kind: 'skip',
+    });
+    expect(classifyContentType('application/zip')).toEqual({ kind: 'skip' });
+    expect(classifyContentType('text/css')).toEqual({ kind: 'skip' });
+  });
+});
+
+describe('documentNameForUrl', () => {
+  it('keeps a matching path basename and decodes escapes', () => {
+    expect(
+      documentNameForUrl('https://x.ch/dam/52_15_steuers%C3%A4tze.pdf', '.pdf'),
+    ).toBe('52_15_steuersätze.pdf');
+  });
+
+  it('forces the mime-derived extension over the path claim', () => {
+    expect(documentNameForUrl('https://x.ch/download?id=7', '.pdf')).toBe(
+      'download.pdf',
+    );
+    expect(documentNameForUrl('https://x.ch/report.php', '.docx')).toBe(
+      'report.php.docx',
+    );
+  });
+
+  it('falls back to a generic name for bare hosts', () => {
+    expect(documentNameForUrl('https://x.ch/', '.pdf')).toBe('document.pdf');
   });
 });
 

--- a/services/platform/lib/knowledge/crawl-parse.ts
+++ b/services/platform/lib/knowledge/crawl-parse.ts
@@ -93,9 +93,12 @@ export function extractLinks(html: string): string[] {
   return links;
 }
 
-/** File suffixes a text crawler never fetches. */
+/** File suffixes the crawler never fetches: assets, media, feeds, archives,
+ * and the legacy Office formats the extraction router has no reader for.
+ * Modern document formats (pdf/docx/xlsx/pptx/odt) are admitted — the fetch
+ * loop routes them through the extraction router like any other page. */
 const SKIPPED_SUFFIXES =
-  /\.(png|jpe?g|gif|webp|svg|ico|css|js|mjs|json|xml|rss|atom|pdf|zip|gz|tar|mp[34]|webm|mov|avi|woff2?|ttf|eot|docx?|xlsx?|pptx?)$/i;
+  /\.(png|jpe?g|gif|webp|svg|ico|css|js|mjs|json|xml|rss|atom|zip|gz|tar|mp[34]|webm|mov|avi|woff2?|ttf|eot|doc|xls|ppt)$/i;
 
 /**
  * Normalize a candidate URL onto the crawl's own site, or return null when
@@ -120,6 +123,96 @@ export function normalizeCandidateUrl(
   if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
   if (!hosts.has(parsed.hostname.toLowerCase())) return null;
   if (SKIPPED_SUFFIXES.test(parsed.pathname)) return null;
+  parsed.protocol = 'https:';
+  parsed.hash = '';
+  return parsed.toString();
+}
+
+/** Where the fetch loop routes a response, decided by its `Content-Type`
+ * alone — an explicit whitelist, never a heuristic. `document` carries the
+ * canonical extension the extraction router keys on (the server's declared
+ * type wins over whatever the URL path claims). Types the crawl lane cannot
+ * turn into text — images (vision-dependent), feeds, binaries — are `skip`:
+ * the scan remembers it looked and stores nothing, exactly as before. */
+export type CrawlDispatch =
+  | { readonly kind: 'html' }
+  | { readonly kind: 'text' }
+  | { readonly kind: 'document'; readonly extension: string }
+  | { readonly kind: 'skip' };
+
+const DOCUMENT_MIME_EXTENSIONS: ReadonlyMap<string, string> = new Map([
+  ['application/pdf', '.pdf'],
+  [
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.docx',
+  ],
+  [
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    '.xlsx',
+  ],
+  [
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    '.pptx',
+  ],
+  ['application/vnd.oasis.opendocument.text', '.odt'],
+]);
+
+export function classifyContentType(contentType: string): CrawlDispatch {
+  const mime = (contentType.split(';')[0] ?? '').trim().toLowerCase();
+  // No Content-Type header: treat as a text page, the pre-dispatch behavior.
+  if (mime === '') return { kind: 'html' };
+  if (mime === 'text/html' || mime === 'application/xhtml+xml') {
+    return { kind: 'html' };
+  }
+  if (mime === 'text/plain' || mime === 'text/markdown') {
+    return { kind: 'text' };
+  }
+  const extension = DOCUMENT_MIME_EXTENSIONS.get(mime);
+  if (extension) return { kind: 'document', extension };
+  return { kind: 'skip' };
+}
+
+/** A display/router filename for a document URL: the decoded basename of its
+ * path with the mime-derived extension forced on — the extraction router
+ * routes by extension, so the declared type must win over the path's. */
+export function documentNameForUrl(url: string, extension: string): string {
+  let basename = '';
+  try {
+    const segments = new URL(url).pathname.split('/');
+    basename = segments.findLast((segment) => segment.length > 0) ?? '';
+    try {
+      basename = decodeURIComponent(basename);
+    } catch {
+      // Keep the raw segment; a bad escape sequence is display noise, not
+      // an error worth failing the page over.
+    }
+  } catch {
+    basename = '';
+  }
+  if (basename === '') basename = 'document';
+  const lower = basename.toLowerCase();
+  if (lower.endsWith(extension)) return basename;
+  return `${basename}${extension}`;
+}
+
+/**
+ * Normalize an operator-listed URL: the same scheme/host/fragment rules as
+ * discovery, but WITHOUT the asset-suffix filter — an explicit list entry is
+ * fetched even when discovery would never admit its type (the fetch loop's
+ * content-type dispatch decides what becomes text).
+ */
+export function normalizeListedUrl(
+  candidate: string,
+  hosts: ReadonlySet<string>,
+): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate.trim());
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+  if (!hosts.has(parsed.hostname.toLowerCase())) return null;
   parsed.protocol = 'https:';
   parsed.hash = '';
   return parsed.toString();

--- a/services/platform/lib/knowledge/types.ts
+++ b/services/platform/lib/knowledge/types.ts
@@ -65,6 +65,14 @@ export interface KnowledgeHit {
   /** Position of the chunk inside its document. */
   readonly chunkIndex: number;
   /**
+   * Character position of this passage within the full text `rag_fetch`
+   * serves for the same ref — pass it as the fetch offset to read around
+   * the match instead of scanning from the start. Absent when the position
+   * cannot be established (legacy chunks without `core_content`, or a web
+   * chunk whose slice crosses a boilerplate-stripped gap).
+   */
+  readonly offset?: number;
+  /**
    * The leg's own relevance score — a BM25 score or a cosine similarity.
    * Scales differ per leg, which is exactly why fusion ranks rather than adds.
    */

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -7490,6 +7490,18 @@ websites:
   scanIntervalPlaceholder: Scan-Intervall auswählen
   domain: Domain
   scanInterval: Scan-Intervall
+  addMode:
+    label: Quellentyp
+    site: Gesamte Website
+    list: URL-Liste
+  urlList: URLs
+  urlListPlaceholder: |-
+    https://www.example.com/reports/annual.pdf
+    https://www.example.com/about
+  urlListHint: Eine URL pro Zeile. Nur diese Seiten werden indexiert — gecrawlt
+    wird sonst nichts. URLs verschiedener Websites werden zu einer Quelle pro
+    Website gruppiert.
+  kindList: URL-Liste
   scanIntervals:
     1hour: Jede Stunde
     6hours: Alle 6 Stunden
@@ -7502,10 +7514,14 @@ websites:
     domainRequired: Domain ist erforderlich
     validDomain: Gib eine gültige Domain ein (z. B. example.com)
     scanIntervalRequired: Scan-Intervall ist erforderlich
+    urlListRequired: Füge mindestens eine URL hinzu
+    urlListInvalid: 'Diese Zeile ist keine gültige URL: {line}'
   toast:
     addSuccess: Website hinzugefügt
     addError: Website konnte nicht hinzugefügt werden
     addErrorDuplicate: Diese Website wurde bereits hinzugefügt
+    addListSuccess: '{count} URLs zur Indexierung vorgemerkt'
+    addListPartial: 'Einige Quellen konnten nicht hinzugefügt werden: {domains}'
     updateSuccess: Website aktualisiert
     updateError: Website konnte nicht aktualisiert werden
     fetchPagesError: Seiten konnten nicht geladen werden

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -7548,6 +7548,16 @@ websites:
   scanIntervalPlaceholder: Select scan interval
   domain: Domain
   scanInterval: Scan interval
+  addMode:
+    label: Source type
+    site: Whole website
+    list: URL list
+  urlList: URLs
+  urlListPlaceholder: |-
+    https://www.example.com/reports/annual.pdf
+    https://www.example.com/about
+  urlListHint: One URL per line. Only these pages are indexed — nothing else is crawled. Links from different websites are grouped into one source per website.
+  kindList: URL list
   scanIntervals:
     1hour: Every 1 hour
     6hours: Every 6 hours
@@ -7560,10 +7570,14 @@ websites:
     domainRequired: Domain is required
     validDomain: Enter a valid domain (e.g. example.com)
     scanIntervalRequired: Scan interval is required
+    urlListRequired: Add at least one URL
+    urlListInvalid: 'This line is not a valid URL: {line}'
   toast:
     addSuccess: Website added successfully
     addError: Failed to add website
     addErrorDuplicate: This website has already been added
+    addListSuccess: '{count} URLs registered for indexing'
+    addListPartial: 'Some sources could not be added: {domains}'
     updateSuccess: Website updated successfully
     updateError: Failed to update website
     fetchPagesError: Failed to load pages

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7584,6 +7584,18 @@ websites:
   scanIntervalPlaceholder: Sélectionner l'intervalle d'analyse
   domain: Domaine
   scanInterval: Intervalle d'analyse
+  addMode:
+    label: Type de source
+    site: Site web entier
+    list: Liste d'URL
+  urlList: URL
+  urlListPlaceholder: |-
+    https://www.example.com/reports/annual.pdf
+    https://www.example.com/about
+  urlListHint: Une URL par ligne. Seules ces pages sont indexées — rien d'autre
+    n'est exploré. Les URL de sites web différents sont regroupées en une
+    source par site web.
+  kindList: Liste d'URL
   scanIntervals:
     1hour: Toutes les heures
     6hours: Toutes les 6 heures
@@ -7596,10 +7608,14 @@ websites:
     domainRequired: Le domaine est requis
     validDomain: Saisis un domaine valide (ex. exemple.com)
     scanIntervalRequired: L'intervalle d'analyse est requis
+    urlListRequired: Ajoute au moins une URL
+    urlListInvalid: "Cette ligne n'est pas une URL valide : {line}"
   toast:
     addSuccess: Site web ajouté avec succès
     addError: Échec de l'ajout du site web
     addErrorDuplicate: Ce site web a déjà été ajouté
+    addListSuccess: "{count} URL enregistrées pour l'indexation"
+    addListPartial: "Échec de l'ajout de certaines sources : {domains}"
     updateSuccess: Site web mis à jour avec succès
     updateError: Échec de la mise à jour du site web
     fetchPagesError: Échec du chargement des pages

--- a/services/platform/scripts/openapi/legacy-schemas.json
+++ b/services/platform/scripts/openapi/legacy-schemas.json
@@ -83,6 +83,13 @@
       },
       "scanInterval": {
         "type": "string"
+      },
+      "urls": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Registers a curated URL list on the domain instead of a whole-site crawl. Every entry must be an http(s) URL on the domain or its www/apex sibling; re-posting merges new URLs into the existing list."
       }
     }
   },


### PR DESCRIPTION
Two corpus fixes and, built on them, the crawler/RAG feature work that turns the Websites lane into a grounding corpus for curated legal sources (the Swiss VAT use case: Fedlex laws, ESTV web publications, BAZG PDFs — 64/64 links index successfully on the dev stack).

# Part 1 — corpus fixes

## Problem

Adding a website ends in a bare **Error** badge with no message (screenshot in the session: `www.fedlex.admin.ch`). The real failure was in the corpus:

```
column "context_header" of relation "chunks" does not exist
```

Two independent defects:

1. **Schema drift.** #2857 added `context_header` by editing the **already-applied** knowledge baselines. An applied migration never runs again — dbmate skips recorded versions, and `applyCorpusSchema` short-circuited whenever the corpus tables existed — so every knowledge DB provisioned before the edit is missing the column, and **every chunk write fails**: website crawls error out, and document indexing would fail the same way once past the embedding gate. The healing `ADD COLUMN IF NOT EXISTS` clauses inside the baselines never execute on exactly the databases that need them.
2. **Invisible errors.** The crawler stores its failure reason in `public_web.websites.error`, but the info SELECT never read the column, and both status syncs overwrote `metadata.lastSyncError` on every successful corpus read — so the dialog had nothing to show. (The "clear" also never worked: it wrote `undefined`, which serialization drops before the metadata merge.)

## Fix

**Convergence migrations + version-aware bootstrap** (`065360429`)
- New `00000000000003_knowledge_private_converge_columns.sql` / `00000000000004_knowledge_web_converge_columns.sql`: the baselines' full column-convergence sets re-stated under new versions. Pure `ADD COLUMN IF NOT EXISTS` with constant defaults — metadata-only, idempotent, a no-op on fresh databases. Bundled databases heal at the next container start via the existing dbmate entrypoint.
- `applyCorpusSchema` is now version-aware against the same per-schema dbmate ledger (`<schema>.schema_migrations`): it applies only unrecorded files and records them, so an **existing** bring-your-own database receives later migrations instead of being skipped forever. A pre-ledger database (old bootstrap) re-applies everything idempotently and is ledgered from then on. The no-files tolerance for bundled action runtimes is preserved.
- Baseline comments now state the rule this bug proved: a column added to an applied baseline must **also** ship as a new numbered migration.

**Error surfacing** (`264b344ad`)
- `fetchWebsiteInfoFromCorpus` reads `w.error`; both syncs put it into `metadata.lastSyncError` when the synced status is `error`, and clear with `null` (survives serialization through the metadata merge). The details dialog already renders the field — no UI change needed.

# Part 2 — crawl documents, URL lists, and JS-rendered pages (`085a1b973`)

One deterministic pipeline, no content heuristics: every page fetch is a single `safeFetchBinary` probe, dispatched on the response **content type**.

- **Documents.** PDF and Office files (docx/xlsx/pptx/odt) linked on pages or listed directly route through the existing extraction router and index like pages; `SKIPPED_SUFFIXES` keeps only formats without a reader. 25MB cap, URL-derived display names.
- **URL-list sources.** A `websites` row can be a curated list (`kind='list'`): its `website_urls` rows ARE the frontier — discovery and robots are skipped (explicitly requested pages, same stance as `web_fetch`). The add dialog gains a source-type toggle; a multi-domain paste splits client-side into one source per domain (www folded); re-registering **merges** new URLs into the existing source; site mode keeps the duplicate guard. Corpus migration `00000000000005` adds `websites.kind` (widen-only `list→site` on the shared pool) and `website_urls.listed`. Full `kind` passthrough (validators/types/sync/REST + OpenAPI), table badge, en/de/fr locales, docs.
- **Render lane.** HTML renders in an ephemeral sandboxed Chromium (finishes the pre-scaffolded `render` session lane: `sessionIdForRender`, `ownerType: 'render'`, own org quota). One session per ~10-URL batch, destroyed in `finally`; the worker resolves the image's own playwright, passes the egress proxy explicitly, re-validates hosts, rewrites its output after every page (partial results survive a hard kill), and settles SPA content by waiting for the rendered text length to stabilize — networkidle alone captures the Angular shell. **Infra failures throw** (scan → visible `error`, retried next interval) and never charge per-page `fail_count`; per-URL render failures do. The probe stays the sole authority on lifecycle (status codes, 404 deletes, caps, SSRF); binaries never enter the sandbox; conditional GET is gone — content hash is the only change detection.

# Part 3 — targeted rag reads (`f580f7b93`)

`rag_search` document/web hits carry the match's character `offset` within the text `rag_fetch` serves — exact prefix-sums for documents (their fetch text is the ordered `core_content` concatenation), `position(core_content IN content)` for pages, omitted when unknowable (legacy chunks, boilerplate-crossing slices). `rag_fetch` gains `limit` (≤20k), so `offset`+`limit` reads an exact range instead of scanning 20k windows from the start. Chunk indices stay internal. The task-lane bridge returns `searchKnowledge` output verbatim, so it inherits the offsets.

## Verification

- Corpus fixes: `ddl.test.ts` ledger suites + live heal on the dev stack (drifted DB received exactly versions 3+4; fedlex rescan wrote 171 embedded chunks where every write previously failed).
- Crawler: platform suite green (74k tests), lint/SAST/`migrations:check` clean (the Convex `kind` field is data-safe growth — no snapshot rewrite). Live E2E on the dev stack: pasting the full 64-link legal list → 4 list sources with badges → **64/64 URLs indexed** (992 chunks, 100% embedded, zero failures; one transient PDF fetch failure self-healed on re-scan). Fedlex laws render to full consolidated texts (MWSTG 25.5k words, `steuerpflichtig` ×142 — exact parity with a host-browser baseline); chat answers the CHF 100'000 threshold citing Art. 10 Abs. 2 Bst. a MWSTG with a verbatim quote.
- Targeted reads: offsets verified exact against the live corpus (monotonic positions across the 46k-char 52.02 PDF); range/clamp/mapping unit tests; live chat answered an Art. 34/164 ZV question from the 28k-word Zollverordnung with **one** targeted `rag_fetch` and verbatim quotes.

Follow-ups (not in this PR): regenerate the `websites-add-dialog` docs screenshot (needs the exclusive screenshot stack); `html-to-text` emits a literal `<!DOCTYPE` on XHTML pages (first-chunk noise); live sandbox-down drill.
