### PR TITLE
fix(platform): hide unbounded BM25 scores on website search

### DIFF
--- a/services/platform/app/features/websites/components/website-pages-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-pages-dialog.tsx
@@ -157,16 +157,9 @@ function SearchResultItem({ result }: { result: CrawlerSearchResult }) {
   return (
     <BorderedSection>
       <div className="space-y-2">
-        <Row gap={2} align="start" justify="between">
-          <Heading level={3} size="sm" weight="medium">
-            {result.title || result.url}
-          </Heading>
-          <Text variant="caption" className="text-muted-foreground shrink-0">
-            {t('pagesDialog.searchResultScore', {
-              score: (result.score * 100).toFixed(0) + '%',
-            })}
-          </Text>
-        </Row>
+        <Heading level={3} size="sm" weight="medium">
+          {result.title || result.url}
+        </Heading>
         <Text variant="caption">
           <a
             href={result.url}

--- a/services/platform/app/features/websites/components/website-view-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-view-dialog.tsx
@@ -168,21 +168,14 @@ function SearchResultItem({ result }: { result: CrawlerSearchResult }) {
   return (
     <BorderedSection>
       <div className="space-y-2">
-        <Row gap={2} align="start" justify="between" className="min-w-0">
-          <Heading
-            level={3}
-            size="sm"
-            weight="medium"
-            className="min-w-0 break-words"
-          >
-            {result.title || result.url}
-          </Heading>
-          <Text variant="caption" className="text-muted-foreground shrink-0">
-            {t('pagesDialog.searchResultScore', {
-              score: (result.score * 100).toFixed(0) + '%',
-            })}
-          </Text>
-        </Row>
+        <Heading
+          level={3}
+          size="sm"
+          weight="medium"
+          className="min-w-0 break-words"
+        >
+          {result.title || result.url}
+        </Heading>
         <Text variant="caption">
           <a
             href={result.url}

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6907,7 +6907,6 @@ websites:
     noSearchResults: Keine Ergebnisse gefunden
     noChunks: Keine Chunks für diese Seite indexiert
     chunkIndex: Chunk {index}
-    searchResultScore: 'Score: {score}'
   filter:
     status:
       idle: Inaktiv

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6958,7 +6958,6 @@ websites:
     noSearchResults: No results found
     noChunks: No chunks indexed for this page
     chunkIndex: Chunk {index}
-    searchResultScore: 'Score: {score}'
   filter:
     status:
       idle: Idle

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7024,7 +7024,6 @@ websites:
     noSearchResults: Aucun résultat trouvé
     noChunks: Aucun fragment indexé pour cette page
     chunkIndex: Fragment {index}
-    searchResultScore: 'Score : {score}'
   filter:
     status:
       idle: Inactif


### PR DESCRIPTION
## Summary
- Website content search treated ParadeDB BM25 (unbounded) as a 0–1 similarity and rendered values like `Score: 1231%`.
- The pages and view dialogs no longer show a score. Results stay ordered by BM25; the API field is unchanged.
- Dropped the unused `pagesDialog.searchResultScore` string from en, de, and fr.

## Test plan
- [ ] Open a website, search crawled content in the pages dialog and the view dialog — no Score caption.
- [ ] Confirm hits still appear in relevance order (title, URL, chunk).
- [ ] i18n parity: `bun run --filter @tale/platform test lib/i18n/messages.test.ts`