### PR TITLE
fix(platform): derive the document scope label from the access rules

### DIFF
--- a/services/platform/app/features/documents/components/documents-table.tsx
+++ b/services/platform/app/features/documents/components/documents-table.tsx
@@ -16,6 +16,7 @@ import { useTeamFilter } from '@/app/hooks/use-team-filter';
 import { api } from '@/convex/_generated/api';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
+import { scopeTeamIds } from '@/lib/knowledge/types';
 import type { DocumentItem, RagStatus } from '@/types/documents';
 
 import {
@@ -111,7 +112,11 @@ export function DocumentsTable({
       type: 'folder' as const,
       folderId: folder._id,
       lastModified: folder._creationTime,
-      teamIds: folder.teamTags ?? (folder.teamId ? [folder.teamId] : []),
+      // Through the shared helper rather than a second copy of its precedence
+      // — a folder carries the same two mutually exclusive scopes as a document
+      // (`folders/schema.ts`), and the scope column classifies both the same way.
+      teamIds: [...scopeTeamIds(folder)],
+      projectId: folder.projectId ?? null,
       syncConfigId: folder.syncConfigId,
       ...(folder.syncConfigId && {
         sourceProvider: 'onedrive',

--- a/services/platform/app/features/documents/hooks/use-documents-table-config.test.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.test.tsx
@@ -22,15 +22,19 @@ type CellRenderer = (ctx: {
   row: { original: Partial<DocumentItem> };
 }) => ReactNode;
 
-/** Render the `uploadedBy` column cell for a given document row. */
-function renderColumnCell(columnId: string, document: Partial<DocumentItem>) {
+/** Render one column's cell for a given document row. */
+function renderColumnCell(
+  columnId: string,
+  document: Partial<DocumentItem>,
+  teamMap: Map<string, string> = new Map(),
+) {
   const { result } = renderHook(
     () =>
       useDocumentsTableConfig({
         onDocumentClick: () => {},
         onFolderDeleted: () => {},
         isLoadingTeams: false,
-        teamMap: new Map(),
+        teamMap,
       }),
     { wrapper: Providers },
   );
@@ -110,5 +114,48 @@ describe('useDocumentsTableConfig — lastModified cell', () => {
     // `medium` + `ll LT` keeps the date compact; timezone stays in `title`.
     expect(screen.getByText(/2026/i).textContent).not.toMatch(/GMT/i);
     expect(screen.getByText(/2026/i)).toHaveAttribute('title');
+  });
+});
+
+describe('useDocumentsTableConfig — teams cell', () => {
+  const teamMap = new Map([
+    ['team_a', 'Compliance'],
+    ['team_b', 'Legal'],
+  ]);
+
+  function renderTeamsCell(
+    document: Partial<DocumentItem>,
+    teams: Map<string, string> = teamMap,
+  ) {
+    return renderColumnCell('teams', document, teams);
+  }
+
+  it('says organization-wide only when there is no team and no project', () => {
+    renderTeamsCell({});
+    expect(screen.getByText('Organization-wide')).toBeInTheDocument();
+  });
+
+  // #2989: a project-scoped document has zero teams by construction (the two
+  // stamps are mutually exclusive), so a cell keyed on `teamIds.length === 0`
+  // called every one of them organization-wide — the opposite of the truth, on
+  // the screen an operator uses to check whether material is restricted.
+  it('never says organization-wide for a project-scoped document', () => {
+    renderTeamsCell({ projectId: 'project_a', teamIds: [] });
+    expect(screen.queryByText('Organization-wide')).not.toBeInTheDocument();
+    expect(screen.getByText('Project-scoped')).toBeInTheDocument();
+  });
+
+  // The reachable sibling: a row written before multi-team support carries only
+  // the deprecated single `teamId`, which `hasTeamAccess` still enforces — but
+  // the cell read `teamTags` alone and so reported it as unrestricted.
+  it('never says organization-wide for a legacy single-team document', () => {
+    renderTeamsCell({ teamId: 'team_a' });
+    expect(screen.queryByText('Organization-wide')).not.toBeInTheDocument();
+    expect(screen.getByText('Compliance')).toBeInTheDocument();
+  });
+
+  it('names the teams of a multi-team document', () => {
+    renderTeamsCell({ teamIds: ['team_a', 'team_b'] });
+    expect(screen.getByText(/Compliance, Legal/)).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
@@ -12,6 +12,7 @@ import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
 import { ACTIONS_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import { useFormatNumber } from '@/app/hooks/use-format-number';
 import { useT } from '@/lib/i18n/client';
+import { documentScopeKind, scopeTeamIds } from '@/lib/knowledge/types';
 import { formatBytes } from '@/lib/utils/format/number';
 import type { DocumentItem } from '@/types/documents';
 
@@ -224,14 +225,27 @@ export function useDocumentsTableConfig({
         size: 160,
         meta: { skeleton: { type: 'badge' as const } },
         cell: ({ row }) => {
-          const teamIds = row.original.teamIds ?? [];
-          if (teamIds.length === 0) {
+          // Classified by the same predicate the access rules use, never by
+          // testing the stamps here: empty teams is ALSO true of a
+          // project-scoped row and of one carrying only the legacy `teamId`,
+          // and calling either "Organization-wide" states the opposite of the
+          // truth on the screen built to audit document access.
+          const scope = documentScopeKind(row.original);
+          if (scope === 'hub') {
             return (
               <Text as="span" variant="muted" className="text-sm">
                 {tDocuments('teamTags.orgWide')}
               </Text>
             );
           }
+          if (scope === 'project') {
+            return (
+              <Text as="span" className="text-sm">
+                {tDocuments('teamTags.projectScoped')}
+              </Text>
+            );
+          }
+          const teamIds = scopeTeamIds(row.original);
           if (isLoadingTeams) {
             return (
               <Skeletonize loading className="contents">
@@ -344,7 +358,13 @@ export function useDocumentsTableConfig({
               isDirectlySelected={row.original.isDirectlySelected}
               sourceMode={row.original.sourceMode}
               sourceProvider={row.original.sourceProvider}
-              teamIds={row.original.teamIds ?? []}
+              // Resolved, not raw: this seeds the team-tags dialog's selection,
+              // and an empty selection reads there as "Organization-wide". A
+              // row carrying only the legacy single stamp would open claiming
+              // to be unrestricted — the label defect again, on a control that
+              // writes. `documents-table.tsx` already resolves it this way for
+              // folders.
+              teamIds={[...scopeTeamIds(row.original)]}
               onFolderDeleted={onFolderDeleted}
               parentFolderTeamId={parentFolderTeamId}
               ragStatus={row.original.ragStatus}

--- a/services/platform/convex/documents/transform_to_document_item.ts
+++ b/services/platform/convex/documents/transform_to_document_item.ts
@@ -169,6 +169,7 @@ export function transformToDocumentItem(
     ocrApplied: document.ocrApplied,
     teamId: document.teamId ?? null,
     teamIds: document.teamTags ?? [],
+    projectId: document.projectId ?? null,
     // Creator tracking
     createdBy: document.createdBy,
     createdByName,

--- a/services/platform/convex/documents/validators.ts
+++ b/services/platform/convex/documents/validators.ts
@@ -89,6 +89,11 @@ export const documentItemValidator = v.object({
   ocrApplied: v.optional(v.boolean()),
   teamId: v.optional(v.union(v.string(), v.null())),
   teamIds: v.optional(v.array(v.string())),
+  /** Project scope, mutually exclusive with the team stamps. Carried so a UI
+   * showing scope can classify the row through `documentScopeKind` instead of
+   * inferring "organization-wide" from empty teams — which is also true of
+   * every project-scoped row. */
+  projectId: v.optional(v.union(v.string(), v.null())),
   createdBy: v.optional(v.string()),
   createdByName: v.optional(v.string()),
   record: v.optional(documentRecordInfoValidator),

--- a/services/platform/lib/knowledge/types.test.ts
+++ b/services/platform/lib/knowledge/types.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DocumentScopeStamp,
+  documentScopeKind,
+  type KnowledgeAccessScope,
+  knowledgeScopeAllows,
+  scopeTeamIds,
+} from './types';
+
+/** A caller with no teams and no projects, who may read hub rows. */
+const hubOnly: KnowledgeAccessScope = {
+  teamIds: [],
+  projectIds: [],
+  includeHub: true,
+};
+
+describe('scopeTeamIds', () => {
+  it('prefers the full list over the deprecated single stamp', () => {
+    expect(
+      scopeTeamIds({ teamId: 'team_a', teamIds: ['team_b', 'team_c'] }),
+    ).toEqual(['team_b', 'team_c']);
+  });
+
+  it('reads a row carrying only the legacy stamp as a one-team list', () => {
+    expect(scopeTeamIds({ teamId: 'team_a' })).toEqual(['team_a']);
+  });
+
+  it('is empty for a row with neither', () => {
+    expect(scopeTeamIds({})).toEqual([]);
+  });
+
+  it('treats an explicitly empty list as empty, not as a legacy fallback', () => {
+    // `teamTags: []` is a real state (teams cleared) and must not resurrect a
+    // stale single stamp.
+    expect(scopeTeamIds({ teamId: 'team_a', teamIds: [] })).toEqual([]);
+  });
+});
+
+describe('documentScopeKind', () => {
+  it('classifies a row with no teams and no project as hub', () => {
+    expect(documentScopeKind({})).toBe('hub');
+  });
+
+  it('classifies a team row as teams', () => {
+    expect(documentScopeKind({ teamIds: ['team_a'] })).toBe('teams');
+  });
+
+  // The defect in #2989: `teamIds.length === 0` reads as "unscoped", but it is
+  // also true of every project-scoped row — so the Documents table rendered
+  // "Organization-wide" for material that is restricted to one project.
+  it('classifies a project row as project, never hub', () => {
+    expect(documentScopeKind({ projectId: 'project_a' })).toBe('project');
+    expect(documentScopeKind({ projectId: 'project_a', teamIds: [] })).toBe(
+      'project',
+    );
+  });
+
+  // The reachable sibling of the same mistake: reading only `teamTags` misses a
+  // row written before multi-team support, which access control still restricts
+  // through the single stamp (`hasTeamAccess`).
+  it('classifies a legacy single-stamp row as teams, never hub', () => {
+    expect(documentScopeKind({ teamId: 'team_a' })).toBe('teams');
+  });
+});
+
+describe('documentScopeKind agrees with knowledgeScopeAllows', () => {
+  const stamps: ReadonlyArray<readonly [string, DocumentScopeStamp]> = [
+    ['no stamps at all', {}],
+    ['explicitly empty teams', { teamIds: [] }],
+    ['null stamps', { teamId: null, teamIds: null, projectId: null }],
+    ['a team list', { teamIds: ['team_a'] }],
+    ['a legacy single team', { teamId: 'team_a' }],
+    ['a project', { projectId: 'project_a' }],
+    ['a project with empty teams', { projectId: 'project_a', teamIds: [] }],
+  ];
+
+  // The label and the access rules must answer "is this organization-wide?"
+  // identically. Pinned behaviourally rather than by comment: a hub-only caller
+  // can read exactly the rows `documentScopeKind` calls 'hub', so a label that
+  // says "Organization-wide" for anything else is claiming access the rules
+  // refuse.
+  it.each(stamps)('%s', (_name, scope) => {
+    expect(knowledgeScopeAllows(hubOnly, scope)).toBe(
+      documentScopeKind(scope) === 'hub',
+    );
+  });
+
+  it('does not let includeHub grant a scoped row', () => {
+    for (const scope of [
+      { teamIds: ['team_a'] },
+      { teamId: 'team_a' },
+      { projectId: 'project_a' },
+    ] satisfies DocumentScopeStamp[]) {
+      expect(knowledgeScopeAllows(hubOnly, scope)).toBe(false);
+    }
+  });
+
+  it('still grants a scoped row to a caller holding that scope', () => {
+    expect(
+      knowledgeScopeAllows(
+        { teamIds: ['team_a'], projectIds: [], includeHub: false },
+        { teamId: 'team_a' },
+      ),
+    ).toBe(true);
+    expect(
+      knowledgeScopeAllows(
+        { teamIds: [], projectIds: ['project_a'], includeHub: false },
+        { projectId: 'project_a' },
+      ),
+    ).toBe(true);
+  });
+
+  it('treats an absent access scope as org-wide, whatever the stamp', () => {
+    expect(knowledgeScopeAllows(undefined, { projectId: 'project_a' })).toBe(
+      true,
+    );
+  });
+});

--- a/services/platform/lib/knowledge/types.ts
+++ b/services/platform/lib/knowledge/types.ts
@@ -137,6 +137,49 @@ export interface KnowledgeAccessScope {
 }
 
 /**
+ * A document's scope stamp, in either encoding: a corpus row (`team_ids`,
+ * `project_id`) or a Convex `documents` row (`teamTags`, `projectId`), plus the
+ * deprecated single `teamId`.
+ */
+export interface DocumentScopeStamp {
+  readonly teamId?: string | null;
+  readonly teamIds?: readonly string[] | null;
+  readonly projectId?: string | null;
+}
+
+/**
+ * The teams a scope stamp names. Precedence mirrors `hasTeamAccess`
+ * (`convex/lib/team_access.ts`), the listing-side truth: the full list wins
+ * when present, and the single stamp is the legacy fallback — so a row written
+ * before multi-team support still reads as the one team it is restricted to.
+ */
+export function scopeTeamIds(scope: DocumentScopeStamp): readonly string[] {
+  return scope.teamIds ?? (scope.teamId != null ? [scope.teamId] : []);
+}
+
+/** Which of the three mutually exclusive scopes a stamp is in. */
+export type DocumentScopeKind = 'hub' | 'teams' | 'project';
+
+/**
+ * Classify a scope stamp — the one definition of what "organization-wide"
+ * means, so a label can never claim something the access rules contradict.
+ *
+ * A UI that re-derives this gets it wrong: `teamIds.length === 0` looks like
+ * "unscoped" but is also true of every project-scoped row, and reading only
+ * `teamTags` misses a row carrying the legacy single `teamId`. Both mistakes
+ * render a restricted document as organization-wide, on the screen an operator
+ * uses to audit exactly that. Anything showing scope to a person must call this
+ * rather than test the fields itself.
+ */
+export function documentScopeKind(
+  scope: DocumentScopeStamp,
+): DocumentScopeKind {
+  if (scope.projectId != null) return 'project';
+  if (scopeTeamIds(scope).length > 0) return 'teams';
+  return 'hub';
+}
+
+/**
  * Whether one document's scope stamp is visible under an access scope — the
  * point-read twin of the search filter (`convex/knowledge/corpus.ts` builds
  * the same disjunction into SQL; the two encodings MUST stay in agreement).
@@ -155,17 +198,11 @@ export interface KnowledgeAccessScope {
  */
 export function knowledgeScopeAllows(
   access: KnowledgeAccessScope | undefined,
-  scope: {
-    readonly teamId?: string | null;
-    readonly teamIds?: readonly string[] | null;
-    readonly projectId?: string | null;
-  },
+  scope: DocumentScopeStamp,
 ): boolean {
   if (access === undefined) return true;
-  // Precedence mirrors `hasTeamAccess`: the full list wins when present, the
-  // single stamp is the legacy fallback.
-  const teamIds = scope.teamIds ?? (scope.teamId != null ? [scope.teamId] : []);
-  const isHub = teamIds.length === 0 && scope.projectId == null;
+  const teamIds = scopeTeamIds(scope);
+  const isHub = documentScopeKind(scope) === 'hub';
   return (
     (isHub && access.includeHub) ||
     teamIds.some((teamId) => access.teamIds.includes(teamId)) ||

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -2079,6 +2079,7 @@ documents:
       Gruppen auf dieses Element zugreifen können.
     goToSettings: Zu Einstellungen
     orgWide: Organisationsweit
+    projectScoped: Projektgebunden
   deleteFile:
     title: Dokument löschen
     confirmation: '„{name}" löschen? Das lässt sich nicht rückgängig machen.'

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -2006,6 +2006,7 @@ documents:
     noTeamsDescription: Create teams in Settings to control which groups can access this item.
     goToSettings: Go to settings
     orgWide: Organization-wide
+    projectScoped: Project-scoped
   deleteFile:
     title: Delete document
     confirmation: Delete "{name}"? This can't be undone.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -2095,6 +2095,7 @@ documents:
       groupes peuvent accéder à cet élément.
     goToSettings: Aller aux paramètres
     orgWide: Toute l'organisation
+    projectScoped: Limité à un projet
   deleteFile:
     title: Supprimer le document
     confirmation: 'Supprimer « {name} » ? Cette action est irréversible.'

--- a/services/platform/types/documents.ts
+++ b/services/platform/types/documents.ts
@@ -45,6 +45,9 @@ export interface DocumentItem {
   ocrApplied?: boolean;
   teamId?: string | null;
   teamIds?: string[];
+  /** Project scope, mutually exclusive with the team stamps. Classify scope
+   *  through `documentScopeKind`, never by testing these fields directly. */
+  projectId?: string | null;
   /** User ID who created/uploaded this document */
   createdBy?: string;
   /** Display name of the user who created/uploaded this document */


### PR DESCRIPTION
Closes #2989 in substance, but **not by the mechanism the issue describes** — see *Scope* below before closing it.

## The defect

The Documents table's scope column decided "Organization-wide" by testing `teamIds.length === 0`. That isn't what organization-wide means. The authoritative definition already existed — `knowledgeScopeAllows` (`lib/knowledge/types.ts`) treats a row as a hub row when it has **no teams AND no project** — and the column reproduced only half of it, on the screen an operator uses to answer "is this material restricted?".

Two row shapes are misreported by the half-rule:

- **project-scoped** — zero teams by construction, since the stamps are mutually exclusive;
- **legacy single `teamId`** — enforced by `hasTeamAccess` (`convex/lib/team_access.ts:27`), which falls back to the single stamp, but invisible to a cell reading `teamTags` alone.

Either renders as unrestricted while access control restricts it. The label states the opposite of the truth.

## The change

Rather than add the missing half in a second place, the classification moved next to the rule it has to agree with — `documentScopeKind` and `scopeTeamIds`, which `knowledgeScopeAllows` now calls as well, so the two cannot drift apart again. The column asks that predicate and renders team names, a project label, or organization-wide.

`projectId` now travels on the row (`documentItemValidator`, the transform, the frontend type) so the predicate sees a complete stamp rather than depending on an upstream filter staying where it is.

## The audit

The issue asked for the other scope surfaces to be checked. One more instance of the same mistake, on a control that **writes** rather than one that reads: the row's team ids seed the team-tags dialog, where an empty selection means organization-wide — so a legacy row opened claiming to be unrestricted. It now passes the resolved list, as the folder rows already did. The folder mapping's hand-rolled copy of the same precedence is replaced with the shared helper.

The remaining `teamTags.orgWide` usages (create-folder, upload, OneDrive settings, the team-tags multi-select itself) are **inputs offering a choice**, not labels reporting state, so they are correct as they stand.

## Tests

`knowledgeScopeAllows` had none. It has them now, including the pinning case: a hub-only caller may read exactly the rows the label calls organization-wide, so the two answers are checked against each other instead of kept in step by a comment. Plus scope-column cases for both misreported shapes.

Every new assertion was mutation-tested — dropping the `projectId` branch, dropping the legacy fallback, and restoring the old `teamIds`-only test each turn the relevant tests red.

## Scope — read before closing #2989

The issue's Cause section attributes the mislabel to project-scoped documents appearing in Knowledge → Documents. **They cannot appear there.** `hasKnowledgeHubDocumentAccess` returns `false` for any project-scoped document (`convex/documents/access.ts:58`) and `list_documents_paginated.ts:84` applies exactly that filter; the project Files tab, where those documents do surface, has no scope column at all. So on the only table that renders the label, every row genuinely has `projectId == null` and the shortcut was accidentally correct.

What this PR fixes is the same defect with a different trigger — the legacy single `teamId` — plus the structural cause both share. The project branch is defense-in-depth: correct if such a row ever reaches a shared table, and directly tested, but not reachable today.

Whether the legacy shape explains what the reporter observed is a data question this PR can't answer: `teamIdsToFields` always writes both stamps together (`convex/documents/team_fields.ts:30`), so only rows predating multi-team support have it. Worth confirming a document exists with `teamId` set and `teamTags` empty before treating #2989 as explained.

One pre-existing edge left alone: when a team id doesn't resolve in `teamMap` (deleted team) the cell renders empty. That already applied to multi-team rows; legacy rows now reach it too. Blank makes no false claim, and inventing a label here would be a new assertion about access, so it's left for a separate change.
