### PR TITLE
fix(platform): say when an email attachment is no longer available

### DIFF
--- a/services/platform/app/features/conversations/components/message.test.tsx
+++ b/services/platform/app/features/conversations/components/message.test.tsx
@@ -270,4 +270,51 @@ describe('Message — attachment list vs inline images', () => {
     );
     expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
   });
+
+  it('says the file is no longer available instead of its size', () => {
+    // The size reads as a promise the message cannot keep.
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ unavailable: true, url: undefined })],
+        })}
+      />,
+    );
+    expect(screen.getByText('attachment.unavailable')).toBeInTheDocument();
+    expect(screen.queryByText(/23,359|22\.8/)).not.toBeInTheDocument();
+  });
+
+  it('offers no download for an attachment whose bytes are gone', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ unavailable: true, url: undefined })],
+        })}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /attachment\.download CV\.pdf/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still shows the size and a download for an attachment that is there', () => {
+    // The other half of the pair: a flag that hid every attachment would
+    // pass the two cases above on its own.
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment()],
+        })}
+      />,
+    );
+    expect(
+      screen.queryByText('attachment.unavailable'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /attachment\.download CV\.pdf/ }),
+    ).toBeInTheDocument();
+  });
 });

--- a/services/platform/app/features/conversations/components/message.tsx
+++ b/services/platform/app/features/conversations/components/message.tsx
@@ -118,6 +118,7 @@ interface AttachmentCardProps {
     size: number;
     storageId?: string;
     url?: string;
+    unavailable?: boolean;
   };
 }
 
@@ -149,7 +150,11 @@ function AttachmentCard({ attachment }: AttachmentCardProps) {
     <AttachmentFileChip
       fileName={attachment.filename}
       contentType={attachment.contentType}
-      detail={formatFileSize(attachment.size)}
+      detail={
+        attachment.unavailable
+          ? t('attachment.unavailable')
+          : formatFileSize(attachment.size)
+      }
       trailing={trailing}
     />
   );

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -13,7 +13,7 @@ import {
   notifyConversationAssignedTeam,
 } from '../collab/service.ts';
 import { emitEvent } from '../events/emit.ts';
