### PR TITLE
fix(platform): ride the zai coding base and refresh the GLM catalog

### DIFF
--- a/configs/platform/system/models/zai/models.yml
+++ b/configs/platform/system/models/zai/models.yml
@@ -1,7 +1,21 @@
 # Static model catalog for the zai connector — captured from
 # the live OpenRouter listing on 2026-07-21 (vendor-native ids; the
 # vendor publishes no usable public listing endpoint). Pricing is
-# cents per million tokens where the source published it.
+# cents per million tokens where the source published it. Pricing
+# refreshed and glm-5.3 / glm-4.6v added from the 2026-08-26 listing.
+- id: glm-5.3
+  provider: zai
+  tags:
+    - chat
+  supportsTools: true
+  supportsVision: false
+  reasoning:
+    knob: effort
+  contextWindow: 1048576
+  maxOutputTokens: 131072
+  pricing:
+    inputCentsPerMillion: 140
+    outputCentsPerMillion: 440
 - id: glm-5.2
   provider: zai
   tags:
@@ -13,8 +27,8 @@
   contextWindow: 1048576
   maxOutputTokens: 131072
   pricing:
-    inputCentsPerMillion: 77.7
-    outputCentsPerMillion: 244.2
+    inputCentsPerMillion: 119
+    outputCentsPerMillion: 374
 - id: glm-5.1
   provider: zai
   tags:
@@ -26,8 +40,8 @@
   contextWindow: 204800
   maxOutputTokens: 128000
   pricing:
-    inputCentsPerMillion: 96.6
-    outputCentsPerMillion: 303.6
+    inputCentsPerMillion: 126
+    outputCentsPerMillion: 396
 - id: glm-5v-turbo
   provider: zai
   tags:
@@ -55,3 +69,17 @@
   pricing:
     inputCentsPerMillion: 120
     outputCentsPerMillion: 400
+- id: glm-4.6v
+  provider: zai
+  tags:
+    - chat
+    - vision
+  supportsTools: true
+  supportsVision: true
+  reasoning:
+    knob: effort
+  contextWindow: 131072
+  maxOutputTokens: 32768
+  pricing:
+    inputCentsPerMillion: 30
+    outputCentsPerMillion: 90

--- a/configs/platform/system/providers/zai/provider.yml
+++ b/configs/platform/system/providers/zai/provider.yml
@@ -1,15 +1,25 @@
 # AI provider connector — Z.ai (Zhipu's international brand, the GLM model
-# family). API traffic rides the vendor's explicit OpenAI-compatibility
-# path. Static model catalog (models/zai/models.yml).
+# family). Direct API traffic rides the vendor's OpenAI-compatible CODING
+# base, which carries its API version IN THE PATH (the gateway appends
+# `/chat/completions` verbatim via its request path overrides). The coding
+# base serves BOTH credential shapes: a GLM Coding Plan key draws on its
+# plan quota there, while the general `/api/paas/v4` base bills the API
+# balance instead — a plan key with no API balance gets 429 "Insufficient
+# balance" on the general base (verified 2026-08-26). The vendor's former
+# `/api/openai/v1` alias no longer exists upstream (404).
+# Static model catalog (models/zai/models.yml).
 #
 # The subscription method is the GLM Coding Plan: a static plan key that
 # only serves agentic coding traffic through Z.ai's Anthropic-compatible
 # endpoint, so it forces sandboxed execution on the claude-code harness and
-# never serves direct API calls.
+# never serves direct API calls. That endpoint silently DROPS image content
+# blocks for every model — even explicitly-requested vision models answer
+# blind (verified 2026-08-26) — so vision-dependent turns must ride the
+# direct lane; the plan key itself is accepted on the direct base too.
 name: zai
 displayName: Z.ai (GLM)
 apiFormat: openai
-baseUrl: https://api.z.ai/api/openai/v1
+baseUrl: https://api.z.ai/api/coding/paas/v4
 catalog:
   source: static
 auth:

--- a/services/sandbox-runtime/tale-vision-transcribe
+++ b/services/sandbox-runtime/tale-vision-transcribe
@@ -38,7 +38,10 @@ const MEDIA_TYPES = {
 
 const DEFAULT_PROMPT =
   'Read this image and extract its text and any structured fields verbatim. ' +
-  'Preserve numbers, dates, and identifiers exactly. Reply with the extracted content only.';
+  'Preserve numbers, dates, and identifiers exactly. ' +
+  'If the image contains no readable text, describe what it shows instead — ' +
+  'colors, layout, and subjects. Reply with the extracted content (or the ' +
+  'description) only, never with an empty message.';
 
 async function callVision(imagePath, prompt) {
   if (!GATEWAY_URL || !GATEWAY_TOKEN || !VISION_MODEL) {


### PR DESCRIPTION
## Summary

Z.ai removed the `/api/openai/v1` alias upstream (404 since 2026-08-26), which broke every direct API call through the zai connector.

- **Base URL** — point the connector at the vendor's OpenAI-compatible coding base `/api/coding/paas/v4` (API version rides in the path; the gateway appends `/chat/completions` verbatim). The coding base serves both credential shapes: a GLM Coding Plan key draws on its plan quota there, while the general `/api/paas/v4` base bills the API balance instead — a plan key with no balance gets 429 "Insufficient balance" on the general base (verified 2026-08-26).
- **Vision blackhole documented** — the subscription lane's Anthropic-compatible endpoint silently drops image content blocks for every model, so even explicitly-requested vision models answer blind (verified 2026-08-26); vision-dependent turns must ride the direct lane. The plan key itself is accepted on the direct base too.
- **Catalog refresh** — add `glm-5.3` (1M context, effort reasoning) and `glm-4.6v` (vision), refresh `glm-5.2` / `glm-5.1` pricing from the 2026-08-26 listing.

## Verification

- `scripts/validate-builtin-configs.ts`: OK — 12 provider connectors, 9 model catalogs validated
- `shipped-models` / `shipped-connectors` / `load_system_config` suites: 131/131 pass