### PR TITLE
feat(platform): apply the org PII policy before indexing

### DIFF
--- a/services/platform/convex/knowledge/indexing.ts
+++ b/services/platform/convex/knowledge/indexing.ts
@@ -41,8 +41,10 @@ import { planIngest, sliceToStore } from '../../lib/knowledge/ingest-plan';
 import { logger } from '../../lib/knowledge/logger';
 import { scanForSecrets } from '../../lib/knowledge/secret-scan';
 import { PRIVATE_KNOWLEDGE_SCHEMA as SCHEMA } from '../../lib/knowledge/types';
+import type { PiiConfig } from '../../lib/shared/schemas/pii';
 import { assertVectorWidth } from './dimensions';
 import type { Embedder } from './embedding';
+import { applyPiiPolicyForIndexing } from './pii_gate';
 
 /** Chunks committed per slice. Small enough that a slice fits comfortably in
  * one invocation's budget, large enough that the per-slice overhead is noise. */
@@ -60,6 +62,12 @@ export interface IndexDocumentArgs {
    * Omitted when the caller has already scanned them. */
   readonly bytes?: Uint8Array;
   readonly embedder: Embedder;
+  /**
+   * The organization's PII policy, already parsed. Absent or disabled indexes
+   * exactly as before. Passed in rather than read here because this module has
+   * no Convex ctx — the caller resolves it once per file.
+   */
+  readonly piiConfig?: PiiConfig | null;
   readonly folderPath?: string | null;
   /**
    * Document scope, from the Convex document row (`teamTags`/`projectId` —
@@ -109,7 +117,7 @@ export interface IndexDocumentResult {
    * which resumes after the committed prefix. */
   readonly partial: boolean;
   /** Set when nothing was done, and why. */
-  readonly skipped?: 'unchanged' | 'secret-detected' | 'empty';
+  readonly skipped?: 'unchanged' | 'secret-detected' | 'empty' | 'pii-blocked';
   /** Present when the upload was refused, in words for the person who made it. */
   readonly refusal?: string;
 }
@@ -138,7 +146,24 @@ export async function indexDocument(
     }
   }
 
-  const chunks = chunkDocument(args.text, {
+  // The organization's own PII policy, applied before anything is chunked or
+  // embedded — so a masked identifier never reaches the vectors, and a blocked
+  // document never reaches the index at all.
+  const decision = applyPiiPolicyForIndexing(args.text, args.piiConfig ?? null);
+  if (decision.kind === 'refuse') {
+    const reason = `Indexing refused by the organization's PII policy (${decision.categoryIds.join(', ')}).`;
+    await markFailed(args.sql, args.orgSlug, args.fileId, reason);
+    return {
+      fileId: args.fileId,
+      chunksWritten: 0,
+      chunksTotal: 0,
+      partial: false,
+      skipped: 'pii-blocked',
+      refusal: reason,
+    };
+  }
+
+  const chunks = chunkDocument(decision.text, {
     title: args.title ?? args.filename,
   });
   if (chunks.length === 0) {
@@ -151,7 +176,11 @@ export async function indexDocument(
     };
   }
 
-  const contentHash = computeContentHash(args.text);
+  // Hashed AFTER the policy, not before. The hash is the content's identity:
+  // skip-if-unchanged and the duplicate-clone lookup both key on it. Hashing
+  // the raw text would make a policy change invisible — the same file would
+  // read as unchanged and keep its old, less-masked chunks forever.
+  const contentHash = computeContentHash(decision.text);
   const stored = await readStoredState(args.sql, args.orgSlug, args.fileId);
   const duplicate = await findDuplicate(
     args.sql,

--- a/services/platform/convex/knowledge/ingest_file.test.ts
+++ b/services/platform/convex/knowledge/ingest_file.test.ts
@@ -17,6 +17,9 @@ vi.mock('../_generated/api', () => ({
         getConversationBindingForBlob: 'getConversationBindingForBlob',
       },
     },
+    governance: {
+      internal_queries: { getPiiConfigInternal: 'getPiiConfigInternal' },
+    },
   },
 }));
 

