### PR TITLE
fix(platform): restore the audit-log, conversation and 2FA gates

### DIFF
--- a/services/platform/backend/auth/access.test.ts
+++ b/services/platform/backend/auth/access.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { authorizeRls } from './access.ts';
+import { isAdminRole } from './membership.ts';
+
+/**
+ * The Better Auth role matrix must agree with the ported RLS matrix in
+ * `core/lib/rls/helpers/access_control.ts` (which has its own suite) on the
+ * rows where the two overlap. `auditLogs` is the row that drifted: the port
+ * derived every role from `uniformGrants`, which handed `member`, `editor`
+ * and `developer` a read they must not have.
+ */
+describe('authorizeRls — auditLogs (#1505 read-side hardening)', () => {
+  it('grants read only to admin and owner', () => {
+    expect(authorizeRls('owner', 'auditLogs', 'read')).toBe(true);
+    expect(authorizeRls('admin', 'auditLogs', 'read')).toBe(true);
+    expect(authorizeRls('developer', 'auditLogs', 'read')).toBe(false);
+    expect(authorizeRls('editor', 'auditLogs', 'read')).toBe(false);
+    expect(authorizeRls('member', 'auditLogs', 'read')).toBe(false);
+    expect(authorizeRls('disabled', 'auditLogs', 'read')).toBe(false);
+  });
+
+  it('keeps write for every role whose own actions are audited', () => {
+    expect(authorizeRls('owner', 'auditLogs', 'write')).toBe(true);
+    expect(authorizeRls('admin', 'auditLogs', 'write')).toBe(true);
+    expect(authorizeRls('developer', 'auditLogs', 'write')).toBe(true);
+    expect(authorizeRls('editor', 'auditLogs', 'write')).toBe(true);
+    expect(authorizeRls('member', 'auditLogs', 'write')).toBe(false);
+    expect(authorizeRls('disabled', 'auditLogs', 'write')).toBe(false);
+  });
+
+  it('agrees with the isAdminRole gate the audit-log doors use', () => {
+    for (const role of ['owner', 'admin', 'developer', 'editor', 'member']) {
+      expect(authorizeRls(role, 'auditLogs', 'read')).toBe(isAdminRole(role));
+    }
+  });
+});
+
+/**
+ * The conversation WRITE gate reads the same matrix. 0.4 gave
+ * `conversations` / `conversationMessages` ALL to editor-and-above and
+ * READ_ONLY to `member`, so a read-only member can see a thread assigned to
+ * them but never change one.
+ */
+describe('authorizeRls — conversations write is editor-or-above', () => {
+  it.each(['conversations', 'conversationMessages'] as const)(
+    'gates %s writes on an editor-or-above role',
+    (table) => {
+      expect(authorizeRls('owner', table, 'write')).toBe(true);
+      expect(authorizeRls('admin', table, 'write')).toBe(true);
+      expect(authorizeRls('developer', table, 'write')).toBe(true);
+      expect(authorizeRls('editor', table, 'write')).toBe(true);
+      expect(authorizeRls('member', table, 'write')).toBe(false);
+      expect(authorizeRls('disabled', table, 'write')).toBe(false);
+    },
+  );
+
+  it.each(['conversations', 'conversationMessages'] as const)(
+    'leaves %s reads open to every active role',
+    (table) => {
+      expect(authorizeRls('editor', table, 'read')).toBe(true);
+      expect(authorizeRls('member', table, 'read')).toBe(true);
+      expect(authorizeRls('disabled', table, 'read')).toBe(false);
+    },
+  );
+});

--- a/services/platform/backend/auth/access.ts
+++ b/services/platform/backend/auth/access.ts
@@ -77,7 +77,14 @@ const admin = ac.newRole({
   ...uniformGrants(['read', 'write']),
 });
 
-const developer = ac.newRole(uniformGrants(['read', 'write']));
+const developer = ac.newRole({
+  ...uniformGrants(['read', 'write']),
+  // Audit-log READS are admin/owner-only (#1505) — the log records every
+  // member's actions (and the GDPR erasure trail), so a non-admin reading it
+  // leaks other people's activity. WRITE stays so a developer's own actions
+  // can still append their audit rows.
+  auditLogs: ['write'],
+});
 
 // Editor: writes content-shaped resources; connector/provider/sync/workflow
 // surfaces are read-only; no settings access (frontend menu restricted).
@@ -89,11 +96,16 @@ const editor = ac.newRole({
   wfDefinitions: ['read'],
   wfExecutions: ['read'],
   governancePolicies: ['read'],
+  // Admin/owner-only reads (#1505) — see the developer row above.
+  auditLogs: ['write'],
 });
 
 const member = ac.newRole({
   ...uniformGrants(['read']),
   messageFeedback: ['read', 'write'],
+  // Admin/owner-only reads (#1505); a member's own audit rows are appended by
+  // the server, never by a client-authorized write.
+  auditLogs: [],
 });
 
 const disabled = ac.newRole(uniformGrants([]));

--- a/services/platform/backend/auth/auth.ts
+++ b/services/platform/backend/auth/auth.ts
@@ -25,8 +25,10 @@ import {
   evaluateTwoFactorEnforcement,
   getTwoFactorLockState,
   recordTwoFactorFailure,
+  recordTwoFactorLifecycleEvent,
   recordTwoFactorSuccess,
   setGraceUntilIfAbsent,
+  type TwoFactorLifecycleAction,
 } from '../domains/two_factor/service.ts';
 import { addJobInTx } from '../jobs/enqueue.ts';
 import { readGovernancePolicy } from '../lib/org-config.ts';
@@ -58,6 +60,32 @@ export interface AuthConfig {
 }
 
 const SIGN_IN_EMAIL_PATH = '/sign-in/email';
