### PR TITLE
fix(platform): close tasks/collab authz, orphan, and notification gaps

### DIFF
--- a/services/platform/app/features/tasks/hooks/mutations.ts
+++ b/services/platform/app/features/tasks/hooks/mutations.ts
@@ -1,6 +1,9 @@
 import { useBackendMutation } from '@/app/hooks/use-backend-mutation';
 import { useT } from '@/lib/i18n/client';
-import { backendUserMessage } from '@/lib/utils/backend-error';
+import {
+  backendErrorCode,
+  backendUserMessage,
+} from '@/lib/utils/backend-error';
 
 import { reviewPolicyErrorMessage } from '../lib/review-policy-error';
 
@@ -17,7 +20,20 @@ export function useUpdateTaskStatus() {
 }
 
 export function useAssignTask() {
-  return useBackendMutation('tasks/mutations:assignTask');
+  const { t } = useT('tasks');
+  const { t: tToast } = useT('toast');
+  // A live run holds the task for its current worker, so the server refuses
+  // a mid-run transfer (`TASK_HAS_LIVE_RUN`) — name the reason on every
+  // picker (board card, list row, sheet) instead of the generic failure copy.
+  return useBackendMutation('tasks/mutations:assignTask', {
+    errorToast: {
+      title: tToast('error.generic.title'),
+      description: (error) =>
+        backendErrorCode(error) === 'TASK_HAS_LIVE_RUN'
+          ? t('assignee.liveRunGuard')
+          : backendUserMessage(error, tToast('error.generic.description')),
+    },
+  });
 }
 
 export function useClaimTask() {

--- a/services/platform/backend/domains/collab/mention-directory.test.ts
+++ b/services/platform/backend/domains/collab/mention-directory.test.ts
@@ -1,0 +1,104 @@
+import type { Sql } from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+
+import { listAutomations } from '../automations/store.ts';
+import {
+  MentionDirectoryError,
+  resolveSurfaceMentions,
+} from './mention-directory.ts';
+
+vi.mock('../automations/store.ts', () => ({ listAutomations: vi.fn() }));
+
+type Row = Record<string, unknown>;
+
+/** A postgres.js tagged-template stand-in answering (or failing) each
+ * statement from its whitespace-collapsed text. */
+function fakeDb(answer: (text: string) => Row[]): Sql {
+  const tag = (
+    strings: TemplateStringsArray,
+    ..._values: unknown[]
+  ): Promise<Row[]> => {
+    const text = strings.join('?').replaceAll(/\s+/g, ' ').trim();
+    return Promise.resolve(answer(text));
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a one-member stand-in for the postgres.js template function
+  return tag as unknown as Sql;
+}
+
+const ADA = {
+  userId: 'u-ada',
+  role: 'member',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+};
+
+describe('mention directory — a leg that cannot be listed fails loudly', () => {
+  it('a failed member listing rejects instead of turning @teammate into text', async () => {
+    // The old contract logged and returned a partial directory: the comment
+    // posted, but the named teammate got no bell and nothing told the
+    // author. The surface must fail (retryable) instead.
+    const db = fakeDb((text) => {
+      if (text.startsWith('SELECT m."userId"')) {
+        throw new Error('connection reset');
+      }
+      return [];
+    });
+    await expect(
+      resolveSurfaceMentions(db, {
+        organizationId: 'org-1',
+        body: '@ada please look',
+      }),
+    ).rejects.toMatchObject({
+      name: 'MentionDirectoryError',
+      code: 'MENTION_DIRECTORY_UNAVAILABLE',
+      status: 503,
+      leg: 'members',
+    });
+  });
+
+  it('a failed automation listing rejects too — the owning-automation trigger rides it', async () => {
+    vi.mocked(listAutomations).mockRejectedValueOnce(new Error('store down'));
+    const db = fakeDb((text) => {
+      if (text.startsWith('SELECT m."userId"')) return [ADA];
+      if (text.startsWith('SELECT team_id AS "teamId"')) {
+        return [{ teamId: null, sharedWithTeamIds: null }];
+      }
+      if (text.startsWith('SELECT allowed_agent_slugs')) {
+        return [
+          {
+            allowedAgentSlugs: [],
+            recommendedAgentSlugs: [],
+            agentMode: 'all',
+          },
+        ];
+      }
+      return [];
+    });
+    const failure: unknown = await resolveSurfaceMentions(db, {
+      organizationId: 'org-1',
+      body: '@ada ship it',
+      projectId: 'proj-1',
+    }).then(
+      () => 'resolved',
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(MentionDirectoryError);
+    expect(failure).toMatchObject({ leg: 'automations', status: 503 });
+  });
+
+  it('a healthy directory still resolves the teammate by every handle', async () => {
+    const db = fakeDb((text) =>
+      text.startsWith('SELECT m."userId"') ? [ADA] : [],
+    );
+    const resolved = await resolveSurfaceMentions(db, {
+      organizationId: 'org-1',
+      body: '@ada.lovelace please look, @ghost too',
+    });
+    expect(resolved.mentions).toEqual([
+      expect.objectContaining({ type: 'user', id: 'u-ada' }),
+    ]);
+    // Org-wide surfaces are never permissive: an unclaimed token is a miss
+    // reported back, not an agent.
+    expect(resolved.unresolvedMentionTokens).toEqual(['ghost']);
+  });
+});

--- a/services/platform/backend/domains/collab/mention-directory.ts
+++ b/services/platform/backend/domains/collab/mention-directory.ts
@@ -24,9 +24,13 @@ import { listAutomations } from '../automations/store.ts';
  *    reaches the live lane;
  *  - an `agentMode` that is not `restricted` is PERMISSIVE: a token nobody
  *    claims is treated as an agent handle rather than reported unresolved;
- *  - every leg degrades on its own — a listing that throws is logged and
- *    skipped, because a directory missing its automations is still better
- *    than a comment that cannot be posted.
+ *  - a leg that cannot be listed FAILS the build (`MentionDirectoryError`,
+ *    503, retryable) — 0.4 logged and skipped it, but a partial directory
+ *    turns `@teammate` into plain text: no bell, no steer, no owning-
+ *    automation run, and nothing tells the author. The "quiet refusal"
+ *    contract covers PERMISSION misses (an outsider is not mentionable),
+ *    never infrastructure failures; the surface fails loudly and the comment
+ *    is posted again.
  *
  * The scanning itself (`extractMentions`, `findUnresolvedMentionTokens`,
  * `parseMentionTokens`) is REUSED from the 0.4 pure module: one grammar for
@@ -37,6 +41,33 @@ export interface MentionDirectory {
   entries: MentionDirectoryEntry[];
   /** Non-restricted projects: an unclaimed token reads as an agent handle. */
   permissiveAgents: boolean;
+}
+
+export type MentionDirectoryLeg = 'members' | 'automations' | 'agents';
+
+/**
+ * A directory leg could not be listed. The task-comment door maps it to a
+ * 503 with this code so the composer shows a failure the author can retry,
+ * instead of a posted comment whose mentions silently did nothing.
+ */
+export class MentionDirectoryError extends Error {
+  readonly code = 'MENTION_DIRECTORY_UNAVAILABLE';
+  readonly status = 503;
+  readonly leg: MentionDirectoryLeg;
+
+  constructor(leg: MentionDirectoryLeg, cause: unknown) {
+    super(`mention directory: ${leg} listing failed`, { cause });
+    this.name = 'MentionDirectoryError';
+    this.leg = leg;
+  }
+}
+
+function directoryUnavailable(
+  leg: MentionDirectoryLeg,
+  cause: unknown,
+): MentionDirectoryError {
+  console.error(`[collab] mention directory: ${leg} listing failed`, cause);
+  return new MentionDirectoryError(leg, cause);
 }
 
 function memberHandles(member: {
@@ -156,7 +187,7 @@ export async function buildMentionDirectory(
   try {
     entries.push(...(await accessibleMembers(sql, args)));
   } catch (error) {
-    console.warn('[collab] mention directory: member listing failed', error);
+    throw directoryUnavailable('members', error);
   }
   if (args.projectId === null) {
     // Org-wide surfaces (private agent chat) mention people only — agent
@@ -208,10 +239,7 @@ export async function buildMentionDirectory(
       });
     }
   } catch (error) {
-    console.warn(
-      '[collab] mention directory: automation listing failed',
-      error,
-    );
+    throw directoryUnavailable('automations', error);
   }
 
   // The project's agent INSTANCES go LAST so their handles shadow a
@@ -228,10 +256,7 @@ export async function buildMentionDirectory(
       }
     }
   } catch (error) {
-    console.warn(
-      '[collab] mention directory: agent instance listing failed',
-      error,
-    );
+    throw directoryUnavailable('agents', error);
   }
 
   return {

--- a/services/platform/backend/domains/collab/service.test.ts
+++ b/services/platform/backend/domains/collab/service.test.ts
@@ -6,7 +6,9 @@ import { coalesceKeyFor } from '../../core/collab/coalesce.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 import {
   dismissReviewRequestNotifications,
+  getMyAttentionSummary,
   markAllNotificationsRead,
+  notifyTaskReviewerAssigned,
   writeCoalescedNotification,
 } from './service.ts';
 
@@ -180,5 +182,141 @@ describe('the personal bell hint (wire contract with the web app)', () => {
       expect(hint.entity).toBe(NOTIFICATION_HINT_ENTITY);
       expect(hint.orgId).toBe('org-1');
     }
+  });
+});
+
+describe('the reviewer-designation heads-up (task_reviewer_assigned)', () => {
+  /** Like `fakeDb`, but keeps each statement's VALUES so the row written can
+   * be pinned (type, keys, params), not only the statement shape. */
+  function recordingDb(answer: (text: string) => Row[]): {
+    db: Sql;
+    calls: { text: string; values: unknown[] }[];
+  } {
+    const calls: { text: string; values: unknown[] }[] = [];
+    const tag = (
+      strings: TemplateStringsArray,
+      ...values: unknown[]
+    ): Promise<Row[]> => {
+      const text = strings.join('?').replaceAll(/\s+/g, ' ').trim();
+      calls.push({ text, values });
+      return Promise.resolve(answer(text));
+    };
+    const db = Object.assign(tag, { json: (value: unknown) => value });
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a two-member stand-in for the postgres.js template function
+    return { db: db as unknown as Sql, calls };
+  }
+
+  const designation = {
+    organizationId: 'org-1',
+    task: { id: 'task-1', projectId: 'proj-1', title: 'Ship the brief' },
+    reviewerUserId: 'u-recipient',
+    actorUserId: 'u-actor',
+  };
+
+  it('bells the designee on the task and hints their bell — no pref gate', async () => {
+    // The 0.4 bell that never fired in 0.5: the live reviewer write only
+    // stored the column. The heads-up is bell-only (not actionable, no
+    // email) and skips the preference gate like the request — the review
+    // group is locked on.
+    const { db, calls } = recordingDb((text) => {
+      if (text.startsWith('SELECT "name", "email" FROM "user"')) {
+        return [{ name: 'Ada', email: 'ada@example.com' }];
+      }
+      if (text.startsWith('INSERT INTO app.user_notifications')) {
+        return [{ id: 'n-reviewer' }];
+      }
+      return [];
+    });
+    await notifyTaskReviewerAssigned(db, designation);
+    const insert = calls.find((call) =>
+      call.text.startsWith('INSERT INTO app.user_notifications'),
+    );
+    expect(insert).toBeDefined();
+    expect(insert?.values).toEqual(
+      expect.arrayContaining([
+        'u-recipient',
+        'org-1',
+        'task_reviewer_assigned',
+        'taskReviewerAssigned',
+        'taskReviewerAssignedByBody',
+        'task',
+        'task-1',
+        'user',
+        'u-actor',
+      ]),
+    );
+    expect(insert?.values).toContainEqual({
+      taskId: 'task-1',
+      projectId: 'proj-1',
+      taskTitle: 'Ship the brief',
+      actor: 'Ada',
+    });
+    expect(calls.some((call) => call.text.includes('preferences'))).toBe(false);
+    expect(vi.mocked(emitHintInTx)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(emitHintInTx)).toHaveBeenCalledWith(db, {
+      orgId: 'org-1',
+      userId: 'u-recipient',
+      entity: NOTIFICATION_HINT_ENTITY,
+      entityId: null,
+    });
+  });
+
+  it('designating yourself rings nothing', async () => {
+    const { db, calls } = recordingDb(() => []);
+    await notifyTaskReviewerAssigned(db, {
+      ...designation,
+      reviewerUserId: 'u-actor',
+    });
+    expect(calls).toEqual([]);
+    expect(vi.mocked(emitHintInTx)).not.toHaveBeenCalled();
+  });
+});
+
+describe('the attention summary — "waiting on me" never misses my reviews', () => {
+  it('filters MY pending reviews in SQL, newest first, and counts them exactly', async () => {
+    // The old shape fetched 100 pending reviews org-wide in no order and
+    // filtered `requestedFor` in JS: past 100 pending reviews in the org, a
+    // person's own reviews fell outside the window nondeterministically.
+    const { db, statements } = fakeDb((text) => {
+      if (text.startsWith('SELECT coalesce(a.metadata')) {
+        return [
+          { taskId: 'task-9', total: 3 },
+          { taskId: 'task-4', total: 3 },
+          { taskId: 'task-4', total: 3 },
+        ];
+      }
+      return [];
+    });
+    const summary = await getMyAttentionSummary(db, {
+      organizationId: 'org-1',
+      userId: 'u-recipient',
+    });
+    const reviews = statements.find((text) =>
+      text.startsWith('SELECT coalesce(a.metadata'),
+    );
+    expect(reviews).toBeDefined();
+    expect(reviews).toContain("a.metadata ->> 'requestedFor' = ?");
+    expect(reviews).toContain('ORDER BY a.seq DESC');
+    // Two rows name the same task (two rounds): the task counts once in the
+    // return loop; the review count is the exact total, not the row count.
+    expect(summary.waitingOnMeTaskIds).toEqual(['task-9', 'task-4']);
+    expect(summary.pendingReviewCount).toBe(3);
+  });
+
+  it('counts unread bells exactly instead of scanning a capped page', async () => {
+    const { db } = fakeDb((text) =>
+      text.startsWith('SELECT type, count(*)')
+        ? [
+            { type: 'mention', count: 150 },
+            { type: 'task_status_changed', count: 3 },
+          ]
+        : [],
+    );
+    const summary = await getMyAttentionSummary(db, {
+      organizationId: 'org-1',
+      userId: 'u-recipient',
+    });
+    expect(summary.unreadTotalCount).toBe(153);
+    expect(summary.unreadActionableCount).toBe(150);
   });
 });

