### PR TITLE
fix(platform): enforce the GDPR erasure governance gates

### DIFF
--- a/docs/de/platform/admin/governance/data-subject-requests.md
+++ b/docs/de/platform/admin/governance/data-subject-requests.md
@@ -17,16 +17,16 @@ Um eine Anfrage einzureichen, öffne **Einstellungen > Richtlinien > Anfragen be
 
 ## Status-Lebenszyklus
 
-| Name                | Default        | Beschreibung                                                                                       |
-| ------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
-| Ausstehend          | Anfangszustand | Die Anfrage ist eingereicht und wartet auf das Cooling-off-Fenster oder die zweite Admin-Freigabe. |
-| Wartet auf Freigabe | Vier-Augen     | Ein zweiter Admin muss freigeben, bevor die Kaskade läuft.                                         |
-| Läuft               | mid-cascade    | Die Kaskade läuft; Teilzähler aktualisieren sich, sobald jede Kategorie fertig ist.                |
-| Abgeschlossen       | terminal       | Jede Kategorie ist ohne Fehler gelöscht.                                                           |
-| Teilweise           | terminal       | Einige Zeilen wurden übersprungen — meist hat ein Legal Hold sie blockiert.                        |
-| Fehlgeschlagen      | terminal       | Die Kaskade traf auf einen Fehler; der Beleg benennt die fehlgeschlagene Kategorie.                |
-| Blockiert           | terminal       | Ein aktiver Legal Hold blockiert jeden Kaskade-Schritt.                                            |
-| Abgebrochen         | terminal       | Ein Admin hat vor Ablauf des Cooling-off-Fensters abgebrochen.                                     |
+| Name                | Default        | Beschreibung                                                                                                                                                                  |
+| ------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ausstehend          | Anfangszustand | Die Anfrage ist eingereicht und wartet auf das Cooling-off-Fenster oder die zweite Admin-Freigabe.                                                                            |
+| Wartet auf Freigabe | Vier-Augen     | Ein zweiter Admin muss freigeben, bevor die Kaskade läuft — oder weist die Anfrage zurück, was sie abbricht.                                                                  |
+| Läuft               | mid-cascade    | Die Kaskade läuft; Teilzähler aktualisieren sich, sobald jede Kategorie fertig ist.                                                                                           |
+| Abgeschlossen       | terminal       | Jede Kategorie ist ohne Fehler gelöscht.                                                                                                                                      |
+| Teilweise           | terminal       | Einige Zeilen wurden übersprungen — meist hat ein Legal Hold sie blockiert.                                                                                                   |
+| Fehlgeschlagen      | terminal       | Die Kaskade traf auf einen Fehler; der Beleg benennt die fehlgeschlagene Kategorie.                                                                                           |
+| Blockiert           | terminal       | Ein aktiver Legal Hold blockiert jeden Kaskade-Schritt.                                                                                                                       |
+| Abgebrochen         | terminal       | Ein Admin hat abgebrochen, bevor die Kaskade lief, oder ein zweiter Admin hat die Freigabe zurückgewiesen. Für die betroffene Person lässt sich eine neue Anfrage einreichen. |
 
 ## SLA-Verfolgung
 
@@ -38,7 +38,7 @@ Daten einer betroffenen Person werden _nicht_ gelöscht, solange sie auf Legal H
 
 ## Die Kaskade-Kategorien
 
-Der Beleg schlüsselt die gelöschten Zeilen nach Kategorie auf — Threads, Dokumente, Workflow-Ausführungen, Prompt-Vorlagen, aus dem Vektorspeicher entfernte RAG-Dokumente. Lies das Drawer für Zähler und die Audit-Zeitleiste; das Audit-Log im selben Governance-Bereich trägt die volle Ereigniskette (`gdpr_erasure_requested`, `gdpr_erasure_executed`, `gdpr_erasure_extended`, `gdpr_erasure_cancelled`).
+Der Beleg schlüsselt die gelöschten Zeilen nach Kategorie auf — Threads, Dokumente, Workflow-Ausführungen, Prompt-Vorlagen, aus dem Vektorspeicher entfernte RAG-Dokumente. Lies das Drawer für Zähler und die Audit-Zeitleiste; das Audit-Log im selben Governance-Bereich trägt die volle Ereigniskette (`gdpr_erasure_requested`, `gdpr_erasure_executed`, `gdpr_erasure_extended`, `gdpr_erasure_rejected`, `gdpr_erasure_cancelled`).
 
 ## Wo das hingehört
 

--- a/docs/en/platform/admin/governance/data-subject-requests.md
+++ b/docs/en/platform/admin/governance/data-subject-requests.md
@@ -17,16 +17,16 @@ To file a request, open **Settings > Governance > Data subject requests** and cl
 
 ## Status lifecycle
 
-| Name              | Default       | Description                                                                               |
-| ----------------- | ------------- | ----------------------------------------------------------------------------------------- |
-| Pending           | initial state | The request is filed and waiting for the cooling-off window or the second admin approval. |
-| Awaiting approval | dual-control  | A second Admin must approve before the cascade runs.                                      |
-| Running           | mid-cascade   | The cascade is in flight; partial counters update as each category completes.             |
-| Completed         | terminal      | Every category erased without error.                                                      |
-| Partial           | terminal      | Some rows were skipped — usually a legal hold blocked them.                               |
-| Failed            | terminal      | The cascade hit an error; the receipt names the failed category.                          |
-| Blocked           | terminal      | An active legal hold blocks every cascade step.                                           |
-| Cancelled         | terminal      | An Admin cancelled before the cooling-off window elapsed.                                 |
+| Name              | Default       | Description                                                                                                                          |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Pending           | initial state | The request is filed and waiting for the cooling-off window or the second admin approval.                                            |
+| Awaiting approval | dual-control  | A second Admin must approve before the cascade runs — or reject, which cancels the request.                                          |
+| Running           | mid-cascade   | The cascade is in flight; partial counters update as each category completes.                                                        |
+| Completed         | terminal      | Every category erased without error.                                                                                                 |
+| Partial           | terminal      | Some rows were skipped — usually a legal hold blocked them.                                                                          |
+| Failed            | terminal      | The cascade hit an error; the receipt names the failed category.                                                                     |
+| Blocked           | terminal      | An active legal hold blocks every cascade step.                                                                                      |
+| Cancelled         | terminal      | An Admin cancelled before the cascade ran, or a second Admin rejected the dual approval. A new request can be filed for the subject. |
 
 ## SLA tracking
 
@@ -38,7 +38,7 @@ A subject's data is _not_ erased while it is on legal hold. Rows under hold show
 
 ## The cascade categories
 
-The receipt breaks the erased rows down by category — threads, documents, workflow executions, prompt templates, RAG documents removed from the vector store. Read the drawer to see counts and the audit timeline; the audit log on the same Governance area carries the full event chain (`gdpr_erasure_requested`, `gdpr_erasure_executed`, `gdpr_erasure_extended`, `gdpr_erasure_cancelled`).
+The receipt breaks the erased rows down by category — threads, documents, workflow executions, prompt templates, RAG documents removed from the vector store. Read the drawer to see counts and the audit timeline; the audit log on the same Governance area carries the full event chain (`gdpr_erasure_requested`, `gdpr_erasure_executed`, `gdpr_erasure_extended`, `gdpr_erasure_rejected`, `gdpr_erasure_cancelled`).
 
 ## Where this fits
 

--- a/docs/fr/platform/admin/governance/data-subject-requests.md
+++ b/docs/fr/platform/admin/governance/data-subject-requests.md
@@ -17,16 +17,16 @@ Pour déposer une demande, ouvre **Paramètres > Gouvernance > Demandes des pers
 
 ## Cycle de vie du statut
 
