### PR TITLE
feat(platform): let chat find entities by words in a question

### DIFF
--- a/services/platform/convex/chat/assistant_tools.ts
+++ b/services/platform/convex/chat/assistant_tools.ts
@@ -911,6 +911,9 @@ export function createChatToolExecutor(
           {
             organizationId: who.organizationId,
             topic: query,
+            // A question, not a topic — match its words too, or the whole
+            // phrase is compared as one string and nothing matches.
+            matchWords: true,
             paginationOpts: {
               numItems: Math.min(limit, RAG_SEARCH_ENTITY_LIMIT),
               cursor: null,
@@ -935,6 +938,8 @@ export function createChatToolExecutor(
           {
             organizationId: who.organizationId,
             searchTerm: query,
+            // A question, not a search term — match its words too.
+            matchWords: true,
             paginationOpts: {
               numItems: Math.min(limit, RAG_SEARCH_ENTITY_LIMIT),
               cursor: null,
@@ -959,6 +964,8 @@ export function createChatToolExecutor(
           {
             organizationId: who.organizationId,
             searchTerm: query,
+            // A question, not a search term — match its words too.
+            matchWords: true,
             paginationOpts: {
               numItems: Math.min(limit, RAG_SEARCH_ENTITY_LIMIT),
               cursor: null,

--- a/services/platform/convex/contacts/internal_queries.ts
+++ b/services/platform/convex/contacts/internal_queries.ts
@@ -54,6 +54,9 @@ export const queryContacts = internalQuery({
     ),
     locale: v.optional(v.array(v.string())),
     searchTerm: v.optional(v.string()),
+    /** Match individual words of `searchTerm` as well as the whole phrase.
+     *  The chat leg passes a question, so the phrase alone matches nothing. */
+    matchWords: v.optional(v.boolean()),
     paginationOpts: cursorPaginationOptsValidator,
   },
   returns: v.object({

--- a/services/platform/convex/contacts/query_contacts.ts
+++ b/services/platform/convex/contacts/query_contacts.ts
@@ -12,6 +12,8 @@ import {
   paginateWithFilter,
   type CursorPaginatedResult,
 } from '../lib/pagination';
+import { contactsSearchStrategy } from '../lib/search/strategies/contacts';
+import { matchesAnyWord } from '../lib/search/word_match';
 import type { ContactSource } from './types';
 
 export interface QueryContactsArgs {
@@ -20,6 +22,12 @@ export interface QueryContactsArgs {
   source?: ContactSource | ContactSource[];
   locale?: string[];
   searchTerm?: string;
+  /**
+   * Also match individual WORDS of `searchTerm`, not only the whole phrase.
+   * Off by default, so the contacts page searches exactly as it does today.
+   * The chat leg opts in, because it passes a question rather than a term.
+   */
+  matchWords?: boolean;
   paginationOpts: {
     numItems: number;
     cursor: string | null;
@@ -58,6 +66,8 @@ export async function queryContacts(
   const needsExternalIdFilter =
     !('externalId' in indexedFields) && args.externalId !== undefined;
   const searchLower = args.searchTerm?.toLowerCase();
+  const wordTerm =
+    args.matchWords === true ? args.searchTerm?.trim() : undefined;
 
   const needsFilter =
     sourceSet || localeSet || needsExternalIdFilter || searchLower;
@@ -81,6 +91,14 @@ export async function queryContacts(
         }
 
         if (searchLower) {
+          // Words first — the cheaper test, and the one a question hits. The
+          // phrase checks below still run and still decide on their own.
+          if (
+            wordTerm !== undefined &&
+            matchesAnyWord(contact, contactsSearchStrategy, wordTerm)
+          ) {
+            return true;
+          }
           const nameMatch = contact.name?.toLowerCase().includes(searchLower);
           const emailMatch = contact.email?.toLowerCase().includes(searchLower);
           const externalIdMatch = contact.externalId

--- a/services/platform/convex/knowledge_entries/internal_queries.ts
+++ b/services/platform/convex/knowledge_entries/internal_queries.ts
@@ -6,6 +6,8 @@ import {
   cursorPaginationOptsValidator,
   paginateWithFilter,
 } from '../lib/pagination';
+import { knowledgeEntriesSearchStrategy } from '../lib/search/strategies/knowledge_entries';
+import { matchesAnyWord } from '../lib/search/word_match';
 
 export const getEntryById = internalQuery({
   args: {
@@ -28,6 +30,12 @@ export const listEntriesForAgent = internalQuery({
     organizationId: v.string(),
     /** Case-insensitive contains-filter on the topic. */
     topic: v.optional(v.string()),
+    /**
+     * Also match individual WORDS of `topic`, not only the whole phrase. The
+     * chat leg passes a question rather than a topic, so the phrase alone
+     * matches nothing.
+     */
+    matchWords: v.optional(v.boolean()),
     paginationOpts: cursorPaginationOptsValidator,
   },
   returns: v.object({
@@ -44,6 +52,7 @@ export const listEntriesForAgent = internalQuery({
   }),
   handler: async (ctx, args) => {
     const topicLower = args.topic?.trim().toLowerCase() || undefined;
+    const wordTerm = args.matchWords === true ? args.topic?.trim() : undefined;
     const result = await paginateWithFilter(
       ctx.db
         .query('knowledgeEntries')
@@ -57,6 +66,13 @@ export const listEntriesForAgent = internalQuery({
         filter: (entry) =>
           entry.deletedAt === undefined &&
           (topicLower === undefined ||
+            // Words first — the phrase checks below still decide on their own.
+            (wordTerm !== undefined &&
+              matchesAnyWord(
+                entry,
+                knowledgeEntriesSearchStrategy,
+                wordTerm,
+              )) ||
             entry.topic.toLowerCase().includes(topicLower) ||
             entry.topicKey.includes(topicLower)),
       },

--- a/services/platform/convex/lib/search/strategies/knowledge_entries.ts
+++ b/services/platform/convex/lib/search/strategies/knowledge_entries.ts
@@ -1,0 +1,18 @@
+import type { SearchStrategy } from '../types';
+
+/**
+ * Knowledge entries, for WORD matching only.
+ *
+ * `topic` is the prose; `topicKey` is its slug, matched as an id so an exact
+ * key still wins. `content` is deliberately absent — the agent listing filters
+ * on the topic alone, and matching whole bodies here would turn a topic filter
+ * into a full-text search over every entry.
+ */
+export const knowledgeEntriesSearchStrategy: SearchStrategy<'knowledgeEntries'> =
+  {
+    table: 'knowledgeEntries',
+    orgIndex: 'by_organizationId_and_status',
+    textFields: ['topic'],
+    idFields: ['topicKey'],
+    engine: 'scan',
+  };

--- a/services/platform/convex/lib/search/strategies/products.ts
+++ b/services/platform/convex/lib/search/strategies/products.ts
@@ -1,0 +1,19 @@
+import type { SearchStrategy } from '../types';
+
+/**
+ * Products, for WORD matching only.
+ *
+ * The fields here are the ones this format can express. `query_products.ts`
+ * also matches a whole phrase against each translation's name and description,
+ * and that check stays — the two run together, so a translated name is still
+ * findable. Do not "tidy" one list to match the other: they differ on purpose,
+ * and collapsing them would silently drop translation search.
+ */
+export const productsSearchStrategy: SearchStrategy<'products'> = {
+  table: 'products',
+  orgIndex: 'by_organizationId',
+  textFields: ['name', 'description', 'category'],
+  arrayTextFields: ['tags'],
+  idFields: ['externalId'],
+  engine: 'scan',
+};

--- a/services/platform/convex/lib/search/word_match.test.ts
+++ b/services/platform/convex/lib/search/word_match.test.ts
@@ -1,0 +1,139 @@
+// Word matching runs ALONGSIDE an entity's existing phrase match, never
+// instead of it. These cases pin both halves of that: the words a question
+// should find, and the fields the phrase check is still solely responsible for.
+
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../../_generated/api';
+import schema from '../../schema';
+
+const rawModules = import.meta.glob('../../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  const stack: string[] = [];
+  for (const part of `lib/search/${key}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  modules[stack.join('/')] = loader;
+}
+
+const ORG = 'org_word_match';
+
+async function seedProduct(
+  t: ReturnType<typeof convexTest>,
+  fields: Record<string, unknown>,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('products', {
+      organizationId: ORG,
+      name: 'Placeholder',
+      status: 'active',
+      ...fields,
+    } as never);
+  });
+}
+
+async function searchProducts(
+  t: ReturnType<typeof convexTest>,
+  searchTerm: string,
+  matchWords?: boolean,
+) {
+  const result = await t.query(
+    internal.products.internal_queries.queryProducts,
+    {
+      organizationId: ORG,
+      searchTerm,
+      ...(matchWords !== undefined ? { matchWords } : {}),
+      paginationOpts: { numItems: 20, cursor: null },
+    },
+  );
+  return result.page.map((p: { name: string }) => p.name);
+}
+
+describe('products search — words alongside the phrase', () => {
+  it('finds a product from a multi-word question', async () => {
+    // The whole question as one substring matches nothing, which is the bug.
+    const t = convexTest(schema, modules);
+    await seedProduct(t, { name: 'Red Running Shoes' });
+    expect(
+      await searchProducts(t, 'do we have red running shoes', true),
+    ).toEqual(['Red Running Shoes']);
+  });
+
+  it('finds nothing for the same question without opting in', async () => {
+    // The products page keeps today's behaviour, so this must stay a miss.
+    const t = convexTest(schema, modules);
+    await seedProduct(t, { name: 'Red Running Shoes' });
+    expect(await searchProducts(t, 'do we have red running shoes')).toEqual([]);
+  });
+
+  it('still finds a product by its TRANSLATED name', async () => {
+    // The reason both checks run. This field is not in the word-match config,
+    // so only the phrase check can reach it — swapping instead of adding would
+    // have silently lost this.
+    const t = convexTest(schema, modules);
+    await seedProduct(t, {
+      name: 'Running Shoes',
+      translations: [{ language: 'de', name: 'Laufschuhe', lastUpdated: 0 }],
+    });
+    expect(await searchProducts(t, 'Laufschuhe', true)).toEqual([
+      'Running Shoes',
+    ]);
+  });
+
+  it('still finds a product by its translated DESCRIPTION', async () => {
+    const t = convexTest(schema, modules);
+    await seedProduct(t, {
+      name: 'Running Shoes',
+      translations: [
+        { language: 'de', description: 'Bequeme Sportschuhe', lastUpdated: 0 },
+      ],
+    });
+    expect(await searchProducts(t, 'Bequeme Sportschuhe', true)).toEqual([
+      'Running Shoes',
+    ]);
+  });
+
+  it('does not match on a stopword alone', async () => {
+    // `any` mode drops stopwords, or every question would match everything.
+    const t = convexTest(schema, modules);
+    await seedProduct(t, { name: 'Running Shoes' });
+    expect(await searchProducts(t, 'do we have the', true)).toEqual([]);
+  });
+
+  it('does not match a mid-word fragment', async () => {
+    // `any` requires a word START. Without that floor, "ad" would pull in
+    // every product containing "overhead".
+    const t = convexTest(schema, modules);
+    await seedProduct(t, { name: 'Overhead Projector' });
+    expect(await searchProducts(t, 'ad projector', true)).toContain(
+      'Overhead Projector',
+    );
+    expect(await searchProducts(t, 'ad lamp', true)).toEqual([]);
+  });
+
+  it('applies to the externalId-array path too', async () => {
+    // `queryProducts` filters in memory when `externalId` is an array, a
+    // separate branch from the paginated walk. Both thread the word term, and
+    // only this case exercises the first.
+    const t = convexTest(schema, modules);
+    await seedProduct(t, { name: 'Red Running Shoes', externalId: 'SKU-1' });
+    await seedProduct(t, { name: 'Blue Hat', externalId: 'SKU-2' });
+    const result = await t.query(
+      internal.products.internal_queries.queryProducts,
+      {
+        organizationId: ORG,
+        externalId: ['SKU-1', 'SKU-2'],
+        searchTerm: 'do we have red running shoes',
+        matchWords: true,
+        paginationOpts: { numItems: 20, cursor: null },
+      },
+    );
+    expect(result.page.map((p: { name: string }) => p.name)).toEqual([
+      'Red Running Shoes',
+    ]);
+  });
+});

--- a/services/platform/convex/lib/search/word_match.ts
+++ b/services/platform/convex/lib/search/word_match.ts
@@ -1,0 +1,34 @@
+/**
+ * Word matching, added ALONGSIDE an entity's existing phrase match.
+ *
+ * The chat legs pass a natural-language question, and the entity queries
+ * compare that whole string as one substring — so "do we have red running
+ * shoes" only matches text that literally contains the whole phrase, and finds
+ * nothing. Splitting it into words fixes that.
+ *
+ * Used as an OR, never as a replacement. The phrase check reaches fields this
+ * format cannot express — a product's translated name and description among
+ * them — so swapping to words alone would quietly shrink what is searchable.
+ * Running both keeps everything that worked and adds the multi-word case.
+ *
+ * `'any'` mode is what makes a question usable: it drops stopwords and
+ * one-character tokens, and requires a word-START match rather than any
+ * substring, so an OR over tokens does not pull in every row containing a
+ * common fragment.
+ */
+
+import type { TableNames } from '../../_generated/dataModel';
+import type { Doc } from '../../_generated/dataModel';
+import { rowMatches } from './relevance';
+import type { SearchStrategy } from './types';
+
+/** True when any meaningful word of `term` matches `row` under the strategy. */
+export function matchesAnyWord<T extends TableNames>(
+  row: Doc<T>,
+  strategy: SearchStrategy<T>,
+  term: string,
+): boolean {
+  const raw = term.trim();
+  if (raw === '') return false;
+  return rowMatches(row, strategy, raw.toLowerCase(), raw, 'any');
+}

--- a/services/platform/convex/products/internal_queries.ts
+++ b/services/platform/convex/products/internal_queries.ts
@@ -41,6 +41,9 @@ export const queryProducts = internalQuery({
     category: v.optional(v.string()),
     minStock: v.optional(v.number()),
     searchTerm: v.optional(v.string()),
+    /** Match individual words of `searchTerm` as well as the whole phrase.
+     *  The chat leg passes a question, so the phrase alone matches nothing. */
+    matchWords: v.optional(v.boolean()),
     paginationOpts: cursorPaginationOptsValidator,
   },
   returns: v.object({

--- a/services/platform/convex/products/query_products.ts
+++ b/services/platform/convex/products/query_products.ts
@@ -14,6 +14,8 @@ import {
   paginateWithFilter,
   type CursorPaginatedResult,
 } from '../lib/pagination';
+import { productsSearchStrategy } from '../lib/search/strategies/products';
+import { matchesAnyWord } from '../lib/search/word_match';
 import type { ProductStatus } from './types';
 
 export interface QueryProductsArgs {
@@ -26,6 +28,12 @@ export interface QueryProductsArgs {
    * externalId and translated name/description — the products counterpart of
    * `queryContacts`' searchTerm. */
   searchTerm?: string;
+  /**
+   * Also match individual WORDS of `searchTerm`, not only the whole phrase.
+   * Off by default, so the products page searches exactly as it does today.
+   * The chat leg opts in, because it passes a question rather than a term.
+   */
+  matchWords?: boolean;
   paginationOpts: {
     numItems: number;
     cursor: string | null;
@@ -35,7 +43,16 @@ export interface QueryProductsArgs {
 function matchesSearchTerm(
   product: Doc<'products'>,
   searchLower: string,
+  wordTerm?: string,
 ): boolean {
+  // Words first — the cheaper test, and the one a question usually hits. The
+  // phrase checks below still run, and they are what reach translations.
+  if (
+    wordTerm !== undefined &&
+    matchesAnyWord(product, productsSearchStrategy, wordTerm)
+  ) {
+    return true;
+  }
   if (product.name.toLowerCase().includes(searchLower)) return true;
   if (product.description?.toLowerCase().includes(searchLower)) return true;
   if (product.category?.toLowerCase().includes(searchLower)) return true;
@@ -148,8 +165,12 @@ export async function queryProducts(
       );
     }
     const arraySearchLower = args.searchTerm?.trim().toLowerCase();
+    const wordTerm =
+      args.matchWords === true ? args.searchTerm?.trim() : undefined;
     if (arraySearchLower) {
-      products = products.filter((p) => matchesSearchTerm(p, arraySearchLower));
+      products = products.filter((p) =>
+        matchesSearchTerm(p, arraySearchLower, wordTerm),
+      );
     }
 
     // Sort by creation time (newest first)
@@ -180,6 +201,8 @@ export async function queryProducts(
     !('category' in indexedFields) && args.category !== undefined;
   const needsMinStockFilter = args.minStock !== undefined;
   const searchLower = args.searchTerm?.trim().toLowerCase() || undefined;
+  const wordTerm =
+    args.matchWords === true ? args.searchTerm?.trim() : undefined;
   const needsFilter =
     needsStatusFilter ||
     needsCategoryFilter ||
@@ -200,7 +223,7 @@ export async function queryProducts(
             return false;
           }
         }
-        if (searchLower && !matchesSearchTerm(product, searchLower)) {
+        if (searchLower && !matchesSearchTerm(product, searchLower, wordTerm)) {
           return false;
         }
         return true;


### PR DESCRIPTION
Chat can now find a contact, product or knowledge entry from a multi-word question. Before this it compared the whole question as one string, so it found nothing.

Last code item on #2992.

## Why

The entity legs pass a natural-language question straight through as a search term, and the queries match it as a single substring. "do we have red running shoes" only matches text literally containing that phrase, so it never matches. The tasks and projects legs already split the term into words; these three did not.

## What changed

Word matching is added ALONGSIDE each entity's existing phrase match, never in place of it. A row matches if any meaningful word hits, **or** if the whole phrase hits as it does today.

That combination is the point. The phrase check reaches fields the word-match config cannot express — a product's translated name and description among them — so swapping to words alone would have quietly shrunk what is searchable. A customer running their catalogue in German would have found chat unable to locate a product by the name they actually use, while the products page still could.

Opt-in per call. The contacts and products pages search exactly as they do today; only the chat legs pass `matchWords`, because only they pass a question.

`'any'` mode is what makes a question usable: it drops stopwords and single characters, and requires a word-START match rather than any substring — without that floor, "ad" would pull in every row containing "overhead".

## Risk

**The two field lists differ on purpose.** The word config covers a product's name, description, category, tags and code; the phrase check also covers translations. Anyone "tidying" one to match the other would silently delete translation search. Both strategy files say so.

**Knowledge entries deliberately exclude `content`.** The agent listing filters on topic alone, and matching whole bodies would turn a topic filter into a full-text search over every entry.

**Two code paths in products.** `queryProducts` filters in memory when `externalId` is an array, separately from the paginated walk. Both thread the word term, and both are tested — the first mutation I ran passed because it hit the untested branch, which is how I found out.

## Tests

Seven cases: a multi-word question finding a product, the same question finding nothing without opting in, a translated name and a translated description both still found, a stopword-only question matching nothing, a mid-word fragment not matching while a real word does, and the `externalId`-array path.

Four deliberate breakages, all caught: word matching off, the opt-in ignored on each of the two paths, and `all` instead of `any`.

## Scope

Adds matching; removes none. Ranking is unchanged — this decides whether a row matches, not how matches are ordered.

Gate: repo-wide typecheck, `oxlint --type-aware`, oxfmt, knip, SAST 0 findings, platform suite 75,819 passing.
