### PR TITLE
fix(sandbox): reclaim, fair reconcile, pins, scope, safe rollback

### DIFF
--- a/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.test.ts
@@ -546,7 +546,9 @@ describe('dispatchWorkspaceToolImpl', () => {
     );
     const { dispatch } = await getActions();
     // The default scope mock resolves a binding (allowed), so document_find
-    // lists through listDocumentsForScope with the binding's teams+project.
+    // lists through listDocumentsForScope with the binding's teams + EVERY
+    // authorized project — an org-wide run of a two-project automation lists
+    // both boards' files, not the first one's.
     const result = await dispatch(
       createCtx({
         readQuery,
@@ -554,7 +556,7 @@ describe('dispatchWorkspaceToolImpl', () => {
           allowed: true,
           scope: {
             teamIds: ['team_a'],
-            projectIds: ['proj_1'],
+            projectIds: ['proj_1', 'proj_2'],
             includeHub: true,
           },
         },
@@ -571,7 +573,8 @@ describe('dispatchWorkspaceToolImpl', () => {
     );
     expect(qArgs.organizationId).toBe('org_1');
     expect(qArgs.teamIds).toEqual(['team_a']);
-    expect(qArgs.projectId).toBe('proj_1');
+    expect(qArgs.projectIds).toEqual(['proj_1', 'proj_2']);
+    expect(qArgs.projectId).toBeUndefined();
     // A binding read never carries a user id.
     expect(qArgs.userId).toBeUndefined();
   });

--- a/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.ts
+++ b/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.ts
@@ -402,8 +402,10 @@ async function runWorkspaceTool(
         {
           organizationId: args.organizationId,
           teamIds: [...bound.scope.teamIds],
-          ...(bound.scope.projectIds[0] !== undefined
-            ? { projectId: bound.scope.projectIds[0] }
+          // EVERY authorized project — a multi-bound automation's run lists
+          // the files of all its bound projects, not the first one's.
+          ...(bound.scope.projectIds.length > 0
+            ? { projectIds: [...bound.scope.projectIds] }
             : {}),
           ...(typeof callArgs.fileName === 'string'
             ? { fileName: callArgs.fileName }

--- a/services/platform/backend/db/migrations/0072_sandbox_sessions_last_reconciled.sql
+++ b/services/platform/backend/db/migrations/0072_sandbox_sessions_last_reconciled.sql
@@ -1,0 +1,27 @@
+-- The sandbox watchdog's fair-scan stamp: when a session row was last checked
+-- against the spawner.
+--
+-- The 5-minute drift sweep (domains/sandbox/watchdogs.ts) probes a bounded
+-- batch of compute-holding rows against the spawner — a container gone
+-- spawner-side settles its row as destroyed (the phantom heal) — and, since
+-- the same change, reclaims the per-run sessions of ended automation runs.
+-- The reconcile batch used to be the 25 GLOBALLY-OLDEST rows by created_at_ms
+-- with no rotation: long-lived healthy sessions (a pinned always-on agent
+-- never expires) sat at the head forever, so a younger phantom `active` row
+-- behind them was never probed and held one of the org's few slots until its
+-- 24h TTL — indefinitely when pinned. Every spawner-facing pass now orders its
+-- batch by this stamp (NULL = never visited, first) and stamps the rows it
+-- visited, so the walk is a round-robin over the whole table: every row is
+-- reached within ceil(rows / batch) ticks whatever sits at the head.
+--
+-- Nullable, no backfill: an unstamped row simply sorts first. Rolling-deploy
+-- safe — the previous image never reads or writes the column.
+
+ALTER TABLE app.sandbox_sessions
+  ADD COLUMN IF NOT EXISTS last_reconciled_at_ms bigint;
+
+-- The sweep's walk order: the status filter, then the least-recently visited
+-- row first (never visited before any visited), oldest incarnation first
+-- among equals.
+CREATE INDEX IF NOT EXISTS sandbox_sessions_reconcile_order
+  ON app.sandbox_sessions (status, last_reconciled_at_ms NULLS FIRST, created_at_ms);

--- a/services/platform/backend/domains/documents/agent-list.ts
+++ b/services/platform/backend/domains/documents/agent-list.ts
@@ -25,6 +25,10 @@ export interface AgentDocumentListArgs {
   /** An ALREADY-AUTHORIZED project: set → that project's docs; absent → the
    *  hub lane (project docs excluded). */
   projectId?: string;
+  /** Several ALREADY-AUTHORIZED projects — the binding door's shape for an
+   *  org-wide run of a multi-bound automation (its bound projects). Non-empty
+   *  → those projects' docs; takes precedence over `projectId`. */
+  projectIds?: string[];
   /** Substring match on the title, case-insensitive. */
   fileName?: string;
   /** Exact match; stored lowercased without the dot (e.g. `pdf`). */
@@ -57,7 +61,15 @@ export async function listDocumentsForAgent(
 ): Promise<AgentDocumentPage> {
   const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
   const offset = Math.max(0, args.cursor ?? 0);
-  const projectId = args.projectId ?? null;
+  // The project lane is a SET: the chat door's one validated project, or the
+  // binding door's bound projects. Empty → the hub lane.
+  const projectIds =
+    args.projectIds !== undefined && args.projectIds.length > 0
+      ? args.projectIds
+      : args.projectId !== undefined
+        ? [args.projectId]
+        : [];
+  const projectLane = projectIds.length > 0;
   const like = `%${args.fileName?.trim() ?? ''}%`;
   const rows = await sql<
     {
@@ -94,8 +106,8 @@ export async function listDocumentsForAgent(
       AND (${args.extension === undefined}
         OR d.extension = ${args.extension ?? ''})
       AND (
-        (${projectId}::text IS NOT NULL AND d.project_id = ${projectId})
-        OR (${projectId}::text IS NULL AND d.project_id IS NULL AND (
+        (${projectLane} AND d.project_id = ANY(${projectIds}))
+        OR (${!projectLane} AND d.project_id IS NULL AND (
           (d.team_id IS NULL AND cardinality(d.team_tags) = 0)
           OR d.team_id = ANY(${args.teamIds})
           OR d.team_tags && ${args.teamIds}

--- a/services/platform/backend/domains/sandbox/service.ts
+++ b/services/platform/backend/domains/sandbox/service.ts
@@ -171,12 +171,17 @@ export async function pinSession(
 }
 
 /** Watchdog reconcile for one row: a container gone spawner-side settles the
- * platform row as destroyed; a live one is left alone. */
+ * platform row as destroyed; a live one is left alone. The liveness probe is
+ * injectable (the watchdog's scripted spawner in tests and the integration
+ * probe); production asks the signed session client. */
 export async function reconcileSession(
   sql: Sql,
   args: { organizationId: string; sessionId: string },
+  deps: { isAlive: (sessionId: string) => Promise<boolean> } = {
+    isAlive: sessionIsAlive,
+  },
 ): Promise<'live' | 'healed'> {
-  if (await sessionIsAlive(args.sessionId)) {
+  if (await deps.isAlive(args.sessionId)) {
     return 'live';
   }
   await markSessionDestroyed(sql, args);

--- a/services/platform/backend/domains/sandbox/shim.knowledge-scope.test.ts
+++ b/services/platform/backend/domains/sandbox/shim.knowledge-scope.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment node
+
+/**
+ * Unit lock for the session-binding knowledge scope: an org-wide run of a
+ * MULTI-BOUND automation reads its own bound projects' files (plus the hub),
+ * an automation with no bindings stays hub-only, a project session reads its
+ * one project, and a bound project whose row is gone contributes nothing.
+ * The real-Postgres probe (`integration-check.ts`) drives `document_find`
+ * through the tool door over two bound projects.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { listDocumentsForAgent } from '../documents/agent-list.ts';
+import { sandboxToolShimHandlers } from './shim.ts';
+
+vi.mock('../documents/agent-list.ts', () => ({
+  listDocumentsForAgent: vi.fn(() =>
+    Promise.resolve({
+      documents: [],
+      totalCount: null,
+      hasMore: false,
+      cursor: null,
+      warning: null,
+    }),
+  ),
+}));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+interface ProjectRow {
+  id: string;
+  teamId: string | null;
+  shared: string[];
+  archivedAt: number | null;
+}
+
+/**
+ * Scripted `sql` for the binding resolver's four reads: the session row, the
+ * run row, the binding rows, and the project rows. Everything else answers
+ * with no rows.
+ */
+function fakeSql(script: {
+  session?: { ownerType: string; ownerId: string };
+  run?: { name: string; projectId: string | null };
+  agent?: { id: string; projectId: string };
+  bindings?: string[];
+  projects?: ProjectRow[];
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const fn = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join('?');
+    statements.push({ text, values });
+    if (text.includes('FROM app.sandbox_sessions')) {
+      return Promise.resolve(script.session ? [script.session] : []);
+    }
+    if (text.includes('FROM app.automation_runs')) {
+      return Promise.resolve(script.run ? [script.run] : []);
+    }
+    if (text.includes('FROM app.project_agents')) {
+      return Promise.resolve(script.agent ? [script.agent] : []);
+    }
+    if (text.includes('FROM app.automation_project_bindings')) {
+      return Promise.resolve(
+        (script.bindings ?? []).map((projectId) => ({ projectId })),
+      );
+    }
+    if (text.includes('FROM app.projects')) {
+      const wanted = values.find(Array.isArray);
+      const rows = script.projects ?? [];
+      // The existence probe (`SELECT id … WHERE id = ?`) and the scope read
+      // (`WHERE id = ANY(?)`) both answer from the same project set.
+      if (Array.isArray(wanted)) {
+        return Promise.resolve(rows.filter((row) => wanted.includes(row.id)));
+      }
+      const single = values[0];
+      return Promise.resolve(
+        rows.filter((row) => row.id === single).map((row) => ({ id: row.id })),
+      );
+    }
+    return Promise.resolve([]);
+  };
+  return { sql: fn as unknown as Sql, statements };
+}
+
+const ORG = 'org_1';
+
+async function resolveScope(
+  sql: Sql,
+): Promise<{ allowed: boolean; scope?: Record<string, unknown> }> {
+  const handler =
+    sandboxToolShimHandlers(sql)[
+      'sandbox/workspace_access:resolveKnowledgeToolAccess'
+    ];
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the handler's own return shape
+  return (await handler?.({
+    organizationId: ORG,
+    sessionId: 'ses-1',
+    subject: 'documents',
+  })) as { allowed: boolean; scope?: Record<string, unknown> };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveKnowledgeToolAccess — org-wide run of a multi-bound automation', () => {
+  it('reads EVERY bound project (its teams, shared teams, archived labels) plus the hub', async () => {
+    const { sql } = fakeSql({
+      session: { ownerType: 'workflow_run', ownerId: 'run-1:@workflow' },
+      run: { name: 'triage', projectId: null },
+      bindings: ['p-alpha', 'p-beta'],
+      projects: [
+        {
+          id: 'p-alpha',
+          teamId: 'team-a',
+          shared: ['team-s'],
+          archivedAt: null,
+        },
+        {
+          id: 'p-beta',
+          teamId: null,
+          shared: [],
+          archivedAt: 1_700_000_000_000,
+        },
+      ],
+    });
+
+    const access = await resolveScope(sql);
+
+    expect(access.allowed).toBe(true);
+    expect(access.scope).toEqual({
+      teamIds: [`org_${ORG}`, 'team-a', 'team-s'],
+      projectIds: ['p-alpha', 'p-beta'],
+      includeHub: true,
+      archivedProjectIds: ['p-beta'],
+    });
+  });
+
+  it('a bound project whose row is gone contributes nothing — never a widening', async () => {
+    const { sql } = fakeSql({
+      session: { ownerType: 'workflow_run', ownerId: 'run-1:@workflow' },
+      run: { name: 'triage', projectId: null },
+      bindings: ['p-alpha', 'p-gone'],
+      projects: [
+        { id: 'p-alpha', teamId: 'team-a', shared: [], archivedAt: null },
+      ],
+    });
+
+    const access = await resolveScope(sql);
+
+    expect(access.scope).toMatchObject({
+      projectIds: ['p-alpha'],
+      teamIds: [`org_${ORG}`, 'team-a'],
+      includeHub: true,
+    });
+  });
+
+  it('an automation with NO bindings stays hub-only (org-level)', async () => {
+    const { sql } = fakeSql({
+      session: { ownerType: 'workflow_run', ownerId: 'run-1:@workflow' },
+      run: { name: 'digest', projectId: null },
+      bindings: [],
+    });
+
+    const access = await resolveScope(sql);
+
+    expect(access.scope).toEqual({
+      teamIds: [`org_${ORG}`],
+      projectIds: [],
+      includeHub: true,
+      archivedProjectIds: [],
+    });
+  });
+
+  it('a run PINNED to a project reads that one project (unchanged)', async () => {
+    const { sql } = fakeSql({
+      session: { ownerType: 'workflow_run', ownerId: 'run-1:agent' },
+      run: { name: 'triage', projectId: 'p-alpha' },
+      projects: [
+        {
+          id: 'p-alpha',
+          teamId: 'team-a',
+          shared: ['team-s'],
+          archivedAt: null,
+        },
+      ],
+    });
+
+    const access = await resolveScope(sql);
+
+    expect(access.scope).toEqual({
+      teamIds: [`org_${ORG}`, 'team-a', 'team-s'],
+      projectIds: ['p-alpha'],
+      includeHub: true,
+      archivedProjectIds: [],
+    });
+  });
+});
+
+describe('listDocumentsForScope — the binding door', () => {
+  it('passes the whole authorized project set through to the listing', async () => {
+    const { sql } = fakeSql({});
+    const handler =
+      sandboxToolShimHandlers(sql)[
+        'documents/internal_queries:listDocumentsForScope'
+      ];
+
+    await handler?.({
+      organizationId: ORG,
+      teamIds: [`org_${ORG}`],
+      projectIds: ['p-alpha', 'p-beta'],
+      limit: 10,
+    });
+
+    expect(listDocumentsForAgent).toHaveBeenCalledWith(sql, {
+      organizationId: ORG,
+      teamIds: [`org_${ORG}`],
+      projectIds: ['p-alpha', 'p-beta'],
+      limit: 10,
+    });
+  });
+});

--- a/services/platform/backend/domains/sandbox/shim.ts
+++ b/services/platform/backend/domains/sandbox/shim.ts
@@ -136,11 +136,19 @@ async function resolveSessionBinding(
   return { kind: 'none' };
 }
 
-/** The project's readable team set for a project-bound knowledge scope. */
-async function projectKnowledgeScope(
+/**
+ * The knowledge scope over a set of ALREADY-AUTHORIZED projects: each
+ * project's team and shared teams, the org pseudo-team, the hub, and the
+ * archived subset (labelling only). One helper for both bindings — a project
+ * session reads its one project, an org-wide run of a multi-bound automation
+ * reads its bound projects. Built from the `projects` rows that EXIST: a bound
+ * id whose project is gone contributes nothing (the fail-closed direction),
+ * never a widening.
+ */
+async function projectsKnowledgeScope(
   sql: Sql,
   organizationId: string,
-  projectId: string,
+  projectIds: readonly string[],
 ): Promise<{
   teamIds: string[];
   projectIds: string[];
@@ -148,23 +156,31 @@ async function projectKnowledgeScope(
   archivedProjectIds: string[];
 }> {
   const rows = await sql<
-    { teamId: string | null; shared: string[]; archivedAt: number | null }[]
+    {
+      id: string;
+      teamId: string | null;
+      shared: string[] | null;
+      archivedAt: number | null;
+    }[]
   >`
-    SELECT team_id AS "teamId", shared_with_team_ids AS shared,
+    SELECT id, team_id AS "teamId", shared_with_team_ids AS shared,
            archived_at_ms::float8 AS "archivedAt"
     FROM app.projects
-    WHERE id = ${projectId} AND org_id = ${organizationId}
-    LIMIT 1
+    WHERE id = ANY(${[...projectIds]}) AND org_id = ${organizationId}
+    ORDER BY created_at_ms, id
   `;
-  const row = rows[0];
   const teamIds = new Set<string>([`org_${organizationId}`]);
-  if (row?.teamId != null) teamIds.add(row.teamId);
-  for (const teamId of row?.shared ?? []) teamIds.add(teamId);
+  const archivedProjectIds: string[] = [];
+  for (const row of rows) {
+    if (row.teamId != null) teamIds.add(row.teamId);
+    for (const teamId of row.shared ?? []) teamIds.add(teamId);
+    if (row.archivedAt != null) archivedProjectIds.push(row.id);
+  }
   return {
     teamIds: [...teamIds],
-    projectIds: [projectId],
+    projectIds: rows.map((row) => row.id),
     includeHub: true,
-    archivedProjectIds: row?.archivedAt != null ? [projectId] : [],
+    archivedProjectIds,
   };
 }
 
@@ -294,17 +310,31 @@ export function sandboxToolShimHandlers(sql: Sql): ShimHandlers {
       if (binding.kind === 'project' && binding.projectId !== undefined) {
         return {
           allowed: true,
-          scope: await projectKnowledgeScope(
-            sql,
-            args.organizationId,
+          scope: await projectsKnowledgeScope(sql, args.organizationId, [
             binding.projectId,
-          ),
+          ]),
         };
       }
       if (binding.kind === 'org_run') {
-        // An org-level run reads the org HUB — the knowledge every member
-        // shares — not the union of every project's attached files. The
-        // pseudo-team is what makes a hub document visible at all in 0.5.
+        const bound = binding.boundProjectIds ?? [];
+        if (bound.length > 0) {
+          // A multi-bound automation's run reads ITS bound projects' files —
+          // the same projects `resolveSessionActionContext` confines its task
+          // and document actions to — plus the hub. Hub-only here made the
+          // very documents the run was deployed over `not_found` mid-run.
+          return {
+            allowed: true,
+            scope: await projectsKnowledgeScope(
+              sql,
+              args.organizationId,
+              bound,
+            ),
+          };
+        }
+        // An automation with NO bindings is org-level: it reads the org HUB —
+        // the knowledge every member shares — not the union of every
+        // project's attached files. The pseudo-team is what makes a hub
+        // document visible at all in 0.5.
         return {
           allowed: true,
           scope: {
@@ -404,17 +434,23 @@ export function sandboxToolShimHandlers(sql: Sql): ShimHandlers {
         organizationId: string;
         teamIds: string[];
         projectId?: string;
+        /** The binding's project set — one for a project session, every
+         * bound project for a multi-bound automation's run. */
+        projectIds?: string[];
         fileName?: string;
         extension?: string;
         limit?: number;
         cursor?: number;
       };
-      // The binding door: the bridge already resolved the scope (teams + at
-      // most one project), so it passes straight through.
+      // The binding door: the bridge already resolved the scope (teams + the
+      // authorized projects), so it passes straight through.
       return listDocumentsForAgent(sql, {
         organizationId: args.organizationId,
         teamIds: args.teamIds,
         ...(args.projectId !== undefined ? { projectId: args.projectId } : {}),
+        ...(args.projectIds !== undefined
+          ? { projectIds: args.projectIds }
+          : {}),
         ...(args.fileName !== undefined ? { fileName: args.fileName } : {}),
         ...(args.extension !== undefined ? { extension: args.extension } : {}),
         ...(args.limit !== undefined ? { limit: args.limit } : {}),

--- a/services/platform/backend/domains/sandbox/watchdogs.test.ts
+++ b/services/platform/backend/domains/sandbox/watchdogs.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment node
+
+/**
+ * Unit lock for the sandbox sweep's spawner-facing passes: the reconcile
+ * batch is a FAIR walk (least-recently-visited first, every visited row
+ * stamped — not the 25 globally-oldest rows forever), and the ended-run
+ * reclaim settles a row only when the spawner confirmed the session is gone
+ * or idle (busy and errors leave it for the next tick). The real-Postgres
+ * probe (`integration-check.ts`) proves the rotation and the reclaim guards
+ * on the actual schema.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reconcileSession } from './service.ts';
+import { markSessionDestroyed } from './sessions.ts';
+import {
+  runSandboxWatchdog,
+  SANDBOX_RUN_SESSION_RECLAIM_GRACE_MS,
+  type WatchdogSpawner,
+} from './watchdogs.ts';
+
+vi.mock('../../core/node_only/sandbox/helpers/session_client.ts', () => ({
+  sessionIsAlive: vi.fn(),
+  sessionDestroyIfIdle: vi.fn(),
+}));
+vi.mock('../tasks/agent-runs.ts', () => ({
+  wakeParkedAgentRuns: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('./service.ts', () => ({ reconcileSession: vi.fn() }));
+vi.mock('./sessions.ts', () => ({
+  markSessionDestroyed: vi.fn(() => Promise.resolve(true)),
+  reapStaleAdmissionTickets: vi.fn(() => Promise.resolve(0)),
+}));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+interface Candidate {
+  id: string;
+  sessionId: string;
+  orgId: string;
+}
+
+/**
+ * Scripted `sql`: the reconcile SELECT and the reclaim SELECT pop from their
+ * scripts; the EXPIRE update and the visit stamps answer with no rows. Every
+ * statement is recorded for shape assertions.
+ */
+function fakeSql(script: {
+  reconcile?: Candidate[][];
+  reclaim?: Candidate[][];
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const fn = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join('?');
+    statements.push({ text, values });
+    if (text.includes("s.owner_type = 'workflow_run'")) {
+      return Promise.resolve(script.reclaim?.shift() ?? []);
+    }
+    if (
+      text.includes('SELECT id, session_id') &&
+      text.includes("WHERE status IN ('creating', 'active', 'degraded')")
+    ) {
+      return Promise.resolve(script.reconcile?.shift() ?? []);
+    }
+    return Promise.resolve([]);
+  };
+  return { sql: fn as unknown as Sql, statements };
+}
+
+function candidate(id: string): Candidate {
+  return { id, sessionId: `ses-${id}`, orgId: 'org_1' };
+}
+
+const stampsOf = (statements: Statement[]): Statement[] =>
+  statements.filter((s) => s.text.includes('SET last_reconciled_at_ms'));
+
+beforeEach(() => {
+  vi.mocked(reconcileSession).mockResolvedValue('live');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runSandboxWatchdog — fair reconcile', () => {
+  it('walks least-recently-visited first, probes with the injected spawner, and stamps every visited row', async () => {
+    const batch = [candidate('a'), candidate('b'), candidate('c')];
+    const { sql, statements } = fakeSql({ reconcile: [batch] });
+    const spawner: WatchdogSpawner = {
+      isAlive: vi.fn(() => Promise.resolve(true)),
+      destroyIfIdle: vi.fn(() =>
+        Promise.resolve({ destroyed: false, busy: false }),
+      ),
+    };
+    vi.mocked(reconcileSession).mockResolvedValueOnce('healed');
+
+    const result = await runSandboxWatchdog(sql, {
+      reconcileBatch: 3,
+      spawner,
+    });
+
+    expect(result).toMatchObject({ healed: 1, reclaimed: 0 });
+    const select = statements.find(
+      (s) =>
+        s.text.includes('SELECT id, session_id') &&
+        s.text.includes("WHERE status IN ('creating', 'active', 'degraded')"),
+    );
+    // The rotation: never-visited rows first, then the stalest visit — NOT
+    // `ORDER BY created_at_ms`, which parked the same 25 oldest rows at the
+    // head of every tick.
+    expect(select?.text).toContain(
+      'ORDER BY last_reconciled_at_ms ASC NULLS FIRST, created_at_ms ASC',
+    );
+    expect(select?.values).toContain(3);
+
+    // Each candidate probed through the injected liveness verb.
+    expect(reconcileSession).toHaveBeenCalledTimes(3);
+    for (const row of batch) {
+      expect(reconcileSession).toHaveBeenCalledWith(
+        sql,
+        { organizationId: row.orgId, sessionId: row.sessionId },
+        { isAlive: spawner.isAlive },
+      );
+    }
+
+    // Every visited row is stamped in one statement, by primary key.
+    const stamps = stampsOf(statements);
+    expect(stamps).toHaveLength(1);
+    expect(stamps[0]?.values).toContainEqual(['a', 'b', 'c']);
+  });
+
+  it('stamps a row whose probe failed too, so a persistently erroring row cannot block the rotation', async () => {
+    const { sql, statements } = fakeSql({
+      reconcile: [[candidate('x'), candidate('y')]],
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(reconcileSession).mockRejectedValueOnce(
+      new Error('spawner unreachable'),
+    );
+
+    const result = await runSandboxWatchdog(sql, {
+      reconcileBatch: 2,
+      spawner: {
+        isAlive: vi.fn(() => Promise.resolve(true)),
+        destroyIfIdle: vi.fn(() =>
+          Promise.resolve({ destroyed: false, busy: false }),
+        ),
+      },
+    });
+
+    expect(result.healed).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    expect(stampsOf(statements)[0]?.values).toContainEqual(['x', 'y']);
+  });
+});
+
+describe('runSandboxWatchdog — reclaim of ended runs', () => {
+  it('settles the row only when the spawner destroyed (or lacked) the session; busy and errors wait for the next tick', async () => {
+    const ended = candidate('ended');
+    const busy = candidate('busy');
+    const broken = candidate('broken');
+    const { sql, statements } = fakeSql({ reclaim: [[ended, busy, broken]] });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const destroyIfIdle = vi.fn((sessionId: string) => {
+      if (sessionId === busy.sessionId) {
+        return Promise.resolve({ destroyed: false, busy: true });
+      }
+      if (sessionId === broken.sessionId) {
+        return Promise.reject(new Error('spawner 502'));
+      }
+      return Promise.resolve({ destroyed: true, busy: false });
+    });
+
+    const result = await runSandboxWatchdog(sql, {
+      spawner: { isAlive: vi.fn(() => Promise.resolve(true)), destroyIfIdle },
+    });
+
+    expect(result.reclaimed).toBe(1);
+    expect(destroyIfIdle).toHaveBeenCalledTimes(3);
+    // Only the confirmed-gone session's row settled.
+    expect(markSessionDestroyed).toHaveBeenCalledTimes(1);
+    expect(markSessionDestroyed).toHaveBeenCalledWith(sql, {
+      organizationId: 'org_1',
+      sessionId: ended.sessionId,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('reclaim destroy failed'),
+      expect.any(Error),
+    );
+    // All three were visited: stamped so the rotation moves on.
+    const stamps = stampsOf(statements);
+    expect(stamps).toHaveLength(1);
+    expect(stamps[0]?.values).toContainEqual(['ended', 'busy', 'broken']);
+  });
+
+  it('targets only hibernated/expired workflow_run rows of TERMINAL (or purged) runs past the grace', async () => {
+    const { sql, statements } = fakeSql({});
+    const before = Date.now();
+
+    await runSandboxWatchdog(sql, {
+      spawner: {
+        isAlive: vi.fn(() => Promise.resolve(true)),
+        destroyIfIdle: vi.fn(() =>
+          Promise.resolve({ destroyed: true, busy: false }),
+        ),
+      },
+    });
+
+    const select = statements.find((s) =>
+      s.text.includes("s.owner_type = 'workflow_run'"),
+    );
+    expect(select).toBeDefined();
+    // Never a compute-holding row.
+    expect(select?.text).toContain("s.status IN ('stopped', 'expired')");
+    // Only a run that can never resume its session.
+    expect(select?.text).toContain(
+      "r.status IN ('success', 'failed', 'cancelled')",
+    );
+    // A purged run (retention) leaves an orphan row — reclaimed by its age.
+    expect(select?.text).toContain('r.id IS NULL AND s.created_at_ms <');
+    // The grace horizon is now - grace (two ticks), bound as a value.
+    const horizons = (select?.values ?? []).filter(
+      (v): v is number => typeof v === 'number' && v > 1_000_000_000_000,
+    );
+    expect(horizons.length).toBeGreaterThan(0);
+    for (const horizon of horizons) {
+      expect(horizon).toBeLessThanOrEqual(
+        Date.now() - SANDBOX_RUN_SESSION_RECLAIM_GRACE_MS,
+      );
+      expect(horizon).toBeGreaterThanOrEqual(
+        before - SANDBOX_RUN_SESSION_RECLAIM_GRACE_MS,
+      );
+    }
+    // Same fair walk as the reconcile pass.
+    expect(select?.text).toContain(
+      'ORDER BY s.last_reconciled_at_ms ASC NULLS FIRST, s.created_at_ms ASC',
+    );
+  });
+
+  it('skipReconcile skips both spawner-facing passes', async () => {
+    const { sql, statements } = fakeSql({
+      reconcile: [[candidate('never')]],
+      reclaim: [[candidate('never-either')]],
+    });
+    const spawner: WatchdogSpawner = {
+      isAlive: vi.fn(() => Promise.resolve(true)),
+      destroyIfIdle: vi.fn(() =>
+        Promise.resolve({ destroyed: true, busy: false }),
+      ),
+    };
+
+    const result = await runSandboxWatchdog(sql, {
+      skipReconcile: true,
+      spawner,
+    });
+
+    expect(result).toEqual({ expired: 0, healed: 0, reclaimed: 0, reaped: 0 });
+    expect(reconcileSession).not.toHaveBeenCalled();
+    expect(spawner.destroyIfIdle).not.toHaveBeenCalled();
+    expect(
+      statements.some((s) => s.text.includes("s.owner_type = 'workflow_run'")),
+    ).toBe(false);
+    expect(stampsOf(statements)).toHaveLength(0);
+  });
+});

--- a/services/platform/backend/domains/sandbox/watchdogs.ts
+++ b/services/platform/backend/domains/sandbox/watchdogs.ts
@@ -1,8 +1,60 @@
 import type { Sql } from 'postgres';
 
+import {
+  sessionDestroyIfIdle,
+  sessionIsAlive,
+} from '../../core/node_only/sandbox/helpers/session_client.ts';
 import { wakeParkedAgentRuns } from '../tasks/agent-runs.ts';
 import { reconcileSession } from './service.ts';
-import { reapStaleAdmissionTickets } from './sessions.ts';
+import { markSessionDestroyed, reapStaleAdmissionTickets } from './sessions.ts';
+
+/**
+ * The spawner verbs the sweep's spawner-facing passes use. Injectable so the
+ * unit layer and the real-Postgres integration probe drive the passes with a
+ * scripted spawner; production uses the signed session client.
+ */
+export interface WatchdogSpawner {
+  /** GET /v1/sessions/:id — false ONLY on a definitive 404; throws otherwise. */
+  isAlive: (sessionId: string) => Promise<boolean>;
+  /** DELETE /v1/sessions/:id?if_idle=1 — the spawner arbitrates busy. */
+  destroyIfIdle: (
+    sessionId: string,
+  ) => Promise<{ destroyed: boolean; busy: boolean }>;
+}
+
+const DEFAULT_SPAWNER: WatchdogSpawner = {
+  isAlive: sessionIsAlive,
+  destroyIfIdle: sessionDestroyIfIdle,
+};
+
+/**
+ * How long after an automation run's terminal settle its sessions become
+ * reclaimable. The terminal door hibernates them at once (the slot is what
+ * matters for capacity); the container and workspace are reclaimed a little
+ * later so a node whose settle raced the run's finish is not destroyed under
+ * its last writes. Two sweep ticks.
+ */
+export const SANDBOX_RUN_SESSION_RECLAIM_GRACE_MS = 10 * 60_000;
+
+export interface SandboxWatchdogOptions {
+  ticketStaleMs?: number;
+  /** Rows probed against the spawner per tick (reconcile). */
+  reconcileBatch?: number;
+  /** Ended-run sessions reclaimed per tick. */
+  reclaimBatch?: number;
+  reclaimGraceMs?: number;
+  /** Skip BOTH spawner-facing passes (reconcile + reclaim) — for callers
+   * with no spawner to ask. */
+  skipReconcile?: boolean;
+  spawner?: WatchdogSpawner;
+}
+
+export interface SandboxWatchdogResult {
+  expired: number;
+  healed: number;
+  reclaimed: number;
+  reaped: number;
+}
 
 /**
  * The sandbox drift sweep (5 min) — the 0.5 twin of 0.4's
@@ -13,21 +65,29 @@ import { reapStaleAdmissionTickets } from './sessions.ts';
  *    statuses flip to `expired` (freeing their slots) and the parked-run
  *    wake fires for their orgs. The spawner's own reaper collects the
  *    container on its TTL — the row must not wait for it.
- *  - RECONCILE: a bounded batch of the stalest compute-holding rows is
- *    checked against the spawner; a container gone spawner-side settles the
- *    row as destroyed (phantom heal). Requires a reachable spawner — when
- *    it is down the probes fail closed as `live` (never heal blind).
+ *  - RECONCILE: a bounded batch of compute-holding rows is checked against
+ *    the spawner; a container gone spawner-side settles the row as destroyed
+ *    (phantom heal). Requires a reachable spawner — when it is down the
+ *    probes fail closed as `live` (never heal blind). The batch is a FAIR
+ *    walk: least-recently-visited first (`last_reconciled_at_ms`, never
+ *    visited before any visited), and every visited row is stamped, so a
+ *    long-lived healthy session at the head of `created_at_ms` can no longer
+ *    shadow a younger phantom forever.
+ *  - RECLAIM: the per-execution sessions of ENDED automation runs. The run's
+ *    terminal door only hibernates them (`stopped` — a LIVE status the
+ *    Sandboxes page lists and the spawner keeps a workspace for), so without
+ *    this pass every agent-node run left one dead row and one host workspace
+ *    behind, forever. A row is reclaimed once its run is terminal (or gone —
+ *    the retention purge deletes runs) past a grace, and only when the
+ *    spawner confirms the session is not executing (`if_idle`): a late node
+ *    is left for the next tick, and a spawner error leaves the row alone.
  *  - REAP: admission tickets whose poll chain died are deleted — the ONLY
  *    guard against permanent queue-head starvation in the FIFO.
  */
 export async function runSandboxWatchdog(
   sql: Sql,
-  options: {
-    ticketStaleMs?: number;
-    reconcileBatch?: number;
-    skipReconcile?: boolean;
-  } = {},
-): Promise<{ expired: number; healed: number; reaped: number }> {
+  options: SandboxWatchdogOptions = {},
+): Promise<SandboxWatchdogResult> {
   const now = Date.now();
   const expired = await sql<{ orgId: string }[]>`
     UPDATE app.sandbox_sessions SET status = 'expired'
@@ -42,32 +102,135 @@ export async function runSandboxWatchdog(
   }
 
   let healed = 0;
+  let reclaimed = 0;
   if (options.skipReconcile !== true) {
-    const candidates = await sql<{ sessionId: string; orgId: string }[]>`
-      SELECT session_id AS "sessionId", org_id AS "orgId"
-      FROM app.sandbox_sessions
-      WHERE status IN ('creating', 'active', 'degraded')
-      ORDER BY created_at_ms
-      LIMIT ${options.reconcileBatch ?? 25}
-    `;
-    for (const candidate of candidates) {
-      try {
-        const outcome = await reconcileSession(sql, {
-          organizationId: candidate.orgId,
-          sessionId: candidate.sessionId,
-        });
-        if (outcome === 'healed') healed += 1;
-      } catch (error) {
-        // Spawner unreachable ⇒ no verdict on this row; leave it alone.
-        console.warn(
-          `[watchdog] reconcile probe failed for ${candidate.sessionId}:`,
-          error,
-        );
-      }
-    }
+    const spawner = options.spawner ?? DEFAULT_SPAWNER;
+    healed = await reconcilePass(sql, spawner, {
+      batch: options.reconcileBatch ?? 25,
+      now,
+    });
+    reclaimed = await reclaimEndedRunSessions(sql, spawner, {
+      batch: options.reclaimBatch ?? 25,
+      graceMs: options.reclaimGraceMs ?? SANDBOX_RUN_SESSION_RECLAIM_GRACE_MS,
+      now,
+    });
   }
 
   const staleBefore = now - (options.ticketStaleMs ?? 5 * 60_000);
   const reaped = await reapStaleAdmissionTickets(sql, staleBefore);
-  return { expired: expired.length, healed, reaped };
+  return { expired: expired.length, healed, reclaimed, reaped };
+}
+
+interface Candidate {
+  id: string;
+  sessionId: string;
+  orgId: string;
+}
+
+/** Stamp the rows a pass visited — whatever the verdict — so the next tick's
+ * batch moves on to the rows it has not seen for longest. */
+async function stampVisited(
+  sql: Sql,
+  candidates: readonly Candidate[],
+  now: number,
+): Promise<void> {
+  if (candidates.length === 0) return;
+  await sql`
+    UPDATE app.sandbox_sessions SET last_reconciled_at_ms = ${now}
+    WHERE id = ANY(${candidates.map((candidate) => candidate.id)})
+  `;
+}
+
+async function reconcilePass(
+  sql: Sql,
+  spawner: WatchdogSpawner,
+  args: { batch: number; now: number },
+): Promise<number> {
+  const candidates = await sql<Candidate[]>`
+    SELECT id, session_id AS "sessionId", org_id AS "orgId"
+    FROM app.sandbox_sessions
+    WHERE status IN ('creating', 'active', 'degraded')
+    ORDER BY last_reconciled_at_ms ASC NULLS FIRST, created_at_ms ASC, id ASC
+    LIMIT ${args.batch}
+  `;
+  let healed = 0;
+  for (const candidate of candidates) {
+    try {
+      const outcome = await reconcileSession(
+        sql,
+        { organizationId: candidate.orgId, sessionId: candidate.sessionId },
+        { isAlive: spawner.isAlive },
+      );
+      if (outcome === 'healed') healed += 1;
+    } catch (error) {
+      // Spawner unreachable ⇒ no verdict on this row; leave it alone.
+      console.warn(
+        `[watchdog] reconcile probe failed for ${candidate.sessionId}:`,
+        error,
+      );
+    }
+  }
+  await stampVisited(sql, candidates, args.now);
+  return healed;
+}
+
+/**
+ * Reclaim the per-execution sessions of ended automation runs — see the
+ * RECLAIM lane above. The run is matched off the step-scoped owner id
+ * (`${runId}` or `${runId}:<suffix>`); `stopped` and `expired` rows both
+ * qualify (the terminal door hibernates, the TTL expires — neither destroys).
+ * A live session is never a candidate: `creating`/`active`/`degraded` rows
+ * are excluded outright, and a non-terminal run keeps its hibernated row for
+ * the resume the next node performs.
+ */
+export async function reclaimEndedRunSessions(
+  sql: Sql,
+  spawner: WatchdogSpawner,
+  args: { batch: number; graceMs: number; now: number },
+): Promise<number> {
+  const horizon = args.now - args.graceMs;
+  const candidates = await sql<Candidate[]>`
+    SELECT s.id, s.session_id AS "sessionId", s.org_id AS "orgId"
+    FROM app.sandbox_sessions s
+    LEFT JOIN app.automation_runs r
+      ON r.org_id = s.org_id AND r.id = split_part(s.owner_id, ':', 1)
+    WHERE s.owner_type = 'workflow_run'
+      AND s.status IN ('stopped', 'expired')
+      AND (
+        (r.id IS NOT NULL
+          AND r.status IN ('success', 'failed', 'cancelled')
+          AND coalesce(r.finished_at_ms, r.started_at_ms) < ${horizon})
+        OR (r.id IS NULL AND s.created_at_ms < ${horizon})
+      )
+    ORDER BY s.last_reconciled_at_ms ASC NULLS FIRST, s.created_at_ms ASC,
+             s.id ASC
+    LIMIT ${args.batch}
+  `;
+  let reclaimed = 0;
+  for (const candidate of candidates) {
+    let outcome: { destroyed: boolean; busy: boolean };
+    try {
+      outcome = await spawner.destroyIfIdle(candidate.sessionId);
+    } catch (error) {
+      // Spawner unreachable or refusing ⇒ the container may survive; the row
+      // must not settle ahead of it. Next tick retries.
+      console.warn(
+        `[watchdog] reclaim destroy failed for ${candidate.sessionId}:`,
+        error,
+      );
+      continue;
+    }
+    // A node whose turn outlived the run's terminal settle is still executing
+    // there — the spawner refused; leave the row for a later tick.
+    if (outcome.busy) continue;
+    // Destroyed now, or nothing existed spawner-side — either way the
+    // compute and workspace are gone, so the row settles.
+    await markSessionDestroyed(sql, {
+      organizationId: candidate.orgId,
+      sessionId: candidate.sessionId,
+    });
+    reclaimed += 1;
+  }
+  await stampVisited(sql, candidates, args.now);
+  return reclaimed;
 }

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -23917,6 +23917,7 @@ async function checkAutomationRunToolLane(
     'task_update_status',
     'task_upsert_by_external_ref',
     'document_create',
+    'document_find',
   ];
   // The step-scoped owner spelling (`${runId}:<suffix>`) is what the agent
   // host mints — the resolver must split it back to the run.
@@ -24185,6 +24186,68 @@ async function checkAutomationRunToolLane(
     projectId: randomUUID(),
   });
   const freeBogusDocument = await projectOf('free-run-bogus.md');
+
+  // The org-wide run's KNOWLEDGE reads reach ITS bound projects' files — the
+  // same projects its task/document actions are confined to — not only the
+  // hub. One document per bound project and one on the unbound project:
+  // `document_find` lists exactly the two bound ones (through the real tool
+  // door), and the scope resolver names both projects.
+  await sql`
+    INSERT INTO app.documents (
+      org_id, title, file_ref, extension, project_id, created_by,
+      created_at_ms, updated_at_ms
+    ) VALUES
+      (${orgId}, 'run-tools-bound-a.md', 's3:itest/run-tools-bound-a', 'md',
+       ${boundProjectId}, ${userId}, ${now}, ${now}),
+      (${orgId}, 'run-tools-bound-b.md', 's3:itest/run-tools-bound-b', 'md',
+       ${otherProjectId}, ${userId}, ${now}, ${now}),
+      (${orgId}, 'run-tools-unbound-c.md', 's3:itest/run-tools-unbound-c', 'md',
+       ${unboundProjectId}, ${userId}, ${now}, ${now})
+  `;
+  const orgDocFind = await dispatch(orgToken, 'document_find', {
+    fileName: 'run-tools-',
+  });
+  const pinnedDocFind = await dispatch(pinnedToken, 'document_find', {
+    fileName: 'run-tools-',
+  });
+  const { sandboxToolShimHandlers: sandboxShim } =
+    await import('./domains/sandbox/shim.ts');
+  const orgKnowledgeScope = z
+    .object({
+      allowed: z.literal(true),
+      scope: z.object({
+        projectIds: z.array(z.string()),
+        includeHub: z.boolean(),
+      }),
+    })
+    .safeParse(
+      await sandboxShim(sql)[
+        'sandbox/workspace_access:resolveKnowledgeToolAccess'
+      ]?.({
+        organizationId: orgId,
+        sessionId: 'itest-run-org',
+        subject: 'documents',
+      }),
+    );
+  const orgScopeProjects = orgKnowledgeScope.success
+    ? new Set(orgKnowledgeScope.data.scope.projectIds)
+    : new Set<string>();
+  record(
+    'automation-run knowledge reads span the run’s bound projects (document_find + scope)',
+    orgDocFind.status === 'ok' &&
+      orgDocFind.raw.includes('run-tools-bound-a.md') &&
+      orgDocFind.raw.includes('run-tools-bound-b.md') &&
+      !orgDocFind.raw.includes('run-tools-unbound-c.md') &&
+      pinnedDocFind.status === 'ok' &&
+      pinnedDocFind.raw.includes('run-tools-bound-a.md') &&
+      !pinnedDocFind.raw.includes('run-tools-bound-b.md') &&
+      orgKnowledgeScope.success &&
+      orgKnowledgeScope.data.scope.includeHub &&
+      orgScopeProjects.size === 2 &&
+      orgScopeProjects.has(boundProjectId) &&
+      orgScopeProjects.has(otherProjectId),
+    `orgFind=${orgDocFind.status} (a=${orgDocFind.raw.includes('run-tools-bound-a.md')}, b=${orgDocFind.raw.includes('run-tools-bound-b.md')}, unboundLeak=${orgDocFind.raw.includes('run-tools-unbound-c.md')}), pinnedFind=${pinnedDocFind.status} (a=${pinnedDocFind.raw.includes('run-tools-bound-a.md')}, bLeak=${pinnedDocFind.raw.includes('run-tools-bound-b.md')}), scope=${orgKnowledgeScope.success ? [...orgScopeProjects].length : 'ERR'} project(s)`,
+  );
 
   // Hand back the workflow session budget — the org's cap is small, and the
   // spawner scenarios that follow provision real sessions of their own.
@@ -34162,6 +34225,145 @@ async function checkWatchdogs(
       tickets.length === 1 &&
       tickets[0]?.ownerId === 'wd-ticket-live',
     `ttl=${JSON.stringify(ttlRows)} tickets=${tickets.map((t) => t.ownerId).join(',')}`,
+  );
+
+  // Lane 3b: the spawner-facing passes with a SCRIPTED spawner — the fair
+  // reconcile rotation and the ended-run reclaim, on the real schema.
+  //
+  // Fairness: three compute-holding rows older than every other one in the
+  // table, a batch of TWO. The old `ORDER BY created_at_ms LIMIT n` probed the
+  // same two oldest rows every tick and never reached the third; the fair walk
+  // (least-recently-visited first, visited rows stamped) reaches it on the
+  // second tick.
+  const oldest = await sql<{ min: number | null }[]>`
+    SELECT min(created_at_ms)::float8 AS min FROM app.sandbox_sessions
+    WHERE status IN ('creating', 'active', 'degraded')
+  `;
+  const ancient = Math.min(oldest[0]?.min ?? now, now) - 1_000;
+  await sql`
+    INSERT INTO app.sandbox_sessions (
+      org_id, session_id, status, owner_type, owner_id, created_by,
+      created_at_ms, expires_at_ms
+    ) VALUES
+      (${orgId}, 'wd-fair-1', 'active', 'render', 'wd-fair-1', 'itest:wd',
+       ${ancient}, ${now + 24 * 3_600_000}),
+      (${orgId}, 'wd-fair-2', 'active', 'render', 'wd-fair-2', 'itest:wd',
+       ${ancient + 1}, ${now + 24 * 3_600_000}),
+      (${orgId}, 'wd-fair-3', 'active', 'render', 'wd-fair-3', 'itest:wd',
+       ${ancient + 2}, ${now + 24 * 3_600_000})
+  `;
+  // Reclaim: an ENDED run's hibernated session (reclaimed), an expired
+  // session whose run the retention purge deleted (reclaimed), a LIVE run's
+  // active AND hibernated sessions (both survive — a resume is coming), and
+  // an ended run whose session the spawner reports busy (waits a tick).
+  const wdRun = async (
+    name: string,
+    status: 'success' | 'running' | 'cancelled',
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.automation_runs (
+        org_id, name, version, status, mode, started_by, input,
+        started_at_ms, finished_at_ms
+      ) VALUES (
+        ${orgId}, ${name}, 1, ${status}, 'live', 'itest:wd', ${sql.json({})},
+        ${now - 2 * 3_600_000},
+        ${status === 'running' ? null : now - 3_600_000}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const endedRunId = await wdRun('itest-wd-ended', 'success');
+  const liveRunId = await wdRun('itest-wd-live', 'running');
+  const busyRunId = await wdRun('itest-wd-busy', 'cancelled');
+  await sql`
+    INSERT INTO app.sandbox_sessions (
+      org_id, session_id, status, owner_type, owner_id, created_by,
+      created_at_ms, expires_at_ms
+    ) VALUES
+      (${orgId}, 'wd-reclaim-ended', 'stopped', 'workflow_run',
+       ${`${endedRunId}:@workflow`}, 'itest:wd', ${now - 2 * 3_600_000},
+       ${now + 24 * 3_600_000}),
+      (${orgId}, 'wd-reclaim-purged', 'expired', 'workflow_run',
+       'itest-wd-purged-run:@workflow', 'itest:wd', ${now - 2 * 3_600_000},
+       ${now - 3_600_000}),
+      (${orgId}, 'wd-reclaim-live', 'active', 'workflow_run',
+       ${`${liveRunId}:@workflow`}, 'itest:wd', ${now - 2 * 3_600_000},
+       ${now + 24 * 3_600_000}),
+      (${orgId}, 'wd-reclaim-paused', 'stopped', 'workflow_run',
+       ${`${liveRunId}:agent`}, 'itest:wd', ${now - 2 * 3_600_000},
+       ${now + 24 * 3_600_000}),
+      (${orgId}, 'wd-reclaim-busy', 'stopped', 'workflow_run',
+       ${`${busyRunId}:@workflow`}, 'itest:wd', ${now - 2 * 3_600_000},
+       ${now + 24 * 3_600_000})
+  `;
+  const probed: string[] = [];
+  const destroyAsked: string[] = [];
+  const scriptedSpawner = {
+    isAlive: (sessionId: string): Promise<boolean> => {
+      probed.push(sessionId);
+      return Promise.resolve(true);
+    },
+    destroyIfIdle: (
+      sessionId: string,
+    ): Promise<{ destroyed: boolean; busy: boolean }> => {
+      destroyAsked.push(sessionId);
+      return Promise.resolve(
+        sessionId === 'wd-reclaim-busy'
+          ? { destroyed: false, busy: true }
+          : { destroyed: true, busy: false },
+      );
+    },
+  };
+  const tick1 = await sandboxWatchdogs.runSandboxWatchdog(sql, {
+    reconcileBatch: 2,
+    spawner: scriptedSpawner,
+  });
+  const probedTick1 = probed.filter((id) => id.startsWith('wd-fair-'));
+  const tick2 = await sandboxWatchdogs.runSandboxWatchdog(sql, {
+    reconcileBatch: 2,
+    spawner: scriptedSpawner,
+  });
+  const probedFair = new Set(probed.filter((id) => id.startsWith('wd-fair-')));
+  const fairRows = await sql<
+    { sessionId: string; lastReconciledAt: number | null }[]
+  >`
+    SELECT session_id AS "sessionId",
+           last_reconciled_at_ms::float8 AS "lastReconciledAt"
+    FROM app.sandbox_sessions
+    WHERE session_id IN ('wd-fair-1', 'wd-fair-2', 'wd-fair-3')
+  `;
+  const reclaimRows = await sql<{ sessionId: string; status: string }[]>`
+    SELECT session_id AS "sessionId", status FROM app.sandbox_sessions
+    WHERE session_id LIKE 'wd-reclaim-%'
+  `;
+  const statusOf = (sessionId: string): string | undefined =>
+    reclaimRows.find((r) => r.sessionId === sessionId)?.status;
+  const destroyAskedSet = new Set(destroyAsked);
+  record(
+    'sandbox watchdog reconciles fairly (rotation reaches past the batch) and reclaims ended runs’ sessions',
+    // A batch of two cannot hold all three on tick 1 (another compute-holding
+    // row may even take a slot); the rotation reaches every one by tick 2 —
+    // the created_at_ms order re-probed the same head rows and never did.
+    probedTick1.length < 3 &&
+      ['wd-fair-1', 'wd-fair-2', 'wd-fair-3'].every((id) =>
+        probedFair.has(id),
+      ) &&
+      fairRows.length === 3 &&
+      fairRows.every((r) => r.lastReconciledAt !== null) &&
+      // The ended run's session and the purged run's orphan settled…
+      statusOf('wd-reclaim-ended') === 'destroyed' &&
+      statusOf('wd-reclaim-purged') === 'destroyed' &&
+      // …the live run's sessions were never candidates…
+      statusOf('wd-reclaim-live') === 'active' &&
+      statusOf('wd-reclaim-paused') === 'stopped' &&
+      !destroyAskedSet.has('wd-reclaim-live') &&
+      !destroyAskedSet.has('wd-reclaim-paused') &&
+      // …and the busy one was asked, refused, and left for a later tick.
+      destroyAskedSet.has('wd-reclaim-busy') &&
+      statusOf('wd-reclaim-busy') === 'stopped' &&
+      tick1.reclaimed === 2 &&
+      tick2.reclaimed === 0,
+    `fair(tick1=${probedTick1.join(',')} all=${[...probedFair].join(',')} stamped=${fairRows.filter((r) => r.lastReconciledAt !== null).length}/3) reclaim(${reclaimRows.map((r) => `${r.sessionId}=${r.status}`).join(' ')} asked=${[...destroyAskedSet].join(',')} reclaimed=${tick1.reclaimed}/${tick2.reclaimed})`,
   );
 
   // Lane 4: a stale chat generation (hard-killed turn) clears; the thread

--- a/services/platform/backend/jobs/task-list.ts
+++ b/services/platform/backend/jobs/task-list.ts
@@ -472,9 +472,14 @@ export function createTaskList(deps: TaskDeps): BackendTaskList {
     },
     'watchdog.sandbox': async () => {
       const result = await runSandboxWatchdog(deps.sql);
-      if (result.expired > 0 || result.healed > 0 || result.reaped > 0) {
+      if (
+        result.expired > 0 ||
+        result.healed > 0 ||
+        result.reclaimed > 0 ||
+        result.reaped > 0
+      ) {
         console.log(
-          `[watchdog] sandbox: expired ${result.expired}, healed ${result.healed}, reaped ${result.reaped} tickets`,
+          `[watchdog] sandbox: expired ${result.expired}, healed ${result.healed}, reclaimed ${result.reclaimed} ended-run session(s), reaped ${result.reaped} tickets`,
         );
       }
     },

--- a/services/sandbox/docs/kubernetes.md
+++ b/services/sandbox/docs/kubernetes.md
@@ -61,7 +61,10 @@ metadata:
 rules:
   - apiGroups: ['']
     resources: ['pods']
-    verbs: ['create', 'get', 'list', 'delete']
+    # `patch` records a session's "always-on" pin as a Pod annotation
+    # (`tale.dev/pinned`) so a spawner restart re-adopts it instead of
+    # TTL/idle-reaping the pinned session on its first sweep.
+    verbs: ['create', 'get', 'list', 'delete', 'patch']
   - apiGroups: ['']
     resources: ['pods/log']
     verbs: ['get']

--- a/services/sandbox/src/backend/docker/docker-session-backend.test.ts
+++ b/services/sandbox/src/backend/docker/docker-session-backend.test.ts
@@ -4,9 +4,15 @@
 // healthy session on another spawner replica. These pin that so a refactor
 // can't loosen it to "anything that isn't running".
 
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
+import { TEST_SESSION_CONFIG } from '../../session/session-test-config.ts';
+import type { SpawnerConfig } from '../../types.ts';
 import {
+  DockerSessionBackend,
   isDockerNameConflict,
   isReapableContainerStatus,
 } from './docker-session-backend.ts';
@@ -59,5 +65,227 @@ describe('isReapableContainerStatus', () => {
   test('an unknown/garbage status is not reapable', () => {
     expect(isReapableContainerStatus('')).toBe(false);
     expect(isReapableContainerStatus('wat')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The stop/destroy contract against a FAKE docker CLI. `DOCKER_BIN` points at a
+// bash script that reads its behaviour from a control file beside it (Bun.spawn
+// snapshots the environment at startup, so per-test env vars would not reach
+// the child), so the backend's real code path (inspect → rm → judge) runs end
+// to end without a daemon. spawn-util reads DOCKER_BIN lazily per invocation,
+// so the override works post-import.
+// ---------------------------------------------------------------------------
+
+const FAKE_DOCKER = `#!/usr/bin/env bash
+# Fake docker CLI for tests. Reads three lines from ./mode next to this script:
+#   line 1: 1 when the container exists, else 0
+#   line 2: rm outcome — ok | nosuch | busy
+#   line 3: comma-separated session ids \`docker ps\` lists (may be empty)
+here="$(cd "$(dirname "$0")" && pwd)"
+present="$(sed -n 1p "$here/mode")"
+rm_mode="$(sed -n 2p "$here/mode")"
+listed="$(sed -n 3p "$here/mode")"
+cmd="$1"; shift
+case "$cmd" in
+  ps)
+    IFS=',' read -ra ids <<< "$listed"
+    for id in "\${ids[@]}"; do
+      [ -n "$id" ] && printf '%s\torg_fake\tagent\t1700000000000\trunning\n' "$id"
+    done
+    exit 0 ;;
+  inspect)
+    fmt="$2"; name="$3"
+    if [ "$present" = "1" ]; then
+      case "$fmt" in
+        *State.Running*) echo "true" ;;
+        *State.Status*) echo "running" ;;
+        *Mounts*) echo "" ;;
+        *) echo "abc123" ;;
+      esac
+      exit 0
+    fi
+    echo "Error response from daemon: No such object: $name" >&2
+    exit 1 ;;
+  rm)
+    case "$rm_mode" in
+      ok) exit 0 ;;
+      nosuch)
+        echo "Error response from daemon: No such container: $2" >&2
+        exit 1 ;;
+      busy)
+        echo "Error response from daemon: cannot remove container: device or resource busy" >&2
+        exit 1 ;;
+      *) echo "fake docker: unexpected rm mode '$rm_mode'" >&2; exit 2 ;;
+    esac ;;
+  *)
+    echo "fake docker: unhandled command $cmd" >&2
+    exit 2 ;;
+esac
+`;
+
+let fakeRoot = '';
+let hostSessionRoot = '';
+const ORIGINAL_DOCKER_BIN = process.env.DOCKER_BIN;
+
+/** Point the fake docker at one scenario: does the container exist, and how
+ * does `docker rm` answer. */
+async function fakeDocker(scenario: {
+  present: boolean;
+  rm: 'ok' | 'nosuch' | 'busy';
+  listed?: string[];
+}): Promise<void> {
+  await writeFile(
+    join(fakeRoot, 'mode'),
+    `${scenario.present ? '1' : '0'}\n${scenario.rm}\n${(scenario.listed ?? []).join(',')}\n`,
+  );
+}
+
+/** The rejection of a promise, or null when it resolved — bun:test's
+ * `rejects` matchers type as void, which the await-thenable lint rejects. */
+async function rejection(promise: Promise<unknown>): Promise<Error | null> {
+  try {
+    await promise;
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+beforeAll(async () => {
+  fakeRoot = await mkdtemp(join(tmpdir(), 'tale-fake-docker-'));
+  const bin = join(fakeRoot, 'docker');
+  await writeFile(bin, FAKE_DOCKER);
+  await chmod(bin, 0o755);
+  hostSessionRoot = join(fakeRoot, 'sessions');
+  await mkdir(hostSessionRoot, { recursive: true });
+  process.env.DOCKER_BIN = bin;
+});
+
+afterAll(async () => {
+  if (ORIGINAL_DOCKER_BIN === undefined) delete process.env.DOCKER_BIN;
+  else process.env.DOCKER_BIN = ORIGINAL_DOCKER_BIN;
+  await rm(fakeRoot, { recursive: true, force: true });
+});
+
+function backendConfig(): SpawnerConfig {
+  return {
+    backend: 'docker',
+    port: 8003,
+    sandboxToken: 'test-token',
+    runtimeImage: 'tale-sandbox-runtime:test',
+    runtimeTier: 'runc',
+    dockerInContainer: false,
+    dockerBuildCache: false,
+    buildkitdImage: 'tale-sandbox-buildkitd:test',
+    buildkitdMirrorImage: 'registry:2',
+    browserView: false,
+    transparentEgress: false,
+    k8s: {
+      namespace: 'tale-sandbox',
+      runtimeClassName: null,
+      spawnerImage: 'tale-sandbox:test',
+      cacheMode: 'none',
+      workspaceSizeLimit: '4Gi',
+    },
+    defaultTimeoutMs: 30_000,
+    maxTimeoutMs: 300_000,
+    hostSessionRoot,
+    cacheVolumePrefix: { pip: 'pip', npm: 'npm', bun: 'bun' },
+    egressNetwork: 'tale-sandbox-net',
+    egressProxy: 'http://sandbox-egress:3128',
+    stdoutMaxBytes: 5_242_880,
+    stderrMaxBytes: 5_242_880,
+    outputFileMaxBytes: 52_428_800,
+    outputTotalMaxBytes: 104_857_600,
+    maxRequestBodyBytes: 262_144,
+    session: TEST_SESSION_CONFIG,
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('DockerSessionBackend stop/destroy honour the rm result', () => {
+  test('stopSession THROWS when docker rm fails on a present container (never a silent orphan)', async () => {
+    await fakeDocker({ present: true, rm: 'busy' });
+    const backend = new DockerSessionBackend(backendConfig());
+    // The reaper's contract: a throw keeps the registry entry for a retry; a
+    // resolved "existed" would have dropped it while the container ran on.
+    const err = await rejection(backend.stopSession('rm-busy'));
+    expect(err?.message).toMatch(
+      /docker rm tale-sbx-ses-rm-busy failed \(exit 1\)/,
+    );
+  });
+
+  test('stopSession resolves true when rm succeeds on a present container', async () => {
+    await fakeDocker({ present: true, rm: 'ok' });
+    const backend = new DockerSessionBackend(backendConfig());
+    expect(await backend.stopSession('rm-ok')).toBe(true);
+  });
+
+  test('stopSession is idempotent: an already-gone container resolves false without throwing', async () => {
+    await fakeDocker({ present: false, rm: 'nosuch' });
+    const backend = new DockerSessionBackend(backendConfig());
+    expect(await backend.stopSession('rm-gone')).toBe(false);
+  });
+
+  test('destroySession THROWS on a failed rm and leaves the workspace intact', async () => {
+    await fakeDocker({ present: true, rm: 'busy' });
+    const workspace = join(hostSessionRoot, 'ses-destroy-busy');
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, 'keep.txt'), 'user data');
+    const backend = new DockerSessionBackend(backendConfig());
+    const err = await rejection(backend.destroySession('destroy-busy'));
+    expect(err?.message).toMatch(/docker rm tale-sbx-ses-destroy-busy failed/);
+    // A container that may still be running keeps its bind-mounted data.
+    expect(await exists(join(workspace, 'keep.txt'))).toBe(true);
+  });
+});
+
+describe('DockerSessionBackend durable pin (survives a spawner restart)', () => {
+  test('setPinned records a marker under the host session root that listSessions reports back', async () => {
+    await fakeDocker({ present: true, rm: 'ok', listed: ['pin-a', 'pin-b'] });
+    const backend = new DockerSessionBackend(backendConfig());
+    await backend.setPinned('pin-a', true);
+    // Outside the workspace: the agent cannot pin itself from inside /agent.
+    expect(await exists(join(hostSessionRoot, '.pins', 'pin-a.pinned'))).toBe(
+      true,
+    );
+    expect(await exists(join(hostSessionRoot, 'ses-pin-a'))).toBe(false);
+
+    // What a freshly restarted spawner would re-adopt.
+    const listed = await backend.listSessions();
+    expect(listed.find((s) => s.sessionId === 'pin-a')?.pinned).toBe(true);
+    expect(listed.find((s) => s.sessionId === 'pin-b')?.pinned).toBe(false);
+
+    await backend.setPinned('pin-a', false);
+    expect(await exists(join(hostSessionRoot, '.pins', 'pin-a.pinned'))).toBe(
+      false,
+    );
+  });
+
+  test('stop and destroy clear the pin — a later incarnation starts unpinned', async () => {
+    await fakeDocker({ present: true, rm: 'ok' });
+    const backend = new DockerSessionBackend(backendConfig());
+    await backend.setPinned('pin-stop', true);
+    await backend.stopSession('pin-stop');
+    expect(
+      await exists(join(hostSessionRoot, '.pins', 'pin-stop.pinned')),
+    ).toBe(false);
+
+    await backend.setPinned('pin-destroy', true);
+    // destroySession confirms the container is gone via inspect State.Running.
+    await fakeDocker({ present: false, rm: 'nosuch' });
+    await backend.destroySession('pin-destroy');
+    expect(
+      await exists(join(hostSessionRoot, '.pins', 'pin-destroy.pinned')),
+    ).toBe(false);
   });
 });

--- a/services/sandbox/src/backend/docker/docker-session-backend.ts
+++ b/services/sandbox/src/backend/docker/docker-session-backend.ts
@@ -6,7 +6,7 @@
 // container DNS name on tale-sandbox-net. Cleanup.ts's one-shot sweep ignores
 // these (distinct `tale.sandbox-session=1` label).
 
-import { chown, mkdir, readdir, rm, stat } from 'node:fs/promises';
+import { chown, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { ensureBuildkitd } from '../../buildkitd.ts';
@@ -25,7 +25,12 @@ import {
   sessionContainerName,
   sessionWorkspaceDirName,
 } from '../../session/session-naming.ts';
-import { dockerRm, runDocker } from '../../spawn-util.ts';
+import {
+  dockerRm,
+  dockerRmSucceeded,
+  isDockerNoSuchObject,
+  runDocker,
+} from '../../spawn-util.ts';
 import type { SpawnerConfig } from '../../types.ts';
 import {
   bunCacheVolumeName,
@@ -33,7 +38,12 @@ import {
   npmCacheVolumeName,
   pipCacheVolumeName,
 } from '../../volume.ts';
-import type { BackendSession, SessionBackend, SessionSpec } from '../types.ts';
+import type {
+  BackendSession,
+  CreateSessionResult,
+  SessionBackend,
+  SessionSpec,
+} from '../types.ts';
 
 /** Does a `docker run` stderr report a container-name collision? */
 export function isDockerNameConflict(stderr: string): boolean {
@@ -126,6 +136,8 @@ export class DockerSessionBackend implements SessionBackend {
     }
     for (const e of entries) {
       if (!e.isDirectory() || isSessionWorkspaceDirName(e.name)) continue;
+      // Spawner bookkeeping (`.pins/`) is not a colour root.
+      if (e.name.startsWith('.')) continue;
       const legacy = join(this.cfg.hostSessionRoot, e.name, dirName);
       if (await this.workspaceDirExists(legacy)) {
         console.warn(
@@ -160,8 +172,13 @@ export class DockerSessionBackend implements SessionBackend {
     return src.length > 0 ? src : null;
   }
 
-  async createSession(spec: SessionSpec): Promise<void> {
+  async createSession(spec: SessionSpec): Promise<CreateSessionResult> {
     const containerName = sessionContainerName(spec.sessionId);
+    // A new session starts UNPINNED whatever a prior incarnation under this
+    // deterministic id recorded: the platform row is the truth and re-pushes
+    // its pin; a stale marker would exempt a container the platform believes
+    // is reapable. Cleared before anything else so a failed create leaves none.
+    await this.clearPinMarker(spec.sessionId);
     const workspaceHostDir = await this.resolveWorkspaceDir(spec.sessionId);
     // Agent-profile only — see sessionDindEnabled. Every DinD side-effect below
     // (inner-docker volume, shared buildkitd, cache-volume skip) keys off this,
@@ -281,9 +298,7 @@ export class DockerSessionBackend implements SessionBackend {
         console.warn(
           `[sandbox.session] reaping dead container ${containerName} (status=${status}) and retrying create for ${spec.sessionId}`,
         );
-        await dockerRm(containerName).catch((err) =>
-          console.warn('[sandbox.session] orphan reap dockerRm failed:', err),
-        );
+        await this.bestEffortRm(containerName, 'orphan reap');
         // The dead container may still have pinned the dind volume, so the
         // earlier ensureFreshDindVolume could not actually recreate it; redo it
         // now that the container is gone so the retry mounts a genuinely fresh
@@ -307,9 +322,7 @@ export class DockerSessionBackend implements SessionBackend {
         // Clean up a half-created container before surfacing the failure. On a
         // resume (preexisting dir), preserve the workspace; only a fresh create
         // deletes its own empty dir.
-        await dockerRm(containerName).catch((err) =>
-          console.warn('[sandbox.session] cleanup dockerRm failed:', err),
-        );
+        await this.bestEffortRm(containerName, 'failed-create cleanup');
         if (dind) {
           await this.removeDindVolume(spec.sessionId);
         }
@@ -360,6 +373,7 @@ export class DockerSessionBackend implements SessionBackend {
       }
       throw err;
     }
+    return { resumed: preexisting };
   }
 
   async resolveEndpoint(sessionId: string): Promise<string> {
@@ -423,7 +437,7 @@ export class DockerSessionBackend implements SessionBackend {
     // Only a definitive "the object is gone" answer may return false; any
     // other inspect failure (daemon hiccup, timeout) is "unknown" and must
     // throw per the interface contract.
-    if (/no such (object|container)/i.test(inspect.stderr)) return false;
+    if (isDockerNoSuchObject(inspect.stderr)) return false;
     throw new Error(
       `docker inspect ${containerName} failed: ${inspect.stderr.trim() || inspect.stdout.trim()}`,
     );
@@ -454,9 +468,20 @@ export class DockerSessionBackend implements SessionBackend {
     }
   }
 
-  /** Remove the container (best-effort), leaving the workspace dir untouched.
-   * Shared by stopSession (keep dir) and destroySession (which then deletes
-   * the dir). Returns whether the container existed. */
+  /**
+   * Remove the container, leaving the workspace dir untouched. Shared by
+   * stopSession (keep dir) and destroySession (which then deletes the dir).
+   * Returns whether the container existed.
+   *
+   * THROWS when the removal did not verifiably happen — a `docker rm --force`
+   * that timed out against a wedged daemon (exit 124) or was refused for any
+   * reason other than "no such container". `dockerRm` itself never rejects, so
+   * a swallowed result here used to report a stop as done while the container
+   * kept running: the reaper then dropped the registry entry and the live
+   * container (2 cpu / 4-8 GB) was orphaned until a spawner restart re-adopted
+   * it. Throwing is the stop/destroy contract (types.ts): the reaper keeps the
+   * entry and retries next sweep; destroy leaves the workspace intact.
+   */
   private async removeContainer(sessionId: string): Promise<boolean> {
     const containerName = sessionContainerName(sessionId);
     let existed = false;
@@ -469,10 +494,30 @@ export class DockerSessionBackend implements SessionBackend {
     } catch {
       existed = false;
     }
-    await dockerRm(containerName).catch((err) => {
-      console.warn(`[sandbox.session] dockerRm ${containerName} failed:`, err);
-    });
+    const removal = await dockerRm(containerName);
+    if (!dockerRmSucceeded(removal)) {
+      throw new Error(
+        `docker rm ${containerName} failed (exit ${removal.exitCode}): ` +
+          `${removal.stderr.trim() || removal.stdout.trim() || 'no output'} — container may still be running`,
+      );
+    }
     return existed;
+  }
+
+  /** A cleanup-path `docker rm` whose failure must not mask the error being
+   * surfaced, but must not pass silently either: a leftover container 409s
+   * the next resume by name (the create-conflict reconcile reaps it once it
+   * has exited), so the operator gets a warning line to find it by. */
+  private async bestEffortRm(
+    containerName: string,
+    label: string,
+  ): Promise<void> {
+    const removal = await dockerRm(containerName);
+    if (!dockerRmSucceeded(removal)) {
+      console.warn(
+        `[sandbox.session] ${label}: docker rm ${containerName} failed (exit ${removal.exitCode}): ${removal.stderr.trim()}`,
+      );
+    }
   }
 
   /** Per-session inner-dockerd storage volume (DinD only), mounted at
@@ -534,6 +579,7 @@ export class DockerSessionBackend implements SessionBackend {
       );
     }
     if (this.cfg.dockerInContainer) await this.removeDindVolume(sessionId);
+    await this.clearPinMarker(sessionId);
     await rm(workspaceHostDir, {
       recursive: true,
       force: true,
@@ -552,7 +598,54 @@ export class DockerSessionBackend implements SessionBackend {
     // docker store is ephemeral, so reap it (resume rebuilds the image cache).
     const existed = await this.removeContainer(sessionId);
     if (this.cfg.dockerInContainer) await this.removeDindVolume(sessionId);
+    // The pin belongs to the container that just went away; the resume's
+    // create starts unpinned and the platform re-pushes.
+    await this.clearPinMarker(sessionId);
     return existed;
+  }
+
+  // --- the durable "always-on" pin -----------------------------------------
+  //
+  // The registry's `pinned` flag dies with the spawner process, so a deploy or
+  // crash used to forget every pin and the first sweep after re-adoption
+  // TTL/idle-reaped the user's always-on session. The host session root is the
+  // one place this spawner already keeps durable state (`.spawner.lock`, the
+  // workspaces), mounted identically into the replacement container — so the
+  // pin lives there as a marker file, OUTSIDE the workspace (the agent must not
+  // be able to pin itself by touching a file under /agent). `.pins/` is a
+  // dot-dir: the host-dir sweep skips it (not an id-alphabet name) and the
+  // legacy colour-root scan skips dot entries explicitly.
+
+  private pinMarkerPath(sessionId: string): string {
+    return join(this.cfg.hostSessionRoot, '.pins', `${sessionId}.pinned`);
+  }
+
+  async setPinned(sessionId: string, pinned: boolean): Promise<void> {
+    if (!pinned) {
+      await this.clearPinMarker(sessionId);
+      return;
+    }
+    const marker = this.pinMarkerPath(sessionId);
+    await mkdir(join(this.cfg.hostSessionRoot, '.pins'), { recursive: true });
+    await writeFile(marker, `${Date.now()}\n`);
+  }
+
+  private async clearPinMarker(sessionId: string): Promise<void> {
+    await rm(this.pinMarkerPath(sessionId), { force: true }).catch((err) => {
+      console.warn(
+        `[sandbox.session] clearing pin marker for ${sessionId} failed:`,
+        err,
+      );
+    });
+  }
+
+  private async isPinned(sessionId: string): Promise<boolean> {
+    try {
+      await stat(this.pinMarkerPath(sessionId));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async listSessions(organizationId?: string): Promise<BackendSession[]> {
@@ -588,6 +681,7 @@ export class DockerSessionBackend implements SessionBackend {
         ttlMs: this.cfg.session.maxLifetimeMs,
         idleTimeoutMs: this.cfg.session.maxIdleMs,
         state: state === 'running' ? 'ready' : 'degraded',
+        pinned: await this.isPinned(sessionId),
       });
     }
     return out;

--- a/services/sandbox/src/backend/kubernetes/k8s-session-backend.test.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-session-backend.test.ts
@@ -14,6 +14,7 @@ import type { SpawnerConfig } from '../../types.ts';
 import type { SessionSpec } from '../types.ts';
 import type { K8sClient } from './k8s-client.ts';
 import { KubernetesSessionBackend } from './k8s-session-backend.ts';
+import { sessionPodNameFor } from './k8s-session-pod-spec.ts';
 
 const cfg: SpawnerConfig = {
   backend: 'kubernetes',
@@ -205,5 +206,64 @@ describe('KubernetesSessionBackend.createSession — PVC cleanup on Secret failu
     // envelope must destroy the orphan (fresh create ⇒ destroy, not stop).
     expect(calls.pvcCreated).toBe(true);
     expect(calls.pvcDeleted).toBe(true);
+  });
+});
+
+describe('KubernetesSessionBackend durable pin (Pod annotation)', () => {
+  test('setPinned merge-patches the pin annotation; listSessions reads it back', async () => {
+    const patches: Array<{ name: string; body: unknown }> = [];
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
+    const core = {
+      patchNamespacedPod: (param: { name: string; body: unknown }) => {
+        patches.push({ name: param.name, body: param.body });
+        return Promise.resolve({});
+      },
+      listNamespacedPod: () =>
+        Promise.resolve({
+          items: [
+            {
+              metadata: {
+                annotations: {
+                  'tale.dev/session-id': 'k8s-pinned',
+                  'tale.dev/organization-id': 'org_k8s',
+                  'tale.dev/profile': 'agent',
+                  'tale.dev/created-at': '1700000000000',
+                  'tale.dev/pinned': 'true',
+                },
+              },
+              status: { phase: 'Running' },
+            },
+            {
+              metadata: {
+                annotations: {
+                  'tale.dev/session-id': 'k8s-plain',
+                  'tale.dev/organization-id': 'org_k8s',
+                  'tale.dev/profile': 'agent',
+                  'tale.dev/created-at': '1700000000000',
+                },
+              },
+              status: { phase: 'Running' },
+            },
+          ],
+        }),
+    } as unknown as CoreV1Api;
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
+    const networking = {} as unknown as NetworkingV1Api;
+    const backend = new KubernetesSessionBackend(cfg, {
+      core,
+      networking,
+      namespace: 'tale-sandbox',
+    });
+
+    await backend.setPinned('k8s-pinned', true);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]?.name).toBe(sessionPodNameFor('k8s-pinned'));
+    expect(patches[0]?.body).toEqual({
+      metadata: { annotations: { 'tale.dev/pinned': 'true' } },
+    });
+
+    const listed = await backend.listSessions();
+    expect(listed.find((s) => s.sessionId === 'k8s-pinned')?.pinned).toBe(true);
+    expect(listed.find((s) => s.sessionId === 'k8s-plain')?.pinned).toBe(false);
   });
 });

--- a/services/sandbox/src/backend/kubernetes/k8s-session-backend.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-session-backend.ts
@@ -6,13 +6,23 @@
 // Secret carries the runnerd token + seed env. Deterministic Pod/Secret names
 // let any spawner replica address/destroy any session statelessly.
 
-import type { V1Pod, V1Secret } from '@kubernetes/client-node';
+import {
+  PatchStrategy,
+  setHeaderOptions,
+  type V1Pod,
+  type V1Secret,
+} from '@kubernetes/client-node';
 
 import { waitForRunnerd } from '../../session/runnerd-client.ts';
 import { RUNNERD_PORT } from '../../session/runnerd-protocol.ts';
 import { deriveRunnerdToken } from '../../session/session-naming.ts';
 import type { SpawnerConfig } from '../../types.ts';
-import type { BackendSession, SessionBackend, SessionSpec } from '../types.ts';
+import type {
+  BackendSession,
+  CreateSessionResult,
+  SessionBackend,
+  SessionSpec,
+} from '../types.ts';
 import {
   apiTimeout,
   httpStatusCode,
@@ -28,6 +38,8 @@ import {
 } from './k8s-session-pod-spec.ts';
 
 const SESSION_LABEL_SELECTOR = 'tale.sandbox-session=1';
+/** Pod annotation carrying the durable "always-on" pin (see setPinned). */
+const PINNED_ANNOTATION = 'tale.dev/pinned';
 
 export class KubernetesSessionBackend implements SessionBackend {
   readonly kind = 'kubernetes' as const;
@@ -46,7 +58,7 @@ export class KubernetesSessionBackend implements SessionBackend {
     return deriveRunnerdToken(this.cfg.sandboxToken, sessionId);
   }
 
-  async createSession(spec: SessionSpec): Promise<void> {
+  async createSession(spec: SessionSpec): Promise<CreateSessionResult> {
     // A pre-existing workspace PVC means this is a RESUME of a stopped session.
     // A failed create here must NOT delete that PVC (it holds the user's
     // preserved data) — stop instead. Fresh creates clean up fully.
@@ -127,6 +139,7 @@ export class KubernetesSessionBackend implements SessionBackend {
       await this.cleanupFailedCreate(spec.sessionId, preexisting);
       throw err;
     }
+    return { resumed: preexisting };
   }
 
   /** On a failed create: stop (keep PVC) when resuming a session whose PVC
@@ -424,9 +437,39 @@ export class KubernetesSessionBackend implements SessionBackend {
         ttlMs: this.cfg.session.maxLifetimeMs,
         idleTimeoutMs: this.cfg.session.maxIdleMs,
         state: running ? 'ready' : 'degraded',
+        pinned: ann[PINNED_ANNOTATION] === 'true',
       });
     }
     return out;
+  }
+
+  /**
+   * The durable pin lives on the session Pod as an annotation, so every
+   * spawner replica (the Deployment is multi-replica, stateless) re-adopts it
+   * from the same object. A new Pod (fresh create or resume) carries none —
+   * a new session starts unpinned and the platform re-pushes its pin; stop /
+   * destroy delete the Pod and the annotation with it. Needs `patch` on pods
+   * in the spawner Role (docs/kubernetes.md).
+   */
+  async setPinned(sessionId: string, pinned: boolean): Promise<void> {
+    await withRetry('pin-session-pod', () =>
+      this.client.core.patchNamespacedPod(
+        {
+          name: sessionPodNameFor(sessionId),
+          namespace: this.cfg.k8s.namespace,
+          body: {
+            metadata: {
+              annotations: { [PINNED_ANNOTATION]: pinned ? 'true' : 'false' },
+            },
+          },
+        },
+        setHeaderOptions(
+          'Content-Type',
+          PatchStrategy.MergePatch,
+          apiTimeout(),
+        ),
+      ),
+    );
   }
 
   // No shared cross-session build cache on K8s (DinD is single-container,

--- a/services/sandbox/src/backend/types.ts
+++ b/services/sandbox/src/backend/types.ts
@@ -91,6 +91,22 @@ export interface BackendSession {
    * exited). `degraded` here means the object exists but isn't running;
    * runnerd reachability is layered on top by the route/registry layer. */
   state: Extract<SandboxSessionState, 'ready' | 'degraded'>;
+  /** "Always-on" as recorded by {@link SessionBackend.setPinned} — the reaper
+   * exemption a re-adopting spawner must carry over, or a restart (deploy,
+   * crash) TTL/idle-reaps the user's pinned session on its first sweep. */
+  pinned?: boolean;
+}
+
+/** What `createSession()` reports back once the session is `ready`. */
+export interface CreateSessionResult {
+  /**
+   * True when the workspace (host dir / PVC) already existed — this create
+   * RESUMED a stopped session onto preserved data. The route layer keys its
+   * own post-create rollback on it: a resume rolls back with `stopSession`
+   * (compute released, data kept); only a fresh create may `destroySession`
+   * the half-made workspace it provisioned itself.
+   */
+  resumed: boolean;
 }
 
 export interface SessionBackend {
@@ -99,9 +115,10 @@ export interface SessionBackend {
    * Launch the session container/Pod and wait until runnerd's /healthz
    * answers (budget: cfg.session.createHealthTimeoutMs). On failure the
    * backend cleans up whatever it created before throwing — a failed create
-   * never leaks a container. Returns once the session is `ready`.
+   * never leaks a container, and a failed RESUME never deletes the preserved
+   * workspace (stop, not destroy). Returns once the session is `ready`.
    */
-  createSession(spec: SessionSpec): Promise<void>;
+  createSession(spec: SessionSpec): Promise<CreateSessionResult>;
   /** Base URL of the session's runnerd (e.g. http://tale-sbx-ses-<id>:8200).
    * Resolved per call — on K8s the Pod IP can change across container
    * restarts. Throws if the backend object doesn't exist. */
@@ -132,6 +149,18 @@ export interface SessionBackend {
   /** List live session objects (label-selected), for boot re-adoption, the
    * GET /v1/sessions route, and the TTL/idle sweep. */
   listSessions(organizationId?: string): Promise<BackendSession[]>;
+  /**
+   * Record the "always-on" pin on the backend object's DURABLE state (Docker:
+   * a marker beside the workspace under the host session root; Kubernetes: a
+   * Pod annotation) so `listSessions` reports it back on boot re-adoption.
+   * The registry's own `pinned` flag is a cache that dies with the process;
+   * without this a spawner restart forgets every pin and the next sweep reaps
+   * the user's always-on session. A new create always starts unpinned (the
+   * platform row is the truth and re-pushes); stop/destroy clear the record.
+   * THROWS when the backend cannot record it — the caller keeps the in-memory
+   * pin and warns, so the current process still honours it.
+   */
+  setPinned(sessionId: string, pinned: boolean): Promise<void>;
   /**
    * Reconcile the shared cross-session build cache (the per-org buildkitd) at
    * spawner startup, after running sessions are re-adopted. The daemon is

--- a/services/sandbox/src/cleanup.ts
+++ b/services/sandbox/src/cleanup.ts
@@ -21,7 +21,7 @@ import { join } from 'node:path';
 
 import type { ExecutionBackend } from './backend/types.ts';
 import { isSessionWorkspaceDirName } from './session/session-naming.ts';
-import { runDocker, dockerRm } from './spawn-util.ts';
+import { dockerRm, dockerRmSucceeded, runDocker } from './spawn-util.ts';
 import type { SpawnerConfig } from './types.ts';
 import { ID_ALPHABET_RE } from './wire.ts';
 
@@ -195,6 +195,27 @@ export async function releaseSpawnerLock(cfg: SpawnerConfig): Promise<void> {
   }
 }
 
+/** A sweep's `docker rm`: true only when the container is verifiably gone.
+ * `dockerRm` never rejects (a timeout is exitCode 124), so the result must be
+ * judged — a swallowed failure would count a still-running container as
+ * removed. Logged, never thrown: one stuck container must not stop the sweep. */
+async function sweepRm(containerName: string, label: string): Promise<boolean> {
+  let removal;
+  try {
+    removal = await dockerRm(containerName);
+  } catch (err) {
+    console.warn(`${label} docker rm ${containerName} failed:`, err);
+    return false;
+  }
+  if (!dockerRmSucceeded(removal)) {
+    console.warn(
+      `${label} docker rm ${containerName} failed (exit ${removal.exitCode}): ${removal.stderr.trim()}`,
+    );
+    return false;
+  }
+  return true;
+}
+
 async function listLabeledContainers(...labels: string[]): Promise<string[]> {
   // Each `-f label=…` is AND-ed by docker.
   const filters = labels.flatMap((l) => ['-f', `label=${l}`]);
@@ -319,21 +340,13 @@ export async function bootSweep(cfg?: SpawnerConfig): Promise<void> {
   // here, so re-adoption can recover them.
   const containers = await listLabeledContainers('tale.sandbox=1');
   for (const c of containers) {
-    try {
-      await dockerRm(c);
-    } catch (err) {
-      console.warn(`[sandbox.bootSweep] dockerRm ${c} failed:`, err);
-    }
+    await sweepRm(c, '[sandbox.bootSweep]');
   }
   const stagingContainers = await listLabeledContainers(
     'tale.sandbox-staging=1',
   );
   for (const c of stagingContainers) {
-    try {
-      await dockerRm(c);
-    } catch (err) {
-      console.warn(`[sandbox.bootSweep] dockerRm staging ${c} failed:`, err);
-    }
+    await sweepRm(c, '[sandbox.bootSweep] staging');
   }
   let dirsRemoved = 0;
   if (cfg) {
@@ -398,15 +411,7 @@ export async function dockerSweepOrphans(
         // session id is the second component of the name (tale-sbx-<id>).
         const sessionId = name.replace(/^tale-sbx-/, '');
         if (isLive(sessionId)) continue;
-        try {
-          await dockerRm(name);
-        } catch (err) {
-          console.warn(
-            `[sandbox.periodic] dockerRm stale ${name} failed:`,
-            err,
-          );
-          continue;
-        }
+        if (!(await sweepRm(name, '[sandbox.periodic] stale'))) continue;
         removed += 1;
         console.log(
           `[sandbox] periodic sweep removed stale container ${name} (started ${new Date(started).toISOString()})`,

--- a/services/sandbox/src/session/session-routes.test.ts
+++ b/services/sandbox/src/session/session-routes.test.ts
@@ -220,13 +220,23 @@ let backendCheckThrows = false;
 // Sessions whose backend destroy fails (a wedged dockerd) — destroySession
 // throws for these so the route's honesty path (no laundered success) is tested.
 const backendDestroyThrows = new Set<string>();
+// Sessions whose create is a RESUME (the workspace pre-existed backend-side).
+const resumedSessions = new Set<string>();
+// The backend's durable pin record (what a restart would re-adopt).
+const backendPins = new Map<string, boolean>();
 
 const fakeBackend: SessionBackend = {
   kind: 'docker',
   async createSession(spec: SessionSpec) {
     created.add(spec.sessionId);
+    return { resumed: resumedSessions.has(spec.sessionId) };
   },
   async resolveEndpoint(sessionId: string) {
+    // `unaddressable-`-prefixed sessions exist backend-side but their endpoint
+    // can't be read (the K8s Pod-IP blip) — the create-rollback tests.
+    if (sessionId.startsWith('unaddressable-')) {
+      throw new Error(`session ${sessionId} has no pod IP`);
+    }
     // `dead-`-prefixed sessions get an unreachable runnerd — the zombie tests
     // need the runnerd hop to fail at the transport level.
     return sessionId.startsWith('dead-') ? 'http://127.0.0.1:9' : fakeBaseUrl;
@@ -251,6 +261,9 @@ const fakeBackend: SessionBackend = {
   async sessionExists(sessionId: string) {
     if (backendCheckThrows) throw new Error('docker daemon hiccup');
     return !backendGone.has(sessionId);
+  },
+  async setPinned(sessionId: string, pinned: boolean) {
+    backendPins.set(sessionId, pinned);
   },
   async reconcileBuildCache() {},
 };
@@ -293,6 +306,8 @@ beforeEach(() => {
   backendGone.clear();
   backendCheckThrows = false;
   backendDestroyThrows.clear();
+  resumedSessions.clear();
+  backendPins.clear();
   fakeHealth.lastActivityAtMs = 0;
   fakeHealth.liveExecs = 0;
   fakeHealth.activeScreencasts = 0;
@@ -487,6 +502,44 @@ describe('SessionRoutes (fake runnerd)', () => {
     expect(res.status).toBe(404);
   });
 
+  // The post-create rollback (backend object made, endpoint unreadable) must
+  // never delete data it did not provision: a RESUME re-attached a preserved
+  // workspace, so it rolls back with STOP; only a fresh create destroys.
+  describe('create rollback when the endpoint cannot be resolved', () => {
+    test('a FRESH create destroys the half-made session (nothing to preserve)', async () => {
+      const routes = new SessionRoutes(cfg, fakeBackend);
+      const res = await routes.handleCreate(
+        JSON.stringify({
+          sessionId: 'unaddressable-fresh',
+          organizationId: 'org_rb',
+        }),
+      );
+      expect(res.status).toBe(502);
+      expect(await res.json()).toMatchObject({ error: 'create_failed' });
+      expect(destroyed.has('unaddressable-fresh')).toBe(true);
+      expect(stopped.has('unaddressable-fresh')).toBe(false);
+      // Nothing registered: the sweep would never have walked it.
+      expect((await routes.handleGet('unaddressable-fresh')).status).toBe(404);
+    });
+
+    test('a RESUME stops — the preserved workspace survives for the retry', async () => {
+      resumedSessions.add('unaddressable-resume');
+      const routes = new SessionRoutes(cfg, fakeBackend);
+      const res = await routes.handleCreate(
+        JSON.stringify({
+          sessionId: 'unaddressable-resume',
+          organizationId: 'org_rb',
+        }),
+      );
+      expect(res.status).toBe(502);
+      expect(await res.json()).toMatchObject({ error: 'create_failed' });
+      // Compute released, data kept: the data-deleting verb was never reached.
+      expect(stopped.has('unaddressable-resume')).toBe(true);
+      expect(destroyed.has('unaddressable-resume')).toBe(false);
+      expect((await routes.handleGet('unaddressable-resume')).status).toBe(404);
+    });
+  });
+
   test('duplicate sessionId → 409', async () => {
     const routes = new SessionRoutes(cfg, fakeBackend);
     await routes.handleCreate(
@@ -610,8 +663,11 @@ describe('SessionRoutes (fake runnerd)', () => {
       JSON.stringify({ sessionId: 'pin1', organizationId: 'org_pin' }),
     );
     expect(
-      routes.handleSetPinned('pin1', JSON.stringify({ pinned: true })).status,
+      (await routes.handleSetPinned('pin1', JSON.stringify({ pinned: true })))
+        .status,
     ).toBe(200);
+    // The pin is recorded on the backend's durable state, not only in memory.
+    expect(backendPins.get('pin1')).toBe(true);
 
     // Stale + no live exec → would normally idle-reap, but pinned exempts it.
     fakeHealth.liveExecs = 0;
@@ -619,11 +675,53 @@ describe('SessionRoutes (fake runnerd)', () => {
     expect(await routes.sweepExpired()).toBe(0);
     expect((await routes.handleGet('pin1')).status).toBe(200);
 
-    // Unpin → reaped on the next sweep.
-    routes.handleSetPinned('pin1', JSON.stringify({ pinned: false }));
+    // Unpin → recorded, and reaped on the next sweep.
+    await routes.handleSetPinned('pin1', JSON.stringify({ pinned: false }));
+    expect(backendPins.get('pin1')).toBe(false);
     expect(await routes.sweepExpired()).toBe(1);
     expect((await routes.handleGet('pin1')).status).toBe(404);
     fakeHealth.lastActivityAtMs = 0;
+  });
+
+  test('a pin survives a spawner restart: adoptExisting carries `pinned` and the sweep spares it', async () => {
+    // Two sessions re-adopted from the backend after a restart, both created
+    // long before maxLifetime (TTL long past) with stale activity. Before the
+    // fix the rebuilt entries carried no `pinned`, so the always-on one was
+    // TTL-stopped on the very first sweep like its unpinned sibling.
+    const ancient = Date.now() - 2 * cfg.session.maxLifetimeMs;
+    const restartBackend: SessionBackend = {
+      ...fakeBackend,
+      async listSessions(): Promise<BackendSession[]> {
+        return [
+          {
+            ...mkBackendSession('adopt-pinned', 'org_restart'),
+            createdAtMs: ancient,
+            pinned: true,
+          },
+          {
+            ...mkBackendSession('adopt-plain', 'org_restart'),
+            createdAtMs: ancient,
+          },
+        ];
+      },
+    };
+    const routes = new SessionRoutes(cfg, restartBackend);
+    await routes.adoptExisting();
+    fakeHealth.liveExecs = 0;
+    fakeHealth.lastActivityAtMs = 0;
+
+    // The wire view reports what was adopted.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    const info = (await (await routes.handleGet('adopt-pinned')).json()) as {
+      session: { pinned: boolean };
+    };
+    expect(info.session.pinned).toBe(true);
+
+    expect(await routes.sweepExpired()).toBe(1);
+    expect(stopped.has('adopt-plain')).toBe(true);
+    expect(stopped.has('adopt-pinned')).toBe(false);
+    expect((await routes.handleGet('adopt-pinned')).status).toBe(200);
+    expect((await routes.handleGet('adopt-plain')).status).toBe(404);
   });
 
   test('sweepExpired skips a session with a live browser viewer (activeScreencasts > 0)', async () => {

--- a/services/sandbox/src/session/session-routes.ts
+++ b/services/sandbox/src/session/session-routes.ts
@@ -3,7 +3,7 @@
 // quota + registry bookkeeping; the SessionBackend owns container/Pod
 // lifecycle and runnerd addressing; runnerd owns the actual exec.
 
-import type { SessionBackend } from '../backend/types.ts';
+import type { CreateSessionResult, SessionBackend } from '../backend/types.ts';
 import { jsonResponse } from '../http-util.ts';
 import { sseResponse } from '../sse.ts';
 import type { SpawnerConfig } from '../types.ts';
@@ -145,6 +145,10 @@ export class SessionRoutes {
         idleTimeoutMs: s.idleTimeoutMs,
         endpoint,
         liveExecs: new Map(),
+        // The reaper exemption is re-read from the backend object's durable
+        // record: a restart used to rebuild entries unpinned, and an always-on
+        // session older than maxLifetime was TTL-stopped on the first sweep.
+        pinned: s.pinned === true,
       });
     }
 
@@ -263,6 +267,7 @@ export class SessionRoutes {
       lastActivityAtMs: s.createdAtMs,
       expiresAtMs: s.expiresAtMs,
       idleTimeoutMs: s.idleTimeoutMs,
+      pinned: s.pinned === true,
     };
   }
 
@@ -359,8 +364,9 @@ export class SessionRoutes {
     this.creating.add(req.sessionId);
     try {
       const createdAtMs = Date.now();
+      let created: CreateSessionResult;
       try {
-        await this.backend.createSession({
+        created = await this.backend.createSession({
           sessionId: req.sessionId,
           organizationId: req.organizationId,
           profile: req.profile,
@@ -386,11 +392,20 @@ export class SessionRoutes {
         // The backend object was created above but we can't address it. Roll it
         // back rather than leak an unregistered, unroutable, never-reaped session
         // (the sweep only walks the registry, so an unregistered backend object
-        // lingers until a spawner restart re-adopts it).
-        await this.backend.destroySession(req.sessionId).catch((destroyErr) => {
+        // lingers until a spawner restart re-adopts it). The VERB depends on
+        // what this create provisioned: a RESUME re-attached a preserved
+        // workspace that is not ours to delete — a blip reading a Pod IP must
+        // never wipe the user's data — so it rolls back with stop (compute
+        // released, workspace kept for the retry); only a fresh create destroys
+        // the half-made workspace it created itself. Mirrors the backends' own
+        // failed-create cleanup.
+        const rollback = created.resumed
+          ? this.backend.stopSession(req.sessionId)
+          : this.backend.destroySession(req.sessionId);
+        await rollback.catch((rollbackErr) => {
           console.warn(
-            '[sandbox.session] rollback destroy after resolveEndpoint failure:',
-            destroyErr,
+            `[sandbox.session] rollback ${created.resumed ? 'stop' : 'destroy'} after resolveEndpoint failure:`,
+            rollbackErr,
           );
         });
         return jsonResponse(
@@ -882,9 +897,11 @@ export class SessionRoutes {
 
   /** PATCH /v1/sessions/:id/pin — toggle "always-on". Pinned sessions are
    * exempt from the idle/TTL reaper; unpinning restores a fresh normal TTL.
-   * In-memory only (the platform row is the durable truth; re-pushed on the
-   * next turn after a spawner restart). */
-  handleSetPinned(sessionId: string, body: string): Response {
+   * The flag takes effect in the registry at once and is then recorded on
+   * the backend object's durable state (see SessionBackend.setPinned) so a
+   * spawner restart re-adopts it — the platform row is the durable truth
+   * platform-side, but nothing re-pushes it at spawner boot. */
+  async handleSetPinned(sessionId: string, body: string): Promise<Response> {
     const session = this.registry.get(sessionId);
     if (!session) return jsonResponse({ error: 'not_found' }, 404);
     let parsed: { pinned?: boolean };
@@ -899,6 +916,17 @@ export class SessionRoutes {
     if (!pinned) {
       // Give an unpinned session a fresh lifetime so it isn't reaped instantly.
       session.expiresAtMs = Date.now() + this.cfg.session.maxLifetimeMs;
+    }
+    // Best-effort durability: the in-memory pin already protects this process;
+    // a failed record means the pin would not survive a RESTART, which is
+    // worth an operator-visible line, not a failed toggle.
+    try {
+      await this.backend.setPinned(sessionId, pinned);
+    } catch (err) {
+      console.warn(
+        `[sandbox.session] recording pin=${pinned} for ${sessionId} on the backend failed (in-memory pin applied; will not survive a spawner restart):`,
+        err,
+      );
     }
     return jsonResponse({ ok: true, pinned }, 200);
   }

--- a/services/sandbox/src/spawn-util.ts
+++ b/services/sandbox/src/spawn-util.ts
@@ -32,7 +32,7 @@ interface RunDockerOptions {
   stderrMaxBytes?: number;
 }
 
-interface RunDockerResult {
+export interface RunDockerResult {
   exitCode: number;
   stdout: string;
   stderr: string;
@@ -218,11 +218,33 @@ export async function runDocker(
   };
 }
 
-export async function dockerRm(containerName: string): Promise<void> {
+/** Does a docker CLI stderr say the named object does not exist? The one
+ * definitive "gone" answer — every other failure (daemon hiccup, timeout, a
+ * container stuck in removal) is "unknown", never "gone". */
+export function isDockerNoSuchObject(stderr: string): boolean {
+  return /no such (object|container)/i.test(stderr);
+}
+
+/**
+ * `docker rm --force <name>`. Resolves with the CLI result — it never rejects,
+ * and a host-side timeout reads as exitCode 124 — so callers MUST judge
+ * `exitCode` (see {@link dockerRmSucceeded}): the removal of a still-running
+ * container is the one step whose silent failure orphans compute.
+ */
+export async function dockerRm(
+  containerName: string,
+): Promise<RunDockerResult> {
   // Bounded: a wedged inner dockerd (DinD) with stuck mounts could otherwise
   // hang teardown indefinitely. SIGKILL of PID 1 normally collapses everything
   // fast, so 30s is generous slack, not a routine wait.
-  await runDocker(['rm', '--force', containerName], { timeoutMs: 30_000 });
+  return runDocker(['rm', '--force', containerName], { timeoutMs: 30_000 });
+}
+
+/** Did a `dockerRm` leave the object gone? A clean exit, or a "no such
+ * container" refusal (already gone — the idempotent success). A timeout (124)
+ * or any other daemon error is a FAILURE: the container may still be running. */
+export function dockerRmSucceeded(result: RunDockerResult): boolean {
+  return result.exitCode === 0 || isDockerNoSuchObject(result.stderr);
 }
 
 /**

--- a/services/sandbox/src/wire.ts
+++ b/services/sandbox/src/wire.ts
@@ -143,6 +143,8 @@ export interface SessionInfo {
   lastActivityAtMs: number;
   expiresAtMs: number;
   idleTimeoutMs: number;
+  /** "Always-on": exempt from the idle/TTL reaper (PATCH /pin). */
+  pinned: boolean;
 }
 
 /** execId shares the sessionId alphabet; unique within its session. */


### PR DESCRIPTION
Six verified sandbox-session defects from the backend deep review (mediums), fixed on `fedc8cc15` (post-#3163/#3168 — none were covered by those). Two spawner-side leaks, one dead-end, one data-loss path, one reaper fairness gap, one authz dead-end.

## Per-finding outcome

| #   | Finding                                                                                        | Outcome   | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| --- | ---------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Ended automation runs leak live `stopped` session rows forever                                 | **fixed** | `watchdogs.ts` RECLAIM pass: `workflow_run` rows `stopped`/`expired` whose run is terminal (or purged) past a 10-min grace go through the spawner's `if_idle` destroy; a busy session or a spawner error leaves the row for the next tick; the row settles only after the spawner confirmed the compute gone. Integration probe: ended → `destroyed`, purged-run orphan → `destroyed`, live run's active **and** hibernated rows untouched, busy left `stopped`.                                |
| 2   | Watchdog reconcile probes only the 25 globally-oldest rows, no rotation                        | **fixed** | Migration `0070` adds `sandbox_sessions.last_reconciled_at_ms` (+ walk-order index); both spawner-facing passes order by least-recently-visited (`NULLS FIRST`) and stamp every visited row, so every row is reached within `ceil(rows / batch)` ticks. Integration probe: batch of 2 over 3 rows reaches all 3 by tick 2 (base never reached the third).                                                                                                                                       |
| 3   | Multi-bound runs' knowledge reads are hub-only — own bound projects' files invisible           | **fixed** | `shim.ts` org_run with bindings → scope over every bound project that exists (team, shared teams, archived label) + hub, via the same helper the project binding uses (fail-closed when a bound project is gone); `document_find` lists the whole authorized project set (`listDocumentsForAgent.projectIds`), not `projectIds[0]`. Integration probe through the real `POST /api/tools/execute` door: org run lists both bound projects' docs, no unbound leak; pinned run lists only its own. |
| 4   | `DockerSessionBackend.stopSession` swallows `docker rm` failure, orphaning a running container | **fixed** | `dockerRm` returns the CLI result (it never rejected — a timeout is exit 124); `removeContainer` throws on any outcome other than clean exit / "no such container", which is the stop/destroy throw-on-hiccup contract the reaper already retries on. Create-failure cleanups and the legacy sweeps log failed rms and count only verified removals.                                                                                                                                            |
| 5   | `adoptExisting` drops `pinned`, always-on sessions reaped after a spawner restart              | **fixed** | `SessionBackend.setPinned` records the pin on durable backend state — Docker: `<hostSessionRoot>/.pins/<id>.pinned` (outside the workspace; cleared on create/stop/destroy), Kubernetes: `tale.dev/pinned` Pod annotation (merge-patch; Role gains `patch` on pods) — `listSessions` reports it, `adoptExisting` carries it, `GET /v1/sessions/:id` exposes it.                                                                                                                                 |
| 6   | `handleCreate` rollback destroys a preserved workspace on a resume                             | **fixed** | `createSession` returns `{ resumed }`; the route rolls a resume back with `stopSession` (workspace kept for the retry) and only a fresh create with `destroySession` — mirroring both backends' own failed-create cleanup.                                                                                                                                                                                                                                                                      |

## Tests (all red on base, green on branch)

- `services/sandbox` (bun): 251 pass (+11 new) — fake-`docker` (via `DOCKER_BIN`) stop/destroy honour the rm result (4), durable pin marker lifecycle + `listSessions` (2), k8s pin annotation patch + read-back (1), create rollback stop-vs-destroy (2), pin survives `adoptExisting` + sweep (1), pin toggle recorded on the backend (folded into the existing pinned test).
- `services/platform` (vitest server): `watchdogs.test.ts` (5: fair order + stamp, stamp-on-error, reclaim outcomes, reclaim SQL guards, skipReconcile), `shim.knowledge-scope.test.ts` (5), `workspace_tools_bridge.test.ts` bound `document_find` updated to the project-set shape. Full server+pii suite: 72,718 pass; the 3 `app/routes/*.test.tsx` load failures under the `server` project are pre-existing on base (`Denied ID … @fontsource … woff2?url`).
- `backend:integration` on a throwaway tale-db + MinIO: **base 375/375**, **branch 377/377** — two new probes (fair reconcile + ended-run reclaim with a scripted spawner; org-run `document_find` + knowledge scope over two bound projects).

## Verification

- Sandbox: `bun test`, `tsc --noEmit`, `oxlint --type-aware`, `oxfmt --check` — clean.
- Platform: `tsc --noEmit`, workspace-wide `oxlint --type-aware`, `oxfmt --check` — clean; commitlint on all commits.
- Read-only verified: the K8s `patch` verb lands in `services/sandbox/docs/kubernetes.md` (the deployed Helm Role lives outside this repo — needs the same verb, otherwise the pin falls back to in-memory with a warning).

## Notes

- Migration `0070` is the next contiguous number on `main`; a sibling draft (#3173) also claims `0070` — whichever merges second renumbers.
- Cross-class discoveries (not fixed here): the platform never destroys the spawner workspace of an `expired` non-automation session (TTL flips the row, the spawner only stops); a phantom heal re-provisions a pinned session's deterministic id as an **unpinned** new row (`pinned` is not carried into the healed incarnation); `handleSetPinned`'s durable record is best-effort on backends whose Role lacks `patch`.
