### PR TITLE
fix(platform): tag email-sync contacts as conversation source

### DIFF
--- a/services/platform/app/features/contacts/components/contact-table.tsx
+++ b/services/platform/app/features/contacts/components/contact-table.tsx
@@ -94,6 +94,10 @@ export function ContactsTable({
         options: [
           { value: 'manual_import', label: tContacts('filter.source.manual') },
           { value: 'file_upload', label: tContacts('filter.source.upload') },
+          {
+            value: 'conversation',
+            label: tContacts('filter.source.conversation'),
+          },
         ],
         selectedValues: source ? [source] : [],
         onChange: handleSourceChange,

--- a/services/platform/app/features/contacts/lib/contact-data.test.ts
+++ b/services/platform/app/features/contacts/lib/contact-data.test.ts
@@ -11,6 +11,9 @@ describe('getContactSourceLabel', () => {
 
   it('start-cases a single-word source enum', () => {
     expect(getContactSourceLabel('shopify', 'Unknown')).toBe('Shopify');
+    expect(getContactSourceLabel('conversation', 'Unknown')).toBe(
+      'Conversation',
+    );
   });
 
   it('falls back to the unknown label when source is unset', () => {

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -702,6 +702,7 @@ import type * as migrations_versions_v0_4_1_02_task_labels_to_catalog_migration 
 import type * as migrations_versions_v0_4_1_03_backfill_project_rollup_counts_migration from "../migrations/versions/v0_4_1/03_backfill_project_rollup_counts/migration.js";
 import type * as migrations_versions_v0_4_1_04_backfill_corpus_document_scope_migration from "../migrations/versions/v0_4_1/04_backfill_corpus_document_scope/migration.js";
 import type * as migrations_versions_v0_4_1_05_backfill_mail_attachment_received_at_migration from "../migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.js";
+import type * as migrations_versions_v0_4_1_06_backfill_conversation_contact_source_migration from "../migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration.js";
 import type * as node_only_documents_internal_actions from "../node_only/documents/internal_actions.js";
 import type * as node_only_knowledge_search_action from "../node_only/knowledge/search_action.js";
 import type * as node_only_sandbox_browser_view from "../node_only/sandbox/browser_view.js";
@@ -1705,6 +1706,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/versions/v0_4_1/03_backfill_project_rollup_counts/migration": typeof migrations_versions_v0_4_1_03_backfill_project_rollup_counts_migration;
   "migrations/versions/v0_4_1/04_backfill_corpus_document_scope/migration": typeof migrations_versions_v0_4_1_04_backfill_corpus_document_scope_migration;
   "migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration": typeof migrations_versions_v0_4_1_05_backfill_mail_attachment_received_at_migration;
+  "migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration": typeof migrations_versions_v0_4_1_06_backfill_conversation_contact_source_migration;
   "node_only/documents/internal_actions": typeof node_only_documents_internal_actions;
   "node_only/knowledge/search_action": typeof node_only_knowledge_search_action;
   "node_only/sandbox/browser_view": typeof node_only_sandbox_browser_view;

--- a/services/platform/convex/conversations/ingest/create_conversation_from_email.test.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_email.test.ts
@@ -55,7 +55,7 @@ function createMockCtx(opts: { failBind?: boolean } = {}) {
   const ctx = {
     runQuery: vi.fn(async () => null),
     runMutation: vi.fn(async (_ref, args: Record<string, unknown>) => {
-      if ('source' in args && args.source === 'manual_import') {
+      if ('source' in args && args.source === 'conversation') {
         return {
           contactId: 'cont_1' as Id<'contacts'>,
           created: true,

--- a/services/platform/convex/conversations/ingest/create_conversation_from_sent_email.test.ts
+++ b/services/platform/convex/conversations/ingest/create_conversation_from_sent_email.test.ts
@@ -27,7 +27,7 @@ function createMockCtx() {
   const ctx = {
     runQuery: vi.fn(async () => null),
     runMutation: vi.fn(async (_ref, args: Record<string, unknown>) => {
-      if ('source' in args && args.source === 'manual_import') {
+      if ('source' in args && args.source === 'conversation') {
         return {
           contactId: 'cont_1' as Id<'contacts'>,
           created: true,

--- a/services/platform/convex/conversations/ingest/find_or_create_contact_from_email.test.ts
+++ b/services/platform/convex/conversations/ingest/find_or_create_contact_from_email.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '../../_generated/dataModel';
+import type { ActionCtx } from '../../_generated/server';
+import { findOrCreateContactFromEmail } from './find_or_create_contact_from_email';
+import type { EmailType } from './types';
+
+describe('findOrCreateContactFromEmail', () => {
+  it('creates inbound contacts with source conversation, not manual_import', async () => {
+    const runMutation = vi.fn(async () => ({
+      contactId: 'cont_1' as Id<'contacts'>,
+      created: true,
+    }));
+    const ctx = { runMutation } as unknown as ActionCtx;
+
+    const email: EmailType = {
+      uid: 1,
+      from: [{ address: 'alice@example.com', name: 'Alice' }],
+      to: [{ address: 'support@org.com', name: 'Support' }],
+      date: '2026-08-25T10:00:00.000Z',
+      subject: 'Hello',
+      messageId: '<msg-1@example.com>',
+      flags: [],
+    };
+
+    const result = await findOrCreateContactFromEmail(
+      ctx,
+      'org_1',
+      email,
+      'inbound',
+    );
+
+    expect(result).toEqual({
+      contactId: 'cont_1',
+      email: 'alice@example.com',
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationId: 'org_1',
+        email: 'alice@example.com',
+        name: 'Alice',
+        source: 'conversation',
+        metadata: {
+          createdFrom: 'email_sync',
+          firstEmailDate: '2026-08-25T10:00:00.000Z',
+        },
+      }),
+    );
+  });
+
+  it('creates outbound contacts with source conversation and sent_email_sync', async () => {
+    const runMutation = vi.fn(async () => ({
+      contactId: 'cont_2' as Id<'contacts'>,
+      created: true,
+    }));
+    const ctx = { runMutation } as unknown as ActionCtx;
+
+    const email: EmailType = {
+      uid: 2,
+      from: [{ address: 'support@org.com', name: 'Support' }],
+      to: [{ address: 'bob@example.com', name: 'Bob' }],
+      date: '2026-08-25T11:00:00.000Z',
+      subject: 'Re: Hello',
+      messageId: '<msg-2@example.com>',
+      flags: [],
+    };
+
+    await findOrCreateContactFromEmail(ctx, 'org_1', email, 'outbound');
+
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        email: 'bob@example.com',
+        name: 'Bob',
+        source: 'conversation',
+        metadata: expect.objectContaining({
+          createdFrom: 'sent_email_sync',
+        }),
+      }),
+    );
+  });
+});

--- a/services/platform/convex/conversations/ingest/find_or_create_contact_from_email.ts
+++ b/services/platform/convex/conversations/ingest/find_or_create_contact_from_email.ts
@@ -34,7 +34,7 @@ export async function findOrCreateContactFromEmail(
       organizationId,
       email: contactEmail,
       name: contactName,
-      source: 'manual_import',
+      source: 'conversation',
       metadata: {
         createdFrom: direction === 'inbound' ? 'email_sync' : 'sent_email_sync',
         firstEmailDate: email.date,

--- a/services/platform/convex/lib/validators/common.ts
+++ b/services/platform/convex/lib/validators/common.ts
@@ -17,6 +17,7 @@ export const dataSourceValidator = v.union(
   v.literal('manual_import'),
   v.literal('file_upload'),
   v.literal('api_import'),
+  v.literal('conversation'),
   v.literal('shopify'),
   v.literal('woocommerce'),
   v.literal('magento'),

--- a/services/platform/convex/migrations/config.snapshot.yml
+++ b/services/platform/convex/migrations/config.snapshot.yml
@@ -787,6 +787,7 @@ schemas:
       - manual_import
       - file_upload
       - api_import
+      - conversation
       - shopify
       - woocommerce
       - magento

--- a/services/platform/convex/migrations/framework/registry.gen.ts
+++ b/services/platform/convex/migrations/framework/registry.gen.ts
@@ -13,6 +13,7 @@ import { migration as m0_4_1_01 } from '../versions/v0_4_1/01_automation_pins_to
 import { migration as m0_4_1_02 } from '../versions/v0_4_1/02_task_labels_to_catalog/migration';
 import { migration as m0_4_1_03 } from '../versions/v0_4_1/03_backfill_project_rollup_counts/migration';
 import { migration as m0_4_1_05 } from '../versions/v0_4_1/05_backfill_mail_attachment_received_at/migration';
+import { migration as m0_4_1_06 } from '../versions/v0_4_1/06_backfill_conversation_contact_source/migration';
 
 /** Every migration’s metadata, ordered by (semver, numericId). */
 export const ALL_META: readonly MigrationMeta[] = [
@@ -76,6 +77,18 @@ export const ALL_META: readonly MigrationMeta[] = [
     destructive: false,
     snapshot: 'none',
   },
+  {
+    id: "0.4.1/06_backfill_conversation_contact_source",
+    semver: "0.4.1",
+    numericId: 6,
+    slug: "backfill_conversation_contact_source",
+    title: "Backfill conversation contact source",
+    description: "up rewrites contacts auto-created from email sync from manual_import to conversation; down restores those rows to manual_import when metadata.createdFrom is email_sync or sent_email_sync",
+    kind: 'db',
+    reversible: true,
+    destructive: false,
+    snapshot: 'none',
+  },
 ];
 
 const BY_ID: ReadonlyMap<string, MigrationMeta> = new Map(
@@ -95,6 +108,7 @@ export const DB_MIGRATIONS: Readonly<Record<string, DbMigration>> = {
   "0.4.1/02_task_labels_to_catalog": composeDb(requireMeta("0.4.1/02_task_labels_to_catalog"), m0_4_1_02),
   "0.4.1/03_backfill_project_rollup_counts": composeDb(requireMeta("0.4.1/03_backfill_project_rollup_counts"), m0_4_1_03),
   "0.4.1/05_backfill_mail_attachment_received_at": composeDb(requireMeta("0.4.1/05_backfill_mail_attachment_received_at"), m0_4_1_05),
+  "0.4.1/06_backfill_conversation_contact_source": composeDb(requireMeta("0.4.1/06_backfill_conversation_contact_source"), m0_4_1_06),
 };
 
 /** Runnable `component` migrations, keyed by meta.id. */

--- a/services/platform/convex/migrations/schema.snapshot.yml
+++ b/services/platform/convex/migrations/schema.snapshot.yml
@@ -1572,6 +1572,8 @@ tables:
           - type: literal
             value: api_import
           - type: literal
+            value: conversation
+          - type: literal
             value: shopify
           - type: literal
             value: woocommerce

--- a/services/platform/convex/migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration.test.ts
+++ b/services/platform/convex/migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+import { expect } from 'vitest';
+
+import { buildModules } from '../../../framework/test_helpers';
+import { defineMigrationTest } from '../../../testing/harness.testkit';
+
+const DIR =
+  'migrations/versions/v0_4_1/06_backfill_conversation_contact_source';
+
+const ORG = 'org_contact_source_backfill';
+
+// The harness runs the full ritual automatically: up through the real runner,
+// TRUE handler idempotency over migrated state, digest-equal down (the seeded
+// world must come back byte-for-byte), ledger transitions, snapshot hygiene,
+// and the destructive gate. This file provides DATA + migration-specific truth.
+defineMigrationTest({
+  id: '0.4.1/06_backfill_conversation_contact_source',
+  modules: buildModules(import.meta.glob('../../../../**/*.*s'), DIR),
+
+  async seed(ctx) {
+    // The row this migration exists for: minted by email ingest under the
+    // wrong source stamp, with provenance already in metadata.
+    await ctx.db.insert('contacts', {
+      organizationId: ORG,
+      email: 'inbox@example.com',
+      name: 'Inbox Correspondent',
+      source: 'manual_import',
+      metadata: {
+        createdFrom: 'email_sync',
+        firstEmailDate: '2026-01-15T10:00:00.000Z',
+      },
+    });
+
+    // Outbound sent-folder sync — same bug, different createdFrom tag.
+    await ctx.db.insert('contacts', {
+      organizationId: ORG,
+      email: 'sent@example.com',
+      name: 'Sent Correspondent',
+      source: 'manual_import',
+      metadata: {
+        createdFrom: 'sent_email_sync',
+        firstEmailDate: '2026-01-16T10:00:00.000Z',
+      },
+    });
+
+    // A real manual import: no email-sync metadata. Must stay untouched so a
+    // typed-in contact does not flip to Conversation.
+    await ctx.db.insert('contacts', {
+      organizationId: ORG,
+      email: 'typed@example.com',
+      name: 'Typed In',
+      source: 'manual_import',
+    });
+  },
+
+  async expectUp(world) {
+    const rows = await world.run(
+      async (ctx: {
+        // oxlint-disable-next-line typescript/no-explicit-any -- convex-test world db
+        db: any;
+      }) => {
+        const all = await ctx.db.query('contacts').collect();
+        return (
+          all as Array<{
+            email?: string;
+            source: string;
+          }>
+        ).map((row) => ({ email: row.email, source: row.source }));
+      },
+    );
+    const byEmail = new Map(rows.map((row) => [row.email, row.source]));
+
+    expect(byEmail.get('inbox@example.com')).toBe('conversation');
+    expect(byEmail.get('sent@example.com')).toBe('conversation');
+    expect(byEmail.get('typed@example.com')).toBe('manual_import');
+  },
+});

--- a/services/platform/convex/migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration.ts
+++ b/services/platform/convex/migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration.ts
@@ -1,0 +1,57 @@
+/**
+ * Backfill conversation contact source.
+ *
+ * Email ingest auto-creates a contact for every conversation correspondent,
+ * but it stamped those rows as `manual_import`. The Source column and details
+ * dialog then claimed every inbox-born contact was typed in by hand.
+ *
+ * Provenance was already written into metadata (`createdFrom: email_sync` or
+ * `sent_email_sync`). `up` flips `source` to `conversation` for those rows so
+ * the UI matches how the contact actually arrived. True manual imports and
+ * file uploads have no such metadata and stay untouched.
+ *
+ * `down` restores `manual_import` on the same predicate, so a rollback lands
+ * the pre-fix shape. Both directions are idempotent: a replayed batch that
+ * already carries the target source is a no-op. Nothing is destroyed, so
+ * `snapshot: 'none'` is enough.
+ */
+
+import type { GenericId } from 'convex/values';
+
+import { defineDbMigration } from '../../../framework/define';
+
+const EMAIL_CREATED_FROM = new Set(['email_sync', 'sent_email_sync']);
+
+function createdFromEmail(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return false;
+  }
+  const createdFrom = (metadata as { createdFrom?: unknown }).createdFrom;
+  return typeof createdFrom === 'string' && EMAIL_CREATED_FROM.has(createdFrom);
+}
+
+export const migration = defineDbMigration({
+  title: 'Backfill conversation contact source',
+  description:
+    'up rewrites contacts auto-created from email sync from manual_import to conversation; down restores those rows to manual_import when metadata.createdFrom is email_sync or sent_email_sync',
+  destructive: false,
+  snapshot: 'none',
+  subjects: { tables: ['contacts'] },
+  table: 'contacts',
+
+  async up(ctx, doc) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runner paginates `table: 'contacts'`
+    const id = doc._id as GenericId<'contacts'>;
+    if (doc.source !== 'manual_import') return;
+    if (!createdFromEmail(doc.metadata)) return;
+    await ctx.db.patch(id, { source: 'conversation' });
+  },
+
+  async down(ctx, doc) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- as above
+    const id = doc._id as GenericId<'contacts'>;
+    if (doc.source !== 'conversation') return;
+    if (!createdFromEmail(doc.metadata)) return;
+    await ctx.db.patch(id, { source: 'manual_import' });
+  },
+});

--- a/services/platform/lib/shared/schemas/common.ts
+++ b/services/platform/lib/shared/schemas/common.ts
@@ -4,6 +4,7 @@ const dataSourceLiterals = [
   'manual_import',
   'file_upload',
   'api_import',
+  'conversation',
   'shopify',
   'woocommerce',
   'magento',

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1897,6 +1897,7 @@ contacts:
     source:
       manual: Manuell
       upload: Upload
+      conversation: Konversation
   importForm:
     manualEntry: Manuelle Eingabe
     upload: Upload

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1838,6 +1838,7 @@ contacts:
     source:
       manual: Manual
       upload: Upload
+      conversation: Conversation
   importForm:
     manualEntry: Manual entry
     upload: Upload

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1914,6 +1914,7 @@ contacts:
     source:
       manual: Manuel
       upload: Téléversement
+      conversation: Conversation
   importForm:
     manualEntry: Saisie manuelle
     upload: Téléversement


### PR DESCRIPTION
## Summary
- Stamp contacts auto-created from inbound/sent email sync with source `conversation` instead of `manual_import`
- Add the enum value across shared schema, Convex validators, and contacts filter UI (en/de/fr)
- Ship reversible migration `0.4.1/06_backfill_conversation_contact_source` for existing email-sync rows

## Test plan
- [ ] Create a contact via inbound email sync and confirm source is `conversation` in Contacts
- [ ] Filter Contacts by source → Conversation
- [ ] Run migration up/down on a fixture org with email-sync `manual_import` contacts
- [ ] Confirm existing `manual_import` / upload / Shopify contacts are unchanged