### PR TITLE
feat(platform): trigger automation task runs from @-mention comments

### DIFF
--- a/docs/de/platform/projects/task-automation.md
+++ b/docs/de/platform/projects/task-automation.md
@@ -35,7 +35,9 @@ Das Board benennt die Wartestelle: Karten auf _In Prüfung_ tragen einen Chip **
 
 ## Erwähnungen
 
-**Erwähne einen Agenten mit @** in einem Aufgaben-Kommentar, und er liest den erwähnenden Text und handelt. Ein `@` öffnet eine Autovervollständigung über Mitglieder und die Agenten des Projekts; der Composer zeigt vorab, ob jeder erwähnte Agent wirklich reagiert (Automatisierung aus, Sicherung ausgelöst, im Projekt nicht erwähnbar). Eine Erwähnung des **Zuständigen** gilt als Feedback zu seiner Arbeit: Ein laufender Agent nimmt den Kommentar mitten im Lauf auf, ein untätiger startet einen Überarbeitungslauf, der den Kommentar wortwörtlich mitbekommt und das vorige Gespräch dort fortsetzt, wo es aufgehört hat.
+**Erwähne einen Agenten mit @** in einem Aufgaben-Kommentar, und er liest den erwähnenden Text und handelt. Ein `@` öffnet eine Autovervollständigung über Mitglieder, die Agenten des Projekts und die Automatisierungen dieses Boards; der Composer zeigt vorab, ob jeder erwähnte Agent wirklich reagiert (Automatisierung aus, Sicherung ausgelöst, im Projekt nicht erwähnbar). Eine Erwähnung des **Zuständigen** gilt als Feedback zu seiner Arbeit: Ein laufender Agent nimmt den Kommentar mitten im Lauf auf, ein untätiger startet einen Überarbeitungslauf, der den Kommentar wortwörtlich mitbekommt und das vorige Gespräch dort fortsetzt, wo es aufgehört hat.
+
+Aufgaben, die einer Automatisierung gehören, folgen derselben Regel: Ein einfacher Kommentar bleibt ein Kommentar; erwähnst du die **besitzende Automatisierung mit @**, läuft ihr Workflow erneut und liest deinen Kommentar — samt der übrigen Timeline seit der letzten Lieferung — als Feedback. Die Erwähnung einer anderen Automatisierung startet nichts: Eine Aufgabe führt nur den Workflow aus, dem sie gehört, und eine Aufgabe mit laufendem Lauf behält ihn. **Änderungen anfordern** im Subjekt-Panel setzt genau diese Erwähnung für dich zusammen — die Timeline zeigt denselben @-Kommentar, ob du ihn getippt oder den Button geklickt hast.
 
 ## Leitplanken
 

