### PR TITLE
feat(platform): match questions, not just typed names, in entity search

### DIFF
--- a/services/platform/convex/contacts/list_contacts_paginated.ts
+++ b/services/platform/convex/contacts/list_contacts_paginated.ts
@@ -9,19 +9,7 @@ import type { PaginationOptions, PaginationResult } from 'convex/server';
 
 import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
-import { runEntitySearch, type SearchStrategy } from '../lib/search';
-
-/** Contacts are searched by name + email (substring) and `externalId`
- *  (exact / substring). Soft-deleted rows are excluded. Mirrors the customers
- *  strategy; the shared `lib/search` owns the cross-entity variants. */
-const contactsSearchStrategy: SearchStrategy<'contacts'> = {
-  table: 'contacts',
-  orgIndex: 'by_organizationId',
-  textFields: ['name', 'email'],
-  idFields: ['externalId'],
-  activeOnly: true,
-  engine: 'scan',
-};
+import { contactsSearchStrategy, runEntitySearch } from '../lib/search';
 
 interface FilterIndex {
   field: string;

--- a/services/platform/convex/lib/search/index.ts
+++ b/services/platform/convex/lib/search/index.ts
@@ -6,8 +6,16 @@ export {
   scopedSubstringSearch,
 } from './scoped_substring_search';
 export { runEntitySearch } from './run_entity_search';
-export { isActiveRow, rowMatches, scoreAndSort } from './relevance';
+export {
+  isActiveRow,
+  type MatchMode,
+  queryTokens,
+  rowMatches,
+  scoreAndSort,
+} from './relevance';
 
 // Per-entity strategies.
 export { contactsSearchStrategy } from './strategies/contacts';
 export { documentsSearchStrategy } from './strategies/documents';
+export { projectsSearchStrategy } from './strategies/projects';
+export { tasksSearchStrategy } from './strategies/tasks';

--- a/services/platform/convex/lib/search/relevance.test.ts
+++ b/services/platform/convex/lib/search/relevance.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Doc } from '../../_generated/dataModel';
-import { isActiveRow, rowMatches, scoreAndSort } from './relevance';
+import {
+  isActiveRow,
+  queryTokens,
+  rowMatches,
+  scoreAndSort,
+} from './relevance';
 import { contactsSearchStrategy } from './strategies/contacts';
