### PR TITLE
feat(platform): keep archived work searchable and label it as archived

### DIFF
--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -1437,3 +1437,189 @@ describe('rag_search conversations leg', () => {
     ).toBe(false);
   });
 });
+
+describe('rag_search archive context', () => {
+  const ARCHIVED_SCOPE = () => ({
+    teamIds: [],
+    projectIds: ['project_live', 'project_old'],
+    includeHub: true,
+    archivedProjectIds: ['project_old'],
+  });
+
+  function taskRow(over: Record<string, unknown> = {}) {
+    return {
+      _id: 'task_1',
+      title: 'Ship the pricing page',
+      status: 'todo',
+      projectId: 'project_live',
+      ...over,
+    };
+  }
+
+  // An archived task and a live task inside an archived project are different
+  // facts. One key each, so the assistant can tell them apart.
+  it('marks a task that is itself archived', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [KNOWLEDGE_SCOPE_FN]: ARCHIVED_SCOPE,
+        [TASKS_SEARCH_FN]: () => ({
+          page: [taskRow({ archivedAt: 1_700_000_000_000 })],
+          isDone: true,
+          continueCursor: '',
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'pricing page' },
+    })) as Record<string, unknown>;
+    const rows = result.results as Array<Record<string, unknown>>;
+    const task = rows.find((r) => r.kind === 'task');
+    expect(task?.data).toMatchObject({ archived: true });
+    expect(task?.data).not.toHaveProperty('projectArchived');
+  });
+
+  it('marks a live task whose project is archived, and does not call it archived', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [KNOWLEDGE_SCOPE_FN]: ARCHIVED_SCOPE,
+        [TASKS_SEARCH_FN]: () => ({
+          page: [taskRow({ projectId: 'project_old' })],
+          isDone: true,
+          continueCursor: '',
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'pricing page' },
+    })) as Record<string, unknown>;
+    const rows = result.results as Array<Record<string, unknown>>;
+    const task = rows.find((r) => r.kind === 'task');
+    // Still open work nobody closed; only its context is retired.
+    expect(task?.data).toMatchObject({ projectArchived: true });
+    expect(task?.data).not.toHaveProperty('archived');
+  });
+
+  it('returns an archived task rather than filtering it out', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [KNOWLEDGE_SCOPE_FN]: ARCHIVED_SCOPE,
+        [TASKS_SEARCH_FN]: () => ({
+          page: [taskRow({ archivedAt: 1, projectId: 'project_old' })],
+          isDone: true,
+          continueCursor: '',
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'pricing page' },
+    })) as Record<string, unknown>;
+    const rows = result.results as Array<Record<string, unknown>>;
+    const task = rows.find((r) => r.kind === 'task');
+    expect(task).toBeDefined();
+    // Both facts, both true.
+    expect(task?.data).toMatchObject({ archived: true, projectArchived: true });
+  });
+
+  it('carries neither key for a live task in a live project', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [KNOWLEDGE_SCOPE_FN]: ARCHIVED_SCOPE,
+        [TASKS_SEARCH_FN]: () => ({
+          page: [taskRow()],
+          isDone: true,
+          continueCursor: '',
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'pricing page' },
+    })) as Record<string, unknown>;
+    const rows = result.results as Array<Record<string, unknown>>;
+    const task = rows.find((r) => r.kind === 'task');
+    expect(task?.data).not.toHaveProperty('archived');
+    expect(task?.data).not.toHaveProperty('projectArchived');
+  });
+
+  // A document has no archive state of its own, so its project is the only
+  // source of the fact. It is still returned and still citable.
+  it('marks a document filed under an archived project', async () => {
+    searchKnowledgeMock.mockResolvedValueOnce({
+      hits: [
+        {
+          id: '1',
+          corpus: 'documents',
+          text: 'Pricing decided in Q1.',
+          chunkIndex: 0,
+          source: {
+            ref: 'file_1',
+            title: 'Pricing.pdf',
+            url: null,
+            projectId: 'project_old',
+          },
+          fusedScore: 0.5,
+        },
+      ],
+      diagnostics: {},
+    });
+    const { ctx } = createCtx({
+      reads: { [KNOWLEDGE_SCOPE_FN]: ARCHIVED_SCOPE },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'pricing' },
+    })) as Record<string, unknown>;
+    const rows = result.results as Array<Record<string, unknown>>;
+    const doc = rows.find((r) => r.kind === 'document');
+    expect(doc?.ref).toBe('file_1');
+    expect(doc?.data).toMatchObject({ projectArchived: true });
+    expect(doc?.data).not.toHaveProperty('archived');
+  });
+
+  it('adds no data key to a document in a live project', async () => {
+    searchKnowledgeMock.mockResolvedValueOnce({
+      hits: [
+        {
+          id: '1',
+          corpus: 'documents',
+          text: 'Current pricing.',
+          chunkIndex: 0,
+          source: {
+            ref: 'file_2',
+            title: 'Pricing.pdf',
+            url: null,
+            projectId: 'project_live',
+          },
+          fusedScore: 0.5,
+        },
+      ],
+      diagnostics: {},
+    });
+    const { ctx } = createCtx({
+      reads: { [KNOWLEDGE_SCOPE_FN]: ARCHIVED_SCOPE },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'pricing' },
+    })) as Record<string, unknown>;
+    const rows = result.results as Array<Record<string, unknown>>;
+    const doc = rows.find((r) => r.kind === 'document');
+    expect(doc).toBeDefined();
+    expect(doc).not.toHaveProperty('data');
+  });
+});

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -90,6 +90,32 @@ const SNIPPET_CHARS = 500;
  */
 const WORK_REF_PREFIX = { task: 'task:', project: 'project:' } as const;
 
