### PR TITLE
feat(platform): let chat list the emailed attachments in scope

### DIFF
--- a/services/platform/app/features/chat/utils/activity-label.test.ts
+++ b/services/platform/app/features/chat/utils/activity-label.test.ts
@@ -82,3 +82,26 @@ describe('ragSearchListingKind', () => {
     expect(ragSearchListingKind('list')).toBeUndefined();
   });
 });
+
+describe('a mail-attachment list has its own label', () => {
+  // Without a key of its own the kind falls back to the generic
+  // "Listing the workspace", which is true but tells the reader nothing about
+  // what the turn actually looked at.
+  it('labels the step from the mail-attachment key', () => {
+    // No casts: the field is `tool`, and letting the types check the step
+    // shape is what catches a mistyped field instead of silently falling
+    // through to another branch.
+    const label = stepActivityLabel(fakeT(), {
+      tool: 'rag_search',
+      input: { action: 'list', kind: 'mail-attachment' },
+    });
+    expect(label).toBe('thinking.listing.mailAttachments');
+    expect(label).not.toContain('""');
+  });
+
+  it('resolves the listing kind from the call', () => {
+    expect(
+      ragSearchListingKind({ action: 'list', kind: 'mail-attachment' }),
+    ).toBe('mail-attachment');
+  });
+});

