### PR TITLE
fix(platform): harden untrusted content serving and email HTML escaping

### DIFF
--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -159,7 +159,7 @@ curl -sS -X POST "https://your-host.example.com/api/v1/projects/<projectId>/uplo
 # → 200 { "uploadId": "...", "url": "https://...", "method": "POST", "expiresAt": 1774... }
 ```
 
-`method` benennt die Storage-Spur, die du bekommen hast. `POST` zielt auf den Plattform-Speicher: sende die Bytes mit dieser Methode an `url`, und die Antwort trägt `{"storageId": "..."}` — das ist deine `fileId`. `PUT` ist eine vorsignierte URL für den eigenen Bucket der Organisation: sende die Bytes und binde dann die `s3Ref` aus dem Handoff als `fileId`. So oder so schließt das Binden den Upload ab:
+`method` benennt die Storage-Spur, die du bekommen hast. `POST` zielt auf den Plattform-Speicher: sende die Bytes mit dieser Methode an `url`, und die Antwort trägt `{"storageId": "..."}` — das ist deine `fileId`. `PUT` ist eine vorsignierte URL für den eigenen Bucket der Organisation: sende die Bytes mit einem `Content-Type`-Header, der exakt dem beim Minten deklarierten `contentType` entspricht — der deklarierte Typ ist in die URL signiert, ein abweichender Header wird vom Bucket abgelehnt (ohne `contentType` beim Minten stellt der PUT keine Header-Anforderung) — und binde dann die `s3Ref` aus dem Handoff als `fileId`. So oder so schließt das Binden den Upload ab:
 
 ```bash
 curl -sS -X POST "https://your-host.example.com/api/v1/projects/<projectId>/files" \

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -159,7 +159,7 @@ curl -sS -X POST "https://your-host.example.com/api/v1/projects/<projectId>/uplo
 # → 200 { "uploadId": "...", "url": "https://...", "method": "POST", "expiresAt": 1774... }
 ```
 
-`method` names the storage lane you got. `POST` targets platform storage: send the bytes to `url` with that method and the response answers `{"storageId": "..."}` — that is your `fileId`. `PUT` is a presigned URL for the organization's own bucket: send the bytes, then bind the handoff's `s3Ref` as `fileId`. Either way, the bind completes the upload:
+`method` names the storage lane you got. `POST` targets platform storage: send the bytes to `url` with that method and the response answers `{"storageId": "..."}` — that is your `fileId`. `PUT` is a presigned URL for the organization's own bucket: send the bytes with a `Content-Type` header exactly matching the `contentType` you declared when minting — the declared type is signed into the URL, so the bucket refuses a PUT that carries a different one (omit `contentType` at mint and the PUT has no header requirement) — then bind the handoff's `s3Ref` as `fileId`. Either way, the bind completes the upload:
 
 ```bash
 curl -sS -X POST "https://your-host.example.com/api/v1/projects/<projectId>/files" \

--- a/docs/fr/develop/api-reference.md
+++ b/docs/fr/develop/api-reference.md
@@ -159,7 +159,7 @@ curl -sS -X POST "https://your-host.example.com/api/v1/projects/<projectId>/uplo
 # → 200 { "uploadId": "...", "url": "https://...", "method": "POST", "expiresAt": 1774... }
 ```
 
-`method` nomme la voie de stockage que tu as reçue. `POST` vise le stockage de la plateforme : envoie les octets à `url` avec cette méthode, et la réponse porte `{"storageId": "..."}` — c'est ton `fileId`. `PUT` est une URL présignée pour le bucket propre de l'organisation : envoie les octets, puis lie la `s3Ref` du handoff comme `fileId`. Dans les deux cas, la liaison termine le chargement :
+`method` nomme la voie de stockage que tu as reçue. `POST` vise le stockage de la plateforme : envoie les octets à `url` avec cette méthode, et la réponse porte `{"storageId": "..."}` — c'est ton `fileId`. `PUT` est une URL présignée pour le bucket propre de l'organisation : envoie les octets avec un en-tête `Content-Type` strictement identique au `contentType` déclaré au moment du mint — le type déclaré est signé dans l'URL, le bucket refuse donc un PUT qui en porte un autre (sans `contentType` au mint, le PUT n'impose aucun en-tête) — puis lie la `s3Ref` du handoff comme `fileId`. Dans les deux cas, la liaison termine le chargement :
 
 ```bash
 curl -sS -X POST "https://your-host.example.com/api/v1/projects/<projectId>/files" \

