### PR TITLE
fix(platform): name the row-action column for screen readers

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -696,3 +696,55 @@ describe('DataTable column alignment', () => {
     expect(statusCell).toHaveClass('text-right');
   });
 });
+
+describe('DataTable row-action column accessibility', () => {
+  // Every entity table declares its row-action column with an empty header
+  // string. Without a label that leaves a `<th>` with no discernible text —
+  // a WCAG AA failure (axe `empty-table-header`) that no single table can fix
+  // for the others, so the header lives here.
+  const actionColumns: ColumnDef<TestRow>[] = [
+    { accessorKey: 'name', header: 'Name' },
+    {
+      id: 'actions',
+      header: '',
+      meta: { isAction: true },
+      cell: () => <button type="button">Edit</button>,
+    },
+  ];
+
+  it('gives the empty row-action header an accessible name', () => {
+    render(
+      <DataTable
+        columns={actionColumns}
+        data={sampleRows}
+        approxRowCount={3}
+      />,
+    );
+
+    const headers = screen.getAllByRole('columnheader');
+    const actionHeader = headers[headers.length - 1];
+    // Real copy, not the key — this also pins that `common.aria.rowActions`
+    // actually resolves rather than leaking the key into the a11y tree.
+    expect(actionHeader).toHaveAccessibleName('Row actions');
+  });
+
+  it('leaves a column that declares its own header text alone', () => {
+    const labelled: ColumnDef<TestRow>[] = [
+      { accessorKey: 'name', header: 'Name' },
+      {
+        id: 'actions',
+        header: 'Manage',
+        meta: { isAction: true },
+        cell: () => <button type="button">Edit</button>,
+      },
+    ];
+
+    render(
+      <DataTable columns={labelled} data={sampleRows} approxRowCount={3} />,
+    );
+
+    const headers = screen.getAllByRole('columnheader');
+    const actionHeader = headers[headers.length - 1];
+    expect(actionHeader).toHaveAccessibleName('Manage');
+  });
+});

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -796,6 +796,13 @@ export function DataTable<TData, TValue = unknown>({
                         headerCell.column.columnDef.header,
                         headerCell.getContext(),
                       );
+                  // Every entity table declares its row-action column with an
+                  // empty header string, which leaves a `<th>` with no
+                  // discernible text — a WCAG AA failure (axe
+                  // `empty-table-header`). The label belongs here rather than
+                  // in each table's column definition so all of them get it
+                  // and none can forget it.
+                  const needsActionsLabel = meta?.isAction === true && !content;
                   return (
                     <TableHead
                       key={headerCell.id}
@@ -808,6 +815,9 @@ export function DataTable<TData, TValue = unknown>({
                       )}
                       style={cellWidthStyle(id, size, meta?.isAction)}
                     >
+                      {needsActionsLabel ? (
+                        <span className="sr-only">{t('aria.rowActions')}</span>
+                      ) : null}
                       {utility ? utilityCellBox(id, size, content) : content}
                     </TableHead>
                   );

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1389,6 +1389,7 @@ common:
       {} other {: {error}}}'
   aria:
     close: Schließen
+    rowActions: Aktionen für die Zeile
     resizePanel: Panelgröße ändern
     hidePassword: Passwort ausblenden
     showPassword: Passwort anzeigen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1347,6 +1347,7 @@ common:
     schemaValidationFailed: 'Schema validation failed{error, select, empty {} other {: {error}}}'
   aria:
     close: Close
+    rowActions: Row actions
     resizePanel: Resize panel
     hidePassword: Hide password
     showPassword: Show password

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1399,6 +1399,7 @@ common:
       {} other { : {error}}}'
   aria:
     close: Fermer
+    rowActions: Actions de la ligne
     resizePanel: Redimensionner le panneau
     hidePassword: Masquer le mot de passe
     showPassword: Afficher le mot de passe


### PR DESCRIPTION
## The defect

Every entity table declares its row-action column as:

```ts
{ id: 'actions', header: '', meta: { isAction: true }, ... }
```

That renders a `<th>` with no discernible text. Axe reports `empty-table-header`; it fails WCAG 2.1 AA. A screen-reader user moving across the header row hears nothing where the actions column sits.

Nine tables carry the pattern today — contacts, documents, products, websites, teams, api-keys, knowledge-entries, members, credentials, skills, projects.

## The fix

The `sr-only` label goes in the shared `DataTable` header renderer, not in each column definition. One place, so all nine get it and a tenth cannot forget it. A column that declares its own header text is left alone.

Adds `common.aria.rowActions` to `en`, `de` and `fr`.

## Guard

Two cases in `data-table.test.tsx`: the empty header gets an accessible name, and an explicitly-labelled action column keeps its own. The first asserts the resolved copy (`'Row actions'`) rather than the key, so it also pins that the key actually resolves instead of leaking into the a11y tree.

Mutation-tested — stubbing the label out fails the first case and only that case.

## Note on CI

This branch is cut from `origin/main`, which is currently red from #2935 (3 × `validate_product_name`, 1 × `messages.test.ts`). Those are fixed by #2936 and are unrelated to this change. This branch adds no failures of its own: 74,451 pass, typecheck / lint / format clean.