### PR TITLE
feat(platform): index an emailed attachment for its conversation

### DIFF
--- a/services/db/migrations/knowledge-db/private_knowledge/00000000000008_knowledge_private_conversation_scope.sql
+++ b/services/db/migrations/knowledge-db/private_knowledge/00000000000008_knowledge_private_conversation_scope.sql
@@ -1,0 +1,41 @@
+-- migrate:up
+--
+-- Conversation scope on corpus documents.
+--
+-- An emailed attachment belongs to a conversation, and conversations are scoped
+-- more narrowly than anything else the corpus holds: admins see all, an
+-- unassigned one is admin-triage only, otherwise the caller must be the
+-- assignee or in the assigned team. That rule is also LIVE — a reassignment
+-- changes who may read the mail, and therefore who may read its attachment.
+--
+-- So the column does not carry the answer, only the question. It records which
+-- conversation the row belongs to; the Convex-truth re-check
+-- (`filterRetrievableRagFileIds`) then applies `conversationAssignmentAllows`
+-- against the conversation's CURRENT assignment. Stamping a team here instead
+-- would be wrong the moment somebody reassigned, and every missed rewrite would
+-- leave a file hidden from its new owner or visible to the person who handed it
+-- off.
+--
+-- Its other job is to keep these rows OUT of the hub clause. A row with every
+-- scope column NULL reads as org-hub, so without this an indexed attachment
+-- would be org-wide by default — the outcome being avoided.
+--
+-- Nullable TEXT with no default: NULL means "not a conversation row", which is
+-- every pre-existing row and every document. Metadata-only, idempotent, safe on
+-- any vintage.
+--
+-- Partial index in the same style as `idx_pk_docs_org_project`: conversation
+-- rows are the minority, so the index stays small.
+
+ALTER TABLE private_knowledge.documents
+    ADD COLUMN IF NOT EXISTS conversation_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_pk_docs_org_conversation
+    ON private_knowledge.documents (org_slug, conversation_id)
+    WHERE conversation_id IS NOT NULL;
+
+-- migrate:down
+-- Deliberately empty, like the other private_knowledge migrations: on a
+-- database that received this column it immediately holds tenancy scope, and
+-- dropping it would silently widen every conversation-scoped attachment back to
+-- org-wide hub visibility. Remove it with an explicit, reviewed migration.

--- a/services/platform/convex/conversations/ingest/bind_email_attachments.test.ts
+++ b/services/platform/convex/conversations/ingest/bind_email_attachments.test.ts
@@ -1,0 +1,128 @@
+// The pass that links a stored attachment to the mail it arrived on — and, now,
+// starts its indexing. Two properties matter and neither is provable from the
+// mutation alone: that one failure cannot stop the rest of a page of mail, and
+// that the counts it reports are the counts a sync operator will read when
+// attachments are silently not being bound.
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../_generated/api', () => ({
+  internal: {
+    file_metadata: {
+      internal_mutations: { bindFileToConversation: 'bindFileToConversation' },
+    },
+  },
+}));
+
+const { bindEmailAttachments } = await import('./bind_email_attachments');
+
+/** An ingested email carrying the given stored refs. */
+function email(storageIds: Array<string | undefined>) {
+  return {
+    attachments: storageIds.map((storageId, index) => ({
+      id: `att_${index}`,
+      filename: 'cv.pdf',
+      contentType: 'application/pdf',
+      ...(storageId !== undefined ? { storageId } : {}),
+    })),
+  } as never;
+}
+
+function ctxReturning(outcomes: Record<string, string | Error>): {
+  ctx: never;
+  calls: Array<Record<string, unknown>>;
+} {
+  const calls: Array<Record<string, unknown>> = [];
+  const ctx = {
+    runMutation: vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      calls.push(args);
+      const outcome = outcomes[String(args.storageId)] ?? 'bound';
+      if (outcome instanceof Error) throw outcome;
+      return outcome;
+    }),
+  };
+  return { ctx: ctx as never, calls };
+}
+
+describe('bindEmailAttachments', () => {
+  it('counts what it bound and what it queued for indexing', async () => {
+    const { ctx, calls } = ctxReturning({
+      blob_a: 'bound_and_queued',
+      blob_b: 'bound',
+      blob_c: 'unchanged',
+    });
+
+    const result = await bindEmailAttachments(ctx, {
+      organizationId: 'org_1',
+      bindings: [
+        {
+          email: email(['blob_a', 'blob_b']),
+          conversationId: 'conv_1' as never,
+        },
+        { email: email(['blob_c']), conversationId: 'conv_2' as never },
+      ],
+    });
+
+    expect(result).toEqual({ bound: 2, queued: 1, failed: 0 });
+    // `unchanged` is a re-poll of the same mail: visited, not counted.
+    expect(calls).toHaveLength(3);
+  });
+
+  it('keeps going past a failure, and counts it', async () => {
+    // The mail has already landed. Losing the rest of the page's links because
+    // one row threw would leave those attachments unindexed until a poll that
+    // happens to skip the same row.
+    const { ctx, calls } = ctxReturning({
+      blob_a: 'bound_and_queued',
+      blob_boom: new Error('write conflict'),
+      blob_c: 'bound_and_queued',
+    });
+
+    const result = await bindEmailAttachments(ctx, {
+      organizationId: 'org_1',
+      bindings: [
+        {
+          email: email(['blob_a', 'blob_boom', 'blob_c']),
+          conversationId: 'conv_1' as never,
+        },
+      ],
+    });
+
+    expect(result).toEqual({ bound: 2, queued: 2, failed: 1 });
+    expect(calls).toHaveLength(3);
+  });
+
+  it('skips a part that was never materialized', async () => {
+    // A metadata-only chip has no stored bytes, so there is no row to bind.
+    const { ctx, calls } = ctxReturning({});
+
+    const result = await bindEmailAttachments(ctx, {
+      organizationId: 'org_1',
+      bindings: [
+        {
+          email: email([undefined, 'blob_real', undefined]),
+          conversationId: 'conv_1' as never,
+        },
+      ],
+    });
+
+    expect(result).toEqual({ bound: 1, queued: 0, failed: 0 });
+    expect(calls).toEqual([
+      {
+        organizationId: 'org_1',
+        storageId: 'blob_real',
+        conversationId: 'conv_1',
+      },
+    ]);
+  });
+
+  it('reports nothing for a page of mail with no attachments', async () => {
+    const { ctx, calls } = ctxReturning({});
+    const result = await bindEmailAttachments(ctx, {
+      organizationId: 'org_1',
+      bindings: [{ email: email([]), conversationId: 'conv_1' as never }],
+    });
+    expect(result).toEqual({ bound: 0, queued: 0, failed: 0 });
+    expect(calls).toEqual([]);
+  });
+});

--- a/services/platform/convex/conversations/ingest/bind_email_attachments.test.ts
+++ b/services/platform/convex/conversations/ingest/bind_email_attachments.test.ts
@@ -50,6 +50,8 @@ describe('bindEmailAttachments', () => {
       blob_a: 'bound_and_queued',
       blob_b: 'bound',
       blob_c: 'unchanged',
+      // Already bound by an earlier poll, never indexed: work done, no new link.
+      blob_d: 'queued',
     });
 
     const result = await bindEmailAttachments(ctx, {
@@ -59,13 +61,16 @@ describe('bindEmailAttachments', () => {
           email: email(['blob_a', 'blob_b']),
           conversationId: 'conv_1' as never,
         },
-        { email: email(['blob_c']), conversationId: 'conv_2' as never },
+        {
+          email: email(['blob_c', 'blob_d']),
+          conversationId: 'conv_2' as never,
+        },
       ],
     });
 
