### PR TITLE
fix(platform): knowledge folder search, crawl revival, admin doors

### DIFF
--- a/services/platform/backend/core/knowledge/crawl.test.ts
+++ b/services/platform/backend/core/knowledge/crawl.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+
+import type { Sql } from 'postgres';
+import { describe, expect, it } from 'vitest';
+
+import {
+  admitUrls,
+  admitUrlsStatement,
+  registerUrlList,
+  reviveListedUrls,
+  URL_INSERT_BATCH,
+} from './crawl';
+
+/**
+ * A page that answered 404 once used to be gone for good: the crawler marked
+ * its row `deleted`, and every door that re-admits URLs — discovery, rendered
+ * links, the operator's own list — skipped rows that already existed. These
+ * tests pin the ONE admission statement all doors now speak and its revival
+ * semantics; the real-Postgres proof rides the integration check.
+ *
+ * The database is a recording double: what matters is which statements run
+ * and with which parameters, not that PostgreSQL executes them.
+ */
+
+interface FakeDb {
+  sql: Sql;
+  calls: { text: string; params: unknown[] }[];
+}
+
+function fakeDb(rowsPerCall: (text: string) => unknown[] = () => []): FakeDb {
+  const calls: { text: string; params: unknown[] }[] = [];
+  const unsafe = (text: string, params: unknown[] = []): Promise<unknown[]> => {
+    calls.push({ text, params });
+    return Promise.resolve(rowsPerCall(text));
+  };
+  const sql = { unsafe } as unknown as Sql;
+  return { sql, calls };
+}
+
+describe('admitUrlsStatement', () => {
+  it('numbers one placeholder per URL after the domain', () => {
+    const statement = admitUrlsStatement(3, false);
+    expect(statement).toContain("($1, $2, 'discovered', NOW(), FALSE)");
+    expect(statement).toContain("($1, $3, 'discovered', NOW(), FALSE)");
+    expect(statement).toContain("($1, $4, 'discovered', NOW(), FALSE)");
+    expect(statement).not.toContain('$5');
+  });
+
+  it('revives a deleted row to discovered with its failures cleared', () => {
+    const statement = admitUrlsStatement(1, false);
+    expect(statement).toContain('ON CONFLICT (domain, url) DO UPDATE');
+    expect(statement).toContain(
+      "status = CASE WHEN u.status = 'deleted' THEN 'discovered' ELSE u.status END",
+    );
+    expect(statement).toContain(
+      "fail_count = CASE WHEN u.status = 'deleted' THEN 0 ELSE u.fail_count END",
+    );
+    expect(statement).toContain("WHERE u.status = 'deleted'");
+    expect(statement).toContain('RETURNING u.url');
+  });
+
+  it('only ever widens the listed flag, and touches live rows for that alone', () => {
+    const statement = admitUrlsStatement(1, true);
+    expect(statement).toContain("($1, $2, 'discovered', NOW(), TRUE)");
+    expect(statement).toContain('listed = u.listed OR EXCLUDED.listed');
+    expect(statement).toContain('OR (EXCLUDED.listed AND NOT u.listed)');
+  });
+});
+
+describe('admitUrls', () => {
+  it('collapses duplicates — a multi-row upsert cannot touch one key twice', async () => {
+    const db = fakeDb();
+    await admitUrls(
+      db.sql,
+      'example.test',
+      ['https://example.test/a', 'https://example.test/a'],
+      { listed: false },
+    );
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0]?.params).toEqual([
+      'example.test',
+      'https://example.test/a',
+    ]);
+  });
+
+  it('batches at URL_INSERT_BATCH and sums what each batch admitted', async () => {
+    const db = fakeDb((text) =>
+      // Every batch reports two rows inserted or revived.
+      text.includes('INSERT') ? [{ url: 'x' }, { url: 'y' }] : [],
+    );
+    const urls = Array.from(
+      { length: URL_INSERT_BATCH + 1 },
+      (_, index) => `https://example.test/p${index}`,
+    );
+    const admitted = await admitUrls(db.sql, 'example.test', urls, {
+      listed: false,
+    });
+    expect(db.calls).toHaveLength(2);
+    expect(db.calls[0]?.params).toHaveLength(URL_INSERT_BATCH + 1);
+    expect(db.calls[1]?.params).toHaveLength(2);
+    expect(admitted).toBe(4);
+  });
+
+  it('issues nothing for an empty list', async () => {
+    const db = fakeDb();
+    expect(await admitUrls(db.sql, 'example.test', [], { listed: true })).toBe(
+      0,
+    );
+    expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('registerUrlList', () => {
+  it('admits the listed URLs through the shared door, marked listed', async () => {
+    const db = fakeDb();
+    await registerUrlList(
+      db.sql,
+      'acme',
+      'example.test',
+      ['https://example.test/a', 'https://example.test/b'],
+      3600,
+    );
+    const admit = db.calls.find((call) => call.text.includes('website_urls'));
+    expect(admit).toBeDefined();
+    expect(admit?.text).toBe(admitUrlsStatement(2, true));
+    expect(admit?.params).toEqual([
+      'example.test',
+      'https://example.test/a',
+      'https://example.test/b',
+    ]);
+  });
+});
+
+describe('reviveListedUrls', () => {
+  it('puts only the listed, deleted rows of the domain back on the frontier', async () => {
+    const db = fakeDb(() => [{ url: 'a' }, { url: 'b' }]);
+    const revived = await reviveListedUrls(db.sql, 'example.test');
+    expect(revived).toBe(2);
+    const call = db.calls[0];
+    expect(call?.text).toContain("SET status = 'discovered', fail_count = 0");
+    expect(call?.text).toContain(
+      "WHERE domain = $1 AND listed AND status = 'deleted'",
+    );
+    expect(call?.params).toEqual(['example.test']);
+  });
+});

--- a/services/platform/backend/core/knowledge/crawl.ts
+++ b/services/platform/backend/core/knowledge/crawl.ts
@@ -35,6 +35,87 @@ export const MAX_URLS_PER_DOMAIN = 10_000;
  * would turn a large discovery into thousands of round trips. */
 export const URL_INSERT_BATCH = 500;
 
+/**
+ * The ONE statement that admits URLs to a domain's frontier — discovery, the
+ * rendered-link admission, and operator URL lists all speak it, so a row
+ * behaves the same however it arrives.
+ *
+ * A new row starts `discovered`. A row a past scan marked `deleted` (the page
+ * answered 404/410 then) is REVIVED to `discovered` with its failure count
+ * cleared: the site links to it again, or the operator listed it again, and
+ * that is the only signal a restored page ever sends — nothing else moves a
+ * row out of `deleted`, which is how a deploy gap or a misconfigured origin
+ * used to drop a page from the index for good. A live row is left alone
+ * except `listed`, which only ever widens. `RETURNING url` names the rows the
+ * statement inserted or changed, so a caller can count what it newly tracks.
+ *
+ * `count` is how many URL placeholders follow the domain (`$2..$count+1`).
+ */
+export function admitUrlsStatement(count: number, listed: boolean): string {
+  const flag = listed ? 'TRUE' : 'FALSE';
+  const rows = Array.from(
+    { length: count },
+    (_, index) => `($1, $${index + 2}, 'discovered', NOW(), ${flag})`,
+  ).join(', ');
+  return `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_urls AS u (domain, url, status, discovered_at, listed)
+     VALUES ${rows}
+     ON CONFLICT (domain, url) DO UPDATE SET
+       status = CASE WHEN u.status = 'deleted' THEN 'discovered' ELSE u.status END,
+       fail_count = CASE WHEN u.status = 'deleted' THEN 0 ELSE u.fail_count END,
+       discovered_at = CASE WHEN u.status = 'deleted' THEN NOW() ELSE u.discovered_at END,
+       listed = u.listed OR EXCLUDED.listed
+     WHERE u.status = 'deleted' OR (EXCLUDED.listed AND NOT u.listed)
+     RETURNING u.url`;
+}
+
+/**
+ * Admit URLs to a domain's frontier (see {@link admitUrlsStatement}), in
+ * batches. Returns how many rows were newly tracked or changed — inserted,
+ * revived from `deleted`, or newly marked listed. Duplicates are collapsed
+ * first: a multi-row upsert cannot touch the same key twice.
+ */
+export async function admitUrls(
+  sql: Sql,
+  domain: string,
+  urls: readonly string[],
+  options: { listed: boolean },
+): Promise<number> {
+  const unique = [...new Set(urls)];
+  let admitted = 0;
+  for (let start = 0; start < unique.length; start += URL_INSERT_BATCH) {
+    const batch = unique.slice(start, start + URL_INSERT_BATCH);
+    const rows = await sql.unsafe<{ url: string }[]>(
+      admitUrlsStatement(batch.length, options.listed),
+      [domain, ...batch],
+    );
+    admitted += rows.length;
+  }
+  return admitted;
+}
+
+/**
+ * Put the operator's listed URLs that a past scan marked `deleted` back on
+ * the frontier. A URL list is a standing instruction — "index these" — so a
+ * listed page that once answered 404 is probed again on every scan; the
+ * scan interval is the backoff and one request per scan the bounded cost.
+ * Without this the list silently shrank: a page gone for one deploy never
+ * came back, and re-saving the identical list changed nothing. Returns how
+ * many rows were revived.
+ */
+export async function reviveListedUrls(
+  sql: Sql,
+  domain: string,
+): Promise<number> {
+  const rows = await sql.unsafe<{ url: string }[]>(
+    `UPDATE ${PUBLIC_WEB_SCHEMA}.website_urls
+        SET status = 'discovered', fail_count = 0, discovered_at = NOW()
+      WHERE domain = $1 AND listed AND status = 'deleted'
+      RETURNING url`,
+    [domain],
+  );
+  return rows.length;
+}
+
 /** Corpus → Convex status vocabulary. The corpus distinguishes `completed`
  * (a finished scan) from `active`; the websites row treats both as a healthy
  * scanned site. */
@@ -86,9 +167,11 @@ export async function registerDomain(
 /**
  * Register a curated URL list for an organization. The listed rows in
  * `website_urls` ARE the list — there is no separate list table. Idempotent
- * and merging: re-registering adds new URLs and re-marks existing ones as
- * listed. On a domain some org already crawls as a site, the row's kind
- * stays 'site' ('list' never narrows) and the URLs become extra seeds.
+ * and merging: re-registering adds new URLs, re-marks existing ones as
+ * listed, and revives any the crawler had marked `deleted` (an explicit
+ * re-listing is the operator saying the page is back). On a domain some org
+ * already crawls as a site, the row's kind stays 'site' ('list' never
+ * narrows) and the URLs become extra seeds.
  */
 export async function registerUrlList(
   sql: Sql,
@@ -119,18 +202,7 @@ export async function registerUrlList(
      ON CONFLICT (domain, org_slug) DO NOTHING`,
     [domain, orgSlug],
   );
-  for (let start = 0; start < admitted.length; start += URL_INSERT_BATCH) {
-    const batch = admitted.slice(start, start + URL_INSERT_BATCH);
-    const rows = batch
-      .map((_, index) => `($1, $${index + 2}, 'discovered', NOW(), TRUE)`)
-      .join(', ');
-    await sql.unsafe(
-      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_urls (domain, url, status, discovered_at, listed)
-       VALUES ${rows}
-       ON CONFLICT (domain, url) DO UPDATE SET listed = TRUE`,
-      [domain, ...batch],
-    );
-  }
+  await admitUrls(sql, domain, admitted, { listed: true });
 }
 
 /** Update the scan cadence on the domain row. */

--- a/services/platform/backend/core/knowledge/crawl_action.ts
+++ b/services/platform/backend/core/knowledge/crawl_action.ts
@@ -66,7 +66,7 @@ import { extractText } from '../lib/knowledge/extraction/router';
 import { renderUrlsInSandbox } from '../node_only/sandbox/render_fetch';
 import { isDueForScan } from '../websites/scan_scheduling';
 import { readOrgEmbeddingConfig } from './connection';
-import { MAX_URLS_PER_DOMAIN, URL_INSERT_BATCH } from './crawl';
+import { MAX_URLS_PER_DOMAIN, admitUrls, reviveListedUrls } from './crawl';
 import { pinDimensions } from './dimensions';
 import { Embedder, embedderForOrg, EmbeddingNotConfigured } from './embedding';
 import {
@@ -198,6 +198,15 @@ export async function scanWebsiteImpl(
         // next sync is at the link's end, so without this a rescan sits on
         // a stale Active/Idle row the whole first link.
         await fanOutRowSync(ctx, sql, args.domain);
+        // Listed URLs are a standing instruction: one a past scan marked
+        // `deleted` (404 then) goes back on the frontier every scan, so a
+        // page that is back is re-indexed instead of staying dark for good.
+        const revived = await reviveListedUrls(sql, args.domain);
+        if (revived > 0) {
+          console.log(
+            `[crawl] ${args.domain}: ${revived} listed URL(s) revived for re-probe`,
+          );
+        }
         // A URL list has no discovery: its operator-listed rows ARE the
         // frontier, and robots.txt does not govern explicitly requested
         // pages (the same stance web_fetch takes).
@@ -588,19 +597,10 @@ async function discoverAndRecordUrls(
     );
   }
 
-  const discovered = [...urls];
-  for (let start = 0; start < discovered.length; start += URL_INSERT_BATCH) {
-    const batch = discovered.slice(start, start + URL_INSERT_BATCH);
-    const rows = batch
-      .map((_, index) => `($1, $${index + 2}, 'discovered', NOW())`)
-      .join(', ');
-    await sql.unsafe(
-      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_urls (domain, url, status, discovered_at)
-       VALUES ${rows}
-       ON CONFLICT (domain, url) DO NOTHING`,
-      [domain, ...batch],
-    );
-  }
+  // The shared admission door: new rows start `discovered`, and a row a past
+  // scan marked `deleted` is revived — the site links to the page again, so
+  // the fetch (not the memory of a 404) decides whether it is back.
+  await admitUrls(sql, domain, [...urls], { listed: false });
   console.log(`[crawl] ${domain}: ${urls.size} URLs discovered`);
 }
 
@@ -839,14 +839,9 @@ async function admitRenderedLinks(
     }
     const normalized = normalizeCandidateUrl(href, baseUrl, hosts);
     if (!normalized) continue;
-    const inserted = await sql.unsafe<{ url: string }[]>(
-      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_urls (domain, url, status, discovered_at)
-       VALUES ($1, $2, 'discovered', NOW())
-       ON CONFLICT (domain, url) DO NOTHING
-       RETURNING url`,
-      [domain, normalized],
-    );
-    if (inserted.length > 0) tracked += 1;
+    // Inserted or revived rows are newly tracked (`deleted` rows are not in
+    // the count above); unchanged live rows report zero.
+    tracked += await admitUrls(sql, domain, [normalized], { listed: false });
   }
 }
 

--- a/services/platform/backend/core/knowledge/dimensions.test.ts
+++ b/services/platform/backend/core/knowledge/dimensions.test.ts
@@ -88,6 +88,9 @@ describe('pinning a fresh corpus', () => {
   });
 
   it('leaves nothing pinned when the corpus does not exist yet', async () => {
+    // No table, no ALTER — and therefore no pin on record: recording one
+    // here would make every later write skip the ALTER for the process
+    // lifetime, leaving the column untyped once the table appears.
     const missing = {
       unsafe: () =>
         Promise.reject(Object.assign(new Error('no table'), { code: '42P01' })),
@@ -99,7 +102,37 @@ describe('pinning a fresh corpus', () => {
       dimensions: 1536,
       context: 'organization "acme"',
     });
-    expect(pinnedDimensions('postgresql://empty')).toBe(1536);
+    expect(pinnedDimensions('postgresql://empty')).toBeUndefined();
+  });
+
+  it('pins once the corpus table appears after a missed first attempt', async () => {
+    // A knowledge database that migrates after the platform boots: the
+    // first write finds no table, the next one (same database) must still
+    // narrow the column and build the index rather than trust a stale memo.
+    const missing = {
+      unsafe: () =>
+        Promise.reject(Object.assign(new Error('no table'), { code: '42P01' })),
+    } as unknown as Sql;
+    await pinDimensions({
+      sql: missing,
+      dbUrl: 'postgresql://late',
+      schema: SCHEMA,
+      dimensions: 1536,
+      context: 'organization "acme"',
+    });
+    const db = fakeDb();
+    await pinDimensions({
+      sql: db.sql,
+      dbUrl: 'postgresql://late',
+      schema: SCHEMA,
+      dimensions: 1536,
+      context: 'organization "acme"',
+    });
+    expect(db.statements.join('\n')).toContain(
+      'ALTER COLUMN embedding TYPE vector(1536)',
+    );
+    expect(db.statements.join('\n')).toContain('create_chunks_hnsw_index');
+    expect(pinnedDimensions('postgresql://late')).toBe(1536);
   });
 
   it('accepts a corpus too wide to index, rather than refusing documents', async () => {

--- a/services/platform/backend/core/knowledge/dimensions.ts
+++ b/services/platform/backend/core/knowledge/dimensions.ts
@@ -112,7 +112,16 @@ export async function pinDimensions(args: {
   }
 
   const run = applyPin(args.sql, args.schema, args.dimensions)
-    .then(() => {
+    .then((applied) => {
+      if (!applied) {
+        // Nothing was pinned: the corpus table is not there yet (a knowledge
+        // database that migrates after the platform boots). Recording the
+        // pin anyway would make every later write skip the ALTER and the
+        // index build for the process lifetime — the column would stay an
+        // untyped `vector`, accepting any width, once the table appeared.
+        // Leave nothing recorded so the next write tries again.
+        return;
+      }
       pinned.set(args.dbUrl, args.dimensions);
       const schemas = appliedSchemas.get(args.dbUrl) ?? new Set<string>();
       schemas.add(args.schema);
@@ -163,12 +172,16 @@ export function pinnedDimensions(dbUrl: string): number | undefined {
   return pinned.get(dbUrl);
 }
 
-/** Narrow the vector columns and build the index. */
+/**
+ * Narrow the vector columns and build the index. Resolves `true` when the
+ * width now holds on `${schema}.chunks`, `false` when that table does not
+ * exist yet — the caller must not record a pin that never took effect.
+ */
 async function applyPin(
   sql: Sql,
   schema: string,
   dimensions: number,
-): Promise<void> {
+): Promise<boolean> {
   const expected = `vector(${dimensions})`;
   let current: string | null;
   try {
@@ -184,7 +197,7 @@ async function applyPin(
       logger.warn(
         `${schema}.chunks does not exist yet, so there is nothing to pin`,
       );
-      return;
+      return false;
     }
     throw err;
   }
@@ -239,4 +252,5 @@ async function applyPin(
       );
     }
   }
+  return true;
 }

--- a/services/platform/backend/domains/documents/agent-list.ts
+++ b/services/platform/backend/domains/documents/agent-list.ts
@@ -1,6 +1,6 @@
 import type { Sql } from 'postgres';
 
-import { MAX_FOLDER_DEPTH } from '../folders/paths.ts';
+import { MAX_FOLDER_DEPTH, normalizeFolderPath } from '../folders/paths.ts';
 
 /**
  * The agent-facing document listing — ONE helper behind two doors (the 0.4
@@ -9,10 +9,12 @@ import { MAX_FOLDER_DEPTH } from '../folders/paths.ts';
  * passes its pre-resolved scope verbatim. Hub visibility rules live here and
  * nowhere else.
  *
- * `folderPath` prefers the denormalized `documents.folder_path` (connector
- * docs carry their source path) and otherwise derives the breadcrumb from the
- * folder tree in-query — 0.4 walked parents in memory only because Convex
- * cannot join; Postgres does it with one recursive CTE.
+ * `folderPath` is the folder tree's breadcrumb when the document sits in a
+ * folder (fresh across renames — the denormalized `documents.folder_path` a
+ * connector stamped is not), else that stamped source path; spelled the
+ * canonical way (`normalizeFolderPath`) so an agent can hand it straight
+ * back as a knowledge-search `folder` filter. 0.4 walked parents in memory
+ * only because Convex cannot join; Postgres does it with one recursive CTE.
  */
 
 export interface AgentDocumentListArgs {
@@ -80,7 +82,7 @@ export async function listDocumentsForAgent(
         AND fp.depth < ${MAX_FOLDER_DEPTH + 2}
     )
     SELECT d.file_ref AS "fileId", d.title, d.extension,
-           coalesce(d.folder_path, fp.path) AS "folderPath",
+           coalesce(fp.path, d.folder_path) AS "folderPath",
            d.team_id AS "teamId", d.created_at_ms::float8 AS "createdAt",
            (d.metadata ->> 'size')::float8 AS "sizeBytes"
     FROM app.documents d
@@ -109,7 +111,7 @@ export async function listDocumentsForAgent(
       fileId: row.fileId,
       title: row.title ?? 'Untitled',
       extension: row.extension,
-      folderPath: row.folderPath,
+      folderPath: normalizeFolderPath(row.folderPath),
       teamId: row.teamId,
       createdAt: row.createdAt,
       sizeBytes: row.sizeBytes,

--- a/services/platform/backend/domains/documents/routes.ts
+++ b/services/platform/backend/domains/documents/routes.ts
@@ -49,7 +49,6 @@ import {
   listDocumentVersionsView,
   listHubDocumentsPaginated,
   listProjectDocuments,
-  loadDocumentOrThrow,
   retryRagIndexingForDocument,
   searchDocumentsForMention,
   searchDocumentsView,
@@ -142,21 +141,6 @@ export function createDocumentRoutes(deps: {
       },
       c.get('sessionBundle').user.email,
     );
-
-  /**
-   * Re-stamp a document's corpus rows with its CURRENT scope (team / project)
-   * after a scope-changing write committed — team change, project attach,
-   * project detach. Runs outside the transaction (it talks to the org's
-   * knowledge pool) and is best-effort by contract: a failure is logged
-   * inside, never surfaced as a failed write.
-   */
-  const resyncCorpusScope = async (
-    organizationId: string,
-    documentId: string,
-  ): Promise<void> => {
-    const doc = await loadDocumentOrThrow(deps.sql, documentId);
-    await syncRagDocumentScope(deps.sql, organizationId, doc);
-  };
 
   app.get('/', async (c) => {
     try {
@@ -505,10 +489,14 @@ export function createDocumentRoutes(deps: {
       const result = await transactSerializable(deps.sql, (tx) =>
         updateDocument(tx, auth, { documentId, ...body.data }),
       );
-      // A team change is a corpus SCOPE change — re-stamp retrieval filters
-      // without re-embedding.
-      if (result.teamScopeChanged && result.fileRef !== null) {
-        await resyncCorpusScope(auth.organizationId, documentId);
+      // A team change or a folder move is a corpus FILTER change — re-stamp
+      // retrieval filters without re-embedding. Best-effort by contract
+      // (logged inside).
+      if (
+        (result.teamScopeChanged || result.folderChanged) &&
+        result.fileRef !== null
+      ) {
+        await syncRagDocumentScope(deps.sql, auth.organizationId, documentId);
       }
       return c.json({ ok: true });
     } catch (error) {
@@ -703,7 +691,7 @@ export function createDocumentRoutes(deps: {
       // file keeps answering org-wide retrieval from inside a restricted
       // project.
       if (attached.fileRef !== null) {
-        await resyncCorpusScope(auth.organizationId, documentId);
+        await syncRagDocumentScope(deps.sql, auth.organizationId, documentId);
       }
       return c.json({ ok: true });
     } catch (error) {
@@ -721,7 +709,7 @@ export function createDocumentRoutes(deps: {
       // Back to the org-wide library: drop the old project's scope from the
       // corpus rows, or the document silently vanishes from hub retrieval.
       if (detached.fileRef !== null) {
-        await resyncCorpusScope(auth.organizationId, documentId);
+        await syncRagDocumentScope(deps.sql, auth.organizationId, documentId);
       }
       return c.json({ ok: true });
     } catch (error) {

--- a/services/platform/backend/domains/documents/service.ts
+++ b/services/platform/backend/domains/documents/service.ts
@@ -504,7 +504,11 @@ export async function updateDocument(
     extension?: string | null;
     sourceProvider?: string | null;
   },
-): Promise<{ teamScopeChanged: boolean; fileRef: string | null }> {
+): Promise<{
+  teamScopeChanged: boolean;
+  folderChanged: boolean;
+  fileRef: string | null;
+}> {
   const doc = await requireDocumentWriteAccess(tx, auth, args.documentId);
   // Content-freeze guard (core/documents/access.ts doctrine): the bytes and
   // their identity fields move ONLY while uncontrolled — renames, folder
@@ -589,6 +593,9 @@ export async function updateDocument(
     teamId !== doc.teamId ||
     teamTags.length !== doc.teamTags.length ||
     teamTags.some((tag, index) => tag !== doc.teamTags[index]);
+  // A folder move is a corpus FILTER change too (folder-scoped search
+  // matches the stamped path) — the caller re-stamps after commit.
+  const folderChanged = folderId !== doc.folderId;
 
   await tx`
     UPDATE app.documents SET
@@ -607,7 +614,7 @@ export async function updateDocument(
     entity: 'document',
     entityId: args.documentId,
   });
-  return { teamScopeChanged, fileRef: doc.fileRef };
+  return { teamScopeChanged, folderChanged, fileRef: doc.fileRef };
 }
 
 /** Soft trash / restore. Hard delete + blob erasure land with governance. */

--- a/services/platform/backend/domains/folders/paths.test.ts
+++ b/services/platform/backend/domains/folders/paths.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { documentFolderPathFrom, normalizeFolderPath } from './paths.ts';
+
+/**
+ * The canonical folder-path spelling every path-comparing surface agrees on
+ * — the knowledge folder filter, the corpus stamp it matches against, and the
+ * agent-facing listing that hands the path back as a filter. Two spellings
+ * reach the database (WebDAV's 0.4 `'/A/B'`, the tree's `'A/B'`); neither may
+ * decide whether a document is found.
+ */
+describe('normalizeFolderPath', () => {
+  it('strips leading and trailing slashes and collapses runs', () => {
+    expect(normalizeFolderPath('/Reports/2025/')).toBe('Reports/2025');
+    expect(normalizeFolderPath('Reports//2025')).toBe('Reports/2025');
+    expect(normalizeFolderPath('Reports')).toBe('Reports');
+  });
+
+  it('trims segment whitespace', () => {
+    expect(normalizeFolderPath(' Reports / 2025 ')).toBe('Reports/2025');
+  });
+
+  it('reads the root and nothing as null', () => {
+    expect(normalizeFolderPath('/')).toBeNull();
+    expect(normalizeFolderPath('')).toBeNull();
+    expect(normalizeFolderPath('   ')).toBeNull();
+    expect(normalizeFolderPath(null)).toBeNull();
+    expect(normalizeFolderPath(undefined)).toBeNull();
+  });
+});
+
+describe('documentFolderPathFrom', () => {
+  const tree = new Map([['f1', 'Reports/2025']]);
+
+  it('prefers the folder tree — it stays fresh across renames and moves', () => {
+    expect(
+      documentFolderPathFrom({ folderId: 'f1', folderPath: '/Old/Name' }, tree),
+    ).toBe('Reports/2025');
+  });
+
+  it('falls back to the stamped source path for a document without a hub folder', () => {
+    expect(
+      documentFolderPathFrom(
+        { folderId: null, folderPath: '/Shared/Docs' },
+        tree,
+      ),
+    ).toBe('Shared/Docs');
+    // A folder id the tree does not know (foreign, or gone) falls back too.
+    expect(
+      documentFolderPathFrom({ folderId: 'missing', folderPath: 'X' }, tree),
+    ).toBe('X');
+  });
+
+  it('is null for a root document', () => {
+    expect(
+      documentFolderPathFrom({ folderId: null, folderPath: null }, tree),
+    ).toBe(null);
+  });
+});

--- a/services/platform/backend/domains/folders/paths.ts
+++ b/services/platform/backend/domains/folders/paths.ts
@@ -221,6 +221,137 @@ export async function reapEmptyAncestorFolders(
   }
 }
 
+/**
+ * The canonical spelling of a document's folder path — segment names joined
+ * by `/`, no leading or trailing slash, `null` for the root. Two spellings
+ * reach the database today: the WebDAV lane stores the 0.4 `'/A/B'`, the
+ * folder tree and the sync engines produce `'A/B'`. Everything that COMPARES
+ * paths (the knowledge folder filter and the corpus stamp it matches against)
+ * normalizes through here first, so spelling can never decide whether a
+ * document is found.
+ */
+export function normalizeFolderPath(
+  raw: string | null | undefined,
+): string | null {
+  if (raw === null || raw === undefined) return null;
+  const segments = raw
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  return segments.length > 0 ? segments.join('/') : null;
+}
+
+/**
+ * Root-to-leaf paths for a set of folders in ONE recursive read, keyed by
+ * folder id. The tree is the truth for where a folder sits — a rename or a
+ * move anywhere above is reflected immediately, which no denormalized copy
+ * can promise. Any folder of the organization, hub or project; a missing or
+ * foreign id has no entry.
+ */
+export async function folderTreePaths(
+  db: Sql | TransactionSql,
+  organizationId: string,
+  folderIds: readonly string[],
+): Promise<Map<string, string>> {
+  const unique = [...new Set(folderIds)];
+  if (unique.length === 0) return new Map();
+  const rows = await db<{ folderId: string; path: string }[]>`
+    WITH RECURSIVE chain AS (
+      SELECT f.id AS start_id, f.parent_id, f.name, 1 AS depth
+      FROM app.folders f
+      WHERE f.org_id = ${organizationId} AND f.id = ANY(${unique})
+      UNION ALL
+      SELECT chain.start_id, f.parent_id, f.name, chain.depth + 1
+      FROM app.folders f
+      JOIN chain ON f.id = chain.parent_id
+      WHERE f.org_id = ${organizationId}
+        AND chain.depth < ${MAX_FOLDER_DEPTH + 2}
+    )
+    SELECT start_id AS "folderId",
+           string_agg(name, '/' ORDER BY depth DESC) AS path
+    FROM chain
+    GROUP BY start_id
+  `;
+  return new Map(rows.map((row) => [row.folderId, row.path]));
+}
+
+/**
+ * Where a document is filed, in canonical spelling, from an already-loaded
+ * tree lookup: the folder tree when the document sits in a folder (fresh
+ * across renames and moves), else the denormalized `documents.folder_path` a
+ * connector stamped on a document without a hub folder, else `null` (root,
+ * or unfiled). The ONE rule every path-comparing surface applies.
+ */
+export function documentFolderPathFrom(
+  doc: { folderId: string | null; folderPath: string | null },
+  treePaths: ReadonlyMap<string, string>,
+): string | null {
+  const treePath =
+    doc.folderId !== null ? treePaths.get(doc.folderId) : undefined;
+  return normalizeFolderPath(treePath ?? doc.folderPath);
+}
+
+/** {@link documentFolderPathFrom} for one document, reading the tree. */
+export async function resolveDocumentFolderPath(
+  db: Sql | TransactionSql,
+  organizationId: string,
+  doc: { folderId: string | null; folderPath: string | null },
+): Promise<string | null> {
+  const treePaths =
+    doc.folderId !== null
+      ? await folderTreePaths(db, organizationId, [doc.folderId])
+      : new Map<string, string>();
+  return documentFolderPathFrom(doc, treePaths);
+}
+
+/**
+ * Every live, file-backed document under a folder (the folder itself
+ * included) with its canonical folder path — what a rename or a move of that
+ * folder has to re-stamp wherever the path is copied (the knowledge corpus
+ * row the folder filter matches on).
+ */
+export async function subtreeDocumentFolderPaths(
+  db: Sql | TransactionSql,
+  organizationId: string,
+  folderId: string,
+): Promise<Array<{ fileRef: string; folderPath: string | null }>> {
+  const docs = await db<
+    {
+      fileRef: string;
+      folderId: string | null;
+      folderPath: string | null;
+    }[]
+  >`
+    WITH RECURSIVE subtree AS (
+      SELECT f.id, 1 AS depth
+      FROM app.folders f
+      WHERE f.org_id = ${organizationId} AND f.id = ${folderId}
+      UNION ALL
+      SELECT f.id, subtree.depth + 1
+      FROM app.folders f
+      JOIN subtree ON f.parent_id = subtree.id
+      WHERE f.org_id = ${organizationId}
+        AND subtree.depth < ${MAX_FOLDER_DEPTH + 2}
+    )
+    SELECT d.file_ref AS "fileRef", d.folder_id AS "folderId",
+           d.folder_path AS "folderPath"
+    FROM app.documents d
+    JOIN subtree s ON s.id = d.folder_id
+    WHERE d.org_id = ${organizationId}
+      AND d.file_ref IS NOT NULL
+      AND (d.lifecycle_status IS NULL OR d.lifecycle_status = 'active')
+  `;
+  const treePaths = await folderTreePaths(
+    db,
+    organizationId,
+    docs.flatMap((doc) => (doc.folderId !== null ? [doc.folderId] : [])),
+  );
+  return docs.map((doc) => ({
+    fileRef: doc.fileRef,
+    folderPath: documentFolderPathFrom(doc, treePaths),
+  }));
+}
+
 /** Root-to-leaf hub path (segment names) for a folder id; used to match
  *  sync-config `item_path` values when a hub folder is deleted. */
 export async function buildHubFolderPath(

--- a/services/platform/backend/domains/folders/routes.ts
+++ b/services/platform/backend/domains/folders/routes.ts
@@ -11,7 +11,10 @@ import {
   RateLimitExceededError,
 } from '../../lib/rate-limit.ts';
 import { deleteFolderCascade, DocumentError } from '../documents/service.ts';
-import { syncRagDocumentScope } from '../knowledge/service.ts';
+import {
+  syncRagDocumentScope,
+  syncRagFolderSubtree,
+} from '../knowledge/service.ts';
 import { LegalHoldError } from '../legal_holds/service.ts';
 import {
   getProjectAuthContext,
@@ -151,7 +154,7 @@ export function createFolderRoutes(deps: {
       // The cascade re-scoped these documents — re-stamp their corpus rows
       // (retrieval filters on team scope; scope-only, no re-embed).
       for (const doc of touched) {
-        await syncRagDocumentScope(deps.sql, auth.organizationId, doc);
+        await syncRagDocumentScope(deps.sql, auth.organizationId, doc.id);
       }
       return c.json({ ok: true });
     } catch (error) {
@@ -211,6 +214,13 @@ export function createFolderRoutes(deps: {
       );
       await transactSerializable(deps.sql, (tx) =>
         renameFolder(tx, auth, c.req.param('folderId'), body.data.name),
+      );
+      // Every document beneath now has a new path; the corpus copies it
+      // (folder-scoped search matches on it) — re-stamp after commit.
+      await syncRagFolderSubtree(
+        deps.sql,
+        auth.organizationId,
+        c.req.param('folderId'),
       );
       return c.json({ ok: true });
     } catch (error) {

--- a/services/platform/backend/domains/knowledge/admin.test.ts
+++ b/services/platform/backend/domains/knowledge/admin.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  KnowledgeAdminError,
+  probeKnowledgeConnection,
+  writeKnowledgeConnection,
+  writeKnowledgeEmbedding,
+} from './admin.ts';
+
+/**
+ * The outbound-host policy, spoken in this domain's vocabulary. The shared
+ * check refuses with a coded `AppError`; the knowledge routes map only
+ * `KnowledgeAdminError`, so left untranslated a refusal reached the admin as
+ * a bare 500. Every refusal here happens BEFORE any file or network I/O, so
+ * no config directory and no database are involved.
+ */
+
+const metadataHost = {
+  host: '169.254.169.254',
+  port: 5432,
+  database: 'knowledge',
+  user: 'tale',
+  sslmode: 'require',
+};
+
+async function refusal(
+  run: () => Promise<unknown>,
+): Promise<KnowledgeAdminError> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof KnowledgeAdminError) return error;
+    throw error;
+  }
+  throw new Error('expected a KnowledgeAdminError');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('host policy on the knowledge admin doors', () => {
+  it('refuses a cloud-metadata database host as a coded 400, not a 500', async () => {
+    const error = await refusal(() =>
+      writeKnowledgeConnection('acme', { connection: metadataHost }),
+    );
+    expect(error.status).toBe(400);
+    expect(error.code).toBe('BLOCKED_HOST');
+    expect(error.message).toContain('169.254.169.254');
+  });
+
+  it('names the env opt-in when a private host is refused', async () => {
+    vi.stubEnv('TALE_ALLOW_PRIVATE_PROVIDER_HOSTS', '');
+    const error = await refusal(() =>
+      writeKnowledgeConnection('acme', {
+        connection: { ...metadataHost, host: '10.0.0.5' },
+      }),
+    );
+    expect(error.status).toBe(400);
+    expect(error.code).toBe('PRIVATE_HOST_BLOCKED');
+    expect(error.message).toContain('TALE_ALLOW_PRIVATE_PROVIDER_HOSTS=1');
+  });
+
+  it('refuses a blocked embedding base URL the same way', async () => {
+    const error = await refusal(() =>
+      writeKnowledgeEmbedding('acme', {
+        providerSlug: 'openai',
+        model: 'text-embedding-3-small',
+        dimensions: 1536,
+        baseUrl: 'http://metadata.google.internal/v1',
+      }),
+    );
+    expect(error.status).toBe(400);
+    expect(error.code).toBe('BLOCKED_HOST');
+  });
+
+  it('reports a refused host as a failed probe result, the way it reports every other test failure', async () => {
+    const result = await probeKnowledgeConnection({ connection: metadataHost });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('blocked');
+    expect(result.error).toContain('169.254.169.254');
+  });
+});

--- a/services/platform/backend/domains/knowledge/admin.ts
+++ b/services/platform/backend/domains/knowledge/admin.ts
@@ -2,6 +2,7 @@ import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import { checkProviderHostPolicy } from '../../../lib/net/host-policy.ts';
+import { AppError } from '../../../lib/shared/errors/app-error.ts';
 import { pickEmbeddingRecommendations } from '../../../lib/shared/providers/embedding_recommendations.ts';
 import { zodErrorMessage } from '../../../lib/shared/schemas/format-error.ts';
 import {
@@ -62,6 +63,36 @@ export class KnowledgeAdminError extends Error {
 }
 
 const MAX_HISTORY_ENTRIES = 20;
+
+/**
+ * The outbound-host policy, spoken in this domain's error vocabulary.
+ *
+ * The shared check refuses with a coded `AppError` — cloud metadata endpoints
+ * always, private/loopback hosts unless `TALE_ALLOW_PRIVATE_PROVIDER_HOSTS=1`
+ * — and its message names the opt-in. That is a legitimate, actionable denial
+ * the admin has to SEE. Left as an `AppError` it fell through the knowledge
+ * routes (which map only `KnowledgeAdminError`) to the generic handler: a bare
+ * 500 "Internal Server Error", an error report filed, and the one sentence
+ * that would have fixed the setup never reached anyone.
+ */
+function assertHostAllowed(url: string): void {
+  try {
+    checkProviderHostPolicy(url);
+  } catch (error) {
+    if (!(error instanceof AppError)) throw error;
+    const data: unknown = error.data;
+    const field = (name: string): string | null => {
+      if (data === null || typeof data !== 'object') return null;
+      const value: unknown = Reflect.get(data, name);
+      return typeof value === 'string' && value.length > 0 ? value : null;
+    };
+    throw new KnowledgeAdminError(
+      field('code') ?? 'HOST_BLOCKED',
+      field('message') ?? `Host policy refused ${url}`,
+      400,
+    );
+  }
+}
 
 function historyDir(orgSlug: string, key: string): string {
   return safeJoinWithinDir(
@@ -165,7 +196,7 @@ export async function writeKnowledgeConnection(
     );
   }
   const connection = parsed.data;
-  checkProviderHostPolicy(`http://${connection.host}:${connection.port}`);
+  assertHostAllowed(`http://${connection.host}:${connection.port}`);
 
   const filePath = connectionFilePath(orgSlug);
   const serialized = serializeConnectionJson(connection);
@@ -224,7 +255,16 @@ export async function probeKnowledgeConnection(args: {
     };
   }
   const connection = parsed.data;
-  checkProviderHostPolicy(`http://${connection.host}:${connection.port}`);
+  // A probe REPORTS — a refused host is a test result, not an exception,
+  // the same way an unparseable body or an unreadable password is.
+  try {
+    assertHostAllowed(`http://${connection.host}:${connection.port}`);
+  } catch (error) {
+    if (error instanceof KnowledgeAdminError) {
+      return { ok: false, error: error.message };
+    }
+    throw error;
+  }
 
   let password: string;
   try {
@@ -323,7 +363,7 @@ export async function writeKnowledgeEmbedding(
     );
   }
   if (parsed.data.baseUrl) {
-    checkProviderHostPolicy(parsed.data.baseUrl);
+    assertHostAllowed(parsed.data.baseUrl);
   }
   const filePath = embeddingFilePath(orgSlug);
   const serialized = serializeEmbeddingJson(parsed.data);

--- a/services/platform/backend/domains/knowledge/retrievable.test.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.test.ts
@@ -11,6 +11,7 @@ const activeDoc = (overrides: Partial<DocCandidate> = {}): DocCandidate => ({
   projectId: null,
   teamId: null,
   teamTags: null,
+  folderPath: null,
   ...overrides,
 });
 
@@ -101,5 +102,85 @@ describe('decideRetrievable', () => {
         undefined,
       ),
     ).toBe(false);
+  });
+
+  describe('folder filter', () => {
+    // The corpus row's folder stamp is a copy that can lag a move; the
+    // decision is made from the document's CURRENT folder.
+    it('admits the folder itself and everything beneath it', () => {
+      expect(
+        decideRetrievable(
+          [activeDoc({ folderPath: 'Reports' })],
+          [],
+          undefined,
+          'Reports',
+        ),
+      ).toBe(true);
+      expect(
+        decideRetrievable(
+          [activeDoc({ folderPath: 'Reports/2025/Q1' })],
+          [],
+          undefined,
+          'Reports',
+        ),
+      ).toBe(true);
+    });
+
+    it('denies siblings, prefixes without a separator, and root documents', () => {
+      expect(
+        decideRetrievable(
+          [activeDoc({ folderPath: 'Reports-archive' })],
+          [],
+          undefined,
+          'Reports',
+        ),
+      ).toBe(false);
+      expect(
+        decideRetrievable(
+          [activeDoc({ folderPath: 'Invoices' })],
+          [],
+          undefined,
+          'Reports',
+        ),
+      ).toBe(false);
+      expect(decideRetrievable([activeDoc()], [], undefined, 'Reports')).toBe(
+        false,
+      );
+    });
+
+    it('applies the access scope on top of the folder', () => {
+      const doc = activeDoc({ folderPath: 'Reports', teamId: 't1' });
+      expect(decideRetrievable([doc], [], { teamIds: ['t1'] }, 'Reports')).toBe(
+        true,
+      );
+      expect(decideRetrievable([doc], [], { teamIds: ['t2'] }, 'Reports')).toBe(
+        false,
+      );
+    });
+
+    it('never surfaces unbound files under a folder filter — they are filed nowhere', () => {
+      expect(decideRetrievable([], [unboundFile()], undefined, 'Reports')).toBe(
+        false,
+      );
+      expect(
+        decideRetrievable(
+          [],
+          [unboundFile({ threadId: 'th1' })],
+          { threadIds: ['th1'] },
+          'Reports',
+        ),
+      ).toBe(false);
+    });
+
+    it('is a no-op when no folder is given', () => {
+      expect(
+        decideRetrievable(
+          [activeDoc({ folderPath: 'Reports' })],
+          [],
+          undefined,
+        ),
+      ).toBe(true);
+      expect(decideRetrievable([], [unboundFile()], undefined)).toBe(true);
+    });
   });
 });

--- a/services/platform/backend/domains/knowledge/retrievable.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.ts
@@ -18,6 +18,11 @@
  *     without a document, so a blanket quarantine would dark a legitimate
  *     lane. Trashed file rows (a WebDAV overwrite's strands) and refs with
  *     no row at all are never retrievable.
+ *
+ * A folder filter narrows further, from the CURRENT folder of each document
+ * (the corpus row's stamp is a copy that can lag a move): only a document
+ * filed in that folder or beneath it admits, and an unbound file — filed
+ * nowhere — never does.
  */
 
 export interface AccessScopeArg {
@@ -34,6 +39,14 @@ export interface DocCandidate {
   projectId: string | null;
   teamId: string | null;
   teamTags: string[] | null;
+  /** Canonical folder path (`normalizeFolderPath` spelling); null = root. */
+  folderPath: string | null;
+}
+
+/** The folder itself, or anything beneath it — never `/reports-archive`
+ * for `/reports`, hence the separator in the prefix. */
+function folderContains(folder: string, path: string | null): boolean {
+  return path !== null && (path === folder || path.startsWith(`${folder}/`));
 }
 
 /** A file row holding the ref WITHOUT a document binding. */
@@ -50,9 +63,15 @@ export function decideRetrievable(
   docs: readonly DocCandidate[],
   unboundFiles: readonly UnboundFileCandidate[],
   access: AccessScopeArg | undefined,
+  /** Canonical folder path to restrict to (the folder and everything under
+   * it); absent = no folder filter. */
+  folder?: string,
 ): boolean {
   for (const doc of docs) {
     if (!isActiveLifecycle(doc.lifecycleStatus)) continue;
+    if (folder !== undefined && !folderContains(folder, doc.folderPath)) {
+      continue;
+    }
     if (access === undefined) return true;
     if (doc.projectId !== null) {
       if ((access.projectIds ?? []).includes(doc.projectId)) return true;
@@ -72,6 +91,9 @@ export function decideRetrievable(
       return true;
     }
   }
+  // A folder is a document concept: a thread upload or a transcript row is
+  // filed nowhere, so a folder-scoped search never surfaces one.
+  if (folder !== undefined) return false;
   for (const file of unboundFiles) {
     if (!isActiveLifecycle(file.lifecycleStatus)) continue;
     if (file.threadId !== null) {

--- a/services/platform/backend/domains/knowledge/routes.test.ts
+++ b/services/platform/backend/domains/knowledge/routes.test.ts
@@ -1,0 +1,250 @@
+/**
+ * The knowledge routes' WIRE contract, as the data-residency page and the
+ * retrieval surface drive it:
+ *
+ *  - a BYO connection with `sslmode: 'verify-ca'` — one of the five modes the
+ *    picker offers and the shared schema accepts — saves and probes instead
+ *    of dying at the route gate as a bare "invalid body";
+ *  - a host-policy refusal is a 400 carrying its code and the sentence that
+ *    names the fix, never a generic 500;
+ *  - `/fetch` honours `page` as a window over the text rather than accepting
+ *    it and shipping the whole document regardless.
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrgEnv } from '../../auth/org.ts';
+
+const {
+  writeKnowledgeConnection,
+  probeKnowledgeConnection,
+  writeKnowledgeEmbedding,
+  fetchKnowledgeDocument,
+  searchKnowledgeForOrg,
+} = vi.hoisted(() => ({
+  writeKnowledgeConnection: vi.fn(),
+  probeKnowledgeConnection: vi.fn(),
+  writeKnowledgeEmbedding: vi.fn(),
+  fetchKnowledgeDocument: vi.fn(),
+  searchKnowledgeForOrg: vi.fn(),
+}));
+
+vi.mock('./admin.ts', () => {
+  class KnowledgeAdminError extends Error {
+    readonly code: string;
+    readonly status: 400 | 404;
+    constructor(code: string, message: string, status: 400 | 404 = 400) {
+      super(message);
+      this.name = 'KnowledgeAdminError';
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return {
+    KnowledgeAdminError,
+    writeKnowledgeConnection,
+    probeKnowledgeConnection,
+    writeKnowledgeEmbedding,
+    deleteKnowledgeConnection: vi.fn(),
+    deleteKnowledgeEmbedding: vi.fn(),
+    readKnowledgeConnectionView: vi.fn(),
+    readKnowledgeEmbeddingView: vi.fn(),
+    listEmbeddingRecommendationsForOrg: vi.fn(),
+  };
+});
+
+vi.mock('./service.ts', () => {
+  class KnowledgeError extends Error {
+    readonly code: string;
+    readonly status: 400 | 404 | 503;
+    constructor(code: string, message: string, status: 400 | 404 | 503 = 400) {
+      super(message);
+      this.name = 'KnowledgeError';
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return { KnowledgeError, fetchKnowledgeDocument, searchKnowledgeForOrg };
+});
+
+vi.mock('../projects/service.ts', () => ({
+  getProjectAuthContext: vi.fn(async () => ({
+    organizationId: 'o1',
+    userId: 'u1',
+    role: 'admin',
+    teamIds: [],
+  })),
+  listProjects: vi.fn(async () => []),
+}));
+
+vi.mock('../provider_credentials/service.ts', () => ({
+  listCredentials: vi.fn(async () => []),
+}));
+
+vi.mock('../../lib/org-config.ts', () => ({
+  resolveOrgSlug: vi.fn(async () => 'acme'),
+}));
+
+vi.mock('../../auth/session.ts', () => ({
+  requireSession:
+    () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
+      c.set('sessionBundle', {
+        user: { id: 'u1', email: 'u@example.test' },
+      } as never);
+      await next();
+    },
+}));
+
+vi.mock('../../auth/org.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/org.ts')>();
+  return {
+    ...actual,
+    requireOrgMember:
+      () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
+        c.set('orgId', 'o1');
+        c.set('orgMember', { role: 'admin' } as never);
+        await next();
+      },
+  };
+});
+
+import { FETCH_WINDOW_CHARS } from '../../core/knowledge/fetch.ts';
+import { KnowledgeAdminError } from './admin.ts';
+import { createKnowledgeRoutes } from './routes.ts';
+
+function makeApp() {
+  return createKnowledgeRoutes({ sql: {} as never, auth: {} as never });
+}
+
+async function post(route: string, body: unknown): Promise<Response> {
+  return await makeApp().request(route, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const verifyCaConnection = {
+  host: 'kb.internal.example',
+  port: 5432,
+  database: 'knowledge',
+  user: 'tale',
+  sslmode: 'verify-ca',
+  password: 'secret',
+};
+
+describe('knowledge routes — BYO connection wire contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeKnowledgeConnection.mockResolvedValue(undefined);
+    probeKnowledgeConnection.mockResolvedValue({ ok: true, latencyMs: 3 });
+  });
+
+  it('saves a connection with sslmode verify-ca (the picker offers it)', async () => {
+    const res = await post('/connection?orgId=o1', verifyCaConnection);
+    expect(res.status).toBe(200);
+    expect(writeKnowledgeConnection).toHaveBeenCalledWith('acme', {
+      connection: expect.objectContaining({ sslmode: 'verify-ca' }),
+      password: 'secret',
+    });
+  });
+
+  it('probes a connection with sslmode verify-ca', async () => {
+    const res = await post('/connection/test?orgId=o1', verifyCaConnection);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, latencyMs: 3 });
+    expect(probeKnowledgeConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connection: expect.objectContaining({ sslmode: 'verify-ca' }),
+        orgSlug: 'acme',
+      }),
+    );
+  });
+
+  it('still refuses a mode outside the shared set', async () => {
+    const res = await post('/connection?orgId=o1', {
+      ...verifyCaConnection,
+      sslmode: 'allow',
+    });
+    expect(res.status).toBe(400);
+    expect(writeKnowledgeConnection).not.toHaveBeenCalled();
+  });
+
+  it('answers a host-policy refusal on save as a 400 with code and reason', async () => {
+    writeKnowledgeConnection.mockRejectedValue(
+      new KnowledgeAdminError(
+        'PRIVATE_HOST_BLOCKED',
+        'Host "10.0.0.5" is a private/loopback address and is blocked. Set TALE_ALLOW_PRIVATE_PROVIDER_HOSTS=1 in the platform process env to enable self-hosted backends like Ollama on localhost.',
+        400,
+      ),
+    );
+    const res = await post('/connection?orgId=o1', {
+      ...verifyCaConnection,
+      host: '10.0.0.5',
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('PRIVATE_HOST_BLOCKED');
+    expect(body.message).toContain('TALE_ALLOW_PRIVATE_PROVIDER_HOSTS');
+  });
+
+  it('maps a refusal thrown by the probe the same way instead of a 500', async () => {
+    probeKnowledgeConnection.mockRejectedValue(
+      new KnowledgeAdminError('BLOCKED_HOST', 'Host is blocked.', 400),
+    );
+    const res = await post('/connection/test?orgId=o1', verifyCaConnection);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'BLOCKED_HOST',
+      message: 'Host is blocked.',
+    });
+  });
+});
+
+describe('knowledge routes — fetch paging', () => {
+  const text = 'x'.repeat(FETCH_WINDOW_CHARS * 2 + 5);
+  const document = {
+    fileId: 'ref-1',
+    filename: 'ledger.txt',
+    folderPath: null,
+    modifiedAt: null,
+    text,
+    conversationId: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchKnowledgeDocument.mockResolvedValue(document);
+  });
+
+  it('ships the whole document when no page is asked for', async () => {
+    const res = await post('/fetch?orgId=o1', { fileId: 'ref-1' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { document: { text: string } };
+    expect(body.document.text).toHaveLength(text.length);
+    expect(body).not.toHaveProperty('page');
+  });
+
+  it('windows the text by page and says how many pages there are', async () => {
+    const res = await post('/fetch?orgId=o1', { fileId: 'ref-1', page: 3 });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      document: { text: string };
+      page: number;
+      totalPages: number;
+      totalChars: number;
+    };
+    expect(body.page).toBe(3);
+    expect(body.totalPages).toBe(3);
+    expect(body.totalChars).toBe(text.length);
+    expect(body.document.text).toHaveLength(5);
+  });
+
+  it('keeps a miss a miss', async () => {
+    fetchKnowledgeDocument.mockResolvedValue(null);
+    const res = await post('/fetch?orgId=o1', { fileId: 'ghost', page: 2 });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ document: null });
+  });
+});

--- a/services/platform/backend/domains/knowledge/routes.ts
+++ b/services/platform/backend/domains/knowledge/routes.ts
@@ -3,9 +3,11 @@ import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import { defineAbilityFor } from '../../../lib/permissions/ability.ts';
+import { knowledgeConnectionSchema } from '../../../lib/shared/schemas/knowledge.ts';
 import type { Auth } from '../../auth/auth.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession } from '../../auth/session.ts';
+import { FETCH_WINDOW_CHARS, windowText } from '../../core/knowledge/fetch.ts';
 import { resolveOrgSlug } from '../../lib/org-config.ts';
 import { getProjectAuthContext, listProjects } from '../projects/service.ts';
 import { listCredentials } from '../provider_credentials/service.ts';
@@ -114,10 +116,30 @@ export function createKnowledgeRoutes(deps: {
       const document = await fetchKnowledgeDocument(deps.sql, {
         organizationId: c.get('orgId'),
         fileId: body.data.fileId,
-        ...(body.data.page !== undefined ? { page: body.data.page } : {}),
         access,
       });
-      return c.json({ document });
+      const page = body.data.page;
+      if (document === null || page === undefined) {
+        return c.json({ document });
+      }
+      // `page` is a 1-based window of FETCH_WINDOW_CHARS over the text — the
+      // paging contract every rag_fetch surface shares. Accepted-and-ignored
+      // was worse than absent: a caller asking for page 2 got the whole
+      // document again and no way to tell.
+      const window = windowText(
+        document.text,
+        (page - 1) * FETCH_WINDOW_CHARS,
+        FETCH_WINDOW_CHARS,
+      );
+      return c.json({
+        document: { ...document, text: window.content },
+        page,
+        totalPages: Math.max(
+          1,
+          Math.ceil(window.totalChars / FETCH_WINDOW_CHARS),
+        ),
+        totalChars: window.totalChars,
+      });
     } catch (error) {
       return handleError(c, error);
     }
@@ -149,12 +171,15 @@ export function createKnowledgeRoutes(deps: {
     }
     throw error;
   };
-  const connectionSchema = z.object({
-    host: z.string().min(1).max(500),
-    port: z.number().int().min(1).max(65_535),
-    database: z.string().min(1).max(200),
-    user: z.string().min(1).max(200),
-    sslmode: z.enum(['disable', 'prefer', 'require', 'verify-full']),
+  // The wire shape of a BYO knowledge connection is the SHARED field schemas
+  // (host charset, port range, the full sslmode set the picker offers —
+  // `verify-ca` included) in a strip-mode object: strictness is the config
+  // FILE's policy, not the request body's. A hand-rolled second copy of the
+  // enum is exactly how `verify-ca` went missing here and every save or test
+  // with it died as a bare "invalid body".
+  const connectionBodySchema = z.object({
+    ...knowledgeConnectionSchema.shape,
+    password: z.string().max(2_000).nullable().optional(),
   });
 
   app.get('/connection', async (c) => {
@@ -168,9 +193,7 @@ export function createKnowledgeRoutes(deps: {
   app.post('/connection', async (c) => {
     const denied = requireKnowledgeAdmin(c);
     if (denied) return denied;
-    const body = connectionSchema
-      .extend({ password: z.string().max(2_000).nullable().optional() })
-      .safeParse(await c.req.json());
+    const body = connectionBodySchema.safeParse(await c.req.json());
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
     const orgSlug = await orgSlugOf(c);
     if (orgSlug === null) return c.json({ error: 'ORG_NOT_FOUND' }, 404);
@@ -198,20 +221,22 @@ export function createKnowledgeRoutes(deps: {
   app.post('/connection/test', async (c) => {
     const denied = requireKnowledgeAdmin(c);
     if (denied) return denied;
-    const body = connectionSchema
-      .extend({ password: z.string().max(2_000).nullable().optional() })
-      .safeParse(await c.req.json());
+    const body = connectionBodySchema.safeParse(await c.req.json());
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
     const orgSlug = await orgSlugOf(c);
     if (orgSlug === null) return c.json({ error: 'ORG_NOT_FOUND' }, 404);
     const { password, ...connection } = body.data;
-    return c.json(
-      await probeKnowledgeConnection({
-        connection,
-        ...(password !== undefined ? { password } : {}),
-        orgSlug,
-      }),
-    );
+    try {
+      return c.json(
+        await probeKnowledgeConnection({
+          connection,
+          ...(password !== undefined ? { password } : {}),
+          orgSlug,
+        }),
+      );
+    } catch (error) {
+      return handleAdminError(c, error);
+    }
   });
 
   app.get('/embedding', async (c) => {

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -20,6 +20,7 @@ import {
   getKnowledgePoolForOrg,
   resolveOrgUrl,
 } from '../../core/knowledge/pool.ts';
+import { RAG_ERROR_EMBEDDING_NOT_CONFIGURED } from '../../core/knowledge/rag_error_codes.ts';
 import {
   searchKnowledge,
   type SearchKnowledgeArgs,
@@ -34,6 +35,13 @@ import { createCtxShim, type ShimHandlers } from '../../lib/ctx-shim.ts';
 import { resolveObjectStore } from '../../lib/object-store.ts';
 import { readGovernancePolicy, resolveOrgSlug } from '../../lib/org-config.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
+import {
+  documentFolderPathFrom,
+  folderTreePaths,
+  normalizeFolderPath,
+  resolveDocumentFolderPath,
+  subtreeDocumentFolderPaths,
+} from '../folders/paths.ts';
 import { credentialShimHandlers } from '../provider_credentials/service.ts';
 import {
   decideRetrievable,
@@ -69,6 +77,10 @@ const FILTER_RETRIEVABLE =
  * their thread's scope; document-less lanes like video-link transcripts
  * keep the 0.4 same-org posture). The DECISION is `decideRetrievable`
  * (pure, tested); this wrapper only fetches its candidates.
+ *
+ * `folder` (canonical spelling) re-checks the folder filter against each
+ * document's CURRENT folder — the corpus row's stamp is a copy that can lag
+ * a move, so the SQL pre-filter admits and this decides.
  */
 async function filterRetrievableRagFileIds(
   sql: Sql,
@@ -76,19 +88,40 @@ async function filterRetrievableRagFileIds(
     organizationId: string;
     fileIds: string[];
     access?: AccessScopeArg;
+    folder?: string;
   },
 ): Promise<string[]> {
   if (args.fileIds.length === 0) {
     return [];
   }
-  const docRows = await sql<({ fileRef: string } & DocCandidate)[]>`
+  const docRows = await sql<
+    ({
+      fileRef: string;
+      folderId: string | null;
+      folderPath: string | null;
+    } & Omit<DocCandidate, 'folderPath'>)[]
+  >`
     SELECT d.file_ref AS "fileRef", d.lifecycle_status AS "lifecycleStatus",
            d.project_id AS "projectId", d.team_id AS "teamId",
-           d.team_tags AS "teamTags"
+           d.team_tags AS "teamTags", d.folder_id AS "folderId",
+           d.folder_path AS "folderPath"
     FROM app.documents d
     WHERE d.org_id = ${args.organizationId}
       AND d.file_ref = ANY(${args.fileIds})
   `;
+  // A candidate's folder is decisive only under a folder filter, so the
+  // tree is read only then (one recursive query for every candidate).
+  const folder = normalizeFolderPath(args.folder);
+  const treePaths =
+    folder !== null
+      ? await folderTreePaths(
+          sql,
+          args.organizationId,
+          docRows.flatMap((row) =>
+            row.folderId !== null ? [row.folderId] : [],
+          ),
+        )
+      : new Map<string, string>();
   const fileRows = await sql<({ storageRef: string } & UnboundFileCandidate)[]>`
     SELECT fm.storage_ref AS "storageRef", fm.thread_id AS "threadId",
            fm.lifecycle_status AS "lifecycleStatus"
@@ -99,7 +132,14 @@ async function filterRetrievableRagFileIds(
   `;
   const docsByRef = new Map<string, DocCandidate[]>();
   for (const row of docRows) {
-    const { fileRef, ...candidate } = row;
+    const { fileRef, folderId, folderPath, ...scope } = row;
+    const candidate: DocCandidate = {
+      ...scope,
+      folderPath:
+        folder !== null
+          ? documentFolderPathFrom({ folderId, folderPath }, treePaths)
+          : null,
+    };
     const list = docsByRef.get(fileRef);
     if (list) list.push(candidate);
     else docsByRef.set(fileRef, [candidate]);
@@ -122,6 +162,7 @@ async function filterRetrievableRagFileIds(
         docsByRef.get(ref) ?? [],
         filesByRef.get(ref) ?? [],
         args.access,
+        folder ?? undefined,
       )
     ) {
       retrievable.push(ref);
@@ -180,6 +221,7 @@ export function knowledgeShimHandlers(sql: Sql): ShimHandlers {
         organizationId: string;
         fileIds: string[];
         access?: AccessScopeArg;
+        folder?: string;
       };
       return filterRetrievableRagFileIds(sql, args);
     },
@@ -223,11 +265,15 @@ export async function searchKnowledgeForOrg(
 ): Promise<Awaited<ReturnType<typeof searchKnowledge>>> {
   const orgSlug = await requireOrgSlug(sql, args.organizationId);
   const shim = knowledgeShim(sql);
+  // The folder filter in canonical spelling — the one the corpus stamp is
+  // written in — so `/Reports/` and `Reports` name the same folder.
+  const { folder: rawFolder, ...rest } = args;
+  const folder = normalizeFolderPath(rawFolder);
   try {
     return await searchKnowledge(
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 module; ctx usage covered by the shim handlers
       shim as unknown as Parameters<typeof searchKnowledge>[0],
-      { ...args, orgSlug },
+      { ...rest, orgSlug, ...(folder !== null ? { folder } : {}) },
     );
   } catch (error) {
     if (error instanceof EmbeddingNotConfigured) {
@@ -277,6 +323,12 @@ export async function ensureDefaultCorpusSchema(): Promise<void> {
  * surface is keyed by DOCUMENT, and the list is what has to re-read. Hints
  * carry identity, never data, so the extra breadth costs one refetch of a
  * page the user is already looking at.
+ *
+ * `ragError` and `ragErrorCode` travel together: the prose is what the failed-
+ * indexing dialog prints, the code (`rag_error_codes.ts`) is what it branches
+ * on to attach guidance — the Settings deep link for a missing embedding
+ * model. Both are cleared by any write that does not set them, so a retry
+ * that succeeds leaves no stale cause behind.
  */
 async function writeRagStatus(
   sql: Sql,
@@ -285,6 +337,7 @@ async function writeRagStatus(
     ragStatus?: 'queued' | 'running' | 'completed' | 'failed' | 'unsupported';
     ragProgress?: string | null;
     ragError?: string | null;
+    ragErrorCode?: string | null;
     ragIndexedAt?: number | null;
   },
 ): Promise<void> {
@@ -293,6 +346,7 @@ async function writeRagStatus(
       rag_status = coalesce(${patch.ragStatus ?? null}, rag_status),
       rag_progress = ${patch.ragProgress ?? null},
       rag_error = ${patch.ragError ?? null},
+      rag_error_code = ${patch.ragErrorCode ?? null},
       rag_indexed_at_ms = coalesce(${patch.ragIndexedAt ?? null}, rag_indexed_at_ms)
     WHERE id = ${fileId}
     RETURNING org_id AS "orgId"
@@ -375,19 +429,25 @@ export async function indexUploadedFile(
     );
     const piiConfig = parsePiiConfig(piiPolicy);
 
-    // Scope stamp from the bound document (hub/team/project).
+    // Scope stamp from the bound document (hub/team/project), and its folder
+    // — the corpus filters on both; a NULL folder stamp made every
+    // folder-scoped search miss the document it was filed in.
     let teamIds: string[] | null = null;
     let projectId: string | null = null;
+    let folderPath: string | null = null;
     if (file.documentId !== null) {
       const docRows = await sql<
         {
           teamId: string | null;
           teamTags: string[];
           projectId: string | null;
+          folderId: string | null;
+          folderPath: string | null;
         }[]
       >`
         SELECT team_id AS "teamId", team_tags AS "teamTags",
-               project_id AS "projectId"
+               project_id AS "projectId", folder_id AS "folderId",
+               folder_path AS "folderPath"
         FROM app.documents WHERE id = ${file.documentId} LIMIT 1
       `;
       const doc = docRows[0];
@@ -399,6 +459,11 @@ export async function indexUploadedFile(
               ? [doc.teamId]
               : null;
         projectId = doc.projectId;
+        folderPath = await resolveDocumentFolderPath(
+          sql,
+          file.organizationId,
+          doc,
+        );
       }
     }
 
@@ -422,6 +487,7 @@ export async function indexUploadedFile(
         bytes,
         embedder,
         piiConfig,
+        folderPath,
         teamIds,
         projectId,
       });
@@ -454,10 +520,15 @@ export async function indexUploadedFile(
     });
   } catch (error) {
     if (error instanceof EmbeddingNotConfigured) {
+      // The one failure a member can route to a fix: the code makes the
+      // dialog show the Settings → Data residency deep link (or "ask an
+      // admin"), and the prose says the same for everyone reading the raw
+      // status — an operator file path is not something a member can act on.
       await writeRagStatus(sql, fileId, {
         ragStatus: 'failed',
         ragError:
-          'No embedding model is configured — set knowledge/embedding.json for this organization.',
+          'No embedding model is configured for this organization. An admin can set one under Settings → Data residency → Embedding model, then retry indexing.',
+        ragErrorCode: RAG_ERROR_EMBEDDING_NOT_CONFIGURED,
       });
       return;
     }
@@ -482,23 +553,43 @@ export async function markRagQueued(
 }
 
 /**
- * Re-stamp a document's corpus scope (team/project) after a scope-only edit —
- * retrieval filters on these columns, and re-embedding would be wasted work.
- * Best-effort by contract (0.4 parity): corpus failures log; the next
- * re-index is the backstop.
+ * Re-stamp a document's corpus scope (team/project) and folder after an
+ * edit that moved either — retrieval filters on these columns, and
+ * re-embedding would be wasted work. Reads the document's CURRENT row, so
+ * every caller (the app update, REST, WebDAV MOVE, a sync engine) speaks the
+ * same one-liner. Best-effort by contract (0.4 parity): corpus failures log;
+ * the next re-index is the backstop.
  */
 export async function syncRagDocumentScope(
   sql: Sql,
   organizationId: string,
-  doc: {
-    fileRef: string | null;
-    teamId: string | null;
-    teamTags: string[];
-    projectId: string | null;
-  },
+  documentId: string,
 ): Promise<void> {
-  if (doc.fileRef === null) return;
   try {
+    const rows = await sql<
+      {
+        fileRef: string | null;
+        teamId: string | null;
+        teamTags: string[];
+        projectId: string | null;
+        folderId: string | null;
+        folderPath: string | null;
+      }[]
+    >`
+      SELECT file_ref AS "fileRef", team_id AS "teamId",
+             team_tags AS "teamTags", project_id AS "projectId",
+             folder_id AS "folderId", folder_path AS "folderPath"
+      FROM app.documents
+      WHERE id = ${documentId} AND org_id = ${organizationId}
+      LIMIT 1
+    `;
+    const doc = rows[0];
+    if (!doc || doc.fileRef === null) return;
+    const folderPath = await resolveDocumentFolderPath(
+      sql,
+      organizationId,
+      doc,
+    );
     const orgSlug = await requireOrgSlug(sql, organizationId);
     const pool = await getKnowledgePoolForOrg(orgSlug);
     const teamIds =
@@ -507,20 +598,59 @@ export async function syncRagDocumentScope(
     await pool.unsafe(
       `UPDATE ${PRIVATE_KNOWLEDGE_SCHEMA}.documents
           SET team_ids = $3::text[], team_id = $4, project_id = $5,
-              updated_at = NOW()
+              folder_path = $6, updated_at = NOW()
         WHERE org_slug = $1 AND file_id = $2
           AND (team_ids IS DISTINCT FROM $3::text[]
             OR team_id IS DISTINCT FROM $4
-            OR project_id IS DISTINCT FROM $5)`,
+            OR project_id IS DISTINCT FROM $5
+            OR folder_path IS DISTINCT FROM $6)`,
       [
         orgSlug,
         doc.fileRef,
         teamIds.length > 0 ? teamIds : null,
         teamIds[0] ?? null,
         doc.projectId,
+        folderPath,
       ],
     );
   } catch (error) {
     console.warn('[knowledge] corpus scope sync failed:', error);
+  }
+}
+
+/**
+ * Re-stamp the corpus folder path of every live, file-backed document under a
+ * folder after the folder itself was renamed or moved — the path of each
+ * document changed without any document row being touched. One read of the
+ * subtree, one corpus update; best-effort like the per-document sync.
+ */
+export async function syncRagFolderSubtree(
+  sql: Sql,
+  organizationId: string,
+  folderId: string,
+): Promise<void> {
+  try {
+    const docs = await subtreeDocumentFolderPaths(
+      sql,
+      organizationId,
+      folderId,
+    );
+    if (docs.length === 0) return;
+    const orgSlug = await requireOrgSlug(sql, organizationId);
+    const pool = await getKnowledgePoolForOrg(orgSlug);
+    await pool.unsafe(
+      `UPDATE ${PRIVATE_KNOWLEDGE_SCHEMA}.documents d
+          SET folder_path = v.folder_path, updated_at = NOW()
+         FROM unnest($2::text[], $3::text[]) AS v(file_id, folder_path)
+        WHERE d.org_slug = $1 AND d.file_id = v.file_id
+          AND d.folder_path IS DISTINCT FROM v.folder_path`,
+      [
+        orgSlug,
+        docs.map((doc) => doc.fileRef),
+        docs.map((doc) => doc.folderPath),
+      ],
+    );
+  } catch (error) {
+    console.warn('[knowledge] corpus folder sync failed:', error);
   }
 }

--- a/services/platform/backend/domains/onedrive/service.ts
+++ b/services/platform/backend/domains/onedrive/service.ts
@@ -37,7 +37,7 @@ import {
   getOrCreateHubFolderPath,
   reapEmptyAncestorFolders,
 } from '../folders/paths.ts';
-import { markRagQueued } from '../knowledge/service.ts';
+import { markRagQueued, syncRagDocumentScope } from '../knowledge/service.ts';
 import { assertNotHeld, LegalHoldError } from '../legal_holds/service.ts';
 import { purgeDocument } from '../retention/service.ts';
 import { readSsoSecrets, resolveSignInConfig } from '../sso/config.ts';
@@ -894,6 +894,12 @@ export function createSyncImportDeps(
           updated_at_ms = ${Date.now()}
         WHERE id = ${documentId}
       `;
+      // A re-filed document keeps its embeddings but moves in the corpus
+      // FILTER (folder-scoped search matches the stamped path) — re-stamp.
+      // A replaced blob re-indexes via the schedule below and stamps itself.
+      if (updateArgs.folderId !== undefined && !blobReplaced) {
+        await syncRagDocumentScope(sql, organizationId, documentId);
+      }
 
       // The replaced blob's corpus chunks are keyed by the OLD ref — release
       // them through the shared refcounted seam (the 0.4

--- a/services/platform/backend/domains/webdav/handlers.ts
+++ b/services/platform/backend/domains/webdav/handlers.ts
@@ -26,7 +26,11 @@ import {
 } from '../../lib/rate-limit.ts';
 import { registerUploadedBytes } from '../files/service.ts';
 import { MAX_FOLDER_DEPTH } from '../folders/service.ts';
-import { markRagQueued } from '../knowledge/service.ts';
+import {
+  markRagQueued,
+  syncRagDocumentScope,
+  syncRagFolderSubtree,
+} from '../knowledge/service.ts';
 import {
   assertNotHeld,
   LegalHoldError,
@@ -1136,7 +1140,7 @@ export function webdavHandlers(
       const destName = nfc(args.destName);
       const destParentSegments = args.destParentSegments.map(nfc);
       const srcSegments = args.srcSegments.map(nfc);
-      return sql.begin(async (tx) => {
+      const moved = await sql.begin(async (tx) => {
         if (args.src.kind === 'folder') {
           await assertVisibleFolderSrc(tx, args.organizationId, args.src.id);
         }
@@ -1230,6 +1234,14 @@ export function webdavHandlers(
         );
         return { created: collision === null };
       });
+      // The corpus copies each document's folder path (folder-scoped search
+      // matches on it) — re-stamp what the MOVE re-filed, after commit.
+      if (args.src.kind === 'document') {
+        await syncRagDocumentScope(sql, args.organizationId, args.src.id);
+      } else {
+        await syncRagFolderSubtree(sql, args.organizationId, args.src.id);
+      }
+      return moved;
     },
 
     'webdav/tree_mutations:copyResource': async (raw) => {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -5586,6 +5586,106 @@ async function checkKnowledge(
       : 0;
 
   try {
+    const send = (
+      method: 'POST',
+      route: string,
+      body?: unknown,
+    ): Promise<Response> =>
+      fetch(`${base}${route}`, {
+        method,
+        headers: { 'content-type': 'application/json', cookie, origin: base },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    /** Upload a text file, register it, bind a document (optionally into a
+     * folder) — the three-call journey the later lanes repeat. */
+    const uploadTextDocument = async (
+      fileName: string,
+      text: string,
+      extra: { folderId?: string } = {},
+    ): Promise<{ fileId: string; storageRef: string; documentId: string }> => {
+      const handoff = z
+        .object({ storageRef: z.string(), uploadUrl: z.string().url() })
+        .safeParse(
+          await (
+            await send('POST', `/api/app/files/upload-handoff?orgId=${orgId}`, {
+              contentType: 'text/plain',
+              size: text.length,
+            })
+          ).json(),
+        );
+      if (!handoff.success)
+        throw new Error(`upload handoff failed: ${fileName}`);
+      await fetch(handoff.data.uploadUrl, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: text,
+      });
+      const registered = z.object({ fileId: z.string() }).safeParse(
+        await (
+          await send('POST', `/api/app/files/register?orgId=${orgId}`, {
+            storageRef: handoff.data.storageRef,
+            fileName,
+            contentType: 'text/plain',
+          })
+        ).json(),
+      );
+      if (!registered.success) throw new Error(`register failed: ${fileName}`);
+      const bound = z.object({ documentId: z.string() }).safeParse(
+        await (
+          await send('POST', `/api/app/documents/from-upload?orgId=${orgId}`, {
+            fileId: registered.data.fileId,
+            fileName,
+            ...extra,
+          })
+        ).json(),
+      );
+      if (!bound.success) throw new Error(`document bind failed: ${fileName}`);
+      return {
+        fileId: registered.data.fileId,
+        storageRef: handoff.data.storageRef,
+        documentId: bound.data.documentId,
+      };
+    };
+    const ragRow = async (
+      fileId: string,
+    ): Promise<{
+      status: string | null;
+      error: string | null;
+      code: string | null;
+    }> => {
+      const rows = await sql<
+        { status: string | null; error: string | null; code: string | null }[]
+      >`
+        SELECT rag_status AS status, rag_error AS error,
+               rag_error_code AS code
+        FROM app.file_metadata WHERE id = ${fileId}
+      `;
+      return rows[0] ?? { status: null, error: null, code: null };
+    };
+
+    // 0. No embedding model configured yet: indexing must FAIL with the
+    //    machine-readable cause the failed-indexing dialog branches on (the
+    //    Settings → Data residency deep link) and prose a member can act
+    //    on. Pre-fix the column was never written and the prose named an
+    //    operator file path.
+    const unconfigured = await uploadTextDocument(
+      'unconfigured.txt',
+      'The embedding gate probe: a document uploaded before any model was configured.',
+    );
+    const unconfiguredFailed = await waitFor(
+      async () => (await ragRow(unconfigured.fileId)).status === 'failed',
+      20_000,
+    );
+    const unconfiguredRow = await ragRow(unconfigured.fileId);
+    record(
+      'knowledge indexing without an embedding model writes rag_error_code',
+      unconfiguredFailed &&
+        unconfiguredRow.code === 'embedding_not_configured' &&
+        (unconfiguredRow.error ?? '').includes('Settings') &&
+        !(unconfiguredRow.error ?? '').includes('embedding.json'),
+      `status=${unconfiguredRow.status}/failed code=${unconfiguredRow.code ?? 'NULL'}/embedding_not_configured, prose=${JSON.stringify((unconfiguredRow.error ?? '').slice(0, 90))}`,
+    );
+
     // Org embedding config + corpus bootstrap.
     const configRoot = process.env.TALE_CONFIG_DIR ?? '';
     const dir = path.join(configRoot, orgSlug, 'knowledge');
@@ -5602,17 +5702,6 @@ async function checkKnowledge(
     const { ensureDefaultCorpusSchema } =
       await import('./domains/knowledge/service.ts');
     await ensureDefaultCorpusSchema();
-
-    const send = (
-      method: 'POST',
-      route: string,
-      body?: unknown,
-    ): Promise<Response> =>
-      fetch(`${base}${route}`, {
-        method,
-        headers: { 'content-type': 'application/json', cookie, origin: base },
-        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-      });
 
     const payload =
       'The Heidelberg quarterly review covers verdigris pigments and the zeppelin ledger.';
@@ -5773,6 +5862,247 @@ async function checkKnowledge(
         corpusDoc.total > 64 &&
         Number(corpusDoc.stored) === corpusDoc.total,
       `indexed=${bigIndexed}, corpus=${corpusDoc?.status ?? 'MISSING'}, chunks=${corpusDoc?.stored ?? '0'}/${corpusDoc?.total ?? 0} (want equal, > 64)`,
+    );
+
+    // The retry door, now that a model IS configured: the failure cause must
+    // clear with the failure — a stale code would keep showing the fix for a
+    // problem that is gone.
+    const retried = await send(
+      'POST',
+      `/api/app/documents/${unconfigured.documentId}/retry-rag?orgId=${orgId}`,
+    );
+    const retriedIndexed = await waitFor(
+      async () => (await ragRow(unconfigured.fileId)).status === 'completed',
+      20_000,
+    );
+    const retriedRow = await ragRow(unconfigured.fileId);
+    record(
+      'knowledge retry after configuring a model clears rag_error_code',
+      retried.status === 200 &&
+        retriedIndexed &&
+        retriedRow.code === null &&
+        retriedRow.error === null,
+      `retry=${retried.status}/200 status=${retriedRow.status}/completed code=${retriedRow.code ?? 'NULL'}/NULL error=${retriedRow.error ?? 'NULL'}/NULL`,
+    );
+
+    // Folder-scoped search: a document filed in a folder is found under that
+    // folder (in either spelling), not under another, and the root document
+    // is not found under any — the corpus stamp is written at ingest and
+    // re-checked against the CURRENT folder. Pre-fix the stamp was never
+    // written, so every folder-scoped search returned nothing at all.
+    const folderHits = async (
+      query: string,
+      folder: string,
+    ): Promise<string[]> => {
+      const body = await (
+        await send('POST', `/api/app/knowledge/search?orgId=${orgId}`, {
+          query,
+          folder,
+          limit: 10,
+        })
+      ).json();
+      const parsed = z
+        .object({
+          hits: z.array(z.object({ source: z.object({ ref: z.string() }) })),
+        })
+        .loose()
+        .safeParse(body);
+      return parsed.success
+        ? parsed.data.hits.map((hit) => hit.source.ref)
+        : [];
+    };
+    const reportsFolder = z.object({ folderId: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/folders?orgId=${orgId}`, {
+          name: 'Reports',
+        })
+      ).json(),
+    );
+    const reportsFolderId = reportsFolder.success
+      ? reportsFolder.data.folderId
+      : '';
+    const filed = await uploadTextDocument(
+      'antwerp.txt',
+      'The Antwerp ledger notes cobalt shipments and the harbor tariff schedule for the season.',
+      { folderId: reportsFolderId },
+    );
+    const filedIndexed = await waitFor(
+      async () => (await ragRow(filed.fileId)).status === 'completed',
+      20_000,
+    );
+    const corpusFolderOf = async (fileId: string): Promise<string | null> => {
+      const rows = await corpusPool<{ folderPath: string | null }[]>`
+        SELECT folder_path AS "folderPath" FROM private_knowledge.documents
+        WHERE org_slug = ${orgSlug} AND file_id = ${fileId}
+      `;
+      return rows[0]?.folderPath ?? null;
+    };
+    const stampAtIngest = await corpusFolderOf(filed.storageRef);
+    const inReports = await folderHits('cobalt harbor tariff', 'Reports');
+    const inReportsSlashed = await folderHits(
+      'cobalt harbor tariff',
+      '/Reports/',
+    );
+    const inInvoices = await folderHits('cobalt harbor tariff', 'Invoices');
+    const rootUnderReports = await folderHits(
+      'verdigris zeppelin ledger',
+      'Reports',
+    );
+    record(
+      'knowledge folder-scoped search finds the folder documents',
+      filedIndexed &&
+        stampAtIngest === 'Reports' &&
+        inReports.includes(filed.storageRef) &&
+        inReportsSlashed.includes(filed.storageRef) &&
+        !inInvoices.includes(filed.storageRef) &&
+        !rootUnderReports.includes(handoff.data.storageRef),
+      `indexed=${filedIndexed} stamp=${stampAtIngest ?? 'NULL'}/Reports, Reports=${inReports.includes(filed.storageRef)} '/Reports/'=${inReportsSlashed.includes(filed.storageRef)} Invoices=${inInvoices.includes(filed.storageRef)}(want false) rootDocUnderReports=${rootUnderReports.includes(handoff.data.storageRef)}(want false)`,
+    );
+
+    // The stamp follows the document: a move re-files it, a folder rename
+    // re-paths everything beneath — no re-embedding, the filter just moves.
+    const archiveFolder = z.object({ folderId: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/folders?orgId=${orgId}`, {
+          name: 'Archive',
+        })
+      ).json(),
+    );
+    const archiveFolderId = archiveFolder.success
+      ? archiveFolder.data.folderId
+      : '';
+    const moved = await send(
+      'POST',
+      `/api/app/documents/${filed.documentId}?orgId=${orgId}`,
+      { folderId: archiveFolderId },
+    );
+    const stampAfterMove = await corpusFolderOf(filed.storageRef);
+    const reportsAfterMove = await folderHits(
+      'cobalt harbor tariff',
+      'Reports',
+    );
+    const archiveAfterMove = await folderHits(
+      'cobalt harbor tariff',
+      'Archive',
+    );
+    const renamed = await send(
+      'POST',
+      `/api/app/folders/${archiveFolderId}/rename?orgId=${orgId}`,
+      { name: 'Vault' },
+    );
+    const stampAfterRename = await corpusFolderOf(filed.storageRef);
+    const vaultAfterRename = await folderHits('cobalt harbor tariff', 'Vault');
+    record(
+      'knowledge folder stamp follows document moves and folder renames',
+      moved.status === 200 &&
+        stampAfterMove === 'Archive' &&
+        !reportsAfterMove.includes(filed.storageRef) &&
+        archiveAfterMove.includes(filed.storageRef) &&
+        renamed.status === 200 &&
+        stampAfterRename === 'Vault' &&
+        vaultAfterRename.includes(filed.storageRef),
+      `move=${moved.status}/200 stamp=${stampAfterMove ?? 'NULL'}/Archive Reports=${reportsAfterMove.includes(filed.storageRef)}(want false) Archive=${archiveAfterMove.includes(filed.storageRef)}, rename=${renamed.status}/200 stamp=${stampAfterRename ?? 'NULL'}/Vault Vault=${vaultAfterRename.includes(filed.storageRef)}`,
+    );
+
+    // Fetch paging: `page` is a window over the text, with the page count,
+    // not an accepted-and-ignored parameter shipping the whole document.
+    const pageShape = z
+      .object({
+        document: z.object({ text: z.string() }),
+        page: z.number().optional(),
+        totalPages: z.number().optional(),
+        totalChars: z.number().optional(),
+      })
+      .loose();
+    const pageOne = pageShape.safeParse(
+      await (
+        await send('POST', `/api/app/knowledge/fetch?orgId=${orgId}`, {
+          fileId: bigHandoff.data.storageRef,
+          page: 1,
+        })
+      ).json(),
+    );
+    const pageTwo = pageShape.safeParse(
+      await (
+        await send('POST', `/api/app/knowledge/fetch?orgId=${orgId}`, {
+          fileId: bigHandoff.data.storageRef,
+          page: 2,
+        })
+      ).json(),
+    );
+    const whole = pageShape.safeParse(
+      await (
+        await send('POST', `/api/app/knowledge/fetch?orgId=${orgId}`, {
+          fileId: bigHandoff.data.storageRef,
+        })
+      ).json(),
+    );
+    const { FETCH_WINDOW_CHARS } = await import('./core/knowledge/fetch.ts');
+    record(
+      'knowledge fetch honours page as a window over the document',
+      pageOne.success &&
+        pageTwo.success &&
+        whole.success &&
+        whole.data.document.text.length > FETCH_WINDOW_CHARS &&
+        pageOne.data.document.text.length === FETCH_WINDOW_CHARS &&
+        pageTwo.data.document.text.length === FETCH_WINDOW_CHARS &&
+        pageOne.data.document.text !== pageTwo.data.document.text &&
+        pageOne.data.totalChars === whole.data.document.text.length &&
+        (pageOne.data.totalPages ?? 0) ===
+          Math.ceil(whole.data.document.text.length / FETCH_WINDOW_CHARS) &&
+        whole.data.page === undefined,
+      `whole=${whole.success ? whole.data.document.text.length : 'ERR'} chars, page1=${pageOne.success ? pageOne.data.document.text.length : 'ERR'}/${FETCH_WINDOW_CHARS} page2=${pageTwo.success ? pageTwo.data.document.text.length : 'ERR'}/${FETCH_WINDOW_CHARS} distinct=${pageOne.success && pageTwo.success && pageOne.data.document.text !== pageTwo.data.document.text} totalPages=${pageOne.success ? pageOne.data.totalPages : 'ERR'} wholeHasPage=${whole.success ? whole.data.page !== undefined : 'ERR'}(want false)`,
+    );
+
+    // The data-residency doors: `verify-ca` is one of the five modes the
+    // picker offers — the route gate must accept it (pre-fix a hand-rolled
+    // enum copy answered "invalid body"); a host the outbound policy refuses
+    // is a REPORTED test result and a coded 400 on save (pre-fix: a bare
+    // 500 with an error report filed, the fix sentence never shown). The
+    // cloud-metadata host is refused regardless of the private-host opt-in,
+    // and nothing is written, so the org's corpus stays where it is.
+    const blockedConnection = {
+      host: '169.254.169.254',
+      port: 5432,
+      database: 'knowledge',
+      user: 'tale',
+    };
+    const probeVerifyCa = await send(
+      'POST',
+      `/api/app/knowledge/connection/test?orgId=${orgId}`,
+      { ...blockedConnection, sslmode: 'verify-ca' },
+    );
+    const probeBody = z
+      .object({ ok: z.boolean(), error: z.string().optional() })
+      .loose()
+      .safeParse(await probeVerifyCa.json());
+    const saveBlocked = await send(
+      'POST',
+      `/api/app/knowledge/connection?orgId=${orgId}`,
+      { ...blockedConnection, sslmode: 'require', password: 'x' },
+    );
+    const saveBody = z
+      .object({ error: z.string(), message: z.string().optional() })
+      .loose()
+      .safeParse(await saveBlocked.json().catch(() => null));
+    let connectionWritten = true;
+    try {
+      await stat(path.join(dir, 'connection.json'));
+    } catch {
+      connectionWritten = false;
+    }
+    record(
+      'knowledge admin doors: verify-ca accepted, host refusal is a coded 4xx',
+      probeVerifyCa.status === 200 &&
+        probeBody.success &&
+        !probeBody.data.ok &&
+        (probeBody.data.error ?? '').includes('blocked') &&
+        saveBlocked.status === 400 &&
+        saveBody.success &&
+        saveBody.data.error === 'BLOCKED_HOST' &&
+        (saveBody.data.message ?? '').includes('blocked') &&
+        !connectionWritten,
+      `probe(verify-ca)=${probeVerifyCa.status}/200 ok=${probeBody.success ? probeBody.data.ok : 'ERR'}/false error=${JSON.stringify(probeBody.success ? (probeBody.data.error ?? '').slice(0, 60) : 'ERR')}, save(blocked host)=${saveBlocked.status}/400 code=${saveBody.success ? saveBody.data.error : 'ERR'}/BLOCKED_HOST written=${connectionWritten}(want false)`,
     );
   } finally {
     await new Promise<void>((resolve) => {
@@ -20665,6 +20995,15 @@ async function checkWebsitesCrawl(
   const scheduling = await import('./core/websites/scan_scheduling.ts');
 
   const DOMAIN = 'itest-crawl.example';
+  // The URL-list domain of step 4 — served by the same fake so the listed
+  // page really indexes (and can really 404 and come back).
+  const LIST_DOMAIN = 'itest-list.example';
+  const FAKE_HOSTS = new Set([
+    DOMAIN,
+    `www.${DOMAIN}`,
+    LIST_DOMAIN,
+    `www.${LIST_DOMAIN}`,
+  ]);
   const site = new Map<
     string,
     { body: string; type: string; status?: number }
@@ -20702,7 +21041,7 @@ async function checkWebsitesCrawl(
           ? input.toString()
           : input.url;
     const url = new URL(raw);
-    if (url.hostname === DOMAIN || url.hostname === `www.${DOMAIN}`) {
+    if (FAKE_HOSTS.has(url.hostname)) {
       const page = site.get(url.pathname);
       if (!page) return new Response('gone', { status: 404 });
       return new Response(page.body, {
@@ -20887,6 +21226,44 @@ async function checkWebsitesCrawl(
       `aChunks=${aChunks.length} allV2=${aChunks.every((c) => c.content.includes('v2'))}, b=${bRows[0]?.status}/deleted bChunks=${bChunks[0]?.count}/0, pages=${pagesAfterDrift.success ? pagesAfterDrift.data.total : 'ERR'}/2`,
     );
 
+    // 2b. The page comes back (a deploy gap closed, an origin fixed) with the
+    //     SAME bytes as before: the sitemap still lists it, so discovery
+    //     re-admits the `deleted` row and the fetch re-indexes it — identical
+    //     content with no chunks counts as changed. On the pre-fix engine
+    //     nothing ever moved a row out of `deleted`: the restored page stayed
+    //     dark until someone deleted and re-added the whole website.
+    site.set('/docs/b.txt', {
+      body: 'Bravo content. This nested page covers the bravo subsystem and exists to prove nested paths crawl and index correctly.',
+      type: 'text/plain',
+    });
+    await websites.runWebsitesScan(sql, {
+      domain: DOMAIN,
+      orgSlug,
+      organizationId: orgId,
+    });
+    await drainCrawlJobs();
+    const bRevived = await pool<
+      { status: string; failCount: number; chunks: string }[]
+    >`
+      SELECT u.status, u.fail_count AS "failCount",
+             (SELECT count(*)::text FROM public_web.chunks c
+               WHERE c.domain = u.domain AND c.url = u.url) AS chunks
+      FROM public_web.website_urls u
+      WHERE u.domain = ${DOMAIN} AND u.url = ${`https://${DOMAIN}/docs/b.txt`}
+    `;
+    const pagesAfterRevival = z
+      .object({ total: z.number() })
+      .safeParse(await (await get(`/${websiteId}/pages`)).json());
+    record(
+      'websites revival: a page that 404d once re-indexes when it is back',
+      bRevived[0]?.status === 'active' &&
+        bRevived[0].failCount === 0 &&
+        Number(bRevived[0].chunks) >= 1 &&
+        pagesAfterRevival.success &&
+        pagesAfterRevival.data.total === 3,
+      `b=${bRevived[0]?.status ?? 'MISSING'}/active fail=${bRevived[0]?.failCount ?? '?'}/0 chunks=${bRevived[0]?.chunks ?? '0'}>=1, pages=${pagesAfterRevival.success ? pagesAfterRevival.data.total : 'ERR'}/3`,
+    );
+
     // 3. The failure ledger: attempts advance the scheduler clock, repeated
     //    connection failures pause the site + notify admins ONCE, resume
     //    clears the bookkeeping and re-kicks a scan.
@@ -20954,7 +21331,6 @@ async function checkWebsitesCrawl(
         ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
       });
 
-    const LIST_DOMAIN = 'itest-list.example';
     site.set('/list-1.txt', {
       body: 'Listed page one for the curated URL list lane with enough words to index without any discovery pass at all.',
       type: 'text/plain',
@@ -20985,6 +21361,50 @@ async function checkWebsitesCrawl(
     const listKind = await pool<{ kind: string }[]>`
       SELECT kind FROM public_web.websites WHERE domain = ${LIST_DOMAIN}
     `;
+
+    // 4b. A listed page that 404s is pruned like any other — and REVIVED on
+    //     the next scan without anyone re-saving the list: the list is a
+    //     standing instruction, so the scan puts listed `deleted` rows back
+    //     on the frontier and the fetch decides. Pre-fix, a listed page gone
+    //     for one deploy left the list silently one page shorter for good.
+    const listUrl = `https://${LIST_DOMAIN}/list-1.txt`;
+    const listBody = site.get('/list-1.txt');
+    site.delete('/list-1.txt');
+    await websites.runWebsitesScan(sql, {
+      domain: LIST_DOMAIN,
+      orgSlug,
+      organizationId: orgId,
+    });
+    await drainCrawlJobs();
+    const listPruned = await pool<{ status: string }[]>`
+      SELECT status FROM public_web.website_urls
+      WHERE domain = ${LIST_DOMAIN} AND url = ${listUrl}
+    `;
+    if (listBody) site.set('/list-1.txt', listBody);
+    await websites.runWebsitesScan(sql, {
+      domain: LIST_DOMAIN,
+      orgSlug,
+      organizationId: orgId,
+    });
+    await drainCrawlJobs();
+    const listRevived = await pool<
+      { status: string; listed: boolean; failCount: number; chunks: string }[]
+    >`
+      SELECT u.status, u.listed, u.fail_count AS "failCount",
+             (SELECT count(*)::text FROM public_web.chunks c
+               WHERE c.domain = u.domain AND c.url = u.url) AS chunks
+      FROM public_web.website_urls u
+      WHERE u.domain = ${LIST_DOMAIN} AND u.url = ${listUrl}
+    `;
+    record(
+      'websites revival: a listed page that 404d is re-probed next scan',
+      listPruned[0]?.status === 'deleted' &&
+        listRevived[0]?.status === 'active' &&
+        listRevived[0].listed &&
+        listRevived[0].failCount === 0 &&
+        Number(listRevived[0].chunks) >= 1,
+      `pruned=${listPruned[0]?.status ?? 'MISSING'}/deleted, revived=${listRevived[0]?.status ?? 'MISSING'}/active listed=${listRevived[0]?.listed} fail=${listRevived[0]?.failCount ?? '?'}/0 chunks=${listRevived[0]?.chunks ?? '0'}>=1`,
+    );
 
     const restList = z
       .object({ page: z.array(z.object({ id: z.string() })) })
@@ -21035,7 +21455,8 @@ async function checkWebsitesCrawl(
         restList.data.page.length >= 2 &&
         restPatch.status === 204 &&
         restPages.success &&
-        restPages.data.total === 2 &&
+        // 3 again: step 2b brought the 404'd page back.
+        restPages.data.total === 3 &&
         restSync.success &&
         restSync.data.status === 'syncing' &&
         restSearch.success &&
@@ -21043,7 +21464,7 @@ async function checkWebsitesCrawl(
         restDeleteSite.status === 204 &&
         Number(corpusGone[0]?.count ?? '9') === 0 &&
         Number(rowsGone[0]?.count ?? '9') === 0,
-      `list=${listCreated.success}/${listBadUrl.status}(want 400) urls=${listedUrls.length}/1 listed=${listedUrls[0]?.listed} kind=${listKind[0]?.kind}, rest list=${restList.success ? restList.data.page.length : 'ERR'}>=2 patch=${restPatch.status}/204 pages=${restPages.success ? restPages.data.total : 'ERR'}/2 sync=${restSync.success ? restSync.data.status : 'ERR'} search=${restSearch.success}, delete=${restDeleteList.status}/${restDeleteSite.status} corpusGone=${corpusGone[0]?.count}/0 rowsGone=${rowsGone[0]?.count}/0`,
+      `list=${listCreated.success}/${listBadUrl.status}(want 400) urls=${listedUrls.length}/1 listed=${listedUrls[0]?.listed} kind=${listKind[0]?.kind}, rest list=${restList.success ? restList.data.page.length : 'ERR'}>=2 patch=${restPatch.status}/204 pages=${restPages.success ? restPages.data.total : 'ERR'}/3 sync=${restSync.success ? restSync.data.status : 'ERR'} search=${restSearch.success}, delete=${restDeleteList.status}/${restDeleteSite.status} corpusGone=${corpusGone[0]?.count}/0 rowsGone=${rowsGone[0]?.count}/0`,
     );
   } finally {
     globalThis.fetch = realFetch;

--- a/services/platform/backend/rest/v1-core.ts
+++ b/services/platform/backend/rest/v1-core.ts
@@ -34,7 +34,6 @@ import {
   DocumentError,
   getDocumentById,
   listHubDocumentsPage,
-  loadDocumentOrThrow,
   readDocumentRestExtras,
   updateDocument,
   type DocumentRow,
@@ -443,13 +442,13 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       const result = await deps.sql.begin((tx) =>
         updateDocument(tx, auth, { documentId: doc.id, ...body.data }),
       );
-      // A team change is a corpus SCOPE change — re-stamp retrieval filters
-      // after commit, exactly as the app route does (best-effort, logged
-      // inside), or the REST door leaves the corpus answering with the old
-      // team's scope.
-      if (result.teamScopeChanged && result.fileRef !== null) {
-        const updated = await loadDocumentOrThrow(deps.sql, doc.id);
-        await syncRagDocumentScope(deps.sql, auth.organizationId, updated);
+      // Same post-commit re-stamp as the app door: a team or folder change
+      // moves the corpus filters, not the embeddings.
+      if (
+        (result.teamScopeChanged || result.folderChanged) &&
+        result.fileRef !== null
+      ) {
+        await syncRagDocumentScope(deps.sql, auth.organizationId, doc.id);
       }
       return c.body(null, 204);
     } catch (error) {


### PR DESCRIPTION
Six verified medium-severity knowledge-domain defects — dead-ends where a feature silently returned nothing, and misleading signals — from the backend deep-review campaign. Base is `fedc8cc15` (has #3140 / #3160). No migration.

## Per-finding outcome

| #   | Finding                                                                                   | Outcome   | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
| --- | ----------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Folder-scoped knowledge search always returns zero document hits (`service.ts:447`)       | **fixed** | `indexUploadedFile` never passed `folderPath` to `indexDocument`, so every 0.5 corpus row had `folder_path NULL` and the prefix clause matched nothing; the retrievable re-check dropped `folder`. Now: the ingest stamps the document's canonical folder path; the re-check decides from the document's CURRENT folder (`decideRetrievable(…, folder)`); `syncRagDocumentScope` re-stamps folder + scope from the current row and is called on document move (app + REST v1), OneDrive re-file, WebDAV MOVE; `syncRagFolderSubtree` re-stamps everything beneath a renamed/moved folder (app rename, WebDAV folder MOVE). Base: `stamp=NULL`, zero hits under `Reports`; branch: found under `Reports` and `/Reports/`, not under `Invoices`, follows move → `Archive` and rename → `Vault`. Also in this finding: `/fetch` accepted `page` and ignored it — now a `FETCH_WINDOW_CHARS` window with `page/totalPages/totalChars`. |
| 2   | A page that once 404'd is excluded from crawling forever (`crawl.ts:130`)                 | **fixed** | 404/410 set `status='deleted'`; all three re-admission doors skipped existing rows (`DO NOTHING` ×2, `SET listed = TRUE`). One admission statement (`admitUrls`) now revives a `deleted` row to `discovered` with `fail_count` cleared when discovery links it again or the operator re-lists it; each scan also revives listed `deleted` rows (`reviveListedUrls`) — the list is a standing instruction, one probe per scan is the bounded cost. Base: restored page stays `deleted`, 0 chunks; branch: `active`, chunks ≥ 1, page count back to 3 (site kind) and the listed page re-indexes (list kind).                                                                                                                                                                                                                                                                                                                        |
| 3   | `rag_error_code` is read by the UI but never written (`service.ts:312`)                   | **fixed** | Column exists (0010), `view.ts` selects it, the badge branches on `embedding_not_configured` to show the Settings → Data residency deep link — but `writeRagStatus` had no field. Now written alongside `rag_error` (and cleared with it); the `EmbeddingNotConfigured` prose points at Settings instead of an operator file path. Base: `code=NULL`, prose names `knowledge/embedding.json`; branch: `code=embedding_not_configured`, retry after configuring clears both.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| 4   | Dimension pin marked applied when the chunks table is absent (`dimensions.ts:115`)        | **fixed** | `applyPin` returned early on 42P01 yet `.then()` recorded pinned + applied, so later writes skipped the ALTER/HNSW for the process lifetime. `applyPin` now reports whether it took effect; nothing is recorded otherwise and the next write retries. The test that codified the drift (`"leaves nothing pinned"` asserting 1536) now asserts nothing pinned; a new test proves the pin lands once the table appears.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| 5   | sslmode `verify-ca` offered in UI but rejected by route-local enum copy (`routes.ts:157`) | **fixed** | The wire body is now the shared `knowledgeConnectionSchema` field schemas in a strip-mode object (one source of truth; strictness stays the config-file policy). Base: probe with `verify-ca` → 400 `invalid body`; branch: accepted.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| 6   | Host-policy refusals on knowledge admin endpoints surface as 500 (`admin.ts:168`)         | **fixed** | `checkProviderHostPolicy` throws `AppError`; the routes mapped only `KnowledgeAdminError` (and `/connection/test` had no mapping at all). `assertHostAllowed` translates to `KnowledgeAdminError(code, message, 400)`; the probe reports `{ ok: false, error }` like every other test failure. Base: save → 500; branch: 400 `BLOCKED_HOST` / `PRIVATE_HOST_BLOCKED` with the sentence naming `TALE_ALLOW_PRIVATE_PROVIDER_HOSTS=1`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |

## Tests

Colocated vitest (all red on base — 27 of the new/changed assertions fail against `fedc8cc15`, the three invariants pass on both sides):

- `core/knowledge/dimensions.test.ts` — corrected drift assertion + late-table pin (17 tests)
- `core/knowledge/crawl.test.ts` — the admission statement (revive/listed/placeholders), batching, dedupe, `registerUrlList`, `reviveListedUrls` (8)
- `domains/knowledge/retrievable.test.ts` — folder filter: containment, separator, siblings, root, access on top, unbound files never admit, no-op without folder (+5)
- `domains/folders/paths.test.ts` — `normalizeFolderPath`, `documentFolderPathFrom` (6)
- `domains/knowledge/routes.test.ts` — verify-ca save/probe, out-of-set mode still 400, policy refusal → 400 with code on save and probe, fetch paging window / whole / miss (8)
- `domains/knowledge/admin.test.ts` — metadata host → `BLOCKED_HOST` 400, private host names the env opt-in, blocked embedding baseUrl, probe reports `ok:false` (4)

Integration check (`backend:integration`, real Postgres + MinIO), seven new lanes: unconfigured-embedding upload writes the code; retry after configuring clears it; folder-scoped search finds the folder's documents (both spellings, not other folders, root doc excluded); stamp follows move and rename; fetch page window; admin doors (verify-ca accepted, host refusal coded 4xx, nothing written); site-kind 404'd page re-indexes when back; list-kind listed page re-probed next scan.

## Verification

- `bunx tsc --noEmit` (platform): clean.
- `bunx oxlint --type-aware` on every touched file: clean.
- vitest (six touched files): 57/57 on branch; 27 red on base.
- `backend:integration` on throwaway `tale-db` + MinIO, fresh containers per run, `SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD` set: **branch 382/383**, **base 374/383** with this branch's `integration-check.ts` — the base reds are exactly the new knowledge lanes plus the pre-existing `webdav re-home` lane, which fails on base with byte-identical detail (unrelated, noted below).

## Cross-class discoveries (not fixed here)

- `MAX_FETCH_FAILURES` saturation is a sibling dead-end: a page that failed 5 scans in a row (non-404 errors) is never fetched again and nothing resets `fail_count` except a success it can no longer have. Left as designed (the cap's intent is consecutive-failure backoff); reviving on re-discovery would defeat it. Worth a bounded retry policy of its own.
- Two folder-path spellings coexist in `app.documents.folder_path`: WebDAV writes the 0.4 `'/A/B'`, OneDrive/`buildHubFolderPath` write `'A/B'`; and the denormalized column goes stale after a folder rename (only the folder row is renamed). `normalizeFolderPath` + tree-first resolution make the knowledge filter immune; `agent-list.ts` now prefers the tree too (and normalizes), so agents can hand a listed path straight back as a `folder` filter. Other readers of the raw column (`searchDocumentsView` snippet) still show the stale/unnormalized value.
- REST v1 `PATCH /documents/:id` never re-stamped the corpus on a team change (only the app door did) — fixed in passing here since the same seam carries the folder re-stamp.
- The harness's websites lane never served the URL-list domain from its fake fetch, so the listed page was never actually indexed by that lane (it only asserted the row existed). Fixed in the lane.
- `webdav re-home` integration lane fails on base and branch with identical detail (`chunked=500 (want 500) … ghost={"deleted":false}`) — pre-existing, not touched here.
