### PR TITLE
feat(platform): find a conversation by its message text

### DIFF
--- a/services/platform/convex/conversations/search_for_chat.test.ts
+++ b/services/platform/convex/conversations/search_for_chat.test.ts
@@ -317,3 +317,131 @@ describe('searchConversationsForChat — explicit list mode', () => {
     expect(result.conversations).toEqual([]);
   });
 });
+
+describe('searchConversationsForChat — the message-body leg', () => {
+  let t: T;
+
+  beforeEach(async () => {
+    t = convexTest(schema, modules);
+    await seedWorld(t);
+  });
+
+  /**
+   * A conversation whose SUBJECT cannot match the term, so any hit proves the
+   * body leg found it. Returns the conversation id.
+   */
+  async function seedWithBody(
+    body: string,
+    assignment: Record<string, unknown> = {},
+  ): Promise<string> {
+    return t.run(async (ctx) => {
+      const conversationId = await ctx.db.insert('conversations', {
+        organizationId: ORG,
+        subject: 'Nothing matching here',
+        status: 'open',
+        lastMessageAt: 500,
+        ...assignment,
+      });
+      await ctx.db.insert('conversationMessages', {
+        organizationId: ORG,
+        conversationId,
+        channel: 'email',
+        direction: 'inbound',
+        deliveryState: 'delivered',
+        content: body,
+        deliveredAt: 500,
+      });
+      return String(conversationId);
+    });
+  }
+
+  async function search(userId: string, term: string) {
+    return t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      { organizationId: ORG, userId, term, limit: 10 },
+    );
+  }
+
+  it('finds a conversation by a word only its message body contains', async () => {
+    await seedWithBody('The chassis serial is XJ-4417.', {
+      assigneeUserId: OWNER_USER,
+    });
+    const found = await search(OWNER_USER, 'XJ-4417');
+    expect(found.conversations.map((c) => c.subject)).toContain(
+      'Nothing matching here',
+    );
+  });
+
+  it('still refuses a body match the caller may not read', async () => {
+    // The body walk sees every message in the organization, so this is the
+    // case that matters: matching is not reading.
+    await seedWithBody('The chassis serial is XJ-4417.', {
+      assigneeUserId: OWNER_USER,
+    });
+    const found = await search(PLAIN_MEMBER, 'XJ-4417');
+    expect(found.conversations).toEqual([]);
+  });
+
+  it('matches through HTML rather than against its markup', async () => {
+    await seedWithBody(
+      '<div><p>The chassis serial is <b>XJ-4417</b>.</p></div>',
+      { assigneeUserId: OWNER_USER },
+    );
+    const found = await search(OWNER_USER, 'XJ-4417');
+    expect(found.conversations).toHaveLength(1);
+  });
+
+  it('does not match a word that exists only in the markup', async () => {
+    // Without stripping, a search for "div" would hit every HTML mail.
+    await seedWithBody('<div><p>Nothing useful.</p></div>', {
+      assigneeUserId: OWNER_USER,
+    });
+    const found = await search(OWNER_USER, 'div');
+    expect(found.conversations).toEqual([]);
+  });
+
+  it('reports truncation from the body walk, not just the conversation walk', async () => {
+    // 401 messages against a 400 cap. A caller told "no matches" must be able
+    // to tell that from "no matches in what I looked at".
+    await t.run(async (ctx) => {
+      const conversationId = await ctx.db.insert('conversations', {
+        organizationId: ORG,
+        subject: 'Nothing matching here',
+        status: 'open',
+        lastMessageAt: 1,
+        assigneeUserId: OWNER_USER,
+      });
+      for (let i = 0; i < 401; i += 1) {
+        await ctx.db.insert('conversationMessages', {
+          organizationId: ORG,
+          conversationId,
+          channel: 'email',
+          direction: 'inbound',
+          deliveryState: 'delivered',
+          content: `filler ${i}`,
+          deliveredAt: 1000 + i,
+        });
+      }
+    });
+    const found = await search(OWNER_USER, 'nonexistent-term');
+    expect(found.truncated).toBe(true);
+  });
+
+  it('skips the body walk entirely for a listing', async () => {
+    // A listing has no term, so there is nothing to match and no reason to
+    // pay for the walk.
+    await seedWithBody('irrelevant', { assigneeUserId: OWNER_USER });
+    const found = await t.query(
+      internal.conversations.search_for_chat.searchConversationsForChat,
+      {
+        organizationId: ORG,
+        userId: OWNER_USER,
+        term: '',
+        list: true,
+        limit: 10,
+      },
+    );
+    expect(found.truncated).toBe(false);
+    expect(found.conversations.length).toBeGreaterThan(0);
+  });
+});

