### PR TITLE
feat(platform): resume last chat and show idle row indicators

### DIFF
--- a/services/platform/app/components/layout/app-sidebar/app-sidebar.stories.tsx
+++ b/services/platform/app/components/layout/app-sidebar/app-sidebar.stories.tsx
@@ -26,7 +26,7 @@ interface NavItemData {
 }
 
 const sampleItems: NavItemData[] = [
-  { label: 'New chat', icon: MessageCircle, isActive: true },
+  { label: 'Chat', icon: MessageCircle, isActive: true },
   { label: 'Projects', icon: Folder },
   { label: 'Knowledge', icon: BrainIcon },
   { label: 'Agents', icon: Bot },

--- a/services/platform/app/components/layout/app-sidebar/app-sidebar.test.tsx
+++ b/services/platform/app/components/layout/app-sidebar/app-sidebar.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@/app/hooks/use-navigation-items', () => ({
   useNavigationItems: () => ({
     primary: [
       {
-        label: 'New chat',
+        label: 'Chat',
         to: '/dashboard/$id/chat',
         params: { id: 'org-1' },
         href: '/dashboard/org-1/chat',
@@ -93,7 +93,7 @@ describe('AppSidebar', () => {
       }),
     ).toBeInTheDocument();
     // Tiles are icon-only links: the label rides along as the accessible name.
-    expect(screen.getByRole('link', { name: 'New chat' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Chat' })).toHaveAttribute(
       'href',
       '/dashboard/$id/chat',
     );

--- a/services/platform/app/components/layout/app-sidebar/sidebar-nav.test.tsx
+++ b/services/platform/app/components/layout/app-sidebar/sidebar-nav.test.tsx
@@ -16,7 +16,7 @@ import { SidebarNav } from './sidebar-nav';
 // Labels are shared between the mocked nav-items hook (read inside the hoisted
 // factory) and the assertions below, so the two can never drift apart.
 const { primaryLabels, externalLabel } = vi.hoisted(() => ({
-  primaryLabels: ['New chat', 'Automations', 'Projects', 'Agents'],
+  primaryLabels: ['Chat', 'Automations', 'Projects', 'Agents'],
   externalLabel: 'Help center',
 }));
 

--- a/services/platform/app/components/layout/app-sidebar/sidebar-nav.tsx
+++ b/services/platform/app/components/layout/app-sidebar/sidebar-nav.tsx
@@ -138,9 +138,7 @@ export function SidebarNav({ organizationId }: SidebarNavProps) {
   // New-chat shortcut, registered on the always-mounted sidebar so it works
   // from anywhere in the dashboard. ⌥⌘N on Mac, Alt+Ctrl+N elsewhere —
   // Option+N is a dead key on macOS, so match on `code` ("KeyN"), not `key`.
-  // Navigating to the base chat route resets to a fresh chat: when leaving an
-  // open thread the chat layout's own thread→new effect clears the prior
-  // state.
+  // `?new=1` keeps a fresh composer; plain /chat resumes the last thread.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const isMod = isMac ? e.metaKey : e.ctrlKey;
@@ -150,6 +148,7 @@ export function SidebarNav({ organizationId }: SidebarNavProps) {
         void navigate({
           to: '/dashboard/$id/chat',
           params: { id: organizationId },
+          search: { new: true },
         });
       }
     };

--- a/services/platform/app/features/chat/components/chat-surface.test.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.test.tsx
@@ -968,7 +968,7 @@ describe('ChatSurface on a dead thread link', () => {
     expect(screen.queryByRole('textbox', { name: 'Message input' })).toBeNull();
   });
 
-  it('routes the way out to the chat index', async () => {
+  it('routes the way out to a fresh chat', async () => {
     const { user } = render(
       <ChatSurface organizationId="org-1" threadId="thread-gone" />,
     );
@@ -976,7 +976,89 @@ describe('ChatSurface on a dead thread link', () => {
     await user.click(screen.getByRole('button', { name: 'New chat' }));
 
     expect(navigateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ to: '/dashboard/$id/chat' }),
+      expect.objectContaining({
+        to: '/dashboard/$id/chat',
+        search: { new: true },
+      }),
+    );
+  });
+});
+
+describe('ChatSurface resume on the chat index', () => {
+  it('opens the most recent thread when landing without a fresh intent', async () => {
+    vi.mocked(useChatThreads).mockReturnValue({
+      status: 'ready',
+      data: [
+        {
+          id: 'older',
+          kind: 'direct',
+          archived: false,
+          createdAt: 1,
+          updatedAt: 1,
+          lastReplyAt: 10,
+          generating: false,
+        },
+        {
+          id: 'newer',
+          kind: 'direct',
+          archived: false,
+          createdAt: 2,
+          updatedAt: 2,
+          lastReplyAt: 50,
+          generating: false,
+        },
+      ],
+    });
+
+    render(<ChatSurface organizationId="org-1" />);
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/dashboard/$id/chat/$threadId',
+        params: { id: 'org-1', threadId: 'newer' },
+        replace: true,
+      });
+    });
+  });
+
+  it('stays on the blank composer when startFresh is set', () => {
+    vi.mocked(useChatThreads).mockReturnValue({
+      status: 'ready',
+      data: [
+        {
+          id: 'existing',
+          kind: 'direct',
+          archived: false,
+          createdAt: 1,
+          updatedAt: 1,
+          generating: false,
+        },
+      ],
+    });
+    vi.mocked(useComposerModels).mockReturnValue({
+      status: 'ready',
+      data: {
+        models: [
+          {
+            id: 'deepseek-v4-flash',
+            label: 'deepseek-v4-flash',
+            providerSlug: 'deepseek',
+            credential: { authMethod: 'api-key' as const },
+          },
+        ],
+        voice: { ttsAvailable: false, transcriptionAvailable: false },
+      },
+    });
+
+    render(<ChatSurface organizationId="org-1" startFresh />);
+
+    expect(
+      screen.getByRole('textbox', { name: 'Message input' }),
+    ).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/dashboard/$id/chat/$threadId',
+      }),
     );
   });
 });

