### PR TITLE
chore(platform): drop the Files column from the projects list

### DIFF
--- a/services/platform/app/features/projects/components/projects-table.test.tsx
+++ b/services/platform/app/features/projects/components/projects-table.test.tsx
@@ -47,7 +47,6 @@ vi.mock('./project-create-dialog', () => ({
 const overview = vi.hoisted(() => ({
   projects: [] as unknown[],
   overdueTruncated: false,
-  filesTruncated: false,
   isLoading: false,
 }));
 
@@ -65,7 +64,6 @@ interface RowOverrides {
   doneTaskCount?: number;
   overdueTaskCount?: number;
   projectAgentCount?: number;
-  fileCount?: number;
   teamId?: string;
 }
 
@@ -92,17 +90,15 @@ function row(overrides: RowOverrides = {}) {
     doneTaskCount: overrides.doneTaskCount ?? 0,
     overdueTaskCount: overrides.overdueTaskCount ?? 0,
     projectAgentCount: overrides.projectAgentCount ?? 0,
-    fileCount: overrides.fileCount ?? 0,
   };
 }
 
 function renderTable(
   rows: ReturnType<typeof row>[],
-  flags: { overdueTruncated?: boolean; filesTruncated?: boolean } = {},
+  flags: { overdueTruncated?: boolean } = {},
 ) {
   overview.projects = rows;
   overview.overdueTruncated = flags.overdueTruncated ?? false;
-  overview.filesTruncated = flags.filesTruncated ?? false;
   overview.isLoading = false;
   return render(<ProjectsTable organizationId="test-org-id" />);
 }
@@ -159,22 +155,19 @@ describe('ProjectsTable', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders agent and file counts with accessible labels', () => {
-    renderTable([row({ projectAgentCount: 2, fileCount: 18 })]);
+  it('renders the agent count with an accessible label', () => {
+    renderTable([row({ projectAgentCount: 2 })]);
 
     expect(screen.getByText('projects.list.agentsA11y')).toBeInTheDocument();
-    expect(screen.getByText('projects.list.filesA11y')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('18')).toBeInTheDocument();
   });
 
-  it('marks a capped file count as a lower bound', () => {
-    renderTable([row({ fileCount: 2000 })], { filesTruncated: true });
+  it('reads as empty rather than 0 when a project has no agents', () => {
+    renderTable([row({ projectAgentCount: 0 })]);
 
-    // `countTruncated` renders "{count}+" — the mock substitutes the param.
     expect(
-      screen.getByText('projects.list.countTruncated'),
-    ).toBeInTheDocument();
+      screen.queryByText('projects.list.agentsA11y'),
+    ).not.toBeInTheDocument();
   });
 
   it('distinguishes org-wide from team-scoped sharing without spending a text column', () => {
@@ -199,7 +192,6 @@ describe('ProjectsTable', () => {
         doneTaskCount: 24,
         overdueTaskCount: 2,
         projectAgentCount: 2,
-        fileCount: 18,
       }),
     ]);
 

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -29,28 +29,15 @@ import { ProjectRowActions } from './project-row-actions';
 
 /**
  * A plain count cell: an em-dash at zero so an empty project reads as empty
- * rather than as a stack of noisy zeros, and a `{n}+` form when the query's
- * scan hit its cap and the number is a lower bound.
+ * rather than as a stack of noisy zeros.
  */
-function CountCell({
-  count,
-  label,
-  truncated = false,
-  truncatedLabel,
-}: {
-  count: number;
-  label: string;
-  truncated?: boolean;
-  truncatedLabel?: string;
-}) {
+function CountCell({ count, label }: { count: number; label: string }) {
   if (count === 0) {
     return <span className="text-muted-foreground text-xs">—</span>;
   }
   return (
     <span className="text-xs tabular-nums">
-      <span aria-hidden>
-        {truncated && truncatedLabel ? truncatedLabel : count}
-      </span>
+      <span aria-hidden>{count}</span>
       <span className="sr-only">{label}</span>
     </span>
   );
@@ -81,8 +68,10 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
   const [includeArchived, setIncludeArchived] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-  const { projects, isLoading, overdueTruncated, filesTruncated } =
-    useProjectsOverview(organizationId, { includeArchived });
+  const { projects, isLoading, overdueTruncated } = useProjectsOverview(
+    organizationId,
+    { includeArchived },
+  );
   const { mutateAsync: deleteProject } = useDeleteProject();
 
   const handleClearSelection = useCallback(() => {
@@ -261,22 +250,6 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         ),
       },
       {
-        id: 'files',
-        header: t('list.columnFiles'),
-        size: 80,
-        enableSorting: false,
-        cell: ({ row }) => (
-          <CountCell
-            count={row.original.fileCount}
-            label={t('list.filesA11y', { count: row.original.fileCount })}
-            truncated={filesTruncated}
-            truncatedLabel={t('list.countTruncated', {
-              count: row.original.fileCount,
-            })}
-          />
-        ),
-      },
-      {
         accessorKey: 'sharing',
         header: t('list.columnSharing'),
         size: 88,
@@ -334,7 +307,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         enableSorting: false,
       },
     ],
-    [t, locale, organizationId, overdueTruncated, filesTruncated],
+    [t, locale, organizationId, overdueTruncated],
   );
 
   const list = useListPage<ProjectOverviewRow>({

--- a/services/platform/app/features/projects/hooks/queries.ts
+++ b/services/platform/app/features/projects/hooks/queries.ts
@@ -103,10 +103,9 @@ export function useProjectsOverview(
   );
   return {
     projects: data?.projects ?? [],
-    // Global to each scan, so a truncated walk makes every row's number in
-    // that column a lower bound.
+    // Global to the scan, so a truncated walk makes every row's overdue
+    // number a lower bound.
     overdueTruncated: data?.overdueTruncated ?? false,
-    filesTruncated: data?.filesTruncated ?? false,
     isLoading,
   };
 }

--- a/services/platform/convex/projects/list_projects_overview.test.ts
+++ b/services/platform/convex/projects/list_projects_overview.test.ts
@@ -100,29 +100,6 @@ async function seedTask(
   );
 }
 
-let docSeq = 0;
-async function seedDocument(
-  t: T,
-  opts: {
-    organizationId?: string;
-    projectId?: Id<'projects'>;
-    lifecycleStatus?: 'trashed' | 'expired';
-  } = {},
-): Promise<void> {
-  docSeq += 1;
-  await t.run((ctx) =>
-    ctx.db.insert('documents', {
-      organizationId: opts.organizationId ?? ORG,
-      title: `Doc ${docSeq}`,
-      createdBy: USER,
-      ...(opts.projectId ? { projectId: opts.projectId } : {}),
-      ...(opts.lifecycleStatus
-        ? { lifecycleStatus: opts.lifecycleStatus }
-        : {}),
-    }),
-  );
-}
-
 function run(t: T, args: { asOf?: number; includeArchived?: boolean } = {}) {
   return t
     .withIdentity(IDENTITY)
@@ -150,7 +127,6 @@ describe('listProjectsOverview', () => {
       projectAgentCount: 2,
     });
     expect(result.overdueTruncated).toBe(false);
-    expect(result.filesTruncated).toBe(false);
   });
 
   it('defaults missing counters to 0 rather than leaking undefined', async () => {
@@ -174,7 +150,6 @@ describe('listProjectsOverview', () => {
       doneTaskCount: 0,
       projectAgentCount: 0,
       overdueTaskCount: 0,
-      fileCount: 0,
     });
   });
 
@@ -226,10 +201,10 @@ describe('listProjectsOverview', () => {
     expect(byName).toEqual({ A: 2, B: 1 });
   });
 
-  it('ignores another organization overdue tasks and documents', async () => {
+  it('ignores another organization overdue tasks', async () => {
     const t = convexTest(schema, modules);
     await seedMember(t, ORG);
-    const mine = await seedProject(t, { name: 'Mine' });
+    await seedProject(t, { name: 'Mine' });
     const theirs = await seedProject(t, {
       organizationId: OTHER_ORG,
       name: 'Theirs',
@@ -238,8 +213,6 @@ describe('listProjectsOverview', () => {
       organizationId: OTHER_ORG,
       dueDate: NOW - DAY,
     });
-    await seedDocument(t, { organizationId: OTHER_ORG, projectId: theirs });
-    await seedDocument(t, { projectId: mine });
 
     const result = await run(t);
 
@@ -247,32 +220,9 @@ describe('listProjectsOverview', () => {
     expect(result.projects[0]).toMatchObject({
       name: 'Mine',
       overdueTaskCount: 0,
-      fileCount: 1,
     });
   });
 
-  it('counts project files and excludes trashed and expired documents', async () => {
-    const t = convexTest(schema, modules);
-    await seedMember(t, ORG);
-    const projectId = await seedProject(t);
-
-    await seedDocument(t, { projectId });
-    await seedDocument(t, { projectId });
-    // The bug the retired getProjectStats had: these used to be counted.
-    await seedDocument(t, { projectId, lifecycleStatus: 'trashed' });
-    await seedDocument(t, { projectId, lifecycleStatus: 'expired' });
-    // Unattached org document — must not land on any project.
-    await seedDocument(t, {});
-
-    const result = await run(t);
-
-    expect(result.projects[0]?.fileCount).toBe(2);
-  });
-
-  // Note: an inaccessible project's rows cannot contaminate a visible
-  // project's numbers by construction (buckets are keyed by projectId), so
-  // what this pins is the visibility of the ROW itself plus the accuracy of
-  // the neighbouring project's own counts.
   it('omits a project the caller cannot access while its neighbour still counts correctly', async () => {
     const t = convexTest(schema, modules);
     await seedMember(t, ORG);
@@ -283,7 +233,6 @@ describe('listProjectsOverview', () => {
       teamId: 'team_secret',
     });
     await seedTask(t, hidden, { dueDate: NOW - DAY });
-    await seedDocument(t, { projectId: hidden });
     await seedTask(t, mine, { dueDate: NOW - DAY });
 
     const result = await run(t);
@@ -291,7 +240,6 @@ describe('listProjectsOverview', () => {
     expect(result.projects.map((p) => p.name)).toEqual(['Mine']);
     expect(result.projects[0]).toMatchObject({
       overdueTaskCount: 1,
-      fileCount: 0,
     });
   });
 

--- a/services/platform/convex/projects/queries.ts
+++ b/services/platform/convex/projects/queries.ts
@@ -10,7 +10,6 @@ import { v } from 'convex/values';
 
 import type { Doc, Id } from '../_generated/dataModel';
 import { query, type QueryCtx } from '../_generated/server';
-import { isActiveDocument } from '../documents/_helpers';
 import { getDocumentRagProjectionBatch } from '../documents/get_document_rag_projection';
 import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
@@ -189,13 +188,11 @@ export const listProjects = query({
 const TERMINAL_TASK_STATUSES = new Set(['done', 'cancelled']);
 
 /**
- * Bounds for the two derived walks below. Each is GLOBAL to its scan, so a
- * truncated walk makes every project's number in that column a lower bound —
- * which is why the flags are returned once for the whole result rather than
- * per row.
+ * Bound for the derived overdue walk. GLOBAL to the scan, so a truncated walk
+ * makes every project's overdue number a lower bound — which is why the flag
+ * is returned once for the whole result rather than per row.
  */
 const PROJECT_OVERDUE_SCAN_CAP = 2000;
-const PROJECT_FILES_SCAN_CAP = 2000;
 
 const projectOverviewRowValidator = v.object({
   ...projectListItemValidator.fields,
@@ -203,7 +200,6 @@ const projectOverviewRowValidator = v.object({
   doneTaskCount: v.number(),
   overdueTaskCount: v.number(),
   projectAgentCount: v.number(),
-  fileCount: v.number(),
 });
 
 /**
@@ -215,12 +211,10 @@ const projectOverviewRowValidator = v.object({
  * an action, none of which need these numbers, and its row validator is shared
  * with `getProject`.
  *
- * Cost is THREE bounded index walks regardless of project count, never one
- * walk per project:
- *  - task open/done + agent counts are read straight off the denormalized
- *    project row (see the bucket semantics on `projectsTable`),
- *  - overdue is derived from one `by_org_dueDate` range scan,
- *  - files from one seeked `by_organizationId_and_projectId` scan.
+ * Cost is ONE bounded index walk regardless of project count, never one walk
+ * per project: task open/done and agent counts are read straight off the
+ * denormalized project row (see the bucket semantics on `projectsTable`), and
+ * overdue is derived from a single `by_org_dueDate` range scan.
  */
 export const listProjectsOverview = query({
   args: {
@@ -238,7 +232,6 @@ export const listProjectsOverview = query({
   returns: v.object({
     projects: v.array(projectOverviewRowValidator),
     overdueTruncated: v.boolean(),
-    filesTruncated: v.boolean(),
   }),
   handler: async (ctx, args) => {
     const auth = await getAuthContext(ctx, args.organizationId);
@@ -276,34 +269,6 @@ export const listProjectsOverview = query({
       overdueByProject.set(key, (overdueByProject.get(key) ?? 0) + 1);
     }
 
-    // --- Files -----------------------------------------------------------
-    // `.gt('projectId', undefined)` seeks past every unattached document
-    // (undefined is the least value in Convex's order), so this visits only
-    // project-linked rows instead of the org's whole corpus.
-    const filesByProject = new Map<string, number>();
-    let filesScanned = 0;
-    let filesTruncated = false;
-    for await (const doc of ctx.db
-      .query('documents')
-      .withIndex('by_organizationId_and_projectId', (q) =>
-        q.eq('organizationId', args.organizationId).gt('projectId', undefined),
-      )) {
-      if (filesScanned >= PROJECT_FILES_SCAN_CAP) {
-        filesTruncated = true;
-        break;
-      }
-      filesScanned += 1;
-      // Trashed / expired documents are not files the user has. Every read
-      // pipeline filters on lifecycle for exactly this reason; skipping it
-      // here would overstate the count on every project with a trash bin.
-      if (!isActiveDocument(doc)) continue;
-      if (doc.projectId === undefined) continue;
-      const key = String(doc.projectId);
-      // Same rationale as the overdue walk above — map hygiene, not a boundary.
-      if (!visibleIds.has(key)) continue;
-      filesByProject.set(key, (filesByProject.get(key) ?? 0) + 1);
-    }
-
     return {
       // `Object.assign` rather than a spread: `collectVisibleProjects` already
       // built each of these objects fresh for this call, so mutating in place
@@ -315,11 +280,9 @@ export const listProjectsOverview = query({
           doneTaskCount: project.doneTaskCount ?? 0,
           projectAgentCount: project.projectAgentCount ?? 0,
           overdueTaskCount: overdueByProject.get(key) ?? 0,
-          fileCount: filesByProject.get(key) ?? 0,
         });
       }),
       overdueTruncated,
-      filesTruncated,
     };
   },
 });

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6689,7 +6689,6 @@ projects:
     columnTasks: Aufgaben
     columnOverdue: Überfällig
     columnAgents: Agenten
-    columnFiles: Dateien
     columnSharing: Freigabe
     columnActivity: Letzte Aktivität
     sharingOrgWide: Organisationsweit
@@ -6698,7 +6697,6 @@ projects:
     noTasks: Noch keine Aufgaben
     overdueA11y: '{count, plural, one {# überfällige Aufgabe} other {# überfällige Aufgaben}}'
     agentsA11y: '{count, plural, one {# Agent} other {# Agenten}}'
-    filesA11y: '{count, plural, one {# Datei} other {# Dateien}}'
     countTruncated: '{count}+'
   create:
     title: Projekt erstellen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -4401,7 +4401,6 @@ projects:
     columnTasks: Tasks
     columnOverdue: Overdue
     columnAgents: Agents
-    columnFiles: Files
     columnSharing: Sharing
     columnActivity: Last activity
     sharingOrgWide: Org-wide
@@ -4410,7 +4409,6 @@ projects:
     noTasks: No tasks yet
     overdueA11y: '{count, plural, one {# overdue task} other {# overdue tasks}}'
     agentsA11y: '{count, plural, one {# agent} other {# agents}}'
-    filesA11y: '{count, plural, one {# file} other {# files}}'
     countTruncated: '{count}+'
   create:
     title: Create project

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6811,7 +6811,6 @@ projects:
     columnTasks: Tâches
     columnOverdue: En retard
     columnAgents: Agents
-    columnFiles: Fichiers
     columnSharing: Partage
     columnActivity: Dernière activité
     sharingOrgWide: Toute l'organisation
@@ -6820,7 +6819,6 @@ projects:
     noTasks: Pas encore de tâches
     overdueA11y: '{count, plural, one {# tâche en retard} other {# tâches en retard}}'
     agentsA11y: '{count, plural, one {# agent} other {# agents}}'
-    filesA11y: '{count, plural, one {# fichier} other {# fichiers}}'
     countTruncated: '{count}+'
   create:
     title: Créer un projet


### PR DESCRIPTION
The Files column shipped in #2942 and renders an em-dash on every row:

```
BEFORE   TAL  Acme onboarding   ▓▓▓▓░ 77%  ⚠2   2   —   (globe)  2h
         OPS  Vendor migration  ▓▓░░░ 20%       1   —   (users)  5d
         MKT  Q3 campaign          —          —   —   (globe)  3w
                                              ▲
                                        always empty

AFTER    TAL  Acme onboarding   ▓▓▓▓░ 77%  ⚠2   2   (globe)  2h
         OPS  Vendor migration  ▓▓░░░ 20%       1   (users)  5d
         MKT  Q3 campaign          —          —   (globe)  3w
```

Projects keep their knowledge in the chat and task surfaces, not as documents attached to the project record, so `documents.projectId` is unset for essentially every project. The column spent width and a header to say nothing.

## The backend goes with it

Removing the column leaves `fileCount` unread, and shipping a field nothing renders is exactly what #2938 deleted. So the derived walk comes out too.

That is the more valuable half: `listProjectsOverview` now costs **one** bounded index walk instead of two. The files pass visited every project-linked document row in the org on every load of the page.

| | Before | After |
|---|---|---|
| Walks per load | 2 | 1 |
| Truncation flags | `overdueTruncated`, `filesTruncated` | `overdueTruncated` |
| Scan caps | 2 | 1 |

`CountCell` loses its truncation props along with the only column that used them. The overdue badge keeps its own `{n}+` form.

## Removed

`fileCount`, the documents walk, `PROJECT_FILES_SCAN_CAP`, `filesTruncated`, the `isActiveDocument` import, `projects.list.columnFiles` and `projects.list.filesA11y` (en/de/fr), and the tests that covered them.

The agent-count case in the table test was covering both counts at once; it is now split so the zero-reads-as-em-dash behaviour is pinned on its own.

## Verification

- Server + pii: **74,497 pass**
- UI: **426 files, 3,142 tests pass**
- typecheck, lint, format clean

Main is green again as of #2948 / #2949, so this branch stands on a clean base — no inherited failures.