### PR TITLE
feat(platform): auto-retry failed automation agent turns in place

### DIFF
--- a/docs/de/platform/automations/execution-logs.md
+++ b/docs/de/platform/automations/execution-logs.md
@@ -54,6 +54,12 @@ Ein Live-Lauf läuft nicht in einem Zug durch. Er geht Node für Node vor, und j
 
 Dieselben Checkpoints decken einen Lauf ab, dessen Fortsetzung verloren ging. Ein Lauf, der über eine Schonfrist hinaus in einem nicht abgeschlossenen Zustand liegt, wird von selbst wieder aufgenommen und setzt dort fort, wo seine Checkpoints ihn verorten — statt neu zu starten oder für immer unfertig liegen zu bleiben.
 
+## Wenn ein Agent-Schritt fehlschlägt
+
+Schlägt ein Agent-Schritt aus einem Grund fehl, an dem ein neuer Anlauf etwas ändern kann — der Anbieter hat den Aufruf abgewiesen, die Sandbox ist unter ihm gestorben, der Harness ist abgestürzt —, wiederholt der Lauf ihn von selbst: bis zu drei automatische Versuche, sofort, zusätzlich zum ursprünglichen. Alles oberhalb behält seine Checkpoints, der Lauf bleibt durchgehend live, und sein Kopf zählt die Versuche der Plattform als **Automatischer Versuch 1 von 3** — so unterscheidest du die Wiederholung der Engine von einem Neustart, den du selbst angestoßen hast. Ein Versuch, der echten Fortschritt gemacht hat — fünfzehn Minuten tatsächlicher Ausführung —, frischt das Budget auf, statt es zu verbrauchen; und bei Anbietern, die aus einem Pool von Abo-Konten bedient werden, meidet jeder neue Versuch die Konten, die gerade gescheitert sind.
+
+Zwei Fehlschläge werden nie wiederholt, weil ein frischer Versuch nicht anders enden könnte: ein Schritt, der sein ganzes Zeitfenster aufgebraucht hat, und eine Frage, die bis zu ihrem Ablauf unbeantwortet blieb. Ist das Budget verbraucht, schlägt der Lauf mit dem letzten Fehler fehl und nennt, wie viele Versuche er verbrannt hat; jeder Versuch wird einzeln abgerechnet — ein Lauf mit drei Wiederholungen hat also vier bezahlt. Ein wiederholender Lauf bleibt ein einziger Live-Lauf — **Lauf stoppen** ist der Ausweg, wenn du siehst, dass weitere Versuche nichts mehr ändern.
+
 ## Eine durchgespielte Fehlersuche
 
 Die tägliche Erinnerung ging nicht raus. Öffne die Automatisierung und sieh in die Liste **Läufe**: Der Lauf von heute Morgen steht da und ist **Fehlgeschlagen**, mit dem Grund in der Zeile.

--- a/docs/en/platform/automations/execution-logs.md
+++ b/docs/en/platform/automations/execution-logs.md
@@ -54,6 +54,12 @@ A live run does not execute in one go. It steps node by node, and every complete
 
 The same checkpoints cover a run whose continuation was lost. A run left in a non-terminal state past a grace period is picked back up automatically and continues from where its checkpoints say it got to, rather than restarting or sitting unfinished forever.
 
+## When an agent step fails
+
+An agent step that fails for a reason a fresh attempt could change — the provider refused the call, the sandbox died under it, the harness crashed — is retried by the run itself: up to three automatic attempts, immediately, on top of the original one. Everything upstream keeps its checkpoints, the run stays live the whole time, and its header counts the platform's attempts as **Auto-retry 1 of 3**, so you can tell the engine's retry from a rerun you started yourself. An attempt that made real progress — fifteen minutes of actual execution — refreshes the budget instead of spending it, and on providers served by a pool of subscription accounts each new attempt avoids the accounts that just failed.
+
+Two failures are never retried, because a fresh attempt could not end differently: a step that ran out its whole time window, and a question left unanswered until it expired. Once the budget is spent the run fails with the last error and says how many attempts it burned; each attempt is billed on its own, so a run that retried three times paid for four. A retrying run is still one live run — **Stop the run** is the way out when you can see the retries are not going to change anything.
+
 ## A worked debugging session
 
 The daily reminder did not go out. Open the automation and look at the **Runs** list: this morning's run is there and it is **Failed**, with its reason on the row.

--- a/docs/fr/platform/automations/execution-logs.md
+++ b/docs/fr/platform/automations/execution-logs.md
@@ -54,6 +54,12 @@ Une exécution réelle ne se déroule pas d’un seul tenant. Elle avance nœud 
 
 Ces mêmes points de reprise couvrent une exécution dont la continuation a été perdue. Une exécution restée dans un état non terminal au-delà d’un délai de grâce est reprise automatiquement et continue là où ses points de reprise la situent, plutôt que de redémarrer ou de rester inachevée pour toujours.
 
+## Quand une étape agent échoue
+
+Quand une étape agent échoue pour une raison qu’une nouvelle tentative peut changer — le fournisseur a refusé l’appel, la sandbox est morte sous elle, le harness s’est écrasé — l’exécution la retente d’elle-même : jusqu’à trois tentatives automatiques, immédiates, en plus de la tentative d’origine. Tout ce qui est en amont garde ses points de reprise, l’exécution reste vivante tout du long, et son en-tête compte les tentatives de la plateforme — **Tentative automatique 1 sur 3** — pour distinguer la relance du moteur d’une relance que tu aurais lancée toi-même. Une tentative qui a réellement progressé — quinze minutes d’exécution effective — recharge le budget au lieu de le dépenser ; et chez les fournisseurs servis par un pool de comptes d’abonnement, chaque nouvelle tentative évite les comptes qui viennent d’échouer.
+
+Deux échecs ne sont jamais retentés, parce qu’une tentative fraîche ne pourrait pas finir autrement : une étape qui a épuisé toute sa fenêtre de temps, et une question restée sans réponse jusqu’à son expiration. Une fois le budget épuisé, l’exécution échoue avec la dernière erreur et dit combien de tentatives elle a brûlées ; chaque tentative est facturée séparément — une exécution qui a retenté trois fois en a payé quatre. Une exécution qui retente reste une seule exécution réelle — **Arrêter l’exécution** est la porte de sortie quand tu vois que les tentatives ne changeront plus rien.
+
 ## Une séance de débogage jouée de bout en bout
 
 La relance quotidienne n’est pas partie. Ouvre l’automatisation et regarde la liste **Exécutions** : celle de ce matin est là et elle est **En échec**, avec sa raison sur la ligne.

--- a/services/platform/app/features/automations/components/run-detail.tsx
+++ b/services/platform/app/features/automations/components/run-detail.tsx
@@ -30,6 +30,8 @@ import {
   isRunFinished,
   nodeStatusMap,
   projectRun,
+  readRunAgentRetry,
+  readRunCursorNode,
   readRunStatus,
 } from '../lib/run-view';
 import { AgentExecutionLog } from './agent-execution-log';
