### PR TITLE
feat(platform): report backend errors to Sentry via SENTRY_DSN

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -213,6 +213,7 @@
         "@radix-ui/react-tooltip": "1.2.8",
         "@radix-ui/react-visually-hidden": "1.2.4",
         "@scure/base": "2.0.0",
+        "@sentry/node": "10.48.0",
         "@sentry/tanstackstart-react": "10.48.0",
         "@tailwindcss/postcss": "4.2.2",
         "@tale/shared": "workspace:*",

--- a/docs/de/self-hosted/configuration/environment-reference.md
+++ b/docs/de/self-hosted/configuration/environment-reference.md
@@ -64,7 +64,7 @@ Die auto-konstruierte operative Form ist `postgresql://tale:${DB_PASSWORD}@db:54
 | Name                        | Default | Beschreibung                                                                                                                                 |
 | --------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SENTRY_DSN`                | unset   | Sentry-DSN für Error-Tracking. Unset zum Deaktivieren. Kompatibel mit selbst gehostetem GlitchTip und Bugsink.                               |
-| `SENTRY_TRACES_SAMPLE_RATE` | unset   | Optionale Sample-Rate für Performance-Traces (`0.0`–`1.0`). Standard-Verhalten hängt vom Deployment ab.                                      |
+| `SENTRY_TRACES_SAMPLE_RATE` | unset   | Optionale Sample-Rate für Performance-Traces im Browser (`0.0`–`1.0`). Nur Browser — das Backend meldet Fehler, nie Traces.                  |
 | `METRICS_BEARER_TOKEN`      | unset   | Bearer-Token, das für den Zugriff auf die Prometheus-`/metrics/*`-Endpoints nötig ist. Unset hält Metrics-Endpoints von aussen unerreichbar. |
 
 `METRICS_BEARER_TOKEN` zu setzen exponiert zwei Endpoints hinter dem Token: `/metrics/platform` und `/metrics/convex` (Convex' 261 eingebaute Metriken, die jetzt auch die RAG- und Crawl-Timings tragen). Siehe [Observability-Konfig](/de/self-hosted/configuration/observability-config) für die Scrape-Konfiguration.

--- a/docs/de/self-hosted/configuration/observability-config.md
+++ b/docs/de/self-hosted/configuration/observability-config.md
@@ -49,7 +49,7 @@ Dupliziere die Stanza pro Pfad, oder nutze einen einzelnen Job mit `relabel_conf
 
 ## Error-Tracking mit Sentry
 
-Sentry ist opt-in über `SENTRY_DSN`. Selbst gehostete GlitchTip und Bugsink funktionieren auch, da sie dasselbe DSN-Format sprechen. Die Plattform- und die Convex-Container lesen beide den DSN und taggen Events mit dem Container-Namen.
+Sentry ist opt-in über `SENTRY_DSN`. Selbst gehostete GlitchTip und Bugsink funktionieren auch, da sie dasselbe DSN-Format sprechen. Ein DSN deckt beide Seiten des Stacks ab: die Browser-App meldet Frontend-Fehler, und die Container `backend-api` / `backend-worker` melden die Server-Seite — abgestürzte Anfragen, fehlgeschlagene Hintergrund-Jobs und Boot-Fehler — getaggt mit der Prozessrolle (`tale.role`) und der Release-Version.
 
 ```bash
 # .env
@@ -57,7 +57,7 @@ SENTRY_DSN=https://your-key@your-sentry-host/project-id
 SENTRY_TRACES_SAMPLE_RATE=0.1
 ```
 
-Die Sample-Rate begrenzt Performance-Traces; lass sie unset für den Default 1.0 in Development und ziehe sie an (0.05–0.2) in Produktion. Stack-Frames werden unredigiert geschickt, also richte den DSN auf Infrastruktur, die du kontrollierst, wenn deine Error-Payloads sensibel sind.
+Die Sample-Rate begrenzt Performance-Traces im Browser und gilt nur dort — das Backend meldet Fehler, nie Traces. Lass sie unset für den Default 1.0 in Development und ziehe sie an (0.05–0.2) in Produktion. Stack-Frames werden auf beiden Seiten unredigiert geschickt, also richte den DSN auf Infrastruktur, die du kontrollierst, wenn deine Error-Payloads sensibel sind.
 
 ## Was noch nicht mitkommt
 

--- a/docs/en/self-hosted/configuration/environment-reference.md
+++ b/docs/en/self-hosted/configuration/environment-reference.md
@@ -64,7 +64,7 @@ The auto-constructed operational form is `postgresql://tale:${DB_PASSWORD}@db:54
 | Name                        | Default | Description                                                                                                                            |
 | --------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `SENTRY_DSN`                | unset   | Sentry DSN for error tracking. Leave unset to disable. Compatible with self-hosted GlitchTip and Bugsink.                              |
-| `SENTRY_TRACES_SAMPLE_RATE` | unset   | Optional sample rate for performance traces (`0.0`–`1.0`). Default behaviour depends on the deployment.                                |
+| `SENTRY_TRACES_SAMPLE_RATE` | unset   | Optional sample rate for browser performance traces (`0.0`–`1.0`). Browser-only — the backend reports errors, never traces.            |
 | `METRICS_BEARER_TOKEN`      | unset   | Bearer token required to access the Prometheus `/metrics/*` endpoints. Leave unset to keep metrics endpoints unreachable from outside. |
 
 Setting `METRICS_BEARER_TOKEN` exposes two endpoints behind the token: `/metrics/platform` and `/metrics/convex` (Convex's 261 built-in metrics, which now carry the RAG and crawl timings as well). See [Observability config](/self-hosted/configuration/observability-config) for the scrape config.

--- a/docs/en/self-hosted/configuration/observability-config.md
+++ b/docs/en/self-hosted/configuration/observability-config.md
@@ -49,7 +49,7 @@ Duplicate the stanza per path, or use a single job with `relabel_configs` if you
 
 ## Error tracking with Sentry
 
-Sentry is opt-in via `SENTRY_DSN`. Self-hosted GlitchTip and Bugsink work too, since they speak the same DSN format. The platform and the convex containers both read the DSN and tag events with the container name.
+Sentry is opt-in via `SENTRY_DSN`. Self-hosted GlitchTip and Bugsink work too, since they speak the same DSN format. One DSN covers both sides of the stack: the browser app reports front-end errors, and the `backend-api` / `backend-worker` containers report server-side ones — crashed requests, failed background jobs, and boot failures — tagged with the process role (`tale.role`) and the release version.
 
 ```bash
 # .env
@@ -57,7 +57,7 @@ SENTRY_DSN=https://your-key@your-sentry-host/project-id
 SENTRY_TRACES_SAMPLE_RATE=0.1
 ```
 
-The sample rate caps performance traces; leave it unset for the default 1.0 in development and tighten it (0.05–0.2) in production. Stack frames are sent unredacted, so point the DSN at infrastructure you control if your error payloads are sensitive.
+The sample rate caps browser performance traces and applies only there — the backend reports errors, never traces. Leave it unset for the default 1.0 in development and tighten it (0.05–0.2) in production. Stack frames are sent unredacted on both sides, so point the DSN at infrastructure you control if your error payloads are sensitive.
 
 ## What does not ship yet
 

--- a/docs/fr/self-hosted/configuration/environment-reference.md
+++ b/docs/fr/self-hosted/configuration/environment-reference.md
@@ -64,7 +64,7 @@ La forme opérationnelle auto-construite est `postgresql://tale:${DB_PASSWORD}@d
 | Nom                         | Défaut     | Description                                                                                                                                  |
 | --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SENTRY_DSN`                | non défini | DSN Sentry pour le suivi d'erreurs. Laisse vide pour désactiver. Compatible avec GlitchTip et Bugsink auto-hébergés.                         |
-| `SENTRY_TRACES_SAMPLE_RATE` | non défini | Taux d'échantillonnage optionnel pour les traces de performance (`0.0`–`1.0`). Le comportement par défaut dépend du déploiement.             |
+| `SENTRY_TRACES_SAMPLE_RATE` | non défini | Taux d'échantillonnage optionnel pour les traces de performance du navigateur (`0.0`–`1.0`). Navigateur uniquement — le backend remonte des erreurs, jamais de traces. |
 | `METRICS_BEARER_TOKEN`      | non défini | Token bearer requis pour accéder aux endpoints Prometheus `/metrics/*`. Laisse vide pour rendre les endpoints inatteignables de l'extérieur. |
 
 Définir `METRICS_BEARER_TOKEN` expose deux endpoints derrière le token : `/metrics/platform` et `/metrics/convex` (les 261 métriques intégrées de Convex, qui portent désormais aussi les timings RAG et de crawl). Voir [Configuration d'observabilité](/fr/self-hosted/configuration/observability-config) pour la configuration de scrape.

--- a/docs/fr/self-hosted/configuration/observability-config.md
+++ b/docs/fr/self-hosted/configuration/observability-config.md
@@ -49,7 +49,7 @@ Duplique la stanza par chemin, ou utilise un job unique avec `relabel_configs` s
 
 ## Suivi d'erreurs avec Sentry
 
-Sentry est opt-in via `SENTRY_DSN`. GlitchTip et Bugsink auto-hébergés marchent aussi, puisqu'ils parlent le même format de DSN. Les conteneurs plateforme et convex lisent tous les deux le DSN et taguent les événements avec le nom du conteneur.
+Sentry est opt-in via `SENTRY_DSN`. GlitchTip et Bugsink auto-hébergés marchent aussi, puisqu'ils parlent le même format de DSN. Un seul DSN couvre les deux côtés de la stack : l'app navigateur remonte les erreurs front-end, et les conteneurs `backend-api` / `backend-worker` remontent le côté serveur — requêtes plantées, jobs d'arrière-plan échoués et échecs au boot — tagués avec le rôle du processus (`tale.role`) et la version de release.
 
 ```bash
 # .env
@@ -57,7 +57,7 @@ SENTRY_DSN=https://your-key@your-sentry-host/project-id
 SENTRY_TRACES_SAMPLE_RATE=0.1
 ```
 
-Le sample rate plafonne les traces de performance ; laisse-le non défini pour le défaut 1.0 en développement et resserre-le (0.05–0.2) en production. Les stack frames sont envoyés sans rédaction, donc pointe le DSN sur une infra que tu contrôles si tes payloads d'erreur sont sensibles.
+Le sample rate plafonne les traces de performance du navigateur et ne s'applique que là — le backend remonte des erreurs, jamais de traces. Laisse-le non défini pour le défaut 1.0 en développement et resserre-le (0.05–0.2) en production. Les stack frames sont envoyés sans rédaction des deux côtés, donc pointe le DSN sur une infra que tu contrôles si tes payloads d'erreur sont sensibles.
 
 ## Ce qui ne ship pas encore
 

--- a/services/platform/backend/README.md
+++ b/services/platform/backend/README.md
@@ -48,7 +48,9 @@ One codebase, one image, role via `ROLE`:
 - `all` — both in one process; local-dev convenience only.
 
 Environment: `DATABASE_URL` (required), `PORT` (default 3005), `ROLE`
-(default `all`), `WORKER_CONCURRENCY` (default 5). Production runtime is
+(default `all`), `WORKER_CONCURRENCY` (default 5), `SENTRY_DSN` (optional —
+Sentry-compatible error reporting, errors only, no traces; see
+`error-reporting.ts`). Production runtime is
 **Node** (>= 22.18) running the `.ts` sources directly with
 `--experimental-transform-types` and the `node-loader.mjs` resolve hook — the
 hook lets the backend import runtime-clean 0.4 modules (extensionless

--- a/services/platform/backend/app.ts
+++ b/services/platform/backend/app.ts
@@ -70,6 +70,7 @@ import {
   createWebdavProtocolRoutes,
 } from './domains/webdav/routes.ts';
 import { createWebsiteRoutes } from './domains/websites/routes.ts';
+import { appErrorHandler } from './error-reporting.ts';
 import {
   createScreencastAuthRoutes,
   createSseAuthRoutes,
@@ -96,6 +97,9 @@ export function createApp(deps: AppDeps): Hono<AuthEnv> {
   // app directly — an app with a `/metrics` route that renders an empty
   // registry is worse than no route at all.
   initBackendTelemetry(deps.sql);
+  // Hono's default 500 behavior plus Sentry capture (no-op without a DSN);
+  // sub-app errors bubble up here unless a sub-app registers its own.
+  app.onError(appErrorHandler);
   app.get('/ping', (c) => c.json({ ok: true, service: 'backend' }));
   // Prometheus scrape. Reachable publicly only through the proxy's
   // token-gated `/metrics/backend` lane; inside the network it is the plain

--- a/services/platform/backend/env.test.ts
+++ b/services/platform/backend/env.test.ts
@@ -22,6 +22,17 @@ describe('loadEnv', () => {
     expect(env.WORKER_CONCURRENCY).toBe(2);
   });
 
+  it('passes SENTRY_DSN through and leaves it optional', () => {
+    expect(
+      loadEnv({ DATABASE_URL: 'postgres://x' }).SENTRY_DSN,
+    ).toBeUndefined();
+    const env = loadEnv({
+      DATABASE_URL: 'postgres://x',
+      SENTRY_DSN: 'https://key@sentry.example/1',
+    });
+    expect(env.SENTRY_DSN).toBe('https://key@sentry.example/1');
+  });
+
   it('rejects a missing DATABASE_URL and an unknown role', () => {
     expect(() => loadEnv({})).toThrow();
     expect(() =>

--- a/services/platform/backend/env.ts
+++ b/services/platform/backend/env.ts
@@ -18,6 +18,11 @@ const envSchema = z.object({
   BETTER_AUTH_SECRET: z.string().min(16).optional(),
   /** Public origin auth cookies bind to; defaults to the direct dev port. */
   SITE_URL: z.string().url().default('http://localhost:3005'),
+  /**
+   * Sentry-compatible error reporting (Sentry, GlitchTip, Bugsink), opt-in —
+   * unset disables it entirely. See `error-reporting.ts`.
+   */
+  SENTRY_DSN: z.string().optional(),
 });
 
 export type BackendEnv = z.infer<typeof envSchema>;

--- a/services/platform/backend/error-reporting.test.ts
+++ b/services/platform/backend/error-reporting.test.ts
@@ -1,0 +1,205 @@
+import { createServer, type Server } from 'node:http';
+import { gunzipSync } from 'node:zlib';
+
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  appErrorHandler,
+  errorReportingEnabled,
+  flushErrorReporting,
+  initErrorReporting,
+  reportError,
+} from './error-reporting.ts';
+
+/**
+ * The module holds one process-wide SDK, so ordering is load-bearing: the
+ * disabled-path suite runs first, then one real `init` against a local fake
+ * ingest server serves every reporting assertion. The fake server speaks
+ * just enough of the envelope protocol to prove events leave the process
+ * over real HTTP — which is the actual contract ("respects SENTRY_DSN"),
+ * not an internals mock.
+ */
+
+interface CapturedEnvelope {
+  url: string;
+  events: Record<string, unknown>[];
+}
+
+const captured: CapturedEnvelope[] = [];
+let ingest: Server;
+let ingestPort: number;
+
+function parseEnvelope(url: string, raw: Buffer, gzipped: boolean): void {
+  const body = (gzipped ? gunzipSync(raw) : raw).toString('utf8');
+  // Envelope = newline-delimited JSON: header, then item-header/payload pairs.
+  const events: Record<string, unknown>[] = [];
+  for (const line of body.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        'exception' in parsed
+      ) {
+        events.push(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // Non-JSON payload lines (attachments) are not what these tests read.
+      console.warn('[test] skipping non-JSON envelope line');
+    }
+  }
+  captured.push({ url, events });
+}
+
+function capturedEvents(): Record<string, unknown>[] {
+  return captured.flatMap((envelope) => envelope.events);
+}
+
+describe('error reporting without a DSN', () => {
+  it('stays disabled and every hook is a safe no-op', async () => {
+    expect(initErrorReporting({ dsn: undefined, role: 'all' })).toBe(false);
+    expect(errorReportingEnabled()).toBe(false);
+    expect(() => reportError(new Error('never sent'))).not.toThrow();
+    await expect(flushErrorReporting(10)).resolves.toBeUndefined();
+  });
+});
+
+describe('error reporting with a DSN', () => {
+  beforeAll(async () => {
+    ingest = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        parseEnvelope(
+          req.url ?? '',
+          Buffer.concat(chunks),
+          req.headers['content-encoding'] === 'gzip',
+        );
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+      });
+    });
+    await new Promise<void>((resolve) => {
+      ingest.listen(0, '127.0.0.1', resolve);
+    });
+    const address = ingest.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('fake ingest server has no port');
+    }
+    ingestPort = address.port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      ingest.close(() => resolve());
+    });
+  });
+
+  it('initializes against the DSN and reports over real HTTP', async () => {
+    const dsn = `http://publickey@127.0.0.1:${ingestPort}/42`;
+    expect(initErrorReporting({ dsn, role: 'test-role' })).toBe(true);
+    expect(errorReportingEnabled()).toBe(true);
+
+    reportError(new Error('boom-direct'), {
+      tags: { 'tale.task': 'unit-test' },
+      extra: { jobId: 'job-1' },
+    });
+    await flushErrorReporting();
+
+    expect(captured.length).toBeGreaterThan(0);
+    // Project id 42 from the DSN determines the ingest path (the SDK
+    // appends sentry_key/sentry_version auth as query parameters).
+    expect(captured[0]?.url).toMatch(/^\/api\/42\/envelope\/\?/);
+    const event = capturedEvents().find((e) =>
+      JSON.stringify(e).includes('boom-direct'),
+    );
+    expect(event).toBeDefined();
+    const tags = event?.tags as Record<string, string>;
+    expect(tags['tale.role']).toBe('test-role');
+    expect(tags['tale.task']).toBe('unit-test');
+    const extra = (event?.extra ?? {}) as Record<string, unknown>;
+    expect(extra.jobId).toBe('job-1');
+  });
+
+  it('captures thrown route errors and keeps the stock 500 response', async () => {
+    // Hono's default handler console.errors the throwable; keep the test
+    // output clean while asserting the behavior is preserved.
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    try {
+      const app = new Hono();
+      app.onError(appErrorHandler);
+      app.get('/throws', () => {
+        throw new Error('boom-http');
+      });
+
+      const res = await app.request('http://localhost/throws');
+      expect(res.status).toBe(500);
+      expect(await res.text()).toBe('Internal Server Error');
+      expect(consoleError).toHaveBeenCalled();
+
+      await flushErrorReporting();
+      const event = capturedEvents().find((e) =>
+        JSON.stringify(e).includes('boom-http'),
+      );
+      expect(event).toBeDefined();
+      const tags = event?.tags as Record<string, string>;
+      expect(tags['http.method']).toBe('GET');
+      expect(tags['http.route_class']).toBe('other');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('captures errors thrown inside mounted sub-apps', async () => {
+    // createApp mounts every domain via `app.route(...)` — the production
+    // topology is sub-apps bubbling into the parent's onError.
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    try {
+      const sub = new Hono();
+      sub.get('/boom', () => {
+        throw new Error('boom-subapp');
+      });
+      const app = new Hono();
+      app.onError(appErrorHandler);
+      app.route('/api/app/widgets', sub);
+
+      const res = await app.request('http://localhost/api/app/widgets/boom');
+      expect(res.status).toBe(500);
+
+      await flushErrorReporting();
+      const event = capturedEvents().find((e) =>
+        JSON.stringify(e).includes('boom-subapp'),
+      );
+      expect(event).toBeDefined();
+      const tags = event?.tags as Record<string, string>;
+      expect(tags['http.route_class']).toBe('/api/app/widgets');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('passes HTTPException through untouched and unreported', async () => {
+    const app = new Hono();
+    app.onError(appErrorHandler);
+    app.get('/teapot', () => {
+      throw new HTTPException(418, { message: 'teapot-refusal' });
+    });
+
+    const res = await app.request('http://localhost/teapot');
+    expect(res.status).toBe(418);
+    expect(await res.text()).toBe('teapot-refusal');
+
+    await flushErrorReporting();
+    const leaked = capturedEvents().find((e) =>
+      JSON.stringify(e).includes('teapot-refusal'),
+    );
+    expect(leaked).toBeUndefined();
+  });
+});

--- a/services/platform/backend/error-reporting.ts
+++ b/services/platform/backend/error-reporting.ts
@@ -1,0 +1,114 @@
+import * as Sentry from '@sentry/node';
+import type { ErrorHandler } from 'hono';
+
+import { routeClass } from './telemetry.ts';
+
+/**
+ * Sentry-compatible error reporting for the 0.5 backend (api + worker roles).
+ *
+ * Opt-in via `SENTRY_DSN`, exactly like the browser SPA: unset means every
+ * function here is a no-op and the SDK never initializes. The DSN already
+ * reaches the backend containers (both compose lanes mount `env_file: .env`);
+ * this module is what makes the process honor it.
+ *
+ * Errors only, deliberately: no `tracesSampleRate` is ever set, so span
+ * recording stays disabled and none of the auto-performance instrumentation
+ * loads. `SENTRY_TRACES_SAMPLE_RATE` remains a browser-side knob.
+ *
+ * `registerEsmLoaderHooks: false` because the backend already runs under its
+ * own resolve hook (`node-loader.mjs`); stacking import-in-the-middle's
+ * loader onto that chain buys nothing without tracing and risks resolver
+ * interplay.
+ *
+ * The unhandled-rejection integration is pinned to `mode: 'strict'`: any
+ * `unhandledRejection` listener suppresses Node's default crash, and the
+ * SDK's default `warn` mode would silently convert today's crash-and-restart
+ * semantics into limp-along. Strict captures the event and then exits the
+ * way plain Node 22 does.
+ */
+
+let enabled = false;
+
+export interface ErrorReportingOptions {
+  dsn: string | undefined;
+  /** Process role (`api` | `worker` | `all`) — tagged on every event. */
+  role: string;
+}
+
+export function initErrorReporting(options: ErrorReportingOptions): boolean {
+  if (!options.dsn) return false;
+  try {
+    Sentry.init({
+      dsn: options.dsn,
+      release: process.env.TALE_VERSION,
+      registerEsmLoaderHooks: false,
+      integrations: (defaults) => [
+        ...defaults.filter((i) => i.name !== 'OnUnhandledRejection'),
+        Sentry.onUnhandledRejectionIntegration({ mode: 'strict' }),
+      ],
+      initialScope: { tags: { 'tale.role': options.role } },
+    });
+    enabled = true;
+  } catch (error) {
+    // A malformed DSN must never take the backend down with it.
+    console.warn(
+      '[backend] error reporting init failed (continuing without):',
+      error,
+    );
+  }
+  return enabled;
+}
+
+/** Test seam: whether the SDK initialized (and reset between cases). */
+export function errorReportingEnabled(): boolean {
+  return enabled;
+}
+
+export interface ErrorReportContext {
+  /** Low-cardinality only — tags become filterable index dimensions. */
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}
+
+export function reportError(
+  error: unknown,
+  context?: ErrorReportContext,
+): void {
+  if (!enabled) return;
+  Sentry.captureException(error, context);
+}
+
+/** Drain the outbound queue — call before an intentional `process.exit`. */
+export async function flushErrorReporting(timeoutMs = 2000): Promise<void> {
+  if (!enabled) return;
+  try {
+    await Sentry.flush(timeoutMs);
+  } catch (error) {
+    console.warn('[backend] error reporting flush failed:', error);
+  }
+}
+
+/**
+ * Hono's default error handler, byte-for-byte, plus a capture: `getResponse`
+ * carriers (HTTPException) pass through untouched — those are deliberate
+ * responses, not defects — and everything else is a real 500. The backend
+ * signals expected 4xx via `c.json(..., 4xx)` returns, so an error object
+ * reaching this handler is always report-worthy.
+ */
+export const appErrorHandler: ErrorHandler = (err, c) => {
+  if ('getResponse' in err) {
+    const res = err.getResponse();
+    return c.newResponse(res.body, res);
+  }
+  reportError(err, {
+    tags: {
+      'http.method': c.req.method,
+      // The bounded route vocabulary, never the raw path — same cardinality
+      // rule as the Prometheus labels.
+      'http.route_class': routeClass(c.req.path),
+    },
+    extra: { path: c.req.path },
+  });
+  console.error(err);
+  return c.text('Internal Server Error', 500);
+};

--- a/services/platform/backend/jobs/runner.ts
+++ b/services/platform/backend/jobs/runner.ts
@@ -1,5 +1,6 @@
 import type { JobResult, PgBoss } from 'pg-boss';
 
+import { reportError } from '../error-reporting.ts';
 import type { BackendTaskList } from './task-list.ts';
 
 export interface WorkerOptions {
@@ -43,6 +44,11 @@ export async function startWorker(options: WorkerOptions): Promise<void> {
                 `[backend] task ${name} (job ${job.id}) failed:`,
                 error,
               );
+              // Queue names are a bounded vocabulary — safe as a tag.
+              reportError(error, {
+                tags: { 'tale.task': name },
+                extra: { jobId: job.id },
+              });
               return {
                 id: job.id,
                 status: 'failed',

--- a/services/platform/backend/main.ts
+++ b/services/platform/backend/main.ts
@@ -8,6 +8,11 @@ import { ensureDefaultCorpusSchema } from './domains/knowledge/service.ts';
 import { ensureDefaultObjectStore } from './domains/object_storage/bootstrap.ts';
 import { seedDevUser } from './domains/provisioning/dev-seed.ts';
 import { loadEnv } from './env.ts';
+import {
+  flushErrorReporting,
+  initErrorReporting,
+  reportError,
+} from './error-reporting.ts';
 import { createBoss, ensureQueues } from './jobs/boss.ts';
 import { setEnqueueBoss } from './jobs/enqueue.ts';
 import { startWorker } from './jobs/runner.ts';
@@ -17,6 +22,9 @@ import { initBackendTelemetry } from './telemetry.ts';
 
 async function main(): Promise<void> {
   const env = loadEnv();
+  // First thing after the env parse, so even a failing boot (migrations, DB
+  // connectivity) reports before the process dies. No-op without SENTRY_DSN.
+  initErrorReporting({ dsn: env.SENTRY_DSN, role: env.ROLE });
   const needsApi = env.ROLE !== 'worker';
   const sql = createSql(env.DATABASE_URL);
 
@@ -66,6 +74,7 @@ async function main(): Promise<void> {
     // BYO corpora bootstrap on first use inside the pool router.
     await ensureDefaultCorpusSchema().catch((error: unknown) => {
       console.warn('[backend] default corpus bootstrap failed:', error);
+      reportError(error, { tags: { 'tale.lane': 'boot' } });
     });
   }
 
@@ -80,6 +89,7 @@ async function main(): Promise<void> {
     }
   } catch (error: unknown) {
     console.warn('[backend] default object store bootstrap failed:', error);
+    reportError(error, { tags: { 'tale.lane': 'boot' } });
   }
 
   // Loopback-only dev convenience: seed the owner account + workspace so a
@@ -129,13 +139,16 @@ async function main(): Promise<void> {
     // Graceful: in-flight jobs finish before the instance stops.
     await boss.stop({ graceful: true });
     await sql.end({ timeout: 5 });
+    await flushErrorReporting();
     process.exit(0);
   };
   process.on('SIGTERM', () => void shutdown('SIGTERM'));
   process.on('SIGINT', () => void shutdown('SIGINT'));
 }
 
-main().catch((error: unknown) => {
+main().catch(async (error: unknown) => {
   console.error('[backend] fatal startup error:', error);
+  reportError(error, { tags: { 'tale.lane': 'boot' } });
+  await flushErrorReporting();
   process.exit(1);
 });

--- a/services/platform/backend/realtime/sse.ts
+++ b/services/platform/backend/realtime/sse.ts
@@ -7,6 +7,7 @@ import {
   requireOrganizationMember,
 } from '../auth/membership.ts';
 import type { AuthEnv } from '../auth/session.ts';
+import { reportError } from '../error-reporting.ts';
 import { hintStreamClosed, hintStreamOpened } from '../telemetry.ts';
 import { coalesceHints } from './hints.ts';
 import { latestOutboxId, readHintsAfter } from './outbox.ts';
@@ -82,6 +83,9 @@ export function createEventsHandler(sql: Sql) {
               break;
             }
             console.error('[backend] /events poll failed, backing off:', error);
+            // DB-blip bursts here were a load-bearing production signal in
+            // the 0.4 GlitchTip topology; the SDK's dedupe absorbs repeats.
+            reportError(error, { tags: { 'tale.lane': 'events-poll' } });
             await stream.sleep(ERROR_BACKOFF_MS);
             continue;
           }

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -65,6 +65,7 @@
     "@radix-ui/react-tooltip": "1.2.8",
     "@radix-ui/react-visually-hidden": "1.2.4",
     "@scure/base": "2.0.0",
+    "@sentry/node": "10.48.0",
     "@sentry/tanstackstart-react": "10.48.0",
     "@tailwindcss/postcss": "4.2.2",
     "@tale/shared": "workspace:*",


### PR DESCRIPTION
## Problem

The 0.5 backend does not respect `SENTRY_DSN`. The variable already reaches the `backend-api` / `backend-worker` containers (both compose lanes mount `env_file: .env`), but the process never reads it — the only Sentry SDK in the repo is the browser one, and the web tier uses the DSN solely for its CSP allow-list. Server-side error visibility (the Convex-era exception-reporting integration) was lost in the Postgres cutover, leaving production backend errors on stdout only. The docs still promised "the platform and the convex containers both read the DSN".

## Change

- **`backend/error-reporting.ts`** — `@sentry/node@10.48.0` (same release train as the SPA SDK; bun.lock grows by one line), opt-in via `SENTRY_DSN`, errors only:
  - no `tracesSampleRate` → span recording off, no auto-performance instrumentation loads; `SENTRY_TRACES_SAMPLE_RATE` stays a browser-only knob,
  - `registerEsmLoaderHooks: false` — import-in-the-middle never stacks onto the backend's own `node-loader.mjs` resolve hook,
  - unhandled-rejection integration pinned to `mode: 'strict'` — any listener suppresses Node's default crash, and the SDK default `warn` would silently trade crash-and-restart for limping along,
  - events tagged `tale.role` (api/worker/all), `release` = `TALE_VERSION`; a malformed DSN warns and never takes the boot down.
- **Capture anchors**: Hono `app.onError` (stock 500 behavior replicated byte-for-byte, `getResponse` carriers pass through untouched); pg-boss job failures (queue-name tag + job id, deliberately no `job.data`); fatal boot (report + flush + exit 1); object-store/corpus boot degradations; the `/events` poll catch (DB-blip bursts were a load-bearing production signal in the 0.4 GlitchTip topology).
- **Docs**: `observability-config.md` + `environment-reference.md` rewritten truthfully in en/de/fr; backend README env list gains the variable.

## Evidence

- Real-process probe: `backend:start` + a local fake ingest + an unreachable DB delivers `{"type":"Error","value":"connect ECONNREFUSED …","tags":{"tale.role":"worker","tale.lane":"boot"},"release":"0.5.2-probe"}` and still exits 1; without a DSN the behavior is unchanged.
- New vitest suite (5 cases): real SDK reporting over real HTTP to a fake ingest server (gzip-aware), tags/extra assertions, `HTTPException` passes through unreported, sub-app errors bubble into the parent `onError` (the production topology).
- `bun run check`: 39/40 tasks green; the one red was `test:ui` with 6 `waitFor` timeouts under full parallel load — unrelated to this backend-only diff, and green on an isolated rerun of the three files (84/84) and on a solo full `test:ui` run (447 files / 3455 tests).