### PR TITLE
fix(platform): audit successful 2FA and passkey lifecycle events

### DIFF
--- a/services/platform/backend/auth/auth.ts
+++ b/services/platform/backend/auth/auth.ts
@@ -29,8 +29,10 @@ import {
   evaluateTwoFactorEnforcement,
   getTwoFactorLockState,
   recordTwoFactorFailure,
+  recordTwoFactorLifecycleEvent,
   recordTwoFactorSuccess,
   setGraceUntilIfAbsent,
+  type TwoFactorLifecycleAction,
 } from '../domains/two_factor/service.ts';
 import { addJobInTx } from '../jobs/enqueue.ts';
 import { readGovernancePolicy } from '../lib/org-config.ts';
@@ -62,6 +64,32 @@ export interface AuthConfig {
 }
 
 const SIGN_IN_EMAIL_PATH = '/sign-in/email';
+
+/**
+ * The second-factor LIFECYCLE endpoints. Every one of them audits on success
+ * — the 0.4 posture (#1508), carried by the deleted `two_factor/auth_hooks.ts`
+ * whose lockout half this file already re-implements. These are
+ * account-takeover-relevant: an attacker who registers their own passkey and
+ * turns TOTP off must not be able to do it without leaving a trail.
+ */
+const TWO_FACTOR_ENABLE_PATH = '/two-factor/enable';
+const TWO_FACTOR_DISABLE_PATH = '/two-factor/disable';
+const TWO_FACTOR_BACKUP_CODES_PATH = '/two-factor/generate-backup-codes';
+const PASSKEY_REGISTER_PATH = '/passkey/verify-registration';
+const PASSKEY_DELETE_PATH = '/passkey/delete-passkey';
+const PASSKEY_AUTHENTICATE_PATH = '/passkey/verify-authentication';
+
+/** The user on a Better Auth middleware session payload (`context.session`
+ * or the freshly issued `context.newSession`), or null. */
+function sessionPayloadUser(
+  payload: unknown,
+): { id: string; email?: string } | null {
+  if (!isRecord(payload)) return null;
+  const user = payload.user;
+  if (!isRecord(user) || typeof user.id !== 'string') return null;
+  const email = typeof user.email === 'string' ? user.email : undefined;
+  return { id: user.id, ...(email !== undefined ? { email } : {}) };
+}
 
 // Random delay (ms) added to lockout responses to fuzz the timing channel
 // between "wrong password" (bcrypt, ~100ms) and "locked" (a single read).
@@ -180,6 +208,73 @@ export function createAuth(config: AuthConfig) {
       console.warn('[two-factor] user resolution failed:', error);
       return null;
     }
