### PR TITLE
fix(platform): stop shared chats rendering as blocked and accept ?new=1

### DIFF
--- a/services/platform/app/routes/dashboard/$id/chat/index.search.test.ts
+++ b/services/platform/app/routes/dashboard/$id/chat/index.search.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { Route } from './index';
+
+// Regression coverage for the chat fresh-composer flag. The router parses
+// search params as JSON, so a hand-typed `?new=1` arrives as the number 1 —
+// the validator used to drop it, the layout then resumed the caller's last
+// thread, and a message typed into the "fresh" composer landed there. Every
+// spelling of "yes" must normalize to the one value the layout reads
+// (`new: true`); anything else must leave the flag ABSENT (never `undefined`),
+// so plain links and redirects to /chat need no `search` argument.
+
+function parse(search: Record<string, unknown>) {
+  const validate = Route.options.validateSearch;
+  if (typeof validate !== 'function') {
+    throw new TypeError('chat index route has no search validator');
+  }
+  return validate(search);
+}
+
+describe('chat index search contract', () => {
+  it('accepts the boolean the in-app links send', () => {
+    expect(parse({ new: true })).toEqual({ new: true });
+  });
+
+  it('accepts a hand-typed ?new=1, which the JSON search parser delivers as the number 1', () => {
+    expect(parse({ new: 1 })).toEqual({ new: true });
+  });
+
+  it('accepts the string forms a custom search parser would deliver', () => {
+    expect(parse({ new: '1' })).toEqual({ new: true });
+    expect(parse({ new: 'true' })).toEqual({ new: true });
+  });
+
+  it('leaves the flag absent when the param is missing', () => {
+    const search = parse({});
+    expect(search).toEqual({});
+    expect(search).not.toHaveProperty('new');
+  });
+
+  it('leaves the flag absent for values that do not mean "fresh"', () => {
+    for (const value of [false, 0, 2, 'false', '0', 'yes', null]) {
+      expect(parse({ new: value })).not.toHaveProperty('new');
+    }
+  });
+
+  it('keeps a non-empty projectId and drops an empty or non-string one', () => {
+    expect(parse({ projectId: 'project_1' })).toEqual({
+      projectId: 'project_1',
+    });
+    expect(parse({ projectId: '' })).not.toHaveProperty('projectId');
+    expect(parse({ projectId: 7 })).not.toHaveProperty('projectId');
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/chat/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat/index.tsx
@@ -23,7 +23,15 @@ export const Route = createFileRoute('/dashboard/$id/chat/')({
     if (typeof search.projectId === 'string' && search.projectId !== '') {
       next.projectId = search.projectId;
     }
-    if (search.new === true || search.new === '1' || search.new === 'true') {
+    // The default search parser is JSON-based, so a hand-typed `?new=1`
+    // arrives as the number 1 — accept it alongside the boolean the in-app
+    // links send and the string forms a custom parser would deliver.
+    if (
+      search.new === true ||
+      search.new === 1 ||
+      search.new === '1' ||
+      search.new === 'true'
+    ) {
       next.new = true;
     }
     return next;

--- a/services/platform/backend/domains/chat/threads.test.ts
+++ b/services/platform/backend/domains/chat/threads.test.ts
@@ -99,6 +99,54 @@ describe('getSharedThread', () => {
     const lookup = statements.find((s) => s.text.includes('share_token'));
     expect(lookup?.text).toContain("tm.status = 'active'");
   });
+
+  it('maps NULL blocked_reason/error to ABSENT — a shared message is not a blocked, failed reply', async () => {
+    const messageRow = {
+      id: 'm1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'hello' }],
+      order: 0,
+      stepOrder: 0,
+      model: null,
+      providerSlug: null,
+      blockedReason: null,
+      error: null,
+      createdAt: 10,
+    };
+    const { sql } = fakeSql((statement) => {
+      if (statement.text.includes('share_token')) return [OWNED_ROW];
+      if (statement.text.includes('FROM app.messages')) {
+        return [
+          messageRow,
+          {
+            ...messageRow,
+            id: 'm2',
+            role: 'assistant',
+            order: 1,
+            blockedReason: 'content_policy',
+            error: 'upstream refused',
+            createdAt: 20,
+          },
+        ];
+      }
+      return undefined;
+    });
+    const view = await getSharedThread(sql, ['org_1'], 'tok');
+
+    expect(view?.messages).toHaveLength(2);
+    // The client tests `!== undefined`, so a SQL null must not survive into
+    // the view — on the wire the two keys are simply absent.
+    const [plain, blocked] = view?.messages ?? [];
+    expect(plain?.blockedReason).toBeUndefined();
+    expect(plain?.error).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(plain))).not.toHaveProperty(
+      'blockedReason',
+    );
+    expect(JSON.parse(JSON.stringify(plain))).not.toHaveProperty('error');
+    // A genuinely blocked or failed row keeps its stamps.
+    expect(blocked?.blockedReason).toBe('content_policy');
+    expect(blocked?.error).toBe('upstream refused');
+  });
 });
 
 describe('unshareThread', () => {

--- a/services/platform/backend/domains/chat/threads.ts
+++ b/services/platform/backend/domains/chat/threads.ts
@@ -778,8 +778,8 @@ export interface SharedThreadView {
     sequence: number;
     model: string | null;
     providerSlug: string | null;
-    blockedReason: string | null;
-    error: string | null;
+    blockedReason: string | undefined;
+    error: string | undefined;
     createdAt: number;
   }>;
 }
@@ -850,8 +850,11 @@ export async function getSharedThread(
       sequence: index,
       model: message.model,
       providerSlug: message.providerSlug,
-      blockedReason: message.blockedReason,
-      error: message.error,
+      // Absent, not null: the message view tests `!== undefined`, so a SQL
+      // null here rendered every shared message as a blocked, failed reply.
+      // The live read (shim.ts) normalizes the same two columns the same way.
+      blockedReason: message.blockedReason ?? undefined,
+      error: message.error ?? undefined,
       createdAt: message.createdAt,
     })),
   };

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -27933,7 +27933,11 @@ async function checkChatThreadSurface(
        'complete', ${Date.now() + 60_000})
   `;
   const snapshot = z
-    .object({ messages: z.array(z.unknown()) })
+    .object({
+      messages: z.array(
+        z.object({ blockedReason: z.unknown(), error: z.unknown() }).loose(),
+      ),
+    })
     .loose()
     .safeParse(
       await get(`/api/app/chat/threads/shared/${token}?orgId=${orgId}`),
@@ -27959,6 +27963,23 @@ async function checkChatThreadSurface(
       reshare.success &&
       reshare.data.shareToken === token,
     `snapshot=${snapshot.success ? snapshot.data.messages.length : 'ERR'} (want 2), dark=${dark.status}, stable=${reshare.success && reshare.data.shareToken === token}`,
+  );
+
+  // The two snapshot rows were inserted with NULL blocked_reason/error. The
+  // client tests `!== undefined`, so the snapshot must serialize those as
+  // ABSENT — a null here rendered every shared message as a blocked, failed
+  // reply (the live read already normalizes the same two columns).
+  const snapshotMessages = snapshot.success ? snapshot.data.messages : [];
+  const describeFlag = (value: unknown): string =>
+    value === undefined ? 'absent' : JSON.stringify(value);
+  record(
+    'share links: snapshot carries no null blocked reason or error',
+    snapshotMessages.length === 2 &&
+      snapshotMessages.every(
+        (message) =>
+          message.blockedReason === undefined && message.error === undefined,
+      ),
+    `flags=${snapshotMessages.map((message) => `${describeFlag(message.blockedReason)}/${describeFlag(message.error)}`).join(',')} (want absent/absent,absent/absent)`,
   );
 
   // Branch at the first message: exactly one message crosses.


### PR DESCRIPTION
Two product fixes that were committed inside the docs PR #3199 (`docs/align-ghost-feature-pages`) by the screenshot rig, shipped here as their own reviewable change with regression tests. #3199 will drop them separately.

## 1. Shared chat snapshots rendered every message as a blocked, failed reply

**Symptom.** Opening a shared conversation link showed a "blocked by your organization's content policy" notice and a "Something went wrong" error on **every** message.

**Root cause.** `getSharedThread` (`backend/domains/chat/threads.ts`) passed the SQL `null` of `blocked_reason` / `error` straight into the view, and `c.json` serialized it as `null`. The message view tests `!== undefined` (`message-item.tsx`, `message-toolbar.tsx`), and the frontend contract types both fields as `undefined | string`. The live thread read (`shim.ts`) already normalizes the same two columns with `?? undefined`; the snapshot read did not.

**Fix.** `blockedReason: message.blockedReason ?? undefined`, `error: message.error ?? undefined`; `SharedThreadView` types the two fields `string | undefined`. Still needed on main: `origin/main` line 853 still passes the raw value (#3182 touched the file but not this mapping); the cherry-pick auto-merged with no conflict.

**Tests.**

- `backend/domains/chat/threads.test.ts` — `getSharedThread` fed one plain row (NULL flags) and one genuinely blocked row through the fake sql: the plain row's `blockedReason`/`error` are `undefined` and absent from the JSON wire form; the blocked row keeps `'content_policy'` / `'upstream refused'`. **Red on main's `threads.ts`:** `expected null to be undefined` (1 failed / 7 passed) → green with the fix (8/8).
- `backend/integration-check.ts` — the share-links lane gains `share links: snapshot carries no null blocked reason or error` over the two NULL-flag rows it already seeds (fails on main by construction: the wire carries `"blockedReason": null`).

## 2. `/chat?new=1` resumed the last thread instead of opening a fresh composer

**Symptom.** A hand-typed or bookmarked `/dashboard/<org>/chat?new=1` silently resumed the caller's most recent thread; a message typed into what looked like a fresh composer landed in that old thread.

**Root cause.** TanStack Router's default search parser is JSON-based, so `?new=1` arrives as the **number** `1`. The index route's `validateSearch` accepted only `true | '1' | 'true'` and dropped it. Verified against the installed router (1.168): on main, `router.load()` for `/chat?new=1` answers 200 and every match — the layout's `useSearch({ strict: false })` included — sees `search = { new: 1 }`, so the layout's `startFresh` check fails and it resumes. With the fix the validator returns `{ new: true }`, the router answers with a 307 to the canonical `/chat?new=true`, and every match then reads the boolean the layout already checks.

**Fix.** Accept `search.new === 1` alongside the boolean the in-app links send and the string forms a custom parser would deliver (`app/routes/dashboard/$id/chat/index.tsx`). Still needed on main: `origin/main` line 26 still lacks the number form; cherry-pick applied cleanly.

**Tests.**

- `app/routes/dashboard/$id/chat/index.search.test.ts` — drives the route's real `Route.options.validateSearch`: `true`, `1`, `'1'`, `'true'` all normalize to `{ new: true }`; an absent param, `false`, `0`, `2`, `'false'`, `'0'`, `'yes'`, `null` leave the flag **absent**; `projectId` passthrough pinned. **Red on main's `index.tsx`:** `expected {} to deeply equal { new: true }` (1 failed / 5 passed) → green with the fix (6/6, under both the `test:ui` config and the `server` project).

## Gates observed (platform workspace, final tree)

- `bunx tsc --noEmit` — exit 0
- `bunx oxlint --type-aware` — exit 0
- `bunx oxfmt --check` on the five touched files — clean
- `bunx knip` (repo root) — exit 0 (one pre-existing config hint about `cron-parser`, unrelated)
- vitest: `threads.test.ts` 8/8 (server); `index.search.test.ts` 6/6 (ui config) and 6/6 (server)
- `backend:integration` on a fresh throwaway tale-db (54329) + MinIO (59001): `[itest] 448/451 checks passed`, no fatal, both share-links records PASS (incl. the new `snapshot carries no null blocked reason or error — flags=absent/absent,absent/absent`). The 3 FAILs are in lanes this change does not touch and are pre-existing on main: `blob-ref authority … compose → 403 FORBIDDEN (want 403 attachment_not_owned)` and `outbound send lane … memberDoors=403/403/403 (want 404s)` are the #3187 first-line gate vs. probe drift that #3198 corrects; `webdav re-home` is the known red. Not re-run on base (tally unambiguous).

No user-visible strings, env vars, or schema changed — no locale or migration impact.
