### PR TITLE
fix(platform): round-trip the agent model provider pin in the editor

### DIFF
--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -80,6 +80,7 @@ const CLEARABLE_NODE_FIELDS = [
   'prompt',
   'system',
   'model',
+  'modelProvider',
   'outputSchema',
   'automation',
   // Agent equipment — clearing a picker to empty must delete the field, not

--- a/services/platform/app/features/automations/lib/document.test.ts
+++ b/services/platform/app/features/automations/lib/document.test.ts
@@ -59,14 +59,18 @@ describe('readDocument', () => {
   });
 
   it('round-trips an agent node with its equipment', () => {
-    // The wizard writes harness/skills/connectors/tools/secrets/files onto the
-    // agent node; the canvas reads THIS document and a later prompt edit saves
-    // it back, so dropping any of these here loses the grant on first save.
+    // The wizard writes harness/skills/connectors/tools/secrets/files and the
+    // model picker writes the (model, modelProvider) pair onto the agent node;
+    // the canvas reads THIS document and a later prompt edit saves it back, so
+    // dropping any of these here loses the grant — or the provider pin — on
+    // first save.
     const node = {
       id: 'agent',
       type: 'agent',
       prompt: 'do the thing',
       harness: 'claude-code',
+      model: 'claude-fable-5',
+      modelProvider: 'anthropic',
       skills: ['docx', 'pdf'],
       connectors: ['github'],
       tools: ['task_create', 'document_create'],

--- a/services/platform/app/features/automations/lib/document.ts
+++ b/services/platform/app/features/automations/lib/document.ts
@@ -55,6 +55,10 @@ function readNode(value: unknown): NodeDef | undefined {
     'prompt',
     'system',
     'model',
+    // The provider pin saved with the model pick. Dropping it here made every
+    // stored pick render as unpinned — the editor showed whatever provider the
+    // serving walk would choose — and the next save persisted that loss.
+    'modelProvider',
     'automation',
     // Agent equipment: the harness that runs the turn. Dropping it here would
     // make the canvas read an agent node as unequipped and a later save would


### PR DESCRIPTION
## Problem

Picking a subscription-served model on an automation agent node (e.g. `claude-fable-5` · Anthropic · Subscription) and saving appeared to revert the pick to OpenRouter's `anthropic/claude-fable-5`.

## Root cause

#3056 introduced the `(model, modelProvider)` pair on agent nodes, but the client-side narrowing the editor reads every stored document through — `readNode` in `app/features/automations/lib/document.ts` — whitelists node fields and was never taught `modelProvider`. Consequences:

1. **Display**: after save + refetch the pin is stripped, `findSelectedModel` (exact-pair match by design) finds nothing, and the picker falls back to the unpinned-serving preview (#3057) — showing the provider the walk would resolve (OpenRouter) instead of the saved pin. The pick *is* stored correctly; the editor just can't see it.
2. **Data loss**: any subsequent save builds its draft from the narrowed document, so the next edit silently strips the pin from every agent node in the saved version — exactly the trap the whitelist's own `harness` comment warns about.

## Fix

- `document.ts`: keep `modelProvider` in `readNode`'s field list (next to `model`).
- `automation-detail.tsx`: add `modelProvider` to `CLEARABLE_NODE_FIELDS` so the harness-switch invalidation (`{model: undefined, modelProvider: undefined}`) actually deletes the field from the draft instead of leaning on Convex serialization to drop the leftover.
- `document.test.ts`: the agent-equipment round-trip fixture now carries the `(model, modelProvider)` pair — red before the `readNode` fix, green after.

Scope check: only the `agent` slot declares `modelProvider` in `allowedFields`, the node inspector renders from the slot registry (not node keys), and `AGENT_EQUIPMENT_FIELDS` already excludes the pair from the generic loop — so no new UI surface appears. No user-visible strings changed (no locale sweep), no schema change (documents are `v.any()`).

## Verification

- `vitest --config vitest.ui.config.ts app/features/automations`: 24 files, 164 tests green (regression test verified red-then-green).
- `oxlint --type-aware`, `tsc --noEmit`, `oxfmt --check` on the workspace/changed files: clean.
- Versions saved while the bug was live still hold their pin if the pick happened in that same save; versions saved *after* an unrelated edit lost it and need re-picking once.