### PR TITLE
feat(platform): let a provider declare whether it can embed

### DIFF
--- a/configs/platform/system/providers/anthropic/provider.yml
+++ b/configs/platform/system/providers/anthropic/provider.yml
@@ -9,6 +9,7 @@ apiFormat: anthropic
 baseUrl: https://api.anthropic.com
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/azure/provider.yml
+++ b/configs/platform/system/providers/azure/provider.yml
@@ -21,6 +21,7 @@ wireDialect: openai-modern
 endpointMode: per-credential
 catalog:
   source: none
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/deepseek/provider.yml
+++ b/configs/platform/system/providers/deepseek/provider.yml
@@ -9,6 +9,7 @@ apiFormat: openai
 baseUrl: https://api.deepseek.com
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/gemini/provider.yml
+++ b/configs/platform/system/providers/gemini/provider.yml
@@ -16,6 +16,7 @@ apiFormat: openai
 baseUrl: https://generativelanguage.googleapis.com/v1beta/openai
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/moonshot/provider.yml
+++ b/configs/platform/system/providers/moonshot/provider.yml
@@ -11,6 +11,7 @@ apiFormat: openai
 baseUrl: https://api.moonshot.ai/v1
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/nous-portal/provider.yml
+++ b/configs/platform/system/providers/nous-portal/provider.yml
@@ -13,6 +13,7 @@ apiFormat: openai
 baseUrl: https://portal.nousresearch.com
 catalog:
   source: none
+embedding: unknown
 auth:
   - method: subscription-key
     constraints:

--- a/configs/platform/system/providers/openai/provider.yml
+++ b/configs/platform/system/providers/openai/provider.yml
@@ -12,6 +12,7 @@ wireDialect: openai-modern
 baseUrl: https://api.openai.com/v1
 catalog:
   source: static
+embedding: supported
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/openrouter/provider.yml
+++ b/configs/platform/system/providers/openrouter/provider.yml
@@ -7,6 +7,7 @@ apiFormat: openai
 baseUrl: https://openrouter.ai/api/v1
 catalog:
   source: openrouter-api
+embedding: supported
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/qwen/provider.yml
+++ b/configs/platform/system/providers/qwen/provider.yml
@@ -12,6 +12,7 @@ apiFormat: openai
 baseUrl: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/vercel-ai-gateway/provider.yml
+++ b/configs/platform/system/providers/vercel-ai-gateway/provider.yml
@@ -7,6 +7,7 @@ apiFormat: openai
 baseUrl: https://ai-gateway.vercel.sh/v1
 catalog:
   source: models-endpoint
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/xai/provider.yml
+++ b/configs/platform/system/providers/xai/provider.yml
@@ -11,6 +11,7 @@ apiFormat: openai
 baseUrl: https://api.x.ai/v1
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/configs/platform/system/providers/zai/provider.yml
+++ b/configs/platform/system/providers/zai/provider.yml
@@ -25,6 +25,7 @@ apiFormat: openai
 baseUrl: https://api.z.ai/api/coding/paas/v4
 catalog:
   source: static
+embedding: unknown
 auth:
   - method: api-key
   - method: env

--- a/services/platform/lib/shared/providers/embedding_recommendations.test.ts
+++ b/services/platform/lib/shared/providers/embedding_recommendations.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { modelCatalogEntrySchema } from '../schemas/providers';
-import { pickEmbeddingRecommendations } from './embedding_recommendations';
+import {
+  pickEmbeddingRecommendations,
+  providerEmbeddingOptions,
+} from './embedding_recommendations';
 
 function entry(overrides: Record<string, unknown>) {
   return modelCatalogEntrySchema.parse({
@@ -84,5 +87,94 @@ describe('pickEmbeddingRecommendations', () => {
       { providerSlug: 'p', entries: [duplicate, duplicate] },
     ]);
     expect(picks).toHaveLength(1);
+  });
+});
+
+/**
+ * The declaration exists so the form can tell "cannot embed" from "no
+ * curated width here". Both readings used to render one empty state, and the
+ * fields stayed free either way — which is how a chat-only provider got
+ * chosen and failed later, at index time.
+ */
+describe('providerEmbeddingOptions', () => {
+  const openai = {
+    providerSlug: 'openai',
+    model: 'text-embedding-3-small',
+    dimensions: 1536,
+    recommended: true,
+  };
+
+  it('recommends only where a curated width actually ships', () => {
+    const [option] = providerEmbeddingOptions(
+      [{ slug: 'openai', embedding: 'supported' }],
+      [openai],
+    );
+
+    expect(option).toEqual({
+      providerSlug: 'openai',
+      support: 'supported',
+      recommendations: [openai],
+    });
+  });
+
+  it('reports a declared-unsupported provider as unsupported', () => {
+    const [option] = providerEmbeddingOptions(
+      [{ slug: 'anthropic', embedding: 'unsupported' }],
+      [],
+    );
+
+    expect(option?.support).toBe('unsupported');
+    expect(option?.recommendations).toEqual([]);
+  });
+
+  it('treats an unclassified provider as unknown, never unsupported', () => {
+    // A connector nobody has classified must not be refused — only left
+    // un-recommended, with the manual path open.
+    const [option] = providerEmbeddingOptions([{ slug: 'newcomer' }], []);
+
+    expect(option?.support).toBe('unknown');
+  });
+
+  it('downgrades supported to unknown when this deployment has no width', () => {
+    // The declaration says it can embed; the catalog here still offers no
+    // dimensions. "Enter them yourself" is the state to act on, not "cannot".
+    const [option] = providerEmbeddingOptions(
+      [{ slug: 'openai', embedding: 'supported' }],
+      [],
+    );
+
+    expect(option?.support).toBe('unknown');
+    expect(option?.recommendations).toEqual([]);
+  });
+
+  it('lets the declaration win over a contradictory recommendation', () => {
+    // A curated width can outlive the truth — a catalog entry kept after the
+    // provider dropped its embeddings API, say. The declaration is the
+    // authority, so the form must not offer a one-click pick that cannot
+    // work.
+    const [option] = providerEmbeddingOptions(
+      [{ slug: 'anthropic', embedding: 'unsupported' }],
+      [{ ...openai, providerSlug: 'anthropic' }],
+    );
+
+    expect(option?.support).toBe('unsupported');
+    expect(option?.recommendations).toEqual([]);
+  });
+
+  it('never attaches another provider’s recommendations', () => {
+    const options = providerEmbeddingOptions(
+      [
+        { slug: 'anthropic', embedding: 'unsupported' },
+        { slug: 'openai', embedding: 'supported' },
+      ],
+      [openai],
+    );
+
+    expect(options.map((option) => option.providerSlug)).toEqual([
+      'anthropic',
+      'openai',
+    ]);
+    expect(options[0]?.recommendations).toEqual([]);
+    expect(options[1]?.recommendations).toEqual([openai]);
   });
 });

