### PR TITLE
feat(platform): render task descriptions as prose until edited

### DIFF
--- a/services/platform/app/features/tasks/components/editable-description.browser.test.tsx
+++ b/services/platform/app/features/tasks/components/editable-description.browser.test.tsx
@@ -1,0 +1,110 @@
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { render, screen } from '@/tests/utils/render';
+
+/**
+ * Real-Chromium coverage (project `browser`) for the two guards that decide
+ * whether a click on the description's prose opens the editor. Both are DOM
+ * behaviours jsdom only approximates: hit-testing a click on a link nested
+ * inside the click-to-edit region, and a live `document.getSelection()` left
+ * behind by a drag-select. Getting either wrong is user-visible — following a
+ * link would swap the prose for a textarea on the way out, and selecting a
+ * sentence to copy would do the same.
+ *
+ * The `browser` project ships no setup file, so cleanup is explicit.
+ */
+afterEach(cleanup);
+
+// Convex-backed pieces stubbed exactly as in the jsdom suite; the read view
+// itself renders for real, so the anchor below is react-markdown's own.
+vi.mock('./mention-textarea', () => ({
+  MentionTextarea: ({ label, value }: { label?: string; value: string }) => (
+    <label>
+      {label}
+      <textarea value={value} onChange={() => {}} />
+    </label>
+  ),
+}));
+vi.mock('./mention-trigger-chips', () => ({
+  MentionTriggerChips: () => null,
+}));
+vi.mock('../hooks/use-actor-directory', () => ({
+  useActorDirectory: () => ({ members: [], agents: [] }),
+}));
+vi.mock('@/app/features/shared/markdown/markdown-renderer', () => ({
+  markdownWrapperStyles: '',
+  markdownComponents: {},
+}));
+
+import { EditableDescription } from './editable-description';
+
+// A relative href: a real Chromium click on an absolute one would navigate the
+// test runner's own page away.
+const WRITTEN = 'See [the runbook](/runbook) before starting.';
+
+function renderField() {
+  return render(
+    <EditableDescription
+      taskId={'task_1' as Id<'tasks'>}
+      organizationId="org_1"
+      projectId={'project_1' as Id<'projects'>}
+      value={WRITTEN}
+      label="Description"
+      placeholder="Add a description…"
+      onSave={vi.fn()}
+    />,
+  );
+}
+
+describe('EditableDescription click-to-edit (real browser)', () => {
+  it('opens the editor when the prose around the link is clicked', async () => {
+    const { user } = renderField();
+
+    await user.click(screen.getByText(/before starting/));
+
+    expect(
+      screen.getByRole('textbox', { name: 'Description' }),
+    ).toBeInTheDocument();
+  });
+
+  it('leaves the prose alone when the link itself is clicked', async () => {
+    const { user } = renderField();
+    const link = screen.getByRole('link', { name: 'the runbook' });
+    // Chromium would navigate the runner's page on a real anchor activation.
+    link.addEventListener('click', (event) => event.preventDefault());
+
+    await user.click(link);
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  // A drag-select ends in a click whose selection is still live — that click is
+  // a copy, not an edit. (A plain click can't reach here: Chromium collapses
+  // the selection on mousedown, long before the click handler runs.)
+  it('leaves the prose alone when the click ends a drag-selection', () => {
+    renderField();
+    const paragraph = screen.getByText(/before starting/);
+    const selection = window.getSelection();
+
+    // Hand-dispatched rather than driven through user-event: a drag-select is
+    // the one gesture whose trailing `click` user-event does not emit, and that
+    // trailing click — fired with the selection still live — is the whole case.
+    // `act` so the state update a missing guard WOULD make is flushed and seen.
+    act(() => {
+      paragraph.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      const range = document.createRange();
+      range.selectNodeContents(paragraph);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      paragraph.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      paragraph.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(selection?.toString()).toContain('before starting');
+    expect(screen.queryByRole('textbox')).toBeNull();
+    selection?.removeAllRanges();
+  });
+});

--- a/services/platform/app/features/tasks/components/editable-description.test.tsx
+++ b/services/platform/app/features/tasks/components/editable-description.test.tsx
@@ -6,8 +6,8 @@ import type { Id } from '@/convex/_generated/dataModel';
 import { render, screen } from '@/tests/utils/render';
 
 // The mention machinery is a separate concern with its own tests, and it talks
-// to Convex; this file is about WHEN the field is a textarea and when it is
-// just its own trigger.
+// to Convex; this file is about WHEN the field is prose, when it is a textarea,
+// and when it is just its own trigger.
 vi.mock('./mention-textarea', () => ({
   MentionTextarea: ({
     label,
@@ -38,22 +38,45 @@ vi.mock('./mention-trigger-chips', () => ({
   MentionTriggerChips: () => null,
 }));
 
+// The read view renders for real — it is the whole point of the field — but the
+// directory it resolves `@handles` against is a Convex query, and the shared
+// component map pulls chat chrome (images, citations, the router-aware anchor).
+// Stubbing the map leaves react-markdown's own renderers in place, so the
+// anchors below are the ones the markdown pipeline actually produced.
+vi.mock('../hooks/use-actor-directory', () => ({
+  useActorDirectory: () => ({ members: [], agents: [] }),
+}));
+vi.mock('@/app/features/shared/markdown/markdown-renderer', () => ({
+  markdownWrapperStyles: '',
+  markdownComponents: {},
+}));
+
 import { EditableDescription } from './editable-description';
 
-function renderField(value: string, onSave = vi.fn()) {
+const WRITTEN =
+  'See [the runbook](https://example.com/runbook) before starting.';
+
+function renderField(
+  value: string,
+  onSave: (value: string) => void | Promise<unknown> = vi.fn(),
+) {
+  const field = (next: string) => (
+    <EditableDescription
+      taskId={'task_1' as Id<'tasks'>}
+      organizationId="org_1"
+      projectId={'project_1' as Id<'projects'>}
+      value={next}
+      label="Description"
+      placeholder="Add a description…"
+      onSave={onSave}
+    />
+  );
+  const utils = render(field(value));
   return {
     onSave,
-    ...render(
-      <EditableDescription
-        taskId={'task_1' as Id<'tasks'>}
-        organizationId="org_1"
-        projectId={'project_1' as Id<'projects'>}
-        value={value}
-        label="Description"
-        placeholder="Add a description…"
-        onSave={onSave}
-      />,
-    ),
+    ...utils,
+    /** Echo a saved value back, the way the live Convex query does. */
+    rerenderWith: (next: string) => utils.rerender(field(next)),
   };
 }
 
@@ -85,20 +108,54 @@ describe('EditableDescription', () => {
     ).toBeNull();
   });
 
-  it('opens straight into the editor when a description exists', () => {
-    renderField('Includes the March bordereau correction.');
+  // The regression this field was rewritten for: a permanently-open textarea
+  // holds RAW text, so every link anyone wrote in a description was dead plain
+  // text for exactly the people allowed to edit the task.
+  it('reads as rendered prose, with its links live', () => {
+    renderField(WRITTEN);
 
-    const field = screen.getByRole('textbox', { name: 'Description' });
-    expect(field).toHaveValue('Includes the March bordereau correction.');
-    // Never steals focus from the modal on open — only an explicit ask does.
-    expect(field).not.toHaveFocus();
-    expect(
-      screen.queryByRole('button', { name: 'Add a description…' }),
-    ).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByRole('link', { name: 'the runbook' })).toHaveAttribute(
+      'href',
+      'https://example.com/runbook',
+    );
+    expect(screen.queryByText(WRITTEN)).toBeNull();
   });
 
-  it('saves the draft on demand and keeps the editor open after', async () => {
-    const { user, onSave } = renderField('');
+  it('opens the editor from Edit, seeded with the saved text', async () => {
+    const { user } = renderField(WRITTEN);
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const field = screen.getByRole('textbox', { name: 'Description' });
+    expect(field).toHaveValue(WRITTEN);
+    expect(field).toHaveFocus();
+    expect(screen.queryByRole('link', { name: 'the runbook' })).toBeNull();
+  });
+
+  it('opens the editor when the prose itself is clicked', async () => {
+    const { user } = renderField(WRITTEN);
+
+    await user.click(screen.getByText(/before starting/));
+
+    expect(
+      screen.getByRole('textbox', { name: 'Description' }),
+    ).toBeInTheDocument();
+  });
+
+  // Following a link must not double as "edit this" — the click that navigates
+  // would otherwise swap the prose out for a textarea on the way out.
+  it('leaves the prose alone when a link inside it is clicked', async () => {
+    const { user } = renderField(WRITTEN);
+
+    await user.click(screen.getByRole('link', { name: 'the runbook' }));
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByRole('link', { name: 'the runbook' })).toBeVisible();
+  });
+
+  it('saves the draft and returns to the prose', async () => {
+    const { user, onSave, rerenderWith } = renderField('');
 
     await user.click(
       screen.getByRole('button', { name: 'Add a description…' }),
@@ -110,21 +167,50 @@ describe('EditableDescription', () => {
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(onSave).toHaveBeenCalledWith('Q2 excludes the March bordereau.');
-    expect(screen.getByRole('textbox', { name: 'Description' })).toHaveValue(
-      'Q2 excludes the March bordereau.',
-    );
+    expect(screen.queryByRole('textbox')).toBeNull();
+    rerenderWith('Q2 excludes the March bordereau.');
+    expect(
+      screen.getByText('Q2 excludes the March bordereau.'),
+    ).toBeInTheDocument();
   });
 
-  it('offers Save / Discard only while the draft differs', async () => {
-    const { user } = renderField('Filed by the desk.');
+  it('offers Save only while the draft differs, and discards back to the prose', async () => {
+    const { user, onSave } = renderField('Filed by the desk.');
 
-    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
-    const field = screen.getByRole('textbox', { name: 'Description' });
-    await user.type(field, ' Reviewed.');
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Description' }),
+      ' Reviewed.',
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
 
     await user.click(screen.getByRole('button', { name: 'Discard' }));
-    expect(field).toHaveValue('Filed by the desk.');
-    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByText('Filed by the desk.')).toBeInTheDocument();
+  });
+
+  // A rejected write must not swallow what was typed: the caller has already
+  // reported the failure, so the field's job is to keep the draft on screen.
+  it('keeps the editor and the draft when the save fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { user } = renderField('Filed by the desk.', () =>
+      Promise.reject(new Error('offline')),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.type(
+      screen.getByRole('textbox', { name: 'Description' }),
+      ' Reviewed.',
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByRole('textbox', { name: 'Description' })).toHaveValue(
+      'Filed by the desk. Reviewed.',
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/services/platform/app/features/tasks/components/editable-description.tsx
+++ b/services/platform/app/features/tasks/components/editable-description.tsx
@@ -2,20 +2,29 @@
 
 import { Button } from '@tale/ui/button';
 import { Row } from '@tale/ui/layout';
-import { Plus } from 'lucide-react';
+import { Text } from '@tale/ui/text';
+import { Pencil, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
+import { MentionText } from './mention-text';
 import { MentionTextarea } from './mention-textarea';
 import { MentionTriggerChips } from './mention-trigger-chips';
 
 /**
- * A task's description, inline-editable, with an explicit Save / Discard pair
- * that appears while the draft is dirty (⌘/Ctrl+Enter saves, Escape discards).
- * New @mentions in the draft preview their agent-trigger effect
- * (`MentionTriggerChips`).
+ * A task's description: rendered prose by default, an inline editor on demand,
+ * with an explicit Save / Discard pair while the draft is dirty (⌘/Ctrl+Enter
+ * saves, Escape leaves). New @mentions in the draft preview their agent-trigger
+ * effect (`MentionTriggerChips`).
+ *
+ * Reading comes first because a textarea holds raw text: while the editor was
+ * permanently open, every link someone wrote in a description was unclickable
+ * plain text for anyone allowed to edit the task — only read-only viewers ever
+ * saw the markdown. The read view is the same renderer the comment thread uses
+ * ({@link MentionText}), so links, lists and mention pills all render, and the
+ * editor is one click (or the Edit button) away.
  *
  * With nothing written it is only its own trigger. A six-row textarea for a
  * field the reader may have nothing to say about used to own the top of every
@@ -41,37 +50,98 @@ export function EditableDescription({
   label: string;
   /** Placeholder while open — and the collapsed trigger's own label. */
   placeholder: string;
-  onSave: (value: string) => void;
+  /** Rejects when the write failed, so the draft can be kept on screen. */
+  onSave: (value: string) => void | Promise<unknown>;
 }) {
   const { t: tCommon } = useT('common');
   const [draft, setDraft] = useState(value);
-  const [opened, setOpened] = useState(false);
+  const [editing, setEditing] = useState(false);
   useEffect(() => setDraft(value), [value]);
 
   // Explicit commit instead of save-on-blur: a blur-save would fire on any
   // click-away (incl. reaching for Discard) and silently persist half-edited
-  // text. The buttons appear only while the draft differs from the saved
-  // value and vanish once the server echoes the update back into `value`.
+  // text. The buttons appear only while the draft differs from the saved value.
   const isDirty = draft.trim() !== value.trim();
-  const save = () => {
-    if (isDirty) onSave(draft.trim());
+  const save = async () => {
+    if (!isDirty) {
+      setEditing(false);
+      return;
+    }
+    try {
+      await onSave(draft.trim());
+      setEditing(false);
+    } catch (error) {
+      // The caller reports the failure; the editor stays open so the typed
+      // draft survives it rather than collapsing back to the stale prose.
+      console.warn('[tasks] description save failed', error);
+    }
   };
-  const discard = () => setDraft(value);
+  const discard = () => {
+    setDraft(value);
+    setEditing(false);
+  };
 
-  // Derived, not an effect: anything written (saved or still in the draft)
-  // keeps the editor open, and `opened` only latches the empty-and-untouched
-  // case the reader asked to leave.
-  if (!opened && value === '' && draft === '') {
+  // A click on a link is navigation, and a click that ends a text selection is
+  // a copy — neither is a request to edit. Everything else in the prose is.
+  const editFromProse = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      event.target instanceof HTMLElement &&
+      event.target.closest('a, button, summary, [role="button"]')
+    ) {
+      return;
+    }
+    if ((document.getSelection()?.toString().length ?? 0) > 0) return;
+    setEditing(true);
+  };
+
+  if (!editing) {
+    // Empty and editable collapses to its own trigger — see the note above.
+    if (value === '') {
+      return (
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={Plus}
+          className="-ml-3 self-start"
+          onClick={() => setEditing(true)}
+        >
+          {placeholder}
+        </Button>
+      );
+    }
+
     return (
-      <Button
-        variant="ghost"
-        size="sm"
-        icon={Plus}
-        className="-ml-3 self-start"
-        onClick={() => setOpened(true)}
-      >
-        {placeholder}
-      </Button>
+      <div className="group/description flex flex-col gap-1.5">
+        <Row justify="between" gap={2}>
+          <Text as="h3" variant="label">
+            {label}
+          </Text>
+          {/* Revealed on hover/focus like the comment actions: it is the
+              keyboard path to the editor, so it stays in the tab order and
+              appears the moment it takes focus. */}
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={Pencil}
+            className="-my-1 opacity-0 transition-opacity group-focus-within/description:opacity-100 group-hover/description:opacity-100"
+            onClick={() => setEditing(true)}
+          >
+            {tCommon('actions.edit')}
+          </Button>
+        </Row>
+        {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- click-to-edit shortcut over prose that CONTAINS its own links; the Edit button above is the keyboard path */}
+        <div
+          className="hover:bg-muted/40 -mx-2 cursor-text rounded-md px-2 py-1 transition-colors"
+          onClick={editFromProse}
+        >
+          <MentionText
+            body={value}
+            organizationId={organizationId}
+            projectId={projectId}
+            className="wrap-break-word"
+          />
+        </div>
+      </div>
     );
   }
 
@@ -85,17 +155,15 @@ export function EditableDescription({
         rows={6}
         value={draft}
         placeholder={placeholder}
-        // Focus only when the reader just asked for the field; an existing
-        // description must not steal focus as the modal opens.
-        autoFocus={opened}
+        autoFocus
         onValueChange={setDraft}
         onKeyDown={(e) => {
-          // ⌘/Ctrl+Enter saves, Escape discards (the mention picker consumes
-          // both first while it is open).
+          // ⌘/Ctrl+Enter saves, Escape leaves the editor (the mention picker
+          // consumes both first while it is open).
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
             e.preventDefault();
-            save();
-          } else if (e.key === 'Escape' && isDirty) {
+            void save();
+          } else if (e.key === 'Escape') {
             e.preventDefault();
             discard();
           }
@@ -108,14 +176,14 @@ export function EditableDescription({
         draft={draft}
         baseline={value}
       />
-      {isDirty && (
-        <Row gap={2} align="stretch">
-          <Button onClick={save}>{tCommon('actions.save')}</Button>
-          <Button variant="secondary" onClick={discard}>
-            {tCommon('actions.discard')}
-          </Button>
-        </Row>
-      )}
+      <Row gap={2} align="stretch">
+        <Button disabled={!isDirty} onClick={() => void save()}>
+          {tCommon('actions.save')}
+        </Button>
+        <Button variant="secondary" onClick={discard}>
+          {isDirty ? tCommon('actions.discard') : tCommon('actions.cancel')}
+        </Button>
+      </Row>
     </>
   );
 }

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -1216,12 +1216,17 @@ function EditTaskBody({
           label={t('fields.description')}
           placeholder={t('detail.addDescription')}
           onSave={(description) =>
-            void updateTask
+            updateTask
               .mutateAsync({
                 taskId: task._id,
                 description: description.length ? description : null,
               })
-              .catch(onMutationError)
+              .catch((error: unknown) => {
+                onMutationError(error);
+                // Rethrow after reporting: the field keeps the editor open on
+                // a failed write instead of dropping the typed draft.
+                throw error;
+              })
           }
         />
       ) : (


### PR DESCRIPTION
## Summary
- Task description defaults to rendered prose (`MentionText`) so links and mentions stay usable; Edit / click-to-edit opens the textarea.
- Empty descriptions stay a compact “add description” trigger; Save/Discard only while dirty; failed writes keep the editor and draft open.
- Adds jsdom coverage plus Chromium browser tests for link-click vs prose-click and drag-selection.

## Test plan
- [ ] Open a task with a markdown link in the description — link navigates; clicking prose opens the editor
- [ ] Empty description shows the add trigger; after save, prose view returns
- [ ] Failed save (e.g. offline / forced error) leaves the draft in the editor
- [ ] `bun run --filter @tale/platform test:ui -- app/features/tasks/components/editable-description.test.tsx`
- [ ] `bun run --filter @tale/platform test:browser -- app/features/tasks/components/editable-description.browser.test.tsx`