### PR TITLE
fix(platform): stop a search returning one passage twice

### DIFF
--- a/services/platform/convex/knowledge/search.test.ts
+++ b/services/platform/convex/knowledge/search.test.ts
@@ -97,3 +97,115 @@ describe('searchKnowledge live document validation', () => {
     });
   });
 });
+
+describe('searchKnowledge — the same passage twice', () => {
+  beforeEach(() => {
+    retrieveMock.mockReset();
+  });
+
+  /** Two refs holding identical text — the same file indexed twice. */
+  function duplicatePair(text: string) {
+    return [
+      { ...hit('documents', 'copy_a'), text, fusedScore: 0.9 },
+      { ...hit('documents', 'copy_b'), text, fusedScore: 0.4 },
+    ];
+  }
+
+  const ACCESS = { teamIds: [], projectIds: [], includeHub: true };
+
+  it('returns one copy, keeping the higher-scoring ref', async () => {
+    // A bounded result set spending two slots on one passage pushes a
+    // different answer off the end.
+    retrieveMock.mockResolvedValueOnce({
+      hits: [...duplicatePair('Refunds within 30 days.')],
+      diagnostics: {},
+    });
+    const runQuery = vi.fn(async () => ['copy_a', 'copy_b']);
+    const result = await searchKnowledge({ runQuery } as never, {
+      organizationId: 'org_1',
+      orgSlug: 'acme',
+      query: 'refunds',
+      access: ACCESS,
+    });
+    expect(result.hits.map((h) => h.source.ref)).toEqual(['copy_a']);
+  });
+
+  it('keeps a distinct passage from the same document', async () => {
+    // Deduping is per passage, not per document — a second chunk of the same
+    // file is a different answer.
+    retrieveMock.mockResolvedValueOnce({
+      hits: [
+        { ...hit('documents', 'doc'), text: 'First passage.' },
+        { ...hit('documents', 'doc'), text: 'Second passage.' },
+      ],
+      diagnostics: {},
+    });
+    const runQuery = vi.fn(async () => ['doc']);
+    const result = await searchKnowledge({ runQuery } as never, {
+      organizationId: 'org_1',
+      orgSlug: 'acme',
+      query: 'passages',
+      access: ACCESS,
+    });
+    expect(result.hits).toHaveLength(2);
+  });
+
+  it('treats copies that differ only in whitespace as one', async () => {
+    retrieveMock.mockResolvedValueOnce({
+      hits: [
+        { ...hit('documents', 'copy_a'), text: 'Refunds within 30 days.' },
+        {
+          ...hit('documents', 'copy_b'),
+          text: 'Refunds   within\n30 days.',
+        },
+      ],
+      diagnostics: {},
+    });
+    const runQuery = vi.fn(async () => ['copy_a', 'copy_b']);
+    const result = await searchKnowledge({ runQuery } as never, {
+      organizationId: 'org_1',
+      orgSlug: 'acme',
+      query: 'refunds',
+      access: ACCESS,
+    });
+    expect(result.hits).toHaveLength(1);
+  });
+
+  it('keeps the readable copy when the better-scoring one is denied', async () => {
+    // THE ordering case. Deduping before the retrievability filter would keep
+    // `copy_a`, the gate would then drop it, and the passage would vanish
+    // entirely — worse than showing it twice.
+    retrieveMock.mockResolvedValueOnce({
+      hits: [...duplicatePair('Refunds within 30 days.')],
+      diagnostics: {},
+    });
+    const runQuery = vi.fn(async () => ['copy_b']);
+    const result = await searchKnowledge({ runQuery } as never, {
+      organizationId: 'org_1',
+      orgSlug: 'acme',
+      query: 'refunds',
+      access: ACCESS,
+    });
+    expect(result.hits.map((h) => h.source.ref)).toEqual(['copy_b']);
+  });
+
+  it('does not collapse identical text across different corpora', async () => {
+    // A web page and a document saying the same thing are two findings, and
+    // only one of them is citable by URL.
+    retrieveMock.mockResolvedValueOnce({
+      hits: [
+        { ...hit('documents', 'doc'), text: 'Same words.' },
+        { ...hit('web', 'https://example.com'), text: 'Same words.' },
+      ],
+      diagnostics: {},
+    });
+    const runQuery = vi.fn(async () => ['doc']);
+    const result = await searchKnowledge({ runQuery } as never, {
+      organizationId: 'org_1',
+      orgSlug: 'acme',
+      query: 'same',
+      access: ACCESS,
+    });
+    expect(result.hits).toHaveLength(2);
+  });
+});

