### PR TITLE
fix(db): stop Postgres with SIGINT so container stops are clean

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -55,8 +55,16 @@ services:
     # Container name
     container_name: tale-db
 
-    # Graceful shutdown: give PostgreSQL enough time to complete
-    # checkpoint + WAL flush before Docker sends SIGKILL
+    # Graceful shutdown. SIGINT is PostgreSQL's *fast* shutdown (disconnect
+    # every client, checkpoint, exit); Docker's default SIGTERM is the *smart*
+    # shutdown, which waits for every client session to end and — with a
+    # host-side backend or psql holding connections — never finishes, so Docker
+    # SIGKILLs the server after the grace period: a crash-mode stop that left a
+    # never-initialised page in pg_search's BM25 index. The image sets the same
+    # STOPSIGNAL (services/db/Dockerfile); this covers an older image without it.
+    stop_signal: SIGINT
+    # Give PostgreSQL enough time to complete checkpoint + WAL flush before
+    # Docker sends SIGKILL
     stop_grace_period: 60s
 
     # Shared memory: ParadeDB extensions may exceed Docker's default 64MB /dev/shm
@@ -153,6 +161,8 @@ services:
 
     container_name: tale-knowledge-db
 
+    # Same fast-shutdown contract as `db` above.
+    stop_signal: SIGINT
     stop_grace_period: 60s
     shm_size: 256mb
 

--- a/docs/de/self-hosted/operate/observability/troubleshooting.md
+++ b/docs/de/self-hosted/operate/observability/troubleshooting.md
@@ -45,6 +45,55 @@ docker compose ps db
 
 Zeigen die Logs Verbindungsfehler zur Korpus-Datenbank (`knowledge-db` im Netz, auf einem Single-Host-Deploy in `db` gefaltet), starte sie neu (`docker compose restart db`); die Ingestion versucht es beim nächsten Durchlauf erneut, Uploads müssen also nicht erneut eingereicht werden. Ist die Datenbank healthy, aber ein bestimmter Upload steckt, ist die Datei selbst der Verdächtige — beschädigte PDFs und passwortgeschützte Dokumente landen in einem Fehlzustand und brauchen Löschung und Re-Upload.
 
