### PR TITLE
fix(ui): keep a running run's badge spinning

### DIFF
--- a/services/platform/app/features/automations/components/run-status-badge.test.tsx
+++ b/services/platform/app/features/automations/components/run-status-badge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { NodeStatusIcon, RunBadge, RunStatusBadge } from './run-status-badge';
+
+// `Badge` hardcodes the className on the icon it renders, so a running run can
+// only spin if the icon component spins itself. A regression here is silent —
+// the badge still renders, it just freezes — hence an explicit class assertion.
+
+describe('run status icons', () => {
+  it('spins the running run badge, and respects reduced motion', () => {
+    const { container } = render(<RunBadge status="running" />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveClass('animate-spin');
+    expect(svg).toHaveClass('motion-reduce:animate-none');
+  });
+
+  it('leaves a settled run badge still', () => {
+    const { container } = render(<RunBadge status="success" />);
+    expect(container.querySelector('svg')).not.toHaveClass('animate-spin');
+  });
+
+  it('spins a running node badge but leaves settled ones still', () => {
+    const running = render(<RunStatusBadge status="running" />);
+    expect(running.container.querySelector('svg')).toHaveClass('animate-spin');
+    running.unmount();
+
+    const settled = render(<RunStatusBadge status="ok" />);
+    expect(settled.container.querySelector('svg')).not.toHaveClass(
+      'animate-spin',
+    );
+  });
+
+  it('spins the icon-only running node in the step timeline', () => {
+    render(<NodeStatusIcon status="running" />);
+    // The status word stays readable to a screen reader — that label IS the icon.
+    const icon = screen.getByRole('img', { name: 'Running now' });
+    expect(icon).toHaveClass('animate-spin');
+    expect(icon).toHaveClass('motion-reduce:animate-none');
+  });
+
+  it('leaves a settled icon-only node still', () => {
+    render(<NodeStatusIcon status="ok" />);
+    expect(screen.getByRole('img', { name: 'Ran' })).not.toHaveClass(
+      'animate-spin',
+    );
+  });
+});

--- a/services/platform/app/features/automations/components/run-status-badge.tsx
+++ b/services/platform/app/features/automations/components/run-status-badge.tsx
@@ -9,8 +9,8 @@ import {
   Loader2,
   MinusCircle,
   XCircle,
-  type LucideIcon,
 } from 'lucide-react';
+import type * as React from 'react';
 
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -18,6 +18,20 @@ import { cn } from '@/lib/utils/cn';
 import type { NodeRunStatus, RunStatus } from '../lib/run-view';
 
 type BadgeVariant = 'green' | 'destructive' | 'yellow' | 'blue' | 'slate';
+type StatusIcon = React.ComponentType<React.ComponentProps<typeof Loader2>>;
+
+/** `Badge` hardcodes the icon className, so spinning must live on the icon. */
+function RunningIcon({
+  className,
+  ...props
+}: React.ComponentProps<typeof Loader2>) {
+  return (
+    <Loader2
+      {...props}
+      className={cn(className, 'animate-spin motion-reduce:animate-none')}
+    />
+  );
+}
 
 /**
  * How a run reads at a glance. Colour is never the only signal: each state
@@ -26,10 +40,10 @@ type BadgeVariant = 'green' | 'destructive' | 'yellow' | 'blue' | 'slate';
  */
 const RUN_STATUS_STYLE: Record<
   RunStatus,
-  { variant: BadgeVariant; icon: LucideIcon }
+  { variant: BadgeVariant; icon: StatusIcon }
 > = {
   queued: { variant: 'slate', icon: Clock },
-  running: { variant: 'blue', icon: Loader2 },
+  running: { variant: 'blue', icon: RunningIcon },
   waiting: { variant: 'yellow', icon: Clock },
   success: { variant: 'green', icon: CheckCircle2 },
   failed: { variant: 'destructive', icon: XCircle },
@@ -54,14 +68,14 @@ export function RunBadge({ status }: { status: RunStatus }) {
  */
 const NODE_STATUS_STYLE: Record<
   NodeRunStatus,
-  { variant: BadgeVariant; icon: LucideIcon }
+  { variant: BadgeVariant; icon: StatusIcon }
 > = {
   ok: { variant: 'green', icon: CheckCircle2 },
   skipped: { variant: 'slate', icon: MinusCircle },
   error: { variant: 'destructive', icon: XCircle },
   not_run: { variant: 'slate', icon: CircleDashed },
   pending: { variant: 'blue', icon: Clock },
-  running: { variant: 'blue', icon: Loader2 },
+  running: { variant: 'blue', icon: RunningIcon },
 };
 
 export function RunStatusBadge({ status }: { status: NodeRunStatus }) {
@@ -105,7 +119,6 @@ export function NodeStatusIcon({
       className={cn(
         'size-4 shrink-0',
         NODE_STATUS_ICON_COLOR[variant],
-        status === 'running' && 'animate-spin',
         className,
       )}
     />


### PR DESCRIPTION
## What

`Badge` renders its icon with a hardcoded `className`, so any class passed alongside the icon never reached it. The run badge relied on that, which meant a **running** run showed a motionless spinner — at a glance indistinguishable from a settled one.

## Changes

- A small `RunningIcon` wrapper spins `Loader2` from the inside, where the class survives `Badge`'s hardcoding. Both the run-status and node-status maps point at it.
- `NodeStatusIcon` drops its own `status === 'running' && 'animate-spin'` branch, now that the icon carries its own motion — one source of truth instead of two.
- Added `motion-reduce:animate-none`, so the spinner respects prefers-reduced-motion.

## Tests

New `run-status-badge.test.tsx` asserts the running badge, the running node badge and the icon-only running node all carry `animate-spin` + `motion-reduce:animate-none`, and that settled states carry neither. Verified red against `Loader2` in the status maps.