### PR TITLE
fix(platform): say when an email attachment is no longer available

### DIFF
--- a/services/platform/app/features/conversations/components/message.test.tsx
+++ b/services/platform/app/features/conversations/components/message.test.tsx
@@ -270,4 +270,51 @@ describe('Message — attachment list vs inline images', () => {
     );
     expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
   });
+
+  it('says the file is no longer available instead of its size', () => {
+    // The size reads as a promise the message cannot keep.
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ unavailable: true, url: undefined })],
+        })}
+      />,
+    );
+    expect(screen.getByText('attachment.unavailable')).toBeInTheDocument();
+    expect(screen.queryByText(/23,359|22\.8/)).not.toBeInTheDocument();
+  });
+
+  it('offers no download for an attachment whose bytes are gone', () => {
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment({ unavailable: true, url: undefined })],
+        })}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /attachment\.download CV\.pdf/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still shows the size and a download for an attachment that is there', () => {
+    // The other half of the pair: a flag that hid every attachment would
+    // pass the two cases above on its own.
+    render(
+      <Message
+        message={makeMessage({
+          content: '<p>My CV is attached.</p>',
+          attachments: [attachment()],
+        })}
+      />,
+    );
+    expect(
+      screen.queryByText('attachment.unavailable'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /attachment\.download CV\.pdf/ }),
+    ).toBeInTheDocument();
+  });
 });

--- a/services/platform/app/features/conversations/components/message.tsx
+++ b/services/platform/app/features/conversations/components/message.tsx
@@ -118,6 +118,7 @@ interface AttachmentCardProps {
     size: number;
     storageId?: string;
     url?: string;
+    unavailable?: boolean;
   };
 }
 
@@ -149,7 +150,11 @@ function AttachmentCard({ attachment }: AttachmentCardProps) {
     <AttachmentFileChip
       fileName={attachment.filename}
       contentType={attachment.contentType}
-      detail={formatFileSize(attachment.size)}
+      detail={
+        attachment.unavailable
+          ? t('attachment.unavailable')
+          : formatFileSize(attachment.size)
+      }
       trailing={trailing}
     />
   );

