### PR TITLE
docs: correct compose comments that still describe Convex

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -86,7 +86,8 @@ services:
 
     environment:
       # Platform DB: skip the knowledge-corpus dbmate migrations — the
-      # platform/auth schema in tale_platform is owned by Convex, not dbmate.
+      # app database (`tale_app`) is migrated by the backend at boot, not
+      # by dbmate, so `migrations/db/` is empty and this role is a no-op.
       TALE_DB_ROLE: platform
 
     # Restart policy
@@ -136,9 +137,9 @@ services:
   # Independent datastore for knowledge/RAG content (the `tale_knowledge`
   # database with the `private_knowledge` + `public_web` schemas). Split out
   # from `db` so the knowledge corpus — the data-residency-sensitive store —
-  # can be relocated/replaced independently of the platform/Convex operational
-  # DB. The platform's Convex node-actions connect here via
-  # `KNOWLEDGE_DATABASE_URL` (postgres.js); nothing else talks to it.
+  # can be relocated/replaced independently of the operational DB. The backend
+  # connects here via `KNOWLEDGE_DATABASE_URL` (postgres.js, pooled in
+  # backend/core/knowledge/pool.ts); nothing else talks to it.
   # ============================================================================
   knowledge-db:
     # Same image `db` builds. A second `build:` here makes
@@ -238,7 +239,7 @@ services:
       - internal
 
   # ============================================================================
-  # Tale Platform (TanStack Start + Convex)
+  # Tale Platform (Vite + TanStack Router SPA, served by Bun)
   # ============================================================================
   platform:
     # Image from GHCR (used when PULL_POLICY=always)
@@ -275,12 +276,10 @@ services:
       - path: .env
         required: false
 
-    # Live browser view (read-only mirror). Read here too — the entrypoint pushes
-    # it to Convex (run_external_agent gates on it), and the sandbox spawner reads
-    # the SAME var, so the two MUST stay in lockstep. Unset ⇒ default ON; set
+    # Live browser view (read-only mirror). Read here too — the sandbox spawner
+    # reads the SAME var, so the two MUST stay in lockstep. Unset ⇒ default ON; set
     # SANDBOX_BROWSER_VIEW=0 (or false/no/off) to opt out. Interpolates from the
-    # same root .env as the sandbox service so one value drives both. Empty ⇒ the
-    # entrypoint skips pushing it, leaving the Convex-side default ON. Mirrors the
+    # same root .env as the sandbox service so one value drives both. Mirrors the
     # CLI generator (create-platform-service.ts).
     environment:
       SANDBOX_BROWSER_VIEW: ${SANDBOX_BROWSER_VIEW:-}
@@ -340,11 +339,10 @@ services:
   # Tale 0.5 backend (parallel build) — OPT-IN under the `backend` profile
   # ----------------------------------------------------------------------------
   # The SAME platform image, started in a different role via TALE_ROLE
-  # (docker-entrypoint.sh dispatches before any Convex work). Default topology
+  # (docker-entrypoint.sh dispatches on it). Default topology
   # is one `api` + one `worker` container; either scales independently:
   #   docker compose --profile backend up -d --scale backend-worker=3
   # (no `container_name` on these two services precisely so --scale works).
-  # Runs alongside the Convex stack during the 0.5 parallel build; replaces the
   # State lives in the `tale_app` database on the `db` service (created
   # idempotently by services/db/init-scripts/04-create-app-database.sql).
   # ============================================================================
@@ -587,11 +585,6 @@ services:
         required: false
 
     environment:
-      # The Convex→Postgres cutover switch. Set (with the `backend` profile
-      # running) it routes auth, the app API, the hint stream, both machine
-      # doors, SSO/SCIM/trusted-headers, the control channel, cloud-import
-      # OAuth and WebDAV to the pg backend; unset, every lane stays on
-      # Convex. `tale deploy` writes it into .env once a stack is migrated.
       # The application backend. Every migrated lane routes here; the switch
       # remains an env var so an operator can point the proxy at another
       # host/port, never so the stack can fall back to a runtime that no
@@ -642,7 +635,7 @@ services:
         # `localhost` this alias is inert — every container's /etc/hosts pins
         # `localhost` to 127.0.0.1, which shadows Docker DNS — and that is fine:
         # the platform makes no server-side calls to its own public URL (no SSR;
-        # internal traffic uses Docker service names / the internal Convex URL).
+        # internal traffic uses Docker service names).
         # The alias still does real work when HOST is a custom domain.
         aliases:
           - ${HOST:-localhost}
@@ -748,7 +741,7 @@ services:
     container_name: tale-sandbox
     # Loopback-only port mapping. The spawner mounts /var/run/docker.sock,
     # so an unauthenticated request on this port = remote root via docker.
-    # Convex reaches the spawner through the `internal` Docker network
+    # The backend reaches the spawner through the `internal` Docker network
     # (http://sandbox:8003) — the published port is only for `bun dev`
     # running the backend on the host. NEVER publish on 0.0.0.0.
     ports:
@@ -779,8 +772,8 @@ services:
       SANDBOX_BUILDKITD_MIRROR_IMAGE: ${SANDBOX_BUILDKITD_MIRROR_IMAGE:-registry:2}
       # Live browser view (read-only mirror). Unset here so BOTH sides apply
       # their default-ON; set SANDBOX_BROWSER_VIEW=0 (or false/no/off) to opt out.
-      # ONE value drives both sides — this spawner reads it directly and the
-      # platform pushes it to Convex — so they MUST share a source. It is read on
+      # ONE value drives both sides — this spawner and the sandbox runtime each
+      # read it directly — so they MUST share a source. It is read on
       # the platform service too (NOT a sandbox-only var like the ones above), and
       # both interpolate from the same root .env, so a single value keeps them in
       # lockstep. Mirrors the CLI generator (create-sandbox-service.ts).

