### PR TITLE
ci: harden the bun audit gate (bun 1.4.0, registry retries, timeout)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,9 @@ jobs:
     name: Bun audit
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Budget for a degraded advisory registry: the report step is capped at 4
+    # minutes, the gate below retries hung or 5xx lookups up to three times.
+    timeout-minutes: 20
     permissions:
       contents: read
 
@@ -72,7 +74,9 @@ jobs:
 
       - name: Run bun audit (report)
         # Full advisory list for visibility; does not fail the build itself.
+        # Bounded so a hung registry request cannot eat the gate's time.
         continue-on-error: true
+        timeout-minutes: 4
         run: bun audit --prod | tee bun-audit.txt
 
       - name: Summary
@@ -85,10 +89,29 @@ jobs:
 
       - name: Gate on high/critical advisories
         # The blocking gate: fail on HIGH or CRITICAL production advisories.
-        # pipefail so tee does not mask a non-zero exit.
+        # pipefail so tee does not mask a non-zero exit. The advisory lookup is
+        # one POST to registry.npmjs.org's bulk endpoint, which on 2026-09-04
+        # alternated between 503s and minute-long hangs; a registry outage must
+        # not read as a finding, so a hung (exit 124) or transport-error attempt
+        # is retried up to three times, 30 s apart. A run that lists advisories
+        # exits 1 with no transport error line and keeps the red on the first
+        # pass, exactly as before.
         run: |
-          set -o pipefail
-          bun audit --prod --audit-level=high | tee bun-audit-gate.txt
+          set +e -o pipefail
+          for attempt in 1 2 3; do
+            timeout 240 bun audit --prod --audit-level=high 2>&1 | tee bun-audit-gate.txt
+            status=${PIPESTATUS[0]}
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$status" -ne 124 ] && ! grep -q -E '^error: (GET|POST) https?://' bun-audit-gate.txt; then
+              exit 1
+            fi
+            echo "advisory registry request failed or hung (attempt $attempt/3, exit $status); retrying in 30s"
+            sleep 30
+          done
+          echo "advisory registry unreachable after 3 attempts" >&2
+          exit 1
 
   # ---------------------------------------------------------------------------
   # Scan source tree for known CVEs in dependencies + misconfigurations + secrets.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,15 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: '1.3.12'
+          # Deliberately newer than the 1.3.12 the build jobs pin: before 1.4,
+          # `bun audit --prod` run from a workspace root reported workspace
+          # members' devDependencies as production (oven-sh/bun#26675, fixed
+          # in 1.4 by oven-sh/bun#38333). That made the gate below fail on
+          # @faker-js/faker 5.5.3, reachable only through the dev-only
+          # @stoplight/prism-http mock server (postman-collection pins it and
+          # no upstream release lifts the pin). 1.4.0 keeps reporting real
+          # production findings (verified against the fast-uri/mysql2 lock).
+          bun-version: '1.4.0'
 
       - name: Run bun audit (report)
         # Full advisory list for visibility; does not fail the build itself.


### PR DESCRIPTION
## Why

After #3210 cleared the Trivy gate, the **Security** workflow's *Bun audit* gate is the last red on main (and on PR #3210's own run, [job 100945897852](https://github.com/tale-project/tale/actions/runs/33847247883/job/100945897852)):

```
bun audit v1.3.12
@faker-js/faker  <=10.4.0
  workspace:@tale/platform › @stoplight/prism-http
  high: Faker: helpers.fake exploitable into arbitrary code execution - GHSA-qxc2-j82w-r537
1 vulnerabilities (1 high)
```

That copy is `@faker-js/faker@5.5.3`, pinned exactly by `postman-collection` → `@stoplight/http-spec` → `@stoplight/prism-http` (the mock server), which is a **devDependency** of `@tale/platform` and never in a shipped image. No upstream release lifts the pin: the latest `postman-collection` (5.3.1) still pins 5.5.3, and prism-http 5.16.0 still depends on http-spec ^7.1.0 → postman-collection ^4.1.3. Prism itself already resolves the patched 10.5.0.

The gate runs `bun audit --prod`, which is supposed to exclude exactly this. Before bun 1.4 it did not when run from a workspace root — [oven-sh/bun#26675](https://github.com/oven-sh/bun/issues/26675) ("bun audit --prod won't work in monorepos": workspace members' devDependencies reported as production), fixed in 1.4 by [oven-sh/bun#38333](https://github.com/oven-sh/bun/pull/38333). The job pins bun 1.3.12.

## What changed

`.github/workflows/security.yml`: the *Bun audit* job's `setup-bun` pin goes to `1.4.0`, with a comment saying why it is deliberately newer than the build jobs' 1.3.12. Nothing else — the Trivy job (which already classifies dev deps correctly) and the gate command are unchanged, and no `--ignore` is added.

## Verified locally (bun 1.4.0, direct registry)

- On the **pre-#3210** lock (68463514e): `bun audit --prod --audit-level=high` → `5 vulnerabilities (5 high)`: the four fast-uri advisories via `workspace:@tale/platform > ajv > fast-uri` and mysql2 via `workspace:@tale/platform > mysql2` and `> better-auth > mysql2` — i.e. 1.4.0 still sees workspace **production** findings, root and member alike. No faker.
- On the **current** lock (#3210 applied): `No vulnerabilities found (checked 1651 packages, 6 below --audit-level=high)`, exit 0.

This PR touches `security.yml`, so the Security workflow runs on it and the gate proves itself before merge.

## Also in this PR: survive a degraded advisory registry

The first CI run of this PR failed the same gate for a different reason — `error: POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk - 503` — and the re-run was **cancelled by the job's 5-minute budget** while the report step hung on that endpoint (probing it from here: alternating 1.5 s `200`s and 60 s hangs). A registry outage must not read as a finding, so the second commit:

- runs the gate up to 3 times, 30 s apart, each attempt capped at `timeout 240`; only a hung attempt (exit 124) or a transport-error line is retried — a run that lists advisories still exits 1 on the first pass (stderr now joins the tee'd log so the check can see the error line);
- caps the informational report step at 4 minutes (`continue-on-error` already) and raises the job budget from 5 to 20 minutes so the retries fit.

Simulated against a fake `bun` (flaky 503 → pass on 3rd try; hang → retried once then pass; permanent 503 → red after 3; real finding → red on the 1st call; clean → green on the 1st call): all five behave as intended.