### PR TITLE
feat(platform): move file indexing onto workpools

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -705,6 +705,7 @@ import type * as migrations_versions_v0_4_1_03_backfill_project_rollup_counts_mi
 import type * as migrations_versions_v0_4_1_04_backfill_corpus_document_scope_migration from "../migrations/versions/v0_4_1/04_backfill_corpus_document_scope/migration.js";
 import type * as migrations_versions_v0_4_1_05_backfill_mail_attachment_received_at_migration from "../migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration.js";
 import type * as migrations_versions_v0_4_1_06_backfill_conversation_contact_source_migration from "../migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration.js";
+import type * as migrations_versions_v0_4_1_07_enqueue_pending_rag_indexing_migration from "../migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing/migration.js";
 import type * as node_only_documents_internal_actions from "../node_only/documents/internal_actions.js";
 import type * as node_only_knowledge_search_action from "../node_only/knowledge/search_action.js";
 import type * as node_only_sandbox_browser_view from "../node_only/sandbox/browser_view.js";
@@ -1712,6 +1713,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/versions/v0_4_1/04_backfill_corpus_document_scope/migration": typeof migrations_versions_v0_4_1_04_backfill_corpus_document_scope_migration;
   "migrations/versions/v0_4_1/05_backfill_mail_attachment_received_at/migration": typeof migrations_versions_v0_4_1_05_backfill_mail_attachment_received_at_migration;
   "migrations/versions/v0_4_1/06_backfill_conversation_contact_source/migration": typeof migrations_versions_v0_4_1_06_backfill_conversation_contact_source_migration;
+  "migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing/migration": typeof migrations_versions_v0_4_1_07_enqueue_pending_rag_indexing_migration;
   "node_only/documents/internal_actions": typeof node_only_documents_internal_actions;
   "node_only/knowledge/search_action": typeof node_only_knowledge_search_action;
   "node_only/sandbox/browser_view": typeof node_only_sandbox_browser_view;
@@ -2051,4 +2053,6 @@ export declare const components: {
   agent: import("@convex-dev/agent/_generated/component.js").ComponentApi<"agent">;
   rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
   actionCache: import("@convex-dev/action-cache/_generated/component.js").ComponentApi<"actionCache">;
+  ragInteractivePool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"ragInteractivePool">;
+  ragBackgroundPool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"ragBackgroundPool">;
 };

--- a/services/platform/convex/convex.config.ts
+++ b/services/platform/convex/convex.config.ts
@@ -2,6 +2,7 @@ import actionCache from '@convex-dev/action-cache/convex.config';
 import agent from '@convex-dev/agent/convex.config';
 import rateLimiter from '@convex-dev/rate-limiter/convex.config';
 import workflow from '@convex-dev/workflow/convex.config';
+import workpool from '@convex-dev/workpool/convex.config';
 import { defineApp } from 'convex/server';
 
 import betterAuth from './betterAuth/convex.config';
@@ -15,5 +16,20 @@ app.use(workflow, { name: 'workflow_3' });
 app.use(agent);
 app.use(rateLimiter);
 app.use(actionCache);
+
+// File indexing runs a synchronous extract/chunk/embed inside a Node action
+// against the org's knowledge-db pool, whose size is `KNOWLEDGE_DB_POOL_MAX`
+// (default 10). These two pools bound how many such actions run at once, so
+// the connection budget is never saturated and RAG search keeps headroom.
+//
+// TWO pools, not one, because the budget was undifferentiated: a connector
+// minting one queued row every 5 minutes held the single cap of 3 and no user
+// upload indexed for 7 days (#2987, seen on a live deployment). Interactive
+// work now has a budget a background backlog cannot occupy.
+//
+// Raising `KNOWLEDGE_DB_POOL_MAX` without revisiting these numbers leaves the
+// pools as the binding constraint — the two settings are related.
+app.use(workpool, { name: 'ragInteractivePool' });
+app.use(workpool, { name: 'ragBackgroundPool' });
 
 export default app;

--- a/services/platform/convex/documents/create_document_from_upload_rag_skip.test.ts
+++ b/services/platform/convex/documents/create_document_from_upload_rag_skip.test.ts
@@ -3,17 +3,47 @@
 // → `linkDocumentToFile` (whose "legacy second-chance" branch used to re-queue
 // any never-indexed row the moment a document linked it — the trap that made
 // the per-call hint leak into the org's knowledge corpus). What matters here is
-// the REAL scheduling outcome, so assertions read the `_scheduled_functions`
-// system table rather than mocking the dispatch layer.
+// whether indexing was actually requested, so assertions read the enqueues on
+// the indexing workpool. (They read the `_scheduled_functions` system table
+// until indexing moved onto a workpool, whose internal scheduling does not
+// appear there.)
 
 import rateLimiterComponent from '@convex-dev/rate-limiter/test';
 import { convexTest, type TestConvex } from 'convex-test';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getFunctionName } from 'convex/server';
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+} from 'vitest';
 
 import { api, internal } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