--- a/services/platform/app/features/chat/utils/activity-label.ts
+++ b/services/platform/app/features/chat/utils/activity-label.ts
@@ -45,6 +45,7 @@ const LISTING_LABEL_KEYS: Record<string, string> = {
   website: 'thinking.listing.websites',
   'knowledge-entry': 'thinking.listing.knowledgeEntries',
   conversation: 'thinking.listing.conversations',
+  'mail-attachment': 'thinking.listing.mailAttachments',
 };
 
 /**

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -365,6 +365,7 @@ const LISTABLE_KINDS = RAG_SEARCH_KINDS.filter((kind) => kind !== 'web-page');
  * search legs use, so a list result reads like a one-leg search result. */
 const LIST_SOURCE_KEYS: Record<RagSearchKind, string> = {
   document: 'documents',
+  'mail-attachment': 'mailAttachments',
   'web-page': 'webPages',
   'knowledge-entry': 'knowledgeEntries',
   contact: 'contacts',
@@ -379,6 +380,9 @@ const LIST_SOURCE_KEYS: Record<RagSearchKind, string> = {
  * subject its search leg checks, because a list is not an ACL widening. */
 const LIST_READ_SUBJECTS: Record<RagSearchKind, AgentReadSubject> = {
   document: 'documents',
+  // Conversations, not documents: an emailed attachment is visible exactly when
+  // its conversation is, so the role that gates the inbox gates its files.
+  'mail-attachment': 'conversations',
   'web-page': 'websites',
   'knowledge-entry': 'documents',
   contact: 'contacts',
@@ -1450,6 +1454,63 @@ export function createChatToolExecutor(
               note:
                 'Recent conversations only — this list does not page. ' +
                 'Narrow by asking about a person, a topic, or a timeframe.',
+            }
+          : {}),
+      });
+    }
+
+    if (kind === 'mail-attachment') {
+      // Emailed attachments have no other listing surface: they are not
+      // Document Hub rows, so they are absent from the Documents page and from
+      // `kind="document"`. Scope is each attachment's conversation as it stands
+      // now, decided by the same predicate and the same resolver the retrieval
+      // gate uses.
+      //
+      // Overfetch by one so a full page never claims completeness — the
+      // reader's own `truncated` only reports a scan-budget stop.
+      const found = await ctx.runQuery(
+        internal.file_metadata.internal_queries.listMailAttachmentsForChat,
+        {
+          organizationId: who.organizationId,
+          userId: who.userId,
+          limit: limit + 1,
+        },
+      );
+      const overfetched = found.attachments.length > limit;
+      const rows = overfetched
+        ? found.attachments.slice(0, limit)
+        : found.attachments;
+      const hasMore = overfetched || found.truncated;
+      const results = rows.map(
+        (attachment): SearchResultEntry => ({
+          kind: 'mail-attachment',
+          title: attachment.fileName,
+          // The corpus ref, so a listed attachment can be read with rag_fetch
+          // instead of searched for by name.
+          ref: attachment.ref,
+          data: {
+            conversationId: attachment.conversationId,
+            contentType: attachment.contentType,
+            sizeBytes: attachment.size,
+            receivedAt: attachment.receivedAt,
+            // A received-but-unindexed attachment cannot be fetched for its
+            // text. Saying so beats implying it is readable.
+            indexed: attachment.indexed,
+          },
+        }),
+      );
+      return envelope({
+        results,
+        hasMore,
+        source: hasMore
+          ? 'listed (most recent only — narrowing, not paging)'
+          : 'listed',
+        ...(hasMore
+          ? {
+              note:
+                'Most recent email attachments only, and this list does not ' +
+                'page. Narrow by asking about a conversation, a correspondent, ' +
+                'or a filename.',
             }
           : {}),
       });

--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
@@ -3,10 +3,8 @@ import {
   type KnowledgeAccessScope,
 } from '../../lib/knowledge/types';
 import type { QueryCtx } from '../_generated/server';
-import { getUserTeamIds } from '../lib/get_user_teams';
-import { resolveAgentReadAccess } from '../lib/rls/helpers/agent_read_access';
 import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
-import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import { conversationCallerResolver } from '../lib/rls/helpers/conversation_caller';
 import type { BlobRef } from '../lib/storage/blob_ref';
 import { isActiveDocument } from './_helpers';
 
@@ -45,48 +43,13 @@ export async function filterRetrievableRagFileIds(
   const seen = new Set<string>();
   const allowedThreadIds = new Set(args.access?.threadIds ?? []);
 
-  /**
-   * Role and teams for the assignment decision, resolved once and only when a
-   * conversation-scoped row is actually hit.
-   *
-   * Resolved HERE from the caller's identity rather than accepted as arguments:
-   * an `isAdmin` flag travelling in is one refactor away from being wrong in the
-   * direction that publishes an inbox. `null` means the caller is not a member,
-   * or their role denies conversations.
-   */
-  let callerPromise:
-    | Promise<{
-        isAdmin: boolean;
-        userId: string;
-        teamIds: ReadonlySet<string>;
-      } | null>
-    | undefined;
-  const conversationCaller = (): Promise<{
-    isAdmin: boolean;
-    userId: string;
-    teamIds: ReadonlySet<string>;
-  } | null> => {
-    callerPromise ??= (async () => {
-      const userId = args.userId;
-      // Fail closed on a surface that did not say who is asking: an inbox
-      // attachment is never served to an unidentified caller. This is the ONE
-      // place that decision is made — a second early guard beside the call site
-      // read as belt-and-braces but no test could tell it from dead code.
-      if (userId === undefined) return null;
-      const access = await resolveAgentReadAccess(ctx, {
-        organizationId: args.organizationId,
-        userId,
-        subject: 'conversations',
-      });
-      if (!access.allowed) return null;
-      return {
-        isAdmin: isAdmin(access.role),
-        userId,
-        teamIds: new Set(await getUserTeamIds(ctx, userId)),
-      };
-    })();
-    return callerPromise;
-  };
+  // Resolved once, only when a conversation-scoped row is actually hit, and
+  // by the SAME helper any listing surface uses — see
+  // `conversation_caller.ts` for why the role is never an argument.
+  const conversationCaller = conversationCallerResolver(ctx, {
+    organizationId: args.organizationId,
+    ...(args.userId !== undefined ? { userId: args.userId } : {}),
+  });
 
   for (const fileId of args.fileIds) {
     const ref = String(fileId);

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -4,6 +4,7 @@ import { components } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
 import { internalQuery } from '../_generated/server';
 import { blobRefValidator } from '../lib/storage/blob_ref';
+import { listMailAttachments } from './list_mail_attachments';
 
 export const getById = internalQuery({
   args: { fileMetadataId: v.id('fileMetadata') },
@@ -32,6 +33,38 @@ export const getByStorageId = internalQuery({
  * from parked, a later slice of a large file) picks up whatever the binding is
  * now. Org-scoped, because a blob ref is caller-supplied on some paths.
  */
+/**
+ * The emailed attachments a caller may read. See `list_mail_attachments.ts` for
+ * why scope is the conversation's live assignment and why both bounds are
+ * reported.
+ */
+export const listMailAttachmentsForChat = internalQuery({
+  args: {
+    organizationId: v.string(),
+    /** The turn user. Absent denies everything — an inbox attachment is never
+     *  listed for an unidentified caller. */
+    userId: v.optional(v.string()),
+    limit: v.number(),
+  },
+  returns: v.object({
+    attachments: v.array(
+      v.object({
+        ref: v.string(),
+        fileName: v.string(),
+        contentType: v.string(),
+        size: v.number(),
+        conversationId: v.string(),
+        receivedAt: v.number(),
+        indexed: v.boolean(),
+      }),
+    ),
+    truncated: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    return await listMailAttachments(ctx, args);
+  },
+});
+
 export const getConversationBindingForBlob = internalQuery({
   args: {
     organizationId: v.string(),

--- a/services/platform/convex/file_metadata/list_mail_attachments.test.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.test.ts
@@ -1,0 +1,313 @@
+// Driven through convex-test against the real schema and indexes, because what
+// matters here is not the shape of the rows but who is allowed to see them.
+// An emailed attachment is visible exactly when its conversation is, and this
+// listing is a WIDER door than search — search needs the caller to guess words
+// that appear in the file, a listing hands over the catalogue.
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+import { listMailAttachments } from './list_mail_attachments';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'file_metadata';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_mail_list';
+const TEAM = 'team_inbox';
+const OTHER_TEAM = 'team_other';
+type T = TestConvex<typeof schema>;
+
+async function seedMember(
+  t: T,
+  userId: string,
+  role: string,
+  teamIds: string[] = [],
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      memberId: `m_${userId}`,
+      userId,
+      organizationId: ORG,
+      role,
+      createdAt: 0,
+    });
+    for (const teamId of teamIds) {
+      await ctx.db.insert('teamMemberMirror', {
+        teamMemberId: `tm_${userId}_${teamId}`,
+        userId,
+        teamId,
+      });
+    }
+  });
+}
+
+async function seedConversation(
+  t: T,
+  fields: Record<string, unknown> = {},
+): Promise<string> {
+  return await t.run(async (ctx) =>
+    ctx.db.insert('conversations', {
+      organizationId: ORG,
+      subject: 'Application',
+      status: 'open',
+      channel: 'email',
+      ...fields,
+    }),
+  );
+}
+
+async function seedAttachment(
+  t: T,
+  args: {
+    storageId: string;
+    conversationId?: string;
+    fileName?: string;
+    ragStatus?: string;
+    lifecycleStatus?: string;
+  },
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('fileMetadata', {
+      organizationId: ORG,
+      storageId: args.storageId,
+      fileName: args.fileName ?? 'cv.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+      source: 'imap-smtp',
+      ...(args.conversationId !== undefined
+        ? { conversationId: args.conversationId as never }
+        : {}),
+      ...(args.ragStatus !== undefined
+        ? { ragStatus: args.ragStatus as never }
+        : {}),
+      ...(args.lifecycleStatus !== undefined
+        ? { lifecycleStatus: args.lifecycleStatus as never }
+        : {}),
+    });
+  });
+}
+
+function list(t: T, userId: string | undefined, limit = 20) {
+  return t.query(
+    internal.file_metadata.internal_queries.listMailAttachmentsForChat,
+    { organizationId: ORG, limit, ...(userId !== undefined ? { userId } : {}) },
+  );
+}
+
+describe('listMailAttachments — who may see what', () => {
+  it('shows an admin every attachment, including unassigned mail', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const unassigned = await seedConversation(t);
+    const otherTeam = await seedConversation(t, { assigneeTeamId: OTHER_TEAM });
+    await seedAttachment(t, { storageId: 'b1', conversationId: unassigned });
+    await seedAttachment(t, { storageId: 'b2', conversationId: otherTeam });
+
+    const result = await list(t, 'admin_1');
+    expect(result.attachments.map((a) => a.ref).sort()).toEqual(['b1', 'b2']);
+  });
+
+  it("shows a member only their team's mail", async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'member_1', 'member', [TEAM]);
+    const mine = await seedConversation(t, { assigneeTeamId: TEAM });
+    const theirs = await seedConversation(t, { assigneeTeamId: OTHER_TEAM });
+    const unassigned = await seedConversation(t);
+    await seedAttachment(t, { storageId: 'mine', conversationId: mine });
+    await seedAttachment(t, { storageId: 'theirs', conversationId: theirs });
+    await seedAttachment(t, {
+      storageId: 'triage',
+      conversationId: unassigned,
+    });
+
+    const result = await list(t, 'member_1');
+    // Unassigned mail is admin-triage state, not org-readable.
+    expect(result.attachments.map((a) => a.ref)).toEqual(['mine']);
+  });
+
+  it('shows the individual assignee their own mail', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'member_2', 'member');
+    const mine = await seedConversation(t, { assigneeUserId: 'member_2' });
+    await seedAttachment(t, { storageId: 'assigned', conversationId: mine });
+
+    const result = await list(t, 'member_2');
+    expect(result.attachments.map((a) => a.ref)).toEqual(['assigned']);
+  });
+
+  it('shows nothing to a caller who did not say who they are', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, { storageId: 'b1', conversationId: conv });
+
+    expect((await list(t, undefined)).attachments).toEqual([]);
+  });
+
+  it('shows nothing to a role that cannot read mail', async () => {
+    // The non-MEMBER case is not testable here: a caller absent from
+    // `memberMirror` falls through to the Better Auth component, which
+    // convex-test cannot register. It is covered where the shared resolver is
+    // driven directly, in
+    // `documents/filter_retrievable_rag_file_ids.conversation_scope.test.ts` —
+    // and since both surfaces now call `conversationCallerResolver`, that one
+    // test covers this listing too.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'disabled_1', 'disabled', [TEAM]);
+    const conv = await seedConversation(t, { assigneeTeamId: TEAM });
+    await seedAttachment(t, { storageId: 'b1', conversationId: conv });
+
+    expect((await list(t, 'disabled_1')).attachments).toEqual([]);
+  });
+});
+
+describe('listMailAttachments — what is listed', () => {
+  it('lists only attachments bound to a conversation', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, { storageId: 'bound', conversationId: conv });
+    // A Document Hub upload and an unbound mail attachment are both out.
+    await seedAttachment(t, { storageId: 'unbound' });
+
+    const result = await list(t, 'admin_1');
+    expect(result.attachments.map((a) => a.ref)).toEqual(['bound']);
+  });
+
+  it('excludes a trashed attachment', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, { storageId: 'live', conversationId: conv });
+    await seedAttachment(t, {
+      storageId: 'gone',
+      conversationId: conv,
+      lifecycleStatus: 'trashed',
+    });
+
+    const result = await list(t, 'admin_1');
+    expect(result.attachments.map((a) => a.ref)).toEqual(['live']);
+  });
+
+  it('reports whether each attachment is actually indexed', async () => {
+    // Received but unindexed is a real state. Listing it as if it were
+    // searchable would set the model up to fetch text that is not there.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, {
+      storageId: 'done',
+      conversationId: conv,
+      ragStatus: 'completed',
+    });
+    await seedAttachment(t, { storageId: 'pending', conversationId: conv });
+
+    const byRef = new Map(
+      (await list(t, 'admin_1')).attachments.map((a) => [a.ref, a.indexed]),
+    );
+    expect(byRef.get('done')).toBe(true);
+    expect(byRef.get('pending')).toBe(false);
+  });
+
+  it('keeps the newest when the limit bites, not the oldest', async () => {
+    // The bound decides the answer, so which end it keeps is the feature.
+    // Oldest-first would answer "what has come in?" with the stalest mail.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    for (let index = 0; index < 6; index += 1) {
+      await seedAttachment(t, {
+        storageId: `b${index}`,
+        conversationId: conv,
+        fileName: `f${index}.pdf`,
+      });
+    }
+
+    const result = await list(t, 'admin_1', 2);
+    expect(result.attachments.map((a) => a.ref)).toEqual(['b5', 'b4']);
+  });
+
+  it("never lists an attachment pointing at another organization's conversation", async () => {
+    // A conversation id on a row is a reference, not a permission. Following it
+    // across a tenant boundary would list one org's mail in another's.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const foreign = await t.run(async (ctx) =>
+      ctx.db.insert('conversations', {
+        organizationId: 'org_somewhere_else',
+        subject: 'Theirs',
+        status: 'open',
+        channel: 'email',
+      }),
+    );
+    await seedAttachment(t, {
+      storageId: 'b_foreign',
+      conversationId: foreign,
+    });
+
+    expect((await list(t, 'admin_1')).attachments).toEqual([]);
+  });
+
+  it('stops at its scan budget and says the listing is partial', async () => {
+    // The walk filters as it goes, so a caller who can read little rejects most
+    // of what it touches. Without a bound on rows EXAMINED one question would
+    // read the whole table.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    for (let index = 0; index < 4; index += 1) {
+      await seedAttachment(t, { storageId: `s${index}`, conversationId: conv });
+    }
+
+    const stopped = await t.run(async (ctx) =>
+      listMailAttachments(ctx, {
+        organizationId: ORG,
+        userId: 'admin_1',
+        limit: 20,
+        scanCap: 2,
+      }),
+    );
+    expect(stopped.truncated).toBe(true);
+    expect(stopped.attachments).toHaveLength(2);
+
+    const complete = await t.run(async (ctx) =>
+      listMailAttachments(ctx, {
+        organizationId: ORG,
+        userId: 'admin_1',
+        limit: 20,
+      }),
+    );
+    expect(complete.truncated).toBe(false);
+    expect(complete.attachments).toHaveLength(4);
+  });
+
+  it('carries the corpus ref so a listed row can be fetched', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, {
+      storageId: 'blob_ref',
+      conversationId: conv,
+      ragStatus: 'completed',
+    });
+
+    const [row] = (await list(t, 'admin_1')).attachments;
+    expect(row?.ref).toBe('blob_ref');
+    expect(row?.conversationId).toBe(conv);
+  });
+});

