### PR TITLE
fix(platform): close eight low-severity reliability leaks and races

### DIFF
--- a/services/platform/backend/core/knowledge/crawl.test.ts
+++ b/services/platform/backend/core/knowledge/crawl.test.ts
@@ -3,23 +3,33 @@
 import type { Sql } from 'postgres';
 import { describe, expect, it } from 'vitest';
 
+import { PUBLIC_WEB_SCHEMA } from '../../../lib/knowledge/types';
 import {
   admitUrls,
   admitUrlsStatement,
+  deregisterDomain,
+  registerDomain,
   registerUrlList,
   reviveListedUrls,
   URL_INSERT_BATCH,
 } from './crawl';
 
 /**
- * A page that answered 404 once used to be gone for good: the crawler marked
- * its row `deleted`, and every door that re-admits URLs — discovery, rendered
- * links, the operator's own list — skipped rows that already existed. These
- * tests pin the ONE admission statement all doors now speak and its revival
- * semantics; the real-Postgres proof rides the integration check.
+ * Two rules of the crawl frontier, pinned on recording doubles (what matters
+ * is which statements run, with which parameters, inside which transaction —
+ * the real-Postgres proofs ride the integration check):
  *
- * The database is a recording double: what matters is which statements run
- * and with which parameters, not that PostgreSQL executes them.
+ *  - A page that answered 404 once used to be gone for good: the crawler
+ *    marked its row `deleted`, and every door that re-admits URLs — discovery,
+ *    rendered links, the operator's own list — skipped rows that already
+ *    existed. The ONE admission statement all doors now speak revives them.
+ *  - Registration and removal of a domain are serialized on the domain row:
+ *    each runs as ONE transaction whose first write takes the `websites` row
+ *    lock and holds it until the membership write commits. As two autocommit
+ *    statements, a removal's "last member?" check could run between a
+ *    concurrent registration's domain upsert and its membership insert — the
+ *    fresh domain row was deleted under the registration (cascading its urls
+ *    and chunks) and the membership insert then failed on the foreign key.
  */
 
 interface FakeDb {
@@ -35,6 +45,34 @@ function fakeDb(rowsPerCall: (text: string) => unknown[] = () => []): FakeDb {
   };
   const sql = { unsafe } as unknown as Sql;
   return { sql, calls };
+}
+
+interface Recorded {
+  readonly text: string;
+  readonly params: readonly unknown[];
+  readonly inTx: boolean;
+}
+
+/** Like `fakeDb`, but also records whether a statement ran inside `begin`. */
+function recorder(): { sql: Sql; sent: Recorded[]; begins: () => number } {
+  const sent: Recorded[] = [];
+  let begins = 0;
+  const unsafeFor =
+    (inTx: boolean) =>
+    (text: string, params: unknown[] = []): Promise<unknown[]> => {
+      sent.push({ text: text.replace(/\s+/g, ' ').trim(), params, inTx });
+      return Promise.resolve([]);
+    };
+  const sql = {
+    unsafe: unsafeFor(false),
+    begin: (
+      callback: (tx: { unsafe: ReturnType<typeof unsafeFor> }) => unknown,
+    ): unknown => {
+      begins += 1;
+      return callback({ unsafe: unsafeFor(true) });
+    },
+  } as unknown as Sql;
+  return { sql, sent, begins: () => begins };
 }
 
 describe('admitUrlsStatement', () => {
@@ -110,23 +148,78 @@ describe('admitUrls', () => {
   });
 });
 
