### PR TITLE
fix(platform): make a dead knowledge search visible to the operator

### DIFF
--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -9,7 +9,7 @@
 // rejects, so every failure case here asserts through `.resolves`.
 
 import { getFunctionName } from 'convex/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   CHAT_ASSISTANT_SLUG,
@@ -235,7 +235,9 @@ describe('createChatToolExecutor — dispatch', () => {
 });
 
 describe('rag_search', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   beforeEach(() => vi.clearAllMocks());
+  afterAll(() => warnSpy.mockRestore());
 
   it('fuses every leg into mapped kinds, notes each source, and records the dispatch once', async () => {
     searchKnowledgeMock.mockResolvedValueOnce({
@@ -383,8 +385,19 @@ describe('rag_search', () => {
 
     expect(result.status).toBe('ok');
     expect(result.sources?.documents).toMatch(/^unavailable:/);
-    expect(result.sources?.documents).toContain('No embedding model');
+    // The model gets a STABLE sentence naming the real remedy page — never the
+    // raw `Error.message`. Relaying that verbatim is how internal
+    // configuration prose reached an end user, who read it as a product fault
+    // (#2988). The real error goes to the log instead, asserted below.
+    expect(result.sources?.documents).not.toContain('No embedding model');
+    expect(result.sources?.documents).toContain('Settings → Data residency');
     expect(result.sources?.webPages).toBe(result.sources?.documents);
+    // And the operator hears about it at all: before this the degraded path
+    // logged nothing, so the ONLY channel reporting the outage was the
+    // assistant improvising an explanation to a user mid-conversation.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No embedding model'),
+    );
     // The degradation is per source, never the whole answer.
     expect(result.sources?.knowledgeEntries).toBe('searched (no matches)');
     expect(result.sources?.contacts).toBe('searched');

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -115,6 +115,21 @@ function isWorkStatus(value: unknown): value is WorkStatusFilter {
   );
 }
 
+/**
+ * What the model is told when the corpora cannot be searched.
+ *
+ * Deliberately STABLE and free of internals: the model relays this to a person,
+ * so a raw `Error.message` here becomes internal configuration prose quoted to
+ * an end user who reads it as a product fault. The real cause goes to the log
+ * instead, where the person who can fix it will look. Names the remedy in the
+ * words the UI uses, so an admin who is told this can act on it.
+ */
+const KNOWLEDGE_UNAVAILABLE_FOR_MODEL =
+  'unavailable: document and web-page search is not set up for this ' +
+  'organization yet. An administrator configures it under Settings → Data ' +
+  'residency (the embedding model). Say this plainly if it matters to the ' +
+  'answer; do not guess at the cause.';
+
 // ------------------------------------------------------------ result shapes
 
 /** Every tool answers with one of these statuses, so the model always knows
@@ -378,8 +393,22 @@ export function createChatToolExecutor(
           ? 'searched'
           : 'searched (no matches — no crawled pages may be indexed yet)';
       } catch (error) {
-        // No embedding model / unusable corpus — degraded, said out loud.
-        sources.documents = `unavailable: ${clip(describeError(error), 200)}`;
+        // Two audiences, two messages — conflating them is what made this
+        // outage invisible for hours.
+        //
+        // The OPERATOR needs the real error and needs it in the logs. Before
+        // this, "said out loud" meant only to the model, so nothing reached
+        // anyone who could fix it: no log line, no badge, no alert, while the
+        // tool still returned `status: 'ok'` because the other legs are plain
+        // Convex reads that succeed.
+        console.warn(
+          `[chat] knowledge search unavailable for organization ${who.organizationId}: ${describeError(error)}`,
+        );
+        // The MODEL gets a stable sentence that names the remedy and leaks no
+        // internals. Relaying `Error.message` verbatim is how configuration
+        // prose ended up quoted to an end user, who read it as a product
+        // fault.
+        sources.documents = KNOWLEDGE_UNAVAILABLE_FOR_MODEL;
         sources.webPages = sources.documents;
       }
     } else {

--- a/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_tools_bridge.ts
@@ -637,6 +637,13 @@ const KNOWLEDGE_ACCESS_BLOCKERS: Record<
  * configured or its corpus/pool is unusable — surfaced as guidance, not a
  * transport error, so the agent tells the user instead of retrying. */
 function knowledgeUnavailable(error: unknown): ToolResult {
+  // Same split as the chat leg: the real error to the log, a stable sentence
+  // to the agent. There is no Settings → Knowledge page — the embedding
+  // configuration lives under Settings → Data residency, and pointing an
+  // operator at a page that does not exist is worse than saying nothing.
+  console.warn(
+    `[sandbox] knowledge retrieval unavailable: ${error instanceof Error ? error.message : String(error)}`,
+  );
   return {
     status: 'unavailable',
     blockers: [
@@ -645,8 +652,8 @@ function knowledgeUnavailable(error: unknown): ToolResult {
         guidance:
           'Knowledge retrieval is not available for this organization ' +
           '(no embedding model configured, or the knowledge base is ' +
-          'empty). Ask the user to set it up under Settings → Knowledge. ' +
-          `(${error instanceof Error ? error.message : String(error)})`,
+          'empty). An administrator sets it up under Settings → Data ' +
+          'residency. Do not guess at the cause.',
       },
     ],
   };


### PR DESCRIPTION
Part of #2988 — the observability and honesty half. Two of its five parts remain (see *Not in this PR*).

## What was wrong

Knowledge search had never worked on a deployment where no organization had an embedding model configured, and **nothing reported it**. No log line, no badge, no alert. The only channel in the entire system that surfaced the outage was the chat assistant improvising an explanation to an end user mid-conversation:

> I'm unable to search your organization's documents and web pages at the moment due to a configuration issue with the knowledge base.

The user read that as a product fault. Diagnosing it required source access and several hours.

The cause was one message serving two audiences. The comment on the degraded path said *"degraded, said out loud"* — out loud to the **model**. There was no `console.warn`, so an operator grepping logs found nothing, and the tool still returned `status: 'ok'` because the remaining legs are plain Convex reads that succeed.

## Split by audience

**The operator** gets a `console.warn` with the real error and the organization id — in the chat leg and in the sandbox bridge, which had the same shape.

**The model** gets a stable sentence that names the remedy and leaks no internals. Relaying `Error.message` verbatim is precisely how internal configuration prose reached an end user.

## And the remedy it names now exists

Both messages pointed at **Settings → Knowledge**. There is no such page — the embedding configuration lives under **Settings → Data residency**. Pointing an operator at a page that does not exist is worse than saying nothing. I swept for other occurrences; the docs already say Data residency correctly, so this was the only wrong reference in code.

## Tests

The existing test asserted the raw error **did** reach the model, which is the behaviour being fixed — so it is inverted rather than weakened. It now pins all three properties: the message must not contain the error, must name the real page, and the error must reach the log.

Mutation-tested: restoring the raw-error leak, and dropping the `console.warn`, each turn it red.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, platform 75,097 tests.

## Not in this PR

#2988's other two parts, both larger and independent of this one:

- **An org-level knowledge-health signal** — so an admin sees an unconfigured or unreachable corpus without opening a document. The per-document machinery exists (`embedding-settings-action.tsx`, the `rag.dialog.failed.embeddingNotConfigured.*` copy); it needs an org-level home.
- **Re-queue on save** — configuring an embedding model does not re-queue the documents that failed for want of one, so following the error's own instruction leaves the operator no better off. `retryRagIndexing` and `promoteQueuedRagJobs` exist; the save handler needs to enumerate the affected rows.

Keep #2988 open for those.
