### PR TITLE
feat(platform): store email attachments on ingest

### DIFF
--- a/configs/platform/system/connectors/imap-smtp/connector.yml
+++ b/configs/platform/system/connectors/imap-smtp/connector.yml
@@ -92,7 +92,8 @@ actions:
     exampleInput: { mailbox: 'INBOX', limit: 25 }
   - name: get_message
     description: >-
-      Fetch one message by IMAP UID with plain/HTML body and threading headers
+      Fetch one message by IMAP UID with plain/HTML body, file attachments
+      (metadata plus base64 content when under 5 MiB), and threading headers
       (Message-ID, In-Reply-To, References). Omit mailbox for INBOX.
     effects: read
     input:
@@ -106,7 +107,7 @@ actions:
             description: 'IMAP folder to read. Omit for INBOX; pass `sent` for the Sent folder.',
           }
     output: >-
-      { uid: string, email: { uid: number, messageId: string, from: Array<{ name?: string, address: string }>, to: Array<{ name?: string, address: string }>, cc: Array<{ name?: string, address: string }>, subject: string, date: string, text?: string, html?: string, flags: string[], headers: Record<string, string> } }
+      { uid: string, email: { uid: number, messageId: string, from: Array<{ name?: string, address: string }>, to: Array<{ name?: string, address: string }>, cc: Array<{ name?: string, address: string }>, subject: string, date: string, text?: string, html?: string, flags: string[], headers: Record<string, string>, attachments?: Array<{ id: string, filename: string, contentType: string, size: number, contentId?: string, contentBase64?: string }> } }
     mock: |
       return {
         uid: String(input.uid),

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -174,6 +174,7 @@ import type * as conversations_get_message_by_external_id from "../conversations
 import type * as conversations_helpers from "../conversations/helpers.js";
 import type * as conversations_improve_message from "../conversations/improve_message.js";
 import type * as conversations_ingest_add_message_to_conversation from "../conversations/ingest/add_message_to_conversation.js";
+import type * as conversations_ingest_attachments_for_metadata from "../conversations/ingest/attachments_for_metadata.js";
 import type * as conversations_ingest_build_conversation_metadata from "../conversations/ingest/build_conversation_metadata.js";
 import type * as conversations_ingest_build_email_metadata from "../conversations/ingest/build_email_metadata.js";
 import type * as conversations_ingest_build_initial_message from "../conversations/ingest/build_initial_message.js";
@@ -185,6 +186,7 @@ import type * as conversations_ingest_create_conversation_from_email from "../co
 import type * as conversations_ingest_create_conversation_from_sent_email from "../conversations/ingest/create_conversation_from_sent_email.js";
 import type * as conversations_ingest_find_or_create_contact_from_email from "../conversations/ingest/find_or_create_contact_from_email.js";
 import type * as conversations_ingest_find_related_conversation from "../conversations/ingest/find_related_conversation.js";
+import type * as conversations_ingest_materialize_email_attachments from "../conversations/ingest/materialize_email_attachments.js";
 import type * as conversations_ingest_normalize_email from "../conversations/ingest/normalize_email.js";
 import type * as conversations_ingest_normalize_external_message_id from "../conversations/ingest/normalize_external_message_id.js";
 import type * as conversations_ingest_parse_thread_reference_ids from "../conversations/ingest/parse_thread_reference_ids.js";
@@ -1094,6 +1096,7 @@ declare const fullApi: ApiFromModules<{
   "conversations/helpers": typeof conversations_helpers;
   "conversations/improve_message": typeof conversations_improve_message;
   "conversations/ingest/add_message_to_conversation": typeof conversations_ingest_add_message_to_conversation;
+  "conversations/ingest/attachments_for_metadata": typeof conversations_ingest_attachments_for_metadata;
   "conversations/ingest/build_conversation_metadata": typeof conversations_ingest_build_conversation_metadata;
   "conversations/ingest/build_email_metadata": typeof conversations_ingest_build_email_metadata;
   "conversations/ingest/build_initial_message": typeof conversations_ingest_build_initial_message;
@@ -1105,6 +1108,7 @@ declare const fullApi: ApiFromModules<{
   "conversations/ingest/create_conversation_from_sent_email": typeof conversations_ingest_create_conversation_from_sent_email;
   "conversations/ingest/find_or_create_contact_from_email": typeof conversations_ingest_find_or_create_contact_from_email;
   "conversations/ingest/find_related_conversation": typeof conversations_ingest_find_related_conversation;
+  "conversations/ingest/materialize_email_attachments": typeof conversations_ingest_materialize_email_attachments;
   "conversations/ingest/normalize_email": typeof conversations_ingest_normalize_email;
   "conversations/ingest/normalize_external_message_id": typeof conversations_ingest_normalize_external_message_id;
   "conversations/ingest/parse_thread_reference_ids": typeof conversations_ingest_parse_thread_reference_ids;

--- a/services/platform/convex/conversations/ingest/add_message_to_conversation.ts
+++ b/services/platform/convex/conversations/ingest/add_message_to_conversation.ts
@@ -1,6 +1,7 @@
 import { internal } from '../../_generated/api';
 import type { Id } from '../../_generated/dataModel';
 import type { ActionCtx } from '../../_generated/server';
+import { attachmentsForMetadata } from './attachments_for_metadata';
 import { buildEmailMetadata } from './build_email_metadata';
 import { normalizeExternalMessageId } from './normalize_external_message_id';
 import type { EmailType } from './types';
@@ -18,6 +19,7 @@ export async function addMessageToConversation(
   connectorName?: string,
 ) {
   const emailTimestamp = new Date(email.date).getTime();
+  const attachments = attachmentsForMetadata(email.attachments);
 
   await ctx.runMutation(
     internal.conversations.internal_mutations.addMessageToConversation,
@@ -32,7 +34,7 @@ export async function addMessageToConversation(
       metadata: buildEmailMetadata(email),
       sentAt: emailTimestamp,
       deliveredAt: status === 'delivered' ? emailTimestamp : undefined,
-      ...(email.attachments?.length ? { attachments: email.attachments } : {}),
+      ...(attachments?.length ? { attachments } : {}),
       ...(connectorName ? { connectorName } : {}),
     },
   );

--- a/services/platform/convex/conversations/ingest/attachments_for_metadata.test.ts
+++ b/services/platform/convex/conversations/ingest/attachments_for_metadata.test.ts
@@ -1,0 +1,46 @@
+/**
+ * `contentBase64` is a wire-only field. `emailAttachmentMetaValidator` is a
+ * strict object, so an attachment that still carries it is REJECTED at the
+ * message mutation — and the metadata records, which are untyped JSON, would
+ * silently swell by the whole attachment instead. Every ingest sink runs its
+ * attachments through this helper first.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { attachmentsForMetadata } from './attachments_for_metadata';
+
+const ATTACHMENT = {
+  id: 'cv',
+  filename: 'CV.pdf',
+  contentType: 'application/pdf',
+  size: 3,
+  contentId: 'cid@x',
+  storageId: 'storage-1',
+  url: 'https://example.test/storage/storage-1/CV.pdf',
+};
+
+describe('attachmentsForMetadata', () => {
+  it('drops contentBase64 and keeps every persisted field', () => {
+    const out = attachmentsForMetadata([
+      { ...ATTACHMENT, contentBase64: 'JVBERi0=' },
+    ]);
+
+    expect(out).toEqual([ATTACHMENT]);
+    expect(out?.[0]).not.toHaveProperty('contentBase64');
+  });
+
+  it('leaves metadata-only attachments untouched', () => {
+    const meta = {
+      id: 'a',
+      filename: 'a.txt',
+      contentType: 'text/plain',
+      size: 1,
+    };
+    expect(attachmentsForMetadata([meta])).toEqual([meta]);
+  });
+
+  it('passes undefined through so callers can stay optional', () => {
+    expect(attachmentsForMetadata(undefined)).toBeUndefined();
+  });
+});

--- a/services/platform/convex/conversations/ingest/attachments_for_metadata.ts
+++ b/services/platform/convex/conversations/ingest/attachments_for_metadata.ts
@@ -1,0 +1,12 @@
+import type { EmailType } from './types';
+
+/**
+ * Drop transient wire fields (base64 bodies) before metadata or message rows
+ * land in Convex.
+ */
+export function attachmentsForMetadata(
+  attachments: EmailType['attachments'],
+): EmailType['attachments'] {
+  if (!attachments) return attachments;
+  return attachments.map(({ contentBase64: _drop, ...rest }) => rest);
+}

--- a/services/platform/convex/conversations/ingest/build_conversation_metadata.ts
+++ b/services/platform/convex/conversations/ingest/build_conversation_metadata.ts
@@ -1,5 +1,6 @@
 import { toConvexJsonRecord } from '../../lib/type_cast_helpers';
 import type { ConvexJsonRecord } from '../../lib/validators/json';
+import { attachmentsForMetadata } from './attachments_for_metadata';
 import type { EmailType } from './types';
 
 /**
@@ -20,7 +21,7 @@ export function buildConversationMetadata(
     headers: email.headers,
     uid: email.uid ?? null,
     flags: email.flags,
-    attachments: email.attachments,
+    attachments: attachmentsForMetadata(email.attachments),
     ...additionalMetadata,
   });
 }

--- a/services/platform/convex/conversations/ingest/build_email_metadata.ts
+++ b/services/platform/convex/conversations/ingest/build_email_metadata.ts
@@ -1,5 +1,6 @@
 import { toConvexJsonRecord } from '../../lib/type_cast_helpers';
 import type { ConvexJsonRecord } from '../../lib/validators/json';
+import { attachmentsForMetadata } from './attachments_for_metadata';
 import type { EmailType } from './types';
 
 /**
@@ -20,7 +21,7 @@ export function buildEmailMetadata(email: EmailType): ConvexJsonRecord {
     headers: email.headers,
     uid: email.uid ?? null,
     flags: email.flags,
-    attachments: email.attachments,
+    attachments: attachmentsForMetadata(email.attachments),
     subject: email.subject || '(no subject)',
   });
 }

--- a/services/platform/convex/conversations/ingest/build_initial_message.ts
+++ b/services/platform/convex/conversations/ingest/build_initial_message.ts
@@ -1,3 +1,4 @@
+import { attachmentsForMetadata } from './attachments_for_metadata';
 import { buildEmailMetadata } from './build_email_metadata';
 import { normalizeExternalMessageId } from './normalize_external_message_id';
 import type { EmailType } from './types';
@@ -12,6 +13,7 @@ export function buildInitialMessage(
   connectorName?: string,
 ) {
   const emailTimestamp = new Date(email.date).getTime();
+  const attachments = attachmentsForMetadata(email.attachments);
 
   return {
     sender: email.from?.[0]?.address || email.from?.[0]?.name || 'unknown',
@@ -22,7 +24,7 @@ export function buildInitialMessage(
     metadata: buildEmailMetadata(email),
     sentAt: emailTimestamp,
     deliveredAt: status === 'delivered' ? emailTimestamp : undefined,
-    ...(email.attachments?.length ? { attachments: email.attachments } : {}),
+    ...(attachments?.length ? { attachments } : {}),
     ...(connectorName ? { connectorName } : {}),
   };
 }

--- a/services/platform/convex/conversations/ingest/materialize_email_attachments.test.ts
+++ b/services/platform/convex/conversations/ingest/materialize_email_attachments.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { materializeEmailAttachments } from './materialize_email_attachments';
+
+describe('materializeEmailAttachments', () => {
+  beforeEach(() => {
+    process.env.SITE_URL = 'http://localhost:3000';
+  });
+
+  afterEach(() => {
+    delete process.env.SITE_URL;
+  });
+
+  it('stores base64 parts and strips the wire field', async () => {
+    const storeOrgBlob = vi.fn(async () => 'storage-att-1');
+    const saveFileMetadata = vi.fn(async () => undefined);
+    const ctx = {
+      runAction: vi.fn(async (_ref: unknown, args: unknown) => {
+        expect(args).toMatchObject({
+          organizationId: 'org_1',
+          contentType: 'application/pdf',
+        });
+        return storeOrgBlob();
+      }),
+      runMutation: vi.fn(async () => {
+        await saveFileMetadata();
+        return null;
+      }),
+      storage: { getUrl: vi.fn() },
+    };
+
+    const emails = await materializeEmailAttachments(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+      ctx as never,
+      {
+        organizationId: 'org_1',
+        source: 'imap-smtp',
+        emails: [
+          {
+            messageId: '<cv@x>',
+            subject: 'Test CV emails',
+            attachments: [
+              {
+                id: 'cv',
+                filename: 'CV.pdf',
+                contentType: 'application/pdf',
+                size: 3,
+                contentBase64: Buffer.from('pdf').toString('base64'),
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(storeOrgBlob).toHaveBeenCalledOnce();
+    expect(saveFileMetadata).toHaveBeenCalledOnce();
+    expect(emails).toEqual([
+      {
+        messageId: '<cv@x>',
+        subject: 'Test CV emails',
+        attachments: [
+          {
+            id: 'cv',
+            filename: 'CV.pdf',
+            contentType: 'application/pdf',
+            size: 3,
+            storageId: 'storage-att-1',
+            url: expect.stringContaining('CV.pdf'),
+          },
+        ],
+      },
+    ]);
+    expect(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by expect
+      (emails[0] as { attachments: Array<{ contentBase64?: string }> })
+        .attachments[0]?.contentBase64,
+    ).toBeUndefined();
+  });
+
+  it('passes through emails with no wire bytes', async () => {
+    const ctx = {
+      runAction: vi.fn(),
+      runMutation: vi.fn(),
+      storage: { getUrl: vi.fn() },
+    };
+    const emails = await materializeEmailAttachments(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+      ctx as never,
+      {
+        organizationId: 'org_1',
+        source: 'imap-smtp',
+        emails: [
+          {
+            messageId: '<plain@x>',
+            attachments: [
+              {
+                id: 'a',
+                filename: 'a.txt',
+                contentType: 'text/plain',
+                size: 1,
+              },
+            ],
+          },
+        ],
+      },
+    );
+    expect(ctx.runAction).not.toHaveBeenCalled();
+    expect(emails[0]).toMatchObject({
+      attachments: [{ id: 'a', filename: 'a.txt' }],
+    });
+  });
+});

--- a/services/platform/convex/conversations/ingest/materialize_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/materialize_email_attachments.ts
@@ -1,0 +1,157 @@
+'use node';
+
+/**
+ * Persist attachment bytes returned from a mail connector onto org blob
+ * storage, then replace them with storageId + download URL for Inbox.
+ *
+ * Connector `ctx.files` is deliberately unwired, so Gmail/Outlook's
+ * `downloadAttachments` flag cannot store during `get_message`. IMAP returns
+ * `contentBase64` on each part; this helper is the sync-path sink.
+ *
+ * `'use node'` because the base64 decode goes through `Buffer` — every other
+ * `Buffer` user under `convex/` declares the same, and only the `'use node'`
+ * `sync_mailbox` host calls this.
+ */
+
+import { isRecord } from '../../../lib/utils/type-utils';
+import { internal } from '../../_generated/api';
+import type { ActionCtx } from '../../_generated/server';
+import {
+  buildBlobServeUrl,
+  buildDownloadUrl,
+} from '../../lib/helpers/public_storage_url';
+import { isS3Ref } from '../../lib/storage/blob_ref';
+
+type WireAttachment = {
+  id: string;
+  filename: string;
+  contentType: string;
+  size: number;
+  contentId?: string;
+  storageId?: string;
+  url?: string;
+  contentBase64?: string;
+};
+
+function asWireAttachment(value: unknown): WireAttachment | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== 'string' || typeof value.filename !== 'string') {
+    return null;
+  }
+  if (typeof value.contentType !== 'string' || typeof value.size !== 'number') {
+    return null;
+  }
+  return {
+    id: value.id,
+    filename: value.filename,
+    contentType: value.contentType,
+    size: value.size,
+    ...(typeof value.contentId === 'string' && { contentId: value.contentId }),
+    ...(typeof value.storageId === 'string' && { storageId: value.storageId }),
+    ...(typeof value.url === 'string' && { url: value.url }),
+    ...(typeof value.contentBase64 === 'string' && {
+      contentBase64: value.contentBase64,
+    }),
+  };
+}
+
+async function storeAttachment(
+  ctx: ActionCtx,
+  organizationId: string,
+  source: string,
+  att: WireAttachment,
+): Promise<WireAttachment> {
+  const raw = att.contentBase64;
+  if (raw === undefined || raw === '') {
+    const { contentBase64: _drop, ...rest } = att;
+    return rest;
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = Uint8Array.from(Buffer.from(raw, 'base64'));
+  } catch {
+    console.warn(
+      '[materializeEmailAttachments] invalid base64; keeping metadata only',
+      { filename: att.filename },
+    );
+    const { contentBase64: _drop, ...rest } = att;
+    return rest;
+  }
+
+  const payload = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(payload).set(bytes);
+
+  const storageId = await ctx.runAction(
+    internal.files.blob_actions.storeOrgBlob,
+    {
+      organizationId,
+      bytes: payload,
+      contentType: att.contentType,
+    },
+  );
+
+  await ctx.runMutation(
+    internal.file_metadata.internal_mutations.saveFileMetadata,
+    {
+      organizationId,
+      storageId,
+      fileName: att.filename,
+      contentType: att.contentType,
+      size: bytes.byteLength,
+      source,
+      scheduleRag: false,
+    },
+  );
+
+  let url: string;
+  if (isS3Ref(storageId)) {
+    url = buildBlobServeUrl(storageId, organizationId, att.filename);
+  } else {
+    // Named `/storage` download so the browser saves under the real filename.
+    url = buildDownloadUrl(storageId, att.filename);
+  }
+
+  return {
+    id: att.id,
+    filename: att.filename,
+    contentType: att.contentType,
+    size: bytes.byteLength > 0 ? bytes.byteLength : att.size,
+    storageId,
+    url,
+    ...(att.contentId !== undefined && { contentId: att.contentId }),
+  };
+}
+
+/**
+ * Walk fetched email objects and materialize any `contentBase64` attachments.
+ * Emails without wire bytes pass through unchanged (metadata-only attachments
+ * stay as chips the user can see but not open until a download path lands).
+ */
+export async function materializeEmailAttachments(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    /** Provenance slug for `fileMetadata.source` (e.g. `imap-smtp`). */
+    source: string;
+    emails: unknown[];
+  },
+): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for (const email of args.emails) {
+    if (!isRecord(email) || !Array.isArray(email.attachments)) {
+      out.push(email);
+      continue;
+    }
+    const nextAttachments: WireAttachment[] = [];
+    for (const raw of email.attachments) {
+      const att = asWireAttachment(raw);
+      if (att === null) continue;
+      nextAttachments.push(
+        await storeAttachment(ctx, args.organizationId, args.source, att),
+      );
+    }
+    out.push({ ...email, attachments: nextAttachments });
+  }
+  return out;
+}