--- a/services/platform/convex/file_metadata/list_mail_attachments.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.ts
@@ -1,0 +1,141 @@
+/**
+ * The emailed attachments a caller may read — a catalogue, with the words off.
+ *
+ * An emailed attachment has no listing surface anywhere in the product. It is
+ * not a Document Hub row, so it is absent from the Documents page and from
+ * `list kind="document"`, and its only appearance is on its own conversation in
+ * the Inbox. Retrieval was therefore the sole way to discover one, which means
+ * guessing words that appear inside it — and a CV named for its author contains
+ * none of the words describing the role it was sent for.
+ *
+ * ## Scope is the conversation's LIVE assignment
+ *
+ * Decided per row by `conversationAssignmentAllows` against the conversation as
+ * it stands now, using the caller resolved by `conversationCallerResolver` —
+ * the same predicate and the same resolver the retrieval gate uses. That is
+ * deliberate: a listing that derived its own notion of visibility would be one
+ * refactor away from being wider than the search beside it, and the failure
+ * mode is publishing an inbox.
+ *
+ * Because assignment is read live, reassigning a conversation moves its
+ * attachments in this listing too, with nothing rewritten.
+ *
+ * ## Two bounds, both reported
+ *
+ * `limit` bounds what is KEPT. `SCAN_CAP` bounds what is EXAMINED, which is the
+ * one that matters: the walk filters as it goes, so a caller who can read few
+ * conversations rejects most of what it touches. Without the second bound one
+ * question would read the organization's whole `fileMetadata` table.
+ *
+ * The walk is newest-first. The bound decides the answer, so which end it keeps
+ * is the feature: oldest-first would answer "what has come in?" with the
+ * stalest mail on the box.
+ */
+
+import type { Doc } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
+import { conversationCallerResolver } from '../lib/rls/helpers/conversation_caller';
+
+/** Rows examined before the walk stops, regardless of how many were kept. */
+const SCAN_CAP = 600;
+
+/** One attachment, as a catalogue row rather than a retrieval hit. */
+export interface MailAttachmentListing {
+  /** The corpus ref, so a listed row can be fetched without another search. */
+  readonly ref: string;
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly conversationId: string;
+  readonly receivedAt: number;
+  /** Whether its text is in the corpus. A received-but-unindexed attachment is
+   *  a real state, and saying so beats implying it is searchable. */
+  readonly indexed: boolean;
+}
+
+export interface MailAttachmentListingResult {
+  readonly attachments: MailAttachmentListing[];
+  /** The scan budget stopped the walk, so the listing is a page and not the
+   *  whole set. Distinct from a full page, which the caller detects itself. */
+  readonly truncated: boolean;
+}
+
+export async function listMailAttachments(
+  ctx: QueryCtx,
+  args: {
+    organizationId: string;
+    userId?: string | undefined;
+    limit: number;
+    /** Rows examined before the walk stops. Defaults to {@link SCAN_CAP}; the
+     *  internal query never overrides it. Present so a test can prove the bound
+     *  exists without seeding six hundred rows. */
+    scanCap?: number;
+  },
+): Promise<MailAttachmentListingResult> {
+  const caller = conversationCallerResolver(ctx, {
+    organizationId: args.organizationId,
+    ...(args.userId !== undefined ? { userId: args.userId } : {}),
+  });
+
+  // Many attachments share one conversation, so the assignment decision is
+  // cached per conversation rather than per row.
+  const decided = new Map<string, boolean>();
+  const mayRead = async (
+    conversationId: Doc<'fileMetadata'>['conversationId'],
+  ): Promise<boolean> => {
+    if (conversationId === undefined) return false;
+    const key = String(conversationId);
+    const cached = decided.get(key);
+    if (cached !== undefined) return cached;
+    const identity = await caller();
+    if (identity === null) {
+      decided.set(key, false);
+      return false;
+    }
+    const conversation = await ctx.db.get(conversationId);
+    const allowed =
+      conversation !== null &&
+      conversation.organizationId === args.organizationId &&
+      (await conversationAssignmentAllows(conversation, {
+        isAdmin: identity.isAdmin,
+        userId: identity.userId,
+        hasTeam: (teamId) => identity.teamIds.has(teamId),
+      }));
+    decided.set(key, allowed);
+    return allowed;
+  };
+
+  const attachments: MailAttachmentListing[] = [];
+  let scanned = 0;
+  let truncated = false;
+  for await (const row of ctx.db
+    .query('fileMetadata')
+    .withIndex('by_organizationId', (q) =>
+      q.eq('organizationId', args.organizationId),
+    )
+    .order('desc')) {
+    scanned += 1;
+    if (scanned > (args.scanCap ?? SCAN_CAP)) {
+      truncated = true;
+      break;
+    }
+    if (row.lifecycleStatus === 'trashed') continue;
+    // `mayRead` rejects an unbound row itself, so there is no separate guard
+    // here: a second one read as belt-and-braces but no test could tell it from
+    // dead code.
+    if (!(await mayRead(row.conversationId))) continue;
+    attachments.push({
+      ref: String(row.storageId),
+      fileName: row.fileName,
+      contentType: row.contentType,
+      size: row.size,
+      conversationId: String(row.conversationId),
+      receivedAt: row._creationTime,
+      indexed: row.ragStatus === 'completed',
+    });
+    if (attachments.length >= args.limit) break;
+  }
+
+  return { attachments, truncated };
+}