+/**
+ * The two archive facts a result can carry, as data.
+ *
+ * `archived` means the result itself is archived. `projectArchived` means the
+ * project it belongs to is archived, which is a different fact: a live task in
+ * a retired project may still be real work nobody closed, while an archived
+ * task is not. Both can be true at once, and each key is omitted when false so
+ * a live result in a live project carries neither.
+ *
+ * Nothing here decides what the assistant says about them. They sit beside
+ * `status` and `priority` as fields it may use, which is why a document under a
+ * retired project can be cited with that context instead of being withheld.
+ */
+function archiveFlags(args: {
+  archivedAt?: number | undefined;
+  projectId?: string | null | undefined;
+  archivedProjectIds: ReadonlySet<string>;
+}): { archived?: true; projectArchived?: true } {
+  return {
+    ...(args.archivedAt !== undefined ? { archived: true as const } : {}),
+    ...(args.projectId != null && args.archivedProjectIds.has(args.projectId)
+      ? { projectArchived: true as const }
+      : {}),
+  };
+}
+
 /** Task statuses `rag_search` accepts, plus the `open` shorthand. Mirrors the
  * enum in `RAG_SEARCH_SCHEMA`; a value outside it is dropped rather than
  * refused, so a model guessing never fails the whole search. */
@@ -368,6 +394,8 @@ export function createChatToolExecutor(
     // model; keyword (BM25) hits are never floored.
     if (documentsAllowed) {
       try {
+        const docAccess = await knowledgeAccess();
+        const archivedForDocs = new Set(docAccess.archivedProjectIds ?? []);
         const knowledge = await searchKnowledge(ctx, {
           organizationId: who.organizationId,
           orgSlug: slug,
@@ -375,10 +403,17 @@ export function createChatToolExecutor(
           corpus: 'all',
           limit,
           minSimilarity: RAG_SEARCH_MIN_SIMILARITY,
-          access: await knowledgeAccess(),
+          access: docAccess,
         });
         for (const hit of knowledge.hits) {
           const score = hit.rerankScore ?? hit.fusedScore;
+          // A document has no archive state of its own — only its project
+          // does, so `projectArchived` is the only flag it can carry. It is
+          // still returned and still citable; the label is the context.
+          const flags = archiveFlags({
+            projectId: hit.source.projectId,
+            archivedProjectIds: archivedForDocs,
+          });
           results.push({
             kind: hit.corpus === 'documents' ? 'document' : 'web-page',
             title: hit.source.title ?? hit.source.ref,
@@ -387,6 +422,7 @@ export function createChatToolExecutor(
             snippet: clip(hit.text, SNIPPET_CHARS),
             ...(hit.offset !== undefined ? { offset: hit.offset } : {}),
             score: Math.round(score * 1000) / 1000,
+            ...(flags.projectArchived ? { data: flags } : {}),
           });
         }
         sources.documents = knowledge.hits.some((h) => h.corpus === 'documents')
@@ -549,6 +585,7 @@ export function createChatToolExecutor(
     if (tasksAllowed || projectsAllowed) {
       const access = await knowledgeAccess();
       const projectIds = [...access.projectIds];
+      const archivedProjectIds = new Set(access.archivedProjectIds ?? []);
 
       // Leg 6 — tasks (question-aware; open/status filter).
       if (tasksAllowed) {
@@ -581,6 +618,12 @@ export function createChatToolExecutor(
               ...(task.assigneeType ? { assigneeType: task.assigneeType } : {}),
               ...(task.projectId ? { projectId: String(task.projectId) } : {}),
               ...(task.dueDate ? { dueDate: task.dueDate } : {}),
+              ...archiveFlags({
+                archivedAt: task.archivedAt,
+                projectId:
+                  task.projectId != null ? String(task.projectId) : null,
+                archivedProjectIds,
+              }),
             },
           });
         }
@@ -619,6 +662,12 @@ export function createChatToolExecutor(
               // question about a project usually means. Undefined reads as 0.
               openTasks: project.openTaskCount ?? 0,
               doneTasks: project.doneTaskCount ?? 0,
+              // `projectArchived` would be redundant here: this row is the
+              // project, so its own `archived` says it.
+              ...archiveFlags({
+                archivedAt: project.archivedAt,
+                archivedProjectIds,
+              }),
             },
           });
         }

--- a/services/platform/convex/documents/access.test.ts
+++ b/services/platform/convex/documents/access.test.ts
@@ -198,6 +198,64 @@ describe('resolveKnowledgeAccessForUser', () => {
     ]);
   });
 
