### PR TITLE
feat(platform): grant task and automation agents baseline knowledge tools

### DIFF
--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -59,7 +59,11 @@ import {
   sessionIdForWorkflowExecution,
   workflowExecutionOwnerId,
 } from '../sandbox/session_naming';
-import { ASK_HUMAN_TOOL } from '../sandbox/tool_names';
+import {
+  ASK_HUMAN_TOOL,
+  KNOWLEDGE_READ_TOOLS,
+  KNOWLEDGE_TOOLS_GUIDANCE,
+} from '../sandbox/tool_names';
 import type { AgentTurnFile, AgentTurnResult } from './checkpoints';
 import { resolveServingTarget } from './llm_call';
 
@@ -824,7 +828,11 @@ export const startWorkflowAgentTurn = internalAction({
             // The one workspace tool an automation turn holds: ask the run's
             // operator. The org-data READ tools stay chat-lane only — a run
             // has no turn user to scope them to.
-            toolGrants: [ASK_HUMAN_TOOL],
+            // Baseline knowledge retrieval rides along: visibility derives
+            // from THIS run's project binding at dispatch (an org-level run
+            // reads the org hub only), so the grant alone never widens what
+            // the run can read.
+            toolGrants: [ASK_HUMAN_TOOL, ...KNOWLEDGE_READ_TOOLS],
           },
           expiresAt: args.deadlineAt,
         },
@@ -858,6 +866,7 @@ export const startWorkflowAgentTurn = internalAction({
             ]
           : []),
         ASK_HUMAN_GUIDANCE,
+        KNOWLEDGE_TOOLS_GUIDANCE,
         "Write every file you produce to /user/output/ — files there are collected when your turn ends and become this step's output.",
       ].join('\n\n');
 
@@ -1118,7 +1127,11 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
             allowedModels: [routing.gatewayModel],
             connectorGrants: [...(request.connectors ?? [])],
             budgetCents,
-            toolGrants: [ASK_HUMAN_TOOL],
+            // Baseline knowledge retrieval rides along: visibility derives
+            // from THIS run's project binding at dispatch (an org-level run
+            // reads the org hub only), so the grant alone never widens what
+            // the run can read.
+            toolGrants: [ASK_HUMAN_TOOL, ...KNOWLEDGE_READ_TOOLS],
           },
           expiresAt: deadlineAt,
         },
@@ -1164,6 +1177,7 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
           ? [request.system]
           : []),
         ASK_HUMAN_GUIDANCE,
