### PR TITLE
fix(platform): re-check legal holds per erasure pass and fix the receipt

### DIFF
--- a/services/platform/app/features/settings/governance/data-subject-requests/breakdown-entries.test.ts
+++ b/services/platform/app/features/settings/governance/data-subject-requests/breakdown-entries.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+
+import { foldBreakdownEntries } from './breakdown-entries.ts';
+
+describe('foldBreakdownEntries', () => {
+  test('reads the plain-count shape a pass records', () => {
+    // The whole panel rendered blank on this shape before: every entry was
+    // skipped, so neither a row nor the empty-category line appeared.
+    expect(
+      foldBreakdownEntries({ uploads: 3, cloudGrants: 2, memories: 0 }),
+    ).toEqual({
+      visible: [
+        { key: 'uploads', rows: 3, skippedByHold: 0 },
+        { key: 'cloudGrants', rows: 2, skippedByHold: 0 },
+      ],
+      zeroCount: 1,
+    });
+  });
+
+  test('still reads the older object shape on existing receipts', () => {
+    expect(
+      foldBreakdownEntries({
+        documents: { rows: 4, skippedByHold: 0 },
+        threads: { rows: 0, skippedByHold: 2 },
+        feedback: { rows: 0, skippedByHold: 0 },
+      }),
+    ).toEqual({
+      visible: [
+        { key: 'documents', rows: 4, skippedByHold: 0 },
+        { key: 'threads', rows: 0, skippedByHold: 2 },
+      ],
+      zeroCount: 1,
+    });
+  });
+
+  test('sums the login-attempts pair into one row count', () => {
+    expect(
+      foldBreakdownEntries({
+        loginAttempts: { attempts: 2, blockCounters: 1 },
+      }),
+    ).toEqual({
+      visible: [{ key: 'loginAttempts', rows: 3, skippedByHold: 0 }],
+      zeroCount: 0,
+    });
+  });
+
+  test('counts a held-off category as visible, not as empty', () => {
+    const { visible, zeroCount } = foldBreakdownEntries({
+      uploads: { rows: 0, skippedByHold: 5 },
+    });
+    expect(zeroCount).toBe(0);
+    expect(visible).toEqual([{ key: 'uploads', rows: 0, skippedByHold: 5 }]);
+  });
+
+  test('ignores a value that is neither a count nor an entry', () => {
+    expect(foldBreakdownEntries({ odd: 'nope', missing: null })).toEqual({
+      visible: [],
+      zeroCount: 0,
+    });
+  });
+
+  test('an empty snapshot yields nothing to show', () => {
+    expect(foldBreakdownEntries({})).toEqual({ visible: [], zeroCount: 0 });
+  });
+});

--- a/services/platform/app/features/settings/governance/data-subject-requests/breakdown-entries.ts
+++ b/services/platform/app/features/settings/governance/data-subject-requests/breakdown-entries.ts
@@ -1,0 +1,58 @@
+/**
+ * Folds an erasure receipt's per-category snapshot into the rows the
+ * breakdown panel renders, plus a count of the categories that came back
+ * empty.
+ *
+ * Two shapes reach this. A pass records a plain count. The older shape was an
+ * object per category, and receipts written before that change still carry
+ * it, so both are read. Reading only the object form is what rendered the
+ * panel blank for every recent request: every entry was skipped before the
+ * empty-category branch, so the panel showed neither rows nor the "no data in
+ * N other categories" line.
+ */
+
+export interface BreakdownRow {
+  key: string;
+  rows: number;
+  skippedByHold: number;
+}
+
+interface PerCategoryEntry {
+  rows?: number;
+  skippedByHold?: number;
+  blobs?: number;
+  attempts?: number;
+  blockCounters?: number;
+}
+
+export function foldBreakdownEntries(snapshot: Record<string, unknown>): {
+  visible: BreakdownRow[];
+  zeroCount: number;
+} {
+  const visible: BreakdownRow[] = [];
+  let zeroCount = 0;
+  for (const [key, value] of Object.entries(snapshot)) {
+    let rows: number;
+    let skippedByHold = 0;
+    if (typeof value === 'number') {
+      rows = value;
+    } else if (typeof value === 'object' && value !== null) {
+      const entry = value as PerCategoryEntry;
+      // `loginAttempts` reported {attempts, blockCounters} rather than {rows};
+      // sum them into the same "rows" view.
+      rows =
+        typeof entry.rows === 'number'
+          ? entry.rows
+          : (entry.attempts ?? 0) + (entry.blockCounters ?? 0);
+      skippedByHold = entry.skippedByHold ?? 0;
+    } else {
+      continue;
+    }
+    if (rows === 0 && skippedByHold === 0) {
+      zeroCount++;
+    } else {
+      visible.push({ key, rows, skippedByHold });
+    }
+  }
+  return { visible, zeroCount };
+}

--- a/services/platform/app/features/settings/governance/data-subject-requests/request-detail-drawer.tsx
+++ b/services/platform/app/features/settings/governance/data-subject-requests/request-detail-drawer.tsx
@@ -14,6 +14,7 @@ import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell'
 import { Sheet } from '@/app/components/ui/overlays/sheet';
 import { useT } from '@/lib/i18n/client';
 
+import { foldBreakdownEntries } from './breakdown-entries.ts';
 import { CancelDialog } from './cancel-dialog';
 import { ExtendDeadlineDialog } from './extend-deadline-dialog';
 import { useGetErasureRequest } from './hooks/queries';
@@ -511,38 +512,12 @@ function CancelledBlock({
   );
 }
 
