### PR TITLE
fix(platform): classify dead-org errors and recover stale clients

### DIFF
--- a/services/platform/app/features/settings/data-residency/org-residency-errors.ts
+++ b/services/platform/app/features/settings/data-residency/org-residency-errors.ts
@@ -30,6 +30,7 @@ export function mapOrgResidencyError(err: unknown, t: Translator): string {
 
   switch (code) {
     case 'UNAUTHENTICATED':
+    case 'ORG_ID_REQUIRED':
     case 'ORG_NOT_FOUND':
     case 'ORG_FORBIDDEN':
       return t('dataResidency.orgStorage.errors.forbidden');

--- a/services/platform/app/lib/org-error-recovery.test.ts
+++ b/services/platform/app/lib/org-error-recovery.test.ts
@@ -30,9 +30,11 @@ vi.mock('@/app/router', () => ({
 
 const {
   handleOrgScopedQueryError,
+  installOrgErrorRecovery,
   isDeadOrgError,
   resetOrgErrorRecoveryForTests,
 } = await import('./org-error-recovery');
+const { QueryClient } = await import('@tanstack/react-query');
 
 /** A ConvexError as the client sees it: duck-typed `data` payload. */
 function convexError(code: string): Error {
@@ -127,5 +129,70 @@ describe('handleOrgScopedQueryError', () => {
     expect(mocks.invalidateQueries).toHaveBeenCalled();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+describe('installOrgErrorRecovery (real query cache)', () => {
+  it('dispatches when a queryFn rejects with a dead-org error', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const uninstall = installOrgErrorRecovery(qc);
+
+    await qc.prefetchQuery({
+      queryKey: ['dead-org-fetch'],
+      queryFn: () => Promise.reject(convexError('ORG_NOT_FOUND')),
+    });
+    await recoverySettled();
+
+    expect(mocks.setActive).toHaveBeenCalledWith({ organizationId: null });
+    uninstall();
+    qc.clear();
+  });
+
+  it('dispatches when a live subscription writes the error state directly', async () => {
+    // The @convex-dev/react-query bridge delivers WS-pushed failures via
+    // query.setState — never through a queryFn rejection. This is the path an
+    // OPEN tab sees when its org is deleted mid-session (verified manually);
+    // QueryCache onError never fires for it.
+    const qc = new QueryClient();
+    const uninstall = installOrgErrorRecovery(qc);
+
+    const query = qc
+      .getQueryCache()
+      .build(qc, { queryKey: ['dead-org-live'], queryFn: async () => null });
+    const error = convexError('ORG_NOT_FOUND');
+    query.setState({
+      // Mirrors ConvexQueryClient.onUpdateQueryKeyHash's error delivery.
+      error: error as never,
+      errorUpdateCount: query.state.errorUpdateCount + 1,
+      errorUpdatedAt: Date.now(),
+      fetchFailureCount: query.state.fetchFailureCount + 1,
+      fetchFailureReason: error as never,
+      fetchStatus: 'idle',
+      status: 'error',
+    });
+    await recoverySettled();
+
+    expect(mocks.setActive).toHaveBeenCalledWith({ organizationId: null });
+    uninstall();
+    qc.clear();
+  });
+
+  it('stays quiet for non-dead-org error states', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const uninstall = installOrgErrorRecovery(qc);
+
+    await qc.prefetchQuery({
+      queryKey: ['other-error'],
+      queryFn: () => Promise.reject(convexError('ORG_FORBIDDEN')),
+    });
+    await recoverySettled();
+
+    expect(mocks.setActive).not.toHaveBeenCalled();
+    uninstall();
+    qc.clear();
   });
 });

--- a/services/platform/app/lib/org-error-recovery.test.ts
+++ b/services/platform/app/lib/org-error-recovery.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setActive: vi.fn(),
+  clearMemberContextCache: vi.fn(),
+  navigate: vi.fn(),
+  invalidateQueries: vi.fn(),
+  matches: [] as { routeId: string }[],
+}));
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: { organization: { setActive: mocks.setActive } },
+}));
+
+vi.mock('@/app/lib/member-context-cache', () => ({
+  clearMemberContextCache: mocks.clearMemberContextCache,
+}));
+
+// The recovery imports the router lazily (cycle avoidance) — vitest routes
+// the dynamic import through this mock too.
+vi.mock('@/app/router', () => ({
+  router: {
+    get state() {
+      return { matches: mocks.matches };
+    },
+    navigate: mocks.navigate,
+  },
+  queryClient: { invalidateQueries: mocks.invalidateQueries },
+}));
+
+const {
+  handleOrgScopedQueryError,
+  isDeadOrgError,
+  resetOrgErrorRecoveryForTests,
+} = await import('./org-error-recovery');
+
+/** A ConvexError as the client sees it: duck-typed `data` payload. */
+function convexError(code: string): Error {
+  const error = new Error(`server failure ${code}`);
+  Object.assign(error, { data: { code, message: 'boom' } });
+  return error;
+}
+
+async function recoverySettled(): Promise<void> {
+  // One macro-tick lets the fire-and-forget recovery (dynamic import + two
+  // awaits) run to completion.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetOrgErrorRecoveryForTests();
+  mocks.setActive.mockResolvedValue(undefined);
+  mocks.invalidateQueries.mockResolvedValue(undefined);
+  mocks.matches = [
+    { routeId: '/dashboard/$id' },
+    { routeId: '/dashboard/$id/chat' },
+  ];
+});
+
+describe('isDeadOrgError', () => {
+  it('matches only ConvexError data with code ORG_NOT_FOUND', () => {
+    expect(isDeadOrgError(convexError('ORG_NOT_FOUND'))).toBe(true);
+    expect(isDeadOrgError(convexError('ORG_FORBIDDEN'))).toBe(false);
+    expect(isDeadOrgError(new Error('[CONVEX Q(x)] Server Error'))).toBe(false);
+    expect(isDeadOrgError(null)).toBe(false);
+    expect(isDeadOrgError('ORG_NOT_FOUND')).toBe(false);
+  });
+});
+
+describe('handleOrgScopedQueryError', () => {
+  it('recovers from a dead org: clears hints, leaves the org routes, resets the session org', async () => {
+    handleOrgScopedQueryError(convexError('ORG_NOT_FOUND'));
+    await recoverySettled();
+
+    expect(mocks.clearMemberContextCache).toHaveBeenCalledTimes(1);
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/dashboard',
+      replace: true,
+    });
+    expect(mocks.setActive).toHaveBeenCalledWith({ organizationId: null });
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['auth', 'session'],
+    });
+  });
+
+  it('does not navigate when the user is not inside an org dashboard', async () => {
+    mocks.matches = [{ routeId: '/dashboard/' }];
+
+    handleOrgScopedQueryError(convexError('ORG_NOT_FOUND'));
+    await recoverySettled();
+
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    // Session cleanup still runs — the picker must not re-resolve the dead org.
+    expect(mocks.setActive).toHaveBeenCalledWith({ organizationId: null });
+  });
+
+  it('runs a single recovery for a burst of failures', async () => {
+    handleOrgScopedQueryError(convexError('ORG_NOT_FOUND'));
+    handleOrgScopedQueryError(convexError('ORG_NOT_FOUND'));
+    handleOrgScopedQueryError(convexError('ORG_NOT_FOUND'));
+    await recoverySettled();
+
+    expect(mocks.setActive).toHaveBeenCalledTimes(1);
+    expect(mocks.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores forbidden and unstructured errors', async () => {
+    handleOrgScopedQueryError(convexError('ORG_FORBIDDEN'));
+    handleOrgScopedQueryError(new Error('network flake'));
+    await recoverySettled();
+
+    expect(mocks.clearMemberContextCache).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.setActive).not.toHaveBeenCalled();
+  });
+
+  it('survives a failing setActive call (best-effort cleanup)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.setActive.mockRejectedValue(new Error('offline'));
+
+    handleOrgScopedQueryError(convexError('ORG_NOT_FOUND'));
+    await recoverySettled();
+
+    expect(mocks.navigate).toHaveBeenCalled();
+    expect(mocks.invalidateQueries).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/services/platform/app/lib/org-error-recovery.test.ts
+++ b/services/platform/app/lib/org-error-recovery.test.ts
@@ -108,8 +108,13 @@ describe('handleOrgScopedQueryError', () => {
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores forbidden and unstructured errors', async () => {
+  it('ignores forbidden, empty-arg, and unstructured errors', async () => {
     handleOrgScopedQueryError(convexError('ORG_FORBIDDEN'));
+    // ORG_ID_REQUIRED = a component transiently sent "" (caller-side gap) —
+    // recovering (navigating to the picker) over it would yank a WORKING
+    // session out of its page, which is exactly what broke the E2E project
+    // specs before the code split.
+    handleOrgScopedQueryError(convexError('ORG_ID_REQUIRED'));
     handleOrgScopedQueryError(new Error('network flake'));
     await recoverySettled();
 

--- a/services/platform/app/lib/org-error-recovery.ts
+++ b/services/platform/app/lib/org-error-recovery.ts
@@ -1,0 +1,97 @@
+/**
+ * Global recovery from a dead active organization.
+ *
+ * A client whose persisted active org was deleted (or whose org context is
+ * an empty/garbage id — a stale demo tab) keeps firing org-scoped queries
+ * that can only ever fail: the server classifies them as `ConvexError`
+ * `code: 'ORG_NOT_FOUND'` (`lib/rls/organization/get_organization_member.ts`,
+ * `lib/auth/require_org_membership.ts`, `lib/helpers/org_slug.ts`). Observed
+ * as a month of weekly `listAgents` / `readBranding` / `listProviders` error
+ * bursts from one user in GlitchTip — the session never healed on its own.
+ *
+ * Wired as the query cache's global `onError` (app/router.tsx): on the first
+ * dead-org failure it clears every client hint that would rehydrate the dead
+ * org, then routes back through `/dashboard/` — whose index re-resolves a
+ * valid membership (or the create-organization wizard) and re-persists it.
+ *
+ * Deliberately NOT triggered by `ORG_FORBIDDEN` (org exists, caller isn't a
+ * member): the dashboard layout renders the intentional "you've been removed"
+ * AccessDenied screen for that state (see routes/dashboard/$id.tsx), and a
+ * structured ConvexError is never retried, so forbidden states don't loop.
+ */
+
+import { convexErrorCode } from '@/app/hooks/use-action-query';
+import { clearMemberContextCache } from '@/app/lib/member-context-cache';
+import { authClient } from '@/lib/auth-client';
+
+/** True when a query failed because its organization no longer exists. */
+export function isDeadOrgError(error: unknown): boolean {
+  return convexErrorCode(error) === 'ORG_NOT_FOUND';
+}
+
+/**
+ * One recovery per window: a dead org fails every org-scoped query on the
+ * page at once (sidebar, branding, policy, …), and each failure lands here.
+ */
+const RECOVERY_THROTTLE_MS = 10_000;
+let lastRecoveryAt: number | null = null;
+
+/** Test-only: forget the throttle so each test observes a fresh recovery. */
+export function resetOrgErrorRecoveryForTests(): void {
+  lastRecoveryAt = null;
+}
+
+/**
+ * Query-cache `onError` hook. Fire-and-forget: react-query's error handling
+ * (error states, boundaries) proceeds regardless; this only heals the session
+ * in the background.
+ */
+export function handleOrgScopedQueryError(error: unknown): void {
+  if (!isDeadOrgError(error)) return;
+  const now = Date.now();
+  if (lastRecoveryAt !== null && now - lastRecoveryAt < RECOVERY_THROTTLE_MS) {
+    return;
+  }
+  lastRecoveryAt = now;
+  void recoverFromDeadOrg();
+}
+
+async function recoverFromDeadOrg(): Promise<void> {
+  // Drop the client-side hint that would instantly rehydrate the dead org's
+  // shell on the next dashboard load.
+  clearMemberContextCache();
+
+  // Dynamic import: this module is created BY app/router.tsx, so a static
+  // import would be a cycle (same pattern as branding-provider.tsx).
+  const { router, queryClient } = await import('@/app/router');
+
+  // Leave the dead org's routes for the picker, which re-resolves a valid
+  // membership. Only when actually inside an org's dashboard subtree —
+  // recovery must not yank a user out of the picker or the login shell.
+  const insideOrgDashboard = router.state.matches.some((match) =>
+    match.routeId.startsWith('/dashboard/$id'),
+  );
+  if (insideOrgDashboard) {
+    void router.navigate({ to: '/dashboard', replace: true });
+  }
+
+  // Clear the session's persisted active org so every consumer (other tabs,
+  // the next login) stops resolving to it. Best-effort: /dashboard/ validates
+  // the session org against live memberships anyway.
+  try {
+    await authClient.organization.setActive({ organizationId: null });
+  } catch (err) {
+    console.warn(
+      '[org-error-recovery] failed to clear the session active org',
+      err instanceof Error ? err.message : err,
+    );
+  }
+  await queryClient
+    .invalidateQueries({ queryKey: ['auth', 'session'] })
+    .catch((err: unknown) => {
+      console.warn(
+        '[org-error-recovery] failed to refresh the session cache',
+        err instanceof Error ? err.message : err,
+      );
+    });
+}

--- a/services/platform/app/lib/org-error-recovery.ts
+++ b/services/platform/app/lib/org-error-recovery.ts
@@ -9,16 +9,27 @@
  * as a month of weekly `listAgents` / `readBranding` / `listProviders` error
  * bursts from one user in GlitchTip — the session never healed on its own.
  *
- * Wired as the query cache's global `onError` (app/router.tsx): on the first
- * dead-org failure it clears every client hint that would rehydrate the dead
- * org, then routes back through `/dashboard/` — whose index re-resolves a
- * valid membership (or the create-organization wizard) and re-persists it.
+ * Installed as a query-cache SUBSCRIPTION (`installOrgErrorRecovery`, called
+ * from app/router.tsx): on the first dead-org failure it clears every client
+ * hint that would rehydrate the dead org, then routes back through
+ * `/dashboard/` — whose index re-resolves a valid membership (or the
+ * create-org wizard) and re-persists it.
+ *
+ * A cache subscription, NOT `QueryCache({ onError })`: `onError` only fires
+ * when a queryFn rejects, but the @convex-dev/react-query bridge delivers a
+ * LIVE subscription failure by writing the error state directly
+ * (`query.setState`) — exactly what an open tab receives when its org is
+ * deleted mid-session. Observing cache events covers both delivery paths
+ * (verified manually: an open dashboard tab whose org was deleted only
+ * received the structured error via the setState path).
  *
  * Deliberately NOT triggered by `ORG_FORBIDDEN` (org exists, caller isn't a
  * member): the dashboard layout renders the intentional "you've been removed"
  * AccessDenied screen for that state (see routes/dashboard/$id.tsx), and a
  * structured ConvexError is never retried, so forbidden states don't loop.
  */
+
+import type { QueryClient } from '@tanstack/react-query';
 
 import { convexErrorCode } from '@/app/hooks/use-action-query';
 import { clearMemberContextCache } from '@/app/lib/member-context-cache';
@@ -42,7 +53,7 @@ export function resetOrgErrorRecoveryForTests(): void {
 }
 
 /**
- * Query-cache `onError` hook. Fire-and-forget: react-query's error handling
+ * Per-error entry point. Fire-and-forget: react-query's error handling
  * (error states, boundaries) proceeds regardless; this only heals the session
  * in the background.
  */
@@ -54,6 +65,21 @@ export function handleOrgScopedQueryError(error: unknown): void {
   }
   lastRecoveryAt = now;
   void recoverFromDeadOrg();
+}
+
+/**
+ * Watch every query error the cache ever holds — whether it arrived as a
+ * queryFn rejection or as a live subscription update written via
+ * `query.setState` — and dispatch dead-org recovery. Returns the unsubscribe
+ * for symmetry/tests; the app installs it once for the client's lifetime.
+ */
+export function installOrgErrorRecovery(queryClient: QueryClient): () => void {
+  return queryClient.getQueryCache().subscribe((event) => {
+    if (event.type !== 'updated') return;
+    const { error, status } = event.query.state;
+    if (status !== 'error' || error == null) return;
+    handleOrgScopedQueryError(error);
+  });
 }
 
 async function recoverFromDeadOrg(): Promise<void> {

--- a/services/platform/app/lib/sentry-normalize.test.ts
+++ b/services/platform/app/lib/sentry-normalize.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeConvexSentryEvent,
+  stripConvexRequestId,
+} from './sentry-normalize';
+
+// The exact client-visible shape convex composes (browser/logging.ts):
+// `[CONVEX <kind>(<path>)] <server errorMessage>` where the server message
+// starts with `[Request ID: …] Server Error`.
+const RAW_ACTION_FAILURE =
+  '[CONVEX A(agents/actions:listAgents)] [Request ID: 018f2a4b9c1d] Server Error\n' +
+  'Uncaught ConvexError: {"code":"ORG_NOT_FOUND","message":"Organization \\"jh7csd7\\" not found."}\n' +
+  '  Called by client';
+
+describe('stripConvexRequestId', () => {
+  it('removes the volatile request id but keeps function path and cause', () => {
+    expect(stripConvexRequestId(RAW_ACTION_FAILURE)).toBe(
+      '[CONVEX A(agents/actions:listAgents)] Server Error\n' +
+        'Uncaught ConvexError: {"code":"ORG_NOT_FOUND","message":"Organization \\"jh7csd7\\" not found."}\n' +
+        '  Called by client',
+    );
+  });
+
+  it('collapses to identical text for two occurrences of the same failure', () => {
+    const second = RAW_ACTION_FAILURE.replace('018f2a4b9c1d', 'ffee00112233');
+    expect(stripConvexRequestId(RAW_ACTION_FAILURE)).toBe(
+      stripConvexRequestId(second),
+    );
+  });
+
+  it('handles a message that starts with the request id', () => {
+    expect(
+      stripConvexRequestId('[Request ID: abc123] Server Error\nUncaught …'),
+    ).toBe('Server Error\nUncaught …');
+  });
+
+  it('leaves text without a request id untouched', () => {
+    const plain = 'TypeError: x is not a function';
+    expect(stripConvexRequestId(plain)).toBe(plain);
+  });
+});
+
+describe('normalizeConvexSentryEvent', () => {
+  it('normalizes message events (console-promoted failures)', () => {
+    const event = normalizeConvexSentryEvent({ message: RAW_ACTION_FAILURE });
+    expect(event.message).not.toContain('[Request ID:');
+    expect(event.message).toContain('[CONVEX A(agents/actions:listAgents)]');
+  });
+
+  it('normalizes logentry messages', () => {
+    const event = normalizeConvexSentryEvent({
+      logentry: { message: RAW_ACTION_FAILURE },
+    });
+    expect(event.logentry?.message).not.toContain('[Request ID:');
+  });
+
+  it('normalizes every exception value', () => {
+    const event = normalizeConvexSentryEvent({
+      exception: {
+        values: [
+          { value: RAW_ACTION_FAILURE },
+          { value: '[Request ID: 99] Server Error' },
+        ],
+      },
+    });
+    expect(event.exception?.values?.[0]?.value).not.toContain('[Request ID:');
+    expect(event.exception?.values?.[1]?.value).toBe('Server Error');
+  });
+
+  it('passes unrelated events through unchanged', () => {
+    const event = {
+      message: 'plain failure',
+      exception: { values: [{ value: 'TypeError: boom' }] },
+    };
+    expect(normalizeConvexSentryEvent(event)).toEqual({
+      message: 'plain failure',
+      exception: { values: [{ value: 'TypeError: boom' }] },
+    });
+  });
+});

--- a/services/platform/app/lib/sentry-normalize.ts
+++ b/services/platform/app/lib/sentry-normalize.ts
@@ -1,0 +1,53 @@
+/**
+ * Normalize Convex failure text before events leave for Sentry/GlitchTip.
+ *
+ * Convex composes every client-visible failure as
+ * `[CONVEX A(agents/actions:listAgents)] [Request ID: 018f2a…] Server Error
+ *  Uncaught ConvexError: …` — and the convex client also `console.error`s the
+ * same line, which `captureConsoleIntegration` promotes to a message event.
+ * Sentry groups message events by their text, so the per-call request id
+ * defeats grouping and every occurrence opens a NEW issue (observed as ~40
+ * single-event issue groups on the demo project). Stripping the volatile
+ * token restores one-issue-per-root-cause grouping; the function path and the
+ * underlying error text stay, so issues remain actionable.
+ */
+
+/** `[Request ID: …]` plus the whitespace that follows it. */
+const REQUEST_ID_RE = /\[Request ID: [^\]]*\]\s*/g;
+
+export function stripConvexRequestId(text: string): string {
+  return text.replace(REQUEST_ID_RE, '');
+}
+
+/**
+ * The subset of a Sentry `ErrorEvent` this normalization touches — message
+ * events (including console-promoted ones via `logentry`) and exception
+ * values. Structural so the helper stays SDK-version-agnostic and testable.
+ */
+interface NormalizableSentryEvent {
+  message?: string;
+  logentry?: { message?: string; params?: unknown[] };
+  exception?: { values?: { value?: string }[] };
+}
+
+/**
+ * Strip volatile Convex request ids everywhere Sentry derives grouping from.
+ * Mutates and returns the event — the `beforeSend` contract allows in-place
+ * edits, and events are never reused after sending.
+ */
+export function normalizeConvexSentryEvent<
+  Event extends NormalizableSentryEvent,
+>(event: Event): Event {
+  if (typeof event.message === 'string') {
+    event.message = stripConvexRequestId(event.message);
+  }
+  if (typeof event.logentry?.message === 'string') {
+    event.logentry.message = stripConvexRequestId(event.logentry.message);
+  }
+  for (const exception of event.exception?.values ?? []) {
+    if (typeof exception.value === 'string') {
+      exception.value = stripConvexRequestId(exception.value);
+    }
+  }
+  return event;
+}

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -1,12 +1,15 @@
 import { ConvexQueryClient } from '@convex-dev/react-query';
 import * as Sentry from '@sentry/tanstackstart-react';
-import { QueryClient } from '@tanstack/react-query';
+import { QueryCache, QueryClient } from '@tanstack/react-query';
 import { createRouter as createTanStackRouter } from '@tanstack/react-router';
 
 import { GlobalErrorDisplay } from '@/app/components/error-boundaries/displays/global-error-display';
 import { RouteNotFound } from '@/app/components/layout/route-not-found';
+import { isStructuredConvexError } from '@/app/hooks/use-action-query';
 import { warmSession } from '@/app/lib/auth/session-query';
+import { handleOrgScopedQueryError } from '@/app/lib/org-error-recovery';
 import { markColdLoad } from '@/app/lib/perf/cold-load-trace';
+import { normalizeConvexSentryEvent } from '@/app/lib/sentry-normalize';
 import { getEnv } from '@/lib/env';
 
 import { routeTree } from './routeTree.gen';
@@ -24,10 +27,26 @@ export const convexQueryClient = new ConvexQueryClient(
 );
 
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    // Global stale-org recovery: a query failing with ConvexError
+    // ORG_NOT_FOUND means the active organization is gone (deleted org id
+    // persisted in the session, or an empty/garbage org context in a stale
+    // tab). Without this, such a session retries the same dead org-scoped
+    // queries on every visit, forever — clear the stale org and re-resolve
+    // through the picker instead. No-op for every other error.
+    onError: (error) => handleOrgScopedQueryError(error),
+  }),
   defaultOptions: {
     queries: {
       queryKeyHashFn: convexQueryClient.hashFn(),
       queryFn: convexQueryClient.queryFn(),
+      // ConvexError is deterministic — server-side validation, auth gate, or
+      // expected-state signal. Retrying just delays the error reaching the UI
+      // (and the recovery hook above); each retry also re-executes the failed
+      // function server-side, multiplying error-log volume. Network errors
+      // still retry the default 3 times. Same rationale as useActionQuery.
+      retry: (failureCount, err) =>
+        !isStructuredConvexError(err) && failureCount < 3,
       // 15min: bounds stale Convex subscription leak when components unmount
       // (the @convex-dev/react-query integration ties WS subscription teardown
       // to React Query's cache 'removed' event, which fires only after gcTime
@@ -89,6 +108,10 @@ if (sentryDsn) {
       // Kept to `error` only (not `warn`) to bound event volume.
       Sentry.captureConsoleIntegration({ levels: ['error'] }),
     ],
+    // Convex failure text embeds a per-call `[Request ID: …]`, which defeats
+    // message-based grouping — every action failure opened its own issue.
+    // Strip it so events group by function + root cause.
+    beforeSend: (event) => normalizeConvexSentryEvent(event),
     tracesSampleRate: getEnv('SENTRY_TRACES_SAMPLE_RATE'),
   });
 }

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -1,13 +1,13 @@
 import { ConvexQueryClient } from '@convex-dev/react-query';
 import * as Sentry from '@sentry/tanstackstart-react';