--- a/services/platform/convex/conversations/ingest/types.ts
+++ b/services/platform/convex/conversations/ingest/types.ts
@@ -27,6 +27,10 @@ export type EmailType = {
     contentType: string;
     size: number;
     contentId?: string;
+    storageId?: string;
+    url?: string;
+    /** Transient — stripped before metadata/persist; sync materializes bytes. */
+    contentBase64?: string;
   }>;
   direction?: 'inbound' | 'outbound';
 };

--- a/services/platform/convex/conversations/sync_mailbox.test.ts
+++ b/services/platform/convex/conversations/sync_mailbox.test.ts
@@ -52,18 +52,28 @@ interface ConnectorCall {
 
 type Reply = (call: ConnectorCall) => unknown;
 
-/** A ctx whose only capability is the nested connector action. */
+/** A ctx whose only capability is the nested connector action + blob lane. */
 function harness(
   reply: Reply,
   outcome: { status: 'ok' } | { status: 'error'; message: string } = {
     status: 'ok',
   },
-): { ctx: ActionCtx; calls: ConnectorCall[] } {
+): { ctx: ActionCtx; calls: ConnectorCall[]; trace: string[] } {
   const calls: ConnectorCall[] = [];
+  // Every ctx hop in order — connector calls AND the blob lane, so a test can
+  // see whether attachment bytes drain between fetches or pile up after them.
+  const trace: string[] = [];
+  let stored = 0;
   const runAction = async (
     _ref: unknown,
     args: Record<string, unknown>,
   ): Promise<unknown> => {
+    // `storeOrgBlob` rides the same runAction seam but is not a connector call.
+    if (args.bytes !== undefined) {
+      stored += 1;
+      trace.push(`store:${String(args.contentType)}`);
+      return `storage-${stored}`;
+    }
     const call: ConnectorCall = {
       connector: String(args.connector),
       action: String(args.action),
@@ -71,10 +81,21 @@ function harness(
       mode: String(args.mode),
     };
     calls.push(call);
+    trace.push(
+      call.action === 'get_message'
+        ? `get:${String(call.input.uid ?? call.input.messageId)}`
+        : call.action,
+    );
     if (outcome.status === 'error') return outcome;
     return { status: 'ok', output: reply(call) };
   };
-  return { ctx: { runAction } as unknown as ActionCtx, calls };
+  // `saveFileMetadata` is the only mutation the sync path makes here.
+  const runMutation = async (): Promise<null> => null;
+  return {
+    ctx: { runAction, runMutation } as unknown as ActionCtx,
+    calls,
+    trace,
+  };
 }
 
 /** Each provider names the Sent folder its own way. */
@@ -267,6 +288,95 @@ describe('syncMailbox over Outlook', () => {
         filter: 'sentDateTime ge 1970-01-01T00:00:07.000Z',
       },
     ]);
+  });
+});
+
+describe('syncMailbox attachment handling', () => {
+  it('drains each message’s bytes before fetching the next one', async () => {
+    // Attachment bytes ride inline as base64. Fetching the whole page first
+    // and storing afterwards would hold `limit` messages’ payloads in this
+    // action at once; storing per message keeps one body’s bytes resident.
+    const reply: Reply = (call) => {
+      if (call.action === 'list_messages') {
+        return { messages: [{ uid: '1' }, { uid: '2' }] };
+      }
+      const uid = String(call.input.uid);
+      return {
+        uid,
+        email: {
+          messageId: `<body-${uid}@example.com>`,
+          attachments: [
+            {
+              id: `att-${uid}`,
+              filename: `file-${uid}.pdf`,
+              contentType: 'application/pdf',
+              size: 3,
+              contentBase64: Buffer.from(`pdf${uid}`).toString('base64'),
+            },
+          ],
+        },
+      };
+    };
+    const { ctx, trace } = harness(reply);
+
+    await syncMailbox(ctx, {
+      organizationId: 'org',
+      connectorSlug: 'imap-smtp',
+      limit: 25,
+      includeSent: false,
+      mode: 'live',
+    });
+
+    expect(trace).toEqual([
+      'list_messages',
+      'get:1',
+      'store:application/pdf',
+      'get:2',
+      'store:application/pdf',
+    ]);
+  });
+
+  it('hands ingest the stored reference, never the wire bytes', async () => {
+    const reply: Reply = (call) =>
+      call.action === 'list_messages'
+        ? { messages: [{ uid: '1' }] }
+        : {
+            uid: '1',
+            email: {
+              messageId: '<body-1@example.com>',
+              attachments: [
+                {
+                  id: 'cv',
+                  filename: 'CV.pdf',
+                  contentType: 'application/pdf',
+                  size: 3,
+                  contentBase64: Buffer.from('pdf').toString('base64'),
+                },
+              ],
+            },
+          };
+    const { ctx } = harness(reply);
+
+    await syncMailbox(ctx, {
+      organizationId: 'org',
+      connectorSlug: 'imap-smtp',
+      limit: 25,
+      includeSent: false,
+      mode: 'live',
+    });
+
+    const ingested = createConversationFromEmail.mock.calls[0]?.[1] as {
+      emails: Array<{
+        attachments: Array<Record<string, unknown>>;
+      }>;
+    };
+    const attachment = ingested.emails[0]?.attachments[0];
+    expect(attachment).toMatchObject({
+      id: 'cv',
+      filename: 'CV.pdf',
+      storageId: 'storage-1',
+    });
+    expect(attachment).not.toHaveProperty('contentBase64');
   });
 });
 

