### PR TITLE
feat(platform): transcribe audio attachments in chat

### DIFF
--- a/configs/platform/system/models/openai/models.yml
+++ b/configs/platform/system/models/openai/models.yml
@@ -55,6 +55,25 @@
       fr: nova
     audioFormat: mp3
     centsPerMillionCharacters: 1200
+# Transcription: powers browser dictation's server fallback and audio/video
+# attachment transcription, both through `/audio/transcriptions`. Without an
+# entry carrying this tag `resolveTranscriptionModel` finds nothing and every
+# upload fails `NO_TRANSCRIPTION_MODEL` — the capability exists only because
+# it is declared here, exactly as with the embedding widths below.
+#
+# whisper-1 rather than the gpt-4o-transcribe family: the request asks for
+# `response_format=verbose_json` and the paragraphizer needs the per-segment
+# timestamps it returns, which the newer transcribe models do not serve.
+# Pricing is per audio MINUTE, which this catalog's per-token schema cannot
+# express — so it is omitted and the ledger records minutes at a zero cost
+# estimate. The context window is nominal: transcription takes a file.
+- id: whisper-1
+  provider: openai
+  tags:
+    - transcription
+  supportsTools: false
+  supportsVision: false
+  contextWindow: 2000
 # Embedding model — the everyday knowledge-indexing workhorse. 1536 native
 # dimensions, under pgvector's HNSW index limit.
 - id: text-embedding-3-small

--- a/configs/platform/system/models/openrouter/models.yml
+++ b/configs/platform/system/models/openrouter/models.yml
@@ -287,17 +287,3 @@
   embedding:
     dimensions: 1536
     recommended: true
-# Transcription. OpenRouter routes `/audio/transcriptions` (a bogus path 404s
-# there while this one 401s), but its model listing publishes text-output LLMs
-# only — no whisper id appears in it, so a live refresh can never surface one.
-# This shipped default is therefore the only way the capability exists for an
-# OpenRouter-only organization, the same reason the embedding widths above are
-# pinned here. Pricing is per audio minute, which the per-token schema cannot
-# express; the ledger records minutes at a zero cost estimate.
-- id: openai/whisper-1
-  provider: openrouter
-  tags:
-    - transcription
-  supportsTools: false
-  supportsVision: false
-  contextWindow: 2000

--- a/configs/platform/system/models/openrouter/models.yml
+++ b/configs/platform/system/models/openrouter/models.yml
@@ -287,3 +287,17 @@
   embedding:
     dimensions: 1536
     recommended: true
+# Transcription. OpenRouter routes `/audio/transcriptions` (a bogus path 404s
+# there while this one 401s), but its model listing publishes text-output LLMs
+# only — no whisper id appears in it, so a live refresh can never surface one.
+# This shipped default is therefore the only way the capability exists for an
+# OpenRouter-only organization, the same reason the embedding widths above are
+# pinned here. Pricing is per audio minute, which the per-token schema cannot
+# express; the ledger records minutes at a zero cost estimate.
+- id: openai/whisper-1
+  provider: openrouter
+  tags:
+    - transcription
+  supportsTools: false
+  supportsVision: false
+  contextWindow: 2000

--- a/docs/de/platform/chat/basics.md
+++ b/docs/de/platform/chat/basics.md
@@ -17,13 +17,13 @@ Die Eingabezeile ist der Eingabestreifen am unteren Bildschirmrand. Das Nachrich
 
 Während eine Antwort streamt, wird aus dem Senden-Knopf Stopp. Stoppen behält alles, was schon gestreamt ist — die Antwort bleibt stehen, wie sie ist, notfalls mitten im Satz.
 
-### Bilder
+### Bilder und Audio
 
-Füge einen Screenshot direkt ins Nachrichtenfeld ein — kopierte Bilddaten werden angehängt statt als Text zu landen — oder wähle Dateien über **Fotos & Dateien hinzufügen** im `+`-Menü. Jedes Bild liegt als kleine Miniatur über dem Feld: Ein Klick zoomt hinein, das ✕ entfernt es. Bis zu zehn Bilder reisen mit einer Nachricht, und Senden wartet, bis jeder Upload angekommen ist.
+Füge einen Screenshot direkt ins Nachrichtenfeld ein — kopierte Bilddaten werden angehängt statt als Text zu landen — oder wähle Dateien über **Fotos & Dateien hinzufügen** im `+`-Menü. Jedes Bild liegt als kleine Miniatur über dem Feld: Ein Klick zoomt hinein, das ✕ entfernt es. Audio- und Videodateien erscheinen als benannte Chips; das Transkriptionsmodell deiner Organisation macht Text daraus, bevor Senden freigeht. Bis zu zehn Dateien reisen mit einer Nachricht, und Senden wartet, bis jeder Upload angekommen ist und jede Audio-/Video-Transkription fertig ist (oder fehlgeschlagen / entfernt wurde).
 
-Ein Modell, das Bilder sehen kann, bekommt die Pixel selbst, mitten in deinen Worten; bei einem, das es nicht kann, sagt die Eingabezeile das schon beim Anhängen — dieses Modell sähe nur die Dateinamen. Angehängte Bilder gehören zu dem Chat, in dem du sie angehängt hast (ein Chatwechsel leert sie), und eine neu generierte Antwort schickt dieselben Bilder noch einmal mit.
+Ein Modell, das Bilder sehen kann, bekommt die Pixel selbst, mitten in deinen Worten; bei einem, das es nicht kann, sagt die Eingabezeile das schon beim Anhängen — dieses Modell sähe nur die Dateinamen. Audio erreicht das Chat-Modell nie als Bytes: die Runde trägt das Transkript als Text. Angehängte Dateien gehören zu dem Chat, in dem du sie angehängt hast (ein Chatwechsel leert sie), und eine neu generierte Antwort schickt dieselben Anhänge noch einmal mit.
 
-Bilder sind die einzige Anhangsart im Chat: Dokumente gehören ins [Wissen](/de/platform/knowledge/overview), wo `rag_search` sie erreicht, und Arbeit, die Dateien erzeugt, gehört in einen Task.
+Dokumente bleiben aus diesem Picker raus: sie gehören ins [Wissen](/de/platform/knowledge/overview), wo `rag_search` sie erreicht. Arbeit, die Dateien erzeugt, gehört in einen Task. Ins Mikrofon sprechen ist ein eigener Weg — siehe [Sprachmodus](/de/platform/chat/voice-mode).
 
 <Frame caption="Die Eingabezeile: Nachrichtenfeld, der Picker für Modell und Denkaufwand, Diktat, Senden.">
 

--- a/docs/en/platform/chat/basics.md
+++ b/docs/en/platform/chat/basics.md
@@ -17,13 +17,13 @@ The composer is the input strip at the bottom of the screen. The message field s
 
 While a reply streams, the send button becomes stop. Stopping keeps everything that already streamed — the reply settles as it is, mid-sentence if that is where it was.
 
-### Images
+### Images and audio
 
-Paste a screenshot straight into the message field — copied image bytes attach instead of landing as text — or pick files through the `+` menu's **Add photos & files**. Each image stages as a small thumbnail above the field: click it to zoom, and its ✕ removes it. Up to ten images ride one message, and sending waits until every upload has landed.
+Paste a screenshot straight into the message field — copied image bytes attach instead of landing as text — or pick files through the `+` menu's **Add photos & files**. Each image stages as a small thumbnail above the field: click it to zoom, and its ✕ removes it. Audio and video files stage as named chips; the organisation's transcription model turns them into text before the send unlocks. Up to ten files ride one message, and sending waits until every upload has landed and every audio/video transcription has finished (or failed / been removed).
 
-A model that can see images receives the pixels themselves, inline with your words; for one that cannot, the composer says so while the images are staged — that model would only see the file names. Staged images belong to the conversation they were staged in (switching chats clears them), and regenerating a reply re-sends the same images.
+A model that can see images receives the pixels themselves, inline with your words; for one that cannot, the composer says so while the images are staged — that model would only see the file names. Audio never reaches the chat model as bytes: the turn carries the transcript as text. Staged files belong to the conversation they were staged in (switching chats clears them), and regenerating a reply re-sends the same attachments.
 
-Images are the only attachment kind chat takes: documents belong in [Knowledge](/platform/knowledge/overview), where `rag_search` can reach them, and work that produces files belongs to a task.
+Documents stay out of this picker: they belong in [Knowledge](/platform/knowledge/overview), where `rag_search` can reach them. Work that produces files belongs to a task. Speaking into the microphone is a separate path — see [Voice mode](/platform/chat/voice-mode).
 
 <Frame caption="The composer: message field, the model-and-effort picker, dictation, send.">
 

--- a/docs/fr/platform/chat/basics.md
+++ b/docs/fr/platform/chat/basics.md
@@ -17,13 +17,13 @@ La zone de saisie est la bande en bas de l’écran. Le champ de message envoie 
 
 Pendant qu’une réponse arrive en streaming, le bouton d’envoi devient un bouton d’arrêt. Arrêter garde tout ce qui a déjà été diffusé — la réponse reste telle quelle, au milieu d’une phrase si c’est là qu’elle en était.
 
-### Images
+### Images et audio
 
-Colle une capture d’écran directement dans le champ de message — les données d’image copiées s’attachent au lieu d’arriver en texte — ou choisis des fichiers via **Ajouter photos et fichiers** dans le menu `+`. Chaque image se pose en petite miniature au-dessus du champ : un clic l’agrandit, son ✕ la retire. Jusqu’à dix images voyagent avec un message, et l’envoi attend que chaque téléversement soit arrivé.
+Colle une capture d’écran directement dans le champ de message — les données d’image copiées s’attachent au lieu d’arriver en texte — ou choisis des fichiers via **Ajouter photos et fichiers** dans le menu `+`. Chaque image se pose en petite miniature au-dessus du champ : un clic l’agrandit, son ✕ la retire. Les fichiers audio et vidéo se posent en puces nommées ; le modèle de transcription de ton organisation les transforme en texte avant que l’envoi se débloque. Jusqu’à dix fichiers voyagent avec un message, et l’envoi attend que chaque téléversement soit arrivé et que chaque transcription audio/vidéo soit terminée (ou en échec / retirée).
 
-Un modèle qui sait voir les images reçoit les pixels eux-mêmes, au fil de tes mots ; pour un modèle qui ne le sait pas, la zone de saisie le dit dès l’attache — ce modèle ne verrait que les noms de fichier. Les images attachées appartiennent au chat où tu les as posées (changer de chat les efface), et régénérer une réponse renvoie les mêmes images.
+Un modèle qui sait voir les images reçoit les pixels eux-mêmes, au fil de tes mots ; pour un modèle qui ne le sait pas, la zone de saisie le dit dès l’attache — ce modèle ne verrait que les noms de fichier. L’audio n’atteint jamais le modèle de chat en octets : le tour porte la transcription en texte. Les fichiers attachés appartiennent au chat où tu les as posés (changer de chat les efface), et régénérer une réponse renvoie les mêmes pièces jointes.
 
-Les images sont le seul type de pièce jointe du chat : les documents vont dans la [Base de connaissances](/fr/platform/knowledge/overview), où `rag_search` les atteint, et le travail qui produit des fichiers revient à une tâche.
+Les documents restent hors de ce sélecteur : ils vont dans la [Base de connaissances](/fr/platform/knowledge/overview), où `rag_search` les atteint. Le travail qui produit des fichiers revient à une tâche. Parler dans le micro est un autre chemin — voir [Mode vocal](/fr/platform/chat/voice-mode).
 
 <Frame caption="La zone de saisie : le champ de message, le sélecteur de modèle et d’effort, la dictée, l’envoi.">
 

--- a/services/platform/app/features/chat/components/chat-surface.test.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.test.tsx
@@ -72,6 +72,16 @@ vi.mock('@/app/features/shared/files/use-convex-file-upload', () => ({
     clearAttachments: vi.fn(() => []),
   }),
 }));