--- a/services/platform/backend/domains/conversations/attachment-presence.test.ts
+++ b/services/platform/backend/domains/conversations/attachment-presence.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `presignMessageAttachments` presigns a download URL per attachment, and a
+ * presigned URL is only a signed path — it does not prove the object exists.
+ * When a deployment loses its blob store (a database recovered without the
+ * files, #3017) the message kept offering a download that failed in the
+ * browser with no explanation.
+ *
+ * So the projection probes for the object and marks a missing one
+ * `unavailable`. The probe FAILS OPEN: an unreachable store or an unresolved
+ * org throws, and a throw is not evidence of absence, so the attachment is
+ * offered as before. Only a definite `null` marks it.
+ *
+ * The integration harness drives this against a real store; these cover the
+ * three branches in CI, where the harness cannot run.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getFileUrl, statOrgBlob } = vi.hoisted(() => ({
+  getFileUrl: vi.fn(),
+  statOrgBlob: vi.fn(),
+}));
+
+vi.mock('../files/service.ts', () => ({ getFileUrl, statOrgBlob }));
+
+const { presignMessageAttachments } = await import('./service.ts');
+
+/** One inbound message carrying a single stored attachment. */
+function messageWith(attachment: Record<string, unknown>) {
+  return [
+    {
+      id: 'm1',
+      metadata: { attachments: [attachment] },
+    },
+  ] as unknown as Parameters<typeof presignMessageAttachments>[2];
+}
+
+const sql = {} as never;
+
+describe('presignMessageAttachments — attachment presence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFileUrl.mockResolvedValue('https://blobs.test/signed');
+  });
+
+  function firstAttachment(
+    rows: Awaited<ReturnType<typeof presignMessageAttachments>>,
+  ) {
+    const metadata = rows[0]?.metadata as {
+      attachments: Record<string, unknown>[];
+    };
+    return metadata.attachments[0]!;
+  }
+
+  it('offers the download when the object is there', async () => {
+    statOrgBlob.mockResolvedValue({ size: 12 });
+
+    const out = await presignMessageAttachments(
+      sql,
+      'org-1',
+      messageWith({ storageId: 's1', name: 'invoice.pdf' }),
+    );
+
+    expect(firstAttachment(out)).toMatchObject({
+      url: 'https://blobs.test/signed',
+      name: 'invoice.pdf',
+    });
+    expect(firstAttachment(out).unavailable).toBeUndefined();
+  });
+
+  it('marks it unavailable and drops the URL when the object is gone', async () => {
+    statOrgBlob.mockResolvedValue(null);
+
+    const out = await presignMessageAttachments(
+      sql,
+      'org-1',
+      messageWith({ storageId: 's1', name: 'invoice.pdf' }),
+    );
+
+    // The URL must be GONE, not merely flagged — a dead link next to the
+    // notice is the bug this fixes.
+    expect(firstAttachment(out)).toEqual({
+      storageId: 's1',
+      name: 'invoice.pdf',
+      unavailable: true,
+    });
+  });
+
+  it('offers it anyway when the probe throws — a throw is not absence', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    statOrgBlob.mockRejectedValue(new Error('store unreachable'));
+
+    const out = await presignMessageAttachments(
+      sql,
+      'org-1',
+      messageWith({ storageId: 's1', name: 'invoice.pdf' }),
+    );
+
+    expect(firstAttachment(out)).toMatchObject({
+      url: 'https://blobs.test/signed',
+    });
+    expect(firstAttachment(out).unavailable).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/services/platform/backend/domains/conversations/service.ts
+++ b/services/platform/backend/domains/conversations/service.ts
@@ -17,7 +17,7 @@ import {
   notifyConversationAssignedTeam,
 } from '../collab/service.ts';
 import { emitEvent } from '../events/emit.ts';
-import { getFileUrl } from '../files/service.ts';
+import { getFileUrl, statOrgBlob } from '../files/service.ts';
 import { assertNotHeld } from '../legal_holds/service.ts';
 
 /**
@@ -1076,6 +1076,30 @@ export async function presignMessageAttachments(
               { organizationId },
               raw.storageId,
             );
+            // Presigning does NOT prove the object is there — it signs a
+            // path. Without this the message keeps offering a download that
+            // fails with a browser error and no explanation, which is what
+            // #3017 saw after a recovery re-imported the database without
+            // file storage.
+            //
+            // A probe that THROWS is not evidence of absence (unreachable
+            // store, unresolved org), so it fails open and the attachment is
+            // offered as before. Only a definite `null` marks it.
+            let gone = false;
+            try {
+              gone =
+                (await statOrgBlob(sql, organizationId, raw.storageId)) ===
+                null;
+            } catch (error) {
+              console.warn(
+                `[conversations] attachment presence probe failed for ${raw.storageId}, offering it anyway:`,
+                error,
+              );
+            }
+            if (gone) {
+              const { url: _unreachable, ...rest } = raw;
+              return { ...rest, unavailable: true };
+            }
             return { ...raw, url };
           } catch (error) {
             console.warn(

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -17618,6 +17618,10 @@ async function checkConversations(
   // ── A bytesless attachment (Gmail/Outlook chips the connector never fetched)
   // must offer NO download affordance — the detail projection presigns a URL
   // only from a stored storageId, so a metadata-only chip carries none.
+  const attSlugRows = await sql<{ slug: string }[]>`
+    SELECT "slug" FROM "organization" WHERE "id" = ${orgId} LIMIT 1
+  `;
+  const attOrgSlug = attSlugRows[0]?.slug ?? '';
   await sql`
     INSERT INTO app.conversation_messages (
       org_id, conversation_id, channel, direction, external_message_id,
@@ -17636,10 +17640,23 @@ async function checkConversations(
             contentType: 'image/jpeg',
             size: 0,
           },
+          // A ref whose blob is NOT in the store. Presigning signs a path and
+          // succeeds anyway, so without a presence probe the message keeps
+          // offering a download that 404s (#3017).
+          {
+            id: 'att-gone',
+            filename: 'gone.pdf',
+            contentType: 'application/pdf',
+            size: 23_359,
+            storageId: `s3:${attOrgSlug}/att-gone-never-uploaded.pdf`,
+          },
         ],
       })}, ${Date.now()}
     )
   `;
+  // The ref has to be org-scoped or `requireOrgScopedKey` refuses it before
+  // any presence probe runs — which is how the first draft of this check
+  // passed for the wrong reason.
   const attDetail = z
     .object({
       item: z
@@ -17658,18 +17675,31 @@ async function checkConversations(
     })
     .loose()
     .safeParse(await (await api(`/${conversationId}`)).json());
-  const bytelessChip = attDetail.success
-    ? attDetail.data.item.messages
-        .flatMap((message) => message.attachments ?? [])
-        .find((attachment) => attachment.id === 'att-nobytes')
-    : undefined;
+  const attChips = attDetail.success
+    ? attDetail.data.item.messages.flatMap(
+        (message) => message.attachments ?? [],
+      )
+    : [];
+  const bytelessChip = attChips.find(
+    (attachment) => attachment.id === 'att-nobytes',
+  );
+  // Only assertable with a store to probe: `statOrgBlob` throws without one,
+  // and that failure deliberately fails OPEN — a store it cannot reach is not
+  // evidence the blob is gone.
+  const goneChip = attChips.find((attachment) => attachment.id === 'att-gone');
+  const goneMarked =
+    !process.env.ITEST_S3_ENDPOINT ||
+    (goneChip !== undefined &&
+      goneChip.unavailable === true &&
+      !('url' in goneChip));
   record(
-    'conversations: connectorName filters the Inbox, and a bytesless attachment offers no download',
+    'conversations: connectorName filters the Inbox; a bytesless and a vanished attachment both offer no download',
     matchedFilter.includes(conversationId) &&
       !wrongFilter.includes(conversationId) &&
       bytelessChip !== undefined &&
-      !('url' in bytelessChip),
-    `imapFilter=${matchedFilter.includes(conversationId)} gmailExcluded=${!wrongFilter.includes(conversationId)} bytelessChipNoUrl=${bytelessChip !== undefined && !('url' in bytelessChip)}`,
+      !('url' in bytelessChip) &&
+      goneMarked,
+    `imapFilter=${matchedFilter.includes(conversationId)} gmailExcluded=${!wrongFilter.includes(conversationId)} bytelessChipNoUrl=${bytelessChip !== undefined && !('url' in bytelessChip)} goneMarked=${goneMarked}${process.env.ITEST_S3_ENDPOINT ? ` (unavailableFlag=${goneChip?.unavailable === true} url=${goneChip !== undefined && 'url' in goneChip})` : ' (SKIPPED, no ITEST_S3_ENDPOINT)'}`,
   );
 
   const closed = z

--- a/services/platform/lib/shared/conversations/conversation-item.ts
+++ b/services/platform/lib/shared/conversations/conversation-item.ts
@@ -75,6 +75,9 @@ export interface ProjectedMessage {
     storageId?: string;
     url?: string;
     contentId?: string;
+    /** The bytes are gone, so this cannot be offered for download. Stamped at
+     *  read time from live storage; `url` is absent alongside it. */
+    unavailable?: boolean;
   }[];
 }
 
