### PR TITLE
fix(platform): show assignee names in task activity timeline

### DIFF
--- a/services/platform/app/features/tasks/components/task-timeline.test.tsx
+++ b/services/platform/app/features/tasks/components/task-timeline.test.tsx
@@ -1,27 +1,28 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Id } from '@/convex/_generated/dataModel';
 
+import type { TaskActivityRow } from '../utils/task-timeline';
 import { TaskTimeline } from './task-timeline';
 
-// #2609: a run-admission refusal never creates a `taskAgentRuns` row, so it is
-// recorded as a `taskActivity` row (`action: 'agent_run.refused'`, `toValue`
-// the machine `refusedReason`) instead. The timeline must render it with a
-// human-readable label, not the raw activity/reason codes.
+// Typed as the row the timeline actually consumes, so a fixture can carry any
+// real `actorType` and the shape cannot drift from `TaskActivityRow`.
+const timelineMocks: { activity: TaskActivityRow[] } = {
+  activity: [
+    {
+      _id: 'activity_1' as Id<'taskActivity'>,
+      actorType: 'agent',
+      actorId: 'issue-triager',
+      action: 'agent_run.refused',
+      toValue: 'agent_disabled',
+      createdAt: Date.now(),
+    },
+  ],
+};
+
 vi.mock('../hooks/queries', () => ({
-  useTaskActivity: () => ({
-    activity: [
-      {
-        _id: 'activity_1',
-        actorType: 'agent',
-        actorId: 'issue-triager',
-        action: 'agent_run.refused',
-        toValue: 'agent_disabled',
-        createdAt: Date.now(),
-      },
-    ],
-  }),
+  useTaskActivity: () => ({ activity: timelineMocks.activity }),
   useTaskAgentRuns: () => ({ runs: [] }),
 }));
 
