### PR TITLE
feat(platform): trail the automation name in the area header

### DIFF
--- a/services/platform/app/features/automations/components/automation-breadcrumbs.test.tsx
+++ b/services/platform/app/features/automations/components/automation-breadcrumbs.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import { AutomationBreadcrumbs } from './automation-breadcrumbs';
+
+const fixtures = vi.hoisted(() => ({
+  presentation: undefined as unknown,
+  isPending: false,
+  onRun: false,
+}));
+
+interface MockLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  to?: string;
+  params?: Record<string, string>;
+  preload?: string;
+  activeOptions?: unknown;
+}
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: React.forwardRef<HTMLAnchorElement, MockLinkProps>(function Link(
+    {
+      to,
+      params,
+      preload: _preload,
+      activeOptions: _active,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
+    const href = Object.entries(params ?? {}).reduce(
+      (path, [key, value]) => path.replace(`$${key}`, value),
+      to ?? '',
+    );
+    return (
+      <a ref={ref} href={href} {...rest}>
+        {children}
+      </a>
+    );
+  }),
+  useMatch: ({ from }: { from: string }) => {
+    if (!fixtures.onRun) return undefined;
+    if (from.includes('/runs/$runId')) return { params: {} };
+    return undefined;
+  },
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useAutomation: () => ({
+    data: {
+      document: { name: 'billing/dunning', nodes: [] },
+      ...(fixtures.presentation !== undefined
+        ? { presentation: fixtures.presentation }
+        : {}),
+    },
+    isPending: fixtures.isPending,
+  }),
+}));
+
+describe('AutomationBreadcrumbs', () => {
+  it('links Automations back to the org list and heads with the pack name', () => {
+    fixtures.presentation = {
+      name: 'Chase overdue invoices',
+      description: 'Sends the dunning ladder.',
+    };
+    fixtures.isPending = false;
+    fixtures.onRun = false;
+
+    render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+      />,
+    );
+
+    const parent = screen.getByRole('link', { name: 'Automations' });
+    expect(parent).toHaveAttribute('href', '/dashboard/org-1/automations');
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Chase overdue invoices',
+      }),
+    ).toBeVisible();
+  });
+
+  it('falls back to the slug read as a title when nothing was declared', () => {
+    fixtures.presentation = undefined;
+    fixtures.isPending = false;
+    fixtures.onRun = false;
+
+    render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Dunning' }),
+    ).toBeVisible();
+  });
+
+  it('always returns Automations to the org hub, even from a project-scoped page', () => {
+    fixtures.presentation = undefined;
+    fixtures.isPending = false;
+    fixtures.onRun = false;
+
+    render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+        projectId={asProjectId('proj-1')}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Automations' })).toHaveAttribute(
+      'href',
+      '/dashboard/org-1/automations',
+    );
+  });
+
+  it('on a run, links the automation name back to the automation page', () => {
+    fixtures.presentation = { name: 'Chase overdue invoices' };
+    fixtures.isPending = false;
+    fixtures.onRun = true;
+
+    render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Chase overdue invoices' }),
+    ).toHaveAttribute('href', '/dashboard/org-1/automations/billing__dunning');
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Run' }),
+    ).toBeVisible();
+    // Mobile back follows the immediate parent — the automation, not the list.
+    const back = screen.getByRole('link', { name: /back/i });
+    expect(back).toHaveAttribute(
+      'href',
+      '/dashboard/org-1/automations/billing__dunning',
+    );
+  });
+
+  it('on a project run, the name crumb stays on the project automation route', () => {
+    fixtures.presentation = { name: 'Chase overdue invoices' };
+    fixtures.isPending = false;
+    fixtures.onRun = true;
+
+    render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+        projectId={asProjectId('proj-1')}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Chase overdue invoices' }),
+    ).toHaveAttribute(
+      'href',
+      '/dashboard/org-1/projects/proj-1/automations/billing__dunning',
+    );
+  });
+
+  it('exposes a mobile back control to the parent list', () => {
+    fixtures.presentation = undefined;
+    fixtures.isPending = false;
+    fixtures.onRun = false;
+
+    render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+      />,
+    );
+
+    const back = screen.getByRole('link', { name: /back/i });
+    expect(back).toHaveClass('md:hidden');
+    expect(back).toHaveAttribute('href', '/dashboard/org-1/automations');
+  });
+
+  it('passes an axe audit', async () => {
+    fixtures.presentation = { name: 'Chase overdue invoices' };
+    fixtures.isPending = false;
+    fixtures.onRun = false;
+
+    const { container } = render(
+      <AutomationBreadcrumbs
+        organizationId="org-1"
+        automationSlug="billing/dunning"
+      />,
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/automations/components/automation-breadcrumbs.tsx
+++ b/services/platform/app/features/automations/components/automation-breadcrumbs.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+/**
+ * The adaptive-header trail for one automation (and its runs).
+ *
+ * On the automation page: `Automations / <name>` — the Automations crumb
+ * always returns to the org Automations hub (the project has no Automations
+ * tab; its `/automations` list sits under Projects chrome and reads as a
+ * detour). On a run page: `Automations / <name> / Run` — the name crumb
+ * returns to this automation (project-scoped when opened from a project),
+ * and the mobile back arrow follows that immediate parent.
+ */
+
+import { useLocale } from '@tale/ui/i18n/locale-provider';
+import { SkeletonBox } from '@tale/ui/skeleton';
+import { Skeletonize } from '@tale/ui/skeleton-context';
+import { Link, useMatch } from '@tanstack/react-router';
+
+import {
+  HEADER_CRUMB_LINK_CLASS,
+  HeaderBreadcrumbs,
+} from '@/app/components/layout/header-breadcrumbs';
+import type { Id } from '@/convex/_generated/dataModel';
+import { automationSlugToParam } from '@/lib/automations/slug';
+import { useT } from '@/lib/i18n/client';
+import { automationDisplayName } from '@/lib/shared/schemas/automation_presentation';
+
+import { useAutomation } from '../hooks/queries';
+
+export function AutomationBreadcrumbs({
+  organizationId,
+  automationSlug,
+  projectId,
+}: {
+  organizationId: string;
+  automationSlug: string;
+  /** When set, the automation name crumb (on a run) stays on the project route. */
+  projectId?: Id<'projects'>;
+}) {
+  const { t } = useT('automations');
+  const { t: tCommon } = useT('common');
+  const { locale } = useLocale();
+  const automationQuery = useAutomation(organizationId, automationSlug);
+  const displayName = automationDisplayName(
+    automationQuery.data?.presentation,
+    automationSlug,
+    locale,
+  );
+  const slugParam = automationSlugToParam(automationSlug);
+
+  // Either shell can host a run under this slug; the trail only cares that
+  // we ARE on a run, so the name crumb can point back at the automation.
+  const onOrgRun =
+    useMatch({
+      from: '/dashboard/$id/automations/$automationSlug/runs/$runId',
+      shouldThrow: false,
+    }) !== undefined;
+  const onProjectRun =
+    useMatch({
+      from: '/dashboard/$id/projects/$projectId/automations/$automationSlug/runs/$runId',
+      shouldThrow: false,
+    }) !== undefined;
+  const onRun = onOrgRun || onProjectRun;
+
+  // Always the org hub — project-scoped `/automations` renders inside the
+  // project shell (Projects / …), which is not what this crumb names.
+  const listCrumb = (
+    <Link
+      to="/dashboard/$id/automations"
+      params={{ id: organizationId }}
+      activeOptions={{ exact: true }}
+      className={HEADER_CRUMB_LINK_CLASS}
+    >
+      {t('title')}
+    </Link>
+  );
+
+  const automationCrumb =
+    projectId !== undefined ? (
+      <Link
+        to="/dashboard/$id/projects/$projectId/automations/$automationSlug"
+        params={{
+          id: organizationId,
+          projectId,
+          automationSlug: slugParam,
+        }}
+        activeOptions={{ exact: true }}
+        className={HEADER_CRUMB_LINK_CLASS}
+      >
+        {displayName}
+      </Link>
+    ) : (
+      <Link
+        to="/dashboard/$id/automations/$automationSlug"
+        params={{ id: organizationId, automationSlug: slugParam }}
+        activeOptions={{ exact: true }}
+        className={HEADER_CRUMB_LINK_CLASS}
+      >
+        {displayName}
+      </Link>
+    );
+
+  const nameLeaf = (
+    <Skeletonize
+      loading={automationQuery.isPending}
+      label={t('title')}
+      className="contents"
+    >
+      {automationQuery.isPending ? (
+        <SkeletonBox>
+          <span className="inline-block h-4 w-32 align-middle" />
+        </SkeletonBox>
+      ) : (
+        displayName
+      )}
+    </Skeletonize>
+  );
+
+  return (
+    <HeaderBreadcrumbs
+      ariaLabel={tCommon('aria.breadcrumb')}
+      crumbs={
+        onRun
+          ? [
+              { key: 'automations', content: listCrumb },
+              { key: 'automation', content: automationCrumb },
+            ]
+          : [{ key: 'automations', content: listCrumb }]
+      }
+      leaf={onRun ? t('runs.breadcrumb') : nameLeaf}
+    />
+  );
+}

--- a/services/platform/app/features/automations/components/automation-detail.test.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.test.tsx
@@ -158,27 +158,22 @@ beforeEach(() => {
 });
 
 describe('AutomationDetail', () => {
-  it('heads the page with the name the pack declared, in the reader s language', () => {
+  it('shows the pack description under the area breadcrumb', () => {
     state.presentation = {
       name: 'Chase overdue invoices',
       description: 'Sends the dunning ladder.',
       i18n: { de: { name: 'Offene Rechnungen anmahnen' } },
     };
     renderPage();
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Chase overdue invoices' }),
-    ).toBeVisible();
+    // The display name is the area header's breadcrumb leaf (covered by
+    // `automation-breadcrumbs.test.tsx`); this strip only carries the blurb.
     expect(screen.getByText('Sends the dunning ladder.')).toBeVisible();
   });
 
-  it('falls back to the slug read as a title when nothing was declared', () => {
-    // Canvas-authored automations declare no manifest; the slug is what the
-    // author typed, and its namespace is addressing — never the heading.
+  it('falls back to the document description when nothing was declared', () => {
     state.presentation = undefined;
     renderPage();
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Dunning' }),
-    ).toBeVisible();
+    expect(screen.getByText('Chases unpaid invoices.')).toBeVisible();
   });
 
   it('test-runs the version on screen, not the deployed one', async () => {

--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -29,10 +29,7 @@ import type { Id } from '@/convex/_generated/dataModel';
 import { automationSlugToParam } from '@/lib/automations/slug';
 import type { NodeDef, Automation } from '@/lib/engine/core/types';
 import { useT } from '@/lib/i18n/client';
-import {
-  automationDisplayDescription,
-  automationDisplayName,
-} from '@/lib/shared/schemas/automation_presentation';
+import { automationDisplayDescription } from '@/lib/shared/schemas/automation_presentation';
 
 import { mergeNodeTypes } from '../hooks/backend';
 import { useSaveAutomation, useStartAutomationRun } from '../hooks/mutations';
@@ -178,13 +175,6 @@ export function AutomationDetail({
     [automationQuery.data?.document],
   );
   const { locale } = useLocale();
-  // The heading is the automation's NAME; the slug rides in the subtitle below
-  // it, where an admin can still copy the store identity.
-  const displayName = automationDisplayName(
-    automationQuery.data?.presentation,
-    automationSlug,
-    locale,
-  );
   const automation = draft ?? stored;
   const graph = useMemo(() => buildGraph(automation), [automation]);
   const positions = useMemo(() => readPositions(automation), [automation]);
@@ -341,11 +331,9 @@ export function AutomationDetail({
   return (
     <>
       <PageActionHeader
-        // The automation's name is this page's heading: the area layout owns the
-        // `h1`, and without an `h2` here the outline would jump straight to the
-        // inspector and log headings below.
-        titleAs="h2"
-        title={displayName}
+        // The automation's display name is the area header's `h1` leaf
+        // (`AutomationBreadcrumbs`); this strip carries the description and
+        // the run / save actions only.
         {...(() => {
           // The manifest's own description in the reader's language when the
           // pack declared one; the document's otherwise.

--- a/services/platform/app/routes/dashboard/$id/automations.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet, useMatch } from '@tanstack/react-router';
 
 import {
   AdaptiveHeaderRoot,
@@ -6,6 +6,8 @@ import {
 } from '@/app/components/layout/adaptive-header';
 import { PageLayout } from '@/app/components/layout/page-layout';
 import { ActiveEditorProvider } from '@/app/components/ui/editor';
+import { AutomationBreadcrumbs } from '@/app/features/automations/components/automation-breadcrumbs';
+import { paramToAutomationSlug } from '@/lib/automations/slug';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
 
@@ -17,6 +19,10 @@ export const Route = createFileRoute('/dashboard/$id/automations')({
 /**
  * Shell for the automations area — the listing, one automation's canvas, and
  * one run all render under this header, which owns the page's only `h1`.
+ *
+ * On the hub the title is plain "Automations". On a detail or run route the
+ * header becomes the breadcrumb trail (`Automations / <name>`) so there is
+ * always a way back to the list — the contract pinned by the manual F3 case.
  *
  * `ActiveEditorProvider` is the registry the automation page's Save/Discard
  * cluster reads; this layout deliberately renders no cluster of its own, so the
@@ -31,13 +37,32 @@ export const Route = createFileRoute('/dashboard/$id/automations')({
 function AutomationsLayout() {
   const { id: organizationId } = Route.useParams();
   const { t } = useT('automations');
+  const detailMatch = useMatch({
+    from: '/dashboard/$id/automations/$automationSlug',
+    shouldThrow: false,
+  });
+  const automationSlug =
+    detailMatch !== undefined
+      ? paramToAutomationSlug(detailMatch.params.automationSlug)
+      : undefined;
+
   return (
     <ActiveEditorProvider>
       <PageLayout
         organizationId={organizationId}
         header={
-          <AdaptiveHeaderRoot>
-            <AdaptiveHeaderTitle>{t('title')}</AdaptiveHeaderTitle>
+          <AdaptiveHeaderRoot
+            standalone={false}
+            className={automationSlug !== undefined ? 'gap-2' : undefined}
+          >
+            {automationSlug !== undefined ? (
+              <AutomationBreadcrumbs
+                organizationId={organizationId}
+                automationSlug={automationSlug}
+              />
+            ) : (
+              <AdaptiveHeaderTitle>{t('title')}</AdaptiveHeaderTitle>
+            )}
           </AdaptiveHeaderRoot>
         }
       >

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/automations/$automationSlug.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/automations/$automationSlug.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
+import { AdaptiveHeaderRoot } from '@/app/components/layout/adaptive-header';
 import { PageLayout } from '@/app/components/layout/page-layout';
 import { ActiveEditorProvider } from '@/app/components/ui/editor';
+import { AutomationBreadcrumbs } from '@/app/features/automations/components/automation-breadcrumbs';
+import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
+import { paramToAutomationSlug } from '@/lib/automations/slug';
 import { seo } from '@/lib/utils/seo';
 
 export const Route = createFileRoute(
@@ -18,15 +22,33 @@ export const Route = createFileRoute(
  *
  * The project layout hands these routes a bare outlet — an automation's canvas
  * is not one of the project's tabs — so the shell they need is owned here: the
- * scrolling page frame, and the `ActiveEditorProvider` the automation page's
- * Save/Discard cluster reads. Like the org-level area layout, this renders no
- * cluster itself, so the page keeps exactly one.
+ * scrolling page frame, the Automations / <name> breadcrumb chrome, and the
+ * `ActiveEditorProvider` the automation page's Save/Discard cluster reads.
+ * Like the org-level area layout, this renders no cluster itself, so the page
+ * keeps exactly one.
  */
 function ProjectAutomationShell() {
-  const { id: organizationId } = Route.useParams();
+  const {
+    id: organizationId,
+    projectId,
+    automationSlug: automationSlugParam,
+  } = Route.useParams();
+  const automationSlug = paramToAutomationSlug(automationSlugParam);
+
   return (
     <ActiveEditorProvider>
-      <PageLayout organizationId={organizationId}>
+      <PageLayout
+        organizationId={organizationId}
+        header={
+          <AdaptiveHeaderRoot standalone={false} className="gap-2">
+            <AutomationBreadcrumbs
+              organizationId={organizationId}
+              automationSlug={automationSlug}
+              projectId={asProjectId(projectId)}
+            />
+          </AdaptiveHeaderRoot>
+        }
+      >
         <Outlet />
       </PageLayout>
     </ActiveEditorProvider>

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -843,6 +843,7 @@ automations:
       placeholder: Schreib deine Antwort — Freitext genügt.
       submit: Antwort senden & fortsetzen
     title: Läufe
+    breadcrumb: Lauf
     heading: 'Lauf von {automation}'
     empty: Diese Automatisierung ist noch nicht gelaufen.
     loading: Lauf wird geladen …

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -807,6 +807,7 @@ automations:
       placeholder: Type your answer — plain text is fine.
       submit: Send answer & resume
     title: Runs
+    breadcrumb: Run
     heading: 'Run of {automation}'
     empty: This automation has not run yet.
     loading: Loading the run…

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -848,6 +848,7 @@ automations:
       placeholder: Écris ta réponse — du texte simple suffit.
       submit: Envoyer la réponse & reprendre
     title: Exécutions
+    breadcrumb: Exécution
     heading: 'Exécution de {automation}'
     empty: Cette automatisation ne s’est encore jamais exécutée.
     loading: Chargement de l’exécution…


### PR DESCRIPTION
## Problem

An automation page named itself twice. The area header carried the section, and the detail strip repeated the automation's display name as its own `h2` — while offering no path back to the automations hub except the sidebar. On a run page there was no indication of where the run sat relative to its automation.

## Change

`AutomationBreadcrumbs` turns the area header into the trail:

- `Automations / <name>` on the automation page
- `Automations / <name> / Run` on a run page

The name becomes the `h1` leaf and every ancestor is a link, so the hub is one click away. The detail strip drops its own heading and keeps the description plus the run / save actions. Both the org-level and project-scoped automation shells render it.

## The typed-id fix

The project-scoped route passed its raw `useParams()` string into a prop declared as `Id<'projects'>`, which does not typecheck — `Id` is a branded string. It now brands the param through `asProjectId`, the helper that carries the single lint exemption for exactly this assertion, matching what the sibling project routes do. The component test used `'proj-1' as never` to dodge the same branding; it now uses the helper too, so the test exercises the real prop type.

## Tests

`automation-breadcrumbs.test.tsx` — hub link, name leaf, slug fallback when no display name resolves, the project-scoped run crumb, the mobile back target, and an axe audit. `automation-detail.test.tsx` moves its two heading assertions to the description, since the heading now lives in the trail.

Typecheck, lint, and format clean.

## Pre-existing failures on `main`, not from this branch

Reproduced on a pristine worktree at `121a11b3d`: `messages.test.ts` (2), `new-automation-dialog.test.tsx`, `node-inspector.test.tsx`, `products-crud.test.tsx`, `usage-metrics-page.test.tsx` — all stale assertions or catalog gaps from the #2897 copy rework, fixed in #2901. `providers-settings.test.tsx` is also red there and is flagged separately.