### PR TITLE
fix(platform): answer board questions by listing, not only by matching

### DIFF
--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -1700,6 +1700,39 @@ describe('rag_search reports a listing as a listing', () => {
     expect((result.sources as Record<string, string>).tasks).toContain(
       'listed',
     );
+    // The walk finished, so the leg may claim it saw everything in scope.
+    expect((result.sources as Record<string, string>).tasks).toContain(
+      'in scope',
+    );
+    expect((result.sources as Record<string, string>).tasks).not.toContain(
+      'not the whole set',
+    );
+  });
+
+  it('says the listing is partial when the walk hit its scan budget', async () => {
+    // `isDone: false` means the scan budget stopped the walk before the index
+    // ended, which happens to a caller who can read few projects. Reporting
+    // "these are the tasks in scope" would overclaim.
+    const { ctx } = createCtx({
+      reads: {
+        [TASKS_SEARCH_FN]: () => ({
+          page: [{ _id: 'task_1', title: 'Verify billing', status: 'todo' }],
+          isDone: false,
+          continueCursor: '',
+          listed: true,
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'are there any open tasks' },
+    })) as Record<string, unknown>;
+    const tasks = (result.sources as Record<string, string>).tasks;
+    expect(tasks).toContain('listed');
+    expect(tasks).toContain('most recently updated');
+    expect(tasks).toContain('not the whole set');
   });
 
   it('says searched when the words did match', async () => {

--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -1334,15 +1334,69 @@ describe('rag_fetch work refs', () => {
     expect(result.status).toBe('unavailable');
   });
 
-  it('tells the model a project ref has nothing extra to fetch', async () => {
-    const { ctx } = createCtx();
+  // Was an invalid_args refusal. A real turn called it four times and spent its
+  // whole step budget on the refusals, so it now answers the question the model
+  // was asking: which tasks are on this project.
+  it("returns a project ref's tasks", async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [KNOWLEDGE_SCOPE_FN]: () => ({
+          teamIds: [],
+          projectIds: ['project_1'],
+          includeHub: true,
+          archivedProjectIds: [],
+        }),
+        [TASKS_SEARCH_FN]: () => ({
+          page: [
+            { _id: 'task_1', title: 'Verify billing', status: 'todo' },
+            { _id: 'task_2', title: 'Draft pricing', status: 'in_progress' },
+          ],
+          isDone: true,
+          continueCursor: '',
+          listed: true,
+        }),
+      },
+    });
     const executor = await makeExecutor(ctx);
     const result = (await executor.execute({
       id: 'c1',
       name: 'rag_fetch',
       input: { ref: 'project:project_1' },
     })) as Record<string, unknown>;
-    expect(result.status).toBe('invalid_args');
+
+    expect(result.status).toBe('ok');
+    expect(result.kind).toBe('project');
+    const tasks = result.tasks as Array<Record<string, unknown>>;
+    expect(tasks.map((t) => t.title)).toEqual([
+      'Verify billing',
+      'Draft pricing',
+    ]);
+    // Each task carries its own ref, so depth is one more fetch away.
+    expect(tasks[0].ref).toBe('task:task_1');
+  });
+
+  it('refuses a project ref outside the readable set, as not_found', async () => {
+    const { ctx, runQuery } = createCtx({
+      reads: {
+        [KNOWLEDGE_SCOPE_FN]: () => ({
+          teamIds: [],
+          projectIds: ['project_mine'],
+          includeHub: true,
+          archivedProjectIds: [],
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_fetch',
+      input: { ref: 'project:project_theirs' },
+    })) as Record<string, unknown>;
+    expect(result.status).toBe('not_found');
+    // Refused before reading any task.
+    expect(
+      runQuery.mock.calls.some(([ref]) => fnName(ref) === TASKS_SEARCH_FN),
+    ).toBe(false);
   });
 });
 
@@ -1621,5 +1675,81 @@ describe('rag_search archive context', () => {
     const doc = rows.find((r) => r.kind === 'document');
     expect(doc).toBeDefined();
     expect(doc).not.toHaveProperty('data');
+  });
+});
+
+describe('rag_search reports a listing as a listing', () => {
+  it('says the tasks source listed rather than matched', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [TASKS_SEARCH_FN]: () => ({
+          page: [{ _id: 'task_1', title: 'Verify billing', status: 'todo' }],
+          isDone: true,
+          continueCursor: '',
+          listed: true,
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'are there any open tasks' },
+    })) as Record<string, unknown>;
+    // The model must not read a list as "these matched your words".
+    expect((result.sources as Record<string, string>).tasks).toContain(
+      'listed',
+    );
+  });
+
+  it('says searched when the words did match', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [TASKS_SEARCH_FN]: () => ({
+          page: [{ _id: 'task_1', title: 'Verify billing', status: 'todo' }],
+          isDone: true,
+          continueCursor: '',
+          listed: false,
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'billing' },
+    })) as Record<string, unknown>;
+    expect((result.sources as Record<string, string>).tasks).toBe('searched');
+  });
+
+  it('surfaces a conversation assignment, and marks an unassigned one', async () => {
+    const { ctx } = createCtx({
+      reads: {
+        [CONVERSATIONS_SEARCH_FN]: () => ({
+          conversations: [
+            {
+              _id: 'conv_1',
+              subject: 'Queued work',
+              assigneeTeamId: 'team_support',
+            },
+            { _id: 'conv_2', subject: 'Nobody owns this' },
+          ],
+          truncated: false,
+        }),
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { query: 'work' },
+    })) as Record<string, unknown>;
+    const rows = (result.results as Array<Record<string, unknown>>).filter(
+      (r) => r.kind === 'conversation',
+    );
+    expect(rows[0].data).toMatchObject({ assigneeTeamId: 'team_support' });
+    // Unassigned is a state an admin acts on, so it is stated rather than left
+    // as an absent field the model has to infer from.
+    expect(rows[1].data).toMatchObject({ unassigned: true });
   });
 });

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -90,6 +90,10 @@ const SNIPPET_CHARS = 500;
  */
 const WORK_REF_PREFIX = { task: 'task:', project: 'project:' } as const;
 
