### PR TITLE
feat(platform): record which conversation an email attachment arrived on

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -186,6 +186,7 @@ import type * as conversations_helpers from "../conversations/helpers.js";
 import type * as conversations_improve_message from "../conversations/improve_message.js";
 import type * as conversations_ingest_add_message_to_conversation from "../conversations/ingest/add_message_to_conversation.js";
 import type * as conversations_ingest_attachments_for_metadata from "../conversations/ingest/attachments_for_metadata.js";
+import type * as conversations_ingest_bind_email_attachments from "../conversations/ingest/bind_email_attachments.js";
 import type * as conversations_ingest_build_conversation_metadata from "../conversations/ingest/build_conversation_metadata.js";
 import type * as conversations_ingest_build_email_metadata from "../conversations/ingest/build_email_metadata.js";
 import type * as conversations_ingest_build_initial_message from "../conversations/ingest/build_initial_message.js";
@@ -1141,6 +1142,7 @@ declare const fullApi: ApiFromModules<{
   "conversations/improve_message": typeof conversations_improve_message;
   "conversations/ingest/add_message_to_conversation": typeof conversations_ingest_add_message_to_conversation;
   "conversations/ingest/attachments_for_metadata": typeof conversations_ingest_attachments_for_metadata;
+  "conversations/ingest/bind_email_attachments": typeof conversations_ingest_bind_email_attachments;
   "conversations/ingest/build_conversation_metadata": typeof conversations_ingest_build_conversation_metadata;
   "conversations/ingest/build_email_metadata": typeof conversations_ingest_build_email_metadata;
   "conversations/ingest/build_initial_message": typeof conversations_ingest_build_initial_message;

--- a/services/platform/convex/conversations/ingest/bind_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/bind_email_attachments.ts
@@ -1,0 +1,82 @@
+/**
+ * Record which conversation an email's stored attachments arrived on.
+ *
+ * ## Why this is a second pass
+ *
+ * Attachment bytes are drained per message inside `sync_mailbox.fetchBodies`,
+ * one body at a time, so a page of mail never holds every base64 payload at
+ * once. That happens BEFORE the conversation is resolved, so at storage time
+ * there is no conversation id to write. The binding therefore lands after
+ * ingest, keyed on the `storageId` the materializer already put on the wire
+ * attachment.
+ *
+ * ## Why bind at all
+ *
+ * The bytes were stored with no record of what they arrived on. Nothing
+ * downstream could get from a file back to its mail, which is why an inbound
+ * attachment could not be given a visibility rule, could not be reached by
+ * retention, and could not be recognised as one already seen.
+ *
+ * The visibility rule is the reason it matters most: an emailed file should be
+ * readable by whoever can currently read its conversation. Deriving that needs a
+ * link. Stamping a team on the file instead would be wrong the moment somebody
+ * reassigns the conversation, and every missed rewrite would leave a file either
+ * hidden from its new owner or visible to its old one.
+ *
+ * Best-effort by design. A failed binding must not fail a sync that has already
+ * ingested the mail — the attachment is still stored and still shown; it is the
+ * link that is missing, and the next poll rebinds it.
+ */
+
+import { isRecord } from '../../../lib/utils/type-utils';
+import { internal } from '../../_generated/api';
+import type { Id } from '../../_generated/dataModel';
+import type { ActionCtx } from '../../_generated/server';
+import type { EmailType } from './types';
+
+/** One ingested email and the conversation it landed on. */
+export interface AttachmentBinding {
+  readonly email: EmailType;
+  readonly conversationId: Id<'conversations'>;
+}
+
+/** The stored blob refs an ingested email carries. A part with no `storageId`
+ *  was never materialized (metadata-only chip), so there is no row to bind. */
+function storedRefs(email: EmailType): string[] {
+  const refs: string[] = [];
+  for (const attachment of email.attachments ?? []) {
+    if (!isRecord(attachment)) continue;
+    const storageId = attachment.storageId;
+    if (typeof storageId === 'string' && storageId !== '') refs.push(storageId);
+  }
+  return refs;
+}
+
+export async function bindEmailAttachments(
+  ctx: ActionCtx,
+  args: {
+    organizationId: string;
+    bindings: readonly AttachmentBinding[];
+  },
+): Promise<void> {
+  for (const { email, conversationId } of args.bindings) {
+    for (const storageId of storedRefs(email)) {
+      try {
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.bindFileToConversation,
+          {
+            organizationId: args.organizationId,
+            storageId,
+            conversationId,
+          },
+        );
+      } catch (error) {
+        // Never fail an ingest that already landed the mail.
+        console.warn(
+          `[bindEmailAttachments] could not bind ${storageId} to ${String(conversationId)}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+  }
+}

--- a/services/platform/convex/conversations/ingest/create_conversation_from_email.test.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_email.test.ts
@@ -37,9 +37,19 @@ function isAddMessageArgs(
   return 'conversationId' in args && 'sender' in args;
 }
 
-function createMockCtx() {
+function isBindArgs(
+  args: Record<string, unknown>,
+): args is { storageId: string; conversationId: Id<'conversations'> } {
+  return 'storageId' in args && 'conversationId' in args && !('sender' in args);
+}
+
+function createMockCtx(opts: { failBind?: boolean } = {}) {
   const createdConversationIds: Id<'conversations'>[] = [];
   const addMessageCalls: Array<{ conversationId: Id<'conversations'> }> = [];
+  const bindCalls: Array<{
+    storageId: string;
+    conversationId: Id<'conversations'>;
+  }> = [];
   let conversationCounter = 0;
 
   const ctx = {
@@ -62,11 +72,19 @@ function createMockCtx() {
         addMessageCalls.push({ conversationId: args.conversationId });
         return { messageId: `msg_added_${addMessageCalls.length}` };
       }
+      if (isBindArgs(args)) {
+        if (opts.failBind) throw new Error('transient');
+        bindCalls.push({
+          storageId: args.storageId,
+          conversationId: args.conversationId,
+        });
+        return null;
+      }
       return {};
     }),
   } as unknown as ActionCtx;
 
-  return { ctx, createdConversationIds, addMessageCalls };
+  return { ctx, createdConversationIds, addMessageCalls, bindCalls };
 }
 
 describe('createConversationFromEmail', () => {
@@ -137,5 +155,105 @@ describe('createConversationFromEmail', () => {
     expect(createdConversationIds).toHaveLength(1);
     expect(addMessageCalls).toHaveLength(1);
     expect(addMessageCalls[0]?.conversationId).toBe(createdConversationIds[0]);
+  });
+});
+
+// #2985: an inbound attachment's bytes were stored with no record of the mail
+// they arrived on, so nothing could get from the file back to its conversation.
+// The link is what lets an emailed file be readable by whoever can currently
+// read that conversation, instead of carrying a stamped team that goes stale the
+// moment somebody reassigns it.
+describe('createConversationFromEmail — attachment binding', () => {
+  function withAttachment(messageId: string, storageId: string): EmailType {
+    return makeEmail(messageId, '2026-08-19T10:00:00.000Z', {
+      attachments: [
+        {
+          id: 'p1',
+          filename: 'CV.pdf',
+          contentType: 'application/pdf',
+          size: 23_359,
+          storageId,
+        },
+      ],
+    });
+  }
+
+  it('binds a stored attachment to the conversation it landed on', async () => {
+    const { ctx, createdConversationIds, bindCalls } = createMockCtx();
+    await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [withAttachment('<cv@x>', 'blob_cv')],
+    });
+    expect(bindCalls).toEqual([
+      { storageId: 'blob_cv', conversationId: createdConversationIds[0] },
+    ]);
+  });
+
+  it('binds every stored attachment on one email', async () => {
+    const { ctx, bindCalls } = createMockCtx();
+    const email = makeEmail('<two@x>', '2026-08-19T10:00:00.000Z', {
+      attachments: [
+        {
+          id: 'p1',
+          filename: 'CV.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          storageId: 'blob_a',
+        },
+        {
+          id: 'p2',
+          filename: 'Cover.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          storageId: 'blob_b',
+        },
+      ],
+    });
+    await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [email],
+    });
+    expect(bindCalls.map((c) => c.storageId)).toEqual(['blob_a', 'blob_b']);
+  });
+
+  // A metadata-only chip was never materialized, so there is no row to bind.
+  it('skips a part that was never stored', async () => {
+    const { ctx, bindCalls } = createMockCtx();
+    const email = makeEmail('<meta@x>', '2026-08-19T10:00:00.000Z', {
+      attachments: [
+        {
+          id: 'p1',
+          filename: 'CV.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+        },
+      ],
+    });
+    await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [email],
+    });
+    expect(bindCalls).toEqual([]);
+  });
+
+  it('binds nothing for an email with no attachments', async () => {
+    const { ctx, bindCalls } = createMockCtx();
+    await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [makeEmail('<plain@x>', '2026-08-19T10:00:00.000Z')],
+    });
+    expect(bindCalls).toEqual([]);
+  });
+
+  // The ingest already landed the mail; a failed link must not undo that. The
+  // next poll rebinds.
+  it('still reports the ingest when a binding throws', async () => {
+    const { ctx } = createMockCtx({ failBind: true });
+    const result = await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [withAttachment('<boom@x>', 'blob_boom')],
+    });
+    expect(result.created).toBe(true);
+    expect(result.conversationId).not.toBeNull();
   });
 });

--- a/services/platform/convex/conversations/ingest/create_conversation_from_email.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_email.ts
@@ -4,6 +4,10 @@ import type { Id } from '../../_generated/dataModel';
 import type { ActionCtx } from '../../_generated/server';
 import { createDebugLog } from '../../lib/debug_log';
 import { addMessageToConversation } from './add_message_to_conversation';
+import {
+  type AttachmentBinding,
+  bindEmailAttachments,
+} from './bind_email_attachments';
 import { buildConversationMetadata } from './build_conversation_metadata';
 import { buildInitialMessage } from './build_initial_message';
 import { checkConversationExists } from './check_conversation_exists';
@@ -114,6 +118,10 @@ export async function createConversationFromEmail(
   const inBatchMap = new Map<string, Id<'conversations'>>();
   const customerEmailByConversation = new Map<string, string>();
   const conversationIds = new Set<Id<'conversations'>>();
+  /** Ingested email to the conversation it landed on, for the attachment
+   *  binding below. Collected at every site that learns a conversation id —
+   *  all three of them — so a new branch that forgets is visible here. */
+  const attachmentBindings: AttachmentBinding[] = [];
 
   let lastConversationId: Id<'conversations'> | null = null;
   let anyCreated = false;
@@ -146,6 +154,10 @@ export async function createConversationFromEmail(
         email.messageId,
         existingMessage.conversationId,
       );
+      attachmentBindings.push({
+        email,
+        conversationId: existingMessage.conversationId,
+      });
       continue;
     }
 
@@ -230,6 +242,7 @@ export async function createConversationFromEmail(
       conversationIds.add(targetConversationId);
       processedCount++;
       registerInBatch(inBatchMap, email.messageId, targetConversationId);
+      attachmentBindings.push({ email, conversationId: targetConversationId });
       continue;
     }
 
@@ -294,6 +307,7 @@ export async function createConversationFromEmail(
     anyCreated = true;
     processedCount++;
     registerInBatch(inBatchMap, email.messageId, result.conversationId);
+    attachmentBindings.push({ email, conversationId: result.conversationId });
     customerEmailByConversation.set(result.conversationId, customerEmail);
   }
 
@@ -307,6 +321,14 @@ export async function createConversationFromEmail(
       conversationIds: [],
     };
   }
+
+  // After ingest, because the conversation ids only exist now. Best-effort:
+  // the mail is already landed, so a failed link is retried by the next poll
+  // rather than failing the sync.
+  await bindEmailAttachments(ctx, {
+    organizationId: params.organizationId,
+    bindings: attachmentBindings,
+  });
 
   const uniqueConversationIds = [...conversationIds];
 

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -82,6 +82,11 @@ function createMockCtx(
   return { ctx, builder };
 }
 
+async function getBindHandler() {
+  const { bindFileToConversation } = await import('./internal_mutations');
+  return (bindFileToConversation as unknown as { handler: Function }).handler;
+}
+
 async function getSaveHandler() {
   const { saveFileMetadata } = await import('./internal_mutations');
   return (saveFileMetadata as unknown as { handler: Function }).handler;
@@ -930,5 +935,90 @@ describe('updateFileRagStatus document completion CAS', () => {
     expect(ctx.db.patch.mock.calls[0]?.[1]).not.toMatchObject({
       ragStatus: 'completed',
     });
+  });
+});
+
+// The link an inbound attachment never had. Its whole purpose is that an emailed
+// file is readable by whoever can currently read its conversation, so the write
+// has to be scoped and idempotent: a storage id from another organization must
+// not be re-pointed, and a re-poll of the same mail must not write.
+describe('bindFileToConversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const args = {
+    organizationId: 'org_1',
+    storageId: 'storage_1',
+    conversationId: 'conv_1',
+  };
+
+  it('records the conversation on the matching row', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      storageId: 'storage_1',
+    });
+    const handler = await getBindHandler();
+
+    await handler(ctx, args);
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
+      conversationId: 'conv_1',
+    });
+  });
+
+  it('refuses a row belonging to another organization', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'some_other_org',
+      storageId: 'storage_1',
+    });
+    const handler = await getBindHandler();
+
+    await handler(ctx, args);
+
+    // A storage id is not a capability: it must not re-point a foreign row.
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when the row already names that conversation', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      storageId: 'storage_1',
+      conversationId: 'conv_1',
+    });
+    const handler = await getBindHandler();
+
+    await handler(ctx, args);
+
+    // A re-poll of the same mail is a no-op, not a write.
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('rebinds a row that names a different conversation', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      storageId: 'storage_1',
+      conversationId: 'conv_old',
+    });
+    const handler = await getBindHandler();
+
+    await handler(ctx, args);
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
+      conversationId: 'conv_1',
+    });
+  });
+
+  it('does nothing when no row exists for the storage id', async () => {
+    const { ctx } = createMockCtx(null);
+    const handler = await getBindHandler();
+
+    await handler(ctx, args);
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -22,6 +22,34 @@ import {
 import { maybeDispatchRagIndexing, promoteQueuedRagJobs } from './rag_dispatch';
 import { sourceFromProvider } from './source_from_provider';
 
+/**
+ * Record the conversation an email attachment arrived on.
+ *
+ * Idempotent, and scoped: the row must already belong to the organization doing
+ * the binding, so a storage id from elsewhere cannot be re-pointed. Writes only
+ * when the value actually changes, so a re-poll of the same mail is a no-op
+ * rather than a write.
+ */
+export const bindFileToConversation = internalMutation({
+  args: {
+    organizationId: v.string(),
+    storageId: blobRefValidator,
+    conversationId: v.id('conversations'),
+  },
+  returns: v.null(),
+  async handler(ctx, args) {
+    const row = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
+      .first();
+    if (!row) return null;
+    if (row.organizationId !== args.organizationId) return null;
+    if (row.conversationId === args.conversationId) return null;
+    await ctx.db.patch(row._id, { conversationId: args.conversationId });
+    return null;
+  },
+});
+
 export const saveFileMetadata = internalMutation({
   args: {
     organizationId: v.string(),

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -157,6 +157,23 @@ export const fileMetadataTable = defineTable({
    *    blob + RAG purge via `eraseDocumentBlobs` style helper
    */
   threadId: v.optional(v.string()),
+  /**
+   * The conversation an EMAIL ATTACHMENT belongs to.
+   *
+   * A third binding alongside `documentId` and `threadId`, and the one that was
+   * missing: an inbound attachment's bytes were stored with no record of what
+   * they arrived on, so nothing downstream could resolve the mail it came from.
+   *
+   * Set after ingest rather than at storage time. Attachment bytes are drained
+   * per message inside `fetchBodies`, before the conversation is resolved, so
+   * the id does not exist yet when the row is written — see
+   * `bindEmailAttachments`.
+   *
+   * Its purpose is derived visibility: an emailed file is readable by whoever
+   * can currently read its conversation. Stamping a team on the file instead
+   * would be wrong the moment the conversation is reassigned.
+   */
+  conversationId: v.optional(v.id('conversations')),
   lifecycleStatus: v.optional(lifecycleStatusValidator),
   statusChangedAt: v.optional(v.number()),
 })
@@ -174,6 +191,10 @@ export const fileMetadataTable = defineTable({
   ])
   .index('by_org_user', ['organizationId', 'uploadedBy'])
   .index('by_org_contentHash', ['organizationId', 'contentHash'])
+  .index('by_organizationId_and_conversationId', [
+    'organizationId',
+    'conversationId',
+  ])
   // Chat-upload cascade: trash/restore/erase a thread → enumerate the
   // thread's bound files in O(1) per thread. Same shape as the soft-delete
   // composite index for status-narrowed sweeps.


### PR DESCRIPTION
An email attachment now records which conversation it arrived on. Nothing could get from a stored file back to its mail before this.

## Why

`fileMetadata` knew two bindings, both documented in its schema: a Document Hub row via `documentId`, and a chat upload via `threadId`. An email attachment had neither. Its bytes were stored, and what they arrived on was not recorded anywhere.

The reason it matters is derived visibility. An emailed file should be readable by whoever can **currently** read its conversation. That needs a link to derive from.

The alternative — stamping a team on the file at ingest — is wrong the moment somebody reassigns the conversation. Every missed rewrite then leaves a file either hidden from its new owner or still visible to the person who handed it off. Deriving it means there is nothing to keep in sync.

## What changed

`fileMetadata.conversationId`, with `by_organizationId_and_conversationId`.

It binds **after** ingest, not at storage time. Attachment bytes are drained per message inside `fetchBodies` so a page of mail never holds every base64 payload at once, and that runs before the conversation is resolved — there is no id to write yet. `createConversationFromEmail` collects each ingested email with the conversation it landed on, at all three sites that learn one, then binds in a single pass.

## Risk

The write is scoped: a row must already belong to the organization doing the binding, so a storage id cannot re-point a row in another org. A storage id is not a capability.

It is idempotent: an unchanged value writes nothing, so re-polling the same mail is a no-op rather than a write.

It is best-effort: a failure logs and continues rather than failing a sync that has already landed the mail. The attachment is still stored and still shown; only the link is missing, and the next poll rebinds it.

No migration. An optional field and a new index are data-safe, confirmed by `migrations:check`.

## Tests

Five on the mutation — it records, refuses a foreign organization, writes nothing when unchanged, rebinds a changed value, and no-ops when no row exists. Five through the real ingest path — one attachment, several on one email, a metadata-only part with nothing stored, an email with none, and an ingest that still succeeds when a binding throws.

Mutations, all red: dropping the org scope, writing when unchanged, binding parts with no `storageId`, letting a failure fail the ingest, and never binding at all.

## Scope

Groundwork for #2985, which is not closed by this. The duplicate re-ingestion that issue describes was addressed in #3000 by reusing stored pointers, and the display half was fixed in #3009. What remains there is retention reach over these rows, now that they can be found.

Does not index email attachments for RAG. That is the next change, and it needs this link to derive its scope from. One open question for it: the SQL pre-filter treats a row with all scope stamps NULL as an org-wide hub row, which is the outcome to avoid, so it likely needs a `conversation_id` column on the corpus table and a knowledge-DB migration.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, `migrations:check` (no migration), platform 75,168 tests.
