### PR TITLE
feat(platform): steer live agent runs and paste task attachments

### DIFF
--- a/services/platform/app/features/chat/components/composer.tsx
+++ b/services/platform/app/features/chat/components/composer.tsx
@@ -38,6 +38,7 @@ import { EnterKeyIcon } from '@/app/components/icons/enter-key-icon';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import type { FileTranscriptionInfo } from '@/app/features/chat/hooks/use-file-transcription-status';
+import { extractPastedImageFiles } from '@/app/features/shared/files/clipboard-images';
 import type { FileAttachment } from '@/app/features/shared/files/types';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { toast } from '@/app/hooks/use-toast';
@@ -271,20 +272,10 @@ export const Composer = memo(
       // many clipboards ship alongside — that fallback would double the
       // content as prose the user never wrote.
       if (onAttachFiles !== undefined && !disabled) {
-        const imageFiles: File[] = [];
-        for (const item of event.clipboardData.items) {
-          if (!item.type.startsWith('image/')) continue;
-          const file = item.getAsFile();
-          if (file === null) continue;
-          const extension = item.type.split('/')[1] ?? 'png';
-          imageFiles.push(
-            new File(
-              [file],
-              `pasted-image-${pasteCounterRef.current++}.${extension}`,
-              { type: file.type },
-            ),
-          );
-        }
+        const imageFiles = extractPastedImageFiles(
+          event.clipboardData,
+          () => pasteCounterRef.current++,
+        );
         if (imageFiles.length > 0) {
           event.preventDefault();
           onAttachFiles(imageFiles);

--- a/services/platform/app/features/shared/files/clipboard-images.test.ts
+++ b/services/platform/app/features/shared/files/clipboard-images.test.ts
@@ -1,0 +1,58 @@
+// The one clipboard-image extraction both paste surfaces (chat composer,
+// task modal) attach with: image items become File objects named
+// `pasted-image-N.<ext>` off the caller's counter; everything else in the
+// clipboard is ignored so a text-only paste stays a native paste.
+
+import { describe, expect, it } from 'vitest';
+
+import { extractPastedImageFiles } from './clipboard-images';
+
+function transferWith(
+  items: Array<{ type: string; file: File | null }>,
+): DataTransfer {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal DataTransfer stand-in for the fields the extractor reads
+  return {
+    items: items.map((item) => ({
+      type: item.type,
+      getAsFile: () => item.file,
+    })),
+  } as unknown as DataTransfer;
+}
+
+describe('extractPastedImageFiles', () => {
+  it('names image items off the caller counter, keeping their type', () => {
+    let counter = 3;
+    const files = extractPastedImageFiles(
+      transferWith([
+        {
+          type: 'image/png',
+          file: new File(['a'], 'x', { type: 'image/png' }),
+        },
+        {
+          type: 'image/jpeg',
+          file: new File(['b'], 'y', { type: 'image/jpeg' }),
+        },
+      ]),
+      () => counter++,
+    );
+    expect(files.map((file) => file.name)).toEqual([
+      'pasted-image-3.png',
+      'pasted-image-4.jpeg',
+    ]);
+    expect(files.map((file) => file.type)).toEqual(['image/png', 'image/jpeg']);
+  });
+
+  it('ignores non-image items and null files — a text paste extracts nothing', () => {
+    let counter = 1;
+    const files = extractPastedImageFiles(
+      transferWith([
+        { type: 'text/plain', file: null },
+        { type: 'text/html', file: null },
+        { type: 'image/png', file: null },
+      ]),
+      () => counter++,
+    );
+    expect(files).toEqual([]);
+    expect(counter).toBe(1); // the counter never burns on a miss
+  });
+});

--- a/services/platform/app/features/shared/files/clipboard-images.ts
+++ b/services/platform/app/features/shared/files/clipboard-images.ts
@@ -1,0 +1,27 @@
+/**
+ * Image files carried by a paste, renamed `pasted-image-N.<ext>` — the ONE
+ * clipboard extraction the chat composer and the task modal both attach
+ * with. Clipboards often ship a text/alt fallback beside the image bytes; a
+ * caller that gets a non-empty result prevents the default paste so that
+ * fallback never lands as prose the user never wrote. `nextIndex` is the
+ * caller's own counter (a ref), so names stay unique across pastes within
+ * one surface without this module holding state.
+ */
+export function extractPastedImageFiles(
+  data: DataTransfer,
+  nextIndex: () => number,
+): File[] {
+  const files: File[] = [];
+  for (const item of data.items) {
+    if (!item.type.startsWith('image/')) continue;
+    const file = item.getAsFile();
+    if (file === null) continue;
+    const extension = item.type.split('/')[1] ?? 'png';
+    files.push(
+      new File([file], `pasted-image-${nextIndex()}.${extension}`, {
+        type: file.type,
+      }),
+    );
+  }
+  return files;
+}

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -20,7 +20,13 @@ import {
   Settings2,
   Workflow,
 } from 'lucide-react';
-import { useEffect, useState, type ReactNode } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type ReactNode,
+} from 'react';
 
 import { DatePicker } from '@/app/components/ui/forms/date-picker';
 import { Input } from '@/app/components/ui/forms/input';
@@ -29,6 +35,7 @@ import { AutomationSettingsDialog } from '@/app/features/automations/components/
 import { AutomationSettingsForm } from '@/app/features/automations/components/automation-settings-form';
 import { useAutomationSettingsValues } from '@/app/features/automations/hooks/use-settings-values';
 import { useProject } from '@/app/features/projects/hooks/queries';
+import { extractPastedImageFiles } from '@/app/features/shared/files/clipboard-images';
 import {
   type FileAttachment,
   useConvexFileUpload,
@@ -643,6 +650,7 @@ function CreateTaskBody({
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [status, setStatus] = useState<TaskStatus>(defaultStatus);
+  const pasteCounterRef = useRef(1);
   const [priority, setPriority] = useState<TaskPriority | null>(null);
   const [assignee, setAssignee] = useState<{
     type: TaskActorType;
@@ -681,6 +689,21 @@ function CreateTaskBody({
     }
   };
 
+  // A paste ANYWHERE in the dialog carrying image bytes (a screenshot, a
+  // copied image) attaches it — the same images-over-text-fallback rule the
+  // chat composer applies, so a copied screenshot never lands as alt-text
+  // prose in the description field instead.
+  const onPasteImages = (event: ClipboardEvent<HTMLDivElement>) => {
+    if (submitting) return;
+    const files = extractPastedImageFiles(
+      event.clipboardData,
+      () => pasteCounterRef.current++,
+    );
+    if (files.length === 0) return;
+    event.preventDefault();
+    void uploadFiles(files);
+  };
+
   const chips = (
     <TemplateChips
       templates={templates}
@@ -706,118 +729,121 @@ function CreateTaskBody({
   }
 
   return (
-    <ModalLayout
-      header={
-        <ResponsiveDialogTitle className="text-lg leading-snug font-semibold">
-          {t('actions.create')}
-        </ResponsiveDialogTitle>
-      }
-      main={
-        <>
-          {chips}
-          <Input
-            id="task-title"
-            label={t('fields.title')}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            disabled={submitting}
-            autoFocus
-            required
-            // Hard-cap at the server limit (validateTitle rejects > TASK_TITLE_MAX)
-            // so an over-long title can't reach the mutation and strand the dialog
-            // behind a generic error toast.
-            maxLength={TASK_TITLE_MAX}
-            onKeyDown={(e) => {
-              // Cmd/Ctrl+Enter submits from the title (fast path).
-              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                e.preventDefault();
-                void submit();
-              }
-            }}
-          />
-          <MentionTextarea
-            id="task-description"
-            organizationId={organizationId}
-            projectId={projectId}
-            label={t('fields.description')}
-            rows={8}
-            value={description}
-            onValueChange={setDescription}
-            disabled={submitting}
-            placement="below"
-          />
-          <MentionTriggerChips
-            organizationId={organizationId}
-            target={{ projectId }}
-            draft={description}
-          />
-          <TaskAttachments
-            attachments={attachments}
-            uploadingFiles={uploadingFiles}
-            canEdit
-            disabled={submitting}
-            organizationId={organizationId}
-            onUpload={(files) => void uploadFiles(files)}
-            onRemove={removeAttachment}
-          />
-        </>
-      }
-      panel={
-        <>
-          <PropertyField label={t('fields.status')}>
-            <StatusPicker status={status} onChange={setStatus} align="end" />
-          </PropertyField>
-          <PropertyField label={t('fields.priority')}>
-            <PriorityPicker
-              priority={priority}
-              onChange={setPriority}
-              align="end"
+    // display:contents — a paste-event catcher, never a layout box.
+    <div className="contents" onPaste={onPasteImages}>
+      <ModalLayout
+        header={
+          <ResponsiveDialogTitle className="text-lg leading-snug font-semibold">
+            {t('actions.create')}
+          </ResponsiveDialogTitle>
+        }
+        main={
+          <>
+            {chips}
+            <Input
+              id="task-title"
+              label={t('fields.title')}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={submitting}
+              autoFocus
+              required
+              // Hard-cap at the server limit (validateTitle rejects > TASK_TITLE_MAX)
+              // so an over-long title can't reach the mutation and strand the dialog
+              // behind a generic error toast.
+              maxLength={TASK_TITLE_MAX}
+              onKeyDown={(e) => {
+                // Cmd/Ctrl+Enter submits from the title (fast path).
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                  e.preventDefault();
+                  void submit();
+                }
+              }}
             />
-          </PropertyField>
-          <PropertyField label={t('fields.assignee')}>
-            <AssigneePicker
+            <MentionTextarea
+              id="task-description"
               organizationId={organizationId}
               projectId={projectId}
-              assigneeType={assignee?.type}
-              assigneeId={assignee?.id}
-              taskTitle={title}
-              taskDescription={description}
-              taskLabels={labels}
-              align="end"
-              onAssign={(type, id) => setAssignee({ type, id })}
-              onUnassign={() => setAssignee(null)}
+              label={t('fields.description')}
+              rows={8}
+              value={description}
+              onValueChange={setDescription}
+              disabled={submitting}
+              placement="below"
             />
-          </PropertyField>
-          <PropertyField label={t('dueDate.label')}>
-            <DatePicker
-              value={dueDate}
-              onChange={(ms) => setDueDate(ms ?? undefined)}
+            <MentionTriggerChips
+              organizationId={organizationId}
+              target={{ projectId }}
+              draft={description}
             />
-          </PropertyField>
-          <PanelDivider />
-          <PropertyField label={t('fields.labels')} stacked>
-            <LabelEditor
-              labels={labels}
-              onChange={setLabels}
-              projectId={projectId}
+            <TaskAttachments
+              attachments={attachments}
+              uploadingFiles={uploadingFiles}
+              canEdit
+              disabled={submitting}
+              organizationId={organizationId}
+              onUpload={(files) => void uploadFiles(files)}
+              onRemove={removeAttachment}
             />
-          </PropertyField>
-        </>
-      }
-      footer={
-        <Row gap={2} justify="end">
-          <Button variant="secondary" onClick={onClose} disabled={submitting}>
-            {tCommon('actions.cancel')}
-          </Button>
-          <Button
-            onClick={() => void submit()}
-            disabled={submitting || title.trim().length === 0}
-          >
-            {t('actions.create')}
-          </Button>
-        </Row>
-      }
-    />
+          </>
+        }
+        panel={
+          <>
+            <PropertyField label={t('fields.status')}>
+              <StatusPicker status={status} onChange={setStatus} align="end" />
+            </PropertyField>
+            <PropertyField label={t('fields.priority')}>
+              <PriorityPicker
+                priority={priority}
+                onChange={setPriority}
+                align="end"
+              />
+            </PropertyField>
+            <PropertyField label={t('fields.assignee')}>
+              <AssigneePicker
+                organizationId={organizationId}
+                projectId={projectId}
+                assigneeType={assignee?.type}
+                assigneeId={assignee?.id}
+                taskTitle={title}
+                taskDescription={description}
+                taskLabels={labels}
+                align="end"
+                onAssign={(type, id) => setAssignee({ type, id })}
+                onUnassign={() => setAssignee(null)}
+              />
+            </PropertyField>
+            <PropertyField label={t('dueDate.label')}>
+              <DatePicker
+                value={dueDate}
+                onChange={(ms) => setDueDate(ms ?? undefined)}
+              />
+            </PropertyField>
+            <PanelDivider />
+            <PropertyField label={t('fields.labels')} stacked>
+              <LabelEditor
+                labels={labels}
+                onChange={setLabels}
+                projectId={projectId}
+              />
+            </PropertyField>
+          </>
+        }
+        footer={
+          <Row gap={2} justify="end">
+            <Button variant="secondary" onClick={onClose} disabled={submitting}>
+              {tCommon('actions.cancel')}
+            </Button>
+            <Button
+              onClick={() => void submit()}
+              disabled={submitting || title.trim().length === 0}
+            >
+              {t('actions.create')}
+            </Button>
+          </Row>
+        }
+      />
+    </div>
   );
 }
 
@@ -876,6 +902,7 @@ function EditTaskBody({
 
   const [subtaskTitle, setSubtaskTitle] = useState('');
   const [archiveOpen, setArchiveOpen] = useState(false);
+  const pasteCounterRef = useRef(1);
 
   const onMutationError = (error: unknown) => {
     if (
@@ -895,6 +922,17 @@ function EditTaskBody({
 
   const isArchived = task.archivedAt != null;
   const canMutate = canEdit && !isArchived;
+  // The bound project folder of an automation-owned task, when its contract
+  // takes folder input — the ONE condition that swaps the Attachments zone
+  // for the folder zones, and that keeps paste out of folder-bound tasks
+  // (their input door is the folder, not attachments).
+  const boundFolderId =
+    ownedBy !== null &&
+    ownedBy.contract.input?.kind === 'folder' &&
+    typeof task.externalId === 'string' &&
+    task.externalId !== ''
+      ? toId<'folders'>(task.externalId)
+      : null;
 
   const assigneeName =
     task.assigneeType && task.assigneeId
@@ -944,6 +982,19 @@ function EditTaskBody({
         ),
       })
       .catch(onMutationError);
+  };
+  // A paste anywhere in the dialog carrying image bytes attaches it — same
+  // rule as the chat composer (images win over the text/alt fallback). Kept
+  // off folder-bound automation tasks, whose input door is the folder zone.
+  const onPasteImages = (event: ClipboardEvent<HTMLDivElement>) => {
+    if (!canMutate || boundFolderId !== null) return;
+    const files = extractPastedImageFiles(
+      event.clipboardData,
+      () => pasteCounterRef.current++,
+    );
+    if (files.length === 0) return;
+    event.preventDefault();
+    void onUploadAttachments(files);
   };
 
   const labelsField = (
@@ -1017,393 +1068,395 @@ function EditTaskBody({
 
   return (
     <>
-      <ModalLayout
-        header={
-          <Stack gap={2}>
-            {identifier && (
-              <Text
-                as="span"
-                variant="muted"
-                className="font-mono text-xs tracking-wide"
-              >
-                {identifier}
-              </Text>
-            )}
-            {isArchived && <TaskArchivedBadge />}
-            <ResponsiveDialogTitle className="sr-only">
-              {task.title}
-            </ResponsiveDialogTitle>
-            {canMutate ? (
-              <EditableTitle
-                key={task._id}
-                value={task.title}
-                ariaLabel={t('fields.title')}
-                onSave={(title) =>
-                  void updateTask
-                    .mutateAsync({ taskId: task._id, title })
-                    .catch(onMutationError)
-                }
-              />
-            ) : (
-              <h2 className="text-foreground text-lg leading-snug font-semibold">
+      {/* display:contents — a paste-event catcher, never a layout box. */}
+      <div className="contents" onPaste={onPasteImages}>
+        <ModalLayout
+          header={
+            <Stack gap={2}>
+              {identifier && (
+                <Text
+                  as="span"
+                  variant="muted"
+                  className="font-mono text-xs tracking-wide"
+                >
+                  {identifier}
+                </Text>
+              )}
+              {isArchived && <TaskArchivedBadge />}
+              <ResponsiveDialogTitle className="sr-only">
                 {task.title}
-              </h2>
-            )}
-          </Stack>
-        }
-        main={
-          <>
-            <TaskRunFailureBanner
-              taskId={task._id}
-              organizationId={task.organizationId}
-              projectId={task.projectId}
-            />
-            <TaskReviewCard taskId={task._id} />
+              </ResponsiveDialogTitle>
+              {canMutate ? (
+                <EditableTitle
+                  key={task._id}
+                  value={task.title}
+                  ariaLabel={t('fields.title')}
+                  onSave={(title) =>
+                    void updateTask
+                      .mutateAsync({ taskId: task._id, title })
+                      .catch(onMutationError)
+                  }
+                />
+              ) : (
+                <h2 className="text-foreground text-lg leading-snug font-semibold">
+                  {task.title}
+                </h2>
+              )}
+            </Stack>
+          }
+          main={
+            <>
+              <TaskRunFailureBanner
+                taskId={task._id}
+                organizationId={task.organizationId}
+                projectId={task.projectId}
+              />
+              <TaskReviewCard taskId={task._id} />
 
-            {/* A plain task's description IS its body, so it stays first. An
+              {/* A plain task's description IS its body, so it stays first. An
                 automation-owned task leads with the work instead — who owns it,
                 what it is, what to do next — and keeps the description as the
                 optional note it is, below the files (see the tail of this
                 column). */}
-            {ownedBy === null && descriptionSection}
+              {ownedBy === null && descriptionSection}
 
-            {ownedBy !== null && (
-              <TaskSubjectPanel
-                organizationId={task.organizationId}
-                task={task}
-                ownedBy={ownedBy}
-                canEdit={canMutate}
-              />
-            )}
-
-            {ownedBy !== null &&
-            ownedBy.contract.input?.kind === 'folder' &&
-            typeof task.externalId === 'string' &&
-            task.externalId !== '' ? (
-              <>
-                <TaskInputFilesCard
-                  organizationId={task.organizationId}
-                  projectId={task.projectId}
-                  folderId={toId<'folders'>(task.externalId)}
-                  contract={ownedBy.contract}
-                  automationName={ownedBy.displayName}
-                  canEdit={canMutate}
-                />
-                <TaskOutcomeFilesCard
-                  organizationId={task.organizationId}
-                  projectId={task.projectId}
-                  folderId={toId<'folders'>(task.externalId)}
-                  contract={ownedBy.contract}
-                />
-              </>
-            ) : (
-              <TaskAttachments
-                attachments={task.attachments ?? []}
-                uploadingFiles={uploadingFiles}
-                canEdit={canMutate}
-                organizationId={task.organizationId}
-                onUpload={onUploadAttachments}
-                onRemove={onRemoveAttachment}
-              />
-            )}
-
-            {/* Agent-run deliverables (harvested /user/output) — read-only;
-                the settle merges by fileName, so a rerun's same-named file
-                replaces its row instead of stacking a copy. */}
-            {(task.outputs?.length ?? 0) > 0 && (
-              <TaskAttachments
-                attachments={task.outputs ?? []}
-                uploadingFiles={[]}
-                canEdit={false}
-                organizationId={task.organizationId}
-                label={t('outputs.label')}
-              />
-            )}
-
-            {ownedBy !== null && descriptionSection}
-
-            <Stack as="section" gap={2}>
-              <Row gap={2}>
-                <Text as="h3" variant="label">
-                  {t('detail.subtasks')}
-                </Text>
-                {subtasksTotal > 0 && (
-                  <SubtaskProgress done={subtasksDone} total={subtasksTotal} />
-                )}
-              </Row>
-              {subtasks.length > 0 && (
-                <ul className="border-border divide-border divide-y overflow-hidden rounded-lg border">
-                  {subtasks.map((sub) => {
-                    const subIdentifier = formatTaskIdentifier(
-                      projectKey,
-                      sub.number,
-                    );
-                    const subAssignee =
-                      sub.assigneeType && sub.assigneeId
-                        ? resolveActor(sub.assigneeType, sub.assigneeId)
-                        : null;
-                    return (
-                      <li key={sub._id}>
-                        <button
-                          type="button"
-                          onClick={() => onOpenTask?.(sub._id)}
-                          disabled={!onOpenTask}
-                          className={cn(
-                            'hover:bg-muted focus-visible:ring-ring flex w-full items-center gap-2 px-2.5 py-2 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
-                            !onOpenTask &&
-                              'cursor-default hover:bg-transparent',
-                          )}
-                        >
-                          <TaskStatusBadge status={sub.status} />
-                          {subIdentifier && (
-                            <Text
-                              as="span"
-                              variant="caption"
-                              className="shrink-0 font-mono text-[11px] tracking-wide"
-                            >
-                              {subIdentifier}
-                            </Text>
-                          )}
-                          <span
-                            className={cn(
-                              'flex-1 truncate',
-                              sub.status === 'done' &&
-                                'text-muted-foreground line-through',
-                            )}
-                          >
-                            {sub.title}
-                          </span>
-                          {subAssignee && (
-                            <AssigneeAvatar
-                              assigneeType={subAssignee.type}
-                              assigneeId={subAssignee.id}
-                              name={subAssignee.name}
-                            />
-                          )}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-              {canMutate && (
-                <Row gap={2}>
-                  <Textarea
-                    id="new-subtask"
-                    rows={1}
-                    value={subtaskTitle}
-                    onChange={(e) => setSubtaskTitle(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault();
-                        void addSubtask();
-                      }
-                    }}
-                    placeholder={t('detail.addSubtask')}
-                    className="min-h-0"
-                  />
-                  <Button
-                    icon={Plus}
-                    variant="secondary"
-                    disabled={subtaskTitle.trim().length === 0}
-                    onClick={() => void addSubtask()}
-                  >
-                    {t('actions.add')}
-                  </Button>
-                </Row>
-              )}
-            </Stack>
-
-            <TaskComments
-              taskId={task._id}
-              organizationId={task.organizationId}
-              projectId={task.projectId}
-              canComment={canComment}
-              currentUserId={me?.userId}
-              isAdmin={me?.isAdmin}
-            />
-
-            <TaskTimeline
-              taskId={task._id}
-              organizationId={task.organizationId}
-              projectId={task.projectId}
-            />
-          </>
-        }
-        panel={
-          <>
-            {ownedBy !== null && (
-              <Row gap={2} className="min-w-0">
-                <TaskAutomationBadge
+              {ownedBy !== null && (
+                <TaskSubjectPanel
                   organizationId={task.organizationId}
                   task={task}
-                  showName
-                />
-                {/* The operator-owned configuration of the automation that
-                    drives THIS task — reachable from the task, not only from
-                    the create dialog it was first set up in. */}
-                {ownedBy.settings !== null && settingsFolder !== null && (
-                  <IconButton
-                    icon={Settings2}
-                    size="sm"
-                    variant="ghost"
-                    className="ml-auto shrink-0"
-                    aria-label={tAutomations('settings.dialogTitle', {
-                      name: ownedBy.displayName,
-                    })}
-                    onClick={() => setSettingsOpen(true)}
-                  />
-                )}
-              </Row>
-            )}
-            <PropertyField label={t('fields.status')}>
-              <StatusPicker
-                status={task.status}
-                disabled={!canMutate}
-                align="end"
-                optionDescription={
-                  ownedBy === null
-                    ? undefined
-                    : (option) => {
-                        const kind = plannedTransitionKind(
-                          ownedBy.contract,
-                          task.status,
-                          option,
-                          task.status === 'in_progress',
-                        );
-                        return kind === null
-                          ? undefined
-                          : t(`automation.will.${kind}`, {
-                              name: ownedBy.automationSlug,
-                            });
-                      }
-                }
-                onChange={(status) =>
-                  void (async () => {
-                    const outcome = await choreograph(task, status);
-                    if (outcome !== 'move') return;
-                    await updateStatus
-                      .mutateAsync({ taskId: task._id, status })
-                      .catch(onMutationError);
-                  })()
-                }
-              />
-            </PropertyField>
-            <PropertyField label={t('fields.priority')}>
-              <PriorityPicker
-                priority={task.priority ?? null}
-                disabled={!canMutate}
-                align="end"
-                onChange={(priority) =>
-                  void updateTask
-                    .mutateAsync({ taskId: task._id, priority })
-                    .catch(onMutationError)
-                }
-              />
-            </PropertyField>
-            <PropertyField label={t('fields.assignee')}>
-              <AssigneePicker
-                organizationId={task.organizationId}
-                projectId={task.projectId}
-                taskId={task._id}
-                assigneeType={task.assigneeType}
-                assigneeId={task.assigneeId}
-                taskTitle={task.title}
-                taskDescription={task.description}
-                taskLabels={task.labels}
-                disabled={!canMutate}
-                align="end"
-                afterTrigger={
-                  <span className="text-foreground min-w-0 truncate text-sm">
-                    {assigneeName}
-                  </span>
-                }
-                onAssign={(assigneeType, assigneeId) =>
-                  void assignTask
-                    .mutateAsync({
-                      taskId: task._id,
-                      assigneeType,
-                      assigneeId,
-                    })
-                    .catch(onMutationError)
-                }
-                onUnassign={() =>
-                  void assignTask
-                    .mutateAsync({ taskId: task._id })
-                    .catch(onMutationError)
-                }
-              />
-            </PropertyField>
-            {/* The agent lane's status + verbs live WITH the assignee — the
-                run is Alice's state, not a second card in the task body. */}
-            {task.assigneeType === 'agent' && (
-              <PropertyField label={t('agentRun.label')}>
-                <TaskAgentRunEntry
-                  organizationId={task.organizationId}
-                  taskId={task._id}
+                  ownedBy={ownedBy}
                   canEdit={canMutate}
                 />
-              </PropertyField>
-            )}
-            <PropertyField label={t('dueDate.label')}>
-              <DatePicker
-                value={task.dueDate}
-                disabled={!canMutate}
-                onChange={(dueDate) =>
-                  void updateTask
-                    .mutateAsync({ taskId: task._id, dueDate })
-                    .catch(onMutationError)
-                }
-              />
-            </PropertyField>
+              )}
 
-            <PanelDivider />
-            {/* Labels and dependencies are the BOARD's vocabulary. On an
+              {ownedBy !== null && boundFolderId !== null ? (
+                <>
+                  <TaskInputFilesCard
+                    organizationId={task.organizationId}
+                    projectId={task.projectId}
+                    folderId={boundFolderId}
+                    contract={ownedBy.contract}
+                    automationName={ownedBy.displayName}
+                    canEdit={canMutate}
+                  />
+                  <TaskOutcomeFilesCard
+                    organizationId={task.organizationId}
+                    projectId={task.projectId}
+                    folderId={boundFolderId}
+                    contract={ownedBy.contract}
+                  />
+                </>
+              ) : (
+                <TaskAttachments
+                  attachments={task.attachments ?? []}
+                  uploadingFiles={uploadingFiles}
+                  canEdit={canMutate}
+                  organizationId={task.organizationId}
+                  onUpload={onUploadAttachments}
+                  onRemove={onRemoveAttachment}
+                />
+              )}
+
+              {/* Agent-run deliverables (harvested /user/output) — read-only;
+                the settle merges by fileName, so a rerun's same-named file
+                replaces its row instead of stacking a copy. */}
+              {(task.outputs?.length ?? 0) > 0 && (
+                <TaskAttachments
+                  attachments={task.outputs ?? []}
+                  uploadingFiles={[]}
+                  canEdit={false}
+                  organizationId={task.organizationId}
+                  label={t('outputs.label')}
+                />
+              )}
+
+              {ownedBy !== null && descriptionSection}
+
+              <Stack as="section" gap={2}>
+                <Row gap={2}>
+                  <Text as="h3" variant="label">
+                    {t('detail.subtasks')}
+                  </Text>
+                  {subtasksTotal > 0 && (
+                    <SubtaskProgress
+                      done={subtasksDone}
+                      total={subtasksTotal}
+                    />
+                  )}
+                </Row>
+                {subtasks.length > 0 && (
+                  <ul className="border-border divide-border divide-y overflow-hidden rounded-lg border">
+                    {subtasks.map((sub) => {
+                      const subIdentifier = formatTaskIdentifier(
+                        projectKey,
+                        sub.number,
+                      );
+                      const subAssignee =
+                        sub.assigneeType && sub.assigneeId
+                          ? resolveActor(sub.assigneeType, sub.assigneeId)
+                          : null;
+                      return (
+                        <li key={sub._id}>
+                          <button
+                            type="button"
+                            onClick={() => onOpenTask?.(sub._id)}
+                            disabled={!onOpenTask}
+                            className={cn(
+                              'hover:bg-muted focus-visible:ring-ring flex w-full items-center gap-2 px-2.5 py-2 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+                              !onOpenTask &&
+                                'cursor-default hover:bg-transparent',
+                            )}
+                          >
+                            <TaskStatusBadge status={sub.status} />
+                            {subIdentifier && (
+                              <Text
+                                as="span"
+                                variant="caption"
+                                className="shrink-0 font-mono text-[11px] tracking-wide"
+                              >
+                                {subIdentifier}
+                              </Text>
+                            )}
+                            <span
+                              className={cn(
+                                'flex-1 truncate',
+                                sub.status === 'done' &&
+                                  'text-muted-foreground line-through',
+                              )}
+                            >
+                              {sub.title}
+                            </span>
+                            {subAssignee && (
+                              <AssigneeAvatar
+                                assigneeType={subAssignee.type}
+                                assigneeId={subAssignee.id}
+                                name={subAssignee.name}
+                              />
+                            )}
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+                {canMutate && (
+                  <Row gap={2}>
+                    <Textarea
+                      id="new-subtask"
+                      rows={1}
+                      value={subtaskTitle}
+                      onChange={(e) => setSubtaskTitle(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          void addSubtask();
+                        }
+                      }}
+                      placeholder={t('detail.addSubtask')}
+                      className="min-h-0"
+                    />
+                    <Button
+                      icon={Plus}
+                      variant="secondary"
+                      disabled={subtaskTitle.trim().length === 0}
+                      onClick={() => void addSubtask()}
+                    >
+                      {t('actions.add')}
+                    </Button>
+                  </Row>
+                )}
+              </Stack>
+
+              <TaskComments
+                taskId={task._id}
+                organizationId={task.organizationId}
+                projectId={task.projectId}
+                canComment={canComment}
+                currentUserId={me?.userId}
+                isAdmin={me?.isAdmin}
+              />
+
+              <TaskTimeline
+                taskId={task._id}
+                organizationId={task.organizationId}
+                projectId={task.projectId}
+              />
+            </>
+          }
+          panel={
+            <>
+              {ownedBy !== null && (
+                <Row gap={2} className="min-w-0">
+                  <TaskAutomationBadge
+                    organizationId={task.organizationId}
+                    task={task}
+                    showName
+                  />
+                  {/* The operator-owned configuration of the automation that
+                    drives THIS task — reachable from the task, not only from
+                    the create dialog it was first set up in. */}
+                  {ownedBy.settings !== null && settingsFolder !== null && (
+                    <IconButton
+                      icon={Settings2}
+                      size="sm"
+                      variant="ghost"
+                      className="ml-auto shrink-0"
+                      aria-label={tAutomations('settings.dialogTitle', {
+                        name: ownedBy.displayName,
+                      })}
+                      onClick={() => setSettingsOpen(true)}
+                    />
+                  )}
+                </Row>
+              )}
+              <PropertyField label={t('fields.status')}>
+                <StatusPicker
+                  status={task.status}
+                  disabled={!canMutate}
+                  align="end"
+                  optionDescription={
+                    ownedBy === null
+                      ? undefined
+                      : (option) => {
+                          const kind = plannedTransitionKind(
+                            ownedBy.contract,
+                            task.status,
+                            option,
+                            task.status === 'in_progress',
+                          );
+                          return kind === null
+                            ? undefined
+                            : t(`automation.will.${kind}`, {
+                                name: ownedBy.automationSlug,
+                              });
+                        }
+                  }
+                  onChange={(status) =>
+                    void (async () => {
+                      const outcome = await choreograph(task, status);
+                      if (outcome !== 'move') return;
+                      await updateStatus
+                        .mutateAsync({ taskId: task._id, status })
+                        .catch(onMutationError);
+                    })()
+                  }
+                />
+              </PropertyField>
+              <PropertyField label={t('fields.priority')}>
+                <PriorityPicker
+                  priority={task.priority ?? null}
+                  disabled={!canMutate}
+                  align="end"
+                  onChange={(priority) =>
+                    void updateTask
+                      .mutateAsync({ taskId: task._id, priority })
+                      .catch(onMutationError)
+                  }
+                />
+              </PropertyField>
+              <PropertyField label={t('fields.assignee')}>
+                <AssigneePicker
+                  organizationId={task.organizationId}
+                  projectId={task.projectId}
+                  taskId={task._id}
+                  assigneeType={task.assigneeType}
+                  assigneeId={task.assigneeId}
+                  taskTitle={task.title}
+                  taskDescription={task.description}
+                  taskLabels={task.labels}
+                  disabled={!canMutate}
+                  align="end"
+                  afterTrigger={
+                    <span className="text-foreground min-w-0 truncate text-sm">
+                      {assigneeName}
+                    </span>
+                  }
+                  onAssign={(assigneeType, assigneeId) =>
+                    void assignTask
+                      .mutateAsync({
+                        taskId: task._id,
+                        assigneeType,
+                        assigneeId,
+                      })
+                      .catch(onMutationError)
+                  }
+                  onUnassign={() =>
+                    void assignTask
+                      .mutateAsync({ taskId: task._id })
+                      .catch(onMutationError)
+                  }
+                />
+              </PropertyField>
+              {/* The agent lane's status + verbs live WITH the assignee — the
+                run is Alice's state, not a second card in the task body. */}
+              {task.assigneeType === 'agent' && (
+                <PropertyField label={t('agentRun.label')}>
+                  <TaskAgentRunEntry
+                    organizationId={task.organizationId}
+                    taskId={task._id}
+                    canEdit={canMutate}
+                  />
+                </PropertyField>
+              )}
+              <PropertyField label={t('dueDate.label')}>
+                <DatePicker
+                  value={task.dueDate}
+                  disabled={!canMutate}
+                  onChange={(dueDate) =>
+                    void updateTask
+                      .mutateAsync({ taskId: task._id, dueDate })
+                      .catch(onMutationError)
+                  }
+                />
+              </PropertyField>
+
+              <PanelDivider />
+              {/* Labels and dependencies are the BOARD's vocabulary. On an
                 automation-owned task they are noise around the two properties
                 that matter there (who owns it, where it stands), so they fold
                 into one disclosure — the same controls, still one click away,
                 just not competing with the work. */}
-            {ownedBy !== null ? (
-              <CollapsibleDetails
-                summary={t('detail.moreFields')}
-                variant="compact"
-                className="shrink-0"
-              >
-                <Stack gap={4} className="pt-3">
+              {ownedBy !== null ? (
+                <CollapsibleDetails
+                  summary={t('detail.moreFields')}
+                  variant="compact"
+                  className="shrink-0"
+                >
+                  <Stack gap={4} className="pt-3">
+                    {labelsField}
+                    {dependenciesField}
+                  </Stack>
+                </CollapsibleDetails>
+              ) : (
+                <>
                   {labelsField}
+                  <PanelDivider />
                   {dependenciesField}
-                </Stack>
-              </CollapsibleDetails>
-            ) : (
-              <>
-                {labelsField}
-                <PanelDivider />
-                {dependenciesField}
-              </>
-            )}
+                </>
+              )}
 
-            <PanelDivider />
-            <PropertyField label={t('fields.author')}>
-              <div className="flex min-w-0 items-center gap-1.5">
-                <AssigneeAvatar
-                  assigneeType={task.createdByType}
-                  assigneeId={task.createdBy}
-                  name={author.name}
-                />
-                <span className="text-foreground min-w-0 truncate text-sm">
-                  {author.name}
+              <PanelDivider />
+              <PropertyField label={t('fields.author')}>
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <AssigneeAvatar
+                    assigneeType={task.createdByType}
+                    assigneeId={task.createdBy}
+                    name={author.name}
+                  />
+                  <span className="text-foreground min-w-0 truncate text-sm">
+                    {author.name}
+                  </span>
+                </div>
+              </PropertyField>
+              <PropertyField label={t('fields.created')}>
+                <span className="text-foreground text-sm">
+                  {formatDate(new Date(task.createdAt), 'medium')}
                 </span>
-              </div>
-            </PropertyField>
-            <PropertyField label={t('fields.created')}>
-              <span className="text-foreground text-sm">
-                {formatDate(new Date(task.createdAt), 'medium')}
-              </span>
-            </PropertyField>
-            {canEdit && (
-              <>
-                <PanelDivider />
-                {/* shrink-0, like every PropertyField row: the panel is a
+              </PropertyField>
+              {canEdit && (
+                <>
+                  <PanelDivider />
+                  {/* shrink-0, like every PropertyField row: the panel is a
                     height-constrained flex column, and a flex item's automatic
                     minimum size only protects text — a fixed-height control
                     compresses to its one-line min-content, which rendered this
@@ -1411,20 +1464,21 @@ function EditTaskBody({
                     every Button sits inside its skeleton wrapper's
                     `display: contents` span, so the button, not the span, is
                     the flex item. */}
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="w-full shrink-0"
-                  icon={isArchived ? ArchiveRestore : Archive}
-                  onClick={() => setArchiveOpen(true)}
-                >
-                  {isArchived ? t('actions.restore') : t('actions.archive')}
-                </Button>
-              </>
-            )}
-          </>
-        }
-      />
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="w-full shrink-0"
+                    icon={isArchived ? ArchiveRestore : Archive}
+                    onClick={() => setArchiveOpen(true)}
+                  >
+                    {isArchived ? t('actions.restore') : t('actions.archive')}
+                  </Button>
+                </>
+              )}
+            </>
+          }
+        />
+      </div>
       <TaskArchiveDialog
         open={archiveOpen}
         onOpenChange={setArchiveOpen}

--- a/services/platform/convex/chat/external_turn_drain.test.ts
+++ b/services/platform/convex/chat/external_turn_drain.test.ts
@@ -128,6 +128,9 @@ describe('drainHarnessWindow — turn-ended cut on a lingering exec', () => {
     if (result.kind !== 'terminal') throw new Error('unreachable');
     expect(result.exited).toBe(false);
     expect(result.ended?.isError).toBe(false);
+    // The harness announced its conversation id — the restart-steering
+    // lane's --resume handle, persisted onto the op row by the hosts.
+    expect(result.agentSessionId).toBe('sess-resume-1');
     // The lingering process is reaped so it can't hold the session.
     expect(mockCancel).toHaveBeenCalledWith('session_1', 'exec_1');
   });

--- a/services/platform/convex/chat/external_turn_shared.ts
+++ b/services/platform/convex/chat/external_turn_shared.ts
@@ -291,10 +291,34 @@ function lastTurnEnded(
   return undefined;
 }
 
+/** The harness's OWN conversation id, announced on `turn-started` (or, for
+ * harnesses that only stamp it at the end, `turn-ended`). Every drain window
+ * replays the ring from seq 0, so any window past the announcement sees it.
+ * This is the `--resume` handle a restart needs — the lanes persist it on
+ * the op row so a mid-run restart can continue the same conversation. */
+function harnessSessionIdFromEvents(
+  events: readonly HarnessEvent[],
+): string | undefined {
+  for (const e of events) {
+    if (e.type === 'turn-started' && e.sessionId !== undefined) {
+      return e.sessionId;
+    }
+    if (e.type === 'turn-ended' && e.sessionId !== undefined) {
+      return e.sessionId;
+    }
+  }
+  return undefined;
+}
+
 /** What one harness window observed — the lane-neutral core result. */
 export type HarnessWindowResult =
   | { kind: 'gone' }
-  | { kind: 'running'; text: string; timeline: HarnessTimelinePart[] }
+  | {
+      kind: 'running';
+      text: string;
+      timeline: HarnessTimelinePart[];
+      agentSessionId?: string;
+    }
   | {
       kind: 'terminal';
       text: string;
@@ -302,6 +326,7 @@ export type HarnessWindowResult =
       ended?: Extract<HarnessEvent, { type: 'turn-ended' }>;
       execResult?: SessionExecResult;
       exited: boolean;
+      agentSessionId?: string;
     };
 
 /**
@@ -459,8 +484,16 @@ export async function drainHarnessWindow(args: {
   const text = textFromEvents(events);
   const timeline = timelineFromEvents(events);
   const ended = lastTurnEnded(events);
+  const agentSessionId = harnessSessionIdFromEvents(events);
   const terminal = exited || ended !== undefined;
-  if (!terminal) return { kind: 'running', text, timeline };
+  if (!terminal) {
+    return {
+      kind: 'running',
+      text,
+      timeline,
+      ...(agentSessionId !== undefined ? { agentSessionId } : {}),
+    };
+  }
 
   // A harness that lingers after its turn (held-open stdin) has ended the turn
   // but not the process — reap it so it can't hold the session.
@@ -477,6 +510,7 @@ export async function drainHarnessWindow(args: {
     ...(ended !== undefined ? { ended } : {}),
     ...(execResult !== undefined ? { execResult } : {}),
     exited,
+    ...(agentSessionId !== undefined ? { agentSessionId } : {}),
   };
 }
 

--- a/services/platform/convex/sandbox/session_queries.ts
+++ b/services/platform/convex/sandbox/session_queries.ts
@@ -96,6 +96,41 @@ export const getExternalTurnOpForFinalize = internalQuery({
  * deterministic (executionId, stepSlug) session id, which has no threadId).
  * Null when no agent turn is live in the session. Carries the
  * `agentIdleAt` linger marker a file-stage must respect. */
+/**
+ * The op-row facts the mid-run steer action arbitrates on: whether the turn
+ * is still consuming input (`running` with no finalize claim) and the
+ * harness's own conversation id (`agentSessionId` — the `--resume` handle
+ * the restart lane continues with). Point read; null when the turn never
+ * wrote its op row.
+ */
+export const getOpSteerState = internalQuery({
+  args: { sessionId: v.string(), execId: v.string() },
+  returns: v.union(
+    v.object({
+      status: v.string(),
+      finalized: v.boolean(),
+      agentSessionId: v.optional(v.string()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query('sandboxSessionOps')
+      .withIndex('by_sessionId_and_execId', (q) =>
+        q.eq('sessionId', args.sessionId).eq('execId', args.execId),
+      )
+      .first();
+    if (row === null) return null;
+    return {
+      status: row.status,
+      finalized: row.finalizedAt !== undefined,
+      ...(row.agentSessionId !== undefined
+        ? { agentSessionId: row.agentSessionId }
+        : {}),
+    };
+  },
+});
+
 export const getRunningAgentRunBySession = internalQuery({
   args: { sessionId: v.string() },
   returns: v.union(

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -17,6 +17,8 @@
 
 import { ConvexError, v } from 'convex/values';
 
+import { buildStdinUserMessage } from '../../lib/harnesses/parsers/claude-stream-json';
+import { isHarnessSlug } from '../../lib/harnesses/types';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
@@ -33,6 +35,7 @@ import {
   drainHarnessWindow,
   connectorsBridgeUrlForSessions,
 } from '../chat/external_turn_shared';
+import { loadHarnesses } from '../lib/providers/load_system_config';
 import { resolveTurnVisionModel } from '../lib/providers/resolve_vision_model';
 import { provisionSessionGatewayKey } from '../node_only/sandbox/gateway_provisioning';
 import {
@@ -43,6 +46,7 @@ import {
   sessionIsAlive,
   sessionListFiles,
   sessionStageFiles,
+  sessionWriteExecStdin,
   type SessionStageFile,
 } from '../node_only/sandbox/helpers/session_client';
 import { stageUrlForBlobRef } from '../node_only/sandbox/helpers/stage_url';
@@ -743,6 +747,12 @@ async function continueOrSettle(
       kind: 'task-agent',
       status: 'running',
       heartbeatAt: Date.now(),
+      // The harness's own conversation id, announced on turn start and
+      // replayed into every window — the restart-steering lane's --resume
+      // handle. Patch-only-when-provided keeps an earlier capture.
+      ...(window.agentSessionId !== undefined
+        ? { agentSessionId: window.agentSessionId }
+        : {}),
     });
     await ctx.scheduler.runAfter(
       0,
@@ -783,6 +793,9 @@ async function continueOrSettle(
       status: 'running',
       lastEventAt: Date.now(),
       ...(window.text !== '' ? { progressText: window.text } : {}),
+      ...(window.agentSessionId !== undefined
+        ? { agentSessionId: window.agentSessionId }
+        : {}),
       liveTimeline: window.timeline,
     })
     .catch((err) =>
@@ -851,6 +864,9 @@ async function settleTaskAgentTurn(
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from the turn's own args
       runId: args.runId as never,
       error: result.reason ?? 'the agent run failed',
+      // Exec-guarded: a chain superseded by a restart-steer rotation must
+      // not terminal-stamp the run its successor is working on.
+      execId: args.execId,
     });
     await releaseProjectAgentSlotAfterSettle(ctx, args);
     return;
@@ -957,6 +973,8 @@ async function settleTaskAgentTurn(
     runId: args.runId as never,
     resultText,
     ...(resultMessageId !== undefined ? { resultMessageId } : {}),
+    // Exec-guarded, same reason as the failed mark above.
+    execId: args.execId,
   });
   await releaseProjectAgentSlotAfterSettle(ctx, args);
 }
@@ -981,3 +999,375 @@ async function releaseProjectAgentSlotAfterSettle(
     console.warn('[task-agent] session-slot release failed:', err);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Mid-run comment steering — the @mention door's live-engine branch
+// ---------------------------------------------------------------------------
+
+/** Which steering lane a harness supports: `stdin` when its YAML declares
+ * the steering capability (a held-open NDJSON stdin the CLI keeps reading),
+ * else `restart` — the CLI takes no input once launched, so the comment
+ * reaches the run by killing the exec and continuing on a fresh
+ * incarnation. Exported for its unit test. */
+export function steerLaneForHarness(harness: string): 'stdin' | 'restart' {
+  if (!isHarnessSlug(harness)) return 'restart';
+  const def = loadHarnesses().find((h) => h.slug === harness);
+  return def?.capabilities.steering === true ? 'stdin' : 'restart';
+}
+
+/** The injected line a live turn reads for a mid-run task comment. The CLI
+ * queues a mid-step stdin line to its next API boundary, exactly like
+ * interactive steering, so the turn absorbs it without losing work. */
+export function buildSteerCommentText(author: string, body: string): string {
+  return [
+    `Task comment from ${author}, posted while you are working:`,
+    body,
+    'If this changes what you should do, adjust course now. Otherwise take it into account and cover it in your final report.',
+  ].join('\n\n');
+}
+
+/** The opening prompt of a RESUMED restart — same task, same conversation,
+ * continued on a fresh process with the comment in hand. */
+export function buildResumeSteerPrompt(author: string, body: string): string {
+  return [
+    'Your process was restarted to deliver a task comment that arrived while you were working. This is the SAME task and the SAME conversation — continue from where you left off and do NOT redo completed work.',
+    `Task comment from ${author}:`,
+    body,
+    'When you are done, end with a short report of what you did and what you produced — that report is posted back to the task for human review.',
+  ].join('\n\n');
+}
+
+/** Prefixed to the rebuilt brief when the harness conversation could NOT be
+ * resumed (no --resume handle captured yet): the fresh conversation leans on
+ * the brief and on the standing workspace, which still holds everything the
+ * interrupted attempt produced. */
+export const FRESH_RESTART_NOTE =
+  'You were interrupted mid-run to receive a new task comment, and the previous conversation could not be resumed. Your workspace and delivery box still hold everything already produced — inspect them and continue the work rather than starting over.';
+
+/** Retry ladder while a turn is inside its settle window (finalize claimed,
+ * terminal run state imminent): tight at first — a settle is normally
+ * seconds — then coarse through a long harvest, until the run goes terminal
+ * and the steer degrades to a fresh mention kick. */
+const STEER_RETRY_TIGHT_MS = 5_000;
+const STEER_RETRY_COARSE_MS = 30_000;
+const STEER_TIGHT_ATTEMPTS = 3;
+const STEER_MAX_ATTEMPTS = 15;
+
+/**
+ * Deliver a mid-run task comment INTO the live turn — scheduled by the
+ * @mention door when the mentioned agent is the one already running
+ * (`triggerMentionedProjectAgent`). Two lanes by harness capability
+ * (`steerLaneForHarness`); every miss degrades and none errors: a run found
+ * terminal falls back to a fresh `trigger:'mention'` kick — exactly what
+ * the mention means with no live engine — and a turn caught mid-settle is
+ * retried until its run settles and takes that same fallback. The comment
+ * itself posted long ago; this action only decides HOW it reaches the
+ * agent.
+ */
+export const steerTaskAgentTurn = internalAction({
+  args: {
+    ...turnArgs,
+    model: v.string(),
+    instructions: v.optional(v.string()),
+    skills: v.array(v.string()),
+    connectors: v.array(v.string()),
+    feedback: v.string(),
+    author: v.string(),
+    authorId: v.string(),
+    attempt: v.number(),
+  },
+  returns: v.null(),
+  // The explicit return type breaks the inference cycle: the mention door in
+  // `tasks/mutations.ts` schedules this action, and this action's fallback
+  // calls back into that module's internal kick.
+  handler: async (ctx, args): Promise<null> => {
+    const retry = async (execId: string): Promise<null> => {
+      if (args.attempt >= STEER_MAX_ATTEMPTS) {
+        console.warn(
+          `[task-agent] steer for ${args.execId} gave up after ${String(args.attempt)} attempts — the comment stays in the discussion for the next run`,
+        );
+        return null;
+      }
+      await ctx.scheduler.runAfter(
+        args.attempt < STEER_TIGHT_ATTEMPTS
+          ? STEER_RETRY_TIGHT_MS
+          : STEER_RETRY_COARSE_MS,
+        internal.tasks.agent_run_host.steerTaskAgentTurn,
+        { ...args, execId, attempt: args.attempt + 1 },
+      );
+      return null;
+    };
+    const kickFallback = async (): Promise<null> => {
+      await ctx.runMutation(
+        internal.tasks.mutations.kickMentionRunAfterSteerMiss,
+        {
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from this invocation's own args
+          taskId: args.taskId as never,
+          authorId: args.authorId,
+          feedback: args.feedback,
+        },
+      );
+      return null;
+    };
+
+    const run: {
+      status: string;
+      execId: string;
+      sessionId: string;
+      organizationId: string;
+    } | null = await ctx.runQuery(
+      internal.tasks.agent_runs.getTaskAgentRunForDrive,
+      {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from this invocation's own args
+        runId: args.runId as never,
+      },
+    );
+    if (run === null) return null;
+    if (
+      run.status === 'settled' ||
+      run.status === 'failed' ||
+      run.status === 'cancelled'
+    ) {
+      // The engine settled while the comment was in flight — the mention now
+      // means what it means with no live run: a fresh run carrying it.
+      return await kickFallback();
+    }
+    if (run.status !== 'running') {
+      // Still queued (capacity-parked or start in flight): the start reads
+      // the brief AFTER the comment posted, so the turn opens with it.
+      return null;
+    }
+    if (run.execId !== args.execId) {
+      // A sibling steer rotated the exec under us — re-aim at the current
+      // incarnation.
+      return await retry(run.execId);
+    }
+    if (Date.now() > args.deadlineAt) return null; // the drive's deadline cut owns this turn
+
+    const op = await ctx.runQuery(
+      internal.sandbox.session_queries.getOpSteerState,
+      { sessionId: args.sessionId, execId: args.execId },
+    );
+    if (op === null || op.status !== 'running' || op.finalized) {
+      // The turn is settling (its result exists; nobody reads new input) —
+      // wait for the run to go terminal, then the fallback above kicks.
+      return await retry(args.execId);
+    }
+
+    if (steerLaneForHarness(args.harness) === 'stdin') {
+      const line = buildStdinUserMessage(
+        buildSteerCommentText(args.author, args.feedback),
+      );
+      try {
+        // buildStdinUserMessage is already newline-terminated, and runnerd
+        // fail-closes on anything but exactly one \n-terminated JSON line
+        // (a malformed line kills Claude Code's stream-json reader).
+        const wrote = await sessionWriteExecStdin(args.sessionId, args.execId, {
+          dataBase64: Buffer.from(line, 'utf8').toString('base64'),
+        });
+        if (!wrote.ok) {
+          throw new Error(`stdin write refused: ${wrote.reason ?? 'unknown'}`);
+        }
+      } catch (err) {
+        // Exec just ended, daemon blip — the run re-read on the retry sorts
+        // live (re-inject) from settled (fresh kick).
+        console.warn('[task-agent] stdin steer failed, retrying:', err);
+        return await retry(args.execId);
+      }
+      console.warn(
+        `[task-agent] steered live turn ${args.execId} with a task comment (stdin)`,
+      );
+      return null;
+    }
+
+    // RESTART lane: rotate the run onto a fresh incarnation (the
+    // single-winner claim), kill the old exec, and continue the conversation
+    // with the comment in hand. The superseded chain orphans itself: its
+    // settle marks are exec-guarded and the slot release refuses while the
+    // incarnation's op runs.
+    const rotated = await ctx.runMutation(
+      internal.tasks.agent_runs.rotateTaskAgentRunExec,
+      {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from this invocation's own args
+        runId: args.runId as never,
+        fromExecId: args.execId,
+      },
+    );
+    if (rotated === null) return await retry(args.execId); // raced a settle/cancel/steer
+    const execId = rotated.execId;
+    await sessionCancelExec(args.sessionId, args.execId).catch((err) =>
+      console.warn('[task-agent] steer kill of the old exec failed:', err),
+    );
+    try {
+      const target = await resolveServingTarget(
+        ctx,
+        args.organizationId,
+        args.model,
+      );
+      const routing = resolveGatewayRouting(
+        target.providerSlug,
+        target.modelId,
+      );
+      const projectScope = await ctx.runQuery(
+        internal.projects.internal_queries.getProjectAgentSkillScope,
+        {
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from this invocation's own args
+          agentId: args.agentId as never,
+        },
+      );
+      const skillsAddendum = await stageWorkflowSkills(
+        ctx,
+        args.organizationId,
+        args.sessionId,
+        args.skills,
+        projectScope === null
+          ? { kind: 'org' }
+          : { kind: 'project', teamIds: projectScope.teamIds },
+      );
+      const vision = await resolveTurnVisionModel(
+        ctx,
+        args.organizationId,
+        target,
+      );
+      const visionModelRef =
+        vision !== null
+          ? resolveGatewayRouting(vision.providerSlug, vision.modelId)
+              .gatewayModel
+          : undefined;
+      const budgetCents = workflowAgentBudgetCents();
+      const key = await provisionSessionGatewayKey(ctx, {
+        organizationId: args.organizationId,
+        sessionId: args.sessionId,
+        allowedModels: [
+          { providerSlug: target.providerSlug, modelId: target.modelId },
+          ...(vision !== null ? [vision] : []),
+        ],
+        budgetCents,
+      });
+      await ctx.runMutation(
+        internal.sandbox.session_mutations.insertSessionToken,
+        {
+          organizationId: args.organizationId,
+          sessionId: args.sessionId,
+          tokenHash: key.keyHash,
+          llmGatewayKeyId: key.keyId,
+          scope: {
+            agentKind: args.harness,
+            allowedModels: [routing.gatewayModel],
+            connectorGrants: [...args.connectors],
+            budgetCents,
+          },
+          expiresAt: args.deadlineAt,
+        },
+      );
+
+      const outputDir = taskOutputDir(args.taskId);
+      const resume = op.agentSessionId;
+      let prompt: string;
+      if (resume !== undefined) {
+        prompt = buildResumeSteerPrompt(args.author, args.feedback);
+      } else {
+        // Killed before the harness announced its conversation id — restart
+        // as a fresh conversation over the rebuilt brief; the standing
+        // workspace still holds the interrupted attempt's state.
+        const brief = await ctx.runQuery(
+          internal.tasks.agent_runs.getTaskBriefForAgentRun,
+          {
+            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- carried verbatim from this invocation's own args
+            taskId: args.taskId as never,
+          },
+        );
+        if (brief === null) throw new Error('the task no longer exists');
+        const inputs = await stageTaskInputs(ctx, {
+          organizationId: args.organizationId,
+          sessionId: args.sessionId,
+          taskId: args.taskId,
+          attachments: brief.attachments,
+          outputs: brief.outputs,
+        });
+        prompt = [
+          FRESH_RESTART_NOTE,
+          buildTaskPrompt(brief, args.feedback, outputDir, inputs),
+        ].join('\n\n');
+      }
+
+      await ctx.runMutation(
+        internal.sandbox.session_mutations.upsertSessionOp,
+        {
+          organizationId: args.organizationId,
+          sessionId: args.sessionId,
+          execId,
+          kind: 'task-agent',
+          status: 'running',
+          modelRef: `${target.providerSlug}/${routing.gatewayModel}`,
+          deadlineMs: args.deadlineAt,
+          heartbeatAt: Date.now(),
+          mintedKeyId: key.keyId,
+          // Carry the handle forward so a SECOND restart can resume too.
+          ...(resume !== undefined ? { agentSessionId: resume } : {}),
+        },
+      );
+
+      const instructions = [
+        ...(args.instructions !== undefined && args.instructions !== ''
+          ? [args.instructions]
+          : []),
+        ...(skillsAddendum !== '' ? [skillsAddendum] : []),
+        `Write every file you produce to ${outputDir}/ (this task's own delivery box — never plain /user/output/) — files there are collected when your turn ends and attached to the task.`,
+        `Your workspace (/user/workspace) is a standing area shared across ALL tasks assigned to you — files already there may belong to other tasks. Trust the task brief and its staged inputs over anything found lying around.`,
+      ].join('\n\n');
+
+      const exec = buildExternalTurnExec({
+        harness: args.harness,
+        gatewayModel: routing.gatewayModel,
+        serving: { kind: 'gateway', token: key.token },
+        instructions,
+        prompt,
+        execId,
+        ...(resume !== undefined ? { resume } : {}),
+        ...(args.connectors.length > 0
+          ? { bridgeUrl: connectorsBridgeUrlForSessions() }
+          : {}),
+        ...(visionModelRef !== undefined
+          ? { vision: { model: visionModelRef } }
+          : {}),
+      });
+
+      console.warn(
+        `[task-agent] restarted turn ${args.execId} as ${execId} to take a task comment (${resume !== undefined ? 'resumed conversation' : 'fresh conversation'})`,
+      );
+      const keys = { ...args, execId };
+      const progress = liveProgressSink(
+        ctx,
+        keys,
+        'task-agent',
+        visionModelRef,
+      );
+      const window = await drainHarnessWindow({
+        sessionId: args.sessionId,
+        execId,
+        harness: args.harness,
+        start: exec,
+        onText: progress.onText,
+        onTimeline: progress.onTimeline,
+      });
+      await progress.flush();
+      await continueOrSettle(ctx, keys, window);
+    } catch (err) {
+      // A restart that failed to LAUNCH must not strand the run at `running`
+      // with no engine: settle it under the NEW exec (first-wins,
+      // exec-guarded), so Retry works and the comment heads the next brief.
+      console.error('[task-agent] steer restart failed:', err);
+      await settleTaskAgentTurn(
+        ctx,
+        { ...args, execId },
+        {
+          errored: true,
+          reason: `the run could not be restarted to take a new comment: ${err instanceof Error ? err.message : String(err)}`,
+          text: '',
+        },
+      );
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/tasks/agent_run_steer.test.ts
+++ b/services/platform/convex/tasks/agent_run_steer.test.ts
@@ -1,0 +1,57 @@
+// Pure pieces of the mid-run comment steering lane — which delivery lane a
+// harness gets (its YAML `capabilities.steering` fact), and the exact texts
+// a live turn (stdin) or a restarted turn (--resume / fresh) receives. The
+// convex-test halves (the mention door, the exec rotation, the exec-guarded
+// marks, the steer-miss fallback) live in task_agent_runs.test.ts.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildResumeSteerPrompt,
+  buildSteerCommentText,
+  FRESH_RESTART_NOTE,
+  steerLaneForHarness,
+} from './agent_run_host';
+
+describe('steerLaneForHarness', () => {
+  it('stdin for the steering-capable harness', () => {
+    expect(steerLaneForHarness('claude-code')).toBe('stdin');
+  });
+
+  it('restart for harnesses that take no input once launched', () => {
+    expect(steerLaneForHarness('codex')).toBe('restart');
+    expect(steerLaneForHarness('cursor')).toBe('restart');
+    expect(steerLaneForHarness('gemini')).toBe('restart');
+  });
+
+  it('restart for an unknown slug — never a blind stdin write', () => {
+    expect(steerLaneForHarness('not-a-harness')).toBe('restart');
+  });
+});
+
+describe('steer texts', () => {
+  it('the stdin line names the author, carries the body, and asks for course correction', () => {
+    const text = buildSteerCommentText(
+      'Larry Luo',
+      '空白页太多了，去掉纯背景图片页',
+    );
+    expect(text).toContain('Task comment from Larry Luo');
+    expect(text).toContain('空白页太多了，去掉纯背景图片页');
+    expect(text).toContain('adjust course now');
+  });
+
+  it('the resume prompt continues the conversation and forbids redoing work', () => {
+    const text = buildResumeSteerPrompt(
+      'Larry Luo',
+      'use real photos on page 3',
+    );
+    expect(text).toContain('SAME task and the SAME conversation');
+    expect(text).toContain('use real photos on page 3');
+    expect(text).toContain('do NOT redo completed work');
+  });
+
+  it('the fresh-restart note points at the surviving workspace', () => {
+    expect(FRESH_RESTART_NOTE).toContain('could not be resumed');
+    expect(FRESH_RESTART_NOTE).toContain('workspace');
+  });
+});

--- a/services/platform/convex/tasks/agent_runs.ts
+++ b/services/platform/convex/tasks/agent_runs.ts
@@ -138,11 +138,17 @@ export const markTaskAgentRunSettled = internalMutation({
     runId: v.id('projectAgentRuns'),
     resultText: v.string(),
     resultMessageId: v.optional(v.string()),
+    /** The settling exec. A run can outlive an exec (the restart-steering
+     * lane rotates it under a live run), so a mark from a superseded chain
+     * must be a no-op — without the guard, the killed chain's own settle
+     * would terminal-stamp a run now working on its next incarnation. */
+    execId: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     const run = await ctx.db.get(args.runId);
     if (!run || TERMINAL_RUN_STATUSES.has(run.status)) return null;
+    if (args.execId !== undefined && run.execId !== args.execId) return null;
     const now = Date.now();
     await ctx.db.patch(args.runId, {
       status: 'settled',
@@ -158,11 +164,17 @@ export const markTaskAgentRunSettled = internalMutation({
 });
 
 export const markTaskAgentRunFailed = internalMutation({
-  args: { runId: v.id('projectAgentRuns'), error: v.string() },
+  args: {
+    runId: v.id('projectAgentRuns'),
+    error: v.string(),
+    /** See markTaskAgentRunSettled — a superseded exec's mark is a no-op. */
+    execId: v.optional(v.string()),
+  },
   returns: v.null(),
   handler: async (ctx, args) => {
     const run = await ctx.db.get(args.runId);
     if (!run || TERMINAL_RUN_STATUSES.has(run.status)) return null;
+    if (args.execId !== undefined && run.execId !== args.execId) return null;
     const now = Date.now();
     await ctx.db.patch(args.runId, {
       status: 'failed',
@@ -265,6 +277,31 @@ export const listStalledTaskAgentTurns = internalQuery({
       if (out.length >= args.limit) break;
     }
     return out;
+  },
+});
+
+/**
+ * Swap a LIVE run onto a fresh exec incarnation — the restart-steering lane
+ * (a non-steerable harness absorbing a mid-run comment) kills the exec and
+ * continues the run on a new one. The swap IS the single-winner claim:
+ * guarded on (status `running`, execId === fromExecId), so a raced settle,
+ * cancel, or sibling steer can never double-rotate. The superseded chain
+ * then orphans itself — its settle marks are exec-guarded and the session
+ * slot release refuses while the incarnation's op runs. The new id chains
+ * `-2` onto the old, which keeps the run's op reads following it
+ * (`getTaskAgentRunSandboxOp` matches `${execId}-` prefixes).
+ */
+export const rotateTaskAgentRunExec = internalMutation({
+  args: { runId: v.id('projectAgentRuns'), fromExecId: v.string() },
+  returns: v.union(v.object({ execId: v.string() }), v.null()),
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.runId);
+    if (!run || run.status !== 'running' || run.execId !== args.fromExecId) {
+      return null;
+    }
+    const execId = `${args.fromExecId}-2`;
+    await ctx.db.patch(args.runId, { execId, updatedAt: Date.now() });
+    return { execId };
   },
 });
 

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -17,10 +17,15 @@ import { ConvexError, v } from 'convex/values';
 import { isTaskLabelColor } from '../../lib/shared/task-label-colors';
 import { components, internal } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
-import { mutation, type MutationCtx } from '../_generated/server';
+import {
+  internalMutation,
+  mutation,
+  type MutationCtx,
+} from '../_generated/server';
 import { assertAgentAssigneeLive } from '../agents/installations';
 import { createAuditLog } from '../audit_logs/helpers';
 import { findLiveAutomationRunForTask } from '../automations/queries';
+import { getUserById } from '../betterAuth/trusted_headers/get_user_by_id';
 import {
   autoSubscribe,
   notifyTaskAssigned,
@@ -1306,10 +1311,54 @@ async function triggerMentionedProjectAgent(
   ) {
     return;
   }
-  // The reassign-under-live-run invariant, checked up front so a mention
-  // during a live run changes NOTHING (no reassign, no second engine).
+  // The reassign-under-live-run invariant still holds — a mention during a
+  // live run never reassigns and never starts a second engine. But when the
+  // mentioned instance IS the running agent, the comment now STEERS the live
+  // turn instead of being dropped: `steerTaskAgentTurn` injects it over the
+  // harness's held-open stdin, or — for a harness that takes no input once
+  // launched — restarts the exec around it and resumes the conversation. A
+  // queued (capacity-parked) run needs nothing: its start reads the brief
+  // AFTER this comment posted. An automation-driven task keeps its
+  // automation, unchanged.
+  const liveRun = await liveTaskAgentRun(ctx, task._id);
+  if (liveRun !== null) {
+    if (
+      liveRun.status === 'running' &&
+      String(liveRun.agentId) === String(instance._id)
+    ) {
+      const author = await getUserById(ctx, auth.userId);
+      const authorName =
+        (author?.name ?? '').trim() ||
+        (author?.email ?? '').trim() ||
+        'a teammate';
+      await ctx.scheduler.runAfter(
+        0,
+        internal.tasks.agent_run_host.steerTaskAgentTurn,
+        {
+          organizationId: task.organizationId,
+          runId: liveRun._id,
+          taskId: task._id,
+          agentId: liveRun.agentId,
+          execId: liveRun.execId,
+          sessionId: liveRun.sessionId,
+          harness: liveRun.harness,
+          deadlineAt: liveRun.deadlineAt,
+          model: liveRun.model,
+          ...(instance.instructions !== undefined
+            ? { instructions: instance.instructions }
+            : {}),
+          skills: instance.skills,
+          connectors: instance.connectors,
+          feedback: args.feedback,
+          author: authorName,
+          authorId: auth.userId,
+          attempt: 0,
+        },
+      );
+    }
+    return;
+  }
   if (
-    (await liveTaskAgentRun(ctx, task._id)) !== null ||
     (await findLiveAutomationRunForTask(ctx, {
       organizationId: task.organizationId,
       projectId: task.projectId,
@@ -1350,6 +1399,43 @@ async function triggerMentionedProjectAgent(
 // ---------------------------------------------------------------------------
 // Edit / delete a comment (author-only edit; author-or-admin delete)
 // ---------------------------------------------------------------------------
+
+/**
+ * The steer action's fallback door: the live engine settled while the
+ * comment was in flight, so the mention degrades to what it means with no
+ * live run — a fresh run carrying the comment as feedback. Attribution
+ * stays with the comment's author (the kick is their gesture, delivered
+ * late); the author already passed the comment ACL, and every kick guard
+ * (agent ownership, single engine, breaker, model) still applies inside
+ * `kickTaskAgentRun`.
+ */
+export const kickMentionRunAfterSteerMiss = internalMutation({
+  args: {
+    taskId: v.id('tasks'),
+    authorId: v.string(),
+    feedback: v.string(),
+  },
+  returns: v.null(),
+  // Explicit return type: this module and the run host reference each other
+  // through `internal` (door → steer action → this fallback), and TS needs
+  // one side annotated to break the inference cycle.
+  handler: async (ctx, args): Promise<null> => {
+    const task = await ctx.db.get(args.taskId);
+    if (task === null || task.archivedAt !== undefined) return null;
+    const kicked = await kickTaskAgentRun(ctx, {
+      task,
+      auth: { userId: args.authorId },
+      trigger: 'mention',
+      feedback: args.feedback,
+    });
+    if (!kicked.started) {
+      console.warn(
+        `[tasks] steer-miss mention kick refused: ${kicked.reason ?? 'unknown'}`,
+      );
+    }
+    return null;
+  },
+});
 
 /**
  * Load a task-discussion message's side-car meta + its task/project/auth for an

--- a/services/platform/convex/tasks/task_agent_runs.test.ts
+++ b/services/platform/convex/tasks/task_agent_runs.test.ts
@@ -758,3 +758,213 @@ describe('getTaskBriefForAgentRun', () => {
     expect(brief?.outputs).toEqual([]);
   });
 });
+
+// Mid-run comment steering: a mention of the RUNNING agent no longer drops —
+// the door schedules `steerTaskAgentTurn` against the live exec. The pure
+// lane/text halves live in agent_run_steer.test.ts; here the convex-test
+// halves: the door's branches, the exec rotation's single-winner claim, the
+// exec-guarded terminal marks, and the steer-miss fallback kick.
+describe('mid-run comment steering', () => {
+  function world(): T {
+    const t = convexTest(schema, modules);
+    rateLimiterComponent.register(t);
+    agentComponent.register(t);
+    return t;
+  }
+
+  const runRows = (t: T) =>
+    t.run((ctx) => ctx.db.query('projectAgentRuns').collect());
+
+  const steerJobs = (t: T) =>
+    t.run(async (ctx) =>
+      (await ctx.db.system.query('_scheduled_functions').collect()).filter(
+        (job) => job.name.includes('steerTaskAgentTurn'),
+      ),
+    );
+
+  async function seedRunningRun(t: T) {
+    const { taskId, agentId, projectId } = await seedWorld(t);
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.startTaskAgentRun, { taskId });
+    const run = (await runRows(t))[0];
+    if (!run) throw new Error('run row missing');
+    await t.run(async (ctx) => {
+      await ctx.db.patch(run._id, { status: 'running' });
+    });
+    return { taskId, agentId, projectId, run };
+  }
+
+  it('a mention of the RUNNING agent schedules a steer instead of dropping', async () => {
+    const t = world();
+    const { taskId, run } = await seedRunningRun(t);
+
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: '@pr.reviewer 空白页太多了',
+      });
+
+    expect(await runRows(t)).toHaveLength(1); // no second engine
+    const jobs = await steerJobs(t);
+    expect(jobs).toHaveLength(1);
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- system table args are untyped
+    const args = jobs[0]?.args[0] as {
+      execId: string;
+      feedback: string;
+      author: string;
+      attempt: number;
+      model: string;
+      skills: string[];
+    };
+    expect(args.execId).toBe(run.execId);
+    expect(args.feedback).toBe('@pr.reviewer 空白页太多了');
+    // Test user ids resolve to no Better Auth user — the label falls back.
+    expect(args.author).toBe('a teammate');
+    expect(args.attempt).toBe(0);
+    expect(args.model).toBe('z-ai/glm-5');
+    expect(args.skills).toEqual([]);
+  });
+
+  it('a queued run is left alone — its start reads the brief after the comment', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+    const asEditor = t.withIdentity({ subject: EDITOR });
+    await asEditor.mutation(api.tasks.mutations.startTaskAgentRun, { taskId });
+
+    await asEditor.mutation(api.tasks.mutations.addTaskComment, {
+      taskId,
+      body: '@pr.reviewer also add a summary page',
+    });
+
+    expect(await steerJobs(t)).toHaveLength(0);
+    expect(await runRows(t)).toHaveLength(1);
+  });
+
+  it('a mention of a DIFFERENT agent never preempts the live engine', async () => {
+    const t = world();
+    const { taskId, agentId, projectId } = await seedRunningRun(t);
+    await t.run((ctx) =>
+      ctx.db.insert('projectAgents', {
+        organizationId: ORG,
+        projectId,
+        name: 'Bob',
+        harness: 'claude-code',
+        model: 'z-ai/glm-5',
+        skills: [],
+        connectors: [],
+        createdBy: EDITOR,
+        createdAt: 0,
+        updatedAt: 0,
+      }),
+    );
+
+    await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: '@bob take this over',
+      });
+
+    expect(await steerJobs(t)).toHaveLength(0);
+    expect(await runRows(t)).toHaveLength(1);
+    const task = await t.run((ctx) => ctx.db.get(taskId));
+    expect(task?.assigneeId).toBe(String(agentId)); // no reassign under a live engine
+  });
+
+  it('rotateTaskAgentRunExec swaps the exec exactly once (single-winner)', async () => {
+    const t = world();
+    const { run } = await seedRunningRun(t);
+
+    const rotated = await t.mutation(
+      internal.tasks.agent_runs.rotateTaskAgentRunExec,
+      { runId: run._id, fromExecId: run.execId },
+    );
+    expect(rotated).toEqual({ execId: `${run.execId}-2` });
+    const fresh = await t.run((ctx) => ctx.db.get(run._id));
+    expect(fresh?.execId).toBe(`${run.execId}-2`);
+
+    // A raced second steer still holding the OLD exec loses the claim.
+    const again = await t.mutation(
+      internal.tasks.agent_runs.rotateTaskAgentRunExec,
+      { runId: run._id, fromExecId: run.execId },
+    );
+    expect(again).toBeNull();
+
+    // A terminal run can never rotate.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(run._id, { status: 'settled', settledAt: 1 });
+    });
+    expect(
+      await t.mutation(internal.tasks.agent_runs.rotateTaskAgentRunExec, {
+        runId: run._id,
+        fromExecId: `${run.execId}-2`,
+      }),
+    ).toBeNull();
+  });
+
+  it('the terminal marks are exec-guarded against a superseded chain', async () => {
+    const t = world();
+    const { run } = await seedRunningRun(t);
+    await t.mutation(internal.tasks.agent_runs.rotateTaskAgentRunExec, {
+      runId: run._id,
+      fromExecId: run.execId,
+    });
+
+    // The killed chain settles on its own path — its mark must be a no-op.
+    await t.mutation(internal.tasks.agent_runs.markTaskAgentRunFailed, {
+      runId: run._id,
+      error: 'the harness exited unexpectedly',
+      execId: run.execId,
+    });
+    let fresh = await t.run((ctx) => ctx.db.get(run._id));
+    expect(fresh?.status).toBe('running');
+    expect(fresh?.error).toBeUndefined();
+
+    // The incarnation's own settle lands.
+    await t.mutation(internal.tasks.agent_runs.markTaskAgentRunSettled, {
+      runId: run._id,
+      resultText: 'done',
+      execId: `${run.execId}-2`,
+    });
+    fresh = await t.run((ctx) => ctx.db.get(run._id));
+    expect(fresh?.status).toBe('settled');
+  });
+
+  it('the steer-miss fallback kicks a fresh mention run once the engine settled', async () => {
+    const t = world();
+    const { taskId, run } = await seedRunningRun(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(run._id, { status: 'settled', settledAt: 1 });
+    });
+
+    await t.mutation(internal.tasks.mutations.kickMentionRunAfterSteerMiss, {
+      taskId,
+      authorId: EDITOR,
+      feedback: 'also add a summary page',
+    });
+
+    const rows = await runRows(t);
+    expect(rows).toHaveLength(2);
+    const kicked = rows.find((row) => row.status === 'queued');
+    expect(kicked).toMatchObject({
+      trigger: 'mention',
+      feedback: 'also add a summary page',
+      startedBy: EDITOR,
+    });
+  });
+
+  it('the steer-miss fallback refuses while an engine is still live', async () => {
+    const t = world();
+    const { taskId } = await seedRunningRun(t);
+
+    await t.mutation(internal.tasks.mutations.kickMentionRunAfterSteerMiss, {
+      taskId,
+      authorId: EDITOR,
+      feedback: 'late comment',
+    });
+
+    expect(await runRows(t)).toHaveLength(1); // already_running → refused
+  });
+});

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6149,7 +6149,7 @@ tasks:
     add: Anhänge hinzufügen
     remove: Anhang entfernen
     uploading: Wird hochgeladen …
-    dropHint: Bilder oder Dokumente hierher ziehen oder zum Auswählen klicken
+    dropHint: Bilder oder Dokumente hierher ziehen, einfügen oder zum Auswählen klicken
   outputs:
     label: Ergebnisdateien
   title: Aufgaben

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6170,7 +6170,7 @@ tasks:
     add: Add attachments
     remove: Remove attachment
     uploading: Uploading…
-    dropHint: Drop images or documents, or click to browse
+    dropHint: Drop or paste images or documents, or click to browse
   outputs:
     label: Deliverables
   title: Tasks

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6269,7 +6269,7 @@ tasks:
     add: Ajouter des pièces jointes
     remove: Supprimer la pièce jointe
     uploading: Téléversement…
-    dropHint: Déposez des images ou des documents, ou cliquez pour parcourir
+    dropHint: Dépose ou colle des images ou des documents, ou clique pour parcourir
   outputs:
     label: Fichiers produits
   title: Tâches


### PR DESCRIPTION
Two task-dialog capabilities, one per commit.

## Mention-steering a live run

- A comment @mentioning the agent **already running** the task used to change nothing (the live-run guard swallowed it; only the next run's brief would carry it). It now steers the live engine, and the docs' long-standing promise — "a running agent picks the comment up mid-run" (`task-automation.md`) — becomes true.
- **Two lanes, by the harness's own YAML capability:**
  - `capabilities.steering` (claude-code): the comment lands as one NDJSON user-message line on the exec's held-open stdin. The CLI queues a mid-step line to its next API boundary, so injection is lossless. The line goes out exactly as `buildStdinUserMessage` emits it — runnerd fail-closes on anything but a single newline-terminated JSON line.
  - Every other harness takes no input once launched, so the lane **restarts the run around the comment**: `rotateTaskAgentRunExec` swaps the run onto a fresh exec incarnation (single-winner claim; the `-2` suffix the op reads already follow), kills the old exec, and resumes the harness conversation via the op-captured `agentSessionId` (the drain now surfaces it from `turn-started`; both hosts persist it — the field and upsert arg already existed). No handle yet → fresh conversation over the rebuilt brief, with the standing workspace keeping the interrupted attempt's state.
- **Every miss degrades, none errors:** a run found terminal — or one that settles while the steer retries through the settle window — falls back to a fresh `trigger:'mention'` kick attributed to the comment's author, exactly what a mention means with no live engine. Queued runs stay untouched (their start reads the brief after the comment); mentions of a different agent still never preempt; the automation-run guard is unchanged.
- **Load-bearing hardening:** the run terminal marks are now exec-guarded — a chain superseded by a restart rotation settles its own dead exec but can no longer terminal-stamp the run its successor is working on.

## Paste images straight into task attachments

- A paste anywhere in the task dialog (create and edit) attaches the clipboard's images, under the chat composer's rule: image bytes win over the text/alt fallback, so a screenshot never lands as prose in the description, and a plain text paste stays native.
- The clipboard extraction is now ONE shared helper (`app/features/shared/files/clipboard-images.ts`); the composer reuses it, `pasted-image-N` naming kept verbatim. Folder-bound automation tasks are excluded — their input door is the bound folder, not attachments. The drop-zone hint names all three ways in across en/de/fr; the French string also moves from a stray `vous` imperative to the catalog's `tu` voice.

## Verified

- New coverage: steer lane resolution + injected/restart prompt texts, the mention door's three branches, exec-rotation single-winner, exec-guarded marks, the steer-miss fallback (kicks once the engine settled, refuses while live), drain `agentSessionId` capture, and the clipboard extraction. Full platform suite (74k+), the UI component suite (3,084), and the `@tale/ui` i18n voice suite are green; `tsc` and `oxlint --type-aware` clean; `migrations:check` clean (zero schema change).
- **Live-verified on a dev deployment:** an @mention during a working claude-code turn was injected over stdin and the agent's final report explicitly addressed it; a comment racing the settle auto-kicked the follow-up mention run carrying it as feedback; a synthesized paste in a real browser landed `pasted-image-1.png` in the Attachments zone, persisted.
- Honest boundary: the restart lane is unit-covered but not yet live-exercised (no non-claude agents on the dev org), and kill-mid-work resume fidelity should be verified per pinned CLI before relying on it for a given harness — codex first; its YAML documents the resume edges.