### PR TITLE
fix(platform): repair boot and serving-shell dead-ends

### DIFF
--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -457,7 +457,13 @@ WORKDIR /app
 # Run as root so entrypoint can fix volume ownership before dropping to app user
 USER root
 
-# Re-declare all ENV vars (FROM scratch drops upstream ENV directives)
+# Re-declare all ENV vars (FROM scratch drops upstream ENV directives).
+# MUST mirror the runner stage's ENV block above, name for name — the squash
+# is what ships, so a var declared only in the runner is silently absent from
+# every deployed container (KNOWLEDGE_MIGRATIONS_DIR was dropped exactly this
+# way, regressing the BYO-corpus bootstrap to "apply the migrations
+# yourself"). tests/guards/dockerfile-env-parity.guard.test.ts pins the two
+# blocks equal.
 ENV NODE_ENV=production \
     TALE_VERSION=${VERSION} \
     PORT=3000 \
@@ -466,7 +472,8 @@ ENV NODE_ENV=production \
     DO_NOT_TRACK=1 \
     TALE_CONFIG_DIR=/app/data \
     TALE_CONFIG_BUILTIN_DIR=/app/builtin \
-    TALE_CONFIG_SYSTEM_DIR=/app/system
+    TALE_CONFIG_SYSTEM_DIR=/app/system \
+    KNOWLEDGE_MIGRATIONS_DIR=/app/db/migrations/knowledge-db
 
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api/health || exit 1

