### PR TITLE
fix(platform): mirror the IMAP login into the mailbox From

### DIFF
--- a/configs/platform/system/connectors/imap-smtp/connector.yml
+++ b/configs/platform/system/connectors/imap-smtp/connector.yml
@@ -46,6 +46,14 @@ configFields:
     type: string
     default: Sent
     description: IMAP folder name used when reading sent mail.
+  # Mirrored from the basic-auth username on create/update (and healed on
+  # mailbox sync). Not shown in Settings — From and login are the same value.
+  - key: fromAddress
+    label: From address
+    type: string
+    description: >-
+      Mailbox address used as Conversations From / inbox source. Set
+      automatically from the login username.
 auth:
   - method: basic
 actions:

--- a/services/platform/app/features/settings/connectors/config-fields.test.tsx
+++ b/services/platform/app/features/settings/connectors/config-fields.test.tsx
@@ -171,4 +171,44 @@ describe('connectorConfigExtras', () => {
       '993',
     );
   });
+
+  it('hides fromAddress — it is mirrored from the IMAP username, not typed twice', () => {
+    const Fields = extras.Fields;
+    expect(Fields).not.toBeNull();
+    if (Fields === null) return;
+
+    render(
+      <Fields
+        vendor={{
+          summary: summary([
+            ...imapSmtpFields,
+            {
+              key: 'fromAddress',
+              label: 'From address',
+              type: 'string',
+              required: false,
+            },
+          ]),
+        }}
+        value={{}}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('textbox', { name: /^IMAP server/ })).toBeVisible();
+    expect(
+      screen.queryByRole('textbox', { name: /^From address/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('round-trips the hidden fromAddress it never renders', () => {
+    // Hidden ≠ dropped: `editArgs` replaces config as a whole, so the stored
+    // mirror has to survive an edit that only touches the visible fields.
+    const stored = { imapHost: 'mail.example.com', fromAddress: 'a@b.test' };
+    const value = extras.fromCredential({ config: stored });
+    expect(
+      extras.editArgs({ ...value, imapHost: 'other.example.com' }),
+    ).toEqual({
+      config: { imapHost: 'other.example.com', fromAddress: 'a@b.test' },
+    });
+  });
 });

--- a/services/platform/app/features/settings/connectors/config-fields.tsx
+++ b/services/platform/app/features/settings/connectors/config-fields.tsx
@@ -33,9 +33,15 @@ export interface ConnectorVendorLike {
  */
 export type ConnectorConfigValue = Record<string, string | number | boolean>;
 
-/** Declared fields for a vendor, or an empty list when it declares none. */
+/** Declared fields shown on the create/edit form. `fromAddress` is mirrored
+ * from the IMAP login username server-side and must not appear as a second
+ * input (From and username are the same value). */
+const HIDDEN_CONFIG_KEYS = new Set(['fromAddress']);
+
 function fieldsOf(summary: ConnectorSummary): ConnectorSummary['configFields'] {
-  return summary.configFields;
+  return summary.configFields.filter(
+    (field) => !HIDDEN_CONFIG_KEYS.has(field.key),
+  );
 }
 
 /** Whether a value counts as supplied. `false` is a real boolean answer, and 0

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -114,6 +114,7 @@ import type * as collab_subscriptions from "../collab/subscriptions.js";
 import type * as connector_credentials_actions from "../connector_credentials/actions.js";
 import type * as connector_credentials_auth_injection from "../connector_credentials/auth_injection.js";
 import type * as connector_credentials_connector_catalog from "../connector_credentials/connector_catalog.js";
+import type * as connector_credentials_imap_from_address from "../connector_credentials/imap_from_address.js";
 import type * as connector_credentials_masking from "../connector_credentials/masking.js";
 import type * as connector_credentials_mutations from "../connector_credentials/mutations.js";
 import type * as connector_credentials_queries from "../connector_credentials/queries.js";
@@ -1036,6 +1037,7 @@ declare const fullApi: ApiFromModules<{
   "connector_credentials/actions": typeof connector_credentials_actions;
   "connector_credentials/auth_injection": typeof connector_credentials_auth_injection;
   "connector_credentials/connector_catalog": typeof connector_credentials_connector_catalog;
+  "connector_credentials/imap_from_address": typeof connector_credentials_imap_from_address;
   "connector_credentials/masking": typeof connector_credentials_masking;
   "connector_credentials/mutations": typeof connector_credentials_mutations;
   "connector_credentials/queries": typeof connector_credentials_queries;

--- a/services/platform/convex/connector_credentials/actions.ts
+++ b/services/platform/convex/connector_credentials/actions.ts
@@ -36,6 +36,10 @@ import {
   type ConnectorSecretPayload,
 } from './auth_injection';
 import { loadConnectorDefinitions } from './connector_catalog';
+import {
+  storedImapFromAddress,
+  withImapFromAddress,
+} from './imap_from_address';
 import { maskPayload } from './masking';
 import { normalizeEndpointOrigin } from './mutations';
 import { connectorAuthMethodValidator } from './schema';
@@ -55,6 +59,7 @@ interface CredentialRow {
   name: string;
   encryptedData: EncryptedSecret;
   endpointUrl?: string;
+  config?: Record<string, string | number | boolean>;
   status: 'active' | 'disabled' | 'needs-reauth';
 }
 
@@ -380,7 +385,11 @@ export const createCredential = action({
       args.authMethod,
     );
     const endpointUrl = normalizeEndpointUrl(connector, args.endpointUrl);
-    const config = normalizeConfig(connector, args.config);
+    const config = withImapFromAddress(
+      args.connectorSlug,
+      normalizeConfig(connector, args.config),
+      args.username,
+    );
     const sealed = sealPayload(buildPayload(args.authMethod, args));
     const credentialId: Id<'connectorCredentials'> = await ctx.runMutation(
       internal.connector_credentials.mutations.insertCredentialInternal,
@@ -449,11 +458,25 @@ export const updateCredential = action({
           );
 
     // Config is replaced as a whole when supplied, re-validated against the
-    // connector's declared fields exactly like create.
-    const config =
+    // connector's declared fields exactly like create. IMAP From tracks the
+    // login username (same value) whenever we have a username in this write;
+    // with no username, the stored mirror is carried over rather than dropped —
+    // the field is server-owned and never rendered, so a caller replacing config
+    // has no way to resupply it.
+    const normalizedConfig =
       args.config === undefined
         ? undefined
         : normalizeConfig(requireConnector(row.connectorSlug), args.config);
+    const configPatch =
+      args.config !== undefined
+        ? withImapFromAddress(
+            row.connectorSlug,
+            normalizedConfig,
+            args.username ?? storedImapFromAddress(row),
+          )
+        : args.username !== undefined
+          ? withImapFromAddress(row.connectorSlug, row.config, args.username)
+          : undefined;
 
     const replacing = hasSecretInput(args);
     const sealed = replacing
@@ -475,7 +498,7 @@ export const updateCredential = action({
         credentialId: args.credentialId,
         ...(args.name !== undefined && { name: args.name }),
         ...(endpointUrl !== undefined && { endpointUrl }),
-        ...(config !== undefined && { config }),
+        ...(configPatch !== undefined && { config: configPatch }),
         ...(sealed !== undefined && { encryptedData: sealed.encryptedData }),
         ...previewPatch,
         ...(args.status !== undefined && { status: args.status }),

--- a/services/platform/convex/connector_credentials/imap_from_address.test.ts
+++ b/services/platform/convex/connector_credentials/imap_from_address.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  looksLikeEmailAddress,
+  storedImapFromAddress,
+  withImapFromAddress,
+} from './imap_from_address';
+
+describe('looksLikeEmailAddress', () => {
+  it('accepts a simple local@domain', () => {
+    expect(looksLikeEmailAddress('hello@acme.test')).toBe(true);
+    expect(looksLikeEmailAddress('  Hello@Acme.TEST  ')).toBe(true);
+  });
+
+  it('rejects non-emails', () => {
+    expect(looksLikeEmailAddress('')).toBe(false);
+    expect(looksLikeEmailAddress('resend')).toBe(false);
+    expect(looksLikeEmailAddress('@acme.test')).toBe(false);
+    expect(looksLikeEmailAddress('hello@')).toBe(false);
+    expect(looksLikeEmailAddress('hello @acme.test')).toBe(false);
+  });
+});
+
+describe('storedImapFromAddress', () => {
+  it('carries an existing mirror so a config replace cannot drop it', () => {
+    // The field is server-owned and hidden from the form, so an update that
+    // replaces config without a username has no way to resupply it.
+    expect(storedImapFromAddress({ config: { fromAddress: 'a@b.test' } })).toBe(
+      'a@b.test',
+    );
+  });
+
+  it('ignores an absent or unusable stored value', () => {
+    expect(storedImapFromAddress({})).toBeUndefined();
+    expect(storedImapFromAddress({ config: {} })).toBeUndefined();
+    expect(
+      storedImapFromAddress({ config: { fromAddress: 'resend' } }),
+    ).toBeUndefined();
+    expect(storedImapFromAddress({ config: { fromAddress: 25 } })).toBe(
+      undefined,
+    );
+  });
+});
+
+describe('withImapFromAddress', () => {
+  it('mirrors username into fromAddress for imap-smtp', () => {
+    expect(
+      withImapFromAddress(
+        'imap-smtp',
+        { imapHost: 'imap.example.com' },
+        'hello@acme.test',
+      ),
+    ).toEqual({
+      imapHost: 'imap.example.com',
+      fromAddress: 'hello@acme.test',
+    });
+  });
+
+  it('overwrites a drifted fromAddress so it stays equal to username', () => {
+    expect(
+      withImapFromAddress(
+        'imap-smtp',
+        { fromAddress: 'old@acme.test' },
+        'new@acme.test',
+      ),
+    ).toEqual({ fromAddress: 'new@acme.test' });
+  });
+
+  it('leaves other connectors and non-email usernames alone', () => {
+    expect(
+      withImapFromAddress('gmail', { fromAddress: 'x' }, 'a@b.com'),
+    ).toEqual({ fromAddress: 'x' });
+    expect(
+      withImapFromAddress('imap-smtp', { imapHost: 'imap.example.com' }, 'ops'),
+    ).toEqual({ imapHost: 'imap.example.com' });
+    expect(withImapFromAddress('imap-smtp', undefined, undefined)).toBe(
+      undefined,
+    );
+    expect(
+      withImapFromAddress('imap-smtp', undefined, 'hello@acme.test'),
+    ).toEqual({
+      fromAddress: 'hello@acme.test',
+    });
+  });
+});

--- a/services/platform/convex/connector_credentials/imap_from_address.ts
+++ b/services/platform/convex/connector_credentials/imap_from_address.ts
@@ -1,0 +1,39 @@
+/**
+ * IMAP/SMTP treats the mailbox login and the Conversations From as the same
+ * address. The login lives in encrypted basic-auth secrets; the Inbox header
+ * and compose UI read non-secret `config.fromAddress`. These helpers keep the
+ * public mirror in sync with the username.
+ */
+
+/** True when `value` looks like `local@domain` (non-empty local + domain). */
+export function looksLikeEmailAddress(value: string): boolean {
+  const trimmed = value.trim();
+  const at = trimmed.lastIndexOf('@');
+  return at > 0 && at < trimmed.length - 1 && !/\s/.test(trimmed);
+}
+
+/** The mirrored From already stored on a credential row, when it is usable. */
+export function storedImapFromAddress(row: {
+  config?: Record<string, string | number | boolean>;
+}): string | undefined {
+  const stored = row.config?.fromAddress;
+  return typeof stored === 'string' && looksLikeEmailAddress(stored)
+    ? stored
+    : undefined;
+}
+
+/**
+ * Merge `fromAddress` from the IMAP login username into credential config.
+ * Returns `config` unchanged when the connector is not imap-smtp or the
+ * username is not an email address.
+ */
+export function withImapFromAddress(
+  connectorSlug: string,
+  config: Record<string, string | number | boolean> | undefined,
+  username: string | undefined,
+): Record<string, string | number | boolean> | undefined {
+  if (connectorSlug !== 'imap-smtp') return config;
+  const from = username?.trim();
+  if (!from || !looksLikeEmailAddress(from)) return config;
+  return { ...config, fromAddress: from };
+}

--- a/services/platform/convex/conversations/ingest/resolve_connector_account_email.ts
+++ b/services/platform/convex/conversations/ingest/resolve_connector_account_email.ts
@@ -5,7 +5,12 @@ import type { ActionCtx } from '../../_generated/server';
 /**
  * Best-effort mailbox address for classifying synced mail direction.
  * Prefers a credential `config.fromAddress`, then an explicit fallback
- * (e.g. the IMAP login) the sync host already resolved.
+ * (e.g. the IMAP login the sync host already resolved).
+ *
+ * IMAP From healing (mirroring username → config.fromAddress) lives in
+ * `sync_mailbox.ts` — that file is `'use node'` and can decrypt credentials.
+ * This helper stays V8-safe so it never pulls Node APIs into the default
+ * runtime bundle.
  */
 export async function resolveConnectorAccountEmail(
   ctx: ActionCtx,

--- a/services/platform/convex/conversations/sync_mailbox.ts
+++ b/services/platform/convex/conversations/sync_mailbox.ts
@@ -21,6 +21,11 @@ import { isRecord } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { ActionCtx } from '../_generated/server';
+import {
+  looksLikeEmailAddress,
+  withImapFromAddress,
+} from '../connector_credentials/imap_from_address';
+import { resolveConnectorCredential } from '../connector_credentials/resolve_credential';
 import { createConversationFromEmail } from './ingest/create_conversation_from_email';
 import { createConversationFromSentEmail } from './ingest/create_conversation_from_sent_email';
 import { materializeEmailAttachments } from './ingest/materialize_email_attachments';
@@ -470,6 +475,68 @@ async function listActiveMailCredentials(
   )) as ActiveMailCredential[];
 }
 
+/**
+ * IMAP From and login are the same value. Mirror the basic-auth username into
+ * public `config.fromAddress` when missing so the Inbox Mail line can read it
+ * without decrypting on the client. Returns the username when it looks like an
+ * email, for use as `accountEmail` fallback on this sync pass.
+ *
+ * Backfill only — credentials written after the mirror landed carry it from
+ * create/update, so the caller skips this entirely when the public config
+ * already resolves an address (a decrypt per mailbox per pass otherwise).
+ */
+async function healImapFromAddress(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    connectorSlug: string;
+    credentialRef?: string;
+  },
+): Promise<string | undefined> {
+  if (args.connectorSlug !== 'imap-smtp') return undefined;
+  try {
+    const resolved = await resolveConnectorCredential(ctx, {
+      organizationId: args.organizationId,
+      connectorSlug: args.connectorSlug,
+      ...(args.credentialRef !== undefined && {
+        credentialRef: args.credentialRef,
+      }),
+    });
+    const username = resolved.secrets.username?.trim();
+    if (!username || !looksLikeEmailAddress(username)) return undefined;
+
+    const nextConfig = withImapFromAddress(
+      'imap-smtp',
+      resolved.config,
+      username,
+    );
+    const currentFrom =
+      typeof resolved.config.fromAddress === 'string'
+        ? resolved.config.fromAddress
+        : undefined;
+    if (nextConfig !== undefined && nextConfig.fromAddress !== currentFrom) {
+      await ctx.runMutation(
+        internal.connector_credentials.mutations.patchCredentialInternal,
+        {
+          organizationId: args.organizationId,
+          credentialId: resolved.credentialId,
+          config: nextConfig,
+        },
+      );
+      console.info(
+        `[syncMailbox] mirrored IMAP fromAddress from login for credential ${resolved.credentialId}`,
+      );
+    }
+    return username;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[syncMailbox] IMAP fromAddress heal failed (${args.credentialRef ?? 'default'}): ${message}`,
+    );
+    return undefined;
+  }
+}
+
 async function syncOneMailbox(
   ctx: ActionCtx,
   args: {
@@ -488,13 +555,25 @@ async function syncOneMailbox(
     outboundTip: number | null;
   }
 > {
-  const accountEmail = await resolveConnectorAccountEmail(ctx, {
+  // Public config first: it needs no decryption, and once the mirror exists the
+  // heal below has nothing to do — so the steady state costs one indexed read
+  // per pass instead of a credential decrypt per mailbox per pass.
+  const credentialRefArg =
+    args.credentialRef !== undefined
+      ? { credentialRef: args.credentialRef }
+      : {};
+  let accountEmail = await resolveConnectorAccountEmail(ctx, {
     organizationId: args.organizationId,
     connectorName: args.connectorSlug,
-    ...(args.credentialRef !== undefined && {
-      credentialRef: args.credentialRef,
-    }),
+    ...credentialRefArg,
   });
+  if (accountEmail === undefined) {
+    accountEmail = await healImapFromAddress(ctx, {
+      organizationId: args.organizationId,
+      connectorSlug: args.connectorSlug,
+      ...credentialRefArg,
+    });
+  }
 
   const inboundListed = await listFolder(ctx, {
     organizationId: args.organizationId,


### PR DESCRIPTION
## What

An IMAP/SMTP credential had no way to publish its own address. `config.fromAddress` was read in three places but was never a **declared** config field, and `normalizeConfig` rejects undeclared keys — so nothing could ever set it. Every consumer silently degraded:

- the Inbox header could not name the mailbox a thread belongs to (it fell back to `metadata.to`)
- `resolveConnectorAccountEmail` always fell through to its fallback, weakening sent-mail direction classification
- the compose sender never resolved, so `supportsDynamicSender` was dead code

SMTP already derives From from the login username (`lib/connectors/natives/imap-smtp.ts`), so From and Username are the same value by construction. This declares the field and mirrors it server-side.

## Changes

- `connector.yml`: declare `fromAddress`, documented as set automatically from the login.
- `imap_from_address.ts`: `withImapFromAddress` (mirror on write) and `storedImapFromAddress` (carry an existing mirror).
- `createCredential` / `updateCredential` mirror the username into config. A config replace that omits `fromAddress` **keeps** the stored value rather than dropping it — the field is server-owned and never rendered, so a programmatic caller has no way to resupply it.
- The credential form hides `fromAddress`: From and Username are one answer, and a second input only invites them to disagree. The value still round-trips through form state, so an edit cannot wipe it.
- `sync_mailbox.ts` heals credentials written before the mirror existed — but only when the public config resolves nothing, so the steady state costs one indexed read rather than a credential decrypt per mailbox per sync pass.

## Tests

- `imap_from_address.test.ts` covers the mirror, the overwrite-on-drift case, the non-email login, other connectors, and the carry-over helper.
- `config-fields.test.tsx` keeps its existing coverage (a field per declared setting; nothing at all when none are declared; the declared default stays a placeholder), adds the hidden-field assertion, and adds a round-trip guard proving the hidden value survives an edit.