--- a/docs/en/platform/projects/task-automation.md
+++ b/docs/en/platform/projects/task-automation.md
@@ -35,7 +35,9 @@ The board names the gate: cards waiting at _In review_ carry a **Waiting on {nam
 
 ## Mentions
 
-**@-mention an agent** in a task comment and it reads the mentioning text and acts. Typing `@` opens an autocomplete over members and the project's agents; the composer previews whether each mentioned agent will actually respond (automation off, breaker paused, not mentionable in this project). A mention of the task's **assignee** is treated as feedback on its assigned work: a running agent picks the comment up mid-run, an idle one starts a rework run that carries the comment verbatim and picks its previous conversation up where it left off.
+**@-mention an agent** in a task comment and it reads the mentioning text and acts. Typing `@` opens an autocomplete over members, the project's agents, and the automations operating this board; the composer previews whether each mentioned agent will actually respond (automation off, breaker paused, not mentionable in this project). A mention of the task's **assignee** is treated as feedback on its assigned work: a running agent picks the comment up mid-run, an idle one starts a rework run that carries the comment verbatim and picks its previous conversation up where it left off.
+
+Automation-owned tasks follow the same rule: a plain comment is just a comment, and **@-mentioning the owning automation** runs its workflow again, which reads your comment — with the rest of the timeline since its last delivery — as feedback. Mentioning any other automation starts nothing; a task runs only the workflow it belongs to, and a task with a live run keeps it. The subject panel's **Request changes** composes exactly this mention for you, so the timeline shows the same @-comment whether you typed it or clicked the button.
 
 ## Guardrails
 

--- a/docs/fr/platform/projects/task-automation.md
+++ b/docs/fr/platform/projects/task-automation.md
@@ -35,7 +35,9 @@ Le tableau nomme l’attente : les cartes garées sur _En revue_ portent une puc
 
 ## Mentions
 
-**Mentionne un agent avec @** dans un commentaire de tâche : il lit le texte qui le mentionne et agit. Taper `@` ouvre une autocomplétion sur les membres et les agents du projet ; le composeur montre à l’avance si chaque agent mentionné répondra vraiment (automatisation coupée, disjoncteur déclenché, non mentionnable dans ce projet). Une mention de l’**assigné** vaut feedback sur son travail : un agent en cours d’exécution reprend le commentaire en vol, un agent au repos lance une exécution de reprise qui reçoit le commentaire tel quel et poursuit la conversation précédente là où elle s’était arrêtée.
+**Mentionne un agent avec @** dans un commentaire de tâche : il lit le texte qui le mentionne et agit. Taper `@` ouvre une autocomplétion sur les membres, les agents du projet et les automatisations qui opèrent ce tableau ; le composeur montre à l’avance si chaque agent mentionné répondra vraiment (automatisation coupée, disjoncteur déclenché, non mentionnable dans ce projet). Une mention de l’**assigné** vaut feedback sur son travail : un agent en cours d’exécution reprend le commentaire en vol, un agent au repos lance une exécution de reprise qui reçoit le commentaire tel quel et poursuit la conversation précédente là où elle s’était arrêtée.
+
+Les tâches qui appartiennent à une automatisation suivent la même règle : un commentaire ordinaire reste un commentaire ; **mentionne l’automatisation propriétaire avec @** et son workflow repart, en lisant ton commentaire — avec le reste de la timeline depuis sa dernière livraison — comme feedback. Mentionner une autre automatisation ne lance rien : une tâche n’exécute que le workflow auquel elle appartient, et une tâche avec une exécution en cours la garde. **Demander des modifications** sur le panneau sujet compose exactement cette mention pour toi — la timeline montre le même commentaire @, que tu l’aies tapé ou cliqué.
 
 ## Garde-fous
 

--- a/services/platform/app/features/tasks/components/editable-description.browser.test.tsx
+++ b/services/platform/app/features/tasks/components/editable-description.browser.test.tsx
@@ -32,7 +32,7 @@ vi.mock('./mention-trigger-chips', () => ({
   MentionTriggerChips: () => null,
 }));
 vi.mock('../hooks/use-actor-directory', () => ({
-  useActorDirectory: () => ({ members: [], agents: [] }),
+  useActorDirectory: () => ({ members: [], agents: [], automations: [] }),
 }));
 vi.mock('@/app/features/shared/markdown/markdown-renderer', () => ({
   markdownWrapperStyles: '',

--- a/services/platform/app/features/tasks/components/editable-description.test.tsx
+++ b/services/platform/app/features/tasks/components/editable-description.test.tsx
@@ -44,7 +44,7 @@ vi.mock('./mention-trigger-chips', () => ({
 // Stubbing the map leaves react-markdown's own renderers in place, so the
 // anchors below are the ones the markdown pipeline actually produced.
 vi.mock('../hooks/use-actor-directory', () => ({
-  useActorDirectory: () => ({ members: [], agents: [] }),
+  useActorDirectory: () => ({ members: [], agents: [], automations: [] }),
 }));
 vi.mock('@/app/features/shared/markdown/markdown-renderer', () => ({
   markdownWrapperStyles: '',

--- a/services/platform/app/features/tasks/components/mention-text.test.tsx
+++ b/services/platform/app/features/tasks/components/mention-text.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../hooks/use-actor-directory', () => ({
   useActorDirectory: () => ({
     members: [{ id: 'u1', name: 'Ada', email: 'ada@example.com' }],
     agents: [{ id: 'rs774n7chzm7tbf9p5fhsq2xr58br0nb', name: 'PR Reviewer' }],
+    automations: [{ slug: 'vat-return-desk', name: 'Swiss VAT return desk' }],
   }),
 }));
 
@@ -58,5 +59,17 @@ describe('MentionText — markdown', () => {
 
     expect(screen.getAllByText('@PR Reviewer')).toHaveLength(2);
     expect(screen.queryByText(/@pr\.reviewer/)).not.toBeInTheDocument();
+  });
+
+  it('resolves an automation by store name AND by display-name handle', () => {
+    render(
+      <MentionText
+        body="@vat-return-desk redo — @swiss.vat.return.desk agreed"
+        organizationId="org_1"
+      />,
+    );
+
+    expect(screen.getAllByText('@Swiss VAT return desk')).toHaveLength(2);
+    expect(screen.queryByText(/@vat-return-desk/)).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/tasks/components/mention-text.tsx
+++ b/services/platform/app/features/tasks/components/mention-text.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils/cn';
 import { useActorDirectory } from '../hooks/use-actor-directory';
 import {
   agentHandleVariants,
+  automationHandleVariants,
   memberHandleVariants,
 } from '../lib/mention-handles';
 
@@ -28,7 +29,7 @@ const MENTION_SPLIT_RE = /(^|\s)@([a-zA-Z0-9._/-]+)/g;
 
 interface ResolvedHandle {
   name: string;
-  isAgent: boolean;
+  kind: 'user' | 'agent' | 'automation';
 }
 
 /**
@@ -52,24 +53,33 @@ export function MentionizedText({
   projectId?: string;
 }) {
   const { t } = useT('tasks');
-  const { members, agents } = useActorDirectory(organizationId, projectId);
+  const { members, agents, automations } = useActorDirectory(
+    organizationId,
+    projectId,
+  );
 
-  // Members first, agents after — on a handle collision the agent wins,
-  // matching the server's directory build order.
+  // Members first, then automations, agents last — on a handle collision the
+  // later entry wins, matching the server's directory build order (agent
+  // instances keep the strongest claim).
   const handleToActor = useMemo(() => {
     const map = new Map<string, ResolvedHandle>();
     for (const member of members) {
       for (const variant of memberHandleVariants(member)) {
-        map.set(variant, { name: member.name, isAgent: false });
+        map.set(variant, { name: member.name, kind: 'user' });
+      }
+    }
+    for (const automation of automations) {
+      for (const variant of automationHandleVariants(automation)) {
+        map.set(variant, { name: automation.name, kind: 'automation' });
       }
     }
     for (const agent of agents) {
       for (const variant of agentHandleVariants(agent)) {
-        map.set(variant, { name: agent.name, isAgent: true });
+        map.set(variant, { name: agent.name, kind: 'agent' });
       }
     }
     return map;
-  }, [members, agents]);
+  }, [members, agents, automations]);
 
   const nodes = useMemo(() => {
     const parts: React.ReactNode[] = [];
@@ -87,7 +97,11 @@ export function MentionizedText({
           key={`${mentionStart}-${token}`}
           className="bg-primary/10 text-primary rounded-md box-decoration-clone px-1 py-0.5 text-[0.9em] leading-none font-medium"
           title={
-            actor.isAgent ? `@${token} · ${t('assignee.agents')}` : `@${token}`
+            actor.kind === 'agent'
+              ? `@${token} · ${t('assignee.agents')}`
+              : actor.kind === 'automation'
+                ? `@${token} · ${t('assignee.automations')}`
+                : `@${token}`
           }
         >
           @{actor.name}

--- a/services/platform/app/features/tasks/components/mention-textarea.tsx
+++ b/services/platform/app/features/tasks/components/mention-textarea.tsx
@@ -228,7 +228,11 @@ export function MentionTextarea({
                     onMouseEnter={() => setHighlight(index)}
                   >
                     <AssigneeAvatar
-                      assigneeType={option.type}
+                      // The avatar speaks the task worker vocabulary, where
+                      // an automation is `app`.
+                      assigneeType={
+                        option.type === 'automation' ? 'app' : option.type
+                      }
                       assigneeId={option.id}
                       name={option.name}
                     />
@@ -248,6 +252,8 @@ export function MentionTextarea({
                         @{option.handle}
                         {option.type === 'agent' &&
                           ` · ${t('assignee.agents')}`}
+                        {option.type === 'automation' &&
+                          ` · ${t('assignee.automations')}`}
                       </Text>
                     </span>
                   </li>

--- a/services/platform/app/features/tasks/components/task-comments.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.tsx
@@ -44,7 +44,7 @@ interface TaskComment {
   body: string;
   createdAt: number;
   editedAt?: number;
-  mentions?: Array<{ type: 'user' | 'agent'; id: string }>;
+  mentions?: Array<{ type: 'user' | 'agent' | 'automation'; id: string }>;
   bodyByLocale?: CommentBodyByLocale;
 }
 

--- a/services/platform/app/features/tasks/components/task-subject-panel.tsx
+++ b/services/platform/app/features/tasks/components/task-subject-panel.tsx
@@ -317,44 +317,39 @@ export function TaskSubjectPanel({
   };
 
   /**
-   * Request changes is ONE gesture: the feedback is written as the task's
-   * comment and the rerun starts after it lands. The workflow re-reads the
-   * task's comments on its next pass, so the order is the whole point — a
-   * rerun kicked before the comment exists would read no feedback and repeat
-   * itself, which is exactly the trap of asking the reviewer to remember to
-   * comment first.
+   * Request changes is ONE gesture, and that gesture is an `@`-mention: the
+   * feedback posts as a task comment addressed to the owning automation
+   * (`@<slug> …`), and the comment's mention trigger starts the rerun — the
+   * same lane a hand-typed `@` in the composer uses, so the timeline itself
+   * teaches the pattern. Plain comments stay inert; only the mention runs.
+   * The rerun starts after the comment lands (same transaction), so the
+   * workflow's next pass always reads this feedback.
    */
   const requestChanges = async () => {
     const body = feedback.trim();
     if (body === '') return;
     setBusy(true);
     try {
-      await addComment.mutateAsync({ taskId: task._id, body });
-      const result = await startRun.mutateAsync({
-        organizationId,
+      const result = await addComment.mutateAsync({
         taskId: task._id,
-        workflowSlug: automationSlug,
+        body: `@${automationSlug} ${body}`,
       });
       // The comment landed either way, so the box always closes and empties:
       // leaving the text in a still-open dialog invites a second Send back,
       // which would file the same feedback twice.
       setChangesOpen(false);
       setFeedback('');
-      if (result.started) {
+      if (result.automationTriggered) {
         toast({
           title: t('subject.requestChangesSent', { name: displayName }),
           variant: 'success',
         });
       } else {
-        // Say what did NOT happen — the feedback is recorded, nothing is running.
-        toast({
-          title:
-            result.reason === 'already_running'
-              ? t('run.alreadyRunning', { name: displayName })
-              : t('run.notStarted', { name: displayName }),
-          variant:
-            result.reason === 'already_running' ? undefined : 'destructive',
-        });
+        // Say what did NOT happen — the feedback is recorded, nothing new is
+        // running. The one quiet-refusal cause this gesture can actually hit
+        // is a run already operating the task (the panel hides Request
+        // changes otherwise), so phrase it as that.
+        toast({ title: t('run.alreadyRunning', { name: displayName }) });
       }
     } catch (error) {
       console.error('[tasks] request-changes failed', error);

--- a/services/platform/app/features/tasks/hooks/use-actor-directory.ts
+++ b/services/platform/app/features/tasks/hooks/use-actor-directory.ts
@@ -89,6 +89,12 @@ export function useActorDirectory(organizationId: string, projectId?: string) {
       ),
     [automations, locale],
   );
+  // The same population as a slug→display list, for the mention surfaces
+  // (`@vat-return-desk` renders as the automation's name, mirroring agents).
+  const automationList = useMemo(
+    () => [...appNames.entries()].map(([slug, name]) => ({ slug, name })),
+    [appNames],
+  );
 
   const previewLabels = useMemo(
     () => ({
@@ -251,6 +257,8 @@ export function useActorDirectory(organizationId: string, projectId?: string) {
     resolveWorkflowRunPreview,
     members: memberList,
     agents: agentList,
+    /** Deployed automations visible from this context, slug + display name. */
+    automations: automationList,
     /** True while the project's agent list is still being fetched — an empty
      * `agents` is only "this project HAS no agents" once this settles. */
     agentsLoading,

--- a/services/platform/app/features/tasks/lib/mention-actor-options.ts
+++ b/services/platform/app/features/tasks/lib/mention-actor-options.ts
@@ -1,14 +1,23 @@
+import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { useMemo } from 'react';
 
 import type { Id } from '@/convex/_generated/dataModel';
 
 import { useAssignableActors } from '../hooks/use-actor-directory';
-import { agentInsertHandle, memberInsertHandle } from './mention-handles';
+import {
+  useTaskContractAutomations,
+  taskSubjectEntries,
+} from '../hooks/use-task-subject-contract';
+import {
+  agentInsertHandle,
+  automationInsertHandle,
+  memberInsertHandle,
+} from './mention-handles';
 
 export const MAX_MENTION_OPTIONS = 8;
 
 export interface MentionActorOption {
-  type: 'user' | 'agent';
+  type: 'user' | 'agent' | 'automation';
   id: string;
   name: string;
   email?: string;
@@ -19,11 +28,13 @@ export interface MentionActorOption {
 
 /**
  * Mentionable actors for a project, in picker order: org members first, then
- * agents — the same population the server resolves mentions against
- * (`convex/tasks/directory.ts`). Agent scoping follows the project agent
- * gates: the default `agentMode: 'all'` exposes every org agent
- * (recommended ones first); `'restricted'` limits the list to the project's
- * `allowedAgentSlugs`.
+ * agents, then the automations operating this board — the same population the
+ * server resolves mentions against (`convex/tasks/directory.ts`). Agent
+ * scoping follows the project agent gates: the default `agentMode: 'all'`
+ * exposes every org agent (recommended ones first); `'restricted'` limits the
+ * list to the project's `allowedAgentSlugs`. Automations are the deployed
+ * subject-contract ones the assignee picker offers — @-ing a task's OWNING
+ * automation puts it to work, exactly like @-ing an agent instance.
  *
  * Used by the Tasks `MentionTextarea` as its `@`-mention source, aligned
  * with the server's actor resolution.
@@ -34,6 +45,8 @@ export function useMentionActorOptions(
 ): MentionActorOption[] {
   const { assignableMembers, assignableAgents, currentUserId } =
     useAssignableActors(organizationId, projectId);
+  const automations = useTaskContractAutomations(organizationId, projectId);
+  const { locale } = useLocale();
 
   return useMemo(() => {
     const options: MentionActorOption[] = [];
@@ -62,8 +75,24 @@ export function useMentionActorOptions(
         handle,
       });
     }
+    for (const entry of taskSubjectEntries(automations, locale)) {
+      // Insert the store name — stable addressing the server always resolves,
+      // identical for every reader whatever their locale.
+      const handle = automationInsertHandle({
+        slug: entry.automationSlug,
+        name: entry.displayName,
+      });
+      if (handle) {
+        options.push({
+          type: 'automation',
+          id: entry.automationSlug,
+          name: entry.displayName,
+          handle,
+        });
+      }
+    }
     return options;
-  }, [assignableMembers, assignableAgents, currentUserId]);
+  }, [assignableMembers, assignableAgents, automations, currentUserId, locale]);
 }
 
 export function filterMentionActorOptions(

--- a/services/platform/app/features/tasks/lib/mention-handles.ts
+++ b/services/platform/app/features/tasks/lib/mention-handles.ts
@@ -72,3 +72,41 @@ export function agentHandleVariants(agent: MentionableAgent): string[] {
 export function agentInsertHandle(agent: MentionableAgent): string | null {
   return agentHandleVariants(agent)[0] ?? null;
 }
+
+export interface MentionableAutomation {
+  /** The automation's store name (slug) — the stable addressing form. */
+  slug: string;
+  /** Display name in the reader's locale. */
+  name: string;
+}
+
+/** All candidate handles for a deployed automation, lowercased, the server
+ *  derivation order (`convex/tasks/directory.ts::automationHandles`): store
+ *  name → dotted display name → squashed display name. */
+export function automationHandleVariants(
+  automation: MentionableAutomation,
+): string[] {
+  const name = automation.name.trim().toLowerCase();
+  const candidates = [
+    automation.slug,
+    name.replace(/\s+/g, '.'),
+    name.replace(/\s+/g, ''),
+  ];
+  const variants: string[] = [];
+  for (const candidate of candidates) {
+    if (candidate && MENTION_TOKEN_RE.test(candidate)) {
+      const lowered = candidate.toLowerCase();
+      if (!variants.includes(lowered)) variants.push(lowered);
+    }
+  }
+  return variants;
+}
+
+/** The handle the composer inserts for an automation: the store name — it is
+ *  already readable (`vat-return-desk`) and, unlike the localized display
+ *  name, identical for every teammate reading the comment back. */
+export function automationInsertHandle(
+  automation: MentionableAutomation,
+): string | null {
+  return automationHandleVariants(automation)[0] ?? null;
+}

--- a/services/platform/convex/collab/notify.ts
+++ b/services/platform/convex/collab/notify.ts
@@ -489,7 +489,7 @@ export async function notifyChatMentions(
     organizationId: string;
     threadId: string;
     threadTitle: string;
-    mentions: Array<{ type: 'user' | 'agent'; id: string }>;
+    mentions: Array<{ type: 'user' | 'agent' | 'automation'; id: string }>;
     actorType: ActorType;
     actorId: string;
     projectId?: Id<'projects'>;
@@ -529,7 +529,7 @@ export async function notifyTaskMentions(
   ctx: MutationCtx,
   args: {
     task: Doc<'tasks'>;
-    mentions: Array<{ type: 'user' | 'agent'; id: string }>;
+    mentions: Array<{ type: 'user' | 'agent' | 'automation'; id: string }>;
     actorType: ActorType;
     actorId: string;
   },
@@ -572,7 +572,7 @@ export async function notifyTaskComment(
     // (string) since task comments live in the message store; `resourceId`
     // already stores it via `String()`, and `resourceType:'comment'` is unchanged.
     commentId: string;
-    mentions: Array<{ type: 'user' | 'agent'; id: string }>;
+    mentions: Array<{ type: 'user' | 'agent' | 'automation'; id: string }>;
     actorType: ActorType;
     actorId: string;
     /**

--- a/services/platform/convex/tasks/automation_mention_trigger.test.ts
+++ b/services/platform/convex/tasks/automation_mention_trigger.test.ts
@@ -1,0 +1,384 @@
+// Coverage for the comment `@automation` work trigger — the app-lane twin of
+// the agent mention trigger: a plain comment on an automation-owned task is
+// just a comment; @-ing the OWNING automation schedules its task workflow
+// (`startTaskWorkflowRun` → `automationRuns` row carrying the task subject).
+// Locks the guard matrix (ownership cascade, write access, one engine per
+// task) and the directory contract (store-name + display-name handles).
+
+import agentComponent from '@convex-dev/agent/test';
+import rateLimiterComponent from '@convex-dev/rate-limiter/test';
+import { convexTest, type TestConvex } from 'convex-test';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'tasks';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_automention';
+const EDITOR = 'u_editor';
+const VIEWER = 'u_viewer';
+const DESK = 'vat-return-desk';
+const OTHER = 'other-desk';
+
+type T = TestConvex<typeof schema>;
+
+const testBackends = new Set<T>();
+
+// Drain the scheduled hand-offs a comment kicks (startTaskWorkflowRun, then
+// the stepper's first step) so no background job leaks into the next test.
+async function drain(t: T): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await t.finishInProgressScheduledFunctions();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all([...testBackends].map((t) => drain(t)));
+  testBackends.clear();
+});
+
+function world(): T {
+  const t = convexTest(schema, modules);
+  rateLimiterComponent.register(t);
+  agentComponent.register(t);
+  testBackends.add(t);
+  return t;
+}
+
+/** A minimal runnable automation document — one transform node. */
+function automationDocument(name: string) {
+  return {
+    version: 1,
+    name,
+    nodes: [{ id: 'shape', type: 'transform', code: 'return 1;' }],
+    output: '{{ nodes.shape.output }}',
+  };
+}
+
+async function seedWorld(
+  t: T,
+  taskOverrides: {
+    assigneeType?: 'user' | 'agent' | 'app';
+    assigneeId?: string;
+    createdByType?: 'user' | 'agent' | 'app';
+    createdBy?: string;
+    externalSystem?: string;
+  } = { assigneeType: 'app', assigneeId: DESK },
+): Promise<{ projectId: Id<'projects'>; taskId: Id<'tasks'> }> {
+  return t.run(async (ctx) => {
+    for (const [userId, role] of [
+      [EDITOR, 'editor'],
+      [VIEWER, 'member'],
+    ] as const) {
+      await ctx.db.insert('memberMirror', {
+        memberId: `m_${userId}_${ORG}`,
+        userId,
+        organizationId: ORG,
+        role,
+        createdAt: 0,
+      });
+    }
+    const projectId = await ctx.db.insert('projects', {
+      organizationId: ORG,
+      name: 'Rhône-Alpes SARL',
+      createdBy: EDITOR,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    for (const name of [DESK, OTHER]) {
+      await ctx.db.insert('automations', {
+        organizationId: ORG,
+        name,
+        version: 1,
+        document: automationDocument(name),
+        presentation: {
+          name: name === DESK ? 'Swiss VAT return desk' : 'Other desk',
+        },
+        taskContract: {
+          workflow: name,
+          ...(name === DESK ? { externalSystem: 'vatplus' } : {}),
+        },
+        createdBy: EDITOR,
+        createdAt: 0,
+      });
+      await ctx.db.insert('automationDeployments', {
+        organizationId: ORG,
+        name,
+        version: 1,
+        deployedBy: EDITOR,
+        deployedAt: 0,
+      });
+    }
+    const taskId = await ctx.db.insert('tasks', {
+      organizationId: ORG,
+      projectId,
+      title: 'VAT return 2026Q1',
+      status: 'in_review',
+      rank: 'a0',
+      createdBy: EDITOR,
+      createdByType: 'user',
+      createdAt: 0,
+      updatedAt: 0,
+      ...taskOverrides,
+    });
+    return { projectId, taskId };
+  });
+}
+
+async function runs(t: T) {
+  return await t.run((ctx) => ctx.db.query('automationRuns').collect());
+}
+
+describe('comment @automation trigger', () => {
+  it('@-ing the owning automation schedules its task workflow', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} the summary still cites last period`,
+      });
+    expect(result.automationTriggered).toBe(true);
+    await drain(t);
+
+    const rows = await runs(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: DESK,
+      mode: 'live',
+      startedBy: `user:${EDITOR}`,
+    });
+    const input = rows[0]?.input as { task?: { id?: string } };
+    expect(input.task?.id).toBe(String(taskId));
+  });
+
+  it('the display-name handle resolves and triggers too', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: '@swiss.vat.return.desk please redo the figures',
+      });
+    expect(result.automationTriggered).toBe(true);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(1);
+  });
+
+  it('a plain comment never starts anything', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: 'looks wrong, but let me check the source files first',
+      });
+    expect(result.automationTriggered).toBe(false);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(0);
+  });
+
+  it('@-ing an automation that does not own the task is a quiet no-op', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${OTHER} take over`,
+      });
+    expect(result.automationTriggered).toBe(false);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(0);
+  });
+
+  it("a read-only member's mention only comments", async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t);
+
+    const result = await t
+      .withIdentity({ subject: VIEWER })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} please rerun`,
+      });
+    expect(result.automationTriggered).toBe(false);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(0);
+  });
+
+  it('changes nothing while a run is already operating the task', async () => {
+    const t = world();
+    const { projectId, taskId } = await seedWorld(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('automationRuns', {
+        organizationId: ORG,
+        name: DESK,
+        version: 1,
+        projectId,
+        status: 'running',
+        mode: 'live',
+        startedBy: `user:${EDITOR}`,
+        input: { task: { id: String(taskId) } },
+        checkpoints: { nodes: {}, executions: 0 },
+        wakeAt: Date.now() + 60_000,
+        claimEpoch: 0,
+        startedAt: Date.now(),
+      });
+    });
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} hurry up`,
+      });
+    expect(result.automationTriggered).toBe(false);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(1); // still only the live one
+  });
+
+  it('falls back to the creation stamp for unassigned tasks', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t, {
+      createdByType: 'app',
+      createdBy: DESK,
+    });
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} numbers are stale`,
+      });
+    expect(result.automationTriggered).toBe(true);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(1);
+  });
+
+  it("falls back to the automation's declared externalSystem namespace", async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t, { externalSystem: 'vatplus' });
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} recalculate`,
+      });
+    expect(result.automationTriggered).toBe(true);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(1);
+  });
+
+  it('an agent-assigned task ignores automation mentions', async () => {
+    const t = world();
+    const { taskId } = await seedWorld(t, {
+      assigneeType: 'agent',
+      assigneeId: 'some-agent',
+    });
+
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} run anyway`,
+      });
+    expect(result.automationTriggered).toBe(false);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(0);
+  });
+
+  it('the directory resolves an automation by store name and name variants', async () => {
+    const t = world();
+    const { projectId } = await seedWorld(t);
+
+    const entry = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectId);
+      if (!project) throw new Error('project missing');
+      const { buildMentionDirectory } = await import('./directory');
+      const directory = await buildMentionDirectory(ctx, {
+        organizationId: ORG,
+        project,
+      });
+      return directory.entries.find(
+        (e) => e.type === 'automation' && e.id === DESK,
+      );
+    });
+    expect(entry).toBeDefined();
+    expect(entry?.handles).toContain(DESK);
+    expect(entry?.handles).toContain('swiss.vat.return.desk');
+    expect(entry?.handles).toContain('swissvatreturndesk');
+  });
+
+  it('an automation bound to ANOTHER project is not mentionable here', async () => {
+    const t = world();
+    const { projectId, taskId } = await seedWorld(t);
+    await t.run(async (ctx) => {
+      const otherProject = await ctx.db.insert('projects', {
+        organizationId: ORG,
+        name: 'Elsewhere',
+        createdBy: EDITOR,
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      await ctx.db.insert('automationProjectBindings', {
+        organizationId: ORG,
+        automationName: DESK,
+        projectId: otherProject,
+        boundAt: 0,
+        boundBy: EDITOR,
+      });
+    });
+
+    const listed = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectId);
+      if (!project) throw new Error('project missing');
+      const { buildMentionDirectory } = await import('./directory');
+      const directory = await buildMentionDirectory(ctx, {
+        organizationId: ORG,
+        project,
+      });
+      return directory.entries.some(
+        (e) => e.type === 'automation' && e.id === DESK,
+      );
+    });
+    expect(listed).toBe(false);
+
+    // …and the comment path stays inert for it (the token now resolves via
+    // the permissive-agent fallback, which no-ops at agent run admission).
+    const result = await t
+      .withIdentity({ subject: EDITOR })
+      .mutation(api.tasks.mutations.addTaskComment, {
+        taskId,
+        body: `@${DESK} rerun`,
+      });
+    expect(result.automationTriggered).toBe(false);
+    await drain(t);
+    expect(await runs(t)).toHaveLength(0);
+  });
+});

--- a/services/platform/convex/tasks/directory.ts
+++ b/services/platform/convex/tasks/directory.ts
@@ -2,8 +2,9 @@
  * Mention/assignee directory for tasks.
  *
  * Builds the set of `@`-mentionable actors for a project: organization members
- * (humans) and the agents the project exposes. Used by the task mutations to
- * resolve `@token` mentions to `{type,id}` refs (see `tasks/mentions.ts`).
+ * (humans), the agents the project exposes, and the deployed automations
+ * visible from it. Used by the task mutations to resolve `@token` mentions to
+ * `{type,id}` refs (see `tasks/mentions.ts`).
  *
  * Agent scoping follows the project agent gates (`task_ops.ts`):
  * `agentMode: 'restricted'` limits mentionable agents to the project's
@@ -16,6 +17,7 @@
 
 import type { Doc } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
+import { bindingsOf, versionRow } from '../automations/store';
 import { listByOrganizationHandler } from '../members/queries';
 import { getProjectAccessibleUserIds } from '../projects/accessible_members';
 import type { MentionDirectoryEntry } from './mentions';
@@ -93,6 +95,54 @@ export async function buildMentionDirectory(
     entries.push({ type: 'agent', id: slug, handles: [slug.toLowerCase()] });
   }
 
+  // DEPLOYED automations visible from this project (bound to it, or
+  // org-level) resolve by store name and by display name — '@vat-return-desk',
+  // '@swiss.vat.return.desk'. Mentioning a task's OWNING automation is the
+  // comment-side run trigger (`triggerMentionedTaskAutomation`), exactly as
+  // @-ing an agent instance is for the agent lane; on any other surface the
+  // mention is presentational. Pushed after the legacy slugs (an automation
+  // shadows a retired same-named slug) but before the instances below (a
+  // project's own agent instance stays the strongest claim on a handle).
+  try {
+    const deployments = await ctx.db
+      .query('automationDeployments')
+      .withIndex('by_org', (q) => q.eq('organizationId', args.organizationId))
+      .collect();
+    for (const deployment of deployments) {
+      const bindings = await bindingsOf(
+        ctx,
+        args.organizationId,
+        deployment.name,
+      );
+      if (
+        bindings.length > 0 &&
+        !bindings.some((binding) => binding.projectId === args.project._id)
+      ) {
+        continue;
+      }
+      const version = await versionRow(
+        ctx,
+        args.organizationId,
+        deployment.name,
+        deployment.version,
+      );
+      if (!version) continue;
+      entries.push({
+        type: 'automation',
+        id: deployment.name,
+        handles: automationHandles(
+          deployment.name,
+          presentationName(version.presentation),
+        ),
+      });
+    }
+  } catch (error) {
+    console.warn(
+      '[tasks] buildMentionDirectory: automation listing failed',
+      error,
+    );
+  }
+
   // The project's agent INSTANCES resolve by display name — '@alice',
   // '@pr.reviewer'. Pushed LAST so an instance handle shadows a same-named
   // legacy slug in the resolver's handle map, and a mention reaches the
@@ -119,6 +169,36 @@ export async function buildMentionDirectory(
     entries,
     permissiveAgents: (args.project.agentMode ?? 'all') !== 'restricted',
   };
+}
+
+/** The base (English) display name out of an automation version's untyped
+ * `presentation` blob, if it carries one. Handles are locale-independent, so
+ * only the base name feeds them — per-locale names stay a render concern. */
+function presentationName(presentation: unknown): string | undefined {
+  if (
+    presentation !== null &&
+    typeof presentation === 'object' &&
+    'name' in presentation &&
+    typeof presentation.name === 'string' &&
+    presentation.name.trim() !== ''
+  ) {
+    return presentation.name;
+  }
+  return undefined;
+}
+
+/** Derive candidate `@handle`s for a deployed automation: the store name
+ * (the stable addressing form the composer inserts) plus the display-name
+ * variants (dot-joined and squashed, matching the member/instance
+ * convention) so a hand-typed `@swiss.vat.return.desk` resolves too. */
+function automationHandles(name: string, displayName?: string): string[] {
+  const handles = new Set<string>([name.toLowerCase()]);
+  const normalized = (displayName ?? '').trim().toLowerCase();
+  if (normalized !== '') {
+    handles.add(normalized.replace(/\s+/g, '.'));
+    handles.add(normalized.replace(/\s+/g, ''));
+  }
+  return [...handles];
 }
 
 /** Derive candidate `@handle`s for a project agent instance: the display

--- a/services/platform/convex/tasks/helpers.ts
+++ b/services/platform/convex/tasks/helpers.ts
@@ -11,6 +11,7 @@ import {
 } from '../../lib/shared/task-label-colors';
 import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
+import { parseIssueNumber, parseRepoRef } from './issue_ref';
 import { initialRank, rankBetween } from './rank';
 
 export const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
@@ -349,6 +350,50 @@ export async function hasOpenChildren(
     }
   }
   return false;
+}
+
+/** The task fields a workflow-run subject is built from. */
+export type TaskWorkflowSubjectFields = Pick<
+  Doc<'tasks'>,
+  | '_id'
+  | 'title'
+  | 'status'
+  | 'projectId'
+  | 'externalSystem'
+  | 'externalId'
+  | 'externalUrl'
+>;
+
+/**
+ * The `input.task` subject a task-workflow run receives — ONE builder for
+ * every start door (task-board Start, create→run schedule, REST, the comment
+ * `@automation` trigger), so the shape the workflow templates read
+ * (`input.task.*`) cannot drift between them. The issue number and
+ * `owner/repo` ref are derived from the task's `externalId`
+ * ("owner/repo#N"); both are null-elided for non-issue tasks.
+ */
+export function taskWorkflowSubjectInput(task: TaskWorkflowSubjectFields): {
+  task: Record<string, unknown>;
+} {
+  const issueNumber = parseIssueNumber(task.externalId);
+  const repoRef = parseRepoRef(task.externalId);
+  return {
+    task: {
+      id: String(task._id),
+      title: task.title,
+      status: task.status,
+      projectId: String(task.projectId),
+      ...(task.externalSystem !== undefined
+        ? { externalSystem: task.externalSystem }
+        : {}),
+      ...(task.externalId !== undefined ? { externalId: task.externalId } : {}),
+      ...(task.externalUrl !== undefined
+        ? { externalUrl: task.externalUrl }
+        : {}),
+      ...(issueNumber !== null ? { issueNumber } : {}),
+      ...(repoRef !== null ? { repo: `${repoRef.owner}/${repoRef.repo}` } : {}),
+    },
+  };
 }
 
 export type TaskActivityAttribution = {

--- a/services/platform/convex/tasks/internal_mutations.ts
+++ b/services/platform/convex/tasks/internal_mutations.ts
@@ -47,11 +47,11 @@ import {
   TASK_COMMENT_MAX,
   TASK_TITLE_MAX,
   taskCountBucket,
+  taskWorkflowSubjectInput,
   TERMINAL_STATUSES,
   truncateImportedTitle,
   workflowActivityContext,
 } from './helpers';
-import { parseIssueNumber, parseRepoRef } from './issue_ref';
 import {
   extractMentions,
   parseMentionTokens,
@@ -1871,8 +1871,6 @@ export const scheduleTaskWorkflowStart = internalMutation({
       );
       return null;
     }
-    const issueNumber = parseIssueNumber(task.externalId);
-    const repoRef = parseRepoRef(task.externalId);
     await ctx.scheduler.runAfter(
       0,
       internal.automations.mutations.startTaskWorkflowRun,
@@ -1884,27 +1882,7 @@ export const scheduleTaskWorkflowStart = internalMutation({
         startedBy: `${args.startedVia ?? 'user'}:${args.userId}`,
         // The same subject shape the task-board Start builds — the workflow
         // templates read `input.task.*`.
-        input: {
-          task: {
-            id: String(args.taskId),
-            title: task.title,
-            status: task.status,
-            projectId: String(task.projectId),
-            ...(task.externalSystem !== undefined
-              ? { externalSystem: task.externalSystem }
-              : {}),
-            ...(task.externalId !== undefined
-              ? { externalId: task.externalId }
-              : {}),
-            ...(task.externalUrl !== undefined
-              ? { externalUrl: task.externalUrl }
-              : {}),
-            ...(issueNumber !== null ? { issueNumber } : {}),
-            ...(repoRef !== null
-              ? { repo: `${repoRef.owner}/${repoRef.repo}` }
-              : {}),
-          },
-        },
+        input: taskWorkflowSubjectInput(task),
       },
     );
     return null;

--- a/services/platform/convex/tasks/internal_queries.ts
+++ b/services/platform/convex/tasks/internal_queries.ts
@@ -35,7 +35,7 @@ export interface TaskDiscussionMessage {
   body: string;
   createdAt: number;
   editedAt?: number;
-  mentions?: Array<{ type: 'user' | 'agent'; id: string }>;
+  mentions?: Array<{ type: 'user' | 'agent' | 'automation'; id: string }>;
   /** Write-time locale snapshot when the workflow posted `bodyI18n`. */
   bodyByLocale?: { en: string; de: string; fr: string };
 }

--- a/services/platform/convex/tasks/mentions.test.ts
+++ b/services/platform/convex/tasks/mentions.test.ts
@@ -13,6 +13,11 @@ const directory: MentionDirectoryEntry[] = [
   { type: 'user', id: 'user-alice', handles: ['alice', 'alice.smith'] },
   { type: 'user', id: 'user-bob', handles: ['bob'] },
   { type: 'agent', id: 'researcher', handles: ['researcher'] },
+  {
+    type: 'automation',
+    id: 'vat-return-desk',
+    handles: ['vat-return-desk', 'swiss.vat.return.desk'],
+  },
 ];
 
 describe('parseMentionTokens', () => {
@@ -113,6 +118,16 @@ describe('resolveMentions (permissiveAgents)', () => {
       { type: 'user', id: 'user-alice' },
       { type: 'agent', id: 'unknown' },
     ]);
+  });
+
+  it('automation handles win over the permissive agent fallback', () => {
+    expect(
+      resolveMentions(
+        ['vat-return-desk', 'swiss.vat.return.desk'],
+        directory,
+        true,
+      ),
+    ).toEqual([{ type: 'automation', id: 'vat-return-desk' }]);
   });
 
   it('stays strict when permissiveAgents is off', () => {

--- a/services/platform/convex/tasks/mentions.ts
+++ b/services/platform/convex/tasks/mentions.ts
@@ -13,11 +13,12 @@
 
 const MENTION_RE = /(?:^|\s)@([a-zA-Z0-9._/-]+)/g;
 
-export type MentionActorType = 'user' | 'agent';
+export type MentionActorType = 'user' | 'agent' | 'automation';
 
 export interface MentionDirectoryEntry {
   type: MentionActorType;
-  /** Stable id used as `assigneeId`/`subscriberId` — a userId or agent slug. */
+  /** Stable id used as `assigneeId`/`subscriberId` — a userId, an agent slug
+   *  or instance id, or an automation's store name. */
   id: string;
   /** The `@token` handle(s) that resolve to this entry, lowercased. */
   handles: string[];

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -14,6 +14,7 @@
 
 import { ConvexError, v } from 'convex/values';
 
+import { parseTaskSubjectContract } from '../../lib/shared/schemas/task_contract';
 import { defaultTaskLabelColor } from '../../lib/shared/task-label-colors';
 import { components, internal } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
@@ -26,6 +27,7 @@ import { assertAgentAssigneeLive } from '../agents/installations';
 import { recordTaskAgentRunLedgerEntry } from '../audit_logs/agent_run_ledger';
 import { createAuditLog } from '../audit_logs/helpers';
 import { findLiveAutomationRunForTask } from '../automations/queries';
+import { versionRow } from '../automations/store';
 import { getUserById } from '../betterAuth/trusted_headers/get_user_by_id';
 import {
   autoSubscribe,
@@ -86,6 +88,7 @@ import {
   TASK_COMMENT_MAX,
   TASK_DESCRIPTION_MAX,
   TASK_TITLE_MAX,
+  taskWorkflowSubjectInput,
   TERMINAL_STATUSES,
 } from './helpers';
 import { postTaskDiscussionMessage } from './internal_mutations';
@@ -1216,6 +1219,7 @@ async function applyUserTaskComment(
   messageId: string;
   threadId: string;
   unresolvedMentionTokens: string[];
+  automationTriggered: boolean;
 }> {
   const { task, project, auth } = args;
   // Commenting is a READ-level action on the unified task_discussion surface:
@@ -1334,13 +1338,24 @@ async function applyUserTaskComment(
     feedback: body,
   });
 
+  // @-ing the task's OWNING automation is the app-lane counterpart: the
+  // workflow reruns and reads this comment (with the rest of the timeline)
+  // as its feedback. A plain comment — or any other automation's handle —
+  // never starts anything.
+  const automationTriggered = await triggerMentionedTaskAutomation(ctx, {
+    task,
+    project,
+    auth,
+    mentions,
+  });
+
   const { unresolvedMentionTokens } = await resolveSurfaceMentions(ctx, {
     organizationId: task.organizationId,
     body,
     projectId: task.projectId,
   });
 
-  return { messageId, threadId, unresolvedMentionTokens };
+  return { messageId, threadId, unresolvedMentionTokens, automationTriggered };
 }
 
 export const addTaskComment = mutation({
@@ -1350,11 +1365,15 @@ export const addTaskComment = mutation({
   },
   // Returns the new message id AND the (lazily-created) discussion thread id —
   // the frontend bootstrap needs the threadId to resolve a previously-threadless
-  // task without a read-after-write ordering hole.
+  // task without a read-after-write ordering hole. `automationTriggered` says
+  // whether an @-mention of the task's owning automation scheduled a workflow
+  // start (the Request-changes gesture phrases its toast from it); optional in
+  // the wire shape so a stale client bundle keeps validating.
   returns: v.object({
     messageId: v.string(),
     threadId: v.string(),
     unresolvedMentionTokens: v.array(v.string()),
+    automationTriggered: v.optional(v.boolean()),
   }),
   handler: async (
     ctx,
@@ -1363,6 +1382,7 @@ export const addTaskComment = mutation({
     messageId: string;
     threadId: string;
     unresolvedMentionTokens: string[];
+    automationTriggered: boolean;
   }> => {
     const task = await loadTaskOrThrow(ctx, args.taskId);
     const project = await loadProjectOrThrow(ctx, task.projectId);
@@ -1568,6 +1588,116 @@ async function triggerMentionedProjectAgent(
       `[tasks] mention trigger for agent ${String(instance._id)} refused: ${kicked.reason ?? 'unknown'}`,
     );
   }
+}
+
+/**
+ * Does the named automation OWN this task? The server-side mirror of the
+ * client's `resolveTaskOwnership` cascade: the assignee decides first (an
+ * `app` assignee must match; an agent or human assignee means no automation
+ * owns the task), then — for unassigned rows only — the creation stamp, then
+ * the task's `externalSystem` against the automation's own deployed contract.
+ * That last fallback is STRICTER than the client's unique-namespace guess:
+ * the mention names the automation explicitly, so only that automation's
+ * declared namespace is consulted.
+ */
+async function isOwningTaskAutomation(
+  ctx: MutationCtx,
+  task: Doc<'tasks'>,
+  name: string,
+): Promise<boolean> {
+  if (task.assigneeType === 'app') return task.assigneeId === name;
+  if (task.assigneeType !== undefined) return false;
+  if (task.createdByType === 'app') return task.createdBy === name;
+  if (task.externalSystem === undefined || task.externalSystem === '') {
+    return false;
+  }
+  const deployment = await ctx.db
+    .query('automationDeployments')
+    .withIndex('by_org_name', (q) =>
+      q.eq('organizationId', task.organizationId).eq('name', name),
+    )
+    .unique();
+  if (!deployment) return false;
+  const version = await versionRow(
+    ctx,
+    task.organizationId,
+    name,
+    deployment.version,
+  );
+  const contract =
+    version === null ? null : parseTaskSubjectContract(version.taskContract);
+  return contract?.externalSystem === task.externalSystem;
+}
+
+/**
+ * The comment-@mention work trigger for AUTOMATION-owned tasks — the exact
+ * counterpart of {@link triggerMentionedProjectAgent} on the app lane: a
+ * plain comment on an automation's task is just a comment; @-ing the OWNING
+ * automation starts its task workflow, which re-reads the timeline (this
+ * comment included) as its feedback. Mentioning any OTHER automation never
+ * starts anything — a task runs only the workflow it belongs to.
+ *
+ * Refusals are deliberately quiet, mirroring the agent lane: the comment has
+ * already posted, and a task with a live engine (either lane) keeps it — the
+ * scheduled start's own duplicate guard backstops the pre-check. Gated on
+ * WRITE access: commenting is read-level, but running a workflow is an edit,
+ * so a read-only member's @ stays a plain mention.
+ *
+ * Returns whether a start was scheduled — the Request-changes gesture posts
+ * exactly such a mention and reads this to phrase its toast.
+ */
+async function triggerMentionedTaskAutomation(
+  ctx: MutationCtx,
+  args: {
+    task: Doc<'tasks'>;
+    project: Doc<'projects'>;
+    auth: AuthContext;
+    mentions: ResolvedMention[];
+  },
+): Promise<boolean> {
+  const { task, project, auth } = args;
+  const mentioned = args.mentions.find(
+    (mention) => mention.type === 'automation',
+  );
+  if (mentioned === undefined) return false;
+  if (
+    !checkProjectAccess(project, auth.teamIds, auth.role).canEdit ||
+    task.archivedAt !== undefined
+  ) {
+    return false;
+  }
+  if (!(await isOwningTaskAutomation(ctx, task, mentioned.id))) {
+    console.warn(
+      `[tasks] automation mention "${mentioned.id}" ignored: it does not own task ${String(task._id)}`,
+    );
+    return false;
+  }
+  // One engine per task, across BOTH lanes — same invariant as the agent
+  // trigger. The workflow itself tells commenters that mid-run comments are
+  // not read; a mention during a live run is that case, not a second start.
+  if ((await liveTaskAgentRun(ctx, task._id)) !== null) return false;
+  if (
+    (await findLiveAutomationRunForTask(ctx, {
+      organizationId: task.organizationId,
+      projectId: task.projectId,
+      taskId: task._id,
+    })) !== null
+  ) {
+    return false;
+  }
+  await ctx.scheduler.runAfter(
+    0,
+    internal.automations.mutations.startTaskWorkflowRun,
+    {
+      organizationId: task.organizationId,
+      name: mentioned.id,
+      taskId: String(task._id),
+      projectId: task.projectId,
+      startedBy: `user:${auth.userId}`,
+      input: taskWorkflowSubjectInput(task),
+    },
+  );
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/services/platform/convex/tasks/public_actions.ts
+++ b/services/platform/convex/tasks/public_actions.ts
@@ -4,7 +4,8 @@ import { api, internal } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
 import { type ActionCtx, action } from '../_generated/server';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
-import { parseIssueNumber, parseRepoRef } from './issue_ref';
+import { taskWorkflowSubjectInput } from './helpers';
+import { parseRepoRef } from './issue_ref';
 
 /**
  * Start a workflow ON an existing task, subject-linked so any UI showing the
@@ -40,11 +41,6 @@ export async function startWorkflowForTask(
     startedVia?: 'user' | 'api-key';
   },
 ): Promise<{ runId: string; alreadyRunning: boolean } | null> {
-  const issueNumber = parseIssueNumber(args.task.externalId);
-  // owner/repo from the same "owner/repo#N" ref, so a workflow can address the
-  // upstream issue (e.g. the desk pre-check's get_issue) without re-parsing;
-  // null for a non-issue/malformed ref, which the workflow guards on.
-  const repoRef = parseRepoRef(args.task.externalId);
   try {
     // The workflow slug names a DEPLOYED automation of this organization; the
     // run carries the task as its input — the same contract the retired
@@ -61,27 +57,7 @@ export async function startWorkflowForTask(
         // modal's live-run lookup and the project run log key on.
         projectId: args.task.projectId,
         startedBy: `${args.startedVia ?? 'user'}:${args.startedByUserId}`,
-        input: {
-          task: {
-            id: String(args.task._id),
-            title: args.task.title,
-            status: args.task.status,
-            projectId: String(args.task.projectId),
-            ...(args.task.externalSystem !== undefined
-              ? { externalSystem: args.task.externalSystem }
-              : {}),
-            ...(args.task.externalId !== undefined
-              ? { externalId: args.task.externalId }
-              : {}),
-            ...(args.task.externalUrl !== undefined
-              ? { externalUrl: args.task.externalUrl }
-              : {}),
-            ...(issueNumber !== null ? { issueNumber } : {}),
-            ...(repoRef !== null
-              ? { repo: `${repoRef.owner}/${repoRef.repo}` }
-              : {}),
-          },
-        },
+        input: taskWorkflowSubjectInput(args.task),
       },
     );
     if (started === null) {

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -36,6 +36,7 @@ import {
   boardViewScopeValidator,
   boardViewTypeValidator,
   taskActorTypeValidator,
+  taskMentionTypeValidator,
   taskAssigneeTypeValidator,
   taskAttachmentValidator,
   taskCreatorTypeValidator,
@@ -444,7 +445,7 @@ const taskDiscussionMessageValidator = v.object({
   createdAt: v.number(),
   editedAt: v.optional(v.number()),
   mentions: v.optional(
-    v.array(v.object({ type: taskActorTypeValidator, id: v.string() })),
+    v.array(v.object({ type: taskMentionTypeValidator, id: v.string() })),
   ),
   bodyByLocale: v.optional(
     v.object({

--- a/services/platform/convex/tasks/schema.ts
+++ b/services/platform/convex/tasks/schema.ts
@@ -58,6 +58,20 @@ export const taskActorTypeValidator = v.union(
 );
 
 /**
+ * What an `@mention` can resolve TO — a superset of the author types above:
+ * besides a human or an agent, a comment can mention an AUTOMATION (by store
+ * name), which is how the task surface asks the owning automation to run
+ * (`triggerMentionedTaskAutomation`). Automations never AUTHOR comments under
+ * this type — workflow comments post as `agent` — so authorship keeps the
+ * narrower validator.
+ */
+export const taskMentionTypeValidator = v.union(
+  v.literal('user'),
+  v.literal('agent'),
+  v.literal('automation'),
+);
+
+/**
  * The WORKER a task belongs to — exactly one of three classes: a human
  * (`user`), an AI agent (`agent`), or an automation (`app` — `assigneeId`
  * then holds the automation's store name, and the board's status verbs run
@@ -305,7 +319,7 @@ export const taskDiscussionMessageMetaTable = defineTable({
   mentions: v.optional(
     v.array(
       v.object({
-        type: taskActorTypeValidator,
+        type: taskMentionTypeValidator,
         id: v.string(),
       }),
     ),
@@ -340,7 +354,7 @@ export interface CommentEventComment {
   body: string;
   projectId: string;
   taskId: string;
-  mentions: Array<{ type: 'user' | 'agent'; id: string }>;
+  mentions: Array<{ type: 'user' | 'agent' | 'automation'; id: string }>;
 }
 
 /** Optional workflow attribution on a task-activity row (workflow-engine writes). */

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6720,7 +6720,7 @@ tasks:
     budgetPaused: '{slug} antwortet nicht — Monatsbudget aufgebraucht'
     agentNotLive: '{slug} antwortet nicht — Agent ist nicht installiert oder deaktiviert'
   mentionPicker:
-    title: Mitglied oder Agent erwähnen
+    title: Mitglied, Agent oder Automatisierung erwähnen
     empty: Keine Treffer
   metrics:
     title: Projekt-Metriken

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6794,7 +6794,7 @@ tasks:
     budgetPaused: "{slug} won't respond — monthly budget exhausted"
     agentNotLive: "{slug} won't respond — agent is not installed or is disabled"
   mentionPicker:
-    title: Mention a member or agent
+    title: Mention a member, agent, or automation
     empty: No matches
   metrics:
     title: Project metrics

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6838,7 +6838,7 @@ tasks:
     budgetPaused: '{slug} ne répondra pas — budget mensuel épuisé'
     agentNotLive: "{slug} ne répondra pas — l'agent n'est pas installé ou est désactivé"
   mentionPicker:
-    title: Mentionner un membre ou un agent
+    title: Mentionner un membre, un agent ou une automatisation
     empty: Aucun résultat
   metrics:
     title: Métriques du projet


### PR DESCRIPTION
## What

Tasks assigned to an automation now share the agent-task comment contract: a plain comment is just a comment, and **@-mentioning the task's owning automation** is what starts its workflow again — with the comment (plus the timeline since the last delivery) as feedback. The subject panel's **Request changes** now composes exactly that mention: it posts ONE \`@<slug> <feedback>\` comment and rides the same trigger lane, so the timeline itself teaches the pattern.

## How

- **Mentions grow a third actor type** \`automation\` (id = store name). The directory adds deployed automations visible from the project (bound + org-level), with store-name + display-name handles; agent instances keep the strongest claim on colliding handles, and automation handles shadow the permissive-agent fallback.
- **Trigger** (\`triggerMentionedTaskAutomation\` in \`tasks/mutations.ts\`, run from the USER comment path only — agent/workflow-authored comments never trigger, keeping the loop-safety posture): write access + not archived, the mentioned automation must OWN the task (assignee \`app\` → creation stamp → \`task.externalSystem\` against the mentioned automation's declared contract namespace), one engine per task across both lanes, then schedules the existing \`startTaskWorkflowRun\` (its duplicate guard backstops the pre-check). \`addTaskComment\` returns an optional \`automationTriggered\` for the panel's toast.
- **Request changes** drops its separate \`startTaskWorkflow\` call; the board's status-verb choreography (drag In review → In progress) is unchanged.
- The three copies of the \`input.task\` subject builder collapse into \`taskWorkflowSubjectInput\` (\`tasks/helpers.ts\`).
- Frontend: the \`@\` autocomplete lists the board's automations (Workflow avatar, "· Automations" caption), timeline prose renders \`@vat-return-desk\` as an \`@Swiss VAT return desk\` pill, and \`mentionPicker.title\` + the task-automation docs page (Mentions section) are updated in en/de/fr.
- Schema: \`taskMentionTypeValidator\` widens mention storage/events additively (optional field, no migration); comment authorship stays \`user | agent\`.

## Verification

- New \`convex/tasks/automation_mention_trigger.test.ts\` (11 cases): trigger + subject input, display-name handle, plain comment inert, non-owner mention inert, read-only member inert, live-run guard, ownership fallbacks (creation stamp, externalSystem), agent-assigned task ignores automation mentions, directory handle contract, project-binding isolation.
- Existing suites green: platform typecheck, oxlint, tasks/collab/automations server tests, tasks UI tests, docs structural suite, i18n checks.
- Live on the dev stack (Swiss VAT return desk, BTR-1): a plain comment started nothing; an \`@vat-return-desk\` comment kicked a revision run with the workflow's "Revision you requested" ack; the Request changes dialog posted the mention-prefixed comment and the rerun started; the composer autocomplete lists the desk.

## Out of scope

- The composer's ⚡ trigger-preview chips stay agent-only.
- The vatplus-worker keeps portal change requests operator-gated; it can opt into auto-trigger later by @-mentioning the desk in its relayed comment (apps-repo decision).