### PR TITLE
fix(platform): automations list, archive split, credential errors, UI polish

### DIFF
--- a/docs/de/platform/automations/catalog.md
+++ b/docs/de/platform/automations/catalog.md
@@ -41,7 +41,7 @@ Zum Hochladen öffnest du **Automatisierungen**, wählst im Menü **Neue Automat
 
 Wähle vor dem Absenden, wo die Automatisierung installiert wird — Organisation oder ein Projekt. Die Wahl ist nicht endgültig: Die Installation in ein Projekt bindet die Automatisierung daran, und im Bereich **Projekte** auf ihrer Seite verwaltest du die Bindungen später — binde weitere Projekte oder entferne alle, dann gilt sie organisationsweit.
 
-<Frame caption="Ein Automatisierungs-Paket hochladen — die Dateien oder eine Zip, und die Oberfläche, an die die Automatisierung gebunden wird.">
+<Frame caption="Paket hochladen — die Dateien oder eine Zip, und wo die Automatisierung installiert wird.">
 
 ![Der Dialog zum Paket-Upload mit seiner Ablagezone und dem Auswahlfeld Installieren in, gesetzt auf Organisation.](/images/platform/automations-upload-dialog.webp)
 

--- a/docs/en/platform/automations/catalog.md
+++ b/docs/en/platform/automations/catalog.md
@@ -41,7 +41,7 @@ To upload one, open **Automations**, pick **Upload package** from the **New auto
 
 Pick where the automation installs — the organization, or one project — before you submit. The choice is not final: installing into a project binds the automation to it, and the **Projects** panel on the automation's page manages the whole set afterwards — bind more projects, or none to serve the whole organization.
 
-<Frame caption="Upload an automation package — the files or one zip, and the surface the automation installs into.">
+<Frame caption="Upload package — the files or one zip, and where the automation installs.">
 
 ![The upload package dialog with its file drop zone and the Install into picker set to Organization.](/images/platform/automations-upload-dialog.webp)
 

--- a/docs/fr/platform/automations/catalog.md
+++ b/docs/fr/platform/automations/catalog.md
@@ -41,7 +41,7 @@ Pour téléverser, ouvre **Automatisations**, choisis **Téléverser un paquet**
 
 Choisis avant d’envoyer où l’automatisation s’installe — l’organisation, ou un projet. Le choix n’est pas définitif : installer dans un projet lie l’automatisation à ce projet, et le panneau **Projets** de sa page gère l’ensemble ensuite — lie d’autres projets, ou aucun pour qu’elle serve toute l’organisation.
 
-<Frame caption="Téléverser un paquet d’automatisation — les fichiers ou un zip, et la surface à laquelle l’automatisation est liée.">
+<Frame caption="Téléverser un paquet — les fichiers ou un zip, et où l’automatisation s’installe.">
 
 ![Le dialogue de téléversement de paquet avec sa zone de dépôt et le sélecteur Installer dans réglé sur Organisation.](/images/platform/automations-upload-dialog.webp)
 

--- a/packages/ui/src/components/layout/section-header.tsx
+++ b/packages/ui/src/components/layout/section-header.tsx
@@ -56,7 +56,9 @@ export const SectionHeader = forwardRef<HTMLDivElement, SectionHeaderProps>(
       <div className="flex flex-col gap-1">
         <Tag className={titleVariants({ size, weight })}>{title}</Tag>
         {description && (
-          <Description className="text-sm">{description}</Description>
+          <Description className="max-w-prose text-sm">
+            {description}
+          </Description>
         )}
       </div>
     );

--- a/packages/ui/src/markdown/shiki.test.ts
+++ b/packages/ui/src/markdown/shiki.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { highlightCode, resolveShikiTheme } from './shiki';
+
+describe('resolveShikiTheme', () => {
+  it('maps light aliases onto min-light', () => {
+    expect(resolveShikiTheme('light')).toBe('min-light');
+    expect(resolveShikiTheme('github-light')).toBe('min-light');
+    expect(resolveShikiTheme('min-light')).toBe('min-light');
+  });
+
+  it('maps dark aliases onto min-dark', () => {
+    expect(resolveShikiTheme('dark')).toBe('min-dark');
+    expect(resolveShikiTheme('github-dark')).toBe('min-dark');
+    expect(resolveShikiTheme('min-dark')).toBe('min-dark');
+  });
+});
+
+describe('highlightCode themes', () => {
+  it('emits min-* theme classes for github-* aliases (#2785)', async () => {
+    const dark = await highlightCode('const x = 1;', 'ts', 'github-dark');
+    expect(dark?.html).toContain('class="shiki min-dark"');
+
+    const light = await highlightCode('{"a":1}', 'json', 'github-light');
+    expect(light?.html).toContain('class="shiki min-light"');
+  });
+});

