### PR TITLE
fix(platform): answer the stubbed chat search legs

### DIFF
--- a/services/platform/backend/db/migrations/0070_file_metadata_mail_arrival.sql
+++ b/services/platform/backend/db/migrations/0070_file_metadata_mail_arrival.sql
@@ -1,0 +1,22 @@
+-- 0.5 app migration 0070: the mail-arrival index on file rows.
+--
+-- `app.file_metadata` holds every stored file. Only the rows the email binder
+-- bound to a conversation carry `mail_received_at_ms`, so a partial index over
+-- its non-null values IS the mail index — and it is a tiny slice of the table
+-- (on one deployment, 3 rows of 3,671 carried a conversation).
+--
+-- The chat assistant's `list kind="mail-attachment"` leg answers in ARRIVAL
+-- order, newest first. The only existing index on the pair
+-- (`file_metadata_conversation`, from migration 0037) leads with
+-- `conversation_id`, so it orders by conversation — the shape PR #3035
+-- recorded as REJECTED, because a by-arrival page then reads most of its
+-- budget to return one row, and above the budget reports "most recent" from an
+-- arbitrary window.
+--
+-- `id` is in the index so the walk's tiebreak inside one millisecond is
+-- index-ordered too: which rows a bounded listing keeps is part of its answer,
+-- not an implementation detail.
+
+CREATE INDEX IF NOT EXISTS file_metadata_mail_arrival
+  ON app.file_metadata (org_id, mail_received_at_ms DESC, id DESC)
+  WHERE mail_received_at_ms IS NOT NULL;

--- a/services/platform/backend/domains/chat/shim.test.ts
+++ b/services/platform/backend/domains/chat/shim.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  reachableHandlerNames,
+  unansweredHandlerNames,
+} from '../../lib/ctx-shim-reachability.ts';
+import { chatShimHandlers } from './shim.ts';
+
+/**
+ * The EXHAUSTIVENESS gate for the chat lane's ctx dispatch — the twin of
+ * `domains/sandbox/shim.test.ts`, on the same shared walk.
+ *
+ * `runChatTurn` hands the reused 0.4 `executeTurn` a ctx shim built from
+ * `chatShimHandlers` alone, and the shim fails LOUD on a name it has no
+ * handler for. A chat turn reaches far more than the host: the three-tool
+ * executor's `rag_search` / `rag_fetch` / `web_fetch` legs, the attachment
+ * gate, the composer's catalog walk, and the TTS/dictation resolvers all
+ * dispatch on this one map. Before this file, `domains/chat/` had no test at
+ * all, so an un-shimmed name reached an operator before it reached anyone
+ * else.
+ *
+ * What this gate CANNOT catch is the other half of the same failure: a
+ * handler that is present and answers nothing. `kind="website"` and
+ * `kind="mail-attachment"` shipped as `async () => []` against tables that
+ * existed, and an empty result reads exactly like a real one. That half is
+ * covered by the integration checks (`backend/integration-check.ts`), which
+ * seed rows and require them back.
+ */
+
+/**
+ * Where a chat dispatch begins — the reused 0.4 modules each 0.5 host hands
+ * this shim to — and the one module it does NOT have to answer.
+ *
+ * `core/chat/turn_store.ts` is 0.4's Convex-backed `TurnStore` / `UsageLedger`
+ * pair. `executeTurn` builds it and then spreads `overrides.deps` over it, and
+ * `runChatTurn` always overrides both with the Postgres ports in
+ * `domains/chat/store.ts` — so its seven `internal.chat.*` writes are dead
+ * code here, not a gap in the map. The exclusion is a hole in this gate, so
+ * the test below asserts the override is still wired.
+ */
+const CHAT_DISPATCH = {
+  entryPoints: [
+    // The turn itself, and with it the whole tool executor.
+    'core/chat/turn_action.ts',
+    // The composer's model/voice catalog walk.
+    'core/lib/providers/chat_catalog.ts',
+    // Voice: TTS synthesis and dictation both resolve their model on this map.
+    'core/lib/providers/resolve_tts_model.ts',
+    'core/lib/providers/resolve_transcription_model.ts',
+  ],
+  replacedModules: ['core/chat/turn_store.ts'],
+};
+
+describe('chatShimHandlers', () => {
+  // The factory only closes over `sql`; no handler runs until it is called,
+  // so a stand-in is enough to enumerate the map.
+  const handlers = chatShimHandlers({} as never);
+
+  it('answers every internal function a chat turn can reach', () => {
+    expect(unansweredHandlerNames(handlers, CHAT_DISPATCH)).toEqual([]);
+  });
+
+  it('still replaces the 0.4 turn store the walk excludes', () => {
+    // Without the override, `executeTurn` would dispatch the excluded
+    // module's writes onto this map — which has no handler for any of them,
+    // so every turn would die on its first append. `Partial<TurnDeps>` makes
+    // dropping one a type-clean edit, which is why it needs an assertion.
+    const service = readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), 'service.ts'),
+      'utf8',
+    );
+    expect(service).toContain('store: createPgTurnStore(');
+    expect(service).toContain('usage: createPgUsageLedger(');
+  });
+
+  it('reaches the search legs, not just the turn host', () => {
+    // A guard on the guard: if the walk ever stops following the tool
+    // executor's imports, the assertion above would pass vacuously — and the
+    // legs that shipped dead are exactly the ones behind that edge.
+    const reachable = reachableHandlerNames(CHAT_DISPATCH);
+    expect([...reachable.keys()]).toEqual(
+      expect.arrayContaining([
+        'websites/internal_queries:listWebsiteSummaries',
+        'file_metadata/internal_queries:listMailAttachmentsForChat',
+        'tasks/search_for_chat:searchTasksForChat',
+        'tasks/search_for_chat:searchProjectsForChat',
+        'conversations/search_for_chat:searchConversationsForChat',
+        'knowledge_entries/internal_queries:listEntriesForAgent',
+      ]),
+    );
+  });
+});

--- a/services/platform/backend/domains/chat/shim.ts
+++ b/services/platform/backend/domains/chat/shim.ts
@@ -6,6 +6,7 @@ import { wordStartPatterns } from '../../lib/word-match.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
 import { searchConversationsForChat } from '../conversations/search-chat.ts';
 import { listDocumentsForAgent } from '../documents/agent-list.ts';
