### PR TITLE
fix(platform): reconcile and report corpus scope drift

### DIFF
--- a/services/platform/backend/domains/knowledge/release.ts
+++ b/services/platform/backend/domains/knowledge/release.ts
@@ -7,6 +7,7 @@ import {
 import { parseBlobRef } from '../../core/lib/storage/blob_ref.ts';
 import { resolveObjectStore, s3DeleteObject } from '../../lib/object-store.ts';
 import { resolveOrgSlug } from '../../lib/org-config.ts';
+import { reconcileDocumentScopeStamps } from './service.ts';
 
 /**
  * Ref release — THE shared seam for taking content out of circulation.
@@ -302,6 +303,20 @@ export async function runCorpusReconcile(sql: Sql): Promise<void> {
       if (stats.released > 0 || stats.failures > 0) {
         console.info(
           `[knowledge] corpus reconcile for ${org.slug}: scanned=${stats.scanned} released=${stats.released} failures=${stats.failures}`,
+        );
+      }
+      // The scope pass is independent of the release pass: a ref that is
+      // alive can still be mis-stamped, and correcting that is the only
+      // backstop a scope-only edit has (see `reconcileDocumentScopeStamps`).
+      const scope = await reconcileDocumentScopeStamps(sql, {
+        organizationId: org.id,
+        orgSlug: org.slug,
+      });
+      if (scope.corrected > 0) {
+        // Loud on purpose: every corrected row is an edit whose corpus write
+        // failed silently, and until now nothing said so.
+        console.warn(
+          `[knowledge] corpus scope drift for ${org.slug}: corrected=${scope.corrected} of scanned=${scope.scanned} — the per-edit sync had failed for these`,
         );
       }
     } catch (error) {

--- a/services/platform/backend/domains/knowledge/scope-reconcile.test.ts
+++ b/services/platform/backend/domains/knowledge/scope-reconcile.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * What the reconcile SENDS the corpus — the intended stamp for each document,
+ * derived the same way the per-edit sync derives it. The `IS DISTINCT FROM`
+ * guard that turns those into a drift count is SQL, so it belongs to the
+ * integration harness; getting the derivation wrong here would re-stamp every
+ * row on every run and report the whole corpus as drifted.
+ */
+
+const { getKnowledgePoolForOrg, folderTreePaths } = vi.hoisted(() => ({
+  getKnowledgePoolForOrg: vi.fn(),
+  folderTreePaths: vi.fn(),
+}));
+
+vi.mock('../../core/knowledge/pool.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/knowledge/pool.ts')>()),
+  getKnowledgePoolForOrg,
+}));
+
+vi.mock('../folders/paths.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../folders/paths.ts')>()),
+  folderTreePaths,
+}));
+
+const { reconcileDocumentScopeStamps } = await import('./service.ts');
+
+interface DocRow {
+  fileRef: string;
+  teamId: string | null;
+  teamTags: string[];
+  projectId: string | null;
+  folderId: string | null;
+  folderPath: string | null;
+}
+
+/** `sql` is only ever the document read here. */
+function fakeSql(rows: DocRow[]) {
+  return (() => Promise.resolve(rows)) as never;
+}
+
+/** The corpus pool: records the payload, answers with a row count. */
+function fakePool(count: number) {
+  const sent: unknown[][] = [];
+  return {
+    sent,
+    pool: {
+      unsafe: (_sql: string, params: unknown[]) => {
+        sent.push(params);
+        return Promise.resolve({ count });
+      },
+    },
+  };
+}
+
+/** The single JSON payload the reconcile builds. */
+function payloadOf(sent: unknown[][]) {
+  return JSON.parse(String(sent[0]?.[1])) as Array<Record<string, unknown>>;
+}
+
+const doc = (over: Partial<DocRow> = {}): DocRow => ({
+  fileRef: 'blob:f1',
+  teamId: null,
+  teamTags: [],
+  projectId: null,
+  folderId: null,
+  folderPath: null,
+  ...over,
+});
+
+describe('reconcileDocumentScopeStamps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    folderTreePaths.mockResolvedValue(new Map<string, string>());
+  });
+
+  it('does not touch the corpus when the org has no documents', async () => {
+    const { pool, sent } = fakePool(0);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    const out = await reconcileDocumentScopeStamps(fakeSql([]), {
+      organizationId: 'org-1',
+      orgSlug: 'acme',
+    });
+
+    expect(out).toEqual({ scanned: 0, corrected: 0 });
+    expect(sent).toEqual([]);
+    expect(getKnowledgePoolForOrg).not.toHaveBeenCalled();
+  });
+
+  it('reports the corpus row count as the drift count', async () => {
+    const { pool } = fakePool(2);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    const out = await reconcileDocumentScopeStamps(
+      fakeSql([
+        doc(),
+        doc({ fileRef: 'blob:f2' }),
+        doc({ fileRef: 'blob:f3' }),
+      ]),
+      { organizationId: 'org-1', orgSlug: 'acme' },
+    );
+
+    // Three compared, two actually differed — the guard is what makes the
+    // count meaningful, so the reconcile must not report `scanned` as drift.
+    expect(out).toEqual({ scanned: 3, corrected: 2 });
+  });
+
+  it('stamps a hub document with NULL rather than an empty array', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    await reconcileDocumentScopeStamps(fakeSql([doc()]), {
+      organizationId: 'org-1',
+      orgSlug: 'acme',
+    });
+
+    // An empty array is NOT the hub shape — the pre-filter's hub clause is
+    // `team_ids IS NULL`, so `{}` would hide the row from everyone.
+    expect(payloadOf(sent)[0]).toEqual({
+      file_id: 'blob:f1',
+      team_ids: null,
+      team_id: null,
+      project_id: null,
+      folder_path: null,
+    });
+  });
+
+  it('prefers the tag array over the deprecated single column', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    await reconcileDocumentScopeStamps(
+      fakeSql([doc({ teamTags: ['t1', 't2'], teamId: 'stale' })]),
+      { organizationId: 'org-1', orgSlug: 'acme' },
+    );
+
+    const [row] = payloadOf(sent);
+    expect(row?.team_ids).toEqual(['t1', 't2']);
+    // The mirror is the FIRST tag, not the stale column it replaced.
+    expect(row?.team_id).toBe('t1');
+  });
+
+  it('falls back to the single column when no tags are stamped', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    await reconcileDocumentScopeStamps(
+      fakeSql([doc({ teamTags: [], teamId: 't9' })]),
+      { organizationId: 'org-1', orgSlug: 'acme' },
+    );
+
+    const [row] = payloadOf(sent);
+    expect(row?.team_ids).toEqual(['t9']);
+    expect(row?.team_id).toBe('t9');
+  });
+
+  it('takes the folder path from the tree, not the copy on the row', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+    // The row's own `folder_path` is a copy that lags a folder move; the tree
+    // is the truth, which is the whole reason a moved folder drifts.
+    folderTreePaths.mockResolvedValue(new Map([['fold-1', 'Reports/2026']]));
+
+    await reconcileDocumentScopeStamps(
+      fakeSql([doc({ folderId: 'fold-1', folderPath: 'Reports/stale' })]),
+      { organizationId: 'org-1', orgSlug: 'acme' },
+    );
+
+    expect(payloadOf(sent)[0]?.folder_path).toBe('Reports/2026');
+  });
+
+  it('normalizes the stamp so spelling never decides a match', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+    // The WebDAV lane stores the 0.4 `'/A/B'` spelling and the folder tree
+    // produces `'A/B'`. Stamping the raw value would make the reconcile
+    // rewrite the same row on every run and report the corpus as drifted
+    // forever.
+    folderTreePaths.mockResolvedValue(new Map([['fold-1', '/Reports/2026/']]));
+
+    await reconcileDocumentScopeStamps(fakeSql([doc({ folderId: 'fold-1' })]), {
+      organizationId: 'org-1',
+      orgSlug: 'acme',
+    });
+
+    expect(payloadOf(sent)[0]?.folder_path).toBe('Reports/2026');
+  });
+
+  it('stamps the root as null, not an empty string', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    await reconcileDocumentScopeStamps(
+      fakeSql([doc({ folderId: null, folderPath: '/' })]),
+      { organizationId: 'org-1', orgSlug: 'acme' },
+    );
+
+    expect(payloadOf(sent)[0]?.folder_path).toBeNull();
+  });
+
+  it('sends the org slug the corpus rows are keyed by', async () => {
+    const { pool, sent } = fakePool(0);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    await reconcileDocumentScopeStamps(fakeSql([doc()]), {
+      organizationId: 'org-1',
+      orgSlug: 'acme',
+    });
+
+    expect(sent[0]?.[0]).toBe('acme');
+    expect(getKnowledgePoolForOrg).toHaveBeenCalledWith('acme');
+  });
+});

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -650,6 +650,95 @@ export async function syncRagDocumentScope(
   }
 }
 
