### PR TITLE
fix(platform): download file chips under their real names

### DIFF
--- a/services/platform/app/features/shared/files/file-displays.test.tsx
+++ b/services/platform/app/features/shared/files/file-displays.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { render, screen } from '@/tests/utils/render';
 
@@ -7,12 +7,28 @@ import type { FilePart } from './types';
 // FilePartDisplay gates on live storage existence via useFileUrl; drive the
 // three states (loading / exists / deleted) through this mutable holder. The
 // real hook subscribes to Convex, which throws outside a live deployment.
+// Calls are recorded so FileAttachmentDisplay tests can assert WHICH
+// arguments were passed (the download-naming contract).
 let fileUrlData: string | null | undefined;
+const useFileUrlCalls: unknown[][] = [];
 vi.mock('./use-file-url', () => ({
-  useFileUrl: () => ({ data: fileUrlData }),
+  useFileUrl: (...args: unknown[]) => {
+    useFileUrlCalls.push(args);
+    return { data: fileUrlData };
+  },
 }));
 
-import { FilePartDisplay } from './file-displays';
+// FileAttachmentDisplay's audio-transcript lookup subscribes via the raw
+// convex `useQuery` (needs a live ConvexProvider); not under test here.
+vi.mock('convex/react', () => ({
+  useQuery: () => undefined,
+}));
+
+import { FileAttachmentDisplay, FilePartDisplay } from './file-displays';
+
+beforeEach(() => {
+  useFileUrlCalls.length = 0;
+});
 
 const STORAGE_URL =
   'http://localhost:3000/http_api/storage?id=kg2test123&filename=slide-1.jpg';
