### PR TITLE
fix(platform): replace retired DeepSeek aliases with V4 model ids

### DIFF
--- a/configs/platform/system/models/deepseek/models.yml
+++ b/configs/platform/system/models/deepseek/models.yml
@@ -1,21 +1,10 @@
 # Static model catalog for the deepseek connector. DeepSeek's native API
-# serves two PERSISTENT alias ids — `deepseek-chat` (the non-thinking
-# flagship line) and `deepseek-reasoner` (the thinking line) — that always
-# point at the current model generation, so the catalog pins the aliases,
-# not dated snapshots. Capability facts mirror the current V4 generation as
-# listed publicly on 2026-07-21; pricing is cents per million tokens.
-- id: deepseek-chat
-  provider: deepseek
-  tags:
-    - chat
-  supportsTools: true
-  supportsVision: false
-  contextWindow: 1048576
-  maxOutputTokens: 384000
-  pricing:
-    inputCentsPerMillion: 43.5
-    outputCentsPerMillion: 87
-- id: deepseek-reasoner
+# serves two generation ids — `deepseek-v4-flash` and `deepseek-v4-pro` —
+# each with thinking and non-thinking via the effort knob. The retired
+# `deepseek-chat` / `deepseek-reasoner` aliases stopped resolving on
+# 2026-07-24. Capability facts and pricing (cents per million tokens)
+# match the official API listing as of 2026-08-14.
+- id: deepseek-v4-flash
   provider: deepseek
   tags:
     - chat
@@ -23,6 +12,21 @@
   supportsVision: false
   reasoning:
     knob: effort
+    off: none
+  contextWindow: 1048576
+  maxOutputTokens: 384000
+  pricing:
+    inputCentsPerMillion: 14
+    outputCentsPerMillion: 28
+- id: deepseek-v4-pro
+  provider: deepseek
+  tags:
+    - chat
+  supportsTools: true
+  supportsVision: false
+  reasoning:
+    knob: effort
+    off: none
   contextWindow: 1048576
   maxOutputTokens: 384000
   pricing:

--- a/configs/platform/system/providers/deepseek/provider.yml
+++ b/configs/platform/system/providers/deepseek/provider.yml
@@ -1,8 +1,8 @@
 # AI provider connector — DeepSeek's OpenAI-compatible API. The base URL is
 # the documented root (the vendor accepts both with and without a /v1
 # segment; the platform's client appends its own paths). Static model
-# catalog (models/deepseek/models.yml) pinning the persistent deepseek-chat /
-# deepseek-reasoner alias ids.
+# catalog (models/deepseek/models.yml) pinning the current generation ids
+# (deepseek-v4-flash / deepseek-v4-pro).
 name: deepseek
 displayName: DeepSeek
 apiFormat: openai

