### PR TITLE
fix(platform): gate conversation writes and audit 2FA successes

### DIFF
--- a/services/platform/backend/auth/auth.ts
+++ b/services/platform/backend/auth/auth.ts
@@ -29,8 +29,10 @@ import {
   evaluateTwoFactorEnforcement,
   getTwoFactorLockState,
   recordTwoFactorFailure,
+  recordTwoFactorLifecycleEvent,
   recordTwoFactorSuccess,
   setGraceUntilIfAbsent,
+  type TwoFactorLifecycleAction,
 } from '../domains/two_factor/service.ts';
 import { addJobInTx } from '../jobs/enqueue.ts';
 import { readGovernancePolicy } from '../lib/org-config.ts';
@@ -62,6 +64,32 @@ export interface AuthConfig {
 }
 
 const SIGN_IN_EMAIL_PATH = '/sign-in/email';
+
+/**
+ * The second-factor LIFECYCLE endpoints. Every one of them audits on success
+ * — the 0.4 posture (#1508), carried by the deleted `two_factor/auth_hooks.ts`
+ * whose lockout half this file already re-implements. These are
+ * account-takeover-relevant: an attacker who registers their own passkey and
+ * turns TOTP off must not be able to do it without leaving a trail.
+ */
+const TWO_FACTOR_ENABLE_PATH = '/two-factor/enable';
+const TWO_FACTOR_DISABLE_PATH = '/two-factor/disable';
+const TWO_FACTOR_BACKUP_CODES_PATH = '/two-factor/generate-backup-codes';
+const PASSKEY_REGISTER_PATH = '/passkey/verify-registration';
+const PASSKEY_DELETE_PATH = '/passkey/delete-passkey';
+const PASSKEY_AUTHENTICATE_PATH = '/passkey/verify-authentication';
+
+/** The user on a Better Auth middleware session payload (`context.session`
+ * or the freshly issued `context.newSession`), or null. */
+function sessionPayloadUser(
+  payload: unknown,
+): { id: string; email?: string } | null {
+  if (!isRecord(payload)) return null;
+  const user = payload.user;
+  if (!isRecord(user) || typeof user.id !== 'string') return null;
+  const email = typeof user.email === 'string' ? user.email : undefined;
+  return { id: user.id, ...(email !== undefined ? { email } : {}) };
+}
 
 // Random delay (ms) added to lockout responses to fuzz the timing channel
 // between "wrong password" (bcrypt, ~100ms) and "locked" (a single read).
@@ -180,6 +208,73 @@ export function createAuth(config: AuthConfig) {
       console.warn('[two-factor] user resolution failed:', error);
       return null;
     }
+  };
+
+  /**
+   * The successful second-factor lifecycle event on this request, or null.
+   * Success detection is 0.4's, endpoint by endpoint: `/two-factor/enable`
+   * only answers `{ totpURI, backupCodes }` when it worked and regeneration
+   * only answers `{ backupCodes }`, while disable / passkey add / remove park
+   * an `APIError` on `context.returned` when they fail. Passkey sign-in is
+   * read off the freshly issued session, exactly like `login_success` on the
+   * password path — a passkey FAILURE is challenge-based and attributable to
+   * no user, so there is nothing to log.
+   */
+  const resolveTwoFactorLifecycle = (
+    // oxlint-disable-next-line typescript/no-explicit-any -- better-auth middleware generics are unstable across minors
+    mw: any,
+  ): {
+    userId: string;
+    action: TwoFactorLifecycleAction;
+    email?: string;
+    metadata?: Record<string, unknown>;
+  } | null => {
+    const returned: unknown = mw.context.returned;
+    if (returned instanceof APIError) return null;
+
+    if (mw.path === PASSKEY_AUTHENTICATE_PATH) {
+      const signedIn = sessionPayloadUser(mw.context.newSession);
+      if (signedIn === null) return null;
+      return {
+        userId: signedIn.id,
+        action: 'passkey_sign_in',
+        ...(signedIn.email !== undefined ? { email: signedIn.email } : {}),
+      };
+    }
+
+    // Every remaining endpoint requires an active session, so the actor is
+    // the caller themselves; without one there is nothing to attribute.
+    const actor = sessionPayloadUser(mw.context.session);
+    if (actor === null) return null;
+    const base = {
+      userId: actor.id,
+      ...(actor.email !== undefined ? { email: actor.email } : {}),
+    };
+
+    if (mw.path === TWO_FACTOR_ENABLE_PATH) {
+      return isRecord(returned) && 'totpURI' in returned
+        ? { ...base, action: '2fa_enrolled' }
+        : null;
+    }
+    if (mw.path === TWO_FACTOR_BACKUP_CODES_PATH) {
+      return isRecord(returned) && 'backupCodes' in returned
+        ? {
+            ...base,
+            action: '2fa_enrolled',
+            metadata: { backupCodesRegenerated: true },
+          }
+        : null;
+    }
+    if (mw.path === TWO_FACTOR_DISABLE_PATH) {
+      return { ...base, action: '2fa_disabled' };
+    }
+    if (mw.path === PASSKEY_REGISTER_PATH) {
+      return { ...base, action: 'passkey_added' };
+    }
+    if (mw.path === PASSKEY_DELETE_PATH) {
+      return { ...base, action: 'passkey_removed' };
+    }
+    return null;
   };
 
   return betterAuth({
@@ -395,6 +490,34 @@ export function createAuth(config: AuthConfig) {
             } else {
               await recordTwoFactorSuccess(sql, userId);
             }
+          }
+        }
+
+        // Second-factor lifecycle audit: 2FA enable / disable / backup-code
+        // regeneration and passkey add / remove / sign-in. Non-fatal — the
+        // state change already happened inside Better Auth's own adapter, so
+        // refusing the response here would leave the user with a passkey
+        // registered and an error on screen. A failed write is LOUD instead.
+        const lifecycle = resolveTwoFactorLifecycle(mw);
+        if (lifecycle !== null) {
+          try {
+            await recordTwoFactorLifecycleEvent(sql, {
+              userId: lifecycle.userId,
+              action: lifecycle.action,
+              ...(lifecycle.email !== undefined
+                ? { actorEmail: lifecycle.email }
+                : {}),
+              ...(ip !== undefined ? { ip } : {}),
+              ...(userAgent !== undefined ? { userAgent } : {}),
+              ...(lifecycle.metadata !== undefined
+                ? { metadata: lifecycle.metadata }
+                : {}),
+            });
+          } catch (error) {
+            console.error(
+              `[two-factor] failed to write the ${lifecycle.action} audit row`,
+              error instanceof Error ? error.message : error,
+            );
           }
         }
 

