### PR TITLE
feat(platform): assign a team queue when composing email

### DIFF
--- a/services/platform/app/features/conversations/components/compose-email-pane.tsx
+++ b/services/platform/app/features/conversations/components/compose-email-pane.tsx
@@ -4,8 +4,14 @@ import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { Center, Row, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { Loader2Icon, Trash2Icon } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Check,
+  ChevronDown,
+  Loader2Icon,
+  Trash2Icon,
+  Users,
+} from 'lucide-react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
 import { PanelFooter } from '@/app/components/layout/panel-footer';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -14,13 +20,16 @@ import {
   SearchableSelect,
   type SearchableSelectOption,
 } from '@/app/components/ui/forms/searchable-select';
+import { selectTriggerClasses } from '@/app/components/ui/forms/select';
 import { useMembers } from '@/app/features/settings/organization/hooks/queries';
+import { useOrgTeams } from '@/app/features/settings/teams/hooks/queries';
 import { AssigneeAvatar } from '@/app/features/tasks/components/assignee-avatar';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { useAuth } from '@/app/hooks/use-session-user';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
 import { lazyComponent } from '@/lib/utils/lazy-component';
 
 import {
@@ -49,6 +58,13 @@ const MessageEditor = lazyComponent(
     ),
   },
 );
