### PR TITLE
perf(platform): eliminate the per-request JWKS validation tax

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -105,6 +105,7 @@ import type * as chat_search from "../chat/search.js";
 import type * as chat_thread_lifecycle from "../chat/thread_lifecycle.js";
 import type * as chat_threads from "../chat/threads.js";
 import type * as chat_turn_action from "../chat/turn_action.js";
+import type * as chat_turn_setup from "../chat/turn_setup.js";
 import type * as chat_turn_store from "../chat/turn_store.js";
 import type * as chat_filter_events_internal_mutations from "../chat_filter_events/internal_mutations.js";
 import type * as chat_filter_events_queries from "../chat_filter_events/queries.js";
@@ -1056,6 +1057,7 @@ declare const fullApi: ApiFromModules<{
   "chat/thread_lifecycle": typeof chat_thread_lifecycle;
   "chat/threads": typeof chat_threads;
   "chat/turn_action": typeof chat_turn_action;
+  "chat/turn_setup": typeof chat_turn_setup;
   "chat/turn_store": typeof chat_turn_store;
   "chat_filter_events/internal_mutations": typeof chat_filter_events_internal_mutations;
   "chat_filter_events/queries": typeof chat_filter_events_queries;

--- a/services/platform/convex/chat/arena_action.ts
+++ b/services/platform/convex/chat/arena_action.ts
@@ -20,9 +20,10 @@ import {
 import { internal } from '../_generated/api';
 import { action, type ActionCtx } from '../_generated/server';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { sanitizeError } from '../lib/utils/sanitize_secrets';
 import { reasoningEffortValidator } from './schema';
-import { executeTurn } from './turn_action';
+import { executeTurn, settled, unwrap } from './turn_action';
 
 const sideResultValidator = v.object({
   status: v.union(v.literal('completed'), v.literal('refused')),
@@ -115,16 +116,23 @@ export const startArenaTurn = action({
   },
   returns: v.object({ a: sideResultValidator, b: sideResultValidator }),
   handler: async (ctx, args): Promise<{ a: SideResult; b: SideResult }> => {
-    const auth = await requireOrgMembershipById(ctx, args.organizationId);
-
-    const owned = await ctx.runQuery(
-      internal.chat.threads.getOwnedThreadInternal,
-      {
-        organizationId: args.organizationId,
-        userId: auth.userId,
-        threadId: args.threadId,
-      },
+    // Same entry choreography as `startTurn`: membership ∥ gate, serial
+    // verdicts. The gate answers ownership + busy for the CALLED column;
+    // only the partner column needs its own busy read.
+    const identity = await getAuthUserIdentity(ctx);
+    const pendingAuth = settled(
+      requireOrgMembershipById(ctx, args.organizationId),
     );
+    const pendingGate = settled(
+      ctx.runQuery(internal.chat.turn_setup.getTurnGateInternal, {
+        organizationId: args.organizationId,
+        userId: identity?.userId ?? '',
+        threadId: args.threadId,
+      }),
+    );
+    const auth = unwrap(await pendingAuth);
+    const gate = unwrap(await pendingGate);
+    const owned = gate.thread;
     if (owned === null || owned.arena === undefined) {
       throw new ConvexError({
         code: 'not_found',
@@ -136,15 +144,14 @@ export const startArenaTurn = action({
     const threadIdB =
       owned.arena.role === 'a' ? owned.arena.partnerThreadId : args.threadId;
 
-    const busyA = await ctx.runQuery(
+    const partnerBusy = await ctx.runQuery(
       internal.chat.generations.hasLiveGenerationInternal,
-      { organizationId: args.organizationId, threadId: threadIdA },
+      {
+        organizationId: args.organizationId,
+        threadId: owned.arena.partnerThreadId,
+      },
     );
-    const busyB = await ctx.runQuery(
-      internal.chat.generations.hasLiveGenerationInternal,
-      { organizationId: args.organizationId, threadId: threadIdB },
-    );
-    if (busyA || busyB) {
+    if (gate.busy || partnerBusy) {
       const busy: SideResult = {
         status: 'refused',
         reason: 'This conversation is already generating a response.',

--- a/services/platform/convex/chat/deferred_sends.test.ts
+++ b/services/platform/convex/chat/deferred_sends.test.ts
@@ -277,6 +277,17 @@ describe('deferred sends — claim and settle', () => {
 describe('deferred sends — settle at user append', () => {
   function recordingStore(log: string[]): TurnStore {
     return {
+      async beginTurn(setup) {
+        log.push(
+          setup.userParts !== undefined ? 'beginTurn:user' : 'beginTurn:bare',
+        );
+        return {
+          ...(setup.userParts !== undefined
+            ? { userMessage: { id: 'message_1', sequence: 1 } }
+            : {}),
+          assistantMessage: { id: 'message_2', sequence: 2 },
+        };
+      },
       async appendMessage(message) {
         log.push(`append:${message.role}`);
         return { id: 'message_1', sequence: log.length };
@@ -290,23 +301,13 @@ describe('deferred sends — settle at user append', () => {
       async finalizeAssistantMessage() {
         log.push('finalizeAssistantMessage');
       },
-      async beginGeneration() {
-        log.push('beginGeneration');
-      },
       async endGeneration() {
         log.push('endGeneration');
       },
     };
   }
 
-  const message = (role: 'user' | 'assistant') => ({
-    organizationId: ORG,
-    threadId: 'thread_defer',
-    role,
-    parts: [],
-  });
-
-  it('settles the row exactly when the user message lands — the reply must not carry the tray row to its end', async () => {
+  it('settles the row exactly when the turn-open lands the user message — the reply must not carry the tray row to its end', async () => {
     const log: string[] = [];
     const store = settleDeferredSendOnUserAppend(
       recordingStore(log),
@@ -314,18 +315,15 @@ describe('deferred sends — settle at user append', () => {
         log.push('settle');
       },
     );
-    await store.appendMessage(message('user'));
-    await store.appendMessage(message('assistant'));
-    await store.beginGeneration({ organizationId: ORG, threadId: 't' });
-    expect(log).toEqual([
-      'append:user',
-      'settle',
-      'append:assistant',
-      'beginGeneration',
-    ]);
+    await store.beginTurn({
+      organizationId: ORG,
+      threadId: 'thread_defer',
+      userParts: [],
+    });
+    expect(log).toEqual(['beginTurn:user', 'settle']);
   });
 
-  it('never settles on assistant-only writes (a pre-append refusal keeps the row for the terminal settle)', async () => {
+  it('never settles on a user-less open or an assistant write (a pre-append refusal keeps the row for the terminal settle)', async () => {
     const log: string[] = [];
     const store = settleDeferredSendOnUserAppend(
       recordingStore(log),
@@ -333,11 +331,17 @@ describe('deferred sends — settle at user append', () => {
         log.push('settle');
       },
     );
-    await store.appendMessage(message('assistant'));
-    expect(log).toEqual(['append:assistant']);
+    await store.beginTurn({ organizationId: ORG, threadId: 'thread_defer' });
+    await store.appendMessage({
+      organizationId: ORG,
+      threadId: 'thread_defer',
+      role: 'assistant',
+      parts: [],
+    });
+    expect(log).toEqual(['beginTurn:bare', 'append:assistant']);
   });
 
-  it('a settle failure warns but never fails the append — the terminal settle retries it', async () => {
+  it('a settle failure warns but never fails the open — the terminal settle retries it', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     try {
       const log: string[] = [];
@@ -347,8 +351,12 @@ describe('deferred sends — settle at user append', () => {
           throw new Error('transient settle failure');
         },
       );
-      const appended = await store.appendMessage(message('user'));
-      expect(appended).toEqual({ id: 'message_1', sequence: 1 });
+      const opened = await store.beginTurn({
+        organizationId: ORG,
+        threadId: 'thread_defer',
+        userParts: [],
+      });
+      expect(opened.assistantMessage).toEqual({ id: 'message_2', sequence: 2 });
       expect(warn).toHaveBeenCalledOnce();
     } finally {
       warn.mockRestore();

--- a/services/platform/convex/chat/generations.ts
+++ b/services/platform/convex/chat/generations.ts
@@ -94,18 +94,26 @@ export const getGeneration = query({
 export const hasLiveGenerationInternal = internalQuery({
   args: { organizationId: v.string(), threadId: v.string() },
   returns: v.boolean(),
-  handler: async (ctx, args) => {
-    const normalized = ctx.db.normalizeId('threads', args.threadId);
-    if (!normalized) return false;
-    const generation = await ctx.db
-      .query('generations')
-      .withIndex('by_thread', (q) => q.eq('threadId', normalized))
-      .first();
-    return (
-      generation !== null && generation.organizationId === args.organizationId
-    );
-  },
+  handler: async (ctx, args) =>
+    threadHasLiveGeneration(ctx, args.organizationId, args.threadId),
 });
+
+/** The at-most-one verdict itself, shared between `hasLiveGenerationInternal`
+ * and the merged gate (`turn_setup.getTurnGateInternal`) so the two cannot
+ * drift. */
+export async function threadHasLiveGeneration(
+  ctx: QueryCtx,
+  organizationId: string,
+  threadId: string,
+): Promise<boolean> {
+  const normalized = ctx.db.normalizeId('threads', threadId);
+  if (!normalized) return false;
+  const generation = await ctx.db
+    .query('generations')
+    .withIndex('by_thread', (q) => q.eq('threadId', normalized))
+    .first();
+  return generation !== null && generation.organizationId === organizationId;
+}
 
 /** Load the generation row for a thread, if any. Read-only, so it takes a
  * query OR mutation ctx (a mutation ctx satisfies the read-capable shape). */

--- a/services/platform/convex/chat/generations.ts
+++ b/services/platform/convex/chat/generations.ts
@@ -15,13 +15,14 @@
  * whether the turn succeeded, refused, or threw.
  */
 
-import { v } from 'convex/values';
+import { v, type Infer } from 'convex/values';
 
 import {
   internalMutation,
   internalQuery,
   mutation,
   query,
+  type MutationCtx,
   type QueryCtx,
 } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
@@ -147,36 +148,51 @@ export const beginGenerationInternal = internalMutation({
     external: v.optional(externalTurnStateValidator),
   },
   returns: v.null(),
-  handler: async (ctx, args) => {
-    const now = Date.now();
-    const existing = await currentGeneration(
-      ctx,
-      args.organizationId,
-      args.threadId,
-    );
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        status: 'queued',
-        messageId: args.messageId,
-        external: args.external,
-        waitingOn: undefined,
-        startedAt: now,
-        heartbeatAt: now,
-      });
-      return null;
-    }
-    await ctx.db.insert('generations', {
-      organizationId: args.organizationId,
-      threadId: args.threadId,
+  handler: async (ctx, args) => beginGenerationForThread(ctx, args),
+});
+
+/**
+ * The begin transaction body — reset-or-insert of the thread's generation row
+ * — shared between `beginGenerationInternal` and the merged turn-open write
+ * (`turn_setup.beginTurnInternal`) so the two paths cannot drift.
+ */
+export async function beginGenerationForThread(
+  ctx: MutationCtx,
+  args: {
+    organizationId: string;
+    threadId: string;
+    messageId?: string;
+    external?: Infer<typeof externalTurnStateValidator>;
+  },
+): Promise<null> {
+  const now = Date.now();
+  const existing = await currentGeneration(
+    ctx,
+    args.organizationId,
+    args.threadId,
+  );
+  if (existing) {
+    await ctx.db.patch(existing._id, {
       status: 'queued',
-      ...(args.messageId !== undefined ? { messageId: args.messageId } : {}),
-      ...(args.external !== undefined ? { external: args.external } : {}),
+      messageId: args.messageId,
+      external: args.external,
+      waitingOn: undefined,
       startedAt: now,
       heartbeatAt: now,
     });
     return null;
-  },
-});
+  }
+  await ctx.db.insert('generations', {
+    organizationId: args.organizationId,
+    threadId: args.threadId,
+    status: 'queued',
+    ...(args.messageId !== undefined ? { messageId: args.messageId } : {}),
+    ...(args.external !== undefined ? { external: args.external } : {}),
+    startedAt: now,
+    heartbeatAt: now,
+  });
+  return null;
+}
 
 /**
  * Advance an external turn's reconnect cursor after a drain window, so the next

--- a/services/platform/convex/chat/messages.ts
+++ b/services/platform/convex/chat/messages.ts
@@ -29,11 +29,13 @@ import {
 import { DAY_MS, dailyKeys, utcDateKey } from '../../lib/shared/metrics-window';
 import { isRecord } from '../../lib/utils/type-utils';
 import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
 import {
   internalMutation,
   internalQuery,
   mutation,
   query,
+  type MutationCtx,
 } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { OrganizationMismatchError } from '../lib/rls/errors';
@@ -483,88 +485,111 @@ export const appendMessageInternal = internalMutation({
     truncation: v.optional(v.object({ droppedMessages: v.number() })),
   },
   returns: v.object({ id: v.id('messages'), sequence: v.number() }),
-  handler: async (ctx, args) => {
-    const threadId = ctx.db.normalizeId('threads', args.threadId);
-    if (!threadId) {
-      throw new Error(
-        `[chat] cannot append to unknown thread ${args.threadId}`,
-      );
-    }
-    const thread = await ctx.db.get(threadId);
-    if (!thread || thread.organizationId !== args.organizationId) {
-      throw new Error(
-        `[chat] thread ${args.threadId} is not in organization ${args.organizationId}`,
-      );
-    }
-
-    // The highest existing sequence for this thread, read inside the same
-    // transaction as the insert so the assignment is atomic.
-    const last = await ctx.db
-      .query('messages')
-      .withIndex('by_thread_sequence', (q) => q.eq('threadId', thread._id))
-      .order('desc')
-      .first();
-    const sequence = last ? last.sequence + 1 : 0;
-
-    const id = await ctx.db.insert('messages', {
-      organizationId: args.organizationId,
-      threadId: thread._id,
-      role: args.role,
-      parts: args.parts,
-      sequence,
-      model: args.model,
-      providerSlug: args.providerSlug,
-      usage: args.usage,
-      blockedReason: args.blockedReason,
-      error: args.error,
-      createdAt: Date.now(),
-      ...(args.truncation !== undefined ? { truncation: args.truncation } : {}),
-    });
-
-    // A turn just wrote to the thread; keep its list ordering fresh. An
-    // assistant row also stamps the unread watermark — the sidebar's "new
-    // response" dot compares it against the owner's `lastReadAt`.
-    await ctx.db.patch(thread._id, {
-      updatedAt: Date.now(),
-      ...(args.role === 'assistant' ? { lastReplyAt: Date.now() } : {}),
-    });
-    // Activity on a hidden branch surfaces on its ROOT — the row the sidebar
-    // actually shows for the lineage.
-    if (thread.branchRootId !== undefined) {
-      const rootId = ctx.db.normalizeId('threads', thread.branchRootId);
-      const root = rootId ? await ctx.db.get(rootId) : null;
-      if (root && root.organizationId === args.organizationId) {
-        await ctx.db.patch(root._id, {
-          updatedAt: Date.now(),
-          ...(args.role === 'assistant' ? { lastReplyAt: Date.now() } : {}),
-        });
-      }
-    }
-
-    // The thread's first user message names the conversation: fire the AI
-    // title generation exactly once — for the opening user message of a
-    // thread that has no title yet (a branch copy or an explicitly titled
-    // thread keeps what it has). Scheduled inside this transaction, so the
-    // job exists iff the message committed.
-    if (args.role === 'user' && sequence === 0 && thread.title === undefined) {
-      const firstMessage = textOfParts(args.parts);
-      if (firstMessage.trim().length > 0) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.chat.generate_title.generateThreadTitle,
-          {
-            organizationId: args.organizationId,
-            threadId: thread._id,
-            userId: thread.userId,
-            firstMessage,
-          },
-        );
-      }
-    }
-
-    return { id, sequence };
-  },
+  handler: async (ctx, args) => appendMessageToThread(ctx, args),
 });
+
+/** One append's arguments, as `appendMessageInternal` accepts them. */
+interface AppendMessageArgs {
+  organizationId: string;
+  threadId: string;
+  role: 'user' | 'assistant' | 'tool' | 'system';
+  parts: unknown;
+  model?: string;
+  providerSlug?: string;
+  usage?: unknown;
+  blockedReason?: string;
+  error?: string;
+  truncation?: { droppedMessages: number };
+}
+
+/**
+ * The append transaction body, shared between `appendMessageInternal` and the
+ * merged turn-open write (`turn_setup.beginTurnInternal`) so the two paths
+ * cannot drift: sequence assignment, thread/branch-root freshness stamps, and
+ * the first-message title schedule all live here and only here.
+ */
+export async function appendMessageToThread(
+  ctx: MutationCtx,
+  args: AppendMessageArgs,
+): Promise<{ id: Id<'messages'>; sequence: number }> {
+  const threadId = ctx.db.normalizeId('threads', args.threadId);
+  if (!threadId) {
+    throw new Error(`[chat] cannot append to unknown thread ${args.threadId}`);
+  }
+  const thread = await ctx.db.get(threadId);
+  if (!thread || thread.organizationId !== args.organizationId) {
+    throw new Error(
+      `[chat] thread ${args.threadId} is not in organization ${args.organizationId}`,
+    );
+  }
+
+  // The highest existing sequence for this thread, read inside the same
+  // transaction as the insert so the assignment is atomic.
+  const last = await ctx.db
+    .query('messages')
+    .withIndex('by_thread_sequence', (q) => q.eq('threadId', thread._id))
+    .order('desc')
+    .first();
+  const sequence = last ? last.sequence + 1 : 0;
+
+  const id = await ctx.db.insert('messages', {
+    organizationId: args.organizationId,
+    threadId: thread._id,
+    role: args.role,
+    parts: args.parts,
+    sequence,
+    model: args.model,
+    providerSlug: args.providerSlug,
+    usage: args.usage,
+    blockedReason: args.blockedReason,
+    error: args.error,
+    createdAt: Date.now(),
+    ...(args.truncation !== undefined ? { truncation: args.truncation } : {}),
+  });
+
+  // A turn just wrote to the thread; keep its list ordering fresh. An
+  // assistant row also stamps the unread watermark — the sidebar's "new
+  // response" dot compares it against the owner's `lastReadAt`.
+  await ctx.db.patch(thread._id, {
+    updatedAt: Date.now(),
+    ...(args.role === 'assistant' ? { lastReplyAt: Date.now() } : {}),
+  });
+  // Activity on a hidden branch surfaces on its ROOT — the row the sidebar
+  // actually shows for the lineage.
+  if (thread.branchRootId !== undefined) {
+    const rootId = ctx.db.normalizeId('threads', thread.branchRootId);
+    const root = rootId ? await ctx.db.get(rootId) : null;
+    if (root && root.organizationId === args.organizationId) {
+      await ctx.db.patch(root._id, {
+        updatedAt: Date.now(),
+        ...(args.role === 'assistant' ? { lastReplyAt: Date.now() } : {}),
+      });
+    }
+  }
+
+  // The thread's first user message names the conversation: fire the AI
+  // title generation exactly once — for the opening user message of a
+  // thread that has no title yet (a branch copy or an explicitly titled
+  // thread keeps what it has). Scheduled inside this transaction, so the
+  // job exists iff the message committed.
+  if (args.role === 'user' && sequence === 0 && thread.title === undefined) {
+    const firstMessage = textOfParts(args.parts);
+    if (firstMessage.trim().length > 0) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.chat.generate_title.generateThreadTitle,
+        {
+          organizationId: args.organizationId,
+          threadId: thread._id,
+          userId: thread.userId,
+          firstMessage,
+        },
+      );
+    }
+  }
+
+  return { id, sequence };
+}
 
 /** A message's accumulated text — the user text a title is generated from,
  * and the assistant text a streaming window replaces. Kept tiny so the

--- a/services/platform/convex/chat/threads.ts
+++ b/services/platform/convex/chat/threads.ts
@@ -19,13 +19,12 @@
  * turns that follow. Other organizations still see nothing.
  */
 
-import { ConvexError, v } from 'convex/values';
+import { ConvexError, v, type Infer } from 'convex/values';
 
 import { internal } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
 import {
   internalMutation,
-  internalQuery,
   mutation,
   query,
   type QueryCtx,
@@ -468,50 +467,49 @@ export const setThreadSharedWithProject = mutation({
   },
 });
 
-/** The thread facts an external turn reads, scoped like every other read —
- * the (org, user) pair must own the thread. */
-export const getOwnedThreadInternal = internalQuery({
-  args: {
-    organizationId: v.string(),
-    userId: v.string(),
-    threadId: v.string(),
-  },
-  returns: v.union(
-    v.null(),
-    v.object({
-      kind: chatKindValidator,
-      capabilities: v.optional(threadCapabilitiesValidator),
-      externalResume: v.optional(v.string()),
-      agentSlug: v.optional(v.string()),
-      arena: v.optional(
-        v.object({
-          pairId: v.string(),
-          role: v.union(v.literal('a'), v.literal('b')),
-          partnerThreadId: v.string(),
-          createdAt: v.number(),
-        }),
-      ),
-    }),
-  ),
-  handler: async (ctx, args) => {
-    const thread = await loadOwnedThread(
-      ctx,
-      args.organizationId,
-      args.userId,
-      args.threadId,
-    );
-    if (!thread) return null;
-    return {
-      kind: thread.kind,
-      capabilities: thread.capabilities,
-      // The deprecated `codingResume` read shim lives HERE, so every
-      // consumer sees only `externalResume`.
-      externalResume: thread.externalResume ?? thread.codingResume,
-      agentSlug: thread.agentSlug,
-      arena: thread.arena,
-    };
-  },
-});
+/** The owned-thread projection a turn entry reads, served by the merged gate
+ * (`turn_setup.getTurnGateInternal`) — scoped like every other read: the
+ * (org, user) pair must own the thread. Carries the deprecated `codingResume`
+ * read shim so every consumer sees only `externalResume`. */
+export const ownedThreadViewValidator = v.union(
+  v.null(),
+  v.object({
+    kind: chatKindValidator,
+    capabilities: v.optional(threadCapabilitiesValidator),
+    externalResume: v.optional(v.string()),
+    agentSlug: v.optional(v.string()),
+    arena: v.optional(
+      v.object({
+        pairId: v.string(),
+        role: v.union(v.literal('a'), v.literal('b')),
+        partnerThreadId: v.string(),
+        createdAt: v.number(),
+      }),
+    ),
+  }),
+);
+
+export async function ownedThreadView(
+  ctx: QueryCtx,
+  args: { organizationId: string; userId: string; threadId: string },
+): Promise<Infer<typeof ownedThreadViewValidator>> {
+  const thread = await loadOwnedThread(
+    ctx,
+    args.organizationId,
+    args.userId,
+    args.threadId,
+  );
+  if (!thread) return null;
+  return {
+    kind: thread.kind,
+    capabilities: thread.capabilities,
+    // The deprecated `codingResume` read shim lives HERE, so every
+    // consumer sees only `externalResume`.
+    externalResume: thread.externalResume ?? thread.codingResume,
+    agentSlug: thread.agentSlug,
+    arena: thread.arena,
+  };
+}
 
 /** Remember the harness conversation handle an external turn ended with. */
 export const setExternalResumeInternal = internalMutation({

--- a/services/platform/convex/chat/turn.test.ts
+++ b/services/platform/convex/chat/turn.test.ts
@@ -404,27 +404,21 @@ describe('chat turn — end to end against a fake model', () => {
 
     await t.action(async (ctx) => {
       const store = createConvexTurnStore(ctx);
-      const { id } = await store.appendMessage({
+      // The regenerate-shaped open: no user parts, placeholder + generation.
+      const { assistantMessage } = await store.beginTurn({
         organizationId: ORG,
         threadId,
-        role: 'assistant',
-        parts: [],
-      });
-      await store.beginGeneration({
-        organizationId: ORG,
-        threadId,
-        messageId: id,
       });
       await store.streamProgress({
         organizationId: ORG,
         threadId,
-        messageId: id,
+        messageId: assistantMessage.id,
         text: '',
       });
       await store.streamProgress({
         organizationId: ORG,
         threadId,
-        messageId: id,
+        messageId: assistantMessage.id,
         text: short,
         flush: true,
       });

--- a/services/platform/convex/chat/turn_action.ts
+++ b/services/platform/convex/chat/turn_action.ts
@@ -97,6 +97,7 @@ import {
   resolveChatModel,
   type ChatAutoResolutionRefusal,
 } from '../lib/providers/resolve_chat_model';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { readBlobBytes } from '../lib/storage/blob_access';
 import { blobRefValidator } from '../lib/storage/blob_ref';
 import { sanitizeError } from '../lib/utils/sanitize_secrets';
@@ -964,6 +965,27 @@ function attachmentsFromParts(parts: readonly MessagePart[]): TurnAttachment[] {
  * context — the whole turn runs against the real tables without a Node
  * runtime or a network.
  */
+/**
+ * Concurrency with SERIAL verdicts. Independent reads start together, but the
+ * caller unwraps their settled results in the same order the sequential code
+ * awaited them — so refusal precedence and error surfaces stay byte-identical
+ * (a later read's failure never preempts an earlier read's refusal), and a
+ * discarded branch's rejection is already captured, never unhandled.
+ */
+export function settled<T>(
+  promise: Promise<T>,
+): Promise<PromiseSettledResult<T>> {
+  return promise.then(
+    (value) => ({ status: 'fulfilled' as const, value }),
+    (reason: unknown) => ({ status: 'rejected' as const, reason }),
+  );
+}
+
+export function unwrap<T>(result: PromiseSettledResult<T>): T {
+  if (result.status === 'rejected') throw result.reason;
+  return result.value;
+}
+
 export async function executeTurn(
   ctx: ActionCtx,
   args: ExecuteTurnArgs,
@@ -1005,20 +1027,48 @@ export async function executeTurn(
     modelId = args.modelId;
   }
 
-  // The model-access policy holds at the boundary, not just in the picker:
-  // the composer already hides disallowed models, but a crafted call (or a
-  // stale saved selection) must be refused here with the policy's own
-  // wording, before the credential resolution or any history read. (An Auto
-  // pick was already governance-filtered upstream; this re-check is the
-  // same boundary every explicit id passes.)
-  const access = await ctx.runQuery(
-    internal.governance.queries.checkModelAccessInternal,
-    {
+  // Five independent reads, one wall-clock slot — every syscall from this
+  // action is an authenticated round-trip, so their SUM is the caller's
+  // wait. All are pure reads (policy, lineage, blob ownership, catalog,
+  // context cap); the one side effect (the retroactive attachment bind)
+  // stays behind the verdicts below.
+  const sentAttachments = args.attachments ?? [];
+  const pendingAccess = settled(
+    ctx.runQuery(internal.governance.queries.checkModelAccessInternal, {
       organizationId: args.organizationId,
       userId: args.userId,
       modelId,
-    },
+    }),
   );
+  const pendingLineage = settled(
+    ctx.runQuery(internal.chat.branches.getThreadLineageIds, {
+      organizationId: args.organizationId,
+      threadId: args.threadId,
+    }),
+  );
+  const pendingAttachmentProblem =
+    sentAttachments.length > 0
+      ? settled(
+          validateTurnAttachments(ctx, args.organizationId, sentAttachments),
+        )
+      : null;
+  const pendingResolved = settled(
+    resolveModel(ctx, args.organizationId, modelId, providerSlug),
+  );
+  const pendingGovernanceCap = settled(
+    ctx.runQuery(internal.governance.queries.getContextCapInternal, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+    }),
+  );
+
+  // Verdicts in the serial order the reads used to run, so refusal
+  // precedence is unchanged. The model-access policy holds at the boundary,
+  // not just in the picker: a crafted call (or a stale saved selection) is
+  // refused with the policy's own wording before any credential resolution
+  // or history read. (An Auto pick was already governance-filtered
+  // upstream; this re-check is the same boundary every explicit id passes.)
+  const access = unwrap(await pendingAccess);
   if (!access.allowed) {
     return refuse(
       access.reason ?? `Model "${modelId}" is not available for your account.`,
@@ -1028,26 +1078,15 @@ export async function executeTurn(
   // The thread lineage: a regenerate runs on a hidden sibling while uploads
   // bind against the visible root, so both the retroactive bind target and
   // the knowledge-tool scope speak in lineage terms, not one thread id.
-  const lineage = await ctx.runQuery(
-    internal.chat.branches.getThreadLineageIds,
-    { organizationId: args.organizationId, threadId: args.threadId },
-  );
+  const lineage = unwrap(await pendingLineage);
 
-  // Attachments are refused BEFORE any model resolution or history read: a
-  // foreign blob reference must never get as far as a byte fetch.
-  if (args.attachments !== undefined && args.attachments.length > 0) {
-    const attachmentProblem = await validateTurnAttachments(
-      ctx,
-      args.organizationId,
-      args.attachments,
-    );
+  // Attachments are refused before anything touches them: a foreign blob
+  // reference must never get as far as a byte fetch (bytes are only read
+  // inside the model round, well behind this verdict).
+  if (pendingAttachmentProblem !== null) {
+    const attachmentProblem = unwrap(await pendingAttachmentProblem);
     if (attachmentProblem !== null) {
-      return {
-        status: 'refused',
-        steps: [],
-        step: 'input-guardrails',
-        reason: attachmentProblem,
-      };
+      return refuse(attachmentProblem);
     }
     // A file staged on the chat index uploaded before this thread existed —
     // bind it now (to the ROOT, the conversation the user sees) so the
@@ -1058,27 +1097,18 @@ export async function executeTurn(
       {
         organizationId: args.organizationId,
         threadId: lineage.rootId,
-        storageIds: args.attachments.map((attachment) => attachment.fileId),
+        storageIds: sentAttachments.map((attachment) => attachment.fileId),
       },
     );
   }
 
-  const resolved = await resolveModel(
-    ctx,
-    args.organizationId,
-    modelId,
-    providerSlug,
-  );
+  const resolved = unwrap(await pendingResolved);
 
-  // Resolve the effort → sampling and the effective window FIRST: the
-  // history read is bounded by the same budget the context assembly fits
-  // into, so a long thread never materializes whole. The internal read also
-  // frees the scheduled API-key lane from session auth the public query
-  // demands.
-  const governanceCap = await ctx.runQuery(
-    internal.governance.queries.getContextCapInternal,
-    { organizationId: args.organizationId, userId: args.userId },
-  );
+  // The effort → sampling and the effective window come FIRST: the history
+  // read is bounded by the same budget the context assembly fits into, so a
+  // long thread never materializes whole. The internal read also frees the
+  // scheduled API-key lane from session auth the public query demands.
+  const governanceCap = unwrap(await pendingGovernanceCap);
   const windowTokens = resolveEffectiveWindow({
     contextWindow: resolved.entry.contextWindow,
     governanceMaxContext: governanceCap,
@@ -1254,30 +1284,36 @@ export const startTurn = action({
     ctx,
     args,
   ): Promise<{ status: 'completed' | 'refused'; reason?: string }> => {
-    const auth = await requireOrgMembershipById(ctx, args.organizationId);
+    // Membership and the turn gate are independent reads — started together,
+    // unwrapped in the serial order, so an unauthenticated or foreign caller
+    // still fails on membership before any gate verdict is read. The gate is
+    // keyed by the JWT identity directly (free — no syscall); when there is
+    // no identity the gate runs against no owner and its answer is discarded
+    // because membership throws first.
+    const identity = await getAuthUserIdentity(ctx);
+    const pendingAuth = settled(
+      requireOrgMembershipById(ctx, args.organizationId),
+    );
+    const pendingGate = settled(
+      ctx.runQuery(internal.chat.turn_setup.getTurnGateInternal, {
+        organizationId: args.organizationId,
+        userId: identity?.userId ?? '',
+        threadId: args.threadId,
+      }),
+    );
+    const auth = unwrap(await pendingAuth);
+    const gate = unwrap(await pendingGate);
     // A thread is user-private: only its owner may run turns into it. Without
     // this, org membership alone let any member write user+assistant messages
     // into another member's thread (listMessages returns [] for a foreign
     // thread, but the append path only checked org). The external lane already
     // gates on the same owned-thread query.
-    const owned = await ctx.runQuery(
-      internal.chat.threads.getOwnedThreadInternal,
-      {
-        organizationId: args.organizationId,
-        userId: auth.userId,
-        threadId: args.threadId,
-      },
-    );
-    if (owned === null) {
+    if (gate.thread === null) {
       return { status: 'refused', reason: 'This conversation does not exist.' };
     }
     // At most one turn per thread — refuse a concurrent send rather than let two
     // turns interleave and delete each other's generation row mid-stream.
-    const busy = await ctx.runQuery(
-      internal.chat.generations.hasLiveGenerationInternal,
-      { organizationId: args.organizationId, threadId: args.threadId },
-    );
-    if (busy) {
+    if (gate.busy) {
       return {
         status: 'refused',
         reason: 'This conversation is already generating a response.',
@@ -1345,23 +1381,25 @@ export const regenerateTurn = action({
     ctx,
     args,
   ): Promise<{ status: 'completed' | 'refused'; reason?: string }> => {
-    const auth = await requireOrgMembershipById(ctx, args.organizationId);
-    const owned = await ctx.runQuery(
-      internal.chat.threads.getOwnedThreadInternal,
-      {
-        organizationId: args.organizationId,
-        userId: auth.userId,
-        threadId: args.threadId,
-      },
+    // Same entry choreography as `startTurn`: membership ∥ gate, serial
+    // verdicts.
+    const identity = await getAuthUserIdentity(ctx);
+    const pendingAuth = settled(
+      requireOrgMembershipById(ctx, args.organizationId),
     );
-    if (owned === null) {
+    const pendingGate = settled(
+      ctx.runQuery(internal.chat.turn_setup.getTurnGateInternal, {
+        organizationId: args.organizationId,
+        userId: identity?.userId ?? '',
+        threadId: args.threadId,
+      }),
+    );
+    const auth = unwrap(await pendingAuth);
+    const gate = unwrap(await pendingGate);
+    if (gate.thread === null) {
       return { status: 'refused', reason: 'This conversation does not exist.' };
     }
-    const busy = await ctx.runQuery(
-      internal.chat.generations.hasLiveGenerationInternal,
-      { organizationId: args.organizationId, threadId: args.threadId },
-    );
-    if (busy) {
+    if (gate.busy) {
       return {
         status: 'refused',
         reason: 'This conversation is already generating a response.',
@@ -1445,24 +1483,20 @@ export const runDeferredSend = internalAction({
       });
     };
 
-    const owned = await ctx.runQuery(
-      internal.chat.threads.getOwnedThreadInternal,
+    const gate = await ctx.runQuery(
+      internal.chat.turn_setup.getTurnGateInternal,
       {
         organizationId: row.organizationId,
         userId: row.userId,
         threadId: row.threadId,
       },
     );
-    if (owned === null) {
+    if (gate.thread === null) {
       // Thread erased while waiting — the row is an orphan.
       await settle();
       return null;
     }
-    const busy = await ctx.runQuery(
-      internal.chat.generations.hasLiveGenerationInternal,
-      { organizationId: row.organizationId, threadId: row.threadId },
-    );
-    if (busy) {
+    if (gate.busy) {
       await ctx.runMutation(internal.chat.deferred_sends.requeueDeferredSend, {
         deferredSendId: args.deferredSendId,
       });
@@ -1581,22 +1615,18 @@ export const startTurnForApiKey = internalAction({
     ctx,
     args,
   ): Promise<{ status: 'completed' | 'refused'; reason?: string }> => {
-    const owned = await ctx.runQuery(
-      internal.chat.threads.getOwnedThreadInternal,
+    const gate = await ctx.runQuery(
+      internal.chat.turn_setup.getTurnGateInternal,
       {
         organizationId: args.organizationId,
         userId: args.userId,
         threadId: args.threadId,
       },
     );
-    if (owned === null) {
+    if (gate.thread === null) {
       return { status: 'refused', reason: 'This conversation does not exist.' };
     }
-    const busy = await ctx.runQuery(
-      internal.chat.generations.hasLiveGenerationInternal,
-      { organizationId: args.organizationId, threadId: args.threadId },
-    );
-    if (busy) {
+    if (gate.busy) {
       return {
         status: 'refused',
         reason: 'This conversation is already generating a response.',

--- a/services/platform/convex/chat/turn_setup.test.ts
+++ b/services/platform/convex/chat/turn_setup.test.ts
@@ -66,6 +66,61 @@ async function threadGenerations(t: T, threadId: Id<'threads'>) {
   );
 }
 
+describe('chat turn gate — one round-trip', () => {
+  it('answers ownership and busy together for the idle owner', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+
+    const gate = await t.query(internal.chat.turn_setup.getTurnGateInternal, {
+      organizationId: ORG,
+      userId: USER,
+      threadId,
+    });
+
+    expect(gate.thread?.kind).toBe('direct');
+    expect(gate.busy).toBe(false);
+  });
+
+  it('reports busy while a generation row is live', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+    await t.mutation(internal.chat.generations.beginGenerationInternal, {
+      organizationId: ORG,
+      threadId,
+    });
+
+    const gate = await t.query(internal.chat.turn_setup.getTurnGateInternal, {
+      organizationId: ORG,
+      userId: USER,
+      threadId,
+    });
+
+    expect(gate.thread).not.toBeNull();
+    expect(gate.busy).toBe(true);
+  });
+
+  it('answers null (and never busy) for a foreign org or a non-owner', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+    await t.mutation(internal.chat.generations.beginGenerationInternal, {
+      organizationId: ORG,
+      threadId,
+    });
+
+    const foreignOrg = await t.query(
+      internal.chat.turn_setup.getTurnGateInternal,
+      { organizationId: 'org_other', userId: USER, threadId },
+    );
+    expect(foreignOrg).toEqual({ thread: null, busy: false });
+
+    const nonOwner = await t.query(
+      internal.chat.turn_setup.getTurnGateInternal,
+      { organizationId: ORG, userId: 'user_other', threadId },
+    );
+    expect(nonOwner).toEqual({ thread: null, busy: false });
+  });
+});
+
 describe('chat turn open — one transaction', () => {
   it('lands the user message, the placeholder, and the generation row together', async () => {
     const t = convexTest(schema, modules);

--- a/services/platform/convex/chat/turn_setup.test.ts
+++ b/services/platform/convex/chat/turn_setup.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The merged turn-open write. These pin the contract the merge must keep
+ * identical to the three standalone writes it replaced: sequence assignment,
+ * ordering, the generation row's reset-or-insert, the first-message title
+ * schedule — and the one thing the merge newly guarantees, atomicity (a
+ * failing open persists NOTHING, where the split writes stranded a user
+ * message or an orphaned placeholder).
+ */
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'chat';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+type T = TestConvex<typeof schema>;
+
+const ORG = 'org_turn_setup';
+const USER = 'user_turn_setup';
+
+async function seedThread(t: T): Promise<Id<'threads'>> {
+  return t.run(async (ctx) =>
+    ctx.db.insert('threads', {
+      organizationId: ORG,
+      userId: USER,
+      kind: 'direct',
+      archived: false,
+      createdAt: 0,
+      updatedAt: 0,
+    }),
+  );
+}
+
+async function threadMessages(t: T, threadId: Id<'threads'>) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query('messages')
+      .withIndex('by_thread_sequence', (q) => q.eq('threadId', threadId))
+      .collect(),
+  );
+}
+
+async function threadGenerations(t: T, threadId: Id<'threads'>) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query('generations')
+      .withIndex('by_thread', (q) => q.eq('threadId', threadId))
+      .collect(),
+  );
+}
+
+describe('chat turn open — one transaction', () => {
+  it('lands the user message, the placeholder, and the generation row together', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+
+    const opened = await t.mutation(
+      internal.chat.turn_setup.beginTurnInternal,
+      {
+        organizationId: ORG,
+        threadId,
+        userParts: [{ type: 'text', text: 'Hi there' }],
+        truncation: { droppedMessages: 4 },
+      },
+    );
+
+    expect(opened.userMessage?.sequence).toBe(0);
+    expect(opened.assistantMessage.sequence).toBe(1);
+
+    const messages = await threadMessages(t, threadId);
+    expect(messages.map((m) => [m.role, m.sequence])).toEqual([
+      ['user', 0],
+      ['assistant', 1],
+    ]);
+    expect(messages[0]?.parts).toEqual([{ type: 'text', text: 'Hi there' }]);
+    expect(messages[1]?.parts).toEqual([]);
+    // The truncation stamp rides the reply row, exactly as the split writes
+    // stamped it.
+    expect(messages[1]?.truncation).toEqual({ droppedMessages: 4 });
+
+    const generations = await threadGenerations(t, threadId);
+    expect(generations).toHaveLength(1);
+    expect(generations[0]?.status).toBe('queued');
+    expect(generations[0]?.messageId).toBe(opened.assistantMessage.id);
+
+    // The thread's freshness stamps moved, and the assistant row stamped the
+    // unread watermark.
+    const thread = await t.run(async (ctx) => ctx.db.get(threadId));
+    expect(thread?.updatedAt).toBeGreaterThan(0);
+    expect(thread?.lastReplyAt).toBeGreaterThan(0);
+  });
+
+  it('a user-less open (regenerate) continues the sequence with the placeholder alone', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+    await t.mutation(internal.chat.messages.appendMessageInternal, {
+      organizationId: ORG,
+      threadId,
+      role: 'user',
+      parts: [{ type: 'text', text: 'again please' }],
+    });
+
+    const opened = await t.mutation(
+      internal.chat.turn_setup.beginTurnInternal,
+      {
+        organizationId: ORG,
+        threadId,
+      },
+    );
+
+    expect(opened.userMessage).toBeUndefined();
+    expect(opened.assistantMessage.sequence).toBe(1);
+    const messages = await threadMessages(t, threadId);
+    expect(messages.map((m) => [m.role, m.sequence])).toEqual([
+      ['user', 0],
+      ['assistant', 1],
+    ]);
+  });
+
+  it('schedules the title exactly once — for the opening user message, never the placeholder', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+
+    await t.mutation(internal.chat.turn_setup.beginTurnInternal, {
+      organizationId: ORG,
+      threadId,
+      userParts: [{ type: 'text', text: 'Name this conversation' }],
+    });
+
+    const scheduled = await t.run((ctx) =>
+      ctx.db.system.query('_scheduled_functions').collect(),
+    );
+    const titleJobs = scheduled.filter((job) =>
+      job.name.includes('generateThreadTitle'),
+    );
+    expect(titleJobs).toHaveLength(1);
+    expect(titleJobs[0]?.args[0]).toMatchObject({
+      organizationId: ORG,
+      threadId,
+      userId: USER,
+      firstMessage: 'Name this conversation',
+    });
+  });
+
+  it('resets an existing generation row instead of stacking a second one', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+    await t.mutation(internal.chat.generations.beginGenerationInternal, {
+      organizationId: ORG,
+      threadId,
+    });
+
+    const opened = await t.mutation(
+      internal.chat.turn_setup.beginTurnInternal,
+      {
+        organizationId: ORG,
+        threadId,
+        userParts: [{ type: 'text', text: 'take two' }],
+      },
+    );
+
+    const generations = await threadGenerations(t, threadId);
+    expect(generations).toHaveLength(1);
+    expect(generations[0]?.status).toBe('queued');
+    expect(generations[0]?.messageId).toBe(opened.assistantMessage.id);
+  });
+
+  it('persists NOTHING when the open fails — no stranded user message, no orphan placeholder', async () => {
+    const t = convexTest(schema, modules);
+    const threadId = await seedThread(t);
+    const foreign = 'org_someone_else';
+
+    await expect(
+      t.mutation(internal.chat.turn_setup.beginTurnInternal, {
+        organizationId: foreign,
+        threadId,
+        userParts: [{ type: 'text', text: 'should never land' }],
+      }),
+    ).rejects.toThrow(/not in organization/);
+
+    expect(await threadMessages(t, threadId)).toEqual([]);
+    expect(await threadGenerations(t, threadId)).toEqual([]);
+  });
+});

--- a/services/platform/convex/chat/turn_setup.ts
+++ b/services/platform/convex/chat/turn_setup.ts
@@ -23,9 +23,45 @@
 
 import { v } from 'convex/values';
 
-import { internalMutation } from '../_generated/server';
-import { beginGenerationForThread } from './generations';
+import { internalMutation, internalQuery } from '../_generated/server';
+import {
+  beginGenerationForThread,
+  threadHasLiveGeneration,
+} from './generations';
 import { appendMessageToThread } from './messages';
+import { ownedThreadView, ownedThreadViewValidator } from './threads';
+
+/**
+ * The turn's entry gate — ownership and the at-most-one check in ONE
+ * authenticated round-trip. Every start lane used to run these as two
+ * sequential syscalls; the verdicts are the same shared functions the
+ * standalone queries serve. `busy` is false when the thread is not owned:
+ * the caller refuses on `thread === null` first, exactly as the split
+ * queries did.
+ */
+export const getTurnGateInternal = internalQuery({
+  args: {
+    organizationId: v.string(),
+    userId: v.string(),
+    threadId: v.string(),
+  },
+  returns: v.object({
+    thread: ownedThreadViewValidator,
+    busy: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const thread = await ownedThreadView(ctx, args);
+    if (thread === null) return { thread: null, busy: false };
+    return {
+      thread,
+      busy: await threadHasLiveGeneration(
+        ctx,
+        args.organizationId,
+        args.threadId,
+      ),
+    };
+  },
+});
 
 export const beginTurnInternal = internalMutation({
   args: {

--- a/services/platform/convex/chat/turn_setup.ts
+++ b/services/platform/convex/chat/turn_setup.ts
@@ -1,0 +1,76 @@
+/**
+ * The turn's opening write — one internal mutation, one transaction.
+ *
+ * A turn used to open with three sequential `ctx.runMutation` syscalls from
+ * the node action (append the user message, append the assistant placeholder,
+ * begin the generation row). The backend re-validates the caller's JWT on
+ * EVERY callback that carries one, so the "Setup before model" wait the
+ * message-info panel reports was three validations deep — merging the writes
+ * makes it one. The merge is also a correctness fix: the three writes commit
+ * atomically, so a failure can no longer strand a user message whose reply
+ * will never arrive, or an empty placeholder with no generation row (a state
+ * `recoverStaleDirectGenerations` cannot see, since it walks generations).
+ *
+ * The transaction bodies are the SAME functions the standalone mutations run
+ * (`messages.appendMessageToThread`, `generations.beginGenerationForThread`)
+ * — sequence assignment, thread/branch-root freshness stamps, the
+ * first-message title schedule, and the generation reset-or-insert cannot
+ * drift between the merged and the standalone paths.
+ *
+ * Internal because it is the trusted lower half of a turn: the node action
+ * authenticates the caller and resolves the organization before it writes.
+ */
+
+import { v } from 'convex/values';
+
+import { internalMutation } from '../_generated/server';
+import { beginGenerationForThread } from './generations';
+import { appendMessageToThread } from './messages';
+
+export const beginTurnInternal = internalMutation({
+  args: {
+    organizationId: v.string(),
+    threadId: v.string(),
+    /** The user turn's parts. Absent on a regenerate — the trailing user row
+     * already exists and the turn only re-answers it. */
+    userParts: v.optional(v.any()),
+    /** Silent stamp: context assembly dropped older history for this turn. */
+    truncation: v.optional(v.object({ droppedMessages: v.number() })),
+  },
+  returns: v.object({
+    userMessage: v.optional(
+      v.object({ id: v.id('messages'), sequence: v.number() }),
+    ),
+    assistantMessage: v.object({
+      id: v.id('messages'),
+      sequence: v.number(),
+    }),
+  }),
+  handler: async (ctx, args) => {
+    const userMessage =
+      args.userParts !== undefined
+        ? await appendMessageToThread(ctx, {
+            organizationId: args.organizationId,
+            threadId: args.threadId,
+            role: 'user',
+            parts: args.userParts,
+          })
+        : undefined;
+    const assistantMessage = await appendMessageToThread(ctx, {
+      organizationId: args.organizationId,
+      threadId: args.threadId,
+      role: 'assistant',
+      parts: [],
+      ...(args.truncation !== undefined ? { truncation: args.truncation } : {}),
+    });
+    await beginGenerationForThread(ctx, {
+      organizationId: args.organizationId,
+      threadId: args.threadId,
+      messageId: assistantMessage.id,
+    });
+    return {
+      ...(userMessage !== undefined ? { userMessage } : {}),
+      assistantMessage,
+    };
+  },
+});

--- a/services/platform/convex/chat/turn_store.ts
+++ b/services/platform/convex/chat/turn_store.ts
@@ -109,11 +109,17 @@ export function createConvexTurnStore(ctx: ActionCtx): TurnStore {
         },
       );
     },
-    async beginGeneration(generation) {
-      await ctx.runMutation(
-        internal.chat.generations.beginGenerationInternal,
-        generation,
-      );
+    async beginTurn(setup) {
+      return ctx.runMutation(internal.chat.turn_setup.beginTurnInternal, {
+        organizationId: setup.organizationId,
+        threadId: setup.threadId,
+        ...(setup.userParts !== undefined
+          ? { userParts: setup.userParts }
+          : {}),
+        ...(setup.truncation !== undefined
+          ? { truncation: setup.truncation }
+          : {}),
+      });
     },
     async endGeneration(generation) {
       await ctx.runMutation(
@@ -126,11 +132,12 @@ export function createConvexTurnStore(ctx: ActionCtx): TurnStore {
 
 /**
  * Decorate a turn store so a deferred send's row dies the moment the turn
- * persists the user message. Until that write the row is the parked message's
- * only representation (the tray above the composer); from it on the thread
- * shows the bubble, and a row that survived to the action's terminal settle
- * would double-display the message for the whole generation. A settle failure
- * is logged, never fatal — the terminal settle in the action retries it.
+ * persists the user message — the turn-open write, when it carries the user
+ * parts. Until that write the row is the parked message's only representation
+ * (the tray above the composer); from it on the thread shows the bubble, and
+ * a row that survived to the action's terminal settle would double-display
+ * the message for the whole generation. A settle failure is logged, never
+ * fatal — the terminal settle in the action retries it.
  */
 export function settleDeferredSendOnUserAppend(
   store: TurnStore,
@@ -138,16 +145,16 @@ export function settleDeferredSendOnUserAppend(
 ): TurnStore {
   return {
     ...store,
-    async appendMessage(message) {
-      const appended = await store.appendMessage(message);
-      if (message.role === 'user') {
+    async beginTurn(setup) {
+      const opened = await store.beginTurn(setup);
+      if (setup.userParts !== undefined) {
         try {
           await settle();
         } catch (error) {
           console.warn('Deferred send settle at user append failed:', error);
         }
       }
-      return appended;
+      return opened;
     },
   };
 }

--- a/services/platform/convex/http.ts
+++ b/services/platform/convex/http.ts
@@ -831,6 +831,50 @@ http.route({
 
 authComponent.registerRoutes(http, createAuth);
 
+/** How long the backend may serve the signing keys from its HTTP cache.
+ * Bounds the staleness window after a key rotation — manual, or the
+ * automatic one `jwksRotateOnTokenGenerationError` performs when signing
+ * fails: tokens minted under a brand-new key can 401 for at most this long.
+ * JWTs themselves expire in 15 minutes, so the window never outlives one. */
+const JWKS_MAX_AGE_SECONDS = 300;
+
+// The JWKS endpoint the deployment's own JWT validator fetches, re-routed
+// through an exact path (which outranks better-auth's `/api/auth/` prefix
+// route) so the response carries a freshness lifetime. The backend validates
+// the caller's JWT eagerly on EVERY request that bears one — including each
+// `ctx.run*` callback a `'use node'` action makes — and its RFC-7234 HTTP
+// cache stores this response but treats a header-less 200 as instantly stale,
+// so without `max-age` every validation re-executes this route (~90ms dev,
+// ~250ms+ on a small server) and serializes behind it. `public` is required:
+// the cache applies shared-cache semantics, which refuse to store `private`.
+http.route({
+  path: '/api/auth/convex/jwks',
+  method: 'GET',
+  handler: httpAction(async (ctx, request) => {
+    // Mirror the component handler's forwarded-header restore (its helper is
+    // module-private) so a proxied fetch behaves exactly as on the prefix route.
+    const forwardedHost = request.headers.get('x-better-auth-forwarded-host');
+    const forwardedProto = request.headers.get('x-better-auth-forwarded-proto');
+    let normalized = request;
+    // Truthy checks, exactly like the component: an empty header is ignored.
+    if (forwardedHost || forwardedProto) {
+      const forwarded = new Headers(request.headers);
+      if (forwardedHost) forwarded.set('x-forwarded-host', forwardedHost);
+      if (forwardedProto) forwarded.set('x-forwarded-proto', forwardedProto);
+      normalized = new Request(request, { headers: forwarded });
+    }
+    const auth = createAuth(ctx);
+    const response = await auth.handler(normalized);
+    if (!response.ok) return response;
+    const headers = new Headers(response.headers);
+    headers.set('Cache-Control', `public, max-age=${JWKS_MAX_AGE_SECONDS}`);
+    return new Response(response.body, {
+      status: response.status,
+      headers,
+    });
+  }),
+});
+
 // Connector routes. The OAuth2 pair is the consent flow that turns
 // a connector into a stored credential: `start` is session-authenticated and
 // mints a single-use, server-side state; `callback` consumes it and exchanges

--- a/services/platform/convex/http_jwks_cache.test.ts
+++ b/services/platform/convex/http_jwks_cache.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The JWKS route's freshness contract. The deployment's own JWT validator
+ * fetches this endpoint through an RFC-7234 HTTP cache that treats a
+ * header-less 200 as instantly stale — so if this header disappears, every
+ * JWT-carrying request (every `ctx.run*` callback of a `'use node'` action
+ * included) goes back to executing this route live, and chat setup latency
+ * multiplies by the syscall count. See the exact-path route in `http.ts`.
+ */
+
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import betterAuthSchema from './betterAuth/schema';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.*s');
+const authModules = import.meta.glob('./betterAuth/**/*.*s');
+
+describe('jwks endpoint — shared-cache freshness', () => {
+  it('serves the key set with a public max-age so the validator caches it', async () => {
+    const t = convexTest(schema, modules);
+    t.registerComponent('betterAuth', betterAuthSchema, authModules);
+
+    const response = await t.fetch('/api/auth/convex/jwks', { method: 'GET' });
+
+    expect(response.status).toBe(200);
+    // `public` is load-bearing: the backend applies shared-cache semantics
+    // and refuses to store `private`. A finite max-age bounds key-rotation
+    // staleness; zero or absent re-inflicts one live fetch per validation.
+    expect(response.headers.get('cache-control')).toMatch(
+      /^public, max-age=[1-9]\d*$/,
+    );
+    const body = (await response.json()) as { keys?: unknown[] };
+    expect(Array.isArray(body.keys)).toBe(true);
+    expect(body.keys?.length).toBeGreaterThan(0);
+  });
+});

--- a/services/platform/lib/chat/turn.test.ts
+++ b/services/platform/lib/chat/turn.test.ts
@@ -84,8 +84,10 @@ interface StoreCalls {
   /** Every settle write into the placeholder. */
   readonly finalized: Array<Record<string, unknown>>;
   readonly generations: string[];
-  /** The messageId each beginGeneration carried. */
+  /** The placeholder messageId each turn-open carried. */
   readonly generationMessageIds: Array<string | undefined>;
+  /** Every store call, in order — the setup-cost contract asserts on this. */
+  readonly ops: string[];
 }
 
 function fakeStore(options: { cancelAfterStreamWrites?: number } = {}): {
@@ -99,11 +101,49 @@ function fakeStore(options: { cancelAfterStreamWrites?: number } = {}): {
     finalized: [],
     generations: [],
     generationMessageIds: [],
+    ops: [],
   };
   return {
     calls,
     store: {
+      beginTurn(setup) {
+        calls.ops.push('beginTurn');
+        // Record the merged open as the row appends it commits, so ordering
+        // assertions read the same ledger as before the merge.
+        const appendRow = (row: Record<string, unknown>) => {
+          calls.appended.push(row);
+          return {
+            id: `msg_${calls.appended.length}`,
+            sequence: calls.appended.length,
+          };
+        };
+        const userMessage =
+          setup.userParts !== undefined
+            ? appendRow({
+                organizationId: setup.organizationId,
+                threadId: setup.threadId,
+                role: 'user',
+                parts: setup.userParts,
+              })
+            : undefined;
+        const assistantMessage = appendRow({
+          organizationId: setup.organizationId,
+          threadId: setup.threadId,
+          role: 'assistant',
+          parts: [],
+          ...(setup.truncation !== undefined
+            ? { truncation: setup.truncation }
+            : {}),
+        });
+        calls.generations.push('begin');
+        calls.generationMessageIds.push(assistantMessage.id);
+        return Promise.resolve({
+          ...(userMessage !== undefined ? { userMessage } : {}),
+          assistantMessage,
+        });
+      },
       appendMessage(message) {
+        calls.ops.push('appendMessage');
         calls.appended.push(message);
         return Promise.resolve({
           id: `msg_${calls.appended.length}`,
@@ -111,6 +151,7 @@ function fakeStore(options: { cancelAfterStreamWrites?: number } = {}): {
         });
       },
       streamProgress(update) {
+        calls.ops.push('streamProgress');
         calls.streamed.push({
           messageId: update.messageId,
           text: update.text,
@@ -122,21 +163,19 @@ function fakeStore(options: { cancelAfterStreamWrites?: number } = {}): {
         });
       },
       updateAssistantParts(update) {
+        calls.ops.push('updateAssistantParts');
         calls.partsWrites.push(
           update.parts.map((part) => ({ ...part }) as Record<string, unknown>),
         );
         return Promise.resolve();
       },
       finalizeAssistantMessage(message) {
+        calls.ops.push('finalizeAssistantMessage');
         calls.finalized.push(message);
         return Promise.resolve();
       },
-      beginGeneration(generation) {
-        calls.generations.push('begin');
-        calls.generationMessageIds.push(generation.messageId);
-        return Promise.resolve();
-      },
       endGeneration() {
+        calls.ops.push('endGeneration');
         calls.generations.push('end');
         return Promise.resolve();
       },
@@ -254,6 +293,24 @@ describe('runTurn — the happy path', () => {
     expect(d.store.generations).toEqual(['begin', 'end']);
     // The streaming-progress writes double as the turn's heartbeat.
     expect(d.store.streamed.length).toBeGreaterThan(0);
+  });
+
+  it('opens the turn with ONE store write before the model dispatches', async () => {
+    const { store, calls } = fakeStore();
+    let opsAtDispatch: readonly string[] | undefined;
+    const model: ModelCall = async function* stream() {
+      opsAtDispatch = [...calls.ops];
+      yield { text: 'ok' };
+    };
+    const d = deps({ model, store });
+    await runTurn(request(), d.deps);
+
+    // The setup wait is per-syscall: each store round-trip before the first
+    // model dispatch is an authenticated callback the backend re-validates
+    // one by one. The whole open — user message, placeholder, generation row
+    // — must stay ONE call; a second pre-dispatch write is a setup-latency
+    // regression.
+    expect(opsAtDispatch).toEqual(['beginTurn']);
   });
 
   it('records what the provider reported instead of its own estimate', async () => {

--- a/services/platform/lib/chat/turn.ts
+++ b/services/platform/lib/chat/turn.ts
@@ -230,12 +230,29 @@ export interface TurnStore {
     blockedReason?: string;
     error?: string;
   }): Promise<void>;
-  beginGeneration(generation: {
+  /**
+   * Open the turn in ONE transaction: append the user's message, create the
+   * assistant placeholder the turn streams into, and begin the generation
+   * row. A single store round-trip where three ran before — every round-trip
+   * from the action host is an authenticated syscall, and the setup wait the
+   * message-info panel reports is their sum. Atomic, so a failure can never
+   * strand a user message whose reply will not arrive, or a placeholder with
+   * no generation row.
+   */
+  beginTurn(setup: {
     organizationId: string;
     threadId: string;
-    /** The assistant placeholder the turn streams into. */
-    messageId?: string;
-  }): Promise<void>;
+    /** The user turn's parts. Absent on a regenerate — the trailing user
+     * row already exists and the turn only re-answers it. */
+    userParts?: ChatMessage['parts'];
+    /** Older history was dropped assembling this turn's context — recorded
+     * silently on the reply row for telemetry; never rendered. */
+    truncation?: { droppedMessages: number };
+  }): Promise<{
+    userMessage?: { id: string; sequence: number };
+    /** The placeholder the turn streams into. */
+    assistantMessage: { id: string; sequence: number };
+  }>;
   /** Deletes the row: its absence is what tells every reader the turn
    * settled. Runs whether the turn succeeded, refused, or threw. */
   endGeneration(generation: {
@@ -872,33 +889,25 @@ export async function runTurn(
   steps.push('assemble-context');
   const context = assembleTurnContext(request, input.text, now());
 
-  if (request.appendUserMessage !== false) {
-    await deps.store.appendMessage({
-      organizationId: request.organizationId,
-      threadId: request.threadId,
-      role: 'user',
-      parts: userTurnParts(input.text, request.attachments),
-    });
-  }
   // The assistant message exists BEFORE the stream starts: the turn streams
   // its cleared text into this row, so a reader watching the thread sees the
   // reply grow, and a mid-stream failure keeps the partial text it managed.
-  const placeholder = await deps.store.appendMessage({
+  // User message, placeholder, and generation row commit as ONE transaction —
+  // the setup wait is a single authenticated round-trip, and no partial
+  // combination of the three can survive a failure.
+  const opened = await deps.store.beginTurn({
     organizationId: request.organizationId,
     threadId: request.threadId,
-    role: 'assistant',
-    parts: [],
+    ...(request.appendUserMessage !== false
+      ? { userParts: userTurnParts(input.text, request.attachments) }
+      : {}),
     // Silent observability: the reply records that its context was fitted
     // by dropping history. Never rendered — telemetry and debugging only.
     ...(context.truncation !== undefined
       ? { truncation: { droppedMessages: context.truncation.droppedMessages } }
       : {}),
   });
-  await deps.store.beginGeneration({
-    organizationId: request.organizationId,
-    threadId: request.threadId,
-    messageId: placeholder.id,
-  });
+  const placeholder = opened.assistantMessage;
 
   /** Timings for the message-info panel, all anchored at runTurn start —
    * the action host beginning the reply, not the user's click. Setup is


### PR DESCRIPTION
## Problem

"Setup before model" on the production deployment sat at 677–900 ms for what is three ~12 ms mutations, and every authenticated surface (get-session, composer models, …) dragged for the same reason.

Root cause, independently re-verified three ways (repo read, upstream convex-backend source at the pinned commit, live local measurement): the backend validates the caller's JWT **eagerly on every request that carries one** — including every `ctx.run*` callback a `'use node'` action makes (the node executor re-sends the user JWT on each syscall) — and validation fetches the JWKS **before** checking the signature. The backend has an RFC-7234 header-driven HTTP cache in front of that fetch, but the better-auth `/api/auth/convex/jwks` endpoint returned no cache headers, so a header-less 200 is instantly stale: every validation re-executed the jwks HTTP action live (~92 ms dev, ~250 ms+ prod), with no single-flight. Nothing to upgrade to: no upstream fix exists past the pinned commit, and the `AUTH_CACHE_*` knobs are unconsumed in the OSS build.

## Fix (two layers, each where it lives)

**1. Give the key set a freshness lifetime** — an exact-path route for `GET /api/auth/convex/jwks` (exact outranks the component's `/api/auth/` prefix) stamps `Cache-Control: public, max-age=300` on 2xx responses. The backend's existing cache then serves the keys from memory: JWT validation stops costing an isolate execution per request, deployment-wide. Guarded by `http_jwks_cache.test.ts`.

**2. Open the turn in one transaction** — `TurnStore.beginGeneration` becomes `beginTurn`: user message + assistant placeholder + generation row commit as ONE internal mutation (`chat/turn_setup:beginTurnInternal`) instead of three sequential authenticated syscalls. The transaction bodies are the same functions the standalone mutations now delegate to (`appendMessageToThread`, `beginGenerationForThread`), so the merged and standalone paths cannot drift. This also fixes a real pre-existing failure mode: `beginGeneration` threw outside the turn's `try` and could strand an orphan placeholder invisible to the recovery sweeper. The deferred-send settle decorator moves to the merged open. Regression-locked: store ops at model dispatch must equal `['beginTurn']`; message ordering is safe because `sequence` is assigned in-transaction, never from `_creationTime`.

A follow-up commit on this branch merges the per-lane owned+busy gate queries into one and runs the independent pre-turn reads concurrently.

## Measured (local dev, real browser + backend function logs)

| | before | after |
|---|---|---|
| Setup before model | 388 ms | **41 ms** |
| setup-window mutations | 3 | **1** |
| jwks executions, login window | ~35 | **1** |
| jwks executions, during a turn | 23 | **0** |

On the production server each validation cost ~250–400 ms, so the same ratios apply to the 677–900 ms figure and to the ~9 pre-pipeline syscalls that sit before the measured window.

## Notes for review

- Known trade-off (flagged, not fixed here): in the deferred-send lane an open failure is now all-or-nothing — the razor-thin window where the user's text could previously survive a partial setup (writes 2/3 failing) now loses it like a write-1 failure always did. The interactive lane is unaffected (composer keeps the text).
- `beginGenerationInternal` keeps its shape but is test-only surface now (it delegates to the same shared helper).
- Key-rotation staleness is bounded by the 300 s max-age, including the automatic `jwksRotateOnTokenGenerationError` path; JWTs live 15 min.
- Verified: tsc, oxlint, SAST 0 findings, full server+pii suite (75 037 tests), migrations:check, plus live before/after probes.