### PR TITLE
fix(platform): purge corpus, blobs, and retrievability consistently

### DIFF
--- a/services/platform/backend/auth/access.test.ts
+++ b/services/platform/backend/auth/access.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { authorizeRls } from './access.ts';
+
+/**
+ * The `knowledge` subject: knowledge entries materialize documents rows and
+ * feed the RAG corpus, so their write grant mirrors `documents` — editor
+ * and up write, member reads, disabled nothing.
+ */
+describe('authorizeRls knowledge subject', () => {
+  it('grants write to owner/admin/developer/editor', () => {
+    for (const role of ['owner', 'admin', 'developer', 'editor']) {
+      expect(authorizeRls(role, 'knowledge', 'read')).toBe(true);
+      expect(authorizeRls(role, 'knowledge', 'write')).toBe(true);
+    }
+  });
+
+  it('keeps member read-only and disabled shut out', () => {
+    expect(authorizeRls('member', 'knowledge', 'read')).toBe(true);
+    expect(authorizeRls('member', 'knowledge', 'write')).toBe(false);
+    expect(authorizeRls('disabled', 'knowledge', 'read')).toBe(false);
+    expect(authorizeRls('disabled', 'knowledge', 'write')).toBe(false);
+  });
+
+  it('degrades unknown or missing roles to member', () => {
+    expect(authorizeRls(undefined, 'knowledge', 'write')).toBe(false);
+    expect(authorizeRls('intruder', 'knowledge', 'write')).toBe(false);
+    expect(authorizeRls('intruder', 'knowledge', 'read')).toBe(true);
+  });
+});