+// Mutable so a test can put a staged clip mid-transcription and assert the
+// send gate; reset in the root beforeEach.
+const transcriptionState = {
+  statusMap: new Map<string, { status?: string }>(),
+  isTranscribing: false,
+  isQueryLoading: false,
+};
+vi.mock('../hooks/use-file-transcription-status', () => ({
+  useFileTranscriptionStatus: () => transcriptionState,
+}));
 vi.mock('@/app/features/shared/files/use-file-url', () => ({
   useFileUrl: () => ({ data: null }),
   useFileUrls: () => ({ data: [] }),
@@ -122,6 +132,9 @@ import { ChatSurface } from './chat-surface';
 afterEach(() => {
   navigateMock.mockReset();
   canManageProvidersMock.value = false;
+  transcriptionState.statusMap = new Map();
+  transcriptionState.isTranscribing = false;
+  transcriptionState.isQueryLoading = false;
   // Drafts persist per conversation in localStorage — never across tests.
   localStorage.clear();
   vi.mocked(useComposerModels).mockImplementation(() => ({
@@ -417,6 +430,45 @@ describe('ChatSurface when the backend is live and a model is listed', () => {
     expect(
       screen.getByRole('button', { name: 'Choose model and reasoning effort' }),
     ).toHaveTextContent('deepseek-chat');
+  });
+
+  // The turn injects the transcript as TEXT, so a send that beat the
+  // transcription would reach the model with an "could not be transcribed"
+  // marker in place of the words the user attached — silently worse than
+  // waiting a moment.
+  it('holds send while a staged clip is still transcribing', async () => {
+    transcriptionState.isTranscribing = true;
+    const { user } = render(<ChatSurface organizationId="org-1" />);
+
+    const input = screen.getByRole('textbox', { name: 'Message input' });
+    await user.type(input, 'what did they decide?');
+
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+
+  it('holds send until the transcription status is actually known', async () => {
+    // Pessimistic during the first read: an unknown status could be `running`,
+    // and a fast click must not slip through that window.
+    transcriptionState.isQueryLoading = true;
+    const { user } = render(<ChatSurface organizationId="org-1" />);
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Message input' }),
+      'what did they decide?',
+    );
+
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+
+  it('releases send once transcription finishes', async () => {
+    const { user } = render(<ChatSurface organizationId="org-1" />);
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Message input' }),
+      'what did they decide?',
+    );
+
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled();
   });
 
   it("seeds the user's sticky pick over the listing default", () => {

--- a/services/platform/app/features/chat/components/chat-surface.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.tsx
@@ -59,7 +59,7 @@ import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import type { ArenaVerdict } from '@/lib/shared/arena';
-import { IMAGE_MIME_TYPES } from '@/lib/shared/file-types';
+import { COMPOSER_MEDIA_UPLOAD_ALLOWED_TYPES } from '@/lib/shared/file-types';
 import { cn } from '@/lib/utils/cn';
 
 import { useArenaActions } from '../data/arena-actions';
@@ -86,6 +86,7 @@ import {
 import { useThreadActions } from '../data/thread-actions';
 import { useVoiceActions } from '../data/voice-actions';
 import { AttachmentPreviewProvider } from '../hooks/attachment-preview-context';
+import { useFileTranscriptionStatus } from '../hooks/use-file-transcription-status';
 import {
   moveToProjectMenuItem,
   useThreadMenuActions,
@@ -721,15 +722,15 @@ function ChatSurfaceInner({
     threadActions.markRead(threadId);
   }, [threadId, generationSettled, threadActions]);
 
-  // Images staged for the next send — pasted into (or picked from) the
-  // composer, uploaded eagerly so the send itself is instant. Bound to the
-  // open thread so the file lifecycle follows it; a send from the index
-  // uploads before the thread exists (the v1 grandfather path).
+  // Images + audio/video staged for the next send — pasted into (or picked
+  // from) the composer, uploaded eagerly so the send itself is instant.
+  // Bound to the open thread so the file lifecycle follows it; a send from
+  // the index uploads before the thread exists (the v1 grandfather path).
   const uploadConfig = useMemo(
     () => ({
       organizationId,
       ...(threadId !== undefined ? { threadId } : {}),
-      allowedTypes: [...IMAGE_MIME_TYPES],
+      allowedTypes: [...COMPOSER_MEDIA_UPLOAD_ALLOWED_TYPES],
     }),
     [organizationId, threadId],
   );
@@ -742,7 +743,13 @@ function ChatSurfaceInner({
     uploadingFiles,
     removeAttachment,
     cancelUpload,
+    retryAttachmentTranscription,
   } = attachmentUpload;
+  const {
+    statusMap: transcriptionStatuses,
+    isTranscribing,
+    isQueryLoading: transcriptionQueryLoading,
+  } = useFileTranscriptionStatus(stagedAttachments, organizationId);
   // Staged images belong to the conversation they were staged in — switching
   // threads clears them; entering arena clears them too (the pair lanes
   // deliberately compare MODELS, and attachments would fork that comparison).
@@ -1189,6 +1196,12 @@ function ChatSurfaceInner({
     (fileId: string) => attachHandlersRef.current.cancelUpload(fileId),
     [],
   );
+  const stableRetryTranscription = useCallback(
+    (fileId: string) => {
+      retryAttachmentTranscription(fileId);
+    },
+    [retryAttachmentTranscription],
+  );
   // A starter FILLS the composer for tailoring before send — the 0.3
   // treatment — instead of firing the text as an un-editable first message.
   const handleStarterClick = useCallback((starter: string) => {
@@ -1566,19 +1579,27 @@ function ChatSurfaceInner({
                       generationInFlight ||
                       arenaBusyB ||
                       !threadsAvailable ||
+                      isTranscribing ||
+                      transcriptionQueryLoading ||
                       (threadId !== undefined &&
                         !arenaActive &&
                         !messagesAvailable)
                     }
-                    // Over budget: the send button explains itself on hover and
-                    // Enter raises the reason as a toast — before the round-trip
-                    // the server would refuse anyway (#2345).
+                    // Over budget wins over "still transcribing" — the period
+                    // cap is the harder stop. Transcription progress still
+                    // explains the hover when that is the only gate.
                     {...(budgetExceeded
                       ? { sendBlockedReason: t('budgetExceededDefault') }
-                      : {})}
+                      : isTranscribing || transcriptionQueryLoading
+                        ? {
+                            sendBlockedReason: t(
+                              'transcription.inProgressTooltip',
+                            ),
+                          }
+                        : {})}
                     quotedText={quotedText}
                     onQuotedTextChange={setQuotedText}
-                    // Image attachments: hidden during a live arena pair — the
+                    // Attachments: hidden during a live arena pair — the
                     // lanes compare models on identical input, and the staged
                     // set was cleared when the pair went live.
                     {...(pair === null
@@ -1588,6 +1609,8 @@ function ChatSurfaceInner({
                           onAttachFiles: stableAttachFiles,
                           onRemoveAttachment: stableRemoveAttachment,
                           onCancelAttachmentUpload: stableCancelUpload,
+                          transcriptionStatuses,
+                          onRetryTranscription: stableRetryTranscription,
                         }
                       : {})}
                     voiceOutput={voiceEnabled}

--- a/services/platform/app/features/chat/components/composer-attachments.tsx
+++ b/services/platform/app/features/chat/components/composer-attachments.tsx
@@ -5,24 +5,31 @@
  * the text field.
  *
  * An image renders as a small thumbnail (click = zoomable preview, ✕ =
- * remove); an upload still in flight renders as a spinner chip whose ✕
- * aborts it. The strip disappears entirely when nothing is staged, so the
- * composer's resting chrome is unchanged.
+ * remove); audio/video render as a named chip with transcription status
+ * (and a Retry when transcription failed); an upload still in flight
+ * renders as a spinner chip whose ✕ aborts it. The strip disappears
+ * entirely when nothing is staged, so the composer's resting chrome is
+ * unchanged.
  *
  * When the picked model cannot see images (no `vision` catalog tag) the
- * strip says so up front — the alternative is a model politely explaining it
- * is blind, one full turn too late.
+ * strip says so up front — the alternative is a model politely explaining
+ * it is blind, one full turn too late. Audio never needs that warning:
+ * it rides the turn as transcribed text.
  */
 
 import { Row } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { Loader2, TriangleAlert, X } from 'lucide-react';
+import { FileAudio, Loader2, TriangleAlert, X } from 'lucide-react';
 import { useState } from 'react';
 
+import type { FileTranscriptionInfo } from '@/app/features/chat/hooks/use-file-transcription-status';
 import type { FileAttachment } from '@/app/features/shared/files/types';
 import { useFileUrl } from '@/app/features/shared/files/use-file-url';
 import { ImagePreviewDialog } from '@/app/features/shared/markdown/image-preview-dialog';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
+import { isAudioOrVideo, isImage } from '@/lib/shared/file-types';
+import { formatFileSize } from '@/lib/utils/format/file';
 
 interface ComposerAttachmentsProps {
   attachments: readonly FileAttachment[];
@@ -32,6 +39,9 @@ interface ComposerAttachmentsProps {
   onCancelUpload: (fileId: string) => void;
   /** The picked model cannot see images — warn while any are staged. */
   warnModelCannotSee?: boolean;
+  /** Live transcription status for staged audio/video attachments. */
+  transcriptionStatuses?: ReadonlyMap<BlobRef, FileTranscriptionInfo>;
+  onRetryTranscription?: (fileId: string) => void;
 }
 
 /** One staged image. The object-URL preview serves the common case; a
@@ -83,12 +93,94 @@ function StagedImage({
   );
 }
 
+function StagedMedia({
+  attachment,
+  info,
+  onRemove,
+  onRetry,
+}: {
+  attachment: FileAttachment;
+  info: FileTranscriptionInfo | undefined;
+  onRemove: () => void;
+  onRetry?: () => void;
+}) {
+  const { t } = useT('chat');
+  const status = info?.status;
+  const inFlight = status === 'queued' || status === 'running';
+  const failed = status === 'failed';
+  const completed = status === 'completed';
+
+  let statusLabel: string;
+  if (inFlight) {
+    statusLabel = info?.progress || t('transcription.transcribing');
+  } else if (completed) {
+    statusLabel = t('transcription.transcribed');
+  } else if (failed || status === 'skipped') {
+    statusLabel = t('transcription.couldNotTranscribe');
+  } else {
+    statusLabel = formatFileSize(attachment.fileSize);
+  }
+
+  return (
+    <Row
+      gap={2}
+      align="center"
+      className="border-border bg-muted/40 h-9 max-w-[14rem] shrink-0 rounded-lg border px-2"
+    >
+      {inFlight ? (
+        <Loader2
+          aria-hidden
+          className="text-muted-foreground size-3.5 shrink-0 animate-spin motion-reduce:animate-none"
+        />
+      ) : (
+        <FileAudio
+          aria-hidden
+          className="text-muted-foreground size-3.5 shrink-0"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <Text
+          variant="muted"
+          className="text-foreground block truncate text-xs font-medium"
+        >
+          {attachment.fileName}
+        </Text>
+        <Text
+          variant="muted"
+          className="block truncate text-[10px] leading-tight"
+        >
+          {statusLabel}
+        </Text>
+      </div>
+      {failed && onRetry !== undefined && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-muted-foreground hover:text-foreground shrink-0 text-[10px] underline"
+        >
+          {t('transcription.retry')}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={t('removeAttachment')}
+        className="text-muted-foreground hover:text-foreground flex size-4 shrink-0 items-center justify-center"
+      >
+        <X aria-hidden className="size-3" />
+      </button>
+    </Row>
+  );
+}
+
 export function ComposerAttachments({
   attachments,
   uploadingFiles,
   onRemove,
   onCancelUpload,
   warnModelCannotSee = false,
+  transcriptionStatuses,
+  onRetryTranscription,
 }: ComposerAttachmentsProps) {
   const { t } = useT('chat');
   const [preview, setPreview] = useState<{
@@ -98,17 +190,35 @@ export function ComposerAttachments({
 
   if (attachments.length === 0 && uploadingFiles.length === 0) return null;
 
+  const hasImages = attachments.some((a) => isImage(a.fileType));
+
   return (
     <div>
       <Row gap={2} wrap align="center">
-        {attachments.map((attachment) => (
-          <StagedImage
-            key={attachment.fileId}
-            attachment={attachment}
-            onOpen={(url) => setPreview({ src: url, alt: attachment.fileName })}
-            onRemove={() => onRemove(attachment.fileId)}
-          />
-        ))}
+        {attachments.map((attachment) =>
+          isAudioOrVideo(attachment.fileType) ? (
+            <StagedMedia
+              key={attachment.fileId}
+              attachment={attachment}
+              info={transcriptionStatuses?.get(attachment.fileId)}
+              onRemove={() => onRemove(attachment.fileId)}
+              {...(onRetryTranscription !== undefined
+                ? {
+                    onRetry: () => onRetryTranscription(attachment.fileId),
+                  }
+                : {})}
+            />
+          ) : (
+            <StagedImage
+              key={attachment.fileId}
+              attachment={attachment}
+              onOpen={(url) =>
+                setPreview({ src: url, alt: attachment.fileName })
+              }
+              onRemove={() => onRemove(attachment.fileId)}
+            />
+          ),
+        )}
         {uploadingFiles.map((uploadId) => (
           <Row
             key={uploadId}
@@ -134,7 +244,7 @@ export function ComposerAttachments({
           </Row>
         ))}
       </Row>
-      {warnModelCannotSee && attachments.length > 0 && (
+      {warnModelCannotSee && hasImages && (
         <Row gap={1} align="center" className="mt-1.5">
           <TriangleAlert
             aria-hidden

--- a/services/platform/app/features/chat/components/composer.test.tsx
+++ b/services/platform/app/features/chat/components/composer.test.tsx
@@ -81,6 +81,8 @@ function renderComposer({
   onAttachFiles,
   onRemoveAttachment,
   onCancelAttachmentUpload,
+  transcriptionStatuses,
+  onRetryTranscription,
 }: {
   models?: ComposerModelOption[];
   initial?: ComposerSelection;
@@ -98,6 +100,10 @@ function renderComposer({
   onAttachFiles?: (files: File[]) => void;
   onRemoveAttachment?: (fileId: string) => void;
   onCancelAttachmentUpload?: (fileId: string) => void;
+  transcriptionStatuses?: ComponentProps<
+    typeof Composer
+  >['transcriptionStatuses'];
+  onRetryTranscription?: (fileId: string) => void;
 } = {}) {
   const seen: ComposerSelection[] = [];
   const draftKey = `chat-draft-test-${++draftSeq}`;
@@ -127,6 +133,12 @@ function renderComposer({
         {...(onRemoveAttachment !== undefined ? { onRemoveAttachment } : {})}
         {...(onCancelAttachmentUpload !== undefined
           ? { onCancelAttachmentUpload }
+          : {})}
+        {...(transcriptionStatuses !== undefined
+          ? { transcriptionStatuses }
+          : {})}
+        {...(onRetryTranscription !== undefined
+          ? { onRetryTranscription }
           : {})}
         voiceOutput={false}
         onVoiceOutputChange={onVoiceOutputChange}
@@ -577,5 +589,66 @@ describe('Composer image attachments', () => {
     expect(
       screen.getByRole('menuitem', { name: 'Add photos & files' }),
     ).toBeInTheDocument();
+  });
+});
+
+describe('Composer audio attachments', () => {
+  const AUDIO = {
+    fileId: 'audio1',
+    fileName: 'meeting.mp3',
+    fileType: 'audio/mpeg',
+    fileSize: 128_000,
+  };
+
+  it('renders a media chip with the live transcription status', () => {
+    renderComposer({
+      models: [MODEL],
+      initial: { modelId: MODEL.id },
+      onAttachFiles: vi.fn(),
+      attachments: [AUDIO],
+      transcriptionStatuses: new Map([
+        ['audio1', { status: 'running', progress: 'transcribing' }],
+      ]),
+    });
+
+    expect(screen.getByText('meeting.mp3')).toBeInTheDocument();
+    expect(screen.getByText('transcribing')).toBeInTheDocument();
+  });
+
+  it('offers retry when transcription failed', async () => {
+    const onRetryTranscription = vi.fn();
+    const { user } = renderComposer({
+      models: [MODEL],
+      initial: { modelId: MODEL.id },
+      onAttachFiles: vi.fn(),
+      onRetryTranscription,
+      attachments: [AUDIO],
+      transcriptionStatuses: new Map([
+        ['audio1', { status: 'failed', error: 'provider down' }],
+      ]),
+    });
+
+    expect(screen.getByText('Could not be transcribed')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(onRetryTranscription).toHaveBeenCalledWith('audio1');
+  });
+
+  it('does not warn about vision for audio-only stages', () => {
+    renderComposer({
+      models: [MODEL],
+      initial: { modelId: MODEL.id, providerSlug: MODEL.providerSlug },
+      onAttachFiles: vi.fn(),
+      attachments: [AUDIO],
+      transcriptionStatuses: new Map([
+        ['audio1', { status: 'completed', transcript: 'hi' }],
+      ]),
+    });
+
+    expect(
+      screen.queryByText(
+        "This model can't view images — it only sees their file names.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Transcribed')).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/chat/components/composer.tsx
+++ b/services/platform/app/features/chat/components/composer.tsx
@@ -37,10 +37,13 @@ import { useTranslation } from 'react-i18next';
 import { EnterKeyIcon } from '@/app/components/icons/enter-key-icon';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import type { FileTranscriptionInfo } from '@/app/features/chat/hooks/use-file-transcription-status';
 import type { FileAttachment } from '@/app/features/shared/files/types';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { toast } from '@/app/hooks/use-toast';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
+import { COMPOSER_MEDIA_UPLOAD_ACCEPT } from '@/lib/shared/file-types';
 
 import type { ComposerModelOption, ComposerSelection } from '../types';
 import { normalizeCopiedText } from '../utils/normalize-copied-text';
@@ -111,14 +114,19 @@ interface ComposerProps {
    * chip and prepended to the next send as a markdown blockquote. */
   quotedText?: string | null;
   onQuotedTextChange?: (next: string | null) => void;
-  /** Images staged for the next send. The surface owns the upload state;
-   * the composer renders the tray and feeds it pasted/picked files. Absent
-   * `onAttachFiles` hides the whole attach surface (arena, read-only). */
+  /** Files staged for the next send (images + audio/video). The surface
+   * owns the upload state; the composer renders the tray and feeds it
+   * pasted/picked files. Absent `onAttachFiles` hides the whole attach
+   * surface (arena, read-only). */
   attachments?: readonly FileAttachment[];
   uploadingAttachments?: readonly string[];
   onAttachFiles?: (files: File[]) => void;
   onRemoveAttachment?: (fileId: string) => void;
   onCancelAttachmentUpload?: (fileId: string) => void;
+  /** Live transcription status for staged audio/video — send is also
+   * gated upstream while any are `queued`/`running`. */
+  transcriptionStatuses?: ReadonlyMap<BlobRef, FileTranscriptionInfo>;
+  onRetryTranscription?: (fileId: string) => void;
   /** The SERVER-BACKED "Read replies aloud" mode — resolved thread override
    * / user default, written back through `onVoiceOutputChange`. Hidden
    * entirely under an org veto; disabled when no TTS model is configured. */
@@ -157,6 +165,8 @@ export const Composer = memo(
       onAttachFiles,
       onRemoveAttachment,
       onCancelAttachmentUpload,
+      transcriptionStatuses,
+      onRetryTranscription,
       voiceOutput,
       onVoiceOutputChange,
       voiceOutputHidden,
@@ -353,13 +363,19 @@ export const Composer = memo(
               onRemove={(fileId) => onRemoveAttachment?.(fileId)}
               onCancelUpload={(fileId) => onCancelAttachmentUpload?.(fileId)}
               warnModelCannotSee={warnModelCannotSee}
+              {...(transcriptionStatuses !== undefined
+                ? { transcriptionStatuses }
+                : {})}
+              {...(onRetryTranscription !== undefined
+                ? { onRetryTranscription }
+                : {})}
             />
             {/* The picker path into the same upload lane the paste uses.
-                Images only — documents wait on the extraction pipeline. */}
+                Images + audio/video — documents belong in Knowledge. */}
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/*"
+              accept={COMPOSER_MEDIA_UPLOAD_ACCEPT}
               multiple
               hidden
               onChange={(event) => {

--- a/services/platform/app/features/chat/hooks/use-file-transcription-status.test.ts
+++ b/services/platform/app/features/chat/hooks/use-file-transcription-status.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * The hook that decides the composer's send gate for staged audio/video.
+ *
+ * The gate itself is asserted in `chat-surface.test.tsx`; what matters here is
+ * the input side of it — which staged files are watched at all, and when
+ * "still transcribing" is true. Getting `isTranscribing` wrong in the lenient
+ * direction lets a send beat its transcript and reach the model with a "could
+ * not be transcribed" marker instead of the words the user attached.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FileAttachment } from '@/app/features/shared/files/types';
+
+const useQueryMock = vi.fn();
+vi.mock('convex/react', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: { file_metadata: { queries: { getByStorageIds: 'getByStorageIds' } } },
+}));
+
+const { useFileTranscriptionStatus } =
+  await import('./use-file-transcription-status');
+
+const ORG = 'org-1';
+
+function attachment(overrides: Partial<FileAttachment>): FileAttachment {
+  return {
+    fileId: 'kg2audio',
+    fileName: 'standup.m4a',
+    fileType: 'audio/m4a',
+    fileSize: 1024,
+    ...overrides,
+  } as FileAttachment;
+}
+
+const AUDIO = attachment({});
+const IMAGE = attachment({
+  fileId: 'kg2image',
+  fileName: 'shot.png',
+  fileType: 'image/png',
+});
+
+function run(attachments: readonly FileAttachment[]) {
+  return renderHook(() => useFileTranscriptionStatus(attachments, ORG)).result
+    .current;
+}
+
+beforeEach(() => {
+  useQueryMock.mockReset();
+  useQueryMock.mockReturnValue([]);
+});
+
+describe('useFileTranscriptionStatus', () => {
+  it('does not subscribe when nothing audio is staged', () => {
+    // An images-only compose must not open a metadata subscription, and must
+    // never report itself as transcribing.
+    const result = run([IMAGE]);
+
+    expect(useQueryMock).toHaveBeenCalledWith('getByStorageIds', 'skip');
+    expect(result.isTranscribing).toBe(false);
+    expect(result.isQueryLoading).toBe(false);
+  });
+
+  it('watches only the audio and video files among the staged set', () => {
+    run([IMAGE, AUDIO]);
+
+    expect(useQueryMock).toHaveBeenCalledWith('getByStorageIds', {
+      organizationId: ORG,
+      storageIds: ['kg2audio'],
+    });
+  });
+
+  it('blocks pessimistically until the first read answers', () => {
+    // `undefined` is "not known yet", not "nothing running" — a fast click in
+    // that window would otherwise slip past a `running` row.
+    useQueryMock.mockReturnValue(undefined);
+
+    const result = run([AUDIO]);
+
+    expect(result.isQueryLoading).toBe(true);
+    expect(result.isTranscribing).toBe(false);
+  });
+
+  it.each(['queued', 'running'])('reports %s as still transcribing', (s) => {
+    useQueryMock.mockReturnValue([
+      { storageId: 'kg2audio', transcriptionStatus: s },
+    ]);
+
+    expect(run([AUDIO]).isTranscribing).toBe(true);
+  });
+
+  it.each(['completed', 'failed', 'skipped'])(
+    'lets a %s row send rather than blocking forever',
+    (s) => {
+      // Failed and skipped are terminal: the turn injects a marker. Blocking
+      // on them would strand the composer with no way forward.
+      useQueryMock.mockReturnValue([
+        { storageId: 'kg2audio', transcriptionStatus: s },
+      ]);
+
+      expect(run([AUDIO]).isTranscribing).toBe(false);
+    },
+  );
+
+  it('blocks while ANY staged clip is unfinished', () => {
+    useQueryMock.mockReturnValue([
+      { storageId: 'kg2audio', transcriptionStatus: 'completed' },
+      { storageId: 'kg2audio2', transcriptionStatus: 'running' },
+    ]);
+
+    expect(
+      run([AUDIO, attachment({ fileId: 'kg2audio2' })]).isTranscribing,
+    ).toBe(true);
+  });
+
+  it('exposes progress and error per file for the chip to render', () => {
+    useQueryMock.mockReturnValue([
+      {
+        storageId: 'kg2audio',
+        transcriptionStatus: 'failed',
+        transcriptionError: 'Transcription API 500',
+        transcriptionProgress: '',
+        transcript: undefined,
+        transcriptionDurationSec: undefined,
+      },
+    ]);
+
+    expect(run([AUDIO]).statusMap.get('kg2audio')).toMatchObject({
+      status: 'failed',
+      error: 'Transcription API 500',
+    });
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useQuery } from 'convex/react';
+import { useMemo } from 'react';
+
+import type { FileAttachment } from '@/app/features/shared/files/types';
+import { api } from '@/convex/_generated/api';
+import type { BlobRef } from '@/convex/lib/storage/blob_ref';
+import { isAudioOrVideo } from '@/lib/shared/file-types';
+
+type TranscriptionStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'skipped';
+
+export interface FileTranscriptionInfo {
+  status?: TranscriptionStatus;
+  error?: string;
+  transcript?: string;
+  durationSec?: number;
+  progress?: string;
+}
+
+/**
+ * Query transcription status for audio/video attachments staged in the
+ * composer. Reactive Convex query — the watchdog cron ensures status
+ * eventually leaves `running`.
+ *
+ * Exposes `isQueryLoading` so the send-gate can block pessimistically
+ * during the brief window before metadata first resolves (prevents a
+ * rapid click from slipping past a not-yet-known `running` state).
+ *
+ * Blocks send only while transcription is in flight (`queued`/`running`).
+ * Failed and skipped are sendable — the turn injects a marker when no
+ * transcript is available. Transcript RAG indexing is not part of this
+ * restore, so `transcriptRagStatus` never gates the send.
+ */
+export function useFileTranscriptionStatus(
+  attachments: readonly FileAttachment[],
+  organizationId: string,
+) {
+  const audioFileIds = useMemo(
+    () =>
+      attachments
+        .filter((a) => isAudioOrVideo(a.fileType))
+        .map((a) => a.fileId),
+    [attachments],
+  );
+
+  const metadata = useQuery(
+    api.file_metadata.queries.getByStorageIds,
+    organizationId && audioFileIds.length > 0
+      ? { organizationId, storageIds: audioFileIds }
+      : 'skip',
+  );
+
+  const isQueryLoading = audioFileIds.length > 0 && metadata === undefined;
+
+  const statusMap = useMemo(() => {
+    const map = new Map<BlobRef, FileTranscriptionInfo>();
+    if (!metadata) return map;
+    for (const m of metadata) {
+      map.set(m.storageId, {
+        status: m.transcriptionStatus,
+        error: m.transcriptionError,
+        transcript: m.transcript,
+        durationSec: m.transcriptionDurationSec,
+        progress: m.transcriptionProgress,
+      });
+    }
+    return map;
+  }, [metadata]);
+
+  const isTranscribing = useMemo(() => {
+    if (!metadata || audioFileIds.length === 0) return false;
+    return metadata.some(
+      (m) =>
+        m.transcriptionStatus === 'queued' ||
+        m.transcriptionStatus === 'running',
+    );
+  }, [metadata, audioFileIds.length]);
+
+  return { statusMap, isTranscribing, isQueryLoading };
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -470,6 +470,7 @@ import type * as lib_crypto_get_secret_key from "../lib/crypto/get_secret_key.js
 import type * as lib_crypto_hex_to_bytes from "../lib/crypto/hex_to_bytes.js";
 import type * as lib_debug_log from "../lib/debug_log.js";
 import type * as lib_e2e_cron_guard from "../lib/e2e_cron_guard.js";
+import type * as lib_errors_classify_transcription_error from "../lib/errors/classify_transcription_error.js";
 import type * as lib_errors_upstream_http_error from "../lib/errors/upstream_http_error.js";
 import type * as lib_file_io from "../lib/file_io.js";
 import type * as lib_fnv1a from "../lib/fnv1a.js";
@@ -517,6 +518,7 @@ import type * as lib_providers_direct_credential from "../lib/providers/direct_c
 import type * as lib_providers_harness_status from "../lib/providers/harness_status.js";
 import type * as lib_providers_load_system_config from "../lib/providers/load_system_config.js";
 import type * as lib_providers_org_providers from "../lib/providers/org_providers.js";
+import type * as lib_providers_resolve_transcription_model from "../lib/providers/resolve_transcription_model.js";
 import type * as lib_providers_resolve_tts_model from "../lib/providers/resolve_tts_model.js";
 import type * as lib_providers_resolve_vision_model from "../lib/providers/resolve_vision_model.js";
 import type * as lib_rate_limiter_helpers from "../lib/rate_limiter/helpers.js";
@@ -1364,6 +1366,7 @@ declare const fullApi: ApiFromModules<{
   "lib/crypto/hex_to_bytes": typeof lib_crypto_hex_to_bytes;
   "lib/debug_log": typeof lib_debug_log;
   "lib/e2e_cron_guard": typeof lib_e2e_cron_guard;
+  "lib/errors/classify_transcription_error": typeof lib_errors_classify_transcription_error;
   "lib/errors/upstream_http_error": typeof lib_errors_upstream_http_error;
   "lib/file_io": typeof lib_file_io;
   "lib/fnv1a": typeof lib_fnv1a;
@@ -1411,6 +1414,7 @@ declare const fullApi: ApiFromModules<{
   "lib/providers/harness_status": typeof lib_providers_harness_status;
   "lib/providers/load_system_config": typeof lib_providers_load_system_config;
   "lib/providers/org_providers": typeof lib_providers_org_providers;
+  "lib/providers/resolve_transcription_model": typeof lib_providers_resolve_transcription_model;
   "lib/providers/resolve_tts_model": typeof lib_providers_resolve_tts_model;
   "lib/providers/resolve_vision_model": typeof lib_providers_resolve_vision_model;
   "lib/rate_limiter/helpers": typeof lib_rate_limiter_helpers;

--- a/services/platform/convex/chat/turn_action.ts
+++ b/services/platform/convex/chat/turn_action.ts
@@ -24,6 +24,7 @@
 import { ConvexError, v } from 'convex/values';
 
 import { CHAT_ASSISTANT } from '../../lib/chat/assistant';
+import { buildAudioTranscriptAppendix } from '../../lib/chat/audio-transcript';
 import {
   MAX_HISTORY_BUDGET_TOKENS,
   resolveEffectiveWindow,
@@ -57,7 +58,11 @@ import {
   classifyChatErrorCode,
   encodeChatError,
 } from '../../lib/shared/chat-errors';
-import { CHAT_MAX_FILE_COUNT } from '../../lib/shared/file-types';
+import {
+  CHAT_MAX_FILE_COUNT,
+  isAudioOrVideo,
+  isImage,
+} from '../../lib/shared/file-types';
 import { providerAttributionHeaders } from '../../lib/shared/providers/attribution';
 import {
   buildHarnessTable,
@@ -658,9 +663,10 @@ export interface ExecuteTurnArgs {
   readonly userId: string;
   readonly threadId: string;
   readonly userText: string;
-  /** Uploaded files riding the message — image blob references the caller
-   * staged through the composer. Validated here (count, type, org
-   * ownership) before anything reads their bytes. */
+  /** Uploaded files riding the message — image and audio/video blob
+   * references the caller staged through the composer. Validated here
+   * (count, type, org ownership) before anything reads their bytes.
+   * Images ride the vision wire; audio/video become transcript text. */
   readonly attachments?: readonly TurnAttachment[];
   readonly modelId: string;
   readonly providerSlug?: string;
@@ -681,12 +687,12 @@ export interface ExecuteTurnOverrides {
 }
 
 /**
- * The attachment gate: images only (the one kind the direct lane can put in
- * front of a model today), the composer's count cap re-enforced server-side,
- * and — the part that matters — every blob reference must belong to THIS
- * organization and not be trashed. Without the ownership walk a crafted call
- * could name any blob on the deployment and exfiltrate it through the
- * model's eyes.
+ * The attachment gate: images (vision wire) and audio/video (transcription
+ * → text), the composer's count cap re-enforced server-side, and — the part
+ * that matters — every blob reference must belong to THIS organization and
+ * not be trashed. Without the ownership walk a crafted call could name any
+ * blob on the deployment and exfiltrate it through the model's eyes.
+ * Documents are refused — they belong in Knowledge.
  */
 async function validateTurnAttachments(
   ctx: ActionCtx,
@@ -696,11 +702,12 @@ async function validateTurnAttachments(
   if (attachments.length > CHAT_MAX_FILE_COUNT) {
     return `A message can carry at most ${CHAT_MAX_FILE_COUNT} attachments.`;
   }
-  const nonImage = attachments.find(
-    (attachment) => !attachment.fileType.startsWith('image/'),
+  const unsupported = attachments.find(
+    (attachment) =>
+      !isImage(attachment.fileType) && !isAudioOrVideo(attachment.fileType),
   );
-  if (nonImage !== undefined) {
-    return `Only image attachments are supported in chat — remove "${nonImage.fileName}".`;
+  if (unsupported !== undefined) {
+    return `Only image and audio/video attachments are supported in chat — remove "${unsupported.fileName}".`;
   }
   const owned = new Set(
     await ctx.runQuery(
@@ -718,6 +725,41 @@ async function validateTurnAttachments(
     return `Attachment "${foreign.fileName}" was not found. Remove it and try again.`;
   }
   return null;
+}
+
+/**
+ * Append each audio/video attachment's transcript (or a failure marker) to
+ * the user text. The model never receives raw media bytes — the product
+ * contract is "transcribe, then text". Images are left alone for the vision
+ * wire. Called only on a fresh send; a regenerate already carries the
+ * enriched text from the stored user turn.
+ */
+async function appendAudioTranscripts(
+  ctx: ActionCtx,
+  attachments: readonly TurnAttachment[],
+  userText: string,
+): Promise<string> {
+  const media = attachments.filter((attachment) =>
+    isAudioOrVideo(attachment.fileType),
+  );
+  if (media.length === 0) return userText;
+
+  const entries = await Promise.all(
+    media.map(async (attachment) => {
+      const meta = await ctx.runQuery(
+        internal.file_metadata.internal_queries.getByStorageId,
+        { storageId: attachment.fileId },
+      );
+      return {
+        fileName: attachment.fileName,
+        status: meta?.transcriptionStatus,
+        transcript: meta?.transcript,
+        durationSec: meta?.transcriptionDurationSec,
+        error: meta?.transcriptionError,
+      };
+    }),
+  );
+  return userText + buildAudioTranscriptAppendix(entries);
 }
 
 /** Rebuild the turn-attachment list from a stored user message's parts — how
@@ -847,7 +889,7 @@ export async function executeTurn(
   // turn's attachments — a regenerate must not silently drop the images.
   const trailingParts: readonly MessagePart[] =
     args.resend === true && trailing !== undefined ? trailing.parts : [];
-  const userText =
+  const baseUserText =
     args.resend === true && trailing !== undefined
       ? messageText({
           role: 'user',
@@ -858,6 +900,13 @@ export async function executeTurn(
     args.resend === true
       ? attachmentsFromParts(trailingParts)
       : (args.attachments ?? []);
+  // Fresh sends inject audio/video transcripts into the user text. A
+  // regenerate already carries that enrichment on the stored text parts —
+  // re-appending would double the transcript.
+  const userText =
+    args.resend === true
+      ? baseUserText
+      : await appendAudioTranscripts(ctx, attachments, baseUserText);
   const historyRows = args.resend === true ? stored.slice(0, -1) : stored;
   const history: ChatMessage[] = historyRows.map((message) => ({
     role: message.role,

--- a/services/platform/convex/file_metadata/transcribe_audio.test.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.test.ts
@@ -715,6 +715,78 @@ describe('transcribeAudio — failure handling', () => {
     });
   });
 
+  it('stores a ConvexError payload as prose, not as raw JSON', async () => {
+    // `transcriptionError` is read by a person. A ConvexError stringifies its
+    // whole payload into `.message`, which put
+    // `{"code":"NO_TRANSCRIPTION_MODEL","message":"…"}` on the row verbatim.
+    mockResolveModel.mockRejectedValue(
+      Object.assign(
+        new Error(
+          '{"code":"NO_TRANSCRIPTION_MODEL","message":"No transcription model is configured for this organization."}',
+        ),
+        {
+          data: {
+            code: 'NO_TRANSCRIPTION_MODEL',
+            message:
+              'No transcription model is configured for this organization.',
+          },
+        },
+      ),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(terminalWrite(ctx)?.transcriptionError).toBe(
+      'No transcription model is configured for this organization.',
+    );
+  });
+
+  it('still reads a plain Error message when there is no payload', async () => {
+    mockRequestTranscription.mockRejectedValue(new Error('ffmpeg exploded'));
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(terminalWrite(ctx)?.transcriptionError).toBe('ffmpeg exploded');
+  });
+
+  it("keeps a transport failure's cause, which is the whole diagnosis", async () => {
+    // undici reports EVERY transport failure as the bare string `fetch
+    // failed`; the reason lives on `cause`. A row saying only "fetch failed"
+    // cannot distinguish bad DNS from blocked egress from a dead endpoint.
+    mockRequestTranscription.mockRejectedValue(
+      new Error('fetch failed', {
+        cause: Object.assign(
+          new Error('getaddrinfo ENOTFOUND api.example.com'),
+          {
+            code: 'ENOTFOUND',
+          },
+        ),
+      }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    const stored = String(terminalWrite(ctx)?.transcriptionError);
+    expect(stored).toContain('fetch failed');
+    expect(stored).toContain('ENOTFOUND');
+  });
+
+  it('does not repeat a cause the message already states', async () => {
+    mockRequestTranscription.mockRejectedValue(
+      new Error('connection refused', {
+        cause: new Error('connection refused'),
+      }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(terminalWrite(ctx)?.transcriptionError).toBe('connection refused');
+  });
+
   it('never writes a failure the user already cancelled', async () => {
     // Removing the attachment sets `skipped`; a late error must not resurrect
     // the row as a failure the user then sees a retry chip for.

--- a/services/platform/convex/file_metadata/transcribe_audio.test.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.test.ts
@@ -1,0 +1,776 @@
+/**
+ * Orchestration tests for `transcribeAudio` — the attachment-transcription
+ * pipeline (read blob → ffmpeg compress → chunk if oversized → per-chunk
+ * Whisper → join → ledger).
+ *
+ * What these lock is the ORDER and the MONEY, not the ffmpeg/HTTP mechanics
+ * (`audio_preprocess`, `transcription_request` and `paragraphize` own those):
+ *
+ *   - nothing is paid for twice — the single-flight lock, the content-hash
+ *     dedup, and the cancellation pre-check each short-circuit BEFORE
+ *     compression and before any provider call;
+ *   - a row never ends up stuck — callers schedule this fire-and-forget, so
+ *     every exit writes a terminal status and releases the lease, including
+ *     the paths that throw;
+ *   - a transient failure retries with backoff while a permanent one fails
+ *     fast, so a bad key doesn't burn three provider calls;
+ *   - temp files are always cleaned up, and secrets never reach the
+ *     user-visible `transcriptionError`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — registered before the module under test is imported.
+// ---------------------------------------------------------------------------
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  return {
+    v: {
+      string: stub,
+      number: stub,
+      boolean: stub,
+      optional: stub,
+      id: stub,
+      object: stub,
+      union: stub,
+      literal: stub,
+      array: stub,
+      null: stub,
+      bytes: stub,
+    },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : 'ConvexError');
+        this.data = data;
+      }
+    },
+  };
+});
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return { ...mod, internalAction: vi.fn((config) => config) };
+});
+
+// Token strings stand in for function references so assertions read as the
+// call they represent.
+vi.mock('../_generated/api', () => ({
+  internal: {
+    file_metadata: {
+      internal_queries: {
+        getByStorageId: 'getByStorageId',
+        getStorageSha256: 'getStorageSha256',
+        findCachedTranscript: 'findCachedTranscript',
+      },
+      internal_mutations: {
+        updateFileTranscription: 'updateFileTranscription',
+        acquireTranscriptionLock: 'acquireTranscriptionLock',
+        releaseTranscriptionLock: 'releaseTranscriptionLock',
+      },
+      transcribe_audio: { transcribeAudio: 'transcribeAudio' },
+    },
+    governance: {
+      internal_mutations: {
+        recordTranscriptionUsage: 'recordTranscriptionUsage',
+      },
+    },
+    video_links: {
+      internal_mutations: {
+        heartbeatJobByStorageId: 'heartbeatJobByStorageId',
+      },
+    },
+  },
+}));
+
+const mockCompressAudio = vi.fn();
+const mockChunkCompressedAudio = vi.fn();
+vi.mock('./audio_preprocess', () => ({
+  compressAudio: (...args: unknown[]) => mockCompressAudio(...args),
+  chunkCompressedAudio: (...args: unknown[]) =>
+    mockChunkCompressedAudio(...args),
+  // 24 MiB in production; kept identical so the trigger arithmetic under test
+  // is the real one.
+  CHUNK_TRIGGER_BYTES: 24 * 1024 * 1024,
+}));
+
+const mockRequestTranscription = vi.fn();
+vi.mock('./transcription_request', () => ({
+  requestTranscription: (...args: unknown[]) =>
+    mockRequestTranscription(...args),
+}));
+
+const mockResolveModel = vi.fn();
+vi.mock('../lib/providers/resolve_transcription_model', () => ({
+  resolveTranscriptionModel: (...args: unknown[]) => mockResolveModel(...args),
+}));
+
+const mockCheckHostPolicy = vi.fn();
+vi.mock('../lib/http/host_policy', () => ({
+  checkProviderHostPolicy: (...args: unknown[]) => mockCheckHostPolicy(...args),
+}));
+
+const mockReadBlobBytes = vi.fn();
+vi.mock('../lib/storage/blob_access', () => ({
+  readBlobBytes: (...args: unknown[]) => mockReadBlobBytes(...args),
+}));
+
+const mockOrgSlug = vi.fn();
+vi.mock('../lib/helpers/org_slug', () => ({
+  orgSlugFromIdOrNull: (...args: unknown[]) => mockOrgSlug(...args),
+}));
+
+vi.mock('../governance/cost_estimation', () => ({
+  estimateTranscriptionCostCents: () => 0,
+}));
+
+vi.mock('../../lib/shared/constants/usage', () => ({
+  TRANSCRIPTION_SLUG: '__transcription__',
+}));
+
+// `paragraphize` is pure and cheap — exercise the real joiner so the stored
+// transcript in these assertions is the one users would read.
+
+const { transcribeAudio } = await import('./transcribe_audio');
+
+interface HandlerArgs {
+  storageId: string;
+  fileName: string;
+  contentType: string;
+  organizationId: string;
+  attempt?: number;
+}
+
+const handler = (
+  transcribeAudio as unknown as {
+    handler: (ctx: unknown, args: HandlerArgs) => Promise<null>;
+  }
+).handler;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const ORG_ID = 'org_test';
+const STORAGE_ID = 'kg2abcdefghijklmnop';
+const MODEL = {
+  modelId: 'whisper-1',
+  providerName: 'openai',
+  baseUrl: 'https://api.example.com/v1',
+  apiKey: 'sk-test',
+};
+
+/** The `fileMetadata` row the pre-check, source gate and ledger step read. */
+let row: Record<string, unknown> | null;
+/** `_storage` SHA-256 — null disables dedup (an `s3:` ref has no system row). */
+let sha256: string | null;
+/** A prior row with the same content hash, or null for a dedup miss. */
+let cached: Record<string, unknown> | null;
+
+const compressCleanup = vi.fn();
+const chunkCleanup = vi.fn();
+
+function jobArgs(overrides: Partial<HandlerArgs> = {}): HandlerArgs {
+  return {
+    storageId: STORAGE_ID,
+    fileName: 'standup.m4a',
+    contentType: 'audio/m4a',
+    organizationId: ORG_ID,
+    ...overrides,
+  };
+}
+
+interface MockCtx {
+  runQuery: ReturnType<typeof vi.fn>;
+  runMutation: ReturnType<typeof vi.fn>;
+  scheduler: { runAfter: ReturnType<typeof vi.fn> };
+  storage: { get: ReturnType<typeof vi.fn> };
+}
+
+/** Grants the lease by echoing the caller's runId — what the real mutation
+ * does when no other invocation holds it. */
+function grantLock(callArgs: { runId: string }): string {
+  return callArgs.runId;
+}
+
+let lockResponse: (callArgs: { runId: string }) => string | null;
+
+function createMockCtx(): MockCtx {
+  return {
+    runQuery: vi.fn(async (token: string) => {
+      switch (token) {
+        case 'getByStorageId':
+          return row;
+        case 'getStorageSha256':
+          return sha256;
+        case 'findCachedTranscript':
+          return cached;
+        default:
+          throw new Error(`unexpected query: ${token}`);
+      }
+    }),
+    runMutation: vi.fn(async (token: string, callArgs: { runId: string }) => {
+      if (token === 'acquireTranscriptionLock') return lockResponse(callArgs);
+      return null;
+    }),
+    scheduler: { runAfter: vi.fn().mockResolvedValue('job_1') },
+    storage: { get: vi.fn().mockResolvedValue(new Blob(['raw audio'])) },
+  };
+}
+
+/** Every `updateFileTranscription` payload, in call order. */
+function transcriptionWrites(ctx: MockCtx): Record<string, unknown>[] {
+  return ctx.runMutation.mock.calls
+    .filter(([token]) => token === 'updateFileTranscription')
+    .map(([, payload]) => payload as Record<string, unknown>);
+}
+
+/** The payload that carried a terminal status, if any. */
+function terminalWrite(ctx: MockCtx): Record<string, unknown> | undefined {
+  return transcriptionWrites(ctx)
+    .toReversed()
+    .find(
+      (w) =>
+        w.transcriptionStatus === 'completed' ||
+        w.transcriptionStatus === 'failed',
+    );
+}
+
+function calledWith(ctx: MockCtx, token: string): boolean {
+  return ctx.runMutation.mock.calls.some(([called]) => called === token);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  row = {
+    _id: 'fm_1',
+    storageId: STORAGE_ID,
+    transcriptionStatus: 'queued',
+    uploadedBy: 'user_123',
+    source: 'upload',
+  };
+  sha256 = null;
+  cached = null;
+  lockResponse = grantLock;
+  mockResolveModel.mockResolvedValue(MODEL);
+  mockCheckHostPolicy.mockImplementation((url: string) => new URL(url));
+  mockOrgSlug.mockResolvedValue('acme');
+  mockCompressAudio.mockResolvedValue({
+    blob: new Blob(['compressed opus']),
+    durationSec: 42,
+    sizeBytes: 1_000_000,
+    cleanup: compressCleanup,
+  });
+  mockChunkCompressedAudio.mockResolvedValue({
+    chunks: [
+      { blob: new Blob(['c0']), durationSec: 5400, index: 0 },
+      { blob: new Blob(['c1']), durationSec: 1200, index: 1 },
+    ],
+    cleanup: chunkCleanup,
+  });
+  mockRequestTranscription.mockResolvedValue({
+    text: 'we shipped the thing',
+    duration: 42,
+    segments: [{ start: 0, end: 3, text: 'we shipped the thing' }],
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('transcribeAudio — short circuits before spending money', () => {
+  it.each([
+    ['skipped', 'skipped'],
+    ['failed', 'failed'],
+  ])(
+    'does no work when the row is already %s (user removed the attachment)',
+    async (status) => {
+      row = { ...row, transcriptionStatus: status };
+      const ctx = createMockCtx();
+
+      await handler(ctx, jobArgs());
+
+      // The lease is never taken, so nothing has to release it either.
+      expect(calledWith(ctx, 'acquireTranscriptionLock')).toBe(false);
+      expect(mockCompressAudio).not.toHaveBeenCalled();
+      expect(mockRequestTranscription).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does no work when the row is gone', async () => {
+    row = null;
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(calledWith(ctx, 'acquireTranscriptionLock')).toBe(false);
+    expect(mockCompressAudio).not.toHaveBeenCalled();
+  });
+
+  it('returns without work when another invocation holds the lease', async () => {
+    // A retry double-click used to let both callers through: double provider
+    // bill, double `+=` ledger write.
+    lockResponse = () => null;
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(mockCompressAudio).not.toHaveBeenCalled();
+    expect(mockRequestTranscription).not.toHaveBeenCalled();
+    // Must NOT release a lease it never won — that would free the winner's.
+    expect(calledWith(ctx, 'releaseTranscriptionLock')).toBe(false);
+  });
+
+  it('copies a prior transcript for identical content instead of re-paying', async () => {
+    sha256 = 'hash_abc';
+    cached = {
+      storageId: 'kg2otherfileref',
+      transcript: 'previously transcribed words',
+      transcriptionDurationSec: 99,
+    };
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(mockCompressAudio).not.toHaveBeenCalled();
+    expect(mockRequestTranscription).not.toHaveBeenCalled();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'completed',
+      transcript: 'previously transcribed words',
+      transcriptionDurationSec: 99,
+    });
+    // No provider call happened, so nothing may hit the usage ledger.
+    expect(calledWith(ctx, 'recordTranscriptionUsage')).toBe(false);
+    // The lease is still released — a dedup hit must not park the row.
+    expect(calledWith(ctx, 'releaseTranscriptionLock')).toBe(true);
+  });
+
+  it('stores the content hash so the NEXT identical upload can dedup', async () => {
+    sha256 = 'hash_abc';
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(transcriptionWrites(ctx)).toContainEqual(
+      expect.objectContaining({ contentHash: 'hash_abc' }),
+    );
+  });
+});
+
+describe('transcribeAudio — the transcribing path', () => {
+  it('compresses once, transcribes, and stores transcript + duration', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(mockCompressAudio).toHaveBeenCalledOnce();
+    // Under the chunk trigger, so the compressed blob goes out whole.
+    expect(mockChunkCompressedAudio).not.toHaveBeenCalled();
+    expect(mockRequestTranscription).toHaveBeenCalledOnce();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'completed',
+      transcript: 'we shipped the thing',
+      transcriptionDurationSec: 42,
+      // Cleared so the chip stops showing a stale step.
+      transcriptionProgress: '',
+    });
+  });
+
+  it('re-checks host policy on the resolved base URL before the request', async () => {
+    // Defense-in-depth: a provider file edited to point at an internal host
+    // must not receive the bearer token.
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(mockCheckHostPolicy).toHaveBeenCalledWith(
+      'https://api.example.com/v1',
+    );
+  });
+
+  it('sends a `.ogg` filename — Whisper validates by extension', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(mockRequestTranscription).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'standup.m4a.ogg', format: 'ogg' }),
+    );
+  });
+
+  it('records audio minutes against the uploader', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'recordTranscriptionUsage',
+      expect.objectContaining({
+        organizationId: ORG_ID,
+        userId: 'user_123',
+        agentSlug: '__transcription__',
+        model: 'whisper-1',
+        provider: 'openai',
+        audioDurationSec: 42,
+      }),
+    );
+  });
+
+  it('skips the ledger when the row has no uploader to bill', async () => {
+    row = { ...row, uploadedBy: undefined };
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(calledWith(ctx, 'recordTranscriptionUsage')).toBe(false);
+    // The transcript still lands — usage accounting is not a gate on it.
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'completed',
+    });
+  });
+
+  it('adds [HH:MM:SS] prefixes only for video-link sources', async () => {
+    // Timestamps let an agent cite "at 12:34…" in a video summary; on a plain
+    // voice memo they would just be noise in every paragraph.
+    const plain = createMockCtx();
+    await handler(plain, jobArgs());
+    expect(terminalWrite(plain)?.transcript).toBe('we shipped the thing');
+
+    vi.clearAllMocks();
+    mockResolveModel.mockResolvedValue(MODEL);
+    mockCheckHostPolicy.mockImplementation((url: string) => new URL(url));
+    mockCompressAudio.mockResolvedValue({
+      blob: new Blob(['compressed opus']),
+      durationSec: 42,
+      sizeBytes: 1_000_000,
+      cleanup: compressCleanup,
+    });
+    mockRequestTranscription.mockResolvedValue({
+      text: 'we shipped the thing',
+      duration: 42,
+      segments: [{ start: 0, end: 3, text: 'we shipped the thing' }],
+    });
+    row = { ...row, source: 'video_link' };
+    const video = createMockCtx();
+
+    await handler(video, jobArgs());
+
+    expect(terminalWrite(video)?.transcript).toBe(
+      '[00:00:00] we shipped the thing',
+    );
+  });
+
+  it('heartbeats the owning video-link job so its watchdog does not kill it', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'heartbeatJobByStorageId',
+      expect.objectContaining({ storageId: STORAGE_ID }),
+    );
+  });
+
+  it('always cleans up the compressed temp file', async () => {
+    await handler(createMockCtx(), jobArgs());
+    expect(compressCleanup).toHaveBeenCalledOnce();
+  });
+
+  it('releases the lease on the happy path', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'releaseTranscriptionLock',
+      expect.objectContaining({ storageId: STORAGE_ID }),
+    );
+  });
+});
+
+describe('transcribeAudio — oversized audio', () => {
+  beforeEach(() => {
+    // One byte over OpenAI's limit-minus-margin is enough to force the split.
+    mockCompressAudio.mockResolvedValue({
+      blob: new Blob(['big compressed opus']),
+      durationSec: 6600,
+      sizeBytes: 24 * 1024 * 1024 + 1,
+      cleanup: compressCleanup,
+    });
+  });
+
+  it('splits, transcribes every chunk, and joins the parts', async () => {
+    mockRequestTranscription
+      .mockResolvedValueOnce({
+        text: 'first ninety minutes',
+        duration: 5400,
+        segments: [{ start: 0, end: 10, text: 'first ninety minutes' }],
+      })
+      .mockResolvedValueOnce({
+        text: 'the tail',
+        duration: 1200,
+        segments: [{ start: 0, end: 5, text: 'the tail' }],
+      });
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(mockChunkCompressedAudio).toHaveBeenCalledOnce();
+    expect(mockRequestTranscription).toHaveBeenCalledTimes(2);
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'completed',
+      transcript: 'first ninety minutes\n\nthe tail',
+      // Summed across chunks, not just the last one's.
+      transcriptionDurationSec: 6600,
+    });
+  });
+
+  it('names later chunks distinctly and cleans up every chunk file', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    const names = mockRequestTranscription.mock.calls.map(
+      (call) => (call[0] as { fileName: string }).fileName,
+    );
+    expect(names).toEqual(['standup.m4a.ogg', 'standup.m4a.chunk-1.ogg']);
+    expect(chunkCleanup).toHaveBeenCalledOnce();
+    expect(compressCleanup).toHaveBeenCalledOnce();
+  });
+
+  it('reports which chunk is in flight so the chip can show progress', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    const progress = transcriptionWrites(ctx)
+      .map((w) => w.transcriptionProgress)
+      .filter((p): p is string => typeof p === 'string' && p.length > 0);
+    expect(progress).toContain('transcribing chunk 1 of 2');
+    expect(progress).toContain('transcribing chunk 2 of 2');
+  });
+
+  it('fails when compression yields nothing rather than storing an empty transcript', async () => {
+    mockChunkCompressedAudio.mockResolvedValue({
+      chunks: [],
+      cleanup: chunkCleanup,
+    });
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(mockRequestTranscription).not.toHaveBeenCalled();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'failed',
+      transcriptionError: expect.stringContaining('no output audio'),
+    });
+  });
+});
+
+describe('transcribeAudio — blob backends', () => {
+  it('reads a Convex `_storage` blob through ctx.storage', async () => {
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(ctx.storage.get).toHaveBeenCalledWith(STORAGE_ID);
+    expect(mockReadBlobBytes).not.toHaveBeenCalled();
+  });
+
+  it("reads an `s3:` blob from the org's own bucket", async () => {
+    mockReadBlobBytes.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ storageId: 's3:acme/clip-uuid' }));
+
+    expect(mockReadBlobBytes).toHaveBeenCalledWith(
+      ctx,
+      'acme',
+      's3:acme/clip-uuid',
+    );
+    expect(ctx.storage.get).not.toHaveBeenCalled();
+    // No `_storage` system row exists for an s3 ref, so dedup is off rather
+    // than wrong.
+    expect(ctx.runQuery).not.toHaveBeenCalledWith(
+      'getStorageSha256',
+      expect.anything(),
+    );
+  });
+
+  it('fails loudly when an `s3:` blob has no resolvable org', async () => {
+    mockOrgSlug.mockResolvedValue(null);
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ storageId: 's3:acme/clip-uuid', attempt: 3 }));
+
+    expect(mockRequestTranscription).not.toHaveBeenCalled();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'failed',
+      transcriptionError: expect.stringContaining('unresolvable'),
+    });
+  });
+
+  it('fails when the blob is missing from storage', async () => {
+    const ctx = createMockCtx();
+    ctx.storage.get.mockResolvedValue(null);
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'failed',
+      transcriptionError: expect.stringContaining('not found in storage'),
+    });
+  });
+});
+
+describe('transcribeAudio — failure handling', () => {
+  it('re-queues with backoff on a transient upstream failure', async () => {
+    mockRequestTranscription.mockRejectedValue(
+      Object.assign(new Error('Transcription API 429: slow down'), {
+        status: 429,
+      }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    // Back to `queued`, NOT `failed` — the chip must not offer a retry for
+    // something already being retried.
+    expect(transcriptionWrites(ctx)).toContainEqual(
+      expect.objectContaining({ transcriptionStatus: 'queued' }),
+    );
+    expect(terminalWrite(ctx)).toBeUndefined();
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      30_000,
+      'transcribeAudio',
+      expect.objectContaining({ attempt: 1 }),
+    );
+    // The lease is freed so the rescheduled run can take it.
+    expect(calledWith(ctx, 'releaseTranscriptionLock')).toBe(true);
+  });
+
+  it('lengthens the backoff on each further attempt', async () => {
+    mockRequestTranscription.mockRejectedValue(
+      Object.assign(new Error('upstream exploded'), { status: 503 }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 1 }));
+
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      60_000,
+      'transcribeAudio',
+      expect.objectContaining({ attempt: 2 }),
+    );
+  });
+
+  it('gives up after the last attempt instead of rescheduling forever', async () => {
+    mockRequestTranscription.mockRejectedValue(
+      Object.assign(new Error('still rate limited'), { status: 429 }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'failed',
+      transcriptionProgress: '',
+    });
+  });
+
+  it('fails fast on a permanent failure rather than retrying a bad key', async () => {
+    mockRequestTranscription.mockRejectedValue(
+      Object.assign(new Error('Transcription API 401: invalid key'), {
+        status: 401,
+      }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'failed',
+    });
+  });
+
+  it('fails fast when the org has no transcription model configured', async () => {
+    // An admin has to act; retrying three times just delays the message.
+    mockResolveModel.mockRejectedValue(
+      Object.assign(new Error('No transcription model'), {
+        data: { code: 'NO_TRANSCRIPTION_MODEL' },
+      }),
+    );
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(terminalWrite(ctx)).toMatchObject({
+      transcriptionStatus: 'failed',
+    });
+  });
+
+  it('never writes a failure the user already cancelled', async () => {
+    // Removing the attachment sets `skipped`; a late error must not resurrect
+    // the row as a failure the user then sees a retry chip for.
+    mockRequestTranscription.mockImplementation(() => {
+      row = { ...row, transcriptionStatus: 'skipped' };
+      throw new Error('fetch failed');
+    });
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs());
+
+    expect(terminalWrite(ctx)).toBeUndefined();
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  // `transcriptionError` is rendered to the user, so a provider that echoes
+  // the credential back in its message must not leak it onto the row. One
+  // case per redaction rule — a single message matching several rules would
+  // still pass with all but one of them broken.
+  it.each([
+    ['a bearer header', 'upstream said: Bearer ghp_A1b2C3d4E5f6 is invalid'],
+    ['an OpenAI-style key', 'auth failed for sk-live-abc123def456'],
+    ['an Authorization header dump', 'sent Authorization: Basic dXNlcjpwYXNz'],
+  ])('scrubs %s out of the stored error', async (_label, message) => {
+    mockRequestTranscription.mockRejectedValue(new Error(message));
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    const stored = String(terminalWrite(ctx)?.transcriptionError);
+    expect(stored).toContain('REDACTED');
+    for (const secret of [
+      'ghp_A1b2C3d4E5f6',
+      'sk-live-abc123def456',
+      'dXNlcjpwYXNz',
+    ]) {
+      expect(stored).not.toContain(secret);
+    }
+  });
+
+  it('bounds a runaway upstream message instead of storing all of it', async () => {
+    mockRequestTranscription.mockRejectedValue(new Error('x'.repeat(5_000)));
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(String(terminalWrite(ctx)?.transcriptionError).length).toBe(500);
+  });
+
+  it('cleans up temp files and the lease even when the request throws', async () => {
+    mockRequestTranscription.mockRejectedValue(new Error('boom'));
+    const ctx = createMockCtx();
+
+    await handler(ctx, jobArgs({ attempt: 3 }));
+
+    expect(compressCleanup).toHaveBeenCalledOnce();
+    expect(calledWith(ctx, 'releaseTranscriptionLock')).toBe(true);
+  });
+});

