### PR TITLE
feat(platform): scope a corpus row to its conversation

### DIFF
--- a/services/db/migrations/knowledge-db/private_knowledge/00000000000008_knowledge_private_conversation_scope.sql
+++ b/services/db/migrations/knowledge-db/private_knowledge/00000000000008_knowledge_private_conversation_scope.sql
@@ -1,0 +1,41 @@
+-- migrate:up
+--
+-- Conversation scope on corpus documents.
+--
+-- An emailed attachment belongs to a conversation, and conversations are scoped
+-- more narrowly than anything else the corpus holds: admins see all, an
+-- unassigned one is admin-triage only, otherwise the caller must be the
+-- assignee or in the assigned team. That rule is also LIVE — a reassignment
+-- changes who may read the mail, and therefore who may read its attachment.
+--
+-- So the column does not carry the answer, only the question. It records which
+-- conversation the row belongs to; the Convex-truth re-check
+-- (`filterRetrievableRagFileIds`) then applies `conversationAssignmentAllows`
+-- against the conversation's CURRENT assignment. Stamping a team here instead
+-- would be wrong the moment somebody reassigned, and every missed rewrite would
+-- leave a file hidden from its new owner or visible to the person who handed it
+-- off.
+--
+-- Its other job is to keep these rows OUT of the hub clause. A row with every
+-- scope column NULL reads as org-hub, so without this an indexed attachment
+-- would be org-wide by default — the outcome being avoided.
+--
+-- Nullable TEXT with no default: NULL means "not a conversation row", which is
+-- every pre-existing row and every document. Metadata-only, idempotent, safe on
+-- any vintage.
+--
+-- Partial index in the same style as `idx_pk_docs_org_project`: conversation
+-- rows are the minority, so the index stays small.
+
+ALTER TABLE private_knowledge.documents
+    ADD COLUMN IF NOT EXISTS conversation_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_pk_docs_org_conversation
+    ON private_knowledge.documents (org_slug, conversation_id)
+    WHERE conversation_id IS NOT NULL;
+
+-- migrate:down
+-- Deliberately empty, like the other private_knowledge migrations: on a
+-- database that received this column it immediately holds tenancy scope, and
+-- dropping it would silently widen every conversation-scoped attachment back to
+-- org-wide hub visibility. Remove it with an explicit, reviewed migration.

--- a/services/platform/convex/documents/access.test.ts
+++ b/services/platform/convex/documents/access.test.ts
@@ -198,6 +198,34 @@ describe('resolveKnowledgeAccessForUser', () => {
     ]);
   });
 
+  it('carries the identity, so an emailed attachment can be decided at all', async () => {
+    // The other fields are SETS — a conversation-scoped row cannot be expressed
+    // as one, because its reader is whoever the mail is currently assigned to.
+    // So the scope carries who asked, and the Convex-truth re-check asks the
+    // conversation. Without the identity that re-check denies every such row,
+    // which is the fail-closed direction but also means no inbox attachment is
+    // ever found.
+    memberWithRole('member');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx(projects),
+      orgArgs,
+    );
+    expect(access.userId).toBe('user1');
+    expect(access.includeConversationScoped).toBe(true);
+  });
+
+  it('grants a denied caller no identity and no conversation rows', async () => {
+    memberWithRole('disabled');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx(projects),
+      orgArgs,
+    );
+    expect(access.userId).toBeUndefined();
+    expect(access.includeConversationScoped).toBeUndefined();
+  });
+
   it('names which readable projects are archived, without dropping them', async () => {
     memberWithRole('member');
     mockGetUserTeamIds.mockResolvedValue(['team-a']);

--- a/services/platform/convex/documents/access.ts
+++ b/services/platform/convex/documents/access.ts
@@ -231,6 +231,8 @@ export interface ResolvedKnowledgeAccess {
   teamIds: string[];
   projectIds: string[];
   includeHub: boolean;
+  /** Whether conversation-scoped rows are admitted for the re-check to decide. */
+  includeConversationScoped?: boolean;
   /**
    * Which of `projectIds` are archived. NOT a narrowing of what is
    * retrievable: an archived project's material stays searchable and citable.
@@ -240,6 +242,9 @@ export interface ResolvedKnowledgeAccess {
    * under-labels rather than over-filters.
    */
   archivedProjectIds?: string[];
+  /** The user the scope was resolved for. Needed to decide a
+   *  conversation-scoped corpus row by its live assignment. */
+  userId?: string;
 }
 
 /** Fail-closed scope: no hub, no teams, no projects — a search sees nothing. */
@@ -299,5 +304,14 @@ export async function resolveKnowledgeAccessForUser(
     }
   }
 
-  return { teamIds, projectIds, includeHub: true, archivedProjectIds };
+  return {
+    teamIds,
+    projectIds,
+    includeHub: true,
+    archivedProjectIds,
+    userId: args.userId,
+    // Emailed attachments are considered; the Convex-truth re-check decides
+    // each one by the conversation's current assignment.
+    includeConversationScoped: true,
+  };
 }

--- a/services/platform/convex/documents/access.ts
+++ b/services/platform/convex/documents/access.ts
@@ -16,7 +16,7 @@
  * or `canReadDocument` (async, resolves project access for single-doc reads).
  */
 
-import { ConvexError } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import type { Doc } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
@@ -246,6 +246,28 @@ export interface ResolvedKnowledgeAccess {
    *  conversation-scoped corpus row by its live assignment. */
   userId?: string;
 }