+  it('names which readable projects are archived, without dropping them', async () => {
+    memberWithRole('member');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const withArchived = {
+      ...projects,
+      retired: {
+        _id: 'retired',
+        organizationId: 'org1',
+        teamId: 'team-a',
+        archivedAt: 1_700_000_000_000,
+      },
+    };
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx(withArchived),
+      orgArgs,
+    );
+    // Still readable: an archived project's material stays searchable.
+    expect([...access.projectIds].sort()).toEqual([
+      'mine',
+      'orgWide',
+      'retired',
+      'shared',
+    ]);
+    // And separately labelled, so a result can say the project is retired.
+    expect(access.archivedProjectIds).toEqual(['retired']);
+  });
+
+  it('reports no archived projects when none are', async () => {
+    memberWithRole('member');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx(projects),
+      orgArgs,
+    );
+    expect(access.archivedProjectIds).toEqual([]);
+  });
+
+  it('never names an archived project the caller cannot read', async () => {
+    memberWithRole('member');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx({
+        ...projects,
+        foreignRetired: {
+          _id: 'foreignRetired',
+          organizationId: 'org1',
+          teamId: 'team-z',
+          archivedAt: 1,
+        },
+      }),
+      orgArgs,
+    );
+    // A subset of projectIds, always. Otherwise the label would leak the
+    // existence of a project the caller has no access to.
+    expect(access.archivedProjectIds).toEqual([]);
+    expect(access.projectIds).not.toContain('foreignRetired');
+  });
+
   it('gives org admins every project', async () => {
     memberWithRole('admin');
     mockGetUserTeamIds.mockResolvedValue([]);
@@ -221,7 +279,12 @@ describe('resolveKnowledgeAccessForUser', () => {
       orgArgs,
     );
     warn.mockRestore();
-    expect(access).toEqual({ teamIds: [], projectIds: [], includeHub: false });
+    expect(access).toEqual({
+      teamIds: [],
+      projectIds: [],
+      includeHub: false,
+      archivedProjectIds: [],
+    });
   });
 
   it('fails closed for a disabled member', async () => {
@@ -231,7 +294,12 @@ describe('resolveKnowledgeAccessForUser', () => {
       createMockCtx(projects),
       orgArgs,
     );
-    expect(access).toEqual({ teamIds: [], projectIds: [], includeHub: false });
+    expect(access).toEqual({
+      teamIds: [],
+      projectIds: [],
+      includeHub: false,
+      archivedProjectIds: [],
+    });
   });
 });
 

