### PR TITLE
fix(platform): retire automation triggers of a deleted organization

### DIFF
--- a/services/platform/convex/auth.ts
+++ b/services/platform/convex/auth.ts
@@ -544,6 +544,22 @@ export const getAuthOptions = (ctx: GenericCtx<DataModel>) => {
                   internal.members.mirror_sync.cascadeDeleteOrgMembersMirror,
                   { organizationId: bodyOrgId },
                 );
+                // Same posture for the org's automation triggers: a surviving
+                // schedule row would keep coming due (and crashing its runs)
+                // forever (#3022). Own catch so a failure here isn't logged
+                // under the mirror's label — the schedule scan retires
+                // orphaned rows as the backstop either way.
+                try {
+                  await runCtx.runMutation(
+                    internal.automations.triggers.cascadeDeleteOrgTriggers,
+                    { organizationId: bodyOrgId },
+                  );
+                } catch (err) {
+                  console.warn(
+                    '[automations] trigger cascade after organization delete failed; the schedule scan will retire the rows',
+                    err instanceof Error ? err.message : err,
+                  );
+                }
               }
             } else {
               const returned = isRecord(mw.context.returned)

--- a/services/platform/convex/automations/triggers.test.ts
+++ b/services/platform/convex/automations/triggers.test.ts
@@ -18,7 +18,7 @@ import { convexTest, type TestConvex } from 'convex-test';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Automation } from '../../lib/engine/core/types';
-import { internal } from '../_generated/api';
+import { components, internal } from '../_generated/api';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
 import { cronMatches, dueOccurrence, parseCron } from './cron';
