### PR TITLE
fix(platform): org-scope task loads and gate task mutations

### DIFF
--- a/services/platform/backend/db/migrations/0059_tasks_external_ref_unique.sql
+++ b/services/platform/backend/db/migrations/0059_tasks_external_ref_unique.sql
@@ -1,0 +1,47 @@
+-- One task per (project, external_system, external_id) — DB-enforced.
+--
+-- The external-ref intake (`upsertTaskByExternalRef`, driving the session
+-- create-task door, REST `POST /api/v1/tasks`, and the sandbox task_upsert
+-- shim) used to dedupe by SELECT-then-INSERT with only a plain index
+-- (`tasks_org_external`, 0009): two concurrent intakes of the same external
+-- item — a retried webhook, a double-submitted sync — each saw "no task" in
+-- READ COMMITTED and both inserted, duplicating the task AND the workflow
+-- run started for it. This file makes the dedupe a rule the database cannot
+-- forget; the upsert now inserts with ON CONFLICT DO NOTHING against this
+-- index and reconciles the winner's row when it loses the race.
+--
+-- The key is per PROJECT, not per org, because `dedupeScope: 'project'`
+-- legitimately allows the same external ref in two projects of one org (one
+-- task per issue per project). Org-scope dedupe across different projects
+-- stays advisory (lookup-only) for that reason.
+--
+-- Existing duplicates are resolved DETERMINISTICALLY before the index: per
+-- (project_id, external_system, external_id) group the OLDEST row — lowest
+-- created_at_ms, id as the tiebreak — keeps the external binding; every
+-- newer duplicate is detached from the ref (external_system/external_id set
+-- NULL) rather than deleted, so no task data, comments, or runs are lost.
+-- Detached duplicates keep their external_url for human traceability.
+--
+-- Rolling-deploy safe: the previous image is still serving while this
+-- applies. Its SELECT-then-INSERT keeps working for every non-racing
+-- request; the formerly-duplicating race now surfaces as a unique-violation
+-- error on the loser instead of a silent duplicate, which is the safe side
+-- of the trade until the new image takes over.
+
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY project_id, external_system, external_id
+           ORDER BY created_at_ms ASC, id ASC
+         ) AS keep_rank
+  FROM app.tasks
+  WHERE external_system IS NOT NULL AND external_id IS NOT NULL
+)
+UPDATE app.tasks
+SET external_system = NULL, external_id = NULL
+FROM ranked
+WHERE app.tasks.id = ranked.id AND ranked.keep_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tasks_project_external_unique
+  ON app.tasks (project_id, external_system, external_id)
+  WHERE external_system IS NOT NULL AND external_id IS NOT NULL;