+/** Tasks returned when a project ref is fetched. Enough to answer "what is on
+ *  this project?", small enough that a model reads the whole list. */
+const PROJECT_TASKS_LIMIT = 25;
+
 /**
  * The two archive facts a result can carry, as data.
  *
@@ -628,7 +632,11 @@ export function createChatToolExecutor(
           });
         }
         sources.tasks =
-          tasks.page.length > 0 ? 'searched' : 'searched (no matches)';
+          tasks.page.length === 0
+            ? 'searched (no matches)'
+            : tasks.listed
+              ? 'listed (nothing matched those words, so these are the tasks in scope)'
+              : 'searched';
       } else {
         sources.tasks = 'access denied for your role';
       }
@@ -672,7 +680,11 @@ export function createChatToolExecutor(
           });
         }
         sources.projects =
-          projects.page.length > 0 ? 'searched' : 'searched (no matches)';
+          projects.page.length === 0
+            ? 'searched (no matches)'
+            : projects.listed
+              ? 'listed (nothing matched those words, so these are the projects in scope)'
+              : 'searched';
       } else {
         sources.projects = 'access denied for your role';
       }
@@ -704,6 +716,16 @@ export function createChatToolExecutor(
           data: {
             ...(conversation.status ? { status: conversation.status } : {}),
             ...(conversation.channel ? { channel: conversation.channel } : {}),
+            ...(conversation.assigneeUserId
+              ? { assigneeUserId: conversation.assigneeUserId }
+              : {}),
+            ...(conversation.assigneeTeamId
+              ? { assigneeTeamId: conversation.assigneeTeamId }
+              : {}),
+            ...(conversation.assigneeUserId || conversation.assigneeTeamId
+              ? {}
+              : // Unassigned is a real state an admin acts on, not missing data.
+                { unassigned: true }),
             ...(conversation.lastMessageAt
               ? { lastMessageAt: conversation.lastMessageAt }
               : {}),
@@ -862,16 +884,71 @@ export function createChatToolExecutor(
       };
     }
 
+    // A project ref answers "the row says 8 open tasks — which ones?". It used
+    // to refuse with invalid_args, and a turn was observed calling it four
+    // times and spending its whole step budget on the refusals. The model was
+    // reaching for the right thing.
     if (ref.startsWith(WORK_REF_PREFIX.project)) {
-      const result: ToolFailure = {
-        status: 'invalid_args',
+      const projectId = ref.slice(WORK_REF_PREFIX.project.length);
+      if (!(await readAllowed('tasks'))) {
+        const result: ToolFailure = {
+          status: 'unavailable',
+          message:
+            'Your role does not permit reading tasks in this organization.',
+        };
+        await recordDispatch('rag_fetch', result.status, result.message);
+        return result;
+      }
+      const missing: ToolFailure = {
+        status: 'not_found',
         message:
-          'A project ref carries no extra text to fetch — the rag_search ' +
-          'result already holds everything (name, key, open and done task ' +
-          'counts). To read a project’s work, rag_search its tasks.',
+          'No project with that ref is readable in this organization. Re-run ' +
+          'rag_search and use a ref from its results.',
       };
-      await recordDispatch('rag_fetch', result.status, result.message);
-      return result;
+      const access = await knowledgeAccess();
+      // A ref is not a capability here either: the project must still be in
+      // the caller's readable set on THIS turn.
+      if (!access.projectIds.includes(projectId)) {
+        await recordDispatch('rag_fetch', missing.status, missing.message);
+        return missing;
+      }
+      let tasks;
+      try {
+        tasks = await ctx.runQuery(
+          internal.tasks.search_for_chat.searchTasksForChat,
+          {
+            organizationId: who.organizationId,
+            projectIds: [...access.projectIds],
+            projectId: toId<'projects'>(projectId),
+            term: '',
+            paginationOpts: { numItems: PROJECT_TASKS_LIMIT, cursor: null },
+          },
+        );
+      } catch {
+        // A malformed id fails arg validation; it reads as the same not_found.
+        await recordDispatch('rag_fetch', missing.status, missing.message);
+        return missing;
+      }
+      await recordDispatch('rag_fetch', 'ok');
+      return {
+        status: 'ok',
+        kind: 'project',
+        ref,
+        tasks: tasks.page.map((task) => ({
+          ref: `${WORK_REF_PREFIX.task}${String(task._id)}`,
+          title: task.title,
+          status: task.status,
+          ...(task.priority ? { priority: task.priority } : {}),
+          ...archiveFlags({
+            archivedAt: task.archivedAt,
+            projectId,
+            archivedProjectIds: new Set(access.archivedProjectIds ?? []),
+          }),
+        })),
+        // A capped list must say it is capped, or "that is all of them" is a
+        // claim the tool never made.
+        truncated: tasks.page.length >= PROJECT_TASKS_LIMIT,
+      };
     }
 
     if (isUrl) {

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -90,6 +90,21 @@ const SNIPPET_CHARS = 500;
  */
 const WORK_REF_PREFIX = { task: 'task:', project: 'project:' } as const;
 
+/**
+ * What a listing leg reports as its source.
+ *
+ * A listing walks a bounded number of rows and filters as it goes, so a caller
+ * who can read little may exhaust that budget before the index ends. Saying
+ * "these are the tasks in scope" would then overclaim: the rows returned are
+ * the most recently updated ones the walk reached, not the whole board. Mirrors
+ * how the conversations leg names its own bound.
+ */
+function listedSource(subject: string, complete: boolean): string {
+  return complete
+    ? `listed (nothing matched those words, so these are the ${subject} in scope)`
+    : `listed (nothing matched those words; these are the most recently updated ${subject} in scope, not the whole set)`;
+}
+
 /** Tasks returned when a project ref is fetched. Enough to answer "what is on
  *  this project?", small enough that a model reads the whole list. */
 const PROJECT_TASKS_LIMIT = 25;
