### PR TITLE
feat(platform): make capped list overflow discoverable

### DIFF
--- a/services/platform/app/components/ui/data-display/capped-scroll-region.test.tsx
+++ b/services/platform/app/components/ui/data-display/capped-scroll-region.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { CappedScrollRegion } from './capped-scroll-region';
+
+/**
+ * jsdom's ResizeObserver mock never fires, and scroll metrics are 0. The
+ * suite drives overflow by stubbing geometry and invoking the observer
+ * callback the component registers — the same path a real resize takes.
+ */
+describe('CappedScrollRegion', () => {
+  it('caps the region and keeps short content free of a scroll affordance', () => {
+    const { container } = render(
+      <CappedScrollRegion
+        maxHeightClassName="max-h-40"
+        scrollLabel="Scroll down"
+      >
+        <div>fits</div>
+      </CappedScrollRegion>,
+    );
+
+    const scroller = container.querySelector('.max-h-40');
+    expect(scroller).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Scroll down' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the gradient and scroll button when content overflows', () => {
+    type ObserverCallback = ResizeObserverCallback;
+    let observerCallback: ObserverCallback | null = null;
+
+    class RecordingResizeObserver {
+      constructor(callback: ObserverCallback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    globalThis.ResizeObserver =
+      RecordingResizeObserver as unknown as typeof ResizeObserver;
+
+    const { container } = render(
+      <CappedScrollRegion
+        maxHeightClassName="max-h-40"
+        scrollLabel="Scroll down"
+      >
+        <div>tall content</div>
+      </CappedScrollRegion>,
+    );
+
+    const scroller = container.querySelector('.max-h-40');
+    expect(scroller).toBeInstanceOf(HTMLElement);
+    if (!(scroller instanceof HTMLElement)) return;
+
+    Object.defineProperty(scroller, 'scrollHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(scroller, 'clientHeight', {
+      configurable: true,
+      get: () => 160,
+    });
+    Object.defineProperty(scroller, 'scrollTop', {
+      configurable: true,
+      get: () => 0,
+    });
+
+    act(() => {
+      observerCallback?.([], {} as ResizeObserver);
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Scroll down' }),
+    ).toBeInTheDocument();
+  });
+
+  it('scrolls to the bottom when the affordance is activated', async () => {
+    type ObserverCallback = ResizeObserverCallback;
+    let observerCallback: ObserverCallback | null = null;
+
+    class RecordingResizeObserver {
+      constructor(callback: ObserverCallback) {
+        observerCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    globalThis.ResizeObserver =
+      RecordingResizeObserver as unknown as typeof ResizeObserver;
+
+    const scrollTo = vi.fn();
+    const { container, user } = render(
+      <CappedScrollRegion
+        maxHeightClassName="max-h-40"
+        scrollLabel="Scroll down"
+      >
+        <div>tall content</div>
+      </CappedScrollRegion>,
+    );
+
+    const scroller = container.querySelector('.max-h-40');
+    expect(scroller).toBeInstanceOf(HTMLElement);
+    if (!(scroller instanceof HTMLElement)) return;
+
+    Object.defineProperty(scroller, 'scrollHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(scroller, 'clientHeight', {
+      configurable: true,
+      get: () => 160,
+    });
+    Object.defineProperty(scroller, 'scrollTop', {
+      configurable: true,
+      get: () => 0,
+    });
+    scroller.scrollTo = scrollTo;
+
+    act(() => {
+      observerCallback?.([], {} as ResizeObserver);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Scroll down' }));
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 400,
+      behavior: 'smooth',
+    });
+  });
+});

--- a/services/platform/app/components/ui/data-display/capped-scroll-region.tsx
+++ b/services/platform/app/components/ui/data-display/capped-scroll-region.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { ChevronDown } from 'lucide-react';
+import {
+  type ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Caps a region at a max height and, when more content sits below the fold,
+ * paints a bottom gradient plus a scroll-down control so the overflow is
+ * discoverable without growing the surrounding layout.
+ *
+ * Each consumer owns its own instance — Projects, Versions, and Runs each
+ * scroll independently rather than sharing one viewport.
+ */
+export function CappedScrollRegion({
+  children,
+  className,
+  contentClassName,
+  maxHeightClassName = 'max-h-64',
+  /** Tailwind `from-*` colour that matches the surface behind the fade. */
+  fadeFromClassName = 'from-background',
+  scrollLabel,
+}: {
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  maxHeightClassName?: string;
+  fadeFromClassName?: string;
+  /** Accessible name for the scroll-down button. */
+  scrollLabel: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+
+  const update = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    // 1px tolerance absorbs sub-pixel rounding so a fully scrolled list
+    // does not keep the affordance visible.
+    setCanScrollDown(el.scrollHeight - el.scrollTop - el.clientHeight > 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    // `undefined`, not a bare return: the other path hands back a cleanup, and
+    // the effect's returns have to agree.
+    if (!el) return undefined;
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    // Content size can change without the container resizing (chips wrap,
+    // rows append) — watch the first child when present.
+    const child = el.firstElementChild;
+    if (child !== null) observer.observe(child);
+    return () => observer.disconnect();
+  }, [update, children]);
+
+  return (
+    <div className={cn('relative min-h-0', className)}>
+      <div
+        ref={containerRef}
+        onScroll={update}
+        className={cn(
+          'overflow-y-auto overscroll-contain',
+          maxHeightClassName,
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+      {canScrollDown && (
+        <>
+          <div
+            aria-hidden
+            className={cn(
+              'pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t to-transparent',
+              fadeFromClassName,
+            )}
+          />
+          <div className="absolute inset-x-0 bottom-1.5 z-10 flex justify-center">
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="secondary"
+              icon={ChevronDown}
+              aria-label={scrollLabel}
+              // Nested inside clickable hosts (e.g. a MultiSelect combobox
+              // trigger) — stop the host from treating this as its own click.
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const el = containerRef.current;
+                if (!el) return;
+                el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+              }}
+              onPointerDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+              className="bg-background/95 animate-content-in rounded-full shadow-md"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/services/platform/app/components/ui/forms/multi-select.test.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.test.tsx
@@ -287,4 +287,56 @@ describe('MultiSelect', () => {
       );
     });
   });
+
+  // `chipsMaxHeightClassName` only applies to the DEFAULT trigger, so these
+  // render without the custom `trigger` the other cases use. The scroll button
+  // itself is overflow-driven and jsdom reports zero geometry, so the contract
+  // under test is where the chips live, not whether the cue is showing.
+  describe('capped chip row', () => {
+    it('scrolls the chips inside a capped region when a cap is given', () => {
+      const { container } = render(
+        <MultiSelect
+          value={['apple', 'banana']}
+          onValueChange={vi.fn()}
+          options={options}
+          chipsMaxHeightClassName="max-h-40"
+          aria-label="Fruits"
+        />,
+      );
+
+      const capped = container.querySelector('.max-h-40');
+      expect(capped).not.toBeNull();
+      expect(capped).toHaveClass('overflow-y-auto');
+      expect(capped).toHaveTextContent('Apple');
+      expect(capped).toHaveTextContent('Banana');
+    });
+
+    it('wraps the chips on the trigger when no cap is given', () => {
+      const { container } = render(
+        <MultiSelect
+          value={['apple', 'banana']}
+          onValueChange={vi.fn()}
+          options={options}
+          aria-label="Fruits"
+        />,
+      );
+
+      expect(container.querySelector('.overflow-y-auto')).toBeNull();
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+
+    it('leaves an empty selection uncapped', () => {
+      const { container } = render(
+        <MultiSelect
+          value={[]}
+          onValueChange={vi.fn()}
+          options={options}
+          chipsMaxHeightClassName="max-h-40"
+          aria-label="Fruits"
+        />,
+      );
+
+      expect(container.querySelector('.max-h-40')).toBeNull();
+    });
+  });
 });

--- a/services/platform/app/components/ui/forms/multi-select.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.tsx
@@ -17,6 +17,8 @@ import {
   useState,
 } from 'react';
 
+import { CappedScrollRegion } from '@/app/components/ui/data-display/capped-scroll-region';
+import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 import { Checkbox } from './checkbox';
@@ -117,6 +119,12 @@ export interface MultiSelectProps {
    * @default false
    */
   modal?: boolean;
+  /**
+   * Cap the selected-chip area at this Tailwind max-height class (e.g.
+   * `max-h-40`). When set, overflow shows a bottom gradient and a scroll-down
+   * control instead of growing the trigger without bound.
+   */
+  chipsMaxHeightClassName?: string;
 }
 
 const CONTENT_CLASSES =
@@ -177,7 +185,9 @@ function MultiSelectBase({
   removeChipLabel,
   optionAction,
   modal = false,
+  chipsMaxHeightClassName,
 }: MultiSelectProps) {
+  const { t: tCommon } = useT('common');
   const instanceId = useId();
   const listboxId = `${instanceId}-listbox`;
   const optionId = (index: number) => `${instanceId}-option-${index}`;
@@ -306,6 +316,41 @@ function MultiSelectBase({
     [filteredOptions, highlightedIndex, handleToggle],
   );
 
+  const chips =
+    selectedOptions.length === 0 ? (
+      typeof placeholder === 'string' ? (
+        <span className="text-muted-foreground">{placeholder}</span>
+      ) : (
+        placeholder
+      )
+    ) : (
+      selectedOptions.map((option) => (
+        <span
+          key={option.value}
+          className="bg-muted inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
+        >
+          {option.label}
+          {!disabled && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleToggle(option.value);
+              }}
+              className="text-muted-foreground hover:text-foreground -mr-0.5 rounded-sm"
+              aria-label={
+                removeChipLabel
+                  ? removeChipLabel(option)
+                  : `Remove ${option.label}`
+              }
+            >
+              <X className="size-3" aria-hidden="true" />
+            </button>
+          )}
+        </span>
+      ))
+    );
+
   // The chip remove buttons are nested inside the trigger, so the trigger must
   // be a <div> (not a <button>) to keep the markup valid. As a non-native
   // control it needs its own keyboard activation for Enter/Space.
@@ -332,47 +377,39 @@ function MultiSelectBase({
       }}
       className={cn(
         selectTriggerClasses({ error }),
-        'h-auto min-h-9 cursor-pointer flex-wrap gap-1.5 py-1.5',
+        'h-auto min-h-9 cursor-pointer gap-1.5 py-1.5',
+        // Chips wrap inside the capped region when capped; otherwise on the
+        // trigger itself so a short selection still reads as one line.
+        chipsMaxHeightClassName !== undefined && selectedOptions.length > 0
+          ? 'items-start'
+          : 'flex-wrap items-center',
         disabled && 'pointer-events-none cursor-not-allowed opacity-50',
         triggerClassName,
       )}
     >
-      <div className="flex flex-1 flex-wrap items-center gap-1.5">
-        {selectedOptions.length === 0 ? (
-          typeof placeholder === 'string' ? (
-            <span className="text-muted-foreground">{placeholder}</span>
-          ) : (
-            placeholder
-          )
-        ) : (
-          selectedOptions.map((option) => (
-            <span
-              key={option.value}
-              className="bg-muted inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
-            >
-              {option.label}
-              {!disabled && (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleToggle(option.value);
-                  }}
-                  className="text-muted-foreground hover:text-foreground -mr-0.5 rounded-sm"
-                  aria-label={
-                    removeChipLabel
-                      ? removeChipLabel(option)
-                      : `Remove ${option.label}`
-                  }
-                >
-                  <X className="size-3" aria-hidden="true" />
-                </button>
-              )}
-            </span>
-          ))
+      {chipsMaxHeightClassName !== undefined && selectedOptions.length > 0 ? (
+        <CappedScrollRegion
+          className="min-w-0 flex-1"
+          maxHeightClassName={chipsMaxHeightClassName}
+          fadeFromClassName="from-input"
+          scrollLabel={tCommon('aria.scrollDown')}
+        >
+          <div className="flex flex-wrap items-center gap-1.5">{chips}</div>
+        </CappedScrollRegion>
+      ) : (
+        <div className="flex flex-1 flex-wrap items-center gap-1.5">
+          {chips}
+        </div>
+      )}
+      <ChevronDown
+        className={cn(
+          'size-4 shrink-0 opacity-50',
+          chipsMaxHeightClassName !== undefined &&
+            selectedOptions.length > 0 &&
+            'mt-0.5 self-start',
         )}
-      </div>
-      <ChevronDown className="size-4 shrink-0 opacity-50" aria-hidden="true" />
+        aria-hidden="true"
+      />
     </div>
   );
 

--- a/services/platform/app/features/automations/components/run-list.tsx
+++ b/services/platform/app/features/automations/components/run-list.tsx
@@ -6,6 +6,7 @@ import { Text } from '@tale/ui/text';
 import { Link } from '@tanstack/react-router';
 import { useId } from 'react';
 
+import { CappedScrollRegion } from '@/app/components/ui/data-display/capped-scroll-region';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import type { Id } from '@/convex/_generated/dataModel';
 import { automationSlugToParam } from '@/lib/automations/slug';
@@ -47,6 +48,7 @@ export function RunList({
   projectId?: Id<'projects'>;
 }) {
   const { t } = useT('automations');
+  const { t: tCommon } = useT('common');
   const { formatDate } = useFormatDate();
   const headingId = useId();
 
@@ -62,47 +64,53 @@ export function RunList({
           {t('runs.empty')}
         </Text>
       ) : (
-        <ul className="flex flex-col gap-2">
-          {runs.map((run) => (
-            <li key={run.id}>
-              <Link
-                {...(projectId
-                  ? {
-                      to: '/dashboard/$id/projects/$projectId/automations/$automationSlug/runs/$runId' as const,
-                      params: {
-                        id: organizationId,
-                        projectId,
-                        automationSlug: automationSlugToParam(automationSlug),
-                        runId: run.id,
-                      },
-                    }
-                  : {
-                      to: '/dashboard/$id/automations/$automationSlug/runs/$runId' as const,
-                      params: {
-                        id: organizationId,
-                        automationSlug: automationSlugToParam(automationSlug),
-                        runId: run.id,
-                      },
-                    })}
-                className="border-border bg-card hover:bg-muted/50 focus-visible:ring-ring flex flex-wrap items-center gap-2 rounded-md border p-3 focus-visible:ring-2 focus-visible:outline-none"
-              >
-                <RunBadge status={readRunStatus(run.status)} />
-                <Badge variant={run.mode === 'live' ? 'orange' : 'slate'}>
-                  {t(`runs.mode.${run.mode === 'live' ? 'live' : 'mock'}`)}
-                </Badge>
-                <span className="text-sm">
-                  {t('versions.versionLabel', { version: run.version })}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-sm">
-                  {run.detail ?? t('runs.startedBy', { actor: run.startedBy })}
-                </span>
-                <Text as="span" variant="muted" className="text-xs">
-                  {formatDate(new Date(run.startedAt), 'long')}
-                </Text>
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <CappedScrollRegion
+          maxHeightClassName="max-h-72"
+          scrollLabel={tCommon('aria.scrollDown')}
+        >
+          <ul className="flex flex-col gap-2">
+            {runs.map((run) => (
+              <li key={run.id}>
+                <Link
+                  {...(projectId
+                    ? {
+                        to: '/dashboard/$id/projects/$projectId/automations/$automationSlug/runs/$runId' as const,
+                        params: {
+                          id: organizationId,
+                          projectId,
+                          automationSlug: automationSlugToParam(automationSlug),
+                          runId: run.id,
+                        },
+                      }
+                    : {
+                        to: '/dashboard/$id/automations/$automationSlug/runs/$runId' as const,
+                        params: {
+                          id: organizationId,
+                          automationSlug: automationSlugToParam(automationSlug),
+                          runId: run.id,
+                        },
+                      })}
+                  className="border-border bg-card hover:bg-muted/50 focus-visible:ring-ring flex flex-wrap items-center gap-2 rounded-md border p-3 focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  <RunBadge status={readRunStatus(run.status)} />
+                  <Badge variant={run.mode === 'live' ? 'orange' : 'slate'}>
+                    {t(`runs.mode.${run.mode === 'live' ? 'live' : 'mock'}`)}
+                  </Badge>
+                  <span className="text-sm">
+                    {t('versions.versionLabel', { version: run.version })}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-sm">
+                    {run.detail ??
+                      t('runs.startedBy', { actor: run.startedBy })}
+                  </span>
+                  <Text as="span" variant="muted" className="text-xs">
+                    {formatDate(new Date(run.startedAt), 'long')}
+                  </Text>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </CappedScrollRegion>
       )}
     </section>
   );

--- a/services/platform/app/features/automations/components/version-list.tsx
+++ b/services/platform/app/features/automations/components/version-list.tsx
@@ -8,6 +8,7 @@ import { Text } from '@tale/ui/text';
 import { CheckCircle2, Rocket, XCircle } from 'lucide-react';
 import { useId, useState } from 'react';
 
+import { CappedScrollRegion } from '@/app/components/ui/data-display/capped-scroll-region';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { useT } from '@/lib/i18n/client';
 
@@ -54,6 +55,7 @@ export function VersionList({
   canDeploy?: boolean;
 }) {
   const { t } = useT('automations');
+  const { t: tCommon } = useT('common');
   const { formatDate } = useFormatDate();
   const headingId = useId();
   const deploy = useDeployAutomation();
@@ -83,76 +85,81 @@ export function VersionList({
           {t('versions.empty')}
         </Text>
       ) : (
-        <ul className="flex flex-col gap-2">
-          {ordered.map((entry) => {
-            const isDeployed = entry.version === deployedVersion;
-            const isSelected = entry.version === selectedVersion;
-            return (
-              <li
-                key={entry.version}
-                className="border-border bg-card flex flex-wrap items-center gap-2 rounded-md border p-3"
-              >
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  aria-current={isSelected ? 'true' : undefined}
-                  onClick={() => {
-                    onSelectVersion(entry.version);
-                  }}
+        <CappedScrollRegion
+          maxHeightClassName="max-h-72"
+          scrollLabel={tCommon('aria.scrollDown')}
+        >
+          <ul className="flex flex-col gap-2">
+            {ordered.map((entry) => {
+              const isDeployed = entry.version === deployedVersion;
+              const isSelected = entry.version === selectedVersion;
+              return (
+                <li
+                  key={entry.version}
+                  className="border-border bg-card flex flex-wrap items-center gap-2 rounded-md border p-3"
                 >
-                  {t('versions.versionLabel', { version: entry.version })}
-                </Button>
-                {isDeployed && (
-                  <Badge variant="green" icon={CheckCircle2}>
-                    {t('versions.deployed')}
-                  </Badge>
-                )}
-                {entry.testsPassed === false && (
-                  <Badge variant="destructive" icon={XCircle}>
-                    {t('versions.testsFailed')}
-                  </Badge>
-                )}
-                {entry.testsPassed === true && (
-                  <Badge variant="green">{t('versions.testsPassed')}</Badge>
-                )}
-                <span className="min-w-0 flex-1 truncate text-sm">
-                  {entry.message ?? t('versions.noMessage')}
-                </span>
-                <Text as="span" variant="muted" className="text-xs">
-                  {formatDate(new Date(entry.createdAt), 'long')}
-                </Text>
-                {!isDeployed && canDeploy && (
                   <Button
-                    variant="secondary"
+                    variant="ghost"
                     size="sm"
-                    icon={Rocket}
-                    isLoading={
-                      deploy.isPending &&
-                      deploy.variables?.version === entry.version
-                    }
+                    aria-current={isSelected ? 'true' : undefined}
                     onClick={() => {
-                      setRefusal(null);
-                      deploy.mutate(
-                        {
-                          organizationId,
-                          name,
-                          version: entry.version,
-                        },
-                        {
-                          onError: (error) => {
-                            setRefusal(automationErrorMessage(error));
-                          },
-                        },
-                      );
+                      onSelectVersion(entry.version);
                     }}
                   >
-                    {t('versions.deploy')}
+                    {t('versions.versionLabel', { version: entry.version })}
                   </Button>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+                  {isDeployed && (
+                    <Badge variant="green" icon={CheckCircle2}>
+                      {t('versions.deployed')}
+                    </Badge>
+                  )}
+                  {entry.testsPassed === false && (
+                    <Badge variant="destructive" icon={XCircle}>
+                      {t('versions.testsFailed')}
+                    </Badge>
+                  )}
+                  {entry.testsPassed === true && (
+                    <Badge variant="green">{t('versions.testsPassed')}</Badge>
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-sm">
+                    {entry.message ?? t('versions.noMessage')}
+                  </span>
+                  <Text as="span" variant="muted" className="text-xs">
+                    {formatDate(new Date(entry.createdAt), 'long')}
+                  </Text>
+                  {!isDeployed && canDeploy && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      icon={Rocket}
+                      isLoading={
+                        deploy.isPending &&
+                        deploy.variables?.version === entry.version
+                      }
+                      onClick={() => {
+                        setRefusal(null);
+                        deploy.mutate(
+                          {
+                            organizationId,
+                            name,
+                            version: entry.version,
+                          },
+                          {
+                            onError: (error) => {
+                              setRefusal(automationErrorMessage(error));
+                            },
+                          },
+                        );
+                      }}
+                    >
+                      {t('versions.deploy')}
+                    </Button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </CappedScrollRegion>
       )}
     </section>
   );

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1603,6 +1603,7 @@ common:
     sortAvailable: sortierbar
     unsavedChanges: Nicht gespeicherte Änderungen
     moreTabs: Weitere Tabs
+    scrollDown: Nach unten scrollen
   pagination:
     rowsPerPage: Zeilen pro Seite
     showing: '{start}–{end} von {total}'

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1554,6 +1554,7 @@ common:
     sortAvailable: sort available
     unsavedChanges: Unsaved changes
     moreTabs: More tabs
+    scrollDown: Scroll down
   pagination:
     rowsPerPage: Rows per page
     showing: '{start}-{end} of {total}'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1611,6 +1611,7 @@ common:
     sortAvailable: tri disponible
     unsavedChanges: Modifications non enregistrées
     moreTabs: Autres onglets
+    scrollDown: Défiler vers le bas
   pagination:
     rowsPerPage: Lignes par page
     showing: '{start}-{end} sur {total}'


### PR DESCRIPTION
## Problem

A long list inside a panel had two bad options: stretch the surrounding layout, or cap its height and give the reader no sign that content continues below the fold. The automation workbench's run and version lists hit this, as does a `MultiSelect` whose chips wrap onto many rows.

## Change

`CappedScrollRegion` holds a region at a max height and, when there is more below, paints a bottom gradient plus a scroll-down button so the overflow is discoverable without growing the layout.

- **Per-consumer instances.** Runs, versions, and project bindings each scroll independently rather than sharing one viewport.
- **`ResizeObserver` on the scroller *and* its first child**, so appended rows and rewrapped chips re-evaluate the cue instead of leaving a stale one. The overflow test carries 1px of tolerance to avoid a flickering cue on sub-pixel layouts.
- **`MultiSelect` gains an optional `chipsMaxHeightClassName`.** When set with a non-empty selection, the chips move into a capped region; otherwise the trigger keeps its existing wrap behaviour. The prop is optional and the default path is untouched, so existing callers are unaffected.

The button calls `preventDefault` / `stopPropagation` on both click and pointerdown: it is designed to live inside clickable hosts, and without that it would open the very combobox trigger it sits in.

## Verification

- `capped-scroll-region.test.tsx` — cue appears only on overflow, scrolls on activation, re-measures on resize.
- `multi-select.test.tsx` — three new cases covering the cap: chips move into the scroller when capped, wrap on the trigger when not, and an empty selection stays uncapped. Verified they fail when the capped branch is disabled, rather than passing vacuously. The scroll button itself is overflow-driven and jsdom reports zero geometry, so these assert where the chips live rather than whether the cue is visible.
- Typecheck, lint, and format clean.

## Pre-existing failures on `main`, not from this branch

`messages.test.ts` (2) and `providers-settings.test.tsx` (1) fail on `main` at `121a11b3d`. The first two are fixed in #2901; the third is flagged for whoever landed the credential-error rework.