-import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { createRouter as createTanStackRouter } from '@tanstack/react-router';
 
 import { GlobalErrorDisplay } from '@/app/components/error-boundaries/displays/global-error-display';
 import { RouteNotFound } from '@/app/components/layout/route-not-found';
 import { isStructuredConvexError } from '@/app/hooks/use-action-query';
 import { warmSession } from '@/app/lib/auth/session-query';
-import { handleOrgScopedQueryError } from '@/app/lib/org-error-recovery';
+import { installOrgErrorRecovery } from '@/app/lib/org-error-recovery';
 import { markColdLoad } from '@/app/lib/perf/cold-load-trace';
 import { normalizeConvexSentryEvent } from '@/app/lib/sentry-normalize';
 import { getEnv } from '@/lib/env';
@@ -27,15 +27,6 @@ export const convexQueryClient = new ConvexQueryClient(
 );
 
 export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    // Global stale-org recovery: a query failing with ConvexError
-    // ORG_NOT_FOUND means the active organization is gone (deleted org id
-    // persisted in the session, or an empty/garbage org context in a stale
-    // tab). Without this, such a session retries the same dead org-scoped
-    // queries on every visit, forever — clear the stale org and re-resolve
-    // through the picker instead. No-op for every other error.
-    onError: (error) => handleOrgScopedQueryError(error),
-  }),
   defaultOptions: {
     queries: {
       queryKeyHashFn: convexQueryClient.hashFn(),
@@ -64,6 +55,14 @@ export const queryClient = new QueryClient({
 });
 
 convexQueryClient.connect(queryClient);
+
+// Global stale-org recovery: any query erroring with ConvexError ORG_NOT_FOUND
+// means the active organization is gone (deleted org id persisted in the
+// session, or an empty/garbage org context in a stale tab). Without this, such
+// a session retries the same dead org-scoped queries on every visit, forever —
+// clear the stale org and re-resolve through the picker instead. A cache
+// subscription (not QueryCache onError) so live WS-pushed errors are seen too.
+installOrgErrorRecovery(queryClient);
 
 // Kick off the Better Auth session fetch AND the Convex token mint at module
 // load, in parallel — the auth provider then resolves both against in-flight

--- a/services/platform/convex/connector_credentials/queries.test.ts
+++ b/services/platform/convex/connector_credentials/queries.test.ts
@@ -12,7 +12,7 @@
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
-import { api, internal } from '../_generated/api';
+import { api, components, internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
@@ -100,6 +100,29 @@ async function seedMember(
       role: 'member',
       createdAt: 0,
     });
+  });
+}
+
+/**
+ * Create a betterAuth organization; returns its component `_id`. The
+ * non-member refusal reads the organization row to classify the miss
+ * (`ORG_FORBIDDEN` for a live org vs `ORG_NOT_FOUND` for a dead one), so
+ * that test must query an org that actually exists — same helper as
+ * mutations.test.ts.
+ */
+async function seedAuthOrg(t: T, slug: string): Promise<string> {
+  return await t.run(async (ctx) => {
+    const created = await ctx.runMutation(
+      components.betterAuth.adapter.create,
+      {
+        input: {
+          model: 'organization',
+          data: { name: slug, slug, createdAt: 0 },
+        },
+      },
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter returns the created record as unknown
+    return (created as { _id: string })._id;
   });
 }
 
@@ -279,11 +302,14 @@ describe('listCredentials', () => {
   it('refuses a caller who is not a member of the organization', async () => {
     const t = newWorld();
     await seedMember(t, MEMBER, OTHER_ORG);
+    // A real organization row: the refusal must be the live-org kind
+    // (ORG_FORBIDDEN "Not a member"), not the dead-org ORG_NOT_FOUND.
+    const liveOrgId = await seedAuthOrg(t, 'ic-queries-live');
     await expect(
       t
         .withIdentity({ subject: MEMBER })
         .query(api.connector_credentials.queries.listCredentials, {
-          organizationId: ORG,
+          organizationId: liveOrgId,
         }),
     ).rejects.toThrowError(/Not a member/);
   });

--- a/services/platform/convex/governance/get_policy_org_boundary.test.ts
+++ b/services/platform/convex/governance/get_policy_org_boundary.test.ts
@@ -94,7 +94,7 @@ async function rejection(promise: Promise<unknown>): Promise<unknown> {
 }
 
 describe('org-scoped query boundary with a stale org context', () => {
-  it('rejects an empty organizationId as structured ORG_NOT_FOUND', async () => {
+  it('rejects an empty organizationId as structured ORG_ID_REQUIRED', async () => {
     const t = newT();
 
     const error = await rejection(
@@ -104,7 +104,11 @@ describe('org-scoped query boundary with a stale org context', () => {
       }),
     );
 
-    expect(thrownConvexErrorCode(error)).toBe('ORG_NOT_FOUND');
+    // Distinct from ORG_NOT_FOUND on purpose: an in-app component racing its
+    // data can transiently send "" (observed via the task modal in the E2E
+    // project specs), and the client's dead-org recovery must not treat that
+    // as a dead persisted org and navigate the tab away.
+    expect(thrownConvexErrorCode(error)).toBe('ORG_ID_REQUIRED');
   });
 
   it('rejects a deleted org id as structured ORG_NOT_FOUND, not "not a member"', async () => {

--- a/services/platform/convex/governance/get_policy_org_boundary.test.ts
+++ b/services/platform/convex/governance/get_policy_org_boundary.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Boundary regression for the stale/empty-org error class (GlitchTip
+ * TALE-PROJECT-OU / -VB / -VD): org-scoped public queries reached the RLS
+ * membership gate with `organizationId: ""` (empty persisted org context) or
+ * a deleted org's id, and the gate's raw `UnauthorizedError` surfaced to
+ * clients as an opaque, redacted "Server Error" they retried forever.
+ *
+ * Locks the whole chain at the public-function boundary: the argument passes
+ * `v.string()`, the gate classifies the miss, and the rejection that crosses
+ * the boundary is a structured ConvexError carrying `code: 'ORG_NOT_FOUND'`
+ * — the code the client-side recovery (app/lib/org-error-recovery.ts)
+ * dispatches on.
+ */
+
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import betterAuthSchema from '../betterAuth/schema';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root (this file is at
+// convex/governance/), mirroring tasks/stats.test.ts.
+const TEST_DIR_FROM_CONVEX_ROOT = 'governance';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const authModules = import.meta.glob('../betterAuth/**/*.*s');
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const IDENTITY = {
+  subject: 'user_stale_org',
+  email: 'stale-org@example.com',
+  name: 'Stale Org Tester',
+};
+
+// Syntactically valid Better Auth org id with no organization row behind it —
+// the shape a client keeps polling after its persisted active org is deleted.
+const DELETED_ORG_ID = 'jh7csd7ks8740bza6qsxbz6sph7yegh2';
+
+type T = TestConvex<typeof schema>;
+
+function newT(): T {
+  const t = convexTest(schema, modules);
+  t.registerComponent('betterAuth', betterAuthSchema, authModules);
+  return t;
+}
+
+/**
+ * The `{ code }` payload of a ConvexError rejection. The runtime serializes
+ * `data` to a JSON string when the error crosses a function boundary
+ * (`serializeConvexErrorData`), so accept both shapes.
+ */
+function thrownConvexErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  if (!(Symbol.for('ConvexError') in error)) return undefined;
+  const data = (error as { data?: unknown }).data;
+  if (typeof data === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(data);
+      if (typeof parsed === 'object' && parsed !== null && 'code' in parsed) {
+        const code = (parsed as { code?: unknown }).code;
+        return typeof code === 'string' ? code : undefined;
+      }
+    } catch (parseError) {
+      console.warn('unparseable ConvexError data', parseError);
+    }
+    return undefined;
+  }
+  if (typeof data === 'object' && data !== null && 'code' in data) {
+    const code = (data as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected promise to reject');
+}
+
+describe('org-scoped query boundary with a stale org context', () => {
+  it('rejects an empty organizationId as structured ORG_NOT_FOUND', async () => {
+    const t = newT();
+
+    const error = await rejection(
+      t.withIdentity(IDENTITY).query(api.governance.queries.getPolicy, {
+        organizationId: '',
+        policyType: 'session_idle_timeout',
+      }),
+    );
+
+    expect(thrownConvexErrorCode(error)).toBe('ORG_NOT_FOUND');
+  });
+
+  it('rejects a deleted org id as structured ORG_NOT_FOUND, not "not a member"', async () => {
+    const t = newT();
+
+    const error = await rejection(
+      t.withIdentity(IDENTITY).query(api.governance.queries.getPolicy, {
+        organizationId: DELETED_ORG_ID,
+        policyType: 'session_idle_timeout',
+      }),
+    );
+
+    expect(thrownConvexErrorCode(error)).toBe('ORG_NOT_FOUND');
+  });
+
+  it('getCurrentMemberContext folds the same misses into status not_found', async () => {
+    const t = newT();
+
+    await expect(
+      t
+        .withIdentity(IDENTITY)
+        .query(api.members.queries.getCurrentMemberContext, {
+          organizationId: '',
+        }),
+    ).resolves.toEqual({ status: 'not_found' });
+
+    await expect(
+      t
+        .withIdentity(IDENTITY)
+        .query(api.members.queries.getCurrentMemberContext, {
+          organizationId: DELETED_ORG_ID,
+        }),
+    ).resolves.toEqual({ status: 'not_found' });
+  });
+});

--- a/services/platform/convex/lib/auth/require_org_membership.test.ts
+++ b/services/platform/convex/lib/auth/require_org_membership.test.ts
@@ -69,12 +69,15 @@ describe('requireOrgMembershipById', () => {
     });
   });
 
-  it('throws ORG_NOT_FOUND on an empty organization id (no adapter call)', async () => {
+  it('throws ORG_ID_REQUIRED on an empty organization id (no adapter call)', async () => {
     const ctx = makeCtx({});
+    // ORG_ID_REQUIRED, not ORG_NOT_FOUND: an empty id is a caller-side gap
+    // (a component racing its data), and the client's dead-org recovery —
+    // which keys on ORG_NOT_FOUND — must not fire for it.
     await expect(
       requireOrgMembershipById(ctx as never, ''),
     ).rejects.toMatchObject({
-      data: { code: 'ORG_NOT_FOUND' },
+      data: { code: 'ORG_ID_REQUIRED' },
     });
     // The empty id must never reach the adapter (`db.get('')` would throw).
     expect(ctx.runQuery).not.toHaveBeenCalled();

--- a/services/platform/convex/lib/auth/require_org_membership.ts
+++ b/services/platform/convex/lib/auth/require_org_membership.ts
@@ -73,10 +73,14 @@ export async function requireOrgMembershipById(
 
   // Reject an empty id up front: the adapter resolves an `_id` `eq` filter via
   // `db.get(value)`, and `db.get('')` throws the opaque "Invalid ID length 0"
-  // instead of a clean miss. Surface the same intent as an unknown org.
+  // instead of a clean miss. `ORG_ID_REQUIRED`, not `ORG_NOT_FOUND`: an empty
+  // id is a caller-side gap (a component racing its data), not evidence the
+  // caller's persisted org is gone — the client's dead-org recovery keys on
+  // `ORG_NOT_FOUND` and must not fire for it (see
+  // `lib/rls/organization/get_organization_member.ts`, same rule).
   if (!organizationId) {
     throw new ConvexError({
-      code: 'ORG_NOT_FOUND',
+      code: 'ORG_ID_REQUIRED',
       message: 'Organization id is required.',
     });
   }

--- a/services/platform/convex/lib/helpers/org_slug.ts
+++ b/services/platform/convex/lib/helpers/org_slug.ts
@@ -7,6 +7,8 @@
  * carry `organizationId`; this helper bridges to the slug.
  */
 
+import { ConvexError } from 'convex/values';
+
 import { getString, isRecord } from '../../../lib/utils/type-utils';
 import { components } from '../../_generated/api';
 import { looksLikeConvexDocumentId } from './id_shape';
@@ -25,19 +27,32 @@ type CtxWithRunQuery = {
  * no `slug` field. Both conditions are permanent — retrying will not
  * succeed, so callers (`orgSlugFromIdOrNull`, retry-on-throw layers)
  * should treat this distinctly from transient transport errors.
+ *
+ * Extends `ConvexError` with `code: 'ORG_NOT_FOUND'` so that when it does
+ * propagate uncaught out of a public function (a stale client whose
+ * persisted active org was deleted), the client receives a structured,
+ * dispatchable error — the same code `require_org_membership.ts` and the
+ * RLS membership gate use for a dead org — instead of an opaque redacted
+ * "Server Error" it retries forever. `message` is reassigned after
+ * `super()` so server logs keep the human sentence (the wire serializes
+ * `data`, not `message`).
  */
-export class OrgSlugUnresolvableError extends Error {
+export class OrgSlugUnresolvableError extends ConvexError<{
+  code: string;
+  message: string;
+}> {
   override readonly name = 'OrgSlugUnresolvableError';
 
   constructor(
     readonly organizationId: string,
     readonly reason: 'no_row' | 'no_slug',
   ) {
-    super(
+    const message =
       reason === 'no_row'
         ? `[orgSlugFromId] no organization row found for id ${JSON.stringify(organizationId)}`
-        : `[orgSlugFromId] organization ${JSON.stringify(organizationId)} has no slug`,
-    );
+        : `[orgSlugFromId] organization ${JSON.stringify(organizationId)} has no slug`;
+    super({ code: 'ORG_NOT_FOUND', message });
+    this.message = message;
   }
 }
 

--- a/services/platform/convex/lib/rest/helpers.test.ts
+++ b/services/platform/convex/lib/rest/helpers.test.ts
@@ -112,6 +112,9 @@ describe('httpStatusForConvexCode', () => {
     ['FORBIDDEN_DEVELOPER_SETTINGS', 403],
     ['ORG_FORBIDDEN', 403],
     ['ORG_NOT_FOUND', 404],
+    // An empty organizationId at a membership gate (bad argument, distinct
+    // from ORG_NOT_FOUND's 404).
+    ['ORG_ID_REQUIRED', 400],
     // Org resolution at the REST boundary (resolve_user_organization).
     ['ORG_SLUG_REQUIRED', 400],
     ['ORG_SLUG_INVALID', 400],

--- a/services/platform/convex/lib/rest/helpers.ts
+++ b/services/platform/convex/lib/rest/helpers.ts
@@ -770,6 +770,11 @@ export function httpStatusForConvexCode(code: string | undefined): number {
     // argument (400), distinct from PROJECT_NOT_FOUND's "no such project" (404).
     case 'PROJECT_NOT_BOUND':
       return 400;
+    // An empty organizationId reached a membership gate — a bad argument
+    // (caller-side gap), deliberately distinct from ORG_NOT_FOUND's
+    // "this org id no longer resolves" (404).
+    case 'ORG_ID_REQUIRED':
+      return 400;
     case 'not_found':
     case 'ORG_NOT_FOUND':
     case 'PROJECT_NOT_FOUND':

--- a/services/platform/convex/lib/rls/errors.ts
+++ b/services/platform/convex/lib/rls/errors.ts
@@ -1,26 +1,49 @@
 /**
  * RLS Error Types
+ *
+ * Every RLS error extends `ConvexError`, so an uncaught throw reaches the
+ * client as structured `{ code, message }` data it can dispatch on (the
+ * stale-org recovery keys off `code === 'ORG_NOT_FOUND'`) instead of an
+ * opaque redacted "Server Error" that clients blindly retry — part of the
+ * codebase-wide "throw ConvexError codes" migration
+ * (`lib/auth/require_org_membership.ts` is the reference).
+ *
+ * Server-side semantics are unchanged: class identity is preserved, so the
+ * many `error instanceof UnauthorizedError` degrade-gracefully catch sites
+ * (approvals, sandbox, members, team_members, erasure, …) keep working, and
+ * `message` is reassigned to the human sentence after `super()` so server
+ * logs stay readable (the wire format serializes `data`, never `message`).
  */
+
+import { ConvexError } from 'convex/values';
 
 /**
  * Base RLS error class
  */
-export class RLSError extends Error {
+export class RLSError extends ConvexError<{ code: string; message: string }> {
   constructor(
     message: string,
     public code: string,
   ) {
-    super(message);
+    super({ code, message });
     this.name = 'RLSError';
+    this.message = message;
   }
 }
 
 /**
- * Thrown when user is not authorized to access a resource
+ * Thrown when user is not authorized to access a resource.
+ *
+ * `code` defaults to the generic `UNAUTHORIZED`; org-membership gates pass
+ * `ORG_FORBIDDEN` / `ORG_NOT_FOUND` so clients can tell "you lack access"
+ * apart from "this organization is gone" (stale persisted active org).
  */
 export class UnauthorizedError extends RLSError {
-  constructor(message = 'Not authorized to access this resource') {
-    super(message, 'UNAUTHORIZED');
+  constructor(
+    message = 'Not authorized to access this resource',
+    code = 'UNAUTHORIZED',
+  ) {
+    super(message, code);
   }
 }
 

--- a/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
@@ -97,7 +97,7 @@ describe('getOrganizationMember', () => {
     expect(ctx.runQuery).not.toHaveBeenCalled();
   });
 
-  it('rejects an empty organization id at the boundary with ORG_NOT_FOUND', async () => {
+  it('rejects an empty organization id at the boundary with ORG_ID_REQUIRED', async () => {
     const ctx = createMockCtx();
 
     const error = await rejection(
@@ -106,9 +106,15 @@ describe('getOrganizationMember', () => {
 
     expect(error).toBeInstanceOf(UnauthorizedError);
     // Structured wire payload: clients dispatch stale-org recovery on this.
+    // ORG_ID_REQUIRED, not ORG_NOT_FOUND: an empty id is a caller-side gap,
+    // and the client's dead-org recovery (which keys on ORG_NOT_FOUND) must
+    // not fire for it.
     expect(error).toMatchObject({
-      code: 'ORG_NOT_FOUND',
-      data: { code: 'ORG_NOT_FOUND', message: 'Organization id is required.' },
+      code: 'ORG_ID_REQUIRED',
+      data: {
+        code: 'ORG_ID_REQUIRED',
+        message: 'Organization id is required.',
+      },
       message: 'Organization id is required.',
     });
     // Terminal before any lookup — no mirror read, no adapter round-trip.

--- a/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
@@ -225,27 +225,65 @@ describe('getOrganizationMember', () => {
 
   it('throws UnauthorizedError for disabled member found via email fallback', async () => {
     const ctx = createMockCtx();
-    // First query: no direct match
-    ctx.runQuery.mockResolvedValueOnce({ page: [] });
-    // Email lookup: find user by email
-    ctx.runQuery.mockResolvedValueOnce({
-      page: [{ _id: 'user_2', email: 'test@example.com' }],
-    });
-    // Second member lookup by email-resolved userId
-    ctx.runQuery.mockResolvedValueOnce({
-      page: [
-        {
-          _id: 'om_2',
-          organizationId: ORG_ID,
-          userId: 'user_2',
-          role: 'disabled',
-          createdAt: 1000,
-        },
-      ],
-    });
+    // Ref+model-routed mock: the org-existence check now runs BETWEEN the
+    // direct member lookup and the email fallback, so a call-order sequence
+    // would silently misalign.
+    let memberLookups = 0;
+    ctx.runQuery.mockImplementation(
+      async (ref: string, args: { model?: string }) => {
+        if (ref === 'betterAuth:adapter:findOne') return { _id: ORG_ID };
+        if (args.model === 'user') {
+          return { page: [{ _id: 'user_2', email: 'test@example.com' }] };
+        }
+        memberLookups += 1;
+        // Direct lookup misses; the email-resolved lookup finds the disabled row.
+        if (memberLookups === 1) return { page: [] };
+        return {
+          page: [
+            {
+              _id: 'om_2',
+              organizationId: ORG_ID,
+              userId: 'user_2',
+              role: 'disabled',
+              createdAt: 1000,
+            },
+          ],
+        };
+      },
+    );
 
-    await expect(
+    const error = await rejection(
       getOrganizationMember(ctx as never, ORG_ID, authUser),
-    ).rejects.toThrow(UnauthorizedError);
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({ code: 'ORG_FORBIDDEN' });
+    expect(memberLookups).toBe(2);
+  });
+
+  it('short-circuits a dead org before the email fallback', async () => {
+    const ctx = createMockCtx();
+    const models: string[] = [];
+    ctx.runQuery.mockImplementation(
+      async (ref: string, args: { model?: string }) => {
+        models.push(args.model ?? '?');
+        if (ref === 'betterAuth:adapter:findOne') return null; // org row gone
+        return { page: [] };
+      },
+    );
+
+    const error = await rejection(
+      // authUser HAS an email — the fallback would run if not short-circuited.
+      getOrganizationMember(ctx as never, ORG_ID, authUser),
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({ code: 'ORG_NOT_FOUND' });
+    // Exactly one member lookup + one organization lookup — the 2-read email
+    // fallback must NOT run for a nonexistent org. An org deletion re-executes
+    // every subscribed org-scoped query at once; the shorter path is what
+    // keeps those failures inside the function budget (structured, not a
+    // timeout) on a loaded backend.
+    expect(models).toEqual(['member', 'organization']);
   });
 });

--- a/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../../_generated/api', () => ({
     betterAuth: {
       adapter: {
         findMany: 'betterAuth:adapter:findMany',
+        findOne: 'betterAuth:adapter:findOne',
       },
     },
   },
@@ -14,26 +15,14 @@ vi.mock('../auth/require_authenticated_user', () => ({
   requireAuthenticatedUser: vi.fn(),
 }));
 
-vi.mock('../errors', () => {
-  class RLSError extends Error {
-    constructor(
-      message: string,
-      public code: string,
-    ) {
-      super(message);
-      this.name = 'RLSError';
-    }
-  }
-  class UnauthorizedError extends RLSError {
-    constructor(message = 'Not authorized to access this resource') {
-      super(message, 'UNAUTHORIZED');
-    }
-  }
-  return { UnauthorizedError };
-});
-
+// Real errors module (not mocked): the structured `data` payload and the
+// `instanceof UnauthorizedError` identity are part of the contract under test.
 const { UnauthorizedError } = await import('../errors');
 const { getOrganizationMember } = await import('./get_organization_member');
+
+// A syntactically valid Better Auth organization id (32-char base-32), so the
+// failure-path organization-existence check actually reaches the adapter.
+const ORG_ID = 'jh7csd7ks8740bza6qsxbz6sph7yegh2';
 
 // `mirrorRow` seeds the local memberMirror lookup (the hot path). Default null
 // → mirror miss → fall back to the authoritative Better Auth `runQuery` path the
@@ -54,6 +43,16 @@ function createMockCtx(mirrorRow: unknown = null) {
 
 const authUser = { userId: 'user_1', email: 'test@example.com' };
 
+/** Reject and return the thrown error for payload assertions. */
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected promise to reject');
+}
+
 describe('getOrganizationMember', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,14 +62,14 @@ describe('getOrganizationMember', () => {
     const ctx = createMockCtx();
     const member = {
       _id: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ORG_ID,
       userId: 'user_1',
       role: 'admin',
       createdAt: 1000,
     };
     ctx.runQuery.mockResolvedValueOnce({ page: [member] });
 
-    const result = await getOrganizationMember(ctx as never, 'org_1', authUser);
+    const result = await getOrganizationMember(ctx as never, ORG_ID, authUser);
 
     expect(result).toEqual(member);
   });
@@ -78,18 +77,18 @@ describe('getOrganizationMember', () => {
   it('reads the local mirror without any cross-component query', async () => {
     const ctx = createMockCtx({
       memberId: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ORG_ID,
       userId: 'user_1',
       role: 'admin',
       createdAt: 1000,
     });
 
-    const result = await getOrganizationMember(ctx as never, 'org_1', authUser);
+    const result = await getOrganizationMember(ctx as never, ORG_ID, authUser);
 
     // Reconstructed OrganizationMember._id is the Better Auth member id.
     expect(result).toEqual({
       _id: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ORG_ID,
       userId: 'user_1',
       role: 'admin',
       createdAt: 1000,
@@ -98,46 +97,130 @@ describe('getOrganizationMember', () => {
     expect(ctx.runQuery).not.toHaveBeenCalled();
   });
 
-  it('throws UnauthorizedError for a disabled member found in the mirror', async () => {
+  it('rejects an empty organization id at the boundary with ORG_NOT_FOUND', async () => {
+    const ctx = createMockCtx();
+
+    const error = await rejection(
+      getOrganizationMember(ctx as never, '', authUser),
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    // Structured wire payload: clients dispatch stale-org recovery on this.
+    expect(error).toMatchObject({
+      code: 'ORG_NOT_FOUND',
+      data: { code: 'ORG_NOT_FOUND', message: 'Organization id is required.' },
+      message: 'Organization id is required.',
+    });
+    // Terminal before any lookup — no mirror read, no adapter round-trip.
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('serializes as a ConvexError (structured data reaches the client)', async () => {
+    const ctx = createMockCtx();
+
+    const error = await rejection(
+      getOrganizationMember(ctx as never, '', authUser),
+    );
+
+    // Convex's runtime detects application errors via this symbol field, not
+    // instanceof — the guarantee that `data` (not a redacted "Server Error")
+    // goes over the wire.
+    expect(
+      typeof error === 'object' &&
+        error !== null &&
+        Symbol.for('ConvexError') in error,
+    ).toBe(true);
+  });
+
+  it('throws ORG_FORBIDDEN when the org exists but the user is not a member', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockImplementation(async (ref: string) => {
+      if (ref === 'betterAuth:adapter:findOne') return { _id: ORG_ID };
+      return { page: [] };
+    });
+
+    const error = await rejection(
+      getOrganizationMember(ctx as never, ORG_ID, { userId: 'user_1' }),
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({
+      code: 'ORG_FORBIDDEN',
+      message: `Not a member of organization ${ORG_ID}`,
+    });
+  });
+
+  it('throws ORG_NOT_FOUND when the organization row no longer exists', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockImplementation(async (ref: string) => {
+      if (ref === 'betterAuth:adapter:findOne') return null;
+      return { page: [] };
+    });
+
+    const error = await rejection(
+      getOrganizationMember(ctx as never, ORG_ID, { userId: 'user_1' }),
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({
+      code: 'ORG_NOT_FOUND',
+      message: `Organization "${ORG_ID}" not found.`,
+    });
+  });
+
+  it('classifies a non-id-shaped organization id as ORG_NOT_FOUND without an adapter lookup', async () => {
+    const ctx = createMockCtx();
+    // Member lookup misses; the existence check must NOT reach the adapter
+    // (db.get on a non-id string throws an opaque decode error there).
+    ctx.runQuery.mockResolvedValue({ page: [] });
+
+    const error = await rejection(
+      getOrganizationMember(ctx as never, 'org_1', { userId: 'user_1' }),
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({ code: 'ORG_NOT_FOUND' });
+    const findOneCalls = ctx.runQuery.mock.calls.filter(
+      ([ref]) => ref === 'betterAuth:adapter:findOne',
+    );
+    expect(findOneCalls).toHaveLength(0);
+  });
+
+  it('throws ORG_FORBIDDEN for a disabled member found in the mirror', async () => {
     const ctx = createMockCtx({
       memberId: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ORG_ID,
       userId: 'user_1',
       role: 'disabled',
       createdAt: 1000,
     });
 
-    await expect(
-      getOrganizationMember(ctx as never, 'org_1', authUser),
-    ).rejects.toThrow(UnauthorizedError);
+    const error = await rejection(
+      getOrganizationMember(ctx as never, ORG_ID, authUser),
+    );
+
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({ code: 'ORG_FORBIDDEN' });
     expect(ctx.runQuery).not.toHaveBeenCalled();
   });
 
-  it('throws UnauthorizedError when member role is disabled', async () => {
+  it('throws ORG_FORBIDDEN when member role is disabled', async () => {
     const ctx = createMockCtx();
     const member = {
       _id: 'om_1',
-      organizationId: 'org_1',
+      organizationId: ORG_ID,
       userId: 'user_1',
       role: 'disabled',
       createdAt: 1000,
     };
     ctx.runQuery.mockResolvedValueOnce({ page: [member] });
 
-    await expect(
-      getOrganizationMember(ctx as never, 'org_1', authUser),
-    ).rejects.toThrow(UnauthorizedError);
-  });
+    const error = await rejection(
+      getOrganizationMember(ctx as never, ORG_ID, authUser),
+    );
 
-  it('throws UnauthorizedError when member not found', async () => {
-    const ctx = createMockCtx();
-    ctx.runQuery.mockResolvedValueOnce({ page: [] });
-
-    await expect(
-      getOrganizationMember(ctx as never, 'org_1', {
-        userId: 'user_1',
-      }),
-    ).rejects.toThrow(UnauthorizedError);
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toMatchObject({ code: 'ORG_FORBIDDEN' });
   });
 
   it('throws UnauthorizedError for disabled member found via email fallback', async () => {
@@ -153,7 +236,7 @@ describe('getOrganizationMember', () => {
       page: [
         {
           _id: 'om_2',
-          organizationId: 'org_1',
+          organizationId: ORG_ID,
           userId: 'user_2',
           role: 'disabled',
           createdAt: 1000,
@@ -162,7 +245,7 @@ describe('getOrganizationMember', () => {
     });
 
     await expect(
-      getOrganizationMember(ctx as never, 'org_1', authUser),
+      getOrganizationMember(ctx as never, ORG_ID, authUser),
     ).rejects.toThrow(UnauthorizedError);
   });
 });

--- a/services/platform/convex/lib/rls/organization/get_organization_member.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.ts
@@ -58,12 +58,20 @@ async function findMemberInMirror(
 }
 
 /**
- * Classify a membership miss before throwing: an org that no longer exists
- * (deleted, or the id is not even id-shaped — a stale client polling a dead
- * persisted active org) is `ORG_NOT_FOUND`, a live org the user simply isn't
- * in is `ORG_FORBIDDEN`. Clients dispatch recovery on `ORG_NOT_FOUND` (clear
- * the stale active org, return to the picker), so the two must not be
- * conflated. One extra adapter read, only on the (terminal) failure path.
+ * Classify a membership miss the moment the authoritative member lookup
+ * comes back empty: an org that no longer exists (deleted, or the id is not
+ * even id-shaped — a stale client polling a dead persisted active org) is
+ * `ORG_NOT_FOUND`, a live org the user simply isn't in is `ORG_FORBIDDEN`.
+ * Clients dispatch recovery on `ORG_NOT_FOUND` (clear the stale active org,
+ * return to the picker), so the two must not be conflated.
+ *
+ * Checked BEFORE the email fallback: no fallback can conjure a membership in
+ * an organization that has no row, so a dead org short-circuits here — two
+ * cross-component reads total, CHEAPER than the old always-run fallback
+ * chain. That matters precisely on this path's hot case: an org deletion
+ * re-executes every subscribed org-scoped query at once, and on a loaded
+ * backend the 4-read fallback chain blew the function budget, surfacing
+ * timeouts instead of the structured miss (observed in manual testing).
  * The `looksLikeConvexDocumentId` pre-check keeps a non-id string out of the
  * adapter's `db.get`, which would throw an opaque decode error (see
  * `lib/helpers/id_shape.ts`).
@@ -140,7 +148,18 @@ export async function getOrganizationMember(
 
   member = member ?? result?.page?.[0];
 
-  // Fallback to email lookup if no direct match.
+  // Membership miss: classify the org FIRST. A deleted/nonexistent org is a
+  // terminal, structured miss — running the email fallback for it would only
+  // add two more cross-component reads that cannot succeed (see
+  // `organizationExists` above for why that latency matters here).
+  if (!member && !(await organizationExists(ctx, organizationId))) {
+    throw new UnauthorizedError(
+      `Organization "${organizationId}" not found.`,
+      'ORG_NOT_FOUND',
+    );
+  }
+
+  // Fallback to email lookup if no direct match (org known to exist here).
   // This handles cases where the JWT userId doesn't match the stored userId, which can occur during:
   // - Account migrations (e.g., user data moved between auth providers)
   // - Account linking (e.g., social login linked to existing email account)
@@ -182,12 +201,8 @@ export async function getOrganizationMember(
   }
 
   if (!member) {
-    if (!(await organizationExists(ctx, organizationId))) {
-      throw new UnauthorizedError(
-        `Organization "${organizationId}" not found.`,
-        'ORG_NOT_FOUND',
-      );
-    }
+    // The org exists (checked above before the fallback) — this is a live-org
+    // membership refusal, not a dead-org miss.
     throw new UnauthorizedError(
       `Not a member of organization ${organizationId}`,
       'ORG_FORBIDDEN',

--- a/services/platform/convex/lib/rls/organization/get_organization_member.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.ts
@@ -102,14 +102,23 @@ export async function getOrganizationMember(
   user?: AuthenticatedUser,
 ): Promise<OrganizationMember> {
   // Reject an empty id at the boundary: callers validate `organizationId` as
-  // `v.string()`, so a client with an empty persisted org context reaches
-  // this gate with `""` — which can never match a membership and used to
-  // surface as the unactionable "Not a member of organization " (sic). Fail
-  // it as the structured, terminal miss it is, before any lookup.
+  // `v.string()`, so a client whose org context is still resolving (or a
+  // stale tab with an empty persisted org) reaches this gate with `""` —
+  // which can never match a membership and used to surface as the
+  // unactionable "Not a member of organization " (sic). Fail it as the
+  // structured, terminal miss it is, before any lookup.
+  //
+  // `ORG_ID_REQUIRED`, deliberately NOT `ORG_NOT_FOUND`: an empty id is a
+  // caller-side gap (a component racing its data, a stale tab), not evidence
+  // that the session's persisted org is gone — the client's dead-org
+  // recovery keys on `ORG_NOT_FOUND` and must not yank a working session to
+  // the org picker over it (observed: the E2E project specs open the task
+  // modal, a transient "" query fired, and the recovery navigated the tab
+  // away mid-flow).
   if (!organizationId) {
     throw new UnauthorizedError(
       'Organization id is required.',
-      'ORG_NOT_FOUND',
+      'ORG_ID_REQUIRED',
     );
   }
 

--- a/services/platform/convex/lib/rls/organization/get_organization_member.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.ts
@@ -5,6 +5,7 @@
 import { components } from '../../../_generated/api';
 import type { QueryCtx, MutationCtx } from '../../../_generated/server';
 import { normalizeAuthEmail } from '../../auth/normalize_auth_email';
+import { looksLikeConvexDocumentId } from '../../helpers/id_shape';
 import { requireAuthenticatedUser } from '../auth/require_authenticated_user';
 import { UnauthorizedError } from '../errors';
 import type { AuthenticatedUser, OrganizationMember } from '../types';
@@ -56,11 +57,54 @@ async function findMemberInMirror(
   }
 }
 
+/**
+ * Classify a membership miss before throwing: an org that no longer exists
+ * (deleted, or the id is not even id-shaped — a stale client polling a dead
+ * persisted active org) is `ORG_NOT_FOUND`, a live org the user simply isn't
+ * in is `ORG_FORBIDDEN`. Clients dispatch recovery on `ORG_NOT_FOUND` (clear
+ * the stale active org, return to the picker), so the two must not be
+ * conflated. One extra adapter read, only on the (terminal) failure path.
+ * The `looksLikeConvexDocumentId` pre-check keeps a non-id string out of the
+ * adapter's `db.get`, which would throw an opaque decode error (see
+ * `lib/helpers/id_shape.ts`).
+ */
+async function organizationExists(
+  ctx: QueryCtx | MutationCtx,
+  organizationId: string,
+): Promise<boolean> {
+  if (!looksLikeConvexDocumentId(organizationId)) return false;
+  try {
+    const org = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: 'organization',
+      where: [{ field: '_id', value: organizationId, operator: 'eq' }],
+    });
+    return org != null;
+  } catch (err) {
+    console.warn(
+      '[getOrganizationMember] organization existence check failed; treating as missing',
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
+}
+
 export async function getOrganizationMember(
   ctx: QueryCtx | MutationCtx,
   organizationId: string,
   user?: AuthenticatedUser,
 ): Promise<OrganizationMember> {
+  // Reject an empty id at the boundary: callers validate `organizationId` as
+  // `v.string()`, so a client with an empty persisted org context reaches
+  // this gate with `""` — which can never match a membership and used to
+  // surface as the unactionable "Not a member of organization " (sic). Fail
+  // it as the structured, terminal miss it is, before any lookup.
+  if (!organizationId) {
+    throw new UnauthorizedError(
+      'Organization id is required.',
+      'ORG_NOT_FOUND',
+    );
+  }
+
   const authUser = user || (await requireAuthenticatedUser(ctx));
 
   // Hot path: read the membership from the local mirror (synced inline on every
@@ -138,14 +182,22 @@ export async function getOrganizationMember(
   }
 
   if (!member) {
+    if (!(await organizationExists(ctx, organizationId))) {
+      throw new UnauthorizedError(
+        `Organization "${organizationId}" not found.`,
+        'ORG_NOT_FOUND',
+      );
+    }
     throw new UnauthorizedError(
       `Not a member of organization ${organizationId}`,
+      'ORG_FORBIDDEN',
     );
   }
 
   if (member.role === 'disabled') {
     throw new UnauthorizedError(
       `Member account is disabled in organization ${organizationId}`,
+      'ORG_FORBIDDEN',
     );
   }
 

--- a/services/platform/convex/members/queries.test.ts
+++ b/services/platform/convex/members/queries.test.ts
@@ -36,8 +36,13 @@ vi.mock('../lib/rls/errors', () => {
       }
     },
     UnauthorizedError: class extends RLSError {
-      constructor() {
-        super('Not authorized to access this resource', 'UNAUTHORIZED');
+      // Mirrors the real signature: org-membership gates pass ORG_NOT_FOUND /
+      // ORG_FORBIDDEN so getCurrentMemberContext can map code → status.
+      constructor(
+        message = 'Not authorized to access this resource',
+        code = 'UNAUTHORIZED',
+      ) {
+        super(message, code);
       }
     },
   };
@@ -115,7 +120,37 @@ describe('getCurrentMemberContext handler', () => {
     expect(result).toBeNull();
   });
 
-  it('returns not_found when unauthorized and org lookup fails', async () => {
+  it('returns not_found when the organization no longer exists', async () => {
+    mockedGetAuthUser.mockResolvedValue({ userId: 'user_1', name: 'Alice' });
+    // getOrganizationMember classifies a dead/malformed org id as ORG_NOT_FOUND.
+    mockedGetOrgMember.mockRejectedValue(
+      new UnauthorizedError('Organization "org_1" not found.', 'ORG_NOT_FOUND'),
+    );
+    const ctx = createMockCtx();
+    const handler = await getHandler();
+
+    const result = await handler(ctx, { organizationId: 'org_1' });
+
+    expect(result).toEqual({ status: 'not_found' });
+  });
+
+  it('returns not_member when the org exists but the user is not in it', async () => {
+    mockedGetAuthUser.mockResolvedValue({ userId: 'user_1', name: 'Alice' });
+    mockedGetOrgMember.mockRejectedValue(
+      new UnauthorizedError(
+        'Not a member of organization org_1',
+        'ORG_FORBIDDEN',
+      ),
+    );
+    const ctx = createMockCtx();
+    const handler = await getHandler();
+
+    const result = await handler(ctx, { organizationId: 'org_1' });
+
+    expect(result).toEqual({ status: 'not_member' });
+  });
+
+  it('returns not_member for a generic UnauthorizedError without a code', async () => {
     mockedGetAuthUser.mockResolvedValue({ userId: 'user_1', name: 'Alice' });
     mockedGetOrgMember.mockRejectedValue(new UnauthorizedError());
     const ctx = createMockCtx();
@@ -123,7 +158,7 @@ describe('getCurrentMemberContext handler', () => {
 
     const result = await handler(ctx, { organizationId: 'org_1' });
 
-    expect(result).toEqual({ status: 'not_found' });
+    expect(result).toEqual({ status: 'not_member' });
   });
 
   it('re-throws non-authorization errors from getOrganizationMember', async () => {

--- a/services/platform/convex/members/queries.ts
+++ b/services/platform/convex/members/queries.ts
@@ -92,10 +92,12 @@ export const getCurrentMemberContext = query({
     } catch (error) {
       if (error instanceof UnauthorizedError) {
         // getOrganizationMember already disambiguated the miss: a dead or
-        // malformed org id throws `ORG_NOT_FOUND`, a live org the user isn't
-        // a (non-disabled) member of throws `ORG_FORBIDDEN` — no second
-        // organization lookup needed here.
-        return error.code === 'ORG_NOT_FOUND'
+        // malformed org id throws `ORG_NOT_FOUND`, an empty id throws
+        // `ORG_ID_REQUIRED` (both mean "no such workspace" to this caller),
+        // and a live org the user isn't a (non-disabled) member of throws
+        // `ORG_FORBIDDEN` — no second organization lookup needed here.
+        return error.code === 'ORG_NOT_FOUND' ||
+          error.code === 'ORG_ID_REQUIRED'
           ? { status: 'not_found' as const }
           : { status: 'not_member' as const };
       }

--- a/services/platform/convex/members/queries.ts
+++ b/services/platform/convex/members/queries.ts
@@ -91,22 +91,13 @@ export const getCurrentMemberContext = query({
       };
     } catch (error) {
       if (error instanceof UnauthorizedError) {
-        try {
-          const org = await ctx.runQuery(
-            components.betterAuth.adapter.findOne,
-            {
-              model: 'organization',
-              where: [
-                { field: '_id', value: args.organizationId, operator: 'eq' },
-              ],
-            },
-          );
-          return org
-            ? { status: 'not_member' as const }
-            : { status: 'not_found' as const };
-        } catch {
-          return { status: 'not_found' as const };
-        }
+        // getOrganizationMember already disambiguated the miss: a dead or
+        // malformed org id throws `ORG_NOT_FOUND`, a live org the user isn't
+        // a (non-disabled) member of throws `ORG_FORBIDDEN` — no second
+        // organization lookup needed here.
+        return error.code === 'ORG_NOT_FOUND'
+          ? { status: 'not_found' as const }
+          : { status: 'not_member' as const };
       }
       throw error;
     }

--- a/services/platform/convex/provider_credentials/queries.test.ts
+++ b/services/platform/convex/provider_credentials/queries.test.ts
@@ -10,7 +10,7 @@
 import { convexTest, type TestConvex } from 'convex-test';
 import { describe, expect, it } from 'vitest';
 
-import { api, internal } from '../_generated/api';
+import { api, components, internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
@@ -98,6 +98,29 @@ async function seedMember(
       role: 'member',
       createdAt: 0,
     });
+  });
+}
+
+/**
+ * Create a betterAuth organization; returns its component `_id`. The
+ * non-member refusal reads the organization row to classify the miss
+ * (`ORG_FORBIDDEN` for a live org vs `ORG_NOT_FOUND` for a dead one), so
+ * that test must query an org that actually exists — same helper as
+ * mutations.test.ts.
+ */
+async function seedAuthOrg(t: T, slug: string): Promise<string> {
+  return await t.run(async (ctx) => {
+    const created = await ctx.runMutation(
+      components.betterAuth.adapter.create,
+      {
+        input: {
+          model: 'organization',
+          data: { name: slug, slug, createdAt: 0 },
+        },
+      },
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter returns the created record as unknown
+    return (created as { _id: string })._id;
   });
 }
 
@@ -231,11 +254,14 @@ describe('listCredentials', () => {
   it('refuses a caller who is not a member of the organization', async () => {
     const t = newWorld();
     await seedMember(t, MEMBER, OTHER_ORG);
+    // A real organization row: the refusal must be the live-org kind
+    // (ORG_FORBIDDEN "Not a member"), not the dead-org ORG_NOT_FOUND.
+    const liveOrgId = await seedAuthOrg(t, 'pc-queries-live');
     await expect(
       t
         .withIdentity({ subject: MEMBER })
         .query(api.provider_credentials.queries.listCredentials, {
-          organizationId: ORG,
+          organizationId: liveOrgId,
         }),
     ).rejects.toThrowError(/Not a member/);
   });


### PR DESCRIPTION
Closes the stale/empty-org error class behind the demo project's active GlitchTip cluster (~250 events across ~45 issue groups): a client whose persisted active organization was deleted — or whose org context is an empty string in a stale tab — failed org-scoped queries forever and spammed a new issue group per action failure.

- [TALE-PROJECT-OU](https://app.glitchtip.com/tale-project/issues/7266834) — `Not a member of organization ` (empty id), 63 events, still firing the day of this fix; latest event culprit is `getOrganizationMember`.
- [TALE-PROJECT-VB](https://app.glitchtip.com/tale-project/issues/7489510) / [VA](https://app.glitchtip.com/tale-project/issues/7489509) / [VC](https://app.glitchtip.com/tale-project/issues/7489511) / [VD](https://app.glitchtip.com/tale-project/issues/7489512) — one user polling a deleted org (`jh7csd7…`) weekly for a month, never recovering.
- ~40 single-event `[CONVEX A(…)] [Request ID: xxxx] Server Error` groups — the request id defeats message grouping.

### Server
- `lib/rls/errors.ts`: RLS errors now extend `ConvexError<{code, message}>` (the ongoing "throw ConvexError codes" migration; `lib/auth/require_org_membership.ts` is the reference). Class identity and the human `message` are preserved, so every `instanceof UnauthorizedError` degrade-gracefully catch site and the server log/title shapes are unchanged; only the wire gains structured `data`.
- `lib/rls/organization/get_organization_member.ts`: rejects an empty `organizationId` at the boundary (`ORG_NOT_FOUND`) before any lookup, and classifies membership misses with one failure-path adapter read — dead/malformed org id → `ORG_NOT_FOUND`, live org without membership → `ORG_FORBIDDEN` (disabled member too). The `looksLikeConvexDocumentId` pre-check keeps non-id strings out of the adapter's `db.get` decode throw.
- `lib/helpers/org_slug.ts`: `OrgSlugUnresolvableError` becomes a structured `ConvexError` (`ORG_NOT_FOUND`); `isOrgSlugUnresolvable` and all catch sites unchanged.
- `members/queries.ts`: `getCurrentMemberContext` maps the gate's code to `not_found`/`not_member` instead of re-looking up the organization in its catch.

### Client
- New `app/lib/org-error-recovery.ts`, wired as the query cache's global `onError`: on a `code: 'ORG_NOT_FOUND'` failure it clears the member-context hint, leaves the dead org's dashboard routes for `/dashboard/` (the index re-resolves a valid membership), clears the session's active org (`setActive({organizationId: null})`, best-effort), and refreshes the session cache — once per burst. `ORG_FORBIDDEN` deliberately does NOT redirect: the dashboard layout's "you've been removed" AccessDenied screen is an intentional design (`routes/dashboard/$id.tsx`), and structured errors are no longer retried, so forbidden states cannot loop.
- Query default `retry` now skips structured ConvexErrors (same rationale `useActionQuery` documents) — deterministic failures reach the UI and the recovery hook once instead of 4 server executions each.
- New `app/lib/sentry-normalize.ts` + `beforeSend`: strips `[Request ID: …]` from message/logentry/exception values so failures group one-issue-per-root-cause (covers `captureConsoleIntegration`-promoted convex console lines too).

### Tests
New boundary regression `convex/governance/get_policy_org_boundary.test.ts` reproduces the GlitchTip evidence end-to-end in a convex-test world (empty id and deleted org id both reject as structured `ORG_NOT_FOUND` across the function boundary; `getCurrentMemberContext` folds both into `not_found`). Rewritten/extended unit suites for the gate, the status mapping, the recovery hook, and the normalizer. The `{provider,connector}_credentials` non-member refusal tests now seed a real betterAuth organization row so they assert the live-org refusal they were written for.

### Verification
On `a91763c` + this branch: `tsc --noEmit` clean; `oxlint --type-aware` clean on all changed files; `lint:sast` clean; platform suites — server 672 files/8,440 tests pass, client 3,312 tests pass, pii 67,214 tests pass. The single server-suite failure (`lib/mocks/contract/openai-compat.test.ts`, embedding dim 16384≠1536) fails identically on the pristine base with this change stashed — pre-existing, unrelated.

Related: #3019 · complements 72bc189-style endpoint softening (`readBranding` default-branding fallback) by closing the class centrally.