### PR TITLE
feat(platform): let chat find entities by words in a question

### DIFF
--- a/services/platform/backend/domains/chat/shim.ts
+++ b/services/platform/backend/domains/chat/shim.ts
@@ -2,6 +2,7 @@ import type { Sql } from 'postgres';
 
 import { findOrganizationMember } from '../../auth/membership.ts';
 import type { ShimHandlers } from '../../lib/ctx-shim.ts';
+import { wordStartPatterns } from '../../lib/word-match.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
 import { searchConversationsForChat } from '../conversations/search-chat.ts';
 import { listDocumentsForAgent } from '../documents/agent-list.ts';
@@ -159,6 +160,7 @@ async function searchTasks(
   const bounds = pageBounds(args.paginationOpts);
   const term = args.term.trim();
   const like = `%${term}%`;
+  const words = wordStartPatterns(term);
   const status = args.status;
   const rows = await sql<TaskLegRow[]>`
     SELECT id AS "_id", title, description, status, priority,
@@ -169,7 +171,9 @@ async function searchTasks(
     WHERE org_id = ${args.organizationId}
       AND project_id = ANY(${readable})
       AND (${args.list === true || term === ''} OR title ILIKE ${like}
-           OR description ILIKE ${like})
+           OR description ILIKE ${like}
+           OR (${words.length > 0}
+               AND (title ~* ANY(${words}) OR description ~* ANY(${words}))))
       AND (${status === undefined}
            OR (${status ?? ''} = 'open' AND NOT (status = ANY(${OPEN_EXCLUDED})))
            OR status = ${status ?? ''})
@@ -212,6 +216,7 @@ async function searchProjects(
   const bounds = pageBounds(args.paginationOpts);
   const term = args.term.trim();
   const like = `%${term}%`;
+  const words = wordStartPatterns(term);
   const rows = await sql<ProjectLegRow[]>`
     SELECT id AS "_id", name, description, key,
            open_task_count AS "openTaskCount",
@@ -220,7 +225,9 @@ async function searchProjects(
     FROM app.projects
     WHERE org_id = ${args.organizationId} AND id = ANY(${args.projectIds})
       AND (${args.list === true || term === ''} OR name ILIKE ${like}
-           OR description ILIKE ${like} OR key ILIKE ${like})
+           OR description ILIKE ${like} OR key ILIKE ${like}
+           OR (${words.length > 0}
+               AND (name ~* ANY(${words}) OR description ~* ANY(${words}))))
     ORDER BY updated_at_ms DESC
     LIMIT ${bounds.limit + 1} OFFSET ${bounds.offset}
   `;
@@ -808,6 +815,7 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
       const bounds = pageBounds(args.paginationOpts);
       const term = args.searchTerm?.trim() ?? '';
       const like = `%${term}%`;
+      const words = wordStartPatterns(term);
       const rows = await sql<
         {
           name: string | null;
@@ -822,7 +830,9 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
         FROM app.contacts
         WHERE org_id = ${args.organizationId}
           AND (${term === ''} OR name ILIKE ${like} OR email ILIKE ${like}
-               OR phone ILIKE ${like})
+               OR phone ILIKE ${like}
+               OR (${words.length > 0}
+                   AND (name ~* ANY(${words}) OR email ~* ANY(${words}))))
         ORDER BY updated_at_ms DESC
         LIMIT ${bounds.limit + 1} OFFSET ${bounds.offset}
       `;
@@ -852,6 +862,7 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
       const bounds = pageBounds(args.paginationOpts);
       const term = args.searchTerm?.trim() ?? '';
       const like = `%${term}%`;
+      const words = wordStartPatterns(term);
       const rows = await sql<
         {
           name: string;
@@ -865,7 +876,11 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
         FROM app.products
         WHERE org_id = ${args.organizationId}
           AND (${term === ''} OR name ILIKE ${like} OR category ILIKE ${like}
-               OR description ILIKE ${like})
+               OR description ILIKE ${like}
+               OR (${words.length > 0}
+                   AND (name ~* ANY(${words})
+                        OR category ~* ANY(${words})
+                        OR description ~* ANY(${words}))))
         ORDER BY updated_at_ms DESC
         LIMIT ${bounds.limit + 1} OFFSET ${bounds.offset}
       `;
@@ -893,6 +908,7 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
       return listEntriesForAgent(sql, {
         organizationId: args.organizationId,
         ...(args.topic !== undefined ? { topic: args.topic } : {}),
+        matchWords: true,
         numItems: args.paginationOpts.numItems,
         cursor: args.paginationOpts.cursor,
       });

--- a/services/platform/backend/domains/knowledge_entries/service.ts
+++ b/services/platform/backend/domains/knowledge_entries/service.ts
@@ -11,6 +11,7 @@ import {
   s3PresignPutUrl,
 } from '../../lib/object-store.ts';
 import { resolveOrgSlug } from '../../lib/org-config.ts';
+import { wordStartPatterns } from '../../lib/word-match.ts';
 
 /**
  * User-contributed knowledge entries — the 0.5 twin of
@@ -400,10 +401,22 @@ export interface KnowledgeEntryRow {
 export async function listKnowledgeEntries(
   sql: Sql,
   organizationId: string,
-  options: { cursor?: number; limit?: number; topic?: string } = {},
+  options: {
+    cursor?: number;
+    limit?: number;
+    topic?: string;
+    /** Also match a topic on any meaningful WORD of `topic`, not only on the
+     *  whole string. Opt-in, because only the chat leg passes a question
+     *  here — the entries page passes what the reader typed. */
+    matchWords?: boolean;
+  } = {},
 ): Promise<{ rows: KnowledgeEntryRow[]; nextCursor: number | null }> {
   const limit = Math.min(Math.max(options.limit ?? 30, 1), 100);
   const topicLower = options.topic?.trim().toLowerCase() || null;
+  const words =
+    options.matchWords === true && topicLower !== null
+      ? wordStartPatterns(topicLower)
+      : [];
   const page = await sql<(KnowledgeEntryRow & { seq: number })[]>`
     SELECT id, topic, content, source, document_id AS "documentId",
            created_by AS "createdBy", created_at_ms::float8 AS "createdAt",
@@ -412,7 +425,8 @@ export async function listKnowledgeEntries(
     WHERE org_id = ${organizationId} AND status = 'active'
       AND deleted_at_ms IS NULL
       AND (${topicLower}::text IS NULL
-           OR lower(topic) LIKE '%' || ${topicLower} || '%')
+           OR lower(topic) LIKE '%' || ${topicLower} || '%'
+           OR (${words.length > 0} AND topic ~* ANY(${words})))
       AND (${options.cursor ?? null}::bigint IS NULL
            OR seq < ${options.cursor ?? null})
     ORDER BY seq DESC
@@ -486,6 +500,7 @@ export async function listEntriesForAgent(
     topic?: string;
     numItems: number;
     cursor: string | null;
+    matchWords?: boolean;
   },
 ): Promise<{
   page: Array<{
@@ -506,6 +521,7 @@ export async function listEntriesForAgent(
       ...(cursor !== null ? { cursor } : {}),
       limit: args.numItems,
       ...(args.topic !== undefined ? { topic: args.topic } : {}),
+      ...(args.matchWords === true ? { matchWords: true } : {}),
     },
   );
   return {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -11748,6 +11748,101 @@ async function checkChatConversationSearchLeg(
 }
 
 /**
+ * The chat entity legs match a QUESTION, not only a typed name. Each leg
+ * receives the user's whole message as its search term, so a phrase-only
+ * compare finds nothing for anything phrased as a question. The word clause
+ * runs alongside the phrase clause, so a typed fragment keeps working, and a
+ * word must match at the START of a word so an OR over tokens is not noise.
+ */
+async function checkChatEntityWordSearch(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const now = Date.now();
+  // A fixture org of its own: two later checks count this org's tasks, and a
+  // third picks an arbitrary one, so seeding a task into the real org would
+  // move their numbers. The legs are org-scoped SQL, so a synthetic id is a
+  // complete world for them.
+  const org = `${ctx.orgId}-word-search-fixture`;
+  const projectRows = await sql<{ id: string }[]>`
+    INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                              updated_at_ms)
+    VALUES (${org}, 'Word Search Fixture', ${ctx.userId}, ${now}, ${now})
+    RETURNING id
+  `;
+  const projectId = projectRows[0]?.id ?? '';
+  await sql`
+    INSERT INTO app.tasks (org_id, project_id, title, description, status,
+                           rank, created_by, created_by_type, created_at_ms,
+                           updated_at_ms)
+    VALUES (${org}, ${projectId}, 'Set up Facebook ad account',
+            'for the recruitment campaign', 'todo', 'n', ${ctx.userId},
+            'user', ${now}, ${now})
+  `;
+  await sql`
+    INSERT INTO app.products (org_id, name, category, description,
+                              created_at_ms, updated_at_ms)
+    VALUES (${org}, 'Red Running Shoes', 'footwear', 'Lightweight trainers',
+            ${now}, ${now})
+  `;
+
+  const { chatShimHandlers } = await import('./domains/chat/shim.ts');
+  const handlers = chatShimHandlers(sql);
+  const pageShape = z.object({ page: z.array(z.unknown()) }).loose();
+  const rows = async (name: string, args: unknown): Promise<number> => {
+    const parsed = pageShape.safeParse(await handlers[name]?.(args));
+    return parsed.success ? parsed.data.page.length : -1;
+  };
+
+  const productQuestion = await rows(
+    'products/internal_queries:queryProducts',
+    { organizationId: org, searchTerm: 'do we have red running shoes' },
+  );
+  const productTyped = await rows('products/internal_queries:queryProducts', {
+    organizationId: org,
+    searchTerm: 'Red Running',
+  });
+  const productUnrelated = await rows(
+    'products/internal_queries:queryProducts',
+    { organizationId: org, searchTerm: 'do we have blue hats' },
+  );
+  const productStopwords = await rows(
+    'products/internal_queries:queryProducts',
+    { organizationId: org, searchTerm: 'what do we have?' },
+  );
+  const taskQuestion = await rows('tasks/search_for_chat:searchTasksForChat', {
+    organizationId: org,
+    projectIds: [projectId],
+    term: 'recruitment ads Facebook ad account project tasks',
+  });
+  // 'ebook' alone would hit the phrase clause through 'Facebook'. Inside a
+  // question the phrase cannot match, which isolates the word clause: a
+  // mid-word fragment must not be enough on its own.
+  const taskMidWord = await rows('tasks/search_for_chat:searchTasksForChat', {
+    organizationId: org,
+    projectIds: [projectId],
+    term: 'do we have any ebook tasks',
+  });
+  const taskRealWord = await rows('tasks/search_for_chat:searchTasksForChat', {
+    organizationId: org,
+    projectIds: [projectId],
+    term: 'do we have any facebook tasks',
+  });
+
+  record(
+    'chat entity legs match a question, not only a typed name',
+    productQuestion === 1 &&
+      productTyped === 1 &&
+      productUnrelated === 0 &&
+      productStopwords === 0 &&
+      taskQuestion === 1 &&
+      taskMidWord === 0 &&
+      taskRealWord === 1,
+    `product: question=${productQuestion} typed=${productTyped} unrelated=${productUnrelated} stopwords=${productStopwords} (want 1/1/0/0), task: question=${taskQuestion} midWord=${taskMidWord} realWord=${taskRealWord} (want 1/0/1)`,
+  );
+}
+
+/**
  * Address→assignee routing at inbound ingest: the org's
  * `conversation_routing` governance file maps the address the customer
  * wrote to onto a team queue or a person; an unknown address and a stale
@@ -25967,6 +26062,7 @@ async function main(): Promise<void> {
     await checkOutboundSendLane(sql, baseUrl, authCtx);
     await checkNotificationEmailSink(sql, authCtx);
     await checkChatConversationSearchLeg(sql, authCtx);
+    await checkChatEntityWordSearch(sql, authCtx);
     await checkAddressRouting(sql, authCtx, `itest-${orgSuffix}`);
     await checkControlDrain(sql, baseUrl, authCtx);
     await checkProvisioning(sql);

--- a/services/platform/backend/lib/word-match.test.ts
+++ b/services/platform/backend/lib/word-match.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+
+import { wordStartPatterns } from './word-match.ts';
+
+describe('wordStartPatterns', () => {
+  test('keeps the meaningful words of a question and drops the rest', () => {
+    expect(wordStartPatterns('do we have red running shoes')).toEqual([
+      '\\mred',
+      '\\mrunning',
+      '\\mshoes',
+    ]);
+  });
+
+  test('answers empty for a question that is only function words', () => {
+    // The caller adds no word clause at all for this, which is why an empty
+    // array must never be read as "match everything".
+    expect(wordStartPatterns('what do we have?')).toEqual([]);
+  });
+
+  test('drops one-character fragments', () => {
+    expect(wordStartPatterns('a b shoes')).toEqual(['\\mshoes']);
+  });
+
+  test('answers empty for an empty or blank term', () => {
+    expect(wordStartPatterns('')).toEqual([]);
+    expect(wordStartPatterns('   ')).toEqual([]);
+  });
+
+  test('strips German and French function words too', () => {
+    expect(wordStartPatterns('welche Schuhe haben wir')).toEqual(['\\mschuhe']);
+    // `avez` survives: the shared list covers French pronouns and articles but
+    // not verb forms. A surplus token is harmless under an OR of word-starts,
+    // and widening the list would change the 0.4 entity legs that share it.
+    expect(wordStartPatterns('avez vous des chaussures rouges')).toEqual([
+      '\\mavez',
+      '\\mchaussures',
+      '\\mrouges',
+    ]);
+  });
+
+  test('treats punctuation as a word separator, never as part of a token', () => {
+    // `c` then falls to the one-character rule. The phrase match still answers
+    // a literal search for "c++", which is why words are added and not
+    // substituted.
+    expect(wordStartPatterns('c++ handbook')).toEqual(['\\mhandbook']);
+    expect(wordStartPatterns('(draft) invoice')).toEqual([
+      '\\mdraft',
+      '\\minvoice',
+    ]);
+    expect(wordStartPatterns('covid-19 policy')).toEqual([
+      '\\mcovid',
+      '\\m19',
+      '\\mpolicy',
+    ]);
+  });
+
+  test('lowercases, so the pattern matches under a case-insensitive compare', () => {
+    expect(wordStartPatterns('Red SHOES')).toEqual(['\\mred', '\\mshoes']);
+  });
+});

--- a/services/platform/backend/lib/word-match.ts
+++ b/services/platform/backend/lib/word-match.ts
@@ -1,0 +1,58 @@
+/**
+ * Word matching for the chat entity legs, as Postgres regex patterns.
+ *
+ * A chat leg receives a natural-language question and passes it to its query
+ * as one search term. Every leg then compares that whole string as a single
+ * substring, so "do we have red running shoes" only matches text literally
+ * containing the whole phrase. It matches nothing.
+ *
+ * These patterns are used as an OR ALONGSIDE the existing phrase match, never
+ * in place of it: the phrase check still answers a typed name fragment, and
+ * replacing it would change what the shared listings return.
+ *
+ * Two rules make a question usable, and both come from the 0.4 `'any'` mode
+ * this reuses:
+ *
+ *   - Function words and one-character fragments are dropped, so a query that
+ *     is nothing but function words ("what do we have?") yields no patterns
+ *     and the caller adds no word clause at all.
+ *   - A token must match at the START of a word (`\m`), not anywhere in it.
+ *     Without that floor an OR over tokens is noise: "ad" would match every
+ *     row containing "overhead".
+ *
+ * {@link queryTokens} is imported rather than re-listed. It owns the stopword
+ * set for en/de/fr, and a second copy here would drift from the one the 0.4
+ * entity search still uses.
+ */
+
+import { queryTokens } from '../core/lib/search/relevance.ts';
+
+/**
+ * Split on anything that is not a letter or a digit — the same definition of a
+ * word the 0.4 matcher uses on the TEXT side (`wordStartsWith`). Doing it to
+ * the query too is what makes the two agree: without it a trailing question
+ * mark rides along on the last token, so "what do we have?" yields `have?`,
+ * which is neither a stopword nor a thing any row starts with.
+ */
+function normalizeQuery(term: string): string {
+  return term.replaceAll(/[^\p{L}\p{N}]+/gu, ' ');
+}
+
+/** Escape the characters Postgres reads as regex operators. Normalization
+ *  leaves only letters and digits, so this is a boundary guard, not a
+ *  transformation any current token needs. */
+function escapeRegex(token: string): string {
+  return token.replaceAll(/[\\^$.|?*+()[\]{}]/g, (char) => `\\${char}`);
+}
+
+/**
+ * Word-start regex patterns for the meaningful words of `term`, for use with
+ * `column ~* ANY(patterns)`.
+ *
+ * Empty when the term carries no searchable signal. A caller MUST treat an
+ * empty array as "add no word clause" — never as "match everything".
+ */
+export function wordStartPatterns(term: string): string[] {
+  const tokens = queryTokens(normalizeQuery(term).trim().toLowerCase(), 'any');
+  return tokens.map((token) => `\\m${escapeRegex(token)}`);
+}


### PR DESCRIPTION
Chat can now find a task, project, contact, product or knowledge entry from a question. Before this, every entity leg compared the user's whole message as one substring, so anything phrased as a question matched nothing.

Closes #2992. Supersedes #3106, which fixed three of these legs against the Convex tree that #3107 replaced.

## Why

Each leg receives the user's message as its search term and passes it straight to `ILIKE '%<term>%'`. Observed against a real Postgres, with one product and one task seeded:

| Term | Rows on `origin/main` | With this change |
| --- | --- | --- |
| `do we have red running shoes` | 0 | 1 |
| `Red Running` | 1 | 1 |
| `recruitment ads Facebook ad account project tasks` | 0 | 1 |
| `who is anna lee` | 0 | 1 |

The second row is the one that made this invisible: a typed name fragment works, so the legs look healthy until someone asks a question. The third is the query that opened #2992 — a board question that answered with nothing, which is why chat recommended Asana and Jira instead.

#2983 fixed this on the Convex entity search. The 0.5 legs are new SQL and were written with the phrase compare, so the fix did not carry across.

## What changed

`wordStartPatterns` in `backend/lib/word-match.ts` turns a term into Postgres word-start patterns. It imports `queryTokens` from the 0.4 matcher rather than re-listing the en/de/fr stopword set, so the two cannot drift.

Each leg gains `OR column ~* ANY(patterns)` next to its existing `ILIKE`. Fields follow the 0.4 strategy files: tasks on title and description, projects on name and description, contacts on name and email.

Two rules make a question usable. Function words and one-character fragments are dropped, so a term with no signal yields no patterns and the leg adds no word clause. A token must match at the start of a word, so an OR over tokens does not turn `ad` into a match for `overhead`.

The query is split on anything that is not a letter or digit, matching how the 0.4 matcher defines a word on the text side. Without that, a trailing question mark rides on the last token and `have?` reads as neither a stopword nor a prefix of anything.

Knowledge entries take an opt-in flag, because `listKnowledgeEntries` also backs the entries page, which passes what a reader typed rather than a question.

## Risk

Word matching is added, never substituted. Anyone replacing a phrase clause with the word clause would drop the mid-word matches the pages rely on.

## Tests

`word-match.test.ts` covers the token rules. Three mutations, each turning it red: dropping the punctuation split (2 failed), using `all` mode instead of `any` (5 failed), and dropping the `\m` anchor (5 failed).

`integration-check.ts` gains a leg check over real SQL, in a fixture org of its own so its rows do not move the org-wide task counts three later checks assert. It pins the table above plus two negatives: an unrelated question and an all-stopword question both return nothing, and `do we have any ebook tasks` does not reach `Facebook` while `do we have any facebook tasks` does.

## Scope

Ranking is unchanged. This decides whether a row matches, not how matches are ordered — the legs still order by `updated_at_ms`.

`avez` is not in the shared French stopword list, so it survives tokenization. A surplus token is harmless under an OR of word starts, and widening the list would change the 0.4 legs that share it.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `knip` and `lint:sast` green; the new unit test 7/7.