+        KNOWLEDGE_TOOLS_GUIDANCE,
         "Write every file you produce to /user/output/ — files there are collected when your turn ends and become this step's output.",
       ].join('\n\n');
       const prompt = [

--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -21,11 +21,17 @@ vi.mock('../knowledge/search', () => ({
 
 const fetchDocumentByFileIdMock = vi.fn();
 const fetchWebPageByUrlMock = vi.fn();
-vi.mock('../knowledge/fetch', () => ({
-  fetchDocumentByFileId: (...args: unknown[]) =>
-    fetchDocumentByFileIdMock(...args),
-  fetchWebPageByUrl: (...args: unknown[]) => fetchWebPageByUrlMock(...args),
-}));
+vi.mock('../knowledge/fetch', async (importOriginal) => {
+  // Only the corpus readers are mocked — the window helpers stay real, so
+  // the paging the model sees is the paging these tests lock.
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    fetchDocumentByFileId: (...args: unknown[]) =>
+      fetchDocumentByFileIdMock(...args),
+    fetchWebPageByUrl: (...args: unknown[]) => fetchWebPageByUrlMock(...args),
+  };
+});
 
 vi.mock('../lib/helpers/org_slug', () => ({
   orgSlugFromId: () => Promise.resolve('org-slug'),

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -39,7 +39,12 @@ import {
 } from '../../lib/knowledge/types';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
-import { fetchDocumentByFileId, fetchWebPageByUrl } from '../knowledge/fetch';
+import {
+  FETCH_WINDOW_CHARS,
+  fetchDocumentByFileId,
+  fetchWebPageByUrl,
+  windowText,
+} from '../knowledge/fetch';
 import { searchKnowledge } from '../knowledge/search';
 import { orgSlugFromId } from '../lib/helpers/org_slug';
 import { SafeFetchError, isPrivateIp, safeFetch } from '../lib/http/safe_fetch';
@@ -51,9 +56,6 @@ export interface ChatToolContext {
   readonly userId: string;
 }
 
-/** One serving of fetched content — enough to answer from, small enough to
- * never flood the context. Longer content pages through `offset`. */
-const FETCH_WINDOW_CHARS = 20_000;
 /** A page bigger than this is cut BEFORE extraction — a tool result must
  * never threaten the Convex value ceiling. */
 const WEB_FETCH_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
@@ -442,18 +444,6 @@ export function createChatToolExecutor(
         ? Math.min(Math.floor(args.limit), FETCH_WINDOW_CHARS)
         : FETCH_WINDOW_CHARS;
 
-    const window = (
-      text: string,
-    ): { content: string; totalChars: number; nextOffset?: number } => {
-      const slice = text.slice(offset, offset + limit);
-      const nextOffset = offset + limit;
-      return {
-        content: slice,
-        totalChars: text.length,
-        ...(nextOffset < text.length ? { nextOffset } : {}),
-      };
-    };
-
     const isUrl = ref.startsWith('http://') || ref.startsWith('https://');
     const slug = await orgSlug();
 
@@ -478,7 +468,7 @@ export function createChatToolExecutor(
         await recordDispatch('rag_fetch', result.status, result.message);
         return result;
       }
-      const paged = window(page.text);
+      const paged = windowText(page.text, offset, limit);
       await recordDispatch('rag_fetch', 'ok');
       return {
         status: 'ok',
@@ -581,7 +571,7 @@ export function createChatToolExecutor(
       );
     }
 
-    const paged = window(text);
+    const paged = windowText(text, offset, limit);
     await recordDispatch('rag_fetch', 'ok');
     return {
       status: 'ok',

--- a/services/platform/convex/knowledge/fetch.ts
+++ b/services/platform/convex/knowledge/fetch.ts
@@ -36,6 +36,28 @@ import {
   isUndefinedTable,
 } from './pool';
 
+/** One serving of fetched content — enough to answer from, small enough to
+ * never flood the model's context (nor the Convex value ceiling). Longer
+ * content pages through `offset`; every `rag_fetch` surface shares this
+ * window so paging behaves identically wherever the tool is mounted. */
+export const FETCH_WINDOW_CHARS = 20_000;
+
+/** Cut one `offset`/`limit` window out of a fetched text, with the follow-up
+ * offset when more remains — the paging contract of `rag_fetch` results. */
+export function windowText(
+  text: string,
+  offset: number,
+  limit: number,
+): { content: string; totalChars: number; nextOffset?: number } {
+  const slice = text.slice(offset, offset + limit);
+  const nextOffset = offset + limit;
+  return {
+    content: slice,
+    totalChars: text.length,
+    ...(nextOffset < text.length ? { nextOffset } : {}),
+  };
+}
+
 /** A document loaded whole from the corpus. */
 export interface FetchedDocument {
   readonly fileId: string;

--- a/services/platform/convex/node_only/sandbox/workspace_tools_bridge.test.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_tools_bridge.test.ts
@@ -21,6 +21,18 @@ const searchKnowledgeMock = vi.fn();
 vi.mock('../../knowledge/search', () => ({
   searchKnowledge: (...args: unknown[]) => searchKnowledgeMock(...args),
 }));
+const fetchDocumentMock = vi.fn();
+const fetchWebPageMock = vi.fn();
+vi.mock('../../knowledge/fetch', async (importOriginal) => {
+  // Only the corpus readers are mocked — the window helpers stay real, so
+  // the paging the model sees is the paging these tests lock.
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    fetchDocumentByFileId: (...args: unknown[]) => fetchDocumentMock(...args),
+    fetchWebPageByUrl: (...args: unknown[]) => fetchWebPageMock(...args),
+  };
+});
 vi.mock('../../lib/helpers/org_slug', () => ({
   orgSlugFromId: () => Promise.resolve('acme'),
 }));
@@ -41,7 +53,7 @@ async function getActions(): Promise<{ dispatch: Handler; status: Handler }> {
 }
 
 const ACCESS_FN = 'sandbox/workspace_access:resolveWorkspaceReadAccess';
-const SCOPE_FN = 'sandbox/workspace_access:resolveWorkspaceKnowledgeScope';
+const SCOPE_FN = 'sandbox/workspace_access:resolveKnowledgeToolAccess';
 
 function fnName(ref: unknown): string {
   return getFunctionName(ref as Parameters<typeof getFunctionName>[0]);
@@ -73,7 +85,10 @@ function createCtx(
   );
   const scopeQuery = vi.fn<(...a: unknown[]) => Promise<unknown>>(() =>
     Promise.resolve(
-      overrides.scope ?? { teamIds: [], projectIds: [], includeHub: true },
+      overrides.scope ?? {
+        allowed: true,
+        scope: { teamIds: [], projectIds: [], includeHub: true },
+      },
     ),
   );
   const runQuery = vi.fn((ref: unknown, args: unknown) => {
@@ -181,7 +196,7 @@ describe('dispatchWorkspaceTool', () => {
   it('rag_search is gated too — denied means no retrieval at all', async () => {
     const { dispatch } = await getActions();
     const { ctx } = createCtx({
-      access: { allowed: false, reason: 'not_a_member' },
+      scope: { allowed: false, reason: 'not_a_member' },
     });
     const result = await dispatch(ctx, {
       ...BASE,
@@ -189,6 +204,28 @@ describe('dispatchWorkspaceTool', () => {
       callArgs: { query: 'anything' },
     });
     expect(result.status).toBe('unavailable');
+    expect((result.blockers as { code: string }[])[0]?.code).toBe(
+      'access_denied',
+    );
+    expect(searchKnowledgeMock).not.toHaveBeenCalled();
+  });
+
+  it('a session with neither binding nor user refuses knowledge tools, named', async () => {
+    const { dispatch } = await getActions();
+    const { ctx } = createCtx({
+      scope: { allowed: false, reason: 'no_access_context' },
+    });
+    // No userId at all — a task/automation token shape.
+    const result = await dispatch(ctx, {
+      organizationId: 'org_1',
+      sessionId: 'sid_1',
+      tool: 'rag_search',
+      callArgs: { query: 'anything' },
+    });
+    expect(result.status).toBe('unavailable');
+    expect((result.blockers as { code: string }[])[0]?.code).toBe(
+      'no_access_context',
+    );
     expect(searchKnowledgeMock).not.toHaveBeenCalled();
   });
 
@@ -246,7 +283,7 @@ describe('dispatchWorkspaceTool', () => {
       includeHub: true,
     };
     const { dispatch } = await getActions();
-    const { ctx, scopeQuery } = createCtx({ scope });
+    const { ctx, scopeQuery } = createCtx({ scope: { allowed: true, scope } });
     await dispatch(ctx, {
       ...BASE,
       tool: 'rag_search',
@@ -262,6 +299,7 @@ describe('dispatchWorkspaceTool', () => {
       organizationId: 'org_1',
       sessionId: 'sid_1',
       userId: 'user_1',
+      subject: 'documents',
     });
     const call = searchKnowledgeMock.mock.calls[0]?.[1] as Record<
       string,
@@ -351,6 +389,140 @@ describe('dispatchWorkspaceTool', () => {
       const auditArgs = call[1] as Record<string, unknown>;
       expect('knowledgeRefs' in auditArgs).toBe(false);
     }
+  });
+
+  it('rag_fetch needs a ref', async () => {
+    const { dispatch } = await getActions();
+    const result = await dispatch(createCtx({}).ctx, {
+      ...BASE,
+      tool: 'rag_fetch',
+      callArgs: {},
+    });
+    expect(result.status).toBe('invalid_args');
+    expect(fetchDocumentMock).not.toHaveBeenCalled();
+    expect(fetchWebPageMock).not.toHaveBeenCalled();
+  });
+
+  it('rag_fetch routes a URL ref to the crawled corpus, websites-subject gated', async () => {
+    fetchWebPageMock.mockResolvedValueOnce({
+      url: 'https://acme.com/pricing',
+      title: 'Pricing',
+      lastCrawledAt: 123,
+      text: 'per-seat pricing details',
+    });
+    const runMutation = vi.fn<(...a: unknown[]) => Promise<unknown>>(() =>
+      Promise.resolve(null),
+    );
+    const { dispatch } = await getActions();
+    const { ctx, scopeQuery } = createCtx({ runMutation });
+    const result = await dispatch(ctx, {
+      ...BASE,
+      tool: 'rag_fetch',
+      callArgs: { ref: 'https://acme.com/pricing' },
+    });
+    expect(result.status).toBe('ok');
+    const output = result.output as Record<string, unknown>;
+    expect(output.kind).toBe('web-page');
+    expect(output.url).toBe('https://acme.com/pricing');
+    // Third-party page content is relayed wrapped, never raw.
+    expect(String(output.content)).toContain('per-seat pricing details');
+    const resolveArgs = scopeQuery.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(resolveArgs.subject).toBe('websites');
+    // The read-set records the page URL for the provenance ledger.
+    const auditArgs = runMutation.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(auditArgs.knowledgeRefs).toEqual(['https://acme.com/pricing']);
+  });
+
+  it('rag_fetch reads a document by file id, windowed to the fetch budget', async () => {
+    fetchDocumentMock.mockResolvedValueOnce({
+      fileId: 'file-1',
+      filename: 'sop.txt',
+      folderPath: null,
+      modifiedAt: null,
+      text: 'a'.repeat(25_000),
+    });
+    const readQuery = vi.fn<(...a: unknown[]) => Promise<unknown>>(
+      (ref: unknown) =>
+        fnName(ref) === 'file_metadata/internal_queries:lookupVideoLinkSources'
+          ? Promise.resolve([])
+          : Promise.resolve(null),
+    );
+    const runMutation = vi.fn<(...a: unknown[]) => Promise<unknown>>(() =>
+      Promise.resolve(null),
+    );
+    const { dispatch } = await getActions();
+    const { ctx, scopeQuery } = createCtx({ readQuery, runMutation });
+    const result = await dispatch(ctx, {
+      ...BASE,
+      tool: 'rag_fetch',
+      callArgs: { ref: 'file-1' },
+    });
+    expect(result.status).toBe('ok');
+    const output = result.output as Record<string, unknown>;
+    expect(output.kind).toBe('document');
+    expect(output.filename).toBe('sop.txt');
+    expect(output.totalChars).toBe(25_000);
+    expect(output.nextOffset).toBe(20_000);
+    expect(String(output.content)).toHaveLength(20_000);
+    const resolveArgs = scopeQuery.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(resolveArgs.subject).toBe('documents');
+    // The fetch runs under the session-resolved scope, never an org-wide one.
+    const fetchArgs = fetchDocumentMock.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(fetchArgs.access).toEqual({
+      teamIds: [],
+      projectIds: [],
+      includeHub: true,
+    });
+    const auditArgs = runMutation.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(auditArgs.knowledgeRefs).toEqual(['file-1']);
+  });
+
+  it('rag_fetch answers a denied or missing document as the same not_found', async () => {
+    // The scoped corpus read returns null for denied AND missing alike; the
+    // Convex-row fallback finds nothing either.
+    fetchDocumentMock.mockResolvedValueOnce(null);
+    const { dispatch } = await getActions();
+    const result = await dispatch(createCtx({}).ctx, {
+      ...BASE,
+      tool: 'rag_fetch',
+      callArgs: { ref: 'file-denied' },
+    });
+    expect(result.status).toBe('not_found');
+  });
+
+  it('rag_fetch serves hub-authored inline content under the same scope rule', async () => {
+    fetchDocumentMock.mockResolvedValueOnce(null);
+    const readQuery = vi.fn<(...a: unknown[]) => Promise<unknown>>(
+      (ref: unknown) => {
+        const name = fnName(ref);
+        if (name === 'documents/internal_queries:findDocumentByFileId') {
+          return Promise.resolve({ title: 'Note', content: 'inline text' });
+        }
+        if (name === 'file_metadata/internal_queries:lookupVideoLinkSources') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve(null);
+      },
+    );
+    const { dispatch } = await getActions();
+    const result = await dispatch(createCtx({ readQuery }).ctx, {
+      ...BASE,
+      tool: 'rag_fetch',
+      callArgs: { ref: 'file-inline' },
+    });
+    expect(result.status).toBe('ok');
+    const output = result.output as Record<string, unknown>;
+    expect(output.content).toBe('inline text');
+    expect(output.filename).toBe('Note');
   });
 
   it('document_find lists the org+user-scoped documents', async () => {

--- a/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
@@ -11,24 +11,39 @@
  * Same discipline as the connector surface: whatever these actions return is
  * relayed verbatim to the external agent as the tool result, so every shape is
  * written FOR THE MODEL (structured status + guidance, never a bare throw).
- * Every dispatch first re-resolves the turn user's access the way a user-side
- * `queryWithRLS` read would — active membership + the role matrix for the
- * table the tool exposes (`resolveWorkspaceReadAccess`) — so the session
- * token proves WHO the turn runs as, never that they may still read. V1 is
- * READ-ONLY (a write tool would need the approvals lane an async turn can't
- * answer), matching the connector bridge's stance.
+ * Access is re-resolved per dispatch from what the token PROVES, never from
+ * the request. The knowledge pair (`rag_search`/`rag_fetch`) derives its
+ * visibility from the SESSION's binding first — a project-bound run reads its
+ * project + the org hub, an org-level automation run reads the hub — falling
+ * back to the turn user's own scope (`resolveKnowledgeToolAccess`), so it
+ * runs on the user-less task/automation tokens. The org-data find tools run
+ * AS the turn's user: active membership + the role matrix for the table the
+ * tool exposes (`resolveWorkspaceReadAccess`), the same policy the user-side
+ * `queryWithRLS` reads enforce. V1 is READ-ONLY (a write tool would need the
+ * approvals lane an async turn can't answer), matching the connector bridge's
+ * stance.
  *
  * `'use node'` because knowledge search binds an embedder (filesystem/network).
  */
 
 import { v } from 'convex/values';
 
-import type { KnowledgeAccessScope } from '../../../lib/knowledge/types';
+import {
+  knowledgeScopeAllows,
+  type KnowledgeAccessScope,
+} from '../../../lib/knowledge/types';
 import { internal } from '../../_generated/api';
 import { internalAction, type ActionCtx } from '../../_generated/server';
+import {
+  FETCH_WINDOW_CHARS,
+  fetchDocumentByFileId,
+  fetchWebPageByUrl,
+  windowText,
+} from '../../knowledge/fetch';
 import { searchKnowledge } from '../../knowledge/search';
 import { orgSlugFromId } from '../../lib/helpers/org_slug';
 import type { AgentReadSubject } from '../../lib/rls/helpers/agent_read_access';
+import { wrapUntrusted } from '../../lib/untrusted_content';
 import {
   ASK_HUMAN_TOOL,
   KNOWLEDGE_REFS_PER_CALL_CAP,
@@ -44,6 +59,7 @@ import {
  */
 export const WORKSPACE_READ_TOOLS = [
   'rag_search',
+  'rag_fetch',
   'document_find',
   'knowledge_entry_find',
   'contact_find',
@@ -61,6 +77,9 @@ type WorkspaceReadTool = (typeof WORKSPACE_READ_TOOLS)[number];
  */
 const TOOL_READ_SUBJECT: Record<WorkspaceReadTool, AgentReadSubject> = {
   rag_search: 'documents',
+  // A URL ref reads the crawled-pages corpus; the dispatch narrows the
+  // subject to 'websites' per call — this entry is the file-id default.
+  rag_fetch: 'documents',
   document_find: 'documents',
   knowledge_entry_find: 'documents',
   contact_find: 'contacts',
@@ -80,7 +99,13 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
     'the same question.',
   rag_search:
     "Search the organization's knowledge base; returns the most relevant " +
-    'passages with their text. Args: {query: string, limit?: number}.',
+    'passages with their text and the refs rag_fetch reads in full. ' +
+    'Args: {query: string, limit?: number}.',
+  rag_fetch:
+    "Read one knowledge source's full text by the ref a rag_search hit " +
+    'carried — a document file id or a crawled page URL. Args: {ref: string, ' +
+    'offset?: number, limit?: number}; long content is windowed — pass the ' +
+    "returned nextOffset as offset until it's absent.",
   document_find:
     'List/browse documents in the organization Documents hub this user can ' +
     'access. Args: {fileName?: string, extension?: string, limit?: number}.',
@@ -111,6 +136,7 @@ type ToolResult =
   | { status: 'ok'; output: unknown }
   | { status: 'unavailable'; blockers: BridgeBlocker[] }
   | { status: 'invalid_args'; message: string }
+  | { status: 'not_found'; message: string }
   | { status: 'error'; message: string };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -130,8 +156,9 @@ export const dispatchWorkspaceTool = internalAction({
   args: {
     organizationId: v.string(),
     sessionId: v.string(),
-    /** The turn's user — absent on an automation run's token, whose only
-     * grantable tool (`ask_human`) needs none. */
+    /** The turn's user — absent on task/automation run tokens, whose tools
+     * (`ask_human`, the knowledge pair) resolve access from the session's
+     * binding instead. */
     userId: v.optional(v.string()),
     /** The per-turn gateway VK id off the session-token row (HTTP dispatch
      * auth, never the request body) — `recordToolCall` resolves it to the
@@ -243,8 +270,22 @@ async function runWorkspaceTool(
     };
   }
 
-  // An external-turn token always carries the turn's user for the READ tools;
-  // without one the read cannot be access-scoped, so it cannot run.
+  // The knowledge pair resolves its visibility from the SESSION's binding
+  // first (a project-bound run reads its project + the org hub; an org-level
+  // automation run reads the hub), falling back to the turn user's own scope
+  // — so it runs on the user-less task/automation tokens.
+  if (args.tool === 'rag_search' || args.tool === 'rag_fetch') {
+    return await runKnowledgeTool(ctx, {
+      organizationId: args.organizationId,
+      sessionId: args.sessionId,
+      ...(args.userId !== undefined ? { userId: args.userId } : {}),
+      tool: args.tool,
+      callArgs,
+    });
+  }
+
+  // The org-data find tools run AS the turn's user; without one the read
+  // cannot be access-scoped, so it cannot run.
   if (args.userId === undefined) {
     return {
       status: 'unavailable',
@@ -284,60 +325,6 @@ async function runWorkspaceTool(
         },
       ],
     };
-  }
-
-  if (args.tool === 'rag_search') {
-    const query =
-      typeof callArgs.query === 'string' ? callArgs.query.trim() : '';
-    if (query === '') {
-      return {
-        status: 'invalid_args',
-        message: 'rag_search needs a non-empty "query" string.',
-      };
-    }
-    const limit =
-      typeof callArgs.limit === 'number' && callArgs.limit > 0
-        ? Math.min(Math.floor(callArgs.limit), 20)
-        : 8;
-    const orgSlug = await orgSlugFromId(ctx, args.organizationId);
-    // The caller's document visibility, derived from what the SESSION proves
-    // (a project-bound sandbox sees its project; a chat turn sees its user's
-    // scope) — never from the request, which a container could shape.
-    const knowledgeScope: KnowledgeAccessScope = await ctx.runQuery(
-      internal.sandbox.workspace_access.resolveWorkspaceKnowledgeScope,
-      {
-        organizationId: args.organizationId,
-        sessionId: args.sessionId,
-        userId,
-      },
-    );
-    try {
-      const result = await searchKnowledge(ctx, {
-        organizationId: args.organizationId,
-        orgSlug,
-        query,
-        limit,
-        access: knowledgeScope,
-      });
-      return { status: 'ok', output: result };
-    } catch (error) {
-      // searchKnowledge REFUSES (throws) when the org has no embedding model
-      // configured or its corpus is unusable — surface that as guidance, not
-      // a transport error, so the agent tells the user instead of retrying.
-      return {
-        status: 'unavailable',
-        blockers: [
-          {
-            code: 'knowledge_unavailable',
-            guidance:
-              'Knowledge search is not available for this organization ' +
-              '(no embedding model configured, or the knowledge base is ' +
-              'empty). Ask the user to set it up under Settings → Knowledge. ' +
-              `(${error instanceof Error ? error.message : String(error)})`,
-          },
-        ],
-      };
-    }
   }
 
   if (args.tool === 'document_find') {
@@ -428,6 +415,294 @@ async function runWorkspaceTool(
   return {
     status: 'error',
     message: `Workspace tool "${requestedTool}" has no handler.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The knowledge pair — rag_search / rag_fetch
+// ---------------------------------------------------------------------------
+
+/** Resolve what this dispatch may read — the session's binding first, then
+ * the turn user (role-checked for `subject`), else refused. */
+async function resolveKnowledgeAccess(
+  ctx: ActionCtx,
+  args: { organizationId: string; sessionId: string; userId?: string },
+  subject: 'documents' | 'websites',
+): Promise<
+  | { allowed: true; scope: KnowledgeAccessScope }
+  | {
+      allowed: false;
+      reason: 'no_access_context' | 'not_a_member' | 'read_denied';
+    }
+> {
+  return await ctx.runQuery(
+    internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+    {
+      organizationId: args.organizationId,
+      sessionId: args.sessionId,
+      ...(args.userId !== undefined ? { userId: args.userId } : {}),
+      subject,
+    },
+  );
+}
+
+/** The blocker a refused knowledge dispatch relays, by refusal reason. */
+const KNOWLEDGE_ACCESS_BLOCKERS: Record<
+  'no_access_context' | 'not_a_member' | 'read_denied',
+  BridgeBlocker
+> = {
+  no_access_context: {
+    code: 'no_access_context',
+    guidance:
+      'This session is neither bound to a project nor carries a user ' +
+      'context, so knowledge reads cannot run from it.',
+  },
+  not_a_member: {
+    code: 'access_denied',
+    guidance:
+      'The user this turn runs as is not an active member of this ' +
+      'organization, so knowledge reads are unavailable. Tell the user; ' +
+      'do not retry.',
+  },
+  read_denied: {
+    code: 'access_denied',
+    guidance:
+      "The user's role does not permit reading this content in this " +
+      'organization. Tell the user; do not retry.',
+  },
+};
+
+/** The retrieval backends REFUSE (throw) when the org has no embedding model
+ * configured or its corpus/pool is unusable — surfaced as guidance, not a
+ * transport error, so the agent tells the user instead of retrying. */
+function knowledgeUnavailable(error: unknown): ToolResult {
+  return {
+    status: 'unavailable',
+    blockers: [
+      {
+        code: 'knowledge_unavailable',
+        guidance:
+          'Knowledge retrieval is not available for this organization ' +
+          '(no embedding model configured, or the knowledge base is ' +
+          'empty). Ask the user to set it up under Settings → Knowledge. ' +
+          `(${error instanceof Error ? error.message : String(error)})`,
+      },
+    ],
+  };
+}
+
+async function runKnowledgeTool(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    sessionId: string;
+    userId?: string;
+    tool: 'rag_search' | 'rag_fetch';
+    callArgs: Record<string, unknown>;
+  },
+): Promise<ToolResult> {
+  const { callArgs } = args;
+
+  if (args.tool === 'rag_search') {
+    const query =
+      typeof callArgs.query === 'string' ? callArgs.query.trim() : '';
+    if (query === '') {
+      return {
+        status: 'invalid_args',
+        message: 'rag_search needs a non-empty "query" string.',
+      };
+    }
+    const limit =
+      typeof callArgs.limit === 'number' && callArgs.limit > 0
+        ? Math.min(Math.floor(callArgs.limit), 20)
+        : 8;
+    const access = await resolveKnowledgeAccess(ctx, args, 'documents');
+    if (!access.allowed) {
+      return {
+        status: 'unavailable',
+        blockers: [KNOWLEDGE_ACCESS_BLOCKERS[access.reason]],
+      };
+    }
+    const orgSlug = await orgSlugFromId(ctx, args.organizationId);
+    try {
+      const result = await searchKnowledge(ctx, {
+        organizationId: args.organizationId,
+        orgSlug,
+        query,
+        limit,
+        access: access.scope,
+      });
+      return { status: 'ok', output: result };
+    } catch (error) {
+      return knowledgeUnavailable(error);
+    }
+  }
+
+  const ref = typeof callArgs.ref === 'string' ? callArgs.ref.trim() : '';
+  if (ref === '') {
+    return {
+      status: 'invalid_args',
+      message:
+        'rag_fetch needs a "ref": a document file id or a crawled page URL.',
+    };
+  }
+  const offset =
+    typeof callArgs.offset === 'number' && callArgs.offset > 0
+      ? Math.floor(callArgs.offset)
+      : 0;
+  // An explicit range: `limit` caps the returned window below the default,
+  // so the model can read exactly the region a search hit points at.
+  const limit =
+    typeof callArgs.limit === 'number' && callArgs.limit > 0
+      ? Math.min(Math.floor(callArgs.limit), FETCH_WINDOW_CHARS)
+      : FETCH_WINDOW_CHARS;
+  const isUrl = ref.startsWith('http://') || ref.startsWith('https://');
+
+  // A URL ref reads the crawled-pages corpus; a file id reads documents.
+  const access = await resolveKnowledgeAccess(
+    ctx,
+    args,
+    isUrl ? 'websites' : 'documents',
+  );
+  if (!access.allowed) {
+    return {
+      status: 'unavailable',
+      blockers: [KNOWLEDGE_ACCESS_BLOCKERS[access.reason]],
+    };
+  }
+  const orgSlug = await orgSlugFromId(ctx, args.organizationId);
+
+  if (isUrl) {
+    let page;
+    try {
+      page = await fetchWebPageByUrl(orgSlug, ref);
+    } catch (error) {
+      return knowledgeUnavailable(error);
+    }
+    if (page === null) {
+      return {
+        status: 'not_found',
+        message:
+          "No crawled page with that URL is in this organization's " +
+          'knowledge. For a public page outside the knowledge base, fetch ' +
+          'it yourself over the network.',
+      };
+    }
+    const paged = windowText(page.text, offset, limit);
+    return {
+      status: 'ok',
+      output: {
+        kind: 'web-page',
+        url: page.url,
+        ...(page.title !== null ? { title: page.title } : {}),
+        ...(page.lastCrawledAt !== null
+          ? { lastCrawledAt: page.lastCrawledAt }
+          : {}),
+        totalChars: paged.totalChars,
+        offset,
+        ...(paged.nextOffset !== undefined
+          ? { nextOffset: paged.nextOffset }
+          : {}),
+        // Crawled third-party content reads wrapped, like every other
+        // untrusted source.
+        content: wrapUntrusted(paged.content, {
+          tool: 'rag_fetch',
+          url: page.url,
+        }),
+      },
+    };
+  }
+
+  // A document file id. The dispatch's scope gates the fetch exactly like the
+  // search: a ref in hand (quoted, guessed, remembered from before a scope
+  // change) is not a capability, and a denied document reads as the same
+  // not_found as a missing one.
+  let fromCorpus;
+  try {
+    fromCorpus = await fetchDocumentByFileId(ctx, {
+      organizationId: args.organizationId,
+      orgSlug,
+      fileId: ref,
+      access: access.scope,
+    });
+  } catch (error) {
+    return knowledgeUnavailable(error);
+  }
+  let filename = fromCorpus?.filename ?? null;
+  let text =
+    fromCorpus !== null && fromCorpus.text.length > 0 ? fromCorpus.text : null;
+  if (text === null) {
+    // The corpus may not carry it (ingest offline, or a hub-authored
+    // document whose text lives inline on the Convex row). The row carries
+    // its own scope stamp — the same visibility rule applies before its
+    // inline content is served.
+    const row = await ctx.runQuery(
+      internal.documents.internal_queries.findDocumentByFileId,
+      { organizationId: args.organizationId, fileId: ref },
+    );
+    if (
+      row &&
+      knowledgeScopeAllows(access.scope, {
+        teamIds: row.teamTags ?? null,
+        teamId: row.teamId ?? null,
+        projectId: row.projectId ?? null,
+      }) &&
+      typeof row.content === 'string' &&
+      row.content.length > 0
+    ) {
+      text = row.content;
+      filename ??= row.title ?? null;
+    }
+  }
+  if (text === null) {
+    return {
+      status: 'not_found',
+      message:
+        'No readable content for that file id. The document may not be ' +
+        "indexed yet, or it is outside this run's scope — rag_search shows " +
+        'what is reachable.',
+    };
+  }
+
+  // A document that arrived through a video link is third-party content; it
+  // reads wrapped, like every other untrusted source.
+  let untrustedSourceUrl: string | undefined;
+  try {
+    const videoSources = await ctx.runQuery(
+      internal.file_metadata.internal_queries.lookupVideoLinkSources,
+      { storageIds: [ref] },
+    );
+    if (videoSources.length > 0) {
+      untrustedSourceUrl = videoSources[0]?.sourceUrl ?? 'video-link';
+    }
+  } catch (error) {
+    console.warn(
+      `[workspace-tools] video-link source lookup failed for rag_fetch: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const paged = windowText(text, offset, limit);
+  return {
+    status: 'ok',
+    output: {
+      kind: 'document',
+      ref,
+      ...(filename !== null ? { filename } : {}),
+      totalChars: paged.totalChars,
+      offset,
+      ...(paged.nextOffset !== undefined
+        ? { nextOffset: paged.nextOffset }
+        : {}),
+      content:
+        untrustedSourceUrl !== undefined
+          ? wrapUntrusted(paged.content, {
+              tool: 'rag_fetch',
+              url: untrustedSourceUrl,
+            })
+          : paged.content,
+    },
   };
 }
 

--- a/services/platform/convex/projects/list_project_agents.test.ts
+++ b/services/platform/convex/projects/list_project_agents.test.ts
@@ -1,0 +1,116 @@
+// Read-side coverage for `listProjectAgents` — the one query behind the
+// project Agents tab, the task assignee picker, and actor-directory name
+// resolution. Locks the regression where a row written by a retired feature
+// build (vestigial `autonomyTier`, kept optional in the schema for rolling
+// upgrades) failed the strict returns validator and blanked the whole list.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root (this file is at
+// convex/projects/), mirroring accessible_members.test.ts.
+const TEST_DIR_FROM_CONVEX_ROOT = 'projects';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_agent_list';
+const MEMBER = 'u_member';
+
+type T = TestConvex<typeof schema>;
+
+/** Seed an org member and an org-wide project; return the project id. */
+async function seedWorld(t: T): Promise<Id<'projects'>> {
+  return t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      memberId: `m_${MEMBER}_${ORG}`,
+      userId: MEMBER,
+      organizationId: ORG,
+      role: 'member',
+      createdAt: 0,
+    });
+    return ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Project',
+      createdBy: 'u_creator',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+  });
+}
+
+function agentRow(
+  projectId: Id<'projects'>,
+  name: string,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    organizationId: ORG,
+    projectId,
+    name,
+    harness: 'claude-code',
+    model: 'claude-sonnet-5',
+    skills: [],
+    connectors: [],
+    createdBy: 'u_creator',
+    createdAt: 0,
+    updatedAt: 0,
+    ...extra,
+  };
+}
+
+function listAsMember(t: T, projectId: Id<'projects'>) {
+  return t
+    .withIdentity({ subject: MEMBER })
+    .query(api.projects.queries.listProjectAgents, {
+      projectId,
+      organizationId: ORG,
+    });
+}
+
+describe('listProjectAgents', () => {
+  it('lists the project agents name-sorted', async () => {
+    const t = convexTest(schema, modules);
+    const projectId = await seedWorld(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('projectAgents', agentRow(projectId, 'Mike'));
+      await ctx.db.insert('projectAgents', agentRow(projectId, 'Alice'));
+    });
+
+    const rows = await listAsMember(t, projectId);
+    expect(rows.map((r) => r.name)).toEqual(['Alice', 'Mike']);
+  });
+
+  it('still lists every agent when a row carries a vestigial autonomyTier', async () => {
+    const t = convexTest(schema, modules);
+    const projectId = await seedWorld(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('projectAgents', agentRow(projectId, 'Alice'));
+      await ctx.db.insert(
+        'projectAgents',
+        agentRow(projectId, 'Legacy tiered', { autonomyTier: 'a2' }),
+      );
+      await ctx.db.insert('projectAgents', agentRow(projectId, 'Mike'));
+    });
+
+    const rows = await listAsMember(t, projectId);
+    expect(rows.map((r) => r.name)).toEqual(['Alice', 'Legacy tiered', 'Mike']);
+    // The vestige never leaves the db layer.
+    expect(rows.some((r) => 'autonomyTier' in r)).toBe(false);
+  });
+});

--- a/services/platform/convex/projects/queries.ts
+++ b/services/platform/convex/projects/queries.ts
@@ -6,7 +6,7 @@
  * `hasProjectAccess` (from `./access`).
  */
 
-import { v } from 'convex/values';
+import { v, type Infer } from 'convex/values';
 
 import type { Doc, Id } from '../_generated/dataModel';
 import { query, type QueryCtx } from '../_generated/server';
@@ -371,6 +371,32 @@ const projectAgentRowValidator = v.object({
 });
 
 /**
+ * Project a `projectAgents` doc onto exactly the declared row fields. The
+ * table can carry vestigial fields from retired features (`autonomyTier`),
+ * and a raw doc with one fails the strict returns validator — which blanks
+ * the whole list for every consumer.
+ */
+function toProjectAgentRow(
+  agent: Doc<'projectAgents'>,
+): Infer<typeof projectAgentRowValidator> {
+  return {
+    _id: agent._id,
+    _creationTime: agent._creationTime,
+    organizationId: agent.organizationId,
+    projectId: agent.projectId,
+    name: agent.name,
+    harness: agent.harness,
+    model: agent.model,
+    skills: agent.skills,
+    connectors: agent.connectors,
+    instructions: agent.instructions,
+    createdBy: agent.createdBy,
+    createdAt: agent.createdAt,
+    updatedAt: agent.updatedAt,
+  };
+}
+
+/**
  * The project's user-created agents, name-sorted, for the Agents tab and the
  * task assignee picker. Fails closed to an empty list when the project is
  * missing, in another org, or unreadable — same posture as
@@ -393,7 +419,9 @@ export const listProjectAgents = query({
       .query('projectAgents')
       .withIndex('by_project', (q) => q.eq('projectId', args.projectId))
       .collect();
-    return agents.sort((a, b) => a.name.localeCompare(b.name));
+    return agents
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(toProjectAgentRow);
   },
 });
 

--- a/services/platform/convex/sandbox/tool_names.ts
+++ b/services/platform/convex/sandbox/tool_names.ts
@@ -14,6 +14,29 @@
 export const ASK_HUMAN_TOOL = 'ask_human';
 
 /**
+ * The baseline knowledge-retrieval pair every managed agent run is granted —
+ * task-agent turns and automation agent turns alike: semantic search over the
+ * organization's knowledge plus the windowed fetch of one source a hit named.
+ * Read-only, and the grant alone never widens visibility: the dispatch
+ * derives what a call may read from the SESSION's binding (a project-bound
+ * run reads its project + the org hub; an org-level automation run reads the
+ * hub only), so a run sees exactly what its deployment surface owns.
+ */
+export const KNOWLEDGE_READ_TOOLS = ['rag_search', 'rag_fetch'] as const;
+
+/** The instructions line that makes the knowledge pair discoverable — the
+ * shim only advertises generic `workspace_tool`, so the turn is told the
+ * names (the same reason the ask_human guidance exists). Shared by every
+ * lane that grants {@link KNOWLEDGE_READ_TOOLS}. */
+export const KNOWLEDGE_TOOLS_GUIDANCE =
+  "The organization's knowledge base is available through the " +
+  '"workspace_tool" MCP tool: rag_search {query} finds the most relevant ' +
+  "passages, rag_fetch {ref} reads one hit's full source (a document file " +
+  'id or a crawled page URL). Use them when you need organization facts ' +
+  'that are not in your staged files; call workspace_status to see ' +
+  'everything granted.';
+
+/**
  * Knowledge refs kept per recorded tool call (`sandboxToolCalls.knowledgeRefs`
  * — the read-set the provenance ledger folds into a run's settle entry).
  * Order-preserving truncation: the first N distinct refs of a result are the

--- a/services/platform/convex/sandbox/workspace_access.test.ts
+++ b/services/platform/convex/sandbox/workspace_access.test.ts
@@ -118,8 +118,9 @@ describe('resolveAgentReadAccess', () => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveWorkspaceKnowledgeScope — the retrieval visibility of one dispatch,
-// derived from what the SESSION proves (never the request).
+// resolveKnowledgeToolAccess — the retrieval access of one dispatch, derived
+// from what the SESSION proves (never the request): binding first, then the
+// turn user (role-checked), else refused with the reason.
 // ---------------------------------------------------------------------------
 
 async function seedProject(
@@ -161,77 +162,139 @@ async function seedSession(
   });
 }
 
-describe('resolveWorkspaceKnowledgeScope', () => {
-  it("a project agent's session sees its project, the project's teams, and the hub", async () => {
+async function seedProjectAgent(
+  t: ReturnType<typeof newTest>,
+  projectId: string,
+): Promise<string> {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('projectAgents', {
+        organizationId: ORG,
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the seeded projects row id
+        projectId: projectId as never,
+        name: 'Filer',
+        harness: 'claude-code',
+        skills: [],
+        connectors: [],
+        createdBy: 'user_seed',
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+  );
+}
+
+async function seedAutomationRun(
+  t: ReturnType<typeof newTest>,
+  args: { projectId?: string },
+): Promise<string> {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('automationRuns', {
+        organizationId: ORG,
+        name: 'filing-desk',
+        version: 1,
+        ...(args.projectId !== undefined
+          ? {
+              // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the seeded projects row id
+              projectId: args.projectId as never,
+            }
+          : {}),
+        status: 'running',
+        mode: 'live',
+        startedBy: 'user_seed',
+        input: {},
+        startedAt: 1,
+      }),
+  );
+}
+
+describe('resolveKnowledgeToolAccess', () => {
+  it("a project agent's session reads its project, the project's teams, and the hub", async () => {
     const t = newTest();
     const projectId = await seedProject(t, {
       teamId: 'team-x',
       sharedWithTeamIds: ['team-y'],
     });
-    const agentId = await t.run(
-      async (ctx) =>
-        await ctx.db.insert('projectAgents', {
-          organizationId: ORG,
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the seeded projects row id
-          projectId: projectId as never,
-          name: 'Filer',
-          harness: 'claude-code',
-          skills: [],
-          connectors: [],
-          createdBy: 'user_seed',
-          createdAt: 1,
-          updatedAt: 1,
-        }),
-    );
+    const agentId = await seedProjectAgent(t, projectId);
     await seedSession(t, {
       sessionId: 'sess_pa',
       ownerType: 'project_agent',
       ownerId: agentId,
     });
-    const scope = await t.query(
-      internal.sandbox.workspace_access.resolveWorkspaceKnowledgeScope,
-      { organizationId: ORG, sessionId: 'sess_pa' },
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      { organizationId: ORG, sessionId: 'sess_pa', subject: 'documents' },
     );
-    expect(scope).toEqual({
-      teamIds: ['team-x', 'team-y'],
-      projectIds: [projectId],
-      includeHub: true,
+    expect(access).toEqual({
+      allowed: true,
+      scope: {
+        teamIds: ['team-x', 'team-y'],
+        projectIds: [projectId],
+        includeHub: true,
+      },
     });
   });
 
-  it("an automation run's session sees the run's project", async () => {
+  it("a project-bound automation run's session reads the run's project", async () => {
     const t = newTest();
     const projectId = await seedProject(t, { teamId: 'team-x' });
-    const runId = await t.run(
-      async (ctx) =>
-        await ctx.db.insert('automationRuns', {
-          organizationId: ORG,
-          name: 'filing-desk',
-          version: 1,
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the seeded projects row id
-          projectId: projectId as never,
-          status: 'running',
-          mode: 'live',
-          startedBy: 'user_seed',
-          input: {},
-          startedAt: 1,
-        }),
-    );
+    const runId = await seedAutomationRun(t, { projectId });
     await seedSession(t, {
       sessionId: 'sess_wf',
       ownerType: 'workflow_run',
       // The owner key format the session naming module writes.
       ownerId: `${runId}:@workflow`,
     });
-    const scope = await t.query(
-      internal.sandbox.workspace_access.resolveWorkspaceKnowledgeScope,
-      { organizationId: ORG, sessionId: 'sess_wf' },
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      { organizationId: ORG, sessionId: 'sess_wf', subject: 'documents' },
     );
-    expect(scope).toEqual({
-      teamIds: ['team-x'],
-      projectIds: [projectId],
-      includeHub: true,
+    expect(access).toEqual({
+      allowed: true,
+      scope: {
+        teamIds: ['team-x'],
+        projectIds: [projectId],
+        includeHub: true,
+      },
     });
+  });
+
+  it('an ORG-LEVEL automation run (no project) reads the hub only', async () => {
+    const t = newTest();
+    const runId = await seedAutomationRun(t, {});
+    await seedSession(t, {
+      sessionId: 'sess_wf_org',
+      ownerType: 'workflow_run',
+      ownerId: `${runId}:@workflow`,
+    });
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      { organizationId: ORG, sessionId: 'sess_wf_org', subject: 'documents' },
+    );
+    expect(access).toEqual({
+      allowed: true,
+      scope: { teamIds: [], projectIds: [], includeHub: true },
+    });
+  });
+
+  it('a run stamped with a DELETED project fails closed, never widened to the hub', async () => {
+    const t = newTest();
+    const projectId = await seedProject(t, { teamId: 'team-x' });
+    const runId = await seedAutomationRun(t, { projectId });
+    await t.run(async (ctx) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the seeded projects row id
+      await ctx.db.delete(projectId as never);
+    });
+    await seedSession(t, {
+      sessionId: 'sess_wf_gone',
+      ownerType: 'workflow_run',
+      ownerId: `${runId}:@workflow`,
+    });
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      { organizationId: ORG, sessionId: 'sess_wf_gone', subject: 'documents' },
+    );
+    expect(access).toEqual({ allowed: false, reason: 'no_access_context' });
   });
 
   it("a user-keyed session falls back to the USER's own visibility", async () => {
@@ -247,59 +310,76 @@ describe('resolveWorkspaceKnowledgeScope', () => {
     const orgWideProject = await seedProject(t, {});
     await seedProject(t, { teamId: 'team-foreign' });
     // Chat external turns own no project-bound session row.
-    const scope = await t.query(
-      internal.sandbox.workspace_access.resolveWorkspaceKnowledgeScope,
-      { organizationId: ORG, sessionId: 'sess_chat', userId: 'u9' },
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      {
+        organizationId: ORG,
+        sessionId: 'sess_chat',
+        userId: 'u9',
+        subject: 'documents',
+      },
     );
-    expect(scope).toEqual({
-      teamIds: [`org_${ORG}`, 'team-mine'],
-      projectIds: [orgWideProject],
-      includeHub: true,
+    expect(access).toEqual({
+      allowed: true,
+      scope: {
+        teamIds: [`org_${ORG}`, 'team-mine'],
+        projectIds: [orgWideProject],
+        includeHub: true,
+      },
     });
   });
 
-  it('a session with neither a project owner nor a user fails CLOSED', async () => {
+  it('the user fallback is role-checked: a disabled membership is refused', async () => {
+    const t = newTest();
+    await seedMember(t, {
+      userId: 'u10',
+      organizationId: ORG,
+      role: 'disabled',
+    });
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      {
+        organizationId: ORG,
+        sessionId: 'sess_chat2',
+        userId: 'u10',
+        subject: 'documents',
+      },
+    );
+    expect(access).toEqual({ allowed: false, reason: 'not_a_member' });
+  });
+
+  it('a session with neither a binding nor a user is refused with the reason', async () => {
     const t = newTest();
     await seedSession(t, {
       sessionId: 'sess_render',
       ownerType: 'render',
       ownerId: 'render_1',
     });
-    const scope = await t.query(
-      internal.sandbox.workspace_access.resolveWorkspaceKnowledgeScope,
-      { organizationId: ORG, sessionId: 'sess_render' },
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      { organizationId: ORG, sessionId: 'sess_render', subject: 'documents' },
     );
-    expect(scope).toEqual({ teamIds: [], projectIds: [], includeHub: false });
+    expect(access).toEqual({ allowed: false, reason: 'no_access_context' });
   });
 
   it("another org's session never yields this org's scope", async () => {
     const t = newTest();
     const projectId = await seedProject(t, { teamId: 'team-x' });
-    const agentId = await t.run(
-      async (ctx) =>
-        await ctx.db.insert('projectAgents', {
-          organizationId: ORG,
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the seeded projects row id
-          projectId: projectId as never,
-          name: 'Filer',
-          harness: 'claude-code',
-          skills: [],
-          connectors: [],
-          createdBy: 'user_seed',
-          createdAt: 1,
-          updatedAt: 1,
-        }),
-    );
+    const agentId = await seedProjectAgent(t, projectId);
     await seedSession(t, {
       sessionId: 'sess_pa2',
       ownerType: 'project_agent',
       ownerId: agentId,
     });
     // The dispatch claims a different org than the session's — fail closed.
-    const scope = await t.query(
-      internal.sandbox.workspace_access.resolveWorkspaceKnowledgeScope,
-      { organizationId: 'org_OTHER', sessionId: 'sess_pa2' },
+    const access = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      {
+        organizationId: 'org_OTHER',
+        sessionId: 'sess_pa2',
+        subject: 'documents',
+      },
     );
-    expect(scope).toEqual({ teamIds: [], projectIds: [], includeHub: false });
+    expect(access).toEqual({ allowed: false, reason: 'no_access_context' });
   });
 });

--- a/services/platform/convex/sandbox/workspace_access.ts
+++ b/services/platform/convex/sandbox/workspace_access.ts
@@ -13,7 +13,6 @@ import { v } from 'convex/values';
 import type { Doc, Id } from '../_generated/dataModel';
 import { internalQuery, type QueryCtx } from '../_generated/server';
 import {
-  NO_KNOWLEDGE_ACCESS,
   resolveKnowledgeAccessForUser,
   type ResolvedKnowledgeAccess,
 } from '../documents/access';
@@ -46,25 +45,32 @@ export const resolveWorkspaceReadAccess = internalQuery({
   },
 });
 
-/** The project a session is bound to, when its owner is one that carries a
- * project: a project agent's standing sandbox (`ownerId` = the projectAgents
- * row id) or an automation run's sandbox (`ownerId` = `${runId}:…`, the run
- * stamped with the task/automation project). `null` for every other owner —
- * chat external turns, renders, legacy sessions. */
-async function sessionProject(
+/** What a session's OWNER proves about knowledge visibility: bound to one
+ * project (a project agent's standing sandbox — `ownerId` = the projectAgents
+ * row id — or an automation run stamped with a project), an org-level
+ * automation run (`ownerType` `workflow_run` whose run carries no project),
+ * or nothing at all — chat external turns, renders, legacy sessions, and any
+ * row whose owner cannot be resolved in this org. */
+type SessionBinding =
+  | { kind: 'project'; project: Doc<'projects'> }
+  | { kind: 'org_run' }
+  | { kind: 'none' };
+
+async function sessionBinding(
   ctx: QueryCtx,
   organizationId: string,
   sessionId: string,
-): Promise<Doc<'projects'> | null> {
+): Promise<SessionBinding> {
   const session = await ctx.db
     .query('sandboxSessions')
     .withIndex('by_sessionId', (q) => q.eq('sessionId', sessionId))
     .first();
   if (session === null || session.organizationId !== organizationId) {
-    return null;
+    return { kind: 'none' };
   }
 
   let projectId: Id<'projects'> | null = null;
+  let orgRun = false;
   if (session.ownerType === 'project_agent') {
     const agentId = ctx.db.normalizeId('projectAgents', session.ownerId);
     const agent = agentId === null ? null : await ctx.db.get(agentId);
@@ -78,59 +84,111 @@ async function sessionProject(
     const run = runId === null ? null : await ctx.db.get(runId);
     if (run !== null && run.organizationId === organizationId) {
       projectId = run.projectId ?? null;
+      // A run deployed without a project is an ORG-LEVEL surface; a run whose
+      // project row is gone stays fail-closed below, never widened.
+      orgRun = run.projectId === undefined;
     }
   }
-  if (projectId === null) return null;
-
-  const project = await ctx.db.get(projectId);
-  return project !== null && project.organizationId === organizationId
-    ? project
-    : null;
+  if (projectId !== null) {
+    const project = await ctx.db.get(projectId);
+    if (project !== null && project.organizationId === organizationId) {
+      return { kind: 'project', project };
+    }
+    return { kind: 'none' };
+  }
+  return orgRun ? { kind: 'org_run' } : { kind: 'none' };
 }
 
 /**
- * The knowledge-retrieval visibility of one sandbox dispatch — derived
- * SERVER-SIDE from what the session token proves, never from the request:
+ * The access of one knowledge-tool dispatch (`rag_search` / `rag_fetch`) —
+ * derived SERVER-SIDE from what the session token proves, never from the
+ * request:
  *
- * - a PROJECT-BOUND session (a project agent's sandbox, an automation run
- *   with a project) sees its project's documents, the libraries of the teams
- *   that project is shared with (`teamId` + `sharedWithTeamIds`), and the
- *   org hub;
- * - a user-keyed session (a chat external turn) sees exactly what that USER
- *   sees — the same rules as the chat assistant and the library listings
- *   (`resolveKnowledgeAccessForUser`);
- * - a session that is neither fails CLOSED.
+ * - a PROJECT-BOUND session (a project agent's sandbox — every task-agent
+ *   turn — or an automation run with a project) reads its project's
+ *   documents, the libraries of the teams that project is shared with
+ *   (`teamId` + `sharedWithTeamIds`), and the org hub;
+ * - an ORG-LEVEL automation run (no project on the run) reads the org hub
+ *   only — exactly the documents every active member already sees;
+ * - a user-keyed session (a chat external turn) reads what that USER reads —
+ *   their role checked against the same matrix as the user-side RLS queries
+ *   (`subject` names the table the ref resolves to), then their own
+ *   team/project visibility (`resolveKnowledgeAccessForUser`);
+ * - a session with neither binding nor user is REFUSED, with the reason.
  */
-export const resolveWorkspaceKnowledgeScope = internalQuery({
+export const resolveKnowledgeToolAccess = internalQuery({
   args: {
     organizationId: v.string(),
     sessionId: v.string(),
     userId: v.optional(v.string()),
+    subject: v.union(v.literal('documents'), v.literal('websites')),
   },
-  returns: v.object({
-    teamIds: v.array(v.string()),
-    projectIds: v.array(v.string()),
-    includeHub: v.boolean(),
-  }),
-  handler: async (ctx, args): Promise<ResolvedKnowledgeAccess> => {
-    const project = await sessionProject(
+  returns: v.union(
+    v.object({
+      allowed: v.literal(true),
+      scope: v.object({
+        teamIds: v.array(v.string()),
+        projectIds: v.array(v.string()),
+        includeHub: v.boolean(),
+      }),
+    }),
+    v.object({
+      allowed: v.literal(false),
+      reason: v.union(
+        v.literal('no_access_context'),
+        v.literal('not_a_member'),
+        v.literal('read_denied'),
+      ),
+    }),
+  ),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    | { allowed: true; scope: ResolvedKnowledgeAccess }
+    | {
+        allowed: false;
+        reason: 'no_access_context' | 'not_a_member' | 'read_denied';
+      }
+  > => {
+    const binding = await sessionBinding(
       ctx,
       args.organizationId,
       args.sessionId,
     );
-    if (project !== null) {
+    if (binding.kind === 'project') {
       return {
-        teamIds: getProjectTeamIds(project),
-        projectIds: [project._id],
-        includeHub: true,
+        allowed: true,
+        scope: {
+          teamIds: getProjectTeamIds(binding.project),
+          projectIds: [binding.project._id],
+          includeHub: true,
+        },
+      };
+    }
+    if (binding.kind === 'org_run') {
+      return {
+        allowed: true,
+        scope: { teamIds: [], projectIds: [], includeHub: true },
       };
     }
     if (args.userId !== undefined) {
-      return await resolveKnowledgeAccessForUser(ctx, {
+      const access = await resolveAgentReadAccess(ctx, {
         organizationId: args.organizationId,
         userId: args.userId,
+        subject: args.subject,
       });
+      if (!access.allowed) {
+        return { allowed: false, reason: access.reason };
+      }
+      return {
+        allowed: true,
+        scope: await resolveKnowledgeAccessForUser(ctx, {
+          organizationId: args.organizationId,
+          userId: args.userId,
+        }),
+      };
     }
-    return { ...NO_KNOWLEDGE_ACCESS };
+    return { allowed: false, reason: 'no_access_context' };
   },
 });

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -56,6 +56,10 @@ import {
   OUTPUT_DIR,
 } from '../node_only/sandbox/session_exec';
 import { projectAgentOwnerId } from '../sandbox/session_naming';
+import {
+  KNOWLEDGE_READ_TOOLS,
+  KNOWLEDGE_TOOLS_GUIDANCE,
+} from '../sandbox/tool_names';
 
 /** The argument shape every turn phase carries verbatim. */
 const turnArgs = {
@@ -528,6 +532,10 @@ export const startTaskAgentTurn = internalAction({
             allowedModels: [routing.gatewayModel],
             connectorGrants: [...args.connectors],
             budgetCents,
+            // Baseline knowledge retrieval: visibility derives from THIS
+            // session's project binding at dispatch, so the grant alone
+            // never widens what the run can read.
+            toolGrants: [...KNOWLEDGE_READ_TOOLS],
           },
           expiresAt: args.deadlineAt,
         },
@@ -558,6 +566,7 @@ export const startTaskAgentTurn = internalAction({
         ...(skillsAddendum !== '' ? [skillsAddendum] : []),
         `Write every file you produce to ${outputDir}/ (this task's own delivery box — never plain /user/output/) — files there are collected when your turn ends and attached to the task.`,
         `Your workspace (/user/workspace) is a standing area shared across ALL tasks assigned to you — files already there may belong to other tasks. Trust the task brief and its staged inputs over anything found lying around.`,
+        KNOWLEDGE_TOOLS_GUIDANCE,
       ].join('\n\n');
 
       const exec = buildExternalTurnExec({
@@ -567,9 +576,9 @@ export const startTaskAgentTurn = internalAction({
         instructions,
         prompt: buildTaskPrompt(brief, args.feedback, outputDir, inputs),
         execId: args.execId,
-        ...(args.connectors.length > 0
-          ? { bridgeUrl: connectorsBridgeUrlForSessions() }
-          : {}),
+        // Always mounted: the knowledge pair rides the bridge, so every
+        // task turn gets the shim even when the agent has no connectors.
+        bridgeUrl: connectorsBridgeUrlForSessions(),
         ...(visionModelRef !== undefined
           ? { vision: { model: visionModelRef } }
           : {}),
@@ -1262,6 +1271,8 @@ export const steerTaskAgentTurn = internalAction({
             allowedModels: [routing.gatewayModel],
             connectorGrants: [...args.connectors],
             budgetCents,
+            // Baseline knowledge retrieval — same grant as the first start.
+            toolGrants: [...KNOWLEDGE_READ_TOOLS],
           },
           expiresAt: args.deadlineAt,
         },
@@ -1321,6 +1332,7 @@ export const steerTaskAgentTurn = internalAction({
         ...(skillsAddendum !== '' ? [skillsAddendum] : []),
         `Write every file you produce to ${outputDir}/ (this task's own delivery box — never plain /user/output/) — files there are collected when your turn ends and attached to the task.`,
         `Your workspace (/user/workspace) is a standing area shared across ALL tasks assigned to you — files already there may belong to other tasks. Trust the task brief and its staged inputs over anything found lying around.`,
+        KNOWLEDGE_TOOLS_GUIDANCE,
       ].join('\n\n');
 
       const exec = buildExternalTurnExec({
@@ -1331,9 +1343,9 @@ export const steerTaskAgentTurn = internalAction({
         prompt,
         execId,
         ...(resume !== undefined ? { resume } : {}),
-        ...(args.connectors.length > 0
-          ? { bridgeUrl: connectorsBridgeUrlForSessions() }
-          : {}),
+        // Always mounted: the knowledge pair rides the bridge, so every
+        // task turn gets the shim even when the agent has no connectors.
+        bridgeUrl: connectorsBridgeUrlForSessions(),
         ...(visionModelRef !== undefined
           ? { vision: { model: visionModelRef } }
           : {}),


### PR DESCRIPTION
## What

Task-agent and automation agent turns now carry `rag_search` + `rag_fetch` as baseline workspace-tool grants, so every managed run can retrieve organization knowledge without per-agent configuration.

- **`rag_fetch` joins the workspace bridge** — windowed full-text reads of a document (by the file id a search hit carries) or a crawled page (by URL), reusing the chat lane's `fetchDocumentByFileId`/`fetchWebPageByUrl` and the same untrusted-content wrapping; the window helpers moved into `knowledge/fetch.ts` so chat and bridge share one implementation.
- **Knowledge-tool access resolves from the SESSION's binding first** (`resolveKnowledgeToolAccess`, evolved from `resolveWorkspaceKnowledgeScope`): a project-bound run (project agent sandbox / automation run with a project) reads its project + shared team libraries + the org hub; an org-level automation run reads the hub only (exactly what every member already sees); a user-keyed turn keeps the role-checked user scope; a session with neither is refused with the reason. A run stamped with a deleted project fails closed, never widened.
- **Grants at all four mint sites**: task lane adds `[rag_search, rag_fetch]`, automation lane extends `[ask_human]` with the pair. The task lane now mounts the connectors-MCP bridge unconditionally (it only mounted with connectors before, which would have left the tools invisible), matching the automation lane's stance.
- Both lanes' instructions name the pair via a shared `KNOWLEDGE_TOOLS_GUIDANCE`; `workspace_status` relays the new tool's description automatically — no shim change, no sandbox image rebuild.
- The other four find tools (`document_find`, `contact_find`, …) still require the turn user's RLS-checked identity — unchanged.

## Why

The six-tool read bridge existed since #2585 but after the AI-backend rewrite (#2857) no lane granted any of it — task tokens carried no `toolGrants` and automation tokens only `ask_human`, so agents in tasks/automations had zero knowledge retrieval. The deploy-time binding is the honest authorization root for user-less runs, and it's the same philosophy the task lane already uses for skills ("a project agent's equipment is the PROJECT's").

## Verification

- `bun run check` green (format, lint, typecheck, all tests: 45/45 tasks).
- New/updated unit coverage: `resolveKnowledgeToolAccess` branches (project agent, project-bound run, org-level run hub-only, deleted-project fail-closed, user fallback incl. role denial, cross-org, no-context refusal) and bridge dispatch (`rag_fetch` URL/doc/windowing/not_found/inline-fallback, subject routing, audit read-set for both shapes).
- **Live E2E on the dev stack, both lanes**:
  - Task lane: a task assigned to a project agent ran `workspace_status` → `rag_search` (ok, hits incl. `sop-9-cleaning.txt`) → `rag_fetch` (ok, quoted real content) and delivered the report file.
  - Automation lane: a minimal project-bound automation with one agent node ran live: `workspace_status` listed `ask_human + rag_search + rag_fetch`, both rag calls ok.
  - Backend: `sandboxSessionTokens.scope.toolGrants` carries the expected sets per lane; `sandboxToolCalls` audit rows record outcome, param-key fingerprints, and the `knowledgeRefs` read-set pinned to the exec — feeding the provenance ledger.

## Notes / follow-ups

- The automation agent node's runtime tool surface (incl. the pre-existing `ask_human`) has no end-user docs yet — the docs tree lost the automation workflow guides in the rewrite; documenting that surface is a standing gap, not widened here.
- Unrelated pre-existing nit noticed while verifying: an automation without an `output` mapping renders its null run output as a JSON-viewer error ('src property must be a valid json object') on the run page.