### PR TITLE
feat(platform): offer one-click deploy after automation upload

### DIFF
--- a/docs/de/platform/automations/catalog.md
+++ b/docs/de/platform/automations/catalog.md
@@ -39,7 +39,7 @@ Zum Hochladen öffnest du **Automatisierungen**, wählst im Menü **Neue Automat
 - **Die Dateien** — `workflow.yml`, plus `automation.yml`, wenn das Pack eine mitbringt. Richtig für ein Pack, das nur aus seinem Dokument besteht.
 - **Eine `.zip` des Pack-Verzeichnisses** — Pflicht, wenn das Pack Skills mitbringt, denn nur die Zip kann deren Ordner tragen. Markdown-Notizen außerhalb von `skills/` — etwa ein README — ignoriert der Upload, genauso wie Dotfiles und Build-Reste (`__pycache__/`, `node_modules/`); zippe das Verzeichnis also, wie es ist, ruhig direkt nach einem Testlauf. Die Zip bleibt unter 20 MiB.
 
-Wähle vor dem Absenden, wo die Automatisierung installiert wird — Organisation oder ein Projekt. Die Wahl ist nicht endgültig: Die Installation in ein Projekt bindet die Automatisierung daran, und im Bereich **Projekte** auf ihrer Seite verwaltest du die Bindungen später — binde weitere Projekte oder entferne alle, dann gilt sie organisationsweit.
+Wähle vor dem Absenden, wo die Automatisierung installiert wird — Organisation oder ein Projekt. Ein Pack, dessen Manifest `scope: project` deklariert, installiert sich nur in ein Projekt; einen organisationsweiten Upload lehnt der Server ab. Die Wahl ist nicht endgültig: Die Installation in ein Projekt bindet die Automatisierung daran, und im Bereich **Projekte** auf ihrer Seite verwaltest du die Bindungen später — binde weitere Projekte oder entferne alle, dann gilt sie organisationsweit.
 
 <Frame caption="Paket hochladen — die Dateien oder eine Zip, und wo die Automatisierung installiert wird.">
 
@@ -47,7 +47,7 @@ Wähle vor dem Absenden, wo die Automatisierung installiert wird — Organisatio
 
 </Frame>
 
