### PR TITLE
fix(platform): clear the automations workbench CI failures

### DIFF
--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -40,7 +40,6 @@ import type { Id } from '@/convex/_generated/dataModel';
 import type { NodeDef, Automation } from '@/lib/engine/core/types';
 import { useT } from '@/lib/i18n/client';
 import { automationDisplayDescription } from '@/lib/shared/schemas/automation_presentation';
-import { cn } from '@/lib/utils/cn';
 
 import { mergeNodeTypes } from '../hooks/backend';
 import {
@@ -417,9 +416,10 @@ export function AutomationDetail({
             type: 'item' as const,
             label: t('versions.versionLabel', { version: entry.version }),
             selected: entry.version === lookingVersion,
-            ...(entry.version === meta?.deployedVersion
-              ? { trailing: t('versions.deployed') }
-              : {}),
+            trailing:
+              entry.version === meta?.deployedVersion
+                ? t('versions.deployed')
+                : undefined,
             onClick: () => {
               if (entry.version !== lookingVersion) {
                 requestVersionSwitch(entry.version);

--- a/services/platform/app/features/automations/components/node-inspector.tsx
+++ b/services/platform/app/features/automations/components/node-inspector.tsx
@@ -265,9 +265,11 @@ export function NodeInspector({
   useDeselectOnEscape(selectedNodeId !== undefined, onDeselect);
 
   useEffect(() => {
-    sectionRef.current.scrollTop = 0;
+    const section = sectionRef.current;
+    if (section === null) return;
+    section.scrollTop = 0;
     if (selectedNodeId !== undefined) {
-      sectionRef.current?.focus({ preventScroll: true });
+      section.focus({ preventScroll: true });
     }
   }, [selectedNodeId]);
 

--- a/services/platform/app/features/automations/hooks/use-deselect-on-escape.ts
+++ b/services/platform/app/features/automations/hooks/use-deselect-on-escape.ts
@@ -30,7 +30,7 @@ export function useDeselectOnEscape(
   onDeselect: (() => void) | undefined,
 ): void {
   useEffect(() => {
-    if (!enabled || onDeselect === undefined) return;
+    if (!enabled || onDeselect === undefined) return undefined;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       if (event.defaultPrevented) return;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1001,6 +1001,7 @@ import type * as websites_match_website_search from "../websites/match_website_s
 import type * as websites_mutations from "../websites/mutations.js";
 import type * as websites_queries from "../websites/queries.js";
 import type * as websites_rest_api from "../websites/rest_api.js";
+import type * as websites_scan_scheduling from "../websites/scan_scheduling.js";
 import type * as websites_search_websites from "../websites/search_websites.js";
 import type * as websites_types from "../websites/types.js";
 import type * as websites_update_website from "../websites/update_website.js";
@@ -2006,6 +2007,7 @@ declare const fullApi: ApiFromModules<{
   "websites/mutations": typeof websites_mutations;
   "websites/queries": typeof websites_queries;
   "websites/rest_api": typeof websites_rest_api;
+  "websites/scan_scheduling": typeof websites_scan_scheduling;
   "websites/search_websites": typeof websites_search_websites;
   "websites/types": typeof websites_types;
   "websites/update_website": typeof websites_update_website;

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -724,7 +724,6 @@ automations:
     empty: Es wurde noch keine Version gespeichert.
     versionLabel: v{version}
     deployed: Live
-    deploy: Live schalten
     deployRefused: Diese Version wurde nicht live geschaltet
     testsPassed: Tests bestanden
     testsFailed: Tests fehlgeschlagen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -691,7 +691,6 @@ automations:
     empty: No versions saved yet.
     versionLabel: v{version}
     deployed: Live
-    deploy: Deploy
     deployRefused: This version was not deployed
     testsPassed: Tests passed
     testsFailed: Tests failed

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -730,7 +730,6 @@ automations:
     empty: Aucune version n’a encore été enregistrée.
     versionLabel: v{version}
     deployed: En service
-    deploy: Mettre en service
     deployRefused: Cette version n’a pas été mise en service
     testsPassed: Tests réussis
     testsFailed: Tests en échec


### PR DESCRIPTION
## Summary

Main has been red since #3068 (Checks: Unit, Type check, and Lint all failing). This fixes all five findings, plus one stale codegen artifact from #3049.

- **Type check** — `node-inspector.tsx`: guard `sectionRef.current` against `null` before the scroll reset and focus (TS18047).
- **Lint** — `automation-detail.tsx`: drop the unused `cn` import; build the version menu item's `trailing` text as a plain conditional property instead of a spread inside `map` (no-map-spread).
- **Lint** — `use-deselect-on-escape.ts`: return `undefined` explicitly on the early exit so the effect's returns stay consistent (consistent-return), matching `use-thinking-timer.ts`.
- **Unit** — remove the orphaned `automations.versions.deploy` key from `en`/`de`/`fr` (`de-CH` never carried it). The workbench deploy button ships `detail.deployThis`; nothing references the old key.
- **Codegen** — `convex/_generated/api.d.ts`: register `websites/scan_scheduling`, which #3049 added without committing the regenerated registration.

## Verification

- `bun run typecheck` (platform): clean
- `bun run lint` (platform): exit 0
- `lib/i18n/messages.test.ts`: 24/24 pass (orphan + four-locale parity)
- `bunx oxfmt --check` on the edited files: clean