+
+/**
+ * The second-factor LIFECYCLE endpoints. Every one of them audits on success
+ * — the 0.4 posture (#1508), carried by the deleted `two_factor/auth_hooks.ts`
+ * whose lockout half this file already re-implements. These are
+ * account-takeover-relevant: an attacker who registers their own passkey and
+ * turns TOTP off must not be able to do it without leaving a trail.
+ */
+const TWO_FACTOR_ENABLE_PATH = '/two-factor/enable';
+const TWO_FACTOR_DISABLE_PATH = '/two-factor/disable';
+const TWO_FACTOR_BACKUP_CODES_PATH = '/two-factor/generate-backup-codes';
+const PASSKEY_REGISTER_PATH = '/passkey/verify-registration';
+const PASSKEY_DELETE_PATH = '/passkey/delete-passkey';
+const PASSKEY_AUTHENTICATE_PATH = '/passkey/verify-authentication';
+
+/** The user on a Better Auth middleware session payload (`context.session`
+ * or the freshly issued `context.newSession`), or null. */
+function sessionPayloadUser(
+  payload: unknown,
+): { id: string; email?: string } | null {
+  if (!isRecord(payload)) return null;
+  const user = payload.user;
+  if (!isRecord(user) || typeof user.id !== 'string') return null;
+  const email = typeof user.email === 'string' ? user.email : undefined;
+  return { id: user.id, ...(email !== undefined ? { email } : {}) };
+}
 
 // Random delay (ms) added to lockout responses to fuzz the timing channel
 // between "wrong password" (bcrypt, ~100ms) and "locked" (a single read).
@@ -159,6 +187,73 @@ export function createAuth(config: AuthConfig) {
       console.warn('[two-factor] user resolution failed:', error);
       return null;
     }
+  };
+
+  /**
+   * The successful second-factor lifecycle event on this request, or null.
+   * Success detection is 0.4's, endpoint by endpoint: `/two-factor/enable`
+   * only answers `{ totpURI, backupCodes }` when it worked and regeneration
+   * only answers `{ backupCodes }`, while disable / passkey add / remove park
+   * an `APIError` on `context.returned` when they fail. Passkey sign-in is
+   * read off the freshly issued session, exactly like `login_success` on the
+   * password path — a passkey FAILURE is challenge-based and attributable to
+   * no user, so there is nothing to log.
+   */
+  const resolveTwoFactorLifecycle = (
+    // oxlint-disable-next-line typescript/no-explicit-any -- better-auth middleware generics are unstable across minors
+    mw: any,
+  ): {
+    userId: string;
+    action: TwoFactorLifecycleAction;
+    email?: string;
+    metadata?: Record<string, unknown>;
+  } | null => {
+    const returned: unknown = mw.context.returned;
+    if (returned instanceof APIError) return null;
+
+    if (mw.path === PASSKEY_AUTHENTICATE_PATH) {
+      const signedIn = sessionPayloadUser(mw.context.newSession);
+      if (signedIn === null) return null;
+      return {
+        userId: signedIn.id,
+        action: 'passkey_sign_in',
+        ...(signedIn.email !== undefined ? { email: signedIn.email } : {}),
+      };
+    }
+
+    // Every remaining endpoint requires an active session, so the actor is
+    // the caller themselves; without one there is nothing to attribute.
+    const actor = sessionPayloadUser(mw.context.session);
+    if (actor === null) return null;
+    const base = {
+      userId: actor.id,
+      ...(actor.email !== undefined ? { email: actor.email } : {}),
+    };
+
+    if (mw.path === TWO_FACTOR_ENABLE_PATH) {
+      return isRecord(returned) && 'totpURI' in returned
+        ? { ...base, action: '2fa_enrolled' }
+        : null;
+    }
+    if (mw.path === TWO_FACTOR_BACKUP_CODES_PATH) {
+      return isRecord(returned) && 'backupCodes' in returned
+        ? {
+            ...base,
+            action: '2fa_enrolled',
+            metadata: { backupCodesRegenerated: true },
+          }
+        : null;
+    }
+    if (mw.path === TWO_FACTOR_DISABLE_PATH) {
+      return { ...base, action: '2fa_disabled' };
+    }
+    if (mw.path === PASSKEY_REGISTER_PATH) {
+      return { ...base, action: 'passkey_added' };
+    }
+    if (mw.path === PASSKEY_DELETE_PATH) {
+      return { ...base, action: 'passkey_removed' };
+    }
+    return null;
   };
 
   return betterAuth({
@@ -374,6 +469,34 @@ export function createAuth(config: AuthConfig) {
             } else {
               await recordTwoFactorSuccess(sql, userId);
             }
+          }
+        }
+
+        // Second-factor lifecycle audit: 2FA enable / disable / backup-code
+        // regeneration and passkey add / remove / sign-in. Non-fatal — the
+        // state change already happened inside Better Auth's own adapter, so
+        // refusing the response here would leave the user with a passkey
+        // registered and an error on screen. A failed write is LOUD instead.
+        const lifecycle = resolveTwoFactorLifecycle(mw);
+        if (lifecycle !== null) {
+          try {
+            await recordTwoFactorLifecycleEvent(sql, {
+              userId: lifecycle.userId,
+              action: lifecycle.action,
+              ...(lifecycle.email !== undefined
+                ? { actorEmail: lifecycle.email }
+                : {}),
+              ...(ip !== undefined ? { ip } : {}),
+              ...(userAgent !== undefined ? { userAgent } : {}),
+              ...(lifecycle.metadata !== undefined
+                ? { metadata: lifecycle.metadata }
+                : {}),
+            });
+          } catch (error) {
+            console.error(
+              `[two-factor] failed to write the ${lifecycle.action} audit row`,
+              error instanceof Error ? error.message : error,
+            );
           }
         }
 

