### PR TITLE
fix(sandbox): safe cleanup sweep, kill-safe AGENTS.md, tini reaper

### DIFF
--- a/configs/platform/system/harnesses/openclaw/harness.yml
+++ b/configs/platform/system/harnesses/openclaw/harness.yml
@@ -6,8 +6,10 @@
 # The wrapper stages the config (OPENCLAW_CONFIG_PATH), the prompt
 # (--message-file) and the instructions (workspace AGENTS.md — OpenClaw
 # appends workspace bootstrap files to its system prompt every turn WITHOUT
-# replacing its core prompt; the wrapper backs up any pre-existing AGENTS.md
-# and restores it after). The resume handle is passed as OpenClaw's
+# replacing its core prompt; the wrapper parks any pre-existing AGENTS.md
+# outside the workspace by an atomic rename and puts it back on every exit
+# path — clean end, cancel signal, or the next start after a hard kill). The
+# resume handle is passed as OpenClaw's
 # --session-id explicit-session selector (key agent:main:explicit:<id>,
 # persisted in the state-dir session store). The pinned CLI has no per-run
 # tool-iteration cap (its `runRetries` config bounds retry loops, not

--- a/services/platform/lib/harnesses/parsers/openclaw-jsonl.test.ts
+++ b/services/platform/lib/harnesses/parsers/openclaw-jsonl.test.ts
@@ -76,6 +76,21 @@ describe('openclaw-jsonl parser', () => {
     });
   });
 
