### PR TITLE
fix(platform): rebalance projects list column widths

### DIFF
--- a/services/platform/app/features/projects/components/projects-table.test.tsx
+++ b/services/platform/app/features/projects/components/projects-table.test.tsx
@@ -131,47 +131,35 @@ describe('ProjectsTable', () => {
     // (that packed Overdue…Activity against the right edge).
     renderTable([row({ name: 'Acme onboarding' })]);
 
-    const headers = screen.getAllByRole('columnheader');
-    const nameHeader = headers.find((header) =>
-      header.textContent?.includes('projects.list.columnName'),
-    );
-    const tasksHeader = headers.find((header) =>
-      header.textContent?.includes('projects.list.columnTasks'),
-    );
-    const activityHeader = headers.find((header) =>
-      header.textContent?.includes('projects.list.columnActivity'),
-    );
-    expect(nameHeader).toBeTruthy();
-    expect(tasksHeader).toBeTruthy();
-    expect(activityHeader).toBeTruthy();
-    expect(nameHeader!.style.width).toBe('');
-    expect(tasksHeader!.style.width).toContain('0.1995');
-    expect(activityHeader!.style.width).toContain('0.1444');
+    const nameHeader = screen.getByRole('columnheader', {
+      name: 'projects.list.columnName',
+    });
+    const tasksHeader = screen.getByRole('columnheader', {
+      name: 'projects.list.columnTasks',
+    });
+    const activityHeader = screen.getByRole('columnheader', {
+      name: 'projects.list.columnActivity',
+    });
+    expect(nameHeader.style.width).toBe('');
+    expect(tasksHeader.style.width).toContain('0.1995');
+    expect(activityHeader.style.width).toContain('0.1444');
   });
 
   it('hides low-priority columns on small screens so Name stays readable', () => {
     // Agents/sharing/activity progressive-disclose; Overdue stays (compact).
     renderTable([row({ name: 'Getting started' })]);
 
-    const agents = screen
-      .getAllByRole('columnheader')
-      .find((header) =>
-        header.textContent?.includes('projects.list.columnAgents'),
-      );
-    const sharing = screen
-      .getAllByRole('columnheader')
-      .find((header) =>
-        header.textContent?.includes('projects.list.columnSharing'),
-      );
-    const activity = screen
-      .getAllByRole('columnheader')
-      .find((header) =>
-        header.textContent?.includes('projects.list.columnActivity'),
-      );
-
-    expect(agents).toHaveClass('hidden', 'md:table-cell');
-    expect(sharing).toHaveClass('hidden', 'md:table-cell');
-    expect(activity).toHaveClass('hidden', 'lg:table-cell');
+    expect(
+      screen.getByRole('columnheader', { name: 'projects.list.columnAgents' }),
+    ).toHaveClass('hidden', 'md:table-cell');
+    expect(
+      screen.getByRole('columnheader', { name: 'projects.list.columnSharing' }),
+    ).toHaveClass('hidden', 'md:table-cell');
+    expect(
+      screen.getByRole('columnheader', {
+        name: 'projects.list.columnActivity',
+      }),
+    ).toHaveClass('hidden', 'lg:table-cell');
   });
 
   it('renders task progress out of open + done', () => {

--- a/services/platform/app/features/projects/components/projects-table.test.tsx
+++ b/services/platform/app/features/projects/components/projects-table.test.tsx
@@ -114,15 +114,64 @@ describe('ProjectsTable', () => {
     expect(screen.getByText('TAL')).toBeInTheDocument();
   });
 
-  it('exposes the description on hover without adding a second line', () => {
+  it('exposes name + description on hover without adding a second line', () => {
     renderTable([
       row({ name: 'Acme onboarding', description: 'Enterprise rollout' }),
     ]);
 
     expect(screen.getByText('Acme onboarding')).toHaveAttribute(
       'title',
-      'Enterprise rollout',
+      'Acme onboarding — Enterprise rollout',
     );
+  });
+
+  it('shares width proportionally so metadata columns are not clustered', () => {
+    // Name is the implicit flex column; Tasks/Activity use size ratios —
+    // 152 and 110 of 240+152+92+80+88+110 = 762. No meta.flex on Tasks
+    // (that packed Overdue…Activity against the right edge).
+    renderTable([row({ name: 'Acme onboarding' })]);
+
+    const headers = screen.getAllByRole('columnheader');
+    const nameHeader = headers.find((header) =>
+      header.textContent?.includes('projects.list.columnName'),
+    );
+    const tasksHeader = headers.find((header) =>
+      header.textContent?.includes('projects.list.columnTasks'),
+    );
+    const activityHeader = headers.find((header) =>
+      header.textContent?.includes('projects.list.columnActivity'),
+    );
+    expect(nameHeader).toBeTruthy();
+    expect(tasksHeader).toBeTruthy();
+    expect(activityHeader).toBeTruthy();
+    expect(nameHeader!.style.width).toBe('');
+    expect(tasksHeader!.style.width).toContain('0.1995');
+    expect(activityHeader!.style.width).toContain('0.1444');
+  });
+
+  it('hides low-priority columns on small screens so Name stays readable', () => {
+    // Agents/sharing/activity progressive-disclose; Overdue stays (compact).
+    renderTable([row({ name: 'Getting started' })]);
+
+    const agents = screen
+      .getAllByRole('columnheader')
+      .find((header) =>
+        header.textContent?.includes('projects.list.columnAgents'),
+      );
+    const sharing = screen
+      .getAllByRole('columnheader')
+      .find((header) =>
+        header.textContent?.includes('projects.list.columnSharing'),
+      );
+    const activity = screen
+      .getAllByRole('columnheader')
+      .find((header) =>
+        header.textContent?.includes('projects.list.columnActivity'),
+      );
+
+    expect(agents).toHaveClass('hidden', 'md:table-cell');
+    expect(sharing).toHaveClass('hidden', 'md:table-cell');
+    expect(activity).toHaveClass('hidden', 'lg:table-cell');
   });
 
   it('renders task progress out of open + done', () => {

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -149,6 +149,10 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       {
         accessorKey: 'name',
         header: t('list.columnName'),
+        // Implicit first-column flex + a larger size ratio than Activity so
+        // names lead without a fixed-px or meta.flex pin (those either
+        // truncated names or clustered Overdue…Activity on the far right).
+        size: 240,
         cell: ({ row }) => (
           // The row stays SINGLE-LINE (density matches customers/agents), so
           // the description rides on `title` rather than a second line — the
@@ -166,8 +170,12 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
               </span>
             ) : null}
             <span
-              className="truncate text-sm font-medium"
-              title={row.original.description || undefined}
+              className="min-w-0 truncate text-sm font-medium"
+              title={
+                row.original.description
+                  ? `${row.original.name} — ${row.original.description}`
+                  : row.original.name
+              }
             >
               {row.original.name}
               {row.original.archivedAt ? (
@@ -182,7 +190,9 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       {
         id: 'tasks',
         header: t('list.columnTasks'),
-        size: 132,
+        // Proportional sibling — grows with the row so metadata columns aren't
+        // packed against the right edge behind a flex Tasks canyon.
+        size: 152,
         enableSorting: false,
         cell: ({ row }) => {
           const done = row.original.doneTaskCount;
@@ -210,6 +220,8 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         id: 'overdue',
         header: t('list.columnOverdue'),
         size: 92,
+        // Always shown — compact badge/dash. Agents/sharing/activity still
+        // progressive-disclose below so Name keeps room on small screens.
         enableSorting: false,
         cell: ({ row }) => {
           const count = row.original.overdueTaskCount;
@@ -234,6 +246,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         id: 'agents',
         header: t('list.columnAgents'),
         size: 80,
+        meta: { className: 'hidden md:table-cell' },
         enableSorting: false,
         cell: ({ row }) => (
           <CountCell
@@ -248,6 +261,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         accessorKey: 'sharing',
         header: t('list.columnSharing'),
         size: 88,
+        meta: { className: 'hidden md:table-cell' },
         cell: ({ row }) => {
           const teamCount =
             (row.original.teamId ? 1 : 0) +
@@ -273,8 +287,11 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       {
         accessorKey: 'updatedAt',
         header: t('list.columnActivity'),
+        // Below TanStack's default 150 so Last activity doesn't rival Name.
+        size: 110,
+        meta: { className: 'hidden lg:table-cell' },
         cell: ({ row }) => (
-          <span className="text-muted-foreground text-xs">
+          <span className="text-muted-foreground text-xs whitespace-nowrap">
             {formatRelative(row.original.updatedAt, locale)}
           </span>
         ),


### PR DESCRIPTION
## Summary
- Bulk archive already landed in #2953 — this PR only adjusts projects list column layout.
- Give Name/Tasks a larger proportional share; shrink Last activity's default rivalry with Name.
- Progressive-disclose Agents/Sharing (`md+`) and Last activity (`lg+`) so names stay readable on small screens without parking metadata in a pack on the far right.

## Test plan
- [ ] Wide viewport: Name leads; Overdue…Last activity are spaced, not clustered right
- [ ] Narrow viewport: Agents/Sharing/Activity hide; Name + Tasks (+ Overdue) remain readable
- [ ] Hover a row name: `title` shows name (and description when present)
- [ ] `bun run --filter @tale/platform test:ui app/features/projects/components/projects-table.test.tsx`