### PR TITLE
fix(platform): make the RAG retrieval gate fail closed

### DIFF
--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -63,9 +63,21 @@ interface AccessScopeArg {
 }
 
 /**
- * Tier-A retrievable filter over app tables: a file ref passes when its
- * metadata row belongs to the org AND (bound document is un-trashed and in
- * scope | thread-bound and the thread is in scope | legacy unbound same-org).
+ * The mandatory re-check over app tables: which corpus refs may this turn
+ * actually read.
+ *
+ * This is the gate `core/knowledge/corpus.ts` delegates to by name. The SQL
+ * half only ADMITS rows — its own comment says so — so this function is the
+ * one that decides, and it must FAIL CLOSED. A ref passes only when its
+ * metadata row belongs to the org, finished indexing, is not trashed, and
+ * lands in exactly one of the two allow branches: a bound document that is
+ * live, un-trashed, still the document's current file, and in scope; or a
+ * thread-bound upload whose thread is in the turn's lineage.
+ *
+ * Everything else is denied, including a row bound to nothing. Denying the
+ * unbound case is what 0.4 did, and it matters because the corpus stamps no
+ * project and no team for such a row, which the SQL half then reads as an
+ * org-wide hub row.
  */
 async function filterRetrievableRagFileIds(
   sql: Sql,
@@ -82,7 +94,12 @@ async function filterRetrievableRagFileIds(
     {
       storageRef: string;
       threadId: string | null;
+      conversationId: string | null;
+      ragStatus: string | null;
+      fileTrashed: boolean;
       documentId: string | null;
+      docExists: boolean;
+      docFileRef: string | null;
       docTrashed: boolean | null;
       docProjectId: string | null;
       docTeamId: string | null;
@@ -90,7 +107,12 @@ async function filterRetrievableRagFileIds(
     }[]
   >`
     SELECT fm.storage_ref AS "storageRef", fm.thread_id AS "threadId",
+           fm.conversation_id AS "conversationId",
+           fm.rag_status AS "ragStatus",
+           (fm.lifecycle_status = 'trashed') AS "fileTrashed",
            fm.document_id AS "documentId",
+           (d.id IS NOT NULL) AS "docExists",
+           d.file_ref AS "docFileRef",
            (d.lifecycle_status = 'trashed') AS "docTrashed",
            d.project_id AS "docProjectId", d.team_id AS "docTeamId",
            d.team_tags AS "docTeamTags"
@@ -111,8 +133,29 @@ async function filterRetrievableRagFileIds(
     if (!row) {
       continue;
     }
+    // Indexing has to have finished. A row mid-reindex still has its previous
+    // chunks in the corpus, and answering from them would serve content the
+    // caller's current scope was never checked against.
+    if (row.ragStatus !== 'completed') {
+      continue;
+    }
+    if (row.fileTrashed) {
+      continue;
+    }
     if (row.documentId !== null) {
+      // A document id pointing at a row that is gone is not a hub document —
+      // without this the LEFT JOIN's NULLs fall through to the hub branch and
+      // the ref is served to the whole org.
+      if (!row.docExists) {
+        continue;
+      }
       if (row.docTrashed === true) {
+        continue;
+      }
+      // A replacement upload moves the document's `file_ref` on and leaves the
+      // previous corpus row behind. Serving it would answer from a superseded
+      // version with nothing marking it stale.
+      if ((row.docFileRef ?? '') !== ref) {
         continue;
       }
       if (access === undefined) {
@@ -155,8 +198,18 @@ async function filterRetrievableRagFileIds(
       }
       continue;
     }
-    // Legacy/unbound: same-org fallback (the 0.4 posture).
-    retrievable.push(ref);
+    // An emailed attachment, once something indexes one. The allow branch
+    // belongs here and is decided by `conversationAssignmentAllows` against
+    // the conversation's CURRENT assignment, so a reassignment moves the
+    // attachment with the mail. Until that lands (#3121) a conversation-scoped
+    // row is denied rather than falling through.
+    if (row.conversationId !== null) {
+      continue;
+    }
+    // Bound to nothing: denied. The corpus stamps no project and no team for
+    // such a row, and the SQL half reads that as org-wide, so allowing it here
+    // would serve one caller's file to every member of the organization.
+    continue;
   }
   return retrievable;
 }

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -3627,6 +3627,99 @@ async function checkProviderCredentials(
 }
 
 /**
+ * The mandatory retrieval re-check, which decides which corpus refs a turn may
+ * read. The SQL half of the two-gate design admits rows and fails open by
+ * design, so this function is the one that has to fail CLOSED. Needs no object
+ * storage — it is pure SQL over `app.file_metadata` and `app.documents` — so it
+ * runs on every invocation, unlike the S3-gated RAG loop below.
+ */
+async function checkRetrievalGate(
+  sql: Sql,
+  ctx: { orgId: string },
+): Promise<void> {
+  const org = `${ctx.orgId}-gate-fixture`;
+  const now = Date.now();
+  const { knowledgeShimHandlers } =
+    await import('./domains/knowledge/service.ts');
+
+  const docRows = await sql<{ id: string }[]>`
+    INSERT INTO app.documents (org_id, title, file_ref, lifecycle_status,
+                               created_by, created_at_ms, updated_at_ms)
+    VALUES (${org}, 'Gate fixture', 's3:gate/current.txt', 'active', 'gate-user',
+            ${now}, ${now})
+    RETURNING id
+  `;
+  const documentId = docRows[0]?.id ?? '';
+  const seedFile = async (
+    ref: string,
+    row: {
+      ragStatus?: string;
+      documentId?: string;
+      conversationId?: string;
+      lifecycle?: string;
+    },
+  ): Promise<void> => {
+    await sql`
+      INSERT INTO app.file_metadata (
+        org_id, storage_ref, file_name, content_type, size, rag_status,
+        document_id, conversation_id, lifecycle_status, created_at_ms
+      ) VALUES (${org}, ${ref}, 'f.txt', 'text/plain', 10,
+                ${row.ragStatus ?? 'completed'}, ${row.documentId ?? null},
+                ${row.conversationId ?? null}, ${row.lifecycle ?? null}, ${now})
+    `;
+  };
+  // The one ref that must pass: the document's CURRENT file, live and un-trashed.
+  await seedFile('s3:gate/current.txt', { documentId });
+  // A replacement moved the document's file_ref on; this row is superseded.
+  await seedFile('s3:gate/superseded.txt', { documentId });
+  // A document id whose row is gone must not read as a hub document.
+  await seedFile('s3:gate/orphan.txt', { documentId: 'gate-no-such-document' });
+  // Bound to nothing: the corpus stamps no project and no team for this shape,
+  // which the SQL half reads as org-wide.
+  await seedFile('s3:gate/unbound.txt', {});
+  // An emailed attachment, denied until the conversation branch lands.
+  await seedFile('s3:gate/mail.txt', { conversationId: 'gate-conv' });
+  // Mid-reindex: the previous chunks are still in the corpus.
+  await seedFile('s3:gate/running.txt', { documentId, ragStatus: 'running' });
+  await seedFile('s3:gate/trashed.txt', { documentId, lifecycle: 'trashed' });
+
+  const expectations: [string, boolean][] = [
+    ['s3:gate/current.txt', true],
+    ['s3:gate/superseded.txt', false],
+    ['s3:gate/orphan.txt', false],
+    ['s3:gate/unbound.txt', false],
+    ['s3:gate/mail.txt', false],
+    ['s3:gate/running.txt', false],
+    ['s3:gate/trashed.txt', false],
+  ];
+  const handler =
+    knowledgeShimHandlers(sql)[
+      'documents/internal_queries:filterRetrievableRagFileIds'
+    ];
+  const parsed = z.array(z.string()).safeParse(
+    await handler?.({
+      organizationId: org,
+      fileIds: expectations.map(([ref]) => ref),
+      access: {
+        projectIds: [],
+        teamIds: [],
+        includeHub: true,
+        threadIds: [],
+      },
+    }),
+  );
+  const allowed = new Set(parsed.success ? parsed.data : []);
+  const wrong = expectations.filter(
+    ([ref, expect]) => allowed.has(ref) !== expect,
+  );
+  record(
+    'retrieval gate fails closed (unbound, superseded, orphan, mid-index)',
+    parsed.success && wrong.length === 0,
+    `parsed=${parsed.success}, wrong=${wrong.map(([ref]) => ref).join('|') || 'none'}, allowed=${[...allowed].join('|') || 'none'} (want only s3:gate/current.txt)`,
+  );
+}
+
+/**
  * Knowledge (RAG) vertical against the real corpus database and a local
  * fake embedding endpoint: upload → document bind → rag.index_file job
  * (extract → embed → chunk upsert) → hybrid search → windowed fetch.
@@ -25902,6 +25995,7 @@ async function main(): Promise<void> {
     await checkAgents(baseUrl, authCtx);
     await checkSkills(baseUrl, authCtx);
     await checkProviderCredentials(sql, baseUrl, authCtx);
+    await checkRetrievalGate(sql, authCtx);
     await checkKnowledge(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkChat(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkTts(sql, baseUrl, authCtx, `itest-${orgSuffix}`);


### PR DESCRIPTION
The re-check that decides which corpus refs a chat turn may read was serving refs it should refuse. A file row bound to nothing was allowed to any member of the organization.

## Why

Retrieval has two gates. The SQL half admits rows and fails open on purpose — `backend/core/knowledge/corpus.ts` says so and names `filterRetrievableRagFileIds` as the decider. That function had drifted to allow by default, under a comment claiming it was 0.4's posture:

```ts
// Legacy/unbound: same-org fallback (the 0.4 posture).
retrievable.push(ref);
```

0.4's line for the same case is `continue` — deny.

The shape is reachable. `indexUploadedFile` stamps corpus scope only from a bound document, so a row with no document carries no project and no team, and `corpus.ts` reads that as an org-wide hub row. Both gates then passed it.

Four guards 0.4 had were missing. Measured against a real Postgres, seven refs where only the first should pass:

| Ref | `origin/main` | This branch |
| --- | --- | --- |
| the document's current file | allowed | allowed |
| a ref the document has since replaced | **allowed** | denied |
| `document_id` pointing at a deleted row | **allowed** | denied |
| bound to nothing | **allowed** | denied |
| bound to a conversation | **allowed** | denied |
| `rag_status = 'running'` | **allowed** | denied |
| the file row trashed | **allowed** | denied |

Six of the seven denials were being served.

## What changed

The SELECT reads four more columns: `fm.rag_status`, `fm.lifecycle_status`, `fm.conversation_id`, and both `d.id IS NOT NULL` and `d.file_ref`.

- Indexing must have finished. A row mid-reindex still has its previous chunks in the corpus, and answering from them serves content the caller's current scope was never checked against.
- A trashed file row is denied, not only a trashed document.
- A `document_id` whose row is gone no longer reads as a hub document. The LEFT JOIN's NULLs were falling into the hub branch.
- A ref the document has since replaced is denied. A replacement upload moves `file_ref` on and leaves the previous corpus row behind, so this also closes the retrieval half of the superseded-document defect.
- Bound to nothing, or bound to a conversation, is denied.

The conversation case gets its own explicit branch rather than relying on the new default, so the next reader sees where the allow branch goes. That branch is #3121's, decided by `conversationAssignmentAllows` against the conversation's current assignment.

## Risk

The `rag_status = 'completed'` requirement makes retrieval briefly deny a knowledge entry while a new version reindexes — `knowledge_entries/service.ts` sets `rag_status = NULL` and re-queues. That is the conservative direction and it is what 0.4 did. Every other `rag_status` writer converges on the one completion write in `knowledge/service.ts`.

## Tests

A new `checkRetrievalGate` in `integration-check.ts` pins the table above. It needs no object storage, so it runs on every invocation — unlike the RAG loop below it, which skips without `ITEST_S3_ENDPOINT`. Placing it inside that function would have meant it never ran where the gate matters most.

Mutation: against `origin/main`'s copy of the function, six of the seven assertions go red and the legitimate hub document still passes.

## Scope

Does not close #3121. Emailed attachments still are not indexed; this makes the gate safe for that work to land against, which is why it goes first.

The indexer-side half of the superseded defect is untouched — a replacement still leaves an orphaned corpus row, and a stale job still spends extract-and-embed cost on a blob nobody will read. This denies the read; purging the row is separate.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check` and `lint:sast` green.