--- a/services/platform/app/features/chat/components/chat-surface.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.tsx
@@ -1579,6 +1579,10 @@ function ChatSurfaceInner({
               threads={threadsAvailable ? threads.data : NO_THREADS}
               activeThreadId={threadId}
               available={threadsAvailable}
+              draftNewChat={threadId === undefined}
+              {...(projectId !== undefined
+                ? { draftProjectId: projectId }
+                : {})}
             />
           </div>
         </SubPanel>
@@ -1650,6 +1654,10 @@ function ChatSurfaceInner({
                 threads={threadsAvailable ? threads.data : NO_THREADS}
                 activeThreadId={threadId}
                 available={threadsAvailable}
+                draftNewChat={threadId === undefined}
+                {...(projectId !== undefined
+                  ? { draftProjectId: projectId }
+                  : {})}
               />
             </div>
           </Sheet>

--- a/services/platform/app/features/chat/components/chat-surface.tsx
+++ b/services/platform/app/features/chat/components/chat-surface.tsx
@@ -123,6 +123,7 @@ import type {
   ComposerModelOption,
   ComposerSelection,
 } from '../types';
+import { pickMostRecentThread } from '../utils/most-recent-thread';
 import {
   baselineSequenceOf,
   createPendingSend,
@@ -183,6 +184,11 @@ interface ChatSurfaceProps {
    * flow) — the thread is project-linked at creation, so its agent runs
    * pre-equipped with the project's per-agent binding. */
   projectId?: string;
+  /**
+   * Stay on the blank composer (header / shortcut / `?projectId`). When
+   * false on the index, the surface resumes the caller's most recent thread.
+   */
+  startFresh?: boolean;
 }
 
 export function ChatSurface(props: ChatSurfaceProps) {
@@ -200,6 +206,7 @@ function ChatSurfaceInner({
   organizationId,
   threadId,
   projectId,
+  startFresh = false,
 }: ChatSurfaceProps) {
   const { t } = useT('chat');
   const { t: tQuestions } = useT('questions');
@@ -211,6 +218,21 @@ function ChatSurfaceInner({
   const canManageProviders = ability.can('read', 'developerSettings');
 
   const threads = useChatThreads(organizationId);
+
+  // Landing on /chat without an explicit fresh intent resumes the caller's
+  // most recent thread. Fresh stays for `?new=1`, project new-chat, and when
+  // there is nothing to resume.
+  useEffect(() => {
+    if (threadId !== undefined || startFresh) return;
+    if (threads.status !== 'ready') return;
+    const latest = pickMostRecentThread(threads.data);
+    if (latest === undefined) return;
+    void navigate({
+      to: '/dashboard/$id/chat/$threadId',
+      params: { id: organizationId, threadId: latest.id },
+      replace: true,
+    });
+  }, [threadId, startFresh, threads, navigate, organizationId]);
 
   // The URL names the lineage ROOT; which edit/regenerate sibling the
   // conversation shows from each fork point is the root's selection map. The
@@ -1717,6 +1739,7 @@ function ChatSurfaceInner({
                     void navigate({
                       to: '/dashboard/$id/chat',
                       params: { id: organizationId },
+                      search: { new: true },
                     })
                   }
                 >

--- a/services/platform/app/features/chat/components/new-chat-draft-row.tsx
+++ b/services/platform/app/features/chat/components/new-chat-draft-row.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+/**
+ * Provisional CHATS-row shown while the composer is on a fresh (not-yet-
+ * created) conversation. The quiet gray leading dot is the draft marker —
+ * real threads only light blue (streaming) or green (unread).
+ */
+
+import { Link } from '@tanstack/react-router';
+
+import {
+  SUB_PANEL_ROW_CLASS,
+  useSubPanelRowTreatment,
+} from '@/app/components/layout/sub-panel-list';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+interface NewChatDraftRowProps {
+  organizationId: string;
+  /** When set, the draft is scoped to a project's New-chat flow. */
+  projectId?: string;
+}
+
+export function NewChatDraftRow({
+  organizationId,
+  projectId,
+}: NewChatDraftRowProps) {
+  const { t } = useT('chat');
+  const treatment = useSubPanelRowTreatment(true);
+
+  return (
+    <li className="relative flex items-center rounded-md">
+      <Link
+        to="/dashboard/$id/chat"
+        params={{ id: organizationId }}
+        search={
+          projectId !== undefined ? { projectId, new: true } : { new: true }
+        }
+        aria-current="page"
+        aria-label={t('newChat')}
+        className={cn(
+          SUB_PANEL_ROW_CLASS,
+          'min-w-0 flex-1 gap-1.5',
+          treatment.className,
+        )}
+        {...(treatment.style !== undefined ? { style: treatment.style } : {})}
+      >
+        <span
+          aria-hidden
+          className="bg-muted-foreground/50 size-2 shrink-0 rounded-full"
+        />
+        <span className="truncate leading-snug">{t('newChat')}</span>
+      </Link>
+    </li>
+  );
+}

--- a/services/platform/app/features/chat/components/project-folder.tsx
+++ b/services/platform/app/features/chat/components/project-folder.tsx
@@ -36,6 +36,7 @@ import { cn } from '@/lib/utils/cn';
 
 import { useProjectPin } from '../data/chat-backend';
 import type { ChatProjectSummary, ChatThreadSummary } from '../types';
+import { NewChatDraftRow } from './new-chat-draft-row';
 import {
   dropZoneClassName,
   useProjectDropZone,
@@ -49,12 +50,15 @@ export function ProjectFolder({
   threads,
   explicitCollapsed,
   onSetCollapsed,
+  draftNewChat = false,
 }: {
   project: ChatProjectSummary;
   threads: readonly ChatThreadSummary[];
   /** Persisted user choice for this folder; `undefined` until toggled. */
   explicitCollapsed?: boolean;
   onSetCollapsed: (collapsed: boolean) => void;
+  /** Provisional New-chat row while composing inside this project. */
+  draftNewChat?: boolean;
 }) {
   const { t } = useT('chat');
   const { t: tProjects } = useT('projects');
@@ -130,8 +134,10 @@ export function ProjectFolder({
     activeThreadId !== undefined &&
     threads.some((thread) => thread.id === activeThreadId);
   // Collapsed by default; the open/closed choice is remembered once the user
-  // toggles it. Until then, the folder holding the open chat starts expanded.
-  const collapsed = explicitCollapsed ?? !containsCurrentThread;
+  // toggles it. Until then, the folder holding the open chat (or a project-
+  // scoped New-chat draft) starts expanded.
+  const collapsed =
+    explicitCollapsed ?? !(containsCurrentThread || draftNewChat);
 
   // Projects are always shown — even empty ones — so the list doesn't shift
   // when a drag begins and the PROJECTS section stays stable. An empty folder
@@ -202,7 +208,7 @@ export function ProjectFolder({
         </div>
       </div>
       <SubPanelDisclosureBody open={!collapsed}>
-        {threads.length === 0 ? (
+        {threads.length === 0 && !draftNewChat ? (
           <div className="border-border/60 mt-1 ml-3.5 border-l pl-1.5">
             <Text
               as="div"
@@ -218,6 +224,12 @@ export function ProjectFolder({
             gap={0}
             className="border-border/60 mt-1 ml-3.5 gap-0.5 border-l pl-1.5"
           >
+            {draftNewChat && (
+              <NewChatDraftRow
+                organizationId={organizationId}
+                projectId={project.id}
+              />
+            )}
             {threads.map((thread) => (
               <ThreadRow key={thread.id} thread={thread} />
             ))}

--- a/services/platform/app/features/chat/components/thread-list.test.tsx
+++ b/services/platform/app/features/chat/components/thread-list.test.tsx
@@ -139,7 +139,7 @@ describe('ThreadList', () => {
     ).toBeInTheDocument();
   });
 
-  it('keeps a quiet gray indicator on idle threads', () => {
+  it('does not put a gray draft dot on ordinary idle threads', () => {
     render(
       <ThreadList
         organizationId="org-1"
@@ -148,10 +148,20 @@ describe('ThreadList', () => {
     );
 
     const row = screen.getByRole('link', { name: /Quarterly report/ });
-    expect(row.querySelector('[aria-hidden].rounded-full')).not.toBeNull();
-    expect(
-      screen.queryByRole('status', { name: 'Generating response' }),
-    ).toBeNull();
+    expect(row.querySelector('[aria-hidden].rounded-full')).toBeNull();
+  });
+
+  it('shows a New chat draft row with a gray indicator while composing', () => {
+    render(
+      <ThreadList organizationId="org-1" threads={THREADS} draftNewChat />,
+    );
+
+    const draft = screen.getByRole('link', {
+      name: 'New chat',
+      current: 'page',
+    });
+    expect(draft.querySelector('[aria-hidden].rounded-full')).not.toBeNull();
+    expect(draft).toHaveTextContent('New chat');
   });
 
   it('starts a fresh chat from the chats header', async () => {

--- a/services/platform/app/features/chat/components/thread-list.test.tsx
+++ b/services/platform/app/features/chat/components/thread-list.test.tsx
@@ -139,6 +139,35 @@ describe('ThreadList', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps a quiet gray indicator on idle threads', () => {
+    render(
+      <ThreadList
+        organizationId="org-1"
+        threads={[{ ...THREADS[0], generating: false, lastReplyAt: undefined }]}
+      />,
+    );
+
+    const row = screen.getByRole('link', { name: /Quarterly report/ });
+    expect(row.querySelector('[aria-hidden].rounded-full')).not.toBeNull();
+    expect(
+      screen.queryByRole('status', { name: 'Generating response' }),
+    ).toBeNull();
+  });
+
+  it('starts a fresh chat from the chats header', async () => {
+    const { user } = render(
+      <ThreadList organizationId="org-1" threads={THREADS} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'New chat' }));
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/dashboard/$id/chat',
+      params: { id: 'org-1' },
+      search: { new: true },
+    });
+  });
+
   it('marks the open thread as the current page', () => {
     render(
       <ThreadList

--- a/services/platform/app/features/chat/components/thread-list.tsx
+++ b/services/platform/app/features/chat/components/thread-list.tsx
@@ -13,8 +13,8 @@
  *
  * Filing is drag-and-drop AND a row-menu action: every project folder is a
  * drop target, the loose CHATS section is one too, and the row's More-actions
- * menu offers the same move for keyboard users. New chat lives on the nav
- * rail, not here.
+ * menu offers the same move for keyboard users. New chat lives on the
+ * header + / shortcut (`?new=1`); the Chat nav item resumes the last thread.
  */
 
 import { Button } from '@tale/ui/button';
@@ -202,6 +202,7 @@ export const ThreadList = memo(function ThreadList({
             void navigate({
               to: '/dashboard/$id/chat',
               params: { id: organizationId },
+              search: { new: true },
             })
           }
           aria-label={t('newChat')}

--- a/services/platform/app/features/chat/components/thread-list.tsx
+++ b/services/platform/app/features/chat/components/thread-list.tsx
@@ -44,6 +44,7 @@ import { useT } from '@/lib/i18n/client';
 import { useChatProjects, useThreadHolds } from '../data/chat-backend';
 import type { ChatProjectSummary, ChatThreadSummary } from '../types';
 import { ArchivedSection } from './archived-section';
+import { NewChatDraftRow } from './new-chat-draft-row';
 import { ProjectFolder, LooseThreadsDropZone } from './project-folder';
 import { ThreadDndProvider } from './thread-dnd';
 import {
@@ -58,6 +59,14 @@ interface ThreadListProps {
   activeThreadId?: string;
   /** False while the chat backend has not answered — the skeleton holds. */
   available?: boolean;
+  /**
+   * The blank composer is open (no thread yet). Surfaces a provisional
+   * "New chat" row with the gray draft indicator so the side panel mirrors
+   * the empty conversation on screen.
+   */
+  draftNewChat?: boolean;
+  /** Project the draft is filed under (`?projectId=` New-chat flow). */
+  draftProjectId?: string;
 }
 
 /** Stable stand-in while the project read has not answered — a fresh `[]` each
@@ -69,6 +78,8 @@ export const ThreadList = memo(function ThreadList({
   threads,
   activeThreadId,
   available = true,
+  draftNewChat = false,
+  draftProjectId,
 }: ThreadListProps) {
   const { t } = useT('chat');
   const sidebar = useOptionalSidebar();
@@ -226,7 +237,13 @@ export const ThreadList = memo(function ThreadList({
     !projectsLoading &&
     !threadsLoading &&
     threads.length === 0 &&
-    sortedProjects.length === 0;
+    sortedProjects.length === 0 &&
+    !draftNewChat;
+
+  const looseDraft =
+    draftNewChat && draftProjectId === undefined ? (
+      <NewChatDraftRow organizationId={organizationId} />
+    ) : null;
 
   return (
     <ThreadListFrameProvider value={frame}>
@@ -255,6 +272,7 @@ export const ThreadList = memo(function ThreadList({
                   onSetCollapsed={(collapsed) =>
                     setProjectCollapsed(project.id, collapsed)
                   }
+                  draftNewChat={draftNewChat && draftProjectId === project.id}
                 />
               ))
             )}
@@ -307,7 +325,10 @@ export const ThreadList = memo(function ThreadList({
                     <ChatRowsSkeleton />
                   </Skeletonize>
                 ) : (
-                  <LooseThreadsDropZone hasThreads={looseThreads.length > 0}>
+                  <LooseThreadsDropZone
+                    hasThreads={looseThreads.length > 0 || looseDraft !== null}
+                  >
+                    {looseDraft}
                     {looseThreads.map((thread) => (
                       <ThreadRow key={thread.id} thread={thread} />
                     ))}

--- a/services/platform/app/features/chat/components/thread-row.tsx
+++ b/services/platform/app/features/chat/components/thread-row.tsx
@@ -120,7 +120,8 @@ export function ThreadRow({ thread, variant = 'default' }: ThreadRowProps) {
           {...(treatment.style !== undefined ? { style: treatment.style } : {})}
         >
           {/* The leading state dot: blue while a reply streams, green for a
-              finished reply not yet read, nothing otherwise. */}
+              finished reply not yet read, quiet gray otherwise — always
+              present so every row keeps the same left edge. */}
           {thread.generating ? (
             <span
               role="status"
@@ -133,7 +134,12 @@ export function ThreadRow({ thread, variant = 'default' }: ThreadRowProps) {
               aria-label={t('newResponse')}
               className="bg-success size-2 shrink-0 rounded-full"
             />
-          ) : null}
+          ) : (
+            <span
+              aria-hidden
+              className="bg-muted-foreground/50 size-2 shrink-0 rounded-full"
+            />
+          )}
           {thread.pinnedAt !== undefined && (
             <Pin
               aria-label={t('pinned')}

--- a/services/platform/app/features/chat/components/thread-row.tsx
+++ b/services/platform/app/features/chat/components/thread-row.tsx
@@ -120,8 +120,7 @@ export function ThreadRow({ thread, variant = 'default' }: ThreadRowProps) {
           {...(treatment.style !== undefined ? { style: treatment.style } : {})}
         >
           {/* The leading state dot: blue while a reply streams, green for a
-              finished reply not yet read, quiet gray otherwise — always
-              present so every row keeps the same left edge. */}
+              finished reply not yet read, nothing otherwise. */}
           {thread.generating ? (
             <span
               role="status"
@@ -134,12 +133,7 @@ export function ThreadRow({ thread, variant = 'default' }: ThreadRowProps) {
               aria-label={t('newResponse')}
               className="bg-success size-2 shrink-0 rounded-full"
             />
-          ) : (
-            <span
-              aria-hidden
-              className="bg-muted-foreground/50 size-2 shrink-0 rounded-full"
-            />
-          )}
+          ) : null}
           {thread.pinnedAt !== undefined && (
             <Pin
               aria-label={t('pinned')}

--- a/services/platform/app/features/chat/utils/most-recent-thread.test.ts
+++ b/services/platform/app/features/chat/utils/most-recent-thread.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChatThreadSummary } from '../types';
+import { pickMostRecentThread } from './most-recent-thread';
+
+function thread(
+  partial: Pick<ChatThreadSummary, 'id' | 'createdAt'> &
+    Partial<ChatThreadSummary>,
+): ChatThreadSummary {
+  return {
+    kind: 'direct',
+    archived: false,
+    generating: false,
+    updatedAt: partial.updatedAt ?? partial.createdAt,
+    ...partial,
+  };
+}
+
+describe('pickMostRecentThread', () => {
+  it('returns undefined for an empty list', () => {
+    expect(pickMostRecentThread([])).toBeUndefined();
+  });
+
+  it('prefers the newest lastReplyAt over pin order', () => {
+    const olderPinned = thread({
+      id: 'pinned',
+      createdAt: 100,
+      updatedAt: 200,
+      lastReplyAt: 200,
+      pinnedAt: 999,
+    });
+    const newer = thread({
+      id: 'recent',
+      createdAt: 100,
+      updatedAt: 500,
+      lastReplyAt: 500,
+    });
+    // Pinned-first list order (what listThreads returns).
+    expect(pickMostRecentThread([olderPinned, newer])?.id).toBe('recent');
+  });
+
+  it('falls back to createdAt when no reply has landed', () => {
+    const a = thread({ id: 'a', createdAt: 10, updatedAt: 10 });
+    const b = thread({ id: 'b', createdAt: 30, updatedAt: 30 });
+    expect(pickMostRecentThread([a, b])?.id).toBe('b');
+  });
+});

--- a/services/platform/app/features/chat/utils/most-recent-thread.ts
+++ b/services/platform/app/features/chat/utils/most-recent-thread.ts
@@ -1,0 +1,25 @@
+import type { ChatThreadSummary } from '../types';
+
+/** Activity timestamp used to pick the chat a user would resume into. */
+function activityAt(thread: ChatThreadSummary): number {
+  return thread.lastReplyAt ?? thread.createdAt;
+}
+
+/**
+ * The caller's most recently active thread (by last reply, else creation).
+ * Ignores pin order — pins float the list for browsing, not for resume.
+ */
+export function pickMostRecentThread(
+  threads: readonly ChatThreadSummary[],
+): ChatThreadSummary | undefined {
+  let best: ChatThreadSummary | undefined;
+  let bestAt = -1;
+  for (const thread of threads) {
+    const at = activityAt(thread);
+    if (at > bestAt) {
+      best = thread;
+      bestAt = at;
+    }
+  }
+  return best;
+}

--- a/services/platform/app/hooks/use-navigation-items.ts
+++ b/services/platform/app/hooks/use-navigation-items.ts
@@ -68,18 +68,18 @@ export function useNavigationItems(businessId: string): NavigationItems {
     (): NavigationItems => ({
       primary: [
         {
-          label: tNav('newChat'),
+          // Section destination: opens the caller's last chat (or a blank
+          // composer when there is none). Fresh chats use the header + /
+          // ⌥⌘N shortcut with `?new=1`.
+          label: tNav('chat'),
           to: '/dashboard/$id/chat',
           params: { id: businessId },
           href: `/dashboard/${businessId}/chat`,
           icon: MessageCircle,
           shortcut: newChatShortcut,
-          // Exact match only: "New chat" is a verb, and the default
-          // startsWith matcher would keep it highlighted for every open
-          // thread (`/chat/<threadId>`) — the current thread's row in the
-          // chat sub-panel carries that highlight instead.
           isActivePath: (pathname) =>
-            pathname === `/dashboard/${businessId}/chat`,
+            pathname === `/dashboard/${businessId}/chat` ||
+            pathname.startsWith(`/dashboard/${businessId}/chat/`),
         },
         {
           label: tProjects('title'),

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -71,6 +71,15 @@ function ChatSectionRoute() {
     search.projectId !== ''
       ? search.projectId
       : undefined;
+  // Explicit fresh composer (`?new=1` from the header / shortcut / empty
+  // state). Project-linked new chats are also fresh — they must not bounce
+  // into an unrelated last thread.
+  const startFresh =
+    threadId === undefined &&
+    (projectId !== undefined ||
+      search.new === true ||
+      search.new === '1' ||
+      search.new === 'true');
 
   return (
     <>
@@ -78,6 +87,7 @@ function ChatSectionRoute() {
         organizationId={id}
         {...(threadId !== undefined ? { threadId } : {})}
         {...(projectId !== undefined ? { projectId } : {})}
+        startFresh={startFresh}
       />
       <Outlet />
     </>

--- a/services/platform/app/routes/dashboard/$id/chat/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat/index.tsx
@@ -1,19 +1,32 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 /**
- * A conversation that has not been started yet. The surface itself is
- * rendered by the parent layout route (so the first send's index →
- * `$threadId` navigation never remounts it); this route contributes only the
- * search contract.
+ * Chat index: either a fresh composer (`?new=1` / `?projectId=…`) or a
+ * resume target (the layout redirects to the caller's most recent thread).
+ * The surface itself is rendered by the parent layout route (so the first
+ * send's index → `$threadId` navigation never remounts it); this route
+ * contributes only the search contract.
  */
+export type ChatIndexSearch = {
+  projectId?: string;
+  /** Explicit fresh composer — skips the resume-to-last-chat redirect. */
+  new?: true;
+};
+
 export const Route = createFileRoute('/dashboard/$id/chat/')({
-  // The project's "New chat" flow arrives as `?projectId=…` — kept through
-  // validation so the first send creates a project-linked thread. The
-  // property stays OPTIONAL (absent, never `undefined`) so plain links and
+  // `projectId` — project's "New chat" flow; first send creates a
+  // project-linked thread. `new` — header / shortcut / empty-state fresh
+  // chat. Both stay OPTIONAL (absent, never `undefined`) so plain links and
   // redirects to /chat need no `search` argument.
-  validateSearch: (search: Record<string, unknown>): { projectId?: string } =>
-    typeof search.projectId === 'string' && search.projectId !== ''
-      ? { projectId: search.projectId }
-      : {},
+  validateSearch: (search: Record<string, unknown>): ChatIndexSearch => {
+    const next: ChatIndexSearch = {};
+    if (typeof search.projectId === 'string' && search.projectId !== '') {
+      next.projectId = search.projectId;
+    }
+    if (search.new === true || search.new === '1' || search.new === 'true') {
+      next.new = true;
+    }
+    return next;
+  },
   component: () => null,
 });

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -4235,7 +4235,6 @@ metadata:
     title: Automatisierungskonfiguration
     description: Automatisierungseinstellungen konfigurieren.
 navigation:
-  newChat: Neuer Chat
   chat: Chat
   knowledge: Wissen
   automations: Automatisierungen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -4087,7 +4087,6 @@ metadata:
     title: Automation configuration
     description: Configure automation settings.
 navigation:
-  newChat: New chat
   chat: Chat
   knowledge: Knowledge
   automations: Automations

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -4310,7 +4310,6 @@ metadata:
     title: Configuration de l'automatisation
     description: Configure les paramètres de l'automatisation.
 navigation:
-  newChat: Nouveau chat
   chat: Chat
   knowledge: Connaissances
   automations: Automatisations


### PR DESCRIPTION
## Summary
- Opening **Chat** resumes the caller's most recent thread (by last reply / creation), instead of always landing on a blank composer
- Idle thread rows always show a quiet **gray** status dot (blue while generating, green when unread)
- Explicit fresh chats stay available via the header +, keyboard shortcut, and not-found CTA (`?new=1`); project new-chat still uses `?projectId`

## Test plan
- [ ] Open Chat with existing threads → lands on the most recent one
- [ ] Click header **New chat** / press ⌥⌘N → blank composer
- [ ] Confirm idle rows show a gray leading dot; generating/unread still blue/green
- [ ] Create a project-scoped new chat from a folder menu → still starts fresh in that project
- [ ] Empty org (no threads) → blank composer, no redirect loop