+  };
+
+  /**
+   * The successful second-factor lifecycle event on this request, or null.
+   * Success detection is 0.4's, endpoint by endpoint: `/two-factor/enable`
+   * only answers `{ totpURI, backupCodes }` when it worked and regeneration
+   * only answers `{ backupCodes }`, while disable / passkey add / remove park
+   * an `APIError` on `context.returned` when they fail. Passkey sign-in is
+   * read off the freshly issued session, exactly like `login_success` on the
+   * password path — a passkey FAILURE is challenge-based and attributable to
+   * no user, so there is nothing to log.
+   */
+  const resolveTwoFactorLifecycle = (
+    // oxlint-disable-next-line typescript/no-explicit-any -- better-auth middleware generics are unstable across minors
+    mw: any,
+  ): {
+    userId: string;
+    action: TwoFactorLifecycleAction;
+    email?: string;
+    metadata?: Record<string, unknown>;
+  } | null => {
+    const returned: unknown = mw.context.returned;
+    if (returned instanceof APIError) return null;
+
+    if (mw.path === PASSKEY_AUTHENTICATE_PATH) {
+      const signedIn = sessionPayloadUser(mw.context.newSession);
+      if (signedIn === null) return null;
+      return {
+        userId: signedIn.id,
+        action: 'passkey_sign_in',
+        ...(signedIn.email !== undefined ? { email: signedIn.email } : {}),
+      };
+    }
+
+    // Every remaining endpoint requires an active session, so the actor is
+    // the caller themselves; without one there is nothing to attribute.
+    const actor = sessionPayloadUser(mw.context.session);
+    if (actor === null) return null;
+    const base = {
+      userId: actor.id,
+      ...(actor.email !== undefined ? { email: actor.email } : {}),
+    };
+
+    if (mw.path === TWO_FACTOR_ENABLE_PATH) {
+      return isRecord(returned) && 'totpURI' in returned
+        ? { ...base, action: '2fa_enrolled' }
+        : null;
+    }
+    if (mw.path === TWO_FACTOR_BACKUP_CODES_PATH) {
+      return isRecord(returned) && 'backupCodes' in returned
+        ? {
+            ...base,
+            action: '2fa_enrolled',
+            metadata: { backupCodesRegenerated: true },
+          }
+        : null;
+    }
+    if (mw.path === TWO_FACTOR_DISABLE_PATH) {
+      return { ...base, action: '2fa_disabled' };
+    }
+    if (mw.path === PASSKEY_REGISTER_PATH) {
+      return { ...base, action: 'passkey_added' };
+    }
+    if (mw.path === PASSKEY_DELETE_PATH) {
+      return { ...base, action: 'passkey_removed' };
+    }
+    return null;
   };
 
   return betterAuth({
@@ -395,6 +490,34 @@ export function createAuth(config: AuthConfig) {
             } else {
               await recordTwoFactorSuccess(sql, userId);
             }
+          }
+        }
+
+        // Second-factor lifecycle audit: 2FA enable / disable / backup-code
+        // regeneration and passkey add / remove / sign-in. Non-fatal — the
+        // state change already happened inside Better Auth's own adapter, so
+        // refusing the response here would leave the user with a passkey
+        // registered and an error on screen. A failed write is LOUD instead.
+        const lifecycle = resolveTwoFactorLifecycle(mw);
+        if (lifecycle !== null) {
+          try {
+            await recordTwoFactorLifecycleEvent(sql, {
+              userId: lifecycle.userId,
+              action: lifecycle.action,
+              ...(lifecycle.email !== undefined
+                ? { actorEmail: lifecycle.email }
+                : {}),
+              ...(ip !== undefined ? { ip } : {}),
+              ...(userAgent !== undefined ? { userAgent } : {}),
+              ...(lifecycle.metadata !== undefined
+                ? { metadata: lifecycle.metadata }
+                : {}),
+            });
+          } catch (error) {
+            console.error(
+              `[two-factor] failed to write the ${lifecycle.action} audit row`,
+              error instanceof Error ? error.message : error,
+            );
           }
         }
 

--- a/services/platform/backend/domains/two_factor/service.ts
+++ b/services/platform/backend/domains/two_factor/service.ts
@@ -1,8 +1,13 @@
+import { transactSerializable } from '@tale/shared/db/serializable';
 import { symmetricDecrypt } from 'better-auth/crypto';
 import type { Sql, TransactionSql } from 'postgres';
 
 import { DEFAULT_TWO_FACTOR_POLICY } from '../../../lib/shared/schemas/governance.ts';
 import { mergeStrictestTwoFactorPolicy } from '../../core/governance/helpers.ts';