+  it('maps a cancelled run_end to the cancelled status with no error event', () => {
+    // The wrapper unwinding on runnerd's cancel signal (a user Stop).
+    const text = `${[
+      { type: 'run_start', session_id: 'oc-2' },
+      { type: 'run_end', status: 'cancelled', signal: 15, session_id: 'oc-2' },
+    ]
+      .map((l) => JSON.stringify(l))
+      .join('\n')}\n`;
+    const events = collectEvents(createParser('openclaw'), text);
+    expect(events).toEqual([
+      { type: 'turn-started', harness: 'openclaw', sessionId: 'oc-2' },
+      { type: 'turn-ended', status: 'cancelled', sessionId: 'oc-2' },
+    ]);
+  });
+
   it('suppresses zero-token usage and passes unknown events through as raw', () => {
     const unknown = { type: 'novel_openclaw_event', v: 9 };
     const text = `${[{ type: 'usage', input: 0, output: 0 }, unknown]

--- a/services/platform/lib/harnesses/parsers/openclaw-jsonl.ts
+++ b/services/platform/lib/harnesses/parsers/openclaw-jsonl.ts
@@ -11,8 +11,10 @@
 //   { schema_version, type: "run_start", session_id, model? }
 //   { type: "assistant_message", text }
 //   { type: "usage", input, output, cache_read?, cache_write?, model? }
-//   { type: "run_end", status: "ok"|"error", session_id?, final_text?,
-//     error?, duration_ms? }
+//   { type: "run_end", status: "ok"|"error"|"cancelled", session_id?,
+//     final_text?, error?, duration_ms?, signal? }
+//   ("cancelled" is the wrapper unwinding on runnerd's cancel signal — a user
+//   Stop, not a failure; `signal` carries the signal number.)
 
 import { asNumber, asString, LineReassembler, parseJsonLine } from '../jsonl';
 import type {
@@ -26,6 +28,7 @@ function mapRunStatus(status: string | undefined): HarnessTurnStatus {
   if (status === 'ok' || status === 'success' || status === 'completed') {
     return 'completed';
   }
+  if (status === 'cancelled') return 'cancelled';
   return status ? 'error' : 'completed';
 }
 

--- a/services/sandbox-runtime/README.md
+++ b/services/sandbox-runtime/README.md
@@ -19,7 +19,9 @@ bun run --filter @tale/sandbox-runtime docker:build
 
 `docker-entrypoint.sh` (PID 1, container-level envelope) `exec`s `entrypoint.sh`
 with args preserved, which dispatches on mode and `exec`s the executor so
-signals (SIGTERM) reach it directly. `install-playwright-browsers.sh` bakes the
+signals (SIGTERM) reach it directly. The `daemon` (session) dispatch `exec`s
+`tini -g` with runnerd as its child on every path, so PID 1 reaps the orphans a
+long-lived session accumulates. `install-playwright-browsers.sh` bakes the
 browser bundles at build time. See the script headers for the split rationale.
 
 ```bash

--- a/services/sandbox-runtime/daemon/src/main.ts
+++ b/services/sandbox-runtime/daemon/src/main.ts
@@ -1,7 +1,9 @@
 // runnerd — the in-container control daemon for persistent sandbox sessions.
 //
-// PID 1 of a session container (entrypoint dispatch `daemon`). Listens on
-// :8200 inside tale-sandbox-net; the spawner is its only client and proxies
+// The control process of a session container (entrypoint dispatch `daemon`),
+// run under the image's tini init so the orphans that cancelled exec trees and
+// browser recycles leave behind are reaped rather than left as zombies. Listens
+// on :8200 inside tale-sandbox-net; the spawner is its only client and proxies
 // in-session operations here over HTTP. Auth is the per-session token in
 // x-tale-runnerd-token (derived spawner-side as HMAC(SANDBOX_TOKEN,
 // "runnerd-v1:"+sessionId); empty disables the check in unsigned dev mode).

--- a/services/sandbox-runtime/daemon/src/tale-openclaw-run.test.ts
+++ b/services/sandbox-runtime/daemon/src/tale-openclaw-run.test.ts
@@ -1,0 +1,224 @@
+// tale-openclaw-run AGENTS.md safety. The system prompt rides the workspace
+// AGENTS.md bootstrap file (the only channel the pinned CLI reads it from), so
+// the wrapper must hand the user's own AGENTS.md back on EVERY exit path: a
+// clean run, runnerd's cancel (a process-group SIGTERM, then SIGKILL after a
+// 5s grace) and a hard SIGKILL (grace expired, container teardown). These
+// cases drive the real wrapper against a fake `openclaw` on PATH and signal
+// its process group exactly as runnerd's exec-manager does.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawn, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const WRAPPER = resolve(import.meta.dir, '../../tale-openclaw-run');
+const hasPython = spawnSync('python3', ['-V']).status === 0;
+const pyTest = hasPython ? test : test.skip;
+
+const ORIGINAL = '# My repo rules\n\nKeep it tidy.\n';
+const PROMPT_V1 = 'TALE SYSTEM PROMPT v1';
+const PROMPT_V2 = 'TALE SYSTEM PROMPT v2';
+
+// Fake CLI: record the AGENTS.md OpenClaw would load, then either answer with
+// a final `--json` envelope (`ok`) or hang like a long agent turn (`hang`).
+const FAKE_OPENCLAW = `#!/bin/sh
+if [ -f "$FAKE_WORKSPACE/AGENTS.md" ]; then
+  cat "$FAKE_WORKSPACE/AGENTS.md" > "$FAKE_SEEN"
+else
+  printf '<absent>' > "$FAKE_SEEN"
+fi
+if [ "$FAKE_MODE" = "hang" ]; then sleep 60; exit 0; fi
+printf '%s' '{"payloads":[{"text":"hi"}],"meta":{"durationMs":1,"agentMeta":{"sessionId":"s","model":"m","usage":{"input":1,"output":1}}}}'
+`;
+
+let root: string;
+let workspace: string;
+let seenPath: string;
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'tale-openclaw-')));
+  workspace = join(root, 'workspace');
+  seenPath = join(root, 'seen.txt');
+  for (const d of ['workspace', 'bin', 'home', 'state', 'tmp']) {
+    mkdirSync(join(root, d), { recursive: true });
+  }
+  const fake = join(root, 'bin', 'openclaw');
+  writeFileSync(fake, FAKE_OPENCLAW);
+  chmodSync(fake, 0o755);
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+interface RunResult {
+  code: number | null;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+}
+
+function startWrapper(opts: { mode: 'ok' | 'hang'; systemPrompt?: string }) {
+  const payload: Record<string, unknown> = {
+    prompt: 'hello',
+    config: { agents: { defaults: { workspace } } },
+  };
+  if (opts.systemPrompt !== undefined)
+    payload.system_prompt = opts.systemPrompt;
+  rmSync(seenPath, { force: true });
+  const child = spawn('python3', [WRAPPER, '--workdir', workspace], {
+    // Own process group — exactly how runnerd spawns an exec, so a group
+    // signal reaches the wrapper AND the CLI it launched.
+    detached: true,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      PATH: `${join(root, 'bin')}:${process.env.PATH ?? ''}`,
+      HOME: join(root, 'home'),
+      TMPDIR: join(root, 'tmp'),
+      OPENCLAW_STATE_DIR: join(root, 'state'),
+      FAKE_WORKSPACE: workspace,
+      FAKE_SEEN: seenPath,
+      FAKE_MODE: opts.mode,
+    },
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (d: Buffer) => {
+    stdout += d.toString();
+  });
+  child.stderr.on('data', (d: Buffer) => {
+    stderr += d.toString();
+  });
+  const done = new Promise<RunResult>((r) => {
+    child.on('close', (code, signal) => r({ code, signal, stdout, stderr }));
+  });
+  child.stdin.end(JSON.stringify(payload));
+  const killGroup = (sig: NodeJS.Signals) => {
+    if (child.pid !== undefined) process.kill(-child.pid, sig);
+  };
+  return { done, killGroup };
+}
+
+/** Wait until the fake CLI has started (it records AGENTS.md first thing). */
+async function waitForSeen(): Promise<string> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (existsSync(seenPath)) return readFileSync(seenPath, 'utf8');
+    await Bun.sleep(20);
+  }
+  throw new Error('fake openclaw never started');
+}
+
+const agentsMd = (): string | null => {
+  const p = join(workspace, 'AGENTS.md');
+  return existsSync(p) ? readFileSync(p, 'utf8') : null;
+};
+
+/** Every regular file under `dir` whose content is exactly `content`. */
+function filesWithContent(dir: string, content: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...filesWithContent(p, content));
+    else if (e.isFile() && readFileSync(p, 'utf8') === content) out.push(p);
+  }
+  return out;
+}
+
+describe('tale-openclaw-run AGENTS.md safety', () => {
+  pyTest(
+    'clean run: the CLI sees the system prompt, the user file comes back',
+    async () => {
+      writeFileSync(join(workspace, 'AGENTS.md'), ORIGINAL);
+
+      const res = await startWrapper({ mode: 'ok', systemPrompt: PROMPT_V1 })
+        .done;
+
+      expect(res.code).toBe(0);
+      expect(readFileSync(seenPath, 'utf8')).toBe(PROMPT_V1);
+      expect(agentsMd()).toBe(ORIGINAL);
+      expect(res.stdout).toContain('"type": "run_end"');
+      // No parked copy lingers after a clean turn.
+      expect(filesWithContent(root, ORIGINAL)).toEqual([
+        join(workspace, 'AGENTS.md'),
+      ]);
+    },
+  );
+
+  pyTest('without a system prompt the user file is never touched', async () => {
+    writeFileSync(join(workspace, 'AGENTS.md'), ORIGINAL);
+
+    const res = await startWrapper({ mode: 'ok' }).done;
+
+    expect(res.code).toBe(0);
+    expect(readFileSync(seenPath, 'utf8')).toBe(ORIGINAL);
+    expect(agentsMd()).toBe(ORIGINAL);
+  });
+
+  pyTest(
+    'cancel (process-group SIGTERM) mid-turn restores the user file before exit',
+    async () => {
+      writeFileSync(join(workspace, 'AGENTS.md'), ORIGINAL);
+      const run = startWrapper({ mode: 'hang', systemPrompt: PROMPT_V1 });
+      expect(await waitForSeen()).toBe(PROMPT_V1);
+
+      run.killGroup('SIGTERM');
+      const res = await run.done;
+
+      expect(res.code).not.toBe(0);
+      expect(agentsMd()).toBe(ORIGINAL);
+      // A cancel is reported as such — a user Stop is not a failure.
+      expect(res.stdout).toContain('"type": "run_end", "status": "cancelled"');
+    },
+  );
+
+  pyTest(
+    'SIGKILL mid-turn never loses the user file; the next turn restores it',
+    async () => {
+      writeFileSync(join(workspace, 'AGENTS.md'), ORIGINAL);
+      const run = startWrapper({ mode: 'hang', systemPrompt: PROMPT_V1 });
+      expect(await waitForSeen()).toBe(PROMPT_V1);
+
+      run.killGroup('SIGKILL');
+      await run.done;
+
+      // The original survives the kill on disk …
+      expect(filesWithContent(root, ORIGINAL).length).toBeGreaterThan(0);
+      // … and the next wrapper start puts it back BEFORE staging its own prompt,
+      // so the new prompt still reaches the CLI and the user file wins at the end.
+      const res = await startWrapper({ mode: 'ok', systemPrompt: PROMPT_V2 })
+        .done;
+      expect(res.code).toBe(0);
+      expect(readFileSync(seenPath, 'utf8')).toBe(PROMPT_V2);
+      expect(agentsMd()).toBe(ORIGINAL);
+    },
+  );
+
+  pyTest(
+    'SIGKILL with no user file leaves no stale prompt after the next turn',
+    async () => {
+      const run = startWrapper({ mode: 'hang', systemPrompt: PROMPT_V1 });
+      expect(await waitForSeen()).toBe(PROMPT_V1);
+
+      run.killGroup('SIGKILL');
+      await run.done;
+
+      const res = await startWrapper({ mode: 'ok', systemPrompt: PROMPT_V2 })
+        .done;
+      expect(res.code).toBe(0);
+      expect(readFileSync(seenPath, 'utf8')).toBe(PROMPT_V2);
+      expect(agentsMd()).toBeNull();
+    },
+  );
+});

--- a/services/sandbox-runtime/entrypoint.sh
+++ b/services/sandbox-runtime/entrypoint.sh
@@ -724,8 +724,14 @@ fi
 # Session daemon dispatch (sessions plan). The spawner launches a long-lived
 # session container with a single positional arg `daemon` (see
 # session/docker-session-args.ts); everything else is the one-shot