--- a/services/platform/convex/documents/access.ts
+++ b/services/platform/convex/documents/access.ts
@@ -231,6 +231,15 @@ export interface ResolvedKnowledgeAccess {
   teamIds: string[];
   projectIds: string[];
   includeHub: boolean;
+  /**
+   * Which of `projectIds` are archived. NOT a narrowing of what is
+   * retrievable: an archived project's material stays searchable and citable.
+   * It travels so a result can be labelled as belonging to a retired project,
+   * and it is a subset of `projectIds` — a project the caller cannot read is
+   * absent from both. Optional: absent reads as "none known", which
+   * under-labels rather than over-filters.
+   */
+  archivedProjectIds?: string[];
 }
 
 /** Fail-closed scope: no hub, no teams, no projects — a search sees nothing. */
@@ -238,6 +247,7 @@ export const NO_KNOWLEDGE_ACCESS: ResolvedKnowledgeAccess = {
   teamIds: [],
   projectIds: [],
   includeHub: false,
+  archivedProjectIds: [],
 };
 
 /**
@@ -275,6 +285,8 @@ export async function resolveKnowledgeAccessForUser(
   ];
 
   const projectIds: string[] = [];
+  // Collected in the SAME walk, so labelling costs no extra reads.
+  const archivedProjectIds: string[] = [];
   const projects = ctx.db
     .query('projects')
     .withIndex('by_organization', (q) =>
@@ -283,8 +295,9 @@ export async function resolveKnowledgeAccessForUser(
   for await (const project of projects) {
     if (hasProjectAccess(project, context.teamIds, context.role)) {
       projectIds.push(project._id);
+      if (project.archivedAt) archivedProjectIds.push(project._id);
     }
   }
 
-  return { teamIds, projectIds, includeHub: true };
+  return { teamIds, projectIds, includeHub: true, archivedProjectIds };
 }

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -363,6 +363,7 @@ export const resolveKnowledgeAccess = internalQuery({
     teamIds: v.array(v.string()),
     projectIds: v.array(v.string()),
     includeHub: v.boolean(),
+    archivedProjectIds: v.optional(v.array(v.string())),
   }),
   handler: async (ctx, args): Promise<ResolvedKnowledgeAccess> => {
     return await resolveKnowledgeAccessForUser(ctx, args);
@@ -383,6 +384,7 @@ export const filterRetrievableRagFileIds = internalQuery({
         teamIds: v.array(v.string()),
         projectIds: v.array(v.string()),
         includeHub: v.boolean(),
+        archivedProjectIds: v.optional(v.array(v.string())),
         threadIds: v.optional(v.array(v.string())),
       }),
     ),

--- a/services/platform/convex/knowledge/corpus.test.ts
+++ b/services/platform/convex/knowledge/corpus.test.ts
@@ -228,7 +228,10 @@ describe('the documents corpus is scoped to one organization', () => {
     });
     const statement = corpusStatements(sent)[0];
     expect(statement.text).not.toContain('d.team_id');
-    expect(statement.text).not.toContain('d.project_id');
+    // The PREDICATE, not the column. `d.project_id` is now also SELECTed, so a
+    // caller can be told a hit belongs to a retired project; that is not a
+    // scope clause and must not read as one.
+    expect(statement.text).not.toContain('d.project_id = ANY');
   });
 
   it('passes the query vector as a parameter, never as interpolated text', async () => {

--- a/services/platform/convex/knowledge/corpus.ts
+++ b/services/platform/convex/knowledge/corpus.ts
@@ -62,6 +62,10 @@ interface CorpusRow {
   ref: string;
   title: string | null;
   url: string | null;
+  /** The document's project scope stamp; NULL for an org-hub document and for
+   * every web page. Selected so a caller can label a hit as belonging to a
+   * retired project without a second read. */
+  project_id: string | null;
   modified_at: Date | null;
   /** Char position of the chunk within the ref's fetchable text, cast to
    * text (SUM is bigint); NULL when it cannot be established. */
