### PR TITLE
test(sandbox): wait for the fake CLI's AGENTS.md record to be written

### DIFF
--- a/services/sandbox-runtime/daemon/src/tale-openclaw-run.test.ts
+++ b/services/sandbox-runtime/daemon/src/tale-openclaw-run.test.ts
@@ -114,7 +114,14 @@ function startWrapper(opts: { mode: 'ok' | 'hang'; systemPrompt?: string }) {
 async function waitForSeen(): Promise<string> {
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
-    if (existsSync(seenPath)) return readFileSync(seenPath, 'utf8');
+    // The fake CLI records through a shell redirection, which creates (and
+    // truncates) the file BEFORE `cat` fills it: an existence check alone can
+    // read that empty in-between state and fail the assertion on a busy
+    // runner. Both branches write a non-empty record, so wait for content.
+    if (existsSync(seenPath)) {
+      const seen = readFileSync(seenPath, 'utf8');
+      if (seen !== '') return seen;
+    }
     await Bun.sleep(20);
   }
   throw new Error('fake openclaw never started');


### PR DESCRIPTION
## Why

The `tale-openclaw-run AGENTS.md safety` cases in `services/sandbox-runtime/daemon/src/tale-openclaw-run.test.ts` fail intermittently in CI with

```
Expected: "TALE SYSTEM PROMPT v1"
Received: ""
```

Observed on five of the last seven pull-request `Unit` runs (#3173, #3175, #3183, #3197, #3198), never on `main` — a timing flake on the shared runners.

## Root cause

The fake `openclaw` records the AGENTS.md it saw with `cat … > "$FAKE_SEEN"`. The shell redirection creates (and truncates) `seen.txt` BEFORE `cat` fills it, and `waitForSeen()` returned as soon as the file existed — so on a slow runner it read the empty in-between state.

## Fix

`waitForSeen()` now waits for a non-empty record. Both fake-CLI branches write one (`<absent>` for a missing file), so the loop cannot spin on a legitimately empty result; the 10s deadline is unchanged.

Test-only; `bun test src/tale-openclaw-run.test.ts` in `services/sandbox-runtime/daemon`: 5 pass.