-Der Server validiert, bevor irgendetwas gespeichert wird. Das Dokument durchläuft dieselbe Engine-Validierung wie im Editor — ein Upload, der nicht laufen würde, wird mit den Meldungen der Engine abgelehnt statt kaputt gespeichert — und die Blöcke `subjects` und `settings` des Manifests werden zum Task-Vertrag und zu den [Einstellungsformularen](#einstellungen-die-das-paket-deklariert) der Automatisierung, genau wie ein Save vom Canvas sie setzen würde. Was landet, ist eine **Entwurfsversion** hinter dem normalen Deploy-Gate: Kein Trigger läuft, bevor du sie auf der Seite der Automatisierung deployst.
+Der Server validiert, bevor irgendetwas gespeichert wird. Das Dokument durchläuft dieselbe Engine-Validierung wie im Editor — ein Upload, der nicht laufen würde, wird mit den Meldungen der Engine abgelehnt statt kaputt gespeichert — und die Blöcke `subjects` und `settings` des Manifests werden zum Task-Vertrag und zu den [Einstellungsformularen](#einstellungen-die-das-paket-deklariert) der Automatisierung, genau wie ein Save vom Canvas sie setzen würde. Was landet, ist eine **Entwurfsversion** hinter dem normalen Deploy-Gate — kein Trigger läuft, solange keine Version live ist. Der Dialog bietet das Deployen direkt nach dem Upload an: Schalte die neue Version gleich dort live, oder wähle **Später** und deploye von der Seite der Automatisierung, wenn du bereit bist.
 
 Lädst du das Pack einer bestehenden Automatisierung erneut hoch, entsteht die nächste Version — der Store überschreibt nie Geschichte, jede frühere Version bleibt exakt, wo sie war. Wählst du dabei ein Projekt als Ziel, kommt dessen Bindung zu den bestehenden hinzu.
 

--- a/docs/en/platform/automations/catalog.md
+++ b/docs/en/platform/automations/catalog.md
@@ -39,7 +39,7 @@ To upload one, open **Automations**, pick **Upload package** from the **New auto
 - **The files** — `workflow.yml`, plus `automation.yml` when the pack ships one. Right for a pack that is only its document.
 - **One `.zip` of the pack directory** — required when the pack carries skills, since only the zip can hold their folders. Markdown notes outside `skills/` — a README, a design record — are ignored, as are dotfiles and build leftovers (`__pycache__/`, `node_modules/`), so zip the directory as it is, straight after a test run; the zip stays under 20 MiB.
 
-Pick where the automation installs — the organization, or one project — before you submit. The choice is not final: installing into a project binds the automation to it, and the **Projects** panel on the automation's page manages the whole set afterwards — bind more projects, or none to serve the whole organization.
+Pick where the automation installs — the organization, or one project — before you submit. A pack whose manifest declares `scope: project` only installs into a project; an organization-wide upload of one is refused. The choice is not final: installing into a project binds the automation to it, and the **Projects** panel on the automation's page manages the whole set afterwards — bind more projects, or none to serve the whole organization.
 
 <Frame caption="Upload package — the files or one zip, and where the automation installs.">
 
@@ -47,7 +47,7 @@ Pick where the automation installs — the organization, or one project — befo
 
 </Frame>
 
-The server validates before anything is stored. The document runs through the same engine validation the editor uses — an upload that would not run is refused with the engine's own issues, not saved broken — and the manifest's `subjects` and `settings` blocks become the automation's task contract and [settings forms](#settings-the-pack-declares), exactly as a save from the canvas would set them. What lands is a **draft version** behind the normal deploy gate: nothing triggers run until you deploy it from the automation's page.
+The server validates before anything is stored. The document runs through the same engine validation the editor uses — an upload that would not run is refused with the engine's own issues, not saved broken — and the manifest's `subjects` and `settings` blocks become the automation's task contract and [settings forms](#settings-the-pack-declares), exactly as a save from the canvas would set them. What lands is a **draft version** behind the normal deploy gate — nothing triggers run until a version is deployed. The dialog offers the deploy the moment the upload succeeds: make the new version live right there, or pick **Later** and deploy from the automation's page when you're ready.
 
 Uploading an existing automation's pack again appends the next version — the store never overwrites history, so every earlier version stays exactly where it was. Choosing a project as the target also binds the existing automation to that project, on top of whatever projects it already serves.
 

--- a/docs/fr/platform/automations/catalog.md
+++ b/docs/fr/platform/automations/catalog.md
@@ -39,7 +39,7 @@ Pour téléverser, ouvre **Automatisations**, choisis **Téléverser un paquet**
 - **Les fichiers** — `workflow.yml`, plus `automation.yml` si le pack en fournit un. Le bon choix pour un pack qui n’est que son document.
 - **Un seul `.zip` du dossier du pack** — obligatoire quand le pack embarque des skills, puisque seul le zip peut porter leurs dossiers. Les notes Markdown hors de `skills/` (un README, par exemple) sont ignorées, tout comme les dotfiles et les résidus de build (`__pycache__/`, `node_modules/`) — alors zippe le dossier tel quel, même juste après avoir lancé les tests. Le zip reste sous 20 MiB.
 
-Choisis avant d’envoyer où l’automatisation s’installe — l’organisation, ou un projet. Le choix n’est pas définitif : installer dans un projet lie l’automatisation à ce projet, et le panneau **Projets** de sa page gère l’ensemble ensuite — lie d’autres projets, ou aucun pour qu’elle serve toute l’organisation.
+Choisis avant d’envoyer où l’automatisation s’installe — l’organisation, ou un projet. Un pack dont le manifeste déclare `scope: project` ne s’installe que dans un projet ; le serveur refuse de l’installer à l’échelle de l’organisation. Le choix n’est pas définitif : installer dans un projet lie l’automatisation à ce projet, et le panneau **Projets** de sa page gère l’ensemble ensuite — lie d’autres projets, ou aucun pour qu’elle serve toute l’organisation.
 
 <Frame caption="Téléverser un paquet — les fichiers ou un zip, et où l’automatisation s’installe.">
 
@@ -47,7 +47,7 @@ Choisis avant d’envoyer où l’automatisation s’installe — l’organisati
 
 </Frame>
 
-Le serveur valide avant d’enregistrer quoi que ce soit. Le document passe par la même validation moteur que l’éditeur — un téléversement qui ne tournerait pas est refusé avec les messages du moteur, pas enregistré cassé — et les blocs `subjects` et `settings` du manifeste deviennent le contrat de tâches et les [formulaires de paramètres](#paramètres-déclarés-par-le-pack) de l’automatisation, exactement comme le ferait un enregistrement depuis le canvas. Ce qui atterrit est une **version brouillon** derrière la barrière de déploiement habituelle : aucun déclencheur ne tourne avant que tu la déploies depuis la page de l’automatisation.
+Le serveur valide avant d’enregistrer quoi que ce soit. Le document passe par la même validation moteur que l’éditeur — un téléversement qui ne tournerait pas est refusé avec les messages du moteur, pas enregistré cassé — et les blocs `subjects` et `settings` du manifeste deviennent le contrat de tâches et les [formulaires de paramètres](#paramètres-déclarés-par-le-pack) de l’automatisation, exactement comme le ferait un enregistrement depuis le canvas. Ce qui atterrit est une **version brouillon** derrière la barrière de déploiement habituelle — aucun déclencheur ne tourne tant qu’aucune version n’est en service. Le dialogue propose la mise en service dès que le téléversement réussit : mets la nouvelle version en service directement, ou choisis **Plus tard** et fais-le depuis la page de l’automatisation quand tu veux.
 
 Téléverser à nouveau le pack d’une automatisation existante ajoute la version suivante — le store n’écrase jamais l’historique, chaque version antérieure reste exactement où elle était. Choisir un projet comme cible lie aussi l’automatisation existante à ce projet, en plus de ceux qu’elle sert déjà.
 

--- a/services/platform/app/features/automations/components/upload-automation-dialog.test.tsx
+++ b/services/platform/app/features/automations/components/upload-automation-dialog.test.tsx
@@ -39,6 +39,13 @@ vi.mock('convex/react', () => ({
       : recordIntent,
 }));
 
+// The success step's deploy button rides the shared mutation hook; the mock
+// hands the test control over the onSuccess/onError callbacks.
+const deployMutate = vi.fn();
+vi.mock('../hooks/mutations', () => ({
+  useDeployAutomation: () => ({ mutate: deployMutate, isPending: false }),
+}));
+
 // The generated api proxies are plain objects here; the useMutation mock keys
 // off the reference identity strings below.
 vi.mock('@/convex/_generated/api', () => ({
@@ -68,6 +75,7 @@ beforeEach(() => {
     json: async () => ({ storageId: 'storage_1' }),
   });
   uploadAction.mockReset();
+  deployMutate.mockReset();
   toast.mockReset();
   invalidateQueries.mockReset();
   generateUploadUrl.mockClear();
@@ -79,12 +87,15 @@ afterEach(() => {
 });
 
 /** The dialog is controlled — its trigger lives in the list's create menu. */
-async function openDialogWith(files: File[]) {
+async function openDialogWith(
+  files: File[],
+  onOpenChange: (open: boolean) => void = () => {},
+) {
   const utils = render(
     <UploadAutomationDialog
       organizationId="org_1"
       open
-      onOpenChange={() => {}}
+      onOpenChange={onOpenChange}
     />,
   );
   const input = screen.getByLabelText('automations.upload.filesLabel', {
@@ -93,6 +104,9 @@ async function openDialogWith(files: File[]) {
   await utils.user.upload(input, files);
   return utils;
 }
+
+const WORKFLOW_FILE = () =>
+  new File(['name: demo\nnodes: []\n'], 'workflow.yml', { type: 'text/yaml' });
 
 describe('UploadAutomationDialog', () => {
   it('sends text files through the text lane', async () => {
@@ -174,6 +188,84 @@ describe('UploadAutomationDialog', () => {
     });
     // The carried skill invalidates the skills queries.
     expect(invalidateQueries).toHaveBeenCalled();
+  });
+
+  it('offers deploying the uploaded draft and closes on success', async () => {
+    uploadAction.mockResolvedValue({
+      ok: true,
+      name: 'demo',
+      version: 2,
+      warnings: ['n1 [W_TEST] check this'],
+      skills: [],
+    });
+    deployMutate.mockImplementation(
+      (_vars: unknown, opts?: { onSuccess?: () => void }) =>
+        opts?.onSuccess?.(),
+    );
+    const onOpenChange = vi.fn();
+    const { user } = await openDialogWith([WORKFLOW_FILE()], onOpenChange);
+    await user.click(
+      screen.getByRole('button', { name: 'automations.upload.submit' }),
+    );
+    const deployButton = await screen.findByTestId('deploy-uploaded-version');
+    // The upload's validation warnings surface inline on the success step.
+    expect(screen.getByText('n1 [W_TEST] check this')).toBeVisible();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    await user.click(deployButton);
+    expect(deployMutate).toHaveBeenCalledWith(
+      { organizationId: 'org_1', name: 'demo', version: 2 },
+      expect.anything(),
+    );
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('surfaces a deploy refusal inline and stays open', async () => {
+    uploadAction.mockResolvedValue({
+      ok: true,
+      name: 'demo',
+      version: 1,
+      warnings: [],
+      skills: [],
+    });
+    deployMutate.mockImplementation(
+      (_vars: unknown, opts?: { onError?: (error: unknown) => void }) =>
+        opts?.onError?.({
+          data: { code: 'X', message: 'deploy gate: failing tests' },
+        }),
+    );
+    const onOpenChange = vi.fn();
+    const { user } = await openDialogWith([WORKFLOW_FILE()], onOpenChange);
+    await user.click(
+      screen.getByRole('button', { name: 'automations.upload.submit' }),
+    );
+    await user.click(await screen.findByTestId('deploy-uploaded-version'));
+    expect(await screen.findByText('deploy gate: failing tests')).toBeVisible();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it('closes without deploying via Later', async () => {
+    uploadAction.mockResolvedValue({
+      ok: true,
+      name: 'demo',
+      version: 1,
+      warnings: [],
+      skills: [],
+    });
+    const onOpenChange = vi.fn();
+    const { user } = await openDialogWith([WORKFLOW_FILE()], onOpenChange);
+    await user.click(
+      screen.getByRole('button', { name: 'automations.upload.submit' }),
+    );
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'automations.upload.deployLater',
+      }),
+    );
+    expect(deployMutate).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it('shows the conflict panel and re-runs the flow with the allowlist', async () => {

--- a/services/platform/app/features/automations/components/upload-automation-dialog.tsx
+++ b/services/platform/app/features/automations/components/upload-automation-dialog.tsx
@@ -7,7 +7,14 @@ import { Row, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAction, useMutation } from 'convex/react';
-import { FileArchive, FileText, Upload, X } from 'lucide-react';
+import {
+  FileArchive,
+  FileText,
+  Rocket,
+  Upload,
+  X,
+  XCircle,
+} from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
@@ -20,6 +27,7 @@ import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
+import { useDeployAutomation } from '../hooks/mutations';
 import { automationErrorMessage } from '../lib/errors';
 
 /** The org sentinel of the destination picker — not a project id. */
@@ -31,6 +39,13 @@ const MAX_ZIP_BYTES = 20 * 1024 * 1024;
 interface SkillReport {
   slug: string;
   action: 'created' | 'replaced' | 'unchanged';
+}
+
+/** The saved draft the success step offers to deploy. */
+interface UploadedVersion {
+  name: string;
+  version: number;
+  warnings: string[];
 }
 
 /**
@@ -63,7 +78,10 @@ export function UploadAutomationDialog({
   const [phase, setPhase] = useState<'uploading' | 'validating'>('validating');
   const [refusal, setRefusal] = useState<string | null>(null);
   const [skillConflicts, setSkillConflicts] = useState<string[] | null>(null);
+  const [uploaded, setUploaded] = useState<UploadedVersion | null>(null);
+  const [deployRefusal, setDeployRefusal] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const deploy = useDeployAutomation();
 
   const { projects } = useProjects(organizationId);
   const upload = useAction(api.automations.upload_action.uploadAutomation);
@@ -86,6 +104,8 @@ export function UploadAutomationDialog({
     setTarget(projectId ?? ORG_TARGET);
     setRefusal(null);
     setSkillConflicts(null);
+    setUploaded(null);
+    setDeployRefusal(null);
     abortRef.current?.abort();
     abortRef.current = null;
   };
@@ -106,13 +126,6 @@ export function UploadAutomationDialog({
     warnings: string[];
     skills: SkillReport[];
   }) => {
-    toast({
-      title: t('upload.uploaded', {
-        name: result.name,
-        version: result.version,
-      }),
-      variant: 'success',
-    });
     if (result.skills.length > 0) {
       const count = (action: SkillReport['action']) =>
         result.skills.filter((skill) => skill.action === action).length;
@@ -127,13 +140,43 @@ export function UploadAutomationDialog({
         queryKey: configKeys.type('skills'),
       });
     }
-    if (result.warnings.length > 0) {
-      toast({
-        title: t('upload.warnings', { count: result.warnings.length }),
-      });
-    }
-    onOpenChange(false);
-    reset();
+    // The form gives way to the success step instead of closing: the saved
+    // version is a draft that never runs on its own, and a transient toast
+    // proved too easy to miss for that to be the only deploy prompt.
+    setFiles([]);
+    setUploaded({
+      name: result.name,
+      version: result.version,
+      warnings: result.warnings,
+    });
+  };
+
+  const deployUploaded = () => {
+    if (uploaded === null) return;
+    setDeployRefusal(null);
+    deploy.mutate(
+      {
+        organizationId,
+        name: uploaded.name,
+        version: uploaded.version,
+      },
+      {
+        onSuccess: () => {
+          toast({
+            title: t('upload.deployed', {
+              name: uploaded.name,
+              version: uploaded.version,
+            }),
+            variant: 'success',
+          });
+          onOpenChange(false);
+          reset();
+        },
+        onError: (error) => {
+          setDeployRefusal(automationErrorMessage(error));
+        },
+      },
+    );
   };
 
   /** The zip lane: presign → POST the blob → bind the intent → validate. */
@@ -222,13 +265,20 @@ export function UploadAutomationDialog({
         onOpenChange(next);
         if (!next) reset();
       }}
-      title={t('upload.title')}
-      description={t('upload.description')}
+      title={uploaded === null ? t('upload.title') : t('upload.successTitle')}
+      description={
+        uploaded === null
+          ? t('upload.description')
+          : t('upload.successNote', {
+              name: uploaded.name,
+              version: uploaded.version,
+            })
+      }
       submitText={t('upload.submit')}
       submittingText={
         phase === 'uploading' ? t('upload.uploading') : t('upload.submitting')
       }
-      isSubmitting={pending}
+      isSubmitting={pending || deploy.isPending}
       isValid={
         files.length > 0 && !mixedZipSelection && skillConflicts === null
       }
@@ -238,136 +288,193 @@ export function UploadAutomationDialog({
         event.preventDefault();
         void run();
       }}
+      customFooter={
+        uploaded === null ? undefined : (
+          <>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={deploy.isPending}
+              onClick={() => {
+                onOpenChange(false);
+                reset();
+              }}
+            >
+              {t('upload.deployLater')}
+            </Button>
+            <Button
+              type="button"
+              icon={Rocket}
+              isLoading={deploy.isPending}
+              onClick={deployUploaded}
+              data-testid="deploy-uploaded-version"
+            >
+              {t('upload.deployNow', { version: uploaded.version })}
+            </Button>
+          </>
+        )
+      }
     >
-      <Stack gap={4}>
-        {refusal !== null && (
-          <Alert variant="destructive" description={refusal} />
-        )}
-
-        {skillConflicts !== null && (
-          <Alert
-            variant="warning"
-            description={
-              <Stack gap={2}>
-                <Text as="p" className="font-medium">
-                  {t('upload.skillConflictTitle', {
-                    count: skillConflicts.length,
-                  })}
-                </Text>
-                <Text as="p" variant="muted" className="text-xs">
-                  {t('upload.skillConflictDescription')}
-                </Text>
+      {uploaded !== null ? (
+        <Stack gap={4}>
+          {deployRefusal !== null && (
+            <Alert
+              variant="destructive"
+              icon={XCircle}
+              title={t('versions.deployRefused')}
+              description={deployRefusal}
+            />
+          )}
+          <Text as="p" variant="muted" className="text-sm">
+            {t('upload.successHint')}
+          </Text>
+          {uploaded.warnings.length > 0 && (
+            <Alert
+              variant="warning"
+              title={t('upload.warnings', {
+                count: uploaded.warnings.length,
+              })}
+              description={
                 <ul className="list-disc pl-4 text-sm">
-                  {skillConflicts.map((slug) => (
-                    <li key={slug}>{slug}</li>
+                  {uploaded.warnings.map((line) => (
+                    <li key={line}>{line}</li>
                   ))}
                 </ul>
-                <Row gap={2}>
-                  <Button
-                    type="button"
-                    size="sm"
-                    disabled={pending}
-                    onClick={() => void run(skillConflicts)}
-                    data-testid="confirm-skill-overwrite"
-                  >
-                    {t('upload.skillConflictConfirm', {
+              }
+            />
+          )}
+        </Stack>
+      ) : (
+        <Stack gap={4}>
+          {refusal !== null && (
+            <Alert variant="destructive" description={refusal} />
+          )}
+
+          {skillConflicts !== null && (
+            <Alert
+              variant="warning"
+              description={
+                <Stack gap={2}>
+                  <Text as="p" className="font-medium">
+                    {t('upload.skillConflictTitle', {
                       count: skillConflicts.length,
                     })}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    disabled={pending}
-                    onClick={() => setSkillConflicts(null)}
-                  >
-                    {t('upload.skillConflictCancel')}
-                  </Button>
-                </Row>
-              </Stack>
-            }
-          />
-        )}
+                  </Text>
+                  <Text as="p" variant="muted" className="text-xs">
+                    {t('upload.skillConflictDescription')}
+                  </Text>
+                  <ul className="list-disc pl-4 text-sm">
+                    {skillConflicts.map((slug) => (
+                      <li key={slug}>{slug}</li>
+                    ))}
+                  </ul>
+                  <Row gap={2}>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={pending}
+                      onClick={() => void run(skillConflicts)}
+                      data-testid="confirm-skill-overwrite"
+                    >
+                      {t('upload.skillConflictConfirm', {
+                        count: skillConflicts.length,
+                      })}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={pending}
+                      onClick={() => setSkillConflicts(null)}
+                    >
+                      {t('upload.skillConflictCancel')}
+                    </Button>
+                  </Row>
+                </Stack>
+              }
+            />
+          )}
 
-        <Field label={t('upload.filesLabel')} htmlFor={filesId}>
-          <FileUpload.Root>
-            <FileUpload.DropZone
-              onFilesSelected={(picked) => {
-                setFiles(picked);
-                setRefusal(null);
-                setSkillConflicts(null);
-              }}
-              accept=".yml,.yaml,.json,.zip"
-              multiple
+          <Field label={t('upload.filesLabel')} htmlFor={filesId}>
+            <FileUpload.Root>
+              <FileUpload.DropZone
+                onFilesSelected={(picked) => {
+                  setFiles(picked);
+                  setRefusal(null);
+                  setSkillConflicts(null);
+                }}
+                accept=".yml,.yaml,.json,.zip"
+                multiple
+                disabled={pending}
+                inputId={filesId}
+                aria-label={t('upload.filesLabel')}
+                className="hover:border-primary/50 relative flex cursor-pointer flex-col items-center gap-1 rounded-lg border-2 border-dashed p-4 transition-colors"
+              >
+                <Upload className="text-muted-foreground size-5" aria-hidden />
+                <Text as="p" variant="muted" className="text-xs">
+                  {t('upload.filesHelp')}
+                </Text>
+                <FileUpload.Overlay />
+              </FileUpload.DropZone>
+            </FileUpload.Root>
+          </Field>
+          {mixedZipSelection && (
+            <Alert variant="destructive" description={t('upload.zipOnly')} />
+          )}
+          {files.length > 0 && (
+            <ul className="flex flex-col gap-1">
+              {files.map((file) => (
+                <li key={file.name}>
+                  <Row gap={2} align="center" className="min-w-0 text-sm">
+                    {file.name.toLowerCase().endsWith('.zip') ? (
+                      <FileArchive
+                        className="text-muted-foreground size-4 shrink-0"
+                        aria-hidden
+                      />
+                    ) : (
+                      <FileText
+                        className="text-muted-foreground size-4 shrink-0"
+                        aria-hidden
+                      />
+                    )}
+                    <span className="min-w-0 flex-1 truncate">{file.name}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={t('upload.removeFile', { name: file.name })}
+                      disabled={pending}
+                      onClick={() =>
+                        setFiles((current) =>
+                          current.filter((entry) => entry.name !== file.name),
+                        )
+                      }
+                    >
+                      <X className="size-4" aria-hidden />
+                    </Button>
+                  </Row>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {projectId === undefined && (
+            <Select
+              label={t('upload.targetLabel')}
+              description={t('upload.targetHelp')}
+              value={target}
+              onValueChange={setTarget}
+              options={[
+                { value: ORG_TARGET, label: t('upload.targetOrg') },
+                ...projects.map((project) => ({
+                  value: String(project._id),
+                  label: project.name,
+                })),
+              ]}
               disabled={pending}
-              inputId={filesId}
-              aria-label={t('upload.filesLabel')}
-              className="hover:border-primary/50 relative flex cursor-pointer flex-col items-center gap-1 rounded-lg border-2 border-dashed p-4 transition-colors"
-            >
-              <Upload className="text-muted-foreground size-5" aria-hidden />
-              <Text as="p" variant="muted" className="text-xs">
-                {t('upload.filesHelp')}
-              </Text>
-              <FileUpload.Overlay />
-            </FileUpload.DropZone>
-          </FileUpload.Root>
-        </Field>
-        {mixedZipSelection && (
-          <Alert variant="destructive" description={t('upload.zipOnly')} />
-        )}
-        {files.length > 0 && (
-          <ul className="flex flex-col gap-1">
-            {files.map((file) => (
-              <li key={file.name}>
-                <Row gap={2} align="center" className="min-w-0 text-sm">
-                  {file.name.toLowerCase().endsWith('.zip') ? (
-                    <FileArchive
-                      className="text-muted-foreground size-4 shrink-0"
-                      aria-hidden
-                    />
-                  ) : (
-                    <FileText
-                      className="text-muted-foreground size-4 shrink-0"
-                      aria-hidden
-                    />
-                  )}
-                  <span className="min-w-0 flex-1 truncate">{file.name}</span>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={t('upload.removeFile', { name: file.name })}
-                    disabled={pending}
-                    onClick={() =>
-                      setFiles((current) =>
-                        current.filter((entry) => entry.name !== file.name),
-                      )
-                    }
-                  >
-                    <X className="size-4" aria-hidden />
-                  </Button>
-                </Row>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        {projectId === undefined && (
-          <Select
-            label={t('upload.targetLabel')}
-            description={t('upload.targetHelp')}
-            value={target}
-            onValueChange={setTarget}
-            options={[
-              { value: ORG_TARGET, label: t('upload.targetOrg') },
-              ...projects.map((project) => ({
-                value: String(project._id),
-                label: project.name,
-              })),
-            ]}
-            disabled={pending}
-          />
-        )}
-      </Stack>
+            />
+          )}
+        </Stack>
+      )}
     </FormDialog>
   );
 }

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -655,9 +655,9 @@ import type * as node_only_sandbox_summary_reentry from "../node_only/sandbox/su
 import type * as node_only_sandbox_workspace_files from "../node_only/sandbox/workspace_files.js";
 import type * as node_only_sandbox_workspace_tool_context from "../node_only/sandbox/workspace_tool_context.js";
 import type * as node_only_sandbox_workspace_tools_bridge from "../node_only/sandbox/workspace_tools_bridge.js";
+import type * as notifications_actionable_email_connectors from "../notifications/actionable_email_connectors.js";
 import type * as notifications_actor_name from "../notifications/actor_name.js";
 import type * as notifications_dispatch_notification from "../notifications/dispatch_notification.js";
-import type * as notifications_actionable_email_connectors from "../notifications/actionable_email_connectors.js";
 import type * as notifications_email_notification from "../notifications/email_notification.js";
 import type * as notifications_email_notification_queries from "../notifications/email_notification_queries.js";
 import type * as notifications_event_catalog from "../notifications/event_catalog.js";
@@ -1575,9 +1575,9 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/workspace_files": typeof node_only_sandbox_workspace_files;
   "node_only/sandbox/workspace_tool_context": typeof node_only_sandbox_workspace_tool_context;
   "node_only/sandbox/workspace_tools_bridge": typeof node_only_sandbox_workspace_tools_bridge;
+  "notifications/actionable_email_connectors": typeof notifications_actionable_email_connectors;
   "notifications/actor_name": typeof notifications_actor_name;
   "notifications/dispatch_notification": typeof notifications_dispatch_notification;
-  "notifications/actionable_email_connectors": typeof notifications_actionable_email_connectors;
   "notifications/email_notification": typeof notifications_email_notification;
   "notifications/email_notification_queries": typeof notifications_email_notification_queries;
   "notifications/event_catalog": typeof notifications_event_catalog;

--- a/services/platform/convex/automations/upload_action.test.ts
+++ b/services/platform/convex/automations/upload_action.test.ts
@@ -87,6 +87,7 @@ function fakeCtx(options?: {
 }) {
   const calls = {
     storeSave: [] as Record<string, unknown>[],
+    bindProject: [] as Record<string, unknown>[],
     intentVerified: 0,
     intentDeleted: 0,
     blobDeleted: [] as string[],
@@ -113,6 +114,10 @@ function fakeCtx(options?: {
       },
     },
     runMutation: async (_ref: unknown, args: Record<string, unknown>) => {
+      if ('automationName' in args) {
+        calls.bindProject.push(args);
+        return null;
+      }
       if ('automation' in args) {
         calls.storeSave.push(args);
         if (options?.storeSaveError !== undefined) {
@@ -207,6 +212,41 @@ describe('the text lane', () => {
     );
   });
 
+  it('refuses a project-scoped pack installed org-wide', async () => {
+    const upload = await loadUpload();
+    const { ctx, calls } = fakeCtx();
+    await expectRefusal(
+      upload.handler(ctx, {
+        organizationId: 'org_1',
+        files: [
+          { name: 'workflow.yml', content: VALID_DOC },
+          { name: 'automation.yml', content: 'name: X\nscope: project\n' },
+        ],
+      }),
+      'AUTOMATION_PROJECT_REQUIRED',
+    );
+    expect(calls.storeSave).toHaveLength(0);
+  });
+
+  it('saves a project-scoped pack into the chosen project', async () => {
+    const upload = await loadUpload();
+    const { ctx, calls } = fakeCtx();
+    const result = await upload.handler(ctx, {
+      organizationId: 'org_1',
+      files: [
+        { name: 'workflow.yml', content: VALID_DOC },
+        { name: 'automation.yml', content: 'name: X\nscope: project\n' },
+      ],
+      projectId: 'project_1',
+    });
+    expect(result).toMatchObject({ ok: true, name: 'order-report' });
+    expect(calls.storeSave[0]).toMatchObject({ projectId: 'project_1' });
+    expect(calls.bindProject[0]).toMatchObject({
+      automationName: 'order-report',
+      projectId: 'project_1',
+    });
+  });
+
   it('refuses both lanes and neither lane', async () => {
     const upload = await loadUpload();
     const { ctx } = fakeCtx();
@@ -297,6 +337,24 @@ describe('the zip lane', () => {
       );
       expect(calls.storeSave).toHaveLength(0);
     }
+  });
+
+  it('refuses a project-scoped zip installed org-wide, before touching skills', async () => {
+    const upload = await loadUpload();
+    const bytes = await buildZip({
+      'workflow.yml': VALID_DOC,
+      'automation.yml': 'name: X\nscope: project\nskills: [triage]\n',
+      'skills/triage/SKILL.md': SKILL_MD,
+    });
+    const { ctx, calls } = fakeCtx({ blobs: { blob_1: bytes } });
+    await expectRefusal(
+      upload.handler(ctx, { organizationId: 'org_1', storageId: 'blob_1' }),
+      'AUTOMATION_PROJECT_REQUIRED',
+    );
+    expect(calls.storeSave).toHaveLength(0);
+    await expect(
+      readFile(path.join(configRoot, 'acme', 'skills', 'triage', 'SKILL.md')),
+    ).rejects.toThrow();
   });
 
   it('installs a carried skill and reports it created', async () => {

--- a/services/platform/convex/automations/upload_action.ts
+++ b/services/platform/convex/automations/upload_action.ts
@@ -48,6 +48,7 @@ import {
 } from '../../lib/skills/visibility';
 import { isRecord } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
 import { action } from '../_generated/server';
 import { loadConnectorDefinitions } from '../connector_credentials/connector_catalog';
 import { requireOrgAdminOrDeveloper } from '../lib/auth/require_org_admin_or_developer';
@@ -181,6 +182,24 @@ function parseManifest(name: string, text: string): AutomationPackManifest {
     );
   }
   return manifest.data;
+}
+
+/**
+ * The manifest's `scope` declaration is enforced at install time: a pack that
+ * says `scope: project` exists to serve one board, so installing it org-wide
+ * is refused before anything is written. Packs declaring `scope: org` — or
+ * nothing — install anywhere.
+ */
+function assertScopeTarget(
+  manifest: AutomationPackManifest | undefined,
+  projectId: Id<'projects'> | undefined,
+): void {
+  if (manifest?.scope === 'project' && projectId === undefined) {
+    refuse(
+      'AUTOMATION_PROJECT_REQUIRED',
+      'the pack declares scope: project — choose a project under "Install into" and upload again',
+    );
+  }
 }
 
 /**
@@ -367,6 +386,7 @@ export const uploadAutomation = action({
         manifestFile === undefined
           ? undefined
           : parseManifest(manifestFile.name, manifestFile.content);
+      assertScopeTarget(manifest, args.projectId);
       if ((manifest?.skills?.length ?? 0) > 0) {
         refuse(
           'PACK_SKILLS_MISMATCH',
@@ -444,6 +464,7 @@ export const uploadAutomation = action({
         parsed.manifest === undefined
           ? undefined
           : parseManifest(parsed.manifest.name, parsed.manifest.text);
+      assertScopeTarget(manifest, args.projectId);
 
       // The declaration is authoritative in BOTH directions: a package can
       // neither smuggle an undeclared bundle nor promise one it doesn't ship.

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -820,8 +820,13 @@ automations:
     targetHelp: Ein Projekt bindet sie an dieses Board; Organisation teilt sie org-weit.
     submit: Paket hochladen
     submitting: Validieren und speichern…
-    uploaded: '{name} v{version} hochgeladen — deploye sie, wenn du bereit bist.'
-    warnings: '{count, plural, one {# Validierungswarnung} other {# Validierungswarnungen}} — öffne die Automatisierung zur Prüfung.'
+    successTitle: Paket hochgeladen
+    successNote: '{name} v{version} ist als Entwurf gespeichert.'
+    successHint: Entwürfe laufen nie von selbst — Trigger und Aufgaben-Boards nutzen nur die Live-Version. Schalte den Entwurf jetzt live oder später auf der Seite der Automatisierung.
+    deployNow: 'v{version} live schalten'
+    deployLater: Später
+    deployed: '{name} v{version} ist live.'
+    warnings: '{count, plural, one {# Validierungswarnung} other {# Validierungswarnungen}}'
   runs:
     agentLog:
       title: Agenten-Log

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -784,8 +784,13 @@ automations:
     targetHelp: Project binds it to that board; Organization shares it org-wide.
     submit: Upload package
     submitting: Validating and saving…
-    uploaded: 'Uploaded {name} v{version} — deploy it when ready.'
-    warnings: '{count, plural, one {# validation warning} other {# validation warnings}} — open the automation to review.'
+    successTitle: Package uploaded
+    successNote: '{name} v{version} is saved as a draft.'
+    successHint: Drafts never run — triggers and task boards only use the deployed version. Deploy now to make this version live, or do it later from the automation's page.
+    deployNow: 'Deploy v{version}'
+    deployLater: Later
+    deployed: '{name} v{version} is live.'
+    warnings: '{count, plural, one {# validation warning} other {# validation warnings}}'
   runs:
     agentLog:
       title: Agent log

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -825,8 +825,13 @@ automations:
     targetHelp: Un projet la lie à ce board ; Organisation la partage dans toute l'organisation.
     submit: Téléverser le paquet
     submitting: Validation et enregistrement…
-    uploaded: '{name} v{version} téléversé — déploie-la quand tu es prêt.'
-    warnings: "{count, plural, one {# avertissement de validation} other {# avertissements de validation}} — ouvre l'automatisation pour vérifier."
+    successTitle: Paquet téléversé
+    successNote: 'La v{version} de {name} est enregistrée comme brouillon.'
+    successHint: Un brouillon ne s'exécute jamais seul — les déclencheurs et les boards de tâches n'utilisent que la version en service. Mets ce brouillon en service maintenant, ou plus tard depuis la page de l'automatisation.
+    deployNow: 'Mettre v{version} en service'
+    deployLater: Plus tard
+    deployed: '{name} v{version} est en service.'
+    warnings: '{count, plural, one {# avertissement de validation} other {# avertissements de validation}}'
   runs:
     agentLog:
       title: Journal de l'agent


### PR DESCRIPTION
## Summary

- **Upload success step with one-click deploy.** The upload dialog no longer closes on success with only a transient "deploy it when ready" toast. It swaps to a success step: "{name} v{n} is saved as a draft", the upload's validation warnings inline, and **Deploy v{n}** / **Later** buttons. Deploy goes through the normal `deployAutomation` gate and renders refusals verbatim (e.g. the failing-tests gate); nothing auto-deploys. Covers both a fresh install and uploading v2 while v1 is live.
- **`scope: project` enforced at upload.** A pack whose `automation.yml` declares `scope: project` refuses an organization-wide install with `AUTOMATION_PROJECT_REQUIRED` — in both the text and zip lanes, before any skill or version is written; the zip lane's blob/intent cleanup still runs. The field existed in the manifest schema but the upload lane never read it.
- Message catalogs (en/de/fr) and `docs/{en,de,fr}/platform/automations/catalog.md` updated. The DE/FR deploy wording follows the shipped versions section ("live schalten" / "Mettre en service"). The removed `upload.uploaded` toast key is referenced nowhere.

## Why

An undeployed automation fails silently: schedule triggers match and stamp `lastFiredAt` but only warn server-side, webhooks 409, event triggers skip, and task boards filter drafts out entirely. Users uploaded a pack, saw the dialog close, and never realized nothing would run.

## Verification

- vitest: automations feature + convex suites 383 passed (3 new server cases: refusal in each lane + project install binds; 3 new dialog cases: success step + deploy args, inline refusal, Later closes without deploying); i18n parity 24; docs structure 22. tsc, oxlint, oxfmt all green.
- Driven live in a real browser on a throwaway org: org-wide upload of a `scope: project` pack shows the refusal verbatim → picking a project under "Install into" fixes it → success step → **Deploy v1** → the list shows **Live: v1** with the project chip. The throwaway org was deleted afterwards.

Known follow-up: the docs screenshot of the dialog still shows the form step only — a success-step capture needs the exclusive `docs:screenshots` stack (same standing debt as the Install-into caption).