### PR TITLE
fix(platform): map edge refusals to 4xx, lock skill writers, dedup audio

### DIFF
--- a/services/platform/backend/core/agents/file_actions.test.ts
+++ b/services/platform/backend/core/agents/file_actions.test.ts
@@ -428,6 +428,36 @@ describe('deleting an agent', () => {
     ).toBe(true);
   });
 
+  // The regression under test: delete parsed the file first, so a malformed
+  // agent answered AGENT_MALFORMED on the one operation that needs no parsed
+  // definition — and agents have no upload lane to replace it through.
+  it('lets an administrator, and only an administrator, remove a malformed agent', async () => {
+    await seedAgent('acme', 'assistant', 'name: assistant\ncolour: blue\n');
+    const deleteAgent = await load('deleteAgentForCaller');
+    const listAgents = await load('listAgentsForCaller');
+
+    const refused = await deleteAgent({
+      orgSlug: 'acme',
+      slug: 'assistant',
+      ...bob,
+    }).catch((e: unknown) => e);
+    expect(errorCode(refused)).toBe('AGENT_FORBIDDEN');
+    expect((await listAgents({ orgSlug: 'acme', ...admin })).failures).toEqual([
+      expect.objectContaining({ slug: 'assistant' }),
+    ]);
+
+    expect(
+      await deleteAgent({
+        orgSlug: 'acme',
+        slug: 'assistant',
+        ...admin,
+      }),
+    ).toBe(true);
+    expect((await listAgents({ orgSlug: 'acme', ...admin })).failures).toEqual(
+      [],
+    );
+  });
+
   it('cannot delete another organization’s agent — in both directions', async () => {
     await seedAgent('acme', 'assistant', shared);
     await seedAgent(

--- a/services/platform/backend/core/agents/file_actions.ts
+++ b/services/platform/backend/core/agents/file_actions.ts
@@ -352,13 +352,36 @@ export async function restoreFromHistoryForCaller(
     viewer,
   );
 }
-/** Delete an agent and its history. Deleting an absent one is a no-op. */
+/**
+ * Delete an agent and its history. Deleting an absent one is a no-op.
+ *
+ * Deleting is the one operation that needs no readable definition. A file
+ * that fails to parse — the library lists it as a failure — has no owner or
+ * visibility left to consult, so removing it falls to an org admin; agents
+ * have no upload lane, so this is the only in-product repair there is.
+ */
 export async function deleteAgentForCaller(
   args: AgentCallerArgs & { slug: string },
 ): Promise<boolean> {
   assertValidSlug(args.slug);
   const viewer = viewerFrom(args);
-  const existing = await loadAgentOrThrow(args.orgSlug, args.slug);
+  let existing: OrgAgent | null;
+  try {
+    existing = await readOrgAgent(
+      createOrgAgentReader(args.orgSlug),
+      args.slug,
+    );
+  } catch (err) {
+    if (!(err instanceof AgentParseError)) throw err;
+    console.error(`[agents] ${args.orgSlug}: ${err.message}`);
+    if (!viewer.isOrgAdmin) {
+      throw new AppError({
+        code: 'AGENT_FORBIDDEN',
+        message: `Only an organization admin can delete the unreadable agent "${args.slug}".`,
+      });
+    }
+    return removeAgentFile(args.orgSlug, args.slug);
+  }
   if (existing === null) return false;
   if (!canEditAgent(existing.definition, viewer)) {
     throw new AppError({

--- a/services/platform/backend/core/file_metadata/transcribe_audio.ts
+++ b/services/platform/backend/core/file_metadata/transcribe_audio.ts
@@ -1,4 +1,6 @@
 'use node';
+import { createHash } from 'node:crypto';
+
 import { checkProviderHostPolicy } from '../../../lib/net/host-policy';
 import { TRANSCRIPTION_SLUG } from '../../../lib/shared/constants/usage';
 import { estimateTranscriptionCostCents } from '../governance/cost_estimation';
@@ -140,6 +142,23 @@ async function patchProgress(
   );
 }
 
+/**
+ * The audio blob's bytes: an `s3:` ref through the org's store, a legacy
+ * Convex ref through `ctx.storage`. Only the S3 path needs the org slug.
+ */
+async function readAudioBytes(
+  ctx: ActionCtx,
+  orgSlug: string | null,
+  ref: BlobRef,
+): Promise<Uint8Array> {
+  if (convexStorageId(ref) === null && orgSlug === null) {
+    throw new Error(
+      `[transcribeAudio] org unresolvable; cannot read S3 audio blob ${ref}`,
+    );
+  }
+  return readBlobBytes(ctx, orgSlug ?? '', ref);
+}
+
 /** The pipeline body, hoisted so the 0.5 backend can run it on a ctx shim
  * (the wrapper above keeps the 0.4 wiring). */
 export async function transcribeAudioImpl(
@@ -187,6 +206,21 @@ export async function transcribeAudioImpl(
       );
       return null;
     }
+    if (preCheck.transcriptionStatus === 'completed') {
+      // A completed row is never re-run: a duplicate job (a re-registered
+      // blob, a retry racing a finish) must not re-bill the provider or
+      // rewrite the transcript. The lease's status guard fences this too;
+      // saying so here keeps the log honest instead of "deduplicated".
+      console.log(
+        JSON.stringify({
+          event: 'transcription.already_completed',
+          requestId,
+          storageId: args.storageId,
+          attempt,
+        }),
+      );
+      return null;
+    }
 
     // Single-flight gate. Two concurrent invocations on the same
     // storageId (retryTranscription double-click, scheduled retry +
@@ -224,56 +258,49 @@ export async function transcribeAudioImpl(
         },
       );
 
-      // Dedup: Convex stores a SHA-256 of every upload on `_storage`. If the
-      // same content was already transcribed in this org, short-circuit and
-      // copy the prior transcript rather than paying ffmpeg + OpenAI again.
-      // An `s3:` ref has no `_storage` system row, so the checksum is
-      // unavailable — dedup gracefully degrades to off for BYO-bucket orgs.
-      const audioConvexId = convexStorageId(args.storageId);
-      const contentHash = audioConvexId
-        ? await ctx.runQuery(
-            internal.file_metadata.internal_queries.getStorageSha256,
-            { storageId: audioConvexId },
-          )
-        : null;
-
-      if (contentHash) {
+      // Dedup by content. The blob's bytes are needed for compression anyway,
+      // so they are read first and hashed: if the same audio was already
+      // transcribed in this org, the prior transcript is copied and neither
+      // the ffmpeg pass nor the provider call is paid for again. The hash is
+      // stamped on the row before the lookup, so the NEXT identical upload
+      // finds this one. (0.4 read a SHA-256 off Convex `_storage`; an `s3:`
+      // ref has no such system row, which is why it is computed here.)
+      const bytes = await readAudioBytes(ctx, orgSlug, args.storageId);
+      const contentHash = createHash('sha256').update(bytes).digest('hex');
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileTranscription,
+        { storageId: args.storageId, contentHash },
+      );
+      const cached = await ctx.runQuery(
+        internal.file_metadata.internal_queries.findCachedTranscript,
+        {
+          organizationId: args.organizationId,
+          contentHash,
+          excludeStorageId: args.storageId,
+        },
+      );
+      if (cached) {
+        console.log(
+          JSON.stringify({
+            event: 'transcription.dedup_hit',
+            requestId,
+            storageId: args.storageId,
+            sourceStorageId: cached.storageId,
+            contentHash,
+            durationSec: cached.transcriptionDurationSec,
+          }),
+        );
         await ctx.runMutation(
           internal.file_metadata.internal_mutations.updateFileTranscription,
-          { storageId: args.storageId, contentHash },
-        );
-
-        const cached = await ctx.runQuery(
-          internal.file_metadata.internal_queries.findCachedTranscript,
           {
-            organizationId: args.organizationId,
-            contentHash,
-            excludeStorageId: args.storageId,
+            storageId: args.storageId,
+            transcriptionStatus: 'completed',
+            transcript: cached.transcript,
+            transcriptionDurationSec: cached.transcriptionDurationSec,
+            transcriptionProgress: '',
           },
         );
-        if (cached) {
-          console.log(
-            JSON.stringify({
-              event: 'transcription.dedup_hit',
-              requestId,
-              storageId: args.storageId,
-              sourceStorageId: cached.storageId,
-              contentHash,
-              durationSec: cached.transcriptionDurationSec,
-            }),
-          );
-          await ctx.runMutation(
-            internal.file_metadata.internal_mutations.updateFileTranscription,
-            {
-              storageId: args.storageId,
-              transcriptionStatus: 'completed',
-              transcript: cached.transcript,
-              transcriptionDurationSec: cached.transcriptionDurationSec,
-              transcriptionProgress: '',
-            },
-          );
-          return null;
-        }
+        return null;
       }
 
       await patchProgress(ctx, args.storageId, 'compressing');
@@ -286,25 +313,10 @@ export async function transcribeAudioImpl(
       // token (mirrors dictation / TTS).
       checkProviderHostPolicy(modelData.baseUrl);
 
-      let origBlob: Blob;
-      if (audioConvexId) {
-        const b = await ctx.storage.get(audioConvexId);
-        if (!b) {
-          throw new Error(`Audio blob not found in storage: ${args.storageId}`);
-        }
-        origBlob = b;
-      } else {
-        if (orgSlug === null) {
-          throw new Error(
-            `[transcribeAudio] org ${args.organizationId} unresolvable; cannot read S3 audio blob ${args.storageId}`,
-          );
-        }
-        const bytes = await readBlobBytes(ctx, orgSlug, args.storageId);
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
-        origBlob = new Blob([bytes as BlobPart], {
-          type: args.contentType || 'application/octet-stream',
-        });
-      }
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
+      const origBlob = new Blob([bytes as BlobPart], {
+        type: args.contentType || 'application/octet-stream',
+      });
 
       compressed = await compressAudio(origBlob, args.fileName);
 

--- a/services/platform/backend/core/google_drive/import_files.test.ts
+++ b/services/platform/backend/core/google_drive/import_files.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '../lib/rows';
+import {
+  importFiles,
+  type ImportFilesDependencies,
+  type ImportItem,
+} from './import_files';
+
+/**
+ * The Google Drive twin of the OneDrive import pipeline carries the same
+ * sync binding (`sourceMode: 'auto'` + `syncConfigId`), and had the same
+ * two holes: a one-time re-import of a changed file detached a sync-owned
+ * document, and a sync import over an unchanged one-time document never
+ * adopted it.
+ */
+
+function makeDeps(overrides: Partial<ImportFilesDependencies> = {}) {
+  const deps = {
+    getFileMetadata: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: { hash: 'same' } }),
+    downloadToStorage: vi.fn().mockResolvedValue({
+      success: true,
+      storageId: 's3:org-1/blob' as never,
+      mimeType: 'text/plain',
+      size: 10,
+    }),
+    findDocumentByExternalId: vi.fn().mockResolvedValue(null),
+    createDocument: vi.fn().mockResolvedValue('doc-new'),
+    updateDocument: vi.fn().mockResolvedValue(undefined),
+    saveFileMetadata: vi.fn().mockResolvedValue(undefined),
+    linkDocumentToFile: vi.fn().mockResolvedValue(undefined),
+    scheduleHubDocumentRagIndexing: vi.fn().mockResolvedValue(undefined),
+    upsertSyncConfig: vi.fn().mockResolvedValue('cfg-1'),
+  };
+  return { ...deps, ...overrides };
+}
+
+const folderItems: ImportItem[] = [
+  {
+    id: 'file-a',
+    name: 'a.docx',
+    size: 10,
+    relativePath: 'Meetings/a.docx',
+    isDirectlySelected: false,
+    selectedParentId: 'folder-meetings',
+    selectedParentName: 'Meetings',
+    selectedParentPath: 'Meetings',
+  },
+];
+
+const baseArgs = {
+  organizationId: 'org-1',
+  token: 'tok',
+  userId: 'user-1',
+};
+
+describe('google_drive importFiles keeps the sync binding', () => {
+  it('keeps a sync-owned document bound when a one-time import re-imports it changed', async () => {
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue({
+        _id: 'doc-9' as Id<'documents'>,
+        contentHash: 'old',
+        metadata: {
+          sourceMode: 'auto',
+          syncConfigId: 'cfg-9',
+          isDirectlySelected: true,
+        },
+      }),
+      getFileMetadata: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: { hash: 'new' } }),
+    });
+
+    const result = await importFiles(
+      {
+        ...baseArgs,
+        items: [{ id: 'file-a', name: 'a.docx', size: 10 }],
+        importType: 'one-time',
+      },
+      deps,
+    );
+
+    expect(result.successCount).toBe(1);
+    expect(deps.updateDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: 'doc-9',
+        metadata: expect.objectContaining({
+          googleDriveItemId: 'file-a',
+          sourceMode: 'auto',
+          syncConfigId: 'cfg-9',
+          isDirectlySelected: true,
+        }),
+      }),
+    );
+  });
+
+  it('adopts an unchanged document from an earlier one-time import into the sync config', async () => {
+    const bindDocumentToSync = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue({
+        _id: 'doc-1' as Id<'documents'>,
+        contentHash: 'same',
+        metadata: { sourceMode: 'manual' },
+      }),
+      bindDocumentToSync,
+    });
+
+    const result = await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'sync' },
+      deps,
+    );
+
+    expect(result.skippedCount).toBe(1);
+    expect(bindDocumentToSync).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      metadata: {
+        sourceMode: 'auto',
+        syncConfigId: 'cfg-1',
+        selectedParentId: 'folder-meetings',
+        selectedParentName: 'Meetings',
+        selectedParentPath: 'Meetings',
+        isDirectlySelected: false,
+      },
+    });
+    expect(deps.downloadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unchanged document alone when it is already bound to this config', async () => {
+    const bindDocumentToSync = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue({
+        _id: 'doc-1' as Id<'documents'>,
+        contentHash: 'same',
+        metadata: { sourceMode: 'auto', syncConfigId: 'cfg-1' },
+      }),
+      bindDocumentToSync,
+    });
+
+    await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'sync' },
+      deps,
+    );
+
+    expect(bindDocumentToSync).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/core/google_drive/import_files.ts
+++ b/services/platform/backend/core/google_drive/import_files.ts
@@ -57,7 +57,12 @@ export interface ImportFilesDependencies {
   findDocumentByExternalId: (args: {
     organizationId: string;
     externalItemId: string;
-  }) => Promise<{ _id: Id<'documents'>; contentHash?: string } | null>;
+  }) => Promise<{
+    _id: Id<'documents'>;
+    contentHash?: string;
+    /** The stored metadata — read for the sync binding it may carry. */
+    metadata?: Record<string, unknown> | null;
+  } | null>;
   createDocument: (args: {
     organizationId: string;
     title: string;
@@ -103,6 +108,16 @@ export interface ImportFilesDependencies {
   scheduleHubDocumentRagIndexing?: (
     documentId: Id<'documents'>,
   ) => Promise<void>;
+  /**
+   * Bind an already-imported document to a sync config without touching its
+   * content — a merge into its metadata. A "Sync import" over a file an
+   * earlier one-time import already brought in, unchanged, adopts it this
+   * way, so the config updates and prunes it from now on.
+   */
+  bindDocumentToSync?: (args: {
+    documentId: Id<'documents'>;
+    metadata: Record<string, unknown>;
+  }) => Promise<void>;
   upsertSyncConfig?: (
     target: SyncTarget & {
       organizationId: string;
@@ -112,6 +127,58 @@ export interface ImportFilesDependencies {
       storagePrefix?: string;
     },
   ) => Promise<string | null>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** The keys that describe the user's selection an import item came from. */
+function selectionOf(item: ImportItem): Record<string, unknown> {
+  return {
+    ...(item.selectedParentId && { selectedParentId: item.selectedParentId }),
+    ...(item.selectedParentName && {
+      selectedParentName: item.selectedParentName,
+    }),
+    ...(item.selectedParentPath && {
+      selectedParentPath: item.selectedParentPath,
+    }),
+    ...(item.isDirectlySelected !== undefined && {
+      isDirectlySelected: item.isDirectlySelected,
+    }),
+  };
+}
+
+const SYNC_SELECTION_KEYS = [
+  'selectedParentId',
+  'selectedParentName',
+  'selectedParentPath',
+  'isDirectlySelected',
+] as const;
+
+/**
+ * The binding a sync-owned document already carries, so a one-time re-import
+ * of the same file does not detach it: the config keeps updating and pruning
+ * it, and the selection keys stay so the trash lane can still stop a
+ * single-file sync. Empty for a manual document.
+ */
+function inheritedSyncBinding(
+  existingMeta: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    existingMeta.sourceMode !== 'auto' ||
+    typeof existingMeta.syncConfigId !== 'string'
+  ) {
+    return {};
+  }
+  const kept: Record<string, unknown> = {
+    sourceMode: 'auto',
+    syncConfigId: existingMeta.syncConfigId,
+  };
+  for (const key of SYNC_SELECTION_KEYS) {
+    if (existingMeta[key] !== undefined) kept[key] = existingMeta[key];
+  }
+  return kept;
 }
 
 export async function importFiles(
@@ -160,11 +227,34 @@ export async function importFiles(
       }
 
       const contentHash = metadataResult.data.hash;
+      const syncConfigId = configIdByItemId.get(
+        item.selectedParentId ?? item.id,
+      );
+      const existingMeta = isRecord(existingDoc?.metadata)
+        ? existingDoc.metadata
+        : {};
+
       if (
         existingDoc &&
         contentHash &&
         existingDoc.contentHash === contentHash
       ) {
+        // Unchanged — but a sync import still adopts a document an earlier
+        // one-time import left unbound; otherwise the config would neither
+        // track nor prune it until its content happened to change.
+        const boundToThisSync =
+          existingMeta.syncConfigId === syncConfigId &&
+          existingMeta.sourceMode === 'auto';
+        if (syncConfigId !== undefined && !boundToThisSync) {
+          await deps.bindDocumentToSync?.({
+            documentId: existingDoc._id,
+            metadata: {
+              sourceMode: 'auto',
+              syncConfigId,
+              ...selectionOf(item),
+            },
+          });
+        }
         await deps.scheduleHubDocumentRagIndexing?.(existingDoc._id);
         results.push({
           fileId: item.id,
@@ -194,10 +284,6 @@ export async function importFiles(
         ? `${args.organizationId}/${item.relativePath}`
         : `${args.organizationId}/${item.name}`;
 
-      const syncConfigId = configIdByItemId.get(
-        item.selectedParentId ?? item.id,
-      );
-
       const metadata: Record<string, unknown> = {
         googleDriveItemId: item.id,
         itemPath: item.relativePath || '',
@@ -205,18 +291,13 @@ export async function importFiles(
         storagePath,
         size: fileSize,
         ...(syncConfigId && { syncConfigId }),
-        ...(item.selectedParentId && {
-          selectedParentId: item.selectedParentId,
-        }),
-        ...(item.selectedParentName && {
-          selectedParentName: item.selectedParentName,
-        }),
-        ...(item.selectedParentPath && {
-          selectedParentPath: item.selectedParentPath,
-        }),
-        ...(item.isDirectlySelected !== undefined && {
-          isDirectlySelected: item.isDirectlySelected,
-        }),
+        ...selectionOf(item),
+        // A one-time re-import of a file a sync config owns must not detach
+        // it (the metadata is written whole, so the binding has to be
+        // carried over explicitly).
+        ...(syncConfigId === undefined
+          ? inheritedSyncBinding(existingMeta)
+          : {}),
       };
 
       let folderId: Id<'folders'> | undefined;

--- a/services/platform/backend/core/onedrive/import_files.test.ts
+++ b/services/platform/backend/core/onedrive/import_files.test.ts
@@ -54,6 +54,153 @@ const baseArgs = {
   userId: 'user-1',
 };
 
+/**
+ * The sync binding — `sourceMode: 'auto'` + `syncConfigId` — is what lets a
+ * later run update and prune a document. The regression under test: the
+ * metadata was rebuilt from the CURRENT import type and written whole, so a
+ * one-time re-import of a changed file inside a synced folder rewrote it to
+ * manual (never pruned again once the source file was deleted), while a
+ * sync import over an unchanged one-time document skipped it without ever
+ * adopting it.
+ */
+describe('importFiles keeps the sync binding', () => {
+  const syncOwned = {
+    _id: 'doc-9' as Id<'documents'>,
+    contentHash: 'old',
+    metadata: {
+      sourceMode: 'auto',
+      syncConfigId: 'cfg-9',
+      isDirectlySelected: true,
+      selectedParentId: 'file-a',
+    },
+  };
+
+  it('keeps a sync-owned document bound when a one-time import re-imports it changed', async () => {
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue(syncOwned),
+      getFileMetadata: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: { hash: 'new' } }),
+    });
+
+    const result = await importFiles(
+      {
+        ...baseArgs,
+        items: [{ id: 'file-a', name: 'a.docx', size: 10 }],
+        importType: 'one-time',
+      },
+      deps,
+    );
+
+    expect(result.successCount).toBe(1);
+    expect(deps.updateDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: 'doc-9',
+        metadata: expect.objectContaining({
+          sourceMode: 'auto',
+          syncConfigId: 'cfg-9',
+          isDirectlySelected: true,
+          selectedParentId: 'file-a',
+        }),
+      }),
+    );
+  });
+
+  it('still re-imports a manual document as manual', async () => {
+    const updateDocument = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue({
+        _id: 'doc-2' as Id<'documents'>,
+        contentHash: 'old',
+        metadata: { sourceMode: 'manual' },
+      }),
+      getFileMetadata: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: { hash: 'new' } }),
+      updateDocument,
+    });
+
+    await importFiles(
+      {
+        ...baseArgs,
+        items: [{ id: 'file-a', name: 'a.docx', size: 10 }],
+        importType: 'one-time',
+      },
+      deps,
+    );
+
+    expect(updateDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.not.objectContaining({
+          syncConfigId: expect.anything(),
+        }),
+      }),
+    );
+    expect(updateDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ sourceMode: 'manual' }),
+      }),
+    );
+  });
+
+  it('adopts an unchanged document from an earlier one-time import into the sync config', async () => {
+    const bindDocumentToSync = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue({
+        _id: 'doc-1' as Id<'documents'>,
+        contentHash: 'same',
+        metadata: { sourceMode: 'manual' },
+      }),
+      getFileMetadata: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: { hash: 'same' } }),
+      bindDocumentToSync,
+    });
+
+    const result = await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'sync' },
+      deps,
+    );
+
+    expect(result.skippedCount).toBe(1);
+    expect(bindDocumentToSync).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      metadata: {
+        sourceMode: 'auto',
+        syncConfigId: 'cfg-1',
+        selectedParentId: 'folder-meetings',
+        selectedParentName: 'Meetings',
+        selectedParentPath: 'Meetings',
+        isDirectlySelected: false,
+      },
+    });
+    expect(deps.downloadToStorage).not.toHaveBeenCalled();
+    expect(deps.updateDocument).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unchanged document alone when it is already bound to this config', async () => {
+    const bindDocumentToSync = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      findDocumentByExternalId: vi.fn().mockResolvedValue({
+        _id: 'doc-1' as Id<'documents'>,
+        contentHash: 'same',
+        metadata: { sourceMode: 'auto', syncConfigId: 'cfg-1' },
+      }),
+      getFileMetadata: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: { hash: 'same' } }),
+      bindDocumentToSync,
+    });
+
+    await importFiles(
+      { ...baseArgs, items: folderItems, importType: 'sync' },
+      deps,
+    );
+
+    expect(bindDocumentToSync).not.toHaveBeenCalled();
+  });
+});
+
 describe('importFiles sync configs', () => {
   it('registers a sync config per selected folder on sync import', async () => {
     const deps = makeDeps();

--- a/services/platform/backend/core/onedrive/import_files.ts
+++ b/services/platform/backend/core/onedrive/import_files.ts
@@ -75,7 +75,12 @@ export interface ImportFilesDependencies {
   findDocumentByExternalId: (args: {
     organizationId: string;
     externalItemId: string;
-  }) => Promise<{ _id: Id<'documents'>; contentHash?: string } | null>;
+  }) => Promise<{
+    _id: Id<'documents'>;
+    contentHash?: string;
+    /** The stored metadata — read for the sync binding it may carry. */
+    metadata?: Record<string, unknown> | null;
+  } | null>;
   createDocument: (args: {
     organizationId: string;
     title: string;
@@ -122,6 +127,16 @@ export interface ImportFilesDependencies {
   scheduleHubDocumentRagIndexing?: (
     documentId: Id<'documents'>,
   ) => Promise<void>;
+  /**
+   * Bind an already-imported document to a sync config without touching its
+   * content — a merge into its metadata. A "Sync import" over a file an
+   * earlier one-time import already brought in, unchanged, adopts it this
+   * way, so the config updates and prunes it from now on.
+   */
+  bindDocumentToSync?: (args: {
+    documentId: Id<'documents'>;
+    metadata: Record<string, unknown>;
+  }) => Promise<void>;
   /** Create-or-reactivate the sync config for a selected item ("Sync import"
    *  only). Returns the config id so imported documents can point back at it. */
   upsertSyncConfig?: (
@@ -133,6 +148,58 @@ export interface ImportFilesDependencies {
       storagePrefix?: string;
     },
   ) => Promise<string | null>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** The keys that describe the user's selection an import item came from. */
+function selectionOf(item: ImportItem): Record<string, unknown> {
+  return {
+    ...(item.selectedParentId && { selectedParentId: item.selectedParentId }),
+    ...(item.selectedParentName && {
+      selectedParentName: item.selectedParentName,
+    }),
+    ...(item.selectedParentPath && {
+      selectedParentPath: item.selectedParentPath,
+    }),
+    ...(item.isDirectlySelected !== undefined && {
+      isDirectlySelected: item.isDirectlySelected,
+    }),
+  };
+}
+
+const SYNC_SELECTION_KEYS = [
+  'selectedParentId',
+  'selectedParentName',
+  'selectedParentPath',
+  'isDirectlySelected',
+] as const;
+
+/**
+ * The binding a sync-owned document already carries, so a one-time re-import
+ * of the same file does not detach it: the config keeps updating and pruning
+ * it, and the selection keys stay so the trash lane can still stop a
+ * single-file sync. Empty for a manual document.
+ */
+function inheritedSyncBinding(
+  existingMeta: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    existingMeta.sourceMode !== 'auto' ||
+    typeof existingMeta.syncConfigId !== 'string'
+  ) {
+    return {};
+  }
+  const kept: Record<string, unknown> = {
+    sourceMode: 'auto',
+    syncConfigId: existingMeta.syncConfigId,
+  };
+  for (const key of SYNC_SELECTION_KEYS) {
+    if (existingMeta[key] !== undefined) kept[key] = existingMeta[key];
+  }
+  return kept;
 }
 
 export async function importFiles(
@@ -193,12 +260,34 @@ export async function importFiles(
       }
 
       const contentHash = metadataResult.data.hash;
+      const syncConfigId = configIdByItemId.get(
+        item.selectedParentId ?? item.id,
+      );
+      const existingMeta = isRecord(existingDoc?.metadata)
+        ? existingDoc.metadata
+        : {};
 
       if (
         existingDoc &&
         contentHash &&
         existingDoc.contentHash === contentHash
       ) {
+        // Unchanged — but a sync import still adopts a document an earlier
+        // one-time import left unbound; otherwise the config would neither
+        // track nor prune it until its content happened to change.
+        const boundToThisSync =
+          existingMeta.syncConfigId === syncConfigId &&
+          existingMeta.sourceMode === 'auto';
+        if (syncConfigId !== undefined && !boundToThisSync) {
+          await deps.bindDocumentToSync?.({
+            documentId: existingDoc._id,
+            metadata: {
+              sourceMode: 'auto',
+              syncConfigId,
+              ...selectionOf(item),
+            },
+          });
+        }
         await deps.scheduleHubDocumentRagIndexing?.(existingDoc._id);
         results.push({
           fileId: item.id,
@@ -237,10 +326,6 @@ export async function importFiles(
         ? `${args.organizationId}/${item.relativePath}`
         : `${args.organizationId}/${item.name}`;
 
-      const syncConfigId = configIdByItemId.get(
-        item.selectedParentId ?? item.id,
-      );
-
       const metadata: Record<string, unknown> = {
         oneDriveItemId: item.id,
         itemPath: item.relativePath || '',
@@ -248,20 +333,15 @@ export async function importFiles(
         storagePath,
         size: fileSize,
         ...(syncConfigId && { syncConfigId }),
-        ...(item.selectedParentId && {
-          selectedParentId: item.selectedParentId,
-        }),
-        ...(item.selectedParentName && {
-          selectedParentName: item.selectedParentName,
-        }),
-        ...(item.selectedParentPath && {
-          selectedParentPath: item.selectedParentPath,
-        }),
-        ...(item.isDirectlySelected !== undefined && {
-          isDirectlySelected: item.isDirectlySelected,
-        }),
+        ...selectionOf(item),
         ...(item.siteId && { siteId: item.siteId }),
         ...(item.driveId && { driveId: item.driveId }),
+        // A one-time re-import of a file a sync config owns must not detach
+        // it (the metadata is written whole, so the binding has to be
+        // carried over explicitly).
+        ...(syncConfigId === undefined
+          ? inheritedSyncBinding(existingMeta)
+          : {}),
       };
 
       let folderId: Id<'folders'> | undefined;

--- a/services/platform/backend/core/skills/bundle_zip.ts
+++ b/services/platform/backend/core/skills/bundle_zip.ts
@@ -32,6 +32,28 @@ import {
 } from '../../../lib/shared/schemas/skills';
 import { parseSkillMd } from '../../../lib/skills/parse';
 
+/**
+ * Every code this module refuses a zip with. The HTTP boundary maps each one
+ * to a 4xx and BUILDS that map from this list, so a new refusal cannot ship
+ * as an unmapped 500 — {@link refuse} is typed on it, which is what keeps the
+ * throw sites and the list in step.
+ */
+export const SKILL_BUNDLE_REFUSAL_CODES = [
+  'INVALID_BUNDLE',
+  'MISSING_SKILL_MD',
+  'INVALID_SKILL_MD',
+  'INVALID_SKILL_SLUG',
+  'FILE_TOO_LARGE',
+  'BUNDLE_TOO_LARGE',
+] as const;
+
+export type SkillBundleRefusalCode =
+  (typeof SKILL_BUNDLE_REFUSAL_CODES)[number];
+
+function refuse(code: SkillBundleRefusalCode, message: string): AppError {
+  return new AppError({ code, message });
+}
+
 export interface ParsedBundleFile {
   /** Path relative to the bundle root (no leading slash, POSIX separators). */
   relPath: string;
@@ -155,20 +177,19 @@ function inflateCapped(
 }
 
 function fileTooLarge(relPath: string, declared?: number): AppError {
-  return new AppError({
-    code: 'FILE_TOO_LARGE',
-    message:
-      declared === undefined
-        ? `"${relPath}" exceeds per-file cap of ${MAX_SKILL_BUNDLE_FILE_BYTES} bytes`
-        : `"${relPath}" declares ${declared} bytes (per-file cap ${MAX_SKILL_BUNDLE_FILE_BYTES})`,
-  });
+  return refuse(
+    'FILE_TOO_LARGE',
+    declared === undefined
+      ? `"${relPath}" exceeds per-file cap of ${MAX_SKILL_BUNDLE_FILE_BYTES} bytes`
+      : `"${relPath}" declares ${declared} bytes (per-file cap ${MAX_SKILL_BUNDLE_FILE_BYTES})`,
+  );
 }
 
 function bundleTooLarge(): AppError {
-  return new AppError({
-    code: 'BUNDLE_TOO_LARGE',
-    message: `Decompressed bundle exceeds ${MAX_SKILL_BUNDLE_TOTAL_BYTES} bytes`,
-  });
+  return refuse(
+    'BUNDLE_TOO_LARGE',
+    `Decompressed bundle exceeds ${MAX_SKILL_BUNDLE_TOTAL_BYTES} bytes`,
+  );
 }
 
 /** Decode and validate one uploaded zip. Throws `AppError` on refusal. */
@@ -177,26 +198,23 @@ export async function parseSkillBundleZip(buf: Buffer): Promise<ParsedBundle> {
   try {
     zip = await JSZip.loadAsync(buf);
   } catch (err) {
-    throw new AppError({
-      code: 'INVALID_BUNDLE',
-      message: `Not a valid zip archive: ${err instanceof Error ? err.message : String(err)}`,
-    });
+    throw refuse(
+      'INVALID_BUNDLE',
+      `Not a valid zip archive: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   const rawEntries = Object.entries(zip.files).filter(
     ([name]) => !isOsMetadataEntry(name),
   );
   if (rawEntries.length === 0) {
-    throw new AppError({
-      code: 'INVALID_BUNDLE',
-      message: 'Zip is empty',
-    });
+    throw refuse('INVALID_BUNDLE', 'Zip is empty');
   }
   if (rawEntries.length > MAX_SKILL_BUNDLE_FILES) {
-    throw new AppError({
-      code: 'INVALID_BUNDLE',
-      message: `Bundle contains ${rawEntries.length} entries (max ${MAX_SKILL_BUNDLE_FILES})`,
-    });
+    throw refuse(
+      'INVALID_BUNDLE',
+      `Bundle contains ${rawEntries.length} entries (max ${MAX_SKILL_BUNDLE_FILES})`,
+    );
   }
 
   const stripPrefix = detectSingleTopLevelFolder(rawEntries);
@@ -209,24 +227,15 @@ export async function parseSkillBundleZip(buf: Buffer): Promise<ParsedBundle> {
     const rel = stripPrefix ? name.slice(stripPrefix.length) : name;
     if (rel === '') continue;
     if (rel.includes('\0')) {
-      throw new AppError({
-        code: 'INVALID_BUNDLE',
-        message: `Bundle entry path contains NUL byte`,
-      });
+      throw refuse('INVALID_BUNDLE', 'Bundle entry path contains NUL byte');
     }
     if (rel.startsWith('/') || /^[A-Za-z]:/.test(rel)) {
-      throw new AppError({
-        code: 'INVALID_BUNDLE',
-        message: `Bundle entry uses absolute path: ${rel}`,
-      });
+      throw refuse('INVALID_BUNDLE', `Bundle entry uses absolute path: ${rel}`);
     }
     const segments = rel.split('/');
     for (const seg of segments) {
       if (seg === '' || seg === '..' || seg === '.') {
-        throw new AppError({
-          code: 'INVALID_BUNDLE',
-          message: `Bundle entry path is unsafe: ${rel}`,
-        });
+        throw refuse('INVALID_BUNDLE', `Bundle entry path is unsafe: ${rel}`);
       }
     }
     if (rel === 'SKILL.md') {
@@ -239,10 +248,7 @@ export async function parseSkillBundleZip(buf: Buffer): Promise<ParsedBundle> {
   }
 
   if (!skillMdEntry) {
-    throw new AppError({
-      code: 'MISSING_SKILL_MD',
-      message: 'Bundle is missing SKILL.md at the root',
-    });
+    throw refuse('MISSING_SKILL_MD', 'Bundle is missing SKILL.md at the root');
   }
 
   // Declared sizes gate BEFORE any inflation — per entry and in total.
@@ -271,18 +277,18 @@ export async function parseSkillBundleZip(buf: Buffer): Promise<ParsedBundle> {
   try {
     ({ meta, body } = parseSkillMd(skillMdContent, 'SKILL.md'));
   } catch (err) {
-    throw new AppError({
-      code: 'INVALID_SKILL_MD',
-      message: `SKILL.md frontmatter rejected: ${err instanceof Error ? err.message : String(err)}`,
-    });
+    throw refuse(
+      'INVALID_SKILL_MD',
+      `SKILL.md frontmatter rejected: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   const slug = meta.name;
   if (!isValidSkillSlug(slug)) {
-    throw new AppError({
-      code: 'INVALID_SKILL_SLUG',
-      message: `Frontmatter name "${slug}" is not a valid skill slug`,
-    });
+    throw refuse(
+      'INVALID_SKILL_SLUG',
+      `Frontmatter name "${slug}" is not a valid skill slug`,
+    );
   }
 
   const files: ParsedBundleFile[] = [];

--- a/services/platform/backend/core/skills/file_actions.test.ts
+++ b/services/platform/backend/core/skills/file_actions.test.ts
@@ -1,12 +1,16 @@
 // @vitest-environment node
 
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { AppError } from '../../../lib/shared/errors/app-error';
+import type { OrgSkill } from '../../../lib/skills/listing';
+import { parseSkillMd } from '../../../lib/skills/parse';
+import type { ParsedBundle } from './bundle_zip';
+import { normalizedBundleFiles } from './file_actions';
 
 // The `*ForViewer` functions ARE the skill-file surface now — the Convex
 // action wrappers that used to delegate to them retired with the runtime —
@@ -574,6 +578,206 @@ describe('deleteSkill', () => {
     expect((await listSkills({ orgSlug: 'acme', ...alice })).skills).toEqual(
       [],
     );
+  });
+
+  // The regression under test: delete loaded the document first, so a bundle
+  // whose SKILL.md fails to parse answered SKILL_MALFORMED on the one
+  // operation that needs no parsed document — the failure row the library
+  // shows was a dead end without filesystem access.
+  it('lets an org admin, and only an org admin, delete a malformed bundle', async () => {
+    await seedSkill('acme', 'broken', '# no frontmatter\n');
+    const deleteSkill = await load('deleteSkillForViewer');
+    const listSkills = await load('listSkillsForViewer');
+
+    try {
+      await deleteSkill({ orgSlug: 'acme', slug: 'broken', ...bob });
+      expect.unreachable('a member must not remove a bundle nobody can read');
+    } catch (err) {
+      expect(errorCode(err)).toBe('SKILL_FORBIDDEN');
+    }
+    expect((await listSkills({ orgSlug: 'acme', ...admin })).failures).toEqual([
+      expect.objectContaining({ slug: 'broken' }),
+    ]);
+
+    expect(
+      await deleteSkill({ orgSlug: 'acme', slug: 'broken', ...admin }),
+    ).toBe(true);
+    expect((await listSkills({ orgSlug: 'acme', ...admin })).failures).toEqual(
+      [],
+    );
+  });
+
+  it('lets an org admin clear a bundle directory that has no SKILL.md', async () => {
+    const dir = path.join(configRoot, 'acme', 'skills', 'half-written');
+    await mkdir(path.join(dir, 'scripts'), { recursive: true });
+    await writeFile(path.join(dir, 'scripts', 'run.py'), 'print(1)\n', 'utf-8');
+    const deleteSkill = await load('deleteSkillForViewer');
+
+    try {
+      await deleteSkill({ orgSlug: 'acme', slug: 'half-written', ...bob });
+      expect.unreachable('a member must not remove a bundle nobody can read');
+    } catch (err) {
+      expect(errorCode(err)).toBe('SKILL_FORBIDDEN');
+    }
+    expect(
+      await deleteSkill({ orgSlug: 'acme', slug: 'half-written', ...admin }),
+    ).toBe(true);
+    await expect(stat(dir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});
+
+/**
+ * The upload lane's normalization is the editor's rule set at a second
+ * door. The regression under test: a zip that declared an `owner` was
+ * honored verbatim — installing a skill in another member's name — and one
+ * declaring `visibility: private` minted the retired state the editor
+ * refuses.
+ */
+describe('normalizedBundleFiles', () => {
+  function bundleOf(content: string): ParsedBundle {
+    const { meta, body } = parseSkillMd(content, 'SKILL.md');
+    const skillMdBytes = Buffer.from(content, 'utf-8');
+    const asset = Buffer.from('print("unpack")\n', 'utf-8');
+    return {
+      slug: meta.name,
+      meta,
+      body,
+      files: [
+        { relPath: 'SKILL.md', content: skillMdBytes },
+        { relPath: 'scripts/unpack.py', content: asset },
+      ],
+      totalBytes: skillMdBytes.length + asset.length,
+    };
+  }
+  function existingOf(content: string): OrgSkill {
+    const { meta, body } = parseSkillMd(content, 'SKILL.md');
+    return {
+      slug: meta.name,
+      path: `skills/${meta.name}/SKILL.md`,
+      meta,
+      body,
+    };
+  }
+  function writtenMeta(files: Array<{ path: string; content: Buffer }>) {
+    const doc = files.find((file) => file.path === 'SKILL.md');
+    if (doc === undefined) throw new Error('no SKILL.md written');
+    return parseSkillMd(doc.content.toString('utf-8'), 'SKILL.md').meta;
+  }
+
+  it('attributes a new bundle to its uploader, whatever owner the zip declares', () => {
+    const files = normalizedBundleFiles(
+      bundleOf(
+        skillMd({
+          name: 'house-voice',
+          description: 'Ours.',
+          owner: 'user_someone_else',
+        }),
+      ),
+      alice.viewer,
+      null,
+    );
+
+    expect(files.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'scripts/unpack.py',
+    ]);
+    expect(writtenMeta(files)).toMatchObject({
+      owner: 'user_alice',
+      visibility: 'org',
+    });
+  });
+
+  it('adopts the uploader as owner of an unmarked bundle', () => {
+    const files = normalizedBundleFiles(
+      bundleOf(skillMd({ name: 'house-voice', description: 'Ours.' })),
+      bob.viewer,
+      null,
+    );
+    expect(writtenMeta(files).owner).toBe('user_bob');
+  });
+
+  it('refuses to mint a private skill, exactly like the editor', () => {
+    expect(() =>
+      normalizedBundleFiles(
+        bundleOf(
+          skillMd({
+            name: 'alice-drafts',
+            description: 'Mine alone.',
+            visibility: 'private',
+            owner: 'user_alice',
+          }),
+        ),
+        alice.viewer,
+        null,
+      ),
+    ).toThrow(/SKILL_PRIVATE_RETIRED/);
+  });
+
+  it('keeps a pre-existing private bundle private when its owner re-uploads it', () => {
+    const files = normalizedBundleFiles(
+      bundleOf(
+        skillMd({
+          name: 'alice-drafts',
+          description: 'Mine alone, v2.',
+          visibility: 'private',
+          owner: 'user_alice',
+        }),
+      ),
+      alice.viewer,
+      existingOf(
+        skillMd({
+          name: 'alice-drafts',
+          description: 'Mine alone.',
+          visibility: 'private',
+          owner: 'user_alice',
+        }),
+      ),
+    );
+    expect(writtenMeta(files)).toMatchObject({
+      visibility: 'private',
+      owner: 'user_alice',
+    });
+  });
+
+  it('keeps the current owner on a replacement, whatever the zip declares', () => {
+    const files = normalizedBundleFiles(
+      bundleOf(
+        skillMd({
+          name: 'house-voice',
+          description: 'Replaced.',
+          owner: 'user_someone_else',
+        }),
+      ),
+      admin.viewer,
+      existingOf(
+        skillMd({
+          name: 'house-voice',
+          description: 'Original.',
+          visibility: 'org',
+          owner: 'user_alice',
+        }),
+      ),
+    );
+    expect(writtenMeta(files).owner).toBe('user_alice');
+  });
+
+  it('attributes the replacement of an ownerless bundle to its uploader', () => {
+    const files = normalizedBundleFiles(
+      bundleOf(skillMd({ name: 'house-voice', description: 'Replaced.' })),
+      admin.viewer,
+      existingOf(skillMd({ name: 'house-voice', description: 'Original.' })),
+    );
+    expect(writtenMeta(files).owner).toBe('user_admin');
+  });
+
+  it('leaves SKILL.md byte-for-byte when the zip already says what the readers conclude', () => {
+    const content = skillMd({
+      name: 'house-voice',
+      description: 'Ours.',
+      owner: 'user_alice',
+    });
+    const files = normalizedBundleFiles(bundleOf(content), alice.viewer, null);
+    expect(files[0]?.content.toString('utf-8')).toBe(content);
   });
 });
 

--- a/services/platform/backend/core/skills/file_actions.ts
+++ b/services/platform/backend/core/skills/file_actions.ts
@@ -211,8 +211,7 @@ export async function saveSkillForViewer(
     if (visibility === 'private' && existing?.meta.visibility !== 'private') {
       throw new AppError({
         code: 'SKILL_PRIVATE_RETIRED',
-        message:
-          'Private skills are retired — nothing can equip one. Share the skill with a team or the organization instead.',
+        message: PRIVATE_SKILLS_RETIRED_MESSAGE,
       });
     }
     const teams = resolveTeams(visibility, args.teams, existing?.meta.teams);
@@ -277,25 +276,55 @@ export async function saveSkillForViewer(
   }
 }
 
+const PRIVATE_SKILLS_RETIRED_MESSAGE =
+  'Private skills are retired — nothing can equip one. Share the skill with a team or the organization instead.';
+
 /**
- * The bundle files as they will be persisted. An unmarked upload lands as an
- * `org` skill (the parse default) with the uploader adopted as owner for
- * attribution — by rewriting the `SKILL.md` about to be written, so the file
- * on disk always says what the readers will conclude. A bundle that declares
- * its sharing is honored verbatim (any member may share, and the parse step
- * already refused the inconsistent shapes).
+ * The bundle files as they will be persisted, with `SKILL.md` rewritten so
+ * the file on disk says exactly what the readers will conclude — under the
+ * SAME rules {@link saveSkillForViewer} applies, because an upload is a
+ * second door into the same create-or-replace action:
+ *
+ * - a new bundle is attributed to its uploader; a replacement keeps the
+ *   bundle's current owner (or, when nobody owned it, the uploader). A
+ *   declared `owner` is never honored — the editor never lets a member pick
+ *   one, so a zip cannot install a skill in someone else's name either;
+ * - `private` is retired: a bundle may stay private only when the one it
+ *   replaces already is (its owner re-uploading), never become it.
+ *
+ * `existing` is the bundle the upload replaces, or `null` for a new slug — a
+ * slug whose current document is unreadable counts as new, since there is
+ * nothing left to preserve. Sharing (`team`/`org` + `teams`) is honored as
+ * declared: any member may share, and the parse step already refused the
+ * inconsistent shapes. `SKILL.md` stays byte-for-byte when the zip already
+ * says what the readers will conclude.
  */
 export function normalizedBundleFiles(
   parsed: ParsedBundle,
   uploader: UserSkillViewer,
+  existing: OrgSkill | null,
 ): Array<{ path: string; content: Buffer }> {
+  if (
+    parsed.meta.visibility === 'private' &&
+    existing?.meta.visibility !== 'private'
+  ) {
+    throw new AppError({
+      code: 'SKILL_PRIVATE_RETIRED',
+      message: PRIVATE_SKILLS_RETIRED_MESSAGE,
+    });
+  }
+  const owner =
+    existing === null
+      ? uploader.userId
+      : (existing.meta.owner ?? uploader.userId);
+
   const files = parsed.files.map((file) => ({
     path: file.relPath,
     content: file.content,
   }));
-  if (parsed.meta.owner !== undefined) return files;
+  if (parsed.meta.owner === owner) return files;
 
-  const meta: SkillFrontmatter = { ...parsed.meta, owner: uploader.userId };
+  const meta: SkillFrontmatter = { ...parsed.meta, owner };
   const rewritten = serializeSkillMd(meta, parsed.body);
   return files.map((file) =>
     file.path === SKILL_DOCUMENT_NAME
@@ -304,7 +333,17 @@ export function normalizedBundleFiles(
   );
 }
 
-/** Delete a skill bundle and its history. Deleting an absent one is a no-op. */
+/**
+ * Delete a skill bundle and its history. Deleting an absent one is a no-op.
+ *
+ * Deleting is the one operation that needs no readable document. A bundle
+ * whose `SKILL.md` fails to parse — the library lists it as a failure — has
+ * no owner or sharing left to consult, so removing it falls to an org admin;
+ * without that, the failure row is a dead end only filesystem access can
+ * clear. The same rule covers a bundle directory with no `SKILL.md` at all
+ * (an upload that died mid-way): invisible to the library, yet present to
+ * the upload lane's slug check.
+ */
 export async function deleteSkillForViewer(args: {
   orgSlug: string;
   slug: string;
@@ -312,8 +351,22 @@ export async function deleteSkillForViewer(args: {
 }): Promise<boolean> {
   assertValidSlug(args.slug);
   const viewer = assertUserViewer(args.viewer);
-  const existing = await loadSkillOrThrow(args.orgSlug, args.slug);
-  if (existing === null) return false;
+  let existing: OrgSkill | null;
+  try {
+    existing = await readOrgSkill(
+      createOrgSkillReader(args.orgSlug),
+      args.slug,
+    );
+  } catch (err) {
+    if (!(err instanceof SkillParseError)) throw err;
+    console.error(`[skills] ${args.orgSlug}: ${err.message}`);
+    return removeUnreadableBundle(args.orgSlug, args.slug, viewer);
+  }
+  if (existing === null) {
+    const entries = await listSkillBundleFileEntries(args.orgSlug, args.slug);
+    if (entries === null) return false;
+    return removeUnreadableBundle(args.orgSlug, args.slug, viewer);
+  }
   if (!canEditSkill(existing.meta, viewer)) {
     throw new AppError({
       code: 'SKILL_FORBIDDEN',
@@ -321,6 +374,21 @@ export async function deleteSkillForViewer(args: {
     });
   }
   return removeSkillBundle(args.orgSlug, args.slug);
+}
+
+/** A bundle nobody can read is the org admin's to remove. */
+function removeUnreadableBundle(
+  orgSlug: string,
+  slug: string,
+  viewer: UserSkillViewer,
+): Promise<boolean> {
+  if (!viewer.isOrgAdmin) {
+    throw new AppError({
+      code: 'SKILL_FORBIDDEN',
+      message: `Only an organization admin can delete the unreadable skill "${slug}".`,
+    });
+  }
+  return removeSkillBundle(orgSlug, slug);
 }
 /**
  * The teams a saved skill ends up with. A `team` skill keeps or receives a

--- a/services/platform/backend/domains/agents/errors.ts
+++ b/services/platform/backend/domains/agents/errors.ts
@@ -1,0 +1,29 @@
+import type { Context, Env } from 'hono';
+
+import {
+  appErrorResponse,
+  type CodedRefusalStatus,
+} from '../../lib/app-error-response.ts';
+
+/**
+ * HTTP status for every coded refusal the agent file layer can throw — ONE
+ * map for the app routes and the REST family, so a permission or validation
+ * failure reads as the 403/400 it is on both doors instead of a 500 on one
+ * of them.
+ */
+export const AGENT_ERROR_STATUS: Readonly<Record<string, CodedRefusalStatus>> =
+  {
+    INVALID_AGENT_SLUG: 400,
+    INVALID_AGENT: 400,
+    AGENT_FORBIDDEN: 403,
+    AGENT_HISTORY_ENTRY_NOT_FOUND: 404,
+    AGENT_MALFORMED: 422,
+  };
+
+/** `{ error, message }` with the mapped status; rethrows an unmapped error. */
+export function agentErrorResponse<E extends Env>(
+  c: Context<E>,
+  error: unknown,
+): Response {
+  return appErrorResponse(c, error, AGENT_ERROR_STATUS);
+}

--- a/services/platform/backend/domains/agents/routes.ts
+++ b/services/platform/backend/domains/agents/routes.ts
@@ -3,7 +3,6 @@ import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import { defineAbilityFor } from '../../../lib/permissions/ability.ts';
-import { AppError } from '../../../lib/shared/errors/app-error';
 import type { Auth } from '../../auth/auth.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession } from '../../auth/session.ts';
@@ -18,6 +17,7 @@ import {
   type AgentCallerArgs,
 } from '../../core/agents/file_actions.ts';
 import { resolveOrgSlug } from '../../lib/org-config.ts';
+import { agentErrorResponse } from './errors.ts';
 
 /**
  * /api/app/agents — the org's agent personas, REUSING the 0.4 file layer
@@ -25,7 +25,8 @@ import { resolveOrgSlug } from '../../lib/org-config.ts';
  * the org config tree, yaml definitions + a history trail). Visibility
  * (`private | org`), owner adoption, verify-before-write, and additive
  * restore all live in the reused functions; this module only authenticates,
- * derives the caller, and maps the reused error codes onto HTTP.
+ * derives the caller, and maps the reused error codes onto HTTP through the
+ * map the REST family shares (`errors.ts`).
  */
 
 const editSchema = z.object({
@@ -41,39 +42,6 @@ const editSchema = z.object({
 });
 
 const restoreSchema = z.object({ entry: z.string().min(1).max(255) });
-
-/** HTTP status for a reused-layer error code. */
-const ERROR_STATUS: Record<string, 400 | 403 | 404 | 422> = {
-  INVALID_AGENT_SLUG: 400,
-  INVALID_AGENT: 400,
-  AGENT_FORBIDDEN: 403,
-  AGENT_HISTORY_ENTRY_NOT_FOUND: 404,
-  AGENT_MALFORMED: 422,
-};
-
-function handleError<E extends OrgEnv>(
-  c: Context<E>,
-  error: unknown,
-): Response {
-  if (error instanceof AppError) {
-    const data: unknown = error.data;
-    if (data !== null && typeof data === 'object' && 'code' in data) {
-      const record = data as { code?: unknown; message?: unknown };
-      const code = typeof record.code === 'string' ? record.code : 'ERROR';
-      const status = ERROR_STATUS[code];
-      if (status !== undefined) {
-        return c.json(
-          {
-            error: code,
-            message: typeof record.message === 'string' ? record.message : code,
-          },
-          status,
-        );
-      }
-    }
-  }
-  throw error;
-}
 
 export function createAgentRoutes(deps: {
   sql: Sql;
@@ -114,7 +82,7 @@ export function createAgentRoutes(deps: {
       }
       return c.json({ agent });
     } catch (error) {
-      return handleError(c, error);
+      return agentErrorResponse(c, error);
     }
   });
 
@@ -130,7 +98,7 @@ export function createAgentRoutes(deps: {
       }
       return c.json({ agent: resolved });
     } catch (error) {
-      return handleError(c, error);
+      return agentErrorResponse(c, error);
     }
   });
 
@@ -147,7 +115,7 @@ export function createAgentRoutes(deps: {
       });
       return c.json({ agent });
     } catch (error) {
-      return handleError(c, error);
+      return agentErrorResponse(c, error);
     }
   });
 
@@ -159,7 +127,7 @@ export function createAgentRoutes(deps: {
       });
       return c.json({ deleted });
     } catch (error) {
-      return handleError(c, error);
+      return agentErrorResponse(c, error);
     }
   });
 
@@ -171,7 +139,7 @@ export function createAgentRoutes(deps: {
       });
       return c.json({ entries });
     } catch (error) {
-      return handleError(c, error);
+      return agentErrorResponse(c, error);
     }
   });
 
@@ -188,7 +156,7 @@ export function createAgentRoutes(deps: {
       });
       return c.json({ agent });
     } catch (error) {
-      return handleError(c, error);
+      return agentErrorResponse(c, error);
     }
   });
 

--- a/services/platform/backend/domains/files/transcription.test.ts
+++ b/services/platform/backend/domains/files/transcription.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { addJobInTx } from '../../jobs/enqueue.ts';
+import { queueTranscription } from './transcription.ts';
+
+/**
+ * The regression under test: `queueTranscription` enqueued a
+ * `files.transcribe` job unconditionally, even when its `queued` stamp
+ * matched no row — a row already queued, running, or completed got a second
+ * job with no work to do (the lease's status guard fences the bill, but the
+ * job, the log line, and the intent were wrong). A job now follows only the
+ * stamp that actually landed.
+ */
+
+vi.mock('../../jobs/enqueue.ts', () => ({
+  addJobInTx: vi.fn(async () => 'job-1'),
+}));
+
+interface Captured {
+  text: string;
+  values: unknown[];
+}
+
+/** Tagged-template Sql double answering every statement with `rows`. */
+function fakeSql(rows: object[]): { sql: Sql; queries: Captured[] } {
+  const queries: Captured[] = [];
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    queries.push({
+      text: strings.join('$?').replace(/\s+/g, ' ').trim(),
+      values,
+    });
+    return Promise.resolve(rows);
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double
+  return { sql: tag as unknown as Sql, queries };
+}
+
+const args = {
+  organizationId: 'org-1',
+  storageRef: 's3:org-1/audio.wav',
+  fileName: 'audio.wav',
+  contentType: 'audio/wav',
+};
+
+describe('queueTranscription', () => {
+  beforeEach(() => {
+    vi.mocked(addJobInTx).mockClear();
+  });
+
+  it('stamps a fresh row queued and enqueues exactly one job', async () => {
+    const { sql, queries } = fakeSql([{ id: 'file-1' }]);
+
+    expect(await queueTranscription(sql, args)).toBe(true);
+
+    expect(queries[0]?.text).toContain("transcription_status = 'queued'");
+    expect(queries[0]?.text).toContain('transcription_status IS NULL');
+    expect(queries[0]?.text).toContain('RETURNING id');
+    expect(addJobInTx).toHaveBeenCalledTimes(1);
+    expect(addJobInTx).toHaveBeenCalledWith(sql, 'files.transcribe', {
+      storageId: args.storageRef,
+      fileName: args.fileName,
+      contentType: args.contentType,
+      organizationId: args.organizationId,
+    });
+  });
+
+  it('enqueues nothing for a row that already has a transcription lifecycle', async () => {
+    const { sql } = fakeSql([]);
+
+    expect(await queueTranscription(sql, args)).toBe(false);
+
+    expect(addJobInTx).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/files/transcription.ts
+++ b/services/platform/backend/domains/files/transcription.ts
@@ -29,9 +29,11 @@ import { FileError } from './service.ts';
  * ledger minutes. The engine's ctx runs on the chat shim (the provider walk
  * `resolveTranscriptionModel` shares with TTS/dictation) plus the file-row
  * verbs below; its `[30s, 60s, 120s]` retry self-chain maps onto delayed
- * `files.transcribe` jobs. The 0.4 content-hash dedup rides Convex
- * `_storage` sha256 rows and degrades to OFF here by design (0.5 blobs are
- * `s3:` refs — the 0.4 code takes the same branch for BYO-bucket orgs).
+ * `files.transcribe` jobs. The 0.4 content-hash dedup — the same bytes
+ * transcribed once per org, whatever blob they arrive in — stays alive on
+ * pg: the engine hashes the blob it reads anyway, stamps `content_hash`, and
+ * `findCachedTranscript` answers from the org's completed rows (0.4 read the
+ * hash off Convex `_storage`; an `s3:` ref has no such system row).
  */
 
 const DICTATION_TIMEOUT_MS = 60_000;
@@ -60,6 +62,7 @@ async function applyTranscriptionPatch(
       transcription_duration_sec = ${patch.transcriptionDurationSec !== undefined ? patch.transcriptionDurationSec : db.unsafe('transcription_duration_sec')},
       transcription_progress = ${patch.transcriptionProgress !== undefined ? patch.transcriptionProgress : db.unsafe('transcription_progress')},
       transcription_error = ${patch.transcriptionError !== undefined ? patch.transcriptionError : db.unsafe('transcription_error')},
+      content_hash = ${patch.contentHash !== undefined ? patch.contentHash : db.unsafe('content_hash')},
       status_changed_at_ms = ${patch.transcriptionStatus !== undefined ? Date.now() : db.unsafe('status_changed_at_ms')}
     WHERE storage_ref = ${storageRef}
   `;
@@ -165,11 +168,42 @@ function transcriptionHandlers(sql: Sql): ShimHandlers {
         contentType: row.contentType,
       };
     },
-    // 0.5 blobs are `s3:` refs with no Convex `_storage` system row — the
-    // engine never reaches these two on that branch, but the honest answers
-    // keep any stray call harmless (dedup off, exactly like 0.4 BYO-bucket).
-    'file_metadata/internal_queries:getStorageSha256': async () => null,
-    'file_metadata/internal_queries:findCachedTranscript': async () => null,
+    // The org's completed transcript for these exact bytes, if any other blob
+    // carried them. Org-scoped by construction: a transcript never crosses
+    // organizations, however identical the audio.
+    'file_metadata/internal_queries:findCachedTranscript': async (raw) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the engine passes exactly this shape
+      const args = raw as {
+        organizationId: string;
+        contentHash: string;
+        excludeStorageId: string;
+      };
+      const rows = await sql<
+        {
+          storageId: string;
+          transcript: string;
+          transcriptionDurationSec: number | null;
+        }[]
+      >`
+        SELECT storage_ref AS "storageId", transcript,
+               transcription_duration_sec AS "transcriptionDurationSec"
+        FROM app.file_metadata
+        WHERE org_id = ${args.organizationId}
+          AND content_hash = ${args.contentHash}
+          AND transcription_status = 'completed'
+          AND transcript IS NOT NULL
+          AND storage_ref <> ${args.excludeStorageId}
+        ORDER BY created_at_ms DESC
+        LIMIT 1
+      `;
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        storageId: row.storageId,
+        transcript: row.transcript,
+        transcriptionDurationSec: row.transcriptionDurationSec ?? 0,
+      };
+    },
     'file_metadata/internal_mutations:updateFileTranscription': async (raw) => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the engine passes exactly this shape
       const args = raw as { storageId: string } & TranscriptionRowPatch;
@@ -303,6 +337,11 @@ export async function runTranscribeJob(
 /**
  * Queue transcription for a freshly registered audio/video upload (the 0.4
  * `saveFileMetadata` audio branch): stamp `queued` + enqueue the job.
+ *
+ * Only a row THIS call moved into `queued` gets a job. A row that is already
+ * queued, running, or terminal has its own lifecycle — a job in flight, the
+ * retry door — and a second job would at best be wasted and at worst a
+ * second attempt at paid work. Answers whether a job was enqueued.
  */
 export async function queueTranscription(
   sql: Sql,
@@ -312,20 +351,23 @@ export async function queueTranscription(
     fileName: string;
     contentType: string;
   },
-): Promise<void> {
-  await sql`
+): Promise<boolean> {
+  const stamped = await sql<{ id: string }[]>`
     UPDATE app.file_metadata SET
       transcription_status = 'queued',
       status_changed_at_ms = ${Date.now()}
     WHERE org_id = ${args.organizationId} AND storage_ref = ${args.storageRef}
       AND transcription_status IS NULL
+    RETURNING id
   `;
+  if (stamped.length === 0) return false;
   await addJobInTx(sql, 'files.transcribe', {
     storageId: args.storageRef,
     fileName: args.fileName,
     contentType: args.contentType,
     organizationId: args.organizationId,
   });
+  return true;
 }
 
 // ------------------------------------------------------------ user actions

--- a/services/platform/backend/domains/google_drive/routes.test.ts
+++ b/services/platform/backend/domains/google_drive/routes.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+
+import type { Sql } from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Auth } from '../../auth/auth.ts';
+import { checkOrganizationRateLimit } from '../../lib/rate-limit.ts';
+import { createGoogleDriveRoutes } from './routes.ts';
+
+/**
+ * The regression under test: the Google Drive picker and import applied no
+ * rate limit at all while their OneDrive twins did — one org could hammer
+ * the vendor unbounded through one door and not the other. Both lanes now
+ * charge their own buckets and answer the same 429 with Retry-After when
+ * spent. Auth is stubbed to a fixed member; the limiter is stubbed spent.
+ */
+
+vi.mock('../../auth/session.ts', () => ({
+  requireSession:
+    () =>
+    async (
+      c: { set: (key: string, value: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('sessionBundle', { user: { id: 'user-1' } });
+      await next();
+    },
+}));
+
+vi.mock('../../auth/org.ts', () => ({
+  requireOrgMember:
+    () =>
+    async (
+      c: { set: (key: string, value: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('orgId', 'org-1');
+      c.set('orgMember', { role: 'admin' });
+      await next();
+    },
+  requireOrgAbility: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+vi.mock('../../lib/rate-limit.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../lib/rate-limit.ts')>();
+  return {
+    ...actual,
+    checkOrganizationRateLimit: vi.fn(async () => {
+      throw new actual.RateLimitExceededError('spent', 2500);
+    }),
+  };
+});
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test doubles; auth and the limiter are mocked
+const deps = { sql: {} as Sql, auth: {} as Auth };
+
+const post = (route: string, body: unknown): Promise<Response> =>
+  Promise.resolve(
+    createGoogleDriveRoutes(deps).request(route, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+
+describe('Google Drive routes under a spent org budget', () => {
+  it.each([
+    ['/list-files', {}, 'external:google-drive-list'],
+    [
+      '/import',
+      {
+        items: [{ id: 'item', name: 'a.txt', size: 1 }],
+        importType: 'one-time',
+      },
+      'external:google-drive-read',
+    ],
+  ] as const)(
+    '%s charges its own bucket and answers 429 with Retry-After',
+    async (route, body, rule) => {
+      const res = await post(route, body);
+
+      expect(res.status).toBe(429);
+      expect(res.headers.get('retry-after')).toBe('3');
+      expect(await res.json()).toEqual({
+        error: 'RATE_LIMITED',
+        data: { retryAfterMs: 2500 },
+      });
+      expect(checkOrganizationRateLimit).toHaveBeenLastCalledWith(
+        deps.sql,
+        rule,
+        'org-1',
+      );
+    },
+  );
+});

--- a/services/platform/backend/domains/google_drive/routes.ts
+++ b/services/platform/backend/domains/google_drive/routes.ts
@@ -11,6 +11,7 @@ import {
 import { requireSession } from '../../auth/session.ts';
 import { importFiles } from '../../core/google_drive/import_files.ts';
 import { listFiles } from '../../core/google_drive/list_files.ts';
+import { chargeOrgRateLimit } from '../../lib/rate-limit-response.ts';
 import { SyncConfigError } from '../onedrive/service.ts';
 import {
   cancelSyncConfig,
@@ -25,6 +26,8 @@ import {
  * `knowledgeWrite` — the same gate the cloud-import OAuth start enforces and
  * the UI hides the import behind. Tokens are grant-only and never reach the
  * client. Native Google Workspace files are excluded by the reused listers.
+ * The org-wide vendor budgets mirror the OneDrive twin's and answer a 429
+ * with Retry-After when spent.
  */
 
 function handleError<E extends OrgEnv>(
@@ -79,6 +82,13 @@ export function createGoogleDriveRoutes(deps: {
       })
       .safeParse(await c.req.json().catch(() => ({})));
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
+    const limited = await chargeOrgRateLimit(
+      deps.sql,
+      c,
+      'external:google-drive-list',
+      c.get('orgId'),
+    );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({ success: false, error: token.error });
@@ -95,6 +105,13 @@ export function createGoogleDriveRoutes(deps: {
       await c.req.json().catch(() => null),
     );
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
+    const limited = await chargeOrgRateLimit(
+      deps.sql,
+      c,
+      'external:google-drive-read',
+      c.get('orgId'),
+    );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({

--- a/services/platform/backend/domains/onedrive/routes.test.ts
+++ b/services/platform/backend/domains/onedrive/routes.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+
+import type { Sql } from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Auth } from '../../auth/auth.ts';
+import { checkOrganizationRateLimit } from '../../lib/rate-limit.ts';
+import { createOneDriveRoutes } from './routes.ts';
+
+/**
+ * The regression under test: `checkOrganizationRateLimit` throws
+ * `RateLimitExceededError`, and no OneDrive route caught it — a member
+ * browsing the picker briskly got a 500 (and a Sentry page) instead of the
+ * retryable 429 every sibling door answers. The org-wide budget is one
+ * bucket for all members, so this is the picker's normal weather, not an
+ * edge. Auth is stubbed to a fixed member; the limiter is stubbed spent.
+ */
+
+vi.mock('../../auth/session.ts', () => ({
+  requireSession:
+    () =>
+    async (
+      c: { set: (key: string, value: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('sessionBundle', { user: { id: 'user-1' } });
+      await next();
+    },
+}));
+
+vi.mock('../../auth/org.ts', () => ({
+  requireOrgMember:
+    () =>
+    async (
+      c: { set: (key: string, value: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('orgId', 'org-1');
+      c.set('orgMember', { role: 'admin' });
+      await next();
+    },
+  requireOrgAbility: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+vi.mock('../../lib/rate-limit.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../lib/rate-limit.ts')>();
+  return {
+    ...actual,
+    checkOrganizationRateLimit: vi.fn(async () => {
+      throw new actual.RateLimitExceededError('spent', 2500);
+    }),
+  };
+});
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test doubles; auth and the limiter are mocked
+const deps = { sql: {} as Sql, auth: {} as Auth };
+
+const post = (route: string, body: unknown): Promise<Response> =>
+  Promise.resolve(
+    createOneDriveRoutes(deps).request(route, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+
+describe('OneDrive routes under a spent org budget', () => {
+  it.each([
+    ['/list-files', {}, 'external:onedrive-list'],
+    ['/sharepoint/sites', {}, 'external:onedrive-list'],
+    ['/sharepoint/drives', { siteId: 'site' }, 'external:onedrive-list'],
+    [
+      '/sharepoint/files',
+      { siteId: 'site', driveId: 'drive' },
+      'external:onedrive-list',
+    ],
+    [
+      '/import',
+      {
+        items: [{ id: 'item', name: 'a.txt', size: 1 }],
+        importType: 'one-time',
+      },
+      'external:onedrive-read',
+    ],
+  ] as const)('%s answers 429 with Retry-After', async (route, body, rule) => {
+    const res = await post(route, body);
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBe('3');
+    expect(await res.json()).toEqual({
+      error: 'RATE_LIMITED',
+      data: { retryAfterMs: 2500 },
+    });
+    expect(checkOrganizationRateLimit).toHaveBeenLastCalledWith(
+      deps.sql,
+      rule,
+      'org-1',
+    );
+  });
+});

--- a/services/platform/backend/domains/onedrive/routes.ts
+++ b/services/platform/backend/domains/onedrive/routes.ts
@@ -14,7 +14,7 @@ import { listFiles } from '../../core/onedrive/list_files.ts';
 import { listSharePointDrives } from '../../core/onedrive/list_sharepoint_drives.ts';
 import { listSharePointFiles } from '../../core/onedrive/list_sharepoint_files.ts';
 import { listSharePointSites } from '../../core/onedrive/list_sharepoint_sites.ts';
-import { checkOrganizationRateLimit } from '../../lib/rate-limit.ts';
+import { chargeOrgRateLimit } from '../../lib/rate-limit-response.ts';
 import {
   cancelSyncConfig,
   createPgImportDeps,
@@ -30,7 +30,9 @@ import {
  * the UI hides the import behind; a read-only member holding a usable Graph
  * token (the login-account lane) must not import or cancel syncs through the
  * API. Tokens resolve per signed-in member (cloud grant first, login account
- * second) and never reach the client.
+ * second) and never reach the client. The org-wide vendor budgets answer a
+ * 429 with Retry-After when spent — a member browsing briskly is asked to
+ * wait, never shown an outage.
  */
 
 function handleError<E extends OrgEnv>(
@@ -88,11 +90,13 @@ export function createOneDriveRoutes(deps: {
       })
       .safeParse(await c.req.json().catch(() => ({})));
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    await checkOrganizationRateLimit(
+    const limited = await chargeOrgRateLimit(
       deps.sql,
+      c,
       'external:onedrive-list',
       c.get('orgId'),
     );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({ success: false, error: token.error });
@@ -107,11 +111,13 @@ export function createOneDriveRoutes(deps: {
       .object({ search: z.string().optional() })
       .safeParse(await c.req.json().catch(() => ({})));
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    await checkOrganizationRateLimit(
+    const limited = await chargeOrgRateLimit(
       deps.sql,
+      c,
       'external:onedrive-list',
       c.get('orgId'),
     );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({ success: false, error: token.error });
@@ -129,11 +135,13 @@ export function createOneDriveRoutes(deps: {
       .object({ siteId: z.string().min(1) })
       .safeParse(await c.req.json().catch(() => null));
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    await checkOrganizationRateLimit(
+    const limited = await chargeOrgRateLimit(
       deps.sql,
+      c,
       'external:onedrive-list',
       c.get('orgId'),
     );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({ success: false, error: token.error });
@@ -155,11 +163,13 @@ export function createOneDriveRoutes(deps: {
       })
       .safeParse(await c.req.json().catch(() => null));
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    await checkOrganizationRateLimit(
+    const limited = await chargeOrgRateLimit(
       deps.sql,
+      c,
       'external:onedrive-list',
       c.get('orgId'),
     );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({ success: false, error: token.error });
@@ -183,11 +193,13 @@ export function createOneDriveRoutes(deps: {
       await c.req.json().catch(() => null),
     );
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    await checkOrganizationRateLimit(
+    const limited = await chargeOrgRateLimit(
       deps.sql,
+      c,
       'external:onedrive-read',
       c.get('orgId'),
     );
+    if (limited !== null) return limited;
     const token = await tokenFor(c);
     if (!token.success) {
       return c.json({

--- a/services/platform/backend/domains/onedrive/service.ts
+++ b/services/platform/backend/domains/onedrive/service.ts
@@ -711,7 +711,11 @@ export interface PgSyncImportDeps {
   findDocumentByExternalId: (args: {
     organizationId: string;
     externalItemId: string;
-  }) => Promise<{ _id: never; contentHash?: string } | null>;
+  }) => Promise<{
+    _id: never;
+    contentHash?: string;
+    metadata?: Record<string, unknown> | null;
+  } | null>;
   createDocument: (args: {
     organizationId: string;
     title: string;
@@ -752,6 +756,10 @@ export interface PgSyncImportDeps {
   ) => Promise<void>;
   linkDocumentToFile: (storageId: string, documentId: string) => Promise<void>;
   scheduleHubDocumentRagIndexing: (documentId: string) => Promise<void>;
+  bindDocumentToSync: (args: {
+    documentId: string;
+    metadata: Record<string, unknown>;
+  }) => Promise<void>;
   upsertSyncConfig: (
     target: {
       itemType: 'file' | 'folder';
@@ -792,8 +800,14 @@ export function createSyncImportDeps(
       // Deliberately NO lifecycle filter (0.4 contract): a trashed row with
       // the same external id must update in place, or the next sweep would
       // resurrect the document the user just trashed as a duplicate.
-      const rows = await sql<{ id: string; contentHash: string | null }[]>`
-        SELECT id, content_hash AS "contentHash" FROM app.documents
+      const rows = await sql<
+        {
+          id: string;
+          contentHash: string | null;
+          metadata: Record<string, unknown> | null;
+        }[]
+      >`
+        SELECT id, content_hash AS "contentHash", metadata FROM app.documents
         WHERE org_id = ${findArgs.organizationId}
           AND external_item_id = ${findArgs.externalItemId}
         ORDER BY created_at_ms ASC
@@ -805,6 +819,7 @@ export function createSyncImportDeps(
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- pg ids stand in for the reused pipeline's Convex Id<'documents'> brand
         _id: row.id as never,
         ...(row.contentHash !== null ? { contentHash: row.contentHash } : {}),
+        metadata: row.metadata,
       };
     },
     createDocument: async (createArgs) => {
@@ -973,6 +988,17 @@ export function createSyncImportDeps(
     },
     scheduleHubDocumentRagIndexing: async (documentId) => {
       await scheduleDocumentRagIndexing(sql, documentId);
+    },
+    // A metadata MERGE, never a replace: the document's content, hash, and
+    // every other key stay; only the sync binding lands.
+    bindDocumentToSync: async ({ documentId, metadata }) => {
+      await sql`
+        UPDATE app.documents SET
+          metadata = COALESCE(metadata, '{}'::jsonb)
+            || ${sql.json(toJson(metadata))}::jsonb,
+          updated_at_ms = ${Date.now()}
+        WHERE id = ${documentId} AND org_id = ${organizationId}
+      `;
     },
     upsertSyncConfig: async (target) =>
       upsertSyncConfigRow(sql, adapter.configTable, target),

--- a/services/platform/backend/domains/skills/errors.test.ts
+++ b/services/platform/backend/domains/skills/errors.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { AppError } from '../../../lib/shared/errors/app-error';
+import { SKILL_BUNDLE_REFUSAL_CODES } from '../../core/skills/bundle_zip.ts';
+import { SKILL_ERROR_STATUS, skillErrorResponse } from './errors.ts';
+
+/**
+ * The regression under test: the zip parser is "the authoritative check"
+ * for an uploaded bundle, yet three of its refusals (a missing SKILL.md, bad
+ * frontmatter, a per-file cap) had no entry in the route's code→status map
+ * and reached the client as a blank 500. The map is now built from the
+ * parser's own exported list, and every door speaks it.
+ */
+
+async function answer(error: unknown): Promise<Response> {
+  const app = new Hono();
+  app.onError(() => new Response('unmapped', { status: 500 }));
+  app.get('/', (c) => skillErrorResponse(c, error));
+  return await app.request('/');
+}
+
+describe('skill refusal → HTTP status', () => {
+  it('maps every refusal the zip parser can throw to a 4xx', () => {
+    expect(SKILL_BUNDLE_REFUSAL_CODES.length).toBeGreaterThan(0);
+    for (const code of SKILL_BUNDLE_REFUSAL_CODES) {
+      const status = SKILL_ERROR_STATUS[code];
+      expect(status, code).toBeGreaterThanOrEqual(400);
+      expect(status, code).toBeLessThan(500);
+    }
+  });
+
+  it('answers a SKILL.md-less bundle with 400 and the parser’s own words', async () => {
+    const res = await answer(
+      new AppError({
+        code: 'MISSING_SKILL_MD',
+        message: 'Bundle is missing SKILL.md at the root',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'MISSING_SKILL_MD',
+      message: 'Bundle is missing SKILL.md at the root',
+    });
+  });
+
+  it('keeps the file-layer statuses the doors already spoke', async () => {
+    const forbidden = await answer(
+      new AppError({ code: 'SKILL_FORBIDDEN', message: 'no' }),
+    );
+    const malformed = await answer(
+      new AppError({ code: 'SKILL_MALFORMED', message: 'broken' }),
+    );
+    expect(forbidden.status).toBe(403);
+    expect(malformed.status).toBe(422);
+  });
+
+  it('lets an unmapped code and a plain Error reach the app-level handler', async () => {
+    expect(
+      (await answer(new AppError({ code: 'SOMETHING_NEW', message: 'x' })))
+        .status,
+    ).toBe(500);
+    expect((await answer(new Error('disk on fire'))).status).toBe(500);
+  });
+});

--- a/services/platform/backend/domains/skills/errors.ts
+++ b/services/platform/backend/domains/skills/errors.ts
@@ -1,0 +1,38 @@
+import type { Context, Env } from 'hono';
+
+import { SKILL_BUNDLE_REFUSAL_CODES } from '../../core/skills/bundle_zip.ts';
+import {
+  appErrorResponse,
+  type CodedRefusalStatus,
+} from '../../lib/app-error-response.ts';
+
+/**
+ * HTTP status for every coded refusal the skill file layer and the
+ * bundle-upload lane can throw — ONE map for the app routes and the REST
+ * family, so a code mapped on one door cannot 500 on the other. The zip
+ * parser's refusals come straight from its own exported list: a bundle
+ * missing its SKILL.md, or one that lies about its size, is the uploader's
+ * mistake to read about, never an outage to page on.
+ */
+export const SKILL_ERROR_STATUS: Readonly<Record<string, CodedRefusalStatus>> =
+  {
+    INVALID_SKILL_SLUG: 400,
+    INVALID_SKILL: 400,
+    SKILL_PRIVATE_RETIRED: 400,
+    SKILL_FORBIDDEN: 403,
+    SKILL_MALFORMED: 422,
+    STORAGE_NOT_OWNED: 403,
+    STORAGE_NOT_FOUND: 404,
+    WRITE_FAILED: 400,
+    ...Object.fromEntries(
+      SKILL_BUNDLE_REFUSAL_CODES.map((code) => [code, 400 as const]),
+    ),
+  };
+
+/** `{ error, message }` with the mapped status; rethrows an unmapped error. */
+export function skillErrorResponse<E extends Env>(
+  c: Context<E>,
+  error: unknown,
+): Response {
+  return appErrorResponse(c, error, SKILL_ERROR_STATUS);
+}

--- a/services/platform/backend/domains/skills/routes.ts
+++ b/services/platform/backend/domains/skills/routes.ts
@@ -3,7 +3,6 @@ import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import { defineAbilityFor } from '../../../lib/permissions/ability.ts';
-import { AppError } from '../../../lib/shared/errors/app-error';
 import type { Auth } from '../../auth/auth.ts';
 import { getUserTeamIds } from '../../auth/membership.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
@@ -16,7 +15,9 @@ import {
   saveSkillForViewer,
 } from '../../core/skills/file_actions.ts';
 import { resolveOrgSlug } from '../../lib/org-config.ts';
+import { skillErrorResponse } from './errors.ts';
 import { uploadSkillBundlePg } from './upload.ts';
+import { withSkillWriterLock } from './writer-lock.ts';
 
 /**
  * /api/app/skills — the org's skill bundles, REUSING the 0.4 file layer
@@ -24,8 +25,9 @@ import { uploadSkillBundlePg } from './upload.ts';
  * files on the org config tree). Visibility (`org | team`), owner
  * adoption, and verify-before-write live in the reused functions; this
  * module authenticates, derives the viewer (teams + the orgSettings admin
- * capability), and maps error codes onto HTTP. The zip-upload lane rides a
- * later increment with the upload-intent flow.
+ * capability), and maps error codes onto HTTP through the map the REST
+ * family shares (`errors.ts`). The zip-upload lane rides the upload-intent
+ * flow (`upload.ts`).
  */
 
 const editSchema = z.object({
@@ -36,43 +38,6 @@ const editSchema = z.object({
   icon: z.string().max(100).optional(),
   labels: z.array(z.string().max(100)).max(50).optional(),
 });
-
-const ERROR_STATUS: Record<string, 400 | 403 | 404 | 422> = {
-  INVALID_SKILL_SLUG: 400,
-  INVALID_SKILL: 400,
-  SKILL_PRIVATE_RETIRED: 400,
-  SKILL_FORBIDDEN: 403,
-  SKILL_MALFORMED: 422,
-  STORAGE_NOT_OWNED: 403,
-  STORAGE_NOT_FOUND: 404,
-  BUNDLE_TOO_LARGE: 400,
-  INVALID_BUNDLE: 400,
-  WRITE_FAILED: 400,
-};
-
-function handleError<E extends OrgEnv>(
-  c: Context<E>,
-  error: unknown,
-): Response {
-  if (error instanceof AppError) {
-    const data: unknown = error.data;
-    if (data !== null && typeof data === 'object' && 'code' in data) {
-      const record = data as { code?: unknown; message?: unknown };
-      const code = typeof record.code === 'string' ? record.code : 'ERROR';
-      const status = ERROR_STATUS[code];
-      if (status !== undefined) {
-        return c.json(
-          {
-            error: code,
-            message: typeof record.message === 'string' ? record.message : code,
-          },
-          status,
-        );
-      }
-    }
-  }
-  throw error;
-}
 
 export function createSkillRoutes(deps: {
   sql: Sql;
@@ -114,7 +79,7 @@ export function createSkillRoutes(deps: {
       if (skill === null) return c.json({ error: 'skill not found' }, 404);
       return c.json({ skill });
     } catch (error) {
-      return handleError(c, error);
+      return skillErrorResponse(c, error);
     }
   });
 
@@ -128,7 +93,7 @@ export function createSkillRoutes(deps: {
       if (asset === null) return c.json({ error: 'asset not found' }, 404);
       return c.json({ asset });
     } catch (error) {
-      return handleError(c, error);
+      return skillErrorResponse(c, error);
     }
   });
 
@@ -138,14 +103,19 @@ export function createSkillRoutes(deps: {
       return c.json({ error: 'invalid body' }, 400);
     }
     try {
-      const skill = await saveSkillForViewer({
-        ...(await caller(c)),
-        slug: c.req.param('slug'),
-        ...body.data,
-      });
+      const who = await caller(c);
+      const slug = c.req.param('slug');
+      // Serialized with the upload lane on the per-slug writer lock: a save
+      // must never land between an upload's two swap renames.
+      const skill = await withSkillWriterLock(
+        deps.sql,
+        c.get('orgId'),
+        slug,
+        () => saveSkillForViewer({ ...who, slug, ...body.data }),
+      );
       return c.json({ skill });
     } catch (error) {
-      return handleError(c, error);
+      return skillErrorResponse(c, error);
     }
   });
 
@@ -170,19 +140,23 @@ export function createSkillRoutes(deps: {
         }),
       );
     } catch (error) {
-      return handleError(c, error);
+      return skillErrorResponse(c, error);
     }
   });
 
   app.delete('/:slug', async (c) => {
     try {
-      const deleted = await deleteSkillForViewer({
-        ...(await caller(c)),
-        slug: c.req.param('slug'),
-      });
+      const who = await caller(c);
+      const slug = c.req.param('slug');
+      const deleted = await withSkillWriterLock(
+        deps.sql,
+        c.get('orgId'),
+        slug,
+        () => deleteSkillForViewer({ ...who, slug }),
+      );
       return c.json({ deleted });
     } catch (error) {
-      return handleError(c, error);
+      return skillErrorResponse(c, error);
     }
   });
 

--- a/services/platform/backend/domains/skills/upload.ts
+++ b/services/platform/backend/domains/skills/upload.ts
@@ -2,7 +2,7 @@ import type { Sql } from 'postgres';
 
 import { AppError } from '../../../lib/shared/errors/app-error';
 import { MAX_SKILL_BUNDLE_TOTAL_BYTES } from '../../../lib/shared/schemas/skills.ts';
-import { readOrgSkill } from '../../../lib/skills/listing.ts';
+import { readOrgSkill, type OrgSkill } from '../../../lib/skills/listing.ts';
 import { SkillParseError } from '../../../lib/skills/parse.ts';
 import {
   canEditSkill,
@@ -25,6 +25,7 @@ import {
 } from '../../core/skills/file_utils.ts';
 import { resolveObjectStore } from '../../lib/object-store.ts';
 import { consumeUploadIntent } from '../files/upload-intents.ts';
+import { withSkillWriterLock } from './writer-lock.ts';
 
 /**
  * The skill bundle-upload lane on pg — the 0.4
@@ -34,9 +35,9 @@ import { consumeUploadIntent } from '../files/upload-intents.ts';
  * the org-prefixed key alone proves tenancy, not ownership, because every
  * document blob in the org carries the same prefix and this lane DELETES
  * its staged blob on every path. The per-(org, slug) claim lock becomes a
- * pg advisory xact lock, and the parse/replace/write protocol
- * (needs_confirm, force + edit rights, owner adoption) is the reused
- * helpers verbatim.
+ * pg advisory xact lock (`writer-lock.ts`, shared with the editor's save and
+ * delete), and the parse/replace/write protocol (needs_confirm, force +
+ * edit rights, owner adoption) is the reused helpers verbatim.
  */
 export async function uploadSkillBundlePg(
   sql: Sql,
@@ -115,7 +116,7 @@ export async function uploadSkillBundlePg(
     });
   }
 
-  let existing = null;
+  let existing: OrgSkill | null = null;
   let existingUnreadable = false;
   try {
     existing = await readOrgSkill(
@@ -152,21 +153,23 @@ export async function uploadSkillBundlePg(
     }
   }
 
-  // Per-(org, slug) writer mutex — the 0.4 claim-slot table collapses into
-  // one advisory xact lock (rule 5).
+  // The owner and sharing rules the editor applies, decided BEFORE the lock
+  // so a refusal never holds it. An unreadable existing document counts as
+  // no bundle: there is nothing left to preserve.
+  let files: ReturnType<typeof normalizedBundleFiles>;
   try {
-    await sql.begin(async (tx) => {
-      await tx`
-        SELECT pg_advisory_xact_lock(
-          hashtext(${`skill:${args.organizationId}:${parsed.slug}`})
-        )
-      `;
-      await writeSkillBundleFiles(
-        args.orgSlug,
-        parsed.slug,
-        normalizedBundleFiles(parsed, args.viewer),
-      );
-    });
+    files = normalizedBundleFiles(parsed, args.viewer, existing);
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+
+  // Per-(org, slug) writer mutex — the one every skill writer holds, so the
+  // editor's save and delete cannot land between this swap's two renames.
+  try {
+    await withSkillWriterLock(sql, args.organizationId, parsed.slug, () =>
+      writeSkillBundleFiles(args.orgSlug, parsed.slug, files),
+    );
   } catch (err) {
     if (err instanceof AppError) throw err;
     throw new AppError({

--- a/services/platform/backend/domains/skills/writer-lock.test.ts
+++ b/services/platform/backend/domains/skills/writer-lock.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+
+import type { Sql } from 'postgres';
+import { describe, expect, it } from 'vitest';
+
+import { skillWriterLockKey, withSkillWriterLock } from './writer-lock.ts';
+
+/**
+ * The regression under test: `writeSkillBundleFiles` documents that callers
+ * serialize writers per (org, slug), but only the upload lane took the
+ * advisory lock — the editor's save and delete wrote unlocked, so a save
+ * landing between an upload's aside-rename and commit-rename stranded the
+ * previous bundle. Every door now goes through this one helper; the tests
+ * pin the key and the protocol (lock first, inside one transaction).
+ */
+
+interface Recorded {
+  text: string;
+  values: unknown[];
+}
+
+/** A `sql` double whose `begin` hands the callback a recording tag. */
+function fakeSql(): { sql: Sql; statements: Recorded[]; events: string[] } {
+  const statements: Recorded[] = [];
+  const events: string[] = [];
+  const tx = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    statements.push({
+      text: strings.join('?').replace(/\s+/g, ' ').trim(),
+      values,
+    });
+    events.push('lock');
+    return Promise.resolve([]);
+  };
+  const begin = async (
+    callback: (tx: unknown) => Promise<unknown>,
+  ): Promise<unknown> => {
+    events.push('begin');
+    try {
+      const out = await callback(tx);
+      events.push('commit');
+      return out;
+    } catch (error) {
+      events.push('rollback');
+      throw error;
+    }
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double
+  return { sql: { begin } as unknown as Sql, statements, events };
+}
+
+describe('withSkillWriterLock', () => {
+  it('keys the lock exactly as the upload lane always did', () => {
+    expect(skillWriterLockKey('org-1', 'house-voice')).toBe(
+      'skill:org-1:house-voice',
+    );
+  });
+
+  it('takes the advisory lock before the work runs, inside one transaction', async () => {
+    const { sql, statements, events } = fakeSql();
+
+    const result = await withSkillWriterLock(
+      sql,
+      'org-1',
+      'house-voice',
+      async () => {
+        events.push('work');
+        return 'written';
+      },
+    );
+
+    expect(result).toBe('written');
+    expect(events).toEqual(['begin', 'lock', 'work', 'commit']);
+    expect(statements[0]?.text).toMatch(
+      /^SELECT pg_advisory_xact_lock\(\s*hashtext\(\?\)\s*\)$/,
+    );
+    expect(statements[0]?.values).toEqual(['skill:org-1:house-voice']);
+  });
+
+  it('rolls the transaction back and rethrows when the work fails', async () => {
+    const { sql, events } = fakeSql();
+
+    await expect(
+      withSkillWriterLock(sql, 'org-1', 'house-voice', async () => {
+        throw new Error('disk on fire');
+      }),
+    ).rejects.toThrow('disk on fire');
+    expect(events).toEqual(['begin', 'lock', 'rollback']);
+  });
+});

--- a/services/platform/backend/domains/skills/writer-lock.ts
+++ b/services/platform/backend/domains/skills/writer-lock.ts
@@ -1,0 +1,46 @@
+import type { Sql } from 'postgres';
+
+/**
+ * The per-(org, slug) writer mutex every skill write holds — the 0.4
+ * claim-slot table collapsed into one pg advisory xact lock.
+ *
+ * The bundle swap in `writeSkillBundleFiles` is atomic only while writers to
+ * one slug are serialized: a save landing between its aside-rename and its
+ * commit-rename recreates the bundle directory, so the commit fails, the
+ * rollback fails too, and the previous bundle is stranded invisible in a
+ * `.replacing-*` sibling while the visible one holds just the editor's
+ * SKILL.md. The upload lane always took this lock; the editor's save and
+ * delete — the app route and the REST family alike — take the SAME one, so
+ * no door can slip between another's two renames.
+ *
+ * The lock lives for the transaction, which is open only for `work`: the
+ * filesystem write happens inside it and the lock releases on commit or
+ * rollback either way. Every api replica shares the database, which is what
+ * makes this serialize across replicas where an in-process mutex could not.
+ */
+export function skillWriterLockKey(
+  organizationId: string,
+  slug: string,
+): string {
+  return `skill:${organizationId}:${slug}`;
+}
+
+export async function withSkillWriterLock<T>(
+  sql: Sql,
+  organizationId: string,
+  slug: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  // Assigned inside the callback: postgres.js types `begin`'s result through
+  // an array-unwrapping conditional a generic `T` cannot collapse.
+  let result!: T;
+  await sql.begin(async (tx) => {
+    await tx`
+      SELECT pg_advisory_xact_lock(
+        hashtext(${skillWriterLockKey(organizationId, slug)})
+      )
+    `;
+    result = await work();
+  });
+  return result;
+}

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -10627,6 +10627,48 @@ async function checkRestResources(
       searchOk,
     `bulk=${bulk.success ? `${bulk.data.success}/${bulk.data.failed} ${bulk.data.errors[0]?.errorCode ?? ''}` : 'ERR'} (want 2/1 duplicate_email), docListed=${docListed.success && docListed.data.page.some((d) => d.id === docId)}, entryListed=${entryList.success ? `${entryList.data.page.some((e) => e.id === newEntryId)}/${!entryList.data.page.some((e) => e.id === entryId)}` : 'ERR'}, skillsListed=${skillsListed.success}, skillRead=${skillReadBody.success}, doc=${docCreated.success}/${docPatch.status}/${docRead.success ? docRead.data.content : 'ERR'}/retry=${retry.success ? retry.data.status : 'ERR'}/del=${docDeleted.status}→${docGone.status}, entry chain=${entryCreated.success}/dup=${entryDup.status}/new≠old=${newEntryId !== entryId}/old=${oldEntry.success ? oldEntry.data.status : 'ERR'}/del=${entryDeleted.status}, skill=${skillSaved.success}/${skillRead.status}/del=${skillDeleted.status}→${skillGone.status}, chat: ${chatDetail}, search: ${searchDetail}`,
   );
+
+  // Agents: a refusal is the 4xx it is, never a 500 — an invalid slug 400,
+  // someone else's private agent 403, a malformed file 422, and deleting an
+  // absent agent 404 (the deletion semantics the API reference documents,
+  // which the skills family already answered).
+  const agentsDir = path.join(
+    process.env.TALE_CONFIG_DIR ?? '',
+    orgSlug,
+    'agents',
+  );
+  await mkdir(agentsDir, { recursive: true });
+  const privateAgentFile = path.join(agentsDir, 'itest-private-agent.yml');
+  const brokenAgentFile = path.join(agentsDir, 'itest-broken-agent.yml');
+  await writeFile(
+    privateAgentFile,
+    'name: itest-private-agent\ndisplay-name: Private\ndescription: Someone else’s persona.\nvisibility: private\nowner: user_someone_else\ninstructions: Keep quiet.\n',
+    'utf8',
+  );
+  await writeFile(
+    brokenAgentFile,
+    'name: itest-broken-agent\ncolour: blue\n',
+    'utf8',
+  );
+  const agentBadSlug = await v1('/agents/Not_A_Slug');
+  const agentForbidden = await v1('/agents/itest-private-agent', {
+    method: 'PUT',
+    body: { displayName: 'Hijacked' },
+  });
+  const agentMalformed = await v1('/agents/itest-broken-agent');
+  const agentAbsentDelete = await v1('/agents/itest-absent-agent', {
+    method: 'DELETE',
+  });
+  await rm(privateAgentFile, { force: true });
+  await rm(brokenAgentFile, { force: true });
+  record(
+    'REST resources: agent refusals map to 400/403/422/404, never 500',
+    agentBadSlug.status === 400 &&
+      agentForbidden.status === 403 &&
+      agentMalformed.status === 422 &&
+      agentAbsentDelete.status === 404,
+    `badSlug=${agentBadSlug.status} (want 400), forbidden=${agentForbidden.status} (want 403), malformed=${agentMalformed.status} (want 422), absentDelete=${agentAbsentDelete.status} (want 404)`,
+  );
 }
 
 /** Mint an API key for the session user through the same surface the
@@ -21279,6 +21321,120 @@ async function checkOneDriveSync(
       `created=${tmpCreated}, heldSurvives=${tmpHeld} run=${heldRunStatus} (prune skipped, not failed), prunedAfterRelease=${tmpAfterRelease}`,
     );
 
+    // 4b. Re-import keeps the sync binding. A one-time re-import of a file
+    //     the folder config owns must not detach it (the config keeps
+    //     updating AND pruning it), and a "Sync import" over a file an
+    //     earlier one-time import brought in adopts it even when its content
+    //     is unchanged — both used to leave stale mirrors nothing pruned.
+    const syncBindingOf = async (
+      externalId: string,
+    ): Promise<{
+      sourceMode: string | null;
+      syncConfigId: string | null;
+    } | null> => {
+      const rows = await sql<
+        { sourceMode: string | null; syncConfigId: string | null }[]
+      >`
+        SELECT metadata->>'sourceMode' AS "sourceMode",
+               metadata->>'syncConfigId' AS "syncConfigId"
+        FROM app.documents
+        WHERE org_id = ${orgId} AND external_item_id = ${externalId}
+        LIMIT 1
+      `;
+      return rows[0] ?? null;
+    };
+    seed({
+      id: 'f-bind',
+      name: 'bind.txt',
+      parent: 'folder-reports',
+      content: 'bind v1',
+      hash: 'h-bind-v1',
+      mime: 'text/plain',
+    });
+    await runConfig(folderConfig.id);
+    const bindAfterSync = await docsByExternalId('f-bind');
+    seed({
+      id: 'f-bind',
+      name: 'bind.txt',
+      parent: 'folder-reports',
+      content: 'bind v2 body',
+      hash: 'h-bind-v2',
+      mime: 'text/plain',
+    });
+    const bindReimport = importResultSchema.safeParse(
+      await (
+        await post('/import', {
+          importType: 'one-time',
+          items: [
+            {
+              id: 'f-bind',
+              name: 'bind.txt',
+              size: 12,
+              relativePath: 'ODReports/bind.txt',
+            },
+          ],
+        })
+      ).json(),
+    );
+    await muteRagJobs();
+    const bindAfterReimport = await syncBindingOf('f-bind');
+    drive.delete('f-bind');
+    await runConfig(folderConfig.id);
+    const bindPruned = (await docsByExternalId('f-bind')).length === 0;
+
+    seed({
+      id: 'f-adopt',
+      name: 'adopt.md',
+      content: 'adopt v1',
+      hash: 'h-adopt-v1',
+      mime: 'text/markdown',
+    });
+    const adoptItem = {
+      id: 'f-adopt',
+      name: 'adopt.md',
+      size: 8,
+      relativePath: 'adopt.md',
+      isDirectlySelected: true,
+    };
+    const adoptOneTime = importResultSchema.safeParse(
+      await (
+        await post('/import', { importType: 'one-time', items: [adoptItem] })
+      ).json(),
+    );
+    const adoptBefore = await syncBindingOf('f-adopt');
+    const adoptSync = importResultSchema.safeParse(
+      await (
+        await post('/import', { importType: 'sync', items: [adoptItem] })
+      ).json(),
+    );
+    await muteRagJobs();
+    const adoptConfig = await configByItem('f-adopt');
+    const adoptAfter = await syncBindingOf('f-adopt');
+    // Leave the folder config as the only syncable one for the scan below.
+    if (adoptConfig !== null) {
+      await post(`/sync-configs/${adoptConfig.id}/cancel`, {});
+    }
+    record(
+      'onedrive re-import keeps the sync binding; sync import adopts a one-time doc',
+      bindAfterSync.length === 1 &&
+        bindAfterSync[0]?.syncConfigId === folderConfig.id &&
+        bindReimport.success &&
+        bindReimport.data.successCount === 1 &&
+        bindAfterReimport?.sourceMode === 'auto' &&
+        bindAfterReimport.syncConfigId === folderConfig.id &&
+        bindPruned &&
+        adoptOneTime.success &&
+        adoptOneTime.data.successCount === 1 &&
+        adoptBefore?.sourceMode === 'manual' &&
+        adoptBefore.syncConfigId === null &&
+        adoptSync.success &&
+        adoptSync.data.skippedCount === 1 &&
+        adoptConfig !== null &&
+        adoptAfter?.sourceMode === 'auto' &&
+        adoptAfter.syncConfigId === adoptConfig.id,
+      `bind: synced=${bindAfterSync.length === 1 && bindAfterSync[0]?.syncConfigId === folderConfig.id} reimport=${bindReimport.success ? bindReimport.data.successCount : 'ERR'}/1 → ${bindAfterReimport?.sourceMode}/${bindAfterReimport?.syncConfigId === folderConfig.id ? 'cfg' : String(bindAfterReimport?.syncConfigId)} (want auto/cfg) pruned=${bindPruned}; adopt: oneTime=${adoptOneTime.success ? adoptOneTime.data.successCount : 'ERR'}/1 before=${adoptBefore?.sourceMode}/${adoptBefore?.syncConfigId} sync=${adoptSync.success ? `${adoptSync.data.skippedCount}skipped` : 'ERR'} after=${adoptAfter?.sourceMode}/${adoptAfter?.syncConfigId === adoptConfig?.id ? 'cfg' : String(adoptAfter?.syncConfigId)} (want auto/cfg)`,
+    );
+
     // 5. Single-file config: content change updates the ONE row in place; a
     //    definitive 404 at the source removes the mirror and deactivates.
     seed({
@@ -22577,31 +22733,38 @@ async function checkTranscription(
       : 0;
   const whisperBase = `http://127.0.0.1:${whisperPort}/v1`;
 
-  // A real WAV (16-bit PCM mono 8 kHz, 0.6 s of 440 Hz sine) so ffmpeg's
-  // compress pass has genuine audio — silence-strip must not eat it.
-  const sampleRate = 8000;
-  const seconds = 0.6;
-  const sampleCount = Math.floor(sampleRate * seconds);
-  const wav = Buffer.alloc(44 + sampleCount * 2);
-  wav.write('RIFF', 0);
-  wav.writeUInt32LE(36 + sampleCount * 2, 4);
-  wav.write('WAVE', 8);
-  wav.write('fmt ', 12);
-  wav.writeUInt32LE(16, 16);
-  wav.writeUInt16LE(1, 20);
-  wav.writeUInt16LE(1, 22);
-  wav.writeUInt32LE(sampleRate, 24);
-  wav.writeUInt32LE(sampleRate * 2, 28);
-  wav.writeUInt16LE(2, 32);
-  wav.writeUInt16LE(16, 34);
-  wav.write('data', 36);
-  wav.writeUInt32LE(sampleCount * 2, 40);
-  for (let i = 0; i < sampleCount; i++) {
-    const sample = Math.round(
-      Math.sin((2 * Math.PI * 440 * i) / sampleRate) * 12_000,
-    );
-    wav.writeInt16LE(sample, 44 + i * 2);
-  }
+  // A real WAV (16-bit PCM mono 8 kHz, 0.6 s of a sine) so ffmpeg's compress
+  // pass has genuine audio — silence-strip must not eat it. Two pitches, so
+  // a probe that needs DIFFERENT bytes (a real provider round-trip) does not
+  // collide with the content-hash dedup the identical-bytes probe asserts.
+  const synthWav = (frequencyHz: number): Buffer => {
+    const sampleRate = 8000;
+    const seconds = 0.6;
+    const sampleCount = Math.floor(sampleRate * seconds);
+    const buffer = Buffer.alloc(44 + sampleCount * 2);
+    buffer.write('RIFF', 0);
+    buffer.writeUInt32LE(36 + sampleCount * 2, 4);
+    buffer.write('WAVE', 8);
+    buffer.write('fmt ', 12);
+    buffer.writeUInt32LE(16, 16);
+    buffer.writeUInt16LE(1, 20);
+    buffer.writeUInt16LE(1, 22);
+    buffer.writeUInt32LE(sampleRate, 24);
+    buffer.writeUInt32LE(sampleRate * 2, 28);
+    buffer.writeUInt16LE(2, 32);
+    buffer.writeUInt16LE(16, 34);
+    buffer.write('data', 36);
+    buffer.writeUInt32LE(sampleCount * 2, 40);
+    for (let i = 0; i < sampleCount; i++) {
+      const sample = Math.round(
+        Math.sin((2 * Math.PI * frequencyHz * i) / sampleRate) * 12_000,
+      );
+      buffer.writeInt16LE(sample, 44 + i * 2);
+    }
+    return buffer;
+  };
+  const wav = synthWav(440);
+  const wavAlt = synthWav(880);
 
   try {
     const send = (route: string, body?: unknown): Promise<Response> =>
@@ -22622,14 +22785,14 @@ async function checkTranscription(
       throw new Error('transcription check: no default openai credential');
     }
 
-    const uploadAudio = async (): Promise<string> => {
+    const uploadAudio = async (bytes: Buffer = wav): Promise<string> => {
       const handoff = z
         .object({ storageRef: z.string(), uploadUrl: z.string() })
         .safeParse(
           await (
             await send(`/api/app/files/upload-handoff?orgId=${orgId}`, {
               contentType: 'audio/wav',
-              size: wav.length,
+              size: bytes.length,
             })
           ).json(),
         );
@@ -22638,7 +22801,7 @@ async function checkTranscription(
         method: 'PUT',
         headers: { 'content-type': 'audio/wav' },
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Buffer is a valid BodyInit at runtime
-        body: wav as never,
+        body: bytes as never,
       });
       if (!put.ok) throw new Error(`audio PUT failed: ${put.status}`);
       const registered = await send(`/api/app/files/register?orgId=${orgId}`, {
@@ -22712,10 +22875,44 @@ async function checkTranscription(
       `queued=${queuedRow?.status} drained=${drained} done=${doneRow?.status} transcriptOk=${(doneRow?.transcript ?? '').includes('Second sentence here.')} duration=${doneRow?.duration} calls=${whisperCalls}/1 ledgerSec=${ledger[0]?.seconds}`,
     );
 
+    // 1b. The same bytes uploaded again — a second blob, a second row — reuse
+    //     the completed transcript: no ffmpeg pass, no provider call, no
+    //     ledger minutes. The engine hashes what it reads and stamps
+    //     content_hash, so the next identical upload finds the first.
+    const ledgerBeforeDup = ledger[0]?.seconds ?? 0;
+    const dupRef = await uploadAudio();
+    await drainTranscribe();
+    const dupRow = await rowFor(dupRef);
+    const hashes = await sql<{ hash: string | null }[]>`
+      SELECT content_hash AS hash FROM app.file_metadata
+      WHERE org_id = ${orgId} AND storage_ref IN (${firstRef}, ${dupRef})
+    `;
+    const ledgerAfterDup = await sql<{ seconds: number | null }[]>`
+      SELECT audio_duration_sec::float8 AS seconds
+      FROM app.usage_ledger
+      WHERE org_id = ${orgId} AND agent_slug = '__transcription__'
+        AND granularity = 'daily'
+      LIMIT 1
+    `;
+    record(
+      'transcription dedup: identical bytes reuse the completed transcript',
+      dupRow?.status === 'completed' &&
+        dupRow.transcript === doneRow?.transcript &&
+        dupRow.duration === doneRow?.duration &&
+        whisperCalls === 1 &&
+        hashes.length === 2 &&
+        hashes[0]?.hash !== null &&
+        hashes[0]?.hash === hashes[1]?.hash &&
+        (ledgerAfterDup[0]?.seconds ?? 0) === ledgerBeforeDup,
+      `dup=${dupRow?.status} sameTranscript=${dupRow?.transcript === doneRow?.transcript} calls=${whisperCalls}/1 hashes=${hashes.map((h) => (h.hash ?? 'null').slice(0, 8)).join('=')} ledger=${ledgerAfterDup[0]?.seconds}/${ledgerBeforeDup} (unchanged)`,
+    );
+
     // 2. A permanent 400 fails fast (no 30s retry chain), the error lands
-    //    sanitized (the sk- token redacted); the retry door re-queues.
+    //    sanitized (the sk- token redacted); the retry door re-queues. Other
+    //    bytes than step 1's, or the dedup above would answer before the
+    //    provider is ever asked.
     failNextWith = 400;
-    const secondRef = await uploadAudio();
+    const secondRef = await uploadAudio(wavAlt);
     await drainTranscribe();
     const failedRow = await rowFor(secondRef);
     const retry = await send(
@@ -22927,7 +23124,12 @@ VTT
   exit 0
 fi
 if [[ "$*" == *" -x "* || "\${args[0]}" == "-x" ]]; then
-  /usr/bin/ffmpeg -hide_banner -loglevel error -f lavfi -i sine=frequency=440:duration=2 -b:a 32k "$home_dir/whis1.mp3"
+  # Distinct audio per video: the transcription lane reuses a completed
+  # transcript for identical bytes within an org, and whis2's injected
+  # provider failure must actually reach the provider.
+  freq=440
+  case "$vid" in whis2) freq=660;; esac
+  /usr/bin/ffmpeg -hide_banner -loglevel error -f lavfi -i "sine=frequency=$freq:duration=2" -b:a 32k "$home_dir/whis1.mp3"
   exit 0
 fi
 echo "ERROR: itest fake yt-dlp got unexpected args: $*" >&2
@@ -32719,6 +32921,70 @@ async function checkAutomationsSurface(
 }
 
 /**
+ * A spent drive-picker budget is a 429 with Retry-After on BOTH providers.
+ * OneDrive used to let RateLimitExceededError escape as a 500 (plus a
+ * Sentry page), and Google Drive had no limiter at all. The org bucket is
+ * drained by hand (value 0, refilled from now) and restored afterwards so
+ * later probes keep their budget.
+ */
+async function checkDrivePickerRateLimit(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string },
+): Promise<void> {
+  const { cookie, orgId } = ctx;
+  const rules = ['external:onedrive-list', 'external:google-drive-list'];
+  // The org bucket's key, exactly as `checkOrganizationRateLimit` charges it.
+  const bucketKey = `org:${orgId}`;
+  const now = Date.now();
+  // A deep deficit, not an empty bucket: both lanes refill one token every
+  // 600 ms, so a balance of zero would admit the very next request.
+  for (const rule of rules) {
+    await sql`
+      INSERT INTO app.rate_limits (name, key, value, ts)
+      VALUES (${rule}, ${bucketKey}, -600, ${now})
+      ON CONFLICT (name, key) DO UPDATE SET value = -600, ts = ${now}
+    `;
+  }
+  const listFiles = (
+    provider: 'onedrive' | 'google-drive',
+  ): Promise<Response> =>
+    fetch(`${base}/api/app/${provider}/list-files?orgId=${orgId}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: '{}',
+    });
+  const codeOf = async (res: Response): Promise<string> => {
+    const parsed = z
+      .object({ error: z.string() })
+      .safeParse(await res.json().catch(() => null));
+    return parsed.success ? parsed.data.error : 'no-json';
+  };
+  try {
+    const onedrive = await listFiles('onedrive');
+    const onedriveCode = await codeOf(onedrive);
+    const google = await listFiles('google-drive');
+    const googleCode = await codeOf(google);
+    record(
+      'drive pickers: a spent budget answers 429 with Retry-After on both providers',
+      onedrive.status === 429 &&
+        onedriveCode === 'RATE_LIMITED' &&
+        onedrive.headers.get('retry-after') !== null &&
+        google.status === 429 &&
+        googleCode === 'RATE_LIMITED' &&
+        google.headers.get('retry-after') !== null,
+      `onedrive=${onedrive.status}/${onedriveCode}/retry-after=${onedrive.headers.get('retry-after') ?? 'none'} (want 429/RATE_LIMITED/header), google=${google.status}/${googleCode}/retry-after=${google.headers.get('retry-after') ?? 'none'} (want 429/RATE_LIMITED/header)`,
+    );
+  } finally {
+    for (const rule of rules) {
+      await sql`
+        DELETE FROM app.rate_limits WHERE name = ${rule} AND key = ${bucketKey}
+      `;
+    }
+  }
+}
+
+/**
  * Inc-95 library surface: the skill BUNDLE-UPLOAD lane on pg — a zip staged
  * through the org byte lane installs a new slug, a repeat answers
  * needs_confirm (nothing written), and force replaces; a foreign/garbage
@@ -32738,9 +33004,13 @@ async function checkLibrarySurface(
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
   const { default: JSZip } = await import('jszip');
-  const stageZip = async (body: string): Promise<string> => {
+  const stageZipFiles = async (
+    files: Record<string, string>,
+  ): Promise<string> => {
     const zip = new JSZip();
-    zip.file('SKILL.md', body);
+    for (const [name, content] of Object.entries(files)) {
+      zip.file(name, content);
+    }
     const blob = await zip.generateAsync({ type: 'blob' });
     // Staged FOR the skill lane (the upload intent's purpose).
     const res = await fetch(
@@ -32755,6 +33025,22 @@ async function checkLibrarySurface(
       .object({ storageId: z.string() })
       .safeParse(await res.json());
     return parsed.success ? parsed.data.storageId : '';
+  };
+  const stageZip = (body: string): Promise<string> =>
+    stageZipFiles({ 'SKILL.md': body });
+  /** A refusal's `{ error, message }`, or null for a body that is not JSON
+   * (a 500 answers plain text — the very shape these probes rule out). */
+  const refusalOf = async (
+    res: Response,
+  ): Promise<{ error: string; message: string } | null> => {
+    try {
+      const parsed = z
+        .object({ error: z.string(), message: z.string().default('') })
+        .safeParse(await res.json());
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
   };
   const skillMd = (description: string): string =>
     `---\nname: itest-bundle-skill\ndescription: ${description}\n---\n\nAudit steps v1.`;
@@ -32821,6 +33107,220 @@ async function checkLibrarySurface(
       foreign.status === 403 &&
       garbage.status === 403,
     `first=${first.success ? first.data.slug : 'ERR'}, repeat=${repeat.success ? repeat.data.status : 'ERR'}, forced=${forced.success}, disk=${replacedOnDisk}, foreign=${foreign.status} (want 403), garbage=${garbage.status} (want 403)`,
+  );
+
+  // The zip parser is the authoritative check, and its refusals must reach
+  // the uploader as the 4xx that says what to fix — a zip without SKILL.md
+  // and one whose frontmatter fails to parse both used to fall through the
+  // route's code map as blank 500s.
+  const noSkillMd = await post(`/api/app/skills/upload?orgId=${orgId}`, {
+    storageId: await stageZipFiles({ 'README.md': 'No SKILL.md in here.' }),
+  });
+  const noSkillMdRefusal = await refusalOf(noSkillMd);
+  const badFrontmatter = await post(`/api/app/skills/upload?orgId=${orgId}`, {
+    storageId: await stageZip(
+      '---\nname: itest-bad-frontmatter\n---\n\nNo description at all.',
+    ),
+  });
+  const badFrontmatterRefusal = await refusalOf(badFrontmatter);
+  record(
+    'library surface: zip refusals answer 400 with the parser’s reason',
+    noSkillMd.status === 400 &&
+      noSkillMdRefusal?.error === 'MISSING_SKILL_MD' &&
+      noSkillMdRefusal.message.includes('SKILL.md') &&
+      badFrontmatter.status === 400 &&
+      badFrontmatterRefusal?.error === 'INVALID_SKILL_MD',
+    `noSkillMd=${noSkillMd.status}/${noSkillMdRefusal?.error ?? 'no-json'} (want 400/MISSING_SKILL_MD), badFrontmatter=${badFrontmatter.status}/${badFrontmatterRefusal?.error ?? 'no-json'} (want 400/INVALID_SKILL_MD)`,
+  );
+
+  // A bundle nobody can parse must still be deletable: the library shows it
+  // as a failure row, and removing it is the only in-product repair (delete
+  // used to load the document first and answer 422). Same for a malformed
+  // agent file, which has no upload lane to replace it through at all.
+  const configDir = process.env.TALE_CONFIG_DIR ?? '';
+  const brokenSkillDir = path.join(
+    configDir,
+    orgSlug,
+    'skills',
+    'itest-broken-skill',
+  );
+  await mkdir(brokenSkillDir, { recursive: true });
+  await writeFile(
+    path.join(brokenSkillDir, 'SKILL.md'),
+    '# no frontmatter\n',
+    'utf8',
+  );
+  const brokenAgentFile = path.join(
+    configDir,
+    orgSlug,
+    'agents',
+    'itest-broken-agent.yml',
+  );
+  await mkdir(path.dirname(brokenAgentFile), { recursive: true });
+  await writeFile(
+    brokenAgentFile,
+    'name: itest-broken-agent\ncolour: blue\n',
+    'utf8',
+  );
+  const del = (route: string): Promise<Response> =>
+    fetch(`${base}${route}`, {
+      method: 'DELETE',
+      headers: { cookie, origin: base },
+    });
+  const isGone = (file: string): Promise<boolean> =>
+    stat(file).then(
+      () => false,
+      () => true,
+    );
+  const brokenSkillDeleted = await del(
+    `/api/app/skills/itest-broken-skill?orgId=${orgId}`,
+  );
+  const brokenSkillGone = await isGone(brokenSkillDir);
+  const brokenAgentDeleted = await del(
+    `/api/app/agents/itest-broken-agent?orgId=${orgId}`,
+  );
+  const brokenAgentGone = await isGone(brokenAgentFile);
+  record(
+    'library surface: an admin deletes a malformed skill and agent',
+    brokenSkillDeleted.status === 200 &&
+      brokenSkillGone &&
+      brokenAgentDeleted.status === 200 &&
+      brokenAgentGone,
+    `skill=${brokenSkillDeleted.status} gone=${brokenSkillGone} (want 200/true), agent=${brokenAgentDeleted.status} gone=${brokenAgentGone} (want 200/true)`,
+  );
+
+  // The upload door applies the editor's rules: `private` is retired for a
+  // new bundle (the docs promise the refusal), and a declared owner is never
+  // honored — the uploader is attributed, exactly as a save would.
+  const privateUpload = await post(`/api/app/skills/upload?orgId=${orgId}`, {
+    storageId: await stageZip(
+      `---\nname: itest-private-upload\ndescription: Mine alone.\nvisibility: private\nowner: ${ctx.userId}\n---\n\nBody.`,
+    ),
+  });
+  const privateRefusal = await refusalOf(privateUpload);
+  const foreignOwnerUpload = z.object({ ok: z.literal(true) }).safeParse(
+    await (
+      await post(`/api/app/skills/upload?orgId=${orgId}`, {
+        storageId: await stageZip(
+          '---\nname: itest-owner-upload\ndescription: Attributed elsewhere.\nowner: user_someone_else\n---\n\nBody.',
+        ),
+      })
+    )
+      .json()
+      .catch(() => null),
+  );
+  const ownerRead = z
+    .object({ skill: z.looseObject({ owner: z.string().optional() }) })
+    .safeParse(
+      await (
+        await fetch(
+          `${base}/api/app/skills/itest-owner-upload?orgId=${orgId}`,
+          {
+            headers: { cookie, origin: base },
+          },
+        )
+      )
+        .json()
+        .catch(() => null),
+    );
+  record(
+    'library surface: upload applies the editor’s owner and sharing rules',
+    privateUpload.status === 400 &&
+      privateRefusal?.error === 'SKILL_PRIVATE_RETIRED' &&
+      foreignOwnerUpload.success &&
+      ownerRead.success &&
+      ownerRead.data.skill.owner === ctx.userId,
+    `private=${privateUpload.status}/${privateRefusal?.error ?? 'no-json'} (want 400/SKILL_PRIVATE_RETIRED), foreignOwner=${foreignOwnerUpload.success} owner=${ownerRead.success ? ownerRead.data.skill.owner : 'ERR'} (want ${ctx.userId})`,
+  );
+
+  // The editor's save and delete hold the per-slug writer lock the upload
+  // lane takes (the bundle swap is atomic only while writers to one slug are
+  // serialized). With the lock held by another transaction, a PUT and a
+  // DELETE must wait and land only once it is released — they used to write
+  // straight through.
+  const lockKey = `skill:${orgId}:itest-bundle-skill`;
+  const holdLock = (): {
+    held: Promise<void>;
+    release: () => void;
+    done: Promise<void>;
+  } => {
+    let release = (): void => undefined;
+    let taken = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const held = new Promise<void>((resolve) => {
+      taken = resolve;
+    });
+    const done = sql
+      .begin(async (tx) => {
+        await tx`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
+        taken();
+        await gate;
+      })
+      .then(() => undefined);
+    return { held, release, done };
+  };
+  const bundleSkillMd = path.join(
+    configDir,
+    orgSlug,
+    'skills',
+    'itest-bundle-skill',
+    'SKILL.md',
+  );
+  const editedOnDisk = (): Promise<boolean> =>
+    readFile(bundleSkillMd, 'utf8').then(
+      (content) => content.includes('Edited while locked.'),
+      () => false,
+    );
+  const raceLock = (
+    request: Promise<Response>,
+  ): Promise<'waiting' | `landed:${number}`> =>
+    Promise.race([
+      request.then((res) => `landed:${res.status}` as const),
+      sleep(750).then(() => 'waiting' as const),
+    ]);
+
+  const saveLock = holdLock();
+  await saveLock.held;
+  const lockedPut = fetch(
+    `${base}/api/app/skills/itest-bundle-skill?orgId=${orgId}`,
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: JSON.stringify({
+        description: 'Locked edit.',
+        body: 'Edited while locked.',
+      }),
+    },
+  );
+  const putWhileLocked = await raceLock(lockedPut);
+  const diskWhileLocked = await editedOnDisk();
+  saveLock.release();
+  await saveLock.done;
+  const putAfter = await lockedPut;
+  const diskAfter = await editedOnDisk();
+
+  const deleteLock = holdLock();
+  await deleteLock.held;
+  const lockedDelete = del(`/api/app/skills/itest-bundle-skill?orgId=${orgId}`);
+  const deleteWhileLocked = await raceLock(lockedDelete);
+  const dirWhileLocked = !(await isGone(path.dirname(bundleSkillMd)));
+  deleteLock.release();
+  await deleteLock.done;
+  const deleteAfter = await lockedDelete;
+  const dirAfter = await isGone(path.dirname(bundleSkillMd));
+  record(
+    'library surface: editor save and delete wait for the per-slug writer lock',
+    putWhileLocked === 'waiting' &&
+      !diskWhileLocked &&
+      putAfter.status === 200 &&
+      diskAfter &&
+      deleteWhileLocked === 'waiting' &&
+      dirWhileLocked &&
+      deleteAfter.status === 200 &&
+      dirAfter,
+    `put: ${putWhileLocked} disk=${diskWhileLocked} → ${putAfter.status} disk=${diskAfter} (want waiting/false → 200/true); delete: ${deleteWhileLocked} dir=${dirWhileLocked} → ${deleteAfter.status} gone=${dirAfter} (want waiting/true → 200/true)`,
   );
 }
 
@@ -37111,6 +37611,7 @@ async function main(): Promise<void> {
     await checkDataResidency(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkAutomationsSurface(sql, baseUrl, authCtx);
     await checkLibrarySurface(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
+    await checkDrivePickerRateLimit(sql, baseUrl, authCtx);
     await checkEngagementSurface(sql, baseUrl, authCtx);
     await checkMetricsSurface(sql, baseUrl, authCtx);
     await checkArenaAndQuestions(sql, baseUrl, authCtx);

--- a/services/platform/backend/lib/app-error-response.ts
+++ b/services/platform/backend/lib/app-error-response.ts
@@ -1,0 +1,45 @@
+import type { Context, Env } from 'hono';
+
+import { AppError } from '../../lib/shared/errors/app-error';
+
+/**
+ * The statuses a coded refusal may map onto. Every entry is a 4xx: the whole
+ * point of a code→status map is that a refusal the domain layer explains
+ * never reads as a server outage.
+ */
+export type CodedRefusalStatus = 400 | 403 | 404 | 409 | 422;
+
+/** The `{ code, message }` an `AppError` carries, or `null` for anything else. */
+export function codedAppError(
+  error: unknown,
+): { code: string; message: string } | null {
+  if (!(error instanceof AppError)) return null;
+  const data: unknown = error.data;
+  if (data === null || typeof data !== 'object' || !('code' in data)) {
+    return null;
+  }
+  const code: unknown = Reflect.get(data, 'code');
+  if (typeof code !== 'string') return null;
+  const message: unknown = Reflect.get(data, 'message');
+  return { code, message: typeof message === 'string' ? message : code };
+}
+
+/**
+ * Answer a coded `AppError` with the status its code maps to, as
+ * `{ error: <code>, message }` — the shape every file-layer door (agents,
+ * skills, app and REST alike) speaks. Anything else — an unmapped code, a
+ * plain Error — is rethrown for the app-level handler, which reports it as
+ * the defect it is. A code the domain layer can throw but the map does not
+ * carry therefore surfaces as a 500: keep each family's map in ONE module
+ * and build it from the layer's own exported code lists where there are any.
+ */
+export function appErrorResponse<E extends Env>(
+  c: Context<E>,
+  error: unknown,
+  statusByCode: Readonly<Record<string, CodedRefusalStatus>>,
+): Response {
+  const coded = codedAppError(error);
+  const status = coded === null ? undefined : statusByCode[coded.code];
+  if (coded === null || status === undefined) throw error;
+  return c.json({ error: coded.code, message: coded.message }, status);
+}

--- a/services/platform/backend/lib/rate-limit-response.test.ts
+++ b/services/platform/backend/lib/rate-limit-response.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+
+import { Hono } from 'hono';
+import type { Sql } from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  chargeOrgRateLimit,
+  rateLimitedResponse,
+} from './rate-limit-response.ts';
+import { RateLimitExceededError } from './rate-limit.ts';
+
+vi.mock('./rate-limit.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./rate-limit.ts')>();
+  return {
+    ...actual,
+    checkOrganizationRateLimit: vi.fn(
+      async (_sql: unknown, rule: string): Promise<void> => {
+        if (rule === 'external:onedrive-list') {
+          throw new actual.RateLimitExceededError('spent', 1500);
+        }
+      },
+    ),
+  };
+});
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double; the charge is mocked
+const sql = {} as Sql;
+
+describe('rateLimitedResponse', () => {
+  it('answers 429 with the RATE_LIMITED code and a whole-second Retry-After', async () => {
+    const app = new Hono();
+    app.get('/', (c) =>
+      rateLimitedResponse(c, new RateLimitExceededError('spent', 1500)),
+    );
+    const res = await app.request('/');
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBe('2');
+    expect(await res.json()).toEqual({
+      error: 'RATE_LIMITED',
+      data: { retryAfterMs: 1500 },
+    });
+  });
+
+  it('never advertises a zero-second wait', async () => {
+    const app = new Hono();
+    app.get('/', (c) =>
+      rateLimitedResponse(c, new RateLimitExceededError('spent', 120)),
+    );
+    expect((await app.request('/')).headers.get('retry-after')).toBe('1');
+  });
+});
+
+describe('chargeOrgRateLimit', () => {
+  it('hands back the 429 when the budget is spent and null when it is not', async () => {
+    const app = new Hono();
+    app.get('/spent', async (c) => {
+      const limited = await chargeOrgRateLimit(
+        sql,
+        c,
+        'external:onedrive-list',
+        'org-1',
+      );
+      return limited ?? c.json({ ok: true });
+    });
+    app.get('/fresh', async (c) => {
+      const limited = await chargeOrgRateLimit(
+        sql,
+        c,
+        'external:google-drive-list',
+        'org-1',
+      );
+      return limited ?? c.json({ ok: true });
+    });
+    const spent = await app.request('/spent');
+    expect(spent.status).toBe(429);
+    expect(spent.headers.get('retry-after')).toBe('2');
+    expect((await app.request('/fresh')).status).toBe(200);
+  });
+});

--- a/services/platform/backend/lib/rate-limit-response.ts
+++ b/services/platform/backend/lib/rate-limit-response.ts
@@ -1,0 +1,48 @@
+import type { Context, Env } from 'hono';
+import type { Sql } from 'postgres';
+
+import {
+  checkOrganizationRateLimit,
+  RateLimitExceededError,
+  type RateLimitName,
+} from './rate-limit.ts';
+
+/**
+ * The 429 an app route answers when an org or user budget is spent: the
+ * `RATE_LIMITED` code plus `retryAfterMs` the surfaces read, and the
+ * standard `Retry-After` header (whole seconds, rounded up, never zero) for
+ * every generic client and proxy in between. One shape for every door, so a
+ * spent budget never reads as an outage.
+ */
+export function rateLimitedResponse<E extends Env>(
+  c: Context<E>,
+  error: RateLimitExceededError,
+): Response {
+  return c.json(
+    { error: 'RATE_LIMITED', data: { retryAfterMs: error.retryAfter } },
+    429,
+    { 'retry-after': String(Math.max(1, Math.ceil(error.retryAfter / 1000))) },
+  );
+}
+
+/**
+ * Charge an org-scoped rule and hand back the 429 to return when the budget
+ * is spent, `null` when the call may proceed — the REST door's `chargeLane`
+ * shape, so a route never has to wrap its whole body to map the refusal.
+ */
+export async function chargeOrgRateLimit<E extends Env>(
+  sql: Sql,
+  c: Context<E>,
+  rule: RateLimitName,
+  organizationId: string,
+): Promise<Response | null> {
+  try {
+    await checkOrganizationRateLimit(sql, rule, organizationId);
+    return null;
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      return rateLimitedResponse(c, error);
+    }
+    throw error;
+  }
+}

--- a/services/platform/backend/lib/rate-limit.ts
+++ b/services/platform/backend/lib/rate-limit.ts
@@ -73,6 +73,20 @@ export const RATE_LIMITS = {
     period: MINUTE,
     capacity: 40,
   },
+  // The Google Drive picker and import lanes: the OneDrive twins' budgets,
+  // in buckets of their own.
+  'external:google-drive-list': {
+    kind: 'token bucket',
+    rate: 100,
+    period: MINUTE,
+    capacity: 120,
+  },
+  'external:google-drive-read': {
+    kind: 'token bucket',
+    rate: 50,
+    period: MINUTE,
+    capacity: 60,
+  },
   'external:email-test': {
     kind: 'token bucket',
     rate: 10,

--- a/services/platform/backend/rest/v1-core.test.ts
+++ b/services/platform/backend/rest/v1-core.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment node
 
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { Hono } from 'hono';
 import type { Sql } from 'postgres';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { parseKeysetCursor, type RestEnv } from './shared.ts';
 import { createCoreRoutes } from './v1-core.ts';
@@ -187,5 +191,90 @@ describe('GET /products filters', () => {
     const { values } = listQuery(queries, 'products');
     expect(values).toContain('archived');
     expect(values).toContain('tools');
+  });
+});
+
+/**
+ * The agents family reuses the file layer, whose refusals are coded
+ * AppErrors. The regression under test: the routes called it with no error
+ * mapping, so editing an agent the key holder cannot edit or naming an
+ * uppercase slug threw through Hono as a 500 — a permission or validation
+ * failure reading as an outage. The internal /api/app/agents routes mapped
+ * the same codes to 400/403/422 all along; both doors now share one map.
+ * Driven against a real temporary config tree: the org slug falls back to
+ * the door's `orgSlug` when the slug lookup finds no row.
+ */
+describe('agents error mapping', () => {
+  let configRoot: string;
+  let savedConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    savedConfigDir = process.env.TALE_CONFIG_DIR;
+    configRoot = await mkdtemp(path.join(tmpdir(), 'tale-rest-agents-'));
+    process.env.TALE_CONFIG_DIR = configRoot;
+  });
+
+  afterEach(async () => {
+    if (savedConfigDir === undefined) {
+      delete process.env.TALE_CONFIG_DIR;
+    } else {
+      process.env.TALE_CONFIG_DIR = savedConfigDir;
+    }
+    await rm(configRoot, { recursive: true, force: true });
+  });
+
+  async function seedAgent(slug: string, yaml: string): Promise<void> {
+    const dir = path.join(configRoot, 'acme', 'agents');
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, `${slug}.yml`), yaml, 'utf-8');
+  }
+
+  const request = async (
+    route: string,
+    init: { method?: string; body?: unknown } = {},
+  ): Promise<Response> =>
+    await mount(fakeSql([]).sql).request(`http://localhost${route}`, {
+      method: init.method ?? 'GET',
+      headers: { 'content-type': 'application/json' },
+      ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+    });
+
+  it('answers a permission refusal with 403', async () => {
+    await seedAgent(
+      'drafts',
+      'name: drafts\ndisplay-name: Drafts\ndescription: Someone else’s\nvisibility: private\nowner: user-2\ninstructions: Keep quiet.\n',
+    );
+    const res = await request('/agents/drafts', {
+      method: 'PUT',
+      body: { displayName: 'Hijacked' },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'AGENT_FORBIDDEN' });
+  });
+
+  it('answers an invalid slug with 400', async () => {
+    const res = await request('/agents/Not_A_Slug');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'INVALID_AGENT_SLUG' });
+  });
+
+  it('answers a malformed agent file with 422', async () => {
+    await seedAgent('broken', 'name: broken\ncolour: blue\n');
+    const res = await request('/agents/broken');
+    expect(res.status).toBe(422);
+    expect(await res.json()).toMatchObject({ error: 'AGENT_MALFORMED' });
+  });
+
+  it('deletes with 204, and answers 404 for an agent that is not there', async () => {
+    await seedAgent(
+      'helper',
+      'name: helper\ndisplay-name: Helper\ndescription: Shared\nvisibility: org\nowner: user-1\ninstructions: Help.\n',
+    );
+    expect((await request('/agents/helper', { method: 'DELETE' })).status).toBe(
+      204,
+    );
+    expect((await request('/agents/helper', { method: 'DELETE' })).status).toBe(
+      404,
+    );
   });
 });

--- a/services/platform/backend/rest/v1-core.ts
+++ b/services/platform/backend/rest/v1-core.ts
@@ -3,7 +3,6 @@ import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import { defineAbilityFor } from '../../lib/permissions/ability.ts';
-import { AppError } from '../../lib/shared/errors/app-error';
 import { dataSourceSchema } from '../../lib/shared/schemas/common.ts';
 import { getUserTeamIds } from '../auth/membership.ts';
 import {
@@ -18,6 +17,7 @@ import {
   readSkillForViewer,
   saveSkillForViewer,
 } from '../core/skills/file_actions.ts';
+import { agentErrorResponse } from '../domains/agents/errors.ts';
 import {
   bulkCreateContacts,
   createContact,
@@ -56,6 +56,8 @@ import {
   updateProduct,
   type ProductScope,
 } from '../domains/products/service.ts';
+import { skillErrorResponse } from '../domains/skills/errors.ts';
+import { withSkillWriterLock } from '../domains/skills/writer-lock.ts';
 import { addJobInTx } from '../jobs/enqueue.ts';
 import { resolveOrgSlug } from '../lib/org-config.ts';
 import { checkOrganizationRateLimit } from '../lib/rate-limit.ts';
@@ -737,13 +739,20 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
     return c.json(await listAgentsForCaller(await agentCaller(c)));
   });
 
+  // The file layer's coded refusals — an invalid slug, an agent the key
+  // holder may not edit, a malformed file — map onto 400/403/422 exactly as
+  // the app route maps them; uncaught they read as a 500 outage.
   app.get('/agents/:slug', async (c) => {
-    const agent = await readAgentForCaller({
-      ...(await agentCaller(c)),
-      slug: c.req.param('slug'),
-    });
-    if (agent === null) return c.json({ error: 'Agent not found' }, 404);
-    return c.json({ agent });
+    try {
+      const agent = await readAgentForCaller({
+        ...(await agentCaller(c)),
+        slug: c.req.param('slug'),
+      });
+      if (agent === null) return c.json({ error: 'Agent not found' }, 404);
+      return c.json({ agent });
+    } catch (error) {
+      return agentErrorResponse(c, error);
+    }
   });
 
   app.put('/agents/:slug', async (c) => {
@@ -758,57 +767,34 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
     if (!body.success) {
       return c.json({ error: 'invalid body' }, 400);
     }
-    const agent = await saveAgentForCaller({
-      ...(await agentCaller(c)),
-      slug: c.req.param('slug'),
-      ...body.data,
-    });
-    return c.json({ agent });
-  });
-
-  app.delete('/agents/:slug', async (c) => {
-    return c.json({
-      deleted: await deleteAgentForCaller({
+    try {
+      const agent = await saveAgentForCaller({
         ...(await agentCaller(c)),
         slug: c.req.param('slug'),
-      }),
-    });
+        ...body.data,
+      });
+      return c.json({ agent });
+    } catch (error) {
+      return agentErrorResponse(c, error);
+    }
+  });
+
+  /** Removing a resource that is not there is a 404 — the deletion
+   * semantics the API reference documents, and the skills family's. */
+  app.delete('/agents/:slug', async (c) => {
+    try {
+      const deleted = await deleteAgentForCaller({
+        ...(await agentCaller(c)),
+        slug: c.req.param('slug'),
+      });
+      if (!deleted) return c.json({ error: 'Agent not found' }, 404);
+      return c.body(null, 204);
+    } catch (error) {
+      return agentErrorResponse(c, error);
+    }
   });
 
   // ---- skills (the file layer, reused) -------------------------------------
-  const SKILL_ERROR_STATUS: Record<string, 400 | 403 | 404 | 422> = {
-    INVALID_SKILL_SLUG: 400,
-    INVALID_SKILL: 400,
-    SKILL_PRIVATE_RETIRED: 400,
-    SKILL_FORBIDDEN: 403,
-    SKILL_MALFORMED: 422,
-  };
-
-  const skillErrorResponse = (
-    c: Context<RestEnv>,
-    error: unknown,
-  ): Response => {
-    if (error instanceof AppError) {
-      const data: unknown = error.data;
-      if (data !== null && typeof data === 'object' && 'code' in data) {
-        const record = data as { code?: unknown; message?: unknown };
-        const code = typeof record.code === 'string' ? record.code : 'ERROR';
-        const status = SKILL_ERROR_STATUS[code];
-        if (status !== undefined) {
-          return c.json(
-            {
-              error: code,
-              message:
-                typeof record.message === 'string' ? record.message : code,
-            },
-            status,
-          );
-        }
-      }
-    }
-    throw error;
-  };
-
   /** The key acts as its user: team skills follow the user's own teams. */
   const skillCaller = async (c: Context<RestEnv>) => ({
     orgSlug:
@@ -854,11 +840,16 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       return c.json({ error: 'invalid body' }, 400);
     }
     try {
-      const saved = await saveSkillForViewer({
-        ...(await skillCaller(c)),
-        slug: c.req.param('slug'),
-        ...body.data,
-      });
+      const who = await skillCaller(c);
+      const slug = c.req.param('slug');
+      // Serialized with the upload lane and the app editor on the per-slug
+      // writer lock (`writer_lock.ts`).
+      const saved = await withSkillWriterLock(
+        deps.sql,
+        c.get('organizationId'),
+        slug,
+        () => saveSkillForViewer({ ...who, slug, ...body.data }),
+      );
       return c.json(saved);
     } catch (error) {
       return skillErrorResponse(c, error);
@@ -867,10 +858,14 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
 
   app.delete('/skills/:slug', async (c) => {
     try {
-      const deleted = await deleteSkillForViewer({
-        ...(await skillCaller(c)),
-        slug: c.req.param('slug'),
-      });
+      const who = await skillCaller(c);
+      const slug = c.req.param('slug');
+      const deleted = await withSkillWriterLock(
+        deps.sql,
+        c.get('organizationId'),
+        slug,
+        () => deleteSkillForViewer({ ...who, slug }),
+      );
       if (!deleted) return c.json({ error: 'Skill not found' }, 404);
       return c.body(null, 204);
     } catch (error) {


### PR DESCRIPTION
Eight verified medium findings from the backend deep review — legitimate refusals surfacing as 500s, a broken artifact nobody could delete, an upload door minting states the editor forbids, an unlocked writer on an atomic swap, a re-import that detached documents from prune, and a paid transcription run twice for the same bytes. One commit per finding; two verify-only items checked against base.

Base: `019d0a062` (includes #3160 #3161 #3165 #3167). No migration.

## Per-finding outcome

| #   | Finding                                                                          | Outcome   | Evidence / change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| --- | -------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | A malformed skill bundle cannot be deleted through the API                       | **fixed** | `deleteSkillForViewer` loaded the document first → 422 on the one operation that needs no parsed document. An org admin can now delete an unreadable bundle (and a bundle directory that lost its `SKILL.md`); members still get `SKILL_FORBIDDEN`. Mirrored for agents (`deleteAgentForCaller`), which have no upload lane to repair through at all.                                                                                                                                                                                    |
| 2   | Three authoritative zip-refusal codes map to 500                                 | **fixed** | `MISSING_SKILL_MD`, `INVALID_SKILL_MD`, `FILE_TOO_LARGE` were absent from the route's map and fell through as blank 500s. `bundle_zip.ts` now exports `SKILL_BUNDLE_REFUSAL_CODES` with a typed `refuse()`, and ONE `SKILL_ERROR_STATUS` (`domains/skills/errors.ts`, over a shared `appErrorResponse`) is built from it and used by the app route and the REST family.                                                                                                                                                                  |
| 3   | Upload lane mints retired-private skills and arbitrary owners the editor refuses | **fixed** | `normalizedBundleFiles` now takes the bundle being replaced and applies the editor's rules: a new bundle is attributed to its uploader, a replacement keeps its current owner, a declared `owner` is never honored, and `visibility: private` is refused unless the replaced bundle already is (`SKILL_PRIVATE_RETIRED`, which the skills docs already promised for uploads). Decided before the lock so a refusal never holds it.                                                                                                       |
| 4   | Editor save and delete skip the per-slug writer lock the swap protocol assumes   | **fixed** | `domains/skills/writer-lock.ts` — one `withSkillWriterLock` (the pg advisory xact lock the upload lane took) now wraps the upload write, the app PUT/DELETE and the REST PUT/DELETE, so no door can land between another's aside-rename and commit-rename.                                                                                                                                                                                                                                                                               |
| 5   | REST agents routes surface AGENT_FORBIDDEN and invalid-slug errors as 500        | **fixed** | `GET/PUT/DELETE /api/v1/agents/:slug` now map coded refusals through `domains/agents/errors.ts` (shared with `/api/app/agents`): 400 / 403 / 422. `DELETE` answers 204, or 404 for an absent agent — the deletion semantics the API reference documents and the skills family already had (it answered `{deleted:false}` 200).                                                                                                                                                                                                           |
| 6   | Rate-limit hit returns 500 on OneDrive routes; Google twin unthrottled           | **fixed** | `lib/rate-limit-response.ts` — `rateLimitedResponse` (`RATE_LIMITED` + `retryAfterMs` + whole-second `Retry-After`) and `chargeOrgRateLimit` (the REST door's `chargeLane` shape). All five OneDrive routes use it; Google Drive gets its own `external:google-drive-list/-read` buckets (the OneDrive budgets) on list and import.                                                                                                                                                                                                      |
| 7   | Re-import flips sync ownership metadata, detaching docs from prune               | **fixed** | Both `import_files` twins carry a sync-owned document's binding (`sourceMode: auto`, `syncConfigId`, and the selection keys the trash lane reads) through a one-time re-import, and a sync import ADOPTS an unchanged document from an earlier one-time import via a new `bindDocumentToSync` dep (pg: a jsonb merge, never a rewrite). `findDocumentByExternalId` returns the stored metadata.                                                                                                                                          |
| 8   | Re-registering an audio file re-transcribes completed work at full cost          | **fixed** | Same-ref re-runs were already fenced by the lease's status guard on base, but identical bytes in a NEW blob paid ffmpeg + provider again: `findCachedTranscript` was hardwired to null and `content_hash` never written. The engine now hashes the bytes it reads anyway, stamps `content_hash`, and copies the org's completed transcript on a hit (no compress, no provider call, no ledger write); its pre-check exits on `completed`; `queueTranscription` enqueues only when its `queued` stamp landed. Org-scoped by construction. |

Verify-only:

- **Provider credential `endpointUrl` update skips the https validation** — **already fixed** on base by #3161: `updateCredential` refuses a non-`https://` patch (`provider_credentials/service.ts:461-467`).
- **PUT /automations/{name}/triggers accepts triggers that can never fire** — **mostly fixed** by #3167: `assertTriggerValid` refuses a schedule without a parseable cron, an unknown IANA zone, and an event without a name (`AUTOMATION_TRIGGER_INVALID`). **Residual, not in this batch:** the route still answers 200 for an automation name that does not exist (no existence check, unlike the `/projects` bind's 404).

## Tests

Colocated vitest (all new cases red on base):

- `core/skills/file_actions.test.ts` — admin-only delete of a malformed bundle and of a `SKILL.md`-less directory; 7 `normalizedBundleFiles` cases (uploader attribution, declared owner ignored, private refused / kept for its owner, replacement keeps owner, byte-for-byte when nothing changes).
- `core/agents/file_actions.test.ts` — admin-only delete of a malformed agent.
- `domains/skills/errors.test.ts` — every zip refusal code maps to a 4xx; `MISSING_SKILL_MD` → 400 with the parser's words; unmapped codes still reach the app handler.
- `domains/skills/writer-lock.test.ts` — lock key, lock-before-work inside one transaction, rollback on failure.
- `rest/v1-core.test.ts` — agents: 403 / 400 / 422, DELETE 204 then 404 (real temp config tree).
- `lib/rate-limit-response.test.ts`, `domains/onedrive/routes.test.ts`, `domains/google_drive/routes.test.ts` — 429 + `Retry-After` on every drive route; Google charges its own buckets.
- `core/onedrive/import_files.test.ts`, `core/google_drive/import_files.test.ts` — binding kept on one-time re-import; adoption on sync import; no-op when already bound; manual stays manual.
- `domains/files/transcription.test.ts` — `queueTranscription` enqueues once for a fresh row, nothing otherwise.

Integration harness (`backend:integration`, real Postgres + MinIO), new probes:

- `library surface: zip refusals answer 400 with the parser’s reason`
- `library surface: an admin deletes a malformed skill and agent`
- `library surface: upload applies the editor’s owner and sharing rules`
- `library surface: editor save and delete wait for the per-slug writer lock` (holds the advisory lock in a transaction; PUT and DELETE must wait, then land)
- `REST resources: agent refusals map to 400/403/422/404, never 500`
- `drive pickers: a spent budget answers 429 with Retry-After on both providers`
- `onedrive re-import keeps the sync binding; sync import adopts a one-time doc` (fake Graph, real engine: re-imported file stays bound and is pruned when the source vanishes; one-time doc adopted unchanged)
- `transcription dedup: identical bytes reuse the completed transcript` (second blob, same bytes: completed, `whisperCalls` stays 1, ledger unchanged)

Two fixtures needed distinct bytes once dedup was real: the transcription check's failure step uses an 880 Hz WAV, and the fake yt-dlp renders `whis2` at 660 Hz.

## Verification

- Platform `tsc --noEmit`: clean. `oxlint --type-aware` on every touched file: clean.
- `backend:integration` on fresh throwaway tale-db + MinIO (`SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD` set):
  - branch: **390 PASS / 0 FAIL** (all eight new probes green).
  - base (`019d0a062` + this harness): **382 PASS / 8 FAIL** — the eight failures are exactly the eight new probes:
    - `onedrive re-import …` — `reimport → manual/null (want auto/cfg) pruned=false; adopt … after=manual/null`
    - `transcription dedup …` — `calls=2/1 hashes=null=null ledger=8.4/4.2`
    - `REST resources: agent refusals …` — `badSlug=500 forbidden=500 malformed=500 absentDelete=200`
    - `zip refusals answer 400 …` — `noSkillMd=500/no-json badFrontmatter=500/no-json`
    - `an admin deletes a malformed skill and agent` — `skill=422 gone=false agent=422 gone=false`
    - `upload applies the editor’s owner and sharing rules` — `private=200 (installed) owner=user_someone_else`
    - `editor save and delete wait for the per-slug writer lock` — `put: landed:200 … delete: landed:200` (wrote straight through)
    - `drive pickers: a spent budget answers 429 …` — `onedrive=500/no-json google=200 (unthrottled)`
- Whole `server` vitest project: 72 767 passed; the only failures are 2 cases in `lib/i18n/messages.test.ts` (3 orphan keys such as `automations.trigger.enabledBadge`) that fail identically on the untouched base tree, plus 3 `app/routes/**.test.tsx` files that belong to the `test:ui` project.

## Cross-class discoveries (not fixed here)

- REST `PUT /automations/{name}/triggers` still accepts an unknown automation name (200) — the `/projects` bind answers 404; #3167 territory.
- Eight more app domains hand-roll the same `RateLimitExceededError → 429` mapping in slightly different shapes (`folders`, `files`, `tasks`, `projects`, `knowledge_entries`, `webdav`, …); `rateLimitedResponse` is the one to converge on.
- The two `import_files.ts` twins (OneDrive / Google Drive) are near-verbatim copies; this batch applies the same fix to both rather than unifying them.
- `lib/i18n/messages.test.ts` is red on `main` (3 orphan keys from the automations workbench, e.g. `automations.trigger.enabledBadge`).
