### PR TITLE
feat(platform): explain sandbox session pools on hover

### DIFF
--- a/services/platform/app/features/settings/sandboxes/sandboxes-settings.tsx
+++ b/services/platform/app/features/settings/sandboxes/sandboxes-settings.tsx
@@ -1,5 +1,11 @@
 import { Badge } from '@tale/ui/badge';
 import { Row, Stack } from '@tale/ui/layout';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@tale/ui/tooltip';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { FunctionReturnType } from 'convex/server';
 import { Box, Pin, PinOff, Square, Trash2 } from 'lucide-react';
@@ -278,18 +284,33 @@ export function SandboxesSettings({ organizationId }: SandboxesSettingsProps) {
   return (
     <SettingsSection title={t('title')} description={t('description')}>
       {quotaRows.length > 0 && (
-        <Row gap={2} wrap className="mb-4">
-          {quotaRows.map((b) => (
-            <Badge
-              key={b.budget}
-              variant={
-                b.atLimit ? 'destructive' : b.nearLimit ? 'yellow' : 'slate'
-              }
-            >
-              {t(`quota.budgets.${b.budget}`)}: {b.used} / {b.cap}
-            </Badge>
-          ))}
-        </Row>
+        <TooltipProvider delayDuration={300}>
+          <Row gap={2} wrap className="mb-4">
+            {quotaRows.map((b) => (
+              <Tooltip key={b.budget}>
+                {/* The chip itself is the trigger; tabIndex makes it
+                  keyboard-reachable so the hint opens on focus too. */}
+                <TooltipTrigger asChild>
+                  <Badge
+                    tabIndex={0}
+                    variant={
+                      b.atLimit
+                        ? 'destructive'
+                        : b.nearLimit
+                          ? 'yellow'
+                          : 'slate'
+                    }
+                  >
+                    {t(`quota.budgets.${b.budget}`)}: {b.used} / {b.cap}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  {t(`quota.budgetHints.${b.budget}`)}
+                </TooltipContent>
+              </Tooltip>
+            ))}
+          </Row>
+        </TooltipProvider>
       )}
       <DataTable<SandboxRow>
         columns={columns}

--- a/services/platform/convex/chat/external_turn.test.ts
+++ b/services/platform/convex/chat/external_turn.test.ts
@@ -211,7 +211,8 @@ describe('getSandboxQuotaUsage — session usage vs cap', () => {
   it('counts creating+active per budget (not stopped) and flags at/near limit', async () => {
     const t = convexTest(schema, modules);
     await seedMember(t, ADMIN2, ORG, 'admin');
-    // Default user cap is 2. Two active user sessions → at limit.
+    // Default project-budget cap is 2; legacy 'user'-owned rows draw from it.
+    // Two holding a slot → at limit.
     await insertSession(t, 'user', 'active', 'u1');
     await insertSession(t, 'user', 'creating', 'u2');
     // A stopped session freed its slot — must NOT count.
@@ -228,10 +229,14 @@ describe('getSandboxQuotaUsage — session usage vs cap', () => {
       });
     expect(usage).not.toBeNull();
     if (usage === null) throw new Error('unreachable');
-    expect(usage.map((b) => b.budget)).toEqual(['user', 'workflow', 'render']);
-    const user = usage.find((b) => b.budget === 'user');
-    expect(user?.used).toBe(2);
-    expect(user?.atLimit).toBe(true);
+    expect(usage.map((b) => b.budget)).toEqual([
+      'project',
+      'workflow',
+      'render',
+    ]);
+    const project = usage.find((b) => b.budget === 'project');
+    expect(project?.used).toBe(2);
+    expect(project?.atLimit).toBe(true);
     const workflow = usage.find((b) => b.budget === 'workflow');
     expect(workflow?.used).toBe(0);
   });

--- a/services/platform/convex/chat/external_turn.test.ts
+++ b/services/platform/convex/chat/external_turn.test.ts
@@ -217,9 +217,8 @@ describe('getSandboxQuotaUsage — session usage vs cap', () => {
     await insertSession(t, 'user', 'creating', 'u2');
     // A stopped session freed its slot — must NOT count.
     await insertSession(t, 'user', 'stopped', 'u3');
-    // A legacy thread-owned session: its budget is no longer reported (the
-    // per-thread run_code lane is retired) and it must not leak into another
-    // budget's count.
+    // A legacy thread-owned session: its lane is retired (routes to no
+    // budget) and it must not leak into another budget's count.
     await insertSession(t, 'thread', 'active', 't1');
 
     const usage = await t

--- a/services/platform/convex/migrations/config.snapshot.yml
+++ b/services/platform/convex/migrations/config.snapshot.yml
@@ -2964,17 +2964,12 @@ schemas:
         maximum: 500
         minimum: 1
         type: integer
-      maxThreadSessionsPerOrg:
-        maximum: 500
-        minimum: 1
-        type: integer
       maxWorkflowSessionsPerOrg:
         maximum: 500
         minimum: 1
         type: integer
     required:
       - maxSessionsPerOrg
-      - maxThreadSessionsPerOrg
       - maxWorkflowSessionsPerOrg
       - maxRenderSessionsPerOrg
     type: object

--- a/services/platform/convex/sandbox/admission.ts
+++ b/services/platform/convex/sandbox/admission.ts
@@ -338,7 +338,7 @@ export const pollAdmission = internalMutation({
       now,
       createdAtForNew,
     );
-    // Sessions are budgeted per workload (user / thread / workflow / render).
+    // Sessions are budgeted per workload (project / thread / workflow / render).
     const sessionBudget = sessionBudgetForOwnerType(args.ownerType);
     const cap = await admissionCap(ctx, args.organizationId, sessionBudget);
     const inFlight = await admissionInFlight(

--- a/services/platform/convex/sandbox/admission.ts
+++ b/services/platform/convex/sandbox/admission.ts
@@ -21,6 +21,7 @@ import { internalMutation, type MutationCtx } from '../_generated/server';
 import { isE2ECronSuppressed } from '../lib/e2e_cron_guard';
 import {
   readSandboxQuotaPolicy,
+  requireSessionBudgetForOwnerType,
   type SessionBudget,
   sessionBudgetForOwnerType,
   sessionCapFor,
@@ -338,8 +339,9 @@ export const pollAdmission = internalMutation({
       now,
       createdAtForNew,
     );
-    // Sessions are budgeted per workload (project / thread / workflow / render).
-    const sessionBudget = sessionBudgetForOwnerType(args.ownerType);
+    // Sessions are budgeted per workload (project / workflow / render); a new
+    // waiter must belong to a live lane.
+    const sessionBudget = requireSessionBudgetForOwnerType(args.ownerType);
     const cap = await admissionCap(ctx, args.organizationId, sessionBudget);
     const inFlight = await admissionInFlight(
       ctx,

--- a/services/platform/convex/sandbox/quota_policy.ts
+++ b/services/platform/convex/sandbox/quota_policy.ts
@@ -1,4 +1,5 @@
 import type { GenericDatabaseReader } from 'convex/server';
+import { ConvexError } from 'convex/values';
 
 import {
   DEFAULT_SANDBOX_QUOTA,
@@ -43,15 +44,19 @@ export async function readSandboxQuotaPolicy(
  * The persistent-session workloads are limited separately so they never
  * compete for one pool. The `project` budget is the project agents' standing
  * sandboxes; its cap lives in the `maxSessionsPerOrg` config field, whose
- * name predates the rename and stays for shipped-config compatibility. The
- * `thread` budget's run_code lane has no producer since chat became
- * plain-conversation (#2877); the key is kept for the same reason.
+ * name predates the rename and stays for shipped-config compatibility.
  */
-export type SessionBudget = 'project' | 'thread' | 'workflow' | 'render';
+export type SessionBudget = 'project' | 'workflow' | 'render';
 
-/** Which budget an `ownerType` draws from. */
-export function sessionBudgetForOwnerType(ownerType: string): SessionBudget {
-  if (ownerType === 'thread') return 'thread';
+/**
+ * Which budget an `ownerType` draws from — `null` for the retired per-thread
+ * run_code lane (dead since chat became plain-conversation, #2877), whose
+ * leftover rows must not count against any live budget.
+ */
+export function sessionBudgetForOwnerType(
+  ownerType: string,
+): SessionBudget | null {
+  if (ownerType === 'thread') return null;
   if (ownerType === 'workflow_run') return 'workflow';
   if (ownerType === 'render') return 'render';
   // `project_agent` standing sandboxes — plus any legacy per-user rows —
@@ -59,12 +64,25 @@ export function sessionBudgetForOwnerType(ownerType: string): SessionBudget {
   return 'project';
 }
 
+/** As above for the reserve/resume paths, where the lane must be live. */
+export function requireSessionBudgetForOwnerType(
+  ownerType: string,
+): SessionBudget {
+  const budget = sessionBudgetForOwnerType(ownerType);
+  if (budget === null) {
+    throw new ConvexError({
+      code: 'SESSION_LANE_RETIRED',
+      message: `Sandbox sessions owned by '${ownerType}' can no longer be created or resumed.`,
+    });
+  }
+  return budget;
+}
+
 /** The per-org cap for a session budget, from the quota policy. */
 export function sessionCapFor(
   budget: SessionBudget,
   quota: SandboxQuotaConfig,
 ): number {
-  if (budget === 'thread') return quota.maxThreadSessionsPerOrg;
   if (budget === 'workflow') return quota.maxWorkflowSessionsPerOrg;
   if (budget === 'render') return quota.maxRenderSessionsPerOrg;
   // 'project' — the field name predates the rename (shipped org config).

--- a/services/platform/convex/sandbox/quota_policy.ts
+++ b/services/platform/convex/sandbox/quota_policy.ts
@@ -41,14 +41,13 @@ export async function readSandboxQuotaPolicy(
 
 /**
  * The persistent-session workloads are limited separately so they never
- * compete for one pool. The `user` budget is the PROJECT-AGENT pool: since
- * chat became plain-conversation (#2877) no per-user sandbox can be created,
- * so agents' standing sessions are its only occupants — the budget key stays
- * `user` because `maxSessionsPerOrg` is shipped org config. The `thread`
- * budget's run_code lane is likewise unreachable; the key is kept for the
- * same config-compatibility reason.
+ * compete for one pool. The `project` budget is the project agents' standing
+ * sandboxes; its cap lives in the `maxSessionsPerOrg` config field, whose
+ * name predates the rename and stays for shipped-config compatibility. The
+ * `thread` budget's run_code lane has no producer since chat became
+ * plain-conversation (#2877); the key is kept for the same reason.
  */
-export type SessionBudget = 'user' | 'thread' | 'workflow' | 'render';
+export type SessionBudget = 'project' | 'thread' | 'workflow' | 'render';
 
 /** Which budget an `ownerType` draws from. */
 export function sessionBudgetForOwnerType(ownerType: string): SessionBudget {
@@ -57,7 +56,7 @@ export function sessionBudgetForOwnerType(ownerType: string): SessionBudget {
   if (ownerType === 'render') return 'render';
   // `project_agent` standing sandboxes — plus any legacy per-user rows —
   // draw from the org's main session budget.
-  return 'user';
+  return 'project';
 }
 
 /** The per-org cap for a session budget, from the quota policy. */
@@ -68,5 +67,6 @@ export function sessionCapFor(
   if (budget === 'thread') return quota.maxThreadSessionsPerOrg;
   if (budget === 'workflow') return quota.maxWorkflowSessionsPerOrg;
   if (budget === 'render') return quota.maxRenderSessionsPerOrg;
+  // 'project' — the field name predates the rename (shipped org config).
   return quota.maxSessionsPerOrg;
 }

--- a/services/platform/convex/sandbox/session_mutations.ts
+++ b/services/platform/convex/sandbox/session_mutations.ts
@@ -25,6 +25,7 @@ import {
 } from './admission';
 import {
   readSandboxQuotaPolicy,
+  requireSessionBudgetForOwnerType,
   sessionBudgetForOwnerType,
   sessionCapFor,
 } from './quota_policy';
@@ -109,15 +110,15 @@ export const reserveSessionSlotAndInsert = internalMutation({
         args.organizationId,
         'session',
         ticketCreatedAt,
-        sessionBudgetForOwnerType(args.ownerType),
+        requireSessionBudgetForOwnerType(args.ownerType),
       );
       await claimTicket(ctx, args.ownerType, args.ownerId, now);
     } else {
       // Per-org cap (defense in depth; the spawner enforces its own cap too).
-      // The three session workloads (user agent / thread run_code / workflow)
-      // are limited separately, so count + cap only this owner's budget.
+      // The session workloads (project agents / workflow runs / render) are
+      // limited separately, so count + cap only this owner's budget.
       const quota = await readSandboxQuotaPolicy(ctx.db, args.organizationId);
-      const budget = sessionBudgetForOwnerType(args.ownerType);
+      const budget = requireSessionBudgetForOwnerType(args.ownerType);
       const cap = sessionCapFor(budget, quota);
       let orgActive = 0;
       for (const status of ['creating', 'active'] as const) {
@@ -530,7 +531,7 @@ export const resumeAutomationSessionSlot = internalMutation({
           args.organizationId,
           'session',
           ticketCreatedAt,
-          sessionBudgetForOwnerType(row.ownerType),
+          requireSessionBudgetForOwnerType(row.ownerType),
         );
         await claimTicket(ctx, row.ownerType, row.ownerId, now);
       }
@@ -911,7 +912,7 @@ export const resumeSessionSlotWithCapCheck = internalMutation({
       if (!isLiveSessionStatus(row.status)) continue;
       if (row.status !== 'stopped') return true; // already admitted
       const quota = await readSandboxQuotaPolicy(ctx.db, args.organizationId);
-      const budget = sessionBudgetForOwnerType(row.ownerType);
+      const budget = requireSessionBudgetForOwnerType(row.ownerType);
       const cap = sessionCapFor(budget, quota);
       let orgActive = 0;
       for (const status of ['creating', 'active'] as const) {

--- a/services/platform/convex/sandbox/session_ops_coverage.test.ts
+++ b/services/platform/convex/sandbox/session_ops_coverage.test.ts
@@ -271,8 +271,8 @@ describe('reserveSessionSlotAndInsert', () => {
         organizationId: ORG,
         sessionId: 'sid-a',
         profile: 'agent',
-        ownerType: 'thread',
-        ownerId: 'thread-1',
+        ownerType: 'project_agent',
+        ownerId: 'agent-1',
         createdBy: 'user-1',
       },
     );
@@ -284,8 +284,8 @@ describe('reserveSessionSlotAndInsert', () => {
           organizationId: ORG,
           sessionId: 'sid-b',
           profile: 'agent',
-          ownerType: 'thread',
-          ownerId: 'thread-1',
+          ownerType: 'project_agent',
+          ownerId: 'agent-1',
           createdBy: 'user-1',
         },
       ),
@@ -300,8 +300,8 @@ describe('reserveSessionSlotAndInsert', () => {
         organizationId: ORG,
         sessionId: 'sid-a',
         profile: 'agent',
-        ownerType: 'thread',
-        ownerId: 'thread-2',
+        ownerType: 'project_agent',
+        ownerId: 'agent-2',
         createdBy: 'user-1',
       },
     );
@@ -313,11 +313,28 @@ describe('reserveSessionSlotAndInsert', () => {
         organizationId: ORG,
         sessionId: 'sid-c',
         profile: 'agent',
-        ownerType: 'thread',
-        ownerId: 'thread-2',
+        ownerType: 'project_agent',
+        ownerId: 'agent-2',
         createdBy: 'user-1',
       },
     );
     expect(id2).toBeTruthy();
+  });
+
+  it('rejects the retired per-thread lane outright', async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(
+        internal.sandbox.session_mutations.reserveSessionSlotAndInsert,
+        {
+          organizationId: ORG,
+          sessionId: 'sid-thr',
+          profile: 'agent',
+          ownerType: 'thread',
+          ownerId: 'thread-1',
+          createdBy: 'user-1',
+        },
+      ),
+    ).rejects.toThrow(/no longer be created/);
   });
 });

--- a/services/platform/convex/sandbox/session_queries_public.ts
+++ b/services/platform/convex/sandbox/session_queries_public.ts
@@ -559,10 +559,9 @@ const QUOTA_WARN_FRACTION = 0.8;
  * Per-budget sandbox session usage vs cap for the org — the "配额打满有预警"
  * surface. A session holds a slot while `creating`/`active` (a `stopped` one
  * freed it), so those are what count against the cap, split by the same budget
- * mapping the reserve uses. Reported budgets are project / workflow / render; the
- * `thread` budget still exists in the policy but has no live producer (the
- * per-thread run_code lane is retired), so a forever-empty row would only
- * mislead. Each budget reports `used`, `cap`, `atLimit` (a new session of
+ * mapping the reserve uses. Reported budgets are project / workflow / render —
+ * every live lane; leftover rows of the retired per-thread run_code lane route
+ * to no budget and count nowhere. Each budget reports `used`, `cap`, `atLimit` (a new session of
  * that kind would be refused), and `nearLimit` (≥80% — the soft warning).
  * Admin-gated (developerSettings) like the Sandboxes page; null on
  * access-denied.
@@ -589,7 +588,6 @@ export const getSandboxQuotaUsage = query({
     const quota = await readSandboxQuotaPolicy(ctx.db, args.organizationId);
     const used: Record<SessionBudget, number> = {
       project: 0,
-      thread: 0,
       workflow: 0,
       render: 0,
     };
@@ -601,7 +599,8 @@ export const getSandboxQuotaUsage = query({
         .withIndex('by_organizationId_and_status', (q) =>
           q.eq('organizationId', args.organizationId).eq('status', status),
         )) {
-        used[sessionBudgetForOwnerType(row.ownerType)] += 1;
+        const budget = sessionBudgetForOwnerType(row.ownerType);
+        if (budget !== null) used[budget] += 1;
       }
     }
 

--- a/services/platform/convex/sandbox/session_queries_public.ts
+++ b/services/platform/convex/sandbox/session_queries_public.ts
@@ -559,7 +559,7 @@ const QUOTA_WARN_FRACTION = 0.8;
  * Per-budget sandbox session usage vs cap for the org — the "配额打满有预警"
  * surface. A session holds a slot while `creating`/`active` (a `stopped` one
  * freed it), so those are what count against the cap, split by the same budget
- * mapping the reserve uses. Reported budgets are user / workflow / render; the
+ * mapping the reserve uses. Reported budgets are project / workflow / render; the
  * `thread` budget still exists in the policy but has no live producer (the
  * per-thread run_code lane is retired), so a forever-empty row would only
  * mislead. Each budget reports `used`, `cap`, `atLimit` (a new session of
@@ -588,7 +588,7 @@ export const getSandboxQuotaUsage = query({
 
     const quota = await readSandboxQuotaPolicy(ctx.db, args.organizationId);
     const used: Record<SessionBudget, number> = {
-      user: 0,
+      project: 0,
       thread: 0,
       workflow: 0,
       render: 0,
@@ -605,7 +605,7 @@ export const getSandboxQuotaUsage = query({
       }
     }
 
-    const budgets: SessionBudget[] = ['user', 'workflow', 'render'];
+    const budgets: SessionBudget[] = ['project', 'workflow', 'render'];
     return budgets.map((budget) => {
       const cap = sessionCapFor(budget, quota);
       const u = used[budget];

--- a/services/platform/convex/sandbox/sessions_schema.ts
+++ b/services/platform/convex/sandbox/sessions_schema.ts
@@ -43,7 +43,7 @@ export const sandboxSessionsTable = defineTable({
     v.literal('failed'),
   ),
   // Polymorphic owner (open set — see note above).
-  ownerType: v.string(), // 'thread' | 'workflow_run' | 'user' | …
+  ownerType: v.string(), // 'project_agent' | 'workflow_run' | 'render' | legacy 'user'/'thread' | …
   ownerId: v.string(),
   createdBy: v.string(),
   agentKind: v.optional(v.string()), // 'claude-code' | 'cursor' | …
@@ -332,7 +332,7 @@ export const sandboxAdmissionTicketsTable = defineTable({
    *  still read-validate; nothing writes it). Caps on `sandboxSessions`. */
   kind: v.union(v.literal('session'), v.literal('oneshot')),
   // Polymorphic owner (open set, like sandboxSessions.ownerType).
-  ownerType: v.string(), // 'thread' | 'user' | 'workflow_run' | …
+  ownerType: v.string(), // 'project_agent' | 'workflow_run' | 'render' | legacy 'user'/'thread' | …
   ownerId: v.string(),
   /** Where the waiter lives, so the reaper can cross-check liveness. */
   source: v.union(v.literal('chat'), v.literal('workflow')),

--- a/services/platform/lib/shared/schemas/governance.ts
+++ b/services/platform/lib/shared/schemas/governance.ts
@@ -141,8 +141,6 @@ export const sandboxQuotaConfigSchema = z.object({
    * own separate budgets below so they never compete for one pool.
    */
   maxSessionsPerOrg: z.number().int().min(1).max(500).default(2),
-  /** Max concurrently-active per-**thread** run_code sandbox sessions. */
-  maxThreadSessionsPerOrg: z.number().int().min(1).max(500).default(8),
   /** Max concurrently-active per-**workflow-run** sandbox sessions. */
   maxWorkflowSessionsPerOrg: z.number().int().min(1).max(500).default(4),
   /**

--- a/services/platform/lib/shared/schemas/governance.ts
+++ b/services/platform/lib/shared/schemas/governance.ts
@@ -135,10 +135,10 @@ export type TaskAutomationConfig = z.infer<typeof taskAutomationConfigSchema>;
  */
 export const sandboxQuotaConfigSchema = z.object({
   /**
-   * Max concurrently-active persistent **user** sandbox sessions (external
-   * agents — Claude Code / Cursor, one per user). Per-thread run_code and
-   * per-workflow-run sessions have their own separate budgets below so the
-   * three workloads never compete for one pool.
+   * Max concurrently-active **project-agent** standing sandbox sessions (the
+   * `project` budget). The field name predates the project-agent rename and
+   * stays for shipped-config compatibility. The other workloads have their
+   * own separate budgets below so they never compete for one pool.
    */
   maxSessionsPerOrg: z.number().int().min(1).max(500).default(2),
   /** Max concurrently-active per-**thread** run_code sandbox sessions. */

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -7955,9 +7955,14 @@ sandboxes:
     sie immer bereit ist.
   quota:
     budgets:
-      user: Agent-Sitzungen
+      project: Agent-Sitzungen
       workflow: Automatisierungssitzungen
       render: Render-Sitzungen
+    budgetHints:
+      project: Dauerhafte Sandboxes, in denen deine Projekt-Agenten arbeiten.
+      workflow: Jeder aktive Automatisierungslauf nutzt eine eigene Sandbox.
+      render: Kurzlebige Sandboxes, die beim Crawlen deiner Websites
+        JavaScript-lastige Seiten rendern.
   columns:
     owner: Eigentümer
     agent: Agent

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -7653,9 +7653,14 @@ sandboxes:
     automation runs do their work; pin one to keep it always ready.
   quota:
     budgets:
-      user: Agent sessions
+      project: Agent sessions
       workflow: Automation sessions
       render: Render sessions
+    budgetHints:
+      project: Standing sandboxes where your project agents do their work.
+      workflow: Each active automation run works in its own sandbox.
+      render: Short-lived sandboxes that render JavaScript-heavy pages while
+        your websites are crawled.
   columns:
     owner: Owner
     agent: Agent

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -8091,9 +8091,14 @@ sandboxes:
     épingle-en une pour la garder toujours prête.
   quota:
     budgets:
-      user: Sessions d’agent
+      project: Sessions d’agent
       workflow: Sessions d'automatisation
       render: Sessions de rendu
+    budgetHints:
+      project: Sandboxes persistantes où travaillent tes agents de projet.
+      workflow: Chaque exécution d'automatisation active utilise sa propre sandbox.
+      render: Sandboxes éphémères qui font le rendu des pages riches en
+        JavaScript pendant l'exploration de tes sites web.
   columns:
     owner: Propriétaire
     agent: Agent


### PR DESCRIPTION
## What

- Hovering (or Tab-focusing) a session-quota chip on **Settings → Sandboxes** now explains what draws from that pool, in en/de/fr.
- Renames the internal session budget key `user` → `project`. Since #2877 the pool's only occupants are project agents' standing sandboxes; the old key needed a comment to apologize for itself.
- **Retires the dead `thread` budget** (second commit). The per-thread run_code lane has had no producer since #2877: the budget key is gone, `maxThreadSessionsPerOrg` is dropped from the `sandbox_quota` schema, and `sessionBudgetForOwnerType` returns `null` for the retired lane so leftover thread-owned rows count against **no** live budget — they must not leak into the project pool (cap 2). Reserve/resume of a retired lane throws `SESSION_LANE_RETIRED`, pinned by a new test. Row-level readers/cleaners for legacy thread-owned sessions stay.

## Why there is no migration

The budget is derived from `ownerType` at read time and never persisted. The `user` → `project` rename therefore touches no data, and `maxSessionsPerOrg` keeps its shipped name (noted at the schema and the cap lookup). Removing `maxThreadSessionsPerOrg` is a data-safe narrowing under the migrations snapshot ritual: Zod strips the leftover key from existing org config files at parse time; the refreshed `config.snapshot.yml` baseline records the decision, and `migrations:check` (registries, corpus, schema + config snapshots) is green.

## Verified

- Typecheck, oxlint, `migrations:check`, the migrations chain + versions suites, all sandbox/chat unit tests (268 in the final run) and the `@tale/ui` i18n suite are green.
- Driven in a real browser: chip labels resolve through the new key, all three tooltips open on hover **and** on keyboard focus (`tooltip` role exposed), and the quota chips still render correctly after the usage-query change.