+
+/** Prefixes / sentinels for the dual-dimension assign picker (person + team). */
+const USER_PREFIX = 'user:';
+const TEAM_PREFIX = 'team:';
+const PEOPLE_HEADER = '__people_header__';
+const TEAM_HEADER = '__team_header__';
+const UNASSIGN_TEAM = '__unassign_team__';
 
 /**
  * Build the full sender from an edited local part + the inbox's fixed domain.
@@ -101,6 +117,7 @@ export function ComposeEmailPane({
 }: ComposeEmailPaneProps) {
   const { t } = useT('conversations');
   const { user } = useAuth();
+  const assignTriggerId = useId();
   const { emailConnectors, isLoading: connectorsLoading } =
     useEmailConnectors(organizationId);
   const { mutateAsync: composeEmail } = useComposeEmailConversation();
@@ -125,12 +142,16 @@ export function ComposeEmailPane({
   );
   const [assigneeUserId, setAssigneeUserId, clearAssigneeUserId] =
     usePersistedState(`${draftPrefix}-assignee`, user?.userId ?? '');
+  const [assigneeTeamId, setAssigneeTeamId, clearAssigneeTeamId] =
+    usePersistedState(`${draftPrefix}-assignee-team`, '');
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+  const [assignOpen, setAssignOpen] = useState(false);
 
   // Default the assignee to the creator once auth resolves (a fresh draft has no
-  // stored value). Only admins can pick someone else; the field is read-only
-  // otherwise, and the server clamps a non-admin to self regardless.
+  // stored value). Only admins can pick someone else or a team; the field is
+  // read-only otherwise, and the server clamps a non-admin to self / no team.
   const { members = [] } = useMembers(organizationId);
+  const { teams = [] } = useOrgTeams();
   const { data: memberContext } = useCurrentMemberContext(organizationId);
   const canReassign =
     !!memberContext &&
@@ -140,22 +161,62 @@ export function ComposeEmailPane({
     if (!assigneeUserId && user?.userId) setAssigneeUserId(user.userId);
   }, [assigneeUserId, user?.userId, setAssigneeUserId]);
 
+  const assignee = members.find((m) => m.userId === assigneeUserId);
+  const assigneeName =
+    assignee?.displayName ?? assignee?.email ?? assigneeUserId;
+  const team = teams.find((tm) => tm.id === assigneeTeamId);
+  const teamName = team?.name;
+
+  // Shared-inbox model: person owner and team queue are independent. Trigger
+  // shows both when both are set (team · person), matching the header picker.
+  const assignTriggerLabel = useMemo(() => {
+    const parts: string[] = [];
+    if (teamName) parts.push(teamName);
+    if (assigneeName) parts.push(assigneeName);
+    return parts.length > 0 ? parts.join(' · ') : null;
+  }, [teamName, assigneeName]);
+
   const assigneeOptions = useMemo<SearchableSelectOption[]>(() => {
-    const sorted = [...members].sort((a, b) =>
-      a.userId === user?.userId ? -1 : b.userId === user?.userId ? 1 : 0,
-    );
-    return sorted.map((member) => ({
-      value: member.userId,
-      label: member.displayName ?? member.email ?? member.userId,
-      description: member.userId === user?.userId ? undefined : member.email,
-      labelBadge:
-        member.userId === user?.userId ? (
-          <Badge variant="outline" className="text-[10px]">
-            {t('compose.assignYou')}
-          </Badge>
-        ) : undefined,
-    }));
-  }, [members, user?.userId, t]);
+    const options: SearchableSelectOption[] = [];
+    if (members.length > 0) {
+      options.push({
+        value: PEOPLE_HEADER,
+        label: t('header.peopleSection'),
+        isSectionHeader: true,
+      });
+      const sorted = [...members].sort((a, b) =>
+        a.userId === user?.userId ? -1 : b.userId === user?.userId ? 1 : 0,
+      );
+      for (const member of sorted) {
+        options.push({
+          value: `${USER_PREFIX}${member.userId}`,
+          label: member.displayName ?? member.email ?? member.userId,
+          description:
+            member.userId === user?.userId ? undefined : member.email,
+          labelBadge:
+            member.userId === user?.userId ? (
+              <Badge variant="outline" className="text-[10px]">
+                {t('compose.assignYou')}
+              </Badge>
+            ) : undefined,
+        });
+      }
+    }
+    if (teams.length > 0) {
+      options.push({
+        value: TEAM_HEADER,
+        label: t('header.teamsSection'),
+        isSectionHeader: true,
+      });
+      for (const tm of teams) {
+        options.push({
+          value: `${TEAM_PREFIX}${tm.id}`,
+          label: tm.name,
+        });
+      }
+    }
+    return options;
+  }, [members, teams, user?.userId, t]);
 
   // Seeded recipient (from a contact row) wins over a restored draft contact.
   useEffect(() => {
@@ -214,13 +275,35 @@ export function ComposeEmailPane({
     clearSenderAddress();
     clearSubject();
     clearAssigneeUserId();
+    clearAssigneeTeamId();
   }, [
     clearContactId,
     clearConnectorName,
     clearSenderAddress,
     clearSubject,
     clearAssigneeUserId,
+    clearAssigneeTeamId,
   ]);
+
+  const handleAssignChange = (value: string) => {
+    if (value === PEOPLE_HEADER || value === TEAM_HEADER) return;
+    if (value === UNASSIGN_TEAM) {
+      clearAssigneeTeamId();
+      setAssignOpen(false);
+      return;
+    }
+    if (value.startsWith(USER_PREFIX)) {
+      const next = value.slice(USER_PREFIX.length);
+      if (next !== assigneeUserId) setAssigneeUserId(next);
+      setAssignOpen(false);
+      return;
+    }
+    if (value.startsWith(TEAM_PREFIX)) {
+      const next = value.slice(TEAM_PREFIX.length);
+      if (next !== assigneeTeamId) setAssigneeTeamId(next);
+      setAssignOpen(false);
+    }
+  };
 
   const discardDraft = useCallback(() => {
     clearDraftFields();
@@ -292,6 +375,7 @@ export function ComposeEmailPane({
         content: message,
         ...(sourceMarkdown ? { sourceMarkdown } : {}),
         ...(assigneeUserId ? { assigneeUserId } : {}),
+        ...(assigneeTeamId ? { assigneeTeamId } : {}),
         ...(dynamicSender && effectiveSender ? { from: effectiveSender } : {}),
         ...(uploaded?.length ? { attachments: uploaded } : {}),
       });
@@ -345,21 +429,85 @@ export function ComposeEmailPane({
 
               <SearchableSelect
                 label={t('compose.assignLabel')}
-                value={assigneeUserId || null}
-                onValueChange={setAssigneeUserId}
+                id={assignTriggerId}
+                // Two dimensions can be selected at once, so there is no single
+                // controlled value — current picks are marked via optionAction.
+                value={null}
+                onValueChange={handleAssignChange}
                 options={assigneeOptions}
                 disabled={!canReassign}
+                open={assignOpen}
+                onOpenChange={setAssignOpen}
                 placeholder={t('compose.assignPlaceholder')}
                 searchPlaceholder={t('compose.assignSearch')}
-                emptyText={t('header.noMembers')}
+                emptyText={t('header.noAssignees')}
                 aria-label={t('compose.assignLabel')}
-                optionAction={(opt) => (
-                  <AssigneeAvatar
-                    assigneeType="user"
-                    assigneeId={opt.value}
-                    name={opt.label}
-                  />
-                )}
+                trigger={
+                  <button
+                    type="button"
+                    id={assignTriggerId}
+                    disabled={!canReassign}
+                    className={selectTriggerClasses()}
+                  >
+                    <span
+                      className={cn(
+                        'truncate',
+                        !assignTriggerLabel && 'text-muted-foreground',
+                      )}
+                    >
+                      {assignTriggerLabel ?? t('compose.assignPlaceholder')}
+                    </span>
+                    <ChevronDown
+                      className="size-4 shrink-0 opacity-50"
+                      aria-hidden="true"
+                    />
+                  </button>
+                }
+                optionAction={(opt) => {
+                  if (opt.value.startsWith(USER_PREFIX)) {
+                    const uid = opt.value.slice(USER_PREFIX.length);
+                    return (
+                      <span className="flex items-center gap-1.5">
+                        {assigneeUserId === uid && (
+                          <Check className="text-primary size-4 shrink-0" />
+                        )}
+                        <AssigneeAvatar
+                          assigneeType="user"
+                          assigneeId={uid}
+                          name={opt.label}
+                        />
+                      </span>
+                    );
+                  }
+                  if (opt.value.startsWith(TEAM_PREFIX)) {
+                    const tid = opt.value.slice(TEAM_PREFIX.length);
+                    return (
+                      <span className="flex items-center gap-1.5">
+                        {assigneeTeamId === tid && (
+                          <Check className="text-primary size-4 shrink-0" />
+                        )}
+                        <Users
+                          className="text-muted-foreground size-4 shrink-0"
+                          aria-hidden="true"
+                        />
+                      </span>
+                    );
+                  }
+                  return null;
+                }}
+                footer={
+                  assigneeTeamId ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="w-full justify-start"
+                      onClick={() => handleAssignChange(UNASSIGN_TEAM)}
+                    >
+                      {t('header.unassignTeam')}
+                    </Button>
+                  ) : undefined
+                }
               />
 
               <Input

--- a/services/platform/app/lib/backend/contract/conversations.ts
+++ b/services/platform/app/lib/backend/contract/conversations.ts
@@ -67,6 +67,7 @@ export interface ConversationsContract {
         contentType: string;
       }>;
       assigneeUserId?: string;
+      assigneeTeamId?: string;
       from?: string;
       sourceMarkdown?: string;
       organizationId: string;

--- a/services/platform/app/lib/backend/conversations.ts
+++ b/services/platform/app/lib/backend/conversations.ts
@@ -241,6 +241,9 @@ export const conversationWriteAdapters: Record<string, WriteAdapter> = {
           ...(typeof args.assigneeUserId === 'string'
             ? { assigneeUserId: args.assigneeUserId }
             : {}),
+          ...(typeof args.assigneeTeamId === 'string'
+            ? { assigneeTeamId: args.assigneeTeamId }
+            : {}),
           ...(Array.isArray(args.attachments)
             ? { attachments: args.attachments }
             : {}),

--- a/services/platform/backend/domains/conversations/compose-assignment.test.ts
+++ b/services/platform/backend/domains/conversations/compose-assignment.test.ts
@@ -1,0 +1,74 @@
+import type { Sql } from 'postgres';
+import { describe, expect, test } from 'vitest';
+
+import { resolveComposeAssignment } from './send.ts';
+import { ConversationError } from './service.ts';
+
+/** A `sql` stand-in that answers every tagged-template query with `rows`. */
+function fakeSql(rows: unknown[]): Sql {
+  const tag = (..._args: unknown[]) => Promise.resolve(rows);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double
+  return Object.assign(tag, {
+    unsafe: (text: string) => text,
+  }) as unknown as Sql;
+}
+
+describe('resolveComposeAssignment', () => {
+  test('defaults the assignee to the actor', async () => {
+    const result = await resolveComposeAssignment(fakeSql([]), {
+      organizationId: 'org_1',
+      actor: { userId: 'user_self', role: 'member' },
+    });
+    expect(result).toEqual({ assigneeUserId: 'user_self' });
+  });
+
+  test('an admin may assign another member and a team in-org', async () => {
+    const result = await resolveComposeAssignment(
+      fakeSql([{ organizationId: 'org_1' }]),
+      {
+        organizationId: 'org_1',
+        assigneeUserId: 'user_other',
+        assigneeTeamId: 'team_1',
+        actor: { userId: 'user_admin', role: 'admin' },
+      },
+    );
+    expect(result).toEqual({
+      assigneeUserId: 'user_other',
+      assigneeTeamId: 'team_1',
+    });
+  });
+
+  test('a non-admin team pick is dropped (person clamped to self)', async () => {
+    // Team query must not run — empty rows would otherwise look like not-in-org.
+    const result = await resolveComposeAssignment(fakeSql([]), {
+      organizationId: 'org_1',
+      assigneeUserId: 'user_other',
+      assigneeTeamId: 'team_1',
+      actor: { userId: 'user_member', role: 'member' },
+    });
+    expect(result).toEqual({ assigneeUserId: 'user_member' });
+    expect(result).not.toHaveProperty('assigneeTeamId');
+  });
+
+  test('rejects a team that is not in the organization', async () => {
+    await expect(
+      resolveComposeAssignment(fakeSql([{ organizationId: 'org_other' }]), {
+        organizationId: 'org_1',
+        assigneeTeamId: 'team_foreign',
+        actor: { userId: 'user_admin', role: 'owner' },
+      }),
+    ).rejects.toMatchObject({
+      code: 'team_not_in_org',
+    } satisfies Partial<ConversationError>);
+  });
+
+  test('rejects a missing team the same as a foreign team', async () => {
+    await expect(
+      resolveComposeAssignment(fakeSql([]), {
+        organizationId: 'org_1',
+        assigneeTeamId: 'team_gone',
+        actor: { userId: 'user_admin', role: 'admin' },
+      }),
+    ).rejects.toBeInstanceOf(ConversationError);
+  });
+});