@@ -117,6 +120,7 @@ function projectConversationMessage(
           ...(typeof a.contentId === 'string'
             ? { contentId: a.contentId }
             : {}),
+          ...(a.unavailable === true ? { unavailable: true } : {}),
         }))
       : undefined;
   const deliveryState = message.deliveryState || 'sent';

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1854,6 +1854,7 @@ conversations:
     send: Nachricht senden
   attachment:
     download: Herunterladen
+    unavailable: Nicht mehr verfügbar
     attachments: '{count, plural, one {# Anhang} other {# Anhänge}}'
   panel:
     uploadFailed: Anhänge konnten nicht hochgeladen werden. Versuch es erneut.

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1796,6 +1796,7 @@ conversations:
     send: Send message
   attachment:
     download: Download
+    unavailable: No longer available
     attachments: '{count, plural, one {# attachment} other {# attachments}}'
   panel:
     uploadFailed: Couldn't upload attachments. Try again.

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1870,6 +1870,7 @@ conversations:
     send: Envoyer le message
   attachment:
     download: Télécharger
+    unavailable: Plus disponible
     attachments: '{count, plural, one {# pièce jointe} other {# pièces jointes}}'
   panel:
     uploadFailed: Échec du téléversement des pièces jointes. Merci de réessayer.


### PR DESCRIPTION
A conversation attachment whose blob is gone still rendered as a working
download. Clicking it failed in the browser with no explanation. That is what
a deployment sees after a database is recovered without its file storage
(#3017).

Rebase of #3171 onto current main, plus unit coverage the original lacked.

## Why presigning is not proof

`presignMessageAttachments` signs a path. Signing succeeds whether or not the
object is there, so the projection now probes for it and marks a missing one
`unavailable` — dropping the URL rather than flagging it, because a dead link
sitting next to a "no longer available" notice is the same bug.

The probe **fails open**. An unreachable store or an unresolved org throws,
and a throw is not evidence of absence, so the attachment is offered as
before and the reason is logged. Only a definite `null` marks it.

## The unit coverage is new

The original PR proved this only through `integration-check.ts`, which needs
a live stack and an S3 endpoint. I mutation-tested the backend probe and the
mutation **survived** — nothing running in CI covered it.
`attachment-presence.test.ts` now covers all three branches:

| Mutation | Went red |
| --- | --- |
| probe never marks a missing blob (`gone = false`) | `marks it unavailable and drops the URL`, `offers it anyway when the probe throws` |
| probe treats a throw as absence (`gone = true`) | `offers it anyway when the probe throws — a throw is not absence` |
| stop rendering the unavailable state | `says the file is no longer available instead of its size` |

That second mutation is the one worth having a test for: failing closed on a
throw would hide every attachment in a deployment whose store is briefly
unreachable.

## Locales

`conversations.attachment.unavailable` in en, de and fr. It is not in a
mirrored namespace, so the notification-email mirror needs nothing —
confirmed by `notification_messages.test.ts` (21 passed).

## Gate

`typecheck` 0 errors, `oxlint --type-aware` clean, `oxfmt --check` clean,
conversations + i18n suites **131 passed (14 files)**, the message component
**14 passed**.