--- a/services/platform/convex/lib/rls/helpers/conversation_caller.ts
+++ b/services/platform/convex/lib/rls/helpers/conversation_caller.ts
@@ -1,0 +1,70 @@
+/**
+ * Who is asking, for a decision that depends on conversation assignment.
+ *
+ * Extracted so the retrieval gate and any listing surface resolve the caller
+ * the SAME way. Assignment privacy is the narrowest rule the platform has, and
+ * a listing that resolved its own notion of "admin" would be one refactor away
+ * from being wider than the search it sits beside — the failure mode there is
+ * publishing an inbox.
+ *
+ * ## Resolved here, never accepted as an argument
+ *
+ * The role comes from `resolveAgentReadAccess`, not from a caller-supplied
+ * flag. An `isAdmin` boolean travelling in through several frames is exactly
+ * how a gate ends up trusting the wrong value.
+ *
+ * ## Lazy by construction
+ *
+ * Both lookups cost a cross-component Better Auth round-trip, so nothing is
+ * resolved until a caller actually asks. Memoise the returned promise per
+ * request — {@link conversationCallerResolver} does that for you — so a page of
+ * rows pays for one resolution rather than one per row.
+ */
+
+import type { QueryCtx } from '../../../_generated/server';
+import { getUserTeamIds } from '../../get_user_teams';
+import { resolveAgentReadAccess } from './agent_read_access';
+import { isAdmin } from './role_helpers';
+
+/** The caller, as an assignment decision needs them. */
+export interface ConversationCallerIdentity {
+  readonly isAdmin: boolean;
+  readonly userId: string;
+  readonly teamIds: ReadonlySet<string>;
+}
+
+/**
+ * A memoised resolver for one request.
+ *
+ * Returns `null` when the caller cannot be decided — no identity supplied, not
+ * a member, or a role that denies conversations. Every `null` is a denial, so a
+ * surface that forgets to say who is asking serves nothing rather than
+ * everything.
+ */
+export function conversationCallerResolver(
+  ctx: QueryCtx,
+  args: { organizationId: string; userId?: string | undefined },
+): () => Promise<ConversationCallerIdentity | null> {
+  let pending: Promise<ConversationCallerIdentity | null> | undefined;
+  return () => {
+    pending ??= (async () => {
+      const userId = args.userId;
+      // Fail closed on a surface that did not say who is asking. This is the
+      // ONE place that decision is made; a second guard at a call site reads as
+      // belt-and-braces but no test can tell it from dead code.
+      if (userId === undefined) return null;
+      const access = await resolveAgentReadAccess(ctx, {
+        organizationId: args.organizationId,
+        userId,
+        subject: 'conversations',
+      });
+      if (!access.allowed) return null;
+      return {
+        isAdmin: isAdmin(access.role),
+        userId,
+        teamIds: new Set(await getUserTeamIds(ctx, userId)),
+      };
+    })();
+    return pending;
+  };
+}

