### PR TITLE
test(ui): wait for the mermaid diagram, not the toolbar icons

### DIFF
--- a/packages/ui/src/markdown/components/mermaid.test.tsx
+++ b/packages/ui/src/markdown/components/mermaid.test.tsx
@@ -114,16 +114,28 @@ describe('Mermaid', () => {
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40" width="100%"><foreignObject width="100" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><img src="x" onerror="alert(1)"/></div></foreignObject><use href="javascript:alert(1)" x="10" y="10"/></svg>';
     mockMermaid.render.mockResolvedValueOnce({ svg: malicious });
 
-    const { container } = render(<Mermaid chart="flowchart TD\nA --> B" />);
+    const { getByRole } = render(<Mermaid chart="flowchart TD\nA --> B" />);
 
+    // Gate on the diagram slot, not on any <svg> in the tree: the zoom
+    // toolbar's lucide icons are <svg>s too and render synchronously, so a
+    // bare `container.querySelector('svg')` was satisfied before mermaid's
+    // (async, mocked) import had resolved — the assertions then ran against
+    // an empty stage whenever that import lost the race, which it did on a
+    // loaded CI runner (main run 33829189967: "expected undefined to be null").
+    const stage = getByRole('img', { name: 'Mermaid diagram' });
     await waitFor(() => {
-      expect(container.querySelector('svg')).not.toBeNull();
+      expect(stage.querySelector('svg')).not.toBeNull();
     });
 
-    expect(container.querySelector('img')?.getAttribute('onerror')).toBeNull();
-    expect(container.innerHTML).not.toContain('onerror');
-    expect(container.querySelector('use')?.getAttribute('href')).toBeNull();
-    expect(container.innerHTML).not.toContain('javascript:');
+    // The malicious markup is what rendered — its foreignObject label survives
+    // sanitizing — so the negatives below are not passing against nothing.
+    expect(stage.querySelector('foreignObject')).not.toBeNull();
+    expect(
+      stage.querySelector('img')?.getAttribute('onerror') ?? null,
+    ).toBeNull();
+    expect(stage.innerHTML).not.toContain('onerror');
+    expect(stage.querySelector('use')?.getAttribute('href') ?? null).toBeNull();
+    expect(stage.innerHTML).not.toContain('javascript:');
   });
 
   it('renders a realistic flowchart output with its foreignObject label intact', async () => {


### PR DESCRIPTION
## Why

main's Checks run [33829189967](https://github.com/tale-project/tale/actions/runs/33829189967) (6cbb8b7cc, 2026-09-03) failed in **Unit** on `@tale/ui`:

```
FAIL  src/markdown/components/mermaid.test.tsx > Mermaid > strips a malicious mermaid render() output before it reaches the DOM
AssertionError: expected undefined to be null
  ❯ src/markdown/components/mermaid.test.tsx:123:69
  123|     expect(container.querySelector('img')?.getAttribute('onerror')).toBeNull();
```

`undefined` means `querySelector('img')` found nothing: the diagram had not been injected yet. The test gated on `container.querySelector('svg')`, but `Mermaid` renders its zoom toolbar — four lucide icons, each an `<svg>` — synchronously on first paint, so that `waitFor` is satisfied immediately, before the mocked `import('mermaid')` (which goes through vitest's module runner, i.e. real async work) has resolved. Whenever the import loses that race the assertions run against an empty stage. Locally the import wins; on a loaded two-core runner it lost once.

**Reproduced deterministically**: making the mocked import take a macrotask (`await new Promise(r => setTimeout(r, 50))` in the `vi.mock` factory) fails the unmodified test 3/3 runs with exactly the CI error, and passes 2/2 with this fix. The delay is not committed.

## What changed

`mermaid.test.tsx`, first `Mermaid` test only:

- Gate on the diagram slot (`getByRole('img', { name: 'Mermaid diagram' })` → its `<svg>`), which only exists once the sanitized output is injected — the toolbar icons are `aria-hidden` and live outside it.
- Assert the slot's `<foreignObject>` rendered, so the negative assertions (`onerror`, `javascript:`, `use[href]`) can never pass against an empty stage.
- `img`/`use` attribute checks use `?? null`: a sanitizer that drops the element entirely is as safe as one that strips the attribute, and the `foreignObject` assertion proves the malicious markup is what rendered.

The second `Mermaid` test already gates on `foreignObject` and is unaffected. Component code unchanged.

## Gates observed

- `bunx vitest --run src/markdown/components/mermaid.test.tsx` (packages/ui): 10/10 ×3; with the slow-import experiment on top: 10/10 ×2 (unmodified test: 1 failed ×3)
- `bunx oxfmt --check`, `bunx oxlint --type-aware` on the file: clean
