### PR TITLE
fix(platform): recover background jobs stranded on crash or restart

### DIFF
--- a/services/platform/backend/core/tasks/agent_run_host.steer_fallback.test.ts
+++ b/services/platform/backend/core/tasks/agent_run_host.steer_fallback.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ActionCtx } from '../lib/ctx.ts';
+import {
+  steerTaskAgentTurnImpl,
+  type SteerTaskAgentTurnArgs,
+} from './agent_run_host.ts';
+
+/**
+ * Regression lock for the steer-miss fallback (job-liveness class): when a
+ * `task.agent_steer` finds its run already settled — the exact case the
+ * fallback exists for — it kicks a fresh mention run through
+ * `kickMentionRunAfterSteerMiss`, whose shim handler binds `organizationId`
+ * into SQL. The host once omitted it, so postgres.js threw UNDEFINED_VALUE and
+ * the kick was lost (steer has retryLimit 0). The payload MUST carry the org.
+ */
+
+function steerArgs(): SteerTaskAgentTurnArgs {
+  // Branded Convex ids in the host type; the fallback path never dereferences
+  // them, so plain strings cast through are faithful to the job payload shape.
+  return {
+    organizationId: 'org_steer_fallback',
+    runId: 'run_1',
+    taskId: 'task_1',
+    agentId: 'agent_1',
+    execId: 'exec_1',
+    sessionId: 'sess_1',
+    harness: 'claude-code',
+    deadlineAt: Date.now() + 60_000,
+    model: 'anthropic/claude',
+    skills: [],
+    connectors: [],
+    tools: [],
+    secrets: [],
+    feedback: 'please also check the invoice total',
+    author: 'Dana',
+    authorId: 'user_1',
+    attempt: 0,
+  } as unknown as SteerTaskAgentTurnArgs;
+}
+
+describe('steerTaskAgentTurnImpl settled-run fallback', () => {
+  it('passes organizationId to the mention-kick fallback', async () => {
+    const args = steerArgs();
+    const mutationCalls: Array<{ ref: unknown; payload: unknown }> = [];
+    const ctx = {
+      // The run settled while the comment was in flight — the fallback path.
+      runQuery: async () => ({
+        status: 'settled',
+        execId: args.execId,
+        sessionId: args.sessionId,
+        organizationId: args.organizationId,
+      }),
+      runMutation: async (ref: unknown, payload: unknown) => {
+        mutationCalls.push({ ref, payload });
+        return { started: true };
+      },
+      runAction: async () => null,
+      scheduler: {
+        runAfter: async () => 'job',
+        runAt: async () => 'job',
+        cancel: async () => undefined,
+      },
+    } as unknown as ActionCtx;
+
+    await steerTaskAgentTurnImpl(ctx, args);
+
+    expect(mutationCalls).toHaveLength(1);
+    const payload = mutationCalls[0]?.payload as Record<string, unknown>;
+    expect(payload.organizationId).toBe(args.organizationId);
+    expect(payload.taskId).toBe(args.taskId);
+    expect(payload.feedback).toBe(args.feedback);
+  });
+});

