### PR TITLE
fix(ui): give a section header's description the full width

### DIFF
--- a/packages/ui/src/components/layout/section-header.test.tsx
+++ b/packages/ui/src/components/layout/section-header.test.tsx
@@ -50,6 +50,24 @@ describe('SectionHeader', () => {
       expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
     });
 
+    it('keeps the description full-width when an action is present', () => {
+      // Regression: description used to sit in the title column beside the
+      // action, so a long trailing badge squeezed copy into a narrow stack.
+      const { container } = render(
+        <SectionHeader
+          title="sync"
+          description="List new messages from the named mail connector."
+          action={<span>conversation.sync_mailbox</span>}
+        />,
+      );
+      const root = container.firstElementChild;
+      expect(root).toHaveClass('flex', 'flex-col');
+      const description = screen.getByText(
+        'List new messages from the named mail connector.',
+      );
+      expect(description.parentElement).toBe(root);
+    });
+
     it('renders ReactNode title', () => {
       render(
         <SectionHeader

--- a/packages/ui/src/components/layout/section-header.tsx
+++ b/packages/ui/src/components/layout/section-header.tsx
@@ -52,33 +52,47 @@ export const SectionHeader = forwardRef<HTMLDivElement, SectionHeaderProps>(
     },
     ref,
   ) => {
-    const titleContent = (
-      <div className="flex flex-col gap-1">
-        <Tag className={titleVariants({ size, weight })}>{title}</Tag>
-        {description && (
-          <Description className="max-w-prose text-sm">
-            {description}
-          </Description>
-        )}
-      </div>
-    );
-
+    // Title and action share one row; description always spans the full width
+    // below. Putting the description beside a trailing action squeezed long
+    // copy into a narrow column (e.g. a node inspector with a long type badge).
+    // `max-w-prose` still caps the measure — full width is about escaping the
+    // title column, not about letting a line run the width of the page.
     if (action) {
       return (
         <div
           ref={ref}
-          className={cn('flex items-center justify-between gap-4', className)}
+          className={cn('flex flex-col gap-1', className)}
           {...props}
         >
-          {titleContent}
-          <div className="shrink-0">{action}</div>
+          <div className="flex items-start justify-between gap-4">
+            <Tag
+              className={cn(titleVariants({ size, weight }), 'min-w-0 flex-1')}
+            >
+              {title}
+            </Tag>
+            <div className="shrink-0">{action}</div>
+          </div>
+          {description ? (
+            <Description className="max-w-prose text-sm">
+              {description}
+            </Description>
+          ) : null}
         </div>
       );
     }
 
     return (
-      <div ref={ref} className={className} {...props}>
-        {titleContent}
+      <div
+        ref={ref}
+        className={cn('flex flex-col gap-1', className)}
+        {...props}
+      >
+        <Tag className={titleVariants({ size, weight })}>{title}</Tag>
+        {description ? (
+          <Description className="max-w-prose text-sm">
+            {description}
+          </Description>
+        ) : null}
       </div>
     );
   },


### PR DESCRIPTION
## Problem

When a `SectionHeader` carries a trailing action, the title and description shared one column beside it. Long description copy got squeezed into whatever width the action left over — worst where the action is wide, such as a node inspector whose badge carries a long node type.

## Change

Title and action now share a row; the description spans the full width below it. Both the action and no-action branches use the same `flex flex-col gap-1` root, so the two paths no longer fork their markup and the description sits at the same DOM depth in each.

`max-w-prose` is kept on the description. Full width here means escaping the title column — not letting a line run the width of the page.

## Note for reviewers

This rebases onto #2897, which added `max-w-prose` to the same element. Both changes are wanted and they compose: #2897 caps the measure, this one frees the column. The merge keeps the cap in both branches.

## Verification

`section-header.test.tsx` — 23 passing, including a new case pinning a full-width description alongside an action. Checked that the new case genuinely fails against the pre-change component rather than passing vacuously.

`SectionHeaderProps` is unchanged, so this is internal restructuring — no consumer edits required. Indirect consumers through `PageSection` and `StickySectionHeader` were checked; their suites assert on the wrapper elements, not this internal layout.