### PR TITLE
feat(platform): task agent run details, live transcript, and output attachments

### DIFF
--- a/services/platform/app/features/automations/components/agent-execution-log.tsx
+++ b/services/platform/app/features/automations/components/agent-execution-log.tsx
@@ -208,38 +208,41 @@ export function AgentActivityLine({
   );
 }
 
+/** The op fields the transcript view reads — the common projection of the
+ * automation (`getAgentNodeSandboxOp`) and task (`getTaskAgentRunSandboxOp`)
+ * queries, so both lanes render through ONE view. */
+export interface AgentSandboxOpView {
+  execId: string;
+  status: string;
+  progressText?: string;
+  liveTimeline?: TimelinePart[];
+}
+
 /**
  * What the agent did INSIDE the sandbox, as a chronological transcript: its
  * own words as flowing prose, each tool call as one compact row that unfolds
  * into the full payload. Streamed onto the run's session op by the agent host
- * and read back here — the only window into a sandbox turn, which would
- * otherwise be an opaque "working…" spinner until it settles.
+ * and read back by the caller's op query — the only window into a sandbox
+ * turn, which would otherwise be an opaque "working…" spinner until it
+ * settles.
  *
  * The transcript reads DOWNWARD like the turn itself: the pane pins to its
  * bottom while the reader stays there (new entries just appear, chat-style)
  * and stops following the moment they scroll up, with a jump-back pill.
  * Entries accumulate client-side across the op's bounded flushes, so rows
- * never vanish mid-read. Renders nothing when the run never ran an agent
- * node.
+ * never vanish mid-read. Renders nothing while `op` is null.
  */
