### PR TITLE
fix(platform): close the transcription lifecycle dead-ends

### DIFF
--- a/services/platform/app/features/chat/hooks/use-chat-video-links.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-video-links.ts
@@ -202,9 +202,13 @@ export function useChatVideoLinks(args: {
           const code = backendErrorCode(err);
           toast({
             title: t('videoLink.toast.ingestFailedTitle'),
-            description: t(
-              code ? `videoLink.errors.${code}` : 'videoLink.errors.generic',
-            ),
+            // defaultValue: an unmapped backend code degrades to the generic
+            // copy instead of rendering a raw i18n key (the chip's pattern).
+            description: code
+              ? t(`videoLink.errors.${code}`, {
+                  defaultValue: t('videoLink.errors.generic'),
+                })
+              : t('videoLink.errors.generic'),
             variant: 'destructive',
           });
           console.error(
@@ -256,9 +260,13 @@ export function useChatVideoLinks(args: {
         const code = backendErrorCode(err);
         toast({
           title: t('videoLink.toast.retryFailedTitle'),
-          description: t(
-            code ? `videoLink.errors.${code}` : 'videoLink.errors.generic',
-          ),
+          // defaultValue: an unmapped backend code degrades to the generic
+          // copy instead of rendering a raw i18n key (the chip's pattern).
+          description: code
+            ? t(`videoLink.errors.${code}`, {
+                defaultValue: t('videoLink.errors.generic'),
+              })
+            : t('videoLink.errors.generic'),
           variant: 'destructive',
         });
         console.error(

--- a/services/platform/backend/domains/file_metadata/watchdogs.ts
+++ b/services/platform/backend/domains/file_metadata/watchdogs.ts
@@ -20,15 +20,31 @@ import { emitHintInTx } from '../../realtime/outbox.ts';
 /** A transcription running longer than this is not going to finish. */
 const TRANSCRIPTION_STALE_MS = 35 * 60 * 1000;
 const TRANSCRIPTION_TIMEOUT_MESSAGE = 'Transcription timed out (watchdog)';
+const TRANSCRIPTION_NEVER_STARTED_MESSAGE =
+  'Transcription never started (watchdog)';
 
 /**
- * Fail transcriptions whose runner died, and cascade to the video-link job
- * waiting on them.
+ * Fail transcriptions whose chain died, and cascade to the video-link job
+ * waiting on them. Two shapes of dead chain exist:
  *
- * The cascade is load-bearing: the video-link watchdog deliberately SKIPS
- * `transcribing_handoff` (that state is delegated here), so without it the
- * job never reaches a terminal status, its cleanup never runs, and the audio
- * blob orphans.
+ *  - a dead RUN: the lease claim stamped `running` + `started_at` (see
+ *    `acquireTranscriptionLease`) and the runner then crashed — the row is
+ *    `running` past the stale window;
+ *  - a dead QUEUE: the crash hit between pickup and claim, or the enqueue
+ *    itself was lost (`files.transcribe` has retryLimit 0) — the row is
+ *    `queued`, stale, and no live lease protects it. The engine's own
+ *    delayed self-retries re-claim within minutes, so a stale, lease-free
+ *    `queued` row is a chain nothing will resume. Failing it is safe even
+ *    against a merely-backlogged job: the engine's pre-check treats a
+ *    `failed` row as cancelled and does no work.
+ *
+ * Both fail with a watchdog-attributed, RETRYABLE error — the user sees a
+ * failed chip with a working Retry, not a forever-spinner.
+ *
+ * The cascade is load-bearing: the video-link watchdog deliberately leaves
+ * a LIVE `transcribing_handoff` alone (that state is delegated here), so
+ * without it the job never reaches a terminal status, its cleanup never
+ * runs, and the audio blob orphans.
  */
 export async function recoverStuckTranscriptions(
   sql: Sql,
@@ -36,7 +52,7 @@ export async function recoverStuckTranscriptions(
 ): Promise<{ failed: number; cascaded: number }> {
   const now = Date.now();
   const cutoff = now - (options.staleMs ?? TRANSCRIPTION_STALE_MS);
-  const failed = await sql<{ storageRef: string | null }[]>`
+  const deadRuns = await sql<{ storageRef: string | null }[]>`
     UPDATE app.file_metadata SET
       transcription_status = 'failed',
       transcription_error = ${TRANSCRIPTION_TIMEOUT_MESSAGE},
@@ -47,6 +63,21 @@ export async function recoverStuckTranscriptions(
       AND coalesce(transcription_started_at_ms, created_at_ms) < ${cutoff}
     RETURNING storage_ref AS "storageRef"
   `;
+  const deadQueued = await sql<{ storageRef: string | null }[]>`
+    UPDATE app.file_metadata SET
+      transcription_status = 'failed',
+      transcription_error = ${TRANSCRIPTION_NEVER_STARTED_MESSAGE},
+      transcription_run_id = NULL,
+      transcription_lease_expires_at_ms = NULL,
+      status_changed_at_ms = ${now}
+    WHERE transcription_status = 'queued'
+      AND coalesce(status_changed_at_ms, created_at_ms) < ${cutoff}
+      AND (transcription_run_id IS NULL
+           OR transcription_lease_expires_at_ms IS NULL
+           OR transcription_lease_expires_at_ms < ${now})
+    RETURNING storage_ref AS "storageRef"
+  `;
+  const failed = [...deadRuns, ...deadQueued];
   if (failed.length === 0) return { failed: 0, cascaded: 0 };
 
   // Join on the raw blob REFERENCE so `s3:`-backed audio flips too (the 0.4

--- a/services/platform/backend/domains/files/transcription.ts
+++ b/services/platform/backend/domains/files/transcription.ts
@@ -15,7 +15,10 @@ import {
 } from '../../lib/ctx-shim.ts';
 import { chatShimHandlers } from '../chat/shim.ts';
 import { incrementUsageLedger } from '../governance/service.ts';
-import { heartbeatJobByStorageRef } from '../video_links/service.ts';
+import {
+  heartbeatJobByStorageRef,
+  settleHandoffJobsByStorageRef,
+} from '../video_links/service.ts';
 import { FileError } from './service.ts';
 
 /**
@@ -45,20 +48,87 @@ interface TranscriptionRowPatch {
   contentHash?: string;
 }
 
+async function applyTranscriptionPatch(
+  db: Sql | TransactionSql,
+  storageRef: string,
+  patch: TranscriptionRowPatch,
+): Promise<void> {
+  await db`
+    UPDATE app.file_metadata SET
+      transcription_status = ${patch.transcriptionStatus !== undefined ? patch.transcriptionStatus : db.unsafe('transcription_status')},
+      transcript = ${patch.transcript !== undefined ? patch.transcript : db.unsafe('transcript')},
+      transcription_duration_sec = ${patch.transcriptionDurationSec !== undefined ? patch.transcriptionDurationSec : db.unsafe('transcription_duration_sec')},
+      transcription_progress = ${patch.transcriptionProgress !== undefined ? patch.transcriptionProgress : db.unsafe('transcription_progress')},
+      transcription_error = ${patch.transcriptionError !== undefined ? patch.transcriptionError : db.unsafe('transcription_error')},
+      status_changed_at_ms = ${patch.transcriptionStatus !== undefined ? Date.now() : db.unsafe('status_changed_at_ms')}
+    WHERE storage_ref = ${storageRef}
+  `;
+}
+
 async function updateFileTranscription(
   sql: Sql,
   storageRef: string,
   patch: TranscriptionRowPatch,
 ): Promise<void> {
-  await sql`
+  const status = patch.transcriptionStatus;
+  if (status !== 'completed' && status !== 'failed' && status !== 'skipped') {
+    await applyTranscriptionPatch(sql, storageRef, patch);
+    return;
+  }
+  // A terminal transcription settles the video-link job that handed off to
+  // this blob IN THE SAME TRANSACTION — the missing transition that left
+  // whisper jobs parked in 'transcribing_handoff' forever (holding an org
+  // ingest slot each and making the chip's Retry 409).
+  await sql.begin(async (tx) => {
+    await applyTranscriptionPatch(tx, storageRef, patch);
+    await settleHandoffJobsByStorageRef(tx, {
+      storageId: storageRef,
+      transcriptionStatus: status,
+      ...(patch.transcriptionError !== undefined
+        ? { errorMessage: patch.transcriptionError }
+        : {}),
+    });
+  });
+}
+
+/**
+ * Claim the single-flight transcription lease (the engine's
+ * `acquireTranscriptionLock`): CAS on a free/expired lease AND a claimable
+ * status. Winning the claim IS the `running` transition — the status,
+ * `transcription_started_at_ms`, and the staleness clock are stamped in the
+ * same statement, which is what makes the crash watchdog's predicate
+ * (`running` + stale `started_at`) reachable at all: a runner that dies
+ * mid-transcription leaves a row the sweep recognizes instead of a
+ * forever-`queued` one nothing will ever touch. The status guard also means
+ * a skip/fail that lands between the engine's pre-check and its claim
+ * refuses the claim instead of being resurrected to `running`.
+ * Returns the winning run's id (the caller compares against its own).
+ */
+export async function acquireTranscriptionLease(
+  sql: Sql,
+  args: { storageRef: string; runId: string; leaseMs: number },
+): Promise<string | null> {
+  const now = Date.now();
+  const rows = await sql<{ runId: string }[]>`
     UPDATE app.file_metadata SET
-      transcription_status = ${patch.transcriptionStatus !== undefined ? patch.transcriptionStatus : sql.unsafe('transcription_status')},
-      transcript = ${patch.transcript !== undefined ? patch.transcript : sql.unsafe('transcript')},
-      transcription_duration_sec = ${patch.transcriptionDurationSec !== undefined ? patch.transcriptionDurationSec : sql.unsafe('transcription_duration_sec')},
-      transcription_progress = ${patch.transcriptionProgress !== undefined ? patch.transcriptionProgress : sql.unsafe('transcription_progress')},
-      transcription_error = ${patch.transcriptionError !== undefined ? patch.transcriptionError : sql.unsafe('transcription_error')}
-    WHERE storage_ref = ${storageRef}
+      transcription_run_id = ${args.runId},
+      transcription_lease_expires_at_ms = ${now + args.leaseMs},
+      transcription_status = 'running',
+      transcription_started_at_ms = ${now},
+      status_changed_at_ms = ${now}
+    WHERE storage_ref = ${args.storageRef}
+      AND transcription_status IN ('queued', 'running')
+      AND (transcription_run_id IS NULL
+           OR transcription_lease_expires_at_ms IS NULL
+           OR transcription_lease_expires_at_ms < ${now})
+    RETURNING transcription_run_id AS "runId"
   `;
+  if (rows[0]) return rows[0].runId;
+  const holders = await sql<{ runId: string | null }[]>`
+    SELECT transcription_run_id AS "runId" FROM app.file_metadata
+    WHERE storage_ref = ${args.storageRef} LIMIT 1
+  `;
+  return holders[0]?.runId ?? null;
 }
 
 // ------------------------------------------------------------- crawl host
@@ -112,23 +182,11 @@ function transcriptionHandlers(sql: Sql): ShimHandlers {
     ) => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the engine passes exactly this shape
       const args = raw as { storageId: string; runId: string; leaseMs: number };
-      const now = Date.now();
-      const rows = await sql<{ runId: string }[]>`
-        UPDATE app.file_metadata SET
-          transcription_run_id = ${args.runId},
-          transcription_lease_expires_at_ms = ${now + args.leaseMs}
-        WHERE storage_ref = ${args.storageId}
-          AND (transcription_run_id IS NULL
-               OR transcription_lease_expires_at_ms IS NULL
-               OR transcription_lease_expires_at_ms < ${now})
-        RETURNING transcription_run_id AS "runId"
-      `;
-      if (rows[0]) return rows[0].runId;
-      const holders = await sql<{ runId: string | null }[]>`
-        SELECT transcription_run_id AS "runId" FROM app.file_metadata
-        WHERE storage_ref = ${args.storageId} LIMIT 1
-      `;
-      return holders[0]?.runId ?? null;
+      return acquireTranscriptionLease(sql, {
+        storageRef: args.storageId,
+        runId: args.runId,
+        leaseMs: args.leaseMs,
+      });
     },
     'file_metadata/internal_mutations:releaseTranscriptionLock': async (
       raw,
@@ -256,7 +314,9 @@ export async function queueTranscription(
   },
 ): Promise<void> {
   await sql`
-    UPDATE app.file_metadata SET transcription_status = 'queued'
+    UPDATE app.file_metadata SET
+      transcription_status = 'queued',
+      status_changed_at_ms = ${Date.now()}
     WHERE org_id = ${args.organizationId} AND storage_ref = ${args.storageRef}
       AND transcription_status IS NULL
   `;
@@ -271,20 +331,30 @@ export async function queueTranscription(
 // ------------------------------------------------------------ user actions
 
 /** Skip an in-flight transcription (the 0.4 `skipTranscription`): only a
- * `queued`/`running` row can be skipped; the engine's phase re-checks bail. */
+ * `queued`/`running` row can be skipped; the engine's phase re-checks bail.
+ * A video-link job waiting on the blob settles to `skipped` with it. */
 export async function skipTranscription(
   sql: Sql,
   organizationId: string,
   storageRef: string,
 ): Promise<void> {
-  const rows = await sql<{ id: string }[]>`
-    UPDATE app.file_metadata SET
-      transcription_status = 'skipped', transcription_progress = ''
-    WHERE org_id = ${organizationId} AND storage_ref = ${storageRef}
-      AND transcription_status IN ('queued', 'running')
-    RETURNING id
-  `;
-  if (rows.length === 0) {
+  const skipped = await sql.begin(async (tx) => {
+    const rows = await tx<{ id: string }[]>`
+      UPDATE app.file_metadata SET
+        transcription_status = 'skipped', transcription_progress = '',
+        status_changed_at_ms = ${Date.now()}
+      WHERE org_id = ${organizationId} AND storage_ref = ${storageRef}
+        AND transcription_status IN ('queued', 'running')
+      RETURNING id
+    `;
+    if (rows.length === 0) return false;
+    await settleHandoffJobsByStorageRef(tx, {
+      storageId: storageRef,
+      transcriptionStatus: 'skipped',
+    });
+    return true;
+  });
+  if (!skipped) {
     throw new FileError(
       'TRANSCRIPTION_NOT_SKIPPABLE',
       'Transcription is not in a skippable state',
@@ -304,7 +374,8 @@ export async function retryTranscription(
   const rows = await sql<{ fileName: string; contentType: string }[]>`
     UPDATE app.file_metadata SET
       transcription_status = 'queued', transcription_error = NULL,
-      transcription_run_id = NULL, transcription_lease_expires_at_ms = NULL
+      transcription_run_id = NULL, transcription_lease_expires_at_ms = NULL,
+      status_changed_at_ms = ${Date.now()}
     WHERE org_id = ${organizationId} AND storage_ref = ${storageRef}
       AND transcription_status IN ('failed', 'skipped')
     RETURNING file_name AS "fileName", content_type AS "contentType"

--- a/services/platform/backend/domains/video_links/service.test.ts
+++ b/services/platform/backend/domains/video_links/service.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+
+import { describe, expect, test } from 'vitest';
+
+import { isVideoJobRetryable } from './service.ts';
+
+/**
+ * The retry door's truth table (the un-retryable dead-end regression): a
+ * whisper handoff whose transcription settled failed/skipped is exactly as
+ * retryable as a terminal job — the chip already offers Retry for that
+ * shape — while every live state stays refused (a retry there would
+ * double-run the pipeline).
+ */
+describe('isVideoJobRetryable', () => {
+  test('terminal failed/skipped jobs retry regardless of the file lane', () => {
+    expect(isVideoJobRetryable('failed', null)).toBe(true);
+    expect(isVideoJobRetryable('skipped', null)).toBe(true);
+    expect(isVideoJobRetryable('failed', 'completed')).toBe(true);
+  });
+
+  test('a handoff over a settled-failed/skipped file row opens the door', () => {
+    expect(isVideoJobRetryable('transcribing_handoff', 'failed')).toBe(true);
+    expect(isVideoJobRetryable('transcribing_handoff', 'skipped')).toBe(true);
+  });
+
+  test('a live handoff stays non-retryable', () => {
+    expect(isVideoJobRetryable('transcribing_handoff', 'queued')).toBe(false);
+    expect(isVideoJobRetryable('transcribing_handoff', 'running')).toBe(false);
+    expect(isVideoJobRetryable('transcribing_handoff', null)).toBe(false);
+  });
+
+  test('a settled-completed handoff and other in-flight states stay closed', () => {
+    expect(isVideoJobRetryable('transcribing_handoff', 'completed')).toBe(
+      false,
+    );
+    expect(isVideoJobRetryable('completed', null)).toBe(false);
+    expect(isVideoJobRetryable('queued', null)).toBe(false);
+    expect(isVideoJobRetryable('fetching_metadata', null)).toBe(false);
+    expect(isVideoJobRetryable('indexing', 'failed')).toBe(false);
+  });
+});

--- a/services/platform/backend/domains/video_links/service.ts
+++ b/services/platform/backend/domains/video_links/service.ts
@@ -378,6 +378,45 @@ export async function heartbeatJobByStorageRef(
   `;
 }
 
+/**
+ * The handoff's missing terminal transition: when the transcription lane
+ * settles the file row for this blob, drive the video-link job that handed
+ * off to it to the SAME terminal state. Without this write the job sits in
+ * `transcribing_handoff` forever — `countInFlight` keeps charging the org's
+ * ingest cap for finished work, the GC never reaps it, and retry 409s.
+ * The transcription seam calls this in the SAME transaction as the file
+ * row's terminal write, so chip state and slot accounting cannot diverge.
+ */
+export async function settleHandoffJobsByStorageRef(
+  db: Sql | TransactionSql,
+  args: {
+    storageId: string;
+    transcriptionStatus: 'completed' | 'failed' | 'skipped';
+    errorMessage?: string;
+  },
+): Promise<void> {
+  const now = Date.now();
+  if (args.transcriptionStatus === 'failed') {
+    await db`
+      UPDATE app.video_link_jobs SET
+        status = 'failed',
+        status_changed_at_ms = ${now},
+        progress = NULL,
+        error_reason_code = 'whisperFailed',
+        error_message = ${args.errorMessage ?? 'Whisper transcription failed'}
+      WHERE status = 'transcribing_handoff' AND storage_ref = ${args.storageId}
+    `;
+    return;
+  }
+  await db`
+    UPDATE app.video_link_jobs SET
+      status = ${args.transcriptionStatus},
+      status_changed_at_ms = ${now},
+      progress = NULL
+    WHERE status = 'transcribing_handoff' AND storage_ref = ${args.storageId}
+  `;
+}
+
 // ---------------------------------------------------------------- watchdog
 
 const STATUS_WINDOWS: ReadonlyArray<readonly [string, number]> = [
@@ -390,12 +429,19 @@ const STATUS_WINDOWS: ReadonlyArray<readonly [string, number]> = [
 const UNBOUND_GC_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const UNBOUND_GC_BATCH = 50;
 const STUCK_RECOVERY_BATCH = 200;
+/** How long a handoff row may sit over a MISSING file row before it is
+ * declared dead. Matches the transcription lane's own stale window; live
+ * runs advance `status_changed_at_ms` via the per-chunk heartbeat. */
+const HANDOFF_ORPHAN_WINDOW_MS = 35 * 60_000;
 
 /**
  * The 0.4 stuck-row watchdog + lazy GC: flip stuck non-terminal jobs to
- * `failed`/transient (per-status windows; `transcribing_handoff` is owned
- * by the transcription pipeline's own recovery), and reap terminal-but-
- * unbound rows older than 7 days (blob + non-completed file row + job).
+ * `failed`/transient (per-status windows; a LIVE `transcribing_handoff` is
+ * owned by the transcription pipeline's own recovery), reconcile parked
+ * handoff rows whose transcription already settled (the safety net under
+ * the settle cascade — and the heal for rows parked by older deployments),
+ * fail handoff rows whose file row is gone, and reap terminal-but-unbound
+ * rows older than 7 days (blob + non-completed file row + job).
  */
 export async function runVideoLinkWatchdog(sql: Sql): Promise<void> {
   const now = Date.now();
@@ -417,6 +463,69 @@ export async function runVideoLinkWatchdog(sql: Sql): Promise<void> {
       if (flipped === 'ok') {
         await cleanupCancelledVideoLink(sql, row.id);
       }
+    }
+  }
+
+  // Reconcile: a handoff row over a SETTLED file row mirrors the terminal
+  // state, at ANY age. The settle cascade writes this transactionally on
+  // the live path; this sweep is the idempotent backstop that also flips
+  // the rows existing deployments parked forever (freeing their org's
+  // ingest slots within one tick).
+  const settledRows = await sql<
+    { id: string; fileStatus: string; fileError: string | null }[]
+  >`
+    SELECT j.id, m.transcription_status AS "fileStatus",
+           m.transcription_error AS "fileError"
+    FROM app.video_link_jobs j
+    JOIN app.file_metadata m ON m.id = j.file_metadata_id
+    WHERE j.status = 'transcribing_handoff'
+      AND m.transcription_status IN ('completed', 'failed', 'skipped')
+    LIMIT ${STUCK_RECOVERY_BATCH}
+  `;
+  for (const row of settledRows) {
+    if (row.fileStatus === 'failed') {
+      await updateJob(sql, {
+        jobId: row.id,
+        status: 'failed',
+        expectedStatus: 'transcribing_handoff',
+        errorReasonCode: 'whisperFailed',
+        errorMessage: row.fileError ?? 'Whisper transcription failed',
+        progress: null,
+      });
+      continue;
+    }
+    await updateJob(sql, {
+      jobId: row.id,
+      status: row.fileStatus,
+      expectedStatus: 'transcribing_handoff',
+      progress: null,
+    });
+  }
+
+  // A handoff row whose file row is GONE (or was never recorded) can never
+  // settle — no engine write and no cascade will ever reach it. Fail it
+  // once the transcription lane's own stale window has passed so the user
+  // gets a retryable failure instead of a forever-spinner, and reap its
+  // audio blob.
+  const orphanRows = await sql<{ id: string }[]>`
+    SELECT j.id
+    FROM app.video_link_jobs j
+    LEFT JOIN app.file_metadata m ON m.id = j.file_metadata_id
+    WHERE j.status = 'transcribing_handoff'
+      AND j.status_changed_at_ms < ${now - HANDOFF_ORPHAN_WINDOW_MS}
+      AND (j.file_metadata_id IS NULL OR m.id IS NULL)
+    LIMIT ${STUCK_RECOVERY_BATCH}
+  `;
+  for (const row of orphanRows) {
+    const flipped = await updateJob(sql, {
+      jobId: row.id,
+      status: 'failed',
+      expectedStatus: 'transcribing_handoff',
+      errorReasonCode: 'whisperFailed',
+      errorMessage: 'Transcription record disappeared — retry to re-process',
+    });
+    if (flipped === 'ok') {
+      await cleanupCancelledVideoLink(sql, row.id);
     }
   }
 
@@ -1054,9 +1163,13 @@ export async function cancelDeferredJobs(
       job.storageRef !== null &&
       job.status === 'transcribing_handoff'
     ) {
+      // Only an in-flight transcription is skipped along; a SETTLED file
+      // row keeps its state — clobbering a completed transcript here would
+      // hand it to the cleanup's delete and destroy the org's donor copy.
       await sql`
         UPDATE app.file_metadata SET transcription_status = 'skipped'
         WHERE storage_ref = ${job.storageRef}
+          AND transcription_status IN ('queued', 'running')
       `;
     }
     await cleanupCancelledVideoLink(sql, jobId);
@@ -1086,9 +1199,14 @@ export async function cancelVideoLink(
     job.storageRef !== null &&
     job.status === 'transcribing_handoff'
   ) {
+    // Only an in-flight transcription is skipped along; a SETTLED file row
+    // keeps its state — clobbering a completed transcript here would hand
+    // it to the cleanup's delete and destroy the org's donor copy (the
+    // donor contract at findReusableTranscriptDonor: cancel keeps the row).
     await sql`
       UPDATE app.file_metadata SET transcription_status = 'skipped'
       WHERE storage_ref = ${job.storageRef}
+        AND transcription_status IN ('queued', 'running')
     `;
   }
   await cleanupCancelledVideoLink(sql, args.jobId);
@@ -1111,8 +1229,32 @@ export async function cancelVideoLink(
   );
 }
 
+/**
+ * The retry door's truth table. Terminal `failed`/`skipped` jobs retry as
+ * always; a `transcribing_handoff` job retries exactly when its file row's
+ * transcription settled failed/skipped — the chip already shows Retry for
+ * that shape (the reactive join), so the door must accept it even if the
+ * settle cascade was missed (rows parked by older deployments, drift).
+ * A live handoff (file queued/running) and every other in-flight status
+ * stay non-retryable: retrying them would double-run the pipeline.
+ */
+export function isVideoJobRetryable(
+  jobStatus: string,
+  fileTranscriptionStatus: string | null,
+): boolean {
+  if (jobStatus === 'failed' || jobStatus === 'skipped') return true;
+  return (
+    jobStatus === 'transcribing_handoff' &&
+    (fileTranscriptionStatus === 'failed' ||
+      fileTranscriptionStatus === 'skipped')
+  );
+}
+
 /** Retry a failed/skipped job (the 0.4 semantics): bot-wall cooldown,
- * the same abuse gates as ingest, cleanup of stale artifacts, re-queue. */
+ * the same abuse gates as ingest, cleanup of stale artifacts, re-queue.
+ * Accepts a whisper handoff whose transcription settled failed/skipped —
+ * the cleanup below resets the file lane (drops the settled-non-completed
+ * file row + blob) so the re-queued pipeline starts coherently. */
 export async function retryVideoLink(
   sql: Sql,
   args: { organizationId: string; userId: string; jobId: string },
@@ -1128,7 +1270,15 @@ export async function retryVideoLink(
       403,
     );
   }
-  if (job.status !== 'failed' && job.status !== 'skipped') {
+  let fileTranscriptionStatus: string | null = null;
+  if (job.status === 'transcribing_handoff' && job.fileMetadataId !== null) {
+    const metas = await sql<{ status: string | null }[]>`
+      SELECT transcription_status AS status FROM app.file_metadata
+      WHERE id = ${job.fileMetadataId} LIMIT 1
+    `;
+    fileTranscriptionStatus = metas[0]?.status ?? null;
+  }
+  if (!isVideoJobRetryable(job.status, fileTranscriptionStatus)) {
     throw new VideoLinkError(
       'notRetryable',
       `Can only retry failed or skipped video links (current: ${job.status})`,

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -9760,6 +9760,253 @@ async function checkRecoverySweeps(
     `failed=${transcriptions.failed} cascaded=${transcriptions.cascaded}, stuck=${stuckRow?.status}, freshUntouched=${freshRow?.status === 'running'}, video=${videoRow[0]?.status}/${videoRow[0]?.code}`,
   );
 
+  // ---- transcriptions: a claim-less stale 'queued' row (crash between
+  //      pickup and claim, or a lost enqueue — files.transcribe has
+  //      retryLimit 0) fails and cascades exactly like a dead run --------
+  await sql`
+    INSERT INTO app.file_metadata (
+      org_id, file_name, content_type, size, storage_ref, uploaded_by,
+      transcription_status, created_at_ms
+    ) VALUES
+      (${orgId}, 'stuck-q.mp3', 'audio/mpeg', 10, 's3:stuck-q-1',
+       ${userId}, 'queued', ${stale}),
+      (${orgId}, 'fresh-q.mp3', 'audio/mpeg', 10, 's3:fresh-q-1',
+       ${userId}, 'queued', ${now})
+  `;
+  await sql`
+    INSERT INTO app.video_link_jobs (
+      org_id, source_url, source_url_hash, source_platform, pasted_token,
+      status, status_changed_at_ms, storage_ref, uploaded_by, created_at_ms
+    ) VALUES (
+      ${orgId}, 'https://example.test/q', 'hash-stuck-q', 'youtube',
+      'https://example.test/q', 'transcribing_handoff', ${stale},
+      's3:stuck-q-1', ${userId}, ${stale}
+    )
+  `;
+  const queuedSweep = await recoverStuckTranscriptions(sql);
+  const queuedRows = await sql<{ fileName: string; status: string | null }[]>`
+    SELECT file_name AS "fileName", transcription_status AS status
+    FROM app.file_metadata WHERE org_id = ${orgId}
+      AND file_name IN ('stuck-q.mp3', 'fresh-q.mp3')
+  `;
+  const stuckQ = queuedRows.find((row) => row.fileName === 'stuck-q.mp3');
+  const freshQ = queuedRows.find((row) => row.fileName === 'fresh-q.mp3');
+  const queuedVideo = await sql<{ status: string; code: string | null }[]>`
+    SELECT status, error_reason_code AS code FROM app.video_link_jobs
+    WHERE source_url_hash = 'hash-stuck-q'
+  `;
+  record(
+    'watchdog: a never-claimed stale queued transcription fails and cascades',
+    queuedSweep.failed >= 1 &&
+      stuckQ?.status === 'failed' &&
+      freshQ?.status === 'queued' &&
+      queuedVideo[0]?.status === 'failed' &&
+      queuedVideo[0]?.code === 'whisperFailed',
+    `failed=${queuedSweep.failed} (want >=1) stuckQueued=${stuckQ?.status} (want failed), freshUntouched=${freshQ?.status === 'queued'}, video=${queuedVideo[0]?.status}/${queuedVideo[0]?.code}`,
+  );
+
+  // ---- video reconcile: a parked handoff row over a SETTLED file row
+  //      mirrors its terminal state (any age — this is the deployed-debt
+  //      backfill), and an orphan handoff row (file row gone) fails after
+  //      the stale window while a fresh orphan gets grace -----------------
+  const parkedDoneFile = await sql<{ id: string }[]>`
+    INSERT INTO app.file_metadata (
+      org_id, file_name, content_type, size, storage_ref, uploaded_by,
+      transcript, transcription_status, created_at_ms
+    ) VALUES (
+      ${orgId}, 'parked-done.mp3', 'audio/mpeg', 10, 's3:parked-done-1',
+      ${userId}, 'Settled transcript.', 'completed', ${stale}
+    )
+    RETURNING id
+  `;
+  await sql`
+    INSERT INTO app.video_link_jobs (
+      org_id, source_url, source_url_hash, source_platform, pasted_token,
+      status, status_changed_at_ms, storage_ref, file_metadata_id,
+      uploaded_by, created_at_ms
+    ) VALUES
+      (${orgId}, 'https://example.test/p1', 'hash-parked-done', 'youtube',
+       'p1', 'transcribing_handoff', ${now}, 's3:parked-done-1',
+       ${parkedDoneFile[0]?.id ?? ''}, ${userId}, ${stale}),
+      (${orgId}, 'https://example.test/o1', 'hash-orphan-stale', 'youtube',
+       'o1', 'transcribing_handoff', ${stale}, 's3:orphan-stale-1',
+       'fm_gone_stale', ${userId}, ${stale}),
+      (${orgId}, 'https://example.test/o2', 'hash-orphan-fresh', 'youtube',
+       'o2', 'transcribing_handoff', ${now}, 's3:orphan-fresh-1',
+       'fm_gone_fresh', ${userId}, ${now})
+  `;
+  const videoService = await import('./domains/video_links/service.ts');
+  await videoService.runVideoLinkWatchdog(sql);
+  const reconciled = await sql<
+    { hash: string; status: string; code: string | null }[]
+  >`
+    SELECT source_url_hash AS hash, status, error_reason_code AS code
+    FROM app.video_link_jobs
+    WHERE source_url_hash IN
+      ('hash-parked-done', 'hash-orphan-stale', 'hash-orphan-fresh')
+  `;
+  const byHash = new Map(reconciled.map((row) => [row.hash, row]));
+  record(
+    'watchdog: video reconcile settles parked handoff rows and orphans',
+    byHash.get('hash-parked-done')?.status === 'completed' &&
+      byHash.get('hash-orphan-stale')?.status === 'failed' &&
+      byHash.get('hash-orphan-stale')?.code === 'whisperFailed' &&
+      byHash.get('hash-orphan-fresh')?.status === 'transcribing_handoff',
+    `parkedDone=${byHash.get('hash-parked-done')?.status} (want completed), orphanStale=${byHash.get('hash-orphan-stale')?.status}/${byHash.get('hash-orphan-stale')?.code} (want failed/whisperFailed), orphanFreshGrace=${byHash.get('hash-orphan-fresh')?.status}`,
+  );
+
+  // ---- claim seam: winning the lease IS the 'running' transition --------
+  await sql`
+    INSERT INTO app.file_metadata (
+      org_id, file_name, content_type, size, storage_ref, uploaded_by,
+      transcription_status, created_at_ms
+    ) VALUES
+      (${orgId}, 'claim.mp3', 'audio/mpeg', 10, 's3:claim-1', ${userId},
+       'queued', ${now}),
+      (${orgId}, 'claim-skip.mp3', 'audio/mpeg', 10, 's3:claim-skip-1',
+       ${userId}, 'skipped', ${now})
+  `;
+  const transcriptionModule = await import('./domains/files/transcription.ts');
+  // Optional-typed so the pre-fix tree (no such export) records a failure
+  // instead of crashing the suite.
+  const acquireTranscriptionLease = (
+    transcriptionModule as {
+      acquireTranscriptionLease?: (
+        db: Sql,
+        args: { storageRef: string; runId: string; leaseMs: number },
+      ) => Promise<string | null>;
+    }
+  ).acquireTranscriptionLease;
+  if (!acquireTranscriptionLease) {
+    record(
+      'watchdog: the transcription lease claim stamps running + started_at',
+      false,
+      'acquireTranscriptionLease is not exported — nothing ever writes running/started_at, the crash watchdog is dead code',
+    );
+  } else {
+    const won = await acquireTranscriptionLease(sql, {
+      storageRef: 's3:claim-1',
+      runId: 'run-A',
+      leaseMs: 60_000,
+    });
+    const claimRows = await sql<
+      {
+        status: string | null;
+        startedAt: number | null;
+        runId: string | null;
+      }[]
+    >`
+      SELECT transcription_status AS status,
+             transcription_started_at_ms::float8 AS "startedAt",
+             transcription_run_id AS "runId"
+      FROM app.file_metadata WHERE storage_ref = 's3:claim-1'
+    `;
+    const lost = await acquireTranscriptionLease(sql, {
+      storageRef: 's3:claim-1',
+      runId: 'run-B',
+      leaseMs: 60_000,
+    });
+    const refused = await acquireTranscriptionLease(sql, {
+      storageRef: 's3:claim-skip-1',
+      runId: 'run-C',
+      leaseMs: 60_000,
+    });
+    const skipClaimRows = await sql<{ status: string | null }[]>`
+      SELECT transcription_status AS status FROM app.file_metadata
+      WHERE storage_ref = 's3:claim-skip-1'
+    `;
+    record(
+      'watchdog: the transcription lease claim stamps running + started_at',
+      won === 'run-A' &&
+        claimRows[0]?.status === 'running' &&
+        claimRows[0]?.startedAt !== null &&
+        claimRows[0]?.runId === 'run-A' &&
+        lost === 'run-A' &&
+        refused !== 'run-C' &&
+        skipClaimRows[0]?.status === 'skipped',
+      `won=${won}/run-A row=${claimRows[0]?.status}(startedAt=${claimRows[0]?.startedAt !== null}) holderKept=${lost === 'run-A'} skippedRefused=${refused !== 'run-C'}→${skipClaimRows[0]?.status}`,
+    );
+  }
+
+  // ---- skip propagation: a user skip on the file lane cascades onto the
+  //      waiting video job ------------------------------------------------
+  const skipFile = await sql<{ id: string }[]>`
+    INSERT INTO app.file_metadata (
+      org_id, file_name, content_type, size, storage_ref, uploaded_by,
+      transcription_status, created_at_ms
+    ) VALUES (
+      ${orgId}, 'skip-audio.mp3', 'audio/mpeg', 10, 's3:skip-audio-1',
+      ${userId}, 'queued', ${now}
+    )
+    RETURNING id
+  `;
+  await sql`
+    INSERT INTO app.video_link_jobs (
+      org_id, source_url, source_url_hash, source_platform, pasted_token,
+      status, status_changed_at_ms, storage_ref, file_metadata_id,
+      uploaded_by, created_at_ms
+    ) VALUES (
+      ${orgId}, 'https://example.test/s1', 'hash-skip-1', 'youtube', 's1',
+      'transcribing_handoff', ${now}, 's3:skip-audio-1',
+      ${skipFile[0]?.id ?? ''}, ${userId}, ${now}
+    )
+  `;
+  const { skipTranscription } =
+    await import('./domains/files/transcription.ts');
+  await skipTranscription(sql, orgId, 's3:skip-audio-1');
+  const skipVideo = await sql<{ status: string }[]>`
+    SELECT status FROM app.video_link_jobs
+    WHERE source_url_hash = 'hash-skip-1'
+  `;
+  record(
+    'watchdog: skipping a file transcription cascades onto its video job',
+    skipVideo[0]?.status === 'skipped',
+    `video=${skipVideo[0]?.status} (want skipped)`,
+  );
+
+  // ---- dismissal keeps a settled transcript: cancelling a whisper chip
+  //      whose transcription already COMPLETED must not clobber the file
+  //      row to 'skipped' (the cleanup would then delete the org's donor
+  //      transcript). Blob cleanup runs, so this needs the S3 lane. ------
+  if (process.env.ITEST_S3_ENDPOINT) {
+    const donorKeepFile = await sql<{ id: string }[]>`
+      INSERT INTO app.file_metadata (
+        org_id, file_name, content_type, size, storage_ref, uploaded_by,
+        transcript, transcription_status, created_at_ms
+      ) VALUES (
+        ${orgId}, 'donor-keep.mp3', 'audio/mpeg', 10, 's3:donor-keep-1',
+        ${userId}, 'Donor transcript to keep.', 'completed', ${now}
+      )
+      RETURNING id
+    `;
+    const donorKeepJob = await sql<{ id: string }[]>`
+      INSERT INTO app.video_link_jobs (
+        org_id, source_url, source_url_hash, source_platform, pasted_token,
+        status, status_changed_at_ms, storage_ref, file_metadata_id,
+        uploaded_by, created_at_ms
+      ) VALUES (
+        ${orgId}, 'https://example.test/d1', 'hash-donor-keep', 'youtube',
+        'd1', 'transcribing_handoff', ${now}, 's3:donor-keep-1',
+        ${donorKeepFile[0]?.id ?? ''}, ${userId}, ${now}
+      )
+      RETURNING id
+    `;
+    await videoService.cancelVideoLink(sql, {
+      organizationId: orgId,
+      userId,
+      jobId: donorKeepJob[0]?.id ?? '',
+    });
+    const donorKeptRows = await sql<{ status: string | null }[]>`
+      SELECT transcription_status AS status FROM app.file_metadata
+      WHERE id = ${donorKeepFile[0]?.id ?? ''}
+    `;
+    record(
+      'watchdog: dismissing a Ready whisper chip keeps the settled donor',
+      donorKeptRows[0]?.status === 'completed',
+      `fileRow=${donorKeptRows[0]?.status ?? 'DELETED'} (want completed — dismissal must not skip-clobber a settled transcript)`,
+    );
+  }
+
   // ---- RAG: adopt / fail / leave-alone against the corpus ---------------
   await sql`
     INSERT INTO app.file_metadata (
@@ -15456,6 +15703,11 @@ async function checkVideoLinks(
   // Fake whisper for the audio branch (the transcription check's fake has
   // closed; re-point the default openai credential at this one).
   let whisperCalls = 0;
+  // One-shot failure valve: the whisper-failure regression arc arms it, the
+  // next /audio/transcriptions call burns it (HTTP 400 → the classifier's
+  // permanent branch, so the engine terminalizes without its delayed
+  // self-retries stalling the drain).
+  let whisperFailNext = false;
   const whisperServer = createServer((req, res) => {
     req.on('data', () => undefined);
     req.on('end', () => {
@@ -15465,6 +15717,17 @@ async function checkVideoLinks(
         return;
       }
       whisperCalls += 1;
+      if (whisperFailNext) {
+        whisperFailNext = false;
+        res.statusCode = 400;
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            error: { message: 'Invalid file format (itest forced failure)' },
+          }),
+        );
+        return;
+      }
       res.setHeader('content-type', 'application/json');
       res.end(
         JSON.stringify({
@@ -15509,6 +15772,7 @@ vid=""
 case "$url" in
   *v=capt1*) vid="capt1";;
   *v=whis1*) vid="whis1";;
+  *v=whis2*) vid="whis2";;
   *v=gone1*) vid="gone1";;
 esac
 if [[ "$*" == *" -J "* || "\${args[0]}" == "-J" || "$*" == *"-J --"* ]]; then
@@ -15518,6 +15782,9 @@ if [[ "$*" == *" -J "* || "\${args[0]}" == "-J" || "$*" == *"-J --"* ]]; then
       exit 0;;
     whis1)
       echo '{"id":"whis1","title":"Whisper itest video","duration":42,"subtitles":{},"automatic_captions":{}}'
+      exit 0;;
+    whis2)
+      echo '{"id":"whis2","title":"Whisper retry itest video","duration":21,"subtitles":{},"automatic_captions":{}}'
       exit 0;;
     gone1)
       echo "ERROR: [youtube] gone1: Video unavailable" >&2
@@ -15780,9 +16047,16 @@ exit 1
     const whisJob = await jobRow(whisJobId);
     const whisFile = whisJob?.storageRef
       ? await sql<
-          { transcriptionStatus: string | null; transcript: string | null }[]
+          {
+            transcriptionStatus: string | null;
+            transcript: string | null;
+            startedAt: number | null;
+            runId: string | null;
+          }[]
         >`
-          SELECT transcription_status AS "transcriptionStatus", transcript
+          SELECT transcription_status AS "transcriptionStatus", transcript,
+                 transcription_started_at_ms::float8 AS "startedAt",
+                 transcription_run_id AS "runId"
           FROM app.file_metadata
           WHERE org_id = ${orgId} AND storage_ref = ${whisJob.storageRef}
           LIMIT 1
@@ -15865,10 +16139,17 @@ exit 1
     `;
     record(
       'video links: whisper path + failure/retry/cancel + cap + watchdog',
-      whisJob?.status === 'transcribing_handoff' &&
+      // The job row itself must land terminal when the transcription lane
+      // settles — the parked 'transcribing_handoff' forever was the bug
+      // (it held an org ingest slot for every whisper video ever finished).
+      whisJob?.status === 'completed' &&
         whisJob.transcriptSource === 'whisper' &&
         whisFile[0]?.transcriptionStatus === 'completed' &&
         (whisFile[0].transcript ?? '').includes('Whisper transcript') &&
+        // The engine stamps running + started_at at claim time (the crash
+        // watchdog's predicate) and the lease is released on settle.
+        whisFile[0].startedAt !== null &&
+        whisFile[0].runId === null &&
         whisperCalls >= 1 &&
         whisChip.success &&
         whisChip.data.jobs.some(
@@ -15884,8 +16165,114 @@ exit 1
         capped.status === 429 &&
         staleAfter?.status === 'failed' &&
         staleAfter.errorReasonCode === 'transient',
-      `whisper: job=${whisJob?.status}/${whisJob?.transcriptSource} file=${whisFile[0]?.transcriptionStatus} calls=${whisperCalls} chip=${whisChip.success ? whisChip.data.jobs.find((j) => j.jobId === whisJobId)?.displayStatus : 'ERR'}; gone=${goneJob?.status}/${goneJob?.errorReasonCode} retry=${retry.status}→${goneAfterRetry?.status}(attempts=${goneAfterRetry?.attempts}) cancel=${cancel.status}→${goneAfterCancel?.status}; cap=${capped.status}/429 watchdog=${staleAfter?.status}/${staleAfter?.errorReasonCode}`,
+      `whisper: job=${whisJob?.status}/${whisJob?.transcriptSource} file=${whisFile[0]?.transcriptionStatus} startedAt=${whisFile[0]?.startedAt !== null} lease=${whisFile[0]?.runId === null} calls=${whisperCalls} chip=${whisChip.success ? whisChip.data.jobs.find((j) => j.jobId === whisJobId)?.displayStatus : 'ERR'}; gone=${goneJob?.status}/${goneJob?.errorReasonCode} retry=${retry.status}→${goneAfterRetry?.status}(attempts=${goneAfterRetry?.attempts}) cancel=${cancel.status}→${goneAfterCancel?.status}; cap=${capped.status}/429 watchdog=${staleAfter?.status}/${staleAfter?.errorReasonCode}`,
     );
+
+    // 4. REGRESSION (transcription lifecycle): a whisper FAILURE must land
+    //    the job row itself terminal ('failed'/whisperFailed via the
+    //    settle cascade), and the Retry door must accept it — the pre-fix
+    //    shape kept the row 'transcribing_handoff' so every retry 409'd.
+    const whis2Url = 'https://www.youtube.com/watch?v=whis2';
+    whisperFailNext = true;
+    const whis2Ingest = z.object({ jobId: z.string() }).safeParse(
+      await (
+        await send(`/api/app/video-links/ingest?orgId=${orgId}`, {
+          url: whis2Url,
+          pastedToken: whis2Url,
+          threadId,
+        })
+      ).json(),
+    );
+    const whis2JobId = whis2Ingest.success ? whis2Ingest.data.jobId : '';
+    await drainVideoJobs();
+    await muteRagJobs();
+    const whis2Failed = await jobRow(whis2JobId);
+    const retryDoor = await send(
+      `/api/app/video-links/${whis2JobId}/retry?orgId=${orgId}`,
+      {},
+    );
+    await drainVideoJobs();
+    await muteRagJobs();
+    const whis2After = await jobRow(whis2JobId);
+    record(
+      'video links: whisper failure lands terminal and Retry actually retries',
+      whis2Ingest.success &&
+        whis2Failed?.status === 'failed' &&
+        whis2Failed.errorReasonCode === 'whisperFailed' &&
+        retryDoor.status === 200 &&
+        whis2After?.status === 'completed' &&
+        (whis2After.attempts ?? 0) === 1,
+      `failedRow=${whis2Failed?.status}/${whis2Failed?.errorReasonCode} (want failed/whisperFailed), retryDoor=${retryDoor.status} (want 200; the un-retryable dead-end 409s), afterRetry=${whis2After?.status} attempts=${whis2After?.attempts}`,
+    );
+
+    // 5. REGRESSION (slot cap): parked-but-settled handoff rows (the debt
+    //    shape existing deployments carry) are reconciled terminal by the
+    //    video watchdog, giving the org its ingest slots back.
+    const parkedIds: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const parkedFile = await sql<{ id: string }[]>`
+        INSERT INTO app.file_metadata (
+          org_id, file_name, content_type, size, storage_ref, source,
+          uploaded_by, transcript, transcription_status, skip_rag_indexing,
+          created_at_ms
+        ) VALUES (
+          ${orgId}, ${`parked-${i}.mp3`}, 'audio/mpeg', 10,
+          ${`s3:parked-audio-${i}`}, 'video_link', ${userId},
+          'Parked whisper transcript.', 'completed', true, ${Date.now()}
+        )
+        RETURNING id
+      `;
+      const parkedJob = await sql<{ id: string }[]>`
+        INSERT INTO app.video_link_jobs (
+          org_id, thread_id, uploaded_by, source_url, source_url_hash,
+          source_platform, pasted_token, status, status_changed_at_ms,
+          storage_ref, file_metadata_id, attempts, lifecycle_status,
+          created_at_ms
+        ) VALUES (
+          ${orgId}, ${threadId}, ${userId},
+          ${`https://www.youtube.com/watch?v=park${i}`}, ${`parkhash${i}`},
+          'youtube', 'park', 'transcribing_handoff', ${Date.now()},
+          ${`s3:parked-audio-${i}`}, ${parkedFile[0]?.id ?? ''}, 0, 'active',
+          ${Date.now()}
+        )
+        RETURNING id
+      `;
+      const id = parkedJob[0]?.id;
+      if (id) parkedIds.push(id);
+    }
+    await video.runVideoLinkWatchdog(sql);
+    const parkedAfter = await sql<{ status: string }[]>`
+      SELECT status FROM app.video_link_jobs WHERE id = ANY(${parkedIds})
+    `;
+    const freed = await send(`/api/app/video-links/ingest?orgId=${orgId}`, {
+      url: 'https://www.youtube.com/watch?v=freedX1',
+      pastedToken: 'freedX1',
+      threadId,
+    });
+    await drainVideoJobs();
+    record(
+      'video links: reconcile settles parked whisper rows and frees the cap',
+      parkedIds.length === 3 &&
+        parkedAfter.length === 3 &&
+        parkedAfter.every((row) => row.status === 'completed') &&
+        freed.status === 200,
+      `parked=${parkedAfter.map((row) => row.status).join(',')} (want completed×3), nextIngest=${freed.status} (want 200; the parked-forever cap 429s)`,
+    );
+    const freedJson = z
+      .object({ jobId: z.string() })
+      .safeParse(await freed.json().catch(() => null));
+    await sql`
+      DELETE FROM app.file_metadata
+      WHERE org_id = ${orgId} AND storage_ref LIKE 's3:parked-audio-%'
+    `;
+    await sql`
+      DELETE FROM app.video_link_jobs WHERE id = ANY(${parkedIds})
+    `;
+    if (freedJson.success) {
+      await sql`
+        DELETE FROM app.video_link_jobs WHERE id = ${freedJson.data.jobId}
+      `;
+    }
   } finally {
     whisperServer.close();
     if (savedBinDir === undefined) {

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1152,6 +1152,9 @@ chat:
       privateIpResolved: Dieser Link verweist auf eine private/interne Adresse
       inFlightCap: Zu viele Videos in Verarbeitung — bitte warten, bis eines fertig ist
       budgetExceeded: Nutzungslimit erreicht — Administrator kontaktieren
+      notFound: Video-Link nicht gefunden — möglicherweise wurde er entfernt
+      notUploader: Nur die Person, die dieses Video hinzugefügt hat, kann es ändern
+      notRetryable: Erneuter Versuch gerade nicht möglich — das Video wird womöglich schon wieder verarbeitet
     actions:
       removeLink: Entfernen
       retry: Erneut versuchen
@@ -5239,8 +5242,7 @@ settings:
       clientSecretLabel: Client-Secret
       clientSecretKeep: Leer lassen, um das aktuelle Secret beizubehalten.
       tenantIdLabel: Verzeichnis-ID (Tenant)
-      tenantIdHint:
-        Nötig für Single-Tenant-Registrierungen bei Microsoft; bei
+      tenantIdHint: Nötig für Single-Tenant-Registrierungen bei Microsoft; bei
         Multi-Tenant-Apps leer lassen.
       redirectUrisLabel: Zu registrierende Redirect-URIs
       redirectUrisHint:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1115,6 +1115,9 @@ chat:
       privateIpResolved: This link points to a private/internal address
       inFlightCap: Too many videos processing — wait for one to finish
       budgetExceeded: Usage limit reached — contact your administrator
+      notFound: Video link not found — it may have been removed
+      notUploader: Only the person who added this video can change it
+      notRetryable: Can't retry right now — the video may already be processing again
     actions:
       removeLink: Remove
       retry: Try again
@@ -5366,8 +5369,7 @@ settings:
         Required for single-tenant Microsoft app registrations; leave blank
         for multi-tenant ones.
       redirectUrisLabel: Redirect URIs to register
-      redirectUrisHint:
-        Add each of these to the vendor app registration before connecting.
+      redirectUrisHint: Add each of these to the vendor app registration before connecting.
       reuseSso: Use Entra ID SSO app
       reuseSsoTitle: Reuse the Entra ID SSO app registration
       reuseSsoBody:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1160,6 +1160,9 @@ chat:
       privateIpResolved: Ce lien pointe vers une adresse privée/interne
       inFlightCap: Trop de vidéos en cours de traitement — attends qu'une se termine
       budgetExceeded: Limite d'usage atteinte — contacte ton administrateur
+      notFound: Lien vidéo introuvable — il a peut-être été supprimé
+      notUploader: Seule la personne qui a ajouté cette vidéo peut la modifier
+      notRetryable: Nouvelle tentative impossible pour le moment — la vidéo est peut-être déjà en cours de traitement
     actions:
       removeLink: Retirer
       retry: Réessayer


### PR DESCRIPTION
Fixes the verified review class **transcription/video-ingest lifecycle dead-ends**: whisper video jobs that never reach a terminal state (permanently filling the org's 3-slot ingest cap), a Retry button that could only ever 409, and a crash watchdog whose predicate no production write could satisfy. All three findings verified in code before changing anything; none refuted.

## The lifecycle, as one machine (state → transition → writer)

**file_metadata transcription lane**

- `NULL → queued` — `queueTranscription` / the whisper handoff's `saveFileMetadata` shim (stamps `status_changed_at_ms`).
- `queued → running` — **new**: winning the single-flight lease claim IS the transition. `acquireTranscriptionLease` (exported from `domains/files/transcription.ts`, the engine's `acquireTranscriptionLock` handler delegates) stamps `transcription_status='running'`, `transcription_started_at_ms`, and `status_changed_at_ms` atomically with the lease CAS. The claim also refuses non-`queued`/`running` rows, so a skip landing between the engine's pre-check and its claim is no longer resurrected.
- `running → completed | failed` — the engine's terminal write through `updateFileTranscription`.
- `running → queued` — the engine's own delayed self-retry (unchanged).
- `queued|running → skipped` — `skipTranscription` (user skip).
- `failed|skipped → queued` — `retryTranscription` (unchanged semantics, now stamps the clock).
- **Crash recovery** — `recoverStuckTranscriptions` (`watchdog.transcriptions`, */5, verified scheduled in `jobs/schedules.ts` + handled in `jobs/task-list.ts`): fails stale `running` rows (started_at clock — now actually written) **and** stale, lease-free `queued` rows (crash between pickup and claim, or a lost enqueue — `files.transcribe` has retryLimit 0). Both produce a watchdog-attributed, retryable failure, never a forever-spinner.

**video_link_jobs lane (the whisper branch)**

- `transcribing_handoff → completed|failed|skipped` — **new, the missing transition**: `settleHandoffJobsByStorageRef`, called by the transcription seam **in the same transaction** as the file row's terminal write (and by `skipTranscription`). A failed transcription carries `whisperFailed` + the sanitized engine error onto the job row.
- **Reconcile backstop** — `runVideoLinkWatchdog` (`video.watchdog`, */5) now also: (a) mirrors the terminal state onto any handoff row whose file row already settled, at ANY age — this is the deployed-debt backfill: every org that pre-fix parked whisper rows forever gets its ingest slots back within one 5-minute tick; (b) fails handoff rows whose file row is gone/never recorded after the 35-min stale window (heartbeats advance the clock for live runs) and reaps their audio blob.
- `failed|skipped → queued` — `retryVideoLink`. The door now also accepts a handoff row whose file transcription settled failed/skipped (`isVideoJobRetryable` truth table) as drift/legacy defense; the existing cleanup resets the file lane coherently before the re-queue.
- `countInFlight`/`NON_TERMINAL_STATUSES` unchanged — with the transitions real, `transcribing_handoff` rows counted by the cap are genuinely active.

## Per-finding

### 1. [critical] Whisper jobs never leave `transcribing_handoff`; the org's 3-slot cap fills forever — **fixed**

Verified: no writer of a terminal job status existed for the whisper branch (completion was display-only via the `projectJob` join); `integration-check.ts` even asserted the parked state. Fix: the transactional settle cascade + the watchdog reconcile above. The user invariant holds: finished work frees the slot, and the chip's state now IS the row's state.
Regression tests (each observed failing at this branch's base, `6eed31e60`):

- whisper E2E assertion flipped: job row lands `completed` (was the enshrined `transcribing_handoff`); chip shows Ready off the real status.
- "reconcile settles parked whisper rows and frees the cap": 3 parked settled-handoff rows + one watchdog tick → all `completed`, next ingest 200 (was 429).

### 2. [high] Retry on a whisper-failed chip always 409s — **fixed**

Verified: `retryVideoLink` accepted only `failed`/`skipped` while the row stayed `transcribing_handoff`; the toast rendered a raw i18n key (`videoLink.errors.notRetryable` absent, hook toasts had no `defaultValue` fallback). Fix: clean failures now cascade the job row to `failed` (so the existing door opens), the door additionally accepts settled-failed/skipped handoff rows, and the refusal codes are localized (`notRetryable`/`notFound`/`notUploader` in en/de/fr; de-CH ships overrides only and has none for videoLink) with the chip's `defaultValue` fallback added to both hook toasts.
Regression tests: "whisper failure lands terminal and Retry actually retries" — forced one-shot whisper 400 → job `failed`/`whisperFailed`, POST retry → 200, full re-run → `completed`, attempts=1 (observed on base: row parked `transcribing_handoff`, retry **409**). Colocated vitest: `isVideoJobRetryable` truth table.

### 3. [high×2] Transcription crash watchdog can never fire — **fixed**

Verified: nothing wrote `transcription_status='running'` or `transcription_started_at_ms` (zero production writers; the integration check seeded them by hand), so the sweep matched nothing and a crash mid-transcription stuck the row forever (`files.transcribe` retryLimit 0). The schedule itself was wired (`schedules.ts:53`) — only the predicate was dead. Fix: the lease claim stamps `running`+`started_at` atomically (see above); the sweep additionally covers stale lease-free `queued` rows; recovery is fail-with-reason (retryable via finding 2's door), not re-enqueue — no crash-loop on poison input, matching the 0.4 twin's posture.
Regression tests: "the transcription lease claim stamps running + started_at" (claim → `running`+`started_at`+run id; second claim refused; skipped row refuses the claim); "a never-claimed stale queued transcription fails and cascades" (fresh queued row untouched); whisper E2E now asserts `started_at` stamped and the lease released after settle.

## Folded-in mediums (same mechanisms, from `video_links` in mediums.md)

- **Handoff rows dodge watchdog + 7-day GC (audio blobs leak, slots held)** — terminalization makes the existing GC filter (`completed/failed/skipped` + unbound + 7d) apply to whisper rows exactly as to captions rows; never-settling orphans are failed by the new orphan sweep and their blobs reaped.
- **Dismissing a Ready whisper chip destroys the completed transcript** — both skip-propagation sites now guard `transcription_status IN ('queued','running')`, so a settled transcript survives dismissal as an org donor (the documented donor contract: cancel keeps the row). Regression test: "dismissing a Ready whisper chip keeps the settled donor" (observed on base: the file row was DELETED).

## Refuted findings

None — all three findings and both mediums confirmed in code.

## Backfill: no migration (0061 not used) — deliberate

The schema already carries every column and CHECK value this state machine needs (`running`, `transcription_started_at_ms`, lease columns, terminal job statuses — migrations 0010/0046); only the writers were missing. Historical stuck rows are healed by the watchdog reconcile within one 5-minute tick of deploy: idempotent, deterministic per row (the terminal state derives from that row's own file join), safe mid-roll (an old-image engine finishing during the roll is reconciled on the next tick), and no migration-number race with sibling branches. A one-shot backfill would duplicate the reconcile logic for zero additional benefit.

Known bounded edge: a legacy handoff row whose file settled _failed_ still counts against its own retry's in-flight cap until the reconcile tick settles it (≤5 min, legacy rows only — live failures land terminal transactionally).

## Verification (all observed)

- Proof run at branch base + probes: **278/286** — the 8 failures are exactly the 8 new/changed regression probes, each reporting the dead-end behavior described above.
- Green run with fixes: **286/286** on a fresh throwaway tale-db + MinIO.
- Platform vitest (server+pii): **373 files / 72,279 tests passed** (includes the new truth table + i18n parity for the three new keys across en/de/fr).
- `bun run --filter @tale/platform typecheck` and `lint`: green.