--- a/services/platform/backend/domains/audit_logs/routes.ts
+++ b/services/platform/backend/domains/audit_logs/routes.ts
@@ -2,7 +2,6 @@ import { Hono, type Context } from 'hono';
 import type { Sql } from 'postgres';
 import { z } from 'zod';
 
-import { authorizeRls } from '../../auth/access.ts';
 import type { Auth } from '../../auth/auth.ts';
 import { isAdminRole } from '../../auth/membership.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
@@ -40,10 +39,21 @@ const listQuerySchema = z.object({
 });
 
 /**
- * /api/app/audit-logs — the compliance read surface. Row access follows the
- * role matrix (`authorizeRls`: every active role reads, `disabled` cannot —
- * the middleware already rejects disabled members). Export/integrity-verify
- * surfaces land with the governance tooling (ledger).
+ * /api/app/audit-logs — the compliance read surface.
+ *
+ * EVERY door here is admin/owner-only (`isAdminRole`), which is the 0.4 gate
+ * (#1505: `assertAuditLogReadAccess` on the list/detail/summary queries, the
+ * same `isAdmin` check on integrity verify/status, and the admin-only export
+ * action). The log enumerates who did what to whom across the whole org and
+ * carries the GDPR erasure trail — naming data subjects and the lawful
+ * grounds for erasing them — so a non-admin member reading it leaks other
+ * people's activity. The role matrix in `auth/access.ts` says the same thing
+ * a second time (`auditLogs` read = admin/owner), and the frontend hides the
+ * page from non-admins (`lib/permissions/ability.ts`); this is the door.
+ *
+ * The role comes from `c.get('orgMember')`, which `requireOrgMember` resolves
+ * from the SESSION when trusted-headers mode is on — the `member` row is a
+ * proxy-fed placeholder there, so a raw table read would misjudge the caller.
  */
 export function createAuditLogRoutes(deps: {
   sql: Sql;
@@ -53,8 +63,8 @@ export function createAuditLogRoutes(deps: {
   app.use(requireSession(deps.auth), requireOrgMember(deps.sql));
 
   app.get('/', async (c: Context<OrgEnv>) => {
-    if (!authorizeRls(c.get('orgMember').role, 'auditLogs', 'read')) {
-      return c.json({ error: 'forbidden' }, 403);
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     const query = listQuerySchema.safeParse({
       category: c.req.query('category'),
@@ -104,8 +114,8 @@ export function createAuditLogRoutes(deps: {
   });
 
   app.get('/errors', async (c: Context<OrgEnv>) => {
-    if (!authorizeRls(c.get('orgMember').role, 'auditLogs', 'read')) {
-      return c.json({ error: 'forbidden' }, 403);
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     const limitParam = Number(c.req.query('limit') ?? '50');
     const cursorTs = Number(c.req.query('cursorTs') ?? Number.NaN);
@@ -128,8 +138,8 @@ export function createAuditLogRoutes(deps: {
   });
 
   app.get('/summary', async (c: Context<OrgEnv>) => {
-    if (!authorizeRls(c.get('orgMember').role, 'auditLogs', 'read')) {
-      return c.json({ error: 'forbidden' }, 403);
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     const periodParam = Number(c.req.query('periodDays') ?? '7');
     return c.json(
@@ -142,8 +152,8 @@ export function createAuditLogRoutes(deps: {
   });
 
   app.get('/integrity/status', async (c: Context<OrgEnv>) => {
-    if (!authorizeRls(c.get('orgMember').role, 'auditLogs', 'read')) {
-      return c.json({ error: 'forbidden' }, 403);
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     return c.json({
       status: await getIntegrityStatus(deps.sql, c.get('orgId')),
@@ -153,8 +163,8 @@ export function createAuditLogRoutes(deps: {
   /** On-demand chain walk (admin click; a READ that works, so POST-free
    * would fit — but the walk is expensive, so it stays explicit). */
   app.post('/integrity/verify', async (c: Context<OrgEnv>) => {
-    if (!authorizeRls(c.get('orgMember').role, 'auditLogs', 'read')) {
-      return c.json({ error: 'forbidden' }, 403);
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     const body = z
       .object({
@@ -172,7 +182,7 @@ export function createAuditLogRoutes(deps: {
    * (the 0.4 `requestExport` {storageId, fileName, url} contract). */
   app.post('/export', async (c: Context<OrgEnv>) => {
     if (!isAdminRole(c.get('orgMember').role)) {
-      return c.json({ error: 'forbidden' }, 403);
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     const body = z
       .object({
@@ -223,8 +233,8 @@ export function createAuditLogRoutes(deps: {
 
   /** One row (deep link / detail dialog). LAST: fixed paths win above. */
   app.get('/:logId', async (c) => {
-    if (!authorizeRls(c.get('orgMember').role, 'auditLogs', 'read')) {
-      return c.json({ error: 'forbidden' }, 403);
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'FORBIDDEN' }, 403);
     }
     const log = await getAuditLogById(
       deps.sql,

--- a/services/platform/backend/domains/conversations/routes.ts
+++ b/services/platform/backend/domains/conversations/routes.ts
@@ -31,13 +31,38 @@ import {
   projectConversationForView,
   type ConversationViewer,
   updateConversation,
+  viewerCanWrite,
 } from './service.ts';
 
 /**
- * /api/app/conversations — the shared Inbox surface. Reads are
- * assignment-scoped through the reused predicate (an unassigned row is
- * admin-triage only); assignment writes are admin-gated in the service.
+ * /api/app/conversations — the shared Inbox surface.
+ *
+ * Access has two independent halves, both ported from 0.4:
+ *  - WHO CAN SEE a thread — assignment privacy, per row, through the reused
+ *    `conversationAssignmentAllows` predicate (an unassigned row is
+ *    admin-triage only). Applied by `loadVisibleConversation`.
+ *  - WHO MAY CHANGE one — an editor-or-above role (`viewerCanWrite`, the 0.4
+ *    `conversations`/`conversationMessages` RLS write rule). A read-only
+ *    `member` may read the threads assigned to them but must not reply, send
+ *    outbound mail under the org's name, change status, bulk-act, or delete.
+ *  Assignment itself is stricter than both: admin-only, gated in the service.
+ *
+ * Roles come from `c.get('orgMember')` — the membership `requireOrgMember`
+ * resolves, which prefers the SESSION-carried role in trusted-headers
+ * deployments (there the `member` row is only a proxy-fed placeholder).
  */
+
+/** The write-role refusal, shaped like the service's own `ConversationError`
+ * envelope so every conversation 403 reads the same on the wire. */
+function forbidWrite<E extends OrgEnv>(c: Context<E>): Response {
+  return c.json(
+    {
+      error: 'FORBIDDEN',
+      message: 'Only editors and above can change conversations',
+    },
+    403,
+  );
+}
 
 function handleError<E extends OrgEnv>(
   c: Context<E>,
@@ -168,6 +193,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.patch('/:id', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         contactId: z.string().max(64).optional(),
@@ -191,6 +217,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.post('/:id/read', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadVisibleConversation(deps.sql, viewer(c), c.req.param('id'));
       await deps.sql.begin((tx) =>
@@ -205,6 +232,7 @@ export function createConversationRoutes(deps: {
   /** Append a message (an internal note or a manually logged reply — the
    * connector SEND lane is its own increment). */
   app.post('/:id/messages', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         content: z.string().min(1).max(200_000),
@@ -279,6 +307,7 @@ export function createConversationRoutes(deps: {
 
   /** One reply body to many conversations (cap 50, partial failure). */
   app.post('/bulk/reply', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         conversationIds: z.array(z.string().max(64)).min(1).max(200),
@@ -316,6 +345,7 @@ export function createConversationRoutes(deps: {
 
   /** Send a reply through the conversation's connector (undo window). */
   app.post('/:id/reply', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         content: z.string().min(1).max(200_000),
@@ -346,6 +376,7 @@ export function createConversationRoutes(deps: {
 
   /** Start a new outbound email conversation with a contact. */
   app.post('/compose', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         contactId: z.string().min(1).max(64),
@@ -386,6 +417,7 @@ export function createConversationRoutes(deps: {
 
   /** Cancel a still-queued send; hands the composer draft back. */
   app.post('/messages/:messageId/undo', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       const result = await undoSendMessage(deps.sql, {
         organizationId: c.get('orgId'),
@@ -440,6 +472,7 @@ export function createConversationRoutes(deps: {
 
   /** Re-attempt a failed send immediately (no undo window). */
   app.post('/messages/:messageId/retry', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await retrySendMessage(deps.sql, {
         organizationId: c.get('orgId'),
@@ -454,6 +487,7 @@ export function createConversationRoutes(deps: {
 
   /** Remove a failed outbound bubble — the email never left. */
   app.post('/messages/:messageId/discard', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await discardOutboundMessage(deps.sql, {
         organizationId: c.get('orgId'),
@@ -467,6 +501,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.post('/bulk/:verb', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const verb = z
       .enum(['close', 'reopen', 'spam', 'archive', 'unarchive'])
       .safeParse(c.req.param('verb'));
@@ -500,6 +535,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.delete('/:id', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadVisibleConversation(deps.sql, viewer(c), c.req.param('id'));
       await deleteConversation(deps.sql, c.get('orgId'), c.req.param('id'));

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -2,6 +2,7 @@ import type { Sql, TransactionSql } from 'postgres';
 
 import { projectConversationItem } from '../../../lib/shared/conversations/conversation-item.ts';
 import { nextConversationLastMessageAt } from '../../../lib/shared/conversations/message-order.ts';
+import { authorizeRls } from '../../auth/access.ts';
 import { getUserTeamIds } from '../../auth/membership.ts';
 import { conversationAssignmentAllows } from '../../core/lib/rls/helpers/conversation_assignment.ts';
 import { toJson } from '../../db/sql.ts';
@@ -113,6 +114,27 @@ export interface ConversationViewer {
 export function viewerIsAdmin(role: string): boolean {
   const normalized = role.toLowerCase();
   return normalized === 'owner' || normalized === 'admin';
+}
+
+/**
+ * May this role CHANGE a conversation? Editor-or-above, which is the 0.4
+ * gate: every conversation mutation ran through `mutationWithRLS`, and the
+ * `conversations` / `conversationMessages` RLS rules put each insert/modify
+ * (and delete) through `authorizeRls(role, …, 'write')` — ALL for
+ * owner/admin/developer/editor, READ_ONLY for `member`, NONE for `disabled`.
+ *
+ * This is the WRITE half of conversation access and it is role-shaped, org
+ * wide. The other half is assignment privacy — `conversationAssignmentAllows`
+ * per row, which decides who can SEE a thread at all — and the two compose:
+ * a write door checks this first, then loads the row through
+ * `loadVisibleConversation`. Assignment itself is stricter still
+ * (`viewerIsAdmin`).
+ */
+export function viewerCanWrite(role: string): boolean {
+  return (
+    authorizeRls(role, 'conversations', 'write') &&
+    authorizeRls(role, 'conversationMessages', 'write')
+  );
 }
 
 /** One conversation readable by the viewer, or the opaque 404. Evaluates the

--- a/services/platform/backend/domains/two_factor/service.ts
+++ b/services/platform/backend/domains/two_factor/service.ts
@@ -1,8 +1,13 @@
+import { transactSerializable } from '@tale/shared/db/serializable';
 import { symmetricDecrypt } from 'better-auth/crypto';
 import type { Sql, TransactionSql } from 'postgres';
 
 import { DEFAULT_TWO_FACTOR_POLICY } from '../../../lib/shared/schemas/governance.ts';
 import { mergeStrictestTwoFactorPolicy } from '../../core/governance/helpers.ts';
+import {
+  splitEmailForAudit,
+  splitIpForAudit,
+} from '../../core/lib/helpers/pii_hash.ts';
 import {
   computeLockedUntil,
   DEFAULT_LOGIN_POLICY,
@@ -123,6 +128,75 @@ export async function recordTwoFactorSuccess(
   userId: string,
 ): Promise<void> {
   await sql`DELETE FROM app.two_factor_attempts WHERE user_id = ${userId}`;
+}
+
+/**
+ * The second-factor lifecycle events. Action names are the 0.4 ones verbatim
+ * (`two_factor/internal_mutations.ts` → `logEnrollmentEvent`) — a rename
+ * would silently break any saved audit query or export that groups on them.
+ */
+export type TwoFactorLifecycleAction =
+  | '2fa_enrolled'
+  | '2fa_disabled'
+  | 'passkey_added'
+  | 'passkey_removed'
+  | 'passkey_sign_in';
+
+/**
+ * Audit a SUCCESSFUL 2FA / passkey lifecycle event (#1508 in 0.4). These are
+ * the account-takeover-relevant ones: an attacker who adds a passkey and
+ * disables TOTP must not be able to do it without leaving a trail. The
+ * failure side is `recordTwoFactorFailure` above — on 0.5 that was the only
+ * half that survived the port, because the 0.4 hook file carrying these
+ * calls was deleted with the Convex tree.
+ *
+ * Org-scoped like every other security event: one row per org the user
+ * belongs to, PII split into plaintext + peppered hash by the reused
+ * helpers, all inside ONE serializable transaction so a user in several orgs
+ * gets all their rows or none.
+ */
+export async function recordTwoFactorLifecycleEvent(
+  sql: Sql,
+  args: {
+    userId: string;
+    action: TwoFactorLifecycleAction;
+    actorEmail?: string;
+    ip?: string;
+    userAgent?: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<void> {
+  const emailParts =
+    args.actorEmail !== undefined
+      ? await splitEmailForAudit(args.actorEmail)
+      : {};
+  const ipParts = args.ip !== undefined ? await splitIpForAudit(args.ip) : {};
+  await transactSerializable(sql, async (tx) => {
+    for (const organizationId of await userOrgIds(tx, args.userId)) {
+      await createAuditLog(tx, {
+        organizationId,
+        actorId: args.userId,
+        ...(emailParts.plaintext !== undefined
+          ? { actorEmail: emailParts.plaintext }
+          : {}),
+        ...(emailParts.hash !== undefined
+          ? { actorEmailHash: emailParts.hash }
+          : {}),
+        actorType: 'user',
+        action: args.action,
+        category: 'security',
+        resourceType: 'twoFactorAuth',
+        resourceId: args.userId,
+        ...(ipParts.plaintext !== undefined
+          ? { ipAddress: ipParts.plaintext }
+          : {}),
+        ...(ipParts.hash !== undefined ? { actorIpHash: ipParts.hash } : {}),
+        ...(args.userAgent !== undefined ? { userAgent: args.userAgent } : {}),
+        status: 'success',
+        ...(args.metadata !== undefined ? { metadata: args.metadata } : {}),
+      });
+    }
+  });
 }
 
 export interface TwoFactorEnforcement {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -10934,6 +10934,158 @@ async function checkConversations(
       remnants[0]?.count === '0',
     `listed=${row !== undefined} unread=${row?.unread} preview=${row?.lastMessagePreview === 'Where is my order?'} contact=${row?.contact?.email}, counts=${counts.success ? `${counts.data.byStatus.open ?? 0}/${counts.data.unread}` : 'ERR'}, memberHidden=${hiddenBefore}→assigned visible=${visibleAfter} bell=${assignBell[0]?.count}, teamSees=${teammateSees} teamBell=${teamBell[0]?.count}, noteKeepsUnread=${unreadStillOne} readClears=${afterRead.success && afterRead.data.conversation.metadata?.unread_count === 0}, close=${closed.success ? closed.data.successCount : 'ERR'} status=${closedRow[0]?.status}/${closedRow[0]?.resolvedBy !== null}, del=${deleted.status} remnants=${remnants[0]?.count}`,
   );
+
+  // --- Write gate: editor-or-above, assignment privacy held constant ----
+  // 0.4 ran every conversation mutation through `mutationWithRLS`, whose
+  // `conversations`/`conversationMessages` rules demanded WRITE — ALL for
+  // owner/admin/developer/editor, READ_ONLY for `member`. The probe thread is
+  // ASSIGNED to the probing user, so assignment privacy passes on every call
+  // and the ONLY thing that can refuse is the role.
+  const gateSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `conv-gate-${orgId.slice(0, 8)}@door.test`,
+      password: 'itest-password-1',
+      name: 'Inbox Gate Probe',
+    }),
+  });
+  const gateCookie = cookieHeaderFrom(gateSignUp);
+  const gateUser = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await gateSignUp.json());
+  const gateUserId = gateUser.success ? gateUser.data.user.id : '';
+  const gateMemberId = `m-conv-gate-${gateUserId}`;
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${gateMemberId}, ${orgId}, ${gateUserId}, 'member', ${new Date()})
+  `;
+  const gated = await sql.begin(async (tx) => {
+    const id = await createConversation(tx, {
+      organizationId: orgId,
+      contactId,
+      assigneeUserId: gateUserId,
+      subject: 'Write gate probe',
+      channel: 'email',
+      direction: 'inbound',
+      connectorName: 'imap-smtp',
+    });
+    await addMessageToConversation(tx, {
+      conversationId: id,
+      organizationId: orgId,
+      sender: 'customer@inbox.test',
+      content: 'Can a read-only member answer this?',
+      isCustomer: true,
+      connectorName: 'imap-smtp',
+    });
+    return id;
+  });
+  const gateMessages = await sql<{ id: string }[]>`
+    SELECT id FROM app.conversation_messages
+    WHERE conversation_id = ${gated} LIMIT 1
+  `;
+  const gateMessageId = gateMessages[0]?.id ?? '';
+  const asGate = (
+    route: string,
+    init: { method?: string; body?: unknown } = {},
+  ): Promise<Response> =>
+    fetch(`${base}/api/app/conversations${route}?orgId=${orgId}`, {
+      method: init.method ?? (init.body !== undefined ? 'POST' : 'GET'),
+      headers: {
+        'content-type': 'application/json',
+        cookie: gateCookie,
+        origin: base,
+      },
+      ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+    });
+  const writeDoors = async (): Promise<number[]> =>
+    (
+      await Promise.all([
+        asGate(`/${gated}`, { method: 'PATCH', body: { status: 'closed' } }),
+        asGate(`/${gated}/read`, { body: {} }),
+        asGate(`/${gated}/messages`, { body: { content: 'a note' } }),
+        asGate(`/${gated}/reply`, { body: { content: 'an outbound reply' } }),
+        asGate('/compose', {
+          body: {
+            contactId,
+            connectorName: 'imap-smtp',
+            subject: 'Unauthorized outbound',
+            content: 'This must never leave the building.',
+          },
+        }),
+        asGate('/bulk/reply', {
+          body: { conversationIds: [gated], content: 'bulk reply' },
+        }),
+        asGate('/bulk/close', { body: { conversationIds: [gated] } }),
+        asGate(`/messages/${gateMessageId}/undo`, { body: {} }),
+        asGate(`/messages/${gateMessageId}/retry`, { body: {} }),
+        asGate(`/messages/${gateMessageId}/discard`, { body: {} }),
+        asGate(`/${gated}`, { method: 'DELETE' }),
+      ])
+    ).map((res) => res.status);
+  const memberDoors = await writeDoors();
+  // Refused means REFUSED: the thread is untouched and nothing was appended.
+  const afterMember = await sql<{ status: string | null; msgs: string }[]>`
+    SELECT c.status,
+           (SELECT count(*)::text FROM app.conversation_messages m
+             WHERE m.conversation_id = c.id) AS msgs
+    FROM app.conversations c WHERE c.id = ${gated}
+  `;
+  // Reads are NOT gated — a member still opens the thread assigned to them.
+  const memberRead = await asGate(`/${gated}`);
+
+  // The same doors as `editor` now go THROUGH the gate. The send doors are
+  // probed with an invalid body so the proof is "the gate opened, the schema
+  // refused" (400) — no real outbound mail, no state to clean up after.
+  await sql`UPDATE "member" SET "role" = 'editor' WHERE "id" = ${gateMemberId}`;
+  const editorNote = await asGate(`/${gated}/messages`, {
+    body: { content: 'an editor may answer' },
+  });
+  const editorPatch = await asGate(`/${gated}`, {
+    method: 'PATCH',
+    body: { status: 'closed' },
+  });
+  const editorRead = await asGate(`/${gated}/read`, { body: {} });
+  const editorBulk = await asGate('/bulk/close', {
+    body: { conversationIds: [gated] },
+  });
+  const afterEditor = await sql<{ status: string | null; msgs: string }[]>`
+    SELECT c.status,
+           (SELECT count(*)::text FROM app.conversation_messages m
+             WHERE m.conversation_id = c.id) AS msgs
+    FROM app.conversations c WHERE c.id = ${gated}
+  `;
+  const editorPastGate = (
+    await Promise.all([
+      asGate(`/${gated}/reply`, { body: {} }),
+      asGate('/compose', { body: {} }),
+      asGate('/bulk/reply', { body: {} }),
+      asGate(`/messages/${gateMessageId}/undo`, { body: {} }),
+      asGate(`/messages/${gateMessageId}/retry`, { body: {} }),
+      asGate(`/messages/${gateMessageId}/discard`, { body: {} }),
+    ])
+  ).map((res) => res.status);
+  const editorDelete = await asGate(`/${gated}`, { method: 'DELETE' });
+
+  await sql`DELETE FROM app.conversations WHERE id = ${gated}`;
+  await sql`DELETE FROM "member" WHERE "id" = ${gateMemberId}`;
+  record(
+    'conversations: writes need editor-or-above, reads do not',
+    memberDoors.every((status) => status === 403) &&
+      afterMember[0]?.status === 'open' &&
+      afterMember[0]?.msgs === '1' &&
+      memberRead.status === 200 &&
+      editorNote.status === 201 &&
+      editorPatch.status === 200 &&
+      editorRead.status === 200 &&
+      editorBulk.status === 200 &&
+      afterEditor[0]?.status === 'closed' &&
+      afterEditor[0]?.msgs === '2' &&
+      editorPastGate.every((status) => status !== 403) &&
+      editorDelete.status === 204,
+    `member=${memberDoors.join(',')} (want all 403) untouched=${afterMember[0]?.status}/${afterMember[0]?.msgs}msg read=${memberRead.status} (want 200), editor note=${editorNote.status} patch=${editorPatch.status} read=${editorRead.status} bulk=${editorBulk.status} → ${afterEditor[0]?.status}/${afterEditor[0]?.msgs}msg, pastGate=${editorPastGate.join(',')} (want none 403), del=${editorDelete.status}`,
+  );
 }
 
 /**
@@ -22561,6 +22713,94 @@ async function checkAuditSurface(
     exported.success && exported.data.fileName.endsWith('.csv') && csvOk,
     `export=${exported.success ? exported.data.fileName : 'ERR'}, csv=${csvOk}`,
   );
+
+  // --- Read gate: admin/owner only, on EVERY door (#1505) ---------------
+  // The log enumerates who did what to whom and carries the GDPR erasure
+  // trail, so 0.4 gated every public audit query on `isAdmin`. One seeded
+  // user walks the doors at three roles: the same cookie, the `member` row
+  // rewritten between passes (that is where `requireOrgMember` reads from).
+  const gateSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `audit-gate-${orgId.slice(0, 8)}@door.test`,
+      password: 'itest-password-1',
+      name: 'Audit Gate Probe',
+    }),
+  });
+  const gateCookie = cookieHeaderFrom(gateSignUp);
+  const gateUser = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await gateSignUp.json());
+  const gateUserId = gateUser.success ? gateUser.data.user.id : '';
+  const gateMemberId = `m-audit-gate-${gateUserId}`;
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${gateMemberId}, ${orgId}, ${gateUserId}, 'member', ${new Date()})
+  `;
+  const asRole = async (role: string): Promise<number[]> => {
+    await sql`
+      UPDATE "member" SET "role" = ${role} WHERE "id" = ${gateMemberId}
+    `;
+    const doors: Promise<Response>[] = [
+      fetch(`${base}/api/app/audit-logs?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/errors?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/summary?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/integrity/status?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/block-counters?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      // The by-id detail door: a real row, so a leak would be a real leak.
+      fetch(`${base}/api/app/audit-logs/${anyId}?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/integrity/verify?orgId=${orgId}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: gateCookie,
+          origin: base,
+        },
+        body: JSON.stringify({ maxEntries: 10 }),
+      }),
+      fetch(`${base}/api/app/audit-logs/export?orgId=${orgId}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: gateCookie,
+          origin: base,
+        },
+        body: JSON.stringify({ format: 'json' }),
+      }),
+    ];
+    return (await Promise.all(doors)).map((res) => res.status);
+  };
+  // `member` and `developer` are both refused — 0.4's matrix gave developer
+  // auditLogs WRITE only. `admin` passes every door (the export needs the
+  // object store, so "not 403" is the gate assertion there).
+  const asMember = await asRole('member');
+  const asDeveloper = await asRole('developer');
+  const asAdmin = await asRole('admin');
+  // The detail door must refuse with 403, never leak "no such row" as a 404.
+  const detailRefused = asMember[5] === 403 && asDeveloper[5] === 403;
+  await sql`DELETE FROM "member" WHERE "id" = ${gateMemberId}`;
+  record(
+    'audit surface: every read door is admin/owner-only (#1505)',
+    asMember.every((status) => status === 403) &&
+      asDeveloper.every((status) => status === 403) &&
+      detailRefused &&
+      asAdmin.every((status) => status !== 403),
+    `member=${asMember.join(',')} developer=${asDeveloper.join(',')} (want all 403), admin=${asAdmin.join(',')} (want none 403)`,
+  );
 }
 
 /**
@@ -24940,6 +25180,105 @@ async function checkTwoFactor(
       (verifyWhileLocked.status === 429 || verifyWhileLocked.status === 400) &&
       stateAfter[0]?.count === '0',
     `blocked=${blockedRes.status}/${blockedBody.success ? blockedBody.data.enrollRequired : 'ERR'} (want true), grace=${graceBody.success ? graceBody.data.enrollRequired !== true : 'ERR'}, anchored=${anchor1.length === 1 && anchor2[0]?.graceUntil === anchor1[0]?.graceUntil}, status=${wireStatus.success ? wireStatus.data.decision : 'ERR'}, locked=${lockedUntil !== null}, verify=${verifyWhileLocked.status}, cleared=${stateAfter[0]?.count}`,
+  );
+
+  // --- Lifecycle audit: enable / regenerate / disable, and the passkey trio
+  // 0.4 audited every SUCCESSFUL second-factor lifecycle event (#1508); the
+  // port kept only the failure half, so an attacker who registered their own
+  // passkey and turned TOTP off left no trace at all. Action names are 0.4's
+  // verbatim — a rename would break any saved query grouping on them.
+  const authPost = (route: string, body: unknown): Promise<Response> =>
+    fetch(`${base}/api/auth${route}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: JSON.stringify(body),
+    });
+  const lifecycleActions = async (): Promise<string[]> => {
+    const rows = await sql<{ action: string }[]>`
+      SELECT action FROM app.audit_logs
+      WHERE org_id = ${ctx.orgId} AND resource_type = 'twoFactorAuth'
+        AND resource_id = ${userId}
+      ORDER BY ts ASC
+    `;
+    return rows.map((row) => row.action);
+  };
+  const before2fa = await lifecycleActions();
+  const enableRes = await authPost('/two-factor/enable', {
+    password: 'itest-password-1',
+  });
+  const afterEnable = await lifecycleActions();
+  const regenRes = await authPost('/two-factor/generate-backup-codes', {
+    password: 'itest-password-1',
+  });
+  const afterRegen = await lifecycleActions();
+  const disableRes = await authPost('/two-factor/disable', {
+    password: 'itest-password-1',
+  });
+  const afterDisable = await lifecycleActions();
+  // Backup-code regeneration audits as a `2fa_enrolled` carrying the 0.4
+  // `backupCodesRegenerated` stamp. The endpoint needs a COMPLETED TOTP
+  // enrolment (a verified code), which a script cannot produce — so the
+  // assertion covers whichever way it answers: a 200 must leave the stamped
+  // row, and a refusal must leave NOTHING (the hook audits success only).
+  const regenRow = await sql<
+    { category: string; status: string; regenerated: boolean | null }[]
+  >`
+    SELECT category, status,
+           (metadata->>'backupCodesRegenerated')::boolean AS regenerated
+    FROM app.audit_logs
+    WHERE org_id = ${ctx.orgId} AND resource_id = ${userId}
+      AND action = '2fa_enrolled' AND metadata ? 'backupCodesRegenerated'
+    ORDER BY ts DESC LIMIT 1
+  `;
+  const regenConsistent =
+    regenRes.status === 200
+      ? regenRow.length === 1 &&
+        regenRow[0]?.regenerated === true &&
+        afterRegen.join(',') === '2fa_enrolled,2fa_enrolled'
+      : regenRow.length === 0 && afterRegen.join(',') === afterEnable.join(',');
+  // WebAuthn cannot be driven from a script, so the passkey trio is proven at
+  // the writer: the action names land as rows with the security shape.
+  const { recordTwoFactorLifecycleEvent } =
+    await import('./domains/two_factor/service.ts');
+  for (const action of [
+    'passkey_added',
+    'passkey_sign_in',
+    'passkey_removed',
+  ] as const) {
+    await recordTwoFactorLifecycleEvent(sql, {
+      userId,
+      action,
+      actorEmail: email,
+      ip: '203.0.113.9',
+      userAgent: 'itest-passkey/1.0',
+    });
+  }
+  const afterPasskeys = await lifecycleActions();
+  // Every lifecycle row carries the 0.4 security shape, not just the name.
+  const shapes = await sql<{ category: string; status: string }[]>`
+    SELECT DISTINCT category, status FROM app.audit_logs
+    WHERE org_id = ${ctx.orgId} AND resource_type = 'twoFactorAuth'
+      AND resource_id = ${userId}
+  `;
+  // Leave 2FA OFF: later lanes sign this account in with password alone.
+  const enrolled = await sql<{ enabled: boolean | null }[]>`
+    SELECT "twoFactorEnabled" AS enabled FROM "user" WHERE "id" = ${userId}
+  `;
+  record(
+    'two-factor: successful lifecycle events audit (#1508 action names)',
+    before2fa.length === 0 &&
+      enableRes.status === 200 &&
+      afterEnable.join(',') === '2fa_enrolled' &&
+      regenConsistent &&
+      disableRes.status === 200 &&
+      afterDisable.join(',') === `${afterRegen.join(',')},2fa_disabled` &&
+      afterPasskeys.join(',') ===
+        `${afterDisable.join(',')},passkey_added,passkey_sign_in,passkey_removed` &&
+      shapes.length === 1 &&
+      shapes[0]?.category === 'security' &&
+      shapes[0]?.status === 'success' &&
+      enrolled[0]?.enabled !== true,
+    `before=${before2fa.length}, enable=${enableRes.status} regen=${regenRes.status} (stamped=${regenRow.length}) disable=${disableRes.status}, trail=${afterPasskeys.join(',')}, shape=${shapes.map((s) => `${s.category}/${s.status}`).join('|')}, enabledLeftOn=${enrolled[0]?.enabled}`,
   );
 }
 


### PR DESCRIPTION
Three authorization and audit behaviours the port dropped. Any member could read the audit log; a read-only member could send outbound mail.

Refs #3142.

## Audit-log reads were open to every role

0.4 restricted them to admin and owner (#1505). The log enumerates who did what to whom across the organization, and it carries the GDPR erasure trail — data subject names and the lawful grounds for erasing them.

Fixed in the ability matrix rather than route by route, so all six doors are covered together: list, detail, summary, export, integrity verify and status. Gating them individually invites the next door to ship ungated.

Developers keep `write`, so a developer's own actions still append their audit rows. Members hold neither.

## A read-only member could write to conversations

Reply, send outbound mail, close, bulk-act, delete. 0.4 ran every conversation mutation through `mutationWithRLS`, whose `conversations` and `conversationMessages` rules put each write through `authorizeRls` at editor-or-above.

`viewerCanWrite` reuses that same matrix rather than declaring a second role list. It composes with the half that was correctly ported: a write door checks the role first, then loads the row through `loadVisibleConversation`, which applies `conversationAssignmentAllows` per row. Role decides *whether you may change a conversation*; assignment decides *which ones you can see at all*; assignment itself is stricter still.

Sending outbound mail is the sharpest of the five — it leaves the building under the organization's name.

## 2FA and passkey events audited only on failure

An attacker who added a passkey and disabled 2FA left no successful-action trail. All five events now audit, inside the same serializable transaction as the state change.

The 0.4 action names are reused verbatim — `2fa_enrolled`, `2fa_disabled`, `passkey_added`, `passkey_removed`, `passkey_sign_in`. A renamed action silently breaks any existing query or export that groups on it. Checked against 0.4's full vocabulary: `passkey_removed` and `passkey_revoked_by_admin` were distinct events there and stay distinct here.

## Tests

`access.test.ts` pins the matrix, and `integration-check.ts` covers the doors end to end.

| Mutation | Went red |
| --- | --- |
| `auditLogs: ['read', 'write']` restored to the developer role | two assertions |

Each finding asserts both directions — the lower role is refused **and** the higher role still allowed. Testing only the refusal is half a test: a gate that refuses everyone passes it.

## The caller audit

Tightening a gate breaks callers, so every door was traced before commit. The audit-log doors are reached only from the admin-facing settings surface. The conversation write doors are reached from the inbox UI, the REST surface (which carries its own editor-role gate), and the connector lanes, which run under system auth. The 2FA changes add audit writes and gate nothing, so they have no caller risk.

Role comes from the session-resolved value where the seam offers it, not a raw `member` table read — trusted-headers deployments insert a placeholder member row, so a proxy-declared admin can hold a non-admin role in that table.

## Scope

Retention destruction still emits no audit rows — sixteen 0.4 action names exist nowhere in the tree. Same class, different file, and #3143 is already editing it.

The audit chain's `pii_scrubbed` recompute skip and its oldest-row trust anchor are untouched. Both are signed off in `backend/MIGRATION.md` as intentional divergences, so they are a design question rather than a porting defect.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `lint:sast` green; the new unit suite 7/7.
