### PR TITLE
fix(platform): recover agent runs whose settle died mid-flight

### DIFF
--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -1512,6 +1512,7 @@ async function settleWorkflowAgentTurn(
       const harvested = await harvestSessionOutput(ctx, {
         organizationId: args.organizationId,
         sessionId: args.sessionId,
+        execId: args.execId,
       });
       files = harvested.files.map((file) => ({
         name: file.path.split('/').at(-1) ?? file.path,

--- a/services/platform/convex/automations/queries.ts
+++ b/services/platform/convex/automations/queries.ts
@@ -26,6 +26,7 @@ import type { QueryCtx } from '../_generated/server';
 import { internalQuery, query } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { sessionOpLastSignOfLifeMs } from '../sandbox/agent_deadline';
 import { readCheckpoints } from './checkpoints';
 import {
   automationReadStore,
@@ -1102,8 +1103,21 @@ export const listStalledAgentTurns = internalQuery({
         )
         .first();
       if (op !== null) {
-        if (op.status !== 'running') continue; // already settled
-        if ((op.heartbeatAt ?? op.startedAt) >= args.staleBeforeMs) continue;
+        // ONE liveness rule for every phase: the op's lease must be silent
+        // past the staleness window (drain bumps per window, the finalize
+        // claim and per-file harvest bumps carry the settle, the terminal
+        // write stamps `finishedAt`). An op that settled while the cursor
+        // never got its result is a mid-settle death and goes stale like any
+        // other dead chain — EXCEPT the ask-park: an awaiting_human op is
+        // terminal with no result for up to 7 days by design, and
+        // re-attaching it would settle a question mid-wait.
+        if (
+          op.status !== 'running' &&
+          op.agentResultStatus === 'awaiting_human'
+        ) {
+          continue;
+        }
+        if (sessionOpLastSignOfLifeMs(op) >= args.staleBeforeMs) continue;
       }
       out.push({
         organizationId: row.organizationId,

--- a/services/platform/convex/automations/recover_agent_turns.ts
+++ b/services/platform/convex/automations/recover_agent_turns.ts
@@ -21,6 +21,14 @@
  * exec's ring buffer from the start of the window, the settle is claimed exactly
  * once (`releaseTurnKey`), and `claimRecoveryResume` closes the
  * query→schedule race so two sweeps cannot both resurrect one turn.
+ *
+ * A chain that died SETTLING is covered too: the settle holds the same
+ * liveness lease the drain does (claim-time and per-file harvest bumps), so
+ * a dead settle goes stale like any dead drainer — `claimRecoveryResume`
+ * re-opens a dead winner's finalize election, and the stalled query lists a
+ * settled op whose cursor never got its result (sparing the ask-park); both
+ * halves of a mid-settle death heal through the same re-attach (see the
+ * claim's doc for the three phase shapes).
  */
 
 import { v } from 'convex/values';
@@ -95,7 +103,16 @@ export const recoverStalledAgentTurns = internalAction({
           },
         },
       );
-      if (!claimed) continue;
+      if (!claimed) {
+        // Refused = something signed the op's lease after the stalled query
+        // read it (a live chain's bump, a concurrent sweep, a settle still
+        // proving life). Diagnosable, not silent: the original dead-winner
+        // wedge hid behind a logless skip for hours.
+        console.warn(
+          `[agent-turn-watchdog] resume claim refused for ${turn.execId} of run ${String(turn.runId)} — a live chain or a fresh settle owns it`,
+        );
+        continue;
+      }
       await ctx.scheduler.runAfter(
         0,
         internal.automations.agent_host.driveWorkflowAgentTurn,

--- a/services/platform/convex/automations/stalled_agent_turns.test.ts
+++ b/services/platform/convex/automations/stalled_agent_turns.test.ts
@@ -89,6 +89,9 @@ async function seedOp(
     status?: 'running' | 'completed';
     heartbeatAt?: number;
     execId?: string;
+    finalizedAt?: number;
+    finishedAt?: number;
+    agentResultStatus?: string;
   } = {},
 ): Promise<void> {
   await t.run((ctx) =>
@@ -100,6 +103,11 @@ async function seedOp(
       status: args.status ?? 'running',
       startedAt: 1_000,
       ...(args.heartbeatAt !== undefined && { heartbeatAt: args.heartbeatAt }),
+      ...(args.finalizedAt !== undefined && { finalizedAt: args.finalizedAt }),
+      ...(args.finishedAt !== undefined && { finishedAt: args.finishedAt }),
+      ...(args.agentResultStatus !== undefined && {
+        agentResultStatus: args.agentResultStatus,
+      }),
     }),
   );
 }
@@ -145,10 +153,42 @@ describe('listStalledAgentTurns', () => {
     expect(stalled).toHaveLength(1);
   });
 
-  it('skips a turn whose op already settled — the stepper consumes that one', async () => {
+  it('spares a settle whose lease is still fresh — its winner is still working', async () => {
     const t = convexTest(schema, modules);
     await seedRun(t, { cursor: agentCursor() });
-    await seedOp(t, { status: 'completed', heartbeatAt: 1_000 });
+    await seedOp(t, {
+      status: 'completed',
+      heartbeatAt: 1_000,
+      finalizedAt: Date.now(),
+      finishedAt: Date.now(),
+    });
+    expect(await listStalled(t)).toEqual([]);
+  });
+
+  it('lists a dead settle — op terminal, lease silent, cursor still resultless', async () => {
+    const t = convexTest(schema, modules);
+    await seedRun(t, { cursor: agentCursor() });
+    await seedOp(t, {
+      status: 'completed',
+      heartbeatAt: 1_000,
+      finalizedAt: 2_000,
+      finishedAt: 2_000,
+    });
+    const stalled = await listStalled(t);
+    expect(stalled).toHaveLength(1);
+    expect(stalled[0]).toMatchObject({ execId: 'exec-1', sessionId: SID });
+  });
+
+  it('spares the ask-park — awaiting_human is a wait, not a dead settle', async () => {
+    const t = convexTest(schema, modules);
+    await seedRun(t, { cursor: agentCursor() });
+    await seedOp(t, {
+      status: 'completed',
+      heartbeatAt: 1_000,
+      finalizedAt: 2_000,
+      finishedAt: 2_000,
+      agentResultStatus: 'awaiting_human',
+    });
     expect(await listStalled(t)).toEqual([]);
   });
 

--- a/services/platform/convex/node_only/sandbox/session_exec.test.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.test.ts
@@ -3,6 +3,7 @@
 // harvest's per-file skip semantics. The session wire is mocked at the
 // session_client boundary, the same seam the crawler render tests use.
 
+import { getFunctionName } from 'convex/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ActionCtx } from '../../_generated/server';
@@ -294,6 +295,38 @@ describe('harvestSessionOutput — per-file harvest skips', () => {
     // Nothing to reap: the rejected store never produced a blob, and b.txt's
     // blob stays.
     expect(storageDelete).not.toHaveBeenCalled();
+  });
+
+  it('renews the turn lease once per file when the settle names its exec', async () => {
+    sessionListFiles.mockResolvedValue([
+      outputEntry('a.txt'),
+      outputEntry('b.txt'),
+    ]);
+    sessionReadFile.mockResolvedValue(textBytes('x'));
+    const runMutation = vi.fn().mockResolvedValue(null);
+    const ctx = harvestCtx({ runMutation });
+    await harvestSessionOutput(ctx, { ...harvestArgs, execId: 'exec-9' });
+    const bumps = runMutation.mock.calls.filter(
+      (call) =>
+        getFunctionName(call[0]) ===
+        'sandbox/session_mutations:bumpSessionOpHeartbeat',
+    );
+    expect(bumps).toHaveLength(2);
+    expect(bumps[0]?.[1]).toEqual({ sessionId: 'sid', execId: 'exec-9' });
+  });
+
+  it('leaves the lease alone when no exec is named (the script-host shape)', async () => {
+    sessionListFiles.mockResolvedValue([outputEntry('a.txt')]);
+    sessionReadFile.mockResolvedValue(textBytes('x'));
+    const runMutation = vi.fn().mockResolvedValue(null);
+    const ctx = harvestCtx({ runMutation });
+    await harvestSessionOutput(ctx, harvestArgs);
+    const bumps = runMutation.mock.calls.filter(
+      (call) =>
+        getFunctionName(call[0]) ===
+        'sandbox/session_mutations:bumpSessionOpHeartbeat',
+    );
+    expect(bumps).toHaveLength(0);
   });
 
   it('reports files beyond the per-run cap and unreadable files', async () => {

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -296,12 +296,18 @@ export async function harvestSessionOutput(
      * each turn to its own subdir so one subject's harvest can never pick up
      * another's deliverables. Per-run/turn sessions keep the default. */
     outputDir?: string;
+    /** The turn whose settle this harvest belongs to. When set, the loop
+     * renews the op's liveness lease once per file — the harvest is the one
+     * settle step that can legitimately run for minutes, and without the
+     * bumps the recovery sweep would read a working settle as a dead chain
+     * and re-attach a second one. */
+    execId?: string;
   },
 ): Promise<{
   files: HarvestedOutputFile[];
   harvestSkipped: Array<{ path: string; reason: string }>;
 }> {
-  const { sessionId, organizationId } = args;
+  const { sessionId, organizationId, execId } = args;
   const outputDir = args.outputDir ?? OUTPUT_DIR;
   // Backend routing for harvested outputs: the org's own bucket when
   // configured, else Convex `_storage` (also the unresolvable-slug fallback).
@@ -328,6 +334,22 @@ export async function harvestSessionOutput(
         )} per-file harvest cap — split the output or have the user download it another way`,
       });
       continue;
+    }
+    if (execId !== undefined) {
+      // Lease renewal per file: read + store below are bounded (30s client
+      // timeout) but a many-file harvest as a whole is not. Best-effort — a
+      // missed bump only hastens a takeover verdict, never corrupts one.
+      await ctx
+        .runMutation(
+          internal.sandbox.session_mutations.bumpSessionOpHeartbeat,
+          {
+            sessionId,
+            execId,
+          },
+        )
+        .catch((err) =>
+          console.warn('[session_exec] harvest lease bump failed:', err),
+        );
     }
     const read = await sessionReadFile(sessionId, absPath);
     if (read === null) {

--- a/services/platform/convex/sandbox/agent_deadline.test.ts
+++ b/services/platform/convex/sandbox/agent_deadline.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { agentWorkTurnDeadlineMs } from './agent_deadline';
+import {
+  agentWorkTurnDeadlineMs,
+  sessionOpLastSignOfLifeMs,
+} from './agent_deadline';
 
 describe('agentWorkTurnDeadlineMs', () => {
   afterEach(() => {
@@ -22,5 +25,28 @@ describe('agentWorkTurnDeadlineMs', () => {
     expect(agentWorkTurnDeadlineMs()).toBe(12 * 3_600_000);
     vi.stubEnv('TALE_AUTOMATION_AGENT_DEADLINE_MS', '0');
     expect(agentWorkTurnDeadlineMs()).toBe(12 * 3_600_000);
+  });
+});
+
+describe('sessionOpLastSignOfLifeMs', () => {
+  it('takes the freshest signal across all phases', () => {
+    expect(
+      sessionOpLastSignOfLifeMs({
+        startedAt: 1_000,
+        heartbeatAt: 5_000,
+        finalizedAt: 7_000,
+        finishedAt: 6_000,
+      }),
+    ).toBe(7_000);
+  });
+
+  it('floors at the op’s own birth when no other signal exists', () => {
+    expect(sessionOpLastSignOfLifeMs({ startedAt: 1_000 })).toBe(1_000);
+  });
+
+  it('a lone drain heartbeat governs while the settle has not signed', () => {
+    expect(
+      sessionOpLastSignOfLifeMs({ startedAt: 1_000, heartbeatAt: 4_000 }),
+    ).toBe(4_000);
   });
 });

--- a/services/platform/convex/sandbox/agent_deadline.ts
+++ b/services/platform/convex/sandbox/agent_deadline.ts
@@ -23,3 +23,35 @@ export function agentWorkTurnDeadlineMs(): number {
     ? configured
     : DEFAULT_AGENT_WORK_TURN_DEADLINE_MS;
 }
+
+/**
+ * The moment a session op's chain last proved it was alive, across ALL turn
+ * phases: the drain bumps `heartbeatAt` every attach window, the settle
+ * holds the same lease (the finalize claim bumps it, the harvest bumps it
+ * per file), and the terminal write stamps `finishedAt`. `finalizedAt` is
+ * the settle election's claim stamp — a sign of life the instant it is
+ * written. `startedAt` floors the result so a just-created row is never
+ * younger than its own birth.
+ *
+ * This is the ONE liveness signal recovery judges — deliberately NOT an
+ * execution-environment bound (an action time cap is deployment config and
+ * an implementation accident of today's single-action settle, not a
+ * contract). Every settle step is itself bounded (session-client and
+ * gateway-admin calls carry 15–30s AbortSignal timeouts, mutations are
+ * ms-scale), so a chain silent past the recovery staleness window is dead,
+ * however slow or loaded the host. Read by the V8 recovery-claim mutation
+ * and both lanes' stalled-turn queries.
+ */
+export function sessionOpLastSignOfLifeMs(op: {
+  startedAt: number;
+  heartbeatAt?: number;
+  finalizedAt?: number;
+  finishedAt?: number;
+}): number {
+  return Math.max(
+    op.startedAt,
+    op.heartbeatAt ?? 0,
+    op.finalizedAt ?? 0,
+    op.finishedAt ?? 0,
+  );
+}

--- a/services/platform/convex/sandbox/recovery_resume.test.ts
+++ b/services/platform/convex/sandbox/recovery_resume.test.ts
@@ -1,9 +1,12 @@
 // claimRecoveryResume: the atomic single-claimant gate the restorative recovery
-// watchdog uses before re-attaching an abandoned-but-alive exec. It must reject
-// when the op is finalized, not running, or its heartbeat is no longer stale (a
-// live drainer bumped it between the abandoned-ops query and the claim) — the
-// fix that stops the watchdog from double-mirroring a live action. convexTest
-// (real OCC over the row), mirroring session_lifecycle.test.ts.
+// watchdog uses before re-attaching a dead chain. ONE rule arbitrates every
+// phase: the op's liveness lease (`sessionOpLastSignOfLifeMs` — heartbeat,
+// finalize claim, terminal write, birth) must be silent past `staleBeforeMs`.
+// It must reject while any signal is fresh, and claim each of the three
+// dead-chain shapes: a stale drainer, a dead finalize winner (re-opening its
+// election by clearing `finalizedAt`), and a settled op whose run-side settle
+// died (latch only, status untouched). convexTest (real OCC over the row),
+// mirroring session_lifecycle.test.ts.
 
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
@@ -38,6 +41,7 @@ async function insertOp(
     status: 'running' | 'completed' | 'failed' | 'cancelled';
     heartbeatAt: number;
     finalizedAt: number;
+    finishedAt: number;
     kind: string;
   }>,
 ): Promise<void> {
@@ -54,6 +58,9 @@ async function insertOp(
       }),
       ...(patch.finalizedAt !== undefined && {
         finalizedAt: patch.finalizedAt,
+      }),
+      ...(patch.finishedAt !== undefined && {
+        finishedAt: patch.finishedAt,
       }),
     }),
   );
@@ -94,12 +101,12 @@ describe('claimRecoveryResume', () => {
     expect(won).toBe(false);
   });
 
-  it('rejects an already-finalized op', async () => {
+  it('rejects a freshly-finalized op — its winner may still be settling', async () => {
     const t = convexTest(schema, modules);
     await insertOp(t, {
       status: 'running',
       heartbeatAt: 1_000,
-      finalizedAt: 2_000,
+      finalizedAt: 9_999,
     });
     const won = await t.mutation(
       internal.sandbox.session_mutations.claimRecoveryResume,
@@ -108,9 +115,13 @@ describe('claimRecoveryResume', () => {
     expect(won).toBe(false);
   });
 
-  it('rejects a non-running op', async () => {
+  it('rejects a freshly-settled op — the run-side settle may be mid-harvest', async () => {
     const t = convexTest(schema, modules);
-    await insertOp(t, { status: 'completed', heartbeatAt: 1_000 });
+    await insertOp(t, {
+      status: 'completed',
+      heartbeatAt: 1_000,
+      finishedAt: 9_999,
+    });
     const won = await t.mutation(
       internal.sandbox.session_mutations.claimRecoveryResume,
       { sessionId: SID, execId: EXEC, staleBeforeMs: 5_000 },
@@ -131,6 +142,80 @@ describe('claimRecoveryResume', () => {
     );
     expect(first).toBe(true);
     expect(second).toBe(false); // heartbeat now bumped past staleBeforeMs
+  });
+});
+
+describe('claimRecoveryResume — dead finalize winner (running + stale finalizedAt)', () => {
+  it('takes the turn over and re-opens the election', async () => {
+    const t = convexTest(schema, modules);
+    await insertOp(t, {
+      status: 'running',
+      heartbeatAt: 1_000,
+      finalizedAt: 2_000,
+    });
+    const won = await t.mutation(
+      internal.sandbox.session_mutations.claimRecoveryResume,
+      { sessionId: SID, execId: EXEC, staleBeforeMs: 5_000 },
+    );
+    expect(won).toBe(true);
+    const row = await opRow(t);
+    expect(row?.status).toBe('running');
+    expect(row?.finalizedAt).toBeUndefined(); // election re-opened
+    expect(row?.resumedBy).toBe('watchdog');
+    expect(row?.heartbeatAt ?? 0).toBeGreaterThan(1_000);
+    // The resumed chain's own releaseTurnKey can now win the settle for real.
+    const reElected = await t.mutation(
+      internal.sandbox.session_mutations.claimSessionOpFinalize,
+      { sessionId: SID, execId: EXEC },
+    );
+    expect(reElected).toBe(true);
+    expect((await opRow(t))?.finalizedAt).toBeDefined();
+  });
+
+  it('a second sweep straight after the takeover is refused (heartbeat latch)', async () => {
+    const t = convexTest(schema, modules);
+    await insertOp(t, {
+      status: 'running',
+      heartbeatAt: 1_000,
+      finalizedAt: 2_000,
+    });
+    const first = await t.mutation(
+      internal.sandbox.session_mutations.claimRecoveryResume,
+      { sessionId: SID, execId: EXEC, staleBeforeMs: 5_000 },
+    );
+    const second = await t.mutation(
+      internal.sandbox.session_mutations.claimRecoveryResume,
+      { sessionId: SID, execId: EXEC, staleBeforeMs: 5_000 },
+    );
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+});
+
+describe('claimRecoveryResume — settled op whose run-side settle died', () => {
+  it('latches the row without resurrecting the terminal status', async () => {
+    const t = convexTest(schema, modules);
+    await insertOp(t, {
+      status: 'completed',
+      heartbeatAt: 1_000,
+      finalizedAt: 2_000,
+      finishedAt: 2_000,
+    });
+    const won = await t.mutation(
+      internal.sandbox.session_mutations.claimRecoveryResume,
+      { sessionId: SID, execId: EXEC, staleBeforeMs: 5_000 },
+    );
+    expect(won).toBe(true);
+    const row = await opRow(t);
+    expect(row?.status).toBe('completed'); // untouched — the op itself is done
+    expect(row?.finalizedAt).toBeDefined(); // its election stays closed
+    expect(row?.resumedBy).toBe('watchdog');
+    // The latch: an immediate second sweep is refused via the fresh heartbeat.
+    const second = await t.mutation(
+      internal.sandbox.session_mutations.claimRecoveryResume,
+      { sessionId: SID, execId: EXEC, staleBeforeMs: 5_000 },
+    );
+    expect(second).toBe(false);
   });
 });
 

--- a/services/platform/convex/sandbox/session_mutations.ts
+++ b/services/platform/convex/sandbox/session_mutations.ts
@@ -23,6 +23,7 @@ import {
   reserveTicketArg,
   upsertWaitingTicket,
 } from './admission';
+import { sessionOpLastSignOfLifeMs } from './agent_deadline';
 import {
   readSandboxQuotaPolicy,
   requireSessionBudgetForOwnerType,
@@ -1111,7 +1112,12 @@ export const upsertSessionOp = internalMutation({
  * the continuation, the recovery watchdog, and cancel all race to finalize a
  * turn; only the winner runs the VK revoke + usage ledger + message finalize.
  * Serializable OCC makes the read-then-set race-free (same property as
- * reserveSessionSlotAndInsert).
+ * reserveSessionSlotAndInsert). Exactly-once PER ELECTION: a winner that dies
+ * mid-settle leaves a stale claim, and `claimRecoveryResume` re-opens the
+ * election (clears `finalizedAt`) once the op's lease goes silent. The win
+ * bumps `heartbeatAt` — the settle phase holds the same liveness lease the
+ * drain phase does, so recovery never mistakes a working winner for a dead
+ * one.
  */
 export const claimSessionOpFinalize = internalMutation({
   args: { sessionId: v.string(), execId: v.string() },
@@ -1125,21 +1131,68 @@ export const claimSessionOpFinalize = internalMutation({
       .first();
     if (!row) return false; // op row gone → nothing to finalize
     if (row.finalizedAt !== undefined) return false; // already finalized
-    await ctx.db.patch(row._id, { finalizedAt: Date.now() });
+    await ctx.db.patch(row._id, {
+      finalizedAt: Date.now(),
+      heartbeatAt: Date.now(),
+    });
     return true;
   },
 });
 
 /**
- * Atomic single-claimant gate for a watchdog-driven RESUME (re-attach of an
- * abandoned-but-alive exec). Succeeds only if the op is still `running`, not
- * finalized, and its heartbeat is STILL stale (`heartbeatAt < staleBeforeMs`) —
- * re-checked here so a live action that bumped its heartbeat between the
+ * Renew a turn's liveness lease from inside a long settle step — the
+ * per-file harvest bump. Every other settle step is sub-minute (bounded
+ * session-client/gateway calls, ms-scale mutations) and rides on the lease
+ * the finalize claim or the terminal write stamped; the harvest is the one
+ * loop that can legitimately run long, so it proves life once per file.
+ * Best-effort by contract: a missed bump can only delay recovery's takeover
+ * verdict, never corrupt it.
+ */
+export const bumpSessionOpHeartbeat = internalMutation({
+  args: { sessionId: v.string(), execId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query('sandboxSessionOps')
+      .withIndex('by_sessionId_and_execId', (q) =>
+        q.eq('sessionId', args.sessionId).eq('execId', args.execId),
+      )
+      .first();
+    if (row === null) return null;
+    await ctx.db.patch(row._id, { heartbeatAt: Date.now() });
+    return null;
+  },
+});
+
+/**
+ * Atomic single-claimant gate for a watchdog-driven RESUME. Every liveness
+ * signal is re-checked here so a live chain that signed the row between the
  * abandoned-ops query and this claim is seen and the resume is rejected (the
  * fix for the watchdog double-mirroring a live drainer). On success it bumps
  * `heartbeatAt` (so a concurrent sweep + the resuming continuation's startup
  * window don't re-grab it) and stamps `resumedBy`. Serializable OCC makes the
  * read-then-set race-free, exactly like claimSessionOpFinalize.
+ *
+ * A turn's chain can die in THREE phases, and each leaves a distinct row
+ * shape this claim must arbitrate — all judged by ONE rule, the liveness
+ * lease going silent (`sessionOpLastSignOfLifeMs` older than
+ * `staleBeforeMs`). The lease is held in every phase: the drain bumps per
+ * attach window, the finalize claim bumps at the win, the harvest bumps per
+ * file, the terminal write stamps `finishedAt` — and every settle step in
+ * between is itself bounded (15–30s call timeouts, ms mutations), so a
+ * silent lease means a dead chain, never a slow one.
+ * - drain died: `running`, no `finalizedAt` → claim and re-attach.
+ * - settle died BEFORE the terminal op write: `running` + `finalizedAt`
+ *   set. RE-OPEN the election by clearing `finalizedAt`; the resumed
+ *   chain's own `releaseTurnKey` wins it and writes terminal state for
+ *   real. (Observed live 2026-08-05: a dev-stack shutdown in that window
+ *   left a task run at `running` forever, every sweep refusing it as
+ *   "already terminal".)
+ * - settle died AFTER the terminal op write (mid-harvest / mid-report):
+ *   op terminal, run row still live. The op needs nothing — the claim only
+ *   latches the row (heartbeat bump) so exactly one sweep re-attaches the
+ *   chain, whose settle fallback finishes the run-side work; the
+ *   never-resurrect guard in `upsertSessionOp` keeps the status terminal.
  */
 export const claimRecoveryResume = internalMutation({
   args: {
@@ -1185,13 +1238,21 @@ export const claimRecoveryResume = internalMutation({
       });
       return true;
     }
-    if (row.finalizedAt !== undefined) return false; // already terminal
-    if (row.status !== 'running') return false; // not a live turn
-    // A live drainer bumped the heartbeat after the query → NOT abandoned.
-    if ((row.heartbeatAt ?? 0) >= args.staleBeforeMs) return false;
+    // A live chain signed the lease after the query → NOT abandoned.
+    if (sessionOpLastSignOfLifeMs(row) >= args.staleBeforeMs) return false;
+    if (row.status !== 'running') {
+      // Terminal op, dead run-side settle: latch only — the op itself is done.
+      await ctx.db.patch(row._id, {
+        heartbeatAt: Date.now(),
+        resumedBy: 'watchdog',
+      });
+      return true;
+    }
     await ctx.db.patch(row._id, {
       heartbeatAt: Date.now(),
       resumedBy: 'watchdog',
+      // Dead finalize winner: re-open the election it claimed but never won.
+      ...(row.finalizedAt !== undefined && { finalizedAt: undefined }),
     });
     return true;
   },

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -862,6 +862,7 @@ async function settleTaskAgentTurn(
       organizationId: args.organizationId,
       sessionId: args.sessionId,
       outputDir: taskOutputDir(args.taskId),
+      execId: args.execId,
     });
     const files = harvested.files.map((file) => ({
       fileId: file.storageId,

--- a/services/platform/convex/tasks/agent_runs.ts
+++ b/services/platform/convex/tasks/agent_runs.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { internal } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
 import { internalMutation, internalQuery } from '../_generated/server';
+import { sessionOpLastSignOfLifeMs } from '../sandbox/agent_deadline';
 import { readTaskDiscussionMessages } from './internal_queries';
 
 /**
@@ -236,9 +237,15 @@ export const listStalledTaskAgentTurns = internalQuery({
         // op row and kill it with a wrong reason.
         if (run.waitingForCapacityAt !== undefined) continue;
         if (op !== null) {
-          if (op.status !== 'running') continue; // settled — the host's turn
-          const beat = op.heartbeatAt ?? op.startedAt;
-          if (beat >= args.staleBeforeMs) continue; // alive drainer
+          // ONE liveness rule for every phase: the op's lease must be silent
+          // past the staleness window. The drain bumps it per attach window,
+          // the finalize claim and the per-file harvest bumps carry it
+          // through the settle, the terminal write stamps `finishedAt`. An
+          // op that settled while the RUN never did is a mid-settle death —
+          // it goes stale here like any other dead chain, and the
+          // re-attached chain's settle fallback (`!release.won` +
+          // first-wins marks) finishes the run side.
+          if (sessionOpLastSignOfLifeMs(op) >= args.staleBeforeMs) continue;
         } else if (run.startedAt >= args.staleBeforeMs) {
           // No op row yet, but the start was scheduled moments ago — give it
           // the same staleness window before calling it dead.

--- a/services/platform/convex/tasks/recover_agent_turns.ts
+++ b/services/platform/convex/tasks/recover_agent_turns.ts
@@ -16,7 +16,13 @@
  * (`releaseTurnKey`), and `claimRecoveryResume` closes the query→schedule
  * race. A run whose op row was never written (a start that died first) is
  * claimed by creating the row — the run row is the durable proof the turn
- * exists.
+ * exists. A chain that died SETTLING is covered too: the settle holds the
+ * same liveness lease the drain does (claim-time and per-file harvest
+ * bumps), so a dead settle goes stale like any dead drainer —
+ * `claimRecoveryResume` re-opens a dead winner's finalize election, and the
+ * stalled query lists a settled op whose run never settled; both halves of
+ * a mid-settle death heal through the same re-attach (see the claim's doc
+ * for the three phase shapes).
  */
 
 import { v } from 'convex/values';
@@ -77,7 +83,16 @@ export const recoverStalledTaskAgentTurns = internalAction({
           },
         },
       );
-      if (!claimed) continue;
+      if (!claimed) {
+        // Refused = something signed the op's lease after the stalled query
+        // read it (a live chain's bump, a concurrent sweep, a settle still
+        // proving life). Diagnosable, not silent: the original dead-winner
+        // wedge hid behind a logless skip for hours.
+        console.warn(
+          `[task-agent-watchdog] resume claim refused for ${turn.execId} of run ${String(turn.runId)} — a live chain or a fresh settle owns it`,
+        );
+        continue;
+      }
       await ctx.scheduler.runAfter(
         0,
         internal.tasks.agent_run_host.driveTaskAgentTurn,

--- a/services/platform/convex/tasks/task_agent_runs.test.ts
+++ b/services/platform/convex/tasks/task_agent_runs.test.ts
@@ -281,7 +281,7 @@ describe('listStalledTaskAgentTurns', () => {
     expect(await stalled(t)).toHaveLength(0);
   });
 
-  it('skips settled ops and terminal runs — those are the host’s to finish', async () => {
+  it('spares a fresh settle, lists a dead one, skips terminal runs', async () => {
     const t = convexTest(schema, modules);
     const { run } = await seedRun(t);
     await t.run(async (ctx) => {
@@ -294,9 +294,26 @@ describe('listStalledTaskAgentTurns', () => {
         status: 'completed',
         startedAt: STALE_BEFORE - 1,
         heartbeatAt: STALE_BEFORE - 1,
+        finalizedAt: Date.now(),
+        finishedAt: Date.now(),
       });
     });
+    // Settle lease fresh: its winner is still doing the run-side work
+    // (harvest, report, markSettled) — the host's to finish, not ours.
     expect(await stalled(t)).toHaveLength(0);
+
+    // Lease silent past the staleness window with the run never settled:
+    // the settle died mid-flight — list it for re-attach.
+    await t.run(async (ctx) => {
+      const op = await ctx.db.query('sandboxSessionOps').first();
+      if (op) {
+        await ctx.db.patch(op._id, {
+          finalizedAt: STALE_BEFORE - 1,
+          finishedAt: STALE_BEFORE - 1,
+        });
+      }
+    });
+    expect(await stalled(t)).toHaveLength(1);
 
     await t.run(async (ctx) => {
       await ctx.db.patch(run._id, { status: 'settled', startedAt: 0 });


### PR DESCRIPTION
## What

- A turn's chain could die **mid-settle** and leave a permanent zombie in both work lanes — observed live: a task run stuck at "running" for 20 hours, 7+ hours past its 12h deadline, after a dev-stack shutdown landed between the finalize claim and the terminal write. Two shapes, both previously unrecoverable:
  - **op `running` + `finalizedAt` set** (death between `claimSessionOpFinalize` and `releaseTurnKey`'s terminal upsert — two outbound HTTP calls sit in that window): `claimRecoveryResume` refused it as "already terminal", so the watchdog listed it every 2 minutes and dropped it silently, forever.
  - **op terminal + run/cursor never settled** (death during harvest / report / run-row marks): both lanes' stalled queries skipped any settled op, so nothing ever re-attached.
- The settle now holds the **same liveness lease the drain does**: the finalize claim bumps the op heartbeat at the win, the harvest renews it once per file (`harvestSessionOutput` gains an optional `execId`; both agent hosts pass it — the script host has no op row and is unchanged), and the terminal write already stamps `finishedAt`.
- Recovery needs **one rule** for every phase: `sessionOpLastSignOfLifeMs(op)` (max of startedAt / heartbeatAt / finalizedAt / finishedAt) silent past the existing 4-min staleness knob. On takeover it re-opens a dead winner's election (clears `finalizedAt`, so the resumed chain's `releaseTurnKey` wins it for real) or merely latches a settled op so the existing first-wins fallbacks finish the run side; `upsertSessionOp`'s never-resurrect guard keeps terminal ops terminal throughout.
- The automations **ask-park is spared** (`agentResultStatus: 'awaiting_human'` is a legitimate 7-day silence, not a dead settle), and both watchdogs now **log refused claims** — the original wedge hid behind a logless skip.

## Why a lease and not a timeout anchor

The drive chain is deliberately decoupled from Convex action limits (self-chaining short windows), so recovery must not re-couple correctness to the deployment's action time cap or to the settle happening to be single-action today. It also must not lean on "typical settle duration" — a host also serving a local model can stretch a live settle arbitrarily. Every settle step is individually bounded (session-client calls carry 30s AbortSignal timeouts, gateway-admin calls 15s, mutations are ms-scale), so with per-step lease renewal a chain silent past the staleness window is dead, not slow. Worst live-winner silence is one file cycle (~35s) against a 4-minute window; a wedged run now heals in ~4–6 minutes instead of never.

## Verified

- New regression coverage pins each dead-chain shape: dead-winner takeover + election re-open (and that a re-election then wins), the terminal-op latch that never resurrects status, fresh-lease refusals, the ask-park spare, both stalled queries' dead-vs-fresh settle behaviour, and the per-file harvest bump (asserted via `getFunctionName` — generated api refs are proxies).
- Full platform suite green (608 files / 74,367 tests), `tsc` clean, `oxlint --type-aware` clean, opengrep clean.
- The real wedged run on the dev deployment healed **autonomously by the 2-minute cron** within one sweep of the code push — run flipped to `failed` with the truthful deadline reason, op terminal, gateway key revoked, no manual data surgery.