### PR TITLE
test(skills): lift the 5 s cap on the analyzer's spawned CLI tests

### DIFF
--- a/configs/platform/custom/skills/visual-aspect-analyzer/src/analyze-cli.test.ts
+++ b/configs/platform/custom/skills/visual-aspect-analyzer/src/analyze-cli.test.ts
@@ -579,6 +579,14 @@ describe('renderSummary', () => {
 
 const CLI = new URL('./analyze-cli.ts', import.meta.url).pathname;
 
+// Each test here spawns a cold Bun process (the launch-failure case also
+// imports playwright before it can throw). Locally that is well under a
+// second; on CI the whole repo's suites run at once on a two-core runner
+// and one cold start took over bun's 5 s default, which killed the child
+// mid-spawn (2026-09-04, main run 33843933336). Give the out-of-process
+// tests the time a cold start under load actually needs.
+const SPAWNED_CLI_TIMEOUT_MS = 60_000;
+
 async function runCli(
   args: readonly string[],
   env: Record<string, string> = {},
@@ -597,29 +605,41 @@ async function runCli(
 }
 
 describe('CLI entry (import.meta.main)', () => {
-  test('no url: prints usage and exits 1', async () => {
-    const { code, stdout, stderr } = await runCli([]);
-    expect(code).toBe(1);
-    expect(stderr).toContain('usage: analyze <url>');
-    expect(stdout).toBe('');
-  });
+  test(
+    'no url: prints usage and exits 1',
+    async () => {
+      const { code, stdout, stderr } = await runCli([]);
+      expect(code).toBe(1);
+      expect(stderr).toContain('usage: analyze <url>');
+      expect(stdout).toBe('');
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 
-  test('--help: prints usage and exits 0', async () => {
-    const { code, stderr } = await runCli(['--help']);
-    expect(code).toBe(0);
-    expect(stderr).toContain('usage: analyze <url>');
-  });
+  test(
+    '--help: prints usage and exits 0',
+    async () => {
+      const { code, stderr } = await runCli(['--help']);
+      expect(code).toBe(0);
+      expect(stderr).toContain('usage: analyze <url>');
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 
-  test('a browser-launch failure is caught as a one-line error and exits 1', async () => {
-    // Point playwright at an empty browser root so `chromium.launch()` throws;
-    // the entry wrapper's catch must surface that message and set exit code 1.
-    const empty = `${process.cwd()}/.tmp-no-browsers-${Date.now()}`;
-    const { code, stdout, stderr } = await runCli(['https://example.test/'], {
-      PLAYWRIGHT_BROWSERS_PATH: empty,
-    });
-    expect(code).toBe(1);
-    expect(stdout).toBe('');
-    // The thrown launch error reduced to a one-line message (no JSON emitted).
-    expect(stderr).toContain("Executable doesn't exist");
-  });
+  test(
+    'a browser-launch failure is caught as a one-line error and exits 1',
+    async () => {
+      // Point playwright at an empty browser root so `chromium.launch()` throws;
+      // the entry wrapper's catch must surface that message and set exit code 1.
+      const empty = `${process.cwd()}/.tmp-no-browsers-${Date.now()}`;
+      const { code, stdout, stderr } = await runCli(['https://example.test/'], {
+        PLAYWRIGHT_BROWSERS_PATH: empty,
+      });
+      expect(code).toBe(1);
+      expect(stdout).toBe('');
+      // The thrown launch error reduced to a one-line message (no JSON emitted).
+      expect(stderr).toContain("Executable doesn't exist");
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 });

--- a/configs/platform/custom/skills/visual-aspect-analyzer/src/cli.test.ts
+++ b/configs/platform/custom/skills/visual-aspect-analyzer/src/cli.test.ts
@@ -13,6 +13,14 @@ const CLI = new URL('./cli.ts', import.meta.url).pathname;
 const RECORDING = new URL('../examples/sample-recording.json', import.meta.url)
   .pathname;
 
+// Each test here spawns a cold Bun process that loads the analyzer and the
+// recording. Locally that is well under a second; on CI the whole repo's
+// suites run at once on a two-core runner, and a sibling spawned-CLI test
+// (analyze-cli.test.ts) took over bun's 5 s default and was killed mid-spawn
+// (2026-09-04, main run 33843933336). Give the out-of-process tests the time
+// a cold start under load actually needs.
+const SPAWNED_CLI_TIMEOUT_MS = 60_000;
+
 async function runCli(
   args: readonly string[],
 ): Promise<{ code: number; stdout: string; stderr: string }> {
@@ -29,46 +37,66 @@ async function runCli(
 }
 
 describe('cli (offline recording analysis)', () => {
-  test('default: prints the compact report (numeric score) and exits 0', async () => {
-    const { code, stdout, stderr } = await runCli([RECORDING]);
-    expect(code).toBe(0);
-    const parsed: unknown = JSON.parse(stdout);
-    // The compact report carries a numeric `score`; the faithful Report does not.
-    expect(typeof (parsed as { score?: unknown }).score === 'number').toBe(
-      true,
-    );
-    expect(stderr).toBe('');
-  });
+  test(
+    'default: prints the compact report (numeric score) and exits 0',
+    async () => {
+      const { code, stdout, stderr } = await runCli([RECORDING]);
+      expect(code).toBe(0);
+      const parsed: unknown = JSON.parse(stdout);
+      // The compact report carries a numeric `score`; the faithful Report does not.
+      expect(typeof (parsed as { score?: unknown }).score === 'number').toBe(
+        true,
+      );
+      expect(stderr).toBe('');
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 
-  test('--full: prints the faithful Report (session, no compact score)', async () => {
-    const { code, stdout } = await runCli([RECORDING, '--full']);
-    expect(code).toBe(0);
-    const parsed: unknown = JSON.parse(stdout);
-    expect(Reflect.has(parsed as object, 'session')).toBe(true);
-    expect(Reflect.has(parsed as object, 'score')).toBe(false);
-  });
+  test(
+    '--full: prints the faithful Report (session, no compact score)',
+    async () => {
+      const { code, stdout } = await runCli([RECORDING, '--full']);
+      expect(code).toBe(0);
+      const parsed: unknown = JSON.parse(stdout);
+      expect(Reflect.has(parsed as object, 'session')).toBe(true);
+      expect(Reflect.has(parsed as object, 'score')).toBe(false);
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 
-  test('--full before the path still works (path = first non-flag arg)', async () => {
-    const { code, stdout } = await runCli(['--full', RECORDING]);
-    expect(code).toBe(0);
-    expect(Reflect.has(JSON.parse(stdout) as object, 'session')).toBe(true);
-  });
+  test(
+    '--full before the path still works (path = first non-flag arg)',
+    async () => {
+      const { code, stdout } = await runCli(['--full', RECORDING]);
+      expect(code).toBe(0);
+      expect(Reflect.has(JSON.parse(stdout) as object, 'session')).toBe(true);
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 
-  test('no path: prints usage to stderr and exits 1 (stdout stays clean)', async () => {
-    const { code, stdout, stderr } = await runCli([]);
-    expect(code).toBe(1);
-    expect(stderr).toContain('usage: bun src/cli.ts');
-    expect(stdout).toBe('');
-  });
+  test(
+    'no path: prints usage to stderr and exits 1 (stdout stays clean)',
+    async () => {
+      const { code, stdout, stderr } = await runCli([]);
+      expect(code).toBe(1);
+      expect(stderr).toContain('usage: bun src/cli.ts');
+      expect(stdout).toBe('');
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 
-  test('a missing file is reduced to a one-line error and exit 1 (no stack trace)', async () => {
-    const { code, stdout, stderr } = await runCli([
-      '/no/such/recording-xyz.json',
-    ]);
-    expect(code).toBe(1);
-    expect(stdout).toBe('');
-    expect(stderr.trim().length).toBeGreaterThan(0);
-    // The `import.meta.main` catch prints `error.message`, never a raw stack.
-    expect(stderr).not.toContain('\n    at ');
-  });
+  test(
+    'a missing file is reduced to a one-line error and exit 1 (no stack trace)',
+    async () => {
+      const { code, stdout, stderr } = await runCli([
+        '/no/such/recording-xyz.json',
+      ]);
+      expect(code).toBe(1);
+      expect(stdout).toBe('');
+      expect(stderr.trim().length).toBeGreaterThan(0);
+      // The `import.meta.main` catch prints `error.message`, never a raw stack.
+      expect(stderr).not.toContain('\n    at ');
+    },
+    SPAWNED_CLI_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Why

main's Checks run [33843933336](https://github.com/tale-project/tale/actions/runs/33843933336) (34ccd23b2) failed in **Unit**: `@tale/visual-aspect-analyzer#test` →

```
src/analyze-cli.test.ts:
killed 1 dangling process
(fail) CLI entry (import.meta.main) > a browser-launch failure is caught as a one-line error and exits 1 [5009.06ms]
  ^ this test timed out after 5000ms.
```

Nothing under `configs/platform/custom/skills/visual-aspect-analyzer` has changed since 2026-08-22, and the same test passed in every PR run merged today, so this is a timing flake, not a regression. The test spawns a cold Bun process (`bun src/analyze-cli.ts <url>`) that imports playwright and then lets `chromium.launch()` throw against an empty `PLAYWRIGHT_BROWSERS_PATH`. Locally the whole file runs in ~0.4 s; on CI `turbo run test` runs every workspace's suite concurrently on a two-core runner, and that cold start crossed bun's 5 s default per-test timeout.

The `@tale/web#test` "Worker exited unexpectedly" in the same log is collateral: turbo cancels the sibling tasks once one fails, which kills the web vitest worker mid-run. It passed in every PR run.

## What changed

- `src/analyze-cli.test.ts` and `src/cli.test.ts`: the eight tests that spawn the CLI out-of-process get a `SPAWNED_CLI_TIMEOUT_MS = 60_000` per-test timeout, with a comment recording why. No behaviour or assertion changed. (oxfmt reflows a `test()` with a third argument onto multiple lines, hence the larger-looking diff.)

## Gates observed

- `bun test src/analyze-cli.test.ts src/cli.test.ts` in the skill: 30 pass, 0 fail (0.4 s)
- `bun run typecheck` (skill): clean
- `bunx oxfmt --check` on both files: clean; repo-root `bunx oxlint` on both files: no findings
- The skill has no `lint` script, so turbo's lint task does not cover it (unchanged)
