### PR TITLE
fix(platform): close five low-severity authz and tenant-isolation gaps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -221,6 +221,7 @@
         "@tanstack/react-router": "1.168.10",
         "@tanstack/react-table": "8.21.3",
         "@tanstack/react-virtual": "3.13.26",
+        "@xmldom/xmldom": "0.8.13",
         "@xyflow/react": "12.10.2",
         "ai": "6.0.156",
         "ajv": "8.20.0",

--- a/docs/de/platform/admin/enterprise-sso.md
+++ b/docs/de/platform/admin/enterprise-sso.md
@@ -58,7 +58,7 @@ Wenn ein Anbieter OAuth2, aber kein Discovery-Dokument bietet, wähle **OAuth2**
 3. Füge unter **IdP-Metadaten importieren** die Föderations-Metadaten-URL deines IdP ein und klick auf **Importieren** — oder klick auf **XML hochladen**, falls dein IdP nur eine Datei zum Herunterladen anbietet. Tale liest die Metadaten aus und füllt Entity-ID, Anmelde-URL und Signaturzertifikat in den Feldern darunter, ohne dass du etwas abtippen musst. Alle drei Felder bleiben bearbeitbar — prüfe die importierten Werte (oder trag sie von Hand ein, falls dein IdP keine Metadaten veröffentlicht), bevor du speicherst.
 4. Ordne die Attribute für **E-Mail**, **Name** und **Gruppe** in deinem IdP zu; weichen die Namen von den Standardwerten ab, trage die passenden Attributnamen in Tales erweiterten Feldern ein.
 
-Tale unterstützt sowohl IdP-initiiertes SAML (der IdP sendet eine Assertion an die ACS-URL) als auch SP-initiiertes SAML (ein Mitglied klickt auf **Mit SSO anmelden** und Tale leitet zum IdP weiter). Signierte Assertions sind erforderlich; verschlüsselte Assertions werden unterstützt, wenn du ein SP-Schlüsselpaar bereitstellst.
+Tale unterstützt sowohl IdP-initiiertes SAML (der IdP sendet eine Assertion an die ACS-URL) als auch SP-initiiertes SAML (ein Mitglied klickt auf **Mit SSO anmelden** und Tale leitet zum IdP weiter). Signierte Assertions sind erforderlich; verschlüsselte Assertions werden unterstützt, wenn du ein SP-Schlüsselpaar bereitstellst — und eine Verbindung, die sie verlangt, weist jede unverschlüsselt eintreffende Assertion ab.
 
 ## Mehrere Organisationen auf einem Deployment
 

--- a/docs/en/platform/admin/enterprise-sso.md
+++ b/docs/en/platform/admin/enterprise-sso.md
@@ -58,7 +58,7 @@ If a provider exposes OAuth2 but no discovery document, choose **OAuth2** and en
 3. Under **Import IdP metadata**, paste the IdP's federation-metadata URL and click **Import** — or click **Upload XML** if your IdP only offers a downloadable file. Tale parses the metadata and fills the entity ID, sign-on URL, and signing certificate fields below, so there's nothing to retype by hand. All three stay editable, so review the imported values (or fill them in yourself, if your IdP publishes no metadata document) before saving.
 4. Map the **email**, **name**, and **group** attributes in your IdP; if their names differ from the defaults, set the matching attribute names in Tale's advanced fields.
 
-Tale supports both IdP-initiated SAML (the IdP posts an assertion to the ACS URL) and SP-initiated SAML (a member clicks **Sign in with SSO** and Tale redirects to the IdP). Signed assertions are required; encrypted assertions are supported when you supply an SP keypair.
+Tale supports both IdP-initiated SAML (the IdP posts an assertion to the ACS URL) and SP-initiated SAML (a member clicks **Sign in with SSO** and Tale redirects to the IdP). Signed assertions are required; encrypted assertions are supported when you supply an SP keypair, and a connection that requires them refuses any assertion that arrives unencrypted.
 
 ## Several organizations on one deployment
 

--- a/docs/fr/platform/admin/enterprise-sso.md
+++ b/docs/fr/platform/admin/enterprise-sso.md
@@ -58,7 +58,7 @@ Si un fournisseur expose OAuth2 mais pas de document de découverte, choisis **O
 3. Sous **Importer les métadonnées de l'IdP**, colle l’URL des métadonnées de fédération de ton IdP et clique sur **Importer** — ou clique sur **Téléverser le XML** si ton IdP ne propose qu’un fichier à télécharger. Tale lit les métadonnées et remplit l’ID d’entité, l’URL de connexion et le certificat de signature dans les champs ci-dessous, sans que tu aies à les ressaisir. Les trois champs restent modifiables — vérifie les valeurs importées (ou saisis-les toi-même si ton IdP ne publie aucune métadonnée) avant d’enregistrer.
 4. Mappe les attributs **e-mail**, **nom** et **groupe** dans ton IdP ; si leurs noms diffèrent des valeurs par défaut, indique les noms d’attributs correspondants dans les champs avancés de Tale.
 
-Tale prend en charge le SAML initié par l’IdP (l’IdP envoie une assertion à l’URL ACS) et le SAML initié par le SP (un membre clique sur **Se connecter avec le SSO** et Tale redirige vers l’IdP). Les assertions signées sont requises ; les assertions chiffrées sont prises en charge si tu fournis une paire de clés SP.
+Tale prend en charge le SAML initié par l’IdP (l’IdP envoie une assertion à l’URL ACS) et le SAML initié par le SP (un membre clique sur **Se connecter avec le SSO** et Tale redirige vers l’IdP). Les assertions signées sont requises ; les assertions chiffrées sont prises en charge si tu fournis une paire de clés SP — et une connexion qui les exige refuse toute assertion qui arrive en clair.
 
 ## Plusieurs organisations sur un même déploiement
 

--- a/services/platform/backend/core/enterprise_sso/login/callback_handler.test.ts
+++ b/services/platform/backend/core/enterprise_sso/login/callback_handler.test.ts
@@ -2,8 +2,41 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ActionCtx } from '../../lib/ctx';
 import { signValue } from '../sign_cookie_value';
+import type { SsoProviderAdapter } from '../types';
 import { ssoCallbackHandler } from './callback_handler';
 import type { FinishLogin } from './finish_login';
+
+/** An IdP that answers the token exchange and userinfo without a network —
+ * the provisioning-refusal case needs the callback to get PAST the adapter. */
+const { fakeAdapter } = vi.hoisted(() => ({
+  fakeAdapter: {
+    providerId: 'fake-idp',
+    displayName: 'Fake IdP',
+    capabilities: {
+      supportsGroupSync: false,
+      supportsRoleMapping: false,
+      supportsOneDriveAccess: false,
+      supportsGoogleDriveAccess: false,
+      supportsPkce: false,
+    },
+    buildAuthorizeUrl: vi.fn(),
+    exchangeCodeForTokens: vi.fn(),
+    getUserInfo: vi.fn(),
+    validateConfig: vi.fn(),
+  },
+}));
+
+vi.mock('../registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../registry')>();
+  return {
+    ...actual,
+    getAdapter: (providerId: string): SsoProviderAdapter | null =>
+      providerId === 'fake-idp'
+        ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the vi.fn() members satisfy the adapter contract at runtime
+          (fakeAdapter as unknown as SsoProviderAdapter)
+        : actual.getAdapter(providerId),
+  };
+});
 
 /**
  * Regressions for A2.1 error handling:
@@ -183,5 +216,121 @@ describe('ssoCallbackHandler — error redirects land on the public origin', () 
     const target = new URL(res.headers.get('Location') as string);
     expect(target.origin).toBe(PUBLIC_ORIGIN);
     expect(target.searchParams.get('error')).toBe('sso.errors.userNotAssigned');
+  });
+});
+
+describe('ssoCallbackHandler — a refused provisioning is audited', () => {
+  beforeEach(() => {
+    process.env.BETTER_AUTH_SECRET = SECRET;
+    process.env.SITE_URL = PUBLIC_ORIGIN;
+    delete process.env.BASE_PATH;
+    fakeAdapter.exchangeCodeForTokens.mockResolvedValue({
+      accessToken: 'access-token',
+    });
+    fakeAdapter.getUserInfo.mockResolvedValue({
+      externalId: 'ext-outsider',
+      email: 'outsider@example.test',
+      name: 'Outsider',
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.BETTER_AUTH_SECRET;
+    delete process.env.SITE_URL;
+    vi.clearAllMocks();
+  });
+
+  /** ctx whose config resolves to the fake IdP and whose `handleSsoLogin`
+   * answers `outcome`; `runMutation` is the audit sink under test. */
+  function refusingCtx(outcome: unknown): {
+    ctx: ActionCtx;
+    runMutation: ReturnType<typeof vi.fn>;
+  } {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue({
+        organizationId: 'org1',
+        providerId: 'fake-idp',
+        issuer: 'https://idp.example.test',
+        scopes: ['openid'],
+        autoProvisionRole: false,
+        autoProvisionTeam: false,
+        roleMappingRules: [],
+      }),
+      runAction: vi
+        .fn()
+        // getConnectionSecrets, then handleSsoLogin.
+        .mockResolvedValueOnce({ clientId: 'client', clientSecret: 'secret' })
+        .mockResolvedValueOnce(outcome),
+      runMutation,
+    } as unknown as ActionCtx;
+    return { ctx, runMutation };
+  }
+
+  it('writes the audit row for a refused login and bounces with its key', async () => {
+    const state = await signedState({
+      redirectUri: `${PUBLIC_ORIGIN}/http_api/api/sso/callback`,
+      timestamp: Date.now(),
+      organizationId: 'org1',
+    });
+    const { ctx, runMutation } = refusingCtx({
+      success: false,
+      error: 'sso.errors.notOrgMember',
+    });
+
+    const res = await ssoCallbackHandler(
+      ctx,
+      callbackRequest({ code: 'code', state }),
+      { finishLogin: neverFinishes },
+    );
+
+    expect(res.status).toBe(302);
+    const target = new URL(res.headers.get('Location') as string);
+    expect(target.pathname).toBe('/log-in');
+    expect(target.searchParams.get('error')).toBe('sso.errors.notOrgMember');
+    // The refusal happened with org and email already resolved — exactly
+    // the row an operator investigating a locked-out user needs.
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationId: 'org1',
+        action: 'sso_login_failed',
+        category: 'auth',
+        status: 'failure',
+        actorEmail: 'outsider@example.test',
+        errorMessage: 'sso.errors.notOrgMember',
+        metadata: expect.objectContaining({
+          stage: 'callback',
+          errorKey: 'sso.errors.notOrgMember',
+          providerId: 'fake-idp',
+        }),
+      }),
+    );
+  });
+
+  it('audits a success without a session token the same way', async () => {
+    const state = await signedState({
+      redirectUri: `${PUBLIC_ORIGIN}/http_api/api/sso/callback`,
+      timestamp: Date.now(),
+      organizationId: 'org1',
+    });
+    const { ctx, runMutation } = refusingCtx({ success: true });
+
+    const res = await ssoCallbackHandler(
+      ctx,
+      callbackRequest({ code: 'code', state }),
+      { finishLogin: neverFinishes },
+    );
+
+    expect(res.status).toBe(302);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sso_login_failed',
+        errorMessage: 'Failed to create session',
+        actorEmail: 'outsider@example.test',
+      }),
+    );
   });
 });