--- a/services/platform/backend/domains/collab/service.ts
+++ b/services/platform/backend/domains/collab/service.ts
@@ -600,6 +600,48 @@ export async function notifyTaskReviewRequested(
   });
 }
 
+/**
+ * Heads-up to a freshly designated reviewer while the work is still in
+ * flight — "you're on the hook for this one". Bell only: the review is not
+ * due yet, so the type stays out of `ACTIONABLE_NOTIFICATION_TYPES` (no
+ * email); the actionable request + email follow when the task reaches
+ * `in_review`. Skips the preference gate like the request (the review group
+ * is locked on) and never pings a person about designating themselves. The
+ * 0.4 emitter existed only in the dead Convex shim — this is the live one.
+ */
+export async function notifyTaskReviewerAssigned(
+  db: Db,
+  args: {
+    organizationId: string;
+    task: { id: string; projectId: string; title: string };
+    reviewerUserId: string;
+    actorUserId: string;
+  },
+): Promise<void> {
+  if (args.reviewerUserId === args.actorUserId) return;
+  const actorName = await resolveUserDisplayName(db, args.actorUserId);
+  await writeCoalescedNotification(db, {
+    userId: args.reviewerUserId,
+    organizationId: args.organizationId,
+    type: 'task_reviewer_assigned',
+    titleKey: 'taskReviewerAssigned',
+    bodyKey: actorName
+      ? 'taskReviewerAssignedByBody'
+      : 'taskReviewerAssignedBody',
+    params: {
+      taskId: args.task.id,
+      projectId: args.task.projectId,
+      taskTitle: args.task.title,
+      ...(actorName ? { actor: actorName } : {}),
+    },
+    resourceType: 'task',
+    resourceId: args.task.id,
+    taskId: args.task.id,
+    actorType: 'user',
+    actorId: args.actorUserId,
+  });
+}
+
 /** Review outcome to watchers (minus the deciding actor), pref-gated. */
 export async function notifyTaskReviewResolved(
   db: Db,
@@ -1156,9 +1198,10 @@ export async function notifyConversationAssignedTeam(
 
 // ------------------------------------------------------------- attention
 
-/** Cap on every list this summary walks — the badge is a nudge, not a
- * report, and an unbounded count would make the return loop the most
- * expensive query on the page. */
+/** Cap on the task-id LISTS this summary walks — the badge is a nudge, not
+ * a report, and an unbounded list would make the return loop the most
+ * expensive query on the page. The COUNTS are exact: they come from SQL
+ * aggregates, never from the size of a capped page. */
 const ATTENTION_LIST_CAP = 100;
 
 export interface AttentionSummary {
@@ -1181,50 +1224,48 @@ export async function getMyAttentionSummary(
   sql: Sql,
   args: { organizationId: string; userId: string; projectId?: string },
 ): Promise<AttentionSummary> {
-  const unread = await sql<{ type: string }[]>`
-    SELECT type FROM app.user_notifications
+  // Exact unread counts from one aggregate bounded by the number of
+  // distinct types — a capped page scan skewed both counts once a person
+  // had more than the cap unread.
+  const unreadByType = await sql<{ type: string; count: number }[]>`
+    SELECT type, count(*)::int AS count FROM app.user_notifications
     WHERE user_id = ${args.userId} AND org_id = ${args.organizationId}
       AND read = false
-    LIMIT ${ATTENTION_LIST_CAP}
+    GROUP BY type
   `;
   let unreadActionableCount = 0;
-  for (const row of unread) {
-    if (isActionableNotificationType(row.type)) unreadActionableCount += 1;
+  let unreadTotalCount = 0;
+  for (const row of unreadByType) {
+    unreadTotalCount += row.count;
+    if (isActionableNotificationType(row.type)) {
+      unreadActionableCount += row.count;
+    }
   }
 
-  const waitingOnMe = new Set<string>();
-  const reviews = await sql<{ taskId: string; metadata: unknown }[]>`
-    SELECT a.resource_id AS "taskId", a.metadata
+  // Reviews waiting on THIS person: the reviewer filter (and the project
+  // scope) run in SQL before the cap, newest gate first, so a busy org's
+  // backlog can never push someone's own reviews out of the window — the
+  // old filter-after-LIMIT shape missed them nondeterministically past 100
+  // pending reviews org-wide. The window count is the exact total.
+  const projectId = args.projectId ?? null;
+  const reviews = await sql<{ taskId: string; total: number }[]>`
+    SELECT coalesce(a.metadata ->> 'taskId', a.resource_id) AS "taskId",
+           (count(*) OVER ())::int AS total
     FROM app.approvals a
     WHERE a.org_id = ${args.organizationId} AND a.status = 'pending'
       AND a.resource_type = 'task_review'
+      AND a.metadata ->> 'requestedFor' = ${args.userId}
+      AND (${projectId}::text IS NULL OR EXISTS (
+        SELECT 1 FROM app.tasks t
+        WHERE t.id = coalesce(a.metadata ->> 'taskId', a.resource_id)
+          AND t.project_id = ${projectId}
+      ))
+    ORDER BY a.seq DESC
     LIMIT ${ATTENTION_LIST_CAP}
   `;
-  let pendingReviewCount = 0;
-  for (const review of reviews) {
-    const metadata = review.metadata;
-    if (metadata === null || typeof metadata !== 'object') continue;
-    if (
-      !('requestedFor' in metadata) ||
-      metadata.requestedFor !== args.userId
-    ) {
-      continue;
-    }
-    const taskId =
-      'taskId' in metadata && typeof metadata.taskId === 'string'
-        ? metadata.taskId
-        : review.taskId;
-    if (args.projectId !== undefined) {
-      const owned = await sql<{ one: number }[]>`
-        SELECT 1 AS one FROM app.tasks
-        WHERE id = ${taskId} AND project_id = ${args.projectId} LIMIT 1
-      `;
-      if (owned.length === 0) continue;
-    }
-    waitingOnMe.add(taskId);
-    pendingReviewCount += 1;
-    if (waitingOnMe.size >= ATTENTION_LIST_CAP) break;
-  }
+  const waitingOnMe = new Set<string>();
+  for (const review of reviews) waitingOnMe.add(review.taskId);
+  const pendingReviewCount = reviews[0]?.total ?? 0;
 
   const assigned = await sql<{ id: string }[]>`
     SELECT id FROM app.tasks
@@ -1232,8 +1273,8 @@ export async function getMyAttentionSummary(
       AND assignee_type = 'user' AND assignee_id = ${args.userId}
       AND archived_at_ms IS NULL
       AND status IN ('todo', 'in_progress', 'in_review')
-      AND (${args.projectId ?? null}::text IS NULL
-           OR project_id = ${args.projectId ?? null})
+      AND (${projectId}::text IS NULL OR project_id = ${projectId})
+    ORDER BY updated_at_ms DESC
     LIMIT ${ATTENTION_LIST_CAP}
   `;
   for (const task of assigned) {
@@ -1243,7 +1284,7 @@ export async function getMyAttentionSummary(
 
   return {
     unreadActionableCount,
-    unreadTotalCount: unread.length,
+    unreadTotalCount,
     waitingOnMeTaskIds: [...waitingOnMe],
     pendingReviewCount,
   };

--- a/services/platform/backend/domains/tasks/agent-runs.test.ts
+++ b/services/platform/backend/domains/tasks/agent-runs.test.ts
@@ -1,0 +1,71 @@
+import type { TransactionSql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cancelAgentRunInTx } from './agent-runs.ts';
+import { recordTaskAgentRunLedgerEntry } from './run-ledger.ts';
+
+vi.mock('./run-ledger.ts', () => ({ recordTaskAgentRunLedgerEntry: vi.fn() }));
+vi.mock('../../jobs/enqueue.ts', () => ({ addJobInTx: vi.fn() }));
+
+type Row = Record<string, unknown>;
+
+/** A postgres.js tagged-template stand-in answering each statement from its
+ * (whitespace-collapsed) text; the statements are what these tests pin. */
+function fakeTx(answer: (text: string) => Row[]): {
+  tx: TransactionSql;
+  statements: string[];
+} {
+  const statements: string[] = [];
+  const tag = (
+    strings: TemplateStringsArray,
+    ..._values: unknown[]
+  ): Promise<Row[]> => {
+    const text = strings.join('?').replaceAll(/\s+/g, ' ').trim();
+    statements.push(text);
+    return Promise.resolve(answer(text));
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a one-member stand-in for the postgres.js template function
+  return { tx: tag as unknown as TransactionSql, statements };
+}
+
+const KEYS = { organizationId: 'org-1', runId: 'run-1', taskId: 'task-1' };
+
+describe('cancelAgentRunInTx — the run must belong to the authorized task', () => {
+  beforeEach(() => {
+    vi.mocked(recordTaskAgentRunLedgerEntry).mockReset();
+  });
+
+  it('binds the cancel to the task in the SAME guard as the org and status', async () => {
+    // The authorization happened on the URL's task; a run id from another
+    // task (IDOR) must never match — the task binding is part of the UPDATE
+    // predicate itself, not a separate read a racing caller could slip past.
+    const { tx, statements } = fakeTx(() => []);
+    const cancelled = await cancelAgentRunInTx(tx, KEYS);
+    expect(cancelled).toBe(false);
+    const update = statements.find((text) =>
+      text.startsWith('UPDATE app.project_agent_runs'),
+    );
+    expect(update).toBeDefined();
+    expect(update).toContain('WHERE id = ? AND org_id = ? AND task_id = ?');
+    expect(update).toContain("status IN ('queued', 'running')");
+    // A refused cancel writes no provenance entry — nothing was cancelled.
+    expect(recordTaskAgentRunLedgerEntry).not.toHaveBeenCalled();
+  });
+
+  it('records the cancelled ledger entry when the bound run was live', async () => {
+    const { tx } = fakeTx((text) =>
+      text.startsWith('UPDATE app.project_agent_runs') ? [{ id: 'run-1' }] : [],
+    );
+    const cancelled = await cancelAgentRunInTx(tx, KEYS);
+    expect(cancelled).toBe(true);
+    expect(recordTaskAgentRunLedgerEntry).toHaveBeenCalledTimes(1);
+    expect(recordTaskAgentRunLedgerEntry).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        runId: 'run-1',
+        organizationId: 'org-1',
+        finalStatus: 'cancelled',
+      }),
+    );
+  });
+});

--- a/services/platform/backend/domains/tasks/agent-runs.ts
+++ b/services/platform/backend/domains/tasks/agent-runs.ts
@@ -236,28 +236,52 @@ export async function failAgentRun(
   });
 }
 
-export async function cancelAgentRun(
-  sql: Sql,
-  args: { organizationId: string; runId: string },
+export interface CancelAgentRunArgs {
+  organizationId: string;
+  runId: string;
+  /** The task the caller was AUTHORIZED on. The cancel binds to it inside
+   * the UPDATE predicate, so a run id lifted from another task (one the
+   * caller may not even read) never matches — there is no unbound cancel
+   * door: every lane that cancels a run holds its task. */
+  taskId: string;
+}
+
+/**
+ * The transactional body of {@link cancelAgentRun} — for callers already
+ * inside a transaction (the task hard delete cancels the subtree's live runs
+ * in the same tx that removes the rows, so the provenance entry lands before
+ * the FK cascade takes the run row). The status guard is the settle
+ * election, so the ledger entry rides the same transaction: a raced cancel
+ * that degrades to a no-op also writes no second row.
+ */
+export async function cancelAgentRunInTx(
+  tx: TransactionSql,
+  args: CancelAgentRunArgs,
 ): Promise<boolean> {
   const now = Date.now();
-  return sql.begin(async (tx) => {
-    const rows = await tx<{ id: string }[]>`
-      UPDATE app.project_agent_runs SET
-        status = 'cancelled', settled_at_ms = ${now}, updated_at_ms = ${now}
-      WHERE id = ${args.runId} AND org_id = ${args.organizationId}
-        AND status IN ('queued', 'running')
-      RETURNING id
-    `;
-    if (rows.length === 0) return false;
-    await recordTaskAgentRunLedgerEntry(tx, {
-      runId: args.runId,
-      organizationId: args.organizationId,
-      finalStatus: 'cancelled',
-      settledAt: now,
-    });
-    return true;
+  const rows = await tx<{ id: string }[]>`
+    UPDATE app.project_agent_runs SET
+      status = 'cancelled', settled_at_ms = ${now}, updated_at_ms = ${now}
+    WHERE id = ${args.runId} AND org_id = ${args.organizationId}
+      AND task_id = ${args.taskId}
+      AND status IN ('queued', 'running')
+    RETURNING id
+  `;
+  if (rows.length === 0) return false;
+  await recordTaskAgentRunLedgerEntry(tx, {
+    runId: args.runId,
+    organizationId: args.organizationId,
+    finalStatus: 'cancelled',
+    settledAt: now,
   });
+  return true;
+}
+
+export async function cancelAgentRun(
+  sql: Sql,
+  args: CancelAgentRunArgs,
+): Promise<boolean> {
+  return sql.begin((tx) => cancelAgentRunInTx(tx, args));
 }
 
 /** Park the run on a full session budget: it stays queued, stamped. */

--- a/services/platform/backend/domains/tasks/external-ref.ts
+++ b/services/platform/backend/domains/tasks/external-ref.ts
@@ -11,7 +11,10 @@ import {
 import { createAuditLog } from '../audit_logs/service.ts';
 import { beginRun } from '../automations/store.ts';
 import { emitEvent } from '../events/emit.ts';
-import { closePendingTaskReviewOnStatusLeave } from './reviews.ts';
+import {
+  closePendingTaskReviewOnStatusLeave,
+  requestTaskReview,
+} from './reviews.ts';
 import {
   applyTaskCountTransition,
   computeEndRank,
@@ -291,6 +294,28 @@ export async function upsertTaskByExternalRef(
         action: 'status.changed',
         fromValue: statusFrom,
         toValue: newStatus,
+      });
+    }
+    // A non-workflow external close PARKS the card at `in_review`, and that
+    // park IS the request for review — the gate belongs to the state, so the
+    // reviewer is belled, the board gets its chip, and the later leave to
+    // done records a real approval. Idempotent: a pending row is reused, so
+    // a re-close of an already parked card heals a missing gate rather than
+    // minting twice.
+    if (newStatus === 'in_review') {
+      await requestTaskReview(tx, {
+        task: {
+          ...existing,
+          status: 'in_review',
+          assigneeType: assigneePatch?.assigneeType ?? existing.assigneeType,
+          assigneeId: assigneePatch?.assigneeId ?? existing.assigneeId,
+        },
+        trigger: {
+          kind: 'automation',
+          ...(args.automationSlug !== undefined
+            ? { slug: args.automationSlug }
+            : {}),
+        },
       });
     }
     await externalRefAudit(tx, {

--- a/services/platform/backend/domains/tasks/routes.ts
+++ b/services/platform/backend/domains/tasks/routes.ts
@@ -13,6 +13,7 @@ import {
   RateLimitExceededError,
 } from '../../lib/rate-limit.ts';
 import { cancelRunInTx } from '../automations/store.ts';
+import { MentionDirectoryError } from '../collab/mention-directory.ts';
 import { getOrCreateProjectFolder } from '../folders/service.ts';
 import { knowledgeShimHandlers } from '../knowledge/service.ts';
 import {
@@ -24,6 +25,7 @@ import {
 } from '../projects/service.ts';
 import {
   cancelAgentRun,
+  getAgentRun,
   getAgentRunSandboxOp,
   getLatestAgentRunCardForTask,
   listAgentRunsForTask,
@@ -170,6 +172,12 @@ function handleError<E extends OrgEnv>(
       { error: 'RATE_LIMITED', data: { retryAfterMs: error.retryAfter } },
       429,
     );
+  }
+  // A comment whose @mentions could not be resolved is NOT posted — the
+  // author sees a retryable failure instead of a comment that silently
+  // notified nobody.
+  if (error instanceof MentionDirectoryError) {
+    return c.json({ error: error.code }, error.status);
   }
   throw error;
 }
@@ -1140,6 +1148,7 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
           : await cancelAgentRun(deps.sql, {
               organizationId: auth.organizationId,
               runId,
+              taskId: task.id,
             });
       return c.json({ cancelled });
     } catch (error) {
@@ -1157,9 +1166,23 @@ export function createTaskRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
       );
       const project = await loadProjectOrThrow(deps.sql, task.projectId);
       assertTaskWritable(project, auth);
+      // Write access was asserted on the URL's task, so the run must be THAT
+      // task's: a run id lifted from another project's task (one the caller
+      // may not even read) answers as missing — the same opaque 404 a garbage
+      // id gets, so probing confirms nothing. The cancel itself binds to the
+      // task once more inside its UPDATE predicate.
+      const run = await getAgentRun(
+        deps.sql,
+        auth.organizationId,
+        c.req.param('runId'),
+      );
+      if (run === null || run.taskId !== task.id) {
+        throw new TaskError('AGENT_RUN_NOT_FOUND', 'Agent run not found', 404);
+      }
       const cancelled = await cancelAgentRun(deps.sql, {
         organizationId: auth.organizationId,
-        runId: c.req.param('runId'),
+        runId: run.id,
+        taskId: task.id,
       });
       return c.json({ cancelled });
     } catch (error) {

--- a/services/platform/backend/domains/tasks/service.blobs.test.ts
+++ b/services/platform/backend/domains/tasks/service.blobs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { collectTaskBlobRefs } from './service.ts';
+
+/**
+ * The hard delete reclaims a task subtree's attachment/output blobs through
+ * the shared ref-release seam; this pins WHICH refs it hands over — every
+ * `fileId` (the `s3:` ref both columns hold, per files/access.ts) across
+ * every task in the tree, de-duplicated, with malformed rows skipped rather
+ * than failing the delete.
+ */
+describe('collectTaskBlobRefs — the blobs a task subtree holds', () => {
+  it('collects every fileId from attachments and outputs across the tree', () => {
+    const refs = collectTaskBlobRefs([
+      {
+        attachments: [{ fileId: 's3:org/a.pdf', fileName: 'a.pdf' }],
+        outputs: [
+          { fileId: 's3:org/out-1.docx', fileName: 'out-1.docx' },
+          { fileId: 's3:org/out-2.xlsx', fileName: 'out-2.xlsx' },
+        ],
+      },
+      {
+        attachments: null,
+        outputs: [{ fileId: 's3:org/child.md', fileName: 'child.md' }],
+      },
+    ]);
+    expect(refs).toEqual([
+      's3:org/a.pdf',
+      's3:org/out-1.docx',
+      's3:org/out-2.xlsx',
+      's3:org/child.md',
+    ]);
+  });
+
+  it('de-duplicates a ref two tasks list and ignores malformed entries', () => {
+    const refs = collectTaskBlobRefs([
+      { attachments: [{ fileId: 's3:org/shared.pdf' }], outputs: 'garbage' },
+      {
+        attachments: [{ fileId: 's3:org/shared.pdf' }, { fileName: 'no-ref' }],
+        outputs: [null, 42, { fileId: '' }],
+      },
+    ]);
+    expect(refs).toEqual(['s3:org/shared.pdf']);
+  });
+
+  it('answers nothing for a tree without files', () => {
+    expect(collectTaskBlobRefs([{ attachments: null, outputs: null }])).toEqual(
+      [],
+    );
+    expect(collectTaskBlobRefs([])).toEqual([]);
+  });
+});

--- a/services/platform/backend/domains/tasks/service.test.ts
+++ b/services/platform/backend/domains/tasks/service.test.ts
@@ -4,6 +4,7 @@ import type { ProjectAuthContext, ProjectRow } from '../projects/service.ts';
 import {
   assertTaskReadable,
   assertTaskWritable,
+  assigneeChanges,
   TaskError,
 } from './service.ts';
 
@@ -117,5 +118,35 @@ describe('task guards — write access', () => {
     for (const role of ['owner', 'admin', 'developer', 'editor']) {
       expect(() => assertTaskWritable(project(), auth({ role }))).not.toThrow();
     }
+  });
+});
+
+describe('assigneeChanges — one transfer rule for the picker and the bulk bar', () => {
+  // The live-run gate refuses (single card) or skips (bulk) exactly when the
+  // write TRANSFERS the task; both doors ask this one function, so they can
+  // never disagree about what a transfer is.
+  const held = { assigneeType: 'agent' as const, assigneeId: 'agent-1' };
+  const idle = { assigneeType: null, assigneeId: null };
+
+  it('re-selecting the current assignee is not a transfer', () => {
+    expect(assigneeChanges(held, held)).toBe(false);
+  });
+
+  it('another worker, or clearing a held task, is a transfer', () => {
+    expect(
+      assigneeChanges(held, { assigneeType: 'user', assigneeId: 'user-2' }),
+    ).toBe(true);
+    expect(assigneeChanges(held, null)).toBe(true);
+  });
+
+  it('assigning an idle task is a transfer; clearing an idle task is not', () => {
+    expect(assigneeChanges(idle, held)).toBe(true);
+    expect(assigneeChanges(idle, null)).toBe(false);
+  });
+
+  it('a mid-run transfer refusal is a 409 the picker can name', () => {
+    const error = new TaskError('TASK_HAS_LIVE_RUN', 'held', 409);
+    expect(error.status).toBe(409);
+    expect(error.code).toBe('TASK_HAS_LIVE_RUN');
   });
 });

--- a/services/platform/backend/domains/tasks/service.ts
+++ b/services/platform/backend/domains/tasks/service.ts
@@ -4,6 +4,7 @@ import {
   defaultTaskLabelColor,
   PREDEFINED_TASK_LABELS,
 } from '../../../lib/shared/task-label-colors.ts';
+import { findOrganizationMember } from '../../auth/membership.ts';
 import {
   checkProjectAccess,
   EDITOR_ROLES,
@@ -16,12 +17,15 @@ import {
 import { initialRank, rankBetween } from '../../core/tasks/rank.ts';
 import { REVIEW_POLICY_REFUSAL_CODES } from '../../core/tasks/review_shared.ts';
 import { toJson } from '../../db/sql.ts';
+import { addJobInTx } from '../../jobs/enqueue.ts';
 import { readGovernancePolicyForOrg } from '../../lib/org-config.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
+import { cancelRunInTx } from '../automations/store.ts';
 import {
   autoSubscribe,
   notifyTaskAssigned,
+  notifyTaskReviewerAssigned,
   notifyTaskStatusChanged,
 } from '../collab/service.ts';
 import { emitEvent } from '../events/emit.ts';
@@ -31,11 +35,12 @@ import {
   type ProjectAuthContext,
   type ProjectRow,
 } from '../projects/service.ts';
-import { kickAgentRun } from './agent-runs.ts';
+import { cancelAgentRunInTx, kickAgentRun } from './agent-runs.ts';
 import {
   closePendingTaskReviewOnStatusLeave,
   collectPendingReviewsForProjects,
   requestTaskReview,
+  type TaskReviewTrigger,
 } from './reviews.ts';
 
 /**
@@ -81,13 +86,13 @@ export const TASK_BOARD_CAP = 2000;
 
 export class TaskError extends Error {
   readonly code: string;
-  readonly status: 400 | 403 | 404;
+  readonly status: 400 | 403 | 404 | 409;
   readonly data: Record<string, unknown> | undefined;
 
   constructor(
     code: string,
     message: string,
-    status: 400 | 403 | 404 = 400,
+    status: 400 | 403 | 404 | 409 = 400,
     data?: Record<string, unknown>,
   ) {
     super(message);
@@ -635,9 +640,26 @@ function taskAudit(
 // Assignee validation
 // ---------------------------------------------------------------------------
 
-interface AssigneeRef {
+export interface AssigneeRef {
   assigneeType: TaskAssigneeType;
   assigneeId: string;
+}
+
+/**
+ * Whether writing `assignee` onto `task` changes who holds it — ONE rule for
+ * the picker (`assignTask`) and the bulk bar (`bulkUpdateTasks`), so the
+ * live-run transfer gate they share can never disagree about what counts as
+ * a transfer. A same-assignee re-select and clearing an already-unassigned
+ * task are not transfers.
+ */
+export function assigneeChanges(
+  task: Pick<TaskRow, 'assigneeType' | 'assigneeId'>,
+  assignee: AssigneeRef | null,
+): boolean {
+  return (
+    task.assigneeId !== (assignee?.assigneeId ?? null) ||
+    task.assigneeType !== (assignee?.assigneeType ?? null)
+  );
 }
 
 function normalizeAssignee(args: {
@@ -1066,6 +1088,29 @@ export async function updateTask(
     previousState.reviewerUserId = task.reviewerUserId;
     newState.reviewerUserId = reviewerUserId;
   }
+  // A NEW designee (not a clear, not a re-select) is about to be subscribed
+  // and belled: only a live member of THIS org can be on the hook — the
+  // picker offers members only, so a miss is a stale or hand-built request,
+  // and a disabled account cannot review.
+  const designatedReviewer =
+    args.reviewerUserId !== undefined &&
+    reviewerUserId !== null &&
+    reviewerUserId !== task.reviewerUserId
+      ? reviewerUserId
+      : null;
+  if (designatedReviewer !== null) {
+    const member = await findOrganizationMember(
+      tx,
+      auth.organizationId,
+      designatedReviewer,
+    );
+    if (member === null || member.role === 'disabled') {
+      throw new TaskError(
+        'TASK_REVIEWER_INVALID',
+        'The reviewer must be an active member of this organization',
+      );
+    }
+  }
 
   if (Object.keys(newState).length === 0) {
     return;
@@ -1091,6 +1136,26 @@ export async function updateTask(
       newState,
     }),
   );
+  if (designatedReviewer !== null) {
+    // The designee owns the gate from now on: they follow the task (its
+    // progress, not just the request moment) and get the heads-up bell —
+    // "you're on the hook for this one". The actionable request + email
+    // follow when the card reaches In review. Before this, the column was
+    // written and nobody was told.
+    await autoSubscribe(tx, {
+      organizationId: auth.organizationId,
+      taskId: task.id,
+      subscriberType: 'user',
+      subscriberId: designatedReviewer,
+      reason: 'reviewer',
+    });
+    await notifyTaskReviewerAssigned(tx, {
+      organizationId: auth.organizationId,
+      task: { id: task.id, projectId: task.projectId, title },
+      reviewerUserId: designatedReviewer,
+      actorUserId: auth.userId,
+    });
+  }
 }
 
 export async function hasOpenChildren(
@@ -1335,8 +1400,9 @@ export async function agentCreateTaskTrusted(
  * TRUSTED agent-side status flip — the settle's park to `in_review` (and the
  * failure paths that leave `in_progress` alone). The turn host already
  * resolved authority (the run belongs to the agent); this is the lower half:
- * status + rank + rollup + activity, attributed to the agent actor. The
- * review-row mint (task_review + reviewer bell) lands with the review arc.
+ * status + rank + rollup + activity, attributed to the agent actor, plus the
+ * review-gate mint (task_review row + reviewer bell) whenever the park lands
+ * at `in_review`.
  */
 export async function agentUpdateTaskStatusTrusted(
   tx: TransactionSql,
@@ -1345,9 +1411,11 @@ export async function agentUpdateTaskStatusTrusted(
     actorId: string;
     taskId: string;
     status: TaskStatus;
-    /** Present only on the settle park to `in_review`: mint the run's
-     * workflow-free review in the SAME transaction as the flip (find-or-
-     * insert by runId — the burned-claim replay never double-mints). */
+    /** The settle park to `in_review` names its run: the review is minted
+     * in the SAME transaction as the flip, keyed on the runId (find-or-
+     * insert — the burned-claim replay never double-mints). Lanes without a
+     * run key (the agent tool, the workflow native) still mint; see
+     * `mintReview`. */
     review?: { runId: string };
   },
   // `reason` is a CODE, not prose: the workspace-tool bridge branches on
@@ -1357,14 +1425,33 @@ export async function agentUpdateTaskStatusTrusted(
   // Org-scoped load: a task in another org answers as missing (opaque 404
   // through the tool bridge) — one refusal shape for foreign and garbage ids.
   const task = await loadTaskOrThrow(tx, args.taskId, args.organizationId);
+  // Reaching `in_review` IS the request for review, whichever trusted lane
+  // parked the card: the settle carries its run key; the agent's own
+  // `task_update_status` tool and the workflow `task.update_status` native
+  // carry none, so the key is the task's LIVE run when one exists (the
+  // settle's later park then finds this same row instead of superseding it
+  // with a second bell) and an automation-keyed row otherwise. Idempotent.
   const mintReview = async (): Promise<void> => {
-    if (args.review === undefined || args.status !== 'in_review') return;
+    if (args.status !== 'in_review') return;
     const fresh = await loadTaskOrThrow(tx, args.taskId, args.organizationId);
     if (fresh.status !== 'in_review') return;
-    await requestTaskReview(tx, {
-      task: fresh,
-      trigger: { kind: 'agent_run', runId: args.review.runId },
-    });
+    let trigger: TaskReviewTrigger;
+    if (args.review !== undefined) {
+      trigger = { kind: 'agent_run', runId: args.review.runId };
+    } else {
+      const live = await tx<{ id: string }[]>`
+        SELECT id FROM app.project_agent_runs
+        WHERE task_id = ${args.taskId} AND org_id = ${args.organizationId}
+          AND status IN ('queued', 'running')
+        ORDER BY started_at_ms DESC
+        LIMIT 1
+      `;
+      trigger =
+        live[0] !== undefined
+          ? { kind: 'agent_run', runId: live[0].id }
+          : { kind: 'automation' };
+    }
+    await requestTaskReview(tx, { task: fresh, trigger });
   };
   if (task.status === args.status) {
     await mintReview();
@@ -1521,7 +1608,20 @@ export async function assignTask(
 
   const assignee = normalizeAssignee(args);
   await assertAssigneeValid(tx, { project, auth, assignee });
-  // TODO(agent runs/automations): reject while a live run holds the task.
+  // A live run holds the task for its current worker: transferring it
+  // mid-flight would leave the old agent driving (settle comments, the
+  // in_review park) a card that now shows someone else's name, and "Run
+  // agent" answering already_running for the wrong agent. The bulk bar
+  // applies the same rule as a skip; here the caller asked for one card, so
+  // the refusal names itself — the picker cancels the run first, then
+  // reassigns (its confirmed-handoff flow).
+  if (assigneeChanges(task, assignee) && (await taskHasLiveRun(tx, task))) {
+    throw new TaskError(
+      'TASK_HAS_LIVE_RUN',
+      'A live run holds this task; cancel it before reassigning',
+      409,
+    );
+  }
 
   await tx`
     UPDATE app.tasks SET
@@ -1727,9 +1827,48 @@ export async function restoreTask(
 }
 
 /**
+ * Every blob ref a set of task rows holds — the `fileId` of each
+ * attachment/output element (the `s3:` ref both columns carry, the same
+ * vocabulary `files/access.ts` reads back), de-duplicated in first-seen
+ * order. Malformed elements are skipped: a hard delete must never fail on a
+ * row it is about to remove.
+ */
+export function collectTaskBlobRefs(
+  rows: ReadonlyArray<{ attachments: unknown; outputs: unknown }>,
+): string[] {
+  const refs = new Set<string>();
+  for (const row of rows) {
+    for (const column of [row.attachments, row.outputs]) {
+      if (!Array.isArray(column)) continue;
+      for (const element of column) {
+        if (
+          element !== null &&
+          typeof element === 'object' &&
+          'fileId' in element &&
+          typeof element.fileId === 'string' &&
+          element.fileId !== ''
+        ) {
+          refs.add(element.fileId);
+        }
+      }
+    }
+  }
+  return [...refs];
+}
+
+/**
  * Hard delete — admin-only (0.4 contract). Deletes the WHOLE SUBTREE
  * (subtasks recursively) with each task's discussion thread; returns how
  * many children went with it (the confirm dialog names the count).
+ *
+ * Nothing the subtree owned outlives it: its live runs are cancelled in
+ * this transaction (the agent run through the ledgered cancel door, so the
+ * provenance entry lands before the FK cascade takes the row and the turn
+ * host reaps the exec as an orphan; a bound automation run through its own
+ * terminal door), and its attachment/output blobs are handed to the shared
+ * ref-release seam — the tasks' unbound file rows are trashed here and the
+ * durable `knowledge.release_refs` job deletes the bytes after commit,
+ * keeping any ref another task, document or file row still holds.
  */
 export async function deleteTask(
   tx: TransactionSql,
@@ -1748,22 +1887,57 @@ export async function deleteTask(
       status: TaskStatus;
       archivedAt: number | null;
       discussionThreadId: string | null;
+      attachments: unknown;
+      outputs: unknown;
     }[]
   >`
     WITH RECURSIVE tree AS (
-      SELECT id, status, archived_at_ms, discussion_thread_id, 0 AS depth
+      SELECT id, status, archived_at_ms, discussion_thread_id, attachments,
+             outputs, 0 AS depth
       FROM app.tasks WHERE id = ${taskId}
       UNION ALL
       SELECT t.id, t.status, t.archived_at_ms, t.discussion_thread_id,
-             tree.depth + 1
+             t.attachments, t.outputs, tree.depth + 1
       FROM app.tasks t JOIN tree ON t.parent_task_id = tree.id
       WHERE tree.depth < 32
     )
     SELECT id, status, archived_at_ms::float8 AS "archivedAt",
-           discussion_thread_id AS "discussionThreadId"
+           discussion_thread_id AS "discussionThreadId", attachments, outputs
     FROM tree
   `;
   const ids = tree.map((row) => row.id);
+
+  // Live runs die WITH their tasks, not after them. The agent run's row
+  // would FK-cascade away mid-turn, leaving the sandbox turn executing with
+  // nowhere to land and no provenance entry; cancelling it here writes the
+  // ledger row first, and the turn host's orphan check reaps the exec. A
+  // bound automation run keeps its own terminal contract (audit row,
+  // sessions released).
+  let cancelledRunCount = 0;
+  const liveAgentRuns = await tx<{ id: string; taskId: string }[]>`
+    SELECT id, task_id AS "taskId" FROM app.project_agent_runs
+    WHERE org_id = ${auth.organizationId} AND task_id = ANY(${ids})
+      AND status IN ('queued', 'running')
+  `;
+  for (const run of liveAgentRuns) {
+    const cancelled = await cancelAgentRunInTx(tx, {
+      organizationId: auth.organizationId,
+      runId: run.id,
+      taskId: run.taskId,
+    });
+    if (cancelled) cancelledRunCount += 1;
+  }
+  const liveAutomationRuns = await tx<{ id: string }[]>`
+    SELECT id FROM app.automation_runs
+    WHERE org_id = ${auth.organizationId} AND project_id = ${task.projectId}
+      AND status IN ('queued', 'running', 'waiting')
+      AND input -> 'task' ->> 'id' = ANY(${ids})
+  `;
+  for (const run of liveAutomationRuns) {
+    const outcome = await cancelRunInTx(tx, auth.organizationId, run.id);
+    if (outcome.cancelled) cancelledRunCount += 1;
+  }
+
   for (const row of tree) {
     await applyTaskCountTransition(
       tx,
@@ -1798,11 +1972,54 @@ export async function deleteTask(
       )
   `;
   await tx`DELETE FROM app.tasks WHERE id = ANY(${ids})`;
+
+  // Blob reclaim through the shared release seam. A ref some SURVIVING task
+  // still lists stays (the same deliverable can sit on two cards); for the
+  // rest, the tasks' own unbound file rows are trashed so the release sees
+  // them dead, and the durable job deletes the bytes after commit — network
+  // I/O never runs inside this transaction, and the release re-checks
+  // liveness itself (a document or a chat thread holding the same ref keeps
+  // its bytes). Before this, every deleted task leaked its files for good.
+  const refs = collectTaskBlobRefs(tree);
+  let releasedRefs: string[] = [];
+  if (refs.length > 0) {
+    const orphaned = await tx<{ ref: string }[]>`
+      SELECT r.ref FROM unnest(${refs}::text[]) AS r(ref)
+      WHERE NOT EXISTS (
+        SELECT 1 FROM app.tasks t
+        WHERE t.org_id = ${auth.organizationId}
+          AND (t.outputs @> jsonb_build_array(jsonb_build_object('fileId', r.ref))
+               OR t.attachments
+                  @> jsonb_build_array(jsonb_build_object('fileId', r.ref)))
+      )
+    `;
+    releasedRefs = orphaned.map((row) => row.ref);
+    if (releasedRefs.length > 0) {
+      await tx`
+        UPDATE app.file_metadata SET
+          lifecycle_status = 'trashed', status_changed_at_ms = ${Date.now()}
+        WHERE org_id = ${auth.organizationId}
+          AND storage_ref = ANY(${releasedRefs})
+          AND document_id IS NULL AND thread_id IS NULL
+          AND conversation_id IS NULL
+          AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
+      `;
+      await addJobInTx(tx, 'knowledge.release_refs', {
+        organizationId: auth.organizationId,
+        refs: releasedRefs,
+      });
+    }
+  }
+
   await createAuditLog(
     tx,
     taskAudit(auth, task, TASK_AUDIT_ACTIONS.deleted, {
       previousState: { status: task.status, title: task.title },
-      metadata: { deletedChildCount: ids.length - 1 },
+      metadata: {
+        deletedChildCount: ids.length - 1,
+        cancelledRunCount,
+        releasedBlobRefCount: releasedRefs.length,
+      },
     }),
   );
   // Deletes leave no activity row (the task is gone) — hint explicitly.
@@ -1811,7 +2028,6 @@ export async function deleteTask(
     entity: 'task',
     entityId: taskId,
   });
-  // TODO(storage router): delete attachment/output blobs with the task.
   return { deletedChildCount: ids.length - 1 };
 }
 
@@ -2784,9 +3000,10 @@ export async function bulkUpdateTasks(
     }
     const assigneeChanged =
       (args.clearAssignee === true || assignee !== null) &&
-      task.assigneeId !== (assignee?.assigneeId ?? null);
+      assigneeChanges(task, assignee);
     if (assigneeChanged && (await taskHasLiveRun(tx, task))) {
-      // Same live-run transfer gate as `assignTask`, applied as a skip.
+      // Same live-run transfer gate as `assignTask` (one `assigneeChanges`
+      // rule), applied as a skip.
       skipped += 1;
       continue;
     }
@@ -2842,6 +3059,26 @@ export async function bulkUpdateTasks(
         actorId: auth.userId,
         audit: auth,
       });
+      // Reaching `in_review` IS the request for review from the bulk bar
+      // too — the gate belongs to the STATE, not to the door that moved the
+      // card. Without the mint the cards sat In review with nobody belled
+      // and nothing to respond to. The row reflects this patch's assignee
+      // so the review names the right driver.
+      if (statusAfter === 'in_review') {
+        await requestTaskReview(tx, {
+          task: {
+            ...task,
+            status: 'in_review',
+            ...(assigneeChanged
+              ? {
+                  assigneeType: assignee?.assigneeType ?? null,
+                  assigneeId: assignee?.assigneeId ?? null,
+                }
+              : {}),
+          },
+          trigger: { kind: 'human', actorId: auth.userId },
+        });
+      }
     }
     // An archive/restore riding the same patch moves the rollup bucket
     // once more, from where the status step left the row.

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -14304,6 +14304,577 @@ async function checkCompetences(
   await sql`DELETE FROM app.projects WHERE id = ${projectId}`;
 }
 
+/**
+ * The tasks/collab integrity batch — the user-expectation lens on the task
+ * board: you cannot cancel another task's run through your own task's door;
+ * a card parked at In review (by the bulk bar, an external close, the
+ * agent's tool, or the workflow native) always carries a review gate that a
+ * person can resolve.
+ */
+async function checkTasksCollabIntegrity(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string; userId: string },
+  orgSlug: string,
+): Promise<void> {
+  const { cookie, orgId, userId } = ctx;
+  const post = (route: string, body?: unknown): Promise<Response> =>
+    fetch(`${base}${route}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  const idOf = async (
+    response: Response,
+    key: 'projectId' | 'taskId' | 'agentId',
+  ): Promise<string> => {
+    const parsed = z
+      .object({ [key]: z.string() })
+      .loose()
+      .safeParse(await response.json());
+    const value = parsed.success ? parsed.data[key] : undefined;
+    return typeof value === 'string' ? value : '';
+  };
+  const projectId = await idOf(
+    await post(`/api/app/projects?orgId=${orgId}`, { name: 'Integrity' }),
+    'projectId',
+  );
+  const agentId = await idOf(
+    await post(`/api/app/projects/${projectId}/agents?orgId=${orgId}`, {
+      name: 'Integrity Bot',
+      harness: 'claude-code',
+      model: 'itest-model',
+      skills: [],
+      connectors: [],
+    }),
+    'agentId',
+  );
+  const newTask = async (title: string): Promise<string> =>
+    idOf(
+      await post(`/api/app/tasks?orgId=${orgId}`, { projectId, title }),
+      'taskId',
+    );
+  const seedRun = async (
+    taskId: string,
+    exec: string,
+    status: 'queued' | 'running',
+  ): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.project_agent_runs (
+        org_id, project_id, task_id, agent_id, exec_id, session_id, status,
+        harness, model, started_by, started_at_ms, launched_at_ms,
+        deadline_at_ms, updated_at_ms
+      ) VALUES (
+        ${orgId}, ${projectId}, ${taskId}, ${agentId}, ${exec},
+        ${`pa-${agentId}`}, ${status}, 'claude-code', 'itest-model',
+        ${userId}, ${Date.now()}, ${Date.now()}, ${Date.now() + 3_600_000},
+        ${Date.now()}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const pendingGate = async (
+    taskId: string,
+  ): Promise<{ id: string; metadata: Record<string, unknown> | null }[]> =>
+    sql<{ id: string; metadata: Record<string, unknown> | null }[]>`
+      SELECT id, metadata FROM app.approvals
+      WHERE resource_type = 'task_review' AND resource_id = ${taskId}
+        AND status = 'pending'
+    `;
+
+  // ---- run cancel binds the run to the AUTHORIZED task --------------------
+  // Task A is the door the caller is authorized on; the run belongs to task
+  // B. Cancelling B's run through A's door must be refused (opaque 404) and
+  // leave the run live; B's own door cancels it exactly once.
+  const doorTask = await newTask('Cancel door');
+  const heldTask = await newTask('Held by a run');
+  const foreignRun = await seedRun(
+    heldTask,
+    'exec-integrity-foreign',
+    'running',
+  );
+  const throughOtherDoor = await post(
+    `/api/app/tasks/${doorTask}/agent-runs/${foreignRun}/cancel?orgId=${orgId}`,
+  );
+  const refusal = z
+    .object({ error: z.string() })
+    .loose()
+    .safeParse(await throughOtherDoor.json());
+  const stillLive = await sql<{ status: string }[]>`
+    SELECT status FROM app.project_agent_runs WHERE id = ${foreignRun}
+  `;
+  const ownDoor = z
+    .object({ cancelled: z.boolean() })
+    .safeParse(
+      await (
+        await post(
+          `/api/app/tasks/${heldTask}/agent-runs/${foreignRun}/cancel?orgId=${orgId}`,
+        )
+      ).json(),
+    );
+  const afterOwn = await sql<{ status: string }[]>`
+    SELECT status FROM app.project_agent_runs WHERE id = ${foreignRun}
+  `;
+  const ledger = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.audit_logs
+    WHERE org_id = ${orgId} AND action = 'agent.run_settled'
+      AND resource_id = ${foreignRun}
+  `;
+  record(
+    "tasks/collab: a run cancel is refused through another task's door",
+    throughOtherDoor.status === 404 &&
+      refusal.success &&
+      refusal.data.error === 'AGENT_RUN_NOT_FOUND' &&
+      stillLive[0]?.status === 'running' &&
+      ownDoor.success &&
+      ownDoor.data.cancelled &&
+      afterOwn[0]?.status === 'cancelled' &&
+      ledger[0]?.count === '1',
+    `foreign door → ${throughOtherDoor.status}/${refusal.success ? refusal.data.error : 'ERR'} (want 404/AGENT_RUN_NOT_FOUND), run after=${stillLive[0]?.status} (want running); own door → ${ownDoor.success ? ownDoor.data.cancelled : 'ERR'}, run=${afterOwn[0]?.status}, ledger=${ledger[0]?.count} (want 1)`,
+  );
+
+  // ---- every in_review park mints the review gate --------------------------
+  // The bulk bar: the card reaches In review with a pending gate the creator
+  // (the resolved reviewer) can close — the leave to done records the
+  // approve instead of nothing.
+  const bulkTask = await newTask('Bulk parked');
+  await post(`/api/app/tasks/bulk?orgId=${orgId}`, {
+    taskIds: [bulkTask],
+    status: 'in_review',
+  });
+  const bulkGate = await pendingGate(bulkTask);
+  await post(`/api/app/tasks/${bulkTask}/status?orgId=${orgId}`, {
+    status: 'done',
+  });
+  const bulkClosed = await sql<
+    { status: string; metadata: Record<string, unknown> | null }[]
+  >`
+    SELECT status, metadata FROM app.approvals WHERE id = ${bulkGate[0]?.id ?? ''}
+  `;
+  const bulkDecision =
+    bulkClosed[0]?.metadata !== null &&
+    typeof bulkClosed[0]?.metadata === 'object' &&
+    'response' in bulkClosed[0].metadata &&
+    typeof bulkClosed[0].metadata.response === 'object' &&
+    bulkClosed[0].metadata.response !== null &&
+    'decision' in bulkClosed[0].metadata.response
+      ? String(bulkClosed[0].metadata.response.decision)
+      : 'none';
+  record(
+    'tasks/collab: a bulk move to In review mints the gate the leave resolves',
+    bulkGate.length === 1 &&
+      bulkGate[0]?.metadata?.requestedFor === userId &&
+      bulkClosed[0]?.status === 'completed' &&
+      bulkDecision === 'approve',
+    `gate rows=${bulkGate.length} (want 1) reviewer=${String(bulkGate[0]?.metadata?.requestedFor)} → after done: ${bulkClosed[0]?.status}/${bulkDecision} (want completed/approve)`,
+  );
+
+  // An external close by a non-workflow actor parks the card at In review;
+  // that park carries the gate too.
+  const { upsertTaskByExternalRef } =
+    await import('./domains/tasks/external-ref.ts');
+  const externalArgs = {
+    organizationId: orgId,
+    actorId: userId,
+    projectId,
+    externalSystem: 'itest-gate',
+    externalId: 'GATE-1',
+    title: 'External item',
+    creatorType: 'user' as const,
+    dedupeScope: 'project' as const,
+  };
+  const created = await transactSerializable(sql, (tx) =>
+    upsertTaskByExternalRef(tx, externalArgs),
+  );
+  await transactSerializable(sql, (tx) =>
+    upsertTaskByExternalRef(tx, { ...externalArgs, externalState: 'closed' }),
+  );
+  const externalTask = created.taskId ?? '';
+  const externalStatus = await sql<{ status: string }[]>`
+    SELECT status FROM app.tasks WHERE id = ${externalTask}
+  `;
+  const externalGate = await pendingGate(externalTask);
+  record(
+    'tasks/collab: an external close parks at In review WITH the review gate',
+    created.created &&
+      externalStatus[0]?.status === 'in_review' &&
+      externalGate.length === 1 &&
+      externalGate[0]?.metadata?.requestedFor === userId,
+    `status=${externalStatus[0]?.status} (want in_review), gate rows=${externalGate.length} (want 1), reviewer=${String(externalGate[0]?.metadata?.requestedFor)}`,
+  );
+
+  // The agent's own `task_update_status` tool parks without a run key: the
+  // gate is minted on the task's LIVE run, so the settle's later park (which
+  // names the run) finds the same row instead of superseding it with a
+  // second bell. The workflow native (no live run) mints an automation row.
+  const { agentTurnShimHandlers } =
+    await import('./domains/tasks/agent-turn-shim.ts');
+  const statusDoor =
+    agentTurnShimHandlers(sql)[
+      'tasks/internal_mutations:agentUpdateTaskStatus'
+    ];
+  const toolTask = await newTask('Tool parked');
+  await post(`/api/app/tasks/${toolTask}/assign?orgId=${orgId}`, {
+    assigneeType: 'agent',
+    assigneeId: agentId,
+  });
+  await sql`UPDATE app.tasks SET status = 'in_progress' WHERE id = ${toolTask}`;
+  const toolRun = await seedRun(toolTask, 'exec-integrity-tool', 'running');
+  await statusDoor?.({
+    organizationId: orgId,
+    actorId: agentId,
+    taskId: toolTask,
+    status: 'in_review',
+  });
+  const toolGate = await pendingGate(toolTask);
+  await statusDoor?.({
+    organizationId: orgId,
+    actorId: agentId,
+    taskId: toolTask,
+    status: 'in_review',
+    review: { runId: toolRun },
+  });
+  const toolRows = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.approvals
+    WHERE resource_type = 'task_review' AND resource_id = ${toolTask}
+  `;
+  const workflowTask = await newTask('Workflow parked');
+  await statusDoor?.({
+    organizationId: orgId,
+    actorId: 'workflow',
+    taskId: workflowTask,
+    status: 'in_review',
+  });
+  const workflowGate = await pendingGate(workflowTask);
+  record(
+    'tasks/collab: agent-tool and workflow parks mint the gate (run-keyed, replay-safe)',
+    toolGate.length === 1 &&
+      toolGate[0]?.metadata?.runId === toolRun &&
+      toolRows[0]?.count === '1' &&
+      workflowGate.length === 1 &&
+      workflowGate[0]?.metadata?.runId === undefined &&
+      workflowGate[0]?.metadata?.requestedFor === userId,
+    `tool gate rows=${toolGate.length} runKeyed=${toolGate[0]?.metadata?.runId === toolRun}, after settle replay rows=${toolRows[0]?.count} (want 1); workflow gate rows=${workflowGate.length} runId=${String(workflowGate[0]?.metadata?.runId)} (want none)`,
+  );
+
+  // ---- hard delete: nothing the subtree owned outlives it -------------------
+  // A parent with a live agent run and a bound live automation run, and a
+  // child carrying a deliverable blob. Deleting the parent must cancel both
+  // runs (the agent run through the ledgered door — its provenance entry
+  // survives the FK cascade), and hand the child's blob to the release seam:
+  // the file row is trashed in the delete's transaction and the durable job
+  // deletes the bytes after commit.
+  const { putOrgBlobBytes, registerUploadedBytes } =
+    await import('./domains/files/service.ts');
+  const { s3BlobSize } = await import('./core/lib/storage/blob_access.ts');
+  const parentTask = await newTask('Delete me');
+  const childTask = await idOf(
+    await post(`/api/app/tasks?orgId=${orgId}`, {
+      projectId,
+      title: 'Child deliverable',
+      parentTaskId: parentTask,
+    }),
+    'taskId',
+  );
+  await post(`/api/app/tasks/${parentTask}/assign?orgId=${orgId}`, {
+    assigneeType: 'agent',
+    assigneeId: agentId,
+  });
+  await sql`
+    UPDATE app.tasks SET status = 'in_progress' WHERE id = ${parentTask}
+  `;
+  const doomedRun = await seedRun(
+    parentTask,
+    'exec-integrity-doomed',
+    'running',
+  );
+  const doomedAutomation = await sql<{ id: string }[]>`
+    INSERT INTO app.automation_runs (
+      org_id, name, version, project_id, status, mode, started_by, input,
+      checkpoints, claim_epoch, started_at_ms
+    ) VALUES (
+      ${orgId}, 'itest-delete-flow', 1, ${projectId}, 'running', 'live',
+      ${userId}, ${sql.json({ task: { id: parentTask } })},
+      ${sql.json({ nodes: {}, executions: 0 })}, 0, ${Date.now()}
+    ) RETURNING id
+  `;
+  const doomedAutomationId = doomedAutomation[0]?.id ?? '';
+  const blobLane = process.env.ITEST_S3_ENDPOINT !== undefined;
+  let deliverableRef = '';
+  let blobBefore: number | null = null;
+  if (blobLane) {
+    const bytes = new TextEncoder().encode('deliverable bytes');
+    deliverableRef = await putOrgBlobBytes(sql, orgId, {
+      bytes,
+      contentType: 'text/plain',
+    });
+    await registerUploadedBytes(sql, {
+      organizationId: orgId,
+      storageRef: deliverableRef,
+      fileName: 'deliverable.txt',
+      contentType: 'text/plain',
+      size: bytes.byteLength,
+      source: 'task_output',
+      skipRagIndexing: true,
+    });
+    await sql`
+      UPDATE app.tasks SET outputs = ${sql.json([
+        {
+          fileId: deliverableRef,
+          fileName: 'deliverable.txt',
+          fileType: 'text/plain',
+          fileSize: bytes.byteLength,
+        },
+      ])}
+      WHERE id = ${childTask}
+    `;
+    blobBefore = await s3BlobSize(orgSlug, deliverableRef);
+  }
+  const deletion = await fetch(
+    `${base}/api/app/tasks/${parentTask}?orgId=${orgId}`,
+    { method: 'DELETE', headers: { cookie, origin: base } },
+  );
+  const deletionBody = z
+    .object({ deletedChildCount: z.number() })
+    .loose()
+    .safeParse(await deletion.json());
+  const rowsLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.tasks
+    WHERE id IN (${parentTask}, ${childTask})
+  `;
+  const doomedLedger = await sql<
+    { metadata: Record<string, unknown> | null }[]
+  >`
+    SELECT metadata FROM app.audit_logs
+    WHERE org_id = ${orgId} AND action = 'agent.run_settled'
+      AND resource_id = ${doomedRun}
+  `;
+  const automationAfter = await sql<{ status: string }[]>`
+    SELECT status FROM app.automation_runs WHERE id = ${doomedAutomationId}
+  `;
+  let blobGone = !blobLane;
+  let fileRowDead = !blobLane;
+  if (blobLane) {
+    // The release job runs on the harness worker after the delete commits.
+    blobGone = await waitFor(
+      async () => (await s3BlobSize(orgSlug, deliverableRef)) === null,
+      30_000,
+    );
+    const fileRows = await sql<{ lifecycleStatus: string | null }[]>`
+      SELECT lifecycle_status AS "lifecycleStatus" FROM app.file_metadata
+      WHERE org_id = ${orgId} AND storage_ref = ${deliverableRef}
+    `;
+    // Reaped by the release (bytes gone — no rows) or, at minimum, trashed
+    // by the delete — never left as a live row pointing at leaked bytes.
+    fileRowDead = fileRows.every((row) => row.lifecycleStatus === 'trashed');
+  }
+  record(
+    `tasks/collab: hard delete stops the subtree's live runs and reclaims its blobs${blobLane ? '' : ' (blob lane SKIPPED: no ITEST_S3_ENDPOINT)'}`,
+    deletion.ok &&
+      deletionBody.success &&
+      deletionBody.data.deletedChildCount === 1 &&
+      rowsLeft[0]?.count === '0' &&
+      doomedLedger.length === 1 &&
+      doomedLedger[0]?.metadata?.finalStatus === 'cancelled' &&
+      automationAfter[0]?.status === 'cancelled' &&
+      (!blobLane || blobBefore !== null) &&
+      blobGone &&
+      fileRowDead,
+    `delete → ${deletion.status} children=${deletionBody.success ? deletionBody.data.deletedChildCount : 'ERR'} rowsLeft=${rowsLeft[0]?.count} (want 0); agent run ledger=${doomedLedger.length}/${String(doomedLedger[0]?.metadata?.finalStatus)} (want 1/cancelled); automation run=${automationAfter[0]?.status} (want cancelled); blob before=${String(blobBefore)} gone=${blobGone} fileRowDead=${fileRowDead}`,
+  );
+
+  // ---- designating a reviewer tells them -----------------------------------
+  // The designee is subscribed (reason 'reviewer') and gets the heads-up
+  // bell on the wire entity the app keys the bell on; designating yourself
+  // rings nothing, and a non-member cannot be put on the hook at all.
+  const reviewer = 'integrity-reviewer-1';
+  await sql`
+    INSERT INTO "user" ("id", "name", "email", "emailVerified", "createdAt",
+                        "updatedAt")
+    VALUES (${reviewer}, 'Integrity Reviewer', ${`${reviewer}@example.com`},
+            true, ${new Date()}, ${new Date()})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role", "createdAt")
+    VALUES (${`m-${reviewer}`}, ${orgId}, ${reviewer}, 'member', ${new Date()})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+  const reviewedTask = await newTask('Needs a reviewer');
+  const designated = await post(
+    `/api/app/tasks/${reviewedTask}?orgId=${orgId}`,
+    {
+      reviewerUserId: reviewer,
+    },
+  );
+  const reviewerBell = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.user_notifications
+    WHERE org_id = ${orgId} AND user_id = ${reviewer}
+      AND type = 'task_reviewer_assigned' AND task_id = ${reviewedTask}
+  `;
+  const reviewerFollows = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.task_subscriptions
+    WHERE task_id = ${reviewedTask} AND subscriber_id = ${reviewer}
+      AND reason = 'reviewer'
+  `;
+  const reviewerHint = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app_realtime.outbox
+    WHERE org_id = ${orgId} AND user_id = ${reviewer}
+      AND entity = 'notification'
+  `;
+  const selfTask = await newTask('Self reviewed');
+  await post(`/api/app/tasks/${selfTask}?orgId=${orgId}`, {
+    reviewerUserId: userId,
+  });
+  const selfBell = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.user_notifications
+    WHERE org_id = ${orgId} AND user_id = ${userId}
+      AND type = 'task_reviewer_assigned' AND task_id = ${selfTask}
+  `;
+  const bogus = await post(`/api/app/tasks/${reviewedTask}?orgId=${orgId}`, {
+    reviewerUserId: 'nobody-here',
+  });
+  const bogusBody = z
+    .object({ error: z.string() })
+    .loose()
+    .safeParse(await bogus.json());
+  record(
+    'tasks/collab: designating a reviewer subscribes and bells them (never yourself, never a non-member)',
+    designated.ok &&
+      reviewerBell[0]?.count === '1' &&
+      reviewerFollows[0]?.count === '1' &&
+      Number(reviewerHint[0]?.count ?? '0') >= 1 &&
+      selfBell[0]?.count === '0' &&
+      bogus.status === 400 &&
+      bogusBody.success &&
+      bogusBody.data.error === 'TASK_REVIEWER_INVALID',
+    `designate → ${designated.status}, bell=${reviewerBell[0]?.count} (want 1), follows=${reviewerFollows[0]?.count} (want 1), hint=${reviewerHint[0]?.count} (want ≥1); self bell=${selfBell[0]?.count} (want 0); non-member → ${bogus.status}/${bogusBody.success ? bogusBody.data.error : 'ERR'} (want 400/TASK_REVIEWER_INVALID)`,
+  );
+  // ---- a mention directory that cannot be listed fails the surface -------
+  // Against the real schema: the same resolution with the agent-instance
+  // leg failing rejects (MENTION_DIRECTORY_UNAVAILABLE, 503) instead of
+  // answering a partial directory that turns `@teammate` into plain text;
+  // the healthy resolution still names the teammate.
+  const { MentionDirectoryError, resolveSurfaceMentions } =
+    await import('./domains/collab/mention-directory.ts');
+  const instanceLegDown = Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]): unknown => {
+      if (strings.join('').includes('app.project_agents')) {
+        throw new Error('itest: instance listing down');
+      }
+      // Every other statement reaches the real handle unchanged.
+      const forwarded: unknown = Reflect.apply(sql, undefined, [
+        strings,
+        ...values,
+      ]);
+      return forwarded;
+    },
+    { json: sql.json.bind(sql), unsafe: sql.unsafe.bind(sql) },
+  );
+  const degraded: unknown = await resolveSurfaceMentions(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a tag + json/unsafe stand-in over the real handle
+    instanceLegDown as unknown as Sql,
+    { organizationId: orgId, body: `@${reviewer} please look`, projectId },
+  ).then(
+    () => 'resolved',
+    (error: unknown) => error,
+  );
+  const healthy = await resolveSurfaceMentions(sql, {
+    organizationId: orgId,
+    body: `@${reviewer} please look`,
+    projectId,
+  });
+  // Typed against the module's export so the probe stays a plain FAIL (not
+  // a crash) on a tree that has no `MentionDirectoryError` yet.
+  const degradedError =
+    typeof MentionDirectoryError === 'function' &&
+    degraded instanceof MentionDirectoryError
+      ? degraded
+      : null;
+  record(
+    'tasks/collab: a mention directory that cannot be listed fails loudly, never silently degrades',
+    degradedError !== null &&
+      degradedError.code === 'MENTION_DIRECTORY_UNAVAILABLE' &&
+      degradedError.status === 503 &&
+      degradedError.leg === 'agents' &&
+      healthy.mentions.some(
+        (mention) => mention.type === 'user' && mention.id === reviewer,
+      ),
+    `degraded → ${degradedError !== null ? `${degradedError.code}/${degradedError.status}/${degradedError.leg}` : String(degraded)} (want MENTION_DIRECTORY_UNAVAILABLE/503/agents); healthy mentions=${healthy.mentions.map((m) => `${m.type}:${m.id}`).join(',') || 'none'}`,
+  );
+
+  // ---- "waiting on me" never misses my reviews ----------------------------
+  // 120 pending reviews for OTHER people land first; the caller's own review
+  // is minted last. The old org-wide unordered LIMIT 100 scan filtered the
+  // reviewer in JS and dropped it; the summary must name the task and count
+  // the caller's pending reviews exactly, org-wide and project-scoped.
+  const busyTask = await newTask('Everyone else is busy');
+  const mineTask = await newTask('Waiting on me');
+  for (let i = 0; i < 120; i += 1) {
+    await sql`
+      INSERT INTO app.approvals (
+        org_id, status, resource_type, resource_id, priority, metadata,
+        created_at_ms
+      ) VALUES (
+        ${orgId}, 'pending', 'task_review', ${busyTask}, 'medium',
+        ${sql.json({ requestedFor: `busy-reviewer-${i}`, taskId: busyTask })},
+        ${Date.now()}
+      )
+    `;
+  }
+  await sql`
+    INSERT INTO app.approvals (
+      org_id, status, resource_type, resource_id, priority, metadata,
+      created_at_ms
+    ) VALUES (
+      ${orgId}, 'pending', 'task_review', ${mineTask}, 'medium',
+      ${sql.json({ requestedFor: userId, taskId: mineTask, projectId })},
+      ${Date.now()}
+    )
+  `;
+  const minePending = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.approvals
+    WHERE org_id = ${orgId} AND status = 'pending'
+      AND resource_type = 'task_review'
+      AND metadata ->> 'requestedFor' = ${userId}
+  `;
+  const attentionSchema = z
+    .object({
+      waitingOnMeTaskIds: z.array(z.string()),
+      pendingReviewCount: z.number(),
+    })
+    .loose();
+  const attention = attentionSchema.safeParse(
+    await (
+      await fetch(`${base}/api/app/collab/attention?orgId=${orgId}`, {
+        headers: { cookie },
+      })
+    ).json(),
+  );
+  const attentionScoped = attentionSchema.safeParse(
+    await (
+      await fetch(
+        `${base}/api/app/collab/attention?orgId=${orgId}&projectId=${projectId}`,
+        { headers: { cookie } },
+      )
+    ).json(),
+  );
+  record(
+    'tasks/collab: the attention summary finds my review behind 120 other pending ones',
+    attention.success &&
+      attention.data.waitingOnMeTaskIds.includes(mineTask) &&
+      attention.data.pendingReviewCount === Number(minePending[0]?.count) &&
+      attentionScoped.success &&
+      attentionScoped.data.waitingOnMeTaskIds.includes(mineTask),
+    `org-wide: mine listed=${attention.success ? attention.data.waitingOnMeTaskIds.includes(mineTask) : 'ERR'} count=${attention.success ? attention.data.pendingReviewCount : 'ERR'} (want ${minePending[0]?.count}); scoped: mine listed=${attentionScoped.success ? attentionScoped.data.waitingOnMeTaskIds.includes(mineTask) : 'ERR'}`,
+  );
+  await sql`
+    DELETE FROM app.approvals
+    WHERE org_id = ${orgId} AND resource_id IN (${busyTask}, ${mineTask})
+  `;
+  await sql`DELETE FROM "member" WHERE "id" = ${`m-${reviewer}`}`;
+}
+
 async function checkCollabMentions(
   sql: Sql,
   base: string,
@@ -35915,6 +36486,12 @@ async function main(): Promise<void> {
     await checkAnsweredAskRecovery(sql, authCtx);
     await checkAutoRetryAndKickPlan(sql, baseUrl, authCtx);
     await checkReviewArc(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
+    await checkTasksCollabIntegrity(
+      sql,
+      baseUrl,
+      authCtx,
+      `itest-${orgSuffix}`,
+    );
     await checkSandboxSessions(sql, authCtx);
     await checkAutomationRunToolLane(sql, baseUrl, authCtx);
     await checkSandboxSpawner(sql, baseUrl, authCtx);

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6722,6 +6722,9 @@ tasks:
     handoffConfirmLiveRun:
       '{name} arbeitet gerade an dieser Aufgabe — die Neuzuweisung bricht
       den laufenden Lauf zuerst ab.'
+    liveRunGuard:
+      Diese Aufgabe hat gerade einen laufenden Lauf — brich ihn ab, bevor du
+      sie neu zuweist.
     handoffConfirmAction: Neu zuweisen
     unassign: Zuweisung aufheben
     you: Du

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6792,6 +6792,7 @@ tasks:
     handoffConfirmLiveRun:
       '{name} is working this task right now — reassigning cancels the live
       run first.'
+    liveRunGuard: This task has a live run — cancel it before reassigning.
     handoffConfirmAction: Reassign
     unassign: Unassign
     you: You

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6840,6 +6840,7 @@ tasks:
     handoffConfirmLiveRun:
       "{name} travaille sur cette tâche en ce moment — la réassignation
       annule d'abord l'exécution en cours."
+    liveRunGuard: Cette tâche a une exécution en cours — annule-la avant de réassigner.
     handoffConfirmAction: Réassigner
     unassign: Désassigner
     you: Vous


### PR DESCRIPTION
Seven verified medium findings in the task board's authorization, delete, review-gate and notification seams, from the backend deep-review campaign (`/tmp/tale-review/triage/mediums.md`, modules `tasks` + `collab`). Base `899fcc08a` (has #3130 / #3157 / #3158 / #3164); every finding was re-verified live on that base before the fix. One commit per seam.

## Per-finding outcome

| #   | Finding                                                                                                     | Outcome                 | Evidence                                                                                                                                                                                                                                                                                                                      |
| --- | ----------------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Run-cancel route never checks the run belongs to the authorized task (`tasks/routes.ts` cancel by `:runId`) | **fixed** — `b97e14b74` | Route resolves the run and answers the opaque 404 `AGENT_RUN_NOT_FOUND` when it is not this task's; `cancelAgentRunInTx` binds `task_id` inside the UPDATE predicate (no unbound cancel door left).                                                                                                                           |
| 2   | Task hard delete orphans attachment/output blobs and live runs (`deleteTask` TODO)                          | **fixed** — `954214d2e` | Subtree's live agent runs cancelled through the ledgered in-tx door before the FK cascade, bound automation runs through `cancelRunInTx`; the tasks' unbound `file_metadata` rows are trashed for refs no surviving task lists and the durable `knowledge.release_refs` job (#3140 seam) deletes the bytes after commit.      |
| 3   | Single-card reassign ignores live runs while bulk enforces the gate                                         | **fixed** — `0cb174b4e` | One pure `assigneeChanges` rule for `assignTask` and `bulkUpdateTasks`; the single door refuses `TASK_HAS_LIVE_RUN` (409), bulk keeps skipping; every picker names the refusal (en/de/fr). The comment-mention dispatcher only reaches `assignTask` with no live run (steer lane returns first), so it is unaffected.         |
| 4   | Bulk moves and external closes park tasks `in_review` without minting the review gate                       | **fixed** — `ea58c2fa3` | `requestTaskReview` now runs from the bulk bar, the non-workflow external close, and `agentUpdateTaskStatusTrusted` (the agent's `task_update_status` tool + the workflow native, which also parked without a gate). Lanes without a run key mint on the task's live run so the settle replay finds the same row; idempotent. |
| 5   | Reviewer-designation heads-up notification never fires in 0.5                                               | **fixed** — `67501dd96` | Live `notifyTaskReviewerAssigned` in `collab/service.ts` (bell only, pref gate skipped like the request, never for yourself) on the `notification` hint entity from #3164; `updateTask` subscribes the designee (reason `reviewer`) and refuses a non-member (`TASK_REVIEWER_INVALID`).                                       |
| 6   | Mention directory swallows listing failures — @mentions silently become plain text                          | **fixed** — `6bfb0f7a2` | Each leg throws `MentionDirectoryError`; the task-comment door answers 503 `MENTION_DIRECTORY_UNAVAILABLE` instead of posting a comment that notified nobody.                                                                                                                                                                 |
| 7   | Attention summary drops reviews when org has >100 pending approvals (both duplicate records)                | **fixed** — `edd19cb38` | `requestedFor` + project scope filtered in SQL before the cap, `ORDER BY seq DESC`, exact total via window count; unread counts from a `GROUP BY` aggregate instead of a capped page (badge now exact rather than capped at 100).                                                                                             |

No migration needed (0070/0071 untouched): the pending-review filter rides `approvals_org_status`, and pending reviews are rare org-wide.

## Tests (red on base, green on branch)

Colocated vitest, each observed failing before its fix:

- `tasks/agent-runs.test.ts` — the cancel binds `task_id` in the guard; a refused cancel writes no ledger entry (2, red: no `cancelAgentRunInTx`).
- `tasks/service.test.ts` — `assigneeChanges` transfer rule + the 409 refusal (4).
- `tasks/service.blobs.test.ts` — `collectTaskBlobRefs` across a subtree, de-dup, malformed rows (3, red: no export).
- `collab/service.test.ts` — `notifyTaskReviewerAssigned` writes the row + bell hint with no pref gate, skips self (2, red); attention summary filters `requestedFor` in SQL, exact counts (2, red on the JS filter).
- `collab/mention-directory.test.ts` — a failed member/automation listing rejects (2, red: "promise resolved instead of rejecting"), healthy directory still resolves.

Integration (`backend/integration-check.ts`, new `checkTasksCollabIntegrity`, 8 probes): foreign-door cancel refused 404 + own door cancels once with one ledger row; bulk → In review mints the gate the leave-to-done resolves (`completed/approve`); external close parks WITH the gate; agent-tool park run-keyed + settle replay finds it (1 row), workflow park mints an automation row; hard delete → children gone, agent run ledgered `cancelled`, automation run `cancelled`, deliverable blob gone from MinIO via the release job, file row reaped; reviewer designation → bell + subscription + `notification` hint, self silent, non-member 400; mention directory leg down → `MENTION_DIRECTORY_UNAVAILABLE/503/agents`; the caller's review found behind 120 other pending reviews with the exact count, org-wide and project-scoped.

## Verification (observed)

- `bunx tsc --noEmit` (platform): clean after every seam.
- `bun run --filter @tale/platform lint`: exit 0.
- `bunx vitest --run --project server --project pii`: 72,736 tests pass; 3 `app/routes/*.test.tsx` files fail to LOAD with `Denied ID …@fontsource/inter…woff2?url` — the known worktree + symlinked `node_modules` symptom, also on base, unrelated.
- `backend:integration` on fresh throwaway tale-db + MinIO (`SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD` set), branch: **387/387 checks passed**, all 8 new probes PASS.
- Same suite with the branch probes over the BASE sources (fresh containers): **379/387** — every pre-existing check green, exactly the 8 new probes red with the defect signatures (foreign-door cancel answered 200 and killed the other task's run; 0 gate rows on bulk / external / tool / workflow parks; hard delete left the automation run running and the blob + live file row behind with no ledger entry; no reviewer bell/subscription and a non-member accepted; degraded directory "resolved"; the caller's review missing behind the 120 others).

## Cross-class discoveries (not fixed here)

- `core/collab/notify_task_reviews.ts` and most of `core/tasks/review_shared.ts` are dead Convex-shim code still compiled by the platform tsconfig; only `REVIEW_POLICY_REFUSAL_CODES` is live. Cleanup candidate.
- The `/api/app/collab/attention` summary has no caller under `app/` that I could find; its unread counts are now exact instead of capped at 100 — worth confirming the badge consumer (if any) renders large counts.
- `TaskError` now admits status 409 (previously 400|403|404).