--- a/services/platform/app/features/settings/branding/utils/image-upload-error.test.ts
+++ b/services/platform/app/features/settings/branding/utils/image-upload-error.test.ts
@@ -17,6 +17,11 @@ describe('imageUploadErrorToastKey', () => {
     expect(
       imageUploadErrorToastKey(new AppError({ code: 'IMAGE_TYPE_INVALID' })),
     ).toBe('error.imageTypeInvalid');
+    expect(
+      imageUploadErrorToastKey(
+        new AppError({ code: 'IMAGE_SVG_ACTIVE_CONTENT' }),
+      ),
+    ).toBe('error.imageSvgActiveContent');
   });
 
   it('reads the code from a duck-typed error data shape (HMR-safe)', () => {

--- a/services/platform/app/features/settings/branding/utils/image-upload-error.ts
+++ b/services/platform/app/features/settings/branding/utils/image-upload-error.ts
@@ -26,6 +26,8 @@ export function imageUploadErrorToastKey(err: unknown): string {
       return 'error.imageTooLarge';
     case 'IMAGE_MIME_UNSUPPORTED':
       return 'error.imageMimeUnsupported';
+    case 'IMAGE_SVG_ACTIVE_CONTENT':
+      return 'error.imageSvgActiveContent';
     case 'IMAGE_TYPE_INVALID':
       return 'error.imageTypeInvalid';
     default:

--- a/services/platform/backend/core/branding/file_utils.test.ts
+++ b/services/platform/backend/core/branding/file_utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { svgHasActiveContent } from './file_utils';
+
+describe('svgHasActiveContent', () => {
+  it.each([
+    ['a script element', '<svg><script>alert(1)</script></svg>'],
+    ['a namespaced script element', '<svg><svg:script href="x"/></svg>'],
+    ['a script element with whitespace', '<svg>< script >1</script></svg>'],
+    ['a self-closing script element', '<svg><script/></svg>'],
+    ['an onload handler', '<svg onload="alert(1)"><rect/></svg>'],
+    ['a mixed-case handler', '<svg oNcLiCk = "alert(1)"/>'],
+    [
+      'a javascript: URL',
+      '<svg><a href="javascript:alert(1)"><text>x</text></a></svg>',
+    ],
+    [
+      'a javascript: URL with whitespace',
+      '<svg><a xlink:href="javascript\t:alert(1)"/></svg>',
+    ],
+  ])('flags %s', (_name, svg) => {
+    expect(svgHasActiveContent(svg)).toBe(true);
+  });
+
+  it.each([
+    [
+      'a typical vector-tool export',
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><defs><linearGradient id="g"><stop offset="0" stop-color="#fff"/></linearGradient></defs><path d="M0 0h24v24H0z" fill="url(#g)" stroke="none"/></svg>',
+    ],
+    [
+      'style, font, and fragment references',
+      '<svg><style>.a{font-weight:700}</style><use xlink:href="#icon"/><text>conditions apply</text></svg>',
+    ],
+    [
+      'a data-* attribute whose name contains "on"',
+      '<svg><rect data-on-color="red" width="1" height="1"/></svg>',
+    ],
+    [
+      'a description mentioning scripting',
+      '<svg><desc>no scripts</desc></svg>',
+    ],
+  ])('accepts %s', (_name, svg) => {
+    expect(svgHasActiveContent(svg)).toBe(false);
+  });
+});

--- a/services/platform/backend/core/branding/file_utils.ts
+++ b/services/platform/backend/core/branding/file_utils.ts
@@ -104,6 +104,27 @@ export function validateImageFilename(filename: string): boolean {
   return ALLOWED_IMAGE_EXTENSIONS.has(ext);
 }
 
+/**
+ * Best-effort detector for ACTIVE content in an SVG upload: script elements
+ * (namespace-prefixed included), `on*=` event-handler attributes, and
+ * `javascript:` URLs. Branding accepts SVG logos from org admins, and an SVG
+ * is a full document when navigated to — this rejects the obvious scripting
+ * vectors at intake with a clear error instead of storing them.
+ *
+ * DEFENSE LAYERING: this is a UX nicety, not the guarantee. XML entity
+ * tricks can smuggle markup past any regex — the guarantee is the serving
+ * side, which delivers branding images under `Content-Security-Policy:
+ * sandbox` so a navigated SVG can never script (see server.ts and
+ * vite-plugins/serve-branding-images.ts).
+ */
+export function svgHasActiveContent(svgText: string): boolean {
+  return (
+    /<\s*(?:[a-z0-9]+:)?script[\s>/]/i.test(svgText) ||
+    /\bon\w+\s*=/i.test(svgText) ||
+    /javascript\s*:/i.test(svgText)
+  );
+}
+
 export function mimeToExtension(mimeType: string): string | null {
   const map: Record<string, string> = {
     'image/png': 'png',

--- a/services/platform/backend/core/lib/storage/object_store.test.ts
+++ b/services/platform/backend/core/lib/storage/object_store.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildS3ObjectStore,
+  s3PresignGetUrl,
+  s3PresignPutUrl,
+} from './object_store';
+
+function testStore() {
+  return buildS3ObjectStore(
+    {
+      endpoint: 'http://127.0.0.1:9000',
+      bucket: 'tale-blobs',
+      region: 'us-east-1',
+      forcePathStyle: true,
+    },
+    { accessKeyId: 'test-access', secretAccessKey: 'test-secret' },
+  );
+}
+
+describe('s3PresignPutUrl — content-type binding', () => {
+  // Regression: `opts.contentType` used to be accepted and silently ignored
+  // (and aws4fetch drops `content-type` from signing unless allHeaders is
+  // set), so the uploader's PUT could set ANY Content-Type — e.g. text/html,
+  // which the same-origin bucket GET would then serve inline (stored XSS).
+  it('signs the declared content type into X-Amz-SignedHeaders', async () => {
+    const url = new URL(
+      await s3PresignPutUrl(testStore(), 'org/blob-1', {
+        contentType: 'application/pdf',
+      }),
+    );
+    expect(url.searchParams.get('X-Amz-SignedHeaders')).toBe(
+      'content-type;host',
+    );
+  });
+
+  it('produces distinct signatures for distinct declared types', async () => {
+    const store = testStore();
+    const a = new URL(
+      await s3PresignPutUrl(store, 'org/blob-1', {
+        contentType: 'application/pdf',
+      }),
+    );
+    const b = new URL(
+      await s3PresignPutUrl(store, 'org/blob-1', {
+        contentType: 'text/html',
+      }),
+    );
+    expect(a.searchParams.get('X-Amz-Signature')).not.toBe(
+      b.searchParams.get('X-Amz-Signature'),
+    );
+  });
+
+  it('stays header-agnostic when no content type is declared', async () => {
+    const url = new URL(await s3PresignPutUrl(testStore(), 'org/blob-1'));
+    expect(url.searchParams.get('X-Amz-SignedHeaders')).toBe('host');
+  });
+});
+
+describe('s3PresignGetUrl — attachment forcing', () => {
+  // Regression: without a filename no disposition was signed at all, so a
+  // navigation to the presigned URL rendered the blob inline with the
+  // uploader-chosen Content-Type on the app origin.
+  it('forces response-content-disposition: attachment on every URL', async () => {
+    const url = new URL(await s3PresignGetUrl(testStore(), 'org/blob-1'));
+    expect(url.searchParams.get('response-content-disposition')).toBe(
+      'attachment',
+    );
+  });
+
+  it('names the download when a filename is given', async () => {
+    const url = new URL(
+      await s3PresignGetUrl(testStore(), 'org/blob-1', {
+        filename: 'report.pdf',
+      }),
+    );
+    expect(url.searchParams.get('response-content-disposition')).toBe(
+      'attachment; filename="report.pdf"',
+    );
+  });
+
+  it('strips quotes and control characters from the filename', async () => {
+    const url = new URL(
+      await s3PresignGetUrl(testStore(), 'org/blob-1', {
+        filename: 'a"b\r\nc d.pdf',
+      }),
+    );
+    expect(url.searchParams.get('response-content-disposition')).toBe(
+      'attachment; filename="abc d.pdf"',
+    );
+  });
+
+  it('signs the disposition (SignedHeaders stays host-only, param is signed via query)', async () => {
+    const url = new URL(await s3PresignGetUrl(testStore(), 'org/blob-1'));
+    // Query-signed URL: every query param, the forced disposition included,
+    // is covered by the signature — a tampered disposition invalidates it.
+    expect(url.searchParams.get('X-Amz-SignedHeaders')).toBe('host');
+    expect(url.searchParams.get('X-Amz-Signature')).toBeTruthy();
+  });
+});

--- a/services/platform/backend/core/lib/storage/object_store.ts
+++ b/services/platform/backend/core/lib/storage/object_store.ts
@@ -329,8 +329,19 @@ export const DEFAULT_PRESIGN_TTL_SEC = 15 * 60;
 
 /**
  * Presign a time-limited GET URL for the browser to download the object
- * directly from the store (no proxy through the platform). `filename` sets a
- * `Content-Disposition: attachment` so the download names the file.
+ * directly from the store (no proxy through the platform). `filename` names
+ * the download.
+ *
+ * EVERY presigned GET is forced to `Content-Disposition: attachment`. On a
+ * default deployment the bucket is published on the app origin (the proxy
+ * forwards `/<bucket>/*` with no security headers), so an uploaded blob
+ * whose stored Content-Type is text/html would otherwise render as a
+ * SAME-ORIGIN document on navigation — stored XSS with full app-origin
+ * reach. `attachment` affects only navigations: `<img>`/`<video>`/`<audio>`
+ * embeds and `fetch()`-based previews ignore Content-Disposition, so every
+ * preview lane is unchanged and only a direct click-through becomes a
+ * download. The invariant: no user-uploaded bytes ever execute on the app
+ * origin.
  */
 export async function s3PresignGetUrl(
   store: S3ObjectStore,
@@ -342,17 +353,15 @@ export async function s3PresignGetUrl(
     'X-Amz-Expires',
     String(opts.expiresInSec ?? DEFAULT_PRESIGN_TTL_SEC),
   );
-  if (opts.filename) {
-    // The store reflects this param as a response header — strip quotes AND
-    // control chars (CR/LF/NUL…) so a hostile filename can't splice into the
-    // Content-Disposition header (mirrors the `/storage` route's sanitizer).
-    // oxlint-disable-next-line no-control-regex -- stripping control chars is the point
-    const safeName = opts.filename.replace(/["\u0000-\u001f\u007f]/g, '');
-    url.searchParams.set(
-      'response-content-disposition',
-      `attachment; filename="${safeName}"`,
-    );
-  }
+  // The store reflects this param as a response header — strip quotes AND
+  // control chars (CR/LF/NUL…) so a hostile filename can't splice into the
+  // Content-Disposition header (mirrors the WebDAV GET sanitizer).
+  // oxlint-disable-next-line no-control-regex -- stripping control chars is the point
+  const safeName = opts.filename?.replace(/["\u0000-\u001f\u007f]/g, '');
+  url.searchParams.set(
+    'response-content-disposition',
+    safeName ? `attachment; filename="${safeName}"` : 'attachment',
+  );
   const signed = await store.client.sign(url.toString(), {
     method: 'GET',
     aws: { signQuery: true },
@@ -363,6 +372,23 @@ export async function s3PresignGetUrl(
 /**
  * Presign a time-limited PUT URL for the browser to upload a blob directly to
  * the org's bucket — the S3 analogue of `ctx.storage.generateUploadUrl()`.
+ *
+ * When `contentType` is provided it is SIGNED INTO the URL: `content-type`
+ * joins `X-Amz-SignedHeaders`, so the store refuses a PUT whose actual
+ * header differs. Without this, the uploader could mint a URL declaring one
+ * type and land the bytes as any other (e.g. text/html, which a same-origin
+ * bucket GET would serve inline — see s3PresignGetUrl). Binding requires the
+ * executor to send the IDENTICAL `Content-Type` header on the PUT — every
+ * in-repo executor does (browser XHR/fetch uploaders, the WebDAV service,
+ * knowledge-entry blobs), and the REST API reference documents the contract
+ * for external clients. A caller that passes no `contentType` gets a
+ * header-agnostic URL (the REST mint without a declared type keeps working
+ * for bare `curl -T` clients); the serving side neutralizes those blobs
+ * regardless.
+ *
+ * `allHeaders: true` is load-bearing: aws4fetch lists `content-type` among
+ * its UNSIGNABLE_HEADERS and would otherwise silently drop it from the
+ * signature — exactly the no-op this fixes.
  */
 export async function s3PresignPutUrl(
   store: S3ObjectStore,
@@ -374,9 +400,17 @@ export async function s3PresignPutUrl(
     'X-Amz-Expires',
     String(opts.expiresInSec ?? DEFAULT_PRESIGN_TTL_SEC),
   );
+  const bindType =
+    opts.contentType !== undefined && opts.contentType !== ''
+      ? opts.contentType
+      : null;
   const signed = await store.client.sign(url.toString(), {
     method: 'PUT',
-    aws: { signQuery: true },
+    ...(bindType !== null ? { headers: { 'content-type': bindType } } : {}),
+    aws: {
+      signQuery: true,
+      ...(bindType !== null ? { allHeaders: true } : {}),
+    },
   });
   return signed.url;
 }

--- a/services/platform/backend/core/notifications/notification_messages.test.ts
+++ b/services/platform/backend/core/notifications/notification_messages.test.ts
@@ -129,6 +129,80 @@ describe('renderActionableEmailContent', () => {
     expect(content.text).toContain('notifications enabled in Tale');
     expect(content.html).toContain('href="https://app.example.com');
   });
+
+  // Regression: the html lane used to re-interpolate the ALREADY-interpolated
+  // body, so the escape transform saw no placeholders and external text (task
+  // titles, user names, conversation subjects) landed raw in HTML email.
+  it('HTML-escapes hostile params in the html lane', () => {
+    const content = renderActionableEmailContent('en', {
+      titleKey: 'taskAssigned',
+      bodyKey: 'taskAssignedByBody',
+      params: {
+        actor: '<script>alert(1)</script>',
+        title: 'a "quoted" & <b>bold</b> title',
+      },
+      deepLink: null,
+    });
+    expect(content.html).toContain(
+      '&lt;script&gt;alert(1)&lt;/script&gt; assigned you to',
+    );
+    expect(content.html).toContain(
+      'a &quot;quoted&quot; &amp; &lt;b&gt;bold&lt;/b&gt; title',
+    );
+    expect(content.html).not.toContain('<script>');
+    expect(content.html).not.toContain('<b>');
+  });
+
+  it('escapes params exactly once (pre-entitied input is not left as markup)', () => {
+    const content = renderActionableEmailContent('en', {
+      titleKey: 'taskAssigned',
+      bodyKey: 'taskAssignedByBody',
+      params: { actor: 'A&B', title: '&amp;<i>' },
+      deepLink: null,
+    });
+    // The literal string `&amp;<i>` renders as itself in the mail client,
+    // never as an entity/tag — i.e. it is escaped to `&amp;amp;&lt;i&gt;`.
+    expect(content.html).toContain('A&amp;B assigned you to');
+    expect(content.html).toContain('&amp;amp;&lt;i&gt;');
+  });
+
+  it('keeps the plain-text lane and subject unescaped', () => {
+    const content = renderActionableEmailContent('en', {
+      titleKey: 'taskAssigned',
+      bodyKey: 'taskAssignedByBody',
+      params: { actor: '<script>alert(1)</script>', title: 'T & Co' },
+      deepLink: null,
+    });
+    // Plain text is not an HTML context; entities there would show literally.
+    expect(content.text).toContain(
+      '<script>alert(1)</script> assigned you to "T & Co".',
+    );
+    expect(content.subject).toBe('Task assigned to you');
+  });
+
+  // The old double pass ALSO re-interpolated placeholder-shaped param values:
+  // a hostile `{title}` param was substituted again on the second pass.
+  it('does not re-interpolate placeholder-shaped param values', () => {
+    const content = renderActionableEmailContent('en', {
+      titleKey: 'taskAssigned',
+      bodyKey: 'taskAssignedByBody',
+      params: { actor: '{title}', title: 'Real title' },
+      deepLink: null,
+    });
+    expect(content.html).toContain('{title} assigned you to');
+    expect(content.text).toContain('{title} assigned you to');
+  });
+
+  it('falls back to the escaped key in the html lane for an unknown body key', () => {
+    const content = renderActionableEmailContent('en', {
+      titleKey: 'taskAssigned',
+      bodyKey: 'no-such-key <x>',
+      params: {},
+      deepLink: null,
+    });
+    expect(content.html).toContain('no-such-key &lt;x&gt;');
+    expect(content.text).toContain('no-such-key <x>');
+  });
 });
 
 describe('escapeSlackText', () => {

--- a/services/platform/backend/core/notifications/notification_messages.ts
+++ b/services/platform/backend/core/notifications/notification_messages.ts
@@ -535,6 +535,12 @@ function escapeHtml(value: string): string {
     .replace(/"/g, '&quot;');
 }
 
+/** Resolve an `inbox` template in `locale`, falling back to English. */
+function resolveInboxTemplate(locale: string, key: string): string | undefined {
+  const loc: NotificationLocale = isSupportedLocale(locale) ? locale : 'en';
+  return INBOX_I18N[loc][key] ?? INBOX_I18N.en[key];
+}
+
 /**
  * Render an `inbox` namespace string for outbound email. Interpolated values are
  * left as-is (proper nouns / task titles); the template's punctuation is preserved.
@@ -544,8 +550,7 @@ export function renderInboxMessage(
   key: string,
   params?: Record<string, unknown>,
 ): string {
-  const loc: NotificationLocale = isSupportedLocale(locale) ? locale : 'en';
-  const template = INBOX_I18N[loc][key] ?? INBOX_I18N.en[key];
+  const template = resolveInboxTemplate(locale, key);
   if (template === undefined) {
     console.warn(`[notification_messages] no inbox string for key "${key}"`);
     return key;
@@ -573,11 +578,17 @@ export function renderActionableEmailContent(
   }
   text += `\n\n${footer}`;
 
-  const bodyHtml = interpolateTemplate(
-    renderInboxMessage(locale, args.bodyKey, args.params),
-    args.params,
-    escapeHtml,
-  );
+  // Params enter HTML exactly ONCE, escaped at that single entry point: the
+  // template is interpolated one time with the `escapeHtml` transform. The
+  // previous shape re-interpolated the ALREADY-interpolated body — the escape
+  // pass saw no placeholders left, so external text (task titles, user names,
+  // conversation subjects) landed raw in the email HTML, and a hostile param
+  // containing a literal `{title}` was even substituted a second time.
+  const bodyTemplate = resolveInboxTemplate(locale, args.bodyKey);
+  const bodyHtml =
+    bodyTemplate === undefined
+      ? escapeHtml(args.bodyKey)
+      : interpolateTemplate(bodyTemplate, args.params, escapeHtml);
   const ctaHtml = escapeHtml(cta);
   const footerHtml = escapeHtml(footer);
   const linkHtml = args.deepLink ? escapeHtml(args.deepLink) : null;

--- a/services/platform/backend/domains/branding/service.test.ts
+++ b/services/platform/backend/domains/branding/service.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BrandingError, saveBrandingImage } from './service';
+
+function toBase64(text: string): string {
+  return Buffer.from(text, 'utf8').toString('base64');
+}
+
+describe('saveBrandingImage — SVG active-content intake gate', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // Regression for the stored-XSS class: a scripted SVG logo must be
+  // refused at intake with a precise code (the serving side additionally
+  // sandboxes whatever is on disk — this gate is the UX layer).
+  it('rejects an SVG containing a script element before touching disk', async () => {
+    await expect(
+      saveBrandingImage('acme', {
+        type: 'logo',
+        base64: toBase64(
+          '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.domain)</script></svg>',
+        ),
+        mimeType: 'image/svg+xml',
+      }),
+    ).rejects.toMatchObject({
+      name: 'BrandingError',
+      code: 'IMAGE_SVG_ACTIVE_CONTENT',
+    });
+  });
+
+  it('rejects an SVG with an event-handler attribute', async () => {
+    await expect(
+      saveBrandingImage('acme', {
+        type: 'logo',
+        base64: toBase64('<svg onload="fetch(`/api/x`)"><rect/></svg>'),
+        mimeType: 'image/svg+xml',
+      }),
+    ).rejects.toBeInstanceOf(BrandingError);
+  });
+
+  it('stores a benign SVG logo', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'tale-branding-svc-'));
+    try {
+      vi.stubEnv('TALE_CONFIG_DIR', configDir);
+      const svg =
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1" fill="#123"/></svg>';
+      const result = await saveBrandingImage('acme', {
+        type: 'logo',
+        base64: toBase64(svg),
+        mimeType: 'image/svg+xml',
+      });
+      expect(result.filename).toBe('logo.svg');
+      const written = await readFile(
+        join(configDir, 'acme', 'branding', 'images', 'logo.svg'),
+        'utf8',
+      );
+      expect(written).toBe(svg);
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not scan non-SVG uploads for markup-shaped bytes', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'tale-branding-svc-'));
+    try {
+      vi.stubEnv('TALE_CONFIG_DIR', configDir);
+      // A raster payload whose bytes happen to contain handler-shaped text
+      // must pass — the gate is specific to the scriptable SVG document
+      // format.
+      const result = await saveBrandingImage('acme', {
+        type: 'favicon-light',
+        base64: toBase64('PNGDATA onload="x" <script>'),
+        mimeType: 'image/png',
+      });
+      expect(result.filename).toBe('favicon-light.png');
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/services/platform/backend/domains/branding/service.ts
+++ b/services/platform/backend/domains/branding/service.ts
@@ -16,6 +16,7 @@ import {
   resolveImagesDir,
   serializeBrandingJson,
   sha256,
+  svgHasActiveContent,
   validateImageType,
   type BrandingJsonConfig,
   type BrandingReadResult,
@@ -184,6 +185,16 @@ export async function saveBrandingImage(
     throw new BrandingError(
       'IMAGE_TOO_LARGE',
       `Image exceeds maximum size of ${MAX_IMAGE_SIZE_BYTES} bytes`,
+    );
+  }
+  // Intake nicety for the stored-XSS class: refuse SVGs carrying scripting
+  // vectors with a precise error. The serving side stays the guarantee —
+  // branding images are delivered under a `sandbox` CSP either way (see
+  // svgHasActiveContent's doc comment).
+  if (ext === 'svg' && svgHasActiveContent(buffer.toString('utf8'))) {
+    throw new BrandingError(
+      'IMAGE_SVG_ACTIVE_CONTENT',
+      'SVG contains scripts, event handlers, or javascript: URLs',
     );
   }
   const filename = `${args.type}.${ext}`;

--- a/services/platform/backend/domains/documents/replacement.ts
+++ b/services/platform/backend/domains/documents/replacement.ts
@@ -16,7 +16,10 @@ import {
   parseBlobRef,
   s3KeyBelongsToOrg,
 } from '../../core/lib/storage/blob_ref.ts';
-import { s3GetObjectBytes } from '../../core/lib/storage/object_store.ts';
+import {
+  browserFacing,
+  s3GetObjectBytes,
+} from '../../core/lib/storage/object_store.ts';
 import { checkProjectAccess } from '../../core/projects/access.ts';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
@@ -347,7 +350,11 @@ export async function beginReplacementUpload(
   const uploadContentType =
     args.contentType?.trim() || 'application/octet-stream';
   const uploadExpiresAt = Date.now() + PRESIGN_TTL_SEC * 1000;
-  const url = await s3PresignPutUrl(store, stagingKey, {
+  // The browser executes this PUT (mutations.ts uploadWithProgress), so the
+  // URL must be signed against the origin the browser can reach — this lane
+  // was the one browser-handed presign missing `browserFacing`, which broke
+  // replacement uploads on deployments whose store endpoint is internal.
+  const url = await s3PresignPutUrl(browserFacing(store), stagingKey, {
     contentType: uploadContentType,
     expiresInSec: PRESIGN_TTL_SEC,
   });

--- a/services/platform/backend/domains/files/sandbox-blob-routes.ts
+++ b/services/platform/backend/domains/files/sandbox-blob-routes.ts
@@ -104,6 +104,12 @@ export function createSandboxBlobRoutes(deps: { sql: Sql }): Hono {
     const headers: Record<string, string> = {
       'Content-Type':
         upstream.headers.get('content-type') ?? 'application/octet-stream',
+      // These bytes are user-uploaded and this route lives on the app
+      // origin: force download semantics so a leaked stage-token URL pasted
+      // into a browser can never render as a same-origin document (the
+      // in-sandbox consumer is curl/fetch, which ignores disposition).
+      'Content-Disposition': 'attachment',
+      'X-Content-Type-Options': 'nosniff',
     };
     // Forward the declared length when the bucket provides it — the
     // daemon's cheap over-cap rejection reads it before streaming a byte.

--- a/services/platform/backend/domains/files/service.ts
+++ b/services/platform/backend/domains/files/service.ts
@@ -88,7 +88,11 @@ export async function createUploadHandoff(
 /**
  * REST-door presign: the caller declares no size (unlike the session lane) —
  * the bind step HEADs the landed object, so the ceiling is enforced at
- * registration instead. Only the content type shapes the PUT.
+ * registration instead. A DECLARED content type is signed into the PUT (the
+ * client's PUT must then carry the identical `Content-Type` header — see the
+ * API reference); an omitted one leaves the URL header-agnostic so bare
+ * `curl -T` clients keep working, with the attachment-forced GET lane as the
+ * serve-side guarantee.
  */
 export async function createRestUploadHandoff(
   sql: Sql,
@@ -97,9 +101,13 @@ export async function createRestUploadHandoff(
 ): Promise<UploadHandoff> {
   const { orgSlug, store } = await requireOrgStore(sql, scope.organizationId);
   const key = buildObjectKey(store, orgSlug);
-  const uploadUrl = await s3PresignPutUrl(browserFacing(store), key, {
-    contentType: args.contentType ?? 'application/octet-stream',
-  });
+  const uploadUrl = await s3PresignPutUrl(
+    browserFacing(store),
+    key,
+    args.contentType !== undefined && args.contentType !== ''
+      ? { contentType: args.contentType }
+      : {},
+  );
   return { storageRef: encodeS3Ref(key), uploadUrl };
 }
 

--- a/services/platform/lib/canvas-preview-shell.ts
+++ b/services/platform/lib/canvas-preview-shell.ts
@@ -157,6 +157,19 @@ export function wrapCanvasPreviewHtml(userHtml: string): string {
 // supplied entry is validated to be a bare origin (no path/query/fragment,
 // http or https only) before being appended; malformed entries are
 // dropped with a warning.
+//
+// The `sandbox` directive (deliberately WITHOUT `allow-same-origin`) is the
+// load-bearing isolation: it gives the response document an opaque origin no
+// matter how it was navigated to. The embedder's
+// `sandbox="allow-scripts allow-modals"` iframe attribute imposes exactly the
+// same flags, so the legit in-app preview is unchanged — but an attacker who
+// form-POSTs a victim's browser here TOP-LEVEL (where no iframe attribute
+// exists) now gets an inert null-origin document instead of script running
+// with the app origin's cookies, storage, and same-origin API access.
+// `allow-scripts` keeps AI demo scripts running; `allow-modals` keeps the
+// print listener working (`window.print()` is gated on it). CSP source
+// matching uses the document's URL, not its (opaque) origin, so the vendored
+// `'self'` canvas-libs still load.
 export function buildCanvasPreviewCsp(
   extraOrigins: readonly string[] = [],
 ): string {
@@ -179,7 +192,8 @@ export function buildCanvasPreviewCsp(
     // sandbox + opaque-origin combo already prevents meaningful
     // cross-origin form submissions, so this directive is just collateral.
     "base-uri 'none'; " +
-    "object-src 'none'"
+    "object-src 'none'; " +
+    'sandbox allow-scripts allow-modals'
   );
 }
 

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6890,6 +6890,7 @@ toast:
     logoTooSmall: Das Logo muss mindestens {min}×{min} Pixel groß sein.
     imageTooLarge: Bild ist zu groß. Maximale Größe ist 2 MB.
     imageMimeUnsupported: Nicht unterstütztes Bildformat. Verwende PNG, SVG, JPG, WebP oder ICO.
+    imageSvgActiveContent: Die SVG-Datei enthält Skripte oder Event-Handler. Entferne sie oder lade ein PNG hoch.
     imageTypeInvalid: Ungültiger Bildtyp
     addMemberFailed:
       title: Mitglied konnte nicht hinzugefügt werden

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6955,6 +6955,7 @@ toast:
     logoTooSmall: The logo must be at least {min}×{min} pixels.
     imageTooLarge: Image is too large. Maximum size is 2 MB.
     imageMimeUnsupported: Unsupported image format. Use PNG, SVG, JPG, WebP, or ICO.
+    imageSvgActiveContent: The SVG contains scripts or event handlers. Remove them or upload a PNG.
     imageTypeInvalid: Invalid image type
     addMemberFailed:
       title: Couldn't add member

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -7008,6 +7008,7 @@ toast:
     logoTooSmall: Le logo doit faire au moins {min}×{min} pixels.
     imageTooLarge: L'image est trop volumineuse. La taille maximale est de 2 Mo.
     imageMimeUnsupported: Format d'image non pris en charge. Utilise PNG, SVG, JPG, WebP ou ICO.
+    imageSvgActiveContent: Le SVG contient des scripts ou des gestionnaires d'événements. Retire-les ou téléverse un PNG.
     imageTypeInvalid: Type d'image invalide
     addMemberFailed:
       title: Impossible d'ajouter le membre

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -2043,7 +2043,7 @@
       "post": {
         "tags": ["Projects"],
         "summary": "Mint an upload handoff",
-        "description": "Answers where to send the bytes: `method: \"PUT\"` is a presigned URL for the organization’s own bucket (bind the returned `s3Ref` afterwards); `method: \"POST\"` targets platform storage and answers `{\"storageId\": …}` — bind that id. The `uploadId` is a single-use intent valid until `expiresAt` (60 minutes); complete the upload with `POST /api/v1/projects/{id}/files`. Requires the org editor role and project edit access. Uses the upload lane bucket (240/min — one logical upload is several calls; IP-keyed, so a NAT’d worker fleet shares the budget).",
+        "description": "Answers where to send the bytes: `method: \"PUT\"` is a presigned URL for the organization’s own bucket (bind the returned `s3Ref` afterwards) — a declared `contentType` is signed into the URL, so the PUT must carry that exact `Content-Type` header (omit `contentType` and the PUT has no header requirement); `method: \"POST\"` targets platform storage and answers `{\"storageId\": …}` — bind that id. The `uploadId` is a single-use intent valid until `expiresAt` (60 minutes); complete the upload with `POST /api/v1/projects/{id}/files`. Requires the org editor role and project edit access. Uses the upload lane bucket (240/min — one logical upload is several calls; IP-keyed, so a NAT’d worker fleet shares the budget).",
         "operationId": "createProjectUpload",
         "security": [
           {

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -395,7 +395,10 @@ function buildSpec(): Json {
       description:
         'Answers where to send the bytes: `method: "PUT"` is a presigned ' +
         'URL for the organization’s own bucket (bind the returned `s3Ref` ' +
-        'afterwards); `method: "POST"` targets platform storage and answers ' +
+        'afterwards) — a declared `contentType` is signed into the URL, so ' +
+        'the PUT must carry that exact `Content-Type` header (omit ' +
+        '`contentType` and the PUT has no header requirement); ' +
+        '`method: "POST"` targets platform storage and answers ' +
         '`{"storageId": …}` — bind that id. The `uploadId` is a single-use ' +
         'intent valid until `expiresAt` (60 minutes); complete the upload ' +
         'with `POST /api/v1/projects/{id}/files`. Requires the org editor ' +

--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import * as vm from 'node:vm';
 
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -268,16 +272,97 @@ describe('security headers', () => {
 });
 
 describe('POST /canvas-preview', () => {
-  test('echoes the form-posted html with permissive CSP and no nonce', async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The route validates the session cookie against the backend oracle
+  // (`/api/sse/auth`, the same door /events/file uses) before rendering.
+  function mockSessionOracleOk() {
+    return vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ userId: 'u1', orgSlugs: ['acme'] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  }
+
+  function previewRequest(body: string): Request {
+    return new Request('http://localhost/canvas-preview', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        cookie: 'better-auth.session_token=valid',
+      },
+      body,
+    });
+  }
+
+  // Regression: this route used to render for ANY caller — an attacker could
+  // form-POST a victim's browser here top-level and have arbitrary HTML
+  // echoed on the app origin under a script-permissive CSP (reflected XSS).
+  test('rejects an unauthenticated POST without calling the oracle', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const app = createApp(baseEnv);
     const res = await app.fetch(
       new Request('http://localhost/canvas-preview', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: 'html=' + encodeURIComponent('<h1>hi</h1><script>1+1</script>'),
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'html=' + encodeURIComponent('<script>steal()</script>'),
       }),
+    );
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toBe('Cookie');
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    // The echoed HTML must not appear anywhere in the refusal.
+    expect(await res.text()).not.toContain('steal()');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('rejects a POST whose session the oracle refuses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Unauthenticated', { status: 401 }),
+    );
+    const app = createApp(baseEnv);
+    const res = await app.fetch(
+      previewRequest('html=' + encodeURIComponent('<h1>hi</h1>')),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // Regression: the response CSP now carries a `sandbox` directive (without
+  // `allow-same-origin`), so even for an authenticated victim a top-level
+  // navigation renders as an inert opaque-origin document — the same flags
+  // the in-app iframe embed already imposes, so the legit preview is
+  // unchanged.
+  test('response CSP sandboxes the document without allow-same-origin', async () => {
+    mockSessionOracleOk();
+    const app = createApp(baseEnv);
+    const res = await app.fetch(previewRequest('html=x'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).toContain('sandbox allow-scripts allow-modals');
+    expect(csp).not.toContain('allow-same-origin');
+  });
+
+  // A GET to the same path is NOT the preview render — it falls through to
+  // the SPA shell and must keep the standard strict headers (the exemption
+  // from `secureHeaders` is scoped to the POST).
+  test('GET /canvas-preview keeps the strict SPA security headers', async () => {
+    const app = createApp(baseEnv);
+    const res = await app.fetch(new Request('http://localhost/canvas-preview'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+  });
+
+  test('echoes the form-posted html with permissive CSP and no nonce', async () => {
+    mockSessionOracleOk();
+    const app = createApp(baseEnv);
+    const res = await app.fetch(
+      previewRequest(
+        'html=' + encodeURIComponent('<h1>hi</h1><script>1+1</script>'),
+      ),
     );
     expect(res.status).toBe(200);
     const csp = res.headers.get('content-security-policy') ?? '';
@@ -302,16 +387,9 @@ describe('POST /canvas-preview', () => {
   });
 
   test('returns an empty document body when the html field is missing', async () => {
+    mockSessionOracleOk();
     const app = createApp(baseEnv);
-    const res = await app.fetch(
-      new Request('http://localhost/canvas-preview', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: '',
-      }),
-    );
+    const res = await app.fetch(previewRequest(''));
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text).toContain('<!doctype html>');
@@ -325,14 +403,9 @@ describe('POST /canvas-preview', () => {
   // demo might legitimately need (script/style/font/img/connect).
 
   async function getCanvasCsp(env: typeof baseEnv): Promise<string> {
+    mockSessionOracleOk();
     const app = createApp(env);
-    const res = await app.fetch(
-      new Request('http://localhost/canvas-preview', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: '',
-      }),
-    );
+    const res = await app.fetch(previewRequest(''));
     return res.headers.get('content-security-policy') ?? '';
   }
 
@@ -419,15 +492,25 @@ describe('canvas-preview storage shim', () => {
   }
 
   test('shim sentinel appears in the canvas-preview response body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ userId: 'u1', orgSlugs: ['acme'] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
     const app = createApp(baseEnv);
     const res = await app.fetch(
       new Request('http://localhost/canvas-preview', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          cookie: 'better-auth.session_token=valid',
+        },
         body: '',
       }),
     );
     const text = await res.text();
+    fetchSpy.mockRestore();
     // Stable substring — small enough not to churn on minor tweaks, specific
     // enough to fail loudly if the shim ever stops being injected.
     expect(text).toContain(
@@ -508,6 +591,75 @@ describe('canvas-preview storage shim', () => {
     expect(() => {
       localStorage.setItem('again', fourMiB);
     }).not.toThrow();
+  });
+});
+
+describe('GET /branding/images', () => {
+  // Branding images are org-admin-uploaded bytes (SVG included). Navigating
+  // to one directly must never yield a scriptable same-origin document —
+  // the response carries a bare `sandbox` CSP + nosniff instead of the SPA
+  // policy (whose `script-src 'self'` would still let a hostile SVG load
+  // same-origin scripts into an app-origin document).
+  test('the branding-images path serves the sandbox CSP, not the SPA policy', async () => {
+    const app = createApp(baseEnv);
+    // No TALE_CONFIG_DIR in the test env → 404; the security headers come
+    // from the path-scoped middleware and must be present regardless.
+    const res = await app.fetch(
+      new Request('http://localhost/branding/images/acme/logo.svg'),
+    );
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).toBe('sandbox');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+  });
+
+  test('serves an uploaded SVG sandboxed with its allowlisted content type', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'tale-branding-test-'));
+    try {
+      const imagesDir = join(configDir, 'acme', 'branding', 'images');
+      await mkdir(imagesDir, { recursive: true });
+      await writeFile(
+        join(imagesDir, 'logo.svg'),
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.domain)</script></svg>',
+      );
+      // The vitest server project runs under Node; shim the two BunFile
+      // members the branding handler uses (`exists`, body streaming) with a
+      // Blob so the real serve path executes.
+      vi.stubGlobal('Bun', {
+        file: (path: string) => {
+          let bytes: Uint8Array | null = null;
+          try {
+            bytes = readFileSync(path);
+          } catch {
+            bytes = null;
+          }
+          const blob = new Blob(bytes === null ? [] : [bytes]);
+          return Object.assign(blob, {
+            exists: () => Promise.resolve(bytes !== null),
+          });
+        },
+      });
+      // The branding root is read from the process env at module load, so
+      // serve through a fresh module instance seeing the stubbed dir.
+      vi.stubEnv('TALE_CONFIG_DIR', configDir);
+      vi.resetModules();
+      const freshServer = await import('./server');
+      const app = freshServer.createApp(baseEnv);
+      const res = await app.fetch(
+        new Request('http://localhost/branding/images/acme/logo.svg'),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toBe('image/svg+xml');
+      // The document is fully sandboxed: opaque origin, no script execution
+      // on navigation; <img>/<link rel=icon> embeds are unaffected.
+      expect(res.headers.get('content-security-policy')).toBe('sandbox');
+      expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    } finally {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+      vi.resetModules();
+      await rm(configDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -627,9 +627,11 @@ describe('GET /branding/images', () => {
       // Blob so the real serve path executes.
       vi.stubGlobal('Bun', {
         file: (path: string) => {
-          let bytes: Uint8Array | null = null;
+          let bytes: Uint8Array<ArrayBuffer> | null = null;
           try {
-            bytes = readFileSync(path);
+            // Copy into a fresh Uint8Array so the backing store is a plain
+            // ArrayBuffer (Buffer's ArrayBufferLike is not a valid BlobPart).
+            bytes = new Uint8Array(readFileSync(path));
           } catch {
             bytes = null;
           }

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -122,6 +122,12 @@ function backendBaseUrl(): string {
   return configured === '' ? 'http://127.0.0.1:3005' : configured;
 }
 
+/**
+ * Validate the request's session cookie against the backend's `/api/sse/auth`
+ * door and answer the caller's org memberships — `null` means "no valid
+ * session". Shared by the `/events/file` SSE gate and the `/canvas-preview`
+ * gate; this process has no database, so the backend is the oracle.
+ */
 async function resolveAllowedOrgSlugs(
   cookieHeader: string | undefined,
 ): Promise<Set<string> | null> {
@@ -132,7 +138,7 @@ async function resolveAllowedOrgSlugs(
     });
     if (res.status === 401) return null;
     if (!res.ok) {
-      console.warn(`[/events/file] backend auth lookup returned ${res.status}`);
+      console.warn(`[session auth] backend auth lookup returned ${res.status}`);
       return null;
     }
     const body: unknown = await res.json();
@@ -145,7 +151,7 @@ async function resolveAllowedOrgSlugs(
       slugs.filter((s): s is string => typeof s === 'string' && s.length > 0),
     );
   } catch (err) {
-    console.warn('[/events/file] backend auth lookup failed', err);
+    console.warn('[session auth] backend auth lookup failed', err);
     return null;
   }
 }
@@ -639,14 +645,62 @@ export function createApp(
   // header overrides. The Canvas preview shell needs its own permissive
   // CSP; bypass `secureHeaders` for that single path explicitly. Path
   // guard, not registration order — the latter is fragile to refactors.
+  // Branding images are org-admin-uploaded bytes (SVG included) served on
+  // the app origin. In the app they are embedded ONLY as `<img>` / `<link
+  // rel="icon">`, where a response CSP is irrelevant — but a direct
+  // NAVIGATION to the URL makes an SVG a same-origin document whose scripts
+  // run with the app origin (stored XSS from any org's admin against every
+  // user of every org on the deployment). A bare `sandbox` CSP directive (no
+  // allow-* flags) turns any such navigation into an inert opaque-origin
+  // document — no script, no same-origin reach — while pixel rendering in
+  // image contexts is untouched. nosniff pins the allowlisted Content-Type.
+  const secureForBrandingImages = secureHeaders({
+    contentSecurityPolicy: { sandbox: [] },
+    strictTransportSecurity: isHttpsSite(env) ? 'max-age=15552000' : false,
+    xContentTypeOptions: 'nosniff',
+    xFrameOptions: 'DENY',
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    crossOriginEmbedderPolicy: false,
+    crossOriginOpenerPolicy: false,
+    crossOriginResourcePolicy: false,
+  });
   app.use('*', async (c, next) => {
-    if (c.req.path === '/canvas-preview') return next();
+    // Only the POST (preview render) escapes the strict headers — its
+    // handler sets the bespoke sandboxed CSP itself. A GET here falls
+    // through to the SPA shell and must keep the standard policy.
+    if (c.req.path === '/canvas-preview' && c.req.method === 'POST')
+      return next();
+    if (c.req.path.startsWith('/branding/images/'))
+      return secureForBrandingImages(c, next);
     if (c.req.path.startsWith('/dav/') || c.req.path === '/dav')
       return secureForDav(c, next);
     return currentSecure()(c, next);
   });
 
   app.post('/canvas-preview', async (c) => {
+    // Session gate. This response deliberately escapes the SPA's strict CSP
+    // (inline/eval script allowed), so it must never render for an anonymous
+    // caller: an attacker could otherwise form-POST a victim's browser here
+    // and have their HTML echoed on the app origin. The backend session
+    // oracle (the same door `/events/file` uses) validates the cookie. The
+    // in-app preview posts same-origin, so the session cookie always rides
+    // along. Defense-in-depth on top of the gate, the response CSP carries a
+    // `sandbox` directive (see buildCanvasPreviewCsp) so even an
+    // authenticated victim navigated here top-level gets an opaque-origin
+    // document with no reach into the app.
+    const allowedOrgSlugs = await resolveAllowedOrgSlugs(
+      c.req.header('cookie'),
+    );
+    if (allowedOrgSlugs === null) {
+      return new Response('Unauthenticated', {
+        status: 401,
+        headers: {
+          'Cache-Control': 'no-store',
+          Vary: 'Cookie',
+          'WWW-Authenticate': 'Cookie',
+        },
+      });
+    }
     const body = await c.req.parseBody();
     const userHtml = typeof body.html === 'string' ? body.html : '';
     return new Response(wrapCanvasPreviewHtml(userHtml), {
@@ -658,6 +712,7 @@ export function createApp(
         'X-Frame-Options': 'SAMEORIGIN',
         // Per-request bespoke HTML — no caching.
         'Cache-Control': 'no-store',
+        Vary: 'Cookie',
       },
     });
   });

--- a/services/platform/vite-plugins/serve-branding-images.ts
+++ b/services/platform/vite-plugins/serve-branding-images.ts
@@ -63,12 +63,25 @@ export function serveBrandingImages(): Plugin {
     }
 
     const ext = filename.split('.').pop()?.toLowerCase() ?? '';
-    const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+    const contentType = MIME_TYPES[ext];
+    // Unknown extension: fall through (Vite 404s), matching the prod
+    // handler's allowlist-or-404 — never serve a guessable octet-stream.
+    if (!contentType) {
+      next();
+      return;
+    }
 
     void readFile(filePath)
       .then((data) => {
         res.setHeader('Content-Type', contentType);
         res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+        // Mirror the prod handler's hardening (see server.ts): branding
+        // images are org-admin-uploaded bytes (SVG included) — a direct
+        // navigation must never yield a scriptable same-origin document.
+        // Bare `sandbox` gives any such navigation an inert opaque-origin
+        // document; <img>/<link rel=icon> embeds are unaffected.
+        res.setHeader('Content-Security-Policy', 'sandbox');
+        res.setHeader('X-Content-Type-Options', 'nosniff');
         res.end(data);
       })
       .catch((err: unknown) => {

--- a/services/platform/vite-plugins/serve-canvas-preview.ts
+++ b/services/platform/vite-plugins/serve-canvas-preview.ts
@@ -16,7 +16,32 @@ import {
 // In dev, Vite is in front of the SPA — Hono is not in the request path.
 // Without this middleware, `POST /canvas-preview` falls through to Vite's
 // SPA fallback (404, then index.html for GETs). This serves the same
-// response Hono serves in production.
+// response Hono serves in production — including the session gate: the
+// render escapes the SPA's strict CSP, so it must never answer an
+// anonymous caller (see the prod route in server.ts).
+
+/** The backend the dev server asks for session verdicts — same default as
+ * vite.config.ts's proxy target and server.ts's backendBaseUrl(). */
+function backendBaseUrl(): string {
+  const configured = (process.env.TALE_BACKEND_URL ?? '').replace(/\/+$/, '');
+  return configured === '' ? 'http://127.0.0.1:3005' : configured;
+}
+
+async function hasValidSession(
+  cookieHeader: string | undefined,
+): Promise<boolean> {
+  if (!cookieHeader) return false;
+  try {
+    const res = await fetch(`${backendBaseUrl()}/api/sse/auth`, {
+      headers: { cookie: cookieHeader },
+    });
+    return res.ok;
+  } catch (err) {
+    console.warn('canvas-preview: backend session check failed', err);
+    return false;
+  }
+}
+
 export function serveCanvasPreview(): Plugin {
   // Read once at plugin init — restart vite to pick up changes, matching
   // how the rest of the dev server treats env. The same parsing rule as
@@ -104,23 +129,43 @@ export function serveCanvasPreview(): Plugin {
         next();
         return;
       }
-      const chunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => chunks.push(chunk));
-      req.on('end', () => {
-        const raw = Buffer.concat(chunks).toString('utf8');
-        const userHtml = parseHtmlField(raw);
-        res.setHeader('Content-Type', 'text/html; charset=utf-8');
-        res.setHeader('Content-Security-Policy', csp);
-        // nosemgrep: javascript.express.security.x-frame-options-misconfiguration.x-frame-options-misconfiguration -- header value is the hardcoded constant 'SAMEORIGIN', never derived from request input (the taint rule fires only because req body is read in the same handler)
-        res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-        res.setHeader('Cache-Control', 'no-store');
-        res.end(wrapCanvasPreviewHtml(userHtml));
-      });
-      req.on('error', (err) => {
-        console.warn('canvas-preview body read error', err);
-        res.statusCode = 400;
-        res.end();
-      });
+      // Session gate first (mirrors the prod route): the response escapes
+      // the SPA's strict CSP, so an anonymous caller gets a 401, never an
+      // echo of their HTML.
+      hasValidSession(req.headers.cookie)
+        .then((authorized) => {
+          if (!authorized) {
+            res.statusCode = 401;
+            res.setHeader('Cache-Control', 'no-store');
+            res.setHeader('Vary', 'Cookie');
+            res.setHeader('WWW-Authenticate', 'Cookie');
+            res.end('Unauthenticated');
+            return;
+          }
+          const chunks: Buffer[] = [];
+          req.on('data', (chunk: Buffer) => chunks.push(chunk));
+          req.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf8');
+            const userHtml = parseHtmlField(raw);
+            res.setHeader('Content-Type', 'text/html; charset=utf-8');
+            res.setHeader('Content-Security-Policy', csp);
+            // nosemgrep: javascript.express.security.x-frame-options-misconfiguration.x-frame-options-misconfiguration -- header value is the hardcoded constant 'SAMEORIGIN', never derived from request input (the taint rule fires only because req body is read in the same handler)
+            res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+            res.setHeader('Cache-Control', 'no-store');
+            res.setHeader('Vary', 'Cookie');
+            res.end(wrapCanvasPreviewHtml(userHtml));
+          });
+          req.on('error', (err) => {
+            console.warn('canvas-preview body read error', err);
+            res.statusCode = 400;
+            res.end();
+          });
+        })
+        .catch((err: unknown) => {
+          console.warn('canvas-preview session gate failed', err);
+          res.statusCode = 502;
+          res.end();
+        });
     });
   };
 


### PR DESCRIPTION
Fixes the verified class from the deep review: **untrusted content served executable on the app origin, and HTML injection in outbound email.** Four findings, all verified in code; none refuted. Three commits, one per seam.

## Findings

### 1. Unauthenticated `/canvas-preview` echoes attacker HTML (critical, reflected XSS)

**Threat:** a crafted cross-site form POST navigates a victim top-level onto the app origin with attacker HTML running under `unsafe-inline`/`unsafe-eval` — full same-origin reach (the legit flow's iframe `sandbox` attribute exists only on the embedder, never on a top-level navigation).

**Fix** (`server.ts`, `lib/canvas-preview-shell.ts`, `vite-plugins/serve-canvas-preview.ts`):

- The route now requires a valid session, validated against the backend `/api/sse/auth` oracle (the `/events/file` pattern; this process has no DB). The dev/preview Vite middleware mirrors the gate.
- `buildCanvasPreviewCsp` now emits `sandbox allow-scripts allow-modals` (no `allow-same-origin`) — byte-identical flags to the documented iframe embed, so the legit preview semantics are unchanged, while any top-level navigation renders an inert opaque-origin document (no cookies, no storage, no credentialed same-origin fetch, links/forms dead).
- The `secureHeaders` exemption is now scoped to the POST — `GET /canvas-preview` (SPA fallback) previously served the shell with **no CSP at all**; it now keeps the strict nonce policy.

**Context:** the canvas pane that consumed this endpoint was removed in the 0.5 rewrite (#2857); the endpoint, vendored canvas-libs, and browser tests remain as infrastructure. The hardening preserves the documented embed contract for its return.

**Regression tests** (`server.test.ts`): unauthenticated POST → 401 without echoing the payload and without calling the oracle; oracle-refused session → 401; response CSP contains the sandbox directive and never `allow-same-origin`; GET keeps strict headers. Proven failing on the unfixed source (6 failures), green with the fix. Canvas shell browser suite (real Chromium) 3/3 green.

### 2. Branding SVG upload is stored XSS on the shared app origin (high, tenant isolation)

**Threat:** any org admin uploads a scripted SVG logo; navigating to `/branding/images/<org>/logo.svg` executes it same-origin against every user of every org on the deployment.

**Fix** (`server.ts`, `vite-plugins/serve-branding-images.ts`, `domains/branding/service.ts`, `core/branding/file_utils.ts`):

- **Serve side (the guarantee):** branding images are delivered under a bare `Content-Security-Policy: sandbox` + `X-Content-Type-Options: nosniff` via a dedicated path-scoped `secureHeaders` branch (handler-set headers get overwritten by the middleware, so it must branch there). The frontend embeds logos exclusively as `<img>`/`<link rel=icon>` (verified across the app) — those ignore a response CSP, so nothing user-visible changes; navigation becomes an inert opaque-origin document. Dev/preview middleware mirrors the headers and stops serving unknown extensions as `application/octet-stream` (now allowlist-or-404 like prod).
- **Intake (UX nicety):** `saveBrandingImage` rejects SVGs containing script elements, `on*=` handlers, or `javascript:` URLs with a dedicated `IMAGE_SVG_ACTIVE_CONTENT` code, mapped to a precise toast in en/de/fr. Documented as best-effort (XML entity tricks can evade any regex) — the serve-side sandbox is the invariant.

**Regression tests:** middleware-branch headers on the branding path; a real scripted SVG served from a temp config tree gets `CSP: sandbox` + `image/svg+xml` + nosniff (both proven failing on unfixed source); intake corpus tests (hostile/benign SVGs, non-SVG bytes not scanned); toast-key mapping test.

### 3. Presigned PUT ignores contentType; uploaded HTML serves inline (high, stored XSS)

**Threat:** `s3PresignPutUrl` accepted `opts.contentType` and never signed it, so the uploader's PUT could set any `Content-Type`. On default deployments the bucket is proxied **same-origin** (`publicEndpoint` = SITE_URL, Caddy forwards `/<bucket>/*` verbatim with zero security headers), so a presigned GET of uploader-typed `text/html` rendered as a same-origin document.

**Fix** (`core/lib/storage/object_store.ts` + lanes):

- **PUT:** a declared `contentType` is signed into `X-Amz-SignedHeaders` (requires aws4fetch `allHeaders: true` — `content-type` is on its UNSIGNABLE_HEADERS list, so plain `headers` is silently dropped; that trap is exactly how the original no-op happened). The store now refuses a PUT whose header differs. Every in-repo executor already sends the identical header (documents XHR, files fetch, WebDAV service PUT, knowledge-entry blobs, replacement XHR — all verified). The REST mint (`/api/v1/projects/:id/uploads`) binds **only when the caller declared a type**, so bare `curl -T` clients that never declared one keep working; the API reference (en/de/fr) and the OpenAPI description now state the contract, and `public/openapi.json` is regenerated.
- **GET:** every presigned GET now signs `response-content-disposition: attachment` (named when a filename is given). Embeds and `fetch()`-based previews ignore Content-Disposition — all document previews fetch+DOMPurify or use `<img>` (verified) — so the only behavior change is that directly navigating a blob URL downloads instead of rendering. The `/api/sandbox-blob` re-stream gets explicit `Content-Disposition: attachment` + nosniff (its consumer is in-sandbox curl/fetch, which ignores both).

**Also fixed in the sweep:** `documents/replacement.ts` was the one browser-executed presign not wrapped in `browserFacing` — replacement uploads signed against the internal `object-store:9000` endpoint were unreachable from real browsers on default deployments (the integration harness runs in-cluster and cannot see it). Now wrapped like the other four browser-handed sites; `backend/MIGRATION.md`'s "exactly four sites" is a historical increment record and was left as history.

**Regression tests** (`object_store.test.ts`, new): declared type appears in `X-Amz-SignedHeaders` (`content-type;host`), distinct types produce distinct signatures, undeclared stays `host`-only; every GET carries `attachment`, filename naming + control-char/quote stripping preserved. 3/7 proven failing on unfixed source.

### 4. Notification emails embed unescaped external HTML (high)

**Threat:** `renderActionableEmailContent` re-interpolated the already-interpolated body, so the `escapeHtml` transform saw no placeholders — external text (inbound-email conversation subjects, which need **no auth** to set; agent question excerpts; task/document titles; user display names) landed raw in outbound HTML email. A param containing a literal `{title}` was even substituted a second time.

**Fix** (`core/notifications/notification_messages.ts`): the HTML lane interpolates the template exactly once with the escape transform at the single point params enter HTML; subject and plain-text lanes stay raw by design. Sweep result: this is the **only** HTML-email builder in the backend (no invite/digest/support/auth mail HTML exists), and the Slack lane already escapes single-pass.

**Regression tests:** hostile params (`<script>`, quotes, `&`, pre-entitied input escaped exactly once), placeholder-shaped params not re-interpolated, text/subject lanes unescaped, unknown-key fallback escaped. 4 proven failing on unfixed source.

## Refuted

None — all four findings verified in code before fixing.

## Interaction with #3132 (not merged)

Sibling PR #3132 adds `GET /api/app/files/serve` — a proxy-served blob route that is **absent from this branch** (verified). This branch hardens what exists on main. When #3132 lands, its serve route re-introduces an inline-serving surface on the app origin for these same blobs and must apply the same doctrine: safe-type allowlist for inline, otherwise `Content-Disposition: attachment` + `nosniff` (the WebDAV GET handler and the sandbox-blob route in this branch are the in-tree templates). With this branch's PUT binding, a blob's stored Content-Type is trustworthy wherever the mint declared one — which makes that allowlist meaningful.

## Cross-class discoveries (not addressed here)

- `domains/sso/routes.ts` interpolates `BASE_PATH` unescaped into an inline script string and hrefs — operator-controlled env, not user input; worth a defensive escape someday.
- The REST upload doc example still shows a `method: "POST"` response for the platform-storage lane; the 0.5 handoff answers `PUT` for the S3 lane — example drift predates this branch.
- The integration harness signs `browserFacing` as identity (no `publicEndpoint` in its seeded store), so it structurally cannot catch a missing-`browserFacing` regression — the class the replacement-lane bug sat in.

## Verification

- Platform unit suites (`server` + `pii`): **375 files / 72,309 tests green** (worktree reinstall was needed for 3 pre-existing vite fs-deny failures in app-route suites — unrelated to this diff).
- `test:ui`: 447 files / 3,453 green (locale parity + usage for the new toast key). `@tale/ui` (i18n framework checks) 124/1,173 green; `@tale/docs` green.
- Browser project (real Chromium): canvas shell 3/3.
- Typecheck: 0 errors. `oxlint --type-aware`: clean. Pre-commit opengrep SAST: 0 findings.
- `backend:integration` against a throwaway tale-db + MinIO: **279/279 green** — covers presign→PUT→bind, REST v1 uploads, replacement lanes, knowledge RAG, audit export, BYO residency with the binding + attachment changes live.
- Every new regression test demonstrated failing against the unfixed source (via `git stash` runs) before passing with the fix.
