### PR TITLE
fix(platform): clear undo draft when the message editor remounts

### DIFF
--- a/services/platform/app/features/conversations/components/conversation-panel.tsx
+++ b/services/platform/app/features/conversations/components/conversation-panel.tsx
@@ -143,6 +143,8 @@ export function ConversationPanel({
 
   // Draft handed back by an undo-send: seeds the composer's pendingMessage so
   // the message the user just cancelled reappears exactly as they wrote it.
+  // Cleared via MessageEditor.onPendingMessageConsumed on a successful resend
+  // (same turn as the editor remount) so the remount cannot re-seed from it.
   const [restoredDraft, setRestoredDraft] = useState<
     { id: string; content: string } | undefined
   >(undefined);
@@ -212,11 +214,6 @@ export function ConversationPanel({
     if (!conversation) {
       return;
     }
-
-    // A previous undo's draft has served its purpose the moment a new send
-    // goes out — dropping it keeps the editor's re-seed effect from restoring
-    // stale content after this send clears the composer.
-    setRestoredDraft(undefined);
 
     let uploadedAttachments:
       | Array<{
@@ -670,6 +667,7 @@ export function ConversationPanel({
                     onSelectedConversationChange(null);
                   }}
                   pendingMessage={restoredDraft ?? pendingMessage}
+                  onPendingMessageConsumed={() => setRestoredDraft(undefined)}
                   hasMessageHistory={displayMessages.length > 0}
                   organizationId={conversation.organizationId}
                 />

--- a/services/platform/app/features/conversations/components/message-editor.test.tsx
+++ b/services/platform/app/features/conversations/components/message-editor.test.tsx
@@ -188,6 +188,49 @@ describe('MessageEditor', () => {
     expect(renderCount).toBe(initialCount);
   });
 
+  it('notifies onPendingMessageConsumed before remount on successful send', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onPendingMessageConsumed = vi.fn();
+
+    render(
+      <MessageEditor
+        onSave={onSave}
+        organizationId="org_test"
+        pendingMessage={{ id: 'msg_1', content: 'restored draft' }}
+        onPendingMessageConsumed={onPendingMessageConsumed}
+      />,
+    );
+
+    const countBefore = renderCount;
+
+    await act(async () => {
+      capturedOnSend?.();
+    });
+
+    expect(onPendingMessageConsumed).toHaveBeenCalledTimes(1);
+    expect(renderCount).toBeGreaterThan(countBefore);
+  });
+
+  it('does not consume pendingMessage when send fails', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('Send failed'));
+    const onPendingMessageConsumed = vi.fn();
+
+    render(
+      <MessageEditor
+        onSave={onSave}
+        organizationId="org_test"
+        pendingMessage={{ id: 'msg_1', content: 'restored draft' }}
+        onPendingMessageConsumed={onPendingMessageConsumed}
+      />,
+    );
+
+    await act(async () => {
+      capturedOnSend?.();
+    });
+
+    expect(onPendingMessageConsumed).not.toHaveBeenCalled();
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<MessageEditor organizationId="org_test" />);

--- a/services/platform/app/features/conversations/components/message-editor.tsx
+++ b/services/platform/app/features/conversations/components/message-editor.tsx
@@ -57,9 +57,11 @@ function MilkdownEditorInner({
 
   const editorPlaceholder = placeholder || tConversations('messagePlaceholder');
   const draftKeys = messageDraftKeys(user?.userId, messageId);
+  // Empty string — never `pendingMessage.content`. `clear()` resets to this
+  // initial value; tying it to the undo draft would put the draft back on clear.
   const [message, setMessage, clearMessage] = usePersistedState(
     draftKeys.body,
-    pendingMessage?.content || '',
+    '',
   );
   const [improveInstruction, setImproveInstruction, clearImproveInstruction] =
     usePersistedState(draftKeys.improveInstruction, '');
@@ -81,6 +83,10 @@ function MilkdownEditorInner({
   );
 
   const crepeRef = useRef<Crepe | null>(null);
+  // Seed from pending only when the pending payload changes — not when the
+  // body is cleared after send (that used to re-write the undo draft into
+  // localStorage right before remount).
+  const appliedPendingKeyRef = useRef<string | null>(null);
 
   useEditor(
     (root) => {
@@ -121,14 +127,21 @@ function MilkdownEditorInner({
     }
   }, [programmaticContent, isLoading]);
 
+  const pendingId = pendingMessage?.id;
+  const pendingContent = pendingMessage?.content ?? '';
+
   useEffect(() => {
-    const pending = pendingMessage?.content ?? '';
-    if (!message.trim() && pending.trim()) {
-      setMessage(pending);
-      setProgrammaticContent(pending);
-      setHasContent(true);
+    if (!pendingContent.trim()) {
+      appliedPendingKeyRef.current = null;
+      return;
     }
-  }, [pendingMessage, message, setMessage]);
+    const applyKey = `${pendingId ?? ''}:${pendingContent}`;
+    if (appliedPendingKeyRef.current === applyKey) return;
+    appliedPendingKeyRef.current = applyKey;
+    setMessage(pendingContent);
+    setProgrammaticContent(pendingContent);
+    setHasContent(true);
+  }, [pendingId, pendingContent, setMessage]);
 
   const handleOpenInstructionTextarea = useCallback(() => {
     setSavedEditorContent(message);
@@ -398,10 +411,14 @@ function MilkdownEditorInner({
 
 export function MessageEditor(props: MessageEditorProps) {
   const [editorKey, setEditorKey] = useState(0);
+  const { onPendingMessageConsumed } = props;
 
   const handleMessageSent = useCallback(() => {
+    // Clear the undo seed in the same synchronous turn as the remount so
+    // React batches them: the new editor mounts without `pendingMessage`.
+    onPendingMessageConsumed?.();
     setEditorKey((k) => k + 1);
-  }, []);
+  }, [onPendingMessageConsumed]);
 
   return (
     <MilkdownProvider key={editorKey}>

--- a/services/platform/app/features/conversations/components/message-editor/types.tsx
+++ b/services/platform/app/features/conversations/components/message-editor/types.tsx
@@ -26,6 +26,14 @@ export interface MessageEditorProps {
   conversationId?: string;
   onConversationResolved?: () => void;
   pendingMessage?: Pick<ConversationMessage, 'id' | 'content'>;
+  /**
+   * Fired on a successful send, before the editor remounts. Callers that seed
+   * via `pendingMessage` (undo-send restore) must clear that seed here so the
+   * remount does not re-initialize from a still-present draft — send runs
+   * inside `startTransition`, so clearing the seed at send-start can lag the
+   * remount.
+   */
+  onPendingMessageConsumed?: () => void;
   hasMessageHistory?: boolean;
   organizationId: string;
 }


### PR DESCRIPTION
## Summary
- Clear the undo-send restored draft via `onPendingMessageConsumed` in the same turn as the editor remount so a successful resend cannot re-seed the composer.
- Stop seeding the persisted body from `pendingMessage.content` as the initial `usePersistedState` value (that put the draft back on clear).

## Test plan
- [ ] `bun run --filter @tale/platform test:ui -- app/features/conversations/components/message-editor.test.tsx`
- [ ] Reply in a conversation, undo within the window, edit, send — composer stays empty after send
- [ ] Undo, then fail a send — draft remains for retry