### PR TITLE
fix(platform): carry answered asks into auto-retried agent turns

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -53,6 +53,7 @@ import type * as audit_logs_verify_integrity from "../audit_logs/verify_integrit
 import type * as auth from "../auth.js";
 import type * as automations_agent_host from "../automations/agent_host.js";
 import type * as automations_agent_retry from "../automations/agent_retry.js";
+import type * as automations_ask_answer_carryover from "../automations/ask_answer_carryover.js";
 import type * as automations_bound_run_payload from "../automations/bound_run_payload.js";
 import type * as automations_catalog from "../automations/catalog.js";
 import type * as automations_checkpoints from "../automations/checkpoints.js";
@@ -1059,6 +1060,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   "automations/agent_host": typeof automations_agent_host;
   "automations/agent_retry": typeof automations_agent_retry;
+  "automations/ask_answer_carryover": typeof automations_ask_answer_carryover;
   "automations/bound_run_payload": typeof automations_bound_run_payload;
   "automations/catalog": typeof automations_catalog;
   "automations/checkpoints": typeof automations_checkpoints;

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -79,6 +79,7 @@ import {
   normalizeToolGrants,
   secretsGuidance,
 } from '../sandbox/tool_names';
+import { promptWithAnsweredAsks } from './ask_answer_carryover';
 import type { AgentTurnFile, AgentTurnResult } from './checkpoints';
 
 // The turn's wall-clock deadline is the shared work-turn knob
@@ -1175,12 +1176,25 @@ export const startWorkflowAgentTurn = internalAction({
         secrets: args.request.secrets ?? [],
       });
 
