### PR TITLE
feat(platform): let a message ref pass the retrieval gate

### DIFF
--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.message_scope.test.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.message_scope.test.ts
@@ -1,0 +1,224 @@
+// The gate that decides an email MESSAGE.
+//
+// A sibling of the emailed-attachment suite, and mocked the same way: only the
+// Better Auth I/O is faked, so `resolveAgentReadAccess`, `authorizeRls` and
+// `conversationAssignmentAllows` all run for real and the rule under test is
+// the shipped rule.
+//
+// A message is the only corpus class that is not a blob, so these cases also
+// pin that it never reaches the `fileMetadata` lookup: the ctx below has no
+// `fileMetadata` at all, and every pass here proves the decision happened
+// before it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getUserTeamIds = vi.fn();
+const getUserOrganizations = vi.fn();
+
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: (...args: unknown[]) => getUserTeamIds(...args),
+}));
+vi.mock('../lib/rls/organization/get_user_organizations', () => ({
+  getUserOrganizations: (...args: unknown[]) => getUserOrganizations(...args),
+}));
+
+const { filterRetrievableRagFileIds } =
+  await import('./filter_retrievable_rag_file_ids');
+const { encodeMessageRef } = await import('../../lib/knowledge/message-ref');
+
+const ORG = 'org_mail';
+const USER = 'user_asking';
+const TEAM_MINE = 'team_mine';
+const TEAM_THEIRS = 'team_theirs';
+const MESSAGE = 'msg_inbound';
+const CONVERSATION = 'conv_inbound';
+const REF = encodeMessageRef(MESSAGE);
+
+const ACCESS = {
+  teamIds: [],
+  projectIds: [],
+  includeHub: true,
+  includeConversationScoped: true,
+  userId: USER,
+} as const;
+
+/**
+ * A ctx holding one message on one conversation, and NO `fileMetadata`.
+ *
+ * `normalizeId` answers for the message id only, so a case can hand in a ref
+ * that is not a message id and see it refused before `get`.
+ */
+function createCtx(
+  overrides: {
+    message?: Record<string, unknown> | null;
+    conversation?: Record<string, unknown> | null;
+  } = {},
+) {
+  const message =
+    overrides.message === null
+      ? null
+      : {
+          _id: MESSAGE,
+          organizationId: ORG,
+          conversationId: CONVERSATION,
+          ...overrides.message,
+        };
+  const conversation =
+    overrides.conversation === null
+      ? null
+      : { _id: CONVERSATION, organizationId: ORG, ...overrides.conversation };
+  return {
+    db: {
+      normalizeId: (table: string, id: string) =>
+        table === 'conversationMessages' && id === MESSAGE ? id : null,
+      query: () => {
+        throw new Error(
+          'a message must be decided before the fileMetadata lookup',
+        );
+      },
+      get: async (id: string) => {
+        if (id === MESSAGE) return message;
+        if (id === CONVERSATION) return conversation;
+        return null;
+      },
+    },
+  } as never;
+}
+
+async function retrievableFor(
+  ctx: unknown,
+  args: Record<string, unknown> = {},
+): Promise<string[]> {
+  return filterRetrievableRagFileIds(ctx as never, {
+    organizationId: ORG,
+    fileIds: [REF],
+    access: ACCESS,
+    userId: USER,
+    ...args,
+  });
+}
+
+describe('filterRetrievableRagFileIds — email messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'member' },
+    ]);
+    getUserTeamIds.mockResolvedValue([TEAM_MINE]);
+  });
+
+  it('serves the individual assignee', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+      ),
+    ).toEqual([REF]);
+  });
+
+  it('serves a member of the assigned team', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_MINE } }),
+      ),
+    ).toEqual([REF]);
+  });
+
+  it('denies another team’s mail, and unassigned mail, to a plain member', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeTeamId: TEAM_THEIRS } }),
+      ),
+    ).toEqual([]);
+    expect(await retrievableFor(createCtx({ conversation: {} }))).toEqual([]);
+  });
+
+  it('serves an admin anything, including unassigned mail', async () => {
+    getUserOrganizations.mockResolvedValue([
+      { organizationId: ORG, role: 'admin' },
+    ]);
+    expect(await retrievableFor(createCtx({ conversation: {} }))).toEqual([
+      REF,
+    ]);
+  });
+
+  it('denies a message whose conversation is in another organization', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({
+          conversation: { organizationId: 'org_other', assigneeUserId: USER },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies a message row belonging to another organization', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({
+          message: { organizationId: 'org_other' },
+          conversation: { assigneeUserId: USER },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies a ref whose message row is gone', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ message: null, conversation: { assigneeUserId: USER } }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies a ref whose conversation is gone', async () => {
+    expect(await retrievableFor(createCtx({ conversation: null }))).toEqual([]);
+  });
+
+  it('denies a ref that is not a conversationMessages id', async () => {
+    // `normalizeId` refuses it, so the decision never reaches `get`.
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { fileIds: ['msg:not-an-id'] },
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies a bare prefix carrying no id', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { fileIds: ['msg:'] },
+      ),
+      // Denied by the message branch. It must NOT fall through to the blob
+      // path: this ctx's `query` throws, so a fall-through fails the test.
+    ).toEqual([]);
+  });
+
+  it('honours a scope that excludes conversations', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { access: { ...ACCESS, includeConversationScoped: false } },
+      ),
+    ).toEqual([]);
+  });
+
+  it('never answers a folder-scoped search', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { folder: 'Contracts' },
+      ),
+    ).toEqual([]);
+  });
+
+  it('denies when there is no caller to decide with', async () => {
+    expect(
+      await retrievableFor(
+        createCtx({ conversation: { assigneeUserId: USER } }),
+        { userId: undefined },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
+++ b/services/platform/convex/documents/filter_retrievable_rag_file_ids.ts
@@ -1,3 +1,4 @@
+import { isMessageRef, parseMessageRef } from '../../lib/knowledge/message-ref';
 import {
   knowledgeScopeAllows,
   type KnowledgeAccessScope,
@@ -30,6 +31,10 @@ export interface FilterRetrievableRagFileIdsArgs {
  * stamp: the caller must currently be able to read the conversation the mail
  * arrived on, so reassigning the mail moves its attachments with it.
  *
+ * An email MESSAGE (`msg:` ref) is the one class that is not a blob at all, so
+ * it is decided before the blob lookup. Its rule is the attachment's rule:
+ * the caller must currently be able to read the conversation it arrived on.
+ *
  * A thread-bound chat upload (`threadId` set, no `documentId`) is its own
  * access class — the 0.3 model (`verify_thread_scoped_access`): retrievable
  * ONLY when the caller's access lists that thread. It is private to its
@@ -55,6 +60,55 @@ export async function filterRetrievableRagFileIds(
     const ref = String(fileId);
     if (seen.has(ref)) continue;
     seen.add(ref);
+
+    // An email MESSAGE. Decided before the blob lookup because a message has
+    // no `fileMetadata` row at all: without this branch the lookup below
+    // returns null and the ref is denied outright, which is why this ships
+    // before anything writes one.
+    //
+    // Same rule as the attachment branch — the conversation's CURRENT
+    // assignment, so a reassignment moves the message with the mail — and the
+    // SAME caller resolution, so a message hit and an attachment hit in one
+    // result set resolve the caller once.
+    // Keyed on the PREFIX, not on a successful parse: a malformed `msg:` ref
+    // must be denied here, never fall through to the blob path below, where
+    // `parseBlobRef` would coerce it into a Convex storage id.
+    if (isMessageRef(ref)) {
+      const messageId = parseMessageRef(ref);
+      if (messageId === null) continue;
+      // A scope that excludes conversations is honoured here too, not only in
+      // the SQL pre-filter — the pre-filter is the half that fails open.
+      if (args.access !== undefined && !args.access.includeConversationScoped) {
+        continue;
+      }
+      // The folder filter is a Document Hub concept; a folder-scoped search
+      // never returns messages, exactly as it never returns attachments.
+      if (args.folder !== undefined && args.folder !== '') continue;
+      // `normalizeId` refuses an id that is not a `conversationMessages` id,
+      // so a malformed ref reads as a miss rather than reaching `get`.
+      const id = ctx.db.normalizeId('conversationMessages', messageId);
+      if (id === null) continue;
+      const message = await ctx.db.get(id);
+      if (message === null || message.organizationId !== args.organizationId) {
+        continue;
+      }
+      const conversation = await ctx.db.get(message.conversationId);
+      if (
+        conversation === null ||
+        conversation.organizationId !== args.organizationId
+      ) {
+        continue;
+      }
+      const caller = await conversationCaller();
+      if (caller === null) continue;
+      const allowed = await conversationAssignmentAllows(conversation, {
+        isAdmin: caller.isAdmin,
+        userId: caller.userId,
+        hasTeam: (teamId) => caller.teamIds.has(teamId),
+      });
+      if (allowed) retrievable.push(ref);
+      continue;
+    }
 
     const metadata = await ctx.db
       .query('fileMetadata')

--- a/services/platform/lib/knowledge/message-ref.ts
+++ b/services/platform/lib/knowledge/message-ref.ts
@@ -1,0 +1,41 @@
+/**
+ * Corpus refs for an email MESSAGE, as distinct from a blob.
+ *
+ * Every other corpus ref names bytes: a Convex `_storage` id, or an `s3:` key
+ * (`convex/lib/storage/blob_ref.ts`). A message has no bytes of its own — its
+ * text is a column on the row — so it needs a ref that a blob path can never
+ * mistake for one of its own.
+ *
+ * Deliberately NOT part of `BlobRef`. `parseBlobRef` treats any string without
+ * an `s3:` prefix as a Convex storage id rather than rejecting it, so a `msg:`
+ * ref reaching a blob read or delete would be coerced instead of refused. That
+ * is safe only while no Convex row carries one: every `parseBlobRef` caller
+ * takes its ref from `documents.fileId`, `documents.historyFiles`, or
+ * `fileMetadata.storageId`, and a message has none of those rows.
+ *
+ * If a message ever gains a `documents` or `fileMetadata` row, that reasoning
+ * expires — add a `msg:` arm to `ParsedBlobRef` so the compiler forces every
+ * blob caller to handle it.
+ */
+
+const MESSAGE_REF_PREFIX = 'msg:';
+
+/** Encode a `conversationMessages` id as a corpus ref. */
+export function encodeMessageRef(messageId: string): string {
+  return `${MESSAGE_REF_PREFIX}${messageId}`;
+}
+
+/** True when a corpus ref names a message rather than a blob. */
+export function isMessageRef(ref: string): boolean {
+  return ref.startsWith(MESSAGE_REF_PREFIX);
+}
+
+/**
+ * The message id inside a corpus ref, or null when the ref names something
+ * else. An empty id reads as null, so `msg:` alone is not a valid ref.
+ */
+export function parseMessageRef(ref: string): string | null {
+  if (!isMessageRef(ref)) return null;
+  const id = ref.slice(MESSAGE_REF_PREFIX.length);
+  return id.length > 0 ? id : null;
+}


### PR DESCRIPTION
An email message can now pass the retrieval gate. Nothing writes such a ref yet, so no search result changes.

This is the mechanism half of #3015, the way #3011 preceded #3012.

## Why

Every corpus ref today resolves through `fileMetadata.by_storageId`, and the gate skips a ref whose row is missing. A message is not a blob and has no such row, so a message hit is denied before reaching any access branch.

That is why this ships first. Index bodies without it and the rows are admitted by SQL, then silently dropped.

## What changed

`msg:<messageId>` is a corpus ref for a message, in a new `lib/knowledge/message-ref.ts`.

The gate gains one branch, decided before the blob lookup. A message is retrievable only when the caller can currently read the conversation it arrived on — `conversationAssignmentAllows`, the same predicate emailed attachments use, so reassigning a conversation moves its messages with it. Scope exclusions and the folder filter are honoured exactly as the attachment branch honours them.

The branch keys on the `msg:` prefix rather than on a successful parse. A malformed ref is denied there instead of falling through to the blob path, where `parseBlobRef` would coerce it into a Convex storage id rather than reject it. A test pins that.

One branch covers both readers: `knowledge/search.ts` filters hits through this gate, and `knowledge/fetch.ts` returns null unless the ref comes back retrievable.

## Risk

**`msg:` is deliberately not part of `BlobRef`.** `parseBlobRef` treats any non-`s3:` string as a storage id, and six modules call it or `convexStorageId`, including `blob_delete.ts` and `erase_document_blobs.ts`. That is safe only because every one of them reads its ref from a Convex row — `documents.fileId`, `documents.historyFiles`, `fileMetadata.storageId` — and a message has none of those. `eraseDocumentBlobs` was checked specifically: it walks `doc.fileId` and `doc.historyFiles`, never a corpus ref.

If a message ever gains a `documents` or `fileMetadata` row, that reasoning expires and `msg:` must join `ParsedBlobRef` so the compiler forces all six to handle it. The module says so.

## Tests

Thirteen cases in a new suite: the individual assignee, a member of the assigned team, another team's mail, unassigned mail, an admin, a cross-org message, a cross-org conversation, a missing message, a missing conversation, a ref that is not a message id, a bare prefix, a scope excluding conversations, a folder-scoped search, and an absent caller.

The suite's ctx has no `fileMetadata` at all and throws if queried, so every passing case also proves the decision happened before the blob lookup.

Eight deliberate breakages were introduced one at a time to confirm each is caught: always-allow, both org checks, the scope exclusion, the folder filter, the absent caller, the id check, and the malformed prefix. All eight were caught. The malformed-prefix case found a real flaw during development — the branch originally keyed on a successful parse, so a bare `msg:` fell through to the blob path.

## Scope

Nothing writes a `msg:` ref. Bodies are not indexed, and no erasure cascade exists for them; both belong to #3015's second half, which must ship the cascade in the same change so message text is not left behind after an erasure request.

No SQL or DDL change. The corpus pre-filter already admits any row carrying a conversation, deliberately, because enumerating a caller's readable conversations is unbounded under assignment privacy.

Gate: typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, platform suite 75,716 passing.
