### PR TITLE
fix(platform): say when an attachment is no longer available

### DIFF
--- a/services/platform/app/features/conversations/components/message.test.tsx
+++ b/services/platform/app/features/conversations/components/message.test.tsx
@@ -271,3 +271,65 @@ describe('Message — attachment list vs inline images', () => {
     expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
   });
 });
+
+describe('Message — an attachment whose bytes are gone', () => {
+  function attachment(over: Record<string, unknown> = {}) {
+    return {
+      id: 'a1',
+      filename: 'CV.pdf',
+      contentType: 'application/pdf',
+      size: 23_359,
+      ...over,
+    } as NonNullable<MessageType['attachments']>[number];
+  }
+
+  it('says the file is no longer available instead of its size', () => {
+    // The size reads as a promise the message cannot keep.
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ unavailable: true })],
+        })}
+      />,
+    );
+    expect(screen.getByText('CV.pdf')).toBeInTheDocument();
+    expect(screen.getByText('attachment.unavailable')).toBeInTheDocument();
+    expect(screen.queryByText(/KB|bytes/)).not.toBeInTheDocument();
+  });
+
+  it('offers no download control for it, even with a download handler', () => {
+    // A button that can only fail is worse than no button. The handler is what
+    // makes this load-bearing: without a URL the chip would still render a
+    // "fetch it" button, and for a file that no longer exists it can only fail.
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ unavailable: true })],
+        })}
+        onDownloadAttachments={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /download cv\.pdf/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still offers the download when the file is there', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ url: '/storage/blob_1/CV.pdf' })],
+        })}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /download cv\.pdf/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('attachment.unavailable'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/conversations/components/message.tsx
+++ b/services/platform/app/features/conversations/components/message.tsx
@@ -142,14 +142,10 @@ function getFileIcon(contentType: string, filename: string) {
 }
 
 interface AttachmentCardProps {
-  attachment: {
-    id: string;
-    filename: string;
-    contentType: string;
-    size: number;
-    storageId?: string;
-    url?: string;
-  };
+  // Derived from the query's own type rather than restated. The hand-written
+  // copy this replaces had already drifted — it was missing `contentId`, and
+  // would have silently ignored any field added later.
+  attachment: Attachment;
   isDownloading?: boolean;
   onDownload?: () => void;
 }
@@ -178,9 +174,11 @@ function AttachmentCard({
           {middleEllipsis(attachment.filename, 28)}
         </Text>
         <Text variant="caption" className="text-[10px]">
-          {isDownloading
-            ? t('attachment.downloading')
-            : formatFileSize(attachment.size)}
+          {attachment.unavailable
+            ? t('attachment.unavailable')
+            : isDownloading
+              ? t('attachment.downloading')
+              : formatFileSize(attachment.size)}
         </Text>
       </div>
       {isDownloading ? (
@@ -191,7 +189,7 @@ function AttachmentCard({
         >
           <Loader2 className="size-3.5 animate-spin" />
         </Row>
-      ) : hasUrl || onDownload ? (
+      ) : attachment.unavailable ? null : hasUrl || onDownload ? (
         <button
           type="button"
           onClick={() => {

--- a/services/platform/convex/conversations/transform_conversation.test.ts
+++ b/services/platform/convex/conversations/transform_conversation.test.ts
@@ -312,3 +312,130 @@ describe('transformConversation flat list-row fields', () => {
     expect(result.lastMessagePreview).toBeUndefined();
   });
 });
+
+/**
+ * A ctx whose message walk yields `messages`, and whose `fileMetadata` lookups
+ * answer only for `presentBlobs` — so a case can say which attachment bytes
+ * still exist.
+ */
+function createMockCtxWithBlobs(
+  messages: Doc<'conversationMessages'>[],
+  presentBlobs: string[],
+) {
+  const present = new Set(presentBlobs);
+  const ctx = {
+    db: {
+      query: vi.fn((table: string) => {
+        if (table === 'fileMetadata') {
+          let asked = '';
+          const fileBuilder = {
+            withIndex: vi.fn(
+              (
+                _name: string,
+                bind: (q: {
+                  eq: (f: string, v: unknown) => unknown;
+                }) => unknown,
+              ) => {
+                const q = {
+                  eq(_field: string, value: unknown) {
+                    asked = String(value);
+                    return q;
+                  },
+                };
+                bind(q);
+                return fileBuilder;
+              },
+            ),
+            first: vi.fn(async () =>
+              present.has(asked) ? { _id: 'fm' } : null,
+            ),
+          };
+          return fileBuilder;
+        }
+        return {
+          withIndex: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          first: vi.fn().mockResolvedValue(null),
+          [Symbol.asyncIterator]: async function* () {
+            for (const message of messages) yield message;
+          },
+        };
+      }),
+      get: vi.fn().mockResolvedValue(null),
+    },
+  };
+  return ctx as unknown as QueryCtx;
+}
+
+function messageWithAttachment(storageId: string, url = 'https://x/y.pdf') {
+  return makeMessageDoc({
+    _id: 'msg_att',
+    metadata: {
+      attachments: [
+        {
+          id: 'a1',
+          filename: 'invoice.pdf',
+          contentType: 'application/pdf',
+          size: 1024,
+          storageId,
+          url,
+        },
+      ],
+    },
+  });
+}
+
+describe('transformConversation — an attachment whose bytes are gone', () => {
+  it('marks it unavailable and withholds the link', async () => {
+    // The URL is built at ingest and stored on the message, so it outlives the
+    // blob. Leaving it would let the UI keep offering a download that 404s.
+    const ctx = createMockCtxWithBlobs(
+      [messageWithAttachment('blob_gone')],
+      [],
+    );
+    const result = await transformConversation(ctx, makeConversation(), {
+      includeAllMessages: true,
+    });
+    const attachment = result.messages?.[0]?.attachments?.[0];
+    expect(attachment?.unavailable).toBe(true);
+    expect(attachment?.url).toBeUndefined();
+  });
+
+  it('leaves an attachment whose bytes exist untouched', async () => {
+    const ctx = createMockCtxWithBlobs(
+      [messageWithAttachment('blob_here')],
+      ['blob_here'],
+    );
+    const result = await transformConversation(ctx, makeConversation(), {
+      includeAllMessages: true,
+    });
+    const attachment = result.messages?.[0]?.attachments?.[0];
+    expect(attachment?.unavailable).toBeUndefined();
+    expect(attachment?.url).toBe('https://x/y.pdf');
+  });
+
+  it('leaves an attachment with no storageId alone', async () => {
+    // Nothing to verify against, so nothing is claimed either way.
+    const message = makeMessageDoc({
+      _id: 'msg_att',
+      metadata: {
+        attachments: [
+          {
+            id: 'a1',
+            filename: 'inline.png',
+            contentType: 'image/png',
+            size: 10,
+            url: 'https://x/inline.png',
+          },
+        ],
+      },
+    });
+    const ctx = createMockCtxWithBlobs([message], []);
+    const result = await transformConversation(ctx, makeConversation(), {
+      includeAllMessages: true,
+    });
+    const attachment = result.messages?.[0]?.attachments?.[0];
+    expect(attachment?.unavailable).toBeUndefined();
+    expect(attachment?.url).toBe('https://x/inline.png');
+  });
+});

--- a/services/platform/convex/conversations/transform_conversation.ts
+++ b/services/platform/convex/conversations/transform_conversation.ts
@@ -16,6 +16,73 @@ const debugLog = createDebugLog('DEBUG_CONVERSATIONS', '[Conversations]');
 // truncated line, so shipping more than this per row is dead weight.
 const LAST_MESSAGE_PREVIEW_MAX_CHARS = 200;
 
+/**
+ * How many distinct attachment blobs one conversation view will verify.
+ *
+ * Each is an indexed point read. A conversation long enough to exceed this is
+ * rare, and the walk FAILS OPEN past the cap — nothing is marked — because
+ * wrongly telling someone a file is gone is worse than leaving a link that
+ * might 404.
+ */
+const ATTACHMENT_CHECK_CAP = 60;
+
+/**
+ * The attachment blobs that still exist, or null when there is nothing to
+ * check or the cap was exceeded.
+ *
+ * One deduped pass before the message projection, so the projection stays
+ * synchronous and a blob referenced by ten messages costs one read.
+ */
+async function presentAttachmentBlobs(
+  ctx: QueryCtx,
+  messageDocs: readonly Doc<'conversationMessages'>[],
+): Promise<Set<string> | null> {
+  const storageIds = new Set<string>();
+  for (const m of messageDocs) {
+    const raw = m.metadata?.attachments;
+    if (!Array.isArray(raw)) continue;
+    for (const a of raw) {
+      if (!isAttachmentRecord(a)) continue;
+      const storageId = a.storageId;
+      if (typeof storageId === 'string' && storageId !== '') {
+        storageIds.add(storageId);
+      }
+    }
+  }
+  if (storageIds.size === 0 || storageIds.size > ATTACHMENT_CHECK_CAP) {
+    return null;
+  }
+
+  const present = new Set<string>();
+  await Promise.all(
+    [...storageIds].map(async (storageId) => {
+      const row = await ctx.db
+        .query('fileMetadata')
+        .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
+        .first();
+      if (row !== null) present.add(storageId);
+    }),
+  );
+  return present;
+}
+
+/** Narrow one entry of the untyped `metadata.attachments` array. */
+function isAttachmentRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** True when the attachment names a blob the deduped pass could not find. */
+function isAttachmentGone(
+  a: { storageId?: string | undefined },
+  presentBlobs: Set<string> | null,
+): boolean {
+  return (
+    a.storageId !== undefined &&
+    presentBlobs !== null &&
+    !presentBlobs.has(a.storageId)
+  );
+}
+
 export async function transformConversation(
   ctx: QueryCtx,
   conversation: Doc<'conversations'>,
@@ -99,6 +166,9 @@ export async function transformConversation(
 
   debugLog('messageDocs', messageDocs.length);
   debugLog('conversation', conversation._id);
+
+  const presentBlobs = await presentAttachmentBlobs(ctx, messageDocs);
+
   const messages: MessageInfo[] = messageDocs.map((m) => {
     let timestamp = '';
 
@@ -145,7 +215,17 @@ export async function transformConversation(
               size: typeof a.size === 'number' ? a.size : 0,
               storageId:
                 typeof a.storageId === 'string' ? a.storageId : undefined,
-              url: typeof a.url === 'string' ? a.url : undefined,
+              // The stored URL outlives the bytes, so a message can offer a
+              // link that 404s. Decided from live truth rather than trusted
+              // from the message. The URL is withheld with it, or anything
+              // holding the attachment could still offer the broken link
+              // regardless of the flag.
+              url: isAttachmentGone(a, presentBlobs)
+                ? undefined
+                : typeof a.url === 'string'
+                  ? a.url
+                  : undefined,
+              unavailable: isAttachmentGone(a, presentBlobs) ? true : undefined,
               contentId:
                 typeof a.contentId === 'string' ? a.contentId : undefined,
             }))

--- a/services/platform/convex/conversations/validators.ts
+++ b/services/platform/convex/conversations/validators.ts
@@ -50,6 +50,14 @@ export const emailAttachmentMetaValidator = v.object({
   storageId: v.optional(v.string()),
   url: v.optional(v.string()),
   contentId: v.optional(v.string()),
+  /**
+   * The bytes are gone, so this cannot be downloaded. The URL is built at
+   * ingest and stored on the message, which means it outlives the blob — a
+   * restore, a bucket migration or a failed write leaves the message offering
+   * a link that 404s. Set at read time from live truth, and `url` is withheld
+   * alongside it so nothing can offer the broken link anyway.
+   */
+  unavailable: v.optional(v.boolean()),
 });
 
 export const messageValidator = v.object({

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1832,6 +1832,7 @@ conversations:
   attachment:
     download: Herunterladen
     downloading: Lade herunter...
+    unavailable: Nicht mehr verfügbar
     attachments: '{count, plural, one {# Anhang} other {# Anhänge}}'
   panel:
     uploadFailed: Anhänge konnten nicht hochgeladen werden. Versuch es erneut.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1775,6 +1775,7 @@ conversations:
   attachment:
     download: Download
     downloading: Downloading...
+    unavailable: No longer available
     attachments: '{count, plural, one {# attachment} other {# attachments}}'
   panel:
     uploadFailed: Couldn't upload attachments. Try again.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1848,6 +1848,7 @@ conversations:
   attachment:
     download: Télécharger
     downloading: Téléchargement...
+    unavailable: Plus disponible
     attachments: '{count, plural, one {# pièce jointe} other {# pièces jointes}}'
   panel:
     uploadFailed: Échec du téléversement des pièces jointes. Merci de réessayer.


### PR DESCRIPTION
A message that advertises an attachment whose bytes are gone now says so, instead of offering a download that fails with a browser error.

Closes #3017.

## Why

`materialize_email_attachments.ts` builds the download URL at ingest and stores it in the message metadata, so the URL outlives the blob. Nothing notices: the message keeps offering the link, and the failure surfaces as a browser error with no explanation.

Seen on a deployment after a recovery cycle re-imported the database without file storage, so rows came back and blobs did not. The trigger was a one-off, but nothing in the product detects the state, so any lost blob — a restore, a bucket migration, a failed write — leaves the same broken offer.

## What changed

`transformConversation` resolves attachment availability from live truth before projecting messages, and marks a missing one `unavailable`. The UI then shows "No longer available" in place of the file size and renders no download control.

**The URL is withheld along with the flag.** Leaving it would let anything holding the attachment offer the broken link regardless of what the flag says.

One deduped pass ahead of the projection, so the projection stays synchronous and a blob referenced by ten messages costs one indexed read.

## Risk

**It fails open past a cap.** `ATTACHMENT_CHECK_CAP` is 60 distinct blobs per conversation view; beyond it nothing is marked. Wrongly telling someone a file is gone is worse than leaving a link that might 404, so the cap errs toward silence.

**The check costs one indexed read per distinct blob.** A long conversation pays for that on every view. The dedupe keeps it to distinct blobs rather than per attachment.

**An attachment with no `storageId` is left alone** — there is nothing to verify against, so nothing is claimed either way.

## A duplication removed on the way

`AttachmentCardProps` hand-declared its own attachment shape instead of deriving it from the query type, and had already drifted: it was missing `contentId`, and would have silently ignored this field too. It now derives from the query's own type.

## Tests

Three on the server: a missing blob marked and its URL withheld, a present blob untouched, and an attachment with no `storageId` left alone. Three on the UI: the unavailable text replacing the size, no download control even when a download handler is supplied, and the normal case still offering the download.

Six deliberate breakages, all caught. One survived the first round: the no-button case passed without the guard, because that fixture had no URL and no handler, so no button rendered either way. The fixture now supplies the handler, which is what makes the guard load-bearing — without a URL the chip would otherwise render a "fetch it" button that can only fail.

Locales: `en`, `de`, `fr`.

## Scope

Detects a missing blob at read time. It does not clean up the message metadata, and it does not stop the URL being stored at ingest — the stored URL is still the mechanism, this only stops it being served once it cannot work.

Gate: repo-wide typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, platform suite 75,815 passing and the UI suite 3,463 passing.