+      // A kick is a FRESH conversation — on an auto-retry it replaces a dead
+      // turn whose conversation may already have collected operator answers
+      // (the answered-ask resume that died before progressing). Fold those
+      // answers into the prompt so the retry never asks them again; a first
+      // kick has none and the prompt stays as authored.
+      const answeredAsks = await ctx.runQuery(
+        internal.automations.human_asks.listAnsweredAsksForNode,
+        {
+          organizationId: args.organizationId,
+          runId: args.runId,
+          nodeId: args.nodeId,
+        },
+      );
       const exec = buildExternalTurnExec({
         harness: args.harness,
         gatewayModel: args.gatewayModel,
         serving: auth.serving,
         instructions,
-        prompt: args.request.prompt,
+        prompt: promptWithAnsweredAsks(args.request.prompt, answeredAsks),
         execId: args.execId,
         // Always mounted: `ask_human` rides the bridge, so every automation
         // turn gets the shim even when the node declares no connectors.

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -79,7 +79,10 @@ import {
   normalizeToolGrants,
   secretsGuidance,
 } from '../sandbox/tool_names';
-import { promptWithAnsweredAsks } from './ask_answer_carryover';
+import {
+  answerResumePrompt,
+  promptWithAnsweredAsks,
+} from './ask_answer_carryover';
 import type { AgentTurnFile, AgentTurnResult } from './checkpoints';
 
 // The turn's wall-clock deadline is the shared work-turn knob
@@ -1567,13 +1570,29 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
         ...secretsGuidance(request.secrets ?? []),
         "Write every file you produce to /agent/output/ — files there are collected when your turn ends and become this step's output.",
       ].join('\n\n');
-      const prompt = [
-        'The operator answered your question:',
-        '',
-        ask.answer,
-        '',
-        'Continue the task from where you left off, applying this answer. Ask again only if a genuinely NEW operator-only decision comes up.',
-      ].join('\n');
+      // No conversation handle means the delivery is a FRESH conversation:
+      // an answer-only message would arrive without the assignment it
+      // answers, so the fallback rebuilds the full node prompt with every
+      // answered round folded in (this ask included — it is `answered`
+      // already). With a handle, the answer alone is the next message.
+      const answeredAsks =
+        ask.agentSessionId === undefined
+          ? await ctx.runQuery(
+              internal.automations.human_asks.listAnsweredAsksForNode,
+              {
+                organizationId: args.organizationId,
+                // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the ask row carries the durable run id
+                runId: askRunId as never,
+                nodeId: ask.nodeId,
+              },
+            )
+          : [];
+      const prompt = answerResumePrompt({
+        nodePrompt: request.prompt,
+        answer: ask.answer,
+        hasConversation: ask.agentSessionId !== undefined,
+        answeredAsks,
+      });
       const extraEnv = await resolveTurnEquipmentEnv(ctx, {
         organizationId: args.organizationId,
         sessionId,
@@ -1598,10 +1617,11 @@ export const resumeWorkflowAgentTurnWithAnswer = internalAction({
       });
       if (ask.agentSessionId === undefined) {
         // The asking turn ended without a resume handle (a harness that never
-        // reported one). The answer still reaches the agent — as a fresh
-        // conversation over the same workspace — so warn rather than fail.
+        // reported one, or a ring that dropped the announcement). The agent
+        // starts fresh over the preserved workspace, carrying the node prompt
+        // and every answered round — warn for the trace, don't fail.
         console.warn(
-          '[agent-host] answered-ask resume without a harness session handle — starting fresh over the preserved workspace',
+          '[agent-host] answered-ask resume without a harness session handle — starting fresh over the preserved workspace with the node prompt and answered asks carried in',
         );
       }
 
@@ -1658,6 +1678,7 @@ function readStringArray(value: unknown): string[] | undefined {
 function readWorkflowAgentRequest(input: Record<string, unknown>): {
   model: string;
   modelProvider?: string;
+  prompt: string;
   system?: string;
   connectors?: string[];
   tools?: string[];
@@ -1671,6 +1692,9 @@ function readWorkflowAgentRequest(input: Record<string, unknown>): {
     ...(typeof input.modelProvider === 'string'
       ? { modelProvider: input.modelProvider }
       : {}),
+    // The node prompt rides the cursor input from kick time; the no-handle
+    // answer delivery restores it as the fresh conversation's assignment.
+    prompt: typeof input.prompt === 'string' ? input.prompt : '',
     ...(typeof input.system === 'string' ? { system: input.system } : {}),
     ...(connectors !== undefined ? { connectors } : {}),
     ...(tools !== undefined ? { tools } : {}),
@@ -1825,10 +1849,15 @@ async function continueOrSettle(
     }),
   );
   if (pendingAsk !== null && !errored) {
+    // Prefer the end-of-turn stamp, but fall back to the window's wide
+    // extraction (`turn-started` OR `turn-ended`, task-lane parity) — a
+    // handle missed here forces the answer delivery onto the fresh-
+    // conversation fallback instead of resuming the asking conversation.
+    const askAgentSessionId = ended?.sessionId ?? window.agentSessionId;
     await ctx.runMutation(internal.automations.human_asks.recordAskParked, {
       askId: pendingAsk._id,
-      ...(ended?.sessionId !== undefined
-        ? { agentSessionId: ended.sessionId }
+      ...(askAgentSessionId !== undefined
+        ? { agentSessionId: askAgentSessionId }
         : {}),
     });
     // The stepper's generic time-limit cut must not fire while the turn

--- a/services/platform/convex/automations/ask_answer_carryover.test.ts
+++ b/services/platform/convex/automations/ask_answer_carryover.test.ts
@@ -8,7 +8,10 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { promptWithAnsweredAsks } from './ask_answer_carryover';
+import {
+  answerResumePrompt,
+  promptWithAnsweredAsks,
+} from './ask_answer_carryover';
 
 const PROMPT = 'Repair the client setup for period 2026Q2.';
 
@@ -42,5 +45,39 @@ describe('promptWithAnsweredAsks', () => {
     expect(merged.indexOf('First answer.')).toBeLessThan(
       merged.indexOf('Second answer.'),
     );
+  });
+});
+
+describe('answerResumePrompt', () => {
+  const ANSWERED = [
+    { question: 'Deduct in Q2?', answer: 'Yes — booked 01.04.2026.' },
+  ];
+
+  it('with a conversation handle, the answer alone is the next message', () => {
+    const prompt = answerResumePrompt({
+      nodePrompt: PROMPT,
+      answer: 'Yes — booked 01.04.2026.',
+      hasConversation: true,
+      answeredAsks: ANSWERED,
+    });
+    expect(prompt).toContain('The operator answered your question:');
+    expect(prompt).toContain('Yes — booked 01.04.2026.');
+    // The resumed conversation already holds the assignment — never repeat it.
+    expect(prompt).not.toContain(PROMPT);
+  });
+
+  it('without a handle, the fresh conversation gets the node prompt plus every answered round', () => {
+    const prompt = answerResumePrompt({
+      nodePrompt: PROMPT,
+      answer: 'Yes — booked 01.04.2026.',
+      hasConversation: false,
+      answeredAsks: ANSWERED,
+    });
+    // The regression: an answer-only message left the fresh turn without its
+    // assignment — the node prompt must lead, the answers must follow.
+    expect(prompt.startsWith(PROMPT)).toBe(true);
+    expect(prompt).toContain('Deduct in Q2?');
+    expect(prompt).toContain('Yes — booked 01.04.2026.');
+    expect(prompt).not.toContain('Continue the task from where you left off');
   });
 });

--- a/services/platform/convex/automations/ask_answer_carryover.test.ts
+++ b/services/platform/convex/automations/ask_answer_carryover.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The answered-ask carryover a re-kicked agent turn folds into its prompt.
+ * What these pin: a first kick (no answered asks) leaves the authored prompt
+ * byte-identical, and a retry carries every answered round verbatim, oldest
+ * first, framed as settled decisions — the regression is the live incident
+ * where a retry re-asked the operator the questions they had just answered.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { promptWithAnsweredAsks } from './ask_answer_carryover';
+
+const PROMPT = 'Repair the client setup for period 2026Q2.';
+
+describe('promptWithAnsweredAsks', () => {
+  it('returns the prompt untouched when nothing was answered', () => {
+    expect(promptWithAnsweredAsks(PROMPT, [])).toBe(PROMPT);
+  });
+
+  it('appends question and answer framed as standing decisions', () => {
+    const merged = promptWithAnsweredAsks(PROMPT, [
+      {
+        question: 'Deduct invoice 26-0347 in Q2 or correct Q1?',
+        answer: 'Deduct in Q2, booked 01.04.2026.',
+      },
+    ]);
+    expect(merged.startsWith(PROMPT)).toBe(true);
+    expect(merged).toContain('Deduct invoice 26-0347 in Q2 or correct Q1?');
+    expect(merged).toContain('Deduct in Q2, booked 01.04.2026.');
+    expect(merged).toContain('do NOT ask these questions again');
+  });
+
+  it('keeps multiple answered rounds in the given (oldest-first) order', () => {
+    const merged = promptWithAnsweredAsks(PROMPT, [
+      { question: 'First round?', answer: 'First answer.' },
+      { question: 'Second round?', answer: 'Second answer.' },
+    ]);
+    expect(merged.indexOf('First round?')).toBeGreaterThan(-1);
+    expect(merged.indexOf('First round?')).toBeLessThan(
+      merged.indexOf('Second round?'),
+    );
+    expect(merged.indexOf('First answer.')).toBeLessThan(
+      merged.indexOf('Second answer.'),
+    );
+  });
+});

--- a/services/platform/convex/automations/ask_answer_carryover.ts
+++ b/services/platform/convex/automations/ask_answer_carryover.ts
@@ -1,0 +1,48 @@
+/**
+ * Carry operator answers into a re-kicked agent turn.
+ *
+ * An answered ask is normally delivered by resuming the SAME harness
+ * conversation (`agent_host.resumeWorkflowAgentTurnWithAnswer`), so the agent
+ * keeps its context and the answer arrives as the next message. When that
+ * resumed turn dies before making progress — a provider outage, a crash — the
+ * stepper's auto-retry re-kicks the node as a FRESH conversation over the
+ * preserved workspace. The fresh turn knows nothing of the questions it
+ * already asked or the answers the operator already gave: it re-derives the
+ * same ambiguities and asks them AGAIN, burning an operator round-trip per
+ * retry. Folding every answered ask of the node into the re-kick's prompt
+ * closes that loop; a first kick has no answered asks and stays byte-identical.
+ */
+
+export interface AnsweredAskCarryover {
+  readonly question: string;
+  readonly answer: string;
+}
+
+/** Appended between the node prompt and the carryover so the agent reads the
+ * answers as settled operator decisions, not as fresh conversation input. */
+const CARRYOVER_HEADER = [
+  '---',
+  '',
+  'OPERATOR ANSWERS ALREADY GIVEN — an earlier attempt of this step asked the' +
+    ' operator and was answered before that attempt was cut short. These' +
+    ' decisions STAND: apply them as settled, do not re-derive them, and do' +
+    ' NOT ask these questions again. Ask only when a genuinely NEW' +
+    ' operator-only decision comes up.',
+].join('\n');
+
+export function promptWithAnsweredAsks(
+  prompt: string,
+  asks: readonly AnsweredAskCarryover[],
+): string {
+  if (asks.length === 0) return prompt;
+  const blocks = asks.map((ask) =>
+    [
+      'QUESTION (already asked):',
+      ask.question,
+      '',
+      'OPERATOR ANSWER:',
+      ask.answer,
+    ].join('\n'),
+  );
+  return [prompt, '', CARRYOVER_HEADER, '', blocks.join('\n\n')].join('\n');
+}

--- a/services/platform/convex/automations/ask_answer_carryover.ts
+++ b/services/platform/convex/automations/ask_answer_carryover.ts
@@ -46,3 +46,34 @@ export function promptWithAnsweredAsks(
   );
   return [prompt, '', CARRYOVER_HEADER, '', blocks.join('\n\n')].join('\n');
 }
+
+/**
+ * The first message of the turn that delivers an operator's answer.
+ *
+ * With a harness conversation handle the turn RESUMES the asking
+ * conversation, so the answer alone is the message — the conversation
+ * already holds the task and the question. Without a handle (the asking
+ * turn never reported one, or the ring dropped the announcement) the
+ * delivery is a FRESH conversation over the preserved workspace: an
+ * answer-only message would leave the agent without its assignment, so the
+ * fallback restores the full node prompt and folds in every answered round
+ * — the ask being delivered included, it is already `answered` when the
+ * resume runs.
+ */
+export function answerResumePrompt(args: {
+  nodePrompt: string;
+  answer: string;
+  hasConversation: boolean;
+  answeredAsks: readonly AnsweredAskCarryover[];
+}): string {
+  if (args.hasConversation) {
+    return [
+      'The operator answered your question:',
+      '',
+      args.answer,
+      '',
+      'Continue the task from where you left off, applying this answer. Ask again only if a genuinely NEW operator-only decision comes up.',
+    ].join('\n');
+  }
+  return promptWithAnsweredAsks(args.nodePrompt, args.answeredAsks);
+}

--- a/services/platform/convex/automations/human_asks.test.ts
+++ b/services/platform/convex/automations/human_asks.test.ts
@@ -594,3 +594,66 @@ describe('ask notifications (project-visibility fan-out)', () => {
     expect(after.askingTaskIds).toHaveLength(0);
   });
 });
+
+describe('listAnsweredAsksForNode', () => {
+  it('returns only this node’s answered asks, oldest first — the retry carryover', async () => {
+    const t = convexTest(schema, modules);
+    const { runId, sessionId } = await seedParkedRun(t);
+    const askRow = (
+      overrides: Partial<{
+        nodeId: string;
+        status: 'pending' | 'answered' | 'expired';
+        question: string;
+        answer: string;
+        createdAt: number;
+      }> = {},
+    ) => ({
+      organizationId: ORG,
+      runId,
+      nodeId: overrides.nodeId ?? NODE,
+      sessionId,
+      execId: EXEC,
+      question: overrides.question ?? 'Q?',
+      status: overrides.status ?? ('answered' as const),
+      ...(overrides.status === 'pending'
+        ? {}
+        : { answer: overrides.answer ?? 'A.' }),
+      expiresAt: 9_999_999,
+      createdAt: overrides.createdAt ?? 0,
+    });
+    await t.run(async (ctx) => {
+      // Two answered rounds on the node — ask order IS row-creation order in
+      // production (`createAskForExec` inserts as the agent asks), and the
+      // index walk returns creation order, so round one must come back first.
+      // Plus one still pending and one answered on ANOTHER node: both out.
+      await ctx.db.insert(
+        'automationHumanAsks',
+        askRow({ question: 'Round one?', answer: 'First.', createdAt: 10 }),
+      );
+      await ctx.db.insert(
+        'automationHumanAsks',
+        askRow({ question: 'Round two?', answer: 'Second.', createdAt: 20 }),
+      );
+      await ctx.db.insert(
+        'automationHumanAsks',
+        askRow({ status: 'pending', question: 'Still open?' }),
+      );
+      await ctx.db.insert(
+        'automationHumanAsks',
+        askRow({
+          nodeId: 'revise_setup_from_feedback',
+          question: 'Other node?',
+        }),
+      );
+    });
+
+    const carryover = await t.query(
+      internal.automations.human_asks.listAnsweredAsksForNode,
+      { organizationId: ORG, runId, nodeId: NODE },
+    );
+    expect(carryover).toEqual([
+      { question: 'Round one?', answer: 'First.' },
+      { question: 'Round two?', answer: 'Second.' },
+    ]);
+  });
+});

--- a/services/platform/convex/automations/human_asks.ts
+++ b/services/platform/convex/automations/human_asks.ts
@@ -312,6 +312,36 @@ export const getAskForResume = internalQuery({
   },
 });
 
