### PR TITLE
fix(platform): show the serving unpinned agent model picks actually use

### DIFF
--- a/services/platform/app/features/automations/components/agent-execution-log.test.tsx
+++ b/services/platform/app/features/automations/components/agent-execution-log.test.tsx
@@ -94,6 +94,28 @@ describe('AgentExecutionLog', () => {
     expect(screen.getByText('new turn')).toBeInTheDocument();
   });
 
+  it('names the serving the turn ran on as a footnote', () => {
+    state.data = {
+      ...op([{ type: 'text', text: 'working' }]),
+      modelRef: 'anthropic/claude-fable-5',
+    };
+    render(<AgentExecutionLog organizationId="org-1" runId={runId} />);
+    expect(
+      screen.getByText(/ran on anthropic\/claude-fable-5/),
+    ).toBeInTheDocument();
+  });
+
+  it('collapses the doubled provider segment of a gateway-lane ref', () => {
+    state.data = {
+      ...op([{ type: 'text', text: 'working' }]),
+      modelRef: 'openrouter/openrouter/anthropic/claude-fable-5',
+    };
+    render(<AgentExecutionLog organizationId="org-1" runId={runId} />);
+    expect(
+      screen.getByText(/ran on openrouter\/anthropic\/claude-fable-5/),
+    ).toBeInTheDocument();
+  });
+
   it('renders nothing for a run without an agent op', () => {
     state.data = null;
     const { container } = render(

--- a/services/platform/app/features/automations/components/agent-execution-log.tsx
+++ b/services/platform/app/features/automations/components/agent-execution-log.tsx
@@ -136,10 +136,25 @@ export interface AgentSandboxOpView {
   status: string;
   progressText?: string;
   liveTimeline?: TimelinePart[];
+  /** The provider-qualified model this turn ran on (`provider/model`),
+   * stamped by the kick that resolved the serving — the answer to "which
+   * provider actually served (and billed) this turn". */
+  modelRef?: string;
   /** The model that read images for this turn — absent when the serving model
    * reads them itself. Recorded per turn, so this is the model that actually
    * ran, not whatever the org would resolve to today. */
   visionModelRef?: string;
+}
+
+/** A stamped ref is `provider/model`, and on the gateway lane the model half
+ * is itself a gateway ref that starts with the same provider slug — collapse
+ * the doubled segment so `openrouter/openrouter/anthropic/x` reads as the
+ * one provider it names. */
+function displayModelRef(ref: string): string {
+  const [first, second, ...rest] = ref.split('/');
+  return first !== undefined && first === second
+    ? [first, ...rest].join('/')
+    : ref;
 }
 
 /**
@@ -347,13 +362,26 @@ export function ExecutionLogView({
           )}
         </div>
       )}
+      {/* Which serving the turn ACTUALLY ran on. A footnote like the vision
+          line: the question ("whose key billed this?") is only asked after
+          the fact, and the ref names the provider a pinless node's walk
+          landed on — which the editor cannot promise in advance. */}
+      {op.modelRef !== undefined && (
+        <Text as="p" variant="muted" className="text-xs">
+          {t('runs.agentLog.servedBy', {
+            model: displayModelRef(op.modelRef),
+          })}
+        </Text>
+      )}
       {/* Which model read this turn's images. A footnote, not a header row:
           it answers a question the reader only asks when an image read went
           wrong — and the task dialog hides the header entirely, which is
           exactly where that question gets asked. */}
       {op.visionModelRef !== undefined && (
         <Text as="p" variant="muted" className="text-xs">
-          {t('runs.agentLog.visionModel', { model: op.visionModelRef })}
+          {t('runs.agentLog.visionModel', {
+            model: displayModelRef(op.visionModelRef),
+          })}
         </Text>
       )}
     </Stack>

--- a/services/platform/app/features/automations/components/agent-node-fields.test.tsx
+++ b/services/platform/app/features/automations/components/agent-node-fields.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { NodeDef } from '@/lib/engine/core/types';
+import { render, screen } from '@/tests/utils/render';
+
+import { AgentNodeFields } from './agent-node-fields';
+
+// The picker's roster: the SAME model id served twice — the subscription copy
+// carries the bare vendor id, the OpenRouter copy the vendor-prefixed one.
+// This is exactly the constellation where a pinless pick used to LOOK like
+// the subscription entry while the run's walk picked the other provider.
+vi.mock('@/app/features/projects/hooks/queries', () => ({
+  useProjectHarnesses: () => ({
+    data: {
+      harnesses: [{ harness: 'claude-code', label: 'Claude Code' }],
+      models: [
+        {
+          id: 'anthropic/claude-fable-5',
+          label: 'anthropic/claude-fable-5',
+          providerSlug: 'openrouter',
+          providerLabel: 'OpenRouter',
+          credential: { authMethod: 'api-key' },
+        },
+        {
+          id: 'claude-fable-5',
+          label: 'claude-fable-5',
+          providerSlug: 'anthropic',
+          providerLabel: 'Anthropic',
+          credential: {
+            authMethod: 'subscription-broker',
+            constraints: { harness: 'claude-code' },
+          },
+        },
+      ],
+    },
+  }),
+  useAgentSecrets: () => ({ data: [] }),
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useAutomationCapabilities: () => ({
+    data: { skills: [], connectors: [] },
+  }),
+}));
+
+// The secrets manager talks to Convex actions on mount; the model pin story
+// never touches it.
+vi.mock('@/app/features/projects/components/agent-secrets-field', () => ({
+  AgentSecretsField: () => null,
+}));
+
+// The runtime's own answer for a pinless pick — what the walk would use NOW.
+const { previewState } = vi.hoisted(() => ({
+  previewState: { data: undefined as unknown },
+}));
+vi.mock('@/app/features/projects/hooks/use-unpinned-serving-preview', () => ({
+  useUnpinnedServingPreview: () => ({ data: previewState.data }),
+}));
+
+function renderFields(node: NodeDef, onChange = vi.fn()) {
+  const view = render(
+    <AgentNodeFields
+      organizationId="org-1"
+      node={node}
+      readOnly={false}
+      onChange={onChange}
+    />,
+  );
+  return { ...view, onChange };
+}
+
+const PINLESS: NodeDef = {
+  id: 'agent',
+  type: 'agent',
+  model: 'claude-fable-5',
+};
+
+describe('AgentNodeFields model pin', () => {
+  it('shows the provider a run would ACTUALLY use for a pinless pick', () => {
+    previewState.data = {
+      ok: true,
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+      lane: 'gateway',
+    };
+    renderFields(PINLESS);
+
+    // The trigger sits on the walk's answer (the OpenRouter copy), never on
+    // the id-lookalike subscription entry the old fallback preselected.
+    expect(screen.getByText('anthropic/claude-fable-5')).toBeVisible();
+    expect(
+      screen.getByText(/runs currently resolve to OpenRouter/),
+    ).toBeVisible();
+  });
+
+  it('says it is still resolving before the runtime has answered', () => {
+    previewState.data = undefined;
+    renderFields(PINLESS);
+    expect(
+      screen.getByText(/checking which provider runs would use/),
+    ).toBeVisible();
+  });
+
+  it('surfaces the resolver’s own refusal when nothing serves the model', () => {
+    previewState.data = {
+      ok: false,
+      reason: 'no configured provider serves "claude-fable-5"',
+    };
+    renderFields(PINLESS);
+    expect(
+      screen.getByText(/no configured provider serves "claude-fable-5"/),
+    ).toBeVisible();
+  });
+
+  it('stays quiet once the pick carries its provider', () => {
+    previewState.data = undefined;
+    renderFields({
+      id: 'agent',
+      type: 'agent',
+      model: 'claude-fable-5',
+      modelProvider: 'anthropic',
+    });
+
+    expect(screen.getByText('claude-fable-5')).toBeVisible();
+    expect(screen.queryByText(/without a pinned provider/)).toBeNull();
+  });
+});

--- a/services/platform/app/features/automations/components/agent-node-fields.tsx
+++ b/services/platform/app/features/automations/components/agent-node-fields.tsx
@@ -29,6 +29,7 @@ import {
   useAgentSecrets,
   useProjectHarnesses,
 } from '@/app/features/projects/hooks/queries';
+import { useUnpinnedServingPreview } from '@/app/features/projects/hooks/use-unpinned-serving-preview';
 import {
   findSelectedModel,
   toModelOptions,
@@ -158,9 +159,48 @@ export function AgentNodeFields({
   );
   const selectedModel = findSelectedModel(offeredModels, model, modelProvider);
   // Only claim "not offered" once the listing has answered — an empty roster
-  // while it loads is not a missing model.
+  // while it loads is not a missing model. Pinned picks only: a pinless pick
+  // is not missing, it is unresolved, and gets the preview treatment below.
   const modelUnlisted =
-    roster.data !== undefined && model !== '' && selectedModel === undefined;
+    roster.data !== undefined &&
+    model !== '' &&
+    modelProvider !== '' &&
+    selectedModel === undefined;
+  // A pick saved before providers were part of it names a model but no
+  // provider — the run's walk decides at kick time. Show what that walk
+  // would pick RIGHT NOW (the runtime's own resolver answers, so display
+  // and run cannot drift), never a lookalike row matched by id alone.
+  const unpinnedModel = model !== '' && modelProvider === '';
+  const preview = useUnpinnedServingPreview(
+    'workflow',
+    unpinnedModel
+      ? { organizationId, model, harness: effectiveHarness }
+      : undefined,
+  );
+  const resolved = preview.data;
+  const resolvedRow =
+    unpinnedModel && resolved?.ok === true
+      ? offeredModels.find(
+          (option) =>
+            option.providerSlug === resolved.providerSlug &&
+            option.id === resolved.modelId,
+        )
+      : undefined;
+  // What the trigger displays: the pinned pair, or the row runs would use.
+  const displayedModel = selectedModel ?? resolvedRow;
+  const unpinnedDescription = !unpinnedModel
+    ? undefined
+    : resolved === undefined
+      ? tProjects('agents.modelUnpinnedResolving', { model })
+      : resolved.ok
+        ? tProjects('agents.modelUnpinnedResolved', {
+            model,
+            provider: resolvedRow?.providerLabel ?? resolved.providerSlug,
+          })
+        : tProjects('agents.modelUnpinnedUnserved', {
+            model,
+            reason: resolved.reason,
+          });
   const modelOptions = useMemo(
     () =>
       offeredModels.map((option, index) => ({
@@ -222,13 +262,15 @@ export function AgentNodeFields({
         required
         disabled={readOnly}
         value={
-          selectedModel !== undefined
-            ? String(offeredModels.indexOf(selectedModel))
+          displayedModel !== undefined
+            ? String(offeredModels.indexOf(displayedModel))
             : null
         }
         {...(modelUnlisted
           ? { description: t('editor.agent.modelUnlisted', { model }) }
-          : {})}
+          : unpinnedDescription !== undefined
+            ? { description: unpinnedDescription }
+            : {})}
         onValueChange={(value) => {
           const option = offeredModels[Number(value)];
           if (option === undefined) return;

--- a/services/platform/app/features/automations/components/automation-detail.test.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.test.tsx
@@ -32,6 +32,8 @@ const {
     } as unknown,
     /** The pack manifest's display half, when the test wants one. */
     presentation: undefined as unknown,
+    /** Agent nodes of the DEPLOYED version without a provider pin. */
+    deployedUnpinnedAgentNodes: undefined as string[] | undefined,
   },
   /** The org's projects and the automation's bindings — the run-scope picker
    * appears only when two or more projects are bound. */
@@ -84,6 +86,9 @@ vi.mock('../hooks/queries', () => ({
       deployedVersion: 2,
       ...(state.presentation !== undefined
         ? { presentation: state.presentation }
+        : {}),
+      ...(state.deployedUnpinnedAgentNodes !== undefined
+        ? { deployedUnpinnedAgentNodes: state.deployedUnpinnedAgentNodes }
         : {}),
     },
     isPending: false,
@@ -188,6 +193,7 @@ beforeEach(() => {
   mockNavigate.mockClear();
   projectsData.list = [];
   projectsData.bound = [];
+  state.deployedUnpinnedAgentNodes = undefined;
 });
 
 describe('AutomationDetail', () => {
@@ -207,6 +213,23 @@ describe('AutomationDetail', () => {
     state.presentation = undefined;
     renderPage();
     expect(screen.getByText('Chases unpaid invoices.')).toBeVisible();
+  });
+
+  it('warns when the DEPLOYED version runs agent nodes without a pin', () => {
+    state.deployedUnpinnedAgentNodes = ['agent'];
+    renderPage();
+    // The standing warning names the live version and its pinless nodes —
+    // the page otherwise shows v3, whose picker may look pinned.
+    expect(
+      screen.getByText(/The live version \(v2\) has an agent node \(agent\)/),
+    ).toBeVisible();
+  });
+
+  it('stays quiet when the deployed version has no pinless agent node', () => {
+    renderPage();
+    expect(
+      screen.queryByText(/without a pinned provider/, { exact: false }),
+    ).toBeNull();
   });
 
   it('test-runs the version on screen, not the deployed one', async () => {

--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -575,6 +575,22 @@ export function AutomationDetail({
           <Alert variant="destructive" description={refusal} />
         )}
 
+        {/* The LIVE version runs agent nodes without a provider pin: serving
+            resolves by walk at run time, so the model picker's preselect is
+            not what necessarily bills. Standing warning until a pinned
+            version is deployed — saving alone does not move the trigger. */}
+        {meta?.deployedUnpinnedAgentNodes !== undefined &&
+          meta.deployedVersion !== undefined && (
+            <Alert
+              variant="warning"
+              description={t('detail.unpinnedModels', {
+                version: meta.deployedVersion,
+                nodes: meta.deployedUnpinnedAgentNodes.join(', '),
+                count: meta.deployedUnpinnedAgentNodes.length,
+              })}
+            />
+          )}
+
         {lastRun && (
           <div className="flex flex-wrap items-center gap-2">
             <Button

--- a/services/platform/app/features/projects/components/project-agent-dialog.test.tsx
+++ b/services/platform/app/features/projects/components/project-agent-dialog.test.tsx
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { render, screen } from '@/tests/utils/render';
+
+import type { ProjectAgentRow } from '../hooks/queries';
+import { ProjectAgentDialog } from './project-agent-dialog';
+
+const { updateAgent, previewState } = vi.hoisted(() => ({
+  updateAgent: vi.fn().mockResolvedValue(undefined),
+  previewState: { data: undefined as unknown },
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useCreateProjectAgent: () => ({ mutateAsync: vi.fn() }),
+  useUpdateProjectAgent: () => ({ mutateAsync: updateAgent }),
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useAgentSecrets: () => ({ data: [] }),
+}));
+
+// The runtime's own answer for a pinless pick — what the walk would use NOW.
+vi.mock('../hooks/use-unpinned-serving-preview', () => ({
+  useUnpinnedServingPreview: () => ({ data: previewState.data }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+// FormDialog reads the route for the org id; there is no router in the test.
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useParams: () => ({ id: 'org-1' }),
+}));
+
+// The secrets manager talks to Convex actions on mount; the model pin story
+// never touches it.
+vi.mock('./agent-secrets-field', () => ({
+  AgentSecretsField: () => null,
+}));
+
+// The same model id served twice — the constellation where a pinless row
+// used to LOOK like the subscription entry while a run billed the other lane.
+const MODELS = [
+  {
+    id: 'anthropic/claude-fable-5',
+    label: 'anthropic/claude-fable-5',
+    providerSlug: 'openrouter',
+    providerLabel: 'OpenRouter',
+  },
+  {
+    id: 'claude-fable-5',
+    label: 'claude-fable-5',
+    providerSlug: 'anthropic',
+    providerLabel: 'Anthropic',
+    subscription: { harness: 'claude-code' },
+  },
+];
+
+// A row saved before picks carried providers: model only, no modelProvider.
+const LEGACY_AGENT = {
+  _id: 'agent-1',
+  name: 'PR reviewer',
+  harness: 'claude-code',
+  model: 'claude-fable-5',
+  skills: [],
+  connectors: [],
+} as unknown as ProjectAgentRow;
+
+function renderDialog(agent: ProjectAgentRow) {
+  return render(
+    <ProjectAgentDialog
+      open
+      onOpenChange={() => undefined}
+      projectId={'p1' as Id<'projects'>}
+      organizationId="org-1"
+      harnesses={[{ harness: 'claude-code', label: 'Claude Code' }]}
+      models={MODELS}
+      skills={[]}
+      connectors={[]}
+      agent={agent}
+    />,
+  );
+}
+
+beforeEach(() => {
+  updateAgent.mockClear();
+  previewState.data = undefined;
+});
+
+describe('ProjectAgentDialog model pin', () => {
+  it('shows the provider a run would ACTUALLY use for a pinless row', async () => {
+    previewState.data = {
+      ok: true,
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+      lane: 'gateway',
+    };
+    renderDialog(LEGACY_AGENT);
+
+    // The trigger sits on the walk's answer (the OpenRouter copy), never on
+    // the id-lookalike subscription entry the old fallback preselected.
+    expect(await screen.findByText('anthropic/claude-fable-5')).toBeVisible();
+    expect(
+      screen.getByText(/runs currently resolve to OpenRouter/),
+    ).toBeVisible();
+  });
+
+  it('keeps an untouched legacy row unpinned rather than adopting a guess', async () => {
+    previewState.data = {
+      ok: true,
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+      lane: 'gateway',
+    };
+    const { user } = renderDialog(LEGACY_AGENT);
+
+    await screen.findByText(/runs currently resolve to OpenRouter/);
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+    expect(updateAgent).toHaveBeenCalled();
+    expect(updateAgent.mock.calls.at(-1)?.[0]).not.toHaveProperty(
+      'modelProvider',
+    );
+  });
+});

--- a/services/platform/app/features/projects/components/project-agent-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-agent-dialog.tsx
@@ -34,6 +34,7 @@ import {
 } from '../hooks/mutations';
 import { useAgentSecrets, type AgentSecretSummary } from '../hooks/queries';
 import type { ProjectAgentRow } from '../hooks/queries';
+import { useUnpinnedServingPreview } from '../hooks/use-unpinned-serving-preview';
 import { findSelectedModel, type ModelOption } from '../lib/model-options';
 import { AgentSecretsField } from './agent-secrets-field';
 
@@ -149,6 +150,41 @@ export function ProjectAgentDialog({
     [models, harness],
   );
   const selectedModel = findSelectedModel(offeredModels, model, modelProvider);
+  // A pick saved before providers were part of it names a model but no
+  // provider — the run's walk decides at kick time. Show what that walk
+  // would pick RIGHT NOW (the task lane's own resolver answers, so display
+  // and run cannot drift), never a lookalike row matched by id alone.
+  const unpinnedModel = model !== '' && modelProvider === '';
+  const preview = useUnpinnedServingPreview(
+    'task',
+    open && unpinnedModel && harness !== ''
+      ? { organizationId, model, harness }
+      : undefined,
+  );
+  const resolved = preview.data;
+  const resolvedRow =
+    unpinnedModel && resolved?.ok === true
+      ? offeredModels.find(
+          (option) =>
+            option.providerSlug === resolved.providerSlug &&
+            option.id === resolved.modelId,
+        )
+      : undefined;
+  // What the trigger displays: the pinned pair, or the row runs would use.
+  const displayedModel = selectedModel ?? resolvedRow;
+  const unpinnedDescription = !unpinnedModel
+    ? undefined
+    : resolved === undefined
+      ? t('agents.modelUnpinnedResolving', { model })
+      : resolved.ok
+        ? t('agents.modelUnpinnedResolved', {
+            model,
+            provider: resolvedRow?.providerLabel ?? resolved.providerSlug,
+          })
+        : t('agents.modelUnpinnedUnserved', {
+            model,
+            reason: resolved.reason,
+          });
   const modelOptions = useMemo(
     () =>
       offeredModels.map((option, index) => ({
@@ -176,8 +212,9 @@ export function ProjectAgentDialog({
         harness,
         model,
         // A pick made in this dialog always carries its provider; the empty
-        // string only survives from a legacy row whose saved id no longer
-        // matches any offered option — keep that row unpinned.
+        // string survives only from a legacy row the author left untouched
+        // (the picker warns and offers pinning, but never adopts a provider
+        // on its own) — keep that row unpinned.
         ...(modelProvider !== '' ? { modelProvider } : {}),
         skills: [...binding.skills],
         connectors: [...binding.connectors],
@@ -293,10 +330,13 @@ export function ProjectAgentDialog({
         options={modelOptions}
         required
         value={
-          selectedModel !== undefined
-            ? String(offeredModels.indexOf(selectedModel))
+          displayedModel !== undefined
+            ? String(offeredModels.indexOf(displayedModel))
             : null
         }
+        {...(unpinnedDescription !== undefined
+          ? { description: unpinnedDescription }
+          : {})}
         onValueChange={(value) => {
           const option = offeredModels[Number(value)];
           if (option === undefined) return;

--- a/services/platform/app/features/projects/hooks/use-unpinned-serving-preview.ts
+++ b/services/platform/app/features/projects/hooks/use-unpinned-serving-preview.ts
@@ -1,0 +1,36 @@
+/**
+ * What an UNPINNED model pick would run on right now — the runtime's own
+ * resolution, asked per lane so the display can never drift from what a run
+ * would do: the automation agent node asks the workflow resolver (two-pass
+ * walk), the project-agent dialog asks the task resolver (direct-only walk).
+ * Disabled entirely for pinned picks; the answer is a snapshot the wording
+ * must present as "currently".
+ */
+
+import { useActionQuery } from '@/app/hooks/use-action-query';
+import { api } from '@/convex/_generated/api';
+
+/** Which lane's resolver answers — they intentionally differ unpinned. */
+export type ServingPreviewLane = 'workflow' | 'task';
+
+export interface ServingPreviewArgs {
+  organizationId: string;
+  model: string;
+  harness: string;
+}
+
+export function useUnpinnedServingPreview(
+  lane: ServingPreviewLane,
+  args: ServingPreviewArgs | undefined,
+) {
+  const func =
+    lane === 'workflow'
+      ? api.automations.serving_preview.previewUnpinnedAgentServing
+      : api.tasks.serving_preview.previewUnpinnedTaskServing;
+  return useActionQuery(
+    ['unpinned-serving-preview', lane, args ?? null],
+    func,
+    args ?? { organizationId: '', model: '', harness: '' },
+    { enabled: args !== undefined },
+  );
+}

--- a/services/platform/app/features/projects/lib/model-options.ts
+++ b/services/platform/app/features/projects/lib/model-options.ts
@@ -57,20 +57,18 @@ export function toModelOptions(
 }
 
 /** The offered option matching a saved pick: the exact (provider, id) pair,
- * falling back to the id alone for a row saved before providers were part of
- * the pick (same precedent as the chat composer's picker). */
+ * and nothing looser. A pinless legacy pick deliberately matches NOTHING
+ * here — an id-alone fallback used to preselect whichever provider happened
+ * to share the id, asserting a provider the run's walk might not use. The
+ * pickers render a pinless pick from the runtime's own resolution preview
+ * instead, so what is shown is what would actually serve. */
 export function findSelectedModel(
   options: readonly ModelOption[],
   model: string,
   modelProvider: string,
 ): ModelOption | undefined {
-  if (model === '') return undefined;
-  return (
-    options.find(
-      (option) => option.id === model && option.providerSlug === modelProvider,
-    ) ??
-    (modelProvider === ''
-      ? options.find((option) => option.id === model)
-      : undefined)
+  if (model === '' || modelProvider === '') return undefined;
+  return options.find(
+    (option) => option.id === model && option.providerSlug === modelProvider,
   );
 }

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -68,6 +68,7 @@ import type * as automations_recover_agent_turns from "../automations/recover_ag
 import type * as automations_rest_api from "../automations/rest_api.js";
 import type * as automations_run_status from "../automations/run_status.js";
 import type * as automations_script_host from "../automations/script_host.js";
+import type * as automations_serving_preview from "../automations/serving_preview.js";
 import type * as automations_stepper from "../automations/stepper.js";
 import type * as automations_store from "../automations/store.js";
 import type * as automations_triggers from "../automations/triggers.js";
@@ -886,6 +887,7 @@ import type * as tasks_rest_api from "../tasks/rest_api.js";
 import type * as tasks_review_mutations from "../tasks/review_mutations.js";
 import type * as tasks_review_shared from "../tasks/review_shared.js";
 import type * as tasks_search_for_chat from "../tasks/search_for_chat.js";
+import type * as tasks_serving_preview from "../tasks/serving_preview.js";
 import type * as tasks_stats from "../tasks/stats.js";
 import type * as tasks_task_auto_retry from "../tasks/task_auto_retry.js";
 import type * as tasks_task_kick_resume from "../tasks/task_kick_resume.js";
@@ -1041,6 +1043,7 @@ declare const fullApi: ApiFromModules<{
   "automations/rest_api": typeof automations_rest_api;
   "automations/run_status": typeof automations_run_status;
   "automations/script_host": typeof automations_script_host;
+  "automations/serving_preview": typeof automations_serving_preview;
   "automations/stepper": typeof automations_stepper;
   "automations/store": typeof automations_store;
   "automations/triggers": typeof automations_triggers;
@@ -1859,6 +1862,7 @@ declare const fullApi: ApiFromModules<{
   "tasks/review_mutations": typeof tasks_review_mutations;
   "tasks/review_shared": typeof tasks_review_shared;
   "tasks/search_for_chat": typeof tasks_search_for_chat;
+  "tasks/serving_preview": typeof tasks_serving_preview;
   "tasks/stats": typeof tasks_stats;
   "tasks/task_auto_retry": typeof tasks_task_auto_retry;
   "tasks/task_kick_resume": typeof tasks_task_kick_resume;

--- a/services/platform/convex/automations/queries.test.ts
+++ b/services/platform/convex/automations/queries.test.ts
@@ -296,3 +296,104 @@ describe('getOrgAutomationMetrics', () => {
     ).rejects.toThrow(/disabled/);
   });
 });
+
+describe('getAutomation deployed unpinned agent nodes', () => {
+  /** One stored version row; the document is the engine's own shape. */
+  async function seedVersion(
+    t: T,
+    name: string,
+    version: number,
+    nodes: Record<string, unknown>[],
+  ): Promise<void> {
+    await t.run(async (ctx) => {
+      await ctx.db.insert('automations', {
+        organizationId: ORG,
+        name,
+        version,
+        document: { version: 1, name, nodes },
+        createdBy: MEMBER,
+        createdAt: version,
+      });
+    });
+  }
+
+  async function deploy(t: T, name: string, version: number): Promise<void> {
+    await t.run(async (ctx) => {
+      await ctx.db.insert('automationDeployments', {
+        organizationId: ORG,
+        name,
+        version,
+        deployedBy: MEMBER,
+        deployedAt: version,
+      });
+    });
+  }
+
+  it('reports the DEPLOYED version’s pinless agent nodes, not the loaded one’s', async () => {
+    const t = convexTest(schema, modules);
+    await seedMembers(t);
+    // v1 (deployed): an unpinned agent node — the walk picks its provider.
+    // v2 (latest, what the editor loads): the same node, pinned. The warning
+    // must still fire, because triggers run v1.
+    await seedVersion(t, 'triage', 1, [
+      { id: 'agent', type: 'agent', model: 'claude-fable-5', prompt: 'p' },
+      // Same shape on a non-agent node: llm nodes are direct-only by design,
+      // so they are not the pin story and must not be reported.
+      { id: 'summarize', type: 'llm', model: 'claude-fable-5', prompt: 'p' },
+    ]);
+    await seedVersion(t, 'triage', 2, [
+      {
+        id: 'agent',
+        type: 'agent',
+        model: 'claude-fable-5',
+        modelProvider: 'anthropic',
+        prompt: 'p',
+      },
+    ]);
+    await deploy(t, 'triage', 1);
+
+    const loaded = await t
+      .withIdentity({ subject: MEMBER })
+      .query(api.automations.queries.getAutomation, {
+        organizationId: ORG,
+        name: 'triage',
+      });
+    expect(loaded?.version).toBe(2);
+    expect(loaded?.deployedVersion).toBe(1);
+    expect(loaded?.deployedUnpinnedAgentNodes).toEqual(['agent']);
+  });
+
+  it('stays silent when the deployed version is pinned, or nothing is deployed', async () => {
+    const t = convexTest(schema, modules);
+    await seedMembers(t);
+    await seedVersion(t, 'pinned', 1, [
+      {
+        id: 'agent',
+        type: 'agent',
+        model: 'claude-fable-5',
+        modelProvider: 'anthropic',
+        prompt: 'p',
+      },
+    ]);
+    await deploy(t, 'pinned', 1);
+    await seedVersion(t, 'draft-only', 1, [
+      { id: 'agent', type: 'agent', model: 'claude-fable-5', prompt: 'p' },
+    ]);
+
+    const pinned = await t
+      .withIdentity({ subject: MEMBER })
+      .query(api.automations.queries.getAutomation, {
+        organizationId: ORG,
+        name: 'pinned',
+      });
+    expect(pinned?.deployedUnpinnedAgentNodes).toBeUndefined();
+
+    const draftOnly = await t
+      .withIdentity({ subject: MEMBER })
+      .query(api.automations.queries.getAutomation, {
+        organizationId: ORG,
+        name: 'draft-only',
+      });
+    expect(draftOnly?.deployedUnpinnedAgentNodes).toBeUndefined();
+  });
+});

--- a/services/platform/convex/automations/queries.ts
+++ b/services/platform/convex/automations/queries.ts
@@ -304,6 +304,27 @@ export const getLiveRunForTask = query({
   },
 });
 
+/**
+ * Agent nodes of one stored document whose model pick predates provider
+ * pinning — a model without a `modelProvider`. Such a node runs on the
+ * unpinned serving walk (whichever connector reaches the model first), while
+ * the editor's fallback preselect makes it LOOK pinned — so the detail page
+ * warns about the deployed version instead of letting the checkmark lie.
+ */
+function unpinnedAgentNodeIds(document: unknown): string[] {
+  if (!isRecord(document) || !Array.isArray(document.nodes)) return [];
+  const ids: string[] = [];
+  for (const node of document.nodes) {
+    if (!isRecord(node) || node.type !== 'agent') continue;
+    if (typeof node.model !== 'string' || node.model === '') continue;
+    if (typeof node.modelProvider === 'string' && node.modelProvider !== '') {
+      continue;
+    }
+    if (typeof node.id === 'string') ids.push(node.id);
+  }
+  return ids;
+}
+
 /** One version's document — the latest when `version` is omitted. */
 export const getAutomation = query({
   args: {
@@ -320,6 +341,10 @@ export const getAutomation = query({
       message: v.optional(v.string()),
       testsPassed: v.optional(v.boolean()),
       deployedVersion: v.optional(v.number()),
+      /** Agent nodes of the DEPLOYED version (not the loaded one) whose model
+       * carries no provider pin — present only when there is something to
+       * warn about, so the editor can nudge "re-pin and deploy". */
+      deployedUnpinnedAgentNodes: v.optional(v.array(v.string())),
       /** The version's display half — the name and description the automation's
        * own page shows above its slug. */
       presentation: v.optional(v.any()),
@@ -337,6 +362,22 @@ export const getAutomation = query({
     );
     if (!row) return null;
     const deployment = await deploymentRow(ctx, args.organizationId, args.name);
+    // The warning reads the version triggers RUN, which need not be the one
+    // the editor loaded — a pinned draft over an unpinned live version is
+    // exactly the trap worth naming.
+    const deployedRow =
+      deployment === null
+        ? null
+        : deployment.version === row.version
+          ? row
+          : await versionRow(
+              ctx,
+              args.organizationId,
+              args.name,
+              deployment.version,
+            );
+    const unpinned =
+      deployedRow === null ? [] : unpinnedAgentNodeIds(deployedRow.document);
     return {
       name: row.name,
       version: row.version,
@@ -345,6 +386,7 @@ export const getAutomation = query({
       ...(row.testsPassed !== undefined && { testsPassed: row.testsPassed }),
       ...(row.presentation !== undefined && { presentation: row.presentation }),
       ...(deployment !== null && { deployedVersion: deployment.version }),
+      ...(unpinned.length > 0 && { deployedUnpinnedAgentNodes: unpinned }),
       createdBy: row.createdBy,
       createdAt: row.createdAt,
     };

--- a/services/platform/convex/automations/serving_preview.test.ts
+++ b/services/platform/convex/automations/serving_preview.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Wiring tests for the unpinned-serving preview: the caller must be an org
+ * member, the resolver is asked WITHOUT a pin (exactly like a pinless kick),
+ * and a resolution failure comes back as a result — the resolver's own
+ * sentence — never as a thrown error the picker cannot render. Direct-handler
+ * pattern: the codegen surface is mocked so `action(config)` returns the
+ * config, and the resolver is stubbed.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+}));
+
+const mockRequireOrgMembershipById = vi.fn();
+vi.mock('../lib/auth/require_org_membership', () => ({
+  requireOrgMembershipById: (...args: unknown[]) =>
+    mockRequireOrgMembershipById(...args),
+}));
+
+const mockResolve = vi.fn();
+vi.mock('../lib/providers/agent_serving', () => ({
+  resolveWorkflowAgentServing: (...args: unknown[]) => mockResolve(...args),
+}));
+
+const { previewUnpinnedAgentServing } = await import('./serving_preview');
+
+type ActionConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+const handler = (previewUnpinnedAgentServing as unknown as ActionConfig)
+  .handler;
+
+const ARGS = {
+  organizationId: 'org-1',
+  model: 'claude-fable-5',
+  harness: 'claude-code',
+} as never;
+
+beforeEach(() => {
+  mockRequireOrgMembershipById.mockReset().mockResolvedValue({});
+  mockResolve.mockReset();
+});
+
+describe('previewUnpinnedAgentServing', () => {
+  it('asks the workflow resolver with NO pin and passes its answer through', async () => {
+    mockResolve.mockResolvedValue({
+      lane: 'gateway',
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+    });
+
+    const result = await handler({} as never, ARGS);
+
+    expect(mockRequireOrgMembershipById).toHaveBeenCalledWith({}, 'org-1');
+    // No `modelProvider` in the resolver call — the preview must take the
+    // exact unpinned path a pinless node's kick takes.
+    expect(mockResolve).toHaveBeenCalledWith(
+      {},
+      {
+        organizationId: 'org-1',
+        model: 'claude-fable-5',
+        harness: 'claude-code',
+      },
+    );
+    expect(result).toEqual({
+      ok: true,
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+      lane: 'gateway',
+    });
+  });
+
+  it('returns the resolver’s refusal as a result, not a thrown error', async () => {
+    mockResolve.mockRejectedValue(
+      new Error('no configured provider serves "claude-fable-5"'),
+    );
+
+    const result = await handler({} as never, ARGS);
+    expect(result).toEqual({
+      ok: false,
+      reason: 'no configured provider serves "claude-fable-5"',
+    });
+  });
+
+  it('refuses before resolving when the caller is not a member', async () => {
+    mockRequireOrgMembershipById.mockRejectedValue(new Error('ORG_FORBIDDEN'));
+
+    await expect(handler({} as never, ARGS)).rejects.toThrow('ORG_FORBIDDEN');
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/automations/serving_preview.ts
+++ b/services/platform/convex/automations/serving_preview.ts
@@ -1,0 +1,64 @@
+'use node';
+
+/**
+ * What an UNPINNED agent-node model pick would run on RIGHT NOW.
+ *
+ * The node editor must display the provider a run would actually use, and
+ * the only non-drifting source of that answer is the runtime's own resolver
+ * — so this action asks {@link resolveWorkflowAgentServing} with no pin,
+ * exactly as the stepper's kick would for a pinless node. The answer is a
+ * snapshot, not a promise: connectors, credentials, and allowlists move it,
+ * which is precisely why the editor offers pinning.
+ *
+ * A resolution failure is a RESULT here, not an error — "nothing serves this
+ * model" is what the editor needs to render, and the resolver's own message
+ * names the reason the way it would fail a run.
+ */
+
+import { v } from 'convex/values';
+
+import { action } from '../_generated/server';
+import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
+import { resolveWorkflowAgentServing } from '../lib/providers/agent_serving';
+
+export const previewUnpinnedAgentServing = action({
+  args: {
+    organizationId: v.string(),
+    model: v.string(),
+    /** The node's EFFECTIVE harness (the host default when the field is
+     * unset) — subscription servings are sanctioned per harness. */
+    harness: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      ok: v.literal(true),
+      providerSlug: v.string(),
+      /** The catalog id the serving provider lists the model under — the
+       * vendor-prefixed ref on an aggregator, the bare id elsewhere. */
+      modelId: v.string(),
+      lane: v.union(v.literal('gateway'), v.literal('subscription')),
+    }),
+    v.object({ ok: v.literal(false), reason: v.string() }),
+  ),
+  handler: async (ctx, args) => {
+    await requireOrgMembershipById(ctx, args.organizationId);
+    try {
+      const serving = await resolveWorkflowAgentServing(ctx, {
+        organizationId: args.organizationId,
+        model: args.model,
+        harness: args.harness,
+      });
+      return {
+        ok: true as const,
+        providerSlug: serving.providerSlug,
+        modelId: serving.modelId,
+        lane: serving.lane,
+      };
+    } catch (error) {
+      return {
+        ok: false as const,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+});

--- a/services/platform/convex/sandbox/agent_node_op.test.ts
+++ b/services/platform/convex/sandbox/agent_node_op.test.ts
@@ -64,6 +64,7 @@ async function seedOp(
     liveTimeline?: { type: string; text?: string }[];
     progressText?: string;
     startedAt?: number;
+    modelRef?: string;
   } = {},
 ): Promise<void> {
   await t.run(async (ctx) => {
@@ -79,6 +80,9 @@ async function seedOp(
       }),
       ...(overrides.liveTimeline !== undefined && {
         liveTimeline: overrides.liveTimeline,
+      }),
+      ...(overrides.modelRef !== undefined && {
+        modelRef: overrides.modelRef,
       }),
     });
   });
@@ -104,6 +108,31 @@ describe('getAgentNodeSandboxOp', () => {
       progressText: 'reading the invoices',
       liveTimeline: [{ type: 'tool-Read' }],
     });
+  });
+
+  it('surfaces the serving the turn ran on, absent on pre-field rows', async () => {
+    const t = convexTest(schema, modules);
+    const runId = await seedRun(t);
+    await seedOp(t, runId, { startedAt: 1 });
+    const bare = await t
+      .withIdentity({ subject: MEMBER })
+      .query(api.sandbox.session_queries_public.getAgentNodeSandboxOp, {
+        organizationId: ORG,
+        runId,
+      });
+    expect(bare?.modelRef).toBeUndefined();
+
+    await seedOp(t, runId, {
+      startedAt: 2,
+      modelRef: 'openrouter/anthropic/claude-fable-5',
+    });
+    const op = await t
+      .withIdentity({ subject: MEMBER })
+      .query(api.sandbox.session_queries_public.getAgentNodeSandboxOp, {
+        organizationId: ORG,
+        runId,
+      });
+    expect(op?.modelRef).toBe('openrouter/anthropic/claude-fable-5');
   });
 
   it('ignores non-agent ops of the same session', async () => {

--- a/services/platform/convex/sandbox/session_queries_public.ts
+++ b/services/platform/convex/sandbox/session_queries_public.ts
@@ -154,6 +154,9 @@ export const getAgentNodeSandboxOp = query({
       ),
       progressText: v.optional(v.string()),
       liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
+      /** The provider-qualified model this turn actually ran on — the serving
+       * the kick resolved, not whatever the org would resolve to today. */
+      modelRef: v.optional(v.string()),
       /** The model that read this turn's images, when the polyfill was armed. */
       visionModelRef: v.optional(v.string()),
       startedAt: v.number(),
@@ -190,6 +193,7 @@ export const getAgentNodeSandboxOp = query({
         status: op.status,
         ...(op.progressText !== undefined && { progressText: op.progressText }),
         ...(op.liveTimeline !== undefined && { liveTimeline: op.liveTimeline }),
+        ...(op.modelRef !== undefined && { modelRef: op.modelRef }),
         ...(op.visionModelRef !== undefined && {
           visionModelRef: op.visionModelRef,
         }),

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -1405,6 +1405,9 @@ export const getTaskAgentRunSandboxOp = query({
       ),
       progressText: v.optional(v.string()),
       liveTimeline: v.optional(v.array(sessionOpTimelinePartValidator)),
+      /** The provider-qualified model this turn actually ran on — the serving
+       * the kick resolved, not whatever the org would resolve to today. */
+      modelRef: v.optional(v.string()),
       /** The model that read this turn's images, when the polyfill was armed. */
       visionModelRef: v.optional(v.string()),
       startedAt: v.number(),
@@ -1436,6 +1439,7 @@ export const getTaskAgentRunSandboxOp = query({
         status: op.status,
         ...(op.progressText !== undefined && { progressText: op.progressText }),
         ...(op.liveTimeline !== undefined && { liveTimeline: op.liveTimeline }),
+        ...(op.modelRef !== undefined && { modelRef: op.modelRef }),
         ...(op.visionModelRef !== undefined && {
           visionModelRef: op.visionModelRef,
         }),

--- a/services/platform/convex/tasks/serving_preview.test.ts
+++ b/services/platform/convex/tasks/serving_preview.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Wiring tests for the task-lane unpinned-serving preview: the caller must be
+ * an org member, the TASK resolver is asked WITHOUT a pin (the direct-only
+ * legacy walk — deliberately not the automation lane's two-pass), and a
+ * resolution failure comes back as a result the dialog can render.
+ * Direct-handler pattern: the codegen surface is mocked so `action(config)`
+ * returns the config, and the resolver is stubbed.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+}));
+
+const mockRequireOrgMembershipById = vi.fn();
+vi.mock('../lib/auth/require_org_membership', () => ({
+  requireOrgMembershipById: (...args: unknown[]) =>
+    mockRequireOrgMembershipById(...args),
+}));
+
+const mockResolve = vi.fn();
+vi.mock('./task_serving', () => ({
+  resolveTaskServing: (...args: unknown[]) => mockResolve(...args),
+}));
+
+const { previewUnpinnedTaskServing } = await import('./serving_preview');
+
+type ActionConfig = {
+  handler: (ctx: never, args: never) => Promise<unknown>;
+};
+const handler = (previewUnpinnedTaskServing as unknown as ActionConfig).handler;
+
+const ARGS = {
+  organizationId: 'org-1',
+  model: 'claude-fable-5',
+  harness: 'claude-code',
+} as never;
+
+beforeEach(() => {
+  mockRequireOrgMembershipById.mockReset().mockResolvedValue({});
+  mockResolve.mockReset();
+});
+
+describe('previewUnpinnedTaskServing', () => {
+  it('asks the task resolver with NO pin and passes its answer through', async () => {
+    mockResolve.mockResolvedValue({
+      lane: 'gateway',
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+    });
+
+    const result = await handler({} as never, ARGS);
+
+    expect(mockRequireOrgMembershipById).toHaveBeenCalledWith({}, 'org-1');
+    // No `modelProvider` in the resolver call — the preview must take the
+    // exact unpinned path a pinless agent's run takes.
+    expect(mockResolve).toHaveBeenCalledWith(
+      {},
+      {
+        organizationId: 'org-1',
+        model: 'claude-fable-5',
+        harness: 'claude-code',
+      },
+    );
+    expect(result).toEqual({
+      ok: true,
+      providerSlug: 'openrouter',
+      modelId: 'anthropic/claude-fable-5',
+      lane: 'gateway',
+    });
+  });
+
+  it('returns the resolver’s refusal as a result, not a thrown error', async () => {
+    mockResolve.mockRejectedValue(
+      new Error('no provider is configured to serve model claude-fable-5'),
+    );
+
+    const result = await handler({} as never, ARGS);
+    expect(result).toEqual({
+      ok: false,
+      reason: 'no provider is configured to serve model claude-fable-5',
+    });
+  });
+
+  it('refuses before resolving when the caller is not a member', async () => {
+    mockRequireOrgMembershipById.mockRejectedValue(new Error('ORG_FORBIDDEN'));
+
+    await expect(handler({} as never, ARGS)).rejects.toThrow('ORG_FORBIDDEN');
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/tasks/serving_preview.ts
+++ b/services/platform/convex/tasks/serving_preview.ts
@@ -1,0 +1,64 @@
+'use node';
+
+/**
+ * What an UNPINNED project-agent model pick would run on RIGHT NOW.
+ *
+ * The agent dialog must display the provider a run would actually use, and
+ * the only non-drifting source of that answer is the task lane's own
+ * resolver — so this action asks {@link resolveTaskServing} with no pin,
+ * exactly as the run host would for a pinless agent. The task lane's
+ * unpinned walk is DIRECT-ONLY (unlike the automation lane's two-pass), so
+ * the two surfaces each ask their own lane instead of sharing a guess.
+ *
+ * A resolution failure is a RESULT here, not an error — "nothing serves this
+ * model" is what the dialog needs to render, and the resolver's own message
+ * names the reason the way it would fail a run.
+ */
+
+import { v } from 'convex/values';
+
+import { action } from '../_generated/server';
+import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
+import { resolveTaskServing } from './task_serving';
+
+export const previewUnpinnedTaskServing = action({
+  args: {
+    organizationId: v.string(),
+    model: v.string(),
+    /** The agent's harness — kept in the contract for parity with the pinned
+     * split even though the unpinned direct walk ignores it. */
+    harness: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      ok: v.literal(true),
+      providerSlug: v.string(),
+      /** The catalog id the serving provider lists the model under — the
+       * vendor-prefixed ref on an aggregator, the bare id elsewhere. */
+      modelId: v.string(),
+      lane: v.union(v.literal('gateway'), v.literal('subscription')),
+    }),
+    v.object({ ok: v.literal(false), reason: v.string() }),
+  ),
+  handler: async (ctx, args) => {
+    await requireOrgMembershipById(ctx, args.organizationId);
+    try {
+      const serving = await resolveTaskServing(ctx, {
+        organizationId: args.organizationId,
+        model: args.model,
+        harness: args.harness,
+      });
+      return {
+        ok: true as const,
+        providerSlug: serving.providerSlug,
+        modelId: serving.modelId,
+        lane: serving.lane,
+      };
+    } catch (error) {
+      return {
+        ok: false as const,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+});

--- a/services/platform/convex/tasks/task_agent_run_op.test.ts
+++ b/services/platform/convex/tasks/task_agent_run_op.test.ts
@@ -100,6 +100,7 @@ async function seedOp(
     progressText?: string;
     liveTimeline?: { type: string; text?: string }[];
     startedAt?: number;
+    modelRef?: string;
   } = {},
 ): Promise<void> {
   await t.run(async (ctx) => {
@@ -115,6 +116,9 @@ async function seedOp(
       }),
       ...(overrides.liveTimeline !== undefined && {
         liveTimeline: overrides.liveTimeline,
+      }),
+      ...(overrides.modelRef !== undefined && {
+        modelRef: overrides.modelRef,
       }),
     });
   });
@@ -141,6 +145,20 @@ describe('getTaskAgentRunSandboxOp', () => {
       progressText: 'laying out the slides',
       liveTimeline: [{ type: 'tool-Bash' }],
     });
+  });
+
+  it('surfaces the serving the turn ran on', async () => {
+    const t = convexTest(schema, modules);
+    const { run } = await seedRun(t);
+    await seedOp(t, run, { modelRef: 'anthropic/claude-fable-5' });
+
+    const op = await t
+      .withIdentity({ subject: EDITOR })
+      .query(api.tasks.queries.getTaskAgentRunSandboxOp, {
+        organizationId: ORG,
+        runId: run._id,
+      });
+    expect(op?.modelRef).toBe('anthropic/claude-fable-5');
   });
 
   it('matches a derived exec incarnation of the same run', async () => {

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -579,6 +579,11 @@ automations:
   detail:
     loading: Automatisierung wird geladen …
     deployedVersion: 'Live: v{version}'
+    unpinnedModels: 'Die Live-Version (v{version}) hat {count, plural, one
+      {einen Agent-Node ({nodes})} other {Agent-Nodes ({nodes})}} ohne festen
+      Modellanbieter: Jeder Lauf wählt den Anbieter automatisch — nicht
+      unbedingt den, den der Editor anzeigt. Lege den Anbieter am Node fest,
+      speichere und schalte die neue Version live.'
     runMock: Testlauf
     saveVersion: Version speichern
     saveMessageLabel: Notiz zur Version
@@ -766,6 +771,7 @@ automations:
       title: Agenten-Log
       starting: Der Agent startet in der Sandbox…
       empty: Der Agent hat für diesen Lauf kein Log erzeugt.
+      servedBy: 'Diese Runde lief auf {model}.'
       visionModel: 'Bilder in diesem Lauf hat {model} gelesen.'
     approval:
       title: 'Wartet auf deine Freigabe: {operation}'
@@ -7121,6 +7127,13 @@ projects:
     modelSearchPlaceholder: Modelle suchen
     modelSearchEmpty: Keine Modelle gefunden
     modelProviderSubscription: '{provider} · Abo'
+    modelUnpinnedResolving: 'Als "{model}" ohne festen Anbieter gespeichert —
+      Tale ermittelt gerade, welchen Anbieter ein Lauf nehmen würde …'
+    modelUnpinnedResolved: 'Als "{model}" ohne festen Anbieter gespeichert —
+      Läufe landen aktuell bei {provider}. Wähle einen Eintrag, um ihn
+      festzulegen.'
+    modelUnpinnedUnserved: 'Als "{model}" ohne festen Anbieter gespeichert —
+      und aktuell kann kein Anbieter es bedienen: {reason}'
     equipmentLabel: Skills, Connectors & Tools
     equipmentVisibilityHint: Die Skills hier folgen dem Team-Zugriff des
       Projekts, nicht deiner persönlichen Sichtbarkeit.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -554,6 +554,11 @@ automations:
   detail:
     loading: Loading the automation…
     deployedVersion: 'Live: v{version}'
+    unpinnedModels: 'The live version (v{version}) {count, plural, one {has an
+      agent node ({nodes}) that names} other {has agent nodes ({nodes}) that
+      name}} a model without a pinned provider, so each run picks a provider
+      automatically — possibly not the one the editor shows. Pin the model on
+      the node, save, and deploy the new version.'
     runMock: Test run
     saveVersion: Save version
     saveMessageLabel: Version message
@@ -732,6 +737,7 @@ automations:
       title: Agent log
       starting: The agent is starting up in the sandbox…
       empty: The agent produced no log for this run.
+      servedBy: 'This turn ran on {model}.'
       visionModel: 'Images in this run were read by {model}.'
     approval:
       title: 'Waiting for your approval: {operation}'
@@ -4801,6 +4807,12 @@ projects:
     modelSearchPlaceholder: Search models
     modelSearchEmpty: No models found
     modelProviderSubscription: '{provider} · Subscription'
+    modelUnpinnedResolving: 'Saved as "{model}" without a pinned provider —
+      checking which provider runs would use…'
+    modelUnpinnedResolved: 'Saved as "{model}" without a pinned provider —
+      runs currently resolve to {provider}. Pick an entry to pin it.'
+    modelUnpinnedUnserved: 'Saved as "{model}" without a pinned provider —
+      and no run could serve it right now: {reason}'
     equipmentLabel: Skills, connectors & tools
     equipmentVisibilityHint: Skills offered here follow the project’s
       team access, not your personal visibility.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -585,6 +585,12 @@ automations:
   detail:
     loading: Chargement de l’automatisation…
     deployedVersion: 'En service : v{version}'
+    unpinnedModels: 'La version en service (v{version}) contient {count,
+      plural, one {un nœud agent ({nodes})} other {des nœuds agent ({nodes})}}
+      sans fournisseur de modèle épinglé : chaque exécution choisit un
+      fournisseur automatiquement — pas forcément celui que l''éditeur
+      affiche. Épingle le fournisseur sur le nœud, enregistre, puis mets la
+      nouvelle version en service.'
     runMock: Essai
     saveVersion: Enregistrer une version
     saveMessageLabel: Note de version
@@ -772,6 +778,7 @@ automations:
       title: Journal de l'agent
       starting: "L'agent démarre dans le bac à sable…"
       empty: "L'agent n'a produit aucun journal pour cette exécution."
+      servedBy: 'Ce tour a tourné sur {model}.'
       visionModel: 'Les images de cette exécution ont été lues par {model}.'
     approval:
       title: 'En attente de ton approbation : {operation}'
@@ -7239,6 +7246,14 @@ projects:
     modelSearchPlaceholder: Rechercher des modèles
     modelSearchEmpty: Aucun modèle trouvé
     modelProviderSubscription: '{provider} · Abonnement'
+    modelUnpinnedResolving: 'Enregistré comme "{model}" sans fournisseur
+      épinglé — Tale vérifie quel fournisseur une exécution utiliserait…'
+    modelUnpinnedResolved: 'Enregistré comme "{model}" sans fournisseur
+      épinglé — les exécutions passent actuellement par {provider}. Choisis
+      une entrée pour l''épingler.'
+    modelUnpinnedUnserved: 'Enregistré comme "{model}" sans fournisseur
+      épinglé — et aucun fournisseur ne peut le servir pour l''instant :
+      {reason}'
     equipmentLabel: Skills, connectors & outils
     equipmentVisibilityHint: Les skills proposés ici suivent l'accès des
       équipes du projet, pas ta visibilité personnelle.


### PR DESCRIPTION
## Problem

A model pick saved without a provider pin (every agent node and project agent saved before #3056, including the ones the pack seeder ships) rendered as a clean checkmark on whichever offered entry shared the bare model id — while the run's serving walk could pick, and bill, another provider entirely. On demo this misled directly: the editor showed `claude-fable-5 · Anthropic · Subscription` as selected, while every cron run of the deployed (pinless) version went through OpenRouter and died on its 402. The display asserted a provider the runtime never promised.

## Principle

What the editor shows must be what a run would actually use. No id-lookalike preselects, no silent pin adoption, no shortcut that promotes the lookalike into a pick — the picker asks the runtime's own resolver and renders its answer.

## Changes

- **Serving preview, per lane** — new `previewUnpinnedAgentServing` (automations) and `previewUnpinnedTaskServing` (tasks) actions call each lane's real resolver with no pin and return the serving a run would use right now — `{ok, providerSlug, modelId, lane}` — or the resolver's own refusal as a result. The lanes intentionally differ unpinned (two-pass walk vs direct-only), so each surface asks its own. Org-member gated, same as the model listing.
- **Honest pickers** — the automation node editor and the project-agent dialog select the *resolved* row and describe the state: resolving / “Saved as "{model}" without a pinned provider — runs currently resolve to {provider}. Pick an entry to pin it.” / the refusal when nothing serves. `findSelectedModel` is exact-(provider, id) only now; a pinless pick can no longer impersonate a pinned one. Picking any entry pins it, unchanged.
- **Deployed-version warning** — `getAutomation` reports `deployedUnpinnedAgentNodes` read from the DEPLOYED document (not the loaded one — a pinned draft over a pinless live version is exactly the trap), and the automation detail page shows a standing warning until a pinned version is deployed.
- **Actual serving in the run log** — both lanes' op queries project the op row's `modelRef`, and the agent log renders “This turn ran on {provider}/{model}.” (gateway refs' doubled provider segment collapsed for display). Closes the run-side visibility gap: the OpenRouter detour is now one glance in the log.

## Verification

- `tsc`, oxlint 1.79 (probe-confirmed engine), platform server suite 75 697 green, platform UI suite 3 370 green, packages/ui i18n suite 1 173 green (en/de/fr keys ship together).
- Live on dev against the real trap state (`triage-glitchtip-issues`, live v2 pinless): the detail warning names v2 and its node; the node editor shows the pick sitting on `anthropic/claude-fable-5 · OpenRouter` — the walk's actual answer — instead of the subscription lookalike; explicitly picking the subscription entry pins it (description clears, draft dirties); a past run's agent log reads “This turn ran on openrouter/anthropic/claude-fable-5.”, matching what actually billed.