### PR TITLE
fix(ui): paint stat-card grid dividers with a gap

### DIFF
--- a/packages/ui/src/components/data-display/stat-card-grid.stories.tsx
+++ b/packages/ui/src/components/data-display/stat-card-grid.stories.tsx
@@ -15,7 +15,9 @@ const meta: Meta<typeof StatCardGrid> = {
         component: `
 A bordered, divided strip of headline metrics. Pass already formatted/translated
 strings; each \`StatCard\` masks its value while a surrounding \`<Skeletonize loading>\`
-is active so the strip height never shifts.
+is active so the strip height never shifts. Dividers come from a 1px grid gap over
+a border-colored background, so wrapped rows keep full-length rules — pick a
+\`cols\` value that fills every row.
         `,
       },
     },
@@ -49,6 +51,20 @@ export const TwoColumn: Story = {
     <StatCardGrid cols={2}>
       <StatCard label="Success rate" value="98.6%" />
       <StatCard label="Avg duration" value="1.4s" />
+    </StatCardGrid>
+  ),
+};
+
+/** Six metrics in a filled 3×2 strip (avoids a short last row). */
+export const ThreeColumnWrapped: Story = {
+  render: () => (
+    <StatCardGrid cols={3}>
+      <StatCard label="Total turns" value="1,240" />
+      <StatCard label="Success rate" value="94%" />
+      <StatCard label="Timeout rate" value="2%" />
+      <StatCard label="p95 duration" value="12.0s" />
+      <StatCard label="Stopped by user" value="18" />
+      <StatCard label="Recovered" value="7" />
     </StatCardGrid>
   ),
 };

--- a/packages/ui/src/components/data-display/stat-card-grid.test.tsx
+++ b/packages/ui/src/components/data-display/stat-card-grid.test.tsx
@@ -26,8 +26,19 @@ describe('StatCardGrid', () => {
       );
       expect(container.firstChild).toHaveClass(
         'md:grid-cols-4',
+        'gap-px',
         'custom-class',
       );
+    });
+
+    it('paints cell backgrounds so gap-px dividers show through', () => {
+      const { container } = render(
+        <StatCardGrid>
+          <StatCard label="A" value="1" />
+        </StatCardGrid>,
+      );
+      expect(container.firstChild).toHaveClass('bg-border-base');
+      expect(container.querySelector('.bg-bg-base')).toBeInTheDocument();
     });
 
     it('applies cols=2', () => {

--- a/packages/ui/src/components/data-display/stat-card-grid.tsx
+++ b/packages/ui/src/components/data-display/stat-card-grid.tsx
@@ -18,9 +18,15 @@ import { Text } from '../typography/text';
  * Each `StatCard` masks its value to its own line box while a surrounding
  * `<Skeletonize loading>` is active, so the strip's height is identical loading
  * vs loaded.
+ *
+ * Dividers are a 1px `gap` painted by the grid's border-colored background —
+ * that keeps vertical and horizontal rules full-length across wrapped rows,
+ * which Tailwind `divide-*` cannot do (sibling borders only span each cell).
+ * Prefer a column count that fills every row; a short last row leaves empty
+ * tracks showing the divider color.
  */
 const statCardGridVariants = cva(
-  'border-border-base divide-border-base grid divide-y rounded-lg border md:divide-x md:divide-y-0',
+  'border-border-base bg-border-base grid gap-px overflow-hidden rounded-lg border',
   {
     variants: {
       cols: {
@@ -81,7 +87,7 @@ export function StatCard({
   return (
     <div
       className={cn(
-        'flex flex-1 flex-col gap-1 p-5',
+        'bg-bg-base flex flex-1 flex-col gap-1 p-5',
         colSpan === 2 && 'col-span-2',
         className,
       )}

--- a/services/platform/app/features/analytics/external-turns/external-turns-metrics-page.test.tsx
+++ b/services/platform/app/features/analytics/external-turns/external-turns-metrics-page.test.tsx
@@ -54,9 +54,12 @@ describe('ExternalTurnMetricsPage', () => {
     );
     expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
 
-    // Success rate 15/19 ≈ 79%, timeout rate 1/19 ≈ 5%, p95 12.0s.
+    // Six SLO cards in a filled 3×2 strip.
     expect(screen.getByText('79%')).toBeInTheDocument();
     expect(screen.getByText('12.0s')).toBeInTheDocument();
+    expect(
+      screen.getByText('Total turns').closest('[class*="grid"]'),
+    ).toHaveClass('md:grid-cols-3');
 
     // The per-harness table row.
     expect(screen.getByText('claude-code')).toBeInTheDocument();

--- a/services/platform/app/features/analytics/external-turns/external-turns-metrics-page.tsx
+++ b/services/platform/app/features/analytics/external-turns/external-turns-metrics-page.tsx
@@ -88,7 +88,7 @@ export function ExternalTurnMetricsPageView({
         ) : undefined
       }
     >
-      <StatCardGrid>
+      <StatCardGrid cols={3}>
         <StatCard
           label={t('externalTurns.cards.total')}
           value={formatNumber(data?.total ?? 0)}

--- a/services/platform/app/features/analytics/feedback/feedback-summary-cards.tsx
+++ b/services/platform/app/features/analytics/feedback/feedback-summary-cards.tsx
@@ -45,7 +45,7 @@ export function FeedbackSummaryCards({
       {/* Bespoke sentiment cell: a percentage with an inline denominator and a
           positive/negative bar — too specialized for the plain StatCard, so it
           rides along as a `col-span-2` child of the same grid. */}
-      <div className="col-span-2 flex flex-col gap-3 p-5">
+      <div className="bg-bg-base col-span-2 flex flex-col gap-3 p-5">
         <Text className="text-fg-muted text-sm">
           {t('feedback.cards.sentiment')}
         </Text>


### PR DESCRIPTION
## Problem

`StatCardGrid` drew its dividers with `divide-y` / `md:divide-x`. Tailwind's `divide-*` puts a border on each cell relative to its **siblings**, which only describes a single unwrapped row — so any grid that wrapped left stub rules hanging where the row broke.

## Change

Paint the dividers instead of bordering the cells: a 1px `gap` over a border-coloured parent, clipped by `overflow-hidden`. The result reads identically however many rows the grid wraps to.

The trade-off is that cells now own their background, because the parent's colour *is* the divider. Two consumers needed updating for that, and both are in this PR so nothing regresses visually:

- **`feedback-summary-cards`** — the one place in the repo that puts a bespoke `div` directly inside the grid rather than a `StatCard`. Without a background it showed through as a border-coloured block.
- **`external-turns-metrics-page`** — six cards in the default four-column grid, so the last row left two empty tracks that now render as visible divider bands. Three columns fill exactly.

## Scope check

`StatCardGridProps` and `StatCardProps` are unchanged, so this is not an API break — every other consumer compiles untouched. I checked all of them for the two patterns that would regress (a non-`StatCard` direct child, or a short last row): `activity-log-view`, `arena-summary`, `usage-summary-cards`, `chat-health-metrics-page`, `automation-summary-cards`, `project-metrics-page`, `trend-indicator.stories`, `metrics-layout.stories` all fill their rows with `StatCard`s.

## Verification

`stat-card-grid.test.tsx` pins the new geometry (`gap-px`, divider background, cell background); a `ThreeColumnWrapped` story covers the wrap case that used to show stubs. The two consumer suites pass.

## Pre-existing failure, not from this branch

`usage-metrics-page.test.tsx` fails on `main` at `121a11b3d` — #2897 moved the KPI labels to sentence case without updating the assertions. Fixed in #2901.