--- a/services/platform/lib/shared/providers/embedding_recommendations.ts
+++ b/services/platform/lib/shared/providers/embedding_recommendations.ts
@@ -12,7 +12,10 @@
  * Pure data mapping; the caller resolves the catalogs.
  */
 
-import type { ModelCatalogEntry } from '../schemas/providers';
+import type {
+  ModelCatalogEntry,
+  ProviderEmbeddingSupport,
+} from '../schemas/providers';
 
 export interface EmbeddingRecommendation {
   readonly providerSlug: string;
@@ -52,4 +55,58 @@ export function pickEmbeddingRecommendations(
       a.providerSlug.localeCompare(b.providerSlug) ||
       a.model.localeCompare(b.model),
   );
+}
+
+/**
+ * What the form should say when a provider offers no recommendation.
+ *
+ * "No recommendation" used to mean two different things with one empty
+ * state: a provider that cannot embed at all, and one that can but ships no
+ * curated vector width here (every live catalog, since listings publish no
+ * width and a guessed one poisons a corpus invisibly). An operator could not
+ * tell which, and the fields stayed free either way — so choosing a
+ * chat-only provider failed later, at index time, as a runtime error.
+ *
+ * The provider connector now declares it, so the two are separable:
+ *  - `unsupported` → say so, and refuse the choice at the point of choosing.
+ *  - `unknown`     → invite the model and dimensions by hand.
+ *  - `supported`   → recommend.
+ */
+export interface ProviderEmbeddingOption {
+  readonly providerSlug: string;
+  readonly support: ProviderEmbeddingSupport;
+  /** Recommendations for this provider; empty unless `supported`. */
+  readonly recommendations: readonly EmbeddingRecommendation[];
+}
+
+/**
+ * Group the recommendations by provider and pair each with its declared
+ * support, so a caller never has to read "no entries" as an answer.
+ *
+ * A provider declaring `supported` with no curated entry is reported as
+ * `unknown`: the declaration says it can embed, but this deployment still has
+ * no width to offer, and that is the state the operator has to act on.
+ */
+export function providerEmbeddingOptions(
+  providers: ReadonlyArray<{
+    readonly slug: string;
+    readonly embedding?: ProviderEmbeddingSupport;
+  }>,
+  recommendations: readonly EmbeddingRecommendation[],
+): ProviderEmbeddingOption[] {
+  return providers
+    .map((provider) => {
+      const own = recommendations.filter(
+        (entry) => entry.providerSlug === provider.slug,
+      );
+      const declared = provider.embedding ?? 'unknown';
+      const support =
+        declared === 'supported' && own.length === 0 ? 'unknown' : declared;
+      return {
+        providerSlug: provider.slug,
+        support,
+        recommendations: support === 'supported' ? own : [],
+      };
+    })
+    .sort((a, b) => a.providerSlug.localeCompare(b.providerSlug));
 }

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -231,6 +231,39 @@ export type ProviderAuthMethod = z.infer<typeof providerAuthMethodSchema>;
 /** The auth-method discriminant values — the credential-side vocabulary. */
 export type ProviderAuthMethodName = ProviderAuthMethod['method'];
 