-| Nom                      | Par défaut      | Description                                                                                             |
-| ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------- |
-| En attente               | état initial    | La demande est déposée et attend la fenêtre d’attente ou la seconde approbation administrateur.         |
-| En attente d’approbation | double contrôle | Un second Administrateur doit approuver avant que la cascade ne s’exécute.                              |
-| En cours                 | mid-cascade     | La cascade est en cours ; les compteurs partiels se mettent à jour à mesure que chaque catégorie finit. |
-| Terminée                 | terminal        | Chaque catégorie effacée sans erreur.                                                                   |
-| Partielle                | terminal        | Certaines lignes ont été ignorées — généralement une conservation légale les a bloquées.                |
-| Échouée                  | terminal        | La cascade a rencontré une erreur ; le reçu nomme la catégorie en échec.                                |
-| Bloquée                  | terminal        | Une conservation légale active bloque chaque étape de cascade.                                          |
-| Annulée                  | terminal        | Un Administrateur a annulé avant que la fenêtre d’attente n’expire.                                     |
+| Nom                      | Par défaut      | Description                                                                                                                                                                      |
+| ------------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| En attente               | état initial    | La demande est déposée et attend la fenêtre d’attente ou la seconde approbation administrateur.                                                                                  |
+| En attente d’approbation | double contrôle | Un second Administrateur doit approuver avant que la cascade ne s’exécute — ou rejeter, ce qui annule la demande.                                                                |
+| En cours                 | mid-cascade     | La cascade est en cours ; les compteurs partiels se mettent à jour à mesure que chaque catégorie finit.                                                                          |
+| Terminée                 | terminal        | Chaque catégorie effacée sans erreur.                                                                                                                                            |
+| Partielle                | terminal        | Certaines lignes ont été ignorées — généralement une conservation légale les a bloquées.                                                                                         |
+| Échouée                  | terminal        | La cascade a rencontré une erreur ; le reçu nomme la catégorie en échec.                                                                                                         |
+| Bloquée                  | terminal        | Une conservation légale active bloque chaque étape de cascade.                                                                                                                   |
+| Annulée                  | terminal        | Un Administrateur a annulé avant l’exécution de la cascade, ou un second Administrateur a rejeté la double approbation. Une nouvelle demande peut être déposée pour la personne. |
 
 ## Suivi du SLA
 
@@ -38,7 +38,7 @@ Les données d’une personne ne sont _pas_ effacées tant qu’elles sont sous 
 
 ## Les catégories de cascade
 
-Le reçu ventile les lignes effacées par catégorie — threads, documents, exécutions de workflow, modèles de prompts, documents RAG retirés du magasin vectoriel. Lis le drawer pour voir les compteurs et la timeline d’audit ; le journal d’audit dans la même zone Gouvernance porte la chaîne d’événements complète (`gdpr_erasure_requested`, `gdpr_erasure_executed`, `gdpr_erasure_extended`, `gdpr_erasure_cancelled`).
+Le reçu ventile les lignes effacées par catégorie — threads, documents, exécutions de workflow, modèles de prompts, documents RAG retirés du magasin vectoriel. Lis le drawer pour voir les compteurs et la timeline d’audit ; le journal d’audit dans la même zone Gouvernance porte la chaîne d’événements complète (`gdpr_erasure_requested`, `gdpr_erasure_executed`, `gdpr_erasure_extended`, `gdpr_erasure_rejected`, `gdpr_erasure_cancelled`).
 
 ## Où cela s’inscrit
 