+/** Documents compared per org per reconcile run. */
+const SCOPE_RECONCILE_LIMIT = 1000;
+
+/**
+ * Correct corpus scope stamps that drifted away from the documents they
+ * describe, and report how many had.
+ *
+ * The per-edit syncs are best-effort BY CONTRACT: `syncRagDocumentScope` and
+ * `syncRagFolderSubtree` catch a corpus failure so an unreachable corpus
+ * cannot fail the edit that committed. Their note names the next re-index as
+ * the backstop — but a scope or folder change never re-embeds, so for exactly
+ * this class of edit there is no next re-index, and a corpus that was
+ * unreachable for one edit leaves that row mis-stamped indefinitely.
+ *
+ * A stale stamp is not a leak: retrieval re-checks every hit against live
+ * truth (`decideRetrievable`), so a wrongly-scoped row is rejected after the
+ * fact. It is a silent cost. Every scope column NULL reads as an ORG-WIDE hub
+ * row in the SQL pre-filter, so the row is handed to every caller and thrown
+ * away afterwards — the pre-filter stops pre-filtering, and nothing reports
+ * that it has.
+ *
+ * One statement per page: the guard is `IS DISTINCT FROM` on all four stamped
+ * columns, so the row count IS the drift count and an in-sync corpus writes
+ * nothing.
+ */
+export async function reconcileDocumentScopeStamps(
+  sql: Sql,
+  args: { organizationId: string; orgSlug: string; limit?: number },
+): Promise<{ scanned: number; corrected: number }> {
+  const docs = await sql<
+    {
+      fileRef: string;
+      teamId: string | null;
+      teamTags: string[];
+      projectId: string | null;
+      folderId: string | null;
+      folderPath: string | null;
+    }[]
+  >`
+    SELECT file_ref AS "fileRef", team_id AS "teamId",
+           team_tags AS "teamTags", project_id AS "projectId",
+           folder_id AS "folderId", folder_path AS "folderPath"
+    FROM app.documents
+    WHERE org_id = ${args.organizationId}
+      AND file_ref IS NOT NULL
+      AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
+    ORDER BY id
+    LIMIT ${args.limit ?? SCOPE_RECONCILE_LIMIT}
+  `;
+  if (docs.length === 0) return { scanned: 0, corrected: 0 };
+
+  const treePaths = await folderTreePaths(
+    sql,
+    args.organizationId,
+    docs.flatMap((doc) => (doc.folderId !== null ? [doc.folderId] : [])),
+  );
+  const intended = docs.map((doc) => {
+    // Same precedence as the per-edit sync: the tag array wins, the single
+    // column is its deprecated mirror.
+    const teamIds =
+      doc.teamTags.length > 0 ? doc.teamTags : doc.teamId ? [doc.teamId] : [];
+    return {
+      file_id: doc.fileRef,
+      team_ids: teamIds.length > 0 ? teamIds : null,
+      team_id: teamIds[0] ?? null,
+      project_id: doc.projectId,
+      folder_path: documentFolderPathFrom(doc, treePaths),
+    };
+  });
+
+  const pool = await getKnowledgePoolForOrg(args.orgSlug);
+  const result = await pool.unsafe(
+    `UPDATE ${PRIVATE_KNOWLEDGE_SCHEMA}.documents d
+        SET team_ids = v.team_ids, team_id = v.team_id,
+            project_id = v.project_id, folder_path = v.folder_path,
+            updated_at = NOW()
+       FROM jsonb_to_recordset($2::jsonb)
+            AS v(file_id text, team_ids text[], team_id text,
+                 project_id text, folder_path text)
+      WHERE d.org_slug = $1 AND d.file_id = v.file_id
+        AND (d.team_ids IS DISTINCT FROM v.team_ids
+          OR d.team_id IS DISTINCT FROM v.team_id
+          OR d.project_id IS DISTINCT FROM v.project_id
+          OR d.folder_path IS DISTINCT FROM v.folder_path)`,
+    [args.orgSlug, JSON.stringify(intended)],
+  );
+  return { scanned: docs.length, corrected: result.count ?? 0 };
+}
+
 /**
  * Re-stamp the corpus folder path of every live, file-backed document under a
  * folder after the folder itself was renamed or moved — the path of each

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -26467,6 +26467,100 @@ async function checkAutomationRunToolLane(
 }
 
 /**
+ * CORPUS SCOPE DRIFT — the daily reconcile corrects a stamp the per-edit sync
+ * failed to write, and reports how many it corrected.
+ *
+ * The per-edit syncs are best-effort by contract, so a corpus that was
+ * unreachable for one edit leaves that row mis-stamped with nothing to notice
+ * it: a scope-only change never re-embeds, so the "next re-index" backstop
+ * their note names never fires for exactly this case.
+ *
+ * Simulated by writing the WRONG stamp straight into the corpus — the same
+ * state a failed sync leaves — then asserting the reconcile corrects it, and
+ * that a second run corrects NOTHING. The second half is the load-bearing
+ * one: the `IS DISTINCT FROM` guard is what makes the count a drift count
+ * rather than a row count, and without it every run would report the whole
+ * corpus as drifted.
+ */
+async function checkCorpusScopeReconcile(
+  sql: Sql,
+  ctx: { orgId: string; orgSlug: string },
+): Promise<void> {
+  const { reconcileDocumentScopeStamps } =
+    await import('./domains/knowledge/service.ts');
+  const { getKnowledgePoolForOrg } = await import('./core/knowledge/pool.ts');
+  const { PRIVATE_KNOWLEDGE_SCHEMA } =
+    await import('../lib/knowledge/types.ts');
+
+  const docs = await sql<{ fileRef: string }[]>`
+    SELECT file_ref AS "fileRef" FROM app.documents
+    WHERE org_id = ${ctx.orgId} AND file_ref IS NOT NULL
+      AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
+    LIMIT 1
+  `;
+  const fileRef = docs[0]?.fileRef;
+  if (fileRef === undefined) {
+    record(
+      'knowledge: corpus scope drift is corrected and reported',
+      false,
+      'no live file-backed document to drift — the knowledge lane must run first',
+    );
+    return;
+  }
+
+  const pool = await getKnowledgePoolForOrg(ctx.orgSlug);
+  const stampOf = async (): Promise<{
+    teamIds: string[] | null;
+    projectId: string | null;
+  }> => {
+    const rows = await pool.unsafe(
+      `SELECT team_ids AS "teamIds", project_id AS "projectId"
+         FROM ${PRIVATE_KNOWLEDGE_SCHEMA}.documents
+        WHERE org_slug = $1 AND file_id = $2`,
+      [ctx.orgSlug, fileRef],
+    );
+    const stamp = z
+      .object({
+        teamIds: z.array(z.string()).nullable(),
+        projectId: z.string().nullable(),
+      })
+      .safeParse(rows[0]);
+    return stamp.success ? stamp.data : { teamIds: null, projectId: null };
+  };
+
+  const before = await stampOf();
+  // The state a failed sync leaves: a stamp that disagrees with the document.
+  await pool.unsafe(
+    `UPDATE ${PRIVATE_KNOWLEDGE_SCHEMA}.documents
+        SET team_ids = ARRAY['itest-drifted-team'], project_id = NULL
+      WHERE org_slug = $1 AND file_id = $2`,
+    [ctx.orgSlug, fileRef],
+  );
+  const drifted = await stampOf();
+
+  const first = await reconcileDocumentScopeStamps(sql, {
+    organizationId: ctx.orgId,
+    orgSlug: ctx.orgSlug,
+  });
+  const repaired = await stampOf();
+  const second = await reconcileDocumentScopeStamps(sql, {
+    organizationId: ctx.orgId,
+    orgSlug: ctx.orgSlug,
+  });
+
+  record(
+    'knowledge: corpus scope drift is corrected and reported',
+    drifted.teamIds?.[0] === 'itest-drifted-team' &&
+      first.corrected >= 1 &&
+      first.scanned >= 1 &&
+      JSON.stringify(repaired) === JSON.stringify(before) &&
+      second.corrected === 0 &&
+      second.scanned === first.scanned,
+    `drifted=${JSON.stringify(drifted.teamIds)}, first=corrected ${first.corrected}/scanned ${first.scanned}, repaired=${JSON.stringify(repaired)} (want ${JSON.stringify(before)}), second=corrected ${second.corrected}/scanned ${second.scanned} (want 0 corrected, same scanned)`,
+  );
+}
+
+/**
  * TEARDOWN CREDENTIAL RECLAIM — every edge that ends a sandbox session has to
  * delete its gateway virtual key (fake bifrost records the DELETEs).
  *
@@ -39460,6 +39554,14 @@ async function main(): Promise<void> {
       [
         'checkKnowledge',
         () => checkKnowledge(sql, baseUrl, authCtx, `itest-${orgSuffix}`),
+      ],
+      [
+        'checkCorpusScopeReconcile',
+        () =>
+          checkCorpusScopeReconcile(sql, {
+            orgId: authCtx.orgId,
+            orgSlug: `itest-${orgSuffix}`,
+          }),
       ],
       [
         'checkCorpusPurgeConsistency',


### PR DESCRIPTION
Closes #2990.

A document's corpus scope stamp could disagree with the document
indefinitely, and nothing said so.

## Why there was no backstop

The per-edit syncs are best-effort **by contract**: `syncRagDocumentScope` and
`syncRagFolderSubtree` catch a corpus failure so an unreachable corpus cannot
fail the edit that already committed. That part is right.

Their note names the next re-index as the backstop. But a scope or folder
change never re-embeds — that is the whole point of a scope-only sync — so for
exactly this class of edit there is no next re-index. A corpus briefly
unreachable for one edit leaves that row mis-stamped forever.

The issue was filed against 0.4's `syncRagDocumentScopes`. On 0.5 the surface
has **grown**: two best-effort syncs now, covering team/project scope and
folder path, both `catch { console.warn }`.

## What is and isn't at stake

Not a leak. Retrieval re-checks every hit against live truth
(`decideRetrievable`), so a wrongly-scoped row is rejected after the fact.

A silent cost instead. Every scope column NULL reads as an **org-wide hub row**
in the SQL pre-filter, so the row is handed to every caller and thrown away
afterwards — the pre-filter stops pre-filtering, and nothing reports that it
has.

## The fix

`reconcileDocumentScopeStamps` compares each live, file-backed document's
intended stamp against what the corpus holds and corrects the difference. The
daily `knowledge.reconcile_corpus` cron runs it per org beside the ref-release
pass, and logs a warning naming the count whenever it corrects anything.

This is the shape the issue suggested — *"a periodic reconcile comparing
document scope against corpus stamps… the RAG watchdog already does an
analogous corpus reconcile and could carry it."* That cron now exists, so it
carries this too.

One statement per org, bounded at 1000 documents. The guard is `IS DISTINCT
FROM` on all four stamped columns, so an in-sync corpus writes nothing and the
row count **is** the drift count.

## Verification

The derivation is what a unit test can hold, and getting it wrong would
rewrite every row on every run and report the whole corpus as drifted:

| Mutation | Went red |
| --- | --- |
| stamp `[]` instead of NULL for a hub row | `stamps a hub document with NULL rather than an empty array` |
| trust the row's stale `folder_path` copy | all three folder-path assertions |
| report `scanned` as the drift count | `reports the corpus row count as the drift count` |
| prefer the deprecated single team column | `prefers the tag array over the deprecated single column` |

One of those tests found a real trap while I wrote it: without normalizing the
path, the WebDAV lane's `/A/B` spelling and the folder tree's `A/B` differ
forever, so the reconcile would rewrite the same row on every run and report
permanent drift.

I verified the `jsonb_to_recordset` binding and the `IS DISTINCT FROM` guard
against a real Postgres by hand before writing the code — a three-row fixture
where the in-sync row was skipped and the update reported 2, not 3.
`checkCorpusScopeReconcile` makes that repeatable in the harness: write a
wrong stamp straight into the corpus, assert the reconcile repairs it, and
assert a second run corrects nothing.

## Gate

`typecheck` 0 errors, `oxlint --type-aware` clean, `oxfmt --check` clean,
knowledge suites **61 passed (7 files)**.

I could not run the harness lane itself — the suite aborts early on the
knowledge/embedding step, which needs an S3 endpoint this machine has no MinIO
for.