@@ -635,7 +650,7 @@ export function createChatToolExecutor(
           tasks.page.length === 0
             ? 'searched (no matches)'
             : tasks.listed
-              ? 'listed (nothing matched those words, so these are the tasks in scope)'
+              ? listedSource('tasks', tasks.isDone)
               : 'searched';
       } else {
         sources.tasks = 'access denied for your role';
@@ -683,7 +698,7 @@ export function createChatToolExecutor(
           projects.page.length === 0
             ? 'searched (no matches)'
             : projects.listed
-              ? 'listed (nothing matched those words, so these are the projects in scope)'
+              ? listedSource('projects', projects.isDone)
               : 'searched';
       } else {
         sources.projects = 'access denied for your role';

--- a/services/platform/convex/conversations/search_for_chat.test.ts
+++ b/services/platform/convex/conversations/search_for_chat.test.ts
@@ -208,3 +208,51 @@ describe('searchConversationsForChat — assignment privacy', () => {
     expect(plain.conversations).toEqual([]);
   });
 });
+
+describe('searchConversationsForChat — the assignment is returned', () => {
+  let t: T;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    await seedWorld(t);
+  });
+
+  // Observed in production: asked "what team is this assigned to", chat could
+  // find the conversation and could not say. The assignment is the field this
+  // leg's whole privacy rule is built on, and it was withheld from the answer.
+  it('names the team a conversation is queued to', async () => {
+    const result = await t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      { organizationId: ORG, userId: ADMIN, term: 'refund', limit: 10 },
+    );
+    const queued = result.conversations.find(
+      (c) => c.subject === 'Refund queued to team X',
+    );
+    expect(queued?.assigneeTeamId).toBe(TEAM_X);
+    expect(queued?.assigneeUserId).toBeUndefined();
+  });
+
+  it('names the person a conversation is owned by', async () => {
+    const result = await t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      { organizationId: ORG, userId: ADMIN, term: 'refund', limit: 10 },
+    );
+    const owned = result.conversations.find(
+      (c) => c.subject === 'Refund owned by a person',
+    );
+    expect(owned?.assigneeUserId).toBe(OWNER_USER);
+  });
+
+  it('returns neither field for an unassigned conversation', async () => {
+    const result = await t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      { organizationId: ORG, userId: ADMIN, term: 'refund', limit: 10 },
+    );
+    const pool = result.conversations.find(
+      (c) => c.subject === 'Refund pool unassigned',
+    );
+    expect(pool).toBeDefined();
+    expect(pool?.assigneeUserId).toBeUndefined();
+    expect(pool?.assigneeTeamId).toBeUndefined();
+  });
+});

