### PR TITLE
fix(platform): shim the Map method pdfjs needs on Node

### DIFF
--- a/services/platform/backend/core/lib/knowledge/extraction/pdfjs_dom_polyfill.test.ts
+++ b/services/platform/backend/core/lib/knowledge/extraction/pdfjs_dom_polyfill.test.ts
@@ -61,3 +61,64 @@ describe('installPdfjsDomGlobals base64 codecs', () => {
     expect(new TextDecoder().decode(plaintext)).toBe('integration-secret');
   });
 });
+
+describe('installPdfjsDomGlobals Map.getOrInsertComputed', () => {
+  it('installs the method pdfjs calls on its Maps', () => {
+    // Its absence is what broke the operator-list read per page (#3018).
+    installPdfjsDomGlobals();
+    expect(typeof Map.prototype.getOrInsertComputed).toBe('function');
+  });
+
+  it('computes and inserts when the key is absent', () => {
+    installPdfjsDomGlobals();
+    const map = new Map<string, number>();
+    const calls: string[] = [];
+    const value = map.getOrInsertComputed('a', (key) => {
+      calls.push(key);
+      return 1;
+    });
+    expect(value).toBe(1);
+    expect(map.get('a')).toBe(1);
+    expect(calls).toEqual(['a']);
+  });
+
+  it('returns the existing value without calling the callback', () => {
+    // pdfjs relies on this: the callback builds an intent state, and calling
+    // it twice would discard the one already in flight.
+    installPdfjsDomGlobals();
+    const map = new Map<string, number>([['a', 1]]);
+    let called = false;
+    const value = map.getOrInsertComputed('a', () => {
+      called = true;
+      return 2;
+    });
+    expect(value).toBe(1);
+    expect(called).toBe(false);
+  });
+
+  it('stores a value the callback returns even when it is undefined', () => {
+    // Presence, not truthiness: a second call must not recompute.
+    installPdfjsDomGlobals();
+    const map = new Map<string, undefined>();
+    map.getOrInsertComputed('a', () => undefined);
+    expect(map.has('a')).toBe(true);
+    let recomputed = false;
+    map.getOrInsertComputed('a', () => {
+      recomputed = true;
+      return undefined;
+    });
+    expect(recomputed).toBe(false);
+  });
+
+  it('refuses a callback that is not callable', () => {
+    installPdfjsDomGlobals();
+    const map = new Map<string, number>();
+    expect(() =>
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the guard exists for callers without types
+      map.getOrInsertComputed(
+        'a',
+        undefined as unknown as (k: string) => number,
+      ),
+    ).toThrow(TypeError);
+  });
+});

--- a/services/platform/backend/core/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
+++ b/services/platform/backend/core/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
@@ -1,8 +1,8 @@
 'use node';
 
 /**
- * Pure-JS DOM-global polyfills for running pdfjs-dist in the Convex node
- * action runtime.
+ * Pure-JS DOM-global polyfills, plus the ES2025 shims pdfjs expects, for
+ * running pdfjs-dist on the backend's Node worker.
  *
  * pdfjs 5.x's Node setup polyfills `DOMMatrix` / `ImageData` / `Path2D` by
  * `require("@napi-rs/canvas")` — a NATIVE module. Convex extracts a bundled
@@ -319,6 +319,37 @@ function ensureEs2025Shims(): void {
     Object.defineProperty(Promise, 'try', {
       value: (fn: (...args: unknown[]) => unknown, ...args: unknown[]) =>
         new Promise((resolve) => resolve(fn(...args))),
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  // pdfjs 5.x calls this on plain Maps in both the main and worker builds
+  // (`_intentStates`, `methodPromises`, `objs`, …). Node 22 lacks it, and the
+  // failure is quiet: the operator-list read throws once per page, and that is
+  // the path that finds embedded images and decides "scanned page → OCR". Text
+  // extraction still runs, so a digital PDF looks fine while a scanned one
+  // indexes thin or empty with only a warning to say so (#3018).
+  //
+  // Spec shape: return the existing value when the key is present; otherwise
+  // compute, insert, and return. Presence, not truthiness — a callback that
+  // returns `undefined` still counts, so a second call does not recompute.
+  // `set` runs after the callback, as the proposal does: the callback may have
+  // inserted the key itself, and the computed value wins.
+  if (typeof Map.prototype.getOrInsertComputed !== 'function') {
+    // oxlint-disable-next-line no-extend-native -- deliberate spec-shaped polyfill of an ES2025 method Node 22 lacks; guarded so a real runtime implementation wins
+    Object.defineProperty(Map.prototype, 'getOrInsertComputed', {
+      value: function <K, V>(this: Map<K, V>, key: K, callbackfn: (k: K) => V) {
+        if (typeof callbackfn !== 'function') {
+          throw new TypeError(
+            'Map.prototype.getOrInsertComputed: callback is not a function',
+          );
+        }
+        if (this.has(key)) return this.get(key);
+        const value = callbackfn(key);
+        this.set(key, value);
+        return value;
+      },
       writable: true,
       configurable: true,
     });


### PR DESCRIPTION
Scanned PDFs index thin or empty because image detection never runs.

Closes #3018. Supersedes #3103, whose two files #3125 deleted.

## Why

pdfjs 5.x calls `Map.prototype.getOrInsertComputed` on its own Maps in both the main and worker builds. Node 22 does not ship it:

```
$ node -e 'console.log(typeof Map.prototype.getOrInsertComputed)'
undefined
```

So the operator-list read throws once per page — and that read is the path that finds embedded images and decides a page is scanned and needs OCR. Text extraction uses a different call and still runs, which is why the damage hides: an ordinary digital PDF indexes fine and only produces log noise, while a scanned one indexes with almost nothing and a warning nobody reads.

## What changed

The shim goes in `ensureEs2025Shims`, beside the `Promise.try` and base64-codec fills that already exist for the same reason and use the same `typeof` guard plus `defineProperty` idiom. `lib.esnext` declares the method, so no local type declaration is needed — the same reason the neighbouring fills need none.

Spec shape: return the existing value when the key is present, otherwise compute, insert, and return. Presence rather than truthiness, so a callback returning `undefined` still counts and a second call does not recompute. `set` runs after the callback, as the proposal does, because the callback may have inserted the key itself and the computed value wins.

Also corrects the module docstring, which still described the Convex node action runtime that no longer exists.

## Tests

Five assertions on the shim: it installs, it computes-and-inserts, it does **not** call the callback when the key is present (pdfjs depends on that — the callback builds an intent state, and calling it twice would discard the one in flight), it stores an `undefined` result, and it refuses a non-callable callback.

Mutation: with the shim deleted, 4 of the 7 assertions in the file go red.

Worth stating because it nearly made the test worthless — **Bun ships this method natively and Node does not**. The suite runs under Node, which is also the shipping runtime, so the test exercises the real gap. Had it run under Bun it would have passed against the native implementation and proven nothing.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `lint:sast` green; branched from `origin/main` at `5f9dc6eb2`.
