### PR TITLE
fix(platform): stop re-storing an email attachment on every mail poll

### DIFF
--- a/services/platform/convex/conversations/ingest/reuse_stored_attachments.test.ts
+++ b/services/platform/convex/conversations/ingest/reuse_stored_attachments.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { reuseStoredAttachments } from './reuse_stored_attachments';
+
+/**
+ * One fetched email carrying wire bytes, as a mail connector returns it on
+ * every fetch — including a re-fetch of a message already ingested.
+ */
+function emailWithBytes(
+  messageId: string,
+  filename = 'report.pdf',
+): Record<string, unknown> {
+  return {
+    messageId,
+    subject: 'Quarterly figures',
+    attachments: [
+      {
+        // A per-fetch part handle, NOT stable across fetches — which is why
+        // filename is the identifier used for matching.
+        id: '2.1',
+        filename,
+        contentType: 'application/pdf',
+        size: 128,
+        contentBase64: 'Ynl0ZXM=',
+      },
+    ],
+  };
+}
+
+/** A stored attachment as it sits in an ingested message's metadata. */
+function storedMetadata(filename = 'report.pdf', storageId = 'blob_abc') {
+  return {
+    attachments: [
+      {
+        id: '1.2',
+        filename,
+        contentType: 'application/pdf',
+        size: 128,
+        storageId,
+        url: `/storage/${storageId}/${filename}`,
+      },
+    ],
+  };
+}
+
+function ctxReturning(existing: unknown) {
+  const runQuery = vi.fn(async () => existing);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+  return { ctx: { runQuery } as never, runQuery };
+}
+
+describe('reuseStoredAttachments', () => {
+  it('reuses the stored pointers for an already-ingested message', async () => {
+    const { ctx } = ctxReturning({
+      _id: 'msg_1',
+      metadata: storedMetadata(),
+    });
+
+    const [out] = await reuseStoredAttachments(ctx, {
+      organizationId: 'org_1',
+      emails: [emailWithBytes('<q3@example.com>')],
+    });
+
+    const attachments = (out as { attachments: Array<Record<string, unknown>> })
+      .attachments;
+    expect(attachments).toHaveLength(1);
+    // The existing blob, and crucially NO wire bytes — so the materializer
+    // downstream has nothing to store.
+    expect(attachments[0].storageId).toBe('blob_abc');
+    expect(attachments[0]).not.toHaveProperty('contentBase64');
+  });
+
+  it('leaves a new message untouched so its bytes are stored', async () => {
+    const { ctx } = ctxReturning(null);
+    const email = emailWithBytes('<new@example.com>');
+
+    const [out] = await reuseStoredAttachments(ctx, {
+      organizationId: 'org_1',
+      emails: [email],
+    });
+
+    expect(out).toBe(email);
+  });
+
+  // A chip from before attachment storage shipped, or a materialization that
+  // failed: there is nothing to reuse, and this pass is the chance to fix it.
+  it('stores normally when the existing message has no stored bytes', async () => {
+    const { ctx } = ctxReturning({
+      _id: 'msg_1',
+      metadata: {
+        attachments: [
+          {
+            id: '1.2',
+            filename: 'report.pdf',
+            contentType: 'application/pdf',
+            size: 128,
+          },
+        ],
+      },
+    });
+    const email = emailWithBytes('<q3@example.com>');
+
+    const [out] = await reuseStoredAttachments(ctx, {
+      organizationId: 'org_1',
+      emails: [email],
+    });
+
+    expect(out).toBe(email);
+  });
+
+  it('stores normally when the fetched parts do not all match what is stored', async () => {
+    // Stored covers report.pdf; this fetch also carries invoice.pdf. Reusing
+    // partially would silently drop the new file.
+    const { ctx } = ctxReturning({ _id: 'msg_1', metadata: storedMetadata() });
+    const email = emailWithBytes('<q3@example.com>');
+    (email.attachments as Array<Record<string, unknown>>).push({
+      id: '2.2',
+      filename: 'invoice.pdf',
+      contentType: 'application/pdf',
+      size: 64,
+      contentBase64: 'bW9yZQ==',
+    });
+
+    const [out] = await reuseStoredAttachments(ctx, {
+      organizationId: 'org_1',
+      emails: [email],
+    });
+
+    expect(out).toBe(email);
+  });
+
+  it('stores normally when the lookup throws', async () => {
+    const runQuery = vi.fn(async () => {
+      throw new Error('transient');
+    });
+    const email = emailWithBytes('<q3@example.com>');
+
+    const [out] = await reuseStoredAttachments(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+      { runQuery } as never,
+      { organizationId: 'org_1', emails: [email] },
+    );
+
+    // Never lose a file to a failed lookup: a duplicate blob is recoverable,
+    // a dropped attachment is not.
+    expect(out).toBe(email);
+  });
+
+  it('does not look up an email with no attachments', async () => {
+    const { ctx, runQuery } = ctxReturning(null);
+
+    await reuseStoredAttachments(ctx, {
+      organizationId: 'org_1',
+      emails: [{ messageId: '<plain@example.com>', subject: 'no files' }],
+    });
+
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('passes through a non-email value untouched', async () => {
+    const { ctx } = ctxReturning(null);
+    const out = await reuseStoredAttachments(ctx, {
+      organizationId: 'org_1',
+      emails: [null, 'nonsense'],
+    });
+    expect(out).toEqual([null, 'nonsense']);
+  });
+});

--- a/services/platform/convex/conversations/ingest/reuse_stored_attachments.ts
+++ b/services/platform/convex/conversations/ingest/reuse_stored_attachments.ts
@@ -1,0 +1,152 @@
+/**
+ * Reuse the attachment pointers a message already has, instead of storing its
+ * bytes a second time.
+ *
+ * A mail poll re-fetches messages it has already ingested — most reliably the
+ * one sitting exactly on the sync cursor, which is derived from that message's
+ * own timestamp and compared inclusively (see the boundary re-fetch issue). The
+ * body arrives complete with `contentBase64` every time, and
+ * `materializeEmailAttachments` would faithfully store it again: blob keys are
+ * `randomUUID()` (`lib/storage/object_store.ts`), so identical bytes always get
+ * a fresh object, and `saveFileMetadata` dedupes on `storageId`, so a fresh key
+ * always means a fresh row. One attachment on a message that stays on the
+ * cursor therefore accumulates one blob and one `fileMetadata` row per poll,
+ * indefinitely.
+ *
+ * The bytes are immutable, so a message that already carries `storageId`s needs
+ * nothing stored: handing back the pointers it already has makes the ingest
+ * path's metadata rewrite a no-op for attachments and leaves the wire
+ * `contentBase64` to be dropped as usual.
+ *
+ * Deliberately keyed on the message being ALREADY INGESTED rather than on the
+ * bytes being familiar. Content-addressed storage would be the deeper fix, but
+ * it changes every blob writer; this is the narrow one, and it cannot skip a
+ * genuinely new attachment because a new message has nothing stored to reuse.
+ */
+
+import { isRecord } from '../../../lib/utils/type-utils';
+import type { ActionCtx } from '../../_generated/server';
+import { checkMessageExists } from './check_message_exists';
+
+/** One stored attachment, as it sits in a message's metadata. */
+interface StoredAttachment {
+  id: string;
+  filename: string;
+  contentType: string;
+  size: number;
+  contentId?: string;
+  storageId: string;
+  url?: string;
+}
+
+/**
+ * The attachments an already-ingested message holds, keyed by filename.
+ *
+ * Filename is the only identifier that survives the round trip: the wire `id`
+ * is a per-fetch part handle (an IMAP part number), not stable across fetches,
+ * while `storageId` is what we are trying to avoid re-minting. Two parts sharing
+ * a filename collapse to one entry — harmless, since identical filenames on one
+ * message carry identical bytes in every case this path is reached, and a
+ * mismatch simply falls through to storing normally.
+ */
+function storedByFilename(metadata: unknown): Map<string, StoredAttachment> {
+  const byName = new Map<string, StoredAttachment>();
+  if (!isRecord(metadata) || !Array.isArray(metadata.attachments))
+    return byName;
+  for (const raw of metadata.attachments) {
+    if (!isRecord(raw)) continue;
+    const { filename, storageId } = raw;
+    // No `storageId` means the bytes were never stored (a metadata-only chip
+    // from before attachment storage shipped, or a failed materialization).
+    // Those SHOULD be stored on this pass, so they are not reusable.
+    if (typeof filename !== 'string' || typeof storageId !== 'string') continue;
+    if (typeof raw.contentType !== 'string' || typeof raw.size !== 'number') {
+      continue;
+    }
+    byName.set(filename, {
+      id: typeof raw.id === 'string' ? raw.id : filename,
+      filename,
+      contentType: raw.contentType,
+      size: raw.size,
+      storageId,
+      ...(typeof raw.contentId === 'string' && { contentId: raw.contentId }),
+      ...(typeof raw.url === 'string' && { url: raw.url }),
+    });
+  }
+  return byName;
+}
+
+/**
+ * Swap each fetched email's attachments for the ones its already-ingested
+ * message holds, and report which emails still need materializing.
+ *
+ * An email is returned untouched when it is new, when the existing message has
+ * no usable stored attachment for a part, or when anything about the lookup is
+ * unclear — the fallback is always "store it", so a missed reuse costs a
+ * duplicate blob while a wrong reuse would cost a broken download link.
+ */
+export async function reuseStoredAttachments(
+  ctx: ActionCtx,
+  args: { organizationId: string; emails: readonly unknown[] },
+): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for (const email of args.emails) {
+    if (
+      !isRecord(email) ||
+      !Array.isArray(email.attachments) ||
+      email.attachments.length === 0 ||
+      typeof email.messageId !== 'string'
+    ) {
+      out.push(email);
+      continue;
+    }
+
+    let existing: Awaited<ReturnType<typeof checkMessageExists>> = null;
+    try {
+      existing = await checkMessageExists(
+        ctx,
+        args.organizationId,
+        email.messageId,
+      );
+    } catch (error) {
+      // A lookup failure must not lose the attachment: fall through and store
+      // it, accepting a duplicate rather than dropping a file.
+      console.warn(
+        '[reuseStoredAttachments] existing-message lookup failed; storing normally',
+        error instanceof Error ? error.message : String(error),
+      );
+      out.push(email);
+      continue;
+    }
+
+    if (existing === null) {
+      out.push(email);
+      continue;
+    }
+
+    const stored = storedByFilename(existing.metadata);
+    if (stored.size === 0) {
+      out.push(email);
+      continue;
+    }
+
+    // All-or-nothing per email: mixing reused and freshly stored parts would
+    // make the "did anything change?" reasoning below much harder to trust for
+    // no practical gain — a message either has its attachments stored or it
+    // does not.
+    const reused: StoredAttachment[] = [];
+    for (const raw of email.attachments) {
+      if (!isRecord(raw) || typeof raw.filename !== 'string') break;
+      const match = stored.get(raw.filename);
+      if (match === undefined) break;
+      reused.push(match);
+    }
+    if (reused.length !== email.attachments.length) {
+      out.push(email);
+      continue;
+    }
+
+    out.push({ ...email, attachments: reused });
+  }
+  return out;
+}

--- a/services/platform/convex/conversations/sync_mailbox.test.ts
+++ b/services/platform/convex/conversations/sync_mailbox.test.ts
@@ -69,6 +69,12 @@ interface HarnessOptions {
   }>;
   /** Credential ids whose connector calls fail — one unreachable mailbox. */
   failCredentials?: Record<string, string>;
+  /**
+   * Already-ingested messages, by normalized external id — what
+   * `getMessageByExternalId` finds. Lets a test re-fetch a message the org
+   * already has, which is what every poll does to the message on the cursor.
+   */
+  existingMessages?: Record<string, { metadata?: unknown }>;
 }
 
 /** A ctx whose only capability is the nested connector action + credential list. */
