### PR TITLE
fix(platform): let an upload outrank a sync backlog when indexing

### DIFF
--- a/services/platform/backend/domains/documents/replacement.ts
+++ b/services/platform/backend/domains/documents/replacement.ts
@@ -21,7 +21,7 @@ import {
   s3GetObjectBytes,
 } from '../../core/lib/storage/object_store.ts';
 import { toJson } from '../../db/sql.ts';
-import { addJobInTx } from '../../jobs/enqueue.ts';
+import { addJobInTx, PRIORITY_INTERACTIVE } from '../../jobs/enqueue.ts';
 import {
   buildObjectKey,
   resolveObjectStore,
@@ -770,7 +770,14 @@ async function bindReplacement(
     throw rejectionError('DOCUMENT_RECORD_VERSION_MISMATCH');
   }
   if (shouldIndex) {
-    await addJobInTx(tx, 'rag.index_file', { fileId: fileMetadataId });
+    await addJobInTx(
+      tx,
+      'rag.index_file',
+      { fileId: fileMetadataId },
+      {
+        priority: PRIORITY_INTERACTIVE,
+      },
+    );
   }
   if (previousFileRef !== null && previousFileRef !== intent.finalRef) {
     // The corpus is keyed by blob ref, so the replaced version's rows must

--- a/services/platform/backend/domains/documents/service.ts
+++ b/services/platform/backend/domains/documents/service.ts
@@ -10,7 +10,7 @@ import { authorizeRls } from '../../auth/access.ts';
 import { hasTeamAccess } from '../../core/lib/team_access.ts';
 import { checkProjectAccess } from '../../core/projects/access.ts';
 import { toJson } from '../../db/sql.ts';
-import { addJobInTx } from '../../jobs/enqueue.ts';
+import { addJobInTx, PRIORITY_INTERACTIVE } from '../../jobs/enqueue.ts';
 import {
   readGovernancePolicyForOrg,
   resolveOrgSlug,
@@ -482,7 +482,14 @@ export async function createDocumentFromUpload(
   // skip-flagged upload never enters the corpus (sticky on the file row).
   if (args.skipRagIndexing !== true) {
     await markRagQueued(tx, args.fileId);
-    await addJobInTx(tx, 'rag.index_file', { fileId: args.fileId });
+    await addJobInTx(
+      tx,
+      'rag.index_file',
+      { fileId: args.fileId },
+      {
+        priority: PRIORITY_INTERACTIVE,
+      },
+    );
   }
   return documentId;
 }
@@ -1002,7 +1009,14 @@ export async function createHubDocument(
       WHERE id = ${file.id}
     `;
     await markRagQueued(tx, file.id);
-    await addJobInTx(tx, 'rag.index_file', { fileId: file.id });
+    await addJobInTx(
+      tx,
+      'rag.index_file',
+      { fileId: file.id },
+      {
+        priority: PRIORITY_INTERACTIVE,
+      },
+    );
   }
   await createAuditLog(tx, {
     organizationId: auth.organizationId,
@@ -1483,7 +1497,14 @@ export async function retryRagIndexingForDocument(
   }
   await sql.begin(async (tx) => {
     await markRagQueued(tx, meta.id);
-    await addJobInTx(tx, 'rag.index_file', { fileId: meta.id });
+    await addJobInTx(
+      tx,
+      'rag.index_file',
+      { fileId: meta.id },
+      {
+        priority: PRIORITY_INTERACTIVE,
+      },
+    );
     await emitHintInTx(tx, {
       orgId: auth.organizationId,
       entity: 'document',

--- a/services/platform/backend/jobs/enqueue.ts
+++ b/services/platform/backend/jobs/enqueue.ts
@@ -11,10 +11,32 @@ export interface EnqueueOptions {
    * state (a duplicate send is dropped — pg-boss `singletonKey`).
    */
   singletonKey?: string;
+  /**
+   * Fetch order within a queue: pg-boss orders `priority DESC, created_on`,
+   * so a higher number is taken first and work of equal priority stays fair
+   * oldest-first. Omitted = 0.
+   */
   priority?: number;
 }
 
 let bossInstance: PgBoss | null = null;
+
+/**
+ * Indexing a file somebody is watching outranks indexing a backlog.
+ *
+ * `rag.index_file` is one queue for every source: a person's upload, a
+ * OneDrive sync, a crawl, a video link, an emailed attachment. A background
+ * source that mints rows faster than they drain used to put every interactive
+ * upload behind it — on 0.4 by holding a shared per-org cap of 3, and here by
+ * simply being ahead in a FIFO queue. Neither is a bug in the source; the
+ * queue was just undifferentiated.
+ *
+ * One level is enough. pg-boss keeps `created_on` as the tiebreak, so
+ * interactive work is still fair among itself, and the backlog still drains
+ * whenever no one is waiting — no reserved slot, no second queue, no starving
+ * the sources.
+ */
+export const PRIORITY_INTERACTIVE = 10;
 
 /**
  * Install the process-wide pg-boss instance the enqueue façade sends

--- a/services/platform/backend/jobs/rag-priority.test.ts
+++ b/services/platform/backend/jobs/rag-priority.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { PRIORITY_INTERACTIVE } from './enqueue.ts';
+
+/**
+ * `rag.index_file` is one queue for every source. pg-boss fetches
+ * `priority DESC, created_on`, so a background source that mints rows faster
+ * than they drain sits ahead of a person's upload for as long as it runs —
+ * the 0.5 shape of the starvation #2985 caused on 0.4 through a shared cap.
+ *
+ * The fix is one field per call site, which makes it exactly the kind of
+ * thing a new call site forgets. So the split is asserted from the source:
+ * the doors a person waits at carry the priority, and the background sources
+ * carry none — a background enqueue that took it would put a sync backlog
+ * level with an upload again.
+ */
+
+const BACKEND = new URL('..', import.meta.url).pathname;
+
+/** Files a person is waiting behind, by the door they came through. */
+const INTERACTIVE = new Set([
+  'domains/documents/service.ts', // upload, hub create, retry
+  'domains/documents/replacement.ts', // replacing a version
+  'rest/v1-core.ts', // the REST retry-indexing door
+]);
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return entry.isFile() && full.endsWith('.ts') && !full.includes('.test.')
+      ? [full]
+      : [];
+  });
+}
+
+/** Every `rag.index_file` enqueue, with whether it asks for priority. */
+const sites = walk(BACKEND).flatMap((file) => {
+  const source = readFileSync(file, 'utf8');
+  return [
+    ...source.matchAll(
+      /addJobInTx\(\s*tx,\s*'rag\.index_file'[\s\S]{0,200}?\);/g,
+    ),
+  ].map((match) => ({
+    file: file.slice(BACKEND.length),
+    prioritized: match[0].includes('PRIORITY_INTERACTIVE'),
+  }));
+});
+
+describe('rag.index_file fetch priority', () => {
+  // A pattern that stops matching would make every assertion below vacuous.
+  it('finds the enqueue sites', () => {
+    expect(sites.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('is a positive level, so it outranks an unset background job', () => {
+    // pg-boss defaults an unset priority to 0 and orders DESC.
+    expect(PRIORITY_INTERACTIVE).toBeGreaterThan(0);
+  });
+
+  it('prioritizes every door a person waits at', () => {
+    const missing = sites
+      .filter((site) => INTERACTIVE.has(site.file) && !site.prioritized)
+      .map((site) => site.file);
+
+    expect(
+      missing,
+      `interactive enqueue(s) with no priority — an upload here queues behind any sync backlog:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('leaves every background source unprioritized', () => {
+    const raised = sites
+      .filter((site) => !INTERACTIVE.has(site.file) && site.prioritized)
+      .map((site) => site.file);
+
+    expect(
+      raised,
+      `background enqueue(s) claiming interactive priority — this puts a backlog level with a person's upload again:\n  ${raised.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/services/platform/backend/rest/v1-core.ts
+++ b/services/platform/backend/rest/v1-core.ts
@@ -58,7 +58,7 @@ import {
 } from '../domains/products/service.ts';
 import { skillErrorResponse } from '../domains/skills/errors.ts';
 import { withSkillWriterLock } from '../domains/skills/writer-lock.ts';
-import { addJobInTx } from '../jobs/enqueue.ts';
+import { addJobInTx, PRIORITY_INTERACTIVE } from '../jobs/enqueue.ts';
 import { resolveOrgSlug } from '../lib/org-config.ts';
 import { checkOrganizationRateLimit } from '../lib/rate-limit.ts';
 import {
@@ -513,7 +513,14 @@ export function createCoreRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       }
       await deps.sql.begin(async (tx) => {
         await markRagQueued(tx, file.id);
-        await addJobInTx(tx, 'rag.index_file', { fileId: file.id });
+        await addJobInTx(
+          tx,
+          'rag.index_file',
+          { fileId: file.id },
+          {
+            priority: PRIORITY_INTERACTIVE,
+          },
+        );
       });
       return c.json({ status: 'indexing' });
     } catch (error) {


### PR DESCRIPTION
Closes #2987.

A background source that mints index jobs faster than they drain puts every
interactive upload behind it.

## The mechanism changed; the starvation didn't

The issue was filed against 0.4, where a shared per-org cap of 3 was held
permanently by whatever produced rows fastest — an integration minting one row
every 5 minutes stalled all user uploads on a deployment for 7 days (#2985).

That cap died with Convex. But `rag.index_file` is still **one queue for every
source**, and pg-boss fetches `ORDER BY priority DESC, created_on`, so a
backlog is simply ahead of the person. Same outcome, one less counter.

Neither is a bug in the source. The queue was undifferentiated, which is what
the issue actually said.

## The fix the issue suggested

> *"Prefer interactive work at promotion time… source-aware priority would fit
> there."*

pg-boss takes a `priority`, and `addJobInTx` already threaded it — no
production caller had used it. The five doors where a person is waiting for
**that** file now pass `PRIORITY_INTERACTIVE`:

| Interactive | Background (unchanged) |
| --- | --- |
| upload (`createDocumentFromUpload`) | OneDrive sync |
| hub create (`createHubDocument`) | knowledge entries (crawler) |
| retry indexing (app) | video links |
| retry indexing (REST door) | WebDAV folder-move fixup |
| version replacement (`bindReplacement`) | an agent writing a file |
| | post-rebuild requeue |

One level is enough. `created_on` stays the tiebreak, so interactive work is
still fair oldest-first among itself, and the backlog still drains whenever
nobody is waiting. No reserved slot, no second queue, no starved sources.

I confirmed the ordering from pg-boss's own plan — `ORDER BY ${priority ?
'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id`, with
`priority = true` its default — and that `startWorker` does not disable it.
Without that the field would have been inert.

## Verification

The fix is one field per call site, which makes it exactly what a new call site
forgets, so the split is asserted from the source rather than from the five
files I happened to edit.

| Mutation | Went red |
| --- | --- |
| drop the priority from the upload door | `prioritizes every door a person waits at` |
| give OneDrive sync the interactive priority | `leaves every background source unprioritized` |
| set the level to 0 | `is a positive level, so it outranks an unset background job` |

The second direction matters as much as the first: a background enqueue that
claimed the priority would put a sync backlog level with an upload again, and
nothing else would notice.

## Gate

`typecheck` 0 errors, `oxlint --type-aware` clean, `oxfmt --check` clean,
jobs + documents suites **49 passed (6 files)**.