--- a/services/platform/backend/domains/conversations/routes.test.ts
+++ b/services/platform/backend/domains/conversations/routes.test.ts
@@ -5,10 +5,19 @@
  * Inbox to one mailbox no longer shows every connector's conversations.
  */
 
+import { readFileSync } from 'node:fs';
+
 import type { Context } from 'hono';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { OrgEnv } from '../../auth/org.ts';
+
+/**
+ * The role `requireOrgMember` resolves. Hoisted, because the `vi.mock`
+ * factory below closes over it and mock factories run before module-body
+ * consts initialize. Defaults to admin — every other suite here relies on it.
+ */
+const viewerRole = vi.hoisted(() => ({ current: 'admin' }));
 
 const {
   listConversationsPage,
@@ -69,14 +78,14 @@ vi.mock('../../auth/org.ts', async (importOriginal) => {
     requireOrgMember:
       () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
         c.set('orgId', 'o1');
-        c.set('orgMember', { role: 'admin' } as never);
+        c.set('orgMember', { role: viewerRole.current } as never);
         await next();
       },
   };
 });
 
 import { createConversationRoutes } from './routes.ts';
-import { ConversationError } from './service.ts';
+import { ConversationError, viewerCanWrite } from './service.ts';
 
 function makeApp() {
   return createConversationRoutes({
@@ -208,6 +217,237 @@ describe('conversations route — message doors share the visibility guard', () 
         expect.anything(),
         expect.objectContaining({ organizationId: 'o1', messageId: 'm1' }),
       );
+    });
+  }
+});
+
+/**
+ * Every write-shaped door must check the role, and the check must be the
+ * FIRST statement in the handler — before the body parse, so a refusal never
+ * depends on the payload. Twelve doors carry it today. The two assignment
+ * doors are the deliberate exception: `assignConversation` /
+ * `assignConversationTeam` gate on `viewerIsAdmin` in the service, which is
+ * stricter than editor, so a route-level editor check there would LOOSEN them.
+ *
+ * This reads the source rather than driving each handler because the failure
+ * it catches is a NEW door shipping ungated — a case no existing test would
+ * cover, by definition.
+ */
+describe('conversations route — every write door checks the role', () => {
+  /** Doors whose role gate lives in the service, at a stricter level. */
+  const ADMIN_ONLY_IN_SERVICE = new Set(['/:id/assign', '/:id/assign-team']);
+
+  const source = readFileSync(
+    new URL('./routes.ts', import.meta.url),
+    'utf8',
+  ).split('\n');
+
+  const writeRoutes = source.flatMap((line, index) => {
+    const match = /^\s*app\.(post|patch|delete)\('([^']*)'/.exec(line);
+    return match === null
+      ? []
+      : [
+          {
+            door: `${match[1].toUpperCase()} ${match[2]}`,
+            path: match[2],
+            next: source[index + 1] ?? '',
+          },
+        ];
+  });
+
+  // A pattern that stops matching would make the gate assertion vacuous.
+  it('finds the write doors', () => {
+    expect(writeRoutes.length).toBe(14);
+  });
+
+  it('gates all of them but the admin-only assignment pair', () => {
+    const ungated = writeRoutes
+      .filter(
+        ({ path, next }) =>
+          !ADMIN_ONLY_IN_SERVICE.has(path) &&
+          !next.includes("viewerCanWrite(c.get('orgMember').role)"),
+      )
+      .map(({ door }) => door);
+
+    expect(
+      ungated,
+      `write door(s) with no role check on the handler's first line — a read-only member could reach them:\n  ${ungated.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps the assignment pair admin-gated in the service', () => {
+    const service = readFileSync(
+      new URL('./service.ts', import.meta.url),
+      'utf8',
+    );
+    for (const fn of ['assignConversation', 'assignConversationTeam']) {
+      const body = service.slice(
+        service.indexOf(`export async function ${fn}`),
+      );
+      expect(body.slice(0, body.indexOf('\n}')), fn).toContain(
+        'viewerIsAdmin(args.actor.role)',
+      );
+    }
+  });
+});
+
+/**
+ * The write gate, driven through the REAL handlers: a read-only `member` is
+ * refused at every write-shaped door and no service function is reached, while
+ * an `editor` gets through all of them. The static check above proves the gate
+ * is PRESENT on each door; this proves it DECIDES correctly, and that the
+ * refusal lands before the handler touches the service.
+ */
+describe('conversations route — the write gate decides by role', () => {
+  /** Every write-shaped door except the admin-only assignment pair. */
+  const doors = [
+    ['PATCH', '/c1', { status: 'closed' }],
+    ['POST', '/c1/read', {}],
+    ['POST', '/c1/messages', { content: 'a note' }],
+    ['POST', '/c1/reply', { content: 'a reply' }],
+    [
+      'POST',
+      '/compose',
+      {
+        contactId: 'ct1',
+        connectorName: 'imap-smtp',
+        subject: 's',
+        content: 'c',
+      },
+    ],
+    ['POST', '/bulk/reply', { conversationIds: ['c1'], content: 'b' }],
+    ['POST', '/bulk/close', { conversationIds: ['c1'] }],
+    ['POST', '/messages/m1/undo', {}],
+    ['POST', '/messages/m1/retry', {}],
+    ['POST', '/messages/m1/discard', {}],
+    ['POST', '/messages/m1/attachments', {}],
+    ['DELETE', '/c1', undefined],
+  ] as const;
+
+  const call = (method: string, path: string, body: unknown) =>
+    makeApp().request(`${path}?orgId=o1`, {
+      method,
+      ...(body === undefined
+        ? {}
+        : {
+            body: JSON.stringify(body),
+            headers: { 'content-type': 'application/json' },
+          }),
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadMessageForViewer.mockResolvedValue({
+      id: 'm1',
+      conversationId: 'c1',
+      connectorName: 'imap-smtp',
+    });
+    undoSendMessage.mockResolvedValue({ sourceMarkdown: null });
+    retrySendMessage.mockResolvedValue(undefined);
+    discardOutboundMessage.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    viewerRole.current = 'admin';
+  });
+
+  it('covers every gated door', () => {
+    expect(doors.length).toBe(12);
+  });
+
+  for (const [method, path, body] of doors) {
+    it(`refuses a read-only member at ${method} ${path}`, async () => {
+      viewerRole.current = 'member';
+      const res = await call(method, path, body);
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: 'FORBIDDEN' });
+      // Refused before the handler reached anything that could change state.
+      expect(loadMessageForViewer).not.toHaveBeenCalled();
+      expect(undoSendMessage).not.toHaveBeenCalled();
+      expect(retrySendMessage).not.toHaveBeenCalled();
+      expect(discardOutboundMessage).not.toHaveBeenCalled();
+    });
+  }
+
+  // `disabled` is refused by the middleware in production; the gate must also
+  // refuse it on its own, so neither layer is the only thing standing there.
+  it('refuses a disabled member too', async () => {
+    viewerRole.current = 'disabled';
+    const res = await call('POST', '/c1/reply', { content: 'a reply' });
+
+    expect(res.status).toBe(403);
+  });
+
+  /**
+   * The other direction: an editor is never refused BY THE GATE. Only the
+   * message-door services are mocked here, so the other doors reach the real
+   * service over a stub `sql` and answer 500 — which is itself past the gate,
+   * but a bare `!== 403` would accept that 500 even if the gate were broken
+   * open in a different way. So check the refusal ENVELOPE, which only the
+   * gate produces, and then pin the four doors the mocks carry end to end.
+   */
+  it('never shows an editor the gate refusal', async () => {
+    viewerRole.current = 'editor';
+    const bodies = await Promise.all(
+      doors.map(async ([method, path, body]) => {
+        const res = await call(method, path, body);
+        return {
+          door: `${method} ${path}`,
+          status: res.status,
+          body: await res.text(),
+        };
+      }),
+    );
+
+    expect(bodies.filter(({ status }) => status === 403)).toEqual([]);
+    expect(
+      bodies.filter(({ body }) =>
+        body.includes('Only editors and above can change conversations'),
+      ),
+    ).toEqual([]);
+  });
+
+  /** The doors whose services are mocked run all the way through. */
+  it('runs an editor through the fully-mocked message doors', async () => {
+    viewerRole.current = 'editor';
+
+    for (const door of ['undo', 'retry', 'discard'] as const) {
+      const res = await call('POST', `/messages/m1/${door}`, {});
+      expect(res.status, door).toBe(200);
+    }
+    expect(loadMessageForViewer).toHaveBeenCalledTimes(3);
+
+    // The attachment door reaches its own honest answer, not the gate's.
+    const attachments = await call('POST', '/messages/m1/attachments', {});
+    expect(attachments.status).toBe(501);
+    expect(await attachments.json()).toMatchObject({
+      error: 'attachment_bytes_unavailable',
+    });
+  });
+});
+
+/**
+ * The predicate itself, across the whole role vocabulary. The route suites
+ * above drive the boundary role (`editor`) and the two refused ones; this
+ * pins the remaining three, so widening `viewerCanWrite` — or a matrix edit
+ * that widens it by accident — cannot pass unnoticed.
+ */
+describe('viewerCanWrite', () => {
+  const cases = [
+    ['owner', true],
+    ['admin', true],
+    ['developer', true],
+    ['editor', true],
+    ['member', false],
+    ['disabled', false],
+    ['', false],
+    ['nonsense', false],
+  ] as const;
+
+  for (const [role, allowed] of cases) {
+    it(`${allowed ? 'admits' : 'refuses'} ${role === '' ? '<empty>' : role}`, () => {
+      expect(viewerCanWrite(role)).toBe(allowed);
     });
   }
 });

--- a/services/platform/backend/domains/conversations/routes.ts
+++ b/services/platform/backend/domains/conversations/routes.ts
@@ -32,13 +32,38 @@ import {
   projectConversationForView,
   type ConversationViewer,
   updateConversation,
+  viewerCanWrite,
 } from './service.ts';
 
 /**
- * /api/app/conversations — the shared Inbox surface. Reads are
- * assignment-scoped through the reused predicate (an unassigned row is
- * admin-triage only); assignment writes are admin-gated in the service.
+ * /api/app/conversations — the shared Inbox surface.
+ *
+ * Access has two independent halves, both ported from 0.4:
+ *  - WHO CAN SEE a thread — assignment privacy, per row, through the reused
+ *    `conversationAssignmentAllows` predicate (an unassigned row is
+ *    admin-triage only). Applied by `loadVisibleConversation`.
+ *  - WHO MAY CHANGE one — an editor-or-above role (`viewerCanWrite`, the 0.4
+ *    `conversations`/`conversationMessages` RLS write rule). A read-only
+ *    `member` may read the threads assigned to them but must not reply, send
+ *    outbound mail under the org's name, change status, bulk-act, or delete.
+ *  Assignment itself is stricter than both: admin-only, gated in the service.
+ *
+ * Roles come from `c.get('orgMember')` — the membership `requireOrgMember`
+ * resolves, which prefers the SESSION-carried role in trusted-headers
+ * deployments (there the `member` row is only a proxy-fed placeholder).
  */
+
+/** The write-role refusal, shaped like the service's own `ConversationError`
+ * envelope so every conversation 403 reads the same on the wire. */
+function forbidWrite<E extends OrgEnv>(c: Context<E>): Response {
+  return c.json(
+    {
+      error: 'FORBIDDEN',
+      message: 'Only editors and above can change conversations',
+    },
+    403,
+  );
+}
 
 function handleError<E extends OrgEnv>(
   c: Context<E>,
@@ -182,6 +207,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.patch('/:id', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         contactId: z.string().max(64).optional(),
@@ -207,6 +233,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.post('/:id/read', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadVisibleConversation(deps.sql, viewer(c), c.req.param('id'));
       await deps.sql.begin((tx) =>
@@ -221,6 +248,7 @@ export function createConversationRoutes(deps: {
   /** Append a message (an internal note or a manually logged reply — the
    * connector SEND lane is its own increment). */
   app.post('/:id/messages', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         content: z.string().min(1).max(200_000),
@@ -295,6 +323,7 @@ export function createConversationRoutes(deps: {
 
   /** One reply body to many conversations (cap 50, partial failure). */
   app.post('/bulk/reply', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         conversationIds: z.array(z.string().max(64)).min(1).max(200),
@@ -360,6 +389,7 @@ export function createConversationRoutes(deps: {
 
   /** Send a reply through the conversation's connector (undo window). */
   app.post('/:id/reply', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         content: z.string().min(1).max(200_000),
@@ -391,6 +421,7 @@ export function createConversationRoutes(deps: {
 
   /** Start a new outbound email conversation with a contact. */
   app.post('/compose', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const body = z
       .object({
         contactId: z.string().min(1).max(64),
@@ -435,14 +466,18 @@ export function createConversationRoutes(deps: {
   });
 
   /**
-   * The message-level doors (undo / retry / discard / attachments) all pass
-   * `loadMessageForViewer` first: a member acts on a message only inside a
-   * conversation they can open — org scoping alone let a member holding an id
-   * cancel or resend a colleague's mail in a conversation hidden from them.
+   * The message-level doors (undo / retry / discard / attachments) all check
+   * `viewerCanWrite` and then pass `loadMessageForViewer`: the role decides
+   * whether the caller may act on mail at all, and the load decides which
+   * mail they can reach — a member acts on a message only inside a
+   * conversation they can open, because org scoping alone let a member
+   * holding an id cancel or resend a colleague's mail in a conversation
+   * hidden from them.
    */
 
   /** Cancel a still-queued send; hands the composer draft back. */
   app.post('/messages/:messageId/undo', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       const result = await undoSendMessage(deps.sql, {
@@ -468,6 +503,7 @@ export function createConversationRoutes(deps: {
    * the org blob store) is the tracked follow-up that lights this up.
    */
   app.post('/messages/:messageId/attachments', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       return c.json(
@@ -485,6 +521,7 @@ export function createConversationRoutes(deps: {
 
   /** Re-attempt a failed send immediately (no undo window). */
   app.post('/messages/:messageId/retry', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       await retrySendMessage(deps.sql, {
@@ -500,6 +537,7 @@ export function createConversationRoutes(deps: {
 
   /** Remove a failed outbound bubble — the email never left. */
   app.post('/messages/:messageId/discard', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadMessageForViewer(deps.sql, viewer(c), c.req.param('messageId'));
       await discardOutboundMessage(deps.sql, {
@@ -514,6 +552,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.post('/bulk/:verb', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     const verb = z
       .enum(['close', 'reopen', 'spam', 'archive', 'unarchive'])
       .safeParse(c.req.param('verb'));
@@ -547,6 +586,7 @@ export function createConversationRoutes(deps: {
   });
 
   app.delete('/:id', async (c) => {
+    if (!viewerCanWrite(c.get('orgMember').role)) return forbidWrite(c);
     try {
       await loadVisibleConversation(deps.sql, viewer(c), c.req.param('id'));
       await deleteConversation(deps.sql, c.get('orgId'), c.req.param('id'));

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -3,6 +3,7 @@ import type { Sql, TransactionSql } from 'postgres';
 import { projectConversationItem } from '../../../lib/shared/conversations/conversation-item.ts';
 import { nextConversationLastMessageAt } from '../../../lib/shared/conversations/message-order.ts';
 import { isRecord } from '../../../lib/utils/type-utils.ts';
+import { authorizeRls } from '../../auth/access.ts';
 import {
   findOrganizationMember,
   getUserTeamIds,
@@ -118,6 +119,27 @@ export interface ConversationViewer {
 export function viewerIsAdmin(role: string): boolean {
   const normalized = role.toLowerCase();
   return normalized === 'owner' || normalized === 'admin';
+}
+
+/**
+ * May this role CHANGE a conversation? Editor-or-above, which is the 0.4
+ * gate: every conversation mutation ran through `mutationWithRLS`, and the
+ * `conversations` / `conversationMessages` RLS rules put each insert/modify
+ * (and delete) through `authorizeRls(role, …, 'write')` — ALL for
+ * owner/admin/developer/editor, READ_ONLY for `member`, NONE for `disabled`.
+ *
+ * This is the WRITE half of conversation access and it is role-shaped, org
+ * wide. The other half is assignment privacy — `conversationAssignmentAllows`
+ * per row, which decides who can SEE a thread at all — and the two compose:
+ * a write door checks this first, then loads the row through
+ * `loadVisibleConversation`. Assignment itself is stricter still
+ * (`viewerIsAdmin`).
+ */
+export function viewerCanWrite(role: string): boolean {
+  return (
+    authorizeRls(role, 'conversations', 'write') &&
+    authorizeRls(role, 'conversationMessages', 'write')
+  );
 }
 
 /** One conversation readable by the viewer, or the opaque 404. Evaluates the

--- a/services/platform/backend/domains/two_factor/service.ts
+++ b/services/platform/backend/domains/two_factor/service.ts
@@ -1,8 +1,13 @@
+import { transactSerializable } from '@tale/shared/db/serializable';
 import { symmetricDecrypt } from 'better-auth/crypto';
 import type { Sql, TransactionSql } from 'postgres';
 
 import { DEFAULT_TWO_FACTOR_POLICY } from '../../../lib/shared/schemas/governance.ts';
 import { mergeStrictestTwoFactorPolicy } from '../../core/governance/helpers.ts';
+import {
+  splitEmailForAudit,
+  splitIpForAudit,
+} from '../../core/lib/helpers/pii_hash.ts';
 import {
   computeLockedUntil,
   DEFAULT_LOGIN_POLICY,
@@ -123,6 +128,75 @@ export async function recordTwoFactorSuccess(
   userId: string,
 ): Promise<void> {
   await sql`DELETE FROM app.two_factor_attempts WHERE user_id = ${userId}`;
+}
+
+/**
+ * The second-factor lifecycle events. Action names are the 0.4 ones verbatim
+ * (`two_factor/internal_mutations.ts` → `logEnrollmentEvent`) — a rename
+ * would silently break any saved audit query or export that groups on them.
+ */
+export type TwoFactorLifecycleAction =
+  | '2fa_enrolled'
+  | '2fa_disabled'
+  | 'passkey_added'
+  | 'passkey_removed'
+  | 'passkey_sign_in';
+
+/**
+ * Audit a SUCCESSFUL 2FA / passkey lifecycle event (#1508 in 0.4). These are
+ * the account-takeover-relevant ones: an attacker who adds a passkey and
+ * disables TOTP must not be able to do it without leaving a trail. The
+ * failure side is `recordTwoFactorFailure` above — on 0.5 that was the only
+ * half that survived the port, because the 0.4 hook file carrying these
+ * calls was deleted with the Convex tree.
+ *
+ * Org-scoped like every other security event: one row per org the user
+ * belongs to, PII split into plaintext + peppered hash by the reused
+ * helpers, all inside ONE serializable transaction so a user in several orgs
+ * gets all their rows or none.
+ */
+export async function recordTwoFactorLifecycleEvent(
+  sql: Sql,
+  args: {
+    userId: string;
+    action: TwoFactorLifecycleAction;
+    actorEmail?: string;
+    ip?: string;
+    userAgent?: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<void> {
+  const emailParts =
+    args.actorEmail !== undefined
+      ? await splitEmailForAudit(args.actorEmail)
+      : {};
+  const ipParts = args.ip !== undefined ? await splitIpForAudit(args.ip) : {};
+  await transactSerializable(sql, async (tx) => {
+    for (const organizationId of await userOrgIds(tx, args.userId)) {
+      await createAuditLog(tx, {
+        organizationId,
+        actorId: args.userId,
+        ...(emailParts.plaintext !== undefined
+          ? { actorEmail: emailParts.plaintext }
+          : {}),
+        ...(emailParts.hash !== undefined
+          ? { actorEmailHash: emailParts.hash }
+          : {}),
+        actorType: 'user',
+        action: args.action,
+        category: 'security',
+        resourceType: 'twoFactorAuth',
+        resourceId: args.userId,
+        ...(ipParts.plaintext !== undefined
+          ? { ipAddress: ipParts.plaintext }
+          : {}),
+        ...(ipParts.hash !== undefined ? { actorIpHash: ipParts.hash } : {}),
+        ...(args.userAgent !== undefined ? { userAgent: args.userAgent } : {}),
+        status: 'success',
+        ...(args.metadata !== undefined ? { metadata: args.metadata } : {}),
+      });
+    }
+  });
 }
 
 export interface TwoFactorEnforcement {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -15049,6 +15049,161 @@ async function checkConversations(
       remnants[0]?.count === '0',
     `listed=${row !== undefined} unread=${row?.unread} preview=${row?.lastMessagePreview === 'Where is my order?'} contact=${row?.contact?.email}, counts=${counts.success ? `${counts.data.byStatus.open ?? 0}/${counts.data.unread}` : 'ERR'}, memberHidden=${hiddenBefore}→assigned visible=${visibleAfter} bell=${assignBell[0]?.count}, strangerRefused=${strangerRefused} (${strangerAssign.status}/${strangerBody.success ? strangerBody.data.error : 'ERR'}), teamSees=${teammateSees} teamBell=${teamBell[0]?.count}, noteKeepsUnread=${unreadStillOne} readClears=${afterRead.success && afterRead.data.conversation.metadata?.unread_count === 0}, close=${closed.success ? closed.data.successCount : 'ERR'} status=${closedRow[0]?.status}/${closedRow[0]?.resolvedBy !== null}, patchClose=${patchClose.status}/${patchMeta.status} record=${patchKeepsRecord} (resolved_by=${patched?.metadata?.resolved_by === userId} unread=${String(patched?.metadata?.unread_count)} note=${String(patched?.metadata?.priority_note)}) countsWithJunk=${countsWithJunk.status}, del=${deleted.status} remnants=${remnants[0]?.count}`,
   );
+
+  // --- Write gate: editor-or-above, assignment privacy held constant ----
+  // 0.4 ran every conversation mutation through `mutationWithRLS`, whose
+  // `conversations`/`conversationMessages` rules demanded WRITE — ALL for
+  // owner/admin/developer/editor, READ_ONLY for `member`. The probe thread is
+  // ASSIGNED to the probing user, so assignment privacy passes on every call
+  // and the ONLY thing that can refuse is the role.
+  const gateSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `conv-gate-${orgId.slice(0, 8)}@door.test`,
+      password: 'itest-password-1',
+      name: 'Inbox Gate Probe',
+    }),
+  });
+  const gateCookie = cookieHeaderFrom(gateSignUp);
+  const gateUser = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await gateSignUp.json());
+  const gateUserId = gateUser.success ? gateUser.data.user.id : '';
+  const gateMemberId = `m-conv-gate-${gateUserId}`;
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${gateMemberId}, ${orgId}, ${gateUserId}, 'member', ${new Date()})
+  `;
+  const gated = await sql.begin(async (tx) => {
+    const id = await createConversation(tx, {
+      organizationId: orgId,
+      contactId,
+      assigneeUserId: gateUserId,
+      subject: 'Write gate probe',
+      channel: 'email',
+      direction: 'inbound',
+      connectorName: 'imap-smtp',
+    });
+    await addMessageToConversation(tx, {
+      conversationId: id,
+      organizationId: orgId,
+      sender: 'customer@inbox.test',
+      content: 'Can a read-only member answer this?',
+      isCustomer: true,
+      connectorName: 'imap-smtp',
+    });
+    return id;
+  });
+  const gateMessages = await sql<{ id: string }[]>`
+    SELECT id FROM app.conversation_messages
+    WHERE conversation_id = ${gated} LIMIT 1
+  `;
+  const gateMessageId = gateMessages[0]?.id ?? '';
+  const asGate = (
+    route: string,
+    init: { method?: string; body?: unknown } = {},
+  ): Promise<Response> =>
+    fetch(`${base}/api/app/conversations${route}?orgId=${orgId}`, {
+      method: init.method ?? (init.body !== undefined ? 'POST' : 'GET'),
+      headers: {
+        'content-type': 'application/json',
+        cookie: gateCookie,
+        origin: base,
+      },
+      ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+    });
+  const writeDoors = async (): Promise<number[]> =>
+    (
+      await Promise.all([
+        asGate(`/${gated}`, { method: 'PATCH', body: { status: 'closed' } }),
+        asGate(`/${gated}/read`, { body: {} }),
+        asGate(`/${gated}/messages`, { body: { content: 'a note' } }),
+        asGate(`/${gated}/reply`, { body: { content: 'an outbound reply' } }),
+        asGate('/compose', {
+          body: {
+            contactId,
+            connectorName: 'imap-smtp',
+            subject: 'Unauthorized outbound',
+            content: 'This must never leave the building.',
+          },
+        }),
+        asGate('/bulk/reply', {
+          body: { conversationIds: [gated], content: 'bulk reply' },
+        }),
+        asGate('/bulk/close', { body: { conversationIds: [gated] } }),
+        asGate(`/messages/${gateMessageId}/undo`, { body: {} }),
+        asGate(`/messages/${gateMessageId}/retry`, { body: {} }),
+        asGate(`/messages/${gateMessageId}/discard`, { body: {} }),
+        asGate(`/messages/${gateMessageId}/attachments`, { body: {} }),
+        asGate(`/${gated}`, { method: 'DELETE' }),
+      ])
+    ).map((res) => res.status);
+  const memberDoors = await writeDoors();
+  // Refused means REFUSED: the thread is untouched and nothing was appended.
+  const afterMember = await sql<{ status: string | null; msgs: string }[]>`
+    SELECT c.status,
+           (SELECT count(*)::text FROM app.conversation_messages m
+             WHERE m.conversation_id = c.id) AS msgs
+    FROM app.conversations c WHERE c.id = ${gated}
+  `;
+  // Reads are NOT gated — a member still opens the thread assigned to them.
+  const memberRead = await asGate(`/${gated}`);
+
+  // The same doors as `editor` now go THROUGH the gate. The send doors are
+  // probed with an invalid body so the proof is "the gate opened, the schema
+  // refused" (400) — no real outbound mail, no state to clean up after.
+  await sql`UPDATE "member" SET "role" = 'editor' WHERE "id" = ${gateMemberId}`;
+  const editorNote = await asGate(`/${gated}/messages`, {
+    body: { content: 'an editor may answer' },
+  });
+  const editorPatch = await asGate(`/${gated}`, {
+    method: 'PATCH',
+    body: { status: 'closed' },
+  });
+  const editorRead = await asGate(`/${gated}/read`, { body: {} });
+  const editorBulk = await asGate('/bulk/close', {
+    body: { conversationIds: [gated] },
+  });
+  const afterEditor = await sql<{ status: string | null; msgs: string }[]>`
+    SELECT c.status,
+           (SELECT count(*)::text FROM app.conversation_messages m
+             WHERE m.conversation_id = c.id) AS msgs
+    FROM app.conversations c WHERE c.id = ${gated}
+  `;
+  const editorPastGate = (
+    await Promise.all([
+      asGate(`/${gated}/reply`, { body: {} }),
+      asGate('/compose', { body: {} }),
+      asGate('/bulk/reply', { body: {} }),
+      asGate(`/messages/${gateMessageId}/undo`, { body: {} }),
+      asGate(`/messages/${gateMessageId}/retry`, { body: {} }),
+      asGate(`/messages/${gateMessageId}/discard`, { body: {} }),
+      asGate(`/messages/${gateMessageId}/attachments`, { body: {} }),
+    ])
+  ).map((res) => res.status);
+  const editorDelete = await asGate(`/${gated}`, { method: 'DELETE' });
+
+  await sql`DELETE FROM app.conversations WHERE id = ${gated}`;
+  await sql`DELETE FROM "member" WHERE "id" = ${gateMemberId}`;
+  record(
+    'conversations: writes need editor-or-above, reads do not',
+    memberDoors.length === 12 &&
+      memberDoors.every((status) => status === 403) &&
+      afterMember[0]?.status === 'open' &&
+      afterMember[0]?.msgs === '1' &&
+      memberRead.status === 200 &&
+      editorNote.status === 201 &&
+      editorPatch.status === 200 &&
+      editorRead.status === 200 &&
+      editorBulk.status === 200 &&
+      afterEditor[0]?.status === 'closed' &&
+      afterEditor[0]?.msgs === '2' &&
+      editorPastGate.every((status) => status !== 403) &&
+      editorDelete.status === 204,
+    `member=${memberDoors.join(',')} (want 12x403) untouched=${afterMember[0]?.status}/${afterMember[0]?.msgs}msg read=${memberRead.status} (want 200), editor note=${editorNote.status} patch=${editorPatch.status} read=${editorRead.status} bulk=${editorBulk.status} → ${afterEditor[0]?.status}/${afterEditor[0]?.msgs}msg, pastGate=${editorPastGate.join(',')} (want none 403), del=${editorDelete.status}`,
+  );
 }
 
 /**
@@ -28753,6 +28908,94 @@ async function checkAuditSurface(
     exported.success && exported.data.fileName.endsWith('.csv') && csvOk,
     `export=${exported.success ? exported.data.fileName : 'ERR'}, csv=${csvOk}`,
   );
+
+  // --- Read gate: admin/owner only, on EVERY door (#1505) ---------------
+  // The log enumerates who did what to whom and carries the GDPR erasure
+  // trail, so 0.4 gated every public audit query on `isAdmin`. One seeded
+  // user walks the doors at three roles: the same cookie, the `member` row
+  // rewritten between passes (that is where `requireOrgMember` reads from).
+  const gateSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `audit-gate-${orgId.slice(0, 8)}@door.test`,
+      password: 'itest-password-1',
+      name: 'Audit Gate Probe',
+    }),
+  });
+  const gateCookie = cookieHeaderFrom(gateSignUp);
+  const gateUser = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await gateSignUp.json());
+  const gateUserId = gateUser.success ? gateUser.data.user.id : '';
+  const gateMemberId = `m-audit-gate-${gateUserId}`;
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (${gateMemberId}, ${orgId}, ${gateUserId}, 'member', ${new Date()})
+  `;
+  const asRole = async (role: string): Promise<number[]> => {
+    await sql`
+      UPDATE "member" SET "role" = ${role} WHERE "id" = ${gateMemberId}
+    `;
+    const doors: Promise<Response>[] = [
+      fetch(`${base}/api/app/audit-logs?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/errors?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/summary?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/integrity/status?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/block-counters?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      // The by-id detail door: a real row, so a leak would be a real leak.
+      fetch(`${base}/api/app/audit-logs/${anyId}?orgId=${orgId}`, {
+        headers: { cookie: gateCookie },
+      }),
+      fetch(`${base}/api/app/audit-logs/integrity/verify?orgId=${orgId}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: gateCookie,
+          origin: base,
+        },
+        body: JSON.stringify({ maxEntries: 10 }),
+      }),
+      fetch(`${base}/api/app/audit-logs/export?orgId=${orgId}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: gateCookie,
+          origin: base,
+        },
+        body: JSON.stringify({ format: 'json' }),
+      }),
+    ];
+    return (await Promise.all(doors)).map((res) => res.status);
+  };
+  // `member` and `developer` are both refused — 0.4's matrix gave developer
+  // auditLogs WRITE only. `admin` passes every door (the export needs the
+  // object store, so "not 403" is the gate assertion there).
+  const asMember = await asRole('member');
+  const asDeveloper = await asRole('developer');
+  const asAdmin = await asRole('admin');
+  // The detail door must refuse with 403, never leak "no such row" as a 404.
+  const detailRefused = asMember[5] === 403 && asDeveloper[5] === 403;
+  await sql`DELETE FROM "member" WHERE "id" = ${gateMemberId}`;
+  record(
+    'audit surface: every read door is admin/owner-only (#1505)',
+    asMember.every((status) => status === 403) &&
+      asDeveloper.every((status) => status === 403) &&
+      detailRefused &&
+      asAdmin.every((status) => status !== 403),
+    `member=${asMember.join(',')} developer=${asDeveloper.join(',')} (want all 403), admin=${asAdmin.join(',')} (want none 403)`,
+  );
 }
 
 /**
@@ -31507,6 +31750,105 @@ async function checkTwoFactor(
       (verifyWhileLocked.status === 429 || verifyWhileLocked.status === 400) &&
       stateAfter[0]?.count === '0',
     `blocked=${blockedRes.status}/${blockedBody.success ? blockedBody.data.enrollRequired : 'ERR'} (want true), grace=${graceBody.success ? graceBody.data.enrollRequired !== true : 'ERR'}, anchored=${anchor1.length === 1 && anchor2[0]?.graceUntil === anchor1[0]?.graceUntil}, status=${wireStatus.success ? wireStatus.data.decision : 'ERR'}, locked=${lockedUntil !== null}, verify=${verifyWhileLocked.status}, cleared=${stateAfter[0]?.count}`,
+  );
+
+  // --- Lifecycle audit: enable / regenerate / disable, and the passkey trio
+  // 0.4 audited every SUCCESSFUL second-factor lifecycle event (#1508); the
+  // port kept only the failure half, so an attacker who registered their own
+  // passkey and turned TOTP off left no trace at all. Action names are 0.4's
+  // verbatim — a rename would break any saved query grouping on them.
+  const authPost = (route: string, body: unknown): Promise<Response> =>
+    fetch(`${base}/api/auth${route}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: JSON.stringify(body),
+    });
+  const lifecycleActions = async (): Promise<string[]> => {
+    const rows = await sql<{ action: string }[]>`
+      SELECT action FROM app.audit_logs
+      WHERE org_id = ${ctx.orgId} AND resource_type = 'twoFactorAuth'
+        AND resource_id = ${userId}
+      ORDER BY ts ASC
+    `;
+    return rows.map((row) => row.action);
+  };
+  const before2fa = await lifecycleActions();
+  const enableRes = await authPost('/two-factor/enable', {
+    password: 'itest-password-1',
+  });
+  const afterEnable = await lifecycleActions();
+  const regenRes = await authPost('/two-factor/generate-backup-codes', {
+    password: 'itest-password-1',
+  });
+  const afterRegen = await lifecycleActions();
+  const disableRes = await authPost('/two-factor/disable', {
+    password: 'itest-password-1',
+  });
+  const afterDisable = await lifecycleActions();
+  // Backup-code regeneration audits as a `2fa_enrolled` carrying the 0.4
+  // `backupCodesRegenerated` stamp. The endpoint needs a COMPLETED TOTP
+  // enrolment (a verified code), which a script cannot produce — so the
+  // assertion covers whichever way it answers: a 200 must leave the stamped
+  // row, and a refusal must leave NOTHING (the hook audits success only).
+  const regenRow = await sql<
+    { category: string; status: string; regenerated: boolean | null }[]
+  >`
+    SELECT category, status,
+           (metadata->>'backupCodesRegenerated')::boolean AS regenerated
+    FROM app.audit_logs
+    WHERE org_id = ${ctx.orgId} AND resource_id = ${userId}
+      AND action = '2fa_enrolled' AND metadata ? 'backupCodesRegenerated'
+    ORDER BY ts DESC LIMIT 1
+  `;
+  const regenConsistent =
+    regenRes.status === 200
+      ? regenRow.length === 1 &&
+        regenRow[0]?.regenerated === true &&
+        afterRegen.join(',') === '2fa_enrolled,2fa_enrolled'
+      : regenRow.length === 0 && afterRegen.join(',') === afterEnable.join(',');
+  // WebAuthn cannot be driven from a script, so the passkey trio is proven at
+  // the writer: the action names land as rows with the security shape.
+  const { recordTwoFactorLifecycleEvent } =
+    await import('./domains/two_factor/service.ts');
+  for (const action of [
+    'passkey_added',
+    'passkey_sign_in',
+    'passkey_removed',
+  ] as const) {
+    await recordTwoFactorLifecycleEvent(sql, {
+      userId,
+      action,
+      actorEmail: email,
+      ip: '203.0.113.9',
+      userAgent: 'itest-passkey/1.0',
+    });
+  }
+  const afterPasskeys = await lifecycleActions();
+  // Every lifecycle row carries the 0.4 security shape, not just the name.
+  const shapes = await sql<{ category: string; status: string }[]>`
+    SELECT DISTINCT category, status FROM app.audit_logs
+    WHERE org_id = ${ctx.orgId} AND resource_type = 'twoFactorAuth'
+      AND resource_id = ${userId}
+  `;
+  // Leave 2FA OFF: later lanes sign this account in with password alone.
+  const enrolled = await sql<{ enabled: boolean | null }[]>`
+    SELECT "twoFactorEnabled" AS enabled FROM "user" WHERE "id" = ${userId}
+  `;
+  record(
+    'two-factor: successful lifecycle events audit (#1508 action names)',
+    before2fa.length === 0 &&
+      enableRes.status === 200 &&
+      afterEnable.join(',') === '2fa_enrolled' &&
+      regenConsistent &&
+      disableRes.status === 200 &&
+      afterDisable.join(',') === `${afterRegen.join(',')},2fa_disabled` &&
+      afterPasskeys.join(',') ===
+        `${afterDisable.join(',')},passkey_added,passkey_sign_in,passkey_removed` &&
+      shapes.length === 1 &&
+      shapes[0]?.category === 'security' &&
+      shapes[0]?.status === 'success' &&
+      enrolled[0]?.enabled !== true,
+    `before=${before2fa.length}, enable=${enableRes.status} regen=${regenRes.status} (stamped=${regenRow.length}) disable=${disableRes.status}, trail=${afterPasskeys.join(',')}, shape=${shapes.map((s) => `${s.category}/${s.status}`).join('|')}, enabledLeftOn=${enrolled[0]?.enabled}`,
   );
 }
 


### PR DESCRIPTION
Two authorization and audit behaviours the port dropped. A read-only member
could send outbound mail under the organization's name; an attacker who added
a passkey and disabled 2FA left no successful-action trail.

Refs #3142. Supersedes #3149, which was 35 commits behind main.

## A read-only member could write to conversations

Reply, send outbound mail, close, bulk-act, delete, and act on individual
messages. 0.4 ran every conversation mutation through `mutationWithRLS`, whose
`conversations` and `conversationMessages` rules put each write through
`authorizeRls` at editor-or-above.

`viewerCanWrite` reuses that same matrix rather than declaring a second role
list. It composes with the half that was correctly ported: a write door checks
the role first, then loads the row through `loadVisibleConversation`, which
applies `conversationAssignmentAllows` per row. Role decides whether you may
change a conversation; assignment decides which ones you can see at all, and
is stricter still.

Twelve doors carry the check, as the handler's first statement — before the
body parse, so a refusal never depends on the payload.

The two assignment doors are the deliberate exception: they gate on
`viewerIsAdmin` in the service, which is stricter than editor, so a
route-level editor check would loosen them.

The attachment-fetch door answers 501 today, but it is where the
Gmail/Outlook `get_attachments` fetch lands, so it is gated now rather than
after that wiring makes it live. If you would rather keep it a pure read,
say so and I will drop that one line.

## 2FA and passkey events audited only on failure

All five events now audit, inside the same serializable transaction as the
state change.

The 0.4 action names are reused verbatim — `2fa_enrolled`, `2fa_disabled`,
`passkey_added`, `passkey_removed`, `passkey_sign_in`. A renamed action
silently breaks any existing query or export that groups on it. Checked
against 0.4's full vocabulary: `passkey_removed` and
`passkey_revoked_by_admin` were distinct events there and stay distinct here.

## Tests

Three layers, because they fail on different mistakes.

| Layer | Catches |
| --- | --- |
| `viewerCanWrite` pinned across all 8 role values | a matrix edit that widens the gate by accident |
| 12 doors driven through the real handlers | the gate present but deciding wrongly |
| static read of the route table | a NEW door shipping ungated |

At `member`, every door answers 403 and no service function is reached — the
refusal lands before the handler can touch state. At `editor`, no door returns
the gate's refusal envelope, and the four doors whose services are mocked run
all the way through (undo/retry/discard 200, attachments its own honest 501).

The third layer exists because a gate applied door by door invites the next
door to ship ungated. The assignment pair is allowlisted there, and a
companion assertion pins their service-side admin check so the allowlist
cannot quietly become a hole.

Each assertion was mutation-tested:

| Mutation | Went red |
| --- | --- |
| un-gate the attachment door | static check, naming the door |
| un-gate `POST /:id/reply` | static check **and** that door's behavioural test |
| drop `viewerIsAdmin` from `assignConversation` | the allowlist companion assertion |
| break the route-matching pattern | the door-count floor (`expected 0 to be 14`) |

`integration-check.ts` walks all twelve doors end to end at `member` expecting
403 and confirms the thread is untouched, then flips the member row to
`editor` and re-walks. I could not observe that lane: the suite aborts early
on the knowledge/embedding step, which needs `KNOWLEDGE_DATABASE_URL` and an
S3 endpoint this machine has no MinIO for. The three unit layers above are
what I actually ran.

## The audit-log third is dropped

The original #3149 also swapped the six audit-log doors from `authorizeRls` to
`isAdminRole`. That is now redundant: #3159 landed the same role matrix, and
main's doors already call `authorizeRls(role, 'auditLogs', 'read')`, which
that matrix denies for developer, editor and member. Restating the rule as a
second check at each door would be a divergent copy of a concept that already
has one home.

`access.ts` and `access.test.ts` came out of this branch empty for the same
reason — main already has them.

## Scope

Retention destruction still emits no audit rows — sixteen 0.4 action names
exist nowhere in the tree. Same class, different file.

The audit chain's `pii_scrubbed` recompute skip and its oldest-row trust
anchor are untouched; both are signed off in `backend/MIGRATION.md` as
intentional divergences, so they are a design question rather than a porting
defect.

## Gate

`typecheck` 0 errors, `oxlint --type-aware` clean, `oxfmt --check` clean,
conversations + auth + two_factor suites **98 passed (13 files)**.
