### PR TITLE
feat(platform): let chat search conversations, under assignment privacy

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -225,6 +225,7 @@ import type * as conversations_reopen_conversation from "../conversations/reopen
 import type * as conversations_reply_from from "../conversations/reply_from.js";
 import type * as conversations_reply_to_conversation from "../conversations/reply_to_conversation.js";
 import type * as conversations_retry_send_message from "../conversations/retry_send_message.js";
+import type * as conversations_search_for_chat from "../conversations/search_for_chat.js";
 import type * as conversations_send_message_via_connector from "../conversations/send_message_via_connector.js";
 import type * as conversations_sync_mailbox from "../conversations/sync_mailbox.js";
 import type * as conversations_transform_conversation from "../conversations/transform_conversation.js";
@@ -1178,6 +1179,7 @@ declare const fullApi: ApiFromModules<{
   "conversations/reply_from": typeof conversations_reply_from;
   "conversations/reply_to_conversation": typeof conversations_reply_to_conversation;
   "conversations/retry_send_message": typeof conversations_retry_send_message;
+  "conversations/search_for_chat": typeof conversations_search_for_chat;
   "conversations/send_message_via_connector": typeof conversations_send_message_via_connector;
   "conversations/sync_mailbox": typeof conversations_sync_mailbox;
   "conversations/transform_conversation": typeof conversations_transform_conversation;

--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -109,6 +109,8 @@ const TASKS_SEARCH_FN = 'tasks/search_for_chat:searchTasksForChat';
 const PROJECTS_SEARCH_FN = 'tasks/search_for_chat:searchProjectsForChat';
 const TASK_BY_ID_FN = 'tasks/internal_queries:getTaskByIdInternal';
 const TASK_CONTEXT_FN = 'tasks/internal_queries:getTaskContextForAgent';
+const CONVERSATIONS_SEARCH_FN =
+  'conversations/search_for_chat:searchConversationsForChat';
 
 const WHO = { organizationId: 'org_1', userId: 'user_1' };
 
@@ -140,6 +142,7 @@ function createCtx(
       isDone: true,
       continueCursor: '',
     }),
+    [CONVERSATIONS_SEARCH_FN]: () => ({ conversations: [], truncated: false }),
     [TASK_BY_ID_FN]: () => null,
     [TASK_CONTEXT_FN]: () => null,
     [DOCUMENT_ROW_FN]: () => null,
@@ -328,6 +331,7 @@ describe('rag_search', () => {
       // rather than indistinguishable from an empty knowledge base.
       tasks: 'searched (no matches)',
       projects: 'searched (no matches)',
+      conversations: 'searched (no matches)',
     });
     // Ran for the turn's org (slug resolved), never a default corpus.
     const searchArgs = searchKnowledgeMock.mock.calls[0]?.[1] as Record<
@@ -1326,5 +1330,97 @@ describe('rag_fetch work refs', () => {
       input: { ref: 'project:project_1' },
     })) as Record<string, unknown>;
     expect(result.status).toBe('invalid_args');
