### PR TITLE
fix(platform): type RLS errors as ConvexError and name a deleted org

### DIFF
--- a/services/platform/convex/connector_credentials/queries.test.ts
+++ b/services/platform/convex/connector_credentials/queries.test.ts
@@ -12,7 +12,7 @@
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
-import { api, internal } from '../_generated/api';
+import { api, components, internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
@@ -100,6 +100,26 @@ async function seedMember(
       role: 'member',
       createdAt: 0,
     });
+  });
+}
+
+/** A real betterAuth organization row: a membership REFUSAL requires the org
+ * to exist — an unknown org id reports ORG_NOT_FOUND instead (#3021). The
+ * fixture ORG strings above deliberately have no row. Returns the created
+ * component-side document id. */
+async function seedOrganization(t: T, slug: string): Promise<string> {
+  return t.run(async (ctx) => {
+    const created = await ctx.runMutation(
+      components.betterAuth.adapter.create,
+      {
+        input: {
+          model: 'organization',
+          data: { name: slug, slug, createdAt: 0 },
+        },
+      },
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter returns the created record as unknown
+    return (created as { _id: string })._id;
   });
 }
 
@@ -278,14 +298,30 @@ describe('listCredentials', () => {
 
   it('refuses a caller who is not a member of the organization', async () => {
     const t = newWorld();
+    const realOrg = await seedOrganization(t, 'ic-queries-real');
     await seedMember(t, MEMBER, OTHER_ORG);
+    await expect(
+      t
+        .withIdentity({ subject: MEMBER })
+        .query(api.connector_credentials.queries.listCredentials, {
+          organizationId: realOrg,
+        }),
+    ).rejects.toThrowError(/Not a member/);
+  });
+
+  it('reports an organization that does not exist as not found', async () => {
+    const t = newWorld();
+    await seedMember(t, MEMBER, OTHER_ORG);
+    // The fixture ORG string never had an organization row — the exact state
+    // a deleted org's stale id leaves behind. It must not read as a
+    // permissions bug (#3021).
     await expect(
       t
         .withIdentity({ subject: MEMBER })
         .query(api.connector_credentials.queries.listCredentials, {
           organizationId: ORG,
         }),
-    ).rejects.toThrowError(/Not a member/);
+    ).rejects.toThrowError(/not found/);
   });
 });
 

--- a/services/platform/convex/lib/rls/errors.ts
+++ b/services/platform/convex/lib/rls/errors.ts
@@ -1,26 +1,52 @@
 /**
  * RLS Error Types
+ *
+ * Every RLS refusal extends `ConvexError`, so a throw that escapes a public
+ * function is an APPLICATION error to the Convex runtime (detected via the
+ * `Symbol.for('ConvexError')` marker, which subclasses inherit): the client
+ * receives the structured `data` (`{ code, message }`) instead of a redacted
+ * "Server Error", and the UI can dispatch on `data.code` exactly as it does
+ * for `requireOrgMembershipById`'s errors. Server-side `instanceof` catches
+ * (approvals, sandbox, members, tasks, governance, …) keep working unchanged
+ * — the hierarchy is the same, only the base class changed. (#3021)
+ *
+ * `message` stays the human sentence (`ConvexError` would stringify the data
+ * into it) so server logs and error reporters keep reading naturally.
  */
+
+import { ConvexError } from 'convex/values';
+
+/** Wire payload of an RLS refusal — what a client reads off `error.data`. */
+type RLSErrorData = { code: string; message: string };
 
 /**
  * Base RLS error class
  */