--- a/services/platform/lib/chat/tools.ts
+++ b/services/platform/lib/chat/tools.ts
@@ -162,12 +162,13 @@ export const RAG_SEARCH_DEFAULT_LIMIT = 8;
 export const RAG_SEARCH_ACTIONS = ['search', 'list'] as const;
 export type RagSearchAction = (typeof RAG_SEARCH_ACTIONS)[number];
 
-/** The nine result kinds `rag_search` returns — and the browse targets the
+/** The ten result kinds `rag_search` returns — and the browse targets the
  * `list` action accepts (all but `web-page`, which has no bounded catalog;
  * the executor refuses it with a steer). Singular, because one list call
  * browses ONE backend — this is not a type-tag array over a shared index. */
 export const RAG_SEARCH_KINDS = [
   'document',
+  'mail-attachment',
   'web-page',
   'knowledge-entry',
   'product',

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1412,6 +1412,7 @@ chat:
       websites: Listet Websites auf
       knowledgeEntries: Listet Wissenseinträge auf
       conversations: Listet Konversationen auf
+      mailAttachments: Listet E-Mail-Anhänge auf
     seconds: '{seconds}s'
     summaryReasoningOnly: Hat den Gedankengang gezeigt
   sources:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1369,6 +1369,7 @@ chat:
       websites: Listing websites
       knowledgeEntries: Listing knowledge entries
       conversations: Listing conversations
+      mailAttachments: Listing email attachments
     seconds: '{seconds}s'
     summaryReasoningOnly: Showed its reasoning
   sources:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1420,6 +1420,7 @@ chat:
       websites: Liste des sites web
       knowledgeEntries: Liste des entrées de connaissances
       conversations: Liste des conversations
+      mailAttachments: Liste des pièces jointes
     seconds: '{seconds}s'
     summaryReasoningOnly: A montré son raisonnement
   sources:


### PR DESCRIPTION
Chat can now list the emailed attachments a caller may read. Closes the remaining half of #3016.

## Why

An emailed attachment had no listing surface anywhere in the product. It is not a Document Hub row, so it is absent from the Documents page and from `list kind="document"` — `list_documents_for_agent.ts` walks the `documents` table, and a mail attachment has only a `fileMetadata` row plus a corpus row. Its sole appearance was on its own conversation in the Inbox.

So retrieval was the only way to discover one, which means guessing words inside a file whose name says nothing about why it was sent. #3029 gave the Document Hub a `list` action; this gives mail attachments one.

## What changed

- `rag_search` gains a tenth kind, `mail-attachment`, listable through `action: "list"`.
- Rows carry the corpus `ref`, so a listed attachment can be read with `rag_fetch` rather than searched for by name.
- Rows carry `indexed`. Received-but-unindexed is a real state, and implying it is readable sets the model up to fetch text that is not there.
- The caller resolution behind the retrieval gate moved into `conversation_caller.ts`, and both the gate and this listing call it.
- Timeline label `thinking.listing.mailAttachments` in `en`, `de` and `fr`. `de-CH` overrides nothing in that block.

## Risk

**Scope is shared, not copied.** Each row is decided by `conversationAssignmentAllows` against the conversation as it stands now, through the same resolver the gate uses. A listing is a wider door than a search — search needs the caller to guess words in the file, a listing hands over the catalogue — so one deriving its own notion of visibility would drift wider than the search beside it. The read subject is `conversations`, not `documents`, because an attachment is visible exactly when its conversation is.

Because assignment is read live, reassigning a conversation moves its attachments in this listing too, with nothing rewritten.

**Two bounds, both reported.** `limit` bounds what is kept; the scan cap bounds what is examined. The second is the one that matters: the walk filters as it goes, so a caller who can read few conversations rejects most of what it touches, and an unbounded walk would read the whole table. Newest-first, because the bound decides the answer.

This kind narrows rather than pages, matching the choice #3029 made for conversations and websites.

## Tests

Twelve at the reader, through convex-test against the real schema: admin sees unassigned and other-team mail, a member sees only their team's, an individual assignee sees theirs, a disabled role sees nothing, an unidentified caller sees nothing, unbound and trashed rows are excluded, the `indexed` flag is real, the newest survive the limit, the corpus ref is carried, a cross-org conversation reference lists nothing, and the scan budget stops the walk and says so.

The non-member case is not testable here — a caller absent from `memberMirror` falls through to the Better Auth component, which convex-test cannot register. It is covered where the shared resolver is driven directly, and since both surfaces now use that resolver, that one test covers this listing too.

Ten mutations, all red. Three survived first: a cross-org conversation reference was unasserted, the scan bound was unasserted, and an unbound-row guard was redundant with the check inside the allow helper, so no test could tell it from dead code — removed rather than kept.

## Scope

Does not page. Does not index message bodies (#3015). Does not give attachments a Documents-page surface — this is the chat tool only.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, platform server+pii 75,399 tests, client 3,316 tests.