--- a/services/platform/backend/core/governance/erasure_constants.ts
+++ b/services/platform/backend/core/governance/erasure_constants.ts
@@ -36,14 +36,15 @@ export const ERASURE_STATUSES = [
 export type ErasureStatus = (typeof ERASURE_STATUSES)[number];
 
 /**
- * Sentinel `errorMessage` value written by the watchdog when it flips a
- * stuck `running` row to `'failed'`. The late-finalize race-guard in
- * `finalizeProcessing` matches against this value to detect that a
- * watchdog already won (and preserves the watchdog's verdict instead of
- * overwriting it with a delayed `done`/`partial`).
+ * Sentinel `error` value the watchdog writes when it flips a stuck
+ * `running` receipt to `'failed'`. Load-bearing beyond the message: the
+ * retry path refuses a receipt carrying it (`retryErasure` — a run that
+ * timed out mid-cascade has unknown partial state, so the next attempt
+ * must be a FRESH request, not a resume).
  *
- * Centralised so a typo in any one of the three call sites cannot
- * silently break the guard.
+ * Centralised so the writer (`recoverStuckErasureRequests`) and the
+ * matcher (`retryErasure`) cannot drift apart — the value is persisted on
+ * receipt rows, so it must NEVER change without a data migration.
  */
 export const ERASURE_WATCHDOG_TIMEOUT_MESSAGE =
-  'Erasure timed out (watchdog)' as const;
+  'Erasure timed out and was stopped by the watchdog. File a new request.' as const;

--- a/services/platform/backend/db/migrations/0062_erasure_reason_code_child.sql
+++ b/services/platform/backend/db/migrations/0062_erasure_reason_code_child.sql
@@ -1,0 +1,16 @@
+-- 0.5 app migration 0062: normalize the GDPR erasure reason code for the
+-- Art 17(1)(f) ground to 'child'.
+--
+-- The reason-code vocabulary lives in core/governance/erasure_constants.ts
+-- ('child' — the code the file-request picker, the i18n catalogs, and the
+-- docs all use), but the erasure service carried a divergent local copy
+-- with 'child_consent': the documented code could never be filed, while
+-- raw API callers could store the undocumented one. The service now
+-- validates against the constants module; this backfill folds any stored
+-- 'child_consent' rows into the one vocabulary so every receipt renders a
+-- real label. Idempotent and rolling-safe: reads never validate stored
+-- codes, so the previous image keeps serving these rows unchanged.
+
+UPDATE app.gdpr_erasure_requests
+SET reason_code = 'child'
+WHERE reason_code = 'child_consent';

--- a/services/platform/backend/domains/approvals/routes.ts
+++ b/services/platform/backend/domains/approvals/routes.ts
@@ -17,7 +17,9 @@ import {
 /**
  * /api/app/approvals — the approvals inbox. Reads and the generic decision
  * are org-member operations (the 0.4 posture); review-gate rows refuse
- * toward their dedicated respond doors.
+ * toward their dedicated respond doors, and erasure rows additionally
+ * demand an org-admin decider (the dual-control half of the GDPR
+ * contract) — the service checks the session-resolved role per KIND.
  */
 
 function handleError<E extends OrgEnv>(
@@ -105,6 +107,7 @@ export function createApprovalRoutes(deps: {
           : {}),
         actor: {
           userId: c.get('sessionBundle').user.id,
+          role: c.get('orgMember').role,
           email: c.get('sessionBundle').user.email,
         },
       });

--- a/services/platform/backend/domains/approvals/service.test.ts
+++ b/services/platform/backend/domains/approvals/service.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+
+import { ApprovalError, assertRoleMayDecideKind } from './service';
+
+/**
+ * `assertRoleMayDecideKind` is the per-KIND authorization rule on the
+ * generic decide door (`POST /api/app/approvals/:id/decide`). The door is
+ * an org-member surface, but a GDPR erasure decision is the second half
+ * of the dual-control contract the DSR docs promise ("a second Admin must
+ * approve"), so the erasure kind demands an org admin for BOTH deciding
+ * directions. The DB-backed arc (member refused over HTTP, receipt
+ * settled on reject, schedule on approve) runs in the integration check.
+ */
+
+describe('assertRoleMayDecideKind', () => {
+  it('refuses a plain member deciding an erasure approval', () => {
+    expect(() => assertRoleMayDecideKind('erasure', 'member')).toThrowError(
+      ApprovalError,
+    );
+    try {
+      assertRoleMayDecideKind('erasure', 'member');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApprovalError);
+      if (error instanceof ApprovalError) {
+        expect(error.code).toBe('FORBIDDEN');
+        expect(error.status).toBe(403);
+      }
+    }
+  });
+
+  it('refuses the developer role — admin means admin/owner only', () => {
+    expect(() => assertRoleMayDecideKind('erasure', 'developer')).toThrowError(
+      ApprovalError,
+    );
+  });
+
+  it('passes admins and owners for the erasure kind', () => {
+    expect(() => assertRoleMayDecideKind('erasure', 'admin')).not.toThrow();
+    expect(() => assertRoleMayDecideKind('erasure', 'owner')).not.toThrow();
+  });
+
+  it('normalizes role case like the membership reader does', () => {
+    expect(() => assertRoleMayDecideKind('erasure', 'Admin')).not.toThrow();
+    expect(() => assertRoleMayDecideKind('erasure', 'OWNER')).not.toThrow();
+  });
+
+  it('leaves every non-erasure kind on the org-member posture', () => {
+    for (const kind of [
+      'connector_operation',
+      'human_input_request',
+      'conversations',
+      'document_record_review',
+      'task_review',
+    ]) {
+      expect(() => assertRoleMayDecideKind(kind, 'member')).not.toThrow();
+    }
+  });
+});

--- a/services/platform/backend/domains/approvals/service.ts
+++ b/services/platform/backend/domains/approvals/service.ts
@@ -1,18 +1,23 @@
 import type { Sql } from 'postgres';
 
+import { isAdminRole } from '../../auth/membership.ts';
 import { toJson } from '../../db/sql.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
 import { pokeParkedRun } from '../automations/store.ts';
-import { confirmAndScheduleErasure } from '../erasure/service.ts';
+import {
+  confirmAndScheduleErasure,
+  rejectErasure,
+} from '../erasure/service.ts';
 
 /**
  * The approvals INBOX surface — the 0.5 twin of the 0.4 read/decide half of
  * `convex/approvals/{queries,mutations,helpers,list_approvals_paginated}`:
  * paginated listing, per-status counts, one-row read, and the generic
  * human decision (`updateApprovalStatus`) with the same FSM and the same
- * dedicated-door refusals. The gate half lives in `gate.ts`; the
- * conversations fold lives in the send lane.
+ * dedicated-door refusals. Kind-scoped authorization rides the decision:
+ * erasure rows demand an org admin (`assertRoleMayDecideKind`). The gate
+ * half lives in `gate.ts`; the conversations fold lives in the send lane.
  */
 
 export class ApprovalError extends Error {
@@ -135,7 +140,32 @@ export interface DecideApprovalArgs {
   approvalId: string;
   status: 'executing' | 'rejected';
   comments?: string;
-  actor: { userId: string; email?: string };
+  /** `role` is the caller's SESSION-RESOLVED org role (`orgMember.role`
+   * from `requireOrgMember` — trusted-headers aware), never a raw member
+   * row read. Kind-gated decisions check it. */
+  actor: { userId: string; role: string; email?: string };
+}
+
+/**
+ * The per-KIND authorization rule for the generic decide door. The door
+ * itself is an org-member surface (the 0.4 posture — connector operations,
+ * human-input asks, and conversation approvals are decided by the people
+ * working the thread), but a GDPR erasure decision IS the second half of
+ * the dual-control contract the docs promise ("a second Admin must
+ * approve"), so both deciding directions — approve AND reject — demand an
+ * org admin. Pure so the rule is unit-testable.
+ */
+export function assertRoleMayDecideKind(
+  resourceType: string,
+  role: string,
+): void {
+  if (resourceType === 'erasure' && !isAdminRole(role)) {
+    throw new ApprovalError(
+      'FORBIDDEN',
+      'Only org admins decide erasure approvals.',
+      403,
+    );
+  }
 }
 
 /**
@@ -187,6 +217,7 @@ export async function decideApproval(
         409,
       );
     }
+    assertRoleMayDecideKind(approval.resourceType, args.actor.role);
     if (approval.status !== 'pending') {
       throw new ApprovalError(
         'ALREADY_RESOLVED',
@@ -238,13 +269,24 @@ export async function decideApproval(
     // GDPR Art 17 dispatch: approving an erasure row starts its cooling-off
     // window and schedules the processor. Filer ≠ approver is re-enforced
     // there and throws, rolling the decision back with it — an approval the
-    // policy forbids must not stand.
-    if (args.status === 'executing' && approval.resourceType === 'erasure') {
-      await confirmAndScheduleErasure(tx, {
-        requestId: approval.resourceId,
-        approverId: args.actor.userId,
-        organizationId: args.organizationId,
-      });
+    // policy forbids must not stand. REJECTING one settles the receipt
+    // terminally (`cancelled`) in the same transaction — a rejected request
+    // must never wedge the subject behind the live-unique index.
+    if (approval.resourceType === 'erasure') {
+      if (args.status === 'executing') {
+        await confirmAndScheduleErasure(tx, {
+          requestId: approval.resourceId,
+          approverId: args.actor.userId,
+          organizationId: args.organizationId,
+        });
+      } else {
+        await rejectErasure(tx, {
+          requestId: approval.resourceId,
+          rejectedBy: args.actor.userId,
+          organizationId: args.organizationId,
+          ...(args.comments !== undefined ? { comments: args.comments } : {}),
+        });
+      }
     }
     await emitHintInTx(tx, {
       orgId: args.organizationId,

--- a/services/platform/backend/domains/erasure/routes.ts
+++ b/services/platform/backend/domains/erasure/routes.ts
@@ -3,6 +3,7 @@ import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import type { Auth } from '../../auth/auth.ts';
+import { isAdminRole } from '../../auth/membership.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession } from '../../auth/session.ts';
 import {
@@ -15,7 +16,13 @@ import {
   getErasureRequest,
 } from './service.ts';
 
-/** /api/app/erasure — GDPR Art 17 receipts (admin-gated in the service). */
+/**
+ * /api/app/erasure — GDPR Art 17 receipts. The WHOLE lifecycle is
+ * admin-only (the docs' contract: admins file, cancel, retry, extend, and
+ * read receipts), enforced by the router-level role gate below on the
+ * session-resolved membership (so a trusted-headers `trustedRole` counts);
+ * filing additionally re-checks in the service with an audited deny.
+ */
 function handleError<E extends OrgEnv>(
   c: Context<E>,
   error: unknown,
@@ -35,6 +42,18 @@ export function createErasureRoutes(deps: {
 }): Hono<OrgEnv> {
   const app = new Hono<OrgEnv>();
   app.use(requireSession(deps.auth), requireOrgMember(deps.sql));
+  // Admin gate over every erasure operation — reads included: receipts
+  // name subjects, filers, and lawful grounds, none of which an ordinary
+  // member may enumerate. `mapDsrError` localizes the `forbidden` code.
+  app.use(async (c, next) => {
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json(
+        { error: 'forbidden', message: 'Only org admins manage erasure.' },
+        403,
+      );
+    }
+    return next();
+  });
 
   app.get('/', async (c) => {
     const limitParam = Number(c.req.query('limit') ?? '100');
@@ -114,6 +133,10 @@ export function createErasureRoutes(deps: {
       await retryErasure(deps.sql, {
         organizationId: c.get('orgId'),
         requestId: c.req.param('requestId'),
+        actor: {
+          userId: c.get('sessionBundle').user.id,
+          email: c.get('sessionBundle').user.email,
+        },
       });
       return c.json({ ok: true });
     } catch (error) {

--- a/services/platform/backend/domains/erasure/service.test.ts
+++ b/services/platform/backend/domains/erasure/service.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  ERASURE_REASON_CODES,
+  ERASURE_WATCHDOG_TIMEOUT_MESSAGE,
+} from '../../core/governance/erasure_constants';
+import { isValidErasureReasonCode } from './service';
+
+/**
+ * The reason-code vocabulary has exactly ONE source of truth —
+ * `core/governance/erasure_constants.ts`, the list the file-request
+ * picker, the i18n labels, and the docs speak. The service once carried a
+ * divergent local copy (`child_consent` instead of `child`), so the
+ * documented "child subject" ground could never be filed; these tests pin
+ * the live validator to the shared list. The full filing arc (including
+ * `child` over HTTP) runs in the integration check.
+ */
+
+describe('isValidErasureReasonCode', () => {
+  it('accepts every code the constants module (and the picker) offers', () => {
+    for (const code of ERASURE_REASON_CODES) {
+      expect(isValidErasureReasonCode(code)).toBe(true);
+    }
+  });
+
+  it("accepts the documented Art 17(1)(f) ground 'child'", () => {
+    expect(isValidErasureReasonCode('child')).toBe(true);
+  });
+
+  it("rejects the retired divergent copy's 'child_consent'", () => {
+    // Stored rows with the old code were folded into 'child' by migration
+    // 0062; the filing door speaks only the documented vocabulary.
+    expect(isValidErasureReasonCode('child_consent')).toBe(false);
+  });
+
+  it('rejects unknown codes', () => {
+    expect(isValidErasureReasonCode('')).toBe(false);
+    expect(isValidErasureReasonCode('gdpr')).toBe(false);
+  });
+});
+
+describe('ERASURE_WATCHDOG_TIMEOUT_MESSAGE', () => {
+  it('stays the exact persisted sentinel — stored receipts match on it', () => {
+    // The watchdog WRITES this string onto failed receipts and
+    // `retryErasure` refuses receipts carrying it. Changing the value
+    // orphans every already-written row (their retry guard silently stops
+    // matching), so a change requires a data migration — this pin makes
+    // that explicit.
+    expect(ERASURE_WATCHDOG_TIMEOUT_MESSAGE).toBe(
+      'Erasure timed out and was stopped by the watchdog. File a new request.',
+    );
+  });
+});

--- a/services/platform/backend/domains/erasure/service.ts
+++ b/services/platform/backend/domains/erasure/service.ts
@@ -1,9 +1,18 @@
 import type { Sql, TransactionSql } from 'postgres';
 
 import { isAdminRole } from '../../auth/membership.ts';
+import {
+  ERASURE_REASON_CODES,
+  ERASURE_WATCHDOG_TIMEOUT_MESSAGE,
+} from '../../core/governance/erasure_constants.ts';
+import { parseBlobRef } from '../../core/lib/storage/blob_ref.ts';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
-import { readGovernancePolicyForOrg } from '../../lib/org-config.ts';
+import { resolveObjectStore, s3DeleteObject } from '../../lib/object-store.ts';
+import {
+  readGovernancePolicyForOrg,
+  resolveOrgSlug,
+} from '../../lib/org-config.ts';
 import { checkOrganizationRateLimit } from '../../lib/rate-limit.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
@@ -48,21 +57,18 @@ export class ErasureError extends Error {
 }
 
 /**
- * The watchdog's verdict text. Load-bearing beyond the message: the retry
- * path refuses a receipt carrying it (see `retryErasureRequest`).
+ * Membership test over the closed reason-code list. The ONE list is
+ * `core/governance/erasure_constants.ts` — the file-request picker, the
+ * i18n labels, and the docs all speak it. (A divergent local copy here
+ * once carried `child_consent` while everything user-facing offered
+ * `child`, making the documented Art 17(1)(f) ground unfileable.)
  */
-export const ERASURE_WATCHDOG_TIMEOUT_MESSAGE =
-  'Erasure timed out and was stopped by the watchdog. File a new request.';
-
-export const ERASURE_REASON_CODES = [
-  'consent_withdrawn',
-  'no_longer_necessary',
-  'unlawful_processing',
-  'legal_obligation',
-  'objection',
-  'child_consent',
-  'contract_termination',
-] as const;
+export function isValidErasureReasonCode(code: string): boolean {
+  return ERASURE_REASON_CODES.includes(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- membership test over the closed list
+    code as (typeof ERASURE_REASON_CODES)[number],
+  );
+}
 
 async function dsarPolicy(sql: Sql | TransactionSql, organizationId: string) {
   const config = await readGovernancePolicyForOrg(
@@ -120,12 +126,7 @@ export async function requestErasure(
   if (!args.reason.trim()) {
     throw new ErasureError('validation', 'reason is required');
   }
-  if (
-    !ERASURE_REASON_CODES.includes(
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- membership test over the closed list
-      args.reasonCode as (typeof ERASURE_REASON_CODES)[number],
-    )
-  ) {
+  if (!isValidErasureReasonCode(args.reasonCode)) {
     throw new ErasureError('validation', 'unknown reason code');
   }
   // Self-deletion guard: erasure scrubs the actor's audit trail — a
@@ -363,7 +364,12 @@ export async function cancelErasure(
     );
   }
   const now = Date.now();
-  if (row.effectiveAt === null || row.effectiveAt <= now) {
+  // A NULL `effective_at_ms` on a pending row means the request is parked
+  // awaiting the second admin's approval (dual-approval mode): nothing is
+  // scheduled yet, so it is trivially cancellable — the docs promise "any
+  // Admin can cancel" before the cascade runs. Only a stamp in the PAST
+  // means the processor was already dispatched.
+  if (row.effectiveAt !== null && row.effectiveAt <= now) {
     throw new ErasureError(
       'cannotCancelAfterCooldown',
       'The cooling-off window has elapsed; the processor has already been dispatched. Use Retry on the resulting receipt instead.',
@@ -390,6 +396,27 @@ export async function cancelErasure(
         'The request left the cancellable window while cancelling.',
         409,
       );
+    }
+    // Dual-approval mode parks an approvals-inbox row per request; a
+    // cancelled receipt's approval must not stay decidable, so settle any
+    // still-pending row as rejected (an approve that raced ahead flipped
+    // it to 'executing' — this update then no-ops, which is fine: the
+    // receipt cancel above already prevailed and the processor no-ops on
+    // non-pending receipts).
+    const settledApprovals = await tx<{ id: string }[]>`
+      UPDATE app.approvals SET
+        status = 'rejected', approved_by = ${args.actorId},
+        reviewed_at_ms = ${now}
+      WHERE org_id = ${args.organizationId} AND resource_type = 'erasure'
+        AND resource_id = ${row.id} AND status = 'pending'
+      RETURNING id
+    `;
+    for (const approval of settledApprovals) {
+      await emitHintInTx(tx, {
+        orgId: args.organizationId,
+        entity: 'approval',
+        entityId: approval.id,
+      });
     }
     await createAuditLog(tx, {
       organizationId: args.organizationId,
@@ -419,7 +446,13 @@ export async function cancelErasure(
  * or wants a fresh pass). Re-checks the hold gate. */
 export async function retryErasure(
   sql: Sql,
-  args: { organizationId: string; requestId: string },
+  args: {
+    organizationId: string;
+    requestId: string;
+    /** The admin who clicked Retry — audited as the actor. Absent only
+     * for system-driven re-arms, which audit as `system`. */
+    actor?: { userId: string; email?: string };
+  },
 ): Promise<void> {
   const holds = await loadActiveHolds(sql, args.organizationId);
   const rows = await sql<{ targetUserId: string; error: string | null }[]>`
@@ -472,8 +505,11 @@ export async function retryErasure(
     });
     await createAuditLog(tx, {
       organizationId: args.organizationId,
-      actorId: 'system',
-      actorType: 'system',
+      actorId: args.actor?.userId ?? 'system',
+      ...(args.actor?.email !== undefined
+        ? { actorEmail: args.actor.email }
+        : {}),
+      actorType: args.actor !== undefined ? 'user' : 'system',
       action: 'gdpr_erasure_retried',
       category: 'admin',
       resourceType: 'user',
@@ -584,7 +620,6 @@ export async function processErasure(
       FROM app.documents
       WHERE org_id = ${organizationId} AND created_by = ${targetUserId}
     `;
-    const { resolveOrgSlug } = await import('../../lib/org-config.ts');
     const orgSlug = await resolveOrgSlug(sql, organizationId);
     for (const doc of docs) {
       await purgeDocument(sql, orgSlug, {
@@ -598,13 +633,44 @@ export async function processErasure(
   });
 
   await pass('uploads', async () => {
-    const removed = await sql<{ id: string }[]>`
-      DELETE FROM app.file_metadata
+    // Chat/task uploads — document-bound file rows ride the documents pass
+    // (`purgeDocument` deletes them with the document's own blobs).
+    const uploads = await sql<{ id: string; storageRef: string }[]>`
+      SELECT id, storage_ref AS "storageRef" FROM app.file_metadata
       WHERE org_id = ${organizationId} AND uploaded_by = ${targetUserId}
         AND document_id IS NULL
-      RETURNING id
     `;
-    return removed.length;
+    if (uploads.length === 0) return 0;
+    const orgSlug = await resolveOrgSlug(sql, organizationId);
+    if (orgSlug === null) {
+      // Rows exist but no slug resolves a store: fail the pass (receipt
+      // 'partial', rows kept, Retry re-attempts) instead of dropping the
+      // ledger rows while the subject's bytes live on in object storage.
+      throw new Error(
+        `no org slug for ${organizationId}; upload blobs not deletable`,
+      );
+    }
+    // STRICT blob-then-row — deliberately NOT the retention sweeps'
+    // best-effort idiom: an erasure receipt that says done must be TRUE,
+    // so a failed S3 delete throws and keeps the row for Retry. A 404 is
+    // success (already gone — `s3DeleteObject` treats it so); a legacy
+    // Convex ref has no reachable backend left, so only the row remains
+    // to delete. The store resolves lazily inside the s3 branch so a
+    // legacy-only batch never trips over an unconfigured store; upload
+    // keys are minted per object (`buildObjectKey`), and the ref-dedupe
+    // set guards a double-listed ref the way `purgeDocument` guards
+    // `historyFiles` against `fileRef`.
+    const deletedRefs = new Set<string>();
+    for (const upload of uploads) {
+      const parsed = parseBlobRef(upload.storageRef);
+      if (parsed.backend === 's3' && !deletedRefs.has(upload.storageRef)) {
+        const store = await resolveObjectStore(orgSlug);
+        await s3DeleteObject(store, parsed.key);
+        deletedRefs.add(upload.storageRef);
+      }
+      await sql`DELETE FROM app.file_metadata WHERE id = ${upload.id}`;
+    }
+    return uploads.length;
   });
 
   await pass('preferences', async () => {
@@ -1073,8 +1139,10 @@ export async function getErasureRequest(
  * the cooling-off window starts now and the processor is scheduled (the 0.4
  * `confirmAndScheduleErasure`). Filer ≠ approver is a HARD refusal here, not
  * just a UI gate — the approvals inbox enforces it above, this enforces it
- * again at the write. An already-scheduled or no-longer-pending row is a
- * no-op: approving twice is a double-submit, not an error.
+ * again at the write (the approver-must-be-an-admin half of the contract is
+ * `decideApproval`'s kind gate, which runs before this dispatch). An
+ * already-scheduled or no-longer-pending row is a no-op: approving twice is
+ * a double-submit, not an error.
  */
 export async function confirmAndScheduleErasure(
   tx: TransactionSql,
@@ -1149,6 +1217,81 @@ export async function confirmAndScheduleErasure(
     },
     subjectUserId: row.targetUserId,
     link: { kind: 'dsar' },
+  });
+}
+
+/**
+ * The dual-approval refusal hand-off: the second admin REJECTED the erasure
+ * row in the approvals inbox. Without this the receipt stayed `pending`
+ * with `effective_at_ms` NULL forever — unschedulable, and the live
+ * partial-unique index blocked ever re-filing the subject. A rejection
+ * lands the receipt in the terminal `cancelled` state (the existing status
+ * vocabulary; the live index covers only pending/running, so the subject
+ * becomes re-filable), attributed to the rejecting admin with a distinct
+ * `gdpr_erasure_rejected` audit action. An already-scheduled or settled
+ * row is a no-op: the decision FSM refuses a second decide anyway, and a
+ * cancel that raced ahead already settled the receipt.
+ */
+export async function rejectErasure(
+  tx: TransactionSql,
+  args: {
+    requestId: string;
+    rejectedBy: string;
+    organizationId: string;
+    comments?: string;
+  },
+): Promise<void> {
+  const rows = await tx<
+    {
+      id: string;
+      targetUserId: string;
+      status: string;
+      effectiveAt: number | null;
+    }[]
+  >`
+    SELECT id, target_user_id AS "targetUserId", status,
+           effective_at_ms::float8 AS "effectiveAt"
+    FROM app.gdpr_erasure_requests
+    WHERE id = ${args.requestId} AND org_id = ${args.organizationId}
+    FOR UPDATE
+  `;
+  const row = rows[0];
+  if (row === undefined) return;
+  if (row.status !== 'pending' || row.effectiveAt !== null) return;
+  const now = Date.now();
+  const trimmed = args.comments?.trim() ?? '';
+  await tx`
+    UPDATE app.gdpr_erasure_requests SET
+      status = 'cancelled', cancelled_by = ${args.rejectedBy},
+      cancellation_reason = ${
+        trimmed !== ''
+          ? `Dual approval rejected: ${trimmed}`
+          : 'Dual approval rejected.'
+      },
+      finished_at_ms = ${now}
+    WHERE id = ${row.id}
+  `;
+  await createAuditLog(tx, {
+    organizationId: args.organizationId,
+    actorId: args.rejectedBy,
+    actorType: 'user',
+    action: 'gdpr_erasure_rejected',
+    category: 'admin',
+    resourceType: 'user',
+    resourceId: row.targetUserId,
+    status: 'success',
+    previousState: { status: 'pending' },
+    newState: {
+      requestId: row.id,
+      status: 'cancelled',
+      rejectedBy: args.rejectedBy,
+      ...(trimmed !== '' ? { comments: trimmed } : {}),
+    },
+  });
+  await emitHintInTx(tx, {
+    orgId: args.organizationId,
+    entity: 'gdpr_erasure',
+    entityId: row.id,
   });
 }
 

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -21187,6 +21187,27 @@ async function checkErasure(
                               created_at_ms)
     VALUES (${orgId}, ${subject}, 'subject fact', 'approved', ${now})
   `;
+  // A chat upload with a REAL MinIO object behind it: the uploads pass must
+  // delete the blob, not just the ledger row — an erased receipt with the
+  // subject's bytes still in the bucket is a false statement to the DPO.
+  const objectStore = await import('./lib/object-store.ts');
+  const { encodeS3Ref: encodeUploadRef } =
+    await import('./core/lib/storage/blob_ref.ts');
+  const uploadStore = await objectStore.resolveObjectStore(orgSlug);
+  const uploadKey = objectStore.buildObjectKey(uploadStore, orgSlug);
+  await objectStore.s3PutObject(
+    uploadStore,
+    uploadKey,
+    new TextEncoder().encode('subject upload bytes'),
+    'text/plain',
+  );
+  await sql`
+    INSERT INTO app.file_metadata (
+      org_id, storage_ref, file_name, content_type, size, uploaded_by,
+      created_at_ms
+    ) VALUES (${orgId}, ${encodeUploadRef(uploadKey)}, 'subject-upload.txt',
+              'text/plain', 20, ${subject}, ${now})
+  `;
 
   const selfRefused = await post(`/api/app/erasure?orgId=${orgId}`, {
     targetUserId: userId,
@@ -21234,6 +21255,25 @@ async function checkErasure(
     WHERE org_id = ${orgId} AND resource_type = 'user'
       AND resource_id = ${subject} AND pii_scrubbed = true
   `;
+  const uploadRowsLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.file_metadata
+    WHERE org_id = ${orgId} AND uploaded_by = ${subject}
+  `;
+  const uploadBlobAfter = await objectStore.s3HeadObject(
+    uploadStore,
+    uploadKey,
+  );
+  const receiptCounts = await sql<{ counts: Record<string, number> | null }[]>`
+    SELECT counts FROM app.gdpr_erasure_requests WHERE id = ${requestId}
+  `;
+  record(
+    'erasure: the uploads pass deletes the blob behind the ledger row',
+    receiptStatus === 'done' &&
+      uploadRowsLeft[0]?.count === '0' &&
+      uploadBlobAfter === null &&
+      receiptCounts[0]?.counts?.uploads === 1,
+    `receipt=${receiptStatus} (want done), rowsLeft=${uploadRowsLeft[0]?.count} (want 0), blobHead=${uploadBlobAfter === null ? '404' : 'present'} (want 404), counts.uploads=${receiptCounts[0]?.counts?.uploads} (want 1)`,
+  );
 
   // Cancel lane: a fresh subject inside a real cooling window.
   await writeFile(
@@ -21334,6 +21374,206 @@ async function checkErasure(
       threeStatus === 'done',
     `self=${selfRefused.status} (want 403), receipt=${receiptStatus}, thread=${threadGone[0]?.count}, leftovers=${leftovers[0]?.count}, scrubbed=${scrubbed[0]?.count}, cancel=${cancelled.success ? cancelled.data.ok : 'ERR'}, twoIntact=${twoIntact[0]?.count}, blocked=${blockedRes.status}/${filedThree.success ? filedThree.data.error : 'ERR'}/${blockedReceipt[0]?.status ?? '?'} (want 409/LEGAL_HOLD_BLOCKS_ERASURE/blocked), retried=${threeStatus}`,
   );
+
+  // ---- the documented 'child' reason code files -------------------------
+  // The picker, the i18n labels, and the docs all offer 'child'
+  // (Art 17(1)(f)); the service once validated against a divergent local
+  // list carrying 'child_consent', so the documented ground dead-ended.
+  const subjectFour = await seedMember('four');
+  const childRes = await post(`/api/app/erasure?orgId=${orgId}`, {
+    targetUserId: subjectFour,
+    reason: 'Child subject probe',
+    reasonCode: 'child',
+  });
+  const childFiled = z
+    .object({ requestId: z.string() })
+    .loose()
+    .safeParse(await childRes.json().catch(() => ({})));
+  record(
+    "erasure: the documented 'child' reason code files",
+    childRes.status === 201 && childFiled.success,
+    `status=${childRes.status} (want 201), requestId=${childFiled.success ? 'minted' : 'ERR'}`,
+  );
+
+  // ---- the whole erasure router is admin-gated --------------------------
+  // Receipts name subjects, filers, and lawful grounds; the docs put every
+  // lifecycle action with Admins. A plain member must bounce off every
+  // door — list, file, cancel, retry, detail, extend — with the localized
+  // 'forbidden' code, not reach the service at all.
+  const erasureMemberSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: 'itest-erasure-member@example.com',
+      password: 'itest-password-1',
+      name: 'Erasure Member',
+    }),
+  });
+  const erasureMemberCookie = cookieHeaderFrom(erasureMemberSignUp);
+  const erasureMemberBody = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await erasureMemberSignUp.json());
+  const erasureMemberId = erasureMemberBody.success
+    ? erasureMemberBody.data.user.id
+    : '';
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (gen_random_uuid(), ${orgId}, ${erasureMemberId}, 'member',
+            ${new Date()})
+  `;
+  const memberSend = (
+    method: 'GET' | 'POST',
+    route: string,
+    body?: unknown,
+  ): Promise<Response> =>
+    fetch(`${base}${route}`, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        cookie: erasureMemberCookie,
+        origin: base,
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  const someReceiptId = filedTwo.success ? filedTwo.data.requestId : 'x';
+  const memberProbes = [
+    await memberSend('GET', `/api/app/erasure?orgId=${orgId}`),
+    await memberSend('POST', `/api/app/erasure?orgId=${orgId}`, {
+      targetUserId: subject,
+      reason: 'member probe',
+      reasonCode: 'objection',
+    }),
+    await memberSend(
+      'POST',
+      `/api/app/erasure/${someReceiptId}/cancel?orgId=${orgId}`,
+      { reason: 'member cancel probe' },
+    ),
+    await memberSend(
+      'POST',
+      `/api/app/erasure/${someReceiptId}/retry?orgId=${orgId}`,
+    ),
+    await memberSend('GET', `/api/app/erasure/${someReceiptId}?orgId=${orgId}`),
+    await memberSend(
+      'POST',
+      `/api/app/erasure/${someReceiptId}/extend?orgId=${orgId}`,
+      { extraDays: 10, extensionReason: 'member extend probe' },
+    ),
+  ];
+  const memberBodies = await Promise.all(
+    memberProbes.map(async (res) =>
+      z
+        .object({ error: z.string() })
+        .loose()
+        .safeParse(await res.json().catch(() => ({}))),
+    ),
+  );
+  record(
+    'erasure: every lifecycle door refuses a plain member (403 forbidden)',
+    memberProbes.every((res) => res.status === 403) &&
+      memberBodies.every(
+        (body) => body.success && body.data.error === 'forbidden',
+      ),
+    `statuses=${memberProbes.map((res) => res.status).join(',')} (want all 403), codes=${memberBodies.map((body) => (body.success ? body.data.error : 'ERR')).join(',')} (want all forbidden)`,
+  );
+
+  // ---- a failed blob delete keeps the receipt honest --------------------
+  // An org-BYO connection.json WITHOUT its secrets sidecar makes store
+  // resolution throw (fail closed), standing in for an unreachable bucket:
+  // the uploads pass must FAIL the receipt ('partial') and keep the ledger
+  // row, never report erased while the bytes may live on. Removing the
+  // broken config and retrying finishes the job for real.
+  const subjectFive = await seedMember('five');
+  const fiveKey = objectStore.buildObjectKey(uploadStore, orgSlug);
+  await objectStore.s3PutObject(
+    uploadStore,
+    fiveKey,
+    new TextEncoder().encode('subject five bytes'),
+    'text/plain',
+  );
+  await sql`
+    INSERT INTO app.file_metadata (
+      org_id, storage_ref, file_name, content_type, size, uploaded_by,
+      created_at_ms
+    ) VALUES (${orgId}, ${encodeUploadRef(fiveKey)}, 'five-upload.txt',
+              'text/plain', 18, ${subjectFive}, ${Date.now()})
+  `;
+  const fiveReceipt = await sql<{ id: string }[]>`
+    INSERT INTO app.gdpr_erasure_requests (
+      org_id, target_user_id, reason, reason_code, requested_by,
+      requested_at_ms, sla_deadline_at_ms, status, effective_at_ms,
+      threads_targeted
+    ) VALUES (
+      ${orgId}, ${subjectFive}, 'honest failure probe', 'objection',
+      ${userId}, ${Date.now()}, ${Date.now() + 30 * 86_400_000}, 'pending',
+      ${Date.now()}, ARRAY[]::text[]
+    ) RETURNING id
+  `;
+  const fiveId = fiveReceipt[0]?.id ?? '';
+  const orgStorageDir = path.join(configRoot, orgSlug, 'object-storage');
+  await mkdir(orgStorageDir, { recursive: true });
+  const brokenConnectionPath = path.join(orgStorageDir, 'connection.json');
+  await writeFile(
+    brokenConnectionPath,
+    await readFile(
+      path.join(configRoot, 'default', 'object-storage', 'connection.json'),
+      'utf8',
+    ),
+  );
+  objectStore.clearObjectStoreCache();
+  orgConfig.clearOrgConfigCaches();
+  const erasureService = await import('./domains/erasure/service.ts');
+  await erasureService.processErasure(sql, fiveId);
+  const fiveAfterFail = await sql<{ status: string; error: string | null }[]>`
+    SELECT status, error FROM app.gdpr_erasure_requests WHERE id = ${fiveId}
+  `;
+  const fiveRowSurvives = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.file_metadata
+    WHERE org_id = ${orgId} AND uploaded_by = ${subjectFive}
+  `;
+  const fiveBlobSurvives = await objectStore.s3HeadObject(uploadStore, fiveKey);
+  // Heal the store and retry through the route — the receipt must finish
+  // for real this time, blob included.
+  await rm(brokenConnectionPath, { force: true });
+  objectStore.clearObjectStoreCache();
+  orgConfig.clearOrgConfigCaches();
+  await post(`/api/app/erasure/${fiveId}/retry?orgId=${orgId}`);
+  let fiveStatus = '';
+  for (let i = 0; i < 50; i++) {
+    const rows = await sql<{ status: string }[]>`
+      SELECT status FROM app.gdpr_erasure_requests WHERE id = ${fiveId}
+    `;
+    fiveStatus = rows[0]?.status ?? '';
+    if (fiveStatus === 'done') break;
+    await sleep(300);
+  }
+  const fiveRowAfterRetry = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.file_metadata
+    WHERE org_id = ${orgId} AND uploaded_by = ${subjectFive}
+  `;
+  const fiveBlobAfterRetry = await objectStore.s3HeadObject(
+    uploadStore,
+    fiveKey,
+  );
+  record(
+    'erasure: a failed blob delete lands partial + row kept, retry finishes',
+    fiveAfterFail[0]?.status === 'partial' &&
+      (fiveAfterFail[0]?.error ?? '').includes('uploads') &&
+      fiveRowSurvives[0]?.count === '1' &&
+      fiveBlobSurvives !== null &&
+      fiveStatus === 'done' &&
+      fiveRowAfterRetry[0]?.count === '0' &&
+      fiveBlobAfterRetry === null,
+    `afterFail=${fiveAfterFail[0]?.status}/${fiveAfterFail[0]?.error ?? ''} (want partial/failed passes: uploads), row=${fiveRowSurvives[0]?.count} (want 1), blob=${fiveBlobSurvives === null ? '404' : 'present'} (want present), retry=${fiveStatus} (want done), rowAfter=${fiveRowAfterRetry[0]?.count} (want 0), blobAfter=${fiveBlobAfterRetry === null ? '404' : 'present'} (want 404)`,
+  );
+
+  // This section spent 4 of the admin's 5/day DSAR filings; the limiter is
+  // per (key, subject), so clearing its rows hands downstream sections the
+  // full budget their probes assume.
+  await sql`
+    DELETE FROM app.rate_limits
+    WHERE name = 'governance:dsar_request' AND key LIKE ${`org:${orgId}:%`}
+  `;
 }
 
 /**
@@ -24644,6 +24884,66 @@ async function checkGovernanceEnforcement(
     SELECT status FROM app.approvals WHERE id = ${approvalId}
   `;
 
+  // A plain MEMBER can decide neither direction of an erasure approval —
+  // dual control means two admins, so the generic decide door kind-gates
+  // erasure rows on the session-resolved role.
+  const dsarMemberSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: 'itest-dsar-member@example.com',
+      password: 'itest-password-1',
+      name: 'DSAR Member',
+    }),
+  });
+  const dsarMemberCookie = cookieHeaderFrom(dsarMemberSignUp);
+  const dsarMemberBody = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await dsarMemberSignUp.json());
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (gen_random_uuid(), ${orgId},
+            ${dsarMemberBody.success ? dsarMemberBody.data.user.id : ''},
+            'member', ${new Date()})
+  `;
+  const memberDecide = async (
+    status: 'executing' | 'rejected',
+  ): Promise<Response> =>
+    fetch(`${base}/api/app/approvals/${approvalId}/decide?orgId=${orgId}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        cookie: dsarMemberCookie,
+        origin: base,
+      },
+      body: JSON.stringify({ status }),
+    });
+  const memberApprove = await memberDecide('executing');
+  const memberReject = await memberDecide('rejected');
+  const memberApproveBody = z
+    .object({ error: z.string() })
+    .loose()
+    .safeParse(await memberApprove.json().catch(() => ({})));
+  const memberRejectBody = z
+    .object({ error: z.string() })
+    .loose()
+    .safeParse(await memberReject.json().catch(() => ({})));
+  const stillPendingAfterMember = await sql<{ status: string }[]>`
+    SELECT status FROM app.approvals WHERE id = ${approvalId}
+  `;
+  record(
+    'governance: a plain member can decide an erasure approval in neither direction',
+    memberApprove.status === 403 &&
+      memberApproveBody.success &&
+      memberApproveBody.data.error === 'FORBIDDEN' &&
+      memberReject.status === 403 &&
+      memberRejectBody.success &&
+      memberRejectBody.data.error === 'FORBIDDEN' &&
+      stillPendingAfterMember[0]?.status === 'pending',
+    `approve=${memberApprove.status}/${memberApproveBody.success ? memberApproveBody.data.error : 'ERR'} (want 403/FORBIDDEN), reject=${memberReject.status}/${memberRejectBody.success ? memberRejectBody.data.error : 'ERR'} (want 403/FORBIDDEN), row=${stillPendingAfterMember[0]?.status} (want pending)`,
+  );
+
   // A SECOND admin approves: cooling-off starts and the processor is queued.
   const otherAdmin = 'dual-approver-one';
   await sql`
@@ -24670,7 +24970,11 @@ async function checkGovernanceEnforcement(
       organizationId: orgId,
       approvalId,
       status: 'executing',
-      actor: { userId: otherAdmin, email: `${otherAdmin}@example.com` },
+      actor: {
+        userId: otherAdmin,
+        role: 'admin',
+        email: `${otherAdmin}@example.com`,
+      },
     });
     secondApproveOk = true;
   } catch (error) {
@@ -24703,6 +25007,136 @@ async function checkGovernanceEnforcement(
       jobsAfter[0]?.count === '1',
     `filed=${filed.success}(${filedRes.status}:${JSON.stringify(filedBody).slice(0, 120)}), parked=${parked[0]?.status}/${parked[0]?.effectiveAt === null}, approvalRow=${approvalRows.length}, jobsBefore=${jobsBefore[0]?.count}, bell=${bell[0]?.count}, selfApprove=${selfApprove.status}/${selfApproveBody.success ? selfApproveBody.data.error : 'ERR'}, rolledBack=${stillPending[0]?.status}, second=${secondApproveOk}, scheduled=${scheduled[0]?.effectiveAt !== null}, jobsAfter=${jobsAfter[0]?.count}`,
   );
+
+  // ---- a REJECTED dual approval settles the receipt, not the subject ----
+  // Rejecting used to update only the approvals row: the receipt sat
+  // 'pending' with effective_at_ms NULL forever, and the live-unique index
+  // blocked ever re-filing the subject. Now the rejection lands the
+  // receipt as 'cancelled' (audited as gdpr_erasure_rejected) and the
+  // subject is immediately re-filable.
+  const subjectTwoId = 'dual-subject-two';
+  await sql`
+    INSERT INTO "user" ("id", "name", "email", "emailVerified", "createdAt",
+                        "updatedAt")
+    VALUES (${subjectTwoId}, 'Dual Subject Two',
+            ${`${subjectTwoId}@example.com`}, true, ${new Date()},
+            ${new Date()})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${`m-${subjectTwoId}`}, ${orgId}, ${subjectTwoId}, 'member',
+            ${new Date()})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+  const filedTwoRes = await post(`/api/app/erasure?orgId=${orgId}`, {
+    targetUserId: subjectTwoId,
+    reason: 'reject arc probe',
+    reasonCode: 'consent_withdrawn',
+  });
+  const filedTwoBody = z
+    .object({ requestId: z.string() })
+    .loose()
+    .safeParse(await filedTwoRes.json().catch(() => ({})));
+  const requestTwoId = filedTwoBody.success ? filedTwoBody.data.requestId : '';
+  const approvalTwoRows = await sql<{ id: string }[]>`
+    SELECT id FROM app.approvals
+    WHERE org_id = ${orgId} AND resource_type = 'erasure'
+      AND resource_id = ${requestTwoId}
+  `;
+  let rejectOk = false;
+  try {
+    await approvals.decideApproval(sql, {
+      organizationId: orgId,
+      approvalId: approvalTwoRows[0]?.id ?? '',
+      status: 'rejected',
+      comments: 'wrong subject picked',
+      actor: {
+        userId: otherAdmin,
+        role: 'admin',
+        email: `${otherAdmin}@example.com`,
+      },
+    });
+    rejectOk = true;
+  } catch (error) {
+    console.error('[itest] second-admin rejection failed', error);
+  }
+  const rejectedReceipt = await sql<
+    {
+      status: string;
+      cancelledBy: string | null;
+      cancellationReason: string | null;
+      finishedAt: number | null;
+    }[]
+  >`
+    SELECT status, cancelled_by AS "cancelledBy",
+           cancellation_reason AS "cancellationReason",
+           finished_at_ms::float8 AS "finishedAt"
+    FROM app.gdpr_erasure_requests WHERE id = ${requestTwoId}
+  `;
+  const rejectedAudit = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.audit_logs
+    WHERE org_id = ${orgId} AND action = 'gdpr_erasure_rejected'
+      AND resource_id = ${subjectTwoId}
+  `;
+  const rejectedJobs = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM pgboss.job
+    WHERE name = 'governance.process_erasure'
+      AND data->>'requestId' = ${requestTwoId}
+  `;
+  // The subject is re-filable NOW — the live-unique index no longer holds
+  // a pending row for them.
+  const refiledRes = await post(`/api/app/erasure?orgId=${orgId}`, {
+    targetUserId: subjectTwoId,
+    reason: 'fresh request after rejection',
+    reasonCode: 'consent_withdrawn',
+  });
+  const refiledBody = z
+    .object({ requestId: z.string() })
+    .loose()
+    .safeParse(await refiledRes.json().catch(() => ({})));
+  record(
+    'governance: DSAR rejection lands the receipt cancelled + re-filable',
+    rejectOk &&
+      rejectedReceipt[0]?.status === 'cancelled' &&
+      rejectedReceipt[0]?.cancelledBy === otherAdmin &&
+      (rejectedReceipt[0]?.cancellationReason ?? '').startsWith(
+        'Dual approval rejected',
+      ) &&
+      rejectedReceipt[0]?.finishedAt !== null &&
+      Number(rejectedAudit[0]?.count ?? '0') >= 1 &&
+      rejectedJobs[0]?.count === '0' &&
+      refiledRes.status === 201 &&
+      refiledBody.success,
+    `reject=${rejectOk}, receipt=${rejectedReceipt[0]?.status}/${rejectedReceipt[0]?.cancelledBy}/${(rejectedReceipt[0]?.cancellationReason ?? '').slice(0, 40)} (want cancelled/${otherAdmin}/Dual approval rejected…), audit=${rejectedAudit[0]?.count} (want ≥1), jobs=${rejectedJobs[0]?.count} (want 0), refile=${refiledRes.status}/${refiledBody.success} (want 201/true)`,
+  );
+
+  // ---- cancelling while parked awaiting approval also un-wedges ---------
+  // The refiled request above is parked (effective_at_ms NULL). Cancelling
+  // in that state used to throw the lying 'cannotCancelAfterCooldown';
+  // now it cancels the receipt AND settles the parked approvals row.
+  const refiledId = refiledBody.success ? refiledBody.data.requestId : '';
+  const cancelParkedRes = await post(
+    `/api/app/erasure/${refiledId}/cancel?orgId=${orgId}`,
+    { reason: 'withdrawn while awaiting approval' },
+  );
+  const cancelParkedReceipt = await sql<{ status: string }[]>`
+    SELECT status FROM app.gdpr_erasure_requests WHERE id = ${refiledId}
+  `;
+  const cancelParkedApproval = await sql<{ status: string }[]>`
+    SELECT status FROM app.approvals
+    WHERE org_id = ${orgId} AND resource_type = 'erasure'
+      AND resource_id = ${refiledId}
+  `;
+  record(
+    'governance: cancelling a parked dual-approval request settles both rows',
+    cancelParkedRes.status === 200 &&
+      cancelParkedReceipt[0]?.status === 'cancelled' &&
+      cancelParkedApproval[0]?.status === 'rejected',
+    `cancel=${cancelParkedRes.status} (want 200), receipt=${cancelParkedReceipt[0]?.status} (want cancelled), approval=${cancelParkedApproval[0]?.status} (want rejected)`,
+  );
+
   await writeFile(
     path.join(governanceDir, 'dsar-governance.yml'),
     'coolingOffHours: 0\n',

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -3849,6 +3849,7 @@ governance:
       gdpr_erasure_cascade_attempts_exhausted: Kaskaden-Versuche erschöpft
       gdpr_erasure_extended: Frist verlängert
       gdpr_erasure_retried: Wiederholt
+      gdpr_erasure_rejected: Zurückgewiesen
       gdpr_erasure_cancelled: Abgebrochen
     categories:
       userMemories: Persönliche Memos
@@ -5239,8 +5240,7 @@ settings:
       clientSecretLabel: Client-Secret
       clientSecretKeep: Leer lassen, um das aktuelle Secret beizubehalten.
       tenantIdLabel: Verzeichnis-ID (Tenant)
-      tenantIdHint:
-        Nötig für Single-Tenant-Registrierungen bei Microsoft; bei
+      tenantIdHint: Nötig für Single-Tenant-Registrierungen bei Microsoft; bei
         Multi-Tenant-Apps leer lassen.
       redirectUrisLabel: Zu registrierende Redirect-URIs
       redirectUrisHint:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -3716,6 +3716,7 @@ governance:
       gdpr_erasure_cascade_attempts_exhausted: Cascade attempts exhausted
       gdpr_erasure_extended: Deadline extended
       gdpr_erasure_retried: Retried
+      gdpr_erasure_rejected: Rejected
       gdpr_erasure_cancelled: Cancelled
     categories:
       userMemories: Personal memories
@@ -5366,8 +5367,7 @@ settings:
         Required for single-tenant Microsoft app registrations; leave blank
         for multi-tenant ones.
       redirectUrisLabel: Redirect URIs to register
-      redirectUrisHint:
-        Add each of these to the vendor app registration before connecting.
+      redirectUrisHint: Add each of these to the vendor app registration before connecting.
       reuseSso: Use Entra ID SSO app
       reuseSsoTitle: Reuse the Entra ID SSO app registration
       reuseSsoBody:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -3932,6 +3932,7 @@ governance:
       gdpr_erasure_cascade_attempts_exhausted: Tentatives de cascade épuisées
       gdpr_erasure_extended: Échéance prolongée
       gdpr_erasure_retried: Réessayée
+      gdpr_erasure_rejected: Rejetée
       gdpr_erasure_cancelled: Annulée
     categories:
       userMemories: Mémoires personnelles


### PR DESCRIPTION
The DSR docs promise a specific governance contract — the whole erasure lifecycle is run by org admins, dual approval means a second admin (distinct from the filer) decides, a rejected or cancelled request leaves the subject re-filable, every documented reason code files, and a receipt that says erased is true down to the bytes in object storage. The code enforced almost none of that: the only role check sat on filing. This PR makes the code match the promise, kind-scoped so the generic approvals door keeps its org-member posture for every non-erasure kind (`connector_operation`, `human_input_request`, `conversations`; review kinds already refuse toward their dedicated doors).

## Findings

**1. Any org member could approve or reject a dual-approval erasure — fixed.**
`decideApproval` now carries the caller's session-resolved role (`orgMember.role`, trusted-headers aware) and kind-gates erasure rows via `assertRoleMayDecideKind`: both deciding directions demand an org admin (403 `FORBIDDEN`). Filer ≠ approver stays hard-enforced in `confirmAndScheduleErasure`. Regression: unit tests on the pure gate (`backend/domains/approvals/service.test.ts`) + integration check "a plain member can decide an erasure approval in neither direction" (member approve AND reject → 403, row stays pending; base run: member approve returned 200 and scheduled the cascade).

**2. Cancel/retry/extend/list lacked the admin gate the routes header claimed — fixed.**
The erasure router now has a router-level admin gate over every operation (list, file, detail, cancel, retry, extend) on the session-resolved role — reads included, since receipts enumerate subjects and lawful grounds. The header comment now describes what is actually enforced; filing keeps its in-service audited deny as defense in depth. `retryErasure` also gained the acting admin for honest audit attribution (was hardcoded `system`). Regression: integration check "every lifecycle door refuses a plain member" (six doors × 403 `forbidden`; base run: member list returned 200).

**3. A rejected dual approval wedged the subject forever — fixed.**
Rejection used to update only the approvals row; the receipt sat `pending` with `effective_at_ms` NULL — unschedulable, uncancellable (`cannotCancelAfterCooldown` was a lie in that state), and the live-unique index blocked re-filing. Now `decideApproval(status: 'rejected')` dispatches `rejectErasure` in the same transaction: the receipt lands terminal `cancelled` (the existing status vocabulary; the live index covers only pending/running, so the subject is immediately re-filable), attributed to the rejecting admin, audited as `gdpr_erasure_rejected` (new i18n label in en/de/fr; de-CH carries no override for this block). Cancelling while parked awaiting approval now also works and settles the linked approvals row. UI needs no new state: the existing `cancelled` badge + drawer fields render it. Regression: integration checks "DSAR rejection lands the receipt cancelled + re-filable" and "cancelling a parked dual-approval request settles both rows" (base run: receipt stayed pending and the re-file bounced 409 `ALREADY_PENDING` — the wedge, demonstrated).

**4. The documented `child` reason code could never be filed — fixed.**
The service carried a divergent local copy of `ERASURE_REASON_CODES` with `child_consent`, while the picker, the i18n labels, and the docs all offer `child`. The service now validates against the one constants module (`core/governance/erasure_constants.ts`) via `isValidErasureReasonCode`; migration `0062` folds any stored `child_consent` rows into `child` (idempotent, rolling-safe — reads never validate stored codes). The constants' divergent, unimported `ERASURE_WATCHDOG_TIMEOUT_MESSAGE` copy is unified the same way: the canonical value is the string persisted on receipts today (the retry guard matches on it), pinned by a unit test. Regression: unit tests + integration check "the documented 'child' reason code files" (base run: 400 `unknown reason code`). Note: migration is hand-numbered 0062 — 0059-0061 are taken by sibling branches; the boot runner applies by filename order with no contiguity requirement.

**5. The uploads pass orphaned the subject's blobs in object storage — fixed.**
The pass deleted `app.file_metadata` rows (`document_id IS NULL`) without deleting the S3 objects behind `storage_ref` — after a "done" receipt the subject's bytes lived on. It now deletes blob-then-row per upload with the strict `s3DeleteObject` (404 = already gone = success; legacy Convex refs have no reachable backend, row-only), deliberately NOT the retention sweeps' best-effort idiom: a failed blob delete throws, the pass fails, the receipt lands `partial` with `failed passes: uploads`, the rows stay, and Retry re-attempts. Shared-ref question checked: upload keys are minted per object (`buildObjectKey` → `<org>/<uuid>`), no dedup-reuse in any write path; an in-batch ref-dedupe set guards double-listed refs the way `purgeDocument` guards `historyFiles`. Regression: integration checks "the uploads pass deletes the blob behind the ledger row" (MinIO-backed: blob HEAD 404 after cascade, `counts.uploads` on the receipt) and "a failed blob delete lands partial + row kept, retry finishes" (store resolution broken via an org BYO `connection.json` without its secrets sidecar, then healed; base run: receipt claimed done while the blob survived).

## Verification

- Unit: `bunx vitest --run --project server --project pii` — 374 files / 72,285 tests green (includes the two new colocated suites and the i18n parity checks over the message catalogs).
- `bunx tsc --noEmit` and `bunx oxlint --type-aware` on `services/platform` — clean.
- `packages/ui` i18n suite (voice/terminology over messages + docs): 124 files / 1,173 tests green. `services/docs` structural tests: 30 files / 194 tests green.
- `backend:integration` on a throwaway tale-db + MinIO: **286/286 green** on this branch (observed; the sibling-branch baseline on this box was also 286).
- Red proof: with the five backend source files stashed (probes kept), the suite fails exactly the new checks — see the per-finding base-run notes above. The two vitest suites are structurally red on main (the gate helpers don't exist there).

## Docs

`docs/{en,de,fr}/platform/admin/governance/data-subject-requests.md`: the Awaiting-approval row documents rejection, the Cancelled row covers both cancel windows + rejection + re-filability, and the audit chain gains `gdpr_erasure_rejected`.

## Refuted / notes

- None of the five findings refuted — all reproduced in code and in the base run.
- The approvals door stays org-member for every non-erasure kind on purpose (the 0.4 posture the routes header documents); the gate is kind-scoped to avoid locking down connector/human-input/conversation decisions.

## Cross-class discoveries (not fixed here)

- Docs + i18n cascade categories promise **workflow executions** and **personal prompt templates** erased; the 0.5 cascade has no `wf_executions` / prompt-templates passes (`rg wf_execution|prompt` over `domains/erasure/service.ts` and `domains/retention/service.ts` is empty). Docs-vs-code gap of the same honesty class, but new cascade surface — flagging instead of piggybacking.
- The retention sweeps' `deleteBlobBestEffort` swallows blob-delete failures by design; their counts can include undeleted blobs. Pre-existing posture — the erasure pass is now stricter than its siblings.
- `requestErasure` (and legal-holds) role checks read the `member` table directly; under `TRUSTED_HEADERS_ENABLED` the placeholder row role could deny a proxy-role admin at the service layer. The new router gate uses the session-resolved role, so the erasure lifecycle is correct for trusted-headers admins up to filing's in-service re-check (pre-existing behavior, unchanged).