@@ -84,6 +90,7 @@ function harness(
   const outcome = options.outcome ?? { status: 'ok' };
   const credentials = options.credentials ?? [];
   const failCredentials = options.failCredentials ?? {};
+  const existingMessages = options.existingMessages ?? {};
   const calls: ConnectorCall[] = [];
   const cursorPatches: Array<Record<string, unknown>> = [];
   // Every ctx hop in order — connector calls AND the blob lane, so a test can
@@ -123,7 +130,16 @@ function harness(
     if (failure !== undefined) return { status: 'error', message: failure };
     return { status: 'ok', output: reply(call) };
   };
-  const runQuery = async (): Promise<unknown> => credentials;
+  const runQuery = async (
+    _ref: unknown,
+    args?: Record<string, unknown>,
+  ): Promise<unknown> => {
+    // `getMessageByExternalId` shares this seam with the credential list.
+    if (args !== undefined && typeof args.externalMessageId === 'string') {
+      return existingMessages[args.externalMessageId] ?? null;
+    }
+    return credentials;
+  };
   const runMutation = async (
     _ref: unknown,
     args: Record<string, unknown>,
@@ -381,6 +397,121 @@ describe('syncMailbox attachment handling', () => {
       'get:2',
       'store:application/pdf',
     ]);
+  });
+
+  // Every poll re-fetches at least the message sitting on the cursor: the
+  // cursor is derived from that message's own timestamp and compared with `>=`,
+  // so it satisfies its own filter forever. Storing is not idempotent — blob
+  // keys are `randomUUID()` and `saveFileMetadata` dedupes on `storageId` — so
+  // before this, one attachment on that message minted a fresh blob and a fresh
+  // `fileMetadata` row on every poll, indefinitely.
+  it('stores nothing again when re-fetching a message it already ingested', async () => {
+    const reply: Reply = (call) =>
+      call.action === 'list_messages'
+        ? { messages: [{ uid: '1' }] }
+        : {
+            uid: '1',
+            email: {
+              messageId: '<already@example.com>',
+              date: '2025-04-04T00:00:00.000Z',
+              attachments: [
+                {
+                  // A different part handle than the stored one — per-fetch, so
+                  // matching cannot rely on it.
+                  id: 'part-2.1',
+                  filename: 'report.pdf',
+                  contentType: 'application/pdf',
+                  size: 3,
+                  contentBase64: Buffer.from('pdf').toString('base64'),
+                },
+              ],
+            },
+          };
+    const { ctx, trace } = harness(reply, {
+      existingMessages: {
+        // Keyed WITHOUT angle brackets: the wire header carries them, the
+        // stored id does not, and `normalizeExternalMessageId` strips them on
+        // both write and lookup. Keying this by the wire form is how the first
+        // draft of this test passed for the wrong reason.
+        'already@example.com': {
+          metadata: {
+            attachments: [
+              {
+                id: 'part-1.2',
+                filename: 'report.pdf',
+                contentType: 'application/pdf',
+                size: 3,
+                storageId: 'storage-existing',
+                url: '/storage/storage-existing/report.pdf',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    await syncMailbox(ctx, {
+      organizationId: 'org',
+      connectorSlug: 'imap-smtp',
+      limit: 25,
+      includeSent: false,
+      mode: 'live',
+    });
+
+    // The body is still fetched (identity only exists after parsing), but no
+    // blob is written — no `store:` hop at all.
+    expect(trace).toEqual(['list_messages', 'get:1']);
+  });
+
+  it('still stores when the already-ingested message has no stored bytes', async () => {
+    // A chip from before attachment storage shipped, or a failed
+    // materialization: this pass is the chance to fix it, so it must not be
+    // mistaken for "already stored".
+    const reply: Reply = (call) =>
+      call.action === 'list_messages'
+        ? { messages: [{ uid: '1' }] }
+        : {
+            uid: '1',
+            email: {
+              messageId: '<metaonly@example.com>',
+              date: '2025-04-04T00:00:00.000Z',
+              attachments: [
+                {
+                  id: 'part-2.1',
+                  filename: 'report.pdf',
+                  contentType: 'application/pdf',
+                  size: 3,
+                  contentBase64: Buffer.from('pdf').toString('base64'),
+                },
+              ],
+            },
+          };
+    const { ctx, trace } = harness(reply, {
+      existingMessages: {
+        'metaonly@example.com': {
+          metadata: {
+            attachments: [
+              {
+                id: 'part-1.2',
+                filename: 'report.pdf',
+                contentType: 'application/pdf',
+                size: 3,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    await syncMailbox(ctx, {
+      organizationId: 'org',
+      connectorSlug: 'imap-smtp',
+      limit: 25,
+      includeSent: false,
+      mode: 'live',
+    });
+
+    expect(trace).toEqual(['list_messages', 'get:1', 'store:application/pdf']);
   });
 
   it('hands ingest the stored reference, never the wire bytes', async () => {

--- a/services/platform/convex/conversations/sync_mailbox.ts
+++ b/services/platform/convex/conversations/sync_mailbox.ts
@@ -33,6 +33,7 @@ import { normalizeEmails } from './ingest/normalize_email';
 import { queryLatestMessageByDeliveryState } from './ingest/query_latest_message_by_delivery_state';
 import { queryLatestOutboundMessageForEmailSync } from './ingest/query_latest_outbound_message_for_sync';
 import { resolveConnectorAccountEmail } from './ingest/resolve_connector_account_email';
+import { reuseStoredAttachments } from './ingest/reuse_stored_attachments';
 
 const EMAIL_CONNECTORS = new Set(['gmail', 'outlook', 'imap-smtp']);
 
@@ -293,6 +294,13 @@ async function fetchOneBody(
  * times the connector's per-attachment cap of resident string, enough to
  * exhaust the action. Materializing per message keeps at most one body's bytes
  * live; what accumulates is the small `storageId` + `url` form.
+ *
+ * A message already ingested has its stored pointers reused rather than its
+ * bytes stored again (`reuseStoredAttachments`). Every poll re-fetches at least
+ * the message on the cursor — it is derived from that message's own timestamp
+ * and compared inclusively — and storing is not idempotent, so without this each
+ * poll minted another blob and another `fileMetadata` row for the same
+ * attachment, forever.
  */
 async function fetchBodies(
   ctx: ActionCtx,
@@ -316,10 +324,17 @@ async function fetchBodies(
       }),
     });
     if (fetched === null) continue;
+    // Reuse before materialize: an email whose attachments are already stored
+    // comes back carrying its existing pointers and no `contentBase64`, so the
+    // store below is a no-op for it.
+    const [candidate] = await reuseStoredAttachments(ctx, {
+      organizationId: args.organizationId,
+      emails: [fetched.email],
+    });
     const [materialized] = await materializeEmailAttachments(ctx, {
       organizationId: args.organizationId,
       source: args.connectorSlug,
-      emails: [fetched.email],
+      emails: [candidate],
     });
     emails.push(materialized);
   }


### PR DESCRIPTION
Fixes the duplication reported in #2996 and #2985. **Not** by the fix #2996 proposed — see *Why not the cursor* below.

## The defect

Every mail poll re-fetches the message sitting on the sync cursor. `cursorFromMessage` (`sync_mailbox.ts:154-167`) derives the cursor from the newest message's own timestamp, and the connector filters inclusively:

```ts
// build_initial_message.ts:15,25,26 — both stamped from the same instant
const emailTimestamp = new Date(email.date).getTime();
sentAt: emailTimestamp,
deliveredAt: status === 'delivered' ? emailTimestamp : undefined,

// cursorFromMessage
const since = message.deliveredAt ?? message.sentAt ?? message._creationTime ?? null;

// imap-smtp.ts:1196
.filter((message) => cursor === undefined || message.sentAt >= cursor)
```

Same field, same source, `>=`. That message satisfies its own filter until newer mail displaces it.

And nothing about storing an attachment is idempotent: blob keys are `prefix/orgSlug/randomUUID()` (`lib/storage/object_store.ts:207`), so identical bytes always get a fresh object, and `saveFileMetadata` dedupes on `storageId`, so a fresh key always means a fresh row.

So one attachment on the message at the cursor minted **one blob and one `fileMetadata` row per poll, indefinitely**. Observed on a deployment: a new copy every five minutes for over a day, of a single file. Since #2995 those rows carry `ragStatus` unset, so they no longer consume the RAG indexing cap — but the duplication itself continued.

## The fix

The bytes are immutable, so a message whose attachments are already stored needs nothing stored. `reuseStoredAttachments` looks the message up by its normalized Message-ID and hands back the pointers it already holds, so the materializer downstream has nothing to do. It runs before materialization in `fetchBodies`.

Provider-agnostic by construction: Gmail and Outlook re-list their boundary message too (`after:` and `ge` are both inclusive) — they simply never carried inline bytes for it to duplicate, since connector `ctx.files` is unwired.

Matching is on **filename**, the only identifier that survives the round trip. The wire `id` is a per-fetch part handle (an IMAP part number), and `storageId` is precisely what we are avoiding re-minting.

Every uncertain case falls through to storing normally:

- a stored part with no `storageId` — a metadata-only chip from before attachment storage shipped, or a materialization that failed. This pass is its chance to be fixed, so it must not read as "already stored".
- a fetch whose parts do not **all** match what is stored — partial reuse would silently drop a genuinely new file.
- a lookup that throws — a duplicate blob is recoverable, a dropped attachment is not.

Cursor semantics are untouched, so no mail can be skipped.

## Why not the cursor

#2996 proposed excluding the boundary message by the id the cursor already carries. That does not work: the cursor's `messageId` is `externalMessageId`, the RFC `Message-ID` header, while a listing summary is `MailMessageSummary { uid, from, subject, sentAt }` — no message id at all, and for IMAP the id used to fetch is the UID. The RFC Message-ID only exists after the body is parsed, so excluding at list time by it would require the very fetch it was meant to avoid.

**What this leaves unfixed:** the redundant body *fetch* still happens each poll. That is a wasted round-trip rather than duplicated data, and closing it means threading the UID through the cursor — worth doing separately, at lower priority. #2996 should be retitled to that narrower scope rather than closed by this PR.

## Tests

- `reuse_stored_attachments.test.ts` — reuse on an already-ingested message; store on a new one; store when the stored part has no `storageId`; store when parts don't all match; store when the lookup throws; no lookup at all for an attachment-free email.
- `sync_mailbox.test.ts` — through the real sync path: re-fetching an ingested message produces `['list_messages', 'get:1']` with **no** `store:` hop, while the metadata-only case still stores.

Every assertion mutation-tested. Removing the reuse step, reusing without a stored `storageId`, and reusing partially each turn the relevant tests red. The throw case needed a second look — the catch path and the not-found path both pass the email through, so it initially proved nothing; the mutation that kills it is making the catch rethrow, which is the behaviour that matters (a failed lookup must not abort the whole sync pass).

The harness keys existing messages by the **normalized** id, without angle brackets — the first draft keyed it by the wire form and passed for the wrong reason, since a lookup miss and a successful reuse both leave the email untouched at that level.
