### PR TITLE
fix(platform): stream the chat reply into the transcript mid-turn

### DIFF
--- a/services/platform/app/features/chat/hooks/use-thread-view.ts
+++ b/services/platform/app/features/chat/hooks/use-thread-view.ts
@@ -77,11 +77,7 @@ export function useThreadView(
     includeLiveText && generationText.status === 'ready'
       ? generationText.data
       : undefined;
-  useReportServerNow(
-    liveText != null
-      ? (liveText as { serverNow?: number }).serverNow
-      : undefined,
-  );
+  useReportServerNow(liveText?.serverNow);
 
   const scopeKey = `${organizationId}:${threadId ?? ''}`;
   const stateRef = useRef<{ scope: string; state: ThreadViewState } | null>(

--- a/services/platform/app/features/chat/lib/thread-view-core.test.ts
+++ b/services/platform/app/features/chat/lib/thread-view-core.test.ts
@@ -430,6 +430,209 @@ describe('reduceThreadView', () => {
       expect(view.pendingConsumed).toBe(false);
     });
   });
+
+  describe('synthesized live row (fresh send, transcript not yet refetched)', () => {
+    const pending = createPendingSend({
+      text: 'A new question',
+      sentAt: 1_700_000_100_000,
+      threadId: 't1',
+      baselineSequence: 2,
+    });
+
+    it('streams onto the shell key while the placeholder row is absent', () => {
+      const state = createThreadViewState();
+      reduceThreadView(
+        state,
+        inputs({ messages: thread('old answer'), generation: null, pending }),
+      );
+
+      // The turn started server-side; the message list was NOT refetched.
+      const view = reduceThreadView(
+        state,
+        inputs({
+          messages: thread('old answer'),
+          generation: { status: 'streaming', messageId: 'a4' },
+          generationText: { messageId: 'a4', text: 'Hel' },
+          pending,
+        }),
+      );
+
+      expect(view.items.map((item) => item.key)).toEqual([
+        'u1',
+        'a2',
+        pending.key,
+        pending.shellKey,
+      ]);
+      expect(view.items.at(-1)).toMatchObject({
+        id: 'a4',
+        role: 'assistant',
+        text: 'Hel',
+        isStreaming: true,
+      });
+      // The user bubble is still the overlay's — adoption waits for rows.
+      expect(view.pendingConsumed).toBe(false);
+
+      const grownText = reduceThreadView(
+        state,
+        inputs({
+          messages: thread('old answer'),
+          generation: { status: 'streaming', messageId: 'a4' },
+          generationText: { messageId: 'a4', text: 'Hello wor' },
+          pending,
+        }),
+      );
+      expect(grownText.items.at(-1)?.text).toBe('Hello wor');
+    });
+
+    it('hands over to the settle refetch and drains, even when the idle signal lands first', () => {
+      const state = createThreadViewState();
+      reduceThreadView(
+        state,
+        inputs({ messages: thread('old answer'), generation: null, pending }),
+      );
+      reduceThreadView(
+        state,
+        inputs({
+          messages: thread('old answer'),
+          generation: { status: 'streaming', messageId: 'a4' },
+          generationText: { messageId: 'a4', text: 'Hello world.' },
+          pending,
+        }),
+      );
+
+      // Production ordering: the stream settles (generation gone) BEFORE the
+      // refetched rows arrive — the synthesized row holds the streamed text.
+      const gap = reduceThreadView(
+        state,
+        inputs({
+          messages: thread('old answer'),
+          generation: null,
+          generationText: null,
+          pending,
+        }),
+      );
+      expect(gap.items.at(-1)).toMatchObject({
+        id: 'a4',
+        text: 'Hello world.',
+        isStreaming: true,
+      });
+
+      // The refetch lands: the real rows adopt the overlay keys, the
+      // synthesized row retires, and the reveal drains instead of popping.
+      const settled = reduceThreadView(
+        state,
+        inputs({
+          messages: [
+            ...thread('old answer'),
+            textRow('u3', 'A new question', { role: 'user', sequence: 3 }),
+            textRow('a4', 'Hello world.', { sequence: 4 }),
+          ],
+          generation: null,
+          generationText: null,
+          pending,
+        }),
+      );
+      expect(settled.items.map((item) => item.key)).toEqual([
+        'u1',
+        'a2',
+        pending.key,
+        pending.shellKey,
+      ]);
+      expect(settled.items.at(-1)).toMatchObject({
+        id: 'a4',
+        text: 'Hello world.',
+        isStreaming: false,
+        isFinalReveal: true,
+      });
+      expect(settled.pendingConsumed).toBe(true);
+    });
+
+    it('synthesizes the live row for a mid-turn join with no overlay', () => {
+      const state = createThreadViewState();
+      const view = reduceThreadView(
+        state,
+        inputs({
+          messages: thread('old answer'),
+          generation: { status: 'streaming', messageId: 'a9' },
+          generationText: {
+            messageId: 'a9',
+            text: 'Partial',
+            serverNow: 1_700_000_300_000,
+          },
+        }),
+      );
+
+      expect(view.items.at(-1)).toMatchObject({
+        id: 'a9',
+        key: 'a9',
+        role: 'assistant',
+        text: 'Partial',
+        isStreaming: true,
+        createdAt: 1_700_000_300_000,
+      });
+
+      const settled = reduceThreadView(
+        state,
+        inputs({
+          messages: [...thread('old answer'), textRow('a9', 'Partial done.')],
+          generation: null,
+          generationText: null,
+        }),
+      );
+      expect(settled.items.filter((item) => item.id === 'a9')).toHaveLength(1);
+      expect(settled.items.at(-1)).toMatchObject({
+        id: 'a9',
+        isStreaming: false,
+        isFinalReveal: true,
+      });
+    });
+
+    it('carries streamed tool parts on the synthesized row', () => {
+      const state = createThreadViewState();
+      const view = reduceThreadView(
+        state,
+        inputs({
+          messages: thread('old answer'),
+          generation: { status: 'streaming', messageId: 'a4' },
+          generationText: {
+            messageId: 'a4',
+            text: '',
+            parts: [
+              {
+                type: 'tool-call',
+                callId: 'c1',
+                capabilityId: 'rag_search',
+                input: { query: 'returns' },
+              },
+            ],
+          },
+          pending,
+        }),
+      );
+
+      expect(view.items.at(-1)?.parts).toMatchObject([
+        { type: 'tool-call', callId: 'c1' },
+      ]);
+    });
+
+    it('keeps item and array references across identical synthetic passes', () => {
+      const state = createThreadViewState();
+      const pass = () =>
+        reduceThreadView(
+          state,
+          inputs({
+            messages: thread('old answer'),
+            generation: { status: 'streaming', messageId: 'a4' },
+            generationText: { messageId: 'a4', text: 'Hello' },
+            pending,
+          }),
+        );
+      const first = pass();
+      const second = pass();
+
+      expect(Object.is(first.items, second.items)).toBe(true);
+    });
+  });
 });
 
 describe('optimistic send overlay — image attachments', () => {

--- a/services/platform/app/features/chat/lib/thread-view-core.ts
+++ b/services/platform/app/features/chat/lib/thread-view-core.ts
@@ -44,6 +44,9 @@ export interface GenerationTextView {
   /** The assistant row's parts mid-turn — how a tool call reaches the
    *  transcript before the turn settles. */
   readonly parts?: readonly MessagePart[];
+  /** The backend clock at emit — anchors the synthesized live row's thinking
+   * timer when no optimistic send provides a client-frame anchor. */
+  readonly serverNow?: number;
 }
 
 /** What the reducer consumes each render. `undefined` = that subscription is
@@ -78,6 +81,16 @@ export interface ThreadViewState {
   adoptedPendingKeys: Set<string>;
   /** Optimistic shell keys whose real placeholder has arrived. */
   adoptedShellKeys: Set<string>;
+  /**
+   * Live rows synthesized from the stream channel, by REAL message id. The
+   * transcript is only refetched at settle, so mid-turn the stream is the
+   * row's only source — an entry lives from the first `progress` event
+   * naming the id until the refetched row renders under the same key.
+   */
+  syntheticMetaById: Map<
+    string,
+    { createdAt: number; parts?: readonly MessagePart[] }
+  >;
 }
 
 export function createThreadViewState(): ThreadViewState {
@@ -92,6 +105,7 @@ export function createThreadViewState(): ThreadViewState {
     realToPendingKey: new Map(),
     adoptedPendingKeys: new Set(),
     adoptedShellKeys: new Set(),
+    syntheticMetaById: new Map(),
   };
 }
 
@@ -276,9 +290,11 @@ export function reduceThreadView(
 
   const next: ChatMessageItem[] = [];
   const nextByKey = new Map<string, ChatMessageItem>();
+  const renderedRowIds = new Set<string>();
 
   for (const row of messages) {
     const key = state.realToPendingKey.get(row.id) ?? row.id;
+    renderedRowIds.add(row.id);
     const rowText = messagePlainText(row.parts);
     const settled = isSettledRow(row, rowText);
 
@@ -393,7 +409,85 @@ export function reduceThreadView(
     next.push(kept);
     nextByKey.set(kept.key, kept);
   }
-  if (pending && !state.adoptedShellKeys.has(pending.shellKey)) {
+  // The live row, synthesized while the transcript does not carry it. The
+  // message list is only refetched at settle, so on a fresh send the
+  // placeholder row exists server-side while `messages` still predates it —
+  // without this the streamed text has no row to land on and the whole
+  // reply pops in at settle. The stream channel names the row (`messageId`)
+  // and carries its text/reasoning/parts; render from that, keyed the way
+  // the real row will be, so the refetch hands over held text and reveal
+  // in place.
+  if (targetId !== undefined && !renderedRowIds.has(targetId)) {
+    // Inherit the shell's key while an un-adopted overlay is up — the same
+    // in-place handoff the real placeholder gets, and the shell push below
+    // stays down for it. Adoption proper (and `pendingConsumed`) still
+    // waits for the real rows, so the optimistic user bubble stays up.
+    if (
+      pending &&
+      !state.adoptedShellKeys.has(pending.shellKey) &&
+      !state.realToPendingKey.has(targetId)
+    ) {
+      state.realToPendingKey.set(targetId, pending.shellKey);
+    }
+    const key = state.realToPendingKey.get(targetId) ?? targetId;
+    const held = state.streamTextByKey.get(key) ?? '';
+    const live = generationText?.text ?? '';
+    state.streamTextByKey.set(key, live.length >= held.length ? live : held);
+    const heldReasoning = state.streamReasoningByKey.get(key);
+    const liveReasoning = generationText?.reasoning;
+    if (
+      liveReasoning !== undefined &&
+      (heldReasoning === undefined ||
+        liveReasoning.length >= heldReasoning.length)
+    ) {
+      state.streamReasoningByKey.set(key, liveReasoning);
+    }
+    const meta = state.syntheticMetaById.get(targetId) ?? {
+      createdAt: pending?.sentAt ?? generationText?.serverNow ?? 0,
+    };
+    const streamedParts = generationText?.parts;
+    if (
+      streamedParts !== undefined &&
+      streamedParts.length >= (meta.parts?.length ?? 0)
+    ) {
+      meta.parts = streamedParts;
+    }
+    state.syntheticMetaById.set(targetId, meta);
+  }
+  // Materialize the synthesized rows — held through the settle gap even
+  // after the generation goes idle — and retire each one the pass its real
+  // row renders (that row inherits the key, so the drain branch above
+  // carries the reveal from there).
+  for (const [id, meta] of state.syntheticMetaById) {
+    if (renderedRowIds.has(id)) {
+      state.syntheticMetaById.delete(id);
+      continue;
+    }
+    const key = state.realToPendingKey.get(id) ?? id;
+    const reasoningText = state.streamReasoningByKey.get(key);
+    const item: ChatMessageItem = {
+      id,
+      key,
+      role: 'assistant',
+      parts: meta.parts ?? [],
+      sequence: Number.MAX_SAFE_INTEGER,
+      createdAt: meta.createdAt,
+      text: state.streamTextByKey.get(key) ?? '',
+      ...(reasoningText !== undefined ? { reasoningText } : {}),
+      isStreaming: true,
+      isFinalReveal: false,
+      isPendingShell: true,
+    };
+    const prior = state.itemsByKey.get(key);
+    const kept = prior && chatItemRenderEqual(prior, item) ? prior : item;
+    next.push(kept);
+    nextByKey.set(kept.key, kept);
+  }
+  if (
+    pending &&
+    !state.adoptedShellKeys.has(pending.shellKey) &&
+    !nextByKey.has(pending.shellKey)
+  ) {
     const item = buildPendingShellItem(pending);
     const prior = state.itemsByKey.get(item.key);
     const kept = prior && chatItemRenderEqual(prior, item) ? prior : item;


### PR DESCRIPTION
## Problem

On a deployed instance (demo05), chat replies appear all at once instead of streaming. Verified on demo05 with an instrumented browser session: the SSE lane is healthy — `progress` events arrive every 250-400ms with steadily growing text — but the DOM never moves until settle.

## Root cause

Two layers, both verified live:

1. **On a fresh send the streamed text has no row to land on.** The transcript's message list is refetched only at settle, so the assistant placeholder row is absent from `messages` for the whole turn. `reduceThreadView` attaches stream text only to a fetched row whose id matches the generation's `messageId` — with no such row, every progress frame is dropped and the UI shows only the thinking shell. This is true locally too.
2. **What looked like streaming locally was the settle-time typewriter reveal**, gated on the settle refetch response rendering before the `settled` SSE event nulls the latched generation. Local wins that race (<100ms refetch vs ≤250ms stream-poll lag); a deployed instance always loses (~300-400ms over TLS + proxy + PG), so the row mounts as settled history and the whole reply pops in. Injecting a 600ms delay on the messages GET locally reproduced the production behaviour exactly.

## Fix

Synthesize the live row from the stream channel whenever the named `messageId` has no fetched row yet:

- Text/reasoning ride the existing held-stream maps, so when the refetched row lands it inherits the key and drains into `isFinalReveal` — both settle orderings converge, the race is gone.
- With an optimistic send up, the synthesized row adopts the shell's `pending-assistant-*` key: thinking shell → streaming reply → settled row is one React key, no remount, and the thinking-timer anchor holds. Adoption proper (and `pendingConsumed`) still waits for the real rows so the optimistic user bubble stays up.
- The row carries `isPendingShell: true` so `baselineSequenceOf` skips its `MAX_SAFE_INTEGER` sequence and view-swap holds treat it as overlay.
- Streamed tool parts now reach the transcript while the turn runs, and a mid-turn join with no overlay renders too (`GenerationTextView.serverNow` anchors the timer; drops the ad-hoc cast in `use-thread-view`).

## Verification

- 5 new reducer regression tests, including the production ordering (settled signal first, refetch after → still drains into the reveal).
- Full `test:ui` project green: 447 files / 3460 tests. `tsc` and `oxlint --type-aware` clean.
- Real browser against the dev stack with a 600ms injected delay on the messages GET (the production simulation that previously reproduced the pop): the reply now paints incrementally from the first text segment through settle and the drain, no duplicate bubbles, no React key warnings.