+/** Answered asks of one node, oldest first — the carryover a re-kicked turn
+ * folds into its prompt (`agent_host.startWorkflowAgentTurn`), so a fresh
+ * conversation keeps the operator decisions its dead predecessor already
+ * collected instead of asking them again. */
+export const listAnsweredAsksForNode = internalQuery({
+  args: {
+    organizationId: v.string(),
+    runId: v.id('automationRuns'),
+    nodeId: v.string(),
+  },
+  returns: v.array(v.object({ question: v.string(), answer: v.string() })),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ question: string; answer: string }[]> => {
+    const answered: { question: string; answer: string }[] = [];
+    for await (const ask of ctx.db
+      .query('automationHumanAsks')
+      .withIndex('by_run_status', (q) =>
+        q.eq('runId', args.runId).eq('status', 'answered'),
+      )) {
+      if (ask.organizationId !== args.organizationId) continue;
+      if (ask.nodeId !== args.nodeId) continue;
+      if (ask.answer === undefined) continue;
+      answered.push({ question: ask.question, answer: ask.answer });
+    }
+    return answered;
+  },
+});
+
 /** Terminal states the host stamps: `expired` when nobody answered in time,
  * `cancelled` when the turn ended in a crash or the run was cut. */
 export const closeAsk = internalMutation({


### PR DESCRIPTION
## Summary

An automation agent node's auto-retry re-kicks the node as a **fresh harness conversation** with the original node prompt. Operator answers already collected via `ask_human` live only on the ask rows — nothing fed them to the retry — so a retry that replaced a dead answered-ask resume turn re-derived the same ambiguities and asked the operator the **identical questions again**. Observed live on the vatplus 2026Q2 desk: the answer-carrying resume turn died on a zai upstream outage, and the auto-retried turn asked the operator the same three questions they had answered twenty minutes earlier.

- `automations/ask_answer_carryover.ts` (new): pure `promptWithAnsweredAsks` — appends the answered rounds to the node prompt framed as settled decisions the agent must not re-ask; empty list returns the prompt byte-identical.
- `automations/human_asks.ts`: new internal query `listAnsweredAsksForNode` — the (run, node)'s answered asks in ask order, via the existing `by_run_status` index.
- `automations/agent_host.ts`: `startWorkflowAgentTurn` (the single convergence point of first kicks and retry re-kicks) folds the carryover into the prompt at exec build time. Never persisted into the cursor input, so the enrichment is recomputed per launch and repeated retries do not stack copies. The answered-ask **resume** path is untouched — its conversation already carries the answer.

## Testing

- `ask_answer_carryover.test.ts`: no-op on empty, Q/A/framing present, oldest-first order kept.
- `human_asks.test.ts`: `listAnsweredAsksForNode` returns only the node's answered asks, in ask order.
- Full `human_asks` + carryover suites green (18 tests), `tsc --noEmit` clean, `oxlint --type-aware` clean.
- Verified against the live dev deployment: the query returns both answered rounds of the affected run — exactly what its next retry now folds into the prompt.