### PR TITLE
fix(platform): stop email attachments starving the RAG indexing cap

### DIFF
--- a/services/platform/convex/conversations/ingest/materialize_email_attachments.test.ts
+++ b/services/platform/convex/conversations/ingest/materialize_email_attachments.test.ts
@@ -78,6 +78,58 @@ describe('materializeEmailAttachments', () => {
     ).toBeUndefined();
   });
 
+  // Regression: this path stored attachments with the *defer* flag, whose
+  // contract is "I will dispatch the indexing job myself" — a promise nothing
+  // downstream of here keeps. Each row was left at `ragStatus: 'queued'` and
+  // unparked, which `countRagInFlight` charges against
+  // MAX_CONCURRENT_RAG_INDEXING_PER_ORG (3), so three inbound attachments
+  // permanently saturated an org's indexing budget and every document a person
+  // uploaded parked instead — invisibly, since a parked row still reads
+  // "Queued", which is one of the few statuses RagStatusBadge gives no retry
+  // affordance, and the watchdog skips parked rows by design.
+  it('stores attachments without claiming a RAG indexing slot', async () => {
+    const saved: Array<Record<string, unknown>> = [];
+    const ctx = {
+      runAction: vi.fn(async () => 'storage-att-1'),
+      runMutation: vi.fn(
+        async (_ref: unknown, args: Record<string, unknown>) => {
+          saved.push(args);
+          return null;
+        },
+      ),
+      storage: { getUrl: vi.fn() },
+    };
+
+    await materializeEmailAttachments(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+      ctx as never,
+      {
+        organizationId: 'org_1',
+        source: 'imap-smtp',
+        emails: [
+          {
+            messageId: '<cv@x>',
+            attachments: [
+              {
+                id: 'cv',
+                // An indexable format, so nothing but the explicit skip keeps
+                // this row out of the queue.
+                filename: 'CV.pdf',
+                contentType: 'application/pdf',
+                size: 3,
+                contentBase64: Buffer.from('pdf').toString('base64'),
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({ skipRagIndexing: true });
+    expect(saved[0]).not.toHaveProperty('deferRagDispatch');
+  });
+
   it('passes through emails with no wire bytes', async () => {
     const ctx = {
       runAction: vi.fn(),

--- a/services/platform/convex/conversations/ingest/materialize_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/materialize_email_attachments.ts
@@ -100,7 +100,12 @@ async function storeAttachment(
       contentType: att.contentType,
       size: bytes.byteLength,
       source,
-      scheduleRag: false,
+      // Stored so the Inbox can show and download the attachment — NOT to
+      // enter the knowledge corpus. This must be `skipRagIndexing`, never
+      // `deferRagDispatch`: nothing downstream of this path ever dispatches an
+      // indexing job, and a `'queued'`-but-undispatched row counts against the
+      // org's RAG concurrency cap forever, which starves every real upload.
+      skipRagIndexing: true,
     },
   );
 

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -231,6 +231,110 @@ describe('saveFileMetadata (internal)', () => {
     );
   });
 
+  // The three indexing modes, and the invariant tying them together: a row is
+  // only ever left at `'queued'` when its indexing action is dispatched here or
+  // by a caller that promised to. `countRagInFlight` charges every unparked
+  // `'queued'` row a slot against the per-org cap on trust, so "queued but
+  // nobody dispatched" starves the cap permanently — three such rows and
+  // nothing indexes for that org again. That is exactly what email attachments
+  // did: they wanted "don't index" and reached for the defer flag.
+  describe('RAG indexing modes', () => {
+    it('by default queues and dispatches immediately', async () => {
+      const { ctx } = createMockCtx(null);
+      const handler = await getSaveHandler();
+      const { maybeDispatchRagIndexing } = await import('./rag_dispatch');
+
+      await handler(ctx, baseArgs);
+
+      expect(ctx.db.insert).toHaveBeenCalledWith(
+        'fileMetadata',
+        expect.objectContaining({ ragStatus: 'queued' }),
+      );
+      expect(maybeDispatchRagIndexing).toHaveBeenCalledWith(ctx, 'storage_1');
+    });
+
+    it('queues without dispatching when the caller defers (Hub link-then-index)', async () => {
+      const { ctx } = createMockCtx(null);
+      const handler = await getSaveHandler();
+      const { maybeDispatchRagIndexing } = await import('./rag_dispatch');
+
+      await handler(ctx, { ...baseArgs, deferRagDispatch: true });
+
+      // Queued is correct here ONLY because the caller
+      // (scheduleHubDocumentRagIndexing) dispatches straight after linking.
+      expect(ctx.db.insert).toHaveBeenCalledWith(
+        'fileMetadata',
+        expect.objectContaining({ ragStatus: 'queued' }),
+      );
+      expect(maybeDispatchRagIndexing).not.toHaveBeenCalled();
+    });
+
+    it('leaves an indexable file unqueued and undispatched when indexing is skipped', async () => {
+      const { ctx } = createMockCtx(null);
+      const handler = await getSaveHandler();
+      const { maybeDispatchRagIndexing } = await import('./rag_dispatch');
+
+      await handler(ctx, { ...baseArgs, skipRagIndexing: true });
+
+      // `undefined`, NOT `'queued'` (would burn a cap slot forever) and NOT
+      // `'unsupported'` (a .pdf is indexable — it just isn't being indexed,
+      // and `unsupported` is terminal and refuses retry).
+      expect(ctx.db.insert).toHaveBeenCalledWith(
+        'fileMetadata',
+        expect.objectContaining({
+          ragStatus: undefined,
+          ragQueuedAt: undefined,
+        }),
+      );
+      expect(maybeDispatchRagIndexing).not.toHaveBeenCalled();
+    });
+
+    it('does not queue a skipped file on the patch path either', async () => {
+      const { ctx } = createMockCtx({
+        _id: 'fm_existing',
+        organizationId: 'org_1',
+        storageId: 'storage_1',
+        fileName: 'test.pdf',
+        contentType: 'application/pdf',
+        size: 1024,
+      });
+      const handler = await getSaveHandler();
+      const { maybeDispatchRagIndexing } = await import('./rag_dispatch');
+
+      await handler(ctx, { ...baseArgs, skipRagIndexing: true });
+
+      const patch = (
+        ctx.db.patch as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls[0][1] as Record<string, unknown>;
+      expect(patch).not.toHaveProperty('ragStatus');
+      expect(maybeDispatchRagIndexing).not.toHaveBeenCalled();
+    });
+
+    it('still indexes a previously skipped blob when it is saved again for indexing', async () => {
+      // Skip is not terminal: `needsRagRetry` accepts an `undefined` status, so
+      // the same bytes attached to a Hub document later still index.
+      const { ctx } = createMockCtx({
+        _id: 'fm_existing',
+        organizationId: 'org_1',
+        storageId: 'storage_1',
+        fileName: 'test.pdf',
+        contentType: 'application/pdf',
+        size: 1024,
+        ragStatus: undefined,
+      });
+      const handler = await getSaveHandler();
+      const { maybeDispatchRagIndexing } = await import('./rag_dispatch');
+
+      await handler(ctx, baseArgs);
+
+      expect(ctx.db.patch).toHaveBeenCalledWith(
+        'fm_existing',
+        expect.objectContaining({ ragStatus: 'queued' }),
+      );
+      expect(maybeDispatchRagIndexing).toHaveBeenCalledWith(ctx, 'storage_1');
+    });
+  });
+
   it('queries by storageId index', async () => {
     const { ctx, builder } = createMockCtx(null);
     const handler = await getSaveHandler();

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -38,12 +38,34 @@ export const saveFileMetadata = internalMutation({
      * thread id so the soft-delete cascade + RAG thread-scope auth chain
      * work. Document Hub uploads omit this. */
     threadId: v.optional(v.string()),
-    /** When false, only marks the row queued — caller schedules
-     *  uploadDocumentToRag after the Hub document is linked. */
-    scheduleRag: v.optional(v.boolean()),
+    /**
+     * Mark the row queued but do NOT dispatch — the caller schedules
+     * `uploadDocumentToRag` itself, once the Hub document is linked, so the
+     * job can read the document's folder/scope (see
+     * `documents/schedule_hub_document_rag_indexing.ts`).
+     *
+     * Setting this is a PROMISE to dispatch. A `'queued'` row that is not
+     * parked counts as in-flight against the per-org cap
+     * (`rag_dispatch.ts:countRagInFlight`, and the `ragParked` contract in
+     * `schema.ts`), so a caller that never follows through burns an indexing
+     * slot forever and eventually starves every real upload — three of them
+     * saturate `MAX_CONCURRENT_RAG_INDEXING_PER_ORG`. Use
+     * `skipRagIndexing` when the intent is "never index this", NOT this flag.
+     */
+    deferRagDispatch: v.optional(v.boolean()),
+    /**
+     * Never index this file. Mirrors `skipRagIndexing` on the public
+     * `mutations.saveFileMetadata`: the row keeps `ragStatus: undefined`
+     * ("Not indexed"), nothing is scheduled, and no cap slot is consumed.
+     * Email attachments use this — they are stored so the Inbox can show and
+     * download them, not to enter the knowledge corpus. Still upgradable: a
+     * later save of the same blob with indexing on re-queues it, because
+     * `needsRagRetry` accepts an `undefined` status.
+     */
+    skipRagIndexing: v.optional(v.boolean()),
   },
   async handler(ctx, args) {
-    const scheduleRag = args.scheduleRag ?? true;
+    const deferRagDispatch = args.deferRagDispatch ?? false;
     const existing = await ctx.db
       .query('fileMetadata')
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
@@ -60,12 +82,21 @@ export const saveFileMetadata = internalMutation({
       args.fileName,
       args.contentType,
     );
+    // `skipRagIndexing` folds in here — the same shape the public
+    // `mutations.saveFileMetadata` uses — so a skipped file takes every
+    // "not indexing this" branch below without a second code path.
     const shouldIndex =
-      !isAudio && isRagIndexableFile(args.fileName, resolvedContentType);
+      !args.skipRagIndexing &&
+      !isAudio &&
+      isRagIndexableFile(args.fileName, resolvedContentType);
     // No extractor exists for this format and it isn't routed through the
     // audio/video transcription pipeline either — this file will NEVER
     // index. Distinct from `shouldIndex === false && isAudio`, which is
     // deliberately left `undefined` (indexed later via the transcript).
+    // Deliberately derived from the format alone, NOT from `shouldIndex`: a
+    // caller-skipped file is indexable, just not being indexed, so it must
+    // stay at `undefined` ("Not indexed") rather than claim the terminal,
+    // retry-refusing `'unsupported'`.
     const isUnsupported =
       !isAudio && !isRagIndexableFile(args.fileName, resolvedContentType);
 
@@ -88,7 +119,7 @@ export const saveFileMetadata = internalMutation({
       if (args.threadId !== undefined) patchData.threadId = args.threadId;
 
       const needsRagRetry =
-        scheduleRag &&
+        !deferRagDispatch &&
         shouldIndex &&
         (existing.ragStatus === undefined || existing.ragStatus === 'failed');
       const needsTranscribeRetry =
@@ -102,7 +133,7 @@ export const saveFileMetadata = internalMutation({
         patchData.ragErrorCode = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = now;
-      } else if (shouldIndex && !scheduleRag) {
+      } else if (shouldIndex && deferRagDispatch) {
         patchData.ragStatus = 'queued';
         patchData.ragError = undefined;
         patchData.ragErrorCode = undefined;
@@ -168,7 +199,7 @@ export const saveFileMetadata = internalMutation({
       ...(args.threadId !== undefined && { threadId: args.threadId }),
     });
 
-    if (shouldIndex && scheduleRag) {
+    if (shouldIndex && !deferRagDispatch) {
       await maybeDispatchRagIndexing(ctx, args.storageId);
     }
 

--- a/services/platform/convex/file_metadata/rag_dispatch.test.ts
+++ b/services/platform/convex/file_metadata/rag_dispatch.test.ts
@@ -196,6 +196,37 @@ describe('maybeDispatchRagIndexing — per-org concurrency cap', () => {
     expect(scheduled).toHaveLength(0);
     expect(store.find((r) => r._id === 'c')?.ragParked).toBe(true);
   });
+
+  it('charges an unparked queued row against the cap even with nothing scheduled', async () => {
+    // The cost model behind the `ragParked` contract in schema.ts: the counter
+    // cannot see whether a row's action was ever dispatched, so an unparked
+    // `'queued'` row is charged a slot on trust. Three of them saturate a
+    // whole org — which is exactly how email attachments stored with
+    // `deferRagDispatch` (a promise to dispatch that nothing kept) starved
+    // every real upload. A writer that marks a row queued without dispatching
+    // is therefore not merely untidy; it is indistinguishable from live work.
+    const rows = [row('e1'), row('e2'), row('e3'), row('upload')];
+    const { ctx, scheduled, store } = makeCtx(rows);
+    await maybeDispatchRagIndexing(ctx, 'upload' as never);
+    expect(scheduled).toHaveLength(0);
+    expect(store.find((r) => r._id === 'upload')?.ragParked).toBe(true);
+  });
+
+  it('leaves a slot free for a row stored with indexing skipped', async () => {
+    // The fixed email-attachment shape: `skipRagIndexing` leaves `ragStatus`
+    // unset, so the row is in neither status bucket and costs nothing. Three
+    // of them plus a real upload still dispatches.
+    const rows = [
+      row('e1', { ragStatus: undefined }),
+      row('e2', { ragStatus: undefined }),
+      row('e3', { ragStatus: undefined }),
+      row('upload'),
+    ];
+    const { ctx, scheduled, store } = makeCtx(rows);
+    await maybeDispatchRagIndexing(ctx, 'upload' as never);
+    expect(scheduled).toHaveLength(1);
+    expect(store.find((r) => r._id === 'upload')?.ragParked).toBeUndefined();
+  });
 });
 
 describe('promoteQueuedRagJobs', () => {

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -66,6 +66,13 @@ export const fileMetadataTable = defineTable({
   // A `'queued'` row WITHOUT this flag is in flight (its action is scheduled
   // or running), which is also the safe reading for legacy rows and for the
   // Hub/retry paths that don't park — so only the cap ever sets it.
+  // That reading is load-bearing, not descriptive: `countRagInFlight` charges
+  // every unparked `'queued'` row against the org's cap, so a writer that
+  // marks a row queued without dispatching its action starves the cap
+  // permanently — three such rows and nothing indexes again. Never write
+  // `'queued'` unless the job is (or is about to be) dispatched; to store a
+  // file without indexing it, pass `skipRagIndexing` and leave `ragStatus`
+  // unset.
   ragParked: v.optional(v.boolean()),
   // Unix SECONDS when ragStatus most recently reached 'completed'. Canonical
   // replacement for the retired documents.ragInfo.indexedAt — stamped by

--- a/services/platform/convex/onedrive/import_files_deps.ts
+++ b/services/platform/convex/onedrive/import_files_deps.ts
@@ -65,7 +65,9 @@ export function createImportFilesDeps(
           size,
           documentId,
           // Index after link so uploadDocumentToRag sees folderPath + source.
-          scheduleRag: false,
+          // Honoured by `scheduleHubDocumentRagIndexing` below — the promise
+          // this flag makes.
+          deferRagDispatch: true,
           // Provenance is finalized by linkDocumentToFile from the document's
           // sourceProvider ('onedrive' / 'sharepoint').
           source: 'user',

--- a/services/platform/convex/onedrive/upload_and_create_document_deps.ts
+++ b/services/platform/convex/onedrive/upload_and_create_document_deps.ts
@@ -80,7 +80,9 @@ export function createUploadAndCreateDocDeps(
           contentType,
           size,
           documentId,
-          scheduleRag: false,
+          // Index after link so uploadDocumentToRag sees folderPath + source;
+          // `scheduleHubDocumentRagIndexing` below honours the promise.
+          deferRagDispatch: true,
           source: 'user',
         },
       );


### PR DESCRIPTION
Storing an inbound email attachment left its `fileMetadata` row at `ragStatus: 'queued'` with no indexing job ever dispatched. `countRagInFlight` charges every unparked `'queued'` row against `MAX_CONCURRENT_RAG_INDEXING_PER_ORG` (3), so **three attachments saturate an organization's indexing budget permanently**: every document a person uploads parks instead of indexing.

It fails invisibly. A parked row still reads "Queued", which is one of the statuses `RagStatusBadge` gives no retry affordance, and the watchdog skips parked rows by design. The watchdog does reclaim the phantom rows, but only after the 35-minute stale window, while a 5-minute mail poll refills them faster than they age out — so the cap never drops below its ceiling and `promoteQueuedRagJobs` never gets a slot to hand out.

Observed on a self-hosted deployment: nothing a person uploaded had indexed for a week, with no error surfaced anywhere.

## Cause

One flag carrying two meanings, under a name that reads as the wrong one.

`scheduleRag: false` means *"mark it queued, I will dispatch the job myself once the Hub document is linked"* — so the job can read the document's folder and scope. Both OneDrive paths keep that promise via `scheduleHubDocumentRagIndexing`. The email path never made it: it wanted "don't index this" and reached for the only flag that looked like it said so.

## Change

Split the flag in two so neither can be misread:

- **`deferRagDispatch`** — queue without dispatching; the caller must follow through. Its doc now names the obligation and what breaks without it.
- **`skipRagIndexing`** — never index; the row stays at `ragStatus: undefined` and costs no slot.

`skipRagIndexing` is not a new concept — the public `saveFileMetadata` already had this exact flag and folded it into `shouldIndex` the same way. The internal mutation now mirrors it instead of growing a second vocabulary for the same idea.

Email attachments are stored so the Inbox can show and download them, not to enter the corpus, so they skip indexing outright. A skipped file keeps `undefined` rather than the terminal `unsupported`: the format *is* indexable, it just isn't being indexed, so a later save of the same blob still queues it (`needsRagRetry` accepts an `undefined` status).

Also states the invariant in `fileMetadata`'s schema comment as load-bearing rather than descriptive: never write `'queued'` unless the job is dispatched, because the counter cannot tell the difference.

## Tests

No test covered `scheduleRag`, which is how the two readings drifted. Adds:

- the three indexing modes on `saveFileMetadata`, insert and patch paths, including that a skipped blob still indexes when saved again for indexing
- an email-path regression test asserting it claims no indexing slot
- the cost model the invariant rests on: an unparked `'queued'` row is charged a slot on trust, so a writer that queues without dispatching is indistinguishable from live work

Each new assertion was mutation-tested — reverting the fix, dropping the `shouldIndex` fold, dispatching through a defer, and both counter directions each turn the relevant tests red.

## Deploying

No data fix needed. Existing phantom rows are all past the stale window, so the watchdog fails them at 200 per 5-minute tick and each terminal transition promotes the parked uploads behind them.

## Scope

Refs #2986, #2987. This is the cause underneath both, but neither is closed by it.

#2987 is framed as background ingestion *sharing* the interactive budget. It wasn't sharing it — it was consuming it without doing work. Rows at `ragStatus: undefined` cost nothing, so the duplicate blobs in #2985 were storage waste and nothing more; this flag is what converted them into starvation. A legitimately dispatched background job would still share the cap, so #2987's question stands on its own.

#2986 (a parked job has no recovery path and no signal) is untouched — parked rows are still excluded from the watchdog and still offer no way to invoke a retry.

#2985 (attachments never bound to their conversation) is untouched — the Inbox still shows no file and duplicates still accumulate, just no longer as cap starvation.