--- a/services/platform/convex/file_metadata/transcribe_audio.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.ts
@@ -2,32 +2,138 @@
 
 import { v } from 'convex/values';
 
+import { TRANSCRIPTION_SLUG } from '../../lib/shared/constants/usage';
 import { internal } from '../_generated/api';
+import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
-import { blobRefValidator } from '../lib/storage/blob_ref';
+import { estimateTranscriptionCostCents } from '../governance/cost_estimation';
+import { classifyTranscriptionError } from '../lib/errors/classify_transcription_error';
+import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { checkProviderHostPolicy } from '../lib/http/host_policy';
+import { resolveTranscriptionModel } from '../lib/providers/resolve_transcription_model';
+import { readBlobBytes } from '../lib/storage/blob_access';
+import { blobRefValidator, convexStorageId } from '../lib/storage/blob_ref';
+import {
+  chunkCompressedAudio,
+  compressAudio,
+  CHUNK_TRIGGER_BYTES,
+  type AudioChunk,
+  type CompressedAudio,
+} from './audio_preprocess';
+import {
+  joinSegmentsWithParagraphs,
+  WHISPER_PROFILE,
+  type ParagraphSegment,
+} from './paragraphize';
+import {
+  requestTranscription,
+  type TranscriptionSegment,
+} from './transcription_request';
 