+
+// Indexing is enqueued onto a workpool, and a component's internal scheduling
+// is NOT visible in the app's `_scheduled_functions` — verified empirically.
+// So the pools are mocked and the enqueues observed directly, which asserts the
+// same thing the scheduler probe used to: indexing was requested, or was not.
+const ragEnqueues = vi.hoisted(() => [] as unknown[][]);
+vi.mock('../file_metadata/rag_pools', () => {
+  const pool = {
+    enqueueAction: (...args: unknown[]) => {
+      ragEnqueues.push(args);
+      return Promise.resolve('work_test');
+    },
+  };
+  return {
+    ragInteractivePool: pool,
+    ragBackgroundPool: pool,
+    ragPoolFor: () => pool,
+  };
+});
 
 const TEST_DIR_FROM_CONVEX_ROOT = 'documents';
 function toConvexRootKey(globKey: string): string {
@@ -96,17 +126,12 @@ async function fileRow(
 
 /** Every RAG-indexing job ever written to the scheduler (rows persist after
  * execution, so this is drain-proof). */
-async function ragIndexingJobs(t: T): Promise<string[]> {
-  return t.run(async (ctx) => {
-    const fns = await ctx.db.system.query('_scheduled_functions').collect();
-    return fns
-      .map((fn) => fn.name)
-      .filter(
-        (name) =>
-          name.includes('uploadFileToRag') ||
-          name.includes('uploadDocumentToRag'),
-      );
-  });
+async function ragIndexingJobs(_t: T): Promise<string[]> {
+  // One entry per enqueued indexing job. The pool call carries the action as
+  // its second argument; its name is what the scheduler probe used to read.
+  return ragEnqueues.map((call) =>
+    getFunctionName(call[1] as Parameters<typeof getFunctionName>[0]),
+  );
 }
 
 async function upload(
@@ -126,6 +151,10 @@ async function upload(
     });
   return result.documentId;
 }
+
+beforeEach(() => {
+  ragEnqueues.length = 0;
+});
 
 describe('createDocumentFromUpload with skipRagIndexing (full flow)', () => {
   it('persists the opt-out, keeps ragStatus unset and schedules NO RAG indexing — link included', async () => {

--- a/services/platform/convex/documents/mutation_error_codes.test.ts
+++ b/services/platform/convex/documents/mutation_error_codes.test.ts
@@ -28,6 +28,9 @@ vi.mock('convex/values', async (importOriginal) => {
       literal: stub,
       array: stub,
       null: stub,
+      // Indexing dispatch declares the pool's completion shape, whose
+      // `returnValue` is `v.any()`.
+      any: stub,
     },
   };
 });

--- a/services/platform/convex/documents/records.test.ts
+++ b/services/platform/convex/documents/records.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { api, internal } from '../_generated/api';
 import type { Doc, Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
+import { registerRagPools } from '../file_metadata/rag_pools.testkit';
 import schema from '../schema';
 import {
   DOCUMENT_RECORD_AUDIT_ACTIONS,
@@ -74,6 +75,7 @@ afterEach(async () => {
 
 function makeT(): T {
   const t = convexTest(schema, modules);
+  registerRagPools(t);
   // The WebDAV PUT path registers fileMetadata, which rides the rate-limiter
   // component, and the generic approval resolution resolves the approver's
   // display name through Better Auth — register both (empty is fine);

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -19,7 +19,7 @@ import {
   convexStorageId,
   isS3Ref,
 } from '../lib/storage/blob_ref';
-import { maybeDispatchRagIndexing, promoteQueuedRagJobs } from './rag_dispatch';
+import { maybeDispatchRagIndexing } from './rag_dispatch';
 import { sourceFromProvider } from './source_from_provider';
 
 /**
@@ -465,7 +465,6 @@ export const updateFileRagStatus = internalMutation({
             ragIndexedAt: undefined,
             ...(metadata.ragParked ? { ragParked: undefined } : {}),
           });
-          await promoteQueuedRagJobs(ctx);
           return;
         }
       }
@@ -536,13 +535,6 @@ export const updateFileRagStatus = internalMutation({
       ...(isTerminal && metadata.ragParked ? { ragParked: undefined } : {}),
       ...(args.ocrApplied != null && { ocrApplied: args.ocrApplied }),
     });
-
-    // A terminal transition frees an indexing slot — fairly promote parked jobs
-    // (oldest-first across orgs, still per-org-capped) so the shared global
-    // budget drains as jobs finish.
-    if (isTerminal) {
-      await promoteQueuedRagJobs(ctx);
-    }
 
     // Sync ocrApplied to linked document so the list view can show it
     if (args.ocrApplied != null && metadata.documentId) {

--- a/services/platform/convex/file_metadata/rag_dispatch.test.ts
+++ b/services/platform/convex/file_metadata/rag_dispatch.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+// Dispatch after the queue moved onto workpools.
+//
+// Concurrency is no longer this module's job, so there is nothing here about
+// caps, parking or promotion — the pool owns all three. What is left to pin is
+// the routing (which action, which pool) and the completion callback.
+//
+// `./rag_pools` is mocked so the pools are observable without registering the
+// components: an unregistered component makes convexTest throw, and these are
+// plain-ctx unit tests.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    internalMutation: (config: Record<string, unknown>) => config,
+  };
+});
 
 vi.mock('../_generated/api', () => ({
   internal: {
     file_metadata: {
       internal_actions: { uploadFileToRag: 'uploadFileToRag' },
+      rag_dispatch: { recordRagJobResult: 'recordRagJobResult' },
     },
     documents: {
       internal_actions: { uploadDocumentToRag: 'uploadDocumentToRag' },
@@ -11,8 +30,26 @@ vi.mock('../_generated/api', () => ({
   },
 }));
 
-const { maybeDispatchRagIndexing, promoteQueuedRagJobs } =
-  await import('./rag_dispatch');
+const interactiveEnqueue = vi.fn();
+const backgroundEnqueue = vi.fn();
+const INTERACTIVE = { enqueueAction: interactiveEnqueue };
+const BACKGROUND = { enqueueAction: backgroundEnqueue };
+
+vi.mock('./rag_pools', () => ({
+  ragInteractivePool: INTERACTIVE,
+  ragBackgroundPool: BACKGROUND,
+  // The real rule, restated as the smallest thing that can express it: only
+  // 'user' is interactive, everything else — including undefined — is not.
+  ragPoolFor: (source: string | undefined) =>
+    source === 'user' ? INTERACTIVE : BACKGROUND,
+}));
+
+const dispatchModule = await import('./rag_dispatch');
+const { maybeDispatchRagIndexing } = dispatchModule;
+type Handler = (ctx: unknown, args: Record<string, unknown>) => Promise<null>;
+const recordResult = (
+  dispatchModule.recordRagJobResult as unknown as { handler: Handler }
+).handler;
 
 type Ctx = Parameters<typeof maybeDispatchRagIndexing>[0];
 
@@ -22,341 +59,201 @@ interface Row {
   organizationId: string;
   ragStatus?: string;
   ragParked?: boolean;
-  ragError?: string;
-  ragProgress?: string;
+  source?: string;
   fileName: string;
   contentType: string;
-  _creationTime: number;
   documentId?: string;
   threadId?: string;
 }
 
-function makeCtx(rows: Row[], currentFiles: Record<string, string> = {}) {
-  const store = rows.map((r) => ({ ...r }));
-  const scheduled: Array<{ ref: unknown; args: Record<string, unknown> }> = [];
+function row(overrides: Partial<Row> = {}): Row {
+  return {
+    _id: 'fm_1',
+    storageId: 'blob_1',
+    organizationId: 'org_1',
+    ragStatus: 'queued',
+    fileName: 'report.pdf',
+    contentType: 'application/pdf',
+    ...overrides,
+  };
+}
+
+/** A ctx over one fileMetadata row, plus whatever documents a case needs. */
+function createCtx(
+  target: Row | null,
+  documents: Record<string, unknown> = {},
+) {
+  const patches: Record<string, unknown>[] = [];
   const ctx = {
     db: {
       query: () => ({
-        withIndex: (_name: string, fn: (q: unknown) => unknown) => {
-          const constraints: Record<string, unknown> = {};
-          const q = {
-            eq(field: string, value: unknown) {
-              constraints[field] = value;
-              return q;
-            },
-          };
-          fn(q);
-          const filtered = store.filter((r) =>
-            Object.entries(constraints).every(
-              ([k, v]) => (r as Record<string, unknown>)[k] === v,
-            ),
-          );
-          return {
-            first: async () => filtered[0] ?? null,
-            async *[Symbol.asyncIterator]() {
-              for (const r of filtered) yield r;
-            },
-          };
-        },
+        withIndex: () => ({ first: async () => target }),
       }),
-      patch: async (id: string, updates: Record<string, unknown>) => {
-        const target = store.find((r) => r._id === id);
-        if (target) Object.assign(target, updates);
-      },
-      get: async (id: string) => {
-        const currentFile = currentFiles[id];
-        if (currentFile !== undefined) {
-          return { _id: id, organizationId: 'org', fileId: currentFile };
-        }
-        const linked = store.find((r) => r.documentId === id);
-        return linked
-          ? {
-              _id: id,
-              organizationId: linked.organizationId,
-              fileId: linked.storageId,
-            }
-          : null;
+      get: async (id: string) => documents[id] ?? null,
+      patch: async (id: string, fields: Record<string, unknown>) => {
+        patches.push({ id, ...fields });
       },
     },
-    scheduler: {
-      runAfter: async (
-        _d: number,
-        ref: unknown,
-        args: Record<string, unknown>,
-      ) => {
-        scheduled.push({ ref, args });
-      },
-    },
-  };
-  return { ctx: ctx as unknown as Ctx, scheduled, store };
+  } as unknown as Ctx;
+  return { ctx, patches };
 }
 
-function row(id: string, over: Partial<Row> = {}): Row {
-  return {
-    _id: id,
-    storageId: id,
-    organizationId: 'org',
-    ragStatus: 'queued',
-    fileName: 'f.pdf',
-    contentType: 'application/pdf',
-    _creationTime: 1,
-    ...over,
-  };
-}
+describe('maybeDispatchRagIndexing — routing', () => {
+  beforeEach(() => vi.clearAllMocks());
 
-describe('maybeDispatchRagIndexing — per-org concurrency cap', () => {
-  it('dispatches when the org is under the cap', async () => {
-    const { ctx, scheduled, store } = makeCtx([row('a')]);
-    await maybeDispatchRagIndexing(ctx, 'a');
-    expect(scheduled).toHaveLength(1);
-    expect(scheduled[0].args.storageId).toBe('a');
-    expect(scheduled[0].ref).toBe('uploadFileToRag');
-    expect(store.find((r) => r._id === 'a')?.ragParked).toBeUndefined();
+  it('sends a member upload to the interactive pool', async () => {
+    const { ctx } = createCtx(row({ source: 'user' }));
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(interactiveEnqueue).toHaveBeenCalledTimes(1);
+    expect(backgroundEnqueue).not.toHaveBeenCalled();
   });
 
-  it('dispatches a Document Hub row through the documents pipeline', async () => {
-    // documentId set + no threadId → uploadDocumentToRag with the exact blob
-    // admitted by this row, NOT whatever file the document points at later.
-    const { ctx, scheduled } = makeCtx([row('a', { documentId: 'doc1' })]);
-    await maybeDispatchRagIndexing(ctx, 'a');
-    expect(scheduled).toHaveLength(1);
-    expect(scheduled[0].ref).toBe('uploadDocumentToRag');
-    expect(scheduled[0].args).toEqual({
-      documentId: 'doc1',
-      expectedFileId: 'a',
+  it('sends a connector import to the background pool', async () => {
+    const { ctx } = createCtx(row({ source: 'google_drive' }));
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(backgroundEnqueue).toHaveBeenCalledTimes(1);
+    expect(interactiveEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('sends an unstamped row to the background pool', async () => {
+    // The fail-safe direction: a background job mistaken for interactive can
+    // starve a member's upload, which is the defect the split exists to fix.
+    const { ctx } = createCtx(row({ source: undefined }));
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(backgroundEnqueue).toHaveBeenCalledTimes(1);
+    expect(interactiveEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('indexes a current Hub row through the documents pipeline', async () => {
+    const { ctx } = createCtx(row({ source: 'user', documentId: 'doc_1' }), {
+      doc_1: { organizationId: 'org_1', fileId: 'blob_1' },
+    });
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    const [, fn, args] = interactiveEnqueue.mock.calls[0] ?? [];
+    expect(fn).toBe('uploadDocumentToRag');
+    expect(args).toMatchObject({
+      documentId: 'doc_1',
+      expectedFileId: 'blob_1',
     });
   });
 
-  it('treats a chat-bound row (documentId + threadId) as a file upload', async () => {
-    const { ctx, scheduled } = makeCtx([
-      row('a', { documentId: 'doc1', threadId: 'thread1' }),
-    ]);
-    await maybeDispatchRagIndexing(ctx, 'a');
-    expect(scheduled[0].ref).toBe('uploadFileToRag');
+  it('treats a chat-bound row as a plain file upload', async () => {
+    // `documentId` AND `threadId` is a chat upload, not a Hub document, so it
+    // must not go through the documents pipeline.
+    const { ctx } = createCtx(
+      row({ source: 'user', documentId: 'doc_1', threadId: 'thread_1' }),
+    );
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(interactiveEnqueue.mock.calls[0]?.[1]).toBe('uploadFileToRag');
   });
 
-  it('allows exactly the cap concurrently (target excluded from its own count)', async () => {
-    // 2 already in flight + this one = 3 = cap → dispatch.
-    const rows = [
-      row('a', { ragStatus: 'running' }),
-      row('b', { ragStatus: 'running' }),
-      row('c'),
-    ];
-    const { ctx, scheduled } = makeCtx(rows);
-    await maybeDispatchRagIndexing(ctx, 'c');
-    expect(scheduled).toHaveLength(1);
-  });
-
-  it('parks when the org is at the cap', async () => {
-    const rows = [
-      row('a', { ragStatus: 'running' }),
-      row('b', { ragStatus: 'running' }),
-      row('c', { ragStatus: 'running' }),
-      row('d'),
-    ];
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await maybeDispatchRagIndexing(ctx, 'd');
-    expect(scheduled).toHaveLength(0);
-    expect(store.find((r) => r._id === 'd')?.ragParked).toBe(true);
-  });
-
-  it('does not count parked rows as in flight', async () => {
-    // 2 running + 1 parked: the parked one is not in flight, so a new upload
-    // still has a free slot.
-    const rows = [
-      row('a', { ragStatus: 'running' }),
-      row('b', { ragStatus: 'running' }),
-      row('p', { ragParked: true }),
-      row('c'),
-    ];
-    const { ctx, scheduled } = makeCtx(rows);
-    await maybeDispatchRagIndexing(ctx, 'c');
-    expect(scheduled).toHaveLength(1);
-  });
-
-  it('no-ops for a non-queued or missing row', async () => {
-    const { ctx, scheduled } = makeCtx([row('a', { ragStatus: 'completed' })]);
-    await maybeDispatchRagIndexing(ctx, 'a');
-    await maybeDispatchRagIndexing(ctx, 'missing');
-    expect(scheduled).toHaveLength(0);
-  });
-
-  it('parks when the global budget is full even if the org is idle', async () => {
-    // 8 running across other orgs = global cap. A fresh org's first upload
-    // still has to wait for the shared budget.
-    const rows: Row[] = [];
-    for (let i = 0; i < 8; i += 1) {
-      rows.push(
-        row(`r${i}`, { organizationId: `o${i}`, ragStatus: 'running' }),
-      );
-    }
-    rows.push(row('c', { organizationId: 'fresh' }));
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await maybeDispatchRagIndexing(ctx, 'c');
-    expect(scheduled).toHaveLength(0);
-    expect(store.find((r) => r._id === 'c')?.ragParked).toBe(true);
-  });
-
-  it('charges an unparked queued row against the cap even with nothing scheduled', async () => {
-    // The cost model behind the `ragParked` contract in schema.ts: the counter
-    // cannot see whether a row's action was ever dispatched, so an unparked
-    // `'queued'` row is charged a slot on trust. Three of them saturate a
-    // whole org — which is exactly how email attachments stored with
-    // `deferRagDispatch` (a promise to dispatch that nothing kept) starved
-    // every real upload. A writer that marks a row queued without dispatching
-    // is therefore not merely untidy; it is indistinguishable from live work.
-    const rows = [row('e1'), row('e2'), row('e3'), row('upload')];
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await maybeDispatchRagIndexing(ctx, 'upload');
-    expect(scheduled).toHaveLength(0);
-    expect(store.find((r) => r._id === 'upload')?.ragParked).toBe(true);
-  });
-
-  it('leaves a slot free for a row stored with indexing skipped', async () => {
-    // The fixed email-attachment shape: `skipRagIndexing` leaves `ragStatus`
-    // unset, so the row is in neither status bucket and costs nothing. Three
-    // of them plus a real upload still dispatches.
-    const rows = [
-      row('e1', { ragStatus: undefined }),
-      row('e2', { ragStatus: undefined }),
-      row('e3', { ragStatus: undefined }),
-      row('upload'),
-    ];
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await maybeDispatchRagIndexing(ctx, 'upload');
-    expect(scheduled).toHaveLength(1);
-    expect(store.find((r) => r._id === 'upload')?.ragParked).toBeUndefined();
+  it('enqueues the completion callback with the row it indexed', async () => {
+    const { ctx } = createCtx(row({ source: 'user' }));
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    const opts = interactiveEnqueue.mock.calls[0]?.[3];
+    expect(opts).toMatchObject({
+      onComplete: 'recordRagJobResult',
+      context: { storageId: 'blob_1' },
+    });
   });
 });
 
-describe('promoteQueuedRagJobs', () => {
-  it('fails parked B after replacement and dispatches current C exactly once', async () => {
-    const rows = [
-      row('B', {
-        documentId: 'doc1',
-        ragParked: true,
-        _creationTime: 1,
-      }),
-      row('C', {
-        documentId: 'doc1',
-        ragParked: true,
-        _creationTime: 2,
-      }),
-    ];
-    const { ctx, scheduled, store } = makeCtx(rows, { doc1: 'C' });
+describe('maybeDispatchRagIndexing — rows it refuses', () => {
+  beforeEach(() => vi.clearAllMocks());
 
-    await promoteQueuedRagJobs(ctx);
+  it('does nothing for a missing row', async () => {
+    const { ctx } = createCtx(null);
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(interactiveEnqueue).not.toHaveBeenCalled();
+    expect(backgroundEnqueue).not.toHaveBeenCalled();
+  });
 
-    expect(scheduled).toEqual([
-      {
-        ref: 'uploadDocumentToRag',
-        args: { documentId: 'doc1', expectedFileId: 'C' },
-      },
-    ]);
-    expect(store.find((r) => r.storageId === 'B')).toMatchObject({
-      ragStatus: 'failed',
-      ragError: 'Indexing stopped because this file was replaced.',
+  it('does nothing for a row that is not queued', async () => {
+    const { ctx } = createCtx(row({ ragStatus: 'completed' }));
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(interactiveEnqueue).not.toHaveBeenCalled();
+    expect(backgroundEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('fails a Hub row whose document has moved on, without enqueueing', async () => {
+    const { ctx, patches } = createCtx(
+      row({ source: 'user', documentId: 'doc_1' }),
+      { doc_1: { organizationId: 'org_1', fileId: 'blob_NEWER' } },
+    );
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(interactiveEnqueue).not.toHaveBeenCalled();
+    expect(patches[0]).toMatchObject({ ragStatus: 'failed' });
+  });
+
+  it('clears a park flag left by a row that predates the pools', async () => {
+    // Nothing writes `ragParked` any more. Left set, such a row would read as
+    // parked forever — the defect (#2986) this change removes.
+    const { ctx, patches } = createCtx(
+      row({ source: 'user', ragParked: true }),
+    );
+    await maybeDispatchRagIndexing(ctx, 'blob_1');
+    expect(patches[0]).toMatchObject({ ragParked: undefined });
+    expect(interactiveEnqueue).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('recordRagJobResult — what the pool reports back', () => {
+  it('marks a row failed when the job failed', async () => {
+    const { ctx, patches } = createCtx(row({ ragStatus: 'running' }));
+    await recordResult(ctx, {
+      workId: 'w1',
+      context: { storageId: 'blob_1' },
+      result: { kind: 'failed', error: 'knowledge-db unreachable' },
     });
-    expect(store.find((r) => r.storageId === 'C')?.ragParked).toBeUndefined();
+    expect(patches[0]).toMatchObject({
+      ragStatus: 'failed',
+      ragError: 'knowledge-db unreachable',
+    });
   });
 
-  it('promotes parked rows until the per-org cap is reached', async () => {
-    // 1 running + 3 parked (same org) → per-org cap 3 → promote 2, leave 1.
-    const rows = [
-      row('r', { ragStatus: 'running' }),
-      row('p1', { ragParked: true }),
-      row('p2', { ragParked: true }),
-      row('p3', { ragParked: true }),
-    ];
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await promoteQueuedRagJobs(ctx);
-    expect(scheduled).toHaveLength(2);
-    expect(store.filter((r) => r.ragParked === true)).toHaveLength(1);
+  it('marks a row failed when the job was canceled', async () => {
+    // A cancel from the dashboard, or the pool's recovery pass finding a job
+    // whose completion never ran. Without this the row sits at `running`
+    // forever, which is what the watchdog existed to catch.
+    const { ctx, patches } = createCtx(row({ ragStatus: 'running' }));
+    await recordResult(ctx, {
+      workId: 'w1',
+      context: { storageId: 'blob_1' },
+      result: { kind: 'canceled' },
+    });
+    expect(patches[0]).toMatchObject({ ragStatus: 'failed' });
   });
 
-  it('promotes nothing when the org is already at the cap', async () => {
-    const rows = [
-      row('a', { ragStatus: 'running' }),
-      row('b', { ragStatus: 'running' }),
-      row('c', { ragStatus: 'running' }),
-      row('p', { ragParked: true }),
-    ];
-    const { ctx, scheduled } = makeCtx(rows);
-    await promoteQueuedRagJobs(ctx);
-    expect(scheduled).toHaveLength(0);
+  it('writes nothing on success', async () => {
+    // The indexing action writes `completed` with its chunk counts; this
+    // mutation has no such detail and must not overwrite it.
+    const { ctx, patches } = createCtx(row({ ragStatus: 'running' }));
+    await recordResult(ctx, {
+      workId: 'w1',
+      context: { storageId: 'blob_1' },
+      result: { kind: 'success', returnValue: null },
+    });
+    expect(patches).toEqual([]);
   });
 
-  it('is a no-op when there are no parked rows', async () => {
-    const { ctx, scheduled } = makeCtx([row('a', { ragStatus: 'running' })]);
-    await promoteQueuedRagJobs(ctx);
-    expect(scheduled).toHaveLength(0);
+  it('leaves an already-completed row alone', async () => {
+    // A straggling failure from a killed sibling must not undo a real success.
+    const { ctx, patches } = createCtx(row({ ragStatus: 'completed' }));
+    await recordResult(ctx, {
+      workId: 'w1',
+      context: { storageId: 'blob_1' },
+      result: { kind: 'failed', error: 'too late' },
+    });
+    expect(patches).toEqual([]);
   });
 
-  it('caps one org at its per-org share even with the most/oldest parked', async () => {
-    // Org A parked 5 (oldest, _creationTime 1..5), org B parked 2 (newer).
-    // Fair promotion: A takes only 3 (per-org cap), B takes both. A keeps 2.
-    const rows = [
-      ...[1, 2, 3, 4, 5].map((i) =>
-        row(`a${i}`, {
-          organizationId: 'A',
-          ragParked: true,
-          _creationTime: i,
-        }),
-      ),
-      ...[6, 7].map((i) =>
-        row(`b${i}`, {
-          organizationId: 'B',
-          ragParked: true,
-          _creationTime: i,
-        }),
-      ),
-    ];
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await promoteQueuedRagJobs(ctx);
-    expect(scheduled).toHaveLength(5); // 3 from A + 2 from B
-    const aParked = store.filter(
-      (r) => r.organizationId === 'A' && r.ragParked === true,
-    );
-    expect(aParked).toHaveLength(2);
-    const bParked = store.filter(
-      (r) => r.organizationId === 'B' && r.ragParked === true,
-    );
-    expect(bParked).toHaveLength(0);
-  });
-
-  it('bounds total promotions by the global cap across orgs', async () => {
-    // 3 orgs × 3 parked = 9 promotable per per-org caps, but the global cap
-    // (8) binds → 8 dispatched, 1 stays parked.
-    const rows: Row[] = [];
-    let t = 1;
-    for (const org of ['A', 'B', 'C']) {
-      for (let i = 0; i < 3; i += 1) {
-        rows.push(
-          row(`${org}${i}`, {
-            organizationId: org,
-            ragParked: true,
-            _creationTime: t++,
-          }),
-        );
-      }
-    }
-    const { ctx, scheduled, store } = makeCtx(rows);
-    await promoteQueuedRagJobs(ctx);
-    expect(scheduled).toHaveLength(8);
-    expect(store.filter((r) => r.ragParked === true)).toHaveLength(1);
-  });
-
-  it('does not promote when the global budget is already full', async () => {
-    // 8 running across orgs = global cap; a parked row in a fresh org waits.
-    const rows: Row[] = [];
-    for (let i = 0; i < 8; i += 1) {
-      rows.push(
-        row(`r${i}`, { organizationId: `o${i}`, ragStatus: 'running' }),
-      );
-    }
-    rows.push(row('p', { organizationId: 'fresh', ragParked: true }));
-    const { ctx, scheduled } = makeCtx(rows);
-    await promoteQueuedRagJobs(ctx);
-    expect(scheduled).toHaveLength(0);
+  it('does nothing when the row is gone', async () => {
+    const { ctx, patches } = createCtx(null);
+    await recordResult(ctx, {
+      workId: 'w1',
+      context: { storageId: 'blob_1' },
+      result: { kind: 'failed', error: 'x' },
+    });
+    expect(patches).toEqual([]);
   });
 });

--- a/services/platform/convex/file_metadata/rag_dispatch.ts
+++ b/services/platform/convex/file_metadata/rag_dispatch.ts
@@ -1,108 +1,42 @@
+/**
+ * Enqueue file indexing onto a workpool, and record the outcome on the row.
+ *
+ * Concurrency is the pool's job. This module decides only three things: which
+ * action indexes a row, which pool it belongs in, and what the row's status
+ * says afterwards.
+ *
+ * ## What replaced what
+ *
+ * This used to hand-roll the queue: count an org's in-flight rows, count the
+ * global total, and either dispatch or set `ragParked` and wait for a later
+ * terminal transition to promote it. Two defects came out of that shape.
+ *
+ * A parked row was excluded from the watchdog, so a promotion that never fired
+ * left it queued forever with no signal (#2986). The pool has no parked state —
+ * it owns the queue and drains itself, and its own recovery pass fails a job
+ * whose completion never ran, so a lost job cannot sit invisible.
+ *
+ * The budget was also undifferentiated, so a connector backlog held every slot
+ * and member uploads waited behind it — seven days of it on a live deployment
+ * (#2987). Provenance now picks the pool, so the two kinds of work no longer
+ * compete.
+ */
+
 import type { GenericMutationCtx } from 'convex/server';
+import { v } from 'convex/values';
 
 import { internal } from '../_generated/api';
-import type { DataModel, Doc } from '../_generated/dataModel';
+import type { DataModel, Doc, Id } from '../_generated/dataModel';
+import { internalMutation } from '../_generated/server';
 import type { BlobRef } from '../lib/storage/blob_ref';
+import { ragPoolFor } from './rag_pools';
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
 /**
- * Max file-indexing jobs a single org may run at once. Indexing is a
- * synchronous extract/chunk/embed inside a Node action against the shared
- * knowledge-db pool (default max 10 connections); an unbounded batch of large
- * uploads saturated the pool and pushed single jobs past Convex's 30-min action
- * ceiling — the root of the "larger files didn't work consistently" report.
- * The per-org cap isolates tenants: one org's backlog never touches another's
- * slots or parked queue.
- */
-export const MAX_CONCURRENT_RAG_INDEXING_PER_ORG = 3;
-
-/**
- * Max file-indexing jobs across ALL orgs at once. The knowledge-db pool is
- * shared per deployment, so the per-org cap alone doesn't bound total load —
- * N orgs × the per-org cap can exceed the pool. This global ceiling sits under
- * the default pool max (10), leaving headroom for RAG search + status polls,
- * and promotion is fair (oldest-first, still per-org-capped) so a busy org
- * can't starve a quiet one for the shared budget.
- */
-export const MAX_CONCURRENT_RAG_INDEXING_GLOBAL = 8;
-
-/**
- * Count an org's in-flight file-indexing jobs: rows that are `'running'`, plus
- * `'queued'` rows whose action is actually dispatched (NOT parked). Iterates
- * the `by_organizationId_and_ragStatus_and_documentId` index and short-circuits
- * at the cap, so it never materializes more than a handful of rows.
- *
- * `excludeStorageId` omits the row being decided on: at enqueue the caller's own
- * row is already `'queued'` (and would otherwise count against itself, making
- * the effective cap one too small).
- */
-async function countRagInFlight(
-  ctx: MutationCtx,
-  organizationId: string,
-  excludeStorageId?: BlobRef,
-): Promise<number> {
-  let inFlight = 0;
-  for await (const row of ctx.db
-    .query('fileMetadata')
-    .withIndex('by_organizationId_and_ragStatus_and_documentId', (q) =>
-      q.eq('organizationId', organizationId).eq('ragStatus', 'running'),
-    )) {
-    if (row.storageId === excludeStorageId) continue;
-    inFlight += 1;
-    if (inFlight >= MAX_CONCURRENT_RAG_INDEXING_PER_ORG) return inFlight;
-  }
-  for await (const row of ctx.db
-    .query('fileMetadata')
-    .withIndex('by_organizationId_and_ragStatus_and_documentId', (q) =>
-      q.eq('organizationId', organizationId).eq('ragStatus', 'queued'),
-    )) {
-    if (row.storageId === excludeStorageId) continue;
-    if (row.ragParked !== true) {
-      inFlight += 1;
-      if (inFlight >= MAX_CONCURRENT_RAG_INDEXING_PER_ORG) return inFlight;
-    }
-  }
-  return inFlight;
-}
-
-/**
- * Count in-flight file-indexing jobs across ALL orgs — `'running'` rows plus
- * dispatched (non-parked) `'queued'` rows — via the `by_ragStatus` index.
- * Short-circuits at the global cap.
- */
-async function countGlobalRagInFlight(
-  ctx: MutationCtx,
-  excludeStorageId?: BlobRef,
-): Promise<number> {
-  let inFlight = 0;
-  for await (const row of ctx.db
-    .query('fileMetadata')
-    .withIndex('by_ragStatus', (q) => q.eq('ragStatus', 'running'))) {
-    if (row.storageId === excludeStorageId) continue;
-    inFlight += 1;
-    if (inFlight >= MAX_CONCURRENT_RAG_INDEXING_GLOBAL) return inFlight;
-  }
-  for await (const row of ctx.db
-    .query('fileMetadata')
-    .withIndex('by_ragStatus', (q) => q.eq('ragStatus', 'queued'))) {
-    if (row.storageId === excludeStorageId) continue;
-    if (row.ragParked !== true) {
-      inFlight += 1;
-      if (inFlight >= MAX_CONCURRENT_RAG_INDEXING_GLOBAL) return inFlight;
-    }
-  }
-  return inFlight;
-}
-
-/**
- * Schedule the indexing action for a row and clear any park flag. Both
- * ingestion paths write `fileMetadata` rows and count against the same cap, so
- * the dispatcher must schedule whichever action matches the row: a Document Hub
- * row (`documentId` set, not chat-bound) indexes through the documents pipeline
- * (`uploadDocumentToRag`); every other queued row is a plain file upload
- * (`uploadFileToRag`). Keeps a parked hub-doc row correct when the fair promoter
- * later dispatches it.
+ * A Document Hub row whose document has since been replaced must not index:
+ * its blob is no longer the document's current file. Chat-bound rows
+ * (`threadId`) and plain uploads have no document to diverge from.
  */
 async function isCurrentHubRow(
   ctx: MutationCtx,
@@ -129,47 +63,68 @@ async function failSupersededHubRow(
   });
 }
 
-async function dispatchRow(
-  ctx: MutationCtx,
-  row: Doc<'fileMetadata'>,
-): Promise<boolean> {
-  if (!(await isCurrentHubRow(ctx, row))) {
-    await failSupersededHubRow(ctx, row);
-    return false;
-  }
-  if (row.ragParked) {
-    await ctx.db.patch(row._id, { ragParked: undefined });
-  }
-  if (row.documentId && !row.threadId) {
-    await ctx.scheduler.runAfter(
-      0,
-      internal.documents.internal_actions.uploadDocumentToRag,
-      {
-        documentId: row.documentId,
-        expectedFileId: row.storageId,
-      },
-    );
-    return true;
-  }
-  await ctx.scheduler.runAfter(
-    0,
-    internal.file_metadata.internal_actions.uploadFileToRag,
-    {
-      organizationId: row.organizationId,
-      storageId: row.storageId,
-      fileName: row.fileName,
-      contentType: row.contentType,
-    },
-  );
-  return true;
-}
+/**
+ * Record a pool job's outcome on the row it indexed.
+ *
+ * The pool guarantees this runs — via its recovery pass if the job itself
+ * vanished — so it is the single place a terminal `ragStatus` is written for a
+ * pooled job. A row cannot be stranded mid-flight the way a parked row could.
+ *
+ * A success leaves the status alone: the indexing action writes `'completed'`
+ * with its chunk counts as it finishes, and overwriting that here would erase
+ * detail the action has and this mutation does not.
+ */
+export const recordRagJobResult = internalMutation({
+  // The pool's own `vOnCompleteArgs` helper is NOT used: it builds its
+  // validator with its own resolved copy of `convex`, and the identity check
+  // inside `v.object()` then rejects a validator built with the platform's
+  // copy ("v.object() entries must be validators"). Declaring the documented
+  // shape here with our own validators avoids depending on which copy wins.
+  args: {
+    workId: v.string(),
+    context: v.object({ storageId: v.string() }),
+    result: v.union(
+      v.object({ kind: v.literal('success'), returnValue: v.any() }),
+      v.object({ kind: v.literal('failed'), error: v.string() }),
+      v.object({ kind: v.literal('canceled') }),
+    ),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    if (args.result.kind === 'success') return null;
+    const row = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) =>
+        q.eq('storageId', args.context.storageId),
+      )
+      .first();
+    if (!row) return null;
+    // The action's own catch writes a specific message where it can reach one.
+    // This covers what it cannot: a hard kill at the 30-minute action ceiling,
+    // a backend restart, a cancel from the dashboard.
+    if (row.ragStatus === 'completed') return null;
+    const detail =
+      args.result.kind === 'failed' ? args.result.error : 'Indexing canceled.';
+    await ctx.db.patch(row._id, {
+      ragStatus: 'failed',
+      ragError: detail.slice(0, 500),
+      ragProgress: undefined,
+      ragParked: undefined,
+    });
+    return null;
+  },
+});
 
 /**
- * Enqueue-time gate for the upload → `uploadFileToRag` path. The caller has
- * already written the `fileMetadata` row as `'queued'`; this decides whether to
- * dispatch its indexing action now or park it. Under the cap → dispatch;
- * at/over the cap → set `ragParked` and leave it for `promoteQueuedRagJobs`.
- * No-op if the row is gone or not `'queued'` (e.g. audio/unsupported).
+ * Enqueue a `'queued'` row's indexing action on the pool its provenance picks.
+ *
+ * Called by every writer that marks a row `'queued'`. A no-op when the row is
+ * gone or is not queued (audio, unsupported types), and when a Hub row's
+ * document has moved on.
+ *
+ * Both ingestion paths write `fileMetadata` rows, so the action has to match
+ * the row: a current Document Hub row indexes through the documents pipeline,
+ * every other queued row is a plain file upload.
  */
 export async function maybeDispatchRagIndexing(
   ctx: MutationCtx,
@@ -180,74 +135,68 @@ export async function maybeDispatchRagIndexing(
     .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
     .first();
   if (!row || row.ragStatus !== 'queued') return;
-
-  // Dispatch only when BOTH the org's slots and the shared global budget have
-  // room; otherwise park and let the fair promoter pick it up.
-  const orgInFlight = await countRagInFlight(
-    ctx,
-    row.organizationId,
-    storageId,
-  );
-  const globalInFlight =
-    orgInFlight < MAX_CONCURRENT_RAG_INDEXING_PER_ORG
-      ? await countGlobalRagInFlight(ctx, storageId)
-      : MAX_CONCURRENT_RAG_INDEXING_GLOBAL;
-  if (
-    orgInFlight < MAX_CONCURRENT_RAG_INDEXING_PER_ORG &&
-    globalInFlight < MAX_CONCURRENT_RAG_INDEXING_GLOBAL
-  ) {
-    if (!(await dispatchRow(ctx, row))) {
-      await promoteQueuedRagJobs(ctx);
-    }
-  } else if (row.ragParked !== true) {
-    await ctx.db.patch(row._id, { ragParked: true });
+  if (!(await isCurrentHubRow(ctx, row))) {
+    await failSupersededHubRow(ctx, row);
+    return;
   }
+  // `ragParked` is no longer written. Clearing it keeps a row that predates
+  // the pools readable as in-flight rather than parked forever.
+  if (row.ragParked) {
+    await ctx.db.patch(row._id, { ragParked: undefined });
+  }
+
+  await enqueueRagIndexing(ctx, row);
 }
 
 /**
- * Promote parked jobs across ALL orgs when slots free, called on every terminal
- * RAG transition. Fairness: it walks parked rows oldest-first (the `by_ragStatus`
- * index is ordered by `_creationTime`) and dispatches each whose org is still
- * under its per-org cap, up to the global cap — so the shared budget is shared
- * FIFO across tenants while no single org can take more than its per-org share.
- * Because a job failed by the watchdog is a terminal transition too, a parked
- * row can never be stranded while any job is in flight.
+ * Enqueue a row's indexing action on the pool its provenance selects, writing
+ * nothing to the row itself.
  *
- * Single scan pass: per-org in-flight counts are computed once (lazily) and
- * tracked as dispatches are projected, and rows are dispatched after the scan
- * so iteration is never mutated mid-flight.
+ * Separate from the guards above so the cutover migration can enqueue a row
+ * that predates the pools WITHOUT touching any field — a migration that writes
+ * nothing is reversible by construction, and there is no second copy of the
+ * pool choice or the action choice to drift.
  */
-export async function promoteQueuedRagJobs(ctx: MutationCtx): Promise<void> {
-  let globalInFlight = await countGlobalRagInFlight(ctx);
-  if (globalInFlight >= MAX_CONCURRENT_RAG_INDEXING_GLOBAL) return;
+export interface RagIndexableRow {
+  readonly organizationId: string;
+  readonly storageId: BlobRef;
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly source?: string | undefined;
+  readonly documentId?: Id<'documents'> | undefined;
+  readonly threadId?: string | undefined;
+}
 
-  const orgProjected = new Map<string, number>();
-  const toDispatch: Doc<'fileMetadata'>[] = [];
-  for await (const row of ctx.db
-    .query('fileMetadata')
-    .withIndex('by_ragStatus', (q) => q.eq('ragStatus', 'queued'))) {
-    if (globalInFlight >= MAX_CONCURRENT_RAG_INDEXING_GLOBAL) break;
-    if (row.ragParked !== true) continue;
-    if (!(await isCurrentHubRow(ctx, row))) {
-      await failSupersededHubRow(ctx, row);
-      continue;
-    }
+export async function enqueueRagIndexing(
+  ctx: MutationCtx,
+  row: RagIndexableRow,
+): Promise<void> {
+  const pool = ragPoolFor(row.source);
 
-    let orgCount = orgProjected.get(row.organizationId);
-    if (orgCount === undefined) {
-      orgCount = await countRagInFlight(ctx, row.organizationId);
-    }
-    if (orgCount < MAX_CONCURRENT_RAG_INDEXING_PER_ORG) {
-      toDispatch.push(row);
-      orgProjected.set(row.organizationId, orgCount + 1);
-      globalInFlight += 1;
-    } else {
-      // Remember the cap-hit so the org's later parked rows skip the recount.
-      orgProjected.set(row.organizationId, orgCount);
-    }
+  if (row.documentId && !row.threadId) {
+    await pool.enqueueAction(
+      ctx,
+      internal.documents.internal_actions.uploadDocumentToRag,
+      { documentId: row.documentId, expectedFileId: row.storageId },
+      {
+        onComplete: internal.file_metadata.rag_dispatch.recordRagJobResult,
+        context: { storageId: String(row.storageId) },
+      },
+    );
+    return;
   }
-
-  for (const row of toDispatch) {
-    await dispatchRow(ctx, row);
-  }
+  await pool.enqueueAction(
+    ctx,
+    internal.file_metadata.internal_actions.uploadFileToRag,
+    {
+      organizationId: row.organizationId,
+      storageId: row.storageId,
+      fileName: row.fileName,
+      contentType: row.contentType,
+    },
+    {
+      onComplete: internal.file_metadata.rag_dispatch.recordRagJobResult,
+      context: { storageId: String(row.storageId) },
+    },
+  );
 }

--- a/services/platform/convex/file_metadata/rag_pools.test.ts
+++ b/services/platform/convex/file_metadata/rag_pools.test.ts
@@ -1,0 +1,45 @@
+// The real routing rule, not a restatement of it.
+//
+// `rag_dispatch.test.ts` mocks this module so the pools are observable, which
+// means it cannot catch a mistake in `ragPoolFor` itself. This suite imports
+// the real thing.
+
+import { describe, expect, it } from 'vitest';
+
+const { ragPoolFor, ragInteractivePool, ragBackgroundPool } =
+  await import('./rag_pools');
+
+describe('ragPoolFor', () => {
+  it('routes a member upload to the interactive pool', () => {
+    expect(ragPoolFor('user')).toBe(ragInteractivePool);
+  });
+
+  it('routes every other provenance to the background pool', () => {
+    // An open string, so this is an allow-list: connector slugs, agent output,
+    // transcripts and anything added later are all background.
+    for (const source of [
+      'agent',
+      'video_link',
+      'google_drive',
+      'onedrive',
+      'sharepoint',
+      'confluence',
+      'webdav',
+      'imap_smtp',
+      'something_added_next_year',
+    ]) {
+      expect(ragPoolFor(source)).toBe(ragBackgroundPool);
+    }
+  });
+
+  it('routes an unstamped row to the background pool', () => {
+    // The fail-safe direction. A background job mistaken for interactive can
+    // starve a member's upload, which is the defect the split exists to fix;
+    // the reverse only makes an import wait.
+    expect(ragPoolFor(undefined)).toBe(ragBackgroundPool);
+  });
+
+  it('keeps the two pools distinct', () => {
+    expect(ragInteractivePool).not.toBe(ragBackgroundPool);
+  });
+});

--- a/services/platform/convex/file_metadata/rag_pools.testkit.ts
+++ b/services/platform/convex/file_metadata/rag_pools.testkit.ts
@@ -1,0 +1,23 @@
+/**
+ * Register the indexing workpools on a `convexTest` instance.
+ *
+ * Any mutation that marks a `fileMetadata` row `'queued'` enqueues onto a pool,
+ * and convex-test throws `Component "ragInteractivePool" is not registered` for
+ * an unregistered component — so a test that uploads, binds, or replaces a file
+ * needs this even when indexing is not what it is testing.
+ *
+ * Both pools, always: which one a row lands on depends on its `source`, so
+ * registering only the expected one turns a routing change into a confusing
+ * failure in an unrelated suite.
+ */
+
+import workpoolComponent from '@convex-dev/workpool/test';
+import type { TestConvex } from 'convex-test';
+import type { GenericSchema, SchemaDefinition } from 'convex/server';
+
+export function registerRagPools<
+  Schema extends SchemaDefinition<GenericSchema, boolean>,
+>(t: TestConvex<Schema>): void {
+  workpoolComponent.register(t, 'ragInteractivePool');
+  workpoolComponent.register(t, 'ragBackgroundPool');
+}

--- a/services/platform/convex/file_metadata/rag_pools.ts
+++ b/services/platform/convex/file_metadata/rag_pools.ts
@@ -1,0 +1,76 @@
+/**
+ * The two workpools that bound file indexing, and the rule for choosing
+ * between them.
+ *
+ * Indexing runs a synchronous extract/chunk/embed inside a Node action against
+ * the organization's knowledge-db pool (`KNOWLEDGE_DB_POOL_MAX`, default 10).
+ * An unbounded batch of large uploads saturated that pool and pushed single
+ * jobs past Convex's 30-minute action ceiling — the root of the "larger files
+ * didn't work consistently" report — so the number of concurrent indexing
+ * actions has to be capped. `maxParallelism` is that cap.
+ *
+ * Why two pools rather than one: a single undifferentiated budget let a
+ * background source hold every slot. On a live deployment a connector minting
+ * one queued row every five minutes occupied the cap of 3 and no member upload
+ * indexed for seven days (#2987). Interactive work now draws on a budget that
+ * a background backlog cannot enter.
+ *
+ * The sum stays under the connection budget so RAG search and status polls
+ * keep headroom. Raising `KNOWLEDGE_DB_POOL_MAX` without revisiting these two
+ * numbers leaves them as the binding constraint.
+ */
+
+import { Workpool } from '@convex-dev/workpool';
+
+import { components } from '../_generated/api';
+
+/**
+ * Member-facing indexing: a file someone uploaded and is waiting on. Matches
+ * the previous per-org cap, so a single member's batch behaves as it did.
+ */
+export const ragInteractivePool = new Workpool(components.ragInteractivePool, {
+  maxParallelism: 3,
+  // A file that cannot be indexed fails the same way every attempt — a
+  // corrupt PDF, or one too large for the action ceiling. Retry twice for a
+  // transient knowledge-db blip, then stop, so an impossible file does not
+  // occupy a slot forever.
+  retryActionsByDefault: true,
+  defaultRetryBehavior: {
+    maxAttempts: 3,
+    initialBackoffMs: 2_000,
+    base: 2,
+  },
+});
+
+/**
+ * Everything not waited on by a person: connector imports, email attachments,
+ * transcripts. A backlog here delays only itself.
+ */
+export const ragBackgroundPool = new Workpool(components.ragBackgroundPool, {
+  maxParallelism: 2,
+  retryActionsByDefault: true,
+  defaultRetryBehavior: {
+    maxAttempts: 3,
+    initialBackoffMs: 5_000,
+    base: 2,
+  },
+});
+
+/**
+ * Sources whose indexing a person is actively waiting for.
+ *
+ * `source` is an open provenance string, so this is a small allow-list rather
+ * than an exhaustive switch: anything unrecognised — a connector slug, a new
+ * channel, an unstamped legacy row — is background. That direction is the safe
+ * one. A background job mistaken for interactive can starve a member's upload,
+ * which is the defect this split exists to fix; the reverse only makes an
+ * import wait.
+ */
+const INTERACTIVE_SOURCES: ReadonlySet<string> = new Set(['user']);
+
+/** The pool a row belongs in, decided from its provenance. */
+export function ragPoolFor(source: string | undefined): Workpool {
+  return source !== undefined && INTERACTIVE_SOURCES.has(source)
+    ? ragInteractivePool
+    : ragBackgroundPool;
+}

--- a/services/platform/convex/migrations/framework/registry.gen.ts
+++ b/services/platform/convex/migrations/framework/registry.gen.ts
@@ -14,6 +14,7 @@ import { migration as m0_4_1_02 } from '../versions/v0_4_1/02_task_labels_to_cat
 import { migration as m0_4_1_03 } from '../versions/v0_4_1/03_backfill_project_rollup_counts/migration';
 import { migration as m0_4_1_05 } from '../versions/v0_4_1/05_backfill_mail_attachment_received_at/migration';
 import { migration as m0_4_1_06 } from '../versions/v0_4_1/06_backfill_conversation_contact_source/migration';
+import { migration as m0_4_1_07 } from '../versions/v0_4_1/07_enqueue_pending_rag_indexing/migration';
 
 /** Every migration’s metadata, ordered by (semver, numericId). */
 export const ALL_META: readonly MigrationMeta[] = [
@@ -89,6 +90,18 @@ export const ALL_META: readonly MigrationMeta[] = [
     destructive: false,
     snapshot: 'none',
   },
+  {
+    id: "0.4.1/07_enqueue_pending_rag_indexing",
+    semver: "0.4.1",
+    numericId: 7,
+    slug: "enqueue_pending_rag_indexing",
+    title: "Enqueue indexing rows that predate the workpools",
+    description: "up enqueues every fileMetadata row still marked queued onto the indexing workpool its provenance selects, so rows written before the pools existed are picked up instead of waiting forever; down is a no-op because enqueueing is not a data change and the pool discards its own completed work.",
+    kind: 'db',
+    reversible: true,
+    destructive: false,
+    snapshot: 'none',
+  },
 ];
 
 const BY_ID: ReadonlyMap<string, MigrationMeta> = new Map(
@@ -109,6 +122,7 @@ export const DB_MIGRATIONS: Readonly<Record<string, DbMigration>> = {
   "0.4.1/03_backfill_project_rollup_counts": composeDb(requireMeta("0.4.1/03_backfill_project_rollup_counts"), m0_4_1_03),
   "0.4.1/05_backfill_mail_attachment_received_at": composeDb(requireMeta("0.4.1/05_backfill_mail_attachment_received_at"), m0_4_1_05),
   "0.4.1/06_backfill_conversation_contact_source": composeDb(requireMeta("0.4.1/06_backfill_conversation_contact_source"), m0_4_1_06),
+  "0.4.1/07_enqueue_pending_rag_indexing": composeDb(requireMeta("0.4.1/07_enqueue_pending_rag_indexing"), m0_4_1_07),
 };
 
 /** Runnable `component` migrations, keyed by meta.id. */

--- a/services/platform/convex/migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing/migration.test.ts
+++ b/services/platform/convex/migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing/migration.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+
+import { expect, vi } from 'vitest';
+
+import { buildModules } from '../../../framework/test_helpers';
+import { defineMigrationTest } from '../../../testing/harness.testkit';
+
+const DIR = 'migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing';
+
+// The pools are mocked so the enqueues are observable and no component has to
+// be registered. What the migration must prove is narrow: a `'queued'` row is
+// enqueued, anything else is not, and NO row is written — which is what makes
+// the harness's digest-equal `down` pass with a no-op inverse.
+const enqueued = vi.hoisted(() => [] as string[]);
+vi.mock('../../../../file_metadata/rag_pools', () => {
+  const pool = {
+    enqueueAction: (
+      _ctx: unknown,
+      _fn: unknown,
+      args: { storageId?: string; expectedFileId?: string },
+    ) => {
+      enqueued.push(String(args.storageId ?? args.expectedFileId));
+      return Promise.resolve('work_test');
+    },
+  };
+  return {
+    ragInteractivePool: pool,
+    ragBackgroundPool: pool,
+    ragPoolFor: () => pool,
+  };
+});
+
+defineMigrationTest({
+  id: '0.4.1/07_enqueue_pending_rag_indexing',
+  modules: buildModules(import.meta.glob('../../../../**/*.*s'), DIR),
+
+  async seed(ctx) {
+    enqueued.length = 0;
+    // Queued, so it must be enqueued.
+    await ctx.db.insert('fileMetadata', {
+      organizationId: 'org_1',
+      storageId: 'blob_queued',
+      fileName: 'waiting.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+      source: 'user',
+      ragStatus: 'queued',
+    });
+    // Queued AND parked — the shape #2986 stranded. Its flag must survive
+    // untouched, or `down` could not restore the world byte-for-byte.
+    await ctx.db.insert('fileMetadata', {
+      organizationId: 'org_1',
+      storageId: 'blob_parked',
+      fileName: 'stranded.pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+      source: 'google_drive',
+      ragStatus: 'queued',
+      ragParked: true,
+    });
+    // Already finished: nothing to enqueue.
+    await ctx.db.insert('fileMetadata', {
+      organizationId: 'org_1',
+      storageId: 'blob_done',
+      fileName: 'indexed.pdf',
+      contentType: 'application/pdf',
+      size: 512,
+      source: 'user',
+      ragStatus: 'completed',
+    });
+  },
+
+  async expectUp(world) {
+    // Both queued rows enqueued, the completed one not.
+    expect([...enqueued].sort()).toEqual(['blob_parked', 'blob_queued']);
+
+    // Nothing was written. The park flag in particular survives: clearing it
+    // would be a write this migration would owe a reversal for.
+    // The world ctx is loosely typed, so the shape this reads is declared.
+    interface RagRow {
+      storageId: unknown;
+      ragStatus: unknown;
+      ragParked: unknown;
+    }
+    const rows: RagRow[] = await world.run(async (ctx) => {
+      const all = await ctx.db.query('fileMetadata').collect();
+      return all.map((r: RagRow) => ({
+        storageId: r.storageId,
+        ragStatus: r.ragStatus,
+        ragParked: r.ragParked,
+      }));
+    });
+    const parked = rows.find((r: RagRow) => r.storageId === 'blob_parked');
+    expect(parked?.ragParked).toBe(true);
+    expect(parked?.ragStatus).toBe('queued');
+    expect(
+      rows.find((r: RagRow) => r.storageId === 'blob_done')?.ragStatus,
+    ).toBe('completed');
+  },
+});

--- a/services/platform/convex/migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing/migration.ts
+++ b/services/platform/convex/migrations/versions/v0_4_1/07_enqueue_pending_rag_indexing/migration.ts
@@ -1,0 +1,78 @@
+/**
+ * Pick up indexing rows that predate the workpools.
+ *
+ * Indexing used to be scheduled directly and gated by a hand-rolled cap, with
+ * over-cap rows marked `ragParked` and promoted later. It now goes through a
+ * workpool. A row already marked `'queued'` when that cutover deploys has no
+ * pool job behind it, and nothing else would ever create one — the writers
+ * enqueue at the moment they queue a row, and the promotion pass that used to
+ * sweep the backlog is gone. Such a row would wait forever.
+ *
+ * `up` enqueues each one through `enqueueRagIndexing`, which selects the pool
+ * from the row's provenance and writes NOTHING to the row.
+ *
+ * `down` is therefore a no-op by construction, not by omission: `up` changes no
+ * data, so there is nothing to restore, and the world comes back byte-for-byte.
+ * Rolling back the code is what reverses this; the pool discards its own
+ * completed work. A row's stale `ragParked` flag is left alone — nothing reads
+ * it any more, and clearing it here would be a write this migration would then
+ * owe a reversal for.
+ *
+ * `snapshot: 'none'` is sufficient because nothing is overwritten: a row that
+ * indexes twice is the pool's own cheap no-op, since the corpus writer skips
+ * content whose hash and status are unchanged.
+ */
+
+import type { Id } from '../../../../_generated/dataModel';
+import { defineDbMigration } from '../../../framework/define';
+
+export const migration = defineDbMigration({
+  title: 'Enqueue indexing rows that predate the workpools',
+  description:
+    'up enqueues every fileMetadata row still marked queued onto the indexing workpool its provenance selects, so rows written before the pools existed are picked up instead of waiting forever; down is a no-op because enqueueing is not a data change and the pool discards its own completed work.',
+  destructive: false,
+  snapshot: 'none',
+  subjects: { tables: ['fileMetadata'] },
+  table: 'fileMetadata',
+
+  async up(ctx, doc) {
+    if (doc.ragStatus !== 'queued') return;
+    // Replayed after a crash mid-batch, this enqueues the row a second time.
+    // That is safe and cheap: the corpus writer skips content whose hash and
+    // status are unchanged, so the duplicate job finds nothing to do.
+    //
+    // `enqueueRagIndexing`, not `maybeDispatchRagIndexing`: the latter also
+    // clears `ragParked`, and a migration that writes a field is a migration
+    // that has to restore it. This one writes nothing.
+    // The runner hands rows as `Record<string, unknown>`, so the fields the
+    // enqueue needs are read and checked rather than asserted. A row missing
+    // any of them could not have been indexed before this migration either.
+    const { organizationId, storageId, fileName, contentType } = doc;
+    if (
+      typeof organizationId !== 'string' ||
+      typeof storageId !== 'string' ||
+      typeof fileName !== 'string' ||
+      typeof contentType !== 'string'
+    ) {
+      return;
+    }
+    const { enqueueRagIndexing } =
+      await import('../../../../file_metadata/rag_dispatch');
+    await enqueueRagIndexing(ctx, {
+      organizationId,
+      storageId,
+      fileName,
+      contentType,
+      ...(typeof doc.source === 'string' ? { source: doc.source } : {}),
+      ...(typeof doc.documentId === 'string'
+        ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a documentId on a fileMetadata row is a documents id by schema; a wrong id reads as a superseded row and is refused
+          { documentId: doc.documentId as Id<'documents'> }
+        : {}),
+      ...(typeof doc.threadId === 'string' ? { threadId: doc.threadId } : {}),
+    });
+  },
+
+  async down(_ctx, _doc) {
+    // Nothing to reverse — see the header. Enqueueing is not a data change.
+  },
+});

--- a/services/platform/convex/projects/rest_machine_door.test.ts
+++ b/services/platform/convex/projects/rest_machine_door.test.ts
@@ -2,18 +2,47 @@
 // backend: the internal create-project twin shares the session core
 // (duplicate/blank externalItemId, editor gate), folders get-or-create is
 // scope-safe, and the bind flow writes a project file whose RAG opt-out
-// DEFAULTS the door to "never index" — asserted against the REAL scheduler
-// (`_scheduled_functions`), the same drain-proof style as
-// documents/create_document_from_upload_rag_skip.test.ts.
+// DEFAULTS the door to "never index" — asserted against the indexing workpool,
+// the same style as documents/create_document_from_upload_rag_skip.test.ts.
+// (It read the real `_scheduled_functions` until indexing moved onto a
+// workpool; a component's internal scheduling is not visible there.)
 
 import rateLimiterComponent from '@convex-dev/rate-limiter/test';
 import { convexTest, type TestConvex } from 'convex-test';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getFunctionName } from 'convex/server';
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+} from 'vitest';
 
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import betterAuthSchema from '../betterAuth/schema';
 import schema from '../schema';
+
+// Indexing is enqueued onto a workpool, and a component's internal scheduling
+// is NOT visible in the app's `_scheduled_functions` — verified empirically.
+// So the pools are mocked and the enqueues observed directly, which asserts the
+// same thing the scheduler probe used to: indexing was requested, or was not.
+const ragEnqueues = vi.hoisted(() => [] as unknown[][]);
+vi.mock('../file_metadata/rag_pools', () => {
+  const pool = {
+    enqueueAction: (...args: unknown[]) => {
+      ragEnqueues.push(args);
+      return Promise.resolve('work_test');
+    },
+  };
+  return {
+    ragInteractivePool: pool,
+    ragBackgroundPool: pool,
+    ragPoolFor: () => pool,
+  };
+});
 
 const TEST_DIR_FROM_CONVEX_ROOT = 'projects';
 function toConvexRootKey(globKey: string): string {
@@ -173,17 +202,12 @@ async function bindFile(
 
 /** Every RAG-indexing job ever written to the scheduler (rows persist after
  * execution, so this is drain-proof). */
-async function ragIndexingJobs(t: T): Promise<string[]> {
-  return t.run(async (ctx) => {
-    const fns = await ctx.db.system.query('_scheduled_functions').collect();
-    return fns
-      .map((fn) => fn.name)
-      .filter(
-        (name) =>
-          name.includes('uploadFileToRag') ||
-          name.includes('uploadDocumentToRag'),
-      );
-  });
+async function ragIndexingJobs(_t: T): Promise<string[]> {
+  // One entry per enqueued indexing job. The pool call carries the action as
+  // its second argument; its name is what the scheduler probe used to read.
+  return ragEnqueues.map((call) =>
+    getFunctionName(call[1] as Parameters<typeof getFunctionName>[0]),
+  );
 }
 
 function codeOf(error: unknown): string | undefined {
@@ -210,6 +234,10 @@ async function expectCode(p: Promise<unknown>, code: string): Promise<void> {
   );
   expect(codeOf(error)).toBe(code);
 }
+
+beforeEach(() => {
+  ragEnqueues.length = 0;
+});
 
 describe('createProjectForUser (shared core with the session createProject)', () => {
   it('creates with a derived key and answers the REST projection', async () => {

--- a/services/platform/convex/webdav/tree_mutations.test.ts
+++ b/services/platform/convex/webdav/tree_mutations.test.ts
@@ -2,6 +2,7 @@ import { convexTest } from 'convex-test';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { internal } from '../_generated/api';
+import { registerRagPools } from '../file_metadata/rag_pools.testkit';
 import schema from '../schema';
 
 // ingestPutBlob → saveFileMetadata gates an opportunistic retention-cleanup
@@ -62,6 +63,7 @@ async function expectCode(p: Promise<unknown>, code: string): Promise<void> {
 describe('webdav tree_mutations.mkcol (convex-test)', () => {
   it('creates a top-level collection, then 405s on a repeat (already exists)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId } = await mkcol(t, [], 'docs');
     expect(folderId).toBeTruthy();
     await expectCode(mkcol(t, [], 'docs'), 'METHOD_NOT_ALLOWED');
@@ -69,6 +71,7 @@ describe('webdav tree_mutations.mkcol (convex-test)', () => {
 
   it('405s when a DOCUMENT of the same name already exists (P2.1 collision)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     await t.run(async (ctx) => {
       await ctx.db.insert('documents', {
         organizationId: ORG,
@@ -82,6 +85,7 @@ describe('webdav tree_mutations.mkcol (convex-test)', () => {
 
   it('409s past MAX_FOLDER_DEPTH (P2.5 depth cap)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     // parentSegments.length + 1 > 20 → rejected before any DB lookup.
     await expectCode(
       mkcol(
@@ -95,6 +99,7 @@ describe('webdav tree_mutations.mkcol (convex-test)', () => {
 
   it('409s when the parent collection does not exist', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     await expectCode(mkcol(t, ['missing'], 'child'), 'CONFLICT');
   });
 });
@@ -102,6 +107,7 @@ describe('webdav tree_mutations.mkcol (convex-test)', () => {
 describe('webdav tree_mutations legal-hold gate (convex-test)', () => {
   it('softDeleteDocument refuses under an active org hold (P1.2) and leaves the doc active', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const docId = await t.run(async (ctx) => {
       await ctx.db.insert('legalHolds', {
         organizationId: ORG,
@@ -131,6 +137,7 @@ describe('webdav tree_mutations legal-hold gate (convex-test)', () => {
 
   it('softDeleteDocument succeeds with no hold', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const docId = await t.run(async (ctx) =>
       ctx.db.insert('documents', {
         organizationId: ORG,
@@ -150,6 +157,7 @@ describe('webdav tree_mutations legal-hold gate (convex-test)', () => {
 describe('webdav tree_mutations.moveResource folder reparent (convex-test)', () => {
   it('recomputes descendant folderPath and detaches connector-sourced docs (P2.3)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: srcId } = await mkcol(t, [], 'src');
     await mkcol(t, [], 'dst');
     const docId = await t.run(async (ctx) =>
@@ -222,6 +230,7 @@ describe('webdav tree_mutations.ingestPutBlob content-type derivation (convex-te
 
   it('rewrites octet-stream to application/pdf for a .pdf upload', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { result, mimeType, contentType } = await ingest(
       t,
       'report.pdf',
@@ -234,6 +243,7 @@ describe('webdav tree_mutations.ingestPutBlob content-type derivation (convex-te
 
   it('rewrites octet-stream to the Office MIME for a .pptx upload', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { mimeType, contentType } = await ingest(
       t,
       'deck.pptx',
@@ -245,12 +255,14 @@ describe('webdav tree_mutations.ingestPutBlob content-type derivation (convex-te
 
   it('preserves a correct client-supplied Content-Type', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { mimeType } = await ingest(t, 'photo.png', 'image/png');
     expect(mimeType).toBe('image/png');
   });
 
   it('labels a markdown file (.md) as text/markdown instead of octet-stream', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { mimeType, contentType } = await ingest(
       t,
       'practice.md',
@@ -262,6 +274,7 @@ describe('webdav tree_mutations.ingestPutBlob content-type derivation (convex-te
 
   it('leaves an unknown binary extension as octet-stream', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { mimeType } = await ingest(
       t,
       'firmware.bin',
@@ -272,6 +285,7 @@ describe('webdav tree_mutations.ingestPutBlob content-type derivation (convex-te
 
   it('a second PUT to the same path overwrites in place (created:false)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const first = await ingest(t, 'dup.txt', 'text/plain');
     expect(first.result.created).toBe(true);
     const second = await ingest(t, 'dup.txt', 'text/plain');
@@ -291,6 +305,7 @@ describe('webdav tree_mutations.ingestPutBlob content-type derivation (convex-te
 describe('webdav tree_mutations.copyResource (convex-test)', () => {
   it('copies a document into a new row sharing the storage id; source stays active', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { srcDocId, storageId } = await t.run(async (ctx) => {
       const sid = await ctx.storage.store(new Blob(['x']));
       const id = await ctx.db.insert('documents', {
@@ -327,6 +342,7 @@ describe('webdav tree_mutations.copyResource (convex-test)', () => {
 
   it('copies a folder recursively, duplicating child documents', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: srcId } = await mkcol(t, [], 'src');
     await t.run(async (ctx) =>
       ctx.db.insert('documents', {
@@ -359,6 +375,7 @@ describe('webdav tree_mutations.copyResource (convex-test)', () => {
 
   it('refuses to copy onto an existing destination without Overwrite (DEST_EXISTS)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const srcId = await t.run(async (ctx) =>
       ctx.db.insert('documents', {
         organizationId: ORG,
@@ -414,6 +431,7 @@ describe('webdav tree_mutations project-scope gate (convex-test)', () => {
 
   it('a PUT colliding with a project file creates an independent hub doc and leaves the project blob untouched', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { docId, storageId } = await seedProjectDoc(t, 'spec.pdf');
 
     const putStorageId = await t.run(async (ctx) =>
@@ -447,6 +465,7 @@ describe('webdav tree_mutations project-scope gate (convex-test)', () => {
 
   it('softDeleteDocument refuses a project doc as NOT_FOUND and leaves it active', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { docId } = await seedProjectDoc(t, 'spec.pdf');
 
     await expectCode(
@@ -462,6 +481,7 @@ describe('webdav tree_mutations project-scope gate (convex-test)', () => {
 
   it('moveResource refuses a project doc source as NOT_FOUND and leaves the row unchanged', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { docId } = await seedProjectDoc(t, 'spec.pdf');
 
     await expectCode(
@@ -482,6 +502,7 @@ describe('webdav tree_mutations project-scope gate (convex-test)', () => {
 
   it('copyResource refuses a project doc source as NOT_FOUND', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { docId } = await seedProjectDoc(t, 'spec.pdf');
 
     await expectCode(
@@ -504,6 +525,7 @@ describe('webdav tree_mutations project-scope gate (convex-test)', () => {
 
   it('a MOVE whose destination name collides with a project file never trashes the project doc', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { docId } = await seedProjectDoc(t, 'spec.pdf');
     const hubId = await t.run(async (ctx) =>
       ctx.db.insert('documents', {
@@ -534,6 +556,7 @@ describe('webdav tree_mutations project-scope gate (convex-test)', () => {
 
   it('MKCOL is not blocked by an invisible project doc of the same name', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     await seedProjectDoc(t, 'reports');
     const { folderId } = await mkcol(t, [], 'reports');
     expect(folderId).toBeTruthy();
@@ -565,6 +588,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 
   it('MKCOL colliding with a project folder creates an independent hub folder', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: projectFolderId } = await seedProjectFolder(t, 'reports');
     const { folderId } = await mkcol(t, [], 'reports');
     expect(folderId).toBeTruthy();
@@ -578,6 +602,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 
   it('a PUT path never traverses a project folder — the invisible parent 409s', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: projectFolderId } = await seedProjectFolder(t, 'reports');
     const storageId = await t.run(async (ctx) =>
       ctx.storage.store(new Blob(['hub bytes'], { type: 'text/plain' })),
@@ -611,6 +636,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 
   it('deleteFolderCascade refuses a project folder id as NOT_FOUND', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId } = await seedProjectFolder(t, 'reports');
     await expectCode(
       t.mutation(internal.webdav.tree_mutations.deleteFolderCascade, {
@@ -625,6 +651,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 
   it('moveResource refuses a project folder src as NOT_FOUND', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId } = await seedProjectFolder(t, 'reports');
     await expectCode(
       t.mutation(internal.webdav.tree_mutations.moveResource, {
@@ -644,6 +671,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 
   it('copyResource refuses a project folder src as NOT_FOUND', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId } = await seedProjectFolder(t, 'reports');
     await expectCode(
       t.mutation(internal.webdav.tree_mutations.copyResource, {
@@ -665,6 +693,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 
   it('a MOVE destination colliding with a project folder is not a collision', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: projectFolderId } = await seedProjectFolder(t, 'reports');
     const { folderId: hubId } = await mkcol(t, [], 'drafts');
     // Overwrite:false — an invisible project folder must not DEST_EXISTS.
@@ -691,6 +720,7 @@ describe('webdav tree_mutations project-folder gate (convex-test)', () => {
 describe('webdav tree_mutations.deleteFolderCascade (convex-test)', () => {
   it('trashes every descendant document and removes the folder rows', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: parent } = await mkcol(t, [], 'parent');
     const { folderId: child } = await mkcol(t, ['parent'], 'child');
     const docId = await t.run(async (ctx) =>
@@ -717,6 +747,7 @@ describe('webdav tree_mutations.deleteFolderCascade (convex-test)', () => {
 
   it('refuses the cascade under an org legal hold, leaving the subtree intact', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const { folderId: parent } = await mkcol(t, [], 'held');
     const docId = await t.run(async (ctx) => {
       await ctx.db.insert('legalHolds', {
@@ -751,6 +782,7 @@ describe('webdav tree_mutations.deleteFolderCascade (convex-test)', () => {
 describe('webdav tree_mutations — per-org blob seam (s3: refs, #2737)', () => {
   it('ingestPutBlob accepts an s3: ref: fileId is the ref, no Convex sha256', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const s3Ref = `s3:${ORG}/uuid-webdav-1`;
     const result = await t.mutation(
       internal.webdav.tree_mutations.ingestPutBlob,
@@ -781,6 +813,7 @@ describe('webdav tree_mutations — per-org blob seam (s3: refs, #2737)', () => 
 
   it('deleteWebdavBlob schedules the S3 delete action for an s3: ref', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     await t.mutation(internal.webdav.tree_mutations.deleteWebdavBlob, {
       storageId: `s3:${ORG}/orphan-1`,
       organizationId: ORG,
@@ -798,6 +831,7 @@ describe('webdav tree_mutations — per-org blob seam (s3: refs, #2737)', () => 
 
   it('deleteWebdavBlob deletes a Convex _storage ref inline (no schedule)', async () => {
     const t = convexTest(schema, modules);
+    registerRagPools(t);
     const id = await t.run(async (ctx) =>
       ctx.storage.store(new Blob(['y'], { type: 'text/plain' })),
     );


### PR DESCRIPTION
File indexing now runs on two Convex workpools instead of a hand-rolled queue. A background backlog can no longer hold every slot, and a waiting job can no longer be stranded with no signal.

Closes #2986 and #2987.

## Why

One budget served everything that indexes — a member uploading a file, and every connector sync, crawl and email attachment. On a live deployment a connector minting one queued row every five minutes held the cap of 3 and **no member upload indexed for seven days** (#2987).

The queue itself was ours to run: count an org's in-flight rows, count the global total, then either schedule or set `ragParked` and wait for a later terminal transition to promote it. A parked row was excluded from the watchdog, so a promotion that never fired left it queued forever with nothing reporting it (#2986).

## What changed

Two pools, `ragInteractivePool` (3) and `ragBackgroundPool` (2), chosen by the row's `source`. Only `user` is interactive; every other provenance, including an unstamped row, is background. That direction is the safe one — a background job mistaken for interactive can starve a member's upload, while the reverse only makes an import wait.

`maybeDispatchRagIndexing` keeps its signature and its callers. Inside, the counting and parking are gone: it guards, then enqueues.

There is no parked state left to strand. The pool owns the queue and drains itself, and its own recovery pass fails a job whose completion never ran, so a job lost to a restart or a hard kill cannot sit invisible. `promoteQueuedRagJobs` and its two call sites are deleted.

An `onComplete` mutation records a failed or canceled job on the row. Success is left alone, because the indexing action writes `completed` with chunk counts this mutation does not have.

Migration `0.4.1/07` enqueues rows that were already `'queued'` when this deploys. Nothing else would ever pick them up: writers enqueue at the moment they queue a row, and the promotion pass that used to sweep the backlog is gone.

## Risk

**The 30-minute action ceiling is unchanged.** A workpool cannot lift a platform limit, and it would retry a file that is simply too large, so `maxAttempts` is 3. Slicing is still what keeps an invocation short.

**The two concurrency numbers are tied to `KNOWLEDGE_DB_POOL_MAX`** (default 10). They sum to 5 so RAG search and status polls keep connections. Raising the env var without revisiting them leaves the pools as the binding constraint; both files say so.

**Per-org fairness is gone.** The old promoter walked parked rows oldest-first so a busy org could not starve a quiet one. A pool is FIFO. This is deliberate: one org per deployment is the normal shape, and multiple orgs are never concurrently busy. It is a throughput property, not an isolation one — no data is shared, every job carries its own org, and every read still resolves through that org's own pool.

**Registering a component changes what convex-test needs.** Any suite whose mutations queue a row must register the pools or it throws. `rag_pools.testkit.ts` exists so that is one call, and five suites now use it.

## Tests

Nineteen unit cases over routing and the completion callback, plus the migration's own suite through the shared harness.

Nine deliberate breakages were introduced one at a time, all caught: the non-queued guard, the superseded-Hub-row check, the legacy park-flag clear, chat-bound routing, success-writes-nothing, completed-is-protected, and three on the routing rule itself — widening interactive to `agent`, always-background, and treating an unstamped row as interactive.

The routing rule has its own suite that imports the real module, because the dispatch suite mocks the pools and would otherwise only restate the rule it is meant to test.

Two suites asserted indexing by reading `_scheduled_functions`. A component's internal scheduling is not visible there — verified by probing it — so they now observe the pool's enqueues, and their headers say so.

## Scope

Does not touch `rag_watchdog.ts`. The pool's recovery covers a lost job, but a genuinely stuck `running` row predating this change still needs the sweep, and retiring it deserves its own change with its own evidence.

Gate: typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, `migrations:check` (corpus, schema and config snapshots), platform suite 75,775 passing.