+  });
+});
+
+describe('rag_search conversations leg', () => {
+  it('returns a readable conversation and does not pass authority in', async () => {
+    const { ctx, runQuery } = createCtx({
+      reads: {
+        [CONVERSATIONS_SEARCH_FN]: () => ({
+          conversations: [
+            {
+              _id: 'conv_1',
+              subject: 'Refund for order 12',
+              status: 'open',
+              channel: 'email',
+            },
+          ],
+          truncated: false,
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'refund order 12' },
+    })) as Record<string, unknown>;
+
+    const rows = result.results as Array<Record<string, unknown>>;
+    const conv = rows.find((r) => r.kind === 'conversation');
+    expect(conv?.title).toBe('Refund for order 12');
+    // A conversation is org state, not a citation — no fetchable ref.
+    expect(conv).not.toHaveProperty('ref');
+
+    // The leg passes IDENTITY only. An `isAdmin`/role flag travelling in from
+    // here is one refactor away from being wrong in the direction that
+    // publishes the inbox, so authority is resolved inside the query.
+    const call = runQuery.mock.calls.find(
+      ([ref]) => fnName(ref) === CONVERSATIONS_SEARCH_FN,
+    );
+    const passed = call?.[1] as Record<string, unknown>;
+    expect(passed).toMatchObject({
+      organizationId: 'org_1',
+      userId: 'user_1',
+    });
+    expect(passed).not.toHaveProperty('isAdmin');
+    expect(passed).not.toHaveProperty('role');
+    expect(passed).not.toHaveProperty('teamIds');
+  });
+
+  // "No matches" and "no matches among what I could reach" are different
+  // claims, and the bounded recency scan can only honestly make the second.
+  it('says so when the bounded scan filled up', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [CONVERSATIONS_SEARCH_FN]: () => ({
+          conversations: [],
+          truncated: true,
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'anything' },
+    })) as Record<string, unknown>;
+    expect(result.sources).toMatchObject({
+      conversations: 'searched (no matches among recent conversations)',
+    });
+  });
+
+  it('reports a role denial without running the query', async () => {
+    const { ctx, runQuery } = createCtx({
+      access: (subject) => ({
+        allowed: subject !== 'conversations',
+        role: 'member',
+      }),
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'inbox' },
+    })) as Record<string, unknown>;
+    expect(result.sources).toMatchObject({
+      conversations: 'access denied for your role',
+    });
+    expect(
+      runQuery.mock.calls.some(
+        ([ref]) => fnName(ref) === CONVERSATIONS_SEARCH_FN,
+      ),
+    ).toBe(false);
   });
 });

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -287,7 +287,8 @@ export function createChatToolExecutor(
       | 'contact'
       | 'website'
       | 'task'
-      | 'project';
+      | 'project'
+      | 'conversation';
     readonly title: string;
     /** What `rag_fetch` accepts: a document file id or a page URL. Entity
      * rows carry their content inline instead. */
@@ -334,6 +335,7 @@ export function createChatToolExecutor(
       websitesAllowed,
       tasksAllowed,
       projectsAllowed,
+      conversationsAllowed,
     ] = await Promise.all([
       readAllowed('documents'),
       readAllowed('contacts'),
@@ -341,6 +343,7 @@ export function createChatToolExecutor(
       readAllowed('websites'),
       readAllowed('tasks'),
       readAllowed('projects'),
+      readAllowed('conversations'),
     ]);
 
     // Leg 1 — the RAG corpora (documents + crawled pages), vector+keyword.
@@ -598,6 +601,49 @@ export function createChatToolExecutor(
     } else {
       sources.tasks = 'access denied for your role';
       sources.projects = sources.tasks;
+    }
+
+    // Leg 8 — conversations. The narrowest leg by far: assignment privacy is
+    // stricter than membership, so the query resolves the caller's own role and
+    // teams and evaluates the SAME predicate `rls_rules.ts` uses. It is not
+    // given an `isAdmin` flag to trust, and it is not handed organizationId
+    // alone the way legs 3–4 safely are — those tables are org-scope-only and
+    // an inbox is not.
+    if (conversationsAllowed) {
+      const found = await ctx.runQuery(
+        internal.conversations.search_for_chat.searchConversationsForChat,
+        {
+          organizationId: who.organizationId,
+          userId: who.userId,
+          term: query,
+          limit: Math.min(limit, RAG_SEARCH_ENTITY_LIMIT),
+        },
+      );
+      for (const conversation of found.conversations) {
+        results.push({
+          kind: 'conversation',
+          title: conversation.subject ?? 'Conversation',
+          data: {
+            ...(conversation.status ? { status: conversation.status } : {}),
+            ...(conversation.channel ? { channel: conversation.channel } : {}),
+            ...(conversation.lastMessageAt
+              ? { lastMessageAt: conversation.lastMessageAt }
+              : {}),
+          },
+        });
+      }
+      // A bounded scan that filled up must say so — otherwise "no matches"
+      // reads as "the inbox holds nothing", which is a different claim.
+      sources.conversations =
+        found.conversations.length > 0
+          ? found.truncated
+            ? 'searched (recent conversations only)'
+            : 'searched'
+          : found.truncated
+            ? 'searched (no matches among recent conversations)'
+            : 'searched (no matches)';
+    } else {
+      sources.conversations = 'access denied for your role';
     }
 
     await recordDispatch('rag_search', 'ok');

--- a/services/platform/convex/conversations/search_for_chat.test.ts
+++ b/services/platform/convex/conversations/search_for_chat.test.ts
@@ -1,0 +1,210 @@
+// Drives the REAL chat conversations leg through convex-test, so the privacy
+// claim is proven end to end rather than at the predicate alone. The leg reads
+// through an RLS-BYPASSING internal query, which is exactly why this exists:
+// nothing upstream of it enforces assignment privacy, so if the leg gets it
+// wrong the whole inbox is published to any member.
+//
+// Seeds the local mirrors (memberMirror / teamMemberMirror) directly, the same
+// way `conversation_access_rls.test.ts` does, so no Better Auth component is
+// needed.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'conversations';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_chat_conv_leg';
+const TEAM_X = 'team_x_chat_leg';
+const ADMIN = 'user_chat_leg_admin';
+const TEAM_MEMBER = 'user_chat_leg_team';
+const OWNER_USER = 'user_chat_leg_owner';
+const PLAIN_MEMBER = 'user_chat_leg_plain';
+type T = TestConvex<typeof schema>;
+
+async function seedWorld(t: T): Promise<void> {
+  await t.run(async (ctx) => {
+    for (const [userId, role] of [
+      [ADMIN, 'admin'],
+      [TEAM_MEMBER, 'member'],
+      [OWNER_USER, 'member'],
+      [PLAIN_MEMBER, 'member'],
+    ] as const) {
+      await ctx.db.insert('memberMirror', {
+        memberId: `m_${userId}`,
+        userId,
+        organizationId: ORG,
+        role,
+        createdAt: 0,
+      });
+    }
+    await ctx.db.insert('teamMemberMirror', {
+      teamMemberId: `tm_${TEAM_X}_${TEAM_MEMBER}`,
+      teamId: TEAM_X,
+      userId: TEAM_MEMBER,
+      createdAt: 0,
+    });
+    // Every subject shares the word "refund", so the text match is never what
+    // distinguishes these rows — only the assignment scope is.
+    await ctx.db.insert('conversations', {
+      organizationId: ORG,
+      subject: 'Refund pool unassigned',
+      status: 'open',
+      lastMessageAt: 400,
+    });
+    await ctx.db.insert('conversations', {
+      organizationId: ORG,
+      subject: 'Refund queued to team X',
+      status: 'open',
+      assigneeTeamId: TEAM_X,
+      lastMessageAt: 300,
+    });
+    await ctx.db.insert('conversations', {
+      organizationId: ORG,
+      subject: 'Refund owned by a person',
+      status: 'open',
+      assigneeUserId: OWNER_USER,
+      lastMessageAt: 200,
+    });
+  });
+}
+
+async function subjectsFor(t: T, userId: string): Promise<string[]> {
+  const result = await t.query(
+    internal.conversations.search_for_chat.searchConversationsForChat,
+    { organizationId: ORG, userId, term: 'refund', limit: 10 },
+  );
+  return result.conversations.map((c) => c.subject ?? '').sort();
+}
+
+describe('searchConversationsForChat — assignment privacy', () => {
+  let t: T;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    await seedWorld(t);
+  });
+
+  // THE test. An unassigned conversation is admin-triage state, and a member
+  // who is on no team and owns nothing must come back empty — not with the
+  // inbox.
+  it('shows a plain member nothing', async () => {
+    expect(await subjectsFor(t, PLAIN_MEMBER)).toEqual([]);
+  });
+
+  it('shows an admin every matching conversation, unassigned included', async () => {
+    expect(await subjectsFor(t, ADMIN)).toEqual([
+      'Refund owned by a person',
+      'Refund pool unassigned',
+      'Refund queued to team X',
+    ]);
+  });
+
+  it('shows the individual assignee only their own', async () => {
+    expect(await subjectsFor(t, OWNER_USER)).toEqual([
+      'Refund owned by a person',
+    ]);
+  });
+
+  it("shows a team member only their team's", async () => {
+    expect(await subjectsFor(t, TEAM_MEMBER)).toEqual([
+      'Refund queued to team X',
+    ]);
+  });
+
+  // NOT covered here: a user with no membership at all. `resolveAgentReadAccess`
+  // falls back to the Better Auth component when no `memberMirror` row exists,
+  // and that component is not registered in convex-test. The not-a-member
+  // refusal is exercised by the access resolver's own tests; this file proves
+  // the scope rules that only this leg can get wrong.
+
+  it('does not reach into another organization', async () => {
+    await t.run(async (ctx) => {
+      await ctx.db.insert('conversations', {
+        organizationId: 'some_other_org',
+        subject: 'Refund in a foreign org',
+        status: 'open',
+        assigneeUserId: ADMIN,
+        lastMessageAt: 500,
+      });
+    });
+    expect(await subjectsFor(t, ADMIN)).not.toContain(
+      'Refund in a foreign org',
+    );
+  });
+
+  it('finds a conversation by its contact name, not only its subject', async () => {
+    await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert('contacts', {
+        organizationId: ORG,
+        name: 'Wilhelmina Baker',
+        source: 'manual_import',
+      });
+      await ctx.db.insert('conversations', {
+        organizationId: ORG,
+        subject: 'A subject sharing no words with the query',
+        status: 'open',
+        assigneeUserId: OWNER_USER,
+        contactId,
+        lastMessageAt: 600,
+      });
+    });
+    const result = await t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      {
+        organizationId: ORG,
+        userId: OWNER_USER,
+        term: 'wilhelmina',
+        limit: 10,
+      },
+    );
+    expect(result.conversations.map((c) => c.subject)).toContain(
+      'A subject sharing no words with the query',
+    );
+  });
+
+  it('still applies assignment scope to a contact-name match', async () => {
+    await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert('contacts', {
+        organizationId: ORG,
+        name: 'Wilhelmina Baker',
+        source: 'manual_import',
+      });
+      // Unassigned: findable by contact name for an admin, invisible to a
+      // plain member. The contact match must not become a second way in.
+      await ctx.db.insert('conversations', {
+        organizationId: ORG,
+        subject: 'Unassigned but contact matches',
+        status: 'open',
+        contactId,
+        lastMessageAt: 700,
+      });
+    });
+    const plain = await t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      {
+        organizationId: ORG,
+        userId: PLAIN_MEMBER,
+        term: 'wilhelmina',
+        limit: 10,
+      },
+    );
+    expect(plain.conversations).toEqual([]);
+  });
+});