-// The real pipeline
-// (ffmpeg compression → chunking → Whisper transcription → RAG indexing) is
-// gone with the providers plane (`convex/providers/resolve_model`), the
-// chat-pipeline error classifier (`convex/lib/error_classification`), and the
-// moved RAG upload helper (`convex/workflow_engine/action_defs/rag/helpers/upload_file_direct`).
-//
-// `transcribeAudio` is scheduled fire-and-forget (`ctx.scheduler.runAfter`)
-// from `file_metadata/mutations.ts` and `internal_mutations.ts` — there is no
-// caller awaiting its result, so a bare `throw` here would only show up in
-// Convex's own function logs and leave the fileMetadata row stuck at
-// `'queued'`/`'processing'` forever (the UI has no other way to learn it
-// failed). Instead this marks the row `'failed'` with a clear explanatory
-// `transcriptionError`, reusing the exact mutation the real failure path used
-// — the same user-visible "offline" signal as a thrown error, delivered
-// through the channel this action shape actually has.
+/** Matches EXTRACT_METADATA_RETRY_DELAYS in internal_actions.ts — consistent
+ * backoff pattern across the scheduled-action family. */
+const TRANSCRIBE_RETRY_DELAYS_MS = [30_000, 60_000, 120_000];
+
+/** Per-chunk API timeout. Covers long OpenAI transcriptions on ~21 MB chunks
+ * (empirically 30–90s). */
+const TRANSCRIBE_API_TIMEOUT_MS = 5 * 60_000;
 
 /**
- * No-op — marks the row `'failed'` instead of transcribing.
- * See file header.
+ * Adapter: Whisper `verbose_json` segments → shared `ParagraphSegment` shape.
+ * Optionally offsets timestamps by `chunkStartSec` so the absolute position
+ * in the original audio is preserved across chunks (each chunk's Whisper
+ * response uses chunk-local 0:00 timestamps because we splice with
+ * `-reset_timestamps 1`).
+ */
+function whisperSegmentsToParagraphSegments(
+  segments: TranscriptionSegment[] | undefined,
+  chunkStartSec: number,
+): ParagraphSegment[] {
+  if (!segments) return [];
+  return segments.map((s) => ({
+    startSec: s.start + chunkStartSec,
+    endSec: s.end + chunkStartSec,
+    text: s.text,
+  }));
+}
+
+/**
+ * Scrub secrets from error messages before they land in user-visible
+ * `transcriptionError` or logs. Targets OpenAI-style tokens and generic
+ * Authorization headers; truncates to 500 chars.
+ */
+function sanitizeTranscriptionError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  return (
+    raw
+      .replace(/Bearer\s+[A-Za-z0-9._-]+/g, 'Bearer [REDACTED]')
+      .replace(/sk-[A-Za-z0-9_-]{10,}/g, 'sk-[REDACTED]')
+      // The optional second token matters: a scheme-only redaction turns
+      // `Authorization: Basic dXNlcjpwYXNz` into
+      // `Authorization: [REDACTED] dXNlcjpwYXNz` — the header is hidden and the
+      // credential is not.
+      .replace(
+        /Authorization:\s*\S+(?:\s+[A-Za-z0-9._~+/=-]+)?/gi,
+        'Authorization: [REDACTED]',
+      )
+      .slice(0, 500)
+  );
+}
+
+/**
+ * Whisper validates by file extension, and our compressed output is
+ * Opus-in-OGG, so the `multipart` `file` field must use `.ogg` (`.opus` is NOT
+ * in OpenAI's accepted list even though the content is identical). The same
+ * `'ogg'` value feeds the `json-base64` `input_audio.format` field.
+ * https://platform.openai.com/docs/guides/speech-to-text
+ */
+function chunkFileName(originalFileName: string, chunk: AudioChunk): string {
+  return chunk.index === 0 && chunk.durationSec > 0
+    ? `${originalFileName}.ogg`
+    : `${originalFileName}.chunk-${chunk.index}.ogg`;
+}
+
+async function patchProgress(
+  ctx: ActionCtx,
+  storageId: string,
+  progress: string,
+): Promise<void> {
+  await ctx.runMutation(
+    internal.file_metadata.internal_mutations.updateFileTranscription,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- storageId is branded Id<'_storage'> from args
+    { storageId: storageId as never, transcriptionProgress: progress },
+  );
+}
+
+/**
+ * Transcribe an uploaded audio/video file via the org's configured
+ * transcription provider. Server-side pipeline:
+ *
+ *   1. Compress with ffmpeg (silenceremove + 32 kbps Opus mono 16 kHz)
+ *   2. If compressed output still exceeds OpenAI's 25 MB limit, split into
+ *      90-minute chunks via stream-copy segment (no re-encode).
+ *   3. POST each chunk sequentially to {baseUrl}/audio/transcriptions.
+ *   4. Join transcripts with blank-line separator.
+ *   5. Record usage to the ledger.
+ *
+ * Transcript RAG indexing (indexing the text under the audio's storageId so
+ * `rag_search` can cite the clip) is a deliberate follow-up — the retired
+ * `uploadFile` helper is gone, and chat usefulness only needs the transcript
+ * on `fileMetadata` for the turn to inject. `transcriptRagStatus` stays unset.
+ *
+ * On transient failure (429, 5xx, network): classify via
+ * `classifyTranscriptionError`, retry the whole action up to 3 times with
+ * [30s, 60s, 120s] backoff. Permanent failures (auth, bad input, no model)
+ * fail fast. Failures always land on the row through
+ * `updateFileTranscription` — callers schedule this fire-and-forget, so a
+ * bare throw would leave the row stuck at `queued`/`running`.
  */
 export const transcribeAudio = internalAction({
   args: {
+    // Audio blob reference: a Convex `_storage` id (deployment default) OR an
+    // `s3:<key>` ref when the org has a bring-your-own bucket. The source read
+    // (below) routes off the backend via `readBlobBytes`; the Convex path is
+    // byte-for-byte unchanged.
     storageId: blobRefValidator,
     fileName: v.string(),
     contentType: v.string(),
@@ -36,19 +142,394 @@ export const transcribeAudio = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
-    console.debug(
-      `[transcribeAudio] Audio transcription is offline while the platform AI backend is rewritten; marking ${args.storageId} failed`,
+    const attempt = args.attempt ?? 0;
+    const requestId = `transcribe-${args.storageId}-${Date.now()}`;
+    const startedAt = Date.now();
+
+    const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+
+    let compressed: CompressedAudio | undefined;
+    let chunked:
+      | { chunks: AudioChunk[]; cleanup: () => Promise<void> }
+      | undefined;
+
+    // Early-exit check: user may have cancelled (removed the attachment or
+    // clicked Skip) between this action being scheduled and firing. Skip all
+    // work — no compress, no API call, no reschedule.
+    const preCheck = await ctx.runQuery(
+      internal.file_metadata.internal_queries.getByStorageId,
+      { storageId: args.storageId },
     );
-    await ctx.runMutation(
-      internal.file_metadata.internal_mutations.updateFileTranscription,
+    if (
+      !preCheck ||
+      preCheck.transcriptionStatus === 'skipped' ||
+      preCheck.transcriptionStatus === 'failed'
+    ) {
+      console.log(
+        JSON.stringify({
+          event: 'transcription.cancelled',
+          requestId,
+          storageId: args.storageId,
+          status: preCheck?.transcriptionStatus ?? 'row_missing',
+          attempt,
+        }),
+      );
+      return null;
+    }
+
+    // Single-flight gate. Two concurrent invocations on the same
+    // storageId (retryTranscription double-click, scheduled retry +
+    // user-triggered retry, etc.) used to both proceed: double Whisper
+    // bill, double `+=` ledger write. The lock holds for the action's
+    // 30-min hard timeout + a small grace so the watchdog can break it
+    // if Convex SIGKILLs us. If we lose the race, return without work.
+    const TRANSCRIBE_LEASE_MS = 35 * 60 * 1000;
+    const acquired = await ctx.runMutation(
+      internal.file_metadata.internal_mutations.acquireTranscriptionLock,
       {
         storageId: args.storageId,
-        transcriptionStatus: 'failed',
-        transcriptionError:
-          'Audio transcription is offline while the platform AI backend is rewritten.',
-        transcriptionProgress: '',
+        runId: requestId,
+        leaseMs: TRANSCRIBE_LEASE_MS,
       },
     );
-    return null;
+    if (acquired !== requestId) {
+      console.log(
+        JSON.stringify({
+          event: 'transcription.deduplicated',
+          requestId,
+          storageId: args.storageId,
+          attempt,
+        }),
+      );
+      return null;
+    }
+
+    try {
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileTranscription,
+        {
+          storageId: args.storageId,
+          transcriptionProgress: 'checking',
+        },
+      );
+
+      // Dedup: Convex stores a SHA-256 of every upload on `_storage`. If the
+      // same content was already transcribed in this org, short-circuit and
+      // copy the prior transcript rather than paying ffmpeg + OpenAI again.
+      // An `s3:` ref has no `_storage` system row, so the checksum is
+      // unavailable — dedup gracefully degrades to off for BYO-bucket orgs.
+      const audioConvexId = convexStorageId(args.storageId);
+      const contentHash = audioConvexId
+        ? await ctx.runQuery(
+            internal.file_metadata.internal_queries.getStorageSha256,
+            { storageId: audioConvexId },
+          )
+        : null;
+
+      if (contentHash) {
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileTranscription,
+          { storageId: args.storageId, contentHash },
+        );
+
+        const cached = await ctx.runQuery(
+          internal.file_metadata.internal_queries.findCachedTranscript,
+          {
+            organizationId: args.organizationId,
+            contentHash,
+            excludeStorageId: args.storageId,
+          },
+        );
+        if (cached) {
+          console.log(
+            JSON.stringify({
+              event: 'transcription.dedup_hit',
+              requestId,
+              storageId: args.storageId,
+              sourceStorageId: cached.storageId,
+              contentHash,
+              durationSec: cached.transcriptionDurationSec,
+            }),
+          );
+          await ctx.runMutation(
+            internal.file_metadata.internal_mutations.updateFileTranscription,
+            {
+              storageId: args.storageId,
+              transcriptionStatus: 'completed',
+              transcript: cached.transcript,
+              transcriptionDurationSec: cached.transcriptionDurationSec,
+              transcriptionProgress: '',
+            },
+          );
+          return null;
+        }
+      }
+
+      await patchProgress(ctx, args.storageId, 'compressing');
+
+      const modelData = await resolveTranscriptionModel(ctx, {
+        organizationId: args.organizationId,
+      });
+      // Defense-in-depth: re-check host policy at request time so a provider
+      // file edited to point at an internal host cannot exfiltrate the bearer
+      // token (mirrors dictation / TTS).
+      checkProviderHostPolicy(modelData.baseUrl);
+
+      let origBlob: Blob;
+      if (audioConvexId) {
+        const b = await ctx.storage.get(audioConvexId);
+        if (!b) {
+          throw new Error(`Audio blob not found in storage: ${args.storageId}`);
+        }
+        origBlob = b;
+      } else {
+        if (orgSlug === null) {
+          throw new Error(
+            `[transcribeAudio] org ${args.organizationId} unresolvable; cannot read S3 audio blob ${args.storageId}`,
+          );
+        }
+        const bytes = await readBlobBytes(ctx, orgSlug, args.storageId);
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
+        origBlob = new Blob([bytes as BlobPart], {
+          type: args.contentType || 'application/octet-stream',
+        });
+      }
+
+      compressed = await compressAudio(origBlob, args.fileName);
+
+      let chunks: AudioChunk[];
+      if (compressed.sizeBytes > CHUNK_TRIGGER_BYTES) {
+        chunked = await chunkCompressedAudio(compressed.blob);
+        chunks = chunked.chunks;
+      } else {
+        chunks = [
+          {
+            blob: compressed.blob,
+            durationSec: compressed.durationSec,
+            index: 0,
+          },
+        ];
+      }
+
+      if (chunks.length === 0) {
+        throw new Error('Compression produced no output audio');
+      }
+
+      const chunkParagraphs: string[] = [];
+      let totalDurationSec = 0;
+      let chunkStartSec = 0;
+      for (const chunk of chunks) {
+        const progressLabel =
+          chunks.length === 1
+            ? 'transcribing'
+            : `transcribing chunk ${chunk.index + 1} of ${chunks.length}`;
+        await patchProgress(ctx, args.storageId, progressLabel);
+
+        const result = await requestTranscription({
+          model: modelData,
+          blob: chunk.blob,
+          fileName: chunkFileName(args.fileName, chunk),
+          format: 'ogg',
+          timeoutMs: TRANSCRIBE_API_TIMEOUT_MS,
+        });
+        // Timestamps are only meaningful for video-link transcripts —
+        // they let the agent cite "Chapter 3 @ 12:34" in summaries.
+        // Regular microphone recordings don't carry that context, so
+        // adding [HH:MM:SS] prefixes there changes the artifact format
+        // for every user with no upside. Gate on the source: only
+        // video-link-sourced fileMetadata rows opt in.
+        const paragraphs = joinSegmentsWithParagraphs(
+          whisperSegmentsToParagraphSegments(result.segments, chunkStartSec),
+          result.text ?? '',
+          {
+            profile: WHISPER_PROFILE,
+            addTimestamps: preCheck?.source === 'video_link',
+          },
+        );
+        if (paragraphs.length > 0) {
+          chunkParagraphs.push(paragraphs);
+        }
+        const chunkDuration = result.duration ?? chunk.durationSec;
+        totalDurationSec += chunkDuration;
+        chunkStartSec += chunkDuration;
+
+        // Heartbeat any video-link job that's tracking this storageId so its
+        // statusChangedAt advances past the watchdog window.
+        await ctx.runMutation(
+          internal.video_links.internal_mutations.heartbeatJobByStorageId,
+          {
+            storageId: args.storageId,
+            progress: progressLabel,
+          },
+        );
+      }
+
+      const fullTranscript = chunkParagraphs.join('\n\n');
+
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileTranscription,
+        {
+          storageId: args.storageId,
+          transcriptionStatus: 'completed',
+          transcript: fullTranscript,
+          transcriptionDurationSec: totalDurationSec,
+          transcriptionProgress: '',
+        },
+      );
+
+      const latencyMs = Date.now() - startedAt;
+      console.log(
+        JSON.stringify({
+          event: 'transcription.completed',
+          requestId,
+          storageId: args.storageId,
+          organizationId: args.organizationId,
+          provider: modelData.providerName,
+          model: modelData.modelId,
+          durationSec: totalDurationSec,
+          chunkCount: chunks.length,
+          compressedBytes: compressed.sizeBytes,
+          attempt,
+          latencyMs,
+        }),
+      );
+
+      const metadata = await ctx.runQuery(
+        internal.file_metadata.internal_queries.getByStorageId,
+        { storageId: args.storageId },
+      );
+      const userId = metadata?.uploadedBy;
+      if (userId && totalDurationSec > 0) {
+        // The rewritten catalog schema carries no per-minute transcription
+        // price, so the estimate is 0 until it grows one — the ledger still
+        // records the audio minutes and the request.
+        const costEstimateCents = estimateTranscriptionCostCents(
+          totalDurationSec,
+          undefined,
+        );
+        await ctx.runMutation(
+          internal.governance.internal_mutations.recordTranscriptionUsage,
+          {
+            organizationId: args.organizationId,
+            userId,
+            agentSlug: TRANSCRIPTION_SLUG,
+            model: modelData.modelId,
+            provider: modelData.providerName,
+            audioDurationSec: totalDurationSec,
+            costEstimateCents,
+            timestamp: Date.now(),
+          },
+        );
+      }
+
+      return null;
+    } catch (error) {
+      const classification = classifyTranscriptionError(error);
+      const sanitized = sanitizeTranscriptionError(error);
+
+      const rawStack =
+        error instanceof Error && error.stack
+          ? sanitizeTranscriptionError(error.stack)
+          : undefined;
+
+      const cancelCheck = await ctx.runQuery(
+        internal.file_metadata.internal_queries.getByStorageId,
+        { storageId: args.storageId },
+      );
+      const userCancelled =
+        cancelCheck?.transcriptionStatus === 'skipped' || cancelCheck === null;
+
+      if (
+        !userCancelled &&
+        classification.shouldRetry &&
+        attempt < TRANSCRIBE_RETRY_DELAYS_MS.length
+      ) {
+        const delay = TRANSCRIBE_RETRY_DELAYS_MS[attempt] ?? 30_000;
+        console.error(
+          JSON.stringify({
+            event: 'transcription.retrying',
+            requestId,
+            storageId: args.storageId,
+            organizationId: args.organizationId,
+            attempt,
+            delayMs: delay,
+            errorClass: 'retryable',
+            errorCode: classification.reason,
+            errorMessage: sanitized,
+            errorStack: rawStack,
+          }),
+        );
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileTranscription,
+          {
+            storageId: args.storageId,
+            transcriptionStatus: 'queued',
+            transcriptionProgress: `retrying in ${Math.round(delay / 1000)}s`,
+          },
+        );
+        await ctx.scheduler.runAfter(
+          delay,
+          internal.file_metadata.transcribe_audio.transcribeAudio,
+          {
+            storageId: args.storageId,
+            fileName: args.fileName,
+            contentType: args.contentType,
+            organizationId: args.organizationId,
+            attempt: attempt + 1,
+          },
+        );
+        return null;
+      }
+
+      if (userCancelled) {
+        console.log(
+          JSON.stringify({
+            event: 'transcription.cancelled',
+            requestId,
+            storageId: args.storageId,
+            status: cancelCheck?.transcriptionStatus ?? 'row_missing',
+            attempt,
+            errorMessage: sanitized,
+          }),
+        );
+        return null;
+      }
+
+      console.error(
+        JSON.stringify({
+          event: 'transcription.failed',
+          requestId,
+          storageId: args.storageId,
+          organizationId: args.organizationId,
+          attempt,
+          latencyMs: Date.now() - startedAt,
+          errorClass: classification.shouldRetry ? 'retryable' : 'permanent',
+          errorCode: classification.reason,
+          errorMessage: sanitized,
+          errorStack: rawStack,
+        }),
+      );
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileTranscription,
+        {
+          storageId: args.storageId,
+          transcriptionStatus: 'failed',
+          transcriptionError: sanitized,
+          transcriptionProgress: '',
+        },
+      );
+      return null;
+    } finally {
+      if (compressed) {
+        await compressed.cleanup();
+      }
+      if (chunked) {
+        await chunked.cleanup();
+      }
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.releaseTranscriptionLock,
+        { storageId: args.storageId, runId: requestId },
+      );
+    }
   },
 });