--- a/services/platform/backend/domains/conversations/create-conversation.test.ts
+++ b/services/platform/backend/domains/conversations/create-conversation.test.ts
@@ -1,0 +1,79 @@
+import type { TransactionSql } from 'postgres';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../../realtime/outbox.ts', () => ({
+  emitHintInTx: vi.fn(async () => undefined),
+}));
+vi.mock('../events/emit.ts', () => ({
+  emitEvent: vi.fn(async () => undefined),
+}));
+
+import { createConversation } from './service.ts';
+
+type InsertCapture = {
+  query: string;
+  values: unknown[];
+};
+
+function fakeTx(capture: InsertCapture[]): TransactionSql {
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.join('?');
+    if (query.includes('INSERT INTO app.conversations')) {
+      capture.push({ query, values });
+      return Promise.resolve([{ id: 'conv_test' }]);
+    }
+    return Promise.resolve([]);
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double
+  return Object.assign(tag, {
+    json: (value: unknown) => value,
+    unsafe: (text: string) => text,
+  }) as unknown as TransactionSql;
+}
+
+describe('createConversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('persists assigneeUserId and assigneeTeamId on insert', async () => {
+    const capture: InsertCapture[] = [];
+    const id = await createConversation(fakeTx(capture), {
+      organizationId: 'org_1',
+      contactId: 'contact_1',
+      assigneeUserId: 'user_1',
+      assigneeTeamId: 'team_1',
+      subject: 'Hello',
+      status: 'open',
+      channel: 'email',
+      direction: 'outbound',
+      connectorName: 'imap-smtp',
+    });
+    expect(id).toBe('conv_test');
+    expect(capture).toHaveLength(1);
+    const inserted = capture[0];
+    expect(inserted?.query).toContain('assignee_team_id');
+    // VALUES order: org, contact, assignee_user, assignee_team, …
+    expect(inserted?.values.slice(0, 4)).toEqual([
+      'org_1',
+      'contact_1',
+      'user_1',
+      'team_1',
+    ]);
+  });
+
+  test('stores null team when assigneeTeamId is omitted', async () => {
+    const capture: InsertCapture[] = [];
+    await createConversation(fakeTx(capture), {
+      organizationId: 'org_1',
+      assigneeUserId: 'user_1',
+      subject: 'Solo',
+    });
+    expect(capture[0]?.values.slice(0, 4)).toEqual([
+      'org_1',
+      null,
+      'user_1',
+      null,
+    ]);
+  });
+});