+## Wissensdatenbank startet bei jedem Upload neu
+
+Jede Dokument-Ingestion scheitert auf dieselbe Art: Die Korpus-Datenbank (`knowledge-db`, auf einem Single-Host-Deploy in `db` gefaltet) startet neu, der Backend-Worker verliert seine Verbindung, und der nächste Upload löst denselben Neustart aus. Das Server-Log — eine Datei unter `/var/lib/postgresql/data/log/` im Container; `docker compose logs` trägt nur die Ausgabe des Entrypoints — benennt den Fehler jedes Mal:
+
+```bash
+docker compose exec knowledge-db sh -c 'grep -h -E "PANIC|signal 6" /var/lib/postgresql/data/log/*.log | tail -n 4'
+```
+
+```text
+PANIC:  corrupted page pointers: lower = 0, upper = 0, special = 0
+LOG:  server process (PID 4711) was terminated by signal 6: Aborted
+```
+
+Der BM25-Keyword-Index auf `private_knowledge.chunks` enthält eine Seite, die nie initialisiert wurde, und ein Stopp im Crash-Modus des Datenbank-Containers lässt genau so eine zurück: Der Server erweitert die Index-Datei für einen laufenden Write, `SIGKILL` trifft ein, bevor die Seite geschrieben ist, und die Crash-Recovery hat kein WAL, das sie dafür einspielen könnte. `tale-db`-Images bis v0.5.7 haben Postgres mit `SIGTERM` gestoppt, was Postgres als *smart* shutdown liest — es wartet, bis jede Client-Session beendet ist. Ein Client außerhalb von Compose, der eine Verbindung hält (ein Backend auf dem Host, ein offenes `psql`), hat den Stopp über die Grace-Period hinausgeschoben, Docker hat den Server abgeschossen, und der nächste Start lief als Crash-Recovery. Gewöhnliche Tabellen und Indizes überstehen das; `pg_search` trifft die Null-Seite beim nächsten Write, bricht mit PANIC ab, und Postgres startet zur Recovery neu — bei jedem Upload.
+
+Bestätige, dass der Index der Schuldige ist, bevor du etwas reparierst. Öffne eine Session auf der Korpus-Datenbank — beide Statements lesen nur:
+
+```bash
+docker compose exec knowledge-db psql -U tale -d tale_knowledge
+```
+
+```sql
+select * from pdb.verify_index('private_knowledge.idx_pk_chunks_bm25');
+```
+
+Ein gesunder Index besteht jede Prüfung (`passed = t`); ein beschädigter scheitert an `segment_metadata_valid` oder lässt sich gar nicht lesen. Um die Seite selbst zu sehen, gibt `pageinspect` den Header der letzten Index-Seite aus — `0 | 0 | 0` ist die nie initialisierte Seite, eine gesunde Seite zeigt `24 | 8184 | 8184`:
+
+```sql
+create extension if not exists pageinspect;
+select lower, upper, special
+from page_header(get_raw_page('private_knowledge.idx_pk_chunks_bm25',
+  (pg_relation_size('private_knowledge.idx_pk_chunks_bm25') / 8192 - 1)::int));
+```
+
+Dann baue den Index neu. Er ist aus `private_knowledge.chunks` abgeleitet, also geht nichts verloren und nichts muss erneut hochgeladen werden:
+
+```sql
+REINDEX INDEX private_knowledge.idx_pk_chunks_bm25;
+```
+
+Optional baust du auch den Vektor-Index neu (er existiert, sobald das erste Embedding gespeichert wurde) und gibst die verwaisten Schluss-Seiten der Tabelle frei:
+
+```sql
+REINDEX INDEX private_knowledge.idx_pk_chunks_embedding_hnsw;
+VACUUM private_knowledge.chunks;
+```
+
+Die Ingestion läuft beim nächsten Durchlauf des Workers weiter. `tale-db`-Images neuer als v0.5.7 stoppen Postgres mit `SIGINT` — dem *fast* shutdown, der Clients trennt, einen Checkpoint schreibt und binnen Sekunden beendet, auch während Clients verbunden sind — und `compose.yml` setzt `stop_signal: SIGINT`, damit auch ein älteres Image dasselbe Signal bekommt. Stoppe den Stack mit `docker compose stop` oder `docker compose down` und lass die 60-Sekunden-Grace-Period laufen (die tale-CLI stoppt Container auf demselben Weg); `docker kill` und dem Host den Strom zu ziehen sind die zwei Wege, die weiterhin in einem Stopp im Crash-Modus enden.
+
 ## Chat-Antworten hören mitten im Stream auf
 
 Der Token-Stream vom Upstream-Anbieter ist abgefallen — entweder hat der Anbieter rate-limited, die Verbindung ist getimeoutet, oder der Service des Anbieters ist degradiert. Prüf zuerst die Status-Seite des Anbieters; schau dann in die Plattform-Logs:

--- a/docs/en/self-hosted/operate/observability/troubleshooting.md
+++ b/docs/en/self-hosted/operate/observability/troubleshooting.md
@@ -45,6 +45,55 @@ docker compose ps db
 
 If the logs show connection errors to the corpus database (`knowledge-db` on the network, folded into `db` on a single-host deploy), restart it (`docker compose restart db`); ingestion retries on the next pass, so uploads do not have to be re-submitted. If the database is healthy but a specific upload is stuck, the file itself is the suspect — corrupt PDFs and password-protected documents land in a failure state and require deletion and re-upload.
 
