### PR TITLE
fix(platform): task-agent runs move the card, stream, and self-chain

### DIFF
--- a/services/platform/app/lib/backend/tasks.ts
+++ b/services/platform/app/lib/backend/tasks.ts
@@ -527,6 +527,11 @@ export const taskReadAdapters: Record<string, ReadAdapter> = {
           `/tasks/${encodeURIComponent(taskId)}/agent-runs/latest`,
           { orgId },
         ).then((body) => body.run),
+      // The run card follows a LIVE run through queued → running → settled,
+      // and the run-lifecycle writes emit no task hint — poll while the
+      // task modal holds the card open (the WS lane pushed; the HTTP lane
+      // asks).
+      refetchInterval: 2000,
     };
   },
   'tasks/queries:getTaskAgentRunSandboxOp': (args, ctx) => {
@@ -540,6 +545,10 @@ export const taskReadAdapters: Record<string, ReadAdapter> = {
           `/tasks/agent-runs/${encodeURIComponent(runId)}/sandbox-op`,
           { orgId },
         ).then((body) => body.op),
+      // The live transcript follows a LIVE turn: poll while the details
+      // dialog is open (the WS lane pushed; the HTTP lane asks) — the twin
+      // of the automation agent-node op read above.
+      refetchInterval: 2000,
     };
   },
   'automations/queries:getLiveRunForTask': (args, ctx) => {

--- a/services/platform/backend/app.ts
+++ b/services/platform/backend/app.ts
@@ -31,6 +31,7 @@ import { createDocumentRoutes } from './domains/documents/routes.ts';
 import { createErasureRoutes } from './domains/erasure/routes.ts';
 import { createFeedbackRoutes } from './domains/feedback/routes.ts';
 import { createFileRoutes } from './domains/files/routes.ts';
+import { createSandboxBlobRoutes } from './domains/files/sandbox-blob-routes.ts';
 import { createFolderRoutes } from './domains/folders/routes.ts';
 import { createGoogleDriveRoutes } from './domains/google_drive/routes.ts';
 import { createGovernanceRoutes } from './domains/governance/routes.ts';
@@ -136,6 +137,9 @@ export function createApp(deps: AppDeps): Hono<AuthEnv> {
   // browser session) — the container-facing machine door.
   app.route('/api/tools', createToolDispatchRoutes({ sql: deps.sql }));
   app.route('/api/connectors', createConnectorBridgeRoutes({ sql: deps.sql }));
+  // Org-bucket blob staging for sandbox sessions (HMAC stage-token gated,
+  // not session auth) — the container-facing twin of the bridge above.
+  app.route('/api/sandbox-blob', createSandboxBlobRoutes({ sql: deps.sql }));
   // Connector OAuth2 consent flow — browser-facing: `start` is
   // session-gated, `callback` is authorized by its single-use state row (the
   // vendor redirects the browser back with no cookie guarantee).

--- a/services/platform/backend/domains/connectors/service.ts
+++ b/services/platform/backend/domains/connectors/service.ts
@@ -383,7 +383,7 @@ export async function runConnectorAction(
  * contract the staging callback and the tools bridge use). */
 export function connectorsHostcallUrlForSessions(): string {
   const origin = (
-    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://convex:3211'
+    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://backend-api:3005'
   ).replace(/\/$/, '');
   return `${origin}/api/connectors/hostcall`;
 }

--- a/services/platform/backend/domains/files/sandbox-blob-routes.ts
+++ b/services/platform/backend/domains/files/sandbox-blob-routes.ts
@@ -1,0 +1,118 @@
+import { Hono } from 'hono';
+import type { Sql } from 'postgres';
+
+import {
+  isS3Ref,
+  parseBlobRef,
+  s3KeyBelongsToOrg,
+} from '../../../convex/lib/storage/blob_ref.ts';
+import { verifyStageToken } from '../../../convex/lib/storage/sandbox_stage_token.ts';
+import { resolveObjectStore, s3PresignGetUrl } from '../../lib/object-store.ts';
+import { resolveOrgSlug } from '../../lib/org-config.ts';
+
+/**
+ * `/api/sandbox-blob` — stream an org-bucket (`s3:`) blob to a sandbox
+ * session container: the 0.4 httpAction on the 0.5 backend origin
+ * (`SANDBOX_HTTP_API_BASE_URL`, the same door the connectors bridge rides).
+ *
+ * Session containers sit on the SSRF-locked sandbox net: they reach this
+ * backend through the `backend-api` alias but have no route to an org's
+ * S3/R2 endpoint, and a presigned bucket URL is a bearer credential that
+ * must never enter an untrusted container. The staging path therefore hands
+ * the in-container daemon THIS route: it verifies a short-lived HMAC stage
+ * token (lib/storage/sandbox_stage_token.ts), presigns server-side after
+ * re-checking the key sits in the token org's namespace, and passes the
+ * upstream body through as a stream (no buffering — a workspace file can be
+ * 100 MB).
+ *
+ * No IP rate limit on purpose: the token gate is strictly stronger
+ * (unforgeable, single-blob, minutes-lived), and an IP bucket would
+ * throttle a legitimate 100-file staging burst from one sandbox address.
+ */
+export function createSandboxBlobRoutes(deps: { sql: Sql }): Hono {
+  const app = new Hono();
+
+  app.get('/', async (c) => {
+    const token = c.req.query('token');
+    if (token === undefined || token === '') {
+      return c.text('Missing token', 400);
+    }
+    const verdict = await verifyStageToken(token);
+    if (!verdict.ok) {
+      if (verdict.reason === 'unconfigured') {
+        // The deployment carries no HMAC root — it also could not have
+        // SIGNED a token, so a request landing here is a config gap, not an
+        // attack.
+        console.warn(
+          '[sandbox-blob] refused: no WEBDAV_APP_PASSWORD_HMAC_KEY to verify with',
+        );
+        return c.text('Stage tokens unavailable', 503);
+      }
+      // malformed / bad_signature / expired collapse to one status — a
+      // forger learns nothing about which check tripped.
+      return c.text('Forbidden', 403);
+    }
+
+    const { ref, org } = verdict.payload;
+    // `_storage` blobs stage via their own capability URLs; this route
+    // exists solely for the bucket lane.
+    if (!isS3Ref(ref)) {
+      return c.text('Unsupported ref', 400);
+    }
+    const parsed = parseBlobRef(ref);
+    if (parsed.backend !== 's3') {
+      return c.text('Unsupported ref', 400);
+    }
+
+    // Fail closed as 404: an unresolvable org, a key outside the org's
+    // namespace, and an org with no object storage configured must all be
+    // indistinguishable from a missing object.
+    const orgSlug = await resolveOrgSlug(deps.sql, org);
+    if (orgSlug === null || !s3KeyBelongsToOrg(parsed.key, orgSlug)) {
+      return c.text('File not found', 404);
+    }
+    let presigned: string;
+    try {
+      const store = await resolveObjectStore(orgSlug);
+      presigned = await s3PresignGetUrl(store, parsed.key);
+    } catch (error) {
+      console.warn(
+        `[sandbox-blob] presign refused for org ${org}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return c.text('File not found', 404);
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(presigned);
+    } catch (error) {
+      console.warn(
+        `[sandbox-blob] upstream fetch failed for org ${org}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+      return c.text('Upstream fetch failed', 502);
+    }
+    if (!upstream.ok || upstream.body === null) {
+      console.warn(
+        `[sandbox-blob] upstream returned ${upstream.status} for org ${org}`,
+      );
+      return c.text('Upstream fetch failed', 502);
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type':
+        upstream.headers.get('content-type') ?? 'application/octet-stream',
+    };
+    // Forward the declared length when the bucket provides it — the
+    // daemon's cheap over-cap rejection reads it before streaming a byte.
+    const contentLength = upstream.headers.get('content-length');
+    if (contentLength !== null) {
+      headers['Content-Length'] = contentLength;
+    }
+    return new Response(upstream.body, { status: 200, headers });
+  });
+
+  return app;
+}

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -162,13 +162,13 @@ async function filterRetrievableRagFileIds(
 }
 
 /**
- * The handler map the reused 0.4 knowledge modules dispatch through —
- * exported so the chat lane's wider shim can spread it (the chat tools
- * call `searchKnowledge`/`fetchDocumentByFileId` on the SAME ctx).
+ * The betterAuth org-adapter read (`orgSlugFromId`'s one component ref) —
+ * its own factory because every reused module that resolves an org's
+ * on-disk provider tree needs it: knowledge embedding here, and the agent
+ * lanes' vision-model resolution on the task shim.
  */
-export function knowledgeShimHandlers(sql: Sql): ShimHandlers {
+export function orgAdapterShimHandlers(sql: Sql): ShimHandlers {
   return {
-    ...credentialShimHandlers(sql),
     [ADAPTER_FIND_ONE]: async (raw) => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: adapter.findOne's argument shape
       const { model, where } = raw as {
@@ -193,6 +193,18 @@ export function knowledgeShimHandlers(sql: Sql): ShimHandlers {
       const row = rows[0];
       return row ? { _id: row.id, slug: row.slug ?? undefined } : null;
     },
+  };
+}
+
+/**
+ * The handler map the reused 0.4 knowledge modules dispatch through —
+ * exported so the chat lane's wider shim can spread it (the chat tools
+ * call `searchKnowledge`/`fetchDocumentByFileId` on the SAME ctx).
+ */
+export function knowledgeShimHandlers(sql: Sql): ShimHandlers {
+  return {
+    ...credentialShimHandlers(sql),
+    ...orgAdapterShimHandlers(sql),
     [FILTER_RETRIEVABLE]: async (raw) => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the reused fetch/search callers pass exactly this shape
       const args = raw as {

--- a/services/platform/backend/domains/tasks/agent-turn-shim.ts
+++ b/services/platform/backend/domains/tasks/agent-turn-shim.ts
@@ -4,9 +4,13 @@ import type { Sql } from 'postgres';
 import { readSkillBundleForViewer } from '../../../convex/skills/file_actions.ts';
 import { isAutoRetryableFailure } from '../../../convex/tasks/task_auto_retry.ts';
 import { AppError } from '../../../lib/shared/errors/app-error';
+import { isFilePolicyType } from '../../../lib/shared/schemas/governance';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
 import type { ShimHandlers, ShimScheduler } from '../../lib/convex-shim.ts';
+import { readGovernancePolicyForOrg } from '../../lib/org-config.ts';
+import { orgAdapterShimHandlers } from '../knowledge/service.ts';
+import { credentialShimHandlers } from '../provider_credentials/service.ts';
 import {
   reserveSessionSlot,
   resumeSessionSlot,
@@ -46,6 +50,28 @@ function quotaAsAppError(error: unknown): never {
 export function agentTurnShimHandlers(sql: Sql): ShimHandlers {
   return {
     ...sandboxToolShimHandlers(sql),
+
+    // The vision-model resolution seam: `resolveTurnVisionModel` (the turn
+    // start's gateway mint) walks org slug → provider default credentials →
+    // the `vision_model` policy pin, all over ctx.runQuery. None of these
+    // families were shimmed, so EVERY 0.5 task/automation agent turn
+    // resolved vision as null — the resolver's catch turned the un-shimmed
+    // throw into "text-only", and an image the agent then Read 404'd a
+    // text-only serving model with no polyfill to catch it.
+    ...credentialShimHandlers(sql),
+    ...orgAdapterShimHandlers(sql),
+    'governance/internal_queries:getPolicyConfigInternal': async (raw) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the reused 0.4 caller passes exactly this shape
+      const args = raw as { organizationId: string; policyType: string };
+      // An unknown policy type reads as "no policy configured" — the 0.4
+      // internal query answered null for an absent file the same way.
+      if (!isFilePolicyType(args.policyType)) return null;
+      return readGovernancePolicyForOrg(
+        sql,
+        args.organizationId,
+        args.policyType,
+      );
+    },
 
     // ------------------------------------------------------- the run ledger
     'tasks/agent_runs:getTaskAgentRunForDrive': async (raw) => {

--- a/services/platform/backend/domains/tasks/agent-turn-shim.ts
+++ b/services/platform/backend/domains/tasks/agent-turn-shim.ts
@@ -6,7 +6,7 @@ import { isAutoRetryableFailure } from '../../../convex/tasks/task_auto_retry.ts
 import { AppError } from '../../../lib/shared/errors/app-error';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
-import type { ShimHandlers } from '../../lib/convex-shim.ts';
+import type { ShimHandlers, ShimScheduler } from '../../lib/convex-shim.ts';
 import {
   reserveSessionSlot,
   resumeSessionSlot,
@@ -15,9 +15,15 @@ import {
 } from '../sandbox/sessions.ts';
 import { sandboxToolShimHandlers } from '../sandbox/shim.ts';
 import { kickAgentRun } from './agent-runs.ts';
+import { closePendingTaskReviewOnStatusLeave } from './reviews.ts';
 import {
   agentRecordTaskOutputsTrusted,
   agentUpdateTaskStatusTrusted,
+  applyTaskCountTransition,
+  computeEndRank,
+  loadTaskOrThrow,
+  recordActivity,
+  taskCountBucket,
   type TaskStatus,
 } from './service.ts';
 
@@ -267,8 +273,8 @@ export function agentTurnShimHandlers(sql: Sql): ShimHandlers {
       if (agent === undefined) {
         return { started: false, reason: 'agent_unavailable' };
       }
-      const kicked = await transactSerializable(sql, (tx) =>
-        kickAgentRun(tx, {
+      const kicked = await transactSerializable(sql, async (tx) => {
+        const result = await kickAgentRun(tx, {
           organizationId: args.organizationId,
           projectId: task.projectId,
           taskId: args.taskId,
@@ -281,8 +287,51 @@ export function agentTurnShimHandlers(sql: Sql): ShimHandlers {
           trigger: 'mention',
           feedback: args.feedback,
           startedBy: args.authorId,
-        }),
-      );
+        });
+        if (result.reused) return result;
+        // The mention kick moves the card too (the 0.4 shared-core rule: the
+        // board verb IS the interface). The settled predecessor parked the
+        // task at `in_review` — left there, a fresh run grinds behind a card
+        // that reads "waiting on review", and the pending review gate it
+        // minted must be withdrawn on the way out (every leave closes it).
+        // Attributed to the comment's author: the kick is their gesture,
+        // delivered late. Mirrors the review hand-back's write shape.
+        const fresh = await loadTaskOrThrow(tx, args.taskId);
+        if (fresh.status !== 'in_progress') {
+          await closePendingTaskReviewOnStatusLeave(tx, {
+            task: fresh,
+            toStatus: 'in_progress',
+            actor: { kind: 'user', userId: args.authorId },
+          });
+          const now = Date.now();
+          const rank = await computeEndRank(tx, fresh.projectId, 'in_progress');
+          await tx`
+            UPDATE app.tasks SET
+              status = 'in_progress', rank = ${rank},
+              completed_at_ms = NULL,
+              status_changed_at_ms = ${now}, updated_at_ms = ${now}
+            WHERE id = ${fresh.id}
+          `;
+          await applyTaskCountTransition(
+            tx,
+            fresh.projectId,
+            taskCountBucket(fresh),
+            taskCountBucket({
+              status: 'in_progress',
+              archivedAt: fresh.archivedAt,
+            }),
+          );
+          await recordActivity(tx, {
+            task: fresh,
+            actorType: 'user',
+            actorId: args.authorId,
+            action: 'status.changed',
+            fromValue: fresh.status,
+            toValue: 'in_progress',
+          });
+        }
+        return result;
+      });
       // A reused live run means another turn is already carrying this work;
       // the comment rides that one rather than starting a second.
       return { started: !kicked.reused };
@@ -762,5 +811,35 @@ export function agentTurnShimHandlers(sql: Sql): ShimHandlers {
       const args = raw as Parameters<typeof readSkillBundleForViewer>[0];
       return readSkillBundleForViewer(args);
     },
+  };
+}
+
+/**
+ * The task lane's scheduler seam: the reused hosts self-chain by scheduling
+ * `internal.*` refs — the drive continuation after every `running` window
+ * and the steer retry ladder — and each maps onto its pg-boss job here.
+ * Without the seam the chain dies at the FIRST re-schedule ("no scheduler
+ * seam registered"), settling a working turn as failed while the agent
+ * keeps going (observed live). The turn-drive itest alone never exercises
+ * this: its fake harness finishes in one terminal window, so nothing
+ * re-schedules there.
+ */
+export function taskAgentShimScheduler(sql: Sql): ShimScheduler {
+  return async (functionName, delayMs, args) => {
+    const startAfter =
+      delayMs > 0 ? { startAfter: new Date(Date.now() + delayMs) } : {};
+    if (functionName === 'tasks/agent_run_host:driveTaskAgentTurn') {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the host builds exactly the drive keys its handler re-validates
+      await addJobInTx(sql, 'task.agent_drive', args as never, startAfter);
+      return;
+    }
+    if (functionName === 'tasks/agent_run_host:steerTaskAgentTurn') {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the steer host replays its own args with attempt+1
+      await addJobInTx(sql, 'task.agent_steer', args as never, startAfter);
+      return;
+    }
+    throw new Error(
+      `[task-agent] unmapped scheduled ref ${functionName} — add it to taskAgentShimScheduler`,
+    );
   };
 }

--- a/services/platform/backend/domains/tasks/agent-turn-shim.ts
+++ b/services/platform/backend/domains/tasks/agent-turn-shim.ts
@@ -15,15 +15,10 @@ import {
 } from '../sandbox/sessions.ts';
 import { sandboxToolShimHandlers } from '../sandbox/shim.ts';
 import { kickAgentRun } from './agent-runs.ts';
-import { closePendingTaskReviewOnStatusLeave } from './reviews.ts';
 import {
   agentRecordTaskOutputsTrusted,
   agentUpdateTaskStatusTrusted,
-  applyTaskCountTransition,
-  computeEndRank,
-  loadTaskOrThrow,
-  recordActivity,
-  taskCountBucket,
+  handTaskToInProgressForKick,
   type TaskStatus,
 } from './service.ts';
 
@@ -290,46 +285,14 @@ export function agentTurnShimHandlers(sql: Sql): ShimHandlers {
         });
         if (result.reused) return result;
         // The mention kick moves the card too (the 0.4 shared-core rule: the
-        // board verb IS the interface). The settled predecessor parked the
-        // task at `in_review` — left there, a fresh run grinds behind a card
-        // that reads "waiting on review", and the pending review gate it
-        // minted must be withdrawn on the way out (every leave closes it).
-        // Attributed to the comment's author: the kick is their gesture,
-        // delivered late. Mirrors the review hand-back's write shape.
-        const fresh = await loadTaskOrThrow(tx, args.taskId);
-        if (fresh.status !== 'in_progress') {
-          await closePendingTaskReviewOnStatusLeave(tx, {
-            task: fresh,
-            toStatus: 'in_progress',
-            actor: { kind: 'user', userId: args.authorId },
-          });
-          const now = Date.now();
-          const rank = await computeEndRank(tx, fresh.projectId, 'in_progress');
-          await tx`
-            UPDATE app.tasks SET
-              status = 'in_progress', rank = ${rank},
-              completed_at_ms = NULL,
-              status_changed_at_ms = ${now}, updated_at_ms = ${now}
-            WHERE id = ${fresh.id}
-          `;
-          await applyTaskCountTransition(
-            tx,
-            fresh.projectId,
-            taskCountBucket(fresh),
-            taskCountBucket({
-              status: 'in_progress',
-              archivedAt: fresh.archivedAt,
-            }),
-          );
-          await recordActivity(tx, {
-            task: fresh,
-            actorType: 'user',
-            actorId: args.authorId,
-            action: 'status.changed',
-            fromValue: fresh.status,
-            toValue: 'in_progress',
-          });
-        }
+        // board verb IS the interface): the settled predecessor parked the
+        // task at `in_review`, and left there a fresh run grinds behind a
+        // card that reads "waiting on review". Attributed to the comment's
+        // author — the kick is their gesture, delivered late.
+        await handTaskToInProgressForKick(tx, {
+          taskId: args.taskId,
+          userId: args.authorId,
+        });
         return result;
       });
       // A reused live run means another turn is already carrying this work;

--- a/services/platform/backend/domains/tasks/comments.ts
+++ b/services/platform/backend/domains/tasks/comments.ts
@@ -13,6 +13,7 @@ import { emitEvent } from '../events/emit.ts';
 import {
   loadProjectOrThrow,
   type ProjectAuthContext,
+  type ProjectRow,
 } from '../projects/service.ts';
 import {
   createThread,
@@ -21,11 +22,15 @@ import {
   saveMessage,
   updateMessageText,
 } from '../threads/store.ts';
+import { kickAgentRun } from './agent-runs.ts';
 import {
   assertTaskReadable,
   assertTaskWritable,
+  assignTask,
+  handTaskToInProgressForKick,
   loadTaskOrThrow,
   TaskError,
+  taskHasLiveAutomationRun,
   type TaskRow,
 } from './service.ts';
 
@@ -140,15 +145,16 @@ export async function addTaskComment(
     task,
     mentions,
   });
-  // A comment that @-mentions the agent CURRENTLY running this task steers
-  // the live turn instead of being dropped: the steer host injects it over
-  // the harness's held-open stdin, or restarts the exec around it. A queued
-  // (capacity-parked) run needs nothing — its start reads the brief after
-  // this comment posted.
+  // A comment that @-mentions one of the project's agent INSTANCES puts it
+  // to work: steering its RUNNING turn, or — when the task is idle —
+  // (re)assigning the task to it and kicking a fresh 'mention' run with
+  // this comment as feedback (the 0.4 wire). Runs after the automation
+  // check so a task can only ever have one engine start per comment.
   if (!automationStarted) {
-    await maybeSteerLiveRun(tx, {
-      organizationId: auth.organizationId,
-      taskId: args.taskId,
+    await dispatchMentionedProjectAgent(tx, {
+      auth,
+      task,
+      project,
       mentions,
       authorType: author.actorType,
       authorId: author.actorId,
@@ -384,19 +390,36 @@ export async function deleteTaskComment(
 }
 
 /**
- * Enqueue a steer when the comment names the agent instance that owns a
- * LIVE run on this task.
+ * The comment-@mention work dispatcher for the project's agent INSTANCES —
+ * the 0.4 `triggerMentionedProjectAgent` wire. The FIRST mentioned instance
+ * belonging to THIS project picks the lane:
  *
- * Only a `running` run is steerable: a queued one has not read its brief
- * yet (the comment is already in the discussion it will read), and a
- * settled one is handled by the steer host's own fallback. Only a HUMAN's
- * comment steers — an agent's own comment naming itself would loop.
+ * - the task's live run is RUNNING and its agent is mentioned → STEER the
+ *   live turn (the steer host injects the comment over the harness's
+ *   held-open stdin, or restarts the exec around it);
+ * - the live run is QUEUED → nothing: its start reads the brief AFTER this
+ *   comment posted;
+ * - another engine holds the task (a different instance's live run, a live
+ *   automation run) → nothing: a mention adds work, never preempts it, and
+ *   it never reassigns under a live run;
+ * - the task is idle → (re)assign it to the instance when it isn't the
+ *   assignee yet (`assignTask` — the picker's own choreography) and kick a
+ *   fresh 'mention' run carrying the comment as feedback; the kick moves
+ *   the card to In progress.
+ *
+ * Every refusal is quiet — the comment has already posted and notified. The
+ * gate is WRITE access: commenting is read-level, but assigning and running
+ * are edits, so a read-only member's `@` stays a plain mention. Only a
+ * HUMAN's comment dispatches — an agent's own comment naming itself would
+ * loop. A roster-slug mention that matches no instance row belongs to the
+ * automation lane, never this one.
  */
-async function maybeSteerLiveRun(
+async function dispatchMentionedProjectAgent(
   tx: TransactionSql,
   args: {
-    organizationId: string;
-    taskId: string;
+    auth: ProjectAuthContext;
+    task: TaskRow;
+    project: ProjectRow;
     mentions: { type: string; id: string }[];
     authorType: string;
     authorId: string;
@@ -410,11 +433,21 @@ async function maybeSteerLiveRun(
       .map((mention) => mention.id),
   );
   if (mentionedAgentIds.size === 0) return;
+  if (args.task.archivedAt !== null) return;
+  try {
+    assertTaskWritable(args.project, args.auth);
+  } catch {
+    console.warn(
+      `[tasks] agent mention on ${args.task.id} stays a plain mention (author lacks write access)`,
+    );
+    return;
+  }
 
   const runs = await tx<
     {
       id: string;
       agentId: string;
+      status: string;
       execId: string;
       sessionId: string;
       harness: string;
@@ -423,63 +456,150 @@ async function maybeSteerLiveRun(
       deadlineAt: number;
     }[]
   >`
-    SELECT id, agent_id AS "agentId", exec_id AS "execId",
+    SELECT id, agent_id AS "agentId", status, exec_id AS "execId",
            session_id AS "sessionId", harness, model,
            model_provider AS "modelProvider",
            deadline_at_ms::float8 AS "deadlineAt"
     FROM app.project_agent_runs
-    WHERE task_id = ${args.taskId} AND org_id = ${args.organizationId}
-      AND status = 'running'
+    WHERE task_id = ${args.task.id} AND org_id = ${args.auth.organizationId}
+      AND status IN ('queued', 'running')
     LIMIT 1
   `;
   const run = runs[0];
-  if (run === undefined || !mentionedAgentIds.has(run.agentId)) return;
+  if (run !== undefined) {
+    // A queued run needs nothing (its start reads the brief after this
+    // comment posted); a live run of an UNMENTIONED instance is never
+    // preempted or reassigned over.
+    if (run.status !== 'running' || !mentionedAgentIds.has(run.agentId)) {
+      return;
+    }
+    const agents = await tx<
+      {
+        instructions: string | null;
+        skills: string[];
+        connectors: string[];
+        tools: string[];
+        secrets: string[];
+      }[]
+    >`
+      SELECT instructions, skills, connectors, tools, secrets
+      FROM app.project_agents WHERE id = ${run.agentId} LIMIT 1
+    `;
+    const agent = agents[0];
+    if (agent === undefined) return;
 
-  const agents = await tx<
-    {
-      instructions: string | null;
-      skills: string[];
-      connectors: string[];
-      tools: string[];
-      secrets: string[];
-    }[]
-  >`
-    SELECT instructions, skills, connectors, tools, secrets
-    FROM app.project_agents WHERE id = ${run.agentId} LIMIT 1
-  `;
-  const agent = agents[0];
-  if (agent === undefined) return;
+    const authors = await tx<{ name: string | null; email: string | null }[]>`
+      SELECT "name", "email" FROM "user" WHERE "id" = ${args.authorId} LIMIT 1
+    `;
+    const author =
+      (authors[0]?.name ?? '').trim() ||
+      (authors[0]?.email ?? '').trim() ||
+      'a teammate';
 
-  const authors = await tx<{ name: string | null; email: string | null }[]>`
-    SELECT "name", "email" FROM "user" WHERE "id" = ${args.authorId} LIMIT 1
-  `;
-  const author =
-    (authors[0]?.name ?? '').trim() ||
-    (authors[0]?.email ?? '').trim() ||
-    'a teammate';
+    await addJobInTx(tx, 'task.agent_steer', {
+      organizationId: args.auth.organizationId,
+      runId: run.id,
+      taskId: args.task.id,
+      agentId: run.agentId,
+      execId: run.execId,
+      sessionId: run.sessionId,
+      harness: run.harness,
+      deadlineAt: run.deadlineAt,
+      model: run.model,
+      ...(run.modelProvider !== null
+        ? { modelProvider: run.modelProvider }
+        : {}),
+      ...(agent.instructions !== null
+        ? { instructions: agent.instructions }
+        : {}),
+      skills: agent.skills,
+      connectors: agent.connectors,
+      tools: agent.tools,
+      secrets: agent.secrets,
+      feedback: args.feedback,
+      author,
+      authorId: args.authorId,
+      attempt: 0,
+    });
+    return;
+  }
 
-  await addJobInTx(tx, 'task.agent_steer', {
-    organizationId: args.organizationId,
-    runId: run.id,
-    taskId: args.taskId,
-    agentId: run.agentId,
-    execId: run.execId,
-    sessionId: run.sessionId,
-    harness: run.harness,
-    deadlineAt: run.deadlineAt,
-    model: run.model,
-    ...(run.modelProvider !== null ? { modelProvider: run.modelProvider } : {}),
-    ...(agent.instructions !== null
-      ? { instructions: agent.instructions }
+  // Idle lane: resolve the FIRST mentioned id that is an instance OF THIS
+  // project (mention order is appearance order — the 0.4 rule).
+  let instance:
+    | {
+        id: string;
+        harness: string;
+        model: string;
+        modelProvider: string | null;
+      }
+    | undefined;
+  for (const mention of args.mentions) {
+    if (mention.type !== 'agent') continue;
+    const candidates = await tx<
+      {
+        id: string;
+        harness: string;
+        model: string;
+        modelProvider: string | null;
+      }[]
+    >`
+      SELECT id, harness, model, model_provider AS "modelProvider"
+      FROM app.project_agents
+      WHERE id = ${mention.id} AND project_id = ${args.task.projectId}
+        AND org_id = ${args.auth.organizationId}
+      LIMIT 1
+    `;
+    if (candidates[0] !== undefined) {
+      instance = candidates[0];
+      break;
+    }
+  }
+  if (instance === undefined) return;
+  // An automation-driven task keeps its automation — one engine per task.
+  if (await taskHasLiveAutomationRun(tx, args.task)) return;
+  if (instance.model === '') {
+    console.warn(
+      `[tasks] mention kick for agent ${instance.id} refused: agent_model_missing`,
+    );
+    return;
+  }
+  if (
+    args.task.assigneeType !== 'agent' ||
+    args.task.assigneeId !== instance.id
+  ) {
+    // (Re)assign exactly like the picker — activity, audit, notify.
+    await assignTask(tx, args.auth, {
+      taskId: args.task.id,
+      assigneeType: 'agent',
+      assigneeId: instance.id,
+    });
+  }
+  const kicked = await kickAgentRun(tx, {
+    organizationId: args.auth.organizationId,
+    projectId: args.task.projectId,
+    taskId: args.task.id,
+    agentId: instance.id,
+    harness: instance.harness,
+    model: instance.model,
+    ...(instance.modelProvider !== null
+      ? { modelProvider: instance.modelProvider }
       : {}),
-    skills: agent.skills,
-    connectors: agent.connectors,
-    tools: agent.tools,
-    secrets: agent.secrets,
+    startedBy: args.auth.userId,
+    trigger: 'mention',
     feedback: args.feedback,
-    author,
-    authorId: args.authorId,
-    attempt: 0,
+  });
+  if (kicked.reused) {
+    // A racing kick landed between this transaction's live-run probe and
+    // here — the comment rides the standing run instead.
+    console.warn(
+      `[tasks] mention kick for agent ${instance.id} reused the standing run`,
+    );
+    return;
+  }
+  await handTaskToInProgressForKick(tx, {
+    taskId: args.task.id,
+    userId: args.auth.userId,
   });
 }
 

--- a/services/platform/backend/domains/tasks/kick-plan.ts
+++ b/services/platform/backend/domains/tasks/kick-plan.ts
@@ -61,6 +61,7 @@ export async function resolveTaskKickStartArgs(
       sessionCreatedAt: number | null;
       startedAt: number;
       brokerTokenHash: string | null;
+      apiErrorStatus: number | null;
     }[]
   >`
     SELECT status, agent_id AS "agentId", harness,
@@ -68,7 +69,8 @@ export async function resolveTaskKickStartArgs(
            agent_session_id AS "agentSessionId",
            session_created_at_ms::float8 AS "sessionCreatedAt",
            started_at_ms::float8 AS "startedAt",
-           broker_token_hash AS "brokerTokenHash"
+           broker_token_hash AS "brokerTokenHash",
+           api_error_status AS "apiErrorStatus"
     FROM app.project_agent_runs
     WHERE task_id = ${args.taskId}
     ORDER BY seq DESC
@@ -134,6 +136,9 @@ export async function resolveTaskKickStartArgs(
       ...(handle !== undefined ? { agentSessionId: handle } : {}),
       ...(run.sessionCreatedAt !== null
         ? { sessionCreatedAt: run.sessionCreatedAt }
+        : {}),
+      ...(run.apiErrorStatus !== null
+        ? { apiErrorStatus: run.apiErrorStatus }
         : {}),
     };
     previousExecId = run.execId;

--- a/services/platform/backend/domains/tasks/service.ts
+++ b/services/platform/backend/domains/tasks/service.ts
@@ -2599,7 +2599,8 @@ function isReviewPolicyRefusalError(error: unknown): boolean {
 
 /**
  * The manual "Run agent" kick: the task's ASSIGNED agent starts (or reuses)
- * a run — a contested/ineligible state answers as DATA (the 0.4 wire).
+ * a run AND the card moves to In progress as the caller's own status write
+ * — a contested/ineligible state answers as DATA (the 0.4 wire).
  */
 export async function startTaskAgentRunManual(
   tx: TransactionSql,
@@ -2629,6 +2630,25 @@ export async function startTaskAgentRunManual(
   const agent = agents[0];
   if (!agent) {
     return { started: false, reason: 'agent_missing' };
+  }
+  // The board verb IS the interface (the 0.4 rule): kicking the run moves
+  // the card, and the move is the CALLER's own status write. A task not yet
+  // at `in_progress` routes through `updateTaskStatus`, whose choreography
+  // kicks the queued run inside this same transaction — the board never
+  // shows a To-do agent task with a live run grinding behind it. The
+  // live-run probe answers `already_running` BEFORE any move (0.4's guard
+  // order), so a second click never reshuffles the board.
+  if (task.status !== 'in_progress') {
+    const live = await tx<{ id: string }[]>`
+      SELECT id FROM app.project_agent_runs
+      WHERE task_id = ${taskId} AND status IN ('queued', 'running')
+      LIMIT 1
+    `;
+    if (live.length > 0) {
+      return { started: false, reason: 'already_running' };
+    }
+    await updateTaskStatus(tx, auth, taskId, 'in_progress');
+    return { started: true };
   }
   const kicked = await kickAgentRun(tx, {
     organizationId: auth.organizationId,

--- a/services/platform/backend/domains/tasks/service.ts
+++ b/services/platform/backend/domains/tasks/service.ts
@@ -1157,6 +1157,52 @@ export async function agentUpdateTaskStatusTrusted(
 }
 
 /**
+ * Hand the card to In progress as the lower half of a KICK — the shared
+ * write for every "kicking a run moves the card" lane that cannot route
+ * through `updateTaskStatus` (no full status-writer context, or the kick
+ * carries feedback the status writer's own kick would drop): the steer-miss
+ * mention kick and the comment-mention dispatcher. Withdraws a pending
+ * review gate on the way out (every leave closes it), clears a terminal
+ * `completedAt`, and records the move as the USER's act — the kick is their
+ * gesture. Returns whether the card actually moved.
+ */
+export async function handTaskToInProgressForKick(
+  tx: TransactionSql,
+  args: { taskId: string; userId: string },
+): Promise<boolean> {
+  const fresh = await loadTaskOrThrow(tx, args.taskId);
+  if (fresh.status === 'in_progress') return false;
+  await closePendingTaskReviewOnStatusLeave(tx, {
+    task: fresh,
+    toStatus: 'in_progress',
+    actor: { kind: 'user', userId: args.userId },
+  });
+  const now = Date.now();
+  const rank = await computeEndRank(tx, fresh.projectId, 'in_progress');
+  await tx`
+    UPDATE app.tasks SET
+      status = 'in_progress', rank = ${rank}, completed_at_ms = NULL,
+      status_changed_at_ms = ${now}, updated_at_ms = ${now}
+    WHERE id = ${fresh.id}
+  `;
+  await applyTaskCountTransition(
+    tx,
+    fresh.projectId,
+    taskCountBucket(fresh),
+    taskCountBucket({ status: 'in_progress', archivedAt: fresh.archivedAt }),
+  );
+  await recordActivity(tx, {
+    task: fresh,
+    actorType: 'user',
+    actorId: args.userId,
+    action: 'status.changed',
+    fromValue: fresh.status,
+    toValue: 'in_progress',
+  });
+  return true;
+}
+
+/**
  * TRUSTED deliverables merge into the task's Output zone (same fileName ⇒
  * replace) — the settle's attach step.
  */
@@ -2574,6 +2620,18 @@ async function taskHasLiveRun(
     LIMIT 1
   `;
   if (agent.length > 0) return true;
+  return taskHasLiveAutomationRun(tx, task);
+}
+
+/** Whether a live AUTOMATION run holds this task (subject-linked, the 0.4
+ * `findLiveAutomationRunForTask` probe) — the automation half of
+ * `taskHasLiveRun`, exported for lanes that treat the two families
+ * differently (the comment-mention dispatcher steers an agent run but
+ * yields entirely to an automation). */
+export async function taskHasLiveAutomationRun(
+  tx: TransactionSql,
+  task: Pick<TaskRow, 'id' | 'organizationId' | 'projectId'>,
+): Promise<boolean> {
   const automation = await tx<{ id: string }[]>`
     SELECT id FROM app.automation_runs
     WHERE org_id = ${task.organizationId} AND project_id = ${task.projectId}

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -7728,6 +7728,76 @@ async function checkTurnReattach(
 }
 
 /**
+ * The `/api/sandbox-blob` staging door — the 0.4 httpAction restored on the
+ * 0.5 backend origin: a stage-token-gated stream of an org-bucket blob into
+ * a sandbox session. Without it every `s3:` staging (task attachments, a
+ * task's prior deliverables mirrored into a turn) dies as a skipped file
+ * and the run fails with "staging task inputs failed". Gated on
+ * ITEST_S3_ENDPOINT like the other blob lanes.
+ */
+async function checkSandboxBlobDoor(
+  sql: Sql,
+  base: string,
+  ctx: { orgId: string },
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'sandbox-blob staging door (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — S3 lanes not exercised in this run',
+    );
+    return;
+  }
+  const { resolveOrgSlug } = await import('./lib/org-config.ts');
+  const { resolveObjectStore, s3PutObject, buildObjectKey } =
+    await import('./lib/object-store.ts');
+  const { encodeS3Ref } = await import('../convex/lib/storage/blob_ref.ts');
+  const { signStageToken } =
+    await import('../convex/lib/storage/sandbox_stage_token.ts');
+  const orgSlug = (await resolveOrgSlug(sql, ctx.orgId)) ?? '';
+  const store = await resolveObjectStore(orgSlug);
+  const key = buildObjectKey(store, orgSlug);
+  const payload = 'sandbox-blob staging round-trip';
+  await s3PutObject(
+    store,
+    key,
+    new TextEncoder().encode(payload),
+    'text/plain',
+  );
+  const token = await signStageToken({ ref: encodeS3Ref(key), org: ctx.orgId });
+  // A validly SIGNED token for a key OUTSIDE the org's namespace must fail
+  // closed as 404 — the namespace check is the tenant boundary.
+  const foreignToken = await signStageToken({
+    ref: encodeS3Ref('some-other-org/deadbeef'),
+    org: ctx.orgId,
+  });
+  if (token === null || foreignToken === null) {
+    record(
+      'sandbox-blob: a stage token streams the org blob through the door',
+      false,
+      'stage-token signing unavailable (no WEBDAV_APP_PASSWORD_HMAC_KEY)',
+    );
+    return;
+  }
+  const served = await fetch(
+    `${base}/api/sandbox-blob?token=${encodeURIComponent(token)}`,
+  );
+  const servedBody = served.status === 200 ? await served.text() : '';
+  const forged = await fetch(`${base}/api/sandbox-blob?token=v1.zzzz.zzzz`);
+  const foreign = await fetch(
+    `${base}/api/sandbox-blob?token=${encodeURIComponent(foreignToken)}`,
+  );
+  record(
+    'sandbox-blob: a stage token streams the org blob through the door',
+    served.status === 200 &&
+      servedBody === payload &&
+      forged.status === 403 &&
+      foreign.status === 404,
+    `served=${served.status} bodyOk=${servedBody === payload}, forged=${forged.status} (want 403), foreignKey=${foreign.status} (want 404)`,
+  );
+}
+
+/**
  * The MANUAL "Run agent" kick and the steer-miss mention kick both move the
  * card — kicking a run IS the caller's move to In progress (the 0.4
  * shared-core rule). Without the move the board shows a To-do task with a
@@ -8269,6 +8339,174 @@ async function checkRunProvenance(
   await sql`
     UPDATE app.project_agent_runs SET status = 'cancelled'
     WHERE id = ${steerRunId}
+  `;
+
+  // ---- an idle instance's mention (re)assigns + kicks a mention run ----
+  // The 0.4 `triggerMentionedProjectAgent` wire: no live engine on the
+  // task, so the comment puts the mentioned instance to work — the task is
+  // reassigned off its human assignee, a 'mention' run kicks with the
+  // comment as feedback, and the kick moves the card to In progress.
+  const seedTask = async (
+    title: string,
+    assignee: { type: string; id: string } | null,
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.tasks (
+        org_id, project_id, title, status, rank, assignee_type, assignee_id,
+        created_by, created_by_type, outputs, created_at_ms, updated_at_ms
+      ) VALUES (
+        ${orgId}, ${projectId}, ${title}, 'todo', 'm0',
+        ${assignee?.type ?? null}, ${assignee?.id ?? null}, ${userId},
+        'user', ${sql.json([])}, ${Date.now()}, ${Date.now()}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const idleTaskId = await seedTask('Idle mention task', {
+    type: 'user',
+    id: userId,
+  });
+  await sql.begin((tx) =>
+    addTaskComment(tx, auth, {
+      taskId: idleTaskId,
+      body: `@${agentId} please draft the summary`,
+    }),
+  );
+  const idleRuns = await sql<
+    {
+      id: string;
+      status: string;
+      trigger: string | null;
+      feedback: string | null;
+      agentId: string;
+    }[]
+  >`
+    SELECT id, status, trigger, feedback, agent_id AS "agentId"
+    FROM app.project_agent_runs WHERE task_id = ${idleTaskId}
+  `;
+  const idleTask = await sql<
+    { status: string; assigneeType: string | null; assigneeId: string | null }[]
+  >`
+    SELECT status, assignee_type AS "assigneeType",
+           assignee_id AS "assigneeId"
+    FROM app.tasks WHERE id = ${idleTaskId}
+  `;
+  record(
+    'tasks: @-mentioning an idle instance reassigns the task and kicks a mention run',
+    idleRuns.length === 1 &&
+      idleRuns[0]?.status === 'queued' &&
+      idleRuns[0].trigger === 'mention' &&
+      (idleRuns[0].feedback ?? '').includes('draft the summary') &&
+      idleRuns[0].agentId === agentId &&
+      idleTask[0]?.status === 'in_progress' &&
+      idleTask[0].assigneeType === 'agent' &&
+      idleTask[0].assigneeId === agentId,
+    `runs=${idleRuns.length} (${idleRuns[0]?.status}/${idleRuns[0]?.trigger}), task=${idleTask[0]?.status}, assignee=${idleTask[0]?.assigneeType}/${idleTask[0]?.assigneeId === agentId}`,
+  );
+  await sql`
+    UPDATE app.project_agent_runs SET status = 'cancelled',
+                                      settled_at_ms = ${Date.now()}
+    WHERE task_id = ${idleTaskId}
+  `;
+
+  // ---- a queued run's mention stays quiet (its start reads the brief) --
+  const queuedTaskId = await seedTask('Queued mention task', {
+    type: 'agent',
+    id: agentId,
+  });
+  await sql`
+    INSERT INTO app.project_agent_runs (
+      org_id, task_id, project_id, agent_id, session_id, exec_id, harness,
+      model, trigger, started_by, status, started_at_ms, deadline_at_ms,
+      updated_at_ms
+    ) VALUES (
+      ${orgId}, ${queuedTaskId}, ${projectId}, ${agentId},
+      'mention-queued-session', 'mention-queued-exec', 'claude-code',
+      'itest-model', 'manual', ${userId}, 'queued', ${Date.now()},
+      ${Date.now() + 3_600_000}, ${Date.now()}
+    )
+  `;
+  await sql.begin((tx) =>
+    addTaskComment(tx, auth, {
+      taskId: queuedTaskId,
+      body: `@${agentId} also add a cover page`,
+    }),
+  );
+  const queuedRuns = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.project_agent_runs
+    WHERE task_id = ${queuedTaskId}
+  `;
+  const queuedTask = await sql<{ status: string }[]>`
+    SELECT status FROM app.tasks WHERE id = ${queuedTaskId}
+  `;
+  record(
+    'tasks: mentioning an instance with a queued run starts nothing',
+    queuedRuns[0]?.count === '1' && queuedTask[0]?.status === 'todo',
+    `runs=${queuedRuns[0]?.count} (want 1), task=${queuedTask[0]?.status} (want todo)`,
+  );
+  await sql`
+    UPDATE app.project_agent_runs SET status = 'cancelled',
+                                      settled_at_ms = ${Date.now()}
+    WHERE task_id = ${queuedTaskId}
+  `;
+
+  // ---- an agent's own comment never dispatches -------------------------
+  const agentAuthorTaskId = await seedTask('Agent author task', {
+    type: 'agent',
+    id: agentId,
+  });
+  await sql.begin((tx) =>
+    addTaskComment(tx, auth, {
+      taskId: agentAuthorTaskId,
+      body: `@${agentId} noting my own progress`,
+      author: { actorType: 'agent', actorId: agentId },
+    }),
+  );
+  const agentAuthorRuns = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.project_agent_runs
+    WHERE task_id = ${agentAuthorTaskId}
+  `;
+  record(
+    "tasks: an agent's own comment mention dispatches nothing",
+    agentAuthorRuns[0]?.count === '0',
+    `runs=${agentAuthorRuns[0]?.count} (want 0)`,
+  );
+
+  // ---- an automation-driven task keeps its automation ------------------
+  const automationHeldTaskId = await seedTask('Automation held task', null);
+  await sql`
+    INSERT INTO app.automation_runs (
+      org_id, project_id, name, version, status, mode, started_by, input,
+      started_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'itest-mention-block', 1, 'running', 'live',
+      ${userId}, ${sql.json({ task: { id: automationHeldTaskId } })},
+      ${Date.now()}
+    )
+  `;
+  await sql.begin((tx) =>
+    addTaskComment(tx, auth, {
+      taskId: automationHeldTaskId,
+      body: `@${agentId} take over please`,
+    }),
+  );
+  const automationHeldRuns = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.project_agent_runs
+    WHERE task_id = ${automationHeldTaskId}
+  `;
+  const automationHeldTask = await sql<{ assigneeType: string | null }[]>`
+    SELECT assignee_type AS "assigneeType" FROM app.tasks
+    WHERE id = ${automationHeldTaskId}
+  `;
+  record(
+    'tasks: a live automation run blocks the mention kick entirely',
+    automationHeldRuns[0]?.count === '0' &&
+      automationHeldTask[0]?.assigneeType === null,
+    `runs=${automationHeldRuns[0]?.count} (want 0), assignee=${String(automationHeldTask[0]?.assigneeType)} (want null — never reassigned)`,
+  );
+  await sql`
+    UPDATE app.automation_runs SET status = 'failed'
+    WHERE org_id = ${orgId} AND name = 'itest-mention-block'
   `;
 
   // ---- deleting a task closes the approvals that named it --------------
@@ -24864,6 +25102,7 @@ async function main(): Promise<void> {
     await checkProjectTail(sql, baseUrl, authCtx);
     await checkRunProvenance(sql, authCtx);
     await checkManualKickMovesCard(sql, authCtx);
+    await checkSandboxBlobDoor(sql, baseUrl, authCtx);
     await checkTurnReattach(sql, authCtx);
     await checkConversations(sql, baseUrl, authCtx);
     await checkMailboxSyncLane(sql, authCtx);

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -16066,6 +16066,10 @@ async function checkTaskAgentTurnDrive(
   const gatewayCalls = { minted: 0, revoked: 0 };
   let boxTaskDir = '';
 
+  // The session whose canned turn ends SUCCESSFULLY with an EMPTY result —
+  // the bare-EOS shape a weak model emits mid-work (set by the reportless
+  // scenario below; every other session plays the normal settling turn).
+  let reportlessSessionId = '';
   // --- fake spawner: sessions + exec SSE + files ---------------------------
   const spawner = createServer((req, res) => {
     let body = '';
@@ -16114,14 +16118,18 @@ async function checkTaskAgentTurnDrive(
       }
       const exec = /^\/v1\/sessions\/([^/]+)\/exec$/.exec(url.pathname);
       if (method === 'POST' && exec) {
-        // The canned claude-code stream-json turn, then the exec result.
+        // The canned claude-code stream-json turn, then the exec result. The
+        // reportless session's turn ends SUCCESSFULLY with an empty result —
+        // the parser then sets no finalText, which is the no-report signal.
         res.setHeader('content-type', 'text/event-stream');
         const line = (obj: unknown): string => `${JSON.stringify(obj)}\n`;
+        const reportless = (exec[1] ?? '') === reportlessSessionId;
+        const conv = reportless ? 'conv-43' : 'conv-42';
         const events = [
           line({
             type: 'system',
             subtype: 'init',
-            session_id: 'conv-42',
+            session_id: conv,
             model: 'itest-agent-model',
           }),
           line({
@@ -16129,15 +16137,22 @@ async function checkTaskAgentTurnDrive(
             message: {
               id: 'm1',
               model: 'itest-agent-model',
-              content: [{ type: 'text', text: 'Working on the report…' }],
+              content: [
+                {
+                  type: 'text',
+                  text: reportless
+                    ? 'Mapping the table structure…'
+                    : 'Working on the report…',
+                },
+              ],
               usage: { input_tokens: 120, output_tokens: 40 },
             },
           }),
           line({
             type: 'result',
             subtype: 'success',
-            session_id: 'conv-42',
-            result: FINAL_TEXT,
+            session_id: conv,
+            result: reportless ? '' : FINAL_TEXT,
             duration_ms: 850,
           }),
         ];
@@ -16257,9 +16272,15 @@ async function checkTaskAgentTurnDrive(
       }
       if (url === '/api/governance/virtual-keys' && method === 'POST') {
         gatewayCalls.minted += 1;
+        // Unique per mint: the session-token row hashes the key VALUE, so a
+        // second turn re-minting a byte-identical key would die on the
+        // token-hash unique constraint before its exec ever starts.
         res.end(
           JSON.stringify({
-            virtual_key: { id: 'vk-drive-1', value: 'sk-bf-drive-1' },
+            virtual_key: {
+              id: `vk-drive-${gatewayCalls.minted}`,
+              value: `sk-bf-drive-${gatewayCalls.minted}`,
+            },
           }),
         );
         return;
@@ -16465,6 +16486,105 @@ async function checkTaskAgentTurnDrive(
         gatewayCalls.revoked === 1,
       `run=${run?.status}${run?.error ? ` (${run.error.slice(0, 120)})` : ''} text=${JSON.stringify(run?.resultText)} conv=${run?.agentSessionId}, task=${taskRow?.status} (want in_review) outputs=${outputsRaw.includes('report.md')}, comment=${(comments[0]?.body ?? '').slice(0, 60)}…, op=${opRows[0]?.status}/finalized=${opRows[0]?.finalizedAt !== null}/spent=${opRows[0]?.spentCents}, metadata=${metadataRows[0]?.count}, vk mint/revoke=${gatewayCalls.minted}/${gatewayCalls.revoked}`,
     );
+
+    // --- a SUCCESSFUL end with no final text fails the run retryably ------
+    // The model can end its turn with a bare EOS mid-work (observed live: a
+    // 1-completion-token response at a 42k prompt). That end carries no
+    // report — settling it would park half-done work at in_review as if
+    // reported. The host must fail the run with 'empty_turn' instead, stamp
+    // the conversation handle for the resume, and arm the auto-retry.
+    const agent2 = z.object({ agentId: z.string() }).safeParse(
+      await (
+        await post(`/api/app/projects/${projectId}/agents?orgId=${orgId}`, {
+          name: 'Empty Turn Bot',
+          harness: 'claude-code',
+          model: 'itest-agent-model',
+          skills: [],
+          connectors: [],
+        })
+      ).json(),
+    );
+    const agent2Id = agent2.success ? agent2.data.agentId : '';
+    reportlessSessionId = `pa-${agent2Id}`;
+    const task2 = z.object({ taskId: z.string() }).safeParse(
+      await (
+        await post(`/api/app/tasks?orgId=${orgId}`, {
+          projectId,
+          title: 'End with nothing',
+        })
+      ).json(),
+    );
+    const task2Id = task2.success ? task2.data.taskId : '';
+    await post(`/api/app/tasks/${task2Id}/assign?orgId=${orgId}`, {
+      assigneeType: 'agent',
+      assigneeId: agent2Id,
+    });
+    await post(`/api/app/tasks/${task2Id}/status?orgId=${orgId}`, {
+      status: 'in_progress',
+    });
+    const emptyTerminal = await waitFor(async () => {
+      const rows = await sql<{ status: string }[]>`
+        SELECT status FROM app.project_agent_runs
+        WHERE task_id = ${task2Id} ORDER BY started_at_ms DESC LIMIT 1
+      `;
+      return ['settled', 'failed'].includes(rows[0]?.status ?? '');
+    }, 45_000);
+    // Assert on the FIRST run: the armed auto-retry may already be driving
+    // a second one through the same reportless script.
+    const emptyRuns = await sql<
+      { status: string; error: string | null; agentSessionId: string | null }[]
+    >`
+      SELECT status, error, agent_session_id AS "agentSessionId"
+      FROM app.project_agent_runs
+      WHERE task_id = ${task2Id} ORDER BY started_at_ms ASC LIMIT 1
+    `;
+    const emptyRun = emptyRuns[0];
+    const emptyTask = await sql<{ status: string }[]>`
+      SELECT status FROM app.tasks WHERE id = ${task2Id}
+    `;
+    const retryArmed = await sql<{ count: string }[]>`
+      SELECT count(*)::text AS count FROM pgboss.job
+      WHERE name = 'task.agent_retry' AND data ->> 'taskId' = ${task2Id}
+    `;
+    record(
+      'task-agent: a success end with no final text fails retryably',
+      emptyTerminal &&
+        emptyRun?.status === 'failed' &&
+        (emptyRun.error ?? '').includes('without a final report') &&
+        emptyRun.agentSessionId === 'conv-43' &&
+        emptyTask[0]?.status === 'in_progress' &&
+        Number(retryArmed[0]?.count ?? '0') >= 1,
+      `run=${emptyRun?.status} (${(emptyRun?.error ?? '-').slice(0, 60)}), conv=${emptyRun?.agentSessionId} (want conv-43), task=${emptyTask[0]?.status} (want in_progress — never in_review), retryJobs=${retryArmed[0]?.count}`,
+    );
+    // Stop the retry cascade deterministically: the retry kick re-derives
+    // "task still at in_progress" FOR UPDATE, so moving the card refuses
+    // the pending attempt; cancelling any in-flight run makes the turn
+    // jobs' idempotency gates skip. Then DRAIN this task's jobs before the
+    // finally tears the fakes down — a stray attempt firing after teardown
+    // would run against whatever env the NEXT suite has live.
+    await sql`
+      UPDATE app.tasks SET status = 'todo', updated_at_ms = ${Date.now()}
+      WHERE id = ${task2Id}
+    `;
+    await sql`
+      UPDATE app.project_agent_runs SET status = 'cancelled',
+                                        settled_at_ms = ${Date.now()}
+      WHERE task_id = ${task2Id} AND status IN ('queued', 'running')
+    `;
+    await waitFor(async () => {
+      const pending = await sql<{ count: string }[]>`
+        SELECT count(*)::text AS count FROM pgboss.job
+        WHERE name IN ('task.agent_turn', 'task.agent_retry',
+                       'task.agent_drive')
+          AND state IN ('created', 'retry', 'active')
+          AND (data ->> 'taskId' = ${task2Id}
+               OR data ->> 'runId' IN (
+                 SELECT id FROM app.project_agent_runs
+                 WHERE task_id = ${task2Id}
+               ))
+      `;
+      return pending[0]?.count === '0';
+    }, 30_000);
   } finally {
     delete process.env.SANDBOX_URL;
     delete process.env.SANDBOX_TOKEN;

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -7727,6 +7727,221 @@ async function checkTurnReattach(
   `;
 }
 
+/**
+ * The MANUAL "Run agent" kick and the steer-miss mention kick both move the
+ * card — kicking a run IS the caller's move to In progress (the 0.4
+ * shared-core rule). Without the move the board shows a To-do task with a
+ * live run grinding behind it, the auto-retry guard
+ * (`task.status === 'in_progress'`) refuses every retry of a manually
+ * kicked run, and a steer-miss kick leaves the card parked at In review
+ * with its stale pending gate.
+ */
+async function checkManualKickMovesCard(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const now = Date.now();
+  const auth = {
+    organizationId: orgId,
+    userId,
+    role: 'owner',
+    teamIds: [] as string[],
+  };
+  const projectRows = await sql<{ id: string }[]>`
+    INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                              updated_at_ms)
+    VALUES (${orgId}, 'Kick choreography', ${userId}, ${now}, ${now})
+    RETURNING id
+  `;
+  const projectId = projectRows[0]?.id ?? '';
+  const agentRows = await sql<{ id: string }[]>`
+    INSERT INTO app.project_agents (
+      org_id, project_id, name, harness, model, created_by, created_at_ms,
+      updated_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'Kick Agent', 'claude-code', 'itest-model',
+      ${userId}, ${now}, ${now}
+    ) RETURNING id
+  `;
+  const agentId = agentRows[0]?.id ?? '';
+  const taskRows = await sql<{ id: string }[]>`
+    INSERT INTO app.tasks (
+      org_id, project_id, title, status, rank, assignee_type, assignee_id,
+      created_by, created_by_type, outputs, created_at_ms, updated_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'Manual kick task', 'todo', 'a0', 'agent',
+      ${agentId}, ${userId}, 'user', ${sql.json([])}, ${now}, ${now}
+    ) RETURNING id
+  `;
+  const taskId = taskRows[0]?.id ?? '';
+
+  const { startTaskAgentRunManual } =
+    await import('./domains/tasks/service.ts');
+  // Assert INSIDE the kick's transaction: the worker must not race the
+  // probe by driving the queued turn before the reads land.
+  const manual = await sql.begin(async (tx) => {
+    const first = await startTaskAgentRunManual(tx, auth, taskId);
+    const taskRow = await tx<{ status: string }[]>`
+      SELECT status FROM app.tasks WHERE id = ${taskId}
+    `;
+    const runRow = await tx<{ id: string; status: string }[]>`
+      SELECT id, status FROM app.project_agent_runs
+      WHERE task_id = ${taskId} ORDER BY started_at_ms DESC LIMIT 1
+    `;
+    const jobs = await tx<{ count: string }[]>`
+      SELECT count(*)::text AS count FROM pgboss.job
+      WHERE name = 'task.agent_turn'
+        AND data ->> 'runId' = ${runRow[0]?.id ?? ''}
+    `;
+    const second = await startTaskAgentRunManual(tx, auth, taskId);
+    return {
+      first,
+      second,
+      taskStatus: taskRow[0]?.status ?? 'gone',
+      runId: runRow[0]?.id ?? '',
+      runStatus: runRow[0]?.status ?? 'gone',
+      jobCount: Number(jobs[0]?.count ?? '0'),
+    };
+  });
+  record(
+    'tasks: the manual Run-agent kick moves the card to In progress',
+    manual.first.started &&
+      manual.taskStatus === 'in_progress' &&
+      manual.runStatus === 'queued' &&
+      manual.jobCount === 1 &&
+      !manual.second.started &&
+      manual.second.reason === 'already_running',
+    `started=${manual.first.started}, task=${manual.taskStatus}, run=${manual.runStatus}, jobs=${manual.jobCount}, second=${manual.second.reason ?? 'started'}`,
+  );
+  // Neutralize before the worker polls the job up: the turn job's
+  // idempotency gate skips a run that is no longer queued.
+  await sql`
+    UPDATE app.project_agent_runs SET status = 'cancelled',
+                                      settled_at_ms = ${Date.now()}
+    WHERE id = ${manual.runId}
+  `;
+
+  // ---- the steer-miss mention kick pulls the card back off In review ----
+  const reviewTaskRows = await sql<{ id: string }[]>`
+    INSERT INTO app.tasks (
+      org_id, project_id, title, status, rank, assignee_type, assignee_id,
+      created_by, created_by_type, outputs, created_at_ms, updated_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'Steer-miss task', 'in_review', 'a1', 'agent',
+      ${agentId}, ${userId}, 'user', ${sql.json([])}, ${now}, ${now}
+    ) RETURNING id
+  `;
+  const reviewTaskId = reviewTaskRows[0]?.id ?? '';
+  const gateRows = await sql<{ id: string }[]>`
+    INSERT INTO app.approvals (
+      org_id, status, resource_type, resource_id, priority, metadata,
+      created_at_ms
+    ) VALUES (
+      ${orgId}, 'pending', 'task_review', ${reviewTaskId}, 'medium',
+      ${sql.json({ taskId: reviewTaskId, projectId })}, ${now}
+    ) RETURNING id
+  `;
+  const gateId = gateRows[0]?.id ?? '';
+  const { agentTurnShimHandlers } =
+    await import('./domains/tasks/agent-turn-shim.ts');
+  const steerMiss =
+    agentTurnShimHandlers(sql)['tasks/mutations:kickMentionRunAfterSteerMiss'];
+  const missResult = objectAt(
+    steerMiss === undefined
+      ? null
+      : await steerMiss({
+          organizationId: orgId,
+          taskId: reviewTaskId,
+          authorId: userId,
+          feedback: 'please tighten the summary',
+        }),
+    '',
+  );
+  const missTask = await sql<{ status: string }[]>`
+    SELECT status FROM app.tasks WHERE id = ${reviewTaskId}
+  `;
+  const missRuns = await sql<{ id: string }[]>`
+    SELECT id FROM app.project_agent_runs WHERE task_id = ${reviewTaskId}
+  `;
+  const missGate = await sql<{ status: string; metadata: unknown }[]>`
+    SELECT status, metadata FROM app.approvals WHERE id = ${gateId}
+  `;
+  const missGateMeta = objectAt(missGate[0]?.metadata ?? null, '');
+  record(
+    'tasks: the steer-miss mention kick hands the card back to In progress',
+    missResult?.started === true &&
+      missTask[0]?.status === 'in_progress' &&
+      missRuns.length === 1 &&
+      missGate[0]?.status === 'rejected' &&
+      missGateMeta?.withdrawn === true,
+    `started=${String(missResult?.started)}, task=${missTask[0]?.status}, runs=${missRuns.length}, gate=${missGate[0]?.status}/${String(missGateMeta?.withdrawn)}`,
+  );
+  await sql`
+    UPDATE app.project_agent_runs SET status = 'cancelled',
+                                      settled_at_ms = ${Date.now()}
+    WHERE id = ${missRuns[0]?.id ?? ''}
+  `;
+
+  // ---- the drive chain's scheduler seam maps every self-chained ref ------
+  // The turn-drive scenario cannot catch a missing seam: its fake harness
+  // finishes in one terminal window, so nothing ever re-schedules. Probe the
+  // seam directly — a real turn's FIRST `running` window dies without it.
+  const { taskAgentShimScheduler } =
+    await import('./domains/tasks/agent-turn-shim.ts');
+  const seam = taskAgentShimScheduler(sql);
+  const seamJobsBefore = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM pgboss.job
+    WHERE name IN ('task.agent_drive', 'task.agent_steer')
+      AND data ->> 'execId' = 'seam-probe-exec'
+  `;
+  const seamPayload = {
+    organizationId: orgId,
+    runId: 'seam-probe-run',
+    taskId,
+    agentId,
+    execId: 'seam-probe-exec',
+    sessionId: 'seam-probe-session',
+    harness: 'claude-code',
+    deadlineAt: Date.now() + 3_600_000,
+    sessionCreatedAt: now,
+  };
+  await seam('tasks/agent_run_host:driveTaskAgentTurn', 0, seamPayload);
+  await seam('tasks/agent_run_host:steerTaskAgentTurn', 5_000, {
+    ...seamPayload,
+    feedback: 'probe',
+    author: 'probe',
+    authorId: userId,
+    attempt: 1,
+  });
+  let seamUnmappedThrew = false;
+  try {
+    await seam('tasks/agent_run_host:noSuchRef', 0, {});
+  } catch {
+    seamUnmappedThrew = true;
+  }
+  const seamJobs = await sql<{ name: string; carried: string | null }[]>`
+    SELECT name, data ->> 'sessionCreatedAt' AS carried FROM pgboss.job
+    WHERE name IN ('task.agent_drive', 'task.agent_steer')
+      AND data ->> 'execId' = 'seam-probe-exec'
+  `;
+  const driveJob = seamJobs.find((job) => job.name === 'task.agent_drive');
+  record(
+    'tasks: the drive/steer scheduler seam maps the self-chained refs',
+    Number(seamJobsBefore[0]?.count ?? '0') === 0 &&
+      seamJobs.length === 2 &&
+      driveJob !== undefined &&
+      driveJob.carried === String(now) &&
+      seamUnmappedThrew,
+    `jobs=${seamJobs.length} (want 2), driveCarriesIncarnation=${driveJob?.carried === String(now)}, unmappedThrew=${seamUnmappedThrew}`,
+  );
+  await sql`
+    DELETE FROM pgboss.job
+    WHERE name IN ('task.agent_drive', 'task.agent_steer')
+      AND data ->> 'execId' = 'seam-probe-exec'
+  `;
+}
+
 async function checkRunProvenance(
   sql: Sql,
   ctx: { orgId: string; userId: string },
@@ -24648,6 +24863,7 @@ async function main(): Promise<void> {
     await checkCompetences(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkProjectTail(sql, baseUrl, authCtx);
     await checkRunProvenance(sql, authCtx);
+    await checkManualKickMovesCard(sql, authCtx);
     await checkTurnReattach(sql, authCtx);
     await checkConversations(sql, baseUrl, authCtx);
     await checkMailboxSyncLane(sql, authCtx);

--- a/services/platform/backend/jobs/task-list.ts
+++ b/services/platform/backend/jobs/task-list.ts
@@ -41,7 +41,10 @@ import {
 import { scaffoldNewOrganization } from '../domains/organizations/scaffold.ts';
 import { runSandboxWatchdog } from '../domains/sandbox/watchdogs.ts';
 import { kickAgentRun } from '../domains/tasks/agent-runs.ts';
-import { agentTurnShimHandlers } from '../domains/tasks/agent-turn-shim.ts';
+import {
+  agentTurnShimHandlers,
+  taskAgentShimScheduler,
+} from '../domains/tasks/agent-turn-shim.ts';
 import { resolveTaskKickStartArgs } from '../domains/tasks/kick-plan.ts';
 import { runTaskAgentWatchdog } from '../domains/tasks/watchdogs.ts';
 import {
@@ -87,6 +90,10 @@ const driveSchema = z.object({
   sessionId: z.string().min(1),
   harness: z.string().min(1),
   deadlineAt: z.number(),
+  // The incarnation stamp the settle binds to the conversation handle — the
+  // drive continuation carries it or a later kick's resume check degrades
+  // to the op-recovered leg.
+  sessionCreatedAt: z.number().optional(),
 });
 
 const steerSchema = z.object({
@@ -612,7 +619,9 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       // ring buffer, streams the turn, and runs the settle choreography —
       // the same code a fresh start reaches after launching its exec, which
       // is exactly why re-attaching is safe.
-      const shim = createCtxShim(agentTurnShimHandlers(deps.sql));
+      const shim = createCtxShim(agentTurnShimHandlers(deps.sql), {
+        scheduler: taskAgentShimScheduler(deps.sql),
+      });
       await driveTaskAgentTurnImpl(
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 host; every ctx facility it touches is covered by agentTurnShimHandlers
         shim as unknown as Parameters<typeof driveTaskAgentTurnImpl>[0],
@@ -626,7 +635,9 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       // decision — stdin injection vs exec rotation, the retry ladder, and
       // the settled-turn fallback that turns the comment into a fresh
       // mention run.
-      const shim = createCtxShim(agentTurnShimHandlers(deps.sql));
+      const shim = createCtxShim(agentTurnShimHandlers(deps.sql), {
+        scheduler: taskAgentShimScheduler(deps.sql),
+      });
       await steerTaskAgentTurnImpl(
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 host; every ctx facility it touches is covered by agentTurnShimHandlers
         shim as unknown as Parameters<typeof steerTaskAgentTurnImpl>[0],
@@ -706,7 +717,9 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       });
       // The REUSED 0.4 turn host on the ctx shim — the whole start: session
       // ensure, staging, key mint, exec, drain, settle choreography.
-      const shim = createCtxShim(agentTurnShimHandlers(deps.sql));
+      const shim = createCtxShim(agentTurnShimHandlers(deps.sql), {
+        scheduler: taskAgentShimScheduler(deps.sql),
+      });
       await startTaskAgentTurnImpl(
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 host; every ctx facility it touches is covered by agentTurnShimHandlers
         shim as unknown as Parameters<typeof startTaskAgentTurnImpl>[0],

--- a/services/platform/backend/jobs/tasks.ts
+++ b/services/platform/backend/jobs/tasks.ts
@@ -57,6 +57,7 @@ export interface TaskPayloads {
     sessionId: string;
     harness: string;
     deadlineAt: number;
+    sessionCreatedAt?: number;
   };
   /** Steer a LIVE task-agent turn with a comment (stdin or exec restart). */
   'task.agent_steer': {

--- a/services/platform/convex/automations/agent_host.ts
+++ b/services/platform/convex/automations/agent_host.ts
@@ -700,7 +700,9 @@ export async function stageSkillBundle(
   const result = await sessionStageFiles(sessionId, files);
   if (result.skipped.length > 0) {
     throw new Error(
-      `staging skill "${slug}" failed: ${result.skipped.map((s) => s.path).join(', ')}`,
+      `staging skill "${slug}" failed: ${result.skipped
+        .map((s) => `${s.path} (${s.reason})`)
+        .join(', ')}`,
     );
   }
   return files.length;
@@ -854,7 +856,9 @@ export async function stageWorkflowFiles(
     const staged = await sessionStageFiles(sessionId, toStage);
     if (staged.skipped.length > 0) {
       throw new Error(
-        `staging input files failed: ${staged.skipped.map((s) => s.path).join(', ')}`,
+        `staging input files failed: ${staged.skipped
+          .map((s) => `${s.path} (${s.reason})`)
+          .join(', ')}`,
       );
     }
   }

--- a/services/platform/convex/chat/external_turn_shared.ts
+++ b/services/platform/convex/chat/external_turn_shared.ts
@@ -84,7 +84,7 @@ function gatewayBaseUrlForSessions(): string {
  * as the staging callback), plus the bridge's route prefix. */
 export function connectorsBridgeUrlForSessions(): string {
   const origin = (
-    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://convex:3211'
+    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://backend-api:3005'
   ).replace(/\/$/, '');
   return `${origin}/api/connectors`;
 }

--- a/services/platform/convex/lib/storage/sandbox_stage_token.ts
+++ b/services/platform/convex/lib/storage/sandbox_stage_token.ts
@@ -181,12 +181,12 @@ export async function verifyStageToken(
 
 /**
  * Build the sandbox-reachable staging URL for an `s3:` blob: the
- * `/api/sandbox-blob` httpAction on the Convex http-actions origin as seen
- * from INSIDE the sandbox network (`convex:3211` by default — in prod the
- * convex container is dual-homed onto the sandbox net; in dev the
- * `convex-relay` socat bridges it to the host-run backend; override with
- * SANDBOX_HTTP_API_BASE_URL for non-standard topologies). Returns `null`
- * when no HMAC root is configured.
+ * `/api/sandbox-blob` route on the backend origin as seen from INSIDE the
+ * sandbox network (`backend-api:3005` by default — under compose the api
+ * container is dual-homed onto the sandbox net; in host dev the
+ * `backend-relay` socat carries the alias to the host-run backend; override
+ * with SANDBOX_HTTP_API_BASE_URL for non-standard topologies). Returns
+ * `null` when no HMAC root is configured.
  */
 export async function buildSandboxBlobStageUrl(
   ref: string,
@@ -195,7 +195,7 @@ export async function buildSandboxBlobStageUrl(
   const token = await signStageToken({ ref, org: organizationId });
   if (token === null) return null;
   const base = (
-    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://convex:3211'
+    process.env.SANDBOX_HTTP_API_BASE_URL ?? 'http://backend-api:3005'
   ).replace(/\/$/, '');
   return `${base}/api/sandbox-blob?token=${encodeURIComponent(token)}`;
 }

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -299,9 +299,12 @@ async function stageTaskInputs(
   if (toStage.length === 0) return staged;
   const result = await sessionStageFiles(args.sessionId, toStage);
   if (result.skipped.length > 0) {
+    // Carry each file's skip REASON: the run error is the only diagnostic a
+    // failed staging leaves behind, and a bare path list reads as "file
+    // gone" when the real cause is a dead staging route or a refused fetch.
     throw new Error(
       `staging task inputs failed: ${result.skipped
-        .map((skip) => skip.path)
+        .map((skip) => `${skip.path} (${skip.reason})`)
         .join(', ')}`,
     );
   }

--- a/services/platform/convex/tasks/agent_run_host.ts
+++ b/services/platform/convex/tasks/agent_run_host.ts
@@ -1248,6 +1248,33 @@ async function continueOrSettle(
       console.warn('[task-agent] final progress write failed:', err),
     );
   const ended = window.ended;
+  // A SUCCESSFUL end with no final text is not a settle: the model emitted
+  // a bare end-of-turn mid-work (observed live: a 1-completion-token
+  // response at a 42k-token prompt ended the turn between two file reads),
+  // so there is no report to post and the work is not done. Parking the
+  // half-done task at in_review as if reported is the worst outcome — fail
+  // the run RETRYABLY instead, so the auto-retry resumes the SAME
+  // conversation (the handle is stamped below) and asks it to continue.
+  // Every parser sets `finalText` only from real final text, so its absence
+  // IS the no-report signal; windows that never became a conversation stay
+  // with the resume-launch-failure lane.
+  if (
+    !errored &&
+    !launchFailed &&
+    (ended?.finalText === undefined || ended.finalText.trim() === '')
+  ) {
+    await settleTaskAgentTurn(ctx, args, {
+      errored: true,
+      reason:
+        'the agent ended its turn without a final report — retrying the conversation',
+      text: '',
+      ...(window.agentSessionId !== undefined
+        ? { agentSessionId: window.agentSessionId }
+        : {}),
+      failureCode: 'empty_turn',
+    });
+    return;
+  }
   const text =
     ended?.finalText !== undefined && ended.finalText !== ''
       ? ended.finalText

--- a/services/platform/convex/tasks/task_auto_retry.ts
+++ b/services/platform/convex/tasks/task_auto_retry.ts
@@ -25,6 +25,10 @@ export type TaskRunFailureCode =
   | 'start_failed'
   | 'harvest_failed'
   | 'steer_restart_failed'
+  /** A SUCCESSFUL harness end with no final text — the model emitted a bare
+   * end-of-turn mid-work, so there is no report and the work is not done.
+   * Retryable: the retry resumes the conversation and asks it to continue. */
+  | 'empty_turn'
   | 'deadline'
   | 'park_deadline'
   | 'agent_deleted'

--- a/services/platform/convex/tasks/task_kick_resume.test.ts
+++ b/services/platform/convex/tasks/task_kick_resume.test.ts
@@ -50,6 +50,15 @@ describe('resolveTaskKickResume — provider-rejected conversations', () => {
     expect(plan.inspectNote).toBe(true);
   });
 
+  it('a 400-rejected replay (dropped reasoning_content) also starts FRESH', () => {
+    const plan = resolveTaskKickResume({
+      previous: failedPrevious({ apiErrorStatus: 400 }),
+      kick,
+    });
+    expect(plan.resume).toBeUndefined();
+    expect(plan.inspectNote).toBe(true);
+  });
+
   it('transient provider trouble (429) keeps the conversation continuity', () => {
     const plan = resolveTaskKickResume({
       previous: failedPrevious({ apiErrorStatus: 429 }),

--- a/services/platform/convex/tasks/task_kick_resume.test.ts
+++ b/services/platform/convex/tasks/task_kick_resume.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveTaskKickResume,
+  type KickResumePrevious,
+} from './task_kick_resume';
+
+const SESSION_CREATED_AT = 1_700_000_000_000;
+
+function failedPrevious(
+  overrides?: Partial<KickResumePrevious>,
+): KickResumePrevious {
+  return {
+    status: 'failed',
+    agentId: 'agent-1',
+    harness: 'claude-code',
+    sessionId: 'pa-agent-1',
+    startedAt: SESSION_CREATED_AT + 60_000,
+    agentSessionId: 'conv-abc-123',
+    sessionCreatedAt: SESSION_CREATED_AT,
+    ...overrides,
+  };
+}
+
+const kick = {
+  agentId: 'agent-1',
+  harness: 'claude-code',
+  sessionId: 'pa-agent-1',
+  liveSessionCreatedAt: SESSION_CREATED_AT,
+};
+
+describe('resolveTaskKickResume — provider-rejected conversations', () => {
+  it('a failed predecessor without a provider status resumes its conversation', () => {
+    const plan = resolveTaskKickResume({ previous: failedPrevious(), kick });
+    expect(plan.resume).toBe('conv-abc-123');
+    // Failed shape: the box may hold the only copy of unpublished work.
+    expect(plan.sweep).toBe(false);
+  });
+
+  it('a 404-rejected predecessor starts FRESH on the preserved files', () => {
+    // The transcript itself is what the provider refuses (e.g. an image
+    // block in a text-only model's conversation) — a --resume retry dies on
+    // the same wall in seconds, so the retry must shed the conversation.
+    const plan = resolveTaskKickResume({
+      previous: failedPrevious({ apiErrorStatus: 404 }),
+      kick,
+    });
+    expect(plan.resume).toBeUndefined();
+    expect(plan.sweep).toBe(false);
+    expect(plan.inspectNote).toBe(true);
+  });
+
+  it('transient provider trouble (429) keeps the conversation continuity', () => {
+    const plan = resolveTaskKickResume({
+      previous: failedPrevious({ apiErrorStatus: 429 }),
+      kick,
+    });
+    expect(plan.resume).toBe('conv-abc-123');
+  });
+
+  it('a SETTLED predecessor with a stray status field still resumes', () => {
+    const plan = resolveTaskKickResume({
+      previous: failedPrevious({ status: 'settled', apiErrorStatus: 404 }),
+      kick,
+    });
+    expect(plan.resume).toBe('conv-abc-123');
+    // Settled shape: leftovers are already on task.outputs.
+    expect(plan.sweep).toBe(true);
+  });
+});

--- a/services/platform/convex/tasks/task_kick_resume.ts
+++ b/services/platform/convex/tasks/task_kick_resume.ts
@@ -131,14 +131,20 @@ export function resolveTaskKickResume(args: {
 
   // A predecessor the PROVIDER rejected at the conversation level must not
   // be resumed: the transcript itself is what the model refuses, so every
-  // `--resume` retry dies on the same wall in seconds (observed live: the
-  // agent Read a rendered page image, the text-only serving model's
-  // provider answered 404 "No endpoints found that support image input",
-  // and all three auto-retries burned instantly). A fresh conversation
-  // sheds the refused content; the failed shape above already keeps the box
-  // and points the restart at it. Only 404 — a terminal verdict about WHAT
-  // was sent; transient provider trouble (429/5xx) keeps the continuity.
-  if (previous.status === 'failed' && previous.apiErrorStatus === 404) {
+  // `--resume` retry dies on the same wall in seconds. Both shapes observed
+  // live on one task: the agent Read a rendered page image and the
+  // text-only serving model's provider answered 404 "No endpoints found
+  // that support image input" (three auto-retries burned instantly); and a
+  // thinking-mode assistant message whose `reasoning_content` the dialect
+  // replay drops drew 400 "must be passed back to the API". A fresh
+  // conversation sheds the refused content; the failed shape above already
+  // keeps the box and points the restart at it. Only 400/404 — terminal
+  // verdicts about WHAT was sent; auth/quota/transient trouble
+  // (401/403/429/5xx) keeps the conversation continuity.
+  if (
+    previous.status === 'failed' &&
+    (previous.apiErrorStatus === 404 || previous.apiErrorStatus === 400)
+  ) {
     return fresh;
   }
 

--- a/services/platform/convex/tasks/task_kick_resume.ts
+++ b/services/platform/convex/tasks/task_kick_resume.ts
@@ -29,6 +29,9 @@ export interface KickResumePrevious {
    * on the weaker `createdAt <= startedAt` check (an op row cannot outlive
    * its incarnation — session destroy purges the session's ops). */
   sessionCreatedAt?: number;
+  /** The harness-reported provider HTTP status a FAILED run carried, when
+   * there was one (`markTaskAgentRunFailed` stamps it). */
+  apiErrorStatus?: number;
 }
 
 /** The kick being decided: the CURRENT agent facts + the live session row. */
@@ -125,6 +128,19 @@ export function resolveTaskKickResume(args: {
     previous.status === 'settled'
       ? { sweep: true, inspectNote: false }
       : { sweep: false, inspectNote: true };
+
+  // A predecessor the PROVIDER rejected at the conversation level must not
+  // be resumed: the transcript itself is what the model refuses, so every
+  // `--resume` retry dies on the same wall in seconds (observed live: the
+  // agent Read a rendered page image, the text-only serving model's
+  // provider answered 404 "No endpoints found that support image input",
+  // and all three auto-retries burned instantly). A fresh conversation
+  // sheds the refused content; the failed shape above already keeps the box
+  // and points the restart at it. Only 404 — a terminal verdict about WHAT
+  // was sent; transient provider trouble (429/5xx) keeps the continuity.
+  if (previous.status === 'failed' && previous.apiErrorStatus === 404) {
+    return fresh;
+  }
 
   const handle = previous.agentSessionId;
   if (handle === undefined || !isValidResumeHandle(handle)) return fresh;

--- a/services/platform/lib/harnesses/exec-builder.test.ts
+++ b/services/platform/lib/harnesses/exec-builder.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadHarnesses } from '../../convex/lib/providers/load_system_config';
 import type { HarnessDefinition } from '../shared/schemas/providers';
-import { buildHarnessExec } from './exec-builder';
+import { buildHarnessExec, isClaudeModelRef } from './exec-builder';
 import { GOLDEN_BYO_ENV, GOLDEN_GATEWAY, goldenBattery } from './test-helpers';
 import type { HarnessExec, HarnessRunSpec } from './types';
 
@@ -286,6 +286,18 @@ describe('subscription delivery', () => {
 });
 
 describe('claude reasoning levers scope to Claude models', () => {
+  it.each([
+    [undefined, true],
+    ['default', true],
+    ['claude-opus-4-6', true],
+    ['openrouter/anthropic/claude-sonnet-4.6', true],
+    ['~anthropic/claude-fable-latest', true],
+    ['openrouter/~deepseek/deepseek-v4-flash-latest', false],
+    ['glm-4.7', false],
+  ] as const)('isClaudeModelRef(%j) → %j', (model, expected) => {
+    expect(isClaudeModelRef(model)).toBe(expected);
+  });
+
   // The runtime image floors CLAUDE_CODE_EFFORT_LEVEL=max +
   // CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1; through a gateway's dialect
   // translation that forced effort reaches foreign models and collapses

--- a/services/platform/lib/harnesses/exec-builder.test.ts
+++ b/services/platform/lib/harnesses/exec-builder.test.ts
@@ -284,3 +284,38 @@ describe('subscription delivery', () => {
     expect(withSub).toEqual(without);
   });
 });
+
+describe('claude reasoning levers scope to Claude models', () => {
+  // The runtime image floors CLAUDE_CODE_EFFORT_LEVEL=max +
+  // CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1; through a gateway's dialect
+  // translation that forced effort reaches foreign models and collapses
+  // weak ones (observed live: a 1-completion-token answer at a 42k prompt).
+  it('a non-Claude gateway model gets thinking disabled and no ultrathink prefix', () => {
+    const exec = buildHarnessExec(
+      fact('claude-code'),
+      managedSpec({ model: 'openrouter/~deepseek/deepseek-v4-flash-latest' }),
+    );
+    expect(exec.env.CLAUDE_CODE_DISABLE_THINKING).toBe('1');
+    expect(exec.env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING).toBe('1');
+    expect(exec.stdin ?? '').not.toContain('Ultrathink');
+  });
+
+  it.each([
+    ['vendor-native', 'claude-opus-4-6'],
+    ['gateway path', 'openrouter/anthropic/claude-sonnet-4.6'],
+    ['the CLI default marker', 'default'],
+  ])('a Claude model (%s) keeps the floor and the prefix', (_kind, model) => {
+    const exec = buildHarnessExec(fact('claude-code'), managedSpec({ model }));
+    expect(exec.env.CLAUDE_CODE_DISABLE_THINKING).toBeUndefined();
+    expect(exec.env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING).toBeUndefined();
+    expect(exec.stdin ?? '').toContain('Ultrathink');
+  });
+
+  it('never touches another harness even on a foreign model', () => {
+    const exec = buildHarnessExec(
+      fact('codex'),
+      managedSpec({ model: 'openrouter/~deepseek/deepseek-v4-flash-latest' }),
+    );
+    expect(exec.env.CLAUDE_CODE_DISABLE_THINKING).toBeUndefined();
+  });
+});

--- a/services/platform/lib/harnesses/exec-builder.ts
+++ b/services/platform/lib/harnesses/exec-builder.ts
@@ -64,15 +64,31 @@ function withMaxContext(model: string): string {
   return `${model}[1m]`;
 }
 
+/** True for a Claude model reference in ANY spelling the exec can carry — a
+ * vendor-native id (`claude-*`), a gateway path (`anthropic/claude-…`), a
+ * rolling alias (`~anthropic/claude-…`) — plus the shapes that resolve to
+ * the CLI's own (Claude) default: no model at all, or the literal
+ * `default`. The maximum-reasoning levers below are Claude levers; a
+ * foreign model reached through a gateway's dialect translation does NOT
+ * ignore them (the design assumption of the image's effort floor), and a
+ * weak one collapses under them. Exported for its unit test. */
+export function isClaudeModelRef(model: string | undefined): boolean {
+  if (model === undefined || model === 'default') return true;
+  return model.toLowerCase().includes('claude');
+}
+
 /** Prepend Claude Code's `ultrathink` keyword to the turn prompt so every
  * turn requests maximum reasoning depth. On adaptive-thinking (Opus-class)
  * models the keyword is SAFE: the CLI injects a "reason thoroughly" reminder
  * for the turn — it does NOT set a `budget_tokens` (which would 400 there).
  * Complementary to CLAUDE_CODE_EFFORT_LEVEL=max (the primary depth lever).
- * Default-on; disable with TALE_SANDBOX_ULTRATHINK=0, and skipped when the
- * prompt already contains the keyword. */
-function withUltrathink(prompt: string): string {
+ * Default-on for Claude models; a foreign gateway model is left alone (the
+ * keyword pairs with the forced-effort floor that collapses weak models —
+ * see the env override in `buildHarnessExec`). Disable with
+ * TALE_SANDBOX_ULTRATHINK=0; skipped when the prompt already asks. */
+function withUltrathink(prompt: string, model: string | undefined): string {
   if (process.env.TALE_SANDBOX_ULTRATHINK === '0') return prompt;
+  if (!isClaudeModelRef(model)) return prompt;
   if (/\bultrathink\b/i.test(prompt)) return prompt; // caller already asked
   return `Ultrathink: ${prompt}`;
 }
@@ -549,7 +565,7 @@ export function buildHarnessExec(
     stdin = spec.prompt;
   } else if (exec.stdin.mode === 'ndjson-user-message') {
     const prompt = exec.stdin.promptTransform
-      ? PROMPT_TRANSFORMS[exec.stdin.promptTransform](spec.prompt)
+      ? PROMPT_TRANSFORMS[exec.stdin.promptTransform](spec.prompt, spec.model)
       : spec.prompt;
     stdin = buildStdinUserMessage(prompt);
     // Held open: the platform pushes steer messages as further NDJSON lines
@@ -596,6 +612,22 @@ export function buildHarnessExec(
   }
   for (const [varName, doc] of Object.entries(exec.envDocs ?? {})) {
     env[varName] = JSON.stringify(buildDoc(doc.fragments));
+  }
+  // The runtime image floors CLAUDE_CODE_EFFORT_LEVEL=max +
+  // CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1 for the in-sandbox agent — a
+  // Claude-tuned default whose rationale assumed a foreign model ignores
+  // effort. Through a gateway's dialect translation the forced effort DOES
+  // reach foreign models, and a weak one collapses mid-turn (observed live:
+  // deepseek-flash answering ONE completion token at a 42k-token prompt,
+  // ending its turn between two file reads). For a non-Claude model, turn
+  // the reasoning request OFF for this exec: the explicit disable switches
+  // are the levers the CLI honours regardless of value semantics (the
+  // ALWAYS_ENABLE floor is set-means-on — overriding it to '0' was verified
+  // NOT to strip the effort param on 2.1.173). Per-exec env overrides the
+  // image floor; recognised Claude ids keep full adaptive thinking.
+  if (fact.slug === 'claude-code' && !isClaudeModelRef(spec.model)) {
+    env.CLAUDE_CODE_DISABLE_THINKING = '1';
+    env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = '1';
   }
 
   // -------------------------------------------------------------------------

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6750,9 +6750,12 @@ tasks:
     needsAnswer: Wartet auf deine Antwort
     totalCost: '{amount} gesamt'
     status:
+      queued: Wartet
       running: Läuft
       completed: Abgeschlossen
+      settled: Fertig
       failed: Fehlgeschlagen
+      cancelled: Abgebrochen
       timed_out: Zeitüberschreitung
     trigger:
       assignment: Zuweisung
@@ -6762,6 +6765,7 @@ tasks:
       unblock: entblockt
       decomposition: Aufteilung
       manual: manuell
+      auto_retry: automatische Wiederholung
     refused:
       agent_disabled: Agent ist nicht installiert oder deaktiviert
       agent_not_found: Agent nicht gefunden oder falsch konfiguriert

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6817,9 +6817,12 @@ tasks:
     needsAnswer: Waiting for your answer
     totalCost: '{amount} total'
     status:
+      queued: Queued
       running: Running
       completed: Completed
+      settled: Finished
       failed: Failed
+      cancelled: Cancelled
       timed_out: Timed out
     trigger:
       assignment: assignment
@@ -6829,6 +6832,7 @@ tasks:
       unblock: unblocked
       decomposition: decomposition
       manual: manual
+      auto_retry: auto retry
     refused:
       agent_disabled: agent is not installed or is disabled
       agent_not_found: agent not found or misconfigured

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6865,9 +6865,12 @@ tasks:
     needsAnswer: En attente de ta réponse
     totalCost: '{amount} au total'
     status:
+      queued: En attente
       running: En cours
       completed: Terminé
+      settled: Terminée
       failed: Échoué
+      cancelled: Annulée
       timed_out: Délai dépassé
     trigger:
       assignment: assignation
@@ -6877,6 +6880,7 @@ tasks:
       unblock: débloqué
       decomposition: décomposition
       manual: manuel
+      auto_retry: relance automatique
     refused:
       agent_disabled: l'agent n'est pas installé ou est désactivé
       agent_not_found: agent introuvable ou mal configuré

--- a/services/platform/scripts/dev-engine.ts
+++ b/services/platform/scripts/dev-engine.ts
@@ -311,6 +311,27 @@ function loadEnvFiles() {
     delete mergedEnv.SANDBOX_URL;
   }
 
+  // And for the in-sandbox backend origin: `convex` is the RETIRED 0.4
+  // alias — the 0.5 sandbox net serves the backend as `backend-api` (the
+  // socat relay on a host run, the api container itself under compose), so
+  // a `http://convex:3211` left in a dotenv file dead-ends every staging
+  // fetch and bridge call. Drop it so the host default below applies.
+  const retiredConvexAlias = (value: string | undefined): boolean =>
+    value !== undefined &&
+    URL.canParse(value) &&
+    new URL(value).hostname === 'convex';
+  if (retiredConvexAlias(process.env.SANDBOX_HTTP_API_BASE_URL)) {
+    warnLine(
+      `SANDBOX_HTTP_API_BASE_URL=${process.env.SANDBOX_HTTP_API_BASE_URL} ` +
+        `names the retired 0.4 \`convex\` alias — ignoring it (the 0.5 ` +
+        `sandbox net serves the backend as backend-api).`,
+    );
+    delete process.env.SANDBOX_HTTP_API_BASE_URL;
+  }
+  if (retiredConvexAlias(mergedEnv.SANDBOX_HTTP_API_BASE_URL)) {
+    delete mergedEnv.SANDBOX_HTTP_API_BASE_URL;
+  }
+
   // Pre-existing process.env wins over .env files — only fill the gaps.
   let loadedCount = 0;
   let skippedCount = 0;

--- a/services/platform/scripts/dev-engine.ts
+++ b/services/platform/scripts/dev-engine.ts
@@ -288,6 +288,29 @@ function loadEnvFiles() {
     }
   }
 
+  // Same guard for the spawner URL: `http://sandbox:8003` is the in-compose
+  // alias (compose and the platform entrypoint default it themselves), and
+  // `sandbox` resolves only on the compose network. A host backend
+  // inheriting it dies on every agent start with `TypeError: fetch failed`
+  // (getaddrinfo ENOTFOUND sandbox) — drop it so session_client's host
+  // default (http://localhost:8003) applies.
+  const composeOnlySandboxUrl = (value: string | undefined): boolean =>
+    !existsSync('/app') &&
+    value !== undefined &&
+    URL.canParse(value) &&
+    new URL(value).hostname === 'sandbox';
+  if (composeOnlySandboxUrl(process.env.SANDBOX_URL)) {
+    warnLine(
+      `SANDBOX_URL=${process.env.SANDBOX_URL} is the in-compose alias ` +
+        `(repo-root .env serves docker compose) — ignoring it for this ` +
+        `host run.`,
+    );
+    delete process.env.SANDBOX_URL;
+  }
+  if (composeOnlySandboxUrl(mergedEnv.SANDBOX_URL)) {
+    delete mergedEnv.SANDBOX_URL;
+  }
+
   // Pre-existing process.env wins over .env files — only fill the gaps.
   let loadedCount = 0;
   let skippedCount = 0;

--- a/services/sandbox/src/session/docker-session-args.test.ts
+++ b/services/sandbox/src/session/docker-session-args.test.ts
@@ -80,9 +80,11 @@ describe('buildDockerSessionRunArgs', () => {
     expect(args).toContain('--cap-drop=ALL');
     expect(args).toContain('--read-only');
     expect(args).toContain('no-new-privileges');
-    // Gateway + convex http-actions reachable directly (not via tinyproxy).
+    // Gateway + backend origin reachable directly (not via tinyproxy) —
+    // `backend-api` is the bridge/staging host; the retired aliases stay
+    // one release for in-flight sessions.
     expect(args).toContain(
-      'NO_PROXY=127.0.0.1,localhost,sandbox-llm-gateway,llm-gateway,convex',
+      'NO_PROXY=127.0.0.1,localhost,sandbox-llm-gateway,llm-gateway,backend-api,backend-relay,convex',
     );
     // Runnerd token in env.
     expect(args).toContain(`TALE_RUNNERD_TOKEN=${'a'.repeat(64)}`);

--- a/services/sandbox/src/session/docker-session-args.ts
+++ b/services/sandbox/src/session/docker-session-args.ts
@@ -365,17 +365,18 @@ export function buildDockerSessionRunArgs(
     `HTTPS_PROXY=${cfg.egressProxy}`,
     '--env',
     `HTTP_PROXY=${cfg.egressProxy}`,
-    // Session execs reach the LLM gateway (sandbox-llm-gateway) and the convex
-    // http-actions (the in-sandbox connector bridge → /api/connectors/*)
-    // directly on the internal bridge — not through tinyproxy. The agent adapters
-    // set ANTHROPIC_BASE_URL at the gateway and the bridge calls http://convex:3211,
-    // so both must be in NO_PROXY or the CONNECT would be denied. If
-    // EXTERNAL_AGENT_CONNECTORS_URL overrides the host, this list must match.
-    // The old `llm-gateway` alias is kept for one release so in-flight sessions
-    // pinned to the pre-rename hostname keep resolving (see the transitional
-    // network alias in compose.yml).
+    // Session execs reach the LLM gateway (sandbox-llm-gateway) and the
+    // backend origin (the in-sandbox connector bridge → /api/connectors/*,
+    // the staging callback) directly on the internal bridge — not through
+    // tinyproxy. The agent adapters set ANTHROPIC_BASE_URL at the gateway
+    // and the bridge calls http://backend-api:3005, so both must be in
+    // NO_PROXY or the CONNECT would be denied. If
+    // EXTERNAL_AGENT_CONNECTORS_URL overrides the host, this list must
+    // match. The retired 0.4 `convex` alias and the old `llm-gateway` alias
+    // stay for one release so in-flight sessions pinned to pre-rename
+    // hostnames keep resolving.
     '--env',
-    `NO_PROXY=127.0.0.1,localhost,sandbox-llm-gateway,llm-gateway,convex`,
+    `NO_PROXY=127.0.0.1,localhost,sandbox-llm-gateway,llm-gateway,backend-api,backend-relay,convex`,
     // Per-org shared dep caches (empty under DinD — see cacheEnv above).
     ...cacheEnv,
     // HOME on the persistent workspace volume so agent state (~/.claude,


### PR DESCRIPTION
## Problem

Assigning a task to a project agent and clicking Start (reported on demo05.tale.dev at 0.5.4, reproduced locally):

1. the task never moved to **In progress**, and
2. the run panel sat on *"The agent produced no log for this run."* with a spinner, forever.

Underneath, every real turn also **died after its first drive window**, @-mentioning an idle agent in a comment did nothing, and any run whose task carried attachments or prior deliverables failed at staging. Six stacked 0.5 migration drops, fixed bottom-up across four commits.

## Root causes and fixes

**1. The manual kick lost 0.4's status write** ("the board verb IS the interface"). `startTaskAgentRunManual` now routes a not-in-progress task through `updateTaskStatus` — flip + kick in ONE transaction with the full choreography; a live run answers `already_running` before any move. Beyond the visible symptom, the auto-retry guard requires `task.status = 'in_progress'`, so a manually kicked run that failed could never auto-retry.

**2. The run card and live-transcript reads never refreshed.** 0.4 had Convex reactivity; 0.5's HTTP lane refreshes by `refetchInterval` — the automation twin polls at 2s, the two task rows had neither polling nor a hint emitter behind them. Both now poll at 2s, mirroring the automation precedent.

**3. The task jobs built their ctx shim with no scheduler seam.** The reused turn host self-chains via `ctx.scheduler.runAfter`; the first re-schedule threw and the start's catch settled a WORKING turn as "could not start". New `taskAgentShimScheduler` maps the drive continuation and the steer retry ladder onto their pg-boss jobs; `driveSchema` now carries `sessionCreatedAt` instead of silently stripping the incarnation stamp. The turn-drive itest cannot catch a missing seam (its fake harness ends in one terminal window), so a direct seam probe locks the mapping.

**4. The idle-agent comment-mention kick was never ported.** 0.4's comment door put a mentioned instance to work; 0.5 kept only the steer branch. `dispatchMentionedProjectAgent` restores the full wire: the FIRST mentioned instance of the task's project steers its RUNNING run, stays quiet for a queued run or any other live engine (never reassigning under one), and otherwise (re)assigns the task via `assignTask` and kicks a 'mention' run with the comment as feedback — the kick moves the card. Write-gated, quiet refusals, agent authors never dispatch. The card move is the shared `handTaskToInProgressForKick` (review gate withdrawn, terminal `completedAt` cleared), reused by the steer-miss kick.

**5. `/api/sandbox-blob` was never served by the 0.5 backend.** `buildSandboxBlobStageUrl` minted URLs to the dropped 0.4 httpAction, so EVERY org-bucket staging (task attachments, prior deliverables) failed the run with "staging task inputs failed". Ported onto the backend origin (`domains/files/sandbox-blob-routes.ts`): stage-token verify → org-namespace check (`s3KeyBelongsToOrg`) → server-side presign → stream through. Staging failures now carry each file's skip REASON at all three staging sites.

**6. `convex:3211` / compose-alias vestiges poisoned host dev.** The 0.5 sandbox net serves the backend as `backend-api:3005` (compose: api dual-homed; host dev: the backend-relay socat — no `convex` alias exists any more). The bridge/stage/hostcall URL defaults all move there; dev-engine scrubs a `convex`-host `SANDBOX_HTTP_API_BASE_URL` and an in-compose `SANDBOX_URL` from dotenv files the way it already scrubs container-only paths; the session containers' NO_PROXY gains `backend-api`/`backend-relay` (retired aliases kept one release). The 0.4-era timeline message tree also learns the 0.5 enums (`status.queued/settled/cancelled`, `trigger.auto_retry`) in en/de/fr.

## Proof

- itest **272/272** — eight new probes: the manual kick flips the card in-transaction and answers `already_running` second; the steer-miss kick pulls the card off In review with its gate withdrawn; the scheduler seam maps both self-chained refs and throws on an unmapped one; an idle instance's mention reassigns + kicks + moves the card; a queued run's mention stays quiet; an agent's own comment dispatches nothing; a live automation run blocks the kick; the sandbox-blob door streams the blob for a valid token, answers 403 to a forgery and 404 to a validly signed foreign-namespace key.
- Platform vitest (72k tests), sandbox unit suite, and both workspace typechecks green.
- Live E2E on the dev stack, twice over: (a) Retry → card moves to In progress → live transcript grows in the open dialog → run settles → task at In review with the harvested docx attached and the agent's report as a comment; (b) an `@Alice` comment on that in_review task → pending review gate withdrawn + card back to In progress + 'mention' run → the prior deliverable staged through the new door → the turn ran on the feedback → settled back to In review.


## Round 3 — why a "simple task" kept dying mid-turn (three more fixes)

Live diagnosis on a resumed deepseek-flash conversation surfaced three stacked causes, each verified against the gateway's own request log:

**7. The Claude reasoning levers were forced onto every model.** The sandbox image floors `CLAUDE_CODE_EFFORT_LEVEL=max` + `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` and every prompt got the ultrathink prefix (#2271, "a model without effort support just ignores it"). Through the gateway's anthropic-dialect translation the effort DOES reach foreign models as `reasoning:{effort:"max"}` — and deepseek-flash collapsed to **one-completion-token responses** at long prompts, silently ending turns mid-work. Non-Claude model refs now get the CLI's explicit thinking-disable switches per exec and no ultrathink prefix (the `ALWAYS_ENABLE` floor is set-means-on; `'0'` was verified NOT to strip the param). Verified live: the next turn's requests carry no reasoning field.

**8. A report-less "successful" end settled the task as reviewed.** The bare-EOS end above was treated as a completed turn: the mid-work narration became the agent's report and the half-done task parked at **In review**. A successful terminal window with no `finalText` (every parser sets it only from real final text) now fails the run with the retryable `empty_turn` code — handle stamped, auto-retry resumes the same conversation and asks it to continue. itest drives the scenario end-to-end against a canned empty-result turn.

**9. A provider-rejected conversation was resumed into a guaranteed wall.** The agent Read a page image it had rendered to check its own work; the text-only model's provider then answered **404 "No endpoints found that support image input"** to every subsequent request — including all three auto-retries, which `--resume`d the same poisoned transcript and died in seconds each ("There's an issue with the selected model"). `resolveTaskKickResume` now starts FRESH when the failed predecessor carries a harness-reported 404 (sheds the refused content, keeps the delivery box + restart note); 429/5xx keep continuity. Verified live: Retry on the poisoned task launched without `--resume` and worked on.

(The vision polyfill is the designed answer for the image itself; it could not arm because the org provider's model allowlist carries no vision-capable model — an org-config gap surfaced to the operator, not a code path.)

Final gates on the pushed head: itest **273/273**, platform vitest green, harness suite 115 green (goldens byte-stable for Claude models), both typechecks green.
