### PR TITLE
fix(platform): let mail ingest read an assigned conversation

### DIFF
--- a/services/platform/convex/conversations/internal_queries.ts
+++ b/services/platform/convex/conversations/internal_queries.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 
 import { internalQuery } from '../_generated/server';
+import { lifecycleStatusValidator } from '../governance/soft_delete_validators';
 import { cursorPaginationOptsValidator } from '../lib/pagination';
 import { jsonRecordValidator } from '../lib/validators/json';
 import * as ConversationsHelpers from './helpers';
@@ -9,7 +10,13 @@ import {
   conversationPriorityValidator,
 } from './validators';
 
-const internalConversationRecordValidator = v.object({
+/**
+ * Exported for `internal_record_validators.test.ts`, which asserts these cover
+ * every field their table declares. A closed object validator THROWS on a field
+ * it does not list, so an omission does not narrow a payload — it makes the row
+ * unreadable, and the caller sees the throw as absent data.
+ */
+export const internalConversationRecordValidator = v.object({
   _id: v.id('conversations'),
   _creationTime: v.number(),
   organizationId: v.string(),
@@ -24,9 +31,17 @@ const internalConversationRecordValidator = v.object({
   connectorName: v.optional(v.string()),
   lastMessageAt: v.optional(v.number()),
   metadata: v.optional(jsonRecordValidator),
+  // Assignment, lifecycle and the status clock. Omitting them did not narrow
+  // the payload — a closed object validator THROWS on a field it does not
+  // declare, so every ASSIGNED conversation failed to read through these
+  // queries, and the caller saw the failure as absent data.
+  assigneeUserId: v.optional(v.string()),
+  assigneeTeamId: v.optional(v.string()),
+  lifecycleStatus: v.optional(lifecycleStatusValidator),
+  statusChangedAt: v.optional(v.number()),
 });
 
-const internalMessageRecordValidator = v.object({
+export const internalMessageRecordValidator = v.object({
   _id: v.id('conversationMessages'),
   _creationTime: v.number(),
   organizationId: v.string(),
@@ -45,6 +60,9 @@ const internalMessageRecordValidator = v.object({
   sentAt: v.optional(v.number()),
   deliveredAt: v.optional(v.number()),
   metadata: v.optional(jsonRecordValidator),
+  // Set once a send is retried; absent on every message that never was. Same
+  // failure as above — a retried message could not be read at all.
+  retryCount: v.optional(v.number()),
 });
 
 export const getConversationById = internalQuery({

--- a/services/platform/convex/conversations/internal_record_validators.test.ts
+++ b/services/platform/convex/conversations/internal_record_validators.test.ts
@@ -1,0 +1,73 @@
+// The guard for a defect class, not for one bug.
+//
+// `getMessageByExternalId`, `getConversationById` and
+// `getConversationByExternalMessageId` return whole rows through CLOSED object
+// validators. A closed validator throws on a field it does not declare, so a
+// field added to the table and not to the validator does not shrink the
+// payload — it makes every row carrying that field unreadable. All three
+// queries are on the mail ingest path, so the symptom is mail that will not
+// sync, reported as a ReturnsValidationError.
+//
+// That is what happened: the validators omitted `retryCount` on messages and
+// `assigneeUserId` / `assigneeTeamId` / `lifecycleStatus` / `statusChangedAt` on
+// conversations, so ingest failed on any ASSIGNED conversation — which, on a
+// deployment that routes mail to a team, is all of them.
+//
+// The assertion derives the expected field set from the table definition rather
+// than restating it, so adding a column to the schema and forgetting the
+// validator fails here instead of in production.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  internalConversationRecordValidator,
+  internalMessageRecordValidator,
+} from './internal_queries';
+import { conversationMessagesTable, conversationsTable } from './schema';
+
+/** Field names a `v.object(...)` declares. */
+function declared(validator: unknown): Set<string> {
+  const fields = (validator as { fields: Record<string, unknown> }).fields;
+  return new Set(Object.keys(fields));
+}
+
+/** Field names a `defineTable(...)` declares. */
+function columns(table: unknown): Set<string> {
+  const validator = (
+    table as { validator: { fields: Record<string, unknown> } }
+  ).validator;
+  return new Set(Object.keys(validator.fields));
+}
+
+describe('internal record validators cover their whole table', () => {
+  const cases = [
+    ['conversations', conversationsTable, internalConversationRecordValidator],
+    [
+      'conversationMessages',
+      conversationMessagesTable,
+      internalMessageRecordValidator,
+    ],
+  ] as const;
+
+  it.each(cases)(
+    '%s: every column is declared, so no row is unreadable',
+    (_name, table, validator) => {
+      const missing = [...columns(table)].filter(
+        (field) => !declared(validator).has(field),
+      );
+      expect(missing).toEqual([]);
+    },
+  );
+
+  it.each(cases)(
+    '%s: the validator invents no field the table lacks',
+    (_name, table, validator) => {
+      // System fields are supplied by Convex, not by the table definition.
+      const system = new Set(['_id', '_creationTime']);
+      const extra = [...declared(validator)].filter(
+        (field) => !system.has(field) && !columns(table).has(field),
+      );
+      expect(extra).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
Inbound mail sync fails on any conversation that carries an assignment. On a deployment that routes mail to a team, that is every conversation.

## Why

The three internal queries on the mail ingest path return whole rows through closed object validators, and those validators omit fields the schema declares:

| Validator | Omitted |
| --- | --- |
| `internalConversationRecordValidator` | `assigneeUserId`, `assigneeTeamId`, `lifecycleStatus`, `statusChangedAt` |
| `internalMessageRecordValidator` | `retryCount` |

A closed validator throws on a field it does not list. So the omission does not narrow the payload — it makes the row unreadable. `checkMessageExists` has no catch, so the throw reaches ingest.

Observed in production as `getMessageByExternalId ReturnsValidationError` during a scheduled sync.

Callers, all on the ingest path:

- `getMessageByExternalId` → `check_message_exists.ts` — is this email already ingested?
- `getConversationByExternalMessageId` → `check_conversation_exists.ts` — does this thread exist?
- `getConversationById` → `create_conversation.ts`, `update_conversations.ts`, `create_conversation_from_email.ts`

## What changed

- Both validators now declare every column their table declares.
- A guard derives the expectation from the table definition rather than restating the field list, asserting both directions: no column missing, and no field invented that the table lacks.

## Risk

The guard cannot be applied codebase-wide, and deliberately is not. A validator with fewer fields than its table is either an omission or a projection, and only the handler's return shape distinguishes them — `toProjectAgentRow` in `projects/queries.ts` is a correct field-by-field projection that would fail such a check. So the property is asserted per validator, for the two that return raw rows.

## Tests

Four assertions across both validators, derived from `defineTable`.

Five mutations, all red: dropping `retryCount`, dropping the two assignment fields, dropping `lifecycleStatus`, dropping `statusChangedAt`, and adding a field the table lacks.

## Scope

Does not touch the queries' behaviour, only what they are permitted to return. Does not audit other row-shaped validators, for the reason under Risk.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, platform 75,235 tests.