--- a/services/platform/convex/file_metadata/transcribe_audio.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.ts
@@ -58,12 +58,52 @@ function whisperSegmentsToParagraphSegments(
 }
 
 /**
+ * The prose inside an error, for a field a person reads.
+ *
+ * A `ConvexError` carrying a structured payload stringifies its whole payload
+ * into `.message`, so the plain `err.message` path stored
+ * `{"code":"NO_TRANSCRIPTION_MODEL","message":"No transcription model is
+ * configured for this organization."}` — raw JSON — into `transcriptionError`.
+ * Prefer the payload's own `message` when there is one.
+ */
+function readableMessage(err: unknown): string {
+  if (err !== null && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data: unknown }).data;
+    if (typeof data === 'string' && data.length > 0) return data;
+    if (data !== null && typeof data === 'object' && 'message' in data) {
+      const message = (data as { message: unknown }).message;
+      if (typeof message === 'string' && message.length > 0) return message;
+    }
+  }
+  const base = err instanceof Error ? err.message : String(err);
+  // undici reports every transport failure as the bare string `fetch failed`
+  // and puts the actual reason (ENOTFOUND, ECONNREFUSED, a TLS error) on
+  // `cause`. Without it the row — and the operator reading it — cannot tell a
+  // DNS problem from a blocked egress from a dead endpoint.
+  const cause = err instanceof Error ? err.cause : undefined;
+  if (cause !== undefined && cause !== null) {
+    let detail: string;
+    if (cause instanceof Error) {
+      const code = 'code' in cause ? cause.code : undefined;
+      detail =
+        typeof code === 'string' ? `${code}: ${cause.message}` : cause.message;
+    } else {
+      detail = String(cause);
+    }
+    if (detail.length > 0 && !base.includes(detail)) {
+      return `${base} (${detail})`;
+    }
+  }
+  return base;
+}
+
+/**
  * Scrub secrets from error messages before they land in user-visible
  * `transcriptionError` or logs. Targets OpenAI-style tokens and generic
  * Authorization headers; truncates to 500 chars.
  */
 function sanitizeTranscriptionError(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
+  const raw = readableMessage(err);
   return (
     raw
       .replace(/Bearer\s+[A-Za-z0-9._-]+/g, 'Bearer [REDACTED]')

--- a/services/platform/convex/file_metadata/transcribe_dictation.ts
+++ b/services/platform/convex/file_metadata/transcribe_dictation.ts
@@ -4,98 +4,15 @@ import { ConvexError, v } from 'convex/values';
 
 import { TRANSCRIPTION_SLUG } from '../../lib/shared/constants/usage';
 import { internal } from '../_generated/api';
-import { action, type ActionCtx } from '../_generated/server';
+import { action } from '../_generated/server';
 import { estimateTranscriptionCostCents } from '../governance/cost_estimation';
 import { checkProviderHostPolicy } from '../lib/http/host_policy';
-import { getProviderCatalog } from '../lib/providers/catalog_fetch';
-import { resolveProvidersForOrgId } from '../lib/providers/org_providers';
+import { resolveTranscriptionModel } from '../lib/providers/resolve_transcription_model';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
-import { resolveProviderCredential } from '../provider_credentials/resolve_credential';
 import { requestTranscription } from './transcription_request';
 
 const TRANSCRIBE_API_TIMEOUT_MS = 60_000;
 const MAX_DICTATION_BYTES = 8 * 1024 * 1024;
-
-interface ResolvedTranscriptionModel {
-  readonly modelId: string;
-  readonly providerName: string;
-  readonly baseUrl: string;
-  readonly apiKey: string;
-}
-
-/**
- * Resolve the organization's transcription model against the provider world:
- * the first `transcription`-tagged catalog entry served by an active DIRECT
- * credential (api-key/env) — the same connector set and catalog the
- * composer's `listComposerModels` reads, and the same conditions that derive
- * its `voice.transcriptionAvailable` flag, so the dictation button's
- * availability signal and this resolver can never disagree. Mirrors
- * `convex/lib/providers/resolve_tts_model.ts`.
- *
- * Only `openai`-format connectors qualify: the transcription wire is the
- * OpenAI `/audio/transcriptions` shape, and the Anthropic Messages format
- * has no transcription endpoint at all.
- */
-async function resolveTranscriptionModel(
-  ctx: ActionCtx,
-  opts: { organizationId: string },
-): Promise<ResolvedTranscriptionModel> {
-  const providers = await resolveProvidersForOrgId(ctx, opts.organizationId);
-  for (const provider of providers) {
-    if (provider.apiFormat !== 'openai') continue;
-    let catalog;
-    try {
-      catalog = await getProviderCatalog(provider);
-    } catch (error) {
-      // One unreachable catalog must not blank dictation for the whole org.
-      console.warn(
-        `[dictation] could not resolve catalog for "${provider.name}"`,
-        error instanceof Error ? error.message : error,
-      );
-      continue;
-    }
-    const entry = catalog.find((candidate) =>
-      candidate.tags.includes('transcription'),
-    );
-    if (!entry) continue;
-
-    let credential;
-    try {
-      credential = await resolveProviderCredential(ctx, {
-        organizationId: opts.organizationId,
-        providerSlug: provider.name,
-      });
-    } catch (error) {
-      console.warn(
-        `[dictation] no usable credential for "${provider.name}"`,
-        error instanceof Error ? error.message : error,
-      );
-      continue;
-    }
-    // Transcription is a plain HTTP call — a subscription credential is
-    // bound to a vendor harness and cannot answer it.
-    if (
-      credential.authMethod !== 'api-key' &&
-      credential.authMethod !== 'env'
-    ) {
-      continue;
-    }
-    const baseUrl = credential.endpointUrl ?? provider.baseUrl;
-    if (!baseUrl) continue;
-
-    return {
-      modelId: entry.id,
-      providerName: provider.name,
-      baseUrl,
-      apiKey: credential.secret,
-    };
-  }
-
-  throw new ConvexError({
-    code: 'NO_TRANSCRIPTION_MODEL',
-    message: 'No transcription model is configured for this organization.',
-  });
-}
 
 /**
  * One-shot transcription for short dictation snippets recorded via

--- a/services/platform/convex/lib/errors/classify_transcription_error.test.ts
+++ b/services/platform/convex/lib/errors/classify_transcription_error.test.ts
@@ -1,0 +1,51 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it } from 'vitest';
+
+import { classifyTranscriptionError } from './classify_transcription_error';
+
+describe('classifyTranscriptionError', () => {
+  it('treats a missing transcription model as permanent', () => {
+    expect(
+      classifyTranscriptionError(
+        new ConvexError({
+          code: 'NO_TRANSCRIPTION_MODEL',
+          message:
+            'No transcription model is configured for this organization.',
+        }),
+      ),
+    ).toEqual({ shouldRetry: false, reason: 'no_transcription_model' });
+  });
+
+  it('marks auth and bad-request statuses as permanent', () => {
+    const auth: Error & { status?: number } = new Error('401');
+    auth.status = 401;
+    expect(classifyTranscriptionError(auth)).toEqual({
+      shouldRetry: false,
+      reason: 'auth_error',
+    });
+
+    const bad: Error & { status?: number } = new Error('bad');
+    bad.status = 400;
+    expect(classifyTranscriptionError(bad)).toEqual({
+      shouldRetry: false,
+      reason: 'bad_request',
+    });
+  });
+
+  it('retries rate limits, 5xx, and network failures', () => {
+    const rate: Error & { status?: number } = new Error('slow down');
+    rate.status = 429;
+    expect(classifyTranscriptionError(rate).shouldRetry).toBe(true);
+
+    const server: Error & { status?: number } = new Error('boom');
+    server.status = 503;
+    expect(classifyTranscriptionError(server)).toEqual({
+      shouldRetry: true,
+      reason: 'server_error',
+    });
+
+    expect(classifyTranscriptionError(new Error('fetch failed'))).toMatchObject(
+      { shouldRetry: true, reason: 'network_error' },
+    );
+  });
+});

--- a/services/platform/convex/lib/errors/classify_transcription_error.ts
+++ b/services/platform/convex/lib/errors/classify_transcription_error.ts
@@ -1,0 +1,87 @@
+/**
+ * Retry classification for the file-upload transcription pipeline.
+ * Kept next to the HTTP error helpers rather than resurrecting the retired
+ * chat-wide `error_classification` module — this surface only needs the
+ * status / message rules Whisper and OpenRouter actually return.
+ */
+
+export interface TranscriptionErrorClassification {
+  readonly shouldRetry: boolean;
+  readonly reason: string;
+}
+
+export function classifyTranscriptionError(
+  error: unknown,
+): TranscriptionErrorClassification {
+  const isObject = (val: unknown): val is Record<string, unknown> =>
+    val !== null && typeof val === 'object';
+
+  const err = isObject(error) ? error : {};
+  const data = isObject(err.data) ? err.data : undefined;
+  const message = (
+    typeof err.message === 'string' ? err.message : ''
+  ).toLowerCase();
+  const status =
+    typeof err.status === 'number'
+      ? err.status
+      : typeof err.statusCode === 'number'
+        ? err.statusCode
+        : undefined;
+  const code =
+    typeof err.code === 'string'
+      ? err.code
+      : typeof data?.code === 'string'
+        ? data.code
+        : undefined;
+
+  // No transcription model configured — permanent until an admin adds one.
+  if (code === 'NO_TRANSCRIPTION_MODEL') {
+    return { shouldRetry: false, reason: 'no_transcription_model' };
+  }
+
+  if (status === 401 || status === 403) {
+    return { shouldRetry: false, reason: 'auth_error' };
+  }
+  if (status === 400) {
+    return { shouldRetry: false, reason: 'bad_request' };
+  }
+  if (status === 404) {
+    return { shouldRetry: false, reason: 'not_found' };
+  }
+  if (
+    status === 402 ||
+    message.includes('more credits') ||
+    message.includes('can only afford') ||
+    (message.includes('credit') && message.includes('insufficient'))
+  ) {
+    return { shouldRetry: false, reason: 'credit_exhausted' };
+  }
+
+  if (status === 429 || message.includes('rate limit')) {
+    return { shouldRetry: true, reason: 'rate_limit' };
+  }
+  if (status !== undefined && status >= 500 && status < 600) {
+    return { shouldRetry: true, reason: 'server_error' };
+  }
+  if (
+    code === 'ECONNRESET' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ENOTFOUND' ||
+    code === 'ECONNREFUSED' ||
+    message.includes('network') ||
+    message.includes('connection') ||
+    message.includes('socket') ||
+    message.includes('fetch failed')
+  ) {
+    return { shouldRetry: true, reason: 'network_error' };
+  }
+  if (message.includes('timeout') || message.includes('timed out')) {
+    return { shouldRetry: true, reason: 'timeout' };
+  }
+  if (message.includes('overloaded') || message.includes('capacity')) {
+    return { shouldRetry: true, reason: 'overloaded' };
+  }
+
+  // Conservative default: retry unknown failures a few times.
+  return { shouldRetry: true, reason: 'unknown' };
+}

--- a/services/platform/convex/lib/providers/resolve_transcription_model.ts
+++ b/services/platform/convex/lib/providers/resolve_transcription_model.ts
@@ -1,0 +1,91 @@
+'use node';
+
+/**
+ * Resolve the organization's transcription model against the provider world:
+ * the first `transcription`-tagged catalog entry served by an active DIRECT
+ * credential (api-key/env) — the same connector set and catalog the
+ * composer's `listComposerModels` reads, and the same conditions that derive
+ * its `voice.transcriptionAvailable` flag, so the dictation button, the
+ * file-upload pipeline, and this resolver can never disagree.
+ *
+ * Only `openai`-format connectors qualify: the transcription wire is the
+ * OpenAI `/audio/transcriptions` shape, and the Anthropic Messages format
+ * has no transcription endpoint at all.
+ */
+
+import { ConvexError } from 'convex/values';
+
+import type { ActionCtx } from '../../_generated/server';
+import { resolveProviderCredential } from '../../provider_credentials/resolve_credential';
+import { getProviderCatalog } from './catalog_fetch';
+import { resolveProvidersForOrgId } from './org_providers';
+
+export interface ResolvedTranscriptionModel {
+  readonly modelId: string;
+  readonly providerName: string;
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  /** Request convention; absent ⇒ `multipart` (OpenAI Whisper-compatible). */
+  readonly transcriptionMode?: 'multipart' | 'json-base64';
+}
+
+export async function resolveTranscriptionModel(
+  ctx: ActionCtx,
+  opts: { organizationId: string },
+): Promise<ResolvedTranscriptionModel> {
+  const providers = await resolveProvidersForOrgId(ctx, opts.organizationId);
+  for (const provider of providers) {
+    if (provider.apiFormat !== 'openai') continue;
+    let catalog;
+    try {
+      catalog = await getProviderCatalog(provider);
+    } catch (error) {
+      // One unreachable catalog must not blank transcription for the whole org.
+      console.warn(
+        `[transcription] could not resolve catalog for "${provider.name}"`,
+        error instanceof Error ? error.message : error,
+      );
+      continue;
+    }
+    const entry = catalog.find((candidate) =>
+      candidate.tags.includes('transcription'),
+    );
+    if (!entry) continue;
+
+    let credential;
+    try {
+      credential = await resolveProviderCredential(ctx, {
+        organizationId: opts.organizationId,
+        providerSlug: provider.name,
+      });
+    } catch (error) {
+      console.warn(
+        `[transcription] no usable credential for "${provider.name}"`,
+        error instanceof Error ? error.message : error,
+      );
+      continue;
+    }
+    // Transcription is a plain HTTP call — a subscription credential is
+    // bound to a vendor harness and cannot answer it.
+    if (
+      credential.authMethod !== 'api-key' &&
+      credential.authMethod !== 'env'
+    ) {
+      continue;
+    }
+    const baseUrl = credential.endpointUrl ?? provider.baseUrl;
+    if (!baseUrl) continue;
+
+    return {
+      modelId: entry.id,
+      providerName: provider.name,
+      baseUrl,
+      apiKey: credential.secret,
+    };
+  }
+
+  throw new ConvexError({
+    code: 'NO_TRANSCRIPTION_MODEL',
+    message: 'No transcription model is configured for this organization.',
+  });
+}

--- a/services/platform/lib/chat/audio-transcript.test.ts
+++ b/services/platform/lib/chat/audio-transcript.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAudioTranscriptAppendix } from './audio-transcript';
+
+describe('buildAudioTranscriptAppendix', () => {
+  it('returns empty string when nothing is staged', () => {
+    expect(buildAudioTranscriptAppendix([])).toBe('');
+  });
+
+  it('formats a completed transcript with duration', () => {
+    expect(
+      buildAudioTranscriptAppendix([
+        {
+          fileName: 'meeting.mp3',
+          status: 'completed',
+          transcript: 'Hello world',
+          durationSec: 12.34,
+        },
+      ]),
+    ).toBe(
+      '\n\n---\n**Audio transcript: meeting.mp3** (12.3s)\n\nHello world\n---\n',
+    );
+  });
+
+  it('omits the duration note when duration is absent', () => {
+    expect(
+      buildAudioTranscriptAppendix([
+        {
+          fileName: 'clip.wav',
+          status: 'completed',
+          transcript: 'hi',
+        },
+      ]),
+    ).toBe('\n\n---\n**Audio transcript: clip.wav**\n\nhi\n---\n');
+  });
+
+  it('marks skipped and failed rows without inventing a transcript', () => {
+    expect(
+      buildAudioTranscriptAppendix([
+        { fileName: 'a.mp3', status: 'skipped' },
+        {
+          fileName: 'b.mp3',
+          status: 'failed',
+          error: 'provider down',
+        },
+        { fileName: 'c.mp3', status: 'running' },
+      ]),
+    ).toBe(
+      '\n\n[Audio file "a.mp3" could not be transcribed: skipped]\n' +
+        '\n\n[Audio file "b.mp3" could not be transcribed: provider down]\n' +
+        '\n\n[Audio file "c.mp3" could not be transcribed: transcription incomplete]\n',
+    );
+  });
+
+  it('treats a completed row with an empty transcript as incomplete', () => {
+    expect(
+      buildAudioTranscriptAppendix([
+        { fileName: 'empty.mp3', status: 'completed', transcript: '' },
+      ]),
+    ).toBe(
+      '\n\n[Audio file "empty.mp3" could not be transcribed: transcription incomplete]\n',
+    );
+  });
+});

--- a/services/platform/lib/chat/audio-transcript.ts
+++ b/services/platform/lib/chat/audio-transcript.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure formatting for the audio/video transcript appendix the chat turn
+ * injects into the user message. The host loads `fileMetadata` and hands
+ * the rows here; this module never touches Convex.
+ */
+
+export interface AudioTranscriptEntry {
+  readonly fileName: string;
+  readonly status?: 'queued' | 'running' | 'completed' | 'failed' | 'skipped';
+  readonly transcript?: string;
+  readonly durationSec?: number;
+  readonly error?: string;
+}
+
+/**
+ * Build the markdown appendix for one or more audio/video attachments.
+ * Empty input → empty string (caller leaves `userText` untouched).
+ * Completed rows carry the transcript; everything else gets a marker so
+ * the model still knows a file was attached.
+ */
+export function buildAudioTranscriptAppendix(
+  entries: readonly AudioTranscriptEntry[],
+): string {
+  if (entries.length === 0) return '';
+
+  const pieces: string[] = [];
+  for (const entry of entries) {
+    if (
+      entry.status === 'completed' &&
+      entry.transcript !== undefined &&
+      entry.transcript.length > 0
+    ) {
+      const durationNote =
+        entry.durationSec !== undefined
+          ? ` (${entry.durationSec.toFixed(1)}s)`
+          : '';
+      pieces.push(
+        `\n\n---\n**Audio transcript: ${entry.fileName}**${durationNote}\n\n${entry.transcript}\n---\n`,
+      );
+    } else {
+      const reason =
+        entry.status === 'skipped'
+          ? 'skipped'
+          : (entry.error ?? 'transcription incomplete');
+      pieces.push(
+        `\n\n[Audio file "${entry.fileName}" could not be transcribed: ${reason}]\n`,
+      );
+    }
+  }
+  return pieces.join('');
+}

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -372,9 +372,73 @@ export function getDisplayExtension(filename: string): string {
 // Accept strings (for <input accept="..."> and drop zones)
 // ---------------------------------------------------------------------------
 
+/** Composer attachment input: images + audio + video.
+ * Documents stay out of the chat lane (Knowledge owns them); audio/video
+ * ride the transcription pipeline and become text on the turn. `audio/*`
+ * and `video/*` cover most browsers but some file pickers filter strictly
+ * by extension, so we append the explicit list too. */
+export const COMPOSER_MEDIA_UPLOAD_ACCEPT = [
+  'image/*',
+  'audio/*',
+  'video/*',
+  // Images (explicit — some pickers ignore `image/*`)
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  // Audio
+  '.mp3',
+  '.m4a',
+  '.wav',
+  '.ogg',
+  '.oga',
+  '.mpga',
+  // Video / mixed containers (.mp4/.webm may be audio or video — browser
+  // MIME wins when present; otherwise we assume video since that's what
+  // meeting recordings are)
+  '.mp4',
+  '.m4v',
+  '.mov',
+  '.qt',
+  '.webm',
+  '.mkv',
+  '.avi',
+  '.mpeg',
+  '.mpg',
+  '.ogv',
+  '.3gp',
+  '.3g2',
+  '.ts',
+  '.m2ts',
+].join(',');
+
+/** Composer upload MIME validation list: images + audio + video. */
+export const COMPOSER_MEDIA_UPLOAD_ALLOWED_TYPES: readonly string[] = [
+  MIME_TYPES.JPEG,
+  MIME_TYPES.PNG,
+  MIME_TYPES.GIF,
+  MIME_TYPES.WEBP,
+  MIME_TYPES.MP3,
+  MIME_TYPES.WAV,
+  MIME_TYPES.M4A,
+  MIME_TYPES.WEBM_AUDIO,
+  MIME_TYPES.OGG,
+  MIME_TYPES.VIDEO_MP4,
+  MIME_TYPES.VIDEO_WEBM,
+  MIME_TYPES.VIDEO_QUICKTIME,
+  MIME_TYPES.VIDEO_MATROSKA,
+  MIME_TYPES.VIDEO_AVI,
+  MIME_TYPES.VIDEO_M4V,
+  MIME_TYPES.VIDEO_MPEG,
+  MIME_TYPES.VIDEO_OGG,
+  MIME_TYPES.VIDEO_3GP,
+  MIME_TYPES.VIDEO_MP2T,
+];
+
 /** Chat attachment input: images + documents + text-based files + audio + video.
- * `audio/*` and `video/*` cover most browsers but some file pickers filter
- * strictly by extension, so we append the explicit list too. */
+ * Broader than {@link COMPOSER_MEDIA_UPLOAD_ACCEPT} — retained for policy
+ * surfaces and legacy callers that still accept documents in chat uploads. */
 export const CHAT_UPLOAD_ACCEPT = [
   TEXT_FILE_ACCEPT,
   'audio/*',

--- a/services/platform/lib/shared/schemas/shipped-models.test.ts
+++ b/services/platform/lib/shared/schemas/shipped-models.test.ts
@@ -100,15 +100,21 @@ describe('shipped model catalogs', () => {
     },
   );
 
-  it('gives a transcription model to every provider that can serve one', () => {
-    // Transcription is an OpenAI-wire capability: `resolveTranscriptionModel`
-    // skips non-`openai` apiFormat connectors outright, so a transcription tag
-    // on one of those would be dead weight rather than a working option.
-    const transcribers = ALL_ENTRIES.filter(({ entry }) =>
-      entry.tags.includes('transcription'),
-    ).map(({ provider }) => provider);
+  it('only tags transcription on a provider that can actually serve it', () => {
+    // Measured against the live APIs, not assumed. OpenRouter routes
+    // `/audio/transcriptions` and even validates the model id, but with a
+    // valid funded key (chat returns 200) both `whisper-1` and
+    // `openai/whisper-1` come back `401 Provider returned 401` — its upstream
+    // refuses without BYOK, and its listing publishes no whisper model at all.
+    // Tagging it there would turn an honest "no transcription model
+    // configured" into a misleading auth error pointing at the user's key.
+    const transcribers = new Set(
+      ALL_ENTRIES.filter(({ entry }) =>
+        entry.tags.includes('transcription'),
+      ).map(({ provider }) => provider),
+    );
     expect(transcribers).toContain('openai');
-    expect(transcribers).toContain('openrouter');
+    expect(transcribers).not.toContain('openrouter');
   });
 
   it('keeps transcription entries free of per-token pricing', () => {

--- a/services/platform/lib/shared/schemas/shipped-models.test.ts
+++ b/services/platform/lib/shared/schemas/shipped-models.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The shipped model catalogs are valid, and every capability the app can
+ * resolve has a model declaring it.
+ *
+ * This walks every `configs/platform/system/models/<provider>/models.yml` and
+ * proves what the resolvers rely on: each file satisfies the catalog schema,
+ * every entry's `provider` matches its directory, and — the part that bites —
+ * each capability tag a resolver searches for is declared by at least one
+ * entry.
+ *
+ * That last check exists because it was missing: audio transcription shipped
+ * with a complete pipeline (compress → chunk → Whisper → ledger), a settings
+ * capability label, and a resolver looking for a `transcription`-tagged
+ * entry — while NO shipped catalog declared one. Every upload failed
+ * `NO_TRANSCRIPTION_MODEL` on a stock install, and nothing in the suite
+ * noticed, because a resolver that can never resolve still type-checks and
+ * its own unit tests pass against a mocked catalog.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseYaml } from '../config/yaml';
+import { modelCatalogFileSchema } from './providers';
+
+const MODELS_DIR = path.join(
+  path.dirname(new URL(import.meta.url).pathname),
+  '../../../../../configs/platform/system/models',
+);
+
+/**
+ * Capability tags a resolver looks up, and what breaks when none is declared.
+ * A tag here without a shipped entry is a feature that cannot work on a stock
+ * install — add the model, or drop the resolver.
+ */
+const RESOLVED_CAPABILITIES: Array<{ tag: string; resolver: string }> = [
+  { tag: 'chat', resolver: 'the composer model listing' },
+  { tag: 'embedding', resolver: 'knowledge indexing (one-click setup)' },
+  { tag: 'text-to-speech', resolver: 'resolve_tts_model (read replies aloud)' },
+  {
+    tag: 'transcription',
+    resolver: 'resolve_transcription_model (dictation + audio attachments)',
+  },
+];
+
+function providerDirs(): string[] {
+  return readdirSync(MODELS_DIR)
+    .filter((name) => statSync(path.join(MODELS_DIR, name)).isDirectory())
+    .sort();
+}
+
+function catalogOf(provider: string) {
+  const file = path.join(MODELS_DIR, provider, 'models.yml');
+  // These files are sequence-rooted, which the default mapping-only parse
+  // rejects — the loader passes the same flag.
+  const parsed = parseYaml(readFileSync(file, 'utf8'), {
+    allowArrayRoot: true,
+  });
+  if (!parsed.ok) throw new Error(`${file}: ${parsed.error}`);
+  return modelCatalogFileSchema.parse(parsed.data);
+}
+
+const ALL_ENTRIES = providerDirs().flatMap((provider) =>
+  catalogOf(provider).map((entry) => ({ provider, entry })),
+);
+
+describe('shipped model catalogs', () => {
+  it('ships at least one catalog', () => {
+    // A glob that silently matched nothing would make every check below pass.
+    expect(providerDirs().length).toBeGreaterThan(0);
+    expect(ALL_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it.each(providerDirs())('%s/models.yml satisfies the schema', (provider) => {
+    expect(() => catalogOf(provider)).not.toThrow();
+  });
+
+  it.each(providerDirs())(
+    '%s entries claim the provider whose directory they sit in',
+    (provider) => {
+      // A mismatched `provider` makes an entry unreachable: resolvers walk the
+      // org's providers and read each one's own catalog.
+      for (const entry of catalogOf(provider)) {
+        expect(entry.provider).toBe(provider);
+      }
+    },
+  );
+
+  it.each(RESOLVED_CAPABILITIES)(
+    'declares a $tag model, without which $resolver cannot resolve',
+    ({ tag }) => {
+      const declaring = ALL_ENTRIES.filter(({ entry }) =>
+        entry.tags.includes(tag),
+      );
+      expect(
+        declaring.map(({ provider, entry }) => `${provider}:${entry.id}`),
+      ).not.toEqual([]);
+    },
+  );
+
+  it('gives a transcription model to every provider that can serve one', () => {
+    // Transcription is an OpenAI-wire capability: `resolveTranscriptionModel`
+    // skips non-`openai` apiFormat connectors outright, so a transcription tag
+    // on one of those would be dead weight rather than a working option.
+    const transcribers = ALL_ENTRIES.filter(({ entry }) =>
+      entry.tags.includes('transcription'),
+    ).map(({ provider }) => provider);
+    expect(transcribers).toContain('openai');
+    expect(transcribers).toContain('openrouter');
+  });
+
+  it('keeps transcription entries free of per-token pricing', () => {
+    // Transcription is billed per audio minute. A per-token price here would
+    // be read as a token cost by the usage ledger and quietly misreport spend.
+    for (const { entry } of ALL_ENTRIES) {
+      if (!entry.tags.includes('transcription')) continue;
+      expect(entry.pricing).toBeUndefined();
+    }
+  });
+});

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1141,8 +1141,13 @@ chat:
     video: VIDEO
     file: DATEI
   transcription:
+    inProgressTooltip: Transkribiere Audio…
+    transcribing: Transkribiere…
+    transcribed: Transkribiert
+    couldNotTranscribe: Konnte nicht transkribiert werden
     viewTranscript: Transkript anzeigen
     previewSubtitle: '{seconds}s transkribiert'
+    retry: Erneut versuchen
   videoLink:
     statuses:
       attemptNumber: Versuch {n}

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1099,8 +1099,13 @@ chat:
     video: VIDEO
     file: FILE
   transcription:
+    inProgressTooltip: Transcribing audio…
+    transcribing: Transcribing…
+    transcribed: Transcribed
+    couldNotTranscribe: Could not be transcribed
     viewTranscript: View transcript
     previewSubtitle: '{seconds}s transcribed'
+    retry: Try again
   videoLink:
     statuses:
       attemptNumber: Attempt {n}

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1141,8 +1141,13 @@ chat:
     video: VIDÉO
     file: FICHIER
   transcription:
+    inProgressTooltip: Transcription de l'audio en cours…
+    transcribing: Transcription en cours…
+    transcribed: Transcrit
+    couldNotTranscribe: N'a pas pu être transcrit
     viewTranscript: Voir la transcription
     previewSubtitle: '{seconds}s transcrites'
+    retry: Réessayer
   videoLink:
     statuses:
       attemptNumber: Tentative {n}


### PR DESCRIPTION
Audio and video staged in the composer went nowhere: `transcribeAudio` was a stub that marked every upload failed. `audio_preprocess.ts` (ffmpeg compress + chunk) was already in the tree with no callers, and ffmpeg is already in the convex image — the orchestration and the surface around it were missing.

**Two things were broken, and only the first was obvious.** The pipeline was stubbed, *and* no shipped catalog declared a `transcription`-tagged model — so even a complete pipeline could not run on any deployment. `resolveTranscriptionModel` searches for that tag, found nothing, and every upload failed `NO_TRANSCRIPTION_MODEL` before compressing a byte. Verified against a local deployment: real clips had failed exactly that way.

## What runs now

`transcribeAudio` reads the blob from whichever backend owns it (Convex `_storage`, or the org's own bucket for BYO-S3), compresses to 32 kbps Opus mono 16 kHz with long silences collapsed, splits into 90-minute chunks by stream-copy when the compressed output still exceeds the provider's 25 MB limit, transcribes each chunk, and joins the parts into paragraphs.

Guards, in order:

| Guard | Prevents |
| --- | --- |
| Cancellation pre-check | Work continuing after the user removed the attachment |
| Single-flight lease | A double retry billing the provider twice |
| Content-hash dedup | Re-uploading the same file paying for it again |
| Retry classification | A bad key burning three calls; a 429 giving up on the first |
| `finally` release + cleanup | A row stuck at `running`, temp files left in `/tmp` |

Transient failures (429, 5xx, network) retry with `[30s, 60s, 120s]` backoff; permanent ones (auth, bad request, no model) fail fast. Every exit writes a terminal status — callers schedule this fire-and-forget, so a bare throw would strand the row and the send gate with it.

## The catalog half

The capability existed everywhere except the catalog: a settings label, a resolver, a usage-ledger slug, and dictation's `notConfigured` copy all reference transcription, but no model offered it. Same shape as the embedding widths and TTS voices, which the shipped files *do* carry precisely because a live listing never publishes them.

`openai` gets `whisper-1` — not the `gpt-4o-transcribe` family, because the request asks for `verbose_json` and the paragraphizer needs the per-segment timestamps only whisper returns. No pricing: transcription is billed per audio minute, which the per-token schema cannot express, so the ledger records minutes at a zero cost estimate.

**OpenRouter deliberately gets nothing**, measured rather than assumed. It routes `/audio/transcriptions` and validates the model id (`whisper-1` is recognised; `verbose_json` draws a specific 400), but every request that passes validation returns `401 Provider returned 401` — for both `whisper-1` and `openai/whisper-1` — while the same key returns 200 on `/chat/completions`. Its upstream refuses without BYOK and its listing publishes no whisper model. Tagging it would trade an honest "no transcription model is configured" for an auth error pointing at the user's key, which is wrong and unactionable.

`shipped-models.test.ts` is the guard that was missing. It walks every shipped catalog and fails when a capability a resolver searches for has no model declaring it — it goes red against the tree as it stands today, which is what should have blocked the first commit here. It also fails if the OpenRouter transcription tag reappears.

## Chat and composer

A turn carrying audio appends the transcript as **text**; the model never receives media bytes. The composer accepts audio/video, renders a per-file chip with live progress (`transcribing chunk 2 of 3`) and a retry when transcription failed, and holds send until every clip has settled — the turn injects the transcript, so a send that beat it would reach the model with a marker instead of the words the user attached.

## Refactor

The provider resolver moves out of `transcribe_dictation.ts` into `lib/providers/resolve_transcription_model.ts`, shared by dictation and attachment transcription so the two cannot disagree. Diffed line by line against the original: behaviour identical, only the log tag widens.

## Three failures made legible

All three cost real diagnosis time on the local run:

- a `ConvexError` payload stringifies into `.message`, so the row stored `{"code":"NO_TRANSCRIPTION_MODEL","message":"…"}` — raw JSON — in a field a person reads;
- `Authorization: Basic <base64>` had only its scheme redacted, leaving the credential in that same field;
- undici reports every transport failure as the bare string `fetch failed` and puts the reason on `cause`, so a row could not distinguish bad DNS from blocked egress from a dead endpoint.

## Observed, and what is not

Against a local deployment: the resolver resolves, ffmpeg compresses a real 2.1 MB clip in ~5s, the request reaches the provider, and the response is classified correctly (`auth_error`, permanent, no wasted retries) and written to the row. The provider walk is observable too — it skips `openai` for want of a credential and moves on, exactly as intended.

**Not observed: a successful transcription.** That deployment has only an OpenRouter credential, and OpenRouter cannot serve the endpoint (above). Completing the final hop needs an OpenAI-format credential, which no reviewer should assume has been exercised here.

## Tests

- `transcribe_audio.test.ts` (38) — every short-circuit, chunking and joining, both blob backends, retry vs fail-fast, cleanup and lease release on throwing paths, one case per redaction rule, and the error-legibility fixes.
- `shipped-models.test.ts` (25) — catalog validity plus capability coverage.
- `use-file-transcription-status.test.ts` (10) — what the send gate is computed from.
- `chat-surface.test.tsx` (+3) — send held while transcribing, held while status unknown, released once settled.
- `classify_transcription_error.test.ts`, `audio-transcript.test.ts` — classification and appendix formatting.

Every assertion was verified by mutation: breaking the corresponding line fails the test. Four initially passed against broken code and were rewritten — the secret-scrubbing case (a second rule masked the first), the send gate (asserted through a mocked hook), and the capability guard (shown red against the current tree, then shown red again with the OpenRouter tag restored).

Gate: typecheck, `oxlint --type-aware`, `oxfmt --check`, SAST 0 findings, 74,182 server + 3,012 UI + 194 docs tests green.

## Not in scope

Transcript RAG indexing. `transcriptRagStatus`/`transcriptRagError` stay unset and `indexFileBlob` still rejects audio as unsupported, so a clip is readable in the turn it rides but not citable by `rag_search` later.

A path for OpenRouter-only organizations. OpenRouter publishes 25 audio-**input** chat models, so transcription there would mean a `/chat/completions` turn with an `input_audio` part rather than the transcription endpoint. `requestTranscription` already has a `json-base64` mode but still posts to `/audio/transcriptions`, so this is real work, not a flag.

Known rough edge: a `NO_TRANSCRIPTION_MODEL` failure still shows a generic "Could not be transcribed" chip with a "Try again" that cannot succeed, where the RAG surface would guide the admin to settings. Fixing it properly needs an error *code* on the row (a schema change plus migration), so it is deliberately separate.

One thing worth a second opinion: the transcript is appended to the user text without an untrusted-content wrapper. It is the user's own attachment, matching how pasted text is treated — but a meeting recording carries a third party's speech, which is the one case where the framing could matter.