### PR TITLE
feat(ui): stack settings rows for narrow panes

### DIFF
--- a/services/platform/app/features/settings/components/settings-field-list.tsx
+++ b/services/platform/app/features/settings/components/settings-field-list.tsx
@@ -8,14 +8,15 @@ import { SettingsRow } from './settings-row';
 
 /**
  * The shape a settings section's fields take: one divided list of rows, each
- * row carrying its label + helper text on the left and its control pinned
- * right, so a section reads as one continuous block instead of a stack of
- * loose fields. This is the structure the Organization details section
- * established; every section that edits plain values uses it.
+ * row carrying its label + helper text and its control, so a section reads as
+ * one continuous block instead of a stack of loose fields. Default row layout
+ * is label-left / control-right (the Organization details pattern); pass
+ * `layout="stack"` for label-above-control in dialogs and narrow panes.
  *
- * A row's control column is fixed-width on desktop and full-width on mobile
- * (where the row stacks), so the controls of a section line up with each other
- * regardless of how long their labels are.
+ * In row layout, a row's control column is fixed-width on desktop and
+ * full-width on mobile (where the row stacks), so the controls of a section
+ * line up with each other regardless of how long their labels are. Stack
+ * layout always uses the full width under the label.
  */
 
 export function SettingsFieldList({
@@ -38,11 +39,17 @@ export interface SettingsFieldRowProps {
   description?: ReactNode;
   /** Append a red required asterisk to the label. */
   required?: boolean;
+  /**
+   * `'row'` (default) — label left / control right from `sm` up.
+   * `'stack'` — always label above control; control is full width.
+   */
+  layout?: 'row' | 'stack';
   /** The control — rendered inside the row's fixed-width control column. */
   children: ReactNode;
   /**
    * Let the control fill the row instead of sitting in the fixed-width column
    * — for a control that needs the room (a multi-line field, a chip picker).
+   * Implied when `layout="stack"`.
    */
   wideControl?: boolean;
   className?: string;
@@ -52,18 +59,24 @@ export function SettingsFieldRow({
   label,
   description,
   required,
+  layout = 'row',
   children,
   wideControl = false,
   className,
 }: SettingsFieldRowProps) {
+  const fullWidthControl = wideControl || layout === 'stack';
+
   return (
     <SettingsRow
       className={cn('py-5', className)}
       label={label}
+      layout={layout}
       {...(description !== undefined ? { description } : {})}
       {...(required ? { required } : {})}
     >
-      <div className={cn('w-full', !wideControl && 'sm:w-80')}>{children}</div>
+      <div className={cn('w-full', !fullWidthControl && 'sm:w-80')}>
+        {children}
+      </div>
     </SettingsRow>
   );
 }

--- a/services/platform/app/features/settings/components/settings-row.test.tsx
+++ b/services/platform/app/features/settings/components/settings-row.test.tsx
@@ -80,6 +80,27 @@ describe('SettingsRow', () => {
       const row = container.firstChild as HTMLElement;
       expect(row.getAttribute('aria-describedby')).toBeNull();
     });
+
+    it('uses horizontal row classes by default', () => {
+      const { container } = render(
+        <SettingsRow label="Two-factor auth">
+          <button type="button">Enable</button>
+        </SettingsRow>,
+      );
+      const row = container.firstChild as HTMLElement;
+      expect(row.className).toContain('sm:flex-row');
+    });
+
+    it('omits horizontal row classes when layout is stack', () => {
+      const { container } = render(
+        <SettingsRow layout="stack" label="Description">
+          <button type="button">Edit</button>
+        </SettingsRow>,
+      );
+      const row = container.firstChild as HTMLElement;
+      expect(row.className).toContain('flex-col');
+      expect(row.className).not.toContain('sm:flex-row');
+    });
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/features/settings/components/settings-row.tsx
+++ b/services/platform/app/features/settings/components/settings-row.tsx
@@ -14,21 +14,39 @@ interface SettingsRowProps extends Omit<
   description?: ReactNode;
   /** Append a red required asterisk to the label (mirrors `Label`'s required). */
   required?: boolean;
+  /**
+   * `'row'` (default) — label left / control right from `sm` up, as settings
+   * pages use. `'stack'` — always label above control, for narrow columns and
+   * dialogs where a side-by-side label column would squeeze helper text.
+   */
+  layout?: 'row' | 'stack';
   /** Right-side control (switch, button, copy field, link). */
   children: ReactNode;
 }
 
 /**
- * Horizontal label-control row used for inline settings: toggles, dialog
- * triggers, read-only values with copy buttons, etc. Stacks vertically on
- * narrow viewports so the right-side control wraps cleanly.
+ * Label-control row used for inline settings: toggles, dialog triggers,
+ * read-only values with copy buttons, etc. Default layout is horizontal from
+ * `sm` up; pass `layout="stack"` for label-above-control (dialogs, narrow panes).
  */
 export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
-  ({ label, description, required, children, className, ...props }, ref) => {
+  (
+    {
+      label,
+      description,
+      required,
+      layout = 'row',
+      children,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
     const { t } = useT('common');
     const id = useId();
     const labelId = `${id}-label`;
     const descId = description ? `${id}-desc` : undefined;
+    const stacked = layout === 'stack';
 
     return (
       <div
@@ -36,7 +54,8 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
         aria-labelledby={labelId}
         aria-describedby={descId}
         className={cn(
-          'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6',
+          'flex flex-col gap-3',
+          !stacked && 'sm:flex-row sm:items-start sm:justify-between sm:gap-6',
           className,
         )}
         {...props}
@@ -44,8 +63,11 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
         {/* Cap the text column at a readable line length (matching
             `SettingsSection`'s header and `SettingsToggleRow`) so a long
             description doesn't stretch to the full content width when the
-            right-side control is narrow. */}
-        <div className="flex max-w-2xl min-w-0 flex-col gap-1">
+            right-side control is narrow. Stacked layout already gives the
+            label the full row width, so the cap is only for row mode. */}
+        <div
+          className={cn('flex min-w-0 flex-col gap-1', !stacked && 'max-w-2xl')}
+        >
           <span
             id={labelId}
             className="text-foreground text-sm leading-none font-medium"
@@ -62,7 +84,7 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
           </span>
           {description && <Description id={descId}>{description}</Description>}
         </div>
-        <div className="shrink-0">{children}</div>
+        <div className={cn(!stacked && 'shrink-0')}>{children}</div>
       </div>
     );
   },

--- a/services/platform/app/features/skills/components/skill-bundle-tree-panel.tsx
+++ b/services/platform/app/features/skills/components/skill-bundle-tree-panel.tsx
@@ -312,7 +312,7 @@ export function SkillBundleTreePanel({
       className="contents"
     >
       <aside
-        className="border-border w-72 shrink-0 overflow-y-auto border-r p-3"
+        className="border-border w-72 shrink-0 overflow-y-auto border-r"
         aria-label={heading}
       >
         <Heading level={2} className="sr-only">

--- a/services/platform/app/features/skills/components/skill-create-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-create-pane.tsx
@@ -32,7 +32,8 @@ const EMPTY_METADATA: SkillMetadataValues = {
 /**
  * Create a text-based skill: pick its slug (the immutable identity —
  * directory name AND frontmatter `name`), describe it, share it, write its
- * body — laid out as the divided settings rows every settings section uses.
+ * body — stacked label-above-control rows in a divided list (the dialog
+ * column is too narrow for settings-page label-left rows).
  * `saveSkill` is an upsert keyed by slug, so creating over an existing slug
  * would silently edit it — refused client-side against the known slugs.
  */
@@ -102,10 +103,12 @@ export function SkillCreatePane({
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
       <div className="min-h-0 flex-1 overflow-y-auto pr-2">
-        {/* The settings measure (#2567): fields align exactly as they do on
-            a settings page instead of stretching across the wide dialog. */}
+        {/* Stacked fields in the dialog column — label-left settings rows
+            squeeze helper text beside the controls. Cap width so the form
+            does not stretch across a wide dialog. */}
         <SettingsFieldList className="mx-auto w-full max-w-3xl">
           <SettingsFieldRow
+            layout="stack"
             label={t('createDialog.nameLabel')}
             description={t('createDialog.nameHelp')}
             required
@@ -123,9 +126,9 @@ export function SkillCreatePane({
           <SkillMetadataFields values={metadata} onChange={setMetadata} />
 
           <SettingsFieldRow
+            layout="stack"
             label={t('section.body')}
             description={t('editor.bodyHelp')}
-            wideControl
           >
             <Textarea
               aria-label={t('section.body')}

--- a/services/platform/app/features/skills/components/skill-detail-pane.test.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The detail pane holds the editor form in local state, seeded from the fetched
+ * document and cleared when the pane navigates to another skill. The ORDER of
+ * those two effects is the whole contract: both fire in one commit when the new
+ * slug's document is already cached, so seeding before clearing leaves the form
+ * permanently null and the editor blank.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+const { useSkill, useOrgTeams } = vi.hoisted(() => ({
+  useSkill: vi.fn(),
+  useOrgTeams: vi.fn(),
+}));
+
+vi.mock('../hooks/queries', () => ({ useSkill }));
+vi.mock('../hooks/mutations', () => ({
+  useSaveSkill: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteSkill: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/app/features/settings/teams/hooks/queries', () => ({ useOrgTeams }));
+
+import { SkillDetailPane } from './skill-detail-pane';
+
+function skillDoc(slug: string, body: string) {
+  return {
+    slug,
+    description: `${slug} description`,
+    icon: undefined,
+    labels: [],
+    visibility: 'org',
+    teams: [],
+    usageMode: 'all',
+    body,
+    canEdit: true,
+    files: [{ path: 'SKILL.md' }],
+  };
+}
+
+function mountPane(slug: string) {
+  return render(
+    <SkillDetailPane
+      organizationId="org_1"
+      slug={slug}
+      onDeleted={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+describe('SkillDetailPane', () => {
+  it('seeds the body editor from the fetched document', () => {
+    useOrgTeams.mockReturnValue({ teams: [], isLoading: false });
+    useSkill.mockReturnValue({
+      data: skillDoc('alpha', 'Alpha body'),
+      isPending: false,
+    });
+
+    mountPane('alpha');
+
+    expect(screen.getByDisplayValue('Alpha body')).toBeInTheDocument();
+  });
+
+  it('reseeds when the slug changes and the new document is already cached', () => {
+    useOrgTeams.mockReturnValue({ teams: [], isLoading: false });
+    useSkill.mockReturnValue({
+      data: skillDoc('alpha', 'Alpha body'),
+      isPending: false,
+    });
+
+    const { rerender } = mountPane('alpha');
+    expect(screen.getByDisplayValue('Alpha body')).toBeInTheDocument();
+
+    // No loading gap: the second skill resolves in the same commit as the slug
+    // change, so the reset and the seed effect both fire together.
+    useSkill.mockReturnValue({
+      data: skillDoc('beta', 'Beta body'),
+      isPending: false,
+    });
+    rerender(
+      <SkillDetailPane
+        organizationId="org_1"
+        slug="beta"
+        onDeleted={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('Beta body')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Alpha body')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/skills/components/skill-detail-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.tsx
@@ -193,9 +193,9 @@ export function SkillDetailPane({
                     disabled={!canEdit}
                   />
                   <SettingsFieldRow
+                    layout="stack"
                     label={t('section.body')}
                     description={t('editor.bodyHelp')}
-                    wideControl
                   >
                     <Textarea
                       aria-label={t('section.body')}

--- a/services/platform/app/features/skills/components/skill-detail-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.tsx
@@ -80,15 +80,20 @@ export function SkillDetailPane({
     };
   }, [skill]);
 
-  // Seed the form when the document (or the slug) changes; edits in flight
-  // survive unrelated refetches because the seed only fires from null.
-  useEffect(() => {
-    setForm((current) => current ?? savedForm);
-  }, [savedForm]);
+  // Reset local form when navigating to a different skill. Must run before
+  // the seed effect below — if both fire in the same commit (cached document
+  // already present for the new slug), seeding first then clearing leaves
+  // `form` null forever and the editor pane empty.
   useEffect(() => {
     setForm(null);
     setSelectedPath('SKILL.md');
   }, [slug]);
+
+  // Seed once the document is available; edits in flight survive unrelated
+  // refetches because the seed only fills from null.
+  useEffect(() => {
+    setForm((current) => current ?? savedForm);
+  }, [savedForm]);
 
   const dirty =
     form !== null &&

--- a/services/platform/app/features/skills/components/skill-metadata-fields.tsx
+++ b/services/platform/app/features/skills/components/skill-metadata-fields.tsx
@@ -32,11 +32,12 @@ export function parseLabelsInput(labels: string): string[] {
 }
 
 /**
- * The metadata cluster the create pane and the detail pane share: the
- * label-left rows every settings section uses, rendered WITHOUT their own
- * `SettingsFieldList` wrapper so the owning pane composes one continuous
- * divided list around them (name row before, body row after). Controlled
- * throughout — the owning pane holds the form state and the save wiring.
+ * The metadata cluster the create pane and the detail pane share: stacked
+ * label-above-control rows (the dialog column is too narrow for label-left
+ * settings rows), rendered WITHOUT their own `SettingsFieldList` wrapper so
+ * the owning pane composes one continuous divided list around them (name
+ * row before, body row after). Controlled throughout — the owning pane holds
+ * the form state and the save wiring.
  */
 export function SkillMetadataFields({
   values,
@@ -55,6 +56,7 @@ export function SkillMetadataFields({
   return (
     <>
       <SettingsFieldRow
+        layout="stack"
         label={t('form.description')}
         description={t('editor.descriptionHelp')}
         required
@@ -69,7 +71,7 @@ export function SkillMetadataFields({
         />
       </SettingsFieldRow>
 
-      <SettingsFieldRow label={t('iconPicker.label')}>
+      <SettingsFieldRow layout="stack" label={t('iconPicker.label')}>
         <SkillIconPicker
           value={values.icon}
           onChange={(icon) => onChange({ ...values, icon })}
@@ -78,6 +80,7 @@ export function SkillMetadataFields({
       </SettingsFieldRow>
 
       <SettingsFieldRow
+        layout="stack"
         label={t('editor.labels')}
         description={t('editor.labelsHelp')}
       >
@@ -90,7 +93,7 @@ export function SkillMetadataFields({
         />
       </SettingsFieldRow>
 
-      <SettingsFieldRow label={t('visibility.label')}>
+      <SettingsFieldRow layout="stack" label={t('visibility.label')}>
         <SkillVisibilityField
           value={values.sharing}
           savedValue={savedSharing}
@@ -99,7 +102,7 @@ export function SkillMetadataFields({
         />
       </SettingsFieldRow>
 
-      <SettingsFieldRow label={t('usage.label')}>
+      <SettingsFieldRow layout="stack" label={t('usage.label')}>
         <SkillUsageField
           value={values.usageMode}
           onChange={(usageMode) => onChange({ ...values, usageMode })}


### PR DESCRIPTION
> Stacked on #2912 — review that first; this PR's diff is only the layout change.

`SettingsRow` was horizontal-only: label left, control right from `sm` up. That is right on a settings page, where the text column has room to sit beside the control. It is wrong in the skills dialog, where the column is narrow enough that helper text gets squeezed into a ribbon beside the field it describes.

## The change

New `layout` prop on `SettingsRow` and `SettingsFieldRow`:

| value | behaviour |
| --- | --- |
| `'row'` (default) | label left / control right from `sm` up — unchanged, so no existing settings surface moves |
| `'stack'` | label above control at every width, control gets the full row |

`SettingsFieldRow` treats `layout="stack"` as implying `wideControl` — a stacked control already has the whole width, so the fixed `sm:w-80` control column would only fight it. In row mode the text column keeps its `max-w-2xl` readable cap; stacked rows drop it, since the label already spans the row.

Moves the skills create pane, detail pane, and the metadata cluster they share onto the stacked variant, and drops the bundle tree panel's padding so its heading lines up with the editor column beside it.

## Tests

Two cases added to `settings-row.test.tsx` pinning the class contract in both directions (row keeps `sm:flex-row`, stack does not). The rest of the platform UI suite — 418 files, 3086 tests — passes unchanged, which is what covers the "no existing surface moves" claim.