### PR TITLE
feat(platform): make "assigned to me" visible at a glance

### DIFF
--- a/services/platform/app/features/tasks/components/assignee-avatar.test.tsx
+++ b/services/platform/app/features/tasks/components/assignee-avatar.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { AssigneeAvatar } from './assignee-avatar';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AssigneeAvatar', () => {
+  it('uses the muted chip for another human', () => {
+    render(
+      <AssigneeAvatar
+        assigneeType="user"
+        assigneeId="user-2"
+        name="Jordan Lee"
+      />,
+    );
+    const chip = screen.getByLabelText('Jordan Lee');
+    expect(chip.className).toContain('bg-muted');
+    expect(chip.className).not.toContain('bg-primary');
+  });
+
+  it('uses the filled primary chip when the assignee is the current user', () => {
+    render(
+      <AssigneeAvatar
+        assigneeType="user"
+        assigneeId="user-1"
+        name="Alex"
+        isCurrentUser
+      />,
+    );
+    const chip = screen.getByLabelText('Alex');
+    expect(chip.className).toContain('bg-primary');
+    expect(chip.className).toContain('text-primary-foreground');
+    expect(chip.className).not.toContain('bg-muted');
+  });
+
+  it('keeps the soft primary tint for agents even if isCurrentUser is set', () => {
+    render(
+      <AssigneeAvatar
+        assigneeType="agent"
+        assigneeId="research-bot"
+        name="Research Bot"
+        isCurrentUser
+      />,
+    );
+    const chip = screen.getByLabelText('Research Bot');
+    expect(chip.className).toContain('bg-primary/10');
+    expect(chip.className).not.toContain('text-primary-foreground');
+  });
+});

--- a/services/platform/app/features/tasks/components/assignee-avatar.tsx
+++ b/services/platform/app/features/tasks/components/assignee-avatar.tsx
@@ -20,11 +20,16 @@ function initialsOf(name: string): string {
  * their initials when a resolved `name` is passed (via
  * {@link useActorDirectory}), else a User glyph. The tooltip prefers the
  * resolved name over the raw id.
+ *
+ * When `isCurrentUser` is set for a human assignee, the chip uses the filled
+ * primary surface so "assigned to me" is glanceable and does not share the
+ * muted chip that every other human uses (agents keep the soft primary tint).
  */
 export function AssigneeAvatar({
   assigneeType,
   assigneeId,
   name,
+  isCurrentUser = false,
   size = 'sm',
   className,
 }: {
@@ -32,6 +37,8 @@ export function AssigneeAvatar({
   assigneeId?: string;
   /** Resolved display name; enables initials + a human-readable tooltip. */
   name?: string;
+  /** True when this avatar is the signed-in viewer (self-assign / "you"). */
+  isCurrentUser?: boolean;
   size?: 'sm' | 'md';
   className?: string;
 }) {
@@ -58,6 +65,12 @@ export function AssigneeAvatar({
   const label = name ?? assigneeId;
   const isAgent = assigneeType === 'agent';
   const isApp = assigneeType === 'app';
+  const surface =
+    isAgent || isApp
+      ? 'bg-primary/10 text-primary'
+      : isCurrentUser
+        ? 'bg-primary text-primary-foreground'
+        : 'bg-muted text-foreground';
 
   return (
     <span
@@ -66,9 +79,7 @@ export function AssigneeAvatar({
       className={cn(
         dimension,
         'inline-flex items-center justify-center rounded-full',
-        isAgent || isApp
-          ? 'bg-primary/10 text-primary'
-          : 'bg-muted text-foreground',
+        surface,
         className,
       )}
     >

--- a/services/platform/app/features/tasks/components/assignee-picker.tsx
+++ b/services/platform/app/features/tasks/components/assignee-picker.tsx
@@ -164,11 +164,18 @@ export function AssigneePicker({
 
   const label = resolved?.name ?? t('assignee.unassigned');
 
+  const assignedToCurrentUser =
+    assigneeType === 'user' &&
+    !!assigneeId &&
+    !!currentUserId &&
+    assigneeId === currentUserId;
+
   const avatar = (
     <AssigneeAvatar
       assigneeType={assigneeType}
       assigneeId={assigneeId}
       name={resolved?.name}
+      isCurrentUser={assignedToCurrentUser}
       size={size}
     />
   );
@@ -417,6 +424,9 @@ export function AssigneePicker({
             assigneeType={parsed.type}
             assigneeId={parsed.id}
             name={opt.label}
+            isCurrentUser={
+              parsed.type === 'user' && parsed.id === currentUserId
+            }
           />
         );
       }}

--- a/services/platform/app/features/tasks/components/reviewer-picker.tsx
+++ b/services/platform/app/features/tasks/components/reviewer-picker.tsx
@@ -82,11 +82,17 @@ export function ReviewerPicker({
     }));
   }, [assignableMembers, currentUserId, t]);
 
+  const reviewerIsCurrentUser =
+    reviewerUserId !== undefined &&
+    !!currentUserId &&
+    reviewerUserId === currentUserId;
+
   const avatar = (
     <AssigneeAvatar
       assigneeType={reviewerUserId !== undefined ? 'user' : undefined}
       assigneeId={reviewerUserId}
       name={resolved?.name}
+      isCurrentUser={reviewerIsCurrentUser}
     />
   );
 
@@ -142,6 +148,7 @@ export function ReviewerPicker({
               assigneeType="user"
               assigneeId={opt.value}
               name={opt.label}
+              isCurrentUser={opt.value === currentUserId}
             />
           )}
           footer={

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -1332,6 +1332,10 @@ function EditTaskBody({
                                 assigneeType={subAssignee.type}
                                 assigneeId={subAssignee.id}
                                 name={subAssignee.name}
+                                isCurrentUser={
+                                  subAssignee.type === 'user' &&
+                                  subAssignee.id === me?.userId
+                                }
                               />
                             )}
                           </button>


### PR DESCRIPTION
> Picked up from in-flight work in the shared checkout and finished to green; split out of the date-notification work (#2943), which it was tangled with but unrelated to.

Every human assignee shared one muted avatar chip, so spotting your own tasks on a board meant reading names one by one.

The signed-in viewer now gets the filled primary surface:

```
agent / automation  ->  bg-primary/10 text-primary      (soft tint, unchanged)
you                 ->  bg-primary   text-primary-fg    (filled — new)
anyone else         ->  bg-muted     text-foreground    (unchanged)
```

Keeping agents on the soft tint matters: the three actor classes (you / other human / agent) stay distinguishable rather than collapsing into two.

`AssigneeAvatar` takes an `isCurrentUser` flag and derives the surface from it. Passed from the four render sites: the task modal, the assignee picker (both trigger and options), the reviewer picker, and subtask rows.

## Verification

3 cases in `assignee-avatar.test.tsx`. Typecheck, lint, format clean.

Note: the client test fails to load in a worktree with symlinked `node_modules` (Vite `fs.allow` rejects a `@fontsource` path) — verified passing in a checkout with real `node_modules`. CI is unaffected.

CI will also show 4 failures inherited from `origin/main` (#2935, fixed by #2936).