### PR TITLE
fix(platform): deny a corpus ref bound to neither document nor thread

### DIFF
--- a/services/platform/backend/domains/knowledge/retrievable.test.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.test.ts
@@ -89,8 +89,42 @@ describe('decideRetrievable', () => {
     ).toBe(false);
   });
 
-  it('keeps the same-org posture for live document-less rows (video-link lane)', () => {
-    expect(decideRetrievable([], [unboundFile()], { teamIds: [] })).toBe(true);
+  it('denies a live row bound to neither a document nor a thread', () => {
+    // This replaces an assertion that admitted the same shape same-org. The
+    // corpus stamps no project and no team for a row with no document, and
+    // the SQL half reads that as org-wide — so admitting it here served one
+    // member's file to the whole organization. 0.4 denied it too.
+    expect(decideRetrievable([], [unboundFile()], { teamIds: [] })).toBe(false);
+  });
+
+  it('denies it with no access scope either', () => {
+    // `access === undefined` is the internal-caller path; it must not become
+    // a way around the rule above.
+    expect(decideRetrievable([], [unboundFile()], undefined)).toBe(false);
+  });
+
+  it('still admits the video-link lane once its thread is stamped', () => {
+    // The reason the old assertion gave for admitting unbound rows was that
+    // video-link transcripts index without a document. They do — with a
+    // thread. A welcome-page paste starts thread-less because no thread
+    // exists yet, and the first send stamps it (`bindStorageIdsToThread`
+    // updates exactly the rows with no document and no thread), after which
+    // this branch admits it.
+    expect(
+      decideRetrievable([], [unboundFile({ threadId: 'thread_1' })], {
+        teamIds: [],
+        threadIds: ['thread_1'],
+      }),
+    ).toBe(true);
+  });
+
+  it('does not admit a thread-bound row from outside its thread', () => {
+    expect(
+      decideRetrievable([], [unboundFile({ threadId: 'thread_1' })], {
+        teamIds: [],
+        threadIds: ['thread_2'],
+      }),
+    ).toBe(false);
   });
 
   it('denies trashed unbound rows — the WebDAV overwrite strands', () => {

--- a/services/platform/backend/domains/knowledge/retrievable.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.ts
@@ -12,12 +12,23 @@
  *     (history) never answers as if it were the live document. Scope
  *     (project / hub team) applies per candidate document — a WebDAV COPY
  *     twin admits through its own scope, not its sibling's.
- *   - or a LIVE unbound file row holding the ref: thread-bound rows admit
- *     only inside their thread's scope; rows with neither binding keep the
- *     0.4 same-org posture DELIBERATELY — video-link transcripts index
- *     without a document, so a blanket quarantine would dark a legitimate
- *     lane. Trashed file rows (a WebDAV overwrite's strands) and refs with
- *     no row at all are never retrievable.
+ *   - or a LIVE unbound file row holding the ref, admitted only inside its
+ *     thread's scope. A row with NEITHER binding is DENIED: the corpus
+ *     stamps no project and no team for that shape, and the SQL half then
+ *     reads it as an org-wide hub row, so admitting it here serves one
+ *     member's file to the whole organization. 0.4 denied it too
+ *     (`documentId === undefined` → `continue`).
+ *
+ *     This does not dark the video-link lane, which was the stated reason
+ *     for the earlier same-org posture. A welcome-page paste indexes with
+ *     `thread_id` NULL because no thread exists yet, and the first send
+ *     stamps it (`bindStorageIdsToThread`, which updates exactly the rows
+ *     with no document and no thread). Before that send there is no thread
+ *     for a turn to be scoped to, so nothing can legitimately ask for it;
+ *     after it, the thread branch admits it.
+ *
+ *     Trashed file rows (a WebDAV overwrite's strands) and refs with no row
+ *     at all are never retrievable.
  */
 
 export interface AccessScopeArg {
@@ -84,7 +95,10 @@ export function decideRetrievable(
       }
       continue;
     }
-    return true;
+    // Neither binding: denied. See the note at the top of this file — the
+    // corpus reads an unscoped row as org-wide, so a `return true` here is a
+    // fail-open default rather than a same-org one.
+    continue;
   }
   return false;
 }


### PR DESCRIPTION
The retrieval gate admits a file row bound to neither a document nor a thread, and serves it to any member of the organization. This denies it.

Replaces #3141, which was written against the gate before #3140 rewrote it. Refs #3142.

## Why

Retrieval has two gates. The SQL half admits rows and fails open on purpose — `backend/core/knowledge/corpus.ts` says so and names `decideRetrievable` as the decider. That function ends its unbound-file loop with `return true`.

The shape is not obscure. `indexUploadedFile` stamps corpus scope **only** from a bound document, so a row with no document carries no project and no team, and `corpus.ts` reads exactly that as an org-wide hub row. Both gates then pass it.

0.4 denied it: `if (metadata.documentId === undefined) { continue; }`.

## The premise I had to disprove first

The current posture is deliberate and documented — the module docstring says unbound rows "keep the 0.4 same-org posture DELIBERATELY", on the grounds that "video-link transcripts index without a document, so a blanket quarantine would dark a legitimate lane". There is also a test asserting it.

So I checked the lane before changing it, and the premise does not hold:

- The synthetic transcript row is inserted with `thread_id`, so it admits through the **thread** branch, not the unbound one.
- A welcome-page paste starts thread-less only because no thread exists yet. The first send stamps it — `bindStorageIdsToThread` updates exactly the rows `WHERE document_id IS NULL AND thread_id IS NULL`.
- Before that send there is no thread for a turn to be scoped to, so nothing can legitimately ask for the transcript. After it, the thread branch admits it.

The claim that this "keeps the 0.4 posture" is also the opposite of what 0.4 did.

The docstring is corrected to say all of that, so the next reader does not re-derive it.

## What changed

Two lines of logic. The unbound loop's final `return true` becomes `continue`.

The assertion that locked in the old behaviour is **replaced, not deleted**, with a comment recording what it used to claim and why that changed. Three cases are added: the no-access-scope path denies too (it is the internal-caller path and must not become a way around the rule), the video-link lane still admits once its thread is stamped, and a thread-bound row is not admitted from outside its thread.

## What I dropped from #3141

#3141 also added a `rag_status = 'completed'` guard and a superseded-ref check. Both are unnecessary now: #3140's rewrite queries `app.documents` **by `file_ref`**, so a replaced ref finds no document and is already denied, and the deleted-document and trashed-file cases are handled too.

The remaining `rag_status` gap is a mid-reindex window where a knowledge entry can answer from its previous version's chunks. That is the organization's own content one version stale, not a cross-member leak, and guarding it would mean joining `file_metadata` back into a query the refactor deliberately narrowed. Left out, named here rather than filed as a caveat.

## Tests

| Mutation | Went red |
| --- | --- |
| unbound branch back to `return true` | 2 cases |
| thread scope ignored (admit any thread-bound row) | 2 cases |

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `lint:sast` green; knowledge suite 12/12; branched from `origin/main` at `58c3de381`.