--- a/services/platform/backend/auth/access.ts
+++ b/services/platform/backend/auth/access.ts
@@ -15,6 +15,10 @@ import {
 const platformResourceStatements = {
   agents: ['read', 'write'],
   documents: ['read', 'write'],
+  // Knowledge entries (topic-keyed facts feeding the RAG corpus) — content-
+  // shaped like `documents`, whose rows they materialize: editor and up
+  // write, member reads, disabled nothing (all via `uniformGrants`).
+  knowledge: ['read', 'write'],
   products: ['read', 'write'],
   projects: ['read', 'write'],
   contacts: ['read', 'write'],
@@ -49,6 +53,7 @@ function uniformGrants(
   return {
     agents: [...actions],
     documents: [...actions],
+    knowledge: [...actions],
     products: [...actions],
     projects: [...actions],
     contacts: [...actions],

--- a/services/platform/backend/core/legacy/knowledge_delete.ts
+++ b/services/platform/backend/core/legacy/knowledge_delete.ts
@@ -320,3 +320,76 @@ export interface DeleteDocumentsBatchResult {
   deleted_count: number;
   failed_file_ids: string[];
 }
+
+/**
+ * Delete MANY corpus documents over one connection — the batch twin of
+ * `deleteKnowledgeDocument`, with the same idempotent-on-missing semantics
+ * per ref. The ref-release seam (`domains/knowledge/release.ts`) drives it
+ * for purge cascades and the reconcile sweep, where a connection per ref
+ * would be pure overhead. All-or-nothing per call: a thrown connection
+ * error means NO ref was acknowledged (the two deletes run in one
+ * transaction), so callers retry the whole batch safely.
+ */
+export async function deleteKnowledgeDocumentsBatch(
+  args: DeleteDocumentsBatchArgs,
+): Promise<DeleteDocumentsBatchResult> {
+  if (args.fileIds.length === 0) {
+    return { success: true, deleted_count: 0, failed_file_ids: [] };
+  }
+  const url = await resolveKnowledgeUrlForOrg(args.orgSlug);
+  const sql = postgres(url, { max: 1 });
+  try {
+    const rows = await sql.unsafe<{ id: string }[]>(
+      `SELECT id FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.documents WHERE org_slug = $1 AND file_id = ANY($2)`,
+      [args.orgSlug, args.fileIds],
+    );
+    if (rows.length === 0) {
+      return { success: true, deleted_count: 0, failed_file_ids: [] };
+    }
+    const idsToDelete = rows.map((row) => row.id);
+    await sql.begin(async (tx) => {
+      await tx.unsafe(
+        `DELETE FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.chunks WHERE org_slug = $1 AND document_id = ANY($2)`,
+        [args.orgSlug, idsToDelete],
+      );
+      await tx.unsafe(
+        `DELETE FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.documents WHERE org_slug = $1 AND id = ANY($2)`,
+        [args.orgSlug, idsToDelete],
+      );
+    });
+    return {
+      success: true,
+      deleted_count: idsToDelete.length,
+      failed_file_ids: [],
+    };
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Enumerate one page of an org's corpus documents by file ref (keyset on
+ * `file_id`) — the reconcile sweep's walk. Opens one connection per call,
+ * like the deletes above (a daily sweep, not a hot path).
+ */
+export async function listKnowledgeDocumentRefs(args: {
+  orgSlug: string;
+  afterFileId: string | null;
+  limit: number;
+}): Promise<string[]> {
+  const url = await resolveKnowledgeUrlForOrg(args.orgSlug);
+  const sql = postgres(url, { max: 1 });
+  try {
+    const rows = await sql.unsafe<{ fileId: string }[]>(
+      `SELECT DISTINCT file_id AS "fileId"
+         FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.documents
+        WHERE org_slug = $1 AND ($2::text IS NULL OR file_id > $2)
+        ORDER BY file_id ASC
+        LIMIT $3`,
+      [args.orgSlug, args.afterFileId, args.limit],
+    );
+    return rows.map((row) => row.fileId);
+  } finally {
+    await sql.end();
+  }
+}

--- a/services/platform/backend/db/migrations/0063_documents_history_files_gin.sql
+++ b/services/platform/backend/db/migrations/0063_documents_history_files_gin.sql
@@ -1,0 +1,12 @@
+-- 0.5 app migration 0063: GIN index over documents.history_files.
+--
+-- The ref-release seam (domains/knowledge/release.ts) decides whether a
+-- blob's BYTES may be deleted by asking "does any document still hold this
+-- ref — as its current file_ref OR inside its retained history?". The
+-- history probe is `history_files @> ARRAY[ref]`; without an index every
+-- purge, release job, and reconcile-sweep ref pays a sequential scan over
+-- app.documents. `documents_org_file_ref` (0011) already covers the current-
+-- ref probe; this GIN covers the history containment probe (the planner
+-- BitmapAnds it with the org btree).
+CREATE INDEX IF NOT EXISTS documents_history_files_gin
+  ON app.documents USING gin (history_files);

--- a/services/platform/backend/domains/documents/replacement.ts
+++ b/services/platform/backend/domains/documents/replacement.ts
@@ -764,6 +764,17 @@ async function bindReplacement(
   if (shouldIndex) {
     await addJobInTx(tx, 'rag.index_file', { fileId: fileMetadataId });
   }
+  if (previousFileRef !== null && previousFileRef !== intent.finalRef) {
+    // The corpus is keyed by blob ref, so the replaced version's rows must
+    // go dark now that the ref is history — otherwise the superseded
+    // content keeps answering RAG queries as if current. Bytes stay (the
+    // retained snapshot in `history_files` holds them); the durable job
+    // keeps network I/O out of this transaction and retries on failure.
+    await addJobInTx(tx, 'knowledge.release_refs', {
+      organizationId: intent.organizationId,
+      refs: [previousFileRef],
+    });
+  }
   await createAuditLog(tx, {
     organizationId: auth.organizationId,
     actorId: intent.actorUserId,

--- a/services/platform/backend/domains/knowledge/release.ts
+++ b/services/platform/backend/domains/knowledge/release.ts
@@ -1,0 +1,315 @@
+import type { Sql } from 'postgres';
+
+import {
+  deleteKnowledgeDocumentsBatch,
+  listKnowledgeDocumentRefs,
+} from '../../core/legacy/knowledge_delete.ts';
+import { parseBlobRef } from '../../core/lib/storage/blob_ref.ts';
+import { resolveObjectStore, s3DeleteObject } from '../../lib/object-store.ts';
+import { resolveOrgSlug } from '../../lib/org-config.ts';
+
+/**
+ * Ref release — THE shared seam for taking content out of circulation.
+ *
+ * The knowledge corpus is keyed by BLOB REF (`file_id` =
+ * `app.file_metadata.storage_ref` / `app.documents.file_ref`), so every
+ * lane that rotates a document's ref (controlled-record replacement,
+ * knowledge-entry re-materialize, WebDAV PUT-overwrite, cloud-sync update)
+ * or destroys a document (retention purge, user delete, folder cascade,
+ * erasure, sync prune) must answer the same two questions per ref:
+ *
+ *   1. corpus-liveness — may the corpus still hold rows for this ref?
+ *      Yes while ANY document row's CURRENT `file_ref` is the ref (any
+ *      lifecycle: a trashed document is restorable and the retrievability
+ *      filter hides it meanwhile), or a live UNBOUND file row holds it
+ *      (thread files, video-link transcripts). A ref that is only history
+ *      (`history_files`, a superseded replacement row) is corpus-dead: old
+ *      versions must not answer RAG queries.
+ *   2. blob-liveness — may the BYTES be deleted? Only when no document
+ *      (`file_ref` or `history_files` — retained controlled-record
+ *      snapshots need their bytes) and no live file row references the ref.
+ *      WebDAV COPY shares one blob ref across several document rows, so a
+ *      purge of one copy must never destroy the twin's bytes.
+ *
+ * `releaseRefs` applies both: de-index corpus rows for corpus-dead refs,
+ * delete bytes for blob-dead refs, and REPORT failures instead of
+ * swallowing them — a caller that deletes its rows anyway would turn a
+ * failed purge into a false "done".
+ *
+ * Rotation points enqueue the durable `knowledge.release_refs` job (network
+ * I/O never runs inside their transaction; pg-boss retries); purge lanes
+ * call `releaseRefs` synchronously and keep their rows on failure. The
+ * daily `knowledge.reconcile_corpus` sweep walks each org's corpus and
+ * releases every ref both predicates declare dead — the backstop that also
+ * heals historically stranded rows on existing deployments.
+ */
+
+export interface RefLiveness {
+  ref: string;
+  corpusLive: boolean;
+  blobLive: boolean;
+}
+
+export interface AssessArgs {
+  organizationId: string;
+  refs: string[];
+  /** A document being purged in the same operation — its own rows must not
+   * keep its refs alive. */
+  excludeDocumentId?: string;
+  /** A file row being swept in the same operation (temp-file sweep). */
+  excludeFileMetadataId?: string;
+}
+
+/** Both liveness verdicts for a set of refs, in one round trip. */
+export async function assessRefLiveness(
+  sql: Sql,
+  args: AssessArgs,
+): Promise<RefLiveness[]> {
+  if (args.refs.length === 0) return [];
+  const excludeDoc = args.excludeDocumentId ?? null;
+  const excludeFile = args.excludeFileMetadataId ?? null;
+  return sql<RefLiveness[]>`
+    SELECT r.ref AS ref,
+      (
+        EXISTS(
+          SELECT 1 FROM app.documents d
+          WHERE d.org_id = ${args.organizationId} AND d.file_ref = r.ref
+            AND (${excludeDoc}::text IS NULL OR d.id <> ${excludeDoc})
+        )
+        OR EXISTS(
+          SELECT 1 FROM app.file_metadata fm
+          WHERE fm.org_id = ${args.organizationId}
+            AND fm.storage_ref = r.ref
+            AND fm.document_id IS NULL
+            AND (fm.lifecycle_status IS NULL
+                 OR fm.lifecycle_status = 'active')
+            AND (${excludeFile}::text IS NULL OR fm.id <> ${excludeFile})
+        )
+      ) AS "corpusLive",
+      (
+        EXISTS(
+          SELECT 1 FROM app.documents d
+          WHERE d.org_id = ${args.organizationId}
+            AND (${excludeDoc}::text IS NULL OR d.id <> ${excludeDoc})
+            AND (d.file_ref = r.ref
+                 OR d.history_files @> ARRAY[r.ref])
+        )
+        OR EXISTS(
+          SELECT 1 FROM app.file_metadata fm
+          WHERE fm.org_id = ${args.organizationId}
+            AND fm.storage_ref = r.ref
+            AND (fm.lifecycle_status IS NULL
+                 OR fm.lifecycle_status = 'active')
+            AND (${excludeFile}::text IS NULL OR fm.id <> ${excludeFile})
+            AND (${excludeDoc}::text IS NULL OR fm.document_id IS NULL
+                 OR fm.document_id <> ${excludeDoc})
+        )
+      ) AS "blobLive"
+    FROM unnest(${args.refs}::text[]) AS r(ref)
+  `;
+}
+
+export interface ReleaseFailure {
+  ref: string;
+  stage: 'corpus' | 'blob';
+  message: string;
+}
+
+export interface ReleaseOutcome {
+  /** Refs whose dead surfaces were removed (idempotent: already-absent
+   * counts as removed). */
+  released: string[];
+  /** Refs something still references — corpus row and bytes stay. */
+  kept: string[];
+  failures: ReleaseFailure[];
+}
+
+export interface ReleaseRefsArgs {
+  organizationId: string;
+  orgSlug: string;
+  refs: readonly (string | null | undefined)[];
+  excludeDocumentId?: string;
+  excludeFileMetadataId?: string;
+}
+
+/**
+ * Release every surface of the given refs that nothing references any more:
+ * corpus rows for corpus-dead refs, bytes for blob-dead refs. Failures are
+ * returned, never swallowed; a ref whose corpus delete failed keeps its
+ * blob too, so a retry releases both together. Fully idempotent.
+ */
+export async function releaseRefs(
+  sql: Sql,
+  args: ReleaseRefsArgs,
+): Promise<ReleaseOutcome> {
+  const outcome: ReleaseOutcome = { released: [], kept: [], failures: [] };
+  const refs = [
+    ...new Set(
+      args.refs.filter(
+        (ref): ref is string => typeof ref === 'string' && ref.length > 0,
+      ),
+    ),
+    // Conversation-message refs (`msg:`) belong to another vocabulary — the
+    // file lifecycle never owns them.
+  ].filter((ref) => !ref.startsWith('msg:'));
+  if (refs.length === 0) return outcome;
+
+  const liveness = await assessRefLiveness(sql, {
+    organizationId: args.organizationId,
+    refs,
+    ...(args.excludeDocumentId !== undefined
+      ? { excludeDocumentId: args.excludeDocumentId }
+      : {}),
+    ...(args.excludeFileMetadataId !== undefined
+      ? { excludeFileMetadataId: args.excludeFileMetadataId }
+      : {}),
+  });
+
+  const corpusDead = liveness.filter((entry) => !entry.corpusLive);
+  const corpusFailed = new Set<string>();
+  if (corpusDead.length > 0) {
+    try {
+      await deleteKnowledgeDocumentsBatch({
+        orgSlug: args.orgSlug,
+        fileIds: corpusDead.map((entry) => entry.ref),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const entry of corpusDead) {
+        corpusFailed.add(entry.ref);
+        outcome.failures.push({ ref: entry.ref, stage: 'corpus', message });
+      }
+    }
+  }
+
+  for (const entry of liveness) {
+    if (corpusFailed.has(entry.ref)) continue; // retry releases both surfaces
+    if (entry.blobLive) {
+      if (entry.corpusLive) outcome.kept.push(entry.ref);
+      else outcome.released.push(entry.ref); // corpus gone, bytes retained
+      continue;
+    }
+    try {
+      const parsed = parseBlobRef(entry.ref);
+      if (parsed.backend === 's3') {
+        const store = await resolveObjectStore(args.orgSlug);
+        await s3DeleteObject(store, parsed.key);
+      }
+      // The bytes are gone — reap trashed, unbound file rows that only
+      // existed to remember this ref (the WebDAV overwrite strands).
+      await sql`
+        DELETE FROM app.file_metadata
+        WHERE org_id = ${args.organizationId}
+          AND storage_ref = ${entry.ref}
+          AND lifecycle_status = 'trashed' AND document_id IS NULL
+      `;
+      outcome.released.push(entry.ref);
+    } catch (error) {
+      outcome.failures.push({
+        ref: entry.ref,
+        stage: 'blob',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return outcome;
+}
+
+/** The `knowledge.release_refs` job body: resolve the org, release, and
+ * THROW on any failure so pg-boss retries (the enqueue is transactional
+ * with the rotation that orphaned the refs). */
+export async function runReleaseRefsJob(
+  sql: Sql,
+  payload: { organizationId: string; refs: string[] },
+): Promise<void> {
+  const orgSlug = await resolveOrgSlug(sql, payload.organizationId);
+  if (orgSlug === null) {
+    // The organization is gone — its corpus and bucket went with it.
+    console.warn(
+      `[knowledge] release skipped for org ${payload.organizationId}: organization no longer exists`,
+    );
+    return;
+  }
+  const outcome = await releaseRefs(sql, {
+    organizationId: payload.organizationId,
+    orgSlug,
+    refs: payload.refs,
+  });
+  if (outcome.failures.length > 0) {
+    const detail = outcome.failures
+      .map((failure) => `${failure.ref} (${failure.stage}): ${failure.message}`)
+      .join('; ');
+    throw new Error(`ref release incomplete — ${detail}`);
+  }
+}
+
+const RECONCILE_REFS_PER_ORG = 500;
+const RECONCILE_PAGE = 100;
+
+/**
+ * Walk one org's corpus and release every ref that is dead by both
+ * predicates — the lazy backfill for historically stranded rows (replaced
+ * versions, rotated knowledge entries, swept temp files) and the backstop
+ * for a release job that exhausted its retries. Bounded per run; the daily
+ * schedule drains large backlogs incrementally.
+ */
+export async function reconcileCorpusForOrg(
+  sql: Sql,
+  args: { organizationId: string; orgSlug: string },
+): Promise<{ scanned: number; released: number; failures: number }> {
+  let scanned = 0;
+  let released = 0;
+  let failures = 0;
+  let cursor: string | null = null;
+  while (scanned < RECONCILE_REFS_PER_ORG) {
+    const page: string[] = await listKnowledgeDocumentRefs({
+      orgSlug: args.orgSlug,
+      afterFileId: cursor,
+      limit: Math.min(RECONCILE_PAGE, RECONCILE_REFS_PER_ORG - scanned),
+    });
+    if (page.length === 0) break;
+    scanned += page.length;
+    cursor = page.at(-1) ?? null;
+    const outcome = await releaseRefs(sql, {
+      organizationId: args.organizationId,
+      orgSlug: args.orgSlug,
+      refs: page,
+    });
+    released += outcome.released.length;
+    failures += outcome.failures.length;
+    for (const failure of outcome.failures) {
+      console.warn(
+        `[knowledge] reconcile release failed for ${failure.ref} (${failure.stage}): ${failure.message}`,
+      );
+    }
+    if (page.length < RECONCILE_PAGE) break;
+  }
+  return { scanned, released, failures };
+}
+
+/** The `knowledge.reconcile_corpus` cron body: every org, isolated. */
+export async function runCorpusReconcile(sql: Sql): Promise<void> {
+  const orgs = await sql<{ id: string; slug: string | null }[]>`
+    SELECT "id", "slug" FROM "organization"
+  `;
+  for (const org of orgs) {
+    if (org.slug === null) continue;
+    try {
+      const stats = await reconcileCorpusForOrg(sql, {
+        organizationId: org.id,
+        orgSlug: org.slug,
+      });
+      if (stats.released > 0 || stats.failures > 0) {
+        console.info(
+          `[knowledge] corpus reconcile for ${org.slug}: scanned=${stats.scanned} released=${stats.released} failures=${stats.failures}`,
+        );
+      }
+    } catch (error) {
+      // One org's corpus being unreachable must not starve the fleet.
+      console.warn(
+        `[knowledge] corpus reconcile failed for org ${org.slug}:`,
+        error,
+      );
+    }
+  }
+}

--- a/services/platform/backend/domains/knowledge/retrievable.test.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decideRetrievable,
+  type DocCandidate,
+  type UnboundFileCandidate,
+} from './retrievable.ts';
+
+const activeDoc = (overrides: Partial<DocCandidate> = {}): DocCandidate => ({
+  lifecycleStatus: null,
+  projectId: null,
+  teamId: null,
+  teamTags: null,
+  ...overrides,
+});
+
+const unboundFile = (
+  overrides: Partial<UnboundFileCandidate> = {},
+): UnboundFileCandidate => ({
+  lifecycleStatus: null,
+  threadId: null,
+  ...overrides,
+});
+
+describe('decideRetrievable', () => {
+  it('denies a ref with no candidates (replaced/rotated history, purged rows)', () => {
+    expect(decideRetrievable([], [], undefined)).toBe(false);
+  });
+
+  it('admits a current, active document without an access scope', () => {
+    expect(decideRetrievable([activeDoc()], [], undefined)).toBe(true);
+  });
+
+  it('denies trashed and expired documents — lifecycle truth beats the physical purge', () => {
+    for (const lifecycleStatus of ['trashed', 'expired', 'purge_pending']) {
+      expect(
+        decideRetrievable([activeDoc({ lifecycleStatus })], [], undefined),
+      ).toBe(false);
+    }
+  });
+
+  it('scopes a project document to the granted projects', () => {
+    const doc = activeDoc({ projectId: 'p1' });
+    expect(decideRetrievable([doc], [], { projectIds: ['p1'] })).toBe(true);
+    expect(decideRetrievable([doc], [], { projectIds: ['p2'] })).toBe(false);
+    expect(decideRetrievable([doc], [], {})).toBe(false);
+  });
+
+  it('scopes hub documents by team, honoring includeHub', () => {
+    const teamDoc = activeDoc({ teamId: 't1' });
+    expect(decideRetrievable([teamDoc], [], { teamIds: ['t1'] })).toBe(true);
+    expect(decideRetrievable([teamDoc], [], { teamIds: ['t2'] })).toBe(false);
+    expect(
+      decideRetrievable([teamDoc], [], { teamIds: ['t1'], includeHub: false }),
+    ).toBe(false);
+    // Teamless hub documents are org-wide.
+    expect(decideRetrievable([activeDoc()], [], { teamIds: [] })).toBe(true);
+    // team_tags outrank the deprecated single team column.
+    const tagged = activeDoc({ teamId: 't1', teamTags: ['t2', 't3'] });
+    expect(decideRetrievable([tagged], [], { teamIds: ['t1'] })).toBe(false);
+    expect(decideRetrievable([tagged], [], { teamIds: ['t3'] })).toBe(true);
+  });
+
+  it('lets a live COPY twin admit through its own scope after the sibling dies', () => {
+    const trashedTwin = activeDoc({ lifecycleStatus: 'trashed' });
+    const liveTwin = activeDoc({ projectId: 'p1' });
+    expect(
+      decideRetrievable([trashedTwin, liveTwin], [], { projectIds: ['p1'] }),
+    ).toBe(true);
+    expect(decideRetrievable([trashedTwin], [], { projectIds: ['p1'] })).toBe(
+      false,
+    );
+  });
+
+  it('scopes thread files to their thread and honors the conversation switch', () => {
+    const threadFile = unboundFile({ threadId: 'th1' });
+    expect(decideRetrievable([], [threadFile], undefined)).toBe(true);
+    expect(decideRetrievable([], [threadFile], { threadIds: ['th1'] })).toBe(
+      true,
+    );
+    expect(decideRetrievable([], [threadFile], { threadIds: ['th2'] })).toBe(
+      false,
+    );
+    expect(
+      decideRetrievable([], [threadFile], {
+        threadIds: ['th1'],
+        includeConversationScoped: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the same-org posture for live document-less rows (video-link lane)', () => {
+    expect(decideRetrievable([], [unboundFile()], { teamIds: [] })).toBe(true);
+  });
+
+  it('denies trashed unbound rows — the WebDAV overwrite strands', () => {
+    expect(
+      decideRetrievable(
+        [],
+        [unboundFile({ lifecycleStatus: 'trashed' })],
+        undefined,
+      ),
+    ).toBe(false);
+  });
+});

--- a/services/platform/backend/domains/knowledge/retrievable.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.ts
@@ -1,0 +1,90 @@
+/**
+ * The retrievability DECISION — pure, so the rule that decides what RAG may
+ * surface is testable without a database.
+ *
+ * A corpus ref is retrievable iff lifecycle truth says the content is
+ * current and alive:
+ *
+ *   - a document whose CURRENT `file_ref` is the ref, with an ACTIVE
+ *     lifecycle (`NULL`) — trashed, expired, or any future state is dark
+ *     the moment the row flips, regardless of when the physical corpus
+ *     purge lands; and the ref must be CURRENT, so a replaced version
+ *     (history) never answers as if it were the live document. Scope
+ *     (project / hub team) applies per candidate document — a WebDAV COPY
+ *     twin admits through its own scope, not its sibling's.
+ *   - or a LIVE unbound file row holding the ref: thread-bound rows admit
+ *     only inside their thread's scope; rows with neither binding keep the
+ *     0.4 same-org posture DELIBERATELY — video-link transcripts index
+ *     without a document, so a blanket quarantine would dark a legitimate
+ *     lane. Trashed file rows (a WebDAV overwrite's strands) and refs with
+ *     no row at all are never retrievable.
+ */
+
+export interface AccessScopeArg {
+  teamIds?: string[];
+  projectIds?: string[];
+  includeHub?: boolean;
+  includeConversationScoped?: boolean;
+  threadIds?: string[];
+}
+
+/** A document currently exposing the ref (`file_ref` = ref). */
+export interface DocCandidate {
+  lifecycleStatus: string | null;
+  projectId: string | null;
+  teamId: string | null;
+  teamTags: string[] | null;
+}
+
+/** A file row holding the ref WITHOUT a document binding. */
+export interface UnboundFileCandidate {
+  lifecycleStatus: string | null;
+  threadId: string | null;
+}
+
+function isActiveLifecycle(status: string | null): boolean {
+  return (status ?? 'active') === 'active';
+}
+
+export function decideRetrievable(
+  docs: readonly DocCandidate[],
+  unboundFiles: readonly UnboundFileCandidate[],
+  access: AccessScopeArg | undefined,
+): boolean {
+  for (const doc of docs) {
+    if (!isActiveLifecycle(doc.lifecycleStatus)) continue;
+    if (access === undefined) return true;
+    if (doc.projectId !== null) {
+      if ((access.projectIds ?? []).includes(doc.projectId)) return true;
+      continue;
+    }
+    if (access.includeHub === false) continue;
+    const docTeams =
+      doc.teamTags && doc.teamTags.length > 0
+        ? doc.teamTags
+        : doc.teamId
+          ? [doc.teamId]
+          : [];
+    if (
+      docTeams.length === 0 ||
+      docTeams.some((teamId) => (access.teamIds ?? []).includes(teamId))
+    ) {
+      return true;
+    }
+  }
+  for (const file of unboundFiles) {
+    if (!isActiveLifecycle(file.lifecycleStatus)) continue;
+    if (file.threadId !== null) {
+      if (access === undefined) return true;
+      if (
+        access.includeConversationScoped !== false &&
+        (access.threadIds ?? []).includes(file.threadId)
+      ) {
+        return true;
+      }
+      continue;
+    }
+    return true;
+  }
+  return false;
+}

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -35,6 +35,12 @@ import { resolveObjectStore } from '../../lib/object-store.ts';
 import { readGovernancePolicy, resolveOrgSlug } from '../../lib/org-config.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 import { credentialShimHandlers } from '../provider_credentials/service.ts';
+import {
+  decideRetrievable,
+  type AccessScopeArg,
+  type DocCandidate,
+  type UnboundFileCandidate,
+} from './retrievable.ts';
 
 /**
  * Knowledge (RAG) — the retrieval and ingest lanes over the knowledge
@@ -54,18 +60,15 @@ const ADAPTER_FIND_ONE = '_reference/childComponent/betterAuth/adapter/findOne';
 const FILTER_RETRIEVABLE =
   'documents/internal_queries:filterRetrievableRagFileIds';
 
-interface AccessScopeArg {
-  teamIds?: string[];
-  projectIds?: string[];
-  includeHub?: boolean;
-  includeConversationScoped?: boolean;
-  threadIds?: string[];
-}
-
 /**
- * Tier-A retrievable filter over app tables: a file ref passes when its
- * metadata row belongs to the org AND (bound document is un-trashed and in
- * scope | thread-bound and the thread is in scope | legacy unbound same-org).
+ * Tier-A retrievable filter over app tables — lifecycle truth for the
+ * corpus. A ref passes when a document CURRENTLY exposes it (`file_ref` =
+ * ref, active lifecycle, in scope — a replaced version's ref or a trashed/
+ * expired document is dark immediately, whatever the physical purge is
+ * still doing) or a LIVE unbound file row holds it (thread files inside
+ * their thread's scope; document-less lanes like video-link transcripts
+ * keep the 0.4 same-org posture). The DECISION is `decideRetrievable`
+ * (pure, tested); this wrapper only fetches its candidates.
  */
 async function filterRetrievableRagFileIds(
   sql: Sql,
@@ -78,85 +81,51 @@ async function filterRetrievableRagFileIds(
   if (args.fileIds.length === 0) {
     return [];
   }
-  const rows = await sql<
-    {
-      storageRef: string;
-      threadId: string | null;
-      documentId: string | null;
-      docTrashed: boolean | null;
-      docProjectId: string | null;
-      docTeamId: string | null;
-      docTeamTags: string[] | null;
-    }[]
-  >`
+  const docRows = await sql<({ fileRef: string } & DocCandidate)[]>`
+    SELECT d.file_ref AS "fileRef", d.lifecycle_status AS "lifecycleStatus",
+           d.project_id AS "projectId", d.team_id AS "teamId",
+           d.team_tags AS "teamTags"
+    FROM app.documents d
+    WHERE d.org_id = ${args.organizationId}
+      AND d.file_ref = ANY(${args.fileIds})
+  `;
+  const fileRows = await sql<({ storageRef: string } & UnboundFileCandidate)[]>`
     SELECT fm.storage_ref AS "storageRef", fm.thread_id AS "threadId",
-           fm.document_id AS "documentId",
-           (d.lifecycle_status = 'trashed') AS "docTrashed",
-           d.project_id AS "docProjectId", d.team_id AS "docTeamId",
-           d.team_tags AS "docTeamTags"
+           fm.lifecycle_status AS "lifecycleStatus"
     FROM app.file_metadata fm
-    LEFT JOIN app.documents d ON d.id = fm.document_id
     WHERE fm.org_id = ${args.organizationId}
       AND fm.storage_ref = ANY(${args.fileIds})
+      AND fm.document_id IS NULL
   `;
-  const byRef = new Map(rows.map((row) => [row.storageRef, row]));
-  const access = args.access;
+  const docsByRef = new Map<string, DocCandidate[]>();
+  for (const row of docRows) {
+    const { fileRef, ...candidate } = row;
+    const list = docsByRef.get(fileRef);
+    if (list) list.push(candidate);
+    else docsByRef.set(fileRef, [candidate]);
+  }
+  const filesByRef = new Map<string, UnboundFileCandidate[]>();
+  for (const row of fileRows) {
+    const { storageRef, ...candidate } = row;
+    const list = filesByRef.get(storageRef);
+    if (list) list.push(candidate);
+    else filesByRef.set(storageRef, [candidate]);
+  }
   const retrievable: string[] = [];
   for (const ref of args.fileIds) {
     // Conversation/email-message refs (`msg:`) deny until that domain lands.
     if (ref.startsWith('msg:')) {
       continue;
     }
-    const row = byRef.get(ref);
-    if (!row) {
-      continue;
+    if (
+      decideRetrievable(
+        docsByRef.get(ref) ?? [],
+        filesByRef.get(ref) ?? [],
+        args.access,
+      )
+    ) {
+      retrievable.push(ref);
     }
-    if (row.documentId !== null) {
-      if (row.docTrashed === true) {
-        continue;
-      }
-      if (access === undefined) {
-        retrievable.push(ref);
-        continue;
-      }
-      if (row.docProjectId !== null) {
-        if ((access.projectIds ?? []).includes(row.docProjectId)) {
-          retrievable.push(ref);
-        }
-        continue;
-      }
-      if (access.includeHub === false) {
-        continue;
-      }
-      const docTeams =
-        row.docTeamTags && row.docTeamTags.length > 0
-          ? row.docTeamTags
-          : row.docTeamId
-            ? [row.docTeamId]
-            : [];
-      if (
-        docTeams.length === 0 ||
-        docTeams.some((teamId) => (access.teamIds ?? []).includes(teamId))
-      ) {
-        retrievable.push(ref);
-      }
-      continue;
-    }
-    if (row.threadId !== null) {
-      if (access === undefined) {
-        retrievable.push(ref);
-        continue;
-      }
-      if (
-        access.includeConversationScoped !== false &&
-        (access.threadIds ?? []).includes(row.threadId)
-      ) {
-        retrievable.push(ref);
-      }
-      continue;
-    }
-    // Legacy/unbound: same-org fallback (the 0.4 posture).
-    retrievable.push(ref);
   }
   return retrievable;
 }

--- a/services/platform/backend/domains/knowledge_entries/routes.ts
+++ b/services/platform/backend/domains/knowledge_entries/routes.ts
@@ -85,6 +85,7 @@ export function createKnowledgeEntryRoutes(deps: {
       const id = await createKnowledgeEntry(deps.sql, {
         organizationId: c.get('orgId'),
         userId: c.get('sessionBundle').user.id,
+        role: c.get('orgMember').role,
         topic: body.data.topic,
         content: body.data.content,
       });
@@ -108,6 +109,7 @@ export function createKnowledgeEntryRoutes(deps: {
       const id = await updateKnowledgeEntry(deps.sql, {
         organizationId: c.get('orgId'),
         userId: c.get('sessionBundle').user.id,
+        role: c.get('orgMember').role,
         entryId: c.req.param('entryId'),
         topic: body.data.topic,
         content: body.data.content,
@@ -123,6 +125,7 @@ export function createKnowledgeEntryRoutes(deps: {
       await deleteKnowledgeEntry(deps.sql, {
         organizationId: c.get('orgId'),
         entryId: c.req.param('entryId'),
+        role: c.get('orgMember').role,
       });
       return c.json({ ok: true });
     } catch (error) {

--- a/services/platform/backend/domains/knowledge_entries/service.ts
+++ b/services/platform/backend/domains/knowledge_entries/service.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import type { Sql, TransactionSql } from 'postgres';
 
+import { authorizeRls } from '../../auth/access.ts';
 import { validateTopicAndContent } from '../../core/knowledge_entries/helpers.ts';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
@@ -20,24 +21,50 @@ import { resolveOrgSlug } from '../../lib/org-config.ts';
  * scoping/deletion ride the document pipeline.
  *
  * One deliberate 0.5 simplification: versions RE-MATERIALIZE under the SAME
- * file row (the blob key rotates; the file id — the corpus key — stays), so
- * the corpus `ON CONFLICT (org_slug, file_id)` replace IS the supersede and
- * no stale chunks linger. 0.4 minted a new blob per version and kept
- * `historyFiles` on the document; the 0.5 chain keeps every version's full
- * content on its entry row instead — same audit/undo surface, no blob
- * bookkeeping. Deletion soft-deletes the chain and trashes the backing
- * document — the retrievability filter already excludes trashed documents,
- * so the corpus rows go dark immediately (lazy cleanup posture).
+ * file row and document — but the corpus is keyed by the BLOB REF that row
+ * carries (`indexUploadedFile` passes `storage_ref` as the corpus
+ * `file_id`), so rotating the ref moves the entry to a NEW corpus key. The
+ * rotate branch therefore enqueues `knowledge.release_refs` for the
+ * previous ref in the same transaction: the shared release seam de-indexes
+ * its corpus rows and deletes its blob (nothing else references an entry's
+ * blobs — no `historyFiles`; the version chain keeps every version's full
+ * content on its entry row instead, same audit/undo surface). Deletion
+ * soft-deletes the chain and trashes the backing document — the
+ * retrievability filter excludes trashed documents, so the corpus rows go
+ * dark immediately, and the retention purge releases them physically (lazy
+ * cleanup posture).
+ *
+ * Mutations are role-gated at this seam (`authorizeRls(role, 'knowledge',
+ * 'write')`): entries materialize `app.documents` rows and feed the org's
+ * RAG corpus, so a read-only member must not be able to plant or edit them
+ * through the app or REST lanes.
  */
 
 export class KnowledgeEntryError extends Error {
   readonly code: string;
-  readonly status: 400 | 404 | 409;
-  constructor(code: string, message: string, status: 400 | 404 | 409 = 400) {
+  readonly status: 400 | 403 | 404 | 409;
+  constructor(
+    code: string,
+    message: string,
+    status: 400 | 403 | 404 | 409 = 400,
+  ) {
     super(message);
     this.name = 'KnowledgeEntryError';
     this.code = code;
     this.status = status;
+  }
+}
+
+/** The write gate every mutation lane (app routes, REST) funnels through:
+ * entries materialize documents rows and feed the RAG corpus, so the
+ * `knowledge` write grant (editor and up) is required. */
+function assertCanWriteEntries(role: string | undefined): void {
+  if (!authorizeRls(role, 'knowledge', 'write')) {
+    throw new KnowledgeEntryError(
+      'KNOWLEDGE_ENTRY_FORBIDDEN',
+      'Your role cannot modify knowledge entries',
+      403,
+    );
   }
 }
 
@@ -145,7 +172,17 @@ async function attachEntryDocument(
   const now = Date.now();
 
   if (args.existingDocumentId !== null) {
-    // Same document, same FILE row (the corpus key): rotate the blob ref.
+    // Same document, same FILE row — but the corpus is keyed by the blob
+    // REF, so this rotation re-materializes the entry under a new corpus
+    // key. Capture the outgoing ref first: the release job below de-indexes
+    // its corpus rows and deletes its blob (nothing else references it),
+    // instead of stranding one unpurgeable corpus document per edit.
+    const previous = await tx<{ storageRef: string }[]>`
+      SELECT storage_ref AS "storageRef" FROM app.file_metadata
+      WHERE document_id = ${args.existingDocumentId}
+      LIMIT 1
+    `;
+    const previousRef = previous[0]?.storageRef ?? null;
     await tx`
       UPDATE app.documents SET
         title = ${fileName}, file_ref = ${storageRef},
@@ -165,6 +202,12 @@ async function attachEntryDocument(
     const fileId = files[0]?.id;
     if (fileId !== undefined) {
       await addJobInTx(tx, 'rag.index_file', { fileId });
+    }
+    if (previousRef !== null && previousRef !== storageRef) {
+      await addJobInTx(tx, 'knowledge.release_refs', {
+        organizationId: args.organizationId,
+        refs: [previousRef],
+      });
     }
     await tx`
       UPDATE app.knowledge_entries SET
@@ -214,6 +257,7 @@ export async function createKnowledgeEntry(
   args: {
     organizationId: string;
     userId: string;
+    role: string;
     topic: string;
     content: string;
     source?: 'chat' | 'manual';
@@ -221,6 +265,7 @@ export async function createKnowledgeEntry(
     sourceMessageId?: string;
   },
 ): Promise<string> {
+  assertCanWriteEntries(args.role);
   const { topic, topicKey, content } = validate(args.topic, args.content);
   const precheck = await findActiveByTopicKey(
     sql,
@@ -278,11 +323,13 @@ export async function updateKnowledgeEntry(
   args: {
     organizationId: string;
     userId: string;
+    role: string;
     entryId: string;
     topic: string;
     content: string;
   },
 ): Promise<string> {
+  assertCanWriteEntries(args.role);
   const { topic, topicKey, content } = validate(args.topic, args.content);
   const blob = await storeEntryBlob(sql, args.organizationId, content);
   return sql.begin(async (tx) => {
@@ -352,8 +399,9 @@ export async function updateKnowledgeEntry(
  * retrievability filter excludes trashed documents, so RAG goes dark now. */
 export async function deleteKnowledgeEntry(
   sql: Sql,
-  args: { organizationId: string; entryId: string },
+  args: { organizationId: string; entryId: string; role: string },
 ): Promise<void> {
+  assertCanWriteEntries(args.role);
   await sql.begin(async (tx) => {
     const rows = await tx<{ topicKey: string; documentId: string | null }[]>`
       SELECT topic_key AS "topicKey", document_id AS "documentId"

--- a/services/platform/backend/domains/onedrive/service.ts
+++ b/services/platform/backend/domains/onedrive/service.ts
@@ -12,7 +12,6 @@ import {
 import { extractExtension } from '../../core/documents/extract_extension.ts';
 import { extractTenantId } from '../../core/enterprise_sso/entra_id/constants.ts';
 import { sourceFromProvider } from '../../core/file_metadata/source_from_provider.ts';
-import { deleteKnowledgeDocument } from '../../core/legacy/knowledge_delete.ts';
 import { getFileMetadata } from '../../core/onedrive/get_file_metadata.ts';
 import { importFiles } from '../../core/onedrive/import_files.ts';
 import type { FileItem } from '../../core/onedrive/list_folder_contents.ts';
@@ -888,21 +887,20 @@ export function createSyncImportDeps(
         WHERE id = ${documentId}
       `;
 
-      // The replaced blob's corpus chunks are keyed by the OLD ref — purge
-      // them best-effort (the 0.4 `reindexDocumentInRag` old-entry purge);
-      // the new blob indexes via the schedule dep below.
+      // The replaced blob's corpus chunks are keyed by the OLD ref — release
+      // them through the shared refcounted seam (the 0.4
+      // `reindexDocumentInRag` old-entry purge, made durable: a swallowed
+      // failure used to strand the stale rows forever). The ref sits in
+      // `history_files` now, so the job de-indexes the corpus and keeps the
+      // bytes; the new blob indexes via the schedule dep below.
       if (blobReplaced && doc.fileRef !== null) {
-        const orgSlug = await resolveOrgSlug(sql, organizationId);
-        if (orgSlug) {
-          try {
-            await deleteKnowledgeDocument({ orgSlug, fileId: doc.fileRef });
-          } catch (error) {
-            console.warn(
-              `[${adapter.sourceProvider}] corpus purge failed for replaced blob ${doc.fileRef}:`,
-              error instanceof Error ? error.message : error,
-            );
-          }
-        }
+        const oldRef = doc.fileRef;
+        await sql.begin(async (tx) => {
+          await addJobInTx(tx, 'knowledge.release_refs', {
+            organizationId,
+            refs: [oldRef],
+          });
+        });
       }
     },
     getOrCreateFolderPath: async (orgId, pathSegments, createdBy, teamId) =>

--- a/services/platform/backend/domains/projects/service.ts
+++ b/services/platform/backend/domains/projects/service.ts
@@ -1112,8 +1112,11 @@ export async function deleteProject(
   const now = Date.now();
 
   if (args.mode === 'cascade') {
-    // Mark for deletion via lifecycle status; the retention pipeline
-    // hard-deletes blob + RAG chunks within the grace window.
+    // Mark for deletion via lifecycle status. 'expired' takes the documents
+    // out of the retrievable set IMMEDIATELY (the RAG filter admits only
+    // active-lifecycle documents); the retention documents sweep then
+    // hard-deletes rows + blobs + corpus entries — after the grace window,
+    // or on the next daily run when the org runs with no grace.
     const cascadedDocs = await tx<{ id: string }[]>`
       UPDATE app.documents SET
         project_id = NULL, lifecycle_status = 'expired',

--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -11,17 +11,15 @@ import {
   isRetentionDisabled,
   type EffectiveBoundDef,
 } from '../../core/governance/retention_floors.ts';
-import { deleteKnowledgeDocument } from '../../core/legacy/knowledge_delete.ts';
 import { readDomainConfigFile } from '../../core/lib/config_store/read_domain_file.ts';
 import { getConfigRoot } from '../../core/lib/file_io.ts';
-import { parseBlobRef } from '../../core/lib/storage/blob_ref.ts';
 import { toJson } from '../../db/sql.ts';
-import { resolveObjectStore, s3DeleteObject } from '../../lib/object-store.ts';
 import {
   readGovernancePolicyForOrg,
   resolveOrgSlug,
 } from '../../lib/org-config.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
+import { releaseRefs, type ReleaseFailure } from '../knowledge/release.ts';
 import { loadActiveHolds, type ActiveHolds } from '../legal_holds/service.ts';
 import { cascadeDeleteThreadTtsChunks } from '../tts/service.ts';
 
@@ -399,25 +397,37 @@ interface Phase2Stats {
   tempFiles: number;
 }
 
-/** Best-effort blob removal — a missing object is success. */
-async function deleteBlobBestEffort(
-  orgSlug: string,
-  storageRef: string,
-): Promise<void> {
-  try {
-    const parsed = parseBlobRef(storageRef);
-    if (parsed.backend !== 's3') return;
-    const store = await resolveObjectStore(orgSlug);
-    await s3DeleteObject(store, parsed.key);
-  } catch (error) {
-    console.warn(`[retention] blob delete failed for ${storageRef}:`, error);
+/** A purge that could not remove every dead surface (corpus rows, bytes).
+ * The document row is KEPT so the caller can retry — a delete lane must
+ * never report success while content persists. Deliberately not a 4xx: the
+ * request was valid; the infrastructure failed. */
+export class PurgeIncompleteError extends Error {
+  readonly code = 'PURGE_INCOMPLETE';
+  readonly failures: ReleaseFailure[];
+  constructor(documentId: string, failures: ReleaseFailure[]) {
+    super(
+      `Purge incomplete for document ${documentId}: ${failures
+        .map(
+          (failure) => `${failure.ref} (${failure.stage}): ${failure.message}`,
+        )
+        .join('; ')}`,
+    );
+    this.name = 'PurgeIncompleteError';
+    this.failures = failures;
   }
 }
 
-/** Hard-delete one document: corpus entry (keyed by the file REF), blobs
- * (current + `historyFiles` — replaced blobs a sync/replace appended, the
- * 0.4 `eraseDocumentBlobs` contract), file rows, dependent knowledge-entry
- * chains, then the row. */
+/** Hard-delete one document: corpus entries + blobs first, through the
+ * shared refcounted release seam (current ref + `historyFiles` — replaced
+ * blobs a sync/replace appended, the 0.4 `eraseDocumentBlobs` contract; a
+ * ref another document still holds — a WebDAV COPY twin, a shared history
+ * snapshot — is KEPT for the twin), then file rows, dependent knowledge-
+ * entry chains, and the row. Throws `PurgeIncompleteError` when a corpus or
+ * blob delete fails, WITHOUT touching the app rows — every hard-delete lane
+ * funnels here (user delete, folder cascade, REST, retention sweep, erasure
+ * cascade, sync prune), and each retries from its own loop: the daily
+ * sweep re-selects the row, an erasure lands `partial` and can be re-armed,
+ * a user sees the failure instead of a false receipt. Idempotent. */
 export async function purgeDocument(
   sql: Sql,
   orgSlug: string | null,
@@ -428,32 +438,17 @@ export async function purgeDocument(
     historyFiles?: string[];
   },
 ): Promise<void> {
+  // A null slug means the organization row itself is gone — its corpus and
+  // bucket are unaddressable; only the app rows remain to clean up.
   if (orgSlug !== null) {
-    for (const ref of doc.historyFiles ?? []) {
-      if (ref !== doc.fileRef) {
-        await deleteBlobBestEffort(orgSlug, ref);
-      }
-    }
-  }
-  if (doc.fileRef !== null && orgSlug !== null) {
-    try {
-      const result = await deleteKnowledgeDocument({
-        orgSlug,
-        fileId: doc.fileRef,
-      });
-      if (!result.success) {
-        console.warn(
-          `[retention] corpus delete failed for document ${doc.id}: ${result.message}`,
-        );
-      }
-    } catch (error) {
-      console.warn(
-        `[retention] corpus delete failed for document ${doc.id}:`,
-        error,
-      );
-    }
-    if (orgSlug !== null) {
-      await deleteBlobBestEffort(orgSlug, doc.fileRef);
+    const outcome = await releaseRefs(sql, {
+      organizationId: doc.organizationId,
+      orgSlug,
+      refs: [doc.fileRef, ...(doc.historyFiles ?? [])],
+      excludeDocumentId: doc.id,
+    });
+    if (outcome.failures.length > 0) {
+      throw new PurgeIncompleteError(doc.id, outcome.failures);
     }
   }
   await sql.begin(async (tx) => {
@@ -519,7 +514,13 @@ async function sweepDocuments(
             AND status_changed_at_ms < ${Date.now() - graceDays * DAY_MS}
           LIMIT ${BATCH_LIMIT}
         `
-      : await sql<
+      : // No grace window: trashed/expired rows (user trash, a project-
+        // cascade's 'expired' marks) hard-delete on the next sweep, and
+        // active rows past the cutoff go directly. Without the lifecycle
+        // arm, grace=0 orgs kept 'expired' documents forever — the project-
+        // cascade promise ("the retention pipeline hard-deletes blob + RAG
+        // chunks") silently never ran.
+        await sql<
           {
             id: string;
             fileRef: string | null;
@@ -530,8 +531,9 @@ async function sweepDocuments(
           SELECT id, file_ref AS "fileRef", created_by AS "createdBy",
                  history_files AS "historyFiles"
           FROM app.documents
-          WHERE org_id = ${org.organizationId} AND lifecycle_status IS NULL
-            AND created_at_ms < ${cutoff}
+          WHERE org_id = ${org.organizationId}
+            AND ((lifecycle_status IS NULL AND created_at_ms < ${cutoff})
+                 OR lifecycle_status IN ('trashed', 'expired'))
           LIMIT ${BATCH_LIMIT}
         `;
   if (passB.length === 0) return processed;
@@ -540,12 +542,19 @@ async function sweepDocuments(
     if (doc.createdBy !== null && holds.userMembershipIds.has(doc.createdBy)) {
       continue;
     }
-    await purgeDocument(sql, orgSlug, {
-      id: doc.id,
-      fileRef: doc.fileRef,
-      organizationId: org.organizationId,
-      historyFiles: doc.historyFiles,
-    });
+    try {
+      await purgeDocument(sql, orgSlug, {
+        id: doc.id,
+        fileRef: doc.fileRef,
+        organizationId: org.organizationId,
+        historyFiles: doc.historyFiles,
+      });
+    } catch (error) {
+      // The row is kept (purgeDocument releases before it deletes), so the
+      // next daily run retries; one stuck document must not starve the rest.
+      console.warn(`[retention] purge failed for document ${doc.id}:`, error);
+      continue;
+    }
     processed += 1;
   }
   return processed;
@@ -838,11 +847,31 @@ async function sweepTempFiles(
   `;
   if (rows.length === 0) return 0;
   const orgSlug = await resolveOrgSlug(sql, org.organizationId);
+  let removed = 0;
   for (const row of rows) {
-    if (orgSlug !== null) await deleteBlobBestEffort(orgSlug, row.storageRef);
+    if (orgSlug !== null) {
+      // Refcounted release: an indexed temp/thread file's corpus rows die
+      // with it, a shared blob survives for its other holders, and a failed
+      // delete KEEPS the row so the next daily sweep retries — deleting the
+      // row after a swallowed blob failure leaked the bytes forever.
+      const outcome = await releaseRefs(sql, {
+        organizationId: org.organizationId,
+        orgSlug,
+        refs: [row.storageRef],
+        excludeFileMetadataId: row.id,
+      });
+      if (outcome.failures.length > 0) {
+        console.warn(
+          `[retention] temp-file release failed for ${row.id} — keeping the row for the next sweep:`,
+          outcome.failures,
+        );
+        continue;
+      }
+    }
     await sql`DELETE FROM app.file_metadata WHERE id = ${row.id}`;
+    removed += 1;
   }
-  return rows.length;
+  return removed;
 }
 
 /** The phase-2 categories, run after the row-level ones per org. */

--- a/services/platform/backend/domains/webdav/handlers.ts
+++ b/services/platform/backend/domains/webdav/handlers.ts
@@ -511,7 +511,14 @@ async function purgeLocksAtAndBelow(
   `;
 }
 
-/** PUT-overwrite blob reclaim with the COPY refcount rule. */
+/** PUT-overwrite blob reclaim with the COPY refcount rule: while any ACTIVE
+ * document still exposes the ref, everything stays. Otherwise the file rows
+ * are marked trashed and the physical release rides the durable
+ * `knowledge.release_refs` job — the shared refcounted seam de-indexes the
+ * old ref's corpus rows (a PUT-overwrite used to strand them retrievable
+ * forever) and deletes the bytes ONLY when no document holds the ref in any
+ * lifecycle (a trashed twin is restorable, so its bytes now survive an
+ * overwrite of the live copy), with network I/O out of this transaction. */
 async function purgeOldBlob(
   tx: TransactionSql,
   organizationId: string,
@@ -531,7 +538,10 @@ async function purgeOldBlob(
     WHERE storage_ref = ${oldFileRef}
       AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
   `;
-  await deleteOrgBlobRef(tx, organizationId, oldFileRef);
+  await addJobInTx(tx, 'knowledge.release_refs', {
+    organizationId,
+    refs: [oldFileRef],
+  });
 }
 
 async function deleteOrgBlobRef(

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -3864,6 +3864,596 @@ async function checkKnowledge(
   }
 }
 
+/**
+ * Corpus-purge consistency: deleted/replaced content leaves EVERYWHERE it
+ * lives (corpus rows, blobs) and the retrievable set follows lifecycle
+ * truth; purge failures are never reported as success.
+ *
+ *   1. Controlled-record replacement de-indexes the old ref (bytes stay as
+ *      the retained snapshot) — the superseded version stops answering RAG.
+ *   2. A knowledge-entry edit releases the rotated-away ref (corpus + blob)
+ *      instead of stranding an unpurgeable corpus document per edit.
+ *   3. A purge that cannot reach the corpus KEEPS the document (no false
+ *      "deleted" receipt); a retry after recovery heals everything.
+ *   4. Project cascade delete darkens its documents immediately (lifecycle
+ *      'expired' fails the retrievable filter) and the grace=0 retention
+ *      sweep hard-deletes them (row + corpus + blob).
+ *   5. A shared blob ref (the WebDAV COPY shape) survives its sibling's
+ *      purge — corpus row and bytes stay for the twin, and the twin keeps
+ *      answering through its own scope; the last holder's purge releases.
+ *   6. The corpus reconcile sweep de-indexes historically stranded refs.
+ *   7. Knowledge-entry mutations are role-gated (member is read-only).
+ */
+async function checkCorpusPurgeConsistency(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string },
+  orgSlug: string,
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'corpus purge consistency (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — RAG lanes not exercised in this run',
+    );
+    return;
+  }
+  const { cookie, orgId } = ctx;
+  const { createServer } = await import('node:http');
+  const embedServer = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk: unknown) => {
+      body += String(chunk);
+    });
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json');
+      res.end(fakeEmbeddingsPayload(body));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    embedServer.listen(0, '127.0.0.1', resolve);
+  });
+  const embedAddress = embedServer.address();
+  const embedPort =
+    embedAddress !== null && typeof embedAddress === 'object'
+      ? embedAddress.port
+      : 0;
+  const configRoot = process.env.TALE_CONFIG_DIR ?? '';
+  const knowledgeDir = path.join(configRoot, orgSlug, 'knowledge');
+
+  try {
+    await mkdir(knowledgeDir, { recursive: true });
+    await writeFile(
+      path.join(knowledgeDir, 'embedding.json'),
+      JSON.stringify({
+        providerSlug: 'openai',
+        model: 'itest-embed',
+        dimensions: 8,
+        baseUrl: `http://127.0.0.1:${embedPort}/v1`,
+      }),
+    );
+    const { getKnowledgePoolForOrg } = await import('./core/knowledge/pool.ts');
+    const corpusPool = await getKnowledgePoolForOrg(orgSlug);
+    const { s3BlobSize } = await import('./core/lib/storage/blob_access.ts');
+
+    const send = (
+      method: 'POST' | 'DELETE',
+      route: string,
+      body?: unknown,
+    ): Promise<Response> =>
+      fetch(`${base}${route}`, {
+        method,
+        headers: { 'content-type': 'application/json', cookie, origin: base },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    const corpusCount = async (ref: string): Promise<number> => {
+      const rows = await corpusPool<{ count: string }[]>`
+        SELECT count(*)::text AS count FROM private_knowledge.documents
+        WHERE org_slug = ${orgSlug} AND file_id = ${ref}
+      `;
+      return Number(rows[0]?.count ?? '0');
+    };
+    const blobExists = async (ref: string): Promise<boolean> =>
+      (await s3BlobSize(orgSlug, ref)) !== null;
+    const fetchRaw = async (ref: string): Promise<string> =>
+      JSON.stringify(
+        await (
+          await send('POST', `/api/app/knowledge/fetch?orgId=${orgId}`, {
+            fileId: ref,
+          })
+        ).json(),
+      );
+    /** Upload + bind + wait-indexed; returns ids or null on any failure. */
+    const uploadIndexedDoc = async (
+      fileName: string,
+      content: string,
+      projectId?: string,
+    ): Promise<{ documentId: string; ref: string; fileId: string } | null> => {
+      const handoff = z
+        .object({ storageRef: z.string(), uploadUrl: z.string().url() })
+        .safeParse(
+          await (
+            await send('POST', `/api/app/files/upload-handoff?orgId=${orgId}`, {
+              contentType: 'text/plain',
+              size: content.length,
+            })
+          ).json(),
+        );
+      if (!handoff.success) return null;
+      await fetch(handoff.data.uploadUrl, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: content,
+      });
+      const registered = z.object({ fileId: z.string() }).safeParse(
+        await (
+          await send('POST', `/api/app/files/register?orgId=${orgId}`, {
+            storageRef: handoff.data.storageRef,
+            fileName,
+            contentType: 'text/plain',
+          })
+        ).json(),
+      );
+      if (!registered.success) return null;
+      const bound = z.object({ documentId: z.string() }).safeParse(
+        await (
+          await send('POST', `/api/app/documents/from-upload?orgId=${orgId}`, {
+            fileId: registered.data.fileId,
+            fileName,
+            ...(projectId !== undefined ? { projectId } : {}),
+          })
+        ).json(),
+      );
+      if (!bound.success) return null;
+      const indexed = await waitFor(async () => {
+        const rows = await sql<{ status: string | null }[]>`
+          SELECT rag_status AS status FROM app.file_metadata
+          WHERE id = ${registered.data.fileId}
+        `;
+        return rows[0]?.status === 'completed';
+      }, 30_000);
+      if (!indexed) return null;
+      return {
+        documentId: bound.data.documentId,
+        ref: handoff.data.storageRef,
+        fileId: registered.data.fileId,
+      };
+    };
+
+    // --- 1. Replacement de-indexes the superseded version ------------------
+    const repl = await uploadIndexedDoc(
+      'purge-replace.txt',
+      'purge check alpha quicksilver original body',
+    );
+    if (repl === null) {
+      record('corpus purge: replacement de-index', false, 'seed doc failed');
+      return;
+    }
+    await send(
+      'POST',
+      `/api/app/documents/${repl.documentId}/record/mark-controlled?orgId=${orgId}`,
+      {},
+    );
+    const begin = z
+      .object({ intentId: z.string(), url: z.string().url() })
+      .safeParse(
+        await (
+          await send(
+            'POST',
+            `/api/app/documents/${repl.documentId}/replacement-upload/begin?orgId=${orgId}`,
+            {
+              expectedRecordState: 'draft',
+              expectedVersion: 1,
+              expectedFileId: repl.ref,
+              fileName: 'purge-replace.txt',
+              contentType: 'text/plain',
+            },
+          )
+        ).json(),
+      );
+    if (begin.success) {
+      await fetch(begin.data.url, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: 'purge check beta cinnabar replacement body',
+      });
+    }
+    const finalize = await send(
+      'POST',
+      `/api/app/documents/replacement-uploads/${begin.success ? begin.data.intentId : ''}/finalize?orgId=${orgId}`,
+      {},
+    );
+    const afterReplace = z
+      .object({ document: z.object({ fileId: z.string() }) })
+      .safeParse(
+        await (
+          await fetch(
+            `${base}/api/app/documents/${repl.documentId}?orgId=${orgId}`,
+            { headers: { cookie } },
+          )
+        ).json(),
+      );
+    const newRef = afterReplace.success
+      ? afterReplace.data.document.fileId
+      : '';
+    const oldDeindexed = await waitFor(
+      async () => (await corpusCount(repl.ref)) === 0,
+      30_000,
+    );
+    const newIndexed = await waitFor(
+      async () => (await corpusCount(newRef)) === 1,
+      30_000,
+    );
+    const oldFetchDark = !(await fetchRaw(repl.ref)).includes('quicksilver');
+    const oldBlobRetained = await blobExists(repl.ref);
+    record(
+      'corpus purge: replacement de-indexes the superseded version',
+      finalize.ok &&
+        newRef !== '' &&
+        newRef !== repl.ref &&
+        oldDeindexed &&
+        newIndexed &&
+        oldFetchDark &&
+        oldBlobRetained,
+      `finalize → ${finalize.status}, oldCorpusGone=${oldDeindexed}, newIndexed=${newIndexed}, oldFetchDark=${oldFetchDark}, snapshotBytesKept=${oldBlobRetained}`,
+    );
+
+    // --- 2. Knowledge-entry edit releases the rotated-away ref -------------
+    const entryCreated = z.object({ id: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/knowledge-entries?orgId=${orgId}`, {
+          topic: 'purge rotation topic',
+          content: 'entry version one verdigris facts',
+        })
+      ).json(),
+    );
+    const entryDocRows = await sql<{ documentId: string | null }[]>`
+      SELECT document_id AS "documentId" FROM app.knowledge_entries
+      WHERE id = ${entryCreated.success ? entryCreated.data.id : ''}
+    `;
+    const entryDocId = entryDocRows[0]?.documentId ?? '';
+    const entryFileRows = await sql<{ id: string; storageRef: string }[]>`
+      SELECT id, storage_ref AS "storageRef" FROM app.file_metadata
+      WHERE document_id = ${entryDocId}
+    `;
+    const entryRefV1 = entryFileRows[0]?.storageRef ?? '';
+    const entryIndexedV1 = await waitFor(
+      async () => (await corpusCount(entryRefV1)) === 1,
+      30_000,
+    );
+    const entryUpdated = z.object({ id: z.string() }).safeParse(
+      await (
+        await send(
+          'POST',
+          `/api/app/knowledge-entries/${entryCreated.success ? entryCreated.data.id : ''}?orgId=${orgId}`,
+          {
+            topic: 'purge rotation topic',
+            content: 'entry version two zeppelin facts',
+          },
+        )
+      ).json(),
+    );
+    const entryRefV2Rows = await sql<{ storageRef: string }[]>`
+      SELECT storage_ref AS "storageRef" FROM app.file_metadata
+      WHERE document_id = ${entryDocId}
+    `;
+    const entryRefV2 = entryRefV2Rows[0]?.storageRef ?? '';
+    const v1Released = await waitFor(
+      async () =>
+        (await corpusCount(entryRefV1)) === 0 &&
+        !(await blobExists(entryRefV1)),
+      30_000,
+    );
+    const v2Indexed = await waitFor(
+      async () => (await corpusCount(entryRefV2)) === 1,
+      30_000,
+    );
+    record(
+      'corpus purge: knowledge-entry edit releases the old ref (corpus + blob)',
+      entryCreated.success &&
+        entryIndexedV1 &&
+        entryUpdated.success &&
+        entryRefV2 !== '' &&
+        entryRefV2 !== entryRefV1 &&
+        v1Released &&
+        v2Indexed,
+      `v1Indexed=${entryIndexedV1}, rotated=${entryRefV2 !== entryRefV1}, v1Released=${v1Released} (corpus row + blob gone), v2Indexed=${v2Indexed}`,
+    );
+
+    // --- 3. Purge failure is honest; retry heals ----------------------------
+    const honest = await uploadIndexedDoc(
+      'purge-honest.txt',
+      'purge check epsilon honesty body',
+    );
+    if (honest === null) {
+      record('corpus purge: failure honesty', false, 'seed doc failed');
+      return;
+    }
+    // Point the org's corpus at a dead endpoint — fail-closed by contract.
+    const badConnectionPath = path.join(knowledgeDir, 'connection.json');
+    await writeFile(
+      badConnectionPath,
+      JSON.stringify({
+        host: '127.0.0.1',
+        port: 9,
+        database: 'unreachable',
+        user: 'nobody',
+        sslmode: 'disable',
+      }),
+    );
+    const failedDelete = await send(
+      'POST',
+      `/api/app/documents/${honest.documentId}/delete?orgId=${orgId}`,
+      {},
+    );
+    const rowKeptRows = await sql<{ id: string }[]>`
+      SELECT id FROM app.documents WHERE id = ${honest.documentId}
+    `;
+    const corpusKept = (await corpusCount(honest.ref)) === 1;
+    const blobKept = await blobExists(honest.ref);
+    await rm(badConnectionPath, { force: true });
+    const retryDelete = await send(
+      'POST',
+      `/api/app/documents/${honest.documentId}/delete?orgId=${orgId}`,
+      {},
+    );
+    const rowGoneRows = await sql<{ id: string }[]>`
+      SELECT id FROM app.documents WHERE id = ${honest.documentId}
+    `;
+    const corpusGoneAfterRetry = (await corpusCount(honest.ref)) === 0;
+    const blobGoneAfterRetry = !(await blobExists(honest.ref));
+    record(
+      'corpus purge: failed purge keeps the row (honest), retry heals',
+      !failedDelete.ok &&
+        rowKeptRows.length === 1 &&
+        corpusKept &&
+        blobKept &&
+        retryDelete.ok &&
+        rowGoneRows.length === 0 &&
+        corpusGoneAfterRetry &&
+        blobGoneAfterRetry,
+      `brokenDelete → ${failedDelete.status} (want !ok), rowKept=${rowKeptRows.length === 1}, corpusKept=${corpusKept}, blobKept=${blobKept}; retry → ${retryDelete.status}, rowGone=${rowGoneRows.length === 0}, corpusGone=${corpusGoneAfterRetry}, blobGone=${blobGoneAfterRetry}`,
+    );
+
+    // --- 4. Project cascade: dark immediately, purged by the sweep ---------
+    const projectCreated = z.object({ projectId: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/projects?orgId=${orgId}`, {
+          name: 'Purge Cascade Project',
+        })
+      ).json(),
+    );
+    const projectId = projectCreated.success
+      ? projectCreated.data.projectId
+      : '';
+    const projDoc = await uploadIndexedDoc(
+      'purge-cascade.txt',
+      'purge check theta cascade body',
+      projectId,
+    );
+    if (projDoc === null) {
+      record('corpus purge: project cascade', false, 'seed project doc failed');
+      return;
+    }
+    const cascade = await send(
+      'DELETE',
+      `/api/app/projects/${projectId}?orgId=${orgId}`,
+      { mode: 'cascade', confirmPhrase: 'Purge Cascade Project' },
+    );
+    const expiredRows = await sql<{ lifecycleStatus: string | null }[]>`
+      SELECT lifecycle_status AS "lifecycleStatus" FROM app.documents
+      WHERE id = ${projDoc.documentId}
+    `;
+    // Dark IMMEDIATELY: the corpus row still exists, but the retrievable
+    // filter refuses the expired lifecycle — no job in between.
+    const corpusStillThere = (await corpusCount(projDoc.ref)) === 1;
+    const darkImmediately = !(await fetchRaw(projDoc.ref)).includes('theta');
+    const { sweepOrgPhase2 } = await import('./domains/retention/service.ts');
+    const { loadActiveHolds } =
+      await import('./domains/legal_holds/service.ts');
+    const holds = await loadActiveHolds(sql, orgId);
+    const phase2 = await sweepOrgPhase2(
+      sql,
+      {
+        organizationId: orgId,
+        config: {
+          documentsEnabled: true,
+          documentsRetentionDays: 36_500,
+          deletionGraceDays: 0,
+        },
+      },
+      holds,
+    );
+    const cascadeRowGone =
+      (
+        await sql<{ id: string }[]>`
+          SELECT id FROM app.documents WHERE id = ${projDoc.documentId}
+        `
+      ).length === 0;
+    const cascadeCorpusGone = (await corpusCount(projDoc.ref)) === 0;
+    const cascadeBlobGone = !(await blobExists(projDoc.ref));
+    record(
+      'corpus purge: project cascade darkens now, grace=0 sweep hard-deletes',
+      cascade.ok &&
+        expiredRows[0]?.lifecycleStatus === 'expired' &&
+        corpusStillThere &&
+        darkImmediately &&
+        phase2.documents >= 1 &&
+        cascadeRowGone &&
+        cascadeCorpusGone &&
+        cascadeBlobGone,
+      `cascade → ${cascade.status}, lifecycle=${expiredRows[0]?.lifecycleStatus}, darkImmediately=${darkImmediately} (corpus row still present=${corpusStillThere}), sweepDocs=${phase2.documents}, rowGone=${cascadeRowGone}, corpusGone=${cascadeCorpusGone}, blobGone=${cascadeBlobGone}`,
+    );
+
+    // --- 5. A shared ref survives its sibling's purge (COPY twins) ---------
+    const twin = await uploadIndexedDoc(
+      'purge-twin.txt',
+      'purge check zeta twin body',
+    );
+    if (twin === null) {
+      record('corpus purge: shared-ref twins', false, 'seed doc failed');
+      return;
+    }
+    // The WebDAV COPY shape: a second document row, SAME file_ref, no file
+    // row of its own.
+    const twinRows = await sql<{ id: string }[]>`
+      INSERT INTO app.documents (
+        org_id, title, file_ref, mime_type, extension, source_provider,
+        created_by, created_at_ms, updated_at_ms
+      )
+      SELECT org_id, 'purge-twin copy.txt', file_ref, mime_type, extension,
+             'webdav', created_by, ${Date.now()}, ${Date.now()}
+      FROM app.documents WHERE id = ${twin.documentId}
+      RETURNING id
+    `;
+    const twinId = twinRows[0]?.id ?? '';
+    const deleteFirst = await send(
+      'POST',
+      `/api/app/documents/${twin.documentId}/delete?orgId=${orgId}`,
+      {},
+    );
+    const twinCorpusKept = (await corpusCount(twin.ref)) === 1;
+    const twinBlobKept = await blobExists(twin.ref);
+    const twinStillAnswers = (await fetchRaw(twin.ref)).includes('zeta');
+    const deleteSecond = await send(
+      'POST',
+      `/api/app/documents/${twinId}/delete?orgId=${orgId}`,
+      {},
+    );
+    const twinCorpusGone = (await corpusCount(twin.ref)) === 0;
+    const twinBlobGone = !(await blobExists(twin.ref));
+    record(
+      'corpus purge: shared blob ref survives the sibling, dies with the last holder',
+      deleteFirst.ok &&
+        twinCorpusKept &&
+        twinBlobKept &&
+        twinStillAnswers &&
+        deleteSecond.ok &&
+        twinCorpusGone &&
+        twinBlobGone,
+      `first delete → ${deleteFirst.status}, corpusKept=${twinCorpusKept}, blobKept=${twinBlobKept}, twinAnswers=${twinStillAnswers}; second delete → ${deleteSecond.status}, corpusGone=${twinCorpusGone}, blobGone=${twinBlobGone}`,
+    );
+
+    // --- 6. The reconcile sweep heals historical strands --------------------
+    const strand = await uploadIndexedDoc(
+      'purge-strand.txt',
+      'purge check eta strand body',
+    );
+    if (strand === null) {
+      record('corpus purge: reconcile sweep', false, 'seed doc failed');
+      return;
+    }
+    // Recreate the pre-fix wreckage: app rows vanish, corpus row + blob stay.
+    await sql`DELETE FROM app.file_metadata WHERE document_id = ${strand.documentId}`;
+    await sql`DELETE FROM app.documents WHERE id = ${strand.documentId}`;
+    const strandSeeded = (await corpusCount(strand.ref)) === 1;
+    // A missing release seam is a red result, not a harness crash.
+    let reconcileRan = false;
+    try {
+      const { runCorpusReconcile } =
+        await import('./domains/knowledge/release.ts');
+      await runCorpusReconcile(sql);
+      reconcileRan = true;
+    } catch (error) {
+      console.warn('[itest] corpus reconcile unavailable:', error);
+    }
+    const strandCorpusGone = (await corpusCount(strand.ref)) === 0;
+    const strandBlobGone = !(await blobExists(strand.ref));
+    record(
+      'corpus purge: reconcile sweep de-indexes stranded refs',
+      strandSeeded && reconcileRan && strandCorpusGone && strandBlobGone,
+      `seeded=${strandSeeded}, reconcileRan=${reconcileRan}, corpusGone=${strandCorpusGone}, blobGone=${strandBlobGone}`,
+    );
+
+    // --- 7. Knowledge-entry mutations are role-gated ------------------------
+    const memberSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: base },
+      body: JSON.stringify({
+        email: `purge-member-${orgSlug}@example.com`,
+        password: 'itest-password-1',
+        name: 'Purge Member',
+      }),
+    });
+    const memberCookie = cookieHeaderFrom(memberSignUp);
+    const memberBody = z
+      .object({ user: z.object({ id: z.string() }) })
+      .safeParse(await memberSignUp.json());
+    const memberId = memberBody.success ? memberBody.data.user.id : '';
+    await sql`
+      INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                            "createdAt")
+      VALUES (gen_random_uuid(), ${orgId}, ${memberId}, 'member',
+              ${new Date()})
+    `;
+    const memberSend = (route: string, body: unknown): Promise<Response> =>
+      fetch(`${base}${route}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: memberCookie,
+          origin: base,
+        },
+        body: JSON.stringify(body),
+      });
+    const memberCreate = await memberSend(
+      `/api/app/knowledge-entries?orgId=${orgId}`,
+      { topic: 'member planted topic', content: 'member planted content' },
+    );
+    const memberUpdate = await memberSend(
+      `/api/app/knowledge-entries/${entryUpdated.success ? entryUpdated.data.id : ''}?orgId=${orgId}`,
+      { topic: 'purge rotation topic', content: 'member tampered content' },
+    );
+    const memberDelete = await fetch(
+      `${base}/api/app/knowledge-entries/${entryUpdated.success ? entryUpdated.data.id : ''}?orgId=${orgId}`,
+      {
+        method: 'DELETE',
+        headers: { cookie: memberCookie, origin: base },
+      },
+    );
+    const memberList = await fetch(
+      `${base}/api/app/knowledge-entries?orgId=${orgId}`,
+      { headers: { cookie: memberCookie } },
+    );
+    // The owner CAN delete — and it leaves the org's entry list the way this
+    // check found it (a later check asserts its own delete empties the list).
+    const ownerDelete = await fetch(
+      `${base}/api/app/knowledge-entries/${entryUpdated.success ? entryUpdated.data.id : ''}?orgId=${orgId}`,
+      { method: 'DELETE', headers: { cookie, origin: base } },
+    );
+    if (memberCreate.status === 201) {
+      // Only reachable when the role gate is broken: reap the planted entry
+      // so this scenario's red never bleeds into the later entries check.
+      const planted = z.object({ id: z.string() }).safeParse(
+        await memberCreate
+          .clone()
+          .json()
+          .catch(() => null),
+      );
+      if (planted.success) {
+        await fetch(
+          `${base}/api/app/knowledge-entries/${planted.data.id}?orgId=${orgId}`,
+          { method: 'DELETE', headers: { cookie, origin: base } },
+        );
+      }
+    }
+    record(
+      'knowledge entries: member role is read-only (app + REST seam gate)',
+      memberCreate.status === 403 &&
+        memberUpdate.status === 403 &&
+        memberDelete.status === 403 &&
+        memberList.ok &&
+        ownerDelete.ok,
+      `create → ${memberCreate.status}, update → ${memberUpdate.status}, delete → ${memberDelete.status} (want 403), list → ${memberList.status} (want 200), ownerDelete → ${ownerDelete.status} (want 200)`,
+    );
+  } finally {
+    await rm(path.join(knowledgeDir, 'connection.json'), { force: true });
+    await new Promise<void>((resolve) => {
+      embedServer.close(() => resolve());
+    });
+  }
+}
+
 /** OpenAI-shaped embeddings response for a raw request body — deterministic
  * 8-dim vectors from character statistics; base64 Float32 when asked (the
  * OpenAI SDK's default decode path). */
@@ -25903,6 +26493,12 @@ async function main(): Promise<void> {
     await checkSkills(baseUrl, authCtx);
     await checkProviderCredentials(sql, baseUrl, authCtx);
     await checkKnowledge(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
+    await checkCorpusPurgeConsistency(
+      sql,
+      baseUrl,
+      authCtx,
+      `itest-${orgSuffix}`,
+    );
     await checkChat(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkTts(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkCloudImport(sql, baseUrl, authCtx);

--- a/services/platform/backend/jobs/schedules.ts
+++ b/services/platform/backend/jobs/schedules.ts
@@ -27,6 +27,12 @@ const SCHEDULES: CronSchedule[] = [
   // The agent-lane and sandbox backstops (each its own entry so a throw in
   // one sweep can never disable another — the 0.4 isolation rationale).
   { name: 'governance.retention_cleanup', cron: '0 4 * * *' },
+  // Corpus↔app reconcile: de-index refs nothing references any more — the
+  // backstop for release jobs that exhausted retries, and the lazy backfill
+  // that drains historically stranded rows (replaced versions, rotated
+  // knowledge entries) on existing deployments. After retention, so rows it
+  // just purged reconcile the same night.
+  { name: 'knowledge.reconcile_corpus', cron: '45 4 * * *' },
   { name: 'audit.integrity_check', cron: '30 4 * * *' },
   { name: 'governance.effect_hold_releases', cron: '15 4 * * *' },
   { name: 'watchdog.task_agents', cron: '*/2 * * * *' },

--- a/services/platform/backend/jobs/task-list.ts
+++ b/services/platform/backend/jobs/task-list.ts
@@ -257,6 +257,22 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       const input = z.object({ fileId: z.string().min(1) }).parse(payload);
       await indexUploadedFile(deps.sql, input.fileId);
     },
+    'knowledge.release_refs': async (payload) => {
+      const input = z
+        .object({
+          organizationId: z.string().min(1),
+          refs: z.array(z.string().min(1)).min(1),
+        })
+        .parse(payload);
+      const { runReleaseRefsJob } =
+        await import('../domains/knowledge/release.ts');
+      await runReleaseRefsJob(deps.sql, input);
+    },
+    'knowledge.reconcile_corpus': async () => {
+      const { runCorpusReconcile } =
+        await import('../domains/knowledge/release.ts');
+      await runCorpusReconcile(deps.sql);
+    },
     'org.cleanup_files': async (payload) => {
       const input = orgCleanupSchema.parse(payload);
       const configRoot = process.env.TALE_CONFIG_DIR;

--- a/services/platform/backend/jobs/tasks.ts
+++ b/services/platform/backend/jobs/tasks.ts
@@ -87,6 +87,11 @@ export interface TaskPayloads {
   'maintenance.login_attempts_ttl': Record<string, never>;
   /** Index one uploaded file into the org's RAG corpus. */
   'rag.index_file': { fileId: string };
+  /** Release rotated-away blob refs: de-index dead corpus rows, delete
+   * unreferenced bytes (enqueued transactionally by every ref rotation). */
+  'knowledge.release_refs': { organizationId: string; refs: string[] };
+  /** Daily corpus↔app reconcile: de-index refs nothing references (cron). */
+  'knowledge.reconcile_corpus': Record<string, never>;
   /** One stepper turn of an automation run (claim-fenced, idempotent). */
   'automation.step': { organizationId: string; runId: string };
   /** One hop of a parked run's poll chain (chainSeq-fenced). */
@@ -337,6 +342,16 @@ export const TASK_QUEUE_OPTIONS: Record<TaskIdentifier, TaskQueueOptions> = {
   'task.start_workflow': { retryLimit: 3, retryDelay: 5, expireInSeconds: 300 },
   'maintenance.rate_limit_gc': { retryLimit: 2, expireInSeconds: 300 },
   'maintenance.login_attempts_ttl': { retryLimit: 2, expireInSeconds: 300 },
+  // Releases are idempotent (liveness re-checked at run time; corpus and
+  // blob deletes are no-ops on missing targets) — retry generously, and let
+  // the daily corpus reconcile catch anything that exhausts the ladder.
+  'knowledge.release_refs': {
+    retryLimit: 8,
+    retryDelay: 10,
+    retryBackoff: true,
+    expireInSeconds: 600,
+  },
+  'knowledge.reconcile_corpus': { retryLimit: 1, expireInSeconds: 3600 },
   'rag.index_file': {
     retryLimit: 5,
     retryDelay: 5,

--- a/services/platform/backend/rest/v1-core.ts
+++ b/services/platform/backend/rest/v1-core.ts
@@ -638,6 +638,7 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       const id = await createKnowledgeEntry(deps.sql, {
         organizationId: c.get('organizationId'),
         userId: c.get('userId'),
+        role: c.get('role'),
         topic: body.data.topic,
         content: body.data.content,
         source: 'manual',
@@ -675,6 +676,7 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       const id = await updateKnowledgeEntry(deps.sql, {
         organizationId: c.get('organizationId'),
         userId: c.get('userId'),
+        role: c.get('role'),
         entryId: c.req.param('id'),
         topic: body.data.topic,
         content: body.data.content,
@@ -695,6 +697,7 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       await deleteKnowledgeEntry(deps.sql, {
         organizationId: c.get('organizationId'),
         entryId: c.req.param('id'),
+        role: c.get('role'),
       });
       return c.body(null, 204);
     } catch (error) {


### PR DESCRIPTION
# fix(platform): corpus purge consistency — deleted means gone

## The invariant

The knowledge corpus is keyed by blob ref, so content lives in up to three places — corpus rows,
bytes, app rows — and this PR makes one rule hold everywhere: **every ref a document ever exposed
to the corpus is de-indexed the moment it stops being current (or the document dies), bytes are
deleted exactly when the last reference goes, the retrievable set follows lifecycle truth
immediately, and no purge lane reports success it did not achieve.** One shared implementation per
concept: `releaseRefs` (refcounted corpus de-index + blob delete, failures reported, in
`domains/knowledge/release.ts`), the durable `knowledge.release_refs` job for rotation points, the
pure `decideRetrievable` predicate for the RAG filter, and the daily `knowledge.reconcile_corpus`
sweep as backstop-and-backfill.

## Per-finding outcome

| #   | Finding                                                                     | Verdict                                                                                                                                                                                                                                                                                                                                                                                                          | Fix                                                                                                                                                                                                                                                                                                                                                                                                                                              | Proof                                                                                                                                                          |
| --- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Replaced document versions stay retrievable in RAG forever                  | confirmed                                                                                                                                                                                                                                                                                                                                                                                                        | `bindReplacement` enqueues `knowledge.release_refs` for the rotated-away ref in the bind transaction; the retrievable filter also refuses non-current refs immediately (a history file row no longer admits its ref)                                                                                                                                                                                                                             | itest "corpus purge: replacement de-indexes the superseded version" — old ref de-indexed, fetch dark, snapshot bytes retained                                  |
| 2   | Replaced and deleted versions stay searchable (history refs escape purge)   | confirmed                                                                                                                                                                                                                                                                                                                                                                                                        | the invariant above; `purgeDocument` now releases current + `historyFiles` refs through the shared seam; all rotation points (replacement, knowledge entries, WebDAV PUT-overwrite, cloud-sync update) funnel into the same job                                                                                                                                                                                                                  | same itest + "reconcile sweep de-indexes stranded refs" (heals pre-fix strands)                                                                                |
| 3   | Every knowledge-entry edit strands a stale, unpurgeable corpus document     | confirmed — the module comment claimed the corpus key survives rotation; indexing keys by `storage_ref`, so it does not                                                                                                                                                                                                                                                                                          | rotate branch captures the outgoing ref and enqueues the release job in the same tx (corpus row + blob released — nothing else references entry blobs); comment now states the real contract                                                                                                                                                                                                                                                     | itest "knowledge-entry edit releases the old ref (corpus + blob)"                                                                                              |
| 4   | Document purge swallows corpus/blob failures — erasure receipts lie         | confirmed (high×2)                                                                                                                                                                                                                                                                                                                                                                                               | `purgeDocument` releases refs FIRST and throws `PurgeIncompleteError` on failure — the row is kept so retention re-selects it daily, erasure lands `partial` (operator can re-arm), a user sees the failure. `deleteBlobBestEffort` assessed: **no sweep reconciled it** — a swallowed failure after row deletion was an unrecoverable leak; it is removed, and the temp-file sweep now also releases-before-delete and keeps the row on failure | itest "failed purge keeps the row (honest), retry heals" — corpus endpoint dead → delete 500s, row+corpus+blob intact; recover → retry releases everything     |
| 5   | Project cascade delete never destroys documents; they stay RAG-retrievable  | confirmed in two halves: the grace>0 sweep DID select `expired` rows (claim held there), but (a) the retrievable filter admitted `expired` docs, and (b) the grace=0 pass never selected `trashed`/`expired` rows at all — on no-grace orgs the promised hard-delete never ran                                                                                                                                   | filter refuses every non-active lifecycle (dark immediately); the grace=0 documents pass now includes `trashed`/`expired` rows (mirroring the contacts sweep); cascade comment updated to the true story                                                                                                                                                                                                                                         | itest "project cascade darkens now, grace=0 sweep hard-deletes" — corpus row still present yet fetch dark, then sweep removes row+corpus+blob                  |
| 6   | WebDAV COPY shares blob refs that purge paths delete without refcount       | confirmed                                                                                                                                                                                                                                                                                                                                                                                                        | the shared seam refcounts BOTH surfaces: bytes live while any `file_ref`/`history_files`/live file row holds the ref; corpus rows live while any document's CURRENT ref (any lifecycle — trash is restorable) or live unbound file row holds it. WebDAV's own `purgeOldBlob` now delegates to the job (no more network I/O inside its transaction; a trashed twin's bytes survive an overwrite of the live copy)                                 | itest "shared blob ref survives the sibling, dies with the last holder" — twin keeps corpus + bytes + answers through its own scope; last delete releases both |
| 7   | Retrievable filter ignores file lifecycle and admits unbound refs           | confirmed, with one refinement: refs with NO file row were already denied; the live leaks were history rows admitting non-current refs, trashed unbound rows (WebDAV strands), and `expired` docs. The unbound-fallback audit found ONE legitimate producer — video-link transcripts index with `document_id NULL` — so live unbound rows keep the 0.4 same-org posture; trashed rows and row-less refs are dark | `decideRetrievable` (pure, unit-tested): current-ref + active-lifecycle + per-candidate scope for documents; thread scope for thread files; live unbound retained                                                                                                                                                                                                                                                                                | unit `retrievable.test.ts` (12 cases incl. twins/lifecycle matrix) + every itest scenario above exercises the filter                                           |
| 8   | knowledge_entries mutations lack the write-matrix role gate (#3136's class) | confirmed                                                                                                                                                                                                                                                                                                                                                                                                        | `authorizeRls(role, 'knowledge', 'write')` at the service seam (create/update/delete), enforced for app routes and REST; new `knowledge` subject in the access matrix (editor+ write, member read, disabled none) — mirrors unmerged #3136's idiom for documents, implemented against main's own rls helpers                                                                                                                                     | itest "member role is read-only (app + REST seam gate)" — member 403 on all three mutations, list still 200, owner delete works; unit `access.test.ts`         |

Refuted: none — all eight findings verified in code; #5 and #7 landed narrower than filed (detailed above).

## The lane sweep (every purge/rotation lane, one seam)

| Lane                                                                            | Before                                                                                                       | Now                                                                                                                                                                                                                                                 |
| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| retention documents sweep (`sweepDocuments`)                                    | corpus swallow + best-effort blob, rows deleted anyway; grace=0 never purged trashed/expired                 | honest `purgeDocument`; per-doc catch keeps the sweep alive; grace=0 selects trashed/expired                                                                                                                                                        |
| user hard delete / folder cascade (`deleteDocumentHard`, `deleteFolderCascade`) | same funnel, same swallow                                                                                    | honest funnel — failure surfaces to the caller, row kept                                                                                                                                                                                            |
| REST `DELETE /v1/documents/:id`                                                 | same                                                                                                         | same honest funnel                                                                                                                                                                                                                                  |
| erasure documents pass                                                          | pass counted "done" over swallowed failures                                                                  | purge throws → pass fails → request `partial`, operator re-arm retries (mirrors #3135's uploads-pass honesty contract)                                                                                                                              |
| cloud-sync prune (onedrive/gdrive shared pipeline)                              | same funnel                                                                                                  | honest funnel; sync loop retries next scan                                                                                                                                                                                                          |
| cloud-sync update (ref rotation)                                                | direct best-effort corpus delete, failures swallowed                                                         | durable `knowledge.release_refs` job                                                                                                                                                                                                                |
| controlled-record replacement (`bindReplacement`)                               | never de-indexed the old ref                                                                                 | release job enqueued in the bind tx                                                                                                                                                                                                                 |
| knowledge-entry re-materialize (`attachEntryDocument`)                          | old ref fully stranded (corpus + blob)                                                                       | release job enqueued in the rotation tx                                                                                                                                                                                                             |
| WebDAV PUT-overwrite (`purgeOldBlob`)                                           | blob-only refcount (active docs), corpus stranded, network I/O in tx                                         | file rows trashed in tx + release job (corpus + refcounted blob)                                                                                                                                                                                    |
| temp-file sweep (`sweepTempFiles`)                                              | best-effort blob delete then row delete (failure = permanent leak; indexed thread files left corpus strands) | release first (corpus + refcounted blob), row deleted only on success                                                                                                                                                                               |
| WebDAV upload-abort (`deleteWebdavBlob`)                                        | direct best-effort delete of a never-registered staging blob                                                 | unchanged — pre-registration janitor, outside this class                                                                                                                                                                                            |
| daily reconcile (`knowledge.reconcile_corpus`)                                  | did not exist                                                                                                | walks each org's corpus, releases every ref both liveness predicates declare dead — the lazy backfill for existing deployments (chosen over a synchronous migration backfill; volumes can be large and the sweep is idempotent and bounded per run) |

## Migration

`0063_documents_history_files_gin.sql` — GIN index over `documents.history_files` for the
history-containment probe (`@>`) both liveness predicates use. Forward-only, rolling-safe
(IF NOT EXISTS, plain CREATE INDEX). The stranded-row backfill is deliberately NOT a migration:
the reconcile sweep drains it incrementally.

## Gates (observed)

- unit (branch): `retrievable.test.ts` + `access.test.ts` — 2 files / 12 tests passed; full platform suite 374 files / 72287 tests passed, exit 0
- unit (base src + these tests): 2 files FAIL — `access.test.ts` 3/3 assertions red (no `knowledge` grant), `retrievable.test.ts` fails to load (module absent)
- platform typecheck: exit 0 · platform lint (oxlint type-aware): exit 0
- `backend:integration` on a throwaway tale-db + MinIO:
  - branch (fresh stack): **286/286 checks passed, exit 0** — includes the 7 new corpus-purge scenarios
  - base (main src + this PR's tests, fresh stack): **279/286 — exactly the 7 corpus-purge scenarios FAIL**, every other check green (279 matches the main baseline), with the bug signatures verbatim: replacement `oldCorpusGone=false, oldFetchDark=false`; entry edit `v1Released=false`; honesty `brokenDelete → 200, rowKept=false, corpusKept=true` (success reported, corpus content left behind unrecoverably); cascade `sweepDocs=0, rowGone=false`; twins `corpusKept=false, blobKept=false, twinAnswers=false`; reconcile `reconcileRan=false`; role gate `create → 201, update → 200, delete → 200`

## Cross-class notes

- The erasure `uploads` pass still deletes file rows without blob release — sibling PR #3135's
  territory (unmerged), untouched here to avoid collision; `purgeDocument`'s honesty covers the
  documents pass either way.
- `deleteKnowledgeDocumentsBatch` completes a pre-existing type-only vestige in
  `core/legacy/knowledge_delete.ts` (the batch types existed with no implementation).
