### PR TITLE
fix(docs): skip node_modules and vanished entries in the content walk

### DIFF
--- a/services/docs/scripts/walk-content.ts
+++ b/services/docs/scripts/walk-content.ts
@@ -29,8 +29,21 @@ async function* walk(dir: string): AsyncGenerator<string> {
     return;
   }
   for (const entry of entries) {
+    // Never content: a dependency or cache directory (`node_modules`,
+    // `.vite-temp`) that a concurrent build task may create and remove under
+    // the tree while this walk runs.
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    const info = await stat(full);
+    let info;
+    try {
+      info = await stat(full);
+    } catch (error) {
+      // Listed by readdir, gone by stat: a transient directory another task
+      // just removed. It held no pages, so the walk moves on — a throw here
+      // failed the whole docs build on a race it had nothing to do with.
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
     if (info.isDirectory()) {
       yield* walk(full);
     } else if (/\.mdx?$/.test(entry)) {


### PR DESCRIPTION
## What

`services/docs/scripts/walk-content.ts` — the content walk behind the search index, llms.txt, sitemap and per-page .md scripts — `stat()`s every entry `readdir` returned. It now skips `node_modules` and dot entries outright and treats an entry that vanished between `readdir` and `stat` (`ENOENT`) as nothing to index.

## Why

`bunx turbo run build` runs the package builds concurrently. Another task can create and remove a dependency or cache directory under `docs/` (`node_modules/.vite-temp`) between the walk's `readdir` and `stat`, and the ENOENT then failed the whole `@tale/docs` build:

```
@tale/docs:build
ENOENT: no such file or directory, statx '/home/runner/work/tale/tale/docs/node_modules'
```

Observed twice on #3173's `Build` job while `main` was green. Such directories never hold pages, so skipping them cannot lose content.

## Gates

`bunx tsc --noEmit -p services/docs`: clean. `bun --bun scripts/build-search-index.ts`: en/de/fr indexes built, 438 pages in the manifest — unchanged counts.