### PR TITLE
fix(platform): enable All projects drag and project link

### DIFF
--- a/services/platform/app/features/tasks/components/kanban-board.tsx
+++ b/services/platform/app/features/tasks/components/kanban-board.tsx
@@ -44,9 +44,16 @@ export function KanbanBoard({
   const { confirmCancel, dialog } = useRunCancelConfirm();
   const dnd = useTaskBoardDnd(tasks, { confirmCancel });
   const { isAgentWorking } = useTaskBoardContext();
+  // Single-project boards scope contracts to that project; mixed boards load
+  // org + project-bound automations so drop hints still name the right verb.
+  const choreographyProjectId = useMemo(() => {
+    const first = tasks[0]?.projectId;
+    if (first === undefined) return undefined;
+    return tasks.every((task) => task.projectId === first) ? first : undefined;
+  }, [tasks]);
   const automations = useTaskContractAutomations(
     tasks[0]?.organizationId ?? '',
-    tasks[0]?.projectId,
+    choreographyProjectId,
   );
   // The board keeps every task as a card (grouped by status); this map only
   // feeds the per-card subtask-progress ring.

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveDialogTitle,
 } from '@tale/ui/responsive-dialog';
 import { Text } from '@tale/ui/text';
+import { Link } from '@tanstack/react-router';
 import { ConvexError } from 'convex/values';
 import {
   Archive,
@@ -144,6 +145,7 @@ export function TaskModal({
   taskId,
   defaultStatus,
   onOpenTask,
+  showProjectLink = false,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -155,6 +157,8 @@ export function TaskModal({
   defaultStatus?: TaskStatus;
   /** Navigate to another task (subtasks / dependency links). */
   onOpenTask?: (taskId: Id<'tasks'>) => void;
+  /** All-projects board: show a link to the task's project in the detail. */
+  showProjectLink?: boolean;
 }) {
   const { t } = useT('tasks');
   return (
@@ -179,6 +183,7 @@ export function TaskModal({
             taskId={taskId}
             onOpenTask={onOpenTask}
             onClose={() => onOpenChange(false)}
+            showProjectLink={showProjectLink}
           />
         ) : (
           <CreateTaskBody
@@ -960,10 +965,12 @@ function EditTaskBody({
   taskId,
   onOpenTask,
   onClose,
+  showProjectLink = false,
 }: {
   taskId: Id<'tasks'>;
   onOpenTask?: (taskId: Id<'tasks'>) => void;
   onClose: () => void;
+  showProjectLink?: boolean;
 }) {
   const { t } = useT('tasks');
   const { t: tCommon } = useT('common');
@@ -1509,6 +1516,26 @@ function EditTaskBody({
                     />
                   )}
                 </Row>
+              )}
+              {showProjectLink && project !== null && (
+                <PropertyField label={t('fields.project')}>
+                  <Link
+                    to="/dashboard/$id/projects/$projectId/tasks/board"
+                    params={{
+                      id: task.organizationId,
+                      projectId: task.projectId,
+                    }}
+                    search={(prev) => {
+                      const next = { ...prev };
+                      delete next.projects;
+                      next.task = task._id;
+                      return next;
+                    }}
+                    className="text-foreground hover:text-foreground/80 focus-visible:ring-ring min-w-0 truncate rounded-sm text-sm focus-visible:ring-2 focus-visible:outline-none"
+                  >
+                    {project.name}
+                  </Link>
+                </PropertyField>
               )}
               <PropertyField label={t('fields.status')}>
                 <StatusPicker

--- a/services/platform/app/features/tasks/components/tasks-workspace.tsx
+++ b/services/platform/app/features/tasks/components/tasks-workspace.tsx
@@ -329,8 +329,9 @@ export function TasksWorkspace({
         <Row gap={2}>
           {/* Read-only viewers can't create tasks (the server rejects the
               write); hide the action rather than surface a doomed button.
-              All-projects mode has no single write target — Create stays off. */}
-          {canEdit && (
+              All-projects mode has no single write target — Create stays off
+              even when canEdit is true (drag / pickers still work). */}
+          {canEdit && !allProjects && (
             <Button size="sm" icon={Plus} onClick={() => setCreateOpen(true)}>
               {t('actions.create')}
             </Button>
@@ -391,6 +392,7 @@ export function TasksWorkspace({
         projectId={openTaskProjectId}
         taskId={openTaskId}
         open={openTaskId !== null}
+        showProjectLink={allProjects}
         onOpenChange={(open) => {
           if (!open) setOpenTaskId(null);
         }}

--- a/services/platform/app/features/tasks/hooks/use-task-board-dnd.ts
+++ b/services/platform/app/features/tasks/hooks/use-task-board-dnd.ts
@@ -80,10 +80,17 @@ export function useTaskBoardDnd(
   const moveTask = useMoveTask();
   // Cross-column drags on automation-owned tasks route through the owning
   // workflow's choreography (drag to In progress = start, drag out = cancel)
-  // instead of a bare status write. Rows all belong to one org + project.
+  // instead of a bare status write. A single-project board scopes the
+  // contract catalog to that project; the all-projects board loads org +
+  // project-bound automations (no projectId) so ownership still resolves.
+  const choreographyProjectId = useMemo(() => {
+    const first = tasks[0]?.projectId;
+    if (first === undefined) return undefined;
+    return tasks.every((task) => task.projectId === first) ? first : undefined;
+  }, [tasks]);
   const choreograph = useTaskStatusChoreography(
     tasks[0]?.organizationId ?? '',
-    tasks[0]?.projectId,
+    choreographyProjectId,
     options,
   );
   const [activeId, setActiveId] = useState<string | null>(null);

--- a/services/platform/app/features/tasks/hooks/use-task-subject-contract.ts
+++ b/services/platform/app/features/tasks/hooks/use-task-subject-contract.ts
@@ -64,7 +64,9 @@ interface ContractAutomationEntry {
 /**
  * The DEPLOYED automations visible from one project's task board: the
  * project's own plus the organization-level ones — a contract can operate
- * tasks from either surface.
+ * tasks from either surface. When `projectId` is absent (all-projects board),
+ * org-level listing includes project-bound automations so cross-project
+ * choreography still resolves ownership.
  */
 export function useTaskContractAutomations(
   organizationId: string,
@@ -74,7 +76,14 @@ export function useTaskContractAutomations(
   // than fire a member-gated query for no organization.
   const orgQuery = useConvexQuery(
     api.automations.queries.listAutomations,
-    organizationId === '' ? 'skip' : { organizationId },
+    organizationId === ''
+      ? 'skip'
+      : {
+          organizationId,
+          // All-projects (no single projectId): include every project-bound
+          // automation so drag choreography can resolve owners across the set.
+          ...(projectId === undefined ? { includeProjectBound: true } : {}),
+        },
   );
   const projectQuery = useConvexQuery(
     api.automations.queries.listAutomations,

--- a/services/platform/convex/tasks/queries.test.ts
+++ b/services/platform/convex/tasks/queries.test.ts
@@ -444,13 +444,28 @@ describe('listTasksForAccessibleProjects', () => {
       .query(api.tasks.queries.listTasksForAccessibleProjects, {
         organizationId: ORG,
       });
-    expect(result.canEdit).toBe(false);
+    expect(result.canEdit).toBe(true);
     expect(result.tasks).toHaveLength(2);
     expect(
       result.tasks
         .map((task) => task.projectKey)
         .sort((a, b) => String(a).localeCompare(String(b))),
     ).toEqual(['AAA', 'BBB']);
+  });
+
+  it('reports canEdit false for a read-only member on the aggregate board', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t, 'user_member', 'member');
+    const project = await seedProject(t, 'Open');
+    await seedTask(t, project);
+
+    const result = await t
+      .withIdentity({ subject: 'user_member' })
+      .query(api.tasks.queries.listTasksForAccessibleProjects, {
+        organizationId: ORG,
+      });
+    expect(result.canEdit).toBe(false);
+    expect(result.tasks).toHaveLength(1);
   });
 
   it('excludes tasks in team-private projects the caller cannot read', async () => {

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -22,6 +22,7 @@ import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { UnauthorizedError } from '../lib/rls/errors';
 import { assertActiveOrg } from '../lib/rls/organization/assert_active_org';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { EDITOR_ROLES } from '../projects/access';
 import { sessionOpTimelinePartValidator } from '../sandbox/sessions_schema';
 import { canClaimTask, checkProjectAccess, hasProjectAccess } from './access';
 import { taskLabelDto } from './helpers';
@@ -599,8 +600,12 @@ async function collectAccessibleProjectMeta(
  * {@link listTasksByProject} used when the Tasks switcher is on "All projects".
  * Walks `by_org_updatedAt` newest-first so the {@link TASK_BOARD_CAP} prefers
  * recently touched work; filters to the caller's accessible project set
- * (unlike Apps-hub `listTasksByOrg`, which is membership-only). Always returns
- * `canEdit: false` — the aggregate view has no single write target.
+ * (unlike Apps-hub `listTasksByOrg`, which is membership-only).
+ *
+ * `canEdit` follows the caller's org role ({@link EDITOR_ROLES}) — project
+ * write access is role-uniform once a project is readable, so drag / pickers
+ * match single-project boards. Create stays off in the UI: the aggregate has
+ * no single write target for a new task.
  */
 export const listTasksForAccessibleProjects = query({
   args: {
@@ -620,13 +625,14 @@ export const listTasksForAccessibleProjects = query({
     // not-a-member); the organizationId arg IS the caller's active org from
     // the client, matching every other board read.
     const auth = await getAuthContext(ctx, args.organizationId);
+    const canEdit = EDITOR_ROLES.has(auth.role);
     const { projectIds, projectKeys } = await collectAccessibleProjectMeta(
       ctx,
       args.organizationId,
       auth,
     );
     if (projectIds.size === 0) {
-      return { tasks: [], truncated: false, canEdit: false };
+      return { tasks: [], truncated: false, canEdit };
     }
 
     const rows: Doc<'tasks'>[] = [];
@@ -690,7 +696,7 @@ export const listTasksForAccessibleProjects = query({
         });
       }),
     );
-    return { tasks, truncated, canEdit: false };
+    return { tasks, truncated, canEdit };
   },
 });
 

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6523,6 +6523,7 @@ tasks:
     priority: Priorität
     labels: Labels
     status: Status
+    project: Projekt
     unassigned: Nicht zugewiesen
     author: Autor
     created: Erstellt

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6603,6 +6603,7 @@ tasks:
     priority: Priority
     labels: Labels
     status: Status
+    project: Project
     unassigned: Unassigned
     author: Author
     created: Created

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6642,6 +6642,7 @@ tasks:
     priority: Priorité
     labels: Étiquettes
     status: Statut
+    project: Projet
     unassigned: Non assigné
     author: Auteur
     created: Créé le


### PR DESCRIPTION
## Summary
- All-projects task board returns real `canEdit` (role-based) so editors can drag and use pickers again; Create stays off because there is still no single project write target
- Task detail opened from All projects shows a Project link that opens that project's board and keeps the task open
- Cross-project drag choreography loads org + project-bound automations so owned tasks still resolve start/cancel verbs

## Test plan
- [ ] Open Tasks → All projects as Editor+: drag a card between columns; status persists after reload
- [ ] Same view as Member (read-only): cards still do not drag
- [ ] Create task remains hidden on All projects
- [ ] Open a task from All projects → Project field in the side panel → lands on that project's board with the task still open (no `projects=all`)
- [ ] Drag an automation-owned task to In progress on All projects still starts the run when input is ready