### PR TITLE
fix(platform): shim the credential broker for work-lane agent turns

### DIFF
--- a/services/platform/backend/domains/connector_credentials/service.ts
+++ b/services/platform/backend/domains/connector_credentials/service.ts
@@ -694,6 +694,32 @@ export interface ResolvedConnectorCredential {
   authHeader?: string;
 }
 
+/** The addressed row (explicit id-or-name ref, else the pair's default), or
+ * null on a miss — the 0.4 `resolveCredentialRefInternal` contract the work
+ * lanes' ctx shim serves to the reused credential broker. */
+export async function findCredentialForRef(
+  sql: Sql,
+  args: {
+    organizationId: string;
+    connectorSlug: string;
+    credentialRef?: string;
+  },
+): Promise<CredentialRow | null> {
+  const rows = await rowsForConnector(
+    sql,
+    args.organizationId,
+    args.connectorSlug,
+  );
+  if (args.credentialRef === undefined) {
+    return rows.find((row) => row.isDefault) ?? null;
+  }
+  const ref = args.credentialRef.trim();
+  const byId = rows.find((row) => row.id === ref);
+  if (byId) return byId;
+  const needle = ref.toLowerCase();
+  return rows.find((row) => row.name.toLowerCase() === needle) ?? null;
+}
+
 /** Load the addressed row (explicit id-or-name ref, else the default). */
 async function loadRowForResolve(
   sql: Sql,
@@ -703,26 +729,15 @@ async function loadRowForResolve(
     credentialRef?: string;
   },
 ): Promise<CredentialRow> {
-  const rows = await rowsForConnector(
-    sql,
-    args.organizationId,
-    args.connectorSlug,
-  );
+  const row = await findCredentialForRef(sql, args);
+  if (row) return row;
   if (args.credentialRef === undefined) {
-    const fallback = rows.find((row) => row.isDefault);
-    if (fallback) return fallback;
     throw new ConnectorCredentialError(
       'CREDENTIAL_NONE_CONFIGURED',
       `No default credential is configured for "${args.connectorSlug}" — add one in Settings → Connectors, or name a credential explicitly.`,
       404,
     );
   }
-  const ref = args.credentialRef.trim();
-  const byId = rows.find((row) => row.id === ref);
-  if (byId) return byId;
-  const needle = ref.toLowerCase();
-  const byName = rows.find((row) => row.name.toLowerCase() === needle);
-  if (byName) return byName;
   throw new ConnectorCredentialError(
     'CREDENTIAL_NOT_FOUND',
     `No credential "${args.credentialRef}" is configured for "${args.connectorSlug}" — check the name, or add it in Settings → Connectors.`,

--- a/services/platform/backend/domains/sandbox/shim.test.ts
+++ b/services/platform/backend/domains/sandbox/shim.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { agentTurnShimHandlers } from '../tasks/agent-turn-shim.ts';
 import { sandboxToolShimHandlers } from './shim.ts';
 
 /**
@@ -52,10 +53,12 @@ function resolveImport(fromFile: string, specifier: string): string | null {
 
 /** Every `internal.a.b.c` the entry points can reach, as shim names
  * (`a/b:c`), mapped to the modules that name them. */
-function reachableHandlerNames(): Map<string, Set<string>> {
+function reachableHandlerNames(
+  entryPoints: readonly string[] = ENTRY_POINTS,
+): Map<string, Set<string>> {
   const names = new Map<string, Set<string>>();
   const visited = new Set<string>();
-  const queue = ENTRY_POINTS.map((entry) => path.join(BACKEND, entry));
+  const queue = entryPoints.map((entry) => path.join(BACKEND, entry));
   while (queue.length > 0) {
     const file = queue.pop();
     if (file === undefined || visited.has(file)) continue;
@@ -104,6 +107,43 @@ describe('sandboxToolShimHandlers', () => {
         'tasks/internal_queries:listTasksForAgent',
         'documents/internal_actions:storeRawContent',
         'file_metadata/internal_mutations:linkDocumentToFile',
+      ]),
+    );
+  });
+});
+
+describe('agentTurnShimHandlers', () => {
+  // The SECOND dispatch surface the maps must answer: both work-lane hosts
+  // (task `agent_run_host`, automation `agent_host`) resolve a turn's
+  // equipment env — agent secrets plus the Tier-2 connector broker — on the
+  // ctx shim built from this map. The resolvers swallow a broker failure
+  // into a console.warn by design (a credential gap downgrades a turn, never
+  // kills it), which is exactly how an un-shimmed name here ships as "the
+  // agent says it has no github credentials" instead of an error.
+  const handlers = agentTurnShimHandlers({} as never);
+
+  it('answers every internal function the turn-equipment resolvers reach', () => {
+    const missing = [
+      ...reachableHandlerNames(['core/node_only/sandbox/turn_equipment.ts']),
+    ]
+      .filter(([name]) => handlers[name] === undefined)
+      .map(
+        ([name, callers]) => `${name} (called from ${[...callers].join(', ')})`,
+      );
+    expect(missing).toEqual([]);
+  });
+
+  it('reaches the broker seams, not just the secrets lane', () => {
+    // A guard on the guard, as above.
+    const reachable = reachableHandlerNames([
+      'core/node_only/sandbox/turn_equipment.ts',
+    ]);
+    expect([...reachable.keys()]).toEqual(
+      expect.arrayContaining([
+        'agent_secrets/actions:resolveAgentSecretsEnv',
+        'connector_credentials/queries:resolveCredentialRefInternal',
+        'sandbox/session_mutations:recordCredentialAccess',
+        'sandbox/session_queries:getSessionOwnerIdentity',
       ]),
     );
   });

--- a/services/platform/backend/domains/sandbox/shim.ts
+++ b/services/platform/backend/domains/sandbox/shim.ts
@@ -1,11 +1,14 @@
 import type { Sql } from 'postgres';
 
+import { SANDBOX_SESSION_LIVE_STATUSES } from '../../core/sandbox/session_constants.ts';
 import type { ShimHandlers } from '../../lib/ctx-shim.ts';
 import { resolveAgentSecretsEnv } from '../agent_secrets/service.ts';
 import { automationAskShimHandlers } from '../automations/ask-shim.ts';
 import { chatShimHandlers } from '../chat/shim.ts';
+import { findCredentialForRef } from '../connector_credentials/service.ts';
 import { listDocumentsForAgent } from '../documents/agent-list.ts';
 import { addTaskComment } from '../tasks/comments.ts';
+import { getCurrentUser } from '../users/service.ts';
 import { workspaceWriteShimHandlers } from './workspace-write-shim.ts';
 
 /**
@@ -182,6 +185,82 @@ export function sandboxToolShimHandlers(sql: Sql): ShimHandlers {
         names: string[];
       };
       return resolveAgentSecretsEnv(sql, args);
+    },
+
+    // The turn-equipment CONNECTOR BROKER's three seams
+    // (`node_only/sandbox/session_credentials.ts`): the full credential row
+    // it decrypts, the Tier-2 fetch audit, and the session owner's git
+    // author identity. Un-shimmed, the broker's best-effort catches degrade
+    // every work-lane turn to "no credentials" silently — a granted github
+    // connector must inject GITHUB_TOKEN here, not warn into the job log.
+    'connector_credentials/queries:resolveCredentialRefInternal': async (
+      raw,
+    ) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the credential resolver passes exactly this shape
+      const args = raw as {
+        organizationId: string;
+        connectorSlug: string;
+        credentialRef?: string;
+      };
+      const row = await findCredentialForRef(sql, args);
+      if (row === null) return null;
+      // The 0.4 row shape the reused resolver reads — nullable columns are
+      // ABSENT fields there, never nulls.
+      return {
+        _id: row.id,
+        organizationId: row.organizationId,
+        connectorSlug: row.connectorSlug,
+        authMethod: row.authMethod,
+        name: row.name,
+        encryptedData: row.encryptedData,
+        ...(row.endpointUrl !== null ? { endpointUrl: row.endpointUrl } : {}),
+        ...(row.config !== null ? { config: row.config } : {}),
+        status: row.status,
+        ...(row.statusDetail !== null
+          ? { statusDetail: row.statusDetail }
+          : {}),
+      };
+    },
+
+    'sandbox/session_mutations:recordCredentialAccess': async (raw) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the credential broker passes exactly this shape
+      const args = raw as {
+        organizationId: string;
+        sessionId: string;
+        slug: string;
+        kind: 'bootstrap' | 'git';
+      };
+      await sql`
+        INSERT INTO app.sandbox_credential_access (
+          org_id, session_id, slug, kind, fetched_at_ms
+        ) VALUES (
+          ${args.organizationId}, ${args.sessionId}, ${args.slug},
+          ${args.kind}, ${Date.now()}
+        )
+      `;
+      return null;
+    },
+
+    'sandbox/session_queries:getSessionOwnerIdentity': async (raw) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the credential broker passes exactly this shape
+      const args = raw as { sessionId: string };
+      const rows = await sql<{ createdBy: string }[]>`
+        SELECT created_by AS "createdBy" FROM app.sandbox_sessions
+        WHERE session_id = ${args.sessionId}
+          AND status IN ${sql([...SANDBOX_SESSION_LIVE_STATUSES])}
+        ORDER BY created_at_ms DESC
+        LIMIT 1
+      `;
+      const createdBy = rows[0]?.createdBy;
+      if (createdBy === undefined) return null;
+      // A synthetic owner (`system:automation`) matches no user row and
+      // resolves to null — the broker then injects no git author identity.
+      const user = await getCurrentUser(sql, createdBy);
+      if (user === null) return null;
+      const email = (user.email ?? '').trim();
+      const name = (user.name ?? '').trim() || email;
+      if (name === '' || email === '') return null;
+      return { name, email };
     },
 
     ...base,

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -20183,6 +20183,124 @@ async function checkAgentSecrets(
 }
 
 /**
+ * The turn-equipment CONNECTOR BROKER, end to end on the real work-lane
+ * chain: a stored github credential + a granted `github` connector must
+ * resolve — through the automation shim map, the reused credential resolver,
+ * and the Tier-2 broker — into the exec env (GITHUB_TOKEN/GH_TOKEN, the git
+ * credential helper, the session owner's git identity) plus one audit row.
+ * The resolvers deliberately swallow failures into warnings (a credential
+ * gap downgrades a turn), so only an env-level assertion proves the chain —
+ * this is exactly the lane that shipped as "the agent says it has no github
+ * credentials" while every half was green.
+ */
+async function checkTurnEquipmentBroker(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string; userId: string },
+): Promise<void> {
+  const { cookie, orgId, userId } = ctx;
+  const token = 'ghp_itest_broker_token_123';
+  const sessionId = 'itest-broker-session';
+  const createdRes = await fetch(
+    `${base}/api/app/connector-credentials?orgId=${orgId}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: JSON.stringify({
+        connectorSlug: 'github',
+        authMethod: 'bearer',
+        name: 'itest github',
+        secret: { token },
+      }),
+    },
+  );
+  const created = z
+    .object({ credentialId: z.string() })
+    .safeParse(await createdRes.json());
+  // A live session row owned by the itest USER: the broker resolves the git
+  // author identity off `created_by`, so the env must carry helper + name +
+  // email. (A workflow run's synthetic `system:automation` owner resolves to
+  // null identity — covered by the resolver's own contract, not re-proven
+  // here.)
+  const now = Date.now();
+  await sql`
+    INSERT INTO app.sandbox_sessions (
+      org_id, session_id, status, owner_type, owner_id, created_by,
+      created_at_ms, expires_at_ms
+    ) VALUES (
+      ${orgId}, ${sessionId}, 'active', 'workflow_run', 'itest-broker-run',
+      ${userId}, ${now}, ${now + 3_600_000}
+    )
+  `;
+  const { automationShimHandlers } =
+    await import('./domains/automations/shim.ts');
+  const { createCtxShim } = await import('./lib/ctx-shim.ts');
+  const { resolveTurnEquipmentEnv } =
+    await import('./core/node_only/sandbox/turn_equipment.ts');
+  const shim = createCtxShim(automationShimHandlers(sql));
+  const env = await resolveTurnEquipmentEnv(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the work-lane jobs run the resolver on exactly this shim
+    shim as unknown as Parameters<typeof resolveTurnEquipmentEnv>[0],
+    {
+      organizationId: orgId,
+      sessionId,
+      connectors: ['github'],
+      secrets: [],
+    },
+  );
+  const gitConfigPairs = Object.entries(env)
+    .filter(([key]) => key.startsWith('GIT_CONFIG_KEY_'))
+    .map(([key, value]) => [value, env[key.replace('KEY', 'VALUE')]]);
+  const helperPair = gitConfigPairs.find(
+    ([key]) => key === 'credential.helper',
+  );
+  const audit = await sql<{ slug: string; kind: string }[]>`
+    SELECT slug, kind FROM app.sandbox_credential_access
+    WHERE session_id = ${sessionId}
+  `;
+  record(
+    'turn-equipment broker: github grant resolves env + git identity + audit',
+    created.success &&
+      env.GITHUB_TOKEN === token &&
+      env.GH_TOKEN === token &&
+      env.GIT_CONFIG_COUNT === '3' &&
+      helperPair?.[1] === '/usr/local/bin/tale-git-credential' &&
+      gitConfigPairs.some(([key]) => key === 'user.name') &&
+      gitConfigPairs.some(([key]) => key === 'user.email') &&
+      audit.length === 1 &&
+      audit[0]?.slug === 'github' &&
+      audit[0]?.kind === 'git',
+    `created=${created.success}, GITHUB_TOKEN=${env.GITHUB_TOKEN === token}, GH_TOKEN=${env.GH_TOKEN === token}, gitConfig=${env.GIT_CONFIG_COUNT ?? 'unset'} (want 3), helper=${helperPair?.[1] ?? 'missing'}, audit=${audit.map((row) => `${row.slug}:${row.kind}`).join(',') || 'none'}`,
+  );
+
+  // An UNGRANTED turn does no credential work and injects nothing.
+  const emptyEnv = await resolveTurnEquipmentEnv(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the work-lane jobs run the resolver on exactly this shim
+    shim as unknown as Parameters<typeof resolveTurnEquipmentEnv>[0],
+    { organizationId: orgId, sessionId, connectors: [], secrets: [] },
+  );
+  record(
+    'turn-equipment broker: no grants → empty env',
+    Object.keys(emptyEnv).length === 0,
+    `env keys=${Object.keys(emptyEnv).join(',') || 'none'}`,
+  );
+
+  // Leave no connected github credential behind — later checks read the
+  // org's connected-connector set.
+  if (created.success) {
+    await fetch(
+      `${base}/api/app/connector-credentials/${created.data.credentialId}?orgId=${orgId}`,
+      { method: 'DELETE', headers: { cookie, origin: base } },
+    );
+  }
+  await sql`DELETE FROM app.sandbox_sessions WHERE session_id = ${sessionId}`;
+  await sql`
+    DELETE FROM app.sandbox_credential_access
+    WHERE session_id = ${sessionId}
+  `;
+}
+
+/**
  * Knowledge entries: topic-keyed markdown facts with the supersede chain —
  * create (dup refused), update (chain + SAME backing file re-indexed, so
  * the corpus replaces in place), agent listing through the chat shim,
@@ -25799,6 +25917,7 @@ async function main(): Promise<void> {
     await checkChatThreadSurface(sql, baseUrl, authCtx);
     await checkBrandingAndTeams(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkAgentSecrets(sql, baseUrl, authCtx);
+    await checkTurnEquipmentBroker(sql, baseUrl, authCtx);
     await checkKnowledgeEntries(sql, baseUrl, authCtx);
     await checkCollabEmitters(sql, baseUrl, authCtx);
     await checkChangelogAndAccounts(sql, baseUrl, authCtx);


### PR DESCRIPTION
## Problem

Configuring a GitHub credential in Settings → Connectors and granting `github` on an automation (or task) agent's skills menu still left the agent with no credentials at run time — it would report it has no GitHub access.

## Root cause

The config chain was intact end to end (SkillsMenu → `node.connectors` → stepper request → host → `resolveTurnEquipmentEnv`). The break was in the shim layer: the Tier-2 credential broker (`core/node_only/sandbox/session_credentials.ts`) makes three ctx calls, and none of them were answered by the agent-turn shim family (`agentTurnShimHandlers` ⊃ `sandboxToolShimHandlers`) both work lanes run under:

- `connector_credentials/queries:resolveCredentialRefInternal` — only the conversations lane had a handler, and it returns an identity subset without the encrypted envelope, unusable for the decrypt path
- `sandbox/session_mutations:recordCredentialAccess` — no handler anywhere
- `sandbox/session_queries:getSessionOwnerIdentity` — no handler anywhere

The `[ctx-shim] un-shimmed` throws never surfaced because the equipment resolver deliberately downgrades broker failures to warnings (a credential gap must not kill a turn) — so every granted turn silently ran with an empty env overlay. Same failure shape as #3126: each half was tested, the chain was not, and the existing guard only walks the bridge entry points, not the turn-equipment entry.

## Fix

- `domains/sandbox/shim.ts` — add the three handlers beside the agent-secrets one: the full 0.4-shaped credential row (nullable columns become absent fields) via a new null-returning `findCredentialForRef`, the `sandbox_credential_access` audit insert (table shipped in migration 0017; agent secrets already write to it), and the session owner's git identity off the latest live session row (a synthetic `system:automation` owner resolves to null, as in 0.4).
- `domains/connector_credentials/service.ts` — export `findCredentialForRef`; `loadRowForResolve` becomes a thin throwing wrapper over it.
- `domains/sandbox/shim.test.ts` — parameterize the import-graph walker and add a second guard: every `internal.*` name reachable from `core/node_only/sandbox/turn_equipment.ts` must have a handler in `agentTurnShimHandlers`. This class of gap now fails in CI instead of shipping as a silent downgrade.
- `integration-check.ts` — `checkTurnEquipmentBroker`: on real Postgres, a stored github bearer credential + a granted `github` connector resolve through the automation shim into `GITHUB_TOKEN`/`GH_TOKEN`, the git credential-helper env, the owner's git author identity (`GIT_CONFIG_COUNT=3`), and exactly one `github`/`git` audit row; an ungranted turn injects nothing.

## Verification

- `bun run check` 40/40; shim guard tests 4/4; backend integration 279/279 (was 277 — the two new checks).
- Live E2E on the dev stack: a real GitHub PAT stored through the settings door, a one-node automation (`type: agent`, `connectors: ["github"]`) started in live mode — the run settled `success` with the agent replying `GITHUB_OK:<login>` from `gh api user`, the audit row landed, and the backend log shows zero broker warnings. The task lane heals with the same change (same handler family).
