### PR TITLE
fix(platform): conversation ingest, assignment, visibility, heal, search

### DIFF
--- a/services/platform/backend/core/conversations/ingest/add_message_to_conversation.ts
+++ b/services/platform/backend/core/conversations/ingest/add_message_to_conversation.ts
@@ -3,11 +3,13 @@ import { internal } from '../../lib/handler_names';
 import type { Id } from '../../lib/rows';
 import { attachmentsForMetadata } from './attachments_for_metadata';
 import { buildEmailMetadata } from './build_email_metadata';
+import { emailStamps } from './email_epoch';
 import { normalizeExternalMessageId } from './normalize_external_message_id';
 import type { EmailType } from './types';
 
 /**
- * Add a message to an existing conversation
+ * Add a message to an existing conversation. The instant stamps ride
+ * {@link emailStamps}: absent, never NaN, for a message with no readable date.
  */
 export async function addMessageToConversation(
   ctx: ActionCtx,
@@ -18,7 +20,6 @@ export async function addMessageToConversation(
   status: 'delivered' | 'sent',
   connectorName?: string,
 ) {
-  const emailTimestamp = new Date(email.date).getTime();
   const attachments = attachmentsForMetadata(email.attachments);
 
   await ctx.runMutation(
@@ -32,8 +33,7 @@ export async function addMessageToConversation(
       status,
       externalMessageId: normalizeExternalMessageId(email.messageId),
       metadata: buildEmailMetadata(email),
-      sentAt: emailTimestamp,
-      deliveredAt: status === 'delivered' ? emailTimestamp : undefined,
+      ...emailStamps(email.date, status === 'delivered'),
       ...(attachments?.length ? { attachments } : {}),
       ...(connectorName ? { connectorName } : {}),
     },

--- a/services/platform/backend/core/conversations/ingest/bind_email_attachments.ts
+++ b/services/platform/backend/core/conversations/ingest/bind_email_attachments.ts
@@ -38,6 +38,7 @@ import { isRecord } from '../../../../lib/utils/type-utils';
 import type { ActionCtx } from '../../lib/ctx';
 import { internal } from '../../lib/handler_names';
 import type { Id } from '../../lib/rows';
+import { emailEpochMs } from './email_epoch';
 import type { EmailType } from './types';
 
 /** One ingested email and the conversation it landed on. */
@@ -80,8 +81,7 @@ export async function bindEmailAttachments(
     // The mail's own date, so importing old mail sorts by when it was sent.
     // An unparseable or absent date leaves the stamp to the mutation, which
     // falls back to the row's creation time.
-    const parsed = email.date === undefined ? NaN : Date.parse(email.date);
-    const receivedAt = Number.isFinite(parsed) ? parsed : undefined;
+    const receivedAt = emailEpochMs(email.date) ?? undefined;
     for (const storageId of storedRefs(email)) {
       try {
         const outcome = await ctx.runMutation(

--- a/services/platform/backend/core/conversations/ingest/build_initial_message.test.ts
+++ b/services/platform/backend/core/conversations/ingest/build_initial_message.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The three message writers stamp instants from ONE reading of the email's
+ * date. A Gmail message without a Date header carries `internalDate` (an
+ * epoch-ms string); a malformed one carries nothing readable. The shim behind
+ * `ctx.runMutation` validates every stamp as a number, so a NaN stamp rejects
+ * the write — and one rejected message wedged the whole mailbox pass.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ActionCtx } from '../../lib/ctx';
+import type { Id } from '../../lib/rows';
+import { addMessageToConversation } from './add_message_to_conversation';
+import { buildInitialMessage } from './build_initial_message';
+import type { EmailType } from './types';
+import { updateMessage } from './update_message';
+
+const INTERNAL_DATE = String(Date.UTC(2026, 6, 2, 12));
+
+function email(date: string): EmailType {
+  return {
+    uid: 7,
+    messageId: '<no-date@mail.gmail.com>',
+    from: [{ address: 'customer@ext.test' }],
+    to: [{ address: 'inbox@door.test' }],
+    subject: 'No Date header',
+    date,
+    text: 'hello',
+    flags: [],
+  };
+}
+
+function recordingCtx() {
+  const calls: Record<string, unknown>[] = [];
+  const ctx = {
+    runQuery: vi.fn(async () => null),
+    runMutation: vi.fn(async (_ref, args: Record<string, unknown>) => {
+      calls.push(args);
+      return null;
+    }),
+  } as unknown as ActionCtx;
+  return { ctx, calls };
+}
+
+describe('buildInitialMessage', () => {
+  it("stamps Gmail's internalDate string as a numeric instant", () => {
+    const message = buildInitialMessage(
+      email(INTERNAL_DATE),
+      true,
+      'delivered',
+    );
+    expect(message.sentAt).toBe(Number(INTERNAL_DATE));
+    expect(message.deliveredAt).toBe(Number(INTERNAL_DATE));
+  });
+
+  it('carries no stamp at all — never NaN — for an unreadable date', () => {
+    const message = buildInitialMessage(email(''), true, 'delivered');
+    expect('sentAt' in message).toBe(false);
+    expect('deliveredAt' in message).toBe(false);
+  });
+
+  it('stamps only sentAt for a sent (not delivered) message', () => {
+    const message = buildInitialMessage(
+      email('2026-07-01T09:00:00.000Z'),
+      false,
+      'sent',
+    );
+    expect(message.sentAt).toBe(Date.UTC(2026, 6, 1, 9));
+    expect('deliveredAt' in message).toBe(false);
+  });
+});
+
+describe('addMessageToConversation (ingest writer)', () => {
+  it('stamps the internalDate instant and omits stamps for an unreadable date', async () => {
+    const { ctx, calls } = recordingCtx();
+    const conversationId = 'conv_1' as Id<'conversations'>;
+    await addMessageToConversation(
+      ctx,
+      conversationId,
+      'org_1',
+      email(INTERNAL_DATE),
+      true,
+      'delivered',
+    );
+    await addMessageToConversation(
+      ctx,
+      conversationId,
+      'org_1',
+      email(''),
+      true,
+      'delivered',
+    );
+    expect(calls[0]).toMatchObject({
+      sentAt: Number(INTERNAL_DATE),
+      deliveredAt: Number(INTERNAL_DATE),
+    });
+    expect(calls[1]).not.toHaveProperty('sentAt');
+    expect(calls[1]).not.toHaveProperty('deliveredAt');
+  });
+});
+
+describe('updateMessage (ingest writer)', () => {
+  it('flips to delivered with a numeric deliveredAt, or without one when the date is unreadable', async () => {
+    const { ctx, calls } = recordingCtx();
+    const messageId = 'msg_1' as Id<'conversationMessages'>;
+    await updateMessage(ctx, messageId, email(INTERNAL_DATE));
+    await updateMessage(ctx, messageId, email(''));
+    expect(calls[0]).toMatchObject({
+      deliveryState: 'delivered',
+      deliveredAt: Number(INTERNAL_DATE),
+    });
+    expect(calls[1]).toMatchObject({ deliveryState: 'delivered' });
+    expect(calls[1]).not.toHaveProperty('deliveredAt');
+  });
+});

--- a/services/platform/backend/core/conversations/ingest/build_initial_message.ts
+++ b/services/platform/backend/core/conversations/ingest/build_initial_message.ts
@@ -1,10 +1,13 @@
 import { attachmentsForMetadata } from './attachments_for_metadata';
 import { buildEmailMetadata } from './build_email_metadata';
+import { emailStamps } from './email_epoch';
 import { normalizeExternalMessageId } from './normalize_external_message_id';
 import type { EmailType } from './types';
 
 /**
- * Build initial message object for conversation creation
+ * Build initial message object for conversation creation. The instant stamps
+ * ride {@link emailStamps}: absent, never NaN, for a message with no readable
+ * date (Gmail's no-Date-header shape hands back an epoch-ms string).
  */
 export function buildInitialMessage(
   email: EmailType,
@@ -12,7 +15,6 @@ export function buildInitialMessage(
   status: 'delivered' | 'sent',
   connectorName?: string,
 ) {
-  const emailTimestamp = new Date(email.date).getTime();
   const attachments = attachmentsForMetadata(email.attachments);
 
   return {
@@ -22,8 +24,7 @@ export function buildInitialMessage(
     status,
     externalMessageId: normalizeExternalMessageId(email.messageId),
     metadata: buildEmailMetadata(email),
-    sentAt: emailTimestamp,
-    deliveredAt: status === 'delivered' ? emailTimestamp : undefined,
+    ...emailStamps(email.date, status === 'delivered'),
     ...(attachments?.length ? { attachments } : {}),
     ...(connectorName ? { connectorName } : {}),
   };

--- a/services/platform/backend/core/conversations/ingest/create_conversation_from_email.test.ts
+++ b/services/platform/backend/core/conversations/ingest/create_conversation_from_email.test.ts
@@ -268,9 +268,14 @@ describe('createConversationFromEmail — messages without a readable Date', () 
     expect(threaded[0]?.conversationId).toBe('conv_existing');
     expect(threaded[0]).not.toHaveProperty('sentAt');
 
-    const initialOf = (externalMessageId: string) =>
-      created.find((args) => args.externalMessageId === externalMessageId)
-        ?.initialMessage as Record<string, unknown> | undefined;
+    const initialOf = (externalMessageId: string): unknown => {
+      const args = created.find(
+        (candidate) => candidate.externalMessageId === externalMessageId,
+      );
+      return args === undefined
+        ? undefined
+        : Reflect.get(args, 'initialMessage');
+    };
     expect(initialOf('internal@x')).toMatchObject({
       sentAt: Number(INTERNAL_DATE),
       deliveredAt: Number(INTERNAL_DATE),

--- a/services/platform/backend/core/conversations/ingest/create_conversation_from_email.test.ts
+++ b/services/platform/backend/core/conversations/ingest/create_conversation_from_email.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { functionRefName } from '../../../../lib/shared/handlers/function-refs';
 import type { ActionCtx } from '../../lib/ctx';
 import type { Id } from '../../lib/rows';
 import { createConversationFromEmail } from './create_conversation_from_email';
@@ -169,6 +170,136 @@ describe('createConversationFromEmail', () => {
     });
     // The sync advances the watermark to exactly this, never past it.
     expect(result.ingestedTip).toBe(Date.parse('2026-07-03T09:00:00.000Z'));
+  });
+});
+
+/**
+ * A Gmail message without a Date header arrives with `date` = internalDate (an
+ * epoch-ms STRING); a malformed one may carry no readable date at all. The
+ * ingest shim validates every stamp as a number, so a NaN stamp rejects the
+ * write — and with no per-message isolation one such message wedged the whole
+ * mailbox pass forever (the watermark never advanced past it). Every writer
+ * (create / thread / update) must ingest such a message with the stamp
+ * omitted, and the rest of the batch must land.
+ */
+describe('createConversationFromEmail — messages without a readable Date', () => {
+  const INTERNAL_DATE = String(Date.UTC(2026, 6, 2, 12));
+
+  /** The shim's contract: a stamp is a finite number or absent. */
+  function assertShimStamps(args: Record<string, unknown>): void {
+    const initial = args.initialMessage;
+    const carriers: unknown[] = [args];
+    if (typeof initial === 'object' && initial !== null) carriers.push(initial);
+    for (const carrier of carriers) {
+      for (const key of ['sentAt', 'deliveredAt']) {
+        const value = Reflect.get(Object(carrier), key);
+        if (value !== undefined && !Number.isFinite(value)) {
+          throw new Error(
+            `Invalid input: expected number, received ${String(value)} at ${key}`,
+          );
+        }
+      }
+    }
+  }
+
+  function strictCtx() {
+    const mutations: Record<string, unknown>[] = [];
+    const ctx = {
+      runQuery: vi.fn(async (ref: unknown, args: Record<string, unknown>) => {
+        // One conversation already exists from an earlier pass; its root
+        // Message-ID is what a later undated reply threads onto.
+        if (
+          functionRefName(ref) ===
+            'conversations/internal_queries:getMessageByExternalId' &&
+          args.externalMessageId === 'root@existing'
+        ) {
+          return {
+            _id: 'msg_root',
+            conversationId: 'conv_existing',
+            deliveryState: 'delivered',
+          };
+        }
+        return null;
+      }),
+      runMutation: vi.fn(async (_ref, args: Record<string, unknown>) => {
+        assertShimStamps(args);
+        mutations.push(args);
+        if ('source' in args && args.source === 'conversation') {
+          return { contactId: 'cont_1', created: true };
+        }
+        if (isCreateConversationArgs(args)) {
+          return {
+            conversationId: `conv_${mutations.length}`,
+            messageId: `msg_${mutations.length}`,
+          };
+        }
+        return null;
+      }),
+    } as unknown as ActionCtx;
+    return { ctx, mutations };
+  }
+
+  it('ingests the whole batch: the readable instants are stamped, the rest carry none', async () => {
+    const { ctx, mutations } = strictCtx();
+    const result = await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [
+        makeEmail('<dated@x>', '2026-07-01T09:00:00.000Z'),
+        makeEmail('<internal@x>', INTERNAL_DATE),
+        makeEmail('<undated@x>', ''),
+        makeEmail('<undated-reply@x>', '', {
+          headers: {
+            'message-id': '<undated-reply@x>',
+            'in-reply-to': '<root@existing>',
+            references: '<root@existing>',
+          },
+        }),
+      ],
+      connectorName: 'gmail',
+    });
+
+    expect(result.processedCount).toBe(4);
+    expect(result.skippedCount).toBe(0);
+    // Three new conversations + one message threaded onto the existing one.
+    const created = mutations.filter(isCreateConversationArgs);
+    const threaded = mutations.filter(isAddMessageArgs);
+    expect(created).toHaveLength(3);
+    expect(threaded).toHaveLength(1);
+    expect(threaded[0]?.conversationId).toBe('conv_existing');
+    expect(threaded[0]).not.toHaveProperty('sentAt');
+
+    const initialOf = (externalMessageId: string) =>
+      created.find((args) => args.externalMessageId === externalMessageId)
+        ?.initialMessage as Record<string, unknown> | undefined;
+    expect(initialOf('internal@x')).toMatchObject({
+      sentAt: Number(INTERNAL_DATE),
+      deliveredAt: Number(INTERNAL_DATE),
+    });
+    expect(initialOf('dated@x')).toMatchObject({
+      sentAt: Date.UTC(2026, 6, 1, 9),
+    });
+    expect(initialOf('undated@x')).not.toHaveProperty('sentAt');
+    expect(initialOf('undated@x')).not.toHaveProperty('deliveredAt');
+    // The watermark tip is the newest READABLE instant — undated mail never
+    // moves it, and never freezes it either.
+    expect(result.ingestedTip).toBe(Number(INTERNAL_DATE));
+  });
+
+  it('re-syncing an already-ingested undated message updates it without a NaN stamp', async () => {
+    const { ctx, mutations } = strictCtx();
+    const result = await createConversationFromEmail(ctx, {
+      organizationId: ORG,
+      emails: [makeEmail('<root@existing>', '')],
+    });
+    expect(result.processedCount).toBe(1);
+    const update = mutations.find(
+      (args) => 'messageId' in args && 'deliveryState' in args,
+    );
+    expect(update).toMatchObject({
+      messageId: 'msg_root',
+      deliveryState: 'delivered',
+    });
+    expect(update).not.toHaveProperty('deliveredAt');
   });
 });
 

--- a/services/platform/backend/core/conversations/ingest/create_conversation_from_email.ts
+++ b/services/platform/backend/core/conversations/ingest/create_conversation_from_email.ts
@@ -13,7 +13,7 @@ import { buildInitialMessage } from './build_initial_message';
 import { checkConversationExists } from './check_conversation_exists';
 import { checkMessageExists } from './check_message_exists';
 import { MAX_EMAILS_PER_BATCH, NO_SUBJECT } from './constants';
-import { tipOfEmails } from './email_epoch';
+import { byEmailDateAscending, tipOfEmails } from './email_epoch';
 import { findOrCreateContactFromEmail } from './find_or_create_contact_from_email';
 import { normalizeEmails } from './normalize_email';
 import { normalizeExternalMessageId } from './normalize_external_message_id';
@@ -104,9 +104,7 @@ export async function createConversationFromEmail(
     };
   }
 
-  emailsArray.sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-  );
+  emailsArray.sort(byEmailDateAscending);
 
   if (emailsArray.length > MAX_EMAILS_PER_BATCH) {
     debugLog(

--- a/services/platform/backend/core/conversations/ingest/create_conversation_from_sent_email.ts
+++ b/services/platform/backend/core/conversations/ingest/create_conversation_from_sent_email.ts
@@ -9,7 +9,7 @@ import { buildInitialMessage } from './build_initial_message';
 import { checkConversationExists } from './check_conversation_exists';
 import { checkMessageExists } from './check_message_exists';
 import { MAX_EMAILS_PER_BATCH, NO_SUBJECT } from './constants';
-import { tipOfEmails } from './email_epoch';
+import { byEmailDateAscending, tipOfEmails } from './email_epoch';
 import { findOrCreateContactFromEmail } from './find_or_create_contact_from_email';
 import { normalizeEmails } from './normalize_email';
 import { normalizeExternalMessageId } from './normalize_external_message_id';
@@ -107,9 +107,7 @@ export async function createConversationFromSentEmail(
     };
   }
 
-  emailsArray.sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-  );
+  emailsArray.sort(byEmailDateAscending);
 
   if (emailsArray.length > MAX_EMAILS_PER_BATCH) {
     debugLog(

--- a/services/platform/backend/core/conversations/ingest/email_epoch.test.ts
+++ b/services/platform/backend/core/conversations/ingest/email_epoch.test.ts
@@ -1,0 +1,71 @@
+/**
+ * One instant-reading concept for the whole ingest lane. Gmail hands back
+ * `internalDate` (epoch ms as a STRING) when a message carries no `Date`
+ * header; a message may also carry no readable date at all. Neither may ever
+ * become a NaN stamp — the ingest shim validates stamps as numbers, so one NaN
+ * rejects the write and wedges the mailbox pass behind it.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { byEmailDateAscending, emailEpochMs, emailStamps } from './email_epoch';
+
+describe('emailEpochMs', () => {
+  it('reads an RFC/ISO Date header', () => {
+    expect(emailEpochMs('2026-07-01T09:00:00.000Z')).toBe(
+      Date.UTC(2026, 6, 1, 9),
+    );
+  });
+
+  it("reads Gmail's internalDate epoch-ms string when there is no Date header", () => {
+    expect(emailEpochMs('1751360400000')).toBe(1751360400000);
+  });
+
+  it('accepts a numeric instant and refuses a non-finite one', () => {
+    expect(emailEpochMs(1751360400000)).toBe(1751360400000);
+    expect(emailEpochMs(Number.NaN)).toBeNull();
+  });
+
+  it('answers null for an absent, empty, or unreadable date', () => {
+    expect(emailEpochMs(undefined)).toBeNull();
+    expect(emailEpochMs('')).toBeNull();
+    expect(emailEpochMs('   ')).toBeNull();
+    expect(emailEpochMs('not a date')).toBeNull();
+  });
+});
+
+describe('emailStamps', () => {
+  it('stamps sentAt and deliveredAt for a delivered message with a date', () => {
+    expect(emailStamps('1751360400000', true)).toEqual({
+      sentAt: 1751360400000,
+      deliveredAt: 1751360400000,
+    });
+  });
+
+  it('stamps only sentAt for a message that is not delivered', () => {
+    expect(emailStamps('2026-07-01T09:00:00.000Z', false)).toEqual({
+      sentAt: Date.UTC(2026, 6, 1, 9),
+    });
+  });
+
+  it('carries NO stamp — never NaN — when the date is unreadable', () => {
+    const stamps = emailStamps('', true);
+    expect(stamps).toEqual({});
+    expect('sentAt' in stamps).toBe(false);
+    expect('deliveredAt' in stamps).toBe(false);
+  });
+});
+
+describe('byEmailDateAscending', () => {
+  it('orders oldest first across ISO and epoch-string dates, undated first', () => {
+    const emails = [
+      { messageId: 'c', date: '2026-07-03T00:00:00.000Z' },
+      { messageId: 'b', date: String(Date.UTC(2026, 6, 2)) },
+      { messageId: 'undated', date: '' },
+      { messageId: 'a', date: '2026-07-01T00:00:00.000Z' },
+    ];
+    expect(
+      [...emails].sort(byEmailDateAscending).map((email) => email.messageId),
+    ).toEqual(['undated', 'a', 'b', 'c']);
+  });
+});

--- a/services/platform/backend/core/conversations/ingest/email_epoch.ts
+++ b/services/platform/backend/core/conversations/ingest/email_epoch.ts
@@ -16,6 +16,33 @@ export function emailEpochMs(date: unknown): number | null {
 }
 
 /**
+ * The instant stamps one message writer carries for an email — `sentAt`, plus
+ * `deliveredAt` for a delivered message — or NEITHER when the message carries
+ * no readable date. Absent, never NaN: the ingest shim validates stamps as
+ * numbers, so a NaN stamp rejects the write and one undated message wedges the
+ * whole mailbox pass behind it (the watermark never advances past it). Without
+ * a stamp the row falls back to its own creation time in the display order.
+ */
+export function emailStamps(
+  date: unknown,
+  delivered: boolean,
+): { sentAt?: number; deliveredAt?: number } {
+  const ms = emailEpochMs(date);
+  if (ms === null) return {};
+  return delivered ? { sentAt: ms, deliveredAt: ms } : { sentAt: ms };
+}
+
+/** Oldest-first order for an ingest batch (the root that anchors threading
+ * lands first). An undated email sorts first rather than poisoning the
+ * comparator with NaN. */
+export function byEmailDateAscending(
+  a: { date?: unknown },
+  b: { date?: unknown },
+): number {
+  return (emailEpochMs(a.date) ?? 0) - (emailEpochMs(b.date) ?? 0);
+}
+
+/**
  * The newest instant among a set of emails — the tip the sync watermark may
  * advance to. `null` when none of them carry a readable date.
  */

--- a/services/platform/backend/core/conversations/ingest/update_message.ts
+++ b/services/platform/backend/core/conversations/ingest/update_message.ts
@@ -2,24 +2,27 @@ import type { ActionCtx } from '../../lib/ctx';
 import { internal } from '../../lib/handler_names';
 import type { Id } from '../../lib/rows';
 import { buildEmailMetadata } from './build_email_metadata';
+import { emailEpochMs } from './email_epoch';
 import type { EmailType } from './types';
 
 /**
- * Update an existing message with delivered state and metadata
+ * Update an existing message with delivered state and metadata. A message
+ * with no readable date keeps the `deliveredAt` it has rather than being
+ * stamped NaN (which the mutation would reject, wedging the pass).
  */
 export async function updateMessage(
   ctx: ActionCtx,
   messageId: Id<'conversationMessages'>,
   email: EmailType,
 ) {
-  const emailTimestamp = new Date(email.date).getTime();
+  const deliveredAt = emailEpochMs(email.date);
 
   await ctx.runMutation(
     internal.conversations.internal_mutations.updateConversationMessage,
     {
       messageId,
       deliveryState: 'delivered',
-      deliveredAt: emailTimestamp,
+      ...(deliveredAt !== null ? { deliveredAt } : {}),
       metadata: buildEmailMetadata(email),
     },
   );

--- a/services/platform/backend/domains/connector_credentials/service.shim-row.test.ts
+++ b/services/platform/backend/domains/connector_credentials/service.shim-row.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The one `resolveCredentialRefInternal` answer both reused resolvers read —
+ * the work-lane credential broker and the mailbox sync's IMAP fromAddress
+ * heal. It must carry the sealed envelope (the reused resolver decrypts it
+ * itself) in the 0.4 wire shape: nullable columns absent, never null. The
+ * conversations shim used to serve an identity-only answer, so the heal died
+ * on the missing envelope every pass before it could heal anything.
+ */
+
+import type { Sql } from 'postgres';
+import { describe, expect, it } from 'vitest';
+
+import { resolveCredentialRowForShim } from './service.ts';
+
+/** A `sql` stand-in answering the connector's row listing with `rows`. */
+function fakeSql(rows: unknown[]): Sql {
+  const tag = (..._args: unknown[]) => Promise.resolve(rows);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double
+  return Object.assign(tag, {
+    unsafe: (text: string) => text,
+  }) as unknown as Sql;
+}
+
+const ROW = {
+  id: 'cred_1',
+  organizationId: 'org_1',
+  connectorSlug: 'imap-smtp',
+  authMethod: 'basic',
+  name: 'Support inbox',
+  encryptedData: { keyFingerprint: 'fp', iv: 'iv', ciphertext: 'ct', tag: 't' },
+  endpointUrl: null,
+  config: { host: 'imap.door.test' },
+  maskedPreview: 'in***@door.test',
+  isDefault: true,
+  mailSyncInboundSince: null,
+  mailSyncOutboundSince: null,
+  status: 'active',
+  statusDetail: null,
+  createdBy: 'user_1',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+describe('resolveCredentialRowForShim', () => {
+  it('answers the full 0.4 row — envelope included, nulls absent', async () => {
+    const answer = await resolveCredentialRowForShim(fakeSql([ROW]), {
+      organizationId: 'org_1',
+      connectorSlug: 'imap-smtp',
+    });
+    expect(answer).toEqual({
+      _id: 'cred_1',
+      organizationId: 'org_1',
+      connectorSlug: 'imap-smtp',
+      authMethod: 'basic',
+      name: 'Support inbox',
+      encryptedData: ROW.encryptedData,
+      config: { host: 'imap.door.test' },
+      status: 'active',
+    });
+    expect(answer).not.toHaveProperty('endpointUrl');
+    expect(answer).not.toHaveProperty('statusDetail');
+  });
+
+  it('resolves an explicit ref by id or by name, and null on a miss', async () => {
+    const sql = fakeSql([ROW]);
+    expect(
+      await resolveCredentialRowForShim(sql, {
+        organizationId: 'org_1',
+        connectorSlug: 'imap-smtp',
+        credentialRef: 'support INBOX',
+      }),
+    ).toMatchObject({ _id: 'cred_1' });
+    expect(
+      await resolveCredentialRowForShim(sql, {
+        organizationId: 'org_1',
+        connectorSlug: 'imap-smtp',
+        credentialRef: 'no-such-credential',
+      }),
+    ).toBeNull();
+    expect(
+      await resolveCredentialRowForShim(fakeSql([]), {
+        organizationId: 'org_1',
+        connectorSlug: 'imap-smtp',
+      }),
+    ).toBeNull();
+  });
+
+  it('hands a disabled row back for the reused resolver to refuse on status', async () => {
+    const answer = await resolveCredentialRowForShim(
+      fakeSql([{ ...ROW, status: 'disabled', statusDetail: 'operator' }]),
+      { organizationId: 'org_1', connectorSlug: 'imap-smtp' },
+    );
+    expect(answer).toMatchObject({
+      status: 'disabled',
+      statusDetail: 'operator',
+    });
+  });
+});

--- a/services/platform/backend/domains/connector_credentials/service.ts
+++ b/services/platform/backend/domains/connector_credentials/service.ts
@@ -885,3 +885,24 @@ export async function patchMailSyncWatermarks(
     WHERE id = ${credentialId} AND org_id = ${organizationId}
   `;
 }
+
+/**
+ * The mailbox sync's config heal (the IMAP `fromAddress` mirror): the caller
+ * derived the whole config from the row's own resolved config plus a login
+ * address it validated, so it is written as given — a system seam, not the
+ * user door, hence no per-field normalization — scoped to the org like the
+ * watermark patch.
+ */
+export async function patchCredentialConfigInternal(
+  sql: Sql,
+  organizationId: string,
+  credentialId: string,
+  config: Record<string, string | number | boolean>,
+): Promise<void> {
+  await sql`
+    UPDATE app.connector_credentials SET
+      config = ${sql.json(toJson(config))},
+      updated_at_ms = ${Date.now()}
+    WHERE id = ${credentialId} AND org_id = ${organizationId}
+  `;
+}

--- a/services/platform/backend/domains/connector_credentials/service.ts
+++ b/services/platform/backend/domains/connector_credentials/service.ts
@@ -720,6 +720,39 @@ export async function findCredentialForRef(
   return rows.find((row) => row.name.toLowerCase() === needle) ?? null;
 }
 
+/**
+ * The 0.4 `resolveCredentialRefInternal` answer every reused resolver reads —
+ * the work-lane credential broker and the mailbox sync's IMAP fromAddress
+ * heal alike: the FULL row including the sealed envelope (the reused resolver
+ * decrypts it itself and refuses disabled / needs-reauth rows on `status`), in
+ * the 0.4 wire shape where nullable columns are ABSENT fields, never nulls.
+ * Null on a miss. Internal-only by contract: it carries sealed secret
+ * material and must never reach a client, an agent, or a log.
+ */
+export async function resolveCredentialRowForShim(
+  sql: Sql,
+  args: {
+    organizationId: string;
+    connectorSlug: string;
+    credentialRef?: string;
+  },
+): Promise<Record<string, unknown> | null> {
+  const row = await findCredentialForRef(sql, args);
+  if (row === null) return null;
+  return {
+    _id: row.id,
+    organizationId: row.organizationId,
+    connectorSlug: row.connectorSlug,
+    authMethod: row.authMethod,
+    name: row.name,
+    encryptedData: row.encryptedData,
+    ...(row.endpointUrl !== null ? { endpointUrl: row.endpointUrl } : {}),
+    ...(row.config !== null ? { config: row.config } : {}),
+    status: row.status,
+    ...(row.statusDetail !== null ? { statusDetail: row.statusDetail } : {}),
+  };
+}
+
 /** Load the addressed row (explicit id-or-name ref, else the default). */
 async function loadRowForResolve(
   sql: Sql,

--- a/services/platform/backend/domains/conversations/compose-assignment.test.ts
+++ b/services/platform/backend/domains/conversations/compose-assignment.test.ts
@@ -23,8 +23,10 @@ describe('resolveComposeAssignment', () => {
   });
 
   test('an admin may assign another member and a team in-org', async () => {
+    // One row shape satisfies both reads: the member row (role) and the team
+    // row (organizationId).
     const result = await resolveComposeAssignment(
-      fakeSql([{ organizationId: 'org_1' }]),
+      fakeSql([{ id: 'm1', organizationId: 'org_1', role: 'member' }]),
       {
         organizationId: 'org_1',
         assigneeUserId: 'user_other',
@@ -70,5 +72,42 @@ describe('resolveComposeAssignment', () => {
         actor: { userId: 'user_admin', role: 'admin' },
       }),
     ).rejects.toBeInstanceOf(ConversationError);
+  });
+
+  // The shared assignee gate: a person an admin picks must be an active
+  // member, or the new conversation would be visible to nobody.
+  test('rejects an admin-picked assignee who is not a member of the org', async () => {
+    await expect(
+      resolveComposeAssignment(fakeSql([]), {
+        organizationId: 'org_1',
+        assigneeUserId: 'user_stranger',
+        actor: { userId: 'user_admin', role: 'admin' },
+      }),
+    ).rejects.toMatchObject({
+      code: 'user_not_in_org',
+    } satisfies Partial<ConversationError>);
+  });
+
+  test('rejects an admin-picked assignee whose seat is disabled', async () => {
+    await expect(
+      resolveComposeAssignment(
+        fakeSql([{ id: 'm1', organizationId: 'org_1', role: 'disabled' }]),
+        {
+          organizationId: 'org_1',
+          assigneeUserId: 'user_off',
+          actor: { userId: 'user_admin', role: 'admin' },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'user_not_in_org' });
+  });
+
+  test('self-assignment consults no membership (the actor is a member by construction)', async () => {
+    // An empty answer would otherwise read as "not a member".
+    const result = await resolveComposeAssignment(fakeSql([]), {
+      organizationId: 'org_1',
+      assigneeUserId: 'user_admin',
+      actor: { userId: 'user_admin', role: 'admin' },
+    });
+    expect(result).toEqual({ assigneeUserId: 'user_admin' });
   });
 });

--- a/services/platform/backend/domains/conversations/routes.test.ts
+++ b/services/platform/backend/domains/conversations/routes.test.ts
@@ -15,11 +15,19 @@ const {
   countConversationsByStatus,
   countUnreadConversations,
   projectConversationForView,
+  loadMessageForViewer,
+  undoSendMessage,
+  retrySendMessage,
+  discardOutboundMessage,
 } = vi.hoisted(() => ({
   listConversationsPage: vi.fn(),
   countConversationsByStatus: vi.fn(),
   countUnreadConversations: vi.fn(),
   projectConversationForView: vi.fn(),
+  loadMessageForViewer: vi.fn(),
+  undoSendMessage: vi.fn(),
+  retrySendMessage: vi.fn(),
+  discardOutboundMessage: vi.fn(),
 }));
 
 vi.mock('./service.ts', async (importOriginal) => {
@@ -30,6 +38,17 @@ vi.mock('./service.ts', async (importOriginal) => {
     countConversationsByStatus,
     countUnreadConversations,
     projectConversationForView,
+    loadMessageForViewer,
+  };
+});
+
+vi.mock('./send.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./send.ts')>();
+  return {
+    ...actual,
+    undoSendMessage,
+    retrySendMessage,
+    discardOutboundMessage,
   };
 });
 
@@ -57,6 +76,7 @@ vi.mock('../../auth/org.ts', async (importOriginal) => {
 });
 
 import { createConversationRoutes } from './routes.ts';
+import { ConversationError } from './service.ts';
 
 function makeApp() {
   return createConversationRoutes({
@@ -120,4 +140,74 @@ describe('conversations route — connector filter wire contract', () => {
       'imap-smtp',
     );
   });
+});
+
+/**
+ * The message-level doors act on a message only inside a conversation the
+ * viewer can open. Org scoping alone let a member holding a messageId cancel,
+ * resend, or discard a colleague's outbound mail in a conversation the
+ * assignment predicate hides from them; the guard the attachments door
+ * already ran now fronts undo, retry and discard too.
+ */
+describe('conversations route — message doors share the visibility guard', () => {
+  const doors = [
+    ['undo', undoSendMessage],
+    ['retry', retrySendMessage],
+    ['discard', discardOutboundMessage],
+  ] as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    undoSendMessage.mockResolvedValue({ sourceMarkdown: null });
+    retrySendMessage.mockResolvedValue(undefined);
+    discardOutboundMessage.mockResolvedValue(undefined);
+  });
+
+  for (const [door, service] of doors) {
+    it(`POST /messages/:id/${door} answers the opaque 404 for a hidden conversation and touches nothing`, async () => {
+      loadMessageForViewer.mockRejectedValue(
+        new ConversationError(
+          'conversation_not_found',
+          'Conversation not found',
+          404,
+        ),
+      );
+      const res = await makeApp().request(
+        '/messages/m1/' + door + '?orgId=o1',
+        {
+          method: 'POST',
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+      expect(res.status).toBe(404);
+      expect(loadMessageForViewer).toHaveBeenCalledWith(
+        expect.anything(),
+        { organizationId: 'o1', userId: 'u1', role: 'admin' },
+        'm1',
+      );
+      expect(service).not.toHaveBeenCalled();
+    });
+
+    it(`POST /messages/:id/${door} runs for a message the viewer can open`, async () => {
+      loadMessageForViewer.mockResolvedValue({
+        id: 'm1',
+        conversationId: 'c1',
+        connectorName: 'imap-smtp',
+      });
+      const res = await makeApp().request(
+        '/messages/m1/' + door + '?orgId=o1',
+        {
+          method: 'POST',
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+      expect(res.status).toBe(200);
+      expect(service).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ organizationId: 'o1', messageId: 'm1' }),
+      );
+    });
+  }
 });

--- a/services/platform/backend/domains/conversations/routes.ts
+++ b/services/platform/backend/domains/conversations/routes.ts
@@ -432,9 +432,17 @@ export function createConversationRoutes(deps: {
     }
   });
 
+  /**
+   * The message-level doors (undo / retry / discard / attachments) all pass
+   * `loadMessageForViewer` first: a member acts on a message only inside a
+   * conversation they can open — org scoping alone let a member holding an id
+   * cancel or resend a colleague's mail in a conversation hidden from them.
+   */
+
   /** Cancel a still-queued send; hands the composer draft back. */
   app.post('/messages/:messageId/undo', async (c) => {
     try {
+      await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       const result = await undoSendMessage(deps.sql, {
         organizationId: c.get('orgId'),
         messageId: c.req.param('messageId'),
@@ -459,7 +467,6 @@ export function createConversationRoutes(deps: {
    */
   app.post('/messages/:messageId/attachments', async (c) => {
     try {
-      // Still visibility-scoped: a member must be able to open the message.
       await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       return c.json(
         {
@@ -477,6 +484,7 @@ export function createConversationRoutes(deps: {
   /** Re-attempt a failed send immediately (no undo window). */
   app.post('/messages/:messageId/retry', async (c) => {
     try {
+      await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       await retrySendMessage(deps.sql, {
         organizationId: c.get('orgId'),
         messageId: c.req.param('messageId'),
@@ -491,6 +499,7 @@ export function createConversationRoutes(deps: {
   /** Remove a failed outbound bubble — the email never left. */
   app.post('/messages/:messageId/discard', async (c) => {
     try {
+      await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       await discardOutboundMessage(deps.sql, {
         organizationId: c.get('orgId'),
         messageId: c.req.param('messageId'),

--- a/services/platform/backend/domains/conversations/routes.ts
+++ b/services/platform/backend/domains/conversations/routes.ts
@@ -196,7 +196,9 @@ export function createConversationRoutes(deps: {
     try {
       await loadVisibleConversation(deps.sql, viewer(c), c.req.param('id'));
       await deps.sql.begin((tx) =>
-        updateConversation(tx, c.get('orgId'), c.req.param('id'), body.data),
+        updateConversation(tx, c.get('orgId'), c.req.param('id'), body.data, {
+          userId: c.get('sessionBundle').user.id,
+        }),
       );
       return c.json({ ok: true });
     } catch (error) {

--- a/services/platform/backend/domains/conversations/routing.ts
+++ b/services/platform/backend/domains/conversations/routing.ts
@@ -8,7 +8,7 @@ import {
   notifyConversationAssigned,
   notifyConversationAssignedTeam,
 } from '../collab/service.ts';
-import { ConversationError } from './service.ts';
+import { assertAssignableMember, ConversationError } from './service.ts';
 
 /**
  * Address→assignee routing — the 0.5 twin of
@@ -46,19 +46,12 @@ export async function applyConversationAssignment(
   next: { assigneeUserId?: string; assigneeTeamId?: string },
 ): Promise<boolean> {
   if (next.assigneeUserId) {
-    const members = await db<{ role: string }[]>`
-      SELECT "role" FROM "member"
-      WHERE "organizationId" = ${conversation.organizationId}
-        AND "userId" = ${next.assigneeUserId}
-      LIMIT 1
-    `;
-    if (!members[0]) {
-      throw new ConversationError(
-        'user_not_in_org',
-        'Assignee is not a member of this organization',
-        400,
-      );
-    }
+    // The one assignee gate every assigning door shares (see service.ts).
+    await assertAssignableMember(
+      db,
+      conversation.organizationId,
+      next.assigneeUserId,
+    );
   }
   if (next.assigneeTeamId) {
     const teams = await db<{ organizationId: string }[]>`

--- a/services/platform/backend/domains/conversations/search-chat.test.ts
+++ b/services/platform/backend/domains/conversations/search-chat.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The chat assistant's conversation search must stay bounded as the address
+ * book grows. Mail ingest mints a contact per correspondent, and the contact
+ * leg used to load EVERY contact in the org on every query and match in JS;
+ * it now prefilters in SQL (a superset of what the reused matcher keeps) and
+ * reads a recency-bounded candidate set, like the other two legs.
+ */
+
+import type { Sql } from 'postgres';
+import { describe, expect, it } from 'vitest';
+
+import { searchConversationsForChat } from './search-chat.ts';
+
+/** A `sql` stand-in scripted per query, in call order, recording each
+ * statement's text and parameter values. */
+function scriptedSql(script: unknown[][]) {
+  const statements: { text: string; values: unknown[] }[] = [];
+  let index = 0;
+  const tag = (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown[]> => {
+    statements.push({
+      text: strings.join('?').replace(/\s+/g, ' ').trim(),
+      values,
+    });
+    const rows = script[index] ?? [];
+    index += 1;
+    return Promise.resolve(rows);
+  };
+  const double = Object.assign(tag, { unsafe: (text: string) => text });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for the postgres.js tag
+  return { sql: double as unknown as Sql, statements };
+}
+
+const CONVERSATION = {
+  _id: 'conv_1',
+  subject: 'Invoice question',
+  status: 'open',
+  channel: 'email',
+  lastMessageAt: 1_000,
+  assigneeUserId: 'user_1',
+  assigneeTeamId: null,
+  contactId: 'contact_anna',
+};
+
+describe('searchConversationsForChat — the contact leg', () => {
+  it('prefilters contacts in SQL, bounded and newest-first, then confirms with the matcher', async () => {
+    const { sql, statements } = scriptedSql([
+      [{ role: 'member' }], // the caller's membership
+      [
+        { _id: 'contact_anna', name: 'Anna Lee', email: 'anna@ext.test' },
+        // Prefilter superset: "brianna" contains "anna" mid-word, which the
+        // 'any' matcher (word-start or better) drops again.
+        { _id: 'contact_bri', name: 'Brianna Ext', email: 'b@ext.test' },
+      ],
+      [], // the message-body pre-pass
+      [
+        CONVERSATION,
+        { ...CONVERSATION, _id: 'conv_2', contactId: 'contact_bri' },
+      ],
+    ]);
+
+    const result = await searchConversationsForChat(sql, {
+      organizationId: 'org_1',
+      userId: 'user_1',
+      term: 'what did anna from acme_corp say about the 50% discount',
+      limit: 10,
+    });
+
+    const contactQuery = statements[1];
+    expect(contactQuery?.text).toContain('FROM app.contacts');
+    expect(contactQuery?.text).toContain('ILIKE ANY(');
+    expect(contactQuery?.text).toContain('ORDER BY created_at_ms DESC');
+    expect(contactQuery?.text).toContain('LIMIT');
+    // Function words never reach SQL; `_` and `%` are escaped so they match
+    // themselves rather than any character / any run of characters.
+    const patterns = contactQuery?.values.find((value) => Array.isArray(value));
+    expect(patterns).toEqual(
+      expect.arrayContaining(['%anna%', '%acme\\_corp%', '%50\\%%']),
+    );
+    expect(patterns).not.toEqual(
+      expect.arrayContaining(['%what%', '%the%', '%about%']),
+    );
+    expect(contactQuery?.values).toContain(500);
+
+    // Only the word-start hit survives the matcher, so only its conversation
+    // is answered by the contact leg.
+    expect(result.conversations.map((hit) => hit._id)).toEqual(['conv_1']);
+  });
+
+  it('reads no contacts at all for a question made only of function words', async () => {
+    const { sql, statements } = scriptedSql([
+      [{ role: 'admin' }],
+      [], // body pre-pass
+      [], // conversation scan
+    ]);
+    await searchConversationsForChat(sql, {
+      organizationId: 'org_1',
+      userId: 'user_1',
+      term: 'what do we have',
+      limit: 10,
+    });
+    expect(
+      statements.some((statement) => statement.text.includes('app.contacts')),
+    ).toBe(false);
+  });
+});

--- a/services/platform/backend/domains/conversations/search-chat.ts
+++ b/services/platform/backend/domains/conversations/search-chat.ts
@@ -3,7 +3,7 @@ import type { Sql } from 'postgres';
 import { htmlToText } from '../../../lib/knowledge/html-to-text.ts';
 import { getUserTeamIds } from '../../auth/membership.ts';
 import { conversationAssignmentAllows } from '../../core/lib/rls/helpers/conversation_assignment.ts';
-import { rowMatches } from '../../core/lib/search/relevance.ts';
+import { queryTokens, rowMatches } from '../../core/lib/search/relevance.ts';
 import { contactsSearchStrategy } from '../../core/lib/search/strategies/contacts.ts';
 import { viewerIsAdmin } from './service.ts';
 
@@ -19,14 +19,24 @@ import { viewerIsAdmin } from './service.ts';
  * {@link SCAN_CAP} recent conversations; the body pre-pass reads at most
  * {@link MESSAGE_SCAN_CAP} recent messages (ids only cross that boundary —
  * an unreadable conversation's body match is collected and then discarded
- * by the assignment predicate); contact-name matches feed a bounded id set.
- * A match older than a cap is invisible — `truncated` states the limit.
+ * by the assignment predicate); the contact leg prefilters in SQL and reads
+ * at most {@link CONTACT_SCAN_CAP} recent candidates (mail ingest mints a
+ * contact per correspondent, so the address book is the one table here that
+ * grows without bound). A match older than a cap is invisible — `truncated`
+ * states the limit.
  */
 
 const SCAN_CAP = 300;
 const CONTACT_MATCH_CAP = 25;
+const CONTACT_SCAN_CAP = 500;
 const MESSAGE_SCAN_CAP = 400;
 const BODY_MATCH_CAP = 50;
+
+/** A LIKE pattern matching `token` literally anywhere in the value —
+ * `%`, `_` and `\` are LIKE metacharacters and must not widen the match. */
+function likeContains(token: string): string {
+  return `%${token.replace(/[\\%_]/g, (ch) => `\\${ch}`)}%`;
+}
 
 /** A one-field strategy: `subject` is the only prose a conversation row
  * carries. Declared here rather than exported from the shared strategies,
@@ -67,10 +77,25 @@ async function matchingConversationIdsByBody(
   return { ids, truncated };
 }
 
+/**
+ * Contacts whose name / email / external id the term hits. The reused matcher
+ * (`'any'` mode) keeps a contact only when a surviving token hits a text
+ * field at word-start or better, or an id field as a substring — every such
+ * hit is a substring hit, so the SQL prefilter below is a SUPERSET the
+ * matcher then narrows in JS. Bounded and recency-biased like the other
+ * legs: the newest {@link CONTACT_SCAN_CAP} candidates, never the whole
+ * address book loaded per query.
+ */
 async function matchingContactIds(
   sql: Sql,
   args: { organizationId: string; term: string },
 ): Promise<Set<string>> {
+  const lower = args.term.toLowerCase();
+  const tokens = queryTokens(lower, 'any');
+  // An all-stopword question carries no searchable signal (the matcher would
+  // keep nothing either) — no read at all.
+  if (tokens.length === 0) return new Set();
+  const patterns = tokens.map(likeContains);
   const rows = await sql<
     {
       _id: string;
@@ -82,10 +107,13 @@ async function matchingContactIds(
     SELECT id AS "_id", name, email, external_id AS "externalId"
     FROM app.contacts
     WHERE org_id = ${args.organizationId}
-    ORDER BY created_at_ms ASC
+      AND (name ILIKE ANY(${patterns}::text[])
+        OR email ILIKE ANY(${patterns}::text[])
+        OR external_id ILIKE ANY(${patterns}::text[]))
+    ORDER BY created_at_ms DESC
+    LIMIT ${CONTACT_SCAN_CAP}
   `;
   const ids = new Set<string>();
-  const lower = args.term.toLowerCase();
   for (const contact of rows) {
     const wire = Object.fromEntries(
       Object.entries(contact).filter(([, value]) => value !== null),

--- a/services/platform/backend/domains/conversations/send.ts
+++ b/services/platform/backend/domains/conversations/send.ts
@@ -26,6 +26,7 @@ import { createAuditLog } from '../audit_logs/service.ts';
 import { runConnectorAction } from '../connectors/service.ts';
 import { getFileUrl } from '../files/service.ts';
 import {
+  assertAssignableMember,
   CONVERSATION_COLUMNS,
   ConversationError,
   createConversation,
@@ -514,8 +515,10 @@ export async function bulkReplyToConversations(
  * Resolve who owns a newly composed outbound conversation.
  *
  * Defaults to the creator; only an admin may pick another member or a team
- * queue. Non-admin team requests are dropped (not rejected). A team must
- * belong to the org or we throw `team_not_in_org`.
+ * queue. Non-admin team requests are dropped (not rejected). A picked person
+ * must be an active org member (`user_not_in_org` otherwise — the shared
+ * assignee gate) and a team must belong to the org or we throw
+ * `team_not_in_org`.
  */
 export async function resolveComposeAssignment(
   sql: Sql,
@@ -530,6 +533,11 @@ export async function resolveComposeAssignment(
   const assigneeUserId = isAdmin
     ? (args.assigneeUserId ?? args.actor.userId)
     : args.actor.userId;
+  // The actor is a member by construction (the org middleware); anyone else
+  // an admin picks passes the same gate the assign door and routing apply.
+  if (assigneeUserId !== args.actor.userId) {
+    await assertAssignableMember(sql, args.organizationId, assigneeUserId);
+  }
   if (!(isAdmin && args.assigneeTeamId)) {
     return { assigneeUserId };
   }

--- a/services/platform/backend/domains/conversations/service.assign.test.ts
+++ b/services/platform/backend/domains/conversations/service.assign.test.ts
@@ -1,0 +1,161 @@
+/**
+ * You cannot assign a conversation to someone who cannot see it. The admin
+ * assign door shares the one assignee gate with address routing and compose:
+ * the assignee must hold an ACTIVE membership of the org, or the write is
+ * refused — a non-member "assignee" hid the row from every non-admin while
+ * nobody could ever open it.
+ */
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../audit_logs/service.ts', () => ({
+  createAuditLog: vi.fn(async () => undefined),
+}));
+vi.mock('../collab/service.ts', () => ({
+  notifyConversationAssigned: vi.fn(async () => undefined),
+  notifyConversationAssignedTeam: vi.fn(async () => undefined),
+}));
+vi.mock('../../realtime/outbox.ts', () => ({
+  emitHintInTx: vi.fn(async () => undefined),
+}));
+
+import {
+  assertAssignableMember,
+  assignConversation,
+  ConversationError,
+} from './service.ts';
+
+const ORG = 'org_1';
+const CONVERSATION = {
+  id: 'conv_1',
+  organizationId: ORG,
+  assigneeUserId: null,
+  assigneeTeamId: null,
+  subject: 'Order 42',
+  status: 'open',
+};
+
+/**
+ * A `sql` stand-in scripted per query, in call order, that records every
+ * statement it ran; `begin` hands the same double out as the transaction.
+ */
+function scriptedSql(script: unknown[][]): { sql: Sql; queries: string[] } {
+  const queries: string[] = [];
+  let index = 0;
+  const tag = (strings: TemplateStringsArray): Promise<unknown[]> => {
+    queries.push(strings.join('?').replace(/\s+/g, ' ').trim());
+    const rows = script[index] ?? [];
+    index += 1;
+    return Promise.resolve(rows);
+  };
+  const double = Object.assign(tag, {
+    unsafe: (text: string) => text,
+    json: (value: unknown) => value,
+    begin: (fn: (tx: unknown) => Promise<unknown>) => fn(double),
+  });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for the postgres.js tag
+  return { sql: double as unknown as Sql, queries };
+}
+
+const admin = { userId: 'user_admin', email: 'admin@door.test', role: 'admin' };
+
+describe('assertAssignableMember', () => {
+  it('refuses a user with no member row in the org', async () => {
+    const { sql } = scriptedSql([[]]);
+    await expect(
+      assertAssignableMember(sql, ORG, 'user_stranger'),
+    ).rejects.toMatchObject({
+      code: 'user_not_in_org',
+      status: 400,
+    } satisfies Partial<ConversationError>);
+  });
+
+  it('refuses a disabled seat — the row would be visible to nobody', async () => {
+    const { sql } = scriptedSql([
+      [{ id: 'm1', organizationId: ORG, userId: 'user_off', role: 'disabled' }],
+    ]);
+    await expect(
+      assertAssignableMember(sql, ORG, 'user_off'),
+    ).rejects.toMatchObject({ code: 'user_not_in_org' });
+  });
+
+  it('admits an active member', async () => {
+    const { sql } = scriptedSql([
+      [{ id: 'm1', organizationId: ORG, userId: 'user_m', role: 'member' }],
+    ]);
+    await expect(
+      assertAssignableMember(sql, ORG, 'user_m'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assignConversation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses a non-member assignee before writing anything', async () => {
+    const { sql, queries } = scriptedSql([
+      [CONVERSATION], // the conversation row
+      [], // no member row for the stranger
+    ]);
+    await expect(
+      assignConversation(sql, {
+        organizationId: ORG,
+        conversationId: 'conv_1',
+        assigneeUserId: 'user_stranger',
+        actor: admin,
+      }),
+    ).rejects.toMatchObject({ code: 'user_not_in_org', status: 400 });
+    expect(queries.some((query) => query.startsWith('UPDATE'))).toBe(false);
+  });
+
+  it('writes the assignment for an active member of the org', async () => {
+    const { sql, queries } = scriptedSql([
+      [CONVERSATION],
+      [{ id: 'm1', organizationId: ORG, userId: 'user_m', role: 'member' }],
+      [], // the UPDATE
+    ]);
+    await assignConversation(sql, {
+      organizationId: ORG,
+      conversationId: 'conv_1',
+      assigneeUserId: 'user_m',
+      actor: admin,
+    });
+    expect(queries[1]).toContain('FROM "member"');
+    expect(queries[2]).toContain(
+      'UPDATE app.conversations SET assignee_user_id',
+    );
+  });
+
+  it('unassigning consults no membership — null is always allowed', async () => {
+    const { sql, queries } = scriptedSql([
+      [{ ...CONVERSATION, assigneeUserId: 'user_m' }],
+      [], // the UPDATE
+    ]);
+    await assignConversation(sql, {
+      organizationId: ORG,
+      conversationId: 'conv_1',
+      assigneeUserId: null,
+      actor: admin,
+    });
+    expect(queries.some((query) => query.includes('FROM "member"'))).toBe(
+      false,
+    );
+    expect(queries[1]).toContain(
+      'UPDATE app.conversations SET assignee_user_id',
+    );
+  });
+
+  it('stays admin-only', async () => {
+    const { sql, queries } = scriptedSql([]);
+    await expect(
+      assignConversation(sql, {
+        organizationId: ORG,
+        conversationId: 'conv_1',
+        assigneeUserId: 'user_m',
+        actor: { userId: 'user_member', role: 'member' },
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', status: 403 });
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -3,7 +3,10 @@ import type { Sql, TransactionSql } from 'postgres';
 import { projectConversationItem } from '../../../lib/shared/conversations/conversation-item.ts';
 import { nextConversationLastMessageAt } from '../../../lib/shared/conversations/message-order.ts';
 import { isRecord } from '../../../lib/utils/type-utils.ts';
-import { getUserTeamIds } from '../../auth/membership.ts';
+import {
+  findOrganizationMember,
+  getUserTeamIds,
+} from '../../auth/membership.ts';
 import { conversationAssignmentAllows } from '../../core/lib/rls/helpers/conversation_assignment.ts';
 import { toJson } from '../../db/sql.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
@@ -671,8 +674,31 @@ export async function markConversationAsRead(
 
 // ---------------------------------------------------------------- assign
 
-/** Admin-only individual assignment; unchanged = silent no-op; the new
- * assignee is notified (never on self-assignment or unassign). */
+/**
+ * The assignee gate shared by EVERY door that sets `assignee_user_id` — the
+ * admin assign door, address routing, and compose: the user must hold an
+ * ACTIVE membership of the conversation's organization. A non-member (or a
+ * disabled seat) as assignee is a silent triage black hole — the row is
+ * hidden from every non-admin while the "assignee" can never open it.
+ */
+export async function assertAssignableMember(
+  db: Sql | TransactionSql,
+  organizationId: string,
+  userId: string,
+): Promise<void> {
+  const member = await findOrganizationMember(db, organizationId, userId);
+  if (member === null || member.role === 'disabled') {
+    throw new ConversationError(
+      'user_not_in_org',
+      'Assignee is not a member of this organization',
+      400,
+    );
+  }
+}
+
+/** Admin-only individual assignment; unchanged = silent no-op; the assignee
+ * must be an active org member; the new assignee is notified (never on
+ * self-assignment or unassign). */
 export async function assignConversation(
   sql: Sql,
   args: {
@@ -706,6 +732,9 @@ export async function assignConversation(
     const previous = conversation.assigneeUserId;
     const next = args.assigneeUserId;
     if (previous === next) return;
+    if (next !== null) {
+      await assertAssignableMember(tx, args.organizationId, next);
+    }
     await tx`
       UPDATE app.conversations SET assignee_user_id = ${next}
       WHERE id = ${args.conversationId}

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -575,7 +575,9 @@ export async function countConversationsByStatus(
   return out;
 }
 
-/** Unread among OPEN conversations (`metadata.unread_count` positive). */
+/** Unread among OPEN conversations (`metadata.unread_count` positive). The
+ * cast runs only on a JSON number — one row carrying junk in that key (an
+ * API metadata patch) must not 500 the whole org's count tiles. */
 export async function countUnreadConversations(
   sql: Sql,
   organizationId: string,
@@ -586,7 +588,9 @@ export async function countUnreadConversations(
     WHERE org_id = ${organizationId} AND status = 'open'
       AND (${connectorName ?? null}::text IS NULL
         OR connector_name = ${connectorName ?? null})
-      AND (metadata->>'unread_count')::numeric > 0
+      AND CASE WHEN jsonb_typeof(metadata->'unread_count') = 'number'
+            THEN (metadata->>'unread_count')::numeric > 0
+            ELSE false END
   `;
   return Number(rows[0]?.count ?? '0');
 }
@@ -602,32 +606,75 @@ export interface ConversationUpdates {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * The metadata stamps one status flip carries — SHARED by the PATCH door and
+ * the bulk verbs, so a singly-closed conversation shows the same resolution
+ * record as a bulk-closed one: `closed` stamps who resolved it and when,
+ * `spam` when it was flagged; the other statuses stamp nothing.
+ */
+export function statusChangeStamps(
+  status: ConversationStatus,
+  actorUserId: string,
+  now: number,
+): Record<string, unknown> {
+  if (status === 'closed') {
+    return {
+      resolved_at: new Date(now).toISOString(),
+      resolved_by: actorUserId,
+    };
+  }
+  if (status === 'spam') {
+    return { marked_spam_at: new Date(now).toISOString() };
+  }
+  return {};
+}
+
+/**
+ * The PATCH door. Metadata is a shallow MERGE onto the stored object (the
+ * `patchWebsite` contract), never a wholesale replace — a caller patching one
+ * key must not wipe `unread_count` or routing state — and a status flip
+ * carries the same stamps the bulk verbs write, so close/reopen/spam mean one
+ * thing whichever door they come through.
+ */
 export async function updateConversation(
   tx: TransactionSql,
   organizationId: string,
   conversationId: string,
   updates: ConversationUpdates,
+  actor: { userId: string },
 ): Promise<void> {
-  const rows = await tx<{ id: string; metadata: unknown }[]>`
+  const rows = await tx<
+    { id: string; metadata: Record<string, unknown> | null }[]
+  >`
     SELECT id, metadata FROM app.conversations
     WHERE id = ${conversationId} AND org_id = ${organizationId} LIMIT 1
   `;
-  if (rows.length === 0) {
+  const row = rows[0];
+  if (!row) {
     throw new ConversationError(
       'conversation_not_found',
       'Conversation not found',
       404,
     );
   }
+  const now = Date.now();
+  const stamps =
+    updates.status !== undefined
+      ? statusChangeStamps(updates.status, actor.userId, now)
+      : {};
+  const nextMetadata =
+    updates.metadata !== undefined || Object.keys(stamps).length > 0
+      ? { ...row.metadata, ...updates.metadata, ...stamps }
+      : undefined;
   await tx`
     UPDATE app.conversations SET
       contact_id = ${updates.contactId ?? tx.unsafe('contact_id')},
       subject = ${updates.subject ?? tx.unsafe('subject')},
       status = ${updates.status ?? tx.unsafe('status')},
-      status_changed_at_ms = ${updates.status !== undefined ? Date.now() : tx.unsafe('status_changed_at_ms')},
+      status_changed_at_ms = ${updates.status !== undefined ? now : tx.unsafe('status_changed_at_ms')},
       priority = ${updates.priority ?? tx.unsafe('priority')},
       type = ${updates.type ?? tx.unsafe('type')},
-      metadata = ${updates.metadata !== undefined ? tx.json(toJson(updates.metadata)) : tx.unsafe('metadata')}
+      metadata = ${nextMetadata !== undefined ? tx.json(toJson(nextMetadata)) : tx.unsafe('metadata')}
     WHERE id = ${conversationId}
   `;
   await emitHintInTx(tx, {
@@ -920,15 +967,7 @@ export async function bulkSetConversationStatus(
         result.errors.push(`Conversation ${conversationId} not found`);
         continue;
       }
-      const stamps: Record<string, unknown> =
-        args.verb === 'close'
-          ? {
-              resolved_at: new Date(now).toISOString(),
-              resolved_by: args.actor.userId,
-            }
-          : args.verb === 'spam'
-            ? { marked_spam_at: new Date(now).toISOString() }
-            : {};
+      const stamps = statusChangeStamps(target.status, args.actor.userId, now);
       await tx`
         UPDATE app.conversations SET
           status = ${target.status}, status_changed_at_ms = ${now},

--- a/services/platform/backend/domains/conversations/service.update.test.ts
+++ b/services/platform/backend/domains/conversations/service.update.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Closing a conversation keeps its resolution record, whichever door closes
+ * it. The app's single close/reopen/spam buttons PATCH `{status}`; that door
+ * used to write none of the stamps the bulk verbs write (the closed banner
+ * showed undated) and to REPLACE metadata wholesale, so a one-key patch wiped
+ * `unread_count` and routing state. PATCH and bulk now share one stamp table
+ * and metadata is merged.
+ */
+
+import type { TransactionSql } from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../realtime/outbox.ts', () => ({
+  emitHintInTx: vi.fn(async () => undefined),
+}));
+
+import {
+  ConversationError,
+  statusChangeStamps,
+  updateConversation,
+} from './service.ts';
+
+const ORG = 'org_1';
+const STORED_METADATA = {
+  unread_count: 2,
+  to: [{ address: 'support@door.test' }],
+  routing: 'desk',
+};
+
+/** A transaction double: answers the SELECT with `row`, records the UPDATE's
+ * parameters (json/unsafe are identity so the metadata object is inspectable). */
+function txDouble(row: { id: string; metadata: unknown } | null) {
+  const statements: { text: string; values: unknown[] }[] = [];
+  const tag = (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown[]> => {
+    statements.push({
+      text: strings.join('?').replace(/\s+/g, ' ').trim(),
+      values,
+    });
+    return Promise.resolve(
+      statements.length === 1 ? (row === null ? [] : [row]) : [],
+    );
+  };
+  const tx = Object.assign(tag, {
+    unsafe: (text: string) => text,
+    json: (value: unknown) => value,
+  });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for the postgres.js transaction tag
+  return { tx: tx as unknown as TransactionSql, statements };
+}
+
+function updateParams(statements: { text: string; values: unknown[] }[]) {
+  const update = statements.find((s) => s.text.startsWith('UPDATE'));
+  if (!update) throw new Error('no UPDATE issued');
+  // contact_id, subject, status, status_changed_at_ms, priority, type,
+  // metadata, id — in the statement's column order.
+  const [, , status, statusChangedAt, , , metadata] = update.values;
+  return { status, statusChangedAt, metadata };
+}
+
+describe('statusChangeStamps (shared by PATCH and bulk)', () => {
+  const now = Date.UTC(2026, 8, 3, 12);
+
+  it('closed stamps who resolved it and when', () => {
+    expect(statusChangeStamps('closed', 'user_a', now)).toEqual({
+      resolved_at: new Date(now).toISOString(),
+      resolved_by: 'user_a',
+    });
+  });
+
+  it('spam stamps when it was flagged', () => {
+    expect(statusChangeStamps('spam', 'user_a', now)).toEqual({
+      marked_spam_at: new Date(now).toISOString(),
+    });
+  });
+
+  it('open and archived stamp nothing', () => {
+    expect(statusChangeStamps('open', 'user_a', now)).toEqual({});
+    expect(statusChangeStamps('archived', 'user_a', now)).toEqual({});
+  });
+});
+
+describe('updateConversation (the PATCH door)', () => {
+  const actor = { userId: 'user_admin' };
+
+  it('closing stamps the resolution record AND keeps the stored metadata', async () => {
+    const { tx, statements } = txDouble({
+      id: 'c1',
+      metadata: STORED_METADATA,
+    });
+    await updateConversation(tx, ORG, 'c1', { status: 'closed' }, actor);
+    const { status, statusChangedAt, metadata } = updateParams(statements);
+    expect(status).toBe('closed');
+    expect(typeof statusChangedAt).toBe('number');
+    expect(metadata).toMatchObject({
+      ...STORED_METADATA,
+      resolved_by: 'user_admin',
+    });
+    expect(typeof (metadata as Record<string, unknown>).resolved_at).toBe(
+      'string',
+    );
+  });
+
+  it('marking spam stamps marked_spam_at and keeps unread state', async () => {
+    const { tx, statements } = txDouble({
+      id: 'c1',
+      metadata: STORED_METADATA,
+    });
+    await updateConversation(tx, ORG, 'c1', { status: 'spam' }, actor);
+    const { metadata } = updateParams(statements);
+    expect(metadata).toMatchObject({ unread_count: 2 });
+    expect(typeof (metadata as Record<string, unknown>).marked_spam_at).toBe(
+      'string',
+    );
+  });
+
+  it('a metadata patch MERGES onto the stored object instead of replacing it', async () => {
+    const { tx, statements } = txDouble({
+      id: 'c1',
+      metadata: STORED_METADATA,
+    });
+    await updateConversation(
+      tx,
+      ORG,
+      'c1',
+      { metadata: { priority_note: 'VIP' } },
+      actor,
+    );
+    const { status, metadata } = updateParams(statements);
+    expect(status).toBe('status'); // untouched column passthrough
+    expect(metadata).toEqual({ ...STORED_METADATA, priority_note: 'VIP' });
+  });
+
+  it('a patch with neither status nor metadata leaves metadata untouched', async () => {
+    const { tx, statements } = txDouble({
+      id: 'c1',
+      metadata: STORED_METADATA,
+    });
+    await updateConversation(tx, ORG, 'c1', { subject: 'Renamed' }, actor);
+    const { metadata, statusChangedAt } = updateParams(statements);
+    expect(metadata).toBe('metadata');
+    expect(statusChangedAt).toBe('status_changed_at_ms');
+  });
+
+  it('reopening keeps the record and stamps nothing new', async () => {
+    const stored = {
+      ...STORED_METADATA,
+      resolved_at: '2026-09-01T00:00:00.000Z',
+      resolved_by: 'user_x',
+    };
+    const { tx, statements } = txDouble({ id: 'c1', metadata: stored });
+    await updateConversation(tx, ORG, 'c1', { status: 'open' }, actor);
+    const { status, metadata } = updateParams(statements);
+    expect(status).toBe('open');
+    // No stamps to write and no metadata patch → the column is left alone.
+    expect(metadata).toBe('metadata');
+  });
+
+  it('answers the opaque 404 for a row outside the org', async () => {
+    const { tx, statements } = txDouble(null);
+    await expect(
+      updateConversation(tx, ORG, 'c1', { status: 'closed' }, actor),
+    ).rejects.toMatchObject({
+      code: 'conversation_not_found',
+      status: 404,
+    } satisfies Partial<ConversationError>);
+    expect(statements.some((s) => s.text.startsWith('UPDATE'))).toBe(false);
+  });
+});

--- a/services/platform/backend/domains/conversations/shim.test.ts
+++ b/services/platform/backend/domains/conversations/shim.test.ts
@@ -8,18 +8,21 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { patchMailSyncWatermarks, patchCredentialConfigInternal } = vi.hoisted(
-  () => ({
-    patchMailSyncWatermarks: vi.fn(async () => undefined),
-    patchCredentialConfigInternal: vi.fn(async () => undefined),
-  }),
-);
+const {
+  patchMailSyncWatermarks,
+  patchCredentialConfigInternal,
+  resolveCredentialRowForShim,
+} = vi.hoisted(() => ({
+  patchMailSyncWatermarks: vi.fn(async () => undefined),
+  patchCredentialConfigInternal: vi.fn(async () => undefined),
+  resolveCredentialRowForShim: vi.fn(async () => null),
+}));
 
 vi.mock('../connector_credentials/service.ts', () => ({
   listActiveCredentials: vi.fn(),
-  resolveConnectorCredential: vi.fn(),
   patchMailSyncWatermarks,
   patchCredentialConfigInternal,
+  resolveCredentialRowForShim,
 }));
 vi.mock('../files/service.ts', () => ({
   putOrgBlobBytes: vi.fn(),
@@ -36,6 +39,39 @@ const patch = () => {
   if (!handler) throw new Error('handler missing');
   return handler;
 };
+
+describe('resolveCredentialRefInternal shim', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('serves the shared full-row answer the reused resolver decrypts (not an identity-only stub)', async () => {
+    const row = {
+      _id: 'cred_1',
+      organizationId: 'o1',
+      connectorSlug: 'imap-smtp',
+      authMethod: 'basic',
+      name: 'Support inbox',
+      encryptedData: { keyFingerprint: 'fp' },
+      config: { host: 'imap.door.test' },
+      status: 'active',
+    };
+    resolveCredentialRowForShim.mockResolvedValueOnce(row as never);
+    const handler = conversationShimHandlers(SQL, () => {
+      throw new Error('no connector calls in this test');
+    })['connector_credentials/queries:resolveCredentialRefInternal'];
+    if (!handler) throw new Error('handler missing');
+    const answer = await handler({
+      organizationId: 'o1',
+      connectorSlug: 'imap-smtp',
+      credentialRef: 'cred_1',
+    });
+    expect(resolveCredentialRowForShim).toHaveBeenCalledWith(SQL, {
+      organizationId: 'o1',
+      connectorSlug: 'imap-smtp',
+      credentialRef: 'cred_1',
+    });
+    expect(answer).toBe(row);
+  });
+});
 
 describe('patchCredentialInternal shim', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/services/platform/backend/domains/conversations/shim.test.ts
+++ b/services/platform/backend/domains/conversations/shim.test.ts
@@ -1,0 +1,91 @@
+/**
+ * A heal that says it healed must have written. The sync's IMAP fromAddress
+ * heal patches credential `config` through `patchCredentialInternal`; the shim
+ * used to `.loose()`-parse the call and forward only the two watermark fields,
+ * so `config` was silently dropped — the mirror never landed and the drift was
+ * re-detected (and "mirrored" re-logged) on every pass.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { patchMailSyncWatermarks, patchCredentialConfigInternal } = vi.hoisted(
+  () => ({
+    patchMailSyncWatermarks: vi.fn(async () => undefined),
+    patchCredentialConfigInternal: vi.fn(async () => undefined),
+  }),
+);
+
+vi.mock('../connector_credentials/service.ts', () => ({
+  listActiveCredentials: vi.fn(),
+  resolveConnectorCredential: vi.fn(),
+  patchMailSyncWatermarks,
+  patchCredentialConfigInternal,
+}));
+vi.mock('../files/service.ts', () => ({
+  putOrgBlobBytes: vi.fn(),
+  registerUploadedBytes: vi.fn(),
+}));
+
+import { conversationShimHandlers } from './shim.ts';
+
+const SQL = {} as never;
+const patch = () => {
+  const handler = conversationShimHandlers(SQL, () => {
+    throw new Error('no connector calls in this test');
+  })['connector_credentials/mutations:patchCredentialInternal'];
+  if (!handler) throw new Error('handler missing');
+  return handler;
+};
+
+describe('patchCredentialInternal shim', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('persists a config heal (the IMAP fromAddress mirror)', async () => {
+    const config = { host: 'imap.door.test', fromAddress: 'inbox@door.test' };
+    await patch()({ organizationId: 'o1', credentialId: 'cred_1', config });
+    expect(patchCredentialConfigInternal).toHaveBeenCalledWith(
+      SQL,
+      'o1',
+      'cred_1',
+      config,
+    );
+    // A pure config heal names no watermark, so none is written.
+    expect(patchMailSyncWatermarks).not.toHaveBeenCalled();
+  });
+
+  it('advances the watermarks it is handed, touching no config', async () => {
+    await patch()({
+      organizationId: 'o1',
+      credentialId: 'cred_1',
+      mailSyncInboundSince: 1_000,
+    });
+    expect(patchMailSyncWatermarks).toHaveBeenCalledWith(SQL, 'o1', 'cred_1', {
+      inboundSince: 1_000,
+    });
+    expect(patchCredentialConfigInternal).not.toHaveBeenCalled();
+  });
+
+  it('lands both when a call names both', async () => {
+    await patch()({
+      organizationId: 'o1',
+      credentialId: 'cred_1',
+      mailSyncOutboundSince: 2_000,
+      config: { fromAddress: 'inbox@door.test' },
+    });
+    expect(patchCredentialConfigInternal).toHaveBeenCalledTimes(1);
+    expect(patchMailSyncWatermarks).toHaveBeenCalledWith(SQL, 'o1', 'cred_1', {
+      outboundSince: 2_000,
+    });
+  });
+
+  it('refuses a config carrying non-scalar values', async () => {
+    await expect(
+      patch()({
+        organizationId: 'o1',
+        credentialId: 'cred_1',
+        config: { nested: { not: 'allowed' } },
+      }),
+    ).rejects.toThrow();
+    expect(patchCredentialConfigInternal).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/conversations/shim.ts
+++ b/services/platform/backend/domains/conversations/shim.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { toJson } from '../../db/sql.ts';
 import {
   listActiveCredentials,
+  patchCredentialConfigInternal,
   patchMailSyncWatermarks,
   resolveConnectorCredential,
 } from '../connector_credentials/service.ts';
@@ -588,6 +589,12 @@ export function conversationShimHandlers(
         }),
       );
     },
+    /**
+     * Two callers, two patches: the watermark advance names the since-fields,
+     * the IMAP fromAddress heal names `config`. Each lands only when named —
+     * `config` used to fall through `.loose()` and was silently DROPPED, so
+     * the heal logged "mirrored" every pass and never wrote.
+     */
     'connector_credentials/mutations:patchCredentialInternal': async (
       raw: unknown,
     ) => {
@@ -596,22 +603,38 @@ export function conversationShimHandlers(
           credentialId: z.string(),
           mailSyncInboundSince: z.number().optional(),
           mailSyncOutboundSince: z.number().optional(),
+          config: z
+            .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+            .optional(),
         })
         .loose()
         .parse(raw);
-      await patchMailSyncWatermarks(
-        sql,
-        args.organizationId,
-        args.credentialId,
-        {
-          ...(args.mailSyncInboundSince !== undefined
-            ? { inboundSince: args.mailSyncInboundSince }
-            : {}),
-          ...(args.mailSyncOutboundSince !== undefined
-            ? { outboundSince: args.mailSyncOutboundSince }
-            : {}),
-        },
-      );
+      if (args.config !== undefined) {
+        await patchCredentialConfigInternal(
+          sql,
+          args.organizationId,
+          args.credentialId,
+          args.config,
+        );
+      }
+      if (
+        args.mailSyncInboundSince !== undefined ||
+        args.mailSyncOutboundSince !== undefined
+      ) {
+        await patchMailSyncWatermarks(
+          sql,
+          args.organizationId,
+          args.credentialId,
+          {
+            ...(args.mailSyncInboundSince !== undefined
+              ? { inboundSince: args.mailSyncInboundSince }
+              : {}),
+            ...(args.mailSyncOutboundSince !== undefined
+              ? { outboundSince: args.mailSyncOutboundSince }
+              : {}),
+          },
+        );
+      }
       return null;
     },
 

--- a/services/platform/backend/domains/conversations/shim.ts
+++ b/services/platform/backend/domains/conversations/shim.ts
@@ -6,7 +6,7 @@ import {
   listActiveCredentials,
   patchCredentialConfigInternal,
   patchMailSyncWatermarks,
-  resolveConnectorCredential,
+  resolveCredentialRowForShim,
 } from '../connector_credentials/service.ts';
 import { putOrgBlobBytes, registerUploadedBytes } from '../files/service.ts';
 import { applyAddressRouting } from './routing.ts';
@@ -543,6 +543,13 @@ export function conversationShimHandlers(
     },
 
     // -------------------------------------------------------- credentials
+    /**
+     * The full row the reused resolver reads (the SAME answer the work-lane
+     * shim serves). The sync's account-email read wants only `config`, but the
+     * IMAP fromAddress heal runs the reused resolver on this row and decrypts
+     * `encryptedData` itself — the identity-only answer served before left it
+     * dying on the missing envelope every pass, before it could heal anything.
+     */
     'connector_credentials/queries:resolveCredentialRefInternal': async (
       raw: unknown,
     ) => {
@@ -552,22 +559,7 @@ export function conversationShimHandlers(
           credentialRef: z.string().optional(),
         })
         .parse(raw);
-      // The sync only reads identity fields off this row; refusals for a
-      // missing ref mirror the resolver's null contract.
-      try {
-        const resolved = await resolveConnectorCredential(sql, args);
-        return {
-          _id: resolved.credentialId,
-          organizationId: args.organizationId,
-          connectorSlug: resolved.connectorSlug,
-          authMethod: resolved.authMethod,
-          name: args.credentialRef ?? 'default',
-          config: resolved.config,
-          status: 'active',
-        };
-      } catch {
-        return null;
-      }
+      return resolveCredentialRowForShim(sql, args);
     },
     'connector_credentials/queries:listActiveCredentialsInternal': async (
       raw: unknown,

--- a/services/platform/backend/domains/sandbox/shim.ts
+++ b/services/platform/backend/domains/sandbox/shim.ts
@@ -5,7 +5,7 @@ import type { ShimHandlers } from '../../lib/ctx-shim.ts';
 import { resolveAgentSecretsEnv } from '../agent_secrets/service.ts';
 import { automationAskShimHandlers } from '../automations/ask-shim.ts';
 import { chatShimHandlers } from '../chat/shim.ts';
-import { findCredentialForRef } from '../connector_credentials/service.ts';
+import { resolveCredentialRowForShim } from '../connector_credentials/service.ts';
 import { listDocumentsForAgent } from '../documents/agent-list.ts';
 import { addTaskComment } from '../tasks/comments.ts';
 import { getCurrentUser } from '../users/service.ts';
@@ -202,24 +202,10 @@ export function sandboxToolShimHandlers(sql: Sql): ShimHandlers {
         connectorSlug: string;
         credentialRef?: string;
       };
-      const row = await findCredentialForRef(sql, args);
-      if (row === null) return null;
-      // The 0.4 row shape the reused resolver reads — nullable columns are
-      // ABSENT fields there, never nulls.
-      return {
-        _id: row.id,
-        organizationId: row.organizationId,
-        connectorSlug: row.connectorSlug,
-        authMethod: row.authMethod,
-        name: row.name,
-        encryptedData: row.encryptedData,
-        ...(row.endpointUrl !== null ? { endpointUrl: row.endpointUrl } : {}),
-        ...(row.config !== null ? { config: row.config } : {}),
-        status: row.status,
-        ...(row.statusDetail !== null
-          ? { statusDetail: row.statusDetail }
-          : {}),
-      };
+      // The 0.4 row shape the reused resolver reads — one shared answer with
+      // the conversations shim (the mailbox sync's heal runs the same
+      // resolver), so the two cannot drift.
+      return resolveCredentialRowForShim(sql, args);
     },
 
     'sandbox/session_mutations:recordCredentialAccess': async (raw) => {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -15719,11 +15719,20 @@ async function checkChatConversationSearchLeg(
     term: 'shipped',
     limit: 10,
   });
-  // Contact-name match (a conversation is findable by who it is with).
+  // Contact-name match (a conversation is findable by who it is with) — the
+  // contact leg prefilters in SQL now, so this drives the ILIKE path.
   const byContact = await searchConversationsForChat(sql, {
     organizationId: orgId,
     userId,
     term: 'Carla',
+    limit: 10,
+  });
+  // A LIKE metacharacter in the question matches itself, not any character:
+  // 'carla_' must NOT reach carla@ext.test through an unescaped `_`.
+  const byUnderscore = await searchConversationsForChat(sql, {
+    organizationId: orgId,
+    userId,
+    term: 'carla_',
     limit: 10,
   });
   // Listing skips the text match but keeps the privacy predicate.
@@ -15775,6 +15784,7 @@ async function checkChatConversationSearchLeg(
       subjects.has('Quote 7') &&
       byBody.conversations.some((row) => row.subject === 'Send me a quote') &&
       byContact.conversations.length >= 2 &&
+      byUnderscore.conversations.length === 0 &&
       listedAdmin.conversations.length >= 3 &&
       memberQuote.conversations.length === 1 &&
       memberQuote.conversations[0]?.subject === 'Quote 7' &&
@@ -15783,7 +15793,7 @@ async function checkChatConversationSearchLeg(
         (row) => row.assigneeUserId === memberId,
       ) &&
       stranger.conversations.length === 0,
-    `subject=${[...subjects].sort().join('|')} body=${byBody.conversations.map((r) => r.subject).join('|')} contact=${byContact.conversations.length} adminList=${listedAdmin.conversations.length}, memberQuote=${memberQuote.conversations.map((r) => r.subject).join('|')} (want only Quote 7) memberList=${memberList.conversations.length}/ownOnly=${memberList.conversations.every((row) => row.assigneeUserId === memberId)}, stranger=${stranger.conversations.length} (want 0)`,
+    `subject=${[...subjects].sort().join('|')} body=${byBody.conversations.map((r) => r.subject).join('|')} contact=${byContact.conversations.length} underscoreEscaped=${byUnderscore.conversations.length === 0} adminList=${listedAdmin.conversations.length}, memberQuote=${memberQuote.conversations.map((r) => r.subject).join('|')} (want only Quote 7) memberList=${memberList.conversations.length}/ownOnly=${memberList.conversations.every((row) => row.assigneeUserId === memberId)}, stranger=${stranger.conversations.length} (want 0)`,
   );
 }
 

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -14933,6 +14933,115 @@ async function checkMailboxSyncLane(
 }
 
 /**
+ * Mail without a readable Date must still land. Gmail hands back `internalDate`
+ * (epoch ms as a STRING) when a message carries no Date header, and a malformed
+ * message may carry no readable instant at all. The writers used to stamp
+ * `new Date(...)` → NaN, the shim's number validator rejected the write, and
+ * the whole pass — and its watermark — wedged on that one message forever.
+ * Driven through the REAL shim (the same handlers the sync native runs on).
+ */
+async function checkUndatedMailIngest(
+  sql: Sql,
+  ctx: { orgId: string },
+): Promise<void> {
+  const { orgId } = ctx;
+  const { conversationShimHandlers } =
+    await import('./domains/conversations/shim.ts');
+  const { createCtxShim } = await import('./lib/ctx-shim.ts');
+  const { createConversationFromEmail } =
+    await import('./core/conversations/ingest/create_conversation_from_email.ts');
+  const handlers = conversationShimHandlers(sql, () => {
+    throw new Error('the undated-mail check dispatches no connector calls');
+  });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 module on the real shim
+  const shim = createCtxShim(handlers) as unknown as Parameters<
+    typeof createConversationFromEmail
+  >[0];
+
+  const internalDate = Date.now() - 600_000;
+  const gmailRaw = (
+    id: string,
+    headers: Record<string, string>,
+    internalDateMs?: number,
+  ) => ({
+    id,
+    threadId: `t-${id}`,
+    labelIds: ['INBOX'],
+    ...(internalDateMs !== undefined
+      ? { internalDate: String(internalDateMs) }
+      : {}),
+    payload: {
+      mimeType: 'text/plain',
+      headers: Object.entries(headers).map(([name, value]) => ({
+        name,
+        value,
+      })),
+      body: { data: Buffer.from(`body of ${id}`).toString('base64url') },
+    },
+  });
+  const outcome = await createConversationFromEmail(shim, {
+    organizationId: orgId,
+    connectorName: 'gmail',
+    emails: [
+      gmailRaw(
+        'g-dated',
+        {
+          From: 'Dated Sender <dated@ext.test>',
+          To: 'inbox@door.test',
+          Subject: 'Dated',
+          Date: new Date(internalDate - 60_000).toUTCString(),
+          'Message-ID': '<g-dated@ext.test>',
+        },
+        internalDate - 60_000,
+      ),
+      gmailRaw(
+        'g-nodate',
+        {
+          From: 'No Date <nodate@ext.test>',
+          To: 'inbox@door.test',
+          Subject: 'No Date header',
+          'Message-ID': '<g-nodate@ext.test>',
+        },
+        internalDate,
+      ),
+      gmailRaw('g-nothing', {
+        From: 'Nothing <nothing@ext.test>',
+        To: 'inbox@door.test',
+        Subject: 'No readable instant at all',
+        'Message-ID': '<g-nothing@ext.test>',
+      }),
+    ],
+  });
+  const rows = await sql<
+    {
+      externalMessageId: string | null;
+      sentAt: number | null;
+      deliveryState: string;
+    }[]
+  >`
+    SELECT external_message_id AS "externalMessageId",
+           sent_at_ms::float8 AS "sentAt", delivery_state AS "deliveryState"
+    FROM app.conversation_messages
+    WHERE org_id = ${orgId}
+      AND external_message_id IN ('g-dated@ext.test', 'g-nodate@ext.test',
+                                  'g-nothing@ext.test')
+  `;
+  const byId = new Map(rows.map((row) => [row.externalMessageId, row]));
+  const noDate = byId.get('g-nodate@ext.test');
+  const nothing = byId.get('g-nothing@ext.test');
+  record(
+    'mail ingest: a message without a readable Date lands instead of wedging the pass',
+    outcome.processedCount === 3 &&
+      rows.length === 3 &&
+      noDate?.sentAt === internalDate &&
+      nothing?.sentAt === null &&
+      nothing.deliveryState === 'delivered' &&
+      outcome.ingestedTip === internalDate,
+    `processed=${outcome.processedCount} (want 3) rows=${rows.length} internalDateStamped=${noDate?.sentAt === internalDate} undatedStamp=${nothing?.sentAt ?? 'null'} (want null) state=${nothing?.deliveryState} tip=${outcome.ingestedTip === internalDate}`,
+  );
+}
+
+/**
  * The outbound send surface over the connector door: a reply queues a row
  * and schedules the send one (shortened) undo window out; the worker's job
  * re-checks the row, delivers through the fake SMTP, and stamps the
@@ -31667,6 +31776,7 @@ async function main(): Promise<void> {
     await checkWorkflowTurnReattach(sql, authCtx);
     await checkConversations(sql, baseUrl, authCtx);
     await checkMailboxSyncLane(sql, authCtx);
+    await checkUndatedMailIngest(sql, authCtx);
     await checkOutboundSendLane(sql, baseUrl, authCtx);
     await checkNotificationEmailSink(sql, authCtx);
     await checkChatConversationSearchLeg(sql, authCtx);

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -14380,6 +14380,28 @@ async function checkConversations(
     WHERE org_id = ${orgId} AND user_id = ${memberId}
       AND type = 'conversation_assigned'
   `;
+  // A non-member cannot be the assignee: refused, the row keeps its owner,
+  // and no phantom bell is minted for the stranger.
+  const strangerAssign = await api(`/${conversationId}/assign`, {
+    body: { assigneeUserId: 'user-from-nowhere' },
+  });
+  const strangerBody = z
+    .object({ error: z.string() })
+    .safeParse(await strangerAssign.json());
+  const afterStranger = await sql<{ assigneeUserId: string | null }[]>`
+    SELECT assignee_user_id AS "assigneeUserId" FROM app.conversations
+    WHERE id = ${conversationId}
+  `;
+  const strangerBell = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.user_notifications
+    WHERE org_id = ${orgId} AND user_id = 'user-from-nowhere'
+  `;
+  const strangerRefused =
+    strangerAssign.status === 400 &&
+    strangerBody.success &&
+    strangerBody.data.error === 'user_not_in_org' &&
+    afterStranger[0]?.assigneeUserId === memberId &&
+    strangerBell[0]?.count === '0';
 
   // Team queueing: a fresh team + a second member on it.
   const teamRows = await sql<{ id: string }[]>`
@@ -14640,6 +14662,7 @@ async function checkConversations(
       assignRes.status === 200 &&
       visibleAfter &&
       assignBell[0]?.count === '1' &&
+      strangerRefused &&
       teammateSees &&
       teamBell[0]?.count === '1' &&
       unreadStillOne &&
@@ -14651,7 +14674,7 @@ async function checkConversations(
       closedRow[0]?.resolvedBy !== null &&
       deleted.status === 204 &&
       remnants[0]?.count === '0',
-    `listed=${row !== undefined} unread=${row?.unread} preview=${row?.lastMessagePreview === 'Where is my order?'} contact=${row?.contact?.email}, counts=${counts.success ? `${counts.data.byStatus.open ?? 0}/${counts.data.unread}` : 'ERR'}, memberHidden=${hiddenBefore}→assigned visible=${visibleAfter} bell=${assignBell[0]?.count}, teamSees=${teammateSees} teamBell=${teamBell[0]?.count}, noteKeepsUnread=${unreadStillOne} readClears=${afterRead.success && afterRead.data.conversation.metadata?.unread_count === 0}, close=${closed.success ? closed.data.successCount : 'ERR'} status=${closedRow[0]?.status}/${closedRow[0]?.resolvedBy !== null}, del=${deleted.status} remnants=${remnants[0]?.count}`,
+    `listed=${row !== undefined} unread=${row?.unread} preview=${row?.lastMessagePreview === 'Where is my order?'} contact=${row?.contact?.email}, counts=${counts.success ? `${counts.data.byStatus.open ?? 0}/${counts.data.unread}` : 'ERR'}, memberHidden=${hiddenBefore}→assigned visible=${visibleAfter} bell=${assignBell[0]?.count}, strangerRefused=${strangerRefused} (${strangerAssign.status}/${strangerBody.success ? strangerBody.data.error : 'ERR'}), teamSees=${teammateSees} teamBell=${teamBell[0]?.count}, noteKeepsUnread=${unreadStillOne} readClears=${afterRead.success && afterRead.data.conversation.metadata?.unread_count === 0}, close=${closed.success ? closed.data.successCount : 'ERR'} status=${closedRow[0]?.status}/${closedRow[0]?.resolvedBy !== null}, del=${deleted.status} remnants=${remnants[0]?.count}`,
   );
 }
 
@@ -15268,6 +15291,29 @@ async function checkOutboundSendLane(
           WHERE id = ${composeBody.data.conversationId} LIMIT 1
         `
       : [];
+    // Compose shares the assignee gate: an admin naming a non-member is
+    // refused before anything is created or sent.
+    const composeStranger = await api('/compose', {
+      body: {
+        contactId,
+        connectorName: 'imap-smtp',
+        subject: 'Quote for a stranger',
+        content: 'Never sent.',
+        assigneeUserId: 'user-from-nowhere',
+      },
+    });
+    const composeStrangerBody = z
+      .object({ error: z.string() })
+      .safeParse(await composeStranger.json());
+    const strangerConversations = await sql<{ count: string }[]>`
+      SELECT count(*)::text AS count FROM app.conversations
+      WHERE org_id = ${orgId} AND subject = 'Quote for a stranger'
+    `;
+    const composeStrangerRefused =
+      composeStranger.status === 400 &&
+      composeStrangerBody.success &&
+      composeStrangerBody.data.error === 'user_not_in_org' &&
+      strangerConversations[0]?.count === '0';
 
     // 6. Bulk reply: one visible + one ghost → partial failure.
     const bulkRes = await api('/bulk/reply', {
@@ -15326,12 +15372,13 @@ async function checkOutboundSendLane(
         composedOk &&
         composedConv[0]?.direction === 'outbound' &&
         composedConv[0]?.subject === 'Quote 7' &&
+        composeStrangerRefused &&
         bulkBody.success &&
         bulkBody.data.successCount === 1 &&
         bulkBody.data.failedCount === 1 &&
         drained &&
         finalSendCount === 4,
-      `reply=${replyRes.status} queued=${queuedRow?.deliveryState}/${String(queuedRow?.metadata?.sendContentType)} approval=${approvalAfterSend[0]?.status}/${approvalAfterSend[0]?.approvedBy === userId}, sent=${sentOk} extId=${sentRow?.externalMessageId} smtp[0]=${firstSend?.to}/${firstSend?.subject}/inReplyTo=${firstSend?.inReplyTo}, fail=${failedOk} err=${typeof failedRow?.metadata?.error} retry=${retryRes.status}/${retriedOk}/count=${retriedRow?.retryCount}, undo=${undoRes.status} draft=${undoBody.success ? undoBody.data.sourceMarkdown : 'ERR'} gone=${undoneRow === null} repeat=${undoRepeat.status}, discard=${discardRes.status} gone=${discardedRow === null}, compose=${composeRes.status}/${composedOk} conv=${composedConv[0]?.direction}/${composedConv[0]?.subject}, bulk=${bulkBody.success ? `${bulkBody.data.successCount}/${bulkBody.data.failedCount}` : 'ERR'}, drained=${drained} smtpTotal=${finalSendCount} (want 4)`,
+      `reply=${replyRes.status} queued=${queuedRow?.deliveryState}/${String(queuedRow?.metadata?.sendContentType)} approval=${approvalAfterSend[0]?.status}/${approvalAfterSend[0]?.approvedBy === userId}, sent=${sentOk} extId=${sentRow?.externalMessageId} smtp[0]=${firstSend?.to}/${firstSend?.subject}/inReplyTo=${firstSend?.inReplyTo}, fail=${failedOk} err=${typeof failedRow?.metadata?.error} retry=${retryRes.status}/${retriedOk}/count=${retriedRow?.retryCount}, undo=${undoRes.status} draft=${undoBody.success ? undoBody.data.sourceMarkdown : 'ERR'} gone=${undoneRow === null} repeat=${undoRepeat.status}, discard=${discardRes.status} gone=${discardedRow === null}, compose=${composeRes.status}/${composedOk} conv=${composedConv[0]?.direction}/${composedConv[0]?.subject} strangerRefused=${composeStrangerRefused} (${composeStranger.status}), bulk=${bulkBody.success ? `${bulkBody.data.successCount}/${bulkBody.data.failedCount}` : 'ERR'}, drained=${drained} smtpTotal=${finalSendCount} (want 4)`,
     );
   } finally {
     setMailTransportForTesting(DEFAULT_MAIL_FAKE);

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -14265,9 +14265,9 @@ async function checkConnectorCredentials(
 async function checkConversations(
   sql: Sql,
   base: string,
-  ctx: { cookie: string; orgId: string },
+  ctx: { cookie: string; orgId: string; userId: string },
 ): Promise<void> {
-  const { cookie, orgId } = ctx;
+  const { cookie, orgId, userId } = ctx;
   const api = (
     route: string,
     init: { method?: string; body?: unknown } = {},
@@ -14641,6 +14641,51 @@ async function checkConversations(
   `;
   await api('/bulk/reopen', { body: { conversationIds: [conversationId] } });
 
+  // The PATCH door (the app's single close/spam buttons) writes the SAME
+  // resolution record the bulk verb writes, and a metadata patch merges onto
+  // the stored object instead of wiping unread/routing state.
+  await sql`
+    UPDATE app.conversations
+    SET metadata = coalesce(metadata, '{}'::jsonb)
+      || '{"unread_count": 3, "routing": "desk"}'::jsonb
+    WHERE id = ${conversationId}
+  `;
+  const patchClose = await api(`/${conversationId}`, {
+    method: 'PATCH',
+    body: { status: 'closed' },
+  });
+  const patchMeta = await api(`/${conversationId}`, {
+    method: 'PATCH',
+    body: { metadata: { priority_note: 'VIP' } },
+  });
+  const patchedRow = await sql<
+    { status: string | null; metadata: Record<string, unknown> | null }[]
+  >`
+    SELECT status, metadata FROM app.conversations WHERE id = ${conversationId}
+  `;
+  const patched = patchedRow[0];
+  const patchKeepsRecord =
+    patchClose.status === 200 &&
+    patchMeta.status === 200 &&
+    patched?.status === 'closed' &&
+    patched.metadata?.resolved_by === userId &&
+    typeof patched.metadata?.resolved_at === 'string' &&
+    patched.metadata?.unread_count === 3 &&
+    patched.metadata?.routing === 'desk' &&
+    patched.metadata?.priority_note === 'VIP';
+  // Junk in one row's unread_count must not 500 the org's count tiles.
+  await sql`
+    UPDATE app.conversations
+    SET metadata = coalesce(metadata, '{}'::jsonb)
+      || '{"unread_count": "many"}'::jsonb
+    WHERE id = ${conversationId}
+  `;
+  const countsWithJunk = await api('/counts');
+  await api(`/${conversationId}`, {
+    method: 'PATCH',
+    body: { status: 'open' },
+  });
+
   // Delete cascades the messages.
   const deleted = await api(`/${conversationId}`, { method: 'DELETE' });
   const remnants = await sql<{ count: string }[]>`
@@ -14672,9 +14717,11 @@ async function checkConversations(
       closed.data.successCount === 1 &&
       closedRow[0]?.status === 'closed' &&
       closedRow[0]?.resolvedBy !== null &&
+      patchKeepsRecord &&
+      countsWithJunk.status === 200 &&
       deleted.status === 204 &&
       remnants[0]?.count === '0',
-    `listed=${row !== undefined} unread=${row?.unread} preview=${row?.lastMessagePreview === 'Where is my order?'} contact=${row?.contact?.email}, counts=${counts.success ? `${counts.data.byStatus.open ?? 0}/${counts.data.unread}` : 'ERR'}, memberHidden=${hiddenBefore}→assigned visible=${visibleAfter} bell=${assignBell[0]?.count}, strangerRefused=${strangerRefused} (${strangerAssign.status}/${strangerBody.success ? strangerBody.data.error : 'ERR'}), teamSees=${teammateSees} teamBell=${teamBell[0]?.count}, noteKeepsUnread=${unreadStillOne} readClears=${afterRead.success && afterRead.data.conversation.metadata?.unread_count === 0}, close=${closed.success ? closed.data.successCount : 'ERR'} status=${closedRow[0]?.status}/${closedRow[0]?.resolvedBy !== null}, del=${deleted.status} remnants=${remnants[0]?.count}`,
+    `listed=${row !== undefined} unread=${row?.unread} preview=${row?.lastMessagePreview === 'Where is my order?'} contact=${row?.contact?.email}, counts=${counts.success ? `${counts.data.byStatus.open ?? 0}/${counts.data.unread}` : 'ERR'}, memberHidden=${hiddenBefore}→assigned visible=${visibleAfter} bell=${assignBell[0]?.count}, strangerRefused=${strangerRefused} (${strangerAssign.status}/${strangerBody.success ? strangerBody.data.error : 'ERR'}), teamSees=${teammateSees} teamBell=${teamBell[0]?.count}, noteKeepsUnread=${unreadStillOne} readClears=${afterRead.success && afterRead.data.conversation.metadata?.unread_count === 0}, close=${closed.success ? closed.data.successCount : 'ERR'} status=${closedRow[0]?.status}/${closedRow[0]?.resolvedBy !== null}, patchClose=${patchClose.status}/${patchMeta.status} record=${patchKeepsRecord} (resolved_by=${patched?.metadata?.resolved_by === userId} unread=${String(patched?.metadata?.unread_count)} note=${String(patched?.metadata?.priority_note)}) countsWithJunk=${countsWithJunk.status}, del=${deleted.status} remnants=${remnants[0]?.count}`,
   );
 }
 

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -15231,6 +15231,47 @@ async function checkOutboundSendLane(
     const failedRow = await messageRow(failId);
     failMode = false;
 
+    // A member who cannot open the conversation (unassigned = admin triage)
+    // gets the opaque 404 from retry and discard, and the row is untouched —
+    // holding a messageId is not a licence to act on a colleague's mail.
+    const memberSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: base },
+      body: JSON.stringify({
+        email: `send-lane-member-${Date.now().toString(36)}@example.com`,
+        password: 'itest-password-1',
+        name: 'Send Lane Member',
+      }),
+    });
+    const memberCookie = cookieHeaderFrom(memberSignUp);
+    const memberBody = z
+      .object({ user: z.object({ id: z.string() }) })
+      .safeParse(await memberSignUp.json());
+    const memberId = memberBody.success ? memberBody.data.user.id : '';
+    await sql`
+      INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                            "createdAt")
+      VALUES (gen_random_uuid(), ${orgId}, ${memberId}, 'member',
+              ${new Date()})
+    `;
+    const asMember = (route: string): Promise<Response> =>
+      fetch(`${base}/api/app/conversations${route}?orgId=${orgId}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: memberCookie,
+          origin: base,
+        },
+        body: '{}',
+      });
+    const memberRetry = await asMember(`/messages/${failId}/retry`);
+    const memberDiscard = await asMember(`/messages/${failId}/discard`);
+    const afterMemberDoors = await messageRow(failId);
+    const memberRetryDiscardRefused =
+      memberRetry.status === 404 &&
+      memberDiscard.status === 404 &&
+      afterMemberDoors?.deliveryState === 'failed';
+
     // …and retry (immediate, no undo window) re-delivers.
     const retryRes = await api(`/messages/${failId}/retry`, { body: {} });
     const retriedOk = await waitForState(failId, 'sent');
@@ -15245,6 +15286,11 @@ async function checkOutboundSendLane(
       .object({ messageId: z.string() })
       .safeParse(await undoTarget.json());
     const undoId = undoTargetBody.success ? undoTargetBody.data.messageId : '';
+    // The hidden-conversation member cannot recall the owner's queued reply.
+    const memberUndo = await asMember(`/messages/${undoId}/undo`);
+    const memberUndoRefused =
+      memberUndo.status === 404 &&
+      (await messageRow(undoId))?.deliveryState === 'queued';
     const undoRes = await api(`/messages/${undoId}/undo`, { body: {} });
     const undoBody = z
       .object({ sourceMarkdown: z.string().nullable() })
@@ -15361,6 +15407,8 @@ async function checkOutboundSendLane(
         retryRes.status === 200 &&
         retriedOk &&
         retriedRow?.retryCount === 1 &&
+        memberRetryDiscardRefused &&
+        memberUndoRefused &&
         undoRes.status === 200 &&
         undoBody.success &&
         undoBody.data.sourceMarkdown === 'Recall me.' &&
@@ -15378,7 +15426,7 @@ async function checkOutboundSendLane(
         bulkBody.data.failedCount === 1 &&
         drained &&
         finalSendCount === 4,
-      `reply=${replyRes.status} queued=${queuedRow?.deliveryState}/${String(queuedRow?.metadata?.sendContentType)} approval=${approvalAfterSend[0]?.status}/${approvalAfterSend[0]?.approvedBy === userId}, sent=${sentOk} extId=${sentRow?.externalMessageId} smtp[0]=${firstSend?.to}/${firstSend?.subject}/inReplyTo=${firstSend?.inReplyTo}, fail=${failedOk} err=${typeof failedRow?.metadata?.error} retry=${retryRes.status}/${retriedOk}/count=${retriedRow?.retryCount}, undo=${undoRes.status} draft=${undoBody.success ? undoBody.data.sourceMarkdown : 'ERR'} gone=${undoneRow === null} repeat=${undoRepeat.status}, discard=${discardRes.status} gone=${discardedRow === null}, compose=${composeRes.status}/${composedOk} conv=${composedConv[0]?.direction}/${composedConv[0]?.subject} strangerRefused=${composeStrangerRefused} (${composeStranger.status}), bulk=${bulkBody.success ? `${bulkBody.data.successCount}/${bulkBody.data.failedCount}` : 'ERR'}, drained=${drained} smtpTotal=${finalSendCount} (want 4)`,
+      `reply=${replyRes.status} queued=${queuedRow?.deliveryState}/${String(queuedRow?.metadata?.sendContentType)} approval=${approvalAfterSend[0]?.status}/${approvalAfterSend[0]?.approvedBy === userId}, sent=${sentOk} extId=${sentRow?.externalMessageId} smtp[0]=${firstSend?.to}/${firstSend?.subject}/inReplyTo=${firstSend?.inReplyTo}, fail=${failedOk} err=${typeof failedRow?.metadata?.error} retry=${retryRes.status}/${retriedOk}/count=${retriedRow?.retryCount}, memberDoors=${memberRetry.status}/${memberDiscard.status}/${memberUndo.status} (want 404s, row kept=${memberRetryDiscardRefused && memberUndoRefused}), undo=${undoRes.status} draft=${undoBody.success ? undoBody.data.sourceMarkdown : 'ERR'} gone=${undoneRow === null} repeat=${undoRepeat.status}, discard=${discardRes.status} gone=${discardedRow === null}, compose=${composeRes.status}/${composedOk} conv=${composedConv[0]?.direction}/${composedConv[0]?.subject} strangerRefused=${composeStrangerRefused} (${composeStranger.status}), bulk=${bulkBody.success ? `${bulkBody.data.successCount}/${bulkBody.data.failedCount}` : 'ERR'}, drained=${drained} smtpTotal=${finalSendCount} (want 4)`,
     );
   } finally {
     setMailTransportForTesting(DEFAULT_MAIL_FAKE);

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -15112,6 +15112,76 @@ async function checkUndatedMailIngest(
 }
 
 /**
+ * A heal that says it healed must have written. An IMAP credential whose
+ * public `config.fromAddress` mirror is missing (a pre-mirror row, or a config
+ * edit that dropped the hidden field) is healed by the mailbox sync from the
+ * login username — through the same `patchCredentialInternal` shim the
+ * watermark advance uses, which used to drop `config` on the floor while the
+ * sync logged "mirrored" every pass. Real credential, real decrypt, real row.
+ */
+async function checkImapFromAddressHeal(
+  sql: Sql,
+  ctx: { orgId: string },
+): Promise<void> {
+  const { orgId } = ctx;
+  const { runConnectorAction } =
+    await import('./domains/connectors/service.ts');
+  const defaults = await sql<{ id: string }[]>`
+    SELECT id FROM app.connector_credentials
+    WHERE org_id = ${orgId} AND connector_slug = 'imap-smtp'
+      AND is_default = true AND status = 'active'
+    LIMIT 1
+  `;
+  const credentialId = defaults[0]?.id ?? '';
+  // Drift the row: drop the mirror the create door wrote.
+  await sql`
+    UPDATE app.connector_credentials
+    SET config = coalesce(config, '{}'::jsonb) - 'fromAddress'
+    WHERE id = ${credentialId}
+  `;
+  const fromBefore = await sql<{ fromAddress: string | null }[]>`
+    SELECT config->>'fromAddress' AS "fromAddress"
+    FROM app.connector_credentials WHERE id = ${credentialId}
+  `;
+
+  // An empty mailbox: the pass has nothing to ingest, only the heal to run.
+  setMailTransportForTesting({
+    openImap: async () => ({
+      listMessages: async () => [],
+      getMessage: async () => null,
+      close: async () => {},
+    }),
+    openSmtp: async () => {
+      throw new Error('the heal check sends nothing');
+    },
+  });
+  try {
+    const synced = await runConnectorAction(sql, {
+      organizationId: orgId,
+      connector: 'conversation',
+      action: 'sync_mailbox',
+      input: { connectorSlug: 'imap-smtp', includeSent: false },
+      mode: 'live',
+      caller: { kind: 'system', reason: 'itest fromAddress heal' },
+    });
+    const fromAfter = await sql<{ fromAddress: string | null }[]>`
+      SELECT config->>'fromAddress' AS "fromAddress"
+      FROM app.connector_credentials WHERE id = ${credentialId}
+    `;
+    record(
+      'imap fromAddress heal persists through the credential shim',
+      credentialId !== '' &&
+        fromBefore[0]?.fromAddress === null &&
+        synced.status === 'ok' &&
+        fromAfter[0]?.fromAddress === 'inbox@door.test',
+      `credential=${credentialId !== ''} stripped=${fromBefore[0]?.fromAddress ?? 'null'} sync=${synced.status} healed=${fromAfter[0]?.fromAddress ?? 'null'} (want inbox@door.test)`,
+    );
+  } finally {
+    setMailTransportForTesting(DEFAULT_MAIL_FAKE);
+  }
+}
+
+/**
  * The outbound send surface over the connector door: a reply queues a row
  * and schedules the send one (shortened) undo window out; the worker's job
  * re-checks the row, delivers through the fake SMTP, and stamps the
@@ -31919,6 +31989,7 @@ async function main(): Promise<void> {
     await checkConversations(sql, baseUrl, authCtx);
     await checkMailboxSyncLane(sql, authCtx);
     await checkUndatedMailIngest(sql, authCtx);
+    await checkImapFromAddressHeal(sql, authCtx);
     await checkOutboundSendLane(sql, baseUrl, authCtx);
     await checkNotificationEmailSink(sql, authCtx);
     await checkChatConversationSearchLeg(sql, authCtx);


### PR DESCRIPTION
Six verified medium defects in the conversations domain (backend `core/conversations` + `domains/conversations`), each re-verified against `cac849775` before touching it. User-expectation lens: one malformed email cannot stop your inbox; you cannot assign a conversation to a non-member; undo/retry/discard respect visibility; closing keeps its resolution record; a heal that says it healed actually did; chat contact search is bounded.

## Per-finding outcome

| #   | Finding                                                                                                            | Outcome                                     | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| --- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Gmail message without a Date header wedges its mailbox sync permanently (`build_initial_message.ts:15`)            | **fixed** — cc1161540                       | `#3156` added `emailEpochMs` but only for the watermark tip; the three writers (`buildInitialMessage`, ingest `addMessageToConversation`, `updateMessage`) still stamped `new Date(...)` → NaN, the shim's `z.number()` rejected it, the credential's pass threw and its watermark froze. Writers now spread `emailStamps()` (absent, never NaN); both batch sorts and the attachment `receivedAt` read the same concept.                                                                                                                                                                                                                                                                                      |
| 2   | assignConversation accepts any userId — no org-membership check (`service.ts:704`)                                 | **fixed** — a19a2759d                       | One `assertAssignableMember` gate (active member row; a disabled seat is refused too) now fronts the assign door, compose (`resolveComposeAssignment`, admin-picked assignee), and address routing (its inline copy replaced). Unassign stays unchecked.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| 3   | Undo/retry/discard doors skip the conversation-visibility guard they document (`routes.ts:388`)                    | **fixed** — a489dd6a1                       | All three pass `loadMessageForViewer` before the service call, answering the same opaque 404 as the other doors.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| 4   | PATCH door diverges from bulk verbs: close loses resolution stamps, metadata wholesale-replaced (`service.ts:622`) | **fixed** — 421fa41d9                       | Shared `statusChangeStamps()` for PATCH and bulk; PATCH merges metadata onto the stored object; `countUnreadConversations` casts only JSON numbers (junk `unread_count` no longer 500s `/counts`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
| 5   | fromAddress heal is a silent no-op: shim discards the config patch (`shim.ts:598`)                                 | **fixed** — 53232b0f1 + d807a476c           | The shim now lands `config` via `patchCredentialConfigInternal`. The real-Postgres probe then exposed a **second gap** the review did not see: the heal runs the reused resolver, which decrypts `row.encryptedData`, and the conversations shim answered `resolveCredentialRefInternal` with an identity-only stub — the heal died on the missing envelope every pass (`heal failed … reading 'keyFingerprint'`). One shared `resolveCredentialRowForShim` now serves the full 0.4 row to both shims (the work-lane broker's inline mapping replaced). The heal is not obsolete post-#3156: it is the backfill for pre-mirror rows and config edits that drop the hidden field, as `connector.yml` documents. |
| 6   | Chat conversation search loads every contact in the org on each query (`search-chat.ts:74`)                        | **fixed** — 2e15edf47                       | Contact leg prefilters in SQL (`ILIKE ANY` over the surviving query tokens, `%`/`_`/`\` escaped — a superset of what the reused `'any'`-mode matcher keeps, which still narrows in JS), newest 500 candidates, no read for an all-function-word question.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
| –   | Attachment 'download' door is a fake-success no-op (`routes.ts:435`)                                               | **already-fixed**                           | `#3156` (780467480): the door answers `501 attachment_bytes_unavailable` honestly; `git log -S'attachment_bytes_unavailable'` → 780467480.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
| –   | Outbound email stuck 'queued' forever after a crashed send job (`send.ts:676`)                                     | **already-fixed**                           | `#3157` (49a922cbd): `recoverStuckConversationSends` + `watchdog.conversation_sends` schedule + `send.watchdog.test.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| –   | Chosen From address never applied to outbound mail (`send.ts:889`)                                                 | **still live — deferred, needs its own PR** | NOT fixed by #3156: `runSendMessageJob` still carries `payload.from` "for parity but not injected" (send.ts ~1007), `buildSendInput` has no `from`, the imap-smtp native sends `config.from`. Feature-sized (domain-validated From through `buildSendInput` + the imap-smtp native + `connector.yml`, or remove the compose sender picker and header claim); out of this batch's scope.                                                                                                                                                                                                                                                                                                                        |

## Tests

New/extended vitest (red on base, green on branch — proven by running the same files in a detached worktree at `cac849775`):

- `core/conversations/ingest/email_epoch.test.ts`, `build_initial_message.test.ts`, `create_conversation_from_email.test.ts` (undated batch through a shim-strict ctx) — base 11 failed / 12 passed.
- `domains/conversations/service.assign.test.ts`, `compose-assignment.test.ts` — base 7 failed / 8 passed.
- `domains/conversations/routes.test.ts` (hidden → 404, service never called) — base 3 failed / 7 passed.
- `domains/conversations/service.update.test.ts` — base 6 failed / 3 passed.
- `domains/conversations/shim.test.ts`, `domains/connector_credentials/service.shim-row.test.ts` — base 7 failed.
- `domains/conversations/search-chat.test.ts` — base 2 failed.

Real-Postgres probes added to `integration-check.ts`: `mail ingest: a message without a readable Date lands …` (raw Gmail shapes through the real shim), `imap fromAddress heal persists through the credential shim` (strip the mirror, one sync pass restores it), plus assertions folded into `conversations core` (non-member assign refused, PATCH close keeps unread/routing + records the resolver, junk `unread_count` leaves `/counts` at 200), `outbound send lane` (compose with a non-member assignee refused; a non-assigned member gets 404 from undo/retry/discard, rows untouched), and `chat conversations search leg` (LIKE metacharacter escaped).

## Verification

- `bun run --filter @tale/platform typecheck` → 0; `bun run --filter @tale/platform lint` → 0.
- vitest, conversations + credentials surfaces (`backend/core/conversations`, `backend/domains/conversations`, `backend/domains/connector_credentials`, `backend/core/connector_credentials`): 33 files / 226 tests green (+ 38 in the shim/row/sandbox-shim/sync files after the resolver fix).
- `backend:integration` on a throwaway `tale-db` + MinIO: **base** `cac849775` → 361/364; **branch** → 363/366 (two new probes, both passing). The three failures on both sides are environmental (`SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD is not set` in the task-agent / automation-agent lanes) and untouched by this batch.

## Notes / cross-class

- The From-address lane (above) is a still-live medium that needs its own PR.
- Dormant surface noted, not changed: the 0.4 `conversations/internal_mutations:updateConversations` shim handler still replaces metadata wholesale; nothing in `core/` calls it.
- No migrations, no locale strings (the new `user_not_in_org` refusal is a server code the UI does not map), no docs.