--- a/services/platform/app/features/chat/components/chat-surface.test.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.test.tsx
@@ -356,8 +356,8 @@ describe('ChatSurface while its reads are still loading', () => {
       data: {
         models: [
           {
-            id: 'deepseek-chat',
-            label: 'deepseek-chat',
+            id: 'deepseek-v4-flash',
+            label: 'deepseek-v4-flash',
             providerSlug: 'deepseek',
             credential: { authMethod: 'api-key' as const },
           },
@@ -424,15 +424,15 @@ describe('ChatSurface while its reads are still loading', () => {
  */
 describe('ChatSurface when the backend is live and a model is listed', () => {
   const MODEL = {
-    id: 'deepseek-chat',
-    label: 'deepseek-chat',
+    id: 'deepseek-v4-flash',
+    label: 'deepseek-v4-flash',
     providerSlug: 'deepseek',
     credential: { authMethod: 'api-key' as const },
   };
 
   const SECOND_MODEL = {
-    id: 'deepseek-reasoner',
-    label: 'deepseek-reasoner',
+    id: 'deepseek-v4-pro',
+    label: 'deepseek-v4-pro',
     providerSlug: 'deepseek',
     credential: { authMethod: 'api-key' as const },
   };
@@ -492,7 +492,7 @@ describe('ChatSurface when the backend is live and a model is listed', () => {
     ).toBeEnabled();
     expect(
       screen.getByRole('button', { name: 'Choose model and reasoning effort' }),
-    ).toHaveTextContent('deepseek-chat');
+    ).toHaveTextContent('deepseek-v4-flash');
   });
 
   // Send-then-wait: processing media no longer blocks the button — a click
@@ -600,7 +600,7 @@ describe('ChatSurface when the backend is live and a model is listed', () => {
 
     expect(
       screen.getByRole('button', { name: 'Choose model and reasoning effort' }),
-    ).toHaveTextContent('deepseek-reasoner');
+    ).toHaveTextContent('deepseek-v4-pro');
   });
 
   it('saves an explicit model pick, and only an explicit one', async () => {
@@ -625,11 +625,11 @@ describe('ChatSurface when the backend is live and a model is listed', () => {
     await openSection(user, /^Model/);
     fireEvent.click(
       await screen.findByRole('menuitemradio', {
-        name: (name: string) => name.startsWith('deepseek-reasoner'),
+        name: (name: string) => name.startsWith('deepseek-v4-pro'),
       }),
     );
 
-    expect(save).toHaveBeenCalledWith('deepseek-reasoner');
+    expect(save).toHaveBeenCalledWith('deepseek-v4-pro');
   });
 
   it('defaults a fresh session to Auto when the catalog offers a choice', () => {
@@ -747,7 +747,7 @@ describe('ChatSurface when the backend is live and a model is listed', () => {
     await waitFor(() => {
       expect(start).toHaveBeenCalledWith({
         text: 'Hello there',
-        modelId: 'deepseek-chat',
+        modelId: 'deepseek-v4-flash',
         providerSlug: 'deepseek',
       });
       expect(navigateMock).toHaveBeenCalledWith({
@@ -930,8 +930,8 @@ describe('ChatSurface on a dead thread link', () => {
       data: {
         models: [
           {
-            id: 'deepseek-chat',
-            label: 'deepseek-chat',
+            id: 'deepseek-v4-flash',
+            label: 'deepseek-v4-flash',
             providerSlug: 'deepseek',
             credential: { authMethod: 'api-key' as const },
           },
@@ -1003,8 +1003,8 @@ describe('ChatSurface on an archived thread', () => {
       data: {
         models: [
           {
-            id: 'deepseek-chat',
-            label: 'deepseek-chat',
+            id: 'deepseek-v4-flash',
+            label: 'deepseek-v4-flash',
             providerSlug: 'deepseek',
             credential: { authMethod: 'api-key' as const },
           },

--- a/services/platform/app/features/chat/data/chat-backend.test.tsx
+++ b/services/platform/app/features/chat/data/chat-backend.test.tsx
@@ -194,8 +194,8 @@ describe('useComposerModels device store', () => {
     storeComposerCatalog('org-reload', {
       models: [
         {
-          id: 'deepseek-chat',
-          label: 'deepseek-chat',
+          id: 'deepseek-v4-flash',
+          label: 'deepseek-v4-flash',
           providerSlug: 'deepseek',
           credential: { authMethod: 'api-key' },
         },
@@ -255,7 +255,7 @@ describe('useChatSend', () => {
 
     const handle = await seam.current?.start({
       text: 'hello',
-      modelId: 'deepseek-chat',
+      modelId: 'deepseek-v4-flash',
     });
 
     expect(handle?.threadId).toBe('t-new');
@@ -270,7 +270,7 @@ describe('useChatSend', () => {
       organizationId: 'org-send',
       threadId: 't-new',
       userText: 'hello',
-      modelId: 'deepseek-chat',
+      modelId: 'deepseek-v4-flash',
       sandbox: false,
     });
   });
@@ -283,7 +283,7 @@ describe('useChatSend', () => {
 
     await seam.current?.start({
       text: 'hello',
-      modelId: 'deepseek-chat',
+      modelId: 'deepseek-v4-flash',
       reasoningEffort: 'low',
     });
 
@@ -298,7 +298,7 @@ describe('useChatSend', () => {
       organizationId: 'org-send',
       threadId: 't-new',
       userText: 'hello',
-      modelId: 'deepseek-chat',
+      modelId: 'deepseek-v4-flash',
       reasoningEffort: 'low',
       sandbox: false,
     });
@@ -332,7 +332,7 @@ describe('useChatSend', () => {
     const handle = await seam.current?.start({
       threadId: 't-9',
       text: 'again',
-      modelId: 'deepseek-chat',
+      modelId: 'deepseek-v4-flash',
       providerSlug: 'deepseek',
       reasoningEffort: 'high',
     });
@@ -344,7 +344,7 @@ describe('useChatSend', () => {
       organizationId: 'org-send',
       threadId: 't-9',
       userText: 'again',
-      modelId: 'deepseek-chat',
+      modelId: 'deepseek-v4-flash',
       providerSlug: 'deepseek',
       reasoningEffort: 'high',
       sandbox: false,

--- a/services/platform/app/features/chat/data/composer-catalog-store.test.ts
+++ b/services/platform/app/features/chat/data/composer-catalog-store.test.ts
@@ -11,8 +11,8 @@ import {
 const CATALOG: ComposerCatalog = {
   models: [
     {
-      id: 'deepseek-chat',
-      label: 'deepseek-chat',
+      id: 'deepseek-v4-flash',
+      label: 'deepseek-v4-flash',
       providerSlug: 'deepseek',
       credential: { authMethod: 'api-key' },
     },

--- a/services/platform/convex/chat/external_turn_bridge_exec.test.ts
+++ b/services/platform/convex/chat/external_turn_bridge_exec.test.ts
@@ -14,7 +14,7 @@ import {
 
 const BASE = {
   harness: 'claude-code',
-  gatewayModel: 'deepseek-chat',
+  gatewayModel: 'deepseek-v4-flash',
   serving: { kind: 'gateway' as const, token: 'sk-bf-test-token' },
   instructions: '',
   prompt: 'hello',

--- a/services/platform/convex/lib/providers/load_system_config.test.ts
+++ b/services/platform/convex/lib/providers/load_system_config.test.ts
@@ -115,6 +115,18 @@ describe('shipped static model catalogs', () => {
     }
   });
 
+  it('ships the deepseek V4 lineup, not the retired chat/reasoner aliases', () => {
+    const deepseek = loadStaticCatalogs().get('deepseek');
+    expect(deepseek?.map((m) => m.id)).toEqual([
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+    ]);
+    for (const model of deepseek ?? []) {
+      expect(model.supportsTools).toBe(true);
+      expect(model.reasoning).toEqual({ knob: 'effort', off: 'none' });
+    }
+  });
+
   it('ships the anthropic flagship lineup', () => {
     const anthropic = loadStaticCatalogs().get('anthropic');
     expect(anthropic?.map((m) => m.id)).toEqual([

--- a/services/platform/convex/node_only/sandbox/gateway_provisioning.test.ts
+++ b/services/platform/convex/node_only/sandbox/gateway_provisioning.test.ts
@@ -169,28 +169,30 @@ describe('provisionSessionGatewayKey', () => {
 
   it('provisions a custom provider under its per-model record so the mint can bind', async () => {
     // deepseek is NOT a standard gateway provider, so it routes per model
-    // (`deepseek__deepseek-chat`). The provision record must carry that exact
-    // name, or the mint's key lookup 404s and fails closed.
+    // (`deepseek__deepseek-v4-flash`). The provision record must carry that
+    // exact name, or the mint's key lookup 404s and fails closed.
     mockedResolve.mockResolvedValue(apiKeyResolution('sk-ds'));
     // Only `id` is read by buildProviderProvision; the rest of the catalog
     // shape is irrelevant here.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     mockedCatalog.mockResolvedValue([
-      { id: 'deepseek-chat' },
-      { id: 'deepseek-reasoner' },
+      { id: 'deepseek-v4-flash' },
+      { id: 'deepseek-v4-pro' },
     ] as unknown as Awaited<ReturnType<typeof getProviderCatalog>>);
     await provisionSessionGatewayKey(fakeCtx(), {
       organizationId: 'org_1',
       sessionId: 'sess-ds',
-      allowedModels: [{ providerSlug: 'deepseek', modelId: 'deepseek-chat' }],
+      allowedModels: [
+        { providerSlug: 'deepseek', modelId: 'deepseek-v4-flash' },
+      ],
       budgetCents: 500,
     });
     // One credential resolve for the connector, one per-model gateway record.
     expect(mockedResolve).toHaveBeenCalledTimes(1);
     expect(provisionProviders).toHaveBeenCalledWith('org_1', [
       expect.objectContaining({
-        name: 'deepseek__deepseek-chat',
-        models: ['deepseek-chat'],
+        name: 'deepseek__deepseek-v4-flash',
+        models: ['deepseek-v4-flash'],
         apiKey: 'sk-ds',
       }),
     ]);

--- a/services/platform/convex/node_only/sandbox/gateway_provisioning.ts
+++ b/services/platform/convex/node_only/sandbox/gateway_provisioning.ts
@@ -166,7 +166,7 @@ export async function provisionSessionGatewayKey(
   // model (`<slug>__<model>/<model>`, resolveGatewayRouting), so each of its
   // models needs its own record carrying that name and just that model —
   // otherwise the record the key lands under (`deepseek`) and the one the
-  // mint looks up (`deepseek__deepseek-chat`) disagree and the mint fails
+  // mint looks up (`deepseek__deepseek-v4-flash`) disagree and the mint fails
   // closed.
   const baseBySlug = new Map<string, ProviderProvision>();
   for (const providerSlug of new Set(

--- a/services/platform/convex/node_only/sandbox/llm_gateway_admin.test.ts
+++ b/services/platform/convex/node_only/sandbox/llm_gateway_admin.test.ts
@@ -298,7 +298,7 @@ describe('provisionProviders', () => {
         baseUrl: 'https://api.deepseek.com/anthropic',
         apiFormat: 'anthropic',
         apiKey: 'key-F',
-        models: ['deepseek-chat'],
+        models: ['deepseek-v4-flash'],
       },
     ]);
     expect(writes(calls)[0]?.body).toMatchObject({

--- a/services/platform/convex/user_preferences/mutations.test.ts
+++ b/services/platform/convex/user_preferences/mutations.test.ts
@@ -239,13 +239,16 @@ describe('setChatModel — the composer sticky model pick', () => {
     const setChatModel = await getSetChatModel();
     const { ctx, inserted } = createMockCtx();
 
-    await setChatModel(ctx, { organizationId: ORG, modelId: 'deepseek-chat' });
+    await setChatModel(ctx, {
+      organizationId: ORG,
+      modelId: 'deepseek-v4-flash',
+    });
 
     expect(inserted).toHaveLength(1);
     expect(inserted[0]).toMatchObject({
       userId: 'u_1',
       organizationId: ORG,
-      chatModelId: 'deepseek-chat',
+      chatModelId: 'deepseek-v4-flash',
     });
   });
 

--- a/services/platform/convex/user_preferences/mutations.ts
+++ b/services/platform/convex/user_preferences/mutations.ts
@@ -194,7 +194,7 @@ export const setOnboardingCompleted = mutation({
   },
 });
 
-/** A model id is provider-namespaced ("deepseek-chat",
+/** A model id is provider-namespaced ("deepseek-v4-flash",
  * "anthropic/claude-fable-5"); bound and printable, never free prose. */
 const CHAT_MODEL_ID_RE = /^[\x21-\x7e]{1,200}$/;
 

--- a/services/platform/lib/chat/model-choice.test.ts
+++ b/services/platform/lib/chat/model-choice.test.ts
@@ -167,6 +167,11 @@ describe('chooseChatModel — curated preference', () => {
       expect(PREFERRED_CHAT_MODELS[band]).not.toContain('gpt-5.5-pro');
     }
   });
+
+  it('does not prefer the retired deepseek-chat alias', () => {
+    expect(PREFERRED_CHAT_MODELS.draft).not.toContain('deepseek-chat');
+    expect(PREFERRED_CHAT_MODELS.draft).toContain('deepseek-v4-flash');
+  });
 });
 
 describe('chooseChatModel — price fallback', () => {

--- a/services/platform/lib/chat/model-choice.ts
+++ b/services/platform/lib/chat/model-choice.ts
@@ -66,7 +66,6 @@ export const PREFERRED_CHAT_MODELS: Readonly<
   draft: [
     'claude-haiku-4-5',
     'gemini-3.5-flash-lite',
-    'deepseek-chat',
     'deepseek-v4-flash',
     'qwen3.6-flash',
   ],


### PR DESCRIPTION
## Summary
- Pin the native DeepSeek catalog to the official `deepseek-v4-flash` and `deepseek-v4-pro` ids. The `deepseek-chat` / `deepseek-reasoner` aliases stopped resolving on 2026-07-24.
- Thinking is an effort knob on both models, not a second model name. Flash pricing is the official 14/28 ¢/MTok; Pro stays 43.5/87.
- Drop `deepseek-chat` from the Auto draft preferred list (keep `deepseek-v4-flash`). A leftover sticky pick of the old id already falls back to Auto.

## Test plan
- [x] `configs:validate` on the shipped provider/model catalogs
- [x] Server tests: shipped catalogs, model-choice, load_system_config, gateway provisioning, user preferences
- [x] UI tests: chat-surface, chat-backend, composer-catalog-store
- [ ] On an org with a native DeepSeek credential, confirm the picker lists V4 Flash / V4 Pro and a send uses `deepseek-v4-flash` on the wire