### PR TITLE
fix(platform): guard async actions while pending

### DIFF
--- a/services/platform/app/features/automations/components/settings-uploads-panel.tsx
+++ b/services/platform/app/features/automations/components/settings-uploads-panel.tsx
@@ -95,7 +95,8 @@ export function SettingsUploadsPanel({
   // list would duplicate a chain that already exists server-side.
   const loading = documentsLoading || foldersLoading;
   const { mutateAsync: createFolder } = useCreateFolder();
-  const { mutateAsync: deleteDocument } = useDeleteDocument();
+  const { mutateAsync: deleteDocument, isPending: isDeletingDocument } =
+    useDeleteDocument();
   const { mutateAsync: generateUploadUrl } = useConvexMutation(
     api.files.mutations.generateUploadUrl,
   );
@@ -509,7 +510,7 @@ export function SettingsUploadsPanel({
   };
 
   const handleDelete = async () => {
-    if (confirmDelete === null) return;
+    if (confirmDelete === null || isDeletingDocument) return;
     try {
       await deleteDocument({ documentId: confirmDelete.id });
     } catch (error) {
@@ -745,7 +746,7 @@ export function SettingsUploadsPanel({
       <ConfirmDialog
         open={confirmDelete !== null}
         onOpenChange={(open) => {
-          if (!open) setConfirmDelete(null);
+          if (!open && !isDeletingDocument) setConfirmDelete(null);
         }}
         title={t('settings.uploads.removeTitle')}
         description={t('settings.uploads.removeDescription', {
@@ -753,6 +754,7 @@ export function SettingsUploadsPanel({
         })}
         confirmText={t('settings.uploads.removeConfirm')}
         variant="destructive"
+        isLoading={isDeletingDocument}
         onConfirm={() => void handleDelete()}
       />
     </Stack>

--- a/services/platform/app/features/chat/components/message-toolbar.tsx
+++ b/services/platform/app/features/chat/components/message-toolbar.tsx
@@ -81,6 +81,7 @@ export function MessageToolbar({
   const [infoOpen, setInfoOpen] = useState(false);
   const [commentOpen, setCommentOpen] = useState(false);
   const [comment, setComment] = useState('');
+  const [submittingComment, setSubmittingComment] = useState(false);
   // undefined = follow the server map; null = optimistically removed.
   const [localRating, setLocalRating] = useState<
     FeedbackRating | null | undefined
@@ -127,11 +128,21 @@ export function MessageToolbar({
     setCommentOpen(true);
   };
 
-  const submitComment = () => {
-    if (threadId !== undefined && comment.trim().length > 0) {
-      void feedback.submit(threadId, message.id, 'negative', comment.trim());
+  const submitComment = async () => {
+    if (
+      submittingComment ||
+      threadId === undefined ||
+      comment.trim().length === 0
+    ) {
+      return;
     }
-    setCommentOpen(false);
+    setSubmittingComment(true);
+    try {
+      await feedback.submit(threadId, message.id, 'negative', comment.trim());
+      setCommentOpen(false);
+    } finally {
+      setSubmittingComment(false);
+    }
   };
 
   return (
@@ -288,14 +299,20 @@ export function MessageToolbar({
             onKeyDown={(event) => {
               if (event.key === 'Enter' && !event.shiftKey) {
                 event.preventDefault();
-                submitComment();
+                if (!submittingComment) void submitComment();
               }
               if (event.key === 'Escape') setCommentOpen(false);
             }}
             className="border-border bg-muted/40 focus-visible:ring-ring min-h-[60px] w-full resize-none rounded-lg border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
           />
           <Row gap={2}>
-            <Button size="sm" onClick={submitComment} className="h-7">
+            <Button
+              size="sm"
+              onClick={() => void submitComment()}
+              disabled={comment.trim().length === 0 || submittingComment}
+              isLoading={submittingComment}
+              className="h-7"
+            >
               {t('feedback.submitComment')}
             </Button>
             <Button

--- a/services/platform/app/features/projects/components/agent-secrets-field.tsx
+++ b/services/platform/app/features/projects/components/agent-secrets-field.tsx
@@ -278,7 +278,7 @@ export function AgentSecretsField({
         <ConfirmDialog
           open={pendingDelete !== undefined}
           onOpenChange={(open) => {
-            if (!open) setPendingDelete(undefined);
+            if (!open && !busy) setPendingDelete(undefined);
           }}
           title={t('agents.secrets.deleteTitle')}
           description={t('agents.secrets.deleteConfirm', {
@@ -286,6 +286,7 @@ export function AgentSecretsField({
           })}
           confirmText={t('agents.secrets.deleteConfirmButton')}
           variant="destructive"
+          isLoading={busy}
           onConfirm={() => void onDelete()}
         />
       </Stack>

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
@@ -1208,7 +1208,8 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
                       type="button"
                       variant="ghost"
                       size="sm"
-                      disabled={!canEdit}
+                      disabled={!canEdit || disableScim.isPending}
+                      isLoading={disableScim.isPending}
                       onClick={() => disableScim.mutate({ organizationId })}
                     >
                       {t('enterpriseSso.scim.disable')}

--- a/services/platform/app/features/skills/components/skill-create-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-create-pane.tsx
@@ -118,7 +118,11 @@ export function SkillCreatePane({
         <Button variant="secondary" onClick={onCancel}>
           {tCommon('actions.cancel')}
         </Button>
-        <Button disabled={!canSubmit} onClick={() => void submit()}>
+        <Button
+          disabled={!canSubmit}
+          isLoading={saveSkill.isPending}
+          onClick={() => void submit()}
+        >
           {saveSkill.isPending
             ? t('createDialog.creating')
             : t('createDialog.submit')}

--- a/services/platform/app/features/skills/components/skill-detail-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.tsx
@@ -247,9 +247,12 @@ export function SkillDetailPane({
 
       <DeleteDialog
         open={deleteOpen}
-        onOpenChange={setDeleteOpen}
+        onOpenChange={(open) => {
+          if (!deleteSkill.isPending) setDeleteOpen(open);
+        }}
         title={t('deleteSkill')}
         description={t('deleteConfirmation', { slug })}
+        isDeleting={deleteSkill.isPending}
         onDelete={() => void remove()}
       />
     </div>

--- a/services/platform/app/features/tasks/components/editable-description.tsx
+++ b/services/platform/app/features/tasks/components/editable-description.tsx
@@ -56,6 +56,7 @@ export function EditableDescription({
   const { t: tCommon } = useT('common');
   const [draft, setDraft] = useState(value);
   const [editing, setEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   useEffect(() => setDraft(value), [value]);
 
   // Explicit commit instead of save-on-blur: a blur-save would fire on any
@@ -67,6 +68,8 @@ export function EditableDescription({
       setEditing(false);
       return;
     }
+    if (isSaving) return;
+    setIsSaving(true);
     try {
       await onSave(draft.trim());
       setEditing(false);
@@ -74,6 +77,8 @@ export function EditableDescription({
       // The caller reports the failure; the editor stays open so the typed
       // draft survives it rather than collapsing back to the stale prose.
       console.warn('[tasks] description save failed', error);
+    } finally {
+      setIsSaving(false);
     }
   };
   const discard = () => {
@@ -162,7 +167,7 @@ export function EditableDescription({
           // consumes both first while it is open).
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
             e.preventDefault();
-            void save();
+            if (!isSaving) void save();
           } else if (e.key === 'Escape') {
             e.preventDefault();
             discard();
@@ -177,10 +182,14 @@ export function EditableDescription({
         baseline={value}
       />
       <Row gap={2} align="stretch">
-        <Button disabled={!isDirty} onClick={() => void save()}>
+        <Button
+          disabled={!isDirty || isSaving}
+          isLoading={isSaving}
+          onClick={() => void save()}
+        >
           {tCommon('actions.save')}
         </Button>
-        <Button variant="secondary" onClick={discard}>
+        <Button variant="secondary" onClick={discard} disabled={isSaving}>
           {isDirty ? tCommon('actions.discard') : tCommon('actions.cancel')}
         </Button>
       </Row>

--- a/services/platform/app/features/tasks/components/task-comments.test.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.test.tsx
@@ -5,6 +5,11 @@ import { TaskComments } from './task-comments';
 
 const localeState = { locale: 'en' };
 
+const mutationState = vi.hoisted(() => ({
+  addPending: false,
+  addMutateAsync: vi.fn(),
+}));
+
 vi.mock('@tale/ui/i18n/locale-provider', () => ({
   useLocale: () => localeState,
 }));
@@ -59,8 +64,11 @@ vi.mock('../hooks/queries', () => ({
 }));
 
 vi.mock('../hooks/mutations', () => ({
-  useAddTaskComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useEditTaskComment: () => ({ mutateAsync: vi.fn() }),
+  useAddTaskComment: () => ({
+    mutateAsync: mutationState.addMutateAsync,
+    isPending: mutationState.addPending,
+  }),
+  useEditTaskComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDeleteTaskComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
@@ -260,5 +268,25 @@ describe('TaskComments composer hint', () => {
     expect(container.querySelector('textarea')).not.toHaveAttribute(
       'aria-describedby',
     );
+  });
+});
+
+describe('TaskComments submit loading', () => {
+  it('disables the comment button while a new comment is posting', () => {
+    mutationState.addPending = true;
+    localeState.locale = 'en';
+    render(
+      <TaskComments
+        taskId={'task_1' as never}
+        organizationId="org_1"
+        projectId={'project_1' as never}
+        canComment
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'actions.comment' }),
+    ).toBeDisabled();
+    mutationState.addPending = false;
   });
 });

--- a/services/platform/app/features/tasks/components/task-comments.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.tsx
@@ -128,7 +128,7 @@ export function TaskComments({
   };
 
   const isAdding = addComment.isPending;
-  const isEditing = editComment.isPending;
+  const isEditPending = editComment.isPending;
 
   const submitNew = async () => {
     const body = draft.trim();
@@ -144,7 +144,7 @@ export function TaskComments({
 
   const submitEdit = async (messageId: string) => {
     const body = editDraft.trim();
-    if (!body || isEditing) return;
+    if (!body || isEditPending) return;
     try {
       await editComment.mutateAsync({ messageId, body });
       setEditingId(null);
@@ -171,7 +171,7 @@ export function TaskComments({
     const preview = isPreviewableTaskActor(c.authorType, c.authorId)
       ? resolveActorPreview(c.authorType, c.authorId)
       : null;
-    const isEditing = editingId === c.messageId;
+    const isEditingThisComment = editingId === c.messageId;
     const displayBody = pickCommentBody(c.body, c.bodyByLocale, locale);
     return (
       <Row gap={2} align="start" className="group/comment">
@@ -195,7 +195,7 @@ export function TaskComments({
             )}
           </div>
 
-          {isEditing ? (
+          {isEditingThisComment ? (
             <Stack gap={2} className="mt-1">
               <MentionTextarea
                 id={`edit-comment-${c.messageId}`}
@@ -205,14 +205,14 @@ export function TaskComments({
                 value={editDraft}
                 onValueChange={setEditDraft}
                 onKeyDown={onModEnter(() => {
-                  if (!isEditing) void submitEdit(c.messageId);
+                  if (!isEditPending) void submitEdit(c.messageId);
                 })}
                 autoFocus
               />
               <Row gap={2} align="stretch">
                 <Button
-                  disabled={editDraft.trim().length === 0 || isEditing}
-                  isLoading={isEditing}
+                  disabled={editDraft.trim().length === 0 || isEditPending}
+                  isLoading={isEditPending}
                   onClick={() => void submitEdit(c.messageId)}
                 >
                   {tCommon('actions.save')}
@@ -231,7 +231,7 @@ export function TaskComments({
             />
           )}
 
-          {!isEditing && canComment && (
+          {!isEditingThisComment && canComment && (
             <Row
               gap={3}
               className="mt-1 text-xs opacity-0 transition-opacity group-focus-within/comment:opacity-100 group-hover/comment:opacity-100"

--- a/services/platform/app/features/tasks/components/task-comments.tsx
+++ b/services/platform/app/features/tasks/components/task-comments.tsx
@@ -127,9 +127,12 @@ export function TaskComments({
     toast({ title: tCommon('errors.generic'), variant: 'destructive' });
   };
 
+  const isAdding = addComment.isPending;
+  const isEditing = editComment.isPending;
+
   const submitNew = async () => {
     const body = draft.trim();
-    if (!body) return;
+    if (!body || isAdding) return;
     try {
       const result = await addComment.mutateAsync({ taskId, body });
       toastUnresolvedMentions(result.unresolvedMentionTokens, toast, tCommon);
@@ -141,7 +144,7 @@ export function TaskComments({
 
   const submitEdit = async (messageId: string) => {
     const body = editDraft.trim();
-    if (!body) return;
+    if (!body || isEditing) return;
     try {
       await editComment.mutateAsync({ messageId, body });
       setEditingId(null);
@@ -201,12 +204,15 @@ export function TaskComments({
                 rows={2}
                 value={editDraft}
                 onValueChange={setEditDraft}
-                onKeyDown={onModEnter(() => void submitEdit(c.messageId))}
+                onKeyDown={onModEnter(() => {
+                  if (!isEditing) void submitEdit(c.messageId);
+                })}
                 autoFocus
               />
               <Row gap={2} align="stretch">
                 <Button
-                  disabled={editDraft.trim().length === 0}
+                  disabled={editDraft.trim().length === 0 || isEditing}
+                  isLoading={isEditing}
                   onClick={() => void submitEdit(c.messageId)}
                 >
                   {tCommon('actions.save')}
@@ -267,7 +273,9 @@ export function TaskComments({
         rows={2}
         value={draft}
         onValueChange={setDraft}
-        onKeyDown={onModEnter(() => void submitNew())}
+        onKeyDown={onModEnter(() => {
+          if (!isAdding) void submitNew();
+        })}
         placeholder={t('actions.comment')}
         aria-describedby={composerHint ? 'new-comment-hint' : undefined}
       />
@@ -283,7 +291,8 @@ export function TaskComments({
       />
       <Row gap={0} align="stretch" justify="end">
         <Button
-          disabled={draft.trim().length === 0}
+          disabled={draft.trim().length === 0 || isAdding}
+          isLoading={isAdding}
           onClick={() => void submitNew()}
         >
           {t('actions.comment')}

--- a/services/platform/app/features/tasks/components/task-input-files.tsx
+++ b/services/platform/app/features/tasks/components/task-input-files.tsx
@@ -95,7 +95,8 @@ export function TaskInputFilesCard({
   const { mutateAsync: createDocumentFromUpload } = useConvexMutation(
     api.documents.mutations.createDocumentFromUpload,
   );
-  const { mutateAsync: deleteDocument } = useDeleteDocument();
+  const { mutateAsync: deleteDocument, isPending: isDeletingDocument } =
+    useDeleteDocument();
   const [uploading, setUploading] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [preview, setPreview] = useState<{ id: string; name: string } | null>(
@@ -118,7 +119,7 @@ export function TaskInputFilesCard({
   const listed = showAll ? files : files.slice(0, MAX_LISTED);
 
   const handleDelete = async () => {
-    if (confirmDelete === null) return;
+    if (confirmDelete === null || isDeletingDocument) return;
     try {
       await deleteDocument({ documentId: confirmDelete.id });
     } catch (error) {
@@ -283,7 +284,7 @@ export function TaskInputFilesCard({
       <ConfirmDialog
         open={confirmDelete !== null}
         onOpenChange={(open) => {
-          if (!open) setConfirmDelete(null);
+          if (!open && !isDeletingDocument) setConfirmDelete(null);
         }}
         title={t('inputFiles.removeTitle')}
         description={t('inputFiles.removeDescription', {
@@ -291,6 +292,7 @@ export function TaskInputFilesCard({
         })}
         confirmText={t('inputFiles.removeConfirm')}
         variant="destructive"
+        isLoading={isDeletingDocument}
         onConfirm={() => void handleDelete()}
       />
     </Stack>

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -1098,7 +1098,7 @@ function EditTaskBody({
 
   const addSubtask = async () => {
     const subTitle = subtaskTitle.trim();
-    if (!subTitle) return;
+    if (!subTitle || createTask.isPending) return;
     try {
       await createTask.mutateAsync({
         organizationId: task.organizationId,
@@ -1449,7 +1449,7 @@ function EditTaskBody({
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' && !e.shiftKey) {
                           e.preventDefault();
-                          void addSubtask();
+                          if (!createTask.isPending) void addSubtask();
                         }
                       }}
                       placeholder={t('detail.addSubtask')}
@@ -1459,7 +1459,10 @@ function EditTaskBody({
                     <Button
                       icon={Plus}
                       variant="secondary"
-                      disabled={subtaskTitle.trim().length === 0}
+                      disabled={
+                        subtaskTitle.trim().length === 0 || createTask.isPending
+                      }
+                      isLoading={createTask.isPending}
                       onClick={() => void addSubtask()}
                     >
                       {t('actions.add')}


### PR DESCRIPTION
## Summary
Disable confirm and submit controls during in-flight mutations so double-clicks cannot fire delete, comment, or create twice across tasks, skills, SSO, chat feedback, and uploads.

## Checklist
- [ ] `bun run check` passes (format, lint, typecheck, all tests).
- [ ] `bun run lint:sast` passes (Opengrep) — or N/A.
- [ ] Translations updated in `services/platform/messages/{en,de,fr}.json` — N/A (no new strings).
- [ ] Docs updated in `docs/{en,de,fr}/` for any user-visible change — N/A (behavior hardening only).
- [ ] `README.md` / `README.de.md` / `README.fr.md` updated — N/A.

## Test plan
- [ ] Double-click delete on task input files / uploads / agent secrets — only one delete fires; dialog stays open with loading until done.
- [ ] Submit a negative feedback comment twice quickly — one submit; button shows loading.
- [ ] Add a task comment / subtask / save description while pending — controls disabled.
- [ ] Skills create/delete and SSO SCIM disable show loading and ignore re-entry.