-export class RLSError extends Error {
-  constructor(
-    message: string,
-    public code: string,
-  ) {
-    super(message);
+export class RLSError extends ConvexError<RLSErrorData> {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super({ code, message });
     this.name = 'RLSError';
+    this.message = message;
+    this.code = code;
   }
 }
 
 /**
- * Thrown when user is not authorized to access a resource
+ * Thrown when user is not authorized to access a resource.
+ *
+ * `code` defaults to `UNAUTHORIZED`; the membership check passes the sharper
+ * `ORG_NOT_FOUND` (organization row gone) vs `ORG_FORBIDDEN` (organization
+ * exists, caller is not a non-disabled member) so a deleted organization no
+ * longer reads as a permissions bug.
  */
 export class UnauthorizedError extends RLSError {
-  constructor(message = 'Not authorized to access this resource') {
-    super(message, 'UNAUTHORIZED');
+  constructor(
+    message = 'Not authorized to access this resource',
+    code = 'UNAUTHORIZED',
+  ) {
+    super(message, code);
   }
 }
 

--- a/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../../_generated/api', () => ({
     betterAuth: {
       adapter: {
         findMany: 'betterAuth:adapter:findMany',
+        findOne: 'betterAuth:adapter:findOne',
       },
     },
   },
@@ -14,26 +15,8 @@ vi.mock('../auth/require_authenticated_user', () => ({
   requireAuthenticatedUser: vi.fn(),
 }));
 
-vi.mock('../errors', () => {
-  class RLSError extends Error {
-    constructor(
-      message: string,
-      public code: string,
-    ) {
-      super(message);
-      this.name = 'RLSError';
-    }
-  }
-  class UnauthorizedError extends RLSError {
-    constructor(message = 'Not authorized to access this resource') {
-      super(message, 'UNAUTHORIZED');
-    }
-  }
-  return { UnauthorizedError };
-});
-
-const { UnauthorizedError } = await import('../errors');
-const { getOrganizationMember } = await import('./get_organization_member');
+import { UnauthorizedError } from '../errors';
+import { getOrganizationMember } from './get_organization_member';
 
 // `mirrorRow` seeds the local memberMirror lookup (the hot path). Default null
 // → mirror miss → fall back to the authoritative Better Auth `runQuery` path the
@@ -53,6 +36,20 @@ function createMockCtx(mirrorRow: unknown = null) {
 }
 
 const authUser = { userId: 'user_1', email: 'test@example.com' };
+
+// An org id that passes `looksLikeConvexDocumentId` (the convex-test synthetic
+// shape), so the failure path's existence re-check actually runs — `org_1`
+// style sentinels are rejected by the shape guard before any component read.
+const ID_SHAPED_ORG = '101;organization';
+
+/** Resolve to the thrown `UnauthorizedError`'s code, or undefined. */
+async function rejectionCode(p: Promise<unknown>): Promise<string | undefined> {
+  const err = await p.then(
+    () => null,
+    (e: unknown) => e,
+  );
+  return err instanceof UnauthorizedError ? err.code : undefined;
+}
 
 describe('getOrganizationMember', () => {
   beforeEach(() => {
@@ -98,26 +95,29 @@ describe('getOrganizationMember', () => {
     expect(ctx.runQuery).not.toHaveBeenCalled();
   });
 
-  it('throws UnauthorizedError for a disabled member found in the mirror', async () => {
+  it('reports ORG_FORBIDDEN for a disabled member found in the mirror', async () => {
     const ctx = createMockCtx({
       memberId: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ID_SHAPED_ORG,
       userId: 'user_1',
       role: 'disabled',
       createdAt: 1000,
     });
 
     await expect(
-      getOrganizationMember(ctx as never, 'org_1', authUser),
-    ).rejects.toThrow(UnauthorizedError);
+      rejectionCode(
+        getOrganizationMember(ctx as never, ID_SHAPED_ORG, authUser),
+      ),
+    ).resolves.toBe('ORG_FORBIDDEN');
+    // The member row exists, so no existence re-check either.
     expect(ctx.runQuery).not.toHaveBeenCalled();
   });
 
-  it('throws UnauthorizedError when member role is disabled', async () => {
+  it('reports ORG_FORBIDDEN when member role is disabled', async () => {
     const ctx = createMockCtx();
     const member = {
       _id: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ID_SHAPED_ORG,
       userId: 'user_1',
       role: 'disabled',
       createdAt: 1000,
@@ -125,22 +125,97 @@ describe('getOrganizationMember', () => {
     ctx.runQuery.mockResolvedValueOnce({ page: [member] });
 
     await expect(
-      getOrganizationMember(ctx as never, 'org_1', authUser),
-    ).rejects.toThrow(UnauthorizedError);
+      rejectionCode(
+        getOrganizationMember(ctx as never, ID_SHAPED_ORG, authUser),
+      ),
+    ).resolves.toBe('ORG_FORBIDDEN');
   });
 
-  it('throws UnauthorizedError when member not found', async () => {
+  it('reports ORG_FORBIDDEN when the org exists and the caller is not in it', async () => {
+    const ctx = createMockCtx();
+    // (1) member lookup: empty; (2) existence re-check: the org row is there.
+    // No email on the auth user, so the email fallback stays out of the way.
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+    ctx.runQuery.mockResolvedValueOnce({ _id: ID_SHAPED_ORG, slug: 'acme' });
+
+    const err = await getOrganizationMember(ctx as never, ID_SHAPED_ORG, {
+      userId: 'user_1',
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(UnauthorizedError);
+    if (!(err instanceof UnauthorizedError)) return;
+    expect(err.code).toBe('ORG_FORBIDDEN');
+    expect(err.message).toBe(`Not a member of organization ${ID_SHAPED_ORG}`);
+    // The wire contract: a ConvexError whose data carries the code, so
+    // clients read `{ code, message }` instead of a redacted "Server Error".
+    expect(err.data).toEqual({
+      code: 'ORG_FORBIDDEN',
+      message: `Not a member of organization ${ID_SHAPED_ORG}`,
+    });
+  });
+
+  it('reports ORG_NOT_FOUND when the organization row is gone', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+    ctx.runQuery.mockResolvedValueOnce(null);
+
+    const err = await getOrganizationMember(ctx as never, ID_SHAPED_ORG, {
+      userId: 'user_1',
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(UnauthorizedError);
+    if (!(err instanceof UnauthorizedError)) return;
+    expect(err.code).toBe('ORG_NOT_FOUND');
+    expect(err.message).toBe(`Organization ${ID_SHAPED_ORG} not found`);
+    expect(ctx.runQuery).toHaveBeenCalledTimes(2);
+    expect(ctx.runQuery).toHaveBeenLastCalledWith(
+      'betterAuth:adapter:findOne',
+      {
+        model: 'organization',
+        where: [{ field: '_id', value: ID_SHAPED_ORG, operator: 'eq' }],
+      },
+    );
+  });
+
+  it('reports ORG_NOT_FOUND without a component read for a non-id-shaped org id', async () => {
     const ctx = createMockCtx();
     ctx.runQuery.mockResolvedValueOnce({ page: [] });
 
     await expect(
-      getOrganizationMember(ctx as never, 'org_1', {
-        userId: 'user_1',
-      }),
-    ).rejects.toThrow(UnauthorizedError);
+      rejectionCode(
+        getOrganizationMember(ctx as never, 'org_1', { userId: 'user_1' }),
+      ),
+    ).resolves.toBe('ORG_NOT_FOUND');
+    // Only the member lookup ran — `org_1` cannot be a document id, so the
+    // existence re-check must not reach the betterAuth component (db.get
+    // would throw on it inside the component).
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1);
   });
 
-  it('throws UnauthorizedError for disabled member found via email fallback', async () => {
+  it('falls back to ORG_NOT_FOUND when the existence re-check itself fails', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+    ctx.runQuery.mockRejectedValueOnce(new Error('adapter unavailable'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      rejectionCode(
+        getOrganizationMember(ctx as never, ID_SHAPED_ORG, {
+          userId: 'user_1',
+        }),
+      ),
+    ).resolves.toBe('ORG_NOT_FOUND');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('reports ORG_FORBIDDEN for disabled member found via email fallback', async () => {
     const ctx = createMockCtx();
     // First query: no direct match
     ctx.runQuery.mockResolvedValueOnce({ page: [] });
@@ -162,7 +237,7 @@ describe('getOrganizationMember', () => {
     });
 
     await expect(
-      getOrganizationMember(ctx as never, 'org_1', authUser),
-    ).rejects.toThrow(UnauthorizedError);
+      rejectionCode(getOrganizationMember(ctx as never, 'org_1', authUser)),
+    ).resolves.toBe('ORG_FORBIDDEN');
   });
 });

--- a/services/platform/convex/lib/rls/organization/get_organization_member.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.ts
@@ -5,6 +5,7 @@
 import { components } from '../../../_generated/api';
 import type { QueryCtx, MutationCtx } from '../../../_generated/server';
 import { normalizeAuthEmail } from '../../auth/normalize_auth_email';
+import { looksLikeConvexDocumentId } from '../../helpers/id_shape';
 import { requireAuthenticatedUser } from '../auth/require_authenticated_user';
 import { UnauthorizedError } from '../errors';
 import type { AuthenticatedUser, OrganizationMember } from '../types';
@@ -138,14 +139,45 @@ export async function getOrganizationMember(
   }
 
   if (!member) {
+    // An empty member lookup has two very different causes: the organization
+    // row is gone (a stale bookmark/session after a deletion — routine) or the
+    // organization exists and the caller is simply not in it (a real
+    // authorization refusal). Re-check the org row only on this failure path
+    // so the thrown code and sentence name the right one (#3021) — a deleted
+    // org must not be reported as "Not a member". The shape guard keeps
+    // sentinels/slugs from throwing inside the betterAuth component; the
+    // catch keeps a re-check hiccup from masking the refusal itself.
+    let orgExists = false;
+    if (looksLikeConvexDocumentId(organizationId)) {
+      try {
+        const org = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+          model: 'organization',
+          where: [{ field: '_id', value: organizationId, operator: 'eq' }],
+        });
+        orgExists = org !== null && org !== undefined;
+      } catch (err) {
+        console.warn(
+          '[RLS] organization existence re-check failed; reporting the organization as not found',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    if (!orgExists) {
+      throw new UnauthorizedError(
+        `Organization ${organizationId} not found`,
+        'ORG_NOT_FOUND',
+      );
+    }
     throw new UnauthorizedError(
       `Not a member of organization ${organizationId}`,
+      'ORG_FORBIDDEN',
     );
   }
 
   if (member.role === 'disabled') {
     throw new UnauthorizedError(
       `Member account is disabled in organization ${organizationId}`,
+      'ORG_FORBIDDEN',
     );
   }
 

--- a/services/platform/convex/provider_credentials/queries.test.ts
+++ b/services/platform/convex/provider_credentials/queries.test.ts
@@ -10,7 +10,7 @@
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
-import { api, internal } from '../_generated/api';
+import { api, components, internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
@@ -98,6 +98,26 @@ async function seedMember(
       role: 'member',
       createdAt: 0,
     });
+  });
+}
+
+/** A real betterAuth organization row: a membership REFUSAL requires the org
+ * to exist — an unknown org id reports ORG_NOT_FOUND instead (#3021). The
+ * fixture ORG strings above deliberately have no row. Returns the created
+ * component-side document id. */
+async function seedOrganization(t: T, slug: string): Promise<string> {
+  return t.run(async (ctx) => {
+    const created = await ctx.runMutation(
+      components.betterAuth.adapter.create,
+      {
+        input: {
+          model: 'organization',
+          data: { name: slug, slug, createdAt: 0 },
+        },
+      },
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter returns the created record as unknown
+    return (created as { _id: string })._id;
   });
 }
 
@@ -230,14 +250,30 @@ describe('listCredentials', () => {
 
   it('refuses a caller who is not a member of the organization', async () => {
     const t = newWorld();
+    const realOrg = await seedOrganization(t, 'pc-queries-real');
     await seedMember(t, MEMBER, OTHER_ORG);
+    await expect(
+      t
+        .withIdentity({ subject: MEMBER })
+        .query(api.provider_credentials.queries.listCredentials, {
+          organizationId: realOrg,
+        }),
+    ).rejects.toThrowError(/Not a member/);
+  });
+
+  it('reports an organization that does not exist as not found', async () => {
+    const t = newWorld();
+    await seedMember(t, MEMBER, OTHER_ORG);
+    // The fixture ORG string never had an organization row — the exact state
+    // a deleted org's stale id leaves behind. It must not read as a
+    // permissions bug (#3021).
     await expect(
       t
         .withIdentity({ subject: MEMBER })
         .query(api.provider_credentials.queries.listCredentials, {
           organizationId: ORG,
         }),
-    ).rejects.toThrowError(/Not a member/);
+    ).rejects.toThrowError(/not found/);
   });
 });
 


### PR DESCRIPTION
Org-scoped queries and mutations guarded by the RLS helper crashed with `Uncaught RLSError: Not a member of organization jh7csd…` — 16 events in GlitchTip 7489510 from the deleted-org incident. Two defects in one throw site: the error was **uncaught** (a plain `Error`, redacted to "Server Error" for clients), and it **misdiagnosed** a deleted organization as a membership refusal, which is exactly what sent triage down the permissions path for a month.

Fixes #3021.

## What changed

1. **`RLSError` now extends `ConvexError<{ code, message }>`** (`convex/lib/rls/errors.ts`). The Convex runtime detects application errors via the `Symbol.for('ConvexError')` marker field, which subclasses inherit — so every RLS refusal that escapes a public function now reaches the client as structured `data` with a stable `code`, exactly like `requireOrgMembershipById`'s errors, instead of a redacted "Server Error" plus an uncaught-exception record. `message` is kept as the human sentence (ConvexError would stringify the data into it), so server logs and GlitchTip titles keep reading naturally.
2. **`getOrganizationMember` distinguishes the two failure states** (`convex/lib/rls/organization/get_organization_member.ts`). On an empty member lookup — and only then, so the happy path costs nothing — it re-checks the organization row and throws `UnauthorizedError` with `code: 'ORG_NOT_FOUND'` ("Organization … not found") when the row is gone, vs `code: 'ORG_FORBIDDEN'` ("Not a member of organization …") when the org exists. The disabled-member throw also carries `ORG_FORBIDDEN`, matching `requireOrgMembershipById`. The re-check is guarded by `looksLikeConvexDocumentId` (a sentinel/slug would throw inside the betterAuth component) and its own failure falls back to `ORG_NOT_FOUND` with a warn, mirroring `getCurrentMemberContext`'s catch.

## Why the blast radius is contained

`getOrganizationMember` is referenced across ~88 non-test files, so the design constraint was: don't change what existing catches see.

- All swallow sites catch by `instanceof UnauthorizedError` (approvals ×6, sandbox ×7, members ×3, team_members, tasks, governance/erasure) — the class hierarchy is unchanged, both new codes are still `UnauthorizedError`, so "non-member → return empty/null" behavior is byte-identical, including for deleted orgs (which already took this path).
- `getCurrentMemberContext` (`members/queries.ts`) keeps working unchanged — it catches `UnauthorizedError` and does its own org re-check, so the dashboard's `not_found` bounce is unaffected.
- `http.ts` boundaries catch broadly and map to 403 without echoing the error — unchanged.
- Frontend: `isStructuredConvexError` is a structural `data` check (no `instanceof`), so `useActionQuery` now correctly treats RLS refusals as terminal (no 3×-retry delay); the layout error boundary's transient matcher already deliberately matches the structured `{"code":"UNAUTHENTICATED"}` payload shape (see the #2013 comment in `layout-error-boundary.tsx`) — this PR makes prod behave like that comment always assumed.
- Callers constructing these errors are source-compatible: the `(message, code?)` signatures are supersets of the old ones.

One deliberate information tradeoff: a client can now distinguish "org gone" from "org exists, not yours" — the same distinction `requireOrgMembershipById` (and thus the whole agents/credentials surface) already exposes.

## Tests

`get_organization_member.test.ts` rewritten against the real error classes (it previously mocked the errors module): existing hot-path/mirror/email-fallback cases kept; new cases pin `ORG_FORBIDDEN` (org exists / disabled member, incl. the wire `data` payload), `ORG_NOT_FOUND` (row gone, with the `findOne` call asserted), the shape-guard short-circuit (no component read for a non-id-shaped org id), and the re-check-failure fallback.

Targeted suites over the catch sites: `convex/lib/rls` (84), plus members, team_members, sandbox, governance, tasks error-codes/stats, auth, http_jwks_cache — 584 tests / 50 files, green.

A **full `--project server` sweep** (8,057 tests / 657 files, run twice with identical results) then surfaced the two public-boundary tests that assert the refusal **message** end-to-end: `connector_credentials/queries.test.ts` and `provider_credentials/queries.test.ts` — their fixture org strings never existed as organization rows, so under the new distinction they correctly read "Organization … not found" where they expected `/Not a member/`. Adapted in the second commit: the membership-refusal case now seeds a real betterAuth organization row (the org must exist for "not a member" to be the true state) and keeps asserting `/Not a member/`; the unknown-org flavor is pinned as its own case (`/not found/`). Both credential suites green after: 109 tests / 9 files. The sweep's only other failure is `lib/mocks/contract/openai-compat.test.ts` (Prism-mock embeddings length) — pre-existing, fails identically on untouched `main` in this environment.

## Verifying after deploy

GlitchTip: `RLSError: Not a member of organization jh7csd…` (7489510) stops recurring for the deleted org; new occurrences of the same visit pattern surface as `RLSError: Organization … not found` application errors instead. See the cleanup checklist in #3019.

Related: #3019 (incident), #3020 (browser event grouping), #2018 (same problem class for lifecycle mutations, closed).

Gate: `tsc --noEmit` clean, `oxlint --type-aware` clean, oxfmt, targeted vitest 584 + full server sweep (sole remaining failure pre-exists on `main`).
