### PR TITLE
fix(platform): stop reading a stranger's address as our mailbox

### DIFF
--- a/services/platform/app/features/conversations/components/conversation-header.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-header.test.tsx
@@ -31,9 +31,22 @@ vi.mock('./conversation-assignee-picker', () => ({
 }));
 
 // The From-source line reads email connectors via a Convex query; stub it so
-// the header renders without a live Convex client.
+// the header renders without a live Convex client. Override per-test via
+// `emailConnectorsMock`.
+const emailConnectorsMock = vi.hoisted(() => ({
+  current: [] as Array<{
+    slug: string;
+    title: string;
+    type: string;
+    fromAddress?: string;
+  }>,
+}));
+
 vi.mock('../hooks/queries', () => ({
-  useEmailConnectors: () => ({ emailConnectors: [], isLoading: false }),
+  useEmailConnectors: () => ({
+    emailConnectors: emailConnectorsMock.current,
+    isLoading: false,
+  }),
 }));
 
 vi.mock('../hooks/mutations', () => ({
@@ -91,6 +104,7 @@ function makeConversation(overrides = {}) {
 
 afterEach(() => {
   cleanup();
+  emailConnectorsMock.current = [];
   vi.clearAllMocks();
 });
 
@@ -231,6 +245,134 @@ describe('ConversationHeader', () => {
     );
 
     expect(screen.queryByLabelText('Back')).not.toBeInTheDocument();
+  });
+
+  it('shows the connected mailbox From, not a different @gmail.com To', () => {
+    emailConnectorsMock.current = [
+      {
+        slug: 'gmail',
+        title: 'Gmail',
+        type: 'oauth',
+        fromAddress: 'desk@gmail.com',
+      },
+    ];
+    render(
+      <ConversationHeader
+        conversation={makeConversation({
+          connectorName: 'gmail',
+          metadata: {
+            to: [{ address: 'stranger@gmail.com' }],
+          },
+          contact: {
+            id: 'contact-1',
+            name: 'Stranger',
+            email: 'stranger@gmail.com',
+            source: 'api',
+            locale: 'en',
+            created_at: new Date().toISOString(),
+          },
+        })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(screen.getByText('desk@gmail.com')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Inbox: stranger@gmail.com'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the IMAP login From when config.fromAddress mirrors username', () => {
+    emailConnectorsMock.current = [
+      {
+        slug: 'imap-smtp',
+        title: 'IMAP / SMTP Mailbox',
+        type: 'imap_smtp',
+        fromAddress: 'hello@acme.test',
+      },
+    ];
+    render(
+      <ConversationHeader
+        conversation={makeConversation({
+          connectorName: 'imap-smtp',
+          metadata: {
+            to: [{ address: 'hello@acme.test' }],
+          },
+          contact: {
+            id: 'contact-1',
+            name: 'Jordan',
+            email: 'jordan@customer.test',
+            source: 'api',
+            locale: 'en',
+            created_at: new Date().toISOString(),
+          },
+        })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(screen.getByLabelText('Inbox: hello@acme.test')).toBeInTheDocument();
+  });
+
+  it('reads the sender, not the To, as the mailbox on a sent-folder thread', () => {
+    // Sent-folder mail synced back: `direction: outbound`, `metadata.to` is the
+    // CONTACT. gmail/outlook expose no configured From, so reading `to` blindly
+    // is what showed an unconnected personal address as the inbox source.
+    emailConnectorsMock.current = [
+      { slug: 'gmail', title: 'Gmail', type: 'oauth' },
+    ];
+    render(
+      <ConversationHeader
+        conversation={makeConversation({
+          connectorName: 'gmail',
+          direction: 'outbound' as const,
+          metadata: {
+            from: [{ address: 'desk@gmail.com' }],
+            to: [{ address: 'stranger@gmail.com' }],
+          },
+          contact: {
+            id: 'contact-1',
+            name: undefined,
+            email: 'stranger@gmail.com',
+            source: 'api',
+            locale: 'en',
+            created_at: new Date().toISOString(),
+          },
+        })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(screen.getByLabelText('Inbox: desk@gmail.com')).toBeInTheDocument();
+    // The contact's address stays the primary line only — never repeated as the
+    // mailbox it was sent to.
+    expect(screen.getAllByText('stranger@gmail.com')).toHaveLength(1);
+  });
+
+  it('still names the mailbox on inbound mail when the connector exposes no From', () => {
+    // The multi-mailbox fan-out makes this the signal that says WHICH inbox a
+    // thread arrived at; gmail/outlook have no `config.fromAddress` to fall back
+    // on, so the inbound envelope's recipient has to carry it.
+    emailConnectorsMock.current = [
+      { slug: 'gmail', title: 'Gmail', type: 'oauth' },
+    ];
+    render(
+      <ConversationHeader
+        conversation={makeConversation({
+          connectorName: 'gmail',
+          direction: 'inbound' as const,
+          metadata: {
+            from: [{ address: 'jordan@customer.test' }],
+            to: [{ address: 'support@acme.test' }],
+          },
+        })}
+        organizationId="org-1"
+      />,
+    );
+
+    expect(
+      screen.getByLabelText('Inbox: support@acme.test'),
+    ).toBeInTheDocument();
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/features/conversations/components/conversation-header.tsx
+++ b/services/platform/app/features/conversations/components/conversation-header.tsx
@@ -23,7 +23,7 @@ import {
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { toast } from '@/app/hooks/use-toast';
 import {
-  inboundRecipientAddress,
+  mailboxSideAddress,
   resolveReplyFrom,
 } from '@/convex/conversations/reply_from';
 import { toId } from '@/convex/lib/type_cast_helpers';
@@ -59,21 +59,25 @@ export function ConversationHeader({
   const pendingContactInfo = useRef(false);
   const { formatRelative } = useFormatDate();
 
-  // The org's actual "From" on THIS thread — the address the contact wrote to
-  // (or the chosen compose sender, both captured in `metadata.to`), domain-
-  // guarded against the inbox default. Reuses the send path's reply-from logic
-  // so what's shown matches what a reply actually goes out as, not the
-  // mailbox's generic default. Falls back to the inbox default, then nothing.
+  // Which of the org's mailboxes THIS thread belongs to — read from the side of
+  // the envelope that is ours (`mailboxSideAddress`: the recipient on inbound
+  // mail, the sender on sent-folder mail we synced back, where `metadata.to` is
+  // the contact). Reading `to` blindly is what made an unconnected personal
+  // address look like the inbox source on outbound threads. With a configured
+  // From (imap_smtp mirrors the login) `resolveReplyFrom` keeps the mailbox
+  // address unless the thread ran on a genuine same-domain alias; gmail/outlook
+  // expose no From, so the envelope's own address stands on its own.
   const { emailConnectors } = useEmailConnectors(organizationId);
   const inbox = conversation.connectorName
     ? emailConnectors.find((i) => i.slug === conversation.connectorName)
     : undefined;
-  const inboundTo = inboundRecipientAddress(
+  const ourAddress = mailboxSideAddress(
     isRecord(conversation.metadata) ? conversation.metadata : undefined,
+    conversation.direction,
   );
   const conversationFrom = inbox?.fromAddress
-    ? resolveReplyFrom(inboundTo, inbox.fromAddress)
-    : (inboundTo ?? inbox?.fromAddress);
+    ? resolveReplyFrom(ourAddress, inbox.fromAddress)
+    : ourAddress;
   const inboxLabel = inbox?.title;
 
   const { mutate: closeConversation, isPending: isClosing } =

--- a/services/platform/app/features/conversations/lib/email-connectors.test.ts
+++ b/services/platform/app/features/conversations/lib/email-connectors.test.ts
@@ -88,12 +88,27 @@ describe('supportsDynamicSender', () => {
     ).toBe(false);
     expect(supportsDynamicSender(null)).toBe(false);
   });
+  it('is false for a mailbox on a consumer host — its local parts are strangers', () => {
+    // The mirrored IMAP login can be a personal Gmail; the server-side alias
+    // guard refuses another @gmail.com sender, so the picker must not offer one.
+    expect(
+      supportsDynamicSender({
+        slug: 'imap_smtp',
+        title: 'Mailbox',
+        type: 'imap_smtp',
+        fromAddress: 'desk@gmail.com',
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('isSenderAddressValid', () => {
   it('accepts any local part on the verified domain (case-insensitive)', () => {
     expect(isSenderAddressValid('sales@acme.test', 'acme.test')).toBe(true);
     expect(isSenderAddressValid('Sales@ACME.test', 'acme.test')).toBe(true);
+  });
+  it('rejects an alias on a consumer host even when the domain matches', () => {
+    expect(isSenderAddressValid('sales@gmail.com', 'gmail.com')).toBe(false);
   });
   it('rejects a different domain, empty local part, or whitespace', () => {
     expect(isSenderAddressValid('sales@evil.test', 'acme.test')).toBe(false);

--- a/services/platform/app/features/conversations/lib/email-connectors.ts
+++ b/services/platform/app/features/conversations/lib/email-connectors.ts
@@ -7,7 +7,13 @@
  * These pure helpers shape a resolved connector into a sender option and
  * validate a dynamic sender address, kept React-free so they're unit-testable
  * without rendering.
+ *
+ * The consumer-domain list is NOT restated here: `isPublicEmailDomain` is the
+ * send path's own guard, imported so the UI can never accept a sender the server
+ * would refuse.
  */
+
+import { isPublicEmailDomain } from '@/convex/conversations/reply_from';
 
 /** A connected, email-capable inbox the compose dialog can send through. */
 export interface EmailConnectorOption {
@@ -58,16 +64,17 @@ export function resolvedEmailOption(
  * for imap_smtp over a domain-verified SMTP provider (Resend), where any address
  * on the verified domain is valid — and only when we know that domain (a
  * configured `fromAddress`). gmail/outlook send from the fixed OAuth account, so
- * Tale can't override their sender.
+ * Tale can't override their sender; neither can a mailbox on a consumer host
+ * (`gmail.com`, …), where a different local part is a different person and the
+ * server-side guard (`sameMailboxAliasDomain`) refuses the alias.
  */
 export function supportsDynamicSender(
   connector: EmailConnectorOption | null | undefined,
 ): boolean {
-  return (
-    connector?.type === 'imap_smtp' &&
-    typeof connector.fromAddress === 'string' &&
-    emailDomain(connector.fromAddress) !== ''
-  );
+  if (connector?.type !== 'imap_smtp') return false;
+  if (typeof connector.fromAddress !== 'string') return false;
+  const domain = emailDomain(connector.fromAddress);
+  return domain !== '' && !isPublicEmailDomain(domain);
 }
 
 /** Lowercased domain part of an email address, or '' when it has none. */
@@ -79,8 +86,10 @@ export function emailDomain(address: string): string {
 /**
  * A candidate sender is valid when it is `localpart@domain` on the given
  * verified `domain`, with a non-empty local part and no whitespace. Mirrors the
- * server-side domain-equality guard (`resolveReplyFrom`), so the UI blocks a
- * mismatch the backend would otherwise silently drop back to the configured From.
+ * server-side guard (`resolveReplyFrom` → `sameMailboxAliasDomain`), so the UI
+ * blocks a mismatch the backend would otherwise silently drop back to the
+ * configured From — including a same-domain alias on a consumer host, which is
+ * another person's mailbox rather than an alias of ours.
  */
 export function isSenderAddressValid(
   candidate: string,
@@ -90,5 +99,7 @@ export function isSenderAddressValid(
   if (trimmed === '' || /\s/.test(trimmed)) return false;
   const at = trimmed.lastIndexOf('@');
   if (at <= 0) return false;
-  return emailDomain(trimmed) === domain.toLowerCase();
+  const candidateDomain = emailDomain(trimmed);
+  if (isPublicEmailDomain(candidateDomain)) return false;
+  return candidateDomain === domain.toLowerCase();
 }

--- a/services/platform/convex/conversations/ingest/create_conversation_from_sent_email.test.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_sent_email.test.ts
@@ -65,6 +65,30 @@ describe('createConversationFromSentEmail', () => {
     expect(ctx.runMutation).toHaveBeenCalled();
   });
 
+  it('does not treat a different @gmail.com From as a reply-as alias of the account', async () => {
+    const { ctx } = createMockCtx();
+
+    // From is another person's Gmail; account is desk@. Without a public-domain
+    // guard this would have been accepted as a same-domain alias and the
+    // customer would be taken from To — inventing a conversation for mail that
+    // is not from this mailbox.
+    const result = await createConversationFromSentEmail(ctx, {
+      organizationId: ORG,
+      emails: [
+        makeSentEmail({
+          from: [{ address: 'stranger@gmail.com' }],
+          to: [{ address: 'someone@example.com' }],
+          messageId: '<not-ours@mail.gmail.com>',
+        }),
+      ],
+      accountEmail: 'desk@gmail.com',
+      connectorName: 'gmail',
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.skippedCount).toBe(1);
+  });
+
   it('skips when customer cannot be determined', async () => {
     const { ctx } = createMockCtx();
 

--- a/services/platform/convex/conversations/ingest/create_conversation_from_sent_email.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_sent_email.ts
@@ -2,7 +2,7 @@ import { internal } from '../../_generated/api';
 import type { Id } from '../../_generated/dataModel';
 import type { ActionCtx } from '../../_generated/server';
 import { createDebugLog } from '../../lib/debug_log';
-import { emailDomain } from '../reply_from';
+import { emailDomain, sameMailboxAliasDomain } from '../reply_from';
 import { addMessageToConversation } from './add_message_to_conversation';
 import { buildConversationMetadata } from './build_conversation_metadata';
 import { buildInitialMessage } from './build_initial_message';
@@ -45,7 +45,6 @@ function registerInBatch(
 function identifyCustomerAndAgent(
   email: EmailType,
   explicitAgent: string | undefined,
-  allAddresses: Set<string>,
 ): { customerEmail?: string; accountEmailLower?: string } {
   let accountEmailLower = explicitAgent;
   let customerEmail: string | undefined;
@@ -64,14 +63,13 @@ function identifyCustomerAndAgent(
           .filter((addr): addr is string => !!addr) ?? [];
 
       // Sent-folder outbound with reply-as From (billing@) while account is hello@.
-      if (fromAddr && agentDomain && emailDomain(fromAddr) === agentDomain) {
+      // Public domains (gmail.com, …) are not org aliases — a different
+      // @gmail.com From is another person, not this mailbox. Leave customer
+      // unset so the message is skipped rather than attributed to a stranger.
+      if (fromAddr && sameMailboxAliasDomain(fromAddr, accountEmailLower)) {
         customerEmail =
           toAddrs.find((addr) => emailDomain(addr) !== agentDomain) ??
           toAddrs[0];
-      } else {
-        customerEmail = Array.from(allAddresses).find(
-          (addr) => addr !== accountEmailLower,
-        );
       }
     }
   } else if (email.to?.length === 1) {
@@ -120,16 +118,6 @@ export async function createConversationFromSentEmail(
   debugLog('create_from_sent_email Processing', emailsArray.length, 'emails');
 
   const explicitAgent = params.accountEmail?.toLowerCase();
-  const allAddresses = new Set<string>();
-  for (const email of emailsArray) {
-    if (email.from?.[0]?.address) {
-      allAddresses.add(email.from[0].address.toLowerCase());
-    }
-    if (email.to?.[0]?.address) {
-      allAddresses.add(email.to[0].address.toLowerCase());
-    }
-  }
-
   const inBatchMap = new Map<string, Id<'conversations'>>();
   const customerEmailByConversation = new Map<string, string>();
   const conversationIds = new Set<Id<'conversations'>>();
@@ -204,11 +192,7 @@ export async function createConversationFromSentEmail(
       inBatchMap,
     );
 
-    const { customerEmail } = identifyCustomerAndAgent(
-      email,
-      explicitAgent,
-      allAddresses,
-    );
+    const { customerEmail } = identifyCustomerAndAgent(email, explicitAgent);
 
     if (!customerEmail) {
       debugLog(

--- a/services/platform/convex/conversations/reply_from.test.ts
+++ b/services/platform/convex/conversations/reply_from.test.ts
@@ -3,8 +3,11 @@ import { describe, it, expect } from 'vitest';
 import {
   emailDomain,
   inboundRecipientAddress,
+  isPublicEmailDomain,
+  mailboxSideAddress,
   notificationFromAddress,
   resolveReplyFrom,
+  sameMailboxAliasDomain,
 } from './reply_from';
 
 describe('emailDomain', () => {
@@ -46,6 +49,73 @@ describe('inboundRecipientAddress', () => {
   });
 });
 
+describe('mailboxSideAddress', () => {
+  it('reads the recipient on inbound mail', () => {
+    expect(
+      mailboxSideAddress(
+        {
+          from: [{ address: 'jordan@customer.test' }],
+          to: [{ address: 'support@acme.test' }],
+        },
+        'inbound',
+      ),
+    ).toBe('support@acme.test');
+  });
+
+  it('reads the sender on sent-folder mail, where To is the contact', () => {
+    expect(
+      mailboxSideAddress(
+        {
+          from: [{ address: 'support@acme.test' }],
+          to: [{ address: 'jordan@customer.test' }],
+        },
+        'outbound',
+      ),
+    ).toBe('support@acme.test');
+  });
+
+  it('falls back to To for a compose thread, which stamps only the sender there', () => {
+    expect(
+      mailboxSideAddress(
+        { to: [{ address: 'billing@acme.test' }] },
+        'outbound',
+      ),
+    ).toBe('billing@acme.test');
+  });
+
+  it('treats an unknown direction as inbound and tolerates junk metadata', () => {
+    expect(
+      mailboxSideAddress({ to: [{ address: 'support@acme.test' }] }, undefined),
+    ).toBe('support@acme.test');
+    expect(mailboxSideAddress(undefined, 'outbound')).toBeUndefined();
+    expect(mailboxSideAddress({ from: 'nope' }, 'outbound')).toBeUndefined();
+    expect(
+      mailboxSideAddress({ from: [{ name: 'no address' }] }, 'outbound'),
+    ).toBeUndefined();
+  });
+});
+
+describe('isPublicEmailDomain / sameMailboxAliasDomain', () => {
+  it('flags consumer hosts and allows org domains', () => {
+    expect(isPublicEmailDomain('gmail.com')).toBe(true);
+    expect(isPublicEmailDomain('Gmail.COM')).toBe(true);
+    expect(isPublicEmailDomain('support.example.com')).toBe(false);
+  });
+
+  it('allows aliasing only on non-public matching domains', () => {
+    expect(
+      sameMailboxAliasDomain(
+        'billing@support.example.com',
+        'hello@support.example.com',
+      ),
+    ).toBe(true);
+    expect(sameMailboxAliasDomain('stranger@gmail.com', 'desk@gmail.com')).toBe(
+      false,
+    );
+    expect(sameMailboxAliasDomain('a@example.com', 'b@other.com')).toBe(false);
+  });
+});
+
 describe('resolveReplyFrom', () => {
   it('uses the inbound address when it shares the sender domain', () => {
     expect(
@@ -81,6 +151,20 @@ describe('resolveReplyFrom', () => {
     // e.g. Resend split creds with no From Address set → smtp.user = "resend"
     expect(resolveReplyFrom('billing@support.example.com', 'resend')).toBe(
       'resend',
+    );
+  });
+
+  it('keeps the connected Gmail address when To is a different @gmail.com', () => {
+    // Regression: domain equality alone treated every Gmail To as a From alias,
+    // so the Inbox Mail icon showed unconnected personal addresses.
+    expect(resolveReplyFrom('stranger@gmail.com', 'desk@gmail.com')).toBe(
+      'desk@gmail.com',
+    );
+  });
+
+  it('still uses the inbound address when it equals the connected mailbox', () => {
+    expect(resolveReplyFrom('Desk@Gmail.com', 'desk@gmail.com')).toBe(
+      'Desk@Gmail.com',
     );
   });
 });

--- a/services/platform/convex/conversations/reply_from.ts
+++ b/services/platform/convex/conversations/reply_from.ts
@@ -8,10 +8,55 @@
 
 import { isRecord } from '../../lib/utils/type-utils';
 
+/**
+ * Consumer / free-mail domains where every local-part is a different person.
+ * Same-domain From aliasing is only for org-verified domains (support@ /
+ * billing@ on one Resend domain) — treating `gmail.com` as that lets a
+ * connected mailbox claim any @gmail.com To as its own From.
+ */
+const PUBLIC_EMAIL_DOMAINS = new Set([
+  'aol.com',
+  'gmail.com',
+  'gmx.com',
+  'gmx.net',
+  'googlemail.com',
+  'hotmail.com',
+  'icloud.com',
+  'live.com',
+  'mac.com',
+  'mail.com',
+  'me.com',
+  'msn.com',
+  'outlook.com',
+  'proton.me',
+  'protonmail.com',
+  'qq.com',
+  'yahoo.com',
+  'yandex.com',
+  'ymail.com',
+  'zoho.com',
+]);
+
 /** Lowercased domain part of an email address, or '' when it has none. */
 export function emailDomain(address: string): string {
   const at = address.lastIndexOf('@');
   return at === -1 ? '' : address.slice(at + 1).toLowerCase();
+}
+
+/** True for consumer mail hosts where local-parts are not org aliases. */
+export function isPublicEmailDomain(domain: string): boolean {
+  return PUBLIC_EMAIL_DOMAINS.has(domain.toLowerCase());
+}
+
+/**
+ * Whether two addresses may share a mailbox via domain aliasing (billing@ /
+ * support@ on one verified domain). Exact address equality is handled by the
+ * caller — this is only the same-domain, different-local-part case.
+ */
+export function sameMailboxAliasDomain(a: string, b: string): boolean {
+  const domainA = emailDomain(a);
+  const domainB = emailDomain(b);
+  return domainA !== '' && domainA === domainB && !isPublicEmailDomain(domainA);
 }
 
 /**
@@ -32,16 +77,44 @@ export function inboundRecipientAddress(
 }
 
 /**
+ * The address on OUR side of the thread, as the conversation metadata records
+ * it. Inbound mail: the recipient the contact wrote to (`metadata.to`).
+ * Sent-folder mail synced back from the mailbox (`direction: 'outbound'` with a
+ * `metadata.from`, both written by ingest from the real envelope): the sender,
+ * because `to` there is the CONTACT, not us. Compose stamps only `metadata.to`
+ * (the chosen sender), so a `from`-less outbound thread still reads from `to`.
+ */
+export function mailboxSideAddress(
+  metadata: Record<string, unknown> | undefined,
+  direction: 'inbound' | 'outbound' | undefined,
+): string | undefined {
+  if (direction === 'outbound') {
+    const from = metadata?.from;
+    const first: unknown = Array.isArray(from) ? from[0] : undefined;
+    if (isRecord(first) && typeof first.address === 'string') {
+      return first.address;
+    }
+  }
+  return inboundRecipientAddress(metadata);
+}
+
+/**
  * Choose the reply From: the address the customer wrote to (`inboundFrom`) when
- * it shares the sender's domain, otherwise the configured `fallbackFrom`. The
- * domain guard avoids an unverified From the SMTP provider (e.g. Resend, which
- * is verified per domain) would reject.
+ * it is the same address or a same-domain alias on a non-public domain;
+ * otherwise the configured `fallbackFrom`. The domain guard avoids an
+ * unverified From the SMTP provider (e.g. Resend, verified per domain) would
+ * reject — and avoids treating every `@gmail.com` To as a From for a connected
+ * Gmail mailbox.
  */
 export function resolveReplyFrom(
   inboundFrom: string | undefined,
   fallbackFrom: string,
 ): string {
-  return inboundFrom && emailDomain(inboundFrom) === emailDomain(fallbackFrom)
+  if (!inboundFrom) return fallbackFrom;
+  if (inboundFrom.toLowerCase() === fallbackFrom.toLowerCase()) {
+    return inboundFrom;
+  }
+  return sameMailboxAliasDomain(inboundFrom, fallbackFrom)
     ? inboundFrom
     : fallbackFrom;
 }


### PR DESCRIPTION
## What

Two separate bugs made someone else's address look like the org's own mailbox.

**1. Domain equality is not aliasing.** `resolveReplyFrom` accepted any address sharing the sender's domain as an alias of the mailbox. That is right for an org domain — `support@` and `billing@` on one verified domain are one inbox — and wrong for `gmail.com`, where every local part is a different person. A mailbox connected on a consumer host claimed any address on that host as its own.

**2. The Inbox line read the wrong side of the envelope.** `metadata.to` is ours on inbound mail, but on sent-folder mail synced back it is the **contact** — so outbound threads displayed the contact as the mailbox they arrived at.

## Changes

- `reply_from.ts`: `isPublicEmailDomain` + `sameMailboxAliasDomain`. Aliasing needs a shared **non-public** domain; an exact address match still passes.
- `mailboxSideAddress(metadata, direction)` picks the side that is ours: the recipient on inbound mail, the sender on sent-folder mail, and `to` for a compose thread (which stamps only the chosen sender there).
- The header uses it, so the mailbox stays visible on **gmail/outlook** threads, which expose no configured From to fall back on. That signal matters more now that mail sync fans out over every connected mailbox (#2916).
- `create_conversation_from_sent_email.ts`: the reply-as branch no longer accepts a public-domain From, and the loose "any other address in the batch" fallback is gone — a message we cannot attribute is skipped rather than attached to a stranger.
- The compose validator imports the same guard instead of restating the list, so `supportsDynamicSender` / `isSenderAddressValid` can no longer accept a sender the server would silently replace.

## Tests

- `reply_from.test.ts`: the domain guard, exact-match passthrough, and every `mailboxSideAddress` branch including junk metadata.
- `conversation-header.test.tsx`: a sent-folder thread names the sender (not the contact) as the mailbox, and an inbound thread with no configured From still names the mailbox. Both verified red against the previous logic.
- `create_conversation_from_sent_email.test.ts`: a different `@gmail.com` From is skipped rather than treated as a reply-as alias.
- `email-connectors.test.ts`: a consumer-host mailbox offers no dynamic sender, and a matching-domain alias on such a host is invalid.

## Note

Test fixtures use neutral addresses; the real personal addresses this was reproduced with are not in the diff.