### PR TITLE
fix(platform): re-queue the documents an embedding config unblocks

### DIFF
--- a/services/platform/backend/domains/knowledge/requeue-embedding.test.ts
+++ b/services/platform/backend/domains/knowledge/requeue-embedding.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RAG_ERROR_EMBEDDING_NOT_CONFIGURED } from '../../core/knowledge/rag_error_codes.ts';
+
+/**
+ * Configuring an embedding model has to fix the documents that failed for
+ * want of one. It used to fix nothing: each stayed `failed`, and the failure
+ * text told the operator to configure a model "then retry indexing" — one
+ * document at a time, by hand.
+ *
+ * What is asserted here is the SELECTION and the enqueue, because getting the
+ * selection wrong is the expensive mistake in both directions: too narrow and
+ * the stall persists, too wide and a document that failed on a secret or a
+ * PII block gets silently retried on every config save.
+ */
+
+const { addJobInTx } = vi.hoisted(() => ({ addJobInTx: vi.fn() }));
+
+vi.mock('../../jobs/enqueue.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../jobs/enqueue.ts')>()),
+  addJobInTx,
+}));
+
+const { requeueEmbeddingBlockedDocuments } = await import('./service.ts');
+
+/** Captures the UPDATE and answers with the rows it "returned". */
+function fakeSql(returned: Array<{ id: string }>) {
+  const statements: string[] = [];
+  const values: unknown[][] = [];
+  const tx = (strings: TemplateStringsArray, ...args: unknown[]) => {
+    statements.push(strings.join('?'));
+    values.push(args);
+    return Promise.resolve(returned);
+  };
+  return {
+    statements,
+    values,
+    sql: {
+      begin: (fn: (tx: unknown) => Promise<unknown>) => fn(tx),
+    } as never,
+  };
+}
+
+describe('requeueEmbeddingBlockedDocuments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addJobInTx.mockResolvedValue(undefined);
+  });
+
+  it('re-queues each blocked document and reports the count', async () => {
+    const { sql } = fakeSql([{ id: 'f1' }, { id: 'f2' }]);
+
+    const out = await requeueEmbeddingBlockedDocuments(sql, {
+      organizationId: 'org-1',
+    });
+
+    expect(out).toEqual({ requeued: 2 });
+    expect(
+      addJobInTx.mock.calls.map(([, name, payload]) => [name, payload]),
+    ).toEqual([
+      ['rag.index_file', { fileId: 'f1' }],
+      ['rag.index_file', { fileId: 'f2' }],
+    ]);
+  });
+
+  it('selects on the error CODE, not merely on failed status', async () => {
+    const { sql, statements, values } = fakeSql([]);
+
+    await requeueEmbeddingBlockedDocuments(sql, { organizationId: 'org-1' });
+
+    const [statement] = statements;
+    // Too wide would retry a secret-detected or PII-blocked document on
+    // every save; too narrow leaves the stall in place.
+    expect(statement).toContain('rag_error_code =');
+    expect(statement).toContain("rag_status = 'failed'");
+    expect(values[0]).toContain(RAG_ERROR_EMBEDDING_NOT_CONFIGURED);
+  });
+
+  it('scopes to the organization and respects the skip flag', async () => {
+    const { sql, statements, values } = fakeSql([]);
+
+    await requeueEmbeddingBlockedDocuments(sql, { organizationId: 'org-1' });
+
+    expect(statements[0]).toContain('org_id =');
+    expect(values[0]).toContain('org-1');
+    // A document deliberately excluded from indexing must stay excluded.
+    expect(statements[0]).toContain('skip_rag_indexing IS DISTINCT FROM true');
+  });
+
+  it('clears the stale failure so the UI stops showing it', async () => {
+    const { sql, statements } = fakeSql([]);
+
+    await requeueEmbeddingBlockedDocuments(sql, { organizationId: 'org-1' });
+
+    // Leaving the old error text on a now-queued row reads as "queued AND
+    // broken" in the document dialog.
+    expect(statements[0]).toContain('rag_error = NULL');
+    expect(statements[0]).toContain('rag_error_code = NULL');
+    expect(statements[0]).toContain("rag_status = 'queued'");
+  });
+
+  it('enqueues nothing when no document was blocked', async () => {
+    const { sql } = fakeSql([]);
+
+    const out = await requeueEmbeddingBlockedDocuments(sql, {
+      organizationId: 'org-1',
+    });
+
+    expect(out).toEqual({ requeued: 0 });
+    expect(addJobInTx).not.toHaveBeenCalled();
+  });
+
+  it('enqueues at default priority — a drain must not outrank an upload', async () => {
+    const { sql } = fakeSql([{ id: 'f1' }]);
+
+    await requeueEmbeddingBlockedDocuments(sql, { organizationId: 'org-1' });
+
+    // Fourth argument is the enqueue options; a priority here would put a
+    // whole backlog level with the file somebody is watching.
+    expect(addJobInTx.mock.calls[0]?.[3]).toBeUndefined();
+  });
+});