@@ -89,8 +91,9 @@ export function RunDetail({
       nodeStatusMap(
         projection,
         graph.nodes.map((node) => node.id),
+        readRunCursorNode(run),
       ),
-    [graph.nodes, projection],
+    [graph.nodes, projection, run],
   );
   const nodeTypes = useMemo(
     () => mergeNodeTypes(catalogQuery.data),
@@ -136,6 +139,18 @@ export function RunDetail({
           title={t('runs.heading', { automation: run.name })}
         />
         <RunBadge status={status} />
+        {(() => {
+          const retryAttempt = readRunAgentRetry(run);
+          if (retryAttempt === null) return null;
+          return (
+            <Text as="span" variant="muted" className="text-xs">
+              {t('runs.autoRetrying', {
+                n: retryAttempt,
+                max: run.agentAutoRetryMax,
+              })}
+            </Text>
+          );
+        })()}
         <Badge variant={run.mode === 'live' ? 'orange' : 'slate'}>
           {t(`runs.mode.${run.mode === 'live' ? 'live' : 'mock'}`)}
         </Badge>

--- a/services/platform/app/features/automations/lib/run-view.test.ts
+++ b/services/platform/app/features/automations/lib/run-view.test.ts
@@ -5,6 +5,7 @@ import {
   nodeStatusMap,
   projectRun,
   readEffects,
+  readRunAgentRetry,
   readRunStatus,
 } from './run-view';
 
@@ -85,6 +86,44 @@ describe('nodeStatusMap', () => {
     ]);
     expect(statuses.get('fetch')).toBe('ok');
     expect(statuses.get('later')).toBe('pending');
+  });
+});
+
+describe('readRunAgentRetry', () => {
+  const retrying = {
+    status: 'waiting',
+    checkpoints: {
+      nodes: {},
+      cursor: { node: 'extract', agent: { execId: 'e2', attempt: 2 } },
+      executions: 3,
+    },
+  };
+
+  it('reads the attempt off a live run parked on a retried agent turn', () => {
+    expect(readRunAgentRetry(retrying)).toBe(2);
+  });
+
+  it('reads null on the original attempt and off the agent park', () => {
+    expect(
+      readRunAgentRetry({
+        ...retrying,
+        checkpoints: {
+          ...retrying.checkpoints,
+          cursor: { node: 'extract', agent: { execId: 'e1' } },
+        },
+      }),
+    ).toBeNull();
+    expect(
+      readRunAgentRetry({
+        ...retrying,
+        checkpoints: { nodes: {}, cursor: { node: 'wait' }, executions: 1 },
+      }),
+    ).toBeNull();
+    expect(readRunAgentRetry(null)).toBeNull();
+  });
+
+  it('reads null on a finished run — the cursor is history there', () => {
+    expect(readRunAgentRetry({ ...retrying, status: 'failed' })).toBeNull();
   });
 });
 

--- a/services/platform/app/features/automations/lib/run-view.ts
+++ b/services/platform/app/features/automations/lib/run-view.ts
@@ -150,6 +150,28 @@ export function readRunCursorNode(
     : null;
 }
 
