### PR TITLE
fix(platform): list only managed-capable harnesses

### DIFF
--- a/services/platform/app/features/settings/providers/components/harness-status-section.test.tsx
+++ b/services/platform/app/features/settings/providers/components/harness-status-section.test.tsx
@@ -12,9 +12,9 @@ import { HarnessStatusSection } from './harness-status-section';
  * Component coverage for the harness status section: rows render
  * the managed verdict (pool + default, or the unavailability reason), a
  * subscription badge names its provider and flags an inert binding, and the
- * health signal marks a degraded harness. The derivation itself is covered
- * by the convex-side `harness_status.test.ts`; the hooks are stubbed at the
- * module boundary.
+ * health signal marks a degraded harness. Bring-your-own-only harnesses are
+ * omitted upstream. The derivation itself is covered by the convex-side
+ * `harness_status.test.ts`; the hooks are stubbed at the module boundary.
  */
 
 const fixtures = vi.hoisted(() => ({
@@ -58,12 +58,6 @@ const ROWS: HarnessStatus[] = [
     subscriptions: [{ providerSlug: 'zai', usable: true }],
   },
   {
-    slug: 'cursor',
-    label: 'Cursor',
-    managed: { available: false, reason: 'byo-only' },
-    subscriptions: [],
-  },
-  {
     slug: 'opencode',
     label: 'OpenCode',
     managed: { available: false, reason: 'no-direct-credential' },
@@ -86,7 +80,7 @@ function renderSection() {
 }
 
 describe('HarnessStatusSection', () => {
-  it('shows the managed verdict with the pool and the fallback default', () => {
+  it('shows the managed pool and the fallback default', () => {
     fixtures.status = ROWS;
     fixtures.health = [];
     fixtures.statusError = null;
@@ -94,24 +88,18 @@ describe('HarnessStatusSection', () => {
     renderSection();
 
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
-    expect(screen.getByText('Managed')).toBeInTheDocument();
     expect(
       screen.getByText('2 models · default deepseek/deepseek-v3.2'),
     ).toBeInTheDocument();
   });
 
-  it('explains an unavailable managed lane with its reason', () => {
+  it('explains a missing direct credential', () => {
     fixtures.status = ROWS;
     fixtures.health = [];
     fixtures.statusError = null;
 
     renderSection();
 
-    expect(
-      screen.getByText(
-        "Needs its own vendor credential — platform-managed keys can't run it.",
-      ),
-    ).toBeInTheDocument();
     expect(
       screen.getByText(
         'No directly usable provider credential yet — add an API key or an environment credential above.',

--- a/services/platform/app/features/settings/providers/components/harness-status-section.tsx
+++ b/services/platform/app/features/settings/providers/components/harness-status-section.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 /**
- * Read-only status of every shipped harness for this organization: how the
- * managed lane resolves for it (the direct-served model pool and the default
- * a turn falls back to), which vendor subscriptions are bound to it —
- * flagging an inert binding — and whether the health signal currently marks
- * it as failing.
+ * Read-only status of every managed-capable shipped harness for this
+ * organization: how the managed lane resolves for it (the direct-served
+ * model pool and the default a turn falls back to), which vendor
+ * subscriptions are bound to it — flagging an inert binding — and whether
+ * the health signal currently marks it as failing.
  *
- * The configuration truth lives in the provider credentials above; this panel
- * only SHOWS the resolution, so there is nothing here to edit.
+ * Bring-your-own-only harnesses are omitted upstream; this panel only SHOWS
+ * the resolution for harnesses the org can actually configure above.
  */
 
 import { Badge } from '@tale/ui/badge';
@@ -54,20 +54,15 @@ function HarnessRow({
       </div>
       <div className="flex flex-wrap items-center gap-2">
         {row.managed.available ? (
-          <>
-            <Badge variant="green">{t('providers.harnesses.managed')}</Badge>
-            <span className="text-muted-foreground text-xs">
-              {t('providers.harnesses.modelPool', {
-                count: row.managed.modelCount,
-                model: row.managed.defaultModelId,
-              })}
-            </span>
-          </>
+          <span className="text-muted-foreground text-xs">
+            {t('providers.harnesses.modelPool', {
+              count: row.managed.modelCount,
+              model: row.managed.defaultModelId,
+            })}
+          </span>
         ) : (
           <span className="text-muted-foreground text-xs">
-            {row.managed.reason === 'byo-only'
-              ? t('providers.harnesses.byoOnly')
-              : t('providers.harnesses.noDirectCredential')}
+            {t('providers.harnesses.noDirectCredential')}
           </span>
         )}
         {row.subscriptions.map((sub) => (

--- a/services/platform/convex/lib/providers/harness_status.test.ts
+++ b/services/platform/convex/lib/providers/harness_status.test.ts
@@ -52,17 +52,20 @@ describe('deriveHarnessStatus — against the real shipped harness facts', () =>
     });
   });
 
-  it('marks a byo-only harness (cursor) managed-unavailable even with models', () => {
+  it('omits byo-only harnesses (cursor) from the status list', () => {
     const rows = deriveHarnessStatus({
       harnesses: HARNESSES,
       directModels: DIRECT,
       subscriptions: [],
     });
 
-    expect(entryOf(rows, 'cursor').managed).toEqual({
-      available: false,
-      reason: 'byo-only',
-    });
+    expect(rows.some((row) => row.slug === 'cursor')).toBe(false);
+    expect(
+      rows.every((row) => {
+        const harness = HARNESSES.find((entry) => entry.slug === row.slug);
+        return harness?.credentialPolicy.managed === true;
+      }),
+    ).toBe(true);
   });
 
   it('reports the missing direct credential when nothing is direct-served', () => {
@@ -75,11 +78,6 @@ describe('deriveHarnessStatus — against the real shipped harness facts', () =>
     expect(entryOf(rows, 'claude-code').managed).toEqual({
       available: false,
       reason: 'no-direct-credential',
-    });
-    // A byo-only harness stays byo-only — the sharper reason wins.
-    expect(entryOf(rows, 'cursor').managed).toEqual({
-      available: false,
-      reason: 'byo-only',
     });
   });
 

--- a/services/platform/convex/lib/providers/harness_status.ts
+++ b/services/platform/convex/lib/providers/harness_status.ts
@@ -2,9 +2,13 @@
 
 /**
  * The per-harness status the AI-providers settings page shows: how each
- * shipped harness would run for THIS organization — the managed lane's
- * verdict with its model pool, and any vendor subscription credentials
- * bound to it.
+ * managed-capable shipped harness would run for THIS organization — the
+ * managed lane's verdict with its model pool, and any vendor subscription
+ * credentials bound to it.
+ *
+ * Bring-your-own-only harnesses (Cursor today) are omitted: they cannot use
+ * platform-managed keys, have no vendor credential setup in Providers, and
+ * cannot be selected for agents — listing them only misleads.
  *
  * READ-ONLY aggregation: the configuration truth stays in the org's provider
  * credentials and the shipped harness facts. Every verdict is asked of
@@ -45,7 +49,7 @@ const harnessManagedStatusValidator = v.union(
   }),
   v.object({
     available: v.literal(false),
-    reason: v.union(v.literal('byo-only'), v.literal('no-direct-credential')),
+    reason: v.literal('no-direct-credential'),
   }),
 );
 
@@ -90,7 +94,7 @@ function neutralModelEntry(id: string): ModelCatalogEntry {
 /**
  * Pure derivation, exported for the unit tests: shipped harness facts ×
  * the org's direct-served model pool × its subscription credentials →
- * one status row per harness, sorted by label.
+ * one status row per managed-capable harness, sorted by label.
  */
 export function deriveHarnessStatus(inputs: {
   harnesses: readonly HarnessDefinition[];
@@ -104,27 +108,17 @@ export function deriveHarnessStatus(inputs: {
   const probe = neutralModelEntry(firstDirect?.id ?? 'none');
 
   return [...inputs.harnesses]
+    .filter((harness) => harness.credentialPolicy.managed)
     .sort((a, b) => a.displayName.localeCompare(b.displayName))
     .map((harness) => {
-      const managedVerdict = resolveExecution(
-        {
-          model: probe,
-          credential: { authMethod: 'api-key' },
-          mode: 'sandbox',
-          harness: harness.slug,
-        },
-        table,
-      );
       const managed: HarnessStatusEntry['managed'] =
-        managedVerdict.mode !== 'sandbox'
-          ? { available: false, reason: 'byo-only' }
-          : firstDirect === undefined
-            ? { available: false, reason: 'no-direct-credential' }
-            : {
-                available: true,
-                modelCount: inputs.directModels.length,
-                defaultModelId: firstDirect.id,
-              };
+        firstDirect === undefined
+          ? { available: false, reason: 'no-direct-credential' }
+          : {
+              available: true,
+              modelCount: inputs.directModels.length,
+              defaultModelId: firstDirect.id,
+            };
 
       // One row per provider: several credentials of one vendor bound to the
       // same harness collapse, usable when any of them is.
@@ -155,9 +149,9 @@ export function deriveHarnessStatus(inputs: {
 }
 
 /**
- * The status of every shipped harness for one org. Gated like the rest of
- * the AI-providers settings page; the listing is non-secret capability
- * metadata — credential SHAPES and counts, never secret material.
+ * The status of every managed-capable shipped harness for one org. Gated
+ * like the rest of the AI-providers settings page; the listing is non-secret
+ * capability metadata — credential SHAPES and counts, never secret material.
  */
 export const listHarnessStatus = action({
   args: { organizationId: v.string() },

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -5970,10 +5970,7 @@ settings:
     harnesses:
       title: Agent-Laufzeiten
       description: Wie jede Agent-Laufzeit für diese Organisation konfiguriert ist — welche Modelle verfügbar sind und welche Anbieter-Abos daran gebunden sind. Konfiguriere dies über die Anbieter-Zugangsdaten oben.
-      managed: Verwaltet
       modelPool: '{count, plural, one {# Modell} other {# Modelle}} · Standard: {model}'
-      byoOnly: Braucht eigene Anbieter-Zugangsdaten — mit plattformverwalteten
-        Schlüsseln läuft es nicht.
       noDirectCredential:
         Noch keine direkt nutzbaren Anbieter-Zugangsdaten — füge oben einen
         API-Schlüssel oder eine Umgebungsvariable hinzu.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6075,9 +6075,7 @@ settings:
     harnesses:
       title: Agent runtimes
       description: How each agent runtime is configured for this organization — the models available and any vendor subscriptions bound to it. Configure this through provider credentials above.
-      managed: Managed
       modelPool: '{count, plural, one {# model} other {# models}} · default {model}'
-      byoOnly: Needs its own vendor credential — platform-managed keys can't run it.
       noDirectCredential:
         No directly usable provider credential yet — add an API key or an
         environment credential above.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6107,11 +6107,7 @@ settings:
         modèles que la plateforme lui fournit directement et les abonnements
         fournisseur qui lui sont liés. Cette vue montre seulement la
         résolution ; la configuration passe par les identifiants ci-dessus.
-      managed: Géré
       modelPool: '{count, plural, one {# modèle} other {# modèles}} · {model} par défaut'
-      byoOnly:
-        Exige les identifiants de son propre fournisseur — les clés gérées
-        par la plateforme ne le font pas tourner.
       noDirectCredential:
         Aucun identifiant de fournisseur directement utilisable — ajoute une
         clé API ou une variable d'environnement ci-dessus.


### PR DESCRIPTION
## Problem

The **Agent runtimes** panel on Settings → AI providers listed bring-your-own-only harnesses alongside the rest, annotated *"Needs its own vendor credential — platform-managed keys can't run it."* That is a row an admin can do nothing about, in a panel whose entire subject is how the **managed** lane resolves for this org.

## Change

Filter BYO-only harnesses out where the status is derived, so the listing carries only harnesses the org can actually configure through the credentials above.

With every remaining row managed-capable, the `Managed` badge stops distinguishing anything, so it goes too — the model pool becomes the row's signal. `deriveHarnessStatus` no longer resolves an execution for the managed verdict; availability is now decided by whether a direct credential exists.

## Why frontend, backend, and copy are one commit

The unavailability reason narrows in the public return validator:

```diff
-reason: v.union(v.literal('byo-only'), v.literal('no-direct-credential')),
+reason: v.literal('no-direct-credential'),
```

The frontend consumes that validator's inferred type (`HarnessStatus` via `FunctionReturnType`), so the halves are coupled in both directions — backend alone makes the old `reason === 'byo-only'` comparison a no-overlap type error; frontend alone would render the wrong sentence for a harness the action still returns. The two `harnesses.managed` / `harnesses.byoOnly` keys lose their only references here, and the catalog gate enforces both usage-missing and orphans, so the removals cannot lag or lead this change either.

## Verification

`harness_status.test.ts` and `harness-status-section.test.tsx` updated and green; typecheck clean.

## Pre-existing failures on `main`, not from this branch

Reproduced on a pristine worktree at `121a11b3d`:
- `messages.test.ts` — 2 failures (`auth.userButton.logOutConfirm.description` missing, `products.create.description` orphaned). Fixed in #2901.
- `providers-settings.test.tsx` — `surfaces a whole-catalog failure instead of an empty table`. Untouched here; the correct behaviour is a call for whoever landed the credential-error rework.