### PR TITLE
fix(platform): let the inbox query return coalesced notification rows

### DIFF
--- a/services/platform/convex/collab/coalesce.test.ts
+++ b/services/platform/convex/collab/coalesce.test.ts
@@ -7,6 +7,7 @@
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
+import { api } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
 import schema from '../schema';
 import {
@@ -306,6 +307,38 @@ describe('writeCoalescedNotification', () => {
 
     expect(await rowsFor(t)).toHaveLength(1);
     expect(await rowsFor(t, 'user_other')).toHaveLength(1);
+  });
+
+  // The fields this module adds travel on WHOLE rows through the inbox query's
+  // closed return validator. Omit one there and the query throws on validation,
+  // which the panel shows as an empty inbox — a notification written perfectly
+  // and never seen. So read the row back the way the bell does.
+  it('is readable by the inbox query it will be rendered from', async () => {
+    const t = convexTest(schema, modules);
+    const taskId = await seedTask(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberMirror', {
+        memberId: `m_${RECIPIENT}`,
+        userId: RECIPIENT,
+        organizationId: ORG,
+        role: 'editor',
+        createdAt: 0,
+      });
+      await writeCoalescedNotification(ctx, assignment(taskId, 'assigned'));
+    });
+
+    const inbox = await t
+      .withIdentity({ subject: RECIPIENT })
+      .query(api.collab.notifications.listMyNotifications, {
+        organizationId: ORG,
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+
+    expect(inbox.page).toHaveLength(1);
+    expect(inbox.page[0]).toMatchObject({
+      type: 'task_assigned',
+      coalesceKey: `task:${String(taskId)}:assignment`,
+    });
   });
 
   it('keeps two tasks independent', async () => {

--- a/services/platform/convex/collab/notifications.ts
+++ b/services/platform/convex/collab/notifications.ts
@@ -53,6 +53,12 @@ const notificationRowValidator = v.object({
   read: v.boolean(),
   readAt: v.optional(v.number()),
   createdAt: v.number(),
+  // Collapse plumbing (see `collab/coalesce.ts`). The panel ignores both, but
+  // this validator describes WHOLE rows straight out of `paginate()` — omitting
+  // a field the writer sets makes the query throw on return validation, and an
+  // inbox that throws reads to the user as an inbox with nothing in it.
+  coalesceKey: v.optional(v.string()),
+  emailJobId: v.optional(v.id('_scheduled_functions')),
 });
 
 export const listMyNotifications = query({


### PR DESCRIPTION
## The bug

`listMyNotifications` (`convex/collab/notifications.ts`) describes whole `userNotifications` rows with a **closed** object validator. The coalescing engine added two fields to that table — `coalesceKey` and `emailJobId` — and they were never added to the validator.

Convex validates return values, so every row written since then makes the query **throw**. An inbox that throws renders as an inbox with nothing in it: the bell went quiet for every user and every notification type, while the rows themselves were being written perfectly.

Caught by the `return loop: assigning a task notifies and calls back the assignee` E2E, which assigns a task and then opens the assignee's bell — it failed on all three attempts, which is what distinguished it from the usual shard flake.

## The fix

Add both fields to `notificationRowValidator`, with a comment on why a field the panel ignores still has to be declared here.

Then read a coalesced row **back through the query** in `coalesce.test.ts`. The collapse suite already proved the row was written correctly — that is precisely why it missed a reader that couldn't return it. Verified by removing the validator fields again: the new test fails with `Return value validation failed for query "collab/notifications:listMyNotifications"`.

## Note on scope

The empty inbox is live on `main` (it shipped with the coalescing engine), so this is a fix off `main` rather than part of the remaining stack.
