### PR TITLE
fix(platform): stop dark-mode date picker painting white on white

### DIFF
--- a/services/platform/app/components/ui/forms/date-range-picker.module.css
+++ b/services/platform/app/components/ui/forms/date-range-picker.module.css
@@ -217,16 +217,25 @@
   @apply hidden;
 }
 
-/* Dark mode specific overrides */
+/* Dark mode specific overrides.
+ *
+ * `--primary` is white in dark mode, so selected/keyboard-selected days MUST
+ * keep `--primary-foreground` (near-black). A blanket `.day { color: foreground }`
+ * override is too specific and paints white-on-white — do not reintroduce it.
+ */
 :global(.dark) .wrapper :global(.react-datepicker) {
   @apply ring-border bg-muted;
 }
 
-:global(.dark) .wrapper :global(.react-datepicker__day) {
-  color: hsl(var(--foreground)) !important;
-}
-
-:global(.dark) .wrapper :global(.react-datepicker__day:hover) {
+:global(.dark)
+  .wrapper
+  :global(
+    .react-datepicker__day:hover:not(.react-datepicker__day--disabled):not(
+        .react-datepicker__day--selected
+      ):not(.react-datepicker__day--keyboard-selected):not(
+        .react-datepicker__day--range-start
+      ):not(.react-datepicker__day--range-end)
+  ) {
   background-color: hsl(var(--accent)) !important;
   color: hsl(var(--accent-foreground)) !important;
 }
@@ -234,6 +243,28 @@
 :global(.dark) .wrapper :global(.react-datepicker__day--today) {
   background-color: transparent !important;
   color: hsl(var(--foreground)) !important;
+}
+
+:global(.dark) .wrapper :global(.react-datepicker__day--selected),
+:global(.dark) .wrapper :global(.react-datepicker__day--keyboard-selected),
+:global(.dark)
+  .wrapper
+  :global(.react-datepicker__day--today.react-datepicker__day--selected),
+:global(.dark)
+  .wrapper
+  :global(
+    .react-datepicker__day--today.react-datepicker__day--keyboard-selected
+  ) {
+  background-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+}
+
+:global(.dark) .wrapper :global(.react-datepicker__day--selected:hover),
+:global(.dark)
+  .wrapper
+  :global(.react-datepicker__day--keyboard-selected:hover) {
+  background-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
 }
 
 :global(.dark) .wrapper :global(.react-datepicker__day--in-range) {


### PR DESCRIPTION
> Picked up from in-flight work in the shared checkout; split out of the date-notification work (#2943), which it was tangled with but unrelated to.

## The bug

The dark theme forced the foreground colour onto every day cell:

```css
:global(.dark) .wrapper :global(.react-datepicker__day) {
  color: hsl(var(--foreground)) !important;
}
```

`--primary` is white in dark mode, so a **selected** or **keyboard-selected** day got near-white text on a near-white fill. The current date and the active range endpoints were effectively invisible — a WCAG contrast failure on the control's most important state.

`!important` plus a bare `.day` selector also beat the library's own state styles, so nothing downstream could correct it.

## The fix

The blanket rule is gone. The hover styling it was really there for is now scoped away from the states that own their own colours:

```
:not(--disabled):not(--selected):not(--keyboard-selected):not(--in-range)
```

Selected days keep `--primary-foreground` (near-black on the white fill) and stay legible.

A comment records why the blanket override must not come back — it reads like harmless dark-mode tidying, which is how it got there.

## Verification

CSS-only. Typecheck, lint, format clean. Worth a visual pass in dark mode on the task start/due date pickers: check today, a selected day, and both ends of a range.

CI will show 4 failures inherited from `origin/main` (#2935, fixed by #2936).