--- a/services/platform/convex/conversations/search_for_chat.ts
+++ b/services/platform/convex/conversations/search_for_chat.ts
@@ -92,6 +92,12 @@ export const searchConversationsForChat = internalQuery({
         status: v.optional(v.string()),
         channel: v.optional(v.string()),
         lastMessageAt: v.optional(v.number()),
+        /** Who owns it. Returned because "who is this assigned to?" is the
+         *  first question asked of an inbox row, and because the assignment is
+         *  the field this leg's whole privacy rule is built on — withholding it
+         *  meant the answer could be found but not explained. */
+        assigneeUserId: v.optional(v.string()),
+        assigneeTeamId: v.optional(v.string()),
       }),
     ),
     /** True when the scan hit its cap, so the caller can say the reach was
@@ -189,11 +195,15 @@ export const searchConversationsForChat = internalQuery({
         status?: string;
         channel?: string;
         lastMessageAt?: number;
+        assigneeUserId?: string;
+        assigneeTeamId?: string;
       } = { _id: c._id };
       if (c.subject !== undefined) row.subject = c.subject;
       if (c.status !== undefined) row.status = c.status;
       if (c.channel !== undefined) row.channel = c.channel;
       if (c.lastMessageAt !== undefined) row.lastMessageAt = c.lastMessageAt;
+      if (c.assigneeUserId !== undefined) row.assigneeUserId = c.assigneeUserId;
+      if (c.assigneeTeamId !== undefined) row.assigneeTeamId = c.assigneeTeamId;
       conversations.push(row);
     }
     return { conversations, truncated };

--- a/services/platform/convex/tasks/search_for_chat.test.ts
+++ b/services/platform/convex/tasks/search_for_chat.test.ts
@@ -521,3 +521,128 @@ describe('a listing over-capacity keeps the most recently touched rows', () => {
     expect(names.at(-1)).toBe('Project 19');
   });
 });
+
+// The scan budget. A listing filters as it walks, so a caller who can read
+// little rejects most rows — and without a bound on rows EXAMINED, one board
+// question would read the organization's whole tasks index.
+describe('a listing bounds what it examines, not just what it keeps', () => {
+  const SCAN_ORG = 'org_task_scan';
+
+  it('reports an incomplete listing when the scan budget stops the walk', async () => {
+    const t = convexTest(schema, modules);
+    // 600 tasks in a project the caller cannot read, so every row is rejected.
+    // The default budget is 500, so the walk stops before the index ends.
+    const unreadable = await t.run(async (ctx) => {
+      const project = await ctx.db.insert('projects', {
+        organizationId: SCAN_ORG,
+        name: 'Hidden project',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      for (let index = 0; index < 600; index += 1) {
+        await ctx.db.insert('tasks', {
+          organizationId: SCAN_ORG,
+          title: `Hidden ${index}`,
+          status: 'todo',
+          rank: 'a',
+          projectId: project,
+          createdBy: 'user_1',
+          createdByType: 'user',
+          createdAt: 0,
+          updatedAt: 1_000 + index,
+        });
+      }
+      return project;
+    });
+
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: SCAN_ORG,
+        // Reads nothing: the one project in the org is not in the set.
+        projectIds: [],
+        term: 'are there any open tasks',
+        status: 'open',
+        paginationOpts: { numItems: 25, cursor: null },
+      },
+    );
+
+    expect(String(unreadable)).not.toBe('');
+    expect(result.listed).toBe(true);
+    // Nothing readable, and the walk stopped at the budget rather than proving
+    // the board empty — so the listing does not claim to be complete.
+    expect(result.page).toEqual([]);
+    expect(result.isDone).toBe(false);
+  });
+
+  it('reports an incomplete projects listing on the same budget', async () => {
+    const t = convexTest(schema, modules);
+    // 600 projects, none readable, so the walk stops at the budget having kept
+    // nothing — and must not claim it saw the whole org.
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 600; index += 1) {
+        await ctx.db.insert('projects', {
+          organizationId: 'org_proj_scan',
+          name: `Hidden ${index}`,
+          createdBy: 'user_1',
+          createdAt: 0,
+          updatedAt: 1_000 + index,
+        });
+      }
+    });
+
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchProjectsForChat,
+      {
+        organizationId: 'org_proj_scan',
+        projectIds: [],
+        term: 'which projects are there',
+        paginationOpts: { numItems: 25, cursor: null },
+      },
+    );
+
+    expect(result.page).toEqual([]);
+    expect(result.isDone).toBe(false);
+  });
+
+  it('reports a complete listing when the whole board fits in the budget', async () => {
+    const t = convexTest(schema, modules);
+    const project = await t.run(async (ctx) => {
+      const id = await ctx.db.insert('projects', {
+        organizationId: 'org_task_small',
+        name: 'Small project',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      await ctx.db.insert('tasks', {
+        organizationId: 'org_task_small',
+        title: 'Only task',
+        status: 'todo',
+        rank: 'a',
+        projectId: id,
+        createdBy: 'user_1',
+        createdByType: 'user',
+        createdAt: 0,
+        updatedAt: 1_000,
+      });
+      return id;
+    });
+
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: 'org_task_small',
+        projectIds: [String(project)],
+        term: 'are there any open tasks',
+        status: 'open',
+        paginationOpts: { numItems: 25, cursor: null },
+      },
+    );
+
+    expect(result.listed).toBe(true);
+    expect(result.page).toHaveLength(1);
+    expect(result.isDone).toBe(true);
+  });
+});

--- a/services/platform/convex/tasks/search_for_chat.test.ts
+++ b/services/platform/convex/tasks/search_for_chat.test.ts
@@ -219,3 +219,150 @@ describe('searchProjectsForChat — archived projects are returned', () => {
     ]);
   });
 });
+
+// The defect this fixes, observed in production: "are there any open tasks?"
+// tokenises to open/tasks/projects, no task title contains those words, and the
+// leg correctly returned nothing. Worse, a project whose DESCRIPTION happened to
+// contain "tasks" matched instead, which read as an answer.
+describe('searchTasksForChat — listing when nothing matches the words', () => {
+  let t: T;
+  let ids: Seeded;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    ids = await seed(t);
+  });
+
+  async function search(term: string, status?: 'open') {
+    return t.query(internal.tasks.search_for_chat.searchTasksForChat, {
+      organizationId: ORG,
+      projectIds: [String(ids.live), String(ids.retired)],
+      term,
+      ...(status !== undefined ? { status } : {}),
+      paginationOpts: { numItems: 20, cursor: null },
+    });
+  }
+
+  it('lists tasks in scope when the wording matches nothing', async () => {
+    const result = await search('open tasks projects');
+    expect(result.listed).toBe(true);
+    expect(result.page.length).toBeGreaterThan(0);
+  });
+
+  it('says it matched, not listed, when the wording does match', async () => {
+    const result = await search('pricing');
+    expect(result.listed).toBe(false);
+    expect(result.page.length).toBeGreaterThan(0);
+  });
+
+  it('honours the status filter while listing', async () => {
+    await t.run(async (ctx) => {
+      await ctx.db.insert('tasks', {
+        organizationId: ORG,
+        title: 'Zzz finished work',
+        status: 'done',
+        rank: 'z',
+        projectId: ids.live,
+        createdBy: 'user_1',
+        createdByType: 'user',
+        createdAt: 0,
+        updatedAt: 0,
+      });
+    });
+    const result = await search('anything unmatchable', 'open');
+    expect(result.listed).toBe(true);
+    expect(result.page.map((task) => task.title)).not.toContain(
+      'Zzz finished work',
+    );
+  });
+
+  it('never lists a task from a project the caller cannot read', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        term: 'nothing will match this',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.listed).toBe(true);
+    expect(result.page.map((task) => task.title)).not.toContain(
+      'Pricing task in retired project',
+    );
+  });
+
+  it('narrows to one project when projectId is given', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live), String(ids.retired)],
+        projectId: ids.retired,
+        term: '',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.page.map((task) => task.title)).toEqual([
+      'Pricing task in retired project',
+    ]);
+  });
+
+  // Narrowing must never widen: a project outside the readable set stays out
+  // even when named explicitly.
+  it('returns nothing for a projectId outside the readable set', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        projectId: ids.retired,
+        term: '',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.page).toEqual([]);
+  });
+});
+
+describe('searchProjectsForChat — listing when nothing matches', () => {
+  let t: T;
+  let ids: Seeded;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    ids = await seed(t);
+  });
+
+  // "are there any archived projects?" named no project, so only the one whose
+  // description happened to contain a query word came back.
+  it('lists readable projects when the wording matches nothing', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchProjectsForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live), String(ids.retired)],
+        term: 'are there any archived projects',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.listed).toBe(true);
+    expect(result.page.map((p) => p.name).sort()).toEqual([
+      'Live project',
+      'Retired project',
+    ]);
+  });
+
+  it('lists only readable projects', async () => {
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchProjectsForChat,
+      {
+        organizationId: ORG,
+        projectIds: [String(ids.live)],
+        term: 'unmatchable wording here',
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.page.map((p) => p.name)).toEqual(['Live project']);
+  });
+});

--- a/services/platform/convex/tasks/search_for_chat.test.ts
+++ b/services/platform/convex/tasks/search_for_chat.test.ts
@@ -366,3 +366,158 @@ describe('searchProjectsForChat — listing when nothing matches', () => {
     expect(result.page.map((p) => p.name)).toEqual(['Live project']);
   });
 });
+
+// WHICH rows the cap keeps. A listing is bounded, so on a board bigger than the
+// bound the ordering of the walk decides the whole answer — and the org index
+// yields oldest-first, which would have answered "what is open?" with the most
+// stale work on the board.
+describe('a listing over-capacity keeps the most recently touched rows', () => {
+  const BIG_ORG = 'org_task_cap';
+
+  /** 20 open tasks in one readable project, `updatedAt` ascending, so the
+   *  oldest and the newest are unambiguous. */
+  async function seedOverCap(t: T): Promise<Id<'projects'>> {
+    return t.run(async (ctx) => {
+      const project = await ctx.db.insert('projects', {
+        organizationId: BIG_ORG,
+        name: 'Busy project',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      for (let index = 0; index < 20; index += 1) {
+        await ctx.db.insert('tasks', {
+          organizationId: BIG_ORG,
+          title: `Task ${String(index).padStart(2, '0')}`,
+          status: 'todo',
+          rank: `r${String(index).padStart(2, '0')}`,
+          projectId: project,
+          createdBy: 'user_1',
+          createdByType: 'user',
+          createdAt: 0,
+          updatedAt: 1_000 + index,
+        });
+      }
+      return project;
+    });
+  }
+
+  it('returns the newest 15 open tasks, not the oldest 15', async () => {
+    const t = convexTest(schema, modules);
+    const project = await seedOverCap(t);
+
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: BIG_ORG,
+        projectIds: [String(project)],
+        term: 'are there any open tasks',
+        status: 'open',
+        paginationOpts: { numItems: 25, cursor: null },
+      },
+    );
+
+    expect(result.listed).toBe(true);
+    expect(result.page).toHaveLength(15);
+    const titles = result.page.map((task) => task.title).sort();
+    // Tasks 05..19 are the 15 most recently updated of the 20.
+    expect(titles[0]).toBe('Task 05');
+    expect(titles.at(-1)).toBe('Task 19');
+    // The five oldest are absent — the assertion the org-index walk failed.
+    for (const stale of [
+      'Task 00',
+      'Task 01',
+      'Task 02',
+      'Task 03',
+      'Task 04',
+    ]) {
+      expect(titles).not.toContain(stale);
+    }
+  });
+
+  it('still groups the kept page by status, then rank', async () => {
+    const t = convexTest(schema, modules);
+    const project = await t.run(async (ctx) => {
+      const id = await ctx.db.insert('projects', {
+        organizationId: 'org_task_order',
+        name: 'Ordering project',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      // Inserted newest-first by updatedAt, so recency order and status order
+      // disagree; the returned order must follow status.
+      const rows: Array<[string, 'todo' | 'in_progress' | 'backlog']> = [
+        ['Newest', 'todo'],
+        ['Middle', 'in_progress'],
+        ['Oldest', 'backlog'],
+      ];
+      let updatedAt = 3_000;
+      for (const [title, status] of rows) {
+        await ctx.db.insert('tasks', {
+          organizationId: 'org_task_order',
+          title,
+          status,
+          rank: 'a',
+          projectId: id,
+          createdBy: 'user_1',
+          createdByType: 'user',
+          createdAt: 0,
+          updatedAt,
+        });
+        updatedAt -= 1_000;
+      }
+      return id;
+    });
+
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchTasksForChat,
+      {
+        organizationId: 'org_task_order',
+        projectIds: [String(project)],
+        term: 'what is on the board',
+        paginationOpts: { numItems: 25, cursor: null },
+      },
+    );
+
+    expect(result.listed).toBe(true);
+    // Alphabetical by status: backlog, in_progress, todo.
+    expect(result.page.map((task) => task.status)).toEqual([
+      'backlog',
+      'in_progress',
+      'todo',
+    ]);
+  });
+
+  it('keeps the most recently touched readable projects', async () => {
+    const t = convexTest(schema, modules);
+    const readable: string[] = [];
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 20; index += 1) {
+        const id = await ctx.db.insert('projects', {
+          organizationId: 'org_proj_cap',
+          name: `Project ${String(index).padStart(2, '0')}`,
+          createdBy: 'user_1',
+          createdAt: 0,
+          updatedAt: 1_000 + index,
+        });
+        readable.push(String(id));
+      }
+    });
+
+    const result = await t.query(
+      internal.tasks.search_for_chat.searchProjectsForChat,
+      {
+        organizationId: 'org_proj_cap',
+        projectIds: readable,
+        term: 'which projects are there',
+        paginationOpts: { numItems: 25, cursor: null },
+      },
+    );
+
+    expect(result.page).toHaveLength(15);
+    const names = result.page.map((project) => project.name).sort();
+    expect(names[0]).toBe('Project 05');
+    expect(names.at(-1)).toBe('Project 19');
+  });
+});

