### PR TITLE
fix(deps): patch the fast-uri and mysql2 high-severity advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -260,7 +260,7 @@
         "micromark-extension-gfm": "3.0.0",
         "mssql": "12.2.1",
         "mustache": "4.2.0",
-        "mysql2": "3.21.1",
+        "mysql2": "3.23.1",
         "nodemailer": "9.0.3",
         "openai": "6.42.0",
         "parse5": "8.0.0",
@@ -454,7 +454,7 @@
     "brace-expansion": "5.0.9",
     "defu": "6.1.6",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "follow-redirects": "1.16.0",
     "form-data": "4.0.6",
     "hono": "4.12.34",
@@ -2893,7 +2893,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -3625,7 +3625,7 @@
 
     "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
 
-    "mysql2": ["mysql2@3.21.1", "", { "dependencies": { "aws-ssl-profiles": "^1.1.2", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.2", "long": "^5.3.2", "lru.min": "^1.1.4", "named-placeholders": "^1.1.6", "sql-escaper": "^1.3.3" }, "peerDependencies": { "@types/node": ">= 8" } }, "sha512-vywGTUeqMwPQHJCWTWmmdIpcLfhU0UWIhOYbSWehqL+0Y/NTPGViM0wDtIgLuzqm5RqSygXKLJnxFGhQkhM1wg=="],
+    "mysql2": ["mysql2@3.23.1", "", { "dependencies": { "aws-ssl-profiles": "^1.1.2", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.2", "long": "^5.3.2", "lru.min": "^1.1.4", "named-placeholders": "^1.1.6", "sql-escaper": "^1.5.1" }, "peerDependencies": { "@types/node": ">= 8" } }, "sha512-tTuRnC7qCet2IOfSNMYZ5SwXuBnfvBPAcIA28P0gtruXyZlU1LMxA6uha32kYypoFgyYklMqhLWwt4laYwXR/Q=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "brace-expansion": "5.0.9",
     "defu": "6.1.6",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "follow-redirects": "1.16.0",
     "form-data": "4.0.6",
     "hono": "4.12.34",

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -112,7 +112,7 @@
     "micromark-extension-gfm": "3.0.0",
     "mssql": "12.2.1",
     "mustache": "4.2.0",
-    "mysql2": "3.21.1",
+    "mysql2": "3.23.1",
     "nodemailer": "9.0.3",
     "openai": "6.42.0",
     "parse5": "8.0.0",


### PR DESCRIPTION
## Why

The **Security** workflow fails on main — [run 33846607955](https://github.com/tale-project/tale/actions/runs/33846607955), job [Trivy filesystem scan](https://github.com/tale-project/tale/actions/runs/33846607955/job/100939785614), step *Trivy vulnerability gate (HIGH/CRITICAL)*:

```
bun.lock (bun)  Total: 5 (HIGH: 5, CRITICAL: 0)
fast-uri  CVE-2026-75899  HIGH  fixed  3.1.5  → 2.4.5, 3.1.6, 4.1.3  SSRF via repeated hostname percent-decoding
          CVE-2026-75931                                              Host confusion via skipped IDN canonicalization
          CVE-2026-75975                                              SSRF via malformed IPv6 normalization
          CVE-2026-76172                                              URI parsing flaw enables SSRF and redirects
mysql2    GHSA-3f6p-5ww8-9rcr  HIGH  fixed  3.21.1 → 3.22.0          Auth plugin downgrade to mysql_clear_password leaks plaintext credentials
```

The workflow has been red on main since 2026-09-03 (31a8329e9, 1ab399d96); the push trigger only fires when `bun.lock`, a `package.json`, a Dockerfile or the ignore file changes, which #3208's `services/db/Dockerfile` edit did. The advisories are not new to today's merges.

Renovate already opened one PR per advisory — #3152 (fast-uri → 3.1.6) and #3124 (mysql2 → 3.23.1) — but each of them still fails **both** security gates (Bun audit + Trivy) on the *other* advisory, so neither can land on its own. This PR carries both bumps in one change; renovate will close its two once main has the versions.

## What changed

- `package.json`: root pin `fast-uri` 3.1.5 → 3.1.6 (the pin exists to force the version ajv resolves — `bun why fast-uri`: reached only via `ajv@8.20.0` from `@tale/platform`, `@commitlint/*`, `@modelcontextprotocol/sdk`).
- `services/platform/package.json`: `mysql2` 3.21.1 → 3.23.1 (direct dep of the platform, referenced from `.tale/reference/convex/.../execute_mysql_query.ts` and an optional `better-auth` peer).
- `bun.lock`: the two resolution entries, taken verbatim from renovate's #3152 and #3124 (same integrity hashes). No other entry moves.

Not in scope: renovate's #3153 (qs), #3151 (@xmldom/xmldom), #2830 (dompurify) — the gate does not flag them (not HIGH/CRITICAL fixable production findings); they stay for a separate decision.

## Gates observed

- `git apply --check` of both renovate diffs on current main: clean; `bun install --frozen-lockfile --dry-run` (direct registry, proxies unset): exit 0.
- The Security workflow runs on this PR (it touches `bun.lock`/`package.json`), so its Bun audit and Trivy gates prove the fix before merge.