+import { projectsSearchStrategy } from './strategies/projects';
+import { tasksSearchStrategy } from './strategies/tasks';
 
 /** Build a minimal contact doc for the pure matching/scoring helpers. `_id`
  *  is widened to `string` so a test can label rows ('exact'/'prefix'/…) without
@@ -143,5 +150,206 @@ describe('scoreAndSort', () => {
     ];
     const ordered = scoreAndSort(rows, contactsSearchStrategy, 'cust-7');
     expect(ordered.map((r) => r._id)).toEqual(['id', 'name']);
+  });
+});
+
+// ---------------------------------------------------------------- 'any' mode
+
+/** A minimal task doc. Same widening trick as `contact` — only the searched
+ *  fields matter to the pure helpers. */
+function task(
+  overrides: Partial<Omit<Doc<'tasks'>, '_id'>> & { _id?: string },
+): Doc<'tasks'> {
+  return {
+    _id: 't1',
+    _creationTime: 0,
+    organizationId: 'org',
+    projectId: 'p1',
+    title: '',
+    ...overrides,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; only the searched fields matter
+  } as Doc<'tasks'>;
+}
+
+const anyMatch = (row: Doc<'tasks'>, term: string) =>
+  rowMatches(row, tasksSearchStrategy, term.toLowerCase(), term, 'any');
+const allMatch = (row: Doc<'tasks'>, term: string) =>
+  rowMatches(row, tasksSearchStrategy, term.toLowerCase(), term, 'all');
+
+describe('queryTokens', () => {
+  it("leaves the query verbatim in 'all' mode", () => {
+    expect(queryTokens('what open tasks', 'all')).toEqual([
+      'what',
+      'open',
+      'tasks',
+    ]);
+  });
+
+  it("drops function words and one-character fragments in 'any' mode", () => {
+    expect(queryTokens('what open tasks do we have', 'any')).toEqual([
+      'open',
+      'tasks',
+    ]);
+    expect(queryTokens('a b facebook', 'any')).toEqual(['facebook']);
+  });
+
+  it('drops German and French function words, not just English', () => {
+    expect(queryTokens('welche aufgaben haben wir', 'any')).toEqual([
+      'aufgaben',
+    ]);
+    expect(queryTokens('quelles sont les tâches ouvertes', 'any')).toEqual([
+      'quelles',
+      'tâches',
+      'ouvertes',
+    ]);
+  });
+
+  it('keeps board vocabulary that doubles as a common word', () => {
+    // "open", "done" and "review" are statuses — dropping them as stopwords
+    // would make the most common question about a board unanswerable.
+    expect(queryTokens('open done review', 'any')).toEqual([
+      'open',
+      'done',
+      'review',
+    ]);
+  });
+
+  it("returns nothing for an all-stopword query in 'any' mode", () => {
+    expect(queryTokens('what do we have', 'any')).toEqual([]);
+  });
+});
+
+describe("rowMatches in 'any' mode", () => {
+  it('finds the task the reported failure could not', () => {
+    // The question a user actually asked, verbatim from the bug report. Under
+    // AND semantics "recruitment" alone sinks it, which is exactly why chat
+    // answered "no open project tasks" and recommended a competitor.
+    const question = 'recruitment ads Facebook ad account project tasks';
+    const row = task({ title: 'Set up Facebook ad account' });
+
+    expect(allMatch(row, question)).toBe(false);
+    expect(anyMatch(row, question)).toBe(true);
+  });
+
+  it('matches on the description as well as the title', () => {
+    const row = task({
+      title: 'Q3 launch',
+      description: 'Book the venue in Rotterdam',
+    });
+    expect(anyMatch(row, 'where are we with the venue booking')).toBe(true);
+  });
+
+  it('matches nothing when the query is only function words', () => {
+    // The row's title deliberately CONTAINS the query's words: without the
+    // stopword filter it matches, and so would every other row in the org.
+    // Honest emptiness beats returning the whole board.
+    expect(
+      anyMatch(task({ title: 'What we have on the shelf' }), 'what do we have'),
+    ).toBe(false);
+  });
+
+  it('refuses a bare mid-word substring as the only evidence', () => {
+    // "ad" inside "overhead" is noise once tokens are OR-ed. As a whole word
+    // it is a real hit.
+    expect(anyMatch(task({ title: 'Reduce overhead' }), 'ad spend')).toBe(
+      false,
+    );
+    expect(anyMatch(task({ title: 'Facebook ad spend' }), 'ad spend')).toBe(
+      true,
+    );
+  });
+
+  it('still requires every token under the default mode', () => {
+    const row = task({ title: 'Set up Facebook ad account' });
+    // No explicit mode → 'all', so existing callers are untouched.
+    expect(
+      rowMatches(row, tasksSearchStrategy, 'facebook paris', 'facebook paris'),
+    ).toBe(false);
+  });
+
+  it('ignores fields not configured on the tasks strategy', () => {
+    // `status` and `rank` are real columns but not searchable text — a query
+    // for "todo" must not match every task in the todo column.
+    expect(anyMatch(task({ title: 'x', status: 'todo' }), 'todo')).toBe(false);
+    expect(anyMatch(task({ title: 'x', rank: 'aaz' }), 'aaz')).toBe(false);
+  });
+
+  it('matches a task by its external tracker id', () => {
+    expect(anyMatch(task({ title: 'x', externalId: 'GH-914' }), 'GH-914')).toBe(
+      true,
+    );
+  });
+});
+
+describe("scoreAndSort in 'any' mode", () => {
+  it('puts the row that answers the most of the question first', () => {
+    const question = 'recruitment ads Facebook ad account project tasks';
+    const rows = [
+      // Hits one token, and is the newer row — recency must not win here.
+      task({ _id: 'weak', title: 'Facebook page refresh', _creationTime: 9 }),
+      // Hits three: facebook, ad, account.
+      task({
+        _id: 'strong',
+        title: 'Set up Facebook ad account',
+        _creationTime: 1,
+      }),
+    ];
+    const ordered = scoreAndSort(
+      rows,
+      tasksSearchStrategy,
+      question.toLowerCase(),
+      'any',
+    );
+    expect(ordered.map((r) => r._id)).toEqual(['strong', 'weak']);
+  });
+
+  it('scores over the same tokens it matched on', () => {
+    // Ranking must read the FILTERED tokens, not the raw query. The noise row
+    // is stuffed with function words so that, if stopwords still scored, its
+    // six weak hits would outrank the one row that actually answers.
+    const rows = [
+      task({
+        _id: 'noise',
+        title: 'What do we have about the shelf',
+        _creationTime: 9,
+      }),
+      task({ _id: 'real', title: 'Account', _creationTime: 1 }),
+    ];
+    const ordered = scoreAndSort(
+      rows,
+      tasksSearchStrategy,
+      'what do we have about the account',
+      'any',
+    );
+    expect(ordered.map((r) => r._id)).toEqual(['real', 'noise']);
+  });
+});
+
+describe('projectsSearchStrategy', () => {
+  function project(
+    overrides: Partial<Omit<Doc<'projects'>, '_id'>> & { _id?: string },
+  ): Doc<'projects'> {
+    return {
+      _id: 'p1',
+      _creationTime: 0,
+      organizationId: 'org',
+      name: '',
+      ...overrides,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; only the searched fields matter
+    } as Doc<'projects'>;
+  }
+
+  it('matches a project by name and by its short key', () => {
+    const row = project({ name: 'Recruitment', key: 'REC' });
+    expect(
+      rowMatches(row, projectsSearchStrategy, 'recruitment', 'recruitment'),
+    ).toBe(true);
+    expect(rowMatches(row, projectsSearchStrategy, 'rec', 'REC')).toBe(true);
+  });
+
+  it('does not match on colour or icon', () => {
+    const row = project({ name: 'Recruitment', color: 'teal', icon: 'flag' });
+    expect(rowMatches(row, projectsSearchStrategy, 'teal', 'teal')).toBe(false);
+    expect(rowMatches(row, projectsSearchStrategy, 'flag', 'flag')).toBe(false);
   });
 });

