### PR TITLE
feat(platform): scope project metrics with a visible picker

### DIFF
--- a/services/platform/app/components/metrics/metrics-period-select.tsx
+++ b/services/platform/app/components/metrics/metrics-period-select.tsx
@@ -34,9 +34,16 @@ interface MetricsPeriodSelectProps {
    */
   defaultValue?: MetricsPeriodOption;
   /**
-   * A page's own dimensions (a project picker, a granularity switch),
-   * rendered as sections of the SAME filter button ahead of the period — a
-   * metrics toolbar carries one filter control, never a row of selects.
+   * A page's own OPTIONAL narrowing dimensions (an agent facet, a granularity
+   * switch), rendered as sections of the SAME filter button ahead of the
+   * period — a metrics toolbar carries one filter control, never a row of
+   * selects.
+   *
+   * A required SCOPE — the subject the whole page reports on, without which it
+   * renders an empty state — does not belong here: behind a button labelled
+   * "Filter" the choice reads as optional, and the live scope can't be read
+   * without reopening the panel. Give it `MetricsScopeSelect` beside this
+   * control instead.
    */
   extraFilters?: FilterConfig[];
 }

--- a/services/platform/app/components/metrics/metrics-scope-select.test.tsx
+++ b/services/platform/app/components/metrics/metrics-scope-select.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MetricsScopeOption } from '@/app/components/metrics/metrics-scope';
+import { MetricsScopeSelect } from '@/app/components/metrics/metrics-scope-select';
+import { render, screen, within } from '@/tests/utils/render';
+
+const PROJECTS: MetricsScopeOption[] = [
+  { value: 'p1', label: 'Getting started' },
+  { value: 'p2', label: 'Website migration' },
+];
+
+function renderScope(
+  overrides: Partial<React.ComponentProps<typeof MetricsScopeSelect>> = {},
+) {
+  const onValueChange = vi.fn();
+  return {
+    onValueChange,
+    ...render(
+      <MetricsScopeSelect
+        label="Project"
+        options={PROJECTS}
+        value={undefined}
+        onValueChange={onValueChange}
+        placeholder="Select a project"
+        searchPlaceholder="Search projects"
+        emptyText="No projects found"
+        {...overrides}
+      />,
+    ),
+  };
+}
+
+// The scope select exists because the project picker used to be a section of
+// the "Filter" popover: a required subject hidden behind an optional-sounding
+// control, invisible once chosen. These tests pin both halves of the fix —
+// the picker is reachable without opening anything, and the live scope is
+// readable straight off the toolbar.
+describe('MetricsScopeSelect', () => {
+  it('offers the picker without opening a filter popover', () => {
+    renderScope();
+    expect(
+      screen.getByRole('button', { name: 'Select a project' }),
+    ).toBeInTheDocument();
+  });
+
+  it('names the scoped subject and its dimension on the trigger', () => {
+    renderScope({ value: 'p1' });
+    const trigger = screen.getByRole('button', {
+      name: 'Project: Getting started',
+    });
+    // Separated, not jammed: the trigger's `[&>span]:line-clamp-1` overrides a
+    // nested flex row's display, so a gap utility would render
+    // "ProjectGetting started" — the separator has to survive the cascade.
+    expect(trigger).toHaveTextContent('Project: Getting started');
+    expect(within(trigger).getByText('Project')).toBeInTheDocument();
+  });
+
+  it('lists the subjects and reports the pick', async () => {
+    const { user, onValueChange } = renderScope({ value: 'p1' });
+
+    await user.click(screen.getByRole('button', { name: /^Project:/ }));
+    const listbox = screen.getByRole('listbox', { name: 'Project' });
+    expect(
+      within(listbox).getByRole('option', { name: /Getting started/ }),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(
+      within(listbox).getByRole('option', { name: /Website migration/ }),
+    );
+    expect(onValueChange).toHaveBeenCalledWith('p2');
+  });
+
+  it('says so when there is nothing to scope to', async () => {
+    const { user } = renderScope({ options: [] });
+
+    await user.click(screen.getByRole('button', { name: 'Select a project' }));
+    expect(screen.getByText('No projects found')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/components/metrics/metrics-scope-select.tsx
+++ b/services/platform/app/components/metrics/metrics-scope-select.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
+import { selectTriggerClasses } from '@/app/components/ui/forms/select';
+import { cn } from '@/lib/utils/cn';
+
+import type { MetricsScopeOption } from './metrics-scope';
+
+interface MetricsScopeSelectProps {
+  /** Already-translated dimension name, e.g. "Project". Prefixes the value. */
+  label: string;
+  /** The subjects available to scope to. */
+  options: ReadonlyArray<MetricsScopeOption>;
+  /** Currently scoped subject, or `undefined` while the page is unscoped. */
+  value: string | undefined;
+  onValueChange: (value: string) => void;
+  /** Trigger text while nothing is scoped, e.g. "Select a project". */
+  placeholder: string;
+  /** Search field placeholder inside the popover. */
+  searchPlaceholder: string;
+  /** Shown when the search matches nothing (or there are no subjects at all). */
+  emptyText: string;
+}
+
+/**
+ * The always-visible SUBJECT of a metrics page — the dimension the whole view
+ * is scoped to (which project's KPIs am I reading?).
+ *
+ * Deliberately not a section of `MetricsPeriodSelect`'s filter button: a
+ * required scope that gates every number on the page can't live behind a
+ * control labelled "Filter", where it is neither discoverable from the empty
+ * state nor readable once chosen. Optional narrowing dimensions still belong in
+ * that one filter button — this is only for the subject itself.
+ *
+ * Sits at input height (`h-9`) so it lines up with the filter button beside it,
+ * the same way a data-table toolbar pairs its search input with filters.
+ */
+export function MetricsScopeSelect({
+  label,
+  options,
+  value,
+  onValueChange,
+  placeholder,
+  searchPlaceholder,
+  emptyText,
+}: MetricsScopeSelectProps) {
+  const selected = useMemo(
+    () =>
+      value ? options.find((option) => option.value === value) : undefined,
+    [options, value],
+  );
+
+  return (
+    <SearchableSelect
+      align="end"
+      value={value ?? null}
+      options={options}
+      onValueChange={onValueChange}
+      searchPlaceholder={searchPlaceholder}
+      emptyText={emptyText}
+      aria-label={label}
+      trigger={
+        <button
+          type="button"
+          // The trigger states the dimension, so its accessible name carries
+          // both halves ("Project: Getting started") rather than the bare value.
+          aria-label={selected ? `${label}: ${selected.label}` : placeholder}
+          className={cn(
+            selectTriggerClasses(),
+            // `w-auto` undoes the field-width default: a toolbar control is
+            // sized by its content, capped so a long project name truncates
+            // instead of pushing the filter button off the header.
+            'w-auto min-w-40 max-w-64 gap-2',
+          )}
+        >
+          {selected ? (
+            // Text flow, NOT a nested flex row: the trigger's own
+            // `[&>span]:line-clamp-1` sets `display:-webkit-box` on this direct
+            // child, which silently overrides `flex` and drops the gap — the
+            // label and value then render jammed as "ProjectGetting started".
+            // A literal separator can't be undone by that cascade, and
+            // line-clamp still truncates a long name.
+            <span className="min-w-0">
+              <span className="text-muted-foreground">{label}</span>
+              {': '}
+              {selected.label}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+          <ChevronDown className="size-4 shrink-0 opacity-50" aria-hidden />
+        </button>
+      }
+    />
+  );
+}

--- a/services/platform/app/components/metrics/metrics-scope.test.ts
+++ b/services/platform/app/components/metrics/metrics-scope.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  soleScopeValue,
+  type MetricsScopeOption,
+} from '@/app/components/metrics/metrics-scope';
+
+const ONE: MetricsScopeOption[] = [{ value: 'p1', label: 'Getting started' }];
+const TWO: MetricsScopeOption[] = [
+  { value: 'p1', label: 'Getting started' },
+  { value: 'p2', label: 'Migration' },
+];
+
+// A scope-gated metrics page (Settings → Metrics → Projects) renders its empty
+// state until a subject is chosen. With a single project that state is a dead
+// end, so the page adopts it — but never guesses between several, and never
+// while the list is loading.
+describe('soleScopeValue', () => {
+  it('adopts the only option when nothing is selected', () => {
+    expect(soleScopeValue(ONE, undefined, false)).toBe('p1');
+  });
+
+  it('leaves the choice open when several options exist', () => {
+    expect(soleScopeValue(TWO, undefined, false)).toBeUndefined();
+  });
+
+  it('never overrides an explicit selection', () => {
+    expect(soleScopeValue(ONE, 'p1', false)).toBeUndefined();
+    expect(soleScopeValue(TWO, 'p2', false)).toBeUndefined();
+  });
+
+  it('waits for the option list — a half-loaded list of one is not a scope', () => {
+    expect(soleScopeValue(ONE, undefined, true)).toBeUndefined();
+  });
+
+  it('resolves nothing when there is nothing to scope to', () => {
+    expect(soleScopeValue([], undefined, false)).toBeUndefined();
+  });
+});

--- a/services/platform/app/components/metrics/metrics-scope.ts
+++ b/services/platform/app/components/metrics/metrics-scope.ts
@@ -1,0 +1,25 @@
+/** One selectable subject for a metrics page (a project, an agent, a pack). */
+export interface MetricsScopeOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * The scope a metrics page should adopt on its own, or `undefined` to leave the
+ * choice to the operator.
+ *
+ * A scope-gated page renders nothing until a subject is picked, so with exactly
+ * ONE option and nothing selected the empty state is a pure dead end — the sole
+ * option IS the scope. Two or more stays unselected on purpose: silently
+ * scoping to an arbitrary subject invites reading one project's numbers as
+ * another's. Never resolves while the option list is still loading, since a
+ * half-loaded list of one would auto-scope to the wrong subject.
+ */
+export function soleScopeValue(
+  options: ReadonlyArray<MetricsScopeOption>,
+  selected: string | undefined,
+  isLoading: boolean,
+): string | undefined {
+  if (isLoading || selected) return undefined;
+  return options.length === 1 ? options[0]?.value : undefined;
+}

--- a/services/platform/app/features/tasks/components/project-metrics-page.tsx
+++ b/services/platform/app/features/tasks/components/project-metrics-page.tsx
@@ -12,6 +12,7 @@ import { StatCard, StatCardGrid } from '@tale/ui/stat-card-grid';
 import { Text } from '@tale/ui/text';
 import { TrendIndicator } from '@tale/ui/trend-indicator';
 import { AlertTriangle, BarChart3 } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 import {
   seriesToLegend,
@@ -26,7 +27,6 @@ import {
   type MetricsPeriodDays,
 } from '@/app/components/metrics/metrics-period';
 import { MetricsPeriodSelect } from '@/app/components/metrics/metrics-period-select';
-import type { FilterConfig } from '@/app/components/ui/data-table/data-table-filters';
 import { useFormatNumber } from '@/app/hooks/use-format-number';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -128,9 +128,11 @@ interface ProjectMetricsPageProps {
   projectId: Id<'projects'>;
   periodDays: MetricsPeriodDays;
   onChangePeriod: (period: MetricsPeriodDays) => void;
-  /** A host's own dimensions (the project picker on Settings → Metrics →
-   *  Projects), folded into the one filter button ahead of the period. */
-  extraFilters?: FilterConfig[];
+  /** The host's scope picker (the project select on Settings → Metrics →
+   *  Projects), rendered in the toolbar ahead of the period filter. The
+   *  project's own Metrics tab is already scoped by its route, so it passes
+   *  nothing. */
+  scopeControl?: ReactNode;
 }
 
 /**
@@ -150,7 +152,7 @@ interface ProjectMetricsPageProps {
 export function ProjectMetricsPage({
   periodDays,
   onChangePeriod,
-  extraFilters,
+  scopeControl,
 }: ProjectMetricsPageProps) {
   const { t } = useT('tasks');
   const { formatCostCents } = useFormatNumber();
@@ -254,11 +256,13 @@ export function ProjectMetricsPage({
         title={t('metrics.title')}
         description={t('metrics.description')}
         toolbar={
-          <MetricsPeriodSelect
-            value={String(periodDays)}
-            onValueChange={(v) => onChangePeriod(parseMetricsPeriodDays(v))}
-            {...(extraFilters !== undefined && { extraFilters })}
-          />
+          <>
+            {scopeControl}
+            <MetricsPeriodSelect
+              value={String(periodDays)}
+              onValueChange={(v) => onChangePeriod(parseMetricsPeriodDays(v))}
+            />
+          </>
         }
         notice={
           !isLoading && totals.capped ? (

--- a/services/platform/app/routes/dashboard/$id/settings/metrics/projects.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/metrics/projects.tsx
@@ -2,7 +2,7 @@ import { EmptyState } from '@tale/ui/empty-state';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { BarChart3 } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { z } from 'zod';
 
 import { MetricsLayout } from '@/app/components/metrics/metrics-layout';
@@ -13,6 +13,8 @@ import {
   type MetricsPeriodDays,
 } from '@/app/components/metrics/metrics-period';
 import { MetricsPeriodSelect } from '@/app/components/metrics/metrics-period-select';
+import { soleScopeValue } from '@/app/components/metrics/metrics-scope';
+import { MetricsScopeSelect } from '@/app/components/metrics/metrics-scope-select';
 import { useProjects } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
@@ -34,8 +36,10 @@ export const Route = createFileRoute(
  * Project metrics stay project-scoped (the rollups are per project), so this
  * section is a project picker over the SAME `ProjectMetricsPage` the project's
  * own Metrics sub-view renders — one component, two homes (#2382). The picker
- * lives in the page toolbar next to the period select, and the header stays
- * identical whether or not a project is selected.
+ * is the page's SUBJECT, so it sits in the toolbar as its own always-visible
+ * select left of the filter button — never as a section inside it, where a
+ * required choice reads as optional and the live scope is unreadable. With a
+ * single project the page scopes itself rather than parking on an empty state.
  */
 function ProjectsMetricsRoute() {
   const { id: organizationId } = Route.useParams();
@@ -86,15 +90,29 @@ function ProjectsMetricsRoute() {
     [navigate, organizationId],
   );
 
-  // A section of the ONE filter button (ahead of Period), not a standalone
-  // select — a metrics toolbar carries a single filter control.
-  const projectFilter = {
-    key: 'project',
-    title: t('projects.selectLabel'),
-    options: projectOptions,
-    selectedValues: selectedProjectId ? [selectedProjectId] : [],
-    onChange: (values: string[]) => handleSelectProject(values[0] ?? ''),
-  };
+  // The one project in a single-project org is the scope — an empty pane behind
+  // a picker teaches nothing. Runs as an effect (not a redirect in the loader)
+  // because the project list is a live client query.
+  const autoScopeId = soleScopeValue(
+    projectOptions,
+    selectedProjectId,
+    projectsLoading,
+  );
+  useEffect(() => {
+    if (autoScopeId) handleSelectProject(autoScopeId);
+  }, [autoScopeId, handleSelectProject]);
+
+  const scopeSelect = (
+    <MetricsScopeSelect
+      label={t('projects.selectLabel')}
+      options={projectOptions}
+      value={selectedProjectId}
+      onValueChange={handleSelectProject}
+      placeholder={t('projects.selectPlaceholder')}
+      searchPlaceholder={t('projects.searchPlaceholder')}
+      emptyText={t('projects.searchEmpty')}
+    />
+  );
 
   // `fullWidth`: `ProjectMetricsPage` lays its charts out on a two-column
   // grid designed for the full pane, wider than the `max-w-3xl` standard
@@ -107,7 +125,7 @@ function ProjectsMetricsRoute() {
       <SettingsPage fullWidth>
         <Skeletonize loading={projectsLoading}>
           <ProjectMetricsPage
-            extraFilters={[projectFilter]}
+            scopeControl={scopeSelect}
             projectId={selectedProjectId}
             periodDays={periodDays}
             onChangePeriod={handleChangePeriod}
@@ -128,13 +146,15 @@ function ProjectsMetricsRoute() {
           title={tTasks('metrics.title')}
           description={tTasks('metrics.description')}
           toolbar={
-            <MetricsPeriodSelect
-              value={metricsPeriodToParam(periodDays)}
-              onValueChange={(v) =>
-                handleChangePeriod(parseMetricsPeriodDays(v))
-              }
-              extraFilters={[projectFilter]}
-            />
+            <>
+              {scopeSelect}
+              <MetricsPeriodSelect
+                value={metricsPeriodToParam(periodDays)}
+                onValueChange={(v) =>
+                  handleChangePeriod(parseMetricsPeriodDays(v))
+                }
+              />
+            </>
           }
           className="min-h-0 flex-1"
         >

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -3987,6 +3987,9 @@ metrics:
     allTime: Gesamter Zeitraum
   projects:
     selectLabel: Projekt
+    selectPlaceholder: Projekt auswählen
+    searchPlaceholder: Projekte durchsuchen
+    searchEmpty: Keine Projekte gefunden
     emptyTitle: Projekt auswählen
     emptyDescription: Wähle ein Projekt, um seine Metriken zu sehen.
 humanInputRequest:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -3839,6 +3839,9 @@ metrics:
     allTime: All time
   projects:
     selectLabel: Project
+    selectPlaceholder: Select a project
+    searchPlaceholder: Search projects
+    searchEmpty: No projects found
     emptyTitle: Select a project
     emptyDescription: Choose a project to view its metrics.
 humanInputRequest:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -4060,6 +4060,9 @@ metrics:
     allTime: Tout l'historique
   projects:
     selectLabel: Projet
+    selectPlaceholder: Sélectionner un projet
+    searchPlaceholder: Rechercher un projet
+    searchEmpty: Aucun projet trouvé
     emptyTitle: Sélectionner un projet
     emptyDescription: Choisis un projet pour afficher ses métriques.
 humanInputRequest:

--- a/services/platform/tests/e2e/specs/metrics.spec.ts
+++ b/services/platform/tests/e2e/specs/metrics.spec.ts
@@ -124,21 +124,30 @@ test('automations tab renders translated KPIs, charts, and table', async ({
   await expectNoRawI18nKeys(page);
 });
 
-test('projects tab renders the picker in the toolbar and a stable header', async ({
+test('projects tab exposes the scope picker outside the filter button', async ({
   page,
   org,
 }) => {
   await page.goto(`${metricsBase(org.organizationId)}/projects`);
 
-  // The header is identical with and without a selected project; a fresh org
-  // has no task projects, so the empty state renders under it.
+  // The header is identical with and without a selected project.
   await expect(
     page.getByRole('heading', { name: t('tasks.metrics.title'), level: 3 }),
   ).toBeVisible({ timeout: TIMEOUT.FIRST_PAINT });
-  // The project picker is a section of the shared toolbar filter button
-  // (ahead of Period), not a standalone select; opening the button proves
-  // `metrics.projects.selectLabel` resolves — its section header is a plain
-  // button named by the translated title.
+  // The project picker is the page's SUBJECT, so it stands in the toolbar as
+  // its own select — reachable with nothing opened. A fresh org is seeded with
+  // exactly one project, so the page scopes itself to it rather than parking on
+  // the empty state: the trigger names the dimension AND the live scope
+  // ("Project: <seeded name>"), which the bare placeholder never would. Matched
+  // by prefix so the seed can rename its project.
+  await expect(
+    page.getByRole('button', {
+      name: new RegExp(`^${t('metrics.projects.selectLabel')}: .+`),
+    }),
+  ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
+  // …and it is NOT also a section of the filter button, which now offers the
+  // period alone. A required scope behind a control labelled "Filter" is the
+  // regression this guards.
   const filterButton = page.getByRole('button', {
     name: t('common.labels.filter'),
     exact: true,
@@ -146,17 +155,24 @@ test('projects tab renders the picker in the toolbar and a stable header', async
   await expect(filterButton).toBeVisible({ timeout: TIMEOUT.VISIBLE });
   await filterButton.click();
   await expect(
+    page.getByRole('button', { name: t('metrics.period.label'), exact: true }),
+  ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
+  await expect(
     page.getByRole('button', {
       name: t('metrics.projects.selectLabel'),
       exact: true,
     }),
-  ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
+  ).toBeHidden();
   await page.keyboard.press('Escape');
+  // Scoped, so the "Select a project" dead end is gone and the KPIs render.
   await expect(
     page.getByRole('heading', {
       name: t('metrics.projects.emptyTitle'),
       level: 3,
     }),
+  ).toBeHidden();
+  await expect(
+    page.getByText(t('tasks.metrics.cumulativeFlow'), { exact: true }),
   ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
 
   await expectNoRawI18nKeys(page);


### PR DESCRIPTION
## Problem

On **Settings → Metrics → Projects** the project picker was a section of the toolbar's `Filter` button. A required scope was modelled as an optional filter, with two consequences:

- The gate was undiscoverable. The empty state read *"Select a project"* but offered no affordance — the only path was a button labelled `Filter`.
- Once a project was chosen, its name appeared nowhere on the page. The header still read *"Project metrics"*, so the live scope was only visible by reopening the popover.

## Change

The picker is now the page's **subject**, not a filter.

- `MetricsScopeSelect` — an always-visible toolbar control reading `Project: <name>`, built on the existing `SearchableSelect` (same primitive as the project breadcrumb switcher), so it stays searchable when an org has many projects. It sits at input height beside the filter button, the way a data-table toolbar pairs its search input with filters.
- The filter button now offers the period alone. `MetricsPeriodSelect`'s doc carves required scopes out of the "one filter control, never a row of selects" rule so the next change doesn't re-bury a subject in the popover.
- `ProjectMetricsPage`'s `extraFilters` seam became a `scopeControl` slot. The project's own Metrics tab passes nothing — its route already scopes it.
- `soleScopeValue`: with exactly one project the page adopts it rather than parking on a dead-end empty state. Two or more stays unselected, so nobody reads one project's numbers as another's.

## Note on the trigger markup

The label and value compose as text flow rather than a nested flex row. `selectTriggerClasses()` carries `[&>span]:line-clamp-1`, which sets `display:-webkit-box` on the direct child and silently overrides `flex`, dropping the gap — the trigger then renders `ProjectGetting started`. Caught in a browser; the unit test now asserts the separator survives.

## Tests

- `metrics-scope.test.ts` — the auto-scope rule: adopts a sole option, never guesses between several, never resolves mid-load.
- `metrics-scope-select.test.tsx` — picker reachable with nothing opened, trigger names dimension + scope, selection reported, empty case.
- `metrics.spec.ts` (e2e) — rewritten. Its old premise ("a fresh org has no task projects") was stale: the wizard seeds one, so the auto-scope path is what renders. Now pins picker-outside-the-filter, `Project: <scope>` on the trigger, Project section *absent* from the filter panel, and KPIs painted instead of the empty state.
- Verified in a browser against a running deployment.

## Pre-existing failure, not from this branch

`lib/i18n/messages.test.ts` fails on `main` at `121a11b3d` with 2 errors, reproduced on a pristine baseline worktree with none of this branch applied: `auth.userButton.logOutConfirm.description` is referenced by source but no longer in the catalogs, and `products.create.description` is orphaned. Fixed separately.