### PR TITLE
feat(platform): send actionable emails through the org's mailbox

### DIFF
--- a/configs/platform/system/connectors/imap-smtp/connector.yml
+++ b/configs/platform/system/connectors/imap-smtp/connector.yml
@@ -147,6 +147,11 @@ actions:
             type: string,
             description: 'Message-ID this replies to (threading).',
           }
+        notificationSender:
+          {
+            type: boolean,
+            description: 'When true, send From notification@ on the mailbox domain so system mail is distinct from conversation replies.',
+          }
     output: '{ messageId: string }'
     mock: |
       return { messageId: `mock-smtp-${input.to}-${input.subject.length}` };

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -657,6 +657,7 @@ import type * as node_only_sandbox_workspace_tool_context from "../node_only/san
 import type * as node_only_sandbox_workspace_tools_bridge from "../node_only/sandbox/workspace_tools_bridge.js";
 import type * as notifications_actor_name from "../notifications/actor_name.js";
 import type * as notifications_dispatch_notification from "../notifications/dispatch_notification.js";
+import type * as notifications_actionable_email_connectors from "../notifications/actionable_email_connectors.js";
 import type * as notifications_email_notification from "../notifications/email_notification.js";
 import type * as notifications_email_notification_queries from "../notifications/email_notification_queries.js";
 import type * as notifications_event_catalog from "../notifications/event_catalog.js";
@@ -1576,6 +1577,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/workspace_tools_bridge": typeof node_only_sandbox_workspace_tools_bridge;
   "notifications/actor_name": typeof notifications_actor_name;
   "notifications/dispatch_notification": typeof notifications_dispatch_notification;
+  "notifications/actionable_email_connectors": typeof notifications_actionable_email_connectors;
   "notifications/email_notification": typeof notifications_email_notification;
   "notifications/email_notification_queries": typeof notifications_email_notification_queries;
   "notifications/event_catalog": typeof notifications_event_catalog;

--- a/services/platform/convex/notifications/actionable_email_connectors.ts
+++ b/services/platform/convex/notifications/actionable_email_connectors.ts
@@ -1,0 +1,13 @@
+/**
+ * Mail connectors that can deliver actionable notification email.
+ * Shared between the V8 credential listing query and the Node send helpers.
+ */
+
+export const ACTIONABLE_EMAIL_CONNECTORS = [
+  'imap-smtp',
+  'gmail',
+  'outlook',
+] as const;
+
+export type ActionableEmailConnectorSlug =
+  (typeof ACTIONABLE_EMAIL_CONNECTORS)[number];