--- a/services/platform/app/components/catalog/catalog-view.test.tsx
+++ b/services/platform/app/components/catalog/catalog-view.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { Plug } from 'lucide-react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render, screen } from '@/tests/utils/render';
@@ -56,6 +56,17 @@ describe('CatalogView', () => {
     expect(
       screen.queryByRole('heading', { name: 'github' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('offers an inline Try again control when onRetry is set', () => {
+    const onRetry = vi.fn();
+    renderView({
+      isError: true,
+      errorMessage: "Couldn't load the connectors.",
+      onRetry,
+    });
+    screen.getByRole('button', { name: 'Try again' }).click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
   it('offers the create CTA only when nothing exists yet', () => {

--- a/services/platform/app/components/catalog/catalog-view.tsx
+++ b/services/platform/app/components/catalog/catalog-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Alert } from '@tale/ui/alert';
+import { Button } from '@tale/ui/button';
 import { EmptyState } from '@tale/ui/empty-state';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { SearchX } from 'lucide-react';
@@ -45,8 +46,10 @@ interface CatalogViewProps<T> {
   isPending: boolean;
   /** True when the listing failed outright (no data to show). */
   isError?: boolean;
-  /** Human-readable listing failure, already mapped from the error. */
+  /** Human-readable listing failure — the failure only; retry is a control. */
   errorMessage?: string;
+  /** Refetch the listing. Renders an inline "Try again" link when set. */
+  onRetry?: () => void;
   /** The items that survived search + facets. */
   items: readonly T[];
   /**
@@ -67,10 +70,44 @@ interface CatalogViewProps<T> {
   className?: string;
 }
 
+/** Destructive alert for a failed listing, with an optional inline retry. */
+export function CatalogLoadError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry?: () => void;
+}) {
+  const { t } = useT('common');
+  return (
+    <Alert
+      variant="destructive"
+      description={
+        onRetry ? (
+          <span className="inline-flex flex-wrap items-baseline gap-x-2">
+            <span>{message}</span>
+            <Button
+              type="button"
+              variant="link"
+              className="text-foreground h-auto min-h-0 p-0 text-sm"
+              onClick={onRetry}
+            >
+              {t('actions.tryAgain')}
+            </Button>
+          </span>
+        ) : (
+          message
+        )
+      }
+    />
+  );
+}
+
 export function CatalogView<T>({
   isPending,
   isError = false,
   errorMessage,
+  onRetry,
   items,
   hasItems,
   itemKey,
@@ -86,7 +123,7 @@ export function CatalogView<T>({
   if (isError) {
     return (
       <div className={className}>
-        <Alert variant="destructive" description={errorMessage} />
+        <CatalogLoadError message={errorMessage ?? ''} onRetry={onRetry} />
       </div>
     );
   }

--- a/services/platform/app/components/env/env-var-list-editor.tsx
+++ b/services/platform/app/components/env/env-var-list-editor.tsx
@@ -13,7 +13,6 @@
 import { Button } from '@tale/ui/button';
 import { Input } from '@tale/ui/input';
 import { HStack, VStack } from '@tale/ui/layout';
-import { Table, TableBody, TableCell, TableRow } from '@tale/ui/table';
 import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -381,8 +380,10 @@ export function EnvVarListEditor({
 
   const busy = saving || disabled;
 
-  // Headerless, no-skeleton, no-empty-state table (#1950): when there are no
-  // rows the table isn't rendered at all — only the Add/Save controls remain.
+  // Headerless, no-skeleton, no-empty-state list (#1950): when there are no
+  // rows the list isn't rendered at all — only the Add/Save controls remain.
+  // Flex rows (not a table) keep the NAME/value controls flush with the
+  // surrounding settings section — TableCell padding indented them.
   const renderRow = (r: Row, i: number) => {
     const isBinding = r.tokenSourceSlug !== undefined;
     // When the surface supports token sources, a single per-row "type"
@@ -428,109 +429,100 @@ export function EnvVarListEditor({
       }
     };
     return (
-      <TableRow key={i} data-no-hover>
-        <TableCell className="w-48 align-middle">
-          <Input
-            placeholder={t('keyPlaceholder')}
-            value={r.key}
-            disabled={busy}
-            className="font-mono"
-            onChange={(e) => patch(i, { key: e.target.value })}
-          />
-        </TableCell>
+      <div key={i} className="flex min-w-0 items-center gap-2 overflow-x-auto">
+        <Input
+          placeholder={t('keyPlaceholder')}
+          value={r.key}
+          disabled={busy}
+          className="w-48 shrink-0 font-mono"
+          onChange={(e) => patch(i, { key: e.target.value })}
+        />
         {hasSources && (
-          <TableCell className="w-0 align-middle">
-            <Select
-              aria-label={t('valueType')}
-              className="w-40 shrink-0"
-              disabled={busy}
-              value={rowType}
-              options={[
-                { value: 'value', label: t('typeValue') },
-                { value: 'secret', label: t('secret') },
-                { value: 'token-source', label: t('typeTokenSource') },
-              ]}
-              onValueChange={onTypeChange}
-            />
-          </TableCell>
+          <Select
+            aria-label={t('valueType')}
+            className="w-40 shrink-0"
+            disabled={busy}
+            value={rowType}
+            options={[
+              { value: 'value', label: t('typeValue') },
+              { value: 'secret', label: t('secret') },
+              { value: 'token-source', label: t('typeTokenSource') },
+            ]}
+            onValueChange={onTypeChange}
+          />
         )}
-        <TableCell className="align-middle">
-          {isBinding ? (
-            // Second dropdown: WHICH token source (shown only once the type
-            // is "Token source"). Keeps sources out of the type list.
-            <Select
-              aria-label={t('typeTokenSource')}
-              className="w-full"
+        {isBinding ? (
+          // Second dropdown: WHICH token source (shown only once the type
+          // is "Token source"). Keeps sources out of the type list.
+          <Select
+            aria-label={t('typeTokenSource')}
+            className="min-w-0 flex-1"
+            disabled={busy}
+            value={r.tokenSourceSlug ?? ''}
+            options={(tokenSources ?? []).map((s) => ({
+              value: s.slug,
+              label: s.displayName,
+            }))}
+            onValueChange={(v) => {
+              if (v) patch(i, { tokenSourceSlug: v });
+            }}
+          />
+        ) : (
+          <Input
+            type={r.isSecret && !r.masked ? 'password' : 'text'}
+            placeholder={t('valuePlaceholder')}
+            value={r.value}
+            disabled={busy}
+            className="min-w-0 flex-1 font-mono"
+            onFocus={() => {
+              if (r.masked) patchDisplay(i, { value: '', masked: false });
+            }}
+            onChange={(e) =>
+              patch(i, {
+                value: e.target.value,
+                masked: false,
+                ...(r.isSecret && { secretDirty: true }),
+              })
+            }
+            onBlur={() => {
+              if (
+                r.isSecret &&
+                r.existingKey !== null &&
+                !r.secretDirty &&
+                r.value === ''
+              ) {
+                patchDisplay(i, { value: r.maskedDisplay, masked: true });
+              }
+            }}
+          />
+        )}
+        {!hasSources && !forceSecret && (
+          <label className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-xs">
+            <Checkbox
+              checked={r.isSecret}
               disabled={busy}
-              value={r.tokenSourceSlug ?? ''}
-              options={(tokenSources ?? []).map((s) => ({
-                value: s.slug,
-                label: s.displayName,
-              }))}
-              onValueChange={(v) => {
-                if (v) patch(i, { tokenSourceSlug: v });
-              }}
-            />
-          ) : (
-            <Input
-              type={r.isSecret && !r.masked ? 'password' : 'text'}
-              placeholder={t('valuePlaceholder')}
-              value={r.value}
-              disabled={busy}
-              className="font-mono"
-              onFocus={() => {
-                if (r.masked) patchDisplay(i, { value: '', masked: false });
-              }}
-              onChange={(e) =>
+              onCheckedChange={(c) =>
                 patch(i, {
-                  value: e.target.value,
-                  masked: false,
-                  ...(r.isSecret && { secretDirty: true }),
+                  isSecret: c === true,
+                  secretDirty: true,
+                  ...(r.masked && { value: '', masked: false }),
                 })
               }
-              onBlur={() => {
-                if (
-                  r.isSecret &&
-                  r.existingKey !== null &&
-                  !r.secretDirty &&
-                  r.value === ''
-                ) {
-                  patchDisplay(i, { value: r.maskedDisplay, masked: true });
-                }
-              }}
             />
-          )}
-        </TableCell>
-        {!hasSources && !forceSecret && (
-          <TableCell className="w-0 align-middle">
-            <label className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-xs">
-              <Checkbox
-                checked={r.isSecret}
-                disabled={busy}
-                onCheckedChange={(c) =>
-                  patch(i, {
-                    isSecret: c === true,
-                    secretDirty: true,
-                    ...(r.masked && { value: '', masked: false }),
-                  })
-                }
-              />
-              {t('secret')}
-            </label>
-          </TableCell>
+            {t('secret')}
+          </label>
         )}
-        <TableCell className="w-0 align-middle">
-          <Button
-            size="icon"
-            variant="ghost"
-            disabled={busy}
-            aria-label={t('remove')}
-            onClick={() => requestRemove(i)}
-          >
-            <Trash2 className="size-4" />
-          </Button>
-        </TableCell>
-      </TableRow>
+        <Button
+          size="icon"
+          variant="ghost"
+          disabled={busy}
+          className="shrink-0"
+          aria-label={t('remove')}
+          onClick={() => requestRemove(i)}
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </div>
     );
   };
 
@@ -540,13 +532,13 @@ export function EnvVarListEditor({
   return (
     <VStack gap={2}>
       {localRows.length > 0 && (
-        <Table>
-          <TableBody>{localRows.map((r, i) => renderRow(r, i))}</TableBody>
-        </Table>
+        <div className="flex flex-col gap-2">
+          {localRows.map((r, i) => renderRow(r, i))}
+        </div>
       )}
       <HStack gap={2} className="justify-between">
         <Button
-          variant="ghost"
+          variant="secondary"
           disabled={busy}
           className="self-start"
           onClick={addRow}

--- a/services/platform/app/components/ui/dialog/dialog.test.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.test.tsx
@@ -48,6 +48,35 @@ describe('Dialog', () => {
     });
   });
 
+  describe('body region', () => {
+    it('omits the scroll body when there is no children content', () => {
+      render(
+        <Dialog
+          open
+          onOpenChange={vi.fn()}
+          title="Archive project"
+          description="Hide this project from members."
+          footer={<button type="button">Archive project</button>}
+        />,
+      );
+      expect(
+        document.querySelector('.flex-1.overflow-y-auto'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the scroll body when children are provided', () => {
+      render(
+        <Dialog open onOpenChange={vi.fn()} title="Edit profile">
+          <p>Form fields</p>
+        </Dialog>,
+      );
+      expect(screen.getByText('Form fields')).toBeInTheDocument();
+      expect(
+        document.querySelector('.flex-1.overflow-y-auto'),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('accessibility', () => {
     it('marks the content as a modal dialog (aria-modal)', () => {
       render(

--- a/services/platform/app/components/ui/dialog/dialog.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.tsx
@@ -177,6 +177,7 @@ export function Dialog({
 }: DialogProps) {
   const parentDepth = React.useContext(DialogDepthContext);
   const isNested = parentDepth > 0;
+  const hasBody = React.Children.toArray(children).length > 0;
   // Without a `trigger`, Radix has no element to restore focus to on close, so
   // focus falls to <body> (WCAG 2.4.3). Capture the opener and refocus it.
   const restoreFocus = useRestoreFocus(open, restoreFocusRef);
@@ -278,9 +279,11 @@ export function Dialog({
                 </div>
               </div>
             )}
-            <div className="-mx-2 -my-1 min-h-0 flex-1 overflow-y-auto px-2 py-1">
-              {children}
-            </div>
+            {hasBody && (
+              <div className="-mx-2 -my-1 min-h-0 flex-1 overflow-y-auto px-2 py-1">
+                {children}
+              </div>
+            )}
             {footer && (
               <div
                 className={cn(

--- a/services/platform/app/components/ui/wizard/wizard-footer.tsx
+++ b/services/platform/app/components/ui/wizard/wizard-footer.tsx
@@ -106,7 +106,7 @@ export function WizardFooter({
     <div className={cn('flex items-center justify-between gap-2', className)}>
       <div>
         {!isFirst && (
-          <Button variant="ghost" onClick={goBack} disabled={submitting}>
+          <Button variant="secondary" onClick={goBack} disabled={submitting}>
             {backLabel}
           </Button>
         )}

--- a/services/platform/app/features/automations/components/automations-list.test.tsx
+++ b/services/platform/app/features/automations/components/automations-list.test.tsx
@@ -141,13 +141,24 @@ describe('AutomationsList link targets', () => {
   });
 });
 
-// The header offers ONE create entry — the skill library's grammar: a primary
+// The empty state owns the create entry when there are no rows — one primary
 // button whose menu holds the lanes (author from a goal, upload a pack), not
-// two side-by-side buttons.
+// two side-by-side buttons. The page header already says "Automations".
 describe('AutomationsList create menu', () => {
-  it('offers both create lanes from the one button', async () => {
+  it('offers both create lanes from the empty-state button', async () => {
     automationsData = [];
     const { user } = render(<AutomationsList organizationId="org-1" />);
+
+    expect(
+      screen.getByText('automations.list.empty.title'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('automations.list.empty.description'),
+    ).toBeInTheDocument();
+    // No second page title under the shell header.
+    expect(
+      screen.queryByRole('heading', { level: 2, name: 'automations.title' }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByTestId('new-automation'));
 
@@ -157,5 +168,17 @@ describe('AutomationsList create menu', () => {
     expect(
       screen.getByRole('menuitem', { name: 'automations.upload.trigger' }),
     ).toBeInTheDocument();
+  });
+
+  it('keeps create beside the list description when rows exist', () => {
+    automationsData = [
+      { name: 'org/digest', latest: 1, projectIds: [], deployedVersion: 1 },
+    ];
+    render(<AutomationsList organizationId="org-1" />);
+
+    expect(
+      screen.getByText('automations.list.description'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('new-automation')).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/automations/components/automations-list.tsx
+++ b/services/platform/app/features/automations/components/automations-list.tsx
@@ -6,9 +6,10 @@ import { Button } from '@tale/ui/button';
 import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { EmptyState } from '@tale/ui/empty-state';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
-import { SectionHeader } from '@tale/ui/section-header';
+import { HStack } from '@tale/ui/layout';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import { Text } from '@tale/ui/text';
 import { Link } from '@tanstack/react-router';
 import {
   CheckCircle2,
@@ -18,7 +19,7 @@ import {
   Plus,
   Workflow,
 } from 'lucide-react';
-import { useId, useState } from 'react';
+import { useState } from 'react';
 
 import { ContentArea } from '@/app/components/layout/content-area';
 import { useProjects } from '@/app/features/projects/hooks/queries';
@@ -56,6 +57,10 @@ function ListLoading() {
  * and which one — if any — is live. An automation with versions but no
  * deployment is drafts only; saying so here is what stops someone waiting for a
  * schedule that was never promoted.
+ *
+ * The area shell already owns the page title (`AdaptiveHeaderTitle`), so this
+ * list does not repeat "Automations". Create lives on the empty state when the
+ * list is empty, and beside the list description when it isn't.
  */
 export function AutomationsList({
   organizationId,
@@ -67,7 +72,6 @@ export function AutomationsList({
 }) {
   const { t } = useT('automations');
   const { locale } = useLocale();
-  const headingId = useId();
   const ability = useAbility();
   // Which create lane's dialog is open; the dialogs mount lazily so the
   // builder/upload hooks only run once a lane is actually picked.
@@ -94,6 +98,8 @@ export function AutomationsList({
   const automations = [...(automationsQuery.data ?? [])].sort((a, b) =>
     a.name.localeCompare(b.name),
   );
+  const isEmpty =
+    automationsQuery.data !== undefined && automations.length === 0;
 
   // One create entry, the skill library's grammar: a single primary button
   // whose menu offers the lanes (author from a goal, upload a pack).
@@ -113,28 +119,34 @@ export function AutomationsList({
       },
     ],
   ];
+  const createControl = canAuthor ? (
+    <DropdownMenu
+      items={createMenuGroups}
+      trigger={
+        <Button icon={Plus} data-testid="new-automation">
+          {t('builder.new')}
+        </Button>
+      }
+    />
+  ) : undefined;
 
   return (
-    <ContentArea variant="narrow" className="flex-1">
-      <section aria-labelledby={headingId} className="flex flex-col gap-4">
-        <SectionHeader
-          as="h2"
-          size="lg"
-          title={<span id={headingId}>{t('title')}</span>}
-          description={t('list.description')}
-          action={
-            canAuthor ? (
-              <DropdownMenu
-                items={createMenuGroups}
-                trigger={
-                  <Button icon={Plus} data-testid="new-automation">
-                    {t('builder.new')}
-                  </Button>
-                }
-              />
-            ) : undefined
-          }
-        />
+    <ContentArea variant="narrow" className="flex min-h-0 flex-1">
+      <section
+        aria-label={t('title')}
+        className="flex min-h-0 flex-1 flex-col gap-4"
+      >
+        {/* List chrome only when there is something to describe — empty state
+            carries its own CTA so we don't stack a second "Automations" title
+            under the page header. */}
+        {!isEmpty && automationsQuery.data !== undefined && (
+          <HStack justify="between" align="start" gap={4}>
+            <Text variant="muted" className="text-sm">
+              {t('list.description')}
+            </Text>
+            {createControl}
+          </HStack>
+        )}
 
         {createDialog === 'builder' && (
           <NewAutomationDialog
@@ -171,12 +183,14 @@ export function AutomationsList({
         )}
 
         {automationsQuery.data !== undefined &&
-          (automations.length === 0 ? (
+          (isEmpty ? (
             <EmptyState
               icon={Workflow}
               title={t('list.empty.title')}
               description={t('list.empty.description')}
               headingLevel={2}
+              action={createControl}
+              className="min-h-0"
             />
           ) : (
             // Deliberately a list of link cards rather than a DataTable: a row

--- a/services/platform/app/features/automations/components/upload-automation-dialog.tsx
+++ b/services/platform/app/features/automations/components/upload-automation-dialog.tsx
@@ -34,20 +34,10 @@ interface SkillReport {
 }
 
 /**
- * "Upload package": the manual lane onto the automation store — a pack's
- * `workflow.yml` (required) and `automation.yml` (optional; its
- * `subjects.task` block becomes the task-surface contract) as plain files, or
- * the whole pack directory as ONE zip, which may also carry skill bundles
- * under `skills/<slug>/`. A zip travels through `_storage` behind the presign
- * + intent handshake; carried skills land in the org's skills library at
- * upload, and a slug that would overwrite a differing existing bundle comes
- * back as a confirmation round-trip before anything is written.
- *
- * The destination is an install target, not a pin: a project choice binds the
- * automation to that project (additively for an existing name), and the
- * automation page's Projects panel manages the set afterwards. The server
- * validates the document with the engine before anything is stored; the
- * uploaded version stays a draft behind the normal deploy gate.
+ * "Upload package": the manual lane onto the automation store — pack files
+ * (`workflow.yml` + optional `automation.yml`) or one pack zip (skills under
+ * `skills/<slug>/`). Destination is an install target; the version stays a
+ * draft behind the deploy gate.
  *
  * Controlled: the trigger lives in the list header's create menu, alongside
  * the builder lane's.
@@ -364,6 +354,7 @@ export function UploadAutomationDialog({
         {projectId === undefined && (
           <Select
             label={t('upload.targetLabel')}
+            description={t('upload.targetHelp')}
             value={target}
             onValueChange={setTarget}
             options={[
@@ -376,9 +367,6 @@ export function UploadAutomationDialog({
             disabled={pending}
           />
         )}
-        <Text as="p" variant="muted" className="text-xs">
-          {t('upload.targetHelp')}
-        </Text>
       </Stack>
     </FormDialog>
   );

--- a/services/platform/app/features/products/components/product-create-dialog.tsx
+++ b/services/platform/app/features/products/components/product-create-dialog.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Grid, Row } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { z } from 'zod';
 
 import { Image } from '@/app/components/ui/data-display/image';
@@ -165,8 +165,11 @@ export function ProductCreateDialog({
   const status = values.status;
   const nameValid = values.name.trim().length > 0;
 
+  const [activeIndex, setActiveIndex] = useState(0);
+
   const handleClose = () => {
     reset();
+    setActiveIndex(0);
     onClose();
   };
 
@@ -216,6 +219,12 @@ export function ProductCreateDialog({
     { id: 'review', label: tProducts('createWizard.steps.review') },
   ];
 
+  const stepHints = [
+    tProducts('createWizard.basicsHint'),
+    tProducts('createWizard.pricingHint'),
+    tProducts('createWizard.reviewHint'),
+  ];
+
   // Options are labelled `status.<value>`; derive the current label the same
   // way to avoid an enum-vs-string comparison on the form's string value.
   const statusLabel = status ? tCommon(`status.${status}`) : status;
@@ -225,20 +234,22 @@ export function ProductCreateDialog({
       open={isOpen}
       onOpenChange={(open) => !open && handleClose()}
       title={tProducts('create.title')}
-      description={tProducts('create.description')}
-      size="lg"
+      description={stepHints[activeIndex]}
+      size="md"
     >
       {/* Keyed on open so each fresh open starts at step 1 (form reset lives in
           handleClose). Remounts only the wizard subtree, not the dialog. */}
       <Wizard
         key={isOpen ? 'open' : 'closed'}
         steps={steps}
+        activeIndex={activeIndex}
+        onIndexChange={setActiveIndex}
         onFinish={handleSubmit(onSubmit)}
         formatProgress={(current, total, label) =>
           tCommon('stepProgress', { current, total, label })
         }
       >
-        <WizardProgress ariaLabel={tProducts('create.title')} />
+        <WizardProgress ariaLabel={tProducts('create.title')} segmented />
 
         <WizardStep id="basics" valid={nameValid}>
           <Input
@@ -322,7 +333,6 @@ export function ProductCreateDialog({
         </WizardStep>
 
         <WizardStep id="review">
-          <Text variant="muted">{tProducts('createWizard.reviewHint')}</Text>
           <div className="border-border rounded-lg border p-3">
             {values.imageUrl.trim() ? (
               <Row align="center" justify="between" className="py-1">

--- a/services/platform/app/features/products/components/product-image-field.tsx
+++ b/services/platform/app/features/products/components/product-image-field.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { Button } from '@tale/ui/button';
-import { Row, Stack } from '@tale/ui/layout';
+import { Stack } from '@tale/ui/layout';
 import { Spinner } from '@tale/ui/spinner';
-import { ImagePlus, X } from 'lucide-react';
-import { useRef } from 'react';
+import { Text } from '@tale/ui/text';
+import { ImagePlus, Pencil, X } from 'lucide-react';
+import { useState } from 'react';
 
 import { Image } from '@/app/components/ui/data-display/image';
+import { FileUpload } from '@/app/components/ui/forms/file-upload';
 import { Input } from '@/app/components/ui/forms/input';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
 
 import {
   PRODUCT_IMAGE_ACCEPT,
@@ -24,10 +26,12 @@ interface ProductImageFieldProps {
   errorMessage?: string;
 }
 
+const DROP_ZONE_ID = 'product-image-upload';
+
 /**
- * Product image field: paste a URL or upload a file. Uploads go to Convex
- * storage and resolve to a stable public URL stored in `imageUrl`, so the
- * rest of the product UI (which renders `imageUrl` directly) is unchanged.
+ * Product image field: a clickable/droppable zone that shows the image when
+ * set, with a hover overlay to change it and a corner button to remove it.
+ * A "paste a URL" toggle below reveals a URL input as a secondary option.
  */
 export function ProductImageField({
   value,
@@ -36,14 +40,13 @@ export function ProductImageField({
   errorMessage,
 }: ProductImageFieldProps) {
   const { t: tProducts } = useT('products');
+  const { t: tCommon } = useT('common');
   const { uploadImage, isUploading } = useProductImageUpload();
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [showUrlInput, setShowUrlInput] = useState(false);
   const isDisabled = disabled || isUploading;
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    // Reset so selecting the same file again still fires onChange.
-    e.target.value = '';
+  const handleFilesSelected = async (files: File[]) => {
+    const file = files[0];
     if (!file) return;
 
     if (file.size > PRODUCT_IMAGE_MAX_BYTES) {
@@ -75,57 +78,101 @@ export function ProductImageField({
 
   return (
     <Stack gap={2}>
-      <Input
-        id="imageUrl"
-        type="url"
-        label={tProducts('edit.labels.imageUrl')}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={tProducts('edit.imageUrlPlaceholder')}
-        disabled={isDisabled}
+      <FileUpload.Root
+        id={DROP_ZONE_ID}
+        label={tProducts('edit.labels.image')}
         errorMessage={errorMessage}
-      />
-      <Row gap={3}>
-        {value && (
-          <Image
-            src={value}
-            alt=""
-            className="border-border size-12 shrink-0 rounded-md border object-cover"
-          />
-        )}
-        <input
-          ref={inputRef}
-          type="file"
-          accept={PRODUCT_IMAGE_ACCEPT}
-          className="hidden"
-          onChange={handleFileChange}
-        />
-        <Button
-          type="button"
-          variant="secondary"
-          disabled={isDisabled}
-          onClick={() => inputRef.current?.click()}
-          className="gap-1.5"
-        >
-          {isUploading ? (
-            <Spinner size="sm" />
-          ) : (
-            <ImagePlus className="size-4" />
-          )}
-          {tProducts('edit.uploadImage')}
-        </Button>
-        {value && !isUploading && (
-          <Button
-            type="button"
-            variant="ghost"
-            disabled={disabled}
-            onClick={() => onChange('')}
-            aria-label={tProducts('edit.removeImage')}
+      >
+        {/* Wrapper is relative so the × button can overlay the zone as a sibling,
+            keeping its click out of the DropZone's event path. */}
+        <div className="relative">
+          <FileUpload.DropZone
+            inputId={DROP_ZONE_ID}
+            onFilesSelected={handleFilesSelected}
+            accept={PRODUCT_IMAGE_ACCEPT}
+            disabled={isDisabled}
+            aria-label={tProducts('edit.labels.image')}
+            className={cn(
+              'relative h-40 w-full overflow-hidden rounded-lg transition-colors',
+              value
+                ? 'border border-border cursor-pointer'
+                : 'border-2 border-dashed border-border cursor-pointer hover:border-primary hover:bg-accent/30',
+            )}
           >
-            <X className="size-4" />
-          </Button>
-        )}
-      </Row>
+            <FileUpload.Overlay className="rounded-lg" />
+
+            {isUploading ? (
+              <div className="flex h-full items-center justify-center">
+                <Spinner size="md" />
+              </div>
+            ) : value ? (
+              <div className="group h-full w-full">
+                <Image
+                  src={value}
+                  alt=""
+                  className="h-full w-full object-cover object-center"
+                />
+                {/* Hover overlay signals that clicking will change the image */}
+                <div className="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/50 text-white opacity-0 transition-opacity group-hover:opacity-100">
+                  <Pencil className="size-4" aria-hidden />
+                  <span className="text-sm font-medium">
+                    {tCommon('actions.edit')}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+                <ImagePlus
+                  className="text-muted-foreground size-8"
+                  aria-hidden
+                />
+                <div>
+                  <Text variant="label" className="text-sm">
+                    {tProducts('edit.uploadImage')}
+                  </Text>
+                  <Text variant="caption" className="mt-0.5">
+                    {tCommon('upload.dropFilesHere')}
+                  </Text>
+                </div>
+              </div>
+            )}
+          </FileUpload.DropZone>
+
+          {/* Remove button — outside the DropZone so clicking it does not open
+              the file picker. Absolutely positioned to sit in the zone's corner. */}
+          {value && !isUploading && (
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onChange('')}
+              aria-label={tProducts('edit.removeImage')}
+              className="absolute top-2 right-2 rounded-full bg-black/60 p-1 text-white hover:bg-black/80 focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+            >
+              <X className="size-3.5" aria-hidden />
+            </button>
+          )}
+        </div>
+      </FileUpload.Root>
+
+      {showUrlInput ? (
+        <Input
+          id="product-image-url-input"
+          type="url"
+          label={tProducts('edit.labels.imageUrl')}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={tProducts('edit.imageUrlPlaceholder')}
+          disabled={isDisabled}
+        />
+      ) : (
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground self-start text-sm underline-offset-2 hover:underline"
+          onClick={() => setShowUrlInput(true)}
+        >
+          {tProducts('edit.pasteUrl')}
+        </button>
+      )}
     </Stack>
   );
 }

--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -187,6 +187,7 @@ export function ProductsImportDialog({
     <FormDialog
       open={isOpen}
       onOpenChange={handleClose}
+      size="md"
       title={t('import.uploadProducts')}
       submitText={tCommon('actions.import')}
       submittingText={tCommon('actions.importing')}

--- a/services/platform/app/features/projects/components/project-agents-tab.tsx
+++ b/services/platform/app/features/projects/components/project-agents-tab.tsx
@@ -118,7 +118,7 @@ export function ProjectAgentsTab({
   );
 
   return (
-    <ContentArea variant="narrow" gap={6}>
+    <ContentArea variant="narrow" gap={6} className="min-h-0 flex-1">
       <StickySectionHeader
         title={t('agents.agentsHeading')}
         description={t('agents.sectionDescription')}

--- a/services/platform/app/features/projects/components/project-archive-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-archive-dialog.tsx
@@ -87,9 +87,7 @@ export function ProjectArchiveDialog({
       confirmText={
         isArchived ? t('settings.restoreButton') : t('settings.archiveButton')
       }
-      // Archiving is the cautionary direction (amber, matching the danger
-      // zone's warning alert); restoring is a plain confirm.
-      variant={isArchived ? 'default' : 'warning'}
+      variant="default"
       isLoading={isBusy}
       onConfirm={handleConfirm}
     />

--- a/services/platform/app/features/projects/components/project-archive-section.tsx
+++ b/services/platform/app/features/projects/components/project-archive-section.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { useState } from 'react';
+
+import { SettingsSection } from '@/app/features/settings/components/settings-section';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import { ProjectArchiveDialog } from './project-archive-dialog';
+
+interface ProjectArchiveSectionProps {
+  projectId: Id<'projects'>;
+  projectName: string;
+  isArchived: boolean;
+}
+
+export function ProjectArchiveSection({
+  projectId,
+  projectName,
+  isArchived,
+}: ProjectArchiveSectionProps) {
+  const { t } = useT('projects');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SettingsSection
+      title={t('dangerZone.archiveSectionTitle')}
+      description={t(
+        isArchived ? 'dangerZone.restoreHelp' : 'dangerZone.archiveHelp',
+      )}
+      action={
+        <Button type="button" variant="secondary" onClick={() => setOpen(true)}>
+          {isArchived ? t('rowActions.restore') : t('rowActions.archive')}
+        </Button>
+      }
+    >
+      {open && (
+        <ProjectArchiveDialog
+          open={open}
+          onOpenChange={setOpen}
+          projectId={projectId}
+          isArchived={isArchived}
+          projectName={projectName}
+        />
+      )}
+    </SettingsSection>
+  );
+}

--- a/services/platform/app/features/projects/components/project-danger-zone.tsx
+++ b/services/platform/app/features/projects/components/project-danger-zone.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 /**
- * The project's danger zone — archive (reversible shelf) and delete
- * (dialog-guarded, cascading) — at the bottom of the project's general page,
- * in the same destructive-Alert vocabulary as the organization settings. The
- * chat sidebar's folder menu deep-links here, so both destructive actions
- * have ONE home with their consequences spelled out.
+ * The project's danger zone — delete only (dialog-guarded, cascading) — at
+ * the bottom of the project's general page, in the same destructive-Alert
+ * vocabulary as the organization settings. The chat sidebar's folder menu
+ * deep-links here via PROJECT_DANGER_ZONE_ID.
  */
 
 import { Alert } from '@tale/ui/alert';
@@ -17,7 +16,6 @@ import { SettingsSection } from '@/app/features/settings/components/settings-sec
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
-import { ProjectArchiveDialog } from './project-archive-dialog';
 import { ProjectDeleteDialog } from './project-delete-dialog';
 
 /** The section's DOM id — the chat sidebar's folder menu navigates to it. */
@@ -27,15 +25,12 @@ export function ProjectDangerZone({
   organizationId,
   projectId,
   projectName,
-  isArchived,
 }: {
   organizationId: string;
   projectId: Id<'projects'>;
   projectName: string;
-  isArchived: boolean;
 }) {
   const { t } = useT('projects');
-  const [archiveOpen, setArchiveOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   return (
@@ -44,31 +39,6 @@ export function ProjectDangerZone({
       title={t('dangerZone.title')}
       description={t('dangerZone.description')}
     >
-      <Alert
-        variant="warning"
-        live="off"
-        icon={AlertTriangle}
-        title={isArchived ? t('rowActions.restore') : t('rowActions.archive')}
-      >
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <span className="text-sm">
-            {t(
-              isArchived ? 'dangerZone.restoreHelp' : 'dangerZone.archiveHelp',
-            )}
-          </span>
-          <Button
-            type="button"
-            // Amber for the cautionary archive direction — the counterpart to
-            // the delete row's red; restore is a neutral secondary action.
-            variant={isArchived ? 'secondary' : 'warning'}
-            className="shrink-0"
-            onClick={() => setArchiveOpen(true)}
-          >
-            {isArchived ? t('rowActions.restore') : t('rowActions.archive')}
-          </Button>
-        </div>
-      </Alert>
-
       <Alert
         variant="destructive"
         live="off"
@@ -88,17 +58,8 @@ export function ProjectDangerZone({
         </div>
       </Alert>
 
-      {/* Mounted only while open — their mutation hooks need the app's data
+      {/* Mounted only while open — the mutation hook needs the app's data
           providers, and a closed dialog must cost the page nothing. */}
-      {archiveOpen && (
-        <ProjectArchiveDialog
-          open={archiveOpen}
-          onOpenChange={setArchiveOpen}
-          projectId={projectId}
-          isArchived={isArchived}
-          projectName={projectName}
-        />
-      )}
       {deleteOpen && (
         <ProjectDeleteDialog
           open={deleteOpen}

--- a/services/platform/app/features/projects/components/project-overview.tsx
+++ b/services/platform/app/features/projects/components/project-overview.tsx
@@ -28,6 +28,7 @@ import { convexErrorCode } from '@/lib/utils/convex-error';
 
 import { useUpdateProjectIdentity } from '../hooks/mutations';
 import { useProject } from '../hooks/queries';
+import { ProjectArchiveSection } from './project-archive-section';
 import { ProjectDangerZone } from './project-danger-zone';
 import { ProjectInstructionsEditor } from './project-instructions-editor';
 import { ProjectReadOnlyBanner } from './project-read-only-banner';
@@ -274,14 +275,23 @@ function ProjectOverviewContent({
         />
       </SettingsSection>
 
-      {/* Archive and delete live HERE — the chat sidebar's folder menu and
-          the projects list both point at this one guarded home. */}
+      {/* Archive (reversible) lives above the danger zone — it's a shelf, not
+          a destructive action. Delete (irreversible) stays in the red zone
+          below. The chat sidebar's folder menu deep-links to the danger zone
+          id, so both sections remain at this one guarded home. */}
+      {canAdminister ? (
+        <ProjectArchiveSection
+          projectId={projectId}
+          projectName={project.name}
+          isArchived={project.archivedAt !== undefined}
+        />
+      ) : null}
+
       {canAdminister ? (
         <ProjectDangerZone
           organizationId={organizationId}
           projectId={projectId}
           projectName={project.name}
-          isArchived={project.archivedAt !== undefined}
         />
       ) : null}
     </ContentArea>

--- a/services/platform/app/features/settings/components/settings-row.tsx
+++ b/services/platform/app/features/settings/components/settings-row.tsx
@@ -36,7 +36,7 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
         aria-labelledby={labelId}
         aria-describedby={descId}
         className={cn(
-          'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6',
+          'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6',
           className,
         )}
         {...props}

--- a/services/platform/app/features/settings/components/settings-section.tsx
+++ b/services/platform/app/features/settings/components/settings-section.tsx
@@ -60,7 +60,7 @@ export const SettingsSection = forwardRef<HTMLElement, SettingsSectionProps>(
         className={cn(sectionVariants({ gap }), className)}
         {...props}
       >
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
           {/* Cap the title/description column at a readable line length so long
               descriptions don't stretch the full content width (and run up
               against a right-aligned `action`). */}

--- a/services/platform/app/features/settings/credentials/map-credential-error.test.ts
+++ b/services/platform/app/features/settings/credentials/map-credential-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isOpaqueServerErrorMessage,
+  mapCredentialError,
+} from './map-credential-error';
+
+describe('isOpaqueServerErrorMessage', () => {
+  it('flags Convex action dumps', () => {
+    expect(
+      isOpaqueServerErrorMessage(
+        "[CONVEX A(lib/providers/catalog_actions:listProviderCatalogs)] [Request ID: abc] Server Error Cannot find module '/var/folders/x/T/tmp/modules/lib/providers/catalog_actions.js' Called by client",
+      ),
+    ).toBe(true);
+  });
+
+  it('allows short product sentences', () => {
+    expect(isOpaqueServerErrorMessage('catalog root missing')).toBe(false);
+  });
+});
+
+describe('mapCredentialError', () => {
+  it('returns structured ConvexError messages', () => {
+    expect(
+      mapCredentialError({ data: { message: 'Name already taken' } }),
+    ).toBe('Name already taken');
+  });
+
+  it('replaces opaque Error.message dumps with a reload hint', () => {
+    expect(
+      mapCredentialError(
+        new Error(
+          "[CONVEX A(lib/providers/harness_status:listHarnessStatus)] [Request ID: d508] Server Error Cannot find module '/var/folders/r5/tmp/modules/lib/providers/harness_status.js' Called by client",
+        ),
+      ),
+    ).toBe('Something went wrong. Reload and try again.');
+  });
+});

--- a/services/platform/app/features/settings/credentials/map-credential-error.ts
+++ b/services/platform/app/features/settings/credentials/map-credential-error.ts
@@ -11,14 +11,36 @@
  * splitting can produce multiple `ConvexError` class copies, and a structured
  * error that failed an identity check would silently degrade to its raw
  * `message` — losing exactly the sentence worth showing.
+ *
+ * Unstructured Convex action failures arrive as dumps (`[CONVEX A(…)]`,
+ * `Server Error`, absolute module paths). Those are for the console, not the
+ * Alert — replace them with a short reload hint so Settings stays readable.
  */
+
+/** True when a string is a Convex/runtime dump, not a product sentence. */
+export function isOpaqueServerErrorMessage(message: string): boolean {
+  return (
+    /\[Request ID:/i.test(message) ||
+    /\[CONVEX [AQCOP]\(/i.test(message) ||
+    /Server Error/i.test(message) ||
+    /Cannot find module/i.test(message) ||
+    /\/var\/folders\//i.test(message) ||
+    /Called by client/i.test(message)
+  );
+}
+
+const OPAQUE_FALLBACK = 'Something went wrong. Reload and try again.';
+
 export function mapCredentialError(err: unknown): string {
   if (err != null && typeof err === 'object' && 'data' in err) {
     const data = (err as { data: unknown }).data;
     if (data != null && typeof data === 'object' && 'message' in data) {
       const message = (data as { message: unknown }).message;
-      if (typeof message === 'string' && message.length > 0) return message;
+      if (typeof message === 'string' && message.length > 0) {
+        return isOpaqueServerErrorMessage(message) ? OPAQUE_FALLBACK : message;
+      }
     }
   }
-  return err instanceof Error ? err.message : String(err);
+  const fallback = err instanceof Error ? err.message : String(err);
+  return isOpaqueServerErrorMessage(fallback) ? OPAQUE_FALLBACK : fallback;
 }

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
@@ -747,10 +747,7 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
             );
           })()}
 
-          <SettingsSection
-            title={tNav('enterpriseSso')}
-            description={t('enterpriseSso.description')}
-          >
+          <SettingsSection title={tNav('enterpriseSso')}>
             {connected && (
               <StatusIndicator variant="success">
                 {t('enterpriseSso.connected')}

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -706,10 +706,6 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
             shape; `enabled` is only known once the read settles. */}
         {(loading || enabled) && (
           <Stack gap={6}>
-            <Text variant="muted" className="text-xs">
-              {t('budgets.overrideHint')}
-            </Text>
-
             <Row justify="end">
               <Button
                 variant="primary"
@@ -860,7 +856,9 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
               </Table>
             </Card>
 
-            {/* Add rule sits right-aligned above the table, like every table toolbar. */}
+            <Text variant="muted" className="text-xs">
+              {t('budgets.overrideHint')}
+            </Text>
           </Stack>
         )}
 

--- a/services/platform/app/features/settings/providers/components/harness-status-section.test.tsx
+++ b/services/platform/app/features/settings/providers/components/harness-status-section.test.tsx
@@ -21,6 +21,7 @@ const fixtures = vi.hoisted(() => ({
   status: [] as unknown[],
   health: [] as unknown[],
   statusError: null as Error | null,
+  refetchStatus: vi.fn(),
 }));
 
 vi.mock('../hooks/queries', () => ({
@@ -34,12 +35,14 @@ vi.mock('../hooks/queries', () => ({
     isPending: false,
     isError: fixtures.statusError !== null,
     error: fixtures.statusError,
+    refetch: fixtures.refetchStatus,
   }),
   useHarnessHealth: () => ({
     data: fixtures.health,
     isPending: false,
     isError: false,
     error: null,
+    refetch: vi.fn(),
   }),
 }));
 
@@ -156,7 +159,10 @@ describe('HarnessStatusSection', () => {
     renderSection();
 
     expect(
-      screen.getByText(/Could not load the harness status/),
+      screen.getByText("Couldn't load the agent status."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Try again' }),
     ).toBeInTheDocument();
   });
 

--- a/services/platform/app/features/settings/providers/components/harness-status-section.tsx
+++ b/services/platform/app/features/settings/providers/components/harness-status-section.tsx
@@ -11,13 +11,12 @@
  * only SHOWS the resolution, so there is nothing here to edit.
  */
 
-import { Alert } from '@tale/ui/alert';
 import { Badge } from '@tale/ui/badge';
 import { Stack } from '@tale/ui/layout';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 
-import { mapCredentialError } from '@/app/features/settings/credentials/map-credential-error';
+import { CatalogLoadError } from '@/app/components/catalog/catalog-view';
 import { useT } from '@/lib/i18n/client';
 
 import {
@@ -112,11 +111,9 @@ export function HarnessStatusSection({
     // became the same sentence twice once the tab became a section.
     <Stack gap={4}>
       {statusQuery.isError ? (
-        <Alert
-          variant="destructive"
-          description={t('providers.harnesses.listFailed', {
-            error: mapCredentialError(statusQuery.error),
-          })}
+        <CatalogLoadError
+          message={t('providers.harnesses.listFailed')}
+          onRetry={() => void statusQuery.refetch()}
         />
       ) : statusQuery.isPending ? (
         <Skeletonize loading>

--- a/services/platform/app/features/settings/webdav/components/webdav-settings.tsx
+++ b/services/platform/app/features/settings/webdav/components/webdav-settings.tsx
@@ -2,7 +2,7 @@
 
 import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
-import { Stack, Row } from '@tale/ui/layout';
+import { Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { ColumnDef } from '@tanstack/react-table';
 import { Key, KeyRound, Trash2 } from 'lucide-react';
@@ -91,14 +91,12 @@ export function WebdavSettings(props: WebdavSettingsProps) {
       <SettingsSection
         title={t('list.title')}
         description={t('create.description')}
-      >
-        {/* The table is always on screen — empty state included — with its
-            action right-aligned above it, where every table's action sits. */}
-        <Row justify="end">
+        action={
           <Button icon={KeyRound} onClick={() => setCreateOpen(true)}>
             {t('create.submit')}
           </Button>
-        </Row>
+        }
+      >
         <WebdavAppPasswordsTable rows={rows} />
       </SettingsSection>
 

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -68,9 +68,7 @@ operator:
     button: Erneut ausführen
     started: Erneute Ausführung gestartet
     alreadyRunning: Es läuft bereits eine Ausführung.
-    notStarted:
-      Ausführung konnte nicht gestartet werden – prüfe, ob die Automatisierung
-      installiert ist.
+    notStarted: Ausführung konnte nicht gestartet werden. Stelle sicher, dass die Automatisierung deployt ist, und versuche es erneut.
   stop:
     button: Stoppen
     stopped: Ausführung gestoppt
@@ -101,11 +99,10 @@ accessDenied:
   agents: Du benötigst Admin- oder Entwickler-Berechtigungen, um Agents zu verwalten. Bitte einen Admin, wenn du einen Agent für den Chat brauchst.
   branding: Du benötigst Admin-Berechtigungen, um auf die Branding-Einstellungen
     zuzugreifen.
-  knowledge: Dein Konto hat keine Berechtigung, auf Wissen zuzugreifen.
-  workspaceNotFound: Der gesuchte Workspace existiert nicht oder wurde möglicherweise entfernt.
-  disabled: Dein Konto wurde deaktiviert. Kontaktiere den Support für Unterstützung.
-  noMembership: Du bist kein Mitglied dieses Workspace. Bitte kontaktiere einen
-    Administrator für Zugriff.
+  knowledge: Du hast keine Berechtigung, auf Wissen zuzugreifen.
+  workspaceNotFound: Dieser Workspace existiert nicht oder wurde entfernt.
+  disabled: Dein Konto ist deaktiviert. Kontaktiere den Support.
+  noMembership: Du bist kein Mitglied dieses Workspace. Wende dich an einen Administrator.
   unauthenticated: Deine Sitzung ist abgelaufen. Melde dich erneut an, um fortzufahren.
   enterpriseSso: Sie benötigen Administratorrechte, um auf die
     Enterprise-SSO-Einstellungen zuzugreifen.
@@ -117,7 +114,7 @@ accessDenied:
 analytics:
   automations:
     title: Automatisierungs-Metriken
-    description: Nutzung und Leistung deiner Automatisierungen im Zeitverlauf.
+    description: Laufzahlen, Erfolgsquoten und Durchschnittsdauer über alle deine Automatisierungen.
     cappedNotice: Zeigt die letzten 5.000 Läufe in diesem Zeitraum. Ältere Läufe
       fließen nicht in diese Zahlen ein.
     cards:
@@ -151,8 +148,8 @@ analytics:
       title: Keine Läufe
       description: Im gewählten Zeitraum ist keine Automatisierung gelaufen.
   externalTurns:
-    title: Harness-Runden
-    description: Zuverlässigkeit der Harness-Runden in der Sandbox.
+    title: Agent-Laufzeit-Runden
+    description: Zuverlässigkeit der Agent-Laufzeit-Runden in der Sandbox.
     cappedNotice: Es werden die letzten 5.000 Runden in diesem Zeitraum
       angezeigt. Ältere Runden fließen nicht in diese Summen ein.
     cards:
@@ -163,8 +160,8 @@ analytics:
       cancelled: Von Nutzer gestoppt
       recovered: Wiederhergestellt
     byHarness:
-      title: Nach Harness
-      harness: Harness
+      title: Nach Agent-Laufzeit
+      harness: Agent-Laufzeit
       turns: Runden
       successRate: Erfolgsquote
       timeouts: Timeouts
@@ -485,9 +482,7 @@ auth:
       Passkey-Anmeldung fehlgeschlagen oder abgebrochen. Versuche es
       erneut oder nutze dein Passwort.
     wrongCredentials: Falsche E-Mail oder falsches Passwort
-    accountLockedGeneric: Konto wegen wiederholter Fehlversuche vorübergehend
-      gesperrt. Bitte später erneut versuchen oder einen Administrator
-      kontaktieren.
+    accountLockedGeneric: Konto vorübergehend gesperrt — zu viele Fehlversuche. Später erneut versuchen oder einen Administrator kontaktieren.
     accountLockedSeconds:
       Konto vorübergehend gesperrt. In {seconds, plural, one {#
       Sekunde} other {# Sekunden}} erneut versuchen oder einen Administrator
@@ -540,7 +535,6 @@ auth:
     logOut: Abmelden
     logOutConfirm:
       title: Abmelden
-      description: Bist du sicher, dass du dich abmelden möchtest?
       confirm: Abmelden
     toast:
       signOutFailed: Abmelden fehlgeschlagen
@@ -567,7 +561,7 @@ auth:
     validation:
       currentRequired: Aktuelles Passwort ist erforderlich
       currentIncorrect: Aktuelles Passwort ist falsch
-      confirmRequired: Bitte bestätige dein neues Passwort
+      confirmRequired: Neues Passwort bestätigen
       mismatch: Passwörter stimmen nicht überein
     warning:
       title: Du wirst überall abgemeldet
@@ -580,8 +574,7 @@ auth:
     description:
       Dein Passwort ist gemäß der Rotationsrichtlinie der Organisation
       abgelaufen. Lege ein neues Passwort fest, um fortzufahren.
-    descriptionAdminSet: Dein Passwort wurde von einem Administrator festgelegt.
-      Bitte wähle ein neues Passwort, um fortzufahren.
+    descriptionAdminSet: Ein Administrator hat dein Passwort festgelegt. Wähle ein neues, um fortzufahren.
     signedInAs: Angemeldet als {email}
     notYou: Nicht du?
     logOut: Abmelden
@@ -594,10 +587,7 @@ auth:
     confirmPassword: Passwort bestätigen
   sso:
     errors:
-      serverError:
-        Single Sign-On konnte wegen eines Serverfehlers nicht abgeschlossen
-        werden. Versuche es erneut oder wende dich an deine Administration,
-        falls das Problem bestehen bleibt.
+      serverError: Single Sign-On ist wegen eines Serverfehlers fehlgeschlagen. Versuch es erneut — oder wende dich an deine Administration, wenn's immer wieder passiert.
       multipleConnections:
         Hier nutzen mehrere Organisationen Single Sign-On. Gib
         zuerst die E-Mail-Adresse deiner Organisation ein und versuche es dann
@@ -608,10 +598,9 @@ auth:
       userNotAssigned:
         Dein Konto ist dieser Anwendung nicht zugewiesen. Wende dich an
         deine Administration, um Zugriff anzufordern.
-      silentAuthFailed: Die stille Anmeldung ist fehlgeschlagen. Bitte melde dich interaktiv an.
-      refreshTokenExpired: Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.
-      consentRequired: Für diese Anwendung ist eine Administrator-Zustimmung
-        erforderlich, bevor du dich anmelden kannst.
+      silentAuthFailed: Stille Anmeldung fehlgeschlagen. Melde dich stattdessen manuell an.
+      refreshTokenExpired: Deine Sitzung ist abgelaufen. Melde dich erneut an.
+      consentRequired: Ein Administrator muss die Zustimmung erteilen, bevor du dich anmelden kannst.
       redirectMismatch:
         Die Weiterleitungs-URL für die Anmeldung stimmt nicht mit der
         in Microsoft Entra ID hinterlegten überein. Bitte deine Administration,
@@ -644,20 +633,13 @@ automations:
     loadFailed: 'Die Automatisierungen konnten nicht geladen werden: {error}'
     empty:
       title: Noch keine Automatisierungen
-      description:
-        Eine Automatisierung ist ein gespeichertes Dokument — ein Graph aus
-        Nodes. Die mitgelieferten Starter-Automatisierungen erscheinen hier
-        automatisch, und mit "Neue Automatisierung" baut ein Entwickler neue
-        aus einem Ziel.
+      description: Beschreibe, was du automatisieren möchtest, oder lade eine Workflow-Datei hoch.
   createMenu:
     fromGoal: Aus einem Ziel
   builder:
     new: Neue Automatisierung
     title: Neue Automatisierung
-    description:
-      Beschreibe, was die Automatisierung tun soll. Ein KI-Builder baut sie
-      gegen Mock-Connectors und speichert das Ergebnis hier als Entwurf —
-      live läuft nichts, bevor du eine Version live schaltest.
+    description: Beschreibe dein Ziel.
     goalLabel: Ziel
     goalPlaceholder:
       z. B. Lies jeden Morgen die neuesten Support-E-Mails und schreibe eine
@@ -666,7 +648,7 @@ automations:
     providerPlaceholder: Anbieter wählen
     modelLabel: Modell
     modelPlaceholder: Modell wählen
-    submit: Bauen starten
+    submit: Automatisierung generieren
     submitting: Baut …
     running:
       Der Builder arbeitet — das kann ein paar Minuten dauern. Gespeicherte
@@ -690,13 +672,10 @@ automations:
     saveMessageDescription: Was sich geändert hat, damit die Versionsliste lesbar bleibt.
     saveDialog:
       title: Neue Version speichern
-      description: Beim Speichern kommt eine neue Version dazu. Die angezeigte
-        bleibt unverändert, ein laufender Lauf merkt davon nichts.
+      description: Speichert eine neue Version. Läufe, die gerade aktiv sind, nutzen weiter die deployte Version.
     switchVersion:
       title: Andere Version anzeigen?
-      description:
-        Der Canvas zeigt immer genau eine gespeicherte Version, deshalb
-        gehen deine noch nicht gespeicherten Änderungen dabei verloren.
+      description: Beim Versionswechsel gehen nicht gespeicherte Änderungen verloren.
       confirm: Verwerfen und wechseln
     showLastRun: Letzten Lauf einblenden
     hideLastRun: Letzten Lauf ausblenden
@@ -705,9 +684,7 @@ automations:
     runLiveNeedsDeploy: Schalte zuerst eine Version live — ein Live-Lauf führt
       die Version aus, die live ist.
     runLiveTitle: Live ausführen?
-    runLiveBody: Ein Live-Lauf ruft echte Connectors im Namen der
-      Organisation auf — Mails gehen raus, Daten ändern sich. Die Live-Version
-      läuft einmal, jetzt.
+    runLiveBody: Führt die deployte Version live aus — Mails gehen raus, Daten ändern sich. Ein erneuter Lauf startet nicht automatisch.
   trigger:
     title: Trigger
     none: Noch nichts startet diese Automatisierung.
@@ -727,15 +704,13 @@ automations:
     save: Trigger speichern
     remove: Trigger entfernen
     removeTitle: Trigger entfernen?
-    removeBody: Die Automatisierung behält ihre Versionen und ihre Historie;
-      nichts startet sie, bis eine neue Bindung gespeichert ist.
+    removeBody: Entfernt den Trigger. Die Automatisierung und ihre Versionshistorie bleiben unberührt.
     tokenTitle: Webhook-Token — kopiere ihn jetzt
     tokenHint: Dieser Token erscheint genau einmal und liegt nur als Hash
       gespeichert.
     tokenPath: 'Ein POST auf /api/automations/webhook/{token} startet die
       Automatisierung.'
-    hasToken: Ein Webhook-Token existiert. Rotieren ersetzt ihn; die alte
-      Adresse funktioniert dann nicht mehr.
+    hasToken: Ein Token ist aktiv. Rotieren erzeugt einen neuen — aktualisiere alle Webhooks, die die alte Adresse verwenden.
     noToken: Beim Speichern entsteht ein Token und erscheint einmal.
     rotate: Token rotieren
   canvas:
@@ -787,7 +762,7 @@ automations:
       outputSchema: Ausgabeschema
       automation: Automatisierung
       credential: Zugangsdaten
-      harness: Harness
+      harness: Agent-Laufzeit
       skills: Skills
       connectors: Connectors
       files: Bereitgestellte Dateien
@@ -805,10 +780,7 @@ automations:
     title: Projekte
     orgBadge: Organisationsweit
     countBadge: '{count, plural, one {An # Projekt gebunden} other {An # Projekte gebunden}}'
-    hint: Die Projekte, deren Task-Boards diese Automatisierung sehen. Ohne
-      Auswahl gilt sie für die ganze Organisation; mit Auswahl erscheint sie
-      genau in diesen Projekten. Ein Projekt lässt sich nicht löschen, solange
-      eine Automatisierung daran gebunden ist.
+    hint: Wähle aus, welche Projekte diese Automatisierung nutzen können. Ohne Auswahl steht sie der gesamten Organisation zur Verfügung.
     placeholder: Organisationsweit — keine Projekte ausgewählt
     searchPlaceholder: Projekte durchsuchen
     empty: Keine passenden Projekte
@@ -827,10 +799,10 @@ automations:
     noMessage: Keine Notiz
   upload:
     trigger: Paket hochladen
-    title: Ein Automatisierungs-Paket hochladen
-    description: Die workflow.yml eines Packs (erforderlich) und die automation.yml (optional — ihr subjects-Block wird zum Task-Vertrag), oder das ganze Pack-Verzeichnis als eine .zip, die auch Skill-Bundles unter skills/ mitbringen kann. Das Dokument wird vor dem Speichern validiert; die hochgeladene Version bleibt ein Entwurf, bis du sie deployst.
+    title: Paket hochladen
+    description: Lade eine Workflow-Datei oder Pack-ZIP hoch, um sie zu deinen Automatisierungen hinzuzufügen.
     filesLabel: Paketdateien
-    filesHelp: Wähle workflow.yml (plus automation.yml) — oder eine .zip des Pack-Verzeichnisses, skills/ inklusive.
+    filesHelp: workflow.yml (plus automation.yml) oder eine Pack-.zip.
     uploading: Lädt das Paket hoch…
     zipOnly: Lade die .zip allein hoch — sie bringt das ganze Pack schon mit.
     zipTooLarge: Die .zip liegt über der 20-MiB-Paketgrenze.
@@ -842,8 +814,8 @@ automations:
     removeFile: '{name} entfernen'
     targetLabel: Installieren in
     targetOrg: Organisation
-    targetHelp: Installieren in ein Projekt bindet die Automatisierung an dieses Projekt — im Bereich Projekte auf ihrer Seite fügst du jederzeit Projekte hinzu oder entfernst sie. Organisation installiert sie organisationsweit, sichtbar auf dem Task-Board jedes Projekts.
-    submit: Hochladen
+    targetHelp: Ein Projekt bindet sie an dieses Board; Organisation teilt sie org-weit.
+    submit: Paket hochladen
     submitting: Validieren und speichern…
     uploaded: '{name} v{version} hochgeladen — deploye sie, wenn du bereit bist.'
     warnings: '{count, plural, one {# Validierungswarnung} other {# Validierungswarnungen}} — öffne die Automatisierung zur Prüfung.'
@@ -856,8 +828,8 @@ automations:
       title: 'Wartet auf deine Freigabe: {operation}'
       node: 'Angefragt von Node "{node}" — mit der Freigabe führt sie den Schritt beim nächsten Poll aus; eine Ablehnung lässt ihn fehlschlagen.'
       pending: Mit der Freigabe führt der wartende Schritt beim nächsten Poll aus; eine Ablehnung lässt ihn fehlschlagen.
-      approved: '{operation} wurde freigegeben — der Lauf setzt beim nächsten Poll fort.'
-      rejected: '{operation} wurde abgelehnt — der Schritt schlägt fehl und der Lauf stoppt.'
+      approved: '{operation} freigegeben — der Lauf setzt beim nächsten Poll fort.'
+      rejected: '{operation} abgelehnt — der Schritt schlägt fehl und der Lauf stoppt.'
       input: Der Schritt würde aufrufen mit
       approve: Freigeben
       reject: Ablehnen
@@ -914,14 +886,14 @@ automations:
       actions: '{count, plural, one {# Aktion} other {# Aktionen}}'
   settings:
     loading: Lädt Einstellungen…
-    loadFailed: Die Einstellungen konnten nicht geladen werden — schließe den Dialog und versuche es erneut.
+    loadFailed: Einstellungen konnten nicht geladen werden — schließe den Dialog und versuch es nochmal.
     save: Speichern
     saveAndContinue: Speichern und weiter
     dialogTitle: '{name} — Einstellungen'
     tabsLabel: Einstellungsbereiche
     unsavedTab: Nicht gespeicherte Änderungen
     saved: Einstellungen gespeichert.
-    saveFailed: Die Einstellungen konnten nicht gespeichert werden — versuche es erneut.
+    saveFailed: Einstellungen konnten nicht gespeichert werden. Versuch es nochmal.
     errors:
       required: Dieses Feld ist erforderlich.
       number: Gib eine Zahl ein.
@@ -975,7 +947,7 @@ chat:
   archiveFailed: Chat konnte nicht archiviert werden
   unarchiveSuccess: Chat dearchiviert
   unarchiveFailed: Chat konnte nicht dearchiviert werden
-  archivedBanner: Diese Unterhaltung wurde archiviert
+  archivedBanner: Archiviert
   archived:
     title: Archiviert
     empty: Keine archivierten Chats
@@ -998,7 +970,7 @@ chat:
   removeFromProject: Aus Projekt entfernen
   removeFromProjectFailed: Chat konnte nicht aus dem Projekt entfernt werden
   deleteChat: Chat löschen
-  deleteConfirmation: Möchtest du {title} wirklich löschen?
+  deleteConfirmation: '"{title}" löschen?'
   deletePermanentMessage: Chat in den Papierkorb verschieben. Du kannst ihn während der Schonfrist der Org wiederherstellen; danach löscht die Aufbewahrungsrichtlinie den Chat und seine Nachrichten endgültig.
   deleteFailed: Chat konnte nicht gelöscht werden
   editMessage: Nachricht bearbeiten
@@ -1102,8 +1074,8 @@ chat:
   newProject: Neues Projekt
   notFound: Dieser Chat ist nicht verfügbar.
   placeholder: Frag zu deinen Dokumenten oder dem Web…
-  generationIncomplete: Die Antwort konnte nicht abgeschlossen werden. Bitte versuche es erneut.
-  generationIncompleteWithTools: Die Antwort konnte nach der Ausführung von {tools} nicht abgeschlossen werden. Bitte versuche es erneut.
+  generationIncomplete: Die Antwort konnte nicht abgeschlossen werden. Versuch es erneut.
+  generationIncompleteWithTools: Die Antwort konnte nach der Ausführung von {tools} nicht abgeschlossen werden. Versuch es erneut.
   stepLimitReached: Hier gestoppt — das Schrittlimit dieses Durchgangs ist erreicht. Schreib eine Nachricht, um weiterzumachen.
   send: Nachricht senden
   stopGenerating: Generierung stoppen
@@ -1148,7 +1120,7 @@ chat:
     inProgressTooltip: Transkribiere Audio…
     transcribing: Transkribiere…
     transcribed: Transkribiert
-    couldNotTranscribe: Konnte nicht transkribiert werden
+    couldNotTranscribe: Transkription fehlgeschlagen
     viewTranscript: Transkript anzeigen
     previewSubtitle: '{seconds}s transkribiert'
     retry: Erneut versuchen
@@ -1201,7 +1173,7 @@ chat:
     noMetadata: Token-Verbrauch und Modellinformationen sind für diese Nachricht nicht verfügbar.
   history:
     empty: Noch keine Gespräche
-    emptySubtitle: Starte einen neuen Chat, um zu beginnen
+    emptySubtitle: Starte einen neuen Chat
     untitled: Unbenannter Chat
     noProjects: Noch keine Projekte — erstelle eines im Panel oben.
     legalHold:
@@ -1236,8 +1208,7 @@ chat:
     transcriptionFailedShort: Transkription fehlgeschlagen
     retry: Erneut versuchen
     discard: Aufnahme verwerfen
-    permissionDenied: Mikrofonzugriff wurde verweigert. Bitte erlaube den
-      Mikrofonzugriff in den Browsereinstellungen.
+    permissionDenied: Mikrofonzugriff verweigert. Erlaube ihn in den Browsereinstellungen.
   citations:
     source: Quelle {number}
     page: Seite {page}
@@ -1364,8 +1335,7 @@ chat:
     approvalRejected: Abgelehnt
     humanInputPending: Deine Antwort wird gebraucht
     humanInputAnswered: Beantwortet
-  errorGeneratingDescription: Beim Generieren einer Antwort ist ein Fehler
-    aufgetreten. Bitte versuche es erneut.
+  errorGeneratingDescription: Antwort konnte nicht generiert werden. Versuch es erneut.
   errorHintAuthError: Der API-Schlüssel ist ungültig oder hat keinen Zugriff auf
     dieses Modell. Kontaktiere deinen Administrator.
   errorHintContentFilter: Die Nachricht wurde vom Inhaltsfilter markiert.
@@ -1385,9 +1355,8 @@ chat:
     unterstützt). Versuche es erneut — Tale löscht einen fehlerhaften Cache-Wert
     automatisch — oder bitte deinen Administrator, die maximalen Ausgabe-Tokens
     zu senken.
-  errorHintProviderError: Der KI-Anbieter hat vorübergehend technische Probleme.
-    Bitte versuche es in einem Moment erneut.
-  errorHintRateLimited: Zu viele Anfragen. Bitte warte einen Moment und versuche es erneut.
+  errorHintProviderError: Der KI-Anbieter hat vorübergehend technische Probleme. Versuch es gleich nochmal.
+  errorHintRateLimited: Zu viele Anfragen. Warte einen Moment und versuch es erneut.
   errorHintTokenLimit: Das Token-Limit des Modells wurde überschritten. Versuche
     eine kürzere Anfrage oder bitte deinen Administrator, die
     Modelleinstellungen anzupassen.
@@ -1411,9 +1380,7 @@ chat:
     erneut oder kontaktiere deinen Administrator.'
   errorHintModelNotFoundNamed: Das ausgewählte Modell wurde bei {provider} nicht
     gefunden. Es wurde möglicherweise umbenannt oder entfernt.
-  errorHintRateLimitedNamed:
-    Ratenlimit bei {provider} erreicht. Bitte warte einen
-    Moment und versuche es erneut.
+  errorHintRateLimitedNamed: Ratenlimit bei {provider} erreicht. Warte einen Moment und versuch es erneut.
 
   errorGenerating: Etwas ist schiefgelaufen
   errorTriedModels: '{count} Modelle wurden vor dem Abbruch versucht.'
@@ -1452,8 +1419,8 @@ chat:
     showAll: Alle {count} Quellen anzeigen
     hide: Quellen ausblenden
 
-  budgetExceededDetail: '{type}-Limit für diesen {period}-Zeitraum erreicht ({used} / {limit}). Bitte kontaktiere deinen Administrator.'
-  budgetExceededDefault: Dein Nutzungslimit für diesen Zeitraum wurde erreicht. Bitte kontaktiere deinen Administrator.
+  budgetExceededDetail: '{type}-Limit für diesen {period} erreicht ({used} / {limit}). Wende dich an deinen Administrator.'
+  budgetExceededDefault: Nutzungslimit für diesen Zeitraum erreicht. Wende dich an deinen Administrator.
   budgetRemaining: 'Noch {remaining} von {limit} {type} in diesem {period}'
   budgetLimitReached: 'Nutzungslimit erreicht · setzt sich {period} zurück'
   budgetRequestCredits: Mehr Kontingent anfragen
@@ -1523,6 +1490,7 @@ common:
     openMenu: Menü öffnen
     deleteSelected: Ausgewählte löschen
     export: Exportieren
+    tryAgain: Erneut versuchen
   unsavedChanges:
     title: Ungespeicherte Änderungen
     description: Du hast ungespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.
@@ -1539,15 +1507,12 @@ common:
   bulkActions:
     itemsSelected: '{count, plural, one {# Element ausgewählt} other {# Elemente ausgewählt}}'
     confirmDeleteTitle: '{count, plural, one {# Element} other {# Elemente}} löschen'
-    confirmDeleteDescription:
-      Möchtest du {count, plural, one {dieses Element} other
-      {diese {count} Elemente}} wirklich löschen? Diese Aktion kann nicht
-      rückgängig gemacht werden.
+    confirmDeleteDescription: '{count, plural, one {Dieses Element} other {Diese {count} Elemente}} löschen? Das lässt sich nicht rückgängig machen.'
     deleteSuccess: '{count, plural, one {# Element} other {# Elemente}} gelöscht'
     deleteFailed: Einige Elemente konnten nicht gelöscht werden
     deleting: Lösche...
   upload:
-    clickToUpload: Klicken zum Hochladen
+    clickToUpload: Hochladen
     dropFilesHere: Dateien hier ablegen zum Hochladen
     supportedFormats: .xlsx, .xls oder .csv
     pickADate: Datum auswählen
@@ -1588,14 +1553,14 @@ common:
   validation:
     required: '{field} ist erforderlich'
     maxLength: '{field} darf höchstens {max} Zeichen lang sein'
-    email: Bitte gib eine gültige E-Mail-Adresse ein
+    email: Gib eine gültige E-Mail-Adresse ein
     invalidJson: Ungültiges JSON-Format
-    uploadFile: Bitte lade eine Datei hoch
+    uploadFile: Lade eine Datei hoch
     unsupportedFileType: Nicht unterstützter Dateityp
     schemaValidationFailed:
       'Schema-Validierung fehlgeschlagen{error, select, empty
       {} other {: {error}}}'
-    url: Bitte gib eine gültige URL ein
+    url: Gib eine gültige URL ein
   aria:
     close: Schließen
     resizePanel: Panelgröße ändern
@@ -1657,13 +1622,11 @@ common:
       '{tokens} passt zu niemandem in deiner Organisation — es
       wurde keine Benachrichtigung gesendet.'
   errors:
-    generic: Etwas ist schiefgelaufen. Bitte versuche es erneut.
+    generic: Etwas ist schiefgelaufen — versuch es erneut, oder lade die Seite neu, wenn das Problem bleibt.
     failedToCopy: Kopieren in die Zwischenablage fehlgeschlagen
     somethingWentWrong: Etwas ist schiefgelaufen
-    errorLoadingPage:
-      Beim Laden dieser Seite ist ein Fehler aufgetreten. Du kannst
-      es erneut versuchen oder zu einem anderen Bereich navigieren.
-    persistsProblem: Wenn dieses Problem weiterhin besteht,
+    errorLoadingPage: Beim Laden dieser Seite ist etwas schiefgelaufen. Versuch es erneut oder wechsle zu einem anderen Bereich.
+    persistsProblem: Wenn das immer wieder passiert,
     contactSupport: kontaktiere den Support
     tryAgain: Erneut versuchen
     showDetails: Details anzeigen
@@ -1785,9 +1748,7 @@ conversations:
     discard: Verwerfen
     discardConfirm:
       title: Entwurf verwerfen?
-      description:
-        Du verwirfst diesen E-Mail-Entwurf endgültig. Das lässt sich nicht
-        rückgängig machen.
+      description: Dieser Entwurf wird endgültig verworfen.
     sent: E-Mail gesendet
     uploadFailed: Anhang konnte nicht hochgeladen werden
   updating: Konversationen werden aktualisiert...
@@ -1844,16 +1805,12 @@ conversations:
     assignError: Zuständigkeit konnte nicht aktualisiert werden
     inboxSource: 'Postfach: {inbox}'
     toast:
-      closed: Konversation wurde geschlossen.
-      closeFailed: Beim Schließen der Konversation ist ein unerwarteter Fehler aufgetreten.
-      reopened: Konversation wurde erneut geöffnet.
-      reopenFailed:
-        Beim erneuten Öffnen der Konversation ist ein unerwarteter Fehler
-        aufgetreten.
-      markedAsSpam: Konversation wurde als Spam markiert.
-      markAsSpamFailed:
-        Beim Markieren der Konversation als Spam ist ein unerwarteter
-        Fehler aufgetreten.
+      closed: Konversation geschlossen
+      closeFailed: Konversation konnte nicht geschlossen werden — versuch es erneut.
+      reopened: Konversation erneut geöffnet
+      reopenFailed: Konversation konnte nicht geöffnet werden — versuch es erneut.
+      markedAsSpam: Konversation als Spam markiert
+      markAsSpamFailed: Konversation konnte nicht als Spam markiert werden — versuch es erneut.
     assignedTeam: Team
     assignedToTeam: An {name} zugewiesen
     unassignTeam: Team entfernen
@@ -1864,8 +1821,8 @@ conversations:
     autoAssignSettings: Automatisch zuweisen
   editor:
     noContent: Kein Inhalt zum Verbessern
-    improveFailed: Inhalt konnte nicht verbessert werden. Bitte versuche es erneut.
-    sendFailed: Nachricht konnte nicht gesendet werden. Bitte versuche es erneut.
+    improveFailed: Inhalt konnte nicht verbessert werden. Versuch es erneut.
+    sendFailed: Nachricht konnte nicht gesendet werden. Versuch es erneut.
     backToEditor: Zurück zum Editor
     improving: Wird verbessert...
     improveWithAi: Mit KI verbessern
@@ -1878,8 +1835,8 @@ conversations:
     downloading: Lade herunter...
     attachments: '{count, plural, one {# Anhang} other {# Anhänge}}'
   panel:
-    uploadFailed: Anhänge konnten nicht hochgeladen werden. Bitte versuche es erneut.
-    downloadFailed: Anhänge konnten nicht heruntergeladen werden. Bitte versuche es erneut.
+    uploadFailed: Anhänge konnten nicht hochgeladen werden. Versuch es erneut.
+    downloadFailed: Anhänge konnten nicht heruntergeladen werden. Versuch es erneut.
     noSelected: Keine Konversation ausgewählt
     selectToView: Wähle eine Konversation, um Details anzuzeigen
     notFound: Konversation nicht gefunden
@@ -1891,15 +1848,15 @@ conversations:
     loadFailed: Konversation konnte nicht geladen werden
     loadFailedDescription: Beim Laden dieser Konversation ist ein Fehler aufgetreten.
     tryAgain: Erneut versuchen
-    closedBanner: Diese Konversation wurde am {date} geschlossen
-    closedBannerNoDate: Diese Konversation wurde geschlossen
-    archivedBanner: Diese Konversation wurde archiviert
-    spamBanner: Diese Konversation wurde als Spam markiert
+    closedBanner: Geschlossen am {date}
+    closedBannerNoDate: Geschlossen
+    archivedBanner: Archiviert
+    spamBanner: Als Spam markiert
     unarchive: Dearchivieren
     notSpam: Kein Spam
     delete: Löschen
     deleting: Lösche...
-    deleteSuccess: Konversation gelöscht.
+    deleteSuccess: Konversation gelöscht
     deleteFailed: Konversation konnte nicht gelöscht werden.
     showEarlierMessages: '{count} frühere {count, plural, one {Nachricht} other
       {Nachrichten}} anzeigen'
@@ -1980,7 +1937,7 @@ contacts:
   localePlaceholder: z. B. en-US
   phone: Telefon
   import:
-    provideData: Bitte gib Daten ein
+    provideData: Keine Daten angegeben
     noValidData: Keine gültigen Kontaktdaten gefunden
     success: Import
     successDescription:
@@ -1993,10 +1950,10 @@ contacts:
     errorCodes:
       duplicate_email: Ein Kontakt mit dieser E-Mail existiert bereits
       duplicate_external_id: Ein Kontakt mit dieser externen ID existiert bereits
-      unknown: Ein unerwarteter Fehler ist aufgetreten
-  deleteConfirmation: Möchtest du {name} wirklich löschen?
+      unknown: Etwas ist schiefgelaufen
+  deleteConfirmation: '{name} löschen?'
   deleteError: Kontakt konnte nicht gelöscht werden
-  deleteWarning: Diese Aktion kann nicht rückgängig gemacht werden.
+  deleteWarning: Das lässt sich nicht rückgängig machen.
 dataNotice:
   default: KI kann Fehler machen – prüfe Antworten und teile keine sensiblen Daten.
   footer:
@@ -2009,9 +1966,7 @@ dialogs:
       erforderlich — sie meldet sich mit ihren bestehenden Zugangsdaten an.
   memberAdded:
     title: Mitglied hinzugefügt
-    credentialsWarning:
-      'Wichtig: Speichere diese Zugangsdaten jetzt — sie werden
-      nicht erneut angezeigt.'
+    credentialsWarning: Speichere diese Zugangsdaten jetzt — sie werden nicht erneut angezeigt.
     existingUserNotice: Dieser Benutzer hatte bereits ein Konto, es wurden keine
       neuen Zugangsdaten erstellt. Er kann sich mit seinem bestehenden Passwort
       anmelden.
@@ -2022,9 +1977,7 @@ dialogs:
     noResults: Keine Ergebnisse
     untitledChat: Unbenannter Chat
   thisMember: dieses Mitglied
-  confirmRemoveMember: Bist du sicher, dass du {name} aus dem Team entfernen
-    möchtest? Die Person verliert den Zugriff auf diese Organisation und alle
-    zugehörigen Ressourcen.
+  confirmRemoveMember: '{name} aus dem Team entfernen? Die Person verliert den Zugriff auf diese Organisation und alle zugehörigen Ressourcen.'
   toSend: zum Senden
   contactInfo:
     title: Kontaktdetails
@@ -2041,10 +1994,10 @@ documentWriteApproval:
   savedSuccessfully: In deinen Dokumenten gespeichert
   savedPartially: '{success} von {total} Dateien gespeichert'
   statusExecuting: Dokumente werden gespeichert...
-  statusCompletedFailed: Dieses Dokument wurde genehmigt, konnte aber nicht gespeichert werden.
-  statusCompletedSuccess: Dieses Dokument wurde in deinen Dokumenten gespeichert.
+  statusCompletedFailed: Genehmigt, konnte aber nicht gespeichert werden.
+  statusCompletedSuccess: In deinen Dokumenten gespeichert.
   statusCompletedPartial: Einige Dokumente konnten nicht gespeichert werden.
-  statusRejected: Diese Dokumentspeicherung wurde abgelehnt.
+  statusRejected: Abgelehnt.
   allFilesFailed: Alle {count} Dateien konnten nicht gespeichert werden
   errorSaveFailed: Dokument konnte nicht gespeichert werden
 jobCard:
@@ -2086,13 +2039,13 @@ documents:
   searchPlaceholder: Dokumente suchen
   deleteFolder:
     title: Ordner löschen
-    confirmation: Möchtest du den Ordner {name} wirklich löschen?
+    confirmation: 'Ordner „{name}" löschen?'
     requirement: Alle Dateien und Unterordner in diesem Ordner werden ebenfalls
       dauerhaft gelöscht.
     deleteButton: Ordner löschen
   deleteSyncFolder:
     title: Synchronisierungsordner löschen
-    confirmation: Möchtest du den Synchronisierungsordner {name} wirklich löschen?
+    confirmation: 'Synchronisierungsordner „{name}" löschen?'
     thisWillDelete: 'Folgendes wird dauerhaft gelöscht:'
     willDelete:
       filesAndSubfolders: Alle Dateien und Unterordner
@@ -2114,7 +2067,7 @@ documents:
   actions:
     deleteSyncFolder: Synchronisierungsordner löschen
     deleteFolderFailed: Ordner konnte nicht gelöscht werden
-    deleteFileFailed: Beim Löschen der Datei ist ein unerwarteter Fehler aufgetreten.
+    deleteFileFailed: Datei konnte nicht gelöscht werden — versuch es erneut.
     manageTeams: Team zuweisen
     reindex: Neu indexieren
     stopSync: Synchronisierung beenden
@@ -2144,8 +2097,7 @@ documents:
     orgWide: Organisationsweit
   deleteFile:
     title: Dokument löschen
-    confirmation: Möchtest du {name} wirklich löschen? Diese Aktion kann nicht
-      rückgängig gemacht werden.
+    confirmation: '„{name}" löschen? Das lässt sich nicht rückgängig machen.'
     thisDocument: dieses Dokument
     deleteButton: Löschen
   breadcrumb:
@@ -2175,7 +2127,7 @@ documents:
     downloadComplete: Download abgeschlossen
     downloadFile: Datei herunterladen
     closePreview: Vorschau schließen
-    downloadedSuccessfully: '{filename} wurde heruntergeladen'
+    downloadedSuccessfully: '{filename} heruntergeladen'
     downloadFailed: Datei konnte nicht heruntergeladen werden
     notAvailable: Vorschau nicht verfügbar
     notAvailableDescription:
@@ -2213,14 +2165,14 @@ documents:
     confirming: Bestätige Upload…
     confirmingFileNamed: Upload von {fileName} wird bestätigt
     failedFileName: '{fileName} — Fehlgeschlagen'
-    pleaseWaitForUpload: Bitte warte, bis der aktuelle Upload abgeschlossen ist
+    pleaseWaitForUpload: Warte, bis der aktuelle Upload abgeschlossen ist
     noFilesSelected: Keine Dateien ausgewählt
     fileTooLarge: Datei zu groß
     fileSizeExceeded: 'Datei {name} überschreitet das Limit von {maxSize} MB.
       Aktuelle Größe: {currentSize} MB'
     uploadCancelled: Upload abgebrochen
     uploadFailed: Upload fehlgeschlagen
-    uploadFailedRetry: Upload fehlgeschlagen. Bitte prüfe deine Verbindung und versuche es erneut.
+    uploadFailedRetry: Upload fehlgeschlagen. Prüfe deine Verbindung und versuch es erneut.
     quotaExceeded: Speicherkontingent voll — {used} von {limit} belegt. Lösche
       Dateien, um Platz zu schaffen (fehlgeschlagene Uploads zählen mit).
     quotaUsage: '{used} von {limit} belegt'
@@ -2310,18 +2262,18 @@ documents:
     toast:
       documentIdRequired: Dokument-ID ist für den erneuten Versuch erforderlich
       indexingStarted: Indexierung gestartet
-      indexingQueued: Dokumentindexierung wurde in die Warteschlange gestellt.
+      indexingQueued: Indexierung in die Warteschlange gestellt
       retryFailed: Erneuter Versuch fehlgeschlagen
       retryFailedDescription: RAG-Indexierung konnte nicht erneut gestartet werden
-      unexpectedError: Ein unerwarteter Fehler ist aufgetreten
+      unexpectedError: Etwas ist schiefgelaufen
     dialog:
       indexed:
         title: Dokument indexiert
-        description: Dieses Dokument wurde indexiert und ist für die RAG-Suche verfügbar.
+        description: Dieses Dokument ist indexiert und für die Wissenssuche verfügbar.
         indexedOn: 'Indexiert am:'
       failed:
         title: Indexierung fehlgeschlagen
-        description: Das Dokument konnte nicht für die RAG-Suche indexiert werden.
+        description: Dieses Dokument konnte nicht für die Wissenssuche indexiert werden.
         errorDetails: 'Fehlerdetails:'
         unknownError: Unbekannter Fehler aufgetreten
         embeddingNotConfigured:
@@ -2445,11 +2397,8 @@ onboarding:
     goToDashboard: Zum Dashboard
 emptyStates:
   providers:
-    title: Noch keine Anbieter-Zugangsdaten
-    description:
-      Füge den API-Schlüssel oder die Umgebungs-Zugangsdaten hinzu, mit denen
-      sich ein AI-Anbieter authentifiziert — danach stehen seine Modelle in
-      Chats und Agenten bereit.
+    title: Verbinde deinen ersten AI-Anbieter
+    description: Füge einen API-Schlüssel hinzu, und dein Team kann sofort mit den zugehörigen Modellen chatten.
   connectors:
     title: Noch keine Connectors verbunden
     description: Verbinde einen Dienst — ein Postfach, ein Repository, einen
@@ -2482,9 +2431,7 @@ emptyStates:
       Zugriff zu steuern
   apiKeys:
     title: Noch keine API-Schlüssel
-    description:
-      Erstelle einen API-Schlüssel, um externe Connectors via REST API
-      zu ermöglichen
+    description: Erstelle einen Schlüssel, damit externe Tools und Skripte sich mit diesem Workspace verbinden können.
 governance:
   title: Richtlinien
   toastSavedTitle: Änderungen gespeichert
@@ -2548,7 +2495,7 @@ governance:
     searchApiKeys: API-Schlüssel suchen
     noApiKeysFound: Keine API-Schlüssel gefunden
     selectApiKeyAriaLabel: API-Schlüssel auswählen
-    saved: Budgetregeln wurden aktualisiert
+    saved: Budgetregeln aktualisiert
     saveFailed: Budgetregeln konnten nicht gespeichert werden
     targetRequired: Wählen Sie ein Ziel für diesen Geltungsbereich, sonst greift die Regel nie.
     limitRequired: Legen Sie mindestens ein Limit (Tokens, Kosten oder Anfragen)
@@ -2560,7 +2507,7 @@ governance:
   defaultModels:
     title: Standardmodelle
     description: Standardmodelle für bestimmte Benutzergruppen oder Rollen festlegen.
-    saved: Standardmodell-Konfiguration wurde aktualisiert
+    saved: Standardmodell-Konfiguration aktualisiert
     saveFailed: Standardmodell-Konfiguration konnte nicht gespeichert werden
     addRule: Regel hinzufügen
     addRuleTitle: Standardmodell-Regel hinzufügen
@@ -2620,7 +2567,7 @@ governance:
   retentionPolicy:
     title: Aufbewahrungsrichtlinie
     description: Lege fest, wie lange jeder Datentyp vor der Löschung aufbewahrt wird.
-    saved: Aufbewahrungsrichtlinie wurde aktualisiert
+    saved: Aufbewahrungsrichtlinie aktualisiert
     saveFailed: Aufbewahrungsrichtlinie konnte nicht gespeichert werden
     save: Änderungen speichern
     reset: Auf Standardwerte zurücksetzen
@@ -2775,29 +2722,17 @@ governance:
       helper: Automatisierungsläufe, die älter sind, werden gelöscht (1–365 Tage).
     auditLogs:
       title: Audit-Logs
-      description:
-        'Audit-Log-Einträge, die älter als die Aufbewahrungsfrist sind,
-        automatisch löschen. Hinweis: Audit-Logs sind unveränderliche
-        historische Aufzeichnungen für Compliance-Zwecke; halte die
-        Aufbewahrungsfrist lang genug, um deine Audit-/Compliance-Anforderungen
-        zu erfüllen.'
+      description: Audit-Log-Einträge, die älter als die Aufbewahrungsfrist sind, automatisch löschen. Audit-Logs sind unveränderliche Aufzeichnungen — halte die Frist lang genug, um deine Compliance-Anforderungen zu erfüllen.
       placeholder: z. B. 90
       helper: Audit-Log-Einträge, die älter sind, werden gelöscht (30–365 Tage).
     usageLedger:
       title: Nutzungsbuch
-      description: 'Zeilen des Token-Nutzungsbuchs, die älter als die
-        Aufbewahrungsfrist sind, automatisch löschen. Achtung: Eine kürzere
-        Aufbewahrung schneidet historische Auswertungen ab (Budgets/Berichte
-        stützen sich auf diese Zeilen).'
+      description: Token-Verbrauchsdaten, die älter als die Aufbewahrungsfrist sind, automatisch löschen. Eine kürzere Frist schneidet historische Auswertungen ab — Budgets und Berichte stützen sich auf diese Daten.
       placeholder: z. B. 365
       helper: Nutzungsbuch-Zeilen, die älter sind, werden gelöscht (30–3650 Tage).
     loginAttempts:
       title: Anmeldeversuche
-      description: 'Aufzeichnungen fehlgeschlagener Anmeldungen (loginAttempts,
-        stündliche Sperrzähler), die älter als die Aufbewahrungsfrist sind,
-        automatisch löschen. Hinweis: Diese Tabellen gelten deployment-weit —
-        der strengste (kürzeste) Wert über alle Organisationen hinweg wird
-        verwendet.'
+      description: Aufzeichnungen fehlgeschlagener Anmeldeversuche, die älter als die Aufbewahrungsfrist sind, automatisch löschen. Diese Einstellung gilt deployment-weit — der kürzeste Wert aller Organisationen greift.
       placeholder: z. B. 90
       helper:
         Einträge zu Anmeldeversuchen, die älter sind, werden gelöscht (7–365
@@ -2847,7 +2782,7 @@ governance:
       Übergangsfrist werden Mitglieder abgemeldet, bis sie die Einrichtung
       abschließen.
     confirmEnforceCta: Zwei-Faktor verlangen
-    saved: Zwei-Faktor-Richtlinie wurde aktualisiert
+    saved: Zwei-Faktor-Richtlinie aktualisiert
     saveFailed: Speichern der Zwei-Faktor-Richtlinie fehlgeschlagen
   loginPolicy:
     title: Anmeldeversuch-Limits
@@ -2925,7 +2860,7 @@ governance:
     noRulesDescription:
       Füge eine Regel hinzu, um Funktionen pro Benutzer, Team oder
       Rolle zu steuern.
-    saved: Feature-Steuerung wurde aktualisiert
+    saved: Feature-Steuerung aktualisiert
     saveFailed: Feature-Steuerung konnte nicht gespeichert werden
     actions: Aktionen
     role: Rolle
@@ -2972,7 +2907,7 @@ governance:
     description: Personenbezogene Daten erkennen und maskieren oder blockieren,
       bevor sie an KI-Modelle gesendet werden.
     enableLabel: PII-Schutz aktivieren
-    saved: PII-Konfiguration wurde aktualisiert
+    saved: PII-Konfiguration aktualisiert
     saveFailed: PII-Konfiguration konnte nicht gespeichert werden
   guardrailsOverview:
     title: Guardrails-Übersicht
@@ -3461,9 +3396,7 @@ governance:
     sections:
       activeHolds:
         title: Aktive Holds
-        description:
-          Aktuell vor Bereinigung und Löschung geschützte Entitäten. Setze
-          Holds auf Benutzer- (Custodian) oder Organisationsebene.
+        description: Aktuell vor Bereinigung und Löschung geschützte Entitäten. Holds lassen sich auf einzelne Benutzer oder auf Organisationsebene setzen.
         empty:
           title: Keine aktiven Legal Holds
           description:
@@ -3621,12 +3554,10 @@ governance:
     errors:
       generic:
         title: Etwas ist schiefgelaufen
-        description:
-          Bitte erneut versuchen. Falls das Problem weiterhin besteht, an die
-          Administration wenden.
+        description: Versuch es nochmal. Hält das Problem an, wende dich an die Administration.
       unauthenticated: Anmeldung erforderlich.
       forbidden: Du hast keine Berechtigung dafür.
-      validation: Bitte die Formularfelder prüfen.
+      validation: Prüf die Formularfelder.
       notFound: Nicht gefunden.
       alreadyActive: Auf dieses Ziel besteht bereits ein aktiver Legal Hold.
       matterNotFound: Dieser Fall existiert in der Organisation nicht.
@@ -3675,7 +3606,7 @@ governance:
     noUsersFound: Keine Benutzer gefunden
     noTeamsFound: Keine Teams gefunden
     confirm: Bestätigen
-    saved: Modellzugriffsrichtlinie wurde aktualisiert
+    saved: Modellzugriffsrichtlinie aktualisiert
     saveFailed: Modellzugriffsrichtlinie konnte nicht gespeichert werden
     removeDefaultConfirmTitle: Berechtigung für aktives Standardmodell entfernen?
     removeDefaultConfirmBody:
@@ -3897,12 +3828,10 @@ governance:
     errors:
       generic:
         title: Etwas ist schiefgelaufen
-        description:
-          Versuche es erneut. Wende dich an deinen Administrator, falls das
-          Problem bestehen bleibt.
+        description: Versuch es nochmal. Hält das Problem an, wende dich an die Administration.
       unauthenticated: Anmeldung erforderlich.
       forbidden: Du hast keine Berechtigung dafür.
-      validation: Bitte überprüfe die Formularfelder.
+      validation: Prüf die Formularfelder.
       notFound: Nicht gefunden.
       alreadyPending: Für diese Person läuft bereits eine Löschungsanfrage.
       legalHoldBlocked: Ein aktiver Legal Hold bewahrt die Daten dieser Person.
@@ -3946,9 +3875,7 @@ governance:
         Tag einreichen darf. Begrenzt den Schaden bei kompromittierten
         Admin-Zugängen. Bereich: 1–50.'
     saved: Governance für Anfragen betroffener Personen aktualisiert.
-    saveFailed:
-      Die Governance-Richtlinie konnte nicht gespeichert werden. Versuche
-      es erneut.
+    saveFailed: Governance-Richtlinie konnte nicht gespeichert werden. Versuch es nochmal.
     invalidCoolingOffHours: Die Karenzzeit muss eine ganze Zahl zwischen 0 und 72 sein.
     invalidDailyLimit: Das tägliche Limit muss eine ganze Zahl zwischen 1 und 50 sein.
     ownerOnlyNotice:
@@ -4034,15 +3961,15 @@ metrics:
     emptyDescription: Wähle ein Projekt, um seine Metriken zu sehen.
 humanInputRequest:
   questionTitle: Frage
-  submit: Antwort absenden
+  submit: Antwort senden
   statusResponded: Beantwortet
   statusProcessing: Verarbeite…
   respondedByAt: Beantwortet von {name} am {date}
   stopWorkflow: Stopp
   stopWorkflowTooltip: Die laufende Automatisierung stoppen
-  errorFillRequiredFields: Bitte fülle alle erforderlichen Felder aus
-  errorSelectRequired: Bitte triff eine Auswahl
-  errorFeedbackRequired: Bitte gib dein Feedback ein
+  errorFillRequiredFields: Füll alle erforderlichen Felder aus
+  errorSelectRequired: Triff eine Auswahl
+  errorFeedbackRequired: Gib dein Feedback ein
   errorAlreadyResponded: Diese Anfrage wurde bereits beantwortet.
   errorNotEditable: Nur eine abgeschlossene Antwort kann bearbeitet werden.
   errorWorkflowNotEditable: Antworten einer Automatisierung können nicht bearbeitet werden.
@@ -4058,8 +3985,8 @@ humanInputRequest:
   cancelEdit: Abbrechen
   versionPrevious: Vorherige Antwortversion
   versionNext: Nächste Antwortversion
-  errorTodoListRequired: Bitte füge mindestens einen Eintrag hinzu
-  errorTodoListMinItems: Bitte füge mindestens {count} Einträge hinzu
+  errorTodoListRequired: Füge mindestens einen Eintrag hinzu
+  errorTodoListMinItems: Füge mindestens {count} Einträge hinzu
   todoItemPlaceholder: Teilfrage {n}
   todoItemAriaLabel: '{label} Eintrag {n}'
   todoRemoveItem: Eintrag {n} entfernen
@@ -4071,9 +3998,9 @@ connectorApproval:
   approveTooltip: Diese Operation genehmigen und ausführen
   rejectTooltip: Diese Operation ablehnen
   statusExecuting: Operation wird ausgeführt...
-  statusCompletedFailed: Diese Operation wurde genehmigt, ist aber bei der Ausführung fehlgeschlagen.
-  statusCompletedSuccess: Diese Operation wurde genehmigt und ausgeführt.
-  statusRejected: Diese Operation wurde abgelehnt.
+  statusCompletedFailed: Genehmigt, Ausführung jedoch fehlgeschlagen.
+  statusCompletedSuccess: Genehmigt und ausgeführt.
+  statusRejected: Abgelehnt.
   errorApproveFailed: Operation konnte nicht genehmigt werden
   moreParameters: +{count} weitere
   showLess: Weniger anzeigen
@@ -4125,10 +4052,7 @@ knowledgeEntries:
     deleteError: Wissenseintrag konnte nicht gelöscht werden
   delete:
     title: Wissenseintrag löschen
-    confirmation:
-      Möchtest du diesen Wissenseintrag wirklich löschen? Er wird auch
-      aus der Wissensdatenbank entfernt und ist für Agenten nicht mehr
-      auffindbar. Diese Aktion kann nicht rückgängig gemacht werden.
+    confirmation: Diesen Eintrag löschen? Agenten können ihn danach nicht mehr in der Wissensdatenbank finden.
   viewDialog:
     title: Details zum Wissenseintrag
     indexingStatus: Indexierungsstatus
@@ -4151,9 +4075,9 @@ knowledgeWriteApproval:
   approveTooltipReplace: Genehmigen und den bestehenden Wissenseintrag ersetzen
   rejectTooltip: Diesen Wissenseintrag ablehnen
   statusExecuting: Wissenseintrag wird gespeichert...
-  statusCompletedFailed: Dieser Wissenseintrag wurde genehmigt, konnte aber nicht gespeichert werden.
-  statusCompletedSuccess: Dieser Wissenseintrag wurde in der Wissensdatenbank gespeichert.
-  statusRejected: Dieser Wissenseintrag wurde abgelehnt.
+  statusCompletedFailed: Genehmigt, konnte aber nicht gespeichert werden.
+  statusCompletedSuccess: In der Wissensdatenbank gespeichert.
+  statusRejected: Abgelehnt.
   errorSaveFailed: Wissenseintrag konnte nicht gespeichert werden
 locationRequest:
   title: Standortanfrage
@@ -4165,7 +4089,7 @@ locationRequest:
   statusDenied: Verweigert
   sharedBy: Geteilt von {name} am {date}
   errorNotSupported: Geolokalisierung wird von deinem Browser nicht unterstützt.
-  errorAcquireFailed: Standort konnte nicht ermittelt werden. Bitte versuche es erneut.
+  errorAcquireFailed: Standort konnte nicht ermittelt werden. Versuch es nochmal.
   defaultReason: Der Assistent benötigt deinen Standort, um dir bei deiner Anfrage zu helfen.
 metadata:
   suffix: Tale
@@ -4530,7 +4454,7 @@ personalization:
       title: Ausstehende Vorschläge
       empty: Keine ausstehenden Vorschläge.
   errors:
-    saveFailed: Speichern fehlgeschlagen. Bitte erneut versuchen.
+    saveFailed: Speichern fehlgeschlagen. Versuch es nochmal.
     tooLong: Benutzerdefinierte Anweisungen überschreiten {max} Zeichen.
   toasts:
     preferencesUpdated: Einstellungen aktualisiert.
@@ -4678,8 +4602,9 @@ products:
     imageUrlPlaceholder: https://example.com/image.jpg
     uploadImage: Bild hochladen
     removeImage: Bild entfernen
+    pasteUrl: Oder URL einfügen
     imageTooLarge: Bild ist zu groß (max. 5 MB).
-    imageUploadFailed: Bild-Upload fehlgeschlagen. Bitte versuche es erneut.
+    imageUploadFailed: Bild-Upload fehlgeschlagen. Versuch es nochmal.
     currencyPlaceholder: USD
     labels:
       name: Produktname
@@ -4709,10 +4634,12 @@ products:
       basics: Grundlagen
       pricing: Preis & Bestand
       review: Überprüfen
+    basicsHint: Beginne mit Name, Beschreibung und Bild.
+    pricingHint: Füge Preis, Bestand und Kategorie hinzu.
     reviewHint: Überprüfe die Angaben und erstelle dann das Produkt.
   import:
     uploadProducts: Produkte hochladen
-    uploadFile: Bitte lade eine Datei hoch
+    uploadFile: Lade eine Datei hoch
     success: Import
     successDescription:
       '{success} Produkte importiert{failed, select, 0 {} other {,
@@ -4732,7 +4659,7 @@ products:
     deleteSuccess: Produkt gelöscht
   delete:
     title: Produkt löschen
-    confirmation: Möchtest du {name} wirklich löschen?
+    confirmation: '„{name}" löschen? Alle zugehörigen Daten werden dauerhaft entfernt.'
     thisProduct: dieses Produkt
     warning: Alle zugehörigen Beziehungen und Daten werden dauerhaft entfernt.
   view:
@@ -5047,7 +4974,7 @@ settings:
         Aufbewahrungsrichtlinie sie und ihre Nachrichten endgültig.
       archiveStarted: '{count} Chats werden archiviert'
       deleteStarted: '{count} Chats werden gelöscht'
-      actionFailed: Etwas ist schiefgelaufen. Bitte versuche es erneut.
+      actionFailed: Etwas ist schiefgelaufen. Versuch es nochmal.
   organization:
     title: Organisationsname
     detailsTitle: Organisationsdetails
@@ -5104,16 +5031,10 @@ settings:
     updatePassword: Passwort aktualisieren
     enterNewPassword: Neues Passwort eingeben
     userMustUpdatePassword: Benutzer muss das Passwort bei der Anmeldung ändern
-    adminWarning: 'Warnung: Deine Organisation sollte aus Sicherheitsgründen
-      mindestens 2 Admins haben. Diese Änderung wird blockiert, wenn weniger als
-      2 Admins übrig bleiben.'
-    adminSecurityWarning:
-      'Warnung: Deine Organisation muss aus Sicherheitsgründen
-      mindestens 2 Admins haben. Du kannst den letzten Admin nicht entfernen.'
+    adminWarning: Deine Organisation sollte aus Sicherheitsgründen mindestens 2 Admins haben. Diese Änderung wird blockiert, wenn weniger als 2 Admins übrig bleiben.
+    adminSecurityWarning: Deine Organisation muss aus Sicherheitsgründen mindestens 2 Admins haben. Du kannst den letzten Admin nicht entfernen.
     transferOwnership: Inhaberschaft übertragen
-    transferOwnershipConfirmation:
-      Möchtest du die Inhaberschaft wirklich an {name}
-      übertragen? Du wirst zum Admin herabgestuft.
+    transferOwnershipConfirmation: Inhaberschaft an {name} übertragen? Du wirst zum Admin herabgestuft.
     ownershipTransferred: Inhaberschaft übertragen
     ownershipTransferFailed: Inhaberschaft konnte nicht übertragen werden
   teams:
@@ -5128,14 +5049,11 @@ settings:
       created: Hinzugefügt
     editTeam: Team bearbeiten
     deleteTeam: Team löschen
-    deleteConfirmation: Möchtest du das Team {name} wirklich löschen? Alle
-      Mitglieder werden aus diesem Team entfernt. Diese Aktion kann nicht
-      rückgängig gemacht werden.
+    deleteConfirmation: 'Team „{name}" löschen? Alle Mitglieder werden entfernt. Das lässt sich nicht rückgängig machen.'
     teamDeleted: Team gelöscht
     teamDeleteFailed: Team konnte nicht gelöscht werden
     teamCreated: Team erstellt
-    teamCreatedDescription: Team {name} wurde mit {count} {count, plural, one
-      {Mitglied} other {Mitgliedern}} erstellt.
+    teamCreatedDescription: '{name} mit {count} {count, plural, one {Mitglied} other {Mitgliedern}} erstellt.'
     teamCreateFailed: Team konnte nicht erstellt werden
     teamUpdated: Team aktualisiert
     teamUpdateFailed: Team konnte nicht aktualisiert werden
@@ -5173,9 +5091,7 @@ settings:
       model: Standardmodell
       tools: Tools
     deleteAgent: Agent löschen
-    deleteConfirmation:
-      Möchtest du diesen Agent wirklich löschen? Diese Aktion kann
-      nicht rückgängig gemacht werden.
+    deleteConfirmation: Diesen Agent löschen? Das lässt sich nicht rückgängig machen.
     agentCreated: Agent erstellt
     agentCreateFailed: Agent konnte nicht erstellt werden
     agentAlreadyExists: Ein Agent mit dieser Kennung existiert bereits
@@ -5240,9 +5156,7 @@ settings:
       noSkillsInOrg: In dieser Organisation gibt es noch keine Skills.
     unsavedChanges:
       title: Ungespeicherte Änderungen
-      description:
-        Du hast ungespeicherte Änderungen. Möchtest du wirklich die Seite
-        verlassen? Deine Änderungen gehen verloren.
+      description: Du hast ungespeicherte Änderungen — verlässt du jetzt die Seite, gehen sie verloren.
       leave: Verlassen
       stay: Weiter bearbeiten
     navigation:
@@ -5777,8 +5691,6 @@ settings:
         Storefront-Domain.
       endpointHelpGeneric: Der https-Ursprung der Instanz, zu der dieser Eintrag gehört.
   enterpriseSso:
-    description: Single Sign-On (OIDC, OAuth2, SAML) und SCIM-Bereitstellung von
-      Benutzern und Gruppen.
     connected: Die Anmeldung ist aktiviert.
     copied: In die Zwischenablage kopiert
     copy: Kopieren
@@ -5965,12 +5877,11 @@ settings:
         s5:
           Tragen Sie sie oben mit der Issuer-URL https://accounts.google.com ein – die
           Endpunkte werden automatisch erkannt.
-        groupsNote: 'Hinweis: Das Standard-OIDC von Google liefert keine
-          Gruppenmitgliedschaften – die Gruppen-zu-Team-Synchronisierung
-          benötigt das Admin SDK / die Cloud Identity API mit einem
-          Workspace-Administrator. Andere OIDC-Anbieter (Okta, Auth0,
-          Keycloak) funktionieren genauso: Issuer-URL und Client-Anmeldedaten
-          eintragen.'
+        groupsNote: >-
+          Das Standard-OIDC von Google liefert keine Gruppenmitgliedschaften — die
+          Gruppen-zu-Team-Synchronisierung benötigt das Admin SDK / die Cloud Identity API
+          mit einem Workspace-Administrator. Andere OIDC-Anbieter (Okta, Auth0, Keycloak)
+          funktionieren genauso: Issuer-URL und Client-Anmeldedaten eintragen.
       oauth2:
         intro: Für Anbieter ohne OIDC-Discovery konfigurieren Sie die Endpunkte manuell.
         s1:
@@ -6026,15 +5937,11 @@ settings:
       nothingToRefresh:
         Alle Kataloge werden mit der Plattform ausgeliefert — hier
         gibt es nichts zu aktualisieren.
-      refreshFailed: 'Konnte die Kataloge nicht aktualisieren: {error}'
-      listFailed: 'Konnte die Anbieter nicht laden: {error}'
+      refreshFailed: Konnte die Kataloge nicht aktualisieren.
+      listFailed: Konnte die Anbieter nicht laden.
     harnesses:
-      title: Harnesses
-      description:
-        Wie jedes Harness für diese Organisation läuft — welche direkt
-        bereitgestellten Modelle es bekommt und welche Anbieter-Abos daran
-        gebunden sind. Diese Ansicht zeigt nur das Ergebnis; konfiguriert
-        wird über die Zugangsdaten darüber.
+      title: Agent-Laufzeiten
+      description: Wie jede Agent-Laufzeit für diese Organisation konfiguriert ist — welche Modelle verfügbar sind und welche Anbieter-Abos daran gebunden sind. Konfiguriere dies über die Anbieter-Zugangsdaten oben.
       managed: Verwaltet
       modelPool: '{count, plural, one {# Modell} other {# Modelle}} · Standard: {model}'
       byoOnly: Braucht eigene Anbieter-Zugangsdaten — mit plattformverwalteten
@@ -6045,7 +5952,7 @@ settings:
       degraded: Zuletzt fehlerhaft
       subscriptionVia: Abo · {provider}
       subscriptionInert: Abo · {provider} — nicht nutzbar, dieses Harness läuft nur mit verwalteten Zugangsdaten
-      listFailed: 'Konnte den Harness-Status nicht laden: {error}'
+      listFailed: Konnte den Agenten-Status nicht laden.
     apiFormat:
       openai: OpenAI-kompatible API
       anthropic: Anthropic-Messages-API
@@ -6162,9 +6069,7 @@ settings:
     keyRevokeFailed: API-Schlüssel konnte nicht widerrufen werden
     revokeKey: Schlüssel widerrufen
     revokeKeyTitle: API-Schlüssel widerrufen
-    revokeConfirmation: Möchtest du den API-Schlüssel "{keyName}" wirklich
-      widerrufen? Diese Aktion kann nicht rückgängig gemacht werden. Alle
-      Anwendungen, die diesen Schlüssel verwenden, verlieren sofort den Zugriff.
+    revokeConfirmation: '„{keyName}" widerrufen? Alle Anwendungen, die diesen Schlüssel verwenden, verlieren sofort den Zugriff. Das lässt sich nicht rückgängig machen.'
     keyCopied: API-Schlüssel in Zwischenablage kopiert
     columns:
       name: Name
@@ -7341,12 +7246,12 @@ toast:
   error:
     saveFailed:
       title: Änderungen konnten nicht gespeichert werden
-      description: Etwas ist schiefgelaufen. Bitte versuche es erneut.
+      description: Etwas ist schiefgelaufen. Versuch es nochmal.
     profileUpdateFailed:
       title: Profil konnte nicht aktualisiert werden
     passwordChangeFailed:
       title: Passwort konnte nicht geändert werden
-      description: Bitte überprüfe dein aktuelles Passwort und versuche es erneut.
+      description: Prüf dein aktuelles Passwort und versuch es nochmal.
     organizationUpdateFailed:
       title: Organisation konnte nicht aktualisiert werden
     brandingUpdateFailed:
@@ -7358,10 +7263,10 @@ toast:
     imageTypeInvalid: Ungültiger Bildtyp
     addMemberFailed:
       title: Mitglied konnte nicht hinzugefügt werden
-      description: Etwas ist schiefgelaufen. Bitte versuche es erneut.
+      description: Etwas ist schiefgelaufen. Versuch es nochmal.
     generic:
       title: Etwas ist schiefgelaufen
-      description: Bitte versuche es erneut.
+      description: Versuch es nochmal.
 todoList:
   title: Recherche-Plan
   ariaLabel: Recherche-Plan
@@ -7428,8 +7333,8 @@ twoFactor:
       platform: Dieses Gerät (Face ID, Touch ID, Windows Hello)
       crossPlatform: Security-Key oder Smartphone
     errors:
-      registerFailed: Passkey konnte nicht registriert werden. Bitte versuche es erneut.
-      revokeFailed: Passkey konnte nicht entfernt werden. Bitte versuche es erneut.
+      registerFailed: Passkey konnte nicht registriert werden. Versuch es nochmal.
+      revokeFailed: Passkey konnte nicht entfernt werden. Versuch es nochmal.
   setup:
     title: Zwei-Faktor-Authentifizierung einrichten
     qrInstructions: Scanne den QR-Code mit einer Authenticator-App (Google
@@ -7460,8 +7365,8 @@ twoFactor:
     useAuthenticatorToggle: Stattdessen die Authenticator-App verwenden
     backupCodeLabel: Backup-Code
     submitButton: Prüfen
-    invalid: Ungültiger oder abgelaufener Code. Bitte erneut versuchen.
-    tooManyAttempts: Zu viele Fehlversuche. Bitte später erneut versuchen.
+    invalid: Ungültiger oder abgelaufener Code. Versuch es nochmal.
+    tooManyAttempts: Zu viele Fehlversuche. Versuch es später nochmal.
     success: Angemeldet
     backupCodeSuccess: Backup-Code verwendet. Erwäge, die Backup-Codes in den
       Einstellungen neu zu erzeugen.
@@ -7501,11 +7406,10 @@ twoFactor:
         singleDevice: Gerätegebundener Schlüssel
         multiDevice: Synchronisierter Passkey
   errors:
-    enableFailed: Einrichtung der Zwei-Faktor-Authentifizierung fehlgeschlagen.
-      Bitte erneut versuchen.
+    enableFailed: Zwei-Faktor-Authentifizierung konnte nicht aktiviert werden. Versuch es nochmal.
     disableFailed: Zwei-Faktor-Authentifizierung konnte nicht deaktiviert werden.
     regenerateFailed: Neue Backup-Codes konnten nicht erzeugt werden.
-    invalidCode: Ungültiger oder abgelaufener Code. Bitte erneut versuchen.
+    invalidCode: Ungültiger oder abgelaufener Code. Versuch es nochmal.
 websites:
   title: Websites
   entityLabelOne: Website
@@ -7597,8 +7501,7 @@ websites:
       7d: Alle 7 Tage
       30d: Alle 30 Tage
   delete:
-    confirmation: Möchtest du diese Website wirklich löschen? Diese Aktion kann
-      nicht rückgängig gemacht werden.
+    confirmation: Diese Website löschen? Das lässt sich nicht rückgängig machen.
     title: Website löschen
 projects:
   title: Projekte
@@ -7673,10 +7576,8 @@ projects:
   files:
     title: Dateien
     addButton: Datei hinzufügen
-    emptyTitle: Noch keine Dateien
-    emptyDescription:
-      Lade Referenzmaterial hoch, damit jeder Chat in diesem Projekt
-      darauf zugreifen kann.
+    emptyTitle: Dateien für dieses Projekt hinzufügen
+    emptyDescription: Lade Dokumente, Spezifikationen oder sonstigen Kontext hoch — jeder Chat in diesem Projekt kann darauf zugreifen.
     ragStatusQueued: In Warteschlange
     ragStatusQueuedHint: Wartet darauf, im Chat durchsuchbar zu werden.
     ragStatusRunning: Wird indexiert…
@@ -7729,16 +7630,10 @@ projects:
     agentsHeading: Agenten
     modelsHeading: Modelle
     connectorsHeading: Connectors
-    sectionDescription:
-      Erstelle die Agenten, die in diesem Projekt arbeiten — wähle das Harness,
-      auf dem jeder läuft, rüste ihn mit Skills und Connectors aus und gib ihm
-      feste Anweisungen. Alle hier sehen dieselben Agenten, und Aufgaben lassen
-      sich ihnen zuweisen.
+    sectionDescription: Agenten für dieses Projekt, jeder mit eigenem Modell, eigenen Skills und eigenen Anweisungen.
     newAgent: Neuer Agent
-    emptyTitle: Noch keine Agenten
-    emptyBody:
-      Erstelle den ersten Agenten — einen benannten Mitarbeiter dieses Projekts
-      mit eigener Ausrüstung und eigenen Anweisungen.
+    emptyTitle: Agenten zu diesem Projekt hinzufügen
+    emptyBody: Agenten erledigen Aufgaben in deinem Namen — gib einem ein Modell, Skills und Anweisungen, um loszulegen.
     equippedCount: '{count} ausgerüstet'
     rowEdit: Agent bearbeiten
     rowDelete: Agent löschen
@@ -7746,8 +7641,8 @@ projects:
     dialogEditTitle: Agent bearbeiten
     nameLabel: Name
     namePlaceholder: z. B. PR-Reviewer
-    harnessLabel: Harness
-    harnessPlaceholder: Wähle das Harness, auf dem er läuft
+    harnessLabel: Agent-Laufzeit
+    harnessPlaceholder: Wähle die Agent-Laufzeit, auf der er läuft
     modelLabel: Modell
     modelPlaceholder: Wähle das Modell, das er aufruft
     equipmentLabel: Skills & Connectors
@@ -7860,6 +7755,7 @@ projects:
   dangerZone:
     title: Gefahrenzone
     description: Destruktive Aktionen für dieses Projekt.
+    archiveSectionTitle: Archiv
     archiveHelp: Archivieren blendet das Projekt und seine Chats aus den täglichen Listen aus; du kannst es hier jederzeit wiederherstellen.
     restoreHelp: Wiederherstellen bringt das Projekt und seine Chats zurück in die täglichen Listen.
     deleteHelp: Löschen entfernt das Projekt endgültig, einschließlich seiner Dateien und Einstellungen. Das lässt sich nicht rückgängig machen.
@@ -7987,8 +7883,7 @@ webdav:
     errorLimit:
       Du hast die maximale Anzahl an App-Passwörtern erreicht. Widerrufe
       zuerst ein nicht genutztes.
-    errorRateLimited: Zu viele App-Passwörter in letzter Zeit erstellt. Bitte
-      versuche es später erneut.
+    errorRateLimited: Zu viele App-Passwörter in kurzer Zeit erstellt. Versuch es später nochmal.
     savedTitle: Speichere dieses Passwort — es wird nicht erneut angezeigt.
     copy: Kopieren
     dismiss: Ich habe es gespeichert

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -68,7 +68,7 @@ operator:
     button: Re-run
     started: Re-run started
     alreadyRunning: A run is already in progress.
-    notStarted: Couldn't start the run — check the automation is installed.
+    notStarted: Couldn't start the run. Make sure the automation is deployed and try again.
   stop:
     button: Stop
     stopped: Run stopped
@@ -92,11 +92,10 @@ accessDenied:
   organization: You need Admin permissions to access organization settings.
   agents: You need Admin or Developer permissions to manage agents. Ask an admin if you need an agent installed for chat.
   branding: You need Admin permissions to access branding settings.
-  knowledge: Your account does not have permission to access knowledge.
-  workspaceNotFound: The workspace you're looking for doesn't exist or may have been removed.
-  disabled: Your account has been disabled. Contact support for assistance.
-  noMembership: You are not a member of this workspace. Please contact an
-    administrator for access.
+  knowledge: You don't have permission to access knowledge.
+  workspaceNotFound: That workspace doesn't exist or was removed.
+  disabled: Your account is disabled. Contact support for help.
+  noMembership: You're not a member of this workspace. Contact an administrator for access.
   unauthenticated: Your session expired. Sign in again to continue.
   enterpriseSso: You need Admin permissions to access Enterprise SSO settings.
   dataResidency: You need Admin permissions to access data residency settings.
@@ -104,7 +103,7 @@ accessDenied:
 analytics:
   automations:
     title: Automation metrics
-    description: Usage and performance KPIs across your automations.
+    description: Run counts, success rates, and average duration across your automations.
     cappedNotice: Showing the most recent 5,000 runs in this window. Older
       runs in this period are not included in these totals.
     cards:
@@ -138,8 +137,8 @@ analytics:
       title: No automation runs
       description: No automations have run in the selected period.
   externalTurns:
-    title: Harness turns
-    description: Reliability of harness turns running in the sandbox.
+    title: Agent turns
+    description: Reliability of agent turns running in the sandbox.
     cappedNotice: Showing the most recent 5,000 turns in this window. Older
       turns in this period are not included in these totals.
     cards:
@@ -150,12 +149,12 @@ analytics:
       cancelled: Stopped by user
       recovered: Recovered
     byHarness:
-      title: By harness
-      harness: Harness
+      title: By agent
+      harness: Agent
       turns: Turns
       successRate: Success rate
       timeouts: Timeouts
-      empty: No harness turns have run in the selected period.
+      empty: No agent turns have run in the selected period.
   usage:
     title: Usage metrics
     description: Token consumption, requests, and active users over time.
@@ -177,38 +176,38 @@ analytics:
       tokens: Tokens
       cost: Cost
     cards:
-      totalRequests: Total Requests
-      totalTokens: Total Tokens
-      totalCost: Total Cost
-      activeUsers: Active Users
+      totalRequests: Total requests
+      totalTokens: Total tokens
+      totalCost: Total cost
+      activeUsers: Active users
     chart:
       inputTokens: Input
       outputTokens: Output
     tables:
       topAgents:
-        title: Top Assistants
+        title: Top assistants
         agent: Assistant
         requests: Requests
         tokens: Tokens
         cost: Cost
       topModels:
-        title: Top Models
+        title: Top models
         model: Model
         requests: Requests
         tokens: Tokens
         cost: Cost
       topVoiceModels:
-        title: Top Voice Models
+        title: Top voice models
         model: Model
         requests: Requests
         characters: Characters
         cost: Cost
       users:
-        title: Per-User Usage
+        title: Per-user usage
         user: User
         team: Team
-        inputTokens: Input Tokens
-        outputTokens: Output Tokens
+        inputTokens: Input tokens
+        outputTokens: Output tokens
         requests: Requests
         cost: Cost
     filterChips:
@@ -272,7 +271,7 @@ analytics:
           Per-model breakdown appears here once users rate replies whose
           model is captured.
       topMatchups:
-        title: Top Model Matchups
+        title: Top model matchups
         matchup: Matchup
         vs: vs
         score: Score
@@ -432,8 +431,8 @@ analytics:
 approvalCommon:
   reject: Cancel
   errorNotAuthenticated: User not authenticated
-  errorRejectFailed: Failed to reject
-  errorSubmitFailed: Failed to submit response
+  errorRejectFailed: Couldn't reject
+  errorSubmitFailed: Couldn't submit response
   errorNotFound: This request could no longer be found. It may have already been resolved.
   errorAlreadyResolved: This request has already been resolved.
   copied: Copied!
@@ -462,8 +461,7 @@ auth:
     continueWithPasskey: Sign in with a passkey
     passkeyFailed: Passkey sign-in failed or was cancelled. Try again or use your password.
     wrongCredentials: Wrong email or password
-    accountLockedGeneric: Account temporarily locked due to repeated failures.
-      Please try again later or contact an administrator.
+    accountLockedGeneric: Account temporarily locked — too many failed attempts. Try again later or contact an administrator.
     accountLockedSeconds:
       Account temporarily locked. Try again in {seconds, plural,
       one {# second} other {# seconds}}, or contact an administrator.
@@ -478,7 +476,7 @@ auth:
       title: Contact your administrator
       description: Password reset is managed by your organization.
     toast:
-      success: Signed in successfully
+      success: Signed in
     lockoutAdvisory: Repeated failed attempts will temporarily lock the account.
   signup:
     wrongCredentials: Wrong email or password
@@ -512,7 +510,6 @@ auth:
     logOut: Log out
     logOutConfirm:
       title: Log out
-      description: Are you sure you want to log out?
       confirm: Log out
     toast:
       signOutFailed: Failed to sign out
@@ -539,8 +536,8 @@ auth:
     validation:
       currentRequired: Current password is required
       currentIncorrect: Current password is incorrect
-      confirmRequired: Please confirm your new password
-      mismatch: Passwords do not match
+      confirmRequired: Confirm your new password
+      mismatch: Passwords don't match
     warning:
       title: You'll be signed out everywhere
       description:
@@ -552,9 +549,7 @@ auth:
     description:
       Your password has expired per the organization's rotation policy.
       Set a new password to continue.
-    descriptionAdminSet:
-      Your password was set by an administrator. Please choose a
-      new password to continue.
+    descriptionAdminSet: An administrator set your password. Choose a new password to continue.
     signedInAs: Signed in as {email}
     notYou: Not you?
     logOut: Log out
@@ -567,9 +562,7 @@ auth:
     confirmPassword: Confirm password
   sso:
     errors:
-      serverError:
-        Single sign-on could not complete due to a server error. Please try
-        again, or contact your administrator if it persists.
+      serverError: Single sign-on failed due to a server error. Try again, or contact your administrator if it keeps happening.
       multipleConnections:
         More than one organization uses single sign-on here. Enter
         your organization email address first, then try again.
@@ -578,9 +571,9 @@ auth:
       userNotAssigned:
         Your account is not assigned to this application. Contact your
         administrator to request access.
-      silentAuthFailed: Silent sign-in failed. Please sign in interactively.
-      refreshTokenExpired: Your session has expired. Please sign in again.
-      consentRequired: This application needs admin consent before you can sign in.
+      silentAuthFailed: Silent sign-in failed. Sign in manually instead.
+      refreshTokenExpired: Your session expired. Sign in again.
+      consentRequired: An admin needs to grant consent before you can sign in.
       redirectMismatch:
         The sign-in redirect URL does not match the one registered in
         Microsoft Entra ID. Ask your administrator to register the exact
@@ -608,22 +601,16 @@ automations:
     versionCount: '{count, plural, one {# version} other {# versions}}'
     notDeployed: Not deployed
     projectBound: Project
-    loadFailed: 'Automations could not be loaded: {error}'
+    loadFailed: "Couldn't load automations: {error}"
     empty:
       title: No automations yet
-      description:
-        An automation is a saved document — a graph of nodes. The shipped
-        starter automations appear here automatically, and a developer can
-        author new ones from a goal with "New automation".
+      description: Describe what you want to automate, or upload a workflow file.
   createMenu:
     fromGoal: From a goal
   builder:
     new: New automation
     title: New automation
-    description:
-      Describe what the automation should do. An AI builder authors it against
-      mock connectors and saves the result here as a draft — nothing runs
-      live until a version is deployed.
+    description: Describe your goal.
     goalLabel: Goal
     goalPlaceholder:
       e.g. Every morning, read the newest support emails and write one digest
@@ -632,7 +619,7 @@ automations:
     providerPlaceholder: Select a provider
     modelLabel: Model
     modelPlaceholder: Select a model
-    submit: Start building
+    submit: Generate automation
     submitting: Building…
     running:
       The builder is working — this can take a few minutes. Saved versions
@@ -656,12 +643,10 @@ automations:
     saveMessageDescription: What changed, so the version list stays readable.
     saveDialog:
       title: Save a new version
-      description: Saving appends a new version. The one on screen stays exactly
-        as it is, so a run already in flight is unaffected.
+      description: Saves a new version. Any run already in progress keeps using the deployed version.
     switchVersion:
       title: Show another version?
-      description: The canvas draws one stored version at a time, so switching
-        drops the changes you have not saved yet.
+      description: Switching versions discards any unsaved changes you've made.
       confirm: Discard and switch
     showLastRun: Show last run
     hideLastRun: Hide last run
@@ -670,9 +655,7 @@ automations:
     runLiveNeedsDeploy: Deploy a version first — a live run executes the
       deployed version.
     runLiveTitle: Run live?
-    runLiveBody:
-      A live run performs real connector calls on the organization's behalf
-      — mail is sent, records change. The deployed version runs once, now.
+    runLiveBody: This runs the deployed version for real — emails send, records change. It won't run again automatically.
   trigger:
     title: Trigger
     none: Nothing starts this automation yet.
@@ -692,14 +675,11 @@ automations:
     save: Save trigger
     remove: Remove trigger
     removeTitle: Remove the trigger?
-    removeBody:
-      The automation keeps its versions and history; nothing will start it
-      until a new binding is saved.
+    removeBody: Removes the trigger. The automation and its version history are unaffected.
     tokenTitle: Webhook token — copy it now
     tokenHint: This token is shown once and stored only as a hash.
     tokenPath: 'POST to /api/automations/webhook/{token} starts the automation.'
-    hasToken: A webhook token exists. Rotating replaces it; the old URL stops
-      working.
+    hasToken: A token is active. Rotating it creates a new one — update any webhooks using the old URL.
     noToken: Saving mints a token and shows it once.
     rotate: Rotate token
   canvas:
@@ -730,9 +710,7 @@ automations:
     title: Node
     noSelection: Select a node on the canvas to see and edit what it does.
     unknownType: 'Unknown node type: {type}'
-    catalogUnavailable:
-      The node-type catalog could not be loaded, so only the built-in
-      types are described. The node's own fields are still shown.
+    catalogUnavailable: Couldn't load the node-type catalog — only built-in types are described. The node's fields are still shown.
     invalidJson: This is not valid JSON yet, so the node was not changed.
     controlFlowTitle: Control flow
     runTitle: In this run
@@ -766,10 +744,7 @@ automations:
     title: Projects
     orgBadge: Organization-wide
     countBadge: '{count, plural, one {Bound to # project} other {Bound to # projects}}'
-    hint: The projects whose task boards see this automation. With none
-      selected it serves the whole organization; with a selection it appears
-      in exactly those projects. A project cannot be deleted while an
-      automation is still bound to it.
+    hint: Choose which projects can use this automation. Leave empty to share it org-wide.
     placeholder: Organization-wide — no projects selected
     searchPlaceholder: Search projects
     empty: No projects match
@@ -778,7 +753,7 @@ automations:
     nothingToSave: No changes to save
   versions:
     title: Versions
-    empty: No version has been saved yet.
+    empty: No versions saved yet.
     versionLabel: v{version}
     deployed: Live
     deploy: Deploy
@@ -788,10 +763,10 @@ automations:
     noMessage: No message
   upload:
     trigger: Upload package
-    title: Upload an automation package
-    description: A pack's workflow.yml (required) and automation.yml (optional — its subjects block becomes the task contract), or the whole pack directory as one .zip, which may also carry skill bundles under skills/. The document is validated before anything is stored, and the uploaded version stays a draft until you deploy it.
+    title: Upload package
+    description: Upload a workflow file or pack zip to add it to your automations.
     filesLabel: Package files
-    filesHelp: Pick workflow.yml (plus automation.yml), or one .zip of the pack directory — skills/ included.
+    filesHelp: workflow.yml (+ automation.yml), or a pack .zip.
     uploading: Uploading the package…
     zipOnly: Upload the zip on its own — it already carries the whole pack.
     zipTooLarge: The zip is over the 20 MiB package cap.
@@ -803,8 +778,8 @@ automations:
     removeFile: 'Remove {name}'
     targetLabel: Install into
     targetOrg: Organization
-    targetHelp: Installing into a project binds the automation to it — add or remove projects any time in the Projects panel on the automation's page. Organization installs it org-wide, visible to every project's task board.
-    submit: Upload
+    targetHelp: Project binds it to that board; Organization shares it org-wide.
+    submit: Upload package
     submitting: Validating and saving…
     uploaded: 'Uploaded {name} v{version} — deploy it when ready.'
     warnings: '{count, plural, one {# validation warning} other {# validation warnings}} — open the automation to review.'
@@ -817,8 +792,8 @@ automations:
       title: 'Waiting for your approval: {operation}'
       node: 'Requested by node "{node}" — approving lets it act on the next poll; rejecting fails it.'
       pending: Approving lets the parked step act on the next poll; rejecting fails it.
-      approved: '{operation} was approved — the run resumes on its next poll.'
-      rejected: '{operation} was rejected — the step fails and the run stops.'
+      approved: '{operation} approved — the run resumes on its next poll.'
+      rejected: '{operation} rejected — the step fails and the run stops.'
       input: The step would call with
       approve: Approve
       reject: Reject
@@ -875,14 +850,14 @@ automations:
       actions: '{count, plural, one {# action} other {# actions}}'
   settings:
     loading: Loading settings…
-    loadFailed: The settings could not be loaded — close the dialog and try again.
+    loadFailed: Couldn't load settings — close the dialog and try again.
     save: Save
     saveAndContinue: Save and continue
     dialogTitle: '{name} — settings'
     tabsLabel: Settings sections
     unsavedTab: Unsaved changes
     saved: Settings saved.
-    saveFailed: The settings could not be saved — try again.
+    saveFailed: Couldn't save settings — try again.
     errors:
       required: This field is required.
       number: Enter a number.
@@ -931,10 +906,10 @@ chat:
   archive: Archive
   unarchive: Unarchive
   archiveSuccess: Chat archived
-  archiveFailed: Failed to archive chat
+  archiveFailed: Couldn't archive chat
   unarchiveSuccess: Chat unarchived
-  unarchiveFailed: Failed to unarchive chat
-  archivedBanner: This conversation was archived
+  unarchiveFailed: Couldn't unarchive chat
+  archivedBanner: Archived
   archived:
     title: Archived
     empty: No archived chats
@@ -957,7 +932,7 @@ chat:
   removeFromProject: Remove from project
   removeFromProjectFailed: Failed to remove chat from project
   deleteChat: Delete chat
-  deleteConfirmation: Are you sure you want to delete {title}?
+  deleteConfirmation: Delete "{title}"?
   deletePermanentMessage: Move chat to Trash. You can restore it for the org's grace period; after that retention permanently deletes the chat and its messages.
   deleteFailed: Failed to delete chat
   editMessage: Edit message
@@ -965,7 +940,7 @@ chat:
   tryAgain: Try again
   regenerateFailed: Couldn't regenerate response
   forkChat: Fork chat
-  forkSuccess: Chat forked successfully
+  forkSuccess: Chat forked
   forkFailed: Failed to fork chat
   forkOf: Fork of {title}
   branchNavigator:
@@ -1061,8 +1036,8 @@ chat:
   newProject: New project
   notFound: This chat is not available.
   placeholder: Ask about your documents or the web…
-  generationIncomplete: The response couldn't be completed. Please try again.
-  generationIncompleteWithTools: The response couldn't be completed after running {tools}. Please try again.
+  generationIncomplete: The response couldn't be completed. Try again.
+  generationIncompleteWithTools: The response couldn't be completed after running {tools}. Try again.
   stepLimitReached: Stopped here — this turn reached its step limit. Send a message to continue.
   send: Send message
   stopGenerating: Stop generating
@@ -1075,7 +1050,7 @@ chat:
   fileTypeNotAllowed: '{names}: file type not allowed by upload policy.'
   fileTypeUnsupported: '{names}: file type not supported.'
   fileUploaded: File uploaded
-  uploadedSuccessfully: '{filename} uploaded successfully'
+  uploadedSuccessfully: '{filename} uploaded'
   uploadFailed: Upload failed
   failedToUpload: Failed to upload {filename}
   tooManyFiles: Too many files
@@ -1106,7 +1081,7 @@ chat:
     inProgressTooltip: Transcribing audio…
     transcribing: Transcribing…
     transcribed: Transcribed
-    couldNotTranscribe: Could not be transcribed
+    couldNotTranscribe: Couldn't transcribe
     viewTranscript: View transcript
     previewSubtitle: '{seconds}s transcribed'
     retry: Try again
@@ -1159,7 +1134,7 @@ chat:
     noMetadata: Token usage and model information are not available for this message.
   history:
     empty: No conversations yet
-    emptySubtitle: Start a new chat to begin
+    emptySubtitle: Start a new chat
     untitled: Untitled chat
     noProjects: No projects yet — create one in the panel above.
     legalHold:
@@ -1194,9 +1169,7 @@ chat:
     transcriptionFailedShort: Transcription failed
     retry: Try again
     discard: Discard recording
-    permissionDenied:
-      Microphone access was denied. Please allow microphone access
-      in your browser settings.
+    permissionDenied: Microphone access denied. Allow it in your browser settings.
   citations:
     source: Source {number}
     page: Page {page}
@@ -1320,7 +1293,7 @@ chat:
     approvalRejected: Rejected
     humanInputPending: Your answer is needed
     humanInputAnswered: Answered
-  errorGeneratingDescription: There was an error generating a response. Please try again.
+  errorGeneratingDescription: Couldn't generate a response. Try again.
   errorHintAuthError: The API key is invalid or does not have access to this
     model. Contact your administrator.
   errorHintContentFilter: The message was flagged by the content filter. Try rephrasing your message.
@@ -1338,9 +1311,8 @@ chat:
     prompt (or exceed what the model supports). Try again — Tale clears a bad
     cached cap automatically — or ask an administrator to lower Max output
     tokens.
-  errorHintProviderError: The AI provider is temporarily experiencing issues.
-    Please try again in a moment.
-  errorHintRateLimited: Too many requests. Please wait a moment and try again.
+  errorHintProviderError: The AI provider is temporarily experiencing issues. Try again in a moment.
+  errorHintRateLimited: Too many requests. Wait a moment and try again.
   errorHintTokenLimit:
     The model's output token limit was exceeded. Try a shorter
     request or ask your administrator to adjust the model settings.
@@ -1361,7 +1333,7 @@ chat:
   errorHintModelNotFoundNamed:
     The selected model was not found on {provider}. It
     may have been renamed or removed.
-  errorHintRateLimitedNamed: Rate limit reached on {provider}. Please wait a moment and try again.
+  errorHintRateLimitedNamed: Rate limit reached on {provider}. Wait a moment and try again.
 
   errorGenerating: Something went wrong
   errorTriedModels: 'Tried {count} models before giving up.'
@@ -1400,8 +1372,8 @@ chat:
     showAll: Show all {count} sources
     hide: Hide sources
 
-  budgetExceededDetail: '{type} limit reached for this {period} period ({used} / {limit}). Please contact your administrator.'
-  budgetExceededDefault: Your usage limit has been reached for this period. Please contact your administrator.
+  budgetExceededDetail: '{type} limit reached for this {period} ({used} / {limit}). Contact your administrator.'
+  budgetExceededDefault: Usage limit reached for this period. Contact your administrator.
   budgetRemaining: '{remaining} of {limit} {type} left this {period}'
   budgetLimitReached: 'Usage limit reached · resets {period}'
   budgetRequestCredits: Request usage credits
@@ -1471,6 +1443,7 @@ common:
     openMenu: Open menu
     deleteSelected: Delete selected
     export: Export
+    tryAgain: Try again
   unsavedChanges:
     title: Unsaved changes
     description: You have unsaved changes. Leaving now will discard them.
@@ -1487,14 +1460,12 @@ common:
   bulkActions:
     itemsSelected: '{count, plural, one {# item selected} other {# items selected}}'
     confirmDeleteTitle: Delete {count, plural, one {# item} other {# items}}
-    confirmDeleteDescription:
-      Are you sure you want to delete {count, plural, one
-      {this item} other {these {count} items}}? This action cannot be undone.
-    deleteSuccess: Successfully deleted {count, plural, one {# item} other {# items}}
+    confirmDeleteDescription: Delete {count, plural, one {this item} other {these {count} items}}? This can't be undone.
+    deleteSuccess: Deleted {count, plural, one {# item} other {# items}}
     deleteFailed: Failed to delete some items
     deleting: Deleting...
   upload:
-    clickToUpload: Click to upload
+    clickToUpload: Upload
     dropFilesHere: Drop files here to upload
     supportedFormats: .xlsx, .xls or .csv
     pickADate: Pick a date
@@ -1535,12 +1506,12 @@ common:
   validation:
     required: '{field} is required'
     maxLength: '{field} must be {max} characters or fewer'
-    email: Please enter a valid email address
+    email: Enter a valid email address
     invalidJson: Invalid JSON format
-    uploadFile: Please upload a file
+    uploadFile: Upload a file
     unsupportedFileType: Unsupported file type
     schemaValidationFailed: 'Schema validation failed{error, select, empty {} other {: {error}}}'
-    url: Please enter a valid URL
+    url: Enter a valid URL
   aria:
     close: Close
     resizePanel: Resize panel
@@ -1602,13 +1573,11 @@ common:
       '{tokens} did not match anyone in your organization — no
       notification was sent.'
   errors:
-    generic: Something went wrong. Please try again.
+    generic: Something went wrong — try again, or reload the page if it keeps happening.
     failedToCopy: Failed to copy to clipboard
     somethingWentWrong: Something went wrong
-    errorLoadingPage:
-      An error occurred while loading this page. You can try again
-      or navigate to another section.
-    persistsProblem: If this problem persists, please
+    errorLoadingPage: Something went wrong while loading this page. Try again or go to another section.
+    persistsProblem: If this keeps happening,
     contactSupport: contact support
     tryAgain: Try again
     showDetails: Show details
@@ -1724,7 +1693,7 @@ conversations:
     discard: Discard
     discardConfirm:
       title: Discard draft?
-      description: This draft email will be permanently discarded. This can't be undone.
+      description: This draft will be permanently discarded.
     sent: Email sent
     uploadFailed: Failed to upload attachment
   updating: Updating conversations...
@@ -1733,33 +1702,26 @@ conversations:
     close: Close
     reopen: Reopen
     messagesSent: Messages sent
-    messagesSentDescription:
-      Successfully sent {successCount} messages{failedCount,
-      plural, =0 {} other {, {failedCount} failed}}
+    messagesSentDescription: Sent {successCount} messages{failedCount, plural, =0 {} other {, {failedCount} failed}}
     sendFailed: Failed to send messages
     resolved: Conversations resolved
-    resolvedDescription: Successfully resolved {successCount}
-      conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
+    resolvedDescription: Resolved {successCount} conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
     resolveFailed: Failed to resolve conversations
     reopened: Conversations reopened
-    reopenedDescription: Successfully reopened {successCount}
-      conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
+    reopenedDescription: Reopened {successCount} conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
     reopenFailed: Failed to reopen conversations
     selectedCount: '{count, plural, one {# selected} other {# selected}}'
     archive: Archive
     unarchive: Unarchive
     archived: Conversations archived
-    archivedDescription: Successfully archived {successCount}
-      conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
+    archivedDescription: Archived {successCount} conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
     archiveFailed: Failed to archive conversations
     unarchived: Conversations unarchived
-    unarchivedDescription: Successfully unarchived {successCount}
-      conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
+    unarchivedDescription: Unarchived {successCount} conversations{failedCount, plural, =0 {} other {, {failedCount} failed}}
     unarchiveFailed: Failed to unarchive conversations
     markSpam: Mark as spam
     markedAsSpam: Conversations marked as spam
-    markedAsSpamDescription: Successfully marked {successCount} conversations as
-      spam{failedCount, plural, =0 {} other {, {failedCount} failed}}
+    markedAsSpamDescription: Marked {successCount} conversations as spam{failedCount, plural, =0 {} other {, {failedCount} failed}}
     spamFailed: Failed to mark conversations as spam
   header:
     moreActions: More actions
@@ -1778,12 +1740,12 @@ conversations:
     assignError: Couldn't update the assignee
     inboxSource: 'Inbox: {inbox}'
     toast:
-      closed: Conversation has been closed successfully.
-      closeFailed: An unexpected error occurred while closing the conversation.
-      reopened: Conversation has been reopened successfully.
-      reopenFailed: An unexpected error occurred while reopening the conversation.
-      markedAsSpam: Conversation has been marked as spam successfully.
-      markAsSpamFailed: An unexpected error occurred while marking the conversation as spam.
+      closed: Conversation closed
+      closeFailed: Couldn't close the conversation — try again.
+      reopened: Conversation reopened
+      reopenFailed: Couldn't reopen the conversation — try again.
+      markedAsSpam: Conversation marked as spam
+      markAsSpamFailed: Couldn't mark conversation as spam — try again.
     assignedTeam: Team
     assignedToTeam: Queued to {name}
     unassignTeam: Remove team
@@ -1794,8 +1756,8 @@ conversations:
     autoAssignSettings: Auto assign
   editor:
     noContent: No content to improve
-    improveFailed: Failed to improve content. Please try again.
-    sendFailed: Failed to send message. Please try again.
+    improveFailed: Couldn't improve content. Try again.
+    sendFailed: Couldn't send message. Try again.
     backToEditor: Back to editor
     improving: Improving...
     improveWithAi: Improve with AI
@@ -1808,8 +1770,8 @@ conversations:
     downloading: Downloading...
     attachments: '{count, plural, one {# attachment} other {# attachments}}'
   panel:
-    uploadFailed: Failed to upload attachments. Please try again.
-    downloadFailed: Failed to download attachments. Please try again.
+    uploadFailed: Couldn't upload attachments. Try again.
+    downloadFailed: Couldn't download attachments. Try again.
     noSelected: No conversation selected
     selectToView: Select a conversation to view details
     notFound: Conversation not found
@@ -1821,15 +1783,15 @@ conversations:
     loadFailed: Failed to load conversation
     loadFailedDescription: Something went wrong while loading this conversation.
     tryAgain: Try again
-    closedBanner: This conversation was closed on {date}
-    closedBannerNoDate: This conversation was closed
-    archivedBanner: This conversation was archived
-    spamBanner: This conversation was marked as spam
+    closedBanner: Closed on {date}
+    closedBannerNoDate: Closed
+    archivedBanner: Archived
+    spamBanner: Marked as spam
     unarchive: Unarchive
     notSpam: Not spam
     delete: Delete
     deleting: Deleting...
-    deleteSuccess: Conversation deleted successfully.
+    deleteSuccess: Conversation deleted
     deleteFailed: Failed to delete conversation.
     showEarlierMessages: Show {count} earlier {count, plural, one {message} other {messages}}
     undoSendFailed: Couldn't undo the send — the message may already be on its way.
@@ -1891,11 +1853,11 @@ contacts:
     manualEntry: Manual entry
   create:
     title: Add contact
-    success: Contact created successfully
+    success: Contact created
     error: Failed to create contact
     duplicateEmail: A contact with this email already exists
   thisContact: this contact
-  updateSuccess: Contact updated successfully
+  updateSuccess: Contact updated
   updateError: Failed to update contact
   name: Name
   namePlaceholder: Enter contact name
@@ -1905,12 +1867,10 @@ contacts:
   localePlaceholder: e.g., en-US
   phone: Phone
   import:
-    provideData: Please provide data
+    provideData: No data provided
     noValidData: No valid contact data found
-    success: Import successful
-    successDescription:
-      Successfully imported {success} contacts{failed, select, 0
-      {} other {, {failed} failed}}
+    success: Imported
+    successDescription: Imported {success} contacts{failed, select, 0 {} other {, {failed} failed}}
     noneImported: No contacts were imported
     error: Import error
     uploadContacts: Upload contacts
@@ -1918,10 +1878,10 @@ contacts:
     errorCodes:
       duplicate_email: A contact with this email already exists
       duplicate_external_id: A contact with this external ID already exists
-      unknown: An unexpected error occurred
-  deleteConfirmation: Are you sure you want to delete {name}?
+      unknown: Something went wrong
+  deleteConfirmation: Delete {name}?
   deleteError: Failed to delete contact
-  deleteWarning: This action cannot be undone.
+  deleteWarning: This can't be undone.
 dataNotice:
   default: AI can make mistakes—verify responses and do not share sensitive data.
   footer:
@@ -1933,8 +1893,8 @@ dialogs:
       This person already has an account, so no password is needed —
       they sign in with their existing credentials.
   memberAdded:
-    title: Member added successfully
-    credentialsWarning: "Important: Save these credentials now. They won't be shown again."
+    title: Member added
+    credentialsWarning: Save these credentials now — they won't be shown again.
     existingUserNotice:
       This user already had an account, so no new credentials were
       created. They can log in with their existing password.
@@ -1945,9 +1905,7 @@ dialogs:
     noResults: No results
     untitledChat: Untitled chat
   thisMember: this member
-  confirmRemoveMember:
-    Are you sure you want to remove {name} from the team? They
-    will lose access to this organization and all associated resources.
+  confirmRemoveMember: Remove {name} from the team? They'll lose access to this organization and all associated resources.
   toSend: to send
   contactInfo:
     title: Contact details
@@ -1962,12 +1920,12 @@ documentWriteApproval:
   rejectTooltip: Reject this document save
   rejectTooltipBatch: Reject all document saves
   savedSuccessfully: Saved to your documents
-  savedPartially: '{success} of {total} files saved successfully'
+  savedPartially: '{success} of {total} files saved'
   statusExecuting: Saving documents...
-  statusCompletedFailed: This document was approved but failed to save.
-  statusCompletedSuccess: This document was saved to your documents.
+  statusCompletedFailed: Approved but failed to save.
+  statusCompletedSuccess: Saved to your documents.
   statusCompletedPartial: Some documents failed to save.
-  statusRejected: This document save was rejected.
+  statusRejected: Save rejected.
   allFilesFailed: All {count} files failed to save
   errorSaveFailed: Failed to save document
 jobCard:
@@ -2009,13 +1967,13 @@ documents:
   searchPlaceholder: Search documents
   deleteFolder:
     title: Delete folder
-    confirmation: Are you sure you want to delete the folder {name}?
+    confirmation: Delete folder "{name}"?
     requirement: All files and subfolders inside this folder will also be
       permanently deleted.
     deleteButton: Delete folder
   deleteSyncFolder:
     title: Delete sync folder
-    confirmation: Are you sure you want to delete the sync folder {name}?
+    confirmation: Delete sync folder "{name}"?
     thisWillDelete: 'This will permanently delete:'
     willDelete:
       filesAndSubfolders: All files and subfolders
@@ -2037,7 +1995,7 @@ documents:
   actions:
     deleteSyncFolder: Delete sync folder
     deleteFolderFailed: Failed to delete folder
-    deleteFileFailed: An unexpected error occurred while deleting the file.
+    deleteFileFailed: Couldn't delete the file — try again.
     manageTeams: Assign team
     reindex: Reindex
     stopSync: Stop syncing
@@ -2064,7 +2022,7 @@ documents:
     orgWide: Organization-wide
   deleteFile:
     title: Delete document
-    confirmation: Are you sure you want to delete {name}? This action cannot be undone.
+    confirmation: Delete "{name}"? This can't be undone.
     thisDocument: this document
     deleteButton: Delete
   breadcrumb:
@@ -2094,7 +2052,7 @@ documents:
     downloadComplete: Download complete
     downloadFile: Download file
     closePreview: Close preview
-    downloadedSuccessfully: '{filename} has been downloaded'
+    downloadedSuccessfully: '{filename} downloaded'
     downloadFailed: Failed to download the file
     notAvailable: Preview not available
     notAvailableDescription:
@@ -2132,13 +2090,13 @@ documents:
     confirming: Confirming upload…
     confirmingFileNamed: Confirming upload of {fileName}
     failedFileName: '{fileName} — Failed'
-    pleaseWaitForUpload: Please wait for the current upload to complete
+    pleaseWaitForUpload: Wait for the current upload to finish
     noFilesSelected: No files selected
     fileTooLarge: File too large
     fileSizeExceeded: 'File {name} exceeds {maxSize}MB limit. Current size: {currentSize}MB'
     uploadCancelled: Upload cancelled
     uploadFailed: Upload failed
-    uploadFailedRetry: Upload failed. Please check your connection and try again.
+    uploadFailedRetry: Upload failed. Check your connection and try again.
     quotaExceeded:
       Storage quota full — {used} of {limit} used. Delete files to free
       space (failed uploads still count).
@@ -2204,8 +2162,8 @@ documents:
     syncingItems: Syncing {count} items to storage...
     importCompleted: Import completed
     syncCompleted: Sync completed
-    filesImportedCount: '{count} of {total} files imported successfully'
-    filesSyncedCount: '{count} of {total} files synced successfully'
+    filesImportedCount: '{count} of {total} files imported'
+    filesSyncedCount: '{count} of {total} files synced'
     importFailed: Import failed
     syncFailed: Sync failed
     importItems: Import {count} {count, plural, one {item} other {items}}
@@ -2226,20 +2184,18 @@ documents:
     toast:
       documentIdRequired: Document ID is required for retry
       indexingStarted: Indexing started
-      indexingQueued: Document indexing has been queued.
+      indexingQueued: Indexing queued
       retryFailed: Retry failed
       retryFailedDescription: Failed to retry RAG indexing
-      unexpectedError: An unexpected error occurred
+      unexpectedError: Something went wrong
     dialog:
       indexed:
         title: Document indexed
-        description:
-          This document has been successfully indexed and is available for
-          RAG search.
+        description: This document is indexed and available for knowledge search.
         indexedOn: 'Indexed on:'
       failed:
         title: Indexing failed
-        description: The document could not be indexed for RAG search.
+        description: Couldn't index this document for knowledge search.
         errorDetails: 'Error details:'
         unknownError: Unknown error occurred
         embeddingNotConfigured:
@@ -2355,10 +2311,8 @@ onboarding:
     goToDashboard: Go to dashboard
 emptyStates:
   providers:
-    title: No provider credentials yet
-    description:
-      Add the API key or environment credential an AI provider authenticates
-      with, and its models become available to chats and agents.
+    title: Connect your first AI provider
+    description: Add an API key and your team can start chatting with any of its models.
   connectors:
     title: No connectors connected yet
     description:
@@ -2390,10 +2344,10 @@ emptyStates:
       organization.
   apiKeys:
     title: No API keys yet
-    description: Create an API key to enable external connectors via REST API
+    description: Generate a key to let external tools and scripts connect to this workspace.
 governance:
   title: Governance
-  toastSavedTitle: Changes saved successfully
+  toastSavedTitle: Changes saved
   toastSaveFailedTitle: Failed to save changes
   systemPrompt:
     title: Custom instructions
@@ -2454,7 +2408,7 @@ governance:
     searchApiKeys: Search API keys
     noApiKeysFound: No API keys found
     selectApiKeyAriaLabel: Select API key
-    saved: Budget rules have been updated
+    saved: Budget rules updated
     saveFailed: Failed to save budget rules
     targetRequired: Select a target for this scope, or the rule will never apply.
     limitRequired: Set at least one limit (tokens, cost, or requests) so the rule can enforce.
@@ -2465,7 +2419,7 @@ governance:
   defaultModels:
     title: Default models
     description: Set default models for specific user groups or roles.
-    saved: Default model configuration has been updated
+    saved: Default model configuration updated
     saveFailed: Failed to save default model configuration
     addRule: Add rule
     addRuleTitle: Add default model rule
@@ -2526,7 +2480,7 @@ governance:
   retentionPolicy:
     title: Retention policy
     description: Configure how long each data type is kept before deletion.
-    saved: Retention policy has been updated
+    saved: Retention policy updated
     saveFailed: Failed to save retention policy
     save: Save changes
     reset: Reset to defaults
@@ -2673,27 +2627,17 @@ governance:
       helper: Automation runs older than this will be deleted (1–365 days).
     auditLogs:
       title: Audit logs
-      description:
-        'Automatically delete audit log entries older than the retention
-        period. Note: audit logs are immutable historical records used for
-        compliance; keep retention long enough to satisfy your audit/compliance
-        requirements.'
+      description: Automatically delete audit log entries older than the retention period. Audit logs are immutable records — keep retention long enough to satisfy your compliance requirements.
       placeholder: e.g. 90
       helper: Audit log entries older than this will be deleted (30–365 days).
     usageLedger:
       title: Usage ledger
-      description: 'Automatically delete token-usage ledger rows older than the
-        retention period. Warning: shortening this retention truncates
-        historical analytics (budgets/reports rely on ledger rows).'
+      description: Automatically delete token-usage records older than the retention period. Shortening this truncates historical analytics — budgets and reports depend on these records.
       placeholder: e.g. 365
       helper: Usage ledger rows older than this will be deleted (30–3650 days).
     loginAttempts:
       title: Login attempts
-      description:
-        'Automatically delete failed-login tracking records (loginAttempts,
-        per-hour block counters) older than the retention period. Note: these
-        tables are deployment-wide — the strictest (shortest) value across all
-        orgs is used.'
+      description: Automatically delete failed-login tracking records older than the retention period. These are deployment-wide — the shortest retention across all orgs applies.
       placeholder: e.g. 90
       helper: Login attempt records older than this will be deleted (7–365 days).
   passwordPolicy:
@@ -2739,7 +2683,7 @@ governance:
       two-factor enrollment (SSO users stay exempt while the exemption is
       on). Members past the grace period are signed out until they enroll.
     confirmEnforceCta: Require two-factor
-    saved: Two-factor policy has been updated
+    saved: Two-factor policy updated
     saveFailed: Failed to save two-factor policy
   loginPolicy:
     title: Login attempt limits
@@ -2814,7 +2758,7 @@ governance:
     removeRuleConfirmAction: Delete
     noRulesTitle: No feature control rules configured
     noRulesDescription: Add a rule to manage features per user, team, or role.
-    saved: Feature controls have been updated
+    saved: Feature controls updated
     saveFailed: Failed to save feature controls
     actions: Actions
     role: Role
@@ -2861,7 +2805,7 @@ governance:
     title: PII protection
     description: Detect and mask or block personal data before sending to AI models.
     enableLabel: Enable PII protection
-    saved: PII configuration has been updated
+    saved: PII configuration updated
     saveFailed: Failed to save PII configuration
   guardrailsOverview:
     title: Guardrails overview
@@ -3332,9 +3276,7 @@ governance:
     sections:
       activeHolds:
         title: Active holds
-        description:
-          Entities currently protected from cleanup and deletion. Place holds
-          at the user (custodian) or organization level.
+        description: Items currently protected from cleanup and deletion. Place holds at the user (custodian) or organization level.
         empty:
           title: No active legal holds
           description:
@@ -3487,10 +3429,10 @@ governance:
     errors:
       generic:
         title: Something went wrong
-        description: Please try again. If the problem persists, contact your administrator.
+        description: Try again. If it keeps happening, contact your administrator.
       unauthenticated: Sign in required.
       forbidden: You don't have permission to do this.
-      validation: Please check the form fields.
+      validation: Check the form fields.
       notFound: Not found.
       alreadyActive: An active legal hold already exists on this target.
       matterNotFound: That matter does not exist in this organization.
@@ -3538,7 +3480,7 @@ governance:
     noUsersFound: No users found
     noTeamsFound: No teams found
     confirm: Confirm
-    saved: Model access policy has been updated
+    saved: Model access policy updated
     saveFailed: Failed to save model access policy
     removeDefaultConfirmTitle: Remove permission for active default model?
     removeDefaultConfirmBody:
@@ -3741,10 +3683,10 @@ governance:
     errors:
       generic:
         title: Something went wrong
-        description: Please try again. If the problem persists, contact your administrator.
+        description: Try again. If it keeps happening, contact your administrator.
       unauthenticated: Sign in required.
       forbidden: You don't have permission to do this.
-      validation: Please check the form fields.
+      validation: Check the form fields.
       notFound: Not found.
       alreadyPending: An erasure request for this subject is already pending or running.
       legalHoldBlocked: An active legal hold is preserving this subject's data.
@@ -3791,7 +3733,7 @@ governance:
         day. Caps blast radius from a compromised admin credential. Range:
         1–50.'
     saved: Data subject request governance updated.
-    saveFailed: Could not save the governance policy. Please try again.
+    saveFailed: Couldn't save the policy. Try again.
     invalidCoolingOffHours: Cooling-off window must be a whole number between 0 and 72.
     invalidDailyLimit: Daily limit must be a whole number between 1 and 50.
     ownerOnlyNotice:
@@ -3873,15 +3815,15 @@ metrics:
     emptyDescription: Choose a project to view its metrics.
 humanInputRequest:
   questionTitle: Question
-  submit: Submit response
+  submit: Send answer
   statusResponded: Responded
   statusProcessing: Processing
   respondedByAt: Responded by {name} at {date}
   stopWorkflow: Stop
   stopWorkflowTooltip: Stop the running automation
-  errorFillRequiredFields: Please fill in all required fields
-  errorSelectRequired: Please make a selection
-  errorFeedbackRequired: Please enter your feedback
+  errorFillRequiredFields: Fill in all required fields
+  errorSelectRequired: Make a selection
+  errorFeedbackRequired: Enter your feedback
   errorAlreadyResponded: This request has already been answered.
   errorNotEditable: Only a completed response can be edited.
   errorWorkflowNotEditable: Automation responses can't be edited.
@@ -3896,8 +3838,8 @@ humanInputRequest:
   cancelEdit: Cancel
   versionPrevious: Previous response version
   versionNext: Next response version
-  errorTodoListRequired: Please add at least one item
-  errorTodoListMinItems: Please add at least {count} items
+  errorTodoListRequired: Add at least one item
+  errorTodoListMinItems: Add at least {count} items
   todoItemPlaceholder: Sub-question {n}
   todoItemAriaLabel: '{label} item {n}'
   todoRemoveItem: Remove item {n}
@@ -3905,13 +3847,13 @@ humanInputRequest:
 connectorApproval:
   approve: Approve
   reject: Reject
-  executedSuccessfully: Executed successfully
+  executedSuccessfully: Executed
   approveTooltip: Approve and execute this operation
   rejectTooltip: Reject this operation
   statusExecuting: Executing operation...
-  statusCompletedFailed: This operation was approved but failed during execution.
-  statusCompletedSuccess: This operation was approved and executed successfully.
-  statusRejected: This operation was rejected.
+  statusCompletedFailed: Approved but failed during execution.
+  statusCompletedSuccess: Approved and executed.
+  statusRejected: Rejected.
   errorApproveFailed: Failed to approve operation
   moreParameters: +{count} more
   showLess: Show less
@@ -3963,10 +3905,7 @@ knowledgeEntries:
     deleteError: Failed to delete knowledge entry
   delete:
     title: Delete knowledge entry
-    confirmation:
-      Are you sure you want to delete this knowledge entry? It will also
-      be removed from the knowledge base, so agents can no longer find it. This
-      action cannot be undone.
+    confirmation: Delete this entry? Agents will no longer be able to find it in the knowledge base.
   viewDialog:
     title: Knowledge entry details
     indexingStatus: Indexing status
@@ -3989,9 +3928,9 @@ knowledgeWriteApproval:
   approveTooltipReplace: Approve and replace the existing knowledge entry
   rejectTooltip: Reject this knowledge entry
   statusExecuting: Saving knowledge entry...
-  statusCompletedFailed: This knowledge entry was approved but failed to save.
-  statusCompletedSuccess: This knowledge entry was saved to the knowledge base.
-  statusRejected: This knowledge entry was rejected.
+  statusCompletedFailed: Approved but failed to save.
+  statusCompletedSuccess: Saved to the knowledge base.
+  statusRejected: Rejected.
   errorSaveFailed: Failed to save knowledge entry
 locationRequest:
   title: Location request
@@ -4003,7 +3942,7 @@ locationRequest:
   statusDenied: Denied
   sharedBy: Shared by {name} at {date}
   errorNotSupported: Geolocation is not supported by your browser.
-  errorAcquireFailed: Failed to acquire location. Please try again.
+  errorAcquireFailed: Couldn't get your location. Try again.
   defaultReason: The assistant needs your location to help with your request.
 metadata:
   suffix: Tale
@@ -4159,7 +4098,7 @@ metadata:
     description: Manage governance policies and system prompts.
   metrics:
     title: Metrics
-    description: Organization-wide KPIs for usage, feedback, automations, and projects.
+    description: Organization-wide metrics for usage, feedback, automations, and projects.
   shared-chat:
     title: Shared chat
     description: View a shared chat conversation.
@@ -4360,7 +4299,7 @@ personalization:
       title: Pending suggestions
       empty: No suggestions waiting.
   errors:
-    saveFailed: Couldn't save. Please try again.
+    saveFailed: Couldn't save. Try again.
     tooLong: Custom instructions exceed {max} characters.
   toasts:
     preferencesUpdated: Preferences updated.
@@ -4505,8 +4444,9 @@ products:
     imageUrlPlaceholder: https://example.com/image.jpg
     uploadImage: Upload image
     removeImage: Remove image
+    pasteUrl: Or paste a URL
     imageTooLarge: Image is too large (max 5 MB).
-    imageUploadFailed: Image upload failed. Please try again.
+    imageUploadFailed: Image upload failed. Try again.
     currencyPlaceholder: USD
     labels:
       name: Product name
@@ -4519,7 +4459,7 @@ products:
       category: Category
       status: Status
     toast:
-      success: Product updated successfully
+      success: Product updated
       error: Failed to update product
       duplicateName: A product with this name already exists
   create:
@@ -4528,7 +4468,7 @@ products:
     labels:
       status: Status
     toast:
-      success: Product created successfully
+      success: Product created
       error: Failed to create product
       duplicateName: A product with this name already exists
   createWizard:
@@ -4536,29 +4476,29 @@ products:
       basics: Basics
       pricing: Pricing & inventory
       review: Review
+    basicsHint: Start with a name, description, and image.
+    pricingHint: Add pricing, stock, and category details.
     reviewHint: Review the details, then create the product.
   import:
     uploadProducts: Upload products
-    uploadFile: Please upload a file
+    uploadFile: Upload a file
     success: Import successful
-    successDescription:
-      Successfully imported {success} products{failed, select, 0
-      {} other {, {failed} failed}}
+    successDescription: Imported {success} products{failed, select, 0 {} other {, {failed} failed}}
     error: Failed to import products
-    clickToUpload: Click to upload
+    clickToUpload: Upload
     supportedFormats: .xlsx, .xls or .csv
     expectedColumns:
       'Expected columns: name, description, imageUrl, stock, price,
       currency, category, status'
     draftStatusNote: Imported products are created with 'draft' status by default.
     errorCodes:
-      unknown: An unexpected error occurred
+      unknown: Something went wrong
   actions:
     deleteFailed: Failed to delete product
     deleteSuccess: Product deleted successfully
   delete:
     title: Delete product
-    confirmation: Are you sure you want to delete {name}?
+    confirmation: Delete "{name}"?
     thisProduct: this product
     warning: All related relationships and data will be permanently removed.
   view:
@@ -4670,8 +4610,7 @@ skills:
     uploadSuccess: Skill bundle uploaded
     uploadFailed: Failed to upload skill bundle
     replaceTitle: Replace existing skill?
-    replaceDescription: A skill named "{slug}" already exists. Uploading will
-      overwrite its current contents.
+    replaceDescription: '"{slug}" already exists. Uploading will overwrite it.'
     replaceConfirm: Replace
     replaceSuccess: Skill bundle replaced
     errors:
@@ -4823,10 +4762,8 @@ projects:
   files:
     title: Files
     addButton: Add file
-    emptyTitle: No files yet
-    emptyDescription:
-      Upload reference material to make it available to every chat
-      in this project.
+    emptyTitle: Add files for this project
+    emptyDescription: Upload docs, specs, or any context — every chat in this project can reference them.
     ragStatusQueued: Queued
     ragStatusQueuedHint: Waiting to become searchable in chat.
     ragStatusRunning: Indexing…
@@ -4876,15 +4813,10 @@ projects:
     agentsHeading: Agents
     modelsHeading: Models
     connectorsHeading: Connectors
-    sectionDescription:
-      Create the agents that work in this project — pick the harness each one
-      runs on, equip it with skills and connectors, and give it standing
-      instructions. Everyone here sees the same agents, and tasks can be
-      assigned to them.
+    sectionDescription: Agents assigned to this project, each with their own model, skills, and instructions.
     newAgent: New agent
-    emptyTitle: No agents yet
-    emptyBody: Create an agent to give this project a named worker with its own
-      equipment and instructions.
+    emptyTitle: Add an agent to this project
+    emptyBody: Agents run tasks on your behalf — give one a model, skills, and instructions to get started.
     equippedCount: '{count} equipped'
     rowEdit: Edit agent
     rowDelete: Delete agent
@@ -4892,8 +4824,8 @@ projects:
     dialogEditTitle: Edit agent
     nameLabel: Name
     namePlaceholder: e.g. PR reviewer
-    harnessLabel: Harness
-    harnessPlaceholder: Choose the harness it runs on
+    harnessLabel: Agent type
+    harnessPlaceholder: Choose the agent type
     modelLabel: Model
     modelPlaceholder: Choose the model it calls
     equipmentLabel: Skills & connectors
@@ -4994,9 +4926,10 @@ projects:
   dangerZone:
     title: Danger zone
     description: Destructive actions for this project.
+    archiveSectionTitle: Archive
     archiveHelp: Archiving hides the project and its chats from everyday lists; you can restore it here at any time.
     restoreHelp: Restoring returns the project and its chats to the everyday lists.
-    deleteHelp: Deleting removes the project permanently, including its files and settings. This cannot be undone.
+    deleteHelp: Permanently removes the project, its files, and its settings. This can't be undone.
   rowActions:
     duplicate: Duplicate
     rename: Rename
@@ -5130,7 +5063,7 @@ settings:
     governance:
       description: Policies, security, audit logs, and data retention.
     metrics:
-      description: Organization-wide KPIs for usage, feedback, automations, and projects.
+      description: Organization-wide metrics for usage, feedback, automations, and projects.
     sandboxes:
       description: Manage always-on remote sandboxes.
     enterpriseSso:
@@ -5197,7 +5130,7 @@ settings:
         their messages.
       archiveStarted: Archiving {count} chats
       deleteStarted: Deleting {count} chats
-      actionFailed: Something went wrong. Please try again.
+      actionFailed: Something went wrong. Try again.
   organization:
     title: Organization name
     detailsTitle: Organization details
@@ -5221,15 +5154,12 @@ settings:
       only, starting with a letter or digit.
     nameReserved: This name is reserved by the platform.
     enterCompanyName: Enter your company name
-    organizationCreated: Organization created successfully!
+    organizationCreated: Organization created
     switching: Switching…
     switchingTo: Switching to {name}…
     switchingLabel: Switching organization
     deleteDialogTitle: Delete organization
-    deleteDialogDescription:
-      Delete "{name}"? This removes its agents, automations,
-      providers, and connectors. Members will lose access. This cannot be
-      undone.
+    deleteDialogDescription: Delete "{name}"? This removes all agents, automations, providers, and connectors. Members will lose access. This can't be undone.
     dangerZoneTitle: Danger zone
     dangerZoneDescription: Irreversible actions that affect the entire organization.
     deleteSectionHelp:
@@ -5241,9 +5171,9 @@ settings:
     deleteFailed: Failed to delete organization
     editMember: Edit member
     removeMember: Remove member
-    memberUpdated: Member updated successfully
+    memberUpdated: Member updated
     memberUpdateFailed: Failed to update member
-    memberRemoved: Member removed successfully
+    memberRemoved: Member removed
     memberRemoveFailed: Failed to remove member
     twoFactorResetSuccess: Two-factor reset — the member must enrol again on next sign-in
     twoFactorResetFailed: Failed to reset two-factor authentication
@@ -5252,17 +5182,11 @@ settings:
     updatePassword: Update password
     enterNewPassword: Enter new password
     userMustUpdatePassword: User must update the password on login
-    adminWarning: 'Warning: Your organization should have at least 2 admins for
-      security. This change will be blocked if it would leave fewer than 2
-      admins.'
-    adminSecurityWarning:
-      'Warning: Your organization must have at least 2 Admins
-      for security. You cannot remove the last admin.'
+    adminWarning: Your organization needs at least 2 admins. This change will be blocked if it leaves fewer.
+    adminSecurityWarning: Your organization must have at least 2 admins. You can't remove the last one.
     transferOwnership: Transfer ownership
-    transferOwnershipConfirmation:
-      Are you sure you want to transfer ownership to
-      {name}? You will be demoted to admin.
-    ownershipTransferred: Ownership transferred successfully
+    transferOwnershipConfirmation: Transfer ownership to {name}? You'll be demoted to admin.
+    ownershipTransferred: Ownership transferred
     ownershipTransferFailed: Failed to transfer ownership
   teams:
     title: Teams
@@ -5276,14 +5200,11 @@ settings:
       created: Added
     editTeam: Edit team
     deleteTeam: Delete team
-    deleteConfirmation:
-      Are you sure you want to delete the {name} team? All members
-      will be removed from this team. This action cannot be undone.
+    deleteConfirmation: Delete the {name} team? All members will be removed. This can't be undone.
     teamDeleted: Team deleted
     teamDeleteFailed: Failed to delete team
-    teamCreated: Team created successfully
-    teamCreatedDescription: '{name} team has been created with {count} {count,
-      plural, one {member} other {members}}.'
+    teamCreated: Team created
+    teamCreatedDescription: '{name} created with {count} {count, plural, one {member} other {members}}.'
     teamCreateFailed: Failed to create team
     teamUpdated: Team updated
     teamUpdateFailed: Failed to update team
@@ -5321,7 +5242,7 @@ settings:
       model: Default model
       tools: Tools
     deleteAgent: Delete agent
-    deleteConfirmation: Are you sure you want to delete this agent? This action cannot be undone.
+    deleteConfirmation: Delete this agent? This can't be undone.
     agentCreated: Agent created
     agentCreateFailed: Failed to create agent
     agentAlreadyExists: An agent with this identifier already exists
@@ -5386,9 +5307,7 @@ settings:
       noSkillsInOrg: No skills exist in this organization yet.
     unsavedChanges:
       title: Unsaved changes
-      description:
-        You have unsaved changes. Are you sure you want to leave? Your
-        changes will be lost.
+      description: You have unsaved changes. Leave now and lose them?
       leave: Leave
       stay: Keep editing
     navigation:
@@ -5870,9 +5789,7 @@ settings:
     credential:
       disabled: Disabled
       needsReauth: Reconnect needed
-      needsReauthHint:
-        The stored authorization expired or was revoked. Reconnect to grant
-        consent again.
+      needsReauthHint: Authorization expired or revoked. Reconnect to restore access.
       needsReauthDetail: '{detail} Reconnect to grant consent again.'
       reconnect: Reconnect
     replace:
@@ -5900,7 +5817,6 @@ settings:
         storefront domain.
       endpointHelpGeneric: The https origin of the instance this credential belongs to.
   enterpriseSso:
-    description: Single sign-on (OIDC, OAuth2, SAML) and SCIM user & group provisioning.
     connected: Sign-in is enabled.
     copied: Copied to clipboard
     copy: Copy
@@ -6073,11 +5989,7 @@ settings:
         s5:
           Enter them above with the Issuer URL https://accounts.google.com — the
           endpoints are discovered automatically.
-        groupsNote:
-          "Note: Google's standard OIDC does not return group memberships —
-          group→team sync needs the Admin SDK / Cloud Identity API with a
-          Workspace admin. Other OIDC providers (Okta, Auth0, Keycloak) work
-          the same way: enter the issuer URL and client credentials."
+        groupsNote: Google's standard OIDC doesn't return group memberships — group→team sync needs the Admin SDK / Cloud Identity API with a Workspace admin.
       oauth2:
         intro: For providers without OIDC discovery, configure the endpoints manually.
         s1:
@@ -6132,15 +6044,11 @@ settings:
       resultOk: '{name}: {count, plural, one {# model} other {# models}}'
       resultError: '{name}: {error}'
       nothingToRefresh: Every catalog ships with the platform — there is nothing to refresh.
-      refreshFailed: 'Could not refresh the catalogs: {error}'
-      listFailed: 'Could not load the providers: {error}'
+      refreshFailed: Couldn't refresh the catalogs.
+      listFailed: Couldn't load the providers.
     harnesses:
-      title: Harnesses
-      description:
-        How each harness would run for this organization — the models the
-        managed lane offers it, and the vendor subscriptions bound to it.
-        This only shows the resolution; configure it through the provider
-        credentials above.
+      title: Agent runtimes
+      description: How each agent runtime is configured for this organization — the models available and any vendor subscriptions bound to it. Configure this through provider credentials above.
       managed: Managed
       modelPool: '{count, plural, one {# model} other {# models}} · default {model}'
       byoOnly: Needs its own vendor credential — platform-managed keys can't run it.
@@ -6150,7 +6058,7 @@ settings:
       degraded: Recently failing
       subscriptionVia: Subscription · {provider}
       subscriptionInert: Subscription · {provider} — not usable, this harness runs managed credentials only
-      listFailed: 'Could not load the harness status: {error}'
+      listFailed: Couldn't load the agent status.
     apiFormat:
       openai: OpenAI-compatible API
       anthropic: Anthropic Messages API
@@ -6259,15 +6167,13 @@ settings:
     createKey: Create API key
     createKeySubmit: Create key
     keyCreated: API key created
-    keyCreatedDescription: Make sure to copy your API key now. You won't be able to see it again.
+    keyCreatedDescription: Copy your API key now — it won't be shown again.
     yourApiKey: Your API key
     keyRevoked: API key revoked
     keyRevokeFailed: Failed to revoke API key
     revokeKey: Revoke key
     revokeKeyTitle: Revoke API key
-    revokeConfirmation: Are you sure you want to revoke the API key "{keyName}"?
-      This action cannot be undone. Any applications using this key will lose
-      access immediately.
+    revokeConfirmation: 'Revoke "{keyName}"? Any applications using this key will immediately lose access. This can''t be undone.'
     keyCopied: API key copied to clipboard
     columns:
       name: Name
@@ -7329,7 +7235,7 @@ tasks:
     empty: No matches
   metrics:
     title: Project metrics
-    description: Delivery, intervention, and cost KPIs for this project's tasks.
+    description: Delivery, intervention, and cost metrics for this project's tasks.
     cappedNotice: Some days hit the rollup scan cap — totals in this window may undercount.
     noData: No data
     noDataDescription: Metrics appear after the first daily rollup.
@@ -7391,10 +7297,10 @@ toast:
   success:
     saved:
       title: Changes saved
-      description: Your changes have been saved.
+      description: Changes saved.
     deleted:
       title: Deleted
-      description: The item has been deleted.
+      description: Deleted.
     passwordChanged:
       title: Password changed
       description: Use your new password the next time you sign in.
@@ -7403,17 +7309,17 @@ toast:
       description: You can now sign in with your password.
     newMemberCreated:
       title: Member added
-      description: The new member has been created and added to your organization.
+      description: New member added to your organization.
     existingUserAdded:
       title: Member added
-      description: The user has been added to your organization.
+      description: User added to your organization.
     faviconGenerated:
       title: Favicon generated
       description: We created a favicon from your logo.
   error:
     saveFailed:
       title: Couldn't save changes
-      description: Something went wrong. Please try again.
+      description: Something went wrong. Try again.
     profileUpdateFailed:
       title: Couldn't update profile
     passwordChangeFailed:
@@ -7430,10 +7336,10 @@ toast:
     imageTypeInvalid: Invalid image type
     addMemberFailed:
       title: Couldn't add member
-      description: Something went wrong. Please try again.
+      description: Something went wrong. Try again.
     generic:
       title: Something went wrong
-      description: Please try again.
+      description: Try again.
 todoList:
   title: Research plan
   ariaLabel: Research plan
@@ -7495,8 +7401,8 @@ twoFactor:
       platform: This device (Face ID, Touch ID, Windows Hello)
       crossPlatform: Security key or phone
     errors:
-      registerFailed: Could not register the passkey. Please try again.
-      revokeFailed: Could not remove the passkey. Please try again.
+      registerFailed: Couldn't register the passkey. Try again.
+      revokeFailed: Couldn't remove the passkey. Try again.
   setup:
     title: Set up two-factor authentication
     qrInstructions: Scan the QR code with an authenticator app (Google
@@ -7523,9 +7429,9 @@ twoFactor:
     useAuthenticatorToggle: Use the authenticator app instead
     backupCodeLabel: Backup code
     submitButton: Verify
-    invalid: Invalid or expired code. Please try again.
+    invalid: Invalid or expired code. Try again.
     tooManyAttempts: Too many failed attempts. Try again later.
-    success: Signed in successfully
+    success: Signed in
     backupCodeSuccess: Backup code used. Consider regenerating your backup codes in Settings.
     usePasskeyButton: Use a passkey instead
     passkeyFailed: Passkey sign-in failed or was cancelled. Try again or use a code.
@@ -7560,10 +7466,10 @@ twoFactor:
         singleDevice: Single-device key
         multiDevice: Synced passkey
   errors:
-    enableFailed: Failed to start two-factor setup. Please try again.
-    disableFailed: Failed to disable two-factor authentication.
-    regenerateFailed: Failed to generate new backup codes.
-    invalidCode: Invalid or expired code. Please try again.
+    enableFailed: Couldn't start two-factor setup. Try again.
+    disableFailed: Couldn't disable two-factor authentication.
+    regenerateFailed: Couldn't generate new backup codes.
+    invalidCode: Invalid or expired code. Try again.
 websites:
   title: Websites
   entityLabelOne: website
@@ -7600,12 +7506,12 @@ websites:
     urlListRequired: Add at least one URL
     urlListInvalid: 'This line is not a valid URL: {line}'
   toast:
-    addSuccess: Website added successfully
+    addSuccess: Website added
     addError: Failed to add website
     addErrorDuplicate: This website has already been added
     addListSuccess: '{count} URLs registered for indexing'
     addListPartial: 'Some sources could not be added: {domains}'
-    updateSuccess: Website updated successfully
+    updateSuccess: Website updated
     updateError: Failed to update website
     fetchPagesError: Failed to load pages
     searchError: Search failed
@@ -7653,7 +7559,7 @@ websites:
       7d: Every 7 days
       30d: Every 30 days
   delete:
-    confirmation: Are you sure you want to delete this website? This action cannot be undone.
+    confirmation: Delete this website? This can't be undone.
     title: Delete website
 webdav:
   description: Mount Tale documents as a network drive in Finder, File Explorer,
@@ -7676,7 +7582,7 @@ webdav:
     error: Failed to create app-password
     errorLimit: You have reached the maximum number of app-passwords. Revoke an
       unused one first.
-    errorRateLimited: Too many app-passwords created recently. Please try again later.
+    errorRateLimited: Too many app-passwords created recently. Try again later.
     savedTitle: Save this password — it will not be shown again.
     copy: Copy
     dismiss: I have saved it
@@ -7735,9 +7641,7 @@ sandboxes:
     destroy: Destroy
   destroyConfirm:
     title: Destroy sandbox?
-    description:
-      This tears down the container and its workspace. Any running task
-      is cancelled. The next chat message recreates a fresh sandbox.
+    description: This tears down the sandbox and its workspace. Any running task is cancelled. A fresh sandbox starts on your next message.
     confirm: Destroy
   toast:
     stopped: Task stopped

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -68,7 +68,7 @@ operator:
     button: Relancer
     started: Nouvelle exécution lancée
     alreadyRunning: Une exécution est déjà en cours.
-    notStarted: Impossible de lancer l'exécution — vérifiez que l'automatisation est installée.
+    notStarted: Impossible de lancer l'exécution. Vérifie que l'automatisation est déployée et réessaie.
   stop:
     button: Arrêter
     stopped: Exécution arrêtée
@@ -102,9 +102,7 @@ accessDenied:
   knowledge: Ton compte n'a pas l'autorisation d'accéder à la base de connaissances.
   workspaceNotFound: L'espace de travail que tu recherches n'existe pas ou a été supprimé.
   disabled: Ton compte a été désactivé. Contacte le support pour obtenir de l'aide.
-  noMembership:
-    Tu n'es pas membre de cet espace de travail. Merci de contacter un
-    administrateur pour obtenir l'accès.
+  noMembership: Tu n'es pas membre de cet espace de travail. Contacte un administrateur pour obtenir l'accès.
   unauthenticated: Ta session a expiré. Reconnecte-toi pour continuer.
   enterpriseSso:
     Vous devez disposer des autorisations Administrateur pour accéder
@@ -117,7 +115,7 @@ accessDenied:
 analytics:
   automations:
     title: Métriques des automatisations
-    description: Utilisation et performance de tes automatisations au fil du temps.
+    description: Nombre d'exécutions, taux de réussite et durée moyenne sur l'ensemble de tes automatisations.
     cappedNotice: Affiche les 5 000 dernières exécutions de la période. Les plus
       anciennes ne comptent pas dans ces totaux.
     cards:
@@ -486,8 +484,7 @@ auth:
       La connexion par passkey a échoué ou a été annulée. Réessaie ou
       utilise ton mot de passe.
     wrongCredentials: Courriel ou mot de passe incorrect
-    accountLockedGeneric: Compte temporairement verrouillé en raison d'échecs
-      répétés. Merci de réessayer plus tard ou de contacter un administrateur.
+    accountLockedGeneric: Compte temporairement verrouillé en raison d'échecs répétés. Réessaie plus tard ou contacte un administrateur.
     accountLockedSeconds:
       Compte temporairement verrouillé. Réessaie dans {seconds,
       plural, one {# seconde} other {# secondes}}, ou contacte un
@@ -502,7 +499,7 @@ auth:
       title: Contacte ton administrateur
       description: La réinitialisation du mot de passe est gérée par ton organisation.
     toast:
-      success: Connecté avec succès
+      success: Connecté
     lockoutAdvisory: Des échecs répétés verrouillent temporairement le compte.
   signup:
     wrongCredentials: Courriel ou mot de passe incorrect
@@ -538,7 +535,6 @@ auth:
     logOut: Se déconnecter
     logOutConfirm:
       title: Se déconnecter
-      description: Es-tu sûr de vouloir te déconnecter ?
       confirm: Se déconnecter
     toast:
       signOutFailed: Échec de la déconnexion
@@ -642,20 +638,13 @@ automations:
     loadFailed: 'Impossible de charger les automatisations : {error}'
     empty:
       title: Aucune automatisation pour l’instant
-      description:
-        Une automatisation, c’est un document enregistré — un graphe de
-        nœuds. Les automatisations de départ livrées arrivent ici
-        automatiquement, et un développeur en crée de nouvelles à partir d’un
-        objectif avec "Nouvelle automatisation".
+      description: Décris ce que tu veux automatiser, ou importe un fichier de workflow.
   createMenu:
     fromGoal: À partir d’un objectif
   builder:
     new: Nouvelle automatisation
     title: Nouvelle automatisation
-    description:
-      Décris ce que l’automatisation doit faire. Un builder IA l’écrit contre
-      des connectors simulés et enregistre le résultat ici comme brouillon —
-      rien ne s’exécute en réel tant qu’une version n’est pas mise en service.
+    description: Décris ton objectif.
     goalLabel: Objectif
     goalPlaceholder:
       p. ex. Chaque matin, lis les derniers e-mails du support et écris un
@@ -664,7 +653,7 @@ automations:
     providerPlaceholder: Choisir un fournisseur
     modelLabel: Modèle
     modelPlaceholder: Choisir un modèle
-    submit: Lancer la construction
+    submit: Générer l'automatisation
     submitting: Construction…
     running:
       Le builder travaille — ça peut prendre quelques minutes. Les versions
@@ -688,13 +677,10 @@ automations:
     saveMessageDescription: Ce qui a changé, pour garder la liste des versions lisible.
     saveDialog:
       title: Enregistrer une nouvelle version
-      description: L’enregistrement ajoute une nouvelle version. Celle qui est
-        affichée reste intacte, donc une exécution en cours n’est pas touchée.
+      description: Enregistre une nouvelle version. Les exécutions en cours continuent d’utiliser la version déployée.
     switchVersion:
       title: Afficher une autre version ?
-      description: Le canvas n’affiche qu’une seule version enregistrée à la
-        fois, donc en changer abandonne les modifications que tu n’as pas encore
-        enregistrées.
+      description: Changer de version supprime les modifications non enregistrées.
       confirm: Abandonner et changer
     showLastRun: Afficher la dernière exécution
     hideLastRun: Masquer la dernière exécution
@@ -703,9 +689,7 @@ automations:
     runLiveNeedsDeploy: Mets d’abord une version en service — une exécution
       réelle lance la version en service.
     runLiveTitle: Exécuter en réel ?
-    runLiveBody: Une exécution réelle appelle les vrais connectors au nom de
-      l’organisation — des e-mails partent, des données changent. La version en
-      service s’exécute une fois, maintenant.
+    runLiveBody: Lance la version déployée pour de vrai — des e-mails partent, des données changent. L’automatisation ne se relancera pas automatiquement.
   trigger:
     title: Déclencheur
     none: Rien ne démarre encore cette automatisation.
@@ -725,15 +709,13 @@ automations:
     save: Enregistrer le déclencheur
     remove: Retirer le déclencheur
     removeTitle: Retirer le déclencheur ?
-    removeBody: L’automatisation garde ses versions et son historique ; rien ne
-      la démarre tant qu’une nouvelle liaison n’est pas enregistrée.
+    removeBody: Supprime le déclencheur. L’automatisation et son historique de versions ne sont pas touchés.
     tokenTitle: Token du webhook — copie-le maintenant
     tokenHint: Ce token apparaît une seule fois et n’est conservé que sous
       forme de hash.
     tokenPath: 'Un POST sur /api/automations/webhook/{token} démarre
       l’automatisation.'
-    hasToken: Un token de webhook existe. Le faire tourner le remplace ;
-      l’ancienne adresse cesse de fonctionner.
+    hasToken: Un token est actif. Le renouveler en crée un nouveau — mets à jour les webhooks qui utilisent l’ancienne URL.
     noToken: Enregistrer crée un token et l’affiche une seule fois.
     rotate: Renouveler le token
   canvas:
@@ -803,10 +785,7 @@ automations:
     title: Projets
     orgBadge: Toute l’organisation
     countBadge: '{count, plural, one {Lié à # projet} other {Lié à # projets}}'
-    hint: Les projets dont les boards de tâches voient cette automatisation.
-      Sans sélection, elle sert toute l’organisation ; avec une sélection,
-      elle apparaît exactement dans ces projets. Un projet ne peut pas être
-      supprimé tant qu’une automatisation y est liée.
+    hint: Choisis les projets qui peuvent utiliser cette automatisation. Laisse vide pour la partager à toute l’organisation.
     placeholder: Toute l’organisation — aucun projet sélectionné
     searchPlaceholder: Rechercher des projets
     empty: Aucun projet ne correspond
@@ -825,10 +804,10 @@ automations:
     noMessage: Aucune note
   upload:
     trigger: Téléverser un paquet
-    title: Téléverser un paquet d'automatisation
-    description: "Le workflow.yml d'un pack (requis) et l'automation.yml (optionnel — son bloc subjects devient le contrat de tâches), ou le dossier du pack entier en une seule .zip, qui peut aussi embarquer des bundles de skills sous skills/. Le document est validé avant tout enregistrement ; la version téléversée reste un brouillon jusqu'au déploiement."
+    title: Téléverser un paquet
+    description: Téléverse un fichier de workflow ou un pack zip pour l'ajouter à tes automatisations.
     filesLabel: Fichiers du paquet
-    filesHelp: 'Choisis workflow.yml (plus automation.yml), ou une seule .zip du dossier du pack — skills/ compris.'
+    filesHelp: workflow.yml (plus automation.yml), ou une .zip du pack.
     uploading: Téléversement du paquet…
     zipOnly: Téléverse la .zip seule — elle contient déjà tout le pack.
     zipTooLarge: La .zip dépasse la limite des 20 MiB par paquet.
@@ -840,8 +819,8 @@ automations:
     removeFile: 'Retirer {name}'
     targetLabel: Installer dans
     targetOrg: Organisation
-    targetHelp: Installer dans un projet lie l’automatisation à ce projet — tu ajoutes ou retires des projets à tout moment dans le panneau Projets de sa page. Organisation l’installe pour toute l’organisation, visible sur le board de tâches de chaque projet.
-    submit: Téléverser
+    targetHelp: Un projet la lie à ce board ; Organisation la partage dans toute l'organisation.
+    submit: Téléverser le paquet
     submitting: Validation et enregistrement…
     uploaded: '{name} v{version} téléversé — déploie-la quand tu es prêt.'
     warnings: "{count, plural, one {# avertissement de validation} other {# avertissements de validation}} — ouvre l'automatisation pour vérifier."
@@ -973,10 +952,10 @@ chat:
   archive: Archiver
   unarchive: Désarchiver
   archiveSuccess: Chat archivé
-  archiveFailed: Échec de l'archivage du chat
+  archiveFailed: Impossible d'archiver le chat
   unarchiveSuccess: Chat désarchivé
-  unarchiveFailed: Échec du désarchivage du chat
-  archivedBanner: Cette conversation a été archivée
+  unarchiveFailed: Impossible de désarchiver le chat
+  archivedBanner: Archivé
   archived:
     title: Archivés
     empty: Aucune conversation archivée
@@ -999,7 +978,7 @@ chat:
   removeFromProject: Retirer du projet
   removeFromProjectFailed: Échec du retrait du chat du projet
   deleteChat: Supprimer le chat
-  deleteConfirmation: Es-tu sûr de vouloir supprimer {title} ?
+  deleteConfirmation: Supprimer « {title} » ?
   deletePermanentMessage: Déplacer le chat vers la corbeille. Tu peux le restaurer pendant la période de grâce de l'organisation ; ensuite la rétention supprime définitivement le chat et ses messages.
   deleteFailed: Échec de la suppression du chat
   editMessage: Modifier le message
@@ -1007,7 +986,7 @@ chat:
   tryAgain: Réessayer
   regenerateFailed: Impossible de régénérer la réponse
   forkChat: Dupliquer le chat
-  forkSuccess: Chat dupliqué avec succès
+  forkSuccess: Chat dupliqué
   forkFailed: Échec de la duplication du chat
   forkOf: Fork de {title}
   branchNavigator:
@@ -1103,8 +1082,8 @@ chat:
   newProject: Nouveau projet
   notFound: Ce chat n'est pas disponible.
   placeholder: Pose une question sur tes documents ou le Web…
-  generationIncomplete: La réponse n'a pas pu être terminée. Merci de réessayer.
-  generationIncompleteWithTools: La réponse n'a pas pu être terminée après l'exécution de {tools}. Merci de réessayer.
+  generationIncomplete: La réponse n'a pas pu être terminée. Réessaie.
+  generationIncompleteWithTools: La réponse n'a pas pu être terminée après l'exécution de {tools}. Réessaie.
   stepLimitReached: Arrêt ici — ce tour a atteint sa limite d'étapes. Envoie un message pour continuer.
   send: Envoyer le message
   stopGenerating: Arrêter la génération
@@ -1116,7 +1095,7 @@ chat:
   fileTypeNotAllowed: '{names} : type de fichier non autorisé par la politique de téléversement.'
   fileTypeUnsupported: '{names} : type de fichier non pris en charge.'
   fileUploaded: Fichier téléversé
-  uploadedSuccessfully: '{filename} téléversé avec succès'
+  uploadedSuccessfully: '{filename} téléversé'
   uploadFailed: Échec du téléversement
   failedToUpload: Échec du téléversement de {filename}
   tooManyFiles: Trop de fichiers
@@ -1148,7 +1127,7 @@ chat:
     inProgressTooltip: Transcription de l'audio en cours…
     transcribing: Transcription en cours…
     transcribed: Transcrit
-    couldNotTranscribe: N'a pas pu être transcrit
+    couldNotTranscribe: Transcription impossible
     viewTranscript: Voir la transcription
     previewSubtitle: '{seconds}s transcrites'
     retry: Réessayer
@@ -1236,9 +1215,7 @@ chat:
     transcriptionFailedShort: Échec de la transcription
     retry: Réessayer
     discard: Supprimer l'enregistrement
-    permissionDenied:
-      L'accès au microphone a été refusé. Merci d'autoriser l'accès
-      au microphone dans les paramètres de ton navigateur.
+    permissionDenied: Accès au microphone refusé. Autorise-le dans les paramètres de ton navigateur.
   citations:
     source: Source {number}
     page: Page {page}
@@ -1366,9 +1343,7 @@ chat:
     approvalRejected: Refusé
     humanInputPending: Ta réponse est nécessaire
     humanInputAnswered: Répondu
-  errorGeneratingDescription:
-    Une erreur est survenue lors de la génération de la
-    réponse. Merci de réessayer.
+  errorGeneratingDescription: Une erreur est survenue lors de la génération de la réponse. Réessaie.
   errorHintAuthError: La clé API est invalide ou n'a pas accès à ce modèle.
     Contacte ton administrateur.
   errorHintContentFilter: Le message a été signalé par le filtre de contenu.
@@ -1387,9 +1362,8 @@ chat:
     pas de place pour le prompt (ou dépasse ce que le modèle prend en charge).
     Réessaie — Tale efface automatiquement un plafond mis en cache incorrect —
     ou demande à ton administrateur de le baisser.
-  errorHintProviderError: Le fournisseur d'IA rencontre temporairement des
-    problèmes. Merci de réessayer dans un instant.
-  errorHintRateLimited: Trop de requêtes. Merci de patienter un moment et réessayer.
+  errorHintProviderError: Le fournisseur d'IA rencontre temporairement des problèmes. Réessaie dans un instant.
+  errorHintRateLimited: Trop de requêtes. Patiente un moment, puis réessaie.
   errorHintTokenLimit: La limite de tokens en sortie du modèle a été dépassée.
     Essaie une requête plus courte ou demande à ton administrateur d'ajuster les
     paramètres du modèle.
@@ -1412,8 +1386,7 @@ chat:
     administrateur.'
   errorHintModelNotFoundNamed: Le modèle sélectionné est introuvable chez
     {provider}. Il a peut-être été renommé ou supprimé.
-  errorHintRateLimitedNamed: Limite de débit atteinte chez {provider}. Merci de
-    patienter un moment puis de réessayer.
+  errorHintRateLimitedNamed: Limite de débit atteinte chez {provider}. Patiente un moment, puis réessaie.
 
   errorGenerating: "Une erreur s'est produite"
   errorTriedModels: "{count} modèles ont été essayés avant d'abandonner."
@@ -1452,8 +1425,8 @@ chat:
     showAll: Afficher les {count} sources
     hide: Masquer les sources
 
-  budgetExceededDetail: Limite de {type} atteinte pour cette période {period} ({used} / {limit}). Merci de contacter ton administrateur.
-  budgetExceededDefault: "Ta limite d'utilisation a été atteinte pour cette période. Merci de contacter ton administrateur."
+  budgetExceededDetail: Limite de {type} atteinte pour cette période {period} ({used} / {limit}). Contacte ton administrateur.
+  budgetExceededDefault: "Ta limite d'utilisation a été atteinte pour cette période. Contacte ton administrateur."
   budgetRemaining: 'Encore {remaining} sur {limit} {type} pour ce {period}'
   budgetLimitReached: "Limite d'utilisation atteinte · se réinitialise {period}"
   budgetRequestCredits: Demander plus de crédits
@@ -1523,6 +1496,7 @@ common:
     openMenu: Ouvrir le menu
     deleteSelected: Supprimer la sélection
     export: Exporter
+    tryAgain: Réessayer
   unsavedChanges:
     title: Modifications non enregistrées
     description: Tu as des modifications non enregistrées. Quitter maintenant les fera disparaître.
@@ -1541,11 +1515,8 @@ common:
       '{count, plural, one {# élément sélectionné} other {# éléments
       sélectionnés}}'
     confirmDeleteTitle: Supprimer {count, plural, one {# élément} other {# éléments}}
-    confirmDeleteDescription: Es-tu sûr de vouloir supprimer {count, plural, one
-      {cet élément} other {ces {count} éléments}} ? Cette action est
-      irréversible.
-    deleteSuccess: '{count, plural, one {# élément supprimé} other {# éléments
-      supprimés}} avec succès'
+    confirmDeleteDescription: 'Supprimer {count, plural, one {cet élément} other {ces {count} éléments}} ? Cette action est irréversible.'
+    deleteSuccess: '{count, plural, one {# élément supprimé} other {# éléments supprimés}}'
     deleteFailed: Échec de la suppression de certains éléments
     deleting: Suppression...
   upload:
@@ -1658,13 +1629,13 @@ common:
       "{tokens} ne correspond à personne dans ta organisation —
       aucune notification n'a été envoyée."
   errors:
-    generic: Une erreur s'est produite. Merci de réessayer.
+    generic: Une erreur s'est produite — réessaie, ou recharge la page si le problème persiste.
     failedToCopy: Échec de la copie dans le presse-papiers
     somethingWentWrong: Une erreur s'est produite
     errorLoadingPage:
       Une erreur s'est produite lors du chargement de cette page. Tu
       peux réessayer ou naviguer vers une autre section.
-    persistsProblem: Si ce problème persiste, merci de
+    persistsProblem: Si ce problème persiste,
     contactSupport: contacter le support
     tryAgain: Réessayer
     showDetails: Afficher les détails
@@ -1799,8 +1770,7 @@ conversations:
     close: Fermer
     reopen: Rouvrir
     messagesSent: Messages envoyés
-    messagesSentDescription: '{successCount} messages envoyés avec
-      succès{failedCount, plural, =0 {} other {, {failedCount} échoués}}'
+    messagesSentDescription: '{successCount} messages envoyés{failedCount, plural, =0 {} other {, {failedCount} échoués}}'
     sendFailed: Échec de l'envoi des messages
     resolved: Conversations résolues
     resolvedDescription: '{successCount} conversations résolues avec
@@ -1844,10 +1814,8 @@ conversations:
     assignError: Impossible de mettre à jour le responsable
     inboxSource: 'Boîte de réception : {inbox}'
     toast:
-      closed: La conversation a été fermée avec succès.
-      closeFailed:
-        Une erreur inattendue s'est produite lors de la fermeture de la
-        conversation.
+      closed: Conversation fermée
+      closeFailed: Impossible de fermer la conversation — réessaie.
       reopened: La conversation a été rouverte avec succès.
       reopenFailed:
         Une erreur inattendue s'est produite lors de la réouverture de la
@@ -1968,11 +1936,11 @@ contacts:
     manualEntry: Saisie manuelle
   create:
     title: Ajouter un contact
-    success: Contact créé avec succès
+    success: Contact créé
     error: Échec de la création du contact
     duplicateEmail: Un contact avec cette adresse email existe déjà
   thisContact: ce contact
-  updateSuccess: Contact mis à jour avec succès
+  updateSuccess: Contact mis à jour
   updateError: Échec de la mise à jour du contact
   name: Nom
   namePlaceholder: Saisir le nom du contact
@@ -1984,10 +1952,8 @@ contacts:
   import:
     provideData: Fournis des données
     noValidData: Aucune donnée de contact valide trouvée
-    success: Importation réussie
-    successDescription:
-      Importation réussie de {success} contacts{failed, select, 0
-      {} other {, {failed} échoué(s)}}
+    success: Importé
+    successDescription: '{success} contacts importés{failed, select, 0 {} other {, {failed} échoué(s)}}'
     noneImported: Aucun contact n'a été importé
     error: Erreur d'importation
     uploadContacts: Téléverser des contacts
@@ -1996,7 +1962,7 @@ contacts:
       duplicate_email: Un contact avec cette adresse email existe déjà
       duplicate_external_id: Un contact avec cet identifiant externe existe déjà
       unknown: Une erreur inattendue s'est produite
-  deleteConfirmation: Es-tu sûr de vouloir supprimer {name} ?
+  deleteConfirmation: Supprimer « {name} » ?
   deleteError: Échec de la suppression du contact
   deleteWarning: Cette action est irréversible.
 dataNotice:
@@ -2011,10 +1977,8 @@ dialogs:
     existingUserHint: Cette personne possède déjà un compte ; aucun mot de passe
       n'est nécessaire — elle se connecte avec ses identifiants existants.
   memberAdded:
-    title: Membre ajouté avec succès
-    credentialsWarning:
-      'Important : enregistre ces identifiants maintenant. Ils ne
-      seront plus affichés.'
+    title: Membre ajouté
+    credentialsWarning: Enregistre ces identifiants maintenant. Ils ne seront plus affichés.
     existingUserNotice: Cet utilisateur possédait déjà un compte, aucun nouvel
       identifiant n'a été créé. Il peut se connecter avec son mot de passe
       existant.
@@ -2025,9 +1989,7 @@ dialogs:
     noResults: Aucun résultat
     untitledChat: Discussion sans titre
   thisMember: ce membre
-  confirmRemoveMember: Es-tu sûr de vouloir retirer {name} de l'équipe ? Cette
-    personne perdra l'accès à cette organisation et à toutes les ressources
-    associées.
+  confirmRemoveMember: Retirer {name} de l'équipe ? Cette personne perdra l'accès à cette organisation et à toutes les ressources associées.
   toSend: pour envoyer
   contactInfo:
     title: Détails du contact
@@ -2042,12 +2004,12 @@ documentWriteApproval:
   rejectTooltip: Rejeter l'enregistrement de ce document
   rejectTooltipBatch: Rejeter l'enregistrement de tous les documents
   savedSuccessfully: Enregistré dans tes documents
-  savedPartially: '{success} sur {total} fichiers enregistrés avec succès'
+  savedPartially: '{success} sur {total} fichiers enregistrés'
   statusExecuting: Enregistrement des documents...
-  statusCompletedFailed: Ce document a été approuvé mais n'a pas pu être enregistré.
-  statusCompletedSuccess: Ce document a été enregistré dans tes documents.
+  statusCompletedFailed: Approuvé, mais l'enregistrement a échoué.
+  statusCompletedSuccess: Enregistré dans tes documents.
   statusCompletedPartial: Certains documents n'ont pas pu être enregistrés.
-  statusRejected: L'enregistrement de ce document a été rejeté.
+  statusRejected: Rejeté.
   allFilesFailed: Les {count} fichiers n'ont pas pu être enregistrés
   errorSaveFailed: Échec de l'enregistrement du document
 jobCard:
@@ -2089,14 +2051,14 @@ documents:
   searchPlaceholder: Rechercher des documents
   deleteFolder:
     title: Supprimer le dossier
-    confirmation: Es-tu sûr de vouloir supprimer le dossier {name} ?
+    confirmation: 'Supprimer le dossier « {name} » ?'
     requirement:
       Tous les fichiers et sous-dossiers contenus dans ce dossier seront
       également supprimés définitivement.
     deleteButton: Supprimer le dossier
   deleteSyncFolder:
     title: Supprimer le dossier synchronisé
-    confirmation: Es-tu sûr de vouloir supprimer le dossier synchronisé {name} ?
+    confirmation: 'Supprimer le dossier synchronisé « {name} » ?'
     thisWillDelete: 'Cela supprimera définitivement :'
     willDelete:
       filesAndSubfolders: Tous les fichiers et sous-dossiers
@@ -2118,7 +2080,7 @@ documents:
   actions:
     deleteSyncFolder: Supprimer le dossier synchronisé
     deleteFolderFailed: Échec de la suppression du dossier
-    deleteFileFailed: Une erreur inattendue s'est produite lors de la suppression du fichier.
+    deleteFileFailed: Impossible de supprimer le fichier.
     manageTeams: Assigner une équipe
     reindex: Réindexer
     stopSync: Arrêter la synchronisation
@@ -2149,7 +2111,7 @@ documents:
     orgWide: Toute l'organisation
   deleteFile:
     title: Supprimer le document
-    confirmation: Es-tu sûr de vouloir supprimer {name} ? Cette action est irréversible.
+    confirmation: 'Supprimer « {name} » ? Cette action est irréversible.'
     thisDocument: ce document
     deleteButton: Supprimer
   breadcrumb:
@@ -2179,7 +2141,7 @@ documents:
     downloadComplete: Téléchargement terminé
     downloadFile: Télécharger le fichier
     closePreview: Fermer l'aperçu
-    downloadedSuccessfully: '{filename} a été téléchargé'
+    downloadedSuccessfully: '{filename} téléchargé'
     downloadFailed: Échec du téléchargement du fichier
     notAvailable: Aperçu non disponible
     notAvailableDescription:
@@ -2218,7 +2180,7 @@ documents:
     confirming: Confirmation du téléversement…
     confirmingFileNamed: Confirmation du téléversement de {fileName}
     failedFileName: '{fileName} — Échec'
-    pleaseWaitForUpload: Merci de patienter jusqu'à la fin du téléversement en cours
+    pleaseWaitForUpload: Attends la fin du téléversement en cours
     noFilesSelected: Aucun fichier sélectionné
     fileTooLarge: Fichier trop volumineux
     fileSizeExceeded:
@@ -2226,7 +2188,7 @@ documents:
       actuelle : {currentSize} Mo'
     uploadCancelled: Téléversement annulé
     uploadFailed: Échec du téléversement
-    uploadFailedRetry: Échec du téléversement. Merci de vérifier ta connexion et réessayer.
+    uploadFailedRetry: Échec du téléversement. Vérifie ta connexion et réessaie.
     quotaExceeded:
       Quota de stockage plein — {used} sur {limit} utilisés. Supprime
       des fichiers pour libérer de l'espace (les téléversements échoués comptent
@@ -2303,8 +2265,8 @@ documents:
     syncingItems: Synchronisation de {count} éléments vers le stockage...
     importCompleted: Importation terminée
     syncCompleted: Synchronisation terminée
-    filesImportedCount: '{count} sur {total} fichiers importés avec succès'
-    filesSyncedCount: '{count} sur {total} fichiers synchronisés avec succès'
+    filesImportedCount: '{count} sur {total} fichiers importés'
+    filesSyncedCount: '{count} sur {total} fichiers synchronisés'
     importFailed: Échec de l'importation
     syncFailed: Échec de la synchronisation
     importItems: Importer {count} {count, plural, one {élément} other {éléments}}
@@ -2325,16 +2287,14 @@ documents:
     toast:
       documentIdRequired: L'ID du document est requis pour la relance
       indexingStarted: Indexation démarrée
-      indexingQueued: L'indexation du document a été mise en file d'attente.
+      indexingQueued: Document mis en file d'attente pour l'indexation.
       retryFailed: Échec de la relance
       retryFailedDescription: Échec de la relance de l'indexation RAG
       unexpectedError: Une erreur inattendue s'est produite
     dialog:
       indexed:
         title: Document indexé
-        description:
-          Ce document a été indexé avec succès et est disponible pour la
-          recherche RAG.
+        description: Ce document est indexé et disponible pour la recherche RAG.
         indexedOn: 'Indexé le :'
       failed:
         title: Échec de l'indexation
@@ -2465,11 +2425,8 @@ onboarding:
     goToDashboard: Aller au tableau de bord
 emptyStates:
   providers:
-    title: Aucun identifiant de fournisseur pour l'instant
-    description:
-      Ajoute la clé API ou l'identifiant d'environnement avec lequel un
-      fournisseur AI s'authentifie, et ses modèles deviennent disponibles dans
-      les chats et les agents.
+    title: Connecte ton premier fournisseur AI
+    description: Ajoute une clé API et ton équipe peut commencer à discuter avec ses modèles.
   connectors:
     title: Aucun connector connecté pour l'instant
     description:
@@ -2502,7 +2459,7 @@ emptyStates:
       ressources au sein de ton organisation.
   apiKeys:
     title: Aucune clé API pour l'instant
-    description: Crée une clé API pour activer les connectors externes via l'API REST
+    description: Génère une clé pour que les outils et scripts externes puissent se connecter à ce workspace.
 governance:
   title: Gouvernance
   toastSavedTitle: Modifications enregistrées
@@ -4077,7 +4034,7 @@ metrics:
     emptyDescription: Choisis un projet pour afficher ses métriques.
 humanInputRequest:
   questionTitle: Question
-  submit: Soumettre la réponse
+  submit: Envoyer la réponse
   statusResponded: Répondu
   statusProcessing: Traitement
   respondedByAt: Répondu par {name} le {date}
@@ -4166,9 +4123,7 @@ knowledgeEntries:
     deleteError: Échec de la suppression de l'entrée de connaissances
   delete:
     title: Supprimer l'entrée de connaissances
-    confirmation: Es-tu sûr de vouloir supprimer cette entrée de connaissances ?
-      Elle sera aussi retirée de la base de connaissances et les agents ne
-      pourront plus la trouver. Cette action est irréversible.
+    confirmation: Supprimer cette entrée ? Les agents ne pourront plus la retrouver dans la base de connaissances.
   viewDialog:
     title: Détails de l'entrée de connaissances
     indexingStatus: Statut d'indexation
@@ -4736,6 +4691,7 @@ products:
     imageUrlPlaceholder: https://example.com/image.jpg
     uploadImage: Téléverser une image
     removeImage: Supprimer l'image
+    pasteUrl: Ou coller une URL
     imageTooLarge: L'image est trop volumineuse (max. 5 Mo).
     imageUploadFailed: Échec du téléversement de l'image. Réessaie.
     currencyPlaceholder: EUR
@@ -4767,6 +4723,8 @@ products:
       basics: Bases
       pricing: Prix et stock
       review: Vérification
+    basicsHint: Commence par le nom, la description et l'image.
+    pricingHint: Ajoute le prix, le stock et la catégorie.
     reviewHint: Vérifie les détails, puis crée le produit.
   import:
     uploadProducts: Téléverser des produits
@@ -5855,8 +5813,6 @@ settings:
         pas le domaine de la vitrine.
       endpointHelpGeneric: L'origine https de l'instance à laquelle appartiennent ces identifiants.
   enterpriseSso:
-    description: Authentification unique (OIDC, OAuth2, SAML) et provisionnement
-      SCIM des utilisateurs et des groupes.
     connected: La connexion est activée.
     copied: Copié dans le presse-papiers
     copy: Copier
@@ -6114,8 +6070,8 @@ settings:
       nothingToRefresh:
         Tous les catalogues sont livrés avec la plateforme — il n'y a
         rien à actualiser.
-      refreshFailed: "Impossible d'actualiser les catalogues : {error}"
-      listFailed: 'Impossible de charger les connectors de fournisseurs : {error}'
+      refreshFailed: Impossible d’actualiser les catalogues.
+      listFailed: Impossible de charger les fournisseurs.
     harnesses:
       title: Harnesses
       description:
@@ -6134,7 +6090,7 @@ settings:
       degraded: En échec récemment
       subscriptionVia: Abonnement · {provider}
       subscriptionInert: Abonnement · {provider} — inutilisable, ce harness ne tourne qu'avec des identifiants gérés
-      listFailed: "Impossible de charger l'état des harnesses : {error}"
+      listFailed: Impossible de charger l’état des agents.
     apiFormat:
       openai: API compatible OpenAI
       anthropic: API Anthropic Messages
@@ -7766,10 +7722,8 @@ projects:
   files:
     title: Fichiers
     addButton: Ajouter un fichier
-    emptyTitle: Aucun fichier pour l'instant
-    emptyDescription:
-      Téléverse du matériel de référence pour le rendre accessible à
-      chaque chat de ce projet.
+    emptyTitle: Ajouter des fichiers à ce projet
+    emptyDescription: Téléverse des docs, des specs ou tout autre contexte — chaque chat de ce projet pourra y faire référence.
     ragStatusQueued: En file d'attente
     ragStatusQueuedHint: En attente pour devenir consultable dans le chat.
     ragStatusRunning: Indexation…
@@ -7821,16 +7775,10 @@ projects:
     agentsHeading: Agents
     modelsHeading: Modèles
     connectorsHeading: Connectors
-    sectionDescription:
-      Crée les agents qui travaillent dans ce projet — choisis le harness sur
-      lequel chacun tourne, équipe-le de skills et de connectors, et donne-lui
-      des instructions permanentes. Tout le monde ici voit les mêmes agents, et
-      les tâches peuvent leur être assignées.
+    sectionDescription: Agents rattachés à ce projet, chacun avec son propre modèle, ses skills et ses instructions.
     newAgent: Nouvel agent
-    emptyTitle: Pas encore d'agents
-    emptyBody:
-      Crée un premier agent — un exécutant nommé de ce projet, avec son propre
-      équipement et ses propres instructions.
+    emptyTitle: Ajouter un agent à ce projet
+    emptyBody: Les agents exécutent des tâches en ton nom — donne-en un avec un modèle, des skills et des instructions pour commencer.
     equippedCount: '{count, plural, one {# équipé} other {# équipés}}'
     rowEdit: Modifier l'agent
     rowDelete: Supprimer l'agent
@@ -7948,6 +7896,7 @@ projects:
   dangerZone:
     title: Zone de danger
     description: Actions destructrices pour ce projet.
+    archiveSectionTitle: Archive
     archiveHelp: L'archivage masque le projet et ses chats des listes quotidiennes ; tu peux le restaurer ici à tout moment.
     restoreHelp: La restauration ramène le projet et ses chats dans les listes quotidiennes.
     deleteHelp: La suppression retire définitivement le projet, y compris ses fichiers et ses réglages. Cette action est irréversible.


### PR DESCRIPTION
The automations list had a `SectionHeader` that duplicated the page title already rendered by `AdaptiveHeaderTitle` one level up, and the create button disappeared entirely on an empty list — so a fresh org had no way to start. The header chrome now hides when the list is empty, and the create button moves into the empty state's action so it's always reachable.

Catalog load errors had no recovery path — once a listing failed the only option was a full page reload. `CatalogView` now accepts an `onRetry` prop and renders an inline "Try again" link alongside the error. Harness status uses this immediately, swapping its raw `mapCredentialError` alert for the shared component with a refetch.

Credential error messages were leaking Convex runtime dumps into the Settings UI — `[CONVEX A(…)]`, `Server Error`, absolute module paths, request IDs. Settings pages now detect opaque server strings and replace them with a short "Something went wrong. Reload and try again." so the alert stays readable.

Archive lived inside the danger zone alongside delete, which made a reversible shelf action feel as consequential as an irreversible cascade. Archive moves into its own `ProjectArchiveSection` above the red zone, and the archive dialog drops its amber `warning` variant — it's not a destructive action and the visual weight said otherwise.

The product image field was a plain URL input with a hidden file input bolted on. It's now a clickable/droppable zone that shows the image at full size with a hover overlay to change it, and "paste a URL" toggles as a secondary option below. The create wizard gains per-step description hints in the dialog header so the current step's purpose is visible without reading ahead.

`SettingsRow` had `items-center` on its responsive flex layout, which pushed multi-line control content (budget rows, SSO fields) up and misaligned the label. Flipped to `items-start`; `SettingsSection`'s header row had the same mismatch in the opposite direction and is corrected symmetrically. The WebDAV create button moves from an inline `Row` into the section's `action` slot to match every other settings section. The budget override hint moves below the table where it reads as a footnote rather than a heading.

`SectionHeader` descriptions now cap at `max-w-prose` so long descriptions don't stretch across the full content width when there's no action beside them. The wizard back button changes from `ghost` to `secondary` so it reads as a real nav control rather than a ghost link. The dialog body scroll wrapper is skipped when there are no children, removing a spurious empty `div` from footerless dialogs.

`EnvVarListEditor` replaced its `Table`/`TableRow`/`TableCell` rows with plain flex `div` rows. `TableCell` padding was indenting the key/value inputs relative to the surrounding settings section labels — the flex layout keeps them flush.

Locale copy pass across EN/DE/FR: ~170 improvements — dropped "Merci de" / "avec succès" / "successfully", simplified verbose confirmation dialogs to direct questions, tightened empty states and toasts.