--- a/services/platform/convex/lib/search/relevance.ts
+++ b/services/platform/convex/lib/search/relevance.ts
@@ -19,12 +19,266 @@ function fieldText(value: unknown): string | undefined {
   return undefined;
 }
 
-/** Split a lowercased query into whitespace-delimited tokens. Multi-token
- *  queries match with AND semantics — every token must hit some field — so
- *  "john acme" finds "John" at "Acme Corp" rather than a literal "john acme". */
+/**
+ * How a multi-token query is matched.
+ *
+ * `'all'` — every token must hit some field. Right when the caller TYPED the
+ * term: a picker, a mention autocomplete, a search box. "john acme" finds
+ * "John" at "Acme Corp" rather than a literal "john acme".
+ *
+ * `'any'` — the term is a QUESTION someone asked, not a name they typed. Most
+ * of its words ("what", "do we have", "about") are absent from the data by
+ * construction, so requiring all of them finds nothing: the real query
+ * "recruitment ads Facebook ad account project tasks" cannot match a task
+ * titled "Set up Facebook ad account" under `'all'`. `'any'` drops function
+ * words, keeps rows that hit a remaining token at word-start or better, and
+ * leaves {@link scoreAndSort} to put the row that hit the most tokens first.
+ */
+export type MatchMode = 'all' | 'any';
+
+/**
+ * Function words dropped in `'any'` mode, across the three locales the app
+ * ships (en, de, fr) — a question is asked in the reader's language, so an
+ * English-only list would leave German and French questions full of noise
+ * tokens that match every row.
+ *
+ * Deliberately NO domain vocabulary: "open", "done", "review" and the like
+ * carry real meaning on a task board and must stay searchable.
+ */
+const STOPWORDS: ReadonlySet<string> = new Set([
+  // en
+  'a',
+  'about',
+  'all',
+  'am',
+  'an',
+  'and',
+  'any',
+  'anything',
+  'are',
+  'as',
+  'at',
+  'be',
+  'been',
+  'but',
+  'by',
+  'can',
+  'could',
+  'did',
+  'do',
+  'does',
+  'for',
+  'from',
+  'get',
+  'give',
+  'had',
+  'has',
+  'have',
+  'how',
+  'i',
+  'if',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'just',
+  'know',
+  'like',
+  'list',
+  'me',
+  'my',
+  'need',
+  'of',
+  'on',
+  'one',
+  'or',
+  'our',
+  'out',
+  'over',
+  'please',
+  'show',
+  'so',
+  'some',
+  'tell',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'those',
+  'to',
+  'up',
+  'us',
+  'want',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'where',
+  'which',
+  'who',
+  'why',
+  'will',
+  'with',
+  'would',
+  'you',
+  'your',
+  // de
+  'aber',
+  'alle',
+  'als',
+  'am',
+  'auf',
+  'aus',
+  'bei',
+  'bin',
+  'bitte',
+  'das',
+  'dass',
+  'dem',
+  'den',
+  'denn',
+  'der',
+  'des',
+  'die',
+  'du',
+  'ein',
+  'eine',
+  'einem',
+  'einen',
+  'einer',
+  'eines',
+  'er',
+  'es',
+  'für',
+  'gibt',
+  'hat',
+  'haben',
+  'ich',
+  'ihr',
+  'im',
+  'in',
+  'ist',
+  'kein',
+  'keine',
+  'mein',
+  'mir',
+  'mit',
+  'nicht',
+  'oder',
+  'sich',
+  'sie',
+  'sind',
+  'über',
+  'uns',
+  'unser',
+  'von',
+  'war',
+  'waren',
+  'was',
+  'welche',
+  'welcher',
+  'wer',
+  'werden',
+  'wie',
+  'wir',
+  'wird',
+  'wo',
+  'warum',
+  'zu',
+  'zum',
+  'zur',
+  // fr
+  'au',
+  'aux',
+  'avec',
+  'ce',
+  'ces',
+  'cette',
+  'comment',
+  'dans',
+  'de',
+  'des',
+  'du',
+  'elle',
+  'elles',
+  'en',
+  'est',
+  'et',
+  'il',
+  'ils',
+  'je',
+  'la',
+  'le',
+  'les',
+  'leur',
+  'ma',
+  'mon',
+  'ne',
+  'nos',
+  'notre',
+  'nous',
+  'ont',
+  'ou',
+  'où',
+  'pas',
+  'pour',
+  'pourquoi',
+  'quel',
+  'quelle',
+  'qui',
+  'quoi',
+  'sa',
+  'se',
+  'sera',
+  'ses',
+  'son',
+  'sont',
+  'sur',
+  'tu',
+  'un',
+  'une',
+  'vos',
+  'votre',
+  'vous',
+  'était',
+]);
+
+/** Split a lowercased query into whitespace-delimited tokens. */
 function tokenize(lowerTerm: string): string[] {
   return lowerTerm.split(/\s+/).filter(Boolean);
 }