--- a/services/platform/convex/conversations/search_for_chat.ts
+++ b/services/platform/convex/conversations/search_for_chat.ts
@@ -26,16 +26,22 @@
  * inside a turn. A match older than the cap is invisible — a real limit, stated
  * rather than hidden.
  *
- * Contact names are searched without a `get` per row: one bounded contacts
- * search resolves the term to a set of contact ids first, and a conversation
- * matches on its subject OR on being with one of those contacts. Message bodies
- * are NOT searched yet; `conversationMessages` does carry
- * `by_organizationId_and_deliveredAt`, so a bounded body leg is possible later
- * without a schema change.
+ * Three legs, each resolved without a `get` per row. Contact names and message
+ * bodies are each one bounded pre-pass that turns the term into a set of ids;
+ * a conversation then matches on its subject, on being with one of those
+ * contacts, or on one of its messages containing the term.
+ *
+ * The body leg reads text the caller may not be allowed to see, which is safe
+ * only because it returns conversation ids and nothing else — every id still
+ * faces `conversationAssignmentAllows` in the walk below.
+ *
+ * All of it is keyword matching. A question phrased by meaning rather than by
+ * words in the mail will not match, and neither will anything past either cap.
  */
 
 import { v } from 'convex/values';
 
+import { htmlToText } from '../../lib/knowledge/html-to-text';
 import type { Doc } from '../_generated/dataModel';
 import { internalQuery, type QueryCtx } from '../_generated/server';
 import { getUserTeamIds } from '../lib/get_user_teams';
@@ -54,6 +60,67 @@ const SCAN_CAP = 300;
 /** Matched contacts to resolve before scanning. Bounds the id set the
  *  conversation walk tests against. */
 const CONTACT_MATCH_CAP = 25;
+
+/**
+ * How many recent MESSAGES one search may examine for a body match. Separate
+ * from {@link SCAN_CAP} because messages outnumber conversations several times
+ * over, and this walk pays an HTML strip per row rather than an assignment
+ * decision. A match older than this is invisible — a real limit, reported
+ * rather than hidden.
+ */
+const MESSAGE_SCAN_CAP = 400;
+
+/** Conversations whose bodies matched. Bounds the id set the conversation walk
+ *  tests against, the same way {@link CONTACT_MATCH_CAP} does. */
+const BODY_MATCH_CAP = 50;
+
+/**
+ * The conversations whose MESSAGE BODIES match the term.
+ *
+ * One bounded pre-pass rather than a per-conversation scan: `by_org_deliveredAt`
+ * walks every organization's messages newest-first, so the whole leg costs one
+ * capped walk instead of one per candidate conversation.
+ *
+ * This reads bodies the caller may not be allowed to see, and that is safe
+ * because it returns conversation IDS ONLY. Every id still faces
+ * `conversationAssignmentAllows` in the main walk, so an unreadable
+ * conversation's body match is collected and then discarded — no text and no
+ * existence signal crosses the boundary.
+ *
+ * Bodies arrive as whatever the sender's mail client produced, so HTML is
+ * stripped before matching — otherwise a search for "table" hits every
+ * `<table>`. `htmlToText` is the existing stripper; the cheap `<` test keeps a
+ * plain-text body from paying for it.
+ */
+async function matchingConversationIdsByBody(
+  ctx: QueryCtx,
+  args: { organizationId: string; term: string },
+): Promise<{ ids: Set<string>; truncated: boolean }> {
+  const ids = new Set<string>();
+  const lower = args.term.toLowerCase();
+  let scanned = 0;
+  let truncated = false;
+  for await (const message of ctx.db
+    .query('conversationMessages')
+    .withIndex('by_organizationId_and_deliveredAt', (q) =>
+      q.eq('organizationId', args.organizationId),
+    )
+    .order('desc')) {
+    if (scanned >= MESSAGE_SCAN_CAP) {
+      truncated = true;
+      break;
+    }
+    scanned += 1;
+    const body = message.content;
+    if (body === '') continue;
+    const text = body.includes('<') ? htmlToText(body) : body;
+    if (text.toLowerCase().includes(lower)) {
+      ids.add(String(message.conversationId));
+      if (ids.size >= BODY_MATCH_CAP) break;
+    }
+  }
+  return { ids, truncated };
+}
 
 /** The contact ids whose name matches the term, so a conversation can be found
  *  by who it is with and not only by its subject. */
