### PR TITLE
docs: price the fix before deferring it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,11 @@ Safety and architecture invariants — they hold even where no linter covers the
   run them.
 - **Scaffold a new part** (package / service / tool / skill) from a template (`bun run gen …`),
   never hand-rolled — so it carries the standard configs and test layout.
+- **Price the fix before you defer it** — a shortcoming you could fix in the same change is a
+  defect, not a limitation to write up. Check whether the index, field, or helper already exists,
+  and whether the repo already solves the same shape elsewhere; naming a follow-up route does not
+  make a deferral priced. A bounded listing's walk order, a cap's ordering, and a missing guard
+  are part of the feature, not caveats on it.
 - **Instructions are docs too** — change a path, command, or pattern a skill or an agent contract
   documents, and update it in the same change.
 


### PR DESCRIPTION
Adds one boundary to the shared contract: a shortcoming you could fix in the same change is a defect, not a limitation to write up.

## Why

On #3008 I capped two chat listings at 15 rows and walked a single-field index, so "are there any open tasks?" answered with the 15 stalest tasks on the board, then sorted them convincingly. I documented that as a known limitation, and researched a follow-up route, which made it read as a considered trade-off.

It was not one. `updatedAt` is required on both tables, both org+`updatedAt` indexes already existed, and `convex/tasks/queries.ts` already walked one of them descending. The fix was two index swaps and an `.order('desc')`.

Documenting a shortcoming I could have fixed converts my own omission into something the team has signed off. Naming a follow-up makes it worse, because it signals the cost was weighed.

## What changed

One bullet in `## Non-negotiable boundaries`. No code.

The bullet covers the engineering act only: check the cost before deferring. It deliberately says nothing about where a deferral gets written up, because that convention lives in a per-repo writing skill rather than in this shared contract.

## Scope

Documents an existing expectation rather than introducing a gate, so nothing enforces it. It sits with the other boundaries no linter covers.