### PR TITLE
feat(platform): list emailed attachments by arrival, affordably

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -668,6 +668,7 @@ import type * as migrations_versions_v0_4_1_01_automation_pins_to_bindings_migra
 import type * as migrations_versions_v0_4_1_02_task_labels_to_catalog_migration from "../migrations/versions/v0_4_1/02_task_labels_to_catalog/migration.js";
 import type * as migrations_versions_v0_4_1_03_backfill_project_rollup_counts_migration from "../migrations/versions/v0_4_1/03_backfill_project_rollup_counts/migration.js";
 import type * as migrations_versions_v0_4_1_04_backfill_corpus_document_scope_migration from "../migrations/versions/v0_4_1/04_backfill_corpus_document_scope/migration.js";
+import type * as migrations_versions_v0_4_1_05_backfill_mail_attachment_received_at_migration from "../migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.js";
 import type * as node_only_documents_internal_actions from "../node_only/documents/internal_actions.js";
 import type * as node_only_knowledge_search_action from "../node_only/knowledge/search_action.js";
 import type * as node_only_sandbox_browser_view from "../node_only/sandbox/browser_view.js";
@@ -1636,6 +1637,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/versions/v0_4_1/02_task_labels_to_catalog/migration": typeof migrations_versions_v0_4_1_02_task_labels_to_catalog_migration;
   "migrations/versions/v0_4_1/03_backfill_project_rollup_counts/migration": typeof migrations_versions_v0_4_1_03_backfill_project_rollup_counts_migration;
   "migrations/versions/v0_4_1/04_backfill_corpus_document_scope/migration": typeof migrations_versions_v0_4_1_04_backfill_corpus_document_scope_migration;
+  "migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration": typeof migrations_versions_v0_4_1_05_backfill_mail_attachment_received_at_migration;
   "node_only/documents/internal_actions": typeof node_only_documents_internal_actions;
   "node_only/knowledge/search_action": typeof node_only_knowledge_search_action;
   "node_only/sandbox/browser_view": typeof node_only_sandbox_browser_view;

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -393,6 +393,11 @@ const LIST_READ_SUBJECTS: Record<RagSearchKind, AgentReadSubject> = {
   conversation: 'conversations',
 };
 
+/** How many conversations a mail-attachment listing reaches over. Bounds the
+ *  reads: one row read and one exact index lookup per conversation, regardless
+ *  of how many attachments the organization holds. */
+const MAIL_ATTACHMENT_CONVERSATION_REACH = 50;
+
 const LIST_PAGE_MESSAGE =
   'This is one page, not the whole set. Pass "continueCursor" back as ' +
   '"cursor" for the next page, or say you only saw this page.';