-interface PerCategoryEntry {
-  rows?: number;
-  skippedByHold?: number;
-  blobs?: number;
-  attempts?: number;
-  blockCounters?: number;
-}
-
 function FullBreakdown({ snapshot }: { snapshot: Record<string, unknown> }) {
   const { t } = useT('governance');
   // Sort entries: non-zero first, zero-value categories collapsed to a
   // count at the bottom. Each known field uses an i18n label; unknown
   // category names fall back to the raw key.
-  const entries = Object.entries(snapshot);
-  const visible: { key: string; rows: number; skippedByHold: number }[] = [];
-  let zeroCount = 0;
-  for (const [key, value] of entries) {
-    if (typeof value !== 'object' || value === null) continue;
-    const e = value as PerCategoryEntry;
-    // `loginAttempts` uses {attempts, blockCounters} instead of {rows};
-    // sum them as the "rows" view for the breakdown.
-    const rows =
-      typeof e.rows === 'number'
-        ? e.rows
-        : (e.attempts ?? 0) + (e.blockCounters ?? 0);
-    const skippedByHold = e.skippedByHold ?? 0;
-    if (rows === 0 && skippedByHold === 0) {
-      zeroCount++;
-    } else {
-      visible.push({ key, rows, skippedByHold });
-    }
-  }
+  const { visible, zeroCount } = foldBreakdownEntries(snapshot);
 
   return (
     <details className="border-border bg-muted/20 group rounded-md border p-2 text-sm">

--- a/services/platform/backend/domains/erasure/receipt-status.test.ts
+++ b/services/platform/backend/domains/erasure/receipt-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+
+import { erasureReceiptError, erasureReceiptStatus } from './service.ts';
+
+describe('erasureReceiptStatus', () => {
+  test('a clean cascade is done', () => {
+    expect(erasureReceiptStatus([], [])).toBe('done');
+  });
+
+  test('a failed pass makes the receipt partial', () => {
+    expect(erasureReceiptStatus(['uploads'], [])).toBe('partial');
+  });
+
+  test('a pass held off by a legal hold makes it partial too', () => {
+    // Without this the receipt would claim `done` for a cascade a hold
+    // stopped halfway, which is the Art 19 confirmation the subject reads.
+    expect(erasureReceiptStatus([], ['documents'])).toBe('partial');
+  });
+});
+
+describe('erasureReceiptError', () => {
+  test('says nothing when nothing went wrong', () => {
+    expect(erasureReceiptError([], [])).toBeNull();
+  });
+
+  test('names the failed passes', () => {
+    expect(erasureReceiptError(['uploads', 'threads'], [])).toBe(
+      'failed passes: uploads, threads',
+    );
+  });
+
+  test('names the held-off passes separately from the failed ones', () => {
+    expect(erasureReceiptError(['uploads'], ['documents'])).toBe(
+      'failed passes: uploads; held off by a legal hold: documents',
+    );
+  });
+});

--- a/services/platform/backend/domains/erasure/service.ts
+++ b/services/platform/backend/domains/erasure/service.ts
@@ -1,9 +1,17 @@
 import type { Sql, TransactionSql } from 'postgres';
 
+import { isRecord } from '../../../lib/utils/type-utils.ts';
 import { isAdminRole } from '../../auth/membership.ts';
+import { deleteKnowledgeDocument } from '../../core/legacy/knowledge_delete.ts';
+import { normalizeAuthEmail } from '../../core/lib/auth/normalize_auth_email.ts';
+import { parseBlobRef } from '../../core/lib/storage/blob_ref.ts';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
-import { readGovernancePolicyForOrg } from '../../lib/org-config.ts';
+import { resolveObjectStore, s3DeleteObject } from '../../lib/object-store.ts';
+import {
+  readGovernancePolicyForOrg,
+  resolveOrgSlug,
+} from '../../lib/org-config.ts';
 import { checkOrganizationRateLimit } from '../../lib/rate-limit.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
@@ -22,6 +30,12 @@ import { writeNotificationForOrgs } from '../notifications/service.ts';
  * divergence (the 0.4 signed-checkpoint window collapses to this flag +
  * the receipt + the gdpr audit rows — rule 5).
  */
+
+/** Stands in for the subject on a record that is kept but de-identified. A
+ *  review decision is the audit trail of a governance gate, so the row stays
+ *  and the identity goes. Same value 0.4 used, so old and new rows read
+ *  alike. */
+const ERASED_SUBJECT = 'erased-user';
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -515,6 +529,37 @@ async function scrubSubjectAuditLogs(
   return scrubbed.length;
 }
 
+/**
+ * Does the subject still belong to another organization that has not
+ * disabled them?
+ *
+ * `login_attempts`, `login_block_counters` and the two-factor tables are
+ * keyed globally, by email or by user id, while a GDPR request is scoped to
+ * one organization. Wiping them for one org's request would reset the
+ * lockout and 2FA backoff counters protecting every OTHER org the subject
+ * belongs to, which hands a multi-org user a cross-tenant bypass. 0.4
+ * refused the wipe in that case; so does this.
+ *
+ * 0.4 paged Better Auth's adapter at 256 memberships and failed CLOSED when
+ * the page came back full, because it could not see past the cap. SQL
+ * answers exactly, so neither the cap nor its guard is ported.
+ */
+async function subjectBelongsToOtherActiveOrg(
+  sql: Sql,
+  userId: string,
+  excludeOrgId: string,
+): Promise<boolean> {
+  const rows = await sql<{ elsewhere: boolean }[]>`
+    SELECT EXISTS (
+      SELECT 1 FROM "member"
+      WHERE "userId" = ${userId}
+        AND "organizationId" <> ${excludeOrgId}
+        AND "role" <> 'disabled'
+    ) AS "elsewhere"
+  `;
+  return rows[0]?.elsewhere ?? false;
+}
+
 /** The cascade — each pass bounded and idempotent; per-pass counts land on
  * the receipt. Reuses the retention purge primitives for threads and the
  * document trash for owned documents. */
@@ -560,7 +605,7 @@ export async function processErasure(
     }
   };
 
-  const { purgeThreadLineage, purgeDocument, purgeBlobArtefacts } =
+  const { purgeThreadLineage, purgeDocument } =
     await import('../retention/service.ts');
 
   await pass('threads', async () => {
@@ -584,7 +629,6 @@ export async function processErasure(
       FROM app.documents
       WHERE org_id = ${organizationId} AND created_by = ${targetUserId}
     `;
-    const { resolveOrgSlug } = await import('../../lib/org-config.ts');
     const orgSlug = await resolveOrgSlug(sql, organizationId);
     for (const doc of docs) {
       await purgeDocument(sql, orgSlug, {
@@ -597,42 +641,57 @@ export async function processErasure(
     return docs.length;
   });
 
-  // A bare upload owns its blob directly (no document row carries it), so
-  // deleting the row alone leaves the subject's bytes in object storage and
-  // their chunks in the corpus. Blob-first, as `purgeDocument` orders it.
   await pass('uploads', async () => {
-    const files = await sql<{ id: string; storageRef: string | null }[]>`
-      SELECT id, storage_ref AS "storageRef" FROM app.file_metadata
+    const removed = await sql<{ id: string }[]>`
+      DELETE FROM app.file_metadata
       WHERE org_id = ${organizationId} AND uploaded_by = ${targetUserId}
         AND document_id IS NULL
+      RETURNING id
     `;
-    if (files.length === 0) return 0;
-    const { resolveOrgSlug } = await import('../../lib/org-config.ts');
-    const orgSlug = await resolveOrgSlug(sql, organizationId);
-    for (const file of files) {
-      if (file.storageRef !== null) {
-        await purgeBlobArtefacts(orgSlug, file.storageRef);
-      }
-      await sql`DELETE FROM app.file_metadata WHERE id = ${file.id}`;
-    }
-    return files.length;
+    return removed.length;
   });
 
   // `video_link_jobs` is its own category, not part of `uploads`: the job can
   // own a blob (Whisper audio, captions transcript) even when the linked
   // `file_metadata` row never landed, and a welcome-page paste has no thread,
   // so neither the uploads pass nor the thread cascade reaches it.
+  //
+  // Blob-then-row, and STRICTLY: a failed delete throws, the pass fails, the
+  // receipt lands `partial` with this pass named, and the rows stay for a
+  // retry. The retention sweeps delete blobs best-effort, which is the wrong
+  // idiom here — a receipt that says `done` is a claim about the bytes, so a
+  // swallowed failure would make it false. #3135 makes the same argument for
+  // the `uploads` pass.
   await pass('videoLinks', async () => {
     const jobs = await sql<{ id: string; storageRef: string | null }[]>`
       SELECT id, storage_ref AS "storageRef" FROM app.video_link_jobs
       WHERE org_id = ${organizationId} AND uploaded_by = ${targetUserId}
     `;
     if (jobs.length === 0) return 0;
-    const { resolveOrgSlug } = await import('../../lib/org-config.ts');
     const orgSlug = await resolveOrgSlug(sql, organizationId);
+    // A captions-branch transcript is indexed under its storage ref, so the
+    // corpus entry has to go with the blob.
+    const seen = new Set<string>();
     for (const job of jobs) {
-      if (job.storageRef !== null) {
-        await purgeBlobArtefacts(orgSlug, job.storageRef);
+      const ref = job.storageRef;
+      if (ref !== null && ref !== '' && !seen.has(ref) && orgSlug !== null) {
+        seen.add(ref);
+        const corpus = await deleteKnowledgeDocument({
+          orgSlug,
+          fileId: ref,
+        });
+        if (!corpus.success) {
+          throw new Error(
+            `corpus delete failed for video-link ref ${ref}: ${corpus.message}`,
+          );
+        }
+        const parsed = parseBlobRef(ref);
+        // A legacy Convex ref has no reachable backend; the row is all there
+        // is left to remove.
+        if (parsed.backend === 's3') {
+          const store = await resolveObjectStore(orgSlug);
+          await s3DeleteObject(store, parsed.key);
+        }
       }
       await sql`DELETE FROM app.video_link_jobs WHERE id = ${job.id}`;
     }
@@ -733,6 +792,123 @@ export async function processErasure(
       RETURNING id
     `;
     return onedrive.length + googleDrive.length;
+  });
+
+  // The org-level security and system bells ABOUT the subject, which are a
+  // different table from the per-user inbox the `notifications` pass above
+  // clears. `subject_user_id` exists for exactly this — 0002_notifications
+  // calls it "the data-subject user this notification is ABOUT (GDPR Art 17
+  // erasure matches on it)" — and the lockout alert stamps it on the row
+  // that carries the subject's email and IP in `params`. `notification_reads`
+  // falls with the row on its foreign key.
+  await pass('orgNotifications', async () => {
+    const removed = await sql<{ id: string }[]>`
+      DELETE FROM app.notifications
+      WHERE org_id = ${organizationId}
+        AND subject_user_id = ${targetUserId}
+      RETURNING id
+    `;
+    return removed.length;
+  });
+
+  // Automation runs the subject started. `input`, `output`, `trace` and
+  // `effects` hold every node's resolved values, so the run is subject data
+  // even though the row is org-owned. The two markers are the ones 0.5
+  // writes: `user:<id>` from the app door and `api-key:<id>` from REST.
+  await pass('automationRuns', async () => {
+    const removed = await sql<{ id: string }[]>`
+      DELETE FROM app.automation_runs
+      WHERE org_id = ${organizationId}
+        AND started_by = ANY(${[`user:${targetUserId}`, `api-key:${targetUserId}`]})
+      RETURNING id
+    `;
+    return removed.length;
+  });
+
+  // Review decisions are pseudonymized rather than deleted: the decision is
+  // the audit record of a governance gate, so the row stays and the identity
+  // goes. `tasks.reviewer_user_id` is different — it is live routing, not
+  // history, so it is cleared. Leaving it pointed at an erased user sends
+  // the next review to nobody.
+  await pass('reviewDecisions', async () => {
+    const decisions = await sql<
+      { id: string; approvedBy: string | null; metadata: unknown }[]
+    >`
+      SELECT id, approved_by AS "approvedBy", metadata
+      FROM app.approvals
+      WHERE org_id = ${organizationId} AND resource_type = 'task_review'
+        AND (approved_by = ${targetUserId}
+             OR metadata->>'requestedFor' = ${targetUserId}
+             OR metadata->'response'->>'respondedBy' = ${targetUserId})
+    `;
+    let changed = 0;
+    for (const row of decisions) {
+      const metadata = isRecord(row.metadata) ? { ...row.metadata } : undefined;
+      if (metadata !== undefined) {
+        if (metadata.requestedFor === targetUserId) {
+          metadata.requestedFor = ERASED_SUBJECT;
+        }
+        const response = metadata.response;
+        if (isRecord(response) && response.respondedBy === targetUserId) {
+          metadata.response = { ...response, respondedBy: ERASED_SUBJECT };
+        }
+      }
+      await sql`
+        UPDATE app.approvals SET
+          approved_by = ${row.approvedBy === targetUserId ? ERASED_SUBJECT : row.approvedBy},
+          metadata = ${metadata === undefined ? null : sql.json(toJson(metadata))}
+        WHERE id = ${row.id}
+      `;
+      changed++;
+    }
+    const cleared = await sql<{ id: string }[]>`
+      UPDATE app.tasks SET reviewer_user_id = NULL
+      WHERE org_id = ${organizationId}
+        AND reviewer_user_id = ${targetUserId}
+      RETURNING id
+    `;
+    return changed + cleared.length;
+  });
+
+  // Global auth state: the lockout trail is keyed by email and the two-factor
+  // backoff by user id, so neither is org-scoped. Refused outright while the
+  // subject is still an active member elsewhere, because these counters
+  // protect those organizations too.
+  await pass('authState', async () => {
+    if (
+      await subjectBelongsToOtherActiveOrg(sql, targetUserId, organizationId)
+    ) {
+      console.warn(
+        `[erasure] skipping global auth-state wipe for ${targetUserId}: still an active member of another organization`,
+      );
+      return 0;
+    }
+    const users = await sql<{ email: string | null }[]>`
+      SELECT "email" FROM "user" WHERE "id" = ${targetUserId} LIMIT 1
+    `;
+    const email = users[0]?.email ?? null;
+    let removed = 0;
+    if (email !== null) {
+      const normalized = normalizeAuthEmail(email);
+      const attempts = await sql<{ email: string }[]>`
+        DELETE FROM app.login_attempts WHERE lower(email) = ${normalized}
+        RETURNING email
+      `;
+      const counters = await sql<{ email: string }[]>`
+        DELETE FROM app.login_block_counters WHERE lower(email) = ${normalized}
+        RETURNING email
+      `;
+      removed += attempts.length + counters.length;
+    }
+    const twoFactor = await sql<{ userId: string }[]>`
+      DELETE FROM app.two_factor_attempts WHERE user_id = ${targetUserId}
+      RETURNING user_id AS "userId"
+    `;
+    const grace = await sql<{ userId: string }[]>`
+      DELETE FROM app.two_factor_grace WHERE user_id = ${targetUserId}
+      RETURNING user_id AS "userId"
+    `;
+    return removed + twoFactor.length + grace.length;
   });
 
   await pass('auditScrub', () =>

--- a/services/platform/backend/domains/erasure/service.ts
+++ b/services/platform/backend/domains/erasure/service.ts
@@ -560,7 +560,7 @@ export async function processErasure(
     }
   };
 
-  const { purgeThreadLineage, purgeDocument } =
+  const { purgeThreadLineage, purgeDocument, purgeBlobArtefacts } =
     await import('../retention/service.ts');
 
   await pass('threads', async () => {
@@ -597,14 +597,46 @@ export async function processErasure(
     return docs.length;
   });
 
+  // A bare upload owns its blob directly (no document row carries it), so
+  // deleting the row alone leaves the subject's bytes in object storage and
+  // their chunks in the corpus. Blob-first, as `purgeDocument` orders it.
   await pass('uploads', async () => {
-    const removed = await sql<{ id: string }[]>`
-      DELETE FROM app.file_metadata
+    const files = await sql<{ id: string; storageRef: string | null }[]>`
+      SELECT id, storage_ref AS "storageRef" FROM app.file_metadata
       WHERE org_id = ${organizationId} AND uploaded_by = ${targetUserId}
         AND document_id IS NULL
-      RETURNING id
     `;
-    return removed.length;
+    if (files.length === 0) return 0;
+    const { resolveOrgSlug } = await import('../../lib/org-config.ts');
+    const orgSlug = await resolveOrgSlug(sql, organizationId);
+    for (const file of files) {
+      if (file.storageRef !== null) {
+        await purgeBlobArtefacts(orgSlug, file.storageRef);
+      }
+      await sql`DELETE FROM app.file_metadata WHERE id = ${file.id}`;
+    }
+    return files.length;
+  });
+
+  // `video_link_jobs` is its own category, not part of `uploads`: the job can
+  // own a blob (Whisper audio, captions transcript) even when the linked
+  // `file_metadata` row never landed, and a welcome-page paste has no thread,
+  // so neither the uploads pass nor the thread cascade reaches it.
+  await pass('videoLinks', async () => {
+    const jobs = await sql<{ id: string; storageRef: string | null }[]>`
+      SELECT id, storage_ref AS "storageRef" FROM app.video_link_jobs
+      WHERE org_id = ${organizationId} AND uploaded_by = ${targetUserId}
+    `;
+    if (jobs.length === 0) return 0;
+    const { resolveOrgSlug } = await import('../../lib/org-config.ts');
+    const orgSlug = await resolveOrgSlug(sql, organizationId);
+    for (const job of jobs) {
+      if (job.storageRef !== null) {
+        await purgeBlobArtefacts(orgSlug, job.storageRef);
+      }
+      await sql`DELETE FROM app.video_link_jobs WHERE id = ${job.id}`;
+    }
+    return jobs.length;
   });
 
   await pass('preferences', async () => {
@@ -665,6 +697,42 @@ export async function processErasure(
       RETURNING org_id AS "orgId"
     `;
     return removed.length;
+  });
+
+  // The subject's own OAuth grant for Documents import — a sealed access +
+  // refresh token per (org, user, provider). It outlives their membership
+  // unless erasure takes it, and an in-flight authorization carries the same
+  // identity in its state row.
+  await pass('cloudGrants', async () => {
+    const grants = await sql<{ id: string }[]>`
+      DELETE FROM app.user_cloud_authorizations
+      WHERE org_id = ${organizationId} AND user_id = ${targetUserId}
+      RETURNING id
+    `;
+    const states = await sql<{ id: string }[]>`
+      DELETE FROM app.cloud_import_oauth_states
+      WHERE org_id = ${organizationId} AND user_id = ${targetUserId}
+      RETURNING id
+    `;
+    return grants.length + states.length;
+  });
+
+  // Sync configs name the member whose grant the sync runs under, so they are
+  // subject data AND a schedule that would keep firing against a revoked
+  // grant. Imported documents are not touched here — they are org content,
+  // reached by the `documents` pass when the subject created them.
+  await pass('syncConfigs', async () => {
+    const onedrive = await sql<{ id: string }[]>`
+      DELETE FROM app.onedrive_sync_configs
+      WHERE org_id = ${organizationId} AND user_id = ${targetUserId}
+      RETURNING id
+    `;
+    const googleDrive = await sql<{ id: string }[]>`
+      DELETE FROM app.google_drive_sync_configs
+      WHERE org_id = ${organizationId} AND user_id = ${targetUserId}
+      RETURNING id
+    `;
+    return onedrive.length + googleDrive.length;
   });
 
   await pass('auditScrub', () =>

--- a/services/platform/backend/domains/erasure/service.ts
+++ b/services/platform/backend/domains/erasure/service.ts
@@ -530,6 +530,38 @@ async function scrubSubjectAuditLogs(
 }
 
 /**
+ * `done` is a claim that every category was reached. A pass that threw, or
+ * that a legal hold held off, makes the claim false — so the receipt reads
+ * `partial` and names which, rather than reporting a clean erasure. Under Art
+ * 19 this receipt is the subject's confirmation, so the distinction between
+ * "found nothing" and "never looked" has to survive onto it.
+ */
+export function erasureReceiptStatus(
+  failedPasses: readonly string[],
+  heldOffPasses: readonly string[],
+): 'done' | 'partial' {
+  return failedPasses.length === 0 && heldOffPasses.length === 0
+    ? 'done'
+    : 'partial';
+}
+
+/** One line naming what stopped a `partial` receipt from being `done`, or
+ *  `null` when nothing did. */
+export function erasureReceiptError(
+  failedPasses: readonly string[],
+  heldOffPasses: readonly string[],
+): string | null {
+  const parts: string[] = [];
+  if (failedPasses.length > 0) {
+    parts.push(`failed passes: ${failedPasses.join(', ')}`);
+  }
+  if (heldOffPasses.length > 0) {
+    parts.push(`held off by a legal hold: ${heldOffPasses.join(', ')}`);
+  }
+  return parts.length > 0 ? parts.join('; ') : null;
+}
+
+/**
  * Does the subject still belong to another organization that has not
  * disabled them?
  *
@@ -593,10 +625,29 @@ export async function processErasure(
 
   const counts: Record<string, number> = {};
   const failures: string[] = [];
+  const heldOff: string[] = [];
   const pass = async (
     name: string,
     run: () => Promise<number>,
   ): Promise<void> => {
+    // The hold is re-read before EVERY pass, not once before the cascade.
+    // The passes are not one transaction, and two of them fan out per-thread
+    // and per-document deletes, so a hold placed mid-cascade would otherwise
+    // be ignored for everything after it. 0.4 re-read holds inside all 19 of
+    // its arms and named the reason: FRCP 37(e) spoliation.
+    try {
+      const current = await loadActiveHolds(sql, organizationId);
+      if (current.orgHeld || current.userMembershipIds.has(targetUserId)) {
+        heldOff.push(name);
+        return;
+      }
+    } catch (error) {
+      // An unreadable hold table is not evidence that nothing is held, so the
+      // pass is skipped rather than run.
+      console.error(`[erasure] hold re-check before ${name} failed:`, error);
+      heldOff.push(name);
+      return;
+    }
     try {
       counts[name] = await run();
     } catch (error) {
@@ -915,13 +966,13 @@ export async function processErasure(
     scrubSubjectAuditLogs(sql, organizationId, targetUserId),
   );
 
-  const status = failures.length === 0 ? 'done' : 'partial';
+  const status = erasureReceiptStatus(failures, heldOff);
   await sql.begin(async (tx) => {
     await tx`
       UPDATE app.gdpr_erasure_requests SET
         status = ${status}, finished_at_ms = ${Date.now()},
         counts = ${tx.json(toJson(counts))},
-        error = ${failures.length > 0 ? `failed passes: ${failures.join(', ')}` : null}
+        error = ${erasureReceiptError(failures, heldOff)}
       WHERE id = ${requestId}
     `;
     await createAuditLog(tx, {

--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -414,6 +414,33 @@ async function deleteBlobBestEffort(
   }
 }
 
+/** Hard-delete the artefacts behind ONE storage ref: the corpus entry
+ * (keyed by the ref) and then the blob. Split out of {@link purgeDocument}
+ * because rows that own a blob WITHOUT being a document need the same two
+ * steps in the same order — a bare upload and the video-link sidecar both
+ * reach it from the erasure cascade. The row itself stays the caller's to
+ * delete. */
+export async function purgeBlobArtefacts(
+  orgSlug: string | null,
+  storageRef: string,
+): Promise<void> {
+  if (orgSlug === null) return;
+  try {
+    const result = await deleteKnowledgeDocument({
+      orgSlug,
+      fileId: storageRef,
+    });
+    if (!result.success) {
+      console.warn(
+        `[retention] corpus delete failed for ${storageRef}: ${result.message}`,
+      );
+    }
+  } catch (error) {
+    console.warn(`[retention] corpus delete failed for ${storageRef}:`, error);
+  }
+  await deleteBlobBestEffort(orgSlug, storageRef);
+}
+
 /** Hard-delete one document: corpus entry (keyed by the file REF), blobs
  * (current + `historyFiles` — replaced blobs a sync/replace appended, the
  * 0.4 `eraseDocumentBlobs` contract), file rows, dependent knowledge-entry
@@ -435,26 +462,8 @@ export async function purgeDocument(
       }
     }
   }
-  if (doc.fileRef !== null && orgSlug !== null) {
-    try {
-      const result = await deleteKnowledgeDocument({
-        orgSlug,
-        fileId: doc.fileRef,
-      });
-      if (!result.success) {
-        console.warn(
-          `[retention] corpus delete failed for document ${doc.id}: ${result.message}`,
-        );
-      }
-    } catch (error) {
-      console.warn(
-        `[retention] corpus delete failed for document ${doc.id}:`,
-        error,
-      );
-    }
-    if (orgSlug !== null) {
-      await deleteBlobBestEffort(orgSlug, doc.fileRef);
-    }
+  if (doc.fileRef !== null) {
+    await purgeBlobArtefacts(orgSlug, doc.fileRef);
   }
   await sql.begin(async (tx) => {
     await tx`

--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -414,33 +414,6 @@ async function deleteBlobBestEffort(
   }
 }
 
-/** Hard-delete the artefacts behind ONE storage ref: the corpus entry
- * (keyed by the ref) and then the blob. Split out of {@link purgeDocument}
- * because rows that own a blob WITHOUT being a document need the same two
- * steps in the same order — a bare upload and the video-link sidecar both
- * reach it from the erasure cascade. The row itself stays the caller's to
- * delete. */
-export async function purgeBlobArtefacts(
-  orgSlug: string | null,
-  storageRef: string,
-): Promise<void> {
-  if (orgSlug === null) return;
-  try {
-    const result = await deleteKnowledgeDocument({
-      orgSlug,
-      fileId: storageRef,
-    });
-    if (!result.success) {
-      console.warn(
-        `[retention] corpus delete failed for ${storageRef}: ${result.message}`,
-      );
-    }
-  } catch (error) {
-    console.warn(`[retention] corpus delete failed for ${storageRef}:`, error);
-  }
-  await deleteBlobBestEffort(orgSlug, storageRef);
-}
-
 /** Hard-delete one document: corpus entry (keyed by the file REF), blobs
  * (current + `historyFiles` — replaced blobs a sync/replace appended, the
  * 0.4 `eraseDocumentBlobs` contract), file rows, dependent knowledge-entry
@@ -462,8 +435,26 @@ export async function purgeDocument(
       }
     }
   }
-  if (doc.fileRef !== null) {
-    await purgeBlobArtefacts(orgSlug, doc.fileRef);
+  if (doc.fileRef !== null && orgSlug !== null) {
+    try {
+      const result = await deleteKnowledgeDocument({
+        orgSlug,
+        fileId: doc.fileRef,
+      });
+      if (!result.success) {
+        console.warn(
+          `[retention] corpus delete failed for document ${doc.id}: ${result.message}`,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[retention] corpus delete failed for document ${doc.id}:`,
+        error,
+      );
+    }
+    if (orgSlug !== null) {
+      await deleteBlobBestEffort(orgSlug, doc.fileRef);
+    }
   }
   await sql.begin(async (tx) => {
     await tx`

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -21229,6 +21229,45 @@ async function checkErasure(
     ) VALUES (${orgId}, ${subject}, 'folder', ${`od-${subject}`}, 'Reports',
               'documents', 'active', ${now}, ${now})
   `;
+  // The five categories the cascade gained: the org-level bell ABOUT the
+  // subject (a different table from the per-user inbox above), the runs they
+  // started, the review decision naming them three ways, and the global
+  // auth-state rows keyed by their email and user id.
+  await sql`
+    INSERT INTO app.notifications (
+      org_id, category, severity, title_key, body_key, params,
+      subject_user_id, created_at_ms
+    ) VALUES (${orgId}, 'security', 'warning', 'accountLocked',
+              'lockoutDetails',
+              ${sql.json({ email: `${subject}@example.com`, ip: '203.0.113.9' })},
+              ${subject}, ${now})
+  `;
+  await sql`
+    INSERT INTO app.automation_runs (
+      org_id, name, version, status, mode, started_by, started_at_ms
+    ) VALUES (${orgId}, 'erasure-fixture', 1, 'success', 'live',
+              ${`user:${subject}`}, ${now})
+  `;
+  await sql`
+    INSERT INTO app.approvals (
+      org_id, resource_type, resource_id, status, approved_by, metadata,
+      created_at_ms
+    ) VALUES (${orgId}, 'task_review', ${`er-task-${subject}`}, 'completed',
+              ${subject},
+              ${sql.json({ requestedFor: subject, response: { respondedBy: subject } })},
+              ${now})
+  `;
+  await sql`
+    INSERT INTO app.login_attempts (email, consecutive_failures,
+                                    last_failure_at)
+    VALUES (${`${subject}@example.com`}, 3, ${now})
+    ON CONFLICT (email) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO app.two_factor_attempts (user_id, consecutive_failures,
+                                         last_failure_at_ms)
+    VALUES (${subject}, 2, ${now}) ON CONFLICT (user_id) DO NOTHING
+  `;
   await sql`
     INSERT INTO app.google_drive_sync_configs (
       org_id, user_id, item_type, item_id, item_name, target_bucket, status,
@@ -21288,7 +21327,25 @@ async function checkErasure(
          WHERE org_id = ${orgId} AND user_id = ${subject})
       + (SELECT count(*) FROM app.google_drive_sync_configs
          WHERE org_id = ${orgId} AND user_id = ${subject})
+      + (SELECT count(*) FROM app.notifications
+         WHERE org_id = ${orgId} AND subject_user_id = ${subject})
+      + (SELECT count(*) FROM app.automation_runs
+         WHERE org_id = ${orgId} AND started_by = ${`user:${subject}`})
+      + (SELECT count(*) FROM app.login_attempts
+         WHERE email = ${`${subject}@example.com`})
+      + (SELECT count(*) FROM app.two_factor_attempts
+         WHERE user_id = ${subject})
     )::text AS count
+  `;
+  // A review decision is KEPT and de-identified, not deleted: the decision is
+  // the audit record of a governance gate. All three identity fields must
+  // read as the sentinel, and the row must still be there.
+  const reviewErased = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.approvals
+    WHERE org_id = ${orgId} AND resource_id = ${`er-task-${subject}`}
+      AND approved_by = 'erased-user'
+      AND metadata->>'requestedFor' = 'erased-user'
+      AND metadata->'response'->>'respondedBy' = 'erased-user'
   `;
   const scrubbed = await sql<{ count: string }[]>`
     SELECT count(*)::text AS count FROM app.audit_logs
@@ -21382,6 +21439,7 @@ async function checkErasure(
       receiptStatus === 'done' &&
       threadGone[0]?.count === '0' &&
       leftovers[0]?.count === '0' &&
+      reviewErased[0]?.count === '1' &&
       Number(scrubbed[0]?.count ?? '0') >= 1 &&
       filedTwo.success &&
       cancelled.success &&
@@ -21393,7 +21451,7 @@ async function checkErasure(
       filedThree.data.userCustodianHeld &&
       blockedReceipt[0]?.status === 'blocked' &&
       threeStatus === 'done',
-    `self=${selfRefused.status} (want 403), receipt=${receiptStatus}, thread=${threadGone[0]?.count}, leftovers=${leftovers[0]?.count}, scrubbed=${scrubbed[0]?.count}, cancel=${cancelled.success ? cancelled.data.ok : 'ERR'}, twoIntact=${twoIntact[0]?.count}, blocked=${blockedRes.status}/${filedThree.success ? filedThree.data.error : 'ERR'}/${blockedReceipt[0]?.status ?? '?'} (want 409/LEGAL_HOLD_BLOCKS_ERASURE/blocked), retried=${threeStatus}`,
+    `self=${selfRefused.status} (want 403), receipt=${receiptStatus}, thread=${threadGone[0]?.count}, leftovers=${leftovers[0]?.count}, reviewDeidentified=${reviewErased[0]?.count} (want 1), scrubbed=${scrubbed[0]?.count}, cancel=${cancelled.success ? cancelled.data.ok : 'ERR'}, twoIntact=${twoIntact[0]?.count}, blocked=${blockedRes.status}/${filedThree.success ? filedThree.data.error : 'ERR'}/${blockedReceipt[0]?.status ?? '?'} (want 409/LEGAL_HOLD_BLOCKS_ERASURE/blocked), retried=${threeStatus}`,
   );
 }
 

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -21187,6 +21187,55 @@ async function checkErasure(
                               created_at_ms)
     VALUES (${orgId}, ${subject}, 'subject fact', 'approved', ${now})
   `;
+  // A bare upload (no document row), the video-link sidecar that can own a
+  // blob without one, the subject's own cloud-import grant + an in-flight
+  // authorization, and the two sync configs that run under that grant. Each
+  // is a category the cascade has to reach on its own — none is reachable
+  // from the thread, document or preference passes.
+  await sql`
+    INSERT INTO app.file_metadata (
+      org_id, storage_ref, file_name, content_type, size, uploaded_by,
+      created_at_ms
+    ) VALUES (${orgId}, ${`s3:erasure/${subject}/bare.txt`}, 'bare.txt',
+              'text/plain', 12, ${subject}, ${now})
+  `;
+  await sql`
+    INSERT INTO app.video_link_jobs (
+      org_id, uploaded_by, source_url, source_url_hash, source_platform,
+      pasted_token, status, status_changed_at_ms, storage_ref, created_at_ms
+    ) VALUES (${orgId}, ${subject}, 'https://example.com/v/1',
+              ${`hash-${subject}`}, 'youtube', 'https://example.com/v/1',
+              'completed', ${now}, ${`s3:erasure/${subject}/transcript.txt`},
+              ${now})
+  `;
+  await sql`
+    INSERT INTO app.user_cloud_authorizations (
+      org_id, user_id, provider, encrypted_data, status, created_at_ms,
+      updated_at_ms
+    ) VALUES (${orgId}, ${subject}, 'google-drive', ${sql.json({ sealed: 'x' })},
+              'active', ${now}, ${now})
+  `;
+  await sql`
+    INSERT INTO app.cloud_import_oauth_states (
+      state_hash, org_id, user_id, provider, code_verifier, redirect_uri,
+      created_at_ms, expires_at_ms
+    ) VALUES (${`state-${subject}`}, ${orgId}, ${subject}, 'google-drive',
+              'verifier', 'https://example.com/cb', ${now}, ${now + 600_000})
+  `;
+  await sql`
+    INSERT INTO app.onedrive_sync_configs (
+      org_id, user_id, item_type, item_id, item_name, target_bucket, status,
+      created_at_ms, updated_at_ms
+    ) VALUES (${orgId}, ${subject}, 'folder', ${`od-${subject}`}, 'Reports',
+              'documents', 'active', ${now}, ${now})
+  `;
+  await sql`
+    INSERT INTO app.google_drive_sync_configs (
+      org_id, user_id, item_type, item_id, item_name, target_bucket, status,
+      created_at_ms, updated_at_ms
+    ) VALUES (${orgId}, ${subject}, 'folder', ${`gd-${subject}`}, 'Reports',
+              'documents', 'active', ${now}, ${now})
+  `;
 
   const selfRefused = await post(`/api/app/erasure?orgId=${orgId}`, {
     targetUserId: userId,
@@ -21226,6 +21275,18 @@ async function checkErasure(
       + (SELECT count(*) FROM app.user_notifications
          WHERE org_id = ${orgId} AND user_id = ${subject})
       + (SELECT count(*) FROM app.memories
+         WHERE org_id = ${orgId} AND user_id = ${subject})
+      + (SELECT count(*) FROM app.file_metadata
+         WHERE org_id = ${orgId} AND uploaded_by = ${subject})
+      + (SELECT count(*) FROM app.video_link_jobs
+         WHERE org_id = ${orgId} AND uploaded_by = ${subject})
+      + (SELECT count(*) FROM app.user_cloud_authorizations
+         WHERE org_id = ${orgId} AND user_id = ${subject})
+      + (SELECT count(*) FROM app.cloud_import_oauth_states
+         WHERE org_id = ${orgId} AND user_id = ${subject})
+      + (SELECT count(*) FROM app.onedrive_sync_configs
+         WHERE org_id = ${orgId} AND user_id = ${subject})
+      + (SELECT count(*) FROM app.google_drive_sync_configs
          WHERE org_id = ${orgId} AND user_id = ${subject})
     )::text AS count
   `;


### PR DESCRIPTION
Two ways an erasure receipt could claim more than happened, and the panel meant to show the detail rendered blank.

Stacked on #3122 — review that first. Refs #3142.

## Why

**The legal hold was read once and never again.** `processErasure` gates on it before the cascade, then runs ten passes that are not one transaction. Two of them fan out per-thread lineage purges and per-document blob and corpus deletes, so the window is real. A hold placed during that window was ignored for every remaining pass.

0.4 re-read holds inside all 19 of its arms, and the helper's docstring names why: "a hold placed AFTER scheduling and BEFORE the per-table mutation runs must still win… Pre-fix, only `orgHeld` was checked, leaving a window where a custodian-hold race could let GDPR erasure delete data the hold was meant to preserve — FRCP 37(e) spoliation."

**A hold that stopped the cascade halfway still reported `done`.** Only a thrown pass set `partial`. Under Art 19 that receipt is the subject's confirmation, so `done` has to mean every category was reached.

**The Full breakdown panel rendered blank for every recent request.** A pass records a plain count; the renderer did `if (typeof value !== 'object' || value === null) continue;`, so every entry was dropped *before* the empty-category branch. The result was an empty list with not even the "no data in N other categories" line. The headline counts still rendered, so it looked populated.

## What changed

The hold is re-read before each pass. An unreadable hold table skips the pass rather than running it — a table you cannot read is not evidence that nothing is held.

A held-off pass is tracked separately from a failed one. Both make the receipt `partial`, and the error line names which, so an operator can tell a hold from a fault.

The breakdown fold reads both shapes. Receipts written before the backend change still carry the object form, so dropping it would have broken the panel in the other direction.

## What is not covered

The per-pass re-check itself has no automated test. Proving it needs a hold to appear *between* two passes, and every way I could arrange that was timing-dependent — a flaky test on a spoliation guard is worse than none. What is pinned instead is the rule the re-check feeds: that a held-off pass makes the receipt `partial` and says so. If someone reverts the re-check, that test stays green. Naming the gap rather than implying coverage.

## Tests

`erasureReceiptStatus` and `erasureReceiptError` are extracted from the cascade so the "done means every category was reached" rule is testable at all, with 6 assertions. `foldBreakdownEntries` is extracted from the drawer for the same reason, with 6 more.

| Mutation | Went red |
| --- | --- |
| status ignores held-off passes | the hold case |
| the hold reason dropped from the error line | the combined-reason case |
| the fold's plain-count branch removed | the count-shape case |
| the fold treats a held-off category as empty | two cases |

The fold mutation is the original bug, so seeing that assertion red is seeing the defect reproduced.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `lint:sast` green; 12 unit assertions passing.
