### PR TITLE
fix(platform): label chat task rows with project name and key

### DIFF
--- a/services/platform/convex/chat/assistant_tools.test.ts
+++ b/services/platform/convex/chat/assistant_tools.test.ts
@@ -108,6 +108,7 @@ const VIDEO_SOURCES_FN =
   'file_metadata/internal_queries:lookupVideoLinkSources';
 const TASKS_SEARCH_FN = 'tasks/search_for_chat:searchTasksForChat';
 const PROJECTS_SEARCH_FN = 'tasks/search_for_chat:searchProjectsForChat';
+const PROJECT_LABELS_FN = 'projects/internal_queries:getProjectLabelsForOrg';
 const TASK_BY_ID_FN = 'tasks/internal_queries:getTaskByIdInternal';
 const TASK_CONTEXT_FN = 'tasks/internal_queries:getTaskContextForAgent';
 const CONVERSATIONS_SEARCH_FN =
@@ -144,6 +145,7 @@ function createCtx(
       isDone: true,
       continueCursor: '',
     }),
+    [PROJECT_LABELS_FN]: () => [],
     [CONVERSATIONS_SEARCH_FN]: () => ({ conversations: [], truncated: false }),
     [DOCUMENTS_LIST_FN]: () => ({
       documents: [],
@@ -1130,6 +1132,56 @@ describe('rag_search work legs', () => {
     expect(task?.ref).toBe('task:task_1');
     expect(task?.data).toMatchObject({ status: 'todo', priority: 'p1' });
     expect(result.sources).toMatchObject({ tasks: 'searched' });
+  });
+
+  it('labels task rows with project name and key beside the id', async () => {
+    // #3044 — a multi-project open-task list must not leave the model with
+    // only opaque ids for the Project column.
+    const { ctx } = createCtx({
+      reads: {
+        [TASKS_SEARCH_FN]: () => ({
+          page: [
+            taskRow({
+              _id: 'task_a',
+              title: 'Onboard docs',
+              projectId: 'project_docs',
+            }),
+            taskRow({
+              _id: 'task_b',
+              title: 'Hire agents',
+              projectId: 'project_sales',
+              priority: undefined,
+            }),
+          ],
+          isDone: true,
+          continueCursor: '',
+          listed: true,
+        }),
+        [PROJECT_LABELS_FN]: () => [
+          { id: 'project_docs', name: 'Product Docs', key: 'DOCS' },
+          { id: 'project_sales', name: 'Field Sales' },
+        ],
+      },
+    });
+    const executor = await makeExecutor(ctx);
+    const result = (await executor.execute({
+      id: 'c1',
+      name: 'rag_search',
+      input: { action: 'list', kind: 'task', status: 'open' },
+    })) as Record<string, unknown>;
+
+    const rows = result.results as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.data).toMatchObject({
+      projectId: 'project_docs',
+      project: 'Product Docs',
+      projectKey: 'DOCS',
+    });
+    expect(rows[1]?.data).toMatchObject({
+      projectId: 'project_sales',
+      project: 'Field Sales',
+    });
+    expect(rows[1]?.data).not.toHaveProperty('projectKey');
   });
 
   it('scopes the work legs to the projects the turn user can read', async () => {

--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -167,10 +167,18 @@ interface SearchResultEntry {
 // The search legs and the list action build their rows through ONE mapper
 // per kind, so the two surfaces can never disagree about what a row says.
 
+/** Name (+ optional key) for a project id — what a task row shows the model
+ * next to `projectId`, matching the `rag_fetch` task fields. */
+type ProjectLabel = { name: string; key?: string };
+
 function taskResultEntry(
   task: Doc<'tasks'>,
   archivedProjectIds: ReadonlySet<string>,
+  projectsById: ReadonlyMap<string, ProjectLabel> = new Map(),
 ): SearchResultEntry {
+  const projectId = task.projectId != null ? String(task.projectId) : undefined;
+  const label =
+    projectId !== undefined ? projectsById.get(projectId) : undefined;
   return {
     kind: 'task',
     title: task.title,
@@ -184,17 +192,54 @@ function taskResultEntry(
       status: task.status,
       ...(task.priority ? { priority: task.priority } : {}),
       ...(task.assigneeType ? { assigneeType: task.assigneeType } : {}),
-      ...(task.projectId ? { projectId: String(task.projectId) } : {}),
+      // Keep the id as the follow-up handle; name/key are what a reader
+      // needs to tell one project from another in a multi-project list.
+      ...(projectId !== undefined ? { projectId } : {}),
+      ...(label !== undefined
+        ? {
+            project: label.name,
+            ...(label.key !== undefined ? { projectKey: label.key } : {}),
+          }
+        : {}),
       ...(modelTimestamp(task.dueDate) !== undefined
         ? { dueDate: modelTimestamp(task.dueDate) }
         : {}),
       ...archiveFlags({
         archivedAt: task.archivedAt,
-        projectId: task.projectId != null ? String(task.projectId) : null,
+        projectId: projectId ?? null,
         archivedProjectIds,
       }),
     },
   };
+}
+
+/** Resolve name/key for the distinct project ids on a task page. One query
+ * for the page, never per row — the ids are already the readable set. */
+async function projectLabelsById(
+  ctx: ActionCtx,
+  organizationId: string,
+  projectIds: Iterable<string | null | undefined>,
+): Promise<ReadonlyMap<string, ProjectLabel>> {
+  const unique = [
+    ...new Set(
+      [...projectIds].filter(
+        (id): id is string => typeof id === 'string' && id.length > 0,
+      ),
+    ),
+  ];
+  if (unique.length === 0) return new Map();
+  const labels = await ctx.runQuery(
+    internal.projects.internal_queries.getProjectLabelsForOrg,
+    { organizationId, projectIds: unique },
+  );
+  return new Map(
+    labels.map((row) => [
+      row.id,
+      row.key !== undefined
+        ? { name: row.name, key: row.key }
+        : { name: row.name },
+    ]),
+  );
 }
 
 function projectResultEntry(
@@ -965,8 +1010,17 @@ export function createChatToolExecutor(
                 },
               },
             );
+            const projectsById = await projectLabelsById(
+              ctx,
+              who.organizationId,
+              tasks.page.map((task) =>
+                task.projectId != null ? String(task.projectId) : null,
+              ),
+            );
             for (const task of tasks.page) {
-              results.push(taskResultEntry(task, archivedProjectIds));
+              results.push(
+                taskResultEntry(task, archivedProjectIds, projectsById),
+              );
             }
             sources.tasks =
               tasks.page.length === 0
@@ -1258,8 +1312,15 @@ export function createChatToolExecutor(
         );
       }
       const hasMore = !tasks.isDone;
+      const projectsById = await projectLabelsById(
+        ctx,
+        who.organizationId,
+        tasks.page.map((task) =>
+          task.projectId != null ? String(task.projectId) : null,
+        ),
+      );
       const results = tasks.page.map((task) =>
-        taskResultEntry(task, archivedProjectIds),
+        taskResultEntry(task, archivedProjectIds, projectsById),
       );
       return envelope({
         results,

--- a/services/platform/convex/node_only/sandbox/workspace_domain_tools.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_domain_tools.ts
@@ -127,15 +127,28 @@ function toolResultFromError(error: unknown): ToolResult {
   return { status: 'error', message: message.slice(0, 400) };
 }
 
+/** Name (+ optional key) for the task's project — kept beside `projectId` so
+ * a list spanning several projects is readable without a follow-up fetch. */
+type ProjectLabel = { name: string; key?: string };
+
 /** The compact task shape the list/read tools answer with — identity, board
  * position, and the external-sync key; `description` only on `task_get`. */
-function compactTask(task: Doc<'tasks'>): Record<string, unknown> {
+function compactTask(
+  task: Doc<'tasks'>,
+  project?: ProjectLabel | null,
+): Record<string, unknown> {
   return {
     taskId: String(task._id),
     number: task.number,
     title: task.title,
     status: task.status,
     projectId: String(task.projectId),
+    ...(project != null
+      ? {
+          project: project.name,
+          ...(project.key !== undefined ? { projectKey: project.key } : {}),
+        }
+      : {}),
     ...(task.priority !== undefined ? { priority: task.priority } : {}),
     ...(task.assigneeType !== undefined
       ? { assigneeType: task.assigneeType }
@@ -158,6 +171,27 @@ function compactTask(task: Doc<'tasks'>): Record<string, unknown> {
     createdAt: modelTimestamp(task.createdAt),
     updatedAt: modelTimestamp(task.updatedAt),
   };
+}
+
+async function projectLabelsById(
+  ctx: ActionCtx,
+  organizationId: string,
+  projectIds: readonly string[],
+): Promise<ReadonlyMap<string, ProjectLabel>> {
+  const unique = [...new Set(projectIds)];
+  if (unique.length === 0) return new Map();
+  const labels = await ctx.runQuery(
+    internal.projects.internal_queries.getProjectLabelsForOrg,
+    { organizationId, projectIds: unique },
+  );
+  return new Map(
+    labels.map((row) => [
+      row.id,
+      row.key !== undefined
+        ? { name: row.name, key: row.key }
+        : { name: row.name },
+    ]),
+  );
 }
 
 // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ids are data from the run's own scope; a wrong id fails the callee's validator/org check and reads as a structured refusal
@@ -311,10 +345,18 @@ export async function runTaskTool(
             : {}),
         },
       );
+      const sliced = rows.slice(0, limit);
+      const projectsById = await projectLabelsById(
+        ctx,
+        organizationId,
+        sliced.map((task) => String(task.projectId)),
+      );
       return {
         status: 'ok',
         output: {
-          tasks: rows.slice(0, limit).map(compactTask),
+          tasks: sliced.map((task) =>
+            compactTask(task, projectsById.get(String(task.projectId)) ?? null),
+          ),
           totalFound: rows.length,
           ...(rows.length > limit
             ? { note: `Showing the first ${limit} of ${rows.length}.` }
@@ -358,7 +400,7 @@ export async function runTaskTool(
         status: 'ok',
         output: {
           task: {
-            ...compactTask(context.task),
+            ...compactTask(context.task, context.project),
             ...(context.task.description !== undefined
               ? { description: context.task.description }
               : {}),

--- a/services/platform/convex/node_only/sandbox/workspace_tools_bridge.test.ts
+++ b/services/platform/convex/node_only/sandbox/workspace_tools_bridge.test.ts
@@ -1062,22 +1062,28 @@ describe('dispatchWorkspaceTool — write tools (task family + document_create)'
     // date arrives already in the format its `Current time:` directive uses.
     const { dispatch } = await getActions();
     const { ctx } = createCtx({
-      readQuery: vi.fn((ref: unknown) =>
-        fnName(ref).includes('listTasksForAgent')
-          ? Promise.resolve([
-              {
-                _id: 'task_1',
-                number: 7,
-                title: 'Chase the invoice',
-                status: 'todo',
-                projectId: 'proj_1',
-                commentCount: 0,
-                createdAt: 1_787_124_301_288,
-                updatedAt: 1_787_210_701_288,
-              },
-            ])
-          : Promise.resolve(null),
-      ),
+      readQuery: vi.fn((ref: unknown) => {
+        if (fnName(ref).includes('listTasksForAgent')) {
+          return Promise.resolve([
+            {
+              _id: 'task_1',
+              number: 7,
+              title: 'Chase the invoice',
+              status: 'todo',
+              projectId: 'proj_1',
+              commentCount: 0,
+              createdAt: 1_787_124_301_288,
+              updatedAt: 1_787_210_701_288,
+            },
+          ]);
+        }
+        if (fnName(ref).includes('getProjectLabelsForOrg')) {
+          return Promise.resolve([
+            { id: 'proj_1', name: 'Billing', key: 'BILL' },
+          ]);
+        }
+        return Promise.resolve(null);
+      }),
     });
     const result = await dispatch(ctx, {
       ...BASE,
@@ -1089,6 +1095,11 @@ describe('dispatchWorkspaceTool — write tools (task family + document_create)'
       .tasks;
     expect(task?.createdAt).toBe('2026-08-19T07:25:01.288Z');
     expect(task?.updatedAt).toBe('2026-08-20T07:25:01.288Z');
+    expect(task).toMatchObject({
+      projectId: 'proj_1',
+      project: 'Billing',
+      projectKey: 'BILL',
+    });
   });
 
   it('task_get on a multi-bound org run refuses a task outside the bound set', async () => {

--- a/services/platform/convex/projects/internal_queries.ts
+++ b/services/platform/convex/projects/internal_queries.ts
@@ -309,3 +309,40 @@ export const getProjectByIdForOrg = internalQuery({
     return toProjectLookup(project);
   },
 });
+
+/**
+ * Name + key for a batch of project ids — the labels chat/sandbox task rows
+ * carry next to `projectId`. Org-scoped: foreign or malformed ids are skipped,
+ * never reported. Missing keys stay absent (project key is optional).
+ */
+export const getProjectLabelsForOrg = internalQuery({
+  args: {
+    organizationId: v.string(),
+    projectIds: v.array(v.string()),
+  },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      key: v.optional(v.string()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const labels: Array<{ id: string; name: string; key?: string }> = [];
+    const seen = new Set<string>();
+    for (const raw of args.projectIds) {
+      if (seen.has(raw)) continue;
+      seen.add(raw);
+      const projectId = ctx.db.normalizeId('projects', raw);
+      if (projectId === null) continue;
+      const project = await ctx.db.get(projectId);
+      if (!project || project.organizationId !== args.organizationId) continue;
+      labels.push({
+        id: String(project._id),
+        name: project.name,
+        ...(project.key !== undefined ? { key: project.key } : {}),
+      });
+    }
+    return labels;
+  },
+});


### PR DESCRIPTION
## Summary
- Chat task search/list rows only returned `projectId`, so answers like “list open tasks” printed opaque Convex ids in the Project column (#3044).
- Resolve project **name** and **key** beside the id (id stays the follow-up handle) for chat `rag_search` task rows and sandbox `task_find` / `task_get` compact tasks.
- Adds `getProjectLabelsForOrg` and regression coverage for the multi-project list shape.

## Test plan
- [x] `cd services/platform && bun run test -- convex/chat/assistant_tools.test.ts convex/node_only/sandbox/workspace_tools_bridge.test.ts` (136 passed)
- [ ] On prod/staging after deploy: ask chat “List open tasks” on an org with tasks in ≥2 projects — Project column shows names (and keys when set), not only `rx…` ids
- [ ] Optional: sandbox `task_find` returns `project` / `projectKey` next to `projectId`

Closes #3044