### PR TITLE
fix(platform): restore three dropped retention behaviours

### DIFF
--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -391,6 +391,7 @@ interface Phase2Stats {
   documents: number;
   chatHistory: number;
   contacts: number;
+  externalConversations: number;
   agentRuns: number;
   automationRuns: number;
   auditLogs: number;
@@ -714,6 +715,122 @@ async function sweepContacts(
   return processed + removed.length;
 }
 
+/**
+ * The `externalConversations` category — the Inbox's own payload, and the
+ * heaviest correspondent-PII surface retention governs:
+ * `app.conversation_messages.content` is NOT NULL text holding the inbound
+ * and outbound email BODIES, plus a `metadata` jsonb of envelope detail.
+ *
+ * Ages by `last_message_at_ms` (the 0.4 `lastMessageAt` window, served by
+ * `conversations_org_last_message`). A conversation that never received a
+ * message has no activity timestamp to age against and is intentionally NOT
+ * a candidate — the 0.4 index range said the same, and `NULL < cutoff` is
+ * already false in SQL, so the rule costs nothing to keep.
+ *
+ * Message rows ride the parent's `ON DELETE CASCADE` (migration 0036).
+ * Stored mail attachments do NOT: `app.file_metadata.conversation_id`
+ * (migration 0037) is a plain column with no FK, and the mail lane stamps
+ * `source` with the CONNECTOR slug, so `sweepTempFiles` — which only takes
+ * `source` 'user'/'agent' — never reaches them. Without the cascade below,
+ * deleting the email body would leave its attachment bytes live forever
+ * behind a dangling pointer, which is the opposite of the promise the
+ * window makes. A file promoted into a Document is left alone: the
+ * `documents` category owns that lifecycle, the same `document_id IS NULL`
+ * guard `sweepTempFiles` uses.
+ */
+async function sweepExternalConversations(
+  sql: Sql,
+  org: OrgPolicy,
+  holds: ActiveHolds,
+): Promise<number> {
+  if (org.config.externalConversationsEnabled !== true) return 0;
+  const days = org.config.externalConversationsRetentionDays;
+  if (typeof days !== 'number' || days <= 0) return 0;
+  if (holds.orgHeld) return 0;
+  const cutoff = Date.now() - days * DAY_MS;
+  const graceDays = org.config.deletionGraceDays ?? 0;
+  let processed = 0;
+  if (graceDays > 0) {
+    const flipped = await sql<{ id: string }[]>`
+      UPDATE app.conversations SET
+        lifecycle_status = 'expired', status_changed_at_ms = ${Date.now()}
+      WHERE id IN (
+        SELECT id FROM app.conversations
+        WHERE org_id = ${org.organizationId} AND lifecycle_status IS NULL
+          AND last_message_at_ms < ${cutoff}
+        LIMIT ${BATCH_LIMIT}
+      )
+      RETURNING id
+    `;
+    processed += flipped.length;
+  }
+  const doomed =
+    graceDays > 0
+      ? await sql<{ id: string }[]>`
+          SELECT id FROM app.conversations
+          WHERE org_id = ${org.organizationId}
+            AND lifecycle_status IN ('trashed', 'expired')
+            AND status_changed_at_ms < ${Date.now() - graceDays * DAY_MS}
+          LIMIT ${BATCH_LIMIT}
+        `
+      : await sql<{ id: string }[]>`
+          SELECT id FROM app.conversations
+          WHERE org_id = ${org.organizationId}
+            AND (lifecycle_status IN ('trashed', 'expired')
+                 OR (lifecycle_status IS NULL
+                     AND last_message_at_ms < ${cutoff}))
+          LIMIT ${BATCH_LIMIT}
+        `;
+  if (doomed.length === 0) return processed;
+  const doomedIds = doomed.map((row) => row.id);
+  const attachments = await sql<
+    { id: string; storageRef: string; conversationId: string }[]
+  >`
+    SELECT id, storage_ref AS "storageRef",
+           conversation_id AS "conversationId"
+    FROM app.file_metadata
+    WHERE org_id = ${org.organizationId}
+      AND conversation_id IN ${sql(doomedIds)}
+      AND document_id IS NULL
+  `;
+  const stranded = new Set<string>();
+  if (attachments.length > 0) {
+    const orgSlug = await resolveOrgSlug(sql, org.organizationId);
+    for (const file of attachments) {
+      if (orgSlug !== null) {
+        // The same refcounted release `sweepTempFiles` uses: an indexed
+        // attachment's corpus rows die with it, a blob another holder still
+        // references survives, and a failed delete KEEPS the row so the next
+        // sweep retries rather than leaking the bytes forever.
+        const outcome = await releaseRefs(sql, {
+          organizationId: org.organizationId,
+          orgSlug,
+          refs: [file.storageRef],
+          excludeFileMetadataId: file.id,
+        });
+        if (outcome.failures.length > 0) {
+          console.warn(
+            `[retention] conversation-attachment release failed for ${file.id} — keeping the row and its conversation for the next sweep:`,
+            outcome.failures,
+          );
+          stranded.add(file.conversationId);
+          continue;
+        }
+      }
+      await sql`DELETE FROM app.file_metadata WHERE id = ${file.id}`;
+    }
+  }
+  // A conversation whose attachment could not be released stays too: deleting
+  // the parent would orphan the file row behind a dangling pointer, which is
+  // the failure this cascade exists to prevent.
+  const deletable = doomedIds.filter((id) => !stranded.has(id));
+  if (deletable.length === 0) return processed;
+  const removed = await sql<{ id: string }[]>`
+    DELETE FROM app.conversations WHERE id IN ${sql(deletable)} RETURNING id
+  `;
+  return processed + removed.length;
+}
+
 async function sweepAgentRuns(
   sql: Sql,
   org: OrgPolicy,
@@ -884,6 +1001,7 @@ export async function sweepOrgPhase2(
     documents: 0,
     chatHistory: 0,
     contacts: 0,
+    externalConversations: 0,
     agentRuns: 0,
     automationRuns: 0,
     auditLogs: 0,
@@ -893,6 +1011,11 @@ export async function sweepOrgPhase2(
   stats.documents = await sweepDocuments(sql, org, holds);
   stats.chatHistory = await sweepChatHistory(sql, org, holds);
   stats.contacts = await sweepContacts(sql, org, holds);
+  stats.externalConversations = await sweepExternalConversations(
+    sql,
+    org,
+    holds,
+  );
   stats.agentRuns = await sweepAgentRuns(sql, org, holds);
   stats.automationRuns = await sweepAutomationRuns(sql, org);
   stats.auditLogs = await sweepAuditLogs(sql, org, holds);

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -26070,6 +26070,8 @@ async function checkRetention(
       'messageFeedbackRetentionDays: 7',
       'notificationsEnabled: true',
       'notificationsRetentionDays: 7',
+      'externalConversationsEnabled: true',
+      'externalConversationsRetentionDays: 7',
       'deletionGraceDays: 0',
     ].join('\n'),
   );
@@ -26206,6 +26208,52 @@ async function checkRetention(
     ) RETURNING id
   `;
 
+  // externalConversations: three conversations aged by `last_message_at_ms`.
+  // The ancient one carries an email BODY and a stored mail attachment and
+  // must go; the fresh one stays; the never-messaged one has no activity
+  // timestamp to age against and must survive regardless of its age.
+  await sql`
+    INSERT INTO app.conversations (
+      org_id, subject, status, channel, direction, connector_name,
+      last_message_at_ms, created_at_ms
+    ) VALUES
+      (${orgId}, 'rt-conv-ancient', 'open', 'email', 'inbound', 'imap_smtp',
+       ${ancient}, ${ancient}),
+      (${orgId}, 'rt-conv-fresh', 'open', 'email', 'inbound', 'imap_smtp',
+       ${now}, ${now}),
+      (${orgId}, 'rt-conv-silent', 'open', 'email', 'inbound', 'imap_smtp',
+       NULL, ${ancient})
+  `;
+  const convRows = await sql<{ id: string; subject: string }[]>`
+    SELECT id, subject FROM app.conversations
+    WHERE org_id = ${orgId} AND subject LIKE 'rt-conv-%'
+  `;
+  const convId = (subject: string): string =>
+    convRows.find((row) => row.subject === subject)?.id ?? '';
+  const ancientConv = convId('rt-conv-ancient');
+  await sql`
+    INSERT INTO app.conversation_messages (
+      org_id, conversation_id, channel, direction, delivery_state, content,
+      sent_at_ms, created_at_ms
+    ) VALUES
+      (${orgId}, ${ancientConv}, 'email', 'inbound', 'delivered',
+       'ancient email body', ${ancient}, ${ancient}),
+      (${orgId}, ${convId('rt-conv-fresh')}, 'email', 'inbound', 'delivered',
+       'fresh email body', ${now}, ${now})
+  `;
+  // The mail attachment binding (migration 0037): `source` is the CONNECTOR
+  // slug, so no temp-file sweep can ever collect this row — the
+  // conversation sweep owns it or nothing does.
+  const convAttachment = await sql<{ id: string }[]>`
+    INSERT INTO app.file_metadata (
+      org_id, storage_ref, file_name, content_type, size, source,
+      uploaded_by, conversation_id, mail_received_at_ms, created_at_ms
+    ) VALUES (
+      ${orgId}, 's3:itest/conv-attachment', 'invoice.pdf', 'application/pdf',
+      9, 'imap_smtp', ${userId}, ${ancientConv}, ${ancient}, ${ancient}
+    ) RETURNING id
+  `;
+
   const { runRetentionCleanup } =
     await import('./domains/retention/service.ts');
   // An org hold freezes the whole run.
@@ -26222,6 +26270,10 @@ async function checkRetention(
   const frozen = await sql<{ count: string }[]>`
     SELECT count(*)::text AS count FROM app.message_feedback
     WHERE org_id = ${orgId} AND message_id = 'rt-old'
+  `;
+  const frozenConv = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.conversations
+    WHERE id = ${ancientConv}
   `;
   await sql`
     UPDATE app.legal_holds SET released_at_ms = ${Date.now()}
@@ -26299,6 +26351,182 @@ async function checkRetention(
       automationRunsLeft.map((row) => row.name).join(',') ===
         'rt-wf-running,rt-wf-waiting',
     `doc=${docGone[0]?.count} thread=${threadGone[0]?.count} msgs=${msgGone[0]?.count} run=${runGone[0]?.count} audit=${auditGone[0]?.count} temp=${tempGone[0]?.count} (all want 0), automationRuns=${automationRunsLeft.map((row) => row.name).join(',')} (want rt-wf-running,rt-wf-waiting)`,
+  );
+
+  const convLeft = await sql<{ subject: string }[]>`
+    SELECT subject FROM app.conversations
+    WHERE org_id = ${orgId} AND subject LIKE 'rt-conv-%'
+    ORDER BY subject
+  `;
+  const convBodiesLeft = await sql<{ content: string }[]>`
+    SELECT content FROM app.conversation_messages
+    WHERE org_id = ${orgId} AND conversation_id = ${ancientConv}
+  `;
+  const convAttachmentGone = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.file_metadata
+    WHERE id = ${convAttachment[0]?.id ?? ''}
+  `;
+  record(
+    'retention: external conversations age by last message, org hold freezes',
+    // The org hold froze the ancient conversation on the first run.
+    frozenConv[0]?.count === '1' &&
+      // Past the window the conversation goes; the fresh one and the
+      // never-messaged one (no activity timestamp to age against) stay.
+      convLeft.map((row) => row.subject).join(',') ===
+        'rt-conv-fresh,rt-conv-silent' &&
+      // The email BODIES ride the parent's ON DELETE CASCADE...
+      convBodiesLeft.length === 0 &&
+      // ...and the stored mail attachment, which no temp-file sweep can
+      // reach, goes with them instead of outliving the mail forever.
+      convAttachmentGone[0]?.count === '0',
+    `frozenConv=${frozenConv[0]?.count} (want 1), left=${convLeft.map((row) => row.subject).join(',')} (want rt-conv-fresh,rt-conv-silent), bodies=${convBodiesLeft.length} attachment=${convAttachmentGone[0]?.count} (both want 0)`,
+  );
+
+  // With a deletion grace configured the conversation sweep is TWO-PASS
+  // (the 0.4 model): pass one marks the aged row `expired` and starts the
+  // grace clock, and only a row whose grace has since elapsed is deleted.
+  await writeFile(
+    path.join(governanceDir, 'retention-policy.yml'),
+    [
+      'documentsEnabled: true',
+      'documentsRetentionDays: 7',
+      'externalConversationsEnabled: true',
+      'externalConversationsRetentionDays: 7',
+      'deletionGraceDays: 30',
+    ].join('\n'),
+  );
+  orgConfig.clearOrgConfigCaches();
+  const graceConv = await sql<{ id: string }[]>`
+    INSERT INTO app.conversations (
+      org_id, subject, status, channel, direction, connector_name,
+      last_message_at_ms, created_at_ms
+    ) VALUES (
+      ${orgId}, 'rt-conv-grace', 'open', 'email', 'inbound', 'imap_smtp',
+      ${ancient}, ${ancient}
+    ) RETURNING id
+  `;
+  const graceConvId = graceConv[0]?.id ?? '';
+  await runRetentionCleanup(sql);
+  const graceFirstPass = await sql<{ lifecycleStatus: string | null }[]>`
+    SELECT lifecycle_status AS "lifecycleStatus" FROM app.conversations
+    WHERE id = ${graceConvId}
+  `;
+  // Backdate the stamp pass one just wrote so the grace has elapsed.
+  await sql`
+    UPDATE app.conversations
+    SET status_changed_at_ms = ${now - 60 * 24 * 3_600_000}
+    WHERE id = ${graceConvId}
+  `;
+  await runRetentionCleanup(sql);
+  const graceSecondPass = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.conversations
+    WHERE id = ${graceConvId}
+  `;
+  record(
+    'retention: external conversations honour the two-pass deletion grace',
+    // Pass one marks, and must NOT delete inside the grace window.
+    graceFirstPass[0]?.lifecycleStatus === 'expired' &&
+      // Pass two removes it once the grace has elapsed.
+      graceSecondPass[0]?.count === '0',
+    `firstPass=${graceFirstPass.length === 0 ? 'ROW GONE' : (graceFirstPass[0]?.lifecycleStatus ?? 'unmarked')} (want expired), secondPass=${graceSecondPass[0]?.count} (want 0)`,
+  );
+
+  // Restore the policy this check set up. The grace variant above writes
+  // `deletionGraceDays: 30`, and a later governance check asserts on the
+  // summary of its own policy change — inheriting a grace it never set made
+  // that summary list a reduction it did not expect. Test isolation, not a
+  // product rule.
+  await writeFile(
+    path.join(governanceDir, 'retention-policy.yml'),
+    [
+      'documentsEnabled: true',
+      'documentsRetentionDays: 7',
+      'chatHistoryEnabled: true',
+      'chatHistoryRetentionDays: 7',
+      'agentRunsEnabled: true',
+      'agentRunsRetentionDays: 7',
+      'workflowLogEnabled: true',
+      'workflowLogRetentionDays: 7',
+      'auditLogEnabled: true',
+      'auditLogRetentionDays: 365',
+      'userTempEnabled: true',
+      'userTempRetentionHours: 1',
+      'usageLedgerEnabled: true',
+      // Below the 30-day floor — the clamp must raise it.
+      'usageLedgerRetentionDays: 1',
+      'messageFeedbackEnabled: true',
+      'messageFeedbackRetentionDays: 7',
+      'notificationsEnabled: true',
+      'notificationsRetentionDays: 7',
+      'externalConversationsEnabled: true',
+      'externalConversationsRetentionDays: 7',
+      'deletionGraceDays: 0',
+    ].join('\n'),
+  );
+  orgConfig.clearOrgConfigCaches();
+
+  // Sign-in throttling state is global (no org scope) and swept by the
+  // maintenance job, not the per-org cleanup: one 30-day window for
+  // attempts, block counters AND 2FA attempts.
+  const ttlOld = now - 45 * 24 * 3_600_000;
+  await sql`
+    INSERT INTO app.login_attempts (email, consecutive_failures,
+                                    last_failure_at)
+    VALUES ('rt-ttl-old@example.com', 3, ${ttlOld}),
+           ('rt-ttl-new@example.com', 3, ${now})
+    ON CONFLICT (email) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO app.login_block_counters (email, window_start, lockout_count,
+                                          ip_limit_count, last_ip, updated_at)
+    VALUES ('rt-ttl-old@example.com', ${ttlOld}, 1, 0, '203.0.113.9',
+            ${ttlOld}),
+           ('rt-ttl-new@example.com', ${now}, 1, 0, '203.0.113.9', ${now})
+    ON CONFLICT (email, window_start) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO app.two_factor_attempts (user_id, consecutive_failures,
+                                         last_failure_at_ms)
+    VALUES ('rt-ttl-old-user', 3, ${ttlOld}),
+           ('rt-ttl-new-user', 3, ${now})
+    ON CONFLICT (user_id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO app.two_factor_grace (user_id, grace_until_ms)
+    VALUES ('rt-ttl-old-user', ${ttlOld})
+    ON CONFLICT (user_id) DO NOTHING
+  `;
+  const ttlHandler = createTaskList({ sql })['maintenance.login_attempts_ttl'];
+  if (ttlHandler !== undefined) await ttlHandler({});
+  const attemptsLeft = await sql<{ email: string }[]>`
+    SELECT email FROM app.login_attempts WHERE email LIKE 'rt-ttl-%'
+  `;
+  const countersLeft = await sql<{ email: string }[]>`
+    SELECT email FROM app.login_block_counters WHERE email LIKE 'rt-ttl-%'
+  `;
+  const twoFactorLeft = await sql<{ userId: string }[]>`
+    SELECT user_id AS "userId" FROM app.two_factor_attempts
+    WHERE user_id LIKE 'rt-ttl-%'
+  `;
+  const graceLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.two_factor_grace
+    WHERE user_id = 'rt-ttl-old-user'
+  `;
+  record(
+    'retention: sign-in throttling TTL is one 30-day window, grace kept',
+    attemptsLeft.map((row) => row.email).join(',') ===
+      'rt-ttl-new@example.com' &&
+      // The counters carry `email` + `last_ip`: same window as the attempts
+      // they summarise, never longer.
+      countersLeft.map((row) => row.email).join(',') ===
+        'rt-ttl-new@example.com' &&
+      // Parity for 2FA attempts — cleared on success only, so a user who
+      // failed and never came back left a permanently stuck row.
+      twoFactorLeft.map((row) => row.userId).join(',') === 'rt-ttl-new-user' &&
+      // `two_factor_grace` is NOT age-swept: an absent row mints a FRESH
+      // grace window, so ageing it out would reward staying away.
+      graceLeft[0]?.count === '1',
+    `attempts=${attemptsLeft.map((row) => row.email).join(',')} counters=${countersLeft.map((row) => row.email).join(',')} (both want rt-ttl-new@example.com), twoFactor=${twoFactorLeft.map((row) => row.userId).join(',')} (want rt-ttl-new-user), grace=${graceLeft[0]?.count} (want 1)`,
   );
 }
 

--- a/services/platform/backend/jobs/task-list.ts
+++ b/services/platform/backend/jobs/task-list.ts
@@ -239,18 +239,46 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       console.log(`[maintenance] rate_limit_gc removed ${deleted.count} rows`);
     },
     'maintenance.login_attempts_ttl': async () => {
-      const attemptsCutoff = Date.now() - 30 * 24 * 3_600_000;
-      const countersCutoff = Date.now() - 90 * 24 * 3_600_000;
+      // ONE window for every table this job touches — the 0.4
+      // `cleanupLoginAttemptsGlobal` contract. `login_attempts` and
+      // `login_block_counters` are both keyed by `email`, and the counters
+      // additionally keep `last_ip`, so a longer counter window would hold
+      // identifying data longer than the attempts it summarises. Nothing
+      // needs it there: `listBlockCounters` reads the most recent 200 rows
+      // by `updated_at` with no time window, and the lockout itself lives
+      // on `login_attempts.locked_until`, never on a counter bucket, so a
+      // shorter counter window releases no lockout early. The durable
+      // forensic record is `app.audit_logs`, under its own retention.
+      const cutoff = Date.now() - 30 * 24 * 3_600_000;
       const attempts = await deps.sql`
         DELETE FROM app.login_attempts
-        WHERE last_failure_at < ${attemptsCutoff}
+        WHERE last_failure_at < ${cutoff}
       `;
       const counters = await deps.sql`
         DELETE FROM app.login_block_counters
-        WHERE window_start < ${countersCutoff}
+        WHERE window_start < ${cutoff}
+      `;
+      // Parity for `two_factor_attempts`: a failed TOTP is a failed password
+      // in brute-force terms, but the table is only cleared on SUCCESS (and
+      // on member removal) — a user who failed 2FA and never came back left
+      // a permanently stuck row.
+      //
+      // `app.two_factor_grace` in the same migration is deliberately NOT
+      // swept. Its `grace_until_ms` is the enforcement anchor written once
+      // by `setGraceUntilIfAbsent` on first sign-in under an enforced
+      // policy, and an ABSENT row reads as "no anchor yet" —
+      // `evaluateTwoFactorEnforcement` then mints a fresh
+      // `now + gracePeriodDays`. Ageing those rows out would hand a user who
+      // already burned their grace a brand-new window just for staying away,
+      // which is a security regression, not data minimisation. The row also
+      // carries no PII beyond `user_id`, and member removal already deletes
+      // it (`domains/members/service.ts`).
+      const twoFactor = await deps.sql`
+        DELETE FROM app.two_factor_attempts
+        WHERE last_failure_at_ms < ${cutoff}
       `;
       console.log(
-        `[maintenance] login_attempts_ttl removed ${attempts.count} attempts, ${counters.count} counters`,
+        `[maintenance] login_attempts_ttl removed ${attempts.count} attempts, ${counters.count} counters, ${twoFactor.count} 2fa attempts`,
       );
     },
     'rag.index_file': async (payload) => {


### PR DESCRIPTION
An administrator could set an `externalConversations` retention window and nothing ever deleted. Email bodies were kept forever. Two smaller windows were also wrong.

Refs #3142.

## Why

The category is exposed and validated in three places — `domains/retention/routes.ts:206`, `domains/governance/settings-tail.ts:317`, `lib/shared/schemas/retention.ts:20` — and `domains/retention/service.ts` never read `app.conversations`. `app.conversation_messages.content` is NOT NULL text holding inbound and outbound email bodies, plus a `metadata` jsonb of envelope detail, so this is the heaviest correspondent-PII surface retention governs.

Two windows were also off, neither with a note:

- `login_block_counters` aged at 90 days where 0.4 used one 30-day cutoff for attempts and counters together. Those rows hold `email` and `last_ip`.
- `two_factor_attempts` lost its sweep entirely. 0.4 aged it alongside login attempts, added deliberately because "users who failed 2FA and never came back left a permanently-stuck row".

## What changed

`sweepExternalConversations` ages by `app.conversations.last_message_at_ms`, served by the existing `conversations_org_last_message` index. Same shape as the sweeps beside it: `BATCH_LIMIT` bound, the org-hold skip, the two-pass grace through `lifecycle_status`/`status_changed_at_ms`, wired into `Phase2Stats` and `sweepOrgPhase2`.

A conversation that never received a message has no timestamp to age against and is deliberately not a candidate.

`jobs/task-list.ts` now uses one 30-day cutoff for all three auth tables.

**Beyond the brief, because leaving it would have made the sweep worse than not having it:** deleting a conversation would have orphaned its mail attachments permanently. `file_metadata.conversation_id` has no foreign key, and the mail lane stamps `source` with the connector slug, so `sweepTempFiles` — which takes only `source` `user`/`agent` — can never collect them. The window would have destroyed the email body and left the attachment bytes live behind a dangling pointer. The index and the blob helper both already existed. A file promoted into a Document is left alone, under the same `document_id IS NULL` guard `sweepTempFiles` uses.

## Decisions

**`two_factor_grace` gets no sweep.** An absent row reads as "no anchor yet", and `evaluateTwoFactorEnforcement` then mints a fresh `now + gracePeriodDays` — so ageing it out would hand a user who already burned their grace a new window for staying away. It carries no PII beyond `user_id`, and member removal already deletes it. A mutation locks this in, so nobody adds the sweep later by symmetry.

**30 days for counters, not 90.** `listBlockCounters` has no time window, so nothing reads a counter beyond 30 days, and the lockout itself lives on `login_attempts.locked_until` rather than a counter bucket — so the shorter window releases no lockout early.

## Risk

The retention sweeps delete blobs best-effort, so a failed blob delete is logged and the row is destroyed anyway: the file row goes while the bytes may remain. I kept that idiom to match the neighbouring sweeps rather than diverge inside one file, but it is knowingly weaker than the strict posture #3135 gives erasure. Observed directly — with no object store configured the sweep warns and continues. Worth a deliberate decision rather than inheriting it.

## Tests

Three assertions in `checkRetention`, and eleven mutations, each named with the assertion that went red:

| Mutation | Went red |
| --- | --- |
| both hold guards disabled | `frozenConv=0 (want 1)` |
| only the outer sweep guard disabled | stayed green — the in-function guard is load-bearing |
| age by `created_at_ms` | destroyed the never-messaged conversation |
| foreign key re-created without `ON DELETE CASCADE` | sweep failed, bodies survived |
| attachment cascade removed | `attachment=1 (want 0)` |
| counters back to 90 days | both counter rows survived |
| 2FA delete neutered | both 2FA rows survived |
| a `two_factor_grace` age delete added | `grace=0 (want 1)` |
| attempts window widened to 90 days | both attempt rows survived |
| pass-one flip disabled | `firstPass=unmarked` |
| grace clock dropped from the delete | `firstPass=ROW GONE` — deleted inside the window |

The grace path had no coverage before this — the existing `checkRetention` runs `deletionGraceDays: 0` throughout, so `sweepContacts`'s grace path is untested too. Rather than ship an untested path, there is now an assertion for it.

Proven with a driver importing the real `runRetentionCleanup` and the real task-list handler against a throwaway database, because re-running the full suite eleven times was not viable. Throwaway role and databases dropped afterwards.

## Scope

No per-row audit rows. 0.4's `deleteExpiredExternalConversation` emitted `external_conversation.retention_deleted`, and no 0.5 sweep emits per-row audit events, so this matches its neighbours instead of introducing a lone pattern. Retention emitting no audit rows at all is tracked in #3142.

`chatFilterEvents` is the same defect shape and is left alone: it has no production writer yet, so it should land with one.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check` green.