--- a/services/platform/backend/core/conversations/ingest/materialize_email_attachments.test.ts
+++ b/services/platform/backend/core/conversations/ingest/materialize_email_attachments.test.ts
@@ -87,6 +87,50 @@ describe('materializeEmailAttachments', () => {
   // uploaded parked instead — invisibly, since a parked row still reads
   // "Queued", which is one of the few statuses RagStatusBadge gives no retry
   // affordance, and the watchdog skips parked rows by design.
+  // Regression: the minted URL used to point at the retired 0.4
+  // `/http_api/storage` door — mounted nowhere in the 0.5 backend and
+  // forwarded by no proxy lane — so every ingested attachment stored a dead
+  // link. It must mint the session-gated serve lane instead.
+  it('mints the serve-lane URL, never the retired /http_api/storage', async () => {
+    const ctx = {
+      runAction: vi.fn(async () => 's3:acme/blob-uuid-1'),
+      runMutation: vi.fn(async () => null),
+      storage: { getUrl: vi.fn() },
+    };
+    const emails = await materializeEmailAttachments(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+      ctx as never,
+      {
+        organizationId: 'org_1',
+        source: 'imap-smtp',
+        emails: [
+          {
+            messageId: '<cv@x>',
+            attachments: [
+              {
+                id: 'cv',
+                filename: 'CV.pdf',
+                contentType: 'application/pdf',
+                size: 3,
+                contentBase64: Buffer.from('pdf').toString('base64'),
+              },
+            ],
+          },
+        ],
+      },
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by the assertions below
+    const att = (emails[0] as { attachments: Array<{ url?: string }> })
+      .attachments[0];
+    expect(att?.url).toBeDefined();
+    const url = new URL(att?.url ?? '');
+    expect(url.pathname).toBe('/api/app/files/serve');
+    expect(url.searchParams.get('orgId')).toBe('org_1');
+    expect(url.searchParams.get('ref')).toBe('s3:acme/blob-uuid-1');
+    expect(url.searchParams.get('filename')).toBe('CV.pdf');
+    expect(att?.url).not.toContain('/http_api/storage');
+  });
+
   it('stores attachments without claiming a RAG indexing slot', async () => {
     const saved: Array<Record<string, unknown>> = [];
     const ctx = {

--- a/services/platform/backend/core/conversations/ingest/materialize_email_attachments.ts
+++ b/services/platform/backend/core/conversations/ingest/materialize_email_attachments.ts
@@ -16,11 +16,7 @@
 import { isRecord } from '../../../../lib/utils/type-utils';
 import type { ActionCtx } from '../../lib/ctx';
 import { internal } from '../../lib/handler_names';
-import {
-  buildBlobServeUrl,
-  buildDownloadUrl,
-} from '../../lib/helpers/public_storage_url';
-import { isS3Ref } from '../../lib/storage/blob_ref';
+import { buildBlobServeUrl } from '../../lib/helpers/public_storage_url';
 
 type WireAttachment = {
   id: string;
@@ -116,13 +112,11 @@ async function storeAttachment(
     },
   );
 
-  let url: string;
-  if (isS3Ref(storageId)) {
-    url = buildBlobServeUrl(storageId, organizationId, att.filename);
-  } else {
-    // Named `/storage` download so the browser saves under the real filename.
-    url = buildDownloadUrl(storageId, att.filename);
-  }
+  // Stable serve-lane URL for Inbox (the download anchor + inline cid
+  // images); it 302s to a fresh presigned GET at open time, named after the
+  // real filename. `putOrgBlobBytes` behind `storeOrgBlob` always answers an
+  // `s3:` ref in 0.5, so the one builder covers every stored attachment.
+  const url = buildBlobServeUrl(storageId, organizationId, att.filename);
 
   return {
     id: att.id,

--- a/services/platform/backend/core/lib/helpers/public_storage_url.test.ts
+++ b/services/platform/backend/core/lib/helpers/public_storage_url.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { createApp } from '../../../app.ts';
 import {
+  buildBlobServeUrl,
   SANDBOX_CONVEX_HTTP_API_BASE_DEFAULT,
   SANDBOX_CONVEX_STORAGE_BASE_DEFAULT,
   toSandboxStorageUrl,
@@ -73,5 +75,76 @@ describe('sandbox→convex reachability contract', () => {
         'http://convex:3210/api/storage/abc',
       );
     });
+  });
+});
+
+/**
+ * The blob-serve builder must mint URLs that land on a route the 0.5 app
+ * ACTUALLY MOUNTS. It used to mint the retired 0.4 `/http_api/storage` door
+ * — mounted nowhere and forwarded by no proxy lane — so every stored email
+ * attachment rendered as a dead link. These tests assert against the real
+ * app router (createApp with stub deps), not a string constant: the minted
+ * path must reach a mounted lane (the session gate answers, not Hono's
+ * 404), and the retired path must stay unmounted.
+ */
+
+function stubApp() {
+  const sql = () => Promise.resolve([]);
+  const auth = {
+    handler: () => Promise.resolve(new Response(null, { status: 404 })),
+    api: { getSession: () => Promise.resolve(null) },
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+  return createApp({ sql: sql as never, auth: auth as never });
+}
+
+describe('buildBlobServeUrl', () => {
+  beforeEach(() => {
+    process.env.SITE_URL = 'https://tale.example';
+    delete process.env.BASE_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.SITE_URL;
+    delete process.env.BASE_PATH;
+  });
+
+  it('mints a URL the app router actually mounts', async () => {
+    const app = stubApp();
+    const url = buildBlobServeUrl('s3:acme/blob-1', 'org_1', 'Report Q3.pdf');
+    const { pathname, search, origin } = new URL(url);
+    expect(origin).toBe('https://tale.example');
+
+    const res = await app.request(`${pathname}${search}`);
+    // The SESSION GATE answers (stubbed sessionless → 401): the path reached
+    // the mounted files lane. Hono's own 404 would mean a dead link again.
+    expect(res.status).toBe(401);
+  });
+
+  it('carries orgId, ref, and filename for the serve lane', () => {
+    const url = new URL(
+      buildBlobServeUrl('s3:acme/blob-1', 'org_1', 'Report Q3.pdf'),
+    );
+    expect(url.pathname).toBe('/api/app/files/serve');
+    expect(url.searchParams.get('orgId')).toBe('org_1');
+    expect(url.searchParams.get('ref')).toBe('s3:acme/blob-1');
+    expect(url.searchParams.get('filename')).toBe('Report Q3.pdf');
+  });
+
+  it('honors BASE_PATH sub-path deployments', () => {
+    process.env.BASE_PATH = '/tale';
+    const url = buildBlobServeUrl('s3:acme/blob-1', 'org_1');
+    expect(
+      url.startsWith('https://tale.example/tale/api/app/files/serve?'),
+    ).toBe(true);
+    expect(new URL(url).searchParams.get('filename')).toBeNull();
+  });
+
+  it('the retired /http_api/storage door stays unmounted', async () => {
+    const app = stubApp();
+    const res = await app.request(
+      '/http_api/storage?ref=s3:acme/blob-1&org=org_1',
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/services/platform/backend/core/lib/helpers/public_storage_url.ts
+++ b/services/platform/backend/core/lib/helpers/public_storage_url.ts
@@ -30,29 +30,40 @@ export function getPublicHttpApiUrl(): string {
 }
 
 /**
- * Build a download URL for a file stored in Convex storage.
- *
- * Uses the custom HTTP endpoint that sets Content-Disposition header,
- * ensuring the downloaded file has the correct filename.
+ * Public base for the backend's session-facing app API (`/api/app/...`) —
+ * mounted in backend/app.ts and forwarded whole by the proxy's `/api/app/*`
+ * lane.
  */
-export function buildDownloadUrl(storageId: string, fileName: string): string {
-  return `${getPublicHttpApiUrl()}/storage?id=${storageId}&filename=${encodeURIComponent(fileName)}`;
+export function getPublicAppApiUrl(): string {
+  const siteUrl = process.env.SITE_URL;
+  if (!siteUrl) {
+    throw new Error('Missing required environment variable: SITE_URL');
+  }
+  const basePath = process.env.BASE_PATH ?? '';
+  return `${siteUrl.replace(/\/$/, '')}${basePath}/api/app`;
 }
 
 /**
- * Build the `/storage` route URL for an `s3:` blob reference. A Convex query
- * cannot presign S3, so it hands the browser this URL instead; the node
- * `/storage` httpAction resolves the org's bucket (from `org`, the Better Auth
- * organization id) and 302-redirects to a short-lived presigned GET. `org` is
- * REQUIRED for an S3 ref — the route needs it to address the right bucket.
+ * Stable, link-shaped URL for an org blob — stored on ingested email
+ * attachments and opened directly by the browser (the download anchor and
+ * the inline cid images in conversation messages). Points at the backend's
+ * session-gated serve lane (`GET /api/app/files/serve`), which answers a 302
+ * to a short-lived presigned GET at OPEN time: a presigned URL minted here
+ * would expire in storage, and the 0.4 `/http_api/storage` door this used to
+ * mint is mounted nowhere in 0.5 — those URLs fell through to the SPA
+ * catch-all as dead links. `orgId` addresses the org's bucket and is what
+ * the lane's membership gate checks the session against.
  */
 export function buildBlobServeUrl(
   ref: string,
   orgId: string,
   fileName?: string,
 ): string {
-  const base = `${getPublicHttpApiUrl()}/storage?ref=${encodeURIComponent(ref)}&org=${encodeURIComponent(orgId)}`;
-  return fileName ? `${base}&filename=${encodeURIComponent(fileName)}` : base;
+  const params = new URLSearchParams({ orgId, ref });
+  if (fileName !== undefined && fileName !== '') {
+    params.set('filename', fileName);
+  }
+  return `${getPublicAppApiUrl()}/files/serve?${params.toString()}`;
 }
 
 /**

--- a/services/platform/backend/core/lib/rest/helpers.test.ts
+++ b/services/platform/backend/core/lib/rest/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   BadRequestError,
+  extractPathParts,
   httpStatusForConvexCode,
   optionalBoolean,
   optionalEnum,
@@ -294,5 +295,58 @@ describe('REST_CORS_HEADERS', () => {
     const allowHeaders = REST_CORS_HEADERS['Access-Control-Allow-Headers'];
     expect(allowHeaders).toContain('Authorization');
     expect(allowHeaders).toContain('X-Organization-Slug');
+  });
+});
+
+/**
+ * `extractPathParts` must LOCATE the prefix, not assume it at position 0: the
+ * SCIM door is mounted on `/scim/v2` AND the 0.4 proxy-era alias
+ * `/http_api/scim/v2` (the tenant URL the admin UI advertises to IdPs), and
+ * the dispatchers parse the raw request URL. `/http_api/scim/` is exactly as
+ * long as `/scim/v2/Users/`, so the old blind slice turned every alias-mount
+ * per-resource op into `id: 'v2'` — IdP update/deactivate/delete all 404ed.
+ */
+describe('extractPathParts', () => {
+  it('parses the id on the bare mount', () => {
+    const url = new URL('https://tale.example/scim/v2/Users/u_123');
+    expect(extractPathParts(url, '/scim/v2/Users/')).toEqual({
+      id: 'u_123',
+      subPath: null,
+    });
+  });
+
+  it('parses the id on the /http_api alias mount', () => {
+    const url = new URL('https://tale.example/http_api/scim/v2/Users/u_123');
+    expect(extractPathParts(url, '/scim/v2/Users/')).toEqual({
+      id: 'u_123',
+      subPath: null,
+    });
+  });
+
+  it('parses group ids on both mounts', () => {
+    const bare = new URL('https://tale.example/scim/v2/Groups/team_9');
+    const alias = new URL(
+      'https://tale.example/http_api/scim/v2/Groups/team_9',
+    );
+    expect(extractPathParts(bare, '/scim/v2/Groups/').id).toBe('team_9');
+    expect(extractPathParts(alias, '/scim/v2/Groups/').id).toBe('team_9');
+  });
+
+  it('answers an empty id when the pathname lacks the prefix entirely', () => {
+    const url = new URL('https://tale.example/scim/v2/Users');
+    expect(extractPathParts(url, '/scim/v2/Users/')).toEqual({
+      id: '',
+      subPath: null,
+    });
+  });
+
+  it('keeps sub-path extraction working after the prefix', () => {
+    const url = new URL(
+      'https://tale.example/api/v1/documents/abc123/retry-indexing',
+    );
+    expect(extractPathParts(url, '/api/v1/documents/')).toEqual({
+      id: 'abc123',
+      subPath: 'retry-indexing',
+    });
   });
 });

--- a/services/platform/backend/core/lib/rest/helpers.ts
+++ b/services/platform/backend/core/lib/rest/helpers.ts
@@ -186,17 +186,32 @@ export async function requireRestDeveloper(rc: RestContext): Promise<void> {
 /**
  * Extract path segments after a prefix.
  *
+ * The prefix is LOCATED in the pathname rather than assumed at position 0:
+ * some doors are mounted on more than one path (the SCIM routes serve
+ * `/scim/v2/...` and the 0.4 proxy-era alias `/http_api/scim/v2/...` — the
+ * one the admin UI advertises as the tenant URL), and the handlers parse the
+ * RAW request URL, which carries whichever mount the caller used. Every
+ * prefix starts with `/`, so a match always sits on a segment boundary. A
+ * pathname that does not contain the prefix yields an empty id — the caller
+ * answers 400/404 — instead of mis-slicing unrelated segments into an id
+ * (the bug that broke per-resource SCIM ops on the advertised alias, where
+ * `/http_api/scim/` is exactly as long as `/scim/v2/Users/`).
+ *
  * Example: extractPathParts('/api/v1/documents/abc123/retry-indexing', '/api/v1/documents/')
  *   → { id: 'abc123', subPath: 'retry-indexing' }
  *
- * Example: extractPathParts('/api/v1/documents/abc123', '/api/v1/documents/')
- *   → { id: 'abc123', subPath: null }
+ * Example: extractPathParts('/http_api/scim/v2/Users/u1', '/scim/v2/Users/')
+ *   → { id: 'u1', subPath: null }
  */
 export function extractPathParts(
   url: URL,
   prefix: string,
 ): { id: string; subPath: string | null } {
-  const rest = url.pathname.slice(prefix.length);
+  const at = url.pathname.indexOf(prefix);
+  if (at === -1) {
+    return { id: '', subPath: null };
+  }
+  const rest = url.pathname.slice(at + prefix.length);
   const parts = rest.split('/').filter(Boolean);
   return {
     id: parts[0] ?? '',

--- a/services/platform/backend/core/scim/http_actions.test.ts
+++ b/services/platform/backend/core/scim/http_actions.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  scimGroupResourceImpl,
+  scimUserResourceImpl,
+  type ScimRc,
+} from './http_actions';
+
+/**
+ * Per-resource SCIM ops must resolve the SAME resource id on both mounts:
+ * the bare `/scim/v2` one and the 0.4 proxy-era `/http_api/scim/v2` alias —
+ * the tenant URL the admin UI advertises to IdPs and the one `meta.location`
+ * carries. `/http_api/scim/` is exactly as long as `/scim/v2/Users/`, so the
+ * old blind prefix slice parsed the alias path into `id: 'v2'`: an IdP
+ * configured with the advertised URL could create and list users but every
+ * GET/PUT/PATCH/DELETE on `/Users/:id` and `/Groups/:id` answered 404 —
+ * offboarding silently failed.
+ */
+
+function stubRc(): {
+  rc: ScimRc;
+  runQuery: ReturnType<typeof vi.fn>;
+  runMutation: ReturnType<typeof vi.fn>;
+} {
+  // Queries answer "no record" and mutations "not-found": the dispatchers
+  // then 404 with the id they RESOLVED, which is exactly what these tests
+  // pin — resolution, not the data layer.
+  const runQuery = vi.fn(async () => null);
+  const runMutation = vi.fn(async () => 'not-found');
+  const ctx = { runQuery, runMutation, runAction: vi.fn() };
+  return {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+    rc: { ctx: ctx as never, organizationId: 'org_1', defaultRole: 'member' },
+    runQuery,
+    runMutation,
+  };
+}
+
+describe('scimUserResourceImpl id resolution', () => {
+  it.each([
+    ['bare mount', 'https://tale.example/scim/v2/Users/u_123'],
+    ['alias mount', 'https://tale.example/http_api/scim/v2/Users/u_123'],
+  ])('resolves the user id on the %s', async (_mount, url) => {
+    const { rc, runQuery } = stubRc();
+    const res = await scimUserResourceImpl(rc, new Request(url));
+    expect(runQuery).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'org_1',
+      userId: 'u_123',
+    });
+    // The stub has no record, so the honest answer is a 404 naming the REAL
+    // id — never a 400 "Missing user id" or a lookup of the mis-parsed 'v2'.
+    expect(res.status).toBe(404);
+  });
+
+  it('deletes by the real id on the alias mount', async () => {
+    const { rc, runMutation } = stubRc();
+    const res = await scimUserResourceImpl(
+      rc,
+      new Request('https://tale.example/http_api/scim/v2/Users/u_123', {
+        method: 'DELETE',
+      }),
+    );
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'org_1',
+      userId: 'u_123',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('still answers 400 when no id follows the collection path', async () => {
+    const { rc, runQuery } = stubRc();
+    const res = await scimUserResourceImpl(
+      rc,
+      new Request('https://tale.example/scim/v2/Users'),
+    );
+    expect(res.status).toBe(400);
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('scimGroupResourceImpl id resolution', () => {
+  it.each([
+    ['bare mount', 'https://tale.example/scim/v2/Groups/team_9'],
+    ['alias mount', 'https://tale.example/http_api/scim/v2/Groups/team_9'],
+  ])('resolves the group id on the %s', async (_mount, url) => {
+    const { rc, runQuery } = stubRc();
+    const res = await scimGroupResourceImpl(rc, new Request(url));
+    expect(runQuery).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'org_1',
+      teamId: 'team_9',
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/services/platform/backend/domains/files/routes.ts
+++ b/services/platform/backend/domains/files/routes.ts
@@ -368,6 +368,33 @@ export function createFileRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
     return c.json({ urls });
   });
 
+  /**
+   * Link-shaped blob serve: 302 to a fresh presigned GET. This is the STABLE
+   * URL stored on ingested email attachments (`buildBlobServeUrl`) — a
+   * presigned URL minted at ingest would expire, and the 0.4 `/http_api/
+   * storage` door it used to point at retired with the Convex runtime.
+   * Session + org gated like every other lane here (the browser opens it
+   * same-origin, so cookies ride along); `requireOrgScopedKey` inside
+   * `getFileUrl` refuses a ref outside the caller's org. Declared before the
+   * `/:fileId` routes so `serve` never parses as a file id.
+   */
+  app.get('/serve', async (c) => {
+    const ref = c.req.query('ref');
+    if (!ref) return c.json({ error: 'ref is required' }, 400);
+    const filename = c.req.query('filename');
+    try {
+      const url = await getFileUrl(
+        deps.sql,
+        { organizationId: c.get('orgId') },
+        ref,
+        filename !== undefined && filename !== '' ? { filename } : {},
+      );
+      return c.redirect(url, 302);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  });
+
   app.get('/:fileId', async (c) => {
     try {
       const meta = await getFileMetadataByIdOrRef(

--- a/services/platform/backend/domains/files/service.ts
+++ b/services/platform/backend/domains/files/service.ts
@@ -214,16 +214,24 @@ export async function getFileMetadataByIdOrRef(
   return rows[0] ?? null;
 }
 
-/** Presigned GET for a blob ref the caller's org owns. */
+/**
+ * Presigned GET for a blob ref the caller's org owns. A `filename` presigns
+ * with `response-content-disposition: attachment` so the browser saves under
+ * the real name (object keys are `<org>/<uuid>`, nameless by design); omit
+ * it for inline rendering.
+ */
 export async function getFileUrl(
   sql: Sql,
   scope: { organizationId: string },
   storageRef: string,
+  opts: { filename?: string } = {},
 ): Promise<string> {
   const { orgSlug, store } = await requireOrgStore(sql, scope.organizationId);
   const key = requireOrgScopedKey(storageRef, orgSlug);
   // Handed to the browser, so signed against the origin it can reach.
-  return s3PresignGetUrl(browserFacing(store), key);
+  return s3PresignGetUrl(browserFacing(store), key, {
+    ...(opts.filename !== undefined && { filename: opts.filename }),
+  });
 }
 
 /**

--- a/services/platform/backend/env.test.ts
+++ b/services/platform/backend/env.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import { loadEnv } from './env.ts';
@@ -38,5 +40,47 @@ describe('loadEnv', () => {
     expect(() =>
       loadEnv({ DATABASE_URL: 'postgres://x', ROLE: 'ui' }),
     ).toThrow();
+  });
+
+  /**
+   * The container entrypoint's api/worker branch execs node BEFORE the web
+   * lane's shell derivation runs, so the backend must derive the WebDAV
+   * app-password HMAC key itself at boot — otherwise split-role deployments
+   * silently lose WebDAV, app-password minting, hostcall signing, and
+   * sandbox stage tokens, while the docs promise automatic derivation.
+   */
+  describe('WebDAV HMAC key derivation', () => {
+    const secret = 'a'.repeat(64);
+    const derived = createHash('sha256')
+      .update(`${secret}:webdav-hmac:v1`)
+      .digest('hex');
+
+    it('derives the key from INSTANCE_SECRET onto the boot env', () => {
+      const source: NodeJS.ProcessEnv = {
+        DATABASE_URL: 'postgres://x',
+        INSTANCE_SECRET: secret,
+      };
+      loadEnv(source);
+      // Byte-identical to docker-entrypoint.sh's web-lane derivation:
+      //   printf '%s' "${INSTANCE_SECRET}:webdav-hmac:v1" | sha256sum
+      expect(source.WEBDAV_APP_PASSWORD_HMAC_KEY).toBe(derived);
+    });
+
+    it('never overrides an explicitly set key (operator rotation)', () => {
+      const explicit = 'f'.repeat(64);
+      const source: NodeJS.ProcessEnv = {
+        DATABASE_URL: 'postgres://x',
+        INSTANCE_SECRET: secret,
+        WEBDAV_APP_PASSWORD_HMAC_KEY: explicit,
+      };
+      loadEnv(source);
+      expect(source.WEBDAV_APP_PASSWORD_HMAC_KEY).toBe(explicit);
+    });
+
+    it('leaves the key unset without INSTANCE_SECRET (minimal dev)', () => {
+      const source: NodeJS.ProcessEnv = { DATABASE_URL: 'postgres://x' };
+      loadEnv(source);
+      expect(source.WEBDAV_APP_PASSWORD_HMAC_KEY).toBeUndefined();
+    });
   });
 });

--- a/services/platform/backend/env.ts
+++ b/services/platform/backend/env.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ensureWebdavHmacKey } from '../lib/webdav/hmac-key.ts';
+
 /**
  * Process roles: `api` serves HTTP/SSE, `worker` runs pg-boss task queues,
  * `all` runs both in one process (local-dev convenience). Deployment starts
@@ -28,5 +30,15 @@ const envSchema = z.object({
 export type BackendEnv = z.infer<typeof envSchema>;
 
 export function loadEnv(source: NodeJS.ProcessEnv = process.env): BackendEnv {
+  // The WebDAV app-password HMAC key derives from INSTANCE_SECRET when not
+  // set explicitly — `ensureWebdavHmacKey` (the single derivation, pinned by
+  // test to docker-entrypoint.sh's web-lane sha256) caches it onto `source`
+  // so every lazy reader (webdav hash + verify, hostcall tokens, sandbox
+  // stage tokens) picks it up. The container entrypoint's api/worker branch
+  // execs node BEFORE the web lane's shell derivation runs, so without this
+  // the backend roles never receive the key and every WebDAV/app-password/
+  // stage-token op refuses in split-role deployments. No INSTANCE_SECRET
+  // (minimal dev setups) leaves the key unset, exactly as before.
+  ensureWebdavHmacKey(source);
   return envSchema.parse(source);
 }

--- a/services/platform/backend/http-shutdown.test.ts
+++ b/services/platform/backend/http-shutdown.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AuthEnv } from './auth/session.ts';
+import { closeServerGracefully } from './http-shutdown.ts';
+import { createEventsHandler, endAllEventStreams } from './realtime/sse.ts';
+
+/**
+ * Graceful shutdown must resolve while `/events` SSE clients are connected:
+ * `server.close()` waits for every open connection and an SSE response never
+ * ends on its own (15s heartbeats; the loop exits only on client abort), so
+ * a bare close parked shutdown until the orchestrator's SIGKILL — jobs died
+ * mid-write on every deploy with a browser open. These tests drive the REAL
+ * server (`serve`) with the REAL events handler over a live socket.
+ */
+
+/** Tagged-template `sql` stub routed on query text — the three reads the
+ *  events lane performs (membership, outbox tail, hints after cursor). */
+function fakeSql(strings: TemplateStringsArray): Promise<unknown[]> {
+  const query = strings.join('?');
+  if (query.includes('FROM "member"')) {
+    return Promise.resolve([
+      { id: 'm1', organizationId: 'org1', userId: 'u1', role: 'member' },
+    ]);
+  }
+  if (query.includes('max(id)')) {
+    return Promise.resolve([{ max: '0' }]);
+  }
+  return Promise.resolve([]);
+}
+
+interface Harness {
+  server: ReturnType<typeof serve>;
+  origin: string;
+}
+
+const harnesses: Harness[] = [];
+
+function startServer(): Promise<Harness> {
+  const app = new Hono<AuthEnv>();
+  app.use(async (c, next) => {
+    // requireSession's contract, minus the auth round-trip.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+    c.set('sessionBundle', { user: { id: 'u1' } } as never);
+    await next();
+  });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub
+  app.get('/events', createEventsHandler(fakeSql as never));
+  // A non-SSE response that never ends and is NOT in the stream registry —
+  // stands in for any long streaming response the registry cannot see.
+  app.get('/hang', () => new Response(new ReadableStream<Uint8Array>()));
+
+  return new Promise((resolve) => {
+    const server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+      const harness: Harness = {
+        server,
+        origin: `http://127.0.0.1:${info.port}`,
+      };
+      harnesses.push(harness);
+      resolve(harness);
+    });
+  });
+}
+
+async function openEventStream(origin: string): Promise<Response> {
+  const res = await fetch(`${origin}/events?orgId=org1`);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('text/event-stream');
+  return res;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterEach(async () => {
+  // Belt and braces so one failing test never wedges the runner.
+  endAllEventStreams();
+  for (const { server } of harnesses.splice(0)) {
+    if ('closeAllConnections' in server) server.closeAllConnections();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+});
+
+describe('closeServerGracefully', () => {
+  it('a bare server.close() parks while an /events stream is open', async () => {
+    const { server, origin } = await startServer();
+    await openEventStream(origin);
+
+    let closed = false;
+    const closePromise = new Promise<void>((resolve) => {
+      server.close(() => {
+        closed = true;
+        resolve();
+      });
+    });
+    await sleep(500);
+    // The regression premise: with one SSE client, close never fires.
+    expect(closed).toBe(false);
+
+    // Ending the streams is exactly what unblocks it — plus one idle sweep,
+    // because close() reaps idle connections only at the moment it is
+    // called, and this connection goes idle a tick AFTER the stream ends.
+    expect(endAllEventStreams()).toBe(1);
+    await sleep(300);
+    if ('closeIdleConnections' in server) server.closeIdleConnections();
+    await closePromise;
+    expect(closed).toBe(true);
+  });
+
+  it('resolves with an open /events client, via the graceful path', async () => {
+    const { server, origin } = await startServer();
+    const res = await openEventStream(origin);
+
+    const startedAt = Date.now();
+    await closeServerGracefully(server, { forceAfterMs: 4_000 });
+    // Well before the force deadline: the stream registry did the work.
+    expect(Date.now() - startedAt).toBeLessThan(3_000);
+
+    // The client observes its stream ending rather than hanging forever.
+    const reader = res.body?.getReader();
+    if (reader) {
+      await expect(
+        Promise.race([reader.read(), sleep(2_000).then(() => 'timeout')]),
+      ).resolves.not.toBe('timeout');
+    }
+  });
+
+  it('force-closes connections the registry cannot see at the deadline', async () => {
+    const { server, origin } = await startServer();
+    const hang = fetch(`${origin}/hang`);
+    await hang; // headers received — the response body never ends
+
+    const startedAt = Date.now();
+    await closeServerGracefully(server, { forceAfterMs: 300 });
+    const elapsed = Date.now() - startedAt;
+    expect(elapsed).toBeGreaterThanOrEqual(280);
+    expect(elapsed).toBeLessThan(3_000);
+  });
+});

--- a/services/platform/backend/http-shutdown.ts
+++ b/services/platform/backend/http-shutdown.ts
@@ -1,0 +1,72 @@
+import type { ServerType } from '@hono/node-server';
+
+import { endAllEventStreams } from './realtime/sse.ts';
+
+/**
+ * How long `close` may wait for in-flight requests before force-closing the
+ * remaining connections. Must land well under the orchestrator's kill grace
+ * (compose default: 10s to SIGKILL; backend-api sets no stop_grace_period)
+ * so `boss.stop({ graceful: true })`, `sql.end`, and the error-reporting
+ * flush still get their turn — a request cut at the deadline is retryable,
+ * a SIGKILL mid-job is not.
+ */
+const FORCE_CLOSE_AFTER_MS = 5_000;
+
+/**
+ * How often to sweep freshly-idle connections while close is pending.
+ * `server.close()` reaps idle keep-alive connections once, at the moment it
+ * is called; a connection whose response ends a tick LATER (exactly what
+ * ending the SSE streams produces) is never reaped server-side and lingers
+ * until the CLIENT's keep-alive timer closes it (undici: 4s) — observed as
+ * shutdown stalling to the force deadline. The sweep closes them as they
+ * become idle; in-flight requests are untouched.
+ */
+const IDLE_REAP_INTERVAL_MS = 200;
+
+/**
+ * Close the HTTP server without hanging on connections that never end.
+ *
+ * `server.close()` waits for every open connection, and the `/events` SSE
+ * responses never end on their own (15s heartbeats; their loop exits only on
+ * client abort) — so with any browser connected, a plain close never
+ * resolved and every deploy ended in SIGKILL with in-flight jobs killed
+ * mid-write. Two measures, layered:
+ *
+ * 1. Proactively end every live SSE stream ({@link endAllEventStreams}) —
+ *    the graceful path: clients reconnect and resume via `Last-Event-ID`.
+ * 2. After {@link FORCE_CLOSE_AFTER_MS}, force-close whatever connections
+ *    remain (long streaming responses, stuck keep-alives) — the backstop
+ *    that keeps the deadline honest for anything the registry cannot see.
+ */
+export async function closeServerGracefully(
+  server: ServerType,
+  options: { forceAfterMs?: number } = {},
+): Promise<void> {
+  const forceAfterMs = options.forceAfterMs ?? FORCE_CLOSE_AFTER_MS;
+  const ended = endAllEventStreams();
+  if (ended > 0) {
+    console.log(`[backend] ended ${ended} open /events stream(s) for shutdown`);
+  }
+  await new Promise<void>((resolve) => {
+    // The `in` checks narrow ServerType: the http/1 server (what `serve`
+    // builds here) has both close methods, the HTTP/2 flavors do not.
+    const reap = setInterval(() => {
+      if ('closeIdleConnections' in server) {
+        server.closeIdleConnections();
+      }
+    }, IDLE_REAP_INTERVAL_MS);
+    const force = setTimeout(() => {
+      if ('closeAllConnections' in server) {
+        console.warn(
+          `[backend] connections still open after ${forceAfterMs}ms — force-closing`,
+        );
+        server.closeAllConnections();
+      }
+    }, forceAfterMs);
+    server.close(() => {
+      clearInterval(reap);
+      clearTimeout(force);
+      resolve();
+    });
+  });
+}

--- a/services/platform/backend/main.ts
+++ b/services/platform/backend/main.ts
@@ -13,6 +13,7 @@ import {
   initErrorReporting,
   reportError,
 } from './error-reporting.ts';
+import { closeServerGracefully } from './http-shutdown.ts';
 import { createBoss, ensureQueues } from './jobs/boss.ts';
 import { setEnqueueBoss } from './jobs/enqueue.ts';
 import { startWorker } from './jobs/runner.ts';
@@ -132,9 +133,12 @@ async function main(): Promise<void> {
     shuttingDown = true;
     console.log(`[backend] ${signal} received — shutting down`);
     if (server) {
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
+      // Ends the never-ending /events SSE streams first and force-closes
+      // stragglers on a deadline — a bare server.close() waits for every
+      // open connection, so one connected browser used to park shutdown
+      // here until the orchestrator's SIGKILL, never reaching the graceful
+      // boss.stop below and killing in-flight jobs mid-write.
+      await closeServerGracefully(server);
     }
     // Graceful: in-flight jobs finish before the instance stops.
     await boss.stop({ graceful: true });

--- a/services/platform/backend/realtime/sse.ts
+++ b/services/platform/backend/realtime/sse.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
+import { streamSSE, type SSEStreamingApi } from 'hono/streaming';
 import type { Sql } from 'postgres';
 
 import {
@@ -15,6 +15,32 @@ import { latestOutboxId, readHintsAfter } from './outbox.ts';
 const POLL_INTERVAL_MS = 300;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const ERROR_BACKOFF_MS = 1_000;
+
+/**
+ * Every live `/events` stream of this process. An SSE response never ends on
+ * its own — the loop below exits only on client abort — while
+ * `server.close()` waits for every open connection: without a proactive end,
+ * graceful shutdown hangs until the orchestrator SIGKILLs the process (10s
+ * default compose grace), killing in-flight jobs mid-write. Shutdown calls
+ * {@link endAllEventStreams}; clients reconnect against the next pod and
+ * resume via `Last-Event-ID`.
+ */
+const liveStreams = new Set<SSEStreamingApi>();
+
+/**
+ * Proactively end every live `/events` stream (shutdown path). `abort()`
+ * cancels the response readable — the connection goes idle immediately, so
+ * `server.close()` can complete — and flips `stream.aborted`, which the poll
+ * loop reads as its exit condition. Returns how many streams were ended.
+ */
+export function endAllEventStreams(): number {
+  const ended = liveStreams.size;
+  for (const stream of liveStreams) {
+    stream.abort();
+  }
+  liveStreams.clear();
+  return ended;
+}
 
 /**
  * GET /events — the Tier-2 invalidation-hint stream.
@@ -48,6 +74,7 @@ export function createEventsHandler(sql: Sql) {
 
     return streamSSE(c, async (stream) => {
       hintStreamOpened();
+      liveStreams.add(stream);
       let cursor =
         resumeFrom !== null && /^\d+$/.test(resumeFrom)
           ? resumeFrom
@@ -92,6 +119,7 @@ export function createEventsHandler(sql: Sql) {
           await stream.sleep(POLL_INTERVAL_MS);
         }
       } finally {
+        liveStreams.delete(stream);
         // Paired with the open above — an aborted stream decrements too, or
         // the gauge climbs forever on client churn.
         hintStreamClosed();

--- a/services/platform/tests/guards/dockerfile-env-parity.guard.test.ts
+++ b/services/platform/tests/guards/dockerfile-env-parity.guard.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The platform image ships from a `FROM scratch` squash stage that flattens
+ * the runner's layers — and `FROM scratch` drops every upstream ENV
+ * directive, so the squash re-declares them by hand. A var added to the
+ * runner block but not the squash block is therefore silently absent from
+ * every deployed container: KNOWLEDGE_MIGRATIONS_DIR was dropped exactly
+ * this way, so `findMigrationsDir` (whose repo-walk fallback finds nothing
+ * in a flat image) returned null and the BYO-corpus flow degraded to "apply
+ * the migrations yourself" — the very production bug MIGRATION.md records as
+ * fixed. This guard pins the two ENV blocks equal, name AND value, and pins
+ * the migrations tree copy + pointer pair itself.
+ */
+
+const DOCKERFILE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../Dockerfile',
+);
+
+/**
+ * The env assignments of every ENV instruction in one build stage. Docker
+ * strips full-line comments before joining `\` continuations, so a comment
+ * line inside a continued ENV block neither ends the instruction nor
+ * carries an assignment — this parser does the same.
+ */
+function envOfStage(stage: string): Map<string, string> {
+  const vars = new Map<string, string>();
+  let inEnv = false;
+  for (const line of stage.split('\n')) {
+    if (/^\s*#/.test(line)) continue;
+    const opensEnv = /^ENV\s/.test(line);
+    if (!inEnv && !opensEnv) continue;
+    const continues = /\\\s*$/.test(line);
+    const body = line
+      .replace(/^ENV\s+/, '')
+      .replace(/\\\s*$/, '')
+      .trim();
+    const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(body);
+    if (match) {
+      vars.set(match[1] ?? '', match[2] ?? '');
+    }
+    inEnv = continues;
+  }
+  return vars;
+}
+
+function stages(): { runner: string; squash: string } {
+  const source = readFileSync(DOCKERFILE, 'utf8');
+  const parts = source.split(/^(?=FROM\s)/m);
+  const runner = parts.find((part) => /^FROM\s.*\sAS runner\b/.test(part));
+  const squash = parts.find((part) => /^FROM scratch\b/.test(part));
+  if (!runner || !squash) {
+    throw new Error(
+      'runner/squash stages not found in services/platform/Dockerfile — update this guard alongside the Dockerfile',
+    );
+  }
+  return { runner, squash };
+}
+
+describe('Dockerfile squash-stage ENV parity', () => {
+  it('re-declares every runner ENV var, name and value', () => {
+    const { runner, squash } = stages();
+    const runnerEnv = envOfStage(runner);
+    const squashEnv = envOfStage(squash);
+    // Sanity: the parser actually saw the blocks.
+    expect(runnerEnv.size).toBeGreaterThanOrEqual(10);
+    // Set equality with per-var messages: a drift names the variable.
+    for (const [name, value] of runnerEnv) {
+      expect(squashEnv.get(name), `squash ENV drops or changes ${name}`).toBe(
+        value,
+      );
+    }
+    for (const name of squashEnv.keys()) {
+      expect(runnerEnv.has(name), `squash-only ENV var ${name}`).toBe(true);
+    }
+  });
+
+  it('ships the knowledge-corpus DDL with its ENV pointer', () => {
+    const { runner, squash } = stages();
+    // The tree is copied into the runner (the squash inherits the filesystem
+    // whole via `COPY --from=runner / /`)…
+    expect(runner).toMatch(
+      /COPY[^\n]*services\/db\/migrations\/knowledge-db[^\n]*\.\/db\/migrations\/knowledge-db/,
+    );
+    // …and BOTH stages point KNOWLEDGE_MIGRATIONS_DIR at it, because the
+    // fallback walk finds no repo checkout inside a container.
+    expect(envOfStage(runner).get('KNOWLEDGE_MIGRATIONS_DIR')).toBe(
+      '/app/db/migrations/knowledge-db',
+    );
+    expect(envOfStage(squash).get('KNOWLEDGE_MIGRATIONS_DIR')).toBe(
+      '/app/db/migrations/knowledge-db',
+    );
+  });
+});

--- a/services/platform/tests/guards/dockerfile-env-parity.guard.test.ts
+++ b/services/platform/tests/guards/dockerfile-env-parity.guard.test.ts
@@ -51,17 +51,24 @@ function envOfStage(stage: string): Map<string, string> {
   return vars;
 }
 
-function stages(): { runner: string; squash: string } {
+function stages(): {
+  builder: string;
+  dev: string;
+  runner: string;
+  squash: string;
+} {
   const source = readFileSync(DOCKERFILE, 'utf8');
   const parts = source.split(/^(?=FROM\s)/m);
+  const builder = parts.find((part) => /^FROM\s.*\sAS builder\b/.test(part));
+  const dev = parts.find((part) => /^FROM\s.*\sAS dev\b/.test(part));
   const runner = parts.find((part) => /^FROM\s.*\sAS runner\b/.test(part));
   const squash = parts.find((part) => /^FROM scratch\b/.test(part));
-  if (!runner || !squash) {
+  if (!builder || !dev || !runner || !squash) {
     throw new Error(
-      'runner/squash stages not found in services/platform/Dockerfile — update this guard alongside the Dockerfile',
+      'builder/dev/runner/squash stages not found in services/platform/Dockerfile — update this guard alongside the Dockerfile',
     );
   }
-  return { runner, squash };
+  return { builder, dev, runner, squash };
 }
 
 describe('Dockerfile squash-stage ENV parity', () => {
@@ -96,6 +103,19 @@ describe('Dockerfile squash-stage ENV parity', () => {
     );
     expect(envOfStage(squash).get('KNOWLEDGE_MIGRATIONS_DIR')).toBe(
       '/app/db/migrations/knowledge-db',
+    );
+  });
+
+  it('ships the DDL + pointer in the dev image too (workspace layout)', () => {
+    const { builder, dev } = stages();
+    // The dev stage inherits the builder's filesystem, where the tree sits
+    // at the workspace path — MIGRATION.md promises this copy alongside the
+    // runner's ("into the builder stage (so the dev image inherits it)").
+    expect(builder).toMatch(
+      /COPY[^\n]*services\/db\/migrations\/knowledge-db[^\n]*\.\/services\/db\/migrations\/knowledge-db/,
+    );
+    expect(envOfStage(dev).get('KNOWLEDGE_MIGRATIONS_DIR')).toBe(
+      '/app/services/db/migrations/knowledge-db',
     );
   });
 });


### PR DESCRIPTION
Fixes the boot/serving-shell dead-end class from the deep review: five verified findings, each with a regression test that fails on main (or a structural guard where the artifact is a Dockerfile).

## 1. SCIM per-resource ops broken on the advertised /http_api tenant URL (critical)

`extractPathParts` sliced `prefix.length` chars without checking the path starts with the prefix. On the advertised alias mount (`/http_api/scim/v2`, which `app.ts:171` mounts and the proxy forwards path-preserved) `/http_api/scim/` is exactly as long as `/scim/v2/Users/`, so every per-resource op parsed `id: 'v2'` — an IdP configured with the tenant URL the admin UI advertises (`getPublicHttpApiUrl()` + `/scim/v2`, also `meta.location`) could create/list users but never update, deactivate, or delete them.

- **Fix**: `extractPathParts` now locates the prefix in the pathname (every prefix starts with `/`, so a match always sits on a segment boundary) and answers an empty id when absent (`backend/core/lib/rest/helpers.ts`).
- **Caller sweep**: `rg` shows exactly two callers — the SCIM Users/Groups dispatchers. No other module uses the helper.
- **Tests**: parser cases for both mounts + absent-prefix + subPath (`helpers.test.ts`); dispatcher-level tests pinning that GET/DELETE on `/http_api/scim/v2/Users/:id` and `/Groups/:id` resolve the real id (`backend/core/scim/http_actions.test.ts`). Verified failing on main: the three alias-mount cases fail, the bare-mount ones pass — exactly the reported asymmetry.

## 2. Backend roles never receive WEBDAV_APP_PASSWORD_HMAC_KEY in containers (high)

The entrypoint's `api|worker|all` branch `exec`s node (line ~145) before the web lane sources `env.sh` and derives the key from `INSTANCE_SECRET` (line ~265) — and the web-tier process (`server.ts`) doesn't even read the key, while the backend process that needs it (webdav hash/verify, hostcall tokens, sandbox stage tokens — all reading raw `process.env`) never got it.

- **Fix**: `loadEnv()` (backend boot) now calls the existing `ensureWebdavHmacKey` from `lib/webdav/hmac-key.ts` — the single derivation, already pinned by test to be byte-identical to the entrypoint's shell sha256. It caches the key onto the boot env so all four lazy readers pick it up; an explicit `WEBDAV_APP_PASSWORD_HMAC_KEY` still wins, and no `INSTANCE_SECRET` leaves behavior exactly as before. No shell duplication; single source of truth kept.
- **Role→env trace (by reading, not execution)**:
  - `web`: entrypoint web flow → `env.sh` → `ensure_instance_secret` → shell derivation → `bun server.ts` (unchanged).
  - `api`/`worker`/`all` containers: compose `env_file: .env` (the CLI's `ensure-env.ts:647` writes `INSTANCE_SECRET=<64-hex>` there) → `exec node main.ts` → **new**: `loadEnv()` derives the key.
  - host dev: `scripts/dev-engine.ts` / `dev-secrets.ts` already call `ensureWebdavHmacKey` (unchanged; the boot call is idempotent).
- **Verification limits**: unit-tested derivation (fails on main); `bash -n docker-entrypoint.sh` clean (script untouched); the compose/env_file wiring was traced by reading, not by running a container.

## 3. Squash stage drops KNOWLEDGE_MIGRATIONS_DIR (high)

The `FROM scratch` squash re-declares the runner's ENV by hand and dropped exactly one var: `KNOWLEDGE_MIGRATIONS_DIR`. `findMigrationsDir`'s fallback walks for a repo checkout a flat image doesn't have, so BYO-corpus preparation degraded to "apply the migrations yourself" in every shipped image — the exact production bug `backend/MIGRATION.md:127` records as fixed "with a guard test" that did not exist.

- **Fix**: the var is re-declared in the squash ENV block; diffing the two blocks shows it was the only casualty.
- **Guard** (`tests/guards/dockerfile-env-parity.guard.test.ts`, the promised one): parses the Dockerfile's runner + squash stages and pins the ENV blocks equal name-and-value (any future squash drop fails with the variable named), pins the DDL COPY + both pointer lines, and (follow-up commit) the builder/dev-stage copy + workspace-layout pointer — completing the MIGRATION.md promise. Verified failing on main's Dockerfile.
- **Verification limits**: no docker build was run; the guard asserts the Dockerfile text, and the squash inherits the runner filesystem via `COPY --from=runner / /`, so the ENV pointer is the only missing piece.

## 4. Graceful shutdown hangs on open /events streams → SIGKILL (high)

`shutdown()` awaited a bare `server.close()`, which waits for every open connection; SSE responses never end on their own (15s heartbeats, loop exits only on client abort). One connected browser parked shutdown past the orchestrator's grace (compose default 10s, `backend-api` sets none) → SIGKILL with `boss.stop({graceful})`, `sql.end`, and the error flush unreached — in-flight jobs (including `retryLimit`-0 sends) died mid-write.

- **Fix**:
  - `realtime/sse.ts` keeps a registry of live streams; `endAllEventStreams()` aborts them (hono's `abort()` cancels the response readable, so the connection goes idle immediately and the loop exits on its next tick).
  - New `backend/http-shutdown.ts` `closeServerGracefully()`: ends the streams, then closes with a periodic `closeIdleConnections()` sweep and a 5s `closeAllConnections()` backstop for connections the registry cannot see (long streaming responses) — well under the 10s SIGKILL so the graceful job stop still runs. The sweep matters: `close()` reaps idle connections only at the moment it is called, and a connection that goes idle a tick later otherwise lingers until the client's keep-alive timer (observed: undici's 4s) — found empirically while writing the test.
  - `main.ts` uses the helper.
- **Test** (`backend/http-shutdown.test.ts`, real `serve()` socket + the real events handler over stubbed sql): (a) the premise — a bare `server.close()` does NOT fire within 500ms while one SSE client is connected; (b) `closeServerGracefully` resolves well before the force deadline with an open SSE client, and the client observes its stream end; (c) the force backstop closes an unregistered never-ending response at the deadline. (a) pins main's behavior directly; the helper/registry don't exist on main, so the file as a whole also fails there.

## 5. Email-attachment URLs mint the retired /http_api/storage route (high)

`buildBlobServeUrl`/`buildDownloadUrl` minted `${SITE_URL}${BASE_PATH}/http_api/storage?...`. The 0.5 backend mounts no such route and the proxy injects only four `/http_api` lanes (sso, scim, trusted-headers, cloud-import oauth) — the URL fell through to the SPA catch-all. Every mail-connector attachment stored a dead link (sole live caller: `materialize_email_attachments.ts`, via `syncMailbox`).

- **Decision — re-point, not re-mount**: consumers of the stored URL are exclusively same-origin browser fetches (the conversation download anchor and inline cid `<img>`es; outbound connector sends re-presign fresh per send and never read the stored field — swept every consumer). The live serving contract is a presigned S3 GET minted at open time, which cannot be stored (it expires). So the builder now mints a **stable, session + org-membership-gated redirect**: `GET /api/app/files/serve?orgId&ref&filename` → 302 to a fresh presigned GET (attachment disposition when a filename is given). Reviving the retired unauthenticated `/http_api/storage` door would have required a new proxy lane AND reintroduced a capability-URL surface that outlives conversation access — the gated lane matches how every other `/api/app` surface authorizes, and the proxy's existing `/api/app/*` lane forwards it.
- **Changes**: `/serve` route in `domains/files/routes.ts` (declared before `/:fileId`); `getFileUrl` gains an optional `filename` (presign disposition — object keys are nameless `<org>/<uuid>` by design); `buildBlobServeUrl` re-pointed (+ `getPublicAppApiUrl`); `buildDownloadUrl` deleted — its branch was unreachable (0.5's `putOrgBlobBytes` always answers `s3:` refs) and it had no other importer; the ingest caller now has one lane.
- **Tests**: `public_storage_url.test.ts` asserts the minted URL against the REAL router (`createApp` with stub deps): the path must reach the mounted lane (the session gate's 401, not Hono's 404), the retired path must stay unmounted, plus param/BASE_PATH shape; `materialize_email_attachments.test.ts` pins the stored URL. Verified failing on main — the route-existence test fails there with `expected 404 to be 401`, i.e. the minted URL literally 404s against main's router.
- **Known bound**: attachment rows stored BEFORE this fix keep their old dead URLs (`reuse_stored_attachments` carries pointers forward); re-pointing them would be a data backfill over conversation metadata — deliberately out of this PR. New syncs mint working links.

## Refuted findings

None — all five verified in code before changing anything.

## Gates run

- Touched/new test files (scim, rest helpers, env + hmac-key, http-shutdown, storage-url, materialize, Dockerfile guard): green; each code-level regression test verified to fail against main's sources (stash-swap runs quoted above).
- `bun run --filter @tale/platform typecheck` — exit 0.
- `bun run --filter @tale/platform lint` (oxlint --type-aware) — exit 0.
- `bash -n services/platform/docker-entrypoint.sh` — clean.
- `backend:integration` (throwaway tale-db + MinIO per `backend/README.md`, `ITEST_S3_ENDPOINT` on :59001 to leave the dev stack's store untouched) — run because `main.ts` + app routing were touched: **279/279 checks passed, exit 0** (includes the live `/events` stream + `Last-Event-ID` replay checks against the patched handler, and the suite's own `server.close()` teardown).
- Final consolidated run of all touched + adjacent test files (scim, rest helpers, env, hmac-key, http-shutdown, storage-url, materialize, both guards, `backend/realtime`): 10 files / 135 tests passed; lint + typecheck re-run green after the last merge.

## Verified by reading only (no execution)

- The compose `env_file`/CLI `.env` path that delivers `INSTANCE_SECRET` to backend containers (finding 2).
- The Dockerfile squash semantics (no image build; text-level guard + the `COPY --from=runner / /` inheritance argument, finding 3).
- The proxy lane list (Caddyfile + proxy entrypoint read, not a live proxy, findings 1/5).