+## Knowledge database restarts on every upload
+
+Every document ingestion fails the same way: the corpus database (`knowledge-db`, folded into `db` on a single-host deploy) restarts, the backend worker loses its connection, and the next upload triggers the same restart. The server log — a file under `/var/lib/postgresql/data/log/` inside the container; `docker compose logs` only carries the entrypoint's output — names the failure each time:
+
+```bash
+docker compose exec knowledge-db sh -c 'grep -h -E "PANIC|signal 6" /var/lib/postgresql/data/log/*.log | tail -n 4'
+```
+
+```text
+PANIC:  corrupted page pointers: lower = 0, upper = 0, special = 0
+LOG:  server process (PID 4711) was terminated by signal 6: Aborted
+```
+
+The BM25 keyword index on `private_knowledge.chunks` holds a page that was never initialised, and a crash-mode stop of the database container is what leaves one behind: the server extends the index file for a write in flight, `SIGKILL` lands before the page is written, and crash recovery has no WAL to replay for it. `tale-db` images up to v0.5.7 stopped Postgres with `SIGTERM`, which Postgres reads as a *smart* shutdown — it waits for every client session to end. A client outside compose holding a connection (a host-side backend, an open `psql`) pushed the stop past the grace period, Docker killed the server, and the next start ran crash recovery. Ordinary tables and indexes survive that; `pg_search` meets the all-zero page on its next write and panics, and Postgres restarts to recover — on every upload.
+
+Confirm the index is the culprit before repairing anything. Open a session on the corpus database — both statements only read:
+
+```bash
+docker compose exec knowledge-db psql -U tale -d tale_knowledge
+```
+
+```sql
+select * from pdb.verify_index('private_knowledge.idx_pk_chunks_bm25');
+```
+
+A healthy index passes every check (`passed = t`); a damaged one fails `segment_metadata_valid` or cannot be read at all. To look at the page itself, `pageinspect` prints the header of the index's last page — `0 | 0 | 0` is the never-initialised page, a healthy page reads `24 | 8184 | 8184`:
+
+```sql
+create extension if not exists pageinspect;
+select lower, upper, special
+from page_header(get_raw_page('private_knowledge.idx_pk_chunks_bm25',
+  (pg_relation_size('private_knowledge.idx_pk_chunks_bm25') / 8192 - 1)::int));
+```
+
+Then rebuild the index. It is derived from `private_knowledge.chunks`, so nothing is lost and nothing has to be re-uploaded:
+
+```sql
+REINDEX INDEX private_knowledge.idx_pk_chunks_bm25;
+```
+
+Optionally rebuild the vector index as well (it exists once the first embedding has been stored) and reclaim the orphaned tail pages on the table:
+
+```sql
+REINDEX INDEX private_knowledge.idx_pk_chunks_embedding_hnsw;
+VACUUM private_knowledge.chunks;
+```
+
+Ingestion resumes on the worker's next pass. `tale-db` images newer than v0.5.7 stop Postgres with `SIGINT` — the *fast* shutdown that disconnects clients, checkpoints, and exits within seconds even while clients are attached — and `compose.yml` sets `stop_signal: SIGINT` so an older image receives the same signal. Stop the stack with `docker compose stop` or `docker compose down` and let the 60-second grace period run (the tale CLI stops containers the same way); `docker kill` and pulling the host's plug are the two paths that still end in a crash-mode stop.
+
 ## Chat replies stop mid-stream
 
 The token stream from the upstream provider dropped — either the provider rate-limited, the connection timed out, or the provider's service is degraded. Check the provider's status page first; then look in the platform logs:

--- a/docs/fr/self-hosted/operate/observability/troubleshooting.md
+++ b/docs/fr/self-hosted/operate/observability/troubleshooting.md
@@ -45,6 +45,55 @@ docker compose ps db
 
 Si les logs montrent des erreurs de connexion à la base du corpus (`knowledge-db` sur le réseau, repliée dans `db` sur un déploiement single-host), redémarre-la (`docker compose restart db`) ; l'ingestion retente à la passe suivante, donc les téléversements n'ont pas à être re-soumis. Si la base est saine mais qu'un téléversement spécifique est bloqué, le fichier lui-même est le suspect — les PDFs corrompus et les documents protégés par mot de passe atterrissent en état d'échec et exigent suppression + re-téléversement.
 