-import { getFileUrl } from '../files/service.ts';
+import { getFileUrl, statOrgBlob } from '../files/service.ts';
 import { assertNotHeld } from '../legal_holds/service.ts';
 
 /**
@@ -986,6 +986,30 @@ export async function presignMessageAttachments(
               { organizationId },
               raw.storageId,
             );
+            // Presigning does NOT prove the object is there — it signs a
+            // path. Without this the message keeps offering a download that
+            // fails with a browser error and no explanation, which is what
+            // #3017 saw after a recovery re-imported the database without
+            // file storage.
+            //
+            // A probe that THROWS is not evidence of absence (unreachable
+            // store, unresolved org), so it fails open and the attachment is
+            // offered as before. Only a definite `null` marks it.
+            let gone = false;
+            try {
+              gone =
+                (await statOrgBlob(sql, organizationId, raw.storageId)) ===
+                null;
+            } catch (error) {
+              console.warn(
+                `[conversations] attachment presence probe failed for ${raw.storageId}, offering it anyway:`,
+                error,
+              );
+            }
+            if (gone) {
+              const { url: _unreachable, ...rest } = raw;
+              return { ...rest, unavailable: true };
+            }
             return { ...raw, url };
           } catch (error) {
             console.warn(

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -14873,6 +14873,10 @@ async function checkConversations(
   // ── A bytesless attachment (Gmail/Outlook chips the connector never fetched)
   // must offer NO download affordance — the detail projection presigns a URL
   // only from a stored storageId, so a metadata-only chip carries none.
+  const attSlugRows = await sql<{ slug: string }[]>`
+    SELECT "slug" FROM "organization" WHERE "id" = ${orgId} LIMIT 1
+  `;
+  const attOrgSlug = attSlugRows[0]?.slug ?? '';
   await sql`
     INSERT INTO app.conversation_messages (
       org_id, conversation_id, channel, direction, external_message_id,
@@ -14891,10 +14895,23 @@ async function checkConversations(
             contentType: 'image/jpeg',
             size: 0,
           },
+          // A ref whose blob is NOT in the store. Presigning signs a path and
+          // succeeds anyway, so without a presence probe the message keeps
+          // offering a download that 404s (#3017).
+          {
+            id: 'att-gone',
+            filename: 'gone.pdf',
+            contentType: 'application/pdf',
+            size: 23_359,
+            storageId: `s3:${attOrgSlug}/att-gone-never-uploaded.pdf`,
+          },
         ],
       })}, ${Date.now()}
     )
   `;
+  // The ref has to be org-scoped or `requireOrgScopedKey` refuses it before
+  // any presence probe runs — which is how the first draft of this check
+  // passed for the wrong reason.
   const attDetail = z
     .object({
       item: z
@@ -14913,18 +14930,31 @@ async function checkConversations(
     })
     .loose()
     .safeParse(await (await api(`/${conversationId}`)).json());
-  const bytelessChip = attDetail.success
-    ? attDetail.data.item.messages
-        .flatMap((message) => message.attachments ?? [])
-        .find((attachment) => attachment.id === 'att-nobytes')
-    : undefined;
+  const attChips = attDetail.success
+    ? attDetail.data.item.messages.flatMap(
+        (message) => message.attachments ?? [],
+      )
+    : [];
+  const bytelessChip = attChips.find(
+    (attachment) => attachment.id === 'att-nobytes',
+  );
+  // Only assertable with a store to probe: `statOrgBlob` throws without one,
+  // and that failure deliberately fails OPEN — a store it cannot reach is not
+  // evidence the blob is gone.
+  const goneChip = attChips.find((attachment) => attachment.id === 'att-gone');
+  const goneMarked =
+    !process.env.ITEST_S3_ENDPOINT ||
+    (goneChip !== undefined &&
+      goneChip.unavailable === true &&
+      !('url' in goneChip));
   record(
-    'conversations: connectorName filters the Inbox, and a bytesless attachment offers no download',
+    'conversations: connectorName filters the Inbox; a bytesless and a vanished attachment both offer no download',
     matchedFilter.includes(conversationId) &&
       !wrongFilter.includes(conversationId) &&
       bytelessChip !== undefined &&
-      !('url' in bytelessChip),
-    `imapFilter=${matchedFilter.includes(conversationId)} gmailExcluded=${!wrongFilter.includes(conversationId)} bytelessChipNoUrl=${bytelessChip !== undefined && !('url' in bytelessChip)}`,
+      !('url' in bytelessChip) &&
+      goneMarked,
+    `imapFilter=${matchedFilter.includes(conversationId)} gmailExcluded=${!wrongFilter.includes(conversationId)} bytelessChipNoUrl=${bytelessChip !== undefined && !('url' in bytelessChip)} goneMarked=${goneMarked}${process.env.ITEST_S3_ENDPOINT ? ` (unavailableFlag=${goneChip?.unavailable === true} url=${goneChip !== undefined && 'url' in goneChip})` : ' (SKIPPED, no ITEST_S3_ENDPOINT)'}`,
   );
 
   const closed = z

--- a/services/platform/lib/shared/conversations/conversation-item.ts
+++ b/services/platform/lib/shared/conversations/conversation-item.ts
@@ -75,6 +75,9 @@ export interface ProjectedMessage {
     storageId?: string;
     url?: string;
     contentId?: string;
+    /** The bytes are gone, so this cannot be offered for download. Stamped at
+     *  read time from live storage; `url` is absent alongside it. */
+    unavailable?: boolean;
   }[];
 }
 
