### PR TITLE
fix(platform): space the daily governance crons

### DIFF
--- a/services/platform/backend/jobs/schedules.test.ts
+++ b/services/platform/backend/jobs/schedules.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+
+import { SCHEDULES } from './schedules.ts';
+
+/** `m h dom mon dow` — these three are all daily, so hour and minute suffice. */
+function timeOf(name: string): { hour: number; minute: number } {
+  const entry = SCHEDULES.find((row) => row.name === name);
+  if (entry === undefined) throw new Error(`no schedule named ${name}`);
+  const [minute, hour] = entry.cron.split(' ');
+  return { hour: Number(hour), minute: Number(minute) };
+}
+
+describe('the daily governance schedules stay spaced', () => {
+  const releases = timeOf('governance.effect_hold_releases');
+  const verify = timeOf('audit.integrity_check');
+  const sweep = timeOf('governance.retention_cleanup');
+
+  test('releases run before the sweep that frees their data', () => {
+    // A cleared maker-checker release frees data for the same night's sweep
+    // instead of waiting another day.
+    expect(releases.hour).toBeLessThan(sweep.hour);
+  });
+
+  test('the audit verify does not run inside the retention window', () => {
+    // The verifier anchors on the oldest surviving row, so walking the chain
+    // while retention deletes audit prefixes reads a chain mid-deletion.
+    expect(verify.hour).not.toBe(sweep.hour);
+  });
+
+  test('no two of the three share an hour', () => {
+    const hours = [releases.hour, verify.hour, sweep.hour];
+    expect(new Set(hours).size).toBe(3);
+  });
+
+  test('the corpus reconcile runs after the sweep, not before it', () => {
+    // This one DOES share the sweep's hour, deliberately: its own comment
+    // says it runs after retention so rows the sweep just purged reconcile
+    // the same night. Pinned so the spacing rule above is not read as
+    // "spread everything out" and this gets moved.
+    const reconcile = timeOf('knowledge.reconcile_corpus');
+    expect(reconcile.hour).toBe(sweep.hour);
+    expect(reconcile.minute).toBeGreaterThan(sweep.minute);
+  });
+});
+
+describe('the schedule roster is well formed', () => {
+  test('every name is unique', () => {
+    const names = SCHEDULES.map((row) => row.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test('every cron has five fields', () => {
+    const malformed = SCHEDULES.filter(
+      (row) => row.cron.trim().split(/\s+/).length !== 5,
+    );
+    expect(malformed.map((row) => row.name)).toEqual([]);
+  });
+});

--- a/services/platform/backend/jobs/schedules.ts
+++ b/services/platform/backend/jobs/schedules.ts
@@ -13,7 +13,7 @@ interface CronSchedule {
   cron: string;
 }
 
-const SCHEDULES: CronSchedule[] = [
+export const SCHEDULES: CronSchedule[] = [
   // Rate-limit state is per (rule, subject) — rows idle longer than any
   // window are dead weight. Daily sweep.
   { name: 'maintenance.rate_limit_gc', cron: '20 3 * * *' },
@@ -26,15 +26,31 @@ const SCHEDULES: CronSchedule[] = [
   { name: 'automation.liveness', cron: '* * * * *' },
   // The agent-lane and sandbox backstops (each its own entry so a throw in
   // one sweep can never disable another — the 0.4 isolation rationale).
+  // The three daily governance jobs are SPACED, not batched, and the order
+  // is the point.
+  //
+  // 01:00 releases first: a maker-checker legal-hold release that has cleared
+  // its cooldown frees data for the sweep three hours later, instead of
+  // waiting a further day. It also runs even when the retention kill-switch
+  // is set, so it cannot be gated on the sweep.
+  //
+  // 02:00 verifies the audit chain, deliberately clear of both siblings. The
+  // verifier trusts the oldest surviving row as its anchor, so running it
+  // inside the 04:00 window would have it walk the chain while retention is
+  // deleting audit prefixes.
+  //
+  // 04:00 sweeps. Packing all three into one half-hour window reintroduces
+  // exactly the overlap the 0.4 comments were written to avoid.
+  { name: 'governance.effect_hold_releases', cron: '0 1 * * *' },
+  { name: 'audit.integrity_check', cron: '0 2 * * *' },
   { name: 'governance.retention_cleanup', cron: '0 4 * * *' },
   // Corpus↔app reconcile: de-index refs nothing references any more — the
   // backstop for release jobs that exhausted retries, and the lazy backfill
   // that drains historically stranded rows (replaced versions, rotated
   // knowledge entries) on existing deployments. After retention, so rows it
-  // just purged reconcile the same night.
+  // just purged reconcile the same night — which is why this one DOES share
+  // the sweep's hour, deliberately, unlike the three above.
   { name: 'knowledge.reconcile_corpus', cron: '45 4 * * *' },
-  { name: 'audit.integrity_check', cron: '30 4 * * *' },
-  { name: 'governance.effect_hold_releases', cron: '15 4 * * *' },
   { name: 'watchdog.task_agents', cron: '*/2 * * * *' },
   { name: 'watchdog.automation_agents', cron: '*/2 * * * *' },
   { name: 'watchdog.sandbox', cron: '*/5 * * * *' },


### PR DESCRIPTION
The three daily governance jobs were running in one 30-minute window. They are spaced again, and a test now pins the rule rather than the times.

Refs #3142.

## Why

| Job | 0.4 | Before this | Now |
| --- | --- | --- | --- |
| legal-hold releases | 01:00 | 04:15 | 01:00 |
| audit-chain verify | 02:00 | 04:30 | 02:00 |
| retention sweep | 04:00 | 04:00 | 04:00 |

Both 0.4 comments state the reasoning. The releases cron: "Picks an off-peak hour so it doesn't compete with the main 04:00 sweep." The verify cron: "02:00 avoids the 01:00 legal-hold release sweep and the 04:00 retention sweep."

Two consequences of the packing:

A maker-checker legal-hold release that clears its cooldown used to free data three hours before the sweep. At 04:15 it lands after the sweep has started, so the data it freed waits roughly a day for the next one.

The audit verify ran 30 minutes into the retention window, so it could walk the chain while retention deletes audit prefixes. That is the overlap the 0.4 comment named, and it compounds with the anchor change `backend/MIGRATION.md` documents: the verifier trusts the oldest surviving row, and it may now read that row mid-deletion.

## What changed

Three cron strings, reordered in the file so the sequence reads in the order it runs, with the reasoning written down rather than left to be rediscovered.

## Tests

A new `schedules.test.ts` pins the invariant, not the clock: the three do not share an hour, releases precede the sweep, and the verify is not in the sweep's hour. Plus two roster hygiene checks — unique names, five cron fields each. `SCHEDULES` is exported for this; it was module-private.

Mutation: setting the two times back to `15 4` and `30 4`, which is exactly what main ships, turns three of the five assertions red.

## Scope

Only the three daily governance jobs move. Every other entry is untouched, including the deliberate staggers already in the file — the two Drive scans on offset 15-minute cadences, and the three 5-minute file-pipeline sweeps on offset minutes.

Does not address the anchor change itself, which is signed off in the ledger as an intentional divergence. This removes the overlap that made it sharper.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check` green; 5 unit assertions passing.