--- a/services/platform/convex/knowledge/ingest_file.ts
+++ b/services/platform/convex/knowledge/ingest_file.ts
@@ -49,6 +49,7 @@ import { readOrgEmbeddingConfig } from './connection';
 import { pinDimensions } from './dimensions';
 import { EmbeddingNotConfigured, embedderForOrg } from './embedding';
 import { indexDocument } from './indexing';
+import { parsePiiConfig } from './pii_gate';
 import {
   getKnowledgePoolForOrg,
   PRIVATE_KNOWLEDGE_SCHEMA,
@@ -221,6 +222,16 @@ export async function indexFileBlob(
     // Resolve the org's embedding model and corpus pool. Both refuse loudly
     // (no model configured, BYO database unreachable, vector width mismatch)
     // — each refusal names the fix, so it lands on the row verbatim.
+    // The organization's PII policy, resolved once for this file. A missing or
+    // unparseable policy reads as "no policy" and indexes exactly as before —
+    // a governance typo must not take an organization's corpus offline.
+    const piiConfig = parsePiiConfig(
+      await ctx.runQuery(
+        internal.governance.internal_queries.getPiiConfigInternal,
+        { organizationId: args.organizationId },
+      ),
+    );
+
     const config = await readOrgEmbeddingConfig(orgSlug);
     const embedder = await embedderForOrg(ctx, {
       organizationId: args.organizationId,
@@ -273,6 +284,7 @@ export async function indexFileBlob(
         fileId,
         filename: args.fileName,
         text,
+        piiConfig,
         ...(scanBytes !== undefined ? { bytes: scanBytes } : {}),
         embedder,
         folderPath: args.folderPath ?? null,
@@ -301,6 +313,18 @@ export async function indexFileBlob(
           ragError:
             result.refusal ??
             'The file appears to contain a credential and was not indexed.',
+        });
+        return;
+      }
+      if (result.skipped === 'pii-blocked') {
+        // The organization's own policy refused it. The message names the
+        // pattern categories, never the matched text, so the row is safe to
+        // show and to log. The file itself is untouched and still lists.
+        await writeStatus(ctx, storageId, {
+          ragStatus: 'failed',
+          ragError:
+            result.refusal ??
+            "Not indexed: the organization's PII policy refused this file.",
         });
         return;
       }

--- a/services/platform/convex/knowledge/pii_gate.test.ts
+++ b/services/platform/convex/knowledge/pii_gate.test.ts
@@ -1,0 +1,139 @@
+// The organization's PII policy, applied to text bound for the index.
+//
+// The engine itself is tested in `lib/pii`; what matters here is the mapping
+// from a governance policy to an indexing decision, and that every failure
+// degrades to today's behaviour rather than taking a corpus offline.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { applyPiiPolicyForIndexing, parsePiiConfig } from './pii_gate';
+
+/** A policy with one obvious detector on, so a match is easy to arrange. */
+function policy(overrides: Record<string, unknown> = {}) {
+  return {
+    enabled: true,
+    mode: 'mask',
+    enabledPatterns: ['email', 'ssn'],
+    ...overrides,
+  } as never;
+}
+
+const WITH_PII = 'Contact me at ada@example.com about the role.';
+
+describe('applyPiiPolicyForIndexing', () => {
+  it('indexes unchanged and SILENTLY when there is no policy', () => {
+    // Silence is the point. Most organizations have no policy, so reaching the
+    // scrubber with a null config would throw and log a caught exception for
+    // every file they index — the same decision, arrived at noisily.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(applyPiiPolicyForIndexing(WITH_PII, null)).toEqual({
+      kind: 'index',
+      text: WITH_PII,
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('indexes unchanged when the policy is disabled', () => {
+    // An organization that has not turned this on gets exactly today's
+    // behaviour — this must not become an opt-out.
+    const decision = applyPiiPolicyForIndexing(
+      WITH_PII,
+      policy({ enabled: false }),
+    );
+    expect(decision).toEqual({ kind: 'index', text: WITH_PII });
+  });
+
+  it('masks under mode mask, so the identifier never reaches the vectors', () => {
+    const decision = applyPiiPolicyForIndexing(WITH_PII, policy());
+    expect(decision.kind).toBe('index');
+    if (decision.kind !== 'index') return;
+    expect(decision.text).not.toContain('ada@example.com');
+    // The surrounding words survive, or the file stops being findable at all.
+    expect(decision.text).toContain('about the role');
+  });
+
+  it('refuses under mode block, naming categories and not the matched text', () => {
+    const decision = applyPiiPolicyForIndexing(
+      WITH_PII,
+      policy({ mode: 'block' }),
+    );
+    expect(decision.kind).toBe('refuse');
+    if (decision.kind !== 'refuse') return;
+    expect(decision.categoryIds.length).toBeGreaterThan(0);
+    expect(JSON.stringify(decision.categoryIds)).not.toContain('ada@');
+  });
+
+  it('treats tokenize as mask, because an indexed chunk outlives a restore map', () => {
+    const decision = applyPiiPolicyForIndexing(
+      WITH_PII,
+      policy({ mode: 'tokenize' }),
+    );
+    expect(decision.kind).toBe('index');
+    if (decision.kind !== 'index') return;
+    expect(decision.text).not.toContain('ada@example.com');
+  });
+
+  it('indexes clean text unchanged', () => {
+    const clean = 'The handbook covers refunds within 30 days.';
+    expect(applyPiiPolicyForIndexing(clean, policy())).toEqual({
+      kind: 'index',
+      text: clean,
+    });
+  });
+
+  it('indexes unscrubbed when the scrubber cannot be built', async () => {
+    // Construction throws only on a programmer error, and the governance
+    // resolver filters the usual trigger (an unknown locale) upstream — so the
+    // failure is forced here. What matters is the guarantee: failing the index
+    // would take an organization's corpus offline over a governance typo.
+    vi.resetModules();
+    vi.doMock('../../lib/pii', () => ({
+      createScrubberFromConfig: () => {
+        throw new Error('unknown locale code');
+      },
+    }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { applyPiiPolicyForIndexing: withBrokenScrubber } =
+      await import('./pii_gate');
+    expect(withBrokenScrubber(WITH_PII, policy())).toEqual({
+      kind: 'index',
+      text: WITH_PII,
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    vi.doUnmock('../../lib/pii');
+    vi.resetModules();
+  });
+});
+
+describe('parsePiiConfig', () => {
+  it('reads a policy out of its stored record', () => {
+    const parsed = parsePiiConfig({
+      value: { enabled: true, mode: 'mask', enabledPatterns: ['email'] },
+    });
+    expect(parsed?.mode).toBe('mask');
+  });
+
+  it('reads a bare policy object too', () => {
+    const parsed = parsePiiConfig({
+      enabled: true,
+      mode: 'block',
+      enabledPatterns: [],
+    });
+    expect(parsed?.mode).toBe('block');
+  });
+
+  it('treats an absent policy as no policy', () => {
+    expect(parsePiiConfig(null)).toBeNull();
+    expect(parsePiiConfig(undefined)).toBeNull();
+  });
+
+  it('treats an unparseable policy as no policy, with a warning', () => {
+    // A stale or hand-edited governance row must not brick indexing.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parsePiiConfig({ value: { enabled: 'yes' } })).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/services/platform/convex/knowledge/pii_gate.ts
+++ b/services/platform/convex/knowledge/pii_gate.ts
@@ -1,0 +1,120 @@
+'use node';
+
+/**
+ * The organization's own PII policy, applied to text before it is indexed.
+ *
+ * `'use node'` is load-bearing: `lib/pii` reaches `node:path`, and every file
+ * under `convex/` is bundled for the V8 runtime unless it says otherwise —
+ * regardless of who imports it. Without the directive the Convex deploy fails
+ * with "Could not resolve node:path" and the whole app stops starting.
+ *
+ * ## Why the ingestion path needs this at all
+ *
+ * A document someone uploads was chosen: a person decided it belongs in the
+ * system and knows what is in it. Content that arrives by email is the
+ * opposite — a stranger decides what turns up, and a CV or a support message
+ * is exactly where a national ID, a card number or a date of birth appears
+ * unannounced. Indexing stores a processed derivative of that text and, unless
+ * the organization runs a local embedding model, sends it to whichever provider
+ * it configured.
+ *
+ * ## Why this is not a new judgement
+ *
+ * The policy is already the organization's, set in governance and applied today
+ * to chat input: which patterns are enabled, which locales to load for the
+ * address and national-ID composites, any custom patterns of their own, and
+ * what happens on a match. This module reuses that policy rather than inventing
+ * a second opinion about what counts as sensitive. An organization that has not
+ * enabled it gets exactly today's behaviour.
+ *
+ * ## The modes, as they apply to indexing
+ *
+ * - `mask` — index the masked text. The stored chunks and the vectors never
+ *   carry the identifier, and everything around it stays searchable.
+ * - `block` — do not index. The file still appears in listings, which read
+ *   `fileMetadata` rather than the index, so it stays visible as something that
+ *   arrived; only its contents stay out.
+ * - `tokenize` — treated as `mask`. Tokenizing keeps a per-message restore map
+ *   so a reply can be detokenized back to real details; an indexed chunk
+ *   outlives any such map, so restoring is meaningless here and keeping the
+ *   indexed copy masked is the safe reading.
+ */
+
+import { createScrubberFromConfig } from '../../lib/pii';
+import { piiConfigSchema, type PiiConfig } from '../../lib/shared/schemas/pii';
+
+export type PiiIngestDecision =
+  | { readonly kind: 'index'; readonly text: string }
+  | { readonly kind: 'refuse'; readonly categoryIds: readonly string[] };
+
+/**
+ * Parse a stored policy record. A malformed or absent policy reads as "no
+ * policy", which is today's behaviour — a bad governance row must not stop an
+ * organization indexing its own documents.
+ */
+export function parsePiiConfig(raw: unknown): PiiConfig | null {
+  if (raw === null || raw === undefined) return null;
+  const value =
+    typeof raw === 'object' && raw !== null && 'value' in raw ? raw.value : raw;
+  const parsed = piiConfigSchema.safeParse(value);
+  if (!parsed.success) {
+    console.warn(
+      `[pii-gate] ignoring unparseable pii_config: ${parsed.error.issues[0]?.message ?? 'invalid'}`,
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+/**
+ * Apply a policy to text bound for the index.
+ *
+ * Returns the text to index, masked where the policy says so, or a refusal
+ * carrying the categories that matched. No policy, a disabled policy, or a
+ * clean scan all return the text unchanged.
+ */
+export function applyPiiPolicyForIndexing(
+  text: string,
+  config: PiiConfig | null,
+): PiiIngestDecision {
+  if (config === null) return { kind: 'index', text };
+
+  let scrubber;
+  try {
+    scrubber = createScrubberFromConfig(config);
+  } catch (error) {
+    // `createScrubber` throws only on a programmer error, and the governance
+    // resolver filters the usual trigger (an unknown locale code) before it
+    // gets here — so this is defence, not an expected path. Failing the index
+    // would take an organization's whole corpus offline over a governance
+    // typo, so it degrades to today's behaviour and says so.
+    console.warn(
+      `[pii-gate] scrubber construction failed, indexing unscrubbed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return { kind: 'index', text };
+  }
+  if (scrubber === null) return { kind: 'index', text };
+
+  // The scrubber is built WITH the policy's mode, so it answers `blocked` under
+  // `block` and `modified` under `mask`/`tokenize`. Re-reading `config.mode`
+  // here would be a second opinion about a decision the engine already made.
+  const outcome = scrubber.scrub(text);
+  switch (outcome.kind) {
+    case 'pass':
+      return { kind: 'index', text };
+    case 'modified':
+      return { kind: 'index', text: outcome.text };
+    case 'flagged':
+      // Detected, deliberately not rewritten: the policy asked to be told, not
+      // to change anything. There is no masked text, so the original indexes.
+      return { kind: 'index', text };
+    case 'blocked':
+      return { kind: 'refuse', categoryIds: outcome.categoryIds };
+    default:
+      // A step error. The scan is fail-open by design, so this indexes as it
+      // would have before the policy existed.
+      return { kind: 'index', text };
+  }
+}


### PR DESCRIPTION
The organization's own PII policy now runs over text before it is indexed. An organization that has not enabled it sees no change.

## Why

Indexing stores a processed derivative of a document and, unless the organization runs a local embedding model, sends the text to whichever provider it configured. That is fine for a document someone chose to upload. It is a different proposition for content that arrived by email, where a stranger decides what turns up and a CV or support message is exactly where a national ID or a card number appears unannounced.

The policy for this already existed and was never asked. `lib/pii` is admin-configured — enabled patterns, locales for the address and national-ID composites, custom patterns, and the mode — and applied to chat input. **No module under `convex/` imported it**, so the ingestion path never asked whether it was about to embed a national ID.

## What changed

`convex/knowledge/pii_gate.ts` maps a governance policy to an indexing decision. `indexDocument` applies it before chunking, so a masked identifier never reaches a chunk or a vector, and a refused document never reaches the index. `ingest_file.ts` resolves the policy once per file and passes it in; it is the only caller, so Hub documents and email attachments are both covered.

The modes, as they land here:

- `mask` — index the masked text; everything around the identifier stays searchable.
- `block` — do not index. The file still appears in listings, which read `fileMetadata` rather than the index, so it stays visible as something that arrived.
- `tokenize` — treated as `mask`. Tokenizing keeps a per-message restore map so a reply can be detokenized; an indexed chunk outlives any such map.

A refusal reaches the row as a failure naming the pattern categories, beside the existing credential-scan refusal. `categoryIds` carries pattern names only, never matched text.

**The content hash now covers the indexed text, not the raw text.** The hash is the content's identity for both skip-if-unchanged and the duplicate-clone lookup. Hashing the raw text would make a policy change invisible: the same file would read as unchanged and keep its old, less-masked chunks forever.

## Risk

**Every failure degrades to today's behaviour.** A missing policy, an unparseable one, or a scrubber that cannot be built all index unscrubbed. Failing the index instead would take an organization's whole corpus offline over a governance typo.

**A no-policy organization is also silent.** Reaching the scrubber with no config would throw and log a caught exception for every file indexed — the same decision, arrived at noisily. A test pins the silence, because that is the only observable difference between the guard and its absence.

**Detection is not immunity.** A national-ID format outside the configured locales, or a scanned PDF whose digits OCR mangled, gets through. A configured policy is a much better position than none; it is not a guarantee.

## Tests

Eleven cases over the mapping: no policy, disabled policy, mask, block, tokenize, clean text, a forced construction failure, and four on parsing a stored record.

Five deliberate breakages, all caught. Three survived the first round and each pointed at code rather than a missing test: I had re-checked `config.enabled` and `config.mode` that `resolveScrubberOptions` already decides, leaving branches no test could reach. Removing that duplication killed all three, and the module is shorter for it.

## Scope

Does not change the default: an organization with no policy indexes exactly as before. Whether inbound content should be indexed at all, and what the default embedder posture should be, are separate decisions this does not settle.

Gate: repo-wide typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, platform suite 75,806 passing.