@@ -75,6 +75,28 @@ async function publish(
     const saved = await store.save(automation(name));
     await store.deploy(saved.name, saved.version);
     if (trigger) await store.setTrigger(name, trigger);
+  });
+}
+
+/**
+ * A real betterAuth organization row. The scan retires a due schedule whose
+ * organization no longer resolves (#3022), so a schedule that should FIRE
+ * needs an org that exists — the fixture org names above deliberately do
+ * not. Returns the component-side document id.
+ */
+async function seedOrganization(t: T, slug: string): Promise<string> {
+  return t.run(async (ctx) => {
+    const created = await ctx.runMutation(
+      components.betterAuth.adapter.create,
+      {
+        input: {
+          model: 'organization',
+          data: { name: slug, slug, createdAt: 0 },
+        },
+      },
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter returns the created record as unknown
+    return (created as { _id: string })._id;
   });
 }
 
@@ -185,7 +207,8 @@ describe('schedule triggers', () => {
 
   it('fires a due schedule once and stamps it', async () => {
     const t = newWorld();
-    await publish(t, ORG, 'ops/nightly', {
+    const org = await seedOrganization(t, 'triggers-live');
+    await publish(t, org, 'ops/nightly', {
       kind: 'schedule',
       cron: '* * * * *',
       timezone: 'UTC',
@@ -197,7 +220,7 @@ describe('schedule triggers', () => {
       {},
     );
     expect(first).toEqual({ examined: 1, fired: 1 });
-    expect(await runsOf(t, ORG)).toHaveLength(1);
+    expect(await runsOf(t, org)).toHaveLength(1);
 
     // The same minute does not fire again — `lastFiredAt` is the guard.
     const second = await t.mutation(
@@ -205,21 +228,23 @@ describe('schedule triggers', () => {
       {},
     );
     expect(second.fired).toBe(0);
-    expect(await runsOf(t, ORG)).toHaveLength(1);
+    expect(await runsOf(t, org)).toHaveLength(1);
   });
 
   it('skips disabled schedules and survives one that cannot be parsed', async () => {
     const t = newWorld();
-    await publish(t, ORG, 'ops/broken-cron', {
+    const orgA = await seedOrganization(t, 'triggers-a');
+    const orgB = await seedOrganization(t, 'triggers-b');
+    await publish(t, orgA, 'ops/broken-cron', {
       kind: 'schedule',
       cron: 'not a cron',
     });
-    await publish(t, OTHER_ORG, 'ops/nightly', {
+    await publish(t, orgB, 'ops/nightly', {
       kind: 'schedule',
       cron: '* * * * *',
       timezone: 'UTC',
     });
-    await publish(t, ORG, 'ops/off', {
+    await publish(t, orgA, 'ops/off', {
       kind: 'schedule',
       cron: '* * * * *',
       enabled: false,
@@ -235,8 +260,99 @@ describe('schedule triggers', () => {
     // The unusable expression is skipped; the healthy one in the OTHER org
     // still fires, and each run belongs to its own organization.
     expect(result.fired).toBe(1);
+    expect(await runsOf(t, orgA)).toHaveLength(0);
+    expect(await runsOf(t, orgB)).toHaveLength(1);
+  });
+
+  it('retires a due schedule whose organization is gone (#3022)', async () => {
+    const t = newWorld();
+    // The fixture ORG never existed as a betterAuth organization row — the
+    // exact state a deleted org leaves behind when its triggers survived.
+    await publish(t, ORG, 'ops/orphan', {
+      kind: 'schedule',
+      cron: '* * * * *',
+      timezone: 'UTC',
+    });
+    await backdate(t, 'ops/orphan', 5 * 60 * 1000);
+
+    const first = await t.mutation(
+      internal.automations.triggers.scanScheduledTriggers,
+      {},
+    );
+    // Examined, not fired — and no run row: the trigger is retired instead.
+    expect(first).toEqual({ examined: 1, fired: 0 });
     expect(await runsOf(t, ORG)).toHaveLength(0);
-    expect(await runsOf(t, OTHER_ORG)).toHaveLength(1);
+    const rows = await t.run(
+      async (ctx) => await ctx.db.query('automationTriggers').collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].enabled).toBe(false);
+
+    // Retired means gone from every later scan — nothing to examine, ever.
+    const second = await t.mutation(
+      internal.automations.triggers.scanScheduledTriggers,
+      {},
+    );
+    expect(second).toEqual({ examined: 0, fired: 0 });
+  });
+});
+
+describe('organization delete cascade (#3022)', () => {
+  it('deletes exactly the deleted organization triggers, idempotently', async () => {
+    const t = newWorld();
+    const token = mintWebhookToken();
+    await publish(t, ORG, 'ops/nightly', {
+      kind: 'schedule',
+      cron: '* * * * *',
+      timezone: 'UTC',
+    });
+    await publish(t, ORG, 'ops/inbound', {
+      kind: 'webhook',
+      tokenHash: await hashWebhookToken(token),
+    });
+    await publish(t, OTHER_ORG, 'ops/nightly', {
+      kind: 'schedule',
+      cron: '* * * * *',
+      timezone: 'UTC',
+    });
+
+    const result = await t.mutation(
+      internal.automations.triggers.cascadeDeleteOrgTriggers,
+      { organizationId: ORG },
+    );
+    expect(result).toEqual({ deleted: 2 });
+
+    const rows = await t.run(
+      async (ctx) => await ctx.db.query('automationTriggers').collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organizationId).toBe(OTHER_ORG);
+
+    // A second cascade finds nothing — safe to re-run from the delete hook.
+    await expect(
+      t.mutation(internal.automations.triggers.cascadeDeleteOrgTriggers, {
+        organizationId: ORG,
+      }),
+    ).resolves.toEqual({ deleted: 0 });
+  });
+
+  it('leaves the dead-org webhook token unusable', async () => {
+    const t = newWorld();
+    const token = mintWebhookToken();
+    await publish(t, ORG, 'ops/inbound', {
+      kind: 'webhook',
+      tokenHash: await hashWebhookToken(token),
+    });
+    await t.mutation(internal.automations.triggers.cascadeDeleteOrgTriggers, {
+      organizationId: ORG,
+    });
+
+    const response = await t.fetch(`/api/automations/webhook/${token}`, {
+      method: 'POST',
+      body: '{}',
+    });
+    expect(response.status).toBe(404);
+    expect(await runsOf(t, ORG)).toHaveLength(0);
   });
 });
 

--- a/services/platform/convex/automations/triggers.ts
+++ b/services/platform/convex/automations/triggers.ts
@@ -39,6 +39,7 @@ import {
   internalQuery,
   type MutationCtx,
 } from '../_generated/server';
+import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
 import { dueOccurrence } from './cron';
 import {
   LIVENESS_GRACE_MS,
@@ -111,6 +112,22 @@ export const scanScheduledTriggers = internalMutation({
         continue;
       }
       if (due === null) continue;
+
+      // A trigger can outlive its organization: the org was deleted before
+      // `cascadeDeleteOrgTriggers` existed, or the delete hook failed
+      // mid-flight. Fired anyway, the run would only crash deep in the agent
+      // host's throwing slug resolution — one uncaught error per occurrence,
+      // forever. Retire the trigger the first time it comes due after the org
+      // is gone instead; a transient lookup failure still throws, so the scan
+      // simply retries next tick. (#3022)
+      const orgSlug = await orgSlugFromIdOrNull(ctx, trigger.organizationId);
+      if (orgSlug === null) {
+        await ctx.db.patch(trigger._id, { enabled: false, updatedAt: now });
+        console.warn(
+          `[automations] trigger ${trigger.organizationId}/${trigger.name}: organization no longer resolves; disabling the trigger`,
+        );
+        continue;
+      }
 
       // Stamp BEFORE starting: a run that throws must not leave the schedule
       // re-firing the same minute on every tick.
@@ -376,6 +393,37 @@ export const automationWebhookHandler = httpAction(async (ctx, request) => {
     status: 202,
     headers: { 'Content-Type': 'application/json' },
   });
+});
+
+// --------------------------------------------------------------- lifecycle
+
+/**
+ * Delete every trigger of one organization. Runs from the
+ * `/organization/delete` after-hook (next to the member-mirror cascade), i.e.
+ * only after Better Auth actually deleted the organization row — a failed
+ * deletion keeps the org's schedules and webhook tokens intact. Deleting
+ * rather than disabling matches the platform's hard-delete posture for
+ * org-owned rows (memberMirror, personalization): the rows are unreachable
+ * from any UI once the org is gone, and a merely-disabled row would keep
+ * surfacing the dead org id to every scan. Idempotent; the schedule scan's
+ * retirement above is the backstop for rows this cascade never saw (orgs
+ * deleted before it existed, or a hook that failed mid-flight). (#3022)
+ */
+export const cascadeDeleteOrgTriggers = internalMutation({
+  args: { organizationId: v.string() },
+  returns: v.object({ deleted: v.number() }),
+  handler: async (ctx, args) => {
+    let deleted = 0;
+    for await (const row of ctx.db
+      .query('automationTriggers')
+      .withIndex('by_org', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    return { deleted };
+  },
 });
 
 // -------------------------------------------------------------------- event


### PR DESCRIPTION
Deleting an organization cascades a lot — audit log, personalization hard-delete, the org's config directory, `memberMirror` — but **`automationTriggers` rows were never disabled or deleted**. A surviving `enabled: true` schedule keeps coming due on the minutely scan (`crons.ts` → `scanScheduledTriggers`), and each started run crashes deep in the agent host's throwing slug resolver (`agent_host.ts` `orgSlugFromId`): one uncaught `OrgSlugUnresolvableError` per scheduled occurrence, forever, plus the wasted runs. Unlike the #3019 incident this needs no returning visitor — it self-sustains. The incident's org happened to have no schedule triggers, which is the only reason this gap is still latent.

Fixes #3022.

## What changed

Two layers, so a missed cascade can't error forever:

1. **Delete cascade** (`convex/auth.ts` + `convex/automations/triggers.ts`): the `/organization/delete` after-hook now calls the new `internal.automations.triggers.cascadeDeleteOrgTriggers` right next to `cascadeDeleteOrgMembersMirror` — i.e. only after Better Auth actually deleted the org row, so a failed deletion keeps a live org's schedules and webhook tokens intact. Deleting rather than disabling matches the platform's hard-delete posture for org-owned rows (memberMirror, personalization); the mutation is idempotent and indexed (`by_org`). It has its own catch + warn so a failure is neither mislabeled as a mirror failure nor fatal to the hook.
2. **Scan-side retirement** (`scanScheduledTriggers`): a *due* trigger now resolves its org via `orgSlugFromIdOrNull` (the same graceful pattern the crawler uses in `knowledge/crawl_action.ts`); if the org no longer resolves, the trigger is patched `enabled: false` with a warn and never starts a run. This retires the orphans that pre-date the cascade, and anything a failed hook leaves behind. The lookup runs only for due triggers (not per scan row), so the steady-state cost of the minutely scan is unchanged; a transient lookup failure still throws, and the scan simply retries next tick.

Webhook and event paths need no scan-side guard: their trigger rows die with the cascade, and a deleted row already yields the token-secrecy 404.

## Tests

`convex/automations/triggers.test.ts`:

- new: a due schedule whose org is gone is examined but not fired, its row flips to `enabled: false`, no run row exists, and the next scan examines nothing;
- new: the cascade deletes exactly the deleted org's triggers (schedule + webhook), leaves the other org's intact, and is idempotent;
- new: after the cascade, the dead org's webhook token gets the indistinguishable 404 and starts nothing;
- updated: the two existing scan tests now seed real betterAuth organization rows (`components.betterAuth.adapter.create`, the `arena_action.test.ts` pattern) — required because a schedule that should *fire* now needs an org that resolves; the fixture org names deliberately don't.

Full `convex/automations/` suite: 236 passed (14 files); `convex/auth.test.ts` 7 passed.

## Not in scope (follow-up candidates)

Other org-scoped tables (`automationVersions`, `automationRuns`, `websites`, …) still keep orphan rows after an org deletion — inert without a trigger, but worth an orphan-row policy audit as noted in #3022.

Related: #3019 (the incident this was split from), sibling PRs for #3019/#3020/#3021.

Gate: `tsc --noEmit` clean, `oxlint --type-aware` clean, oxfmt, vitest 243 passed (automations + auth).