+
+/**
+ * The wire shape of {@link ResolvedKnowledgeAccess}, declared ONCE.
+ *
+ * It was declared three times — the resolver's returns, the re-check's args,
+ * and the sandbox bridge's returns — and adding a field to the scope meant
+ * finding all three. Missing one does not fail politely: a closed returns
+ * validator THROWS on the unexpected field, and a throwing query reads to the
+ * caller as "no results", so a widened scope would present as knowledge search
+ * having gone quiet.
+ *
+ * `threadIds` is not here: it belongs to the chat lane's request, not to what
+ * the resolver derives, and the re-check adds it to its own args.
+ */
+export const knowledgeAccessScopeValidator = v.object({
+  teamIds: v.array(v.string()),
+  projectIds: v.array(v.string()),
+  includeHub: v.boolean(),
+  archivedProjectIds: v.optional(v.array(v.string())),
+  includeConversationScoped: v.optional(v.boolean()),
+  userId: v.optional(v.string()),
+});
 
 /** Fail-closed scope: no hub, no teams, no projects — a search sees nothing. */
 export const NO_KNOWLEDGE_ACCESS: ResolvedKnowledgeAccess = {

--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.conversation_scope.test.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.conversation_scope.test.ts
@@ -1,0 +1,231 @@
+// The gate that decides an emailed attachment.
+//
+// Its own file because it needs the identity modules mocked, and the sibling
+// suite deliberately runs against a bare fake ctx. What is mocked here is only
+// the Better Auth I/O — `resolveAgentReadAccess`, `authorizeRls` and
+// `conversationAssignmentAllows` all run for real, so the rule under test is
+// the shipped rule and not a restatement of it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getUserTeamIds = vi.fn();
+const getUserOrganizations = vi.fn();
+
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: (...args: unknown[]) => getUserTeamIds(...args),
+}));
+vi.mock('../lib/rls/organization/get_user_organizations', () => ({
+  getUserOrganizations: (...args: unknown[]) => getUserOrganizations(...args),
+}));
+
+const { filterRetrievableRagFileIds } =
+  await import('./filter_retrievable_rag_file_ids');
+
+const ORG = 'org_mail';
+const OTHER_ORG = 'org_other';
+const USER = 'user_asking';
+const TEAM_MINE = 'team_mine';
+const TEAM_THEIRS = 'team_theirs';
+const ATTACHMENT = 'blob_cv';
+const CONVERSATION = 'conv_inbound';
+
+/** Access that admits conversation rows, as the resolver now always does. */
+const ACCESS = {
+  teamIds: [],
+  projectIds: [],
+  includeHub: true,
+  includeConversationScoped: true,
+  userId: USER,
+} as const;
+
+/**
+ * A ctx holding one emailed attachment bound to one conversation.
+ *
+ * `rows` overrides let a case bend one fact — the conversation's assignment,
+ * its org, the metadata's status — without restating the rest.
+ */
+function createCtx(
+  overrides: {
+    metadata?: Record<string, unknown>;
+    conversation?: Record<string, unknown> | null;
+  } = {},
+) {
+  const metadata = {
+    organizationId: ORG,
+    storageId: ATTACHMENT,
+    conversationId: CONVERSATION,
+    ragStatus: 'completed',
+    ...overrides.metadata,
+  };
+  const conversation =
+    overrides.conversation === null
+      ? null
+      : { _id: CONVERSATION, organizationId: ORG, ...overrides.conversation };
+  return {
+    db: {
+      query: () => ({
+        withIndex: (
+          _name: string,
+          bind: (q: { eq: (f: string, v: unknown) => unknown }) => unknown,
+        ) => {
+          let storageId = '';
+          const q = {
+            eq(field: string, value: unknown) {
+              if (field === 'storageId') storageId = String(value);
+              return q;
+            },
+          };
+          bind(q);
+          return {
+            first: async () => (storageId === ATTACHMENT ? metadata : null),
+          };
+        },
+      }),
+      get: async (id: string) => (id === CONVERSATION ? conversation : null),
+    },
+  } as never;
+}
+
+async function retrievableFor(
+  ctx: unknown,
+  args: Record<string, unknown> = {},
+): Promise<string[]> {
+  return filterRetrievableRagFileIds(ctx as never, {
+    organizationId: ORG,
+    fileIds: [ATTACHMENT as never],
+    access: ACCESS as never,
+    userId: USER,
+    ...args,
+  });
+}
+
+describe('filterRetrievableRagFileIds — emailed attachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'member' },
+    ]);
+    getUserTeamIds.mockResolvedValue([TEAM_MINE]);
+  });
+
+  it('serves the individual assignee', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+      ),
+    ).toEqual([ATTACHMENT]);
+  });
+
+  it('serves a member of the assigned team', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_MINE } }),
+      ),
+    ).toEqual([ATTACHMENT]);
+  });
+
+  it('denies another team’s mail, and unassigned mail, to a plain member', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_THEIRS } }),
+      ),
+    ).toEqual([]);
+    // Neither stamp is admin-triage state, not org-readable.
+    expect(await retrievableFor(createCtx({ conversation: {} }))).toEqual([]);
+  });
+
+  it('serves an admin anything, including unassigned mail', async () => {
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'admin' },
+    ]);
+    expect(await retrievableFor(createCtx({ conversation: {} }))).toEqual([
+      ATTACHMENT,
+    ]);
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_THEIRS } }),
+      ),
+    ).toEqual([ATTACHMENT]);
+  });
+
+  it('denies a caller who did not say who they are', async () => {
+    const ctx = createCtx({ conversation: { assigneeUserId: USER } });
+    expect(await retrievableFor(ctx, { userId: undefined })).toEqual([]);
+    // …and does not spend a membership lookup finding that out.
+    expect(getUserOrganizations).not.toHaveBeenCalled();
+  });
+
+  it('denies when the scope excludes conversation rows', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        {
+          access: { ...ACCESS, includeConversationScoped: false },
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies a non-member and a role that cannot read conversations', async () => {
+    const ctx = createCtx({ conversation: { assigneeUserId: USER } });
+    getUserOrganizations.mockResolvedValue([]);
+    expect(await retrievableFor(ctx)).toEqual([]);
+
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'disabled' },
+    ]);
+    expect(await retrievableFor(ctx)).toEqual([]);
+  });
+
+  it('denies a conversation belonging to another organization', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({
+          conversation: { assigneeUserId: USER, organizationId: OTHER_ORG },
+        }),
+      ),
+    ).toEqual([]);
+    // A dangling reference is a miss, not a crash.
+    expect(await retrievableFor(createCtx({ conversation: null }))).toEqual([]);
+  });
+
+  it('never returns an emailed attachment to a folder-scoped search', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { folder: 'Contracts' },
+      ),
+    ).toEqual([]);
+  });
+
+  it('still requires the attachment itself to be indexed and untrashed', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({
+          metadata: { ragStatus: 'running' },
+          conversation: { assigneeUserId: USER },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      await retrievableFor(
+        createCtx({
+          metadata: { lifecycleStatus: 'trashed' },
+          conversation: { assigneeUserId: USER },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('resolves teams once per call, and not at all when the assignee decides it', async () => {
+    await retrievableFor(
+      createCtx({ conversation: { assigneeUserId: USER } }),
+      { fileIds: [ATTACHMENT, ATTACHMENT] as never },
+    );
+    // The individual-assignee branch settles it, so the Better Auth team
+    // round-trip is never paid — the laziness `conversation_assignment.ts`
+    // documents, preserved through this reader.
+    expect(getUserTeamIds).toHaveBeenCalledTimes(1);
+    expect(getUserOrganizations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
@@ -3,6 +3,10 @@ import {
   type KnowledgeAccessScope,
 } from '../../lib/knowledge/types';
 import type { QueryCtx } from '../_generated/server';
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { resolveAgentReadAccess } from '../lib/rls/helpers/agent_read_access';
+import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
+import { isAdmin } from '../lib/rls/helpers/role_helpers';
 import type { BlobRef } from '../lib/storage/blob_ref';
 import { isActiveDocument } from './_helpers';
 
@@ -10,6 +14,8 @@ export interface FilterRetrievableRagFileIdsArgs {
   readonly organizationId: string;
   readonly fileIds: readonly BlobRef[];
   readonly access?: KnowledgeAccessScope;
+  /** The turn user, for deciding conversation-scoped rows. Absent denies them. */
+  readonly userId?: string;
   readonly folder?: string;
 }
 
@@ -20,6 +26,11 @@ export interface FilterRetrievableRagFileIdsArgs {
  * change. A document hit is returnable only while its metadata is completed,
  * its linked document is active and still points at that exact blob, and its
  * current scope/folder still matches the request.
+ *
+ * An emailed attachment (`conversationId` set, no `documentId`) is its own
+ * access class too, and the only one decided from LIVE state rather than a
+ * stamp: the caller must currently be able to read the conversation the mail
+ * arrived on, so reassigning the mail moves its attachments with it.
  *
  * A thread-bound chat upload (`threadId` set, no `documentId`) is its own
  * access class — the 0.3 model (`verify_thread_scoped_access`): retrievable
@@ -33,6 +44,49 @@ export async function filterRetrievableRagFileIds(
   const retrievable: string[] = [];
   const seen = new Set<string>();
   const allowedThreadIds = new Set(args.access?.threadIds ?? []);
+
+  /**
+   * Role and teams for the assignment decision, resolved once and only when a
+   * conversation-scoped row is actually hit.
+   *
+   * Resolved HERE from the caller's identity rather than accepted as arguments:
+   * an `isAdmin` flag travelling in is one refactor away from being wrong in the
+   * direction that publishes an inbox. `null` means the caller is not a member,
+   * or their role denies conversations.
+   */
+  let callerPromise:
+    | Promise<{
+        isAdmin: boolean;
+        userId: string;
+        teamIds: ReadonlySet<string>;
+      } | null>
+    | undefined;
+  const conversationCaller = (): Promise<{
+    isAdmin: boolean;
+    userId: string;
+    teamIds: ReadonlySet<string>;
+  } | null> => {
+    callerPromise ??= (async () => {
+      const userId = args.userId;
+      // Fail closed on a surface that did not say who is asking: an inbox
+      // attachment is never served to an unidentified caller. This is the ONE
+      // place that decision is made — a second early guard beside the call site
+      // read as belt-and-braces but no test could tell it from dead code.
+      if (userId === undefined) return null;
+      const access = await resolveAgentReadAccess(ctx, {
+        organizationId: args.organizationId,
+        userId,
+        subject: 'conversations',
+      });
+      if (!access.allowed) return null;
+      return {
+        isAdmin: isAdmin(access.role),
+        userId,
+        teamIds: new Set(await getUserTeamIds(ctx, userId)),
+      };
+    })();
+    return callerPromise;
+  };
 
   for (const fileId of args.fileIds) {
     const ref = String(fileId);
@@ -59,6 +113,43 @@ export async function filterRetrievableRagFileIds(
         allowedThreadIds.has(metadata.threadId) &&
         (args.folder === undefined || args.folder === '')
       ) {
+        retrievable.push(ref);
+      }
+      continue;
+    }
+
+    // An emailed attachment. It has no document row, so without this branch it
+    // falls through the `documentId` check below and is denied outright.
+    //
+    // This is the gate that makes conversation scope work. The SQL side only
+    // ADMITTED the row; who may read it is decided here, from the conversation's
+    // CURRENT assignment, using the same predicate `rls_rules.ts` uses. A
+    // reassignment therefore moves the attachment with the mail, and nothing has
+    // to be rewritten.
+    if (metadata.conversationId !== undefined) {
+      // A scope that excludes conversations is honoured here too, not only in
+      // the SQL pre-filter — the pre-filter is the half that fails open.
+      if (args.access !== undefined && !args.access.includeConversationScoped) {
+        continue;
+      }
+      const conversation = await ctx.db.get(metadata.conversationId);
+      if (
+        conversation === null ||
+        conversation.organizationId !== args.organizationId
+      ) {
+        continue;
+      }
+      const caller = await conversationCaller();
+      if (caller === null) continue;
+      const allowed = await conversationAssignmentAllows(conversation, {
+        isAdmin: caller.isAdmin,
+        userId: caller.userId,
+        hasTeam: (teamId) => caller.teamIds.has(teamId),
+      });
+      // The folder filter is a Document Hub concept; a folder-scoped search
+      // never returns emailed attachments, exactly as it never returns chat
+      // uploads.
+      if (allowed && (args.folder === undefined || args.folder === '')) {
         retrievable.push(ref);
       }
       continue;

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -7,8 +7,9 @@ import { blobRefValidator } from '../lib/storage/blob_ref';
 import { toId } from '../lib/type_cast_helpers';
 import { resolveProjectAccessForUser } from '../projects/resolve_project_access';
 import {
-  resolveKnowledgeAccessForUser,
+  knowledgeAccessScopeValidator,
   type ResolvedKnowledgeAccess,
+  resolveKnowledgeAccessForUser,
 } from './access';
 import { checkMembership } from './check_membership';
 import { filterRetrievableRagFileIds as filterRetrievableRagFileIdsHelper } from './filter_retrievable_rag_file_ids';
@@ -359,14 +360,7 @@ export const resolveKnowledgeAccess = internalQuery({
     organizationId: v.string(),
     userId: v.string(),
   },
-  returns: v.object({
-    teamIds: v.array(v.string()),
-    projectIds: v.array(v.string()),
-    includeHub: v.boolean(),
-    archivedProjectIds: v.optional(v.array(v.string())),
-    includeConversationScoped: v.optional(v.boolean()),
-    userId: v.optional(v.string()),
-  }),
+  returns: knowledgeAccessScopeValidator,
   handler: async (ctx, args): Promise<ResolvedKnowledgeAccess> => {
     return await resolveKnowledgeAccessForUser(ctx, args);
   },
@@ -383,12 +377,8 @@ export const filterRetrievableRagFileIds = internalQuery({
     fileIds: v.array(blobRefValidator),
     access: v.optional(
       v.object({
-        teamIds: v.array(v.string()),
-        projectIds: v.array(v.string()),
-        includeHub: v.boolean(),
-        archivedProjectIds: v.optional(v.array(v.string())),
+        ...knowledgeAccessScopeValidator.fields,
         threadIds: v.optional(v.array(v.string())),
-        includeConversationScoped: v.optional(v.boolean()),
       }),
     ),
     folder: v.optional(v.string()),

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -364,6 +364,8 @@ export const resolveKnowledgeAccess = internalQuery({
     projectIds: v.array(v.string()),
     includeHub: v.boolean(),
     archivedProjectIds: v.optional(v.array(v.string())),
+    includeConversationScoped: v.optional(v.boolean()),
+    userId: v.optional(v.string()),
   }),
   handler: async (ctx, args): Promise<ResolvedKnowledgeAccess> => {
     return await resolveKnowledgeAccessForUser(ctx, args);
@@ -386,9 +388,13 @@ export const filterRetrievableRagFileIds = internalQuery({
         includeHub: v.boolean(),
         archivedProjectIds: v.optional(v.array(v.string())),
         threadIds: v.optional(v.array(v.string())),
+        includeConversationScoped: v.optional(v.boolean()),
       }),
     ),
     folder: v.optional(v.string()),
+    /** The turn user. Required to serve a conversation-scoped row; without it
+     *  those rows are denied. */
+    userId: v.optional(v.string()),
   },
   returns: v.array(v.string()),
   handler: async (ctx, args) => {

--- a/services/platform/convex/knowledge/corpus.test.ts
+++ b/services/platform/convex/knowledge/corpus.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import type { Sql } from 'postgres';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DocumentCorpusReader, WebCorpusReader } from './corpus';
 import { markBm25Unavailable } from './pool';
@@ -353,6 +353,54 @@ describe('the keyword leg degrades instead of failing', () => {
       expect(await reader.keyword(LEG)).toBeNull();
     },
   );
+
+  it('names the remedy when a COLUMN is missing, not "no corpus"', async () => {
+    // A corpus whose table exists but lacks a column this release selects is a
+    // deployment mid-upgrade: the bundled knowledge database applies its dbmate
+    // migrations at container start, so a platform image updated without
+    // restarting that container leaves every search returning nothing.
+    //
+    // It must degrade, and the line must not borrow the missing-table message —
+    // that one sends the operator looking for an empty corpus.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const failing = {
+        unsafe: () =>
+          Promise.reject(
+            Object.assign(
+              new Error('column d.conversation_id does not exist'),
+              {
+                code: '42703',
+              },
+            ),
+          ),
+      } as unknown as Sql;
+      const probeOk = Object.assign(
+        () => Promise.resolve([{ '?column?': 1 }]),
+        failing,
+      ) as unknown as Sql;
+
+      expect(await new DocumentCorpusReader(probeOk, 'acme').keyword(LEG)).toBe(
+        null,
+      );
+      expect(
+        await new DocumentCorpusReader(probeOk, 'acme').dense({
+          ...LEG,
+          embedding: EMBEDDING,
+        }),
+      ).toEqual([]);
+
+      const lines = warn.mock.calls.map((call) => call.join(' '));
+      expect(lines).toHaveLength(2);
+      for (const line of lines) {
+        expect(line).toContain('missing a column');
+        expect(line).toContain('knowledge database container');
+        expect(line).not.toContain('not created yet');
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
 
   it('skips the leg entirely on a database known to have no index', async () => {
     const { sql, sent } = recorder();

--- a/services/platform/convex/knowledge/corpus.test.ts
+++ b/services/platform/convex/knowledge/corpus.test.ts
@@ -144,8 +144,12 @@ describe('the documents corpus is scoped to one organization', () => {
     for (const statement of statements) {
       // Hub rows are the unscoped ones — all scope columns NULL — and the
       // caller's teams/projects widen from there; nothing else matches.
+      // `conversation_id IS NULL` belongs to that list: an emailed attachment
+      // carries no team and no project, so without it every indexed inbox
+      // attachment would read as an org-hub document.
       expect(statement.text).toContain(
-        '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL)',
+        '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL' +
+          ' AND d.conversation_id IS NULL)',
       );
       expect(statement.text).toContain('d.project_id = ANY(');
       expect(statement.params).toContainEqual(['team-a', 'team-b']);
@@ -218,6 +222,53 @@ describe('the documents corpus is scoped to one organization', () => {
     expect(statement.text).toContain('d.team_ids && ');
   });
 
+  it('admits conversation rows on both legs when the scope allows them', async () => {
+    // The SQL side only ADMITS an emailed attachment — it cannot know who may
+    // read the mail, because that answer lives in the conversation's current
+    // assignment. So the clause is deliberately the widest possible one, and
+    // `filterRetrievableRagFileIds` is what decides each row.
+    const { sql, sent } = recorder();
+    const reader = new DocumentCorpusReader(sql, 'acme');
+    const access = {
+      teamIds: [],
+      projectIds: [],
+      includeHub: true,
+      includeConversationScoped: true,
+    };
+    await reader.keyword({ ...LEG, access });
+    await reader.dense({ ...LEG, access, embedding: EMBEDDING });
+
+    const statements = corpusStatements(sent);
+    expect(statements.length).toBe(2);
+    for (const statement of statements) {
+      expect(statement.text).toContain('d.conversation_id IS NOT NULL');
+    }
+  });
+
+  it('omits the conversation disjunct for a scope that excludes them', async () => {
+    const { sql, sent } = recorder();
+    await new DocumentCorpusReader(sql, 'acme').dense({
+      ...LEG,
+      access: { teamIds: ['team-a'], projectIds: [], includeHub: true },
+      embedding: EMBEDDING,
+    });
+    const statement = corpusStatements(sent)[0];
+    expect(statement.text).not.toContain('d.conversation_id IS NOT NULL');
+    // The hub clause still names the column, so this must not be read as
+    // "the column is absent" — only the admitting disjunct is.
+    expect(statement.text).toContain('d.conversation_id IS NULL');
+  });
+
+  it('selects the conversation id so a hit can name where it arrived', async () => {
+    const { sql, sent } = recorder();
+    const reader = new DocumentCorpusReader(sql, 'acme');
+    await reader.keyword({ ...LEG });
+    await reader.dense({ ...LEG, embedding: EMBEDDING });
+    for (const statement of corpusStatements(sent)) {
+      expect(statement.text).toContain('d.conversation_id');
+    }
+  });
+
   it('adds no scope clause for an org-wide caller', async () => {
     // Absent access = the admin-keyed surfaces (org REST key, MCP lane):
     // exactly the pre-scoping statement, so nothing changes for them.
@@ -232,6 +283,7 @@ describe('the documents corpus is scoped to one organization', () => {
     // caller can be told a hit belongs to a retired project; that is not a
     // scope clause and must not read as one.
     expect(statement.text).not.toContain('d.project_id = ANY');
+    expect(statement.text).not.toContain('d.conversation_id IS NOT NULL');
   });
 
   it('passes the query vector as a parameter, never as interpolated text', async () => {

--- a/services/platform/convex/knowledge/corpus.ts
+++ b/services/platform/convex/knowledge/corpus.ts
@@ -66,6 +66,10 @@ interface CorpusRow {
    * every web page. Selected so a caller can label a hit as belonging to a
    * retired project without a second read. */
   project_id: string | null;
+  /** The conversation an emailed attachment arrived on; NULL for a document and
+   * for every web page. Selected so the re-check knows which rows it must decide
+   * by assignment rather than by scope stamp. */
+  conversation_id: string | null;
   modified_at: Date | null;
   /** Char position of the chunk within the ref's fetchable text, cast to
    * text (SUM is bigint); NULL when it cannot be established. */
@@ -99,7 +103,7 @@ export class DocumentCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
-             d.project_id,
+             d.project_id, d.conversation_id,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
              (SELECT COALESCE(SUM(length(c2.core_content)), 0)
                 FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
@@ -131,7 +135,7 @@ export class DocumentCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
-             d.project_id,
+             d.project_id, d.conversation_id,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
              (SELECT COALESCE(SUM(length(c2.core_content)), 0)
                 FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
@@ -190,9 +194,27 @@ export class DocumentCorpusReader implements CorpusReader {
       // access means org-wide (admin-keyed surfaces) and adds no clause.
       const disjuncts: string[] = [];
       if (query.access.includeHub) {
+        // `conversation_id IS NULL` is part of being a hub row. Without it an
+        // indexed email attachment — which carries no team and no project —
+        // would read as org-hub and be visible to everyone, which is the
+        // outcome conversation scope exists to prevent.
         disjuncts.push(
-          '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL)',
+          '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL' +
+            ' AND d.conversation_id IS NULL)',
         );
+      }
+      // Conversation-scoped rows are admitted here and DECIDED by the
+      // Convex-truth re-check, which applies `conversationAssignmentAllows`
+      // against the conversation's current assignment.
+      //
+      // Deliberately not `conversation_id = ANY($n)`: that would need the
+      // caller's readable conversations enumerated, and assignment privacy makes
+      // that an unbounded walk — the reason the chat conversations leg caps its
+      // own scan at 300. Admitting and then re-checking is bounded by the result
+      // limit instead, and the re-check fails closed, so a path that reaches SQL
+      // without it returns rows that are then dropped rather than served.
+      if (query.access.includeConversationScoped) {
+        disjuncts.push('d.conversation_id IS NOT NULL');
       }
       params.push([...query.access.teamIds]);
       // A document shared to several teams is visible to a member of ANY of
@@ -255,7 +277,7 @@ export class WebCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
-             NULL::text AS project_id,
+             NULL::text AS project_id, NULL::text AS conversation_id,
              u.last_crawled_at AS modified_at,
              CASE WHEN c.core_content <> ''
                    AND position(c.core_content IN u.content) > 0
@@ -284,7 +306,7 @@ export class WebCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
-             NULL::text AS project_id,
+             NULL::text AS project_id, NULL::text AS conversation_id,
              u.last_crawled_at AS modified_at,
              CASE WHEN c.core_content <> ''
                    AND position(c.core_content IN u.content) > 0
@@ -390,6 +412,7 @@ function toHits(
         title: row.title,
         url: row.url,
         projectId: row.project_id,
+        conversationId: row.conversation_id,
         modifiedAt: row.modified_at ? row.modified_at.getTime() : null,
       },
       score: row.score,

--- a/services/platform/convex/knowledge/corpus.ts
+++ b/services/platform/convex/knowledge/corpus.ts
@@ -339,6 +339,30 @@ export class WebCorpusReader implements CorpusReader {
  * continues dense-only, because an index that needs rebuilding is an operational
  * problem and not a reason to stop answering.
  */
+/**
+ * A corpus whose table exists but lacks a column the current code selects.
+ *
+ * Distinct from a missing table, and it must not borrow that message. The table
+ * being absent means nothing was ever indexed, which is a normal empty result.
+ * A missing COLUMN means the corpus predates the running code: the bundled
+ * knowledge database applies its dbmate migrations at container start
+ * (`services/db/docker-entrypoint.sh`), so a platform image updated without
+ * restarting that container leaves every search returning nothing. Saying "not
+ * created yet" there sends the operator to look for an empty corpus.
+ *
+ * Returns empty rather than throwing, because one deployment mid-upgrade should
+ * degrade to "no results" instead of failing every chat turn. The warning is
+ * what makes the degraded state visible.
+ */
+function missingColumnRemedy(corpus: string, err: unknown): string {
+  return (
+    `the ${corpus} corpus is missing a column this release selects, so ` +
+    'searches return nothing: ' +
+    `${describe(err)}. Apply the knowledge-db migrations — restart the ` +
+    'knowledge database container, which runs them at start.'
+  );
+}
+
 async function runKeywordLeg(
   sql: Sql,
   corpus: Exclude<KnowledgeCorpus, 'all'>,
@@ -361,8 +385,12 @@ async function runKeywordLeg(
       );
       return null;
     }
-    if (isUndefinedTable(err) || isUndefinedColumn(err)) {
+    if (isUndefinedTable(err)) {
       logger.info(`the ${corpus} corpus is not created yet on this database`);
+      return null;
+    }
+    if (isUndefinedColumn(err)) {
+      logger.warn(missingColumnRemedy(corpus, err));
       return null;
     }
     throw err;
@@ -383,8 +411,12 @@ async function runDenseLeg(
   try {
     return toHits(await sql.unsafe<CorpusRow[]>(statement, params), corpus);
   } catch (err) {
-    if (isUndefinedTable(err) || isUndefinedColumn(err)) {
+    if (isUndefinedTable(err)) {
       logger.info(`the ${corpus} corpus is not created yet on this database`);
+      return [];
+    }
+    if (isUndefinedColumn(err)) {
+      logger.warn(missingColumnRemedy(corpus, err));
       return [];
     }
     throw err;

--- a/services/platform/convex/knowledge/ddl.test.ts
+++ b/services/platform/convex/knowledge/ddl.test.ts
@@ -71,6 +71,10 @@ describe('the real migrations are what gets applied', () => {
   it('declares the columns retrieval and reassembly depend on', () => {
     // If a migration ever loses one of these, retrieval breaks in a way that
     // looks like bad search results rather than like a missing column.
+    //
+    // The scope columns are checked in the case below instead: a substring
+    // search over the joined SQL also matches these files' prose, so it would
+    // pass on a migration that only TALKS about `conversation_id`.
     delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
     const all = corpusMigrations()
       .map((m) => m.sql)
@@ -101,6 +105,28 @@ describe('the real migrations are what gets applied', () => {
         later.some((m) =>
           m.sql.includes('ADD COLUMN IF NOT EXISTS context_header'),
         ),
+      ).toBe(true);
+    }
+  });
+
+  it('adds each scope column outside the private_knowledge baseline', () => {
+    // Same regression class as the chunk-context convergence, with a worse
+    // failure mode: a ledgered database never re-runs its baseline, so a scope
+    // column declared only there is absent in production while the code filters
+    // on it — the statement errors, and a failing retrieval reads as "no
+    // results" rather than as a broken deployment.
+    delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
+    const later = corpusMigrations()
+      .filter((m) => m.schema === 'private_knowledge')
+      .slice(1);
+    for (const column of [
+      'team_id',
+      'project_id',
+      'team_ids',
+      'conversation_id',
+    ]) {
+      expect(
+        later.some((m) => m.sql.includes(`ADD COLUMN IF NOT EXISTS ${column}`)),
       ).toBe(true);
     }
   });

--- a/services/platform/convex/knowledge/fetch.test.ts
+++ b/services/platform/convex/knowledge/fetch.test.ts
@@ -236,6 +236,50 @@ describe('fetchDocumentByFileId — access scope', () => {
     expect(doc).toBeNull();
   });
 
+  it('does not serve an emailed attachment to a caller who cannot read mail', async () => {
+    // Scope-by-set cannot decide a conversation row, so the SQL half only
+    // decides whether such rows are in play at all. A caller whose scope
+    // excludes them gets a miss without a Convex round-trip, and the body is
+    // never read.
+    corpusWith({ team_id: null, project_id: null, conversation_id: 'conv_1' });
+    const doc = await fetchDocumentByFileId('acme', 'file_9', SCOPED);
+    expect(doc).toBeNull();
+    expect(unsafe.mock.calls.some(([text]) => text.includes('.chunks'))).toBe(
+      false,
+    );
+    expect(validateLiveFile).not.toHaveBeenCalled();
+  });
+
+  it('hands an emailed attachment to the Convex re-check, hub visibility notwithstanding', async () => {
+    // Its scope columns are all NULL, so scope-by-set would read it as an
+    // org-hub document and serve it. It must instead reach the re-check, which
+    // is the only code that can see the conversation's assignment.
+    corpusWith({ team_id: null, project_id: null, conversation_id: 'conv_1' });
+    validateLiveFile.mockImplementation(async () => []);
+    const denied = await fetchDocumentByFileId('acme', 'file_9', {
+      ...SCOPED,
+      includeConversationScoped: true,
+    });
+    expect(denied).toBeNull();
+    expect(validateLiveFile).toHaveBeenCalled();
+
+    validateLiveFile.mockImplementation(
+      async (_ref: unknown, args: { fileIds: string[] }) => args.fileIds,
+    );
+    const served = await fetchDocumentByFileId('acme', 'file_9', {
+      ...SCOPED,
+      includeConversationScoped: true,
+    });
+    expect(served?.text).toBe('SCOPED BODY');
+  });
+
+  it('selects the conversation column for a scoped caller', async () => {
+    corpusWith({ team_id: null, project_id: null });
+    await fetchDocumentByFileId('acme', 'file_9', SCOPED);
+    const [docCall] = unsafe.mock.calls;
+    expect(docCall?.[0]).toContain('d.conversation_id');
+  });
+
   it('serves a team-library row to a member of that team', async () => {
     corpusWith({
       team_ids: ['team-a'],

--- a/services/platform/convex/knowledge/fetch.ts
+++ b/services/platform/convex/knowledge/fetch.ts
@@ -113,7 +113,9 @@ export async function fetchDocumentByFileId(
   // deprecated first-element mirror, still read so a row the `team_ids` DDL
   // backfill has not stamped keeps its single-team visibility.
   const scopeColumns =
-    args.access !== undefined ? ', d.team_ids, d.team_id, d.project_id' : '';
+    args.access !== undefined
+      ? ', d.team_ids, d.team_id, d.project_id, d.conversation_id'
+      : '';
   try {
     const documents = await sql.unsafe<
       Array<{
@@ -124,6 +126,7 @@ export async function fetchDocumentByFileId(
         team_ids?: string[] | null;
         team_id?: string | null;
         project_id?: string | null;
+        conversation_id?: string | null;
       }>
     >(
       `
@@ -137,7 +140,16 @@ export async function fetchDocumentByFileId(
     );
     const document = documents[0];
     if (!document) return null;
-    if (
+    // A conversation row is decided by the conversation's live assignment, which
+    // this SQL cannot see, so scope-by-set does not apply to it — the mandatory
+    // Convex-truth re-check below is its gate. All that is decided here is
+    // whether such rows are in play for this caller at all: a caller who cannot
+    // read conversations gets an honest miss without touching Convex.
+    if (document.conversation_id != null) {
+      if (args.access !== undefined && !args.access.includeConversationScoped) {
+        return null;
+      }
+    } else if (
       !knowledgeScopeAllows(args.access, {
         teamIds: document.team_ids,
         teamId: document.team_id,
@@ -153,12 +165,21 @@ export async function fetchDocumentByFileId(
       {
         organizationId: args.organizationId,
         fileIds: [args.fileId],
+        ...(args.access?.userId !== undefined
+          ? { userId: args.access.userId }
+          : {}),
         ...(args.access !== undefined
           ? {
               access: {
                 teamIds: [...args.access.teamIds],
                 projectIds: [...args.access.projectIds],
                 includeHub: args.access.includeHub,
+                ...(args.access.includeConversationScoped !== undefined
+                  ? {
+                      includeConversationScoped:
+                        args.access.includeConversationScoped,
+                    }
+                  : {}),
                 ...(args.access.threadIds !== undefined
                   ? { threadIds: [...args.access.threadIds] }
                   : {}),

--- a/services/platform/convex/knowledge/indexing.test.ts
+++ b/services/platform/convex/knowledge/indexing.test.ts
@@ -377,6 +377,30 @@ describe('document scope is stamped on the corpus row', () => {
     expect(stamped?.params[7]).toBe('team-sales');
   });
 
+  it('stamps the conversation an emailed attachment arrived on', async () => {
+    // Without this the row lands with every scope column NULL — an org-hub
+    // document — and the inbox attachment becomes readable by the whole
+    // organization. The stamp is also the QUESTION, not the answer: retrieval
+    // re-asks the conversation's current assignment, so a reassignment moves
+    // the file without touching this row.
+    const db = fakeDb();
+    await indexDocument({
+      ...ARGS,
+      sql: db.sql,
+      embedder: stubEmbedder(),
+      teamIds: null,
+      projectId: null,
+      conversationId: 'conv_inbound',
+    });
+    const stamped = claim(db);
+    expect(stamped?.text).toContain('conversation_id');
+    expect(stamped?.text).toContain(
+      'conversation_id = EXCLUDED.conversation_id',
+    );
+    // $10 is conversation_id, after team_ids/team_id/project_id.
+    expect(stamped?.params[9]).toBe('conv_inbound');
+  });
+
   it('carries the project scope, and stamps NULLs for a hub document', async () => {
     const project = fakeDb();
     await indexDocument({
@@ -404,6 +428,8 @@ describe('document scope is stamped on the corpus row', () => {
       expect(stamped?.params[6]).toBeNull();
       expect(stamped?.params[7]).toBeNull();
       expect(stamped?.params[8]).toBeNull();
+      // …and it is not a conversation row either.
+      expect(stamped?.params[9]).toBeNull();
     }
   });
 });

--- a/services/platform/convex/knowledge/indexing.ts
+++ b/services/platform/convex/knowledge/indexing.ts
@@ -72,6 +72,16 @@ export interface IndexDocumentArgs {
    */
   readonly teamIds?: readonly string[] | null;
   readonly projectId?: string | null;
+  /**
+   * The conversation an emailed attachment arrived on, when the file IS one.
+   *
+   * A third scope dimension rather than a value folded into the two above,
+   * because it is not an answer: conversation visibility is decided live from
+   * the conversation's current assignment, so the row records only which
+   * conversation to ask about. Its other job is to keep the row out of the hub
+   * clause — every scope column NULL reads as org-wide.
+   */
+  readonly conversationId?: string | null;
   readonly sourceCreatedAt?: Date | null;
   readonly sourceModifiedAt?: Date | null;
   /** Chunks to commit in this invocation. */
@@ -166,6 +176,7 @@ export async function indexDocument(
     folderPath: args.folderPath ?? null,
     teamIds: args.teamIds ?? null,
     projectId: args.projectId ?? null,
+    conversationId: args.conversationId ?? null,
     sourceCreatedAt: args.sourceCreatedAt ?? null,
     sourceModifiedAt: args.sourceModifiedAt ?? null,
     // Only content that is actually the same keeps its committed chunks.
@@ -306,6 +317,7 @@ async function claimDocumentRow(args: {
   folderPath: string | null;
   teamIds: readonly string[] | null;
   projectId: string | null;
+  conversationId: string | null;
   sourceCreatedAt: Date | null;
   sourceModifiedAt: Date | null;
   keepChunks: boolean;
@@ -319,9 +331,10 @@ async function claimDocumentRow(args: {
     const rows = await tx.unsafe<{ id: string }[]>(
       `INSERT INTO ${SCHEMA}.documents
           (org_slug, file_id, filename, content_hash, status, chunks_count,
-           folder_path, team_ids, team_id, project_id, source_created_at,
-           source_modified_at)
-       VALUES ($1, $2, $3, $4, 'processing', $5, $6, $7::text[], $8, $9, $10, $11)
+           folder_path, team_ids, team_id, project_id, conversation_id,
+           source_created_at, source_modified_at)
+       VALUES ($1, $2, $3, $4, 'processing', $5, $6, $7::text[], $8, $9, $10,
+               $11, $12)
        ON CONFLICT (org_slug, file_id) DO UPDATE SET
            filename = EXCLUDED.filename,
            content_hash = EXCLUDED.content_hash,
@@ -331,6 +344,7 @@ async function claimDocumentRow(args: {
            team_ids = EXCLUDED.team_ids,
            team_id = EXCLUDED.team_id,
            project_id = EXCLUDED.project_id,
+           conversation_id = EXCLUDED.conversation_id,
            source_created_at = EXCLUDED.source_created_at,
            source_modified_at = EXCLUDED.source_modified_at,
            error = NULL,
@@ -346,6 +360,7 @@ async function claimDocumentRow(args: {
         teamIds,
         teamIds?.[0] ?? null,
         args.projectId,
+        args.conversationId,
         args.sourceCreatedAt,
         args.sourceModifiedAt,
       ],

--- a/services/platform/convex/knowledge/search.ts
+++ b/services/platform/convex/knowledge/search.ts
@@ -120,12 +120,21 @@ export async function searchKnowledge(
     {
       organizationId: args.organizationId,
       fileIds: documentRefs,
+      ...(args.access?.userId !== undefined
+        ? { userId: args.access.userId }
+        : {}),
       ...(args.access !== undefined
         ? {
             access: {
               teamIds: [...args.access.teamIds],
               projectIds: [...args.access.projectIds],
               includeHub: args.access.includeHub,
+              ...(args.access.includeConversationScoped !== undefined
+                ? {
+                    includeConversationScoped:
+                      args.access.includeConversationScoped,
+                  }
+                : {}),
               ...(args.access.threadIds !== undefined
                 ? { threadIds: [...args.access.threadIds] }
                 : {}),

--- a/services/platform/convex/sandbox/workspace_access.test.ts
+++ b/services/platform/convex/sandbox/workspace_access.test.ts
@@ -367,6 +367,46 @@ describe('resolveKnowledgeToolAccess', () => {
         projectIds: [orgWideProject],
         includeHub: true,
         archivedProjectIds: [],
+        // A user-keyed session knows who is asking, so emailed attachments are
+        // in play — decided one by one against each conversation's current
+        // assignment by the Convex-truth re-check.
+        includeConversationScoped: true,
+        userId: 'u9',
+      },
+    });
+  });
+
+  it('a session-keyed run gets no identity, so no emailed attachment', async () => {
+    // The scope a bound session gets is a pair of SETS. A conversation's reader
+    // is its current assignee or assigned team, which no set can express, so a
+    // run with nobody behind it must not admit those rows at all — setting the
+    // flag here would hand every skill run the whole inbox.
+    const t = newTest();
+    const projectId = await seedProject(t, {});
+    const agentId = await seedProjectAgent(t, projectId);
+    await seedSession(t, {
+      sessionId: 'sess_proj',
+      ownerType: 'project_agent',
+      ownerId: agentId,
+    });
+    const bound = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      {
+        organizationId: ORG,
+        sessionId: 'sess_proj',
+        subject: 'documents',
+      },
+    );
+    // Asserted exhaustively rather than field by field: `toEqual` is what
+    // proves the two fields are ABSENT, and it will also catch a later field
+    // arriving here by accident.
+    expect(bound).toEqual({
+      allowed: true,
+      scope: {
+        teamIds: [],
+        projectIds: [projectId],
+        includeHub: true,
+        archivedProjectIds: [],
       },
     });
   });

--- a/services/platform/convex/sandbox/workspace_access.ts
+++ b/services/platform/convex/sandbox/workspace_access.ts
@@ -14,8 +14,9 @@ import type { Doc, Id } from '../_generated/dataModel';
 import { internalQuery, type QueryCtx } from '../_generated/server';
 import { bindingsOf } from '../automations/store';
 import {
-  resolveKnowledgeAccessForUser,
+  knowledgeAccessScopeValidator,
   type ResolvedKnowledgeAccess,
+  resolveKnowledgeAccessForUser,
 } from '../documents/access';
 import {
   resolveAgentReadAccess,
@@ -188,12 +189,7 @@ export const resolveKnowledgeToolAccess = internalQuery({
   returns: v.union(
     v.object({
       allowed: v.literal(true),
-      scope: v.object({
-        teamIds: v.array(v.string()),
-        projectIds: v.array(v.string()),
-        includeHub: v.boolean(),
-        archivedProjectIds: v.optional(v.array(v.string())),
-      }),
+      scope: knowledgeAccessScopeValidator,
     }),
     v.object({
       allowed: v.literal(false),
@@ -219,6 +215,13 @@ export const resolveKnowledgeToolAccess = internalQuery({
       args.organizationId,
       args.sessionId,
     );
+    // Neither session-keyed branch below carries `userId` or
+    // `includeConversationScoped`, so neither can retrieve an emailed
+    // attachment. That is deliberate, not an omission: a conversation's reader
+    // is its current assignee or assigned team, and a session bound to a
+    // project or to an org-level run has no person to check that against.
+    // Setting the flag here without an identity would publish the whole inbox
+    // to every skill run.
     if (binding.kind === 'project') {
       return {
         allowed: true,

--- a/services/platform/lib/knowledge/types.ts
+++ b/services/platform/lib/knowledge/types.ts
@@ -93,6 +93,9 @@ export interface KnowledgeSource {
    * caller can tell whether the project is archived without a second read.
    */
   readonly projectId?: string | null;
+  /** The conversation an emailed attachment arrived on. Present only for those;
+   * the re-check uses it to decide the hit by assignment. */
+  readonly conversationId?: string | null;
 }
 
 /** A hit after fusion, carrying the rank-based score it was ordered by. */
@@ -138,6 +141,23 @@ export interface KnowledgeAccessScope {
    * which under-labels rather than over-filters.
    */
   readonly archivedProjectIds?: readonly string[];
+  /**
+   * Whether conversation-scoped rows — emailed attachments — may be ADMITTED by
+   * the SQL pre-filter for the Convex-truth re-check to decide.
+   *
+   * Not a grant. The re-check applies `conversationAssignmentAllows` against the
+   * conversation's current assignment, so this only says "consider them"; a
+   * caller who can read no conversation gets none of them back. Absent means
+   * they are not considered at all, which is the fail-closed default for a
+   * surface that has not thought about it.
+   */
+  readonly includeConversationScoped?: boolean;
+  /**
+   * Who is asking. Carried because a conversation-scoped row is decided by the
+   * conversation's live assignment, which needs an identity rather than a set —
+   * the sets above cannot express "the assignee". Absent denies those rows.
+   */
+  readonly userId?: string;
   /**
    * Chat threads whose thread-bound uploads the caller may retrieve — the
    * turn's own thread, derived server-side from the owned-thread check.


### PR DESCRIPTION
Chat cannot find a file that arrived by email. This adds the mechanism that will
let it, and nothing more: no row carries the new scope yet, so no search result
changes.

## The problem with stamping a team

An emailed file should be readable by whoever can read its conversation. That
rule is live, not fixed. Admins see all, unassigned mail is admin-triage only,
otherwise the reader is the assignee or the assigned team. Reassigning the mail
has to move its attachments with it.

A team stamped on the corpus row at ingest is wrong the moment somebody reassigns. Every missed rewrite hides a file from its new owner, or leaves it visible to the person who handed it off.

## What the column carries

The question, not the answer. Migration `0008` adds `conversation_id` with a
partial index, following `0006`'s shape and its reasoning for an empty down
section. Retrieval then re-asks the conversation:

- The hub clause gains `conversation_id IS NULL`. A row with every scope column NULL reads as org-wide. An emailed attachment carries no team and no project, so without this every indexed one would be org-hub.
- A new disjunct admits conversation rows.
- `filterRetrievableRagFileIds` decides each one with
  `conversationAssignmentAllows`. The same predicate the RLS rule uses, so
  there is one definition of who may read a conversation.
- `fetch.ts` gets the same split, because scope-by-set would read a
  conversation row as hub and serve it.

It admits and then re-checks, rather than filtering on a list of the caller's readable conversations. Enumerating those is an unbounded walk under assignment privacy, which is why the conversations leg caps its own scan. The re-check
is bounded by the result limit instead, and it fails closed.

## Two things this needed

**The scope now carries the asking user.** Its other fields are sets, and "the
assignee" is not expressible as one. Absent identity denies, which is why the two
session-keyed sandbox lanes cannot retrieve an emailed attachment. A session
bound to a project or an org-level run has no person to check an assignment
against. There is a test on that, because the tempting fix is to set the flag and
hand every skill run the whole inbox.

**The scope's wire shape was declared three times**. The resolver's returns, the
re-check's args, the sandbox bridge's returns. Adding two fields broke the third. A closed returns validator throws on the extra field, so the symptom is a query that reads as "no results". Second commit collapses it to
one `knowledgeAccessScopeValidator`.

## Risk

Both search legs now select `conversation_id`, so a corpus that has not received migration `0008` lacks a column the code reads. `corpus.ts` already caught that and returned empty, logging "the corpus is not created yet on this database". That points the operator at an empty corpus, not at a database behind the code.

That is reachable on a self-hosted deployment. `pool.ts:133` bootstraps the corpus schema only for an organization's own database; the bundled knowledge database gets its migrations from dbmate at container start (`services/db/docker-entrypoint.sh:214`). Updating the platform image without restarting the knowledge database leaves the column absent, and every private search returns nothing.

Second commit makes a missing column its own branch. It still returns empty rather than failing a turn, and logs a warning naming the remedy. After deploying, check that `private_knowledge.documents` has `conversation_id`; if it does not, restart the knowledge database container.

## Proof

Full platform gate green: 75,191 unit tests, type-aware lint, typecheck,
`migrations:check`.

New coverage: the deciding gate (assignee, assigned team, another team,
unassigned, admin, non-member, disabled role, no identity, cross-org, dangling
reference, folder-scoped search, and that the team lookup stays lazy); the SQL
admit clause on both legs; the fetch-path split; the corpus write path; that
every scope column arrives outside the `private_knowledge` baseline, since a
ledgered database never re-runs it.

20 mutations applied, 20 killed. The `42703` missing-column path had no test at all before this; it now has three, covering both legs and the message. Two assertions were rewritten because a mutation survived them. One was a redundant identity guard no test could tell from dead code. The other was a substring check over the joined migration SQL that also matched the migration's own prose.

## Next

3b turns it on: email attachments stop being skipped for RAG, and the binder
passes the conversation id into indexing. The write path is already here.