@@ -95,6 +99,7 @@ export class DocumentCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
+             d.project_id,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
              (SELECT COALESCE(SUM(length(c2.core_content)), 0)
                 FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
@@ -126,6 +131,7 @@ export class DocumentCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
+             d.project_id,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
              (SELECT COALESCE(SUM(length(c2.core_content)), 0)
                 FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
@@ -249,6 +255,7 @@ export class WebCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
+             NULL::text AS project_id,
              u.last_crawled_at AS modified_at,
              CASE WHEN c.core_content <> ''
                    AND position(c.core_content IN u.content) > 0
@@ -277,6 +284,7 @@ export class WebCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
+             NULL::text AS project_id,
              u.last_crawled_at AS modified_at,
              CASE WHEN c.core_content <> ''
                    AND position(c.core_content IN u.content) > 0
@@ -381,6 +389,7 @@ function toHits(
         ref: row.ref,
         title: row.title,
         url: row.url,
+        projectId: row.project_id,
         modifiedAt: row.modified_at ? row.modified_at.getTime() : null,
       },
       score: row.score,

--- a/services/platform/convex/sandbox/workspace_access.test.ts
+++ b/services/platform/convex/sandbox/workspace_access.test.ts
@@ -265,6 +265,7 @@ describe('resolveKnowledgeToolAccess', () => {
         teamIds: ['team-x', 'team-y'],
         projectIds: [projectId],
         includeHub: true,
+        archivedProjectIds: [],
       },
     });
   });
@@ -289,6 +290,7 @@ describe('resolveKnowledgeToolAccess', () => {
         teamIds: ['team-x'],
         projectIds: [projectId],
         includeHub: true,
+        archivedProjectIds: [],
       },
     });
   });
@@ -307,7 +309,12 @@ describe('resolveKnowledgeToolAccess', () => {
     );
     expect(access).toEqual({
       allowed: true,
-      scope: { teamIds: [], projectIds: [], includeHub: true },
+      scope: {
+        teamIds: [],
+        projectIds: [],
+        includeHub: true,
+        archivedProjectIds: [],
+      },
     });
   });
 
@@ -359,6 +366,7 @@ describe('resolveKnowledgeToolAccess', () => {
         teamIds: [`org_${ORG}`, 'team-mine'],
         projectIds: [orgWideProject],
         includeHub: true,
+        archivedProjectIds: [],
       },
     });
   });