@@ -1468,19 +1473,32 @@ export function createChatToolExecutor(
       //
       // Overfetch by one so a full page never claims completeness — the
       // reader's own `truncated` only reports a scan-budget stop.
+      // Conversations lead, so the reads scale with the inbox reached rather
+      // than with every attachment the organization has ever received. The
+      // reader re-checks each conversation, so this list is a starting point
+      // and not an authorization.
+      const inbox = await ctx.runQuery(
+        internal.conversations.search_for_chat.searchConversationsForChat,
+        {
+          organizationId: who.organizationId,
+          userId: who.userId,
+          term: '',
+          list: true,
+          limit: MAIL_ATTACHMENT_CONVERSATION_REACH,
+        },
+      );
       const found = await ctx.runQuery(
         internal.file_metadata.internal_queries.listMailAttachmentsForChat,
         {
           organizationId: who.organizationId,
           userId: who.userId,
-          limit: limit + 1,
+          conversationIds: inbox.conversations.map((c) => String(c._id)),
+          limit,
         },
       );
-      const overfetched = found.attachments.length > limit;
-      const rows = overfetched
-        ? found.attachments.slice(0, limit)
-        : found.attachments;
-      const hasMore = overfetched || found.truncated;
+      const rows = found.attachments;
+      // Either the attachments were cut, or the inbox reach was.
+      const hasMore = found.truncated || inbox.truncated;
       const results = rows.map(
         (attachment): SearchResultEntry => ({
           kind: 'mail-attachment',
@@ -1508,9 +1526,10 @@ export function createChatToolExecutor(
         ...(hasMore
           ? {
               note:
-                'Most recent email attachments only, and this list does not ' +
-                'page. Narrow by asking about a conversation, a correspondent, ' +
-                'or a filename.',
+                `Attachments from the ${MAIL_ATTACHMENT_CONVERSATION_REACH} ` +
+                'most recently active conversations you can read, and this ' +
+                'list does not page. Ask about a conversation, a ' +
+                'correspondent, or a filename to reach older mail.',
             }
           : {}),
       });

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -393,11 +393,6 @@ const LIST_READ_SUBJECTS: Record<RagSearchKind, AgentReadSubject> = {
   conversation: 'conversations',
 };
 
-/** How many conversations a mail-attachment listing reaches over. Bounds the
- *  reads: one row read and one exact index lookup per conversation, regardless
- *  of how many attachments the organization holds. */
-const MAIL_ATTACHMENT_CONVERSATION_REACH = 50;
-
 const LIST_PAGE_MESSAGE =
   'This is one page, not the whole set. Pass "continueCursor" back as ' +
   '"cursor" for the next page, or say you only saw this page.';
@@ -1473,32 +1468,16 @@ export function createChatToolExecutor(
       //
       // Overfetch by one so a full page never claims completeness — the
       // reader's own `truncated` only reports a scan-budget stop.
-      // Conversations lead, so the reads scale with the inbox reached rather
-      // than with every attachment the organization has ever received. The
-      // reader re-checks each conversation, so this list is a starting point
-      // and not an authorization.
-      const inbox = await ctx.runQuery(
-        internal.conversations.search_for_chat.searchConversationsForChat,
-        {
-          organizationId: who.organizationId,
-          userId: who.userId,
-          term: '',
-          list: true,
-          limit: MAIL_ATTACHMENT_CONVERSATION_REACH,
-        },
-      );
       const found = await ctx.runQuery(
         internal.file_metadata.internal_queries.listMailAttachmentsForChat,
         {
           organizationId: who.organizationId,
           userId: who.userId,
-          conversationIds: inbox.conversations.map((c) => String(c._id)),
           limit,
         },
       );
       const rows = found.attachments;
-      // Either the attachments were cut, or the inbox reach was.
-      const hasMore = found.truncated || inbox.truncated;
+      const hasMore = found.truncated;
       const results = rows.map(
         (attachment): SearchResultEntry => ({
           kind: 'mail-attachment',
@@ -1526,9 +1505,8 @@ export function createChatToolExecutor(
         ...(hasMore
           ? {
               note:
-                `Attachments from the ${MAIL_ATTACHMENT_CONVERSATION_REACH} ` +
-                'most recently active conversations you can read, and this ' +
-                'list does not page. Ask about a conversation, a ' +
+                'The most recently received attachments you can read, and ' +
+                'this list does not page. Ask about a conversation, a ' +
                 'correspondent, or a filename to reach older mail.',
             }
           : {}),

--- a/services/platform/convex/conversations/ingest/bind_email_attachments.ts
+++ b/services/platform/convex/conversations/ingest/bind_email_attachments.ts
@@ -77,6 +77,11 @@ export async function bindEmailAttachments(
 ): Promise<BindEmailAttachmentsResult> {
   const result = { bound: 0, queued: 0, failed: 0 };
   for (const { email, conversationId } of args.bindings) {
+    // The mail's own date, so importing old mail sorts by when it was sent.
+    // An unparseable or absent date leaves the stamp to the mutation, which
+    // falls back to the row's creation time.
+    const parsed = email.date === undefined ? NaN : Date.parse(email.date);
+    const receivedAt = Number.isFinite(parsed) ? parsed : undefined;
     for (const storageId of storedRefs(email)) {
       try {
         const outcome = await ctx.runMutation(
@@ -85,6 +90,7 @@ export async function bindEmailAttachments(
             organizationId: args.organizationId,
             storageId,
             conversationId,
+            ...(receivedAt !== undefined ? { receivedAt } : {}),
           },
         );
         if (outcome === 'bound' || outcome === 'bound_and_queued') {

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -1109,6 +1109,66 @@ describe('bindFileToConversation', () => {
     expect(await dispatchSpy()).toHaveBeenCalledWith(ctx, 'storage_1');
   });
 
+  it('stamps when the mail arrived, so the row enters the mail index', async () => {
+    // `mailReceivedAt` is what puts a row in
+    // `by_organizationId_and_mailReceivedAt`. Without it the attachment is
+    // bound, indexed, and still unlistable.
+    const { ctx } = createMockCtx(attachmentRow());
+    const handler = await getBindHandler();
+
+    await handler(ctx, { ...args, receivedAt: 1_234 });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      'fm_1',
+      expect.objectContaining({ mailReceivedAt: 1_234 }),
+    );
+  });
+
+  it("falls back to the row's creation time when the mail date is unknown", async () => {
+    const { ctx } = createMockCtx(attachmentRow({ _creationTime: 9_999 }));
+    const handler = await getBindHandler();
+
+    await handler(ctx, args);
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      'fm_1',
+      expect.objectContaining({ mailReceivedAt: 9_999 }),
+    );
+  });
+
+  it('back-fills the arrival time on a row bound before the field existed', async () => {
+    // Already bound and already indexed, so nothing else needs doing — but a
+    // row with no arrival time is invisible to the listing, so this must not
+    // short-circuit to `unchanged`.
+    const { ctx } = createMockCtx(
+      attachmentRow({
+        conversationId: 'conv_1',
+        ragStatus: 'completed',
+        _creationTime: 4_242,
+      }),
+    );
+    const handler = await getBindHandler();
+
+    expect(await handler(ctx, args)).not.toBe('unchanged');
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
+      mailReceivedAt: 4_242,
+    });
+  });
+
+  it('leaves an arrival time that is already recorded alone', async () => {
+    const { ctx } = createMockCtx(
+      attachmentRow({
+        conversationId: 'conv_1',
+        ragStatus: 'completed',
+        mailReceivedAt: 777,
+      }),
+    );
+    const handler = await getBindHandler();
+
+    expect(await handler(ctx, args)).toBe('unchanged');
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
   it('binds without re-indexing a file that already has a RAG outcome', async () => {
     // Re-embedding a completed file costs money and changes nothing; a failed
     // one belongs to the watchdog, not to a re-poll of the same mail.

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -60,6 +60,10 @@ export const bindFileToConversation = internalMutation({
     organizationId: v.string(),
     storageId: blobRefValidator,
     conversationId: v.id('conversations'),
+    /** When the mail arrived, in ms. The sync knows it from the message; absent
+     *  falls back to the row's creation time, which is within minutes on a live
+     *  poll and is the best available for an import. */
+    receivedAt: v.optional(v.number()),
   },
   returns: v.union(
     v.literal('not_found'),
@@ -80,6 +84,12 @@ export const bindFileToConversation = internalMutation({
     if (row.organizationId !== args.organizationId) return 'other_org';
 
     const alreadyBound = row.conversationId === args.conversationId;
+    // Written whenever it is missing, not only on a fresh binding: rows bound
+    // before this field existed would otherwise be absent from the mail index
+    // and so unlistable forever.
+    const receivedAt =
+      row.mailReceivedAt ?? args.receivedAt ?? row._creationTime;
+    const needsReceivedAt = row.mailReceivedAt !== receivedAt;
 
     // The same predicate the save paths use, so "indexable" has one meaning.
     // Audio is excluded as it is there: it indexes later, via its transcript.
@@ -96,10 +106,11 @@ export const bindFileToConversation = internalMutation({
         resolveFileType(row.fileName, row.contentType),
       );
 
-    if (alreadyBound && !indexable) return 'unchanged';
+    if (alreadyBound && !indexable && !needsReceivedAt) return 'unchanged';
 
     await ctx.db.patch(row._id, {
       ...(alreadyBound ? {} : { conversationId: args.conversationId }),
+      ...(needsReceivedAt ? { mailReceivedAt: receivedAt } : {}),
       ...(indexable ? { ragStatus: 'queued' as const } : {}),
     });
     if (!indexable) return 'bound';

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -45,6 +45,9 @@ export const listMailAttachmentsForChat = internalQuery({
     /** The turn user. Absent denies everything — an inbox attachment is never
      *  listed for an unidentified caller. */
     userId: v.optional(v.string()),
+    /** The conversations to look in, in report order. Each is re-checked here:
+     *  an id that arrived from a privacy-applied reader is still only an id. */
+    conversationIds: v.array(v.string()),
     limit: v.number(),
   },
   returns: v.object({

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -45,9 +45,6 @@ export const listMailAttachmentsForChat = internalQuery({
     /** The turn user. Absent denies everything — an inbox attachment is never
      *  listed for an unidentified caller. */
     userId: v.optional(v.string()),
-    /** The conversations to look in, in report order. Each is re-checked here:
-     *  an id that arrived from a privacy-applied reader is still only an id. */
-    conversationIds: v.array(v.string()),
     limit: v.number(),
   },
   returns: v.object({

--- a/services/platform/convex/file_metadata/list_mail_attachments.test.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.test.ts
@@ -1,14 +1,16 @@
 // Driven through convex-test against the real schema and indexes, because what
-// matters here is not the shape of the rows but who is allowed to see them.
-// An emailed attachment is visible exactly when its conversation is, and this
-// listing is a WIDER door than search — search needs the caller to guess words
-// that appear in the file, a listing hands over the catalogue.
+// matters here is not the shape of the rows but who is allowed to see them and
+// what the walk costs. An emailed attachment is visible exactly when its
+// conversation is, and this listing is a WIDER door than search — search needs
+// the caller to guess words that appear in the file, a listing hands over the
+// catalogue.
 
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
 import { internal } from '../_generated/api';
 import schema from '../schema';
+import { listMailAttachments } from './list_mail_attachments';
 
 const TEST_DIR_FROM_CONVEX_ROOT = 'file_metadata';
 function toConvexRootKey(globKey: string): string {
@@ -29,6 +31,7 @@ for (const [key, loader] of Object.entries(rawModules)) {
 const ORG = 'org_mail_list';
 const TEAM = 'team_inbox';
 const OTHER_TEAM = 'team_other';
+const BASE_TIME = 1_700_000_000_000;
 type T = TestConvex<typeof schema>;
 
 async function seedMember(
@@ -78,6 +81,8 @@ async function seedAttachment(
     fileName?: string;
     ragStatus?: string;
     lifecycleStatus?: string;
+    /** Arrival time. Only a row carrying one is in the mail index at all. */
+    receivedAt?: number;
   },
 ): Promise<void> {
   await t.run(async (ctx) => {
@@ -89,7 +94,10 @@ async function seedAttachment(
       size: 1024,
       source: 'imap-smtp',
       ...(args.conversationId !== undefined
-        ? { conversationId: args.conversationId as never }
+        ? {
+            conversationId: args.conversationId as never,
+            mailReceivedAt: args.receivedAt ?? BASE_TIME,
+          }
         : {}),
       ...(args.ragStatus !== undefined
         ? { ragStatus: args.ragStatus as never }
@@ -101,31 +109,25 @@ async function seedAttachment(
   });
 }
 
-/** Every conversation in the org, newest-created first — a stand-in for what
- *  the executor passes after its own privacy-applied conversation listing.
- *  Deliberately UNFILTERED: the reader must re-check each id itself. */
-async function allConversationIds(t: T): Promise<string[]> {
-  return await t.run(async (ctx) => {
-    const ids: string[] = [];
-    for await (const c of ctx.db
-      .query('conversations')
-      .withIndex('by_organizationId', (q) => q.eq('organizationId', ORG))
-      .order('desc')) {
-      ids.push(String(c._id));
+async function seedUnbound(t: T, count: number): Promise<void> {
+  await t.run(async (ctx) => {
+    for (let index = 0; index < count; index += 1) {
+      await ctx.db.insert('fileMetadata', {
+        organizationId: ORG,
+        storageId: `unbound_${index}`,
+        fileName: `f${index}.pdf`,
+        contentType: 'application/pdf',
+        size: 100,
+        source: 'imap-smtp',
+      });
     }
-    return ids;
   });
 }
 
-async function list(t: T, userId: string | undefined, limit = 20) {
-  return await t.query(
+function list(t: T, userId: string | undefined, limit = 20) {
+  return t.query(
     internal.file_metadata.internal_queries.listMailAttachmentsForChat,
-    {
-      organizationId: ORG,
-      conversationIds: await allConversationIds(t),
-      limit,
-      ...(userId !== undefined ? { userId } : {}),
-    },
+    { organizationId: ORG, limit, ...(userId !== undefined ? { userId } : {}) },
   );
 }
 
@@ -155,9 +157,10 @@ describe('listMailAttachments — who may see what', () => {
       conversationId: unassigned,
     });
 
-    const result = await list(t, 'member_1');
     // Unassigned mail is admin-triage state, not org-readable.
-    expect(result.attachments.map((a) => a.ref)).toEqual(['mine']);
+    expect((await list(t, 'member_1')).attachments.map((a) => a.ref)).toEqual([
+      'mine',
+    ]);
   });
 
   it('shows the individual assignee their own mail', async () => {
@@ -166,8 +169,9 @@ describe('listMailAttachments — who may see what', () => {
     const mine = await seedConversation(t, { assigneeUserId: 'member_2' });
     await seedAttachment(t, { storageId: 'assigned', conversationId: mine });
 
-    const result = await list(t, 'member_2');
-    expect(result.attachments.map((a) => a.ref)).toEqual(['assigned']);
+    expect((await list(t, 'member_2')).attachments.map((a) => a.ref)).toEqual([
+      'assigned',
+    ]);
   });
 
   it('shows nothing to a caller who did not say who they are', async () => {
@@ -185,8 +189,8 @@ describe('listMailAttachments — who may see what', () => {
     // convex-test cannot register. It is covered where the shared resolver is
     // driven directly, in
     // `documents/filter_retrievable_rag_file_ids.conversation_scope.test.ts` —
-    // and since both surfaces now call `conversationCallerResolver`, that one
-    // test covers this listing too.
+    // and since both surfaces use `conversationCallerResolver`, that covers
+    // this listing too.
     const t = convexTest(schema, modules);
     await seedMember(t, 'disabled_1', 'disabled', [TEAM]);
     const conv = await seedConversation(t, { assigneeTeamId: TEAM });
@@ -194,19 +198,128 @@ describe('listMailAttachments — who may see what', () => {
 
     expect((await list(t, 'disabled_1')).attachments).toEqual([]);
   });
+
+  it("never lists an attachment whose conversation is another org's", async () => {
+    // A conversationId on a row is a reference, not a permission.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const foreign = await t.run(async (ctx) =>
+      ctx.db.insert('conversations', {
+        organizationId: 'org_elsewhere',
+        subject: 'Theirs',
+        status: 'open',
+        channel: 'email',
+      }),
+    );
+    await seedAttachment(t, {
+      storageId: 'b_foreign',
+      conversationId: foreign,
+    });
+
+    expect((await list(t, 'admin_1')).attachments).toEqual([]);
+  });
+});
+
+describe('listMailAttachments — order and cost', () => {
+  it('orders by arrival, not by conversation activity', async () => {
+    // The ordering this exists for: a fresh arrival on a quiet thread must not
+    // sort below an older one whose conversation happened to get a reply.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const busy = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    const quiet = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, {
+      storageId: 'older',
+      conversationId: busy,
+      receivedAt: 1_000,
+    });
+    await seedAttachment(t, {
+      storageId: 'newer',
+      conversationId: quiet,
+      receivedAt: 9_000,
+    });
+
+    const result = await list(t, 'admin_1');
+    expect(result.attachments.map((a) => a.ref)).toEqual(['newer', 'older']);
+    expect(result.attachments[0]?.receivedAt).toBe(9_000);
+  });
+
+  it('reads only what it returns, however large the table', async () => {
+    // The property three earlier shapes failed: cost must not grow with the
+    // table. 700 unbound rows exist and none is touched, because a row without
+    // an arrival time is not in the mail index at all.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, { storageId: 'wanted', conversationId: conv });
+    await seedUnbound(t, 700);
+
+    const result = await list(t, 'admin_1');
+    expect(result.attachments.map((a) => a.ref)).toEqual(['wanted']);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('reports truncation when the page fills, and not when it does not', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    for (let index = 0; index < 4; index += 1) {
+      await seedAttachment(t, {
+        storageId: `a${index}`,
+        conversationId: conv,
+        receivedAt: BASE_TIME + index,
+      });
+    }
+
+    const cut = await list(t, 'admin_1', 2);
+    expect(cut.attachments).toHaveLength(2);
+    expect(cut.truncated).toBe(true);
+
+    const whole = await list(t, 'admin_1', 20);
+    expect(whole.attachments).toHaveLength(4);
+    expect(whole.truncated).toBe(false);
+  });
+
+  it('stops at its scan bound and says so, rather than looking empty', async () => {
+    // A caller who can read little passes more rows than it keeps. Reporting
+    // the bound is what stops that reading as "the inbox is empty".
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'member_1', 'member', [TEAM]);
+    const unreadable = await seedConversation(t, {
+      assigneeTeamId: OTHER_TEAM,
+    });
+    for (let index = 0; index < 4; index += 1) {
+      await seedAttachment(t, {
+        storageId: `x${index}`,
+        conversationId: unreadable,
+        receivedAt: BASE_TIME + index,
+      });
+    }
+
+    const stopped = await t.run(async (ctx) =>
+      listMailAttachments(ctx, {
+        organizationId: ORG,
+        userId: 'member_1',
+        limit: 20,
+        scanCap: 2,
+      }),
+    );
+    expect(stopped.attachments).toEqual([]);
+    expect(stopped.truncated).toBe(true);
+  });
 });
 
 describe('listMailAttachments — what is listed', () => {
-  it('lists only attachments bound to a conversation', async () => {
+  it('lists only attachments that arrived by mail', async () => {
     const t = convexTest(schema, modules);
     await seedMember(t, 'admin_1', 'admin');
     const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
     await seedAttachment(t, { storageId: 'bound', conversationId: conv });
-    // A Document Hub upload and an unbound mail attachment are both out.
-    await seedAttachment(t, { storageId: 'unbound' });
+    await seedUnbound(t, 3);
 
-    const result = await list(t, 'admin_1');
-    expect(result.attachments.map((a) => a.ref)).toEqual(['bound']);
+    expect((await list(t, 'admin_1')).attachments.map((a) => a.ref)).toEqual([
+      'bound',
+    ]);
   });
 
   it('excludes a trashed attachment', async () => {
@@ -220,8 +333,9 @@ describe('listMailAttachments — what is listed', () => {
       lifecycleStatus: 'trashed',
     });
 
-    const result = await list(t, 'admin_1');
-    expect(result.attachments.map((a) => a.ref)).toEqual(['live']);
+    expect((await list(t, 'admin_1')).attachments.map((a) => a.ref)).toEqual([
+      'live',
+    ]);
   });
 
   it('reports whether each attachment is actually indexed', async () => {
@@ -244,130 +358,7 @@ describe('listMailAttachments — what is listed', () => {
     expect(byRef.get('pending')).toBe(false);
   });
 
-  it('keeps the newest when the limit bites, not the oldest', async () => {
-    // The bound decides the answer, so which end it keeps is the feature.
-    // Oldest-first would answer "what has come in?" with the stalest mail.
-    const t = convexTest(schema, modules);
-    await seedMember(t, 'admin_1', 'admin');
-    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
-    for (let index = 0; index < 6; index += 1) {
-      await seedAttachment(t, {
-        storageId: `b${index}`,
-        conversationId: conv,
-        fileName: `f${index}.pdf`,
-      });
-    }
-
-    const result = await list(t, 'admin_1', 2);
-    expect(result.attachments.map((a) => a.ref)).toEqual(['b5', 'b4']);
-  });
-
-  it("never lists an attachment pointing at another organization's conversation", async () => {
-    // A conversation id on a row is a reference, not a permission. Following it
-    // across a tenant boundary would list one org's mail in another's.
-    const t = convexTest(schema, modules);
-    await seedMember(t, 'admin_1', 'admin');
-    const foreign = await t.run(async (ctx) =>
-      ctx.db.insert('conversations', {
-        organizationId: 'org_somewhere_else',
-        subject: 'Theirs',
-        status: 'open',
-        channel: 'email',
-      }),
-    );
-    await seedAttachment(t, {
-      storageId: 'b_foreign',
-      conversationId: foreign,
-    });
-
-    expect((await list(t, 'admin_1')).attachments).toEqual([]);
-  });
-
-  it('reads only the conversations it was given, however large the table', async () => {
-    // The property the earlier shapes failed: cost must scale with the inbox
-    // reached, not with how many attachments the organization has received.
-    // 700 unbound rows and a second conversation's attachments both exist and
-    // neither is touched when only one conversation is passed.
-    const t = convexTest(schema, modules);
-    await seedMember(t, 'admin_1', 'admin');
-    const wanted = await seedConversation(t, { assigneeUserId: 'admin_1' });
-    const other = await seedConversation(t, { assigneeUserId: 'admin_1' });
-    await seedAttachment(t, { storageId: 'wanted', conversationId: wanted });
-    await seedAttachment(t, { storageId: 'other', conversationId: other });
-    await t.run(async (ctx) => {
-      for (let index = 0; index < 700; index += 1) {
-        await ctx.db.insert('fileMetadata', {
-          organizationId: ORG,
-          storageId: `u_${index}`,
-          fileName: `f${index}.pdf`,
-          contentType: 'application/pdf',
-          size: 100,
-          source: 'imap-smtp',
-        });
-      }
-    });
-
-    const result = await t.query(
-      internal.file_metadata.internal_queries.listMailAttachmentsForChat,
-      {
-        organizationId: ORG,
-        userId: 'admin_1',
-        conversationIds: [wanted],
-        limit: 20,
-      },
-    );
-    expect(result.attachments.map((a) => a.ref)).toEqual(['wanted']);
-    expect(result.truncated).toBe(false);
-  });
-
-  it('reports truncation when the attachments exceed the limit', async () => {
-    const t = convexTest(schema, modules);
-    await seedMember(t, 'admin_1', 'admin');
-    const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
-    for (let index = 0; index < 4; index += 1) {
-      await seedAttachment(t, { storageId: `a${index}`, conversationId: conv });
-    }
-
-    const cut = await list(t, 'admin_1', 2);
-    expect(cut.attachments).toHaveLength(2);
-    expect(cut.truncated).toBe(true);
-
-    const whole = await list(t, 'admin_1', 20);
-    expect(whole.attachments).toHaveLength(4);
-    expect(whole.truncated).toBe(false);
-  });
-
-  it("ignores a conversation id that is not this organization's", async () => {
-    // An id is a reference, not a capability: the reader re-checks even ids
-    // that arrived from a privacy-applied listing.
-    const t = convexTest(schema, modules);
-    await seedMember(t, 'admin_1', 'admin');
-    const foreign = await t.run(async (ctx) =>
-      ctx.db.insert('conversations', {
-        organizationId: 'org_elsewhere',
-        subject: 'Theirs',
-        status: 'open',
-        channel: 'email',
-      }),
-    );
-    await seedAttachment(t, {
-      storageId: 'b_foreign',
-      conversationId: foreign,
-    });
-
-    const result = await t.query(
-      internal.file_metadata.internal_queries.listMailAttachmentsForChat,
-      {
-        organizationId: ORG,
-        userId: 'admin_1',
-        conversationIds: [foreign, 'not-an-id'],
-        limit: 20,
-      },
-    );
-    expect(result.attachments).toEqual([]);
-  });
-
-  it('carries the corpus ref so a listed row can be fetched', async () => {
+  it('carries the corpus ref and the conversation so a row can be fetched', async () => {
     const t = convexTest(schema, modules);
     await seedMember(t, 'admin_1', 'admin');
     const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });

--- a/services/platform/convex/file_metadata/list_mail_attachments.test.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.test.ts
@@ -9,7 +9,6 @@ import { describe, expect, it } from 'vitest';
 
 import { internal } from '../_generated/api';
 import schema from '../schema';
-import { listMailAttachments } from './list_mail_attachments';
 
 const TEST_DIR_FROM_CONVEX_ROOT = 'file_metadata';
 function toConvexRootKey(globKey: string): string {
@@ -102,10 +101,31 @@ async function seedAttachment(
   });
 }
 
-function list(t: T, userId: string | undefined, limit = 20) {
-  return t.query(
+/** Every conversation in the org, newest-created first — a stand-in for what
+ *  the executor passes after its own privacy-applied conversation listing.
+ *  Deliberately UNFILTERED: the reader must re-check each id itself. */
+async function allConversationIds(t: T): Promise<string[]> {
+  return await t.run(async (ctx) => {
+    const ids: string[] = [];
+    for await (const c of ctx.db
+      .query('conversations')
+      .withIndex('by_organizationId', (q) => q.eq('organizationId', ORG))
+      .order('desc')) {
+      ids.push(String(c._id));
+    }
+    return ids;
+  });
+}
+
+async function list(t: T, userId: string | undefined, limit = 20) {
+  return await t.query(
     internal.file_metadata.internal_queries.listMailAttachmentsForChat,
-    { organizationId: ORG, limit, ...(userId !== undefined ? { userId } : {}) },
+    {
+      organizationId: ORG,
+      conversationIds: await allConversationIds(t),
+      limit,
+      ...(userId !== undefined ? { userId } : {}),
+    },
   );
 }
 
@@ -173,53 +193,6 @@ describe('listMailAttachments — who may see what', () => {
     await seedAttachment(t, { storageId: 'b1', conversationId: conv });
 
     expect((await list(t, 'disabled_1')).attachments).toEqual([]);
-  });
-});
-
-describe('a table dominated by unbound rows', () => {
-  // The shape measured on a live deployment: 3,671 `fileMetadata` rows of which
-  // 3 are bound. Walking every row under a scan budget meant the budget was
-  // spent on rows that can never qualify, and which bound rows were reachable
-  // depended on where they sat in creation order — so the listing silently
-  // emptied as the table grew.
-  //
-  // 700 unbound rows is above the 600 budget, so this fails against a walk over
-  // all rows and passes against a walk over bound rows only.
-  it('finds every bound row regardless of how many unbound rows precede it', async () => {
-    const t = convexTest(schema, modules);
-    await seedMember(t, 'owner_1', 'owner');
-    const conv = await seedConversation(t, { assigneeUserId: 'owner_1' });
-    // Bound rows FIRST, so they are the oldest and sit behind every unbound row
-    // in creation order — the position that used to make them unreachable.
-    for (let index = 0; index < 3; index += 1) {
-      await seedAttachment(t, {
-        storageId: `bound_${index}`,
-        conversationId: conv,
-        ragStatus: 'completed',
-      });
-    }
-    await t.run(async (ctx) => {
-      for (let index = 0; index < 700; index += 1) {
-        await ctx.db.insert('fileMetadata', {
-          organizationId: ORG,
-          storageId: `unbound_${index}`,
-          fileName: `f${index}.pdf`,
-          contentType: 'application/pdf',
-          size: 100,
-          source: 'imap-smtp',
-        });
-      }
-    });
-
-    const result = await list(t, 'owner_1');
-    expect(result.attachments.map((a) => a.ref).sort()).toEqual([
-      'bound_0',
-      'bound_1',
-      'bound_2',
-    ]);
-    // And the walk is not reporting a partial answer, because it never touched
-    // the unbound rows at all.
-    expect(result.truncated).toBe(false);
   });
 });
 
@@ -310,37 +283,88 @@ describe('listMailAttachments — what is listed', () => {
     expect((await list(t, 'admin_1')).attachments).toEqual([]);
   });
 
-  it('stops at its scan budget and says the listing is partial', async () => {
-    // The walk filters as it goes, so a caller who can read little rejects most
-    // of what it touches. Without a bound on rows EXAMINED one question would
-    // read the whole table.
+  it('reads only the conversations it was given, however large the table', async () => {
+    // The property the earlier shapes failed: cost must scale with the inbox
+    // reached, not with how many attachments the organization has received.
+    // 700 unbound rows and a second conversation's attachments both exist and
+    // neither is touched when only one conversation is passed.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const wanted = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    const other = await seedConversation(t, { assigneeUserId: 'admin_1' });
+    await seedAttachment(t, { storageId: 'wanted', conversationId: wanted });
+    await seedAttachment(t, { storageId: 'other', conversationId: other });
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 700; index += 1) {
+        await ctx.db.insert('fileMetadata', {
+          organizationId: ORG,
+          storageId: `u_${index}`,
+          fileName: `f${index}.pdf`,
+          contentType: 'application/pdf',
+          size: 100,
+          source: 'imap-smtp',
+        });
+      }
+    });
+
+    const result = await t.query(
+      internal.file_metadata.internal_queries.listMailAttachmentsForChat,
+      {
+        organizationId: ORG,
+        userId: 'admin_1',
+        conversationIds: [wanted],
+        limit: 20,
+      },
+    );
+    expect(result.attachments.map((a) => a.ref)).toEqual(['wanted']);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('reports truncation when the attachments exceed the limit', async () => {
     const t = convexTest(schema, modules);
     await seedMember(t, 'admin_1', 'admin');
     const conv = await seedConversation(t, { assigneeUserId: 'admin_1' });
     for (let index = 0; index < 4; index += 1) {
-      await seedAttachment(t, { storageId: `s${index}`, conversationId: conv });
+      await seedAttachment(t, { storageId: `a${index}`, conversationId: conv });
     }
 
-    const stopped = await t.run(async (ctx) =>
-      listMailAttachments(ctx, {
-        organizationId: ORG,
-        userId: 'admin_1',
-        limit: 20,
-        scanCap: 2,
-      }),
-    );
-    expect(stopped.truncated).toBe(true);
-    expect(stopped.attachments).toHaveLength(2);
+    const cut = await list(t, 'admin_1', 2);
+    expect(cut.attachments).toHaveLength(2);
+    expect(cut.truncated).toBe(true);
 
-    const complete = await t.run(async (ctx) =>
-      listMailAttachments(ctx, {
-        organizationId: ORG,
-        userId: 'admin_1',
-        limit: 20,
+    const whole = await list(t, 'admin_1', 20);
+    expect(whole.attachments).toHaveLength(4);
+    expect(whole.truncated).toBe(false);
+  });
+
+  it("ignores a conversation id that is not this organization's", async () => {
+    // An id is a reference, not a capability: the reader re-checks even ids
+    // that arrived from a privacy-applied listing.
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'admin_1', 'admin');
+    const foreign = await t.run(async (ctx) =>
+      ctx.db.insert('conversations', {
+        organizationId: 'org_elsewhere',
+        subject: 'Theirs',
+        status: 'open',
+        channel: 'email',
       }),
     );
-    expect(complete.truncated).toBe(false);
-    expect(complete.attachments).toHaveLength(4);
+    await seedAttachment(t, {
+      storageId: 'b_foreign',
+      conversationId: foreign,
+    });
+
+    const result = await t.query(
+      internal.file_metadata.internal_queries.listMailAttachmentsForChat,
+      {
+        organizationId: ORG,
+        userId: 'admin_1',
+        conversationIds: [foreign, 'not-an-id'],
+        limit: 20,
+      },
+    );
+    expect(result.attachments).toEqual([]);
   });
 
   it('carries the corpus ref so a listed row can be fetched', async () => {

--- a/services/platform/convex/file_metadata/list_mail_attachments.test.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.test.ts
@@ -176,6 +176,53 @@ describe('listMailAttachments — who may see what', () => {
   });
 });
 
+describe('a table dominated by unbound rows', () => {
+  // The shape measured on a live deployment: 3,671 `fileMetadata` rows of which
+  // 3 are bound. Walking every row under a scan budget meant the budget was
+  // spent on rows that can never qualify, and which bound rows were reachable
+  // depended on where they sat in creation order — so the listing silently
+  // emptied as the table grew.
+  //
+  // 700 unbound rows is above the 600 budget, so this fails against a walk over
+  // all rows and passes against a walk over bound rows only.
+  it('finds every bound row regardless of how many unbound rows precede it', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'owner_1', 'owner');
+    const conv = await seedConversation(t, { assigneeUserId: 'owner_1' });
+    // Bound rows FIRST, so they are the oldest and sit behind every unbound row
+    // in creation order — the position that used to make them unreachable.
+    for (let index = 0; index < 3; index += 1) {
+      await seedAttachment(t, {
+        storageId: `bound_${index}`,
+        conversationId: conv,
+        ragStatus: 'completed',
+      });
+    }
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 700; index += 1) {
+        await ctx.db.insert('fileMetadata', {
+          organizationId: ORG,
+          storageId: `unbound_${index}`,
+          fileName: `f${index}.pdf`,
+          contentType: 'application/pdf',
+          size: 100,
+          source: 'imap-smtp',
+        });
+      }
+    });
+
+    const result = await list(t, 'owner_1');
+    expect(result.attachments.map((a) => a.ref).sort()).toEqual([
+      'bound_0',
+      'bound_1',
+      'bound_2',
+    ]);
+    // And the walk is not reporting a partial answer, because it never touched
+    // the unbound rows at all.
+    expect(result.truncated).toBe(false);
+  });
+});
+
 describe('listMailAttachments — what is listed', () => {
   it('lists only attachments bound to a conversation', async () => {
     const t = convexTest(schema, modules);

--- a/services/platform/convex/file_metadata/list_mail_attachments.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.ts
@@ -1,55 +1,48 @@
 /**
- * The emailed attachments a caller may read — a catalogue, with the words off.
+ * The emailed attachments a caller may read — driven from conversations.
  *
- * An emailed attachment has no listing surface anywhere in the product. It is
- * not a Document Hub row, so it is absent from the Documents page and from
+ * An emailed attachment has no listing surface anywhere else in the product. It
+ * is not a Document Hub row, so it is absent from the Documents page and from
  * `list kind="document"`, and its only appearance is on its own conversation in
- * the Inbox. Retrieval was therefore the sole way to discover one, which means
- * guessing words that appear inside it — and a CV named for its author contains
- * none of the words describing the role it was sent for.
+ * the Inbox. Retrieval was the sole way to discover one, which means guessing
+ * words inside a file whose name says nothing about why it was sent.
  *
- * ## Scope is the conversation's LIVE assignment
+ * ## Why the conversations lead
  *
- * Decided per row by `conversationAssignmentAllows` against the conversation as
- * it stands now, using the caller resolved by `conversationCallerResolver` —
- * the same predicate and the same resolver the retrieval gate uses. That is
- * deliberate: a listing that derived its own notion of visibility would be one
- * refactor away from being wider than the search beside it, and the failure
- * mode is publishing an inbox.
+ * The reads scale with the conversations shown, not with how many attachments
+ * the organization has ever received. Two earlier shapes both failed on that:
  *
- * Because assignment is read live, reassigning a conversation moves its
- * attachments in this listing too, with nothing rewritten.
+ *  - walking every `fileMetadata` row under a budget spent the budget on rows
+ *    that can never qualify — on one deployment, 3,671 rows of which 3 carried
+ *    a conversation — so which attachments were reachable depended on where
+ *    they sat in creation order;
+ *  - walking only the bound rows fixed reachability but still read up to the
+ *    whole budget to return one page, and above that budget it was silently
+ *    wrong about "most recent", because that index orders by conversation
+ *    rather than by time.
  *
- * ## Only bound rows are walked
+ * Leading with conversations removes both. Each conversation is one exact index
+ * lookup, and the caller decides how many conversations to reach over.
  *
- * The range starts ABOVE `undefined` on `by_organizationId_and_conversationId`.
- * Convex orders `undefined` below every real value, so that bound selects
- * exactly the rows that carry a conversation, and
- * the walk touches only rows that have a conversation. That is not an
- * optimization, it is the correctness fix: an earlier version scanned all of
- * `fileMetadata` newest-first under a scan cap, and on a deployment whose table
- * is mostly unbound rows the cap was exhausted before the walk reached a single
- * bound attachment. It returned nothing while three readable attachments
- * existed. A cap on rows EXAMINED empties the result set when the filter
- * rejects most of what it touches, so the filter has to be the index instead.
+ * ## Ordering
  *
- * `SCAN_CAP` survives as a ceiling on an organization with a very large number
- * of mail attachments, where it now bounds a walk over bound rows only.
+ * Conversation order is the caller's, and attachments follow it — most recently
+ * active mail first, newest attachment first within a conversation. Not
+ * global arrival order: that would need an index over bound rows keyed by time,
+ * which does not exist and would cost a stored field plus a backfill.
  *
- * ## Recency is applied after the walk
+ * ## An id is not a capability
  *
- * The index orders by conversation, not by time, so the page is sorted by
- * arrival before the limit is taken. The bound decides the answer, and
- * oldest-first would report "what has come in?" as the stalest mail on the box.
+ * Every conversation is re-checked here even though the caller resolved them
+ * through a privacy-applied reader. The check is cheap — one row read per
+ * conversation — and it keeps this query fail-closed on its own terms rather
+ * than trusting whatever ids arrived.
  */
 
 import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
 import { conversationCallerResolver } from '../lib/rls/helpers/conversation_caller';
-
-/** Rows examined before the walk stops, regardless of how many were kept. */
-const SCAN_CAP = 600;
 
 /** One attachment, as a catalogue row rather than a retrieval hit. */
 export interface MailAttachmentListing {
@@ -67,8 +60,9 @@ export interface MailAttachmentListing {
 
 export interface MailAttachmentListingResult {
   readonly attachments: MailAttachmentListing[];
-  /** The scan budget stopped the walk, so the listing is a page and not the
-   *  whole set. Distinct from a full page, which the caller detects itself. */
+  /** More attachments exist on the conversations reached than fit the limit.
+   *  Says nothing about conversations NOT reached — that bound belongs to
+   *  whoever chose the conversation list. */
   readonly truncated: boolean;
 }
 
@@ -77,11 +71,9 @@ export async function listMailAttachments(
   args: {
     organizationId: string;
     userId?: string | undefined;
+    /** The conversations to look in, in the order they should be reported. */
+    conversationIds: readonly string[];
     limit: number;
-    /** Rows examined before the walk stops. Defaults to {@link SCAN_CAP}; the
-     *  internal query never overrides it. Present so a test can prove the bound
-     *  exists without seeding six hundred rows. */
-    scanCap?: number;
   },
 ): Promise<MailAttachmentListingResult> {
   const caller = conversationCallerResolver(ctx, {
@@ -89,72 +81,67 @@ export async function listMailAttachments(
     ...(args.userId !== undefined ? { userId: args.userId } : {}),
   });
 
-  // Many attachments share one conversation, so the assignment decision is
-  // cached per conversation rather than per row.
-  const decided = new Map<string, boolean>();
-  const mayRead = async (
-    conversationId: Doc<'fileMetadata'>['conversationId'],
-  ): Promise<boolean> => {
-    if (conversationId === undefined) return false;
-    const key = String(conversationId);
-    const cached = decided.get(key);
-    if (cached !== undefined) return cached;
-    const identity = await caller();
-    if (identity === null) {
-      decided.set(key, false);
-      return false;
-    }
-    const conversation = await ctx.db.get(conversationId);
-    const allowed =
-      conversation !== null &&
-      conversation.organizationId === args.organizationId &&
-      (await conversationAssignmentAllows(conversation, {
-        isAdmin: identity.isAdmin,
-        userId: identity.userId,
-        hasTeam: (teamId) => identity.teamIds.has(teamId),
-      }));
-    decided.set(key, allowed);
-    return allowed;
-  };
-
   const attachments: MailAttachmentListing[] = [];
-  let scanned = 0;
-  let truncated = false;
-  for await (const row of ctx.db
-    .query('fileMetadata')
-    .withIndex('by_organizationId_and_conversationId', (q) =>
-      // Above `null` selects the rows that HAVE a conversation. Unbound rows —
-      // Document Hub uploads, chat uploads, the unreferenced residue of a
-      // re-ingest bug — are never touched, so they cannot exhaust the budget
-      // ahead of a readable attachment.
-      q
-        .eq('organizationId', args.organizationId)
-        .gt('conversationId', undefined),
-    )) {
-    scanned += 1;
-    if (scanned > (args.scanCap ?? SCAN_CAP)) {
-      truncated = true;
+  let more = false;
+
+  for (const rawId of args.conversationIds) {
+    if (attachments.length >= args.limit) {
+      more = true;
       break;
     }
-    if (row.lifecycleStatus === 'trashed') continue;
-    if (!(await mayRead(row.conversationId))) continue;
-    attachments.push({
-      ref: String(row.storageId),
-      fileName: row.fileName,
-      contentType: row.contentType,
-      size: row.size,
-      conversationId: String(row.conversationId),
-      receivedAt: row._creationTime,
-      indexed: row.ragStatus === 'completed',
+    const conversationId = ctx.db.normalizeId('conversations', rawId);
+    if (conversationId === null) continue;
+
+    const identity = await caller();
+    if (identity === null) return { attachments: [], truncated: false };
+
+    const conversation = await ctx.db.get(conversationId);
+    if (
+      conversation === null ||
+      conversation.organizationId !== args.organizationId
+    ) {
+      continue;
+    }
+    const allowed = await conversationAssignmentAllows(conversation, {
+      isAdmin: identity.isAdmin,
+      userId: identity.userId,
+      hasTeam: (teamId) => identity.teamIds.has(teamId),
     });
+    if (!allowed) continue;
+
+    // One exact index lookup per conversation, newest attachment first.
+    const rows: Doc<'fileMetadata'>[] = [];
+    for await (const row of ctx.db
+      .query('fileMetadata')
+      .withIndex('by_organizationId_and_conversationId', (q) =>
+        q
+          .eq('organizationId', args.organizationId)
+          .eq('conversationId', conversationId),
+      )
+      .order('desc')) {
+      if (row.lifecycleStatus === 'trashed') continue;
+      rows.push(row);
+      // One past the limit is enough to know more exist without reading a
+      // conversation's whole attachment history.
+      if (attachments.length + rows.length > args.limit) break;
+    }
+
+    for (const row of rows) {
+      if (attachments.length >= args.limit) {
+        more = true;
+        break;
+      }
+      attachments.push({
+        ref: String(row.storageId),
+        fileName: row.fileName,
+        contentType: row.contentType,
+        size: row.size,
+        conversationId: String(conversationId),
+        receivedAt: row._creationTime,
+        indexed: row.ragStatus === 'completed',
+      });
+    }
   }
 
-  // Newest first, then the limit — the index orders by conversation, so recency
-  // cannot come from the walk.
-  attachments.sort((a, b) => b.receivedAt - a.receivedAt);
-  const page = attachments.slice(0, args.limit);
-  return {
-    attachments: page,
-    truncated: truncated || page.length < attachments.length,
-  };
+  return { attachments, truncated: more };
 }

--- a/services/platform/convex/file_metadata/list_mail_attachments.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.ts
@@ -20,16 +20,27 @@
  * Because assignment is read live, reassigning a conversation moves its
  * attachments in this listing too, with nothing rewritten.
  *
- * ## Two bounds, both reported
+ * ## Only bound rows are walked
  *
- * `limit` bounds what is KEPT. `SCAN_CAP` bounds what is EXAMINED, which is the
- * one that matters: the walk filters as it goes, so a caller who can read few
- * conversations rejects most of what it touches. Without the second bound one
- * question would read the organization's whole `fileMetadata` table.
+ * The range starts ABOVE `undefined` on `by_organizationId_and_conversationId`.
+ * Convex orders `undefined` below every real value, so that bound selects
+ * exactly the rows that carry a conversation, and
+ * the walk touches only rows that have a conversation. That is not an
+ * optimization, it is the correctness fix: an earlier version scanned all of
+ * `fileMetadata` newest-first under a scan cap, and on a deployment whose table
+ * is mostly unbound rows the cap was exhausted before the walk reached a single
+ * bound attachment. It returned nothing while three readable attachments
+ * existed. A cap on rows EXAMINED empties the result set when the filter
+ * rejects most of what it touches, so the filter has to be the index instead.
  *
- * The walk is newest-first. The bound decides the answer, so which end it keeps
- * is the feature: oldest-first would answer "what has come in?" with the
- * stalest mail on the box.
+ * `SCAN_CAP` survives as a ceiling on an organization with a very large number
+ * of mail attachments, where it now bounds a walk over bound rows only.
+ *
+ * ## Recency is applied after the walk
+ *
+ * The index orders by conversation, not by time, so the page is sorted by
+ * arrival before the limit is taken. The bound decides the answer, and
+ * oldest-first would report "what has come in?" as the stalest mail on the box.
  */
 
 import type { Doc } from '../_generated/dataModel';
@@ -111,19 +122,21 @@ export async function listMailAttachments(
   let truncated = false;
   for await (const row of ctx.db
     .query('fileMetadata')
-    .withIndex('by_organizationId', (q) =>
-      q.eq('organizationId', args.organizationId),
-    )
-    .order('desc')) {
+    .withIndex('by_organizationId_and_conversationId', (q) =>
+      // Above `null` selects the rows that HAVE a conversation. Unbound rows —
+      // Document Hub uploads, chat uploads, the unreferenced residue of a
+      // re-ingest bug — are never touched, so they cannot exhaust the budget
+      // ahead of a readable attachment.
+      q
+        .eq('organizationId', args.organizationId)
+        .gt('conversationId', undefined),
+    )) {
     scanned += 1;
     if (scanned > (args.scanCap ?? SCAN_CAP)) {
       truncated = true;
       break;
     }
     if (row.lifecycleStatus === 'trashed') continue;
-    // `mayRead` rejects an unbound row itself, so there is no separate guard
-    // here: a second one read as belt-and-braces but no test could tell it from
-    // dead code.
     if (!(await mayRead(row.conversationId))) continue;
     attachments.push({
       ref: String(row.storageId),
@@ -134,8 +147,14 @@ export async function listMailAttachments(
       receivedAt: row._creationTime,
       indexed: row.ragStatus === 'completed',
     });
-    if (attachments.length >= args.limit) break;
   }
 
-  return { attachments, truncated };
+  // Newest first, then the limit — the index orders by conversation, so recency
+  // cannot come from the walk.
+  attachments.sort((a, b) => b.receivedAt - a.receivedAt);
+  const page = attachments.slice(0, args.limit);
+  return {
+    attachments: page,
+    truncated: truncated || page.length < attachments.length,
+  };
 }

--- a/services/platform/convex/file_metadata/list_mail_attachments.ts
+++ b/services/platform/convex/file_metadata/list_mail_attachments.ts
@@ -1,5 +1,5 @@
 /**
- * The emailed attachments a caller may read — driven from conversations.
+ * The emailed attachments a caller may read, newest arrival first.
  *
  * An emailed attachment has no listing surface anywhere else in the product. It
  * is not a Document Hub row, so it is absent from the Documents page and from
@@ -7,42 +7,47 @@
  * the Inbox. Retrieval was the sole way to discover one, which means guessing
  * words inside a file whose name says nothing about why it was sent.
  *
- * ## Why the conversations lead
+ * ## Why it needs its own index
  *
- * The reads scale with the conversations shown, not with how many attachments
- * the organization has ever received. Two earlier shapes both failed on that:
+ * `mailReceivedAt` is present only on bound rows, so a range above `undefined`
+ * on `by_organizationId_and_mailReceivedAt` is a mail-only walk in arrival
+ * order. No existing index gives that: pairing with `conversationId` orders by
+ * conversation first, and the plain org index is dominated by rows that never
+ * arrived by mail.
+ *
+ * Three earlier shapes each failed on cost or on order:
  *
  *  - walking every `fileMetadata` row under a budget spent the budget on rows
- *    that can never qualify — on one deployment, 3,671 rows of which 3 carried
- *    a conversation — so which attachments were reachable depended on where
- *    they sat in creation order;
- *  - walking only the bound rows fixed reachability but still read up to the
- *    whole budget to return one page, and above that budget it was silently
- *    wrong about "most recent", because that index orders by conversation
- *    rather than by time.
+ *    that could never qualify — on one deployment, 3,671 rows of which 3 carried
+ *    a conversation — so reachability depended on creation position;
+ *  - walking only bound rows fixed that but still read the whole budget to
+ *    return one page, and above it reported "most recent" from an arbitrary
+ *    window;
+ *  - leading with conversations bounded the cost but ordered by conversation
+ *    activity, so a fresh application sorted below an older one that happened
+ *    to get a reply.
  *
- * Leading with conversations removes both. Each conversation is one exact index
- * lookup, and the caller decides how many conversations to reach over.
+ * This walk reads `limit` rows in the order the caller asked for, and stops.
  *
- * ## Ordering
+ * ## What the privacy check costs
  *
- * Conversation order is the caller's, and attachments follow it — most recently
- * active mail first, newest attachment first within a conversation. Not
- * global arrival order: that would need an index over bound rows keyed by time,
- * which does not exist and would cost a stored field plus a backfill.
+ * Assignment is read live, per row, through the same predicate and resolver the
+ * retrieval gate uses — so reassigning a conversation moves its attachments
+ * here too, with nothing rewritten. The decision is cached per conversation, so
+ * a page of attachments from one thread pays for one conversation read.
  *
- * ## An id is not a capability
- *
- * Every conversation is re-checked here even though the caller resolved them
- * through a privacy-applied reader. The check is cheap — one row read per
- * conversation — and it keeps this query fail-closed on its own terms rather
- * than trusting whatever ids arrived.
+ * A row the caller cannot read is skipped, which means the walk may pass more
+ * rows than it keeps. `SCAN_CAP` bounds that, and it is reported: a caller who
+ * can read little should be told the reach was bounded rather than shown an
+ * empty list as if the inbox were empty.
  */
 
-import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { conversationAssignmentAllows } from '../lib/rls/helpers/conversation_assignment';
 import { conversationCallerResolver } from '../lib/rls/helpers/conversation_caller';
+
+/** Bound rows examined before the walk stops, however few were readable. */
+const SCAN_CAP = 200;
 
 /** One attachment, as a catalogue row rather than a retrieval hit. */
 export interface MailAttachmentListing {
@@ -60,9 +65,8 @@ export interface MailAttachmentListing {
 
 export interface MailAttachmentListingResult {
   readonly attachments: MailAttachmentListing[];
-  /** More attachments exist on the conversations reached than fit the limit.
-   *  Says nothing about conversations NOT reached — that bound belongs to
-   *  whoever chose the conversation list. */
+  /** The walk stopped before the end of the mail index — either the page filled
+   *  or the scan bound was reached. Not "the inbox holds nothing more". */
   readonly truncated: boolean;
 }
 
@@ -71,9 +75,11 @@ export async function listMailAttachments(
   args: {
     organizationId: string;
     userId?: string | undefined;
-    /** The conversations to look in, in the order they should be reported. */
-    conversationIds: readonly string[];
     limit: number;
+    /** Bound rows examined before stopping. Defaults to {@link SCAN_CAP}; the
+     *  internal query never overrides it. Present so a test can prove the
+     *  bound without seeding hundreds of rows. */
+    scanCap?: number;
   },
 ): Promise<MailAttachmentListingResult> {
   const caller = conversationCallerResolver(ctx, {
@@ -81,67 +87,64 @@ export async function listMailAttachments(
     ...(args.userId !== undefined ? { userId: args.userId } : {}),
   });
 
+  // Many attachments share one conversation, so the decision is cached per
+  // conversation rather than per row.
+  const decided = new Map<string, boolean>();
   const attachments: MailAttachmentListing[] = [];
-  let more = false;
+  let scanned = 0;
+  let truncated = false;
 
-  for (const rawId of args.conversationIds) {
+  for await (const row of ctx.db
+    .query('fileMetadata')
+    .withIndex('by_organizationId_and_mailReceivedAt', (q) =>
+      // Above `undefined` selects the rows that carry an arrival time, which is
+      // exactly the rows that arrived by mail.
+      q
+        .eq('organizationId', args.organizationId)
+        .gt('mailReceivedAt', undefined),
+    )
+    .order('desc')) {
     if (attachments.length >= args.limit) {
-      more = true;
+      truncated = true;
       break;
     }
-    const conversationId = ctx.db.normalizeId('conversations', rawId);
-    if (conversationId === null) continue;
-
-    const identity = await caller();
-    if (identity === null) return { attachments: [], truncated: false };
-
-    const conversation = await ctx.db.get(conversationId);
-    if (
-      conversation === null ||
-      conversation.organizationId !== args.organizationId
-    ) {
-      continue;
+    scanned += 1;
+    if (scanned > (args.scanCap ?? SCAN_CAP)) {
+      truncated = true;
+      break;
     }
-    const allowed = await conversationAssignmentAllows(conversation, {
-      isAdmin: identity.isAdmin,
-      userId: identity.userId,
-      hasTeam: (teamId) => identity.teamIds.has(teamId),
-    });
+    const conversationId = row.conversationId;
+    if (conversationId === undefined) continue;
+    if (row.lifecycleStatus === 'trashed') continue;
+
+    const key = String(conversationId);
+    let allowed = decided.get(key);
+    if (allowed === undefined) {
+      const identity = await caller();
+      if (identity === null) return { attachments: [], truncated: false };
+      const conversation = await ctx.db.get(conversationId);
+      allowed =
+        conversation !== null &&
+        conversation.organizationId === args.organizationId &&
+        (await conversationAssignmentAllows(conversation, {
+          isAdmin: identity.isAdmin,
+          userId: identity.userId,
+          hasTeam: (teamId) => identity.teamIds.has(teamId),
+        }));
+      decided.set(key, allowed);
+    }
     if (!allowed) continue;
 
-    // One exact index lookup per conversation, newest attachment first.
-    const rows: Doc<'fileMetadata'>[] = [];
-    for await (const row of ctx.db
-      .query('fileMetadata')
-      .withIndex('by_organizationId_and_conversationId', (q) =>
-        q
-          .eq('organizationId', args.organizationId)
-          .eq('conversationId', conversationId),
-      )
-      .order('desc')) {
-      if (row.lifecycleStatus === 'trashed') continue;
-      rows.push(row);
-      // One past the limit is enough to know more exist without reading a
-      // conversation's whole attachment history.
-      if (attachments.length + rows.length > args.limit) break;
-    }
-
-    for (const row of rows) {
-      if (attachments.length >= args.limit) {
-        more = true;
-        break;
-      }
-      attachments.push({
-        ref: String(row.storageId),
-        fileName: row.fileName,
-        contentType: row.contentType,
-        size: row.size,
-        conversationId: String(conversationId),
-        receivedAt: row._creationTime,
-        indexed: row.ragStatus === 'completed',
-      });
-    }
+    attachments.push({
+      ref: String(row.storageId),
+      fileName: row.fileName,
+      contentType: row.contentType,
+      size: row.size,
+      conversationId: key,
+      receivedAt: row.mailReceivedAt ?? row._creationTime,
+      indexed: row.ragStatus === 'completed',
+    });
   }
 
-  return { attachments, truncated: more };
+  return { attachments, truncated };
 }

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -186,6 +186,20 @@ export const fileMetadataTable = defineTable({
    * would be wrong the moment the conversation is reassigned.
    */
   conversationId: v.optional(v.id('conversations')),
+  /**
+   * When the mail carrying this attachment arrived. Set alongside
+   * `conversationId`, absent on every file that did not arrive by mail.
+   *
+   * Exists so "what has come in recently?" can be answered by an index walk
+   * rather than by collecting every bound row and sorting it. Convex has no
+   * partial indexes, so a field that is present only on mail attachments is
+   * what makes `by_organizationId_and_mailReceivedAt` a mail-only index.
+   *
+   * The mail's own date where the sync knows it, so importing old mail sorts by
+   * when it was sent rather than when it was imported. Falls back to the row's
+   * creation time, which is within minutes of arrival on a live sync.
+   */
+  mailReceivedAt: v.optional(v.number()),
   lifecycleStatus: v.optional(lifecycleStatusValidator),
   statusChangedAt: v.optional(v.number()),
 })
@@ -203,6 +217,14 @@ export const fileMetadataTable = defineTable({
   ])
   .index('by_org_user', ['organizationId', 'uploadedBy'])
   .index('by_org_contentHash', ['organizationId', 'contentHash'])
+  // Mail attachments newest-first. Only bound rows carry `mailReceivedAt`, so a
+  // range above `undefined` is a mail-only walk in true arrival order — which
+  // no other index gives: pairing with `conversationId` orders by conversation
+  // first, and the org index is dominated by rows that never arrived by mail.
+  .index('by_organizationId_and_mailReceivedAt', [
+    'organizationId',
+    'mailReceivedAt',
+  ])
   .index('by_organizationId_and_conversationId', [
     'organizationId',
     'conversationId',

--- a/services/platform/convex/migrations/framework/registry.gen.ts
+++ b/services/platform/convex/migrations/framework/registry.gen.ts
@@ -12,6 +12,7 @@ import type { ComponentMigration, DbMigration, MigrationMeta } from './types';
 import { migration as m0_4_1_01 } from '../versions/v0_4_1/01_automation_pins_to_bindings/migration';
 import { migration as m0_4_1_02 } from '../versions/v0_4_1/02_task_labels_to_catalog/migration';
 import { migration as m0_4_1_03 } from '../versions/v0_4_1/03_backfill_project_rollup_counts/migration';
+import { migration as m0_4_1_05 } from '../versions/v0_4_1/05_backfill_mail_attachment_received_at/migration';
 
 /** Every migration’s metadata, ordered by (semver, numericId). */
 export const ALL_META: readonly MigrationMeta[] = [
@@ -63,6 +64,18 @@ export const ALL_META: readonly MigrationMeta[] = [
     destructive: false,
     snapshot: 'none',
   },
+  {
+    id: "0.4.1/05_backfill_mail_attachment_received_at",
+    semver: "0.4.1",
+    numericId: 5,
+    slug: "backfill_mail_attachment_received_at",
+    title: "Backfill mail attachment arrival times",
+    description: "up stamps mailReceivedAt from the row's creation time on every fileMetadata row that carries a conversationId but no arrival time, so attachments bound before the field existed appear in the mail index; down clears mailReceivedAt on rows carrying a conversationId, restoring the pre-field shape.",
+    kind: 'db',
+    reversible: true,
+    destructive: false,
+    snapshot: 'none',
+  },
 ];
 
 const BY_ID: ReadonlyMap<string, MigrationMeta> = new Map(
@@ -81,6 +94,7 @@ export const DB_MIGRATIONS: Readonly<Record<string, DbMigration>> = {
   "0.4.1/01_automation_pins_to_bindings": composeDb(requireMeta("0.4.1/01_automation_pins_to_bindings"), m0_4_1_01),
   "0.4.1/02_task_labels_to_catalog": composeDb(requireMeta("0.4.1/02_task_labels_to_catalog"), m0_4_1_02),
   "0.4.1/03_backfill_project_rollup_counts": composeDb(requireMeta("0.4.1/03_backfill_project_rollup_counts"), m0_4_1_03),
+  "0.4.1/05_backfill_mail_attachment_received_at": composeDb(requireMeta("0.4.1/05_backfill_mail_attachment_received_at"), m0_4_1_05),
 };
 
 /** Runnable `component` migrations, keyed by meta.id. */

--- a/services/platform/convex/migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.test.ts
+++ b/services/platform/convex/migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+
+import { expect } from 'vitest';
+
+import { buildModules } from '../../../framework/test_helpers';
+import { defineMigrationTest } from '../../../testing/harness.testkit';
+
+const DIR =
+  'migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at';
+
+const ORG = 'org_mail_backfill';
+const CREATED = 1_700_000_000_000;
+
+// The harness runs the full ritual automatically: up through the real runner,
+// TRUE handler idempotency over migrated state, digest-equal down (the seeded
+// world must come back byte-for-byte), ledger transitions, snapshot hygiene,
+// and the destructive gate. This file provides DATA + migration-specific truth.
+defineMigrationTest({
+  id: '0.4.1/05_backfill_mail_attachment_received_at',
+  modules: buildModules(import.meta.glob('../../../../**/*.*s'), DIR),
+
+  async seed(ctx) {
+    const conversationId: string = await ctx.db.insert('conversations', {
+      organizationId: ORG,
+      subject: 'Application',
+      status: 'open',
+      channel: 'email',
+    });
+
+    // The row this migration exists for: bound before the field existed, so it
+    // is invisible to the mail index until stamped.
+    await ctx.db.insert('fileMetadata', {
+      organizationId: ORG,
+      storageId: 'blob_unstamped',
+      fileName: 'cv.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+      source: 'imap-smtp',
+      conversationId,
+    });
+
+    // Already stamped by the binder: `up` must leave it exactly as it is, and
+    // it must not be given the creation time instead.
+    await ctx.db.insert('fileMetadata', {
+      organizationId: ORG,
+      storageId: 'blob_stamped',
+      fileName: 'offer.pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+      source: 'imap-smtp',
+      conversationId,
+      mailReceivedAt: CREATED - 90_000,
+    });
+
+    // Never arrived by mail. Nothing to stamp — a Document Hub upload must not
+    // be pulled into the mail index.
+    await ctx.db.insert('fileMetadata', {
+      organizationId: ORG,
+      storageId: 'blob_unbound',
+      fileName: 'handbook.pdf',
+      contentType: 'application/pdf',
+      size: 4096,
+      source: 'user',
+    });
+  },
+
+  async expectUp(world) {
+    const rows = await world.run(
+      async (ctx: {
+        // oxlint-disable-next-line typescript/no-explicit-any -- convex-test world db
+        db: any;
+      }) => {
+        const all = await ctx.db.query('fileMetadata').collect();
+        return (
+          all as Array<{
+            storageId: string;
+            mailReceivedAt?: number;
+            _creationTime: number;
+          }>
+        ).map((row) => ({
+          storageId: row.storageId,
+          stamp: row.mailReceivedAt,
+          created: row._creationTime,
+        }));
+      },
+    );
+    const byId = new Map(rows.map((row) => [row.storageId, row]));
+
+    // Stamped from its own creation time, so it now sits in the mail index.
+    const unstamped = byId.get('blob_unstamped');
+    expect(unstamped?.stamp).toBe(unstamped?.created);
+
+    // An existing stamp is the binder's, and closer to the truth than the
+    // row's creation time — `up` must not overwrite it.
+    expect(byId.get('blob_stamped')?.stamp).toBe(CREATED - 90_000);
+
+    // Not mail: still absent from the index.
+    expect(byId.get('blob_unbound')?.stamp).toBeUndefined();
+  },
+});

--- a/services/platform/convex/migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.ts
+++ b/services/platform/convex/migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.ts
@@ -1,0 +1,68 @@
+/**
+ * Backfill mail attachment arrival times.
+ *
+ * `mailReceivedAt` is what puts an emailed attachment into
+ * `by_organizationId_and_mailReceivedAt`, the index the attachment listing
+ * walks. Convex has no partial indexes, so a field present only on bound rows
+ * is what makes that index mail-only — and a bound row without it is invisible
+ * to the listing entirely.
+ *
+ * Rows bound before the field existed carry no arrival time. The binder
+ * back-fills one whenever it touches a row again, but a conversation that has
+ * gone quiet is never revisited, so those attachments would stay unlistable for
+ * good. That is what this closes.
+ *
+ * `up` stamps the row's own creation time. The mail's true date is not
+ * recoverable here — it lives in the message metadata, and reading it per row
+ * would make a per-row transform fan out across another table — and on a live
+ * sync the two are within minutes of each other. Going forward the binder
+ * prefers the mail's date; this is the best available for history.
+ *
+ * `down` clears the field only where it equals the row's creation time — the
+ * exact value `up` writes. That is what makes it an inverse rather than a
+ * blanket wipe: a stamp the binder wrote from the mail's own date is somebody
+ * else's data and survives. The chain suite caught the blanket version, because
+ * clearing a stamp the seeded world already carried did not restore that world.
+ *
+ * Both directions are idempotent: `up` skips a row that already has a stamp,
+ * `down` skips a row that has none, so a replayed batch is a no-op. Nothing is
+ * destroyed in either direction, which is why `snapshot: 'none'` is sufficient.
+ */
+
+import type { GenericId } from 'convex/values';
+
+import { defineDbMigration } from '../../../framework/define';
+
+export const migration = defineDbMigration({
+  title: 'Backfill mail attachment arrival times',
+  description:
+    "up stamps mailReceivedAt from the row's creation time on every fileMetadata row that carries a conversationId but no arrival time, so attachments bound before the field existed appear in the mail index; down clears mailReceivedAt on rows carrying a conversationId, restoring the pre-field shape.",
+  destructive: false,
+  snapshot: 'none',
+  subjects: { tables: ['fileMetadata'] },
+  table: 'fileMetadata',
+
+  async up(ctx, doc) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runner paginates `table: 'fileMetadata'`, so every doc is a fileMetadata row
+    const id = doc._id as GenericId<'fileMetadata'>;
+    // Only mail attachments have an arrival time to record.
+    if (doc.conversationId === undefined) return;
+    // Already stamped: a replayed batch must not churn the row.
+    if (typeof doc.mailReceivedAt === 'number') return;
+    // `doc` is a generic document, so the creation time arrives untyped.
+    const createdAt = doc._creationTime;
+    if (typeof createdAt !== 'number') return;
+    await ctx.db.patch(id, { mailReceivedAt: createdAt });
+  },
+
+  async down(ctx, doc) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- as above
+    const id = doc._id as GenericId<'fileMetadata'>;
+    if (doc.conversationId === undefined) return;
+    // Clear ONLY what `up` wrote. A stamp that differs from the creation time
+    // came from the mail's own date, so it predates this migration or postdates
+    // it — either way it is not this migration's to remove.
+    if (doc.mailReceivedAt !== doc._creationTime) return;
+    await ctx.db.patch(id, { mailReceivedAt: undefined });
+  },
+});


### PR DESCRIPTION
Chat can list the emailed attachments a caller may read, newest arrival first, at a cost that does not grow with the table.

## Why

An emailed attachment has no listing surface anywhere in the product. It is not a Document Hub row, so it is absent from the Documents page and from `list kind="document"`, and its only appearance is on its own conversation in the Inbox. Retrieval was the sole way to discover one, which means guessing words inside a file whose name says nothing about why it was sent.

#3033 gave it a listing. This makes that listing correct and affordable, after three shapes that were neither:

- walking every `fileMetadata` row under a scan budget spent the budget on rows that can never qualify — measured on a live deployment, 3,671 rows of which 3 carried a conversation — so reachability depended on creation position and the listing emptied as the table grew;
- walking only the bound rows fixed reachability but still read up to the whole budget to return one page, and above it reported "most recent" from an arbitrary window, because that index orders by conversation rather than by time;
- leading with conversations bounded the cost but ordered by conversation activity, so a fresh application sorted below an older one whose thread happened to get a reply.

## What changed

- `fileMetadata` gains `mailReceivedAt`, set alongside `conversationId`, and `by_organizationId_and_mailReceivedAt`. Convex has no partial indexes, so a field present only on bound rows is what makes that index mail-only: a range above `undefined` walks exactly the attachments that arrived by mail, in arrival order.
- The reader reads `limit` rows and stops.
- The stamp prefers the mail's own date, threaded from the sync, so importing old mail sorts by when it was sent. It falls back to the row's creation time, within minutes on a live poll.
- The binder writes the stamp whenever it is missing, so a row bound before the field existed is repaired the next time its mail is touched.
- Migration `v0_4_1/05` backfills the rest, because a quiet conversation is never revisited and an unstamped row is invisible to the listing. The field itself needs no migration — a new optional field is data-safe growth, which `migrations:check` confirms and a snapshot refresh records. `down` clears only the value `up` writes, so a stamp taken from a mail's own date survives a rollback.

## Risk

**An empty list does not mean an empty inbox.** The walk checks each attachment against its conversation, so a caller who can read few conversations is rejected on most rows. It stops after 200 examined and reports that it stopped, so the answer is "none of the most recent were visible to you" rather than "there are none". The residual limit: with that bound, a caller who can read very little may see nothing even though older readable attachments exist.

**The per-row permission check is not redundant.** The rows already come from an org-scoped index, so re-loading each conversation looks removable. It is not: an attachment's conversation id is a reference, not permission to read it. The check applies the live assignment rule through the same predicate the retrieval gate uses, which is also what makes a reassignment move attachments with no re-indexing. Removing it fails a test.

**`down` also clears a fallback stamp.** When the sync cannot parse a mail's date it stamps the row's creation time, which is the same value the migration writes — so a rollback cannot tell the two apart and clears both. Harmless: the binder re-stamps the row the next time its mail is touched. A stamp taken from a real mail date is untouched.

## Tests

14 at the reader through convex-test: the privacy matrix (admin, team member, individual assignee, disabled role, unidentified caller, foreign conversation), arrival ordering against conversation activity, 700 unbound rows left untouched, truncation reported when the page fills and not when it doesn't, the scan bound reported rather than looking empty, unbound and trashed rows excluded, the `indexed` flag, and the corpus ref.

4 at the binder for the stamp: from the mail's date, from the creation time when unknown, back-filled on a row bound before the field existed, and left alone when already recorded.

The migration's own ritual — up through the real runner, handler idempotency, digest-equal down — plus the chain and versions suites: 140 tests.

Mutation-tested: each behaviour was deliberately broken in the source, one at a time, to confirm a test catches it. All 11 were caught, including ascending order, walking the wrong index, and never writing the stamp.

## Scope

Does not index message bodies (#3015). Does not give attachments a Documents-page surface — this is the chat tool only. Does not page; the listing narrows.

Gate: typecheck, `oxlint --type-aware`, oxfmt, SAST 0 findings, `migrations:check`, platform 75,598 tests. One unrelated failure in `audit_logs/integrity_check.test.ts` — the flake filed as #3036; untouched by this diff and 17/17 standalone twice.