--- a/services/platform/convex/notifications/email_notification_queries.test.ts
+++ b/services/platform/convex/notifications/email_notification_queries.test.ts
@@ -1,0 +1,134 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root (this file is at
+// convex/notifications/), mirroring queries.test.ts.
+const TEST_DIR_FROM_CONVEX_ROOT = 'notifications';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_mail';
+const OTHER_ORG = 'org_other';
+
+type T = TestConvex<typeof schema>;
+
+async function seedCredential(
+  t: T,
+  overrides: {
+    organizationId?: string;
+    connectorSlug?: string;
+    status?: 'active' | 'disabled' | 'needs-reauth';
+    isDefault?: boolean;
+    name?: string;
+  } = {},
+) {
+  return t.run(async (ctx) =>
+    ctx.db.insert('connectorCredentials', {
+      organizationId: overrides.organizationId ?? ORG,
+      connectorSlug: overrides.connectorSlug ?? 'imap-smtp',
+      authMethod: 'basic',
+      name: overrides.name ?? 'Mailbox',
+      encryptedData: {
+        ciphertext: 'x',
+        nonce: 'y',
+        authTag: 'z',
+        keyFingerprint: 'k',
+      },
+      isDefault: overrides.isDefault ?? false,
+      status: overrides.status ?? 'active',
+      createdBy: 'user_1',
+      createdAt: 0,
+      updatedAt: 0,
+    }),
+  );
+}
+
+// This query decides WHICH mailbox sends an org's actionable notification
+// mail, so its org scoping is a tenant-isolation boundary, not a filter
+// detail: a leak here would send one org's notifications out of another org's
+// mailbox.
+describe('listActiveMailCredentialsInternal', () => {
+  it('returns only the asking org rows', async () => {
+    const t = convexTest(schema, modules);
+    await seedCredential(t, { name: 'Ours' });
+    await seedCredential(t, { organizationId: OTHER_ORG, name: 'Theirs' });
+
+    const rows = await t.query(
+      internal.notifications.email_notification_queries
+        .listActiveMailCredentialsInternal,
+      { organizationId: ORG },
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.connectorSlug).toBe('imap-smtp');
+  });
+
+  it('skips credentials that are not active', async () => {
+    const t = convexTest(schema, modules);
+    await seedCredential(t, { status: 'disabled' });
+    await seedCredential(t, { status: 'needs-reauth', name: 'Stale' });
+
+    const rows = await t.query(
+      internal.notifications.email_notification_queries
+        .listActiveMailCredentialsInternal,
+      { organizationId: ORG },
+    );
+
+    expect(rows).toEqual([]);
+  });
+
+  it('skips connectors that do not carry mail', async () => {
+    const t = convexTest(schema, modules);
+    await seedCredential(t, { connectorSlug: 'shopify' });
+
+    const rows = await t.query(
+      internal.notifications.email_notification_queries
+        .listActiveMailCredentialsInternal,
+      { organizationId: ORG },
+    );
+
+    expect(rows).toEqual([]);
+  });
+
+  it('reports which credential is the default so the caller can prefer it', async () => {
+    const t = convexTest(schema, modules);
+    await seedCredential(t, { name: 'Secondary', isDefault: false });
+    await seedCredential(t, { name: 'Primary', isDefault: true });
+
+    const rows = await t.query(
+      internal.notifications.email_notification_queries
+        .listActiveMailCredentialsInternal,
+      { organizationId: ORG },
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((row) => row.isDefault)).toHaveLength(1);
+  });
+
+  it('returns nothing when the org has no mail credential at all', async () => {
+    const t = convexTest(schema, modules);
+
+    const rows = await t.query(
+      internal.notifications.email_notification_queries
+        .listActiveMailCredentialsInternal,
+      { organizationId: ORG },
+    );
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/services/platform/convex/notifications/email_notification_queries.ts
+++ b/services/platform/convex/notifications/email_notification_queries.ts
@@ -3,6 +3,9 @@ import { v } from 'convex/values';
 import { internalQuery } from '../_generated/server';
 import { getUserById } from '../betterAuth/trusted_headers/get_user_by_id';
 import { isActionableEmailEnabled } from '../collab/notify';
+import { ACTIONABLE_EMAIL_CONNECTORS } from './actionable_email_connectors';
+
+const MAIL_CONNECTOR_SLUGS = new Set<string>(ACTIONABLE_EMAIL_CONNECTORS);
 
 export const getRecipientEmailInternal = internalQuery({
   args: { userId: v.string() },
@@ -22,4 +25,36 @@ export const isActionableEmailEnabledInternal = internalQuery({
   returns: v.boolean(),
   handler: async (ctx, args) =>
     isActionableEmailEnabled(ctx, args.userId, args.organizationId),
+});
+
+/**
+ * Active mail credentials the org can send actionable notification email
+ * through. Metadata only — ciphertext never leaves the credential table.
+ */
+export const listActiveMailCredentialsInternal = internalQuery({
+  args: { organizationId: v.string() },
+  returns: v.array(
+    v.object({
+      credentialId: v.id('connectorCredentials'),
+      connectorSlug: v.string(),
+      isDefault: v.boolean(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query('connectorCredentials')
+      .withIndex('by_org', (q) => q.eq('organizationId', args.organizationId))
+      .collect();
+    return rows
+      .filter(
+        (row) =>
+          MAIL_CONNECTOR_SLUGS.has(row.connectorSlug) &&
+          row.status === 'active',
+      )
+      .map((row) => ({
+        credentialId: row._id,
+        connectorSlug: row.connectorSlug,
+        isDefault: row.isDefault,
+      }));
+  },
 });

--- a/services/platform/convex/notifications/send_actionable_email.test.ts
+++ b/services/platform/convex/notifications/send_actionable_email.test.ts
@@ -1,0 +1,224 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildActionableEmailInput,
+  pickSendableMailbox,
+  sendActionableEmail,
+} from './send_actionable_email';
+
+describe('pickSendableMailbox', () => {
+  it('prefers imap-smtp over oauth mailboxes', () => {
+    expect(
+      pickSendableMailbox([
+        {
+          credentialId: 'gmail_1',
+          connectorSlug: 'gmail',
+          isDefault: true,
+        },
+        {
+          credentialId: 'smtp_1',
+          connectorSlug: 'imap-smtp',
+          isDefault: false,
+        },
+      ]),
+    ).toEqual({
+      connectorSlug: 'imap-smtp',
+      credentialId: 'smtp_1',
+    });
+  });
+
+  it('prefers the default credential within a slug', () => {
+    expect(
+      pickSendableMailbox([
+        {
+          credentialId: 'gmail_other',
+          connectorSlug: 'gmail',
+          isDefault: false,
+        },
+        {
+          credentialId: 'gmail_default',
+          connectorSlug: 'gmail',
+          isDefault: true,
+        },
+      ]),
+    ).toEqual({
+      connectorSlug: 'gmail',
+      credentialId: 'gmail_default',
+    });
+  });
+
+  it('falls back to outlook when nothing else is active', () => {
+    expect(
+      pickSendableMailbox([
+        {
+          credentialId: 'outlook_1',
+          connectorSlug: 'outlook',
+          isDefault: true,
+        },
+      ]),
+    ).toEqual({
+      connectorSlug: 'outlook',
+      credentialId: 'outlook_1',
+    });
+  });
+
+  it('returns null when no mail credentials are active', () => {
+    expect(pickSendableMailbox([])).toBeNull();
+  });
+});
+
+describe('buildActionableEmailInput', () => {
+  it('asks imap-smtp to send as the notification sender', () => {
+    expect(
+      buildActionableEmailInput('imap-smtp', {
+        to: 'user@example.com',
+        subject: 'Assigned',
+        text: 'plain',
+        html: '<p>html</p>',
+      }),
+    ).toEqual({
+      to: 'user@example.com',
+      subject: 'Assigned',
+      text: 'plain',
+      html: '<p>html</p>',
+      notificationSender: true,
+    });
+  });
+
+  it('shapes gmail and outlook like conversation HTML sends', () => {
+    expect(
+      buildActionableEmailInput('gmail', {
+        to: 'user@example.com',
+        subject: 'Assigned',
+        text: 'plain',
+        html: '<p>html</p>',
+      }),
+    ).toEqual({
+      to: 'user@example.com',
+      subject: 'Assigned',
+      body: '<p>html</p>',
+      contentType: 'HTML',
+    });
+
+    expect(
+      buildActionableEmailInput('outlook', {
+        to: 'user@example.com',
+        subject: 'Assigned',
+        text: 'plain',
+        html: '<p>html</p>',
+      }),
+    ).toEqual({
+      to: ['user@example.com'],
+      subject: 'Assigned',
+      body: '<p>html</p>',
+      contentType: 'HTML',
+    });
+  });
+});
+
+describe('sendActionableEmail', () => {
+  it('invokes the connector send action live as a system caller', async () => {
+    const runAction = vi.fn(async () => ({
+      status: 'ok' as const,
+      connector: 'imap-smtp',
+      action: 'send',
+      nodeType: 'imap-smtp.send',
+      mode: 'live' as const,
+      backend: 'native' as const,
+      effects: 'write' as const,
+      output: { messageId: '<1@example.com>' },
+    }));
+    const ctx = { runAction } as never;
+
+    const result = await sendActionableEmail(ctx, {
+      organizationId: 'org_1',
+      mailbox: {
+        connectorSlug: 'imap-smtp',
+        credentialId: 'cred_1',
+      },
+      to: 'user@example.com',
+      subject: 'Assigned',
+      text: 'plain',
+      html: '<p>html</p>',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(runAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationId: 'org_1',
+        connector: 'imap-smtp',
+        action: 'send',
+        credentialRef: 'cred_1',
+        mode: 'live',
+        caller: {
+          kind: 'system',
+          reason: 'actionable notification email',
+        },
+        input: {
+          to: 'user@example.com',
+          subject: 'Assigned',
+          text: 'plain',
+          html: '<p>html</p>',
+          notificationSender: true,
+        },
+      }),
+    );
+  });
+
+  it('returns the connector error when the send refuses', async () => {
+    const runAction = vi.fn(async () => {
+      throw new ConvexError({
+        code: 'CREDENTIAL_NONE_CONFIGURED',
+        message: 'No default credential is configured for "gmail".',
+      });
+    });
+    const ctx = { runAction } as never;
+
+    const result = await sendActionableEmail(ctx, {
+      organizationId: 'org_1',
+      mailbox: {
+        connectorSlug: 'gmail',
+        credentialId: 'cred_gmail',
+      },
+      to: 'user@example.com',
+      subject: 'Assigned',
+      text: 'plain',
+      html: '<p>html</p>',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'No default credential is configured for "gmail".',
+    });
+  });
+
+  it('returns approval-required as a failed send', async () => {
+    const runAction = vi.fn(async () => ({
+      status: 'approval-required' as const,
+      connector: 'gmail',
+      action: 'send_message',
+      nodeType: 'gmail.send_message',
+      message: 'approval needed',
+    }));
+    const ctx = { runAction } as never;
+
+    const result = await sendActionableEmail(ctx, {
+      organizationId: 'org_1',
+      mailbox: {
+        connectorSlug: 'gmail',
+        credentialId: 'cred_gmail',
+      },
+      to: 'user@example.com',
+      subject: 'Assigned',
+      text: 'plain',
+      html: '<p>html</p>',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'approval needed',
+    });
+  });
+});

--- a/services/platform/convex/notifications/send_actionable_email.ts
+++ b/services/platform/convex/notifications/send_actionable_email.ts
@@ -4,48 +4,115 @@
  * Send helpers for actionable notification email — IMAP/SMTP mailboxes and
  * OAuth connectors (Gmail, Outlook).
  *
- * `../connectors/{build_test_secrets,
- * guards/is_imap_smtp_connector,imap_smtp_config,load_connector}` moved
- * with the connectors rewrite. `email_notification.ts`'s
- * `deliverActionableEmailAction` is already designed to skip silently when
- * "the org has no connected mailbox connector" (its own doc comment) — the
- * in-app bell row is written regardless — so `findSendableMailbox` always
- * returning `null` is a true, in-contract answer, not a lie: it degrades
- * exactly like the "no mailbox configured" case always did, no caller
- * changes needed. `sendActionableEmail` is kept exported (nothing calls it
- * once `findSendableMailbox` always returns `null`, but the stub policy
- * never deletes an export) and returns its established `{ success, error? }`
- * failure shape instead of attempting a send.
+ * Delivery goes through `runConnectorAction` the same way conversation
+ * replies do: pick an active mail credential for the org, then invoke the
+ * connector's send action as a system caller. Skips silently when the org
+ * has no usable mailbox — the in-app bell row is already written.
  */
 
+import { ConvexError } from 'convex/values';
+
+import { isRecord } from '../../lib/utils/type-utils';
+import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
+import { sendConnectorAction } from '../conversations/connector_slug';
+import {
+  ACTIONABLE_EMAIL_CONNECTORS,
+  type ActionableEmailConnectorSlug,
+} from './actionable_email_connectors';
+
+export {
+  ACTIONABLE_EMAIL_CONNECTORS,
+  type ActionableEmailConnectorSlug,
+} from './actionable_email_connectors';
 
 export interface SendableMailbox {
-  kind: 'smtp' | 'connector';
+  connectorSlug: ActionableEmailConnectorSlug;
+  credentialId: string;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof ConvexError) {
+    const data = error.data;
+    if (
+      isRecord(data) &&
+      typeof data.message === 'string' &&
+      data.message.trim() !== ''
+    ) {
+      return data.message;
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return String(error);
 }
 
 /**
- * No-op — always reports "no sendable mailbox found",
- * which callers already treat as a normal, silent skip. See file header.
+ * Build the connector input for an actionable notification. Mirrors
+ * conversation `buildSendInput` for the no-attachment HTML case, and asks
+ * IMAP/SMTP to rewrite From to `notification@` on the mailbox domain.
  */
-export async function findSendableMailbox(
-  _ctx: ActionCtx,
-  _organizationId: string,
-): Promise<SendableMailbox | null> {
-  console.debug(
-    '[findSendableMailbox] Actionable email delivery is offline while the platform AI backend is rewritten; reporting no sendable mailbox',
-  );
+export function buildActionableEmailInput(
+  connectorSlug: ActionableEmailConnectorSlug,
+  args: { to: string; subject: string; text: string; html: string },
+): Record<string, unknown> {
+  const { connector } = sendConnectorAction(connectorSlug);
+  if (connector === 'imap-smtp') {
+    return {
+      to: args.to,
+      subject: args.subject,
+      text: args.text,
+      html: args.html,
+      notificationSender: true,
+    };
+  }
+  return {
+    to: connector === 'outlook' ? [args.to] : args.to,
+    subject: args.subject,
+    body: args.html,
+    contentType: 'HTML',
+  };
+}
+
+/** Prefer IMAP/SMTP, then Gmail, then Outlook; within a slug prefer the default. */
+export function pickSendableMailbox(
+  credentials: ReadonlyArray<{
+    credentialId: string;
+    connectorSlug: string;
+    isDefault: boolean;
+  }>,
+): SendableMailbox | null {
+  for (const slug of ACTIONABLE_EMAIL_CONNECTORS) {
+    const forSlug = credentials.filter((row) => row.connectorSlug === slug);
+    const pick = forSlug.find((row) => row.isDefault) ?? forSlug[0];
+    if (pick) {
+      return { connectorSlug: slug, credentialId: pick.credentialId };
+    }
+  }
   return null;
 }
 
 /**
- * Offline — always fails. See file header. Unreachable in
- * practice since `findSendableMailbox` never returns a mailbox, but kept
- * exported and functional-shaped per the stub policy.
+ * Resolve an active mail credential the org can send actionable email from.
+ * Returns null when none is configured — callers treat that as a silent skip.
+ */
+export async function findSendableMailbox(
+  ctx: ActionCtx,
+  organizationId: string,
+): Promise<SendableMailbox | null> {
+  const credentials = await ctx.runQuery(
+    internal.notifications.email_notification_queries
+      .listActiveMailCredentialsInternal,
+    { organizationId },
+  );
+  return pickSendableMailbox(credentials);
+}
+
+/**
+ * Deliver one actionable notification email through the org's mail connector.
  */
 export async function sendActionableEmail(
-  _ctx: ActionCtx,
-  _args: {
+  ctx: ActionCtx,
+  args: {
     organizationId: string;
     mailbox: SendableMailbox;
     to: string;
@@ -54,9 +121,41 @@ export async function sendActionableEmail(
     html: string;
   },
 ): Promise<{ success: boolean; error?: string }> {
-  return {
-    success: false,
-    error:
-      'Sending actionable email is offline while the platform AI backend is rewritten.',
-  };
+  const { connector, action } = sendConnectorAction(args.mailbox.connectorSlug);
+  const input = buildActionableEmailInput(args.mailbox.connectorSlug, {
+    to: args.to,
+    subject: args.subject,
+    text: args.text,
+    html: args.html,
+  });
+
+  try {
+    const result = await ctx.runAction(
+      internal.connectors.execute_action.runConnectorAction,
+      {
+        organizationId: args.organizationId,
+        connector,
+        action,
+        input,
+        credentialRef: args.mailbox.credentialId,
+        mode: 'live',
+        caller: {
+          kind: 'system',
+          reason: 'actionable notification email',
+        },
+      },
+    );
+
+    if (result.status !== 'ok') {
+      return {
+        success: false,
+        error:
+          result.message ||
+          `connector_send_failed:${args.mailbox.connectorSlug}`,
+      };
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: errorMessage(error) };
+  }
 }

--- a/services/platform/lib/connectors/natives/imap-smtp.test.ts
+++ b/services/platform/lib/connectors/natives/imap-smtp.test.ts
@@ -355,6 +355,21 @@ describe('send', () => {
     });
   });
 
+  it('rewrites From to notification@ when notificationSender is set', async () => {
+    const transport = stubTransport();
+    await natives(transport)['imap-smtp.send'](
+      {
+        to: 'person@example.com',
+        subject: 'Hello',
+        text: 'Hi.',
+        notificationSender: true,
+      },
+      context(),
+    );
+
+    expect(transport.log.sent[0]?.from).toBe('notification@example.com');
+  });
+
   it('carries threading headers when the caller replies to a message', async () => {
     const transport = stubTransport();
     await natives(transport)['imap-smtp.send'](

--- a/services/platform/lib/connectors/natives/imap-smtp.ts
+++ b/services/platform/lib/connectors/natives/imap-smtp.ts
@@ -463,7 +463,17 @@ const sendInput = z.object({
   text: z.string().optional(),
   html: z.string().optional(),
   inReplyTo: z.string().optional(),
+  /** When true, send From `notification@` on the mailbox domain so system
+   * mail is distinct from conversation replies on the same SMTP account. */
+  notificationSender: z.boolean().optional(),
 });
+
+/** From address for system notification mail on the mailbox's send domain. */
+export function notificationSenderFrom(baseFrom: string): string {
+  const at = baseFrom.lastIndexOf('@');
+  if (at === -1) return baseFrom;
+  return `notification@${baseFrom.slice(at + 1).toLowerCase()}`;
+}
 
 const getMessageInput = z.object({
   uid: z.string().min(1),
@@ -571,8 +581,12 @@ export function imapSmtpNatives(
     // nothing to deliver, so a text-less plain send carries an empty body; a
     // caller that sent HTML alone keeps exactly that.
     const text = parsed.text ?? (parsed.html === undefined ? '' : undefined);
+    const from =
+      parsed.notificationSender === true
+        ? notificationSenderFrom(config.from)
+        : config.from;
     const message: OutboundMail = {
-      from: config.from,
+      from,
       to,
       subject: parsed.subject,
       ...(text !== undefined && { text }),


### PR DESCRIPTION
## Problem

`findSendableMailbox` was a hardcoded `return null`, left behind while the AI backend was rewritten. Every actionable notification — assignment, review request, mention — was resolved, rendered, and then silently dropped. No org received one.

## Change

Resolve the org's active mail credentials and dispatch the send through the connector action in `live` mode, as a `system` caller. The connector's default credential is preferred; otherwise the first active mail credential in slug-precedence order.

Delivery stays best-effort by design: a send failure is logged and the caller that triggered the notification is never blocked or shown an error.

### Distinguishing system mail

The imap-smtp native takes a `notificationSender` flag that rewrites the SMTP envelope to `notification@<mailbox domain>`, so a system notification is distinguishable from a conversation reply leaving the same mailbox. The flag is declared in the connector manifest, so the agent-facing schema stays truthful.

### Why a third module

`ACTIONABLE_EMAIL_CONNECTORS` lives in its own file because the credential listing is a V8 query and cannot import the `'use node'` send helpers that share the list.

## Tests

- `send_actionable_email.test.ts` — credential precedence (default within slug, cross-slug fallback, empty), the input shaping for each slug, and send / `ConvexError` / approval-required outcomes.
- `email_notification_queries.test.ts` — **new**. `listActiveMailCredentialsInternal` decides *which* mailbox sends an org's mail, so its org scoping is a tenant-isolation boundary rather than a filter detail. Covers org scoping, non-active statuses, non-mail connectors, default reporting, and the empty case. Verified the isolation case fails when the `by_org` bound is removed.
- `imap-smtp.test.ts` — the `From` rewrite.

92 tests green across the touched suites; typecheck, lint, format clean.

## Notes for the reviewer

- **`api.d.ts`** carries only the two lines codegen emits for the new module; the worktree has no deployment configured, so they were written by hand and diffed against real codegen output.
- **Relay behaviour worth a second opinion:** many SMTP relays reject a `From` that differs from the authenticated identity, and there is no fallback to `config.from` on refusal. Where the SMTP username has no `@`, `config.from` is derived as `<user>@<imap host>`, so the rewrite yields `notification@<imap host>`.
- **Pre-existing duplication:** `notificationSenderFrom` re-implements `notificationFromAddress` in `conversations/reply_from.ts`, which is already tested but currently has no production callers. Left alone here — `lib/` importing from `convex/` is likely why it was rewritten — but worth collapsing.
- No migration, no org-config change, no new i18n keys. `connector.yml` is system config, not per-org.