--- a/services/platform/convex/tasks/search_for_chat.ts
+++ b/services/platform/convex/tasks/search_for_chat.ts
@@ -33,7 +33,10 @@ import { v } from 'convex/values';
 
 import type { Doc } from '../_generated/dataModel';
 import { internalQuery, type QueryCtx } from '../_generated/server';
-import { cursorPaginationOptsValidator } from '../lib/pagination';
+import {
+  cursorPaginationOptsValidator,
+  paginateWithFilter,
+} from '../lib/pagination';
 import {
   projectsSearchStrategy,
   runEntitySearch,
@@ -92,6 +95,12 @@ function taskAllowed(
  *
  * The kept page is then ordered like the agent listing, status then rank, so a
  * model reads it grouped the way the board is.
+ *
+ * Runs through `paginateWithFilter`, which bounds how many rows are EXAMINED,
+ * not just how many are kept. A caller who can read few projects rejects most
+ * of what it walks, and without a scan budget one question would read the
+ * organization's whole tasks index. `complete` is false when the budget stopped
+ * the walk, so the caller can say the listing is partial.
  */
 async function listTasksInScope(
   ctx: QueryCtx,
@@ -100,24 +109,27 @@ async function listTasksInScope(
     readable: ReadonlySet<string>;
     status?: 'open' | Doc<'tasks'>['status'];
   },
-): Promise<Doc<'tasks'>[]> {
-  const rows: Doc<'tasks'>[] = [];
-  for await (const task of ctx.db
-    .query('tasks')
-    .withIndex('by_org_updatedAt', (q) =>
-      q.eq('organizationId', args.organizationId),
-    )
-    .order('desc')) {
-    if (!taskAllowed(task, args.readable, args.status)) continue;
-    rows.push(task);
-    if (rows.length >= LIST_CAP) break;
-  }
+): Promise<{ rows: Doc<'tasks'>[]; complete: boolean }> {
+  const listed = await paginateWithFilter(
+    ctx.db
+      .query('tasks')
+      .withIndex('by_org_updatedAt', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )
+      .order('desc'),
+    {
+      numItems: LIST_CAP,
+      cursor: null,
+      filter: (task) => taskAllowed(task, args.readable, args.status),
+    },
+  );
+  const rows = [...listed.page];
   rows.sort((a, b) =>
     a.status === b.status
       ? a.rank.localeCompare(b.rank)
       : a.status.localeCompare(b.status),
   );
-  return rows;
+  return { rows, complete: listed.isDone };
 }
 
 export const searchTasksForChat = internalQuery({
@@ -152,14 +164,14 @@ export const searchTasksForChat = internalQuery({
     if (found.page.length > 0) return { ...found, listed: false };
 
     // Nothing matched the words. Answer the question the words were describing.
-    const rows = await listTasksInScope(ctx, {
+    const listing = await listTasksInScope(ctx, {
       organizationId: args.organizationId,
       readable,
       ...(status !== undefined ? { status } : {}),
     });
     return {
-      page: rows,
-      isDone: true,
+      page: listing.rows,
+      isDone: listing.complete,
       continueCursor: '',
       /** The caller reports this, so "listed" is never mistaken for "matched". */
       listed: true,
@@ -194,17 +206,24 @@ export const searchProjectsForChat = internalQuery({
     // first, for the reason `listTasksInScope` gives: the cap decides the
     // answer, and the org index would have kept the least recently touched
     // projects in scope.
-    const rows: Doc<'projects'>[] = [];
-    for await (const project of ctx.db
-      .query('projects')
-      .withIndex('by_organization_updatedAt', (q) =>
-        q.eq('organizationId', args.organizationId),
-      )
-      .order('desc')) {
-      if (!readable.has(String(project._id))) continue;
-      rows.push(project);
-      if (rows.length >= LIST_CAP) break;
-    }
-    return { page: rows, isDone: true, continueCursor: '', listed: true };
+    const listed = await paginateWithFilter(
+      ctx.db
+        .query('projects')
+        .withIndex('by_organization_updatedAt', (q) =>
+          q.eq('organizationId', args.organizationId),
+        )
+        .order('desc'),
+      {
+        numItems: LIST_CAP,
+        cursor: null,
+        filter: (project) => readable.has(String(project._id)),
+      },
+    );
+    return {
+      page: listed.page,
+      isDone: listed.isDone,
+      continueCursor: '',
+      listed: true,
+    };
   },
 });

--- a/services/platform/convex/tasks/search_for_chat.ts
+++ b/services/platform/convex/tasks/search_for_chat.ts
@@ -84,7 +84,14 @@ function taskAllowed(
  * falls back to this listing only when the text match found nothing, and says
  * which of the two happened.
  *
- * Ordered like the agent listing: status, then rank. Bounded by `LIST_CAP`.
+ * Bounded by `LIST_CAP`, so WHICH rows the bound keeps decides the answer.
+ * Walks `by_org_updatedAt` newest-first, matching the org-wide task listing in
+ * `queries.ts`. The org index would have kept the OLDEST `LIST_CAP` rows in
+ * scope, so a board with more open tasks than the cap would have answered "what
+ * is open?" with its most stale work, sorted convincingly.
+ *
+ * The kept page is then ordered like the agent listing, status then rank, so a
+ * model reads it grouped the way the board is.
  */
 async function listTasksInScope(
   ctx: QueryCtx,
@@ -97,9 +104,10 @@ async function listTasksInScope(
   const rows: Doc<'tasks'>[] = [];
   for await (const task of ctx.db
     .query('tasks')
-    .withIndex('by_organization', (q) =>
+    .withIndex('by_org_updatedAt', (q) =>
       q.eq('organizationId', args.organizationId),
-    )) {
+    )
+    .order('desc')) {
     if (!taskAllowed(task, args.readable, args.status)) continue;
     rows.push(task);
     if (rows.length >= LIST_CAP) break;
@@ -182,13 +190,17 @@ export const searchProjectsForChat = internalQuery({
 
     // "Are there any archived projects?" names no project, so nothing matches
     // and whichever project has the word in its DESCRIPTION wins by accident.
-    // List instead — the readable set is already the answer's scope.
+    // List instead — the readable set is already the answer's scope. Newest
+    // first, for the reason `listTasksInScope` gives: the cap decides the
+    // answer, and the org index would have kept the least recently touched
+    // projects in scope.
     const rows: Doc<'projects'>[] = [];
     for await (const project of ctx.db
       .query('projects')
-      .withIndex('by_organization', (q) =>
+      .withIndex('by_organization_updatedAt', (q) =>
         q.eq('organizationId', args.organizationId),
-      )) {
+      )
+      .order('desc')) {
       if (!readable.has(String(project._id))) continue;
       rows.push(project);
       if (rows.length >= LIST_CAP) break;

--- a/services/platform/convex/tasks/search_for_chat.ts
+++ b/services/platform/convex/tasks/search_for_chat.ts
@@ -32,7 +32,7 @@
 import { v } from 'convex/values';
 
 import type { Doc } from '../_generated/dataModel';
-import { internalQuery } from '../_generated/server';
+import { internalQuery, type QueryCtx } from '../_generated/server';
 import { cursorPaginationOptsValidator } from '../lib/pagination';
 import {
   projectsSearchStrategy,
@@ -46,6 +46,72 @@ import { taskStatusValidator } from './schema';
  *  mapping cannot drift from `TERMINAL_STATUSES`. */
 const OPEN_EXCLUDES = new Set(['done', 'cancelled']);
 
+/** How many tasks a LISTING returns. Smaller than a search page: a list is
+ *  read in full by a model with a step budget, not paged through. */
+const LIST_CAP = 15;
+
+/**
+ * Whether a task is visible to, and wanted by, this caller — the same rule for
+ * a search hit and for a listing, so the two can never disagree about scope.
+ */
+function taskAllowed(
+  task: Doc<'tasks'>,
+  readable: ReadonlySet<string>,
+  status: 'open' | Doc<'tasks'>['status'] | undefined,
+): boolean {
+  // Project-less work is org-level and readable; anything owned by a project
+  // the caller cannot read is invisible, exactly as its parent is.
+  if (task.projectId != null && !readable.has(String(task.projectId))) {
+    return false;
+  }
+  if (status === 'open') return !OPEN_EXCLUDES.has(task.status);
+  if (status !== undefined) return task.status === status;
+  return true;
+}
+
+/**
+ * Tasks in scope, ignoring the text entirely — the answer to "what is open?".
+ *
+ * A question about the board carries no searchable term. "Are there any open
+ * tasks?" tokenises to `open`/`tasks`/`projects`, and no task title contains
+ * those words, so a text match correctly returns nothing and uselessly. Worse,
+ * whichever project happens to have the word "tasks" in its DESCRIPTION matches
+ * instead, which reads as an answer while being an accident of prose.
+ *
+ * Deliberately not solved with a denylist of words like `task` and `project`:
+ * those appear in real names (a project called "Tale Issues" is found by
+ * "issues"), so stripping them would make named things unfindable. The caller
+ * falls back to this listing only when the text match found nothing, and says
+ * which of the two happened.
+ *
+ * Ordered like the agent listing: status, then rank. Bounded by `LIST_CAP`.
+ */
+async function listTasksInScope(
+  ctx: QueryCtx,
+  args: {
+    organizationId: string;
+    readable: ReadonlySet<string>;
+    status?: 'open' | Doc<'tasks'>['status'];
+  },
+): Promise<Doc<'tasks'>[]> {
+  const rows: Doc<'tasks'>[] = [];
+  for await (const task of ctx.db
+    .query('tasks')
+    .withIndex('by_organization', (q) =>
+      q.eq('organizationId', args.organizationId),
+    )) {
+    if (!taskAllowed(task, args.readable, args.status)) continue;
+    rows.push(task);
+    if (rows.length >= LIST_CAP) break;
+  }
+  rows.sort((a, b) =>
+    a.status === b.status
+      ? a.rank.localeCompare(b.rank)
+      : a.status.localeCompare(b.status),
+  );
+  return rows;
+}
+
 export const searchTasksForChat = internalQuery({
   args: {
     organizationId: v.string(),
@@ -55,27 +121,41 @@ export const searchTasksForChat = internalQuery({
     term: v.string(),
     /** `open` = not done/cancelled. Any concrete status filters exactly. */
     status: v.optional(v.union(v.literal('open'), taskStatusValidator)),
+    /** One project, for "which tasks are in this project?". Narrows BOTH the
+     *  search and the listing; still subject to `projectIds`. */
+    projectId: v.optional(v.id('projects')),
     paginationOpts: cursorPaginationOptsValidator,
   },
   handler: async (ctx, args) => {
-    const readable = new Set(args.projectIds);
+    const readable =
+      args.projectId !== undefined
+        ? // Narrowing to one project can never widen scope: it must already be
+          // readable, or the result is empty.
+          new Set(args.projectIds.filter((id) => id === String(args.projectId)))
+        : new Set(args.projectIds);
     const status = args.status;
-    return await runEntitySearch(ctx, tasksSearchStrategy, {
+    const found = await runEntitySearch(ctx, tasksSearchStrategy, {
       organizationId: args.organizationId,
       term: args.term,
       paginationOpts: args.paginationOpts,
       matchMode: 'any',
-      accessFilter: (task: Doc<'tasks'>) => {
-        // Project-less work is org-level and readable; anything owned by a
-        // project the caller cannot read is invisible, exactly as its parent is.
-        if (task.projectId != null && !readable.has(String(task.projectId))) {
-          return false;
-        }
-        if (status === 'open') return !OPEN_EXCLUDES.has(task.status);
-        if (status !== undefined) return task.status === status;
-        return true;
-      },
+      accessFilter: (task: Doc<'tasks'>) => taskAllowed(task, readable, status),
     });
+    if (found.page.length > 0) return { ...found, listed: false };
+
+    // Nothing matched the words. Answer the question the words were describing.
+    const rows = await listTasksInScope(ctx, {
+      organizationId: args.organizationId,
+      readable,
+      ...(status !== undefined ? { status } : {}),
+    });
+    return {
+      page: rows,
+      isDone: true,
+      continueCursor: '',
+      /** The caller reports this, so "listed" is never mistaken for "matched". */
+      listed: true,
+    };
   },
 });
 
@@ -90,7 +170,7 @@ export const searchProjectsForChat = internalQuery({
   },
   handler: async (ctx, args) => {
     const readable = new Set(args.projectIds);
-    return await runEntitySearch(ctx, projectsSearchStrategy, {
+    const found = await runEntitySearch(ctx, projectsSearchStrategy, {
       organizationId: args.organizationId,
       term: args.term,
       paginationOpts: args.paginationOpts,
@@ -98,5 +178,21 @@ export const searchProjectsForChat = internalQuery({
       accessFilter: (project: Doc<'projects'>) =>
         readable.has(String(project._id)),
     });
+    if (found.page.length > 0) return { ...found, listed: false };
+
+    // "Are there any archived projects?" names no project, so nothing matches
+    // and whichever project has the word in its DESCRIPTION wins by accident.
+    // List instead — the readable set is already the answer's scope.
+    const rows: Doc<'projects'>[] = [];
+    for await (const project of ctx.db
+      .query('projects')
+      .withIndex('by_organization', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      if (!readable.has(String(project._id))) continue;
+      rows.push(project);
+      if (rows.length >= LIST_CAP) break;
+    }
+    return { page: rows, isDone: true, continueCursor: '', listed: true };
   },
 });

--- a/services/platform/lib/chat/tools.ts
+++ b/services/platform/lib/chat/tools.ts
@@ -356,7 +356,11 @@ const CHAT_TOOL_DESCRIPTIONS: Record<ChatToolName, string> = {
     "organization's own material and the conversation does not already " +
     'contain it — not for general knowledge, definitions, or reasoning ' +
     'about what the user wrote. Pass "status" to filter tasks ("open" means ' +
-    'not done and not cancelled). Results come back ranked; "score" orders ' +
+    'not done and not cancelled). A question about the board needs no ' +
+    'matching words: when nothing matches the wording, the tasks and projects ' +
+    'sources LIST what is in scope instead, and say so — so ask "open tasks" ' +
+    'once and read the list rather than rewording the query. Results come ' +
+    'back ranked; "score" orders ' +
     'hits within one response only. Document, web-page and task rows carry ' +
     'a "ref" for rag_fetch (documents and pages also carry the match\'s ' +
     'character "offset"); contact, product, knowledge-entry, website and ' +
@@ -367,9 +371,11 @@ const CHAT_TOOL_DESCRIPTIONS: Record<ChatToolName, string> = {
   rag_fetch:
     'Load the full detail behind a "ref": a document file id (from a ' +
     'rag_search hit or the attached-documents list), a crawled website page ' +
-    "URL, or a task ref. A task ref returns that task's full description " +
-    'plus its comments, subtasks and blockers — use it when a question ' +
-    'needs more than the title and status a search hit already carried. ' +
+    "URL, a task ref, or a project ref. A task ref returns that task's full " +
+    'description plus its comments, subtasks and blockers — use it when a ' +
+    'question needs more than the title and status a search hit already ' +
+    "carried. A project ref returns that project's tasks, which is how you " +
+    'answer "the project has 8 open tasks, which ones?". ' +
     'Fetch before quoting or summarizing content — a search hit ' +
     'is only a snippet. When an attachment already names its ref, fetch it ' +
     'directly; do not rag_search the organization for a file whose ref you ' +


### PR DESCRIPTION
Chat can now answer "are there any open tasks?" and "which tasks are on this project?". Both returned nothing before, or worse, an accidental match.

## Why

Found while verifying #3002 through #3007 on a live deployment.

**Board questions matched nothing.** "Are there any open tasks?" tokenises to `open`, `tasks`, `projects`. No task title contains those words, so the leg matched nothing. Correctly, and uselessly.

What surfaced instead was a project whose description reads *"A starter project to explore tasks and your agents"*. The word "tasks" matched. So the answer was decided by which project happened to have a query word in its prose. That reads as an answer while being an accident, which is worse than an empty result. It is also why a project named "Tale Issues" appeared when named and vanished when the question said "projects".

**Project refs refused.** A turn called `rag_fetch` on a project ref four times. Each call returned `invalid_args`. The refusals consumed its whole step budget. A project row says "8 open tasks" and there was no way to ask which ones. The model was reaching for the right thing and I had blocked it.

**Conversations withheld the assignee.** Asked "what team is this assigned to", chat found the conversation and could not say.

## What changed

- The tasks and projects legs list what is in scope when the wording matches nothing. `sources` reports `listed` rather than `searched`, so the model never reads a list as "these matched your words".
- Both listings walk `updatedAt` newest-first, so the 15-row cap keeps the most recently touched work. The org index yields oldest-first, which would have answered "what is open?" with the most stale tasks on the board.
- Both run through `paginateWithFilter`, which bounds rows examined as well as rows kept. A caller who can read few projects rejects most of what it walks, and an unbounded walk would read the whole tasks index.
- When that budget stops the walk, `sources` says the rows are the most recently updated ones in scope, not the whole set.
- `rag_fetch` on a project ref returns that project's tasks, each with its own task ref so depth is one more fetch away.
- `searchTasksForChat` takes an optional `projectId` to narrow to one project.
- The conversations leg returns `assigneeUserId` and `assigneeTeamId`, and marks an unassigned conversation as `unassigned`.

Not solved with a denylist of words like `task` and `project`. Those appear in real names: "Tale Issues" is found by "issues". Stripping them would make named things unfindable.

## Risk

**Narrowing to one project cannot widen scope.** `projectId` filters the caller's readable list (`tasks/search_for_chat.ts:134`). It never adds to it. Naming a project the caller cannot read leaves the set empty, so the result is empty.

**A project ref is re-checked on the turn it is fetched.** `rag_fetch` requires the id to be in this turn's `access.projectIds` (`chat/assistant_tools.ts:911`). A ref quoted from an earlier turn, after access changed, returns `not_found`. A malformed id returns the same thing, so neither answer reveals whether the project exists.

**The listing and the search decide scope with the same code.** Both call `taskAllowed` (`tasks/search_for_chat.ts:57`). A later change to project visibility reaches both paths or neither.

**A listing is bounded twice, and says so.** Both legs walk `updatedAt` descending, keep 15 rows, and examine at most 500. The tasks page is then grouped by status and rank. On a board over the cap the answer is the 15 most recently touched tasks. When the scan budget ends the walk, `sources` says the rows are not the whole set, so a partial listing is never presented as the board.

## Tests

20 at the query layer through convex-test, plus chat-level coverage of the reporting and the project fetch. Three seed 20 rows against a cap of 15 and assert which 15 survive, in both legs. Three more seed 600 unreadable rows and assert the walk stops at its budget without claiming the board is empty.

Mutations, all red:

- removing the listing fallback
- letting the listing ignore the readable set
- letting `projectId` widen scope
- skipping the project-ref scope re-check
- reporting a listing as a match
- dropping the assignee from the wire
- walking either listing oldest-first
- dropping the descending order
- dropping the status/rank grouping
- removing the scan budget
- claiming a budget-stopped listing is complete, in either leg
- reporting a partial listing as the whole set

## Scope

Does not touch retrieval scope, the archived labelling, or the privacy rule.

Two problems from the same verification session are not in here. Email attachments are stored but hidden in the Inbox, because `message.tsx` filters any attachment carrying both a `contentId` and a `url` as an inline image. And email attachments are still not indexed for RAG, which was a deliberate choice in #2995. Both are being handled separately.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, `migrations:check` (no migration), platform 75,180 tests.