### PR TITLE
fix(platform): unbreak main after the userMessage convention

### DIFF
--- a/services/platform/convex/products/validate_product_name.test.ts
+++ b/services/platform/convex/products/validate_product_name.test.ts
@@ -8,9 +8,17 @@ import {
 
 /**
  * Assert that `fn` throws a `ConvexError` whose `data.code` is `'validation'`
- * (so the REST wrapper maps it to a 400) and whose `data.message` matches.
+ * (so the REST wrapper maps it to a 400), whose `data.message` matches, and
+ * which carries the `userMessage` the toast layer is allowed to render
+ * verbatim (see `convexUserMessage`). Asserting `userMessage` here rather than
+ * ignoring it keeps the two apart: `message` stays the developer-facing string
+ * the REST envelope reports, `userMessage` is the copy a user actually reads.
  */
-function expectValidationError(fn: () => unknown, message: string): void {
+function expectValidationError(
+  fn: () => unknown,
+  message: string,
+  userMessage: string,
+): void {
   let thrown: unknown;
   try {
     fn();
@@ -19,8 +27,14 @@ function expectValidationError(fn: () => unknown, message: string): void {
   }
   expect(thrown).toBeInstanceOf(ConvexError);
   expect(
-    (thrown as ConvexError<{ code: string; message: string }>).data,
-  ).toEqual({ code: 'validation', message });
+    (
+      thrown as ConvexError<{
+        code: string;
+        message: string;
+        userMessage: string;
+      }>
+    ).data,
+  ).toEqual({ code: 'validation', message, userMessage });
 }
 
 describe('validateProductName', () => {
@@ -33,6 +47,7 @@ describe('validateProductName', () => {
     expectValidationError(
       () => validateProductName(''),
       'Product name is required',
+      'Product name is required.',
     );
   });
 
@@ -40,10 +55,12 @@ describe('validateProductName', () => {
     expectValidationError(
       () => validateProductName('   '),
       'Product name is required',
+      'Product name is required.',
     );
     expectValidationError(
       () => validateProductName('\t\n '),
       'Product name is required',
+      'Product name is required.',
     );
   });
 
@@ -57,6 +74,7 @@ describe('validateProductName', () => {
     expectValidationError(
       () => validateProductName(name),
       `Product name exceeds ${PRODUCT_NAME_MAX_LENGTH} characters`,
+      `Product name exceeds ${PRODUCT_NAME_MAX_LENGTH} characters.`,
     );
   });
 

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -4432,8 +4432,6 @@ skills:
       stattdessen „Ordner wählen" darunter.
     singleFileOnly: Lege eine einzelne .zip-Datei ab, nicht mehrere Dateien.
     chooseFolder: Ordner wählen
-    chooseFolderHelp: Wählt einen Skill-Ordner mit SKILL.md im Stammverzeichnis
-      und zippt ihn für dich.
     bundleFiles: Bundle-Dateien
     fileCount: '{count, plural, one {# Datei} other {# Dateien}}'
     frontmatter: Frontmatter
@@ -4492,7 +4490,6 @@ skills:
     creating: Erstelle...
     created: Skill erstellt
     exists: Ein Skill mit diesem Namen existiert bereits.
-    createFailed: Skill konnte nicht erstellt werden
   visibility:
     label: Sichtbarkeit
     org: Organisation
@@ -4674,13 +4671,10 @@ settings:
     editMember: Mitglied bearbeiten
     removeMember: Mitglied entfernen
     memberUpdated: Mitglied aktualisiert
-    memberUpdateFailed: Mitglied konnte nicht aktualisiert werden
     memberRemoved: Mitglied entfernt
-    memberRemoveFailed: Mitglied konnte nicht entfernt werden
     twoFactorResetSuccess:
       Zwei-Faktor zurückgesetzt — das Mitglied muss sich bei
       der nächsten Anmeldung neu einrichten
-    twoFactorResetFailed: Zwei-Faktor-Authentifizierung konnte nicht zurückgesetzt werden
     emailCannotChange: E-Mail kann nicht geändert werden
     cannotChangeOwnRole: Du kannst deine eigene Rolle nicht ändern
     updatePassword: Passwort aktualisieren
@@ -4691,7 +4685,6 @@ settings:
     transferOwnership: Inhaberschaft übertragen
     transferOwnershipConfirmation: Inhaberschaft an {name} übertragen? Du wirst zum Admin herabgestuft.
     ownershipTransferred: Inhaberschaft übertragen
-    ownershipTransferFailed: Inhaberschaft konnte nicht übertragen werden
   teams:
     title: Teams
     entityLabel: Teams
@@ -4845,7 +4838,6 @@ settings:
       endpointHelpGeneric: Der https-Ursprung der Instanz, zu der dieser Eintrag gehört.
   enterpriseSso:
     connected: Die Anmeldung ist aktiviert.
-    copied: In die Zwischenablage kopiert
     copy: Kopieren
     protocolLabel: Protokoll
     protocolHelp:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -4278,8 +4278,6 @@ skills:
       below instead.
     singleFileOnly: Drop a single .zip bundle, not multiple files.
     chooseFolder: Choose folder
-    chooseFolderHelp: Picks a skill folder with SKILL.md at its root and zips
-      it for you.
     bundleFiles: Bundle files
     fileCount: '{count, plural, one {# file} other {# files}}'
     frontmatter: Frontmatter
@@ -4335,7 +4333,6 @@ skills:
     creating: Creating...
     created: Skill created
     exists: A skill with this name already exists.
-    createFailed: Couldn't create the skill
   visibility:
     label: Visibility
     org: Organization
@@ -4747,11 +4744,8 @@ settings:
     editMember: Edit member
     removeMember: Remove member
     memberUpdated: Member updated
-    memberUpdateFailed: Failed to update member
     memberRemoved: Member removed
-    memberRemoveFailed: Failed to remove member
     twoFactorResetSuccess: Two-factor reset — the member must enrol again on next sign-in
-    twoFactorResetFailed: Failed to reset two-factor authentication
     emailCannotChange: Email cannot be changed
     cannotChangeOwnRole: You cannot change your own role
     updatePassword: Update password
@@ -4762,7 +4756,6 @@ settings:
     transferOwnership: Transfer ownership
     transferOwnershipConfirmation: Transfer ownership to {name}? You'll be demoted to admin.
     ownershipTransferred: Ownership transferred
-    ownershipTransferFailed: Failed to transfer ownership
   teams:
     title: Teams
     entityLabel: teams
@@ -4912,7 +4905,6 @@ settings:
       endpointHelpGeneric: The https origin of the instance this credential belongs to.
   enterpriseSso:
     connected: Sign-in is enabled.
-    copied: Copied to clipboard
     copy: Copy
     protocolLabel: Protocol
     protocolHelp: Choose how users sign in. OIDC endpoints are discovered automatically.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -4520,8 +4520,6 @@ skills:
       utilise « Choisir un dossier » en dessous.
     singleFileOnly: Dépose un seul fichier .zip, pas plusieurs fichiers.
     chooseFolder: Choisir un dossier
-    chooseFolderHelp: Sélectionne un dossier de skill avec SKILL.md à la
-      racine et le zippe pour toi.
     bundleFiles: Fichiers du bundle
     fileCount: '{count, plural, one {# fichier} other {# fichiers}}'
     frontmatter: Frontmatter
@@ -4579,7 +4577,6 @@ skills:
     creating: Création...
     created: Skill créé
     exists: Un skill avec ce nom existe déjà.
-    createFailed: Impossible de créer le skill
   visibility:
     label: Visibilité
     org: Organisation
@@ -4760,12 +4757,9 @@ settings:
     editMember: Modifier le membre
     removeMember: Retirer le membre
     memberUpdated: Membre mis à jour avec succès
-    memberUpdateFailed: Échec de la mise à jour du membre
     memberRemoved: Membre retiré avec succès
-    memberRemoveFailed: Échec du retrait du membre
     twoFactorResetSuccess: Double facteur réinitialisé — le membre devra se
       réinscrire lors de sa prochaine connexion
-    twoFactorResetFailed: Échec de la réinitialisation de l'authentification à double facteur
     emailCannotChange: L'email ne peut pas être modifié
     cannotChangeOwnRole: Tu ne peux pas modifier ton propre rôle
     updatePassword: Mettre à jour le mot de passe
@@ -4782,7 +4776,6 @@ settings:
       Es-tu sûr de vouloir transférer la propriété à
       {name} ? Tu seras rétrogradé au rôle d'administrateur.
     ownershipTransferred: Propriété transférée avec succès
-    ownershipTransferFailed: Échec du transfert de propriété
   teams:
     title: Équipes
     entityLabel: équipes
@@ -4943,7 +4936,6 @@ settings:
       endpointHelpGeneric: L'origine https de l'instance à laquelle appartiennent ces identifiants.
   enterpriseSso:
     connected: La connexion est activée.
-    copied: Copié dans le presse-papiers
     copy: Copier
     protocolLabel: Protocole
     protocolHelp:


### PR DESCRIPTION
`#2935` landed with five failing tests on `main`. Verified against a pristine checkout of `origin/main`, not against local WIP.

### `validateProductName` — 3 failures

The source now attaches `userMessage` alongside `message`, but the tests assert the error data with `toEqual`, so the extra field failed every validation case:

```
- { code: 'validation', message: 'Product name is required' }
+ { code: 'validation', message: 'Product name is required', userMessage: 'Product name is required.' }
```

The helper now takes the expected `userMessage` explicitly rather than loosening the assertion to a subset match. Keeping both pinned is the point of the convention: `message` stays the developer-facing string the REST envelope reports, `userMessage` is the copy a user actually reads.

### 7 orphaned translation keys — 1 failure

`messages.test.ts` fails because the same PR replaced the UI that referenced them:

| Key | Why it is orphaned |
|---|---|
| `settings.organization.memberRemoveFailed` | local toast deleted; `useConvexMutation` now owns error toasts |
| `settings.organization.memberUpdateFailed` | same |
| `settings.organization.ownershipTransferFailed` | same |
| `settings.organization.twoFactorResetFailed` | same |
| `settings.enterpriseSso.copied` | replaced by inline pill feedback |
| `skills.createDialog.createFailed` | local toast deleted |
| `skills.upload.chooseFolderHelp` | caption removed from the upload step |

Each was confirmed dead by reading the call site before deleting, not just by trusting the scanner. Removed from `en`, `de` and `fr` (`de-CH` does not override any of them).

### Verification

`bun run check` green: 74,442 tests, typecheck, lint, format, `migrations:check`.