-# /v1/execute path below, untouched. runnerd is PID 1 of a session container,
-# so we `exec` it (SIGTERM from container-stop must reach it directly).
+# /v1/execute path below, untouched. PID 1 of a session container is tini,
+# exec'd here with runnerd as its only child — on EVERY path (plain,
+# transparent-egress, DinD). A long-lived container needs a real init: every
+# cancelled/timed-out exec tree and every SIGKILLed Chromium recycle leaves
+# orphans that reparent to PID 1, and node never wait()s children it did not
+# spawn, so as PID 1 it would let them pile up as zombies against pids-limit
+# until fork() fails. `tini -g` forwards container-stop SIGTERM to runnerd's
+# process group, so graceful shutdown is unchanged.
 # ---------------------------------------------------------------------------
 if [ "$1" = "daemon" ]; then
   # Both DinD and transparent egress boot the container as root (DinD to run the
@@ -815,11 +821,11 @@ if [ "$1" = "daemon" ]; then
     start_browser_stack
   fi
 
-  # DinD: bring up the inner dockerd as root, then hand off. tini becomes PID 1
-  # to reap the many short-lived shims native docker spawns (teardown is a
-  # SIGKILL to PID 1, so runnerd no longer needs to be PID 1 itself); the
-  # already-backgrounded dockerd reparents to tini. setpriv drops to the agent
-  # user so Claude Code's bypassPermissions (refused as root) still works.
+  # DinD: bring up the inner dockerd as root, then hand off under tini like
+  # every session path (here it also reaps the many short-lived shims native
+  # docker spawns); the already-backgrounded dockerd reparents to tini. setpriv
+  # drops to the agent user so Claude Code's bypassPermissions (refused as
+  # root) still works.
   if [ "${TALE_DIND:-}" = "1" ]; then
     start_inner_dockerd
     # Also redirect the session's OWN processes (not just nested containers) when
@@ -833,16 +839,17 @@ if [ "$1" = "daemon" ]; then
       node /usr/local/lib/tale/runnerd.mjs
   fi
 
-  # Non-DinD path. With transparent egress the container booted as root to install
-  # the OUTPUT REDIRECT, so drop to the profile uid for runnerd (setpriv execs it
-  # in place → node stays PID 1, so container-stop SIGTERM still reaches it).
-  # Without transparent egress, runnerd is already PID 1 at the container's
-  # --user — exactly as before.
+  # Non-DinD paths — same reaper. With transparent egress the container booted
+  # as root to install the OUTPUT REDIRECT, so setpriv drops to the profile uid
+  # for runnerd (tini itself stays root, exactly as on the DinD path: it only
+  # reaps and forwards signals). Without transparent egress the container is
+  # already at its --user, so tini runs unprivileged too.
   if [ "${TALE_TRANSPARENT_EGRESS:-}" = "1" ]; then
-    exec setpriv --reuid "${TALE_DROP_UID:-10001}" --regid "${TALE_DROP_GID:-10001}" --init-groups -- \
+    exec tini -g -- \
+      setpriv --reuid "${TALE_DROP_UID:-10001}" --regid "${TALE_DROP_GID:-10001}" --init-groups -- \
       node /usr/local/lib/tale/runnerd.mjs
   fi
-  exec node /usr/local/lib/tale/runnerd.mjs
+  exec tini -g -- node /usr/local/lib/tale/runnerd.mjs
 fi
 
 LANG_NAME="$1"

--- a/services/sandbox-runtime/tale-openclaw-run
+++ b/services/sandbox-runtime/tale-openclaw-run
@@ -21,8 +21,10 @@ The wrapper exists because (verified openclaw 2026.6.11):
     process lists leak argv, and a leading-dash prompt would parse as a flag);
     and the system-prompt APPEND — staged as the workspace AGENTS.md bootstrap
     file, which OpenClaw appends to its system prompt every turn without
-    replacing its core prompt (any pre-existing AGENTS.md is backed up and
-    restored afterwards).
+    replacing its core prompt. That file is the USER's (a cloned repo's own
+    instructions), so it is parked by an atomic rename outside the workspace
+    for the turn and put back on EVERY exit path — clean end, cancel signal,
+    and (via the next start) a hard kill. See AgentsMdSwap.
   - session continuity is an explicit-id contract: `--session-id <handle>`
     maps to the persisted session key `agent:main:explicit:<handle>` in the
     OPENCLAW_STATE_DIR session store, so the SAME handle resumes the SAME
@@ -40,10 +42,13 @@ resolves that env template natively.
 from __future__ import annotations
 
 import argparse
+import errno
+import hashlib
 import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -52,6 +57,12 @@ from datetime import datetime, timezone
 from typing import Any
 
 ENV_TEMPLATE_RE = re.compile(r"^\$\{([A-Z][A-Z0-9_]*)\}$")
+
+# runnerd cancels an exec with a process-group SIGTERM and follows up with a
+# SIGKILL 5s later (exec-manager.ts); SIGINT/SIGHUP are the interactive
+# equivalents. Each gets the same treatment: give the user's AGENTS.md back
+# FIRST, then unwind as a cancelled run.
+CANCEL_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
 
 
 def _ts() -> str:
@@ -75,6 +86,24 @@ def fail(message: str, session_id: str | None = None, code: int = 1) -> int:
         }
     )
     return code
+
+
+def cancelled(session_id: str, signum: int) -> int:
+    """A cancel signal unwound the run: a user Stop, not a failure. The parser
+    maps `status: cancelled` to the cancelled turn status (no error event)."""
+    emit(
+        {
+            "type": "run_end",
+            "status": "cancelled",
+            "signal": signum,
+            "session_id": session_id,
+        }
+    )
+    return 128 + signum
+
+
+def warn(message: str) -> None:
+    print(f"[tale-openclaw-run] {message}", file=sys.stderr)
 
 
 def read_stdin_payload() -> dict[str, Any] | None:
@@ -113,10 +142,7 @@ def resolve_mcp_env_templates(config: dict[str, Any]) -> None:
                 continue
             resolved = os.environ.get(match.group(1))
             if resolved is None:
-                print(
-                    f"[tale-openclaw-run] mcp env {key}: ${{{match.group(1)}}} is unset",
-                    file=sys.stderr,
-                )
+                warn(f"mcp env {key}: ${{{match.group(1)}}} is unset")
                 continue
             env[key] = resolved
 
@@ -125,6 +151,182 @@ def config_primary_model(config: dict[str, Any]) -> str | None:
     model = config.get("agents", {}).get("defaults", {}).get("model", {})
     primary = model.get("primary") if isinstance(model, dict) else None
     return primary if isinstance(primary, str) and primary else None