@@ -117,6 +120,7 @@ function projectConversationMessage(
           ...(typeof a.contentId === 'string'
             ? { contentId: a.contentId }
             : {}),
+          ...(a.unavailable === true ? { unavailable: true } : {}),
         }))
       : undefined;
   const deliveryState = message.deliveryState || 'sent';

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1835,6 +1835,7 @@ conversations:
     send: Nachricht senden
   attachment:
     download: Herunterladen
+    unavailable: Nicht mehr verfügbar
     attachments: '{count, plural, one {# Anhang} other {# Anhänge}}'
   panel:
     uploadFailed: Anhänge konnten nicht hochgeladen werden. Versuch es erneut.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1778,6 +1778,7 @@ conversations:
     send: Send message
   attachment:
     download: Download
+    unavailable: No longer available
     attachments: '{count, plural, one {# attachment} other {# attachments}}'
   panel:
     uploadFailed: Couldn't upload attachments. Try again.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1851,6 +1851,7 @@ conversations:
     send: Envoyer le message
   attachment:
     download: Télécharger
+    unavailable: Plus disponible
     attachments: '{count, plural, one {# pièce jointe} other {# pièces jointes}}'
   panel:
     uploadFailed: Échec du téléversement des pièces jointes. Merci de réessayer.


### PR DESCRIPTION
A message that advertises an attachment whose bytes are gone now says so, instead of offering a download that fails with a browser error and no explanation.

Closes #3017. Supersedes #3104, three of whose files #3125 deleted.

## Why

The read path already re-derives each attachment URL rather than trusting the one stored at ingest, and drops it when the presign fails. That is not enough: **presigning does not prove the object is there — it signs a path.** For a missing object the presign succeeds, so the chip went on showing a file size and a download button, and the failure surfaced as a browser error.

Seen on a deployment after a recovery cycle re-imported the database without file storage, so rows came back and blobs did not.

## What changed

The presence probe rides the presign loop that already walks every attachment, using the existing `statOrgBlob` — rather than a second pass over the same metadata, which would have been a divergent second copy of the same walk.

A probe that **throws** is not evidence of absence: an unreachable store, an unresolved org. Those fail open and the attachment is offered exactly as before. Only a definite miss marks it — `url` withheld, `unavailable` stamped, and the chip reads "No longer available" where the size was.

Withholding `url` alongside the flag means nothing downstream can offer the broken link even if it ignores the flag. The download button already keyed on the URL, so it disappears without a UI change.

`unavailable` is carried through the shared conversation projection the list and detail lanes both use, so the two cannot drift into different answers.

## Note on the original design

#3104 built a separate deduped pre-pass with a 60-blob cap and its own fail-open rule. That was the right shape against 0.4, where the check was a Convex storage read in a different place. On 0.5 the presign loop already does the per-attachment object-storage work, so the cap and the second walk are unnecessary — the probe is one call inside a loop that was already running.

## Tests

Three UI cases and one integration assertion, and the pairing matters: each asserts the negative **and** the positive, because a change that hid every attachment would pass the negatives alone.

| Mutation | Went red |
| --- | --- |
| the presence probe removed | `goneMarked=false (unavailableFlag=false)` |
| the chip's label reverted to the size | 1 of the 14 UI cases |

The integration fixture caught its own bug first, which is worth recording: the seeded ref was not org-scoped, so `requireOrgScopedKey` refused it and the presign threw before the probe ever ran. The assertion failed for the wrong reason and looked like a code defect. A comment in the fixture now names that.

Run against a real Postgres and MinIO: **367/373**, identical to a baseline run of unmodified `main` on the same box — the six failures are the object-store warm-bucket collision, two `yt-dlp`-dependent probes, and three agent-lane probes, all failing the same way without this diff. With the probe removed the count drops to 366, and the one extra failure is this assertion.

`@tale/ui` i18n suite 1173/1173, so the new key is present in all three locales.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `lint:sast` green; branched from `origin/main` at `5f9dc6eb2`.