--- a/services/platform/convex/conversations/search_for_chat.ts
+++ b/services/platform/convex/conversations/search_for_chat.ts
@@ -1,0 +1,201 @@
+/**
+ * Question-shaped search over conversations, for the chat assistant.
+ *
+ * ## Why this one is not like the other legs
+ *
+ * Contacts and products can safely hand `organizationId` to an RLS-bypassing
+ * internal query, because those tables are org-scope-and-role only. Conversations
+ * are not: assignment privacy is narrower than membership, and the role gate the
+ * chat leg already runs (`resolveWorkspaceReadAccess`) returns `allowed: true`
+ * for ANY active member. So the role gate is necessary and nowhere near
+ * sufficient — copying the contacts leg's shape here would publish the whole
+ * inbox to every member.
+ *
+ * Every row therefore passes {@link conversationAssignmentAllows}, the same
+ * predicate `rls_rules.ts` uses, rather than a second copy of the rule. Role and
+ * team ids are resolved HERE from the caller's identity, not accepted as
+ * arguments — an `isAdmin` flag travelling in from a caller is one refactor away
+ * from being wrong in the direction that leaks.
+ *
+ * ## Bounded, recency-biased
+ *
+ * There is no text index on conversations, so this walks
+ * `by_org_lastMessageAt` newest-first and stops at {@link SCAN_CAP}. That
+ * mirrors `convex/chat/search.ts`: recent conversations are what a question is
+ * almost always about, and an unbounded scan over a fat table is not an option
+ * inside a turn. A match older than the cap is invisible — a real limit, stated
+ * rather than hidden.
+ *
+ * Contact names are searched without a `get` per row: one bounded contacts
+ * search resolves the term to a set of contact ids first, and a conversation
+ * matches on its subject OR on being with one of those contacts. Message bodies
+ * are NOT searched yet; `conversationMessages` does carry
+ * `by_organizationId_and_deliveredAt`, so a bounded body leg is possible later
+ * without a schema change.
+ */
+
+import { v } from 'convex/values';
+
+import type { Doc } from '../_generated/dataModel';
+import { internalQuery, type QueryCtx } from '../_generated/server';
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { resolveAgentReadAccess } from '../lib/rls/helpers/agent_read_access';
+import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
+import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import { contactsSearchStrategy, rowMatches } from '../lib/search';
+
+/**
+ * How many recent conversations one search may examine. Deliberately small:
+ * each row costs an assignment decision, and the answer a question needs is
+ * almost always recent. Raising it trades turn latency for reach.
+ */
+const SCAN_CAP = 300;
+
+/** Matched contacts to resolve before scanning. Bounds the id set the
+ *  conversation walk tests against. */
+const CONTACT_MATCH_CAP = 25;
+
+/** The contact ids whose name matches the term, so a conversation can be found
+ *  by who it is with and not only by its subject. */
+async function matchingContactIds(
+  ctx: QueryCtx,
+  args: { organizationId: string; term: string },
+): Promise<Set<string>> {
+  const ids = new Set<string>();
+  const lower = args.term.toLowerCase();
+  for await (const contact of ctx.db
+    .query('contacts')
+    .withIndex('by_organizationId', (q) =>
+      q.eq('organizationId', args.organizationId),
+    )) {
+    if (rowMatches(contact, contactsSearchStrategy, lower, args.term, 'any')) {
+      ids.add(String(contact._id));
+      if (ids.size >= CONTACT_MATCH_CAP) break;
+    }
+  }
+  return ids;
+}
+
+export const searchConversationsForChat = internalQuery({
+  args: {
+    organizationId: v.string(),
+    /** The turn user. Authority is derived from this, never passed in. */
+    userId: v.string(),
+    term: v.string(),
+    limit: v.number(),
+  },
+  returns: v.object({
+    conversations: v.array(
+      v.object({
+        _id: v.id('conversations'),
+        subject: v.optional(v.string()),
+        status: v.optional(v.string()),
+        channel: v.optional(v.string()),
+        lastMessageAt: v.optional(v.number()),
+      }),
+    ),
+    /** True when the scan hit its cap, so the caller can say the reach was
+     *  bounded instead of implying the inbox held nothing older. */
+    truncated: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const access = await resolveAgentReadAccess(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      subject: 'conversations',
+    });
+    // Not a member, or the role denies the subject: no rows, and no scan.
+    if (!access.allowed) return { conversations: [], truncated: false };
+
+    const admin = isAdmin(access.role);
+    // One Better Auth round-trip at most, and only when it can matter. An
+    // admin's decision never consults teams.
+    let teamIds: Set<string> | undefined;
+    const hasTeam = async (teamId: string): Promise<boolean> => {
+      teamIds ??= new Set(await getUserTeamIds(ctx, args.userId));
+      return teamIds.has(teamId);
+    };
+
+    const term = args.term.trim();
+    const lower = term.toLowerCase();
+    const contactIds =
+      term === ''
+        ? new Set<string>()
+        : await matchingContactIds(ctx, {
+            organizationId: args.organizationId,
+            term,
+          });
+
+    const out: Array<Doc<'conversations'>> = [];
+    let scanned = 0;
+    let truncated = false;
+    for await (const conversation of ctx.db
+      .query('conversations')
+      .withIndex('by_org_lastMessageAt', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )
+      .order('desc')) {
+      if (scanned >= SCAN_CAP) {
+        truncated = true;
+        break;
+      }
+      scanned += 1;
+
+      const bySubject =
+        conversation.subject !== undefined &&
+        rowMatches(
+          conversation,
+          // A one-field strategy: `subject` is the only prose a conversation
+          // row carries. Declared inline rather than exported, because nothing
+          // else searches this table.
+          {
+            table: 'conversations',
+            orgIndex: 'by_organizationId',
+            textFields: ['subject'],
+            idFields: [],
+            engine: 'scan',
+          },
+          lower,
+          term,
+          'any',
+        );
+      const byContact =
+        conversation.contactId !== undefined &&
+        contactIds.has(String(conversation.contactId));
+      if (!bySubject && !byContact) continue;
+
+      // The scope decision comes AFTER the text match so an unreadable row
+      // never costs a team lookup it cannot benefit from.
+      const readable = await conversationAssignmentAllows(conversation, {
+        isAdmin: admin,
+        userId: args.userId,
+        hasTeam,
+      });
+      if (!readable) continue;
+
+      out.push(conversation);
+      if (out.length >= args.limit) break;
+    }
+
+    // Built field-by-field rather than by spreading in a `map`: the returns
+    // validator is closed, so only these five fields may cross the wire — a
+    // whole-row spread would both trip `no-map-spread` and risk leaking a
+    // column added to the table later.
+    const conversations = [];
+    for (const c of out) {
+      const row: {
+        _id: typeof c._id;
+        subject?: string;
+        status?: string;
+        channel?: string;
+        lastMessageAt?: number;
+      } = { _id: c._id };
+      if (c.subject !== undefined) row.subject = c.subject;
+      if (c.status !== undefined) row.status = c.status;
+      if (c.channel !== undefined) row.channel = c.channel;
+      if (c.lastMessageAt !== undefined) row.lastMessageAt = c.lastMessageAt;
+      conversations.push(row);
+    }
+    return { conversations, truncated };
+  },
+});