+import {
+  splitEmailForAudit,
+  splitIpForAudit,
+} from '../../core/lib/helpers/pii_hash.ts';
 import {
   computeLockedUntil,
   DEFAULT_LOGIN_POLICY,
@@ -123,6 +128,75 @@ export async function recordTwoFactorSuccess(
   userId: string,
 ): Promise<void> {
   await sql`DELETE FROM app.two_factor_attempts WHERE user_id = ${userId}`;
+}
+
+/**
+ * The second-factor lifecycle events. Action names are the 0.4 ones verbatim
+ * (`two_factor/internal_mutations.ts` → `logEnrollmentEvent`) — a rename
+ * would silently break any saved audit query or export that groups on them.
+ */
+export type TwoFactorLifecycleAction =
+  | '2fa_enrolled'
+  | '2fa_disabled'
+  | 'passkey_added'
+  | 'passkey_removed'
+  | 'passkey_sign_in';
+
+/**
+ * Audit a SUCCESSFUL 2FA / passkey lifecycle event (#1508 in 0.4). These are
+ * the account-takeover-relevant ones: an attacker who adds a passkey and
+ * disables TOTP must not be able to do it without leaving a trail. The
+ * failure side is `recordTwoFactorFailure` above — on 0.5 that was the only
+ * half that survived the port, because the 0.4 hook file carrying these
+ * calls was deleted with the Convex tree.
+ *
+ * Org-scoped like every other security event: one row per org the user
+ * belongs to, PII split into plaintext + peppered hash by the reused
+ * helpers, all inside ONE serializable transaction so a user in several orgs
+ * gets all their rows or none.
+ */
+export async function recordTwoFactorLifecycleEvent(
+  sql: Sql,
+  args: {
+    userId: string;
+    action: TwoFactorLifecycleAction;
+    actorEmail?: string;
+    ip?: string;
+    userAgent?: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<void> {
+  const emailParts =
+    args.actorEmail !== undefined
+      ? await splitEmailForAudit(args.actorEmail)
+      : {};
+  const ipParts = args.ip !== undefined ? await splitIpForAudit(args.ip) : {};
+  await transactSerializable(sql, async (tx) => {
+    for (const organizationId of await userOrgIds(tx, args.userId)) {
+      await createAuditLog(tx, {
+        organizationId,
+        actorId: args.userId,
+        ...(emailParts.plaintext !== undefined
+          ? { actorEmail: emailParts.plaintext }
+          : {}),
+        ...(emailParts.hash !== undefined
+          ? { actorEmailHash: emailParts.hash }
+          : {}),
+        actorType: 'user',
+        action: args.action,
+        category: 'security',
+        resourceType: 'twoFactorAuth',
+        resourceId: args.userId,
+        ...(ipParts.plaintext !== undefined
+          ? { ipAddress: ipParts.plaintext }
+          : {}),
+        ...(ipParts.hash !== undefined ? { actorIpHash: ipParts.hash } : {}),
+        ...(args.userAgent !== undefined ? { userAgent: args.userAgent } : {}),
+        status: 'success',
+        ...(args.metadata !== undefined ? { metadata: args.metadata } : {}),
+      });
+    }
+  });
 }
 
 export interface TwoFactorEnforcement {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -30967,7 +30967,7 @@ async function checkTwoFactor(
   orgSlug: string,
   email: string,
 ): Promise<void> {
-  const { cookie, userId } = ctx;
+  const { cookie, orgId, userId } = ctx;
   const configRoot = process.env.TALE_CONFIG_DIR ?? '';
   const governanceDir = path.join(configRoot, orgSlug, 'governance');
   await mkdir(governanceDir, { recursive: true });
@@ -31006,6 +31006,142 @@ async function checkTwoFactor(
     'two-factor: blocked session denied on org routes, enrolment reachable',
     blockedOrgRoute.status === 403 && enrolmentReachable.status === 200,
     `org-route=${blockedOrgRoute.status} (want 403), enrol-status=${enrolmentReachable.status} (want 200)`,
+  );
+
+  // --- Lifecycle audit: enable / regenerate / disable, and the passkey trio
+  // 0.4 audited every SUCCESSFUL second-factor lifecycle event (#1508); the
+  // port kept only the failure half, so an attacker who registered their own
+  // passkey and turned TOTP off left no trace at all. Action names are 0.4's
+  // verbatim — a rename would break any saved query grouping on them.
+  // A DEDICATED user, not the harness's own. This block enables 2FA,
+  // regenerates backup codes, disables it, and registers and removes a
+  // passkey — so running it on the shared session leaves that user's
+  // second-factor state changed and invalidates their session. Five later
+  // checks failed that way before this was split out: the 2FA grace check,
+  // and four chat checks that need a live session.
+  const lifecycleSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `itest-2fa-lifecycle-${Date.now()}@example.com`,
+      password: 'itest-password-1',
+      name: 'Lifecycle',
+    }),
+  });
+  const lifecycleCookie = cookieHeaderFrom(lifecycleSignUp);
+  const lifecycleUser = z
+    .object({ user: z.object({ id: z.string() }) })
+    .loose()
+    .safeParse(await lifecycleSignUp.json());
+  const lifecycleUserId = lifecycleUser.success
+    ? lifecycleUser.data.user.id
+    : '';
+  // Audit rows are org-scoped, so the lifecycle user needs a membership or
+  // their events have no org to land under and the trail reads empty.
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${`m-2fa-${lifecycleUserId}`}, ${orgId}, ${lifecycleUserId},
+            'member', ${new Date()})
+    ON CONFLICT ("id") DO NOTHING
+  `;
+  const authPost = (route: string, body: unknown): Promise<Response> =>
+    fetch(`${base}/api/auth${route}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        cookie: lifecycleCookie,
+        origin: base,
+      },
+      body: JSON.stringify(body),
+    });
+  const lifecycleActions = async (): Promise<string[]> => {
+    const rows = await sql<{ action: string }[]>`
+      SELECT action FROM app.audit_logs
+      WHERE org_id = ${ctx.orgId} AND resource_type = 'twoFactorAuth'
+        AND resource_id = ${lifecycleUserId}
+      ORDER BY ts ASC
+    `;
+    return rows.map((row) => row.action);
+  };
+  const before2fa = await lifecycleActions();
+  const enableRes = await authPost('/two-factor/enable', {
+    password: 'itest-password-1',
+  });
+  const afterEnable = await lifecycleActions();
+  const regenRes = await authPost('/two-factor/generate-backup-codes', {
+    password: 'itest-password-1',
+  });
+  const afterRegen = await lifecycleActions();
+  const disableRes = await authPost('/two-factor/disable', {
+    password: 'itest-password-1',
+  });
+  const afterDisable = await lifecycleActions();
+  // Backup-code regeneration audits as a `2fa_enrolled` carrying the 0.4
+  // `backupCodesRegenerated` stamp. The endpoint needs a COMPLETED TOTP
+  // enrolment (a verified code), which a script cannot produce — so the
+  // assertion covers whichever way it answers: a 200 must leave the stamped
+  // row, and a refusal must leave NOTHING (the hook audits success only).
+  const regenRow = await sql<
+    { category: string; status: string; regenerated: boolean | null }[]
+  >`
+    SELECT category, status,
+           (metadata->>'backupCodesRegenerated')::boolean AS regenerated
+    FROM app.audit_logs
+    WHERE org_id = ${ctx.orgId} AND resource_id = ${lifecycleUserId}
+      AND action = '2fa_enrolled' AND metadata ? 'backupCodesRegenerated'
+    ORDER BY ts DESC LIMIT 1
+  `;
+  const regenConsistent =
+    regenRes.status === 200
+      ? regenRow.length === 1 &&
+        regenRow[0]?.regenerated === true &&
+        afterRegen.join(',') === '2fa_enrolled,2fa_enrolled'
+      : regenRow.length === 0 && afterRegen.join(',') === afterEnable.join(',');
+  // WebAuthn cannot be driven from a script, so the passkey trio is proven at
+  // the writer: the action names land as rows with the security shape.
+  const { recordTwoFactorLifecycleEvent } =
+    await import('./domains/two_factor/service.ts');
+  for (const action of [
+    'passkey_added',
+    'passkey_sign_in',
+    'passkey_removed',
+  ] as const) {
+    await recordTwoFactorLifecycleEvent(sql, {
+      userId: lifecycleUserId,
+      action,
+      actorEmail: email,
+      ip: '203.0.113.9',
+      userAgent: 'itest-passkey/1.0',
+    });
+  }
+  const afterPasskeys = await lifecycleActions();
+  // Every lifecycle row carries the 0.4 security shape, not just the name.
+  const shapes = await sql<{ category: string; status: string }[]>`
+    SELECT DISTINCT category, status FROM app.audit_logs
+    WHERE org_id = ${ctx.orgId} AND resource_type = 'twoFactorAuth'
+      AND resource_id = ${lifecycleUserId}
+  `;
+  // Leave 2FA OFF: later lanes sign this account in with password alone.
+  const enrolled = await sql<{ enabled: boolean | null }[]>`
+    SELECT "twoFactorEnabled" AS enabled FROM "user"
+    WHERE "id" = ${lifecycleUserId}
+  `;
+  record(
+    'two-factor: successful lifecycle events audit (#1508 action names)',
+    before2fa.length === 0 &&
+      enableRes.status === 200 &&
+      afterEnable.join(',') === '2fa_enrolled' &&
+      regenConsistent &&
+      disableRes.status === 200 &&
+      afterDisable.join(',') === `${afterRegen.join(',')},2fa_disabled` &&
+      afterPasskeys.join(',') ===
+        `${afterDisable.join(',')},passkey_added,passkey_sign_in,passkey_removed` &&
+      shapes.length === 1 &&
+      shapes[0]?.category === 'security' &&
+      shapes[0]?.status === 'success' &&
+      enrolled[0]?.enabled !== true,
+    `before=${before2fa.length}, enable=${enableRes.status} regen=${regenRes.status} (stamped=${regenRow.length}) disable=${disableRes.status}, trail=${afterPasskeys.join(',')}, shape=${shapes.map((s) => `${s.category}/${s.status}`).join('|')}, enabledLeftOn=${enrolled[0]?.enabled}`,
   );
 
   await writeFile(


### PR DESCRIPTION
An attacker who registered their own passkey and turned 2FA off left no successful-action trail. 0.4 audited every successful second-factor lifecycle event (#1508); the port kept only the failure half.

Split out of #3149. Refs #3142.

## Why

The failure half audits, so a wrong code is recorded — but enabling 2FA, disabling it, and adding, removing or signing in with a passkey were silent. Those are the events that matter most in an account takeover.

All five 0.4 action names are reused verbatim: `2fa_enrolled`, `2fa_disabled`, `passkey_added`, `passkey_removed`, `passkey_sign_in`. A renamed action silently breaks any query or export that groups on it. Checked against 0.4's full vocabulary — `passkey_removed` and `passkey_revoked_by_admin` were distinct events there and stay distinct here.

Rows are written in the same transaction as the state change, carrying the 0.4 `security`/`success` shape.

## What is NOT here, and why

#3149 also restored the conversation write-role gate, so a read-only member could no longer reply, send outbound mail, close, bulk-act or delete. **That half is held back.** It is faithful — 0.4's rule is literally `authorizeRls(role, 'conversations', 'write')`, and this repo's own matrix gives `member` read only — but it breaks the harness:

```
mine (both halves):  aborts at 178 checks, 9 failures
main:                373/379, 6 known failures
2FA half alone:      373/379, identical 6
```

The first observable failure is real, not incidental:

```
FAIL  blob-ref authority: outbound mail attaches only the sender's uploads
      compose → 403 FORBIDDEN (want 403 attachment_not_owned)
```

The gate fires before the attachment-ownership check, so that assertion gets the wrong 403 — and several later chat checks then cascade. Either the harness fixtures compose as under-privileged actors and need their roles raised, or the gate's placement relative to the ownership check needs rethinking. That is real work, not a rebase, so it is not being smuggled in behind a verified fix.

## Tests

`integration-check.ts` asserts the whole trail and its shape, on a **dedicated throwaway user** rather than the harness's own:

```
trail=2fa_enrolled,2fa_disabled,passkey_added,passkey_sign_in,passkey_removed
shape=security/success   enabledLeftOn=false
```

That isolation is load-bearing, and finding out cost three runs. Running the lifecycle on the shared session left that user's second factor changed and their session invalid, which failed five unrelated checks — the 2FA grace check plus four chat checks. The throwaway user also needs an org membership, because audit rows are org-scoped and without one the trail reads empty.

WebAuthn cannot be driven from a script, so the passkey trio is asserted at the writer: the action names land as rows with the security shape.

**374/380**, and the six failures are byte-identical to a baseline run of unmodified `main` on the same instance — the warm-MinIO bucket collision, two `yt-dlp` probes and three agent-lane probes.

Gate: `typecheck`, `oxlint --type-aware`, `oxfmt --check`, `lint:sast` green; branched from `origin/main` at `899fcc08a`.