--- a/services/platform/backend/domains/conversations/routes.ts
+++ b/services/platform/backend/domains/conversations/routes.ts
@@ -355,6 +355,7 @@ export function createConversationRoutes(deps: {
         sourceMarkdown: z.string().max(200_000).optional(),
         from: z.string().max(320).optional(),
         assigneeUserId: z.string().max(128).optional(),
+        assigneeTeamId: z.string().max(128).optional(),
         attachments: z.array(attachmentSchema).max(50).optional(),
       })
       .safeParse(await c.req.json());
@@ -372,6 +373,9 @@ export function createConversationRoutes(deps: {
         ...(body.data.from !== undefined ? { from: body.data.from } : {}),
         ...(body.data.assigneeUserId !== undefined
           ? { assigneeUserId: body.data.assigneeUserId }
+          : {}),
+        ...(body.data.assigneeTeamId !== undefined
+          ? { assigneeTeamId: body.data.assigneeTeamId }
           : {}),
         ...(body.data.attachments?.length
           ? { attachments: body.data.attachments }

--- a/services/platform/backend/domains/conversations/send.ts
+++ b/services/platform/backend/domains/conversations/send.ts
@@ -27,6 +27,7 @@ import {
   ConversationError,
   createConversation,
   MESSAGE_COLUMNS,
+  viewerIsAdmin,
   type BulkOperationResult,
   type ConversationMessageRow,
   type ConversationRow,
@@ -506,19 +507,57 @@ export async function bulkReplyToConversations(
   };
 }
 
+/**
+ * Resolve who owns a newly composed outbound conversation.
+ *
+ * Defaults to the creator; only an admin may pick another member or a team
+ * queue. Non-admin team requests are dropped (not rejected). A team must
+ * belong to the org or we throw `team_not_in_org`.
+ */
+export async function resolveComposeAssignment(
+  sql: Sql,
+  args: {
+    organizationId: string;
+    assigneeUserId?: string;
+    assigneeTeamId?: string;
+    actor: { userId: string; role: string };
+  },
+): Promise<{ assigneeUserId: string; assigneeTeamId?: string }> {
+  const isAdmin = viewerIsAdmin(args.actor.role);
+  const assigneeUserId = isAdmin
+    ? (args.assigneeUserId ?? args.actor.userId)
+    : args.actor.userId;
+  if (!(isAdmin && args.assigneeTeamId)) {
+    return { assigneeUserId };
+  }
+  const teams = await sql<{ organizationId: string }[]>`
+    SELECT "organizationId" FROM "team" WHERE "id" = ${args.assigneeTeamId}
+    LIMIT 1
+  `;
+  if (teams[0]?.organizationId !== args.organizationId) {
+    throw new ConversationError(
+      'team_not_in_org',
+      'Team does not belong to this organization',
+    );
+  }
+  return { assigneeUserId, assigneeTeamId: args.assigneeTeamId };
+}
+
 export async function composeEmailConversation(
   sql: Sql,
   args: {
     organizationId: string;
     contactId: string;
     assigneeUserId?: string;
+    /** Team queue. Admin-only; validated in-org. Non-admin requests are dropped. */
+    assigneeTeamId?: string;
     connectorName: string;
     subject: string;
     content: string;
     sourceMarkdown?: string;
     from?: string;
     attachments?: SendAttachment[];
-    actor: { userId: string; email?: string };
+    actor: { userId: string; email?: string; role: string };
   },
 ): Promise<{ conversationId: string; messageId: string }> {
   const subject = args.subject.trim();
@@ -555,14 +594,28 @@ export async function composeEmailConversation(
   // Refuse over-cap attachments BEFORE creating the conversation — the 0.4
   // compose is one atomic mutation, so a cap denial must leave nothing.
   validateConversationAttachmentCaps(args.attachments);
+
+  const { assigneeUserId, assigneeTeamId } = await resolveComposeAssignment(
+    sql,
+    {
+      organizationId: args.organizationId,
+      actor: args.actor,
+      ...(args.assigneeUserId !== undefined
+        ? { assigneeUserId: args.assigneeUserId }
+        : {}),
+      ...(args.assigneeTeamId !== undefined
+        ? { assigneeTeamId: args.assigneeTeamId }
+        : {}),
+    },
+  );
+
   const chosenFrom = args.from?.trim();
   const conversationId = await sql.begin((tx) =>
     createConversation(tx, {
       organizationId: args.organizationId,
       contactId: args.contactId,
-      ...(args.assigneeUserId !== undefined
-        ? { assigneeUserId: args.assigneeUserId }
-        : {}),
+      assigneeUserId,
+      ...(assigneeTeamId !== undefined ? { assigneeTeamId } : {}),
       subject,
       status: 'open',
       channel: 'email',

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -163,6 +163,8 @@ export interface CreateConversationArgs {
   organizationId: string;
   contactId?: string;
   assigneeUserId?: string;
+  /** Team queue (Better Auth teamId). May sit alongside assigneeUserId. */
+  assigneeTeamId?: string;
   externalMessageId?: string;
   subject?: string;
   status?: ConversationStatus;
@@ -181,12 +183,13 @@ export async function createConversation(
   const now = Date.now();
   const inserted = await tx<{ id: string }[]>`
     INSERT INTO app.conversations (
-      org_id, contact_id, assignee_user_id, external_message_id, subject,
-      status, priority, type, channel, direction, connector_name, metadata,
-      created_at_ms
+      org_id, contact_id, assignee_user_id, assignee_team_id, external_message_id,
+      subject, status, priority, type, channel, direction, connector_name,
+      metadata, created_at_ms
     ) VALUES (
       ${args.organizationId}, ${args.contactId ?? null},
-      ${args.assigneeUserId ?? null}, ${args.externalMessageId ?? null},
+      ${args.assigneeUserId ?? null}, ${args.assigneeTeamId ?? null},
+      ${args.externalMessageId ?? null},
       ${args.subject ?? null}, ${args.status ?? 'open'},
       ${args.priority ?? null}, ${args.type ?? null}, ${args.channel ?? null},
       ${args.direction ?? null}, ${args.connectorName ?? null},

--- a/services/platform/backend/domains/conversations/shim.ts
+++ b/services/platform/backend/domains/conversations/shim.ts
@@ -246,13 +246,6 @@ export function conversationShimHandlers(
       return sql.begin(async (tx) => {
         const { initialMessage, ...conversationArgs } = args;
         const conversationId = await createConversation(tx, conversationArgs);
-        if (args.assigneeTeamId !== undefined) {
-          await tx`
-            UPDATE app.conversations
-            SET assignee_team_id = ${args.assigneeTeamId}
-            WHERE id = ${conversationId}
-          `;
-        }
         const { messageId } = await addMessageToConversation(tx, {
           conversationId,
           organizationId: args.organizationId,

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1799,7 +1799,6 @@ conversations:
     assignee: Zuständig
     assign: Zuweisen
     assignedTo: 'Zuständig: {name}'
-    noMembers: Keine Mitglieder gefunden
     unassign: Zuweisung aufheben
     assignError: Zuständigkeit konnte nicht aktualisiert werden
     inboxSource: 'Postfach: {inbox}'

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1739,8 +1739,8 @@ conversations:
     subject: Betreff
     subjectPlaceholder: Worum geht es?
     assignLabel: Zuständig
-    assignPlaceholder: Mitglied auswählen
-    assignSearch: Mitglieder suchen
+    assignPlaceholder: Person oder Team wählen
+    assignSearch: Personen und Teams suchen
     assignYou: Du
     bodyPlaceholder: Schreib deine Nachricht…
     fillRequired: Wähle einen Kontakt, ein Postfach und einen Betreff, um zu senden.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1692,8 +1692,8 @@ conversations:
     subject: Subject
     subjectPlaceholder: What's this about?
     assignLabel: Assign to
-    assignPlaceholder: Choose a member
-    assignSearch: Search members
+    assignPlaceholder: Choose a person or team
+    assignSearch: Search people and teams
     assignYou: You
     bodyPlaceholder: Write your message…
     fillRequired: Choose a contact, an inbox, and a subject to send.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1742,7 +1742,6 @@ conversations:
     assignee: Assignee
     assign: Assign
     assignedTo: Assigned to {name}
-    noMembers: No members found
     unassign: Unassign
     assignError: Couldn't update the assignee
     inboxSource: 'Inbox: {inbox}'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1811,7 +1811,6 @@ conversations:
     assignee: Responsable
     assign: Assigner
     assignedTo: Attribué à {name}
-    noMembers: Aucun membre trouvé
     unassign: Retirer l'attribution
     assignError: Impossible de mettre à jour le responsable
     inboxSource: 'Boîte de réception : {inbox}'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1753,8 +1753,8 @@ conversations:
     subject: Objet
     subjectPlaceholder: De quoi s'agit-il ?
     assignLabel: Responsable
-    assignPlaceholder: Choisir un membre
-    assignSearch: Rechercher des membres
+    assignPlaceholder: Choisir une personne ou une équipe
+    assignSearch: Rechercher des personnes et des équipes
     assignYou: Toi
     bodyPlaceholder: Écris ton message…
     fillRequired: Choisis un contact, une boîte et un objet pour envoyer.


### PR DESCRIPTION
## Summary
- Compose email can assign a person and/or team queue (admins only), matching the inbox header picker.
- Postgres path: client adapter + `/compose` + `resolveComposeAssignment` (admin clamp, in-org team check) + `createConversation` writes `assignee_team_id`.
- Adds unit tests for compose assignment and createConversation team insert.

## Test plan
- [ ] `bun run --filter @tale/platform test -- backend/domains/conversations/compose-assignment.test.ts backend/domains/conversations/create-conversation.test.ts`
- [ ] As admin: compose a new email, pick a team (+ optional person), send — conversation shows the team queue
- [ ] As member: team options are not offered / server drops a forged `assigneeTeamId`
- [ ] Foreign `assigneeTeamId` returns `team_not_in_org`