### PR TITLE
fix(platform): ui polish — archive, chat, dialogs, form hints

### DIFF
--- a/services/platform/app/components/ui/forms/field-shell.tsx
+++ b/services/platform/app/components/ui/forms/field-shell.tsx
@@ -46,6 +46,8 @@ export interface FieldShellProps {
   label?: ReactNode;
   /** The rendered `<Description>` — sits under the label. */
   description?: ReactNode;
+  /** A hint rendered below the control (above the error) — for notes that make sense after seeing the input. */
+  hint?: ReactNode;
   /** The rendered error paragraph — sits under the control. */
   error?: ReactNode;
   /** The control itself. */
@@ -69,6 +71,7 @@ export interface FieldShellProps {
 export function FieldShell({
   label,
   description,
+  hint,
   error,
   children,
   className,
@@ -101,6 +104,7 @@ export function FieldShell({
         )}
       >
         {children}
+        {hint}
         {error}
       </div>
     </div>

--- a/services/platform/app/components/ui/forms/input.tsx
+++ b/services/platform/app/components/ui/forms/input.tsx
@@ -55,6 +55,8 @@ type BaseProps = Omit<
     isInvalid?: boolean;
     label?: string;
     description?: ReactNode;
+    /** A note rendered below the input (above the error) — for rules that make sense after seeing the field. */
+    hint?: ReactNode;
     /**
      * A fixed, non-editable addon rendered INSIDE the field's border, right after
      * the value (e.g. a locked email domain `@acme.com`). The value input is
@@ -96,6 +98,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
       isInvalid,
       label,
       description,
+      hint,
       suffix,
       prefix,
       labelInfo,
@@ -114,6 +117,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
     const id = providedId ?? generatedId;
     const errorId = `${id}-error`;
     const descriptionId = `${id}-description`;
+    const hintId = `${id}-hint`;
     const isPassword = type === 'password';
     // A native `readOnly` input auto-selects the borderless display variant
     // (transparent, no ring) unless the caller pins an explicit `variant`, so
@@ -183,7 +187,12 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
     // parent passing e.g. a counter id doesn't clobber the internal error /
     // description associations the Input owns.
     const describedBy =
-      [description && descriptionId, hasError && errorId, callerDescribedBy]
+      [
+        description && descriptionId,
+        hint && hintId,
+        hasError && errorId,
+        callerDescribedBy,
+      ]
         .filter(Boolean)
         .join(' ') || undefined;
 
@@ -219,6 +228,11 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
                 description: (
                   <Description id={descriptionId}>{description}</Description>
                 ),
+              }
+            : {})}
+          {...(hint !== undefined
+            ? {
+                hint: <Description id={hintId}>{hint}</Description>,
               }
             : {})}
           {...(errorMessage !== undefined
@@ -310,6 +324,11 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
                 ),
               }
             : {})}
+          {...(hint !== undefined
+            ? {
+                hint: <Description id={hintId}>{hint}</Description>,
+              }
+            : {})}
           {...(errorMessage !== undefined
             ? {
                 error: (
@@ -399,6 +418,11 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
               description: (
                 <Description id={descriptionId}>{description}</Description>
               ),
+            }
+          : {})}
+        {...(hint !== undefined
+          ? {
+              hint: <Description id={hintId}>{hint}</Description>,
             }
           : {})}
         {...(errorMessage !== undefined

--- a/services/platform/app/components/ui/forms/select.tsx
+++ b/services/platform/app/components/ui/forms/select.tsx
@@ -86,6 +86,8 @@ interface SelectProps extends Omit<
   error?: boolean;
   /** Description text displayed below the select */
   description?: ReactNode;
+  /** A note rendered below the control (above any error) — for context that makes sense after seeing the field. */
+  hint?: ReactNode;
   /**
    * Tooltip shown on the disabled control while `options` is empty — why
    * there is nothing to pick and what creates the first option (e.g. "Add an
@@ -123,6 +125,7 @@ const SelectBase = forwardRef<
       required,
       error,
       description,
+      hint,
       emptyHint,
       className,
       wrapperClassName,
@@ -146,6 +149,7 @@ const SelectBase = forwardRef<
     const generatedId = useId();
     const id = providedId ?? generatedId;
     const descriptionId = `${id}-description`;
+    const hintId = `${id}-hint`;
     const labelId = `${id}-label`;
     // A Radix trigger is a <button>, so a `<label htmlFor>` does NOT name it.
     // Point the trigger at the rendered label via aria-labelledby (unless the
@@ -174,7 +178,11 @@ const SelectBase = forwardRef<
           aria-invalid={error}
           aria-label={ariaLabel}
           aria-labelledby={resolvedLabelledBy}
-          aria-describedby={description ? descriptionId : undefined}
+          aria-describedby={
+            [description && descriptionId, hint && hintId]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
         >
           <SelectPrimitive.Value placeholder={placeholder} />
           <SelectPrimitive.Icon asChild>
@@ -269,7 +277,7 @@ const SelectBase = forwardRef<
       selectRoot
     );
 
-    if (!label && !description) {
+    if (!label && !description && !hint) {
       return wrapperClassName ? (
         <div className={wrapperClassName}>{trigger}</div>
       ) : (
@@ -298,6 +306,11 @@ const SelectBase = forwardRef<
               description: (
                 <Description id={descriptionId}>{description}</Description>
               ),
+            }
+          : {})}
+        {...(hint
+          ? {
+              hint: <Description id={hintId}>{hint}</Description>,
             }
           : {})}
         {...(wrapperClassName !== undefined

--- a/services/platform/app/features/automations/components/upload-automation-dialog.tsx
+++ b/services/platform/app/features/automations/components/upload-automation-dialog.tsx
@@ -460,7 +460,7 @@ export function UploadAutomationDialog({
           {projectId === undefined && (
             <Select
               label={t('upload.targetLabel')}
-              description={t('upload.targetHelp')}
+              hint={t('upload.targetHelp')}
               value={target}
               onValueChange={setTarget}
               options={[

--- a/services/platform/app/features/chat/components/archived-banner.tsx
+++ b/services/platform/app/features/chat/components/archived-banner.tsx
@@ -24,7 +24,7 @@ export function ArchivedBanner({
       gap={2}
       justify="center"
       align="center"
-      className="border-border bg-muted/50 mx-auto w-full max-w-3xl rounded-xl border px-3 py-3 sm:rounded-2xl"
+      className="border-border bg-muted/50 w-full border-t px-3 py-3"
     >
       <Archive className="text-muted-foreground size-4" aria-hidden="true" />
       <span className="text-muted-foreground text-sm">

--- a/services/platform/app/features/chat/components/archived-section.tsx
+++ b/services/platform/app/features/chat/components/archived-section.tsx
@@ -48,8 +48,9 @@ export function ArchivedSection() {
     <section
       ref={setNodeRef}
       className={cn(
-        'border-border mt-1.5 shrink-0 border-t pt-2',
+        'border-border -mx-2.5 mt-1.5 shrink-0 border-t pt-2',
         dropZoneClassName(isOver),
+        'rounded-none',
       )}
     >
       {/* Same header vocabulary as PROJECTS and CHATS, but the WHOLE row is
@@ -59,7 +60,7 @@ export function ArchivedSection() {
         type="button"
         onClick={() => setExpanded((open) => !open)}
         aria-expanded={expanded}
-        className="hover:bg-muted/60 flex h-7 w-full cursor-pointer items-center justify-between gap-1 rounded-md px-2 transition-colors"
+        className="hover:bg-muted/60 flex h-7 w-full cursor-pointer items-center justify-between gap-1 px-2 transition-colors"
       >
         <Text
           as="div"

--- a/services/platform/app/features/chat/components/chat-surface.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.tsx
@@ -1546,14 +1546,14 @@ function ChatSurfaceInner({
             <WelcomeView onSuggestionClick={handleStarterClick} />
           )}
 
-          {!threadNotFound && (
-            <div className="shrink-0 px-4 pb-4">
-              {threadArchived ? (
-                <ArchivedBanner
-                  isUnarchiving={unarchiving}
-                  onUnarchive={handleUnarchive}
-                />
-              ) : (
+          {!threadNotFound &&
+            (threadArchived ? (
+              <ArchivedBanner
+                isUnarchiving={unarchiving}
+                onUnarchive={handleUnarchive}
+              />
+            ) : (
+              <div className="shrink-0 px-4 pb-4">
                 <>
                   <BudgetBanner organizationId={organizationId} />
                   <Composer
@@ -1638,9 +1638,8 @@ function ChatSurfaceInner({
                     className="pt-1 pb-1"
                   />
                 </>
-              )}
-            </div>
-          )}
+              </div>
+            ))}
         </Stack>
 
         {/* Mounted only while open; exports read the view thread — the sibling

--- a/services/platform/app/features/chat/components/export-chat-dialog.tsx
+++ b/services/platform/app/features/chat/components/export-chat-dialog.tsx
@@ -150,46 +150,54 @@ export function ExportChatDialog({
           {t('export.noMessages')}
         </Text>
       ) : (
-        <Stack gap={2} className="min-h-0">
-          <label className="flex items-center gap-2 text-sm">
-            <Checkbox
-              checked={allSelected}
-              onCheckedChange={(checked) =>
-                setDeselected(
-                  checked === true
-                    ? new Set()
-                    : new Set(rows.map((row) => row.id)),
-                )
-              }
-            />
-            {allSelected ? t('export.deselectAll') : t('export.selectAll')}
-          </label>
-          <Stack as="ul" gap={1} className="max-h-72 overflow-y-auto pr-1">
-            {rows.map((row) => (
-              <li key={row.id} className="flex items-start gap-2">
-                <Checkbox
-                  checked={!deselected.has(row.id)}
-                  onCheckedChange={() => toggle(row.id)}
-                  aria-label={roleLabel(row.role)}
-                  className="mt-0.5"
-                />
-                <div className="min-w-0">
-                  <Text variant="muted" className="text-xs font-medium">
-                    {roleLabel(row.role)}
-                  </Text>
-                  <p className="truncate text-sm">
-                    {messagePlainText(row.parts)}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </Stack>
-          <Text variant="muted" className="text-xs">
-            {t('export.messagesCount', {
-              count: selectedRows.length,
-              total: rows.length,
-            })}
-          </Text>
+        <Stack gap={3} className="min-h-0">
+          <div className="border-border divide-border divide-y overflow-hidden rounded-lg border">
+            <label className="hover:bg-muted/30 flex w-full cursor-pointer items-center gap-3 p-3 transition-colors">
+              <Checkbox
+                checked={allSelected}
+                onCheckedChange={(checked) =>
+                  setDeselected(
+                    checked === true
+                      ? new Set()
+                      : new Set(rows.map((row) => row.id)),
+                  )
+                }
+              />
+              <Text className="flex-1 text-sm font-medium">
+                {allSelected ? t('export.deselectAll') : t('export.selectAll')}
+              </Text>
+              <Text variant="muted" className="text-xs">
+                {t('export.messagesCount', {
+                  count: selectedRows.length,
+                  total: rows.length,
+                })}
+              </Text>
+            </label>
+            <div className="max-h-64 overflow-y-auto">
+              <ul className="divide-border divide-y">
+                {rows.map((row) => (
+                  <li key={row.id}>
+                    <label className="hover:bg-muted/30 flex w-full cursor-pointer items-start gap-3 p-3 transition-colors">
+                      <Checkbox
+                        checked={!deselected.has(row.id)}
+                        onCheckedChange={() => toggle(row.id)}
+                        aria-label={roleLabel(row.role)}
+                        className="mt-0.5"
+                      />
+                      <Stack gap={1} className="min-w-0 flex-1">
+                        <Text className="text-sm font-medium">
+                          {roleLabel(row.role)}
+                        </Text>
+                        <Text variant="caption" className="truncate">
+                          {messagePlainText(row.parts)}
+                        </Text>
+                      </Stack>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
         </Stack>
       )}
     </Dialog>

--- a/services/platform/app/features/projects/components/project-create-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-create-dialog.tsx
@@ -184,7 +184,7 @@ export function ProjectCreateDialog({
       <Input
         id="project-key"
         label={t('create.keyLabel')}
-        description={t('create.keyDescription')}
+        hint={t('create.keyDescription')}
         placeholder="TAL"
         maxLength={6}
         autoComplete="off"

--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Alert } from '@tale/ui/alert';
 import { Button } from '@tale/ui/button';
 import { Row } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Skeletonize, useSkeleton } from '@tale/ui/skeleton-context';
-import { AlertTriangle } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { z } from 'zod';
 
@@ -373,19 +371,13 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
       open={open}
       onOpenChange={handleOpenChange}
       title={tAuth('changePassword.title')}
+      description={tAuth('changePassword.warning.description')}
       submitText={tAuth('changePassword.title')}
       isSubmitting={isSubmitting}
       isDirty={isDirty}
       isValid={isValid}
       onSubmit={handleSubmit(onSubmit)}
     >
-      <Alert
-        variant="warning"
-        icon={AlertTriangle}
-        title={tAuth('changePassword.warning.title')}
-        description={tAuth('changePassword.warning.description')}
-      />
-
       <Input
         id="current-password"
         type="password"

--- a/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Alert } from '@tale/ui/alert';
 import { Button } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
 import { ConvexError } from 'convex/values';
 import { useState, useMemo, useEffect } from 'react';
 import * as z from 'zod';
@@ -280,10 +280,9 @@ export function AddMemberDialog({
         />
 
         {emailBelongsToExistingUser ? (
-          <Alert
-            variant="info"
-            description={tDialogs('addMember.existingUserHint')}
-          />
+          <Text variant="muted" className="text-sm">
+            {tDialogs('addMember.existingUserHint')}
+          </Text>
         ) : (
           <FormSection>
             <Input
@@ -311,33 +310,24 @@ export function AddMemberDialog({
         open={showCredentials}
         onOpenChange={handleClose}
         title={tDialogs('memberAdded.title')}
+        description={
+          isExistingUser
+            ? tDialogs('memberAdded.existingUserNotice')
+            : tDialogs('memberAdded.credentialsWarning')
+        }
       >
         <Stack gap={4}>
-          {isExistingUser ? (
-            <Alert
-              variant="info"
-              description={tDialogs('memberAdded.existingUserNotice')}
-            />
-          ) : (
-            <>
-              <Alert
-                variant="warning"
-                description={tDialogs('memberAdded.credentialsWarning')}
+          {!isExistingUser && credentials && (
+            <Stack gap={4}>
+              <CopyableField
+                value={credentials.email}
+                label={tSettings('form.email')}
               />
-
-              {credentials && (
-                <Stack gap={4}>
-                  <CopyableField
-                    value={credentials.email}
-                    label={tSettings('form.email')}
-                  />
-                  <CopyableField
-                    value={credentials.password}
-                    label={tSettings('form.password')}
-                  />
-                </Stack>
-              )}
-            </>
+              <CopyableField
+                value={credentials.password}
+                label={tSettings('form.password')}
+              />
+            </Stack>
           )}
 
           <Button onClick={handleClose} fullWidth>

--- a/services/platform/app/features/shared/markdown/structured-message/section-renderers.tsx
+++ b/services/platform/app/features/shared/markdown/structured-message/section-renderers.tsx
@@ -11,7 +11,6 @@
 import { Button } from '@tale/ui/button';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
-import { Text } from '@tale/ui/text';
 import { memo, useMemo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
@@ -43,9 +42,6 @@ export const NextStepsSection = memo(
 
     return (
       <section aria-label={t('structured.nextSteps')}>
-        <Text variant="label-sm" className="text-muted-foreground mb-2">
-          {t('structured.nextSteps')}
-        </Text>
         <div className="structured-next-steps">
           {items.map((item) => (
             <Button

--- a/services/platform/app/routes/dashboard/$id/chat/shared/$shareToken.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat/shared/$shareToken.tsx
@@ -1,4 +1,12 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { Button } from '@tale/ui/button';
+import {
+  createFileRoute,
+  useCanGoBack,
+  useNavigate,
+  useRouter,
+} from '@tanstack/react-router';
+import { X } from 'lucide-react';
+import { useCallback } from 'react';
 
 import {
   AdaptiveHeaderRoot,
@@ -15,12 +23,32 @@ export const Route = createFileRoute('/dashboard/$id/chat/shared/$shareToken')({
 function SharedChatPage() {
   const { id: organizationId, shareToken } = Route.useParams();
   const { t } = useT('chat');
+  const { t: tCommon } = useT('common');
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+  const navigate = useNavigate();
+
+  const handleClose = useCallback(() => {
+    if (canGoBack) {
+      router.history.back();
+    } else {
+      void navigate({ to: '/dashboard/$id', params: { id: organizationId } });
+    }
+  }, [canGoBack, router, navigate, organizationId]);
 
   return (
     <PageLayout
       header={
         <AdaptiveHeaderRoot standalone={false}>
           <AdaptiveHeaderTitle>{t('share.sharedChat')}</AdaptiveHeaderTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={X}
+            onClick={handleClose}
+            aria-label={tCommon('close')}
+            className="-mr-1 ml-auto"
+          />
         </AdaptiveHeaderRoot>
       }
       organizationId={organizationId}

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -447,7 +447,6 @@ auth:
       confirmRequired: Neues Passwort bestätigen
       mismatch: Passwörter stimmen nicht überein
     warning:
-      title: Du wirst überall abgemeldet
       description:
         Beim Ändern deines Passworts wirst du auf allen Geräten abgemeldet.
         Du musst dich anschließend mit deinem neuen Passwort erneut anmelden.
@@ -522,7 +521,7 @@ automations:
   builder:
     new: Neue Automatisierung
     title: Neue Automatisierung
-    description: Beschreibe dein Ziel.
+    description: Beschreibe, welches Ziel diese Automatisierung erreichen soll.
     goalLabel: Ziel
     goalPlaceholder:
       z. B. Lies jeden Morgen die neuesten Support-E-Mails und schreibe eine

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -425,7 +425,6 @@ auth:
       confirmRequired: Confirm your new password
       mismatch: Passwords don't match
     warning:
-      title: You'll be signed out everywhere
       description:
         Changing your password signs you out of all devices. You'll need to
         sign in again with your new password.
@@ -496,7 +495,7 @@ automations:
   builder:
     new: New automation
     title: New automation
-    description: Describe your goal.
+    description: Describe what goal you want this automation to achieve.
     goalLabel: Goal
     goalPlaceholder:
       e.g. Every morning, read the newest support emails and write one digest

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -447,7 +447,6 @@ auth:
       confirmRequired: Confirme ton nouveau mot de passe
       mismatch: Les mots de passe ne correspondent pas
     warning:
-      title: Tu seras déconnecté partout
       description:
         Changer ton mot de passe te déconnecte de tous les appareils. Tu
         devras te reconnecter avec ton nouveau mot de passe.
@@ -527,7 +526,7 @@ automations:
   builder:
     new: Nouvelle automatisation
     title: Nouvelle automatisation
-    description: Décris ton objectif.
+    description: Décris l'objectif que tu veux que cette automatisation atteigne.
     goalLabel: Objectif
     goalPlaceholder:
       p. ex. Chaque matin, lis les derniers e-mails du support et écris un


### PR DESCRIPTION
## Summary

- **Export chat dialog** — the message list was using raw HTML elements with no visual structure. Restructured to match the share chat dialog's bordered divide-y pattern so both dialogs feel consistent. The selected count was floating below the list with no clear relationship to it, so it was moved into the select-all header row where it reads as one unit.

- **Shared chat preview** — when a user clicked Preview from the share dialog, they were taken to the shared chat page with no way to get back. Added an X button to the header so they can close the preview and return to where they came from.

- **Archive banner (chat)** — the banner was constrained by its parent's padding so it didn't fill the full width, and had a border radius that made it feel like a card rather than a bar. Moved it outside the padded container, stripped the radius, and kept only a top border so it sits flush as a proper footer bar.

- **Archived section (sidebar)** — similarly had a border radius and was inset from the sidebar edges. Pulled it to full width with a negative margin and removed the radius so it reads as a section divider, not a card.

- **"Suggested follow-ups" label** — the AI response already closes with a line like "Want me to tweak anything?" before the follow-up buttons. The "Suggested follow-ups" heading above the buttons was redundant and added visual noise. Removed the visible label while keeping the aria-label on the section for screen readers.

- **Form hint slot** — some field descriptions explain rules that only make sense after you see the input (e.g. "Fixed — can't be changed after the project is created"). These were rendering above the input using the description slot, which is by design for the label column layout but wrong for this use case. Added a hint prop to FieldShell, Input, and Select that renders below the control instead. Used for the project key field and the upload automation target field.

- **Change password dialog** — had a yellow warning alert inside the dialog body saying "You'll be signed out everywhere". Being signed out after a password change is standard expected behaviour, not a danger worth alarming users over. Moved it to the dialog subtitle as a calm one-liner.

- **Member add dialog** — after adding a member, a warning alert inside the body said "Save these credentials now — they won't be shown again." and a separate info alert explained the existing-user case. Both were moved to the ViewDialog description where they belong, and the inline existing-user hint in the add form was changed from an Alert to plain muted text.

- **New automation dialog** — the description just said "Describe your goal." which was too vague. Updated to "Describe what goal you want this automation to achieve." across all three locales.

## Test plan

- [ ] Export chat: message list shows bordered rows; count appears in the select-all header row
- [ ] Shared chat preview: X button closes and returns to the previous page (or dashboard if deep-linked)
- [ ] Archived banner fills the full chat width with only a top border, no radius
- [ ] Archived sidebar section fills the full sidebar width with no radius
- [ ] Project key field: hint text appears below the input
- [ ] Upload automation target: hint text appears below the dropdown
- [ ] Change password dialog: sign-out note appears as the dialog subtitle, no yellow alert
- [ ] Member add dialog: existing-user flow shows plain muted text; credentials dialog shows warning as subtitle
- [ ] New automation dialog: description reads the updated text