### PR TITLE
fix(platform): pass the corpus scope rows as one jsonb parameter

### DIFF
--- a/services/platform/backend/domains/knowledge/scope-reconcile.test.ts
+++ b/services/platform/backend/domains/knowledge/scope-reconcile.test.ts
@@ -41,12 +41,19 @@ function fakeSql(rows: DocRow[]) {
   return (() => Promise.resolve(rows)) as never;
 }
 
+/** What postgres.js's `sql.json()` hands back: a typed parameter. */
+interface JsonParameter {
+  type: 3802;
+  value: unknown;
+}
+
 /** The corpus pool: records the payload, answers with a row count. */
 function fakePool(count: number) {
   const sent: unknown[][] = [];
   return {
     sent,
     pool: {
+      json: (value: unknown): JsonParameter => ({ type: 3802, value }),
       unsafe: (_sql: string, params: unknown[]) => {
         sent.push(params);
         return Promise.resolve({ count });
@@ -55,9 +62,10 @@ function fakePool(count: number) {
   };
 }
 
-/** The single JSON payload the reconcile builds. */
+/** The single jsonb payload the reconcile builds. */
 function payloadOf(sent: unknown[][]) {
-  return JSON.parse(String(sent[0]?.[1])) as Array<Record<string, unknown>>;
+  const param = sent[0]?.[1] as JsonParameter;
+  return param.value as Array<Record<string, unknown>>;
 }
 
 const doc = (over: Partial<DocRow> = {}): DocRow => ({
@@ -106,6 +114,25 @@ describe('reconcileDocumentScopeStamps', () => {
     // Three compared, two actually differed — the guard is what makes the
     // count meaningful, so the reconcile must not report `scanned` as drift.
     expect(out).toEqual({ scanned: 3, corrected: 2 });
+  });
+
+  it('sends the rows as one jsonb parameter, never as a pre-serialized string', async () => {
+    const { pool, sent } = fakePool(1);
+    getKnowledgePoolForOrg.mockResolvedValue(pool);
+
+    await reconcileDocumentScopeStamps(fakeSql([doc()]), {
+      organizationId: 'org-1',
+      orgSlug: 'acme',
+    });
+
+    // postgres.js JSON-encodes a jsonb-typed parameter itself; a string here
+    // would arrive double-encoded and `jsonb_to_recordset` would refuse it
+    // ("cannot call jsonb_to_recordset on a non-array") — the defect that
+    // truncated the integration proof at the reconcile lane.
+    const param = sent[0]?.[1] as JsonParameter;
+    expect(typeof param).toBe('object');
+    expect(param.type).toBe(3802);
+    expect(Array.isArray(param.value)).toBe(true);
   });
 
   it('stamps a hub document with NULL rather than an empty array', async () => {

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -859,6 +859,10 @@ export async function reconcileDocumentScopeStamps(
   });
 
   const pool = await getKnowledgePoolForOrg(args.orgSlug);
+  // `pool.json` hands postgres.js the rows as ONE jsonb parameter. A
+  // pre-serialized string would be JSON-encoded a second time once the server
+  // reports the parameter as jsonb, and `jsonb_to_recordset` then refuses the
+  // resulting JSON string ("cannot call jsonb_to_recordset on a non-array").
   const result = await pool.unsafe(
     `UPDATE ${PRIVATE_KNOWLEDGE_SCHEMA}.documents d
         SET team_ids = v.team_ids, team_id = v.team_id,
@@ -872,7 +876,7 @@ export async function reconcileDocumentScopeStamps(
           OR d.team_id IS DISTINCT FROM v.team_id
           OR d.project_id IS DISTINCT FROM v.project_id
           OR d.folder_path IS DISTINCT FROM v.folder_path)`,
-    [args.orgSlug, JSON.stringify(intended)],
+    [args.orgSlug, pool.json(intended)],
   );
   return { scanned: docs.length, corrected: result.count ?? 0 };
 }


### PR DESCRIPTION
## Summary

`reconcileDocumentScopeStamps` (the daily corpus scope reconcile from #3216) passed a pre-serialized JSON string as the `$2::jsonb` parameter of `pool.unsafe`. postgres.js learns the parameter type from the server's description and JSON-encodes jsonb parameters itself, so the payload arrived double-encoded and Postgres refused it with `cannot call jsonb_to_recordset on a non-array`. Effects on main: the reconcile never corrected a drifted row, and the real-Postgres integration proof truncated at that lane (`RUN TRUNCATED at checkCorpusScopeReconcile`, 19/133 lanes).

## Change

- `services/platform/backend/domains/knowledge/service.ts`: hand the rows over as `pool.json(intended)`, the typed jsonb parameter the rest of the backend uses.
- `scope-reconcile.test.ts`: the fake pool models `sql.json`; a new case pins that the payload is a jsonb parameter carrying an array, never a string.

## Tests & gates observed

- `bunx vitest --run --project server backend/domains/knowledge/scope-reconcile.test.ts` → 10 passed
- `bunx tsc --noEmit` → 0 errors
- Integration proof: see the follow-up comment (run on this branch against a throwaway tale-db + MinIO).

Found while gating the backend deep-review fix campaign (every fixer's itest run stopped at this lane).