@@ -138,10 +205,19 @@ export const searchConversationsForChat = internalQuery({
             organizationId: args.organizationId,
             term,
           });
+    const body =
+      listing || term === ''
+        ? { ids: new Set<string>(), truncated: false }
+        : await matchingConversationIdsByBody(ctx, {
+            organizationId: args.organizationId,
+            term,
+          });
 
     const out: Array<Doc<'conversations'>> = [];
     let scanned = 0;
-    let truncated = false;
+    // A cut-short body walk makes the whole answer partial, not just that leg —
+    // a caller told "no matches" would otherwise read it as complete.
+    let truncated = body.truncated;
     for await (const conversation of ctx.db
       .query('conversations')
       .withIndex('by_org_lastMessageAt', (q) =>
@@ -178,7 +254,8 @@ export const searchConversationsForChat = internalQuery({
         const byContact =
           conversation.contactId !== undefined &&
           contactIds.has(String(conversation.contactId));
-        if (!bySubject && !byContact) continue;
+        const byBody = body.ids.has(String(conversation._id));
+        if (!bySubject && !byContact && !byBody) continue;
       }
 
       // The scope decision comes AFTER the text match so an unreadable row


### PR DESCRIPTION
Chat can now find a conversation by a word in one of its messages, not only by its subject or who it is with.

## Why

An email arrives with a CV attached. The attachment is searchable; the covering note that explains what the sender wants is not. Asking about an order number, a serial, or a name that appears only in the body of a message found nothing, so the only route to a conversation was remembering its subject line.

The file already said this was the missing leg, and that the index it needed existed.

## What changed

One bounded pre-pass over `conversationMessages`, walking `by_organizationId_and_deliveredAt` newest-first, turning the term into a set of conversation ids — the same shape the contact-name leg already uses. A conversation then matches on its subject, on being with a matching contact, or on one of its messages containing the term.

HTML is stripped before matching. Bodies arrive as whatever the sender's mail client produced, so matching raw would make a search for "table" hit every `<table>`. `htmlToText` is the existing stripper, and the cheap `<` test keeps a plain-text body from paying for it.

`MESSAGE_SCAN_CAP` is 400 and `BODY_MATCH_CAP` is 50, both separate from the conversation walk's own cap. Messages outnumber conversations several times over, and this walk pays a strip per row rather than an assignment decision.

## Risk

**The body walk reads text the caller may not be allowed to see.** That is safe only because it returns conversation ids and nothing else — every id still faces `conversationAssignmentAllows` in the main walk, so an unreadable conversation's body match is collected and then discarded. A test asserts a member outside the assignment gets nothing from a body that plainly matches.

**Truncation from the body walk makes the whole answer partial**, not just that leg, so it is folded into the returned `truncated`. A caller told "no matches" would otherwise read it as complete when the walk stopped at 400 messages.

**It is keyword matching.** A question phrased by meaning rather than by words that appear in the mail will not match, and neither will anything past either cap. Nothing here embeds or stores anything, which is the trade: no third-party processing, no backfill, and it works on existing mail immediately.

## Tests

Six cases: a body-only match, a body match refused for the wrong caller, matching through HTML, not matching a word that exists only in markup, truncation surfacing from the body walk, and a listing skipping the walk entirely.

Five deliberate breakages, all caught: the leg switched off, the HTML strip removed, truncation dropped, the cap raised, and the assignment check disabled.

## Scope

Does not index anything. Email bodies still have no presence in the search index, which is #3015 — a different trade, and one that owes an erasure cascade.

Gate: repo-wide typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, platform suite 75,801 passing.