--- a/services/platform/convex/sandbox/workspace_access.ts
+++ b/services/platform/convex/sandbox/workspace_access.ts
@@ -192,6 +192,7 @@ export const resolveKnowledgeToolAccess = internalQuery({
         teamIds: v.array(v.string()),
         projectIds: v.array(v.string()),
         includeHub: v.boolean(),
+        archivedProjectIds: v.optional(v.array(v.string())),
       }),
     }),
     v.object({
@@ -225,13 +226,26 @@ export const resolveKnowledgeToolAccess = internalQuery({
           teamIds: getProjectTeamIds(binding.project),
           projectIds: [binding.project._id],
           includeHub: true,
+          // The bound project itself, when it is archived. A bound session
+          // keeps reading a retired project's material; the flag only lets a
+          // result say so.
+          archivedProjectIds: binding.project.archivedAt
+            ? [binding.project._id]
+            : [],
         },
       };
     }
     if (binding.kind === 'org_run') {
       return {
         allowed: true,
-        scope: { teamIds: [], projectIds: [], includeHub: true },
+        // An org-level run has no project scope, so no project can be
+        // archived within it.
+        scope: {
+          teamIds: [],
+          projectIds: [],
+          includeHub: true,
+          archivedProjectIds: [],
+        },
       };
     }
     if (args.userId !== undefined) {

--- a/services/platform/convex/tasks/search_for_chat.test.ts
+++ b/services/platform/convex/tasks/search_for_chat.test.ts
@@ -1,0 +1,221 @@
+// Drives the REAL tasks and projects legs through convex-test. The point of
+// this file is one behaviour: an archived task or project is RETURNED, not
+// filtered. The chat-level tests mock this query away, so without this the
+// change is unverified where it actually happens.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'tasks';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_task_search';
+type T = TestConvex<typeof schema>;
+
+interface Seeded {
+  live: Id<'projects'>;
+  retired: Id<'projects'>;
+}
+
+async function seed(t: T): Promise<Seeded> {
+  return t.run(async (ctx) => {
+    const live = await ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Live project',
+      createdBy: 'user_1',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const retired = await ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Retired project',
+      createdBy: 'user_1',
+      createdAt: 0,
+      updatedAt: 0,
+      archivedAt: 1_700_000_000_000,
+    });
+    // Every title shares "pricing", so only archive state differs.
+    await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      title: 'Pricing live task',
+      status: 'todo',
+      rank: 'a',
+      projectId: live,
+      createdBy: 'user_1',
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      title: 'Pricing archived task',
+      status: 'todo',
+      rank: 'b',
+      projectId: live,
+      createdBy: 'user_1',
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+      archivedAt: 1_700_000_000_000,
+    });
+    await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      title: 'Pricing task in retired project',
+      status: 'todo',
+      rank: 'c',
+      projectId: retired,
+      createdBy: 'user_1',
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    return { live, retired };
+  });
+}
+
+describe('searchTasksForChat — archived rows are returned', () => {
+  let t: T;
+  let ids: Seeded;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    ids = await seed(t);
+  });
+
+  it('returns an archived task alongside a live one', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live), String(ids.retired)],
+        term: 'pricing',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    const titles = result.page.map((task) => task.title).sort();
+    expect(titles).toEqual([
+      'Pricing archived task',
+      'Pricing live task',
+      'Pricing task in retired project',
+    ]);
+  });
+
+  it('carries archivedAt through, so the caller can label it', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        term: 'pricing',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    const archived = result.page.find(
+      (task) => task.title === 'Pricing archived task',
+    );
+    expect(archived?.archivedAt).toBeDefined();
+  });
+
+  // Archive is orthogonal to the status filter. "Open" still means not done and
+  // not cancelled, and an archived task can be either.
+  it('still honours the status filter over archived rows', async () => {
+    await t.run(async (ctx) => {
+      await ctx.db.insert('tasks', {
+        organizationId: ORG,
+        title: 'Pricing archived and done',
+        status: 'done',
+        rank: 'd',
+        projectId: ids.live,
+        createdBy: 'user_1',
+        createdByType: 'user',
+        createdAt: 0,
+        updatedAt: 0,
+        archivedAt: 1,
+      });
+    });
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        term: 'pricing',
+        status: 'open',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    const titles = result.page.map((task) => task.title);
+    expect(titles).not.toContain('Pricing archived and done');
+    expect(titles).toContain('Pricing archived task');
+  });
+
+  it('still hides a task whose project the caller cannot read', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        term: 'pricing',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.page.map((task) => task.title)).not.toContain(
+      'Pricing task in retired project',
+    );
+  });
+});
+
+describe('searchProjectsForChat — archived projects are returned', () => {
+  let t: T;
+  let ids: Seeded;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    ids = await seed(t);
+  });
+
+  it('returns an archived project alongside a live one', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchProjectsForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live), String(ids.retired)],
+        term: 'project',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    const names = result.page.map((project) => project.name).sort();
+    expect(names).toEqual(['Live project', 'Retired project']);
+  });
+
+  it('still hides a project the caller cannot read', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchProjectsForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        term: 'project',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.page.map((project) => project.name)).toEqual([
+      'Live project',
+    ]);
+  });
+});

--- a/services/platform/convex/tasks/search_for_chat.ts
+++ b/services/platform/convex/tasks/search_for_chat.ts
@@ -20,9 +20,13 @@
  *
  * A task whose `projectId` is absent is org-level work and readable by any
  * member — matching how `hasProjectAccess` treats a project with no teams.
- * Archived rows are excluded: every other surface excludes them by default
- * (`projects/queries.ts` uses `by_organization_archived`), and a retired
- * project's work should not answer a question about current work.
+ *
+ * Archived rows are RETURNED, not filtered. A retired project is often still
+ * the only record of a decision, so hiding it makes chat worse at exactly the
+ * questions history answers. The caller labels them instead: `archivedAt` on
+ * the row itself, and the project's archive state from
+ * `KnowledgeAccessScope.archivedProjectIds`. What the assistant then says is
+ * its own choice, not a fixed sentence in code.
  */
 
 import { v } from 'convex/values';
