### PR TITLE
fix(platform): restore a green main after the preview polish

### DIFF
--- a/services/platform/app/features/chat/components/chat-surface.test.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.test.tsx
@@ -234,9 +234,7 @@ describe('ChatSurface when the model listing answers and is empty', () => {
       screen.getByRole('heading', { name: 'No AI provider connected yet' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'Connect a provider under Settings → AI providers to start chatting.',
-      ),
+      screen.getByText('Connect an AI provider to start chatting.'),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: "Chat isn't connected yet" }),

--- a/services/platform/app/features/documents/components/document-preview-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.tsx
@@ -279,7 +279,7 @@ export function DocumentPreviewDialog({
                   mimeType={doc?.mimeType}
                   className="size-8 shrink-0"
                 />
-                <Stack gap={0.5} className="min-w-0">
+                <Stack gap={1} className="min-w-0">
                   <Text
                     as="span"
                     className="text-foreground truncate text-base leading-tight font-semibold tracking-tight"
@@ -331,7 +331,7 @@ export function DocumentPreviewDialog({
                   mimeType={doc?.mimeType}
                   className="size-8 shrink-0"
                 />
-                <Stack gap={0.5} className="min-w-0">
+                <Stack gap={1} className="min-w-0">
                   <Text
                     as="span"
                     className="text-foreground truncate text-base leading-tight font-semibold tracking-tight"

--- a/services/platform/messages/de-CH.yml
+++ b/services/platform/messages/de-CH.yml
@@ -26,8 +26,6 @@ documents:
     closePreview: Vorschau schliessen
     truncatedNotice: Diese Datei ist zu gross für eine vollständige Vorschau —
       angezeigt wird der Anfang. Lade die Datei herunter, um alles zu sehen.
-    sidebar:
-      size: Grösse
   upload:
     fileTooLarge: Datei zu gross
     fileSizeExceeded: 'Datei {name} überschreitet das Limit von {maxSize} MB.

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1909,7 +1909,6 @@ documents:
       visit: Link öffnen
     sidebar:
       document: Dokument
-      size: Größe
       source: Quelle
       ragStatus: RAG-Status
       teams: Teams

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1844,7 +1844,6 @@ documents:
       visit: Visit link
     sidebar:
       document: Document
-      size: Size
       source: Source
       ragStatus: RAG status
       teams: Teams

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1927,7 +1927,6 @@ documents:
       visit: Ouvrir le lien
     sidebar:
       document: Document
-      size: Taille
       source: Source
       ragStatus: Statut RAG
       teams: Équipes


### PR DESCRIPTION
`main` is red at `aa34391fc` (#2928) on three checks. All three are consequences of that PR's polish + copy pass; its intent is preserved here.

## Type check

The filename/size stack asks for `gap={0.5}`:

```tsx
<Stack gap={0.5} className="min-w-0">
```

`@tale/ui`'s `gapScale` is `0, 1, 2, 3, 4, 5, 6, 8, 10, 12` — there is no half step, and the scale's own doc comment treats the set as deliberate (it already discourages `5`, `10`, `12` for new code). These were the only two `gap={0.5}` call sites in the repo. Changed to `gap={1}`, the nearest defined value, visually equivalent for a two-line stack.

An alternative would be to add `0.5` to the scale, but that widens the design system's spacing vocabulary for one call site — left for whoever owns the token set to decide.

## Unit — orphaned i18n key

The same change moved the file size out of a labelled sidebar row and into a bare caption under the filename:

```tsx
{doc?.size != null && <Text …>{formatBytes(doc.size, locale)}</Text>}
```

That orphaned the `documents.preview.sidebar.size` label, which the i18n usage test fails on. Removed from `en`, `de`, `fr`, and from the `de-CH` override — where it was the only entry, so the now-empty `sidebar:` block goes too.

## UI — assertion left behind by the copy pass

`chat.empty.descriptionAdmin` was reworded:

> ~~Connect a provider under Settings → AI providers to start chatting.~~
> Connect an AI provider to start chatting.

`chat-surface.test.tsx` still asserted the old sentence. Updated to the shipped copy. This was the only test in the suite that hardcoded a string the copy pass changed (CI reported 1 failed, 422 passed).

## Verification

`tsc --noEmit` clean, and `vitest --project server lib/i18n` passes 48/48 (locale parity + orphan-key scan). The chat assertion is checked against `en.yml` directly — heading, body, and link text all match the shipped values.

Unblocks #2929, #2930 and #2931, which inherit all three failures.