### PR TITLE
test(platform): pin both Stop paths that doubled a round's text

### DIFF
--- a/services/platform/lib/chat/turn.test.ts
+++ b/services/platform/lib/chat/turn.test.ts
@@ -91,7 +91,17 @@ interface StoreCalls {
   readonly ops: string[];
 }
 
-function fakeStore(options: { cancelAfterStreamWrites?: number } = {}): {
+function fakeStore(
+  options: {
+    cancelAfterStreamWrites?: number;
+    /** Report the Stop on the tool-round boundary flush — a cancel that
+     *  landed while the round streamed its calls, before the tools ran. */
+    cancelOnToolBoundary?: boolean;
+    /** Report the Stop on the post-batch verdict read — a cancel that landed
+     *  while the tools were executing. */
+    cancelOnToolVerdict?: boolean;
+  } = {},
+): {
   store: TurnStore;
   calls: StoreCalls;
 } {
@@ -158,9 +168,20 @@ function fakeStore(options: { cancelAfterStreamWrites?: number } = {}): {
           text: update.text,
         });
         const cancelAt = options.cancelAfterStreamWrites;
+        // The tool-round boundary is the only write that is both flushed and
+        // empty; the post-batch verdict is the only empty, unflushed one.
+        const isEmpty = update.text === '';
+        const atBoundary =
+          options.cancelOnToolBoundary === true &&
+          isEmpty &&
+          update.flush === true;
+        const atVerdict =
+          options.cancelOnToolVerdict === true && isEmpty && !update.flush;
         return Promise.resolve({
           cancelRequested:
-            cancelAt !== undefined && calls.streamed.length >= cancelAt,
+            atBoundary ||
+            atVerdict ||
+            (cancelAt !== undefined && calls.streamed.length >= cancelAt),
         });
       },
       updateAssistantParts(update) {
@@ -1239,6 +1260,81 @@ describe('runTurn — the tool loop', () => {
     expect(outcome.status === 'completed' && outcome.paused).toBeUndefined();
     const parts = d.store.finalized[0]?.parts as MessagePart[];
     expect(parts.some((part) => part.type === 'human-input')).toBe(false);
+  });
+
+  // The two Stop paths #2962 named. Both break AFTER the round settles its
+  // text, so the finalize would append `streamed` a second time without the
+  // `roundSettled` guard. The pre-tool text has to be NON-EMPTY: a model that
+  // says nothing before calling passes straight through the bug, which is why
+  // it went unnoticed.
+  const introducingModel = (intro: string): ModelCall =>
+    async function* stream() {
+      yield { text: intro };
+      yield {
+        text: '',
+        toolCalls: [
+          { id: 'call_1', name: 'rag_search', input: { query: 'returns' } },
+        ],
+      };
+    };
+
+  const searchExecutor = (): ChatToolExecutor => ({
+    wireTools: [
+      {
+        name: 'rag_search',
+        description: 'Search.',
+        parameters: { type: 'object' },
+      },
+    ],
+    execute: () => Promise.resolve({ status: 'ok' }),
+  });
+
+  it('settles pre-tool text once when Stop lands before the tools run', async () => {
+    const intro = 'Let me look that up. ';
+    const { store, calls } = fakeStore({ cancelOnToolBoundary: true });
+    const executed: ToolCallRequest[] = [];
+    const executor = searchExecutor();
+    const d = deps({
+      model: introducingModel(intro),
+      tools: {
+        ...executor,
+        execute: (call) => {
+          executed.push(call);
+          return Promise.resolve({ status: 'ok' });
+        },
+      },
+      store,
+    });
+
+    await runTurn(request(), d.deps);
+
+    // The Stop landed at the boundary, so the tools never started...
+    expect(executed).toEqual([]);
+    // ...and the intro is recorded exactly once.
+    const parts = calls.finalized[0]?.parts as MessagePart[];
+    expect(parts.filter((part) => part.type === 'text')).toEqual([
+      { type: 'text', text: intro },
+    ]);
+  });
+
+  it('settles pre-tool text once when Stop lands while the tools run', async () => {
+    const intro = 'Searching now. ';
+    const { store, calls } = fakeStore({ cancelOnToolVerdict: true });
+    const d = deps({
+      model: introducingModel(intro),
+      tools: searchExecutor(),
+      store,
+    });
+
+    await runTurn(request(), d.deps);
+
+    const parts = calls.finalized[0]?.parts as MessagePart[];
+    expect(parts.filter((part) => part.type === 'text')).toEqual([
+      { type: 'text', text: intro },
+    ]);
+    // The batch that finished keeps its record — the Stop ends the loop, it
+    // does not erase the round.
+    expect(parts.some((part) => part.type === 'tool-result')).toBe(true);
   });
 
   it('deduplicates identical same-round calls, settling a result for every callId', async () => {


### PR DESCRIPTION
Closes #2962 — the bug itself is already fixed on main; this adds the coverage
for the two paths the issue actually named.

## What was and wasn't covered

`lib/chat/turn.ts` settles a round's text before running its tools, so any
`break` after that point leaves `streamed` pointing at what was just settled
and the finalize would append it twice. Three paths break there:

| Path | Test before this |
| --- | --- |
| pausing `ask_question` tool | `settles pre-question text exactly once` |
| Stop on the tool-round boundary flush, before the tools run | none |
| Stop on the post-batch verdict read, while they run | none |

The `roundSettled` flag and its per-iteration reset are both in place, and the
guard is shared, so the two Stop paths were correct — but only by sharing a
flag the pause test happens to cover. A new `break` placed before
`roundSettled = true` would reintroduce the bug on a path nothing asserts.

## The tests

Both stream **non-empty** text before the call. That is the whole reason this
went unnoticed: a model that says nothing before calling passes straight
through the bug. The issue says so, and the existing pause test carries the
same note about its own first attempt.

`fakeStore` gains two hooks so the Stop lands exactly where each path reads
it. No write-counting or index guessing is needed — the tool-round boundary is
the only `streamProgress` write that is both flushed and empty, and the
post-batch verdict the only empty unflushed one.

The boundary test also asserts the tools never executed, and the verdict test
that the finished batch keeps its `tool-result` — a Stop ends the loop, it does
not erase the round.

## Verification

| Mutation | Went red |
| --- | --- |
| drop the `!roundSettled` guard | all three: `settles pre-question text exactly once`, and both new tests |
| never reset `roundSettled` between rounds | `executes the calls, settles parts in order, and answers` |

Before this PR the first mutation failed one test. Now it fails three.

Test-only: `turn.test.ts` **46 passed**, `typecheck` 0 errors, `oxlint
--type-aware` clean, `oxfmt --check` clean.