+## La base de connaissances redémarre à chaque téléversement
+
+Chaque ingestion de document échoue de la même façon : la base du corpus (`knowledge-db`, repliée dans `db` sur un déploiement single-host) redémarre, le backend worker perd sa connexion, et le téléversement suivant déclenche le même redémarrage. Le log du serveur — un fichier sous `/var/lib/postgresql/data/log/` dans le conteneur ; `docker compose logs` ne porte que la sortie de l'entrypoint — nomme l'échec à chaque fois :
+
+```bash
+docker compose exec knowledge-db sh -c 'grep -h -E "PANIC|signal 6" /var/lib/postgresql/data/log/*.log | tail -n 4'
+```
+
+```text
+PANIC:  corrupted page pointers: lower = 0, upper = 0, special = 0
+LOG:  server process (PID 4711) was terminated by signal 6: Aborted
+```
+
+L'index BM25 de mots-clés sur `private_knowledge.chunks` contient une page qui n'a jamais été initialisée, et c'est un arrêt en mode crash du conteneur de base qui en laisse une derrière lui : le serveur étend le fichier d'index pour une écriture en cours, `SIGKILL` arrive avant que la page soit écrite, et la récupération après crash n'a aucun WAL à rejouer pour elle. Les images `tale-db` jusqu'à v0.5.7 arrêtaient Postgres avec `SIGTERM`, que Postgres lit comme un arrêt *smart* — il attend la fin de chaque session client. Un client hors compose qui garde une connexion (un backend sur l'hôte, un `psql` ouvert) a poussé l'arrêt au-delà du délai de grâce, Docker a tué le serveur, et le démarrage suivant a tourné en récupération après crash. Les tables et index ordinaires y survivent ; `pg_search` tombe sur la page à zéro à sa prochaine écriture et panique, et Postgres redémarre pour récupérer — à chaque téléversement.
+
+Confirme que l'index est le coupable avant de réparer quoi que ce soit. Ouvre une session sur la base du corpus — les deux requêtes ne font que lire :
+
+```bash
+docker compose exec knowledge-db psql -U tale -d tale_knowledge
+```
+
+```sql
+select * from pdb.verify_index('private_knowledge.idx_pk_chunks_bm25');
+```
+
+Un index sain passe chaque vérification (`passed = t`) ; un index abîmé échoue sur `segment_metadata_valid` ou ne se lit pas du tout. Pour voir la page elle-même, `pageinspect` affiche l'en-tête de la dernière page de l'index — `0 | 0 | 0` est la page jamais initialisée, une page saine affiche `24 | 8184 | 8184` :
+
+```sql
+create extension if not exists pageinspect;
+select lower, upper, special
+from page_header(get_raw_page('private_knowledge.idx_pk_chunks_bm25',
+  (pg_relation_size('private_knowledge.idx_pk_chunks_bm25') / 8192 - 1)::int));
+```
+
+Puis reconstruis l'index. Il dérive de `private_knowledge.chunks`, donc rien n'est perdu et rien n'est à re-téléverser :
+
+```sql
+REINDEX INDEX private_knowledge.idx_pk_chunks_bm25;
+```
+
+En option, reconstruis aussi l'index vectoriel (il existe dès que le premier embedding a été stocké) et récupère les pages de queue orphelines de la table :
+
+```sql
+REINDEX INDEX private_knowledge.idx_pk_chunks_embedding_hnsw;
+VACUUM private_knowledge.chunks;
+```
+
+L'ingestion reprend à la passe suivante du worker. Les images `tale-db` plus récentes que v0.5.7 arrêtent Postgres avec `SIGINT` — l'arrêt *fast*, qui déconnecte les clients, écrit un checkpoint et se termine en quelques secondes même avec des clients attachés — et `compose.yml` pose `stop_signal: SIGINT` pour qu'une image plus ancienne reçoive le même signal. Arrête la stack avec `docker compose stop` ou `docker compose down` et laisse courir le délai de grâce de 60 secondes (la CLI tale arrête les conteneurs de la même manière) ; `docker kill` et débrancher l'hôte sont les deux chemins qui finissent encore en arrêt en mode crash.
+
 ## Les réponses chat s'arrêtent au milieu du stream
 
 Le stream de tokens depuis le fournisseur amont est tombé — soit le fournisseur a rate-limité, soit la connexion a timeouté, soit le service du fournisseur est dégradé. Vérifie la page de statut du fournisseur d'abord ; puis regarde dans les logs plateforme :

--- a/services/db/Dockerfile
+++ b/services/db/Dockerfile
@@ -125,6 +125,20 @@ ENV DB_LOG_STATEMENT=none \
 
 EXPOSE 5432
 
+# Stop with SIGINT — PostgreSQL's *fast* shutdown (disconnect every client,
+# checkpoint, exit cleanly). The official postgres image and the ParadeDB base
+# built on it set exactly this (`docker inspect paradedb/paradedb:0.22.6-pg16`
+# → Config.StopSignal = SIGINT), but the `FROM scratch` stage above drops it
+# with the rest of the image config, leaving Docker's default SIGTERM. For
+# PostgreSQL SIGTERM is the *smart* shutdown, which waits for every client
+# session to end: a client outside compose (a host-side `bun dev` backend, a
+# psql shell) keeps its pooled sessions open, the stop never completes, and
+# Docker SIGKILLs the server once the grace period runs out — turning every
+# orderly stop into a crash recovery. One such kill left a never-initialised
+# tail page in the knowledge corpus's BM25 index, and pg_search then PANICked
+# on every write. compose.yml mirrors this as `stop_signal: SIGINT`.
+STOPSIGNAL SIGINT
+
 HEALTHCHECK --interval=10s --timeout=5s --start-period=90s --retries=10 \
     CMD pg_isready -U ${DB_USER:-tale} -d ${DB_NAME:-tale} && test -f /tmp/.db_ready || exit 1
 

--- a/tools/cli/src/lib/compose/services/compose-parity.test.ts
+++ b/tools/cli/src/lib/compose/services/compose-parity.test.ts
@@ -19,6 +19,7 @@ import {
   createBackendApiService,
   createBackendWorkerService,
 } from './create-backend-services';
+import { createDbService } from './create-db-service';
 import { createObjectStorageService } from './create-object-storage-service';
 
 // Guards the class of "works in dev, silently broken in `tale deploy`" bugs:
@@ -48,6 +49,7 @@ const compose = parse(readFileSync(composePath, 'utf8')) as {
       networks?: unknown;
       cap_add?: string[];
       stop_grace_period?: string;
+      stop_signal?: string;
       image?: string;
       build?: unknown;
       ports?: unknown[];
@@ -405,5 +407,32 @@ describe('service → image parity', () => {
     expect(compose.services['object-store']?.image).toBe(
       THIRD_PARTY_IMAGES['object-store'],
     );
+  });
+});
+
+describe('database fast-shutdown parity (SIGINT)', () => {
+  // The tale-db runtime stage is `FROM scratch`, which drops the upstream
+  // postgres image's STOPSIGNAL; without it Docker's SIGTERM is Postgres'
+  // *smart* shutdown, which waits for every client session and gets SIGKILLed
+  // after the grace period whenever a host-side client holds a connection.
+  // That crash-mode stop left a never-initialised page in pg_search's BM25
+  // index (PANIC on every knowledge insert). All three definition sites must
+  // agree on SIGINT — the *fast* shutdown that disconnects clients,
+  // checkpoints, and exits cleanly.
+  test('the tale-db image declares STOPSIGNAL SIGINT', () => {
+    const dockerfile = readFileSync(
+      resolve(repoRoot, 'services/db/Dockerfile'),
+      'utf8',
+    );
+    expect(dockerfile).toMatch(/^STOPSIGNAL SIGINT$/m);
+  });
+
+  test('compose.yml stops both Postgres services with SIGINT', () => {
+    expect(compose.services.db?.stop_signal).toBe('SIGINT');
+    expect(compose.services['knowledge-db']?.stop_signal).toBe('SIGINT');
+  });
+
+  test('CLI generator stops the db with SIGINT', () => {
+    expect(createDbService(config).stop_signal).toBe('SIGINT');
   });
 });