--- a/services/platform/backend/domains/knowledge/routes.ts
+++ b/services/platform/backend/domains/knowledge/routes.ts
@@ -26,6 +26,7 @@ import {
   fetchKnowledgeDocument,
   KnowledgeError,
   searchKnowledgeForOrg,
+  requeueEmbeddingBlockedDocuments,
 } from './service.ts';
 
 const searchSchema = z.object({
@@ -263,7 +264,21 @@ export function createKnowledgeRoutes(deps: {
     if (orgSlug === null) return c.json({ error: 'ORG_NOT_FOUND' }, 404);
     try {
       await writeKnowledgeEmbedding(orgSlug, body);
-      return c.json({ ok: true });
+      // Configuring a model is only half the fix: every document that failed
+      // while there was none stays `failed` until something re-queues it, and
+      // the failure text tells the operator to configure one "then retry
+      // indexing" — one document at a time, by hand. Do it for them, and say
+      // how many, so the page can report the recovery instead of looking as
+      // though nothing happened.
+      const { requeued } = await requeueEmbeddingBlockedDocuments(deps.sql, {
+        organizationId: c.get('orgId'),
+      });
+      if (requeued > 0) {
+        console.info(
+          `[knowledge] embedding configured for ${orgSlug}: re-queued ${requeued} document(s) that had failed for want of a model`,
+        );
+      }
+      return c.json({ ok: true, requeued });
     } catch (error) {
       return handleAdminError(c, error);
     }

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -33,6 +33,7 @@ import {
 } from '../../core/lib/knowledge/extraction/router.ts';
 import { parseBlobRef } from '../../core/lib/storage/blob_ref.ts';
 import { s3GetObjectBytes } from '../../core/lib/storage/object_store.ts';
+import { addJobInTx } from '../../jobs/enqueue.ts';
 import { createCtxShim, type ShimHandlers } from '../../lib/ctx-shim.ts';
 import { resolveObjectStore } from '../../lib/object-store.ts';
 import { readGovernancePolicy, resolveOrgSlug } from '../../lib/org-config.ts';
@@ -570,6 +571,51 @@ export async function indexUploadedFile(
     });
     throw error;
   }
+}
+
+/**
+ * Re-queue every document that failed for want of an embedding model.
+ *
+ * Configuring one did not previously fix anything: each document that failed
+ * while unconfigured stayed `failed`, and the only remedy was knowing to
+ * retry every one by hand. The failure text tells the operator to "set one
+ * under Settings → Data residency … then retry indexing" — following it
+ * exactly left them no better off, one document at a time.
+ *
+ * Scoped by `rag_error_code`, not by status: `embedding_not_configured` is
+ * stamped by exactly this cause, so a document that failed for any other
+ * reason (a secret, a PII block, an unreadable file) is left alone — its
+ * operator still has the per-document Retry.
+ *
+ * The flip and the enqueues share ONE transaction, so a crash between them
+ * cannot leave a row `queued` with no job to drain it — the state the
+ * watchdog would then have to guess about.
+ *
+ * Enqueued at DEFAULT priority: this is a backlog drain, not the one file
+ * somebody is watching, so it must not push ahead of a live upload.
+ */
+export async function requeueEmbeddingBlockedDocuments(
+  sql: Sql,
+  args: { organizationId: string },
+): Promise<{ requeued: number }> {
+  return await sql.begin(async (tx) => {
+    const rows = await tx<{ id: string }[]>`
+      UPDATE app.file_metadata SET
+        rag_status = 'queued',
+        rag_queued_at_ms = ${Date.now()},
+        rag_error = NULL,
+        rag_error_code = NULL
+      WHERE org_id = ${args.organizationId}
+        AND rag_status = 'failed'
+        AND rag_error_code = ${RAG_ERROR_EMBEDDING_NOT_CONFIGURED}
+        AND skip_rag_indexing IS DISTINCT FROM true
+      RETURNING id
+    `;
+    for (const row of rows) {
+      await addJobInTx(tx, 'rag.index_file', { fileId: row.id });
+    }
+    return { requeued: rows.length };
+  });
 }
 
 /** Enqueue-side marker so the UI shows queued state immediately. */


### PR DESCRIPTION
Part of #2988 — the third of its problems, *"fixing it does not fix it"*.

Configuring an embedding model fixed nothing for the documents that had
already failed for want of one. Each stayed `failed`, and its own failure text
told the operator to set a model "under Settings → Data residency … then retry
indexing" — following that instruction exactly left them no better off, one
document at a time.

`POST /embedding` now re-queues them and answers with the count, so the page
can report the recovery instead of looking as though nothing happened.

## Why the selection is by error code

`embedding_not_configured` is stamped by exactly this cause
(`knowledge/service.ts`, the `EmbeddingNotConfigured` arm), so the affected
rows are precisely identifiable. A document that failed on a detected secret,
a PII block, or an unreadable file is left alone — its operator still has the
per-document Retry.

Getting that wrong is expensive in both directions: too narrow leaves the
stall in place, too wide silently retries a blocked document on every config
save. Both directions are asserted.

The flip and the enqueues share one transaction, so a crash between them
cannot leave a row `queued` with no job to drain it — the state the watchdog
would then have to guess about.

Enqueued at **default** priority. This is a backlog drain, not the one file
somebody is watching, so it must not push ahead of a live upload. (That
distinction is #3217; this PR is consistent with it either way.)

## What was already fixed on main

Three of #2988's five asks are done, which is why this PR is only the third:

| Ask | State |
| --- | --- |
| the degraded path emits a `console.warn` with the real error | done — `assistant_tools.ts` logs it with the org id |
| the model gets a stable, non-leaking message | done — `KNOWLEDGE_UNAVAILABLE_FOR_MODEL` |
| every "Settings → Knowledge" corrected | done — the sandbox bridge now says there is no such page |
| **saving a config re-queues the blocked documents** | **this PR** |
| an org-level knowledge-health signal | still open |

## Verification

| Mutation | Went red |
| --- | --- |
| widen the selection to any failed row | `selects on the error CODE, not merely on failed status` |
| stop clearing the stale failure | `clears the stale failure so the UI stops showing it` |
| give the drain interactive priority | `enqueues at default priority — a drain must not outrank an upload` |
| drop the skip-flag guard | `scopes to the organization and respects the skip flag` |

Clearing the stale text matters for the reason the third mutation shows:
leaving the old error on a now-queued row reads as "queued **and** broken" in
the document dialog.

## Gate

`typecheck` 0 errors, `oxlint --type-aware` clean, `oxfmt --check` clean,
knowledge suites **58 passed (7 files)**.