### PR TITLE
fix(platform): align imap-smtp TLS mode with well-known ports

### DIFF
--- a/configs/platform/system/connectors/imap-smtp/connector.yml
+++ b/configs/platform/system/connectors/imap-smtp/connector.yml
@@ -31,14 +31,16 @@ configFields:
   - key: smtpPort
     label: SMTP port
     type: number
-    default: 587
-    description: SMTP port (587 for STARTTLS, 465 for implicit TLS).
+    default: 465
+    description: SMTP port (465 for implicit TLS, 587 for STARTTLS).
   - key: security
     label: Connection security
     type: string
     enum: [tls, starttls]
     default: tls
-    description: Transport security for both servers.
+    description: >-
+      Fallback when a port is not standard. Ports 465 and 993 always use
+      implicit TLS; ports 587 and 143 always use STARTTLS.
   - key: sentMailbox
     label: Sent folder
     type: string

--- a/services/platform/lib/connectors/natives/imap-smtp.test.ts
+++ b/services/platform/lib/connectors/natives/imap-smtp.test.ts
@@ -526,6 +526,57 @@ describe('mailbox configuration', () => {
     expect(config.sentMailbox).toBe('INBOX.Sent');
   });
 
+  it('lets well-known ports override a mismatched security setting', () => {
+    // The connector declares one `security` for both servers, and the catalog
+    // once defaulted smtpPort to 587 while security stayed `tls` — implicit
+    // TLS against a STARTTLS greeting is OpenSSL's `wrong version number`.
+    const mismatched = mailboxConfigFromCredential(
+      context({
+        config: {
+          imapHost: 'imap.gmail.com',
+          smtpHost: 'smtp.gmail.com',
+          security: 'tls',
+          smtpPort: 587,
+        },
+      }),
+      'send',
+    );
+    expect(mismatched.imap).toMatchObject({ port: 993, secure: true });
+    expect(mismatched.smtp).toMatchObject({ port: 587, secure: false });
+
+    const reverse = mailboxConfigFromCredential(
+      context({
+        config: {
+          imapHost: 'imap.gmail.com',
+          smtpHost: 'smtp.gmail.com',
+          security: 'starttls',
+          imapPort: 993,
+          smtpPort: 465,
+        },
+      }),
+      'send',
+    );
+    expect(reverse.imap).toMatchObject({ port: 993, secure: true });
+    expect(reverse.smtp).toMatchObject({ port: 465, secure: true });
+  });
+
+  it('honours security only for non-standard ports', () => {
+    const config = mailboxConfigFromCredential(
+      context({
+        config: {
+          imapHost: 'mail.example.com',
+          smtpHost: 'mail.example.com',
+          security: 'starttls',
+          imapPort: 10143,
+          smtpPort: 10465,
+        },
+      }),
+      'send',
+    );
+    expect(config.imap.secure).toBe(false);
+    expect(config.smtp.secure).toBe(false);
+  });
+
   it('sends through a separate SMTP relay login when one is stored', () => {
     // 0.3's "Use a separate SMTP provider" — IMAP keeps the mailbox login,
     // SMTP authenticates as the relay (Resend's `resend` + API key, …).

--- a/services/platform/lib/connectors/natives/imap-smtp.ts
+++ b/services/platform/lib/connectors/natives/imap-smtp.ts
@@ -46,6 +46,9 @@ const MAX_LIMIT = 100;
 /** Standard IMAPS port: implicit TLS from the first byte. */
 const IMAPS_PORT = 993;
 
+/** Standard IMAP port: cleartext handshake upgraded by STARTTLS. */
+const IMAP_PORT = 143;
+
 /** Standard submission port: cleartext handshake upgraded by STARTTLS. */
 const SUBMISSION_PORT = 587;
 
@@ -63,7 +66,8 @@ const SOCKET_TIMEOUT_MS = 30_000;
 export interface MailServer {
   readonly host: string;
   readonly port: number;
-  /** `true` → TLS from the first byte (993, 465). `false` → STARTTLS. */
+  /** `true` → TLS from the first byte (993, 465). `false` → STARTTLS
+   * (143, 587). Derived from the port for those well-known values. */
   readonly secure: boolean;
 }
 
@@ -260,22 +264,32 @@ export function mailboxConfigFromCredential(
 
   // `tls` means TLS from the first byte (implicit); `starttls` upgrades a
   // plaintext connection, which the transport then REQUIRES — see
-  // `nodeMailTransport`. Defaults match the connector's declared defaults.
-  const secure = configString(ctx, 'security', 'tls') !== 'starttls';
+  // `nodeMailTransport`. Well-known ports always win over the shared
+  // `security` field: the connector declares one mode for both servers, but
+  // Gmail-style setups mix IMAPS 993 with submission 587, and a mismatched
+  // pair (tls + 587, or starttls + 465) is exactly OpenSSL's
+  // `wrong version number`. Defaults match the connector's declared defaults.
+  const configuredSecure = configString(ctx, 'security', 'tls') !== 'starttls';
   const imapPort = configPort(ctx, 'imapPort', IMAPS_PORT);
   const smtpPort = configPort(
     ctx,
     'smtpPort',
-    secure ? SMTPS_PORT : SUBMISSION_PORT,
+    configuredSecure ? SMTPS_PORT : SUBMISSION_PORT,
   );
   const pinnedSent = configString(ctx, 'sentMailbox');
 
   return {
-    imap: { host: imapHost, port: imapPort, secure, user, password },
+    imap: {
+      host: imapHost,
+      port: imapPort,
+      secure: secureForPort(imapPort, configuredSecure),
+      user,
+      password,
+    },
     smtp: {
       host: smtpHost,
       port: smtpPort,
-      secure,
+      secure: secureForPort(smtpPort, configuredSecure),
       user: useSeparateSmtp ? smtpUser : user,
       password: useSeparateSmtp ? smtpPassword : password,
     },
@@ -308,6 +322,24 @@ function configPort(
   const value = ctx.config[key];
   const port = typeof value === 'number' ? value : Number(value);
   return Number.isInteger(port) && port > 0 && port <= 65535 ? port : fallback;
+}
+
+/**
+ * Resolve whether a mail port speaks TLS from the first byte.
+ *
+ * Standard ports encode the mode themselves — 993/465 are implicit TLS,
+ * 143/587 are STARTTLS — so a shared `security` select cannot override them
+ * without producing OpenSSL's `wrong version number` (client starts TLS on a
+ * plaintext greeting, or the reverse). Non-standard ports honour the
+ * configured fallback.
+ */
+export function secureForPort(
+  port: number,
+  configuredSecure: boolean,
+): boolean {
+  if (port === IMAPS_PORT || port === SMTPS_PORT) return true;
+  if (port === IMAP_PORT || port === SUBMISSION_PORT) return false;
+  return configuredSecure;
 }
 
 /** Which folder the caller asked for. `sent` is a role, not a path: servers

--- a/services/platform/lib/shared/schemas/shipped-connectors.test.ts
+++ b/services/platform/lib/shared/schemas/shipped-connectors.test.ts
@@ -127,4 +127,19 @@ describe('shipped connector catalog', () => {
       }
     },
   );
+
+  it('imap-smtp: smtp port and security defaults agree on the TLS mode', () => {
+    // normalizeConfig applies every declared default when the form leaves a
+    // field blank. tls+587 (or starttls+465) is OpenSSL's wrong version number
+    // on the live send path — keep the pair coherent.
+    const fields = Object.fromEntries(
+      loadConnector('imap-smtp').configFields.map((field) => [
+        field.key,
+        field,
+      ]),
+    );
+    expect(fields.security?.default).toBe('tls');
+    expect(fields.smtpPort?.default).toBe(465);
+    expect(fields.imapPort?.default).toBe(993);
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes live `imap-smtp.send` failing with OpenSSL `wrong version number` when the connector defaults paired `smtpPort: 587` (STARTTLS) with `security: tls` (implicit TLS).
- Well-known ports now own the TLS mode (`465`/`993` → implicit TLS; `587`/`143` → STARTTLS), so Gmail-style mixed setups and already-saved mismatched credentials work without a migration.
- Aligns catalog defaults to `smtpPort: 465` + `security: tls` and locks the pair with a catalog regression test.

## Test plan
- [x] `bun run --filter @tale/platform test -- lib/connectors/natives/imap-smtp.test.ts lib/shared/schemas/shipped-connectors.test.ts`
- [ ] Re-test live `imap-smtp.send` against Gmail (`smtp.gmail.com:465` or `:587`) with a previously failing credential
- [ ] Confirm a fresh IMAP/SMTP credential form still saves with coherent defaults