--- a/services/platform/backend/core/tasks/agent_run_host.ts
+++ b/services/platform/backend/core/tasks/agent_run_host.ts
@@ -1659,6 +1659,10 @@ export async function steerTaskAgentTurnImpl(
     await ctx.runMutation(
       internal.tasks.mutations.kickMentionRunAfterSteerMiss,
       {
+        // The shim handler binds organizationId into its SQL; omitting it made
+        // postgres.js throw UNDEFINED_VALUE, losing every settled-run fallback
+        // kick (task.agent_steer has retryLimit 0). TurnKeys carries it.
+        organizationId: args.organizationId,
         taskId: args.taskId,
         authorId: args.authorId,
         feedback: args.feedback,

--- a/services/platform/backend/db/migrations/0065_conversation_message_status_changed.sql
+++ b/services/platform/backend/db/migrations/0065_conversation_message_status_changed.sql
@@ -1,0 +1,31 @@
+-- 0.5 app migration 0065: a durable "entered the current delivery state at"
+-- stamp for outbound conversation messages, so the send crash-recovery
+-- watchdog can find replies stranded 'queued' by a lost or expired send job.
+--
+-- The row already carries created_at_ms (the original insert) and, in
+-- metadata, scheduledSendAt (the undo-window send time) — but a RETRY
+-- re-queues the row without touching either, so neither dates the CURRENT
+-- 'queued' state, and a watchdog keyed on them would fail a freshly retried
+-- send before its job ran. This column is stamped on every delivery_state
+-- transition (queued at insert and on retry; sent/failed on settle), giving
+-- the sweep a truthful clock.
+--
+-- Forward-only and rolling-safe: the column is nullable and the watchdog
+-- coalesces it to created_at_ms, so the previous image keeps working. The
+-- backfill touches only the small in-flight 'queued' set. The partial index
+-- keeps the fleet sweep O(queued) on a table that is otherwise all-history.
+ALTER TABLE app.conversation_messages
+  ADD COLUMN IF NOT EXISTS status_changed_at_ms bigint;
+
+-- In-flight queued rows written before this migration get a truthful stamp so
+-- the watchdog neither misses them nor fails them prematurely. (A queued row's
+-- sent_at_ms is stamped to the insert instant, so it dates the queue.)
+UPDATE app.conversation_messages
+  SET status_changed_at_ms = coalesce(sent_at_ms, created_at_ms)
+  WHERE delivery_state = 'queued' AND status_changed_at_ms IS NULL;
+
+-- The crash-recovery sweep scans only stuck 'queued' rows fleet-wide; a
+-- partial index keeps that O(queued), never a full-table scan.
+CREATE INDEX IF NOT EXISTS conversation_messages_stuck_queued
+  ON app.conversation_messages (status_changed_at_ms)
+  WHERE delivery_state = 'queued';

--- a/services/platform/backend/domains/automations/reattach.ask.test.ts
+++ b/services/platform/backend/domains/automations/reattach.ask.test.ts
@@ -1,0 +1,67 @@
+import type { PgBoss } from 'pg-boss';
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setEnqueueBoss } from '../../jobs/enqueue.ts';
+import { recoverAnsweredAskResumes } from './reattach.ts';
+
+/**
+ * Unit lock for the answered-ask resume waker (job-liveness class): a run
+ * still parked on the asking exec whose ask is already answered has a lost
+ * `automation.ask_resume`; the waker re-enqueues it. The precise scan (cursor
+ * still on the asking exec, no result, ask answered past the staleness gate)
+ * lives in the real-Postgres probe; this locks the re-enqueue payload.
+ */
+
+function scriptedSql(script: unknown[][]): Sql {
+  let i = 0;
+  const nextRows = (): unknown[] =>
+    i < script.length ? (script[i++] ?? []) : [];
+  const fn = (): Promise<unknown[]> => Promise.resolve(nextRows());
+  return fn as unknown as Sql;
+}
+
+interface SentJob {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+function fakeBoss(sent: SentJob[]): void {
+  const boss = {
+    send: (name: string, data: Record<string, unknown>): Promise<string> => {
+      sent.push({ name, data });
+      return Promise.resolve('job-id');
+    },
+  };
+  setEnqueueBoss(boss as unknown as PgBoss);
+}
+
+afterEach(() => {
+  setEnqueueBoss(null as unknown as PgBoss);
+});
+
+describe('recoverAnsweredAskResumes', () => {
+  it('re-enqueues ask_resume for an answered ask still parked on the asking exec', async () => {
+    const sent: SentJob[] = [];
+    fakeBoss(sent);
+    const sql = scriptedSql([[{ organizationId: 'org_1', askId: 'ask_1' }]]);
+
+    const result = await recoverAnsweredAskResumes(sql);
+
+    expect(result).toEqual({ examined: 1, requeued: 1 });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.name).toBe('automation.ask_resume');
+    expect(sent[0]?.data).toEqual({ organizationId: 'org_1', askId: 'ask_1' });
+  });
+
+  it('does nothing when no answered ask is still parked', async () => {
+    const sent: SentJob[] = [];
+    fakeBoss(sent);
+    const sql = scriptedSql([[]]);
+
+    const result = await recoverAnsweredAskResumes(sql);
+
+    expect(result).toEqual({ examined: 0, requeued: 0 });
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/services/platform/backend/domains/automations/reattach.ts
+++ b/services/platform/backend/domains/automations/reattach.ts
@@ -214,3 +214,56 @@ export async function recoverStalledWorkflowAgentTurns(
   }
   return { examined: stalled.length, resumed };
 }
+
+/**
+ * Recover answered asks whose resume was lost — the counterpart to the
+ * awaiting_human exemption above.
+ *
+ * Answering an ask enqueues one `automation.ask_resume` job. If the worker
+ * dies between the answer and the cursor retarget (a deploy/restart), nothing
+ * re-drives it: the re-attach sweep SKIPS any ask-parked turn (op terminal,
+ * `awaiting_human`) unconditionally — right while the ask is pending, but it
+ * cannot tell answered from unanswered — so the run parks on the dead asking
+ * exec until the ask's 7-day deadline, then fails with a misleading reason.
+ *
+ * A run still parked on the ASKING exec (cursor.agent.execId == ask.execId,
+ * no result) whose ask is already `answered` is exactly that lost resume.
+ * Re-enqueue it. The resume is idempotent: `retargetAgentCursor` is a
+ * FOR-UPDATE CAS on the asking exec, and any throw self-settles the run — so a
+ * resume that already retargeted (cursor moved off the asking exec) no-ops
+ * here, and a racing pair yields a single winner. The `answered_at_ms` gate
+ * spares a resume that is merely in flight (a healthy one retargets in
+ * seconds, well inside the staleness window).
+ */
+export async function recoverAnsweredAskResumes(
+  sql: Sql,
+  options: { staleMs?: number } = {},
+): Promise<{ examined: number; requeued: number }> {
+  const staleBefore = Date.now() - (options.staleMs ?? RECOVERY_STALE_MS);
+  const rows = await sql<{ organizationId: string; askId: string }[]>`
+    SELECT r.org_id AS "organizationId", a.id AS "askId"
+    FROM app.automation_runs r
+    JOIN app.automation_human_asks a
+      ON a.run_id = r.id AND a.org_id = r.org_id
+    WHERE r.status = 'waiting'
+      AND a.status = 'answered'
+      AND a.answered_at_ms < ${staleBefore}
+      AND r.checkpoints -> 'cursor' ->> 'node' = a.node_id
+      AND r.checkpoints -> 'cursor' -> 'agent' ->> 'execId' = a.exec_id
+      AND r.checkpoints -> 'cursor' -> 'agent' -> 'result' IS NULL
+    ORDER BY a.answered_at_ms
+    LIMIT ${SWEEP_LIMIT}
+  `;
+  let requeued = 0;
+  for (const row of rows) {
+    await addJobInTx(sql, 'automation.ask_resume', {
+      organizationId: row.organizationId,
+      askId: row.askId,
+    });
+    requeued += 1;
+    console.warn(
+      `[automation-agent-watchdog] re-enqueued lost ask_resume for ask ${row.askId} — its run still parks on the asking exec`,
+    );
+  }
+  return { examined: rows.length, requeued };
+}

--- a/services/platform/backend/domains/chat/deferred-sends.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.ts
@@ -192,7 +192,15 @@ export async function enqueueDeferredSend(
     `;
     const deferredSendId = rows[0]?.id;
     if (!deferredSendId) throw new Error('deferred send insert failed');
-    await addJobInTx(tx, 'chat.deferred_send_poll', { deferredSendId });
+    // The per-send singletonKey (queue policy 'short') collapses the poll
+    // self-chain to at most one queued hop, so the watchdog can blindly
+    // re-enqueue a poll for a stalled row without doubling a live chain.
+    await addJobInTx(
+      tx,
+      'chat.deferred_send_poll',
+      { deferredSendId },
+      { singletonKey: deferredSendId },
+    );
     return { deferredSendId };
   });
 }
@@ -379,7 +387,10 @@ export async function pollDeferredSend(
       sql,
       'chat.deferred_send_poll',
       { deferredSendId },
-      { startAfter: new Date(Date.now() + delayMs) },
+      {
+        startAfter: new Date(Date.now() + delayMs),
+        singletonKey: deferredSendId,
+      },
     );
   };
 
@@ -406,7 +417,8 @@ export async function pollDeferredSend(
   }
 
   const claimed = await sql<{ id: string }[]>`
-    UPDATE app.deferred_sends SET status = 'claimed'
+    UPDATE app.deferred_sends
+    SET status = 'claimed', waiting_since_ms = ${Date.now()}
     WHERE id = ${row.id} AND status = 'waiting'
     RETURNING id
   `;
@@ -456,4 +468,66 @@ export async function pollDeferredSend(
     await sql`DELETE FROM app.deferred_sends WHERE id = ${row.id}`;
   }
   return 'ran';
+}
+
+/** A waiting row is re-polled once it is older than this — a floor to skip a
+ * row whose first poll simply has not run yet (the re-enqueue is
+ * singletonKey-deduped, so it never doubles a live chain). */
+const WAITING_STALE_MS = 30 * 1000;
+/** A claimed row whose turn never finished — the process died between the
+ * claim and the finally-DELETE. Generous: a turn is quick. */
+const CLAIMED_STALE_MS = 15 * 60 * 1000;
+
+/**
+ * Crash-recovery watchdog for parked sends (the job-liveness class), covering
+ * both dead-ends the poll self-chain leaves behind:
+ *
+ *  - a WAITING row whose poll chain SEVERED (a hop threw, or a worker died
+ *    mid-hop — the poll has retryLimit 0) sits forever with no error and no
+ *    way to cancel. Re-enqueue its poll. The per-send singletonKey ('short'
+ *    queue policy) means a row with a live chain is a no-op and only a dead
+ *    chain is revived, so this never doubles the healthy fast-poll cadence.
+ *  - a CLAIMED row wedged by a crash between the claim and the finally-DELETE
+ *    is uncancellable (cancel needs 'waiting') and a permanent tray chip.
+ *    Clear it. The chat-generation watchdog owns the thread's composer; this
+ *    only removes the tray row. At-most-once LLM spend: the turn is never
+ *    re-run (a crash surfaces through the generation watchdog, not a rerun).
+ *
+ * `waiting_since_ms` is stamped at both park and claim, so it dates the
+ * CURRENT state for either arm.
+ */
+export async function recoverStuckDeferredSends(
+  sql: Sql,
+  options: { waitingStaleMs?: number; claimedStaleMs?: number } = {},
+): Promise<{ repolled: number; cleared: number }> {
+  const now = Date.now();
+  const waitingCutoff = now - (options.waitingStaleMs ?? WAITING_STALE_MS);
+  const claimedCutoff = now - (options.claimedStaleMs ?? CLAIMED_STALE_MS);
+  const waiting = await sql<{ id: string }[]>`
+    SELECT id FROM app.deferred_sends
+    WHERE status = 'waiting' AND waiting_since_ms < ${waitingCutoff}
+    ORDER BY waiting_since_ms
+    LIMIT 200
+  `;
+  let repolled = 0;
+  for (const row of waiting) {
+    await addJobInTx(
+      sql,
+      'chat.deferred_send_poll',
+      { deferredSendId: row.id },
+      { singletonKey: row.id },
+    );
+    repolled += 1;
+  }
+  const cleared = await sql<{ id: string }[]>`
+    DELETE FROM app.deferred_sends
+    WHERE status = 'claimed' AND waiting_since_ms < ${claimedCutoff}
+    RETURNING id
+  `;
+  if (repolled > 0 || cleared.length > 0) {
+    console.warn(
+      `[deferred-send-watchdog] re-polled ${repolled} waiting, cleared ${cleared.length} wedged claimed`,
+    );
+  }
+  return { repolled, cleared: cleared.length };
 }

--- a/services/platform/backend/domains/chat/deferred-sends.watchdog.test.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.watchdog.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setEnqueueBoss } from '../../jobs/enqueue.ts';
+import { recoverStuckDeferredSends } from './deferred-sends.ts';
+
+/**
+ * Unit lock for the deferred-send crash-recovery waker (job-liveness class):
+ * a severed waiting row is re-polled with a per-send singletonKey (so a live
+ * chain is never doubled) and a wedged claimed row is cleared. The stale-window
+ * scan rides the real-Postgres probe in `integration-check.ts`.
+ */
+
+// oxlint-disable-next-line typescript/no-explicit-any -- test double for the postgres.js tag
+function scriptedSql(script: unknown[][]): any {
+  let i = 0;
+  const nextRows = (): unknown[] =>
+    i < script.length ? (script[i++] ?? []) : [];
+  return () => Promise.resolve(nextRows());
+}
+
+interface SentJob {
+  name: string;
+  data: Record<string, unknown>;
+  options: { singletonKey?: string } | undefined;
+}
+
+afterEach(() => {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reset the process-wide boss between tests
+  setEnqueueBoss(null as never);
+});
+
+describe('recoverStuckDeferredSends', () => {
+  it('re-polls severed waiting rows (singletonKey) and clears wedged claimed rows', async () => {
+    const sent: SentJob[] = [];
+    setEnqueueBoss({
+      send: (
+        name: string,
+        data: Record<string, unknown>,
+        options: { singletonKey?: string },
+      ) => {
+        sent.push({ name, data, options });
+        return Promise.resolve('job-id');
+      },
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- only `send` is exercised
+    } as never);
+    const sql = scriptedSql([
+      // waiting rows the sever-recovery re-polls
+      [{ id: 'wait_1' }, { id: 'wait_2' }],
+      // claimed rows the wedge-recovery deletes
+      [{ id: 'claim_1' }],
+    ]);
+
+    const result = await recoverStuckDeferredSends(sql);
+
+    expect(result).toEqual({ repolled: 2, cleared: 1 });
+    expect(sent).toHaveLength(2);
+    expect(sent.every((job) => job.name === 'chat.deferred_send_poll')).toBe(
+      true,
+    );
+    // The singletonKey is the send id — this is what dedups a live chain.
+    expect(sent[0]?.data.deferredSendId).toBe('wait_1');
+    expect(sent[0]?.options?.singletonKey).toBe('wait_1');
+    expect(sent[1]?.options?.singletonKey).toBe('wait_2');
+  });
+
+  it('reports zero when nothing is stalled', async () => {
+    const sent: SentJob[] = [];
+    setEnqueueBoss({
+      send: (name: string, data: Record<string, unknown>) => {
+        sent.push({ name, data, options: undefined });
+        return Promise.resolve('job-id');
+      },
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- only `send` is exercised
+    } as never);
+    const sql = scriptedSql([[], []]);
+
+    const result = await recoverStuckDeferredSends(sql);
+
+    expect(result).toEqual({ repolled: 0, cleared: 0 });
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/services/platform/backend/domains/conversations/send.ts
+++ b/services/platform/backend/domains/conversations/send.ts
@@ -259,12 +259,12 @@ export async function sendMessageViaConnector(
       INSERT INTO app.conversation_messages (
         org_id, conversation_id, connector_name, channel, direction,
         delivery_state, content, sent_at_ms, delivered_at_ms, metadata,
-        created_at_ms
+        created_at_ms, status_changed_at_ms
       ) VALUES (
         ${args.organizationId}, ${args.conversationId},
         ${args.connectorName}, 'email', 'outbound', 'queued',
         ${args.content}, ${now}, ${now},
-        ${tx.json(toJson(messageMetadata))}, ${now}
+        ${tx.json(toJson(messageMetadata))}, ${now}, ${now}
       )
       RETURNING id
     `;
@@ -719,6 +719,7 @@ export async function retrySendMessage(
     await tx`
       UPDATE app.conversation_messages SET
         delivery_state = 'queued', retry_count = ${retryCount},
+        status_changed_at_ms = ${Date.now()},
         metadata = ${tx.json(toJson(retainedMetadata))}
       WHERE id = ${args.messageId}
     `;
@@ -909,6 +910,7 @@ export async function runSendMessageJob(
     await sql`
       UPDATE app.conversation_messages SET
         delivery_state = 'sent', sent_at_ms = ${now},
+        status_changed_at_ms = ${now},
         external_message_id = ${externalMessageId ?? sql.unsafe('external_message_id')}
       WHERE id = ${payload.messageId}
     `;
@@ -924,7 +926,7 @@ export async function runSendMessageJob(
     );
     await sql`
       UPDATE app.conversation_messages SET
-        delivery_state = 'failed',
+        delivery_state = 'failed', status_changed_at_ms = ${Date.now()},
         metadata = coalesce(metadata, '{}'::jsonb)
           || ${sql.json(
             toJson({
@@ -942,4 +944,58 @@ export async function runSendMessageJob(
       entityId: message.conversationId,
     });
   }
+}
+
+/** A send left 'queued' this long past its last state change lost its job:
+ * the undo window is seconds and the send job's own expiry is 600s, so a row
+ * still queued well past both was never settled by a live handler. Generous,
+ * so a slow-but-live connector send is never failed out from under itself. */
+const SEND_STALE_MS = 20 * 60 * 1000;
+const SEND_WATCHDOG_ERROR =
+  'the message could not be delivered — the send was interrupted before it completed';
+
+/**
+ * Crash-recovery watchdog for outbound conversation sends (the job-liveness
+ * class): `conversation.send_message` has retryLimit 0, so a worker killed
+ * mid-send, or a job expired past its 600s window, leaves the message row
+ * `delivery_state='queued'` with no job behind it — an eternal "sending"
+ * clock, and the retry/discard controls only appear on `failed`.
+ *
+ * Flip stale queued rows to `failed` with a reason so the existing retry
+ * surface lights up (`retrySendMessage` re-queues from the stored args). The
+ * window is far past the send job's own expiry, so a live-but-slow handler is
+ * never failed under itself; and were one to finish afterwards it settles the
+ * row `sent`, correcting the bubble.
+ */
+export async function recoverStuckConversationSends(
+  sql: Sql,
+  options: { staleMs?: number } = {},
+): Promise<{ failed: number }> {
+  const now = Date.now();
+  const cutoff = now - (options.staleMs ?? SEND_STALE_MS);
+  const failed = await sql<
+    { id: string; conversationId: string; orgId: string }[]
+  >`
+    UPDATE app.conversation_messages SET
+      delivery_state = 'failed', status_changed_at_ms = ${now},
+      metadata = coalesce(metadata, '{}'::jsonb) || ${sql.json(
+        toJson({ error: SEND_WATCHDOG_ERROR, errorCode: 'send_interrupted' }),
+      )}
+    WHERE direction = 'outbound' AND delivery_state = 'queued'
+      AND coalesce(status_changed_at_ms, created_at_ms) < ${cutoff}
+    RETURNING id, conversation_id AS "conversationId", org_id AS "orgId"
+  `;
+  for (const row of failed) {
+    await emitHintInTx(sql, {
+      orgId: row.orgId,
+      entity: 'conversation',
+      entityId: row.conversationId,
+    });
+  }
+  if (failed.length > 0) {
+    console.warn(
+      `[conversation-send-watchdog] failed ${failed.length} stranded queued send(s)`,
+    );
+  }
+  return { failed: failed.length };
 }

--- a/services/platform/backend/domains/conversations/send.watchdog.test.ts
+++ b/services/platform/backend/domains/conversations/send.watchdog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { recoverStuckConversationSends } from './send.ts';
+
+/**
+ * Unit lock for the outbound-send crash-recovery waker (job-liveness class): a
+ * send stranded 'queued' by a lost/expired job is flipped to an HONEST
+ * 'failed' state (with a reason) and a realtime hint is emitted so the
+ * sender's retry/discard controls appear. The stale-window scan and the
+ * retry-surface round-trip ride the real-Postgres probe in
+ * `integration-check.ts`.
+ */
+
+function capturingSql(
+  script: unknown[][],
+  queries: string[],
+  // oxlint-disable-next-line typescript/no-explicit-any -- test double for the postgres.js tag
+): any {
+  let i = 0;
+  const fn = (strings: TemplateStringsArray): Promise<unknown[]> => {
+    if (Array.isArray(strings)) queries.push(strings.join('?'));
+    return Promise.resolve(i < script.length ? (script[i++] ?? []) : []);
+  };
+  fn.json = (value: unknown): unknown => value;
+  return fn;
+}
+
+describe('recoverStuckConversationSends', () => {
+  it('fails stranded queued sends with a reason and emits a hint', async () => {
+    const queries: string[] = [];
+    const sql = capturingSql(
+      [
+        // the UPDATE ... RETURNING flips the queued row to failed
+        [{ id: 'msg_1', conversationId: 'conv_1', orgId: 'org_1' }],
+        // emitHintInTx's outbox insert
+        [],
+      ],
+      queries,
+    );
+
+    const result = await recoverStuckConversationSends(sql, { staleMs: 1_000 });
+
+    expect(result).toEqual({ failed: 1 });
+    // Honest terminal state, keyed off outbound queued rows.
+    expect(queries[0]).toContain("delivery_state = 'failed'");
+    expect(queries[0]).toContain("delivery_state = 'queued'");
+    expect(queries[0]).toContain("direction = 'outbound'");
+    // A realtime hint lights up the retry surface in the open inbox.
+    expect(queries[1]).toContain('app_realtime.outbox');
+  });
+
+  it('reports zero and emits nothing when no send is stranded', async () => {
+    const queries: string[] = [];
+    const sql = capturingSql([[]], queries);
+
+    const result = await recoverStuckConversationSends(sql);
+
+    expect(result).toEqual({ failed: 0 });
+    // Only the sweep query ran — no per-row hint.
+    expect(queries).toHaveLength(1);
+  });
+});

--- a/services/platform/backend/domains/object_storage/service.backfill-watchdog.test.ts
+++ b/services/platform/backend/domains/object_storage/service.backfill-watchdog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { recoverStuckBackfills } from './service.ts';
+
+/**
+ * Unit lock for the backfill crash-recovery waker (job-liveness class): a
+ * stalled `running` backfill must be flipped to an HONEST terminal `failed`
+ * state (with a watchdog reason) so the one-running partial index stops
+ * blocking future backfills. The real-Postgres proof (the stale-window scan
+ * and the re-run unblock) rides `integration-check.ts`.
+ */
+
+function capturingSql(
+  script: unknown[][],
+  queries: string[],
+  // oxlint-disable-next-line typescript/no-explicit-any -- test double for the postgres.js tag
+): any {
+  let i = 0;
+  return (strings: TemplateStringsArray): Promise<unknown[]> => {
+    if (Array.isArray(strings)) queries.push(strings.join('?'));
+    return Promise.resolve(i < script.length ? (script[i++] ?? []) : []);
+  };
+}
+
+describe('recoverStuckBackfills', () => {
+  it('flips stalled running backfills to a failed terminal state', async () => {
+    const queries: string[] = [];
+    const sql = capturingSql([[{ id: 'run_1' }, { id: 'run_2' }]], queries);
+
+    const result = await recoverStuckBackfills(sql, { staleMs: 1_000 });
+
+    expect(result).toEqual({ failed: 2 });
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toContain('object_storage_backfill_runs');
+    expect(queries[0]).toContain("status = 'failed'");
+    // The status UI shows the reason; it must be present, not a bare flip.
+    expect(queries[0]).toContain('last_error');
+  });
+
+  it('reports zero when nothing is stalled', async () => {
+    const queries: string[] = [];
+    const sql = capturingSql([[]], queries);
+
+    const result = await recoverStuckBackfills(sql);
+
+    expect(result).toEqual({ failed: 0 });
+  });
+});

--- a/services/platform/backend/domains/object_storage/service.ts
+++ b/services/platform/backend/domains/object_storage/service.ts
@@ -582,3 +582,41 @@ export async function runBackfill(
     `;
   }
 }
+
+/**
+ * A backfill that has not stamped progress in this long is dead. The engine
+ * stamps `updated_at_ms` per ~100-blob batch, so silence past this window
+ * means its process died mid-copy — generous, because a single batch of large
+ * blobs can be slow.
+ */
+const BACKFILL_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * Crash-recovery watchdog for the blob backfill (the job-liveness class): a
+ * run whose process died mid-copy is left `status='running'` forever, and the
+ * `object_storage_backfill_one_running` partial unique index then rejects
+ * every future backfill for the org (409). Fail stale runs so the status UI
+ * stops spinning and the org can re-run — re-running is idempotent
+ * (`handleRef` skips blobs already present in the target bucket), so a fresh
+ * run finishes the copy cheaply.
+ */
+export async function recoverStuckBackfills(
+  sql: Sql,
+  options: { staleMs?: number } = {},
+): Promise<{ failed: number }> {
+  const now = Date.now();
+  const cutoff = now - (options.staleMs ?? BACKFILL_STALE_MS);
+  const failed = await sql<{ id: string }[]>`
+    UPDATE app.object_storage_backfill_runs SET
+      status = 'failed', finished_at_ms = ${now}, updated_at_ms = ${now},
+      last_error = 'the backfill process stopped before finishing (watchdog)'
+    WHERE status = 'running' AND updated_at_ms < ${cutoff}
+    RETURNING id
+  `;
+  if (failed.length > 0) {
+    console.warn(
+      `[object-storage] watchdog failed ${failed.length} stalled backfill run(s)`,
+    );
+  }
+  return { failed: failed.length };
+}

--- a/services/platform/backend/domains/tasks/reattach.queued.test.ts
+++ b/services/platform/backend/domains/tasks/reattach.queued.test.ts
@@ -1,0 +1,102 @@
+import type { PgBoss } from 'pg-boss';
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setEnqueueBoss } from '../../jobs/enqueue.ts';
+import { recoverStuckQueuedTaskAgentRuns } from './reattach.ts';
+
+/**
+ * Unit lock for the queued-run waker (job-liveness class): a run stranded at
+ * `queued` because its start job was lost must be re-kicked under a ROTATED
+ * exec id (single-winner claim), never left for the 12-hour deadline.
+ *
+ * A scripted `sql` returns each query's rows in call order; a fake boss
+ * captures the re-enqueue without a real queue. The real-Postgres proof (both
+ * branches, the agent-gone fail, the stale gate) rides `integration-check.ts`.
+ */
+
+function scriptedSql(script: unknown[][]): Sql {
+  let i = 0;
+  const nextRows = (): unknown[] =>
+    i < script.length ? (script[i++] ?? []) : [];
+  const tag = (): Promise<unknown[]> => Promise.resolve(nextRows());
+  const fn = (): Promise<unknown[]> => tag();
+  Object.assign(fn, {
+    begin: (cb: (tx: unknown) => unknown): unknown => cb(fn),
+    json: (v: unknown): unknown => v,
+    unsafe: (): Promise<unknown[]> => tag(),
+  });
+  return fn as unknown as Sql;
+}
+
+interface SentJob {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+function fakeBoss(sent: SentJob[]): void {
+  const boss = {
+    send: (name: string, data: Record<string, unknown>): Promise<string> => {
+      sent.push({ name, data });
+      return Promise.resolve('job-id');
+    },
+  };
+  setEnqueueBoss(boss as unknown as PgBoss);
+}
+
+afterEach(() => {
+  setEnqueueBoss(null as unknown as PgBoss);
+});
+
+describe('recoverStuckQueuedTaskAgentRuns', () => {
+  it('re-kicks a stranded queued run under a rotated exec id', async () => {
+    const sent: SentJob[] = [];
+    fakeBoss(sent);
+    const sql = scriptedSql([
+      // 1: the stale-queued listing
+      [
+        {
+          runId: 'run_1',
+          organizationId: 'org_1',
+          execId: 'exec_old',
+          agentPresent: true,
+        },
+      ],
+      // 2: the single-winner CAS claim wins
+      [{ id: 'run_1' }],
+    ]);
+
+    const result = await recoverStuckQueuedTaskAgentRuns(sql);
+
+    expect(result).toEqual({ examined: 1, requeued: 1, failed: 0 });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.name).toBe('task.agent_turn');
+    expect(sent[0]?.data.runId).toBe('run_1');
+    expect(sent[0]?.data.organizationId).toBe('org_1');
+    // The exec id is rotated so a lost-but-slow original start orphans itself.
+    expect(sent[0]?.data.execId).not.toBe('exec_old');
+    expect(typeof sent[0]?.data.execId).toBe('string');
+  });
+
+  it('does not re-kick when the claim is lost to a concurrent winner', async () => {
+    const sent: SentJob[] = [];
+    fakeBoss(sent);
+    const sql = scriptedSql([
+      [
+        {
+          runId: 'run_2',
+          organizationId: 'org_1',
+          execId: 'exec_old',
+          agentPresent: true,
+        },
+      ],
+      // The CAS returns no row — a live start or another sweep already claimed.
+      [],
+    ]);
+
+    const result = await recoverStuckQueuedTaskAgentRuns(sql);
+
+    expect(result).toEqual({ examined: 1, requeued: 0, failed: 0 });
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/services/platform/backend/domains/tasks/reattach.ts
+++ b/services/platform/backend/domains/tasks/reattach.ts
@@ -1,8 +1,11 @@
+import { randomUUID } from 'node:crypto';
+
 import type { Sql } from 'postgres';
 
 import { sessionExecStatus } from '../../core/node_only/sandbox/helpers/session_client.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
 import { claimRecoveryResume, RECOVERY_STALE_MS } from '../sandbox/recovery.ts';
+import { failAgentRun } from './agent-runs.ts';
 
 /**
  * Re-attach abandoned task-agent turns — the 0.5 twin of 0.4's
@@ -131,4 +134,99 @@ export async function recoverStalledTaskAgentTurns(
     );
   }
   return { examined: stalled.length, resumed };
+}
+
+/**
+ * Recover runs stranded at `queued` — the start job (task.agent_turn) died
+ * before it could flip the run to `running` (a deploy/restart in the start
+ * window: resolve model, ensure session, stage, spawn).
+ *
+ * This is the gap the running-state re-attach above cannot see and the
+ * deadline sweep will not touch until the 12-hour wall — the run has no op
+ * row yet (the start dies before writing one), no capacity stamp (it never
+ * parked), and its deadline is hours away, so `recoverStalledTaskAgentTurns`
+ * (status='running' only), the parked-run wake (needs a capacity stamp), and
+ * `listOverdueAgentRuns` (past deadline only) all pass it by. Without this
+ * the card shows `queued` for up to 12 hours, then fails with a misleading
+ * time-limit message.
+ *
+ * Two outcomes, both honest:
+ *  - the assigned agent is GONE (deleted after the kick): the start job skips
+ *    forever (task-list.ts), so the run is FAILED immediately with a real
+ *    reason instead of aging to the deadline;
+ *  - otherwise the start is re-kicked under a ROTATED exec id — the
+ *    single-winner claim (guarded on the old exec id) means a lost-but-slow
+ *    original start, if it ever runs, reads the mismatch and skips, so the
+ *    turn can never double-start (at-most-once LLM spend preserved).
+ *
+ * A run only enters this list once it has been idle past the staleness window
+ * (a healthy start flips to `running` within seconds), and the claim bumps
+ * `updated_at_ms`, so a re-kicked run is not swept again on the next tick.
+ */
+export async function recoverStuckQueuedTaskAgentRuns(
+  sql: Sql,
+  options: { staleMs?: number } = {},
+): Promise<{ examined: number; requeued: number; failed: number }> {
+  const staleBeforeMs = Date.now() - (options.staleMs ?? RECOVERY_STALE_MS);
+  const now = Date.now();
+  const stuck = await sql<
+    {
+      runId: string;
+      organizationId: string;
+      execId: string;
+      agentPresent: boolean;
+    }[]
+  >`
+    SELECT r.id AS "runId", r.org_id AS "organizationId",
+           r.exec_id AS "execId", (a.id IS NOT NULL) AS "agentPresent"
+    FROM app.project_agent_runs r
+    LEFT JOIN app.project_agents a
+      ON a.id = r.agent_id AND a.org_id = r.org_id
+    WHERE r.status = 'queued'
+      AND r.waiting_for_capacity_at_ms IS NULL
+      AND r.deadline_at_ms > ${now}
+      AND r.updated_at_ms < ${staleBeforeMs}
+    ORDER BY r.updated_at_ms
+    LIMIT ${SWEEP_LIMIT}
+  `;
+  let requeued = 0;
+  let failed = 0;
+  for (const run of stuck) {
+    if (!run.agentPresent) {
+      const didFail = await failAgentRun(sql, {
+        organizationId: run.organizationId,
+        runId: run.runId,
+        execId: run.execId,
+        error: 'the assigned agent was deleted before the run could start',
+      });
+      if (didFail) {
+        failed += 1;
+        console.warn(
+          `[task-agent-watchdog] failed stranded queued run ${run.runId} — its agent was deleted`,
+        );
+      }
+      continue;
+    }
+    // Single-winner claim: rotate the exec id so a lost-but-slow original
+    // start orphans itself (its setAgentRunRunning is exec-id fenced).
+    const newExecId = randomUUID();
+    const claimed = await sql<{ id: string }[]>`
+      UPDATE app.project_agent_runs SET
+        exec_id = ${newExecId}, updated_at_ms = ${Date.now()}
+      WHERE id = ${run.runId} AND status = 'queued'
+        AND exec_id = ${run.execId} AND waiting_for_capacity_at_ms IS NULL
+      RETURNING id
+    `;
+    if (claimed.length === 0) continue;
+    await addJobInTx(sql, 'task.agent_turn', {
+      organizationId: run.organizationId,
+      runId: run.runId,
+      execId: newExecId,
+    });
+    requeued += 1;
+    console.warn(
+      `[task-agent-watchdog] re-kicked stranded queued run ${run.runId} (exec ${run.execId} → ${newExecId})`,
+    );
+  }
+  return { examined: stuck.length, requeued, failed };
 }

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -7727,6 +7727,246 @@ async function checkTurnReattach(
 }
 
 /**
+ * The queued-start recovery (job-liveness): a run stranded at `queued`
+ * because its start job was lost re-kicks under a rotated exec id; one whose
+ * agent was deleted fails with a real reason; a fresh queued run and a
+ * capacity-parked one are both left for their own lanes.
+ */
+async function checkQueuedRunRecovery(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const now = Date.now();
+  const projectRows = await sql<{ id: string }[]>`
+    INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                              updated_at_ms)
+    VALUES (${orgId}, 'Queued recovery project', ${userId}, ${now}, ${now})
+    RETURNING id
+  `;
+  const projectId = projectRows[0]?.id ?? '';
+  const taskRows = await sql<{ id: string }[]>`
+    INSERT INTO app.tasks (
+      org_id, project_id, title, status, rank, created_by, created_by_type,
+      created_at_ms, updated_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'Queued recovery task', 'in_progress', 'a0',
+      ${userId}, 'user', ${now}, ${now}
+    ) RETURNING id
+  `;
+  const taskId = taskRows[0]?.id ?? '';
+  const agentRows = await sql<{ id: string }[]>`
+    INSERT INTO app.project_agents (
+      org_id, project_id, name, harness, model, created_by, created_at_ms,
+      updated_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'Queued recovery agent', 'claude-code',
+      'itest-model', ${userId}, ${now}, ${now}
+    ) RETURNING id
+  `;
+  const agentId = agentRows[0]?.id ?? '';
+
+  const mkQueuedRun = async (
+    execId: string,
+    opts: { agentId: string; updatedAt: number; parked?: boolean },
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.project_agent_runs (
+        org_id, task_id, project_id, agent_id, session_id, exec_id, harness,
+        model, trigger, started_by, status, waiting_for_capacity_at_ms,
+        started_at_ms, deadline_at_ms, updated_at_ms
+      ) VALUES (
+        ${orgId}, ${taskId}, ${projectId}, ${opts.agentId},
+        ${`pa-${opts.agentId}`}, ${execId}, 'claude-code', 'itest-model',
+        'manual', ${userId}, 'queued',
+        ${opts.parked === true ? now : null},
+        ${now - 600_000}, ${now + 3_600_000}, ${opts.updatedAt}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+
+  // Stale + agent present → re-kick; stale + agent gone → fail; fresh and
+  // capacity-parked → untouched.
+  const stranded = await mkQueuedRun('exec-stranded', {
+    agentId,
+    updatedAt: now - 600_000,
+  });
+  const orphaned = await mkQueuedRun('exec-orphaned', {
+    agentId: 'agent-was-deleted',
+    updatedAt: now - 600_000,
+  });
+  const fresh = await mkQueuedRun('exec-fresh', { agentId, updatedAt: now });
+  const parked = await mkQueuedRun('exec-parked', {
+    agentId,
+    updatedAt: now - 600_000,
+    parked: true,
+  });
+
+  const { recoverStuckQueuedTaskAgentRuns } =
+    await import('./domains/tasks/reattach.ts');
+  const result = await recoverStuckQueuedTaskAgentRuns(sql, {
+    staleMs: 60_000,
+  });
+
+  const readRun = async (
+    id: string,
+  ): Promise<{ status: string; execId: string } | undefined> =>
+    (
+      await sql<{ status: string; execId: string }[]>`
+        SELECT status, exec_id AS "execId" FROM app.project_agent_runs
+        WHERE id = ${id}
+      `
+    )[0];
+  const strandedRow = await readRun(stranded);
+  const orphanedRow = await readRun(orphaned);
+  const freshRow = await readRun(fresh);
+  const parkedRow = await readRun(parked);
+  const turnJobs = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM pgboss.job
+    WHERE name = 'task.agent_turn' AND data ->> 'runId' = ${stranded}
+  `;
+
+  record(
+    'queued recovery: stranded re-kicked (rotated exec), orphan failed, fresh/parked untouched',
+    result.requeued === 1 &&
+      result.failed === 1 &&
+      strandedRow?.status === 'queued' &&
+      strandedRow.execId !== 'exec-stranded' &&
+      turnJobs[0]?.count === '1' &&
+      orphanedRow?.status === 'failed' &&
+      freshRow?.status === 'queued' &&
+      freshRow.execId === 'exec-fresh' &&
+      parkedRow?.status === 'queued' &&
+      parkedRow.execId === 'exec-parked',
+    `requeued=${result.requeued}/1 failed=${result.failed}/1 stranded=${strandedRow?.status}/${strandedRow?.execId !== 'exec-stranded' ? 'rotated' : 'same'} turnJob=${turnJobs[0]?.count} orphan=${orphanedRow?.status} fresh=${freshRow?.execId} parked=${parkedRow?.execId}`,
+  );
+
+  // Leave nothing the live worker could act on.
+  await sql`
+    UPDATE app.project_agent_runs SET status = 'cancelled'
+    WHERE task_id = ${taskId} AND status IN ('queued', 'running')
+  `;
+}
+
+/**
+ * The steer-miss mention fallback (job-liveness): a comment steer that finds
+ * its run already settled kicks a fresh mention run through the real shim,
+ * which binds organizationId into SQL. Driving the host over a genuinely
+ * settled run proves the fallback no longer throws UNDEFINED_VALUE and a fresh
+ * run actually lands (the kick was silently lost before).
+ */
+async function checkSteerFallbackRecovery(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const now = Date.now();
+  const projectId =
+    (
+      await sql<{ id: string }[]>`
+        INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                                  updated_at_ms)
+        VALUES (${orgId}, 'Steer fallback project', ${userId}, ${now}, ${now})
+        RETURNING id
+      `
+    )[0]?.id ?? '';
+  const agentId =
+    (
+      await sql<{ id: string }[]>`
+        INSERT INTO app.project_agents (
+          org_id, project_id, name, harness, model, created_by, created_at_ms,
+          updated_at_ms
+        ) VALUES (
+          ${orgId}, ${projectId}, 'Steer fallback agent', 'claude-code',
+          'itest-model', ${userId}, ${now}, ${now}
+        ) RETURNING id
+      `
+    )[0]?.id ?? '';
+  const taskId =
+    (
+      await sql<{ id: string }[]>`
+        INSERT INTO app.tasks (
+          org_id, project_id, title, status, rank, created_by, created_by_type,
+          assignee_type, assignee_id, created_at_ms, updated_at_ms
+        ) VALUES (
+          ${orgId}, ${projectId}, 'Steer fallback task', 'in_progress', 'a0',
+          ${userId}, 'user', 'agent', ${agentId}, ${now}, ${now}
+        ) RETURNING id
+      `
+    )[0]?.id ?? '';
+  // A genuinely settled run — the exact state the fallback exists for.
+  const settledRunId =
+    (
+      await sql<{ id: string }[]>`
+        INSERT INTO app.project_agent_runs (
+          org_id, task_id, project_id, agent_id, session_id, exec_id, harness,
+          model, trigger, started_by, status, started_at_ms, deadline_at_ms,
+          settled_at_ms, updated_at_ms
+        ) VALUES (
+          ${orgId}, ${taskId}, ${projectId}, ${agentId}, ${`pa-${agentId}`},
+          'exec-settled', 'claude-code', 'itest-model', 'manual', ${userId},
+          'settled', ${now - 600_000}, ${now + 3_600_000}, ${now - 60_000},
+          ${now - 60_000}
+        ) RETURNING id
+      `
+    )[0]?.id ?? '';
+
+  const { steerTaskAgentTurnImpl } =
+    await import('./core/tasks/agent_run_host.ts');
+  const { agentTurnShimHandlers, taskAgentShimScheduler } =
+    await import('./domains/tasks/agent-turn-shim.ts');
+  const { createCtxShim } = await import('./lib/ctx-shim.ts');
+  const shim = createCtxShim(agentTurnShimHandlers(sql), {
+    scheduler: taskAgentShimScheduler(sql),
+  });
+  let threw = '';
+  try {
+    await steerTaskAgentTurnImpl(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused host over the shim, as task-list.ts wires it
+      shim as unknown as Parameters<typeof steerTaskAgentTurnImpl>[0],
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the job payload shape (branded ids are plain strings on the wire)
+      {
+        organizationId: orgId,
+        runId: settledRunId,
+        taskId,
+        agentId,
+        execId: 'exec-settled',
+        sessionId: `pa-${agentId}`,
+        harness: 'claude-code',
+        deadlineAt: now + 3_600_000,
+        model: 'itest-model',
+        skills: [],
+        connectors: [],
+        tools: [],
+        secrets: [],
+        feedback: 'please recheck the total',
+        author: 'Dana',
+        authorId: userId,
+        attempt: 0,
+      } as unknown as Parameters<typeof steerTaskAgentTurnImpl>[1],
+    );
+  } catch (error) {
+    threw = error instanceof Error ? error.message : String(error);
+  }
+  const mentionRuns = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.project_agent_runs
+    WHERE task_id = ${taskId} AND trigger = 'mention'
+  `;
+
+  record(
+    'steer fallback: settled-run mention kick lands (organizationId reaches the shim)',
+    threw === '' && mentionRuns[0]?.count === '1',
+    `threw="${threw}" mentionRuns=${mentionRuns[0]?.count} (want 1)`,
+  );
+
+  await sql`
+    UPDATE app.project_agent_runs SET status = 'cancelled'
+    WHERE task_id = ${taskId} AND status IN ('queued', 'running')
+  `;
+}
+
+/**
  * The workflow twin of the task-agent re-attach: automation runs parked on
  * an agent turn whose drive chain died are resurrected from the run CURSOR
  * (the drive keys live in `checkpoints.cursor.agent`, not on columns).
@@ -18435,6 +18675,122 @@ async function checkLoginThrottleAndAuditChain(
 }
 
 /**
+ * The answered-ask resume waker (job-liveness): a run still parked on the
+ * asking exec whose ask is already answered had its `automation.ask_resume`
+ * lost to a restart. The waker re-enqueues it. A run whose cursor has moved
+ * off the asking exec (resume applied), a still-pending ask, and a freshly
+ * answered ask (resume merely in flight) are all left alone.
+ */
+async function checkAnsweredAskRecovery(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId } = ctx;
+  const { toJson } = await import('./db/sql.ts');
+  const now = Date.now();
+  const cursor = (node: string, execId: string): unknown => ({
+    nodes: {},
+    cursor: { node, agent: { execId, input: {}, harness: 'claude-code' } },
+    executions: {},
+  });
+  const mkRun = async (node: string, execId: string): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.automation_runs (
+        org_id, name, version, status, mode, started_by, checkpoints,
+        started_at_ms
+      ) VALUES (
+        ${orgId}, ${`itest/ask-recovery-${node}`}, 1, 'waiting', 'live',
+        'itest:ask-recovery', ${sql.json(toJson(cursor(node, execId)))}, ${now}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const mkAsk = async (
+    runId: string,
+    node: string,
+    execId: string,
+    status: 'pending' | 'answered',
+    answeredAt: number | null,
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.automation_human_asks (
+        org_id, run_id, node_id, session_id, exec_id, question, status,
+        expires_at_ms, answer, answered_by, answered_at_ms, created_at_ms
+      ) VALUES (
+        ${orgId}, ${runId}, ${node}, 'wf-ask-recovery', ${execId},
+        'Recovery question?', ${status}, ${now + 7 * 24 * 3_600_000},
+        ${status === 'answered' ? 'yes' : null},
+        ${status === 'answered' ? 'itest:answerer' : null},
+        ${answeredAt}, ${now - 3_600_000}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+
+  // Lost resume: cursor still on the asking exec, ask answered long ago.
+  const lostRun = await mkRun('ask_lost', 'exec-lost-ask');
+  const lostAsk = await mkAsk(
+    lostRun,
+    'ask_lost',
+    'exec-lost-ask',
+    'answered',
+    now - 600_000,
+  );
+  // Resume already applied: cursor moved to a fresh exec.
+  const movedRun = await mkRun('ask_moved', 'exec-new');
+  const movedAsk = await mkAsk(
+    movedRun,
+    'ask_moved',
+    'exec-old-ask',
+    'answered',
+    now - 600_000,
+  );
+  // Still pending: nothing to resume.
+  const pendingRun = await mkRun('ask_pending', 'exec-pending-ask');
+  const pendingAsk = await mkAsk(
+    pendingRun,
+    'ask_pending',
+    'exec-pending-ask',
+    'pending',
+    null,
+  );
+  // Freshly answered: a healthy resume is still in flight — spare it.
+  const freshRun = await mkRun('ask_fresh', 'exec-fresh-ask');
+  const freshAsk = await mkAsk(
+    freshRun,
+    'ask_fresh',
+    'exec-fresh-ask',
+    'answered',
+    now,
+  );
+
+  const { recoverAnsweredAskResumes } =
+    await import('./domains/automations/reattach.ts');
+  const result = await recoverAnsweredAskResumes(sql, { staleMs: 60_000 });
+  const resumeJobs = await sql<{ askId: string }[]>`
+    SELECT data ->> 'askId' AS "askId" FROM pgboss.job
+    WHERE name = 'automation.ask_resume'
+  `;
+  const enqueued = new Set(resumeJobs.map((job) => job.askId));
+
+  record(
+    'answered-ask recovery: lost resume re-enqueued, moved/pending/fresh spared',
+    result.examined === 1 &&
+      result.requeued === 1 &&
+      enqueued.has(lostAsk) &&
+      !enqueued.has(movedAsk) &&
+      !enqueued.has(pendingAsk) &&
+      !enqueued.has(freshAsk),
+    `examined=${result.examined}/1 requeued=${result.requeued}/1 lost=${enqueued.has(lostAsk)} moved=${!enqueued.has(movedAsk)} pending=${!enqueued.has(pendingAsk)} fresh=${!enqueued.has(freshAsk)}`,
+  );
+
+  await sql`
+    UPDATE app.automation_runs SET status = 'cancelled'
+    WHERE org_id = ${orgId} AND started_by = 'itest:ask-recovery'
+  `;
+}
+
+/**
  * The human-ask ANSWER surface: the pending-ask read skips expired rows, an
  * expired ask refuses the answer, a live one records it and enqueues the
  * resume job in the same transaction, a second answer is refused, and the
@@ -25535,6 +25891,284 @@ async function checkReviewArc(
 }
 
 /**
+ * Outbound-send crash recovery (job-liveness): a reply stranded 'queued' by a
+ * lost/expired send job is failed with a reason (and a hint), which lights up
+ * the retry surface — proven by `retrySendMessage` re-queueing it; a fresh
+ * queued send is left alone.
+ */
+async function checkStuckSendRecovery(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const { toJson } = await import('./db/sql.ts');
+  const now = Date.now();
+  const stale = now - 30 * 60_000;
+  const conv =
+    (
+      await sql<{ id: string }[]>`
+        INSERT INTO app.conversations (
+          org_id, subject, status, channel, direction, connector_name,
+          created_at_ms, last_message_at_ms
+        ) VALUES (
+          ${orgId}, 'Send recovery', 'open', 'email', 'inbound', 'imap-smtp',
+          ${now}, ${now}
+        ) RETURNING id
+      `
+    )[0]?.id ?? '';
+  const meta = {
+    to: ['c@example.com'],
+    connectorName: 'imap-smtp',
+    subject: 'Re: Send recovery',
+    sendContentType: 'Text',
+  };
+  const mkMsg = async (changedAt: number): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.conversation_messages (
+        org_id, conversation_id, connector_name, channel, direction,
+        delivery_state, content, sent_at_ms, delivered_at_ms, metadata,
+        created_at_ms, status_changed_at_ms
+      ) VALUES (
+        ${orgId}, ${conv}, 'imap-smtp', 'email', 'outbound', 'queued',
+        'reply body', ${changedAt}, ${changedAt}, ${sql.json(toJson(meta))},
+        ${changedAt}, ${changedAt}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const staleMsg = await mkMsg(stale);
+  const freshMsg = await mkMsg(now);
+
+  const { recoverStuckConversationSends, retrySendMessage } =
+    await import('./domains/conversations/send.ts');
+  const swept = await recoverStuckConversationSends(sql, { staleMs: 60_000 });
+  const readMsg = async (
+    id: string,
+  ): Promise<{ state: string; metadata: Record<string, unknown> | null }> => {
+    const row = (
+      await sql<{ state: string; metadata: Record<string, unknown> | null }[]>`
+        SELECT delivery_state AS state, metadata
+        FROM app.conversation_messages WHERE id = ${id}
+      `
+    )[0];
+    return row ?? { state: 'gone', metadata: null };
+  };
+  const staleRow = await readMsg(staleMsg);
+  const freshRow = await readMsg(freshMsg);
+
+  // The failed row now accepts a retry (the dead-end is truly exited).
+  let retried = false;
+  let retryError = '';
+  try {
+    await retrySendMessage(sql, {
+      organizationId: orgId,
+      messageId: staleMsg,
+      actor: { userId },
+    });
+    retried = true;
+  } catch (error) {
+    retryError = error instanceof Error ? error.message : String(error);
+  }
+  const afterRetry = await readMsg(staleMsg);
+  const staleCode =
+    typeof staleRow.metadata?.errorCode === 'string'
+      ? staleRow.metadata.errorCode
+      : '';
+
+  record(
+    'outbound-send recovery: stale queued failed with reason, retry re-opens, fresh spared',
+    swept.failed === 1 &&
+      staleRow.state === 'failed' &&
+      staleCode === 'send_interrupted' &&
+      freshRow.state === 'queued' &&
+      retried &&
+      retryError === '' &&
+      afterRetry.state === 'queued',
+    `swept=${swept.failed}/1 stale=${staleRow.state} code=${staleCode} fresh=${freshRow.state} retried=${retried} err="${retryError}" afterRetry=${afterRetry.state}`,
+  );
+
+  await sql`DELETE FROM app.conversation_messages WHERE conversation_id = ${conv}`;
+  await sql`DELETE FROM app.conversations WHERE id = ${conv}`;
+}
+
+/**
+ * Deferred-send crash recovery (job-liveness): a WAITING send whose poll
+ * chain severed is re-polled (its first poll reschedules because a gate
+ * attachment is still indexing, so no turn runs); a CLAIMED send wedged by a
+ * crash is cleared; a fresh waiting send and a fresh claimed send are spared.
+ */
+async function checkDeferredSendRecovery(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const { toJson } = await import('./db/sql.ts');
+  const now = Date.now();
+  const stale = now - 30 * 60_000;
+  const thread =
+    (
+      await sql<{ id: string }[]>`
+        INSERT INTO app.threads (org_id, user_id, title, kind, created_at_ms,
+                                 updated_at_ms)
+        VALUES (${orgId}, ${userId}, 'Deferred recovery', 'chat', ${now}, ${now})
+        RETURNING id
+      `
+    )[0]?.id ?? '';
+  // A still-indexing attachment so a re-polled turn reschedules, never runs.
+  await sql`
+    INSERT INTO app.file_metadata (
+      org_id, file_name, content_type, size, storage_ref, uploaded_by,
+      rag_status, rag_queued_at_ms, created_at_ms
+    ) VALUES (
+      ${orgId}, 'defer-gate.pdf', 'application/pdf', 10, 's3:defer-gate-1',
+      ${userId}, 'running', ${now}, ${now}
+    )
+  `;
+  const gate = [
+    {
+      fileId: 's3:defer-gate-1',
+      fileName: 'defer-gate.pdf',
+      fileType: 'application/pdf',
+      fileSize: 10,
+    },
+  ];
+  const mkDeferred = async (
+    status: 'waiting' | 'claimed',
+    waitingSince: number,
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.deferred_sends (
+        org_id, user_id, thread_id, user_text, attachments, status,
+        created_at_ms, waiting_since_ms
+      ) VALUES (
+        ${orgId}, ${userId}, ${thread}, 'hello',
+        ${sql.json(toJson(gate))}, ${status}, ${now}, ${waitingSince}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const staleWaiting = await mkDeferred('waiting', stale);
+  const freshWaiting = await mkDeferred('waiting', now);
+  const staleClaimed = await mkDeferred('claimed', stale);
+  const freshClaimed = await mkDeferred('claimed', now);
+
+  const { recoverStuckDeferredSends } =
+    await import('./domains/chat/deferred-sends.ts');
+  const result = await recoverStuckDeferredSends(sql, {
+    waitingStaleMs: 60_000,
+    claimedStaleMs: 60_000,
+  });
+
+  const pollJobs = await sql<{ id: string }[]>`
+    SELECT data ->> 'deferredSendId' AS "id" FROM pgboss.job
+    WHERE name = 'chat.deferred_send_poll'
+  `;
+  const polled = new Set(pollJobs.map((job) => job.id));
+  const statusOf = async (id: string): Promise<string> =>
+    (
+      await sql<{ status: string }[]>`
+        SELECT status FROM app.deferred_sends WHERE id = ${id}
+      `
+    )[0]?.status ?? 'gone';
+
+  record(
+    'deferred-send recovery: severed waiting re-polled, wedged claimed cleared, fresh spared',
+    result.repolled === 1 &&
+      result.cleared === 1 &&
+      polled.has(staleWaiting) &&
+      !polled.has(freshWaiting) &&
+      (await statusOf(staleClaimed)) === 'gone' &&
+      (await statusOf(freshClaimed)) === 'claimed',
+    `repolled=${result.repolled}/1 cleared=${result.cleared}/1 staleWaitingPolled=${polled.has(staleWaiting)} freshWaitingPolled=${polled.has(freshWaiting)} staleClaimed=${await statusOf(staleClaimed)} freshClaimed=${await statusOf(freshClaimed)}`,
+  );
+
+  // Delete my rows so any worker pickup of the re-poll finds them 'gone'.
+  await sql`DELETE FROM app.deferred_sends WHERE thread_id = ${thread}`;
+  await sql`DELETE FROM app.threads WHERE id = ${thread}`;
+  await sql`
+    DELETE FROM app.file_metadata
+    WHERE org_id = ${orgId} AND storage_ref = 's3:defer-gate-1'
+  `;
+}
+
+/**
+ * Blob-backfill crash recovery (job-liveness): a `running` backfill whose
+ * process died is failed with a reason, which unblocks the
+ * `object_storage_backfill_one_running` partial unique index so the org can
+ * re-run; a fresh running backfill is left alone.
+ */
+async function checkBackfillRecovery(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const slugRows = await sql<{ slug: string }[]>`
+    SELECT "slug" FROM "organization" WHERE "id" = ${orgId} LIMIT 1
+  `;
+  const orgSlug = slugRows[0]?.slug ?? '';
+  const now = Date.now();
+  const staleRows = await sql<{ id: string }[]>`
+    INSERT INTO app.object_storage_backfill_runs (
+      org_id, org_slug, dry_run, status, phase, triggered_by,
+      started_at_ms, updated_at_ms
+    ) VALUES (
+      ${orgId}, ${orgSlug}, true, 'running', 'documents', ${userId},
+      ${now - 3_600_000}, ${now - 3_600_000}
+    ) RETURNING id
+  `;
+  const staleId = staleRows[0]?.id ?? '';
+
+  const { createBackfillRun, recoverStuckBackfills } =
+    await import('./domains/object_storage/service.ts');
+  const swept = await recoverStuckBackfills(sql, { staleMs: 60_000 });
+  const staleRow = (
+    await sql<{ status: string; lastError: string | null }[]>`
+      SELECT status, last_error AS "lastError"
+      FROM app.object_storage_backfill_runs WHERE id = ${staleId}
+    `
+  )[0];
+
+  // The one-running index must now admit a fresh run.
+  let createdId = '';
+  let createError = '';
+  try {
+    createdId = await createBackfillRun(sql, {
+      organizationId: orgId,
+      orgSlug,
+      dryRun: true,
+      triggeredBy: userId,
+    });
+  } catch (error) {
+    createError = error instanceof Error ? error.message : String(error);
+  }
+
+  // The fresh run is not stale — the sweep must leave it running.
+  const swept2 = await recoverStuckBackfills(sql, { staleMs: 60_000 });
+  const freshRow = (
+    await sql<{ status: string }[]>`
+      SELECT status FROM app.object_storage_backfill_runs WHERE id = ${createdId}
+    `
+  )[0];
+
+  record(
+    'backfill recovery: stale run failed with reason, re-run unblocked, fresh left running',
+    swept.failed === 1 &&
+      staleRow?.status === 'failed' &&
+      (staleRow.lastError ?? '').includes('watchdog') &&
+      createdId !== '' &&
+      createError === '' &&
+      swept2.failed === 0 &&
+      freshRow?.status === 'running',
+    `swept=${swept.failed}/1 stale=${staleRow?.status} reason=${(staleRow?.lastError ?? '').includes('watchdog')} created=${createdId !== ''} err="${createError}" swept2=${swept2.failed}/0 fresh=${freshRow?.status}`,
+  );
+
+  await sql`
+    UPDATE app.object_storage_backfill_runs SET status = 'failed'
+    WHERE org_id = ${orgId} AND status = 'running'
+  `;
+}
+
+/**
  * The watchdog sweeps on hand-stranded rows — the handler bodies invoked
  * directly (the scheduled lane is just a cron row over the same functions;
  * assertions are on ROW STATE so a cron firing mid-check changes nothing):
@@ -25961,6 +26595,8 @@ async function main(): Promise<void> {
     await checkManualKickMovesCard(sql, authCtx);
     await checkSandboxBlobDoor(sql, baseUrl, authCtx);
     await checkTurnReattach(sql, authCtx);
+    await checkQueuedRunRecovery(sql, authCtx);
+    await checkSteerFallbackRecovery(sql, authCtx);
     await checkWorkflowTurnReattach(sql, authCtx);
     await checkConversations(sql, baseUrl, authCtx);
     await checkMailboxSyncLane(sql, authCtx);
@@ -25996,11 +26632,15 @@ async function main(): Promise<void> {
     await checkTaskAgentTurnDrive(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkAutomationAgentNode(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkAskAnswer(sql, baseUrl, authCtx);
+    await checkAnsweredAskRecovery(sql, authCtx);
     await checkAutoRetryAndKickPlan(sql, baseUrl, authCtx);
     await checkReviewArc(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkSandboxSessions(sql, authCtx);
     await checkAutomationRunToolLane(sql, baseUrl, authCtx);
     await checkSandboxSpawner(sql, baseUrl, authCtx);
+    await checkStuckSendRecovery(sql, authCtx);
+    await checkDeferredSendRecovery(sql, authCtx);
+    await checkBackfillRecovery(sql, authCtx);
     await checkWatchdogs(sql, baseUrl, authCtx);
     await checkLoginThrottleAndAuditChain(
       sql,

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -7923,9 +7923,8 @@ async function checkSteerFallbackRecovery(
   let threw = '';
   try {
     await steerTaskAgentTurnImpl(
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused host over the shim, as task-list.ts wires it
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion, typescript/no-unnecessary-type-assertion -- reused host over the shim, as task-list.ts wires it; tsc requires the widening while tsgolint false-positives it as unnecessary
       shim as unknown as Parameters<typeof steerTaskAgentTurnImpl>[0],
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the job payload shape (branded ids are plain strings on the wire)
       {
         organizationId: orgId,
         runId: settledRunId,
@@ -7944,7 +7943,7 @@ async function checkSteerFallbackRecovery(
         author: 'Dana',
         authorId: userId,
         attempt: 0,
-      } as unknown as Parameters<typeof steerTaskAgentTurnImpl>[1],
+      },
     );
   } catch (error) {
     threw = error instanceof Error ? error.message : String(error);

--- a/services/platform/backend/jobs/schedules.ts
+++ b/services/platform/backend/jobs/schedules.ts
@@ -33,9 +33,15 @@ const SCHEDULES: CronSchedule[] = [
   { name: 'watchdog.automation_agents', cron: '*/2 * * * *' },
   { name: 'watchdog.sandbox', cron: '*/5 * * * *' },
   { name: 'watchdog.chat_generations', cron: '*/2 * * * *' },
+  // Deferred-send crash recovery: revive severed poll chains and clear sends
+  // wedged 'claimed' by a crash mid-turn (an un-cancellable tray chip).
+  { name: 'watchdog.deferred_sends', cron: '*/2 * * * *' },
   // Replacement-upload blob reclaim backstop (event-driven enqueues cover
   // the common paths; this drains expiry/crash leftovers).
   { name: 'documents.replacement_cleanup', cron: '*/10 * * * *' },
+  // Blob-backfill crash recovery: a run whose process died mid-copy would
+  // otherwise wedge 'running' and block every future backfill for the org.
+  { name: 'watchdog.object_storage', cron: '*/10 * * * *' },
   // OneDrive / Google Drive mirrors refresh on a 15-minute cadence,
   // staggered so the two vendors' scans don't land on the same tick.
   { name: 'onedrive.sync_scan', cron: '*/15 * * * *' },
@@ -55,6 +61,9 @@ const SCHEDULES: CronSchedule[] = [
   { name: 'watchdog.erasures', cron: '4-59/5 * * * *' },
   // Session-idle enforcement: the control only exists if something revokes.
   { name: 'governance.revoke_idle_sessions', cron: '*/5 * * * *' },
+  // Outbound-send crash recovery: fail replies stranded 'queued' by a lost or
+  // expired send job so the sender's retry/discard controls appear.
+  { name: 'watchdog.conversation_sends', cron: '*/5 * * * *' },
   // Voice-chunk retention GC + the task date ladder (the 0.4 hourly crons),
   // offset so the hour boundary is not a thundering herd.
   { name: 'tts.gc_chunks', cron: '10 * * * *' },

--- a/services/platform/backend/jobs/task-list.ts
+++ b/services/platform/backend/jobs/task-list.ts
@@ -324,6 +324,16 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
         await import('../domains/object_storage/service.ts');
       await runBackfill(deps.sql, input);
     },
+    'watchdog.object_storage': async () => {
+      const { recoverStuckBackfills } =
+        await import('../domains/object_storage/service.ts');
+      const result = await recoverStuckBackfills(deps.sql);
+      if (result.failed > 0) {
+        console.log(
+          `[watchdog] object-storage: failed ${result.failed} stalled backfill run(s)`,
+        );
+      }
+    },
     'audit.integrity_check': async () => {
       const { listAuditedOrgIds, runScheduledIntegrityCheck } =
         await import('../domains/audit_logs/verify.ts');
@@ -354,12 +364,21 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       // Re-attach BEFORE the deadline pass: a turn whose chain died is
       // still doing work, and failing it for a stale heartbeat would throw
       // away a live agent's output.
-      const { recoverStalledTaskAgentTurns } =
+      const { recoverStalledTaskAgentTurns, recoverStuckQueuedTaskAgentRuns } =
         await import('../domains/tasks/reattach.ts');
       const reattached = await recoverStalledTaskAgentTurns(deps.sql);
       if (reattached.resumed > 0) {
         console.log(
           `[watchdog] task agents: re-attached ${reattached.resumed} of ${reattached.examined} abandoned turn(s)`,
+        );
+      }
+      // The queued-start twin: a start job lost before setAgentRunRunning
+      // leaves the run 'queued' with no op row and no capacity stamp — invisible
+      // to the re-attach above and the deadline sweep below until the 12h wall.
+      const queued = await recoverStuckQueuedTaskAgentRuns(deps.sql);
+      if (queued.requeued > 0 || queued.failed > 0) {
+        console.log(
+          `[watchdog] task agents: re-kicked ${queued.requeued} stranded queued run(s), failed ${queued.failed} with a deleted agent`,
         );
       }
       const result = await runTaskAgentWatchdog(deps.sql);
@@ -373,12 +392,22 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       // The workflow twin of the task-agent re-attach: a drive chain that
       // died mid-turn is resurrected from the run cursor, never failed —
       // the agent in the sandbox is still doing (or has finished) the work.
-      const { recoverStalledWorkflowAgentTurns } =
+      const { recoverAnsweredAskResumes, recoverStalledWorkflowAgentTurns } =
         await import('../domains/automations/reattach.ts');
       const reattached = await recoverStalledWorkflowAgentTurns(deps.sql);
       if (reattached.resumed > 0) {
         console.log(
           `[watchdog] automation agents: re-attached ${reattached.resumed} of ${reattached.examined} abandoned turn(s)`,
+        );
+      }
+      // The answered-ask twin: a resume lost to a restart while the run still
+      // parks on the asking exec (the re-attach above spares it as
+      // awaiting_human) is re-enqueued instead of stranding to the 7-day ask
+      // deadline.
+      const asks = await recoverAnsweredAskResumes(deps.sql);
+      if (asks.requeued > 0) {
+        console.log(
+          `[watchdog] automation agents: re-enqueued ${asks.requeued} lost answered-ask resume(s)`,
         );
       }
     },
@@ -481,6 +510,16 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
         await import('../domains/conversations/send.ts');
       await runSendMessageJob(deps.sql, input);
     },
+    'watchdog.conversation_sends': async () => {
+      const { recoverStuckConversationSends } =
+        await import('../domains/conversations/send.ts');
+      const result = await recoverStuckConversationSends(deps.sql);
+      if (result.failed > 0) {
+        console.log(
+          `[watchdog] conversation sends: failed ${result.failed} stranded queued send(s)`,
+        );
+      }
+    },
     'chat.deferred_send_poll': async (payload) => {
       const input = z
         .object({ deferredSendId: z.string().min(1) })
@@ -493,6 +532,16 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
       const cleared = await runChatGenerationWatchdog(deps.sql);
       if (cleared > 0) {
         console.log(`[watchdog] chat: cleared ${cleared} stale generations`);
+      }
+    },
+    'watchdog.deferred_sends': async () => {
+      const { recoverStuckDeferredSends } =
+        await import('../domains/chat/deferred-sends.ts');
+      const result = await recoverStuckDeferredSends(deps.sql);
+      if (result.repolled > 0 || result.cleared > 0) {
+        console.log(
+          `[watchdog] deferred sends: re-polled ${result.repolled} waiting, cleared ${result.cleared} wedged claimed`,
+        );
       }
     },
     'documents.replacement_cleanup': async () => {

--- a/services/platform/backend/jobs/tasks.ts
+++ b/services/platform/backend/jobs/tasks.ts
@@ -129,6 +129,9 @@ export interface TaskPayloads {
   /** One readiness-poll step of a parked send — self-chaining until the
    * media settle and the thread idles, then claims and runs the turn. */
   'chat.deferred_send_poll': { deferredSendId: string };
+  /** Crash-recovery sweep: re-poke waiting sends whose poll chain severed and
+   * clear claimed sends wedged by a crash mid-turn. */
+  'watchdog.deferred_sends': Record<string, never>;
   /** One REST-accepted chat turn (`POST /api/v1/threads/{id}/messages`
    * answered 202) — re-gates and drives the direct turn detached. */
   'chat.api_turn': {
@@ -161,6 +164,9 @@ export interface TaskPayloads {
       size: number;
     }>;
   };
+  /** Crash-recovery sweep: fail outbound sends stranded 'queued' by a lost or
+   * expired send job so the retry/discard surface appears. */
+  'watchdog.conversation_sends': Record<string, never>;
   /** Stuck-pending TTS watchdog: identity-gated failed flip so a crashed
    * synthesis can't strand the player on a forever-pending chunk. */
   'tts.watchdog_chunk': { chunkId: string; attemptCreatedAt: number };
@@ -193,6 +199,9 @@ export interface TaskPayloads {
   'audit.integrity_check': Record<string, never>;
   /** Copy an org's blobs default-store -> BYO bucket (admin-triggered). */
   'object_storage.backfill': { runId: string; organizationId: string };
+  /** Crash-recovery sweep: fail backfill runs whose process died mid-copy, so
+   * the one-running partial index stops rejecting every future backfill. */
+  'watchdog.object_storage': Record<string, never>;
   /** Daily: approved legal-hold releases past their cooldown take effect. */
   'governance.effect_hold_releases': Record<string, never>;
   /** 2-min backstops for the task-agent lane: deadline-fail overdue runs,
@@ -363,13 +372,22 @@ export const TASK_QUEUE_OPTIONS: Record<TaskIdentifier, TaskQueueOptions> = {
   // of the same exec would replay the ring buffer twice, so no pg-boss retry.
   'automation.agent_drive': { retryLimit: 0, expireInSeconds: 43_200 },
   'chat.generate_title': { retryLimit: 0, expireInSeconds: 60 },
-  'chat.deferred_send_poll': { retryLimit: 0, expireInSeconds: 3_600 },
+  // 'short' + the per-send singletonKey (see deferred-sends.ts) collapses the
+  // poll self-chain to at most one queued hop, so the recovery sweep can
+  // blindly re-enqueue a poll for a stalled row without doubling a live chain.
+  'chat.deferred_send_poll': {
+    policy: 'short',
+    retryLimit: 0,
+    expireInSeconds: 3_600,
+  },
+  'watchdog.deferred_sends': { retryLimit: 1, expireInSeconds: 120 },
   // At-most-once LLM spend, like the other turn lanes: a crash surfaces via
   // the generation watchdog + the appended error row, never a silent rerun.
   'chat.api_turn': { retryLimit: 0, expireInSeconds: 3_600 },
   // At-most-once outbound mail: a lost job settles via retrySendMessage by a
   // human, never a silent duplicate email from pg-boss.
   'conversation.send_message': { retryLimit: 0, expireInSeconds: 600 },
+  'watchdog.conversation_sends': { retryLimit: 1, expireInSeconds: 300 },
   // Best-effort at-most-once: the bell row is the durable record; a lost or
   // failed email is never retried into a duplicate.
   'notification.email': { retryLimit: 0, expireInSeconds: 300 },
@@ -381,6 +399,7 @@ export const TASK_QUEUE_OPTIONS: Record<TaskIdentifier, TaskQueueOptions> = {
   'governance.retention_cleanup': { retryLimit: 1, expireInSeconds: 1_500 },
   'audit.integrity_check': { retryLimit: 1, expireInSeconds: 1_500 },
   'object_storage.backfill': { retryLimit: 0, expireInSeconds: 3_600 },
+  'watchdog.object_storage': { retryLimit: 1, expireInSeconds: 300 },
   'governance.effect_hold_releases': { retryLimit: 1, expireInSeconds: 300 },
   'watchdog.task_agents': { retryLimit: 1, expireInSeconds: 120 },
   'watchdog.automation_agents': { retryLimit: 1, expireInSeconds: 120 },


### PR DESCRIPTION
## The invariant

Every background job that advances a user-visible row must, on a crash or restart, **either retry to completion (idempotently) or land the row in an honest terminal/retryable state that a waker re-drives.** This PR closes the "断头路" (dead-end) class the review kept surfacing: a job registered `retryLimit: 0` with no watchdog, so if the worker dies or the handler throws once between claiming work and finishing it, the row is left non-terminal (`queued`/`claimed`/`running`/parked) that **nothing** ever re-drives — and the user is never told.

Each lane's waker is a directly-callable function (unit- and integration-testable), never a reliance on pg-boss's internal expiry-retry timing.

## Per-lane table

| Lane (job)                  | Failure on crash/restart                                                                                                                                                                | Mechanism chosen                                                                                                                                                                                                         | Waker                                          |
| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| `task.agent_steer`          | `kickFallback` omitted `organizationId`; the shim binds it into SQL → postgres.js `UNDEFINED_VALUE` → every settled-run fallback kick lost (retryLimit 0)                               | Plain bug: pass `args.organizationId` (TurnKeys carries it)                                                                                                                                                              | Immediate — the kick itself                    |
| `task.agent_turn`           | Start job lost before `setAgentRunRunning` → run `queued`, no op row, no capacity stamp → invisible to the running-state re-attach, the parked wake, and the deadline sweep for **12h** | `recoverStuckQueuedTaskAgentRuns`: CAS-rotate the exec id (single-winner) + re-enqueue `task.agent_turn`; fail immediately if the agent was deleted                                                                      | `watchdog.task_agents` (2 min)                 |
| `automation.ask_resume`     | Resume lost to a restart while the run parks on the asking exec → the `awaiting_human` exemption skips it → stranded to the **7-day** ask deadline                                      | `recoverAnsweredAskResumes`: re-enqueue `ask_resume` (idempotent — `retargetAgentCursor` is a FOR-UPDATE CAS on the asking exec; a throw self-settles)                                                                   | `watchdog.automation_agents` (2 min)           |
| `object_storage.backfill`   | Crash mid-copy → `status='running'` forever → the `object_storage_backfill_one_running` partial unique index rejects **every** future backfill (409)                                    | `recoverStuckBackfills`: fail stale runs with a reason (re-run is idempotent — copied blobs are skipped)                                                                                                                 | `watchdog.object_storage` (10 min, **new**)    |
| `chat.deferred_send_poll`   | Poll self-chain severs → send `waiting` forever; crash after the claim → `claimed` wedge (uncancellable tray chip)                                                                      | `singletonKey` + `short` policy dedups the chain, so a blind re-poll only revives dead chains; `recoverStuckDeferredSends` re-polls waiting rows and clears wedged claimed rows; the claim now stamps `waiting_since_ms` | `watchdog.deferred_sends` (2 min, **new**)     |
| `conversation.send_message` | Worker killed mid-send or job expired past 600s → reply `queued` forever, retry/discard UI hidden (needs `failed`)                                                                      | Migration `0065` adds `status_changed_at_ms` + a partial index; `recoverStuckConversationSends` flips stale queued rows to `failed` with a reason                                                                        | `watchdog.conversation_sends` (5 min, **new**) |

## Per-finding: fix · test · verification

**1 — Outbound conversation reply stuck `queued` forever (send.ts:840 / tasks.ts:372).** VERIFIED. The handler settles `failed` on its own throw, so the dead-end is specifically a _lost/expired job_ leaving the row `queued` with no waker; a retry also re-queues without touching `created_at_ms`, so no existing column dates the current queued state → migration `0065` adds `status_changed_at_ms` (stamped at insert/retry/sent/failed) + a partial index; the sweep flips stale queued → `failed` and emits a hint so the existing retry surface appears. Test: colocated unit locks the failed-flip + hint; integration probe seeds a stale queued send, sweeps it, and proves `retrySendMessage` re-opens it (fresh queued spared).

**2 — Deferred-send chain severs / claimed wedge (deferred-sends.ts:370 & :408).** VERIFIED. `singletonKey`+`short` collapses the self-chain to one queued hop; the sweep re-polls waiting rows (deduped against a live chain) and clears wedged `claimed` rows (at-most-once: the turn is never re-run — the chat-generation watchdog owns the composer). Test: colocated unit asserts the re-poll carries the per-send `singletonKey`; integration probe seeds a severed waiting + a wedged claimed (fresh of each spared).

**3 — Answered-ask resume lost on restart (automations/reattach.ts:128).** VERIFIED, scope narrowed on read: the resume handler _self-settles_ the run on a throw (its catch), so only a worker death before the cursor retarget is a true dead-end. Because `retargetAgentCursor` is a FOR-UPDATE CAS, re-enqueuing `ask_resume` is idempotent (a completed resume no-ops) — so the waker re-enqueues rather than changing `retryLimit` (preserving at-most-once LLM spend). Test: colocated unit locks the re-enqueue payload; integration probe seeds an answered ask still parked on the asking exec and spares moved/pending/fresh.

**4 — Task run stranded `queued` up to 12h (tasks/reattach.ts:66).** VERIFIED. New sweep for `queued` + `waiting_for_capacity_at_ms IS NULL` + stale, past no deadline; CAS-rotates the exec (so a lost-but-slow start orphans itself via the exec-fenced `setAgentRunRunning`) and re-enqueues, or fails a run whose agent was deleted. Test: colocated unit (rotate + claim-lost branches); integration probe covers requeue, agent-gone fail, and fresh/parked untouched.

**5 — Crashed backfill blocks all future backfills (object_storage/service.ts:356).** VERIFIED. The handler settles `failed` on its own throw, so the dead-end is a _process death_ leaving `running` forever; the sweep fails stale runs (`updated_at_ms` stamped per ~100-blob batch). Test: colocated unit locks the failed-flip + reason; integration probe proves a re-run is unblocked after recovery and a fresh run is left running.

**6 — Steer-miss fallback always throws (core/tasks/agent_run_host.ts:1660).** VERIFIED. One-line fix; the `internal.*` ref is a loose `FunctionRef` so the extra arg type-checks. Test: colocated unit drives `steerTaskAgentTurnImpl` over a settled run and asserts the fallback payload carries `organizationId` (**red on base**: `expected undefined to be 'org_steer_fallback'`); integration probe drives the real shim over a genuinely settled run — `threw="" mentionRuns=1`.

**Refuted:** none — all six are genuine dead-ends confirmed in code (charitable read). **Excluded per brief:** the transcription-status watchdog (fixed on a sibling branch) and the realtime-outbox unbounded-growth issue (a different class).

## Tests added

- 6 colocated vitest files (11 tests, `server` project, no DB): `agent_run_host.steer_fallback.test.ts`, `reattach.queued.test.ts`, `reattach.ask.test.ts`, `service.backfill-watchdog.test.ts`, `deferred-sends.watchdog.test.ts`, `send.watchdog.test.ts`.
- 6 real-Postgres crash-recovery probes in `integration-check.ts` (`checkSteerFallbackRecovery`, `checkQueuedRunRecovery`, `checkAnsweredAskRecovery`, `checkBackfillRecovery`, `checkDeferredSendRecovery`, `checkStuckSendRecovery`) — each seeds the crash state (non-terminal row / lost job) and asserts the waker re-drives it or lands an honest failed state.

## Gates observed

- `bunx tsc --noEmit` → **exit 0**.
- `bunx oxlint --type-aware` → **exit 0**; opengrep (pre-commit SAST) → **0 findings** on every commit.
- Colocated vitest (`--project server`): **11/11 pass** on branch; **11/11 FAIL** with the six source files reverted to base (each fix is load-bearing).
- `backend:integration` on throwaway `tale-db` + MinIO (`minioadmin`): **BASE (main-tip) 279/279**, **BRANCH 285/285**. The +6 are this PR's probes — all green on branch, absent on base. (A transient object-store-boot fail was confirmed to be MinIO-container state carryover, not code; clean containers → 285/285.)

## Cross-class discovery (not in scope here)

`core/automations/stepper.ts:986` ("Crash between agent-node kick and cursor persist double-spends a turn") is a **double-spend**, not a strand — the automation-agent watchdog scans only `status='waiting'`, so a crash between the kick and the cursor persist can re-enter `stepAgentNode` and spend a _second_ turn. It's the same crash window as this class but the opposite failure mode (over-run, not dead-end); flagging for a follow-up.

Draft — do not merge.