+describe('deregisterDomain', () => {
+  it('locks the domain row, then removes the membership and the orphaned domain, in one transaction', async () => {
+    const { sql, sent, begins } = recorder();
+
+    await deregisterDomain(sql, 'acme', 'example.com');
+
+    expect(begins()).toBe(1);
+    expect(sent).toHaveLength(3);
+    expect(sent.every((s) => s.inTx)).toBe(true);
+    expect(sent[0]?.text).toBe(
+      `SELECT 1 FROM ${PUBLIC_WEB_SCHEMA}.websites WHERE domain = $1 FOR UPDATE`,
+    );
+    expect(sent[0]?.params).toEqual(['example.com']);
+    expect(sent[1]?.text).toContain(
+      `DELETE FROM ${PUBLIC_WEB_SCHEMA}.website_org_memberships`,
+    );
+    expect(sent[1]?.params).toEqual(['example.com', 'acme']);
+    expect(sent[2]?.text).toContain(
+      `DELETE FROM ${PUBLIC_WEB_SCHEMA}.websites`,
+    );
+    expect(sent[2]?.text).toContain('NOT EXISTS');
+  });
+});
+
+describe('registerDomain', () => {
+  it('upserts the domain and inserts the membership under one transaction', async () => {
+    const { sql, sent, begins } = recorder();
+
+    await registerDomain(sql, 'acme', 'example.com', 3600);
+
+    expect(begins()).toBe(1);
+    expect(sent).toHaveLength(2);
+    expect(sent.every((s) => s.inTx)).toBe(true);
+    expect(sent[0]?.text).toContain(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites`,
+    );
+    expect(sent[0]?.text).toContain('ON CONFLICT (domain)');
+    expect(sent[1]?.text).toContain(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships`,
+    );
+  });
+});
+
 describe('registerUrlList', () => {
-  it('admits the listed URLs through the shared door, marked listed', async () => {
-    const db = fakeDb();
+  it('keeps the domain upsert, the membership and the URL admission in one transaction', async () => {
+    const { sql, sent, begins } = recorder();
+
     await registerUrlList(
-      db.sql,
+      sql,
       'acme',
-      'example.test',
-      ['https://example.test/a', 'https://example.test/b'],
+      'example.com',
+      ['https://example.com/a', 'https://example.com/b'],
       3600,
     );
-    const admit = db.calls.find((call) => call.text.includes('website_urls'));
-    expect(admit).toBeDefined();
-    expect(admit?.text).toBe(admitUrlsStatement(2, true));
-    expect(admit?.params).toEqual([
-      'example.test',
-      'https://example.test/a',
-      'https://example.test/b',
+
+    expect(begins()).toBe(1);
+    expect(sent).toHaveLength(3);
+    expect(sent.every((s) => s.inTx)).toBe(true);
+    expect(sent[0]?.text).toContain(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites`,
+    );
+    expect(sent[1]?.text).toContain(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships`,
+    );
+    // The URL rows go through the shared admission door, marked listed.
+    expect(sent[2]?.text).toBe(
+      admitUrlsStatement(2, true).replace(/\s+/g, ' ').trim(),
+    );
+    expect(sent[2]?.params).toEqual([
+      'example.com',
+      'https://example.com/a',
+      'https://example.com/b',
     ]);
   });
 });

--- a/services/platform/backend/core/knowledge/crawl.ts
+++ b/services/platform/backend/core/knowledge/crawl.ts
@@ -15,7 +15,7 @@
  * data seam both it and `websites/internal_actions.ts` share.
  */
 
-import type { Sql } from 'postgres';
+import type { Sql, TransactionSql } from 'postgres';
 
 import { PUBLIC_WEB_SCHEMA } from '../../../lib/knowledge/types';
 import type {
@@ -75,7 +75,7 @@ export function admitUrlsStatement(count: number, listed: boolean): string {
  * first: a multi-row upsert cannot touch the same key twice.
  */
 export async function admitUrls(
-  sql: Sql,
+  sql: Sql | TransactionSql,
   domain: string,
   urls: readonly string[],
   options: { listed: boolean },
@@ -135,6 +135,19 @@ function toWebsiteStatus(status: string): CrawlerWebsiteInfo['status'] {
 }
 
 /**
+ * Registration and removal of one domain are serialized on the domain row.
+ * Each runs as ONE transaction whose first write locks the
+ * `websites` row (the upsert takes the row lock; the removal asks for it
+ * explicitly), and holds it until the membership write commits. Two
+ * autocommit statements let a removal's "last member?" check run BETWEEN a
+ * concurrent registration's domain upsert and its membership insert: the
+ * check saw no member, the fresh domain row was deleted (cascading its urls
+ * and chunks), and the registration's membership insert then failed on the
+ * foreign key — a domain half-registered for one org and half-removed for
+ * another. Same lock, same order, every door: no interleaving is left.
+ */
+
+/**
  * Register a domain for an organization: upsert the domain row (idle until
  * its first scan) and the membership that makes it visible to this org.
  * Idempotent — re-adding an existing domain only refreshes the interval.
@@ -145,23 +158,25 @@ export async function registerDomain(
   domain: string,
   scanIntervalSeconds: number,
 ): Promise<void> {
-  // `kind = 'site'` on conflict too: kind only ever WIDENS — a domain some
-  // org tracked as a URL list becomes a crawled site the moment any org
-  // registers the site proper (its listed URLs stay as extra seeds).
-  await sql.unsafe(
-    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval, kind)
-     VALUES ($1, $2, 'site')
-     ON CONFLICT (domain)
-     DO UPDATE SET scan_interval = EXCLUDED.scan_interval, kind = 'site',
-                   updated_at = NOW()`,
-    [domain, scanIntervalSeconds],
-  );
-  await sql.unsafe(
-    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships (domain, org_slug)
-     VALUES ($1, $2)
-     ON CONFLICT (domain, org_slug) DO NOTHING`,
-    [domain, orgSlug],
-  );
+  await sql.begin(async (tx) => {
+    // `kind = 'site'` on conflict too: kind only ever WIDENS — a domain some
+    // org tracked as a URL list becomes a crawled site the moment any org
+    // registers the site proper (its listed URLs stay as extra seeds).
+    await tx.unsafe(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval, kind)
+       VALUES ($1, $2, 'site')
+       ON CONFLICT (domain)
+       DO UPDATE SET scan_interval = EXCLUDED.scan_interval, kind = 'site',
+                     updated_at = NOW()`,
+      [domain, scanIntervalSeconds],
+    );
+    await tx.unsafe(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships (domain, org_slug)
+       VALUES ($1, $2)
+       ON CONFLICT (domain, org_slug) DO NOTHING`,
+      [domain, orgSlug],
+    );
+  });
 }
 
 /**
@@ -189,20 +204,25 @@ export async function registerUrlList(
       `[crawl] ${domain}: URL list truncated to the ${MAX_URLS_PER_DOMAIN}-URL cap (${unique.length} given)`,
     );
   }
-  await sql.unsafe(
-    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval, kind)
-     VALUES ($1, $2, 'list')
-     ON CONFLICT (domain)
-     DO UPDATE SET scan_interval = EXCLUDED.scan_interval, updated_at = NOW()`,
-    [domain, scanIntervalSeconds],
-  );
-  await sql.unsafe(
-    `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships (domain, org_slug)
-     VALUES ($1, $2)
-     ON CONFLICT (domain, org_slug) DO NOTHING`,
-    [domain, orgSlug],
-  );
-  await admitUrls(sql, domain, admitted, { listed: true });
+  await sql.begin(async (tx) => {
+    await tx.unsafe(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.websites (domain, scan_interval, kind)
+       VALUES ($1, $2, 'list')
+       ON CONFLICT (domain)
+       DO UPDATE SET scan_interval = EXCLUDED.scan_interval, updated_at = NOW()`,
+      [domain, scanIntervalSeconds],
+    );
+    await tx.unsafe(
+      `INSERT INTO ${PUBLIC_WEB_SCHEMA}.website_org_memberships (domain, org_slug)
+       VALUES ($1, $2)
+       ON CONFLICT (domain, org_slug) DO NOTHING`,
+      [domain, orgSlug],
+    );
+    // The shared admission door, inside the same transaction as the domain
+    // row and the membership: revived `deleted` rows and the listed flag land
+    // with them or not at all.
+    await admitUrls(tx, domain, admitted, { listed: true });
+  });
 }
 
 /** Update the scan cadence on the domain row. */
@@ -229,20 +249,29 @@ export async function deregisterDomain(
   orgSlug: string,
   domain: string,
 ): Promise<void> {
-  await sql.unsafe(
-    `DELETE FROM ${PUBLIC_WEB_SCHEMA}.website_org_memberships
-      WHERE domain = $1 AND org_slug = $2`,
-    [domain, orgSlug],
-  );
-  await sql.unsafe(
-    `DELETE FROM ${PUBLIC_WEB_SCHEMA}.websites w
-      WHERE w.domain = $1
-        AND NOT EXISTS (
-          SELECT 1 FROM ${PUBLIC_WEB_SCHEMA}.website_org_memberships m
-           WHERE m.domain = w.domain
-        )`,
-    [domain],
-  );
+  await sql.begin(async (tx) => {
+    // Take the domain row first: a registration in flight holds this lock
+    // from its upsert to its commit, so the member count below is read only
+    // after its membership is visible — never between its two writes.
+    await tx.unsafe(
+      `SELECT 1 FROM ${PUBLIC_WEB_SCHEMA}.websites WHERE domain = $1 FOR UPDATE`,
+      [domain],
+    );
+    await tx.unsafe(
+      `DELETE FROM ${PUBLIC_WEB_SCHEMA}.website_org_memberships
+        WHERE domain = $1 AND org_slug = $2`,
+      [domain, orgSlug],
+    );
+    await tx.unsafe(
+      `DELETE FROM ${PUBLIC_WEB_SCHEMA}.websites w
+        WHERE w.domain = $1
+          AND NOT EXISTS (
+            SELECT 1 FROM ${PUBLIC_WEB_SCHEMA}.website_org_memberships m
+             WHERE m.domain = w.domain
+          )`,
+      [domain],
+    );
+  });
 }
 
 /** True when the organization registered this domain — the guard every

--- a/services/platform/backend/db/migrations/0073_documents_unique_external_item.sql
+++ b/services/platform/backend/db/migrations/0073_documents_unique_external_item.sql
@@ -1,0 +1,46 @@
+-- 0.5 app migration 0073: one document per (org, external item) — the
+-- idempotency key the agent `document_create` tool, the project-text panel
+-- files, and the OneDrive / Google Drive sync engine all upsert on.
+--
+-- Why: every upsert lane was SELECT … FOR UPDATE then INSERT over a PLAIN
+-- index (0011 `documents_org_external`). FOR UPDATE over zero rows locks
+-- nothing, so two concurrent runs both missed and both inserted — and every
+-- later refresh updated only the OLDEST row (each lane reads ORDER BY
+-- created_at_ms ASC), so the duplicate lingered in listings and in RAG
+-- forever. The rule the lanes assumed becomes the schema's: a partial
+-- unique index the database cannot forget, and the lanes insert with
+-- ON CONFLICT so the loser of a race refreshes the winner's row.
+--
+-- Existing duplicates: the oldest row per key is the one every refresh has
+-- been landing on, so it keeps the key. Newer duplicates are DETACHED from
+-- the key, never deleted — a document is the user's content. The key they
+-- carried is kept in `metadata.dedupedExternalItemId`, so an operator can
+-- find the strays and trash them deliberately.
+--
+-- Rolling-deploy safe: the previous image keeps working — its check-then-
+-- insert only ever races itself, and the winner of that race is now the
+-- database's answer rather than a second row.
+
+WITH ranked AS (
+  SELECT id, external_item_id,
+         row_number() OVER (
+           PARTITION BY org_id, external_item_id
+           ORDER BY created_at_ms ASC, id ASC
+         ) AS rn
+  FROM app.documents
+  WHERE external_item_id IS NOT NULL
+)
+UPDATE app.documents d SET
+  external_item_id = NULL,
+  metadata = coalesce(d.metadata, '{}'::jsonb)
+             || jsonb_build_object('dedupedExternalItemId', ranked.external_item_id)
+FROM ranked
+WHERE d.id = ranked.id AND ranked.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS documents_org_external_unique
+  ON app.documents (org_id, external_item_id)
+  WHERE external_item_id IS NOT NULL;
+
+-- The plain index is now a strict subset of the unique one for every lookup
+-- the lanes issue (`org_id = $1 AND external_item_id = $2`).
+DROP INDEX IF EXISTS app.documents_org_external;

--- a/services/platform/backend/db/migrations/0074_approvals_one_pending_per_operation.sql
+++ b/services/platform/backend/db/migrations/0074_approvals_one_pending_per_operation.sql
@@ -1,0 +1,51 @@
+-- 0.5 app migration 0074: one PENDING approval per connector operation.
+--
+-- Why: the approvals gate (`domains/approvals/gate.ts`) keys a live
+-- connector write to its operation (`resource_type = 'connector_operation'`,
+-- `resource_id` = the dispatcher's idempotency key) and was check-then-
+-- insert. SELECT … FOR UPDATE over zero rows locks nothing, so two
+-- evaluations racing for one operation both minted a pending row. Re-entry
+-- reads the newest row (ORDER BY seq DESC), so a decision on the newer card
+-- left the older one pending forever — a duplicate card nobody can resolve,
+-- inflating the pending count for good. The gate's contract becomes the
+-- schema's: at most one pending row per operation. The gate inserts with
+-- ON CONFLICT, and the loser of a race answers with the winner's card.
+--
+-- Scoped to connector operations on purpose: the task-review lane
+-- (`resource_type = 'task_review'`) supersedes its own stale pending rows
+-- when a new round is minted (tasks/reviews.ts), and other kinds may hold
+-- several open questions per resource legitimately.
+--
+-- Existing duplicates: per operation the NEWEST pending row is the one the
+-- gate answers with, so it stays. Older pending twins are closed the way the
+-- review lane closes a superseded round — `rejected`, with
+-- `metadata.supersededBy` naming the survivor — never deleted: the ledger
+-- keeps every row it minted.
+--
+-- Rolling-deploy safe: the previous image's insert only ever races itself
+-- for one operation; where it used to mint a twin it now fails that one
+-- evaluation with a unique violation the dispatcher surfaces and the caller
+-- retries into the surviving card. Nothing it reads changes shape.
+
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY org_id, resource_type, resource_id ORDER BY seq DESC
+         ) AS rn,
+         first_value(id) OVER (
+           PARTITION BY org_id, resource_type, resource_id ORDER BY seq DESC
+         ) AS survivor_id
+  FROM app.approvals
+  WHERE resource_type = 'connector_operation' AND status = 'pending'
+)
+UPDATE app.approvals a SET
+  status = 'rejected',
+  reviewed_at_ms = (extract(epoch FROM now()) * 1000)::bigint,
+  metadata = coalesce(a.metadata, '{}'::jsonb)
+             || jsonb_build_object('supersededBy', ranked.survivor_id)
+FROM ranked
+WHERE a.id = ranked.id AND ranked.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS approvals_one_pending_connector_operation
+  ON app.approvals (org_id, resource_type, resource_id)
+  WHERE resource_type = 'connector_operation' AND status = 'pending';

--- a/services/platform/backend/db/migrations/0075_upload_intents_bound_at.sql
+++ b/services/platform/backend/db/migrations/0075_upload_intents_bound_at.sql
@@ -1,0 +1,22 @@
+-- 0.5 app migration 0075: `upload_intents.bound_at_ms` — the mark a
+-- NON-consuming ownership proof leaves on a minted upload.
+--
+-- Why: an intent row (0067) is the only record that a presigned blob key
+-- exists at all. A key the browser never PUT to, or PUT to and never bound
+-- (closed tab, refused register), had no `file_metadata` row for the row-
+-- driven retention sweeps to find and no explicit reject call, so its bytes
+-- stayed in the org's bucket forever — and the mint path's lazy sweep only
+-- dropped the expired ROW, erasing the last trace of the blob. The mint path
+-- now reclaims the blob of an intent that expired unconsumed
+-- (`sweepUploadIntents` in domains/files/upload-intents.ts).
+--
+-- That is only safe for a ref NOTHING vouched for. Two lanes prove ownership
+-- through `ownsUploadedBlob` WITHOUT consuming the intent: the document
+-- upload binds one blob into one document per selected team, and an outbound
+-- mail attachment is read straight from the ref it names — no file row on
+-- either path. The proof stamps this column; a stamped ref is somebody's,
+-- and the sweep drops its intent row but leaves its blob alone.
+--
+-- Rolling-deploy safe: nullable, unread by the previous image.
+
+ALTER TABLE app.upload_intents ADD COLUMN IF NOT EXISTS bound_at_ms bigint;

--- a/services/platform/backend/domains/approvals/gate.test.ts
+++ b/services/platform/backend/domains/approvals/gate.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+
+/**
+ * One operation, one approval. The gate's read-then-insert cannot lock what
+ * is not there (FOR UPDATE over zero rows), so two evaluations racing for
+ * one operation both reached the insert and minted twin pending cards — the
+ * gate re-reads the NEWEST, so the older twin stayed pending forever. The
+ * insert is now a claim against the partial unique index (0074) and the
+ * loser answers with the winner's card. The real-Postgres race rides the
+ * integration check; this double locks the statement shape and the lost-
+ * claim path.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { readGovernancePolicyForOrg } from '../../lib/org-config.ts';
+import { evaluateApprovalGate } from './gate.ts';
+
+vi.mock('../../lib/org-config.ts', () => ({
+  readGovernancePolicyForOrg: vi.fn(() => Promise.resolve(null)),
+}));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+/** Scripted transaction: record reads pop `records`, the insert pops
+ * `inserts`; everything else answers no rows. */
+function fakeGate(script: {
+  records: { id: string; status: string; metadata: unknown }[][];
+  inserts: { id: string }[][];
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const tx = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join('?').replace(/\s+/g, ' ').trim();
+    statements.push({ text, values });
+    if (text.startsWith('SELECT id, status, metadata FROM app.approvals')) {
+      return Promise.resolve(script.records.shift() ?? []);
+    }
+    if (text.startsWith('INSERT INTO app.approvals')) {
+      return Promise.resolve(script.inserts.shift() ?? []);
+    }
+    return Promise.resolve([]);
+  };
+  tx.json = (value: unknown): unknown => value;
+  const sql = {
+    begin: (callback: (t: typeof tx) => unknown): unknown => callback(tx),
+  } as unknown as Sql;
+  return { sql, statements };
+}
+
+const args = {
+  organizationId: 'org_1',
+  source: 'connector' as const,
+  resourceKey: 'op-1',
+  connector: 'imap-smtp',
+  action: 'send',
+  effect: 'write' as const,
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('evaluateApprovalGate', () => {
+  it('claims the pending row with an ON CONFLICT insert and answers with it', async () => {
+    const fake = fakeGate({ records: [[]], inserts: [[{ id: 'a-1' }]] });
+
+    const decision = await evaluateApprovalGate(fake.sql, args);
+
+    expect(decision).toEqual({ decision: 'needs-approval', approvalId: 'a-1' });
+    expect(readGovernancePolicyForOrg).toHaveBeenCalledTimes(1);
+    const insert = fake.statements.find((s) =>
+      s.text.startsWith('INSERT INTO app.approvals'),
+    );
+    expect(insert?.text).toContain(
+      "ON CONFLICT (org_id, resource_type, resource_id) WHERE resource_type = 'connector_operation' AND status = 'pending' DO NOTHING",
+    );
+    expect(insert?.text).toContain('RETURNING id');
+  });
+
+  it('answers with the winner card when a concurrent evaluation claimed the operation first', async () => {
+    const fake = fakeGate({
+      // Empty on the first read; the winner's committed row on the re-read.
+      records: [[], [{ id: 'a-winner', status: 'pending', metadata: null }]],
+      // The insert conflicted — no row back.
+      inserts: [[]],
+    });
+
+    const decision = await evaluateApprovalGate(fake.sql, args);
+
+    expect(decision).toEqual({
+      decision: 'needs-approval',
+      approvalId: 'a-winner',
+    });
+    const reads = fake.statements.filter((s) =>
+      s.text.startsWith('SELECT id, status, metadata FROM app.approvals'),
+    );
+    expect(reads).toHaveLength(2);
+    for (const read of reads) expect(read.text).toContain('FOR UPDATE');
+  });
+
+  it('keeps answering a re-entry from the record on file without a new insert', async () => {
+    const fake = fakeGate({
+      records: [[{ id: 'a-1', status: 'pending', metadata: null }]],
+      inserts: [],
+    });
+
+    const decision = await evaluateApprovalGate(fake.sql, args);
+
+    expect(decision).toEqual({ decision: 'needs-approval', approvalId: 'a-1' });
+    expect(readGovernancePolicyForOrg).not.toHaveBeenCalled();
+    expect(
+      fake.statements.some((s) =>
+        s.text.startsWith('INSERT INTO app.approvals'),
+      ),
+    ).toBe(false);
+  });
+
+  it('consumes an approved record to completed on its first pass through', async () => {
+    const fake = fakeGate({
+      records: [[{ id: 'a-1', status: 'executing', metadata: null }]],
+      inserts: [],
+    });
+
+    const decision = await evaluateApprovalGate(fake.sql, args);
+
+    expect(decision).toEqual({ decision: 'allow', approvalId: 'a-1' });
+    const update = fake.statements.find((s) =>
+      s.text.startsWith('UPDATE app.approvals'),
+    );
+    expect(update?.text).toContain("SET status = 'completed'");
+  });
+});

--- a/services/platform/backend/domains/approvals/gate.ts
+++ b/services/platform/backend/domains/approvals/gate.ts
@@ -1,4 +1,4 @@
-import type { Sql } from 'postgres';
+import type { Sql, TransactionSql } from 'postgres';
 
 import { resolveApprovalRequirement } from '../../core/approvals/policy.ts';
 import { toJson } from '../../db/sql.ts';
@@ -56,71 +56,29 @@ export async function evaluateApprovalGate(
   }
 
   return sql.begin(async (tx) => {
-    const existingRows = await tx<
-      {
-        id: string;
-        status: 'pending' | 'executing' | 'completed' | 'rejected';
-        metadata: Record<string, unknown> | null;
-      }[]
-    >`
-      SELECT id, status, metadata FROM app.approvals
-      WHERE resource_type = 'connector_operation'
-        AND resource_id = ${args.resourceKey}
-        AND org_id = ${args.organizationId}
-      ORDER BY seq DESC
-      LIMIT 1
-      FOR UPDATE
-    `;
-    const existing = existingRows[0] ?? null;
+    const existing = await lockNewestRecord(tx, args);
+    if (existing !== null) return answerFromRecord(tx, existing);
 
-    // An operation already on file keeps its answer, whatever the policy
-    // says now.
-    if (existing === null) {
-      const policy = await readGovernancePolicyForOrg(
-        tx,
-        args.organizationId,
-        'approval_policy',
-      );
-      const requirement = resolveApprovalRequirement({
-        connector: args.connector,
-        action: args.action,
-        platformInternal: args.platformInternal === true,
-        policy,
-      });
-      if (requirement === 'allow') return { decision: 'allow' };
-    }
+    // Nothing on file: the policy decides whether this operation needs a
+    // human at all.
+    const policy = await readGovernancePolicyForOrg(
+      tx,
+      args.organizationId,
+      'approval_policy',
+    );
+    const requirement = resolveApprovalRequirement({
+      connector: args.connector,
+      action: args.action,
+      platformInternal: args.platformInternal === true,
+      policy,
+    });
+    if (requirement === 'allow') return { decision: 'allow' };
 
-    if (existing !== null) {
-      switch (existing.status) {
-        case 'pending':
-          return { decision: 'needs-approval', approvalId: existing.id };
-        case 'executing': {
-          await tx`
-            UPDATE app.approvals
-            SET status = 'completed', executed_at_ms = ${Date.now()}
-            WHERE id = ${existing.id}
-          `;
-          return { decision: 'allow', approvalId: existing.id };
-        }
-        case 'completed':
-          return { decision: 'allow', approvalId: existing.id };
-        case 'rejected': {
-          const comments = existing.metadata?.comments;
-          return {
-            decision: 'rejected',
-            approvalId: existing.id,
-            ...(typeof comments === 'string' ? { reason: comments } : {}),
-          };
-        }
-        default: {
-          const exhaustive: never = existing.status;
-          throw new Error(
-            `[approvals] unhandled approval status: ${String(exhaustive)}`,
-          );
-        }
-      }
-    }
-
+    // The insert IS the claim. FOR UPDATE over zero rows locks nothing, so
+    // two evaluations for one operation can both read "nothing on file";
+    // the partial unique index (0074: one pending row per connector
+    // operation) turns the second insert into a no-op instead of a twin
+    // card, and the loser answers with the winner's record below.
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.approvals (
         org_id, status, resource_type, resource_id, priority, thread_id,
@@ -153,10 +111,78 @@ export async function evaluateApprovalGate(
         )},
         ${Date.now()}
       )
+      ON CONFLICT (org_id, resource_type, resource_id)
+        WHERE resource_type = 'connector_operation' AND status = 'pending'
+        DO NOTHING
       RETURNING id
     `;
     const approvalId = inserted[0]?.id;
-    if (!approvalId) throw new Error('approval insert failed');
-    return { decision: 'needs-approval', approvalId };
+    if (approvalId !== undefined) {
+      return { decision: 'needs-approval', approvalId };
+    }
+    // Lost the race: the winner's row is committed by now (ON CONFLICT
+    // waits for it), so re-read the operation and answer as a re-entry.
+    const winner = await lockNewestRecord(tx, args);
+    if (winner === null) throw new Error('approval insert failed');
+    return answerFromRecord(tx, winner);
   });
+}
+
+interface ApprovalRecord {
+  id: string;
+  status: 'pending' | 'executing' | 'completed' | 'rejected';
+  metadata: Record<string, unknown> | null;
+}
+
+/** The operation's newest record, row-locked for the transaction. */
+async function lockNewestRecord(
+  tx: TransactionSql,
+  args: { organizationId: string; resourceKey: string },
+): Promise<ApprovalRecord | null> {
+  const rows = await tx<ApprovalRecord[]>`
+    SELECT id, status, metadata FROM app.approvals
+    WHERE resource_type = 'connector_operation'
+      AND resource_id = ${args.resourceKey}
+      AND org_id = ${args.organizationId}
+    ORDER BY seq DESC
+    LIMIT 1
+    FOR UPDATE
+  `;
+  return rows[0] ?? null;
+}
+
+/** An operation already on file keeps its answer, whatever the policy says
+ * now; an approved (`executing`) record is consumed the first time through. */
+async function answerFromRecord(
+  tx: TransactionSql,
+  existing: ApprovalRecord,
+): Promise<ApprovalGateDecision> {
+  switch (existing.status) {
+    case 'pending':
+      return { decision: 'needs-approval', approvalId: existing.id };
+    case 'executing': {
+      await tx`
+        UPDATE app.approvals
+        SET status = 'completed', executed_at_ms = ${Date.now()}
+        WHERE id = ${existing.id}
+      `;
+      return { decision: 'allow', approvalId: existing.id };
+    }
+    case 'completed':
+      return { decision: 'allow', approvalId: existing.id };
+    case 'rejected': {
+      const comments = existing.metadata?.comments;
+      return {
+        decision: 'rejected',
+        approvalId: existing.id,
+        ...(typeof comments === 'string' ? { reason: comments } : {}),
+      };
+    }
+    default: {
+      const exhaustive: never = existing.status;
+      throw new Error(
+        `[approvals] unhandled approval status: ${String(exhaustive)}`,
+      );
+    }
+  }
 }

--- a/services/platform/backend/domains/documents/agent-write.test.ts
+++ b/services/platform/backend/domains/documents/agent-write.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+
+/**
+ * The agent document upsert converges concurrent runs on ONE row. Its
+ * SELECT … FOR UPDATE cannot lock a row that is not there, so two runs both
+ * missed and both inserted — and every later refresh updated only the
+ * oldest, leaving the twin in listings and RAG forever. The key is unique in
+ * the schema now (0073); the insert is `ON CONFLICT DO NOTHING`, and a run
+ * that loses the insert race refreshes the winner's row instead. The live
+ * race rides the integration check; this double locks the statement shape
+ * and the lost-race path.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createAuditLog } from '../audit_logs/service.ts';
+import { upsertAgentDocument } from './agent-write.ts';
+
+vi.mock('../audit_logs/service.ts', () => ({ createAuditLog: vi.fn() }));
+vi.mock('../files/service.ts', () => ({
+  putOrgBlobBytes: vi.fn(),
+  registerUploadedBytes: vi.fn(),
+}));
+vi.mock('../knowledge/service.ts', () => ({ markRagQueued: vi.fn() }));
+vi.mock('../../jobs/enqueue.ts', () => ({ addJobInTx: vi.fn() }));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+function fakeUpsert(script: {
+  lookups: { id: string; record: Record<string, unknown> | null }[][];
+  inserts: { id: string }[][];
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const tx = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join('?').replace(/\s+/g, ' ').trim();
+    statements.push({ text, values });
+    if (text.startsWith('SELECT content_hash')) {
+      return Promise.resolve([{ contentHash: 'sha-1' }]);
+    }
+    if (text.startsWith('SELECT id, record FROM app.documents')) {
+      return Promise.resolve(script.lookups.shift() ?? []);
+    }
+    if (text.startsWith('INSERT INTO app.documents')) {
+      return Promise.resolve(script.inserts.shift() ?? []);
+    }
+    return Promise.resolve([]);
+  };
+  const sql = {
+    begin: (callback: (t: typeof tx) => unknown): unknown => callback(tx),
+  } as unknown as Sql;
+  return { sql, statements };
+}
+
+const args = {
+  organizationId: 'org_1',
+  externalItemId: 'agent:report.md',
+  title: 'report.md',
+  fileRef: 's3:acme/blob-1',
+  mimeType: 'text/markdown',
+  createdBy: 'agent-1',
+  auditActorId: 'user-1',
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('upsertAgentDocument', () => {
+  it('inserts with an ON CONFLICT claim on the unique key', async () => {
+    const fake = fakeUpsert({ lookups: [[]], inserts: [[{ id: 'doc-1' }]] });
+
+    const result = await upsertAgentDocument(fake.sql, args);
+
+    expect(result).toEqual({ documentId: 'doc-1', action: 'created' });
+    const insert = fake.statements.find((s) =>
+      s.text.startsWith('INSERT INTO app.documents'),
+    );
+    expect(insert?.text).toContain(
+      'ON CONFLICT (org_id, external_item_id) WHERE external_item_id IS NOT NULL DO NOTHING',
+    );
+    expect(insert?.text).toContain('RETURNING id');
+    expect(createAuditLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'document.created',
+        resourceId: 'doc-1',
+      }),
+    );
+  });
+
+  it('refreshes the winner row when a concurrent run inserted first', async () => {
+    const fake = fakeUpsert({
+      // Nothing on the first locked read; the winner's row on the re-read.
+      lookups: [[], [{ id: 'doc-winner', record: null }]],
+      // The insert conflicted — no row back.
+      inserts: [[]],
+    });
+
+    const result = await upsertAgentDocument(fake.sql, args);
+
+    expect(result).toEqual({ documentId: 'doc-winner', action: 'updated' });
+    const lookups = fake.statements.filter((s) =>
+      s.text.startsWith('SELECT id, record FROM app.documents'),
+    );
+    expect(lookups).toHaveLength(2);
+    for (const lookup of lookups) expect(lookup.text).toContain('FOR UPDATE');
+    const update = fake.statements.find((s) =>
+      s.text.startsWith('UPDATE app.documents'),
+    );
+    expect(update?.values).toContain('doc-winner');
+    expect(update?.values).toContain('s3:acme/blob-1');
+    expect(createAuditLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'document.updated',
+        resourceId: 'doc-winner',
+      }),
+    );
+  });
+
+  it('refreshes an existing row (any lifecycle) without inserting', async () => {
+    const fake = fakeUpsert({
+      lookups: [[{ id: 'doc-1', record: null }]],
+      inserts: [],
+    });
+
+    const result = await upsertAgentDocument(fake.sql, args);
+
+    expect(result).toEqual({ documentId: 'doc-1', action: 'updated' });
+    expect(
+      fake.statements.some((s) =>
+        s.text.startsWith('INSERT INTO app.documents'),
+      ),
+    ).toBe(false);
+    const lookup = fake.statements.find((s) =>
+      s.text.startsWith('SELECT id, record FROM app.documents'),
+    );
+    expect(lookup?.text).not.toContain('lifecycle_status');
+  });
+});

--- a/services/platform/backend/domains/documents/agent-write.ts
+++ b/services/platform/backend/domains/documents/agent-write.ts
@@ -90,6 +90,11 @@ export interface UpsertAgentDocumentArgs {
  * is refreshed in place rather than resurrected as a duplicate. A row that
  * became a controlled record refuses the refresh (content freeze) — the
  * record lifecycle owns those bytes.
+ *
+ * Concurrent runs converge on ONE row: the key is unique in the schema
+ * (0073), the insert is `ON CONFLICT DO NOTHING`, and a run that loses the
+ * insert race re-reads the winner's row under the lock and refreshes it —
+ * FOR UPDATE over zero rows locks nothing, so the check alone never could.
  */
 export async function upsertAgentDocument(
   sql: Sql,
@@ -128,23 +133,16 @@ export async function upsertAgentDocument(
       LIMIT 1
     `;
     const contentHash = ledger[0]?.contentHash ?? null;
-    const existing = await tx<
-      { id: string; record: Record<string, unknown> | null }[]
-    >`
-      SELECT id, record FROM app.documents
-      WHERE org_id = ${args.organizationId}
-        AND external_item_id = ${args.externalItemId}
-      ORDER BY created_at_ms
-      LIMIT 1
-      FOR UPDATE
-    `;
-    const documentId = existing[0]?.id;
-    if (documentId !== undefined) {
+
+    const refresh = async (existing: {
+      id: string;
+      record: Record<string, unknown> | null;
+    }): Promise<{ documentId: string; action: 'updated' }> => {
       // 'agent' documents can be controlled records (records.ts): a re-run
       // is a generic content writer, so the SAME freeze rule every human
       // content path applies holds here — a controlled record's bytes move
       // only through the attested replacement flow.
-      assertGenericDocumentContentWritableJson(existing[0]?.record ?? null);
+      assertGenericDocumentContentWritableJson(existing.record);
       await tx`
         UPDATE app.documents SET
           title = ${title}, file_ref = ${args.fileRef},
@@ -152,11 +150,15 @@ export async function upsertAgentDocument(
           content_hash = ${contentHash},
           project_id = ${args.projectId ?? null},
           lifecycle_status = 'active', updated_at_ms = ${now}
-        WHERE id = ${documentId}
+        WHERE id = ${existing.id}
       `;
-      await auditWrite(tx, args, 'updated', documentId, title);
-      return { documentId, action: 'updated' as const };
-    }
+      await auditWrite(tx, args, 'updated', existing.id, title);
+      return { documentId: existing.id, action: 'updated' as const };
+    };
+
+    const existing = await lockAgentDocument(tx, args);
+    if (existing !== null) return refresh(existing);
+
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.documents (
         org_id, title, file_ref, mime_type, extension, source_provider,
@@ -168,15 +170,42 @@ export async function upsertAgentDocument(
         ${args.externalItemId}, ${contentHash}, ${args.projectId ?? null},
         ${args.createdBy}, ${now}, ${now}
       )
+      ON CONFLICT (org_id, external_item_id)
+        WHERE external_item_id IS NOT NULL
+        DO NOTHING
       RETURNING id
     `;
     const created = inserted[0]?.id;
-    if (created === undefined) {
+    if (created !== undefined) {
+      await auditWrite(tx, args, 'created', created, title);
+      return { documentId: created, action: 'created' as const };
+    }
+    // Lost the insert race: the winner's row is committed by now (ON
+    // CONFLICT waits for it) — refresh it exactly as a re-run would.
+    const winner = await lockAgentDocument(tx, args);
+    if (winner === null) {
       throw new DocumentError('DOCUMENT_CREATE_FAILED', 'Insert failed');
     }
-    await auditWrite(tx, args, 'created', created, title);
-    return { documentId: created, action: 'created' as const };
+    return refresh(winner);
   });
+}
+
+/** The key's row (any lifecycle), locked for the upsert transaction. */
+async function lockAgentDocument(
+  tx: TransactionSql,
+  args: { organizationId: string; externalItemId: string },
+): Promise<{ id: string; record: Record<string, unknown> | null } | null> {
+  const rows = await tx<
+    { id: string; record: Record<string, unknown> | null }[]
+  >`
+    SELECT id, record FROM app.documents
+    WHERE org_id = ${args.organizationId}
+      AND external_item_id = ${args.externalItemId}
+    ORDER BY created_at_ms
+    LIMIT 1
+    FOR UPDATE
+  `;
+  return rows[0] ?? null;
 }
 
 /** The governance trail a standing-grant document write leaves. Rides the

--- a/services/platform/backend/domains/documents/project-text.ts
+++ b/services/platform/backend/domains/documents/project-text.ts
@@ -1,4 +1,4 @@
-import type { Sql } from 'postgres';
+import type { Sql, TransactionSql } from 'postgres';
 
 import { parseYamlMap } from '../../core/documents/parse_yaml_map.ts';
 import { serializeYamlMap } from '../../core/documents/serialize_yaml_map.ts';
@@ -149,34 +149,44 @@ export async function ensureProjectTextDocument(
       name: args.folderName,
     });
     const now = Date.now();
-    const existing = await tx<{ id: string }[]>`
-      SELECT id FROM app.documents
-      WHERE org_id = ${auth.organizationId}
-        AND external_item_id = ${externalItemId}
-        AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
-      LIMIT 1
-      FOR UPDATE
-    `;
-    if (existing[0]) {
+    // The key is unique per org in the schema (0073), so the lookup ignores
+    // lifecycle on purpose: the panel writing its file again brings a
+    // TRASHED twin back in place (the document IS the file; a second row
+    // under the same key can no longer exist).
+    const refresh = async (
+      documentId: string,
+    ): Promise<EnsureProjectTextResult> => {
       await tx`
         UPDATE app.documents SET
           title = ${fileName}, file_ref = ${storageRef},
           mime_type = ${contentType}, extension = ${extension},
           folder_id = ${folder.folderId}, project_id = ${args.projectId},
+          status_changed_at_ms = CASE
+            WHEN lifecycle_status IS NULL OR lifecycle_status = 'active'
+              THEN status_changed_at_ms
+            ELSE ${now}
+          END,
+          lifecycle_status = NULL,
           updated_at_ms = ${now}
-        WHERE id = ${existing[0].id}
+        WHERE id = ${documentId}
       `;
       await tx`
-        UPDATE app.file_metadata SET document_id = ${existing[0].id}
+        UPDATE app.file_metadata SET document_id = ${documentId}
         WHERE id = ${fileId}
       `;
       return {
         folderId: folder.folderId,
-        documentId: existing[0].id,
+        documentId,
         createdFolder: folder.created,
         action: 'updated' as const,
       };
-    }
+    };
+    const existing = await lockProjectTextDocument(tx, auth, externalItemId);
+    if (existing !== null) return refresh(existing);
+    // FOR UPDATE over zero rows locks nothing: two panels saving at once
+    // both reach this insert, the unique key admits one, and the loser
+    // refreshes the winner's row instead of failing (or, before 0073,
+    // parking a duplicate).
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.documents (
         org_id, title, file_ref, mime_type, extension, source_provider,
@@ -186,11 +196,19 @@ export async function ensureProjectTextDocument(
         ${auth.organizationId}, ${fileName}, ${storageRef}, ${contentType},
         ${extension}, 'project_text', ${externalItemId}, ${args.projectId},
         ${folder.folderId}, ${auth.userId}, ${now}, ${now}
-      ) RETURNING id
+      )
+      ON CONFLICT (org_id, external_item_id)
+        WHERE external_item_id IS NOT NULL
+        DO NOTHING
+      RETURNING id
     `;
     const documentId = inserted[0]?.id;
     if (documentId === undefined) {
-      throw new DocumentError('DOCUMENT_CREATE_FAILED', 'Insert failed');
+      const winner = await lockProjectTextDocument(tx, auth, externalItemId);
+      if (winner === null) {
+        throw new DocumentError('DOCUMENT_CREATE_FAILED', 'Insert failed');
+      }
+      return refresh(winner);
     }
     await tx`
       UPDATE app.file_metadata SET document_id = ${documentId}
@@ -203,6 +221,23 @@ export async function ensureProjectTextDocument(
       action: 'created' as const,
     };
   });
+}
+
+/** The key's row (any lifecycle), locked for the write transaction. */
+async function lockProjectTextDocument(
+  tx: TransactionSql,
+  auth: ProjectAuthContext,
+  externalItemId: string,
+): Promise<string | null> {
+  const rows = await tx<{ id: string }[]>`
+    SELECT id FROM app.documents
+    WHERE org_id = ${auth.organizationId}
+      AND external_item_id = ${externalItemId}
+    ORDER BY created_at_ms
+    LIMIT 1
+    FOR UPDATE
+  `;
+  return rows[0]?.id ?? null;
 }
 
 /**

--- a/services/platform/backend/domains/files/upload-intents.test.ts
+++ b/services/platform/backend/domains/files/upload-intents.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment node
+
+/**
+ * The upload-intent ledger is the only record that a presigned blob exists.
+ * A key the browser never bound had no file row for the row-driven sweeps,
+ * so its bytes stayed in the bucket forever while the mint path dropped the
+ * expired ROW — the last trace of the blob. The sweep now reclaims the blob
+ * of an intent that expired unconsumed — and only of one NOTHING vouched
+ * for: the non-consuming ownership proof stamps the row, and a stamped or
+ * file-backed ref keeps its blob. The live MinIO round-trip rides the
+ * integration check; this double locks the statement shape and the per-row
+ * outcomes.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { s3DeleteObject } from '../../lib/object-store.ts';
+import { ownsUploadedBlob, sweepUploadIntents } from './upload-intents.ts';
+
+vi.mock('../../lib/object-store.ts', () => ({
+  resolveObjectStore: vi.fn(() => Promise.resolve({ bucket: 'itest' })),
+  s3DeleteObject: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../../lib/org-config.ts', () => ({
+  resolveOrgSlug: vi.fn(() => Promise.resolve('acme')),
+}));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+const FRAGMENT = Symbol('fragment');
+
+interface Fragment {
+  [FRAGMENT]: true;
+  text: string;
+  values: unknown[];
+}
+
+function isFragment(value: unknown): value is Fragment {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { [FRAGMENT]?: true })[FRAGMENT] === true
+  );
+}
+
+/** A recorder that inlines nested fragments (`sql.unsafe`, `sql\`…\``) the
+ * way postgres.js does; answers per statement from the script. */
+function fakeLedger(script: {
+  abandoned?: { id: string; s3Ref: string }[];
+  stamped?: { id: string }[];
+  uploaderRow?: boolean;
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let text = '';
+    const flat: unknown[] = [];
+    strings.forEach((part, index) => {
+      text += part;
+      if (index >= values.length) return;
+      const value = values[index];
+      if (isFragment(value)) {
+        text += value.text;
+        flat.push(...value.values);
+      } else {
+        text += '?';
+        flat.push(value);
+      }
+    });
+    text = text.replace(/\s+/g, ' ').trim();
+    statements.push({ text, values: flat });
+    let rows: unknown[] = [];
+    if (text.startsWith('SELECT i.id, i.s3_ref')) {
+      rows = script.abandoned ?? [];
+    } else if (text.startsWith('UPDATE app.upload_intents SET bound_at_ms')) {
+      rows = script.stamped ?? [];
+    } else if (text.startsWith('SELECT EXISTS')) {
+      rows = [{ owned: script.uploaderRow === true }];
+    }
+    const fragment: Fragment = { [FRAGMENT]: true, text, values: flat };
+    return Object.assign(Promise.resolve(rows), fragment);
+  };
+  tag.unsafe = (text: string): Fragment => ({
+    [FRAGMENT]: true,
+    text,
+    values: [],
+  });
+  return { sql: tag as unknown as Sql, statements };
+}
+
+/** The fake records nested fragment creations too; only real statements
+ * (what Postgres would receive) matter to the assertions. */
+function sqlStatements(statements: Statement[]): Statement[] {
+  return statements.filter((s) =>
+    /^(SELECT|INSERT|UPDATE|DELETE)/.test(s.text),
+  );
+}
+
+const scope = { organizationId: 'org_1', userId: 'user_1' };
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe('ownsUploadedBlob', () => {
+  it('stamps the intent it proves ownership through', async () => {
+    const fake = fakeLedger({ stamped: [{ id: 'i-1' }] });
+
+    const owned = await ownsUploadedBlob(fake.sql, {
+      ...scope,
+      storageRef: 's3:blobs/acme/aaa',
+    });
+
+    expect(owned).toBe(true);
+    const stamp = fake.statements.find((s) =>
+      s.text.startsWith('UPDATE app.upload_intents'),
+    );
+    expect(stamp?.text).toContain('SET bound_at_ms = coalesce(bound_at_ms, ?)');
+    expect(stamp?.text).toContain('expires_at_ms > ?');
+    expect(stamp?.text).toContain('RETURNING id');
+    expect(stamp?.values).toContain('s3:blobs/acme/aaa');
+    expect(
+      fake.statements.some((s) => s.text.startsWith('SELECT EXISTS')),
+    ).toBe(false);
+  });
+
+  it('falls back to the registered uploader row when no intent is live', async () => {
+    const fake = fakeLedger({ stamped: [], uploaderRow: true });
+
+    const owned = await ownsUploadedBlob(fake.sql, {
+      ...scope,
+      storageRef: 's3:blobs/acme/aaa',
+    });
+
+    expect(owned).toBe(true);
+    const proof = fake.statements.find((s) =>
+      s.text.startsWith('SELECT EXISTS'),
+    );
+    expect(proof?.text).toContain('FROM app.file_metadata');
+    expect(proof?.text).toContain('uploaded_by = ?');
+  });
+
+  it('refuses a ref that is neither minted for the caller nor theirs by row', async () => {
+    const fake = fakeLedger({ stamped: [], uploaderRow: false });
+
+    expect(
+      await ownsUploadedBlob(fake.sql, {
+        ...scope,
+        storageRef: 's3:blobs/acme/zzz',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('sweepUploadIntents', () => {
+  it('reclaims the blob of an abandoned intent and drops its row, leaving vouched-for and file-backed refs alone', async () => {
+    const fake = fakeLedger({
+      abandoned: [{ id: 'i-abandoned', s3Ref: 's3:blobs/acme/aaa' }],
+    });
+
+    const outcome = await sweepUploadIntents(fake.sql, {
+      organizationId: 'org_1',
+    });
+
+    expect(outcome).toEqual({ reclaimed: 1 });
+    expect(s3DeleteObject).toHaveBeenCalledTimes(1);
+    expect(s3DeleteObject).toHaveBeenCalledWith(
+      { bucket: 'itest' },
+      'blobs/acme/aaa',
+    );
+
+    const issued = sqlStatements(fake.statements);
+    // Consumed rows are dead handshakes.
+    expect(issued[0]?.text).toBe(
+      'DELETE FROM app.upload_intents WHERE org_id = ? AND consumed_at_ms IS NOT NULL',
+    );
+    // Vouched-for or file-backed rows drop WITHOUT touching their blob.
+    const heldDrop = issued[1];
+    expect(heldDrop?.text).toContain('DELETE FROM app.upload_intents i');
+    expect(heldDrop?.text).toContain('i.expires_at_ms < ?');
+    expect(heldDrop?.text).toContain(
+      '(i.bound_at_ms IS NOT NULL OR EXISTS ( SELECT 1 FROM app.file_metadata m',
+    );
+    // Only a ref nobody holds is a reclaim candidate.
+    const candidates = issued[2];
+    expect(candidates?.text).toContain(
+      'SELECT i.id, i.s3_ref AS "s3Ref" FROM app.upload_intents i',
+    );
+    expect(candidates?.text).toContain('i.consumed_at_ms IS NULL');
+    expect(candidates?.text).toContain('NOT (i.bound_at_ms IS NOT NULL)');
+    expect(candidates?.text).toContain(
+      'NOT EXISTS ( SELECT 1 FROM app.file_metadata m',
+    );
+    expect(candidates?.text).toContain('ORDER BY i.expires_at_ms LIMIT ?');
+    // The row goes only after its bytes did.
+    const rowDrop = fake.statements.find(
+      (s) => s.text === 'DELETE FROM app.upload_intents WHERE id = ?',
+    );
+    expect(rowDrop?.values).toEqual(['i-abandoned']);
+  });
+
+  it('keeps the row of a blob whose delete failed, for the next sweep', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(s3DeleteObject).mockRejectedValueOnce(new Error('503 slow down'));
+    const fake = fakeLedger({
+      abandoned: [{ id: 'i-stuck', s3Ref: 's3:blobs/acme/bbb' }],
+    });
+
+    const outcome = await sweepUploadIntents(fake.sql, {
+      organizationId: 'org_1',
+    });
+
+    expect(outcome).toEqual({ reclaimed: 0 });
+    expect(
+      fake.statements.some(
+        (s) => s.text === 'DELETE FROM app.upload_intents WHERE id = ?',
+      ),
+    ).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'abandoned-upload delete failed for blobs/acme/bbb',
+      ),
+      '503 slow down',
+    );
+  });
+
+  it('drops a row naming a ref outside the org namespace without a store call', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fake = fakeLedger({
+      abandoned: [{ id: 'i-foreign', s3Ref: 's3:blobs/other-org/ccc' }],
+    });
+
+    const outcome = await sweepUploadIntents(fake.sql, {
+      organizationId: 'org_1',
+    });
+
+    expect(outcome).toEqual({ reclaimed: 0 });
+    expect(s3DeleteObject).not.toHaveBeenCalled();
+    const rowDrop = fake.statements.find(
+      (s) => s.text === 'DELETE FROM app.upload_intents WHERE id = ?',
+    );
+    expect(rowDrop?.values).toEqual(['i-foreign']);
+  });
+
+  it('sweeps the REST ledger on its own table, where consumed is the only bind', async () => {
+    const fake = fakeLedger({ abandoned: [] });
+
+    await sweepUploadIntents(fake.sql, {
+      organizationId: 'org_1',
+      ledger: 'app.rest_upload_intents',
+    });
+
+    const issued = sqlStatements(fake.statements);
+    expect(issued).toHaveLength(3);
+    for (const statement of issued) {
+      expect(statement.text).toContain('app.rest_upload_intents');
+      expect(statement.text).not.toContain('app.upload_intents');
+      expect(statement.text).not.toContain('bound_at_ms');
+    }
+    expect(issued[2]?.text).toContain('NOT (FALSE)');
+  });
+});

--- a/services/platform/backend/domains/files/upload-intents.ts
+++ b/services/platform/backend/domains/files/upload-intents.ts
@@ -1,6 +1,13 @@
 import type { Sql, TransactionSql } from 'postgres';
 import { z } from 'zod';
 
+import {
+  parseBlobRef,
+  s3KeyBelongsToOrg,
+} from '../../core/lib/storage/blob_ref.ts';
+import { resolveObjectStore, s3DeleteObject } from '../../lib/object-store.ts';
+import { resolveOrgSlug } from '../../lib/org-config.ts';
+
 /**
  * The app upload-intent ledger (`app.upload_intents`, migration 0067) — the
  * session lanes' twin of the REST door's `rest_upload_intents`.
@@ -14,6 +21,11 @@ import { z } from 'zod';
  * names. Ownership of a BOUND blob is the row it became (`file_metadata.
  * uploaded_by`) and, for reads, the ACL of the parent it is bound to
  * (`domains/files/access.ts`).
+ *
+ * The row is also the only record that the blob EXISTS: a key the browser
+ * never PUT to, or PUT to and never bound, has no file row for the row-
+ * driven sweeps to find. `sweepUploadIntents` reclaims those bytes lazily
+ * from the mint path (lazy cleanup over cron, the house rule).
  */
 
 export const UPLOAD_PURPOSES = [
@@ -33,6 +45,25 @@ export const uploadPurposeSchema = z.enum(UPLOAD_PURPOSES);
  */
 export const UPLOAD_INTENT_TTL_MS = 2 * 60 * 60_000;
 
+/**
+ * How long past its TTL an unconsumed, unvouched-for intent may sit before
+ * its blob counts as ABANDONED and is reclaimed. Nothing can still bind it
+ * (the PUT died 15 minutes in, the intent two hours in); the day is slack
+ * for a bind lane that proved ownership in a transaction still committing.
+ */
+export const ABANDONED_UPLOAD_GRACE_MS = 24 * 3_600_000;
+
+/** Blobs reclaimed per sweep — bounded work on a request path; a backlog
+ * drains over the following mints. */
+const RECLAIM_BATCH = 25;
+
+/** The two ledgers the sweep serves: the session lanes' and the REST door's
+ * (0033). Only the session ledger carries `bound_at_ms` — the REST bind
+ * always consumes, so there a row is either consumed or nobody's. */
+export type UploadIntentLedger =
+  | 'app.upload_intents'
+  | 'app.rest_upload_intents';
+
 export interface UploadIntentKey {
   organizationId: string;
   userId: string;
@@ -42,7 +73,8 @@ export interface UploadIntentKey {
 /**
  * Record that `storageRef` was minted for `userId` and `purpose`. Called by
  * the mint lanes right after the key is minted (and, for the byte lane,
- * after the bytes landed). Sweeps the org's dead handshakes lazily.
+ * after the bytes landed). Sweeps the org's dead handshakes and abandoned
+ * uploads lazily.
  */
 export async function recordUploadIntent(
   sql: Sql | TransactionSql,
@@ -57,13 +89,7 @@ export async function recordUploadIntent(
       ${args.storageRef}, ${now + UPLOAD_INTENT_TTL_MS}, ${now}
     )
   `;
-  // Consumed rows, or rows expired a day ago, are dead handshakes.
-  await sql`
-    DELETE FROM app.upload_intents
-    WHERE org_id = ${args.organizationId}
-      AND (consumed_at_ms IS NOT NULL
-        OR expires_at_ms < ${now - 24 * 3_600_000})
-  `;
+  await sweepUploadIntents(sql, { organizationId: args.organizationId });
 }
 
 /**
@@ -101,19 +127,28 @@ export async function consumeUploadIntent(
  * more than once — a document upload creates one document per selected team
  * from one blob — and for lanes that only READ the named blob on the
  * caller's behalf (an outbound mail attachment).
+ *
+ * The intent arm STAMPS the row (`bound_at_ms`): this proof does not
+ * consume, so the stamp is the only trace that somebody bound or sent the
+ * blob — and the abandoned-upload sweep must never reclaim a ref that was
+ * vouched for. A stamp inside a bind transaction rolls back with a refusal.
  */
 export async function ownsUploadedBlob(
   sql: Sql | TransactionSql,
   args: UploadIntentKey,
 ): Promise<boolean> {
+  const now = Date.now();
+  const stamped = await sql<{ id: string }[]>`
+    UPDATE app.upload_intents SET bound_at_ms = coalesce(bound_at_ms, ${now})
+    WHERE s3_ref = ${args.storageRef}
+      AND org_id = ${args.organizationId}
+      AND user_id = ${args.userId}
+      AND expires_at_ms > ${now}
+    RETURNING id
+  `;
+  if (stamped.length > 0) return true;
   const rows = await sql<{ owned: boolean }[]>`
     SELECT EXISTS (
-      SELECT 1 FROM app.upload_intents
-      WHERE s3_ref = ${args.storageRef}
-        AND org_id = ${args.organizationId}
-        AND user_id = ${args.userId}
-        AND expires_at_ms > ${Date.now()}
-    ) OR EXISTS (
       SELECT 1 FROM app.file_metadata
       WHERE org_id = ${args.organizationId}
         AND storage_ref = ${args.storageRef}
@@ -135,4 +170,113 @@ export async function firstForeignUpload(
     }
   }
   return null;
+}
+
+/**
+ * The mint path's lazy sweep of one org's ledger:
+ *
+ *  1. consumed rows are dead handshakes — the bind lane owns the blob now;
+ *  2. rows expired past the grace whose blob SOMEBODY holds (a file row, or
+ *     a non-consuming proof stamped `bound_at_ms`) drop the same way: the
+ *     blob's lifecycle belongs to whatever holds it;
+ *  3. what is left past the grace is ABANDONED — minted, maybe PUT, never
+ *     bound, never vouched for — and nothing else will ever find it: the
+ *     bytes are reclaimed, then the row. A failed delete keeps the row, so
+ *     a later sweep retries; a bounded batch keeps the mint request cheap.
+ *
+ * Never reclaims a blob that got bound: a bound blob is either consumed (1),
+ * vouched for (2), or carried by a file row (2).
+ */
+export async function sweepUploadIntents(
+  sql: Sql | TransactionSql,
+  args: { organizationId: string; ledger?: UploadIntentLedger },
+): Promise<{ reclaimed: number }> {
+  const ledgerName: UploadIntentLedger = args.ledger ?? 'app.upload_intents';
+  const ledger = sql.unsafe(ledgerName);
+  const vouchedFor =
+    ledgerName === 'app.upload_intents'
+      ? sql`i.bound_at_ms IS NOT NULL`
+      : sql`FALSE`;
+  const now = Date.now();
+  const horizon = now - ABANDONED_UPLOAD_GRACE_MS;
+
+  await sql`
+    DELETE FROM ${ledger}
+    WHERE org_id = ${args.organizationId} AND consumed_at_ms IS NOT NULL
+  `;
+  await sql`
+    DELETE FROM ${ledger} i
+    WHERE i.org_id = ${args.organizationId}
+      AND i.consumed_at_ms IS NULL
+      AND i.expires_at_ms < ${horizon}
+      AND (${vouchedFor} OR EXISTS (
+        SELECT 1 FROM app.file_metadata m
+        WHERE m.org_id = i.org_id AND m.storage_ref = i.s3_ref
+      ))
+  `;
+  const abandoned = await sql<{ id: string; s3Ref: string }[]>`
+    SELECT i.id, i.s3_ref AS "s3Ref" FROM ${ledger} i
+    WHERE i.org_id = ${args.organizationId}
+      AND i.consumed_at_ms IS NULL
+      AND i.expires_at_ms < ${horizon}
+      AND NOT (${vouchedFor})
+      AND NOT EXISTS (
+        SELECT 1 FROM app.file_metadata m
+        WHERE m.org_id = i.org_id AND m.storage_ref = i.s3_ref
+      )
+    ORDER BY i.expires_at_ms
+    LIMIT ${RECLAIM_BATCH}
+  `;
+  if (abandoned.length === 0) return { reclaimed: 0 };
+
+  let orgSlug: string | null;
+  let store: Awaited<ReturnType<typeof resolveObjectStore>>;
+  try {
+    orgSlug = await resolveOrgSlug(sql, args.organizationId);
+    if (orgSlug === null) return { reclaimed: 0 };
+    store = await resolveObjectStore(orgSlug);
+  } catch (error) {
+    console.warn(
+      '[files] abandoned-upload reclaim skipped (store unresolved):',
+      error instanceof Error ? error.message : error,
+    );
+    return { reclaimed: 0 };
+  }
+  let reclaimed = 0;
+  for (const row of abandoned) {
+    const key = orgScopedKey(row.s3Ref, orgSlug);
+    if (key === null) {
+      // Not a key this org's mint could have produced — nothing to reclaim,
+      // and a row that can never be acted on must not be retried forever.
+      console.warn(
+        `[files] abandoned-upload row ${row.id} names a ref outside the org namespace; dropping it`,
+      );
+      await sql`DELETE FROM ${ledger} WHERE id = ${row.id}`;
+      continue;
+    }
+    try {
+      await s3DeleteObject(store, key);
+    } catch (error) {
+      console.warn(
+        `[files] abandoned-upload delete failed for ${key}:`,
+        error instanceof Error ? error.message : error,
+      );
+      continue;
+    }
+    await sql`DELETE FROM ${ledger} WHERE id = ${row.id}`;
+    reclaimed += 1;
+  }
+  return { reclaimed };
+}
+
+function orgScopedKey(ref: string, orgSlug: string): string | null {
+  try {
+    const parsed = parseBlobRef(ref);
+    if (parsed.backend !== 's3' || !s3KeyBelongsToOrg(parsed.key, orgSlug)) {
+      return null;
+    }
+    return parsed.key;
+  } catch {
+    return null;
+  }
 }

--- a/services/platform/backend/domains/folders/service.ts
+++ b/services/platform/backend/domains/folders/service.ts
@@ -451,12 +451,35 @@ export async function getOrCreateProjectFolder(
   if (found !== undefined) {
     return { folderId: found.id, name: found.name, created: false };
   }
-  const folderId = await createFolder(tx, auth, {
-    name,
-    projectId: args.projectId,
-    ...(args.parentId !== undefined ? { parentId: args.parentId } : {}),
-  });
-  return { folderId, name, created: true };
+  try {
+    const folderId = await createFolder(tx, auth, {
+      name,
+      projectId: args.projectId,
+      ...(args.parentId !== undefined ? { parentId: args.parentId } : {}),
+    });
+    return { folderId, name, created: true };
+  } catch (error) {
+    // Two writers can pass the lookup above before either commits (the
+    // project-text panel saving twice, two syncs filing into one folder);
+    // the create's own sibling check then sees the winner's row and refuses
+    // with FOLDER_NAME_TAKEN. The folder this caller asked for exists now —
+    // hand it back as "found" instead of failing a save on a name the caller
+    // never chose to collide with.
+    if (!(error instanceof FolderError) || error.code !== 'FOLDER_NAME_TAKEN') {
+      throw error;
+    }
+    const won = await tx<{ id: string; name: string }[]>`
+      SELECT id, name FROM app.folders
+      WHERE org_id = ${auth.organizationId}
+        AND project_id = ${args.projectId}
+        AND parent_id IS NOT DISTINCT FROM ${args.parentId ?? null}
+        AND name = ${name}
+      LIMIT 1
+    `;
+    const winner = won[0];
+    if (winner === undefined) throw error;
+    return { folderId: winner.id, name: winner.name, created: false };
+  }
 }
 
 /** Point-read with 0.4 semantics: null (not 404) on any access failure. */

--- a/services/platform/backend/domains/onedrive/service.scan.test.ts
+++ b/services/platform/backend/domains/onedrive/service.scan.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+
+/**
+ * Unit lock for the cloud-sync scan's shape (the OneDrive and Google Drive
+ * engines share it): the scan is a keyset walk over EVERY syncable config —
+ * pages in id order, not a cap. The 0.4-era `LIMIT 1000 ORDER BY
+ * created_at_ms` handed every config past the thousandth to never: newest
+ * syncs sat `active` with no job, no error and no log.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { addJobInTx } from '../../jobs/enqueue.ts';
+import { ONEDRIVE_SYNC_ADAPTER, runSyncScanWith } from './service.ts';
+
+vi.mock('../../jobs/enqueue.ts', () => ({ addJobInTx: vi.fn() }));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+function configRow(id: string): { id: string; organizationId: string } {
+  return { id, organizationId: 'org_1' };
+}
+
+/** Scripted `sql`: each page query pops the next page. */
+function fakeScan(pages: { id: string; organizationId: string }[][]): {
+  sql: Sql;
+  statements: Statement[];
+} {
+  const statements: Statement[] = [];
+  const fn = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    statements.push({ text: strings.join('?'), values });
+    return Promise.resolve(pages.shift() ?? []);
+  };
+  fn.unsafe = (text: string): { text: string } => ({ text });
+  return { sql: fn as unknown as Sql, statements };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runSyncScanWith', () => {
+  it('walks every page by keyset and enqueues one job per config', async () => {
+    const fake = fakeScan([
+      [configRow('c1'), configRow('c2'), configRow('c3')],
+      [configRow('c4'), configRow('c5')],
+    ]);
+
+    const enqueued = await runSyncScanWith(fake.sql, ONEDRIVE_SYNC_ADAPTER, {
+      pageSize: 3,
+    });
+
+    expect(enqueued).toBe(5);
+    expect(addJobInTx).toHaveBeenCalledTimes(5);
+    for (const id of ['c1', 'c2', 'c3', 'c4', 'c5']) {
+      expect(addJobInTx).toHaveBeenCalledWith(
+        fake.sql,
+        ONEDRIVE_SYNC_ADAPTER.configJobName,
+        { organizationId: 'org_1', configId: id },
+        { singletonKey: `${ONEDRIVE_SYNC_ADAPTER.singletonPrefix}${id}` },
+      );
+    }
+
+    const pageQueries = fake.statements.filter((s) =>
+      s.text.includes('SELECT'),
+    );
+    expect(pageQueries).toHaveLength(2);
+    for (const query of pageQueries) {
+      expect(query.text).toContain("status IN ('active', 'error')");
+      expect(query.text).toContain('ORDER BY id');
+      expect(query.text).not.toContain('created_at_ms');
+      expect(query.values).toContain(3);
+    }
+    // The second page starts after the last id of the first.
+    expect(pageQueries[0]?.values).toContain(null);
+    expect(pageQueries[1]?.values).toContain('c3');
+  });
+
+  it('stops after a short page', async () => {
+    const fake = fakeScan([[configRow('c1')]]);
+
+    const enqueued = await runSyncScanWith(fake.sql, ONEDRIVE_SYNC_ADAPTER, {
+      pageSize: 3,
+    });
+
+    expect(enqueued).toBe(1);
+    expect(
+      fake.statements.filter((s) => s.text.includes('SELECT')),
+    ).toHaveLength(1);
+  });
+});

--- a/services/platform/backend/domains/onedrive/service.ts
+++ b/services/platform/backend/domains/onedrive/service.ts
@@ -846,9 +846,27 @@ export function createSyncImportDeps(
           ${createArgs.createdBy ?? null}, ${folderId}, ${folderPath},
           ${now}, ${now}
         )
+        ON CONFLICT (org_id, external_item_id)
+          WHERE external_item_id IS NOT NULL
+          DO NOTHING
         RETURNING id
       `;
-      const id = inserted[0]?.id;
+      let id = inserted[0]?.id;
+      if (id === undefined) {
+        // Lost a race with a concurrent sync of the same item (an
+        // overlapping run, a second config over the same folder): the key
+        // is unique in the schema (0073), so the row exists now — hand it
+        // back and let this run refresh it rather than fail the config on
+        // a unique violation.
+        const existing = await sql<{ id: string }[]>`
+          SELECT id FROM app.documents
+          WHERE org_id = ${createArgs.organizationId}
+            AND external_item_id = ${createArgs.externalItemId}
+          ORDER BY created_at_ms ASC
+          LIMIT 1
+        `;
+        id = existing[0]?.id;
+      }
       if (!id) throw new Error('Document insert failed');
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- pg ids stand in for the reused pipeline's Convex Id<'documents'> brand
       return id as never;
@@ -1416,31 +1434,60 @@ async function renewSyncClaim(
   `;
 }
 
+/** Configs per scan page — how many sit in memory at once, not how many
+ * the platform syncs. */
+const SYNC_SCAN_PAGE_SIZE = 1000;
+
 /**
  * Cron scan: one per-config job per syncable config. `error` configs are
  * retried too (a transient vendor failure must not silently end a sync
  * forever — the 0.4 active-only listing predates this engine); `inactive`
  * is the only terminal state (cancel, source deleted, folder removed).
+ *
+ * The scan WALKS every syncable config (keyset pages in id order, the
+ * trigger scanner's idiom) rather than taking the first N: a bare
+ * `LIMIT 1000 ORDER BY created_at_ms` handed every config past the
+ * thousandth to never — the newest syncs sat `active` with no job, no
+ * error and no log. The per-config `singletonKey` keeps a config that is
+ * still queued from being enqueued twice, so a complete walk costs one
+ * no-op enqueue per busy config and nothing else.
  */
 export async function runSyncScanWith(
   sql: Sql,
   adapter: SyncProviderAdapter,
+  options: { pageSize?: number } = {},
 ): Promise<number> {
-  const rows = await sql<{ id: string; organizationId: string }[]>`
-    SELECT id, org_id AS "organizationId" FROM ${sql.unsafe(adapter.configTable)}
-    WHERE status IN ('active', 'error')
-    ORDER BY created_at_ms ASC
-    LIMIT 1000
-  `;
-  for (const row of rows) {
-    await addJobInTx(
-      sql,
-      adapter.configJobName,
-      { organizationId: row.organizationId, configId: row.id },
-      { singletonKey: `${adapter.singletonPrefix}${row.id}` },
-    );
+  const pageSize = options.pageSize ?? SYNC_SCAN_PAGE_SIZE;
+  let enqueued = 0;
+  let cursor: string | null = null;
+  for (;;) {
+    const page: SyncScanRow[] = await sql<SyncScanRow[]>`
+      SELECT id, org_id AS "organizationId" FROM ${sql.unsafe(adapter.configTable)}
+      WHERE status IN ('active', 'error')
+        AND (${cursor}::text IS NULL OR id > ${cursor})
+      ORDER BY id
+      LIMIT ${pageSize}
+    `;
+    for (const row of page) {
+      await addJobInTx(
+        sql,
+        adapter.configJobName,
+        { organizationId: row.organizationId, configId: row.id },
+        { singletonKey: `${adapter.singletonPrefix}${row.id}` },
+      );
+      enqueued += 1;
+    }
+    if (page.length < pageSize) break;
+    const last: SyncScanRow | undefined = page.at(-1);
+    if (last === undefined) break;
+    cursor = last.id;
   }
-  return rows.length;
+  return enqueued;
+}
+
+interface SyncScanRow {
+  id: string;
+  organizationId: string;
 }
 
 /**

--- a/services/platform/backend/domains/retention/service.sweep.test.ts
+++ b/services/platform/backend/domains/retention/service.sweep.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+/**
+ * The custodian filter of the document and chat sweeps lives in SQL, on
+ * every pass. Skipping held rows in JS after `LIMIT` starved the sweep: once
+ * an org held more than a batch of trashed rows, the same held rows were
+ * re-selected every night and the unheld rows behind them were never
+ * reached — retention quietly under-deleted forever. The double reads the
+ * statements the sweep issues (fragments inlined) and checks that the
+ * filter is part of the candidate query, that a creator-less row stays a
+ * candidate, and that what the query answers is what gets purged.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { releaseRefs } from '../knowledge/release.ts';
+import { sweepOrgPhase2 } from './service.ts';
+
+vi.mock('../../lib/org-config.ts', () => ({
+  readGovernancePolicyForOrg: vi.fn(() => Promise.resolve(null)),
+  resolveOrgSlug: vi.fn(() => Promise.resolve('acme')),
+}));
+vi.mock('../knowledge/release.ts', () => ({
+  releaseRefs: vi.fn(() => Promise.resolve({ failures: [] })),
+}));
+vi.mock('../legal_holds/service.ts', () => ({ loadActiveHolds: vi.fn() }));
+vi.mock('../audit_logs/service.ts', () => ({ createAuditLog: vi.fn() }));
+vi.mock('../tts/service.ts', () => ({ cascadeDeleteThreadTtsChunks: vi.fn() }));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+const FRAGMENT = Symbol('fragment');
+
+interface Fragment {
+  [FRAGMENT]: true;
+  text: string;
+  values: unknown[];
+}
+
+function isFragment(value: unknown): value is Fragment {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { [FRAGMENT]?: true })[FRAGMENT] === true
+  );
+}
+
+/**
+ * A recorder that inlines nested `sql\`…\`` fragments the way postgres.js
+ * does, so the recorded text is the statement Postgres would see. Answers
+ * the documents pass-B candidate query from the script; everything else
+ * answers no rows.
+ */
+function fakeSweep(script: {
+  documentsPassB: {
+    id: string;
+    fileRef: string | null;
+    historyFiles: string[];
+  }[];
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let text = '';
+    const flat: unknown[] = [];
+    strings.forEach((part, index) => {
+      text += part;
+      if (index >= values.length) return;
+      const value = values[index];
+      if (isFragment(value)) {
+        text += value.text;
+        flat.push(...value.values);
+      } else {
+        text += '?';
+        flat.push(value);
+      }
+    });
+    text = text.replace(/\s+/g, ' ').trim();
+    statements.push({ text, values: flat });
+    const rows =
+      text.startsWith('SELECT id, file_ref') &&
+      text.includes('FROM app.documents')
+        ? script.documentsPassB
+        : [];
+    const fragment: Fragment = { [FRAGMENT]: true, text, values: flat };
+    return Object.assign(Promise.resolve(rows), fragment);
+  };
+  tag.begin = (callback: (tx: typeof tag) => unknown): unknown => callback(tag);
+  tag.unsafe = (text: string): Fragment => ({
+    [FRAGMENT]: true,
+    text,
+    values: [],
+  });
+  tag.json = (value: unknown): unknown => value;
+  return { sql: tag as unknown as Sql, statements };
+}
+
+const org = {
+  organizationId: 'org_1',
+  config: {
+    documentsEnabled: true,
+    documentsRetentionDays: 30,
+    chatHistoryEnabled: true,
+    chatHistoryRetentionDays: 30,
+    deletionGraceDays: 7,
+  },
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sweepOrgPhase2 — custodian holds', () => {
+  it('filters held creators and owners in SQL on every pass, keeping creator-less rows as candidates', async () => {
+    const fake = fakeSweep({ documentsPassB: [] });
+
+    await sweepOrgPhase2(fake.sql, org, {
+      orgHeld: false,
+      userMembershipIds: new Set(['held-user']),
+    });
+
+    const documentsPassA = fake.statements.find(
+      (s) =>
+        s.text.startsWith(
+          "UPDATE app.documents SET lifecycle_status = 'expired'",
+        ) && s.text.includes('lifecycle_status IS NULL'),
+    );
+    const documentsPassB = fake.statements.find(
+      (s) =>
+        s.text.startsWith('SELECT id, file_ref') &&
+        s.text.includes("lifecycle_status IN ('trashed', 'expired')"),
+    );
+    expect(documentsPassA?.text).toContain(
+      'created_by IS NULL OR created_by <> ALL(?)',
+    );
+    expect(documentsPassB?.text).toContain(
+      'created_by IS NULL OR created_by <> ALL(?)',
+    );
+    expect(documentsPassB?.values).toContainEqual(['held-user']);
+
+    const chatPasses = fake.statements.filter(
+      (s) =>
+        s.text.includes('FROM app.thread_metadata tm') &&
+        s.text.includes("tm.chat_type = 'chat'"),
+    );
+    expect(chatPasses).toHaveLength(2);
+    for (const pass of chatPasses) {
+      expect(pass.text).toContain('tm.user_id <> ALL(?)');
+      expect(pass.values).toContainEqual(['held-user']);
+    }
+  });
+
+  it('purges every candidate the query answers — the query is the filter', async () => {
+    const fake = fakeSweep({
+      documentsPassB: [
+        { id: 'doc-unheld', fileRef: 's3:acme/unheld', historyFiles: [] },
+      ],
+    });
+
+    const stats = await sweepOrgPhase2(fake.sql, org, {
+      orgHeld: false,
+      userMembershipIds: new Set(['held-user']),
+    });
+
+    expect(stats.documents).toBe(1);
+    expect(releaseRefs).toHaveBeenCalledTimes(1);
+    const purge = fake.statements.find(
+      (s) => s.text === 'DELETE FROM app.documents WHERE id = ?',
+    );
+    expect(purge?.values).toEqual(['doc-unheld']);
+  });
+});

--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -477,6 +477,18 @@ async function sweepDocuments(
   const protectedIds = [...holds.userMembershipIds];
   let processed = 0;
 
+  // The custodian filter lives in SQL, on every pass: a held creator's rows
+  // are never candidates, so they cannot fill the batch. Skipping them in
+  // JS after `LIMIT` starved the sweep — once an org held more than a
+  // batch of trashed rows, the same held rows were re-selected every night
+  // and the unheld rows behind them were never reached. A creator-less row
+  // (a synced document) is nobody's to hold: `NULL <> ALL(...)` is NULL,
+  // so the IS NULL arm keeps it a candidate.
+  const custodianFree = sql`
+    (${protectedIds.length === 0}
+     OR created_by IS NULL OR created_by <> ALL(${protectedIds}))
+  `;
+
   // Pass A (grace > 0): flip active expired rows into the admin Trash. A
   // document's age is its creation — or its last lifecycle change, when a
   // restore from the Trash stamped one: a restore restarts the retention
@@ -491,8 +503,7 @@ async function sweepDocuments(
         WHERE org_id = ${org.organizationId} AND lifecycle_status IS NULL
           AND GREATEST(created_at_ms, coalesce(status_changed_at_ms, 0))
               < ${cutoff}
-          AND (${protectedIds.length === 0}
-               OR created_by <> ALL(${protectedIds}))
+          AND ${custodianFree}
         LIMIT ${BATCH_LIMIT}
       )
       RETURNING id
@@ -508,16 +519,15 @@ async function sweepDocuments(
           {
             id: string;
             fileRef: string | null;
-            createdBy: string | null;
             historyFiles: string[];
           }[]
         >`
-          SELECT id, file_ref AS "fileRef", created_by AS "createdBy",
-                 history_files AS "historyFiles"
+          SELECT id, file_ref AS "fileRef", history_files AS "historyFiles"
           FROM app.documents
           WHERE org_id = ${org.organizationId}
             AND lifecycle_status IN ('trashed', 'expired')
             AND status_changed_at_ms < ${Date.now() - graceDays * DAY_MS}
+            AND ${custodianFree}
           LIMIT ${BATCH_LIMIT}
         `
       : // No grace window: trashed/expired rows (user trash, a project-
@@ -530,26 +540,22 @@ async function sweepDocuments(
           {
             id: string;
             fileRef: string | null;
-            createdBy: string | null;
             historyFiles: string[];
           }[]
         >`
-          SELECT id, file_ref AS "fileRef", created_by AS "createdBy",
-                 history_files AS "historyFiles"
+          SELECT id, file_ref AS "fileRef", history_files AS "historyFiles"
           FROM app.documents
           WHERE org_id = ${org.organizationId}
             AND ((lifecycle_status IS NULL
                   AND GREATEST(created_at_ms, coalesce(status_changed_at_ms, 0))
                       < ${cutoff})
                  OR lifecycle_status IN ('trashed', 'expired'))
+            AND ${custodianFree}
           LIMIT ${BATCH_LIMIT}
         `;
   if (passB.length === 0) return processed;
   const orgSlug = await resolveOrgSlug(sql, org.organizationId);
   for (const doc of passB) {
-    if (doc.createdBy !== null && holds.userMembershipIds.has(doc.createdBy)) {
-      continue;
-    }
     try {
       await purgeDocument(sql, orgSlug, {
         id: doc.id,
@@ -608,7 +614,14 @@ async function sweepChatHistory(
   if (typeof days !== 'number' || days <= 0) return 0;
   const cutoff = Date.now() - days * DAY_MS;
   const graceDays = org.config.deletionGraceDays ?? 0;
+  const protectedIds = [...holds.userMembershipIds];
   let processed = 0;
+
+  // Custodian filter in SQL (see sweepDocuments): a held owner's threads
+  // are never candidates, so they cannot fill a batch and starve the rest.
+  const custodianFree = sql`
+    (${protectedIds.length === 0} OR tm.user_id <> ALL(${protectedIds}))
+  `;
 
   // Pass A (grace > 0): expire active chat threads past the cutoff — they
   // land in the admin Trash for the grace window. A thread's age is its
@@ -616,18 +629,18 @@ async function sweepChatHistory(
   // Trash stamped one: the restore restarts the retention clock, or the
   // next sweep re-expires the thread the admin just brought back.
   if (graceDays > 0) {
-    const candidates = await sql<{ threadId: string; userId: string }[]>`
-      SELECT tm.thread_id AS "threadId", tm.user_id AS "userId"
+    const candidates = await sql<{ threadId: string }[]>`
+      SELECT tm.thread_id AS "threadId"
       FROM app.thread_metadata tm
       JOIN app.threads t ON t.id = tm.thread_id
       WHERE tm.org_id = ${org.organizationId} AND tm.chat_type = 'chat'
         AND tm.status = 'active'
         AND GREATEST(t.updated_at_ms, coalesce(tm.status_changed_at_ms, 0))
             < ${cutoff}
+        AND ${custodianFree}
       LIMIT ${BATCH_LIMIT}
     `;
     for (const thread of candidates) {
-      if (holds.userMembershipIds.has(thread.userId)) continue;
       await sql`
         UPDATE app.thread_metadata SET
           status = 'expired', status_changed_at_ms = ${Date.now()}
@@ -642,17 +655,18 @@ async function sweepChatHistory(
   // — hidden siblings travel with their root.
   const passB =
     graceDays > 0
-      ? await sql<{ threadId: string; userId: string }[]>`
-          SELECT tm.thread_id AS "threadId", tm.user_id AS "userId"
+      ? await sql<{ threadId: string }[]>`
+          SELECT tm.thread_id AS "threadId"
           FROM app.thread_metadata tm
           WHERE tm.org_id = ${org.organizationId} AND tm.chat_type = 'chat'
             AND tm.status IN ('trashed', 'expired')
             AND tm.branch_root_id IS NULL
             AND tm.status_changed_at_ms < ${Date.now() - graceDays * DAY_MS}
+            AND ${custodianFree}
           LIMIT ${BATCH_LIMIT}
         `
-      : await sql<{ threadId: string; userId: string }[]>`
-          SELECT tm.thread_id AS "threadId", tm.user_id AS "userId"
+      : await sql<{ threadId: string }[]>`
+          SELECT tm.thread_id AS "threadId"
           FROM app.thread_metadata tm
           JOIN app.threads t ON t.id = tm.thread_id
           WHERE tm.org_id = ${org.organizationId} AND tm.chat_type = 'chat'
@@ -662,10 +676,10 @@ async function sweepChatHistory(
                                coalesce(tm.status_changed_at_ms, 0))
                       < ${cutoff})
                  OR tm.status IN ('trashed', 'expired'))
+            AND ${custodianFree}
           LIMIT ${BATCH_LIMIT}
         `;
   for (const thread of passB) {
-    if (holds.userMembershipIds.has(thread.userId)) continue;
     processed += await purgeThreadLineage(
       sql,
       org.organizationId,

--- a/services/platform/backend/domains/tasks/watchdogs.test.ts
+++ b/services/platform/backend/domains/tasks/watchdogs.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+/**
+ * The deadline sweep must stop the PROCESS, not only its ledger: failing an
+ * overdue run while its sandbox exec keeps running leaked the exec's compute
+ * until the agent gave up on its own (its gateway key revoked, it ground on
+ * auth errors), and a Retry could then start a second exec against the same
+ * standing workspace. The sweep cancels the exec — best-effort, before the
+ * op row is settled — and an unreachable spawner never keeps the run alive.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sessionCancelExec } from '../../core/node_only/sandbox/helpers/session_client.ts';
+import {
+  type AgentRunRow,
+  failAgentRun,
+  listOverdueAgentRuns,
+  listParkedAgentRuns,
+} from './agent-runs.ts';
+import { runTaskAgentWatchdog } from './watchdogs.ts';
+
+vi.mock('../../core/node_only/sandbox/helpers/session_client.ts', () => ({
+  sessionCancelExec: vi.fn(),
+}));
+vi.mock('./agent-runs.ts', () => ({
+  failAgentRun: vi.fn(),
+  listOverdueAgentRuns: vi.fn(),
+  listParkedAgentRuns: vi.fn(() => Promise.resolve([])),
+  wakeParkedAgentRuns: vi.fn(() => Promise.resolve(0)),
+}));
+
+const overdueRun = {
+  id: 'run-1',
+  organizationId: 'org-1',
+  agentId: 'agent-1',
+  execId: 'exec-1',
+  sessionId: 'pa-agent-1',
+  status: 'running',
+} as unknown as AgentRunRow;
+
+/** A recorder `sql`: every statement lands in `events` in call order, next
+ * to the exec cancels the mock records — the order IS the contract. */
+function fakeSql(events: string[]): Sql {
+  const fn = (strings: TemplateStringsArray): Promise<unknown[]> => {
+    const text = strings.join('?').replace(/\s+/g, ' ').trim();
+    events.push(`sql:${text.slice(0, 36)}`);
+    return Promise.resolve([]);
+  };
+  return fn as unknown as Sql;
+}
+
+beforeEach(() => {
+  vi.mocked(listOverdueAgentRuns).mockResolvedValue([overdueRun]);
+  vi.mocked(listParkedAgentRuns).mockResolvedValue([]);
+  vi.mocked(failAgentRun).mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe('runTaskAgentWatchdog (deadline lane)', () => {
+  it('cancels the sandbox exec of a deadline-failed run before settling its op row', async () => {
+    const events: string[] = [];
+    vi.mocked(sessionCancelExec).mockImplementation((sessionId, execId) => {
+      events.push(`cancel:${sessionId}/${execId}`);
+      return Promise.resolve(true);
+    });
+
+    const result = await runTaskAgentWatchdog(fakeSql(events));
+
+    expect(result.failed).toBe(1);
+    expect(sessionCancelExec).toHaveBeenCalledTimes(1);
+    expect(sessionCancelExec).toHaveBeenCalledWith('pa-agent-1', 'exec-1');
+    const cancelAt = events.indexOf('cancel:pa-agent-1/exec-1');
+    const opSettleAt = events.findIndex((event) =>
+      event.startsWith('sql:UPDATE app.sandbox_session_ops'),
+    );
+    expect(cancelAt).toBeGreaterThanOrEqual(0);
+    expect(opSettleAt).toBeGreaterThan(cancelAt);
+  });
+
+  it('settles the run even when the spawner is unreachable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(sessionCancelExec).mockRejectedValue(
+      new TypeError('fetch failed'),
+    );
+    const events: string[] = [];
+
+    const result = await runTaskAgentWatchdog(fakeSql(events));
+
+    expect(result.failed).toBe(1);
+    expect(
+      events.some((event) =>
+        event.startsWith('sql:UPDATE app.sandbox_session_ops'),
+      ),
+    ).toBe(true);
+    expect(
+      events.some((event) =>
+        event.startsWith('sql:UPDATE app.sandbox_sessions'),
+      ),
+    ).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('exec cancel failed for run run-1'),
+      'fetch failed',
+    );
+  });
+
+  it('leaves the exec alone when another settle already claimed the run', async () => {
+    vi.mocked(failAgentRun).mockResolvedValue(false);
+    const events: string[] = [];
+
+    const result = await runTaskAgentWatchdog(fakeSql(events));
+
+    expect(result.failed).toBe(0);
+    expect(sessionCancelExec).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/tasks/watchdogs.ts
+++ b/services/platform/backend/domains/tasks/watchdogs.ts
@@ -1,5 +1,6 @@
 import type { Sql } from 'postgres';
 
+import { sessionCancelExec } from '../../core/node_only/sandbox/helpers/session_client.ts';
 import {
   failAgentRun,
   listOverdueAgentRuns,
@@ -13,11 +14,15 @@ import {
  * capacity machinery:
  *
  *  - DEADLINE: a run past its hard deadline is failed with the deadline
- *    reason, its session op settled `cancelled`, and its session slot
- *    released — a lost drive chain must never strand a run `running`
- *    forever with its gateway key alive. A PARKED run past deadline fails
- *    too (it never launched, so there is no op or slot to settle) — under
- *    permanent capacity pressure the queue must still drain.
+ *    reason, its sandbox exec STOPPED, its session op settled `cancelled`,
+ *    and its session slot released — a lost drive chain must never strand
+ *    a run `running` forever with its gateway key alive, and failing the
+ *    run must not leave the agent process grinding on in the still-warm
+ *    container (the in-chain deadline cut in `agent_run_host` cancels the
+ *    exec too; a Retry that starts a second exec against the same standing
+ *    workspace must never meet the first one). A PARKED run past deadline
+ *    fails too (it never launched, so there is no exec, op or slot to
+ *    settle) — under permanent capacity pressure the queue must still drain.
  *  - PARKED: the release-edge wake is best-effort; this sweep re-runs the
  *    claim per org so a lost edge costs minutes, never forever.
  *
@@ -39,6 +44,18 @@ export async function runTaskAgentWatchdog(sql: Sql): Promise<{
     });
     if (!didFail) continue;
     failed += 1;
+    // Stop the process, not just its ledger: the exec keeps running until
+    // its own end otherwise (its gateway key is revoked, so it grinds on
+    // auth errors), burning the slot this sweep is about to free. Best-
+    // effort — an unreachable spawner must not keep the run `running`.
+    try {
+      await sessionCancelExec(run.sessionId, run.execId);
+    } catch (error) {
+      console.warn(
+        `[task-agent] watchdog: exec cancel failed for run ${run.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
     await sql`
       UPDATE app.sandbox_session_ops SET
         status = 'cancelled', finished_at_ms = ${Date.now()},

--- a/services/platform/backend/domains/video_links/service.finalizer.test.ts
+++ b/services/platform/backend/domains/video_links/service.finalizer.test.ts
@@ -1,0 +1,292 @@
+// @vitest-environment node
+
+/**
+ * Terminal writes on a video-link job are conditional. The captions
+ * finalizer used to patch `completed` unconditionally: a cancel landing
+ * during the seconds-wide transcript store (its `skipped` write and blob
+ * delete already done) was overwritten, and the chip came back Ready over a
+ * file row whose bytes were gone. The finalizer's patch is now a CAS on
+ * `indexing` inside the transaction that inserts the file row — a lost CAS
+ * rolls everything back and reaps the orphan blob — and the cancel itself is
+ * a CAS on the state the user saw, so a job that settled on its own is left
+ * as it settled. The real-Postgres arc rides the integration check.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { addJobInTx } from '../../jobs/enqueue.ts';
+import { createAuditLog } from '../audit_logs/service.ts';
+import { deleteOrgBlobRefs } from '../files/service.ts';
+import { markRagQueued } from '../knowledge/service.ts';
+import {
+  cancelVideoLink,
+  finalizeClonedTranscript,
+  insertSyntheticFileMetadata,
+} from './service.ts';
+
+vi.mock('../files/service.ts', () => ({
+  deleteOrgBlobRefs: vi.fn(() => Promise.resolve()),
+  putOrgBlobBytes: vi.fn(),
+}));
+vi.mock('../knowledge/service.ts', () => ({
+  markRagQueued: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../../jobs/enqueue.ts', () => ({
+  addJobInTx: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../audit_logs/service.ts', () => ({
+  createAuditLog: vi.fn(() => Promise.resolve()),
+}));
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+const FRAGMENT = Symbol('fragment');
+
+interface Fragment {
+  [FRAGMENT]: true;
+  text: string;
+}
+
+function isFragment(value: unknown): value is Fragment {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { [FRAGMENT]?: true })[FRAGMENT] === true
+  );
+}
+
+function jobRow(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 'job-1',
+    organizationId: 'org-1',
+    threadId: null,
+    uploadedBy: 'user-1',
+    status: 'indexing',
+    statusChangedAt: Date.now(),
+    storageRef: null,
+    fileMetadataId: null,
+    messageBoundAt: null,
+    attempts: 0,
+    errorReasonCode: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Scripted `sql`: job reads pop `jobs`, job patches pop `updates` (an empty
+ * answer is a CAS miss — the follow-up existence read answers "still
+ * there"), the file insert answers one id. `begin` records COMMIT or
+ * ROLLBACK so the transactional outcome is observable.
+ */
+function fakeJobs(script: {
+  jobs: Record<string, unknown>[];
+  updates: { id: string }[][];
+}): { sql: Sql; statements: Statement[] } {
+  const statements: Statement[] = [];
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let text = '';
+    const flat: unknown[] = [];
+    strings.forEach((part, index) => {
+      text += part;
+      if (index >= values.length) return;
+      const value = values[index];
+      if (isFragment(value)) {
+        text += value.text;
+      } else {
+        text += '?';
+        flat.push(value);
+      }
+    });
+    text = text.replace(/\s+/g, ' ').trim();
+    statements.push({ text, values: flat });
+    let rows: unknown[] = [];
+    if (text.startsWith('SELECT id, org_id AS "organizationId"')) {
+      rows = script.jobs.length > 0 ? [script.jobs.shift()] : [];
+    } else if (text.startsWith('INSERT INTO app.file_metadata')) {
+      rows = [{ id: 'fm-1' }];
+    } else if (text.startsWith('UPDATE app.video_link_jobs SET')) {
+      rows = script.updates.shift() ?? [];
+    } else if (text.startsWith('SELECT id FROM app.video_link_jobs WHERE id')) {
+      rows = [{ id: 'job-1' }];
+    }
+    return Promise.resolve(rows);
+  };
+  tag.unsafe = (text: string): Fragment => ({ [FRAGMENT]: true, text });
+  tag.begin = async (
+    callback: (tx: typeof tag) => unknown,
+  ): Promise<unknown> => {
+    try {
+      const result = await callback(tag);
+      statements.push({ text: 'COMMIT', values: [] });
+      return result;
+    } catch (error) {
+      statements.push({ text: 'ROLLBACK', values: [] });
+      throw error;
+    }
+  };
+  return { sql: tag as unknown as Sql, statements };
+}
+
+const captionsArgs = {
+  jobId: 'job-1',
+  storageId: 's3:acme/transcript-1',
+  transcript: 'hello world',
+  fileSize: 11,
+  videoTitle: 'Talk',
+  videoDurationSec: 60,
+  sourceUrl: 'https://videos.test/1',
+  sourcePlatform: 'youtube',
+  transcriptSource: 'captions_auto',
+  organizationId: 'org-1',
+  uploadedBy: 'user-1',
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe('insertSyntheticFileMetadata', () => {
+  it('rolls back and reaps the blob when a cancel landed before the terminal patch', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fake = fakeJobs({ jobs: [jobRow({})], updates: [[]] });
+
+    const result = await insertSyntheticFileMetadata(fake.sql, captionsArgs);
+
+    expect(result).toBeNull();
+    const patch = fake.statements.find((s) =>
+      s.text.startsWith('UPDATE app.video_link_jobs SET'),
+    );
+    // The patch is a CAS: `completed` lands only over `indexing`.
+    expect(patch?.values).toContain('completed');
+    expect(patch?.values).toContain('indexing');
+    expect(fake.statements.map((s) => s.text)).toContain('ROLLBACK');
+    expect(fake.statements.map((s) => s.text)).not.toContain('COMMIT');
+    expect(deleteOrgBlobRefs).toHaveBeenCalledWith(fake.sql, 'org-1', [
+      's3:acme/transcript-1',
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("left 'indexing' before its finalizer landed"),
+    );
+  });
+
+  it('lands the file row, the RAG job and the completed patch in one committed transaction', async () => {
+    const fake = fakeJobs({ jobs: [jobRow({})], updates: [[{ id: 'job-1' }]] });
+
+    const result = await insertSyntheticFileMetadata(fake.sql, captionsArgs);
+
+    expect(result).toBe('fm-1');
+    expect(fake.statements.map((s) => s.text)).toContain('COMMIT');
+    expect(markRagQueued).toHaveBeenCalledWith(expect.anything(), 'fm-1');
+    expect(addJobInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      'rag.index_file',
+      {
+        fileId: 'fm-1',
+      },
+    );
+    expect(deleteOrgBlobRefs).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing for a job that already left indexing before it started', async () => {
+    const fake = fakeJobs({
+      jobs: [jobRow({ status: 'skipped' })],
+      updates: [],
+    });
+
+    const result = await insertSyntheticFileMetadata(fake.sql, captionsArgs);
+
+    expect(result).toBeNull();
+    expect(
+      fake.statements.some((s) =>
+        s.text.startsWith('INSERT INTO app.file_metadata'),
+      ),
+    ).toBe(false);
+    expect(deleteOrgBlobRefs).toHaveBeenCalledWith(fake.sql, 'org-1', [
+      's3:acme/transcript-1',
+    ]);
+  });
+});
+
+describe('finalizeClonedTranscript', () => {
+  it('rolls back and reaps the blob on a lost CAS inside the transaction', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fake = fakeJobs({ jobs: [jobRow({})], updates: [[]] });
+
+    const result = await finalizeClonedTranscript(fake.sql, {
+      jobId: 'job-1',
+      storageId: 's3:acme/clone-1',
+      organizationId: 'org-1',
+      transcript: 'donor text',
+      fileName: 'donor.txt',
+      fileSize: 10,
+    });
+
+    expect(result).toBeNull();
+    expect(fake.statements.map((s) => s.text)).toContain('ROLLBACK');
+    expect(deleteOrgBlobRefs).toHaveBeenCalledWith(fake.sql, 'org-1', [
+      's3:acme/clone-1',
+    ]);
+  });
+});
+
+describe('cancelVideoLink', () => {
+  const cancelArgs = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    jobId: 'job-1',
+  };
+
+  it('leaves a job alone that completed while the cancel was in flight', async () => {
+    const fake = fakeJobs({
+      // Seen `indexing`; by the time the CAS runs the finalizer settled it.
+      jobs: [
+        jobRow({}),
+        jobRow({ status: 'completed', storageRef: 's3:acme/t' }),
+      ],
+      updates: [[]],
+    });
+
+    await cancelVideoLink(fake.sql, cancelArgs);
+
+    const patches = fake.statements.filter((s) =>
+      s.text.startsWith('UPDATE app.video_link_jobs SET'),
+    );
+    expect(patches).toHaveLength(1);
+    expect(patches[0]?.values).toContain('skipped');
+    expect(patches[0]?.values).toContain('indexing');
+    expect(deleteOrgBlobRefs).not.toHaveBeenCalled();
+    expect(
+      fake.statements.some((s) =>
+        s.text.startsWith('DELETE FROM app.file_metadata'),
+      ),
+    ).toBe(false);
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('cancels a job that merely advanced, in the state it advanced to', async () => {
+    const fake = fakeJobs({
+      jobs: [
+        jobRow({ status: 'fetching_captions' }),
+        jobRow({ status: 'indexing' }),
+        // The cleanup's own read after the cancel landed.
+        jobRow({ status: 'skipped' }),
+      ],
+      updates: [[], [{ id: 'job-1' }]],
+    });
+
+    await cancelVideoLink(fake.sql, cancelArgs);
+
+    const patches = fake.statements.filter((s) =>
+      s.text.startsWith('UPDATE app.video_link_jobs SET'),
+    );
+    expect(patches).toHaveLength(2);
+    expect(patches[0]?.values).toContain('fetching_captions');
+    expect(patches[1]?.values).toContain('indexing');
+    expect(createAuditLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/backend/domains/video_links/service.ts
+++ b/services/platform/backend/domains/video_links/service.ts
@@ -72,6 +72,10 @@ const NON_TERMINAL_STATUSES = [
   'indexing',
 ] as const;
 
+function isNonTerminalStatus(status: string): boolean {
+  return (NON_TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
 /** FNV-1a double-pass, hex — the 0.4 dedup key (stable, non-crypto). */
 export function hashUrlForDedup(normalized: string): string {
   const fnv = (seed: number, str: string): number => {
@@ -239,10 +243,67 @@ export async function cleanupCancelledVideoLink(
 }
 
 /**
+ * Thrown inside a finalizer transaction when the job is no longer where the
+ * finalizer left it (`indexing`): a cancel, a watchdog flip or a retry moved
+ * it while the transcript was being stored. The throw rolls the file row and
+ * the RAG job back with it — nothing may outlive the state that changed.
+ */
+class FinalizerStateLostError extends Error {
+  constructor(jobId: string, outcome: UpdateJobResult) {
+    super(
+      `[video_links] job ${jobId} left 'indexing' before its finalizer landed (${outcome})`,
+    );
+    this.name = 'FinalizerStateLostError';
+  }
+}
+
+/**
+ * Both finalizers' terminal step: the synthetic file row + RAG enqueue
+ * (`insertRow`) and the job's `indexing → completed` patch ride ONE
+ * transaction, and the patch is a CAS on `indexing`. Without it a cancel
+ * landing during the seconds-wide transcript store (its `skipped` write and
+ * blob delete already done) was overwritten `completed`: the chip came back
+ * Ready over a file row whose bytes were just deleted, and its RAG index
+ * then failed. A lost CAS rolls everything back and reaps the orphan blob;
+ * the caller's `null` means "nothing landed", exactly as a vanished job.
+ */
+async function finalizeVideoLinkFile(
+  sql: Sql,
+  args: { jobId: string; storageId: string; organizationId: string },
+  insertRow: (tx: TransactionSql) => Promise<string>,
+): Promise<string | null> {
+  try {
+    return await sql.begin(async (tx) => {
+      const fileMetadataId = await insertRow(tx);
+      await markRagQueued(tx, fileMetadataId);
+      await addJobInTx(tx, 'rag.index_file', { fileId: fileMetadataId });
+      const patched = await updateJob(tx, {
+        jobId: args.jobId,
+        fileMetadataId,
+        storageRef: args.storageId,
+        status: 'completed',
+        expectedStatus: 'indexing',
+        progress: null,
+      });
+      if (patched !== 'ok') {
+        throw new FinalizerStateLostError(args.jobId, patched);
+      }
+      return fileMetadataId;
+    });
+  } catch (error) {
+    if (!(error instanceof FinalizerStateLostError)) throw error;
+    console.warn(error.message);
+    await deleteOrgBlobRefs(sql, args.organizationId, [args.storageId]);
+    return null;
+  }
+}
+
+/**
  * The captions-branch finalizer (the 0.4 `insertSyntheticFileMetadata`):
  * provenance header + synthetic transcript row (source `video_link`,
  * dual RAG statuses) + RAG enqueue + terminal job patch. Bails (and reaps
- * the orphan blob) when the job row vanished mid-flight.
+ * the orphan blob) when the job row vanished or left `indexing` mid-flight
+ * — the terminal patch is CAS'd, so a cancel is never undone.
  */
 export async function insertSyntheticFileMetadata(
   sql: Sql,
@@ -264,7 +325,7 @@ export async function insertSyntheticFileMetadata(
   },
 ): Promise<string | null> {
   const job = await getJob(sql, args.jobId);
-  if (!job) {
+  if (!job || job.status !== 'indexing') {
     await deleteOrgBlobRefs(sql, args.organizationId, [args.storageId]);
     return null;
   }
@@ -280,7 +341,7 @@ export async function insertSyntheticFileMetadata(
     .join('\n');
   const transcriptWithHeader = `${provenanceHeader}\n\n${args.transcript}`;
 
-  return sql.begin(async (tx) => {
+  return finalizeVideoLinkFile(sql, args, async (tx) => {
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.file_metadata (
         org_id, storage_ref, source, file_name, content_type, size,
@@ -298,22 +359,14 @@ export async function insertSyntheticFileMetadata(
     `;
     const fileMetadataId = inserted[0]?.id;
     if (!fileMetadataId) throw new Error('synthetic file insert failed');
-    await markRagQueued(tx, fileMetadataId);
-    await addJobInTx(tx, 'rag.index_file', { fileId: fileMetadataId });
-    await updateJob(tx, {
-      jobId: args.jobId,
-      fileMetadataId,
-      storageRef: args.storageId,
-      status: 'completed',
-      progress: null,
-    });
     return fileMetadataId;
   });
 }
 
 /** The donor-clone finalizer (the 0.4 twin): transcript stored VERBATIM
  * (the donor text already carries its provenance header), CAS on
- * status='indexing' — a raced cancel reaps the blob and writes nothing. */
+ * status='indexing' inside the transaction — a raced cancel reaps the blob
+ * and writes nothing. */
 export async function finalizeClonedTranscript(
   sql: Sql,
   args: {
@@ -331,7 +384,7 @@ export async function finalizeClonedTranscript(
     await deleteOrgBlobRefs(sql, args.organizationId, [args.storageId]);
     return null;
   }
-  return sql.begin(async (tx) => {
+  return finalizeVideoLinkFile(sql, args, async (tx) => {
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.file_metadata (
         org_id, storage_ref, source, file_name, content_type, size,
@@ -350,15 +403,6 @@ export async function finalizeClonedTranscript(
     `;
     const fileMetadataId = inserted[0]?.id;
     if (!fileMetadataId) throw new Error('clone file insert failed');
-    await markRagQueued(tx, fileMetadataId);
-    await addJobInTx(tx, 'rag.index_file', { fileId: fileMetadataId });
-    await updateJob(tx, {
-      jobId: args.jobId,
-      fileMetadataId,
-      storageRef: args.storageId,
-      status: 'completed',
-      progress: null,
-    });
     return fileMetadataId;
   });
 }
@@ -1193,11 +1237,30 @@ export async function cancelVideoLink(
   }
   if (job.status === 'skipped') return;
 
-  await updateJob(sql, { jobId: args.jobId, status: 'skipped' });
+  // The cancel is a CAS on the state the user saw. The finalizers settle a
+  // job `indexing → completed` in one transaction; a cancel that landed on
+  // that completed row afterwards would take its blob with it (the cleanup
+  // keeps a completed file row) and leave a Ready chip over deleted bytes.
+  // A job that merely ADVANCED (still in flight) is cancelled in its new
+  // state; a job that SETTLED on its own is left as it settled.
+  let cancelled = job;
+  for (;;) {
+    const flipped = await updateJob(sql, {
+      jobId: args.jobId,
+      status: 'skipped',
+      expectedStatus: cancelled.status,
+    });
+    if (flipped === 'ok') break;
+    if (flipped === 'not_found') return;
+    const current = await getJob(sql, args.jobId);
+    if (!current || current.status === 'skipped') return;
+    if (!isNonTerminalStatus(current.status)) return;
+    cancelled = current;
+  }
   if (
-    job.fileMetadataId !== null &&
-    job.storageRef !== null &&
-    job.status === 'transcribing_handoff'
+    cancelled.fileMetadataId !== null &&
+    cancelled.storageRef !== null &&
+    cancelled.status === 'transcribing_handoff'
   ) {
     // Only an in-flight transcription is skipped along; a SETTLED file row
     // keeps its state — clobbering a completed transcript here would hand
@@ -1205,7 +1268,7 @@ export async function cancelVideoLink(
     // donor contract at findReusableTranscriptDonor: cancel keeps the row).
     await sql`
       UPDATE app.file_metadata SET transcription_status = 'skipped'
-      WHERE storage_ref = ${job.storageRef}
+      WHERE storage_ref = ${cancelled.storageRef}
         AND transcription_status IN ('queued', 'running')
     `;
   }

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -35735,10 +35735,20 @@ async function checkTwoFactor(
   // port kept only the failure half, so an attacker who registered their own
   // passkey and turned TOTP off left no trace at all. Action names are 0.4's
   // verbatim — a rename would break any saved query grouping on them.
+  // Better Auth's two-factor plugin deletes the CALLING session on enable
+  // and on disable (its own anti-hijack rule), so these calls ride a
+  // throwaway session of their own — on the shared harness cookie they took
+  // every later cookie-based probe down with them.
+  const lifecycleCookie =
+    ((await signIn()).headers.get('set-cookie') ?? '').split(';')[0] ?? '';
   const authPost = (route: string, body: unknown): Promise<Response> =>
     fetch(`${base}/api/auth${route}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', cookie, origin: base },
+      headers: {
+        'content-type': 'application/json',
+        cookie: lifecycleCookie,
+        origin: base,
+      },
       body: JSON.stringify(body),
     });
   const lifecycleActions = async (): Promise<string[]> => {
@@ -36709,6 +36719,651 @@ async function checkBackfillRecovery(
  * while a live one stays; a stale chat generation clears with its thread
  * settled idle and its pending placeholder failed.
  */
+/**
+ * Abandoned presigned uploads (files/upload-intents): a key minted and PUT to
+ * but never bound had no file row for the row-driven sweeps, so its bytes
+ * leaked forever while the mint path dropped the expired ROW. The sweep
+ * reclaims the abandoned blob with its row and leaves alone a blob a file row
+ * carries or a non-consuming proof vouched for (`bound_at_ms`) — on both
+ * ledgers (session + REST). Gated on ITEST_S3_ENDPOINT.
+ */
+async function checkAbandonedUploadReclaim(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'abandoned upload reclaim (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — S3 lanes not exercised in this run',
+    );
+    return;
+  }
+  const { orgId, userId } = ctx;
+  const slugRows = await sql<{ slug: string }[]>`
+    SELECT "slug" FROM "organization" WHERE "id" = ${orgId} LIMIT 1
+  `;
+  const orgSlug = slugRows[0]?.slug ?? '';
+  const storage = await import('./lib/object-store.ts');
+  const { encodeS3Ref } = await import('./core/lib/storage/blob_ref.ts');
+  // Optional-typed so the pre-fix tree (no such export) records a failure
+  // instead of crashing the suite.
+  const intents = (await import('./domains/files/upload-intents.ts')) as {
+    sweepUploadIntents?: (
+      db: Sql,
+      args: {
+        organizationId: string;
+        ledger?: 'app.upload_intents' | 'app.rest_upload_intents';
+      },
+    ) => Promise<{ reclaimed: number }>;
+  };
+  const store = await storage.resolveObjectStore(orgSlug);
+  const mint = async (label: string): Promise<{ key: string; ref: string }> => {
+    const key = storage.buildObjectKey(store, orgSlug);
+    await storage.s3PutObject(
+      store,
+      key,
+      new TextEncoder().encode(`abandoned-upload probe: ${label}`),
+      'text/plain',
+    );
+    return { key, ref: encodeS3Ref(key) };
+  };
+  const abandoned = await mint('abandoned');
+  const bound = await mint('bound');
+  const vouched = await mint('vouched');
+  const restAbandoned = await mint('rest-abandoned');
+  // Expired well past the intent TTL (2h) plus the reclaim grace (24h).
+  const expired = Date.now() - 27 * 3_600_000;
+  let setup = 'ok';
+  try {
+    await sql`
+      INSERT INTO app.upload_intents (
+        org_id, user_id, purpose, s3_ref, expires_at_ms, created_at_ms
+      ) VALUES
+        (${orgId}, ${userId}, 'file', ${abandoned.ref}, ${expired}, ${expired - 7_200_000}),
+        (${orgId}, ${userId}, 'file', ${bound.ref}, ${expired}, ${expired - 7_200_000}),
+        (${orgId}, ${userId}, 'file', ${vouched.ref}, ${expired}, ${expired - 7_200_000})
+    `;
+    await sql`
+      UPDATE app.upload_intents SET bound_at_ms = ${expired - 60_000}
+      WHERE s3_ref = ${vouched.ref}
+    `;
+    await sql`
+      INSERT INTO app.file_metadata (
+        org_id, storage_ref, file_name, content_type, size, uploaded_by,
+        created_at_ms
+      ) VALUES (
+        ${orgId}, ${bound.ref}, 'bound.txt', 'text/plain', 32, ${userId},
+        ${Date.now()}
+      )
+    `;
+    await sql`
+      INSERT INTO app.rest_upload_intents (
+        id, org_id, user_id, project_id, s3_ref, expires_at_ms, created_at_ms
+      ) VALUES (
+        ${randomUUID()}, ${orgId}, ${userId}, 'itest-project',
+        ${restAbandoned.ref}, ${expired}, ${expired - 1_800_000}
+      )
+    `;
+  } catch (error) {
+    setup = error instanceof Error ? error.message : String(error);
+  }
+  let reclaimed = -1;
+  let restReclaimed = -1;
+  if (setup === 'ok' && intents.sweepUploadIntents !== undefined) {
+    reclaimed = (
+      await intents.sweepUploadIntents(sql, { organizationId: orgId })
+    ).reclaimed;
+    restReclaimed = (
+      await intents.sweepUploadIntents(sql, {
+        organizationId: orgId,
+        ledger: 'app.rest_upload_intents',
+      })
+    ).reclaimed;
+  }
+  const present = async (key: string): Promise<boolean> =>
+    (await storage.s3HeadObject(store, key)) !== null;
+  const abandonedGone = !(await present(abandoned.key));
+  const boundKept = await present(bound.key);
+  const vouchedKept = await present(vouched.key);
+  const restGone = !(await present(restAbandoned.key));
+  const rowsLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.upload_intents
+    WHERE s3_ref IN (${abandoned.ref}, ${bound.ref}, ${vouched.ref})
+  `;
+  const restRowsLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.rest_upload_intents
+    WHERE s3_ref = ${restAbandoned.ref}
+  `;
+  record(
+    'abandoned presigned uploads are reclaimed; bound and vouched-for blobs survive',
+    setup === 'ok' &&
+      reclaimed === 1 &&
+      restReclaimed === 1 &&
+      abandonedGone &&
+      boundKept &&
+      vouchedKept &&
+      restGone &&
+      rowsLeft[0]?.count === '0' &&
+      restRowsLeft[0]?.count === '0',
+    `setup=${setup}, reclaimed=${reclaimed}/${restReclaimed} (want 1/1), abandonedGone=${abandonedGone}, boundKept=${boundKept}, vouchedKept=${vouchedKept}, restGone=${restGone}, intentRowsLeft=${rowsLeft[0]?.count ?? '?'}/${restRowsLeft[0]?.count ?? '?'} (want 0/0)`,
+  );
+  // Leave no probe bytes behind.
+  for (const key of [
+    abandoned.key,
+    bound.key,
+    vouched.key,
+    restAbandoned.key,
+  ]) {
+    await storage
+      .s3DeleteObject(store, key)
+      .catch((error: unknown) =>
+        console.warn('[itest] probe blob cleanup failed:', error),
+      );
+  }
+  await sql`
+    DELETE FROM app.file_metadata
+    WHERE org_id = ${orgId} AND storage_ref = ${bound.ref}
+  `;
+}
+
+/**
+ * Captions finalizer (video_links): the terminal `completed` patch is a CAS
+ * on `indexing` inside the finalizer's transaction. A cancel that landed
+ * while the transcript was being stored stays a cancel — no file row, no
+ * resurrected chip, and the orphan transcript blob is reaped — while a live
+ * job completes normally over its blob. Gated on ITEST_S3_ENDPOINT (the
+ * transcript bytes are real blobs, so the reap is observable).
+ */
+async function checkVideoFinalizerCas(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'video finalizer CAS (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — S3 lanes not exercised in this run',
+    );
+    return;
+  }
+  const { orgId, userId } = ctx;
+  const video = await import('./domains/video_links/service.ts');
+  const files = await import('./domains/files/service.ts');
+  const storage = await import('./lib/object-store.ts');
+  const { parseBlobRef } = await import('./core/lib/storage/blob_ref.ts');
+  const slugRows = await sql<{ slug: string }[]>`
+    SELECT "slug" FROM "organization" WHERE "id" = ${orgId} LIMIT 1
+  `;
+  const store = await storage.resolveObjectStore(slugRows[0]?.slug ?? '');
+  const now = Date.now();
+  const insertJob = async (hash: string, status: string): Promise<string> => {
+    const rows = await sql<{ id: string }[]>`
+      INSERT INTO app.video_link_jobs (
+        org_id, source_url, source_url_hash, source_platform, pasted_token,
+        status, status_changed_at_ms, uploaded_by, created_at_ms
+      ) VALUES (
+        ${orgId}, ${`https://example.test/${hash}`}, ${hash}, 'youtube',
+        ${hash}, ${status}, ${now}, ${userId}, ${now}
+      ) RETURNING id
+    `;
+    return rows[0]?.id ?? '';
+  };
+  const transcript = 'finalizer probe transcript';
+  const storeTranscript = (): Promise<string> =>
+    files.putOrgBlobBytes(sql, orgId, {
+      bytes: new TextEncoder().encode(transcript),
+      contentType: 'text/plain; charset=utf-8',
+    });
+  const cancelledId = await insertJob(`itest-fin-cancelled-${now}`, 'skipped');
+  const liveId = await insertJob(`itest-fin-live-${now}`, 'indexing');
+  const cancelledBlob = await storeTranscript();
+  const liveBlob = await storeTranscript();
+  const finalize = (jobId: string, storageId: string): Promise<string | null> =>
+    video.insertSyntheticFileMetadata(sql, {
+      jobId,
+      storageId,
+      transcript,
+      fileSize: transcript.length,
+      videoTitle: 'Finalizer probe',
+      videoDurationSec: 30,
+      sourceUrl: 'https://example.test/finalizer',
+      sourcePlatform: 'youtube',
+      transcriptSource: 'captions_auto',
+      organizationId: orgId,
+      uploadedBy: userId,
+    });
+  const overCancel = await finalize(cancelledId, cancelledBlob);
+  const overLive = await finalize(liveId, liveBlob);
+  const jobs = await sql<
+    { id: string; status: string; fileMetadataId: string | null }[]
+  >`
+    SELECT id, status, file_metadata_id AS "fileMetadataId"
+    FROM app.video_link_jobs
+    WHERE id IN (${cancelledId}, ${liveId})
+  `;
+  const cancelledRow = jobs.find((row) => row.id === cancelledId);
+  const liveRow = jobs.find((row) => row.id === liveId);
+  const strayRows = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.file_metadata
+    WHERE org_id = ${orgId} AND storage_ref = ${cancelledBlob}
+  `;
+  const blobPresent = async (ref: string): Promise<boolean> => {
+    const parsed = parseBlobRef(ref);
+    return (
+      parsed.backend === 's3' &&
+      (await storage.s3HeadObject(store, parsed.key)) !== null
+    );
+  };
+  const cancelledBlobReaped = !(await blobPresent(cancelledBlob));
+  const liveBlobKept = await blobPresent(liveBlob);
+  record(
+    'video finalizer: a cancel is never overwritten with completed; a live job completes',
+    overCancel === null &&
+      cancelledRow?.status === 'skipped' &&
+      cancelledRow.fileMetadataId === null &&
+      strayRows[0]?.count === '0' &&
+      cancelledBlobReaped &&
+      overLive !== null &&
+      liveRow?.status === 'completed' &&
+      liveRow.fileMetadataId === overLive &&
+      liveBlobKept,
+    `overCancel=${overCancel === null ? 'null' : 'file row'} (want null), cancelled=${cancelledRow?.status}/${cancelledRow?.fileMetadataId ?? 'null'} (want skipped/null), strayFileRows=${strayRows[0]?.count ?? '?'} (want 0), cancelledBlobReaped=${cancelledBlobReaped}, live=${liveRow?.status} (want completed), liveFileBound=${liveRow?.fileMetadataId === overLive}, liveBlobKept=${liveBlobKept}`,
+  );
+}
+
+/**
+ * Approvals gate: concurrent evaluations of ONE operation share one pending
+ * card — the insert is a claim against the partial unique index (0074), and
+ * the loser answers with the winner's record.
+ */
+async function checkApprovalGateSingleClaim(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const gate = await import('./domains/approvals/gate.ts');
+  const resourceKey = `itest-gate-race-${randomUUID()}`;
+  const evaluate = (): ReturnType<typeof gate.evaluateApprovalGate> =>
+    gate.evaluateApprovalGate(sql, {
+      organizationId: orgId,
+      source: 'connector',
+      resourceKey,
+      connector: 'imap-smtp',
+      action: 'send',
+      effect: 'write',
+      requestedBy: userId,
+    });
+  const settled = await Promise.allSettled([
+    evaluate(),
+    evaluate(),
+    evaluate(),
+    evaluate(),
+  ]);
+  const decisions = settled.flatMap((outcome) =>
+    outcome.status === 'fulfilled' ? [outcome.value] : [],
+  );
+  const approvalIds = new Set(
+    decisions.map((decision) =>
+      'approvalId' in decision ? decision.approvalId : 'none',
+    ),
+  );
+  const pending = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.approvals
+    WHERE org_id = ${orgId} AND resource_type = 'connector_operation'
+      AND resource_id = ${resourceKey} AND status = 'pending'
+  `;
+  const indexRows = await sql<{ indexname: string }[]>`
+    SELECT indexname FROM pg_indexes
+    WHERE schemaname = 'app'
+      AND indexname = 'approvals_one_pending_connector_operation'
+  `;
+  record(
+    'approval gate: concurrent evaluations of one operation share one pending card',
+    settled.every((outcome) => outcome.status === 'fulfilled') &&
+      decisions.every((decision) => decision.decision === 'needs-approval') &&
+      approvalIds.size === 1 &&
+      pending[0]?.count === '1' &&
+      indexRows.length === 1,
+    `fulfilled=${decisions.length}/4, distinctCards=${approvalIds.size} (want 1), pendingRows=${pending[0]?.count ?? '?'} (want 1), uniqueIndex=${indexRows.length === 1}`,
+  );
+}
+
+/**
+ * Agent document upsert: concurrent runs writing the same key converge on
+ * ONE row — the key is unique in the schema (0073), the insert is
+ * ON CONFLICT DO NOTHING, and a run that loses the race refreshes the
+ * winner's row.
+ */
+async function checkAgentUpsertConvergence(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const { upsertAgentDocument } =
+    await import('./domains/documents/agent-write.ts');
+  const key = `itest:agent-race:${randomUUID()}`;
+  const write = (attempt: number): ReturnType<typeof upsertAgentDocument> =>
+    upsertAgentDocument(sql, {
+      organizationId: orgId,
+      externalItemId: key,
+      title: 'race-report.md',
+      fileRef: `s3:itest/agent-race-${attempt}`,
+      mimeType: 'text/markdown',
+      createdBy: userId,
+    });
+  const settled = await Promise.allSettled([
+    write(1),
+    write(2),
+    write(3),
+    write(4),
+  ]);
+  const writes = settled.flatMap((outcome) =>
+    outcome.status === 'fulfilled' ? [outcome.value] : [],
+  );
+  const documentIds = new Set(writes.map((result) => result.documentId));
+  const created = writes.filter((result) => result.action === 'created').length;
+  const rows = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.documents
+    WHERE org_id = ${orgId} AND external_item_id = ${key}
+  `;
+  const indexRows = await sql<{ indexname: string }[]>`
+    SELECT indexname FROM pg_indexes
+    WHERE schemaname = 'app' AND indexname = 'documents_org_external_unique'
+  `;
+  record(
+    'agent document upsert: concurrent runs converge on one row',
+    settled.every((outcome) => outcome.status === 'fulfilled') &&
+      documentIds.size === 1 &&
+      created === 1 &&
+      rows[0]?.count === '1' &&
+      indexRows.length === 1,
+    `fulfilled=${writes.length}/4, distinctRows=${documentIds.size} (want 1), created=${created} (want 1), rows=${rows[0]?.count ?? '?'} (want 1), uniqueIndex=${indexRows.length === 1}`,
+  );
+  await sql`
+    DELETE FROM app.documents
+    WHERE org_id = ${orgId} AND external_item_id = ${key}
+  `;
+}
+
+/**
+ * Project-text panel file: one key is one document — concurrent saves
+ * converge, and a TRASHED twin comes back in place instead of parking a
+ * duplicate under the same key. Gated on ITEST_S3_ENDPOINT (the lane stores
+ * the file bytes).
+ */
+async function checkProjectTextConvergence(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string },
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'project-text convergence (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — document lanes not exercised in this run',
+    );
+    return;
+  }
+  const { cookie, orgId } = ctx;
+  const post = (route: string, body: unknown): Promise<Response> =>
+    fetch(`${base}${route}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: JSON.stringify(body),
+    });
+  const project = z.object({ projectId: z.string() }).safeParse(
+    await (
+      await post(`/api/app/projects?orgId=${orgId}`, {
+        name: 'Project text convergence',
+      })
+    ).json(),
+  );
+  const projectId = project.success ? project.data.projectId : '';
+  const write = (content: string): Promise<Response> =>
+    post(`/api/app/documents/project-text?orgId=${orgId}`, {
+      projectId,
+      folderName: 'Settings',
+      fileName: 'panel.yml',
+      content,
+    });
+  const shape = z.object({ documentId: z.string(), action: z.string() });
+  const concurrent = await Promise.all([
+    write('a: 1'),
+    write('a: 2'),
+    write('a: 3'),
+  ]);
+  const parsed = await Promise.all(
+    concurrent.map(async (response) => shape.safeParse(await response.json())),
+  );
+  const documentIds = new Set(
+    parsed.flatMap((result) =>
+      result.success ? [result.data.documentId] : [],
+    ),
+  );
+  const rowsAfterRace = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.documents
+    WHERE org_id = ${orgId} AND project_id = ${projectId} AND title = 'panel.yml'
+  `;
+  const documentId = [...documentIds][0] ?? '';
+  await sql`
+    UPDATE app.documents SET
+      lifecycle_status = 'trashed', status_changed_at_ms = ${Date.now()}
+    WHERE id = ${documentId}
+  `;
+  const rewritten = shape.safeParse(await (await write('a: 4')).json());
+  const after = await sql<{ id: string; lifecycleStatus: string | null }[]>`
+    SELECT id, lifecycle_status AS "lifecycleStatus" FROM app.documents
+    WHERE org_id = ${orgId} AND project_id = ${projectId} AND title = 'panel.yml'
+  `;
+  record(
+    'project-text file: concurrent saves converge on one document; a trashed twin comes back in place',
+    concurrent.every((response) => response.status === 200) &&
+      documentIds.size === 1 &&
+      rowsAfterRace[0]?.count === '1' &&
+      rewritten.success &&
+      rewritten.data.documentId === documentId &&
+      after.length === 1 &&
+      after[0]?.lifecycleStatus === null,
+    `saves=${concurrent.map((response) => response.status).join('/')}, distinctDocs=${documentIds.size} (want 1), rowsAfterRace=${rowsAfterRace[0]?.count ?? '?'} (want 1), rewrite=${rewritten.success ? rewritten.data.action : 'ERR'} sameDoc=${rewritten.success && rewritten.data.documentId === documentId}, rowsAfterRewrite=${after.length} (want 1), lifecycle=${after[0]?.lifecycleStatus ?? 'null'} (want null)`,
+  );
+}
+
+/**
+ * Crawl registry: registration and removal of one domain are serialized on
+ * the domain row. A removal racing a new member's registration used to run
+ * its "last member?" check between the registration's two writes — the
+ * fresh domain row was deleted under it (cascading urls and chunks) and the
+ * membership insert failed on the foreign key. Both orders now end in the
+ * same state: the row stands with exactly the surviving member.
+ */
+async function checkCrawlRegistrationSerialization(): Promise<void> {
+  const crawl = await import('./core/knowledge/crawl.ts');
+  const corpus = await import('./core/knowledge/pool.ts');
+  const pool = corpus.getKnowledgePool();
+  const domain = `itest-race-${randomUUID().slice(0, 8)}.example`;
+  const members = async (): Promise<string[]> =>
+    (
+      await pool<{ orgSlug: string }[]>`
+        SELECT org_slug AS "orgSlug" FROM public_web.website_org_memberships
+        WHERE domain = ${domain} ORDER BY org_slug
+      `
+    ).map((row) => row.orgSlug);
+  const rowExists = async (): Promise<boolean> =>
+    (
+      await pool<{ domain: string }[]>`
+        SELECT domain FROM public_web.websites WHERE domain = ${domain}
+      `
+    ).length === 1;
+  let rejected = 0;
+  const inconsistencies: string[] = [];
+  for (let round = 0; round < 8; round += 1) {
+    const leaving = `itest-race-org-${round % 2}`;
+    const joining = `itest-race-org-${(round + 1) % 2}`;
+    await crawl.registerDomain(pool, leaving, domain, 3600);
+    const outcomes = await Promise.allSettled([
+      crawl.deregisterDomain(pool, leaving, domain),
+      crawl.registerDomain(pool, joining, domain, 3600),
+    ]);
+    rejected += outcomes.filter(
+      (outcome) => outcome.status === 'rejected',
+    ).length;
+    const survivors = await members();
+    if (
+      !(await rowExists()) ||
+      survivors.length !== 1 ||
+      survivors[0] !== joining
+    ) {
+      inconsistencies.push(`round ${round}: [${survivors.join(',')}]`);
+    }
+    await crawl.deregisterDomain(pool, joining, domain);
+    if (await rowExists()) {
+      inconsistencies.push(`round ${round}: row outlived its last member`);
+    }
+  }
+  record(
+    'crawl registry: a removal racing a registration leaves the domain consistent',
+    rejected === 0 && inconsistencies.length === 0,
+    `rejected=${rejected} (want 0), inconsistencies=${inconsistencies.length === 0 ? 'none' : inconsistencies.join('; ')}`,
+  );
+}
+
+/**
+ * Retention: custodian-held rows never fill the purge batch. With more held
+ * trashed rows than one batch, the unheld row behind them must still purge —
+ * the custodian filter is part of the candidate query, not a skip after it.
+ */
+async function checkRetentionHeldRowsProgress(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const tag = randomUUID().slice(0, 8);
+  const heldUser = `itest-held-${tag}`;
+  const unheldUser = `itest-unheld-${tag}`;
+  const holdRows = await sql<{ id: string }[]>`
+    INSERT INTO app.legal_holds (
+      org_id, target_type, target_id, target_label, reason, placed_by,
+      placed_at_ms
+    ) VALUES (
+      ${orgId}, 'userMembership', ${heldUser}, 'itest held custodian',
+      'retention batch probe', ${userId}, ${Date.now()}
+    ) RETURNING id
+  `;
+  const stale = Date.now() - 30 * 24 * 3_600_000;
+  // One more held trashed row than the sweep's batch, then one unheld row.
+  const heldDocs = Array.from({ length: 1001 }, (_, index) => ({
+    org_id: orgId,
+    title: `held-${tag}-${index}`,
+    lifecycle_status: 'trashed',
+    status_changed_at_ms: stale,
+    created_by: heldUser,
+    created_at_ms: stale,
+    updated_at_ms: stale,
+  }));
+  await sql`INSERT INTO app.documents ${sql(heldDocs)}`;
+  const unheld = await sql<{ id: string }[]>`
+    INSERT INTO app.documents (
+      org_id, title, lifecycle_status, status_changed_at_ms, created_by,
+      created_at_ms, updated_at_ms
+    ) VALUES (
+      ${orgId}, ${`unheld-${tag}`}, 'trashed', ${stale}, ${unheldUser},
+      ${stale}, ${stale}
+    ) RETURNING id
+  `;
+  const unheldId = unheld[0]?.id ?? '';
+  const { sweepOrgPhase2 } = await import('./domains/retention/service.ts');
+  const { loadActiveHolds } = await import('./domains/legal_holds/service.ts');
+  const holds = await loadActiveHolds(sql, orgId);
+  const stats = await sweepOrgPhase2(
+    sql,
+    {
+      organizationId: orgId,
+      config: {
+        documentsEnabled: true,
+        documentsRetentionDays: 36_500,
+        deletionGraceDays: 1,
+      },
+    },
+    holds,
+  );
+  const unheldLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.documents WHERE id = ${unheldId}
+  `;
+  const heldLeft = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.documents
+    WHERE org_id = ${orgId} AND created_by = ${heldUser}
+  `;
+  record(
+    'retention: a batch of custodian-held rows does not starve the unheld rows behind it',
+    holds.userMembershipIds.has(heldUser) &&
+      !holds.orgHeld &&
+      unheldLeft[0]?.count === '0' &&
+      heldLeft[0]?.count === '1001' &&
+      stats.documents >= 1,
+    `held=${holds.userMembershipIds.has(heldUser)}, orgHeld=${holds.orgHeld}, unheldLeft=${unheldLeft[0]?.count ?? '?'} (want 0), heldLeft=${heldLeft[0]?.count ?? '?'} (want 1001), purged=${stats.documents}`,
+  );
+  await sql`
+    DELETE FROM app.documents WHERE org_id = ${orgId} AND created_by = ${heldUser}
+  `;
+  await sql`
+    UPDATE app.legal_holds SET released_at_ms = ${Date.now()}
+    WHERE id = ${holdRows[0]?.id ?? ''}
+  `;
+}
+
+/**
+ * Cloud-sync scan: every syncable config gets its job — a keyset walk over
+ * the whole table, not the first thousand. The probe rows are removed right
+ * after the scan: each enqueued per-config job then finds no row to claim
+ * and returns.
+ */
+async function checkSyncScanFairness(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const onedrive = await import('./domains/onedrive/service.ts');
+  const tag = randomUUID().slice(0, 8);
+  const now = Date.now();
+  const configs = Array.from({ length: 1001 }, (_, index) => ({
+    org_id: orgId,
+    user_id: userId,
+    item_type: 'file',
+    item_id: `itest-scan-${tag}-${index}`,
+    item_name: `scan-${index}.txt`,
+    target_bucket: 'itest',
+    status: 'active',
+    created_at_ms: now - 2000 + index,
+    updated_at_ms: now,
+  }));
+  await sql`INSERT INTO app.onedrive_sync_configs ${sql(configs)}`;
+  const syncable = await sql<{ count: string }[]>`
+    SELECT count(*)::text AS count FROM app.onedrive_sync_configs
+    WHERE status IN ('active', 'error')
+  `;
+  let enqueued = -1;
+  let failure = '';
+  try {
+    enqueued = await onedrive.runSyncScanWith(
+      sql,
+      onedrive.ONEDRIVE_SYNC_ADAPTER,
+    );
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  }
+  await sql`
+    DELETE FROM app.onedrive_sync_configs
+    WHERE org_id = ${orgId} AND item_id LIKE ${`itest-scan-${tag}-%`}
+  `;
+  const total = Number(syncable[0]?.count ?? '0');
+  record(
+    'cloud-sync scan reaches every config past the first thousand',
+    failure === '' && total >= 1001 && enqueued === total,
+    `enqueued=${enqueued} of ${total} syncable configs (want all)${failure ? ` — ${failure}` : ''}`,
+  );
+}
+
 async function checkWatchdogs(
   sql: Sql,
   base: string,
@@ -36787,8 +37442,40 @@ async function checkWatchdogs(
   `;
   const parkedId = parked[0]?.id ?? '';
 
+  // The deadline sweep must stop the exec itself, not only its ledger row:
+  // a fake spawner records the cancel the sweep sends for the overdue run.
+  const { createServer } = await import('node:http');
+  const cancels: string[] = [];
+  const spawner = createServer((req, res) => {
+    res.setHeader('content-type', 'application/json');
+    if (req.method === 'POST' && (req.url ?? '').endsWith('/cancel')) {
+      cancels.push(req.url ?? '');
+      res.end(JSON.stringify({ killed: true }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end('{}');
+  });
+  await new Promise<void>((resolve) => {
+    spawner.listen(0, '127.0.0.1', resolve);
+  });
+  const spawnerAddress = spawner.address();
+  const spawnerPort =
+    spawnerAddress !== null && typeof spawnerAddress === 'object'
+      ? spawnerAddress.port
+      : 0;
+  const previousSandboxUrl = process.env.SANDBOX_URL;
+  process.env.SANDBOX_URL = `http://127.0.0.1:${spawnerPort}`;
   const taskWatchdogs = await import('./domains/tasks/watchdogs.ts');
-  await taskWatchdogs.runTaskAgentWatchdog(sql);
+  try {
+    await taskWatchdogs.runTaskAgentWatchdog(sql);
+  } finally {
+    if (previousSandboxUrl === undefined) delete process.env.SANDBOX_URL;
+    else process.env.SANDBOX_URL = previousSandboxUrl;
+    await new Promise<void>((resolve) => {
+      spawner.close(() => resolve());
+    });
+  }
   const runsAfter = await sql<
     { id: string; status: string; error: string | null }[]
   >`
@@ -36817,6 +37504,12 @@ async function checkWatchdogs(
       opAfter[0].finalizedAt !== null &&
       slotAfter[0]?.status === 'stopped',
     `overdue=${overdueAfter?.status} parked=${parkedAfter?.status} op=${opAfter[0]?.status} slot=${slotAfter[0]?.status}`,
+  );
+  record(
+    'task-agent watchdog stops the sandbox exec of a deadline-failed run',
+    cancels.length === 1 &&
+      cancels[0] === '/v1/sessions/pa-wd-agent/exec/exec-wd-1/cancel',
+    `cancels=${cancels.length === 0 ? 'none' : cancels.join(', ')} (want exactly /v1/sessions/pa-wd-agent/exec/exec-wd-1/cancel — the parked run never launched, so no cancel for it)`,
   );
 
   // Lane 3: sandbox expiry + admission reap (reconcile skipped — no spawner
@@ -38012,6 +38705,16 @@ async function main(): Promise<void> {
     await checkLegalHolds(sql, baseUrl, authCtx);
     await checkRetention(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
     await checkErasure(sql, baseUrl, authCtx, `itest-${orgSuffix}`);
+    // Reliability batch probes (self-contained; each seeds and cleans its
+    // own rows).
+    await checkAbandonedUploadReclaim(sql, authCtx);
+    await checkCrawlRegistrationSerialization();
+    await checkVideoFinalizerCas(sql, authCtx);
+    await checkAgentUpsertConvergence(sql, authCtx);
+    await checkProjectTextConvergence(sql, baseUrl, authCtx);
+    await checkApprovalGateSingleClaim(sql, authCtx);
+    await checkRetentionHeldRowsProgress(sql, authCtx);
+    await checkSyncScanFairness(sql, authCtx);
     await checkTwoFactor(
       sql,
       baseUrl,

--- a/services/platform/backend/rest/v1-projects.ts
+++ b/services/platform/backend/rest/v1-projects.ts
@@ -14,6 +14,7 @@ import {
   getFileUrl,
   registerUpload,
 } from '../domains/files/service.ts';
+import { sweepUploadIntents } from '../domains/files/upload-intents.ts';
 import {
   getOrCreateProjectFolder,
   listFolders,
@@ -275,13 +276,13 @@ export function createProjectRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
           ${project.id}, ${handoff.storageRef}, ${expiresAt}, ${now}
         )
       `;
-      // Lazy sweep of dead handshakes (consumed, or expired a day ago).
-      await deps.sql`
-        DELETE FROM app.rest_upload_intents
-        WHERE org_id = ${c.get('organizationId')}
-          AND (consumed_at_ms IS NOT NULL
-            OR expires_at_ms < ${now - 24 * 3_600_000})
-      `;
+      // Lazy sweep of dead handshakes (consumed) and ABANDONED uploads (never
+      // bound: their blob is reclaimed with the row — the intent is the only
+      // record the bytes exist).
+      await sweepUploadIntents(deps.sql, {
+        organizationId: c.get('organizationId'),
+        ledger: 'app.rest_upload_intents',
+      });
       return c.json({
         uploadId,
         url: handoff.uploadUrl,


### PR DESCRIPTION
## Summary

Eight verified low-severity reliability defects (leaks, races, silent starvation) from the backend
deep-review triage, fixed with the invariant encoded where it belongs (schema or transaction), each
locked by a red-on-base regression test; one finding verified as already fixed.

## Per-finding outcome

| #   | Finding                                                                         | Outcome                                                                                                                                                                 | Evidence / fix                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| --- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Abandoned presigned uploads leak blobs forever                                  | **fixed**                                                                                                                                                               | `0067` intents recorded the blob but the mint-path sweep dropped only the expired _row_ (same in the REST twin). `sweepUploadIntents` (files/upload-intents.ts) now reclaims the blob of an intent that expired unconsumed and unvouched-for, then the row — on both ledgers; `ownsUploadedBlob` stamps `bound_at_ms` (`0073`) because the document multi-bind and outbound-mail-attachment lanes prove ownership _without_ consuming (an outbound attachment lives only as a `storageId` in message metadata, so "unconsumed" is not "unbound"). File-backed refs are excluded by an `EXISTS` guard; a failed delete keeps the row for the next sweep. |
| 2   | Captions finalizer can overwrite a user's cancel with `completed`               | **fixed**                                                                                                                                                               | Both finalizers run file row + RAG job + terminal patch in one tx with the patch CAS'd on `indexing` (`finalizeVideoLinkFile`); a lost CAS rolls back and reaps the blob. Mirror race closed too: `cancelVideoLink` is a CAS on the state the user saw (advances with an in-flight job, leaves a settled one alone).                                                                                                                                                                                                                                                                                                                                    |
| 3   | Deadline watchdog fails the run but leaves the sandbox exec running             | **fixed**                                                                                                                                                               | `runTaskAgentWatchdog` calls `sessionCancelExec(run.sessionId, run.execId)` (best-effort) after winning the settle and before cancelling the op row — the in-chain deadline cut's seam.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| 4   | Approval gate can mint duplicate pending rows for one operation                 | **fixed**                                                                                                                                                               | `0072`: partial unique index `(org_id, resource_type, resource_id) WHERE resource_type = 'connector_operation' AND status = 'pending'` (existing dup pendings closed the review lane's way: `rejected` + `metadata.supersededBy`); the gate inserts `ON CONFLICT … DO NOTHING` and the loser re-reads the winner's record.                                                                                                                                                                                                                                                                                                                              |
| 5   | Sync scan silently starves configs beyond the first 1000                        | **fixed**                                                                                                                                                               | `runSyncScanWith` (OneDrive + Google Drive) is a keyset walk in id order (the `#3167` trigger-scanner idiom), `pageSize` option for tests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| 6   | `deregisterDomain` races concurrent registration without a transaction          | **fixed**                                                                                                                                                               | `registerDomain`, `registerUrlList`, `deregisterDomain` each run as one transaction; removal takes the `websites` row `FOR UPDATE` first, so the "last member?" check can never run between a registration's two writes.                                                                                                                                                                                                                                                                                                                                                                                                                                |
| 7   | Agent upsert idempotency lacks a unique index — concurrent runs fork duplicates | **fixed**                                                                                                                                                               | `0071`: partial unique `(org_id, external_item_id) WHERE external_item_id IS NOT NULL` (existing newer duplicates detached from the key, old key kept in `metadata.dedupedExternalItemId`; the redundant plain index dropped). `upsertAgentDocument`, `ensureProjectTextDocument` and the sync engine's `createDocument` insert `ON CONFLICT … DO NOTHING` and refresh the winner's row on a lost race; project-text now brings a trashed twin back in place instead of parking a duplicate key.                                                                                                                                                        |
| 8   | Custodian-held rows can starve document/chat purge batches forever              | **fixed**                                                                                                                                                               | The custodian filter is part of the candidate SQL on every pass (documents A/B, chat A/B); pass A also gained the `created_by IS NULL` arm (`NULL <> ALL(...)` is NULL, so creator-less synced documents never expired under any hold).                                                                                                                                                                                                                                                                                                                                                                                                                 |
| 9   | Per-user bell writes emit org-wide realtime hints                               | **already fixed** by `#3164` (`0f5f024da`): every write routes through `emitBellHint`, which passes `userId`; the outbox narrows on `user_id IS NULL OR user_id = $me`. |

## Tests

Unit (vitest `server`, 8 files / 30 tests — **21 red on the base tree**, every file red):
watchdogs, onedrive scan, crawl tx shape, gate claim, agent-write claim, retention SQL filter,
upload-intent stamp + sweep, video finalizer CAS + cancel CAS.

Integration (`backend/integration-check.ts`), 9 probes — abandoned upload reclaimed while bound and
vouched-for blobs survive (both ledgers, real MinIO); crawl removal racing registration ×8 rounds;
finalizer never overwrites a cancel + reaps the orphan blob; concurrent gate evaluations share one
card; concurrent agent upserts converge on one row; project-text concurrent saves + trashed twin
comes back; 1001 held trashed docs do not starve the unheld one; 1001 sync configs all enqueued;
deadline watchdog cancels the exec (fake spawner records the call).

## Verification

- platform `tsc --noEmit`: 0 errors; `oxlint --type-aware` on touched files: clean
- `backend:integration` (throwaway tale-db + MinIO, fresh per run): branch **392/394**,
  base + probes **383/394** (the 11 base failures = the 9 new probes + the same 2 pre-existing failures the branch shows: `blob-ref authority` compose and `outbound send lane`, byte-identical on both trees)

## Cross-class discoveries (not in this batch)

- The harness's 2FA lifecycle probe (`#3187`) enabled/disabled 2FA on the shared harness cookie;
  Better Auth's two-factor plugin deletes the _calling_ session on both, so every later cookie-based
  probe failed (`ERR`, `401`) and `checkAutomations` died on a `404 Not Found` body — on `main` too.
  Fixed here in the harness (throwaway session for those calls).
- `blob-ref authority: outbound mail attaches only the sender's uploads` answers `403 FORBIDDEN`
  instead of `403 attachment_not_owned` on `main` as well — the conversation write gate from `#3187`
  now refuses before the ownership check; the probe's expectation needs a decision.
- A retry racing a finalizer at `indexing` (both at the same status) is not distinguished by the
  status CAS alone; a `storage_ref` guard would close it (the clone lane has no prior patch to key on).