--- a/services/platform/backend/core/enterprise_sso/saml/acs_handler.ts
+++ b/services/platform/backend/core/enterprise_sso/saml/acs_handler.ts
@@ -18,9 +18,10 @@ function loginRedirect(origin: string, message: string): Response {
 
 /**
  * POST /api/sso/saml/acs — SAML Assertion Consumer Service. Verifies the signed
- * (optionally encrypted) assertion in a Node action, maps attributes to our
- * identity, then funnels into the shared provisioning action and sets the
- * session cookie. RelayState carries the org id for SP-initiated flows.
+ * (and, when the connection requires it, encrypted) assertion in a Node
+ * action, maps attributes to our identity, then funnels into the shared
+ * provisioning action and sets the session cookie. RelayState carries the org
+ * id for SP-initiated flows.
  */
 export async function samlAcsHandler(
   ctx: ActionCtx,
@@ -93,13 +94,17 @@ export async function samlAcsHandler(
         acsUrl,
         spPrivateKey,
         wantAssertionsSigned: config.wantAssertionsSigned,
+        wantAssertionsEncrypted: config.wantAssertionsEncrypted,
       },
     );
     if (!validation.ok) {
       console.error('[SSO] SAML validation failed:', validation.error);
       const message = validation.error || 'SAML validation failed';
-      await auditFailure(message);
-      return loginRedirect(origin, message);
+      // A refusal with its own login-page key (the encryption requirement)
+      // is audited under its readable reason and bounced with the key; every
+      // other validator error is bounced as the readable reason itself.
+      await auditFailure(message, validation.errorKey);
+      return loginRedirect(origin, validation.errorKey ?? message);
     }
 
     const identity = mapSamlIdentity(

--- a/services/platform/backend/core/enterprise_sso/saml/validate_assertion.test.ts
+++ b/services/platform/backend/core/enterprise_sso/saml/validate_assertion.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment node
 
-import { createHash, createSign, generateKeyPairSync } from 'node:crypto';
+import {
+  constants as cryptoConstants,
+  createCipheriv,
+  createHash,
+  createSign,
+  generateKeyPairSync,
+  publicEncrypt,
+  randomBytes,
+  type KeyObject,
+} from 'node:crypto';
 import { inflateRawSync } from 'node:zlib';
 
 import type { CacheItem, CacheProvider } from '@node-saml/node-saml';
@@ -8,6 +17,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import {
   buildSamlAuthnRedirectImpl,
+  SAML_ASSERTION_NOT_ENCRYPTED_KEY,
   validateSamlResponseImpl,
 } from './validate_assertion';
 
@@ -21,7 +31,10 @@ import {
  * The signing fixture mirrors `integration-check.ts`'s checkSamlLogin: a
  * per-run RSA keypair, hand-canonicalized assertion XML signed with
  * node:crypto, and the "certificate" is a bare public-key PEM (node-saml's
- * keyInfoToPem accepts any RFC 7468 PEM) — no committed key material.
+ * keyInfoToPem accepts any RFC 7468 PEM) — no committed key material. The
+ * encryption fixture wraps that signed assertion the way an IdP does
+ * (XML-Enc: AES-256-CBC content key, RSA-OAEP key transport — the shape
+ * xml-encryption's `decrypt` reads), under a per-run SP keypair.
  */
 
 const SP_ENTITY_ID = 'http://sp.itest/http_api/api/sso/saml/metadata';
@@ -51,6 +64,8 @@ function memoryCache(): CacheProvider & { keys: () => string[] } {
 
 let publicKeyPem: string;
 let privateKey: ReturnType<typeof generateKeyPairSync>['privateKey'];
+let spPublicKey: KeyObject;
+let spPrivateKeyPem: string;
 
 beforeAll(() => {
   const pair = generateKeyPairSync('rsa', { modulusLength: 2048 });
@@ -58,18 +73,25 @@ beforeAll(() => {
     .export({ type: 'spki', format: 'pem' })
     .toString();
   privateKey = pair.privateKey;
+  const spPair = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  spPublicKey = spPair.publicKey;
+  spPrivateKeyPem = spPair.privateKey
+    .export({ type: 'pkcs8', format: 'pem' })
+    .toString();
 });
 
 function iso(ms: number): string {
   return new Date(ms).toISOString();
 }
 
-/** A canonical, signed SAMLResponse (base64), optionally answering a request. */
-function buildSignedResponse(opts: {
+interface ResponseOpts {
   id: string;
   email: string;
   inResponseTo?: string;
-}): string {
+}
+
+/** A canonical, signed `saml:Assertion` (the IdP's signing step). */
+function signedAssertion(opts: ResponseOpts): string {
   const now = Date.now();
   const notOnOrAfter = now + 300_000;
   const subjectConfirmationData = opts.inResponseTo
@@ -108,19 +130,67 @@ function buildSignedResponse(opts: {
   const signature =
     `<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">${signedInfo}` +
     `<ds:SignatureValue>${signatureValue}</ds:SignatureValue></ds:Signature>`;
-  const signed = assertion.replace(
-    '</saml:Issuer>',
-    `</saml:Issuer>${signature}`,
-  );
+  return assertion.replace('</saml:Issuer>', `</saml:Issuer>${signature}`);
+}
+
+/** The `samlp:Response` envelope (base64, POST binding) around `body`. */
+function wrapResponse(body: string, opts: ResponseOpts): string {
   const inResponseToAttr = opts.inResponseTo
     ? ` InResponseTo="${opts.inResponseTo}"`
     : '';
   return Buffer.from(
-    `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_resp${opts.id}" IssueInstant="${iso(now)}" Version="2.0" Destination="${ACS_URL}"${inResponseToAttr}>` +
+    `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_resp${opts.id}" IssueInstant="${iso(Date.now())}" Version="2.0" Destination="${ACS_URL}"${inResponseToAttr}>` +
       `<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"></samlp:StatusCode></samlp:Status>` +
-      signed +
+      body +
       `</samlp:Response>`,
   ).toString('base64');
+}
+
+/** A canonical, signed SAMLResponse (base64), optionally answering a request. */
+function buildSignedResponse(opts: ResponseOpts): string {
+  return wrapResponse(signedAssertion(opts), opts);
+}
+
+/**
+ * The IdP's encryption step over a signed assertion: a fresh AES-256-CBC
+ * content key (IV prefixed, PKCS#7 padded — what xml-encryption strips),
+ * transported under RSA-OAEP (SHA-1 MGF1, xml-encryption's default) to the
+ * SP's public key, laid out as `EncryptedData/KeyInfo/EncryptedKey`.
+ */
+function encryptedAssertion(
+  assertionXml: string,
+  recipient: KeyObject,
+): string {
+  const contentKey = randomBytes(32);
+  const iv = randomBytes(16);
+  const cipher = createCipheriv('aes-256-cbc', contentKey, iv);
+  const ciphertext = Buffer.concat([
+    iv,
+    cipher.update(assertionXml, 'utf8'),
+    cipher.final(),
+  ]);
+  const wrappedKey = publicEncrypt(
+    {
+      key: recipient,
+      padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: 'sha1',
+    },
+    contentKey,
+  );
+  return (
+    `<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">` +
+    `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Type="http://www.w3.org/2001/04/xmlenc#Element">` +
+    `<xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"></xenc:EncryptionMethod>` +
+    `<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">` +
+    `<xenc:EncryptedKey>` +
+    `<xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"></xenc:EncryptionMethod>` +
+    `<xenc:CipherData><xenc:CipherValue>${wrappedKey.toString('base64')}</xenc:CipherValue></xenc:CipherData>` +
+    `</xenc:EncryptedKey>` +
+    `</ds:KeyInfo>` +
+    `<xenc:CipherData><xenc:CipherValue>${ciphertext.toString('base64')}</xenc:CipherValue></xenc:CipherData>` +
+    `</xenc:EncryptedData>` +
+    `</saml:EncryptedAssertion>`
+  );
 }
 
 function validateArgs(samlResponse: string) {
@@ -217,5 +287,104 @@ describe('SAML InResponseTo replay protection (real node-saml)', () => {
 
     expect(result.ok).toBe(true);
     expect(result.nameId).toBe('idp.initiated@door.test');
+  });
+});
+
+/**
+ * `wantAssertionsEncrypted` is a REQUIREMENT, not a capability flag: with it
+ * set, a validly signed plaintext assertion is refused (bounced under its own
+ * login-page key), while the same assertion encrypted to the SP keypair is
+ * accepted — and everything that is not the encryption question stays
+ * node-saml's call.
+ */
+describe('SAML wantAssertionsEncrypted (real node-saml)', () => {
+  it('refuses a signed plaintext assertion when the connection requires encryption', async () => {
+    const response = buildSignedResponse({
+      id: '_plain1',
+      email: 'saml.user@door.test',
+    });
+
+    const result = await validateSamlResponseImpl(
+      {
+        ...validateArgs(response),
+        spPrivateKey: spPrivateKeyPem,
+        wantAssertionsEncrypted: true,
+      },
+      { cacheProvider: memoryCache() },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKey).toBe(SAML_ASSERTION_NOT_ENCRYPTED_KEY);
+    expect(result.error).toMatch(/requires encrypted assertions/);
+    expect(result.nameId).toBeUndefined();
+  });
+
+  it('keeps accepting the plaintext assertion while encryption is not required', async () => {
+    const response = buildSignedResponse({
+      id: '_plain2',
+      email: 'saml.user@door.test',
+    });
+
+    const relaxed = await validateSamlResponseImpl(
+      { ...validateArgs(response), spPrivateKey: spPrivateKeyPem },
+      { cacheProvider: memoryCache() },
+    );
+    const explicit = await validateSamlResponseImpl(
+      {
+        ...validateArgs(response),
+        spPrivateKey: spPrivateKeyPem,
+        wantAssertionsEncrypted: false,
+      },
+      { cacheProvider: memoryCache() },
+    );
+
+    expect(relaxed.ok).toBe(true);
+    expect(explicit.ok).toBe(true);
+    expect(explicit.nameId).toBe('saml.user@door.test');
+  });
+
+  it('accepts the same assertion encrypted to the SP keypair when required', async () => {
+    const opts = { id: '_enc1', email: 'encrypted.user@door.test' };
+    const response = wrapResponse(
+      encryptedAssertion(signedAssertion(opts), spPublicKey),
+      opts,
+    );
+
+    const result = await validateSamlResponseImpl(
+      {
+        ...validateArgs(response),
+        spPrivateKey: spPrivateKeyPem,
+        wantAssertionsEncrypted: true,
+      },
+      { cacheProvider: memoryCache() },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.nameId).toBe('encrypted.user@door.test');
+  });
+
+  it('leaves every other verdict on an encrypted assertion to node-saml', async () => {
+    // Encrypted to a key the SP does NOT hold: the requirement is met, so the
+    // refusal is node-saml's decryption failure — never the encryption key.
+    const opts = { id: '_enc2', email: 'encrypted.user@door.test' };
+    const stranger = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const response = wrapResponse(
+      encryptedAssertion(signedAssertion(opts), stranger.publicKey),
+      opts,
+    );
+
+    const result = await validateSamlResponseImpl(
+      {
+        ...validateArgs(response),
+        spPrivateKey: spPrivateKeyPem,
+        wantAssertionsEncrypted: true,
+      },
+      { cacheProvider: memoryCache() },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKey).toBeUndefined();
+    expect(result.error).not.toMatch(/requires encrypted assertions/);
   });
 });

--- a/services/platform/backend/core/enterprise_sso/saml/validate_assertion.ts
+++ b/services/platform/backend/core/enterprise_sso/saml/validate_assertion.ts
@@ -6,6 +6,7 @@ import {
   type CacheProvider,
   type SamlConfig,
 } from '@node-saml/node-saml';
+import { DOMParser } from '@xmldom/xmldom';
 
 /**
  * SAML 2.0 assertion handling, isolated in a Node action (node-saml needs
@@ -14,6 +15,50 @@ import {
  * a normalized identity. Keeps the node/V8 bundling boundary clean (see the
  * `convex` skill): file I/O and Node-only libs live here, plain data crosses out.
  */
+
+/** The login-page key a connection that requires encrypted assertions
+ * bounces a plaintext one with (audited under its readable reason). */
+export const SAML_ASSERTION_NOT_ENCRYPTED_KEY =
+  'sso.errors.assertionNotEncrypted';
+
+/**
+ * Whether the POSTed Response carries its assertion as an
+ * `EncryptedAssertion`. node-saml has no "require encryption" option — it
+ * decrypts when it finds one and accepts a plaintext `Assertion` otherwise —
+ * so the requirement is enforced here, on the SAME parse node-saml runs:
+ * the same library with the same options, direct children of the root by
+ * local name (`saml.js`'s `validatePostResponseAsync`), so the gate can never
+ * judge a different document than the validator processes. `null` when the
+ * document does not parse: there is no assertion to judge, and node-saml
+ * fails the response with its own error.
+ */
+function carriesEncryptedAssertion(samlResponse: string): boolean | null {
+  let malformed = false;
+  const flag = (): void => {
+    malformed = true;
+  };
+  const doc = new DOMParser({
+    locator: {},
+    errorHandler: { error: flag, fatalError: flag },
+  }).parseFromString(
+    Buffer.from(samlResponse, 'base64').toString('utf8'),
+    'text/xml',
+  );
+  const root = doc.documentElement;
+  if (malformed || !root || root.localName !== 'Response') return null;
+  let encryptedAssertions = 0;
+  for (let index = 0; index < root.childNodes.length; index += 1) {
+    const node = root.childNodes.item(index);
+    if (
+      node !== null &&
+      'localName' in node &&
+      node.localName === 'EncryptedAssertion'
+    ) {
+      encryptedAssertions += 1;
+    }
+  }
+  return encryptedAssertions > 0;
+}
 
 export interface SamlValidationDeps {
   /**
@@ -76,22 +121,38 @@ export interface ValidateSamlResponseArgs {
   acsUrl: string;
   spPrivateKey?: string;
   wantAssertionsSigned?: boolean;
+  /** The connection's "require encrypted assertions" setting: a plaintext
+   * assertion is refused BEFORE validation when set. */
+  wantAssertionsEncrypted?: boolean;
 }
 
 /** Verify a SAMLResponse (POST binding) and return the normalized identity —
  * the plain body {@link validateSamlResponse} wraps (reused by 0.5). A
  * present InResponseTo must match an unconsumed issued-request ID in
- * `deps.cacheProvider` (consumed on success — one-time use). */
+ * `deps.cacheProvider` (consumed on success — one-time use). A refusal
+ * that has its own login-page key carries it as `errorKey`. */
 export async function validateSamlResponseImpl(
   args: ValidateSamlResponseArgs,
   deps: SamlValidationDeps,
 ): Promise<{
   ok: boolean;
   error?: string;
+  errorKey?: string;
   nameId?: string;
   attributes?: Record<string, unknown>;
 }> {
   try {
+    if (
+      args.wantAssertionsEncrypted &&
+      carriesEncryptedAssertion(args.samlResponse) === false
+    ) {
+      return {
+        ok: false,
+        error:
+          'This connection requires encrypted assertions, but the identity provider sent a plaintext assertion',
+        errorKey: SAML_ASSERTION_NOT_ENCRYPTED_KEY,
+      };
+    }
     const saml = buildSaml(args, deps);
     const { profile } = await saml.validatePostResponseAsync({
       SAMLResponse: args.samlResponse,

--- a/services/platform/backend/domains/connector_credentials/service.ts
+++ b/services/platform/backend/domains/connector_credentials/service.ts
@@ -486,6 +486,34 @@ export async function createCredential(
   sql: Sql,
   args: CreateCredentialArgs,
 ): Promise<{ credentialId: string }> {
+  const prepared = prepareCredential(args);
+  return sql.begin((tx) => insertPreparedCredential(tx, args, prepared));
+}
+
+/**
+ * {@link createCredential} on a transaction the CALLER owns — for a flow
+ * whose credential must commit together with another write, or not at all.
+ * The connector OAuth callback claims the Slack workspace in the same
+ * transaction: a lost claim then rolls the credential back instead of
+ * leaving a foreign workspace's live token stored as this organization's
+ * default. Validation and sealing still run before the first statement.
+ */
+export async function createCredentialInTransaction(
+  tx: TransactionSql,
+  args: CreateCredentialArgs,
+): Promise<{ credentialId: string }> {
+  return insertPreparedCredential(tx, args, prepareCredential(args));
+}
+
+interface PreparedCredential {
+  endpointUrl: ReturnType<typeof normalizeEndpointUrl>;
+  config: Record<string, string | number | boolean> | undefined;
+  name: string;
+  sealed: ReturnType<typeof sealPayload>;
+}
+
+/** Everything that can refuse a new credential, before any statement. */
+function prepareCredential(args: CreateCredentialArgs): PreparedCredential {
   const connector = requireConnectorAuthMethod(
     args.connectorSlug,
     args.authMethod,
@@ -501,45 +529,48 @@ export async function createCredential(
   } catch (error) {
     translateAppError(error);
   }
-  const name = normalizeName(args.name);
-  const sealed = sealPayload(buildPayload(args.authMethod, args.secret));
+  return {
+    endpointUrl,
+    config,
+    name: normalizeName(args.name),
+    sealed: sealPayload(buildPayload(args.authMethod, args.secret)),
+  };
+}
 
-  return sql.begin(async (tx) => {
-    const siblings = await rowsForConnector(
-      tx,
-      args.organizationId,
-      args.connectorSlug,
-    );
-    assertNameFree(siblings, name);
-    const isDefault = args.isDefault ?? siblings.length === 0;
-    if (isDefault) {
-      await clearOtherDefaults(
-        tx,
-        args.organizationId,
-        args.connectorSlug,
-        null,
-      );
-    }
-    const now = Date.now();
-    const inserted = await tx<{ id: string }[]>`
-      INSERT INTO app.connector_credentials (
-        org_id, connector_slug, auth_method, name, encrypted_data,
-        endpoint_url, config, masked_preview, is_default, status,
-        created_by, created_at_ms, updated_at_ms
-      ) VALUES (
-        ${args.organizationId}, ${args.connectorSlug}, ${args.authMethod},
-        ${name}, ${tx.json(toJson(sealed.encryptedData))},
-        ${endpointUrl ?? null},
-        ${config === undefined ? null : tx.json(toJson(config))},
-        ${sealed.maskedPreview ?? null}, ${isDefault}, 'active',
-        ${args.createdBy}, ${now}, ${now}
-      )
-      RETURNING id
-    `;
-    const credentialId = inserted[0]?.id;
-    if (!credentialId) throw new Error('credential insert failed');
-    return { credentialId };
-  });
+async function insertPreparedCredential(
+  tx: TransactionSql,
+  args: CreateCredentialArgs,
+  prepared: PreparedCredential,
+): Promise<{ credentialId: string }> {
+  const siblings = await rowsForConnector(
+    tx,
+    args.organizationId,
+    args.connectorSlug,
+  );
+  assertNameFree(siblings, prepared.name);
+  const isDefault = args.isDefault ?? siblings.length === 0;
+  if (isDefault) {
+    await clearOtherDefaults(tx, args.organizationId, args.connectorSlug, null);
+  }
+  const now = Date.now();
+  const inserted = await tx<{ id: string }[]>`
+    INSERT INTO app.connector_credentials (
+      org_id, connector_slug, auth_method, name, encrypted_data,
+      endpoint_url, config, masked_preview, is_default, status,
+      created_by, created_at_ms, updated_at_ms
+    ) VALUES (
+      ${args.organizationId}, ${args.connectorSlug}, ${args.authMethod},
+      ${prepared.name}, ${tx.json(toJson(prepared.sealed.encryptedData))},
+      ${prepared.endpointUrl ?? null},
+      ${prepared.config === undefined ? null : tx.json(toJson(prepared.config))},
+      ${prepared.sealed.maskedPreview ?? null}, ${isDefault}, 'active',
+      ${args.createdBy}, ${now}, ${now}
+    )
+    RETURNING id
+  `;
+  const credentialId = inserted[0]?.id;
+  if (!credentialId) throw new Error('credential insert failed');
+  return { credentialId };
 }
 
 export interface UpdateCredentialArgs {

--- a/services/platform/backend/domains/connectors/oauth.ts
+++ b/services/platform/backend/domains/connectors/oauth.ts
@@ -15,7 +15,7 @@ import {
   OAUTH_STATE_TTL_MS,
 } from '../../core/http_connectors/oauth_state.ts';
 import { exchangeAuthorizationCode } from '../../core/http_connectors/token_exchange.ts';
-import { createCredential } from '../connector_credentials/service.ts';
+import { createCredentialInTransaction } from '../connector_credentials/service.ts';
 import {
   applyMicrosoftTenant,
   resolveConnectorOauthApp,
@@ -286,6 +286,15 @@ export async function startOauth2(
   }
 }
 
+/** Thrown inside the store-and-claim transaction so the credential rolls
+ * back with the lost claim — never surfaces past `completeOauth2`. */
+class WorkspaceClaimedError extends Error {
+  constructor() {
+    super('workspace already connected to another organization');
+    this.name = 'WorkspaceClaimedError';
+  }
+}
+
 export type CallbackOutcome =
   | { kind: 'connected'; settingsUrl: string; connectorSlug: string }
   | {
@@ -398,27 +407,43 @@ export async function completeOauth2(
     }
   }
 
-  let credentialId: string;
+  // Store the credential and claim the workspace in ONE transaction. Two
+  // organizations can pass the pre-check for the same workspace at once;
+  // the route's key decides the winner, and the loser must keep nothing —
+  // a committed credential for a workspace routed elsewhere would be a
+  // live foreign token stored (and default) for this organization.
   try {
-    const stored = await createCredential(sql, {
-      organizationId,
-      connectorSlug,
-      authMethod: 'oauth2',
-      name: endpoints.displayName,
-      createdBy: userId,
-      secret: {
-        accessToken: tokens.accessToken,
-        ...(tokens.refreshToken !== undefined
-          ? { refreshToken: tokens.refreshToken }
-          : {}),
-        ...(tokens.expiresAt !== undefined
-          ? { expiresAt: tokens.expiresAt }
-          : {}),
-        scopes: tokens.scopes,
-      },
+    await sql.begin(async (tx) => {
+      const stored = await createCredentialInTransaction(tx, {
+        organizationId,
+        connectorSlug,
+        authMethod: 'oauth2',
+        name: endpoints.displayName,
+        createdBy: userId,
+        secret: {
+          accessToken: tokens.accessToken,
+          ...(tokens.refreshToken !== undefined
+            ? { refreshToken: tokens.refreshToken }
+            : {}),
+          ...(tokens.expiresAt !== undefined
+            ? { expiresAt: tokens.expiresAt }
+            : {}),
+          scopes: tokens.scopes,
+        },
+      });
+      if (tokens.teamId !== undefined) {
+        const claim = await claimTeamRoute(tx, {
+          teamId: tokens.teamId,
+          organizationId,
+          credentialId: stored.credentialId,
+        });
+        if (!claim.ok) throw new WorkspaceClaimedError();
+      }
     });
-    credentialId = stored.credentialId;
   } catch (error) {
+    if (error instanceof WorkspaceClaimedError) {
+      return { kind: 'error', error: 'workspace_claimed', organizationId };
+    }
     // The message may embed the arguments, which include the access token —
     // log the SHAPE of the failure, never the error itself.
     console.error(
@@ -427,17 +452,6 @@ export async function completeOauth2(
       })`,
     );
     return { kind: 'error', error: 'storage_failed', organizationId };
-  }
-
-  if (tokens.teamId !== undefined) {
-    const claim = await claimTeamRoute(sql, {
-      teamId: tokens.teamId,
-      organizationId,
-      credentialId,
-    });
-    if (!claim.ok) {
-      return { kind: 'error', error: 'workspace_claimed', organizationId };
-    }
   }
 
   const settingsUrl = resolveConnectorSettingsUrl(organizationId);

--- a/services/platform/backend/domains/feedback/routes.test.ts
+++ b/services/platform/backend/domains/feedback/routes.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The vote key is server-owned: the one-vote-per-(message, user) upsert is
+ * arbitrated by the partial unique index `WHERE metadata IS NULL`, so any
+ * `metadata` a client sends must be dropped at the door — otherwise one
+ * member could stack unlimited rows for one message, or forge the
+ * `arenaVerdict` rows the analytics count as arena results.
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrgEnv } from '../../auth/org.ts';
+
+const { submitMessageFeedback } = vi.hoisted(() => ({
+  submitMessageFeedback: vi.fn(),
+}));
+
+vi.mock('./service.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./service.ts')>();
+  return { ...actual, submitMessageFeedback };
+});
+
+vi.mock('@tale/shared/db/serializable', () => ({
+  transactSerializable: (_sql: unknown, fn: (tx: unknown) => unknown) => fn({}),
+}));
+
+vi.mock('../../auth/session.ts', () => ({
+  requireSession:
+    () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
+      c.set('sessionBundle', {
+        user: { id: 'u1', email: 'u@example.test' },
+      } as never);
+      await next();
+    },
+}));
+
+vi.mock('../../auth/org.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/org.ts')>();
+  return {
+    ...actual,
+    requireOrgMember:
+      () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
+        c.set('orgId', 'o1');
+        c.set('orgMember', { role: 'member' } as never);
+        await next();
+      },
+  };
+});
+
+import { createFeedbackRoutes } from './routes.ts';
+
+function makeApp() {
+  return createFeedbackRoutes({ sql: {} as never, auth: {} as never });
+}
+
+async function vote(body: Record<string, unknown>): Promise<Response> {
+  return makeApp().request('/?orgId=o1', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('feedback route — the vote key is server-owned', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    submitMessageFeedback.mockResolvedValue(undefined);
+  });
+
+  it('drops client metadata before the vote reaches the service', async () => {
+    const res = await vote({
+      threadId: 't1',
+      messageId: 'm1',
+      rating: 'positive',
+      metadata: { stacked: true },
+    });
+
+    expect(res.status).toBe(200);
+    expect(submitMessageFeedback).toHaveBeenCalledTimes(1);
+    expect(submitMessageFeedback.mock.calls[0]?.[2]).toEqual({
+      threadId: 't1',
+      messageId: 'm1',
+      rating: 'positive',
+    });
+  });
+
+  it('never lets a client-forged arena verdict through as a vote payload', async () => {
+    const res = await vote({
+      threadId: 't1',
+      messageId: 'arena:model-a:model-b',
+      rating: 'positive',
+      metadata: {
+        arenaVerdict: 'a_better',
+        modelA: 'model-a',
+        modelB: 'model-b',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(submitMessageFeedback.mock.calls[0]?.[2]).not.toHaveProperty(
+      'metadata',
+    );
+  });
+});

--- a/services/platform/backend/domains/feedback/routes.ts
+++ b/services/platform/backend/domains/feedback/routes.ts
@@ -18,6 +18,13 @@ import {
   listRecentFeedbackPage,
 } from './service.ts';
 
+/**
+ * A vote carries NO client metadata: the one-vote-per-(message, user) upsert
+ * is arbitrated by the partial unique index `WHERE metadata IS NULL`, and the
+ * `metadata.arenaVerdict` rows the analytics count as arena results are
+ * written by the arena settle lane alone (`domains/chat/arena.ts`). Anything
+ * else a client sends under `metadata` is dropped here, never stored.
+ */
 const submitSchema = z.object({
   threadId: z.string().min(1).max(200),
   messageId: z.string().min(1).max(200),
@@ -26,7 +33,6 @@ const submitSchema = z.object({
   agentSlug: z.string().max(100).optional(),
   model: z.string().max(200).optional(),
   provider: z.string().max(100).optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 /** /api/app/feedback — thumbs on assistant messages + the insights feed. */

--- a/services/platform/backend/domains/feedback/service.ts
+++ b/services/platform/backend/domains/feedback/service.ts
@@ -1,11 +1,12 @@
 import type { Sql, TransactionSql } from 'postgres';
 
-import { toJson } from '../../db/sql.ts';
-
 /**
  * Message feedback — thumbs up/down on assistant messages, one row per
  * (message, user), upsert-on-revote. Every active member may read and write
- * (the one table the 0.4 matrix opens to `member` writes).
+ * (the one table the 0.4 matrix opens to `member` writes). A vote row never
+ * carries metadata — that column belongs to the arena settle lane's verdict
+ * rows (`domains/chat/arena.ts`), and its NULL-ness is what the vote's
+ * partial unique index keys on.
  */
 
 export interface FeedbackScope {
@@ -21,7 +22,6 @@ export interface SubmitFeedbackArgs {
   agentSlug?: string;
   model?: string;
   provider?: string;
-  metadata?: Record<string, unknown>;
 }
 
 export async function submitMessageFeedback(
@@ -30,14 +30,16 @@ export async function submitMessageFeedback(
   args: SubmitFeedbackArgs,
 ): Promise<void> {
   const now = Date.now();
+  // `metadata` is written NULL unconditionally: it is the vote's upsert key
+  // (the partial unique index is `WHERE metadata IS NULL`), so a value here
+  // would fork the key and let one member stack rows for one message.
   await tx`
     INSERT INTO app.message_feedback (
       org_id, thread_id, message_id, user_id, rating, comment, metadata,
       agent_slug, model, provider, created_at_ms
     ) VALUES (
       ${scope.organizationId}, ${args.threadId}, ${args.messageId},
-      ${scope.userId}, ${args.rating}, ${args.comment ?? null},
-      ${args.metadata === undefined ? null : tx.json(toJson(args.metadata))},
+      ${scope.userId}, ${args.rating}, ${args.comment ?? null}, NULL,
       ${args.agentSlug ?? null}, ${args.model ?? null},
       ${args.provider ?? null}, ${now}
     )

--- a/services/platform/backend/domains/members/routes.ts
+++ b/services/platform/backend/domains/members/routes.ts
@@ -4,6 +4,7 @@ import type { Sql } from 'postgres';
 import { z } from 'zod';
 
 import type { Auth } from '../../auth/auth.ts';
+import { isAdminRole } from '../../auth/membership.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession, type AuthEnv } from '../../auth/session.ts';
 import { LegalHoldError } from '../legal_holds/service.ts';
@@ -103,6 +104,14 @@ export function createMemberRoutes(deps: {
     }
   });
   orgScoped.get('/user-id-by-email', async (c) => {
+    // The lookup serves the admin add-member dialog and answers for ANY
+    // registered account on the deployment (the person being added is not
+    // a member yet), so it is gated exactly like the add itself — otherwise
+    // every member could enumerate which emails hold an account here. The
+    // refusal is one uniform 403 whatever the email says.
+    if (!isAdminRole(c.get('orgMember').role)) {
+      return c.json({ error: 'MEMBER_ADD_FORBIDDEN' }, 403);
+    }
     const email = c.req.query('email') ?? '';
     if (email.trim() === '') {
       return c.json({ error: 'invalid email' }, 400);

--- a/services/platform/backend/domains/video_links/routes.ts
+++ b/services/platform/backend/domains/video_links/routes.ts
@@ -157,11 +157,16 @@ export function createVideoLinkRoutes(deps: {
       .object({ jobIds: z.array(z.string().min(1)).max(50) })
       .safeParse(await c.req.json().catch(() => null));
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    await unbindJobsFromMessage(deps.sql, {
-      userId: c.get('sessionBundle').user.id,
-      jobIds: body.data.jobIds,
-    });
-    return c.json({ ok: true });
+    try {
+      await unbindJobsFromMessage(deps.sql, {
+        organizationId: c.get('orgId'),
+        userId: c.get('sessionBundle').user.id,
+        jobIds: body.data.jobIds,
+      });
+      return c.json({ ok: true });
+    } catch (error) {
+      return handleError(c, error);
+    }
   });
 
   app.post('/:jobId/cancel', async (c) => {

--- a/services/platform/backend/domains/video_links/service.ts
+++ b/services/platform/backend/domains/video_links/service.ts
@@ -1552,19 +1552,50 @@ export async function bindCompletedJobsToMessage(
   });
 }
 
-/** Reverse a bind after a failed send (the 0.4 twin) — idempotent,
- * uploader-owned rows only. */
+/**
+ * Reverse a bind after a failed send (the 0.4 twin) — idempotent for the
+ * caller's OWN rows in THIS organization. Every supplied id must resolve to
+ * such a row or the whole batch is refused before anything changes: a job
+ * the caller holds in another organization is not theirs here (the org is
+ * the scope, like every other video-links verb), and an id the composer
+ * never held is a probe, not a chip.
+ *
+ * A job whose transcript already rides a SENT message in its thread stays
+ * bound. The server can tell — the user row carries the attachment part —
+ * and unbinding it would hand the transcript to the unbound-GC a week later
+ * and strand the sent message's attachment; the legitimate caller (a send
+ * that failed) never has such a message.
+ */
 export async function unbindJobsFromMessage(
   sql: Sql,
-  args: { userId: string; jobIds: readonly string[] },
+  args: { organizationId: string; userId: string; jobIds: readonly string[] },
 ): Promise<void> {
-  for (const jobId of args.jobIds) {
-    await sql`
-      UPDATE app.video_link_jobs SET message_bound_at_ms = NULL
-      WHERE id = ${jobId} AND uploaded_by = ${args.userId}
-        AND message_bound_at_ms IS NOT NULL
+  const jobIds = [...new Set(args.jobIds)];
+  if (jobIds.length === 0) return;
+  await sql.begin(async (tx) => {
+    const owned = await tx<{ id: string }[]>`
+      SELECT id FROM app.video_link_jobs
+      WHERE id = ANY(${jobIds}) AND org_id = ${args.organizationId}
+        AND uploaded_by = ${args.userId}
+      FOR UPDATE
     `;
-  }
+    if (owned.length !== jobIds.length) {
+      throw new VideoLinkError('notFound', 'Video link not found', 404);
+    }
+    await tx`
+      UPDATE app.video_link_jobs j SET message_bound_at_ms = NULL
+      WHERE j.id = ANY(${jobIds}) AND j.org_id = ${args.organizationId}
+        AND j.uploaded_by = ${args.userId}
+        AND j.message_bound_at_ms IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM app.messages m
+          WHERE m.thread_id = j.thread_id AND m.role = 'user'
+            AND m.parts @> jsonb_build_array(jsonb_build_object(
+              'type', 'attachment', 'fileId', j.storage_ref
+            ))
+        )
+    `;
+  });
 }
 
 /** Video-link provenance for RAG retrieval wrapping (the 0.4

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -4817,6 +4817,7 @@ async function checkDocumentWriteGuards(
  * feedback upsert/toggle/stats, support case lifecycle.
  */
 async function checkSmallDomains(
+  sql: Sql,
   base: string,
   ctx: { cookie: string; orgId: string },
 ): Promise<void> {
@@ -4984,6 +4985,50 @@ async function checkSmallDomains(
       stats.data.stats.negative === 1 &&
       stats.data.stats.positive === 0,
     `items=${stats.success ? stats.data.items.length : 'ERR'} (want 1 after toggle), stats=${stats.success ? JSON.stringify(stats.data.stats) : 'ERR'}`,
+  );
+
+  // The vote is keyed by the SERVER: whatever a client puts in `metadata` is
+  // dropped, so a repeated vote upserts (the partial-unique arbiter is
+  // `metadata IS NULL`) and a forged arena verdict never lands as one — the
+  // arena settle lane is the only writer of metadata rows.
+  await send('POST', `/api/app/feedback?orgId=${orgId}`, {
+    threadId: 'itest-thread',
+    messageId: 'itest-msg-2',
+    rating: 'positive',
+    metadata: {},
+  });
+  await send('POST', `/api/app/feedback?orgId=${orgId}`, {
+    threadId: 'itest-thread',
+    messageId: 'itest-msg-2',
+    rating: 'negative',
+    metadata: { stacked: true },
+  });
+  await send('POST', `/api/app/feedback?orgId=${orgId}`, {
+    threadId: 'itest-thread',
+    messageId: 'arena:forged-a:forged-b',
+    rating: 'positive',
+    metadata: {
+      arenaVerdict: 'a_better',
+      modelA: 'forged-a',
+      modelB: 'forged-b',
+    },
+  });
+  const stackedVotes = await sql<{ count: string; rating: string | null }[]>`
+    SELECT count(*)::text AS count, min(rating) AS rating
+    FROM app.message_feedback
+    WHERE org_id = ${orgId} AND message_id = 'itest-msg-2'
+  `;
+  const forgedArenaRows = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.message_feedback
+    WHERE org_id = ${orgId} AND message_id = 'arena:forged-a:forged-b'
+      AND metadata IS NOT NULL
+  `;
+  record(
+    'message feedback: client metadata cannot fork the vote or forge arena rows',
+    stackedVotes[0]?.count === '1' &&
+      stackedVotes[0].rating === 'negative' &&
+      forgedArenaRows[0]?.count === '0',
+    `rows=${stackedVotes[0]?.count} (want 1) rating=${stackedVotes[0]?.rating} (want negative), forgedArenaRows=${forgedArenaRows[0]?.count} (want 0)`,
   );
 
   // Products: unique-name conflict + translation upsert.
@@ -11753,6 +11798,61 @@ async function checkSamlLogin(
         (refusalAudit[0]?.count ?? 0) >= 1,
       `refused=${crossOrg.status}→${crossOrgLocation.includes('/log-in') ? 'log-in' : crossOrgLocation} key=${crossOrgLocation.includes('notOrgMember')} noCookie=${(crossOrg.headers.get('set-cookie') ?? '') === ''}, joined=${joined.length} (want 0), audited=${refusalAudit[0]?.count}`,
     );
+
+    // ---- required encryption is enforced --------------------------------
+    // With `wantAssertionsEncrypted` on the connection, the SAME validly
+    // signed plaintext assertion that signed a user in above is refused —
+    // bounced under its own login-page key and audited — instead of being
+    // accepted as if the setting were decorative.
+    await writeFile(
+      connectionPath,
+      serializeSsoConnectionYaml({
+        enabled: true,
+        protocol: 'saml',
+        displayName: 'Itest SAML IdP',
+        saml: {
+          idpEntityId: 'https://idp.saml.itest/entity',
+          idpSsoUrl: 'https://idp.saml.itest/sso',
+          idpCertificate: publicKey
+            .export({ type: 'spki', format: 'pem' })
+            .toString(),
+          wantAssertionsSigned: true,
+          wantAssertionsEncrypted: true,
+        },
+        provisioning: {
+          autoProvisionRole: true,
+          defaultRole: 'member',
+          roleMappingRules: [
+            { source: 'group', pattern: 'SamlOps', targetRole: 'developer' },
+          ],
+          autoProvisionTeam: true,
+          excludeGroups: ['Everyone'],
+        },
+      }),
+    );
+    const plaintextRes = await postAssertion(
+      buildResponse({
+        id: '_itestsaml7',
+        email: 'saml.user@door.test',
+        groups: ['SamlOps'],
+        notOnOrAfterMs: Date.now() + 300_000,
+      }),
+    );
+    const plaintextLocation = plaintextRes.headers.get('location') ?? '';
+    const encryptionAudit = await sql<{ count: number }[]>`
+      SELECT count(*)::int AS count FROM app.audit_logs
+      WHERE org_id = ${orgId} AND action = 'sso_login_failed'
+        AND metadata ->> 'errorKey' = 'sso.errors.assertionNotEncrypted'
+    `;
+    record(
+      'SAML: a connection requiring encrypted assertions refuses a plaintext one',
+      plaintextRes.status === 302 &&
+        plaintextLocation.includes('/log-in') &&
+        plaintextLocation.includes('assertionNotEncrypted') &&
+        (plaintextRes.headers.get('set-cookie') ?? '') === '' &&
+        (encryptionAudit[0]?.count ?? 0) >= 1,
+      `plaintext=${plaintextRes.status}→${plaintextLocation.includes('/log-in') ? 'log-in' : plaintextLocation} key=${plaintextLocation.includes('assertionNotEncrypted')} noCookie=${(plaintextRes.headers.get('set-cookie') ?? '') === ''}, audited=${encryptionAudit[0]?.count} (want ≥1)`,
+    );
   } finally {
     if (savedSiteUrl === undefined) delete process.env.SITE_URL;
     else process.env.SITE_URL = savedSiteUrl;
@@ -16097,6 +16197,7 @@ async function checkConnectorOauth(
   // vendor shape — including `team.id`, which drives the workspace claim.
   const seen: { body: string; auth: string | null }[] = [];
   let denyExchange = false;
+  let vendorTeamId = 'T-ITEST-1';
   const vendor = createServer((req, res) => {
     let body = '';
     req.on('data', (chunk: unknown) => {
@@ -16114,7 +16215,7 @@ async function checkConnectorOauth(
               refresh_token: 'xoxe-itest-refresh',
               expires_in: 3600,
               scope: 'channels:read,chat:write',
-              team: { id: 'T-ITEST-1' },
+              team: { id: vendorTeamId },
             }),
       );
     });
@@ -16340,6 +16441,95 @@ async function checkConnectorOauth(
         routeAfter[0]?.orgId === orgId &&
         resolved?.organizationId === orgId,
       `claim=${claim.ok ? 'ALLOWED' : 'refused'}, routeOwner=${routeAfter[0]?.orgId === orgId}, resolve=${resolved?.organizationId === orgId}`,
+    );
+
+    // ---- the claim race: the pre-check passes, another org claims first --
+    // Two organizations can pass the pre-check for one workspace; the
+    // route's key decides the winner and the LOSER must keep nothing. The
+    // other organization's claim is held open (its route insert
+    // uncommitted), so this org's pre-check sees no route while its own
+    // claim queues behind the key — and loses once the holder commits.
+    // The racing organization is a THIRD org: the happy path above already
+    // holds this org's Slack credential (one credential per connector name),
+    // so only a fresh organization walks the store-then-claim path — and the
+    // credential it must not keep would have been its FIRST, i.e. its default.
+    vendorTeamId = 'T-ITEST-RACE';
+    const raceOrgId = 'itest-race-org';
+    const raceState = 'itest-oauth-state-race';
+    await oauth.createPendingAuthorization(sql, {
+      stateHash: await hashStateToken(raceState),
+      organizationId: raceOrgId,
+      userId,
+      connectorSlug: 'slack',
+      codeVerifier: 'itest-verifier-value-222222222222222222222',
+      redirectUri: `${base}/api/connectors/oauth2/callback`,
+    });
+    const credentialService =
+      await import('./domains/connector_credentials/service.ts');
+    const foreignCredential = await credentialService.createCredential(sql, {
+      organizationId: 'some-other-org',
+      connectorSlug: 'slack',
+      authMethod: 'oauth2',
+      name: 'Foreign workspace',
+      createdBy: userId,
+      secret: { accessToken: 'xoxb-foreign-access', scopes: ['chat:write'] },
+    });
+    let releaseForeignClaim: () => void = () => undefined;
+    const foreignClaimReleased = new Promise<void>((resolve) => {
+      releaseForeignClaim = resolve;
+    });
+    let foreignClaimHeld: () => void = () => undefined;
+    const foreignClaimInPlace = new Promise<void>((resolve) => {
+      foreignClaimHeld = resolve;
+    });
+    const foreignClaim = sql.begin(async (tx) => {
+      await oauth.claimTeamRoute(tx, {
+        teamId: 'T-ITEST-RACE',
+        organizationId: 'some-other-org',
+        credentialId: foreignCredential.credentialId,
+      });
+      foreignClaimHeld();
+      await foreignClaimReleased;
+    });
+    await foreignClaimInPlace;
+    const racing = oauth.completeOauth2(
+      sql,
+      { state: raceState, code: 'itest-auth-code-race', vendorError: null },
+      { fetchImpl: vendorFetch },
+    );
+    // Release the holder once this org's claim is queued behind it — after
+    // a bounded wait regardless, so a regression cannot hang the suite.
+    const queuedBehindHolder = await waitFor(async () => {
+      const rows = await sql<{ count: string }[]>`
+        SELECT count(*)::text AS count FROM pg_stat_activity
+        WHERE wait_event_type = 'Lock'
+          AND query ILIKE '%connector_team_routes%'
+      `;
+      return rows[0]?.count !== '0';
+    }, 5_000);
+    releaseForeignClaim();
+    await foreignClaim;
+    const raced = await racing;
+    vendorTeamId = 'T-ITEST-1';
+    const raceCredentials = await sql<
+      { count: string; isDefault: boolean | null }[]
+    >`
+      SELECT count(*)::text AS count, bool_or(is_default) AS "isDefault"
+      FROM app.connector_credentials
+      WHERE org_id = ${raceOrgId} AND connector_slug = 'slack'
+    `;
+    const raceRoute = await sql<{ orgId: string }[]>`
+      SELECT org_id AS "orgId" FROM app.connector_team_routes
+      WHERE team_id = 'T-ITEST-RACE'
+    `;
+    record(
+      'connector oauth: losing the workspace-claim race stores no credential',
+      raced.kind === 'error' &&
+        raced.error === 'workspace_claimed' &&
+        queuedBehindHolder &&
+        raceCredentials[0]?.count === '0' &&
+        raceRoute[0]?.orgId === 'some-other-org',
+      `outcome=${raced.kind}/${raced.kind === 'error' ? raced.error : '-'} (want workspace_claimed), queuedBehindHolder=${queuedBehindHolder}, loserCredentials=${raceCredentials[0]?.count} (want 0) default=${raceCredentials[0]?.isDefault}, routeOwner=${raceRoute[0]?.orgId}`,
     );
 
     // ---- a rejected exchange writes nothing -----------------------------
@@ -23298,9 +23488,88 @@ exit 1
           await send(`/api/app/video-links/bind?orgId=${orgId}`, { threadId })
         ).json(),
       );
+    // The unbind door's two guards. The org is the scope: a row this user
+    // uploaded in ANOTHER organization is not theirs here, and a batch that
+    // mixes it in is refused whole (the own row stays bound). And a SENT
+    // message keeps its transcript: while a user message in the thread
+    // carries the attachment, the unbind is a no-op for that job — otherwise
+    // the unbound-GC would strand the sent message's attachment a week later.
+    const boundState = async (jobId: string): Promise<boolean | null> => {
+      const rows = await sql<{ bound: boolean }[]>`
+        SELECT message_bound_at_ms IS NOT NULL AS bound
+        FROM app.video_link_jobs WHERE id = ${jobId}
+      `;
+      return rows[0]?.bound ?? null;
+    };
+    const foreignJob = await sql<{ id: string }[]>`
+      INSERT INTO app.video_link_jobs (
+        org_id, uploaded_by, source_url, source_url_hash, source_platform,
+        pasted_token, status, status_changed_at_ms, message_bound_at_ms,
+        created_at_ms
+      ) VALUES (
+        'itest-other-org', ${userId},
+        'https://www.youtube.com/watch?v=elsewhere', 'itest-elsewhere-hash',
+        'youtube', 'https://www.youtube.com/watch?v=elsewhere', 'completed',
+        ${Date.now()}, ${Date.now()}, ${Date.now()}
+      )
+      RETURNING id
+    `;
+    const foreignJobId = foreignJob[0]?.id ?? '';
+    const crossOrgUnbind = await send(
+      `/api/app/video-links/unbind?orgId=${orgId}`,
+      { jobIds: [foreignJobId] },
+    );
+    const foreignBoundAfter = await boundState(foreignJobId);
+    const mixedUnbind = await send(
+      `/api/app/video-links/unbind?orgId=${orgId}`,
+      { jobIds: [captJobId, foreignJobId] },
+    );
+    const ownBoundAfterMixed = await boundState(captJobId);
+    const captStorageRef = (await jobRow(captJobId))?.storageRef ?? '';
+    const sentMessage = await sql<{ id: string }[]>`
+      INSERT INTO app.messages (
+        thread_id, org_id, "order", step_order, role, parts, text, status,
+        created_at_ms
+      ) VALUES (
+        ${threadId}, ${orgId}, 999, 0, 'user',
+        ${sql.json([
+          { type: 'text', text: 'Summarize the video' },
+          {
+            type: 'attachment',
+            name: 'Captioned itest video',
+            mediaType: 'video/mp4',
+            fileId: captStorageRef,
+            sizeBytes: 1,
+          },
+        ])},
+        'Summarize the video', 'complete', ${Date.now()}
+      )
+      RETURNING id
+    `;
+    const unbindWhileSent = await send(
+      `/api/app/video-links/unbind?orgId=${orgId}`,
+      { jobIds: [captJobId] },
+    );
+    const boundWhileSent = await boundState(captJobId);
+    await sql`
+      DELETE FROM app.messages WHERE id = ${sentMessage[0]?.id ?? ''}
+    `;
+    await sql`DELETE FROM app.video_link_jobs WHERE id = ${foreignJobId}`;
+    record(
+      'video links: unbind is org-scoped and keeps a sent message bound',
+      crossOrgUnbind.status === 404 &&
+        foreignBoundAfter === true &&
+        mixedUnbind.status === 404 &&
+        ownBoundAfterMixed === true &&
+        unbindWhileSent.status === 200 &&
+        boundWhileSent === true,
+      `crossOrg=${crossOrgUnbind.status} (want 404) stillBound=${foreignBoundAfter}, mixed=${mixedUnbind.status} (want 404) ownStillBound=${ownBoundAfterMixed}, whileSent=${unbindWhileSent.status} stillBound=${boundWhileSent} (want true)`,
+    );
+
     const unbind = await send(`/api/app/video-links/unbind?orgId=${orgId}`, {
       jobIds: [captJobId],
     });
+    const unboundAfter = await boundState(captJobId);
 
     const thread2 = z.object({ id: z.string() }).safeParse(
       await (
@@ -23344,11 +23613,12 @@ exit 1
         rebind.success &&
         rebind.data.attachments.length === 0 &&
         unbind.status === 200 &&
+        unboundAfter === false &&
         donorJobId !== captJobId &&
         donorJob?.status === 'completed' &&
         (donorFile[0]?.transcript ?? '').includes('Hello from captions') &&
         Number(donorAudit[0]?.count ?? '0') === 1,
-      `dedup=${dedup.success && dedup.data.jobId === captJobId}, bind=${bind.success ? bind.data.attachments.length : 'ERR'}/1 rebind=${rebind.success ? rebind.data.attachments.length : 'ERR'}/0 unbind=${unbind.status}, donor=${donorJob?.status} sameText=${(donorFile[0]?.transcript ?? '').includes('Hello from captions')} auditReuse=${donorAudit[0]?.count}/1`,
+      `dedup=${dedup.success && dedup.data.jobId === captJobId}, bind=${bind.success ? bind.data.attachments.length : 'ERR'}/1 rebind=${rebind.success ? rebind.data.attachments.length : 'ERR'}/0 unbind=${unbind.status}/unbound=${unboundAfter}, donor=${donorJob?.status} sameText=${(donorFile[0]?.transcript ?? '').includes('Hello from captions')} auditReuse=${donorAudit[0]?.count}/1`,
     );
 
     // 3. Whisper path via the inc-68 pipeline, the never-retry failure +
@@ -28278,6 +28548,50 @@ async function checkBrandingAndTeams(
       emailMiss.success &&
       emailMiss.data.userId === null,
     `teams=${orgTeams.success ? orgTeams.data.teams.length : 'ERR'}, countMine=${countMine.success ? countMine.data.count : 'ERR'}, hit=${emailHit.success ? typeof emailHit.data.userId : 'ERR'}, miss=${emailMiss.success ? String(emailMiss.data.userId) : 'ERR'}`,
+  );
+
+  // The email lookup answers for ANY account on the deployment (the person
+  // being added is not a member yet), so only the roles that may add a
+  // member get an answer at all — a plain member is refused uniformly,
+  // whether or not the email is registered.
+  const lookupSuffix = Date.now().toString(36);
+  const lookupMemberSignUp = await fetch(`${base}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: base },
+    body: JSON.stringify({
+      email: `email-lookup-member-${lookupSuffix}@example.com`,
+      password: 'itest-password-1',
+      name: 'Email Lookup Member',
+    }),
+  });
+  const lookupMemberCookie = cookieHeaderFrom(lookupMemberSignUp);
+  const lookupMemberBody = z
+    .object({ user: z.object({ id: z.string() }) })
+    .safeParse(await lookupMemberSignUp.json());
+  await sql`
+    INSERT INTO "member" ("id", "organizationId", "userId", "role",
+                          "createdAt")
+    VALUES (gen_random_uuid(), ${orgId},
+            ${lookupMemberBody.success ? lookupMemberBody.data.user.id : ''},
+            'member', ${new Date()})
+  `;
+  const lookupAsMember = (email: string): Promise<Response> =>
+    fetch(
+      `${base}/api/app/members/user-id-by-email?orgId=${orgId}&email=${encodeURIComponent(email)}`,
+      { headers: { cookie: lookupMemberCookie } },
+    );
+  const memberProbeHit = await lookupAsMember(callerEmailRows[0]?.email ?? '');
+  const memberProbeMiss = await lookupAsMember('nobody@nowhere.test');
+  const memberProbeHitBody = await memberProbeHit.text();
+  const memberProbeMissBody = await memberProbeMiss.text();
+  record(
+    'members: only admins may look an account up by email (uniform refusal)',
+    memberProbeHit.status === 403 &&
+      memberProbeMiss.status === 403 &&
+      memberProbeHitBody === memberProbeMissBody &&
+      emailHit.success &&
+      typeof emailHit.data.userId === 'string',
+    `member: registered=${memberProbeHit.status} unknown=${memberProbeMiss.status} (want 403/403) sameBody=${memberProbeHitBody === memberProbeMissBody}; owner still resolves=${emailHit.success ? typeof emailHit.data.userId : 'ERR'}`,
   );
 
   // Member 2FA/passkey admin: the caller is the org's ONLY owner, so a
@@ -37505,7 +37819,7 @@ async function main(): Promise<void> {
     await checkDocuments(sql, baseUrl, authCtx);
     await checkWorkflowDocumentListing(sql, baseUrl, authCtx);
     await checkBlobRefAuthority(sql, baseUrl, authCtx);
-    await checkSmallDomains(baseUrl, authCtx);
+    await checkSmallDomains(sql, baseUrl, authCtx);
     await checkAgents(baseUrl, authCtx);
     await checkSkills(baseUrl, authCtx);
     await checkProviderCredentials(sql, baseUrl, authCtx);

--- a/services/platform/lib/i18n/keys-dynamic.yml
+++ b/services/platform/lib/i18n/keys-dynamic.yml
@@ -195,9 +195,12 @@ entries:
   # in convex/enterprise_sso/entra_id/error_codes.ts; the generic server-error
   # fallback (`sso.errors.serverError`) and the multi-org "enter your email"
   # bounce (`sso.errors.multipleConnections`) are passed as literals from the
-  # handlers but under a namespace the client-source scanner can't resolve.
+  # handlers but under a namespace the client-source scanner can't resolve;
+  # the SAML validator's encryption-required refusal
+  # (`sso.errors.assertionNotEncrypted`) rides the same redirect.
   - 'auth.sso.errors.multipleConnections'
   - 'auth.sso.errors.notOrgMember'
+  - 'auth.sso.errors.assertionNotEncrypted'
 
   # Skill load-error detail titles: skill-load-error.ts maps machine error codes
   # (yaml_syntax, not_found, …) to `skills.loadErrorDetail.title.*` /

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -478,6 +478,11 @@ auth:
       notOrgMember: Dein Konto ist kein Mitglied dieser Organisation. Bitte die
         Administration dieser Organisation, dich einzuladen, und melde dich
         danach erneut an.
+      assertionNotEncrypted:
+        Diese Organisation verlangt verschlüsselte SAML-Assertions, der
+        Identitätsanbieter hat aber eine unverschlüsselte geschickt. Bitte
+        deine Administration, die Verschlüsselung der Assertions im
+        Identitätsanbieter einzuschalten.
       silentAuthFailed: Stille Anmeldung fehlgeschlagen. Melde dich stattdessen manuell an.
       refreshTokenExpired: Deine Sitzung ist abgelaufen. Melde dich erneut an.
       consentRequired: Ein Administrator muss die Zustimmung erteilen, bevor du dich anmelden kannst.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -454,6 +454,10 @@ auth:
       notOrgMember:
         Your account is not a member of this organization. Ask an admin of
         this organization to invite you, then sign in again.
+      assertionNotEncrypted:
+        This organization requires encrypted SAML assertions, but the identity
+        provider sent one in plain text. Ask your administrator to turn on
+        assertion encryption in the identity provider.
       silentAuthFailed: Silent sign-in failed. Sign in manually instead.
       refreshTokenExpired: Your session expired. Sign in again.
       consentRequired: An admin needs to grant consent before you can sign in.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -479,6 +479,11 @@ auth:
       notOrgMember: Ton compte n’est pas membre de cette organisation. Demande à
         l’administration de cette organisation de t’inviter, puis
         reconnecte-toi.
+      assertionNotEncrypted:
+        Cette organisation exige des assertions SAML chiffrées, mais le
+        fournisseur d’identité en a envoyé une en clair. Demande à ton
+        administration d’activer le chiffrement des assertions côté
+        fournisseur d’identité.
       silentAuthFailed: La connexion silencieuse a échoué. Connecte-toi de manière interactive.
       refreshTokenExpired: Ta session a expiré. Reconnecte-toi.
       consentRequired:

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -73,6 +73,7 @@
     "@tanstack/react-router": "1.168.10",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.26",
+    "@xmldom/xmldom": "0.8.13",
     "@xyflow/react": "12.10.2",
     "ai": "6.0.156",
     "ajv": "8.20.0",


### PR DESCRIPTION
## Summary

Low-severity authz / tenant-isolation / info-leak batch from the backend review triage (`findings.json`, severity `low`), verified against `origin/main` 907cfb036. Five findings were live and are fixed here; one was already fixed by #3131 and now has a regression test. No migration: every fix rides an existing key (the team route's primary key, the vote's partial unique index).

## Per-finding outcome

| # | Finding | Outcome | What changed |
|---|---------|---------|--------------|
| 1 | Unbind route has no org scope and can strand a sent message's transcript — `domains/video_links/service.ts` (the triage anchor; the brief's "conversations" path was a mis-anchor) | **fixed** | `unbindJobsFromMessage` resolves every id to the caller's own row in the request's org inside one transaction; a foreign or unknown id refuses the whole batch with 404 before anything changes; a job whose transcript rides a sent user message (attachment part in `app.messages.parts`) stays bound instead of becoming GC-eligible. |
| 2 | Slack workspace-claim race leaves a foreign workspace's live credential stored as the org default | **fixed** | New `createCredentialInTransaction` + `claimTeamRoute` run in ONE `sql.begin` in `completeOauth2`; a lost claim throws and rolls the credential back. The pre-check stays as the cheap early refusal. |
| 3 | `wantAssertionsEncrypted` is stored and displayed but never enforced | **fixed** | The ACS passes the setting to the validator, which refuses a Response with no `EncryptedAssertion` before node-saml runs — judged on the same parser and options node-saml uses (`@xmldom/xmldom`, promoted from a root override to a declared platform dependency; lockfile validated with `bun install --frozen-lockfile --dry-run` in a scratch tree). New login-page key `auth.sso.errors.assertionNotEncrypted` (en/de/fr + `keys-dynamic.yml`); the refusal is audited under its readable reason with the key in `metadata.errorKey`. Docs sentence updated in en/de/fr. |
| 4 | Any org member can probe whether an email is registered instance-wide | **fixed** | `GET /members/user-id-by-email` is gated with `isAdminRole` — the add-member flow's own gate; non-admins get one uniform 403 (`MEMBER_ADD_FORBIDDEN`) whatever the email. Its only consumer is the admin add-member dialog. |
| 5 | Client-supplied metadata bypasses the one-vote-per-message upsert; members can stack/forge feedback rows | **fixed** | `metadata` removed from the submit schema (zod strips it) and from the service; the INSERT writes `NULL` unconditionally, so the partial unique index `(message_id, user_id) WHERE metadata IS NULL` always arbitrates. The arena settle lane (`domains/chat/arena.ts`) remains the only writer of verdict rows. The frontend never sent metadata. |
| 6 | OIDC callback refusals from provisioning are never audited | **already fixed** | #3131 (92f19584b): `callback_handler.ts` 296-313 calls `recordSsoLoginFailure` on `!result.success \|\| !result.sessionToken`. Added a regression test (fake adapter → refused provisioning → `sso_login_failed` row + bounce); it passes on base, as expected. |

## Tests

- `saml/validate_assertion.test.ts`: required + plaintext refused with the key (**red on base**); not-required plaintext still accepted; a real XML-Enc assertion (AES-256-CBC content key, RSA-OAEP transport, built with `node:crypto`) accepted when required; an assertion encrypted to a stranger's key refused by node-saml, not by the gate.
- `feedback/routes.test.ts` (new): client metadata never reaches the service; forged arena metadata is dropped (**both red on base**).
- `login/callback_handler.test.ts`: refused provisioning and success-without-token are both audited (green on base — #6 already fixed).
- `integration-check.ts`, five new probes (**all red on base**): cross-org and mixed-batch unbind → 404 and a sent message keeps its job bound; the claim race (holder's uncommitted claim, this org's claim observed queued behind the key via `pg_stat_activity`) leaves the losing org zero credentials (base: 1 row, `is_default = true`); a connection with `wantAssertionsEncrypted` bounces a signed plaintext assertion to `/log-in?error=sso.errors.assertionNotEncrypted` with no cookie and an audit row (base: signed in to `/dashboard`); a plain member gets 403/403 with identical bodies for a registered and an unknown email (base: 200/200); `metadata: {}` twice yields one row and a forged `arenaVerdict` never lands (base: 2 rows + 1 forged).

## Verification (observed)

- `bunx vitest --run` on the touched files: 5 files / 45 tests green. Full platform suite (`--project server --project pii`): 439 files green; the 3 `app/routes/**` files that fail do so identically on base (Vite denies the symlinked `@fontsource` path in the worktree — environmental).
- `bunx tsc --noEmit`: 0 errors. `bunx oxlint --type-aware`: 0. `bun run knip:check`: 0 (pre-existing `cron-parser` hint only). `@tale/docs test`: 194/194. `oxfmt --check` on the changed files: clean.
- `backend:integration` on a fresh tale-db + MinIO per run (`SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD` set): **branch 387 PASS / 0 FAIL**; **base (907cfb036 + these probes) 382 PASS / 5 FAIL** — the five failures are exactly the new probes, each in the vulnerable form quoted above.

## Notes for reviewers

- `/video-links/unbind` can now answer 404. The app calls it fire-and-forget (`void chatSend.unbindVideoJobs(...)`) with the ids the bind just returned, so the legitimate client never reaches it; there is no global `unhandledrejection` handler, so even a stale id would only log to the console.
- Discovered, not in scope: connecting a SECOND Slack workspace to one organization always fails as `storage_failed`, because every OAuth credential is named after the connector and trips `CREDENTIAL_NAME_TAKEN` (the race probe therefore races from a fresh org). The SAML admin form has no input for `wantAssertionsEncrypted` / `spCertificate` (values are preserved on re-save and set through the admin API or the connection file). `POST /feedback` never checks that `messageId` / `threadId` belong to the caller's organization.