+import { listMailAttachments } from '../file_metadata/mail-attachments.ts';
 import {
   resolveFileReadAccess,
   viewerForUser,
@@ -25,6 +26,7 @@ import {
   type ProjectRow,
 } from '../projects/service.ts';
 import { listServingCredentialFacts } from '../provider_credentials/service.ts';
+import { listWebsites } from '../websites/service.ts';
 import { getThreadLineageIds, setThreadTitleIfAbsent } from './threads.ts';
 
 /**
@@ -38,10 +40,14 @@ import { getThreadLineageIds, setThreadTitleIfAbsent } from './threads.ts';
  *  - governance seams answered permissively (`checkModelAccessInternal`
  *    allows, `getContextCapInternal` un-caps, `recordConnectorUsage`
  *    no-ops) until the governance domain ports — the MIGRATION.md ledger
- *    carries each one;
- *  - honest empties for corpora 0.5 has no tables for yet (websites,
- *    video links) — an empty result is factually right against this
- *    database, and the tool layer already words empties for the model.
+ *    carries each one.
+ *
+ * No handler in this map is a placeholder empty any more. An empty stub for
+ * a corpus whose table DOES exist is not an honest empty: it is a leg that
+ * answers "there is nothing" over rows that are right there, and it hides
+ * because "no results" is a legitimate answer. `chat/shim.test.ts` gates the
+ * map's exhaustiveness; what it cannot gate is a handler that returns
+ * nothing on purpose, so a new one needs the table to be genuinely absent.
  *
  * Everything stays fail-loud for names NOT in this map — a new ctx call in
  * 0.4 surfaces as `[ctx-shim] un-shimmed …` naming the function.
@@ -128,6 +134,21 @@ async function resolveAccessScope(
   };
 }
 
+/**
+ * A crawl that is mid-teardown or broken is not part of the catalog — the 0.4
+ * reader skipped both statuses, so naming one to the model would offer a site
+ * nothing can be fetched from.
+ */
+const WEBSITE_HIDDEN_STATUSES = new Set(['deleting', 'error']);
+
+/**
+ * Registered domains read for one turn. The catalog is admin-registered
+ * domains — tens, not thousands — and both consumers cap far below this
+ * (`RAG_SEARCH_MAX_LIMIT` is 20), so the leg's own "more than shown" note
+ * stays truthful for any org this bound can cut.
+ */
+const WEBSITE_SUMMARY_CAP = 200;
+
 interface TaskLegRow {
   _id: string;
   title: string;
@@ -142,6 +163,18 @@ interface TaskLegRow {
 }
 
 const OPEN_EXCLUDED = ['done', 'cancelled'];
+
+/**
+ * The zero-hit listing fallback's page size — the 0.4 `LIST_CAP`.
+ *
+ * A question names something and matches nothing far more often than it names
+ * nothing at all: "are there any archived projects?" contains no project name,
+ * so the text match returns empty and the leg would answer `searched (no
+ * matches)` over a board that is full. Listing instead answers the question the
+ * words were describing, and the reply is stamped `listed: true` so the model
+ * is told these rows were browsed, not matched.
+ */
+const LIST_CAP = 15;
 
 async function searchTasks(
   sql: Sql,
@@ -168,32 +201,49 @@ async function searchTasks(
   const like = `%${term}%`;
   const words = wordStartPatterns(term);
   const status = args.status;
-  const rows = await sql<TaskLegRow[]>`
-    SELECT id AS "_id", title, description, status, priority,
-           assignee_type AS "assigneeType", assignee_id AS "assigneeId",
-           project_id AS "projectId", due_date_ms::float8 AS "dueDate",
-           archived_at_ms::float8 AS "archivedAt"
-    FROM app.tasks
-    WHERE org_id = ${args.organizationId}
-      AND project_id = ANY(${readable})
-      AND (${args.list === true || term === ''} OR title ILIKE ${like}
-           OR description ILIKE ${like}
-           OR (${words.length > 0}
-               AND (title ~* ANY(${words}) OR description ~* ANY(${words}))))
-      AND (${status === undefined}
-           OR (${status ?? ''} = 'open' AND NOT (status = ANY(${OPEN_EXCLUDED})))
-           OR status = ${status ?? ''})
-      AND (${args.excludeArchived !== true} OR archived_at_ms IS NULL)
-    ORDER BY updated_at_ms DESC
-    LIMIT ${bounds.limit + 1} OFFSET ${bounds.offset}
-  `;
-  const nullsStripped = rows.map((row) =>
-    Object.fromEntries(
-      Object.entries(row).filter(([, value]) => value !== null),
-    ),
-  );
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- null-stripping keeps the selected shape, minus absent optionals
-  return pageOf(nullsStripped as TaskLegRow[], bounds, args.list === true);
+  const walk = async (
+    listing: boolean,
+    page: { limit: number; offset: number },
+  ): Promise<TaskLegRow[]> => {
+    const rows = await sql<TaskLegRow[]>`
+      SELECT id AS "_id", title, description, status, priority,
+             assignee_type AS "assigneeType", assignee_id AS "assigneeId",
+             project_id AS "projectId", due_date_ms::float8 AS "dueDate",
+             archived_at_ms::float8 AS "archivedAt"
+      FROM app.tasks
+      WHERE org_id = ${args.organizationId}
+        AND project_id = ANY(${readable})
+        AND (${listing || term === ''} OR title ILIKE ${like}
+             OR description ILIKE ${like}
+             OR (${words.length > 0}
+                 AND (title ~* ANY(${words}) OR description ~* ANY(${words}))))
+        AND (${status === undefined}
+             OR (${status ?? ''} = 'open' AND NOT (status = ANY(${OPEN_EXCLUDED})))
+             OR status = ${status ?? ''})
+        AND (${args.excludeArchived !== true} OR archived_at_ms IS NULL)
+      ORDER BY updated_at_ms DESC
+      LIMIT ${page.limit + 1} OFFSET ${page.offset}
+    `;
+    const nullsStripped = rows.map((row) =>
+      Object.fromEntries(
+        Object.entries(row).filter(([, value]) => value !== null),
+      ),
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- null-stripping keeps the selected shape, minus absent optionals
+    return nullsStripped as TaskLegRow[];
+  };
+
+  const listing = args.list === true;
+  const found = await walk(listing, bounds);
+  if (listing || found.length > 0) return pageOf(found, bounds, listing);
+
+  // Nothing matched the words. Answer the question the words were describing.
+  const listBounds = { limit: LIST_CAP, offset: 0 };
+  return {
+    ...pageOf(await walk(true, listBounds), listBounds, true),
+    // The fallback page is fixed, not resumable — 0.4 returned no cursor.
+    continueCursor: '',
+  };
 }
 
 interface ProjectLegRow {
@@ -223,27 +273,44 @@ async function searchProjects(
   const term = args.term.trim();
   const like = `%${term}%`;
   const words = wordStartPatterns(term);
-  const rows = await sql<ProjectLegRow[]>`
-    SELECT id AS "_id", name, description, key,
-           open_task_count AS "openTaskCount",
-           done_task_count AS "doneTaskCount",
-           archived_at_ms::float8 AS "archivedAt"
-    FROM app.projects
-    WHERE org_id = ${args.organizationId} AND id = ANY(${args.projectIds})
-      AND (${args.list === true || term === ''} OR name ILIKE ${like}
-           OR description ILIKE ${like} OR key ILIKE ${like}
-           OR (${words.length > 0}
-               AND (name ~* ANY(${words}) OR description ~* ANY(${words}))))
-    ORDER BY updated_at_ms DESC
-    LIMIT ${bounds.limit + 1} OFFSET ${bounds.offset}
-  `;
-  const nullsStripped = rows.map((row) =>
-    Object.fromEntries(
-      Object.entries(row).filter(([, value]) => value !== null),
-    ),
-  );
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- null-stripping keeps the selected shape, minus absent optionals
-  return pageOf(nullsStripped as ProjectLegRow[], bounds, args.list === true);
+  const walk = async (
+    listing: boolean,
+    page: { limit: number; offset: number },
+  ): Promise<ProjectLegRow[]> => {
+    const rows = await sql<ProjectLegRow[]>`
+      SELECT id AS "_id", name, description, key,
+             open_task_count AS "openTaskCount",
+             done_task_count AS "doneTaskCount",
+             archived_at_ms::float8 AS "archivedAt"
+      FROM app.projects
+      WHERE org_id = ${args.organizationId} AND id = ANY(${args.projectIds})
+        AND (${listing || term === ''} OR name ILIKE ${like}
+             OR description ILIKE ${like} OR key ILIKE ${like}
+             OR (${words.length > 0}
+                 AND (name ~* ANY(${words}) OR description ~* ANY(${words}))))
+      ORDER BY updated_at_ms DESC
+      LIMIT ${page.limit + 1} OFFSET ${page.offset}
+    `;
+    const nullsStripped = rows.map((row) =>
+      Object.fromEntries(
+        Object.entries(row).filter(([, value]) => value !== null),
+      ),
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- null-stripping keeps the selected shape, minus absent optionals
+    return nullsStripped as ProjectLegRow[];
+  };
+
+  const listing = args.list === true;
+  const found = await walk(listing, bounds);
+  if (listing || found.length > 0) return pageOf(found, bounds, listing);
+
+  // Nothing matched the words — list the readable portfolio instead, exactly
+  // as the tasks leg does above.
+  const listBounds = { limit: LIST_CAP, offset: 0 };
+  return {
+    ...pageOf(await walk(true, listBounds), listBounds, true),
+    continueCursor: '',
+  };
 }
 
 /** All ctx handlers for one turn. `sql` outlives the turn (the pool). */
@@ -495,11 +562,21 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
       return null;
     },
 
-    // Mail-ingest and video-link corpora have no 0.5 tables yet.
-    'file_metadata/internal_queries:listMailAttachmentsForChat': async () => ({
-      attachments: [],
-      truncated: false,
-    }),
+    // `list kind="mail-attachment"` — the ONLY listing surface an emailed
+    // attachment has. Scope is each attachment's conversation as it stands
+    // now, so the reader resolves the caller's own role and teams and runs
+    // the shared assignment predicate per row.
+    'file_metadata/internal_queries:listMailAttachmentsForChat': async (
+      raw,
+    ) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the 0.4 tool leg passes exactly this shape
+      const args = raw as {
+        organizationId: string;
+        userId: string;
+        limit: number;
+      };
+      return listMailAttachments(sql, args);
+    },
     'file_metadata/internal_queries:lookupVideoLinkSources': async (raw) => {
       // Inline SQL (not the video_links service) — that service composes
       // ON TOP of this shim, so an import here would be a cycle.
@@ -929,8 +1006,29 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
         cursor: args.paginationOpts.cursor,
       });
     },
-    // A corpus without a 0.5 table yet — an honest empty (see header).
-    'websites/internal_queries:listWebsiteSummaries': async () => [],
+    // The registered-domain catalog, behind BOTH the `website` search leg and
+    // `list kind="website"` — the listing the tool description points the
+    // model at when it refuses `kind="web-page"`.
+    'websites/internal_queries:listWebsiteSummaries': async (raw) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the 0.4 tool leg passes exactly this shape
+      const args = raw as { organizationId: string };
+      const listing = await listWebsites(sql, args.organizationId, {
+        limit: WEBSITE_SUMMARY_CAP,
+      });
+      return listing.page
+        .filter(
+          (site) =>
+            site.status === null || !WEBSITE_HIDDEN_STATUSES.has(site.status),
+        )
+        .map((site) =>
+          Object.assign(
+            { domain: site.domain },
+            site.title !== null ? { title: site.title } : {},
+            site.description !== null ? { description: site.description } : {},
+            site.pageCount !== null ? { pageCount: site.pageCount } : {},
+          ),
+        );
+    },
     'conversations/search_for_chat:searchConversationsForChat': async (raw) => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the 0.4 tool leg passes exactly this shape
       const args = raw as Parameters<typeof searchConversationsForChat>[1];

--- a/services/platform/backend/domains/file_metadata/mail-attachments.ts
+++ b/services/platform/backend/domains/file_metadata/mail-attachments.ts
@@ -1,0 +1,211 @@
+import type { Sql } from 'postgres';
+
+import { getUserTeamIds } from '../../auth/membership.ts';
+import { conversationAssignmentAllows } from '../../core/lib/rls/helpers/conversation_assignment.ts';
+import { viewerIsAdmin } from '../conversations/service.ts';
+
+/**
+ * The emailed attachments a caller may read, newest arrival first — the 0.5
+ * twin of `convex/file_metadata/list_mail_attachments.ts`.
+ *
+ * An emailed attachment has no listing surface anywhere else in the product.
+ * It is not a Document Hub row, so it is absent from the Documents page and
+ * from `list kind="document"`, and its only appearance is on its own
+ * conversation in the Inbox. Retrieval was the sole way to discover one, which
+ * means guessing words inside a file whose name says nothing about why it was
+ * sent.
+ *
+ * ## Why the walk needs its own index
+ *
+ * `mail_received_at_ms` is written only on rows the email binder bound to a
+ * conversation, so a partial index over the non-null values IS the mail index,
+ * in arrival order. Migration 0064 adds it. The only other index on the pair
+ * (`file_metadata_conversation`) leads with `conversation_id`, so it orders by
+ * conversation — the shape PR #3035 recorded as rejected, because a
+ * by-arrival page then reads most of its budget to return one row.
+ *
+ * ## What the privacy check costs, and why it is not optional
+ *
+ * A conversation is scoped more narrowly than membership: an unassigned inbox
+ * row is admin-triage only. So every row passes the REUSED
+ * `conversationAssignmentAllows` predicate, with the caller's role and team
+ * ids resolved HERE from their identity and never accepted as arguments —
+ * the same discipline `domains/conversations/search-chat.ts` follows. Skipping
+ * it would publish the whole inbox to any member who asked for a listing.
+ *
+ * Assignment is read live, so reassigning a conversation moves its
+ * attachments here too, with nothing rewritten. The decision is made once per
+ * conversation, and the assignment stamps for the whole candidate window come
+ * back in ONE query rather than a round-trip per row; the team lookup behind
+ * `hasTeam` still happens at most once, and only for a conversation whose
+ * decision actually turns on it.
+ *
+ * A row the caller cannot read is skipped, which means the walk may pass more
+ * rows than it keeps. {@link SCAN_CAP} bounds that, and it is reported: a
+ * caller who can read little should be told the reach was bounded rather than
+ * shown an empty list as if the inbox were empty.
+ */
+
+/** Bound rows examined before the walk stops, however few were readable. */
+const SCAN_CAP = 200;
+
+/** One attachment, as a catalogue row rather than a retrieval hit. */
+export interface MailAttachmentListing {
+  /** The corpus ref, so a listed row can be fetched without another search. */
+  readonly ref: string;
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly conversationId: string;
+  readonly receivedAt: number;
+  /** Whether its text is in the corpus. A received-but-unindexed attachment is
+   *  a real state, and saying so beats implying it is searchable. */
+  readonly indexed: boolean;
+}
+
+export interface MailAttachmentListingResult {
+  readonly attachments: MailAttachmentListing[];
+  /** The walk stopped before the end of the mail index — either the page
+   *  filled or the scan bound was reached. Not "the inbox holds nothing
+   *  more". */
+  readonly truncated: boolean;
+}
+
+interface CandidateRow {
+  ref: string;
+  fileName: string;
+  contentType: string;
+  size: number;
+  conversationId: string;
+  receivedAt: number;
+  ragStatus: string | null;
+}
+
+export async function listMailAttachments(
+  sql: Sql,
+  args: {
+    organizationId: string;
+    /** The turn user. Authority is derived from this, never passed in. */
+    userId: string;
+    limit: number;
+    /** Bound rows examined before stopping. Defaults to {@link SCAN_CAP}; the
+     *  shim handler never overrides it. Present so a check can prove the bound
+     *  without seeding hundreds of rows. */
+    scanCap?: number;
+  },
+): Promise<MailAttachmentListingResult> {
+  // Tier-A role gate (the per-subject matrix ports with governance): an
+  // active member may list; the assignment predicate below is the real
+  // privacy boundary.
+  const members = await sql<{ role: string }[]>`
+    SELECT "role" FROM "member"
+    WHERE "organizationId" = ${args.organizationId}
+      AND "userId" = ${args.userId}
+    LIMIT 1
+  `;
+  const role = members[0]?.role;
+  if (role === undefined || role === 'disabled') {
+    return { attachments: [], truncated: false };
+  }
+
+  const admin = viewerIsAdmin(role);
+  let teamIds: Set<string> | undefined;
+  const hasTeam = async (teamId: string): Promise<boolean> => {
+    teamIds ??= new Set(await getUserTeamIds(sql, args.userId));
+    return teamIds.has(teamId);
+  };
+
+  const cap = Math.max(args.scanCap ?? SCAN_CAP, 1);
+  // Over-fetch by one: the extra row is what distinguishes "the mail index
+  // ended" from "the scan bound cut the walk short".
+  const rows = await sql<CandidateRow[]>`
+    SELECT storage_ref AS "ref", file_name AS "fileName",
+           content_type AS "contentType", size::float8 AS size,
+           conversation_id AS "conversationId",
+           mail_received_at_ms::float8 AS "receivedAt",
+           rag_status AS "ragStatus"
+    FROM app.file_metadata
+    WHERE org_id = ${args.organizationId}
+      AND mail_received_at_ms IS NOT NULL
+      AND conversation_id IS NOT NULL
+      AND (lifecycle_status IS NULL OR lifecycle_status <> 'trashed')
+    ORDER BY mail_received_at_ms DESC, id DESC
+    LIMIT ${cap + 1}
+  `;
+  const candidates = rows.slice(0, cap);
+  /** The scan bound cut the walk before the mail index ended. */
+  let truncated = rows.length > cap;
+
+  // One read for every conversation the window touches, instead of a
+  // round-trip per attachment: many attachments share one conversation, and
+  // the window is already bounded by the scan cap.
+  const conversationIds = [
+    ...new Set(candidates.map((row) => row.conversationId)),
+  ];
+  const conversations =
+    conversationIds.length === 0
+      ? []
+      : await sql<
+          {
+            id: string;
+            assigneeUserId: string | null;
+            assigneeTeamId: string | null;
+          }[]
+        >`
+          SELECT id, assignee_user_id AS "assigneeUserId",
+                 assignee_team_id AS "assigneeTeamId"
+          FROM app.conversations
+          WHERE org_id = ${args.organizationId}
+            AND id = ANY(${conversationIds})
+        `;
+  const stamps = new Map(
+    conversations.map((row) => [
+      row.id,
+      {
+        ...(row.assigneeUserId !== null
+          ? { assigneeUserId: row.assigneeUserId }
+          : {}),
+        ...(row.assigneeTeamId !== null
+          ? { assigneeTeamId: row.assigneeTeamId }
+          : {}),
+      },
+    ]),
+  );
+
+  const decided = new Map<string, boolean>();
+  const attachments: MailAttachmentListing[] = [];
+  for (const row of candidates) {
+    if (attachments.length >= args.limit) {
+      // A candidate is still standing, so the mail index has more.
+      truncated = true;
+      break;
+    }
+    let allowed = decided.get(row.conversationId);
+    if (allowed === undefined) {
+      const stamp = stamps.get(row.conversationId);
+      // A conversation missing from this org's rows (deleted, or another
+      // org's id on the file row) is fail-closed, never org-readable.
+      allowed =
+        stamp !== undefined &&
+        (await conversationAssignmentAllows(stamp, {
+          isAdmin: admin,
+          userId: args.userId,
+          hasTeam,
+        }));
+      decided.set(row.conversationId, allowed);
+    }
+    if (!allowed) continue;
+
+    attachments.push({
+      ref: row.ref,
+      fileName: row.fileName,
+      contentType: row.contentType,
+      size: row.size,
+      conversationId: row.conversationId,
+      receivedAt: row.receivedAt,
+      indexed: row.ragStatus === 'completed',
+    });
+  }
+
+  return { attachments, truncated };
+}

--- a/services/platform/backend/domains/sandbox/shim.test.ts
+++ b/services/platform/backend/domains/sandbox/shim.test.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { describe, expect, it } from 'vitest';
 
+import {
+  reachableHandlerNames,
+  unansweredHandlerNames,
+} from '../../lib/ctx-shim-reachability.ts';
 import { agentTurnShimHandlers } from '../tasks/agent-turn-shim.ts';
 import { sandboxToolShimHandlers } from './shim.ts';
 
@@ -18,69 +18,22 @@ import { sandboxToolShimHandlers } from './shim.ts';
  * different session), but nothing asserted that the map answers everything
  * the bridge can actually reach.
  *
