### PR TITLE
fix(platform): deny a corpus ref bound to neither document nor thread

### DIFF
--- a/services/platform/backend/domains/knowledge/retrievable.test.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.test.ts
@@ -90,8 +90,42 @@ describe('decideRetrievable', () => {
     ).toBe(false);
   });
 
-  it('keeps the same-org posture for live document-less rows (video-link lane)', () => {
-    expect(decideRetrievable([], [unboundFile()], { teamIds: [] })).toBe(true);
+  it('denies a live row bound to neither a document nor a thread', () => {
+    // This replaces an assertion that admitted the same shape same-org. The
+    // corpus stamps no project and no team for a row with no document, and
+    // the SQL half reads that as org-wide — so admitting it here served one
+    // member's file to the whole organization. 0.4 denied it too.
+    expect(decideRetrievable([], [unboundFile()], { teamIds: [] })).toBe(false);
+  });
+
+  it('denies it with no access scope either', () => {
+    // `access === undefined` is the internal-caller path; it must not become
+    // a way around the rule above.
+    expect(decideRetrievable([], [unboundFile()], undefined)).toBe(false);
+  });
+
+  it('still admits the video-link lane once its thread is stamped', () => {
+    // The reason the old assertion gave for admitting unbound rows was that
+    // video-link transcripts index without a document. They do — with a
+    // thread. A welcome-page paste starts thread-less because no thread
+    // exists yet, and the first send stamps it (`bindStorageIdsToThread`
+    // updates exactly the rows with no document and no thread), after which
+    // this branch admits it.
+    expect(
+      decideRetrievable([], [unboundFile({ threadId: 'thread_1' })], {
+        teamIds: [],
+        threadIds: ['thread_1'],
+      }),
+    ).toBe(true);
+  });
+
+  it('does not admit a thread-bound row from outside its thread', () => {
+    expect(
+      decideRetrievable([], [unboundFile({ threadId: 'thread_1' })], {
+        teamIds: [],
+        threadIds: ['thread_2'],
+      }),
+    ).toBe(false);
   });
 
   it('denies trashed unbound rows — the WebDAV overwrite strands', () => {
@@ -180,7 +214,13 @@ describe('decideRetrievable', () => {
           undefined,
         ),
       ).toBe(true);
-      expect(decideRetrievable([], [unboundFile()], undefined)).toBe(true);
+      // A thread-bound file, because a row bound to NEITHER a document nor
+      // a thread is denied on its own merits — see the deny tests above. The
+      // claim here is that the absent folder changes nothing, so the fixture
+      // has to be one that admits without it.
+      expect(
+        decideRetrievable([], [unboundFile({ threadId: 'th1' })], undefined),
+      ).toBe(true);
     });
   });
 });

--- a/services/platform/backend/domains/knowledge/retrievable.ts
+++ b/services/platform/backend/domains/knowledge/retrievable.ts
@@ -12,12 +12,23 @@
  *     (history) never answers as if it were the live document. Scope
  *     (project / hub team) applies per candidate document — a WebDAV COPY
  *     twin admits through its own scope, not its sibling's.
- *   - or a LIVE unbound file row holding the ref: thread-bound rows admit
- *     only inside their thread's scope; rows with neither binding keep the
- *     0.4 same-org posture DELIBERATELY — video-link transcripts index
- *     without a document, so a blanket quarantine would dark a legitimate
- *     lane. Trashed file rows (a WebDAV overwrite's strands) and refs with
- *     no row at all are never retrievable.
+ *   - or a LIVE unbound file row holding the ref, admitted only inside its
+ *     thread's scope. A row with NEITHER binding is DENIED: the corpus
+ *     stamps no project and no team for that shape, and the SQL half then
+ *     reads it as an org-wide hub row, so admitting it here serves one
+ *     member's file to the whole organization. 0.4 denied it too
+ *     (`documentId === undefined` → `continue`).
+ *
+ *     This does not dark the video-link lane, which was the stated reason
+ *     for the earlier same-org posture. A welcome-page paste indexes with
+ *     `thread_id` NULL because no thread exists yet, and the first send
+ *     stamps it (`bindStorageIdsToThread`, which updates exactly the rows
+ *     with no document and no thread). Before that send there is no thread
+ *     for a turn to be scoped to, so nothing can legitimately ask for it;
+ *     after it, the thread branch admits it.
+ *
+ *     Trashed file rows (a WebDAV overwrite's strands) and refs with no row
+ *     at all are never retrievable.
  *
  * A folder filter narrows further, from the CURRENT folder of each document
  * (the corpus row's stamp is a copy that can lag a move): only a document
@@ -106,7 +117,10 @@ export function decideRetrievable(
       }
       continue;
     }
-    return true;
+    // Neither binding: denied. See the note at the top of this file — the
+    // corpus reads an unscoped row as org-wide, so a `return true` here is a
+    // fail-open default rather than a same-org one.
+    continue;
   }
   return false;
 }


### PR DESCRIPTION
A corpus row bound to neither a document nor a thread was retrievable by any
member of the organization. `decideRetrievable`'s unbound-file loop ended in
`return true`, so a row that passed no scope check at all was admitted.

Rebase of #3177 onto current main; no content change.

## The premise it was defended on is wrong

The module docstring called this "the 0.4 same-org posture DELIBERATELY",
citing video-link transcripts as the lane that needs it. That lane does not
need it: `bindStorageIdsToThread` in `backend/domains/chat/shim.ts` stamps
`thread_id` at send time (`WHERE document_id IS NULL AND thread_id IS NULL`),
so those rows arrive at the gate thread-bound and are served by the branch
directly above — the one that checks `access.threadIds`.

So nothing reaches the unbound arm by design. What reaches it is a row whose
binding never landed, and the corpus reads an unscoped row as org-wide. That
makes `return true` a fail-open default, not a same-org one. Changed to
`continue`, and the docstring now says that.

## Tests

The suite had a test asserting the old behaviour. It is **replaced**, not
deleted — two assertions now pin the denial, one with an access scope and one
without, because the two arms return through different paths.

Mutation-tested: restoring `return true` fails both.

| Mutation | Went red |
| --- | --- |
| `continue` → `return true` | `denies a live row bound to neither a document nor a thread`, `denies it with no access scope either` |

## Gate

`retrievable.test.ts` **12 passed**, `typecheck` 0 errors, `oxlint --type-aware`
clean, `oxfmt --check` clean.