### PR TITLE
feat(platform): let agent read tools name tasks, projects and conversations

### DIFF
--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -51,6 +51,7 @@ import {
 import { searchKnowledge } from '../knowledge/search';
 import { orgSlugFromId } from '../lib/helpers/org_slug';
 import { SafeFetchError, isPrivateIp, safeFetch } from '../lib/http/safe_fetch';
+import type { AgentReadSubject } from '../lib/rls/helpers/agent_read_access';
 import { wrapUntrusted } from '../lib/untrusted_content';
 
 /** Who the tools run for. The user is re-checked per dispatch. */
@@ -147,10 +148,10 @@ export function createChatToolExecutor(
   };
 
   /** Role-matrix read check for one subject; a denial is a result, not a
-   * throw, so one denied leg never hides the others. */
-  const readAllowed = async (
-    subject: 'documents' | 'contacts' | 'products' | 'websites',
-  ): Promise<boolean> => {
+   * throw, so one denied leg never hides the others. Typed off the shared
+   * {@link AgentReadSubject} rather than a second copy of the literal list,
+   * so a subject added to the matrix cannot go missing here. */
+  const readAllowed = async (subject: AgentReadSubject): Promise<boolean> => {
     const access = await ctx.runQuery(
       internal.sandbox.workspace_access.resolveWorkspaceReadAccess,
       { organizationId: who.organizationId, userId: who.userId, subject },

--- a/services/platform/convex/lib/rls/helpers/access_control.ts
+++ b/services/platform/convex/lib/rls/helpers/access_control.ts
@@ -9,6 +9,12 @@ type PlatformTable =
   | 'documents'
   | 'products'
   | 'projects'
+  // A task has no ACL of its own — `tasks/access.ts` delegates every check to
+  // its parent project. Its grants therefore MIRROR `projects` on every row
+  // below; a task must never be reachable at a role that could not open the
+  // project holding it. The entry exists because `authorizeRls` denies by
+  // default, so an agent read subject without one is refused outright.
+  | 'tasks'
   | 'contacts'
   | 'connectorCredentials'
   | 'connectors'
@@ -59,6 +65,7 @@ const platformPermissions: Record<
     documents: ALL,
     products: ALL,
     projects: ALL,
+    tasks: ALL,
     contacts: ALL,
     connectorCredentials: ALL,
     connectors: ALL,
@@ -86,6 +93,7 @@ const platformPermissions: Record<
     documents: ALL,
     products: ALL,
     projects: ALL,
+    tasks: ALL,
     contacts: ALL,
     connectorCredentials: ALL,
     connectors: ALL,
@@ -111,6 +119,7 @@ const platformPermissions: Record<
     documents: ALL,
     products: ALL,
     projects: ALL,
+    tasks: ALL,
     contacts: ALL,
     connectorCredentials: READ_ONLY,
     connectors: READ_ONLY,
@@ -136,6 +145,7 @@ const platformPermissions: Record<
     documents: READ_ONLY,
     products: READ_ONLY,
     projects: READ_ONLY,
+    tasks: READ_ONLY,
     contacts: READ_ONLY,
     connectorCredentials: READ_ONLY,
     connectors: READ_ONLY,
@@ -165,6 +175,7 @@ const platformPermissions: Record<
     documents: NONE,
     products: NONE,
     projects: NONE,
+    tasks: NONE,
     contacts: NONE,
     connectorCredentials: NONE,
     connectors: NONE,

--- a/services/platform/convex/lib/rls/helpers/agent_read_access.ts
+++ b/services/platform/convex/lib/rls/helpers/agent_read_access.ts
@@ -17,12 +17,31 @@ import type { QueryCtx } from '../../../_generated/server';
 import { getUserOrganizations } from '../organization/get_user_organizations';
 import { authorizeRls } from './access_control';
 
-/** The tables the workspace read tools expose, as role-matrix subjects. */
-export type AgentReadSubject =
-  | 'documents'
-  | 'contacts'
-  | 'products'
-  | 'websites';
+/**
+ * The tables the workspace read tools expose, as role-matrix subjects.
+ *
+ * Every member of this union MUST have a row in `platformPermissions` —
+ * {@link authorizeRls} denies by default, so a subject without one is refused
+ * outright rather than falling through to a laxer rule.
+ *
+ * A `true` here means only that the caller's ROLE may read the table. Some
+ * subjects need a second, narrower gate that this module deliberately does not
+ * own: `documents` and `tasks` narrow to the caller's team/project visibility,
+ * and `conversations` narrows further still to its assignment scope (a
+ * conversation assigned to nobody is admin triage only). Treating `allowed:
+ * true` as "read the whole org" is a leak for those three.
+ */
+export const AGENT_READ_SUBJECTS = [
+  'documents',
+  'contacts',
+  'products',
+  'websites',
+  'tasks',
+  'projects',
+  'conversations',
+] as const;
+
+export type AgentReadSubject = (typeof AGENT_READ_SUBJECTS)[number];
 
 export type AgentReadAccess =
   | { allowed: true; role: string }

--- a/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
@@ -55,13 +55,13 @@ import {
 } from '../../knowledge/fetch';
 import { searchKnowledge } from '../../knowledge/search';
 import { orgSlugFromId } from '../../lib/helpers/org_slug';
-import type { AgentReadSubject } from '../../lib/rls/helpers/agent_read_access';
 import { wrapUntrusted } from '../../lib/untrusted_content';
 import {
   ASK_HUMAN_TOOL,
   KNOWLEDGE_REFS_PER_CALL_CAP,
   WRITE_EFFECT_TOOLS,
 } from '../../sandbox/tool_names';
+import type { SessionActionSubject } from '../../sandbox/workspace_access';
 import {
   isWorkspaceTaskTool,
   runDocumentCreate,
@@ -110,7 +110,7 @@ const WRITE_TOOL_SET: ReadonlySet<string> = new Set(WRITE_EFFECT_TOOLS);
  * `documents`: passages ARE document content and entries are document-backed,
  * so one subject governs the whole knowledge read path.
  */
-const TOOL_READ_SUBJECT: Record<WorkspaceReadTool, AgentReadSubject> = {
+const TOOL_READ_SUBJECT: Record<WorkspaceReadTool, SessionActionSubject> = {
   rag_search: 'documents',
   // A URL ref reads the crawled-pages corpus; the dispatch narrows the
   // subject to 'websites' per call — this entry is the file-id default.

--- a/services/platform/convex/sandbox/workspace_access.test.ts
+++ b/services/platform/convex/sandbox/workspace_access.test.ts
@@ -14,11 +14,15 @@ import {
   automationProjectBindingsTable,
   automationRunsTable,
 } from '../automations/schema';
-import { resolveAgentReadAccess } from '../lib/rls/helpers/agent_read_access';
+import {
+  AGENT_READ_SUBJECTS,
+  resolveAgentReadAccess,
+} from '../lib/rls/helpers/agent_read_access';
 import { memberMirrorTable, teamMemberMirrorTable } from '../members/schema';
 import { buildModules } from '../migrations/framework/test_helpers';
 import { projectAgentsTable, projectsTable } from '../projects/schema';
 import { sandboxSessionsTable } from './sessions_schema';
+import { agentReadSubjectValidator } from './workspace_access';
 
 const schema = defineSchema({
   memberMirror: memberMirrorTable,
@@ -56,12 +60,10 @@ describe('resolveAgentReadAccess', () => {
   it('an active member reads every workspace subject', async () => {
     const t = newTest();
     await seedMember(t, { userId: 'u1', organizationId: ORG, role: 'member' });
-    for (const subject of [
-      'documents',
-      'contacts',
-      'products',
-      'websites',
-    ] as const) {
+    // Driven off the exported list, not a copy of it: a subject added to the
+    // union without a `platformPermissions` row would be denied by default,
+    // and this loop is what catches that.
+    for (const subject of AGENT_READ_SUBJECTS) {
       const access = await t.run((ctx) =>
         resolveAgentReadAccess(ctx, {
           userId: 'u1',
@@ -71,6 +73,16 @@ describe('resolveAgentReadAccess', () => {
       );
       expect(access).toEqual({ allowed: true, role: 'member' });
     }
+  });
+
+  it('the wire validator lists exactly the subjects the resolver knows', () => {
+    // Convex needs literal validators, so the union is spelled by hand. A
+    // subject in one list and not the other is an argument-validation error at
+    // dispatch — invisible to the type checker, so it is pinned here.
+    const wireSubjects = agentReadSubjectValidator.members.map(
+      (member) => member.value,
+    );
+    expect([...wireSubjects].sort()).toEqual([...AGENT_READ_SUBJECTS].sort());
   });
 
   it('owner normalizes like the RLS path (admin matrix row)', async () => {

--- a/services/platform/convex/sandbox/workspace_access.ts
+++ b/services/platform/convex/sandbox/workspace_access.ts
@@ -23,16 +23,56 @@ import {
 } from '../lib/rls/helpers/agent_read_access';
 import { getProjectTeamIds } from '../projects/access';
 
+/**
+ * The wire spelling of {@link AgentReadSubject}. Convex needs literal
+ * validators, so this list cannot be generated from the const array — a test
+ * asserts the two agree instead, because a subject present in one and missing
+ * from the other is an argument-validation error at dispatch, not a type error
+ * at build.
+ */
+export const agentReadSubjectValidator = v.union(
+  v.literal('documents'),
+  v.literal('contacts'),
+  v.literal('products'),
+  v.literal('websites'),
+  v.literal('tasks'),
+  v.literal('projects'),
+  v.literal('conversations'),
+);
+
+/**
+ * The subjects the SESSION-BINDING gate arbitrates — a strict subset of
+ * {@link AgentReadSubject}, and a different question.
+ *
+ * `resolveWorkspaceReadAccess` asks "may this role read this table"; this asks
+ * "may this run act on this subject, given the project its automation is bound
+ * to". `projects` and `conversations` are absent because nothing dispatches a
+ * session-bound action on them, and `tasks` is present here yet answered by
+ * binding rather than by the role matrix.
+ */
+export const SESSION_ACTION_SUBJECTS = [
+  'tasks',
+  'documents',
+  'contacts',
+  'products',
+  'websites',
+] as const;
+
+export type SessionActionSubject = (typeof SESSION_ACTION_SUBJECTS)[number];
+
+const sessionActionSubjectValidator = v.union(
+  v.literal('tasks'),
+  v.literal('documents'),
+  v.literal('contacts'),
+  v.literal('products'),
+  v.literal('websites'),
+);
+
 export const resolveWorkspaceReadAccess = internalQuery({
   args: {
     organizationId: v.string(),
     userId: v.string(),
-    subject: v.union(
-      v.literal('documents'),
-      v.literal('contacts'),
-      v.literal('products'),
-      v.literal('websites'),
-    ),
+    subject: agentReadSubjectValidator,
   },
   returns: v.union(
     v.object({ allowed: v.literal(true), role: v.string() }),
@@ -255,13 +295,7 @@ export const resolveSessionActionContext = internalQuery({
     organizationId: v.string(),
     sessionId: v.string(),
     userId: v.optional(v.string()),
-    subject: v.union(
-      v.literal('tasks'),
-      v.literal('documents'),
-      v.literal('contacts'),
-      v.literal('products'),
-      v.literal('websites'),
-    ),
+    subject: sessionActionSubjectValidator,
     effect: v.union(v.literal('read'), v.literal('write')),
   },
   returns: v.union(


### PR DESCRIPTION
## Why

The workspace read gate (`resolveWorkspaceReadAccess`) knows exactly four subjects: `documents`, `contacts`, `products`, `websites`. Tasks, projects and conversations cannot be *named* to it, so a read tool over any of them cannot be authorized at all — and `tasks` has no row in `platformPermissions` either, so `authorizeRls` would deny it by default even if it could be named.

Groundwork for giving the chat assistant reach into the organization's work. No behaviour changes here: nothing calls the new subjects yet.

## What changed

**Three subjects added**, and a `platformPermissions` row for `tasks` that mirrors `projects` on every role. A task has no ACL of its own — `tasks/access.ts` delegates every check to its parent project — so it must never be reachable at a role that could not open the project holding it. `projects`, `conversations` and `conversationMessages` already had rows.

**Two lists that could silently disagree are now pinned.**

- `AGENT_READ_SUBJECTS` is a runtime array and `AgentReadSubject` derives from it, so the existing *"an active member reads every workspace subject"* test iterates the real list rather than its own copy of it.
- Convex needs literal validators, so the wire union is still spelled by hand. A new test asserts it matches the array — a subject present in one and missing from the other is an argument-validation error at dispatch, invisible to the type checker.

**`SessionActionSubject` is now its own name.** `resolveSessionActionContext` answers a different question — *may this run act here, given its automation's project binding* — over a strict subset that excludes `projects` and `conversations`. It had been borrowing the read-gate's type, which is what surfaced the problem: typecheck failed at `workspace_tools_bridge.ts:499` because `TOOL_READ_SUBJECT` was declared as the wider union while every value it holds is a session-action subject. Naming the narrower set fixes the call site and documents the distinction.

## A note on what this does *not* grant

Widening the role gate does not by itself make these surfaces readable, and `allowed: true` must not be read as "the whole org":

- `documents` and `tasks` narrow further to the caller's team and project visibility;
- `conversations` narrows further still to its **assignment scope** — `passesAssignmentScope` in `rls_rules.ts` makes a conversation assigned to nobody admin-triage-only, and otherwise requires the caller to be the assignee or in the assigned team. The role matrix grants `conversations: READ_ONLY` to every member, so the role check is necessary but **not sufficient** for that subject.

The `AgentReadSubject` doc comment records this so the next caller does not have to rediscover it. `agent_read_access.ts` still owns no rules of its own, per its module contract.

## Verification

`bun run check` clean — 438 tests pass across `convex/sandbox`, `convex/lib/rls`, `convex/node_only/sandbox` and the chat tool suite; typecheck, oxlint, oxfmt clean; SAST 0 findings.

Both new guards were mutation-tested — seen red before being accepted:

| Mutation | Result |
| --- | --- |
| drop `tasks: READ_ONLY` from the member row | *an active member reads every workspace subject* fails |
| drop `v.literal('projects')` from the wire validator | *the wire validator lists exactly the subjects the resolver knows* fails |