- * So this test walks the bridge's own import graph, collects every
- * `internal.a.b.c` reference the reachable modules make, and requires a
- * handler for each. A module that grows a new ctx dependency fails here
- * instead of at an operator's first tool call.
+ * The walk itself lives in `lib/ctx-shim-reachability.ts` — shared with the
+ * chat map's gate, so both surfaces are held to one standard.
  */
-
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-const BACKEND = path.resolve(HERE, '../..');
 
 /** Where a dispatch begins: the bridge and the domain handlers it delegates
  * to. Everything they hand this ctx to is reached transitively. */
-const ENTRY_POINTS = [
-  'core/node_only/sandbox/workspace_tools_bridge.ts',
-  'core/node_only/sandbox/workspace_domain_tools.ts',
-];
+const TOOL_DISPATCH = {
+  entryPoints: [
+    'core/node_only/sandbox/workspace_tools_bridge.ts',
+    'core/node_only/sandbox/workspace_domain_tools.ts',
+  ],
+};
 
-/** The two modules that DEFINE the reference vocabulary rather than call it —
- * their doc comments name example refs (`internal.a.b.c`) that no code
- * dispatches. */
-const VOCABULARY_MODULES = new Set([
-  path.join(BACKEND, 'core/lib/handler_names.ts'),
-  path.resolve(BACKEND, '../lib/shared/handlers/function-refs.ts'),
-]);
-
-function resolveImport(fromFile: string, specifier: string): string | null {
-  if (!specifier.startsWith('.')) return null;
-  const base = path.resolve(path.dirname(fromFile), specifier);
-  for (const candidate of [base, `${base}.ts`, path.join(base, 'index.ts')]) {
-    if (candidate.endsWith('.ts') && existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-/** Every `internal.a.b.c` the entry points can reach, as shim names
- * (`a/b:c`), mapped to the modules that name them. */
-function reachableHandlerNames(
-  entryPoints: readonly string[] = ENTRY_POINTS,
-): Map<string, Set<string>> {
-  const names = new Map<string, Set<string>>();
-  const visited = new Set<string>();
-  const queue = entryPoints.map((entry) => path.join(BACKEND, entry));
-  while (queue.length > 0) {
-    const file = queue.pop();
-    if (file === undefined || visited.has(file)) continue;
-    visited.add(file);
-    const source = readFileSync(file, 'utf8');
-    if (!VOCABULARY_MODULES.has(file)) {
-      for (const match of source.matchAll(
-        /internal\.([a-zA-Z_]+)\.([a-zA-Z_]+)\.([a-zA-Z_]+)/g,
-      )) {
-        const name = `${match[1]}/${match[2]}:${match[3]}`;
-        const callers = names.get(name) ?? new Set<string>();
-        callers.add(path.relative(BACKEND, file));
-        names.set(name, callers);
-      }
-    }
-    for (const match of source.matchAll(/from\s+'([^']+)'/g)) {
-      const target = resolveImport(file, match[1] ?? '');
-      if (target !== null && !target.includes('.test.')) queue.push(target);
-    }
-  }
-  return names;
-}
+const TURN_EQUIPMENT = {
+  entryPoints: ['core/node_only/sandbox/turn_equipment.ts'],
+};
 
 describe('sandboxToolShimHandlers', () => {
   // The factories only close over `sql`; no handler runs until it is called,
@@ -88,18 +41,13 @@ describe('sandboxToolShimHandlers', () => {
   const handlers = sandboxToolShimHandlers({} as never);
 
   it('answers every internal function the tool dispatch can reach', () => {
-    const missing = [...reachableHandlerNames()]
-      .filter(([name]) => handlers[name] === undefined)
-      .map(
-        ([name, callers]) => `${name} (called from ${[...callers].join(', ')})`,
-      );
-    expect(missing).toEqual([]);
+    expect(unansweredHandlerNames(handlers, TOOL_DISPATCH)).toEqual([]);
   });
 
   it('reaches the write and ask lanes, not just the read doors', () => {
     // A guard on the guard: if the walk ever stops finding the bridge's
     // imports, the assertion above would pass vacuously.
-    const reachable = reachableHandlerNames();
+    const reachable = reachableHandlerNames(TOOL_DISPATCH);
     expect([...reachable.keys()]).toEqual(
       expect.arrayContaining([
         'automations/human_asks:createAskForExec',
@@ -123,21 +71,12 @@ describe('agentTurnShimHandlers', () => {
   const handlers = agentTurnShimHandlers({} as never);
 
   it('answers every internal function the turn-equipment resolvers reach', () => {
-    const missing = [
-      ...reachableHandlerNames(['core/node_only/sandbox/turn_equipment.ts']),
-    ]
-      .filter(([name]) => handlers[name] === undefined)
-      .map(
-        ([name, callers]) => `${name} (called from ${[...callers].join(', ')})`,
-      );
-    expect(missing).toEqual([]);
+    expect(unansweredHandlerNames(handlers, TURN_EQUIPMENT)).toEqual([]);
   });
 
   it('reaches the broker seams, not just the secrets lane', () => {
     // A guard on the guard, as above.
-    const reachable = reachableHandlerNames([
-      'core/node_only/sandbox/turn_equipment.ts',
-    ]);
+    const reachable = reachableHandlerNames(TURN_EQUIPMENT);
     expect([...reachable.keys()]).toEqual(
       expect.arrayContaining([
         'agent_secrets/actions:resolveAgentSecretsEnv',

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -16164,10 +16164,16 @@ async function checkChatEntityWordSearch(
 
   const { chatShimHandlers } = await import('./domains/chat/shim.ts');
   const handlers = chatShimHandlers(sql);
-  const pageShape = z.object({ page: z.array(z.unknown()) }).loose();
+  const pageShape = z
+    .object({ page: z.array(z.unknown()), listed: z.boolean().optional() })
+    .loose();
+  // MATCHED rows, not returned rows: the task and project legs fall back to a
+  // listing when the words match nothing (stamped `listed: true`), so a
+  // non-empty page is not by itself evidence of a match.
   const rows = async (name: string, args: unknown): Promise<number> => {
     const parsed = pageShape.safeParse(await handlers[name]?.(args));
-    return parsed.success ? parsed.data.page.length : -1;
+    if (!parsed.success) return -1;
+    return parsed.data.listed === true ? 0 : parsed.data.page.length;
   };
 
   const productQuestion = await rows(
@@ -16215,6 +16221,404 @@ async function checkChatEntityWordSearch(
       taskMidWord === 0 &&
       taskRealWord === 1,
     `product: question=${productQuestion} typed=${productTyped} unrelated=${productUnrelated} stopwords=${productStopwords} (want 1/1/0/0), task: question=${taskQuestion} midWord=${taskMidWord} realWord=${taskRealWord} (want 1/0/1)`,
+  );
+}
+/**
+ * The chat assistant's website catalog leg (`rag_search` leg 5 and
+ * `list kind="website"`), previously an empty stub against a table that had
+ * existed since migration 0045 — so the leg answered "no sites" while the tool
+ * description shipped to the model on every turn pointed at it as the way to
+ * browse crawled content.
+ *
+ * Reuses `listWebsites`, and keeps the 0.4 reader's one editorial rule: a
+ * site mid-teardown or in error is not offered, because nothing can be
+ * fetched from it.
+ */
+async function checkChatWebsiteCatalogLeg(
+  sql: Sql,
+  ctx: { orgId: string },
+): Promise<void> {
+  const now = Date.now();
+  const org = `${ctx.orgId}-website-leg-fixture`;
+  await sql`
+    INSERT INTO app.websites (org_id, domain, title, description,
+                              scan_interval, status, page_count,
+                              created_at_ms, updated_at_ms)
+    VALUES
+      (${org}, 'handbook.example', 'Company Handbook',
+       'Policies and onboarding', 'weekly', 'active', 42, ${now}, ${now}),
+      (${org}, 'blog.example', NULL, NULL, 'daily', 'idle', NULL,
+       ${now - 1}, ${now - 1}),
+      (${org}, 'gone.example', 'Being removed', NULL, 'weekly', 'deleting',
+       7, ${now - 2}, ${now - 2}),
+      (${org}, 'broken.example', 'Crawl failed', NULL, 'weekly', 'error',
+       0, ${now - 3}, ${now - 3})
+  `;
+
+  const { chatShimHandlers } = await import('./domains/chat/shim.ts');
+  const handlers = chatShimHandlers(sql);
+  const summaries = z
+    .array(
+      z.object({
+        domain: z.string(),
+        title: z.string().optional(),
+        description: z.string().optional(),
+        pageCount: z.number().optional(),
+      }),
+    )
+    .safeParse(
+      await handlers['websites/internal_queries:listWebsiteSummaries']?.({
+        organizationId: org,
+      }),
+    );
+  const rows = summaries.success ? summaries.data : [];
+  const domains = rows.map((row) => row.domain).sort();
+  const handbook = rows.find((row) => row.domain === 'handbook.example');
+  const bare = rows.find((row) => row.domain === 'blog.example');
+
+  record(
+    'chat website catalog leg (real rows, teardown/error sites withheld)',
+    domains.join('|') === 'blog.example|handbook.example' &&
+      handbook?.title === 'Company Handbook' &&
+      handbook?.description === 'Policies and onboarding' &&
+      // The catalog answer "how big is each site?" — the search rows skip it.
+      handbook?.pageCount === 42 &&
+      // Absent optionals stay absent rather than arriving as nulls.
+      bare !== undefined &&
+      bare.title === undefined &&
+      bare.description === undefined &&
+      bare.pageCount === undefined,
+    `domains=${domains.join('|')} (want blog.example|handbook.example), handbook=title:${handbook?.title}/desc:${handbook?.description}/pages:${handbook?.pageCount}, bareOptionalsAbsent=${bare !== undefined && bare.title === undefined && bare.pageCount === undefined}`,
+  );
+}
+
+/**
+ * `list kind="mail-attachment"` — the ONLY listing surface an emailed
+ * attachment has, previously an empty stub even though migration 0037 added
+ * the binding columns and the email binder writes both.
+ *
+ * The assertion that matters is the ACCESS decision, because a listing that
+ * skips it publishes the whole inbox: an admin reaches an unassigned
+ * conversation's attachment, a plain member reaches only their own and their
+ * team's, and a non-member reaches nothing. Arrival order and an honest
+ * `truncated` are checked alongside — the stub returned `truncated: false`
+ * while listing nothing, which claims the mail index was fully walked.
+ */
+async function checkChatMailAttachmentListing(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const now = Date.now();
+  const org = `${ctx.orgId}-mail-attachment-fixture`;
+  const stamp = new Date();
+  // `member`/`team` carry a FK to `organization`, so the fixture org is a real
+  // row (a direct INSERT — the scaffold hook lives in the auth API, not here).
+  await sql`
+    INSERT INTO "organization" ("id", "name", "slug", "createdAt")
+    VALUES (${org}, 'Mail Attachment Fixture', ${org}, ${stamp})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+
+  // An admin, a plain member with a team, and a member of no team — all in
+  // the fixture org only, so the real org's inbox checks stay untouched.
+  const seedUser = async (email: string, role: string): Promise<string> => {
+    const users = await sql<{ id: string }[]>`
+      INSERT INTO "user" ("id", "email", "name", "emailVerified", "createdAt",
+                          "updatedAt")
+      VALUES (gen_random_uuid(), ${email}, ${email}, true, ${stamp}, ${stamp})
+      RETURNING "id"
+    `;
+    const id = users[0]?.id ?? '';
+    await sql`
+      INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                            "createdAt")
+      VALUES (gen_random_uuid(), ${org}, ${id}, ${role}, ${stamp})
+    `;
+    return id;
+  };
+  const adminId = await seedUser('mail.admin@leg.test', 'admin');
+  const memberId = await seedUser('mail.member@leg.test', 'member');
+  const outsiderId = await seedUser('mail.outsider@leg.test', 'member');
+  const teamRows = await sql<{ id: string }[]>`
+    INSERT INTO "team" ("id", "name", "organizationId", "createdAt",
+                        "updatedAt")
+    VALUES (gen_random_uuid(), 'Mail Squad', ${org}, ${stamp}, ${stamp})
+    RETURNING "id"
+  `;
+  const teamId = teamRows[0]?.id ?? '';
+  await sql`
+    INSERT INTO "teamMember" ("id", "teamId", "userId", "createdAt")
+    VALUES (gen_random_uuid(), ${teamId}, ${memberId}, ${stamp})
+  `;
+
+  const seedConversation = async (
+    subject: string,
+    assignment: { userId?: string; teamId?: string },
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.conversations (org_id, subject, status, channel,
+                                     direction, assignee_user_id,
+                                     assignee_team_id, last_message_at_ms,
+                                     created_at_ms)
+      VALUES (${org}, ${subject}, 'open', 'email', 'inbound',
+              ${assignment.userId ?? null}, ${assignment.teamId ?? null},
+              ${now}, ${now})
+      RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const unassigned = await seedConversation('Unassigned application', {});
+  const mine = await seedConversation('Assigned to me', { userId: memberId });
+  const ours = await seedConversation('Assigned to my team', { teamId });
+
+  const bind = async (
+    conversationId: string,
+    fileName: string,
+    receivedAt: number,
+    options: { ragStatus?: string; trashed?: boolean } = {},
+  ): Promise<void> => {
+    await sql`
+      INSERT INTO app.file_metadata (org_id, storage_ref, file_name,
+                                     content_type, size, rag_status,
+                                     lifecycle_status, conversation_id,
+                                     mail_received_at_ms, created_at_ms)
+      VALUES (${org}, ${`s3://mail/${fileName}`}, ${fileName},
+              'application/pdf', 1024, ${options.ragStatus ?? null},
+              ${options.trashed === true ? 'trashed' : null},
+              ${conversationId}, ${receivedAt}, ${receivedAt})
+    `;
+  };
+  // Arrival order deliberately disagrees with insert order.
+  await bind(mine, 'mine-older.pdf', now - 5000, { ragStatus: 'completed' });
+  await bind(ours, 'ours-newest.pdf', now - 1000);
+  await bind(unassigned, 'triage-middle.pdf', now - 3000);
+  await bind(mine, 'mine-trashed.pdf', now - 500, { trashed: true });
+  // A file with no mail arrival time is not an emailed attachment.
+  await sql`
+    INSERT INTO app.file_metadata (org_id, storage_ref, file_name,
+                                   content_type, size, created_at_ms)
+    VALUES (${org}, 's3://hub/not-mail.pdf', 'not-mail.pdf',
+            'application/pdf', 10, ${now})
+  `;
+
+  // Through the SHIM HANDLER, not the module: an empty stub in the map is
+  // exactly the defect this replaces, and the map's exhaustiveness test
+  // cannot see it (a handler that is present and answers nothing looks like
+  // a handler that works).
+  const { chatShimHandlers } = await import('./domains/chat/shim.ts');
+  const handlers = chatShimHandlers(sql);
+  const listingShape = z.object({
+    attachments: z.array(
+      z.object({
+        ref: z.string(),
+        fileName: z.string(),
+        contentType: z.string(),
+        size: z.number(),
+        conversationId: z.string(),
+        receivedAt: z.number(),
+        indexed: z.boolean(),
+      }),
+    ),
+    truncated: z.boolean(),
+  });
+  type Listing = z.infer<typeof listingShape>;
+  const listFor = async (userId: string, limit: number): Promise<Listing> => {
+    const parsed = listingShape.safeParse(
+      await handlers[
+        'file_metadata/internal_queries:listMailAttachmentsForChat'
+      ]?.({ organizationId: org, userId, limit }),
+    );
+    return parsed.success ? parsed.data : { attachments: [], truncated: false };
+  };
+  const names = (result: Listing): string =>
+    result.attachments.map((attachment) => attachment.fileName).join('|');
+
+  const admin = await listFor(adminId, 10);
+  const member = await listFor(memberId, 10);
+  const outsider = await listFor(outsiderId, 10);
+  const stranger = await listFor('no-such-user', 10);
+  // `truncated` is the walk's own claim, so both ways of cutting it short
+  // have to raise it: a filled page (through the handler), and an exhausted
+  // scan budget (the module, because the handler never overrides the cap).
+  const pageFilled = await listFor(adminId, 1);
+  const { listMailAttachments } =
+    await import('./domains/file_metadata/mail-attachments.ts');
+  const scanCut = await listMailAttachments(sql, {
+    organizationId: org,
+    userId: outsiderId,
+    limit: 10,
+    scanCap: 1,
+  });
+
+  record(
+    'chat mail-attachment listing (assignment scope, arrival order, truncated)',
+    // Newest arrival first, the trashed row skipped, the non-mail row absent.
+    names(admin) === 'ours-newest.pdf|triage-middle.pdf|mine-older.pdf' &&
+      !admin.truncated &&
+      // A plain member never sees the unassigned triage row.
+      names(member) === 'ours-newest.pdf|mine-older.pdf' &&
+      !member.truncated &&
+      // Same org, same role, no assignment and no team: nothing.
+      names(outsider) === '' &&
+      !outsider.truncated &&
+      // Not a member at all.
+      names(stranger) === '' &&
+      !stranger.truncated &&
+      // Indexed state is reported, not implied.
+      admin.attachments.find((a) => a.fileName === 'mine-older.pdf')
+        ?.indexed === true &&
+      admin.attachments.find((a) => a.fileName === 'ours-newest.pdf')
+        ?.indexed === false &&
+      // Rows carry the conversation they arrived on and a fetchable ref.
+      member.attachments.every(
+        (a) => a.conversationId !== '' && a.ref.startsWith('s3://mail/'),
+      ) &&
+      names(pageFilled) === 'ours-newest.pdf' &&
+      pageFilled.truncated &&
+      // Nothing readable, but the reach WAS bounded — saying "false" here
+      // would claim the inbox is empty.
+      names(scanCut) === '' &&
+      scanCut.truncated,
+    `admin=${names(admin)}/trunc=${admin.truncated}, member=${names(member)}/trunc=${member.truncated} (want team+own only), outsider=${names(outsider) || '(none)'}, stranger=${names(stranger) || '(none)'}, indexed=${admin.attachments.map((a) => `${a.fileName}:${a.indexed}`).join(',')}, pageFilled=${names(pageFilled)}/trunc=${pageFilled.truncated} (want true), scanCut=${names(scanCut) || '(none)'}/trunc=${scanCut.truncated} (want true)`,
+  );
+}
+
+/**
+ * The zero-hit listing fallback on the task and project legs.
+ *
+ * A mixed question names something and matches nothing — "anything blocked on
+ * procurement?" over a board whose rows say none of those words. 0.4 answered
+ * it by listing the readable rows and stamping `listed: true`, which is what
+ * makes `listedSource` in `core/chat/assistant_tools.ts` reachable; without
+ * the fallback the leg reports `searched (no matches)` over a full board.
+ *
+ * `detectListingIntent` already routes a PURE listing utterance to
+ * `action: "list"`, so the mixed query is the case that has nothing else to
+ * fall back to. The fallback must not widen scope: it lists the SAME readable
+ * project set the search was restricted to.
+ */
+async function checkChatZeroHitListingFallback(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const now = Date.now();
+  const org = `${ctx.orgId}-list-fallback-fixture`;
+  const seedProject = async (name: string): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                                updated_at_ms)
+      VALUES (${org}, ${name}, ${ctx.userId}, ${now}, ${now})
+      RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const readableId = await seedProject('Marketing Site Rebuild');
+  const hiddenId = await seedProject('Secret Board');
+  const seedTask = async (projectId: string, title: string): Promise<void> => {
+    await sql`
+      INSERT INTO app.tasks (org_id, project_id, title, description, status,
+                             rank, created_by, created_by_type, created_at_ms,
+                             updated_at_ms)
+      VALUES (${org}, ${projectId}, ${title}, NULL, 'todo', 'n',
+              ${ctx.userId}, 'user', ${now}, ${now})
+    `;
+  };
+  await seedTask(readableId, 'Draft the launch email');
+  await seedTask(hiddenId, 'Do not surface this');
+
+  const { chatShimHandlers } = await import('./domains/chat/shim.ts');
+  const handlers = chatShimHandlers(sql);
+  const legShape = z
+    .object({
+      page: z.array(
+        z
+          .object({
+            title: z.string().optional(),
+            name: z.string().optional(),
+          })
+          .loose(),
+      ),
+      isDone: z.boolean(),
+      listed: z.boolean().optional(),
+    })
+    .loose();
+  const leg = async (
+    name: string,
+    args: unknown,
+  ): Promise<{ titles: string; listed: boolean | undefined }> => {
+    const parsed = legShape.safeParse(await handlers[name]?.(args));
+    if (!parsed.success) return { titles: '(unparseable)', listed: undefined };
+    return {
+      titles: parsed.data.page
+        .map((row) => row.title ?? row.name ?? '')
+        .join('|'),
+      listed: parsed.data.listed,
+    };
+  };
+  const TASKS = 'tasks/search_for_chat:searchTasksForChat';
+  const PROJECTS = 'tasks/search_for_chat:searchProjectsForChat';
+
+  // The mixed query: real words, no match on this board.
+  const taskFallback = await leg(TASKS, {
+    organizationId: org,
+    projectIds: [readableId],
+    term: 'is anything blocked on procurement',
+  });
+  // A term that DOES match must stay a search, not a listing.
+  const taskMatched = await leg(TASKS, {
+    organizationId: org,
+    projectIds: [readableId],
+    term: 'what about the launch email',
+  });
+  // An explicit listing is unchanged.
+  const taskListed = await leg(TASKS, {
+    organizationId: org,
+    projectIds: [readableId],
+    term: '',
+    list: true,
+  });
+  // The fallback lists the readable set, never the whole org.
+  const taskScope = await leg(TASKS, {
+    organizationId: org,
+    projectIds: [readableId, hiddenId],
+    term: 'is anything blocked on procurement',
+  });
+  // A status filter still applies to the fallback page.
+  const taskFiltered = await leg(TASKS, {
+    organizationId: org,
+    projectIds: [readableId],
+    term: 'is anything blocked on procurement',
+    status: 'done',
+  });
+
+  const projectFallback = await leg(PROJECTS, {
+    organizationId: org,
+    projectIds: [readableId],
+    term: 'are there any archived initiatives',
+  });
+  const projectMatched = await leg(PROJECTS, {
+    organizationId: org,
+    projectIds: [readableId],
+    term: 'how is the rebuild going',
+  });
+
+  record(
+    'chat task/project legs list when the words match nothing',
+    taskFallback.titles === 'Draft the launch email' &&
+      taskFallback.listed === true &&
+      taskMatched.titles === 'Draft the launch email' &&
+      taskMatched.listed === false &&
+      taskListed.titles === 'Draft the launch email' &&
+      taskListed.listed === true &&
+      taskScope.titles.split('|').sort().join('|') ===
+        'Do not surface this|Draft the launch email' &&
+      taskFiltered.titles === '' &&
+      taskFiltered.listed === true &&
+      projectFallback.titles === 'Marketing Site Rebuild' &&
+      projectFallback.listed === true &&
+      projectMatched.titles === 'Marketing Site Rebuild' &&
+      projectMatched.listed === false,
+    `taskFallback=${taskFallback.titles || '(none)'}/listed=${taskFallback.listed} (want listed), taskMatched=${taskMatched.titles || '(none)'}/listed=${taskMatched.listed} (want searched), taskListed=${taskListed.titles || '(none)'}/listed=${taskListed.listed}, scopedFallback=${taskScope.titles || '(none)'} (want both readable), statusFiltered=${taskFiltered.titles || '(none)'}/listed=${taskFiltered.listed} (want empty), projectFallback=${projectFallback.titles || '(none)'}/listed=${projectFallback.listed} (want listed), projectMatched=${projectMatched.titles || '(none)'}/listed=${projectMatched.listed} (want searched)`,
   );
 }
 
@@ -33200,6 +33604,9 @@ async function main(): Promise<void> {
     await checkNotificationEmailSink(sql, authCtx);
     await checkChatConversationSearchLeg(sql, authCtx);
     await checkChatEntityWordSearch(sql, authCtx);
+    await checkChatWebsiteCatalogLeg(sql, authCtx);
+    await checkChatMailAttachmentListing(sql, authCtx);
+    await checkChatZeroHitListingFallback(sql, authCtx);
     await checkAddressRouting(sql, authCtx, `itest-${orgSuffix}`);
     await checkControlDrain(sql, baseUrl, authCtx);
     await checkProvisioning(sql);

--- a/services/platform/backend/lib/ctx-shim-reachability.ts
+++ b/services/platform/backend/lib/ctx-shim-reachability.ts
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The EXHAUSTIVENESS walk behind every ctx-shim gate.
+ *
+ * A shim map (`ShimHandlers`) fails LOUD on a name it has no handler for — at
+ * the call, in production. Each half of a dispatch surface is easy to cover in
+ * isolation (the handlers exist; the route is tested with a different
+ * session), and nothing then asserts that the map answers everything the
+ * reused 0.4 code can actually reach. That is how `ask_human` and the whole
+ * task/document write family shipped broken on the sandbox surface, and how
+ * three chat search legs shipped as empty stubs.
+ *
+ * So a gate walks its entry points' own import graph, collects every
+ * `internal.a.b.c` reference the reachable modules make, and requires a
+ * handler for each. A module that grows a new ctx dependency fails in the
+ * suite instead of at an operator's first tool call.
+ *
+ * This lives here, imported by each `shim.test.ts`, so the surfaces share ONE
+ * walk. A second copy is how one gate ends up subtly weaker than the other —
+ * and a weaker gate is indistinguishable from a passing one.
+ *
+ * Test-only: it reads the source tree with `node:fs` and nothing in the
+ * shipping path imports it.
+ */
+
+const BACKEND = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+/** The two modules that DEFINE the reference vocabulary rather than call it —
+ * their doc comments name example refs (`internal.a.b.c`) that no code
+ * dispatches. */
+const VOCABULARY_MODULES = [
+  'core/lib/handler_names.ts',
+  '../lib/shared/handlers/function-refs.ts',
+];
+
+/**
+ * Modules whose `internal.*` references this map never has to answer — the
+ * vocabulary definitions above, plus whatever a caller adds.
+ *
+ * A caller adds one only for a 0.4 module the 0.5 host REPLACES wholesale (a
+ * `deps` override), never for one it merely does not exercise yet. Every
+ * exclusion needs its own assertion that the replacement is still wired,
+ * because an exclusion is a hole in the gate.
+ */
+function excluded(extra: readonly string[]): Set<string> {
+  return new Set(
+    [...VOCABULARY_MODULES, ...extra].map((entry) =>
+      path.resolve(BACKEND, entry),
+    ),
+  );
+}
+
+function resolveImport(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  for (const candidate of [base, `${base}.ts`, path.join(base, 'index.ts')]) {
+    if (candidate.endsWith('.ts') && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Where a dispatch begins, and which reachable modules do not count. */
+export interface ReachabilityScope {
+  /** Backend-relative paths the reused code is entered through. */
+  readonly entryPoints: readonly string[];
+  /** Backend-relative paths whose `internal.*` names this map never answers
+   *  (see {@link excluded}). */
+  readonly replacedModules?: readonly string[];
+}
+
+/**
+ * Every `internal.a.b.c` the entry points can reach, as shim names
+ * (`a/b:c`), mapped to the backend-relative modules that name them.
+ */
+export function reachableHandlerNames(
+  scope: ReachabilityScope,
+): Map<string, Set<string>> {
+  const skip = excluded(scope.replacedModules ?? []);
+  const names = new Map<string, Set<string>>();
+  const visited = new Set<string>();
+  const queue = scope.entryPoints.map((entry) => path.join(BACKEND, entry));
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (file === undefined || visited.has(file)) continue;
+    visited.add(file);
+    const source = readFileSync(file, 'utf8');
+    if (!skip.has(file)) {
+      for (const match of source.matchAll(
+        /internal\.([a-zA-Z_]+)\.([a-zA-Z_]+)\.([a-zA-Z_]+)/g,
+      )) {
+        const name = `${match[1]}/${match[2]}:${match[3]}`;
+        const callers = names.get(name) ?? new Set<string>();
+        callers.add(path.relative(BACKEND, file));
+        names.set(name, callers);
+      }
+    }
+    for (const match of source.matchAll(/from\s+'([^']+)'/g)) {
+      const target = resolveImport(file, match[1] ?? '');
+      if (target !== null && !target.includes('.test.')) queue.push(target);
+    }
+  }
+  return names;
+}
+
+/**
+ * The names a shim map does NOT answer, each labelled with the modules that
+ * reach it — the assertion's whole message, so a red gate names the handler
+ * to write and where it is called from.
+ */
+export function unansweredHandlerNames(
+  handlers: Record<string, unknown>,
+  scope: ReachabilityScope,
+): string[] {
+  return [...reachableHandlerNames(scope)]
+    .filter(([name]) => handlers[name] === undefined)
+    .map(
+      ([name, callers]) => `${name} (called from ${[...callers].join(', ')})`,
+    );
+}


### PR DESCRIPTION
Three chat search legs returned nothing, each under a comment saying no 0.5 table existed. All three tables existed.

Stacked on #3123 — review that first. Refs #3142.

## Why

| Leg | What the stub said | What is actually there |
| --- | --- | --- |
| `kind="website"` | "A corpus without a 0.5 table yet" | migration 0045 created `app.websites` with every column 0.4's reader projected, and `listWebsites` already existed |
| `kind="mail-attachment"` | "no 0.5 tables yet" | migration 0037 shipped `conversation_id` and `mail_received_at_ms`, and the email binder writes both |

Both kinds are advertised to the model on every turn — the tool description says `kind="web-page" cannot be listed — search it, or list kind="website"`. The website stub killed the search leg too.

The mail stub also made a false claim: `truncated: false` is defined by the 0.4 contract as "the walk reached the end of the mail index", and it was returning that while listing nothing.

Separately, the task and project legs lost their **zero-hit listing fallback**. 0.4, on a text match that returned nothing, fell back to a 15-row listing and stamped `listed: true` — "Nothing matched the words. Answer the question the words were describing." #3029's own table promises it stays byte-identical. 0.5 returned `listed: args.list === true`, always false on a search, which left `listedSource` unreachable code.

## What changed

A real mail-attachment reader in `domains/file_metadata/mail-attachments.ts`. **Every row is gated on `conversationAssignmentAllows` against the conversation's current assignment**, with the caller's role and team ids resolved rather than accepted as arguments, and `disabled` denied. A listing that skipped that would serve the whole inbox. `truncated` now reports the truth.

Migration `0064` adds `(org_id, mail_received_at_ms DESC, id DESC) WHERE mail_received_at_ms IS NOT NULL`. The only existing index leads with `conversation_id`, so it orders by conversation — the shape #3035 recorded as rejected, because a by-arrival page then reads most of its budget to return one row and, above the budget, reports "most recent" from an arbitrary window. `id` is in the index so the tiebreak inside one millisecond is index-ordered: which rows a bounded listing keeps is part of its answer.

Numbered 0064 to clear 0059 (#3130), 0060 (#3131) and 0062 (#3135). The boot runner applies by filename order and needs no contiguity.

The website leg calls the existing `listWebsites`. The two work legs get their fallback back.

## The guard that would have caught all three

`backend/domains/chat/` had no test file. The sandbox bridge has exactly the right one — a walker over its import graph requiring a handler for every reachable `internal.*` name. That absence is how #3112's and #3128's missing handlers shipped.

The walker is now extracted to `backend/lib/ctx-shim-reachability.ts` and used by both maps, rather than copied.

## Tests

| Mutation | Went red |
| --- | --- |
| a chat shim handler deleted | the reachability gate, naming `queryContacts (called from core/chat/assistant_tools.ts)` |

Plus integration coverage for the three legs and the mail listing's privacy: an admin sees an unassigned conversation's attachment, a plain member sees only their own or their team's, a non-member sees nothing.

## Scope

Does not index anything. `kind="mail-attachment"` lists attachments and reports `indexed: false` per row; making their **content** searchable is #3121, which is a different mechanism and needs the retrieval gate #3141 lands first.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check` green; the two shim suites 7/7.
