### PR TITLE
fix(platform): pause website scans when the knowledge db is unreachable

### DIFF
--- a/services/platform/app/features/websites/components/website-row-actions.test.tsx
+++ b/services/platform/app/features/websites/components/website-row-actions.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
+
+const mockResumeScanning = vi.fn();
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: (ns: string) => ({
@@ -30,6 +34,7 @@ vi.mock('@/app/hooks/use-toast', () => ({
 vi.mock('../hooks/mutations', () => ({
   useDeleteWebsite: () => ({ mutateAsync: vi.fn() }),
   useUpdateWebsite: () => ({ mutateAsync: vi.fn() }),
+  useResumeScanning: () => ({ mutate: mockResumeScanning }),
 }));
 
 vi.mock('./website-edit-dialog', () => ({
@@ -50,11 +55,50 @@ const mockWebsite = {
   scanInterval: '6h',
 } as Parameters<typeof WebsiteRowActions>[0]['website'];
 
+// A site the crawler paused after repeated failures to reach the knowledge
+// database (metadata.scanPausedAt is the flag recordScanFailure writes).
+const pausedWebsite = {
+  ...mockWebsite,
+  status: 'error',
+  metadata: { scanPausedAt: 1700000100000 },
+} as Parameters<typeof WebsiteRowActions>[0]['website'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('WebsiteRowActions', () => {
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<WebsiteRowActions website={mockWebsite} />);
       await checkAccessibility(container);
+    });
+  });
+
+  describe('resume scanning', () => {
+    const openMenu = async () => {
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole('button', { name: 'common.actions.openMenu' }),
+      );
+      return user;
+    };
+
+    it('offers resume only while the crawler has paused the site', async () => {
+      render(<WebsiteRowActions website={mockWebsite} />);
+      await openMenu();
+      expect(
+        screen.queryByText('websites.resumeScanning'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('resumes a paused site from the row menu', async () => {
+      render(<WebsiteRowActions website={pausedWebsite} />);
+      const user = await openMenu();
+      await user.click(screen.getByText('websites.resumeScanning'));
+      expect(mockResumeScanning).toHaveBeenCalledWith({
+        websiteId: 'website-1',
+      });
     });
   });
 });

--- a/services/platform/app/features/websites/components/website-row-actions.tsx
+++ b/services/platform/app/features/websites/components/website-row-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Play, Trash2 } from 'lucide-react';
 import { useMemo } from 'react';
 
 import {
@@ -11,6 +11,8 @@ import { useAbility } from '@/app/hooks/use-ability';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
+import { useResumeScanning } from '../hooks/mutations';
+import { isScanPaused } from '../lib/scan-paused';
 import { DeleteWebsiteDialog } from './website-delete-dialog';
 import { EditWebsiteDialog } from './website-edit-dialog';
 
@@ -20,12 +22,28 @@ interface WebsiteRowActionsProps {
 
 export function WebsiteRowActions({ website }: WebsiteRowActionsProps) {
   const { t: tCommon } = useT('common');
+  const { t } = useT('websites');
   const ability = useAbility();
   const canWrite = ability.can('write', 'knowledgeWrite');
   const dialogs = useEntityRowDialogs(['edit', 'delete']);
+  const { mutate: resumeScanning } = useResumeScanning();
+  const paused = isScanPaused(website);
 
   const actions = useMemo(
     () => [
+      // Only offered while the crawler has paused this site (repeated
+      // failures to reach the knowledge database): clears the pause and
+      // starts a scan right away, so the fix is verified immediately.
+      ...(paused
+        ? [
+            {
+              key: 'resume',
+              label: t('resumeScanning'),
+              icon: Play,
+              onClick: () => resumeScanning({ websiteId: website._id }),
+            },
+          ]
+        : []),
       {
         key: 'edit',
         label: tCommon('actions.edit'),
@@ -40,7 +58,7 @@ export function WebsiteRowActions({ website }: WebsiteRowActionsProps) {
         destructive: true,
       },
     ],
-    [tCommon, dialogs.open],
+    [tCommon, t, dialogs.open, paused, resumeScanning, website._id],
   );
 
   if (!canWrite) return null;

--- a/services/platform/app/features/websites/components/website-view-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-view-dialog.tsx
@@ -37,6 +37,8 @@ import type {
 } from '@/convex/websites/types';
 import { useT } from '@/lib/i18n/client';
 
+import { isScanPaused } from '../lib/scan-paused';
+
 const PAGE_SIZE = 20;
 
 const statusVariant = {
@@ -326,30 +328,44 @@ export function ViewWebsiteDialog({
         label: t('viewDialog.status'),
         value: (
           <Row gap={2} wrap>
-            <Badge
-              variant={
-                website.status && website.status in statusVariant
-                  ? statusVariant[website.status]
-                  : 'outline'
-              }
-              dot
-            >
-              {(website.status &&
-                (
-                  {
-                    idle: t('filter.status.idle'),
-                    scanning: t('filter.status.scanning'),
-                    active: t('filter.status.active'),
-                    error: t('filter.status.error'),
-                    deleting: t('filter.status.deleting'),
-                  } satisfies Record<string, string>
-                )[website.status]) ||
-                website.status ||
-                t('viewDialog.unknown')}
-            </Badge>
+            {isScanPaused(website) ? (
+              // Paused (repeated failures to reach the knowledge database)
+              // wins over the stored `error` status — this site stopped
+              // retrying and needs a manual resume.
+              <Badge variant="orange" dot>
+                {t('scanPausedBadge')}
+              </Badge>
+            ) : (
+              <Badge
+                variant={
+                  website.status && website.status in statusVariant
+                    ? statusVariant[website.status]
+                    : 'outline'
+                }
+                dot
+              >
+                {(website.status &&
+                  (
+                    {
+                      idle: t('filter.status.idle'),
+                      scanning: t('filter.status.scanning'),
+                      active: t('filter.status.active'),
+                      error: t('filter.status.error'),
+                      deleting: t('filter.status.deleting'),
+                    } satisfies Record<string, string>
+                  )[website.status]) ||
+                  website.status ||
+                  t('viewDialog.unknown')}
+              </Badge>
+            )}
             {website.status === 'error' && website.metadata?.lastSyncError && (
               <Text variant="caption" className="text-destructive">
                 {String(website.metadata.lastSyncError)}
+              </Text>
+            )}
+            {isScanPaused(website) && (
+              <Text variant="caption" className="text-muted-foreground">
+                {t('viewDialog.scanPausedNotice')}
               </Text>
             )}
           </Row>

--- a/services/platform/app/features/websites/hooks/mutations.ts
+++ b/services/platform/app/features/websites/hooks/mutations.ts
@@ -16,3 +16,7 @@ export function useUpdateWebsite() {
 export function useSyncWebsiteStatuses() {
   return useConvexAction(api.websites.actions.syncStatuses);
 }
+
+export function useResumeScanning() {
+  return useConvexAction(api.websites.actions.resumeScanning);
+}

--- a/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
+++ b/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
@@ -9,6 +9,7 @@ import { CopyableTimestamp } from '@/app/components/ui/data-display/copyable-tim
 import { createTableConfigHook } from '@/app/hooks/use-table-config-factory';
 
 import { WebsiteRowActions } from '../components/website-row-actions';
+import { isScanPaused } from '../lib/scan-paused';
 
 const statusVariant = {
   active: 'green',
@@ -56,6 +57,16 @@ export const useWebsitesTableConfig = createTableConfigHook<'websites'>(
       header: tTables('headers.status'),
       size: 108,
       cell: ({ row }) => {
+        // Paused (repeated failures to reach the knowledge database) wins
+        // over the stored status: the row keeps `error`, but "Error" alone
+        // would suggest the crawler is still retrying.
+        if (isScanPaused(row.original)) {
+          return (
+            <Badge variant="orange" dot>
+              {tEntity('scanPausedBadge')}
+            </Badge>
+          );
+        }
         const s = row.original.status;
         const variant = s && s in statusVariant ? statusVariant[s] : 'outline';
         const statusLabels: Record<string, string> = {

--- a/services/platform/app/features/websites/lib/scan-paused.ts
+++ b/services/platform/app/features/websites/lib/scan-paused.ts
@@ -1,0 +1,12 @@
+import type { Doc } from '@/convex/_generated/dataModel';
+
+/**
+ * Whether this website's scans are paused — the `metadata.scanPausedAt` flag
+ * the crawler writes after repeated failures to reach the organization's
+ * knowledge database (see convex/websites/scan_scheduling.ts). Paused rows
+ * keep `status: 'error'`; this flag is what distinguishes "failed, will
+ * retry" from "gave up, needs a manual resume".
+ */
+export function isScanPaused(website: Doc<'websites'>): boolean {
+  return typeof website.metadata?.scanPausedAt === 'number';
+}

--- a/services/platform/convex/knowledge/crawl_action.ts
+++ b/services/platform/convex/knowledge/crawl_action.ts
@@ -26,6 +26,13 @@
  * organization's own database when it brought one. On a shared database a
  * domain is crawled once for all member organizations; the claim is what
  * keeps two of them from crawling it concurrently.
+ *
+ * When that database itself cannot be reached (a rotated credential, DNS, a
+ * refused connection), the failure is recorded on the Convex `websites` row —
+ * the only store still standing — instead of the corpus. Failed scans back
+ * off to a bounded retry window, and repeated connection failures pause the
+ * site's scans and notify the organization's admins; the policy lives in
+ * `websites/scan_scheduling.ts`.
  */
 
 import { computeContentHash } from '@tale/shared/utils/hashing';
@@ -59,11 +66,16 @@ import {
 } from '../lib/http/safe_fetch';
 import { extractText } from '../lib/knowledge/extraction/router';
 import { renderUrlsInSandbox } from '../node_only/sandbox/render_fetch';
+import { isDueForScan } from '../websites/scan_scheduling';
 import { readOrgEmbeddingConfig } from './connection';
 import { MAX_URLS_PER_DOMAIN, URL_INSERT_BATCH } from './crawl';
 import { pinDimensions } from './dimensions';
 import { Embedder, embedderForOrg, EmbeddingNotConfigured } from './embedding';
-import { getKnowledgePoolForOrg, resolveOrgUrl } from './pool';
+import {
+  getKnowledgePoolForOrg,
+  isConnectionFailure,
+  resolveOrgUrl,
+} from './pool';
 
 /** One continuation link crawls at most this long before rescheduling —
  * far under the ~10-minute point where the runtime kills a node action
@@ -162,7 +174,21 @@ export const scanWebsite = internalAction({
       orgSlug: args.orgSlug,
       organizationId: args.organizationId,
     };
-    const sql = await getKnowledgePoolForOrg(args.orgSlug);
+
+    // Acquiring the pool runs real SQL on a bring-your-own database (the
+    // corpus-schema bootstrap), so a rotated credential or an unreachable
+    // host throws right here. Uncaught, this was TALE-PROJECT-106: the error
+    // escaped the action, nothing was recorded anywhere, and the scheduler
+    // re-queued the domain forever.
+    let sql: Sql;
+    try {
+      sql = await getKnowledgePoolForOrg(args.orgSlug);
+    } catch (error) {
+      await recordFailureOnWebsiteRow(ctx, identity, error, {
+        corpusUnreachable: true,
+      });
+      return null;
+    }
 
     try {
       const kind = await domainKind(sql, args.domain);
@@ -315,9 +341,32 @@ export const scanWebsite = internalAction({
         [args.domain],
       );
       console.log(`[crawl] ${args.domain}: scan finished`);
+      // The scan completed, so the site leaves the failure-retry cadence and
+      // returns to its own interval. Best-effort: a hiccup here must not
+      // flip a finished scan into the error path.
+      await ctx
+        .runMutation(internal.websites.internal_mutations.clearScanFailures, {
+          organizationId: args.organizationId,
+          domain: args.domain,
+        })
+        .catch((clearError: unknown) => {
+          console.warn(
+            `[crawl] ${args.domain}: could not clear the failure bookkeeping:`,
+            clearError instanceof Error ? clearError.message : clearError,
+          );
+        });
     } catch (error) {
+      if (isConnectionFailure(error)) {
+        // The corpus database dropped away mid-scan. Recording the failure
+        // into it would fail with it, and the row-sync fan-out below reads
+        // it — the Convex row is the only store still standing, so record
+        // there and stop.
+        await recordFailureOnWebsiteRow(ctx, identity, error, {
+          corpusUnreachable: true,
+        });
+        return null;
+      }
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`[crawl] ${args.domain}: scan failed:`, message);
       await sql
         .unsafe(
           `UPDATE ${PUBLIC_WEB_SCHEMA}.websites
@@ -331,6 +380,12 @@ export const scanWebsite = internalAction({
             markError,
           );
         });
+      // Stamp the attempt on the Convex row too: it advances the scheduler's
+      // clock (the backoff), where the corpus-side marker alone left the
+      // domain due again on the very next five-minute tick.
+      await recordFailureOnWebsiteRow(ctx, identity, error, {
+        corpusUnreachable: false,
+      });
     }
 
     await fanOutRowSync(ctx, sql, args.domain);
@@ -353,19 +408,9 @@ export const scanDueWebsites = internalAction({
       {},
     );
     const now = Date.now();
-    const due = websites.filter((site) => {
-      if (site.status === 'deleting') return false;
-      const intervalMs = site.scanIntervalSeconds * 1000;
-      if (site.status === 'scanning') {
-        // A healthy scan refreshes its corpus claim, not the Convex row —
-        // treat a row stuck in `scanning` for two hours as crashed and let
-        // the corpus-side claim takeover decide.
-        const since = site.lastScannedAt ?? site.createdAt;
-        return now - since > 2 * 60 * 60 * 1000;
-      }
-      if (site.lastScannedAt === undefined) return true;
-      return now - site.lastScannedAt > intervalMs;
-    });
+    // The policy (intervals, stuck-scan takeover, failure backoff, pause) is
+    // the pure `isDueForScan` in websites/scan_scheduling.ts.
+    const due = websites.filter((site) => isDueForScan(site, now));
 
     const batch = due.slice(0, MAX_SCANS_PER_TICK);
     if (due.length > batch.length) {
@@ -1003,6 +1048,48 @@ async function boilerplateHashes(
     [domain],
   );
   return new Set(rows.map((row) => row.paragraph_hash));
+}
+
+/**
+ * Record a failed scan attempt on the organization's Convex `websites` row —
+ * for connection-class failures the ONLY reachable store — and log the pause
+ * transition when the failure streak crosses the threshold. Never throws: a
+ * failure to record must not mask the scan failure being recorded.
+ */
+async function recordFailureOnWebsiteRow(
+  ctx: ActionCtx,
+  identity: ScanIdentity,
+  error: unknown,
+  options: { corpusUnreachable: boolean },
+): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(
+    `[crawl] ${identity.domain}: scan failed${
+      options.corpusUnreachable ? ' (knowledge database unreachable)' : ''
+    }:`,
+    message,
+  );
+  try {
+    const { paused } = await ctx.runMutation(
+      internal.websites.internal_mutations.recordScanFailure,
+      {
+        organizationId: identity.organizationId,
+        domain: identity.domain,
+        message,
+        corpusUnreachable: options.corpusUnreachable,
+      },
+    );
+    if (paused) {
+      console.warn(
+        `[crawl] ${identity.domain}: scans paused after repeated connection failures; org admins notified`,
+      );
+    }
+  } catch (recordError) {
+    console.error(
+      `[crawl] ${identity.domain}: could not record the failure on the websites row:`,
+      recordError instanceof Error ? recordError.message : recordError,
+    );
+  }
 }
 
 /** Push the corpus-side truth onto every member organization's Convex row —

--- a/services/platform/convex/knowledge/pool.test.ts
+++ b/services/platform/convex/knowledge/pool.test.ts
@@ -14,6 +14,7 @@ import {
   getKnowledgePool,
   getKnowledgePoolForOrg,
   invalidateOrgUrl,
+  isConnectionFailure,
   markBm25Unavailable,
   resolveOrgUrl,
   setPoolFactory,
@@ -296,5 +297,65 @@ describe('the deployment default connection string', () => {
       'postgresql://tale:secret@knowledge-db:5432/tale_knowledge',
     );
     process.env.KNOWLEDGE_DATABASE_URL = DEFAULT_URL;
+  });
+});
+
+describe('connection-failure classification', () => {
+  /**
+   * The distinction under test: a connection-class failure means the database
+   * itself is unreachable, so recording anything INTO it is futile — the
+   * crawl engine must record on the Convex row instead. Misclassifying a
+   * statement error as connection-class would hide real scan bugs from the
+   * corpus-side status; missing a connection error re-creates
+   * TALE-PROJECT-106 (an uncaught auth failure retried forever).
+   */
+  function withCode(code: string): Error {
+    return Object.assign(new Error(`failure carrying ${code}`), { code });
+  }
+
+  it('classifies the failures that mean the database is unreachable', () => {
+    // Server-reported SQLSTATEs: a rotated credential, connection
+    // exceptions, a missing database, a server refusing connections.
+    for (const code of [
+      '28P01',
+      '28000',
+      '08006',
+      '08001',
+      '08P01',
+      '3D000',
+      '57P03',
+    ]) {
+      expect(isConnectionFailure(withCode(code)), code).toBe(true);
+    }
+    // Below the protocol: postgres.js lifecycle codes and the Node system
+    // errors that surface through it.
+    for (const code of [
+      'CONNECT_TIMEOUT',
+      'CONNECTION_CLOSED',
+      'CONNECTION_ENDED',
+      'ECONNREFUSED',
+      'ECONNRESET',
+      'ENOTFOUND',
+      'EAI_AGAIN',
+      'ETIMEDOUT',
+    ]) {
+      expect(isConnectionFailure(withCode(code)), code).toBe(true);
+    }
+  });
+
+  it('leaves statement-level failures alone — the database answered', () => {
+    // An FK violation (the Jul 18 website_urls incident), missing
+    // tables/columns mid-migration, syntax errors, index limits, corruption:
+    // all failures OF a statement, all recordable in the corpus itself.
+    for (const code of ['23503', '42P01', '42703', '42601', '54000', 'XX000']) {
+      expect(isConnectionFailure(withCode(code)), code).toBe(false);
+    }
+  });
+
+  it('never classifies an error that carries no code', () => {
+    expect(isConnectionFailure(new Error('boom'))).toBe(false);
+    expect(isConnectionFailure('password authentication failed')).toBe(false);
+    expect(isConnectionFailure(null)).toBe(false);
+    expect(isConnectionFailure(undefined)).toBe(false);
   });
 });

--- a/services/platform/convex/knowledge/pool.ts
+++ b/services/platform/convex/knowledge/pool.ts
@@ -317,6 +317,55 @@ export function isDataCorrupted(err: unknown): boolean {
   return sqlState(err) === 'XX001';
 }
 
+/** SQLSTATE classes where the failure is about REACHING the database, not
+ * about the statement: 08 (connection exception) and 28 (invalid
+ * authorization — a rotated or revoked credential). */
+const CONNECTION_SQLSTATE_CLASSES = new Set(['08', '28']);
+
+/** Single connection-class SQLSTATEs outside those classes: 3D000 (the
+ * database does not exist) and 57P03 (the server is not accepting
+ * connections). */
+const CONNECTION_SQLSTATES = new Set(['3D000', '57P03']);
+
+/** Errors thrown below the protocol: postgres.js's own connection lifecycle
+ * codes plus the Node system errors that surface through it (DNS, refused,
+ * reset, unreachable). */
+const CONNECTION_ERRNO_CODES = new Set([
+  'CONNECT_TIMEOUT',
+  'CONNECTION_CLOSED',
+  'CONNECTION_ENDED',
+  'CONNECTION_DESTROYED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+]);
+
+/**
+ * Whether an error means the database itself could not be reached or used at
+ * all — bad credentials, DNS, refused/reset connections, a missing database —
+ * as opposed to a statement that failed against a healthy connection.
+ *
+ * The distinction matters to callers whose FALLBACK STORE is the same
+ * database: recording a failure into an unreachable corpus loses the record,
+ * so a connection-class failure has to be reported somewhere else (the crawl
+ * engine records it on the Convex `websites` row).
+ */
+export function isConnectionFailure(err: unknown): boolean {
+  const code = sqlState(err);
+  if (code === '') return false;
+  if (CONNECTION_ERRNO_CODES.has(code)) return true;
+  if (code.length !== 5) return false;
+  return (
+    CONNECTION_SQLSTATES.has(code) ||
+    CONNECTION_SQLSTATE_CLASSES.has(code.slice(0, 2))
+  );
+}
+
 function sqlState(err: unknown): string {
   if (err instanceof Error && 'code' in err && typeof err.code === 'string') {
     return err.code;

--- a/services/platform/convex/notifications/notification_messages.ts
+++ b/services/platform/convex/notifications/notification_messages.ts
@@ -61,6 +61,9 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
     auditIntegrityUnverifiable: "Audit log signatures can't be verified",
     auditIntegrityUnverifiableDetails:
       "This organization's audit log checkpoints are signed, but no signing key is configured to verify them: {reason}. Set TALE_AUDIT_SIGNING_KEY to restore tamper-evidence — this is a configuration gap, not detected tampering.",
+    websiteScanPaused: 'Website scans paused: {domain}',
+    websiteScanPausedDetails:
+      "Scans of {domain} were paused after {failures} consecutive attempts couldn't reach this organization's knowledge database. Check the connection under Settings → Data residency, then resume scanning from the Websites page.",
     dsarScheduled: 'Erasure request scheduled',
     dsarScheduledBody:
       'An erasure request was filed for a member of this organization. It runs in {coolingOffHours} hours — open the receipt to review or cancel it.',
@@ -131,6 +134,9 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
       'Audit-Log-Signaturen können nicht überprüft werden',
     auditIntegrityUnverifiableDetails:
       'Die Audit-Log-Checkpoints dieser Organisation sind signiert, aber es ist kein Signaturschlüssel zur Überprüfung konfiguriert: {reason}. Setze TALE_AUDIT_SIGNING_KEY, um die Manipulationssicherheit wiederherzustellen — das ist eine Konfigurationslücke, keine festgestellte Manipulation.',
+    websiteScanPaused: 'Website-Scans pausiert: {domain}',
+    websiteScanPausedDetails:
+      'Die Scans von {domain} wurden pausiert, nachdem die Wissensdatenbank dieser Organisation {failures} Mal in Folge nicht erreichbar war. Prüfe die Verbindung unter Einstellungen → Datenresidenz und setze die Scans danach auf der Websites-Seite fort.',
     dsarScheduled: 'Löschungsanfrage geplant',
     dsarScheduledBody:
       'Eine Löschungsanfrage wurde für ein Mitglied dieser Organisation eingereicht. Sie wird in {coolingOffHours} Stunden ausgeführt — öffne den Beleg, um sie zu prüfen oder abzubrechen.',
@@ -204,6 +210,9 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
       "Les signatures du journal d'audit ne peuvent pas être vérifiées",
     auditIntegrityUnverifiableDetails:
       "Les points de contrôle du journal d'audit de cette organisation sont signés, mais aucune clé de signature n'est configurée pour les vérifier : {reason}. Définis TALE_AUDIT_SIGNING_KEY pour rétablir la protection contre l'altération — il s'agit d'une lacune de configuration, pas d'une altération détectée.",
+    websiteScanPaused: 'Analyses du site web suspendues : {domain}',
+    websiteScanPausedDetails:
+      "Les analyses de {domain} ont été suspendues après {failures} tentatives consécutives sans parvenir à joindre la base de connaissances de cette organisation. Vérifie la connexion sous Paramètres → Résidence des données, puis reprends l'analyse depuis la page Sites web.",
     dsarScheduled: "Demande d'effacement planifiée",
     dsarScheduledBody:
       "Une demande d'effacement a été déposée concernant un membre de cette organisation. Elle s'exécute dans {coolingOffHours} heures — ouvre le reçu pour la consulter ou l'annuler.",

--- a/services/platform/convex/websites/actions.ts
+++ b/services/platform/convex/websites/actions.ts
@@ -303,6 +303,50 @@ export const updateWebsite = action({
   },
 });
 
+/**
+ * Resume a website whose scans were paused after repeated failures to reach
+ * the organization's knowledge database (see `scan_scheduling.ts`), and kick
+ * a scan immediately so the fix is verified now instead of on the next
+ * interval. Clears the whole failure bookkeeping: a resume is a fresh start,
+ * and if the connection is still broken the pause re-arms after the usual
+ * threshold — with a fresh admin notification.
+ */
+export const resumeScanning = action({
+  args: {
+    websiteId: v.id('websites'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { website } = await loadOwnedWebsite(ctx, args.websiteId);
+    const orgSlug = await orgSlugFromId(ctx, website.organizationId);
+
+    await ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
+      websiteId: args.websiteId,
+      status: 'scanning',
+      metadata: {
+        // Cleared with null, never undefined — undefined would not survive
+        // serialization and the metadata merge would keep the stale values.
+        scanPausedAt: null,
+        corpusConnectionFailures: null,
+        lastScanAttemptAt: null,
+        lastSyncError: null,
+      },
+    });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.knowledge.crawl_action.scanWebsite,
+      {
+        domain: website.domain,
+        orgSlug,
+        organizationId: website.organizationId,
+      },
+    );
+
+    return null;
+  },
+});
+
 export const syncStatuses = action({
   args: {
     organizationId: v.string(),

--- a/services/platform/convex/websites/internal_mutations.ts
+++ b/services/platform/convex/websites/internal_mutations.ts
@@ -2,7 +2,13 @@ import { ConvexError, v } from 'convex/values';
 
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { internalMutation } from '../_generated/server';
+import { writeNotificationForOrgs } from '../notifications/helpers';
 import * as WebsitesHelpers from './helpers';
+import {
+  CONNECTION_FAILURES_BEFORE_PAUSE,
+  connectionFailureCount,
+  scanPausedAt,
+} from './scan_scheduling';
 import {
   isValidScanInterval,
   SCAN_INTERVAL_VALUES,
@@ -49,6 +55,115 @@ export const deleteWebsite = internalMutation({
   returns: v.string(),
   handler: async (ctx, args) => {
     return await WebsitesHelpers.deleteWebsite(ctx, args.websiteId);
+  },
+});
+
+/**
+ * Record a failed scan on the organization's `websites` row — the store that
+ * stays reachable when the corpus database itself is the problem (the crawl
+ * engine's own failure marker lives in that corpus, so for connection-class
+ * failures this row is the ONLY record; see TALE-PROJECT-106).
+ *
+ * Every failure stamps `metadata.lastScanAttemptAt`, which is what backs the
+ * scheduler off to the bounded retry window instead of re-queueing the domain
+ * on every five-minute tick. `corpusUnreachable` failures additionally count
+ * toward the pause threshold; a reachable-but-failed scan resets the streak
+ * (the database answered, so the configuration is not the problem). Crossing
+ * the threshold pauses the site's scans and notifies the org's admins —
+ * once per incident: a site that is already paused never re-notifies until
+ * someone resumes it.
+ */
+export const recordScanFailure = internalMutation({
+  args: {
+    organizationId: v.string(),
+    domain: v.string(),
+    message: v.string(),
+    // The corpus database could not be reached at all (bad credential, DNS,
+    // refused) — a configuration problem, not a flaky page or provider.
+    corpusUnreachable: v.boolean(),
+  },
+  returns: v.object({ paused: v.boolean() }),
+  handler: async (ctx, args) => {
+    const website = await WebsitesHelpers.getWebsiteByDomain(ctx, {
+      organizationId: args.organizationId,
+      domain: args.domain,
+    });
+    if (!website || website.status === 'deleting') return { paused: false };
+
+    const failures = args.corpusUnreachable
+      ? connectionFailureCount(website.metadata) + 1
+      : 0;
+    const alreadyPaused = scanPausedAt(website.metadata) !== null;
+    const pauseNow =
+      args.corpusUnreachable &&
+      !alreadyPaused &&
+      failures >= CONNECTION_FAILURES_BEFORE_PAUSE;
+    const now = Date.now();
+
+    await WebsitesHelpers.updateWebsite(ctx, {
+      websiteId: website._id,
+      status: 'error',
+      metadata: {
+        lastSyncError: args.message.slice(0, 1000),
+        lastScanAttemptAt: now,
+        // Cleared with null, never undefined: undefined would not survive
+        // serialization and the metadata merge would keep the stale value.
+        corpusConnectionFailures: failures > 0 ? failures : null,
+        ...(pauseNow ? { scanPausedAt: now } : {}),
+      },
+    });
+
+    if (pauseNow) {
+      await writeNotificationForOrgs(ctx, {
+        organizationIds: [args.organizationId],
+        category: 'security',
+        severity: 'warning',
+        // Resolved client-side against the `notifications` i18n namespace;
+        // the Slack sink renders the mirrored strings in
+        // notification_messages.ts.
+        titleKey: 'websiteScanPaused',
+        bodyKey: 'websiteScanPausedDetails',
+        params: { domain: args.domain, failures },
+      });
+    }
+    return { paused: pauseNow };
+  },
+});
+
+/**
+ * Clear the failure bookkeeping after a scan completed: the site leaves the
+ * bounded failure-retry cadence and returns to its own interval. Also clears
+ * a pause — a scan can only have run past a pause when an admin resumed it
+ * or an already-queued attempt succeeded, and either way a completed scan
+ * proves the connection works again.
+ */
+export const clearScanFailures = internalMutation({
+  args: {
+    organizationId: v.string(),
+    domain: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const website = await WebsitesHelpers.getWebsiteByDomain(ctx, {
+      organizationId: args.organizationId,
+      domain: args.domain,
+    });
+    if (!website) return null;
+    const metadata = website.metadata ?? {};
+    const dirty =
+      metadata.lastScanAttemptAt != null ||
+      metadata.corpusConnectionFailures != null ||
+      metadata.scanPausedAt != null;
+    if (!dirty) return null;
+    await WebsitesHelpers.updateWebsite(ctx, {
+      websiteId: website._id,
+      metadata: {
+        lastScanAttemptAt: null,
+        corpusConnectionFailures: null,
+        scanPausedAt: null,
+      },
+    });
+    return null;
   },
 });
 

--- a/services/platform/convex/websites/internal_queries.ts
+++ b/services/platform/convex/websites/internal_queries.ts
@@ -6,6 +6,11 @@ import { getOrganizationMember } from '../lib/rls/organization/get_organization_
 import * as WebsitesHelpers from './helpers';
 import { scanIntervalToSeconds } from './internal_actions';
 import { listWebsitesPaginated as listWebsitesPaginatedHelper } from './list_websites_paginated';
+import {
+  connectionFailureCount,
+  lastScanAttemptAt,
+  scanPausedAt,
+} from './scan_scheduling';
 
 export const getWebsite = internalQuery({
   args: {
@@ -71,8 +76,11 @@ export const listWebsitesForScanScheduling = internalQuery({
       organizationId: v.string(),
       scanIntervalSeconds: v.number(),
       lastScannedAt: v.optional(v.number()),
+      lastAttemptAt: v.optional(v.number()),
       status: v.optional(v.string()),
       createdAt: v.number(),
+      connectionFailures: v.number(),
+      scanPaused: v.boolean(),
     }),
   ),
   handler: async (ctx) => {
@@ -82,8 +90,11 @@ export const listWebsitesForScanScheduling = internalQuery({
       organizationId: website.organizationId,
       scanIntervalSeconds: scanIntervalToSeconds(website.scanInterval),
       lastScannedAt: website.lastScannedAt,
+      lastAttemptAt: lastScanAttemptAt(website.metadata) ?? undefined,
       status: website.status,
       createdAt: website._creationTime,
+      connectionFailures: connectionFailureCount(website.metadata),
+      scanPaused: scanPausedAt(website.metadata) !== null,
     }));
   },
 });

--- a/services/platform/convex/websites/record_scan_failure.test.ts
+++ b/services/platform/convex/websites/record_scan_failure.test.ts
@@ -1,0 +1,185 @@
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+import { CONNECTION_FAILURES_BEFORE_PAUSE } from './scan_scheduling';
+
+// convex-test module map, keyed relative to the convex/ root. This file lives at
+// convex/websites/, so the glob reaches the root via ../ and keys are normalized
+// back to convex-root-relative paths.
+const TEST_DIR_FROM_CONVEX_ROOT = 'websites';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_scanfail';
+const DOMAIN = 'demo.example.com';
+
+async function provision(t: ReturnType<typeof convexTest>) {
+  return await t.mutation(
+    internal.websites.internal_mutations.provisionWebsite,
+    {
+      organizationId: ORG,
+      domain: DOMAIN,
+      scanInterval: '6h',
+      status: 'scanning',
+      metadata: { workflowId: 'wf_1' },
+    },
+  );
+}
+
+function recordFailure(
+  t: ReturnType<typeof convexTest>,
+  corpusUnreachable: boolean,
+) {
+  return t.mutation(internal.websites.internal_mutations.recordScanFailure, {
+    organizationId: ORG,
+    domain: DOMAIN,
+    message: "password authentication failed for user 'neondb_owner'",
+    corpusUnreachable,
+  });
+}
+
+describe('recordScanFailure', () => {
+  it('records a connection failure on the Convex row — the only reachable store', async () => {
+    const t = convexTest(schema, modules);
+    const websiteId = await provision(t);
+
+    const { paused } = await recordFailure(t, true);
+
+    expect(paused).toBe(false);
+    await t.run(async (ctx) => {
+      const website = await ctx.db.get(websiteId);
+      expect(website?.status).toBe('error');
+      expect(website?.metadata?.lastSyncError).toContain(
+        'password authentication failed',
+      );
+      expect(website?.metadata?.corpusConnectionFailures).toBe(1);
+      expect(typeof website?.metadata?.lastScanAttemptAt).toBe('number');
+      // The pre-existing metadata survives the merge.
+      expect(website?.metadata?.workflowId).toBe('wf_1');
+      // Below the threshold nothing pauses and no one is notified.
+      expect(website?.metadata?.scanPausedAt ?? null).toBeNull();
+      expect(await ctx.db.query('notifications').collect()).toHaveLength(0);
+    });
+  });
+
+  it('pauses at the threshold and notifies org admins exactly once', async () => {
+    const t = convexTest(schema, modules);
+    const websiteId = await provision(t);
+
+    for (let i = 0; i < CONNECTION_FAILURES_BEFORE_PAUSE - 1; i++) {
+      const { paused } = await recordFailure(t, true);
+      expect(paused).toBe(false);
+    }
+    const { paused } = await recordFailure(t, true);
+    expect(paused).toBe(true);
+
+    // A further failure from an already-queued scan neither re-pauses nor
+    // re-notifies — one incident, one notification.
+    const again = await recordFailure(t, true);
+    expect(again.paused).toBe(false);
+
+    await t.run(async (ctx) => {
+      const website = await ctx.db.get(websiteId);
+      expect(typeof website?.metadata?.scanPausedAt).toBe('number');
+      const notifications = await ctx.db.query('notifications').collect();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toMatchObject({
+        organizationId: ORG,
+        category: 'security',
+        severity: 'warning',
+        titleKey: 'websiteScanPaused',
+        bodyKey: 'websiteScanPausedDetails',
+        params: { domain: DOMAIN, failures: CONNECTION_FAILURES_BEFORE_PAUSE },
+      });
+    });
+  });
+
+  it('a reachable-but-failed scan resets the connection streak', async () => {
+    // The streak means "the database configuration is broken"; a scan the
+    // database answered proves it is not, whatever else went wrong.
+    const t = convexTest(schema, modules);
+    const websiteId = await provision(t);
+
+    await recordFailure(t, true);
+    await recordFailure(t, true);
+    const { paused } = await recordFailure(t, false);
+
+    expect(paused).toBe(false);
+    await t.run(async (ctx) => {
+      const website = await ctx.db.get(websiteId);
+      expect(website?.metadata?.corpusConnectionFailures ?? null).toBeNull();
+      // The attempt still counts toward the retry backoff.
+      expect(typeof website?.metadata?.lastScanAttemptAt).toBe('number');
+    });
+  });
+
+  it('is a no-op for a domain the organization does not track', async () => {
+    const t = convexTest(schema, modules);
+    const { paused } = await recordFailure(t, true);
+    expect(paused).toBe(false);
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query('notifications').collect()).toHaveLength(0);
+    });
+  });
+});
+
+describe('clearScanFailures', () => {
+  it('clears the failure bookkeeping and keeps unrelated metadata', async () => {
+    const t = convexTest(schema, modules);
+    const websiteId = await provision(t);
+    for (let i = 0; i < CONNECTION_FAILURES_BEFORE_PAUSE; i++) {
+      await recordFailure(t, true);
+    }
+
+    await t.mutation(internal.websites.internal_mutations.clearScanFailures, {
+      organizationId: ORG,
+      domain: DOMAIN,
+    });
+
+    await t.run(async (ctx) => {
+      const website = await ctx.db.get(websiteId);
+      expect(website?.metadata?.corpusConnectionFailures ?? null).toBeNull();
+      expect(website?.metadata?.lastScanAttemptAt ?? null).toBeNull();
+      expect(website?.metadata?.scanPausedAt ?? null).toBeNull();
+      expect(website?.metadata?.workflowId).toBe('wf_1');
+    });
+  });
+});
+
+describe('listWebsitesForScanScheduling', () => {
+  it('projects the failure bookkeeping for the scheduler', async () => {
+    const t = convexTest(schema, modules);
+    await provision(t);
+    for (let i = 0; i < CONNECTION_FAILURES_BEFORE_PAUSE; i++) {
+      await recordFailure(t, true);
+    }
+
+    const sites = await t.query(
+      internal.websites.internal_queries.listWebsitesForScanScheduling,
+      {},
+    );
+
+    expect(sites).toHaveLength(1);
+    expect(sites[0]).toMatchObject({
+      domain: DOMAIN,
+      organizationId: ORG,
+      connectionFailures: CONNECTION_FAILURES_BEFORE_PAUSE,
+      scanPaused: true,
+    });
+    expect(typeof sites[0]?.lastAttemptAt).toBe('number');
+  });
+});

--- a/services/platform/convex/websites/scan_scheduling.test.ts
+++ b/services/platform/convex/websites/scan_scheduling.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONNECTION_FAILURES_BEFORE_PAUSE,
+  connectionFailureCount,
+  FAILED_SCAN_RETRY_MS,
+  isDueForScan,
+  lastScanAttemptAt,
+  scanPausedAt,
+  STUCK_SCANNING_RETRY_MS,
+  type ScanSchedulingSite,
+} from './scan_scheduling';
+
+/**
+ * The regression locked here is TALE-PROJECT-106: a site whose scans kept
+ * failing (an invalid corpus credential) never advanced any clock the
+ * scheduler reads, so every five-minute tick re-queued it — for three weeks,
+ * with no cap and no signal. The policy now anchors on the last ATTEMPT, not
+ * only the last success, retries failures on a bounded window, and stops
+ * entirely once the site is paused.
+ */
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const NOW = 1_756_000_000_000;
+
+function site(overrides: Partial<ScanSchedulingSite>): ScanSchedulingSite {
+  return {
+    scanIntervalSeconds: 6 * 3600,
+    createdAt: NOW - 30 * 24 * HOUR,
+    connectionFailures: 0,
+    scanPaused: false,
+    ...overrides,
+  };
+}
+
+describe('interval scheduling', () => {
+  it('a never-scanned site is due immediately', () => {
+    expect(isDueForScan(site({}), NOW)).toBe(true);
+  });
+
+  it('a healthy site is due after its interval, not before', () => {
+    const healthy = site({ lastScannedAt: NOW - 5 * HOUR });
+    expect(isDueForScan(healthy, NOW)).toBe(false);
+    expect(isDueForScan(site({ lastScannedAt: NOW - 7 * HOUR }), NOW)).toBe(
+      true,
+    );
+  });
+
+  it('a site being deleted is never due', () => {
+    expect(isDueForScan(site({ status: 'deleting' }), NOW)).toBe(false);
+  });
+});
+
+describe('failure backoff (the TALE-PROJECT-106 regression)', () => {
+  it('a failed attempt is NOT re-queued on the next tick', () => {
+    // Before the fix a failing site's clock never advanced, so the very
+    // next five-minute tick re-queued it, forever (~10 uncaught errors a
+    // day for three weeks on the demo org).
+    const failing = site({
+      status: 'error',
+      lastScannedAt: NOW - 20 * 24 * HOUR,
+      lastAttemptAt: NOW - 5 * MINUTE,
+      connectionFailures: 1,
+    });
+    expect(isDueForScan(failing, NOW)).toBe(false);
+  });
+
+  it('a failing site retries on the bounded window, not its own interval', () => {
+    // A 30-day site must not wait 30 days between failure retries — it
+    // would take a quarter to reach the pause threshold.
+    const monthly = site({
+      scanIntervalSeconds: 30 * 24 * 3600,
+      status: 'error',
+      lastAttemptAt: NOW - FAILED_SCAN_RETRY_MS - MINUTE,
+      connectionFailures: 1,
+    });
+    expect(isDueForScan(monthly, NOW)).toBe(true);
+  });
+
+  it('a short interval floors the failure retry window', () => {
+    // An hourly site keeps retrying hourly — the bound only ever slows
+    // sites down relative to their interval, never speeds them up past it.
+    const hourly = site({
+      scanIntervalSeconds: 3600,
+      status: 'error',
+      lastAttemptAt: NOW - 90 * MINUTE,
+      connectionFailures: 1,
+    });
+    expect(isDueForScan(hourly, NOW)).toBe(true);
+    expect(
+      isDueForScan({ ...hourly, lastAttemptAt: NOW - 30 * MINUTE }, NOW),
+    ).toBe(false);
+  });
+
+  it('a paused site is never due, no matter how overdue', () => {
+    const paused = site({
+      status: 'error',
+      lastScannedAt: NOW - 365 * 24 * HOUR,
+      lastAttemptAt: NOW - 365 * 24 * HOUR,
+      connectionFailures: CONNECTION_FAILURES_BEFORE_PAUSE,
+      scanPaused: true,
+    });
+    expect(isDueForScan(paused, NOW)).toBe(false);
+  });
+});
+
+describe('stuck-scanning takeover', () => {
+  it('a row stuck in scanning is retried only after the takeover window', () => {
+    const stuck = site({
+      status: 'scanning',
+      lastScannedAt: NOW - STUCK_SCANNING_RETRY_MS - MINUTE,
+    });
+    expect(isDueForScan(stuck, NOW)).toBe(true);
+    expect(
+      isDueForScan(
+        site({ status: 'scanning', lastScannedAt: NOW - HOUR }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('a failed attempt re-arms the takeover window too', () => {
+    // A scanning row whose last ATTEMPT just failed must not be re-queued
+    // every tick while the corpus-side claim is still fresh.
+    const stuck = site({
+      status: 'scanning',
+      lastScannedAt: NOW - 3 * STUCK_SCANNING_RETRY_MS,
+      lastAttemptAt: NOW - 5 * MINUTE,
+    });
+    expect(isDueForScan(stuck, NOW)).toBe(false);
+  });
+
+  it('a scanning row with no activity at all falls back to its creation time', () => {
+    expect(
+      isDueForScan(
+        site({
+          status: 'scanning',
+          createdAt: NOW - STUCK_SCANNING_RETRY_MS - MINUTE,
+        }),
+        NOW,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('metadata accessors', () => {
+  it('read valid values', () => {
+    expect(
+      connectionFailureCount({ corpusConnectionFailures: 2, other: 'x' }),
+    ).toBe(2);
+    expect(lastScanAttemptAt({ lastScanAttemptAt: NOW })).toBe(NOW);
+    expect(scanPausedAt({ scanPausedAt: NOW })).toBe(NOW);
+  });
+
+  it('treat cleared (null), absent, and junk values as not set', () => {
+    for (const metadata of [
+      undefined,
+      {},
+      {
+        corpusConnectionFailures: null,
+        lastScanAttemptAt: null,
+        scanPausedAt: null,
+      },
+      {
+        corpusConnectionFailures: 'three',
+        lastScanAttemptAt: 'yesterday',
+        scanPausedAt: true,
+      },
+      {
+        corpusConnectionFailures: -1,
+        lastScanAttemptAt: Number.NaN,
+        scanPausedAt: 0,
+      },
+    ]) {
+      expect(connectionFailureCount(metadata)).toBe(0);
+      expect(lastScanAttemptAt(metadata)).toBeNull();
+      expect(scanPausedAt(metadata)).toBeNull();
+    }
+  });
+});

--- a/services/platform/convex/websites/scan_scheduling.ts
+++ b/services/platform/convex/websites/scan_scheduling.ts
@@ -1,0 +1,133 @@
+/**
+ * The scan-scheduling policy: when a registered website is due for a crawl,
+ * and how repeated failures slow it down and eventually pause it.
+ *
+ * Pure and runtime-agnostic on purpose — the five-minute scheduler action
+ * (`knowledge/crawl_action.scanDueWebsites`, node) and the websites
+ * queries/mutations (V8) both import it, and the tests exercise the policy
+ * without either runtime.
+ *
+ * ## Failure bookkeeping lives on the Convex row's `metadata`
+ *
+ * A scan that cannot reach the organization's knowledge database has exactly
+ * one reachable store left: the Convex `websites` row. Recording failures
+ * there (instead of the corpus, which is what failed) is what makes them
+ * visible at all — TALE-PROJECT-106 was three weeks of an invalid corpus
+ * credential failing on schedule with zero signal, because every record of
+ * the failure was written into the database that was down.
+ *
+ * The fields are plain `metadata` keys, not schema columns, so no schema
+ * change ships with them; a cleared field is written as `null` (the
+ * `updateWebsite` metadata merge drops nothing, and `undefined` would not
+ * survive serialization).
+ *
+ * - `lastScanAttemptAt` — when the last FAILED scan attempt ran. Present only
+ *   while the site is failing (cleared on success); its presence switches the
+ *   retry cadence from the site's own interval to the bounded
+ *   {@link FAILED_SCAN_RETRY_MS} window, so a failing site neither storms the
+ *   scheduler every tick nor waits out a 30-day interval to try again.
+ * - `corpusConnectionFailures` — consecutive attempts that could not REACH
+ *   the corpus database (auth, DNS, refused). A reachable-but-failing scan
+ *   resets it; {@link CONNECTION_FAILURES_BEFORE_PAUSE} of them in a row mean
+ *   the organization's knowledge-database configuration is broken, not
+ *   flaky.
+ * - `scanPausedAt` — set when the failure streak hits the threshold. A paused
+ *   site is never due; org admins are notified once, and scanning stays off
+ *   until someone fixes the connection and resumes it from the Websites page.
+ */
+
+/** Retry cadence while a site's scans are failing: `min(interval, this)`.
+ * Bounded so a 30-day site still retries (and can reach the pause threshold)
+ * promptly, and floored by the interval so a 1-hour site is not retried more
+ * often than it would be scanned. */
+export const FAILED_SCAN_RETRY_MS = 2 * 60 * 60 * 1000;
+
+/** Consecutive connection-class failures before the site's scans pause and
+ * its org admins are notified. Combined with {@link FAILED_SCAN_RETRY_MS}
+ * this pauses a broken configuration within ~6 hours of the first failure. */
+export const CONNECTION_FAILURES_BEFORE_PAUSE = 3;
+
+/** A Convex row stuck in `scanning` longer than this belongs to a crashed
+ * scan; the corpus-side claim takeover makes the retry safe. */
+export const STUCK_SCANNING_RETRY_MS = 2 * 60 * 60 * 1000;
+
+/** The scheduler's view of one `websites` row, as
+ * `listWebsitesForScanScheduling` projects it. */
+export interface ScanSchedulingSite {
+  readonly scanIntervalSeconds: number;
+  readonly lastScannedAt?: number;
+  readonly lastAttemptAt?: number;
+  readonly status?: string;
+  readonly createdAt: number;
+  readonly connectionFailures: number;
+  readonly scanPaused: boolean;
+}
+
+/**
+ * Whether one website is due for a scan at `now`.
+ *
+ * The anchor for every window is the LATEST scan activity — a successful
+ * scan's `lastScannedAt` or a failed attempt's `lastAttemptAt`. Anchoring
+ * failures too is the backoff: before it, a row whose scans kept failing
+ * never advanced its clock and was re-queued on every five-minute tick,
+ * forever.
+ */
+export function isDueForScan(site: ScanSchedulingSite, now: number): boolean {
+  if (site.scanPaused) return false;
+  if (site.status === 'deleting') return false;
+
+  const anchor = latestOf(site.lastScannedAt, site.lastAttemptAt);
+
+  if (site.status === 'scanning') {
+    // A healthy scan refreshes its corpus claim, not the Convex row — treat
+    // a row stuck in `scanning` beyond the window as crashed and let the
+    // corpus-side claim takeover decide.
+    return now - (anchor ?? site.createdAt) > STUCK_SCANNING_RETRY_MS;
+  }
+
+  if (anchor === undefined) return true;
+  const intervalMs = site.scanIntervalSeconds * 1000;
+  const window =
+    site.lastAttemptAt === undefined
+      ? intervalMs
+      : Math.min(intervalMs, FAILED_SCAN_RETRY_MS);
+  return now - anchor > window;
+}
+
+function latestOf(a?: number, b?: number): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+
+// ------------------------------------------------ metadata field accessors
+
+/** Consecutive connection-class scan failures recorded on the row. */
+export function connectionFailureCount(
+  metadata: Record<string, unknown> | undefined,
+): number {
+  const raw = metadata?.corpusConnectionFailures;
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return 0;
+  return Math.floor(raw);
+}
+
+/** When the last failed scan attempt ran, or `null` when the site is not in
+ * a failure streak (the field is cleared on success). */
+export function lastScanAttemptAt(
+  metadata: Record<string, unknown> | undefined,
+): number | null {
+  const raw = metadata?.lastScanAttemptAt;
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0
+    ? raw
+    : null;
+}
+
+/** When the site's scans were paused, or `null` while scanning is active. */
+export function scanPausedAt(
+  metadata: Record<string, unknown> | undefined,
+): number | null {
+  const raw = metadata?.scanPausedAt;
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0
+    ? raw
+    : null;
+}

--- a/services/platform/lib/i18n/keys-dynamic.yml
+++ b/services/platform/lib/i18n/keys-dynamic.yml
@@ -27,6 +27,8 @@ entries:
   - 'notifications.auditIntegrityFailedDetails'
   - 'notifications.auditIntegrityUnverifiable'
   - 'notifications.auditIntegrityUnverifiableDetails'
+  - 'notifications.websiteScanPaused'
+  - 'notifications.websiteScanPausedDetails'
   - 'notifications.dsarScheduled'
   - 'notifications.dsarScheduledBody'
   - 'notifications.dsarScheduledByBody'

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -4342,6 +4342,11 @@ notifications:
     Überprüfung konfiguriert: {reason}. Setze TALE_AUDIT_SIGNING_KEY, um die
     Manipulationssicherheit wiederherzustellen — das ist eine
     Konfigurationslücke, keine festgestellte Manipulation.'
+  websiteScanPaused: 'Website-Scans pausiert: {domain}'
+  websiteScanPausedDetails: 'Die Scans von {domain} wurden pausiert, nachdem
+    die Wissensdatenbank dieser Organisation {failures} Mal in Folge nicht
+    erreichbar war. Prüfe die Verbindung unter Einstellungen → Datenresidenz
+    und setze die Scans danach auf der Websites-Seite fort.'
   dsarScheduled: Löschungsanfrage geplant
   dsarScheduledBody: Eine Löschungsanfrage wurde für ein Mitglied dieser
     Organisation eingereicht. Sie wird in {coolingOffHours} Stunden ausgeführt —
@@ -6946,6 +6951,11 @@ websites:
     description: Beschreibung
     created: Erstellt
     unknown: Unbekannt
+    scanPausedNotice: Die Scans sind pausiert, weil die Wissensdatenbank
+      mehrfach nicht erreichbar war. Prüfe die Verbindung unter Einstellungen →
+      Datenresidenz und setze die Scans danach fort.
+  scanPausedBadge: Pausiert
+  resumeScanning: Scans fortsetzen
   viewPages: Seiten anzeigen
   indexed: Indexiert
   indexedTooltip: '{percentage} % – {crawled} von {total} Seiten'

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -4194,6 +4194,11 @@ notifications:
     are signed, but no signing key is configured to verify them: {reason}. Set
     TALE_AUDIT_SIGNING_KEY to restore tamper-evidence — this is a configuration
     gap, not detected tampering."
+  websiteScanPaused: 'Website scans paused: {domain}'
+  websiteScanPausedDetails: "Scans of {domain} were paused after {failures}
+    consecutive attempts couldn't reach this organization's knowledge database.
+    Check the connection under Settings → Data residency, then resume scanning
+    from the Websites page."
   dsarScheduled: Erasure request scheduled
   dsarScheduledBody: An erasure request was filed for a member of this
     organization. It runs in {coolingOffHours} hours — open the receipt to
@@ -7001,6 +7006,11 @@ websites:
     description: Description
     created: Created
     unknown: Unknown
+    scanPausedNotice: Scanning is paused after repeated failures to reach the
+      knowledge database. Fix the connection under Settings → Data residency,
+      then resume scanning.
+  scanPausedBadge: Paused
+  resumeScanning: Resume scanning
   viewPages: View pages
   indexed: Indexed
   indexedTooltip: '{percentage} % - {crawled} of {total} pages'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -4422,6 +4422,11 @@ notifications:
     configurée pour les vérifier : {reason}. Définis TALE_AUDIT_SIGNING_KEY pour
     rétablir la protection contre l'altération — il s'agit d'une lacune de
     configuration, pas d'une altération détectée."
+  websiteScanPaused: 'Analyses du site web suspendues : {domain}'
+  websiteScanPausedDetails: "Les analyses de {domain} ont été suspendues après
+    {failures} tentatives consécutives sans parvenir à joindre la base de
+    connaissances de cette organisation. Vérifie la connexion sous Paramètres →
+    Résidence des données, puis reprends l'analyse depuis la page Sites web."
   dsarScheduled: Demande d'effacement planifiée
   dsarScheduledBody: Une demande d'effacement a été déposée concernant un membre
     de cette organisation. Elle s'exécute dans {coolingOffHours} heures — ouvre
@@ -7064,6 +7069,11 @@ websites:
     description: Description
     created: Créé
     unknown: Inconnu
+    scanPausedNotice: L'analyse est suspendue après plusieurs échecs d'accès à
+      la base de connaissances. Vérifie la connexion sous Paramètres →
+      Résidence des données, puis reprends l'analyse.
+  scanPausedBadge: Suspendu
+  resumeScanning: Reprendre l'analyse
   viewPages: Voir les pages
   indexed: Indexé
   indexedTooltip: '{percentage} % - {crawled} sur {total} pages'

--- a/services/web/vite.config.ts
+++ b/services/web/vite.config.ts
@@ -3,7 +3,7 @@ import { yamlImports } from '@tale/ui/vite/yaml';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import viteReact from '@vitejs/plugin-react';
 import type { Connect } from 'vite';
-import { defineConfig } from 'vite';
+import { defineConfig, type PreviewServer, type ViteDevServer } from 'vite';
 
 import {
   RELEASES,
@@ -12,6 +12,23 @@ import {
 import { createReleaseFeed } from './lib/releases/feed';
 import { handleReleasesRequest, RELEASES_ROUTE } from './lib/releases/route';
 import { createMarketingArtifactsServer } from './lib/seo/artifacts-server';
+
+/**
+ * In production the web droplet's Caddy answers `/_a/*` — the first-party
+ * analytics proxy the tag in index.html loads from. Vite's dev and preview
+ * servers have no such upstream, so the script request would 404 into the
+ * browser console and fail the smoke suite's no-console-errors guard. Serve
+ * a no-op stub on exactly that path instead. The BUILT artifact carries no
+ * stub, so a misconfigured droplet proxy still fails loudly in production.
+ */
+function stubAnalyticsScript(server: ViteDevServer | PreviewServer): void {
+  server.middlewares.use('/_a/script.js', (_req, res) => {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(
+      '/* analytics stub — production serves this via the Caddy proxy */',
+    );
+  });
+}
 
 // In dev the SSR loader is bound at the first artifact request via the
 // inline plugin below. Cache is disabled so source edits show up
@@ -124,6 +141,11 @@ export default defineConfig({
       configureServer: (server) => mountReleaseFeedRoute(server.middlewares),
       configurePreviewServer: (server) =>
         mountReleaseFeedRoute(server.middlewares),
+    },
+    {
+      name: 'tale-web:analytics-stub',
+      configureServer: stubAnalyticsScript,
+      configurePreviewServer: stubAnalyticsScript,
     },
     artifactsPlugin({ server: devArtifactsServer }),
   ],


### PR DESCRIPTION
Fixes the endless-retry loop behind [TALE-PROJECT-106](https://app.glitchtip.com/tale-project/issues/7625438) — `Uncaught PostgresError: password authentication failed for user 'neondb_owner'`, **234 events**, 2026-08-01 → 2026-08-21, ~one every 2 h, `userCount: 0` (pure background cron on demo.tale.dev).

## Problem

`scanWebsite` acquired the org corpus pool **before** its `try` block. For a bring-your-own database, `getKnowledgePoolForOrg` runs real SQL (the corpus-schema bootstrap), so an invalid credential threw right there and escaped the action uncaught. The `catch` then recorded `status = 'error'` **into the same unreachable Postgres**, so when the database itself was down nothing was recorded anywhere. The Convex `websites` row never advanced its clock, and the five-minute scheduler re-queued the domain forever — no backoff, no cap, no admin-facing signal.

## Fix

- **Classify connection-class errors** — `isConnectionFailure` in `knowledge/pool.ts`: SQLSTATE classes 08/28, `3D000`, `57P03`, postgres.js lifecycle codes (`CONNECT_TIMEOUT`, `CONNECTION_CLOSED`, …), Node system errors (`ENOTFOUND`, `ECONNREFUSED`, …).
- **Wrap pool acquisition and the scan body** — connection-class failures are recorded on the **Convex `websites` row** (`recordScanFailure`), the only store still reachable; reachable-but-failed scans keep marking the corpus and now also stamp the Convex row.
- **Backoff** — every failed attempt stamps `metadata.lastScanAttemptAt`; the scheduler (pure policy in `websites/scan_scheduling.ts`, unit-tested) retries failing sites on `min(interval, 2 h)` instead of every tick.
- **Pause + notify** — after 3 consecutive connection-class failures the site's scans pause (`metadata.scanPausedAt`) and the org's admins get a one-per-incident bell notification (`security` category, Slack-mirrored): *"Check the connection under Settings → Data residency, then resume scanning from the Websites page."*
- **UI** — paused rows show a **Paused** badge (table + view dialog), the row menu gains **Resume scanning** (clears the pause and kicks a verification scan immediately), and the view dialog explains the pause. Strings ship in en/de/fr, mirrored in `NOTIFICATIONS_I18N` for the Slack sink, and registered in `keys-dynamic.yml` (server-emitted keys are invisible to the client-source scanner).

The failure bookkeeping lives in `websites.metadata` — **no schema change, no migration**.

## Tests

- `pool.test.ts` — classifier: unreachable vs statement-level SQLSTATEs (an FK violation like the Jul 18 `website_urls` incident stays statement-level).
- `scan_scheduling.test.ts` — the regression: a failing site is **not** re-queued on the next tick; bounded failure retry (a 30-day site retries in 2 h, an hourly site stays hourly); paused sites are never due; stuck-`scanning` takeover unchanged and re-armed by failed attempts.
- `record_scan_failure.test.ts` (convex-test) — streak counting, pause at the threshold with **exactly one** notification, no re-notify while paused, streak reset on reachable-but-failed scans, `clearScanFailures`, and the scheduler projection.

Observed: 416 tests green across `convex/websites`, `convex/knowledge`, `convex/notifications`, `lib/i18n`; `tsc --noEmit` clean; `oxlint --type-aware` clean over the touched dirs.

## Ops follow-up (not in this PR)

The demo org's Neon credential (`neondb_owner`) is still invalid — last failure 2026-08-21. Rotate/fix it under **Settings → Data residency**, then hit **Resume scanning** on the site. The GlitchTip issue should stay open until this ships and the credential is fixed.


## CI fixes (reviewer: "fix all ci action errors")

- **UI job** — `website-row-actions.test.tsx` (existing jsdom suite) mocks `../hooks/mutations` with an explicit factory, so the new `useResumeScanning` hook threw "no export defined on the mock". Fixed by extending the mock and locking the new behaviour: the resume item appears only while the site is paused, and clicking it calls the action with the row's `websiteId`. Full `test:ui` suite verified locally (434 files / 3338 tests green); the UI job passed on the next CI round.
- **Playwright (web) job** — inherited from `main`, not from this PR: `500eaa3e8` added a first-party analytics tag loading `/_a/script.js`, a path only the web droplet's Caddy proxy answers in production. Vite's dev/preview servers 404 it, tripping the smoke suite's no-console-errors guard — latent on `main` because change detection skips the web suite there, surfacing on any PR whose merge ref includes it. Fixed here (`fix(web)` commit) with a no-op stub served by vite dev/preview only; the built artifact is untouched, and the `tale-web:release-feed` dev route is preserved. Web smoke suite verified locally against a build carrying the analytics tag. Maintainers may prefer to cherry-pick that one commit straight to `main`, since every open PR that touches web paths will hit the same failure.