+/**
+ * Whether this provider can serve embeddings — declared, not inferred.
+ *
+ * It used to be inferred from whether the shipped model catalog happened to
+ * carry an `embedding`-tagged entry with curated `embedding.dimensions`. That
+ * conflates two different answers, and the embedding form could only show one
+ * empty state for both:
+ *
+ *  - `unsupported` — the provider serves no embeddings at all, so choosing it
+ *    is a mistake the form can catch at the point of choosing instead of at
+ *    index time. NOTHING declares this yet: it is a claim about a vendor's
+ *    API, and this repo holds no evidence either way. Whoever sets it should
+ *    cite the vendor's own docs in the same change.
+ *  - `unknown` — it may well embed, but no vector width is known here. Live
+ *    catalogs publish none, and a guessed width poisons a corpus invisibly,
+ *    so the operator has to supply the model and dimensions themselves.
+ *  - `supported` — a curated width ships with it, so the form can recommend.
+ *
+ * Absent reads as `unknown`, and so does every connector today except the two
+ * whose shipped catalog carries a curated width. That is the honest state:
+ * `supported` is established by the catalog, and the absence of an entry
+ * establishes nothing about the vendor — only that this deployment has no
+ * width to offer. A connector must never be refused for want of evidence.
+ */
+const providerEmbeddingSupportSchema = z.enum([
+  'supported',
+  'unsupported',
+  'unknown',
+]);
+export type ProviderEmbeddingSupport = z.infer<
+  typeof providerEmbeddingSupportSchema
+>;
+
 /** The shape of one `configs/platform/system/providers/<name>/provider.yml`. */
 export const providerDefinitionSchema = z
   .object({
@@ -250,6 +283,8 @@ export const providerDefinitionSchema = z
      */
     endpointMode: z.enum(['fixed', 'per-credential']).optional(),
     catalog: catalogSourceSchema,
+    /** See {@link providerEmbeddingSupportSchema}. Absent = `unknown`. */
+    embedding: providerEmbeddingSupportSchema.optional(),
     auth: z
       .array(providerAuthMethodSchema)
       .min(1)


### PR DESCRIPTION
Part of #2991 — the data model and the two empty states. The form copy is
follow-on work; this is what it needs in order to say anything true.

Nothing recorded whether a provider serves embeddings, so **Settings → Data
residency** accepted one that only routes chat completions and the failure
surfaced later, at index time, as a runtime error.

## Why inference wasn't enough

A provider was treated as embedding-capable if its shipped catalog happened to
carry an `embedding`-tagged model with curated `embedding.dimensions`. That
conflates two different answers behind one empty state:

- the provider **cannot** embed, and
- it **can**, but no vector width is known here.

Every live catalog is the second case — listings publish no width, and a
guessed one poisons a corpus invisibly, so withholding the recommendation is
right. But the operator couldn't tell which, and the fields stayed free either
way.

`provider.yml` now declares `embedding: supported | unsupported | unknown`,
independent of the model catalog, and `providerEmbeddingOptions` pairs each
provider with its declared support so a caller never reads "no entries" as an
answer.

## What is claimed, and what deliberately isn't

| Support | Providers | Established by |
| --- | --- | --- |
| `supported` | openai, openrouter | a curated `dimensions:` entry in their shipped catalog |
| `unknown` | the other ten | nothing — and that is the point |
| `unsupported` | none | needs a source this repo does not hold |

The absence of a catalog entry establishes nothing about a vendor's API. It
establishes that **this deployment has no width to offer**, which is exactly
what `unknown` says. Marking a provider `unsupported` because our catalog is
silent would be the same inference this change sets out to remove, one layer
down.

So nothing declares `unsupported` yet. The value exists because the
distinction is the whole point, and the tests exercise it — but setting it on
a real provider is a claim about that vendor's API. The schema note says so,
and asks whoever sets it to cite the vendor's docs in the same change.

Absent also reads as `unknown`, so a new connector is never refused for want
of evidence.

A provider declaring `supported` with no curated entry is reported as
`unknown` too: the declaration says it can embed, but there's still nothing to
offer, and "enter the model and dimensions yourself" is the state to act on.

## What this does and does not fix

It gives the form a truthful thing to read, and separates the two empty states
so "no recommendation" stops meaning two things.

It does **not** yet warn anyone off a provider that cannot embed, because no
provider is marked `unsupported`. That half of #2991 needs per-vendor evidence
plus the form copy, and stays open.

## Verification

| Mutation | Went red |
| --- | --- |
| default an unclassified provider to `unsupported` | `treats an unclassified provider as unknown, never unsupported` |
| keep `supported` with no curated width | `downgrades supported to unknown when this deployment has no width` |
| attach recommendations regardless of support | `lets the declaration win over a contradictory recommendation` |

The third survived my first pass: nothing covered a provider declared
`unsupported` that still carried a matching recommendation — a curated entry
outliving the truth — which is exactly what the guard defends against.

The `unsupported` branch is covered by synthetic providers in the tests, so it
stays tested without any real provider asserting it.

## Gate

`typecheck` 0 errors, `oxlint --type-aware` clean, `oxfmt --check` clean,
`lib/shared` suites **1020 passed (53 files)**.
