### PR TITLE
fix(platform): green the automations workbench i18n and lint gates

### DIFF
--- a/services/platform/app/components/ui/forms/date-picker-popper.tsx
+++ b/services/platform/app/components/ui/forms/date-picker-popper.tsx
@@ -47,7 +47,7 @@ export function DatePickerPopperContainer({
 
   useEffect(() => {
     const node = ref.current;
-    if (!node) return;
+    if (!node) return undefined;
     // Native bubble, before document listeners. `preventDefault` is wrong
     // here — it cancels the following `click`, so month arrows do nothing.
     const stop = (event: Event) => {

--- a/services/platform/app/features/automations/components/automation-detail.tsx
+++ b/services/platform/app/features/automations/components/automation-detail.tsx
@@ -407,19 +407,20 @@ export function AutomationDetail({
     lookingVersion === undefined || versionEntries.length === 0
       ? []
       : [
-          versionEntries.map((entry) => ({
-            type: 'item' as const,
-            label: t('versions.versionLabel', { version: entry.version }),
-            selected: entry.version === lookingVersion,
-            ...(entry.version === meta?.deployedVersion
-              ? { trailing: t('versions.deployed') }
-              : {}),
-            onClick: () => {
-              if (entry.version !== lookingVersion) {
-                requestVersionSwitch(entry.version);
-              }
-            },
-          })),
+          versionEntries.map((entry) => {
+            const isDeployed = entry.version === meta?.deployedVersion;
+            return {
+              type: 'item' as const,
+              label: t('versions.versionLabel', { version: entry.version }),
+              selected: entry.version === lookingVersion,
+              trailing: isDeployed ? t('versions.deployed') : undefined,
+              onClick: () => {
+                if (entry.version !== lookingVersion) {
+                  requestVersionSwitch(entry.version);
+                }
+              },
+            };
+          }),
         ];
   const selectedNode =
     graph.nodes.find((node) => node.id === selectedNodeId) ?? null;

--- a/services/platform/app/features/automations/components/project-bindings-section.tsx
+++ b/services/platform/app/features/automations/components/project-bindings-section.tsx
@@ -109,7 +109,7 @@ export function ProjectBindingsSection({
   saveRef.current = save;
 
   useEffect(() => {
-    if (onControllerChange === undefined) return;
+    if (onControllerChange === undefined) return undefined;
     onControllerChange({
       dirty,
       pending: setProjects.isPending,

--- a/services/platform/app/features/automations/components/trigger-editor.tsx
+++ b/services/platform/app/features/automations/components/trigger-editor.tsx
@@ -134,7 +134,7 @@ export function TriggerEditor({
         (timezone !== '' && timezone !== 'UTC') ||
         eventName !== '' ||
         kind !== 'schedule' ||
-        enabled !== true
+        !enabled
       );
     }
     return (
@@ -217,7 +217,7 @@ export function TriggerEditor({
   const canRemove = stored !== undefined;
 
   useEffect(() => {
-    if (onControllerChange === undefined) return;
+    if (onControllerChange === undefined) return undefined;
     onControllerChange({
       dirty,
       pending: setTrigger.isPending,

--- a/services/platform/app/features/automations/components/workflow-settings.tsx
+++ b/services/platform/app/features/automations/components/workflow-settings.tsx
@@ -81,7 +81,7 @@ export function WorkflowSettings({
               blocked ? t('trigger.cronInvalid') : t('workflow.nothingToSave')
             }
             onClick={() => {
-              if (trigger?.dirty === true && trigger.blocked !== true) {
+              if (trigger?.dirty === true && !trigger.blocked) {
                 trigger.save();
               }
               if (projects?.dirty === true) {

--- a/services/platform/lib/i18n/e2e-keys.test.ts
+++ b/services/platform/lib/i18n/e2e-keys.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The e2e specs build locators from message keys (`tests/e2e/helpers/i18n.ts`),
+ * so a key that is not in `messages/en.yml` fails inside Playwright — three
+ * retries, a screenshot, and `messages key is not a string: <key>` buried in a
+ * shard log. The `usage-missing` check in `messages.test.ts` cannot see these:
+ * it only reads `t` aliases bound by `useT`/`useTranslation` to a known
+ * namespace, and the e2e helper's `t` takes a whole key path instead.
+ *
+ * So resolve every static literal the specs pass to `t()` through the specs'
+ * OWN resolver. Same function, same catalog — a missing key is named here in
+ * milliseconds instead of costing a Playwright shard.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { t } from '../../tests/e2e/helpers/i18n';
+
+const E2E_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../tests/e2e',
+);
+
+/** Static single-quoted `t('a.b')` arguments — dotted keys only. */
+const T_CALL_RE = /\bt\(\s*'([a-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)'/g;
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return entry.isFile() && full.endsWith('.ts') ? [full] : [];
+  });
+}
+
+const references = walk(E2E_DIR).flatMap((file) =>
+  [...fs.readFileSync(file, 'utf8').matchAll(T_CALL_RE)].map((match) => ({
+    key: match[1],
+    file: path.relative(E2E_DIR, file),
+  })),
+);
+
+describe('e2e message keys', () => {
+  // A regex that stops matching would make every assertion below vacuous, so
+  // pin a floor: the suite referenced far more than this when it was written.
+  it('finds the specs’ key references', () => {
+    expect(references.length).toBeGreaterThan(50);
+  });
+
+  it('resolves every referenced key against the base catalog', () => {
+    const missing = [
+      ...new Set(
+        references
+          .filter(({ key }) => {
+            try {
+              t(key);
+              return false;
+            } catch {
+              return true;
+            }
+          })
+          .map(({ key, file }) => `${key}  (${file})`),
+      ),
+    ].sort();
+
+    expect(
+      missing,
+      `${missing.length} e2e locator key(s) missing from messages/en.yml — the spec would fail in Playwright as "messages key is not a string":\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -505,6 +505,11 @@ automations:
   title: Automatisierungen
   entityLabel: Automatisierungen
   entityLabelOne: Automatisierung
+  switcher:
+    title: Automatisierung wechseln
+    searchPlaceholder: Automatisierungen suchen
+    empty: Keine Automatisierungen gefunden
+    ariaLabel: 'Automatisierung wechseln, aktuell: {name}'
   list:
     searchPlaceholder: Automatisierungen suchen
     columnName: Name
@@ -627,8 +632,6 @@ automations:
     eventLabel: Ereignisname
     eventPlaceholder: Ereignis wählen
     enabledLabel: Aktiv
-    enabledBadge: Aktiv
-    disabledBadge: Aus
     unsavedBadge: Ungespeichert
     lastFired: 'Zuletzt ausgelöst {at}'
     nothingToSave: Die Bindung entspricht dem gespeicherten Stand.
@@ -725,7 +728,6 @@ automations:
     nothingToSave: Nichts zu speichern
   bindings:
     title: Projekte
-    orgBadge: Organisationsweit
     countBadge: '{count, plural, one {An # Projekt gebunden} other {An # Projekte gebunden}}'
     hint: Auf bestimmte Projekte eingrenzen — oder leer lassen für alle.
     placeholder: Projekte wählen

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -480,6 +480,11 @@ automations:
   title: Automations
   entityLabel: automations
   entityLabelOne: automation
+  switcher:
+    title: Switch automation
+    searchPlaceholder: Search automations
+    empty: No automations found
+    ariaLabel: 'Switch automation, current: {name}'
   list:
     searchPlaceholder: Search automations
     columnName: Name
@@ -603,8 +608,6 @@ automations:
     eventLabel: Event name
     eventPlaceholder: Select an event
     enabledLabel: Enabled
-    enabledBadge: Active
-    disabledBadge: Off
     unsavedBadge: Unsaved
     lastFired: 'Last fired {at}'
     nothingToSave: The binding matches what is stored.
@@ -692,7 +695,6 @@ automations:
     nothingToSave: Nothing to save
   bindings:
     title: Projects
-    orgBadge: Organization-wide
     countBadge: '{count, plural, one {Bound to # project} other {Bound to # projects}}'
     hint: Restrict to specific projects, or leave empty for all.
     placeholder: Select projects

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -510,6 +510,11 @@ automations:
   title: Automatisations
   entityLabel: automatisations
   entityLabelOne: automatisation
+  switcher:
+    title: Changer d'automatisation
+    searchPlaceholder: Rechercher des automatisations
+    empty: Aucune automatisation trouvée
+    ariaLabel: "Changer d'automatisation, actuel : {name}"
   list:
     searchPlaceholder: Rechercher des automatisations
     columnName: Nom
@@ -633,8 +638,6 @@ automations:
     eventLabel: Nom de l’événement
     eventPlaceholder: Choisir un événement
     enabledLabel: Actif
-    enabledBadge: Actif
-    disabledBadge: Coupé
     unsavedBadge: Non enregistré
     lastFired: 'Dernier déclenchement {at}'
     nothingToSave: La liaison correspond à ce qui est enregistré.
@@ -731,7 +734,6 @@ automations:
     nothingToSave: Rien à enregistrer
   bindings:
     title: Projets
-    orgBadge: Toute l’organisation
     countBadge: '{count, plural, one {Lié à # projet} other {Lié à # projets}}'
     hint: Limite à des projets précis, ou laisse vide pour tous.
     placeholder: Choisir des projets

--- a/services/platform/tests/e2e/specs/automations.spec.ts
+++ b/services/platform/tests/e2e/specs/automations.spec.ts
@@ -32,10 +32,11 @@ test('uploads a package and switches automations from the breadcrumb leaf', asyn
 }) => {
   const { organizationId } = org;
 
-  // The list toolbar's create menu — a dropdown of three lanes.
+  // The list toolbar's create menu — a dropdown of three lanes. Its trigger
+  // is the DataTable `addAction`, which the list labels `builder.new`.
   await page.goto(`/dashboard/${organizationId}/automations`);
   const createButton = page
-    .getByRole('button', { name: t('automations.list.createButton') })
+    .getByRole('button', { name: t('automations.builder.new') })
     .first();
   await expect(createButton).toBeVisible({ timeout: TIMEOUT.FIRST_PAINT });
   await createButton.click();


### PR DESCRIPTION
`main` is red on four CI jobs. All of it traces to one landed change: the
automations workbench shipped its breadcrumb switcher without adding the
`automations.switcher.*` namespace to the base locale.

## What was failing

| Job | Failure |
| --- | --- |
| `Unit` | `lib/i18n/messages.test.ts` — 4 referenced-but-undefined keys, 3 defined-but-unread keys |
| `UI` | `automation-breadcrumbs` + `automation-breadcrumb-switcher` — 8 assertions |
| `Lint` | 6 oxlint errors in the new components |
| `Playwright (platform 4/16)` | `automations.spec.ts` — all 3 retries on `messages key is not a string` |

The `UI` failures are the same defect, not a separate one. Those two suites
don't mock `useT`, so they resolve real messages — the switcher trigger could
not produce the accessible name they look for, because `switcher.ariaLabel`
didn't exist. Every other automations suite mocks `useT` to echo `ns.key`,
which is why they stayed green and hid it.

This is user-visible, not just a red gate: the switcher's title, search
placeholder, empty state and aria-label all rendered as raw key paths.

## What this changes

**Adds the four `switcher` keys** to `en`, `de` and `fr`, mirroring
`projects.switcher` key-for-key — the only existing instance of this
component's contract. Same wording shape, same quoting convention (fr uses
double quotes around the apostrophe and a plain space before the colon,
matching its neighbours), same `{name}` placeholder. `de-CH` is a sparse
overlay with no `automations` block, so it needs nothing.

**Drops three dead keys** — `trigger.enabledBadge`, `trigger.disabledBadge`,
`bindings.orgBadge`. Nothing renders them, and no hardcoded English stands in
their place: the trigger editor uses a labelled `Switch`
(`trigger.enabledLabel`), the bindings panel a count badge
(`bindings.countBadge`), and `project-bindings-section.test.tsx` asserts the
org badge is *absent* for an unbound automation. They're leftovers from an
earlier design. Flagging it explicitly in case one was meant as UI that never
got wired — say so and I'll build the badge instead.

**Fixes the e2e locator key.** `automations.spec.ts` looked for a button named
`automations.list.createButton`; the list labels that button `builder.new`.
The spec now asks for the key the component renders.

**Six lint fixes**, all mechanical:

- three effects that return a cleanup now `return undefined` on their
  early-out, matching the house pattern in `organization-settings.tsx` and
  `preferences-settings.tsx`
- `enabled !== true` → `!enabled`, and `trigger.blocked !== true` →
  `!trigger.blocked`; both are non-optional booleans. `trigger?.dirty === true`
  stays — that one reaches through an optional chain
- the version menu items build in a block body, so the conditional `trailing`
  is a ternary instead of a spread inside `map`

## New guard

`usage-missing` could not have caught the e2e break: it reads only `t` aliases
bound by `useT`/`useTranslation` to a known namespace, and the e2e helper's `t`
takes a whole key path. I tried widening its `scanRoots` to `tests` first — it
changes nothing, for that same reason, so it isn't in this diff.

`lib/i18n/e2e-keys.test.ts` guards it where the reference actually lives: every
static `t()` literal under `tests/e2e/**` goes through the specs' own resolver.
Same function, same catalog, so there's no second parser to drift. It currently
covers 333 references across 21 files, and a floor on that count keeps it from
passing vacuously if the pattern stops matching.

## Verification

Each gate observed red before and green after, on this branch:

- `oxlint --type-aware`: exit 1 on `main` → exit 0 here
- `lib/i18n/`: 2 failed / 22 passed → **50 passed (50)**
- automations client suites: 8 failed → **165 passed (24 files)**
- full `client` project: **3439 passed**
- `typecheck` 0 errors, `oxfmt --check` clean

Both new assertions mutation-tested: restoring the bad key fails the guard and
names it (`automations.list.createButton (specs/automations.spec.ts)`), and
breaking the extraction pattern fails the floor.

One unrelated pre-existing failure remains in
`app/components/ui/forms/date-picker.test.tsx` (a `pointer-events`
computed-style assertion). It fails identically on unmodified `main` and does
not fail in CI, so it's out of scope here.