+/**
+ * The auto-retry attempt a LIVE run's parked agent turn is on (1-based), or
+ * null when the run is finished, not parked on an agent turn, or still on
+ * its original attempt. The counter lives only in the stepper's cursor, so
+ * a terminal run always reads null — its attempt count survives in the
+ * failure detail instead.
+ */
+export function readRunAgentRetry(
+  run: RunLike | null | undefined,
+): number | null {
+  if (!run || isRunFinished(readRunStatus(run.status))) return null;
+  const checkpoints = run.checkpoints;
+  if (!isRecord(checkpoints)) return null;
+  const cursor = checkpoints.cursor;
+  if (!isRecord(cursor)) return null;
+  const agent = cursor.agent;
+  if (!isRecord(agent)) return null;
+  return typeof agent.attempt === 'number' && agent.attempt >= 1
+    ? agent.attempt
+    : null;
+}
+
 /** One run as the canvas and the run detail read it. */
 export interface RunProjection {
   /** Per-node view, keyed by node id. */

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -52,6 +52,7 @@ import type * as audit_logs_validators from "../audit_logs/validators.js";
 import type * as audit_logs_verify_integrity from "../audit_logs/verify_integrity.js";
 import type * as auth from "../auth.js";
 import type * as automations_agent_host from "../automations/agent_host.js";
+import type * as automations_agent_retry from "../automations/agent_retry.js";
 import type * as automations_bound_run_payload from "../automations/bound_run_payload.js";
 import type * as automations_catalog from "../automations/catalog.js";
 import type * as automations_checkpoints from "../automations/checkpoints.js";
@@ -1024,6 +1025,7 @@ declare const fullApi: ApiFromModules<{
   "audit_logs/verify_integrity": typeof audit_logs_verify_integrity;
   auth: typeof auth;
   "automations/agent_host": typeof automations_agent_host;
+  "automations/agent_retry": typeof automations_agent_retry;
   "automations/bound_run_payload": typeof automations_bound_run_payload;
   "automations/catalog": typeof automations_catalog;
   "automations/checkpoints": typeof automations_checkpoints;

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -65,6 +65,7 @@ import {
 import { harvestSessionOutput } from '../node_only/sandbox/session_exec';
 import { resolveTurnEquipmentEnv } from '../node_only/sandbox/turn_equipment';
 import { resolveProviderCredential } from '../provider_credentials/resolve_credential';
+import { hashBrokerToken } from '../provider_credentials/token_hash';
 import { agentWorkTurnDeadlineMs } from '../sandbox/agent_deadline';
 import {
   sessionIdForWorkflowExecution,
@@ -135,6 +136,9 @@ export interface AutomationAgentHost {
     runId: string;
     nodeId: string;
     request: WorkflowAgentRequest;
+    /** Broker-token hashes burned by prior failed attempts of this node
+     * execution — the mint rotates away from them (softly). */
+    excludeBrokerTokenHashes?: string[];
   }): Promise<WorkflowAgentKick>;
   /** The settled result, or `null` while the turn still runs. Reads fresh —
    * the settle may land after the stepper's turn loaded its checkpoints. */
@@ -295,7 +299,7 @@ export function automationAgentHost(
   organizationId: string,
 ): AutomationAgentHost {
   return {
-    kick: async ({ runId, nodeId, request }) => {
+    kick: async ({ runId, nodeId, request, excludeBrokerTokenHashes }) => {
       const harness = request.harness ?? DEFAULT_HARNESS;
       if (!isManagedHarness(harness)) {
         throw new Error(
@@ -372,6 +376,10 @@ export function automationAgentHost(
                 visionModelId: vision.modelId,
               }
             : {}),
+          ...(excludeBrokerTokenHashes !== undefined &&
+          excludeBrokerTokenHashes.length > 0
+            ? { excludeBrokerTokenHashes }
+            : {}),
           deadlineAt,
           request: {
             model: request.model,
@@ -433,6 +441,7 @@ export function automationAgentHost(
               errored: true,
               reason:
                 'the agent asked the operator a question and nobody answered within 7 days',
+              failureCode: 'ask_expired',
               text: '',
               files: [],
             },
@@ -863,6 +872,9 @@ interface WorkflowTurnAuth {
   allowedModels: string[];
   /** The scope's budget; 0 on the subscription lane (vendor flat-rate). */
   budgetCents: number;
+  /** sha256 of the broker token this turn was minted on — only the
+   * subscription-broker branch, where a retry can rotate accounts. */
+  brokerTokenHash?: string;
 }
 
 /**
@@ -890,6 +902,9 @@ async function mintWorkflowTurnAuth(
     /** Subscription lane only — the vendor API base the CLI calls. */
     apiBaseUrl?: string;
     vision: { providerSlug: string; modelId: string } | null;
+    /** Broker accounts burned by prior failed attempts — excluded softly
+     * (an emptied pool falls back to every account). */
+    excludeBrokerTokenHashes?: readonly string[];
   },
 ): Promise<WorkflowTurnAuth> {
   if (args.lane === 'gateway') {
@@ -921,6 +936,10 @@ async function mintWorkflowTurnAuth(
   const credential = await resolveProviderCredential(ctx, {
     organizationId: args.organizationId,
     providerSlug: args.providerSlug,
+    ...(args.excludeBrokerTokenHashes !== undefined &&
+    args.excludeBrokerTokenHashes.length > 0
+      ? { excludeBrokerTokenHashes: args.excludeBrokerTokenHashes }
+      : {}),
   });
   if (
     credential.authMethod !== 'subscription-key' &&
@@ -946,6 +965,9 @@ async function mintWorkflowTurnAuth(
     tokenHash: hashVirtualKey(bridgeToken),
     allowedModels: [],
     budgetCents: 0,
+    ...(credential.authMethod === 'subscription-broker'
+      ? { brokerTokenHash: hashBrokerToken(credential.token) }
+      : {}),
   };
 }
 
@@ -977,6 +999,10 @@ export const startWorkflowAgentTurn = internalAction({
      * turn key and armed on the exec. */
     visionProviderSlug: v.optional(v.string()),
     visionModelId: v.optional(v.string()),
+    /** Broker accounts burned by prior failed attempts of this node
+     * execution — absent on first kicks and on in-flight calls from before
+     * auto-retry existed. */
+    excludeBrokerTokenHashes: v.optional(v.array(v.string())),
     deadlineAt: v.number(),
     request: requestValidator,
   },
@@ -1033,7 +1059,26 @@ export const startWorkflowAgentTurn = internalAction({
           ? { apiBaseUrl: args.apiBaseUrl }
           : {}),
         vision: visionRef,
+        ...(args.excludeBrokerTokenHashes !== undefined
+          ? { excludeBrokerTokenHashes: args.excludeBrokerTokenHashes }
+          : {}),
       });
+      // Launch facts for the retry gate: the attempt is executing from here
+      // on, and (broker lane) on which account. Best-effort — a refused
+      // stamp only undercounts progress, never blocks the turn.
+      await ctx.runMutation(
+        internal.automations.mutations.stampAgentTurnLaunch,
+        {
+          organizationId: args.organizationId,
+          runId: args.runId,
+          nodeId: args.nodeId,
+          execId: args.execId,
+          launchedAt: Date.now(),
+          ...(auth.brokerTokenHash !== undefined
+            ? { brokerTokenHash: auth.brokerTokenHash }
+            : {}),
+        },
+      );
       await ctx.runMutation(
         internal.sandbox.session_mutations.insertSessionToken,
         {
@@ -1160,6 +1205,7 @@ export const startWorkflowAgentTurn = internalAction({
       await settleWorkflowAgentTurn(ctx, args, {
         errored: true,
         reason: `the agent turn could not start: ${err instanceof Error ? err.message : String(err)}`,
+        failureCode: 'start_failed',
         text: '',
         files: [],
       });
@@ -1231,6 +1277,7 @@ export const driveWorkflowAgentTurn = internalAction({
       await settleWorkflowAgentTurn(ctx, args, {
         errored: true,
         reason: 'the agent turn ran past its time limit and was stopped',
+        failureCode: 'deadline',
         text: '',
         files: [],
       });
@@ -1250,9 +1297,13 @@ export const driveWorkflowAgentTurn = internalAction({
     } catch (err) {
       console.error('[agent-host] drive window threw:', err);
       await progress.flush();
+      // A drain that died at the deadline is the deadline, not a crash — a
+      // retry of a burned 12h window would be pure waste.
+      const pastDeadline = Date.now() > args.deadlineAt;
       await settleWorkflowAgentTurn(ctx, args, {
         errored: true,
-        reason: 'the agent turn stopped unexpectedly',
+        reason: `the agent turn stopped unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+        failureCode: pastDeadline ? 'deadline' : 'turn_crashed',
         text: '',
         files: [],
       });
@@ -1373,6 +1424,12 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
           ? { apiBaseUrl: serving.apiBaseUrl }
           : {}),
         vision,
+        // The resumed turn rotates like a re-kick would — re-minting on an
+        // account prior attempts already burned wastes the answer.
+        ...(agent.burnedBrokerTokenHashes !== undefined &&
+        agent.burnedBrokerTokenHashes.length > 0
+          ? { excludeBrokerTokenHashes: agent.burnedBrokerTokenHashes }
+          : {}),
       });
       await ctx.runMutation(
         internal.sandbox.session_mutations.insertSessionToken,
@@ -1420,6 +1477,23 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
         );
         return null;
       }
+      // Launch facts under the resume's exec (the retarget just installed
+      // it): executed time measures the post-answer slice, matching the
+      // task lane's per-launch semantics.
+      await ctx.runMutation(
+        internal.automations.mutations.stampAgentTurnLaunch,
+        {
+          organizationId: args.organizationId,
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the ask row carries the durable run id
+          runId: askRunId as never,
+          nodeId: ask.nodeId,
+          execId,
+          launchedAt: Date.now(),
+          ...(auth.brokerTokenHash !== undefined
+            ? { brokerTokenHash: auth.brokerTokenHash }
+            : {}),
+        },
+      );
       await ctx.runMutation(
         internal.sandbox.session_mutations.upsertSessionOp,
         {
@@ -1522,6 +1596,7 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
       await settleWorkflowAgentTurn(ctx, keys, {
         errored: true,
         reason: `the agent turn could not resume after the answer: ${err instanceof Error ? err.message : String(err)}`,
+        failureCode: 'resume_failed',
         text: '',
         files: [],
       });
@@ -1667,6 +1742,7 @@ async function continueOrSettle(
     await settleWorkflowAgentTurn(ctx, args, {
       errored: true,
       reason: 'the sandbox session ended before the agent turn finished',
+      failureCode: 'session_gone',
       text: '',
       files: [],
     });
@@ -1753,6 +1829,19 @@ async function continueOrSettle(
     {
       errored,
       ...(crashReason !== undefined ? { reason: crashReason } : {}),
+      // Classification for the retry gate: a harness-reported error and a
+      // crashed-no-result window both read `harness_error` (mirroring the
+      // task lane), except a death at the deadline — retrying a burned 12h
+      // window is waste. The API status rides along for display only.
+      ...(errored
+        ? {
+            failureCode:
+              Date.now() > args.deadlineAt ? 'deadline' : 'harness_error',
+          }
+        : {}),
+      ...(errored && ended?.apiErrorStatus !== undefined
+        ? { apiErrorStatus: ended.apiErrorStatus }
+        : {}),
       text,
       files: [],
       ...(ended?.status !== undefined ? { status: ended.status } : {}),
@@ -1862,8 +1951,9 @@ async function settleWorkflowAgentTurn(
       ...result,
       files,
       ...(harvestSkipped !== undefined ? { harvestSkipped } : {}),
-      // An already-errored turn keeps its primary reason; the harvest fault
-      // rides along instead of replacing it.
+      // An already-errored turn keeps its primary reason AND its primary
+      // failure code (a denylisted code must not be laundered into a
+      // retryable harvest_failed); the harvest fault rides along.
       ...(harvestError !== undefined
         ? {
             errored: true,
@@ -1871,6 +1961,7 @@ async function settleWorkflowAgentTurn(
               result.errored && result.reason !== undefined
                 ? `${result.reason}; output harvest failed: ${harvestError}`
                 : `output harvest failed: ${harvestError}`,
+            failureCode: result.failureCode ?? 'harvest_failed',
           }
         : {}),
     },

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -1379,6 +1379,11 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
       gatewayModel: agent.gatewayModel,
       deadlineAt,
     };
+    // Which exec the cursor names decides where a failure settle can land:
+    // before the retarget it still names the ASKING exec, so a settle under
+    // the fresh id would be refused by the record's execId fence and the run
+    // would sit parked until its ask-extended deadline.
+    let retargeted = false;
     try {
       // The wait may have outlived the container (idle reaper stops and
       // preserves) — the session volume holds the workspace AND the harness's
@@ -1477,6 +1482,7 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
         );
         return null;
       }
+      retargeted = true;
       // Launch facts under the resume's exec (the retarget just installed
       // it): executed time measures the post-answer slice, matching the
       // task lane's per-launch semantics.
@@ -1593,13 +1599,23 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
       await continueOrSettle(ctx, keys, window);
     } catch (err) {
       console.error('[agent-host] answered-ask resume failed:', err);
-      await settleWorkflowAgentTurn(ctx, keys, {
-        errored: true,
-        reason: `the agent turn could not resume after the answer: ${err instanceof Error ? err.message : String(err)}`,
-        failureCode: 'resume_failed',
-        text: '',
-        files: [],
-      });
+      // A death BEFORE the retarget settles under the asking exec the cursor
+      // still names: its finalize claim was burned at the ask park, but the
+      // dead-winner branch completes the record (cursor matches, no result),
+      // so the run wakes into the retry gate instead of burning silently to
+      // the ask-extended deadline. After the retarget the fresh exec is the
+      // cursor's, and the settle targets it as before.
+      await settleWorkflowAgentTurn(
+        ctx,
+        retargeted ? keys : { ...keys, execId: ask.execId },
+        {
+          errored: true,
+          reason: `the agent turn could not resume after the answer: ${err instanceof Error ? err.message : String(err)}`,
+          failureCode: 'resume_failed',
+          text: '',
+          files: [],
+        },
+      );
     }
     return null;
   },

--- a/services/platform/convex/automations/agent_retry.test.ts
+++ b/services/platform/convex/automations/agent_retry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure-function tests for the agent node's in-node auto-retry gate. The
+ * convex-test halves — the re-kick in place, the launch-stamp fences, and
+ * the burned-hash threading — live in stepper.test.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTO_RETRY_MAX_ATTEMPTS,
+  AUTO_RETRY_PROGRESS_MS,
+  executedMsOf,
+  isWorkflowAgentRetryable,
+  MAX_BURNED_BROKER_HASHES,
+  mergeBurnedHashes,
+  nextAttempt,
+} from './agent_retry';
+
+describe('isWorkflowAgentRetryable', () => {
+  it('denies exactly the wasted-window codes', () => {
+    expect(isWorkflowAgentRetryable('deadline')).toBe(false);
+    expect(isWorkflowAgentRetryable('ask_expired')).toBe(false);
+  });
+
+  it('retries every produced failure code by default', () => {
+    for (const code of [
+      'harness_error',
+      'turn_crashed',
+      'session_gone',
+      'start_failed',
+      'harvest_failed',
+      'resume_failed',
+    ]) {
+      expect(isWorkflowAgentRetryable(code)).toBe(true);
+    }
+  });
+
+  it('an absent or unknown code inherits the retry posture', () => {
+    expect(isWorkflowAgentRetryable(undefined)).toBe(true);
+    expect(isWorkflowAgentRetryable('some_future_code')).toBe(true);
+  });
+});
+
+describe('executedMsOf', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('a missing launch stamp reads as zero, never as a long run', () => {
+    expect(executedMsOf(undefined, NOW)).toBe(0);
+  });
+
+  it('measures launch to settle consumption, floored at zero', () => {
+    expect(executedMsOf(NOW - 60_000, NOW)).toBe(60_000);
+    expect(executedMsOf(NOW + 5_000, NOW)).toBe(0);
+  });
+});
+
+describe('nextAttempt', () => {
+  it('counts short-lived failures toward the budget', () => {
+    expect(nextAttempt(0, 0)).toBe(1);
+    expect(nextAttempt(1, AUTO_RETRY_PROGRESS_MS - 1)).toBe(2);
+    expect(nextAttempt(AUTO_RETRY_MAX_ATTEMPTS, 0)).toBe(
+      AUTO_RETRY_MAX_ATTEMPTS + 1,
+    );
+  });
+
+  it('an attempt that executed past the threshold refreshes the budget', () => {
+    expect(nextAttempt(AUTO_RETRY_MAX_ATTEMPTS, AUTO_RETRY_PROGRESS_MS)).toBe(
+      1,
+    );
+  });
+});
+
+describe('mergeBurnedHashes', () => {
+  it('appends the settled attempt hash, deduped and most recent last', () => {
+    expect(mergeBurnedHashes(undefined, 'a')).toEqual(['a']);
+    expect(mergeBurnedHashes(['a'], 'b')).toEqual(['a', 'b']);
+    expect(mergeBurnedHashes(['a', 'b'], 'a')).toEqual(['b', 'a']);
+    expect(mergeBurnedHashes(['a'], undefined)).toEqual(['a']);
+  });
+
+  it('drops the oldest entries past the cap', () => {
+    const many = Array.from({ length: MAX_BURNED_BROKER_HASHES + 2 }, (_, i) =>
+      String(i),
+    );
+    const merged = mergeBurnedHashes(many, 'z');
+    expect(merged).toHaveLength(MAX_BURNED_BROKER_HASHES);
+    expect(merged.at(-1)).toBe('z');
+    expect(merged[0]).toBe('3');
+  });
+});

--- a/services/platform/convex/automations/agent_retry.ts
+++ b/services/platform/convex/automations/agent_retry.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure auto-retry gating for the automation `agent` node. Isolated like
+ * `tasks/task_auto_retry.ts` so the logic is unit-testable without a
+ * database; the orchestration (consume the errored settle → decide → re-kick
+ * in place) lives in `stepper.ts` (`stepAgentNode`).
+ *
+ * Semantics (2026-08-23, parity with the task lane): a failed turn re-kicks
+ * immediately — no backoff, the harness already backed off per-request —
+ * under a fixed in-node budget. Unlike the task lane there is no run-history
+ * walk: the attempt counter lives on the agent cursor and dies with the node
+ * execution, so only the progress reset survives from the streak semantics.
+ */
+
+import {
+  AUTO_RETRY_MAX_ATTEMPTS,
+  AUTO_RETRY_PROGRESS_MS,
+} from '../tasks/task_auto_retry';
+
+export { AUTO_RETRY_MAX_ATTEMPTS, AUTO_RETRY_PROGRESS_MS };
+
+/** Producer-side failure classification, stamped where each failure is
+ * PRODUCED (the `agent_host.ts` settle sites) — never regex-derived from the
+ * free-text reason. */
+export type WorkflowAgentFailureCode =
+  | 'harness_error'
+  | 'turn_crashed'
+  | 'session_gone'
+  | 'start_failed'
+  | 'harvest_failed'
+  | 'resume_failed'
+  | 'deadline'
+  | 'ask_expired';
+
+/** Failures where a retry is pure waste: the turn burned its 12h window, or
+ * the operator ignored the agent's question for the whole ask TTL — a fresh
+ * turn would only ask again. Everything else — provider errors, crashes,
+ * vanished sessions, harvest hiccups — retries by DEFAULT, including an
+ * absent code, so a future failure producer inherits the retry posture
+ * without opting in. */
+const NO_RETRY_FAILURE_CODES: ReadonlySet<string> = new Set([
+  'deadline',
+  'ask_expired',
+] satisfies WorkflowAgentFailureCode[]);
+
+export function isWorkflowAgentRetryable(code: string | undefined): boolean {
+  return code === undefined || !NO_RETRY_FAILURE_CODES.has(code);
+}
+
+/** Execution time of the settled attempt — 0 when it never launched.
+ * `launchedAt` is stamped only after the start action's mint succeeds, so a
+ * turn that died before actually running reads as ZERO duration, never as
+ * progress (the stamp racing the kick-side cursor commit loses the same
+ * way, deliberately: a missing stamp must undercount, not reset). */
+export function executedMsOf(
+  launchedAt: number | undefined,
+  now: number,
+): number {
+  if (launchedAt === undefined) return 0;
+  return Math.max(0, now - launchedAt);
+}
+
+/** The attempt number the re-kick parks under: an attempt that executed past
+ * the progress threshold proved the failure is not a rapid crash loop, so
+ * the budget refreshes instead of counting toward exhaustion. */
+export function nextAttempt(prev: number, executedMs: number): number {
+  return executedMs >= AUTO_RETRY_PROGRESS_MS ? 1 : prev + 1;
+}
+
+/** The burned-hash list is bounded because progress resets can stretch one
+ * node execution past the nominal 4 attempts; the exclusion is soft (the
+ * credential resolve falls back to the full pool when it would empty it),
+ * so dropping the oldest entries only widens rotation, never starves it. */
+export const MAX_BURNED_BROKER_HASHES = 8;
+
+/** Fold the settled attempt's broker-token hash into the carried exclusion
+ * list: deduped, most recent last, oldest dropped past the cap. */
+export function mergeBurnedHashes(
+  prev: readonly string[] | undefined,
+  current: string | undefined,
+): string[] {
+  const merged: string[] = [];
+  for (const hash of [
+    ...(prev ?? []),
+    ...(current === undefined ? [] : [current]),
+  ]) {
+    const existing = merged.indexOf(hash);
+    if (existing !== -1) merged.splice(existing, 1);
+    merged.push(hash);
+  }
+  return merged.slice(-MAX_BURNED_BROKER_HASHES);
+}

--- a/services/platform/convex/automations/checkpoints.ts
+++ b/services/platform/convex/automations/checkpoints.ts
@@ -54,6 +54,14 @@ export interface AgentTurnFile {
 export interface AgentTurnResult {
   errored: boolean;
   reason?: string;
+  /** Producer-side classification of an errored settle (a
+   * `WorkflowAgentFailureCode`), read by the stepper's auto-retry gate.
+   * Absent on results settled before the field existed — that reads as
+   * retryable by design. */
+  failureCode?: string;
+  /** HTTP status of a turn-terminating API error the harness reported
+   * (429, 401, …), carried for display — never branched on for retry. */
+  apiErrorStatus?: number;
   text: string;
   files: AgentTurnFile[];
   /** Outputs the harvest could not bring back (over a cap, unreadable,
@@ -85,6 +93,21 @@ export interface AgentCursor {
   gatewayModel: string;
   harness: string;
   input: Record<string, unknown>;
+  /** How many auto-retries preceded this attempt (0 = the original kick).
+   * The counter lives here — not on the run row — so it dies with the node
+   * execution and `finishRun`'s cursor drop. */
+  attempt?: number;
+  /** Stamped by `stampAgentTurnLaunch` once the start action's mint
+   * succeeds. Absent ⇒ the attempt never actually ran; the retry gate then
+   * counts ZERO executed time, never a long run. */
+  launchedAt?: number;
+  /** sha256 of the subscription-broker token this attempt was minted on
+   * (absent on the gateway lane), so a retry can rotate away from it. */
+  brokerTokenHash?: string;
+  /** Broker-token hashes burned by prior failed attempts of this node
+   * execution, carried so the re-kick's mint can exclude them (softly — an
+   * exhausted pool falls back to every account). */
+  burnedBrokerTokenHashes?: string[];
   result?: AgentTurnResult;
 }
 

--- a/services/platform/convex/automations/mutations.ts
+++ b/services/platform/convex/automations/mutations.ts
@@ -1466,6 +1466,69 @@ export const recordAgentTurnSettled = internalMutation({
 });
 
 /**
+ * Stamp launch facts onto the parked agent cursor once the start action's
+ * mint succeeds: when the attempt actually began executing, and (on the
+ * subscription lane) which broker account served it. Best-effort by design —
+ * the stamp races the kick-side cursor commit, and losing that race leaves
+ * `launchedAt` absent, which the retry gate reads as ZERO executed time
+ * (undercounting progress is safe; overcounting would re-arm the budget).
+ * The gates mirror `recordAgentTurnSettled`: a stamp arriving after the turn
+ * settled or after a re-kick moved the cursor to a new exec is refused.
+ */
+export const stampAgentTurnLaunch = internalMutation({
+  args: {
+    organizationId: v.string(),
+    runId: v.id('automationRuns'),
+    nodeId: v.string(),
+    execId: v.string(),
+    launchedAt: v.number(),
+    brokerTokenHash: v.optional(v.string()),
+  },
+  returns: v.object({ stamped: v.boolean() }),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.runId);
+    if (!row || row.organizationId !== args.organizationId) {
+      return { stamped: false };
+    }
+    if (
+      row.status !== 'waiting' &&
+      row.status !== 'running' &&
+      row.status !== 'queued'
+    ) {
+      return { stamped: false };
+    }
+    const checkpoints = readCheckpoints(row.checkpoints);
+    const cursor = checkpoints.cursor;
+    if (
+      cursor === undefined ||
+      cursor.node !== args.nodeId ||
+      cursor.agent === undefined ||
+      cursor.agent.execId !== args.execId ||
+      cursor.agent.result !== undefined
+    ) {
+      return { stamped: false };
+    }
+    await ctx.db.patch(args.runId, {
+      checkpoints: {
+        nodes: checkpoints.nodes,
+        cursor: {
+          ...cursor,
+          agent: {
+            ...cursor.agent,
+            launchedAt: args.launchedAt,
+            ...(args.brokerTokenHash !== undefined && {
+              brokerTokenHash: args.brokerTokenHash,
+            }),
+          },
+        },
+        executions: checkpoints.executions,
+      },
+    });
+    return { stamped: true };
+  },
+});
+
+/**
  * Start the deployed automation a task's Start action names, as a live run
  * carrying the task as its input — the task-surface entry the retired engine
  * used to serve. Authorization is the CALLER's: the public task action has

--- a/services/platform/convex/automations/queries.ts
+++ b/services/platform/convex/automations/queries.ts
@@ -27,6 +27,7 @@ import { internalQuery, query } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { sessionOpLastSignOfLifeMs } from '../sandbox/agent_deadline';
+import { AUTO_RETRY_MAX_ATTEMPTS } from './agent_retry';
 import { readCheckpoints } from './checkpoints';
 import {
   automationReadStore,
@@ -435,6 +436,9 @@ export const getRun = query({
       detail: v.optional(v.string()),
       startedAt: v.number(),
       finishedAt: v.optional(v.number()),
+      /** The engine's agent-node auto-retry cap, projected so the retry
+       * caption never hardcodes it. */
+      agentAutoRetryMax: v.number(),
     }),
   ),
   handler: async (ctx, args) => {
@@ -444,6 +448,7 @@ export const getRun = query({
     // learns nothing about whether it exists elsewhere.
     if (!row || row.organizationId !== args.organizationId) return null;
     return {
+      agentAutoRetryMax: AUTO_RETRY_MAX_ATTEMPTS,
       id: row._id,
       name: row.name,
       version: row.version,

--- a/services/platform/convex/automations/stepper.test.ts
+++ b/services/platform/convex/automations/stepper.test.ts
@@ -1296,6 +1296,117 @@ describe('durable stepper — agent auto-retry', () => {
     expect(agentKicks[0]?.excludeBrokerTokenHashes).toBeUndefined();
   });
 
+  it('a resume that dies before the retarget settles under the asking exec and the retry rescues the run', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const input = {
+      model: 'vendor/coder-1',
+      prompt: 'Read invoices for 2026Q1',
+    };
+    // A run parked on an answered ask: the cursor still names the asking
+    // exec, whose op was finalized (claim burned) when the ask parked.
+    const runId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('automationRuns', {
+          organizationId: ORG,
+          name: 'ops/read-invoices',
+          version: 1,
+          status: 'waiting',
+          mode: 'live',
+          startedBy: `user:${ACTOR}`,
+          input: { quarter: '2026Q1', folderId: 'fld_1' },
+          checkpoints: {
+            nodes: {},
+            cursor: {
+              node: 'extract',
+              index: 0,
+              passes: 0,
+              outs: [],
+              agent: {
+                execId: 'ask-exec-1',
+                sessionId: 'wf-test-session',
+                deadlineAt: Date.now() + 7 * 24 * 3_600_000,
+                providerSlug: 'vendor',
+                gatewayModel: 'vendor/coder-1',
+                harness: 'claude-code',
+                input,
+              },
+            },
+            executions: 1,
+          },
+          startedAt: Date.now(),
+        }),
+    );
+    const askId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('automationHumanAsks', {
+          organizationId: ORG,
+          runId,
+          nodeId: 'extract',
+          sessionId: 'wf-test-session',
+          execId: 'ask-exec-1',
+          question: 'Which quarter?',
+          status: 'answered',
+          answer: '2026Q1',
+          expiresAt: Date.now() + 7 * 24 * 3_600_000,
+          createdAt: Date.now(),
+        }),
+    );
+    await t.mutation(internal.sandbox.session_mutations.upsertSessionOp, {
+      organizationId: ORG,
+      sessionId: 'wf-test-session',
+      execId: 'ask-exec-1',
+      kind: 'workflow-agent',
+      status: 'completed',
+      agentResultStatus: 'awaiting_human',
+    });
+    await t.mutation(
+      internal.sandbox.session_mutations.claimSessionOpFinalize,
+      {
+        sessionId: 'wf-test-session',
+        execId: 'ask-exec-1',
+      },
+    );
+
+    // The REAL resume action: the suite's fetch stub kills it long before the
+    // retarget (session ensure / serving / mint all reach the network), so
+    // the catch must settle under the ASKING exec the cursor still names.
+    await t.action(
+      internal.automations.agent_host.resumeWorkflowAgentTurnWithAnswer,
+      { organizationId: ORG, askId },
+    );
+
+    const settled = await agentCursor(t, runId);
+    expect(settled.execId).toBe('ask-exec-1');
+    expect(settled.result).toMatchObject({
+      errored: true,
+      failureCode: 'resume_failed',
+    });
+    expect(settled.result?.reason).toContain(
+      'could not resume after the answer',
+    );
+
+    // The settle wakes the run into the retry gate: a fresh attempt kicks,
+    // and its success finishes the run — the answered ask no longer strands
+    // it until the ask-extended deadline.
+    await turn(t, runId);
+    expect(agentKicks).toHaveLength(1);
+    expect(agentKicks[0]?.request).toEqual(input);
+    expect(await agentCursor(t, runId)).toMatchObject({
+      execId: 'exec-1',
+      attempt: 1,
+    });
+    await t.mutation(internal.automations.mutations.recordAgentTurnSettled, {
+      organizationId: ORG,
+      runId,
+      nodeId: 'extract',
+      execId: 'exec-1',
+      result: { errored: false, text: 'extracted', files: [], status: 'ok' },
+    });
+    expect(await drive(t, runId)).toBe('success');
+  });
+
   it('a stale settle from the replaced exec records nothing after the re-kick', async () => {
     recordingAgentFactory();
     const t = convexTest(schema, modules);

--- a/services/platform/convex/automations/stepper.test.ts
+++ b/services/platform/convex/automations/stepper.test.ts
@@ -821,19 +821,33 @@ const readInvoices: Automation = {
 };
 
 /** Every kick/cancel the stepper asked the agent door for. */
-const agentKicks: Array<{ runId: string; nodeId: string; request: unknown }> =
-  [];
+const agentKicks: Array<{
+  runId: string;
+  nodeId: string;
+  request: unknown;
+  excludeBrokerTokenHashes?: string[];
+}> = [];
 const agentCancels: Array<{ sessionId: string; execId: string }> = [];
 
-/** A recording agent host: kicks park, polls see nothing (the settle writes
- * straight into the cursor, which the next turn reads), cancels record. */
+/** A recording agent host: kicks park under sequential exec ids (`exec-1`,
+ * `exec-2`, … — a retry's re-kick is a fresh exec), polls see nothing (the
+ * settle writes straight into the cursor, which the next turn reads),
+ * cancels record. */
 function recordingAgentFactory(kick?: () => never): void {
   setAutomationAgentHostFactory((_ctx, _organizationId) => ({
-    kick: async ({ runId, nodeId, request }) => {
+    kick: async ({ runId, nodeId, request, excludeBrokerTokenHashes }) => {
       if (kick !== undefined) kick();
-      agentKicks.push({ runId, nodeId, request });
+      const execId = `exec-${agentKicks.length + 1}`;
+      agentKicks.push({
+        runId,
+        nodeId,
+        request,
+        ...(excludeBrokerTokenHashes !== undefined
+          ? { excludeBrokerTokenHashes }
+          : {}),
+      });
       return {
-        execId: 'exec-1',
+        execId,
         sessionId: 'wf-session-1',
         deadlineAt: Date.now() + 60_000,
         providerSlug: 'vendor',
@@ -998,7 +1012,7 @@ describe('durable stepper — agent nodes', () => {
     ]);
   });
 
-  it('an errored settle fails the node with its reason', async () => {
+  it('a denylisted errored settle fails the node with its reason, no retry', async () => {
     recordingAgentFactory();
     const t = convexTest(schema, modules);
     await publish(t, readInvoices);
@@ -1015,7 +1029,8 @@ describe('durable stepper — agent nodes', () => {
       execId: 'exec-1',
       result: {
         errored: true,
-        reason: 'the agent turn could not start: staging skills failed',
+        reason: 'the agent turn ran past its time limit and was stopped',
+        failureCode: 'deadline',
         text: '',
         files: [],
       },
@@ -1023,7 +1038,9 @@ describe('durable stepper — agent nodes', () => {
 
     expect(await drive(t, runId)).toBe('failed');
     const row = await runRow(t, runId);
-    expect(row.detail).toContain('staging skills failed');
+    expect(row.detail).toContain('ran past its time limit');
+    expect(row.detail).not.toContain('attempts');
+    expect(agentKicks).toHaveLength(1);
   });
 
   it('a stale settle records nothing and resurrects nothing', async () => {
@@ -1048,6 +1065,267 @@ describe('durable stepper — agent nodes', () => {
     );
     expect(recorded).toEqual({ recorded: false });
     expect((await runRow(t, runId)).status).toBe('waiting');
+  });
+});
+
+describe('durable stepper — agent auto-retry', () => {
+  /** Settle the given exec as a retryable failure (no code = default-retry). */
+  async function settleErrored(
+    t: T,
+    runId: Id<'automationRuns'>,
+    execId: string,
+    result: Record<string, unknown> = {},
+  ) {
+    return await t.mutation(
+      internal.automations.mutations.recordAgentTurnSettled,
+      {
+        organizationId: ORG,
+        runId,
+        nodeId: 'extract',
+        execId,
+        result: {
+          errored: true,
+          reason: 'the agent turn could not start: fetch failed',
+          failureCode: 'start_failed',
+          text: '',
+          files: [],
+          ...result,
+        },
+      },
+    );
+  }
+
+  async function agentCursor(t: T, runId: Id<'automationRuns'>) {
+    const cursor = readCheckpoints((await runRow(t, runId)).checkpoints).cursor;
+    if (cursor?.agent === undefined) throw new Error('no parked agent cursor');
+    return cursor.agent;
+  }
+
+  it('re-kicks a retryable failure in place and consumes the retry settle', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    await settleErrored(t, runId, 'exec-1');
+    await turn(t, runId);
+
+    // Parked again on a fresh exec, run alive, attempt counted.
+    const parked = await runRow(t, runId);
+    expect(parked.status).toBe('waiting');
+    expect(parked.detail).toBe('agent:extract');
+    expect(await agentCursor(t, runId)).toMatchObject({
+      execId: 'exec-2',
+      attempt: 1,
+    });
+    expect(agentKicks).toHaveLength(2);
+    // The retry re-kicks the SAME resolved request — no template re-eval.
+    expect(agentKicks[1]?.request).toEqual(agentKicks[0]?.request);
+
+    await t.mutation(internal.automations.mutations.recordAgentTurnSettled, {
+      organizationId: ORG,
+      runId,
+      nodeId: 'extract',
+      execId: 'exec-2',
+      result: { errored: false, text: 'extracted', files: [], status: 'ok' },
+    });
+    expect(await drive(t, runId)).toBe('success');
+    const row = await runRow(t, runId);
+    expect(row.output).toMatchObject({ text: 'extracted' });
+    // Exactly one agent effect lands — the consuming turn's.
+    expect(
+      (row.effects as Array<{ connector: string }>).filter(
+        (effect) => effect.connector === 'agent',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('exhausts the budget after three retries and records the attempt count', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    for (const execId of ['exec-1', 'exec-2', 'exec-3']) {
+      await settleErrored(t, runId, execId);
+      await turn(t, runId);
+      expect((await runRow(t, runId)).status).toBe('waiting');
+    }
+    expect(await agentCursor(t, runId)).toMatchObject({
+      execId: 'exec-4',
+      attempt: 3,
+    });
+    await settleErrored(t, runId, 'exec-4');
+
+    expect(await drive(t, runId)).toBe('failed');
+    const row = await runRow(t, runId);
+    expect(row.detail).toContain('fetch failed');
+    expect(row.detail).toContain('(after 4 attempts)');
+    // The budget is spent — no fifth kick.
+    expect(agentKicks).toHaveLength(4);
+  });
+
+  it('a settle without a failure code retries by default', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    // No reason, no code — the pre-classification settle shape.
+    await t.mutation(internal.automations.mutations.recordAgentTurnSettled, {
+      organizationId: ORG,
+      runId,
+      nodeId: 'extract',
+      execId: 'exec-1',
+      result: {
+        errored: true,
+        text: 'API Error: Request rejected (429)',
+        files: [],
+      },
+    });
+    await turn(t, runId);
+
+    expect((await runRow(t, runId)).status).toBe('waiting');
+    expect(agentKicks).toHaveLength(2);
+  });
+
+  it('an expired ask never retries — a fresh turn would only re-ask', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    await settleErrored(t, runId, 'exec-1', {
+      reason:
+        'the agent asked the operator a question and nobody answered within 7 days',
+      failureCode: 'ask_expired',
+    });
+
+    expect(await drive(t, runId)).toBe('failed');
+    expect((await runRow(t, runId)).detail).toContain('nobody answered');
+    expect(agentKicks).toHaveLength(1);
+  });
+
+  it('an attempt that executed past the progress threshold refreshes the budget and keeps burned hashes', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    await settleErrored(t, runId, 'exec-1');
+    await turn(t, runId);
+    await settleErrored(t, runId, 'exec-2');
+    await turn(t, runId);
+    expect(await agentCursor(t, runId)).toMatchObject({
+      execId: 'exec-3',
+      attempt: 2,
+    });
+
+    // Attempt 2 launches, runs past the progress threshold on a broker
+    // account, then fails: the counter resets, the burned account does not.
+    const stamped = await t.mutation(
+      internal.automations.mutations.stampAgentTurnLaunch,
+      {
+        organizationId: ORG,
+        runId,
+        nodeId: 'extract',
+        execId: 'exec-3',
+        launchedAt: Date.now() - 16 * 60_000,
+        brokerTokenHash: 'hash-b',
+      },
+    );
+    expect(stamped).toEqual({ stamped: true });
+    await settleErrored(t, runId, 'exec-3');
+    await turn(t, runId);
+
+    expect(await agentCursor(t, runId)).toMatchObject({
+      execId: 'exec-4',
+      attempt: 1,
+      burnedBrokerTokenHashes: ['hash-b'],
+    });
+    expect(agentKicks[3]?.excludeBrokerTokenHashes).toEqual(['hash-b']);
+  });
+
+  it("rotation: the re-kick excludes the settled attempt's broker account", async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    await t.mutation(internal.automations.mutations.stampAgentTurnLaunch, {
+      organizationId: ORG,
+      runId,
+      nodeId: 'extract',
+      execId: 'exec-1',
+      launchedAt: Date.now(),
+      brokerTokenHash: 'hash-a',
+    });
+    await settleErrored(t, runId, 'exec-1');
+    await turn(t, runId);
+
+    expect(agentKicks[1]?.excludeBrokerTokenHashes).toEqual(['hash-a']);
+    expect(await agentCursor(t, runId)).toMatchObject({
+      execId: 'exec-2',
+      burnedBrokerTokenHashes: ['hash-a'],
+    });
+    // The first kick carried no exclusions.
+    expect(agentKicks[0]?.excludeBrokerTokenHashes).toBeUndefined();
+  });
+
+  it('a stale settle from the replaced exec records nothing after the re-kick', async () => {
+    recordingAgentFactory();
+    const t = convexTest(schema, modules);
+    await publish(t, readInvoices);
+    const runId = await queueRun(t, 'ops/read-invoices', {
+      quarter: '2026Q1',
+      folderId: 'fld_1',
+    });
+
+    await turn(t, runId);
+    await settleErrored(t, runId, 'exec-1');
+    await turn(t, runId);
+
+    // The dead attempt's chain settles late — refused, the retry unharmed.
+    const stale = await settleErrored(t, runId, 'exec-1');
+    expect(stale).toEqual({ recorded: false });
+    const launch = await t.mutation(
+      internal.automations.mutations.stampAgentTurnLaunch,
+      {
+        organizationId: ORG,
+        runId,
+        nodeId: 'extract',
+        execId: 'exec-1',
+        launchedAt: Date.now(),
+      },
+    );
+    expect(launch).toEqual({ stamped: false });
+    const cursor = await agentCursor(t, runId);
+    expect(cursor.execId).toBe('exec-2');
+    expect(cursor.launchedAt).toBeUndefined();
   });
 });
 

--- a/services/platform/convex/automations/stepper.ts
+++ b/services/platform/convex/automations/stepper.ts
@@ -67,6 +67,13 @@ import {
   type AutomationAgentHost,
   type WorkflowAgentRequest,
 } from './agent_host';
+import {
+  AUTO_RETRY_MAX_ATTEMPTS,
+  executedMsOf,
+  isWorkflowAgentRetryable,
+  mergeBurnedHashes,
+  nextAttempt,
+} from './agent_retry';
 import type {
   AgentCursor,
   NodeCheckpoint,
@@ -1086,11 +1093,79 @@ async function stepAgentNode(args: AgentStepArgs): Promise<StepOutcome> {
   }
 
   if (settled.errored) {
-    throw new Error(
+    const reason =
       settled.reason ??
-        (settled.text !== ''
-          ? `the agent turn failed: ${settled.text.slice(0, 300)}`
-          : 'the agent turn ended without producing a reply'),
+      (settled.text !== ''
+        ? `the agent turn failed: ${settled.text.slice(0, 300)}`
+        : 'the agent turn ended without producing a reply');
+    const attempt = parked.attempt ?? 0;
+    // In-node auto-retry (task-lane parity): a retryable failure re-kicks the
+    // SAME resolved request in place — upstream checkpoints, the run row, and
+    // the session workspace all survive — under a fixed budget. An attempt
+    // that executed past the progress threshold refreshes the budget instead
+    // of counting toward it, so `nextAttempt` both gates and numbers the
+    // re-kick. Exhaustion and denylisted codes fall through to the throw,
+    // which is the run's durable record of how many attempts burned.
+    const retryAttempt = nextAttempt(
+      attempt,
+      executedMsOf(parked.launchedAt, Date.now()),
+    );
+    if (
+      isWorkflowAgentRetryable(settled.failureCode) &&
+      retryAttempt <= AUTO_RETRY_MAX_ATTEMPTS &&
+      // The runaway guard charges only executions that happen: a trip here
+      // falls through to the exhaust throw carrying the settle's reason.
+      checkpoints.executions < DEFAULT_MAX_NODE_EXECUTIONS
+    ) {
+      checkpoints.executions++;
+      const burned = mergeBurnedHashes(
+        parked.burnedBrokerTokenHashes,
+        parked.brokerTokenHash,
+      );
+      const kicked = await run.agent.kick({
+        runId: run.runId,
+        nodeId: node.id,
+        // The reverse of the kick-time cast: the request was stored as
+        // plain JSON, and the start action re-validates it anyway.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- recorded verbatim from a WorkflowAgentRequest at kick time
+        request: parked.input as unknown as WorkflowAgentRequest,
+        ...(burned.length > 0 ? { excludeBrokerTokenHashes: burned } : {}),
+      });
+      const agent: AgentCursor = {
+        execId: kicked.execId,
+        sessionId: kicked.sessionId,
+        deadlineAt: kicked.deadlineAt,
+        providerSlug: kicked.providerSlug,
+        gatewayModel: kicked.gatewayModel,
+        harness: kicked.harness,
+        input: parked.input,
+        attempt: retryAttempt,
+        ...(burned.length > 0 ? { burnedBrokerTokenHashes: burned } : {}),
+      };
+      const cursor: NodeCursor = {
+        node: node.id,
+        index: 0,
+        passes: 0,
+        outs: [],
+        agent,
+      };
+      const waited = await sink.wait({
+        detail: `agent:${node.id}`,
+        cursor,
+        executions: checkpoints.executions,
+        resumeInMs: AGENT_POLL_MS,
+      });
+      if (waited === 'cancelled') return { kind: 'cancelled' };
+      if (waited === 'suspended') {
+        checkpoints.cursor = cursor;
+        return { kind: 'suspended' };
+      }
+      throw new Error(
+        'an agent node cannot run inside a subautomation — hoist it to the top level of the calling automation',
+      );
+    }
+    throw new Error(
+      attempt > 0 ? `${reason} (after ${attempt + 1} attempts)` : reason,
     );
   }
   const output = {

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -784,6 +784,9 @@ automations:
     heading: 'Lauf von {automation}'
     empty: Diese Automatisierung ist noch nicht gelaufen.
     loading: Lauf wird geladen …
+    # Während die Plattform den fehlgeschlagenen Agent-Schritt von selbst
+    # wiederholt — damit klar ist, dass nicht du es warst.
+    autoRetrying: 'Automatischer Versuch {n} von {max}'
     cancel: Lauf stoppen
     startedBy: 'Gestartet von {actor}'
     startedAt: 'Gestartet {date}'

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -750,6 +750,9 @@ automations:
     heading: 'Run of {automation}'
     empty: This automation has not run yet.
     loading: Loading the run…
+    # The engine's own retry of a failed agent turn — the user must be able
+    # to tell the platform's retry from their own rerun.
+    autoRetrying: 'Auto-retry {n} of {max}'
     cancel: Stop the run
     startedBy: 'Started by {actor}'
     startedAt: 'Started {date}'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -790,6 +790,9 @@ automations:
     heading: 'Exécution de {automation}'
     empty: Cette automatisation ne s’est encore jamais exécutée.
     loading: Chargement de l’exécution…
+    # Pendant que la plateforme retente d’elle-même l’étape agent échouée —
+    # pour distinguer sa relance de la tienne.
+    autoRetrying: 'Tentative automatique {n} sur {max}'
     cancel: Arrêter l’exécution
     startedBy: 'Lancée par {actor}'
     startedAt: 'Lancée {date}'


### PR DESCRIPTION
## What

An automation `agent` node that fails for a retryable reason no longer fails the whole run on the first error. The stepper re-kicks the same resolved request in place — fresh exec, attempt counter on the cursor, upstream checkpoints and the run session untouched — up to 3 automatic retries, mirroring the task lane's semantics (PR #3030):

- **Default-retry posture** with a producer-stamped `failureCode` at every settle site (never regex on reason text). Denylist: `deadline`, `ask_expired` — a fresh attempt cannot end differently there. `apiErrorStatus` now rides the settle for display (it was in scope at the classify site and discarded).
- **15-minute progress reset**: an attempt that actually executed past the threshold refreshes the budget instead of spending it (`launchedAt` stamped post-mint by the new `stampAgentTurnLaunch`; absent reads as zero, never as a long run).
- **Broker rotation**: the mint hashes the vended subscription-broker token onto the cursor; a re-kick (and an answered-ask resume) excludes the accounts prior attempts burned, through the existing soft `excludeBrokerTokenHashes` seam — a one-account org retries on its only account.
- Exhaustion fails the run with the last error plus `(after N attempts)` — the durable record, since `finishRun` drops the cursor.

Everything persists through the existing `v.any()` checkpoints: no schema change, no migration. Task-triggered workflow runs get the same behavior; the run stays one live run throughout and **Stop the run** remains the operator's out.

Also in this PR, found by the adversarial design review and fixed on the same branch:

- **`fix`: a resume that died before the cursor retarget** (session cap, serving, mint) settled under the fresh exec while the cursor still named the asking exec — the settle was dropped by the execId fence, the watchdog spared the row as an ask park, and the run sat silently until its ask-extended deadline with the human's answer wasted. The catch now settles under whichever exec the cursor names; the burned finalize claim takes the existing dead-winner branch, and the run wakes into the retry gate.

## UI / docs

- Run header counts platform retries — `Auto-retry {n} of {max}` (en/de/fr, max projected by the server) — so the engine's retry is distinguishable from a manual rerun.
- The run page now passes the cursor node into `nodeStatusMap`: the parked node shows **Running** during flight instead of pending.
- `execution-logs.md` gains a "When an agent step fails" section in all three locales (including the cost note: up to 4 metered turns).

## Verification

- New pure-module tests plus a stepper retry suite: retry-then-succeed, denylist no-retry, budget exhaustion ("after 4 attempts", no fifth kick), progress reset preserving burned hashes, stale settle from the replaced exec refused, rotation threading, launch-stamp execId fence, and the pre-retarget resume death rescued end-to-end against the real resume action.
- Suites: automations convex 265, automations UI 156, docs 194, i18n parity — green. Full platform run green except the known `integrity_check` load flake (17/17 solo).
- **Live on the dev stack**: with the sandbox stopped, a probe run failed with `agent: the agent turn could not start: fetch failed (after 4 attempts)`, `checkpoints.executions = 4`, and exactly 4 `workflow-agent` op rows with 4 distinct execIds — no fifth. Sandbox restored: the same automation succeeds, node shows **Running now** in flight, no caption on the original attempt.

## Out of scope

- Long-window 429 park + timed wake (deferred alongside the task lane's).
- `llm` node retry (different lane, direct-only by design).
- Agent-log grouping of prior attempts (the log follows the latest exec, as before).