### PR TITLE
fix(platform): stop hiding an email attachment that carries a Content-ID

### DIFF
--- a/services/platform/app/features/conversations/components/message.test.tsx
+++ b/services/platform/app/features/conversations/components/message.test.tsx
@@ -148,3 +148,126 @@ describe('Message — settled outbound', () => {
     expect(screen.queryByText(/message\.notDelivered/)).not.toBeInTheDocument();
   });
 });
+
+// A Content-ID is not proof that an attachment is inline. Many mail clients
+// stamp one on ordinary file parts, and the previous filter hid anything
+// carrying both a contentId and a url — so a real PDF from such a sender
+// vanished from the Inbox while a self-sent test from a client that omits
+// Content-ID displayed fine.
+describe('Message — attachment list vs inline images', () => {
+  function attachment(over: Record<string, unknown> = {}) {
+    return {
+      id: 'a1',
+      filename: 'CV.pdf',
+      contentType: 'application/pdf',
+      size: 23_359,
+      url: '/storage/blob_1/CV.pdf',
+      ...over,
+    } as NonNullable<MessageType['attachments']>[number];
+  }
+
+  it('shows an attachment whose cid the body never references', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ contentId: '<part1.abc@mail>' })],
+        })}
+      />,
+    );
+    expect(screen.getByText('CV.pdf')).toBeInTheDocument();
+  });
+
+  it('hides an inline image the body draws', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>See <img src="cid:logo.abc@mail"> here.</p>',
+          attachments: [
+            attachment({
+              filename: 'logo.png',
+              contentType: 'image/png',
+              contentId: '<logo.abc@mail>',
+              url: '/storage/blob_2/logo.png',
+            }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
+  });
+
+  it('shows a plain attachment alongside a drawn inline image', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p><img src="cid:logo.abc@mail"> CV attached.</p>',
+          attachments: [
+            attachment({ contentId: '<part1.abc@mail>' }),
+            attachment({
+              id: 'a2',
+              filename: 'logo.png',
+              contentType: 'image/png',
+              contentId: '<logo.abc@mail>',
+              url: '/storage/blob_2/logo.png',
+            }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('CV.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
+  });
+
+  it('shows an attachment with no contentId at all', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>Attached.</p>',
+          attachments: [attachment()],
+        })}
+      />,
+    );
+    expect(screen.getByText('CV.pdf')).toBeInTheDocument();
+  });
+
+  // An inline image whose bytes are not stored yet stays visible, so it can be
+  // downloaded by hand if the auto-download fails.
+  it('shows a referenced inline image that has no url yet', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p><img src="cid:logo.abc@mail"></p>',
+          attachments: [
+            attachment({
+              filename: 'logo.png',
+              contentType: 'image/png',
+              contentId: '<logo.abc@mail>',
+              url: undefined,
+            }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('logo.png')).toBeInTheDocument();
+  });
+
+  it('matches a percent-escaped cid reference', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p><img src="cid:logo%2Eabc@mail"></p>',
+          attachments: [
+            attachment({
+              filename: 'logo.png',
+              contentType: 'image/png',
+              contentId: '<logo.abc@mail>',
+              url: '/storage/blob_2/logo.png',
+            }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/conversations/components/message.tsx
+++ b/services/platform/app/features/conversations/components/message.tsx
@@ -20,6 +20,39 @@ import type { Message as MessageType } from '../types';
 
 type Attachment = NonNullable<MessageType['attachments']>[number];
 
+/** A Content-ID with its angle brackets and surrounding space removed, so a
+ *  header value and a `cid:` reference compare equal. */
+function normalizeCid(cid: string): string {
+  return cid.trim().replace(/^<|>$/g, '');
+}
+
+/**
+ * The Content-IDs an HTML body references, from `src="cid:…"` and
+ * `href="cid:…"`.
+ *
+ * This is the only reliable signal that an attachment is inline. A cid is
+ * percent-decoded before comparison, because a reference may be escaped while
+ * the header value is not.
+ */
+function referencedCidsIn(html: string): ReadonlySet<string> {
+  const found = new Set<string>();
+  for (const match of html.matchAll(
+    /(?:src|href)\s*=\s*["']cid:([^"']+)["']/gi,
+  )) {
+    const raw = match[1];
+    if (raw === undefined) continue;
+    let decoded = raw;
+    try {
+      decoded = decodeURIComponent(raw);
+    } catch {
+      // A malformed escape is not a reason to lose the reference; compare raw.
+      decoded = raw;
+    }
+    found.add(normalizeCid(decoded));
+  }
+  return found;
+}
+
 interface MessageProps {
   message: MessageType;
   /** Cancel a queued outbound send inside its undo window. */
@@ -253,7 +286,6 @@ export function Message({
 
   // Build CID→URL map for inline images that have been downloaded
   const cidMap = useMemo(() => {
-    const normalizeCid = (cid: string) => cid.trim().replace(/^<|>$/g, '');
     const map: Record<string, string> = {};
     for (const att of message.attachments ?? []) {
       if (att.contentId && att.url) {
@@ -263,15 +295,34 @@ export function Message({
     return map;
   }, [message.attachments]);
 
-  // Filter out resolved inline attachments from the displayed attachment list.
-  // Unresolved inline attachments (contentId but no url) remain visible as a
-  // fallback so users can still see and manually download them if auto-download fails.
+  /** The cids the body actually draws, from its `cid:` references. */
+  const referencedCids = useMemo(
+    () => referencedCidsIn(message.content),
+    [message.content],
+  );
+
+  // Hide an attachment only when the body actually draws it.
+  //
+  // This used to hide anything carrying both a contentId and a url, taking a
+  // Content-ID as proof of inline use. It is not: many mail clients stamp
+  // Content-ID on ordinary file parts, so a real PDF attachment from such a
+  // sender was silently dropped from the list while a self-sent test from a
+  // client that omits Content-ID showed up fine.
+  //
+  // An unreferenced attachment stays visible even with a cid, and an inline
+  // image with no url yet stays visible as a fallback so it can still be
+  // downloaded by hand if the auto-download fails.
   const displayAttachments = useMemo(
     () =>
       (message.attachments ?? []).filter(
-        (att: Attachment) => !(att.contentId && att.url),
+        (att: Attachment) =>
+          !(
+            att.contentId &&
+            att.url &&
+            referencedCids.has(normalizeCid(att.contentId))
+          ),
       ),
-    [message.attachments],
+    [message.attachments, referencedCids],
   );
 
   // Auto-trigger download for inline images that don't have URLs yet.


### PR DESCRIPTION
An email attachment that carries a Content-ID now appears in the Inbox. Before this, it was stored, given a download URL, written into its message metadata, and then filtered out before render — so the file looked like it had never arrived.

## Why

The list hid anything carrying **both** a `contentId` and a `url`:

```ts
.filter((att) => !(att.contentId && att.url))
```

That treats a Content-ID as proof the part is an inline image already drawn in the body. It is not. Many mail clients stamp Content-ID on ordinary file parts, and `materializeEmailAttachments` gives every stored attachment a `url` — so both conditions were met by a perfectly ordinary attachment.

This is why a self-sent test worked while real mail did not: the test client omits Content-ID.

Reported from a live deployment. The `fileMetadata` row existed with a `storageId`, which is what narrowed it to display rather than to ingest.

## What changed

An attachment is hidden only when the body actually draws it — its cid appears in a `src="cid:…"` or `href="cid:…"` reference in the HTML.

- an unreferenced part stays visible whatever headers it carries
- a referenced inline image with no `url` yet stays visible, so it can be downloaded by hand when the auto-download fails
- `normalizeCid` moves to module scope, so the cid map and the reference test compare values the same way
- a reference is percent-decoded before comparison, because it can be escaped while the header value is not

## Tests

Six cases: an unreferenced attachment with a cid shows, a drawn inline image hides, both together behave correctly, no cid at all shows, a referenced image with no url shows, and an escaped reference still matches.

Mutations, all red: restoring the old `contentId && url` filter, hiding nothing at all, dropping the percent-decode, and no longer stripping angle brackets from a Content-ID.

## Scope

Display only. Ingest, storage and the `fileMetadata` row are unchanged.

Does not make email attachments searchable. They are still skipped for RAG by #2995, which was deliberate. Making them searchable needs the attachment bound to its conversation first (#2985), so visibility can be derived from the conversation's current assignment rather than stamped at ingest and left to drift.