--- a/services/platform/convex/knowledge/search.ts
+++ b/services/platform/convex/knowledge/search.ts
@@ -51,6 +51,7 @@ import type {
 import {
   PRIVATE_KNOWLEDGE_SCHEMA,
   corporaFor,
+  type KnowledgeHit,
   type KnowledgeQuery,
   type KnowledgeResult,
 } from '../../lib/knowledge/types';
@@ -147,10 +148,44 @@ export async function searchKnowledge(
   const allowed = new Set(retrievable);
   return {
     ...result,
-    hits: result.hits.filter(
-      (hit) => hit.corpus !== 'documents' || allowed.has(hit.source.ref),
+    hits: dropRepeatedPassages(
+      result.hits.filter(
+        (hit) => hit.corpus !== 'documents' || allowed.has(hit.source.ref),
+      ),
     ),
   };
+}
+
+/**
+ * Drop a passage the caller has already been given, keeping the best-scoring
+ * one.
+ *
+ * The same text can sit in the corpus twice — the same file uploaded as two
+ * documents, or a paragraph two documents share. Both copies match, and a
+ * bounded result set then spends two of its slots saying one thing while a
+ * different answer falls off the end.
+ *
+ * Runs AFTER the retrievability filter, deliberately. Deduping first could
+ * keep a copy the caller cannot read and drop the readable one, and the gate
+ * would then remove what was kept — losing the passage entirely rather than
+ * showing it once. Fusion has already sorted by score, so the first occurrence
+ * is the best one.
+ */
+function dropRepeatedPassages<Hit extends KnowledgeHit>(
+  hits: readonly Hit[],
+): Hit[] {
+  const seen = new Set<string>();
+  const kept: Hit[] = [];
+  for (const hit of hits) {
+    // Keyed on the text a caller actually reads. Whitespace is normalized so
+    // two copies that differ only in how their source wrapped lines still
+    // count as one.
+    const key = `${hit.corpus}\u0000${hit.text.replace(/\s+/g, ' ').trim()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    kept.push(hit);
+  }
+  return kept;
 }
 
 /**


### PR DESCRIPTION
A search no longer spends two of its result slots on the same passage.

Closes #3061.

## Why

The same text can sit in the corpus twice — a file uploaded as two documents, or a paragraph two documents share. Both copies match, and a bounded result set then says one thing twice while a different answer falls off the end. A caller asking for eight passages can receive seven distinct ones.

Observed as duplication on a deployment: two pairs of corpus rows with matching content hashes, chunk counts and character counts under different refs. The retrieval symptom is reasoned from the code rather than seen there, because both copies of each pair were orphaned and already hidden.

## What changed

`searchKnowledge` drops a passage the caller has already been given, keeping the best-scoring one. Fusion has already sorted by score, so the first occurrence is the best.

**Keyed on the passage, not the document.** The issue proposed deduping by `content_hash`, which the corpus query does not select — plumbing it through the SQL, the row type and fusion would be a lot of moving parts for the same outcome. A result slot holds a passage, so that is what is compared. It catches the whole-document case too, since identical documents produce identical chunks, and it also catches a shared paragraph between otherwise different files.

Whitespace is normalized, so two copies that differ only in how their source wrapped lines still count as one.

Corpus is part of the key: a web page and a document saying the same thing are two findings, and only one is citable by URL.

## Risk

**It runs after the retrievability filter, deliberately.** Deduping first could keep a copy the caller cannot read and drop the readable one — the gate would then remove what was kept, and the passage would vanish entirely. That is worse than showing it twice, and it is the case a reader of this code is most likely to get wrong. A test pins it.

**A second chunk of the same document survives**, because it is a different answer. Deduping per document would have lost it.

## Tests

Five cases: a duplicate pair collapsed to the higher-scoring ref, two distinct passages from one document both kept, copies differing only in whitespace collapsed, the readable copy kept when the better-scoring one is denied, and identical text across different corpora kept separate.

Four deliberate breakages, all caught — including moving the dedupe ahead of the gate, which is the ordering the test exists for.

## Scope

Does not stop duplicates entering the corpus. Identical content still becomes two rows, still costs storage, and the corpus writer still clones chunks for it rather than re-embedding. This only stops the duplication reaching a reader.

Gate: repo-wide typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, platform suite 75,817 passing.