@@ -62,7 +66,6 @@ export const searchTasksForChat = internalQuery({
       paginationOpts: args.paginationOpts,
       matchMode: 'any',
       accessFilter: (task: Doc<'tasks'>) => {
-        if (task.archivedAt) return false;
         // Project-less work is org-level and readable; anything owned by a
         // project the caller cannot read is invisible, exactly as its parent is.
         if (task.projectId != null && !readable.has(String(task.projectId))) {
@@ -93,7 +96,7 @@ export const searchProjectsForChat = internalQuery({
       paginationOpts: args.paginationOpts,
       matchMode: 'any',
       accessFilter: (project: Doc<'projects'>) =>
-        !project.archivedAt && readable.has(String(project._id)),
+        readable.has(String(project._id)),
     });
   },
 });

--- a/services/platform/lib/knowledge/types.ts
+++ b/services/platform/lib/knowledge/types.ts
@@ -87,6 +87,12 @@ export interface KnowledgeSource {
   /** Present for web pages. */
   readonly url?: string | null;
   readonly modifiedAt?: number | null;
+  /**
+   * The project the document is filed under, from the corpus row's scope
+   * stamp. Null for an org-hub document and for a web page. Carried so a
+   * caller can tell whether the project is archived without a second read.
+   */
+  readonly projectId?: string | null;
 }
 
 /** A hit after fusion, carrying the rank-based score it was ordered by. */
@@ -122,6 +128,16 @@ export interface KnowledgeAccessScope {
   readonly projectIds: readonly string[];
   /** Whether org-hub documents (no team, no project) are visible. */
   readonly includeHub: boolean;
+  /**
+   * Which of `projectIds` are archived, for LABELLING only.
+   *
+   * Retrieval is unchanged by it: an archived project's documents stay
+   * searchable and citable, because a retired project is often still the only
+   * source on its topic. Consumers use it to mark a result as belonging to a
+   * retired project, so an answer can say so. Absent reads as "none known",
+   * which under-labels rather than over-filters.
+   */
+  readonly archivedProjectIds?: readonly string[];
   /**
    * Chat threads whose thread-bound uploads the caller may retrieve — the
    * turn's own thread, derived server-side from the owned-thread check.


### PR DESCRIPTION
An archived project's tasks, and the project itself, were filtered out of `rag_search`. They are returned now, labelled as archived, so chat can cite a retired project and say it is retired.

## Why

Archiving a project made its work invisible to chat. A retired project is often the only record of a decision, so hiding it makes chat worse at the questions history answers.

The exclusion was mine, in #3002 (`convex/tasks/search_for_chat.ts:65,96`). It followed the plan, which assumed archive should hide.

## What changed

Two fields on a search result, because they are two different facts:

- `archived` — the result itself is archived
- `projectArchived` — the project it belongs to is archived

A live task in a retired project may still be work nobody closed. An archived task is not. Both fields can be true at once, and each is omitted when false, so a live result in a live project carries neither.

A document has no archive state of its own. `projectArchived` is the only field it can carry, which is accurate rather than a gap.

Nothing decides what the assistant says. The fields sit beside `status` and `priority` as data it may use. No sentence is appended, and no rule is added to the persona — `lib/chat/assistant.test.ts` forbids that class of rule there.

Two supporting changes:

- `resolveKnowledgeAccess` returns `archivedProjectIds`, collected in the walk it already runs over every org project. Labelling costs no extra reads.
- `KnowledgeSource` carries `projectId`, selected from the corpus row's existing scope stamp. Web pages select `NULL`.

## Risk

`archivedProjectIds` is always a subset of `projectIds`. A project the caller cannot read appears in neither, so the field cannot leak that such a project exists. There is a test for it.

Retrieval scope is otherwise unchanged. The field is used for labelling only, never to narrow what a search returns.

## Tests

Three layers, because the first draft tested only the top one:

- the chat legs label correctly, including a live task in an archived project
- `searchTasksForChat` and `searchProjectsForChat` return archived rows through convex-test
- `resolveKnowledgeAccessForUser` collects archived ids and keeps them a subset

Mutations that turn tests red: collapsing the two fields into one, re-excluding archived tasks, re-excluding archived projects, dropping the archived-id collection, and labelling documents unconditionally.

Two mutations survived the first round — re-excluding archived tasks, and dropping the id collection. Both survived because the chat tests mock the query and the resolver. That is what the two lower layers now cover.

One existing assertion changed rather than being weakened. `corpus.test.ts` asserted the SQL contains no `d.project_id` for an org-wide caller, meaning no scope clause. The column is now selected either way, so the assertion checks for the predicate `d.project_id = ANY`.

## Scope

Closes the retrieval half of #2999. The issue also asked whether archive should exclude; that is now answered as no, with labelling instead.

Not included: any UI change. The Documents list and the projects list still hide archived rows by their own rules, which is unaffected.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, `migrations:check` (no migration), platform 75,158 tests.
