### PR TITLE
feat(platform): swap the projects list's bulk delete for bulk archive

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table-bulk-actions.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-bulk-actions.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { render, screen } from '@/tests/utils/render';
 
-import { BulkDeleteBar } from './data-table-bulk-actions';
+import { BulkArchiveBar, BulkDeleteBar } from './data-table-bulk-actions';
 
 describe('BulkDeleteBar', () => {
   const defaultProps = {
@@ -76,5 +76,50 @@ describe('BulkDeleteBar', () => {
     );
 
     expect(screen.getByText(/2 items selected/)).toBeInTheDocument();
+  });
+});
+
+describe('BulkArchiveBar', () => {
+  const defaultProps = {
+    rowSelection: {},
+    onClearSelection: vi.fn(),
+    onArchiveItem: vi.fn().mockResolvedValue(undefined),
+  };
+
+  it('renders nothing when no rows are selected', () => {
+    const { container } = render(<BulkArchiveBar {...defaultProps} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders archive, not delete, when rows are selected', () => {
+    render(
+      <BulkArchiveBar
+        {...defaultProps}
+        rowSelection={{ id1: true, id2: true }}
+      />,
+    );
+
+    expect(screen.getByText(/2 items selected/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /archive selected/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /delete selected/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens a confirm dialog that mentions restore', async () => {
+    const { user } = render(
+      <BulkArchiveBar
+        {...defaultProps}
+        rowSelection={{ id1: true, id2: true }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /archive selected/i }));
+
+    expect(
+      screen.getByText(/archive these 2 items\? you can restore them later/i),
+    ).toBeInTheDocument();
   });
 });

--- a/services/platform/app/components/ui/data-table/data-table-bulk-actions.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-bulk-actions.tsx
@@ -4,9 +4,10 @@ import { Button } from '@tale/ui/button';
 import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { RowSelectionState } from '@tanstack/react-table';
-import { Trash2, X } from 'lucide-react';
+import { Archive, Trash2, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
+import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -22,6 +23,21 @@ interface BulkDeleteBarProps {
   onDeleteComplete?: () => void;
 }
 
+interface BulkArchiveBarProps {
+  /** Current row selection state (keyed by row ID) */
+  rowSelection: RowSelectionState;
+  /** Callback to clear selection */
+  onClearSelection: () => void;
+  /** Async function to archive a single item by ID */
+  onArchiveItem: (id: string) => Promise<void>;
+  /** Callback after all archives complete */
+  onComplete?: () => void;
+}
+
+function selectedIdsFrom(rowSelection: RowSelectionState): string[] {
+  return Object.keys(rowSelection).filter((key) => rowSelection[key]);
+}
+
 export function BulkDeleteBar({
   rowSelection,
   onClearSelection,
@@ -32,9 +48,7 @@ export function BulkDeleteBar({
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const selectedIds = Object.keys(rowSelection).filter(
-    (key) => rowSelection[key],
-  );
+  const selectedIds = selectedIdsFrom(rowSelection);
   const count = selectedIds.length;
 
   const handleDelete = useCallback(async () => {
@@ -101,6 +115,94 @@ export function BulkDeleteBar({
         onDelete={handleDelete}
         isDeleting={isDeleting}
         deletingText={t('bulkActions.deleting')}
+      />
+    </>
+  );
+}
+
+/**
+ * Selection footer for reversible bulk archive. Same chrome as
+ * `BulkDeleteBar`, but the action is archive (ConfirmDialog, non-destructive
+ * button) — use this for high-value entities that must not offer bulk delete.
+ */
+export function BulkArchiveBar({
+  rowSelection,
+  onClearSelection,
+  onArchiveItem,
+  onComplete,
+}: BulkArchiveBarProps) {
+  const { t } = useT('common');
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+
+  const selectedIds = selectedIdsFrom(rowSelection);
+  const count = selectedIds.length;
+
+  const handleArchive = useCallback(async () => {
+    setIsArchiving(true);
+    try {
+      const results = await Promise.allSettled(
+        selectedIds.map((id) => onArchiveItem(id)),
+      );
+      const failedCount = results.filter((r) => r.status === 'rejected').length;
+      const successCount = count - failedCount;
+
+      if (failedCount > 0) {
+        toast({
+          title: t('bulkActions.archiveFailed'),
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('bulkActions.archiveSuccess', { count: successCount }),
+        });
+      }
+
+      setIsConfirmOpen(false);
+      onClearSelection();
+      onComplete?.();
+    } finally {
+      setIsArchiving(false);
+    }
+  }, [selectedIds, count, onArchiveItem, onClearSelection, onComplete, t]);
+
+  if (count === 0) return null;
+
+  return (
+    <>
+      <div className="bg-muted/80 border-border animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border px-4 py-2 duration-200">
+        <HStack gap={3}>
+          <Text as="span" variant="label" className="text-sm">
+            {t('bulkActions.itemsSelected', { count })}
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearSelection}
+            aria-label={t('actions.clearAll')}
+          >
+            <X className="size-4" />
+          </Button>
+        </HStack>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => setIsConfirmOpen(true)}
+        >
+          <Archive className="mr-1.5 size-4" />
+          {t('actions.archiveSelected')}
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={isConfirmOpen}
+        onOpenChange={setIsConfirmOpen}
+        title={t('bulkActions.confirmArchiveTitle', { count })}
+        description={t('bulkActions.confirmArchiveDescription', { count })}
+        confirmText={t('actions.archiveSelected')}
+        loadingText={t('bulkActions.archiving')}
+        isLoading={isArchiving}
+        onConfirm={() => void handleArchive()}
       />
     </>
   );

--- a/services/platform/app/features/projects/components/projects-table.test.tsx
+++ b/services/platform/app/features/projects/components/projects-table.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/app/hooks/use-preload-route', () => ({
 }));
 
 vi.mock('../hooks/mutations', () => ({
-  useDeleteProject: () => ({ mutateAsync: vi.fn() }),
+  useArchiveProject: () => ({ mutateAsync: vi.fn() }),
 }));
 
 vi.mock('./project-row-actions', () => ({
@@ -181,6 +181,28 @@ describe('ProjectsTable', () => {
     expect(
       screen.getByText('projects.list.sharingMultipleTeams'),
     ).toBeInTheDocument();
+  });
+
+  it('offers bulk archive, not bulk delete', async () => {
+    // Selection is for reversible archive only. Delete stays on the per-row
+    // ProjectDeleteDialog (cascade + confirm phrase).
+    const { user } = renderTable([
+      row({ name: 'Acme onboarding', key: 'TAL' }),
+    ]);
+
+    // One administerable, unarchived row => the header select-all plus a
+    // single row checkbox.
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(2);
+    const [, rowCheckbox] = checkboxes;
+    await user.click(rowCheckbox);
+
+    expect(
+      screen.getByRole('button', { name: 'common.actions.archiveSelected' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'common.actions.deleteSelected' }),
+    ).not.toBeInTheDocument();
   });
 
   it('has no accessibility violations', async () => {

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -15,13 +15,13 @@ import {
 } from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
-import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
+import { BulkArchiveBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { usePreloadRoute } from '@/app/hooks/use-preload-route';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 
-import { useDeleteProject } from '../hooks/mutations';
+import { useArchiveProject } from '../hooks/mutations';
 import { useProjectsOverview, type ProjectOverviewRow } from '../hooks/queries';
 import { ProjectAvatar } from './project-avatar';
 import { ProjectCreateDialog } from './project-create-dialog';
@@ -72,7 +72,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
     organizationId,
     { includeArchived },
   );
-  const { mutateAsync: deleteProject } = useDeleteProject();
+  const { mutateAsync: archiveProject } = useArchiveProject();
 
   const handleClearSelection = useCallback(() => {
     setRowSelection({});
@@ -101,20 +101,14 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
     [t, includeArchived, handleArchivedFilterChange],
   );
 
-  const handleDeleteItem = useCallback(
+  const handleArchiveItem = useCallback(
     async (id: string) => {
-      // RowSelectionState keys are the row IDs (Convex doc `_id` here).
-      // `mode: 'detach'` matches the single-row delete dialog's default
-      // (unchecked "cascade") — bulk-delete with cascade would also need a
-      // per-project confirm phrase, which doesn't translate to a multi-row
-      // gesture, so cascade stays single-row-only via the row dialog.
-      await deleteProject({
-        // RowSelectionState keys are the row `_id`s by construction (getRowId).
+      // RowSelectionState keys are the row `_id`s by construction (getRowId).
+      await archiveProject({
         projectId: toId<'projects'>(id),
-        mode: 'detach',
       });
     },
-    [deleteProject],
+    [archiveProject],
   );
 
   const handleRowClick = useCallback(
@@ -148,8 +142,9 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
 
   const columns = useMemo<ColumnDef<ProjectOverviewRow>[]>(
     () => [
-      // Multi-row select — canonical 40px column, identical to every other
-      // entity table. Enables bulk delete via the `BulkDeleteBar` footer.
+      // Multi-row select for bulk archive only. Delete stays on the per-row
+      // ProjectDeleteDialog (cascade + confirm phrase) — projects are too
+      // high-value for a bulk-delete gesture.
       createSelectColumn<ProjectOverviewRow>(),
       {
         accessorKey: 'name',
@@ -340,7 +335,11 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         className="p-4"
         {...list.tableProps}
         columns={columns}
-        enableRowSelection
+        // Mirror single-row archive gating: only admins, and skip rows that
+        // are already archived (restore stays on the row menu).
+        enableRowSelection={(row) =>
+          row.original.canAdminister && !row.original.archivedAt
+        }
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}
         onRowClick={handleRowClick}
@@ -369,11 +368,11 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
           ),
         }}
         footer={
-          <BulkDeleteBar
+          <BulkArchiveBar
             rowSelection={rowSelection}
             onClearSelection={handleClearSelection}
-            onDeleteItem={handleDeleteItem}
-            onDeleteComplete={handleClearSelection}
+            onArchiveItem={handleArchiveItem}
+            onComplete={handleClearSelection}
           />
         }
       />

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1333,6 +1333,7 @@ common:
     importing: Wird importiert...
     openMenu: Menü öffnen
     deleteSelected: Ausgewählte löschen
+    archiveSelected: Ausgewählte archivieren
     tryAgain: Erneut versuchen
   unsavedChanges:
     title: Ungespeicherte Änderungen
@@ -1350,6 +1351,11 @@ common:
     deleteSuccess: '{count, plural, one {# Element} other {# Elemente}} gelöscht'
     deleteFailed: Einige Elemente konnten nicht gelöscht werden
     deleting: Lösche...
+    confirmArchiveTitle: '{count, plural, one {# Element} other {# Elemente}} archivieren'
+    confirmArchiveDescription: '{count, plural, one {Dieses Element} other {Diese {count} Elemente}} archivieren? Du kannst {count, plural, one {es} other {sie}} später wiederherstellen.'
+    archiveSuccess: '{count, plural, one {# Element} other {# Elemente}} archiviert'
+    archiveFailed: Einige Elemente konnten nicht archiviert werden
+    archiving: Archiviere...
   upload:
     clickToUpload: Hochladen
     dropFilesHere: Dateien hier ablegen zum Hochladen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1293,6 +1293,7 @@ common:
     importing: Importing...
     openMenu: Open menu
     deleteSelected: Delete selected
+    archiveSelected: Archive selected
     tryAgain: Try again
   unsavedChanges:
     title: Unsaved changes
@@ -1310,6 +1311,11 @@ common:
     deleteSuccess: Deleted {count, plural, one {# item} other {# items}}
     deleteFailed: Failed to delete some items
     deleting: Deleting...
+    confirmArchiveTitle: Archive {count, plural, one {# item} other {# items}}
+    confirmArchiveDescription: Archive {count, plural, one {this item} other {these {count} items}}? You can restore {count, plural, one {it} other {them}} later.
+    archiveSuccess: Archived {count, plural, one {# item} other {# items}}
+    archiveFailed: Failed to archive some items
+    archiving: Archiving...
   upload:
     clickToUpload: Upload
     dropFilesHere: Drop files here to upload

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1341,6 +1341,7 @@ common:
     importing: Importation...
     openMenu: Ouvrir le menu
     deleteSelected: Supprimer la sélection
+    archiveSelected: Archiver la sélection
     tryAgain: Réessayer
   unsavedChanges:
     title: Modifications non enregistrées
@@ -1360,6 +1361,11 @@ common:
     deleteSuccess: '{count, plural, one {# élément supprimé} other {# éléments supprimés}}'
     deleteFailed: Échec de la suppression de certains éléments
     deleting: Suppression...
+    confirmArchiveTitle: Archiver {count, plural, one {# élément} other {# éléments}}
+    confirmArchiveDescription: 'Archiver {count, plural, one {cet élément} other {ces {count} éléments}} ? Tu pourras {count, plural, one {le} other {les}} restaurer plus tard.'
+    archiveSuccess: '{count, plural, one {# élément archivé} other {# éléments archivés}}'
+    archiveFailed: Échec de l'archivage de certains éléments
+    archiving: Archivage...
   upload:
     clickToUpload: Clique pour téléverser
     dropFilesHere: Dépose les fichiers ici pour téléverser


### PR DESCRIPTION
## Why

Multi-row selection on the projects list drove a **bulk delete**. That delete ran with `mode: 'detach'`, because the cascade checkbox from the single-row dialog has no sensible multi-row equivalent — so the bulk path quietly took the weaker of the two delete behaviours, and did so behind one confirm.

Projects are the highest-value entity in the app. An irreversible multi-row delete is the wrong default for them.

## What changed

Selection now drives **archive** — reversible, and already the project's own soft-delete. Delete stays where it can be done properly: the per-row `ProjectDeleteDialog`, with its cascade choice and confirm phrase.

- **New `BulkArchiveBar`** alongside `BulkDeleteBar` in `data-table-bulk-actions.tsx` — same selection-footer chrome, but a `ConfirmDialog` and a non-destructive button. Reusable by any table whose entity should not offer bulk delete.
- **Row selection is gated** to rows the viewer can administer and that aren't already archived, mirroring how single-row archive is gated. Restore stays on the row menu.
- **Shared helper** `selectedIdsFrom` factored out of `BulkDeleteBar`.
- **Locale keys** `common.bulkActions.{confirmArchiveTitle,confirmArchiveDescription,archiveSuccess,archiveFailed,archiving}` and `common.actions.archiveSelected` added to `en`, `de` and `fr`. No `de-CH` override needed — none of the new German strings carry an `ß`.

The nine other tables using `BulkDeleteBar` are untouched.

## Verification

| Gate | Result |
| --- | --- |
| `data-table` + `projects` UI suites | 150 passed (20 files) |
| `lib/i18n/messages.test.ts` | 24 passed |
| `tsc --noEmit` | clean |
| `oxlint --type-aware` | 0 warnings, 0 errors |
| `oxfmt --check` | clean |

The three new assertions were mutation-tested: swapping the archive label back to the delete label turns all three red, then green again on revert.