### PR TITLE
fix(platform): open Drive/OneDrive import via connect dialog

### DIFF
--- a/services/platform/app/features/documents/components/cloud-import-connect-dialog.tsx
+++ b/services/platform/app/features/documents/components/cloud-import-connect-dialog.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+
+import { Dialog } from '@/app/components/ui/dialog/dialog';
+import { useT } from '@/lib/i18n/client';
+
+import { GoogleReauthButton } from './google-reauth-button';
+import { MicrosoftReauthButton } from './microsoft-reauth-button';
+
+export type CloudImportConnectProvider = 'onedrive' | 'google-drive';
+
+interface CloudImportConnectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  provider: CloudImportConnectProvider;
+}
+
+/**
+ * Compact grant prompt for Documents cloud import — same measure as
+ * From your device / New folder. Kept separate from the wide picker so
+ * authorizing never resizes an open dialog.
+ */
+export function CloudImportConnectDialog({
+  open,
+  onOpenChange,
+  provider,
+}: CloudImportConnectDialogProps) {
+  const { t } = useT('documents');
+
+  const title =
+    provider === 'onedrive'
+      ? t('onedrive.microsoftNotConnected')
+      : t('googledrive.notConnected');
+  const description =
+    provider === 'onedrive'
+      ? t('onedrive.microsoftNotConnectedDescription')
+      : t('googledrive.notConnectedDescription');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} title={title} size="md">
+      <Stack gap={4} className="pt-1">
+        <Text as="div" variant="muted">
+          {description}
+        </Text>
+        <div>
+          {provider === 'onedrive' ? (
+            <MicrosoftReauthButton />
+          ) : (
+            <GoogleReauthButton />
+          )}
+        </div>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/services/platform/app/features/documents/components/documents-action-menu.tsx
+++ b/services/platform/app/features/documents/components/documents-action-menu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FolderPlus, HardDrive, Upload } from 'lucide-react';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 
 import { GoogleIcon } from '@/app/components/icons/google-icon';
 import { MicrosoftIcon } from '@/app/components/icons/microsoft-icon';
@@ -13,6 +13,8 @@ import { useAbility } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { lazyComponent } from '@/lib/utils/lazy-component';
 
