### PR TITLE
fix(platform): render non-object JSON values as text in JsonViewer

### DIFF
--- a/services/platform/app/components/ui/data-display/json-viewer.test.tsx
+++ b/services/platform/app/components/ui/data-display/json-viewer.test.tsx
@@ -1,15 +1,18 @@
-import { vi, describe, it } from 'vitest';
+import { vi, describe, expect, it } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { render, screen } from '@/tests/utils/render';
 
 import { JsonViewer } from './json-viewer';
 
 vi.mock('@/lib/utils/lazy-component', () => ({
   lazyComponent: (_factory: () => Promise<unknown>) => {
-    // Return a simple pre-based fallback for testing
+    // A pre-based stand-in for the react-json-view tree, with a testid so
+    // tests can assert WHICH rendering path a value took.
     const Component = (props: { src: unknown }) => (
-      <pre>{JSON.stringify(props.src, null, 2)}</pre>
+      <pre data-testid="react-json-view">
+        {JSON.stringify(props.src, null, 2)}
+      </pre>
     );
     Component.displayName = 'LazyComponent';
     return Component;
@@ -17,6 +20,57 @@ vi.mock('@/lib/utils/lazy-component', () => ({
 }));
 
 describe('JsonViewer', () => {
+  // react-json-view accepts only an object/array `src` — anything else used
+  // to surface as the library's own {ERROR: "src property must be a valid
+  // json object"} placeholder (e.g. a run whose automation maps no `output`
+  // shows a null output). Scalars must render as plain JSON text instead.
+  describe('non-container values', () => {
+    it('renders null as JSON text, never through the object-only tree', () => {
+      render(<JsonViewer data={null} />);
+      expect(screen.getByText('null')).toBeInTheDocument();
+      expect(screen.queryByTestId('react-json-view')).not.toBeInTheDocument();
+    });
+
+    it('renders a bare string in its JSON form', () => {
+      render(<JsonViewer data="hello" />);
+      expect(screen.getByText('"hello"')).toBeInTheDocument();
+      expect(screen.queryByTestId('react-json-view')).not.toBeInTheDocument();
+    });
+
+    it('renders numbers and booleans as text', () => {
+      const { unmount } = render(<JsonViewer data={42} />);
+      expect(screen.getByText('42')).toBeInTheDocument();
+      unmount();
+      render(<JsonViewer data={false} />);
+      expect(screen.getByText('false')).toBeInTheDocument();
+    });
+
+    it('a JSON string that parses to a scalar renders as that scalar', () => {
+      render(<JsonViewer data='"quoted"' />);
+      expect(screen.getByText('"quoted"')).toBeInTheDocument();
+      expect(screen.queryByTestId('react-json-view')).not.toBeInTheDocument();
+    });
+
+    it('renders undefined as text instead of an empty tree', () => {
+      render(<JsonViewer data={undefined} />);
+      expect(screen.getByText('undefined')).toBeInTheDocument();
+      expect(screen.queryByTestId('react-json-view')).not.toBeInTheDocument();
+    });
+
+    it('still renders objects and arrays through the tree view', () => {
+      const { unmount } = render(<JsonViewer data={{ a: 1 }} />);
+      expect(screen.getByTestId('react-json-view')).toBeInTheDocument();
+      unmount();
+      render(<JsonViewer data={[1, 2]} />);
+      expect(screen.getByTestId('react-json-view')).toBeInTheDocument();
+    });
+
+    it('passes axe audit with null data', async () => {
+      const { container } = render(<JsonViewer data={null} />);
+      await checkAccessibility(container);
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(

--- a/services/platform/app/components/ui/data-display/json-viewer.tsx
+++ b/services/platform/app/components/ui/data-display/json-viewer.tsx
@@ -55,6 +55,17 @@ export function JsonViewer({
     }
   }, [data]);
 
+  // `react-json-view` accepts only an object or array `src` — anything else
+  // renders as the library's own {ERROR: …} placeholder. JSON scalars are
+  // honest values too (an automation that maps no `output` returns null, a
+  // node can output a bare string), so they render as plain JSON text.
+  const isJsonContainer = typeof parsedData === 'object' && parsedData !== null;
+  const scalarText = useMemo(() => {
+    const text = JSON.stringify(parsedData, null, indentWidth);
+    // JSON.stringify(undefined) is undefined, not a string.
+    return text === undefined ? String(parsedData) : text;
+  }, [parsedData, indentWidth]);
+
   const handleCopy = async () => {
     try {
       setCopied(true);
@@ -92,38 +103,44 @@ export function JsonViewer({
           </Button>
         </div>
       )}
-      <ReactJsonView
-        src={parsedData}
-        name={false}
-        collapsed={collapsedDepth}
-        displayObjectSize={false}
-        displayDataTypes={false}
-        enableClipboard={false}
-        quotesOnKeys={false}
-        indentWidth={indentWidth}
-        theme={{
-          base00: 'hsl(var(--background))',
-          base01: 'hsl(var(--muted))',
-          base02: 'hsl(var(--muted))',
-          base03: 'hsl(var(--foreground))',
-          base04: 'hsl(var(--foreground))',
-          base05: 'hsl(var(--foreground))',
-          base06: 'hsl(var(--muted-foreground))',
-          base07: 'hsl(var(--foreground))',
-          base08: 'hsl(var(--foreground))',
-          base09: 'hsl(var(--destructive))',
-          base0A: 'rgba(70, 70, 230, 1)',
-          base0B: 'rgba(70, 70, 230, 1)',
-          base0C: 'rgba(70, 70, 230, 1)',
-          base0D: 'rgba(70, 70, 230, 1)',
-          base0E: 'rgba(70, 70, 230, 1)',
-          base0F: 'rgba(70, 70, 230, 1)',
-        }}
-        style={{
-          backgroundColor: 'transparent',
-          fontSize: '12px',
-        }}
-      />
+      {isJsonContainer ? (
+        <ReactJsonView
+          src={parsedData}
+          name={false}
+          collapsed={collapsedDepth}
+          displayObjectSize={false}
+          displayDataTypes={false}
+          enableClipboard={false}
+          quotesOnKeys={false}
+          indentWidth={indentWidth}
+          theme={{
+            base00: 'hsl(var(--background))',
+            base01: 'hsl(var(--muted))',
+            base02: 'hsl(var(--muted))',
+            base03: 'hsl(var(--foreground))',
+            base04: 'hsl(var(--foreground))',
+            base05: 'hsl(var(--foreground))',
+            base06: 'hsl(var(--muted-foreground))',
+            base07: 'hsl(var(--foreground))',
+            base08: 'hsl(var(--foreground))',
+            base09: 'hsl(var(--destructive))',
+            base0A: 'rgba(70, 70, 230, 1)',
+            base0B: 'rgba(70, 70, 230, 1)',
+            base0C: 'rgba(70, 70, 230, 1)',
+            base0D: 'rgba(70, 70, 230, 1)',
+            base0E: 'rgba(70, 70, 230, 1)',
+            base0F: 'rgba(70, 70, 230, 1)',
+          }}
+          style={{
+            backgroundColor: 'transparent',
+            fontSize: '12px',
+          }}
+        />
+      ) : (
+        <pre className="font-mono break-words whitespace-pre-wrap">
+          {scalarText}
+        </pre>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

`JsonViewer` fed every value straight into `@microlink/react-json-view`'s `src`, but that library only accepts an object or array — for `null`, a bare string/number/boolean, or `undefined` it renders its own `{ERROR: "src property must be a valid json object"}` placeholder.

Real repro: an automation whose document maps no `output` returns `null`, and the run page's **Run output** panel showed the ERROR object (plus two console errors) instead of the value.

Non-container values now render as plain JSON text (`null`, `"hello"`, `42`, `false`; `undefined` as `undefined`); objects and arrays keep the tree view. This fixes every `JsonViewer` consumer at once — run input/output, node/step detail, effects list, approval card, json-input preview, markdown renderer.

## Verification

- Regression tests cover null / bare string / number / boolean / undefined / JSON-string-parsing-to-scalar routing away from the tree view, objects+arrays staying on it, and an axe audit for the text path (10/10 green).
- `bun run check` green (45/45 tasks).
- Live-verified on the dev stack: the run page that reproduced the bug now renders **Run output: null** as text, console errors gone.