### PR TITLE
feat(platform): preview task deliverables like documents

### DIFF
--- a/packages/ui/src/markdown/shiki.test.ts
+++ b/packages/ui/src/markdown/shiki.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { highlightCode, resolveShikiTheme } from './shiki';
+import { highlightCode, resolveLanguage, resolveShikiTheme } from './shiki';
 
 describe('resolveShikiTheme', () => {
   it('maps light aliases onto min-light', () => {
@@ -23,5 +23,30 @@ describe('highlightCode themes', () => {
 
     const light = await highlightCode('{"a":1}', 'json', 'github-light');
     expect(light?.html).toContain('class="shiki min-light"');
+  });
+});
+
+describe('diff highlighting', () => {
+  it('resolves .patch onto the diff grammar', () => {
+    expect(resolveLanguage('patch')).toBe('diff');
+    expect(resolveLanguage('diff')).toBe('diff');
+  });
+
+  // REGRESSION: the min-* themes ship no colors for the diff scopes, so a
+  // previewed .patch file rendered fully monochrome. The extended themes must
+  // give added and removed lines distinct colors.
+  it('colors added and removed lines distinctly', async () => {
+    const result = await highlightCode(
+      '@@ -1,2 +1,2 @@\n-const a = 1;\n+const a = 2;\n',
+      'patch',
+      'light',
+    );
+    expect(result?.language).toBe('diff');
+    expect(result?.html).toContain('#22863A');
+    expect(result?.html).toContain('#B31D28');
+
+    const dark = await highlightCode('-old\n+new\n', 'diff', 'dark');
+    expect(dark?.html).toContain('#85E89D');
+    expect(dark?.html).toContain('#F97583');
   });
 });

--- a/packages/ui/src/markdown/shiki.ts
+++ b/packages/ui/src/markdown/shiki.ts
@@ -7,17 +7,69 @@
  * the bundle off the WASM oniguruma path.
  */
 
-import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
+import {
+  createHighlighterCore,
+  type HighlighterCore,
+  type ThemeRegistration,
+} from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
 let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+/**
+ * The min-* themes define no colors for the diff grammar's scopes, so a
+ * rendered `.patch`/`.diff` file (and every ```diff fence) came out
+ * monochrome. Extend a theme with the standard add/del/hunk palette; the
+ * theme keeps its name, so `codeToHtml` resolves it unchanged.
+ */
+function withDiffColors(
+  theme: ThemeRegistration,
+  palette: { inserted: string; deleted: string; range: string; header: string },
+): ThemeRegistration {
+  return {
+    ...theme,
+    tokenColors: [
+      ...(theme.tokenColors ?? []),
+      {
+        scope: ['markup.inserted'],
+        settings: { foreground: palette.inserted },
+      },
+      {
+        scope: ['markup.deleted'],
+        settings: { foreground: palette.deleted },
+      },
+      {
+        scope: ['meta.diff.range', 'punctuation.definition.range.diff'],
+        settings: { foreground: palette.range },
+      },
+      {
+        scope: ['meta.diff.header', 'meta.diff.index'],
+        settings: { foreground: palette.header },
+      },
+    ],
+  };
+}
 
 function getHighlighter(): Promise<HighlighterCore> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighterCore({
       themes: [
-        import('shiki/themes/min-dark.mjs'),
-        import('shiki/themes/min-light.mjs'),
+        import('shiki/themes/min-dark.mjs').then((m) =>
+          withDiffColors(m.default, {
+            inserted: '#85e89d',
+            deleted: '#f97583',
+            range: '#b392f0',
+            header: '#79b8ff',
+          }),
+        ),
+        import('shiki/themes/min-light.mjs').then((m) =>
+          withDiffColors(m.default, {
+            inserted: '#22863a',
+            deleted: '#b31d28',
+            range: '#6f42c1',
+            header: '#005cc5',
+          }),
+        ),
       ],
       langs: [
         import('shiki/langs/bash.mjs'),
@@ -126,6 +178,8 @@ const LANG_ALIASES: Record<string, string> = {
   gql: 'graphql',
   terraform: 'hcl',
   tf: 'hcl',
+  // Unified diffs: `.patch`/`.diff` files share the one `diff` grammar.
+  patch: 'diff',
 };
 
 export function resolveLanguage(input: string | undefined): string {

--- a/services/platform/app/features/documents/components/document-preview-routing.test.tsx
+++ b/services/platform/app/features/documents/components/document-preview-routing.test.tsx
@@ -205,6 +205,24 @@ describe('DocumentPreview routing', () => {
     expect(screen.getByTestId('markdown-preview')).toBeInTheDocument();
   });
 
+  // REGRESSION: harvested deliverables like `0001-fix.patch` carry a generic
+  // octet-stream mime; the extension alone must route them to the source
+  // preview instead of the "not available" state.
+  it.each(['patch', 'diff'])(
+    'routes .%s files to text preview despite a generic mime',
+    (ext) => {
+      render(
+        <DocumentPreview
+          url={`https://example.com/0001-fix.${ext}`}
+          fileName={`0001-fix.${ext}`}
+          mimeType="application/octet-stream"
+        />,
+      );
+
+      expect(screen.getByTestId('text-preview')).toBeInTheDocument();
+    },
+  );
+
   it('prefers mimeType over an unhelpful filename', () => {
     render(
       <DocumentPreview

--- a/services/platform/app/features/shared/files/file-displays.test.tsx
+++ b/services/platform/app/features/shared/files/file-displays.test.tsx
@@ -24,10 +24,22 @@ vi.mock('convex/react', () => ({
   useQuery: () => undefined,
 }));
 
+// The real preview dialog subscribes to Convex (document metadata, file URL).
+// These are composition tests of the chips' wiring — which chip opens the
+// dialog and with what identity — so stub it down to a queryable marker.
+const previewDialogProps: Array<{ fileId?: string; fileName?: string }> = [];
+vi.mock('@/app/features/documents/components/document-preview-dialog', () => ({
+  DocumentPreviewDialog: (props: { fileId?: string; fileName?: string }) => {
+    previewDialogProps.push(props);
+    return <div role="dialog">{props.fileName}</div>;
+  },
+}));
+
 import { FileAttachmentDisplay, FilePartDisplay } from './file-displays';
 
 beforeEach(() => {
   useFileUrlCalls.length = 0;
+  previewDialogProps.length = 0;
 });
 
 const STORAGE_URL =
@@ -133,26 +145,32 @@ function attachment(
   };
 }
 
-// REGRESSION: task Output / attachment chips resolved a bare
-// `/api/storage/<uuid>` URL, so the browser saved downloads under the storage
-// uuid instead of the real file name. Non-image chips must request a NAMED
-// URL (served with Content-Disposition); images and audio/video must not —
-// their URLs render inline (thumbnail, lightbox, native player).
-describe('FileAttachmentDisplay — download naming', () => {
-  const NAMED_URL =
-    'http://localhost:3000/http_api/storage?id=storage-1&filename=spec.pdf';
-
-  it('resolves a document chip with its file name and links the named URL', () => {
-    fileUrlData = NAMED_URL;
-    render(
+// Document chips open the same preview dialog the documents surfaces use
+// (render in place; the dialog's header owns the named Download for the
+// rest). Images keep the inline thumbnail + lightbox and audio/video the
+// browser's inline player, so only THOSE still resolve a URL — unnamed,
+// because an attachment disposition would break inline rendering.
+describe('FileAttachmentDisplay — preview + inline behavior', () => {
+  it('opens the document preview dialog when a document chip is clicked', async () => {
+    fileUrlData = undefined;
+    const { user } = render(
       <FileAttachmentDisplay
         attachment={attachment()}
         organizationId="org_1"
       />,
     );
 
-    expect(useFileUrlCalls).toEqual([['storage-1', false, 'spec.pdf']]);
-    expect(screen.getByRole('link')).toHaveAttribute('href', NAMED_URL);
+    // No URL fetch for document chips — the dialog resolves its own.
+    expect(useFileUrlCalls).toEqual([['storage-1', true]]);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /spec\.pdf/ }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(previewDialogProps).toEqual([
+      expect.objectContaining({ fileId: 'storage-1', fileName: 'spec.pdf' }),
+    ]);
   });
 
   it('resolves an image without a file name so it keeps rendering inline', () => {
@@ -169,12 +187,13 @@ describe('FileAttachmentDisplay — download naming', () => {
       />,
     );
 
-    expect(useFileUrlCalls).toEqual([['storage-1', true, undefined]]);
+    expect(useFileUrlCalls).toEqual([['storage-1', true]]);
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('resolves audio without a file name so the chip keeps opening the player', () => {
-    fileUrlData = 'http://localhost:3000/api/storage/storage-1';
+  it('keeps audio chips opening the inline player, not the preview dialog', () => {
+    const PLAYER_URL = 'http://localhost:3000/api/storage/storage-1';
+    fileUrlData = PLAYER_URL;
     render(
       <FileAttachmentDisplay
         attachment={attachment({
@@ -185,6 +204,7 @@ describe('FileAttachmentDisplay — download naming', () => {
       />,
     );
 
-    expect(useFileUrlCalls).toEqual([['storage-1', false, undefined]]);
+    expect(useFileUrlCalls).toEqual([['storage-1', false]]);
+    expect(screen.getByRole('link')).toHaveAttribute('href', PLAYER_URL);
   });
 });

--- a/services/platform/app/features/shared/files/file-displays.tsx
+++ b/services/platform/app/features/shared/files/file-displays.tsx
@@ -184,15 +184,15 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
   const { t } = useT('chat');
   const isImage = attachment.fileType.startsWith('image/');
   const isMedia = isAudioOrVideo(attachment.fileType);
-  // Document chips are download targets: resolve their URL with the real file
-  // name so it serves as `Content-Disposition: attachment` and the browser
-  // saves e.g. `slides.pptx` instead of the bare storage uuid. Images stay
-  // unnamed (they render inline in the thumbnail + lightbox); audio/video too,
-  // so their chip keeps opening the browser's inline player.
+  const isDocument = !isImage && !isMedia;
+  // Document chips open the in-app preview dialog (whose header owns the
+  // named Download), so no URL is resolved for them here. Only images
+  // (thumbnail + lightbox) and audio/video (the browser's inline player)
+  // still need one — unnamed, because an attachment disposition would break
+  // inline rendering.
   const { data: serverFileUrl } = useFileUrl(
     attachment.fileId,
-    !!attachment.previewUrl,
-    isImage || isMedia ? undefined : attachment.fileName,
+    !!attachment.previewUrl || isDocument,
   );
   const displayUrl = attachment.previewUrl || serverFileUrl || undefined;
 
@@ -210,6 +210,7 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
     audioMetadata?.transcriptionStatus === 'completed' &&
     !!audioMetadata.transcript;
   const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   if (isImage && !displayUrl) {
     return (
@@ -240,6 +241,55 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
 
   const displayName = middleEllipsis(attachment.fileName, 28);
   const sizeLabel = formatFileSize(attachment.fileSize);
+
+  const chipBody = (
+    <>
+      <FileTypeIcon
+        fileType={attachment.fileType}
+        fileName={attachment.fileName}
+      />
+      <VStack className="min-w-0 flex-1">
+        <Text as="div" variant="label" title={attachment.fileName}>
+          {displayName}
+        </Text>
+        <Text as="div" variant="caption">
+          {sizeLabel}
+        </Text>
+      </VStack>
+    </>
+  );
+
+  // Documents open the same preview dialog the documents surfaces use —
+  // rendered in place when a renderer exists; everything else lands on the
+  // dialog's "not available" state with its header Download button.
+  if (isDocument) {
+    return (
+      <>
+        <Row
+          gap={3}
+          className="bg-muted hover:bg-muted/80 max-w-[280px] rounded-lg px-3 py-2 transition-colors"
+        >
+          <button
+            type="button"
+            onClick={() => setPreviewOpen(true)}
+            className="focus-visible:ring-ring flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-md border-none bg-transparent p-0 text-left focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {chipBody}
+          </button>
+        </Row>
+        {previewOpen && (
+          <DocumentPreviewDialog
+            open
+            onOpenChange={(open) => {
+              if (!open) setPreviewOpen(false);
+            }}
+            fileId={attachment.fileId}
+            fileName={attachment.fileName}
+          />
+        )}
+      </>
+    );
+  }
 
   const viewTranscriptButton = canPreviewTranscript ? (
     <button
@@ -286,18 +336,7 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
     return (
       <>
         <Row gap={3} className="bg-muted max-w-[280px] rounded-lg px-3 py-2">
-          <FileTypeIcon
-            fileType={attachment.fileType}
-            fileName={attachment.fileName}
-          />
-          <VStack className="min-w-0 flex-1">
-            <Text as="div" variant="label" title={attachment.fileName}>
-              {displayName}
-            </Text>
-            <Text as="div" variant="caption">
-              {sizeLabel}
-            </Text>
-          </VStack>
+          {chipBody}
           {viewTranscriptButton}
         </Row>
         {transcriptDialog}
@@ -317,18 +356,7 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
           rel="noopener noreferrer"
           className="flex min-w-0 flex-1 items-center gap-3"
         >
-          <FileTypeIcon
-            fileType={attachment.fileType}
-            fileName={attachment.fileName}
-          />
-          <VStack className="min-w-0 flex-1">
-            <Text as="div" variant="label" title={attachment.fileName}>
-              {displayName}
-            </Text>
-            <Text as="div" variant="caption">
-              {sizeLabel}
-            </Text>
-          </VStack>
+          {chipBody}
         </a>
         {viewTranscriptButton}
       </Row>

--- a/services/platform/app/features/tasks/components/task-attachments.tsx
+++ b/services/platform/app/features/tasks/components/task-attachments.tsx
@@ -56,8 +56,8 @@ export function TaskAttachments({
   // attachment (client-side `previewUrl` first, else a batched server
   // lookup), then let a click open the same `ImagePreviewDialog` chat uses.
   // Before this, images had no `onImageClick` at all — the thumbnail button
-  // rendered but its click was a no-op (#2664). Non-image attachments
-  // already get an open-in-new-tab link from `FileAttachmentDisplay` itself.
+  // rendered but its click was a no-op (#2664). Non-image attachments open
+  // the document preview dialog from `FileAttachmentDisplay` itself.
   const imageAttachments = useMemo(
     () => attachments.filter((a) => isImage(a.fileType)),
     [attachments],

--- a/services/platform/convex/node_only/sandbox/session_exec.ts
+++ b/services/platform/convex/node_only/sandbox/session_exec.ts
@@ -85,6 +85,8 @@ function inferContentType(path: string): string {
     case 'css':
     case 'txt':
     case 'log':
+    case 'patch':
+    case 'diff':
       return 'text/plain; charset=utf-8';
     case 'png':
       return 'image/png';

--- a/services/platform/lib/utils/text-file-types.ts
+++ b/services/platform/lib/utils/text-file-types.ts
@@ -50,6 +50,8 @@ const CODE_EXTENSIONS = new Set([
   'sql',
   'graphql',
   'gql',
+  'patch',
+  'diff',
 ]);
 
 const CONFIG_EXTENSIONS = new Set([

--- a/services/web/public/_a/script.js
+++ b/services/web/public/_a/script.js
@@ -1,0 +1,6 @@
+/* Placeholder for the self-hosted analytics tracker (see the tag in
+ * index.html). In production the web droplet's Caddy proxies /_a/* to the
+ * analytics host before this static file is reachable, so real visitors get
+ * the real script. Everywhere without that proxy — vite dev, vite preview,
+ * the e2e webServer — this no-op answers the request instead of 404ing into
+ * every visitor's console (the home smoke test asserts a clean console). */


### PR DESCRIPTION
## What

Task-modal **Deliverables** (and Attachments) file chips linked a `Content-Disposition: attachment` URL, so clicking any non-image file downloaded it. They now behave like the documents surfaces: clicking a document chip opens `DocumentPreviewDialog` — previewable types render in place, everything else shows the not-available state with the dialog-header **Download** button (which saves under the real file name). Images keep the lightbox, audio/video keep the inline player + transcript.

`.patch`/`.diff` files additionally get a real preview instead of the not-available state. Four pieces were needed:

- `patch`/`diff` registered as code extensions in `text-file-types.ts` → routed to the source preview (also makes the upload gates accept them as text attachments; RAG indexability deliberately untouched — they attach inline, never index)
- `patch → diff` language alias in the shared shiki singleton (the diff grammar was already eager-loaded)
- the min-light/min-dark themes define **no colors** for the diff scopes, so a tokenized diff rendered monochrome — both themes are extended at registration with the standard add/del/hunk/header palette, which also colors every ```diff fence repo-wide
- sandbox harvest `inferContentType` labels `.patch`/`.diff` as `text/plain`

## Verification

Live on the dev stack: a real harvested `.pptx` deliverable shows the dialog fallback + Download; seeded `.patch`/`.md`/`.txt` deliverables render as colored diff / markdown / text; a dead `fileId` degrades to the failed-to-load state; the dialog Download saves as `0001-fix-demo.patch`, not the storage uuid.

Tests: file-displays chip→dialog contract rewritten (the named-URL fetch it replaced is gone from chips; the server's named `getFileUrl` branch stays for the chat lanes that persist download URLs), `.patch`/`.diff` routing regression in document-preview-routing, shiki alias + theme-color assertions. `tsc` green in platform and ui; oxfmt clean.