@@ -98,5 +114,77 @@ describe('FilePartDisplay', () => {
     const editButton = screen.getByRole('button', { name: 'Edit this image' });
     expect(editButton.className).not.toContain('opacity-0');
     expect(editButton.className).not.toContain('group-hover');
+  });
+});
+
+function attachment(
+  overrides: Partial<{
+    fileName: string;
+    fileType: string;
+    previewUrl: string;
+  }> = {},
+) {
+  return {
+    fileId: 'storage-1',
+    fileName: 'spec.pdf',
+    fileType: 'application/pdf',
+    fileSize: 1024,
+    ...overrides,
+  };
+}
+
+// REGRESSION: task Output / attachment chips resolved a bare
+// `/api/storage/<uuid>` URL, so the browser saved downloads under the storage
+// uuid instead of the real file name. Non-image chips must request a NAMED
+// URL (served with Content-Disposition); images and audio/video must not —
+// their URLs render inline (thumbnail, lightbox, native player).
+describe('FileAttachmentDisplay — download naming', () => {
+  const NAMED_URL =
+    'http://localhost:3000/http_api/storage?id=storage-1&filename=spec.pdf';
+
+  it('resolves a document chip with its file name and links the named URL', () => {
+    fileUrlData = NAMED_URL;
+    render(
+      <FileAttachmentDisplay
+        attachment={attachment()}
+        organizationId="org_1"
+      />,
+    );
+
+    expect(useFileUrlCalls).toEqual([['storage-1', false, 'spec.pdf']]);
+    expect(screen.getByRole('link')).toHaveAttribute('href', NAMED_URL);
+  });
+
+  it('resolves an image without a file name so it keeps rendering inline', () => {
+    fileUrlData = undefined;
+    render(
+      <FileAttachmentDisplay
+        attachment={attachment({
+          fileName: 'photo.png',
+          fileType: 'image/png',
+          previewUrl: 'blob:photo-1',
+        })}
+        organizationId="org_1"
+        onImageClick={vi.fn()}
+      />,
+    );
+
+    expect(useFileUrlCalls).toEqual([['storage-1', true, undefined]]);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('resolves audio without a file name so the chip keeps opening the player', () => {
+    fileUrlData = 'http://localhost:3000/api/storage/storage-1';
+    render(
+      <FileAttachmentDisplay
+        attachment={attachment({
+          fileName: 'memo.mp3',
+          fileType: 'audio/mpeg',
+        })}
+        organizationId="org_1"
+      />,
+    );
+
+    expect(useFileUrlCalls).toEqual([['storage-1', false, undefined]]);
   });
 });

--- a/services/platform/app/features/shared/files/file-displays.tsx
+++ b/services/platform/app/features/shared/files/file-displays.tsx
@@ -182,13 +182,19 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
   onImageClick?: () => void;
 }) {
   const { t } = useT('chat');
+  const isImage = attachment.fileType.startsWith('image/');
+  const isMedia = isAudioOrVideo(attachment.fileType);
+  // Document chips are download targets: resolve their URL with the real file
+  // name so it serves as `Content-Disposition: attachment` and the browser
+  // saves e.g. `slides.pptx` instead of the bare storage uuid. Images stay
+  // unnamed (they render inline in the thumbnail + lightbox); audio/video too,
+  // so their chip keeps opening the browser's inline player.
   const { data: serverFileUrl } = useFileUrl(
     attachment.fileId,
     !!attachment.previewUrl,
+    isImage || isMedia ? undefined : attachment.fileName,
   );
   const displayUrl = attachment.previewUrl || serverFileUrl || undefined;
-  const isImage = attachment.fileType.startsWith('image/');
-  const isMedia = isAudioOrVideo(attachment.fileType);
 
   // For audio/video attachments in sent messages, fetch the transcript via
   // the existing plural query (skip when not media to avoid subscriptions).

--- a/services/platform/app/features/shared/files/use-file-url.ts
+++ b/services/platform/app/features/shared/files/use-file-url.ts
@@ -2,11 +2,22 @@ import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 
 // `fileId` is a blob REFERENCE (a `_storage` id or an `s3:` ref) — the server
-// query resolves the URL backend-aware either way.
-export function useFileUrl(fileId: string | undefined, skip = false) {
+// query resolves the URL backend-aware either way. Pass `fileName` when the
+// URL is a download target: the resolved URL then carries the real name via
+// Content-Disposition, so the browser saves it instead of the storage uuid.
+// Leave it off for URLs that must render inline (images, embedded previews).
+export function useFileUrl(
+  fileId: string | undefined,
+  skip = false,
+  fileName?: string,
+) {
   return useConvexQuery(
     api.files.queries.getFileUrl,
-    !fileId || skip ? 'skip' : { fileId },
+    !fileId || skip
+      ? 'skip'
+      : fileName === undefined
+        ? { fileId }
+        : { fileId, fileName },
   );
 }
 

--- a/services/platform/convex/files/queries.test.ts
+++ b/services/platform/convex/files/queries.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return { ...mod, query: (config: Record<string, unknown>) => config };
+});
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+const { getFileUrl } = await import('./queries');
+
+// oxlint-disable-next-line typescript/no-explicit-any -- vi.mock narrows to { handler }
+type Handler = { handler: (ctx: unknown, args: unknown) => Promise<any> };
+const handler = (getFileUrl as unknown as Handler).handler;
+
+const CONVEX_ID = 'kg2abc123';
+const RAW_STORAGE_URL = `http://127.0.0.1:3210/api/storage/${CONVEX_ID}`;
+
+function createCtx(opts: {
+  storageUrl?: string | null;
+  fileMetadata?: unknown;
+}) {
+  return {
+    storage: {
+      getUrl: vi.fn(async () => opts.storageUrl ?? null),
+    },
+    db: {
+      query: () => ({
+        withIndex: () => ({
+          first: async () => opts.fileMetadata ?? null,
+        }),
+      }),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.stubEnv('SITE_URL', 'https://tale.example');
+  vi.stubEnv('BASE_PATH', '');
+  mockGetAuthUserIdentity.mockResolvedValue({ userId: 'user_1' });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe('getFileUrl', () => {
+  it('returns the bare proxy-rewritten storage URL without a fileName', async () => {
+    const ctx = createCtx({ storageUrl: RAW_STORAGE_URL });
+
+    const url = await handler(ctx, { fileId: CONVEX_ID });
+
+    expect(url).toBe(`https://tale.example/api/storage/${CONVEX_ID}`);
+  });
+
+  it('routes through the Content-Disposition endpoint when a fileName is passed', async () => {
+    const ctx = createCtx({ storageUrl: RAW_STORAGE_URL });
+
+    const url = await handler(ctx, {
+      fileId: CONVEX_ID,
+      fileName: '大熊猫介绍.pptx',
+    });
+
+    // The `/storage` httpAction serves `filename=` as
+    // `Content-Disposition: attachment` — the browser saves the real name
+    // instead of the storage uuid.
+    expect(url).toBe(
+      `https://tale.example/http_api/storage?id=${CONVEX_ID}&filename=${encodeURIComponent('大熊猫介绍.pptx')}`,
+    );
+  });
+
+  it('still resolves deleted blobs to null on the named path', async () => {
+    const ctx = createCtx({ storageUrl: null });
+
+    const url = await handler(ctx, {
+      fileId: CONVEX_ID,
+      fileName: 'gone.pdf',
+    });
+
+    // Callers (e.g. FilePartDisplay) drop dead references on null — a named
+    // download URL must never be fabricated for a deleted blob.
+    expect(url).toBeNull();
+    expect(ctx.storage.getUrl).toHaveBeenCalledWith(CONVEX_ID);
+  });
+
+  it('prefers the passed fileName over the fileMetadata name for an s3 ref', async () => {
+    const ctx = createCtx({
+      fileMetadata: { organizationId: 'org_1', fileName: 'server-name.pdf' },
+    });
+
+    const url = await handler(ctx, {
+      fileId: 's3:org_1/abc',
+      fileName: 'client-name.pdf',
+    });
+
+    expect(url).toBe(
+      `https://tale.example/http_api/storage?ref=${encodeURIComponent('s3:org_1/abc')}&org=org_1&filename=client-name.pdf`,
+    );
+  });
+
+  it('falls back to the fileMetadata name for an s3 ref without a fileName', async () => {
+    const ctx = createCtx({
+      fileMetadata: { organizationId: 'org_1', fileName: 'server-name.pdf' },
+    });
+
+    const url = await handler(ctx, { fileId: 's3:org_1/abc' });
+
+    expect(url).toBe(
+      `https://tale.example/http_api/storage?ref=${encodeURIComponent('s3:org_1/abc')}&org=org_1&filename=server-name.pdf`,
+    );
+  });
+
+  it('returns null when unauthenticated', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(null);
+    const ctx = createCtx({ storageUrl: RAW_STORAGE_URL });
+
+    const url = await handler(ctx, { fileId: CONVEX_ID, fileName: 'a.pdf' });
+
+    expect(url).toBeNull();
+  });
+});

--- a/services/platform/convex/files/queries.ts
+++ b/services/platform/convex/files/queries.ts
@@ -5,6 +5,7 @@ import type { QueryCtx } from '../_generated/server';
 import { query } from '../_generated/server';
 import {
   buildBlobServeUrl,
+  buildDownloadUrl,
   toPublicUrl,
 } from '../lib/helpers/public_storage_url';
 import { getAuthUserIdentity } from '../lib/rls';
@@ -22,10 +23,18 @@ import {
  * ref we resolve the owning org from the blob's `fileMetadata` row so the route
  * can address the right bucket; a ref with no fileMetadata row is unservable
  * here → null.
+ *
+ * `fileName` opts into a named download: the URL then routes through the
+ * `/storage` HTTP action, which serves the blob with `Content-Disposition:
+ * attachment; filename=…`. Without it a Convex blob serves from the bare
+ * `/api/storage/<uuid>` path and the browser saves it under the uuid. Leave
+ * it off for URLs that must render inline (image previews, the document
+ * preview dialog).
  */
 async function resolveBlobUrl(
   ctx: QueryCtx,
   ref: BlobRef,
+  fileName?: string,
 ): Promise<string | null> {
   if (isS3Ref(ref)) {
     const meta = await ctx.db
@@ -33,17 +42,27 @@ async function resolveBlobUrl(
       .withIndex('by_storageId', (q) => q.eq('storageId', ref))
       .first();
     if (!meta) return null;
-    return buildBlobServeUrl(String(ref), meta.organizationId, meta.fileName);
+    return buildBlobServeUrl(
+      String(ref),
+      meta.organizationId,
+      fileName ?? meta.fileName,
+    );
   }
   const convexId = convexStorageId(ref);
   if (convexId === null) return null;
+  // Resolve the storage URL even on the named path — a null here means the
+  // blob was deleted, and callers rely on null to drop dead references.
   const url = await ctx.storage.getUrl(convexId);
-  return url ? toPublicUrl(url) : null;
+  if (!url) return null;
+  return fileName === undefined
+    ? toPublicUrl(url)
+    : buildDownloadUrl(String(convexId), fileName);
 }
 
 export const getFileUrl = query({
   args: {
     fileId: blobRefValidator,
+    fileName: v.optional(v.string()),
   },
   returns: v.union(v.string(), v.null()),
   handler: async (ctx, args) => {
@@ -51,7 +70,7 @@ export const getFileUrl = query({
     if (!authUser) return null;
 
     try {
-      return await resolveBlobUrl(ctx, args.fileId);
+      return await resolveBlobUrl(ctx, args.fileId, args.fileName);
     } catch {
       return null;
     }

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -916,11 +916,7 @@ async function settleTaskAgentTurn(
   const body = [
     resultText,
     ...(fileNames.length > 0
-      ? [
-          ['Files produced:', ...fileNames.map((name) => `- ${name}`)].join(
-            '\n',
-          ),
-        ]
+      ? [['Deliverables:', ...fileNames.map((name) => `- ${name}`)].join('\n')]
       : []),
   ].join('\n\n');
 

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -42,7 +42,10 @@ import {
   sessionDeleteFiles,
   sessionIsAlive,
   sessionListFiles,
+  sessionStageFiles,
+  type SessionStageFile,
 } from '../node_only/sandbox/helpers/session_client';
+import { stageUrlForBlobRef } from '../node_only/sandbox/helpers/stage_url';
 import { resolveGatewayRouting } from '../node_only/sandbox/llm_gateway_admin';
 import {
   harvestSessionOutput,
@@ -183,10 +186,106 @@ export function taskOutputDir(taskId: string): string {
   return `${OUTPUT_DIR}/${taskId}`;
 }
 
+/** The task's read-only INPUTS mirror — where the start stages the user's
+ * attachments and the task's current deliverables before every turn. Each
+ * run is a FRESH conversation and the delivery box is swept at start, so
+ * without this mirror a rerun asked to "extend the deck" cannot see the deck
+ * it is extending (it would grab whatever stale files another task left in
+ * the shared standing workspace). Outside `/user/output` so the box sweep
+ * and the settle harvest never touch it. */
+export function taskInputsDir(taskId: string): string {
+  return `/user/inputs/${taskId}`;
+}
+
+/** Flatten a stored file name into a single safe path segment for the inputs
+ * mirror and dedupe collisions. Attachment names are user input and only
+ * length-capped at write time, so separators and dot-tricks must die here —
+ * the daemon would reject the traversal anyway, but as a whole-staging
+ * failure instead of a renamed file. Exported for its unit test. */
+export function safeInputFileName(raw: string, taken: Set<string>): string {
+  let name = raw.replace(/[\\/]/g, '_').trim();
+  if (name === '' || name === '.' || name === '..') name = 'file';
+  let candidate = name;
+  for (let suffix = 2; taken.has(candidate); suffix += 1) {
+    candidate = `${suffix}-${name}`;
+  }
+  taken.add(candidate);
+  return candidate;
+}
+
+/** What `stageTaskInputs` actually landed, for the prompt to name. */
+export interface StagedTaskInputs {
+  dir: string;
+  attachments: string[];
+  outputs: string[];
+}
+
+/**
+ * Mirror the task's inputs into the standing session: the user's attachments
+ * under `<dir>/attachments/`, the task's current deliverables (earlier runs'
+ * harvested outputs) under `<dir>/outputs/`. Re-mirrored from scratch every
+ * turn — attachments and outputs may have changed since the last run, and a
+ * stale mirror would mislead worse than none. A purged blob under a live row
+ * skips that file (mirroring `stageWorkflowFiles`); a staging failure throws
+ * so the run fails with the real reason instead of quietly proceeding
+ * blind.
+ */
+async function stageTaskInputs(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    sessionId: string;
+    taskId: string;
+    attachments: Array<{ fileId: string; fileName: string }>;
+    outputs: Array<{ fileId: string; fileName: string }>;
+  },
+): Promise<StagedTaskInputs> {
+  const dir = taskInputsDir(args.taskId);
+  const staged: StagedTaskInputs = { dir, attachments: [], outputs: [] };
+  try {
+    await sessionDeleteFiles(args.sessionId, [dir]);
+  } catch (err) {
+    console.warn('[task-agent] inputs pre-clear failed (continuing):', err);
+  }
+  const toStage: SessionStageFile[] = [];
+  for (const [kind, files] of [
+    ['attachments', args.attachments],
+    ['outputs', args.outputs],
+  ] as const) {
+    const taken = new Set<string>();
+    for (const file of files) {
+      const url = await stageUrlForBlobRef(
+        ctx,
+        file.fileId,
+        args.organizationId,
+      );
+      if (url === null) continue; // blob purged under a live row — skip, don't fail
+      const name = safeInputFileName(file.fileName, taken);
+      toStage.push({ path: `${dir}/${kind}/${name}`, url });
+      staged[kind].push(name);
+    }
+  }
+  if (toStage.length === 0) return staged;
+  const result = await sessionStageFiles(args.sessionId, toStage);
+  if (result.skipped.length > 0) {
+    throw new Error(
+      `staging task inputs failed: ${result.skipped
+        .map((skip) => skip.path)
+        .join(', ')}`,
+    );
+  }
+  return staged;
+}
+
 /** Phrase the turn's prompt from the task brief. Exported for its unit test.
  * `feedback` is the @mention comment that kicked a rerun — it leads the
  * brief's work section so the agent treats it as the delta to address, not
- * as one more line of context. `outputDir` is the task's OWN delivery box:
+ * as one more line of context (the same comment closes the discussion tail,
+ * so it is dropped from there rather than said twice). `discussion` is the
+ * rerun's only memory of earlier runs — each turn is a fresh conversation.
+ * `inputs` names what `stageTaskInputs` landed, and the same-file-name rule
+ * makes a revision REPLACE the task's deliverable instead of piling a
+ * renamed sibling next to it. `outputDir` is the task's OWN delivery box:
  * named in the user prompt (not only the system addendum) because a resumed
  * standing-session conversation happily reuses last turn's path from memory,
  * and a deliverable written outside the box is not collected. */
@@ -197,14 +296,38 @@ export function buildTaskPrompt(
     labels?: string[];
     identifier?: string;
     projectName?: string;
+    discussion?: Array<{ author: 'user' | 'agent'; body: string }>;
   },
   feedback?: string,
   outputDir?: string,
+  inputs?: StagedTaskInputs,
 ): string {
   const heading =
     brief.identifier !== undefined
       ? `You are working on task ${brief.identifier}: ${brief.title}`
       : `You are working on this task: ${brief.title}`;
+  const feedbackText = feedback?.trim() ?? '';
+  let discussion = brief.discussion ?? [];
+  const lastEntry = discussion.at(-1);
+  if (
+    feedbackText !== '' &&
+    lastEntry?.author === 'user' &&
+    lastEntry.body.trim() === feedbackText
+  ) {
+    discussion = discussion.slice(0, -1);
+  }
+  const stagedLines = [
+    ...(inputs !== undefined && inputs.attachments.length > 0
+      ? [
+          `- ${inputs.dir}/attachments/ — files the user attached to the task: ${inputs.attachments.join(', ')}`,
+        ]
+      : []),
+    ...(inputs !== undefined && inputs.outputs.length > 0
+      ? [
+          `- ${inputs.dir}/outputs/ — the task's current deliverables, produced by earlier runs: ${inputs.outputs.join(', ')}`,
+        ]
+      : []),
+  ];
   return [
     heading,
     ...(brief.projectName !== undefined
@@ -216,9 +339,33 @@ export function buildTaskPrompt(
     ...(brief.description !== undefined && brief.description !== ''
       ? [`Description:\n${brief.description}`]
       : []),
-    ...(feedback !== undefined && feedback.trim() !== ''
+    ...(discussion.length > 0
       ? [
-          `The task was sent back with reviewer feedback — address it before anything else:\n${feedback.trim()}`,
+          [
+            'Task discussion so far (oldest first — earlier runs of you posted the agent messages):',
+            ...discussion.map(
+              (entry) =>
+                `${entry.author === 'user' ? 'User' : 'You (an earlier run)'}: ${entry.body}`,
+            ),
+          ].join('\n\n'),
+        ]
+      : []),
+    ...(feedbackText !== ''
+      ? [
+          `The task was sent back with reviewer feedback — address it before anything else:\n${feedbackText}`,
+        ]
+      : []),
+    ...(stagedLines.length > 0
+      ? [
+          [
+            `Task inputs — read-only copies staged for this turn:`,
+            ...stagedLines,
+            ...(inputs !== undefined && inputs.outputs.length > 0
+              ? [
+                  'To revise an existing deliverable, start from its staged copy and write the updated file into the delivery box under the SAME file name — it replaces the previous version on the task.',
+                ]
+              : []),
+          ].join('\n'),
         ]
       : []),
     ...(outputDir !== undefined
@@ -331,6 +478,14 @@ export const startTaskAgentTurn = internalAction({
       );
       if (brief === null) throw new Error('the task no longer exists');
 
+      const inputs = await stageTaskInputs(ctx, {
+        organizationId: args.organizationId,
+        sessionId: args.sessionId,
+        taskId: args.taskId,
+        attachments: brief.attachments,
+        outputs: brief.outputs,
+      });
+
       // A text-only serving model still meets image inputs (task
       // attachments, scanned PDFs) — arm the vision polyfill so those route
       // through the gateway instead of 404ing the turn.
@@ -398,6 +553,7 @@ export const startTaskAgentTurn = internalAction({
           : []),
         ...(skillsAddendum !== '' ? [skillsAddendum] : []),
         `Write every file you produce to ${outputDir}/ (this task's own delivery box — never plain /user/output/) — files there are collected when your turn ends and attached to the task.`,
+        `Your workspace (/user/workspace) is a standing area shared across ALL tasks assigned to you — files already there may belong to other tasks. Trust the task brief and its staged inputs over anything found lying around.`,
       ].join('\n\n');
 
       const exec = buildExternalTurnExec({
@@ -405,7 +561,7 @@ export const startTaskAgentTurn = internalAction({
         gatewayModel: routing.gatewayModel,
         serving: { kind: 'gateway', token: key.token },
         instructions,
-        prompt: buildTaskPrompt(brief, args.feedback, outputDir),
+        prompt: buildTaskPrompt(brief, args.feedback, outputDir, inputs),
         execId: args.execId,
         ...(args.connectors.length > 0
           ? { bridgeUrl: connectorsBridgeUrlForSessions() }

--- a/services/platform/convex/tasks/agent_run_prompt.test.ts
+++ b/services/platform/convex/tasks/agent_run_prompt.test.ts
@@ -1,10 +1,18 @@
 // `buildTaskPrompt` — the task-agent turn's brief. Feedback (the @mention
 // comment that kicked a rerun) must lead the work section as the delta to
 // address, and its absence must leave the brief byte-identical to before.
+// The discussion tail and the staged-inputs block are a rerun's ONLY memory
+// of earlier runs (each turn is a fresh conversation), so their rendering —
+// and their absence leaving the brief untouched — is pinned here too.
 
 import { describe, expect, it } from 'vitest';
 
-import { buildTaskPrompt, taskOutputDir } from './agent_run_host';
+import {
+  buildTaskPrompt,
+  safeInputFileName,
+  taskInputsDir,
+  taskOutputDir,
+} from './agent_run_host';
 
 const BRIEF = {
   title: 'Build the deck',
@@ -12,6 +20,15 @@ const BRIEF = {
   identifier: 'TAL-7',
   projectName: 'Apollo',
 };
+
+const DISCUSSION = [
+  { author: 'user' as const, body: '请做一份熊猫介绍' },
+  {
+    author: 'agent' as const,
+    body: 'Done — 20 slides delivered as deck.pptx.',
+  },
+  { author: 'user' as const, body: '趣闻栏目再加两页 @alice' },
+];
 
 describe('buildTaskPrompt', () => {
   it('folds reviewer feedback in ahead of the report instruction', () => {
@@ -46,5 +63,101 @@ describe('taskOutputDir', () => {
     expect(prompt.indexOf('Deliverables:')).toBeLessThan(
       prompt.indexOf('When you are done'),
     );
+  });
+});
+
+describe('discussion tail', () => {
+  it('renders oldest-first between the description and the feedback, deduping the kicking comment', () => {
+    const prompt = buildTaskPrompt(
+      { ...BRIEF, discussion: DISCUSSION },
+      '趣闻栏目再加两页 @alice',
+    );
+    expect(prompt).toContain('Task discussion so far');
+    expect(prompt).toContain('User: 请做一份熊猫介绍');
+    expect(prompt).toContain(
+      'You (an earlier run): Done — 20 slides delivered as deck.pptx.',
+    );
+    // The kicking comment appears exactly once — as feedback, not history.
+    expect(prompt.match(/趣闻栏目再加两页/g)).toHaveLength(1);
+    expect(prompt.indexOf('Task discussion')).toBeGreaterThan(
+      prompt.indexOf('Description:'),
+    );
+    expect(prompt.indexOf('Task discussion')).toBeLessThan(
+      prompt.indexOf('reviewer feedback'),
+    );
+  });
+
+  it('keeps a trailing user comment that is NOT the feedback', () => {
+    const prompt = buildTaskPrompt(
+      { ...BRIEF, discussion: DISCUSSION },
+      'a different instruction',
+    );
+    expect(prompt).toContain('User: 趣闻栏目再加两页 @alice');
+  });
+
+  it('an empty tail leaves the brief byte-identical', () => {
+    expect(buildTaskPrompt({ ...BRIEF, discussion: [] })).toBe(
+      buildTaskPrompt(BRIEF),
+    );
+  });
+});
+
+describe('staged task inputs', () => {
+  const INPUTS = {
+    dir: taskInputsDir('wh76abc'),
+    attachments: ['spec.pdf'],
+    outputs: ['deck.pptx'],
+  };
+
+  it('names the staged copies and the same-file-name replace rule', () => {
+    const prompt = buildTaskPrompt(
+      BRIEF,
+      undefined,
+      '/user/output/wh76abc',
+      INPUTS,
+    );
+    expect(prompt).toContain(
+      '- /user/inputs/wh76abc/attachments/ — files the user attached to the task: spec.pdf',
+    );
+    expect(prompt).toContain(
+      "- /user/inputs/wh76abc/outputs/ — the task's current deliverables, produced by earlier runs: deck.pptx",
+    );
+    expect(prompt).toContain('under the SAME file name');
+    expect(prompt.indexOf('Task inputs')).toBeLessThan(
+      prompt.indexOf('Deliverables:'),
+    );
+  });
+
+  it('omits the replace rule when no prior deliverables were staged', () => {
+    const prompt = buildTaskPrompt(BRIEF, undefined, undefined, {
+      ...INPUTS,
+      outputs: [],
+    });
+    expect(prompt).toContain('spec.pdf');
+    expect(prompt).not.toContain('SAME file name');
+  });
+
+  it('nothing staged leaves the brief byte-identical', () => {
+    expect(
+      buildTaskPrompt(BRIEF, undefined, undefined, {
+        ...INPUTS,
+        attachments: [],
+        outputs: [],
+      }),
+    ).toBe(buildTaskPrompt(BRIEF));
+  });
+});
+
+describe('safeInputFileName', () => {
+  it('flattens separators, refuses dot-names, and dedupes collisions', () => {
+    const taken = new Set<string>();
+    expect(safeInputFileName('../../etc/passwd', taken)).toBe(
+      '.._.._etc_passwd',
+    );
+    expect(safeInputFileName('spec.pdf', taken)).toBe('spec.pdf');
+    expect(safeInputFileName('spec.pdf', taken)).toBe('2-spec.pdf');
+    expect(safeInputFileName('spec.pdf', taken)).toBe('3-spec.pdf');
+    expect(safeInputFileName('  ', taken)).toBe('file');
+    expect(safeInputFileName('..', taken)).toBe('2-file');
   });
 });

--- a/services/platform/convex/tasks/agent_runs.ts
+++ b/services/platform/convex/tasks/agent_runs.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { internal } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
 import { internalMutation, internalQuery } from '../_generated/server';
+import { readTaskDiscussionMessages } from './internal_queries';
 
 /**
  * Run-row internals for task agent runs — the small, transactional pieces the
@@ -40,9 +41,23 @@ export const getTaskAgentRunForDrive = internalQuery({
   },
 });
 
-/** Everything the node host needs to phrase the turn's prompt. Comment
- * history is a follow-up: comment text lives in the agent component store,
- * so v1 briefs carry the task fields only. */
+/** The brief carries at most this tail of the task discussion, each message
+ * clipped, so a long thread cannot flood the turn's prompt. The tail always
+ * spans the previous run's report and the review that followed it — the two
+ * messages a rerun must not lose. */
+const BRIEF_DISCUSSION_MAX_MESSAGES = 10;
+const BRIEF_DISCUSSION_MAX_MESSAGE_CHARS = 2000;
+
+function clipDiscussionBody(body: string): string {
+  if (body.length <= BRIEF_DISCUSSION_MAX_MESSAGE_CHARS) return body;
+  return `${body.slice(0, BRIEF_DISCUSSION_MAX_MESSAGE_CHARS)}\n… (truncated)`;
+}
+
+/** Everything the node host needs to phrase the turn's prompt and stage the
+ * task's inputs: the task fields, a bounded tail of the discussion (so a
+ * rerun knows what earlier runs delivered and what reviewers said — each run
+ * is a FRESH conversation, this is its only memory), and the blob refs of the
+ * user's attachments and the task's current deliverables. */
 export const getTaskBriefForAgentRun = internalQuery({
   args: { taskId: v.id('tasks') },
   returns: v.union(
@@ -52,6 +67,16 @@ export const getTaskBriefForAgentRun = internalQuery({
       labels: v.optional(v.array(v.string())),
       identifier: v.optional(v.string()),
       projectName: v.optional(v.string()),
+      discussion: v.array(
+        v.object({
+          author: v.union(v.literal('user'), v.literal('agent')),
+          body: v.string(),
+        }),
+      ),
+      attachments: v.array(
+        v.object({ fileId: v.string(), fileName: v.string() }),
+      ),
+      outputs: v.array(v.object({ fileId: v.string(), fileName: v.string() })),
     }),
     v.null(),
   ),
@@ -63,6 +88,15 @@ export const getTaskBriefForAgentRun = internalQuery({
       project?.key !== undefined && task.number !== undefined
         ? `${project.key}-${task.number}`
         : undefined;
+    const discussion = (await readTaskDiscussionMessages(ctx, task))
+      .slice(-BRIEF_DISCUSSION_MAX_MESSAGES)
+      .map((message) => ({
+        author:
+          message.authorType === 'user'
+            ? ('user' as const)
+            : ('agent' as const),
+        body: clipDiscussionBody(message.body),
+      }));
     return {
       title: task.title,
       ...(task.description !== undefined
@@ -71,6 +105,15 @@ export const getTaskBriefForAgentRun = internalQuery({
       ...(task.labels !== undefined ? { labels: task.labels } : {}),
       ...(identifier !== undefined ? { identifier } : {}),
       ...(project !== null ? { projectName: project.name } : {}),
+      discussion,
+      attachments: (task.attachments ?? []).map((attachment) => ({
+        fileId: String(attachment.fileId),
+        fileName: attachment.fileName,
+      })),
+      outputs: (task.outputs ?? []).map((output) => ({
+        fileId: String(output.fileId),
+        fileName: output.fileName,
+      })),
     };
   },
 });

--- a/services/platform/convex/tasks/task_agent_runs.test.ts
+++ b/services/platform/convex/tasks/task_agent_runs.test.ts
@@ -638,3 +638,106 @@ describe('capacity parking', () => {
     expect(parked).toHaveLength(1);
   });
 });
+
+describe('getTaskBriefForAgentRun', () => {
+  function world(): T {
+    const t = convexTest(schema, modules);
+    rateLimiterComponent.register(t);
+    agentComponent.register(t);
+    return t;
+  }
+
+  it('carries the discussion tail and the input blob refs alongside the task fields', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+    const asEditor = t.withIdentity({ subject: EDITOR });
+
+    // A mention-free comment (never kicks) followed by an agent report — the
+    // exchange a rerun must see to know what was already delivered.
+    await asEditor.mutation(api.tasks.mutations.addTaskComment, {
+      taskId,
+      body: '请对齐字体',
+    });
+    await t.mutation(internal.tasks.internal_mutations.agentAddComment, {
+      organizationId: ORG,
+      actorId: 'agent_alice',
+      taskId,
+      body: 'Done — delivered deck.pptx with 20 slides.',
+    });
+
+    // A prior run's harvested deliverable plus a user attachment on the task.
+    await asEditor.mutation(api.tasks.mutations.startTaskAgentRun, { taskId });
+    await t.run(async (ctx) => {
+      const run = await ctx.db.query('projectAgentRuns').first();
+      if (run === null) throw new Error('seed run missing');
+      await ctx.db.patch(taskId, {
+        attachments: [
+          {
+            fileId: 'blob-spec',
+            fileName: 'spec.pdf',
+            fileType: 'application/pdf',
+            fileSize: 10,
+          },
+        ],
+        outputs: [
+          {
+            fileId: 'blob-deck',
+            fileName: 'deck.pptx',
+            fileType: 'application/vnd.ms-powerpoint',
+            fileSize: 20,
+            producedAt: 1,
+            runId: run._id,
+          },
+        ],
+      });
+    });
+
+    const brief = await t.query(
+      internal.tasks.agent_runs.getTaskBriefForAgentRun,
+      { taskId },
+    );
+    expect(brief?.discussion).toEqual([
+      { author: 'user', body: '请对齐字体' },
+      { author: 'agent', body: 'Done — delivered deck.pptx with 20 slides.' },
+    ]);
+    expect(brief?.attachments).toEqual([
+      { fileId: 'blob-spec', fileName: 'spec.pdf' },
+    ]);
+    expect(brief?.outputs).toEqual([
+      { fileId: 'blob-deck', fileName: 'deck.pptx' },
+    ]);
+  });
+
+  it('clips an oversize comment body instead of flooding the prompt', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: 'x'.repeat(2500),
+      });
+
+    const brief = await t.query(
+      internal.tasks.agent_runs.getTaskBriefForAgentRun,
+      { taskId },
+    );
+    expect(brief?.discussion).toHaveLength(1);
+    expect(brief?.discussion[0]?.body.endsWith('… (truncated)')).toBe(true);
+    expect(brief?.discussion[0]?.body.length).toBeLessThan(2100);
+  });
+
+  it('a task with no discussion, attachments, or outputs yields empty lists', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    const brief = await t.query(
+      internal.tasks.agent_runs.getTaskBriefForAgentRun,
+      { taskId },
+    );
+    expect(brief?.discussion).toEqual([]);
+    expect(brief?.attachments).toEqual([]);
+    expect(brief?.outputs).toEqual([]);
+  });
+});

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -7076,7 +7076,7 @@ tasks:
     uploading: Uploading…
     dropHint: Drop images or documents, or click to browse
   outputs:
-    label: Output
+    label: Deliverables
   title: Tasks
   entityLabel: tasks
   status:


### PR DESCRIPTION
## Problem

Downloading a file from a task's **Output** zone (or any attachment chip) saved it as the storage uuid — e.g. `05886297-2b8b-4a9f-9267-af6ae71021d8.pptx` instead of `大熊猫介绍.pptx`.

## Root cause

`getFileUrl`'s Convex branch returned the bare proxy-rewritten storage URL (`toPublicUrl(storage.getUrl(id))` → `/api/storage/<uuid>`). No filename travels on that path, so the browser names the download from the URL's last segment and infers the extension from Content-Type. The `s3:` branch of the same resolver already passed `meta.fileName` — only Convex-backed blobs were affected.

## Fix

- `getFileUrl` accepts an optional `fileName`; when present, the Convex branch returns `buildDownloadUrl` (the `/storage` HTTP action, which serves `Content-Disposition: attachment` with an RFC 5987 UTF-8 filename — non-ASCII names survive intact). The s3 branch honors the same override. Without `fileName`, behavior is unchanged.
- The named path still resolves `storage.getUrl` first, preserving the null-for-deleted contract callers rely on to drop dead references.
- `FileAttachmentDisplay` requests a named URL for **document chips only**: images keep rendering inline (thumbnail + lightbox), audio/video chips keep opening the native player, and embedded previews (`document-preview-dialog`) stay on unnamed URLs.
- Chat's `FilePartDisplay` needed no change — run_code/doc-gen lanes already persist named URLs.

Note: document chips that browsers can render inline (PDF, txt) now download with their real name instead of opening in a tab — consistent with the Documents area and with S3-backed orgs, which already behaved this way.

## Verification

- New regression tests: `convex/files/queries.test.ts` (named vs bare URL, UTF-8 encoding, deleted-blob null, s3 name override, unauthenticated) and `FileAttachmentDisplay` download-naming contract in `file-displays.test.tsx`.
- 110 tests across the 10 suites touching `use-file-url` pass; `tsc --noEmit` and `oxlint --type-aware` clean.
- Verified live in dev: Output chip href now carries `?id=…&filename=…`, response serves `Content-Disposition: attachment; filename*=UTF-8''大熊猫介绍.pptx`, and a real browser click yields the suggested filename `大熊猫介绍.pptx`.