### PR TITLE
feat(platform): let people follow or silence a task, and notify bulk edits

### DIFF
--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -108,6 +108,7 @@ import { TaskRunFailureBanner } from './task-run-failure-banner';
 import { TaskStatusBadge } from './task-status-badge';
 import { TaskSubjectPanel } from './task-subject-panel';
 import { TaskTimeline } from './task-timeline';
+import { TaskWatchControl } from './task-watch-control';
 
 /** Strip the client-only `previewUrl` so the value matches the mutations'
  *  strict `attachments` validator. Always an array (an empty array sent to
@@ -1628,6 +1629,10 @@ function EditTaskBody({
                   {formatDate(new Date(task.createdAt), 'medium')}
                 </span>
               </PropertyField>
+              {/* Closes this section: who made the task, when — and whether the
+                viewer hears about it. Watching needs read access only, so it
+                sits outside the canEdit gate that follows. */}
+              <TaskWatchControl taskId={task._id} />
               {canEdit && (
                 <>
                   <PanelDivider />

--- a/services/platform/app/features/tasks/components/task-watch-control.tsx
+++ b/services/platform/app/features/tasks/components/task-watch-control.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { Eye, EyeOff } from 'lucide-react';
+
+import { toast } from '@/app/hooks/use-toast';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import { useSetTaskMuted, useSubscribeToTask } from '../hooks/mutations';
+import { useTaskSubscription } from '../hooks/queries';
+
+/**
+ * ONE switch for "do I hear about this task".
+ *
+ * Being notified is otherwise implicit — you get a task's comments and status
+ * because you created it, own it, commented on it, were mentioned, or review it.
+ * That covers the common cases and nothing else: no way to watch a task you
+ * merely care about, and no way to quiet a noisy one short of muting a whole
+ * category in Settings.
+ *
+ * Unwatch MUTES rather than unsubscribes, deliberately. Deleting the
+ * subscription would look identical and then quietly undo itself: `autoSubscribe`
+ * re-creates a row the next time you comment, get mentioned, get assigned or are
+ * made reviewer, so the task starts talking again with no action from you. A
+ * muted row survives all of that (`autoSubscribe` returns early when a row
+ * exists, and `taskSubscriberUserIds` skips muted rows), so "unwatch" means what
+ * it says. Watching again clears the mute — `subscribeToTask` unmutes an existing
+ * row.
+ *
+ * Directed notifications are NOT affected either way: a mention, an assignment
+ * or a review request still reaches you. Unwatch silences the ambient fan-out,
+ * not the things addressed to you.
+ */
+export function TaskWatchControl({ taskId }: { taskId: Id<'tasks'> }) {
+  const { t } = useT('tasks');
+  const { t: tCommon } = useT('common');
+  const { subscribed, muted } = useTaskSubscription(taskId);
+  const subscribe = useSubscribeToTask();
+  const setMuted = useSetTaskMuted();
+  const watching = subscribed && !muted;
+  const busy = subscribe.isPending || setMuted.isPending;
+
+  return (
+    // A panel ACTION, sitting with Archive rather than among the read-only
+    // properties: same secondary full-width button, same verb-first label.
+    // `shrink-0` for the same reason Archive needs it — the panel is a
+    // height-constrained flex column, and a fixed-height control compresses to
+    // its one-line min-content without it.
+    <Button
+      variant="secondary"
+      size="sm"
+      className="w-full shrink-0"
+      icon={watching ? EyeOff : Eye}
+      disabled={busy}
+      onClick={() =>
+        void (async () => {
+          try {
+            await (watching
+              ? setMuted.mutateAsync({ taskId, muted: true })
+              : subscribe.mutateAsync({ taskId }));
+          } catch (error) {
+            console.error('[tasks] watch toggle failed', error);
+            toast({ title: tCommon('errors.generic'), variant: 'destructive' });
+          }
+        })()
+      }
+    >
+      {watching ? t('watch.unwatch') : t('watch.watch')}
+    </Button>
+  );
+}

--- a/services/platform/app/features/tasks/hooks/mutations.ts
+++ b/services/platform/app/features/tasks/hooks/mutations.ts
@@ -100,3 +100,15 @@ export function useStartTaskAgentRun() {
 export function useCancelTaskAgentRun() {
   return useConvexMutation(api.tasks.mutations.cancelTaskAgentRun);
 }
+
+export function useSubscribeToTask() {
+  return useConvexMutation(api.collab.subscriptions.subscribeToTask);
+}
+
+export function useUnsubscribeFromTask() {
+  return useConvexMutation(api.collab.subscriptions.unsubscribeFromTask);
+}
+
+export function useSetTaskMuted() {
+  return useConvexMutation(api.collab.subscriptions.setTaskMuted);
+}

--- a/services/platform/app/features/tasks/hooks/queries.ts
+++ b/services/platform/app/features/tasks/hooks/queries.ts
@@ -175,3 +175,16 @@ export function useMentionTriggerPreview(
   );
   return { previews: data ?? [], isLoading };
 }
+
+/** Whether the viewer follows this task, and whether they've silenced it. */
+export function useTaskSubscription(taskId: Id<'tasks'> | undefined) {
+  const { data, isLoading } = useConvexQuery(
+    api.collab.subscriptions.isSubscribedToTask,
+    taskId ? { taskId } : 'skip',
+  );
+  return {
+    subscribed: data?.subscribed ?? false,
+    muted: data?.muted ?? false,
+    isLoading,
+  };
+}

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -2067,6 +2067,16 @@ export const bulkUpdateTasks = mutation({
           fromValue: task.status,
           toValue: args.status,
         });
+        // Watchers hear a bulk move exactly as they hear a single one — a drag
+        // of twenty cards is twenty state changes, not a silent one. Collapse
+        // keeps it to one row per task per dimension (see collab/coalesce.ts).
+        await notifyTaskStatusChanged(ctx, {
+          task: updatedTask,
+          fromStatus: task.status,
+          toStatus: args.status,
+          actorType: 'user',
+          actorId: auth.userId,
+        });
         await emitEvent(ctx, {
           organizationId: task.organizationId,
           eventType: 'task.status_changed',
@@ -2078,6 +2088,14 @@ export const bulkUpdateTasks = mutation({
             actorId: auth.userId,
           },
         });
+        // And a bulk drag INTO In review opens the gate, like the single-card
+        // path — otherwise those cards sit there with nobody asked to review.
+        if (args.status === 'in_review') {
+          await requestTaskReview(ctx, {
+            task: updatedTask,
+            trigger: { kind: 'human', actorId: auth.userId },
+          });
+        }
       }
       if (assigneeChanged) {
         await recordActivity(ctx, {
@@ -2087,6 +2105,19 @@ export const bulkUpdateTasks = mutation({
           action: 'assignee.changed',
           fromValue: task.assigneeId ?? undefined,
           toValue: assignee?.assigneeId,
+        });
+        await notifyTaskAssigned(ctx, {
+          task: updatedTask,
+          assigneeType: assignee?.assigneeType ?? null,
+          assigneeId: assignee?.assigneeId ?? null,
+          actorType: 'user',
+          actorId: auth.userId,
+          ...(task.assigneeType !== undefined
+            ? { previousAssigneeType: task.assigneeType }
+            : {}),
+          ...(task.assigneeId !== undefined
+            ? { previousAssigneeId: task.assigneeId }
+            : {}),
         });
         await emitEvent(ctx, {
           organizationId: task.organizationId,

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6471,6 +6471,9 @@ tasks:
     search: Personen suchen
     clear: Reviewer entfernen
     editorsOnly: Reviewer kann nur sein, wer dieses Projekt bearbeiten kann.
+  watch:
+    watch: Verfolgen
+    unwatch: Nicht mehr verfolgen
   runFailure:
     title: Agent konnte nicht starten
     description: '{agent} konnte nicht starten: {reason}. Der Status der Aufgabe

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6533,6 +6533,9 @@ tasks:
     search: Search people
     clear: Clear reviewer
     editorsOnly: Only members who can edit this project can be the reviewer.
+  watch:
+    watch: Watch
+    unwatch: Unwatch
   runFailure:
     title: Agent couldn't start this task
     description: '{agent} could not start: {reason}. The task status is unchanged.'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6585,6 +6585,9 @@ tasks:
     search: Rechercher des personnes
     clear: Retirer le relecteur
     editorsOnly: Seuls les membres qui peuvent modifier ce projet peuvent être relecteurs.
+  watch:
+    watch: Suivre
+    unwatch: Ne plus suivre
   runFailure:
     title: L'agent n'a pas pu démarrer
     description: "{agent} n'a pas pu démarrer : {reason}. Le statut de la tâche


### PR DESCRIPTION
> Stacked on #2969 — this PR's diff is the fourth commit.

## Why

**Following a task was implicit and unchangeable.** You heard about a task because you created it, own it, commented, were mentioned, or review it. That covers the common cases and nothing else: there was no way to follow a task you merely care about, and no way to quiet a noisy one short of muting a whole category in Settings. `subscribeToTask` / `unsubscribeFromTask` / `setTaskMuted` / `isSubscribedToTask` already existed in `convex/collab/subscriptions.ts` with no interface reaching them.

**Bulk edits went silent.** `bulkUpdateTasks` recorded activity and emitted automation events but wrote no notifications, and a bulk drag into In review opened no gate — the same move card-by-card told everyone.

## What changes

A Follow / Following control with a mute toggle in the task sheet's property panel (`task-watch-control.tsx`), placed above the immutable metadata: the viewer's own relationship to the task, on their terms. Mute keeps the subscription (so the reason you were subscribed survives) and only stops the fan-out — `taskSubscriberUserIds` skips muted rows.

`bulkUpdateTasks` now fans out exactly like the single-card path — status changes, assignment changes (including the unassignment notice), and a review request when the bulk target is In review. The per-dimension collapse keeps a twenty-card drag to one row per task rather than a flood.

## Verification

`bun run check` clean, including the UI test project. The control is three existing mutations plus a query; the bulk path reuses the same emitters the single-card path was already verified against.