--- a/services/platform/backend/domains/collab/routes.ts
+++ b/services/platform/backend/domains/collab/routes.ts
@@ -1,10 +1,20 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import type { Auth } from '../../auth/auth.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession } from '../../auth/session.ts';
+import {
+  getProjectAuthContext,
+  loadProjectOrThrow,
+  ProjectError,
+} from '../projects/service.ts';
+import {
+  assertTaskReadable,
+  loadTaskOrThrow,
+  TaskError,
+} from '../tasks/service.ts';
 import {
   getNotificationPreferences,
   getTaskSubscription,
@@ -118,7 +128,36 @@ export function createCollabRoutes(deps: {
     return c.json({ ok: true });
   });
 
+  /** Subscriptions follow the task's own visibility: the task must exist in
+   * THIS org and the caller must pass its project's read gate — a foreign or
+   * invisible task id answers 404, exactly like the task surface itself. */
+  const assertSubscribableTask = async (
+    c: Context<OrgEnv>,
+    taskId: string,
+  ): Promise<void> => {
+    const auth = await getProjectAuthContext(deps.sql, {
+      organizationId: c.get('orgId'),
+      userId: c.get('sessionBundle').user.id,
+      role: c.get('orgMember').role,
+    });
+    const task = await loadTaskOrThrow(deps.sql, taskId, auth.organizationId);
+    const project = await loadProjectOrThrow(deps.sql, task.projectId);
+    assertTaskReadable(project, auth);
+  };
+
+  const subscriptionError = (c: Context<OrgEnv>, error: unknown): Response => {
+    if (error instanceof TaskError || error instanceof ProjectError) {
+      return c.json({ error: error.code }, error.status);
+    }
+    throw error;
+  };
+
   app.get('/tasks/:taskId/subscription', async (c) => {
+    try {
+      await assertSubscribableTask(c, c.req.param('taskId'));
+    } catch (error) {
+      return subscriptionError(c, error);
+    }
     return c.json(
       await getTaskSubscription(deps.sql, {
         taskId: c.req.param('taskId'),
@@ -135,6 +174,11 @@ export function createCollabRoutes(deps: {
       })
       .safeParse(await c.req.json());
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
+    try {
+      await assertSubscribableTask(c, c.req.param('taskId'));
+    } catch (error) {
+      return subscriptionError(c, error);
+    }
     await setTaskSubscription(deps.sql, {
       organizationId: c.get('orgId'),
       taskId: c.req.param('taskId'),

--- a/services/platform/backend/domains/connectors/service.ts
+++ b/services/platform/backend/domains/connectors/service.ts
@@ -96,8 +96,7 @@ function pgTaskStore(sql: Sql): WorkflowTaskStore {
   return {
     async get({ organizationId, taskId }) {
       try {
-        const task = await loadTaskOrThrow(sql, taskId);
-        if (task.organizationId !== organizationId) return null;
+        const task = await loadTaskOrThrow(sql, taskId, organizationId);
         return {
           taskId: task.id,
           title: task.title,

--- a/services/platform/backend/domains/tasks/agent-turn-shim.ts
+++ b/services/platform/backend/domains/tasks/agent-turn-shim.ts
@@ -314,6 +314,7 @@ export function agentTurnShimHandlers(sql: Sql): ShimHandlers {
         // card that reads "waiting on review". Attributed to the comment's
         // author — the kick is their gesture, delivered late.
         await handTaskToInProgressForKick(tx, {
+          organizationId: args.organizationId,
           taskId: args.taskId,
           userId: args.authorId,
         });

--- a/services/platform/backend/domains/tasks/comments.ts
+++ b/services/platform/backend/domains/tasks/comments.ts
@@ -92,7 +92,7 @@ export async function addTaskComment(
   threadId: string;
   unresolvedMentionTokens: string[];
 }> {
-  const task = await loadTaskOrThrow(tx, args.taskId);
+  const task = await loadTaskOrThrow(tx, args.taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   // Commenting is READ-level (0.4 `addTaskComment*`): anyone who can see
   // the task may join its discussion; edit/delete stay write-gated below.
@@ -234,7 +234,7 @@ export async function listTaskComments(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<TaskCommentItem[]> {
-  const task = await loadTaskOrThrow(sql, taskId);
+  const task = await loadTaskOrThrow(sql, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(sql, task.projectId);
   assertTaskReadable(project, auth);
   if (!task.discussionThreadId) {
@@ -317,7 +317,7 @@ export async function editTaskComment(
   args: { messageId: string; body: string },
 ): Promise<void> {
   const meta = await loadCommentMeta(tx, args.messageId);
-  const task = await loadTaskOrThrow(tx, meta.taskId);
+  const task = await loadTaskOrThrow(tx, meta.taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertCommentOwnerOrAdmin(auth, meta);
@@ -357,7 +357,7 @@ export async function deleteTaskComment(
   messageId: string,
 ): Promise<void> {
   const meta = await loadCommentMeta(tx, messageId);
-  const task = await loadTaskOrThrow(tx, meta.taskId);
+  const task = await loadTaskOrThrow(tx, meta.taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertCommentOwnerOrAdmin(auth, meta);
@@ -598,6 +598,7 @@ async function dispatchMentionedProjectAgent(
     return;
   }
   await handTaskToInProgressForKick(tx, {
+    organizationId: args.auth.organizationId,
     taskId: args.task.id,
     userId: args.auth.userId,
   });

--- a/services/platform/backend/domains/tasks/external-ref.ts
+++ b/services/platform/backend/domains/tasks/external-ref.ts
@@ -60,9 +60,13 @@ async function findTaskByExternalRef(
         "dedupeScope 'project' requires a projectId",
       );
     }
+    // org_id rides along even though project ids are unique: the caller's
+    // projectId is caller-supplied, and a foreign project must never resolve
+    // (and then update) a foreign org's task through this lane.
     const rows = await tx<TaskRow[]>`
       SELECT ${tx.unsafe(TASK_COLUMNS)} FROM app.tasks
-      WHERE project_id = ${args.projectId}
+      WHERE org_id = ${args.organizationId}
+        AND project_id = ${args.projectId}
         AND external_system = ${args.externalSystem}
         AND external_id = ${args.externalId}
       LIMIT 1
@@ -153,10 +157,16 @@ async function automationOwnerOfWorkflowSlug(
 
 /**
  * Upsert a task from an external system, keyed by the caller-owned natural
- * key within `dedupeScope`. Status policy (task-ops invariant): only the
- * workflow engine (`actorId === 'workflow'`) may COMPLETE — any other actor
- * parks an external close at `in_review`; an external reopen lifts only a
- * `done` task back to the neutral inbox (a human `cancelled` stays rejected).
+ * key within `dedupeScope`. Idempotency is DB-enforced per project (the
+ * `tasks_project_external_unique` partial index): a concurrent duplicate
+ * intake reconciles the winner's row instead of inserting a second task.
+ * Org-scope dedupe across two DIFFERENT projects stays advisory — only the
+ * lookup covers it, because the same external ref in two projects is legal
+ * under `dedupeScope: 'project'`. Status policy (task-ops invariant): only
+ * the workflow engine (`actorId === 'workflow'`) may COMPLETE — any other
+ * actor parks an external close at `in_review`; an external reopen lifts
+ * only a `done` task back to the neutral inbox (a human `cancelled` stays
+ * rejected).
  */
 export async function upsertTaskByExternalRef(
   tx: TransactionSql,
@@ -169,15 +179,17 @@ export async function upsertTaskByExternalRef(
   const now = Date.now();
   const createIfMissing = args.createIfMissing ?? true;
 
-  const existing = await findTaskByExternalRef(tx, {
-    organizationId: args.organizationId,
-    ...(args.projectId !== undefined ? { projectId: args.projectId } : {}),
-    externalSystem: args.externalSystem,
-    externalId: args.externalId,
-    dedupeScope: args.dedupeScope ?? 'org',
-  });
+  const findExisting = (): Promise<TaskRow | null> =>
+    findTaskByExternalRef(tx, {
+      organizationId: args.organizationId,
+      ...(args.projectId !== undefined ? { projectId: args.projectId } : {}),
+      externalSystem: args.externalSystem,
+      externalId: args.externalId,
+      dedupeScope: args.dedupeScope ?? 'org',
+    });
 
-  if (existing) {
+  /** The update lane: reconcile an existing task from the external item. */
+  const reconcileExisting = async (existing: TaskRow): Promise<void> => {
     const preserveDescription =
       args.descriptionMode === 'preserve' &&
       existing.description !== null &&
@@ -292,6 +304,11 @@ export async function upsertTaskByExternalRef(
         externalId: args.externalId,
       },
     });
+  };
+
+  const existing = await findExisting();
+  if (existing) {
+    await reconcileExisting(existing);
     return { taskId: existing.id, created: false };
   }
 
@@ -356,11 +373,26 @@ export async function upsertTaskByExternalRef(
       ${createdByUser ? 'user' : ownerAutomation !== null ? 'app' : 'agent'},
       ${now}, ${now}, ${now}
     )
+    ON CONFLICT (project_id, external_system, external_id)
+      WHERE external_system IS NOT NULL AND external_id IS NOT NULL
+      DO NOTHING
     RETURNING id
   `;
   const taskId = inserted[0]?.id;
-  if (!taskId) {
-    throw new TaskError('TASK_CREATE_FAILED', 'Insert failed');
+  if (taskId === undefined) {
+    // Lost the (project, external ref) uniqueness race: a concurrent intake
+    // (a retried webhook, a double-submitted sync) materialized this item
+    // between the lookup above and this insert. The winner's row IS the
+    // task — reconcile it like any other re-sync instead of duplicating the
+    // task and its run. The task number claimed above stays burned;
+    // numbering gaps are fine. (A serializable caller may see the race as a
+    // serialization failure instead — its retry lands on the update lane.)
+    const winner = await findExisting();
+    if (!winner) {
+      throw new TaskError('TASK_CREATE_FAILED', 'Insert failed');
+    }
+    await reconcileExisting(winner);
+    return { taskId: winner.id, created: false };
   }
   // Read the bucket from the INSERTED state, never assume "create ⇒ open":
   // a closed external issue is materialized directly as `done`.

--- a/services/platform/backend/domains/tasks/reviews.ts
+++ b/services/platform/backend/domains/tasks/reviews.ts
@@ -17,11 +17,15 @@ import {
 } from '../collab/service.ts';
 import { emitEvent } from '../events/emit.ts';
 import { holdsAllCompetences } from '../governance/competence.ts';
-import { type ProjectAuthContext } from '../projects/service.ts';
+import {
+  loadProjectOrThrow,
+  type ProjectAuthContext,
+} from '../projects/service.ts';
 import { kickAgentRun } from './agent-runs.ts';
 import { addTaskComment } from './comments.ts';
 import {
   applyTaskCountTransition,
+  assertTaskWritable,
   computeEndRank,
   hasOpenChildren,
   loadTaskOrThrow,
@@ -530,10 +534,13 @@ export async function respondToTaskReview(
       typeof approval.metadata?.taskId === 'string'
         ? approval.metadata.taskId
         : '';
-    const task = await loadTaskOrThrow(tx, taskId);
-    if (task.organizationId !== args.auth.organizationId) {
-      throw new TaskReviewError('REVIEW_NOT_FOUND', 'Review not found', 404);
-    }
+    const task = await loadTaskOrThrow(tx, taskId, args.auth.organizationId);
+    // Deciding a review IS deciding the task (approve completes it,
+    // request-changes kicks the agent and moves the card): the responder
+    // needs the same project WRITE access as any other task mutation —
+    // the review_policy checks below only narrow WHO among the writers.
+    const project = await loadProjectOrThrow(tx, task.projectId);
+    assertTaskWritable(project, args.auth);
 
     const policyOutcome = await checkReviewPolicyForResponder(tx, {
       approval,
@@ -701,7 +708,7 @@ export async function respondToTaskReview(
       }
       // Changes requested hands the work back to the assignee — the card
       // leaves In review even when no agent kick moved it.
-      const fresh = await loadTaskOrThrow(tx, task.id);
+      const fresh = await loadTaskOrThrow(tx, task.id, task.organizationId);
       if (fresh.status === 'in_review') {
         const rank = await computeEndRank(tx, fresh.projectId, 'in_progress');
         await tx`

--- a/services/platform/backend/domains/tasks/routes.ts
+++ b/services/platform/backend/domains/tasks/routes.ts
@@ -506,7 +506,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
       }
       let executionId: string | null | undefined;
       if (args.runWorkflowSlug !== undefined && result.upserted.created) {
-        const task = await loadTaskOrThrow(deps.sql, taskId);
+        const task = await loadTaskOrThrow(
+          deps.sql,
+          taskId,
+          auth.organizationId,
+        );
         const started = await startWorkflowForTask(deps.sql, {
           organizationId: auth.organizationId,
           task,
@@ -767,7 +771,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.get('/:taskId/comments', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       return c.json({
         // The 0.4 discussion envelope: the lazily-created thread id (null =
         // the threadless-task bootstrap) beside the ordered messages.
@@ -901,7 +909,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.get('/:taskId/agent-runs', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertTaskReadable(project, auth);
       const runs = await listAgentRunsForTask(
@@ -919,7 +931,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.get('/:taskId/agent-runs/latest', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertTaskReadable(project, auth);
       return c.json({
@@ -938,7 +954,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.get('/:taskId/live-automation-run', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertTaskReadable(project, auth);
       return c.json({
@@ -976,9 +996,15 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
     }
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
-      assertTaskReadable(project, auth);
+      // Starting a run is a WRITE (it spends budget and moves the card) —
+      // same gate as the manual agent-run kick, not the read-level banner.
+      assertTaskWritable(project, auth);
       const started = await startWorkflowForTask(deps.sql, {
         organizationId: auth.organizationId,
         task,
@@ -1010,28 +1036,38 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.post('/:taskId/workflow/cancel', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
-      assertTaskReadable(project, auth);
+      // The WRITE gate must precede the run cancel: `updateTaskStatus` below
+      // asserts writable too, but by then the live run would already be dead
+      // — a read-only member must be refused before any side effect.
+      assertTaskWritable(project, auth);
       const live = await findLiveAutomationRunForTask(deps.sql, {
         organizationId: auth.organizationId,
         projectId: task.projectId,
         taskId: task.id,
       });
-      let executionCancelled = false;
-      if (live !== null) {
-        const cancelled = await cancelRun(
-          deps.sql,
-          auth.organizationId,
-          live.runId,
-        );
-        executionCancelled = cancelled.cancelled;
-      }
-      if (task.status !== 'cancelled') {
-        await transactSerializable(deps.sql, (tx) =>
-          updateTaskStatus(tx, auth, task.id, 'cancelled'),
-        );
-      }
+      // ONE transaction for the run cancel and the status flip: if the flip
+      // refuses (open subtasks, archived), the cancel rolls back with it —
+      // never a dead run behind a task that answered an error.
+      const executionCancelled = await transactSerializable(
+        deps.sql,
+        async (tx) => {
+          const cancelled =
+            live === null
+              ? false
+              : (await cancelRun(tx, auth.organizationId, live.runId))
+                  .cancelled;
+          if (task.status !== 'cancelled') {
+            await updateTaskStatus(tx, auth, task.id, 'cancelled');
+          }
+          return cancelled;
+        },
+      );
       return c.json({
         taskCancelled: true,
         executionCancelled,
@@ -1046,7 +1082,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.post('/:taskId/agent-runs/cancel-live', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertTaskWritable(project, auth);
       const live = await deps.sql<{ id: string }[]>`
@@ -1072,7 +1112,11 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   app.post('/:taskId/agent-runs/:runId/cancel', async (c) => {
     try {
       const auth = await authCtx(c);
-      const task = await loadTaskOrThrow(deps.sql, c.req.param('taskId'));
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        c.req.param('taskId'),
+        auth.organizationId,
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertTaskWritable(project, auth);
       const cancelled = await cancelAgentRun(deps.sql, {

--- a/services/platform/backend/domains/tasks/service.test.ts
+++ b/services/platform/backend/domains/tasks/service.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ProjectAuthContext, ProjectRow } from '../projects/service.ts';
+import {
+  assertTaskReadable,
+  assertTaskWritable,
+  TaskError,
+} from './service.ts';
+
+const project = (overrides: Partial<ProjectRow> = {}): ProjectRow => ({
+  id: 'proj-1',
+  organizationId: 'org-a',
+  name: 'Board',
+  description: null,
+  icon: null,
+  color: null,
+  key: null,
+  externalItemId: null,
+  taskCounter: 0,
+  openTaskCount: 0,
+  doneTaskCount: 0,
+  projectAgentCount: 0,
+  teamId: null,
+  sharedWithTeamIds: [],
+  instructions: null,
+  knowledgeMode: null,
+  agentMode: null,
+  recommendedAgentSlugs: [],
+  allowedAgentSlugs: [],
+  modelMode: null,
+  recommendedModels: [],
+  allowedModels: [],
+  connectorsMode: null,
+  allowedConnectorSlugs: [],
+  createdBy: 'user-1',
+  createdAt: 0,
+  updatedAt: 0,
+  archivedAt: null,
+  pinnedAt: null,
+  ...overrides,
+});
+
+const auth = (
+  overrides: Partial<ProjectAuthContext> = {},
+): ProjectAuthContext => ({
+  organizationId: 'org-a',
+  userId: 'user-1',
+  role: 'owner',
+  teamIds: [],
+  ...overrides,
+});
+
+const thrown = (run: () => void): TaskError => {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof TaskError) return error;
+    throw error;
+  }
+  throw new Error('expected a TaskError');
+};
+
+describe('task guards — tenant isolation', () => {
+  it('a foreign org project answers as MISSING even for an owner', () => {
+    // The role matrix is org-relative: an org-B owner is nobody in org A,
+    // and the admin bypass inside checkProjectAccess must never run across
+    // the org boundary. 404 (not 403) so a leaked id confirms nothing.
+    const foreign = auth({ organizationId: 'org-b', role: 'owner' });
+    const read = thrown(() => assertTaskReadable(project(), foreign));
+    expect(read.code).toBe('PROJECT_NOT_FOUND');
+    expect(read.status).toBe(404);
+    const write = thrown(() => assertTaskWritable(project(), foreign));
+    expect(write.code).toBe('PROJECT_NOT_FOUND');
+    expect(write.status).toBe(404);
+  });
+
+  it('the cross-org refusal is indistinguishable from a missing project', () => {
+    // Same code + status the projects domain answers for an id that does
+    // not exist at all — org membership is not confirmable by probing.
+    const error = thrown(() =>
+      assertTaskReadable(project(), auth({ organizationId: 'org-b' })),
+    );
+    expect({ code: error.code, status: error.status }).toEqual({
+      code: 'PROJECT_NOT_FOUND',
+      status: 404,
+    });
+  });
+
+  it('a team-restricted project stays visible only to its teams', () => {
+    const restricted = project({ teamId: 'team-1' });
+    expect(() =>
+      assertTaskReadable(
+        restricted,
+        auth({ role: 'member', teamIds: ['team-1'] }),
+      ),
+    ).not.toThrow();
+    const refused = thrown(() =>
+      assertTaskReadable(restricted, auth({ role: 'member', teamIds: [] })),
+    );
+    expect(refused.code).toBe('TASK_FORBIDDEN');
+    expect(refused.status).toBe(403);
+  });
+});
+
+describe('task guards — write access', () => {
+  it('a read-only member can read but never write', () => {
+    // 'member' is not in EDITOR_ROLES: org-wide projects are readable to
+    // every role, but every task mutation (status, runs, reviews) is edit.
+    const member = auth({ role: 'member' });
+    expect(() => assertTaskReadable(project(), member)).not.toThrow();
+    const refused = thrown(() => assertTaskWritable(project(), member));
+    expect(refused.code).toBe('RBAC_FORBIDDEN');
+    expect(refused.status).toBe(403);
+  });
+
+  it('editors and admins of the SAME org pass the write gate', () => {
+    for (const role of ['owner', 'admin', 'developer', 'editor']) {
+      expect(() => assertTaskWritable(project(), auth({ role }))).not.toThrow();
+    }
+  });
+});

--- a/services/platform/backend/domains/tasks/service.ts
+++ b/services/platform/backend/domains/tasks/service.ts
@@ -167,10 +167,24 @@ export const TASK_COLUMNS = `
 // Guards
 // ---------------------------------------------------------------------------
 
+/** A project in another org answers as MISSING (the projects-domain
+ * `assertSameOrg` idiom): the role matrix is org-relative, so it must never
+ * run across a foreign project row — an org-A admin is nobody in org B, and
+ * a 403 would confirm the foreign id exists. */
+function assertTaskProjectSameOrg(
+  project: ProjectRow,
+  auth: ProjectAuthContext,
+): void {
+  if (project.organizationId !== auth.organizationId) {
+    throw new TaskError('PROJECT_NOT_FOUND', 'Project not found', 404);
+  }
+}
+
 export function assertTaskReadable(
   project: ProjectRow,
   auth: ProjectAuthContext,
 ): void {
+  assertTaskProjectSameOrg(project, auth);
   const access = checkProjectAccess(
     { teamId: project.teamId, sharedWithTeamIds: project.sharedWithTeamIds },
     auth.teamIds,
@@ -185,6 +199,7 @@ export function assertTaskWritable(
   project: ProjectRow,
   auth: ProjectAuthContext,
 ): void {
+  assertTaskProjectSameOrg(project, auth);
   const access = checkProjectAccess(
     { teamId: project.teamId, sharedWithTeamIds: project.sharedWithTeamIds },
     auth.teamIds,
@@ -233,13 +248,17 @@ function assertScheduleOrder(
   }
 }
 
+/** The ONE task-by-id load — always org-scoped: a task in another org answers
+ * exactly like one that does not exist (opaque 404), so a leaked id is worth
+ * nothing across a tenant boundary. */
 export async function loadTaskOrThrow(
   sql: Sql | TransactionSql,
   taskId: string,
+  organizationId: string,
 ): Promise<TaskRow> {
   const rows = await sql<TaskRow[]>`
     SELECT ${sql.unsafe(TASK_COLUMNS)} FROM app.tasks
-    WHERE id = ${taskId} LIMIT 1
+    WHERE id = ${taskId} AND org_id = ${organizationId} LIMIT 1
   `;
   const task = rows[0];
   if (!task) {
@@ -729,9 +748,6 @@ export async function createTask(
   args: CreateTaskArgs,
 ): Promise<string> {
   const project = await loadProjectOrThrow(tx, args.projectId);
-  if (project.organizationId !== auth.organizationId) {
-    throw new TaskError('ORG_FORBIDDEN', 'Wrong organization', 403);
-  }
   assertTaskWritable(project, auth);
 
   const title = validateTitle(args.title);
@@ -748,7 +764,11 @@ export async function createTask(
   await assertAssigneeValid(tx, { project, auth, assignee });
 
   if (args.parentTaskId) {
-    const parent = await loadTaskOrThrow(tx, args.parentTaskId);
+    const parent = await loadTaskOrThrow(
+      tx,
+      args.parentTaskId,
+      auth.organizationId,
+    );
     if (parent.projectId !== args.projectId) {
       throw new TaskError('TASK_PARENT_PROJECT_MISMATCH', 'Parent mismatch');
     }
@@ -847,7 +867,7 @@ export async function updateTask(
   auth: ProjectAuthContext,
   args: UpdateTaskArgs,
 ): Promise<void> {
-  const task = await loadTaskOrThrow(tx, args.taskId);
+  const task = await loadTaskOrThrow(tx, args.taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertTaskNotArchived(task);
@@ -953,7 +973,7 @@ export async function updateTaskStatus(
   taskId: string,
   status: TaskStatus,
 ): Promise<void> {
-  const task = await loadTaskOrThrow(tx, taskId);
+  const task = await loadTaskOrThrow(tx, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertTaskNotArchived(task);
@@ -1113,11 +1133,13 @@ export async function agentCreateTaskTrusted(
   const status = args.status ?? 'backlog';
 
   if (args.parentTaskId !== undefined) {
-    const parent = await loadTaskOrThrow(tx, args.parentTaskId);
-    if (
-      parent.organizationId !== args.organizationId ||
-      parent.projectId !== args.projectId
-    ) {
+    // Org-scoped load: a parent id from another org reads as missing.
+    const parent = await loadTaskOrThrow(
+      tx,
+      args.parentTaskId,
+      args.organizationId,
+    );
+    if (parent.projectId !== args.projectId) {
       throw new TaskError('TASK_PARENT_PROJECT_MISMATCH', 'Parent mismatch');
     }
     if (parent.archivedAt !== null) {
@@ -1225,13 +1247,12 @@ export async function agentUpdateTaskStatusTrusted(
   // `AGENTS_CANNOT_COMPLETE` to tell the agent to park at `in_review`
   // instead, and the connector native renders each code as a sentence.
 ): Promise<{ ok: boolean; reason?: string }> {
-  const task = await loadTaskOrThrow(tx, args.taskId);
-  if (task.organizationId !== args.organizationId) {
-    return { ok: false, reason: 'TASK_WRONG_ORGANIZATION' };
-  }
+  // Org-scoped load: a task in another org answers as missing (opaque 404
+  // through the tool bridge) — one refusal shape for foreign and garbage ids.
+  const task = await loadTaskOrThrow(tx, args.taskId, args.organizationId);
   const mintReview = async (): Promise<void> => {
     if (args.review === undefined || args.status !== 'in_review') return;
-    const fresh = await loadTaskOrThrow(tx, args.taskId);
+    const fresh = await loadTaskOrThrow(tx, args.taskId, args.organizationId);
     if (fresh.status !== 'in_review') return;
     await requestTaskReview(tx, {
       task: fresh,
@@ -1315,9 +1336,9 @@ export async function agentUpdateTaskStatusTrusted(
  */
 export async function handTaskToInProgressForKick(
   tx: TransactionSql,
-  args: { taskId: string; userId: string },
+  args: { organizationId: string; taskId: string; userId: string },
 ): Promise<boolean> {
-  const fresh = await loadTaskOrThrow(tx, args.taskId);
+  const fresh = await loadTaskOrThrow(tx, args.taskId, args.organizationId);
   if (fresh.status === 'in_progress') return false;
   await closePendingTaskReviewOnStatusLeave(tx, {
     task: fresh,
@@ -1367,8 +1388,7 @@ export async function agentRecordTaskOutputsTrusted(
   },
 ): Promise<void> {
   if (args.files.length === 0) return;
-  const task = await loadTaskOrThrow(tx, args.taskId);
-  if (task.organizationId !== args.organizationId) return;
+  const task = await loadTaskOrThrow(tx, args.taskId, args.organizationId);
   const next: Array<{
     fileId: string;
     fileName: string;
@@ -1407,7 +1427,7 @@ export async function assignTask(
     assigneeId?: string;
   },
 ): Promise<void> {
-  const task = await loadTaskOrThrow(tx, args.taskId);
+  const task = await loadTaskOrThrow(tx, args.taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertTaskNotArchived(task);
@@ -1467,7 +1487,7 @@ export async function claimTask(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<{ claimed: boolean; reason?: string }> {
-  const task = await loadTaskOrThrow(tx, taskId);
+  const task = await loadTaskOrThrow(tx, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertTaskNotArchived(task);
@@ -1511,7 +1531,7 @@ export async function moveTask(
     afterTaskId?: string;
   },
 ): Promise<void> {
-  const task = await loadTaskOrThrow(tx, args.taskId);
+  const task = await loadTaskOrThrow(tx, args.taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertTaskNotArchived(task);
@@ -1609,7 +1629,7 @@ export async function archiveTask(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<void> {
-  const task = await loadTaskOrThrow(tx, taskId);
+  const task = await loadTaskOrThrow(tx, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   if (task.archivedAt !== null) {
@@ -1640,7 +1660,7 @@ export async function restoreTask(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<void> {
-  const task = await loadTaskOrThrow(tx, taskId);
+  const task = await loadTaskOrThrow(tx, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   if (task.archivedAt === null) {
@@ -1676,7 +1696,7 @@ export async function deleteTask(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<{ deletedChildCount: number }> {
-  const task = await loadTaskOrThrow(tx, taskId);
+  const task = await loadTaskOrThrow(tx, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   if (!['owner', 'admin'].includes(auth.role)) {
@@ -1804,8 +1824,16 @@ export async function addTaskDependency(
   if (args.blockerTaskId === args.blockedTaskId) {
     throw new TaskError('TASK_DEPENDENCY_SELF', 'A task cannot block itself');
   }
-  const blocker = await loadTaskOrThrow(tx, args.blockerTaskId);
-  const blocked = await loadTaskOrThrow(tx, args.blockedTaskId);
+  const blocker = await loadTaskOrThrow(
+    tx,
+    args.blockerTaskId,
+    auth.organizationId,
+  );
+  const blocked = await loadTaskOrThrow(
+    tx,
+    args.blockedTaskId,
+    auth.organizationId,
+  );
   if (blocker.projectId !== blocked.projectId) {
     throw new TaskError(
       'TASK_DEPENDENCY_PROJECT_MISMATCH',
@@ -1860,7 +1888,11 @@ export async function removeTaskDependency(
   auth: ProjectAuthContext,
   args: { blockerTaskId: string; blockedTaskId: string },
 ): Promise<void> {
-  const blocked = await loadTaskOrThrow(tx, args.blockedTaskId);
+  const blocked = await loadTaskOrThrow(
+    tx,
+    args.blockedTaskId,
+    auth.organizationId,
+  );
   const project = await loadProjectOrThrow(tx, blocked.projectId);
   assertTaskWritable(project, auth);
   const deleted = await tx`
@@ -2313,7 +2345,7 @@ export async function getTask(
   canClaim: boolean;
   canComment: boolean;
 }> {
-  const task = await loadTaskOrThrow(sql, taskId);
+  const task = await loadTaskOrThrow(sql, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(sql, task.projectId);
   assertTaskReadable(project, auth);
   const canEdit = checkProjectAccess(
@@ -2345,7 +2377,7 @@ export async function listSubtasks(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<DecoratedTaskRow[]> {
-  const task = await loadTaskOrThrow(sql, taskId);
+  const task = await loadTaskOrThrow(sql, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(sql, task.projectId);
   assertTaskReadable(project, auth);
   const rows = await sql<TaskRow[]>`
@@ -2375,7 +2407,7 @@ export async function listTaskActivity(
   taskId: string,
   limit = 100,
 ): Promise<TaskActivityRow[]> {
-  const task = await loadTaskOrThrow(sql, taskId);
+  const task = await loadTaskOrThrow(sql, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(sql, task.projectId);
   assertTaskReadable(project, auth);
   return sql<TaskActivityRow[]>`
@@ -2538,7 +2570,7 @@ export async function mentionTriggerPreview(
 
   let project: ProjectRow;
   if (args.taskId !== undefined) {
-    const task = await loadTaskOrThrow(sql, args.taskId);
+    const task = await loadTaskOrThrow(sql, args.taskId, auth.organizationId);
     project = await loadProjectOrThrow(sql, task.projectId);
   } else if (args.projectId !== undefined) {
     project = await loadProjectOrThrow(sql, args.projectId);
@@ -2855,7 +2887,7 @@ export async function startTaskAgentRunManual(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<{ started: boolean; reason?: string }> {
-  const task = await loadTaskOrThrow(tx, taskId);
+  const task = await loadTaskOrThrow(tx, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(tx, task.projectId);
   assertTaskWritable(project, auth);
   assertTaskNotArchived(task);
@@ -3074,7 +3106,7 @@ export async function listTaskDependencies(
   auth: ProjectAuthContext,
   taskId: string,
 ): Promise<{ blockedBy: DecoratedTaskRow[]; blocks: DecoratedTaskRow[] }> {
-  const task = await loadTaskOrThrow(sql, taskId);
+  const task = await loadTaskOrThrow(sql, taskId, auth.organizationId);
   const project = await loadProjectOrThrow(sql, task.projectId);
   assertTaskReadable(project, auth);
   const blockedBy = await sql<TaskRow[]>`

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -1770,6 +1770,356 @@ async function checkTasks(
 }
 
 /**
+ * The tenant-isolation net over the tasks surface (the tasks-org-scoping
+ * class): a task id from another organization answers like one that does
+ * not exist — reads, writes, deletes, run verbs, collab subscriptions —
+ * even when the caller is an OWNER of their own org (the admin bypass in
+ * the role matrix was the hole). Read-only members must not start or
+ * cancel runs, deciding a review takes task-edit access, and the
+ * external-ref intake neither duplicates a task under concurrency (the
+ * 0059 unique index + ON CONFLICT reconcile) nor reaches across orgs.
+ */
+async function checkTasksOrgIsolation(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string; userId: string },
+): Promise<void> {
+  const { cookie, orgId, userId } = ctx;
+  const now = Date.now();
+  const api = (
+    route: string,
+    init: {
+      method?: string;
+      body?: unknown;
+      cookie?: string;
+      org?: string;
+    } = {},
+  ): Promise<Response> =>
+    fetch(`${base}${route}?orgId=${init.org ?? orgId}`, {
+      method: init.method ?? (init.body !== undefined ? 'POST' : 'GET'),
+      headers: {
+        'content-type': 'application/json',
+        cookie: init.cookie ?? cookie,
+        origin: base,
+      },
+      ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+    });
+
+  // The victim org's project + task (org-wide: readable to every role).
+  const projectRows = await sql<{ id: string }[]>`
+    INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                              updated_at_ms)
+    VALUES (${orgId}, 'Isolation project', ${userId}, ${now}, ${now})
+    RETURNING id
+  `;
+  const projectId = projectRows[0]?.id ?? '';
+  const created = z.object({ taskId: z.string() }).safeParse(
+    await (
+      await api('/api/app/tasks', {
+        body: { projectId, title: 'Isolation task', status: 'todo' },
+      })
+    ).json(),
+  );
+  const taskId = created.success ? created.data.taskId : '';
+
+  // An ATTACKER user owning a SECOND org — the exact shape of the hole:
+  // org-blind guards ran checkProjectAccess with the attacker's own OWNER
+  // role, whose admin bypass granted every project in the deployment. A
+  // dedicated user (never the suite's main one) keeps the main user
+  // single-org — REST sections later in the suite resolve their API key's
+  // org implicitly, and a second membership would poison them.
+  const attackerSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `itest-iso-attacker-${now}@example.com`,
+      password: 'itest-password-1',
+      name: 'Iso Attacker',
+    }),
+  });
+  const attackerCookie = cookieHeaderFrom(attackerSignUp);
+  const attackerParsed = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await attackerSignUp.json());
+  const attackerId = attackerParsed.success ? attackerParsed.data.user.id : '';
+  const rivalCreate = await fetch(`${base}/api/auth/organization/create`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: attackerCookie,
+      origin: base,
+    },
+    body: JSON.stringify({
+      name: `Isolation Rival ${now}`,
+      slug: `itest-iso-rival-${now}`,
+    }),
+  });
+  const rivalBody = z
+    .object({ id: z.string().optional() })
+    .safeParse(await rivalCreate.json());
+  const rivalOrgId = rivalBody.success ? (rivalBody.data.id ?? '') : '';
+  /** The attacker's own session, aimed at their own org (the request is
+   * WELL-FORMED — only the task id belongs to the victim). */
+  const rival = { cookie: attackerCookie, org: rivalOrgId };
+
+  // Creating the task auto-subscribed its creator: the invariant is that
+  // the cross-org attempts below ADD nothing, not that the count is zero.
+  const subsBefore = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.task_subscriptions
+    WHERE task_id = ${taskId}
+  `;
+  const crossRead = await api(`/api/app/tasks/${taskId}`, { ...rival });
+  const crossWrite = await api(`/api/app/tasks/${taskId}/status`, {
+    ...rival,
+    body: { status: 'done' },
+  });
+  const crossSubGet = await api(
+    `/api/app/collab/tasks/${taskId}/subscription`,
+    { ...rival },
+  );
+  const crossSubSet = await api(
+    `/api/app/collab/tasks/${taskId}/subscription`,
+    { ...rival, body: { subscribed: true } },
+  );
+  const garbageSub = await api(
+    '/api/app/collab/tasks/no-such-task/subscription',
+    { body: { subscribed: true } },
+  );
+  const crossDelete = await api(`/api/app/tasks/${taskId}`, {
+    ...rival,
+    method: 'DELETE',
+  });
+  const survivor = await sql<{ status: string }[]>`
+    SELECT status FROM app.tasks WHERE id = ${taskId}
+  `;
+  const subsAfter = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.task_subscriptions
+    WHERE task_id = ${taskId}
+  `;
+  record(
+    'tasks: a foreign org owner cannot read, mutate, delete, or follow a task',
+    rivalOrgId.length > 0 &&
+      crossRead.status === 404 &&
+      crossWrite.status === 404 &&
+      crossSubGet.status === 404 &&
+      crossSubSet.status === 404 &&
+      garbageSub.status === 404 &&
+      crossDelete.status === 404 &&
+      survivor[0]?.status === 'todo' &&
+      subsAfter[0]?.count === subsBefore[0]?.count,
+    `read=${crossRead.status}, write=${crossWrite.status}, sub=${crossSubGet.status}/${crossSubSet.status}, garbage-sub=${garbageSub.status}, delete=${crossDelete.status} (want 404s), task=${survivor[0]?.status ?? 'GONE'} (want todo), subs=${subsBefore[0]?.count}→${subsAfter[0]?.count} (want unchanged)`,
+  );
+
+  // A live automation run on the victim task: the rival's cancel answers
+  // 404 and the run keeps running (on the old org-blind guards the task
+  // flipped to cancelled cross-org).
+  await sql`
+    INSERT INTO app.automation_runs (
+      org_id, project_id, name, version, status, mode, started_by, input,
+      started_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'itest-iso-run', 1, 'running', 'live',
+      ${userId}, ${sql.json({ task: { id: taskId } })}, ${now}
+    )
+  `;
+  const crossCancel = await api(`/api/app/tasks/${taskId}/workflow/cancel`, {
+    ...rival,
+    method: 'POST',
+  });
+  const runAfterCross = await sql<{ status: string }[]>`
+    SELECT status FROM app.automation_runs
+    WHERE org_id = ${orgId} AND name = 'itest-iso-run'
+  `;
+  const taskAfterCross = await sql<{ status: string }[]>`
+    SELECT status FROM app.tasks WHERE id = ${taskId}
+  `;
+  record(
+    'tasks: a foreign org owner cannot cancel the live run behind a task',
+    crossCancel.status === 404 &&
+      runAfterCross[0]?.status === 'running' &&
+      taskAfterCross[0]?.status === 'todo',
+    `cancel=${crossCancel.status} (want 404), run=${runAfterCross[0]?.status} (want running), task=${taskAfterCross[0]?.status} (want todo)`,
+  );
+
+  // A read-only MEMBER of the victim org (the harness member idiom): reads
+  // pass, but starting or cancelling a run is an EDIT and refuses BEFORE
+  // any side effect — the run must still be running afterwards.
+  const viewerSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `itest-iso-viewer-${now}@example.com`,
+      password: 'itest-password-1',
+      name: 'Iso Viewer',
+    }),
+  });
+  const viewerCookie = cookieHeaderFrom(viewerSignUp);
+  const viewerParsed = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await viewerSignUp.json());
+  const viewerId = viewerParsed.success ? viewerParsed.data.user.id : '';
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${`m-iso-${viewerId}`}, ${orgId}, ${viewerId}, 'member',
+            ${new Date()})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+  const viewerRead = await api(`/api/app/tasks/${taskId}`, {
+    cookie: viewerCookie,
+  });
+  const viewerStart = await api(`/api/app/tasks/${taskId}/workflow/start`, {
+    cookie: viewerCookie,
+    body: { workflowSlug: 'no-such-automation' },
+  });
+  const viewerCancel = await api(`/api/app/tasks/${taskId}/workflow/cancel`, {
+    cookie: viewerCookie,
+    method: 'POST',
+  });
+  const runAfterViewer = await sql<{ status: string }[]>`
+    SELECT status FROM app.automation_runs
+    WHERE org_id = ${orgId} AND name = 'itest-iso-run'
+  `;
+  record(
+    'tasks: a read-only member reads the task but cannot start/cancel runs',
+    viewerRead.status === 200 &&
+      viewerStart.status === 403 &&
+      viewerCancel.status === 403 &&
+      runAfterViewer[0]?.status === 'running',
+    `read=${viewerRead.status} (want 200), start=${viewerStart.status}/cancel=${viewerCancel.status} (want 403), run=${runAfterViewer[0]?.status} (want running)`,
+  );
+  await sql`
+    UPDATE app.automation_runs SET status = 'failed'
+    WHERE org_id = ${orgId} AND name = 'itest-iso-run'
+  `;
+
+  // Deciding a review is deciding the task: a read-only member's respond
+  // refuses on the project write gate and the gate stays pending.
+  const approvalRows = await sql<{ id: string }[]>`
+    INSERT INTO app.approvals (
+      org_id, status, resource_type, resource_id, priority, metadata,
+      created_at_ms
+    ) VALUES (
+      ${orgId}, 'pending', 'task_review', ${taskId}, 'medium',
+      ${sql.json({ taskId })}, ${now}
+    ) RETURNING id
+  `;
+  const approvalId = approvalRows[0]?.id ?? '';
+  const { respondToTaskReview } = await import('./domains/tasks/reviews.ts');
+  const respondOutcome = await respondToTaskReview(sql, {
+    auth: {
+      organizationId: orgId,
+      userId: viewerId,
+      role: 'member',
+      teamIds: [],
+    },
+    approvalId,
+    decision: 'approve',
+  }).then(
+    () => 'approved',
+    (error: unknown) =>
+      error instanceof Error && 'code' in error
+        ? String(error.code)
+        : 'other-error',
+  );
+  const approvalAfter = await sql<{ status: string }[]>`
+    SELECT status FROM app.approvals WHERE id = ${approvalId}
+  `;
+  record(
+    'tasks: responding to a review requires task-edit access',
+    respondOutcome === 'RBAC_FORBIDDEN' &&
+      approvalAfter[0]?.status === 'pending',
+    `respond → ${respondOutcome} (want RBAC_FORBIDDEN), approval=${approvalAfter[0]?.status} (want pending)`,
+  );
+
+  // The external-ref intake under concurrency: two simultaneous intakes of
+  // the same item land exactly ONE task (unique index + reconcile lane) and
+  // a later replay reconciles instead of creating.
+  const { upsertTaskByExternalRef } =
+    await import('./domains/tasks/external-ref.ts');
+  const upsertArgs = {
+    organizationId: orgId,
+    actorId: userId,
+    projectId,
+    externalSystem: 'itest-iso',
+    externalId: 'ISO-RACE-1',
+    title: 'Raced intake',
+    creatorType: 'user' as const,
+    dedupeScope: 'project' as const,
+  };
+  const [first, second] = await Promise.all([
+    transactSerializable(sql, (tx) => upsertTaskByExternalRef(tx, upsertArgs)),
+    transactSerializable(sql, (tx) => upsertTaskByExternalRef(tx, upsertArgs)),
+  ]);
+  const replay = await transactSerializable(sql, (tx) =>
+    upsertTaskByExternalRef(tx, upsertArgs),
+  );
+  const raceRows = await sql<{ id: string }[]>`
+    SELECT id FROM app.tasks
+    WHERE org_id = ${orgId} AND project_id = ${projectId}
+      AND external_system = 'itest-iso' AND external_id = 'ISO-RACE-1'
+  `;
+  record(
+    'tasks: concurrent external-ref intakes land exactly one task',
+    raceRows.length === 1 &&
+      first.taskId !== null &&
+      first.taskId === second.taskId &&
+      [first.created, second.created].filter(Boolean).length === 1 &&
+      !replay.created &&
+      replay.taskId === raceRows[0]?.id,
+    `rows=${raceRows.length} (want 1), created=[${String(first.created)},${String(second.created)}] (want exactly one true), replay=${String(replay.created)} (want false)`,
+  );
+
+  // The intake seam refuses a foreign project outright: dedupe and create
+  // are both org-scoped, so an org-level agent naming a foreign project id
+  // can neither update nor create on the foreign board.
+  const rivalProject = await sql<{ id: string }[]>`
+    INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                              updated_at_ms)
+    VALUES (${rivalOrgId}, 'Rival project', ${attackerId}, ${now}, ${now})
+    RETURNING id
+  `;
+  const rivalProjectId = rivalProject[0]?.id ?? '';
+  await sql`
+    INSERT INTO app.tasks (
+      org_id, project_id, title, status, rank, number, external_system,
+      external_id, created_by, created_by_type, created_at_ms, updated_at_ms,
+      status_changed_at_ms
+    ) VALUES (
+      ${rivalOrgId}, ${rivalProjectId}, 'Rival task', 'todo', 'a0', 1,
+      'itest-iso', 'ISO-XORG-1', ${attackerId}, 'user', ${now}, ${now}, ${now}
+    )
+  `;
+  const crossUpsert = await transactSerializable(sql, (tx) =>
+    upsertTaskByExternalRef(tx, {
+      organizationId: orgId,
+      actorId: userId,
+      projectId: rivalProjectId,
+      externalSystem: 'itest-iso',
+      externalId: 'ISO-XORG-1',
+      title: 'Hijacked title',
+      dedupeScope: 'project',
+    }),
+  ).then(
+    (result) => `ok:${String(result.created)}`,
+    (error: unknown) =>
+      error instanceof Error && 'code' in error
+        ? String(error.code)
+        : 'other-error',
+  );
+  const rivalAfter = await sql<{ title: string }[]>`
+    SELECT title FROM app.tasks
+    WHERE org_id = ${rivalOrgId} AND external_id = 'ISO-XORG-1'
+  `;
+  record(
+    'tasks: external-ref upsert never resolves or creates across orgs',
+    crossUpsert === 'PROJECT_NOT_FOUND' &&
+      rivalAfter[0]?.title === 'Rival task',
+    `upsert → ${crossUpsert} (want PROJECT_NOT_FOUND), rival title=${rivalAfter[0]?.title ?? 'GONE'} (want untouched)`,
+  );
+}
+
+/**
  * Files vertical against a REAL S3-compatible store (MinIO): seed the
  * deployment-default connection into the config tree, create the bucket,
  * then run handoff → presigned PUT → register (HEAD-verified) → presigned
@@ -25896,6 +26246,7 @@ async function main(): Promise<void> {
     );
     await checkProjects(baseUrl, authCtx);
     await checkTasks(baseUrl, authCtx);
+    await checkTasksOrgIsolation(sql, baseUrl, authCtx);
     await checkFiles(baseUrl, authCtx);
     await checkDocuments(sql, baseUrl, authCtx);
     await checkSmallDomains(baseUrl, authCtx);

--- a/services/platform/backend/rest/v1-tasks.ts
+++ b/services/platform/backend/rest/v1-tasks.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import {
   assertReadable,
+  assertWritable,
   loadProjectOrThrow,
   type ProjectAuthContext,
 } from '../domains/projects/service.ts';
@@ -64,8 +65,11 @@ export function createTaskRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
     taskId: string,
   ): Promise<TaskRow | null> => {
     try {
-      const task = await loadTaskOrThrow(deps.sql, taskId);
-      if (task.organizationId !== c.get('organizationId')) return null;
+      const task = await loadTaskOrThrow(
+        deps.sql,
+        taskId,
+        c.get('organizationId'),
+      );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertReadable(project, auth);
       return task;
@@ -190,7 +194,11 @@ export function createTaskRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       // (or null when the slug is undeployed) is answered directly.
       let executionId: string | null | undefined;
       if (body.data.runWorkflowSlug !== undefined && result.created) {
-        const task = await loadTaskOrThrow(deps.sql, taskId);
+        const task = await loadTaskOrThrow(
+          deps.sql,
+          taskId,
+          c.get('organizationId'),
+        );
         const started = await startWorkflowForTask(deps.sql, {
           organizationId: c.get('organizationId'),
           task,
@@ -268,11 +276,12 @@ export function createTaskRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
 
   /**
    * POST /tasks/{id}/start — start a deployed workflow on the task. RBAC
-   * deliberately mirrors the session action: org membership + the task's
-   * READ visibility, NOT the developer gate the arbitrary-input
-   * `POST /automations/{name}/runs` applies — this run is task-subject-
-   * bound, and deploying the workflow was the privileged act. Work-starting,
-   * so it tops up on the `rest:execute` lane.
+   * deliberately mirrors the session action: the task's project WRITE
+   * access (starting a run spends budget and moves the card), NOT the
+   * developer gate the arbitrary-input `POST /automations/{name}/runs`
+   * applies — this run is task-subject-bound, and deploying the workflow
+   * was the privileged act. Work-starting, so it tops up on the
+   * `rest:execute` lane.
    */
   app.post('/tasks/:id/start', async (c) => {
     const limited = await chargeLane(deps.sql, c, 'rest:execute');
@@ -289,6 +298,12 @@ export function createTaskRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
     const auth = await restProjectAuth(deps.sql, c);
     const task = await loadVisibleTask(c, auth, c.req.param('id'));
     if (task === null) return c.json({ error: 'Task not found' }, 404);
+    try {
+      const project = await loadProjectOrThrow(deps.sql, task.projectId);
+      assertWritable(project, auth);
+    } catch (error) {
+      return domainErrorResponse(c, error);
+    }
 
     const started = await startWorkflowForTask(deps.sql, {
       organizationId: c.get('organizationId'),


### PR DESCRIPTION
Closes the cross-org tenant-isolation and missing-authorization class in the tasks domain. An agent drafted part of this and was killed mid-task; every draft hunk was re-verified against main before completion.

## Findings and fixes

**1. Task guards never check org (critical)** — `domains/tasks/service.ts`
`loadTaskOrThrow` now takes the organization and filters `org_id` (service.ts:251); `assertTaskReadable`/`assertTaskWritable` refuse a foreign-org project as `PROJECT_NOT_FOUND` 404 before the org-relative role matrix runs (service.ts:175-214) — the projects-domain `assertSameOrg` idiom, so a leaked id confirms nothing and the `checkProjectAccess` admin bypass can no longer cross orgs. All ~20 `/:taskId` routes inherit the fix through the loaders; `createTask`'s bespoke `ORG_FORBIDDEN` 403 collapsed into the shared 404-opaque guard. Callers swept across the workspace (comments, reviews, external-ref route lanes, connectors task store, agent-turn shim, REST v1) — typecheck-verified.
Regression: `domains/tasks/service.test.ts` (foreign-org owner → 404 on read and write; opacity equality) + integration probes (foreign org owner GET/status/DELETE by id → 404, task untouched).

**2. `task_upsert_by_external_ref` dedupes without org (critical)** — `domains/tasks/external-ref.ts:63`
The `dedupeScope:'project'` branch now rides `org_id` beside the caller-supplied `project_id` (the org branch already did; the create lane already validated the project's org at external-ref.ts:326) — a foreign project id can neither resolve, update, nor create across the boundary, including through the sandbox bridge (`workspace_domain_tools` → `workspace-write-shim`), which passes a trusted org and a caller-influenced project.
Regression: integration probe — upsert naming a foreign project → `PROJECT_NOT_FOUND`, foreign task untouched.

**3. `respondToTaskReview` had no project access check (high)** — `domains/tasks/reviews.ts:534`
The respond door now loads the project and asserts task-edit access before recording anything: deciding a review IS deciding the task (approve completes it, request-changes kicks the agent). The `review_policy` file checks only narrow WHO among the writers.
Regression: integration probe — a read-only member's respond → `RBAC_FORBIDDEN`, approval stays `pending`.

**4. Run start/cancel behind the read gate, cancel before authz (high)** — `domains/tasks/routes.ts:996,1036`
`POST /:taskId/workflow/{start,cancel}` assert **writable** before any side effect (starting spends budget and moves the card; cancelling killed the live run before the status write's assert could throw). The run cancel and the `cancelled` status flip now share one `transactSerializable` — a refused flip (open subtasks, archived) rolls the cancel back instead of leaving a dead run behind an error response. REST `POST /tasks/{id}/start` gets the same write gate (rest/v1-tasks.ts:301).
Regression: integration probes — read-only member start/cancel → 403 with the run still `running`; foreign-org cancel → 404, run and task untouched.

**5. Check-then-insert dedupe with no unique index (high)** — `external-ref.ts:360`, migration `0059`
`db/migrations/0059_tasks_external_ref_unique.sql` adds the partial unique index `tasks_project_external_unique (project_id, external_system, external_id) WHERE both NOT NULL`, deterministically resolving existing duplicates first: per group the oldest row (`created_at_ms`, id tiebreak) keeps the binding; newer duplicates are **detached** (refs nulled), never deleted, keeping `external_url` for traceability. The insert becomes `ON CONFLICT … DO NOTHING` with a reconcile-the-winner lane, so a lost race updates the surviving task (`created:false`) instead of duplicating the task and its workflow run; serializable callers converge through the 40001 retry. Per-project key on purpose: `dedupeScope:'project'` legitimately allows the same ref in two projects, so org-scope dedupe stays lookup-only.
Regression: integration probe — two concurrent intakes land exactly one task (`created=[false,true]`), replay reconciles. Migration dirty-data lane proven by replaying 0059 over a pre-0059 schema seeded with a 3-row duplicate group, a created_at tie, a sibling-project row, and null-ref rows: oldest kept, tie broken by id, others detached with data intact, re-run idempotent (`UPDATE 0`, index skip).

**6. Collab task subscriptions unverified (high)** — `domains/collab/routes.ts:131`
GET/POST `/collab/tasks/:taskId/subscription` now load the task org-scoped and assert the project read gate; a foreign or invisible task answers 404 exactly like the task surface, and a garbage id answers 404 instead of a 500 on the FK.
Regression: integration probes — cross-org get/set → 404 with the subscription set unchanged; garbage id → 404.

## Draft hunks reverted

None. Every draft hunk verified in-class and kept. The two out-of-class-looking files are the blast radius of the `loadTaskOrThrow`/`handTaskToInProgressForKick` signature changes:

- `domains/connectors/service.ts` — the workflow task store's `get` now passes the org into the loader; behavior identical (org-miss → `null` via the existing catch).
- `domains/tasks/comments.ts` + `agent-turn-shim.ts` — same sweep; the shim handler already binds `args.organizationId`.

## Examined, deliberately unchanged (out of this class)

- `GET /tasks/pending-reviews` and `GET /:taskId/review` — org-filtered reads returning opaque ids; with the respond door now gated they enable no mutation. Same-org cross-team read narrowing is a separate (lower-sev) concern.
- `POST /tasks/from-external-issue` stays read-gated: the desk "file a request" door, same deliberate READ-level posture as task commenting (`comments.ts` documents it). Its project-org validation is covered by fix 1/2.
- The steer-miss `kickFallback` missing `organizationId` (separate triage finding; that lane already throws on main before reaching the swept call).

## Verification

- `bun run --filter @tale/platform typecheck` — clean (proves the caller sweep).
- `bun run --filter @tale/platform lint` — clean.
- `bun run --filter @tale/platform test` — 373 files / 72280 tests green (includes the new `service.test.ts`; the cross-org case fails on main by construction — main's guards never throw there).
- `bun run --filter @tale/platform backend:integration` against a throwaway tale-db + MinIO — full suite green including the six new probes, matching a control run of main's tip in the same environment. (An earlier probe draft had the suite's main user own the rival org; that flipped the user multi-org and poisoned later REST sections, whose API keys resolve their org implicitly — the shipped probes give the rival org a dedicated attacker user, which is also the more faithful attack shape.)
- `migrations:check` (named in the task) does not exist in this repo — the migration proof is `backend:integration` (boot-migrates twice concurrently) per `.agents/skills/create-migration/SKILL.md`, plus the manual dirty-data replay above.