+import { useCloudImportAuthorizationStatus } from '../hooks/queries';
+import { CloudImportConnectDialog } from './cloud-import-connect-dialog';
 import { CreateFolderDialog } from './create-folder-dialog';
 
 const OneDriveImportDialog = lazyComponent(() =>
@@ -57,33 +59,95 @@ export function DocumentsActionMenu({
   const { t: tDocuments } = useT('documents');
   const ability = useAbility();
 
-  const [uncontrolledOneDriveOpen, setUncontrolledOneDriveOpen] =
-    useState(false);
-  const isOneDriveDialogOpen = oneDriveOpen ?? uncontrolledOneDriveOpen;
-  const setIsOneDriveDialogOpen =
-    onOneDriveOpenChange ?? setUncontrolledOneDriveOpen;
+  const { data: microsoftAuth, isLoading: microsoftAuthLoading } =
+    useCloudImportAuthorizationStatus(organizationId, true, 'onedrive');
+  const { data: googleAuth, isLoading: googleAuthLoading } =
+    useCloudImportAuthorizationStatus(organizationId, true, 'google-drive');
 
-  const [uncontrolledGoogleDriveOpen, setUncontrolledGoogleDriveOpen] =
+  const [uncontrolledOneDriveImportOpen, setUncontrolledOneDriveImportOpen] =
     useState(false);
-  const isGoogleDriveDialogOpen =
-    googleDriveOpen ?? uncontrolledGoogleDriveOpen;
-  const setIsGoogleDriveDialogOpen =
-    onGoogleDriveOpenChange ?? setUncontrolledGoogleDriveOpen;
+  const isOneDriveImportOpen = oneDriveOpen ?? uncontrolledOneDriveImportOpen;
+  const setIsOneDriveImportOpen =
+    onOneDriveOpenChange ?? setUncontrolledOneDriveImportOpen;
+
+  const [
+    uncontrolledGoogleDriveImportOpen,
+    setUncontrolledGoogleDriveImportOpen,
+  ] = useState(false);
+  const isGoogleDriveImportOpen =
+    googleDriveOpen ?? uncontrolledGoogleDriveImportOpen;
+  const setIsGoogleDriveImportOpen =
+    onGoogleDriveOpenChange ?? setUncontrolledGoogleDriveImportOpen;
+
+  const [isOneDriveConnectOpen, setIsOneDriveConnectOpen] = useState(false);
+  const [isGoogleDriveConnectOpen, setIsGoogleDriveConnectOpen] =
+    useState(false);
+
+  // Menu click while auth status is still loading — resolve once the query
+  // settles so we open connect vs picker without guessing.
+  const [pendingOneDriveOpen, setPendingOneDriveOpen] = useState(false);
+  const [pendingGoogleDriveOpen, setPendingGoogleDriveOpen] = useState(false);
 
   const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
+
+  const openOneDriveFlow = useCallback(() => {
+    if (microsoftAuth?.status === 'active') {
+      setIsOneDriveImportOpen(true);
+    } else {
+      setIsOneDriveConnectOpen(true);
+    }
+  }, [microsoftAuth?.status, setIsOneDriveImportOpen]);
+
+  const openGoogleDriveFlow = useCallback(() => {
+    if (googleAuth?.status === 'active') {
+      setIsGoogleDriveImportOpen(true);
+    } else {
+      setIsGoogleDriveConnectOpen(true);
+    }
+  }, [googleAuth?.status, setIsGoogleDriveImportOpen]);
+
+  useEffect(() => {
+    if (!pendingOneDriveOpen || microsoftAuthLoading) return;
+    setPendingOneDriveOpen(false);
+    openOneDriveFlow();
+  }, [pendingOneDriveOpen, microsoftAuthLoading, openOneDriveFlow]);
+
+  useEffect(() => {
+    if (!pendingGoogleDriveOpen || googleAuthLoading) return;
+    setPendingGoogleDriveOpen(false);
+    openGoogleDriveFlow();
+  }, [pendingGoogleDriveOpen, googleAuthLoading, openGoogleDriveFlow]);
 
   const handleDeviceUpload = useCallback(() => {
     setIsUploadDialogOpen(true);
   }, []);
 
   const handleOneDriveClick = useCallback(() => {
-    setIsOneDriveDialogOpen(true);
-  }, [setIsOneDriveDialogOpen]);
+    if (microsoftAuthLoading) {
+      setPendingOneDriveOpen(true);
+      return;
+    }
+    openOneDriveFlow();
+  }, [microsoftAuthLoading, openOneDriveFlow]);
 
   const handleGoogleDriveClick = useCallback(() => {
-    setIsGoogleDriveDialogOpen(true);
-  }, [setIsGoogleDriveDialogOpen]);
+    if (googleAuthLoading) {
+      setPendingGoogleDriveOpen(true);
+      return;
+    }
+    openGoogleDriveFlow();
+  }, [googleAuthLoading, openGoogleDriveFlow]);
+
+  const handleOneDriveDisconnected = useCallback(() => {
+    setIsOneDriveImportOpen(false);
+    setIsOneDriveConnectOpen(true);
+  }, [setIsOneDriveImportOpen]);
+
+  const handleGoogleDriveDisconnected = useCallback(() => {
+    setIsGoogleDriveImportOpen(false);
+    setIsGoogleDriveConnectOpen(true);
+  }, [setIsGoogleDriveImportOpen]);
 
   const handleCreateFolder = useCallback(() => {
     setIsCreateFolderOpen(true);
@@ -141,21 +205,39 @@ export function DocumentsActionMenu({
         />
       )}
 
-      {isOneDriveDialogOpen && (
-        <OneDriveImportDialog
-          open={isOneDriveDialogOpen}
-          onOpenChange={setIsOneDriveDialogOpen}
-          organizationId={organizationId}
-          onSuccess={() => setIsOneDriveDialogOpen(false)}
+      {isOneDriveConnectOpen && (
+        <CloudImportConnectDialog
+          open={isOneDriveConnectOpen}
+          onOpenChange={setIsOneDriveConnectOpen}
+          provider="onedrive"
         />
       )}
 
-      {isGoogleDriveDialogOpen && (
-        <GoogleDriveImportDialog
-          open={isGoogleDriveDialogOpen}
-          onOpenChange={setIsGoogleDriveDialogOpen}
+      {isGoogleDriveConnectOpen && (
+        <CloudImportConnectDialog
+          open={isGoogleDriveConnectOpen}
+          onOpenChange={setIsGoogleDriveConnectOpen}
+          provider="google-drive"
+        />
+      )}
+
+      {isOneDriveImportOpen && (
+        <OneDriveImportDialog
+          open={isOneDriveImportOpen}
+          onOpenChange={setIsOneDriveImportOpen}
           organizationId={organizationId}
-          onSuccess={() => setIsGoogleDriveDialogOpen(false)}
+          onSuccess={() => setIsOneDriveImportOpen(false)}
+          onRequireConnect={handleOneDriveDisconnected}
+        />
+      )}
+
+      {isGoogleDriveImportOpen && (
+        <GoogleDriveImportDialog
+          open={isGoogleDriveImportOpen}
+          onOpenChange={setIsGoogleDriveImportOpen}
+          organizationId={organizationId}
+          onSuccess={() => setIsGoogleDriveImportOpen(false)}
+          onRequireConnect={handleGoogleDriveDisconnected}
         />
       )}
 

--- a/services/platform/app/features/documents/components/google-disconnect-button.tsx
+++ b/services/platform/app/features/documents/components/google-disconnect-button.tsx
@@ -16,6 +16,7 @@ interface GoogleDisconnectButtonProps {
 
 /**
  * Revokes the signed-in member's Knowledge cloud-import grant for Google Drive.
+ * The import dialog closes and the compact connect dialog opens.
  */
 export function GoogleDisconnectButton({
   className,

--- a/services/platform/app/features/documents/components/google-drive-import-dialog.tsx
+++ b/services/platform/app/features/documents/components/google-drive-import-dialog.tsx
@@ -1,13 +1,11 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { HStack, Stack } from '@tale/ui/layout';
+import { HStack } from '@tale/ui/layout';
 import { SectionHeader } from '@tale/ui/section-header';
-import { Text } from '@tale/ui/text';
 import { Home } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { GoogleIcon } from '@/app/components/icons/google-icon';
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
@@ -23,7 +21,6 @@ import {
   useGoogleDriveFiles,
 } from '../hooks/queries';
 import { GoogleDisconnectButton } from './google-disconnect-button';
-import { GoogleReauthButton } from './google-reauth-button';
 import { OneDriveFileTable } from './onedrive-import/onedrive-file-table';
 import { OneDriveSettingsStage } from './onedrive-import/onedrive-settings-stage';
 import type {
@@ -50,11 +47,14 @@ interface GoogleDriveImportDialogProps {
   onOpenChange?: (open: boolean) => void;
   organizationId: string;
   onSuccess?: () => void;
+  /** Hand off to the compact connect dialog — never shrink this wide picker. */
+  onRequireConnect?: () => void;
 }
 
 export function GoogleDriveImportDialog({
   organizationId,
   onSuccess,
+  onRequireConnect,
   ...props
 }: GoogleDriveImportDialogProps) {
   const { t } = useT('documents');
@@ -112,6 +112,21 @@ export function GoogleDriveImportDialog({
       (!cloudImportAuth || cloudImportAuth.status !== 'active')) ||
     isCloudImportAuthError(loadError);
 
+  // Safety net: if the picker opens without a grant (or the grant dies
+  // mid-session), hand off to the connect dialog instead of resizing.
+  useEffect(() => {
+    if (props.open !== true || cloudImportAuthLoading) return;
+    if (!isGoogleAccountError) return;
+    (props.onOpenChange ?? noop)(false);
+    onRequireConnect?.();
+  }, [
+    props.open,
+    props.onOpenChange,
+    cloudImportAuthLoading,
+    isGoogleAccountError,
+    onRequireConnect,
+  ]);
+
   const currentItems = useMemo(() => itemsData ?? [], [itemsData]);
 
   const filteredItems = useMemo(() => {
@@ -126,7 +141,9 @@ export function GoogleDriveImportDialog({
     setCurrentFolderId(undefined);
     setFolderPath([{ id: undefined, name: t('breadcrumb.googleDrive') }]);
     setStage('picker');
-  }, [t]);
+    (props.onOpenChange ?? noop)(false);
+    onRequireConnect?.();
+  }, [t, props.onOpenChange, onRequireConnect]);
 
   const buildItemPath = (item: OneDriveApiItem): string => {
     const pathParts: string[] = [];
@@ -372,87 +389,65 @@ export function GoogleDriveImportDialog({
           <div className="border-border border-b">
             <div className="px-8 pt-5 pb-3">
               <SectionHeader
-                title={
-                  isGoogleAccountError
-                    ? t('googledrive.notConnected')
-                    : t('googledrive.title')
-                }
-                description={
-                  isGoogleAccountError
-                    ? undefined
-                    : t('googledrive.selectDescription')
-                }
+                title={t('googledrive.title')}
+                description={t('googledrive.selectDescription')}
                 action={
-                  isGoogleAccountError ? undefined : (
-                    <GoogleDisconnectButton
-                      onDisconnected={handleDisconnected}
-                    />
-                  )
+                  <GoogleDisconnectButton onDisconnected={handleDisconnected} />
                 }
               />
             </div>
           </div>
         }
       >
-        {isGoogleAccountError ? (
-          <Stack gap={3} className="items-center px-8 py-8 text-center">
-            <GoogleIcon className="size-8" />
-            <Text as="div" variant="muted" className="max-w-sm">
-              {t('googledrive.notConnectedDescription')}
-            </Text>
-            <GoogleReauthButton />
-          </Stack>
-        ) : (
-          <div className="flex flex-col gap-3 px-8 pt-3 pb-6">
-            {folderPath.length > 1 && (
-              <HStack gap={2} className="text-muted-foreground text-sm">
-                {folderPath.map((folder, index) => (
-                  <HStack key={folder.id || 'root'} gap={2}>
-                    <button
-                      type="button"
-                      onClick={() => handleBreadcrumbClick(index)}
-                      className="hover:text-blue-600 hover:underline"
-                    >
-                      {index === 0 ? <Home className="size-4" /> : folder.name}
-                    </button>
-                    {index < folderPath.length - 1 && (
-                      <span className="text-muted-foreground">/</span>
-                    )}
-                  </HStack>
-                ))}
-              </HStack>
-            )}
-
-            <HStack gap={3}>
-              <SearchInput
-                placeholder={t('searchFilesAndFolders')}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                wrapperClassName="flex-1"
-              />
-              <Button
-                onClick={proceedToSettings}
-                disabled={selectedItems.size === 0}
-                className="whitespace-nowrap"
-              >
-                {t('googledrive.importCount', { count: selectedItems.size })}
-              </Button>
+        <div className="flex flex-col gap-3 px-8 pt-3 pb-6">
+          {folderPath.length > 1 && (
+            <HStack gap={2} className="text-muted-foreground text-sm">
+              {folderPath.map((folder, index) => (
+                <HStack key={folder.id || 'root'} gap={2}>
+                  <button
+                    type="button"
+                    onClick={() => handleBreadcrumbClick(index)}
+                    className="hover:text-blue-600 hover:underline"
+                  >
+                    {index === 0 ? <Home className="size-4" /> : folder.name}
+                  </button>
+                  {index < folderPath.length - 1 && (
+                    <span className="text-muted-foreground">/</span>
+                  )}
+                </HStack>
+              ))}
             </HStack>
+          )}
 
-            <OneDriveFileTable
-              items={filteredItems}
-              isLoading={loading}
-              searchQuery={searchQuery}
-              selectedItems={selectedItems}
-              getSelectAllState={getSelectAllState}
-              handleSelectAllChange={handleSelectAllChange}
-              getCheckedState={getCheckedState}
-              handleCheckChange={handleCheckChange}
-              handleFolderClick={handleFolderClick}
-              buildItemPath={buildItemPath}
+          <HStack gap={3}>
+            <SearchInput
+              placeholder={t('searchFilesAndFolders')}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              wrapperClassName="flex-1"
             />
-          </div>
-        )}
+            <Button
+              onClick={proceedToSettings}
+              disabled={selectedItems.size === 0}
+              className="whitespace-nowrap"
+            >
+              {t('googledrive.importCount', { count: selectedItems.size })}
+            </Button>
+          </HStack>
+
+          <OneDriveFileTable
+            items={filteredItems}
+            isLoading={loading}
+            searchQuery={searchQuery}
+            selectedItems={selectedItems}
+            getSelectAllState={getSelectAllState}
+            handleSelectAllChange={handleSelectAllChange}
+            getCheckedState={getCheckedState}
+            handleCheckChange={handleCheckChange}
+            handleFolderClick={handleFolderClick}
+            buildItemPath={buildItemPath}
+          />
+        </div>
       </Dialog>
     );
   }

--- a/services/platform/app/features/documents/components/google-drive-import-dialog.tsx
+++ b/services/platform/app/features/documents/components/google-drive-import-dialog.tsx
@@ -55,7 +55,8 @@ export function GoogleDriveImportDialog({
   organizationId,
   onSuccess,
   onRequireConnect,
-  ...props
+  open,
+  onOpenChange,
 }: GoogleDriveImportDialogProps) {
   const { t } = useT('documents');
   const { t: tCommon } = useT('common');
@@ -90,7 +91,7 @@ export function GoogleDriveImportDialog({
   const { data: cloudImportAuth, isLoading: cloudImportAuthLoading } =
     useCloudImportAuthorizationStatus(
       organizationId,
-      props.open === true,
+      open === true,
       'google-drive',
     );
 
@@ -115,13 +116,13 @@ export function GoogleDriveImportDialog({
   // Safety net: if the picker opens without a grant (or the grant dies
   // mid-session), hand off to the connect dialog instead of resizing.
   useEffect(() => {
-    if (props.open !== true || cloudImportAuthLoading) return;
+    if (open !== true || cloudImportAuthLoading) return;
     if (!isGoogleAccountError) return;
-    (props.onOpenChange ?? noop)(false);
+    (onOpenChange ?? noop)(false);
     onRequireConnect?.();
   }, [
-    props.open,
-    props.onOpenChange,
+    open,
+    onOpenChange,
     cloudImportAuthLoading,
     isGoogleAccountError,
     onRequireConnect,
@@ -141,9 +142,9 @@ export function GoogleDriveImportDialog({
     setCurrentFolderId(undefined);
     setFolderPath([{ id: undefined, name: t('breadcrumb.googleDrive') }]);
     setStage('picker');
-    (props.onOpenChange ?? noop)(false);
+    (onOpenChange ?? noop)(false);
     onRequireConnect?.();
-  }, [t, props.onOpenChange, onRequireConnect]);
+  }, [t, onOpenChange, onRequireConnect]);
 
   const buildItemPath = (item: OneDriveApiItem): string => {
     const pathParts: string[] = [];
@@ -378,8 +379,8 @@ export function GoogleDriveImportDialog({
   if (stage === 'picker') {
     return (
       <Dialog
-        open={props.open ?? false}
-        onOpenChange={props.onOpenChange ?? noop}
+        open={open ?? false}
+        onOpenChange={onOpenChange ?? noop}
         title={t('googledrive.title')}
         hideClose
         size="wide"
@@ -470,8 +471,8 @@ export function GoogleDriveImportDialog({
 
   return (
     <Dialog
-      open={props.open ?? false}
-      onOpenChange={props.onOpenChange ?? noop}
+      open={open ?? false}
+      onOpenChange={onOpenChange ?? noop}
       title={settings.title}
       description={settings.description}
       size="md"

--- a/services/platform/app/features/documents/components/microsoft-disconnect-button.tsx
+++ b/services/platform/app/features/documents/components/microsoft-disconnect-button.tsx
@@ -16,7 +16,7 @@ interface MicrosoftDisconnectButtonProps {
 
 /**
  * Revokes the signed-in member's Knowledge cloud-import grant for Microsoft
- * 365 so the import dialog returns to the connect empty state.
+ * 365. The import dialog closes and the compact connect dialog opens.
  */
 export function MicrosoftDisconnectButton({
   className,

--- a/services/platform/app/features/documents/components/onedrive-import-dialog.tsx
+++ b/services/platform/app/features/documents/components/onedrive-import-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useCallback, useState } from 'react';
+import { useMemo, useCallback, useState, useEffect } from 'react';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
@@ -46,6 +46,8 @@ interface OneDriveImportDialogProps {
   onOpenChange?: (open: boolean) => void;
   organizationId: string;
   onSuccess?: () => void;
+  /** Hand off to the compact connect dialog — never shrink this wide picker. */
+  onRequireConnect?: () => void;
 }
 
 const noop = () => {};
@@ -53,6 +55,7 @@ const noop = () => {};
 export function OneDriveImportDialog({
   organizationId,
   onSuccess,
+  onRequireConnect,
   ...props
 }: OneDriveImportDialogProps) {
   const { t } = useT('documents');
@@ -112,7 +115,11 @@ export function OneDriveImportDialog({
     setSpFolderId(undefined);
     setSpFolderPath([]);
     setSourceTab('onedrive');
-  }, [t]);
+    // Close the wide picker and open the compact connect dialog — do not
+    // morph this shell to md.
+    (props.onOpenChange ?? noop)(false);
+    onRequireConnect?.();
+  }, [t, props.onOpenChange, onRequireConnect]);
 
   const handleSelectTeam = useCallback((teamId: string | undefined) => {
     setSelectedTeamId_local(teamId);
@@ -170,6 +177,21 @@ export function OneDriveImportDialog({
       (!cloudImportAuth || cloudImportAuth.status !== 'active')) ||
     isCloudImportAuthError(loadError) ||
     isCloudImportAuthError(sitesError);
+
+  // Safety net: if the picker opens without a grant (or the grant dies
+  // mid-session), hand off to the connect dialog instead of resizing.
+  useEffect(() => {
+    if (props.open !== true || cloudImportAuthLoading) return;
+    if (!isMicrosoftAccountError) return;
+    (props.onOpenChange ?? noop)(false);
+    onRequireConnect?.();
+  }, [
+    props.open,
+    props.onOpenChange,
+    cloudImportAuthLoading,
+    isMicrosoftAccountError,
+    onRequireConnect,
+  ]);
 
   const collectAllFiles = async (
     items: OneDriveApiItem[],
@@ -497,7 +519,6 @@ export function OneDriveImportDialog({
       selectedItems,
       filteredItems,
       loading,
-      isMicrosoftAccountError,
       folderPath,
       sitesData,
       loadingSites,

--- a/services/platform/app/features/documents/components/onedrive-import-dialog.tsx
+++ b/services/platform/app/features/documents/components/onedrive-import-dialog.tsx
@@ -56,7 +56,8 @@ export function OneDriveImportDialog({
   organizationId,
   onSuccess,
   onRequireConnect,
-  ...props
+  open,
+  onOpenChange,
 }: OneDriveImportDialogProps) {
   const { t } = useT('documents');
   const { t: tCommon } = useT('common');
@@ -103,7 +104,7 @@ export function OneDriveImportDialog({
   const { teams, isLoading: isLoadingTeams } = useTeams();
 
   const { data: cloudImportAuth, isLoading: cloudImportAuthLoading } =
-    useCloudImportAuthorizationStatus(organizationId, props.open === true);
+    useCloudImportAuthorizationStatus(organizationId, open === true);
 
   const handleDisconnected = useCallback(() => {
     setSelectedItems(new Map());
@@ -117,9 +118,9 @@ export function OneDriveImportDialog({
     setSourceTab('onedrive');
     // Close the wide picker and open the compact connect dialog — do not
     // morph this shell to md.
-    (props.onOpenChange ?? noop)(false);
+    (onOpenChange ?? noop)(false);
     onRequireConnect?.();
-  }, [t, props.onOpenChange, onRequireConnect]);
+  }, [t, onOpenChange, onRequireConnect]);
 
   const handleSelectTeam = useCallback((teamId: string | undefined) => {
     setSelectedTeamId_local(teamId);
@@ -181,13 +182,13 @@ export function OneDriveImportDialog({
   // Safety net: if the picker opens without a grant (or the grant dies
   // mid-session), hand off to the connect dialog instead of resizing.
   useEffect(() => {
-    if (props.open !== true || cloudImportAuthLoading) return;
+    if (open !== true || cloudImportAuthLoading) return;
     if (!isMicrosoftAccountError) return;
-    (props.onOpenChange ?? noop)(false);
+    (onOpenChange ?? noop)(false);
     onRequireConnect?.();
   }, [
-    props.open,
-    props.onOpenChange,
+    open,
+    onOpenChange,
     cloudImportAuthLoading,
     isMicrosoftAccountError,
     onRequireConnect,
@@ -578,8 +579,8 @@ export function OneDriveImportDialog({
 
     return (
       <Dialog
-        open={props.open ?? false}
-        onOpenChange={props.onOpenChange ?? noop}
+        open={open ?? false}
+        onOpenChange={onOpenChange ?? noop}
         title={t('microsoft365.title')}
         hideClose
         size="wide"
@@ -610,8 +611,8 @@ export function OneDriveImportDialog({
 
     return (
       <Dialog
-        open={props.open ?? false}
-        onOpenChange={props.onOpenChange ?? noop}
+        open={open ?? false}
+        onOpenChange={onOpenChange ?? noop}
         title={settings.title}
         description={settings.description}
         size="md"

--- a/services/platform/app/features/documents/components/onedrive-import/onedrive-picker-stage.tsx
+++ b/services/platform/app/features/documents/components/onedrive-import/onedrive-picker-stage.tsx
@@ -1,21 +1,19 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { Stack, HStack } from '@tale/ui/layout';
+import { HStack } from '@tale/ui/layout';
 import { SectionHeader } from '@tale/ui/section-header';
 import { Tabs } from '@tale/ui/tabs';
 import { Text } from '@tale/ui/text';
 import type { TFunction } from 'i18next';
 import { Home } from 'lucide-react';
 
-import { MicrosoftIcon } from '@/app/components/icons/microsoft-icon';
 import { OneDriveIcon } from '@/app/components/icons/onedrive-icon';
 import { SharePointIcon } from '@/app/components/icons/sharepoint-icon';
 import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { useT } from '@/lib/i18n/client';
 
 import { MicrosoftDisconnectButton } from '../microsoft-disconnect-button';
-import { MicrosoftReauthButton } from '../microsoft-reauth-button';
 import { OneDriveFileTable } from './onedrive-file-table';
 import { SharePointDrivesTable } from './sharepoint-drives-table';
 import { SharePointSitesTable } from './sharepoint-sites-table';
@@ -33,7 +31,6 @@ interface OneDrivePickerStageProps {
   selectedItems: Map<string, OneDriveSelectedItem>;
   filteredItems: OneDriveApiItem[];
   loading: boolean;
-  isMicrosoftAccountError: boolean;
   folderPath: Array<{ id: string | undefined; name: string }>;
   sitesData: SharePointSite[] | undefined;
   loadingSites: boolean;
@@ -74,7 +71,6 @@ export function OneDrivePickerStage({
   selectedItems,
   filteredItems,
   loading,
-  isMicrosoftAccountError,
   folderPath,
   sitesData,
   loadingSites,
@@ -110,65 +106,45 @@ export function OneDrivePickerStage({
       <div className="border-border border-b">
         <div className="px-8 pt-5 pb-3">
           <SectionHeader
-            title={
-              isMicrosoftAccountError
-                ? t('onedrive.microsoftNotConnected')
-                : t('microsoft365.title')
-            }
-            description={
-              isMicrosoftAccountError
-                ? undefined
-                : t('microsoft365.selectDescription')
-            }
+            title={t('microsoft365.title')}
+            description={t('microsoft365.selectDescription')}
             action={
-              isMicrosoftAccountError ? undefined : (
-                <MicrosoftDisconnectButton onDisconnected={onDisconnected} />
-              )
+              <MicrosoftDisconnectButton onDisconnected={onDisconnected} />
             }
           />
         </div>
-        {!isMicrosoftAccountError && (
-          <div className="px-8">
-            <Tabs
-              variant="underline"
-              value={sourceTab}
-              onValueChange={(v) => {
-                if (v === 'onedrive' || v === 'sharepoint') onTabChange(v);
-              }}
-              items={[
-                {
-                  value: 'onedrive',
-                  label: (
-                    <span className="flex items-center gap-2">
-                      <OneDriveIcon className="size-4" />
-                      {t('microsoft365.myOneDrive')}
-                    </span>
-                  ),
-                },
-                {
-                  value: 'sharepoint',
-                  label: (
-                    <span className="flex items-center gap-2">
-                      <SharePointIcon className="size-4" />
-                      {t('microsoft365.sharePointSites')}
-                    </span>
-                  ),
-                },
-              ]}
-            />
-          </div>
-        )}
+        <div className="px-8">
+          <Tabs
+            variant="underline"
+            value={sourceTab}
+            onValueChange={(v) => {
+              if (v === 'onedrive' || v === 'sharepoint') onTabChange(v);
+            }}
+            items={[
+              {
+                value: 'onedrive',
+                label: (
+                  <span className="flex items-center gap-2">
+                    <OneDriveIcon className="size-4" />
+                    {t('microsoft365.myOneDrive')}
+                  </span>
+                ),
+              },
+              {
+                value: 'sharepoint',
+                label: (
+                  <span className="flex items-center gap-2">
+                    <SharePointIcon className="size-4" />
+                    {t('microsoft365.sharePointSites')}
+                  </span>
+                ),
+              },
+            ]}
+          />
+        </div>
       </div>
     ),
-    content: isMicrosoftAccountError ? (
-      <Stack gap={3} className="items-center px-8 py-8 text-center">
-        <MicrosoftIcon className="size-8" />
-        <Text as="div" variant="muted" className="max-w-sm">
-          {t('onedrive.microsoftNotConnectedDescription')}
-        </Text>
-        <MicrosoftReauthButton />
-      </Stack>
-    ) : (
+    content: (
       <div className="flex flex-col gap-3 px-8 pt-3 pb-6">
         {sourceTab === 'onedrive' && (
           <>

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -2269,8 +2269,8 @@ documents:
       {Element} other {Elemente}} importiert werden sollen.
     microsoftNotConnected: Microsoft 365 verbinden
     microsoftNotConnectedDescription:
-      Autorisiere OneDrive und SharePoint, damit du Dateien für Dokumente
-      auswählen kannst.
+      Um Dateien hochzuladen, musst du deinem Microsoft 365-Konto Zugriff
+      gewähren.
     connect: Microsoft 365 verbinden
     reconnect: Microsoft 365 erneut verbinden
     disconnect: Microsoft 365 trennen
@@ -2303,7 +2303,9 @@ documents:
     title: Von Google Drive importieren
     selectDescription: Wähle Dateien oder Ordner zum Importieren
     notConnected: Google Drive verbinden
-    notConnectedDescription: Autorisiere Google Drive, damit du Dateien für Dokumente auswählen kannst.
+    notConnectedDescription:
+      Um Dateien hochzuladen, musst du deinem Google Drive-Konto Zugriff
+      gewähren.
     connect: Google Drive verbinden
     reconnect: Google Drive erneut verbinden
     disconnect: Google Drive trennen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -2191,7 +2191,9 @@ documents:
       Choose how to import your {count} selected {count, plural,
       one {item} other {items}}.
     microsoftNotConnected: Connect Microsoft 365
-    microsoftNotConnectedDescription: Authorize OneDrive and SharePoint so you can pick files for Documents.
+    microsoftNotConnectedDescription:
+      To upload files, you'll need to grant access to your Microsoft 365
+      account.
     connect: Connect Microsoft 365
     reconnect: Reconnect Microsoft 365
     disconnect: Disconnect Microsoft 365
@@ -2224,7 +2226,8 @@ documents:
     title: Import from Google Drive
     selectDescription: Choose files or folders to import
     notConnected: Connect Google Drive
-    notConnectedDescription: Authorize Google Drive so you can pick files for Documents.
+    notConnectedDescription:
+      To upload files, you'll need to grant access to your Google Drive account.
     connect: Connect Google Drive
     reconnect: Reconnect Google Drive
     disconnect: Disconnect Google Drive

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -2294,8 +2294,8 @@ documents:
       {élément sélectionné} other {éléments sélectionnés}}.
     microsoftNotConnected: Connecter Microsoft 365
     microsoftNotConnectedDescription:
-      Autorise OneDrive et SharePoint pour choisir des fichiers à importer dans
-      Documents.
+      Pour importer des fichiers, tu dois autoriser l'accès à ton compte
+      Microsoft 365.
     connect: Connecter Microsoft 365
     reconnect: Reconnecter Microsoft 365
     disconnect: Déconnecter Microsoft 365
@@ -2330,7 +2330,9 @@ documents:
     title: Importer depuis Google Drive
     selectDescription: Choisis des fichiers ou des dossiers à importer
     notConnected: Connecter Google Drive
-    notConnectedDescription: Autorise Google Drive pour choisir des fichiers à importer dans Documents.
+    notConnectedDescription:
+      Pour importer des fichiers, tu dois autoriser l'accès à ton compte Google
+      Drive.
     connect: Connecter Google Drive
     reconnect: Reconnecter Google Drive
     disconnect: Déconnecter Google Drive


### PR DESCRIPTION
## Summary
- When Google Drive / Microsoft 365 cloud-import auth is inactive, open a dedicated connect dialog instead of the file picker
- Share the connect flow via `cloud-import-connect-dialog` and refresh not-connected copy (en/de/fr)

## Test plan
- [ ] Documents → Import from Google Drive while disconnected → connect dialog, then picker after auth
- [ ] Documents → Import from OneDrive while disconnected → same path
- [ ] Already-connected org opens the picker directly
- [ ] Disconnect buttons still work