### PR TITLE
fix(platform): steer chat tool budget and derive limits from catalog

### DIFF
--- a/services/platform/convex/chat/turn_action.ts
+++ b/services/platform/convex/chat/turn_action.ts
@@ -33,12 +33,10 @@ import {
   buildAudioTranscriptAppendix,
   stripAudioTranscriptAppendix,
 } from '../../lib/chat/audio-transcript';
-import {
-  MAX_HISTORY_BUDGET_TOKENS,
-  resolveEffectiveWindow,
-} from '../../lib/chat/budget';
+import { resolveEffectiveWindow } from '../../lib/chat/budget';
 import { buildDocumentAppendix } from '../../lib/chat/document-appendix';
 import {
+  fitSamplingToWindow,
   resolveTurnSampling,
   type ReasoningEffort,
 } from '../../lib/chat/effort';
@@ -1077,7 +1075,6 @@ export async function executeTurn(
   // into, so a long thread never materializes whole. The internal read also
   // frees the scheduled API-key lane from session auth the public query
   // demands.
-  const sampling = resolveTurnSampling(resolved.entry, args.reasoningEffort);
   const governanceCap = await ctx.runQuery(
     internal.governance.queries.getContextCapInternal,
     { organizationId: args.organizationId, userId: args.userId },
@@ -1086,10 +1083,13 @@ export async function executeTurn(
     contextWindow: resolved.entry.contextWindow,
     governanceMaxContext: governanceCap,
   });
-  const historyTokenBudget = Math.min(
-    Math.max(0, windowTokens - sampling.maxTokens),
-    MAX_HISTORY_BUDGET_TOKENS,
+  // Resolved against the model's declarations, then re-fitted in case
+  // governance shrank the window under what the declaration assumed.
+  const sampling = fitSamplingToWindow(
+    resolveTurnSampling(resolved.entry, args.reasoningEffort),
+    windowTokens,
   );
+  const historyTokenBudget = Math.max(0, windowTokens - sampling.maxTokens);
   const { messages: stored, omittedCount } = await ctx.runQuery(
     internal.chat.messages.listRecentForTurnInternal,
     {

--- a/services/platform/lib/chat/budget.ts
+++ b/services/platform/lib/chat/budget.ts
@@ -2,15 +2,11 @@
  * The context-window budget, resolved once per turn.
  *
  * The window is the model's own context size, optionally shrunk by the
- * organization's governance cap (`feature_flags.maxContextTokens`). On top of
- * that sits a hard HISTORY ceiling: a million-token window filled with
- * history is a cost amplifier, not a feature — beyond this cap, older turns
- * are dropped (with the in-context notice) exactly as if the window ended
- * there. Pure data — no Convex, no I/O.
+ * organization's governance cap (`feature_flags.maxContextTokens`). Those
+ * two are the ONLY ceilings: capability comes from the catalog declaration,
+ * cost control from the governance cap — never from a constant here. Pure
+ * data — no Convex, no I/O.
  */
-
-/** History never budgets beyond this many tokens, whatever the window. */
-export const MAX_HISTORY_BUDGET_TOKENS = 96_000;
 
 /** The effective context window: the model's, shrunk by a positive
  * governance cap when one applies. */

--- a/services/platform/lib/chat/context.test.ts
+++ b/services/platform/lib/chat/context.test.ts
@@ -65,6 +65,9 @@ describe('assembleContext', () => {
     expect(result.stablePrefix).toContain('You help with support tickets.');
     expect(result.stablePrefix).toContain(UNTRUSTED_CONTENT_SYSTEM_PROMPT);
     expect(result.stablePrefix).toContain('builtin.run_code');
+    // The parallel-lookup steer is part of the tool-docs block — static
+    // text, so it lives above the breakpoint with the docs it steers.
+    expect(result.stablePrefix).toContain('Lookups are budgeted per reply');
     // Nothing that changes per turn may sit above the breakpoint.
     expect(result.stablePrefix).not.toContain('2026-07-22');
     expect(result.stablePrefix).not.toContain('hello');

--- a/services/platform/lib/chat/context.ts
+++ b/services/platform/lib/chat/context.ts
@@ -41,7 +41,6 @@ import { UNTRUSTED_CONTENT_SYSTEM_PROMPT } from '../../convex/lib/untrusted_cont
 import { boundJson } from '../shared/utils/bound-json';
 import { narrowBcp47 } from '../shared/utils/narrow-bcp47';
 import { pickField } from '../shared/utils/pick-field';
-import { MAX_HISTORY_BUDGET_TOKENS } from './budget';
 import {
   estimateMessageTokens,
   estimateTokens,
@@ -174,6 +173,7 @@ function renderToolDocs(docs: readonly ToolDoc[]): string {
   return [
     'AVAILABLE CAPABILITIES',
     'Call one to act or to look something up. Argument schemas travel with the tool definitions — ask for what you need rather than guessing at a shape.',
+    'Lookups are budgeted per reply: you get a few tool rounds, and a round runs all its calls in parallel — issue independent searches and fetches together in one round rather than one at a time.',
     ...lines,
   ].join('\n');
 }
@@ -364,11 +364,13 @@ export function assembleContext(input: ContextInput): AssembledContext {
     .join(BLOCK_SEPARATOR);
 
   const reserve = input.budget.reserveOutputTokens ?? 0;
-  // The history's slice of the window, additionally capped: a huge window
-  // never turns into an equally huge (and equally billed) history replay.
-  const available = Math.min(
-    Math.max(0, input.budget.maxTokens - reserve - estimateTokens(system)),
-    MAX_HISTORY_BUDGET_TOKENS,
+  // The history's slice: whatever the effective window leaves after the
+  // output reserve and the system prompt. The window (model declaration,
+  // shrunk by governance) is the only ceiling — a flat cap here would
+  // silently waste capability the catalog declared.
+  const available = Math.max(
+    0,
+    input.budget.maxTokens - reserve - estimateTokens(system),
   );
   const { messages, truncation } = fitHistory(
     input.history,

--- a/services/platform/lib/chat/effort.test.ts
+++ b/services/platform/lib/chat/effort.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../shared/schemas/providers';
 import {
   EFFORT_LEVELS,
+  fitSamplingToWindow,
   isReasoningEffort,
   resolveTurnSampling,
   type ReasoningEffort,
@@ -49,7 +50,7 @@ describe('isReasoningEffort', () => {
 });
 
 describe('resolveTurnSampling — the default (no effort, or no reasoning)', () => {
-  it("matches today's constants byte for byte when no effort is picked", () => {
+  it('falls back to 4096 only when the model declares no output ceiling', () => {
     expect(resolveTurnSampling(model())).toEqual({
       maxTokens: 4096,
       temperature: 0.7,
@@ -58,8 +59,10 @@ describe('resolveTurnSampling — the default (no effort, or no reasoning)', () 
       maxTokens: 4096,
       temperature: 0.7,
     });
+    // A declared ceiling is respected in full — up to the half-window share
+    // (128k declared, 200k window → the share wins at 100k).
     expect(resolveTurnSampling(THINKING_MODEL)).toEqual({
-      maxTokens: 4096,
+      maxTokens: 100_000,
       temperature: 0.7,
     });
   });
@@ -73,13 +76,23 @@ describe('resolveTurnSampling — the default (no effort, or no reasoning)', () 
     }
   });
 
-  it("caps the default maxTokens at the model's own output ceiling", () => {
+  it('the declared output ceiling IS the default, under the half-window share', () => {
     expect(resolveTurnSampling(model({ maxOutputTokens: 2000 }))).toEqual({
       maxTokens: 2000,
       temperature: 0.7,
     });
+    // No constant caps a declaration any more: 32k declared rides in full.
     expect(resolveTurnSampling(model({ maxOutputTokens: 32_000 }))).toEqual({
-      maxTokens: 4096,
+      maxTokens: 32_000,
+      temperature: 0.7,
+    });
+    // The share rule: output never claims more than half the model's window.
+    expect(
+      resolveTurnSampling(
+        model({ maxOutputTokens: 32_000, contextWindow: 16_000 }),
+      ),
+    ).toEqual({
+      maxTokens: 8000,
       temperature: 0.7,
     });
   });
@@ -174,8 +187,11 @@ describe("resolveTurnSampling — the 'budget-tokens' knob", () => {
   ] as const)(
     'gives %s its full budget of %d on a roomy model',
     (effort, budget) => {
+      // The answer keeps whatever the budget leaves of the model's full
+      // declared ceiling (128k, share-capped to half the 200k window) —
+      // headroom is no longer a 4096-token constant.
       expect(resolveTurnSampling(THINKING_MODEL, effort)).toEqual({
-        maxTokens: budget + 4096,
+        maxTokens: 100_000,
         reasoning: { kind: 'thinking', budgetTokens: budget },
       });
     },
@@ -204,9 +220,10 @@ describe("resolveTurnSampling — the 'budget-tokens' knob", () => {
       contextWindow: 16_000,
       maxOutputTokens: 64_000,
     });
-    // cap = min(64000, 8000) - 1024 = 6976.
+    // Budget cap = min(64000, 8000) - 1024 = 6976; the declared 64k output
+    // ceiling meets the same half-window share: maxTokens = 8000.
     expect(resolveTurnSampling(narrow, 'max')).toEqual({
-      maxTokens: 6976 + 4096,
+      maxTokens: 8000,
       reasoning: { kind: 'thinking', budgetTokens: 6976 },
     });
   });
@@ -295,5 +312,45 @@ describe("resolveTurnSampling — the 'budget-tokens' knob", () => {
     for (let i = 1; i < budgets.length; i += 1) {
       expect(budgets[i]).toBeGreaterThanOrEqual(budgets[i - 1] ?? 0);
     }
+  });
+});
+
+describe('fitSamplingToWindow — the governance re-fit', () => {
+  it('returns a sampling that already fits, unchanged and by reference', () => {
+    const sampling = resolveTurnSampling(THINKING_MODEL, 'medium');
+    expect(fitSamplingToWindow(sampling, 200_000)).toBe(sampling);
+  });
+
+  it('re-applies the half-window share when governance shrank the window', () => {
+    // Declared 128k rode in full at 100k; a 32k governed window halves it.
+    const sampling = resolveTurnSampling(THINKING_MODEL);
+    expect(fitSamplingToWindow(sampling, 32_000)).toEqual({
+      maxTokens: 16_000,
+      temperature: 0.7,
+    });
+  });
+
+  it('shrinks a thinking budget alongside, keeping the wire invariant', () => {
+    const sampling = resolveTurnSampling(THINKING_MODEL, 'max');
+    // 98304 thinking + 100k ceiling into an 8k governed window: the share
+    // is 4000, the budget re-clamps under it, maxTokens stays above the
+    // budget by the provider minimum.
+    const fitted = fitSamplingToWindow(sampling, 8_000);
+    expect(fitted).toEqual({
+      maxTokens: 4000,
+      reasoning: { kind: 'thinking', budgetTokens: 4000 - 1024 },
+    });
+  });
+
+  it('never drops under the provider-minimum floor on a degenerate window', () => {
+    const fitted = fitSamplingToWindow(
+      resolveTurnSampling(THINKING_MODEL, 'max'),
+      1_000,
+    );
+    if (fitted.reasoning?.kind !== 'thinking') {
+      throw new Error('expected a thinking budget');
+    }
+    expect(fitted.reasoning.budgetTokens).toBeGreaterThanOrEqual(1024);
+    expect(fitted.maxTokens).toBeGreaterThan(fitted.reasoning.budgetTokens);
   });
 });

--- a/services/platform/lib/chat/effort.ts
+++ b/services/platform/lib/chat/effort.ts
@@ -7,11 +7,15 @@
  * model's catalog entry declares (`reasoning.knob`):
  *
  *  - No effort picked, or the model declares no `reasoning` capability: the
- *    turn samples exactly as it always has — `temperature: 0.7` and a
- *    `maxTokens` of 4096 (capped by the model's own `maxOutputTokens` when
- *    that is lower). An effort passed for a non-reasoning model is SILENTLY
- *    ignored — absence-means-default, never a refusal — so a sticky pick
- *    survives switching to a non-reasoning model without blocking the send.
+ *    turn samples at `temperature: 0.7` with the model's own declared
+ *    `maxOutputTokens` as the reply ceiling — the catalog is the authority
+ *    on capability, never a constant here. 4096 is only the FALLBACK for an
+ *    entry that declares nothing. Whatever the source, the ceiling claims at
+ *    most half the model's context window, so the reply can never squeeze
+ *    the history out of its own turn. An effort passed for a non-reasoning
+ *    model is SILENTLY ignored — absence-means-default, never a refusal — so
+ *    a sticky pick survives switching to a non-reasoning model without
+ *    blocking the send.
  *    ONE addition to the no-pick case: an `effort`-knob model whose catalog
  *    entry declares `reasoning.off` sends that value (`reasoning_effort:
  *    "none"` and friends), so a thinks-by-default model answers the Default
@@ -28,13 +32,18 @@
  *    names an explicit thinking-token budget (2048 / 8192 / 24576 / 49152 /
  *    98304), clamped to what the model can actually spend — at most
  *    `min(maxOutputTokens ?? 64000, contextWindow / 2) - 1024`, at least
- *    1024 (the provider minimum). `maxTokens` is the budget plus 4096 tokens
- *    of answer headroom, capped at the model's `maxOutputTokens` — but never
- *    below `budget + 1024`, so the INVARIANT `maxTokens > budgetTokens`
- *    holds even for a mis-declared catalog entry with a tiny output ceiling
- *    (providers hard-reject a `max_tokens` at or under the budget).
- *    Temperature is OMITTED entirely: Anthropic rejects a custom temperature
- *    while thinking is enabled.
+ *    1024 (the provider minimum). `maxTokens` is the model's full declared
+ *    `maxOutputTokens` (budget + 4096 tokens of answer headroom when the
+ *    entry declares none), under the same half-window share rule as the
+ *    default case — but never below `budget + 1024`, so the INVARIANT
+ *    `maxTokens > budgetTokens` holds even for a mis-declared catalog entry
+ *    with a tiny output ceiling (providers hard-reject a `max_tokens` at or
+ *    under the budget). Temperature is OMITTED entirely: Anthropic rejects
+ *    a custom temperature while thinking is enabled.
+ *
+ * The half-window share above fits the MODEL's own window. When governance
+ * shrinks the effective window, {@link fitSamplingToWindow} re-applies the
+ * same rule against the shrunk window at the lane.
  *
  * Pure by design — no Convex, no Node, no network — so the whole mapping
  * table lives in one unit-testable file and every lane (direct turn, arena,
@@ -72,9 +81,10 @@ export interface TurnSampling {
     | { kind: 'thinking'; budgetTokens: number };
 }
 
-/** Today's constants, unchanged: the reply ceiling a chat turn uses when the
- * model declares none, and the default sampling temperature. */
-const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+/** The reply ceiling assumed ONLY when the catalog entry declares no
+ * `maxOutputTokens` — a declared ceiling always wins, whatever its size —
+ * and the default sampling temperature. */
+const FALLBACK_MAX_OUTPUT_TOKENS = 4096;
 const DEFAULT_TEMPERATURE = 0.7;
 
 /** Answer headroom on top of a thinking budget, and the provider's minimum
@@ -104,11 +114,19 @@ const THINKING_BUDGETS: Record<ReasoningEffort, number> = {
  * `maxOutputTokens` — generous, since budget-knob models routinely allow it. */
 const ASSUMED_THINKING_MAX_OUTPUT = 64_000;
 
+/** The output's share of a window: half, so a declared ceiling as large as
+ * the window itself can never starve the history's slice of the same turn.
+ * Floored at twice the provider-minimum thinking budget so a degenerate
+ * window still yields a request every provider accepts. */
+function outputShare(window: number): number {
+  return Math.max(Math.floor(window / 2), 2 * MIN_THINKING_BUDGET);
+}
+
 function defaultSampling(model: ModelCatalogEntry): TurnSampling {
   return {
     maxTokens: Math.min(
-      model.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
-      DEFAULT_MAX_OUTPUT_TOKENS,
+      model.maxOutputTokens ?? FALLBACK_MAX_OUTPUT_TOKENS,
+      outputShare(model.contextWindow),
     ),
     temperature: DEFAULT_TEMPERATURE,
   };
@@ -169,14 +187,43 @@ export function resolveTurnSampling(
     Math.min(THINKING_BUDGETS[effort], budgetCap),
     MIN_THINKING_BUDGET,
   );
-  const uncapped = budgetTokens + THINKING_ANSWER_HEADROOM;
-  const maxTokens =
-    model.maxOutputTokens !== undefined
-      ? Math.max(
-          Math.min(uncapped, model.maxOutputTokens),
-          budgetTokens + MIN_THINKING_BUDGET,
-        )
-      : uncapped;
+  // The full declared ceiling — the answer keeps whatever the budget leaves
+  // of it — under the same half-window share as the default case, with the
+  // `maxTokens > budgetTokens` belt for mis-declared entries.
+  const ceiling =
+    model.maxOutputTokens ?? budgetTokens + THINKING_ANSWER_HEADROOM;
+  const maxTokens = Math.max(
+    Math.min(ceiling, outputShare(model.contextWindow)),
+    budgetTokens + MIN_THINKING_BUDGET,
+  );
   // No temperature: thinking-enabled requests reject a custom one.
   return { maxTokens, reasoning: { kind: 'thinking', budgetTokens } };
+}
+
+/**
+ * Re-fit a resolved sampling to the turn's EFFECTIVE window — the model's
+ * own window shrunk by a governance cap. {@link resolveTurnSampling} already
+ * fits the model's declared window; this applies the identical share rule
+ * when the lane knows a smaller one, shrinking a thinking budget alongside
+ * so the `maxTokens > budgetTokens` invariant survives the squeeze. A
+ * sampling that already fits is returned unchanged.
+ */
+export function fitSamplingToWindow(
+  sampling: TurnSampling,
+  effectiveWindow: number,
+): TurnSampling {
+  const cap = outputShare(effectiveWindow);
+  if (sampling.maxTokens <= cap) return sampling;
+  if (sampling.reasoning?.kind !== 'thinking') {
+    return { ...sampling, maxTokens: cap };
+  }
+  const budgetTokens = Math.max(
+    Math.min(sampling.reasoning.budgetTokens, cap - MIN_THINKING_BUDGET),
+    MIN_THINKING_BUDGET,
+  );
+  return {
+    ...sampling,
+    maxTokens: Math.max(cap, budgetTokens + MIN_THINKING_BUDGET),
+    reasoning: { kind: 'thinking', budgetTokens },
+  };
 }

--- a/services/platform/lib/chat/index.ts
+++ b/services/platform/lib/chat/index.ts
@@ -78,6 +78,7 @@ export {
 export { deriveFallbackTitle } from './derive-fallback-title';
 export {
   EFFORT_LEVELS,
+  fitSamplingToWindow,
   isReasoningEffort,
   resolveTurnSampling,
   type ReasoningEffort,

--- a/services/platform/lib/chat/turn.test.ts
+++ b/services/platform/lib/chat/turn.test.ts
@@ -13,8 +13,10 @@ import {
 import type { GuardrailFilter } from './guardrails';
 import type { ChatToolExecutor, ToolCallRequest } from './tools';
 import {
+  LAST_TOOL_ROUND_NOTICE,
   MAX_TOOL_ROUNDS,
   runTurn,
+  TOOL_BUDGET_SPENT_NOTICE,
   TURN_STEPS,
   type ModelCall,
   type ModelCallRequest,
@@ -591,8 +593,10 @@ describe('runTurn — the happy path', () => {
       request({ model: reasoningModel, reasoningEffort: 'medium' }),
       d.deps,
     );
+    // The full declared 64k ceiling rides the wire — the answer keeps what
+    // the 8192 thinking budget leaves of it, not a 4096-token constant.
     expect(seen[1]).toEqual({
-      maxTokens: 8192 + 4096,
+      maxTokens: 64_000,
       reasoning: { kind: 'thinking', budgetTokens: 8192 },
     });
   });
@@ -963,6 +967,35 @@ describe('runTurn — the tool loop', () => {
     expect(executed).toHaveLength(MAX_TOOL_ROUNDS);
     expect(requests).toHaveLength(MAX_TOOL_ROUNDS + 1);
     expect(requests.at(-1)?.tools).toBeUndefined();
+    // The budget is steered, not silent. The last offered round tells the
+    // model to spend its remaining calls in parallel; the forced round
+    // tells it the budget is gone — withheld tools are invisible on the
+    // wire, and an uninformed model narrates its next lookup instead of
+    // answering.
+    const lastOffered = requests[MAX_TOOL_ROUNDS - 1];
+    expect(lastOffered?.tools).toBeDefined();
+    expect(lastOffered?.messages.at(-1)).toEqual({
+      role: 'user',
+      parts: [{ type: 'text', text: LAST_TOOL_ROUND_NOTICE }],
+    });
+    expect(requests.at(-1)?.messages.at(-1)).toEqual({
+      role: 'user',
+      parts: [{ type: 'text', text: TOOL_BUDGET_SPENT_NOTICE }],
+    });
+    // Earlier rounds carry no notice at all, and neither notice is ever
+    // persisted — the notices ride the wire only.
+    const textsOf = (parts: readonly MessagePart[]): string[] =>
+      parts.flatMap((part) => (part.type === 'text' ? [part.text] : []));
+    for (const req of requests.slice(0, MAX_TOOL_ROUNDS - 1)) {
+      const texts = req.messages.flatMap((m) => textsOf(m.parts));
+      expect(texts).not.toContain(LAST_TOOL_ROUND_NOTICE);
+      expect(texts).not.toContain(TOOL_BUDGET_SPENT_NOTICE);
+    }
+    const storedTexts = textsOf(
+      (d.store.finalized[0]?.parts ?? []) as MessagePart[],
+    );
+    expect(storedTexts).not.toContain(LAST_TOOL_ROUND_NOTICE);
+    expect(storedTexts).not.toContain(TOOL_BUDGET_SPENT_NOTICE);
     // The spent budget is stamped on the usage (`stepLimitHit` is the UI's
     // contract for the "stopped at the cap" notice), on the outcome and the
     // settled message both.

--- a/services/platform/lib/chat/turn.ts
+++ b/services/platform/lib/chat/turn.ts
@@ -38,6 +38,7 @@ import type { ModelCatalogEntry } from '../shared/schemas/providers';
 import { assembleContext, type AssembledContext } from './context';
 import type { AgentInstructions, ContextBudget, ToolDoc } from './context';
 import {
+  fitSamplingToWindow,
   resolveTurnSampling,
   type ReasoningEffort,
   type TurnSampling,
@@ -89,6 +90,30 @@ export type TurnStep = (typeof TURN_STEPS)[number];
  * `stepLimitHit` for the UI's notice.
  */
 export const MAX_TOOL_ROUNDS = 4;
+
+/**
+ * Wire-only budget notices, appended as a trailing user turn on the round
+ * they describe (user role for the same reason as the context truncation
+ * notice: the Anthropic wire hoists system-role messages out of position).
+ * Neither is ever persisted — they steer the model, they are not transcript.
+ *
+ * Without the SPENT notice the withheld tools are invisible: a model
+ * mid-plan announces its next lookup and stops instead of answering. The
+ * LAST notice spends the final round wide — a round's calls execute in
+ * parallel, but an unprompted model issues one call per round. Both open
+ * the exit that `rag_fetch`'s keep-fetching steer otherwise holds shut:
+ * say what was actually read, offer to continue.
+ */
+export const LAST_TOOL_ROUND_NOTICE =
+  '[Last lookup round for this reply: issue every remaining search or ' +
+  'fetch now, as parallel tool calls in this one response — after their ' +
+  'results you must answer.]';
+
+export const TOOL_BUDGET_SPENT_NOTICE =
+  '[The lookup budget for this reply is spent; no further tool calls will ' +
+  'run. Answer now from what you have gathered. If you could not read ' +
+  'everything, say exactly which parts you did read and offer to continue ' +
+  'in a follow-up reply — do not announce further lookups.]';
 
 // ------------------------------------------------------------------- ports
 
@@ -449,9 +474,9 @@ export function assembleTurnContext(
       maxTokens: request.model.contextWindow,
       // The reserve mirrors what the wire will actually request, so budget
       // and reality can never disagree.
-      reserveOutputTokens: resolveTurnSampling(
-        request.model,
-        request.reasoningEffort,
+      reserveOutputTokens: fitSamplingToWindow(
+        resolveTurnSampling(request.model, request.reasoningEffort),
+        request.model.contextWindow,
       ).maxTokens,
     },
   });
@@ -901,10 +926,12 @@ export async function runTurn(
   try {
     steps.push('stream');
     // Resolved ONCE per turn, before any chunk flows: the model call, and
-    // nothing else, decides how to spell it on the wire.
-    const sampling = resolveTurnSampling(
-      request.model,
-      request.reasoningEffort,
+    // nothing else, decides how to spell it on the wire. Fitted to the same
+    // effective window the context budget used, so the reserve the history
+    // made room for and the ceiling the wire requests never disagree.
+    const sampling = fitSamplingToWindow(
+      resolveTurnSampling(request.model, request.reasoningEffort),
+      request.budget?.maxTokens ?? request.model.contextWindow,
     );
 
     // The turn's cancel channel: every throttled progress write reports the
@@ -972,13 +999,26 @@ export async function runTurn(
         executor !== undefined && toolRounds < MAX_TOOL_ROUNDS
           ? executor.wireTools
           : undefined;
-      const roundMessages: readonly ChatMessage[] =
-        settledParts.length === 0
-          ? context.messages
-          : [
-              ...context.messages,
-              { role: 'assistant', parts: [...settledParts] },
-            ];
+      // The notice rides the wire only, never the store: the transcript
+      // shows the answer, not the host steering the model toward it.
+      const budgetNotice =
+        executor === undefined
+          ? undefined
+          : toolRounds >= MAX_TOOL_ROUNDS
+            ? TOOL_BUDGET_SPENT_NOTICE
+            : toolRounds === MAX_TOOL_ROUNDS - 1
+              ? LAST_TOOL_ROUND_NOTICE
+              : undefined;
+      const roundMessages: ChatMessage[] = [...context.messages];
+      if (settledParts.length > 0) {
+        roundMessages.push({ role: 'assistant', parts: [...settledParts] });
+      }
+      if (budgetNotice !== undefined) {
+        roundMessages.push({
+          role: 'user',
+          parts: [{ type: 'text', text: budgetNotice }],
+        });
+      }
       streamed = await streamWithOutputGuardrails(
         request,
         context,


### PR DESCRIPTION
## Problem

Two hardcoded ceilings degraded document-heavy chat turns (repro: 491-page BGB.pdf, a five-topic "详细说说" question):

1. **A turn that hit `MAX_TOOL_ROUNDS` ended without an answer.** The loop withholds the tools on the forced final round, but nothing told the model — mid-plan, it announced its next lookup ("现在让我搜索…") and stopped. The unit test masked this: its fake model conveniently answers when tools vanish; real models don't. The `rag_fetch` keep-fetching steer made it worse on huge documents.
2. **The reply ceiling was a constant 4096**, whatever the catalog declared. deepseek-v4-flash declares 1M context / 384k output on OpenRouter and still got `max_tokens: 4096` — the seven-section answer cut off mid-sentence. The flat 96k history cap was the same class of hardcode.

## Change

**Steer the round budget instead of enforcing it silently** (`turn.ts`, `context.ts`):

- Two wire-only user-role notices (the truncation-notice pattern; never persisted): the last offered round tells the model to batch every remaining lookup as parallel calls in that response; the forced round tells it the budget is spent, to answer from what it read, and to state coverage honestly.
- One tool-docs line declares the per-reply lookup budget and parallel rounds up front.

**Derive capability limits from the model catalog** (`effort.ts`, `budget.ts`, `context.ts`, `turn_action.ts`):

- Default and thinking `maxTokens` follow the declared `maxOutputTokens`; 4096 survives only as the undeclared-entry fallback. The one structural rule left is the output share — half the window (the precedent the thinking budget clamp already used) — so a huge declared output can never starve the history slice.
- New `fitSamplingToWindow` re-applies that share when governance shrinks the effective window, shrinking a thinking budget alongside so the `maxTokens > budgetTokens` wire invariant survives.
- The flat 96k history cap is deleted. The history slice is the effective window minus output reserve and system prompt; cost control belongs to the explicit governance `maxContextTokens` cap, not a hidden constant. Note the cost surface: long threads on 1M-window models now replay what the window allows.

## Verification

- 75031 platform unit tests, typecheck, oxlint, opengrep green; new tests lock the notices (wire-only, right rounds, never persisted), the declaration-driven ceilings, and the governance re-fit.
- Live on the BGB.pdf thread (deepseek-v4-flash-0731 via OpenRouter): the capped turn batches six parallel `rag_fetch` reads in its last round and ends with a complete, cited seven-section answer plus an honest "not read" caveat, instead of a dangling narration. After the ceiling change the wire requests 393216 output tokens instead of 4096, and the previously truncated §§ 355–361 exposition completes with a proper ending; the model's long deliberation lands in the thinking accordion, not the visible text.