@@ -33,6 +34,13 @@ vi.mock('../hooks/use-actor-directory', () => ({
       name: id === 'issue-triager' ? 'Issue Triager' : id,
       isAgent: type === 'agent',
     }),
+    resolveAssigneeId: (id: string) =>
+      (
+        ({
+          'user-old': 'Alex Doe',
+          'user-new': 'Kim Lee',
+        }) as Record<string, string>
+      )[id] ?? id,
     resolveActorPreview: () => null,
     resolveAgentRunPreview: () => null,
     resolveWorkflowRunPreview: () => null,
@@ -52,6 +60,7 @@ vi.mock('@/lib/i18n/client', () => ({
       const labels: Record<string, string> = {
         'detail.activity': 'Activity',
         'activity.agentRunRefused': 'Run refused',
+        'activity.assigneeChanged': 'Assignee changed',
         'agentRuns.refused.agent_disabled':
           'agent is not installed or is disabled',
       };
@@ -78,5 +87,37 @@ describe('TaskTimeline — admission refusal activity (#2609)', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/agent_run\.refused/)).not.toBeInTheDocument();
     expect(screen.queryByText(/agent_disabled/)).not.toBeInTheDocument();
+  });
+});
+
+describe('TaskTimeline — assignee change activity', () => {
+  beforeEach(() => {
+    timelineMocks.activity = [
+      {
+        _id: 'activity_2' as Id<'taskActivity'>,
+        actorType: 'user',
+        actorId: 'user-actor',
+        action: 'assignee.changed',
+        fromValue: 'user-old',
+        toValue: 'user-new',
+        createdAt: Date.now(),
+      },
+    ];
+  });
+
+  it('renders assignee names instead of raw ids', () => {
+    render(
+      <TaskTimeline
+        taskId={'task_1' as Id<'tasks'>}
+        organizationId="org_1"
+        projectId={'project_1' as Id<'projects'>}
+      />,
+    );
+
+    expect(
+      screen.getByText(/assignee changed: Alex Doe → Kim Lee/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/user-old/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/user-new/)).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/tasks/components/task-timeline.tsx
+++ b/services/platform/app/features/tasks/components/task-timeline.tsx
@@ -49,6 +49,7 @@ export function TaskTimeline({
   const { runs } = useTaskAgentRuns(taskId);
   const {
     resolveActor,
+    resolveAssigneeId,
     resolveActorPreview,
     resolveAgentRunPreview,
     resolveWorkflowRunPreview,
@@ -171,20 +172,26 @@ export function TaskTimeline({
             )
               ? (preview?.name ?? t('timeline.unresolvedWorkflow'))
               : actor.name;
-            const from =
-              entry.fromValue && isTaskStatus(entry.fromValue)
-                ? t(`status.${entry.fromValue}`)
-                : entry.fromValue;
-            const refusalLabelKey =
-              entry.action === 'agent_run.refused' && entry.toValue
-                ? TASK_RUN_REFUSAL_LABEL_KEY[entry.toValue]
-                : undefined;
-            const to =
-              entry.toValue && isTaskStatus(entry.toValue)
-                ? t(`status.${entry.toValue}`)
-                : refusalLabelKey
-                  ? t(refusalLabelKey)
-                  : entry.toValue;
+            const formatActivityValue = (
+              value: string | undefined,
+            ): string | undefined => {
+              if (!value) return undefined;
+              if (entry.action === 'assignee.changed') {
+                return resolveAssigneeId(value);
+              }
+              if (isTaskStatus(value)) {
+                return t(`status.${value}`);
+              }
+              if (
+                entry.action === 'agent_run.refused' &&
+                TASK_RUN_REFUSAL_LABEL_KEY[value]
+              ) {
+                return t(TASK_RUN_REFUSAL_LABEL_KEY[value]);
+              }
+              return value;
+            };
+            const from = formatActivityValue(entry.fromValue);
+            const to = formatActivityValue(entry.toValue);
             const detail = from && to ? `${from} → ${to}` : (to ?? from);
 
             return (

--- a/services/platform/app/features/tasks/hooks/use-actor-directory.test.ts
+++ b/services/platform/app/features/tasks/hooks/use-actor-directory.test.ts
@@ -131,4 +131,11 @@ describe('useActorDirectory — members + project-agent instances', () => {
       'timeline.systemActor',
     );
   });
+
+  it('resolves assignee ids without a type for activity timeline rows', () => {
+    const { result } = renderHook(() => useActorDirectory('org-1', 'proj-1'));
+    expect(result.current.resolveAssigneeId('user-1')).toBe('Alex Doe');
+    expect(result.current.resolveAssigneeId('pa_2')).toBe('Docs Writer');
+    expect(result.current.resolveAssigneeId('unknown-id')).toBe('unknown-id');
+  });
 });

--- a/services/platform/app/features/tasks/hooks/use-actor-directory.ts
+++ b/services/platform/app/features/tasks/hooks/use-actor-directory.ts
@@ -153,6 +153,20 @@ export function useActorDirectory(organizationId: string, projectId?: string) {
     return map;
   }, [agentList]);
 
+  const resolveAssigneeId = useMemo(
+    () =>
+      (id: string): string => {
+        const member = memberMap.get(id);
+        if (member) return member.name;
+        const agent = agentMap.get(id) ?? agentCatalog.get(id);
+        if (agent) return agent.name;
+        const appName = appNames.get(id);
+        if (appName) return appName;
+        return id;
+      },
+    [memberMap, agentMap, agentCatalog, appNames],
+  );
+
   const resolveActor = useMemo(
     () =>
       (type: TaskCreatorType, id: string): ResolvedActor => {
@@ -252,6 +266,7 @@ export function useActorDirectory(organizationId: string, projectId?: string) {
 
   return {
     resolveActor,
+    resolveAssigneeId,
     resolveActorPreview,
     resolveAgentRunPreview,
     resolveWorkflowRunPreview,


### PR DESCRIPTION
## Summary
- Resolve assignee IDs in task activity timeline entries to human-readable names (members, agents, automations)
- Add `resolveAssigneeId` to the actor directory for type-less id lookup used by `assignee.changed` rows
- Add regression tests for timeline rendering and id resolution

## Test plan
- [x] `bun run --filter @tale/platform test:ui -- app/features/tasks/components/task-timeline.test.tsx app/features/tasks/hooks/use-actor-directory.test.ts`
- [ ] Open a task with assignee change history and confirm the Activity section shows names (e.g. `Alex Doe → Kim Lee`) instead of raw ids