### PR TITLE
refactor(platform): sit the trigger and projects panels side by side

### DIFF
--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -485,17 +485,19 @@ export function AutomationDetail({
           />
         </div>
 
-        <TriggerEditor
-          organizationId={organizationId}
-          name={automationSlug}
-          canEdit={canAuthor}
-        />
+        <div className="grid items-stretch gap-6 lg:grid-cols-2">
+          <TriggerEditor
+            organizationId={organizationId}
+            name={automationSlug}
+            canEdit={canAuthor}
+          />
 
-        <ProjectBindingsSection
-          organizationId={organizationId}
-          name={automationSlug}
-          canEdit={canAuthor}
-        />
+          <ProjectBindingsSection
+            organizationId={organizationId}
+            name={automationSlug}
+            canEdit={canAuthor}
+          />
+        </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
           <VersionList

--- a/services/platform/app/features/automations/components/node-inspector.tsx
+++ b/services/platform/app/features/automations/components/node-inspector.tsx
@@ -243,16 +243,18 @@ export function NodeInspector({
   );
   const required = new Set(nodeType?.requiredFields ?? []);
 
+  // Match the canvas min-height so selecting a node cannot stretch the
+  // workbench; overflow scrolls natively inside the panel (no scroll-cue
+  // affordance — that pattern belongs to the list panels below).
   return (
     <section
       id={id}
       aria-labelledby={headingId}
-      className="border-border bg-card flex flex-col gap-4 rounded-lg border p-4"
+      className="border-border bg-card flex max-h-[26rem] flex-col gap-4 overflow-y-auto rounded-lg border p-4"
     >
       <SectionHeader
         as="h3"
         size="sm"
-        className="items-start gap-2"
         title={
           <span id={headingId} className="block truncate">
             {node.id}

--- a/services/platform/app/features/automations/components/project-bindings-section.tsx
+++ b/services/platform/app/features/automations/components/project-bindings-section.tsx
@@ -22,8 +22,11 @@ import { automationErrorMessage } from '../lib/errors';
  * every project's board sees it, one or more means exactly those projects —
  * so the panel edits the whole selection and saves it in one reconcile
  * (`setAutomationProjects`), the same one-row-of-truth shape as the trigger
- * panel above it. Deleting a project refuses while an automation is bound to
+ * panel beside it. Deleting a project refuses while an automation is bound to
  * it, so removals happen here first, deliberately.
+ *
+ * Laid out as a self-contained card so it can sit beside the Trigger panel
+ * on wide screens: header, growing body, actions pinned to the bottom.
  */
 export function ProjectBindingsSection({
   organizationId,
@@ -91,46 +94,52 @@ export function ProjectBindingsSection({
   return (
     <section
       aria-labelledby={headingId}
-      className="border-border flex flex-col gap-3 rounded-lg border p-3"
+      className="border-border flex h-full min-w-0 flex-col gap-4 rounded-lg border p-4"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <h3 id={headingId} className="text-sm font-semibold">
-          {t('bindings.title')}
-        </h3>
-        {boundQuery.data !== undefined &&
-          (stored.length === 0 ? (
-            <Badge variant="slate">{t('bindings.orgBadge')}</Badge>
-          ) : (
-            <Badge variant="blue">
-              {t('bindings.countBadge', { count: stored.length })}
-            </Badge>
-          ))}
-      </div>
-
-      <Text as="p" variant="muted" className="text-sm">
-        {t('bindings.hint')}
-      </Text>
-
-      {refusal !== null && (
-        <Alert variant="destructive" description={refusal} />
-      )}
-
-      {options.length === 0 ? (
-        <Text as="p" variant="muted" className="text-sm italic">
-          {t('bindings.noProjects')}
+      <header className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 id={headingId} className="text-sm font-semibold">
+            {t('bindings.title')}
+          </h3>
+          {boundQuery.data !== undefined &&
+            (stored.length === 0 ? (
+              <Badge variant="slate">{t('bindings.orgBadge')}</Badge>
+            ) : (
+              <Badge variant="blue">
+                {t('bindings.countBadge', { count: stored.length })}
+              </Badge>
+            ))}
+        </div>
+        <Text as="p" variant="muted" className="text-xs">
+          {t('bindings.hint')}
         </Text>
-      ) : (
-        <MultiSelect
-          value={selection}
-          onValueChange={setSelection}
-          options={options}
-          placeholder={t('bindings.placeholder')}
-          searchPlaceholder={t('bindings.searchPlaceholder')}
-          emptyText={t('bindings.empty')}
-          aria-label={t('bindings.title')}
-          disabled={!canEdit}
-        />
-      )}
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        {refusal !== null && (
+          <Alert variant="destructive" description={refusal} />
+        )}
+
+        {options.length === 0 ? (
+          <Text as="p" variant="muted" className="text-sm italic">
+            {t('bindings.noProjects')}
+          </Text>
+        ) : (
+          <MultiSelect
+            value={selection}
+            onValueChange={setSelection}
+            options={options}
+            placeholder={t('bindings.placeholder')}
+            searchPlaceholder={t('bindings.searchPlaceholder')}
+            emptyText={t('bindings.empty')}
+            aria-label={t('bindings.title')}
+            disabled={!canEdit}
+            // Bound sets can be long; keep the panel height honest next to
+            // Trigger and surface overflow with a scroll cue.
+            chipsMaxHeightClassName="max-h-40"
+          />
+        )}
+      </div>
 
       {canEdit && options.length > 0 && (
         <div className="flex flex-wrap items-center gap-2">

--- a/services/platform/app/features/automations/components/trigger-editor.tsx
+++ b/services/platform/app/features/automations/components/trigger-editor.tsx
@@ -41,6 +41,9 @@ function isTriggerKind(value: string): value is TriggerKind {
  * A trigger fires nothing until a version is deployed — `beginRun` resolves
  * through the deployment — which is why the panel never warns about arming a
  * draft: arming is safe by construction.
+ *
+ * Laid out as a self-contained card so it can sit beside the Projects panel
+ * on wide screens: header, growing body, actions pinned to the bottom.
  */
 export function TriggerEditor({
   organizationId,
@@ -133,120 +136,132 @@ export function TriggerEditor({
   return (
     <section
       aria-labelledby={headingId}
-      className="border-border flex flex-col gap-3 rounded-lg border p-3"
+      className="border-border flex h-full min-w-0 flex-col gap-4 rounded-lg border p-4"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <h3 id={headingId} className="text-sm font-semibold">
-          {t('trigger.title')}
-        </h3>
-        {stored !== undefined && (
-          <Badge variant={stored.enabled ? 'green' : 'slate'}>
-            {stored.enabled
-              ? t('trigger.enabledBadge')
-              : t('trigger.disabledBadge')}
-          </Badge>
-        )}
-        {stored?.lastFiredAt !== undefined && (
-          <Text as="span" variant="muted" className="text-xs">
-            {t('trigger.lastFired', {
-              at: formatDate(new Date(stored.lastFiredAt), 'long'),
-            })}
-          </Text>
-        )}
-      </div>
-
-      {stored === undefined && !canEdit && (
-        <Text as="p" variant="muted" className="text-sm">
-          {t('trigger.none')}
-        </Text>
-      )}
-
-      {refusal !== null && (
-        <Alert variant="destructive" description={refusal} />
-      )}
-
-      {mintedToken !== null && (
-        <Alert
-          variant="warning"
-          icon={KeyRound}
-          title={t('trigger.tokenTitle')}
-          description={
-            <span className="flex flex-col gap-1">
-              <span>{t('trigger.tokenHint')}</span>
-              <code className="bg-muted rounded px-1.5 py-0.5 text-xs break-all select-all">
-                {mintedToken}
-              </code>
-              <span>{t('trigger.tokenPath', { token: mintedToken })}</span>
-            </span>
-          }
-        />
-      )}
-
-      {(canEdit || stored !== undefined) && (
-        <div className="flex flex-wrap items-end gap-3">
-          <Select
-            label={t('trigger.kindLabel')}
-            options={TRIGGER_KINDS.map((value) => ({
-              value,
-              label: t(`trigger.kinds.${value}`),
-            }))}
-            value={kind}
-            onValueChange={(value) => {
-              if (isTriggerKind(value)) setKind(value);
-            }}
-            disabled={!canEdit}
-            className="w-40"
-          />
-          {kind === 'schedule' && (
-            <>
-              <Field label={t('trigger.cronLabel')} htmlFor={cronId}>
-                <Input
-                  id={cronId}
-                  value={cron}
-                  placeholder="0 */6 * * *"
-                  readOnly={!canEdit}
-                  onChange={(event) => setCron(event.target.value)}
-                  className="w-40 font-mono"
-                />
-              </Field>
-              <Field label={t('trigger.timezoneLabel')} htmlFor={timezoneId}>
-                <Input
-                  id={timezoneId}
-                  value={timezone}
-                  placeholder="UTC"
-                  readOnly={!canEdit}
-                  onChange={(event) => setTimezone(event.target.value)}
-                  className="w-44"
-                />
-              </Field>
-            </>
-          )}
-          {kind === 'event' && (
-            <Field label={t('trigger.eventLabel')} htmlFor={eventId}>
-              <Input
-                id={eventId}
-                value={eventName}
-                readOnly={!canEdit}
-                onChange={(event) => setEventName(event.target.value)}
-                className="w-56"
-              />
-            </Field>
-          )}
-          {kind === 'webhook' && (
-            <Text as="p" variant="muted" className="max-w-md text-xs">
-              {stored?.hasToken === true
-                ? t('trigger.hasToken')
-                : t('trigger.noToken')}
+      <header className="flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 id={headingId} className="text-sm font-semibold">
+              {t('trigger.title')}
+            </h3>
+            {stored !== undefined && (
+              <Badge variant={stored.enabled ? 'green' : 'slate'}>
+                {stored.enabled
+                  ? t('trigger.enabledBadge')
+                  : t('trigger.disabledBadge')}
+              </Badge>
+            )}
+          </div>
+          {stored?.lastFiredAt !== undefined && (
+            <Text as="p" variant="muted" className="text-xs">
+              {t('trigger.lastFired', {
+                at: formatDate(new Date(stored.lastFiredAt), 'long'),
+              })}
             </Text>
           )}
+        </div>
+        {(canEdit || stored !== undefined) && (
           <Switch
             label={t('trigger.enabledLabel')}
             checked={enabled}
             onCheckedChange={setEnabled}
             disabled={!canEdit}
           />
-        </div>
-      )}
+        )}
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        {stored === undefined && !canEdit && (
+          <Text as="p" variant="muted" className="text-sm">
+            {t('trigger.none')}
+          </Text>
+        )}
+
+        {refusal !== null && (
+          <Alert variant="destructive" description={refusal} />
+        )}
+
+        {mintedToken !== null && (
+          <Alert
+            variant="warning"
+            icon={KeyRound}
+            title={t('trigger.tokenTitle')}
+            description={
+              <span className="flex flex-col gap-1">
+                <span>{t('trigger.tokenHint')}</span>
+                <code className="bg-muted rounded px-1.5 py-0.5 text-xs break-all select-all">
+                  {mintedToken}
+                </code>
+                <span>{t('trigger.tokenPath', { token: mintedToken })}</span>
+              </span>
+            }
+          />
+        )}
+
+        {(canEdit || stored !== undefined) && (
+          <div
+            className={
+              kind === 'schedule'
+                ? 'grid gap-3 sm:grid-cols-3'
+                : 'grid gap-3 sm:grid-cols-2'
+            }
+          >
+            <Select
+              label={t('trigger.kindLabel')}
+              options={TRIGGER_KINDS.map((value) => ({
+                value,
+                label: t(`trigger.kinds.${value}`),
+              }))}
+              value={kind}
+              onValueChange={(value) => {
+                if (isTriggerKind(value)) setKind(value);
+              }}
+              disabled={!canEdit}
+              className="min-w-0"
+            />
+            {kind === 'schedule' && (
+              <>
+                <Field label={t('trigger.cronLabel')} htmlFor={cronId}>
+                  <Input
+                    id={cronId}
+                    value={cron}
+                    placeholder="0 */6 * * *"
+                    readOnly={!canEdit}
+                    onChange={(event) => setCron(event.target.value)}
+                    className="font-mono"
+                  />
+                </Field>
+                <Field label={t('trigger.timezoneLabel')} htmlFor={timezoneId}>
+                  <Input
+                    id={timezoneId}
+                    value={timezone}
+                    placeholder="UTC"
+                    readOnly={!canEdit}
+                    onChange={(event) => setTimezone(event.target.value)}
+                  />
+                </Field>
+              </>
+            )}
+            {kind === 'event' && (
+              <Field label={t('trigger.eventLabel')} htmlFor={eventId}>
+                <Input
+                  id={eventId}
+                  value={eventName}
+                  readOnly={!canEdit}
+                  onChange={(event) => setEventName(event.target.value)}
+                />
+              </Field>
+            )}
+            {kind === 'webhook' && (
+              <Text as="p" variant="muted" className="self-end text-xs">
+                {stored?.hasToken === true
+                  ? t('trigger.hasToken')
+                  : t('trigger.noToken')}
+              </Text>
+            )}
+          </div>
+        )}
+      </div>
 
       {canEdit && (
         <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Problem

Trigger and Projects were full-width bands stacked down the automation page. A short trigger left a wide empty strip, and the two settings that together describe *when an automation runs* sat far apart from each other.

## Change

- Both panels get the same card shell — header, growing body, actions pinned to the bottom — and sit on a two-column grid from `lg`, stretched to equal height.
- The trigger's fixed-width fields become a responsive grid so they reflow inside the narrower column.
- The **node inspector** is capped at the canvas min-height, so selecting a node can no longer stretch the workbench. It scrolls natively rather than taking the scroll-cue affordance — that pattern belongs to the list panels below it. Its section header drops the `items-start gap-2` override that the full-width description from #2903 makes unnecessary.
- The **project picker** caps its chip row and surfaces overflow through the shared scroll cue from #2905, since bound sets get long.

## Verification

Rebased onto `main` at 265507a1a, after the four prerequisites (#2903, #2905, #2907) merged — so this is now four files and one commit, with no stack.

- Full typecheck: 14/14 workspaces
- Full lint gate (`oxlint --type-aware`): 19/19
- Automations suite: 117/117, including `node-inspector.test.tsx` — worth noting since this changes that component
- i18n gate: 48/48

`automation-detail.tsx` was split by hunk between #2907 (heading removal) and this PR (the grid wrap). The two `node-inspector` edits sit three lines apart, so that file shipped whole here rather than being carved between the two. All four files were diffed against the working tree they came from and reassemble byte-identically, so nothing was dropped in the split.