--- a/services/platform/convex/conversations/sync_mailbox.ts
+++ b/services/platform/convex/conversations/sync_mailbox.ts
@@ -19,6 +19,7 @@ import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { createConversationFromEmail } from './ingest/create_conversation_from_email';
 import { createConversationFromSentEmail } from './ingest/create_conversation_from_sent_email';
+import { materializeEmailAttachments } from './ingest/materialize_email_attachments';
 import { queryLatestMessageByDeliveryState } from './ingest/query_latest_message_by_delivery_state';
 import { queryLatestOutboundMessageForEmailSync } from './ingest/query_latest_outbound_message_for_sync';
 import { resolveConnectorAccountEmail } from './ingest/resolve_connector_account_email';
@@ -117,6 +118,65 @@ function unwrapFetchedMessage(output: unknown): unknown {
   return output;
 }
 
+/** One body, or `null` when the envelope carries no id to fetch it by. */
+async function fetchOneBody(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    connectorSlug: string;
+    summary: Record<string, unknown>;
+    mode: 'mock' | 'live';
+  },
+): Promise<{ email: unknown } | null> {
+  const { summary } = args;
+  if (args.connectorSlug === 'imap-smtp') {
+    const uid =
+      typeof summary.uid === 'string'
+        ? summary.uid
+        : typeof summary.uid === 'number'
+          ? String(summary.uid)
+          : null;
+    if (!uid) return null;
+    const mailbox =
+      typeof summary.mailbox === 'string' ? summary.mailbox : undefined;
+    const output = await runMailAction(ctx, {
+      organizationId: args.organizationId,
+      connectorSlug: 'imap-smtp',
+      action: 'get_message',
+      input: {
+        uid,
+        ...(mailbox !== undefined ? { mailbox } : {}),
+      },
+      mode: args.mode,
+    });
+    return { email: unwrapFetchedMessage(output) };
+  }
+
+  const messageId =
+    typeof summary.id === 'string'
+      ? summary.id
+      : typeof summary.messageId === 'string'
+        ? summary.messageId
+        : null;
+  if (!messageId) return null;
+  const output = await runMailAction(ctx, {
+    organizationId: args.organizationId,
+    connectorSlug: args.connectorSlug,
+    action: 'get_message',
+    input: { messageId },
+    mode: args.mode,
+  });
+  return { email: unwrapFetchedMessage(output) };
+}
+
+/**
+ * Fetch each body and drain its attachment bytes into blob storage BEFORE
+ * fetching the next one. Fetching the whole page first would hold every
+ * message's base64 payload in this action at once — `limit` (25 by default)
+ * times the connector's per-attachment cap of resident string, enough to
+ * exhaust the action. Materializing per message keeps at most one body's bytes
+ * live; what accumulates is the small `storageId` + `url` form.
+ */
 async function fetchBodies(
   ctx: ActionCtx,
   args: {
@@ -128,45 +188,19 @@ async function fetchBodies(
 ): Promise<unknown[]> {
   const emails: unknown[] = [];
   for (const summary of args.summaries) {
-    if (args.connectorSlug === 'imap-smtp') {
-      const uid =
-        typeof summary.uid === 'string'
-          ? summary.uid
-          : typeof summary.uid === 'number'
-            ? String(summary.uid)
-            : null;
-      if (!uid) continue;
-      const mailbox =
-        typeof summary.mailbox === 'string' ? summary.mailbox : undefined;
-      const output = await runMailAction(ctx, {
-        organizationId: args.organizationId,
-        connectorSlug: 'imap-smtp',
-        action: 'get_message',
-        input: {
-          uid,
-          ...(mailbox !== undefined ? { mailbox } : {}),
-        },
-        mode: args.mode,
-      });
-      emails.push(unwrapFetchedMessage(output));
-      continue;
-    }
-
-    const messageId =
-      typeof summary.id === 'string'
-        ? summary.id
-        : typeof summary.messageId === 'string'
-          ? summary.messageId
-          : null;
-    if (!messageId) continue;
-    const output = await runMailAction(ctx, {
+    const fetched = await fetchOneBody(ctx, {
       organizationId: args.organizationId,
       connectorSlug: args.connectorSlug,
-      action: 'get_message',
-      input: { messageId },
+      summary,
       mode: args.mode,
     });
-    emails.push(unwrapFetchedMessage(output));
+    if (fetched === null) continue;
+    const [materialized] = await materializeEmailAttachments(ctx, {
+      organizationId: args.organizationId,
+      source: args.connectorSlug,
+      emails: [fetched.email],
+    });
+    emails.push(materialized);
   }
   return emails;
 }

--- a/services/platform/lib/connectors/natives/imap-smtp.test.ts
+++ b/services/platform/lib/connectors/natives/imap-smtp.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { NativeConnectorContext } from '../dispatcher';
@@ -5,6 +7,8 @@ import {
   discoverSentMailbox,
   imapSmtpNatives,
   mailboxConfigFromCredential,
+  mailAttachmentsFromParsed,
+  MAX_ATTACHMENT_BYTES,
   resolveImapFlowConstructor,
   resolveNodemailerCreateTransport,
   selectMailbox,
@@ -321,11 +325,134 @@ describe('get_message', () => {
     expect(transport.log.imapClosed).toBe(1);
   });
 
+  it('passes attachments through on the email object', async () => {
+    const transport = stubTransport();
+    transport.openImap = () =>
+      Promise.resolve({
+        listMessages() {
+          return Promise.resolve([]);
+        },
+        getMessage(uid) {
+          return Promise.resolve({
+            uid,
+            messageId: `<msg-${uid}@example.com>`,
+            from: [{ address: 'sender@example.com' }],
+            to: [{ address: 'you@example.com' }],
+            cc: [],
+            subject: `Subject ${uid}`,
+            date: '1970-01-01T00:00:00.000Z',
+            text: `Body for ${uid}`,
+            flags: [],
+            headers: { 'message-id': `<msg-${uid}@example.com>` },
+            attachments: [
+              {
+                id: 'cv',
+                filename: 'CV.pdf',
+                contentType: 'application/pdf',
+                size: 4,
+                contentBase64: 'JVBE',
+              },
+            ],
+          });
+        },
+        close() {
+          return Promise.resolve();
+        },
+      });
+
+    const output = await natives(transport)['imap-smtp.get_message'](
+      { uid: '3' },
+      context(),
+    );
+
+    expect(output).toMatchObject({
+      uid: '3',
+      email: {
+        attachments: [
+          {
+            id: 'cv',
+            filename: 'CV.pdf',
+            contentType: 'application/pdf',
+            size: 4,
+            contentBase64: 'JVBE',
+          },
+        ],
+      },
+    });
+  });
+
   it('refuses a non-numeric UID', async () => {
     const transport = stubTransport();
     await expect(
       natives(transport)['imap-smtp.get_message']({ uid: 'abc' }, context()),
     ).rejects.toThrow(/not a valid IMAP UID/);
+  });
+});
+
+describe('mailAttachmentsFromParsed', () => {
+  it('caps inline bytes at the size the shipped manifest advertises', () => {
+    // `get_message`'s description names this number, and a caller reading the
+    // catalogue budgets against it. Bumping the constant without the manifest
+    // (or the reverse) makes the contract lie, so they are asserted together.
+    const manifest = readFileSync(
+      new URL(
+        '../../../../../configs/platform/system/connectors/imap-smtp/connector.yml',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const advertised = /base64 content when under (\d+) MiB/.exec(manifest);
+    expect(advertised?.[1]).toBeDefined();
+    expect(MAX_ATTACHMENT_BYTES).toBe(Number(advertised?.[1]) * 1024 * 1024);
+  });
+
+  it('encodes small parts as base64 and keeps oversized metadata-only', () => {
+    const small = Buffer.from('hello');
+    const large = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1, 1);
+    const out = mailAttachmentsFromParsed([
+      {
+        filename: 'note.txt',
+        contentType: 'text/plain',
+        size: small.byteLength,
+        content: small,
+      },
+      {
+        filename: 'huge.bin',
+        contentType: 'application/octet-stream',
+        size: large.byteLength,
+        content: large,
+      },
+      {
+        filename: 'inline.png',
+        contentType: 'image/png',
+        contentId: '<cid@x>',
+        content: Buffer.from([1, 2, 3]),
+      },
+    ]);
+
+    expect(out).toEqual([
+      {
+        id: 'att-1-note.txt',
+        filename: 'note.txt',
+        contentType: 'text/plain',
+        size: 5,
+        contentBase64: small.toString('base64'),
+      },
+      {
+        id: 'att-2-huge.bin',
+        filename: 'huge.bin',
+        contentType: 'application/octet-stream',
+        size: large.byteLength,
+      },
+      {
+        id: 'cid@x',
+        filename: 'inline.png',
+        contentType: 'image/png',
+        size: 3,
+        contentId: 'cid@x',
+        contentBase64: Buffer.from([1, 2, 3]).toString('base64'),
+      },
+    ]);
   });
 });
 

--- a/services/platform/lib/connectors/natives/imap-smtp.ts
+++ b/services/platform/lib/connectors/natives/imap-smtp.ts
@@ -113,6 +113,32 @@ export interface MailAddress {
 }
 
 /**
+ * One attachment pulled out of a MIME part. Bytes travel as base64 so the
+ * connector result stays JSON-safe across the Convex action boundary; sync
+ * materializes them into org blob storage before ingest.
+ */
+export interface MailAttachment {
+  readonly id: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly contentId?: string;
+  /** Present when the part's body fit under {@link MAX_ATTACHMENT_BYTES}. */
+  readonly contentBase64?: string;
+}
+
+/**
+ * Cap for attachment bytes returned inline from `get_message`. Deliberately
+ * well under Convex's function-payload ceiling: base64 inflates by ~4/3, and
+ * this string crosses the connector-action boundary before sync writes it to
+ * blob storage. 5 MiB raw (≈6.7 MiB encoded) matches the repo's other
+ * cross-a-Convex-boundary blob cap and covers ordinary mail attachments —
+ * providers cap a whole message near 25 MB. A bigger part is listed as
+ * metadata only rather than risking the pass.
+ */
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+
+/**
  * One message body plus the fields conversation ingest needs — Message-ID
  * idempotency, threading headers, and the envelope addresses.
  */
@@ -133,6 +159,7 @@ export interface MailMessageBody {
     readonly references?: string;
   };
   readonly flags?: readonly string[];
+  readonly attachments?: readonly MailAttachment[];
 }
 
 export interface MailboxQuery {
@@ -656,6 +683,10 @@ export function imapSmtpNatives(
         ...(message.html !== undefined && { html: message.html }),
         flags: message.flags ?? [],
         headers: message.headers,
+        ...(message.attachments !== undefined &&
+          message.attachments.length > 0 && {
+            attachments: [...message.attachments],
+          }),
       },
     };
   };
@@ -755,6 +786,15 @@ type ParsedAddressObject = {
   text?: string;
 };
 
+type ParsedMailAttachment = {
+  filename?: string | false;
+  contentType?: string;
+  size?: number;
+  contentId?: string;
+  cid?: string;
+  content?: Buffer | Uint8Array | string;
+};
+
 type SimpleParser = (source: Buffer | string) => Promise<{
   text?: string;
   html?: string | false;
@@ -766,7 +806,82 @@ type SimpleParser = (source: Buffer | string) => Promise<{
   from?: ParsedAddressObject;
   to?: ParsedAddressObject;
   cc?: ParsedAddressObject;
+  attachments?: ParsedMailAttachment[];
 }>;
+
+/**
+ * Map mailparser attachment parts into the connector's attachment shape.
+ * Oversized parts keep metadata only — sync still lists the file, but bytes
+ * must be fetched another way (not yet wired for IMAP).
+ */
+export function mailAttachmentsFromParsed(
+  attachments: readonly ParsedMailAttachment[] | undefined,
+): MailAttachment[] {
+  if (!attachments || attachments.length === 0) return [];
+  const out: MailAttachment[] = [];
+  for (let i = 0; i < attachments.length; i++) {
+    const part = attachments[i];
+    if (part === undefined) continue;
+    const filename =
+      typeof part.filename === 'string' && part.filename.trim() !== ''
+        ? part.filename
+        : `attachment-${i + 1}`;
+    const contentType =
+      typeof part.contentType === 'string' && part.contentType.trim() !== ''
+        ? part.contentType
+        : 'application/octet-stream';
+    const contentIdRaw =
+      typeof part.contentId === 'string' && part.contentId.trim() !== ''
+        ? part.contentId
+        : typeof part.cid === 'string' && part.cid.trim() !== ''
+          ? part.cid
+          : undefined;
+    const contentId =
+      contentIdRaw !== undefined
+        ? contentIdRaw.replace(/^<|>$/g, '')
+        : undefined;
+    const bytes = attachmentBytes(part.content);
+    const size =
+      typeof part.size === 'number' && Number.isFinite(part.size)
+        ? part.size
+        : (bytes?.byteLength ?? 0);
+    const id =
+      contentId !== undefined && contentId !== ''
+        ? contentId
+        : `att-${i + 1}-${filename}`;
+    const mapped: MailAttachment = {
+      id,
+      filename,
+      contentType,
+      size,
+      ...(contentId !== undefined && contentId !== '' && { contentId }),
+    };
+    if (bytes !== null && bytes.byteLength <= MAX_ATTACHMENT_BYTES) {
+      out.push({
+        ...mapped,
+        contentBase64: Buffer.from(bytes).toString('base64'),
+      });
+    } else {
+      out.push(mapped);
+    }
+  }
+  return out;
+}
+
+function attachmentBytes(
+  content: Buffer | Uint8Array | string | undefined,
+): Uint8Array | null {
+  if (content === undefined) return null;
+  if (typeof content === 'string') {
+    if (content.length === 0) return null;
+    return new TextEncoder().encode(content);
+  }
+  if (content.byteLength === 0) return null;
+  // `Buffer` IS a `Uint8Array` (a view into a pooled ArrayBuffer), so one
+  // branch covers both wire shapes. Callers must go through `Buffer.from(view)`
+  // rather than `view.buffer`, which would read the whole pool.
+  return content;
+}
 
 /** Same interop story as {@link resolveImapFlowConstructor} for mailparser. */
 export function resolveSimpleParser(mod: unknown): SimpleParser {
@@ -1113,6 +1228,7 @@ async function fetchMessageBody(
     parsed.date instanceof Date && Number.isFinite(parsed.date.getTime())
       ? parsed.date.toISOString()
       : new Date(0).toISOString();
+  const attachments = mailAttachmentsFromParsed(parsed.attachments);
   return {
     uid: String(message.uid),
     messageId,
@@ -1125,6 +1241,7 @@ async function fetchMessageBody(
     ...(html !== undefined && { html }),
     headers,
     flags,
+    ...(attachments.length > 0 && { attachments }),
   };
 }
 


### PR DESCRIPTION
Mail arriving over IMAP lost its attachments. `imap-smtp.get_message` returned body text and headers only, so a message carrying a CV or an invoice landed in the Inbox as prose with no trace of the file.

## The path

1. **Connector** — `mailAttachmentsFromParsed` pulls attachment parts out of the parsed MIME and returns metadata always, plus `contentBase64` when the part fits under the inline cap.
2. **Sync** — `materializeEmailAttachments` decodes those bytes into the org's blob storage, records the file in `fileMetadata`, and rewrites the attachment to `storageId` + a download URL.
3. **Ingest** — conversations receive a reference the Inbox can open, never a payload they have to carry.

Gmail and Outlook are unchanged here: connector `ctx.files` is deliberately unwired, so their `downloadAttachments` flag cannot store during `get_message`. This wires the IMAP path, and the helper is shaped to take the others when that seam opens.

## Two things worth reviewing

**Bytes drain per message, not per page.** `fetchBodies` materializes each body before fetching the next. Fetching the whole page first would make resident memory scale with `limit` (25 by default) × the per-attachment cap — hundreds of MiB of base64 string live in one action. A test pins the interleaving (`get:1 → store → get:2 → store`), so a future "batch the stores" refactor fails loudly.

**The cap is 5 MiB raw**, ≈6.7 MiB base64, well inside the Convex function-payload ceiling — that string crosses the connector-action boundary before it reaches storage. A larger part is listed as metadata only rather than risking the pass. The number is asserted against the figure `connector.yml` advertises, so the manifest and the constant cannot drift apart.

**`contentBase64` is wire-only.** `attachmentsForMetadata` strips it at all four ingest sinks — `emailAttachmentMetaValidator` is a strict object that would reject the message row, and the metadata records are untyped JSON that would otherwise swell by the whole attachment.

## Tests

New unit coverage for `mailAttachmentsFromParsed` (small parts encoded, oversized kept metadata-only, `cid` normalised), `materializeEmailAttachments`, and `attachmentsForMetadata`; plus two sync-level cases for the drain ordering and the stored-reference hand-off. Full server suite green: 610 files, 74,366 tests.