### PR TITLE
feat(platform): give a project an Automations tab once one is bound

### DIFF
--- a/services/platform/app/features/automations/components/automations-list.tsx
+++ b/services/platform/app/features/automations/components/automations-list.tsx
@@ -79,8 +79,8 @@ export function AutomationsList({
     null,
   );
   // The org page lists EVERY automation — project-pinned rows carry a chip
-  // and link into their project — since project navigation has no
-  // Automations tab (tasks are the project-side interface).
+  // and link into their project. The project shell also shows an Automations
+  // tab once something is bound to it, so this component serves both.
   const automationsQuery = useAutomations(
     organizationId,
     projectId,

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// ---------------------------------------------------------------------------
+// The project shell shows an Automations tab only when something is bound to
+// THAT project. Tasks stay the day-to-day automation interface, so a project
+// with nothing bound must not carry a tab that opens an empty list — and once
+// something IS bound the operator needs a way in that is not a detour through
+// the org Automations page.
+// ---------------------------------------------------------------------------
+
+const { mockUseAutomations, mockUseProject } = vi.hoisted(() => ({
+  mockUseAutomations: vi.fn(),
+  mockUseProject: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    useParams: () => ({ id: 'org-1', projectId: 'proj-1' }),
+    ...config,
+  }),
+  Outlet: () => <div data-testid="outlet" />,
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useMatch: () => undefined,
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({ t: (key: string) => `${ns}.${key}` }),
+}));
+
+vi.mock('@/app/features/automations/hooks/queries', () => ({
+  useAutomations: mockUseAutomations,
+}));
+
+vi.mock('@/app/features/projects/hooks/queries', () => ({
+  useProject: mockUseProject,
+}));
+
+vi.mock(
+  '@/app/features/projects/components/project-breadcrumb-switcher',
+  () => ({
+    ProjectBreadcrumbSwitcher: () => <span>Apollo</span>,
+  }),
+);
+
+// PageLayout / AdaptiveHeaderRoot need an AdaptiveHeaderProvider this test has
+// no reason to stand up — the subject is the tab strip, not the chrome.
+vi.mock('@/app/components/layout/page-layout', () => ({
+  PageLayout: ({
+    header,
+    children,
+  }: {
+    header?: React.ReactNode;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      {header}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/app/components/layout/adaptive-header', () => ({
+  AdaptiveHeaderRoot: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('@/app/components/layout/header-breadcrumbs', () => ({
+  HEADER_CRUMB_LINK_CLASS: '',
+  HeaderBreadcrumbs: ({ leaf }: { leaf?: React.ReactNode }) => (
+    <div>{leaf}</div>
+  ),
+}));
+
+vi.mock('@/app/components/ui/editor', () => ({
+  ActiveEditorProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  EditorActions: () => null,
+  useActiveEditor: () => null,
+}));
+
+// Render the tab strip as plain links so the test reads what a user would see.
+vi.mock('@/app/components/ui/navigation/tab-navigation', () => ({
+  TabNavigation: ({
+    items,
+  }: {
+    items: Array<{ label: string; href: string }>;
+  }) => (
+    <nav>
+      {items.map((item) => (
+        <a key={item.href} href={item.href}>
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  ),
+}));
+
+import { Route } from './$projectId';
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- createFileRoute is mocked to return the config
+const ProjectDetailLayout = (
+  Route as unknown as { component: () => React.ReactElement }
+).component;
+
+function setup(automations: unknown[] | undefined) {
+  mockUseProject.mockReturnValue({
+    project: {
+      _id: 'proj-1',
+      name: 'Apollo',
+      canAdminister: false,
+    },
+    isLoading: false,
+  });
+  mockUseAutomations.mockReturnValue({ data: automations });
+  return render(<ProjectDetailLayout />);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('project shell — Automations tab', () => {
+  it('shows the tab when the project has an automation bound', () => {
+    setup([{ name: 'sync-emails' }]);
+
+    const tab = screen.getByRole('link', { name: 'automations.title' });
+    expect(tab).toHaveAttribute(
+      'href',
+      '/dashboard/org-1/projects/proj-1/automations',
+    );
+  });
+
+  it('hides the tab when nothing is bound, rather than opening an empty list', () => {
+    setup([]);
+
+    expect(
+      screen.queryByRole('link', { name: 'automations.title' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the tab while the automations query is still loading', () => {
+    setup(undefined);
+
+    expect(
+      screen.queryByRole('link', { name: 'automations.title' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('scopes the automations query to this project, not the whole org', () => {
+    setup([{ name: 'sync-emails' }]);
+
+    expect(mockUseAutomations).toHaveBeenCalledWith('org-1', 'proj-1');
+  });
+
+  it('keeps the tab among the project shell tabs, not replacing them', () => {
+    setup([{ name: 'sync-emails' }]);
+
+    for (const label of [
+      'projects.navigation.overview',
+      'projects.navigation.threads',
+      'tasks.title',
+      'projects.navigation.files',
+      'projects.navigation.agents',
+    ]) {
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
@@ -26,6 +26,7 @@ import {
   TabNavigation,
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
+import { useAutomations } from '@/app/features/automations/hooks/queries';
 import { ProjectBreadcrumbSwitcher } from '@/app/features/projects/components/project-breadcrumb-switcher';
 import { useProject } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
@@ -74,19 +75,30 @@ function ProjectDetailLayout() {
   const { t: tCommon } = useT('common');
   const { t: tTasks } = useT('tasks');
   const { t: tSecrets } = useT('projectSecrets');
+  const { t: tAutomations } = useT('automations');
 
   // Project-scoped automation DETAIL routes live under the AUTOMATIONS chrome
   // (`AutomationDetailShell` — "Automations / <name>" breadcrumb + its own
   // tab strip), not inside the project shell — so those child routes render
   // bare, exactly like the agents layout skips its header on detail pages.
-  // The project-nav Automations tab opens the bound-automations list instead;
-  // detail keeps this bare-outlet match so the list stays under project chrome.
+  // The project-nav Automations tab opens the bound-automations LIST; detail
+  // keeps this bare-outlet match so only the list stays under project chrome.
   const isAutomationDetail = useMatch({
     from: '/dashboard/$id/projects/$projectId/automations/$automationSlug',
     shouldThrow: false,
   });
 
   const { project, isLoading } = useProject(asProjectId(projectId));
+
+  // The Automations tab is conditional: a project with nothing bound gets no
+  // tab rather than one that opens an empty list. `listAutomations` scoped to
+  // a project is a small indexed read, and the tab strip already re-renders on
+  // `project`, so this costs one extra subscription on the shell.
+  const projectAutomations = useAutomations(
+    organizationId,
+    asProjectId(projectId),
+  );
+  const hasAutomations = (projectAutomations.data?.length ?? 0) > 0;
 
   // Bound automations used to contribute one first-class tab per bundled view
   // (the operator surfaces, e.g. a desk automation). The new engine has no views
@@ -129,11 +141,21 @@ function ProjectDetailLayout() {
       // Bound automations' views as first-class tabs (1 view = 1 tab) —
       // the operator surfaces, ahead of the management tabs below.
       ...viewTabs,
-      // No Automations tab: project-side, TASKS are the automation interface
-      // (status verbs run the workflow; approvals and input files live in the
-      // task modal). Admin surfaces stay reachable — the org Automations page
-      // lists project-pinned automations too and links into the project-
-      // scoped routes, which this shell still mounts.
+      // Automations bound to THIS project. Shown only when there are any:
+      // tasks remain the day-to-day automation interface (status verbs run the
+      // workflow, approvals and input files live in the task modal), so a
+      // project with nothing bound has no reason to carry the tab. Once
+      // something is bound, the operator needs a way in that is not a detour
+      // through the org Automations page.
+      ...(hasAutomations
+        ? [
+            {
+              label: tAutomations('title'),
+              href: `/dashboard/${organizationId}/projects/${projectId}/automations`,
+              matchMode: 'exact' as const,
+            },
+          ]
+        : []),
       {
         label: t('navigation.agents'),
         href: `/dashboard/${organizationId}/projects/${projectId}/agents`,
@@ -161,9 +183,11 @@ function ProjectDetailLayout() {
       t,
       tTasks,
       tSecrets,
+      tAutomations,
       organizationId,
       projectId,
       project?.canAdminister,
+      hasAutomations,
       viewTabs,
     ],
   );


### PR DESCRIPTION
Automations bound to a project were reachable **only** through the org Automations page. The project shell mounted the routes but linked to them from nowhere, so an operator working inside a project had to leave it to see what runs there.

```
BEFORE   Overview · Chats · Tasks · Knowledge · Agents · Secrets
AFTER    Overview · Chats · Tasks · Knowledge · Automations · Agents · Secrets
                                                ▲
                                    only when something is bound
```

## Conditional, not permanent

Tasks remain the day-to-day automation interface — status verbs run the workflow, approvals and input files live in the task modal. A project with nothing bound therefore gets **no tab**, rather than one that opens an empty list. Once something is bound, the operator gets a way in.

`useAutomations(organizationId, projectId)` is the signal: the same project-scoped read the list page already uses, so no new query, and the tab strip already re-renders on `project`.

## Placement

After **Knowledge**, before **Agents** — an inspection surface, not a daily one. Easy to move to last (next to Secrets) if you'd rather it read as purely administrative; say so and I'll change it before merge.

## Route was already there

`/dashboard/$id/projects/$projectId/automations` and its detail children have been mounted all along — the shell keeps a bare-outlet match so automation *detail* renders under the Automations chrome while the *list* stays under project chrome. This PR adds the link, nothing else.

## Comments corrected

Three comments asserted the tab does not exist, left behind when the per-view tab experiment (#2709) was retired:

- the project layout's `useMatch` note, which described a tab it then said was absent
- the `// No Automations tab:` block the conditional now replaces
- `automations-list.tsx`, which explained the org page lists everything *"since project navigation has no Automations tab"*

## Verification

Five cases in a new `$projectId.test.tsx`:

| Case | |
|---|---|
| tab shown when an automation is bound | href points at the project-scoped route |
| tab hidden when nothing is bound | no empty-list dead end |
| tab hidden while the query is loading | no flash-then-vanish |
| query scoped to the project | not the whole org |
| the other five tabs still render | the tab is added, not substituted |

Mutation-tested: forcing the tab always-on fails the hidden-when-empty and hidden-while-loading cases; widening the query to org scope fails the scoping case. Each kills exactly its intended case.

- UI suite: **427 files, 3,147 tests pass**
- Server + pii: 74,502 pass
- typecheck, lint, format clean

Rebased onto current `main`.