-    expect(result).toEqual({ bound: 2, queued: 1, failed: 0 });
-    // `unchanged` is a re-poll of the same mail: visited, not counted.
-    expect(calls).toHaveLength(3);
+    expect(result).toEqual({ bound: 2, queued: 2, failed: 0 });
+    // `unchanged` is a re-poll of already-indexed mail: visited, not counted.
+    expect(calls).toHaveLength(4);
   });
 
   it('keeps going past a failure, and counts it', async () => {

--- a/services/platform/convex/conversations/ingest/bind_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/bind_email_attachments.ts
@@ -26,6 +26,12 @@
  * Best-effort by design. A failed binding must not fail a sync that has already
  * ingested the mail — the attachment is still stored and still shown; it is the
  * link that is missing, and the next poll rebinds it.
+ *
+ * Binding is also what starts indexing: the mutation queues and dispatches the
+ * attachment in the same transaction that records the conversation, because the
+ * conversation is what gives the corpus row a visibility rule. So a poll that
+ * cannot bind leaves the file unindexed rather than org-wide, and the next poll
+ * fixes both together.
  */
 
 import { isRecord } from '../../../lib/utils/type-utils';
@@ -52,17 +58,28 @@ function storedRefs(email: EmailType): string[] {
   return refs;
 }
 
+/** What one binding pass did, for the sync's own log line. */
+export interface BindEmailAttachmentsResult {
+  /** Rows newly pointed at their conversation. */
+  bound: number;
+  /** Of those, the ones now queued for indexing. */
+  queued: number;
+  /** Rows whose binding threw; the next poll retries them. */
+  failed: number;
+}
+
 export async function bindEmailAttachments(
   ctx: ActionCtx,
   args: {
     organizationId: string;
     bindings: readonly AttachmentBinding[];
   },
-): Promise<void> {
+): Promise<BindEmailAttachmentsResult> {
+  const result = { bound: 0, queued: 0, failed: 0 };
   for (const { email, conversationId } of args.bindings) {
     for (const storageId of storedRefs(email)) {
       try {
-        await ctx.runMutation(
+        const outcome = await ctx.runMutation(
           internal.file_metadata.internal_mutations.bindFileToConversation,
           {
             organizationId: args.organizationId,
@@ -70,7 +87,12 @@ export async function bindEmailAttachments(
             conversationId,
           },
         );
+        if (outcome === 'bound' || outcome === 'bound_and_queued') {
+          result.bound += 1;
+        }
+        if (outcome === 'bound_and_queued') result.queued += 1;
       } catch (error) {
+        result.failed += 1;
         // Never fail an ingest that already landed the mail.
         console.warn(
           `[bindEmailAttachments] could not bind ${storageId} to ${String(conversationId)}:`,
@@ -79,4 +101,5 @@ export async function bindEmailAttachments(
       }
     }
   }
+  return result;
 }

--- a/services/platform/convex/conversations/ingest/bind_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/bind_email_attachments.ts
@@ -90,7 +90,11 @@ export async function bindEmailAttachments(
         if (outcome === 'bound' || outcome === 'bound_and_queued') {
           result.bound += 1;
         }
-        if (outcome === 'bound_and_queued') result.queued += 1;
+        // `'queued'` is an already-bound row that had never been indexed — no
+        // new link, but real indexing work, so it counts in one column only.
+        if (outcome === 'bound_and_queued' || outcome === 'queued') {
+          result.queued += 1;
+        }
       } catch (error) {
         result.failed += 1;
         // Never fail an ingest that already landed the mail.

--- a/services/platform/convex/conversations/ingest/create_conversation_from_email.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_email.ts
@@ -324,11 +324,19 @@ export async function createConversationFromEmail(
 
   // After ingest, because the conversation ids only exist now. Best-effort:
   // the mail is already landed, so a failed link is retried by the next poll
-  // rather than failing the sync.
-  await bindEmailAttachments(ctx, {
+  // rather than failing the sync. This is also what starts indexing, so the
+  // counts are worth a line — a sync that binds nothing while mail arrives with
+  // attachments is the shape of the failure this pass exists to prevent.
+  const binding = await bindEmailAttachments(ctx, {
     organizationId: params.organizationId,
     bindings: attachmentBindings,
   });
+  if (binding.bound > 0 || binding.failed > 0) {
+    console.info(
+      `[createConversationFromEmail] bound ${binding.bound} attachment(s) ` +
+        `(${binding.queued} queued for indexing, ${binding.failed} failed)`,
+    );
+  }
 
   const uniqueConversationIds = [...conversationIds];
 

--- a/services/platform/convex/conversations/ingest/materialize_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/materialize_email_attachments.ts
@@ -100,11 +100,18 @@ async function storeAttachment(
       contentType: att.contentType,
       size: bytes.byteLength,
       source,
-      // Stored so the Inbox can show and download the attachment — NOT to
-      // enter the knowledge corpus. This must be `skipRagIndexing`, never
-      // `deferRagDispatch`: nothing downstream of this path ever dispatches an
-      // indexing job, and a `'queued'`-but-undispatched row counts against the
-      // org's RAG concurrency cap forever, which starves every real upload.
+      // Not indexed HERE. The conversation is not resolved yet — bytes are
+      // drained per message, before ingest — so there is nothing to scope the
+      // corpus row to, and an unscoped row would be an org-wide hub document.
+      // `bindFileToConversation` queues and dispatches it once the conversation
+      // is known.
+      //
+      // Still `skipRagIndexing`, not `deferRagDispatch`: the latter marks the
+      // row `'queued'`, which is a promise to dispatch, and a queued row that is
+      // never dispatched counts against the org's RAG cap forever — three of
+      // them starve every real upload. Nothing on this path can keep that
+      // promise, because binding is best-effort and may not happen at all. The
+      // binder makes the promise and keeps it in one transaction instead.
       skipRagIndexing: true,
     },
   );

--- a/services/platform/convex/documents/access.test.ts
+++ b/services/platform/convex/documents/access.test.ts
@@ -198,6 +198,34 @@ describe('resolveKnowledgeAccessForUser', () => {
     ]);
   });
 
+  it('carries the identity, so an emailed attachment can be decided at all', async () => {
+    // The other fields are SETS — a conversation-scoped row cannot be expressed
+    // as one, because its reader is whoever the mail is currently assigned to.
+    // So the scope carries who asked, and the Convex-truth re-check asks the
+    // conversation. Without the identity that re-check denies every such row,
+    // which is the fail-closed direction but also means no inbox attachment is
+    // ever found.
+    memberWithRole('member');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx(projects),
+      orgArgs,
+    );
+    expect(access.userId).toBe('user1');
+    expect(access.includeConversationScoped).toBe(true);
+  });
+
+  it('grants a denied caller no identity and no conversation rows', async () => {
+    memberWithRole('disabled');
+    mockGetUserTeamIds.mockResolvedValue(['team-a']);
+    const access = await resolveKnowledgeAccessForUser(
+      createMockCtx(projects),
+      orgArgs,
+    );
+    expect(access.userId).toBeUndefined();
+    expect(access.includeConversationScoped).toBeUndefined();
+  });
+
   it('names which readable projects are archived, without dropping them', async () => {
     memberWithRole('member');
     mockGetUserTeamIds.mockResolvedValue(['team-a']);

--- a/services/platform/convex/documents/access.ts
+++ b/services/platform/convex/documents/access.ts
@@ -231,6 +231,8 @@ export interface ResolvedKnowledgeAccess {
   teamIds: string[];
   projectIds: string[];
   includeHub: boolean;
+  /** Whether conversation-scoped rows are admitted for the re-check to decide. */
+  includeConversationScoped?: boolean;
   /**
    * Which of `projectIds` are archived. NOT a narrowing of what is
    * retrievable: an archived project's material stays searchable and citable.
@@ -240,6 +242,9 @@ export interface ResolvedKnowledgeAccess {
    * under-labels rather than over-filters.
    */
   archivedProjectIds?: string[];
+  /** The user the scope was resolved for. Needed to decide a
+   *  conversation-scoped corpus row by its live assignment. */
+  userId?: string;
 }
 
 /** Fail-closed scope: no hub, no teams, no projects — a search sees nothing. */
@@ -299,5 +304,14 @@ export async function resolveKnowledgeAccessForUser(
     }
   }
 
-  return { teamIds, projectIds, includeHub: true, archivedProjectIds };
+  return {
+    teamIds,
+    projectIds,
+    includeHub: true,
+    archivedProjectIds,
+    userId: args.userId,
+    // Emailed attachments are considered; the Convex-truth re-check decides
+    // each one by the conversation's current assignment.
+    includeConversationScoped: true,
+  };
 }

--- a/services/platform/convex/documents/access.ts
+++ b/services/platform/convex/documents/access.ts
@@ -16,7 +16,7 @@
  * or `canReadDocument` (async, resolves project access for single-doc reads).
  */
 
-import { ConvexError } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import type { Doc } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
@@ -246,6 +246,28 @@ export interface ResolvedKnowledgeAccess {
    *  conversation-scoped corpus row by its live assignment. */
   userId?: string;
 }
+
+/**
+ * The wire shape of {@link ResolvedKnowledgeAccess}, declared ONCE.
+ *
+ * It was declared three times — the resolver's returns, the re-check's args,
+ * and the sandbox bridge's returns — and adding a field to the scope meant
+ * finding all three. Missing one does not fail politely: a closed returns
+ * validator THROWS on the unexpected field, and a throwing query reads to the
+ * caller as "no results", so a widened scope would present as knowledge search
+ * having gone quiet.
+ *
+ * `threadIds` is not here: it belongs to the chat lane's request, not to what
+ * the resolver derives, and the re-check adds it to its own args.
+ */
+export const knowledgeAccessScopeValidator = v.object({
+  teamIds: v.array(v.string()),
+  projectIds: v.array(v.string()),
+  includeHub: v.boolean(),
+  archivedProjectIds: v.optional(v.array(v.string())),
+  includeConversationScoped: v.optional(v.boolean()),
+  userId: v.optional(v.string()),
+});
 
 /** Fail-closed scope: no hub, no teams, no projects — a search sees nothing. */
 export const NO_KNOWLEDGE_ACCESS: ResolvedKnowledgeAccess = {

--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.conversation_scope.test.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.conversation_scope.test.ts
@@ -1,0 +1,231 @@
+// The gate that decides an emailed attachment.
+//
+// Its own file because it needs the identity modules mocked, and the sibling
+// suite deliberately runs against a bare fake ctx. What is mocked here is only
+// the Better Auth I/O — `resolveAgentReadAccess`, `authorizeRls` and
+// `conversationAssignmentAllows` all run for real, so the rule under test is
+// the shipped rule and not a restatement of it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getUserTeamIds = vi.fn();
+const getUserOrganizations = vi.fn();
+
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: (...args: unknown[]) => getUserTeamIds(...args),
+}));
+vi.mock('../lib/rls/organization/get_user_organizations', () => ({
+  getUserOrganizations: (...args: unknown[]) => getUserOrganizations(...args),
+}));
+
+const { filterRetrievableRagFileIds } =
+  await import('./filter_retrievable_rag_file_ids');
+
+const ORG = 'org_mail';
+const OTHER_ORG = 'org_other';
+const USER = 'user_asking';
+const TEAM_MINE = 'team_mine';
+const TEAM_THEIRS = 'team_theirs';
+const ATTACHMENT = 'blob_cv';
+const CONVERSATION = 'conv_inbound';
+
+/** Access that admits conversation rows, as the resolver now always does. */
+const ACCESS = {
+  teamIds: [],
+  projectIds: [],
+  includeHub: true,
+  includeConversationScoped: true,
+  userId: USER,
+} as const;
+
+/**
+ * A ctx holding one emailed attachment bound to one conversation.
+ *
+ * `rows` overrides let a case bend one fact — the conversation's assignment,
+ * its org, the metadata's status — without restating the rest.
+ */
+function createCtx(
+  overrides: {
+    metadata?: Record<string, unknown>;
+    conversation?: Record<string, unknown> | null;
+  } = {},
+) {
+  const metadata = {
+    organizationId: ORG,
+    storageId: ATTACHMENT,
+    conversationId: CONVERSATION,
+    ragStatus: 'completed',
+    ...overrides.metadata,
+  };
+  const conversation =
+    overrides.conversation === null
+      ? null
+      : { _id: CONVERSATION, organizationId: ORG, ...overrides.conversation };
+  return {
+    db: {
+      query: () => ({
+        withIndex: (
+          _name: string,
+          bind: (q: { eq: (f: string, v: unknown) => unknown }) => unknown,
+        ) => {
+          let storageId = '';
+          const q = {
+            eq(field: string, value: unknown) {
+              if (field === 'storageId') storageId = String(value);
+              return q;
+            },
+          };
+          bind(q);
+          return {
+            first: async () => (storageId === ATTACHMENT ? metadata : null),
+          };
+        },
+      }),
+      get: async (id: string) => (id === CONVERSATION ? conversation : null),
+    },
+  } as never;
+}
+
+async function retrievableFor(
+  ctx: unknown,
+  args: Record<string, unknown> = {},
+): Promise<string[]> {
+  return filterRetrievableRagFileIds(ctx as never, {
+    organizationId: ORG,
+    fileIds: [ATTACHMENT as never],
+    access: ACCESS as never,
+    userId: USER,
+    ...args,
+  });
+}
+
+describe('filterRetrievableRagFileIds — emailed attachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'member' },
+    ]);
+    getUserTeamIds.mockResolvedValue([TEAM_MINE]);
+  });
+
+  it('serves the individual assignee', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+      ),
+    ).toEqual([ATTACHMENT]);
+  });
+
+  it('serves a member of the assigned team', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_MINE } }),
+      ),
+    ).toEqual([ATTACHMENT]);
+  });
+
+  it('denies another team’s mail, and unassigned mail, to a plain member', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_THEIRS } }),
+      ),
+    ).toEqual([]);
+    // Neither stamp is admin-triage state, not org-readable.
+    expect(await retrievableFor(createCtx({ conversation: {} }))).toEqual([]);
+  });
+
+  it('serves an admin anything, including unassigned mail', async () => {
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'admin' },
+    ]);
+    expect(await retrievableFor(createCtx({ conversation: {} }))).toEqual([
+      ATTACHMENT,
+    ]);
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_THEIRS } }),
+      ),
+    ).toEqual([ATTACHMENT]);
+  });
+
+  it('denies a caller who did not say who they are', async () => {
+    const ctx = createCtx({ conversation: { assigneeUserId: USER } });
+    expect(await retrievableFor(ctx, { userId: undefined })).toEqual([]);
+    // …and does not spend a membership lookup finding that out.
+    expect(getUserOrganizations).not.toHaveBeenCalled();
+  });
+
+  it('denies when the scope excludes conversation rows', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        {
+          access: { ...ACCESS, includeConversationScoped: false },
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies a non-member and a role that cannot read conversations', async () => {
+    const ctx = createCtx({ conversation: { assigneeUserId: USER } });
+    getUserOrganizations.mockResolvedValue([]);
+    expect(await retrievableFor(ctx)).toEqual([]);
+
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'disabled' },
+    ]);
+    expect(await retrievableFor(ctx)).toEqual([]);
+  });
+
+  it('denies a conversation belonging to another organization', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({
+          conversation: { assigneeUserId: USER, organizationId: OTHER_ORG },
+        }),
+      ),
+    ).toEqual([]);
+    // A dangling reference is a miss, not a crash.
+    expect(await retrievableFor(createCtx({ conversation: null }))).toEqual([]);
+  });
+
+  it('never returns an emailed attachment to a folder-scoped search', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { folder: 'Contracts' },
+      ),
+    ).toEqual([]);
+  });
+
+  it('still requires the attachment itself to be indexed and untrashed', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({
+          metadata: { ragStatus: 'running' },
+          conversation: { assigneeUserId: USER },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      await retrievableFor(
+        createCtx({
+          metadata: { lifecycleStatus: 'trashed' },
+          conversation: { assigneeUserId: USER },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('resolves teams once per call, and not at all when the assignee decides it', async () => {
+    await retrievableFor(
+      createCtx({ conversation: { assigneeUserId: USER } }),
+      { fileIds: [ATTACHMENT, ATTACHMENT] as never },
+    );
+    // The individual-assignee branch settles it, so the Better Auth team
+    // round-trip is never paid — the laziness `conversation_assignment.ts`
+    // documents, preserved through this reader.
+    expect(getUserTeamIds).toHaveBeenCalledTimes(1);
+    expect(getUserOrganizations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
@@ -3,6 +3,10 @@ import {
   type KnowledgeAccessScope,
 } from '../../lib/knowledge/types';
 import type { QueryCtx } from '../_generated/server';
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { resolveAgentReadAccess } from '../lib/rls/helpers/agent_read_access';
+import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
+import { isAdmin } from '../lib/rls/helpers/role_helpers';
 import type { BlobRef } from '../lib/storage/blob_ref';
 import { isActiveDocument } from './_helpers';
 
@@ -10,6 +14,8 @@ export interface FilterRetrievableRagFileIdsArgs {
   readonly organizationId: string;
   readonly fileIds: readonly BlobRef[];
   readonly access?: KnowledgeAccessScope;
+  /** The turn user, for deciding conversation-scoped rows. Absent denies them. */
+  readonly userId?: string;
   readonly folder?: string;
 }
 
@@ -20,6 +26,11 @@ export interface FilterRetrievableRagFileIdsArgs {
  * change. A document hit is returnable only while its metadata is completed,
  * its linked document is active and still points at that exact blob, and its
  * current scope/folder still matches the request.
+ *
+ * An emailed attachment (`conversationId` set, no `documentId`) is its own
+ * access class too, and the only one decided from LIVE state rather than a
+ * stamp: the caller must currently be able to read the conversation the mail
+ * arrived on, so reassigning the mail moves its attachments with it.
  *
  * A thread-bound chat upload (`threadId` set, no `documentId`) is its own
  * access class — the 0.3 model (`verify_thread_scoped_access`): retrievable
@@ -33,6 +44,49 @@ export async function filterRetrievableRagFileIds(
   const retrievable: string[] = [];
   const seen = new Set<string>();
   const allowedThreadIds = new Set(args.access?.threadIds ?? []);
+
+  /**
+   * Role and teams for the assignment decision, resolved once and only when a
+   * conversation-scoped row is actually hit.
+   *
+   * Resolved HERE from the caller's identity rather than accepted as arguments:
+   * an `isAdmin` flag travelling in is one refactor away from being wrong in the
+   * direction that publishes an inbox. `null` means the caller is not a member,
+   * or their role denies conversations.
+   */
+  let callerPromise:
+    | Promise<{
+        isAdmin: boolean;
+        userId: string;
+        teamIds: ReadonlySet<string>;
+      } | null>
+    | undefined;
+  const conversationCaller = (): Promise<{
+    isAdmin: boolean;
+    userId: string;
+    teamIds: ReadonlySet<string>;
+  } | null> => {
+    callerPromise ??= (async () => {
+      const userId = args.userId;
+      // Fail closed on a surface that did not say who is asking: an inbox
+      // attachment is never served to an unidentified caller. This is the ONE
+      // place that decision is made — a second early guard beside the call site
+      // read as belt-and-braces but no test could tell it from dead code.
+      if (userId === undefined) return null;
+      const access = await resolveAgentReadAccess(ctx, {
+        organizationId: args.organizationId,
+        userId,
+        subject: 'conversations',
+      });
+      if (!access.allowed) return null;
+      return {
+        isAdmin: isAdmin(access.role),
+        userId,
+        teamIds: new Set(await getUserTeamIds(ctx, userId)),
+      };
+    })();
+    return callerPromise;
+  };
 
   for (const fileId of args.fileIds) {
     const ref = String(fileId);
@@ -59,6 +113,43 @@ export async function filterRetrievableRagFileIds(
         allowedThreadIds.has(metadata.threadId) &&
         (args.folder === undefined || args.folder === '')
       ) {
+        retrievable.push(ref);
+      }
+      continue;
+    }
+
+    // An emailed attachment. It has no document row, so without this branch it
+    // falls through the `documentId` check below and is denied outright.
+    //
+    // This is the gate that makes conversation scope work. The SQL side only
+    // ADMITTED the row; who may read it is decided here, from the conversation's
+    // CURRENT assignment, using the same predicate `rls_rules.ts` uses. A
+    // reassignment therefore moves the attachment with the mail, and nothing has
+    // to be rewritten.
+    if (metadata.conversationId !== undefined) {
+      // A scope that excludes conversations is honoured here too, not only in
+      // the SQL pre-filter — the pre-filter is the half that fails open.
+      if (args.access !== undefined && !args.access.includeConversationScoped) {
+        continue;
+      }
+      const conversation = await ctx.db.get(metadata.conversationId);
+      if (
+        conversation === null ||
+        conversation.organizationId !== args.organizationId
+      ) {
+        continue;
+      }
+      const caller = await conversationCaller();
+      if (caller === null) continue;
+      const allowed = await conversationAssignmentAllows(conversation, {
+        isAdmin: caller.isAdmin,
+        userId: caller.userId,
+        hasTeam: (teamId) => caller.teamIds.has(teamId),
+      });
+      // The folder filter is a Document Hub concept; a folder-scoped search
+      // never returns emailed attachments, exactly as it never returns chat
+      // uploads.
+      if (allowed && (args.folder === undefined || args.folder === '')) {
         retrievable.push(ref);
       }
       continue;

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -7,8 +7,9 @@ import { blobRefValidator } from '../lib/storage/blob_ref';
 import { toId } from '../lib/type_cast_helpers';
 import { resolveProjectAccessForUser } from '../projects/resolve_project_access';
 import {
-  resolveKnowledgeAccessForUser,
+  knowledgeAccessScopeValidator,
   type ResolvedKnowledgeAccess,
+  resolveKnowledgeAccessForUser,
 } from './access';
 import { checkMembership } from './check_membership';
 import { filterRetrievableRagFileIds as filterRetrievableRagFileIdsHelper } from './filter_retrievable_rag_file_ids';
@@ -359,14 +360,7 @@ export const resolveKnowledgeAccess = internalQuery({
     organizationId: v.string(),
     userId: v.string(),
   },
-  returns: v.object({
-    teamIds: v.array(v.string()),
-    projectIds: v.array(v.string()),
-    includeHub: v.boolean(),
-    archivedProjectIds: v.optional(v.array(v.string())),
-    includeConversationScoped: v.optional(v.boolean()),
-    userId: v.optional(v.string()),
-  }),
+  returns: knowledgeAccessScopeValidator,
   handler: async (ctx, args): Promise<ResolvedKnowledgeAccess> => {
     return await resolveKnowledgeAccessForUser(ctx, args);
   },
@@ -383,12 +377,8 @@ export const filterRetrievableRagFileIds = internalQuery({
     fileIds: v.array(blobRefValidator),
     access: v.optional(
       v.object({
-        teamIds: v.array(v.string()),
-        projectIds: v.array(v.string()),
-        includeHub: v.boolean(),
-        archivedProjectIds: v.optional(v.array(v.string())),
+        ...knowledgeAccessScopeValidator.fields,
         threadIds: v.optional(v.array(v.string())),
-        includeConversationScoped: v.optional(v.boolean()),
       }),
     ),
     folder: v.optional(v.string()),

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -364,6 +364,8 @@ export const resolveKnowledgeAccess = internalQuery({
     projectIds: v.array(v.string()),
     includeHub: v.boolean(),
     archivedProjectIds: v.optional(v.array(v.string())),
+    includeConversationScoped: v.optional(v.boolean()),
+    userId: v.optional(v.string()),
   }),
   handler: async (ctx, args): Promise<ResolvedKnowledgeAccess> => {
     return await resolveKnowledgeAccessForUser(ctx, args);
@@ -386,9 +388,13 @@ export const filterRetrievableRagFileIds = internalQuery({
         includeHub: v.boolean(),
         archivedProjectIds: v.optional(v.array(v.string())),
         threadIds: v.optional(v.array(v.string())),
+        includeConversationScoped: v.optional(v.boolean()),
       }),
     ),
     folder: v.optional(v.string()),
+    /** The turn user. Required to serve a conversation-scoped row; without it
+     *  those rows are denied. */
+    userId: v.optional(v.string()),
   },
   returns: v.array(v.string()),
   handler: async (ctx, args) => {

--- a/services/platform/convex/file_metadata/conversation_binding_query.test.ts
+++ b/services/platform/convex/file_metadata/conversation_binding_query.test.ts
@@ -1,0 +1,107 @@
+// The read that decides an emailed attachment's corpus stamp. Driven through
+// convex-test against the real schema and indexes, because the thing worth
+// proving is the tenant boundary: a blob reference is caller-supplied on some
+// paths, so answering it without checking the organization would let one org's
+// storage id resolve to another org's conversation.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'file_metadata';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_binding';
+const OTHER_ORG = 'org_binding_other';
+type T = TestConvex<typeof schema>;
+
+async function seedConversation(t: T, organizationId: string): Promise<string> {
+  return await t.run(async (ctx) =>
+    ctx.db.insert('conversations', {
+      organizationId,
+      subject: 'CV',
+      status: 'open',
+      channel: 'email',
+    }),
+  );
+}
+
+async function seedAttachment(
+  t: T,
+  args: { organizationId: string; storageId: string; conversationId?: string },
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('fileMetadata', {
+      organizationId: args.organizationId,
+      storageId: args.storageId,
+      fileName: 'cv.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+      ...(args.conversationId !== undefined
+        ? { conversationId: args.conversationId as never }
+        : {}),
+    });
+  });
+}
+
+function read(t: T, organizationId: string, storageId: string) {
+  return t.query(
+    internal.file_metadata.internal_queries.getConversationBindingForBlob,
+    { organizationId, storageId },
+  );
+}
+
+describe('getConversationBindingForBlob', () => {
+  it('returns the conversation a bound attachment arrived on', async () => {
+    const t = convexTest(schema, modules);
+    const conversationId = await seedConversation(t, ORG);
+    await seedAttachment(t, {
+      organizationId: ORG,
+      storageId: 'blob_bound',
+      conversationId,
+    });
+
+    expect(await read(t, ORG, 'blob_bound')).toBe(conversationId);
+  });
+
+  it('returns null for a file that arrived any other way', async () => {
+    const t = convexTest(schema, modules);
+    await seedAttachment(t, { organizationId: ORG, storageId: 'blob_plain' });
+
+    expect(await read(t, ORG, 'blob_plain')).toBeNull();
+  });
+
+  it("never answers with another organization's binding", async () => {
+    const t = convexTest(schema, modules);
+    const foreign = await seedConversation(t, OTHER_ORG);
+    await seedAttachment(t, {
+      organizationId: OTHER_ORG,
+      storageId: 'blob_foreign',
+      conversationId: foreign,
+    });
+
+    // The row exists and is bound; it just is not this org's.
+    expect(await read(t, ORG, 'blob_foreign')).toBeNull();
+    expect(await read(t, OTHER_ORG, 'blob_foreign')).toBe(foreign);
+  });
+
+  it('returns null for a storage id with no row', async () => {
+    const t = convexTest(schema, modules);
+    expect(await read(t, ORG, 'blob_missing')).toBeNull();
+  });
+});

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -82,6 +82,13 @@ function createMockCtx(
   return { ctx, builder };
 }
 
+/** The mocked dispatch helper. Imported inside a function, like every other
+ *  reference to it here, so it does not shadow the per-test imports. */
+async function dispatchSpy() {
+  const { maybeDispatchRagIndexing } = await import('./rag_dispatch');
+  return maybeDispatchRagIndexing;
+}
+
 async function getBindHandler() {
   const { bindFileToConversation } = await import('./internal_mutations');
   return (bindFileToConversation as unknown as { handler: Function }).handler;
@@ -942,6 +949,11 @@ describe('updateFileRagStatus document completion CAS', () => {
 // file is readable by whoever can currently read its conversation, so the write
 // has to be scoped and idempotent: a storage id from another organization must
 // not be re-pointed, and a re-poll of the same mail must not write.
+//
+// Binding is also where indexing starts, because the conversation is what gives
+// the corpus row a visibility rule. The cases below therefore also pin WHICH
+// rows get queued — a re-queue of an already-indexed file re-embeds it, and a
+// queued row that is never dispatched burns an org RAG slot forever.
 describe('bindFileToConversation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -953,27 +965,89 @@ describe('bindFileToConversation', () => {
     conversationId: 'conv_1',
   };
 
-  it('records the conversation on the matching row', async () => {
-    const { ctx } = createMockCtx({
+  /** A stored attachment row. `fileName`/`contentType` are required by the
+   *  schema, so a fixture without them is a row that cannot exist. */
+  function attachmentRow(fields: Record<string, unknown> = {}) {
+    return {
       _id: 'fm_1',
       organizationId: 'org_1',
       storageId: 'storage_1',
-    });
+      fileName: 'cv.pdf',
+      contentType: 'application/pdf',
+      ...fields,
+    };
+  }
+
+  it('records the conversation and queues the attachment for indexing', async () => {
+    const { ctx } = createMockCtx(attachmentRow());
     const handler = await getBindHandler();
 
-    await handler(ctx, args);
-
+    expect(await handler(ctx, args)).toBe('bound_and_queued');
     expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
       conversationId: 'conv_1',
+      ragStatus: 'queued',
     });
+    // Queueing is a promise to dispatch, kept in the same transaction — a
+    // 'queued' row that is neither dispatched nor parked holds an org RAG slot
+    // for good.
+    expect(await dispatchSpy()).toHaveBeenCalledWith(ctx, 'storage_1');
+  });
+
+  it('binds without re-indexing a file that already has a RAG outcome', async () => {
+    // Re-embedding a completed file costs money and changes nothing; a failed
+    // one belongs to the watchdog, not to a re-poll of the same mail.
+    for (const ragStatus of ['completed', 'failed', 'queued', 'processing']) {
+      vi.clearAllMocks();
+      const { ctx } = createMockCtx(attachmentRow({ ragStatus }));
+      const handler = await getBindHandler();
+
+      expect(await handler(ctx, args)).toBe('bound');
+      expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
+        conversationId: 'conv_1',
+      });
+      expect(await dispatchSpy()).not.toHaveBeenCalled();
+    }
+  });
+
+  it('binds an audio attachment without queueing it', async () => {
+    // Audio indexes through its transcript, and queueing it here would strand
+    // the row on a path that has no text to extract.
+    const { ctx } = createMockCtx(
+      attachmentRow({ fileName: 'call.mp3', contentType: 'audio/mpeg' }),
+    );
+    const handler = await getBindHandler();
+
+    expect(await handler(ctx, args)).toBe('bound');
+    expect(await dispatchSpy()).not.toHaveBeenCalled();
+  });
+
+  it('binds a format no extractor handles without queueing it', async () => {
+    const { ctx } = createMockCtx(
+      attachmentRow({
+        fileName: 'archive.zip',
+        contentType: 'application/zip',
+      }),
+    );
+    const handler = await getBindHandler();
+
+    expect(await handler(ctx, args)).toBe('bound');
+    expect(await dispatchSpy()).not.toHaveBeenCalled();
+  });
+
+  it('binds a trashed row without putting it back into the corpus', async () => {
+    const { ctx } = createMockCtx(
+      attachmentRow({ lifecycleStatus: 'trashed' }),
+    );
+    const handler = await getBindHandler();
+
+    expect(await handler(ctx, args)).toBe('bound');
+    expect(await dispatchSpy()).not.toHaveBeenCalled();
   });
 
   it('refuses a row belonging to another organization', async () => {
-    const { ctx } = createMockCtx({
-      _id: 'fm_1',
-      organizationId: 'some_other_org',
-      storageId: 'storage_1',
-    });
+    const { ctx } = createMockCtx(
+      attachmentRow({ organizationId: 'some_other_org' }),
+    );
     const handler = await getBindHandler();
 
     await handler(ctx, args);
@@ -983,12 +1057,7 @@ describe('bindFileToConversation', () => {
   });
 
   it('writes nothing when the row already names that conversation', async () => {
-    const { ctx } = createMockCtx({
-      _id: 'fm_1',
-      organizationId: 'org_1',
-      storageId: 'storage_1',
-      conversationId: 'conv_1',
-    });
+    const { ctx } = createMockCtx(attachmentRow({ conversationId: 'conv_1' }));
     const handler = await getBindHandler();
 
     await handler(ctx, args);
@@ -998,16 +1067,15 @@ describe('bindFileToConversation', () => {
   });
 
   it('rebinds a row that names a different conversation', async () => {
-    const { ctx } = createMockCtx({
-      _id: 'fm_1',
-      organizationId: 'org_1',
-      storageId: 'storage_1',
-      conversationId: 'conv_old',
-    });
+    // Already indexed under the old conversation, so the corpus row exists;
+    // moving the binding moves who may read it, with no re-embedding. That is
+    // the whole point of deriving visibility instead of stamping it.
+    const { ctx } = createMockCtx(
+      attachmentRow({ conversationId: 'conv_old', ragStatus: 'completed' }),
+    );
     const handler = await getBindHandler();
 
-    await handler(ctx, args);
-
+    expect(await handler(ctx, args)).toBe('bound');
     expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
       conversationId: 'conv_1',
     });

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -1056,14 +1056,30 @@ describe('bindFileToConversation', () => {
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
-  it('writes nothing when the row already names that conversation', async () => {
+  it('writes nothing when the row is already bound and already indexed', async () => {
+    const { ctx } = createMockCtx(
+      attachmentRow({ conversationId: 'conv_1', ragStatus: 'completed' }),
+    );
+    const handler = await getBindHandler();
+
+    expect(await handler(ctx, args)).toBe('unchanged');
+    // A re-poll of the same mail is a no-op, not a write.
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('queues an already-bound row that never indexed, without rewriting the binding', async () => {
+    // Attachments bound before binding started indexing sit exactly here: they
+    // point at their conversation and carry no ragStatus. Treating "binding
+    // unchanged" as "nothing to do" would leave them unindexed for good, and no
+    // later poll revisits mail it has already ingested.
     const { ctx } = createMockCtx(attachmentRow({ conversationId: 'conv_1' }));
     const handler = await getBindHandler();
 
-    await handler(ctx, args);
-
-    // A re-poll of the same mail is a no-op, not a write.
-    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(await handler(ctx, args)).toBe('queued');
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
+      ragStatus: 'queued',
+    });
+    expect(await dispatchSpy()).toHaveBeenCalledWith(ctx, 'storage_1');
   });
 
   it('rebinds a row that names a different conversation', async () => {

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -23,12 +23,31 @@ import { maybeDispatchRagIndexing, promoteQueuedRagJobs } from './rag_dispatch';
 import { sourceFromProvider } from './source_from_provider';
 
 /**
- * Record the conversation an email attachment arrived on.
+ * Record the conversation an email attachment arrived on, and index it.
  *
  * Idempotent, and scoped: the row must already belong to the organization doing
  * the binding, so a storage id from elsewhere cannot be re-pointed. Writes only
  * when the value actually changes, so a re-poll of the same mail is a no-op
  * rather than a write.
+ *
+ * ## Why the indexing decision lives here
+ *
+ * The attachment is stored before its conversation is resolved (bytes are
+ * drained per message inside the fetch), so at storage time there is nothing to
+ * scope it to and it is stored unindexed. Here is the first moment the
+ * conversation is known — which is also the moment the corpus row can be given
+ * a visibility rule instead of landing as an org-wide hub document.
+ *
+ * Queueing and dispatching happen in this ONE transaction, deliberately. A
+ * `'queued'` row that is neither dispatched nor parked counts against the
+ * per-org RAG cap forever, and three of them starve every real upload — the
+ * defect that made email attachments skip indexing in the first place. Marking
+ * queued is a promise to dispatch, so the promise and the dispatch are made
+ * together rather than across a best-effort boundary that is allowed to fail.
+ *
+ * Only a row that was never indexed is queued: a re-poll of the same mail must
+ * not re-embed, and a file that already failed keeps its error for the watchdog
+ * rather than looping.
  */
 export const bindFileToConversation = internalMutation({
   args: {
@@ -36,17 +55,46 @@ export const bindFileToConversation = internalMutation({
     storageId: blobRefValidator,
     conversationId: v.id('conversations'),
   },
-  returns: v.null(),
+  returns: v.union(
+    v.literal('not_found'),
+    v.literal('other_org'),
+    v.literal('unchanged'),
+    v.literal('bound'),
+    v.literal('bound_and_queued'),
+  ),
   async handler(ctx, args) {
     const row = await ctx.db
       .query('fileMetadata')
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
-    if (!row) return null;
-    if (row.organizationId !== args.organizationId) return null;
-    if (row.conversationId === args.conversationId) return null;
-    await ctx.db.patch(row._id, { conversationId: args.conversationId });
-    return null;
+    if (!row) return 'not_found';
+    if (row.organizationId !== args.organizationId) return 'other_org';
+    if (row.conversationId === args.conversationId) return 'unchanged';
+
+    // The same predicate the save paths use, so "indexable" has one meaning.
+    // Audio is excluded as it is there: it indexes later, via its transcript.
+    // That half is unreachable while the indexable extensions hold no audio or
+    // video — an invariant asserted in `lib/shared/file-types.test.ts`, so
+    // adding one there fails a test rather than silently routing a recording
+    // into the text pipeline.
+    const indexable =
+      row.ragStatus === undefined &&
+      row.lifecycleStatus !== 'trashed' &&
+      !isAudioOrVideo(row.contentType) &&
+      isRagIndexableFile(
+        row.fileName,
+        resolveFileType(row.fileName, row.contentType),
+      );
+
+    await ctx.db.patch(row._id, {
+      conversationId: args.conversationId,
+      ...(indexable ? { ragStatus: 'queued' as const } : {}),
+    });
+    if (!indexable) return 'bound';
+    // Dispatches under the cap, parks over it. Either way the row is accounted
+    // for before this transaction ends.
+    await maybeDispatchRagIndexing(ctx, args.storageId);
+    return 'bound_and_queued';
   },
 });
 

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -48,6 +48,12 @@ import { sourceFromProvider } from './source_from_provider';
  * Only a row that was never indexed is queued: a re-poll of the same mail must
  * not re-embed, and a file that already failed keeps its error for the watchdog
  * rather than looping.
+ *
+ * The two decisions are INDEPENDENT. An attachment bound before binding started
+ * indexing is already pointed at its conversation and still has no `ragStatus`,
+ * so treating "binding unchanged" as "nothing to do" would leave it unindexed
+ * for good. Whether the binding moved and whether the file needs indexing are
+ * answered separately.
  */
 export const bindFileToConversation = internalMutation({
   args: {
@@ -58,7 +64,10 @@ export const bindFileToConversation = internalMutation({
   returns: v.union(
     v.literal('not_found'),
     v.literal('other_org'),
+    /** Already pointed at this conversation, and nothing to index. */
     v.literal('unchanged'),
+    /** Already pointed at this conversation; queued because it never indexed. */
+    v.literal('queued'),
     v.literal('bound'),
     v.literal('bound_and_queued'),
   ),
@@ -69,7 +78,8 @@ export const bindFileToConversation = internalMutation({
       .first();
     if (!row) return 'not_found';
     if (row.organizationId !== args.organizationId) return 'other_org';
-    if (row.conversationId === args.conversationId) return 'unchanged';
+
+    const alreadyBound = row.conversationId === args.conversationId;
 
     // The same predicate the save paths use, so "indexable" has one meaning.
     // Audio is excluded as it is there: it indexes later, via its transcript.
@@ -86,15 +96,17 @@ export const bindFileToConversation = internalMutation({
         resolveFileType(row.fileName, row.contentType),
       );
 
+    if (alreadyBound && !indexable) return 'unchanged';
+
     await ctx.db.patch(row._id, {
-      conversationId: args.conversationId,
+      ...(alreadyBound ? {} : { conversationId: args.conversationId }),
       ...(indexable ? { ragStatus: 'queued' as const } : {}),
     });
     if (!indexable) return 'bound';
     // Dispatches under the cap, parks over it. Either way the row is accounted
     // for before this transaction ends.
     await maybeDispatchRagIndexing(ctx, args.storageId);
-    return 'bound_and_queued';
+    return alreadyBound ? 'queued' : 'bound_and_queued';
   },
 });
 

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -25,6 +25,30 @@ export const getByStorageId = internalQuery({
 });
 
 /**
+ * The conversation a stored blob arrived on, or null.
+ *
+ * Read at INDEX time rather than passed along the dispatch chain, so the corpus
+ * stamp cannot disagree with the binding: a re-index (watchdog retry, promotion
+ * from parked, a later slice of a large file) picks up whatever the binding is
+ * now. Org-scoped, because a blob ref is caller-supplied on some paths.
+ */
+export const getConversationBindingForBlob = internalQuery({
+  args: {
+    organizationId: v.string(),
+    storageId: blobRefValidator,
+  },
+  returns: v.union(v.string(), v.null()),
+  async handler(ctx, args) {
+    const row = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
+      .first();
+    if (!row || row.organizationId !== args.organizationId) return null;
+    return row.conversationId ?? null;
+  },
+});
+
+/**
  * Which of these blob references belong to this organization — the IDOR gate
  * a chat turn runs over caller-supplied attachment ids before it will read
  * (or replay) their bytes. Trashed rows fail the check too: a deleted

--- a/services/platform/convex/knowledge/corpus.test.ts
+++ b/services/platform/convex/knowledge/corpus.test.ts
@@ -144,8 +144,12 @@ describe('the documents corpus is scoped to one organization', () => {
     for (const statement of statements) {
       // Hub rows are the unscoped ones — all scope columns NULL — and the
       // caller's teams/projects widen from there; nothing else matches.
+      // `conversation_id IS NULL` belongs to that list: an emailed attachment
+      // carries no team and no project, so without it every indexed inbox
+      // attachment would read as an org-hub document.
       expect(statement.text).toContain(
-        '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL)',
+        '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL' +
+          ' AND d.conversation_id IS NULL)',
       );
       expect(statement.text).toContain('d.project_id = ANY(');
       expect(statement.params).toContainEqual(['team-a', 'team-b']);
@@ -218,6 +222,53 @@ describe('the documents corpus is scoped to one organization', () => {
     expect(statement.text).toContain('d.team_ids && ');
   });
 
+  it('admits conversation rows on both legs when the scope allows them', async () => {
+    // The SQL side only ADMITS an emailed attachment — it cannot know who may
+    // read the mail, because that answer lives in the conversation's current
+    // assignment. So the clause is deliberately the widest possible one, and
+    // `filterRetrievableRagFileIds` is what decides each row.
+    const { sql, sent } = recorder();
+    const reader = new DocumentCorpusReader(sql, 'acme');
+    const access = {
+      teamIds: [],
+      projectIds: [],
+      includeHub: true,
+      includeConversationScoped: true,
+    };
+    await reader.keyword({ ...LEG, access });
+    await reader.dense({ ...LEG, access, embedding: EMBEDDING });
+
+    const statements = corpusStatements(sent);
+    expect(statements.length).toBe(2);
+    for (const statement of statements) {
+      expect(statement.text).toContain('d.conversation_id IS NOT NULL');
+    }
+  });
+
+  it('omits the conversation disjunct for a scope that excludes them', async () => {
+    const { sql, sent } = recorder();
+    await new DocumentCorpusReader(sql, 'acme').dense({
+      ...LEG,
+      access: { teamIds: ['team-a'], projectIds: [], includeHub: true },
+      embedding: EMBEDDING,
+    });
+    const statement = corpusStatements(sent)[0];
+    expect(statement.text).not.toContain('d.conversation_id IS NOT NULL');
+    // The hub clause still names the column, so this must not be read as
+    // "the column is absent" — only the admitting disjunct is.
+    expect(statement.text).toContain('d.conversation_id IS NULL');
+  });
+
+  it('selects the conversation id so a hit can name where it arrived', async () => {
+    const { sql, sent } = recorder();
+    const reader = new DocumentCorpusReader(sql, 'acme');
+    await reader.keyword({ ...LEG });
+    await reader.dense({ ...LEG, embedding: EMBEDDING });
+    for (const statement of corpusStatements(sent)) {
+      expect(statement.text).toContain('d.conversation_id');
+    }
+  });
+
   it('adds no scope clause for an org-wide caller', async () => {
     // Absent access = the admin-keyed surfaces (org REST key, MCP lane):
     // exactly the pre-scoping statement, so nothing changes for them.
@@ -232,6 +283,7 @@ describe('the documents corpus is scoped to one organization', () => {
     // caller can be told a hit belongs to a retired project; that is not a
     // scope clause and must not read as one.
     expect(statement.text).not.toContain('d.project_id = ANY');
+    expect(statement.text).not.toContain('d.conversation_id IS NOT NULL');
   });
 
   it('passes the query vector as a parameter, never as interpolated text', async () => {

--- a/services/platform/convex/knowledge/corpus.ts
+++ b/services/platform/convex/knowledge/corpus.ts
@@ -66,6 +66,10 @@ interface CorpusRow {
    * every web page. Selected so a caller can label a hit as belonging to a
    * retired project without a second read. */
   project_id: string | null;
+  /** The conversation an emailed attachment arrived on; NULL for a document and
+   * for every web page. Selected so the re-check knows which rows it must decide
+   * by assignment rather than by scope stamp. */
+  conversation_id: string | null;
   modified_at: Date | null;
   /** Char position of the chunk within the ref's fetchable text, cast to
    * text (SUM is bigint); NULL when it cannot be established. */
@@ -99,7 +103,7 @@ export class DocumentCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
-             d.project_id,
+             d.project_id, d.conversation_id,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
              (SELECT COALESCE(SUM(length(c2.core_content)), 0)
                 FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
@@ -131,7 +135,7 @@ export class DocumentCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              d.file_id AS ref, d.filename AS title, NULL::text AS url,
-             d.project_id,
+             d.project_id, d.conversation_id,
              COALESCE(d.source_modified_at, d.updated_at) AS modified_at,
              (SELECT COALESCE(SUM(length(c2.core_content)), 0)
                 FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks c2
@@ -190,9 +194,27 @@ export class DocumentCorpusReader implements CorpusReader {
       // access means org-wide (admin-keyed surfaces) and adds no clause.
       const disjuncts: string[] = [];
       if (query.access.includeHub) {
+        // `conversation_id IS NULL` is part of being a hub row. Without it an
+        // indexed email attachment — which carries no team and no project —
+        // would read as org-hub and be visible to everyone, which is the
+        // outcome conversation scope exists to prevent.
         disjuncts.push(
-          '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL)',
+          '(d.team_ids IS NULL AND d.team_id IS NULL AND d.project_id IS NULL' +
+            ' AND d.conversation_id IS NULL)',
         );
+      }
+      // Conversation-scoped rows are admitted here and DECIDED by the
+      // Convex-truth re-check, which applies `conversationAssignmentAllows`
+      // against the conversation's current assignment.
+      //
+      // Deliberately not `conversation_id = ANY($n)`: that would need the
+      // caller's readable conversations enumerated, and assignment privacy makes
+      // that an unbounded walk — the reason the chat conversations leg caps its
+      // own scan at 300. Admitting and then re-checking is bounded by the result
+      // limit instead, and the re-check fails closed, so a path that reaches SQL
+      // without it returns rows that are then dropped rather than served.
+      if (query.access.includeConversationScoped) {
+        disjuncts.push('d.conversation_id IS NOT NULL');
       }
       params.push([...query.access.teamIds]);
       // A document shared to several teams is visible to a member of ANY of
@@ -255,7 +277,7 @@ export class WebCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
-             NULL::text AS project_id,
+             NULL::text AS project_id, NULL::text AS conversation_id,
              u.last_crawled_at AS modified_at,
              CASE WHEN c.core_content <> ''
                    AND position(c.core_content IN u.content) > 0
@@ -284,7 +306,7 @@ export class WebCorpusReader implements CorpusReader {
     const statement = `
       SELECT c.id::text AS id, c.chunk_content, c.chunk_index,
              c.url AS ref, c.title, c.url,
-             NULL::text AS project_id,
+             NULL::text AS project_id, NULL::text AS conversation_id,
              u.last_crawled_at AS modified_at,
              CASE WHEN c.core_content <> ''
                    AND position(c.core_content IN u.content) > 0
@@ -390,6 +412,7 @@ function toHits(
         title: row.title,
         url: row.url,
         projectId: row.project_id,
+        conversationId: row.conversation_id,
         modifiedAt: row.modified_at ? row.modified_at.getTime() : null,
       },
       score: row.score,

--- a/services/platform/convex/knowledge/ddl.test.ts
+++ b/services/platform/convex/knowledge/ddl.test.ts
@@ -71,6 +71,10 @@ describe('the real migrations are what gets applied', () => {
   it('declares the columns retrieval and reassembly depend on', () => {
     // If a migration ever loses one of these, retrieval breaks in a way that
     // looks like bad search results rather than like a missing column.
+    //
+    // The scope columns are checked in the case below instead: a substring
+    // search over the joined SQL also matches these files' prose, so it would
+    // pass on a migration that only TALKS about `conversation_id`.
     delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
     const all = corpusMigrations()
       .map((m) => m.sql)
@@ -101,6 +105,28 @@ describe('the real migrations are what gets applied', () => {
         later.some((m) =>
           m.sql.includes('ADD COLUMN IF NOT EXISTS context_header'),
         ),
+      ).toBe(true);
+    }
+  });
+
+  it('adds each scope column outside the private_knowledge baseline', () => {
+    // Same regression class as the chunk-context convergence, with a worse
+    // failure mode: a ledgered database never re-runs its baseline, so a scope
+    // column declared only there is absent in production while the code filters
+    // on it — the statement errors, and a failing retrieval reads as "no
+    // results" rather than as a broken deployment.
+    delete process.env.KNOWLEDGE_MIGRATIONS_DIR;
+    const later = corpusMigrations()
+      .filter((m) => m.schema === 'private_knowledge')
+      .slice(1);
+    for (const column of [
+      'team_id',
+      'project_id',
+      'team_ids',
+      'conversation_id',
+    ]) {
+      expect(
+        later.some((m) => m.sql.includes(`ADD COLUMN IF NOT EXISTS ${column}`)),
       ).toBe(true);
     }
   });

--- a/services/platform/convex/knowledge/fetch.test.ts
+++ b/services/platform/convex/knowledge/fetch.test.ts
@@ -236,6 +236,50 @@ describe('fetchDocumentByFileId — access scope', () => {
     expect(doc).toBeNull();
   });
 
+  it('does not serve an emailed attachment to a caller who cannot read mail', async () => {
+    // Scope-by-set cannot decide a conversation row, so the SQL half only
+    // decides whether such rows are in play at all. A caller whose scope
+    // excludes them gets a miss without a Convex round-trip, and the body is
+    // never read.
+    corpusWith({ team_id: null, project_id: null, conversation_id: 'conv_1' });
+    const doc = await fetchDocumentByFileId('acme', 'file_9', SCOPED);
+    expect(doc).toBeNull();
+    expect(unsafe.mock.calls.some(([text]) => text.includes('.chunks'))).toBe(
+      false,
+    );
+    expect(validateLiveFile).not.toHaveBeenCalled();
+  });
+
+  it('hands an emailed attachment to the Convex re-check, hub visibility notwithstanding', async () => {
+    // Its scope columns are all NULL, so scope-by-set would read it as an
+    // org-hub document and serve it. It must instead reach the re-check, which
+    // is the only code that can see the conversation's assignment.
+    corpusWith({ team_id: null, project_id: null, conversation_id: 'conv_1' });
+    validateLiveFile.mockImplementation(async () => []);
+    const denied = await fetchDocumentByFileId('acme', 'file_9', {
+      ...SCOPED,
+      includeConversationScoped: true,
+    });
+    expect(denied).toBeNull();
+    expect(validateLiveFile).toHaveBeenCalled();
+
+    validateLiveFile.mockImplementation(
+      async (_ref: unknown, args: { fileIds: string[] }) => args.fileIds,
+    );
+    const served = await fetchDocumentByFileId('acme', 'file_9', {
+      ...SCOPED,
+      includeConversationScoped: true,
+    });
+    expect(served?.text).toBe('SCOPED BODY');
+  });
+
+  it('selects the conversation column for a scoped caller', async () => {
+    corpusWith({ team_id: null, project_id: null });
+    await fetchDocumentByFileId('acme', 'file_9', SCOPED);
+    const [docCall] = unsafe.mock.calls;
+    expect(docCall?.[0]).toContain('d.conversation_id');
+  });
+
   it('serves a team-library row to a member of that team', async () => {
     corpusWith({
       team_ids: ['team-a'],

--- a/services/platform/convex/knowledge/fetch.ts
+++ b/services/platform/convex/knowledge/fetch.ts
@@ -113,7 +113,9 @@ export async function fetchDocumentByFileId(
   // deprecated first-element mirror, still read so a row the `team_ids` DDL
   // backfill has not stamped keeps its single-team visibility.
   const scopeColumns =
-    args.access !== undefined ? ', d.team_ids, d.team_id, d.project_id' : '';
+    args.access !== undefined
+      ? ', d.team_ids, d.team_id, d.project_id, d.conversation_id'
+      : '';
   try {
     const documents = await sql.unsafe<
       Array<{
@@ -124,6 +126,7 @@ export async function fetchDocumentByFileId(
         team_ids?: string[] | null;
         team_id?: string | null;
         project_id?: string | null;
+        conversation_id?: string | null;
       }>
     >(
       `
@@ -137,7 +140,16 @@ export async function fetchDocumentByFileId(
     );
     const document = documents[0];
     if (!document) return null;
-    if (
+    // A conversation row is decided by the conversation's live assignment, which
+    // this SQL cannot see, so scope-by-set does not apply to it — the mandatory
+    // Convex-truth re-check below is its gate. All that is decided here is
+    // whether such rows are in play for this caller at all: a caller who cannot
+    // read conversations gets an honest miss without touching Convex.
+    if (document.conversation_id != null) {
+      if (args.access !== undefined && !args.access.includeConversationScoped) {
+        return null;
+      }
+    } else if (
       !knowledgeScopeAllows(args.access, {
         teamIds: document.team_ids,
         teamId: document.team_id,
@@ -153,12 +165,21 @@ export async function fetchDocumentByFileId(
       {
         organizationId: args.organizationId,
         fileIds: [args.fileId],
+        ...(args.access?.userId !== undefined
+          ? { userId: args.access.userId }
+          : {}),
         ...(args.access !== undefined
           ? {
               access: {
                 teamIds: [...args.access.teamIds],
                 projectIds: [...args.access.projectIds],
                 includeHub: args.access.includeHub,
+                ...(args.access.includeConversationScoped !== undefined
+                  ? {
+                      includeConversationScoped:
+                        args.access.includeConversationScoped,
+                    }
+                  : {}),
                 ...(args.access.threadIds !== undefined
                   ? { threadIds: [...args.access.threadIds] }
                   : {}),

--- a/services/platform/convex/knowledge/indexing.test.ts
+++ b/services/platform/convex/knowledge/indexing.test.ts
@@ -377,6 +377,30 @@ describe('document scope is stamped on the corpus row', () => {
     expect(stamped?.params[7]).toBe('team-sales');
   });
 
+  it('stamps the conversation an emailed attachment arrived on', async () => {
+    // Without this the row lands with every scope column NULL — an org-hub
+    // document — and the inbox attachment becomes readable by the whole
+    // organization. The stamp is also the QUESTION, not the answer: retrieval
+    // re-asks the conversation's current assignment, so a reassignment moves
+    // the file without touching this row.
+    const db = fakeDb();
+    await indexDocument({
+      ...ARGS,
+      sql: db.sql,
+      embedder: stubEmbedder(),
+      teamIds: null,
+      projectId: null,
+      conversationId: 'conv_inbound',
+    });
+    const stamped = claim(db);
+    expect(stamped?.text).toContain('conversation_id');
+    expect(stamped?.text).toContain(
+      'conversation_id = EXCLUDED.conversation_id',
+    );
+    // $10 is conversation_id, after team_ids/team_id/project_id.
+    expect(stamped?.params[9]).toBe('conv_inbound');
+  });
+
   it('carries the project scope, and stamps NULLs for a hub document', async () => {
     const project = fakeDb();
     await indexDocument({
@@ -404,6 +428,8 @@ describe('document scope is stamped on the corpus row', () => {
       expect(stamped?.params[6]).toBeNull();
       expect(stamped?.params[7]).toBeNull();
       expect(stamped?.params[8]).toBeNull();
+      // …and it is not a conversation row either.
+      expect(stamped?.params[9]).toBeNull();
     }
   });
 });

--- a/services/platform/convex/knowledge/indexing.ts
+++ b/services/platform/convex/knowledge/indexing.ts
@@ -72,6 +72,16 @@ export interface IndexDocumentArgs {
    */
   readonly teamIds?: readonly string[] | null;
   readonly projectId?: string | null;
+  /**
+   * The conversation an emailed attachment arrived on, when the file IS one.
+   *
+   * A third scope dimension rather than a value folded into the two above,
+   * because it is not an answer: conversation visibility is decided live from
+   * the conversation's current assignment, so the row records only which
+   * conversation to ask about. Its other job is to keep the row out of the hub
+   * clause — every scope column NULL reads as org-wide.
+   */
+  readonly conversationId?: string | null;
   readonly sourceCreatedAt?: Date | null;
   readonly sourceModifiedAt?: Date | null;
   /** Chunks to commit in this invocation. */
@@ -166,6 +176,7 @@ export async function indexDocument(
     folderPath: args.folderPath ?? null,
     teamIds: args.teamIds ?? null,
     projectId: args.projectId ?? null,
+    conversationId: args.conversationId ?? null,
     sourceCreatedAt: args.sourceCreatedAt ?? null,
     sourceModifiedAt: args.sourceModifiedAt ?? null,
     // Only content that is actually the same keeps its committed chunks.
@@ -306,6 +317,7 @@ async function claimDocumentRow(args: {
   folderPath: string | null;
   teamIds: readonly string[] | null;
   projectId: string | null;
+  conversationId: string | null;
   sourceCreatedAt: Date | null;
   sourceModifiedAt: Date | null;
   keepChunks: boolean;
@@ -319,9 +331,10 @@ async function claimDocumentRow(args: {
     const rows = await tx.unsafe<{ id: string }[]>(
       `INSERT INTO ${SCHEMA}.documents
           (org_slug, file_id, filename, content_hash, status, chunks_count,
-           folder_path, team_ids, team_id, project_id, source_created_at,
-           source_modified_at)
-       VALUES ($1, $2, $3, $4, 'processing', $5, $6, $7::text[], $8, $9, $10, $11)
+           folder_path, team_ids, team_id, project_id, conversation_id,
+           source_created_at, source_modified_at)
+       VALUES ($1, $2, $3, $4, 'processing', $5, $6, $7::text[], $8, $9, $10,
+               $11, $12)
        ON CONFLICT (org_slug, file_id) DO UPDATE SET
            filename = EXCLUDED.filename,
            content_hash = EXCLUDED.content_hash,
@@ -331,6 +344,7 @@ async function claimDocumentRow(args: {
            team_ids = EXCLUDED.team_ids,
            team_id = EXCLUDED.team_id,
            project_id = EXCLUDED.project_id,
+           conversation_id = EXCLUDED.conversation_id,
            source_created_at = EXCLUDED.source_created_at,
            source_modified_at = EXCLUDED.source_modified_at,
            error = NULL,
@@ -346,6 +360,7 @@ async function claimDocumentRow(args: {
         teamIds,
         teamIds?.[0] ?? null,
         args.projectId,
+        args.conversationId,
         args.sourceCreatedAt,
         args.sourceModifiedAt,
       ],

--- a/services/platform/convex/knowledge/ingest_file.test.ts
+++ b/services/platform/convex/knowledge/ingest_file.test.ts
@@ -13,6 +13,9 @@ vi.mock('../_generated/api', () => ({
     file_metadata: {
       internal_mutations: { updateFileRagStatus: 'updateFileRagStatus' },
       internal_actions: { uploadFileToRag: 'uploadFileToRag' },
+      internal_queries: {
+        getConversationBindingForBlob: 'getConversationBindingForBlob',
+      },
     },
   },
 }));
@@ -86,7 +89,10 @@ const ARGS = {
   contentType: 'text/plain',
 };
 
-function createCtx(currentFileIds: string[] = ['blob_1']) {
+function createCtx(
+  currentFileIds: string[] = ['blob_1'],
+  conversationBinding: string | null = null,
+) {
   const statusWrites: Array<Record<string, unknown>> = [];
   const scheduled: Array<{ ref: unknown; args: Record<string, unknown> }> = [];
   const deleted: Array<Record<string, unknown>> = [];
@@ -96,7 +102,11 @@ function createCtx(currentFileIds: string[] = ['blob_1']) {
       statusWrites.push(args);
       return null;
     }),
-    runQuery: vi.fn(async () => {
+    // Dispatches by ref: the conversation binding and the document fence are
+    // different reads, and answering both with one shape is how a fixture ends
+    // up proving nothing.
+    runQuery: vi.fn(async (ref: unknown) => {
+      if (ref === 'getConversationBindingForBlob') return conversationBinding;
       const fileId =
         currentFileIds[Math.min(currentRead, currentFileIds.length - 1)];
       currentRead += 1;
@@ -115,7 +125,7 @@ function createCtx(currentFileIds: string[] = ['blob_1']) {
       ),
     },
   };
-  return { ctx: ctx as never, statusWrites, scheduled, deleted };
+  return { ctx: ctx as never, statusWrites, scheduled, deleted, spies: ctx };
 }
 
 function completedResult(chunksTotal = 3) {
@@ -354,5 +364,52 @@ describe('indexFileBlob — slices', () => {
     });
     // Not terminal: the continuation owns the ending.
     expect(statusWrites.at(-1)).toMatchObject({ ragStatus: 'running' });
+  });
+});
+
+describe('indexFileBlob — conversation scope', () => {
+  // An emailed attachment has no Document Hub row, so its corpus row would land
+  // with every scope column NULL — which reads as an org-wide hub document. The
+  // conversation stamp is what keeps it out of that clause and hands the
+  // decision to the assignment re-check at retrieval time.
+  it('stamps the conversation a bound blob arrived on', async () => {
+    const { ctx } = createCtx(['blob_1'], 'conv_inbound');
+    indexDocumentMock.mockResolvedValue(completedResult());
+
+    await indexFileBlob(ctx, ARGS);
+
+    expect(indexDocumentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'conv_inbound' }),
+    );
+  });
+
+  it('stamps null for a file that arrived any other way', async () => {
+    const { ctx } = createCtx();
+    indexDocumentMock.mockResolvedValue(completedResult());
+
+    await indexFileBlob(ctx, ARGS);
+
+    expect(indexDocumentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: null }),
+    );
+  });
+
+  it('reads the binding from truth, not from its arguments', async () => {
+    // Nothing in the dispatch chain carries the conversation id, so a retry, a
+    // promotion from parked, or a later slice of a large file all pick up the
+    // CURRENT binding — a reassignment cannot leave the corpus disagreeing with
+    // the conversation.
+    const { ctx, spies } = createCtx(['blob_1'], 'conv_now');
+    indexDocumentMock.mockResolvedValue(completedResult());
+
+    await indexFileBlob(ctx, { ...ARGS, projectId: 'proj_1' } as never);
+
+    expect(spies.runQuery).toHaveBeenCalledWith(
+      'getConversationBindingForBlob',
+      expect.objectContaining({ organizationId: 'org_1', storageId: 'blob_1' }),
+    );
+    expect(indexDocumentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'conv_now' }),
+    );
   });
 });

--- a/services/platform/convex/knowledge/ingest_file.ts
+++ b/services/platform/convex/knowledge/ingest_file.ts
@@ -219,6 +219,15 @@ export async function indexFileBlob(
     });
 
     const fileId = String(storageId);
+    // The conversation this blob arrived on, when it is an emailed attachment.
+    // Read from Convex truth rather than taken as an argument: the stamp then
+    // cannot disagree with the binding, and a retry or a later slice picks up a
+    // rebinding for free. Null for every other file, which is every file with a
+    // Document Hub row.
+    const conversationId: string | null = await ctx.runQuery(
+      internal.file_metadata.internal_queries.getConversationBindingForBlob,
+      { organizationId: args.organizationId, storageId },
+    );
     // The deprecated single-team arg reads as a one-element list; the full
     // list wins when both are present (`hasTeamAccess` precedence).
     const teamIds: string[] | null =
@@ -243,6 +252,7 @@ export async function indexFileBlob(
         folderPath: args.folderPath ?? null,
         teamIds,
         projectId: args.projectId ?? null,
+        conversationId,
         sourceCreatedAt:
           args.sourceCreatedAtMs != null
             ? new Date(args.sourceCreatedAtMs)

--- a/services/platform/convex/knowledge/search.ts
+++ b/services/platform/convex/knowledge/search.ts
@@ -120,12 +120,21 @@ export async function searchKnowledge(
     {
       organizationId: args.organizationId,
       fileIds: documentRefs,
+      ...(args.access?.userId !== undefined
+        ? { userId: args.access.userId }
+        : {}),
       ...(args.access !== undefined
         ? {
             access: {
               teamIds: [...args.access.teamIds],
               projectIds: [...args.access.projectIds],
               includeHub: args.access.includeHub,
+              ...(args.access.includeConversationScoped !== undefined
+                ? {
+                    includeConversationScoped:
+                      args.access.includeConversationScoped,
+                  }
+                : {}),
               ...(args.access.threadIds !== undefined
                 ? { threadIds: [...args.access.threadIds] }
                 : {}),

--- a/services/platform/convex/sandbox/workspace_access.test.ts
+++ b/services/platform/convex/sandbox/workspace_access.test.ts
@@ -367,6 +367,46 @@ describe('resolveKnowledgeToolAccess', () => {
         projectIds: [orgWideProject],
         includeHub: true,
         archivedProjectIds: [],
+        // A user-keyed session knows who is asking, so emailed attachments are
+        // in play — decided one by one against each conversation's current
+        // assignment by the Convex-truth re-check.
+        includeConversationScoped: true,
+        userId: 'u9',
+      },
+    });
+  });
+
+  it('a session-keyed run gets no identity, so no emailed attachment', async () => {
+    // The scope a bound session gets is a pair of SETS. A conversation's reader
+    // is its current assignee or assigned team, which no set can express, so a
+    // run with nobody behind it must not admit those rows at all — setting the
+    // flag here would hand every skill run the whole inbox.
+    const t = newTest();
+    const projectId = await seedProject(t, {});
+    const agentId = await seedProjectAgent(t, projectId);
+    await seedSession(t, {
+      sessionId: 'sess_proj',
+      ownerType: 'project_agent',
+      ownerId: agentId,
+    });
+    const bound = await t.query(
+      internal.sandbox.workspace_access.resolveKnowledgeToolAccess,
+      {
+        organizationId: ORG,
+        sessionId: 'sess_proj',
+        subject: 'documents',
+      },
+    );
+    // Asserted exhaustively rather than field by field: `toEqual` is what
+    // proves the two fields are ABSENT, and it will also catch a later field
+    // arriving here by accident.
+    expect(bound).toEqual({
+      allowed: true,
+      scope: {
+        teamIds: [],
+        projectIds: [projectId],
+        includeHub: true,
+        archivedProjectIds: [],
       },
     });
   });

--- a/services/platform/convex/sandbox/workspace_access.ts
+++ b/services/platform/convex/sandbox/workspace_access.ts
@@ -14,8 +14,9 @@ import type { Doc, Id } from '../_generated/dataModel';
 import { internalQuery, type QueryCtx } from '../_generated/server';
 import { bindingsOf } from '../automations/store';
 import {
-  resolveKnowledgeAccessForUser,
+  knowledgeAccessScopeValidator,
   type ResolvedKnowledgeAccess,
+  resolveKnowledgeAccessForUser,
 } from '../documents/access';
 import {
   resolveAgentReadAccess,
@@ -188,12 +189,7 @@ export const resolveKnowledgeToolAccess = internalQuery({
   returns: v.union(
     v.object({
       allowed: v.literal(true),
-      scope: v.object({
-        teamIds: v.array(v.string()),
-        projectIds: v.array(v.string()),
-        includeHub: v.boolean(),
-        archivedProjectIds: v.optional(v.array(v.string())),
-      }),
+      scope: knowledgeAccessScopeValidator,
     }),
     v.object({
       allowed: v.literal(false),
@@ -219,6 +215,13 @@ export const resolveKnowledgeToolAccess = internalQuery({
       args.organizationId,
       args.sessionId,
     );
+    // Neither session-keyed branch below carries `userId` or
+    // `includeConversationScoped`, so neither can retrieve an emailed
+    // attachment. That is deliberate, not an omission: a conversation's reader
+    // is its current assignee or assigned team, and a session bound to a
+    // project or to an org-level run has no person to check that against.
+    // Setting the flag here without an identity would publish the whole inbox
+    // to every skill run.
     if (binding.kind === 'project') {
       return {
         allowed: true,

--- a/services/platform/lib/knowledge/types.ts
+++ b/services/platform/lib/knowledge/types.ts
@@ -93,6 +93,9 @@ export interface KnowledgeSource {
    * caller can tell whether the project is archived without a second read.
    */
   readonly projectId?: string | null;
+  /** The conversation an emailed attachment arrived on. Present only for those;
+   * the re-check uses it to decide the hit by assignment. */
+  readonly conversationId?: string | null;
 }
 
 /** A hit after fusion, carrying the rank-based score it was ordered by. */
@@ -138,6 +141,23 @@ export interface KnowledgeAccessScope {
    * which under-labels rather than over-filters.
    */
   readonly archivedProjectIds?: readonly string[];
+  /**
+   * Whether conversation-scoped rows — emailed attachments — may be ADMITTED by
+   * the SQL pre-filter for the Convex-truth re-check to decide.
+   *
+   * Not a grant. The re-check applies `conversationAssignmentAllows` against the
+   * conversation's current assignment, so this only says "consider them"; a
+   * caller who can read no conversation gets none of them back. Absent means
+   * they are not considered at all, which is the fail-closed default for a
+   * surface that has not thought about it.
+   */
+  readonly includeConversationScoped?: boolean;
+  /**
+   * Who is asking. Carried because a conversation-scoped row is decided by the
+   * conversation's live assignment, which needs an identity rather than a set —
+   * the sets above cannot express "the assignee". Absent denies those rows.
+   */
+  readonly userId?: string;
   /**
    * Chat threads whose thread-bound uploads the caller may retrieve — the
    * turn's own thread, derived server-side from the owned-thread check.

--- a/services/platform/lib/shared/file-types.test.ts
+++ b/services/platform/lib/shared/file-types.test.ts
@@ -7,8 +7,10 @@ import {
   extractExtension,
   getDocumentPreviewKind,
   isAllowedDocumentUpload,
+  isAudioOrVideo,
   isRagIndexableFile,
   mimeToExtension,
+  RAG_INDEXABLE_EXTENSIONS,
   resolveFileType,
 } from './file-types';
 
@@ -431,6 +433,38 @@ describe('isRagIndexableFile', () => {
     // Extension wins over MIME — a .doc reported as text/plain is still
     // a .doc to RAG's extension gate.
     expect(isRagIndexableFile('legacy.doc', 'text/plain')).toBe(false);
+  });
+});
+
+describe('RAG-indexable and audio/video are disjoint', () => {
+  // Several callers ask "indexable, and not audio" — the email-attachment
+  // binder among them, which queues an inbound file for text indexing. The
+  // audio half of that condition is unreachable while these two sets are
+  // disjoint, and pinning it is what keeps it from rotting into dead code: add
+  // an audio or video extension to the indexable set and this fails, so the
+  // decision to route it through the text pipeline gets made on purpose.
+  it('no indexable extension resolves to an audio or video type', () => {
+    const overlap = [...RAG_INDEXABLE_EXTENSIONS].filter((ext) =>
+      isAudioOrVideo(
+        resolveFileType(`file.${ext}`, 'application/octet-stream'),
+      ),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it('an audio file is not indexable, whatever its reported type', () => {
+    for (const [name, contentType] of [
+      ['call.mp3', 'audio/mpeg'],
+      ['call.m4a', 'audio/mp4'],
+      ['clip.mp4', 'video/mp4'],
+      ['clip.mov', 'video/quicktime'],
+      // A mislabelled upload must not sneak in on its content type either.
+      ['call.mp3', 'text/plain'],
+    ] as const) {
+      expect(isRagIndexableFile(name, resolveFileType(name, contentType))).toBe(
+        false,
+      );
+    }
   });
 });
 

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -892,7 +892,11 @@ export function getDocumentPreviewKind(
  * usable inline in chat but must not be queued for indexing — RAG rejects
  * them with HTTP 400, which used to surface as a permanent "Index failed".
  */
-const RAG_INDEXABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+/** Exported so the audio/video disjointness invariant can be asserted over the
+ *  whole set rather than a sample of it — several callers gate on "indexable and
+ *  not audio", and that second half is only meaningful while these are
+ *  disjoint. */
+export const RAG_INDEXABLE_EXTENSIONS: ReadonlySet<string> = new Set([
   // Documents
   'pdf',
   'docx',


### PR DESCRIPTION
Turns on what #3011 built. An emailed attachment is now indexed, and it is
readable by whoever can currently read the conversation it arrived on.

Stacked on #3011 — review that one first; this branch contains its two commits.

## Where indexing starts

At binding, not at storage. Attachment bytes are drained one message at a time
inside the fetch, before the conversation is resolved, so at storage time there
is nothing to scope the file to. An unscoped corpus row is an org-wide hub
document, which is the outcome this line of work exists to prevent.

`bindFileToConversation` is the first moment the conversation is known, so that
is where the row is queued and dispatched.

## Why in one transaction

Marking a row `'queued'` is a promise to dispatch. A queued row that is neither
dispatched nor parked counts against the per-org RAG cap forever, and three of
them starve every real upload — the defect that made email attachments skip
indexing in the first place (#2995).

Binding is best-effort by design: it must not fail a sync that has already landed
the mail. So the promise is not made across that boundary. The mutation queues
and dispatches together, and a poll that cannot bind leaves the file unindexed
rather than half-enqueued.

Only a row that was never indexed is queued. A re-poll of the same mail must not
re-embed; a failed row belongs to the watchdog; audio indexes through its
transcript; a format with no extractor is not queued at all.

Whether the binding moved and whether the file needs indexing are independent
facts. An attachment bound by #3010 already has a conversation and still has no
`ragStatus`, so returning early on "binding unchanged" would leave it unindexed
for good — nothing else would ever queue it. Such a row is now queued without
rewriting the link it already had.

## Why the stamp is read, not passed

`indexFileBlob` reads the binding from Convex truth rather than taking it as an
argument. Nothing in the dispatch chain carries a conversation id, so a watchdog
retry, a promotion from parked, and a later slice of a large file all pick up the
current binding. A reassignment cannot leave the corpus disagreeing with the
conversation.

## An invariant this made visible

Several callers gate on "indexable and not audio". Those two sets turn out to be
disjoint, so the audio half is unreachable — which makes it indistinguishable
from dead code. Rather than delete a guard that may matter later, the extension
set is now exported and a test asserts the disjointness. Add an audio extension
to the indexable set and that test fails, so routing a recording into the text
pipeline becomes a decision instead of an accident.

## Proof

Full platform gate green: 75,207 unit tests, type-aware lint, typecheck,
`migrations:check`.

New coverage: which rows the binder queues and which it only binds (already
completed, failed, running, queued, audio, no-extractor, trashed); that the
dispatch happens with the queue write; that the binder keeps going past a failure
and reports honest counts; that a part with no stored bytes is skipped; the
index-time stamp for a bound blob, an unbound one, and that it is read per
invocation; and the binding query's tenant boundary, driven through convex-test
against the real schema.

14 mutations applied, 14 killed.

## Known gap

This converges any attachment on mail a poll touches. It does not reach mail a
poll will never touch again — an attachment stored by an earlier sync, on a
conversation that has since gone quiet, is not revisited, so it stays unindexed.
Draining that backlog needs its own bounded pass and is not part of this change.