--- a/tools/cli/src/lib/compose/services/create-db-service.test.ts
+++ b/tools/cli/src/lib/compose/services/create-db-service.test.ts
@@ -61,3 +61,18 @@ describe('createDbService knowledge-db alias', () => {
     expect(networks.internal?.aliases).toContain('knowledge-db');
   });
 });
+
+describe('createDbService shutdown', () => {
+  // A crash-mode stop left a never-initialised page in pg_search's BM25 index
+  // (PANIC on every knowledge insert). Docker's default SIGTERM is Postgres'
+  // *smart* shutdown, which waits for every client session and gets SIGKILLed
+  // after the grace period whenever a client holds a connection; SIGINT is the
+  // *fast* shutdown that disconnects clients, checkpoints, and exits cleanly.
+  test('stops Postgres with SIGINT (fast shutdown), not the SIGTERM default', () => {
+    expect(createDbService(config).stop_signal).toBe('SIGINT');
+  });
+
+  test('keeps the checkpoint window before SIGKILL', () => {
+    expect(createDbService(config).stop_grace_period).toBe('60s');
+  });
+});

--- a/tools/cli/src/lib/compose/services/create-db-service.ts
+++ b/tools/cli/src/lib/compose/services/create-db-service.ts
@@ -6,6 +6,15 @@ export function createDbService(config: ServiceConfig): ComposeService {
   return {
     image: imageRef(config, 'db'),
     container_name: `${getProjectId()}-db`,
+    // SIGINT = PostgreSQL's *fast* shutdown (disconnect every client,
+    // checkpoint, exit cleanly). Docker's default SIGTERM is the *smart*
+    // shutdown, which waits for every client session to end — with a backend
+    // or psql holding connections it never finishes, and Docker SIGKILLs the
+    // server after the grace period: a crash-mode stop that left a
+    // never-initialised page in pg_search's BM25 index (PANIC on every write).
+    // The tale-db image sets the same STOPSIGNAL; this covers an older image.
+    // Keep in lockstep with the canonical compose.yml db service.
+    stop_signal: 'SIGINT',
     stop_grace_period: '60s',
     shm_size: '256mb',
     volumes: [

--- a/tools/cli/src/lib/compose/types.ts
+++ b/tools/cli/src/lib/compose/types.ts
@@ -23,6 +23,11 @@ export interface ComposeService {
   // (the object store's address + data dir) rather than a baked entrypoint.
   command?: string;
   stop_grace_period?: string;
+  // The signal `docker stop` sends before the grace period runs out. Postgres
+  // reads SIGINT as its fast shutdown; the SIGTERM default (smart shutdown)
+  // waits on every attached client and ends in SIGKILL — see
+  // create-db-service.ts.
+  stop_signal?: string;
   shm_size?: string;
   ports?: string[];
   volumes?: string[];


### PR DESCRIPTION
## Root cause

The `tale-db` image set **no `STOPSIGNAL`**. Its runtime stage is `FROM scratch` + `COPY --from=cleanup / /`, which drops every bit of image config the base carried — the ENV block was re-declared by hand, `STOPSIGNAL` was not. The base still has it: `docker inspect paradedb/paradedb:0.22.6-pg16 --format '{{.Config.StopSignal}}'` → `SIGINT` (inherited from the official postgres image); `ghcr.io/tale-project/tale/tale-db:latest` has no `StopSignal` key at all, and the running `tale-db` / `tale-knowledge-db` containers report an empty one.

Docker therefore stopped Postgres with `SIGTERM` = Postgres **smart** shutdown, which waits for every client session to end. Clients outside compose (the developer's host-side `bun dev` backend pool, any psql) keep sessions open, so the stop never completes and Docker `SIGKILL`s the server after `stop_grace_period` (or after dockerd's 15 s shutdown timeout on a host shutdown). Every orderly host shutdown became a crash: the knowledge-db log shows `database system was interrupted; automatic recovery in progress` at 3/3 restarts following clean systemd shutdowns (Aug 31 ×2, Sep 1). A crash-mode stop leaves never-initialised tail pages in relations extended by in-flight work; pg_search 0.22.6's BM25 index then PANICs on the next write (`corrupted page pointers: lower = 0, upper = 0, special = 0`), taking the server down on every knowledge insert.

## Fix

- `services/db/Dockerfile` — `STOPSIGNAL SIGINT` (fast shutdown: disconnect sessions, checkpoint, exit cleanly), with the why in a comment; matches the official postgres image and the ParadeDB base.
- `compose.yml` — `stop_signal: SIGINT` on `db` and `knowledge-db` (belt and braces for an older image); `stop_grace_period: 60s` kept.
- `tools/cli/src/lib/compose/services/create-db-service.ts` + `types.ts` — the `tale deploy` generator emits `stop_signal: 'SIGINT'` on the db service (`ComposeService.stop_signal?`).
- Tests — `create-db-service.test.ts` pins the generator; `compose-parity.test.ts` pins all three definition sites (Dockerfile `STOPSIGNAL SIGINT`, compose.yml `db` + `knowledge-db`, CLI generator).
- Docs — `docs/{en,de,fr}/self-hosted/operate/observability/troubleshooting.md`: new symptom-first entry *Knowledge database restarts on every upload* (PANIC line + where the server log file lives, cause, read-only diagnosis via `pdb.verify_index` / pageinspect `page_header`, repair via `REINDEX INDEX private_knowledge.idx_pk_chunks_bm25` — derived data, no loss — optional HNSW reindex + `VACUUM`, prevention).

Mirrored / found absent: `compose.dev.yml`, `compose.test.yml`, `compose.test.mock.yml` only layer env/ports onto `compose.yml`'s `db`/`knowledge-db` (nothing to mirror); `compose.web.yml` mentions the services in a comment only; there are **no Helm/k8s manifests for the database** (`tools/cli/src/commands/deploy/` holds only `index.ts`; `services/sandbox/src/backend/kubernetes` is the sandbox session backend).

The new signal reaches the postmaster directly: the wrapper `exec`s the upstream entrypoint, which `exec`s `postgres` as PID 1 (verified: `/proc/1/cmdline` = `postgres -c …`). Existing deployments pick it up when the container is recreated (`docker compose up -d` after pulling, `tale update`).

## Evidence — real image built from this branch (`docker build -f services/db/Dockerfile .`)

`docker inspect tale-db-stop-test --format '{{.Config.StopSignal}}'` → `SIGINT`.

Both containers (`TALE_DB_ROLE=knowledge`, ready via `/tmp/.db_ready`) had a **host-side session held open** through the published port by the repo's own `postgres` (postgres.js) driver — `select pg_sleep(600)` — visible in `pg_stat_activity` before the stop.

| | this branch (`STOPSIGNAL SIGINT`) | shipped `tale-db:latest` (no StopSignal) |
| --- | --- | --- |
| `docker stop` | **1.48 s**, exit code **0** | `docker stop -t 15`: **15.35 s**, exit code **137** (SIGKILL) |
| server log | `received fast shutdown request` → `FATAL: terminating connection due to administrator command` (app=postgres.js) → `checkpoint complete` → **`database system is shut down`** | `received smart shutdown request` — then nothing until the kill |
| next start | **`database system was shut down at 2026-09-04 06:57:51 GMT`** | `database system was interrupted; last known up at 2026-09-04 06:55:25 GMT` / **`database system was not properly shut down; automatic recovery in progress`** / `redo starts at 0/231D158` |
| held client | `terminating connection due to administrator command` (57P01) after 0.5 s | `CONNECTION_CLOSED` after 17.1 s |

```text
# this branch
06:57:49 [1]   LOG:  received fast shutdown request
06:57:49 [318] user=tale,db=tale,app=postgres.js FATAL:  terminating connection due to administrator command
06:57:49 [93]  LOG:  checkpoint starting: shutdown immediate
06:57:51 [93]  LOG:  checkpoint complete: wrote 3546 buffers (10.8%) ...
06:57:51 [1]   LOG:  database system is shut down
06:58:08 [39]  LOG:  database system was shut down at 2026-09-04 06:57:51 GMT

# shipped image
06:57:51 [1]   LOG:  received smart shutdown request
                     (SIGKILL at ~06:58:06 — exit 137)
06:58:08 [39]  LOG:  database system was interrupted; last known up at 2026-09-04 06:55:25 GMT
06:58:08 [39]  LOG:  database system was not properly shut down; automatic recovery in progress
06:58:08 [39]  LOG:  redo starts at 0/231D158
```

The runbook's SQL was validated on the fresh schema in the same container: `pdb.verify_index('private_knowledge.idx_pk_chunks_bm25')` returns the four checks, `pageinspect`'s `page_header` on the tail page reads `24 | 8184 | 8184` when healthy, `REINDEX INDEX … idx_pk_chunks_bm25` and `VACUUM private_knowledge.chunks` run; `idx_pk_chunks_embedding_hnsw` exists only after the first embedding (lazy `create_chunks_hnsw_index()`), so the runbook marks that reindex optional. Note for readers: the server log is a **file** (`logging_collector = on`, `/var/lib/postgresql/data/log/`) — `docker compose logs` never shows the PANIC; the runbook says so.

Throwaway containers and the test image were removed; the running dev containers were not touched.

## Gates

- `bash -n services/db/docker-entrypoint.sh` (untouched, re-checked after rebase) — OK
- `docker compose -f compose.yml config -q` — OK (renders `stop_signal: SIGINT` on both services)
- `bun test src/lib/compose` (tools/cli) — 54 pass / 0 fail (5 new)
- `bun run --filter @tale/cli lint` — exit 0
- `bun run --filter @tale/docs test` — 30 files / 194 tests pass; `bun run --filter @tale/docs lint` — exit 0
- `bunx oxfmt --check` on touched files — clean
- `bunx knip` — exit 0 (one pre-existing hint unrelated to this change)
- `git ls-tree -r --name-only HEAD | grep node_modules` — nothing
