### PR TITLE
fix(platform): enforce the document write matrix and record freeze

### DIFF
--- a/services/platform/backend/domains/documents/agent-write.ts
+++ b/services/platform/backend/domains/documents/agent-write.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { Sql, TransactionSql } from 'postgres';
 
 import { extractExtension } from '../../../lib/shared/file-types.ts';
@@ -5,7 +7,10 @@ import { addJobInTx } from '../../jobs/enqueue.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
 import { putOrgBlobBytes, registerUploadedBytes } from '../files/service.ts';
 import { markRagQueued } from '../knowledge/service.ts';
-import { DocumentError } from './service.ts';
+import {
+  assertGenericDocumentContentWritableJson,
+  DocumentError,
+} from './service.ts';
 
 /**
  * The `document_create` workspace tool's lower half — an AGENT writing an
@@ -33,6 +38,7 @@ export async function storeAgentTextBlob(
   },
 ): Promise<{ storageRef: string; fileId: string; size: number }> {
   const bytes = new TextEncoder().encode(args.content);
+  const contentHash = createHash('sha256').update(bytes).digest('hex');
   // The blob first: a failed store must never leave a document row pointing
   // at nothing (the project-text lane's rule, for the same reason).
   const storageRef = await putOrgBlobBytes(sql, args.organizationId, {
@@ -48,6 +54,14 @@ export async function storeAgentTextBlob(
     source: 'agent',
     ...(args.uploadedBy !== undefined ? { uploadedBy: args.uploadedBy } : {}),
   });
+  // Stamp the ledger row so the document upsert can keep `content_hash`
+  // coherent with the bytes `file_ref` actually serves (the knowledge-entry
+  // lane's sha256-hex convention).
+  await sql`
+    UPDATE app.file_metadata
+    SET content_hash = ${contentHash}, sha256 = ${contentHash}
+    WHERE id = ${fileId} AND org_id = ${args.organizationId}
+  `;
   return { storageRef, fileId, size: bytes.byteLength };
 }
 
@@ -73,7 +87,9 @@ export interface UpsertAgentDocumentArgs {
 /**
  * Create or refresh the agent's document, keyed by `(org, externalItemId)`.
  * The lookup deliberately ignores lifecycle: a trashed row with the same key
- * is refreshed in place rather than resurrected as a duplicate.
+ * is refreshed in place rather than resurrected as a duplicate. A row that
+ * became a controlled record refuses the refresh (content freeze) — the
+ * record lifecycle owns those bytes.
  */
 export async function upsertAgentDocument(
   sql: Sql,
@@ -86,8 +102,19 @@ export async function upsertAgentDocument(
   const extension = args.extension ?? extractExtension(title);
   return sql.begin(async (tx) => {
     const now = Date.now();
-    const existing = await tx<{ id: string }[]>`
-      SELECT id FROM app.documents
+    // `content_hash` mirrors the bytes `file_ref` serves — resolved from the
+    // blob's ledger row (`storeAgentTextBlob` stamps it) so a refreshed
+    // document never keeps the previous blob's hash.
+    const ledger = await tx<{ contentHash: string | null }[]>`
+      SELECT content_hash AS "contentHash" FROM app.file_metadata
+      WHERE org_id = ${args.organizationId} AND storage_ref = ${args.fileRef}
+      LIMIT 1
+    `;
+    const contentHash = ledger[0]?.contentHash ?? null;
+    const existing = await tx<
+      { id: string; record: Record<string, unknown> | null }[]
+    >`
+      SELECT id, record FROM app.documents
       WHERE org_id = ${args.organizationId}
         AND external_item_id = ${args.externalItemId}
       ORDER BY created_at_ms
@@ -96,10 +123,16 @@ export async function upsertAgentDocument(
     `;
     const documentId = existing[0]?.id;
     if (documentId !== undefined) {
+      // 'agent' documents can be controlled records (records.ts): a re-run
+      // is a generic content writer, so the SAME freeze rule every human
+      // content path applies holds here — a controlled record's bytes move
+      // only through the attested replacement flow.
+      assertGenericDocumentContentWritableJson(existing[0]?.record ?? null);
       await tx`
         UPDATE app.documents SET
           title = ${title}, file_ref = ${args.fileRef},
           mime_type = ${args.mimeType}, extension = ${extension ?? null},
+          content_hash = ${contentHash},
           project_id = ${args.projectId ?? null},
           lifecycle_status = 'active', updated_at_ms = ${now}
         WHERE id = ${documentId}
@@ -110,12 +143,13 @@ export async function upsertAgentDocument(
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.documents (
         org_id, title, file_ref, mime_type, extension, source_provider,
-        external_item_id, project_id, created_by, created_at_ms, updated_at_ms
+        external_item_id, content_hash, project_id, created_by,
+        created_at_ms, updated_at_ms
       ) VALUES (
         ${args.organizationId}, ${title}, ${args.fileRef}, ${args.mimeType},
         ${extension ?? null}, ${args.sourceProvider ?? 'agent'},
-        ${args.externalItemId}, ${args.projectId ?? null}, ${args.createdBy},
-        ${now}, ${now}
+        ${args.externalItemId}, ${contentHash}, ${args.projectId ?? null},
+        ${args.createdBy}, ${now}, ${now}
       )
       RETURNING id
     `;

--- a/services/platform/backend/domains/documents/records.ts
+++ b/services/platform/backend/domains/documents/records.ts
@@ -1,5 +1,6 @@
 import type { Sql, TransactionSql } from 'postgres';
 
+import { authorizeRls } from '../../auth/access.ts';
 import { checkProjectAccess } from '../../core/projects/access.ts';
 import { toJson } from '../../db/sql.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
@@ -10,6 +11,7 @@ import {
   type ProjectAuthContext,
 } from '../projects/service.ts';
 import {
+  assertDocumentsWriteRole,
   assertDocumentVisible,
   DocumentError,
   hasKnowledgeHubDocumentAccess,
@@ -143,13 +145,14 @@ function requireControlledRecord(doc: DocumentRow): ControlledRecord {
   return record;
 }
 
-/** The document-write standard (public updateDocument): visible + project
- * canEdit for project files. */
+/** The document-write standard (public updateDocument): org-role write
+ * matrix, visible, + project canEdit for project files. */
 async function requireDocumentWriteAccess(
   db: Sql | TransactionSql,
   auth: ProjectAuthContext,
   documentId: string,
 ): Promise<DocumentRow> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(db, documentId);
   await assertDocumentVisible(db, auth, doc);
   if (doc.projectId !== null) {
@@ -247,8 +250,10 @@ async function userTeamIds(
 /**
  * Whether `userId` could RESPOND to a review on this document — the single
  * rule behind the submit designee gate AND the reviewer picker: a
- * non-disabled member who can see the document (team scope), with edit
- * access to the owning project for project files.
+ * write-capable role (responding transitions the record, and
+ * `respondToDocumentRecordReview` enforces the same matrix — a designee who
+ * could never respond would strand the review) who can see the document
+ * (team scope), with edit access to the owning project for project files.
  */
 export async function isEligibleDocumentReviewer(
   db: Sql | TransactionSql,
@@ -256,7 +261,7 @@ export async function isEligibleDocumentReviewer(
   userId: string,
 ): Promise<boolean> {
   const role = await memberRole(db, doc.organizationId, userId);
-  if (role === null || role.toLowerCase() === 'disabled') return false;
+  if (role === null || !authorizeRls(role, 'documents', 'write')) return false;
   const teamIds = await userTeamIds(db, userId);
   if (doc.projectId !== null) {
     const project = await loadProjectOrThrow(db, doc.projectId);

--- a/services/platform/backend/domains/documents/replacement.ts
+++ b/services/platform/backend/domains/documents/replacement.ts
@@ -40,6 +40,7 @@ import {
   type ControlledRecord,
 } from './records.ts';
 import {
+  assertDocumentsWriteRole,
   assertDocumentVisible,
   DocumentError,
   loadDocumentOrThrow,
@@ -144,13 +145,15 @@ async function requireIntentForPrincipal(
   return intent;
 }
 
-/** The write standard shared with records.ts (project canEdit), plus the
- * controlled + active gates every replacement step re-checks. */
+/** The write standard shared with records.ts (org write matrix + project
+ * canEdit), plus the controlled + active gates every replacement step
+ * re-checks. */
 async function requireReplacementDocument(
   db: Sql | TransactionSql,
   auth: ProjectAuthContext,
   documentId: string,
 ): Promise<{ doc: DocumentRow; record: ControlledRecord }> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(db, documentId);
   await assertDocumentVisible(db, auth, doc);
   if (doc.projectId !== null) {

--- a/services/platform/backend/domains/documents/service.ts
+++ b/services/platform/backend/domains/documents/service.ts
@@ -6,6 +6,7 @@ import {
   isAllowedDocumentUpload,
   resolveFileType,
 } from '../../../lib/shared/file-types.ts';
+import { authorizeRls } from '../../auth/access.ts';
 import { hasTeamAccess } from '../../core/lib/team_access.ts';
 import { checkProjectAccess } from '../../core/projects/access.ts';
 import { toJson } from '../../db/sql.ts';
@@ -181,6 +182,75 @@ export async function assertDocumentVisible(
   }
 }
 
+/**
+ * The org-role write gate every document mutation consults (the
+ * products/contacts idiom): `documents: write` in the role matrix — owner,
+ * admin, developer and editor pass; the read-only `member` and `disabled`
+ * roles refuse. This is the org-wide floor; project lanes ADD their
+ * project-`canEdit` check on top, and team scoping stays a separate
+ * visibility question. Agent standing-grant writes (`agent-write.ts`) are
+ * authorized by their dispatch, not this matrix.
+ */
+export function assertDocumentsWriteRole(
+  auth: Pick<ProjectAuthContext, 'role'>,
+): void {
+  if (!authorizeRls(auth.role, 'documents', 'write')) {
+    throw new DocumentError('RBAC_FORBIDDEN', 'Insufficient role', 403);
+  }
+}
+
+/**
+ * The 0.4 `assertGenericDocumentContentWritable` on the jsonb record
+ * projection (twin of `assertRecordTrashableJson` below; the typed original
+ * lives in `core/documents/access.ts` and guards the WebDAV lane). Generic
+ * writers may change an uncontrolled document's content, but a controlled
+ * record's bytes and identity fields have exactly one door — the attested
+ * replacement flow in `records.ts`: `in_review`/`approved` are frozen, and
+ * even a `draft` refuses here so its content moves only through that flow.
+ */
+export function assertGenericDocumentContentWritableJson(
+  record: Record<string, unknown> | null,
+): void {
+  if (record === null) return;
+  if (record.state === 'in_review' || record.state === 'approved') {
+    throw new DocumentError(
+      'DOCUMENT_RECORD_FROZEN',
+      record.state === 'in_review'
+        ? 'This controlled record is in review and frozen. Wait for the review decision (or request changes) before editing its content.'
+        : 'This controlled record is approved and immutable. Open a new revision to edit its content.',
+      400,
+      { state: record.state },
+    );
+  }
+  throw new DocumentError(
+    'DOCUMENT_RECORD_REPLACEMENT_REQUIRED',
+    'Replace controlled-record content through the dedicated replacement flow.',
+    400,
+    { state: typeof record.state === 'string' ? record.state : null },
+  );
+}
+
+/**
+ * A hub team assignment must come from the caller's own teams — the rule the
+ * plural `teamIds` lane established (`TEAM_ACCESS_DENIED`), applied to every
+ * lane that stamps `team_id`/`team_tags`. Membership implies the team exists
+ * and is in-org, and it keeps the invariant that you can never file a
+ * document into a scope nobody — including you — can see (`hasTeamAccess`
+ * has no admin bypass, so an unknown id would hide the row from everyone).
+ */
+export function assertHubTeamAssignable(
+  auth: Pick<ProjectAuthContext, 'teamIds'>,
+  teamId: string,
+): void {
+  if (!auth.teamIds.includes(teamId)) {
+    throw new DocumentError(
+      'TEAM_ACCESS_DENIED',
+      'Cannot assign document to a team you do not belong to',
+      403,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Create from upload
 // ---------------------------------------------------------------------------
@@ -206,6 +276,7 @@ export async function createDocumentFromUpload(
   auth: ProjectAuthContext,
   args: CreateDocumentFromUploadArgs,
 ): Promise<string> {
+  assertDocumentsWriteRole(auth);
   const file = await getFileMetadata(tx, auth.organizationId, args.fileId);
   if (!file) {
     throw new DocumentError('FILE_NOT_FOUND', 'Upload not found', 404);
@@ -243,7 +314,10 @@ export async function createDocumentFromUpload(
         throw new DocumentError('FOLDER_NOT_FOUND', 'Folder not found', 404);
       }
     }
-  } else if (args.folderId) {
+  } else if (args.teamId) {
+    assertHubTeamAssignable(auth, args.teamId);
+  }
+  if (!args.projectId && args.folderId) {
     const folder = await loadFolderOrThrow(tx, args.folderId);
     if (
       folder.organizationId !== auth.organizationId ||
@@ -349,8 +423,20 @@ export async function updateDocument(
     sourceProvider?: string | null;
   },
 ): Promise<{ teamScopeChanged: boolean; fileRef: string | null }> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(tx, args.documentId);
   await assertDocumentVisible(tx, auth, doc);
+  // Content-freeze guard (core/documents/access.ts doctrine): the bytes and
+  // their identity fields move ONLY while uncontrolled — renames, folder
+  // moves, team and metadata edits stay allowed in every record state.
+  if (
+    args.content !== undefined ||
+    args.mimeType !== undefined ||
+    args.extension !== undefined ||
+    args.sourceProvider !== undefined
+  ) {
+    assertGenericDocumentContentWritableJson(doc.record);
+  }
 
   let title = doc.title;
   if (args.title !== undefined) {
@@ -381,6 +467,9 @@ export async function updateDocument(
         'DOCUMENT_SCOPE_CONFLICT',
         'A project document cannot carry a team',
       );
+    }
+    if (args.teamId !== null) {
+      assertHubTeamAssignable(auth, args.teamId);
     }
     teamId = args.teamId;
     teamTags = args.teamId ? [args.teamId] : [];
@@ -448,6 +537,7 @@ export async function setDocumentTrashed(
   documentId: string,
   trashed: boolean,
 ): Promise<void> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(tx, documentId);
   await assertDocumentVisible(tx, auth, doc);
   if (trashed) {
@@ -508,6 +598,7 @@ export async function attachDocumentToProject(
   auth: ProjectAuthContext,
   args: { documentId: string; projectId: string },
 ): Promise<void> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(tx, args.documentId);
   await assertDocumentVisible(tx, auth, doc);
   if (doc.projectId) {
@@ -558,6 +649,7 @@ export async function detachDocumentFromProject(
   auth: ProjectAuthContext,
   documentId: string,
 ): Promise<void> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(tx, documentId);
   await assertDocumentVisible(tx, auth, doc);
   if (!doc.projectId) {
@@ -712,9 +804,13 @@ export async function createHubDocument(
   auth: ProjectAuthContext,
   args: CreateHubDocumentArgs,
 ): Promise<string> {
+  assertDocumentsWriteRole(auth);
   const title = args.title.trim();
   if (title.length === 0 || title.length > 512) {
     throw new DocumentError('DOCUMENT_TITLE_INVALID', 'Invalid title');
+  }
+  if (args.teamId !== undefined) {
+    assertHubTeamAssignable(auth, args.teamId);
   }
   if (args.folderId !== undefined) {
     const folder = await loadFolderOrThrow(tx, args.folderId);
@@ -1177,6 +1273,9 @@ export async function retryRagIndexingForDocument(
   auth: ProjectAuthContext,
   documentId: string,
 ): Promise<{ success: boolean; error?: string }> {
+  // A write-shaped door (it re-queues billable indexing work and rewrites
+  // the file row's RAG bookkeeping); the UI shows Retry only to writers.
+  assertDocumentsWriteRole(auth);
   try {
     await checkUserRateLimit(sql, 'file:rag-retry', auth.userId);
   } catch (error) {
@@ -1415,6 +1514,7 @@ export async function createDocumentFromBlobUpload(
   auth: ProjectAuthContext,
   args: CreateDocumentFromBlobUploadArgs,
 ): Promise<string> {
+  assertDocumentsWriteRole(auth);
   const stat = await statOrgBlob(sql, auth.organizationId, args.storageRef);
   if (stat === null) {
     throw new DocumentError(
@@ -1501,6 +1601,7 @@ export async function deleteDocumentHard(
   auth: ProjectAuthContext,
   documentId: string,
 ): Promise<void> {
+  assertDocumentsWriteRole(auth);
   const doc = await loadDocumentOrThrow(sql, documentId);
   await assertDocumentVisible(sql, auth, doc);
   if (isProjectScoped(doc)) {
@@ -1579,6 +1680,7 @@ export async function deleteFolderCascade(
   auth: ProjectAuthContext,
   folderId: string,
 ): Promise<void> {
+  assertDocumentsWriteRole(auth);
   const folder = await loadFolderOrThrow(sql, folderId);
   await assertFolderMutable(sql, auth, folder);
   await assertNotHeld(sql, auth.organizationId, 'folder', folderId);

--- a/services/platform/backend/domains/documents/write-guards.test.ts
+++ b/services/platform/backend/domains/documents/write-guards.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertDocumentsWriteRole,
+  assertGenericDocumentContentWritableJson,
+  assertHubTeamAssignable,
+  assertRecordTrashableJson,
+  DocumentError,
+} from './service.ts';
+
+/**
+ * The documents write-guard trio at the service seam — the org-role write
+ * matrix, the controlled-record content freeze on the jsonb projection, and
+ * the retained-history delete protection. Every mutating door (app routes,
+ * REST v1, agent upsert, folder cascade) inherits these; the tables here are
+ * the wire-level contract those doors rely on.
+ */
+
+function codeOf(run: () => void): { code: string; status: number } | null {
+  try {
+    run();
+    return null;
+  } catch (error) {
+    if (error instanceof DocumentError) {
+      return { code: error.code, status: error.status };
+    }
+    throw error;
+  }
+}
+
+describe('assertDocumentsWriteRole (the org-role write matrix)', () => {
+  it.each(['owner', 'admin', 'developer', 'editor'])(
+    'admits the %s role',
+    (role) => {
+      expect(codeOf(() => assertDocumentsWriteRole({ role }))).toBeNull();
+    },
+  );
+
+  it.each(['member', 'disabled'])('refuses the read-only %s role', (role) => {
+    expect(codeOf(() => assertDocumentsWriteRole({ role }))).toEqual({
+      code: 'RBAC_FORBIDDEN',
+      status: 403,
+    });
+  });
+
+  it('fails closed for unknown roles (degrade to member)', () => {
+    expect(codeOf(() => assertDocumentsWriteRole({ role: 'wizard' }))).toEqual({
+      code: 'RBAC_FORBIDDEN',
+      status: 403,
+    });
+  });
+});
+
+describe('assertGenericDocumentContentWritableJson (content freeze)', () => {
+  it('admits an uncontrolled document', () => {
+    expect(
+      codeOf(() => assertGenericDocumentContentWritableJson(null)),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['in_review', 'DOCUMENT_RECORD_FROZEN'],
+    ['approved', 'DOCUMENT_RECORD_FROZEN'],
+    // A draft is not frozen, but controlled bytes still have exactly one
+    // door — the attested replacement flow.
+    ['draft', 'DOCUMENT_RECORD_REPLACEMENT_REQUIRED'],
+  ])('refuses a controlled record in %s as %s', (state, code) => {
+    expect(
+      codeOf(() =>
+        assertGenericDocumentContentWritableJson({
+          state,
+          version: 1,
+          approvedVersions: [],
+        }),
+      ),
+    ).toEqual({ code, status: 400 });
+  });
+});
+
+describe('assertRecordTrashableJson (delete protection incl. history)', () => {
+  it('admits an uncontrolled document', () => {
+    expect(codeOf(() => assertRecordTrashableJson(null))).toBeNull();
+  });
+
+  it('admits a controlled first draft with no approved history', () => {
+    expect(
+      codeOf(() =>
+        assertRecordTrashableJson({
+          state: 'draft',
+          version: 1,
+          approvedVersions: [],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it.each(['in_review', 'approved'])('refuses a record in %s', (state) => {
+    expect(
+      codeOf(() =>
+        assertRecordTrashableJson({ state, version: 1, approvedVersions: [] }),
+      ),
+    ).toEqual({ code: 'DOCUMENT_RECORD_PROTECTED', status: 400 });
+  });
+
+  it('refuses a revision draft that retains approved history', () => {
+    // The "open a new revision, then delete" hole: protection follows the
+    // record's EVIDENCE, never the current state alone.
+    expect(
+      codeOf(() =>
+        assertRecordTrashableJson({
+          state: 'draft',
+          version: 2,
+          approvedVersions: [
+            { version: 1, fileId: 'file_1', approvedAt: 1, approvedBy: 'u1' },
+          ],
+        }),
+      ),
+    ).toEqual({ code: 'DOCUMENT_RECORD_PROTECTED', status: 400 });
+  });
+});
+
+describe('assertHubTeamAssignable (team scope must stay visible)', () => {
+  it('admits a team the caller belongs to', () => {
+    expect(
+      codeOf(() =>
+        assertHubTeamAssignable({ teamIds: ['team_a', 'team_b'] }, 'team_b'),
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['a foreign team', 'team_other'],
+    ['an unknown id', 'no-such-team'],
+  ])('refuses %s', (_label, teamId) => {
+    expect(
+      codeOf(() => assertHubTeamAssignable({ teamIds: ['team_a'] }, teamId)),
+    ).toEqual({ code: 'TEAM_ACCESS_DENIED', status: 403 });
+  });
+});

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -3007,6 +3007,502 @@ async function checkDocuments(
 }
 
 /**
+ * The document write-guard class: the org-role write matrix on every
+ * mutating documents door (app + REST v1), the controlled-record content
+ * freeze at the service seam, REST delete protection derived from the
+ * session predicate (retained approved history included), agent upsert
+ * freeze + content-hash coherence, and hub team assignability. Runs LATE in
+ * the sequence — it adds a member-role user and a team to the org, which
+ * earlier sections' exact-count assertions must not see.
+ */
+async function checkDocumentWriteGuards(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string; userId: string },
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'document write guards (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — document write-guard lanes not exercised',
+    );
+    return;
+  }
+  const { cookie, orgId, userId } = ctx;
+  const sendAs = (
+    asCookie: string,
+    method: 'GET' | 'POST' | 'DELETE',
+    route: string,
+    body?: unknown,
+  ): Promise<Response> =>
+    fetch(`${base}${route}`, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        cookie: asCookie,
+        origin: base,
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+
+  // A blob-backed hub document (upload bind lane), as the owner — the only
+  // controllable source this section can mint over HTTP.
+  const uploadDoc = async (fileName: string): Promise<string> => {
+    const handoff = z
+      .object({ storageRef: z.string(), uploadUrl: z.string().url() })
+      .safeParse(
+        await (
+          await sendAs(
+            cookie,
+            'POST',
+            `/api/app/files/upload-handoff?orgId=${orgId}`,
+            { contentType: 'text/plain', size: 10 },
+          )
+        ).json(),
+      );
+    if (!handoff.success) return '';
+    await fetch(handoff.data.uploadUrl, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'guard body',
+    });
+    const registered = z.object({ fileId: z.string() }).safeParse(
+      await (
+        await sendAs(cookie, 'POST', `/api/app/files/register?orgId=${orgId}`, {
+          storageRef: handoff.data.storageRef,
+          fileName,
+          contentType: 'text/plain',
+        })
+      ).json(),
+    );
+    const created = z.object({ documentId: z.string() }).safeParse(
+      await (
+        await sendAs(
+          cookie,
+          'POST',
+          `/api/app/documents/from-upload?orgId=${orgId}`,
+          {
+            fileId: registered.success ? registered.data.fileId : '',
+            fileName,
+          },
+        )
+      ).json(),
+    );
+    return created.success ? created.data.documentId : '';
+  };
+
+  // ---- fixtures: a member-role user (session + API key), an owner key.
+  const suffix = Date.now().toString(36);
+  const memberSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `doc-guards-member-${suffix}@example.com`,
+      password: 'itest-password-1',
+      name: 'Doc Guards Member',
+    }),
+  });
+  const memberCookie = cookieHeaderFrom(memberSignUp);
+  const memberBody = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await memberSignUp.json());
+  const memberId = memberBody.success ? memberBody.data.user.id : '';
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (gen_random_uuid(), ${orgId}, ${memberId}, 'member', ${new Date()})
+  `;
+  const mintKey = async (asCookie: string, name: string): Promise<string> => {
+    const minted = z.looseObject({ key: z.string() }).safeParse(
+      await (
+        await fetch(`${base}/api/auth/api-key/create`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            cookie: asCookie,
+            origin: base,
+          },
+          body: JSON.stringify({ name }),
+        })
+      ).json(),
+    );
+    return minted.success ? minted.data.key : '';
+  };
+  const memberKey = await mintKey(memberCookie, 'itest-doc-guards-member');
+  const ownerKey = await mintKey(cookie, 'itest-doc-guards-owner');
+  const v1 = (
+    key: string,
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+    route: string,
+    body?: unknown,
+  ): Promise<Response> =>
+    fetch(`${base}/api/v1${route}`, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${key}`,
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  const codeIn = async (response: Response): Promise<string> => {
+    const parsed = z
+      .looseObject({
+        error: z.string().optional(),
+        code: z.string().optional(),
+      })
+      .safeParse(await response.json().catch(() => null));
+    return parsed.success ? (parsed.data.code ?? parsed.data.error ?? '') : '';
+  };
+
+  const docA = await uploadDoc('guards-a.txt');
+  const guardsFolder = z.object({ folderId: z.string() }).safeParse(
+    await (
+      await sendAs(cookie, 'POST', `/api/app/folders?orgId=${orgId}`, {
+        name: `Guards ${suffix}`,
+      })
+    ).json(),
+  );
+  const guardsFolderId = guardsFolder.success ? guardsFolder.data.folderId : '';
+
+  // ---- (1) org-role write matrix — the app door refuses a member ----------
+  const appDoc = `/api/app/documents/${docA}`;
+  const renameDoc = await sendAs(
+    memberCookie,
+    'POST',
+    `${appDoc}?orgId=${orgId}`,
+    {
+      title: 'member-renamed',
+    },
+  );
+  const trash = await sendAs(
+    memberCookie,
+    'POST',
+    `${appDoc}/trash?orgId=${orgId}`,
+  );
+  const hardDelete = await sendAs(
+    memberCookie,
+    'POST',
+    `${appDoc}/delete?orgId=${orgId}`,
+  );
+  const blobBind = await sendAs(
+    memberCookie,
+    'POST',
+    `/api/app/documents/from-blob-upload?orgId=${orgId}`,
+    { storageRef: 's3:junk', fileName: 'member.txt' },
+  );
+  const markByMember = await sendAs(
+    memberCookie,
+    'POST',
+    `${appDoc}/record/mark-controlled?orgId=${orgId}`,
+  );
+  const replaceBegin = await sendAs(
+    memberCookie,
+    'POST',
+    `${appDoc}/replacement-upload/begin?orgId=${orgId}`,
+    {
+      expectedRecordState: 'draft',
+      expectedVersion: 1,
+      expectedFileId: 'file-x',
+      fileName: 'member.txt',
+    },
+  );
+  const retryRag = await sendAs(
+    memberCookie,
+    'POST',
+    `${appDoc}/retry-rag?orgId=${orgId}`,
+  );
+  const cascade = await sendAs(
+    memberCookie,
+    'DELETE',
+    `/api/app/folders/${guardsFolderId}?orgId=${orgId}`,
+  );
+  const memberList = z
+    .object({ documents: z.array(z.object({ id: z.string() })) })
+    .safeParse(
+      await (
+        await sendAs(memberCookie, 'GET', `/api/app/documents?orgId=${orgId}`)
+      ).json(),
+    );
+  const appRefused = [
+    renameDoc,
+    trash,
+    hardDelete,
+    blobBind,
+    markByMember,
+    replaceBegin,
+    retryRag,
+    cascade,
+  ];
+  const renameCode = await codeIn(renameDoc);
+  record(
+    'documents write matrix: app door refuses read-only member',
+    appRefused.every((response) => response.status === 403) &&
+      renameCode === 'RBAC_FORBIDDEN' &&
+      memberList.success &&
+      memberList.data.documents.some((doc) => doc.id === docA),
+    `rename/trash/delete/blob-bind/mark/replace-begin/retry/cascade → ${appRefused.map((r) => r.status).join('/')} (want all 403), code=${renameCode}, memberRead=${memberList.success ? memberList.data.documents.length : 'ERR'} doc(s)`,
+  );
+
+  // ---- (1) org-role write matrix — the REST v1 door refuses a member ------
+  const restPost = await v1(memberKey, 'POST', '/documents', {
+    title: 'member-rest.txt',
+  });
+  const restPatch = await v1(memberKey, 'PATCH', `/documents/${docA}`, {
+    title: 'member-rest-renamed',
+  });
+  const restDelete = await v1(memberKey, 'DELETE', `/documents/${docA}`);
+  const restRetry = await v1(
+    memberKey,
+    'POST',
+    `/documents/${docA}/retry-indexing`,
+  );
+  const restList = await v1(memberKey, 'GET', '/documents');
+  const restPostCode = await codeIn(restPost);
+  record(
+    'documents write matrix: REST v1 door refuses read-only member',
+    restPost.status === 403 &&
+      restPatch.status === 403 &&
+      restDelete.status === 403 &&
+      restRetry.status === 403 &&
+      restPostCode === 'RBAC_FORBIDDEN' &&
+      restList.status === 200,
+    `POST/PATCH/DELETE/retry → ${restPost.status}/${restPatch.status}/${restDelete.status}/${restRetry.status} (want 403), code=${restPostCode}, GET → ${restList.status} (want 200)`,
+  );
+
+  // ---- (3) content freeze at the service seam (REST PATCH) ----------------
+  const docB = await uploadDoc('guards-b.txt');
+  const markB = await sendAs(
+    cookie,
+    'POST',
+    `/api/app/documents/${docB}/record/mark-controlled?orgId=${orgId}`,
+  );
+  const patchDraftContent = await v1(ownerKey, 'PATCH', `/documents/${docB}`, {
+    content: 'rewritten draft bytes',
+  });
+  const patchDraftTitle = await v1(ownerKey, 'PATCH', `/documents/${docB}`, {
+    title: 'guards-b-renamed.txt',
+  });
+  // Eligibility mirrors the respond gate: a read-only member never appears
+  // as a designation candidate (a designee who could not respond would
+  // strand the review).
+  const eligibleIds = z
+    .object({ userIds: z.array(z.string()) })
+    .safeParse(
+      await (
+        await sendAs(
+          cookie,
+          'GET',
+          `/api/app/documents/${docB}/record/eligible-reviewer-ids?orgId=${orgId}`,
+        )
+      ).json(),
+    );
+  const submitB = z
+    .object({ approvalId: z.string() })
+    .safeParse(
+      await (
+        await sendAs(
+          cookie,
+          'POST',
+          `/api/app/documents/${docB}/record/submit?orgId=${orgId}`,
+          { reviewerUserId: userId },
+        )
+      ).json(),
+    );
+  const patchFrozenContent = await v1(ownerKey, 'PATCH', `/documents/${docB}`, {
+    content: 'rewritten in-review bytes',
+  });
+  const patchFrozenMime = await v1(ownerKey, 'PATCH', `/documents/${docB}`, {
+    mimeType: 'application/x-sneaky',
+  });
+  const draftContentCode = await codeIn(patchDraftContent);
+  const frozenContentCode = await codeIn(patchFrozenContent);
+  record(
+    'controlled-record content freeze on updateDocument (REST PATCH)',
+    markB.status === 200 &&
+      patchDraftContent.status === 400 &&
+      draftContentCode === 'DOCUMENT_RECORD_REPLACEMENT_REQUIRED' &&
+      patchDraftTitle.status === 204 &&
+      eligibleIds.success &&
+      eligibleIds.data.userIds.includes(userId) &&
+      !eligibleIds.data.userIds.includes(memberId) &&
+      submitB.success &&
+      patchFrozenContent.status === 400 &&
+      frozenContentCode === 'DOCUMENT_RECORD_FROZEN' &&
+      patchFrozenMime.status === 400,
+    `mark → ${markB.status}, draftContent → ${patchDraftContent.status}/${draftContentCode} (want 400/REPLACEMENT_REQUIRED), rename → ${patchDraftTitle.status} (want 204), eligible=${eligibleIds.success ? `${eligibleIds.data.userIds.includes(userId) ? 'owner' : 'NO-OWNER'}${eligibleIds.data.userIds.includes(memberId) ? '+MEMBER' : ''}` : 'ERR'} (want owner only), inReviewContent → ${patchFrozenContent.status}/${frozenContentCode} (want 400/FROZEN), mime → ${patchFrozenMime.status} (want 400)`,
+  );
+
+  // ---- (4) REST DELETE uses the session protection predicate --------------
+  const approveB = await sendAs(
+    cookie,
+    'POST',
+    `/api/app/documents/records/reviews/${submitB.success ? submitB.data.approvalId : ''}/respond?orgId=${orgId}`,
+    { decision: 'approve' },
+  );
+  const deleteApproved = await v1(ownerKey, 'DELETE', `/documents/${docB}`);
+  const revisionB = await sendAs(
+    cookie,
+    'POST',
+    `/api/app/documents/${docB}/record/open-revision?orgId=${orgId}`,
+  );
+  // The hole this locks: a draft OPENED AFTER approval still retains the
+  // approved history — REST delete must refuse it exactly like the session
+  // paths, not re-derive "draft is deletable" from the state alone.
+  const deleteRetained = await v1(ownerKey, 'DELETE', `/documents/${docB}`);
+  const retainedRow = await sql<{ id: string }[]>`
+    SELECT id FROM app.documents WHERE id = ${docB} LIMIT 1
+  `;
+  const docC = await uploadDoc('guards-c.txt');
+  const deleteUncontrolled = await v1(ownerKey, 'DELETE', `/documents/${docC}`);
+  const auditRows = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.audit_logs
+    WHERE org_id = ${orgId} AND action = 'document.deleted'
+      AND resource_id = ${docC}
+  `;
+  record(
+    'REST DELETE inherits record protection (retained history) + audit',
+    approveB.status === 200 &&
+      deleteApproved.status === 409 &&
+      (await codeIn(deleteApproved)) === 'DOCUMENT_RECORD_PROTECTED' &&
+      revisionB.status === 200 &&
+      deleteRetained.status === 409 &&
+      retainedRow.length === 1 &&
+      deleteUncontrolled.status === 204 &&
+      auditRows[0]?.count === '1',
+    `approve → ${approveB.status}, deleteApproved → ${deleteApproved.status} (want 409), revision → ${revisionB.status}, deleteRetained → ${deleteRetained.status} (want 409), rowKept=${retainedRow.length === 1}, uncontrolled → ${deleteUncontrolled.status} (want 204), auditRows=${auditRows[0]?.count ?? '0'} (want 1)`,
+  );
+
+  // ---- (2) agent upsert: freeze + content-hash coherence ------------------
+  const { createHash } = await import('node:crypto');
+  const { storeAgentTextBlob, upsertAgentDocument } =
+    await import('./domains/documents/agent-write.ts');
+  const { DocumentError } = await import('./domains/documents/service.ts');
+  const sha = (content: string): string =>
+    createHash('sha256').update(content).digest('hex');
+  const agentKey = `itest:doc-guards:${suffix}`;
+  const agentWrite = async (
+    content: string,
+  ): Promise<{ documentId: string; action: string; fileRef: string }> => {
+    const blob = await storeAgentTextBlob(sql, {
+      organizationId: orgId,
+      fileName: 'agent-report.md',
+      content,
+      contentType: 'text/markdown',
+      uploadedBy: userId,
+    });
+    const upserted = await upsertAgentDocument(sql, {
+      organizationId: orgId,
+      externalItemId: agentKey,
+      title: 'agent-report.md',
+      fileRef: blob.storageRef,
+      mimeType: 'text/markdown',
+      createdBy: userId,
+      auditActorId: userId,
+    });
+    return { ...upserted, fileRef: blob.storageRef };
+  };
+  const hashOf = async (documentId: string): Promise<string | null> => {
+    const rows = await sql<{ contentHash: string | null }[]>`
+      SELECT content_hash AS "contentHash" FROM app.documents
+      WHERE id = ${documentId} LIMIT 1
+    `;
+    return rows[0]?.contentHash ?? null;
+  };
+  const first = await agentWrite('agent v1 body');
+  const hashAfterCreate = await hashOf(first.documentId);
+  const second = await agentWrite('agent v2 body');
+  const hashAfterUpdate = await hashOf(second.documentId);
+  const markAgent = await sendAs(
+    cookie,
+    'POST',
+    `/api/app/documents/${first.documentId}/record/mark-controlled?orgId=${orgId}`,
+  );
+  let refusedCode = '';
+  try {
+    await agentWrite('agent v3 body — must not land');
+  } catch (error) {
+    refusedCode = error instanceof DocumentError ? error.code : String(error);
+  }
+  const fileRefRows = await sql<{ fileRef: string | null }[]>`
+    SELECT file_ref AS "fileRef" FROM app.documents
+    WHERE id = ${first.documentId} LIMIT 1
+  `;
+  record(
+    'agent upsert: content-hash coherence + controlled-record freeze',
+    first.action === 'created' &&
+      hashAfterCreate === sha('agent v1 body') &&
+      second.action === 'updated' &&
+      second.documentId === first.documentId &&
+      hashAfterUpdate === sha('agent v2 body') &&
+      markAgent.status === 200 &&
+      refusedCode === 'DOCUMENT_RECORD_REPLACEMENT_REQUIRED' &&
+      fileRefRows[0]?.fileRef === second.fileRef,
+    `create=${first.action}/${hashAfterCreate === sha('agent v1 body') ? 'hash-ok' : `hash=${hashAfterCreate ?? 'null'}`}, update=${second.action}/${hashAfterUpdate === sha('agent v2 body') ? 'hash-ok' : `hash=${hashAfterUpdate ?? 'null'}`}, mark → ${markAgent.status}, rerun=${refusedCode || 'ALLOWED'} (want DOCUMENT_RECORD_REPLACEMENT_REQUIRED), fileRefKept=${fileRefRows[0]?.fileRef === second.fileRef}`,
+  );
+
+  // ---- (5) hub team assignment must stay visible to the caller ------------
+  const bogusRest = await v1(ownerKey, 'POST', '/documents', {
+    title: 'team-scoped.txt',
+    teamId: 'team_bogus',
+  });
+  const teamRows = await sql<{ id: string }[]>`
+    INSERT INTO "team" ("id", "name", "organizationId", "createdAt",
+                        "updatedAt")
+    VALUES (gen_random_uuid(), ${`Doc Guards ${suffix}`}, ${orgId},
+            ${new Date()}, ${new Date()})
+    RETURNING "id"
+  `;
+  const teamId = teamRows[0]?.id ?? '';
+  const foreignRest = await v1(ownerKey, 'POST', '/documents', {
+    title: 'team-scoped.txt',
+    teamId,
+  });
+  const bogusApp = await sendAs(cookie, 'POST', `${appDoc}?orgId=${orgId}`, {
+    teamId: 'team_bogus',
+  });
+  await sql`
+    INSERT INTO "teamMember" ("id", "teamId", "userId", "createdAt")
+    VALUES (gen_random_uuid(), ${teamId}, ${userId}, ${new Date()})
+  `;
+  const memberOfTeam = z.object({ id: z.string() }).safeParse(
+    await (
+      await v1(ownerKey, 'POST', '/documents', {
+        title: 'team-scoped.txt',
+        teamId,
+      })
+    ).json(),
+  );
+  const teamStamp = memberOfTeam.success
+    ? await sql<{ teamId: string | null; teamTags: string[] }[]>`
+        SELECT team_id AS "teamId", team_tags AS "teamTags"
+        FROM app.documents WHERE id = ${memberOfTeam.data.id} LIMIT 1
+      `
+    : [];
+  const patchTeam = await sendAs(cookie, 'POST', `${appDoc}?orgId=${orgId}`, {
+    teamId,
+  });
+  const clearTeam = await sendAs(cookie, 'POST', `${appDoc}?orgId=${orgId}`, {
+    teamId: null,
+  });
+  const bogusRestCode = await codeIn(bogusRest);
+  const bogusAppCode = await codeIn(bogusApp);
+  record(
+    'hub teamId is validated on create + patch (never file into the void)',
+    bogusRest.status === 403 &&
+      bogusRestCode === 'TEAM_ACCESS_DENIED' &&
+      foreignRest.status === 403 &&
+      bogusApp.status === 403 &&
+      bogusAppCode === 'TEAM_ACCESS_DENIED' &&
+      memberOfTeam.success &&
+      teamStamp[0]?.teamId === teamId &&
+      (teamStamp[0]?.teamTags ?? []).join(',') === teamId &&
+      patchTeam.status === 200 &&
+      clearTeam.status === 200,
+    `bogusRest → ${bogusRest.status}/${bogusRestCode} (want 403/TEAM_ACCESS_DENIED), foreignTeam → ${foreignRest.status} (want 403), bogusApp → ${bogusApp.status}/${bogusAppCode}, joined+create → ${memberOfTeam.success ? 'ok' : 'ERR'}, stamp=${teamStamp[0]?.teamId === teamId ? 'ok' : 'MISS'}, patch → ${patchTeam.status}, clear → ${clearTeam.status}`,
+  );
+}
+
+/**
  * Small-domain smoke: contacts CRUD + find-or-create shape, message
  * feedback upsert/toggle/stats, support case lifecycle.
  */
@@ -26002,6 +26498,7 @@ async function main(): Promise<void> {
     await checkAutomationRunToolLane(sql, baseUrl, authCtx);
     await checkSandboxSpawner(sql, baseUrl, authCtx);
     await checkWatchdogs(sql, baseUrl, authCtx);
+    await checkDocumentWriteGuards(sql, baseUrl, authCtx);
     await checkLoginThrottleAndAuditChain(
       sql,
       baseUrl,

--- a/services/platform/backend/rest/v1-core.ts
+++ b/services/platform/backend/rest/v1-core.ts
@@ -28,7 +28,10 @@ import {
   type ContactScope,
 } from '../domains/contacts/service.ts';
 import {
+  assertDocumentsWriteRole,
   createHubDocument,
+  deleteDocumentHard,
+  DocumentError,
   getDocumentById,
   listHubDocumentsPage,
   readDocumentRestExtras,
@@ -42,7 +45,6 @@ import {
   deleteKnowledgeEntry,
   updateKnowledgeEntry,
 } from '../domains/knowledge_entries/service.ts';
-import { assertNotHeld } from '../domains/legal_holds/service.ts';
 import {
   createProduct,
   deleteProduct,
@@ -51,7 +53,6 @@ import {
   updateProduct,
   type ProductScope,
 } from '../domains/products/service.ts';
-import { purgeDocument } from '../domains/retention/service.ts';
 import { addJobInTx } from '../jobs/enqueue.ts';
 import { resolveOrgSlug } from '../lib/org-config.ts';
 import { checkOrganizationRateLimit } from '../lib/rate-limit.ts';
@@ -424,50 +425,33 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
     try {
       const doc = await loadHubDocument(c, c.req.param('id'));
       if (doc instanceof Response) return doc;
-      const extras = await readDocumentRestExtras(deps.sql, doc.id);
-      const record = extras?.record;
-      // Controlled-record gate: an in-review/approved record refuses (409),
-      // exactly like the session trash path.
+      const auth = await restProjectAuth(deps.sql, c);
+      // The SESSION delete whole — org-role write gate, the controlled-record
+      // protection predicate (in_review/approved AND retained approved
+      // history, `assertRecordTrashableJson` — never re-derived from `state`
+      // alone), legal holds, sync stop, the audit row, then the purge.
+      await deleteDocumentHard(deps.sql, auth, doc.id);
+      return c.body(null, 204);
+    } catch (error) {
+      // Wire parity: this door has always refused protected records as 409.
       if (
-        record !== null &&
-        record !== undefined &&
-        typeof record === 'object' &&
-        'state' in record &&
-        (record as { state?: unknown }).state !== 'draft'
+        error instanceof DocumentError &&
+        error.code === 'DOCUMENT_RECORD_PROTECTED'
       ) {
         return c.json(
-          {
-            error: 'DOCUMENT_RECORD_PROTECTED',
-            message: 'This controlled record cannot be deleted.',
-          },
+          { error: 'DOCUMENT_RECORD_PROTECTED', message: error.message },
           409,
         );
       }
-      // Legal holds outrank the delete (the 0.4 `deleteDocumentById` gate) —
-      // the author-scoped custodian cascade included.
-      await assertNotHeld(
-        deps.sql,
-        c.get('organizationId'),
-        'document',
-        doc.id,
-        undefined,
-        doc.createdBy ?? undefined,
-      );
-      const orgSlug = await resolveOrgSlug(deps.sql, c.get('organizationId'));
-      await purgeDocument(deps.sql, orgSlug, {
-        id: doc.id,
-        fileRef: doc.fileRef,
-        organizationId: doc.organizationId,
-        historyFiles: doc.historyFiles,
-      });
-      return c.body(null, 204);
-    } catch (error) {
       return domainErrorResponse(c, error);
     }
   });
 
   app.post('/documents/:id/retry-indexing', async (c) => {
     try {
+      // Write-shaped: it rewrites RAG bookkeeping and enqueues billable
+      // indexing — the same matrix gate as the session Retry affordance.
+      assertDocumentsWriteRole({ role: c.get('role') });
       const doc = await loadHubDocument(c, c.req.param('id'));
       if (doc instanceof Response) return doc;
       if (doc.fileRef === null) {


### PR DESCRIPTION
Fixes the verified review class **document mutations bypass the org role write matrix and the controlled-record freeze** (5 findings, all confirmed in code).

## The enforced matrix

| Role                               | documents read | documents write (create / edit / trash / delete / record + replacement flows / RAG retry / folder cascade) |
| ---------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
| owner / admin / developer / editor | yes            | yes                                                                                                        |
| member                             | yes            | **refused — `RBAC_FORBIDDEN` 403**                                                                         |
| disabled                           | no             | no                                                                                                         |

One implementation: `assertDocumentsWriteRole` (documents service) delegates to `authorizeRls(role, 'documents', 'write')` — the same matrix `auth/access.ts` defines, the same set as the frontend's `knowledgeWrite` ability and `EDITOR_ROLES`. Project-scoped documents keep their additional project-`canEdit` check; agent standing-grant writes stay authorized by their dispatch (no human role there, by design).

## Per-finding outcome

**1. Org role write matrix never enforced on document mutations — fixed (critical/security).**
`assertDocumentsWriteRole` now gates every mutating service function: `createDocumentFromUpload`, `createDocumentFromBlobUpload`, `createHubDocument`, `updateDocument`, `setDocumentTrashed`, `attachDocumentToProject`, `detachDocumentFromProject`, `deleteDocumentHard`, `deleteFolderCascade`, `retryRagIndexingForDocument`, plus the shared write standards in `records.ts` (`requireDocumentWriteAccess` → mark-controlled / submit / respond / open-revision) and `replacement.ts` (`requireReplacementDocument` → begin / finalize / resume). The REST `retry-indexing` route (its own inline body) gets the same gate. Reviewer eligibility (`isEligibleDocumentReviewer`) is tightened to write-capable roles on hub documents so a designated reviewer can never be someone the respond gate refuses (previously any visible role — including member — was hub-eligible server-side while the UI picker filtered to `EDITOR_ROLES`).
_Regression tests:_ unit matrix table (`write-guards.test.ts`), plus integration member-refusal sweeps across the app door (rename/trash/delete/blob-bind/mark-controlled/replacement-begin/RAG-retry/folder-cascade) and the REST door (POST/PATCH/DELETE/retry) with reads proven still open.

**2. Agent document upsert overwrites frozen controlled records — fixed (high/bug).**
`upsertAgentDocument`'s update path now selects the row's `record` and applies `assertGenericDocumentContentWritableJson` — the same generic-content-writer rule the human paths and WebDAV apply (controlled bytes move only through the attested replacement flow; `in_review`/`approved` report frozen). `content_hash` is kept coherent on both paths: `storeAgentTextBlob` stamps the blob's sha256 on its `file_metadata` row (the knowledge-entry convention) and the upsert resolves the hash from that ledger row, so a refreshed document never carries the previous blob's hash.
_Regression tests:_ integration — create/rerun hash coherence (sha256 equality against the row), mark-controlled then rerun → `DOCUMENT_RECORD_REPLACEMENT_REQUIRED` with `file_ref` unchanged.

**3. updateDocument misses the content-freeze guard; REST PATCH edits frozen records — fixed (high/bug).**
The guard lives at the **service seam**: `updateDocument` calls `assertGenericDocumentContentWritableJson` whenever `content`/`mimeType`/`extension`/`sourceProvider` are present, so the app door, REST PATCH, and any future caller inherit it. Renames, folder moves, team and metadata edits stay allowed in every record state (the access-layer doctrine). The guard is the jsonb-projection twin of `core/documents/access.ts#assertGenericDocumentContentWritable` (same precedent as the existing `assertRecordTrashableJson`), throwing `DocumentError` so both error surfaces stay coded: app `{error: code}`, REST `{error: message, code}`.
_Regression tests:_ unit state table (uncontrolled passes; draft → `DOCUMENT_RECORD_REPLACEMENT_REQUIRED`; in_review/approved → `DOCUMENT_RECORD_FROZEN`); integration REST PATCH content/mime refusals on draft and in_review, title-only PATCH still 204.

**4. REST DELETE destroys retained approved history of controlled records — fixed (high/bug).**
`DELETE /api/v1/documents/:id` no longer re-derives protection from `state !== 'draft'` (the exact re-derivation bug class `core/documents/access.ts` names). It calls `deleteDocumentHard` — the session delete whole — inheriting the single trash predicate (`assertRecordTrashableJson`: in_review, approved, **and retained approved history**), the write matrix, legal holds, the sync stop, and the audit row REST previously skipped. Wire parity kept: protected records still answer this door's established `409 {error: 'DOCUMENT_RECORD_PROTECTED', message}`.
_Regression tests:_ unit — revision-draft-with-history refuses; integration — approve → DELETE 409, open-revision → DELETE 409 with the row proven still present, uncontrolled DELETE 204 **with the audit row now written**.

**5. Unvalidated teamId on document create/patch makes documents permanently invisible — fixed (high/bug).**
`assertHubTeamAssignable` applies the plural-`teamIds` lane's rule (caller must belong → `TEAM_ACCESS_DENIED` 403; membership implies the team exists and is in-org) to every lane that stamps `team_id`/`team_tags`: `createHubDocument` (REST POST), `createDocumentFromUpload`'s hub lane (including the previously-skipped teamId+folderId combination), and `updateDocument`'s singular-`teamId` lane (app + REST PATCH). Clearing (`teamId: null`) stays allowed. This matches the product's team-visibility semantics — `hasTeamAccess` has no admin bypass, and the UI's document team pickers (`useTeams` → `myTeamsQuery`) already offer only the caller's own teams.
_Regression tests:_ unit membership rule; integration — bogus and existing-but-foreign teamId refused on REST create and app patch, member-of-team create succeeds with `team_id`/`team_tags` stamped, patch + clear succeed.

Refuted findings: none — all five reproduced in code as reported.

## Call-site sweep (every mutating entry into the documents domain)

| Caller                                                                  | How it inherits the gates                                                                                                                                                                 |
| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| App routes `/api/app/documents/*` (routes.ts)                           | all mutations call the gated service/records/replacement functions                                                                                                                        |
| App folders `DELETE /api/app/folders/:id`                               | `deleteFolderCascade` (gated; record predicate pre-walk unchanged)                                                                                                                        |
| REST `POST/PATCH /api/v1/documents*` (v1-core)                          | `createHubDocument` / `updateDocument` (gated + freeze + teamId)                                                                                                                          |
| REST `DELETE /api/v1/documents/:id`                                     | now `deleteDocumentHard` (gated + predicate + audit)                                                                                                                                      |
| REST `POST /documents/:id/retry-indexing`                               | inline body → explicit `assertDocumentsWriteRole`                                                                                                                                         |
| REST projects upload (v1-projects)                                      | `createDocumentFromUpload` (gated; project lane already required `canEdit` — same role set, unchanged wire code)                                                                          |
| Workflow document store (connectors/service.ts `pgDocumentStore`)       | calls `createHubDocument` with synthetic `role: 'owner'` — passes by construction                                                                                                         |
| Sandbox workspace tool (`workspace-write-shim` → `upsertAgentDocument`) | standing-grant authority (no role matrix, by design); now carries the record freeze + hash coherence                                                                                      |
| OneDrive / Google Drive sync loops                                      | own injected raw-SQL update in `domains/onedrive/service.ts` — never touches the service seam, and sync-owned docs are not controllable (`CONTROLLABLE_SOURCE_PROVIDERS` = upload, agent) |
| WebDAV handlers                                                         | already carry the core record guards (`assertGenericDocumentContentWritable` / `assertRecordTrashable`); write credentials are minted behind the developer capability                     |
| project-text (`ensureProjectTextDocument`)                              | project lane, already gated via `getOrCreateProjectFolder` → `assertProjectFolderWrite` (project `canEdit`); its docs (`source_provider: 'project_text'`) are not controllable            |

## Frontend expectations

No divergence: the app already hides every document mutation (including RAG retry) behind the `knowledgeWrite` ability, whose role set equals this gate; the reviewer picker already filters to `EDITOR_ROLES`; the team pickers already offer only the caller's own teams. The backend now enforces what the UI promises.

## Verification

- Unit (`write-guards.test.ts`, vitest server project): **19/19 on the branch**; on base (implementation files reverted to `main`, tests kept): **14 failed / 5 passed** — the 14 exercise the three new guards, the 5 passing are the pre-existing trash predicate the REST door failed to use. Full platform vitest on the branch: **373 files / 72294 tests passed**.
- `backend:integration` on a throwaway tale-db + MinIO (fresh DB per run): **branch 285/285**; **base proof (implementation reverted, tests kept): 279/285** — exactly the six new checks red, every pre-existing check green. The base reds narrate the holes on main verbatim: member rename/trash/hard-delete/RAG-retry/folder-cascade answered 200 and REST create 201; PATCH content on a draft and an in-review record answered 204; DELETE of a revision draft with approved history answered 204 with the row gone and no audit row; agent rerun over a controlled record was ALLOWED with `content_hash` null and `file_ref` swapped; bogus/foreign teamId answered 201; the eligibility listing offered the member as reviewer.
- Platform `tsc --noEmit` and `oxlint --type-aware`: clean.

## Behaviour changes to be aware of

- A review already assigned to a member-role reviewer (possible only via the old API hole) can no longer be answered by that member; re-submitting designates an eligible reviewer (newest submission supersedes).
- An automation whose report was marked controlled (even a draft) no longer refreshes it in place — the record lifecycle owns those bytes; the run surfaces `DOCUMENT_RECORD_REPLACEMENT_REQUIRED`.
- REST DELETE now also writes the `document.deleted` audit row and stops a 1:1 OneDrive sync, like the session path.

## Cross-class discoveries (not fixed here)

- **knowledge_entries has the same write-matrix hole**: `/api/app/knowledge-entries` and the REST knowledge-entry mutations mount only session+org-member, and the service takes no role — a read-only member can create/update/delete entries, which materialize `app.documents` rows (`source_provider: 'knowledge'`). The UI hides these behind `knowledgeWrite`. Left out: separate module, and `createKnowledgeEntry` also serves a chat-lane caller whose authority model needs its own decision.
- The core guard (`assertGenericDocumentContentWritable`) treats a malformed `record` json as frozen (fail closed) while `parseControlledRecord` treats it as uncontrolled; the new json twin follows the core fail-closed stance. Only unreachable states differ — the records flow never writes malformed json.