+
+
+class Cancelled(BaseException):
+    """Raised in the main thread when the exec's process group is signalled.
+
+    A BaseException (like KeyboardInterrupt) so the generic `except Exception`
+    in main() cannot swallow it: a cancel must unwind through every `finally`.
+    """
+
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = signum
+
+
+def _sha256_file(path: str) -> str | None:
+    try:
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def _move(src: str, dst: str) -> None:
+    """Atomic same-filesystem rename; copy-then-unlink only across devices.
+
+    The default deployment keeps the workspace and the OpenClaw state dir on
+    the one /agent volume, so this is a single rename(2) — no signal can leave
+    a half-written file. Across devices (a non-default `workspace` mount) the
+    copy lands under a temp name and is renamed into place before the source
+    goes, so a kill at any point leaves at least one complete copy.
+    """
+    try:
+        os.replace(src, dst)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise
+        tmp = f"{dst}.tmp-{os.getpid()}"
+        shutil.copy2(src, tmp)
+        os.replace(tmp, dst)
+        os.unlink(src)
+
+
+class AgentsMdSwap:
+    """Kill-safe staging of the system prompt as <workspace>/AGENTS.md.
+
+    OpenClaw reads the append-to-system-prompt file from exactly one place —
+    the workspace AGENTS.md — so for the turn the prompt has to sit where the
+    user's own AGENTS.md lives. Overwriting it with a copy stashed in a temp
+    dir and restoring in a `finally` loses the user's file on any exit that
+    skips the `finally`: runnerd's cancel (process-group SIGTERM, SIGKILL 5s
+    later — Python's default SIGTERM disposition runs no `finally`), the
+    orphan deadline, a container teardown. So instead:
+
+      * the original is PARKED by an atomic rename into a slot OUTSIDE the
+        workspace, under the persistent OpenClaw state dir and keyed by the
+        workspace path — never copied over, never left where the agent or a
+        `git clean` could take it, never moved by anything but a single
+        rename;
+      * a marker in the slot records whether an original existed and the hash
+        of the staged prompt, so a later wrapper start can put the original
+        back — or remove a stale staged prompt it can PROVE it wrote;
+      * restore runs in the `finally`, in the cancel-signal handler, and as
+        the backstop at the start of every turn (`recover`), prompt or not.
+
+    Every step is idempotent, so a signal landing mid-stage or mid-restore
+    leaves nothing a second restore can't finish.
+    """
+
+    PARKED = "AGENTS.md.orig"
+    MARKER = "state.json"
+
+    def __init__(self, workspace: str) -> None:
+        self.workspace = os.path.abspath(workspace)
+        self.agents_md = os.path.join(self.workspace, "AGENTS.md")
+        home = os.environ.get("HOME") or os.path.expanduser("~")
+        state_root = os.environ.get("OPENCLAW_STATE_DIR") or os.path.join(
+            home, ".openclaw"
+        )
+        key = hashlib.sha256(self.workspace.encode("utf-8")).hexdigest()[:16]
+        self.slot = os.path.join(state_root, "tale-agents-md", key)
+        self.parked = os.path.join(self.slot, self.PARKED)
+        self.marker = os.path.join(self.slot, self.MARKER)
+
+    # -- marker ------------------------------------------------------------
+
+    def _read_marker(self) -> dict[str, Any] | None:
+        try:
+            with open(self.marker, encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _write_marker(self, had_original: bool, staged_sha256: str) -> None:
+        tmp = f"{self.marker}.tmp-{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "workspace": self.workspace,
+                    "had_original": had_original,
+                    "staged_sha256": staged_sha256,
+                    "pid": os.getpid(),
+                    "started_at": _ts(),
+                },
+                f,
+            )
+        os.replace(tmp, self.marker)
+
+    def _clear(self) -> None:
+        for path in (self.marker, self.parked):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                warn(f"AGENTS.md swap: could not remove {path}: {exc}")
+        try:
+            os.rmdir(self.slot)
+        except OSError:
+            # Not empty (a temp from a dying step) or already gone — fine.
+            pass
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def recover(self) -> None:
+        """Undo a previous turn's swap that never got to restore (hard kill)."""
+        if os.path.lexists(self.parked) or self._read_marker() is not None:
+            warn("AGENTS.md swap: leftover from an interrupted turn — restoring")
+            self.restore()
+
+    def stage(self, system_prompt: str) -> None:
+        if os.path.lexists(self.parked):
+            # recover() could not put a previous turn's original back (the
+            # restore itself failed). Never park over it — that would replace
+            # the user's file with a stale prompt for good. Fail the turn loudly.
+            raise RuntimeError(
+                f"a parked AGENTS.md is still at {self.parked} and could not be "
+                "restored; refusing to stage a system prompt over it"
+            )
+        os.makedirs(self.slot, exist_ok=True)
+        os.makedirs(self.workspace, exist_ok=True)
+        data = system_prompt.encode("utf-8")
+        had_original = os.path.lexists(self.agents_md)
+        # Marker first: from here on a restore knows what to undo.
+        self._write_marker(had_original, hashlib.sha256(data).hexdigest())
+        if had_original:
+            _move(self.agents_md, self.parked)
+        staged = os.path.join(self.slot, f"AGENTS.md.staged-{os.getpid()}")
+        with open(staged, "wb") as f:
+            f.write(data)
+        _move(staged, self.agents_md)
+
+    def restore(self) -> None:
+        """Put the user's AGENTS.md back (or remove ours). Idempotent."""
+        marker = self._read_marker()
+        try:
+            if os.path.lexists(self.parked):
+                _move(self.parked, self.agents_md)
+            elif marker is not None and marker.get("had_original") is False:
+                # No original to bring back: remove the staged prompt — but only
+                # a file that still hashes to what we wrote. Anything else the
+                # agent (or the user) put there stays.
+                if _sha256_file(self.agents_md) == marker.get("staged_sha256"):
+                    os.unlink(self.agents_md)
+                elif os.path.lexists(self.agents_md):
+                    warn(
+                        "AGENTS.md swap: workspace AGENTS.md changed during the "
+                        "turn; leaving it in place"
+                    )
+        except FileNotFoundError:
+            # Raced with a concurrent restore (signal handler vs finally).
+            pass
+        except OSError as exc:
+            warn(f"AGENTS.md restore failed: {exc}")
+            return
+        self._clear()
 
 
 def emit_envelope_events(
@@ -191,6 +393,25 @@ def emit_envelope_events(
     return exit_code if error_message else 0
 
 
+def install_cancel_handlers(swap: AgentsMdSwap) -> None:
+    """Turn a cancel signal into a restore + `Cancelled` unwind.
+
+    Handlers run in the main thread, interrupting the blocking child wait in
+    `subprocess.run` (which then kills the CLI and re-raises). The restore
+    happens right here, before anything else: on runnerd's cancel path a
+    SIGKILL lands ~5s later and nothing runs after that.
+    """
+
+    def on_signal(signum: int, _frame: Any) -> None:
+        for sig in CANCEL_SIGNALS:
+            signal.signal(sig, signal.SIG_IGN)
+        swap.restore()
+        raise Cancelled(signum)
+
+    for sig in CANCEL_SIGNALS:
+        signal.signal(sig, on_signal)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run OpenClaw for Tale sandbox")
     parser.add_argument("--workdir", default="/user/workspace")
@@ -226,10 +447,13 @@ def main() -> int:
         workspace = args.workdir
 
     stage_dir = None
-    agents_md_path = os.path.join(workspace, "AGENTS.md")
-    agents_md_backup: str | None = None
-    agents_md_written = False
+    swap = AgentsMdSwap(workspace)
+    install_cancel_handlers(swap)
     try:
+        # Backstop for a previous turn that died mid-swap: give the user's
+        # AGENTS.md back before this turn touches anything — with or without a
+        # system prompt of its own.
+        swap.recover()
         resolve_mcp_env_templates(config)
 
         stage_dir = tempfile.mkdtemp(prefix="tale-openclaw-")
@@ -241,16 +465,7 @@ def main() -> int:
             f.write(prompt)
 
         if system_prompt is not None:
-            # System-prompt append rides the workspace AGENTS.md bootstrap
-            # file. Back up whatever is there (a repo's own AGENTS.md must
-            # survive the turn) and restore it in the finally below.
-            os.makedirs(workspace, exist_ok=True)
-            if os.path.exists(agents_md_path):
-                agents_md_backup = os.path.join(stage_dir, "AGENTS.md.orig")
-                shutil.copy2(agents_md_path, agents_md_backup)
-            with open(agents_md_path, "w", encoding="utf-8") as f:
-                f.write(system_prompt)
-            agents_md_written = True
+            swap.stage(system_prompt)
 
         env = dict(os.environ)
         env["OPENCLAW_CONFIG_PATH"] = config_path
@@ -296,25 +511,22 @@ def main() -> int:
                 proc.returncode or 1,
             )
         return emit_envelope_events(envelope, session_id, proc.returncode)
+    except Cancelled as exc:
+        return cancelled(session_id, exc.signum)
     except FileNotFoundError as exc:
         return fail(f"openclaw not installed or file missing: {exc}", session_id)
     except Exception as exc:  # noqa: BLE001 — surface anything as a run error
         return fail(f"wrapper failure: {exc}", session_id)
     finally:
-        if agents_md_written:
-            try:
-                if agents_md_backup is not None:
-                    shutil.copy2(agents_md_backup, agents_md_path)
-                else:
-                    os.unlink(agents_md_path)
-            except OSError as exc:
-                print(
-                    f"[tale-openclaw-run] AGENTS.md restore failed: {exc}",
-                    file=sys.stderr,
-                )
+        swap.restore()
         if stage_dir is not None:
             shutil.rmtree(stage_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except Cancelled as exc:
+        # A cancel that lands inside main()'s own `finally` (restore already
+        # done or in progress) still exits as a cancelled run, not a traceback.
+        raise SystemExit(128 + exc.signum)

--- a/services/sandbox/docs/sessions.md
+++ b/services/sandbox/docs/sessions.md
@@ -20,10 +20,14 @@ thread / workflow / render budgets); the host ceiling is `SANDBOX_MAX_SESSIONS`.
 
 ## Architecture
 
-A session is a long-lived container (Docker) / Pod (K8s) whose PID 1 is
-**runnerd**, a small control daemon (`services/sandbox-runtime/daemon`, bundled
-to a single `runnerd.mjs` and run by the image's Node 24). The spawner proxies
-every in-session operation to runnerd over plain HTTP on `:8200`:
+A session is a long-lived container (Docker) / Pod (K8s) running **runnerd**, a
+small control daemon (`services/sandbox-runtime/daemon`, bundled to a single
+`runnerd.mjs` and run by the image's Node 24), under the image's `tini` init as
+PID 1 on every dispatch path — a long-lived container needs a real reaper, since
+every cancelled exec tree and browser recycle leaves orphans that node (which
+never `wait()`s children it did not spawn) would otherwise accumulate as zombies
+against `pids-limit`. The spawner proxies every in-session operation to runnerd
+over plain HTTP on `:8200`:
 
 - Docker: container DNS name `tale-sbx-ses-<id>` on `tale-sandbox-net`.
 - K8s: the Pod IP (read from `status.podIP`).

--- a/services/sandbox/src/backend/docker/docker-session-backend.ts
+++ b/services/sandbox/src/backend/docker/docker-session-backend.ts
@@ -21,6 +21,7 @@ import {
 import { RUNNERD_PORT } from '../../session/runnerd-protocol.ts';
 import {
   deriveRunnerdToken,
+  isSessionWorkspaceDirName,
   sessionContainerName,
   sessionWorkspaceDirName,
 } from '../../session/session-naming.ts';
@@ -124,7 +125,7 @@ export class DockerSessionBackend implements SessionBackend {
       return flat;
     }
     for (const e of entries) {
-      if (!e.isDirectory() || e.name.startsWith('ses-')) continue;
+      if (!e.isDirectory() || isSessionWorkspaceDirName(e.name)) continue;
       const legacy = join(this.cfg.hostSessionRoot, e.name, dirName);
       if (await this.workspaceDirExists(legacy)) {
         console.warn(

--- a/services/sandbox/src/backend/kubernetes/k8s-session-pod-spec.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-session-pod-spec.ts
@@ -1,7 +1,7 @@
 // Canonical session-Pod builder — the K8s analogue of docker-session-args.ts.
 //
-// One LONG-LIVED Pod per session running runnerd as PID 1 (the image's
-// `daemon` entrypoint dispatch). Unlike the one-shot pod-per-exec shape there
+// One LONG-LIVED Pod per session running runnerd under the image's tini init
+// (the `daemon` entrypoint dispatch). Unlike the one-shot pod-per-exec shape there
 // is no stage initContainer / harvest sidecar — runnerd does staging, exec,
 // and harvest at runtime over HTTP. `restartPolicy: Always` so a runner crash
 // restarts in place against the surviving emptyDir workspace; the daemon is
@@ -252,7 +252,7 @@ export function buildSessionPod(
           name: 'runner',
           image: cfg.runtimeImage,
           imagePullPolicy: 'IfNotPresent',
-          // `daemon` entrypoint dispatch → runnerd as PID 1.
+          // `daemon` entrypoint dispatch → tini (PID 1, reaps orphans) + runnerd.
           args: ['daemon'],
           envFrom,
           env: [

--- a/services/sandbox/src/cleanup.test.ts
+++ b/services/sandbox/src/cleanup.test.ts
@@ -1,0 +1,128 @@
+// Host-dir sweep layout safety. The invariant under test: the sweep removes
+// ONLY genuinely expired legacy one-shot exec dirs and NEVER a session
+// workspace — in the flat layout (`<root>/ses-<id>`) OR the legacy
+// colour-rooted layout (`<root>/<colour>/ses-<id>`) that resolveWorkspaceDir
+// still resumes from. A deleted live/stopped workspace is user data loss; an
+// un-swept unknown dir is a small leak, so anything the sweep cannot classify
+// is left alone.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { sweepHostSessionDirs } from './cleanup.ts';
+
+const OLD = new Date('2020-01-01T00:00:00Z');
+// Everything older than "now minus one hour" counts as stale.
+const threshold = () => Date.now() - 3_600_000;
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'tale-sweep-'));
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Create a dir (with an optional marker file) under root. */
+async function dir(rel: string, withFile = true): Promise<string> {
+  const abs = join(root, rel);
+  await mkdir(abs, { recursive: true });
+  if (withFile) await writeFile(join(abs, 'data.txt'), rel);
+  return abs;
+}
+
+/** Age paths to 2020. Parents LAST: creating a child bumps the parent mtime. */
+async function age(...rels: string[]): Promise<void> {
+  for (const rel of rels) await utimes(join(root, rel), OLD, OLD);
+}
+
+const exists = (rel: string) =>
+  stat(join(root, rel)).then(
+    () => true,
+    () => false,
+  );
+
+describe('sweepHostSessionDirs', () => {
+  test('never removes a flat session workspace, however old', async () => {
+    await dir('ses-flat');
+    await age('ses-flat');
+
+    const removed = await sweepHostSessionDirs(root, threshold());
+
+    expect(removed).toBe(0);
+    expect(await exists('ses-flat/data.txt')).toBe(true);
+  });
+
+  test('never removes a legacy colour-rooted session workspace or its root', async () => {
+    await dir('blue/ses-legacy');
+    await age('blue/ses-legacy', 'blue');
+
+    const removed = await sweepHostSessionDirs(root, threshold());
+
+    expect(removed).toBe(0);
+    expect(await exists('blue/ses-legacy/data.txt')).toBe(true);
+  });
+
+  test('removes stale one-shot dirs in both layouts, keeps the sessions beside them', async () => {
+    await dir('stale-exec_1');
+    await dir('blue/ses-legacy');
+    await dir('blue/oldexec');
+    await age('stale-exec_1', 'blue/ses-legacy', 'blue/oldexec', 'blue');
+
+    const removed = await sweepHostSessionDirs(root, threshold());
+
+    expect(removed).toBe(2);
+    expect(await exists('stale-exec_1')).toBe(false);
+    expect(await exists('blue/oldexec')).toBe(false);
+    expect(await exists('blue/ses-legacy/data.txt')).toBe(true);
+  });
+
+  test('removes an empty legacy root once its last session is gone', async () => {
+    await dir('green', false);
+    await age('green');
+
+    const removed = await sweepHostSessionDirs(root, threshold());
+
+    expect(removed).toBe(1);
+    expect(await exists('green')).toBe(false);
+  });
+
+  test('keeps fresh one-shot dirs and dirs still in flight', async () => {
+    await dir('fresh-exec');
+    await dir('live-exec');
+    await age('live-exec');
+
+    const removed = await sweepHostSessionDirs(
+      root,
+      threshold(),
+      (id) => id === 'live-exec',
+    );
+
+    expect(removed).toBe(0);
+    expect(await exists('fresh-exec/data.txt')).toBe(true);
+    expect(await exists('live-exec/data.txt')).toBe(true);
+  });
+
+  test('leaves files and unclassifiable dirs alone', async () => {
+    await writeFile(join(root, '.spawner.lock'), '{}');
+    await dir('weird+name');
+    await dir('.hidden');
+    await dir('has spaces');
+    await age('weird+name', '.hidden', 'has spaces', '.spawner.lock');
+
+    const removed = await sweepHostSessionDirs(root, threshold());
+
+    expect(removed).toBe(0);
+    expect(await exists('.spawner.lock')).toBe(true);
+    expect(await exists('weird+name/data.txt')).toBe(true);
+    expect(await exists('.hidden/data.txt')).toBe(true);
+    expect(await exists('has spaces/data.txt')).toBe(true);
+  });
+
+  test('a missing root is not an error', async () => {
+    expect(await sweepHostSessionDirs(join(root, 'nope'), threshold())).toBe(0);
+  });
+});

--- a/services/sandbox/src/cleanup.ts
+++ b/services/sandbox/src/cleanup.ts
@@ -1,25 +1,29 @@
 // Two-layer cleanup, audit-cleaned per round-2 findings.
 //
 //   1. Boot sweep: docker rm any tale.sandbox=1 container left over from a
-//      previous spawner process, AND host-dir sweep over old session dirs
-//      whose mtime is past the watchdog cutoff. The dead "volume sweep"
-//      that the original code shipped is gone — workspaces are host bind
-//      mounts (no volume), and the cache volumes carry a different label
-//      and MUST NOT be reaped.
+//      previous spawner process, AND host-dir sweep over stale legacy
+//      one-shot exec dirs whose mtime is past the watchdog cutoff (session
+//      workspaces, in either layout, are never touched — see
+//      sweepHostSessionDirs). The dead "volume sweep" that the original code
+//      shipped is gone — workspaces are host bind mounts (no volume), and the
+//      cache volumes carry a different label and MUST NOT be reaped.
 //   2. Periodic sweep: every 5 min, kill any tale-sbx-* container whose
 //      `tale.started=<ms>` label is older than 2× max_timeout AND whose
 //      session id isn't in the live in-flight set. Same host-dir sweep
-//      for orphan session dirs.
+//      for orphan one-shot dirs.
 //   3. SIGTERM handler (in server.ts after refactor): stop accepting new
 //      requests, wait for in-flight count to drop, then exit.
 
-import { mkdir, readdir, rm, stat, utimes } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { mkdir, readdir, rm, rmdir, stat, utimes } from 'node:fs/promises';
 import { hostname } from 'node:os';
 import { join } from 'node:path';
 
 import type { ExecutionBackend } from './backend/types.ts';
+import { isSessionWorkspaceDirName } from './session/session-naming.ts';
 import { runDocker, dockerRm } from './spawn-util.ts';
 import type { SpawnerConfig } from './types.ts';
+import { ID_ALPHABET_RE } from './wire.ts';
 
 const PERIODIC_INTERVAL_MS = 5 * 60_000;
 const SPAWNER_LOCK_FILE = '.spawner.lock';
@@ -202,36 +206,84 @@ async function listLabeledContainers(...labels: string[]): Promise<string[]> {
     .filter((s) => s.length > 0);
 }
 
-async function sweepHostSessionDirs(
-  cfg: SpawnerConfig,
-  staleThreshold: number,
-): Promise<number> {
-  let entries;
+/**
+ * Read one directory level, or null when it can't be read. A missing dir is
+ * not an error (first boot at the root; a concurrent destroy below it); any
+ * other failure is logged. Callers treat null as "leave it alone".
+ */
+async function readDirEntries(dir: string): Promise<Dirent[] | null> {
   try {
-    entries = await readdir(cfg.hostSessionRoot, { withFileTypes: true });
+    return await readdir(dir, { withFileTypes: true });
   } catch (err) {
-    // Root not yet created (first boot) — fine.
-    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-      return 0;
+    if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT')) {
+      console.warn(`[sandbox.cleanup] failed to read ${dir}:`, err);
     }
-    console.warn(
-      `[sandbox.cleanup] failed to read host session root ${cfg.hostSessionRoot}:`,
-      err,
-    );
-    return 0;
+    return null;
   }
+}
+
+// Legacy colour roots (`<root>/<colour>/`) sit directly under the session
+// root; nothing deeper was ever a session root.
+const LEGACY_ROOT_MAX_DEPTH = 1;
+
+/**
+ * Host-dir sweep — removes ONLY stale legacy one-shot exec dirs, never a
+ * session workspace. The layout rules it enforces (the resume side of the same
+ * contract is docker-session-backend.ts resolveWorkspaceDir):
+ *
+ *   <root>/ses-<id>            flat session workspace          → never touched
+ *   <root>/<colour>/ses-<id>   legacy colour-rooted workspace  → never touched;
+ *                              a dir holding any such child is a legacy session
+ *                              root — swept one level down, never removed
+ *                              itself (once emptied it is reaped like any
+ *                              stale dir, via a non-recursive rmdir)
+ *   <root>/<execId>            legacy one-shot exec dir (its name was the raw
+ *   <root>/<colour>/<execId>   executionId, ID_ALPHABET_RE) → removed once its
+ *                              mtime is past `staleThreshold` and it's not live
+ *   anything else              files, dot-dirs, names outside the id alphabet,
+ *                              unreadable dirs → never touched
+ *
+ * Session workspaces are lifecycle-managed by destroySession alone: the
+ * TTL/idle reaper STOPS a session and keeps its data, so age says nothing about
+ * whether a `ses-*` dir is wanted — a stopped session resumes against it days
+ * later, and a live one has it bind-mounted. Fail-safe by construction: an
+ * un-swept unknown dir is a small leak; a deleted workspace is user data loss.
+ */
+export async function sweepHostSessionDirs(
+  hostSessionRoot: string,
+  staleThreshold: number,
+  isLive: (executionId: string) => boolean = () => false,
+): Promise<number> {
+  return sweepDirLevel(hostSessionRoot, staleThreshold, isLive, 0);
+}
+
+async function sweepDirLevel(
+  dir: string,
+  staleThreshold: number,
+  isLive: (executionId: string) => boolean,
+  depth: number,
+): Promise<number> {
+  const entries = await readDirEntries(dir);
+  if (entries === null) return 0;
   let removed = 0;
   for (const e of entries) {
     if (!e.isDirectory()) continue;
-    // Persistent agent-session workspaces (`ses-<sessionId>`, see
-    // session-naming.ts) are lifecycle-managed by destroySession + the
-    // session TTL/idle sweep — NEVER by this one-shot dir sweep. Without
-    // this skip the 5-min periodic sweep deletes any live session's
-    // workspace once its top-level mtime passes the one-shot watchdog
-    // cutoff (~10 min), yanking the bind mount out from under a running
-    // container.
-    if (e.name.startsWith('ses-')) continue;
-    const abs = join(cfg.hostSessionRoot, e.name);
+    if (isSessionWorkspaceDirName(e.name)) continue;
+    // Not a name a one-shot exec could have had → unknown provenance → skip.
+    if (!ID_ALPHABET_RE.test(e.name)) continue;
+    const abs = join(dir, e.name);
+    const children = await readDirEntries(abs);
+    if (children === null) continue;
+    if (
+      children.some((c) => c.isDirectory() && isSessionWorkspaceDirName(c.name))
+    ) {
+      // A legacy session root: sweep the one-shot leftovers beside its
+      // sessions, but never the root itself while it holds a workspace.
+      if (depth < LEGACY_ROOT_MAX_DEPTH) {
+        removed += await sweepDirLevel(abs, staleThreshold, isLive, depth + 1);
+      }
+      continue;
+    }
     let st;
     try {
       st = await stat(abs);
@@ -239,11 +291,20 @@ async function sweepHostSessionDirs(
       console.warn(`[sandbox.cleanup] stat ${abs} failed:`, err);
       continue;
     }
-    if (st.mtimeMs >= staleThreshold) continue;
+    if (st.mtimeMs >= staleThreshold || isLive(e.name)) continue;
     try {
-      await rm(abs, { recursive: true, force: true });
+      // An empty dir goes through the non-recursive rmdir: atomic, and it
+      // fails (ENOTEMPTY) instead of racing anything that just landed inside.
+      if (children.length === 0) await rmdir(abs);
+      else await rm(abs, { recursive: true, force: true });
       removed += 1;
+      console.log(
+        `[sandbox.cleanup] removed stale one-shot dir ${abs} (mtime ${st.mtime.toISOString()})`,
+      );
     } catch (err) {
+      if (err instanceof Error && 'code' in err && err.code === 'ENOTEMPTY') {
+        continue;
+      }
       console.warn(`[sandbox.cleanup] rm ${abs} failed:`, err);
     }
   }
@@ -286,7 +347,7 @@ export async function bootSweep(cfg?: SpawnerConfig): Promise<void> {
     // path's contract and is robust under any future change where the
     // lock acquire is loosened (audit finding R2-B5).
     dirsRemoved = await sweepHostSessionDirs(
-      cfg,
+      cfg.hostSessionRoot,
       Date.now() - 2 * cfg.maxTimeoutMs,
     );
   }
@@ -355,13 +416,18 @@ export async function dockerSweepOrphans(
   } catch (err) {
     console.warn(`[sandbox.periodic] container sweep error:`, err);
   }
-  // Host-dir sweep: per-execution session dirs that lived past the stale
-  // threshold without an active in-flight entry are orphaned. Replaces the
+  // Host-dir sweep: legacy one-shot exec dirs that lived past the stale
+  // threshold without an active in-flight entry are orphaned (session
+  // workspaces are never touched — see sweepHostSessionDirs). Replaces the
   // old volume-sweep block that targeted volumes nobody creates (audit
   // finding R2-3 C5). Gated on the container probe so a wedged daemon defers
   // dir reaping to the next cycle (matches the prior short-circuit).
   if (containerProbeOk) {
-    removed += await sweepHostSessionDirs(cfg, staleThreshold);
+    removed += await sweepHostSessionDirs(
+      cfg.hostSessionRoot,
+      staleThreshold,
+      isLive,
+    );
     // Reap orphaned per-session inner-docker (DinD) storage volumes. A volume
     // still attached to a live session container fails `volume rm` and is
     // skipped; only volumes whose session is gone (crash, missed teardown) are

--- a/services/sandbox/src/session/docker-session-args.ts
+++ b/services/sandbox/src/session/docker-session-args.ts
@@ -3,7 +3,7 @@
 // Separate from docker-args.ts on purpose: the one-shot builder is snapshot-
 // tested as a frozen contract and must not change. Sessions differ in ways
 // that would break that snapshot — detached (`-d`), no entry positional (the
-// daemon is PID 1 via the `daemon` entrypoint dispatch), a long-lived
+// daemon runs under tini via the `daemon` entrypoint dispatch), a long-lived
 // resource profile (no cpu-time ulimit, bigger mem/pids, /dev/shm for
 // Chromium), the per-session runnerd token in env, and the session label.
 //
@@ -424,8 +424,8 @@ export function buildDockerSessionRunArgs(
     // Per-org cache volume mounts (empty under DinD — cold caches; see above).
     ...cacheMounts,
     cfg.runtimeImage,
-    // Entrypoint dispatch: `daemon` mode boots runnerd as PID 1 instead of
-    // running a one-shot script. See sandbox-runtime/entrypoint.sh.
+    // Entrypoint dispatch: `daemon` mode boots tini (PID 1) + runnerd instead
+    // of running a one-shot script. See sandbox-runtime/entrypoint.sh.
     'daemon',
   ];
 }

--- a/services/sandbox/src/session/session-naming.ts
+++ b/services/sandbox/src/session/session-naming.ts
@@ -19,10 +19,22 @@ export function sessionContainerName(sessionId: string): string {
   return `tale-sbx-ses-${sessionId}`;
 }
 
-/** Per-session workspace dir under the host session root (Docker backend).
- * The `ses-` prefix is also what the one-shot host-dir sweep skips. */
+// Prefix of every per-session workspace dir under the host session root
+// (Docker backend), in BOTH layouts the resolver knows — flat `<root>/ses-<id>`
+// and legacy colour-rooted `<root>/<colour>/ses-<id>`. It is the one marker
+// the host-dir sweep keys its "never delete" rule on.
+const SESSION_WORKSPACE_DIR_PREFIX = 'ses-';
+
+/** Per-session workspace dir under the host session root (Docker backend). */
 export function sessionWorkspaceDirName(sessionId: string): string {
-  return `ses-${sessionId}`;
+  return `${SESSION_WORKSPACE_DIR_PREFIX}${sessionId}`;
+}
+
+/** Is this dir name a session workspace (either layout)? Session workspaces
+ * are lifecycle-managed by destroySession alone — the reaper only ever STOPS
+ * a session and keeps its data — so nothing else may delete one. */
+export function isSessionWorkspaceDirName(name: string): boolean {
+  return name.startsWith(SESSION_WORKSPACE_DIR_PREFIX);
 }
 
 /**


### PR DESCRIPTION
## Invariant

The sandbox runtime fails safe on every unhappy path: it never deletes a workspace it is not sure is dead, never leaves a user's file replaced by a staged overwrite, and never leaks processes. Three verified-review findings, one commit each.

## 1. Host-dir sweep deletes legacy colour-rooted session workspaces — fixed (`cec88dd2c`)

`sweepHostSessionDirs` skipped only flat `ses-*` dirs and `rm -rf`'d every other top-level dir past 2×maxTimeout — including the legacy colour roots (`<root>/<colour>/ses-<id>`) that `resolveWorkspaceDir` still resumes from. Confirmed in code; one-shot dir names were the raw `executionId` (`ID_ALPHABET_RE`), which `blue`/`green` also match, so shape alone cannot classify a dir.

Layout rules now enforced (`services/sandbox/src/cleanup.ts`):

| path | rule |
| --- | --- |
| `<root>/ses-<id>` | flat session workspace — never touched |
| `<root>/<colour>/ses-<id>` | legacy workspace — never touched; a dir holding any `ses-*` child is a legacy session root: swept one level down, never removed itself |
| `<root>/<execId>`, `<root>/<colour>/<execId>` | legacy one-shot dir — removed only when id-shaped, mtime past the threshold and not in flight; an empty one via the atomic non-recursive `rmdir` |
| files, dot-dirs, names outside the id alphabet, unreadable dirs | never touched |

Session workspaces are owned by `destroySession` alone (the reaper stops, it never deletes), so age says nothing about a `ses-*` dir. The `ses-` marker is one shared helper (`isSessionWorkspaceDirName`, `session-naming.ts`) used by both the resolver and the sweep; `isLive` is threaded through from `dockerSweepOrphans`. Each deletion is logged.

- Test: `services/sandbox/src/cleanup.test.ts` (7 cases). **Red on base: 4/7 failed** — `blue/ses-legacy/data.txt` deleted; `weird+name`, `.hidden`, `has spaces` deleted; an in-flight dir deleted. Green after: 7/7.

## 2. Cancelled OpenClaw turn destroys the workspace AGENTS.md — fixed (`b0f21f9cb`)

Confirmed: the wrapper overwrote `<workspace>/AGENTS.md`, backed up into a `/tmp` stage dir, restored only in `finally`; runnerd's cancel is a process-group SIGTERM then SIGKILL after 5s (`exec-manager.ts`), and Python's default SIGTERM disposition runs no `finally`.

Research (OpenClaw 2026.6.11 docs/source): `extraSystemPrompt` exists only on the gateway `agent` RPC, not the `openclaw agent` CLI; the `bootstrap-extra-files` hook takes workspace-relative globs. No channel verifiable offline avoids the workspace file, and silently losing Tale's instructions would be the worse regression — so the verified transport stays and becomes kill-safe:

- the original is **parked by an atomic rename** into `$OPENCLAW_STATE_DIR/tale-agents-md/<sha256(workspace)[:16]>/` — outside the workspace (safe from the agent and `git clean`), on the persistent `/agent` volume (same filesystem → `rename(2)`; cross-device falls back to copy-to-temp → rename → unlink, so a kill at any step leaves a complete copy);
- a marker records `had_original` + the staged prompt's sha256, written before anything moves;
- restore runs in the `finally`, in a SIGTERM/SIGINT/SIGHUP handler **before** unwinding (runnerd's SIGKILL lands ~5s later), and as a backstop at the start of every later turn (`recover()`, prompt or not). With no original, the staged prompt is removed only if it still hashes to what was written; a parked original that could not be restored is never staged over (the turn fails loudly instead).
- A cancel now emits `run_end status: "cancelled"`; `openclaw-jsonl.ts` maps it to the `cancelled` turn status (as `pi-jsonl` already does for its abort) instead of an error event. `harness.yml` comment updated.

- Test: `services/sandbox-runtime/daemon/src/tale-openclaw-run.test.ts` (5 cases) drives the real wrapper against a fake `openclaw` on PATH and signals the process group exactly like runnerd. **Red on base: 3/5 failed** — after SIGTERM `AGENTS.md` was `TALE SYSTEM PROMPT v1`; after SIGKILL the next turn re-backed-up the clobbered file (original lost); with no user file a stale prompt stayed. Green after: 5/5 (clean run, no-prompt turn untouched, SIGTERM restores before exit, SIGKILL + next turn restores and still delivers the new prompt, SIGKILL with no user file leaves nothing).
- Parser: `openclaw-jsonl.test.ts` + cancelled case — vitest 5/5.

Residual, documented: between a SIGKILL and the next OpenClaw turn the workspace shows the staged prompt as `AGENTS.md` (the original is parked, not lost); recovery is wrapper-scoped, so a turn by a *different* harness in that window would not trigger it.

## 3. Non-DinD session containers have no zombie reaper — fixed (`036194dd6`)

Confirmed: only the DinD branch exec'd `tini -g`; the plain and transparent-egress paths exec'd node as PID 1, and node never `wait()`s children it did not spawn. Both paths now `exec tini -g --` with runnerd as the child (the transparent-egress path keeps its `setpriv` drop under tini, exactly like DinD). `tini` is installed unconditionally (Dockerfile docker-ce apt block: "present in every image"). The K8s Pod runs the same `daemon` dispatch, so it is covered too. `-g` forwards the container-stop SIGTERM to runnerd's process group, so graceful shutdown is unchanged. Comments/docs follow (`sessions.md`, sandbox-runtime README, `k8s-session-pod-spec.ts`, `docker-session-args.ts`, runnerd `main.ts`).

- **Read-only verified**: `bash -n` / `sh -n` pass; the exec sites were re-listed. No image was built and no container started, so tini's reaping and signal forwarding are asserted from tini's documented semantics and the pre-existing DinD path, not observed here. `docker:test:sandbox-runtime` should be run on CI/an image build.

## Refuted

None — all three reproduced in code, and 1 and 2 additionally in red tests on base.

## Gates observed

- `@tale/sandbox`: `bun test` 241 pass (234 baseline + 7); `tsc --noEmit` clean; `oxlint --type-aware` rc 0; `oxfmt --check` clean.
- `@tale/sandbox-runtime-daemon`: `bun test` 84 pass (79 + 5); `tsc` clean; `oxlint` rc 0.
- `@tale/platform`: vitest `openclaw-jsonl.test.ts` 5 pass; `tsc --noEmit` clean (46s); `oxlint` on the touched files clean.
- Python: `ruff format --check` / `ruff check` clean, `py_compile` ok. Shell: `bash -n`, `sh -n` ok.
- Not run: docker image build, container conformance, kind/K8s.

## Cross-class notes

- `tale-pi-run` / `tale-gemini-run` already stage their prompt outside the workspace; `tale-hermes-run` passes it in-process — only OpenClaw had the destructive path.
- runnerd's `main.ts` comment says in-flight execs "get their process-group SIGTERM from the orchestrator's container stop"; a `docker stop` signals PID 1 only, and execs live in their own process groups, so they actually end at namespace teardown. Not in this class; noting for the exec-lifecycle owner.
- If a future OpenClaw pin exposes a CLI/config system-prompt channel, the swap can be retired for it.