+
+/**
+ * The tokens a mode actually searches on. `'all'` searches the query verbatim;
+ * `'any'` strips function words and one-character fragments.
+ *
+ * `'any'` can legitimately come back EMPTY — a query that is nothing but
+ * function words ("what do we have?") carries no searchable signal. Returning
+ * `[]` rather than falling back to the raw tokens is what lets the caller say
+ * "too general to search" instead of returning every row in the org.
+ */
+export function queryTokens(lowerTerm: string, mode: MatchMode): string[] {
+  const tokens = tokenize(lowerTerm);
+  if (mode === 'all') return tokens;
+  return tokens.filter((token) => token.length > 1 && !STOPWORDS.has(token));
+}
+
+/**
+ * The weakest tier that counts as a hit in `'any'` mode: a word-start match.
+ *
+ * A bare mid-word substring is noise once tokens are OR-ed — "ad" would pull in
+ * every row containing "overhead" — whereas under `'all'` every other token
+ * still has to hit, so a weak tier there is a supporting signal, not the whole
+ * case for the row.
+ */
+const MIN_ANY_TIER = 2;
 
 /** True when any punctuation/whitespace-delimited word in `text` starts with
  *  `token`. This is the signal that ranks "ann" → "Anna Lee" (word start) above
@@ -46,52 +300,77 @@ function fieldTier(text: string | undefined, token: string): number {
   return 0;
 }
 
-/** True when one token hits any configured field — a text/array substring, or
- *  an id field exactly (raw, case-sensitive) or by substring. */
-function tokenHitsRow<T extends TableNames>(
+/** An id field matched raw and whole — the strongest signal a single token can
+ *  carry, on a par with an exact text-field match. */
+const ID_EXACT_TIER = 4;
+/** An id field containing the token. Rated at word-start strength so a
+ *  deliberate identifier lookup still counts in `'any'` mode, where a bare
+ *  substring would not. */
+const ID_SUBSTRING_TIER = 2;
+
+/**
+ * The strength of one token's best hit anywhere on the row, on the same scale
+ * {@link fieldTier} uses (0 = no hit). Matching and ranking both read this, so
+ * a row can never be kept by one rule and ordered by another.
+ */
+function tokenTier<T extends TableNames>(
   record: Record<string, unknown>,
   strategy: SearchStrategy<T>,
   token: string,
   rawTerm: string,
-): boolean {
+): number {
+  let best = 0;
   for (const field of strategy.textFields) {
-    if (fieldText(record[field])?.includes(token)) return true;
+    best = Math.max(best, fieldTier(fieldText(record[field]), token));
   }
   for (const field of strategy.arrayTextFields ?? []) {
     const arr = record[field];
-    if (
-      Array.isArray(arr) &&
-      arr.some((el) => fieldText(el)?.includes(token))
-    ) {
-      return true;
+    if (!Array.isArray(arr)) continue;
+    for (const element of arr) {
+      best = Math.max(best, fieldTier(fieldText(element), token));
     }
   }
   for (const field of strategy.idFields ?? []) {
     const value = record[field];
     if (typeof value !== 'string' && typeof value !== 'number') continue;
     const text = value.toString();
-    if (text === rawTerm || text.toLowerCase().includes(token)) return true;
+    if (text === rawTerm) return ID_EXACT_TIER;
+    if (text.toLowerCase().includes(token)) {
+      best = Math.max(best, ID_SUBSTRING_TIER);
+    }
   }
-  return false;
+  return best;
 }
 
 /**
- * True when the row matches the query. Multi-token queries use AND semantics:
- * every whitespace-delimited token must hit some configured field, so a row is
- * reachable by any combination of its searchable fields ("john acme" → first
- * name + company) rather than only by a literal substring of the whole query.
+ * True when the row matches the query, under the caller's {@link MatchMode}.
+ *
+ * `'all'` (the default) requires every whitespace-delimited token to hit some
+ * configured field, so a row is reachable by any combination of its searchable
+ * fields ("john acme" → first name + company) rather than only by a literal
+ * substring of the whole query.
+ *
+ * `'any'` requires one surviving token to hit at word-start or better. An
+ * all-stopword query matches NOTHING rather than everything — the caller is
+ * expected to report that as "too general", which is the honest answer.
  */
 export function rowMatches<T extends TableNames>(
   row: Doc<T>,
   strategy: SearchStrategy<T>,
   lowerTerm: string,
   rawTerm: string,
+  mode: MatchMode = 'all',
 ): boolean {
-  const tokens = tokenize(lowerTerm);
-  if (tokens.length === 0) return true;
+  const tokens = queryTokens(lowerTerm, mode);
+  if (tokens.length === 0) return mode === 'all';
   const record = row as Record<string, unknown>;
-  return tokens.every((token) =>
-    tokenHitsRow(record, strategy, token, rawTerm),
+  if (mode === 'any') {
+    return tokens.some(
+      (token) => tokenTier(record, strategy, token, rawTerm) >= MIN_ANY_TIER,
+    );
+  }
+  return tokens.every(
+    (token) => tokenTier(record, strategy, token, rawTerm) > 0,
   );
 }
 
@@ -110,8 +389,9 @@ function rowScore<T extends TableNames>(
   row: Doc<T>,
   strategy: SearchStrategy<T>,
   lowerTerm: string,
+  mode: MatchMode,
 ): number {
-  const tokens = tokenize(lowerTerm);
+  const tokens = queryTokens(lowerTerm, mode);
   if (tokens.length === 0) return 0;
   const record = row as Record<string, unknown>;
 
@@ -152,10 +432,12 @@ export function scoreAndSort<T extends TableNames>(
   rows: ReadonlyArray<Doc<T>>,
   strategy: SearchStrategy<T>,
   lowerTerm: string,
+  mode: MatchMode = 'all',
 ): Doc<T>[] {
   return [...rows].sort((a, b) => {
     const byScore =
-      rowScore(b, strategy, lowerTerm) - rowScore(a, strategy, lowerTerm);
+      rowScore(b, strategy, lowerTerm, mode) -
+      rowScore(a, strategy, lowerTerm, mode);
     if (byScore !== 0) return byScore;
     return b._creationTime - a._creationTime;
   });

--- a/services/platform/convex/lib/search/scoped_substring_search.ts
+++ b/services/platform/convex/lib/search/scoped_substring_search.ts
@@ -2,7 +2,12 @@ import type { PaginationOptions, PaginationResult } from 'convex/server';
 
 import type { Doc, TableNames } from '../../_generated/dataModel';
 import type { QueryCtx } from '../../_generated/server';
-import { isActiveRow, rowMatches, scoreAndSort } from './relevance';
+import {
+  isActiveRow,
+  type MatchMode,
+  rowMatches,
+  scoreAndSort,
+} from './relevance';
 import type { SearchStrategy } from './types';
 
 export const MAX_SEARCH_PAGE_SIZE = 100;
@@ -25,6 +30,10 @@ export interface EntitySearchArgs<T extends TableNames> {
   indexFilter?: (q: IndexRangeBuilder) => IndexRangeBuilder;
   /** Per-row visibility filter applied after the text match (e.g. team access). */
   accessFilter?: (row: Doc<T>) => boolean;
+  /** How `term` is matched. Defaults to `'all'` — the right rule when a person
+   *  typed the term. Pass `'any'` when `term` is a natural-language question
+   *  rather than a name fragment; see {@link MatchMode}. */
+  matchMode?: MatchMode;
 }
 
 /**
@@ -43,6 +52,7 @@ export async function scopedSubstringSearch<T extends TableNames>(
 ): Promise<PaginationResult<Doc<T>>> {
   const rawTerm = args.term.trim();
   const lowerTerm = rawTerm.toLowerCase();
+  const matchMode = args.matchMode ?? 'all';
   const numItems = Math.min(
     Math.max(args.paginationOpts.numItems, 1),
     MAX_SEARCH_PAGE_SIZE,
@@ -68,11 +78,11 @@ export async function scopedSubstringSearch<T extends TableNames>(
     const record = row as Record<string, unknown>;
     if (strategy.activeOnly && !isActiveRow(record)) return false;
     if (args.accessFilter && !args.accessFilter(row)) return false;
-    return rowMatches(row, strategy, lowerTerm, rawTerm);
+    return rowMatches(row, strategy, lowerTerm, rawTerm, matchMode);
   });
 
   return {
     ...result,
-    page: scoreAndSort(page, strategy, lowerTerm),
+    page: scoreAndSort(page, strategy, lowerTerm, matchMode),
   };
 }

--- a/services/platform/convex/lib/search/strategies/projects.ts
+++ b/services/platform/convex/lib/search/strategies/projects.ts
@@ -1,0 +1,21 @@
+import type { SearchStrategy } from '../types';
+
+/** Projects are searched by name + description (substring) and `key` — the
+ *  immutable short prefix (`TAL`) people actually say out loud and that every
+ *  task identifier carries, so `key` is matched as an id rather than as prose.
+ *
+ *  NOT `activeOnly`: `projects` carries no `lifecycleStatus`; archived projects
+ *  are excluded by the caller's `accessFilter` on `archivedAt`, alongside the
+ *  per-row `hasProjectAccess` check that team sharing requires.
+ *
+ *  Swap `engine` to `'searchIndex'` (+ `searchIndexName: 'search_projects'`,
+ *  `searchIndexField: 'name'`) once the bootstrap is fixed — that index existed
+ *  and was dropped in v0.2.75; see `TODO(search-index-disabled)` in
+ *  `projects/queries.ts`. */
+export const projectsSearchStrategy: SearchStrategy<'projects'> = {
+  table: 'projects',
+  orgIndex: 'by_organization',
+  textFields: ['name', 'description'],
+  idFields: ['key'],
+  engine: 'scan',
+};

--- a/services/platform/convex/lib/search/strategies/tasks.ts
+++ b/services/platform/convex/lib/search/strategies/tasks.ts
@@ -1,0 +1,26 @@
+import type { SearchStrategy } from '../types';
+
+/** Tasks are searched by title + description (substring) and `externalId`
+ *  (exact / substring), so a task synced from an issue tracker is reachable by
+ *  its foreign key as well as its words. `labelIds` holds `taskLabels` ids
+ *  rather than text, so there is nothing to put in `arrayTextFields`.
+ *
+ *  NOT `activeOnly`: `tasks` carries no `lifecycleStatus`, so the flag would be
+ *  a silent no-op (`isActiveRow` treats a missing field as active). Archived
+ *  tasks are excluded by the caller's `accessFilter` on `archivedAt` — which is
+ *  also where project-visibility narrowing belongs, since a task inherits its
+ *  project's ACL and has none of its own.
+ *
+ *  Swap `engine` to `'searchIndex'` (+ `searchIndexName: 'search_tasks'`,
+ *  `searchIndexField: 'title'`) once the bootstrap is fixed — see
+ *  `TODO(search-index-disabled)`. */
+export const tasksSearchStrategy: SearchStrategy<'tasks'> = {
+  table: 'tasks',
+  // NOT `by_organizationId` — the tasks table names it `by_organization`, and
+  // `scopedSubstringSearch` @ts-expect-errors its `withIndex` call, so a wrong
+  // name here fails at runtime with no type error to catch it.
+  orgIndex: 'by_organization',
+  textFields: ['title', 'description'],
+  idFields: ['externalId'],
+  engine: 'scan',
+};


### PR DESCRIPTION
## Why

Entity search has exactly one matching rule (`convex/lib/search/relevance.ts`): every whitespace-delimited token must hit some configured field. That is the right rule when a person **typed** the term into a picker or a mention autocomplete. It is the wrong rule when the term is a **question**, because most of a question's words are absent from the data by construction.

Concretely — a real query that came back empty:

> recruitment ads Facebook ad account project tasks

cannot match a task titled *"Set up Facebook ad account"*. `recruitment` alone sinks it, and so do `project` and `tasks`.

This is groundwork: it unblocks giving the chat assistant reach into tasks, projects and conversations, where the search term is always a question rather than a typed name.

## What changed

**An opt-in `matchMode` on the scan engine.** `'all'` (the default, unchanged) requires every token. `'any'`:

- drops function words across the three locales the app ships (en, de, fr) — an English-only list would leave German and French questions full of tokens that match every row;
- keeps a row when a surviving token hits at **word-start or better**, so a bare mid-word substring (`ad` inside `overhead`) is not enough on its own once tokens are OR-ed;
- leaves the existing relevance scoring to order results, so the row that answered the most of the question comes first;
- matches **nothing** when the query is nothing but function words, rather than everything — that lets a caller report "too general" instead of returning the whole org.

Matching and ranking now read the same `queryTokens`, so a row can never be kept by one rule and ordered by another.

The stopword list deliberately carries **no domain vocabulary** — `open`, `done` and `review` are board statuses, and dropping them would make the most common question about a board unanswerable.

**Two new strategies**, `tasks` and `projects`, following the shape and doc-comment convention of `strategies/contacts.ts`. Both note the index-name trap: `tasks`/`projects` name their org index `by_organization`, not `by_organizationId`, and `scopedSubstringSearch` `@ts-expect-error`s its `withIndex` call — so a wrong name fails at runtime with no type error.

**One duplicate collapsed.** `contacts/list_contacts_paginated.ts` had grown its own byte-identical copy of `contactsSearchStrategy` while importing `runEntitySearch` from the shared barrel. It now imports the shared one.

## Verification

`bun run check` clean. 424 tests pass across `convex/lib/search`, `convex/contacts`, `convex/documents`; typecheck, oxlint and oxfmt clean; SAST 0 findings.

Every new assertion was mutation-tested — seen red before being accepted:

| Mutation | Tests that caught it |
| --- | --- |
| `'any'` matches with AND instead of OR | 2 |
| stopword filtering removed | 5 |
| `MIN_ANY_TIER` lowered to accept mid-word substrings | 1 |
| ranking reads raw tokens instead of filtered ones | 1 |

Two tests initially passed under the stopword mutation for the wrong reason — their fixtures did not actually contain the function words being filtered. Both were rewritten against fixtures that do, and now fail as intended.

The reported query is pinned as a regression test asserting both halves: it must **not** match under `'all'`, and must match under `'any'`.

## Note

`tasksSearchStrategy` and `projectsSearchStrategy` have no runtime caller yet — they are exercised by tests here and consumed by the follow-up that adds the chat legs.