-export function AgentExecutionLog({
-  organizationId,
-  runId,
+export function ExecutionLogView({
+  op,
   className,
 }: {
-  organizationId: string;
-  runId: Id<'automationRuns'>;
+  op: AgentSandboxOpView | null;
   /** Sizes the scroll pane — the run dialog stretches it, the run page caps
    * it. The pane must have a bounded height for the pinning to mean anything. */
   className?: string;
 }) {
   const { t } = useT('automations');
   const { t: tChat } = useT('chat');
-  const opQuery = useConvexQuery(
-    api.sandbox.session_queries_public.getAgentNodeSandboxOp,
-    { organizationId, runId },
-  );
-  const op = opQuery.data ?? null;
 
   const [entries, setEntries] = useState<readonly AccumulatedEntry[]>([]);
   // A new exec is a new transcript — the accumulator resets rather than
@@ -414,4 +417,25 @@ export function AgentExecutionLog({
       )}
     </Stack>
   );
+}
+
+/**
+ * An automation run's agent transcript — {@link ExecutionLogView} bound to
+ * the run's `workflow-agent` session op. Renders nothing when the run never
+ * ran an agent node.
+ */
+export function AgentExecutionLog({
+  organizationId,
+  runId,
+  className,
+}: {
+  organizationId: string;
+  runId: Id<'automationRuns'>;
+  className?: string;
+}) {
+  const opQuery = useConvexQuery(
+    api.sandbox.session_queries_public.getAgentNodeSandboxOp,
+    { organizationId, runId },
+  );
+  return <ExecutionLogView op={opQuery.data ?? null} className={className} />;
 }

--- a/services/platform/app/features/tasks/components/mention-text.test.tsx
+++ b/services/platform/app/features/tasks/components/mention-text.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@/lib/i18n/client', () => ({
 vi.mock('../hooks/use-actor-directory', () => ({
   useActorDirectory: () => ({
     members: [{ id: 'u1', name: 'Ada', email: 'ada@example.com' }],
-    agents: [],
+    agents: [{ id: 'rs774n7chzm7tbf9p5fhsq2xr58br0nb', name: 'PR Reviewer' }],
   }),
 }));
 
@@ -46,5 +46,17 @@ describe('MentionText — markdown', () => {
 
     expect(screen.getByText('@Ada')).toBeInTheDocument();
     expect(screen.queryByText('@ada')).not.toBeInTheDocument();
+  });
+
+  it('resolves an agent by name handle AND by raw instance id', () => {
+    render(
+      <MentionText
+        body="@pr.reviewer take over from @rs774n7chzm7tbf9p5fhsq2xr58br0nb"
+        organizationId="org_1"
+      />,
+    );
+
+    expect(screen.getAllByText('@PR Reviewer')).toHaveLength(2);
+    expect(screen.queryByText(/@pr\.reviewer/)).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/tasks/components/mention-text.tsx
+++ b/services/platform/app/features/tasks/components/mention-text.tsx
@@ -17,7 +17,10 @@ import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 import { useActorDirectory } from '../hooks/use-actor-directory';
-import { memberHandleVariants } from '../lib/mention-handles';
+import {
+  agentHandleVariants,
+  memberHandleVariants,
+} from '../lib/mention-handles';
 
 /** Same boundary rule as the server parser (`convex/tasks/mentions.ts`):
  *  `@` at string start or after whitespace, so emails never match. */
@@ -61,7 +64,9 @@ export function MentionizedText({
       }
     }
     for (const agent of agents) {
-      map.set(agent.id.toLowerCase(), { name: agent.name, isAgent: true });
+      for (const variant of agentHandleVariants(agent)) {
+        map.set(variant, { name: agent.name, isAgent: true });
+      }
     }
     return map;
   }, [members, agents]);

--- a/services/platform/app/features/tasks/components/task-agent-run-card.test.tsx
+++ b/services/platform/app/features/tasks/components/task-agent-run-card.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+
+import { TaskAgentRunCard } from './task-agent-run-card';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string, values?: Record<string, unknown>) => {
+      if (key === 'run.details') return 'Details';
+      if (key === 'run.detailsTitle') {
+        return `${String(values?.name)} — progress`;
+      }
+      if (key === 'agentRun.status.settled') return 'Reported for review';
+      if (key === 'runs.agentLog.title') return 'Agent log';
+      if (key === 'runs.agentLog.empty') {
+        return 'The agent produced no log for this run.';
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@tale/ui/responsive-dialog', () => ({
+  ResponsiveDialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div role="dialog">{children}</div> : null),
+  ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useStartTaskAgentRun: () => ({ mutateAsync: vi.fn() }),
+  useCancelTaskAgentRun: () => ({ mutateAsync: vi.fn() }),
+}));
+
+// Routes the card's two reads: the run-card query (args carry `taskId`) and
+// the details dialog's op query (args carry `runId`, `'skip'` until opened).
+const { state } = vi.hoisted(() => ({
+  state: { run: undefined as unknown, op: undefined as unknown },
+}));
+
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: (_func: unknown, args: unknown) => {
+    if (args === 'skip') return { data: undefined };
+    if (typeof args === 'object' && args !== null && 'taskId' in args) {
+      return { data: state.run };
+    }
+    return { data: state.op };
+  },
+}));
+
+const taskId = 'task-1' as Id<'tasks'>;
+
+function settledRun() {
+  return {
+    _id: 'run-1' as Id<'projectAgentRuns'>,
+    status: 'settled',
+    agentId: 'agent-1',
+    agentName: 'Alice',
+    harness: 'claude-code',
+    model: 'deepseek/deepseek-v4-flash',
+    startedAt: 1,
+    settledAt: 2,
+  };
+}
+
+describe('TaskAgentRunCard details', () => {
+  it('opens the transcript dialog from the Details entry, for readers too', async () => {
+    const user = userEvent.setup();
+    state.run = settledRun();
+    state.op = {
+      execId: 'e1',
+      status: 'completed',
+      startedAt: 1,
+      liveTimeline: [
+        { type: 'text', text: 'built the deck' },
+        {
+          type: 'tool-Bash',
+          state: 'output-available',
+          toolCallId: 't1',
+          input: { command: 'ls /user/output' },
+        },
+      ],
+    };
+    render(
+      <TaskAgentRunCard
+        organizationId="org-1"
+        taskId={taskId}
+        canEdit={false}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Alice — progress')).toBeInTheDocument();
+    expect(screen.getByText('built the deck')).toBeInTheDocument();
+    expect(screen.getByText('ls /user/output')).toBeInTheDocument();
+  });
+
+  it('degrades to the empty notice when the run left no op', async () => {
+    const user = userEvent.setup();
+    state.run = settledRun();
+    state.op = null;
+    render(<TaskAgentRunCard organizationId="org-1" taskId={taskId} canEdit />);
+
+    await user.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(
+      screen.getByText('The agent produced no log for this run.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/tasks/components/task-agent-run-card.tsx
+++ b/services/platform/app/features/tasks/components/task-agent-run-card.tsx
@@ -8,14 +8,22 @@
  * task's), a settled one as "reported for review" (the report itself is the
  * agent's comment in the timeline below) — and, before any run exists, an
  * explicit Start so kicking the agent never requires knowing the drag verb.
+ * Every run offers Details: the agent's sandbox transcript, live while it
+ * works and preserved after it settles.
  */
 
 import { Button } from '@tale/ui/button';
 import { Row, Stack } from '@tale/ui/layout';
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogTitle,
+} from '@tale/ui/responsive-dialog';
 import { Text } from '@tale/ui/text';
 import { Bot, Loader2, Play } from 'lucide-react';
 import { useState } from 'react';
 
+import { ExecutionLogView } from '@/app/features/automations/components/agent-execution-log';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
@@ -26,6 +34,56 @@ import {
   useCancelTaskAgentRun,
   useStartTaskAgentRun,
 } from '../hooks/mutations';
+
+/**
+ * The run's sandbox transcript, inspected WITHOUT leaving the task — the
+ * agent twin of the subject panel's `TaskRunDetailsDialog`. Nothing is
+ * fetched until it opens; a run whose turn has not written its op yet (or
+ * whose op was torn down) degrades to the empty line.
+ */
+function TaskAgentRunDetailsDialog({
+  organizationId,
+  runId,
+  name,
+  open,
+  onOpenChange,
+}: {
+  organizationId: string;
+  runId: Id<'projectAgentRuns'>;
+  name: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useT('tasks');
+  const { t: tAutomations } = useT('automations');
+  const opQuery = useConvexQuery(
+    api.tasks.queries.getTaskAgentRunSandboxOp,
+    open ? { organizationId, runId } : 'skip',
+  );
+  const op = opQuery.data ?? null;
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto md:max-w-3xl">
+        <ResponsiveDialogTitle className="text-base font-semibold">
+          {t('run.detailsTitle', { name })}
+        </ResponsiveDialogTitle>
+        {op !== null ? (
+          <ExecutionLogView op={op} className="max-h-[60vh]" />
+        ) : opQuery.data === null ? (
+          <Text as="p" variant="muted">
+            {tAutomations('runs.agentLog.empty')}
+          </Text>
+        ) : (
+          <Loader2
+            className="text-muted-foreground size-4 animate-spin"
+            aria-hidden
+          />
+        )}
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}
 
 interface TaskAgentRunCardProps {
   organizationId: string;
@@ -46,6 +104,7 @@ export function TaskAgentRunCard({
   const { mutateAsync: startRun } = useStartTaskAgentRun();
   const { mutateAsync: cancelRun } = useCancelTaskAgentRun();
   const [busy, setBusy] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const run = runQuery.data;
   if (run === undefined) return null;
@@ -150,31 +209,46 @@ export function TaskAgentRunCard({
             {run.error}
           </Text>
         ) : null}
-        {canEdit &&
-        (live || run.status === 'failed' || run.status === 'cancelled') ? (
-          <Row gap={2}>
-            {live ? (
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={busy}
-                onClick={() => void handleCancel()}
-              >
-                {t('agentRun.cancel')}
-              </Button>
-            ) : (
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={busy}
-                onClick={() => void handleRetry()}
-              >
-                {t('agentRun.retry')}
-              </Button>
-            )}
-          </Row>
-        ) : null}
+        <Row gap={2}>
+          {canEdit && live ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={busy}
+              onClick={() => void handleCancel()}
+            >
+              {t('agentRun.cancel')}
+            </Button>
+          ) : null}
+          {canEdit &&
+          (run.status === 'failed' || run.status === 'cancelled') ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={busy}
+              onClick={() => void handleRetry()}
+            >
+              {t('agentRun.retry')}
+            </Button>
+          ) : null}
+          {/* Reading the transcript is a READ — offered to every viewer, for
+              live and settled runs alike. */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setDetailsOpen(true)}
+          >
+            {t('run.details')}
+          </Button>
+        </Row>
       </Stack>
+      <TaskAgentRunDetailsDialog
+        organizationId={organizationId}
+        runId={run._id}
+        name={run.agentName ?? run.harness}
+        open={detailsOpen}
+        onOpenChange={setDetailsOpen}
+      />
     </section>
   );
 }

--- a/services/platform/app/features/tasks/components/task-agent-run-entry.test.tsx
+++ b/services/platform/app/features/tasks/components/task-agent-run-entry.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { Id } from '@/convex/_generated/dataModel';
 
-import { TaskAgentRunCard } from './task-agent-run-card';
+import { TaskAgentRunEntry } from './task-agent-run-entry';
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({
@@ -75,7 +75,7 @@ function settledRun() {
   };
 }
 
-describe('TaskAgentRunCard details', () => {
+describe('TaskAgentRunEntry details', () => {
   it('opens the transcript dialog from the Details entry, for readers too', async () => {
     const user = userEvent.setup();
     state.run = settledRun();
@@ -94,7 +94,7 @@ describe('TaskAgentRunCard details', () => {
       ],
     };
     render(
-      <TaskAgentRunCard
+      <TaskAgentRunEntry
         organizationId="org-1"
         taskId={taskId}
         canEdit={false}
@@ -113,7 +113,9 @@ describe('TaskAgentRunCard details', () => {
     const user = userEvent.setup();
     state.run = settledRun();
     state.op = null;
-    render(<TaskAgentRunCard organizationId="org-1" taskId={taskId} canEdit />);
+    render(
+      <TaskAgentRunEntry organizationId="org-1" taskId={taskId} canEdit />,
+    );
 
     await user.click(screen.getByRole('button', { name: 'Details' }));
 

--- a/services/platform/app/features/tasks/components/task-agent-run-entry.tsx
+++ b/services/platform/app/features/tasks/components/task-agent-run-entry.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 /**
- * The agent-ownership work panel of the task modal — the agent twin of the
- * automation `TaskSubjectPanel`. Shows the task's LATEST agent run — a live
- * one with progress + Cancel, a failed one with its error + Retry (a failed
- * run keeps the task at In progress — failure is the run's state, not the
- * task's), a settled one as "reported for review" (the report itself is the
- * agent's comment in the timeline below) — and, before any run exists, an
- * explicit Start so kicking the agent never requires knowing the drag verb.
- * Every run offers Details: the agent's sandbox transcript, live while it
- * works and preserved after it settles.
+ * The agent lane's compact work strip, subordinate to the Assignee field in
+ * the task modal's property panel — the run is the ASSIGNEE's state, not a
+ * second subject, so it reads as one status line plus small verbs instead of
+ * a card competing with the task body. Shows the task's LATEST agent run —
+ * live with Cancel, failed with its error + Retry (a failed run keeps the
+ * task at In progress — failure is the run's state, not the task's), settled
+ * as "reported for review" (the report itself is the agent's comment in the
+ * timeline) — and, before any run exists, an explicit Start so kicking the
+ * agent never requires knowing the drag verb. Every run offers Details: the
+ * agent's sandbox transcript, live while it works and preserved after it
+ * settles.
  */
 
 import { Button } from '@tale/ui/button';
@@ -34,6 +36,12 @@ import {
   useCancelTaskAgentRun,
   useStartTaskAgentRun,
 } from '../hooks/mutations';
+
+interface TaskAgentRunEntryProps {
+  organizationId: string;
+  taskId: Id<'tasks'>;
+  canEdit: boolean;
+}
 
 /**
  * The run's sandbox transcript, inspected WITHOUT leaving the task — the
@@ -85,17 +93,11 @@ function TaskAgentRunDetailsDialog({
   );
 }
 
-interface TaskAgentRunCardProps {
-  organizationId: string;
-  taskId: Id<'tasks'>;
-  canEdit: boolean;
-}
-
-export function TaskAgentRunCard({
+export function TaskAgentRunEntry({
   organizationId,
   taskId,
   canEdit,
-}: TaskAgentRunCardProps) {
+}: TaskAgentRunEntryProps) {
   const { t } = useT('tasks');
   const runQuery = useConvexQuery(
     api.tasks.queries.getLatestTaskAgentRunForTask,
@@ -149,99 +151,83 @@ export function TaskAgentRunCard({
   };
 
   // No run yet: the agent lane's explicit entry point — the same kick the
-  // board's drag-to-In-progress performs, as a visible button.
+  // board's drag-to-In-progress performs, as one small verb. Readers see
+  // nothing until a run exists.
   if (run === null) {
+    if (!canEdit) return null;
     return (
-      <section className="rounded-md border p-3">
-        <Stack gap={2}>
-          <Row align="center" gap={2} className="min-w-0">
-            <Bot
-              aria-hidden
-              className="text-muted-foreground size-4 shrink-0"
-            />
-            <Text as="p" variant="muted" className="min-w-0 flex-1 text-sm">
-              {t('agentRun.idle')}
-            </Text>
-          </Row>
-          {canEdit && (
-            <Row gap={2}>
-              <Button
-                size="sm"
-                disabled={busy}
-                icon={Play}
-                onClick={() => void handleRetry()}
-              >
-                {t('agentRun.start')}
-              </Button>
-            </Row>
-          )}
-        </Stack>
-      </section>
+      <Row gap={2}>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={busy}
+          icon={Play}
+          onClick={() => void handleRetry()}
+        >
+          {t('agentRun.start')}
+        </Button>
+      </Row>
     );
   }
 
   return (
-    <section className="rounded-md border p-3">
-      <Stack gap={2}>
-        <Row justify="between" align="center" gap={3}>
-          <Row align="center" gap={2} className="min-w-0">
-            {live ? (
-              <Loader2
-                aria-hidden
-                className="text-muted-foreground size-4 shrink-0 animate-spin"
-              />
-            ) : (
-              <Bot
-                aria-hidden
-                className="text-muted-foreground size-4 shrink-0"
-              />
-            )}
-            <Text className="truncate font-medium">
-              {t(`agentRun.status.${run.status}`)}
-            </Text>
-          </Row>
-          <Text variant="caption" className="text-muted-foreground truncate">
-            {run.harness} · {run.model}
-          </Text>
-        </Row>
-        {run.status === 'failed' && run.error !== undefined ? (
-          <Text variant="caption" className="text-destructive text-pretty">
-            {run.error}
-          </Text>
-        ) : null}
-        <Row gap={2}>
-          {canEdit && live ? (
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={busy}
-              onClick={() => void handleCancel()}
-            >
-              {t('agentRun.cancel')}
-            </Button>
-          ) : null}
-          {canEdit &&
-          (run.status === 'failed' || run.status === 'cancelled') ? (
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={busy}
-              onClick={() => void handleRetry()}
-            >
-              {t('agentRun.retry')}
-            </Button>
-          ) : null}
-          {/* Reading the transcript is a READ — offered to every viewer, for
-              live and settled runs alike. */}
+    <Stack gap={1} className="min-w-0">
+      <Row align="center" gap={2} className="min-w-0">
+        {live ? (
+          <Loader2
+            aria-hidden
+            className="text-muted-foreground size-3.5 shrink-0 animate-spin"
+          />
+        ) : (
+          <Bot
+            aria-hidden
+            className="text-muted-foreground size-3.5 shrink-0"
+          />
+        )}
+        <Text
+          as="span"
+          variant="caption"
+          className="min-w-0 truncate font-medium"
+          title={`${run.harness} · ${run.model}`}
+        >
+          {t(`agentRun.status.${run.status}`)}
+        </Text>
+      </Row>
+      {run.status === 'failed' && run.error !== undefined ? (
+        <Text
+          variant="caption"
+          className="text-destructive line-clamp-2 text-pretty"
+        >
+          {run.error}
+        </Text>
+      ) : null}
+      <Row gap={1} className="-ml-2">
+        {/* Reading the transcript is a READ — offered to every viewer, for
+            live and settled runs alike. */}
+        <Button variant="ghost" size="sm" onClick={() => setDetailsOpen(true)}>
+          {t('run.details')}
+        </Button>
+        {canEdit && live ? (
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => setDetailsOpen(true)}
+            disabled={busy}
+            onClick={() => void handleCancel()}
           >
-            {t('run.details')}
+            {t('agentRun.cancel')}
           </Button>
-        </Row>
-      </Stack>
+        ) : null}
+        {canEdit && (run.status === 'failed' || run.status === 'cancelled') ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={() => void handleRetry()}
+          >
+            {t('agentRun.retry')}
+          </Button>
+        ) : null}
+      </Row>
       <TaskAgentRunDetailsDialog
         organizationId={organizationId}
         runId={run._id}
@@ -249,6 +235,6 @@ export function TaskAgentRunCard({
         open={detailsOpen}
         onOpenChange={setDetailsOpen}
       />
-    </section>
+    </Stack>
   );
 }

--- a/services/platform/app/features/tasks/components/task-agent-run-entry.tsx
+++ b/services/platform/app/features/tasks/components/task-agent-run-entry.tsx
@@ -21,8 +21,9 @@ import {
   ResponsiveDialogContent,
   ResponsiveDialogTitle,
 } from '@tale/ui/responsive-dialog';
+import { StatusIndicator } from '@tale/ui/status-indicator';
 import { Text } from '@tale/ui/text';
-import { Bot, Loader2, Play } from 'lucide-react';
+import { Loader2, Play } from 'lucide-react';
 import { useState } from 'react';
 
 import { ExecutionLogView } from '@/app/features/automations/components/agent-execution-log';
@@ -172,6 +173,9 @@ export function TaskAgentRunEntry({
 
   return (
     <Stack gap={1} className="min-w-0">
+      {/* One word + one signal: a spinner while the run moves, a coloured
+          state dot once it stopped. The agent identity lives in the Assignee
+          row right above; harness · model stay one hover away. */}
       <Row align="center" gap={2} className="min-w-0">
         {live ? (
           <Loader2
@@ -179,9 +183,15 @@ export function TaskAgentRunEntry({
             className="text-muted-foreground size-3.5 shrink-0 animate-spin"
           />
         ) : (
-          <Bot
-            aria-hidden
-            className="text-muted-foreground size-3.5 shrink-0"
+          <StatusIndicator
+            size="sm"
+            variant={
+              run.status === 'settled'
+                ? 'success'
+                : run.status === 'failed'
+                  ? 'error'
+                  : 'neutral'
+            }
           />
         )}
         <Text

--- a/services/platform/app/features/tasks/components/task-attachments.tsx
+++ b/services/platform/app/features/tasks/components/task-attachments.tsx
@@ -33,14 +33,18 @@ export function TaskAttachments({
   organizationId,
   onUpload,
   onRemove,
+  label,
 }: {
   attachments: FileAttachment[];
   uploadingFiles: string[];
   canEdit: boolean;
   disabled?: boolean;
   organizationId: string;
-  onUpload: (files: File[]) => void;
-  onRemove: (fileId: string) => void;
+  onUpload?: (files: File[]) => void;
+  onRemove?: (fileId: string) => void;
+  /** Zone heading — the agent-deliverables Output zone reuses this component
+   * read-only under its own label. Defaults to the Attachments heading. */
+  label?: string;
 }) {
   const { t } = useT('tasks');
   const inputId = useId();
@@ -92,7 +96,7 @@ export function TaskAttachments({
   return (
     <Stack as="section" gap={2}>
       <Text as="h3" variant="label">
-        {t('attachments.label')}
+        {label ?? t('attachments.label')}
       </Text>
 
       {hasContent && (
@@ -114,7 +118,7 @@ export function TaskAttachments({
                       : undefined
                   }
                 />
-                {canEdit && (
+                {canEdit && onRemove !== undefined && (
                   <button
                     type="button"
                     aria-label={t('attachments.remove')}
@@ -144,7 +148,7 @@ export function TaskAttachments({
         </Row>
       )}
 
-      {canEdit && (
+      {canEdit && onUpload !== undefined && (
         <FileUpload.Root>
           <FileUpload.DropZone
             inputId={inputId}

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -83,7 +83,7 @@ import { MentionTriggerChips } from './mention-trigger-chips';
 import { PriorityPicker } from './priority-picker';
 import { useRunCancelConfirm } from './run-cancel-confirm';
 import { StatusPicker } from './status-picker';
-import { TaskAgentRunCard } from './task-agent-run-card';
+import { TaskAgentRunEntry } from './task-agent-run-entry';
 import { TaskArchiveDialog } from './task-archive-dialog';
 import { TaskArchivedBadge } from './task-archived-badge';
 import { TaskAttachments } from './task-attachments';
@@ -1076,14 +1076,6 @@ function EditTaskBody({
               />
             )}
 
-            {task.assigneeType === 'agent' && (
-              <TaskAgentRunCard
-                organizationId={task.organizationId}
-                taskId={task._id}
-                canEdit={canMutate}
-              />
-            )}
-
             {ownedBy !== null &&
             ownedBy.contract.input?.kind === 'folder' &&
             typeof task.externalId === 'string' &&
@@ -1342,6 +1334,17 @@ function EditTaskBody({
                 }
               />
             </PropertyField>
+            {/* The agent lane's status + verbs live WITH the assignee — the
+                run is Alice's state, not a second card in the task body. */}
+            {task.assigneeType === 'agent' && (
+              <PropertyField label={t('agentRun.label')}>
+                <TaskAgentRunEntry
+                  organizationId={task.organizationId}
+                  taskId={task._id}
+                  canEdit={canMutate}
+                />
+              </PropertyField>
+            )}
             <PropertyField label={t('dueDate.label')}>
               <DatePicker
                 value={task.dueDate}

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -1115,6 +1115,19 @@ function EditTaskBody({
               />
             )}
 
+            {/* Agent-run deliverables (harvested /user/output) — read-only;
+                the settle merges by fileName, so a rerun's same-named file
+                replaces its row instead of stacking a copy. */}
+            {(task.outputs?.length ?? 0) > 0 && (
+              <TaskAttachments
+                attachments={task.outputs ?? []}
+                uploadingFiles={[]}
+                canEdit={false}
+                organizationId={task.organizationId}
+                label={t('outputs.label')}
+              />
+            )}
+
             {ownedBy !== null && descriptionSection}
 
             <Stack as="section" gap={2}>

--- a/services/platform/app/features/tasks/lib/mention-actor-options.ts
+++ b/services/platform/app/features/tasks/lib/mention-actor-options.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import type { Id } from '@/convex/_generated/dataModel';
 
 import { useAssignableActors } from '../hooks/use-actor-directory';
-import { memberInsertHandle } from './mention-handles';
+import { agentInsertHandle, memberInsertHandle } from './mention-handles';
 
 export const MAX_MENTION_OPTIONS = 8;
 
@@ -52,11 +52,14 @@ export function useMentionActorOptions(
       }
     }
     for (const agent of assignableAgents) {
+      // Insert the readable name form — the raw instance id resolves too
+      // (server keeps it as a fallback handle) but is noise in prose.
+      const handle = agentInsertHandle(agent) ?? agent.id.toLowerCase();
       options.push({
         type: 'agent',
         id: agent.id,
         name: agent.name,
-        handle: agent.id.toLowerCase(),
+        handle,
       });
     }
     return options;

--- a/services/platform/app/features/tasks/lib/mention-handles.ts
+++ b/services/platform/app/features/tasks/lib/mention-handles.ts
@@ -40,3 +40,35 @@ export function memberHandleVariants(member: MentionableMember): string[] {
 export function memberInsertHandle(member: MentionableMember): string | null {
   return memberHandleVariants(member)[0] ?? null;
 }
+
+export interface MentionableAgent {
+  id: string;
+  name: string;
+}
+
+/** All candidate handles for a project agent instance, lowercased, the
+ *  server derivation order (`convex/tasks/directory.ts::agentInstanceHandles`):
+ *  dotted name → squashed name → instance id (the collision-proof fallback
+ *  the server also resolves). */
+export function agentHandleVariants(agent: MentionableAgent): string[] {
+  const name = agent.name.trim().toLowerCase();
+  const candidates = [
+    name.replace(/\s+/g, '.'),
+    name.replace(/\s+/g, ''),
+    agent.id,
+  ];
+  const variants: string[] = [];
+  for (const candidate of candidates) {
+    if (candidate && MENTION_TOKEN_RE.test(candidate)) {
+      const lowered = candidate.toLowerCase();
+      if (!variants.includes(lowered)) variants.push(lowered);
+    }
+  }
+  return variants;
+}
+
+/** The preferred handle the composer inserts — the readable name form, never
+ *  the raw instance id (that form still resolves, for older comments). */
+export function agentInsertHandle(agent: MentionableAgent): string | null {
+  return agentHandleVariants(agent)[0] ?? null;
+}

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -846,7 +846,7 @@ export const startWorkflowAgentTurn = internalAction({
           : {}),
       });
 
-      const progress = liveProgressSink(ctx, args);
+      const progress = liveProgressSink(ctx, args, 'workflow-agent');
       const window = await drainHarnessWindow({
         sessionId: args.sessionId,
         execId: args.execId,
@@ -929,7 +929,7 @@ export const driveWorkflowAgentTurn = internalAction({
       return null;
     }
 
-    const progress = liveProgressSink(ctx, args);
+    const progress = liveProgressSink(ctx, args, 'workflow-agent');
     let window;
     try {
       window = await drainHarnessWindow({
@@ -1152,7 +1152,7 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
         );
       }
 
-      const progress = liveProgressSink(ctx, keys);
+      const progress = liveProgressSink(ctx, keys, 'workflow-agent');
       const window = await drainHarnessWindow({
         sessionId,
         execId,
@@ -1215,9 +1215,12 @@ interface TurnKeys {
  * `getAgentNodeSandboxOp` reads back. Best-effort: a failed progress write
  * never disturbs the turn.
  */
-function liveProgressSink(
+/** Shared by the workflow AND task agent lanes (`kind` picks the op lane) —
+ * the ONE writer of an agent turn's live transcript. */
+export function liveProgressSink(
   ctx: ActionCtx,
   args: Pick<TurnKeys, 'organizationId' | 'sessionId' | 'execId'>,
+  kind: 'workflow-agent' | 'task-agent',
 ): {
   onText: (text: string) => void;
   onTimeline: (parts: HarnessTimelinePart[]) => void;
@@ -1239,7 +1242,7 @@ function liveProgressSink(
           organizationId: args.organizationId,
           sessionId: args.sessionId,
           execId: args.execId,
-          kind: 'workflow-agent',
+          kind,
           status: 'running',
           lastEventAt: Date.now(),
           ...patch,

--- a/services/platform/convex/lib/providers/resolve_vision_model.test.ts
+++ b/services/platform/convex/lib/providers/resolve_vision_model.test.ts
@@ -99,6 +99,22 @@ describe('resolveOrgVisionModel', () => {
     });
   });
 
+  it('never auto-selects a free-tier variant, however cheap', async () => {
+    // A `:free` variant always wins the price sort at 0, but free tiers sit
+    // behind per-account data-policy gates and hard rate caps — observed
+    // live as a turn-long 401 storm. The priced sibling must win.
+    mockProviders([provider('alpha')]);
+    mockedCatalog.mockResolvedValue([
+      entry({ id: 'gemma-vl:free', inputPrice: 0 }),
+      entry({ id: 'priced-vl', inputPrice: 40 }),
+    ]);
+    const ctx = fakeCtx({ alpha: { authMethod: 'api-key', status: 'active' } });
+    await expect(resolveOrgVisionModel(ctx, 'org_1')).resolves.toEqual({
+      providerSlug: 'alpha',
+      modelId: 'priced-vl',
+    });
+  });
+
   it('skips providers without an active, gateway-servable default credential', async () => {
     mockProviders([
       provider('none'),

--- a/services/platform/convex/lib/providers/resolve_vision_model.ts
+++ b/services/platform/convex/lib/providers/resolve_vision_model.ts
@@ -107,6 +107,12 @@ export async function resolveOrgVisionModel(
 
     for (const entry of entries) {
       if (!entry.supportsVision || !entry.tags.includes('chat')) continue;
+      // Free-tier variants (OpenRouter `:free`) are unfit for a background
+      // capability: they sit behind per-account data-policy gates and hard
+      // rate caps, so the "cheapest" pick turns into a turn-long 401 storm
+      // (observed live: every vision call of a task run refused). They only
+      // ever win the price sort at 0, so skipping them costs nothing.
+      if (entry.id.endsWith(':free')) continue;
       if (
         row.modelAllowlist !== undefined &&
         row.modelAllowlist.length > 0 &&

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -44,7 +44,11 @@ import {
 } from './helpers/session_client';
 
 const SANDBOX_MAX_OUTPUT_FILES_PER_RUN = 16;
-const OUTPUT_DIR = '/user/output';
+/** The session's delivery box — harvested (top-level files only) when a work
+ * turn settles. Exported so lanes on a STANDING session can sweep leftovers
+ * before a new turn (a per-run session dies with its files; a standing one
+ * would re-harvest a prior run's deliverables onto the wrong task). */
+export const OUTPUT_DIR = '/user/output';
 
 // `inferContentType`/`inferStepLanguage` lived in
 // `convex/agent_tools/files/_shared.ts`, moved wholesale with the tool-

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -543,22 +543,31 @@ export interface HarvestedOutputFile {
  */
 export async function harvestSessionOutput(
   ctx: ActionCtx,
-  args: { organizationId: string; sessionId: string },
+  args: {
+    organizationId: string;
+    sessionId: string;
+    /** Harvest THIS directory instead of the session-wide delivery box — a
+     * STANDING session serving several subjects (the task-agent lane) scopes
+     * each turn to its own subdir so one subject's harvest can never pick up
+     * another's deliverables. Per-run/turn sessions keep the default. */
+    outputDir?: string;
+  },
 ): Promise<{
   files: HarvestedOutputFile[];
   harvestSkipped: Array<{ path: string; reason: string }>;
 }> {
   const { sessionId, organizationId } = args;
+  const outputDir = args.outputDir ?? OUTPUT_DIR;
   // Backend routing for harvested outputs: the org's own bucket when
   // configured, else Convex `_storage` (also the unresolvable-slug fallback).
   const orgSlug = await orgSlugFromIdOrNull(ctx, organizationId);
 
   const files: HarvestedOutputFile[] = [];
   const harvestSkipped: Array<{ path: string; reason: string }> = [];
-  const entries = (await sessionListFiles(sessionId, OUTPUT_DIR)) ?? [];
+  const entries = (await sessionListFiles(sessionId, outputDir)) ?? [];
   for (const e of entries) {
     if (e.type !== 'file') continue;
-    const absPath = `${OUTPUT_DIR}/${e.name}`;
+    const absPath = `${outputDir}/${e.name}`;
     if (files.length >= SANDBOX_MAX_OUTPUT_FILES_PER_RUN) {
       harvestSkipped.push({
         path: absPath,

--- a/services/platform/convex/sandbox/session_mutations.ts
+++ b/services/platform/convex/sandbox/session_mutations.ts
@@ -33,6 +33,7 @@ import {
   SANDBOX_MAX_SESSIONS_PER_OWNER,
   SANDBOX_SESSION_LIVE_STATUSES,
   SANDBOX_SESSION_MAX_LIFETIME_MS,
+  sessionOpTimelinePartValidator,
 } from './sessions_schema';
 import { sandboxSessionProfileValidator } from './wire';
 
@@ -845,20 +846,8 @@ export const upsertSessionOp = internalMutation({
       v.literal('cancelled'),
     ),
     progressText: v.optional(v.string()),
-    /** Bounded live UI-part transcript for a workflow-run step (run-view feed). */
-    liveTimeline: v.optional(
-      v.array(
-        v.object({
-          type: v.string(),
-          text: v.optional(v.string()),
-          state: v.optional(v.string()),
-          toolCallId: v.optional(v.string()),
-          input: v.optional(v.any()),
-          output: v.optional(v.any()),
-          errorText: v.optional(v.string()),
-        }),
-      ),
-    ),
+    /** Bounded live UI-part transcript for a work-lane turn (run-view feed). */
+    liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
     agentSessionId: v.optional(v.string()),
     exitCode: v.optional(v.number()),
     /** The agent's self-reported terminal status (turn-ended.status), preferred

--- a/services/platform/convex/sandbox/session_queries_public.ts
+++ b/services/platform/convex/sandbox/session_queries_public.ts
@@ -27,7 +27,10 @@ import {
   sessionIdForWorkflowRun,
   userOwnerId,
 } from './session_naming';
-import { isLiveSessionStatus } from './sessions_schema';
+import {
+  isLiveSessionStatus,
+  sessionOpTimelinePartValidator,
+} from './sessions_schema';
 
 /**
  * Latest in-session `agent-run` op for a thread, for live tool-use/text
@@ -128,19 +131,7 @@ export const getAutomationSandboxOp = query({
         v.literal('cancelled'),
       ),
       progressText: v.optional(v.string()),
-      liveTimeline: v.optional(
-        v.array(
-          v.object({
-            type: v.string(),
-            text: v.optional(v.string()),
-            state: v.optional(v.string()),
-            toolCallId: v.optional(v.string()),
-            input: v.optional(v.any()),
-            output: v.optional(v.any()),
-            errorText: v.optional(v.string()),
-          }),
-        ),
-      ),
+      liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
       lastEventAt: v.optional(v.number()),
       agentIdleAt: v.optional(v.number()),
       continuationCount: v.optional(v.number()),
@@ -237,19 +228,7 @@ export const getAgentNodeSandboxOp = query({
         v.literal('cancelled'),
       ),
       progressText: v.optional(v.string()),
-      liveTimeline: v.optional(
-        v.array(
-          v.object({
-            type: v.string(),
-            text: v.optional(v.string()),
-            state: v.optional(v.string()),
-            toolCallId: v.optional(v.string()),
-            input: v.optional(v.any()),
-            output: v.optional(v.any()),
-            errorText: v.optional(v.string()),
-          }),
-        ),
-      ),
+      liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
       startedAt: v.number(),
       finishedAt: v.optional(v.number()),
       lastEventAt: v.optional(v.number()),

--- a/services/platform/convex/sandbox/sessions_schema.ts
+++ b/services/platform/convex/sandbox/sessions_schema.ts
@@ -108,6 +108,21 @@ export const sandboxSessionTokensTable = defineTable({
   .index('by_organizationId', ['organizationId']);
 
 /**
+ * One entry of an op row's `liveTimeline` — the AI-SDK UI-part shape the run
+ * views render. Exported so the public op-reading queries (automation agent
+ * node, task-agent run) project it without re-declaring the shape.
+ */
+export const sessionOpTimelinePartValidator = v.object({
+  type: v.string(),
+  text: v.optional(v.string()),
+  state: v.optional(v.string()),
+  toolCallId: v.optional(v.string()),
+  input: v.optional(v.any()),
+  output: v.optional(v.any()),
+  errorText: v.optional(v.string()),
+});
+
+/**
  * In-session exec / progress rows. Deliberately NOT the quota-bearing
  * `sandboxExecutions` table (daily-CPU-seconds budgeting doesn't map to
  * long-lived sessions). One row per exec; the reactive progress model writes
@@ -142,19 +157,7 @@ export const sandboxSessionOpsTable = defineTable({
    *  the persisted assistant message, but a workflow run has no message — so its
    *  run view reads a bounded tail (recent N parts) from here. Written only for
    *  threadId-less workflow ops; dies with the op at teardown. */
-  liveTimeline: v.optional(
-    v.array(
-      v.object({
-        type: v.string(),
-        text: v.optional(v.string()),
-        state: v.optional(v.string()),
-        toolCallId: v.optional(v.string()),
-        input: v.optional(v.any()),
-        output: v.optional(v.any()),
-        errorText: v.optional(v.string()),
-      }),
-    ),
-  ),
+  liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
   /** Captured agent session id so the next turn can --resume / -s. */
   agentSessionId: v.optional(v.string()),
   exitCode: v.optional(v.number()),

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -21,6 +21,7 @@ import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
 import {
+  liveProgressSink,
   releaseTurnKey,
   stageWorkflowSkills,
   workflowAgentBudgetCents,
@@ -305,12 +306,16 @@ export const startTaskAgentTurn = internalAction({
           : {}),
       });
 
+      const progress = liveProgressSink(ctx, args, 'task-agent');
       const window = await drainHarnessWindow({
         sessionId: args.sessionId,
         execId: args.execId,
         harness: args.harness,
         start: exec,
+        onText: progress.onText,
+        onTimeline: progress.onTimeline,
       });
+      await progress.flush();
       await continueOrSettle(ctx, args, window);
     } catch (err) {
       console.error('[task-agent] turn start failed:', err);
@@ -367,15 +372,19 @@ export const driveTaskAgentTurn = internalAction({
       return null;
     }
 
+    const progress = liveProgressSink(ctx, args, 'task-agent');
     let window;
     try {
       window = await drainHarnessWindow({
         sessionId: args.sessionId,
         execId: args.execId,
         harness: args.harness,
+        onText: progress.onText,
+        onTimeline: progress.onTimeline,
       });
     } catch (err) {
       console.error('[task-agent] drive window threw:', err);
+      await progress.flush();
       await settleTaskAgentTurn(ctx, args, {
         errored: true,
         reason: 'the agent run stopped unexpectedly',
@@ -383,6 +392,7 @@ export const driveTaskAgentTurn = internalAction({
       });
       return null;
     }
+    await progress.flush();
     await continueOrSettle(ctx, args, window);
     return null;
   },

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -145,14 +145,20 @@ async function ensureProjectAgentSession(
   });
 }
 
-/** Phrase the turn's prompt from the task brief. */
-function buildTaskPrompt(brief: {
-  title: string;
-  description?: string;
-  labels?: string[];
-  identifier?: string;
-  projectName?: string;
-}): string {
+/** Phrase the turn's prompt from the task brief. Exported for its unit test.
+ * `feedback` is the @mention comment that kicked a rerun — it leads the
+ * brief's work section so the agent treats it as the delta to address, not
+ * as one more line of context. */
+export function buildTaskPrompt(
+  brief: {
+    title: string;
+    description?: string;
+    labels?: string[];
+    identifier?: string;
+    projectName?: string;
+  },
+  feedback?: string,
+): string {
   const heading =
     brief.identifier !== undefined
       ? `You are working on task ${brief.identifier}: ${brief.title}`
@@ -167,6 +173,11 @@ function buildTaskPrompt(brief: {
       : []),
     ...(brief.description !== undefined && brief.description !== ''
       ? [`Description:\n${brief.description}`]
+      : []),
+    ...(feedback !== undefined && feedback.trim() !== ''
+      ? [
+          `The task was sent back with reviewer feedback — address it before anything else:\n${feedback.trim()}`,
+        ]
       : []),
     'When you are done, end with a short report of what you did and what you produced — that report is posted back to the task for human review.',
   ].join('\n\n');
@@ -184,6 +195,8 @@ export const startTaskAgentTurn = internalAction({
     instructions: v.optional(v.string()),
     skills: v.array(v.string()),
     connectors: v.array(v.string()),
+    /** The @mention comment that kicked this rerun, folded into the brief. */
+    feedback: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -312,7 +325,7 @@ export const startTaskAgentTurn = internalAction({
         gatewayModel: routing.gatewayModel,
         serving: { kind: 'gateway', token: key.token },
         instructions,
-        prompt: buildTaskPrompt(brief),
+        prompt: buildTaskPrompt(brief, args.feedback),
         execId: args.execId,
         ...(args.connectors.length > 0
           ? { bridgeUrl: connectorsBridgeUrlForSessions() }

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -39,10 +39,15 @@ import {
   SessionDuplicateError,
   sessionCancelExec,
   sessionCreate,
+  sessionDeleteFiles,
   sessionIsAlive,
+  sessionListFiles,
 } from '../node_only/sandbox/helpers/session_client';
 import { resolveGatewayRouting } from '../node_only/sandbox/llm_gateway_admin';
-import { harvestSessionOutput } from '../node_only/sandbox/session_exec';
+import {
+  harvestSessionOutput,
+  OUTPUT_DIR,
+} from '../node_only/sandbox/session_exec';
 import { projectAgentOwnerId } from '../sandbox/session_naming';
 
 /** The argument shape every turn phase carries verbatim. */
@@ -199,6 +204,24 @@ export const startTaskAgentTurn = internalAction({
         args.agentId,
         args.sessionId,
       );
+
+      // The STANDING session's delivery box persists across runs — sweep it
+      // before the turn so the settle's harvest attaches ONLY what this run
+      // produced (observed live: a prior task's deck re-harvested onto an
+      // unrelated task's Output zone). Best-effort: a sweep failure costs
+      // precision, not the run.
+      try {
+        const leftovers = (
+          (await sessionListFiles(args.sessionId, OUTPUT_DIR)) ?? []
+        )
+          .filter((entry) => entry.type === 'file')
+          .map((entry) => `${OUTPUT_DIR}/${entry.name}`);
+        if (leftovers.length > 0) {
+          await sessionDeleteFiles(args.sessionId, leftovers);
+        }
+      } catch (err) {
+        console.warn('[task-agent] output-box sweep failed (continuing):', err);
+      }
 
       // A project agent's equipment is the PROJECT's: team skills resolve
       // against the project's teams, never against whoever configured the
@@ -509,9 +532,48 @@ async function settleTaskAgentTurn(
       organizationId: args.organizationId,
       sessionId: args.sessionId,
     });
-    fileNames = harvested.files.map(
-      (file) => file.path.split('/').at(-1) ?? file.path,
-    );
+    const files = harvested.files.map((file) => ({
+      fileId: file.storageId,
+      fileName: file.path.split('/').at(-1) ?? file.path,
+      fileType: file.contentType,
+      fileSize: file.size,
+    }));
+    fileNames = files.map((file) => file.fileName);
+    if (files.length > 0) {
+      // Deliverables outlive the run: re-source each harvested blob's
+      // metadata row OUT of the agent temp-GC lane (source 'agent' +
+      // no documentId is retention-eligible), then merge the set into the
+      // task's Output zone (same fileName ⇒ replace). Best-effort — losing
+      // the attach must not lose the settle.
+      for (const file of files) {
+        await ctx
+          .runMutation(
+            internal.file_metadata.internal_mutations.saveFileMetadata,
+            {
+              organizationId: args.organizationId,
+              storageId: file.fileId,
+              fileName: file.fileName,
+              contentType: file.fileType,
+              size: file.fileSize,
+              source: 'task-output',
+            },
+          )
+          .catch((err) =>
+            console.warn('[task-agent] output metadata claim failed:', err),
+          );
+      }
+      await ctx.runMutation(
+        internal.tasks.internal_mutations.agentRecordTaskOutputs,
+        {
+          organizationId: args.organizationId,
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from the turn's own args
+          taskId: args.taskId as never,
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from the turn's own args
+          runId: args.runId as never,
+          files,
+        },
+      );
+    }
   } catch (err) {
     console.warn('[task-agent] output harvest failed:', err);
   }

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -145,10 +145,22 @@ async function ensureProjectAgentSession(
   });
 }
 
+/** The task's own delivery box inside the agent's STANDING session — the
+ * subject-scoped subdir the turn's instructions name, the start sweep
+ * clears, and the settle harvests. Scoped per task because the session is
+ * per AGENT: without it, concurrent or successive runs of the agent's other
+ * tasks would share one box and cross-attach deliverables. */
+export function taskOutputDir(taskId: string): string {
+  return `${OUTPUT_DIR}/${taskId}`;
+}
+
 /** Phrase the turn's prompt from the task brief. Exported for its unit test.
  * `feedback` is the @mention comment that kicked a rerun — it leads the
  * brief's work section so the agent treats it as the delta to address, not
- * as one more line of context. */
+ * as one more line of context. `outputDir` is the task's OWN delivery box:
+ * named in the user prompt (not only the system addendum) because a resumed
+ * standing-session conversation happily reuses last turn's path from memory,
+ * and a deliverable written outside the box is not collected. */
 export function buildTaskPrompt(
   brief: {
     title: string;
@@ -158,6 +170,7 @@ export function buildTaskPrompt(
     projectName?: string;
   },
   feedback?: string,
+  outputDir?: string,
 ): string {
   const heading =
     brief.identifier !== undefined
@@ -177,6 +190,11 @@ export function buildTaskPrompt(
     ...(feedback !== undefined && feedback.trim() !== ''
       ? [
           `The task was sent back with reviewer feedback — address it before anything else:\n${feedback.trim()}`,
+        ]
+      : []),
+    ...(outputDir !== undefined
+      ? [
+          `Deliverables: write every file you produce into ${outputDir}/ (create it if needed). Only files in that exact directory are collected and attached to this task — anything written elsewhere, including /user/output/ itself, is discarded.`,
         ]
       : []),
     'When you are done, end with a short report of what you did and what you produced — that report is posted back to the task for human review.',
@@ -218,17 +236,24 @@ export const startTaskAgentTurn = internalAction({
         args.sessionId,
       );
 
-      // The STANDING session's delivery box persists across runs — sweep it
-      // before the turn so the settle's harvest attaches ONLY what this run
-      // produced (observed live: a prior task's deck re-harvested onto an
-      // unrelated task's Output zone). Best-effort: a sweep failure costs
+      // The STANDING session serves every task of this agent, so the
+      // delivery box is PER TASK — /user/output/<taskId>/ — and the harvest
+      // reads only that subdir: another task's run (even a CONCURRENT one —
+      // the live-run mutex is per task, not per agent) can never leak its
+      // deliverables here. Before the turn, sweep this task's own subdir
+      // (the settle must attach exactly what THIS run produced) plus any
+      // legacy loose files at the box root, which are no longer harvested
+      // and would only accumulate. Best-effort: a sweep failure costs
       // precision, not the run.
+      const outputDir = taskOutputDir(args.taskId);
       try {
-        const leftovers = (
-          (await sessionListFiles(args.sessionId, OUTPUT_DIR)) ?? []
-        )
-          .filter((entry) => entry.type === 'file')
-          .map((entry) => `${OUTPUT_DIR}/${entry.name}`);
+        const leftovers: string[] = [];
+        for (const dir of [outputDir, OUTPUT_DIR]) {
+          for (const entry of (await sessionListFiles(args.sessionId, dir)) ??
+            []) {
+            if (entry.type === 'file') leftovers.push(`${dir}/${entry.name}`);
+          }
+        }
         if (leftovers.length > 0) {
           await sessionDeleteFiles(args.sessionId, leftovers);
         }
@@ -317,7 +342,7 @@ export const startTaskAgentTurn = internalAction({
           ? [args.instructions]
           : []),
         ...(skillsAddendum !== '' ? [skillsAddendum] : []),
-        'Write every file you produce to /user/output/ — files there are collected when your turn ends and reported back to the task.',
+        `Write every file you produce to ${outputDir}/ (this task's own delivery box — never plain /user/output/) — files there are collected when your turn ends and attached to the task.`,
       ].join('\n\n');
 
       const exec = buildExternalTurnExec({
@@ -325,7 +350,7 @@ export const startTaskAgentTurn = internalAction({
         gatewayModel: routing.gatewayModel,
         serving: { kind: 'gateway', token: key.token },
         instructions,
-        prompt: buildTaskPrompt(brief, args.feedback),
+        prompt: buildTaskPrompt(brief, args.feedback, outputDir),
         execId: args.execId,
         ...(args.connectors.length > 0
           ? { bridgeUrl: connectorsBridgeUrlForSessions() }
@@ -544,6 +569,7 @@ async function settleTaskAgentTurn(
     const harvested = await harvestSessionOutput(ctx, {
       organizationId: args.organizationId,
       sessionId: args.sessionId,
+      outputDir: taskOutputDir(args.taskId),
     });
     const files = harvested.files.map((file) => ({
       fileId: file.storageId,

--- a/services/platform/convex/tasks/agent_run_prompt.test.ts
+++ b/services/platform/convex/tasks/agent_run_prompt.test.ts
@@ -1,0 +1,34 @@
+// `buildTaskPrompt` — the task-agent turn's brief. Feedback (the @mention
+// comment that kicked a rerun) must lead the work section as the delta to
+// address, and its absence must leave the brief byte-identical to before.
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTaskPrompt } from './agent_run_host';
+
+const BRIEF = {
+  title: 'Build the deck',
+  description: 'A 15-slide panda deck.',
+  identifier: 'TAL-7',
+  projectName: 'Apollo',
+};
+
+describe('buildTaskPrompt', () => {
+  it('folds reviewer feedback in ahead of the report instruction', () => {
+    const prompt = buildTaskPrompt(BRIEF, '第3页的图请换成真实照片');
+    expect(prompt).toContain(
+      'The task was sent back with reviewer feedback — address it before anything else:\n第3页的图请换成真实照片',
+    );
+    expect(prompt.indexOf('reviewer feedback')).toBeGreaterThan(
+      prompt.indexOf('Description:'),
+    );
+    expect(prompt.indexOf('reviewer feedback')).toBeLessThan(
+      prompt.indexOf('When you are done'),
+    );
+  });
+
+  it('leaves the brief untouched without feedback', () => {
+    expect(buildTaskPrompt(BRIEF)).toBe(buildTaskPrompt(BRIEF, '   '));
+    expect(buildTaskPrompt(BRIEF)).not.toContain('reviewer feedback');
+  });
+});

--- a/services/platform/convex/tasks/agent_run_prompt.test.ts
+++ b/services/platform/convex/tasks/agent_run_prompt.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { buildTaskPrompt } from './agent_run_host';
+import { buildTaskPrompt, taskOutputDir } from './agent_run_host';
 
 const BRIEF = {
   title: 'Build the deck',
@@ -30,5 +30,21 @@ describe('buildTaskPrompt', () => {
   it('leaves the brief untouched without feedback', () => {
     expect(buildTaskPrompt(BRIEF)).toBe(buildTaskPrompt(BRIEF, '   '));
     expect(buildTaskPrompt(BRIEF)).not.toContain('reviewer feedback');
+  });
+});
+
+describe('taskOutputDir', () => {
+  it('scopes the delivery box per task under the session box', () => {
+    expect(taskOutputDir('wh76abc')).toBe('/user/output/wh76abc');
+  });
+
+  it('is named in the USER prompt so a resumed session cannot fall back to a remembered path', () => {
+    const prompt = buildTaskPrompt(BRIEF, undefined, '/user/output/wh76abc');
+    expect(prompt).toContain(
+      'write every file you produce into /user/output/wh76abc/',
+    );
+    expect(prompt.indexOf('Deliverables:')).toBeLessThan(
+      prompt.indexOf('When you are done'),
+    );
   });
 });

--- a/services/platform/convex/tasks/directory.ts
+++ b/services/platform/convex/tasks/directory.ts
@@ -103,7 +103,7 @@ export async function buildMentionDirectory(
       .withIndex('by_project', (q) => q.eq('projectId', args.project._id))
       .collect();
     for (const instance of instances) {
-      const handles = agentInstanceHandles(instance.name);
+      const handles = agentInstanceHandles(instance.name, String(instance._id));
       if (handles.length > 0) {
         entries.push({ type: 'agent', id: String(instance._id), handles });
       }
@@ -121,17 +121,18 @@ export async function buildMentionDirectory(
   };
 }
 
-/** Derive candidate `@handle`s for a project agent instance from its display
- * name — the member convention minus email: spaces collapsed and dot-joined. */
-function agentInstanceHandles(name: string): string[] {
+/** Derive candidate `@handle`s for a project agent instance: the display
+ * name (member convention minus email — dot-joined and squashed) plus the
+ * instance id itself, so a picker-inserted or copied id token resolves even
+ * under `agentMode: 'restricted'` (where the permissive fallback is off)
+ * and two same-named instances keep a collision-proof form. */
+function agentInstanceHandles(name: string, instanceId: string): string[] {
   const normalized = name.trim().toLowerCase();
-  if (normalized === '') return [];
-  return [
-    ...new Set([
-      normalized.replace(/\s+/g, ''),
-      normalized.replace(/\s+/g, '.'),
-    ]),
-  ];
+  const variants =
+    normalized === ''
+      ? []
+      : [normalized.replace(/\s+/g, '.'), normalized.replace(/\s+/g, '')];
+  return [...new Set([...variants, instanceId.toLowerCase()])];
 }
 
 /**

--- a/services/platform/convex/tasks/directory.ts
+++ b/services/platform/convex/tasks/directory.ts
@@ -93,10 +93,45 @@ export async function buildMentionDirectory(
     entries.push({ type: 'agent', id: slug, handles: [slug.toLowerCase()] });
   }
 
+  // The project's agent INSTANCES resolve by display name — '@alice',
+  // '@pr.reviewer'. Pushed LAST so an instance handle shadows a same-named
+  // legacy slug in the resolver's handle map, and a mention reaches the
+  // instance lane (comment @mention → assign + run), never the retired one.
+  try {
+    const instances = await ctx.db
+      .query('projectAgents')
+      .withIndex('by_project', (q) => q.eq('projectId', args.project._id))
+      .collect();
+    for (const instance of instances) {
+      const handles = agentInstanceHandles(instance.name);
+      if (handles.length > 0) {
+        entries.push({ type: 'agent', id: String(instance._id), handles });
+      }
+    }
+  } catch (error) {
+    console.warn(
+      '[tasks] buildMentionDirectory: agent instance listing failed',
+      error,
+    );
+  }
+
   return {
     entries,
     permissiveAgents: (args.project.agentMode ?? 'all') !== 'restricted',
   };
+}
+
+/** Derive candidate `@handle`s for a project agent instance from its display
+ * name — the member convention minus email: spaces collapsed and dot-joined. */
+function agentInstanceHandles(name: string): string[] {
+  const normalized = name.trim().toLowerCase();
+  if (normalized === '') return [];
+  return [
+    ...new Set([
+      normalized.replace(/\s+/g, ''),
+      normalized.replace(/\s+/g, '.'),
+    ]),
+  ];
 }
 
 /**

--- a/services/platform/convex/tasks/internal_mutations.ts
+++ b/services/platform/convex/tasks/internal_mutations.ts
@@ -27,6 +27,7 @@ import {
   notifyTaskStatusChanged,
 } from '../collab/notify';
 import { emitEvent } from '../events/emit';
+import { deleteStorageWithMetadata } from '../file_metadata/helpers';
 import { assertAgentAssigneeInProject } from '../projects/resolve_project_access';
 import { canClaimTask, normalizeAssignee } from './access';
 import {
@@ -1630,6 +1631,61 @@ export const scheduleTaskWorkflowStart = internalMutation({
         },
       },
     );
+    return null;
+  },
+});
+
+/**
+ * Merge one settled agent run's harvested deliverables into the task's
+ * `outputs` — the Output zone's write side, called only by the task-agent
+ * settle. Merged by fileName: a rerun producing the same name REPLACES the
+ * entry and purges the superseded blob (idempotent; a rerun handing back the
+ * identical blob is left alone), so the task always shows the latest
+ * deliverable set. New names append in harvest order.
+ */
+export const agentRecordTaskOutputs = internalMutation({
+  args: {
+    organizationId: v.string(),
+    taskId: v.id('tasks'),
+    runId: v.id('projectAgentRuns'),
+    files: v.array(
+      v.object({
+        fileId: v.string(),
+        fileName: v.string(),
+        fileType: v.string(),
+        fileSize: v.number(),
+      }),
+    ),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    if (args.files.length === 0) return null;
+    const task = await loadTaskInOrg(ctx, args.taskId, args.organizationId);
+    const now = Date.now();
+    const next = [...(task.outputs ?? [])];
+    for (const file of args.files) {
+      const fileName = file.fileName.slice(0, 255);
+      if (fileName === '') continue;
+      const entry = {
+        fileId: file.fileId,
+        fileName,
+        fileType: file.fileType,
+        fileSize: file.fileSize,
+        producedAt: now,
+        runId: args.runId,
+      };
+      const at = next.findIndex((output) => output.fileName === fileName);
+      if (at === -1) {
+        next.push(entry);
+        continue;
+      }
+      const replaced = next[at];
+      next[at] = entry;
+      if (replaced !== undefined && replaced.fileId !== file.fileId) {
+        await deleteStorageWithMetadata(ctx, replaced.fileId);
+      }
+    }
+    await ctx.db.patch(args.taskId, { outputs: next, updatedAt: now });
     return null;
   },
 });

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -734,6 +734,98 @@ export const updateTaskStatus = mutation({
 // Assign / unassign (set or clear the polymorphic single assignee)
 // ---------------------------------------------------------------------------
 
+/**
+ * The validated core of an assignee change — live-run guard, patch, activity,
+ * audit, notify, event — shared by `assignTask` and the comment @mention
+ * trigger. The caller has already authorized the write and validated the
+ * assignee ref; this enforces only the cross-engine invariant: ownership
+ * never transfers while ANY engine is live on the task.
+ */
+async function applyAssigneeChange(
+  ctx: MutationCtx,
+  args: {
+    task: Doc<'tasks'>;
+    auth: { userId: string; email?: string };
+    assignee: {
+      assigneeType: 'user' | 'agent' | 'app';
+      assigneeId: string;
+    } | null;
+  },
+): Promise<void> {
+  const { task, auth, assignee } = args;
+  const assigneeChanges =
+    (task.assigneeType ?? null) !== (assignee?.assigneeType ?? null) ||
+    (task.assigneeId ?? null) !== (assignee?.assigneeId ?? null);
+  if (assigneeChanges) {
+    const liveRun =
+      (await liveTaskAgentRun(ctx, task._id)) ??
+      (await findLiveAutomationRunForTask(ctx, {
+        organizationId: task.organizationId,
+        projectId: task.projectId,
+        taskId: task._id,
+      }));
+    if (liveRun !== null) {
+      throw new ConvexError({ code: 'TASK_HAS_LIVE_RUN' });
+    }
+  }
+  const previousAssigneeId = task.assigneeId ?? null;
+
+  await ctx.db.patch(task._id, {
+    assigneeType: assignee?.assigneeType,
+    assigneeId: assignee?.assigneeId,
+    updatedAt: Date.now(),
+  });
+
+  await recordActivity(ctx, {
+    task,
+    actorType: 'user',
+    actorId: auth.userId,
+    action: 'assignee.changed',
+    fromValue: previousAssigneeId ?? undefined,
+    toValue: assignee?.assigneeId,
+  });
+
+  await createAuditLog(ctx, {
+    organizationId: task.organizationId,
+    actorId: auth.userId,
+    actorEmail: auth.email,
+    actorType: 'user',
+    action: assignee
+      ? TASK_AUDIT_ACTIONS.assigned
+      : TASK_AUDIT_ACTIONS.unassigned,
+    category: 'data',
+    resourceType: TASK_RESOURCE_TYPE,
+    resourceId: String(task._id),
+    resourceName: task.title,
+    previousState: { assigneeId: previousAssigneeId },
+    newState: { assigneeId: assignee?.assigneeId ?? null },
+    status: 'success',
+  });
+
+  const updated = await ctx.db.get(task._id);
+  if (updated) {
+    await notifyTaskAssigned(ctx, {
+      task: updated,
+      assigneeType: assignee?.assigneeType ?? null,
+      assigneeId: assignee?.assigneeId ?? null,
+      actorType: 'user',
+      actorId: auth.userId,
+    });
+    await emitEvent(ctx, {
+      organizationId: task.organizationId,
+      eventType: 'task.assigned',
+      eventData: {
+        task: updated,
+        assigneeType: assignee?.assigneeType ?? null,
+        assigneeId: assignee?.assigneeId ?? null,
+        previousAssigneeId,
+        actorType: 'user',
+        actorId: auth.userId,
+      },
+    });
+  }
+}
+
 export const assignTask = mutation({
   args: {
     taskId: v.id('tasks'),
@@ -776,78 +868,8 @@ export const assignTask = mutation({
     // Ownership transfer is refused while ANY engine is live on the task — a
     // reassign under a live run would leave that run driving a task another
     // worker now owns, or start a second engine over the same subject. The
-    // UI offers cancel-then-reassign; this gate is the invariant it relies on.
-    const assigneeChanges =
-      (task.assigneeType ?? null) !== (assignee?.assigneeType ?? null) ||
-      (task.assigneeId ?? null) !== (assignee?.assigneeId ?? null);
-    if (assigneeChanges) {
-      const liveRun =
-        (await liveTaskAgentRun(ctx, args.taskId)) ??
-        (await findLiveAutomationRunForTask(ctx, {
-          organizationId: task.organizationId,
-          projectId: task.projectId,
-          taskId: args.taskId,
-        }));
-      if (liveRun !== null) {
-        throw new ConvexError({ code: 'TASK_HAS_LIVE_RUN' });
-      }
-    }
-    const previousAssigneeId = task.assigneeId ?? null;
-
-    await ctx.db.patch(args.taskId, {
-      assigneeType: assignee?.assigneeType,
-      assigneeId: assignee?.assigneeId,
-      updatedAt: Date.now(),
-    });
-
-    await recordActivity(ctx, {
-      task,
-      actorType: 'user',
-      actorId: auth.userId,
-      action: 'assignee.changed',
-      fromValue: previousAssigneeId ?? undefined,
-      toValue: assignee?.assigneeId,
-    });
-
-    await createAuditLog(ctx, {
-      organizationId: task.organizationId,
-      actorId: auth.userId,
-      actorEmail: auth.email,
-      actorType: 'user',
-      action: assignee
-        ? TASK_AUDIT_ACTIONS.assigned
-        : TASK_AUDIT_ACTIONS.unassigned,
-      category: 'data',
-      resourceType: TASK_RESOURCE_TYPE,
-      resourceId: String(args.taskId),
-      resourceName: task.title,
-      previousState: { assigneeId: previousAssigneeId },
-      newState: { assigneeId: assignee?.assigneeId ?? null },
-      status: 'success',
-    });
-
-    const updated = await ctx.db.get(args.taskId);
-    if (updated) {
-      await notifyTaskAssigned(ctx, {
-        task: updated,
-        assigneeType: assignee?.assigneeType ?? null,
-        assigneeId: assignee?.assigneeId ?? null,
-        actorType: 'user',
-        actorId: auth.userId,
-      });
-      await emitEvent(ctx, {
-        organizationId: task.organizationId,
-        eventType: 'task.assigned',
-        eventData: {
-          task: updated,
-          assigneeType: assignee?.assigneeType ?? null,
-          assigneeId: assignee?.assigneeId ?? null,
-          previousAssigneeId,
-          actorType: 'user',
-          actorId: auth.userId,
-        },
-      });
-    }
+    // UI offers cancel-then-reassign; applyAssigneeChange holds the invariant.
+    await applyAssigneeChange(ctx, { task, auth, assignee });
 
     return null;
   },
@@ -1220,6 +1242,21 @@ export const addTaskComment = mutation({
       });
     }
 
+    // @-ing one of the PROJECT's agent instances puts it to work: the task is
+    // (re)assigned to the first mentioned instance and a run kicks with this
+    // comment as its feedback. Gated on WRITE access — commenting is
+    // read-level, but assigning and running are edits, so a read-only
+    // member's @ only notifies. A refusal (live engine, archived, missing
+    // model) leaves the comment as a plain note; the run card's state is the
+    // user-visible answer either way.
+    await triggerMentionedProjectAgent(ctx, {
+      task,
+      project,
+      auth,
+      mentions,
+      feedback: body,
+    });
+
     const { unresolvedMentionTokens } = await resolveSurfaceMentions(ctx, {
       organizationId: task.organizationId,
       body,
@@ -1229,6 +1266,86 @@ export const addTaskComment = mutation({
     return { messageId, threadId, unresolvedMentionTokens };
   },
 });
+
+/**
+ * The comment-@mention work trigger: resolve the FIRST mentioned project
+ * agent INSTANCE, reassign the task to it when it isn't the assignee yet
+ * (`applyAssigneeChange` — activity, audit, notify, event, exactly like the
+ * picker), then kick a run carrying the comment as feedback. Every refusal
+ * is deliberately quiet: the comment has already posted and notified, and a
+ * task with a live engine must keep it — the mention adds work, never
+ * preempts it.
+ */
+async function triggerMentionedProjectAgent(
+  ctx: MutationCtx,
+  args: {
+    task: Doc<'tasks'>;
+    project: Doc<'projects'>;
+    auth: AuthContext;
+    mentions: ResolvedMention[];
+    feedback: string;
+  },
+): Promise<void> {
+  const { task, project, auth } = args;
+  let instance: Doc<'projectAgents'> | null = null;
+  for (const mention of args.mentions) {
+    if (mention.type !== 'agent') continue;
+    const instanceId = ctx.db.normalizeId('projectAgents', mention.id);
+    if (instanceId === null) continue; // a legacy slug mention — not this lane
+    const candidate = await ctx.db.get(instanceId);
+    if (candidate !== null && candidate.projectId === task.projectId) {
+      instance = candidate;
+      break;
+    }
+  }
+  if (instance === null) return;
+
+  if (
+    !checkProjectAccess(project, auth.teamIds, auth.role).canEdit ||
+    task.archivedAt !== undefined
+  ) {
+    return;
+  }
+  // The reassign-under-live-run invariant, checked up front so a mention
+  // during a live run changes NOTHING (no reassign, no second engine).
+  if (
+    (await liveTaskAgentRun(ctx, task._id)) !== null ||
+    (await findLiveAutomationRunForTask(ctx, {
+      organizationId: task.organizationId,
+      projectId: task.projectId,
+      taskId: task._id,
+    })) !== null
+  ) {
+    return;
+  }
+
+  let current = task;
+  if (
+    task.assigneeType !== 'agent' ||
+    task.assigneeId !== String(instance._id)
+  ) {
+    await applyAssigneeChange(ctx, {
+      task,
+      auth,
+      assignee: { assigneeType: 'agent', assigneeId: String(instance._id) },
+    });
+    const reloaded = await ctx.db.get(task._id);
+    if (reloaded === null) return;
+    current = reloaded;
+  }
+
+  const kicked = await kickTaskAgentRun(ctx, {
+    task: current,
+    auth,
+    trigger: 'mention',
+    feedback: args.feedback,
+  });
+  if (!kicked.started) {
+    console.warn(
+      `[tasks] mention trigger for agent ${String(instance._id)} refused: ${kicked.reason ?? 'unknown'}`,
+    );
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Edit / delete a comment (author-only edit; author-or-admin delete)
@@ -2058,6 +2175,124 @@ async function liveTaskAgentRun(
  * status write, and schedules the node host. Refusals return a reason
  * instead of throwing so the board can toast and snap back.
  */
+/**
+ * The admission + kick core of a task agent run — shared by the explicit
+ * verb (`startTaskAgentRun`) and the comment @mention trigger. The caller
+ * has already authorized the write; this owns the guard matrix (agent
+ * ownership, instance existence, model requirement, single live engine),
+ * the queued run row, the caller-attributed move to In progress, and the
+ * turn-start schedule. `feedback` (the mention comment's body) is stamped
+ * on the run row and carried into the turn's brief.
+ */
+async function kickTaskAgentRun(
+  ctx: MutationCtx,
+  args: {
+    task: Doc<'tasks'>;
+    auth: { userId: string };
+    trigger: 'manual' | 'mention';
+    feedback?: string;
+  },
+): Promise<{ started: boolean; reason?: string }> {
+  const { task, auth } = args;
+  if (task.assigneeType !== 'agent' || task.assigneeId === undefined) {
+    return { started: false, reason: 'not_agent_owned' };
+  }
+  const agentDbId = ctx.db.normalizeId('projectAgents', task.assigneeId);
+  if (agentDbId === null) {
+    return { started: false, reason: 'agent_missing' };
+  }
+  const agent = await ctx.db.get(agentDbId);
+  if (agent === null || agent.projectId !== task.projectId) {
+    return { started: false, reason: 'agent_missing' };
+  }
+  if (agent.model === undefined || agent.model === '') {
+    return { started: false, reason: 'agent_model_missing' };
+  }
+  if ((await liveTaskAgentRun(ctx, task._id)) !== null) {
+    return { started: false, reason: 'already_running' };
+  }
+  // An automation run already operating this task blocks the agent lane —
+  // two engines must never drive one subject at once.
+  if (
+    (await findLiveAutomationRunForTask(ctx, {
+      organizationId: task.organizationId,
+      projectId: task.projectId,
+      taskId: task._id,
+    })) !== null
+  ) {
+    return { started: false, reason: 'automation_run_live' };
+  }
+
+  const now = Date.now();
+  const execId = crypto.randomUUID();
+  const sessionId = sessionIdForProjectAgent(agentDbId);
+  const deadlineAt = now + agentWorkTurnDeadlineMs();
+  const runId = await ctx.db.insert('projectAgentRuns', {
+    organizationId: task.organizationId,
+    projectId: task.projectId,
+    taskId: task._id,
+    agentId: agentDbId,
+    execId,
+    sessionId,
+    status: 'queued',
+    harness: agent.harness,
+    model: agent.model,
+    startedBy: auth.userId,
+    startedAt: now,
+    deadlineAt,
+    updatedAt: now,
+    trigger: args.trigger,
+    ...(args.feedback !== undefined ? { feedback: args.feedback } : {}),
+  });
+
+  // The board verb IS the interface: kicking the run moves the card. The
+  // status write is the CALLER's act (they dragged / clicked / commented),
+  // so it lands as a user activity, not an agent one.
+  if (task.status !== 'in_progress') {
+    const rank = await computeEndRank(ctx, task.projectId, 'in_progress');
+    await ctx.db.patch(task._id, {
+      status: 'in_progress',
+      rank,
+      completedAt: undefined,
+      statusChangedAt: now,
+      updatedAt: now,
+      agentRunsPausedAt: undefined,
+      agentRunsPausedReason: undefined,
+    });
+    await recordActivity(ctx, {
+      task,
+      actorType: 'user',
+      actorId: auth.userId,
+      action: 'status.changed',
+      fromValue: task.status,
+      toValue: 'in_progress',
+    });
+  }
+
+  await ctx.scheduler.runAfter(
+    0,
+    internal.tasks.agent_run_host.startTaskAgentTurn,
+    {
+      organizationId: task.organizationId,
+      runId,
+      taskId: task._id,
+      agentId: agentDbId,
+      execId,
+      sessionId,
+      harness: agent.harness,
+      deadlineAt,
+      model: agent.model,
+      ...(agent.instructions !== undefined
+        ? { instructions: agent.instructions }
+        : {}),
+      skills: agent.skills,
+      connectors: agent.connectors,
+      ...(args.feedback !== undefined ? { feedback: args.feedback } : {}),
+    },
+  );
+  return { started: true };
+}
+
 export const startTaskAgentRun = mutation({
   args: { taskId: v.id('tasks') },
   returns: v.object({ started: v.boolean(), reason: v.optional(v.string()) }),
@@ -2067,101 +2302,7 @@ export const startTaskAgentRun = mutation({
     const auth = await getAuthContext(ctx, task.organizationId);
     assertTaskWritable(project, auth);
     assertTaskNotArchived(task);
-
-    if (task.assigneeType !== 'agent' || task.assigneeId === undefined) {
-      return { started: false, reason: 'not_agent_owned' };
-    }
-    const agentDbId = ctx.db.normalizeId('projectAgents', task.assigneeId);
-    if (agentDbId === null) {
-      return { started: false, reason: 'agent_missing' };
-    }
-    const agent = await ctx.db.get(agentDbId);
-    if (agent === null || agent.projectId !== task.projectId) {
-      return { started: false, reason: 'agent_missing' };
-    }
-    if (agent.model === undefined || agent.model === '') {
-      return { started: false, reason: 'agent_model_missing' };
-    }
-    if ((await liveTaskAgentRun(ctx, args.taskId)) !== null) {
-      return { started: false, reason: 'already_running' };
-    }
-    // An automation run already operating this task blocks the agent lane —
-    // two engines must never drive one subject at once.
-    if (
-      (await findLiveAutomationRunForTask(ctx, {
-        organizationId: task.organizationId,
-        projectId: task.projectId,
-        taskId: args.taskId,
-      })) !== null
-    ) {
-      return { started: false, reason: 'automation_run_live' };
-    }
-
-    const now = Date.now();
-    const execId = crypto.randomUUID();
-    const sessionId = sessionIdForProjectAgent(agentDbId);
-    const deadlineAt = now + agentWorkTurnDeadlineMs();
-    const runId = await ctx.db.insert('projectAgentRuns', {
-      organizationId: task.organizationId,
-      projectId: task.projectId,
-      taskId: args.taskId,
-      agentId: agentDbId,
-      execId,
-      sessionId,
-      status: 'queued',
-      harness: agent.harness,
-      model: agent.model,
-      startedBy: auth.userId,
-      startedAt: now,
-      deadlineAt,
-      updatedAt: now,
-    });
-
-    // The board verb IS the interface: kicking the run moves the card. The
-    // status write is the CALLER's act (they dragged / clicked), so it lands
-    // as a user activity, not an agent one.
-    if (task.status !== 'in_progress') {
-      const rank = await computeEndRank(ctx, task.projectId, 'in_progress');
-      await ctx.db.patch(args.taskId, {
-        status: 'in_progress',
-        rank,
-        completedAt: undefined,
-        statusChangedAt: now,
-        updatedAt: now,
-        agentRunsPausedAt: undefined,
-        agentRunsPausedReason: undefined,
-      });
-      await recordActivity(ctx, {
-        task,
-        actorType: 'user',
-        actorId: auth.userId,
-        action: 'status.changed',
-        fromValue: task.status,
-        toValue: 'in_progress',
-      });
-    }
-
-    await ctx.scheduler.runAfter(
-      0,
-      internal.tasks.agent_run_host.startTaskAgentTurn,
-      {
-        organizationId: task.organizationId,
-        runId,
-        taskId: args.taskId,
-        agentId: agentDbId,
-        execId,
-        sessionId,
-        harness: agent.harness,
-        deadlineAt,
-        model: agent.model,
-        ...(agent.instructions !== undefined
-          ? { instructions: agent.instructions }
-          : {}),
-        skills: agent.skills,
-        connectors: agent.connectors,
-      },
-    );
-    return { started: true };
+    return await kickTaskAgentRun(ctx, { task, auth, trigger: 'manual' });
   },
 });
 

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -21,6 +21,7 @@ import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { UnauthorizedError } from '../lib/rls/errors';
 import { assertActiveOrg } from '../lib/rls/organization/assert_active_org';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { sessionOpTimelinePartValidator } from '../sandbox/sessions_schema';
 import { canClaimTask, checkProjectAccess } from './access';
 import { readTaskDiscussionMessages } from './internal_queries';
 import { listTasksByProjectPaginated as listTasksByProjectPaginatedHelper } from './list_tasks_paginated';
@@ -33,6 +34,7 @@ import {
   taskAssigneeTypeValidator,
   taskAttachmentValidator,
   taskCreatorTypeValidator,
+  taskOutputValidator,
   taskPriorityValidator,
   taskStatusValidator,
 } from './schema';
@@ -218,6 +220,7 @@ export const taskRowValidator = v.object({
   title: v.string(),
   description: v.optional(v.string()),
   attachments: v.optional(v.array(taskAttachmentValidator)),
+  outputs: v.optional(v.array(taskOutputValidator)),
   number: v.optional(v.number()),
   status: taskStatusValidator,
   priority: v.optional(taskPriorityValidator),
@@ -1091,6 +1094,9 @@ const taskAgentRunCardValidator = v.object({
   _id: v.id('projectAgentRuns'),
   status: v.string(),
   agentId: v.string(),
+  /** The agent's display name at read time — absent when the instance was
+   * deleted after the run. */
+  agentName: v.optional(v.string()),
   harness: v.string(),
   model: v.string(),
   error: v.optional(v.string()),
@@ -1123,10 +1129,12 @@ export const getLatestTaskAgentRunForTask = query({
       .collect();
     const latest = runs.sort((a, b) => b.startedAt - a.startedAt)[0];
     if (latest === undefined) return null;
+    const agent = await ctx.db.get(latest.agentId);
     return {
       _id: latest._id,
       status: latest.status,
       agentId: latest.agentId,
+      ...(agent !== null ? { agentName: agent.name } : {}),
       harness: latest.harness,
       model: latest.model,
       ...(latest.error !== undefined ? { error: latest.error } : {}),
@@ -1138,5 +1146,68 @@ export const getLatestTaskAgentRunForTask = query({
         ? { settledAt: latest.settledAt }
         : {}),
     };
+  },
+});
+
+/**
+ * What a task's agent run is DOING inside the sandbox: the harness's live
+ * text plus its bounded tool transcript, read from the run's session op
+ * (`task-agent` kind, written by `tasks/agent_run_host.ts`) — the task-side
+ * twin of `sandbox.session_queries_public.getAgentNodeSandboxOp`. The agent's
+ * STANDING session accumulates one op per run, so the read matches the RUN's
+ * own exec (plus derived incarnations), never a sibling run's op.
+ *
+ * Gated like the run card itself — the task inherits its project's ACL — and
+ * fail-closed: `null` for a non-member, a foreign org, or a run whose turn
+ * has not written its op yet (the card then keeps its plain status line).
+ */
+export const getTaskAgentRunSandboxOp = query({
+  args: { organizationId: v.string(), runId: v.id('projectAgentRuns') },
+  returns: v.union(
+    v.object({
+      execId: v.string(),
+      status: v.union(
+        v.literal('running'),
+        v.literal('completed'),
+        v.literal('failed'),
+        v.literal('cancelled'),
+      ),
+      progressText: v.optional(v.string()),
+      liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
+      startedAt: v.number(),
+      finishedAt: v.optional(v.number()),
+      lastEventAt: v.optional(v.number()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.runId);
+    if (!run || run.organizationId !== args.organizationId) return null;
+    try {
+      await loadAccessibleProject(ctx, run.projectId, args.organizationId);
+    } catch (error) {
+      console.warn('[tasks] agent-run op access refused', error);
+      return null;
+    }
+    const isThisRunsExec = (execId: string) =>
+      execId === run.execId || execId.startsWith(`${run.execId}-`);
+    for await (const op of ctx.db
+      .query('sandboxSessionOps')
+      .withIndex('by_sessionId', (q) => q.eq('sessionId', run.sessionId))
+      .order('desc')) {
+      if (op.kind !== 'task-agent') continue;
+      if (!isThisRunsExec(op.execId)) continue;
+      if (op.organizationId !== args.organizationId) continue;
+      return {
+        execId: op.execId,
+        status: op.status,
+        ...(op.progressText !== undefined && { progressText: op.progressText }),
+        ...(op.liveTimeline !== undefined && { liveTimeline: op.liveTimeline }),
+        startedAt: op.startedAt,
+        ...(op.finishedAt !== undefined && { finishedAt: op.finishedAt }),
+        ...(op.lastEventAt !== undefined && { lastEventAt: op.lastEventAt }),
+      };
+    }
+    return null;
   },
 });

--- a/services/platform/convex/tasks/schema.ts
+++ b/services/platform/convex/tasks/schema.ts
@@ -446,6 +446,12 @@ export const projectAgentRunsTable = defineTable({
   resultText: v.optional(v.string()),
   /** The settled result's task-comment message id (success only). */
   resultMessageId: v.optional(v.string()),
+  /** What kicked the run: the explicit verb / board drag (default) or a
+   * comment @mention of the agent. */
+  trigger: v.optional(v.union(v.literal('manual'), v.literal('mention'))),
+  /** Reviewer feedback carried into the turn's brief — the body of the
+   * @mention comment that kicked this run. */
+  feedback: v.optional(v.string()),
   startedBy: v.string(),
   startedAt: v.number(),
   deadlineAt: v.number(),

--- a/services/platform/convex/tasks/schema.ts
+++ b/services/platform/convex/tasks/schema.ts
@@ -104,6 +104,22 @@ export const taskAttachmentValidator = v.object({
   fileSize: v.number(),
 });
 
+/**
+ * One agent-produced deliverable on the task — the harvested `/user/output`
+ * files of the task's agent runs. Self-described like an attachment, plus the
+ * run that produced it. Merged by `fileName`: a rerun producing the same name
+ * REPLACES the entry (and its blob), so the task always shows the latest
+ * deliverable set instead of accumulating stale copies.
+ */
+export const taskOutputValidator = v.object({
+  fileId: blobRefValidator,
+  fileName: v.string(),
+  fileType: v.string(),
+  fileSize: v.number(),
+  producedAt: v.number(),
+  runId: v.id('projectAgentRuns'),
+});
+
 export const tasksTable = defineTable({
   organizationId: v.string(),
   projectId: v.id('projects'),
@@ -116,6 +132,10 @@ export const tasksTable = defineTable({
   // Self-described so the UI renders without a fileMetadata join; full-replaced
   // by createTask/updateTask like `labels`. Bounded by TASK_MAX_ATTACHMENTS.
   attachments: v.optional(v.array(taskAttachmentValidator)),
+
+  // Agent-run deliverables (harvested `/user/output`), merged by fileName —
+  // written only by the task-agent settle, never by the client.
+  outputs: v.optional(v.array(taskOutputValidator)),
 
   // Per-project sequence number claimed at creation from `projects.taskCounter`.
   // Combined with `projects.key` it forms the human-readable id (e.g. `TAL-7`).

--- a/services/platform/convex/tasks/task_agent_outputs.test.ts
+++ b/services/platform/convex/tasks/task_agent_outputs.test.ts
@@ -1,0 +1,217 @@
+// `agentRecordTaskOutputs` — the Output zone's write side. The settle merges
+// each run's harvested deliverables by fileName: same name REPLACES the entry
+// and purges the superseded blob's metadata, new names append, and the task
+// row always shows the latest deliverable set.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Doc, Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'tasks';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_outputs';
+
+type T = TestConvex<typeof schema>;
+
+async function seedWorld(t: T): Promise<{
+  taskId: Id<'tasks'>;
+  runId: Id<'projectAgentRuns'>;
+}> {
+  return t.run(async (ctx) => {
+    const projectId = await ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Apollo',
+      createdBy: 'u_editor',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const agentId = await ctx.db.insert('projectAgents', {
+      organizationId: ORG,
+      projectId,
+      name: 'Alice',
+      harness: 'claude-code',
+      model: 'z-ai/glm-5',
+      skills: [],
+      connectors: [],
+      createdBy: 'u_editor',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const taskId = await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      projectId,
+      title: 'Build the deck',
+      status: 'in_progress',
+      rank: 'a0',
+      assigneeType: 'agent',
+      assigneeId: agentId,
+      createdBy: 'u_editor',
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const runId = await ctx.db.insert('projectAgentRuns', {
+      organizationId: ORG,
+      projectId,
+      taskId,
+      agentId,
+      execId: 'exec-1',
+      sessionId: 'pa-alice',
+      status: 'running',
+      harness: 'claude-code',
+      model: 'z-ai/glm-5',
+      startedBy: 'u_editor',
+      startedAt: 0,
+      deadlineAt: 10_000,
+      updatedAt: 0,
+    });
+    return { taskId, runId };
+  });
+}
+
+async function seedMetadata(t: T, storageId: string): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('fileMetadata', {
+      organizationId: ORG,
+      storageId,
+      fileName: storageId,
+      contentType: 'application/octet-stream',
+      size: 1,
+      source: 'task-output',
+    });
+  });
+}
+
+function file(name: string, id: string) {
+  return {
+    fileId: id,
+    fileName: name,
+    fileType: 'application/octet-stream',
+    fileSize: 1,
+  };
+}
+
+async function readTask(t: T, taskId: Id<'tasks'>): Promise<Doc<'tasks'>> {
+  const task = await t.run((ctx) => ctx.db.get(taskId));
+  if (!task) throw new Error('task missing');
+  return task;
+}
+
+describe('agentRecordTaskOutputs', () => {
+  it('appends a first run’s deliverables in harvest order', async () => {
+    const t = convexTest(schema, modules);
+    const { taskId, runId } = await seedWorld(t);
+
+    await t.mutation(internal.tasks.internal_mutations.agentRecordTaskOutputs, {
+      organizationId: ORG,
+      taskId,
+      runId,
+      files: [
+        file('deck.pptx', 's3:out/blob-a'),
+        file('notes.md', 's3:out/blob-b'),
+      ],
+    });
+
+    const task = await readTask(t, taskId);
+    expect(task.outputs?.map((o) => [o.fileName, o.fileId])).toEqual([
+      ['deck.pptx', 's3:out/blob-a'],
+      ['notes.md', 's3:out/blob-b'],
+    ]);
+    expect(task.outputs?.every((o) => o.runId === runId)).toBe(true);
+  });
+
+  it('replaces a same-named deliverable and purges the superseded blob', async () => {
+    const t = convexTest(schema, modules);
+    const { taskId, runId } = await seedWorld(t);
+    await seedMetadata(t, 's3:out/blob-old');
+
+    await t.mutation(internal.tasks.internal_mutations.agentRecordTaskOutputs, {
+      organizationId: ORG,
+      taskId,
+      runId,
+      files: [file('deck.pptx', 's3:out/blob-old')],
+    });
+    await t.mutation(internal.tasks.internal_mutations.agentRecordTaskOutputs, {
+      organizationId: ORG,
+      taskId,
+      runId,
+      files: [
+        file('deck.pptx', 's3:out/blob-new'),
+        file('extra.csv', 's3:out/blob-c'),
+      ],
+    });
+
+    const task = await readTask(t, taskId);
+    expect(task.outputs?.map((o) => [o.fileName, o.fileId])).toEqual([
+      ['deck.pptx', 's3:out/blob-new'],
+      ['extra.csv', 's3:out/blob-c'],
+    ]);
+    const oldMeta = await t.run((ctx) =>
+      ctx.db
+        .query('fileMetadata')
+        .withIndex('by_storageId', (q) => q.eq('storageId', 's3:out/blob-old'))
+        .first(),
+    );
+    expect(oldMeta).toBeNull();
+  });
+
+  it('leaves the entry alone when a rerun hands back the identical blob', async () => {
+    const t = convexTest(schema, modules);
+    const { taskId, runId } = await seedWorld(t);
+    await seedMetadata(t, 's3:out/blob-same');
+
+    for (let i = 0; i < 2; i++) {
+      await t.mutation(
+        internal.tasks.internal_mutations.agentRecordTaskOutputs,
+        {
+          organizationId: ORG,
+          taskId,
+          runId,
+          files: [file('deck.pptx', 's3:out/blob-same')],
+        },
+      );
+    }
+
+    const task = await readTask(t, taskId);
+    expect(task.outputs).toHaveLength(1);
+    const meta = await t.run((ctx) =>
+      ctx.db
+        .query('fileMetadata')
+        .withIndex('by_storageId', (q) => q.eq('storageId', 's3:out/blob-same'))
+        .first(),
+    );
+    expect(meta).not.toBeNull();
+  });
+
+  it('is a no-op for an empty harvest', async () => {
+    const t = convexTest(schema, modules);
+    const { taskId, runId } = await seedWorld(t);
+
+    await t.mutation(internal.tasks.internal_mutations.agentRecordTaskOutputs, {
+      organizationId: ORG,
+      taskId,
+      runId,
+      files: [],
+    });
+
+    const task = await readTask(t, taskId);
+    expect(task.outputs).toBeUndefined();
+  });
+});

--- a/services/platform/convex/tasks/task_agent_run_op.test.ts
+++ b/services/platform/convex/tasks/task_agent_run_op.test.ts
@@ -1,0 +1,239 @@
+// `getTaskAgentRunSandboxOp` — the read behind the run card's "Details"
+// transcript. The agent's STANDING session accumulates one op per run, so the
+// query must key to the RUN's own exec (never a sibling run's op), surface
+// only the `task-agent` lane, and stay fail-closed for outsiders.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import type { Doc, Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'tasks';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_runop';
+const EDITOR = 'u_editor';
+const STRANGER = 'u_stranger';
+
+type T = TestConvex<typeof schema>;
+
+/** Seed the world and kick a run through the real door, so the row carries
+ * the host's own execId/sessionId shape. */
+async function seedRun(t: T): Promise<{
+  taskId: Id<'tasks'>;
+  run: Doc<'projectAgentRuns'>;
+}> {
+  const taskId = await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      memberId: `m_${EDITOR}_${ORG}`,
+      userId: EDITOR,
+      organizationId: ORG,
+      role: 'editor',
+      createdAt: 0,
+    });
+    const projectId = await ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Apollo',
+      createdBy: EDITOR,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const agentId = await ctx.db.insert('projectAgents', {
+      organizationId: ORG,
+      projectId,
+      name: 'Alice',
+      harness: 'claude-code',
+      model: 'z-ai/glm-5',
+      skills: [],
+      connectors: [],
+      createdBy: EDITOR,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    return await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      projectId,
+      title: 'Build the deck',
+      status: 'todo',
+      rank: 'a0',
+      assigneeType: 'agent',
+      assigneeId: agentId,
+      createdBy: EDITOR,
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+  });
+  await t
+    .withIdentity({ subject: EDITOR })
+    .mutation(api.tasks.mutations.startTaskAgentRun, { taskId });
+  const run = await t.run(async (ctx) => {
+    const rows = await ctx.db.query('projectAgentRuns').collect();
+    return rows[0];
+  });
+  if (!run) throw new Error('run row missing');
+  return { taskId, run };
+}
+
+async function seedOp(
+  t: T,
+  run: Doc<'projectAgentRuns'>,
+  overrides: {
+    execId?: string;
+    kind?: string;
+    status?: 'running' | 'completed' | 'failed' | 'cancelled';
+    progressText?: string;
+    liveTimeline?: { type: string; text?: string }[];
+    startedAt?: number;
+  } = {},
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('sandboxSessionOps', {
+      organizationId: ORG,
+      sessionId: run.sessionId,
+      execId: overrides.execId ?? run.execId,
+      kind: overrides.kind ?? 'task-agent',
+      status: overrides.status ?? 'running',
+      startedAt: overrides.startedAt ?? 0,
+      ...(overrides.progressText !== undefined && {
+        progressText: overrides.progressText,
+      }),
+      ...(overrides.liveTimeline !== undefined && {
+        liveTimeline: overrides.liveTimeline,
+      }),
+    });
+  });
+}
+
+describe('getTaskAgentRunSandboxOp', () => {
+  it('returns the run’s own op with its transcript', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    await seedOp(t, run, {
+      progressText: 'laying out the slides',
+      liveTimeline: [{ type: 'tool-Bash', text: undefined }],
+    });
+
+    const op = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: ORG,
+        runId: run._id,
+      });
+    expect(op).toMatchObject({
+      execId: run.execId,
+      status: 'running',
+      progressText: 'laying out the slides',
+      liveTimeline: [{ type: 'tool-Bash' }],
+    });
+  });
+
+  it('matches a derived exec incarnation of the same run', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    await seedOp(t, run, { execId: `${run.execId}-t1`, startedAt: 5 });
+
+    const op = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: ORG,
+        runId: run._id,
+      });
+    expect(op).toMatchObject({ execId: `${run.execId}-t1` });
+  });
+
+  it('never surfaces a sibling run’s op from the shared standing session', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    // A NEWER op of another run in the same session must not shadow ours.
+    await seedOp(t, run, {
+      execId: 'run-other-exec',
+      progressText: 'someone else’s turn',
+      startedAt: 99,
+    });
+    await seedOp(t, run, { progressText: 'this run’s turn', startedAt: 1 });
+
+    const op = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: ORG,
+        runId: run._id,
+      });
+    expect(op).toMatchObject({
+      execId: run.execId,
+      progressText: 'this run’s turn',
+    });
+  });
+
+  it('ignores non-agent ops of the same exec', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    await seedOp(t, run, { kind: 'exec', progressText: 'run_code output' });
+
+    const op = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: ORG,
+        runId: run._id,
+      });
+    expect(op).toBeNull();
+  });
+
+  it('fails closed for a non-member', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    await seedOp(t, run, { progressText: 'private' });
+
+    const op = await t
+      .withIdentity({ subject: STRANGER })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: ORG,
+        runId: run._id,
+      });
+    expect(op).toBeNull();
+  });
+
+  it('fails closed when the org does not own the run', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    await seedOp(t, run, { progressText: 'private' });
+
+    const op = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: 'org_other',
+        runId: run._id,
+      });
+    expect(op).toBeNull();
+  });
+});
+
+describe('getLatestTaskAgentRunForTask agent name', () => {
+  it('carries the agent’s display name for the details dialog title', async () => {
+    const t = convexTest(schema, modules);
+    const { taskId } = await seedRun(t);
+
+    const card = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getLatestTaskAgentRunForTask, {
+        organizationId: ORG,
+        taskId,
+      });
+    expect(card).toMatchObject({ agentName: 'Alice' });
+  });
+});

--- a/services/platform/convex/tasks/task_agent_runs.test.ts
+++ b/services/platform/convex/tasks/task_agent_runs.test.ts
@@ -7,6 +7,8 @@
 // out of scope here (it cannot run under convex-test) — the live-run E2E
 // covers that lane.
 
+import agentComponent from '@convex-dev/agent/test';
+import rateLimiterComponent from '@convex-dev/rate-limiter/test';
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
@@ -300,5 +302,132 @@ describe('listStalledTaskAgentTurns', () => {
       await ctx.db.patch(run._id, { status: 'settled', startedAt: 0 });
     });
     expect(await stalled(t)).toHaveLength(0);
+  });
+});
+
+// The comment @mention work trigger: @-ing a project agent INSTANCE by its
+// display name (re)assigns the task and kicks a run that carries the comment
+// as feedback. Comment posting needs the rate-limiter and agent (discussion
+// store) components the mutation rides on.
+describe('comment @mention trigger', () => {
+  function world(): T {
+    const t = convexTest(schema, modules);
+    rateLimiterComponent.register(t);
+    agentComponent.register(t);
+    return t;
+  }
+
+  async function runs(t: T) {
+    return await t.run((ctx) => ctx.db.query('projectAgentRuns').collect());
+  }
+
+  it('kicks a run carrying the comment as feedback (dot handle)', async () => {
+    const t = world();
+    const { taskId, agentId } = await seedWorld(t);
+
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: '@pr.reviewer 第3页的图请换成真实照片',
+      });
+
+    const rows = await runs(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agentId,
+      trigger: 'mention',
+      feedback: '@pr.reviewer 第3页的图请换成真实照片',
+    });
+    const task = await t.run((ctx) => ctx.db.get(taskId));
+    expect(task?.status).toBe('in_progress');
+  });
+
+  it('reassigns to a different mentioned agent, then kicks it', async () => {
+    const t = world();
+    const { taskId, projectId } = await seedWorld(t);
+    const bobId = await t.run((ctx) =>
+      ctx.db.insert('projectAgents', {
+        organizationId: ORG,
+        projectId,
+        name: 'Bob',
+        harness: 'claude-code',
+        model: 'z-ai/glm-5',
+        skills: [],
+        connectors: [],
+        createdBy: EDITOR,
+        createdAt: 0,
+        updatedAt: 0,
+      }),
+    );
+
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: '@bob take this over',
+      });
+
+    const task = await t.run((ctx) => ctx.db.get(taskId));
+    expect(task?.assigneeType).toBe('agent');
+    expect(task?.assigneeId).toBe(String(bobId));
+    const rows = await runs(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ agentId: bobId, trigger: 'mention' });
+  });
+
+  it('changes nothing while a run is live', async () => {
+    const t = world();
+    const { taskId, agentId } = await seedWorld(t);
+    const asEditor = t.withIdentity({ subject: EDITOR });
+    await asEditor.mutation(api.tasks.mutations.startTaskAgentRun, { taskId });
+
+    await asEditor.mutation(api.tasks.mutations.addTaskComment, {
+      taskId,
+      body: '@pr.reviewer hurry up',
+    });
+
+    const rows = await runs(t);
+    expect(rows).toHaveLength(1); // still only the manual run
+    expect(rows[0]).toMatchObject({ agentId, trigger: 'manual' });
+    const task = await t.run((ctx) => ctx.db.get(taskId));
+    expect(task?.assigneeId).toBe(String(agentId));
+  });
+
+  it("a read-only member's mention only comments", async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberMirror', {
+        memberId: `m_u_viewer_${ORG}`,
+        userId: 'u_viewer',
+        organizationId: ORG,
+        role: 'member',
+        createdAt: 0,
+      });
+    });
+
+    await t
+      .withIdentity({ subject: 'u_viewer' })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: '@pr.reviewer please rerun',
+      });
+
+    expect(await runs(t)).toHaveLength(0);
+  });
+
+  it('a comment without an agent mention never kicks', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: 'looks good, minor nits only',
+      });
+
+    expect(await runs(t)).toHaveLength(0);
   });
 });

--- a/services/platform/convex/tasks/task_agent_runs.test.ts
+++ b/services/platform/convex/tasks/task_agent_runs.test.ts
@@ -417,6 +417,30 @@ describe('comment @mention trigger', () => {
     expect(await runs(t)).toHaveLength(0);
   });
 
+  it('the directory resolves an instance by name variants AND raw id', async () => {
+    // A REAL Convex id fits the mention charset, so a picker-inserted or
+    // copied id token must resolve even under agentMode 'restricted' (no
+    // permissive fallback). convex-test ids carry a ';' the parser rejects,
+    // so this locks the DIRECTORY contract rather than the full comment path.
+    const t = world();
+    const { projectId, agentId } = await seedWorld(t);
+
+    const entry = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectId);
+      if (!project) throw new Error('project missing');
+      const { buildMentionDirectory } = await import('./directory');
+      const directory = await buildMentionDirectory(ctx, {
+        organizationId: ORG,
+        project,
+      });
+      return directory.entries.find((e) => e.id === String(agentId));
+    });
+    expect(entry).toBeDefined();
+    expect(entry?.handles).toContain('pr.reviewer');
+    expect(entry?.handles).toContain('prreviewer');
+    expect(entry?.handles).toContain(String(agentId).toLowerCase());
+  });
+
   it('a comment without an agent mention never kicks', async () => {
     const t = world();
     const { taskId } = await seedWorld(t);

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -7052,6 +7052,8 @@ tasks:
     remove: Anhang entfernen
     uploading: Wird hochgeladen …
     dropHint: Bilder oder Dokumente hierher ziehen oder zum Auswählen klicken
+  outputs:
+    label: Ergebnisdateien
   title: Aufgaben
   entityLabel: Aufgaben
   status:

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -7003,12 +7003,14 @@ tasks:
     start: Agent starten
     willStart: Hier ablegen startet den Agenten-Lauf.
     willCancel: Hier ablegen bricht den laufenden Agenten-Lauf ab.
+    # Ein kurzes Wort pro Zustand — die Zeile steht im schmalen
+    # Eigenschaften-Panel neben „Lauf“ und dem Status-Chip der Aufgabe.
     status:
-      queued: Agenten-Lauf wartet
-      running: Agent arbeitet…
-      settled: Zur Prüfung gemeldet
-      failed: Agenten-Lauf fehlgeschlagen
-      cancelled: Agenten-Lauf abgebrochen
+      queued: Wartet
+      running: Arbeitet…
+      settled: Fertig
+      failed: Fehlgeschlagen
+      cancelled: Abgebrochen
     retry: Erneut ausführen
     cancel: Lauf abbrechen
   automation:

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6995,11 +6995,11 @@ tasks:
     cancelConfirmBody: 'Der {name}-Lauf zu dieser Aufgabe stoppt; die Aufgabe parkt auf Abgebrochen und lässt sich erneut starten.'
     cancelConfirmMove: Ein Lauf arbeitet noch an dieser Aufgabe — verschiebst du sie aus In Bearbeitung, bricht das den Lauf ab. Danach lässt er sich erneut starten.
   agentRun:
+    label: Lauf
     started: Der Agent ist dran — er meldet sich zur Prüfung an dieser Aufgabe zurück.
     alreadyRunning: Der Agent dieser Aufgabe läuft bereits.
     notStarted: Der Agenten-Lauf konnte nicht starten.
     cancelled: Der Agenten-Lauf wurde abgebrochen.
-    idle: Der zugewiesene Agent ist noch nicht gelaufen — starte ihn, sobald die Aufgabe bereit ist.
     start: Agent starten
     willStart: Hier ablegen startet den Agenten-Lauf.
     willCancel: Hier ablegen bricht den laufenden Agenten-Lauf ab.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -7075,11 +7075,11 @@ tasks:
     cancelConfirmBody: 'The {name} run working this task stops; the task parks at Cancelled and can be started again.'
     cancelConfirmMove: A run is still working this task — moving it out of In progress cancels that run. It can be started again afterwards.
   agentRun:
+    label: Run
     started: The agent is on it — it reports back to this task for review.
     alreadyRunning: This task's agent is already running.
     notStarted: The agent run could not start.
     cancelled: The agent run was cancelled.
-    idle: The assigned agent has not run yet — start it when the task is ready.
     start: Start agent
     willStart: Dropping here starts the agent run.
     willCancel: Dropping here cancels the agent's live run.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -7083,12 +7083,15 @@ tasks:
     start: Start agent
     willStart: Dropping here starts the agent run.
     willCancel: Dropping here cancels the agent's live run.
+    # One short word per state — the strip sits in the narrow property panel
+    # next to a "Run" label, an agent avatar, and the task's own Status chip,
+    # so anything longer truncates and repeats what the panel already says.
     status:
-      queued: Agent run queued
-      running: Agent working…
-      settled: Reported for review
-      failed: Agent run failed
-      cancelled: Agent run cancelled
+      queued: Queued
+      running: Working…
+      settled: Finished
+      failed: Failed
+      cancelled: Cancelled
     retry: Retry
     cancel: Cancel run
   automation:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -7131,6 +7131,8 @@ tasks:
     remove: Remove attachment
     uploading: Uploading…
     dropHint: Drop images or documents, or click to browse
+  outputs:
+    label: Output
   title: Tasks
   entityLabel: tasks
   status:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7146,6 +7146,8 @@ tasks:
     remove: Supprimer la pièce jointe
     uploading: Téléversement…
     dropHint: Déposez des images ou des documents, ou cliquez pour parcourir
+  outputs:
+    label: Fichiers produits
   title: Tâches
   entityLabel: tâches
   status:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7096,12 +7096,14 @@ tasks:
     start: Démarrer l'agent
     willStart: "Déposer ici démarre l'exécution de l'agent."
     willCancel: "Déposer ici annule l'exécution en cours de l'agent."
+    # Un mot court par état — la ligne vit dans le panneau de propriétés,
+    # à côté du libellé « Exécution » et du statut de la tâche.
     status:
-      queued: Exécution de l'agent en attente
-      running: L'agent travaille…
-      settled: Rendu pour relecture
-      failed: Exécution de l'agent en échec
-      cancelled: Exécution de l'agent annulée
+      queued: En attente
+      running: En cours…
+      settled: Terminée
+      failed: Échouée
+      cancelled: Annulée
     retry: Relancer
     cancel: Annuler l'exécution
   automation:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7088,11 +7088,11 @@ tasks:
     cancelConfirmBody: "L'exécution {name} sur cette tâche s'arrête ; la tâche passe à Annulé et peut être relancée."
     cancelConfirmMove: Une exécution travaille encore sur cette tâche — la sortir de En cours annule cette exécution. Elle pourra être relancée ensuite.
   agentRun:
+    label: Exécution
     started: L'agent s'y met — il rendra compte sur cette tâche pour relecture.
     alreadyRunning: L'agent de cette tâche tourne déjà.
     notStarted: L'exécution de l'agent n'a pas pu démarrer.
     cancelled: L'exécution de l'agent a été annulée.
-    idle: "L'agent assigné n'a pas encore tourné — démarre-le quand la tâche est prête."
     start: Démarrer l'agent
     willStart: "Déposer ici démarre l'exécution de l'agent."
     willCancel: "Déposer ici annule l'exécution en cours de l'agent."


### PR DESCRIPTION
## What

Four related pieces around the task-agent run lane, driven by watching a real run (the panda-deck task) end to end:

1. **Details entry on the task's agent run card.** The run card only said "Agent working…" with no way to see what the agent was doing, and nothing at all after it settled. Every run (live, settled, failed) now offers **Details** — a dialog with the run's sandbox transcript (agent prose + tool rows, unfoldable payloads). The transcript view is extracted from the automation lane's `AgentExecutionLog` so both lanes render through one component; the new `getTaskAgentRunSandboxOp` query is project-ACL-gated like the run card itself and keys to the run's own exec inside the agent's standing session.

2. **The task lane now streams live progress at all.** Root cause of the empty log: `tasks/agent_run_host.ts` ran `drainHarnessWindow` with **no progress sink**, so the op row never carried `progressText`/`liveTimeline` — live or settled. `liveProgressSink` moves out of the automation host (parameterized by op kind) and both task-agent drain sites flush exactly like workflow agent nodes.

3. **Agent deliverables attach to the task (Output zone, overwrite-by-name).** Harvested `/user/output` files previously stranded in blob storage with only their *names* in the report comment — and, unclaimed, the agent temp-retention GC would sweep the blobs. The settle now (a) claims each blob's metadata out of the GC lane, (b) merges the files into a new `outputs` field on the task — **same fileName replaces the entry and purges the superseded blob; new names append** — and (c) the task modal renders them as a read-only **Output** zone (en/de/fr). The standing session's `/user/output` is swept at turn start; without that, a previous task's leftovers re-harvested onto whatever task ran next (observed live: a prior deck landed on an unrelated task).

4. **Vision polyfill: never auto-select a `:free` model.** The cheapest-first pick chose `google/gemma-4-26b-a4b-it:free` (price 0) and **every vision call of the observed run 401'd at the provider** (35/35 in the gateway log) — free tiers sit behind per-account data-policy gates and hard rate caps. Auto-selection now skips `:free` variants; an explicit allowlist pin can still name one.

## Verification

- Unit: new convex-test suites for the op query (exec matching, sibling-run isolation, fail-closed access) and the outputs merge (append / replace+purge / identical-blob no-op / empty no-op); a `:free`-exclusion case for the vision resolver; UI tests for the Details dialog (transcript + empty state). Touched-area suites green: 619 server + 232 UI tests; `migrations:check` green (`outputs` is a data-safe additive field); locale parity suites green.
- Live, against the dev stack: started a fresh agent run — Details shows the transcript streaming while the run works and keeps it after settle; the Output zone appears with the produced file; a second run producing the same fileName **replaced** the entry (new blob id, still one row); the leftover-sweep kept the prior task's stale deck out of the second harvest.

## Notes

- The Output zone reuses the attachments renderer under its own label — no new file-display code path.
- `sessionOpTimelinePartValidator` replaces three inline copies of the timeline-part shape.
- The wrongly-attached deck on my local smoke task predates the sweep fix and stays as dev data; new runs can't reproduce it.