--- a/tools/cli/src/lib/compose/services/create-db-service.ts
+++ b/tools/cli/src/lib/compose/services/create-db-service.ts
@@ -41,7 +41,7 @@ export function createDbService(config: ServiceConfig): ComposeService {
     // is set here or in .env). The split `compose.yml` runs a SEPARATE
     // `knowledge-db` service, so the in-process RAG/crawler code resolves its
     // datastore at host `knowledge-db` by default
-    // (convex/lib/knowledge/db/knowledge_db.ts → getKnowledgeDatabaseUrl). We
+    // (the backend resolves it via getKnowledgeDatabaseUrl). We
     // alias this service to `knowledge-db` so that same default URL resolves
     // here, with no extra env wiring — keeping the runtime identical across
     // both topologies.


### PR DESCRIPTION
The shipped `compose.yml` explains itself to operators, and eleven of its
comments still describe the retired Convex runtime. Comments have no runtime
effect, which is exactly why they went stale — nothing fails when they are
wrong, so the operator reading the file is the one who pays.

Each is replaced with what the file actually does now, verified against the
code rather than reworded.

| Comment said | Verified truth | Source |
| --- | --- | --- |
| the auth schema is "owned by Convex, not dbmate" | `tale_app` is migrated by the backend at boot, so `migrations/db/` is empty and the role is a no-op | `services/db/README.md` |
| platform is "TanStack Start + Convex" | a Vite + TanStack Router SPA served by Bun; no `@tanstack/react-start` dependency exists | `services/platform/package.json` |
| the entrypoint pushes `SANDBOX_BROWSER_VIEW` to Convex | nothing pushes it — the sandbox spawner and the sandbox runtime each read it | `services/sandbox/src/types.ts`, `services/sandbox-runtime/entrypoint.sh` |
| the entrypoint "dispatches before any Convex work" | it dispatches on `TALE_ROLE`, and there is no Convex work | `services/platform/docker-entrypoint.sh:133` |
| `BACKEND_UPSTREAM` is the "Convex→Postgres cutover switch" | an override for split deployments; an unset value 404s the machine doors rather than falling back | `services/proxy/docker-entrypoint.sh:122` |
| "Convex node-actions connect here via `KNOWLEDGE_DATABASE_URL`" | the backend connects, pooled | `backend/core/knowledge/pool.ts` |
| "internal traffic uses ... the internal Convex URL" | Docker service names | — |
| "Convex reaches the spawner" | the backend does | — |

The `BACKEND_UPSTREAM` block already carried a correct paragraph directly
below the stale one, so that fix is a deletion. One sentence had also been
left truncated mid-clause ("replaces the" → nothing) when the parallel-build
note was cut.

Also drops a reference to a path deleted with the Convex tree:
`convex/lib/knowledge/db/knowledge_db.ts` in the CLI's db-service comment.

The docs image's dockerignore still lists `services/convex/`. Removing that
dead line is a no-op for the build, but `services/*/Dockerfile.dockerignore`
is a trigger path for `security.yml` — so a one-line comment cleanup pulled in
`Bun audit` and the Trivy filesystem scan, and both are red for reasons that
have nothing to do with this PR (see below). Left for whoever fixes them.

## What is deliberately kept

Three mentions stay. They explain why the `convex-data` volume keeps its
name, which is load-bearing — renaming it would make every existing operator
migrate a volume. The fourth, `Convex _storage retired`, is a historical note
about why S3 is the only blob backend.

## This replaces #3150, and does not carry its docs diff

#3150 set out to align the self-hosted docs with the Postgres backend. #3154
has since done that, and #3150's version is now *behind* main on two facts:

- It describes eleven containers with a separate `tale-knowledge-db`. That is
  the repo's local-dev `compose.yml`. The `tale deploy` stack is generated by
  the CLI, has no separate knowledge service, and reaches the corpus through a
  `knowledge-db` network alias on `db` — which is what main's page already
  says. `tools/cli/src/lib/compose/services/create-db-service.ts` states it
  outright: "The single-node CLI stack has no separate `knowledge-db` service."
- It describes the platform as React + TanStack Start. Main correctly says
  Vite + TanStack Router.

Applying it would regress both. I started to "correct" main's container count
from the local-dev compose file before finding the generator, so this PR
carries none of that — main's pages are accurate and untouched here.

## Out of scope

There are ~1,500 Convex mentions elsewhere in the tree — schema field names,
test fixtures, identifiers, and wire-contract keys. That is a rename epic with
real compatibility questions, not a comment pass, so nothing outside these
three files is touched.

## Gate

`docker compose -f compose.yml config` valid, `oxfmt --check` clean, the CLI
compose suite **47 pass / 0 fail** (`bun test src/lib/compose` — these use
`bun:test`, not vitest).


## A finding worth its own issue

Touching that dockerignore triggered `security.yml`, which gates on HIGH and
CRITICAL production advisories — and it fails: Faker (`GHSA-qxc2-j82w-r537`),
MySQL2 auth-plugin downgrade (`GHSA-3f6p-5ww8-...`), and three `fast-uri`
SSRF/host-confusion advisories.

That workflow only runs when `bun.lock`, a `package.json`, a `Dockerfile`, a
`Dockerfile.dockerignore`, `.trivyignore.yaml`, or the workflow itself
changes. So main can accumulate advisories without any PR going red, which is
what has happened. Trivy also logs a pre-existing parse error on
`services/db/Dockerfile.dockerignore` (it reads a dockerignore as a
Dockerfile).

Both belong in their own change — a dependency bump with real compatibility
questions — not in a comment pass.
