### PR TITLE
feat(platform): all-projects Tasks board

### DIFF
--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -47,6 +47,11 @@ export interface TabNavigationItem {
    * outright over path matching.
    */
   isActive?: boolean;
+  /**
+   * When true the tab stays visible but is not navigable — used to teach that
+   * a mode (e.g. Tasks "All projects") only applies to the active surface.
+   */
+  disabled?: boolean;
   /** Optional trailing element rendered after the label (e.g. status badge) */
   trailing?: ReactNode;
   /**
@@ -122,7 +127,7 @@ export function TabNavigation({
   // (not to `scrollRef`) — see the indicator's JSX comment for why.
   const navRef = useRef<HTMLElement | null>(null);
   const indicatorRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const itemRefs = useRef<(HTMLElement | null)[]>([]);
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 0, left: 0 });
   // Track if we should animate (only after initial render)
   const [shouldAnimate, setShouldAnimate] = useState(false);
@@ -444,7 +449,9 @@ export function TabNavigation({
           type: 'item' as const,
           label: item.label,
           selected: isPathActive(item),
+          disabled: item.disabled,
           onClick: () => {
+            if (item.disabled) return;
             void navigate({ to: path, search: item.search ?? hrefSearch });
           },
         };
@@ -496,26 +503,16 @@ export function TabNavigation({
             const isItemDirty =
               dirtyKeys !== undefined &&
               (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false);
-
-            return (
-              <Link
-                // Search-param tab strips share one pathname across items, so
-                // the href alone is not unique — the label disambiguates.
-                key={`${item.href}|${item.label}`}
-                ref={(el) => {
-                  itemRefs.current[index] = el;
-                }}
-                to={path}
-                search={item.search ?? hrefSearch}
-                preload={prefetch ? 'render' : false}
-                aria-current={isActive ? 'page' : undefined}
-                className={cn(
-                  'relative flex h-full shrink-0 items-center justify-center gap-1.5 rounded-sm py-1 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:outline-none',
-                  isActive
-                    ? 'text-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
+            const tabClassName = cn(
+              'relative flex h-full shrink-0 items-center justify-center gap-1.5 rounded-sm py-1 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:outline-none',
+              item.disabled
+                ? 'text-muted-foreground/50 cursor-not-allowed'
+                : isActive
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+            );
+            const tabBody = (
+              <>
                 {isItemDirty && (
                   <>
                     <span
@@ -534,6 +531,39 @@ export function TabNavigation({
                 )}
                 {item.label}
                 {item.trailing}
+              </>
+            );
+
+            if (item.disabled) {
+              return (
+                <span
+                  key={`${item.href}|${item.label}`}
+                  ref={(el) => {
+                    itemRefs.current[index] = el;
+                  }}
+                  aria-disabled="true"
+                  className={tabClassName}
+                >
+                  {tabBody}
+                </span>
+              );
+            }
+
+            return (
+              <Link
+                // Search-param tab strips share one pathname across items, so
+                // the href alone is not unique — the label disambiguates.
+                key={`${item.href}|${item.label}`}
+                ref={(el) => {
+                  itemRefs.current[index] = el;
+                }}
+                to={path}
+                search={item.search ?? hrefSearch}
+                preload={prefetch ? 'render' : false}
+                aria-current={isActive ? 'page' : undefined}
+                className={tabClassName}
+              >
+                {tabBody}
               </Link>
             );
           })}

--- a/services/platform/app/features/projects/components/project-breadcrumb-switcher.test.tsx
+++ b/services/platform/app/features/projects/components/project-breadcrumb-switcher.test.tsx
@@ -81,10 +81,15 @@ describe('ProjectBreadcrumbSwitcher', () => {
     );
     await user.click(screen.getByRole('option', { name: 'Acme AG' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/dashboard/org-1/projects/proj-acme/files',
-      search: {},
-    });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/dashboard/org-1/projects/proj-acme/files',
+      }),
+    );
+    const call = mockNavigate.mock.calls[0]?.[0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(call.search({ projects: 'all' })).toEqual({});
   });
 
   it('does not navigate when the current project is chosen again', async () => {
@@ -120,6 +125,107 @@ describe('ProjectBreadcrumbSwitcher', () => {
       screen.queryByRole('button', { name: /switch project/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByText('Getting started')).toBeInTheDocument();
+  });
+
+  it('offers All projects on a Tasks path and sets projects=all', async () => {
+    mockLocation.pathname =
+      '/dashboard/org-1/projects/proj-getting-started/tasks/board';
+    const { user } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: getting started/i,
+      }),
+    );
+    expect(
+      screen.getByRole('option', { name: /all projects/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+    await user.click(screen.getByRole('option', { name: /all projects/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/dashboard/org-1/projects/proj-getting-started/tasks/board',
+      }),
+    );
+    const call = mockNavigate.mock.calls[0]?.[0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(call.search({})).toEqual({ projects: 'all' });
+  });
+
+  it('does not offer All projects off the Tasks path', async () => {
+    const { user } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: getting started/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('option', { name: 'All projects' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows All projects as the leaf when projects=all is active', async () => {
+    mockLocation.pathname =
+      '/dashboard/org-1/projects/proj-getting-started/tasks/board';
+    mockLocation.search = { projects: 'all' };
+    render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /switch project, current: all projects/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('All projects')).toBeInTheDocument();
+  });
+
+  it('clears projects=all when picking a concrete project', async () => {
+    mockLocation.pathname =
+      '/dashboard/org-1/projects/proj-getting-started/tasks/board';
+    mockLocation.search = { projects: 'all' };
+    const { user } = render(
+      <ProjectBreadcrumbSwitcher
+        organizationId="org-1"
+        projectId={CURRENT_ID}
+        projectName="Getting started"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /switch project, current: all projects/i,
+      }),
+    );
+    await user.click(screen.getByRole('option', { name: 'Acme AG' }));
+
+    const call = mockNavigate.mock.calls[0]?.[0] as {
+      to: string;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(call.to).toBe('/dashboard/org-1/projects/proj-acme/tasks/board');
+    expect(call.search({ projects: 'all', task: 't1' })).toEqual({
+      task: 't1',
+    });
   });
 
   it('passes an axe audit with the menu open', async () => {

--- a/services/platform/app/features/projects/components/project-breadcrumb-switcher.tsx
+++ b/services/platform/app/features/projects/components/project-breadcrumb-switcher.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { Badge } from '@tale/ui/badge';
 import { useLocation, useNavigate } from '@tanstack/react-router';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Layers } from 'lucide-react';
 import { useMemo } from 'react';
 
 import {
@@ -15,11 +16,26 @@ import { cn } from '@/lib/utils/cn';
 import { useProjects } from '../hooks/queries';
 import { projectSwitchPathname } from '../lib/project-switch-path';
 
+/** Sentinel value for the Tasks-only "All projects" aggregate scope. */
+export const ALL_PROJECTS_SWITCHER_VALUE = '__all_projects__';
+
+/** True when the pathname is a project Tasks view (board/list/alias). */
+export function isProjectTasksPath(
+  pathname: string,
+  projectId: string,
+): boolean {
+  const prefix = `/projects/${projectId}/tasks`;
+  return pathname.includes(prefix);
+}
+
 /**
  * Breadcrumb leaf for a project detail page: the current project name opens a
  * searchable switcher of sibling projects so the operator can jump between them
  * without returning to the Projects list. Portable tabs (files, tasks, …) stay
  * put; bound-view / nested-automation paths reset to the overview.
+ *
+ * On Tasks paths the menu also offers "All projects" — an aggregate board that
+ * disables the non-Tasks project tabs while active (`?projects=all`).
  */
 export function ProjectBreadcrumbSwitcher({
   organizationId,
@@ -35,53 +51,106 @@ export function ProjectBreadcrumbSwitcher({
   const location = useLocation();
   const { projects } = useProjects(organizationId);
 
-  const options = useMemo<SearchableSelectOption[]>(
-    () =>
-      projects.map((project) => ({
-        value: project._id,
-        label: project.name,
-      })),
-    [projects],
-  );
+  const onTasksPath = isProjectTasksPath(location.pathname, projectId);
+  const allProjectsActive =
+    onTasksPath &&
+    (location.search as { projects?: unknown }).projects === 'all';
+  const displayName = allProjectsActive
+    ? t('switcher.allProjects')
+    : projectName;
+
+  const options = useMemo<SearchableSelectOption[]>(() => {
+    const projectOptions = projects.map((project) => ({
+      value: project._id,
+      label: project.name,
+    }));
+    if (!onTasksPath) return projectOptions;
+    return [
+      {
+        value: ALL_PROJECTS_SWITCHER_VALUE,
+        label: t('switcher.allProjects'),
+        // Blue badge + Layers marks the aggregate scope as different from a
+        // named project row — the same icon appears on the breadcrumb trigger
+        // while the mode is active.
+        labelBadge: (
+          <Badge variant="blue" icon={Layers} className="py-0.5 text-[10px]">
+            {t('switcher.allProjectsBadge')}
+          </Badge>
+        ),
+      },
+      ...projectOptions,
+    ];
+  }, [projects, onTasksPath, t]);
 
   // Nothing to switch to yet (list still empty / loading) — keep the plain
-  // name so the h1 leaf stays readable without a dead chevron.
+  // name so the h1 leaf stays readable without a dead chevron. All-projects
+  // still needs the switcher once at least one sibling exists (or alone when
+  // the option is the only entry).
   if (options.length === 0) {
-    return <>{projectName}</>;
+    return <>{displayName}</>;
   }
+
+  const selectedValue = allProjectsActive
+    ? ALL_PROJECTS_SWITCHER_VALUE
+    : projectId;
 
   return (
     <SearchableSelect
       variant="switcher"
       align="start"
       contentClassName="min-w-64"
-      value={projectId}
+      value={selectedValue}
       options={options}
       title={t('switcher.title')}
       searchPlaceholder={t('switcher.searchPlaceholder')}
       emptyText={t('switcher.empty')}
-      aria-label={t('switcher.ariaLabel', { name: projectName })}
+      aria-label={t('switcher.ariaLabel', { name: displayName })}
       onValueChange={(nextId) => {
-        if (nextId === projectId) return;
+        if (nextId === selectedValue) return;
+
+        if (nextId === ALL_PROJECTS_SWITCHER_VALUE) {
+          void navigate({
+            to: location.pathname,
+            search: (prev) => ({
+              ...prev,
+              projects: 'all' as const,
+            }),
+          });
+          return;
+        }
+
         const to = projectSwitchPathname(
           location.pathname,
           organizationId,
           projectId,
           nextId,
         );
-        void navigate({ to, search: location.search });
+        void navigate({
+          to,
+          search: (prev) => {
+            const next = { ...prev };
+            delete next.projects;
+            return next;
+          },
+        });
       }}
       trigger={
         <button
           type="button"
-          aria-label={t('switcher.ariaLabel', { name: projectName })}
+          aria-label={t('switcher.ariaLabel', { name: displayName })}
           className={cn(
             'inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm',
             'hover:text-muted-foreground transition-colors',
             'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
           )}
         >
-          <span className="min-w-0 truncate">{projectName}</span>
+          {allProjectsActive && (
+            <Layers
+              className="text-muted-foreground size-4 shrink-0"
+              aria-hidden="true"
+            />
+          )}
+          <span className="min-w-0 truncate">{displayName}</span>
           <ChevronDown
             className="text-muted-foreground size-4 shrink-0"
             aria-hidden="true"

--- a/services/platform/app/features/tasks/components/task-board-context.tsx
+++ b/services/platform/app/features/tasks/components/task-board-context.tsx
@@ -8,7 +8,12 @@ import {
 } from '../lib/dependencies';
 import type { TaskDoc } from '../lib/display';
 
-type TaskRow = TaskDoc;
+/** Board row — TaskDoc plus optional stamps from list queries. */
+type TaskRow = TaskDoc & {
+  projectKey?: string;
+  folderExists?: boolean;
+  hasFiles?: boolean;
+};
 
 /** A task's pending review-gate approval, as the ops indicators expose it. */
 export interface PendingReviewRef {

--- a/services/platform/app/features/tasks/components/task-card.tsx
+++ b/services/platform/app/features/tasks/components/task-card.tsx
@@ -33,6 +33,8 @@ export type TaskRow = TaskDoc & {
    * `collectFolderFacts`) — absent on surfaces that don't stamp them. */
   folderExists?: boolean;
   hasFiles?: boolean;
+  /** Stamped by the all-projects board so cards show `KEY-123` per task. */
+  projectKey?: string;
 };
 
 export function TaskCard({
@@ -54,7 +56,8 @@ export function TaskCard({
   canEdit?: boolean;
 }) {
   const { t } = useT('tasks');
-  const identifier = formatTaskIdentifier(projectKey, task.number);
+  const resolvedProjectKey = task.projectKey ?? projectKey;
+  const identifier = formatTaskIdentifier(resolvedProjectKey, task.number);
   const assignTask = useAssignTask();
   const updateTask = useUpdateTask();
   const editable = canEdit && task.archivedAt == null;
@@ -83,7 +86,10 @@ export function TaskCard({
   // parent's title, then a generic label, when the id/parent isn't resolvable.
   const parent = task.parentTaskId ? getTask(task.parentTaskId) : undefined;
   const parentIdentifier = parent
-    ? formatTaskIdentifier(projectKey, parent.number)
+    ? formatTaskIdentifier(
+        parent.projectKey ?? resolvedProjectKey,
+        parent.number,
+      )
     : null;
   const parentLabel = parentIdentifier
     ? t('detail.partOf', { task: parentIdentifier })

--- a/services/platform/app/features/tasks/components/tasks-list.tsx
+++ b/services/platform/app/features/tasks/components/tasks-list.tsx
@@ -64,7 +64,7 @@ export function TasksList({
   // Collapsed status sections, persisted per project so a fold survives reloads.
   const [collapsedStatuses, setCollapsedStatuses] = usePersistedState<
     TaskStatus[]
-  >(`tale.platform.tasks.${projectKey ?? 'p'}.collapsedStatuses`, []);
+  >(`tale.platform.tasks.${projectKey ?? 'all'}.collapsedStatuses`, []);
   const collapsed = useMemo(
     () => new Set(collapsedStatuses),
     [collapsedStatuses],
@@ -261,7 +261,10 @@ function TaskListRow({
   canEdit?: boolean;
 }) {
   const { t } = useT('tasks');
-  const identifier = formatTaskIdentifier(projectKey, task.number);
+  const identifier = formatTaskIdentifier(
+    task.projectKey ?? projectKey,
+    task.number,
+  );
   const assignTask = useAssignTask();
   const updateTask = useUpdateTask();
   const blocked = useTaskBoardContext().isBlocked(task._id);

--- a/services/platform/app/features/tasks/components/tasks-workspace.tsx
+++ b/services/platform/app/features/tasks/components/tasks-workspace.tsx
@@ -16,6 +16,8 @@ import { useT } from '@/lib/i18n/client';
 import {
   useProjectDependencies,
   useTaskOpsIndicators,
+  useTaskOpsIndicatorsAcrossProjects,
+  useTasksAcrossProjects,
   useTasksByProject,
 } from '../hooks/queries';
 import { useActorDirectory } from '../hooks/use-actor-directory';
@@ -50,6 +52,7 @@ export function TasksWorkspace({
   onViewChange,
   openTaskParam,
   onOpenTaskParamChange,
+  allProjects = false,
 }: {
   organizationId: string;
   projectId: string;
@@ -62,6 +65,8 @@ export function TasksWorkspace({
   openTaskParam?: string;
   /** Keeps the URL in sync so open tasks are shareable/linkable. */
   onOpenTaskParamChange?: (taskId: string | null) => void;
+  /** Cross-project aggregate scope (`?projects=all`). */
+  allProjects?: boolean;
 }) {
   const { t } = useT('tasks');
   const typedProjectId = asProjectId(projectId);
@@ -72,24 +77,44 @@ export function TasksWorkspace({
   const [needsMyReviewFilter, setNeedsMyReviewFilter] = useState(false);
   const { members, agents, currentUserId } = useActorDirectory(
     organizationId,
-    projectId,
+    // Agents are project-scoped; in all-projects mode the filter still lists
+    // org members, and agent assignees resolve via the directory without a
+    // project agent catalog.
+    allProjects ? undefined : projectId,
   );
   const assigneeQueryFilter = resolveAssigneeQueryFilter(
     assigneeFilter,
     currentUserId,
   );
-  const {
-    tasks: loadedTasks,
-    canEdit,
-    isLoading,
-  } = useTasksByProject(typedProjectId, {
+  const listOptions = {
     statuses: BOARD_TASK_STATUSES,
     includeArchived,
     assigneeId: assigneeQueryFilter,
+  };
+  const projectList = useTasksByProject(
+    allProjects ? undefined : typedProjectId,
+    listOptions,
+  );
+  const acrossList = useTasksAcrossProjects({
+    ...listOptions,
+    enabled: allProjects,
   });
-  const { edges } = useProjectDependencies(typedProjectId);
-  const { runningTaskIds, pendingReviews } =
-    useTaskOpsIndicators(typedProjectId);
+  const loadedTasks = allProjects ? acrossList.tasks : projectList.tasks;
+  const canEdit = allProjects ? acrossList.canEdit : projectList.canEdit;
+  const isLoading = allProjects ? acrossList.isLoading : projectList.isLoading;
+  const { edges } = useProjectDependencies(
+    allProjects ? undefined : typedProjectId,
+  );
+  const projectOps = useTaskOpsIndicators(
+    allProjects ? undefined : typedProjectId,
+  );
+  const acrossOps = useTaskOpsIndicatorsAcrossProjects(allProjects);
+  const runningTaskIds = allProjects
+    ? acrossOps.runningTaskIds
+    : projectOps.runningTaskIds;
+  const pendingReviews = allProjects
+    ? acrossOps.pendingReviews
+    : projectOps.pendingReviews;
   const reviewRequestedFor = useMemo(
     () =>
       new Map(
@@ -119,25 +144,38 @@ export function TasksWorkspace({
     ],
   );
   const { project } = useProject(typedProjectId);
-  const projectKey = project?.key ?? null;
+  const projectKey = allProjects ? null : (project?.key ?? null);
 
   const [createOpen, setCreateOpen] = useState(false);
   const [openTaskId, setOpenTaskIdState] = useState(
     openTaskParam ? asTaskId(openTaskParam) : null,
   );
+  // When opening from the all-projects board, the modal must target the row's
+  // real project — not the route anchor.
+  const [openTaskProjectId, setOpenTaskProjectId] =
+    useState<Id<'projects'>>(typedProjectId);
   // Re-sync from the URL when `?task=` changes while mounted (e.g. an inbox
   // link clicked from this page) — render-time state adjustment, no effect.
   const [prevOpenTaskParam, setPrevOpenTaskParam] = useState(openTaskParam);
   if (openTaskParam !== prevOpenTaskParam) {
     setPrevOpenTaskParam(openTaskParam);
     setOpenTaskIdState(openTaskParam ? asTaskId(openTaskParam) : null);
+    if (openTaskParam) {
+      const fromRow = loadedTasks.find((task) => task._id === openTaskParam);
+      if (fromRow) setOpenTaskProjectId(fromRow.projectId);
+    }
   }
-  const setOpenTaskId = (taskId: Id<'tasks'> | null) => {
+  const setOpenTaskId = (
+    taskId: Id<'tasks'> | null,
+    taskProjectId?: Id<'projects'>,
+  ) => {
     setOpenTaskIdState(taskId);
+    if (taskProjectId) setOpenTaskProjectId(taskProjectId);
     onOpenTaskParamChange?.(taskId);
   };
 
-  const handleOpenTask = (task: TaskRow) => setOpenTaskId(task._id);
+  const handleOpenTask = (task: TaskRow) =>
+    setOpenTaskId(task._id, task.projectId);
 
   const handleAssigneeFilterChange = useCallback((values: string[]) => {
     setAssigneeFilter(values[0] ?? ALL_ASSIGNEE_FILTER);
@@ -290,7 +328,8 @@ export function TasksWorkspace({
         </Row>
         <Row gap={2}>
           {/* Read-only viewers can't create tasks (the server rejects the
-              write); hide the action rather than surface a doomed button. */}
+              write); hide the action rather than surface a doomed button.
+              All-projects mode has no single write target — Create stays off. */}
           {canEdit && (
             <Button size="sm" icon={Plus} onClick={() => setCreateOpen(true)}>
               {t('actions.create')}
@@ -335,25 +374,27 @@ export function TasksWorkspace({
         </TaskBoardProvider>
       )}
 
+      {!allProjects && (
+        <TaskModal
+          organizationId={organizationId}
+          projectId={typedProjectId}
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          defaultStatus="todo"
+          // A template create lands the user inside the new task, where the
+          // subject panel names the next step (upload input files / Start).
+          onOpenTask={(id) => setOpenTaskId(id, typedProjectId)}
+        />
+      )}
       <TaskModal
         organizationId={organizationId}
-        projectId={typedProjectId}
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-        defaultStatus="todo"
-        // A template create lands the user inside the new task, where the
-        // subject panel names the next step (upload input files / Start).
-        onOpenTask={(id) => setOpenTaskId(id)}
-      />
-      <TaskModal
-        organizationId={organizationId}
-        projectId={typedProjectId}
+        projectId={openTaskProjectId}
         taskId={openTaskId}
         open={openTaskId !== null}
         onOpenChange={(open) => {
           if (!open) setOpenTaskId(null);
         }}
-        onOpenTask={(id) => setOpenTaskId(id)}
+        onOpenTask={(id) => setOpenTaskId(id, openTaskProjectId)}
       />
     </ContentArea>
   );

--- a/services/platform/app/features/tasks/hooks/queries.ts
+++ b/services/platform/app/features/tasks/hooks/queries.ts
@@ -45,6 +45,37 @@ export function useTasksByProject(
   };
 }
 
+/** All-projects board: every task in projects the caller can read. */
+export function useTasksAcrossProjects(options?: {
+  includeArchived?: boolean;
+  status?: TaskStatusFilter;
+  statuses?: TaskStatusFilter[];
+  assigneeId?: string;
+  /** When false the query is skipped (single-project mode owns the board). */
+  enabled?: boolean;
+}) {
+  const organizationId = useOrganizationId();
+  const enabled = options?.enabled !== false;
+  const { data, isLoading } = useConvexQuery(
+    api.tasks.queries.listTasksForAccessibleProjects,
+    enabled && organizationId
+      ? {
+          organizationId,
+          includeArchived: options?.includeArchived,
+          status: options?.status,
+          statuses: options?.statuses,
+          assigneeId: options?.assigneeId,
+        }
+      : 'skip',
+  );
+  return {
+    tasks: data?.tasks ?? [],
+    truncated: data?.truncated ?? false,
+    canEdit: data?.canEdit ?? false,
+    isLoading,
+  };
+}
+
 export function useTask(taskId: Id<'tasks'> | undefined) {
   const organizationId = useOrganizationId();
   const { data, isLoading } = useConvexQuery(
@@ -134,6 +165,19 @@ export function useTaskOpsIndicators(projectId: Id<'projects'> | undefined) {
     runningTaskIds: data?.runningTaskIds ?? [],
     // Full pending-review refs (taskId + the reviewer waited on) — the board
     // chip naming and the needs-my-review facet both read `requestedFor`.
+    pendingReviews: data?.pendingReviews ?? [],
+  };
+}
+
+/** All-projects sibling of {@link useTaskOpsIndicators}. */
+export function useTaskOpsIndicatorsAcrossProjects(enabled = true) {
+  const organizationId = useOrganizationId();
+  const { data } = useConvexQuery(
+    api.tasks.queries.getTaskOpsIndicatorsForAccessibleProjects,
+    enabled && organizationId ? { organizationId } : 'skip',
+  );
+  return {
+    runningTaskIds: data?.runningTaskIds ?? [],
     pendingReviews: data?.pendingReviews ?? [],
   };
 }

--- a/services/platform/app/features/tasks/lib/view.ts
+++ b/services/platform/app/features/tasks/lib/view.ts
@@ -53,11 +53,24 @@ export function persistTaskView(projectId: string, view: TaskView): void {
   }
 }
 
-/** `?task=<id>` deep-link param shared by every tasks route (board, list,
- *  index redirect) — task URLs stay shareable across the view split. */
+/** `?task=<id>` deep-link + optional `?projects=all` aggregate scope — shared
+ *  by every tasks route (board, list, index redirect). */
 export function validateTaskSearch(search: Record<string, unknown>): {
   task?: string;
+  projects?: 'all';
 } {
-  const task = search.task;
-  return typeof task === 'string' && task.length > 0 ? { task } : {};
+  const task =
+    typeof search.task === 'string' && search.task.length > 0
+      ? search.task
+      : undefined;
+  const projects = search.projects === 'all' ? ('all' as const) : undefined;
+  return {
+    ...(task !== undefined ? { task } : {}),
+    ...(projects !== undefined ? { projects } : {}),
+  };
+}
+
+/** True when the Tasks board/list is in the cross-project aggregate scope. */
+export function isAllProjectsSearch(search: { projects?: 'all' }): boolean {
+  return search.projects === 'all';
 }

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.test.tsx
@@ -13,9 +13,13 @@ import { render, screen } from '@/tests/utils/render';
 // the org Automations page.
 // ---------------------------------------------------------------------------
 
-const { mockUseAutomations, mockUseProject } = vi.hoisted(() => ({
+const { mockUseAutomations, mockUseProject, mockLocation } = vi.hoisted(() => ({
   mockUseAutomations: vi.fn(),
   mockUseProject: vi.fn(),
+  mockLocation: {
+    pathname: '/dashboard/org-1/projects/proj-1',
+    search: {} as Record<string, unknown>,
+  },
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -28,6 +32,8 @@ vi.mock('@tanstack/react-router', () => ({
     <a href={to}>{children}</a>
   ),
   useMatch: () => undefined,
+  useLocation: () => mockLocation,
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock('@/lib/i18n/client', () => ({
@@ -46,6 +52,8 @@ vi.mock(
   '@/app/features/projects/components/project-breadcrumb-switcher',
   () => ({
     ProjectBreadcrumbSwitcher: () => <span>Apollo</span>,
+    isProjectTasksPath: (pathname: string, projectId: string) =>
+      pathname.includes(`/projects/${projectId}/tasks`),
   }),
 );
 
@@ -88,18 +96,26 @@ vi.mock('@/app/components/ui/editor', () => ({
 }));
 
 // Render the tab strip as plain links so the test reads what a user would see.
+// Disabled tabs render as spans (mirroring TabNavigation) so All-projects
+// mode can be asserted without the real nav primitive.
 vi.mock('@/app/components/ui/navigation/tab-navigation', () => ({
   TabNavigation: ({
     items,
   }: {
-    items: Array<{ label: string; href: string }>;
+    items: Array<{ label: string; href: string; disabled?: boolean }>;
   }) => (
     <nav>
-      {items.map((item) => (
-        <a key={item.href} href={item.href}>
-          {item.label}
-        </a>
-      ))}
+      {items.map((item) =>
+        item.disabled ? (
+          <span key={item.href} aria-disabled="true">
+            {item.label}
+          </span>
+        ) : (
+          <a key={item.href} href={item.href}>
+            {item.label}
+          </a>
+        ),
+      )}
     </nav>
   ),
 }));
@@ -127,6 +143,8 @@ function setup(automations: unknown[] | undefined) {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  mockLocation.pathname = '/dashboard/org-1/projects/proj-1';
+  mockLocation.search = {};
 });
 
 describe('project shell — Automations tab', () => {
@@ -173,6 +191,29 @@ describe('project shell — Automations tab', () => {
       'projects.navigation.agents',
     ]) {
       expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+  });
+});
+
+describe('project shell — All projects Tasks mode', () => {
+  it('disables non-Tasks tabs while projects=all is active', () => {
+    mockLocation.pathname = '/dashboard/org-1/projects/proj-1/tasks/board';
+    mockLocation.search = { projects: 'all' };
+    setup([]);
+
+    expect(
+      screen.getByRole('link', { name: 'tasks.title' }),
+    ).toBeInTheDocument();
+    for (const label of [
+      'projects.navigation.overview',
+      'projects.navigation.threads',
+      'projects.navigation.files',
+      'projects.navigation.agents',
+    ]) {
+      expect(
+        screen.queryByRole('link', { name: label }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(label)).toHaveAttribute('aria-disabled', 'true');
     }
   });
 });

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
@@ -6,9 +6,11 @@ import {
   createFileRoute,
   Link,
   Outlet,
+  useLocation,
   useMatch,
+  useNavigate,
 } from '@tanstack/react-router';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { AdaptiveHeaderRoot } from '@/app/components/layout/adaptive-header';
 import { ContentArea } from '@/app/components/layout/content-area';
@@ -27,7 +29,10 @@ import {
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
 import { useAutomations } from '@/app/features/automations/hooks/queries';
-import { ProjectBreadcrumbSwitcher } from '@/app/features/projects/components/project-breadcrumb-switcher';
+import {
+  isProjectTasksPath,
+  ProjectBreadcrumbSwitcher,
+} from '@/app/features/projects/components/project-breadcrumb-switcher';
 import { useProject } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
 import { api } from '@/convex/_generated/api';
@@ -76,6 +81,8 @@ function ProjectDetailLayout() {
   const { t: tTasks } = useT('tasks');
   const { t: tSecrets } = useT('projectSecrets');
   const { t: tAutomations } = useT('automations');
+  const location = useLocation();
+  const navigate = useNavigate();
 
   // Project-scoped automation DETAIL routes live under the AUTOMATIONS chrome
   // (`AutomationDetailShell` — "Automations / <name>" breadcrumb + its own
@@ -106,6 +113,29 @@ function ProjectDetailLayout() {
   // the list is deliberately empty and the views route is retired.
   const viewTabs = EMPTY_VIEW_TABS;
 
+  const allProjectsMode =
+    (location.search as { projects?: unknown }).projects === 'all';
+  const onTasksPath = isProjectTasksPath(location.pathname, projectId);
+
+  // Stale `?projects=all` on a non-Tasks child (bookmark / manual URL) — send
+  // the operator to the Tasks board so the disabled sibling tabs stay coherent.
+  useEffect(() => {
+    if (!allProjectsMode || onTasksPath || isAutomationDetail) return;
+    void navigate({
+      to: '/dashboard/$id/projects/$projectId/tasks/board',
+      params: { id: organizationId, projectId },
+      search: { projects: 'all' },
+      replace: true,
+    });
+  }, [
+    allProjectsMode,
+    onTasksPath,
+    isAutomationDetail,
+    navigate,
+    organizationId,
+    projectId,
+  ]);
+
   // Memoize the tabs array — `TabNavigation` feeds it through a chain of
   // memos that bottom out at a `ResizeObserver` effect; a fresh array every
   // render kicks that effect (and the observer it owns) every render.
@@ -115,11 +145,13 @@ function ProjectDetailLayout() {
         label: t('navigation.overview'),
         href: `/dashboard/${organizationId}/projects/${projectId}`,
         matchMode: 'exact',
+        disabled: allProjectsMode,
       },
       {
         label: t('navigation.threads'),
         href: `/dashboard/${organizationId}/projects/${projectId}/threads`,
         matchMode: 'exact',
+        disabled: allProjectsMode,
       },
       {
         label: tTasks('title'),
@@ -127,20 +159,28 @@ function ProjectDetailLayout() {
         matchMode: 'exact',
         // The per-view pages (/tasks/board, /tasks/list — prefix-matched via
         // the bare /tasks entry) and the project metrics page are sub-views
-        // of Tasks, so keep the tab highlighted there.
+        // of Tasks, so keep the tab highlighted there. Metrics stays
+        // project-scoped — when All projects is on, that path is redirected
+        // away, so the highlight only covers board/list.
         additionalActivePaths: [
           `/dashboard/${organizationId}/projects/${projectId}/tasks`,
-          `/dashboard/${organizationId}/projects/${projectId}/metrics`,
+          ...(allProjectsMode
+            ? []
+            : [`/dashboard/${organizationId}/projects/${projectId}/metrics`]),
         ],
+        search: allProjectsMode ? { projects: 'all' } : undefined,
       },
       {
         label: t('navigation.files'),
         href: `/dashboard/${organizationId}/projects/${projectId}/files`,
         matchMode: 'exact',
+        disabled: allProjectsMode,
       },
       // Bound automations' views as first-class tabs (1 view = 1 tab) —
       // the operator surfaces, ahead of the management tabs below.
-      ...viewTabs,
+      ...viewTabs.map((tab) =>
+        allProjectsMode ? { ...tab, disabled: true } : tab,
+      ),
       // Automations bound to THIS project. Shown only when there are any:
       // tasks remain the day-to-day automation interface (status verbs run the
       // workflow, approvals and input files live in the task modal), so a
@@ -153,6 +193,7 @@ function ProjectDetailLayout() {
               label: tAutomations('title'),
               href: `/dashboard/${organizationId}/projects/${projectId}/automations`,
               matchMode: 'exact' as const,
+              disabled: allProjectsMode,
             },
           ]
         : []),
@@ -160,6 +201,7 @@ function ProjectDetailLayout() {
         label: t('navigation.agents'),
         href: `/dashboard/${organizationId}/projects/${projectId}/agents`,
         matchMode: 'exact',
+        disabled: allProjectsMode,
       },
       // Secrets are administer-only data — even the secret *names* are
       // sensitive (per the query doc comment). Hide the tab from non-admin
@@ -172,6 +214,7 @@ function ProjectDetailLayout() {
               label: tSecrets('title'),
               href: `/dashboard/${organizationId}/projects/${projectId}/secrets`,
               matchMode: 'exact' as const,
+              disabled: allProjectsMode,
             },
           ]
         : []),
@@ -189,6 +232,7 @@ function ProjectDetailLayout() {
       project?.canAdminister,
       hasAutomations,
       viewTabs,
+      allProjectsMode,
     ],
   );
 

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/tasks/board.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/tasks/board.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { TasksPageSkeleton } from '@/app/features/tasks/components/tasks-skeleton';
 import {
+  isAllProjectsSearch,
   persistTaskView,
   TASK_VIEW_ROUTES,
   type TaskView,
@@ -26,6 +27,7 @@ export const Route = createFileRoute(
 )({
   // `?task=<id>` deep-links straight into a task's detail sheet — shareable
   // task URLs, and the target of inbox/notification links (review requests).
+  // `?projects=all` is the cross-project aggregate scope.
   validateSearch: validateTaskSearch,
   // Warm the TasksWorkspace chunk during the loader so it's cached by render
   // time — removes the Suspense fallback flash on first nav. The project tab
@@ -38,8 +40,9 @@ export const Route = createFileRoute(
 
 function TasksBoardPage() {
   const { id: organizationId, projectId } = Route.useParams();
-  const { task } = Route.useSearch();
+  const search = Route.useSearch();
   const navigate = Route.useNavigate();
+  const allProjects = isAllProjectsSearch(search);
 
   // Remember the last-visited view so the bare `/tasks` alias reopens it.
   useEffect(() => persistTaskView(projectId, 'board'), [projectId]);
@@ -49,6 +52,7 @@ function TasksBoardPage() {
       organizationId={organizationId}
       projectId={projectId}
       view="board"
+      allProjects={allProjects}
       onViewChange={(next: TaskView) => {
         void navigate({
           to: TASK_VIEW_ROUTES[next],
@@ -56,10 +60,15 @@ function TasksBoardPage() {
           search: (prev) => prev,
         });
       }}
-      openTaskParam={task}
+      openTaskParam={search.task}
       onOpenTaskParamChange={(taskId: string | null) => {
         void navigate({
-          search: taskId ? { task: taskId } : {},
+          search: (prev) => {
+            const next = { ...prev };
+            if (taskId) next.task = taskId;
+            else delete next.task;
+            return next;
+          },
           replace: true,
         });
       }}

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/tasks/list.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/tasks/list.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { TasksPageSkeleton } from '@/app/features/tasks/components/tasks-skeleton';
 import {
+  isAllProjectsSearch,
   persistTaskView,
   TASK_VIEW_ROUTES,
   type TaskView,
@@ -26,6 +27,7 @@ export const Route = createFileRoute(
 )({
   // `?task=<id>` deep-links straight into a task's detail sheet — shareable
   // task URLs, and the target of inbox/notification links (review requests).
+  // `?projects=all` is the cross-project aggregate scope.
   validateSearch: validateTaskSearch,
   // Warm the TasksWorkspace chunk during the loader so it's cached by render
   // time — removes the Suspense fallback flash on first nav. The project tab
@@ -38,8 +40,9 @@ export const Route = createFileRoute(
 
 function TasksListPage() {
   const { id: organizationId, projectId } = Route.useParams();
-  const { task } = Route.useSearch();
+  const search = Route.useSearch();
   const navigate = Route.useNavigate();
+  const allProjects = isAllProjectsSearch(search);
 
   // Remember the last-visited view so the bare `/tasks` alias reopens it.
   useEffect(() => persistTaskView(projectId, 'list'), [projectId]);
@@ -49,6 +52,7 @@ function TasksListPage() {
       organizationId={organizationId}
       projectId={projectId}
       view="list"
+      allProjects={allProjects}
       onViewChange={(next: TaskView) => {
         void navigate({
           to: TASK_VIEW_ROUTES[next],
@@ -56,10 +60,15 @@ function TasksListPage() {
           search: (prev) => prev,
         });
       }}
-      openTaskParam={task}
+      openTaskParam={search.task}
       onOpenTaskParamChange={(taskId: string | null) => {
         void navigate({
-          search: taskId ? { task: taskId } : {},
+          search: (prev) => {
+            const next = { ...prev };
+            if (taskId) next.task = taskId;
+            else delete next.task;
+            return next;
+          },
           replace: true,
         });
       }}

--- a/services/platform/convex/tasks/pending_reviews.ts
+++ b/services/platform/convex/tasks/pending_reviews.ts
@@ -28,7 +28,25 @@ export async function collectPendingReviewsByTask(
   organizationId: string,
   projectId: Id<'projects'>,
 ): Promise<Map<string, PendingTaskReviewRef>> {
+  return collectPendingReviewsForProjects(
+    ctx,
+    organizationId,
+    new Set([String(projectId)]),
+  );
+}
+
+/**
+ * Pending review-gate approvals whose `metadata.projectId` is in the given
+ * set (string form). Used by the all-projects board so "Needs my review"
+ * spans every project the caller can read.
+ */
+export async function collectPendingReviewsForProjects(
+  ctx: Pick<QueryCtx, 'db'>,
+  organizationId: string,
+  projectIds: ReadonlySet<string>,
+): Promise<Map<string, PendingTaskReviewRef>> {
   const byTask = new Map<string, PendingTaskReviewRef>();
+  if (projectIds.size === 0) return byTask;
   for await (const approval of ctx.db
     .query('approvals')
     .withIndex('by_org_status_resourceType', (q) =>
@@ -39,7 +57,12 @@ export async function collectPendingReviewsByTask(
     )) {
     const metadata: unknown = approval.metadata;
     if (!isRecord(metadata)) continue;
-    if (metadata.projectId !== String(projectId)) continue;
+    if (
+      typeof metadata.projectId !== 'string' ||
+      !projectIds.has(metadata.projectId)
+    ) {
+      continue;
+    }
     const requestedFor =
       typeof metadata.requestedFor === 'string' && metadata.requestedFor !== ''
         ? metadata.requestedFor

--- a/services/platform/convex/tasks/queries.test.ts
+++ b/services/platform/convex/tasks/queries.test.ts
@@ -400,3 +400,134 @@ describe('listOpenExternalTaskRefs', () => {
     expect(refs.every((r) => typeof r.taskId === 'string')).toBe(true);
   });
 });
+
+describe('listTasksForAccessibleProjects', () => {
+  async function seedTeam(t: T, userId: string, teamId: string): Promise<void> {
+    await t.run((ctx) =>
+      ctx.db.insert('teamMemberMirror', {
+        teamMemberId: `tm_${userId}_${teamId}`,
+        userId,
+        teamId,
+        createdAt: 0,
+      }),
+    );
+  }
+
+  it('returns tasks from every accessible project and stamps projectKey', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'user_editor', 'editor');
+    const projectA = await t.run((ctx) =>
+      ctx.db.insert('projects', {
+        organizationId: ORG,
+        name: 'A',
+        key: 'AAA',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      }),
+    );
+    const projectB = await t.run((ctx) =>
+      ctx.db.insert('projects', {
+        organizationId: ORG,
+        name: 'B',
+        key: 'BBB',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      }),
+    );
+    await seedTask(t, projectA);
+    await seedTask(t, projectB);
+
+    const result = await t
+      .withIdentity({ subject: 'user_editor' })
+      .query(api.tasks.queries.listTasksForAccessibleProjects, {
+        organizationId: ORG,
+      });
+    expect(result.canEdit).toBe(false);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks.map((task) => task.projectKey).sort()).toEqual([
+      'AAA',
+      'BBB',
+    ]);
+  });
+
+  it('excludes tasks in team-private projects the caller cannot read', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'user_member', 'member');
+    const open = await seedProject(t, 'Open');
+    const hidden = await t.run((ctx) =>
+      ctx.db.insert('projects', {
+        organizationId: ORG,
+        name: 'Hidden',
+        teamId: 'team_hidden',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      }),
+    );
+    const openTask = await seedTask(t, open);
+    await seedTask(t, hidden);
+
+    const result = await t
+      .withIdentity({ subject: 'user_member' })
+      .query(api.tasks.queries.listTasksForAccessibleProjects, {
+        organizationId: ORG,
+      });
+    expect(result.tasks.map((task) => task._id)).toEqual([openTask]);
+  });
+
+  it('includes team-private tasks when the caller is on that team', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'user_member', 'member');
+    await seedTeam(t, 'user_member', 'team_hidden');
+    const hidden = await t.run((ctx) =>
+      ctx.db.insert('projects', {
+        organizationId: ORG,
+        name: 'Hidden',
+        teamId: 'team_hidden',
+        createdBy: 'user_1',
+        createdAt: 0,
+        updatedAt: 0,
+      }),
+    );
+    const taskId = await seedTask(t, hidden);
+
+    const result = await t
+      .withIdentity({ subject: 'user_member' })
+      .query(api.tasks.queries.listTasksForAccessibleProjects, {
+        organizationId: ORG,
+      });
+    expect(result.tasks.map((task) => task._id)).toEqual([taskId]);
+  });
+
+  it('honours the statuses facet', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'user_editor', 'editor');
+    const projectId = await seedProject(t, 'A');
+    await t.run(async (ctx) => {
+      for (const status of ['todo', 'done'] as const) {
+        await ctx.db.insert('tasks', {
+          organizationId: ORG,
+          projectId,
+          title: status,
+          status,
+          rank: 'a0',
+          number: 1,
+          createdBy: 'user_1',
+          createdByType: 'user',
+          createdAt: 0,
+          updatedAt: 0,
+        });
+      }
+    });
+
+    const result = await t
+      .withIdentity({ subject: 'user_editor' })
+      .query(api.tasks.queries.listTasksForAccessibleProjects, {
+        organizationId: ORG,
+        statuses: ['todo'],
+      });
+    expect(result.tasks.map((task) => task.status)).toEqual(['todo']);
+  });
+});

--- a/services/platform/convex/tasks/queries.test.ts
+++ b/services/platform/convex/tasks/queries.test.ts
@@ -446,10 +446,11 @@ describe('listTasksForAccessibleProjects', () => {
       });
     expect(result.canEdit).toBe(false);
     expect(result.tasks).toHaveLength(2);
-    expect(result.tasks.map((task) => task.projectKey).sort()).toEqual([
-      'AAA',
-      'BBB',
-    ]);
+    expect(
+      result.tasks
+        .map((task) => task.projectKey)
+        .sort((a, b) => String(a).localeCompare(String(b))),
+    ).toEqual(['AAA', 'BBB']);
   });
 
   it('excludes tasks in team-private projects the caller cannot read', async () => {

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -23,11 +23,14 @@ import { UnauthorizedError } from '../lib/rls/errors';
 import { assertActiveOrg } from '../lib/rls/organization/assert_active_org';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { sessionOpTimelinePartValidator } from '../sandbox/sessions_schema';
-import { canClaimTask, checkProjectAccess } from './access';
+import { canClaimTask, checkProjectAccess, hasProjectAccess } from './access';
 import { taskLabelDto } from './helpers';
 import { readTaskDiscussionMessages } from './internal_queries';
 import { listTasksByProjectPaginated as listTasksByProjectPaginatedHelper } from './list_tasks_paginated';
-import { collectPendingReviewsByTask } from './pending_reviews';
+import {
+  collectPendingReviewsByTask,
+  collectPendingReviewsForProjects,
+} from './pending_reviews';
 import {
   boardViewFiltersValidator,
   boardViewScopeValidator,
@@ -273,6 +276,10 @@ export const taskRowValidator = v.object({
   // reads.
   folderExists: v.optional(v.boolean()),
   hasFiles: v.optional(v.boolean()),
+  // Stamped by the all-projects board so cards can show `KEY-123` without a
+  // second project lookup. Absent on single-project list reads (the shell
+  // already knows the key).
+  projectKey: v.optional(v.string()),
 });
 
 /**
@@ -556,6 +563,134 @@ export const listTasksByProject = query({
       truncated,
       canEdit,
     };
+  },
+});
+
+/**
+ * The caller's readable projects in an org, as an id set + optional key map.
+ * Same access path as `listProjects` (`hasProjectAccess`); archived projects
+ * are excluded so the all-projects board matches the switcher's live set.
+ */
+async function collectAccessibleProjectMeta(
+  ctx: QueryCtx,
+  organizationId: string,
+  auth: { role: string; teamIds: string[] },
+): Promise<{
+  projectIds: Set<string>;
+  projectKeys: Map<string, string | undefined>;
+}> {
+  const projectIds = new Set<string>();
+  const projectKeys = new Map<string, string | undefined>();
+  for await (const row of ctx.db
+    .query('projects')
+    .withIndex('by_organization_archived', (q) =>
+      q.eq('organizationId', organizationId).eq('archivedAt', undefined),
+    )) {
+    if (!hasProjectAccess(row, auth.teamIds, auth.role)) continue;
+    const id = String(row._id);
+    projectIds.add(id);
+    projectKeys.set(id, row.key);
+  }
+  return { projectIds, projectKeys };
+}
+
+/**
+ * Org-wide task board for every project the caller can read. Sibling of
+ * {@link listTasksByProject} used when the Tasks switcher is on "All projects".
+ * Walks `by_org_updatedAt` newest-first so the {@link TASK_BOARD_CAP} prefers
+ * recently touched work; filters to the caller's accessible project set
+ * (unlike Apps-hub `listTasksByOrg`, which is membership-only). Always returns
+ * `canEdit: false` — the aggregate view has no single write target.
+ */
+export const listTasksForAccessibleProjects = query({
+  args: {
+    organizationId: v.string(),
+    includeArchived: v.optional(v.boolean()),
+    status: v.optional(taskStatusValidator),
+    statuses: v.optional(v.array(taskStatusValidator)),
+    assigneeId: v.optional(v.string()),
+  },
+  returns: v.object({
+    tasks: v.array(taskRowValidator),
+    truncated: v.boolean(),
+    canEdit: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    // getAuthContext resolves org membership (and throws UNAUTHENTICATED /
+    // not-a-member); the organizationId arg IS the caller's active org from
+    // the client, matching every other board read.
+    const auth = await getAuthContext(ctx, args.organizationId);
+    const { projectIds, projectKeys } = await collectAccessibleProjectMeta(
+      ctx,
+      args.organizationId,
+      auth,
+    );
+    if (projectIds.size === 0) {
+      return { tasks: [], truncated: false, canEdit: false };
+    }
+
+    const rows: Doc<'tasks'>[] = [];
+    let truncated = false;
+    for await (const task of ctx.db
+      .query('tasks')
+      .withIndex('by_org_updatedAt', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )
+      .order('desc')) {
+      if (!projectIds.has(String(task.projectId))) continue;
+      if (!args.includeArchived && task.archivedAt) continue;
+      if (args.status && task.status !== args.status) continue;
+      if (args.statuses && !args.statuses.includes(task.status)) continue;
+      if (args.assigneeId && task.assigneeId !== args.assigneeId) continue;
+      rows.push(task);
+      if (rows.length >= TASK_BOARD_CAP) {
+        truncated = true;
+        break;
+      }
+    }
+
+    rows.sort((a, b) =>
+      a.status === b.status
+        ? a.rank.localeCompare(b.rank)
+        : a.status.localeCompare(b.status),
+    );
+
+    // Folder facts are per-project — group the page, stamp, then merge.
+    const byProject = new Map<Id<'projects'>, Doc<'tasks'>[]>();
+    for (const task of rows) {
+      const group = byProject.get(task.projectId);
+      if (group) group.push(task);
+      else byProject.set(task.projectId, [task]);
+    }
+    const folderExists = new Set<string>();
+    const foldersWithFiles = new Set<string>();
+    for (const [projectId, projectRows] of byProject) {
+      const facts = await collectFolderFacts(
+        ctx,
+        args.organizationId,
+        projectId,
+        projectRows,
+      );
+      for (const id of facts.existingFolders) folderExists.add(id);
+      for (const id of facts.foldersWithFiles) foldersWithFiles.add(id);
+    }
+
+    const labelCache = new Map<Id<'taskLabels'>, Doc<'taskLabels'> | null>();
+    const tasks = await Promise.all(
+      rows.map(async (task) => {
+        const resolved = await withResolvedLabels(ctx, task, labelCache);
+        const key = projectKeys.get(String(task.projectId));
+        return Object.assign(resolved, {
+          folderExists:
+            task.externalId === undefined || folderExists.has(task.externalId),
+          hasFiles:
+            task.externalId !== undefined &&
+            foldersWithFiles.has(task.externalId),
+          ...(key !== undefined ? { projectKey: key } : {}),
+        });
+      }),
+    );
+    return { tasks, truncated, canEdit: false };
   },
 });
 
@@ -997,6 +1132,19 @@ const TASK_OPS_INDICATOR_CAP = 50;
  * at the head of the by-project ordering. */
 const TASK_OPS_RUN_SCAN_CAP = 100;
 
+const taskOpsIndicatorsReturnValidator = v.object({
+  runningTaskIds: v.array(v.id('tasks')),
+  pendingReviews: v.array(
+    v.object({
+      taskId: v.id('tasks'),
+      approvalId: v.id('approvals'),
+      // The named reviewer the request waits on — powers the indicator's
+      // "Waiting on {name}" and the "Needs my review" facet.
+      requestedFor: v.optional(v.string()),
+    }),
+  ),
+});
+
 /**
  * Live agent-work indicators for an open board: which tasks have a RUNNING
  * agent run, and which have a PENDING review-gate approval. One reactive
@@ -1005,18 +1153,7 @@ const TASK_OPS_RUN_SCAN_CAP = 100;
  */
 export const getTaskOpsIndicators = query({
   args: { projectId: v.id('projects'), organizationId: v.string() },
-  returns: v.object({
-    runningTaskIds: v.array(v.id('tasks')),
-    pendingReviews: v.array(
-      v.object({
-        taskId: v.id('tasks'),
-        approvalId: v.id('approvals'),
-        // The named reviewer the request waits on — powers the indicator's
-        // "Waiting on {name}" and the "Needs my review" facet.
-        requestedFor: v.optional(v.string()),
-      }),
-    ),
-  }),
+  returns: taskOpsIndicatorsReturnValidator,
   handler: async (ctx, args) => {
     const { project } = await loadAccessibleProject(
       ctx,
@@ -1077,6 +1214,66 @@ export const getTaskOpsIndicators = query({
       ctx,
       project.organizationId,
       args.projectId,
+    );
+    const pendingReviews = [...pendingByTask].map(([taskId, review]) =>
+      Object.assign(
+        {
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- task_review approvals store String(taskId) as resourceId
+          taskId: taskId as Id<'tasks'>,
+          approvalId: review.approvalId,
+        },
+        review.requestedFor !== undefined
+          ? { requestedFor: review.requestedFor }
+          : {},
+      ),
+    );
+
+    return { runningTaskIds, pendingReviews };
+  },
+});
+
+/**
+ * All-projects sibling of {@link getTaskOpsIndicators}: running agent turns
+ * and pending reviews across every project the caller can read. Agent runs
+ * use `by_org_status` (then filter by accessible project via the task row);
+ * pending reviews reuse the org pending scan filtered to those projects.
+ * Automation-run working indicators are omitted here — they need a per-project
+ * walk that does not scale to the aggregate board.
+ */
+export const getTaskOpsIndicatorsForAccessibleProjects = query({
+  args: { organizationId: v.string() },
+  returns: taskOpsIndicatorsReturnValidator,
+  handler: async (ctx, args) => {
+    const auth = await getAuthContext(ctx, args.organizationId);
+    const { projectIds } = await collectAccessibleProjectMeta(
+      ctx,
+      args.organizationId,
+      auth,
+    );
+    if (projectIds.size === 0) {
+      return { runningTaskIds: [], pendingReviews: [] };
+    }
+
+    const runningTaskIds: Id<'tasks'>[] = [];
+    const seenRunning = new Set<Id<'tasks'>>();
+    for await (const run of ctx.db
+      .query('taskAgentRuns')
+      .withIndex('by_org_status', (q) =>
+        q.eq('organizationId', args.organizationId).eq('status', 'running'),
+      )) {
+      const task = await ctx.db.get(run.taskId);
+      if (!task || !projectIds.has(String(task.projectId))) continue;
+      if (!seenRunning.has(run.taskId)) {
+        runningTaskIds.push(run.taskId);
+        seenRunning.add(run.taskId);
+      }
+      if (runningTaskIds.length >= TASK_OPS_INDICATOR_CAP) break;
+    }
+
+    const pendingByTask = await collectPendingReviewsForProjects(
+      ctx,
+      args.organizationId,
+      projectIds,
     );
     const pendingReviews = [...pendingByTask].map(([taskId, review]) =>
       Object.assign(

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -7041,6 +7041,8 @@ projects:
     searchPlaceholder: Projekte suchen
     empty: Keine Projekte gefunden
     ariaLabel: 'Projekt wechseln, aktuell: {name}'
+    allProjects: Alle Projekte
+    allProjectsBadge: Alle
   navigation:
     overview: Allgemein
     files: Wissen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -4724,6 +4724,8 @@ projects:
     searchPlaceholder: Search projects
     empty: No projects found
     ariaLabel: 'Switch project, current: {name}'
+    allProjects: All projects
+    allProjectsBadge: All
   navigation:
     overview: General
     files: Knowledge

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7161,6 +7161,8 @@ projects:
     searchPlaceholder: Rechercher des projets
     empty: Aucun projet trouvé
     ariaLabel: 'Changer de projet, actuel : {name}'
+    allProjects: Tous les projets
+    allProjectsBadge: Tous
   navigation:
     overview: Général
     files: Connaissances


### PR DESCRIPTION
## Summary
- Add `listTasksForAccessibleProjects` and wire Tasks board/list to an org-wide aggregate when `?projects=all`
- Project breadcrumb switcher offers “All projects” on Tasks paths; sibling project tabs disable while that mode is active
- Cards show `projectKey` in the aggregate view

## Test plan
- [ ] On a project Tasks board, switcher → All projects loads the aggregate board
- [ ] Overview / Threads / Files / etc. tabs are disabled in all-projects mode; Tasks stays active
- [ ] Stale `?projects=all` on a non-Tasks project URL redirects to the Tasks board
- [ ] Leaving All projects restores a single-project board and re-enables tabs
- [ ] Pending-review badges still resolve across accessible projects