### PR TITLE
fix(platform): resolve pack model ids across catalog dialects

### DIFF
--- a/services/platform/app/features/automations/components/automation-detail.test.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ActiveEditorProvider } from '@/app/components/ui/editor';
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render, screen, waitFor } from '@/tests/utils/render';
+import { render, screen, waitFor, within } from '@/tests/utils/render';
 
 /**
  * The automation page is an editor: its draft lives in the browser and a save
@@ -196,6 +196,27 @@ describe('AutomationDetail', () => {
       },
       expect.any(Object),
     );
+  });
+
+  it('closes the Run live confirm as soon as the run is started', async () => {
+    // startRun only schedules the run — a later LIVE_BODY_FAILED is a run
+    // outcome, not a start refusal. Waiting on the mutation would leave the
+    // dialog stuck open after a failed live fetch.
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: 'Run live' }));
+    const dialog = screen.getByRole('dialog', { name: 'Run live?' });
+    expect(dialog).toBeVisible();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Run live' }));
+    expect(startRun.mutate).toHaveBeenCalledWith(
+      {
+        organizationId: 'org-1',
+        name: 'billing/dunning',
+        mode: 'live',
+      },
+      expect.any(Object),
+    );
+    expect(screen.queryByRole('dialog', { name: 'Run live?' })).toBeNull();
   });
 
   it('arms the shared cluster as soon as a node is edited', async () => {

--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -591,6 +591,10 @@ export function AutomationDetail({
         confirmText={t('detail.runLive')}
         onConfirm={() => {
           setRefusal(null);
+          // Close before the mutation settles: startRun only schedules the
+          // run — a later LIVE_BODY_FAILED is a run outcome, not a start
+          // refusal, so waiting on it would leave this dialog stuck open.
+          setConfirmLiveRun(false);
           startRun.mutate(
             { organizationId, name: automationSlug, mode: 'live' },
             {

--- a/services/platform/convex/automations/llm_call.test.ts
+++ b/services/platform/convex/automations/llm_call.test.ts
@@ -148,6 +148,88 @@ describe('automationLlmCall', () => {
     ).rejects.toThrow(/no configured provider serves model "vendor\/small-1"/);
   });
 
+  it('serves a pack model id via OpenRouter catalog spelling on the wire', async () => {
+    // Packs / Tale static catalog use hyphen minors; OpenRouter lists dots.
+    resolveConnectors.mockResolvedValue([{ name: 'openrouter' }]);
+    credentials = { openrouter: DIRECT };
+    getProviderCatalog.mockResolvedValue([
+      { id: 'anthropic/claude-haiku-4.5' },
+    ]);
+
+    await automationLlmCall(
+      ctx,
+      ORG,
+    )({
+      model: 'anthropic/claude-haiku-4-5',
+      prompt: 'Triage.',
+    });
+
+    expect(createBuilderModel).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        target: {
+          providerSlug: 'openrouter',
+          modelId: 'anthropic/claude-haiku-4.5',
+        },
+      }),
+    );
+  });
+
+  it('serves a pack model id via Anthropic bare catalog id on the wire', async () => {
+    resolveConnectors.mockResolvedValue([{ name: 'anthropic' }]);
+    credentials = { anthropic: DIRECT };
+    getProviderCatalog.mockResolvedValue([{ id: 'claude-haiku-4-5' }]);
+
+    await automationLlmCall(
+      ctx,
+      ORG,
+    )({
+      model: 'anthropic/claude-haiku-4-5',
+      prompt: 'Triage.',
+    });
+
+    expect(createBuilderModel).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        target: {
+          providerSlug: 'anthropic',
+          modelId: 'claude-haiku-4-5',
+        },
+      }),
+    );
+  });
+
+  it('honors an allowlist written in the catalog dialect when the pack uses Tale form', async () => {
+    resolveConnectors.mockResolvedValue([{ name: 'openrouter' }]);
+    credentials = {
+      openrouter: {
+        ...DIRECT,
+        modelAllowlist: ['anthropic/claude-haiku-4.5'],
+      },
+    };
+    getProviderCatalog.mockResolvedValue([
+      { id: 'anthropic/claude-haiku-4.5' },
+    ]);
+
+    await automationLlmCall(
+      ctx,
+      ORG,
+    )({
+      model: 'anthropic/claude-haiku-4-5',
+      prompt: 'Triage.',
+    });
+
+    expect(createBuilderModel).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        target: {
+          providerSlug: 'openrouter',
+          modelId: 'anthropic/claude-haiku-4.5',
+        },
+      }),
+    );
+  });
+
   it('says so when the only catalogs were unreachable', async () => {
     credentials = { first: DIRECT, second: DIRECT };
     getProviderCatalog.mockRejectedValue(new Error('models endpoint 500'));

--- a/services/platform/convex/automations/llm_call.ts
+++ b/services/platform/convex/automations/llm_call.ts
@@ -28,6 +28,10 @@ import type {
   BuilderModel,
 } from '../../lib/automations_builder/session';
 import type { ModelCatalogEntry } from '../../lib/shared/schemas/providers';
+import {
+  modelAllowlistPermits,
+  modelIdsEquivalent,
+} from '../../lib/shared/utils/model-ref';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import {
@@ -74,6 +78,12 @@ function describe(error: unknown): string {
  * unreachable catalog skips the connector rather than failing the node —
  * unless nothing else serves the model, in which case the failure names it.
  *
+ * Catalog match is by {@link modelIdsEquivalent}: packs name Tale's static
+ * form (`anthropic/claude-haiku-4-5`) while OpenRouter lists
+ * `anthropic/claude-haiku-4.5` and Anthropic's static catalog lists the bare
+ * `claude-haiku-4-5`. The returned `modelId` is the catalog entry's id — the
+ * spelling the serving connector accepts on the wire — not the pack's.
+ *
  * Exported for the agent host: an `agent` node names its model with the same
  * explicitness as an `llm` node, and its gateway key must be scoped to the
  * same serving connector this scan finds.
@@ -92,10 +102,7 @@ export async function resolveServingTarget(
     );
     const credential = directActiveCredential(row);
     if (credential === null) continue;
-    if (
-      credential.modelAllowlist !== undefined &&
-      !credential.modelAllowlist.includes(modelId)
-    ) {
+    if (!modelAllowlistPermits(credential.modelAllowlist, modelId)) {
       continue;
     }
     let catalog: readonly ModelCatalogEntry[];
@@ -109,8 +116,11 @@ export async function resolveServingTarget(
       unreachable.push(connector.name);
       continue;
     }
-    if (catalog.some((entry) => entry.id === modelId)) {
-      return { providerSlug: connector.name, modelId };
+    const entry =
+      catalog.find((candidate) => candidate.id === modelId) ??
+      catalog.find((candidate) => modelIdsEquivalent(candidate.id, modelId));
+    if (entry !== undefined) {
+      return { providerSlug: connector.name, modelId: entry.id };
     }
   }
   const detail =

--- a/services/platform/lib/shared/utils/model-ref.test.ts
+++ b/services/platform/lib/shared/utils/model-ref.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect } from 'vitest';
 import {
   formatModelRef,
   isValidModelRef,
+  modelAllowlistPermits,
+  modelIdMatchKey,
+  modelIdsEquivalent,
   parseModelRef,
   stripModelRefQualifier,
   stripProviderPrefix,
@@ -295,5 +298,78 @@ describe('stripProviderPrefix (capability family key)', () => {
     expect(stripProviderPrefix('bedrock:anthropic.claude-v2:0')).toBe(
       'bedrock:anthropic.claude-v2:0',
     );
+  });
+});
+
+describe('modelIdMatchKey / modelIdsEquivalent', () => {
+  it('equates Tale hyphen minors with OpenRouter dotted minors', () => {
+    expect(modelIdMatchKey('anthropic/claude-haiku-4-5')).toBe(
+      'claude-haiku-4.5',
+    );
+    expect(
+      modelIdsEquivalent(
+        'anthropic/claude-haiku-4-5',
+        'anthropic/claude-haiku-4.5',
+      ),
+    ).toBe(true);
+  });
+
+  it('equates a vendor-prefixed id with the bare Anthropic catalog id', () => {
+    expect(
+      modelIdsEquivalent('anthropic/claude-haiku-4-5', 'claude-haiku-4-5'),
+    ).toBe(true);
+  });
+
+  it('equates mid-version Claude spellings (3-5 ↔ 3.5)', () => {
+    expect(
+      modelIdsEquivalent('anthropic/claude-3-5-sonnet', 'claude-3.5-sonnet'),
+    ).toBe(true);
+  });
+
+  it('does not collapse dated Anthropic stamps into a minor version', () => {
+    expect(modelIdMatchKey('claude-sonnet-4-20250514')).toBe(
+      'claude-sonnet-4-20250514',
+    );
+    expect(
+      modelIdsEquivalent(
+        'claude-sonnet-4-20250514',
+        'claude-sonnet-4.20250514',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not equate unrelated models', () => {
+    expect(
+      modelIdsEquivalent(
+        'anthropic/claude-haiku-4-5',
+        'anthropic/claude-sonnet-4-5',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('modelAllowlistPermits', () => {
+  it('permits every model when the allowlist is unset', () => {
+    expect(modelAllowlistPermits(undefined, 'anthropic/claude-haiku-4-5')).toBe(
+      true,
+    );
+  });
+
+  it('permits an equivalent spelling of an allowlisted id', () => {
+    expect(
+      modelAllowlistPermits(
+        ['anthropic/claude-haiku-4.5'],
+        'anthropic/claude-haiku-4-5',
+      ),
+    ).toBe(true);
+  });
+
+  it('refuses a model that is not on the allowlist', () => {
+    expect(
+      modelAllowlistPermits(
+        ['anthropic/claude-sonnet-4.5'],
+        'anthropic/claude-haiku-4-5',
+      ),
+    ).toBe(false);
   });
 });

--- a/services/platform/lib/shared/utils/model-ref.ts
+++ b/services/platform/lib/shared/utils/model-ref.ts
@@ -118,3 +118,46 @@ export function stripProviderPrefix(modelId: string): string {
   const bare = slash >= 0 ? id.slice(slash + 1) : id;
   return bare.toLowerCase();
 }
+
+/**
+ * Collapse Claude-style major/minor spelling so catalogs that disagree on
+ * separators still resolve to one model:
+ * - `claude-3-5-sonnet` ↔ `claude-3.5-sonnet` (mid-version)
+ * - `claude-haiku-4-5` ↔ `claude-haiku-4.5` (trailing minor; single digit,
+ *   so dated stamps like `…-4-20250514` stay intact)
+ */
+function normalizeVersionSeparators(bareModelId: string): string {
+  return bareModelId
+    .replace(/(\d+)-(\d+)(?=-)/g, '$1.$2')
+    .replace(/-(\d+)-(\d)$/g, '-$1.$2');
+}
+
+/**
+ * Comparison key for "same model across provider id dialects": strip the
+ * vendor slash prefix, lowercase, and normalize Claude minor-version dots
+ * vs hyphens. Used when a pack/workflow names Tale's static catalog form
+ * (`anthropic/claude-haiku-4-5`) but OpenRouter lists `anthropic/claude-haiku-4.5`,
+ * or Anthropic's static catalog lists the bare `claude-haiku-4-5`.
+ */
+export function modelIdMatchKey(modelId: string): string {
+  return normalizeVersionSeparators(stripProviderPrefix(modelId));
+}
+
+/** True when two ids name the same model under {@link modelIdMatchKey}. */
+export function modelIdsEquivalent(a: string, b: string): boolean {
+  return modelIdMatchKey(a) === modelIdMatchKey(b);
+}
+
+/**
+ * Whether a credential allowlist admits `modelId`. Exact string match first;
+ * otherwise any allowlist entry that is equivalent under {@link modelIdsEquivalent}.
+ * An undefined allowlist means every catalog model is permitted.
+ */
+export function modelAllowlistPermits(
+  allowlist: readonly string[] | undefined,
+  modelId: string,
+): boolean {
+  if (allowlist === undefined) return true;
+  if (allowlist.includes(modelId)) return true;
+  return allowlist.some((entry) => modelIdsEquivalent(entry, modelId));
+}


### PR DESCRIPTION
## Summary
- Treat Claude minor-version hyphen/dot spellings and vendor-prefixed vs bare catalog ids as the same model when resolving which connector serves an automation `llm`/`agent` node; return the **catalog** id on the wire.
- Honor credential allowlists against equivalent spellings (OpenRouter dotted allowlist admits Tale hyphen pack ids).
- Close the automation **Run live?** confirm as soon as `startRun` is invoked — a later `LIVE_BODY_FAILED` is a run outcome, not a start refusal.

## Test plan
- [ ] `bun run --filter @tale/platform test -- lib/shared/utils/model-ref.test.ts convex/automations/llm_call.test.ts`
- [ ] `bun run --filter @tale/platform test -- app/features/automations/components/automation-detail.test.tsx`
- [ ] Live: run `imap-smtp/triage-inbox` (or any pack using `anthropic/claude-haiku-4-5`) with only OpenRouter connected — triage should resolve past “no configured provider serves model”
- [ ] UI: confirm Run live → dialog closes immediately; a run that fails in-body does not leave the dialog open