--- a/services/platform/convex/lib/rls/helpers/conversation_assignment.test.ts
+++ b/services/platform/convex/lib/rls/helpers/conversation_assignment.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type ConversationAssignment,
+  conversationAssignmentAllows,
+} from './conversation_assignment';
+
+const NO_TEAMS = { hasTeam: () => false };
+
+function caller(
+  over: Partial<Parameters<typeof conversationAssignmentAllows>[1]> = {},
+) {
+  return { isAdmin: false, userId: 'user_1', ...NO_TEAMS, ...over };
+}
+
+describe('conversationAssignmentAllows', () => {
+  it('grants an admin every conversation', async () => {
+    const unassigned: ConversationAssignment = {};
+    expect(
+      await conversationAssignmentAllows(unassigned, caller({ isAdmin: true })),
+    ).toBe(true);
+  });
+
+  // The most sensitive row, not the least: an inbox row nobody owns yet must
+  // not be org-readable just because it has no assignee to exclude anyone.
+  it('hides an unassigned conversation from a plain member', async () => {
+    expect(await conversationAssignmentAllows({}, caller())).toBe(false);
+  });
+
+  it('grants the individual assignee', async () => {
+    expect(
+      await conversationAssignmentAllows(
+        { assigneeUserId: 'user_1' },
+        caller(),
+      ),
+    ).toBe(true);
+  });
+
+  it('denies a member who is not the individual assignee', async () => {
+    expect(
+      await conversationAssignmentAllows(
+        { assigneeUserId: 'someone_else' },
+        caller(),
+      ),
+    ).toBe(false);
+  });
+
+  it('grants a member of the assigned team', async () => {
+    expect(
+      await conversationAssignmentAllows(
+        { assigneeTeamId: 'team_a' },
+        caller({ hasTeam: (id) => id === 'team_a' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('denies a member of a different team', async () => {
+    expect(
+      await conversationAssignmentAllows(
+        { assigneeTeamId: 'team_a' },
+        caller({ hasTeam: (id) => id === 'team_b' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('grants either side when both stamps are set (the union)', async () => {
+    const both = { assigneeUserId: 'owner_1', assigneeTeamId: 'team_a' };
+    expect(
+      await conversationAssignmentAllows(
+        both,
+        caller({ userId: 'owner_1', hasTeam: () => false }),
+      ),
+    ).toBe(true);
+    expect(
+      await conversationAssignmentAllows(
+        both,
+        caller({ userId: 'nobody', hasTeam: (id) => id === 'team_a' }),
+      ),
+    ).toBe(true);
+  });
+
+  // The laziness `rls_rules.ts` depends on: resolving team ids is a
+  // cross-component Better Auth round-trip, so the cheap branches must decide
+  // without it (see rls_rules.lazy_teams.test.ts).
+  it('never asks about teams when the individual assignee already matches', async () => {
+    const hasTeam = vi.fn(() => true);
+    await conversationAssignmentAllows(
+      { assigneeUserId: 'user_1', assigneeTeamId: 'team_a' },
+      caller({ hasTeam }),
+    );
+    expect(hasTeam).not.toHaveBeenCalled();
+  });
+
+  it('never asks about teams for an admin, or for an unassigned row', async () => {
+    const hasTeam = vi.fn(() => true);
+    await conversationAssignmentAllows(
+      { assigneeTeamId: 'team_a' },
+      caller({ isAdmin: true, hasTeam }),
+    );
+    await conversationAssignmentAllows({}, caller({ hasTeam }));
+    expect(hasTeam).not.toHaveBeenCalled();
+  });
+
+  it('awaits an async team lookup', async () => {
+    expect(
+      await conversationAssignmentAllows(
+        { assigneeTeamId: 'team_a' },
+        caller({ hasTeam: async (id) => id === 'team_a' }),
+      ),
+    ).toBe(true);
+  });
+
+  // Fail-closed: a caller with no identity is not the assignee of anything,
+  // even when the stamp is also absent on that side.
+  it('denies an anonymous caller', async () => {
+    expect(
+      await conversationAssignmentAllows(
+        { assigneeUserId: 'user_1' },
+        caller({ userId: undefined }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/services/platform/convex/lib/rls/helpers/conversation_assignment.ts
+++ b/services/platform/convex/lib/rls/helpers/conversation_assignment.ts
@@ -1,0 +1,80 @@
+/**
+ * Conversation assignment privacy — the ONE definition of who may read a
+ * conversation.
+ *
+ * Conversations are scoped more narrowly than anything else the platform
+ * retrieves. Org membership plus a role is enough for contacts, products and
+ * knowledge entries; it is NOT enough here:
+ *
+ *  - admins and owners see every conversation;
+ *  - a conversation with neither an individual nor a team assignee is
+ *    **admin-triage only** — an unassigned inbox row is not org-readable;
+ *  - otherwise the caller must be the individual assignee, or in the assigned
+ *    team (the union, when both are set).
+ *
+ * This lives on its own so the RLS rule (`rls_rules.ts`) and every non-RLS
+ * reader — the chat assistant's conversations leg, which queries through an
+ * RLS-BYPASSING internal query — evaluate the same rule rather than two copies
+ * of it. A second copy is how a reader ends up subtly wider than the rule it is
+ * supposed to mirror, and the failure mode here is publishing an entire inbox.
+ *
+ * ## Why the team check is a callback
+ *
+ * Resolving a caller's team ids costs a cross-component Better Auth round-trip,
+ * and `rls_rules.ts` deliberately pays it lazily — only when a rule actually
+ * needs it (see `rls_rules.lazy_teams.test.ts`). A predicate taking a resolved
+ * `Set` would force that round-trip for every conversation, including the
+ * majority decided by the admin or individual-assignee branches before teams
+ * matter. So the caller supplies `hasTeam`, and stays in charge of when the
+ * lookup happens: `rls_rules.ts` passes a memoised lazy resolver, while a
+ * per-turn reader that already resolved its teams passes a plain `Set.has`.
+ */
+
+/** The assignment stamps a conversation carries. */
+export interface ConversationAssignment {
+  readonly assigneeUserId?: string | undefined;
+  readonly assigneeTeamId?: string | undefined;
+}
+
+/** Who is asking. */
+export interface ConversationCaller {
+  /** Admin or owner — resolved by the caller via `isAdmin`, never re-derived
+   * here, so there is one role hierarchy in the codebase. */
+  readonly isAdmin: boolean;
+  readonly userId?: string | undefined;
+  /**
+   * Whether the caller belongs to a team. Called at most once, and ONLY for a
+   * conversation whose decision actually depends on it — so a lazy
+   * implementation stays lazy.
+   */
+  readonly hasTeam: (teamId: string) => boolean | Promise<boolean>;
+}
+
+/**
+ * Whether one conversation is readable by one caller.
+ *
+ * Fail-closed: every path that is not an explicit grant returns false, so a new
+ * assignment shape defaults to invisible rather than to org-wide.
+ */
+export async function conversationAssignmentAllows(
+  conversation: ConversationAssignment,
+  caller: ConversationCaller,
+): Promise<boolean> {
+  if (caller.isAdmin) return true;
+
+  const { assigneeUserId, assigneeTeamId } = conversation;
+
+  // Neither stamp: triage state. Deliberately NOT org-readable — an inbox row
+  // nobody owns yet is the most sensitive one, not the least.
+  if (!assigneeUserId && !assigneeTeamId) return false;
+
+  // Cheap branch first, so the individual assignee never pays for the team
+  // lookup even when the row also carries a team.
+  if (assigneeUserId && caller.userId && assigneeUserId === caller.userId) {
+    return true;
+  }
+
+  if (assigneeTeamId && (await caller.hasTeam(assigneeTeamId))) return true;
+
+  return false;
+}

--- a/services/platform/convex/lib/rls/helpers/rls_rules.ts
+++ b/services/platform/convex/lib/rls/helpers/rls_rules.ts
@@ -17,6 +17,7 @@ import type {
   RLSRuleContext,
 } from '../types';
 import { authorizeRls } from './access_control';
+import { conversationAssignmentAllows } from './conversation_assignment';
 import { isAdmin } from './role_helpers';
 
 /**
@@ -60,24 +61,26 @@ export async function rlsRules(
       : Promise.resolve(new Set<string>()));
   };
 
-  // Built-in assignment privacy for conversations: admins/owners see everything;
-  // a conversation with neither person nor team assignee is admin triage only;
-  // otherwise the caller must be the individual owner or a member of the queued
-  // team (the union when both are set). The legacy `conversation_access`
-  // governance row is ignored — privacy is platform behaviour, not a toggle.
+  // Built-in assignment privacy for conversations. The RULE itself lives in
+  // `conversation_assignment.ts` so the chat assistant's conversations leg —
+  // which reads through an RLS-BYPASSING internal query — evaluates the same
+  // predicate instead of a second copy of it; a copy that drifts wider here
+  // publishes an entire inbox. The legacy `conversation_access` governance row
+  // is still ignored: privacy is platform behaviour, not a toggle.
+  //
+  // `hasTeam` keeps the Better Auth round-trip lazy exactly as before — the
+  // predicate calls it only for a conversation whose decision needs it, so the
+  // admin and individual-assignee branches still resolve no teams
+  // (`rls_rules.lazy_teams.test.ts`).
   const passesAssignmentScope = async (
     conversation: Doc<'conversations'>,
     role: MemberRole | undefined,
-  ): Promise<boolean> => {
-    if (isAdmin(role)) return true;
-    const { assigneeUserId, assigneeTeamId } = conversation;
-    if (!assigneeUserId && !assigneeTeamId) return false;
-    if (assigneeUserId && assigneeUserId === user?.userId) return true;
-    if (assigneeTeamId && (await resolveTeamIds()).has(assigneeTeamId)) {
-      return true;
-    }
-    return false;
-  };
+  ): Promise<boolean> =>
+    conversationAssignmentAllows(conversation, {
+      isAdmin: isAdmin(role),
+      userId: user?.userId,
+      hasTeam: async (teamId) => (await resolveTeamIds()).has(teamId),
+    });
 
   // Parent-conversation cache for conversationMessages scoping — one get per
   // conversation per request instead of one per message when a thread loads.


### PR DESCRIPTION
Part of #2992 — the last of the epic's breadth. #3002 has since merged and this branch is rebased onto it, so the diff is now only the conversations leg.

## Why this leg could not be copied from its neighbours

Contacts and products safely hand `organizationId` to an RLS-bypassing internal query, because those tables are org-scope-and-role only. **Conversations are not.** Assignment privacy is narrower than membership, and `resolveAgentReadAccess` returns `allowed: true` for *any* active member — so the role gate the leg already runs is necessary and nowhere near sufficient. Copying the contacts shape here would have published every organization's entire inbox to every member.

## The rule moves somewhere both readers share it

`conversationAssignmentAllows` (`convex/lib/rls/helpers/conversation_assignment.ts`) now holds the one definition:

- admins and owners see everything
- a conversation with **neither** an individual **nor** a team assignee is **admin-triage only** — an unassigned inbox row is not org-readable
- otherwise the caller must be the individual assignee, or in the assigned team (the union when both are set)

`rls_rules.ts` delegates to it instead of keeping its own copy. A second copy is precisely how a reader ends up subtly wider than the rule it is supposed to mirror.

**The drift proof is better than a mock.** Mutating the shared predicate — making unassigned rows readable, or letting any team pass — fails the *existing* `rls_rules.conversation_scope.test.ts` as well as the new tests. The RLS rule demonstrably runs this code, not a copy of it.

**Laziness preserved.** `rls_rules.ts` deliberately pays its Better Auth team round-trip lazily (`rls_rules.lazy_teams.test.ts`). A predicate taking a resolved `Set` would force that round-trip for every conversation, so the team check is a callback and the caller decides when it fires: the predicate invokes it only for a row whose decision depends on it, so the admin and individual-assignee branches still resolve no teams. There's a test asserting exactly that.

## Authority is resolved inside the query

The leg passes **identity only** — `organizationId` and `userId`. Role and team ids are resolved server-side in the query. An `isAdmin` flag travelling in from an action is one refactor away from being wrong in the direction that leaks, and there's a test asserting no such flag is passed.

## Bounded and recency-biased

Conversations carry no text index, so this walks `by_org_lastMessageAt` newest-first and stops at 300, following `convex/chat/search.ts`. A filled scan is reported as such — *"no matches"* and *"no matches among what I could reach"* are different claims, and only the second is honest here.

Contact names are searched without a read per row: one bounded contacts search resolves the term to a set of ids first, then a conversation matches on subject **or** correspondent. That path is scope-checked too, so being findable by contact never becomes a second way in — mutation-tested.

## Tests

18 new assertions: the predicate's own table, plus a convex-test suite driving the **real** query path with seeded `memberMirror`/`teamMemberMirror` — a plain member sees nothing, an admin sees the unassigned row, an assignee sees only theirs, a team member only their team's, and no cross-org reach.

Mutations, all red: dropping the assignment gate, treating every caller as admin, dropping the org scope from the index walk, letting a contact match bypass scope, resolving teams eagerly, and making unassigned rows readable.

**One case deliberately not covered**, stated rather than papered over: a user with *no* membership at all. `resolveAgentReadAccess` falls back to the Better Auth component when no `memberMirror` row exists, and that component is not registered in convex-test. That refusal is covered by the access resolver's own tests; this file proves the scope rules only this leg can get wrong.

## Plan correction

The plan claimed `conversationMessages` has no `by_organizationId` index, and used that to justify deferring body search. It actually has `by_organizationId_and_deliveredAt` — so a bounded body leg needs no schema change when it's wanted. Body search is still out of scope here, but for scope reasons, not index ones.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, `migrations:check` (no migration), platform 75,132 tests.