### PR TITLE
fix(platform): reseed the skill editor when switching skills

### DIFF
--- a/services/platform/app/features/skills/components/skill-detail-pane.test.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The detail pane holds the editor form in local state, seeded from the fetched
+ * document and cleared when the pane navigates to another skill. The ORDER of
+ * those two effects is the whole contract: both fire in one commit when the new
+ * slug's document is already cached, so seeding before clearing leaves the form
+ * permanently null and the editor blank.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+const { useSkill, useOrgTeams } = vi.hoisted(() => ({
+  useSkill: vi.fn(),
+  useOrgTeams: vi.fn(),
+}));
+
+vi.mock('../hooks/queries', () => ({ useSkill }));
+vi.mock('../hooks/mutations', () => ({
+  useSaveSkill: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteSkill: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/app/features/settings/teams/hooks/queries', () => ({ useOrgTeams }));
+
+import { SkillDetailPane } from './skill-detail-pane';
+
+function skillDoc(slug: string, body: string) {
+  return {
+    slug,
+    description: `${slug} description`,
+    icon: undefined,
+    labels: [],
+    visibility: 'org',
+    teams: [],
+    usageMode: 'all',
+    body,
+    canEdit: true,
+    files: [{ path: 'SKILL.md' }],
+  };
+}
+
+function mountPane(slug: string) {
+  return render(
+    <SkillDetailPane
+      organizationId="org_1"
+      slug={slug}
+      onDeleted={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+describe('SkillDetailPane', () => {
+  it('seeds the body editor from the fetched document', () => {
+    useOrgTeams.mockReturnValue({ teams: [], isLoading: false });
+    useSkill.mockReturnValue({
+      data: skillDoc('alpha', 'Alpha body'),
+      isPending: false,
+    });
+
+    mountPane('alpha');
+
+    expect(screen.getByDisplayValue('Alpha body')).toBeInTheDocument();
+  });
+
+  it('reseeds when the slug changes and the new document is already cached', () => {
+    useOrgTeams.mockReturnValue({ teams: [], isLoading: false });
+    useSkill.mockReturnValue({
+      data: skillDoc('alpha', 'Alpha body'),
+      isPending: false,
+    });
+
+    const { rerender } = mountPane('alpha');
+    expect(screen.getByDisplayValue('Alpha body')).toBeInTheDocument();
+
+    // No loading gap: the second skill resolves in the same commit as the slug
+    // change, so the reset and the seed effect both fire together.
+    useSkill.mockReturnValue({
+      data: skillDoc('beta', 'Beta body'),
+      isPending: false,
+    });
+    rerender(
+      <SkillDetailPane
+        organizationId="org_1"
+        slug="beta"
+        onDeleted={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('Beta body')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Alpha body')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/skills/components/skill-detail-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.tsx
@@ -80,15 +80,20 @@ export function SkillDetailPane({
     };
   }, [skill]);
 
-  // Seed the form when the document (or the slug) changes; edits in flight
-  // survive unrelated refetches because the seed only fires from null.
-  useEffect(() => {
-    setForm((current) => current ?? savedForm);
-  }, [savedForm]);
+  // Reset local form when navigating to a different skill. Must run before
+  // the seed effect below — if both fire in the same commit (cached document
+  // already present for the new slug), seeding first then clearing leaves
+  // `form` null forever and the editor pane empty.
   useEffect(() => {
     setForm(null);
     setSelectedPath('SKILL.md');
   }, [slug]);
+
+  // Seed once the document is available; edits in flight survive unrelated
+  // refetches because the seed only fills from null.
+  useEffect(() => {
+    setForm((current) => current ?? savedForm);
+  }, [savedForm]);
 
   const dirty =
     form !== null &&


### PR DESCRIPTION
Opening a second skill from the library left the editor pane blank whenever that skill's document was already in the query cache.

## What was wrong

`SkillDetailPane` keeps the form in local state, seeded from the fetched document and cleared when the pane navigates to another slug. Those are two effects, and they ran seed-first:

```ts
useEffect(() => { setForm((current) => current ?? savedForm) }, [savedForm]) // seed
useEffect(() => { setForm(null); setSelectedPath('SKILL.md') }, [slug])      // reset
```

With a cold cache the two never collide — the slug changes, the query goes pending, and the seed fires later on its own. With a warm cache both fire in the same commit: the seed fills the form, the reset immediately nulls it, and nothing re-fires the seed afterwards because `savedForm` never changed. The form stays `null` and the pane renders nothing.

## The change

Reset before seed, so the commit ends holding the new skill's values. The same ordering also fixes a first mount from a warm cache, which was blank for the same reason.

## Tests

New `skill-detail-pane.test.tsx` — first coverage for this component. Both cases render with the document already present (no loading gap), which is what reproduces the bug; both fail against the previous effect order.