### PR TITLE
fix(platform): scope gateway records per org and bound the sandbox doors

### DIFF
--- a/services/platform/backend/core/automations/agent_host.ts
+++ b/services/platform/backend/core/automations/agent_host.ts
@@ -334,8 +334,11 @@ export function automationAgentHost(
       // authenticates directly and knows nothing of gateway refs).
       const execModel =
         serving.lane === 'gateway'
-          ? resolveGatewayRouting(serving.providerSlug, serving.modelId)
-              .gatewayModel
+          ? resolveGatewayRouting(
+              organizationId,
+              serving.providerSlug,
+              serving.modelId,
+            ).gatewayModel
           : serving.modelId;
       // A text-only serving model still meets image inputs (scanned PDFs,
       // screenshots) — arm the harness vision polyfill with the org's vision
@@ -1078,8 +1081,11 @@ export async function startWorkflowAgentTurnImpl(
       // reading after the fact.
       const visionModelRef =
         visionRef !== null
-          ? resolveGatewayRouting(visionRef.providerSlug, visionRef.modelId)
-              .gatewayModel
+          ? resolveGatewayRouting(
+              args.organizationId,
+              visionRef.providerSlug,
+              visionRef.modelId,
+            ).gatewayModel
           : undefined;
       const auth = await mintWorkflowTurnAuth(ctx, {
         organizationId: args.organizationId,
@@ -1437,8 +1443,11 @@ export async function resumeWorkflowAgentTurnWithAnswerImpl(
       });
       const execModel =
         serving.lane === 'gateway'
-          ? resolveGatewayRouting(serving.providerSlug, serving.modelId)
-              .gatewayModel
+          ? resolveGatewayRouting(
+              args.organizationId,
+              serving.providerSlug,
+              serving.modelId,
+            ).gatewayModel
           : serving.modelId;
       keys.providerSlug = serving.providerSlug;
       keys.gatewayModel = execModel;
@@ -1455,8 +1464,11 @@ export async function resumeWorkflowAgentTurnWithAnswerImpl(
       // model read this turn's images.
       const visionModelRef =
         vision !== null
-          ? resolveGatewayRouting(vision.providerSlug, vision.modelId)
-              .gatewayModel
+          ? resolveGatewayRouting(
+              args.organizationId,
+              vision.providerSlug,
+              vision.modelId,
+            ).gatewayModel
           : undefined;
       const auth = await mintWorkflowTurnAuth(ctx, {
         organizationId: args.organizationId,

--- a/services/platform/backend/core/node_only/sandbox/gateway_provisioning.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/gateway_provisioning.test.ts
@@ -175,10 +175,11 @@ describe('provisionSessionGatewayKey', () => {
     expect(result.keyHash).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('provisions a custom provider under its per-model record so the mint can bind', async () => {
-    // deepseek is NOT a standard gateway provider, so it routes per model
-    // (`deepseek__deepseek-v4-flash`). The provision record must carry that
-    // exact name, or the mint's key lookup 404s and fails closed.
+  it("provisions a custom provider under the org's per-model record so the mint can bind", async () => {
+    // deepseek is NOT a standard gateway provider, so it routes per (org,
+    // model) (`org_1__deepseek__deepseek-v4-flash`). The provision record
+    // must carry that exact name, or the mint's key lookup 404s and fails
+    // closed.
     mockedResolve.mockResolvedValue(apiKeyResolution('sk-ds'));
     // Only `id` is read by buildProviderProvision; the rest of the catalog
     // shape is irrelevant here.
@@ -199,10 +200,43 @@ describe('provisionSessionGatewayKey', () => {
     expect(mockedResolve).toHaveBeenCalledTimes(1);
     expect(provisionProviders).toHaveBeenCalledWith('org_1', [
       expect.objectContaining({
-        name: 'deepseek__deepseek-v4-flash',
+        name: 'org_1__deepseek__deepseek-v4-flash',
         models: ['deepseek-v4-flash'],
         apiKey: 'sk-ds',
       }),
+    ]);
+  });
+
+  it('keeps two orgs sharing a custom connector name on separate gateway records', async () => {
+    // A custom connector is an org-defined file; two orgs may both ship an
+    // `internal.yml`-style connector under one name (here the shipped
+    // `deepseek` stands in) with different endpoints or wire formats. One
+    // shared record let the last org to provision rewrite base_url for
+    // both — org A's inference, carrying A's key, went to B's endpoint.
+    mockedResolve.mockResolvedValue(apiKeyResolution('sk-shared-name'));
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    mockedCatalog.mockResolvedValue([
+      { id: 'deepseek-v4-flash' },
+    ] as unknown as Awaited<ReturnType<typeof getProviderCatalog>>);
+    const models = [{ providerSlug: 'deepseek', modelId: 'deepseek-v4-flash' }];
+    await provisionSessionGatewayKey(fakeCtx(), {
+      organizationId: 'org_a',
+      sessionId: 'sess-a',
+      allowedModels: models,
+      budgetCents: 100,
+    });
+    await provisionSessionGatewayKey(fakeCtx(), {
+      organizationId: 'org_b',
+      sessionId: 'sess-b',
+      allowedModels: models,
+      budgetCents: 100,
+    });
+    const names = vi
+      .mocked(provisionProviders)
+      .mock.calls.map(([org, provisions]) => [org, provisions[0]?.name]);
+    expect(names).toEqual([
+      ['org_a', 'org_a__deepseek__deepseek-v4-flash'],
+      ['org_b', 'org_b__deepseek__deepseek-v4-flash'],
     ]);
   });
 

--- a/services/platform/backend/core/node_only/sandbox/gateway_provisioning.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/gateway_provisioning.test.ts
@@ -19,7 +19,7 @@ vi.mock('./llm_gateway_admin', async (importOriginal) => {
   const original = await importOriginal<typeof import('./llm_gateway_admin')>();
   return {
     ...original,
-    provisionProviders: vi.fn(async () => {}),
+    provisionProviders: vi.fn(async () => []),
     applyGatewayConfig: vi.fn(async () => {}),
     mintVirtualKey: vi.fn(async () => ({ key: 'sk-bf-t', keyId: 'vk-9' })),
   };
@@ -312,6 +312,60 @@ describe('provisionSessionGatewayKey', () => {
     expect(mockedResolve).not.toHaveBeenCalled();
     expect(provisionProviders).not.toHaveBeenCalled();
     expect(applyGatewayConfig).not.toHaveBeenCalled();
+    expect(mintVirtualKey).not.toHaveBeenCalled();
+  });
+
+  it("refuses to mint when a needed provider's gateway push failed (no stale-key mint)", async () => {
+    // provisionProviders never throws — it returns what did not land. The
+    // gateway still holds the org's key from the last successful push under
+    // the same stable name, so a mint here would bind the session to that
+    // pre-rotation secret: opaque upstream 401s after a key rotation, or
+    // spend on a credential the admin revoked.
+    mockedResolve.mockResolvedValue(apiKeyResolution());
+    vi.mocked(provisionProviders).mockResolvedValueOnce([
+      {
+        name: 'openrouter',
+        error: new Error(
+          'llm-gateway update key for openrouter/org org_1 failed (503): upstream unavailable',
+        ),
+      },
+    ]);
+    await expect(
+      provisionSessionGatewayKey(fakeCtx(), {
+        organizationId: 'org_1',
+        sessionId: 'sess-2c',
+        allowedModels: MODELS,
+        budgetCents: 100,
+      }),
+    ).rejects.toThrow(
+      'Provider "openrouter" cannot serve this session: its credential could not be pushed to the sandbox LLM gateway (llm-gateway update key for openrouter/org org_1 failed (503): upstream unavailable)',
+    );
+    expect(applyGatewayConfig).not.toHaveBeenCalled();
+    expect(mintVirtualKey).not.toHaveBeenCalled();
+  });
+
+  it("names the CONNECTOR, not the per-model record, when a custom provider's push failed", async () => {
+    mockedResolve.mockResolvedValue(apiKeyResolution('sk-ds'));
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    mockedCatalog.mockResolvedValue([
+      { id: 'deepseek-v4-flash' },
+    ] as unknown as Awaited<ReturnType<typeof getProviderCatalog>>);
+    vi.mocked(provisionProviders).mockResolvedValueOnce([
+      {
+        name: 'org_1__deepseek__deepseek-v4-flash',
+        error: new Error('llm-gateway create key failed (500)'),
+      },
+    ]);
+    await expect(
+      provisionSessionGatewayKey(fakeCtx(), {
+        organizationId: 'org_1',
+        sessionId: 'sess-2d',
+        allowedModels: [
+          { providerSlug: 'deepseek', modelId: 'deepseek-v4-flash' },
+        ],
+        budgetCents: 100,
+      }),
+    ).rejects.toThrow(/^Provider "deepseek" cannot serve this session/);
     expect(mintVirtualKey).not.toHaveBeenCalled();
   });
 

--- a/services/platform/backend/core/node_only/sandbox/gateway_provisioning.ts
+++ b/services/platform/backend/core/node_only/sandbox/gateway_provisioning.ts
@@ -7,8 +7,9 @@
  *
  *  1. resolves each involved provider's credential (explicit id, else the
  *     org default) and pushes its secret + model catalog into the gateway as
- *     the org's upstream key (best-effort per provider — the mint fails
- *     closed on anything that didn't land),
+ *     the org's upstream key (fail-CLOSED: a push that did not land refuses
+ *     the session — the gateway still holds the previous key by the same
+ *     name, and a mint would silently bind to that stale secret),
  *  2. hardens the gateway auth posture (fail-CLOSED: a gateway that cannot
  *     enforce virtual keys must not serve the session),
  *  3. mints one session-scoped virtual key bound to this org's upstream
@@ -216,7 +217,8 @@ export async function provisionSessionGatewayKey(
   }
 
   const provisions: ProviderProvision[] = [];
-  const provisionedNames = new Set<string>();
+  /** Gateway record name → the connector it serves, for the refusal. */
+  const slugByRecord = new Map<string, string>();
   for (const ref of args.allowedModels) {
     const base = baseBySlug.get(ref.providerSlug);
     if (!base) continue;
@@ -231,11 +233,25 @@ export async function provisionSessionGatewayKey(
           ).gatewayProvider,
           models: [ref.modelId],
         };
-    if (provisionedNames.has(provision.name)) continue;
-    provisionedNames.add(provision.name);
+    if (slugByRecord.has(provision.name)) continue;
+    slugByRecord.set(provision.name, ref.providerSlug);
     provisions.push(provision);
   }
-  await provisionProviders(args.organizationId, provisions);
+  const failures = await provisionProviders(args.organizationId, provisions);
+  // Every record here is one the mint below binds to, so a skipped push
+  // never helps: the gateway keeps the org's key from the last successful
+  // provision under the same stable name, and `mintVirtualKey` would resolve
+  // THAT — a rotated-away secret — and serve the session on it. Refuse with
+  // the connector's own name; the hosts post `message` as the reason the
+  // turn could not start.
+  const failed = failures[0];
+  if (failed !== undefined) {
+    const providerSlug = slugByRecord.get(failed.name) ?? failed.name;
+    throw new Error(
+      `Provider "${providerSlug}" cannot serve this session: its credential could not be pushed to the sandbox LLM gateway (${describeFailure(failed.error)})`,
+      { cause: failed.error },
+    );
+  }
 
   await applyGatewayConfig();
 

--- a/services/platform/backend/core/node_only/sandbox/gateway_provisioning.ts
+++ b/services/platform/backend/core/node_only/sandbox/gateway_provisioning.ts
@@ -185,11 +185,11 @@ export async function provisionSessionGatewayKey(
   // then expand into the EXACT gateway records the mint will bind to. A
   // standard gateway provider routes to one shared record (`<slug>/<model>`),
   // so its raw-slug provision matches as-is. A CUSTOM connector routes per
-  // model (`<slug>__<model>/<model>`, resolveGatewayRouting), so each of its
-  // models needs its own record carrying that name and just that model —
-  // otherwise the record the key lands under (`deepseek`) and the one the
-  // mint looks up (`deepseek__deepseek-v4-flash`) disagree and the mint fails
-  // closed.
+  // (org, model) (`<orgId>__<slug>__<model>/<model>`, resolveGatewayRouting),
+  // so each of its models needs its own record carrying that name and just
+  // that model — otherwise the record the key lands under (`deepseek`) and
+  // the one the mint looks up (`org_1__deepseek__deepseek-v4-flash`) disagree
+  // and the mint fails closed.
   const baseBySlug = new Map<string, ProviderProvision>();
   for (const providerSlug of new Set(
     args.allowedModels.map((ref) => ref.providerSlug),
@@ -224,8 +224,11 @@ export async function provisionSessionGatewayKey(
       ? base
       : {
           ...base,
-          name: resolveGatewayRouting(ref.providerSlug, ref.modelId)
-            .gatewayProvider,
+          name: resolveGatewayRouting(
+            args.organizationId,
+            ref.providerSlug,
+            ref.modelId,
+          ).gatewayProvider,
           models: [ref.modelId],
         };
     if (provisionedNames.has(provision.name)) continue;

--- a/services/platform/backend/core/node_only/sandbox/helpers/session_client.ts
+++ b/services/platform/backend/core/node_only/sandbox/helpers/session_client.ts
@@ -307,28 +307,6 @@ export async function sessionDestroyIfIdle(
   return { destroyed: parsed.destroyed === true, busy: parsed.busy === true };
 }
 
-/** PATCH /v1/sessions/:id/env — inject/rotate session env (gateway token,
- * connector creds). Returns the names runnerd rejected (deny-list). */
-export async function sessionEnvPatch(
-  sessionId: string,
-  patch: { set?: Record<string, string>; unset?: string[] },
-): Promise<string[]> {
-  const path = `/v1/sessions/${encodeURIComponent(sessionId)}/env`;
-  const bodyJson = JSON.stringify(patch);
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'PATCH',
-    headers: signedHeaders('PATCH', path, bodyJson),
-    body: bodyJson,
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!res.ok) {
-    throw new Error(`sandbox session env patch failed (${res.status})`);
-  }
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  const parsed = (await res.json()) as { denied?: string[] };
-  return parsed.denied ?? [];
-}
-
 /** PATCH /v1/sessions/:id/pin — toggle the spawner-side "always-on" reaper
  * exemption. Best-effort; the platform `sandboxSessions.pinned` row is the
  * durable truth (re-pushed on the next turn after a spawner restart). */
@@ -369,68 +347,6 @@ export async function sessionCancelExec(
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
   const parsed = (await res.json()) as { killed?: boolean };
   return parsed.killed === true;
-}
-
-/** Managed live-browser recycle result (restart preserves logins; reset wipes
- * the profile). `ready` = a CDP session attached again within the wait window. */
-export interface BrowserRecycleResult {
-  signalled: boolean;
-  ready: boolean;
-  tabs: number;
-}
-
-async function sessionBrowserControl(
-  sessionId: string,
-  action: 'restart' | 'reset' | 'close-pages',
-): Promise<Record<string, unknown>> {
-  const path = `/v1/sessions/${encodeURIComponent(sessionId)}/browser/${action}`;
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, ''),
-    body: '',
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!res.ok) {
-    throw new Error(`sandbox browser ${action} failed (${res.status})`);
-  }
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return (await res.json()) as Record<string, unknown>;
-}
-
-/** POST /v1/sessions/:id/browser/restart — recycle a wedged managed browser,
- * PRESERVING saved logins (lock hygiene + respawn). Used by recovery paths. */
-export async function sessionBrowserRestart(
-  sessionId: string,
-): Promise<BrowserRecycleResult> {
-  const b = await sessionBrowserControl(sessionId, 'restart');
-  return {
-    signalled: b.signalled === true,
-    ready: b.ready === true,
-    tabs: typeof b.tabs === 'number' ? b.tabs : 0,
-  };
-}
-
-/** POST /v1/sessions/:id/browser/reset — wipe the persistent profile and start
- * fresh. LOSES saved logins; the explicit user-driven "Reset browser". */
-export async function sessionBrowserReset(
-  sessionId: string,
-): Promise<BrowserRecycleResult> {
-  const b = await sessionBrowserControl(sessionId, 'reset');
-  return {
-    signalled: b.signalled === true,
-    ready: b.ready === true,
-    tabs: typeof b.tabs === 'number' ? b.tabs : 0,
-  };
-}
-
-/** POST /v1/sessions/:id/browser/close-pages — close all open tabs WITHOUT
- * clearing cookies (logins persist). The turn-stop cleanup so a runaway/hung
- * tab can't wedge the next turn's attach. */
-export async function sessionBrowserClosePages(
-  sessionId: string,
-): Promise<number> {
-  const b = await sessionBrowserControl(sessionId, 'close-pages');
-  return typeof b.closed === 'number' ? b.closed : 0;
 }
 
 /** Per-exec liveness, decoupled from `sessionIsAlive` (which is session-level). */

--- a/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.test.ts
@@ -559,7 +559,7 @@ describe('mintVirtualKey', () => {
     );
   });
 
-  it('binds a CUSTOM provider model to its per-model gateway record', async () => {
+  it("binds a CUSTOM provider model to THIS org's per-model gateway record", async () => {
     const calls: RecordedCall[] = [];
     vi.stubGlobal(
       'fetch',
@@ -583,7 +583,7 @@ describe('mintVirtualKey', () => {
                 keys: [
                   {
                     id: 'kid-C',
-                    name: 'tale-org_1-my-vllm__llama-3',
+                    name: 'tale-org_1-org_1__my-vllm__llama-3',
                     models: [],
                   },
                 ],
@@ -607,13 +607,18 @@ describe('mintVirtualKey', () => {
       organizationId: ORG,
       sessionId: 'sess-2',
     });
+    // The key lookup and the VK binding both name the ORG-scoped record —
+    // never a `my-vllm__llama-3` record another org could have rewritten.
+    expect(calls[0]?.url).toContain(
+      '/api/providers/org_1__my-vllm__llama-3/keys',
+    );
     const mint = calls.find((c) => c.url.includes('/governance/virtual-keys'));
     expect(mint?.body?.provider_configs).toEqual([
       {
-        provider: 'my-vllm__llama-3',
+        provider: 'org_1__my-vllm__llama-3',
         key_ids: ['kid-C'],
         allow_all_keys: false,
-        allowed_models: ['llama-3', 'my-vllm__llama-3/llama-3'],
+        allowed_models: ['llama-3', 'org_1__my-vllm__llama-3/llama-3'],
       },
     ]);
   });
@@ -754,22 +759,40 @@ describe('applyGatewayConfig', () => {
 });
 
 describe('resolveGatewayRouting', () => {
-  it('routes a standard connector to the shared native record', async () => {
+  it('routes a standard connector to the shared native record, whatever the org', async () => {
     const mod = await loadModule();
-    expect(mod.resolveGatewayRouting('anthropic', 'claude-fable-5')).toEqual({
+    expect(
+      mod.resolveGatewayRouting(ORG, 'anthropic', 'claude-fable-5'),
+    ).toEqual({
       gatewayProvider: 'anthropic',
       gatewayModel: 'anthropic/claude-fable-5',
     });
+    expect(
+      mod.resolveGatewayRouting('org_2', 'anthropic', 'claude-fable-5'),
+    ).toEqual(mod.resolveGatewayRouting(ORG, 'anthropic', 'claude-fable-5'));
   });
 
-  it('routes a custom connector to a per-model record with slashes sanitized out of the record name', async () => {
+  it("routes a custom connector to the org's own per-model record with slashes sanitized out of the record name", async () => {
     const mod = await loadModule();
     expect(
-      mod.resolveGatewayRouting('vercel-ai-gateway', 'alibaba/qwen-3-14b'),
+      mod.resolveGatewayRouting(ORG, 'vercel-ai-gateway', 'alibaba/qwen-3-14b'),
     ).toEqual({
-      gatewayProvider: 'vercel-ai-gateway__alibaba_qwen-3-14b',
-      gatewayModel: 'vercel-ai-gateway__alibaba_qwen-3-14b/alibaba/qwen-3-14b',
+      gatewayProvider: 'org_1__vercel-ai-gateway__alibaba_qwen-3-14b',
+      gatewayModel:
+        'org_1__vercel-ai-gateway__alibaba_qwen-3-14b/alibaba/qwen-3-14b',
     });
+  });
+
+  it('gives two orgs sharing a custom connector name two distinct records', async () => {
+    // Custom connectors are org-defined files: two orgs may name one
+    // `internal` with different base URLs or wire formats. A shared record
+    // let the last provision rewrite base_url for both orgs, so org A's key
+    // was sent to org B's endpoint.
+    const mod = await loadModule();
+    const a = mod.resolveGatewayRouting(ORG, 'internal', 'llama-4');
+    const b = mod.resolveGatewayRouting('org_2', 'internal', 'llama-4');
+    expect(a.gatewayProvider).not.toBe(b.gatewayProvider);
+    expect(a.gatewayModel).not.toBe(b.gatewayModel);
   });
 });
 

--- a/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.test.ts
@@ -189,13 +189,16 @@ describe('provisionProviders', () => {
     expect(w[1]?.body).toMatchObject({ value: 'key-B' });
   });
 
-  it('a failed write warns + leaves no memo (no throw), so the next provision retries', async () => {
+  it('a failed write warns, RETURNS the failure and leaves no memo (no throw), so the next provision retries', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     stubGateway({ keyExists: false, writeStatus: 500 });
     const mod = await loadModule();
-    await expect(
-      mod.provisionProviders(ORG, [PROVIDER]),
-    ).resolves.toBeUndefined();
+    const failures = await mod.provisionProviders(ORG, [PROVIDER]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.name).toBe('openrouter');
+    expect(String(failures[0]?.error)).toContain(
+      'llm-gateway provider config openrouter failed (500)',
+    );
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("provisioning provider 'openrouter'"),
       expect.anything(),
@@ -448,27 +451,12 @@ describe('provisionProviders', () => {
   });
 });
 
-describe('reprovisionProvider', () => {
-  it('creates the org key on a fresh process', async () => {
-    const calls = stubGateway({ keyExists: false });
-    const mod = await loadModule();
-    await mod.reprovisionProvider(ORG, PROVIDER);
-    expect(writes(calls)).toHaveLength(2);
-  });
-
-  it('throws on a failed write (eager push owns the degrade posture)', async () => {
-    stubGateway({ keyExists: false, writeStatus: 500 });
-    const mod = await loadModule();
-    await expect(mod.reprovisionProvider(ORG, PROVIDER)).rejects.toThrow(
-      'llm-gateway provider config openrouter failed (500)',
-    );
-  });
-
+describe('provisionProviders — management-plane auth', () => {
   it('sends Basic auth from SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD on EVERY management call', async () => {
     vi.stubEnv('SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD', 'pw-1');
     const calls = stubGateway({ keyExists: false });
     const mod = await loadModule();
-    await mod.reprovisionProvider(ORG, PROVIDER);
+    await expect(mod.provisionProviders(ORG, [PROVIDER])).resolves.toEqual([]);
     expect(calls.length).toBeGreaterThan(0);
     for (const call of calls) {
       expect(call.headers.authorization).toBe(basicFor('pw-1'));
@@ -480,29 +468,34 @@ describe('reprovisionProvider', () => {
     vi.stubEnv('LLM_GATEWAY_ADMIN_PASSWORD', 'pw-old');
     const calls = stubGateway({ keyExists: false });
     const mod = await loadModule();
-    await mod.reprovisionProvider(ORG, PROVIDER);
+    await mod.provisionProviders(ORG, [PROVIDER]);
     expect(calls[0]?.headers.authorization).toBe(basicFor('pw-old'));
   });
 
   it('fails closed — no management call at all — when no admin password is configured', async () => {
     // The gateway shares one port on the sandbox network for inference and
     // /api/*; an anonymous management plane would let sandboxed code mint its
-    // own keys. Unset (both names) must refuse BEFORE touching the gateway.
+    // own keys. Unset (both names) must refuse BEFORE touching the gateway;
+    // the refusal comes back as the provider's failure.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubEnv('SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD', undefined);
     vi.stubEnv('LLM_GATEWAY_ADMIN_PASSWORD', undefined);
     const calls = stubGateway({ keyExists: false });
     const mod = await loadModule();
-    await expect(mod.reprovisionProvider(ORG, PROVIDER)).rejects.toThrow(
+    const failures = await mod.provisionProviders(ORG, [PROVIDER]);
+    expect(String(failures[0]?.error)).toContain(
       'SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD is not set',
     );
     expect(calls).toHaveLength(0);
   });
 
   it('treats a blank password as unset (fails closed)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubEnv('SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD', '   ');
     const calls = stubGateway({ keyExists: false });
     const mod = await loadModule();
-    await expect(mod.reprovisionProvider(ORG, PROVIDER)).rejects.toThrow(
+    const failures = await mod.provisionProviders(ORG, [PROVIDER]);
+    expect(String(failures[0]?.error)).toContain(
       'SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD is not set',
     );
     expect(calls).toHaveLength(0);

--- a/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.ts
+++ b/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.ts
@@ -685,28 +685,19 @@ async function provisionOne(
   pushedProviderFingerprints.set(memoKey, providerFingerprint(p));
 }
 
-/**
- * Push one provider's current key + model list into the gateway for an org.
- * The credential-save actions call this so a key rotation reaches the
- * gateway immediately instead of at the next session create. Throws on
- * failure — callers own the degrade posture; the memo stays unset, so the
- * next session-create provision retries.
- */
-export async function reprovisionProvider(
-  organizationId: string,
-  p: ProviderProvision,
-): Promise<void> {
-  if (skipUnprovisionable(p)) return;
-  await provisionOne(organizationId, p);
+/** One provider the reconcile could not push: the gateway record name and
+ * the error the write failed with. */
+export interface ProviderProvisionFailure {
+  name: string;
+  error: unknown;
 }
 
 /**
  * Reconcile the org's providers into the gateway: ensure each provider's
- * record config + this org's upstream key. Called once per session create so
- * a fresh gateway (or a rotated key) is in place before the first mint; the
- * credential-save actions also push eagerly via reprovisionProvider, making
- * this the self-heal catch-up for pushes that failed (gateway down) or
- * happened in another process.
+ * record config + this org's upstream key. Called once per session create —
+ * this is the ONLY push (no credential-save action pushes eagerly), so a
+ * fresh gateway, a rotated key, or a push that failed in an earlier process
+ * (gateway down) all land here, before the first mint.
  *
  * Per-org keys coexist under one shared STANDARD provider record, so
  * multiple orgs holding distinct keys for the same provider never clobber
@@ -716,13 +707,18 @@ export async function reprovisionProvider(
  *
  * Per-provider resilient: a single provider's failure is logged and skipped
  * rather than aborting the whole reconcile — one misconfigured upstream must
- * not starve the others; a genuinely broken one surfaces via mintVirtualKey's
- * fail-closed error, not a silent gap here.
+ * not starve the others. Never throws; the failures are RETURNED so the
+ * caller decides. The session mint must treat any failure for a provider it
+ * needs as fatal: the gateway still holds that org's key from the last
+ * successful push, and `mintVirtualKey` resolves it by stable name — so a
+ * mint after a swallowed failure would bind a fresh virtual key to the
+ * pre-rotation secret and keep serving a credential the admin replaced.
  */
 export async function provisionProviders(
   organizationId: string,
   providers: ProviderProvision[],
-): Promise<void> {
+): Promise<ProviderProvisionFailure[]> {
+  const failures: ProviderProvisionFailure[] = [];
   for (const p of providers) {
     if (skipUnprovisionable(p)) continue;
     try {
@@ -732,8 +728,10 @@ export async function provisionProviders(
         `[llm-gateway] provisioning provider '${p.name}' for org '${organizationId}' failed (continuing):`,
         err,
       );
+      failures.push({ name: p.name, error: err });
     }
   }
+  return failures;
 }
 
 /**

--- a/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.ts
+++ b/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.ts
@@ -19,7 +19,9 @@
 // gateway; do not "simplify" them away without re-verifying):
 //   - upstream KEYS are a provider SUB-RESOURCE (`/api/providers/:p/keys`,
 //     CRUD), NOT embedded in the provider PUT (a keys[] there is ignored).
-//     Per-org keys coexist under one shared provider record.
+//     Per-org keys coexist under one shared STANDARD provider record; a
+//     custom connector gets one record per (org, model) — see
+//     customGatewayProviderName.
 //   - VK create takes `provider_configs[]` where each config carries
 //     `key_ids: [<id>]` (the WRITE field — sending `keys:[id]` is silently
 //     ignored, leaving an empty binding that denies everything) +
@@ -153,15 +155,26 @@ export function isStandardGatewayProvider(name: string): boolean {
   return LLM_GATEWAY_STANDARD_PROVIDERS.has(name);
 }
 
-/** Gateway provider name for a CUSTOM connector's per-model upstream. The
- * model's effective (baseUrl, apiFormat, key) lives on its own provider
+/** Gateway provider name for a CUSTOM connector's per-(org, model) upstream.
+ * The model's effective (baseUrl, apiFormat, key) lives on its own provider
  * record so model-level routing actually works — one gateway record holds
- * exactly one base_url + base_provider_type. `/` is sanitized out of the
- * NAME segment because the gateway routes on the FIRST `/`; the model id
- * keeps its own form (matched against the key catalog after the prefix is
- * stripped). */
-function customGatewayProviderName(slug: string, modelId: string): string {
-  return `${slug}__${modelId}`.replace(/\//g, '_');
+ * exactly one base_url + base_provider_type. The record is ORG-SCOPED: a
+ * custom connector is an org-defined file (`<orgSlug>/providers/*.yml`) and
+ * two orgs may define the same connector name with different endpoints or
+ * wire formats. A shared `<slug>__<model>` record let the last org to
+ * provision rewrite `base_url` for every org sharing the name — org A's
+ * key then went to org B's endpoint — and an apiFormat flip recreated the
+ * record and deleted the other orgs' keys. Only the gateway's STANDARD
+ * providers (whose URL + format the gateway owns) keep one shared record.
+ * `/` is sanitized out of the NAME segment because the gateway routes on the
+ * FIRST `/`; the model id keeps its own form (matched against the key
+ * catalog after the prefix is stripped). */
+function customGatewayProviderName(
+  organizationId: string,
+  slug: string,
+  modelId: string,
+): string {
+  return `${organizationId}__${slug}__${modelId}`.replace(/\//g, '_');
 }
 
 export interface GatewayRouting {
@@ -173,14 +186,15 @@ export interface GatewayRouting {
 }
 
 /**
- * Map a (connector, catalog model id) pair onto gateway routing. A standard
- * connector name routes to the shared native provider record
- * (`<name>/<modelId>`); any other connector routes to the model's own
- * per-model upstream record (`<name>__<modelId>/<modelId>`). Single source
- * of truth shared by the harness glue (model env), the mint (VK binding),
- * and the provisioner (record names) so they can never drift.
+ * Map an (org, connector, catalog model id) triple onto gateway routing. A
+ * standard connector name routes to the shared native provider record
+ * (`<name>/<modelId>`); any other connector routes to the org's own
+ * per-model upstream record (`<orgId>__<name>__<modelId>/<modelId>`). Single
+ * source of truth shared by the harness glue (model env), the mint (VK
+ * binding), and the provisioner (record names) so they can never drift.
  */
 export function resolveGatewayRouting(
+  organizationId: string,
   providerSlug: string,
   modelId: string,
 ): GatewayRouting {
@@ -190,7 +204,7 @@ export function resolveGatewayRouting(
       gatewayModel: `${providerSlug}/${modelId}`,
     };
   }
-  const name = customGatewayProviderName(providerSlug, modelId);
+  const name = customGatewayProviderName(organizationId, providerSlug, modelId);
   return { gatewayProvider: name, gatewayModel: `${name}/${modelId}` };
 }
 
@@ -232,12 +246,13 @@ export async function mintVirtualKey(
   args: MintVirtualKeyArgs,
 ): Promise<MintedVirtualKey> {
   // Group the allowed models by the GATEWAY provider record they route to
-  // (the shared record for standard connectors; per-model records for custom
-  // ones). Allow both the bare model id and the full gateway ref so the
+  // (the shared record for standard connectors; this org's per-model records
+  // for custom ones). Allow both the bare model id and the full gateway ref so the
   // allowlist matches however the requesting client spells the model.
   const byProvider = new Map<string, string[]>();
   for (const ref of args.allowedModels) {
     const { gatewayProvider, gatewayModel } = resolveGatewayRouting(
+      args.organizationId,
       ref.providerSlug,
       ref.modelId,
     );
@@ -693,9 +708,11 @@ export async function reprovisionProvider(
  * this the self-heal catch-up for pushes that failed (gateway down) or
  * happened in another process.
  *
- * Per-org keys coexist under one shared provider record, so multiple orgs
- * holding distinct keys for the same provider never clobber each other, and
- * each session VK binds to its own org's key (see mintVirtualKey).
+ * Per-org keys coexist under one shared STANDARD provider record, so
+ * multiple orgs holding distinct keys for the same provider never clobber
+ * each other, and each session VK binds to its own org's key (see
+ * mintVirtualKey). A CUSTOM connector's record is already org-scoped by name
+ * (resolveGatewayRouting), so its base_url / wire format are this org's own.
  *
  * Per-provider resilient: a single provider's failure is logged and skipped
  * rather than aborting the whole reconcile — one misconfigured upstream must

--- a/services/platform/backend/core/node_only/sandbox/session_exec.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/session_exec.test.ts
@@ -1,7 +1,8 @@
-// runStepsInSession's install semantics — pip/npm exit codes must fail the
-// run (INSTALL_FAILED) and installs get their own floored budget — plus the
-// harvest's per-file skip semantics. The session wire is mocked at the
-// session_client boundary, the same seam the crawler render tests use.
+// runStepsInSession's run semantics — the staged steps run from /agent/code
+// with the caller's timeout — plus the harvest's per-file skip semantics and
+// its fail-loud rule for an org whose bucket cannot be resolved. The session
+// wire is mocked at the session_client boundary, the same seam the crawler
+// render tests use.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -62,114 +63,12 @@ function callArg(call: number): {
   };
 }
 
-describe('runStepsInSession — install semantics', () => {
+describe('runStepsInSession — run semantics', () => {
   beforeEach(() => {
     drainSessionExecResilient.mockReset();
   });
 
-  it('runs a packages-only call to completed and surfaces installer stdout', async () => {
-    drainSessionExecResilient.mockResolvedValue(
-      execResult({
-        stdoutBase64: Buffer.from(
-          'Successfully installed pandas-2.2.1\n',
-        ).toString('base64'),
-      }),
-    );
-    const run = await runStepsInSession('sid', {
-      stepPaths: [],
-      packagesByLang: { python: ['pandas'] },
-    });
-    expect(run.status).toBe('completed');
-    expect(run.exitCode).toBe(0);
-    expect(run.errorCode).toBeUndefined();
-    expect(run.stdout).toContain('Successfully installed pandas-2.2.1');
-    expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
-    expect(callArg(0).command).toEqual([
-      'python3',
-      '-m',
-      'pip',
-      'install',
-      '--no-input',
-      'pandas',
-    ]);
-    // Installs run from the workspace root — /agent/code may not exist yet on
-    // a fresh session with nothing staged, and runnerd rejects a missing cwd.
-    expect(callArg(0).cwd).toBe('/agent');
-  });
-
-  it('fails the run when pip exits non-zero: INSTALL_FAILED, nothing else runs', async () => {
-    drainSessionExecResilient.mockResolvedValue(
-      execResult({
-        exitCode: 1,
-        stderrBase64: Buffer.from(
-          'ERROR: No matching distribution found for nope\n',
-        ).toString('base64'),
-      }),
-    );
-    const run = await runStepsInSession('sid', {
-      stepPaths: ['/agent/code/a.py'],
-      packagesByLang: { python: ['nope'], node: ['sharp'] },
-    });
-    expect(run.status).toBe('failed');
-    expect(run.errorCode).toBe('INSTALL_FAILED');
-    expect(run.errorMessage).toContain('pip install failed (exit 1)');
-    expect(run.stderr).toContain('No matching distribution');
-    // Short-circuit: neither the npm install nor the step ran.
-    expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
-  });
-
-  it('fails on npm after a clean pip and names the failing tool', async () => {
-    drainSessionExecResilient
-      .mockResolvedValueOnce(execResult())
-      .mockResolvedValueOnce(execResult({ exitCode: 127 }));
-    const run = await runStepsInSession('sid', {
-      stepPaths: [],
-      packagesByLang: { python: ['pandas'], node: ['sharp'] },
-    });
-    expect(run.status).toBe('failed');
-    expect(run.errorCode).toBe('INSTALL_FAILED');
-    expect(run.errorMessage).toContain('npm install failed (exit 127)');
-    expect(drainSessionExecResilient).toHaveBeenCalledTimes(2);
-  });
-
-  it('treats a non-completed install status as INSTALL_FAILED even with exit 0', async () => {
-    drainSessionExecResilient.mockResolvedValue(
-      execResult({ status: 'failed', errorCode: 'TIMEOUT' }),
-    );
-    const run = await runStepsInSession('sid', {
-      stepPaths: [],
-      packagesByLang: { python: ['torch'] },
-    });
-    expect(run.status).toBe('failed');
-    expect(run.errorCode).toBe('INSTALL_FAILED');
-    expect(run.errorMessage).toContain('TIMEOUT');
-  });
-
-  it('floors the install budget at 120s while the step keeps its own timeout', async () => {
-    drainSessionExecResilient.mockResolvedValue(execResult());
-    await runStepsInSession('sid', {
-      stepPaths: ['/agent/code/a.py'],
-      packagesByLang: { python: ['pandas'] },
-      timeoutMs: 30_000,
-    });
-    expect(callArg(0).timeoutMs).toBe(120_000);
-    expect(callArg(1).timeoutMs).toBe(30_000);
-    expect(callArg(1).command).toEqual(['python3', '/agent/code/a.py']);
-    expect(callArg(0).cwd).toBe('/agent');
-    expect(callArg(1).cwd).toBe('/agent/code');
-  });
-
-  it('keeps a caller-raised timeout for the install too, capped at 300s', async () => {
-    drainSessionExecResilient.mockResolvedValue(execResult());
-    await runStepsInSession('sid', {
-      stepPaths: [],
-      packagesByLang: { python: ['torch'] },
-      timeoutMs: 240_000,
-    });
-    expect(callArg(0).timeoutMs).toBe(240_000);
-  });
-
-  it('does not add install execs for package-less callers (workflow/crawler path)', async () => {
+  it('runs each staged step from /agent/code with the caller timeout', async () => {
     drainSessionExecResilient.mockResolvedValue(
       execResult({
         stdoutBase64: Buffer.from('hello\n').toString('base64'),
@@ -184,27 +83,19 @@ describe('runStepsInSession — install semantics', () => {
     expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
     expect(callArg(0).command).toEqual(['python3', '/agent/code/a.py']);
     expect(callArg(0).timeoutMs).toBe(45_000);
+    expect(callArg(0).cwd).toBe('/agent/code');
   });
 
-  it('keeps install noise out of a successful script run stdout', async () => {
+  it('stops at the first failing step and reports its exit code', async () => {
     drainSessionExecResilient
-      .mockResolvedValueOnce(
-        execResult({
-          stdoutBase64: Buffer.from(
-            'Collecting pandas\nSuccessfully installed pandas-2.2.1\n',
-          ).toString('base64'),
-        }),
-      )
-      .mockResolvedValueOnce(
-        execResult({
-          stdoutBase64: Buffer.from('report written\n').toString('base64'),
-        }),
-      );
+      .mockResolvedValueOnce(execResult({ exitCode: 2 }))
+      .mockResolvedValueOnce(execResult());
     const run = await runStepsInSession('sid', {
-      stepPaths: ['/agent/code/a.py'],
-      packagesByLang: { python: ['pandas'] },
+      stepPaths: ['/agent/code/a.py', '/agent/code/b.js'],
     });
-    expect(run.stdout).toBe('report written\n');
+    expect(run.status).toBe('failed');
+    expect(run.exitCode).toBe(2);
+    expect(drainSessionExecResilient).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -213,18 +104,12 @@ const ORG = 'org-1';
 function harvestCtx(over: {
   runQuery?: ReturnType<typeof vi.fn>;
   runMutation?: ReturnType<typeof vi.fn>;
-  store?: ReturnType<typeof vi.fn>;
-  storageDelete?: ReturnType<typeof vi.fn>;
 }) {
   const ctx = {
     runQuery: over.runQuery ?? vi.fn().mockResolvedValue(null),
     runMutation:
       over.runMutation ??
       vi.fn().mockResolvedValue({ id: 'row', replaced: false }),
-    storage: {
-      store: over.store ?? vi.fn().mockResolvedValue('kg-stored'),
-      delete: over.storageDelete ?? vi.fn(),
-    },
   };
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- harvest touches only these ctx members
   return ctx as unknown as ActionCtx;
@@ -247,10 +132,37 @@ describe('harvestSessionOutput — per-file harvest skips', () => {
     sessionListFiles.mockReset();
     sessionReadFile.mockReset();
     orgSlugFromIdOrNull.mockReset();
-    orgSlugFromIdOrNull.mockResolvedValue(null);
+    orgSlugFromIdOrNull.mockResolvedValue('acme');
+    putBlob.mockReset();
+    putBlob.mockResolvedValue('s3:acme/blob');
+    deleteBlob.mockReset();
   });
 
   const harvestArgs = { organizationId: ORG, sessionId: 'sid' };
+
+  it('fails LOUD before touching the session when the org has no bucket', async () => {
+    // The org bucket is the only store harvested outputs have. An org whose
+    // slug does not resolve was deleted mid-run — skipping every file would
+    // launder that into "produced nothing".
+    orgSlugFromIdOrNull.mockResolvedValue(null);
+    const ctx = harvestCtx({});
+    await expect(harvestSessionOutput(ctx, harvestArgs)).rejects.toThrow(
+      /does not resolve to a slug/,
+    );
+    expect(sessionListFiles).not.toHaveBeenCalled();
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
+  it('stores every harvested file in the org bucket', async () => {
+    sessionListFiles.mockResolvedValue([outputEntry('a.txt')]);
+    sessionReadFile.mockResolvedValue(textBytes('hello'));
+    const ctx = harvestCtx({});
+    const { files } = await harvestSessionOutput(ctx, harvestArgs);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.storageId).toBe('s3:acme/blob');
+    expect(putBlob).toHaveBeenCalledTimes(1);
+    expect(putBlob.mock.calls[0]?.[1]).toBe('acme');
+  });
 
   it('treats a subdir 404 on a LIVE session as a legitimately empty harvest', async () => {
     // A turn that wrote nothing never created its output subdir — that is an
@@ -334,12 +246,10 @@ describe('harvestSessionOutput — per-file harvest skips', () => {
     sessionReadFile
       .mockResolvedValueOnce(textBytes('content-a'))
       .mockResolvedValueOnce(textBytes('content-b'));
-    const store = vi
-      .fn()
+    putBlob
       .mockRejectedValueOnce(new Error('Workspace would exceed the byte cap.'))
-      .mockResolvedValueOnce('kg-b');
-    const storageDelete = vi.fn();
-    const ctx = harvestCtx({ store, storageDelete });
+      .mockResolvedValueOnce('s3:acme/b');
+    const ctx = harvestCtx({});
     const { files, harvestSkipped } = await harvestSessionOutput(
       ctx,
       harvestArgs,
@@ -350,7 +260,7 @@ describe('harvestSessionOutput — per-file harvest skips', () => {
     expect(harvestSkipped[0]?.reason).toContain('not saved to the workspace');
     // Nothing to reap: the rejected store never produced a blob, and b.txt's
     // blob stays.
-    expect(storageDelete).not.toHaveBeenCalled();
+    expect(deleteBlob).not.toHaveBeenCalled();
   });
 
   it('renews the turn lease once per file when the settle names its exec', async () => {

--- a/services/platform/backend/core/node_only/sandbox/session_exec.ts
+++ b/services/platform/backend/core/node_only/sandbox/session_exec.ts
@@ -2,21 +2,19 @@
 
 /**
  * In-session code execution + output harvest — the shared bottom half every
- * session lane settles through. `runStepsInSession` installs declared
- * packages and runs staged scripts as sequential execs (automation `script`
- * steps, the crawler's render lane); `harvestSessionOutput` reads the
- * session's `/agent/output` delivery box into blob storage + `fileMetadata`
- * (automation agent/script hosts, task-agent runs). The CALLER owns the
- * session lifecycle and stages inputs before calling in.
+ * session lane settles through. `runStepsInSession` runs staged scripts as
+ * sequential execs (the crawler's render lane); `harvestSessionOutput` reads
+ * the session's `/agent/output` delivery box into the org bucket +
+ * `fileMetadata` (automation agent hosts, task-agent runs). The CALLER owns
+ * the session lifecycle and stages inputs before calling in.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import type { ActionCtx } from '../../lib/ctx';
 import { internal } from '../../lib/handler_names';
 import { orgSlugFromIdOrNull } from '../../lib/helpers/org_slug';
-import { deleteBlob, putBlob } from '../../lib/storage/blob_access';
-import { convexStorageId, type BlobRef } from '../../lib/storage/blob_ref';
+import { putBlob } from '../../lib/storage/blob_access';
 import {
   drainSessionExecResilient,
   sessionIsAlive,
@@ -159,19 +157,20 @@ export interface StepRunResult {
 }
 
 /**
- * Install declared packages, then run each step in order (stopping at the first
- * failure), collecting stdout/stderr. Pure session I/O — no `ctx`, no harvest —
- * so every session caller shares the exact run semantics: the automation
- * `script` step host AND the crawler render (which reads `/agent/output`
- * straight off the session). The CALLER owns the session lifecycle
- * (create/teardown) and stages inputs before calling this.
+ * Run each staged step in order (stopping at the first failure), collecting
+ * stdout/stderr. Pure session I/O — no `ctx`, no harvest. The one caller is
+ * the crawler render lane (which reads `/agent/output` straight off the
+ * session); it stages its scripts, so every step runs from `/agent/code`.
+ * The CALLER owns the session lifecycle (create/teardown) and stages inputs
+ * before calling this. Package installs were a lane for automation `script`
+ * steps, which never landed in 0.5 — a consumer that needs them adds them
+ * with its own budget.
  */
 export async function runStepsInSession(
   sessionId: string,
   args: {
     /** Absolute `/agent/code/<script>` paths to run in order. */
     stepPaths: string[];
-    packagesByLang?: { python?: string[]; node?: string[] };
     timeoutMs?: number;
   },
 ): Promise<StepRunResult> {
@@ -179,71 +178,18 @@ export async function runStepsInSession(
   const abort = new AbortController();
   const stdoutParts: string[] = [];
   const stderrParts: string[] = [];
-  const runExec = async (
-    command: string[],
-    perTimeout: number,
-    // Steps run from /agent/code (staging created it — a step implies a staged
-    // script). Installs run from the workspace root: /agent always exists,
-    // while /agent/code doesn't on a fresh session with nothing staged (an
-    // install-only call), and runnerd rejects a non-existent cwd.
-    cwd: '/agent/code' | '/agent' = '/agent/code',
-  ) =>
+  const runExec = async (command: string[]) =>
     drainSessionExecResilient(
       sessionId,
       {
         execId: randomUUID(),
         command,
-        cwd,
+        cwd: '/agent/code',
         collectOutput: true,
-        timeoutMs: perTimeout,
+        timeoutMs,
       },
       abort.signal,
     );
-
-  // Install declared packages first (persist in the session for later runs).
-  // Installs get their own budget, floored at 120s — a cold pip/npm resolve
-  // rarely fits the 30s interactive default — and capped at the 300s schema
-  // max. A failed install fails the whole run: running the steps anyway would
-  // surface a confusing downstream ImportError (or, with no steps, report a
-  // success that never happened).
-  const py = args.packagesByLang?.python ?? [];
-  const node = args.packagesByLang?.node ?? [];
-  const installTimeoutMs = Math.min(Math.max(timeoutMs, 120_000), 300_000);
-  const installs: Array<{ tool: 'pip' | 'npm'; command: string[] }> = [];
-  if (py.length > 0) {
-    installs.push({
-      tool: 'pip',
-      command: ['python3', '-m', 'pip', 'install', '--no-input', ...py],
-    });
-  }
-  if (node.length > 0) {
-    installs.push({ tool: 'npm', command: ['npm', 'install', '-g', ...node] });
-  }
-  for (const { tool, command } of installs) {
-    const r = await runExec(command, installTimeoutMs, '/agent');
-    const failed = r.status !== 'completed' || (r.exitCode ?? 0) !== 0;
-    // Install-only runs (and failures) surface installer stdout — it carries
-    // the resolved versions / the resolver error. Successful script runs drop
-    // it so install noise never drowns the script's own stdout; warnings
-    // still route to stderr as before.
-    if (args.stepPaths.length === 0 || failed) {
-      stdoutParts.push(Buffer.from(r.stdoutBase64, 'base64').toString('utf8'));
-    }
-    stderrParts.push(Buffer.from(r.stderrBase64, 'base64').toString('utf8'));
-    if (failed) {
-      const detail = r.errorMessage ?? r.errorCode;
-      return {
-        status: r.status === 'cancelled' ? 'cancelled' : 'failed',
-        exitCode: r.exitCode,
-        stdout: stdoutParts.join(''),
-        stderr: stderrParts.join(''),
-        errorCode: 'INSTALL_FAILED',
-        errorMessage: `${tool} install failed${
-          r.exitCode !== null ? ` (exit ${r.exitCode})` : ''
-        }${detail !== undefined ? `: ${detail}` : ''}`,
-      };
-    }
-  }
 
   // Run each step in order; stop at the first failure.
   let exitCode: number | null = 0;
@@ -256,7 +202,7 @@ export async function runStepsInSession(
       exitCode = 1;
       break;
     }
-    const r = await runExec(command, timeoutMs);
+    const r = await runExec(command);
     stdoutParts.push(Buffer.from(r.stdoutBase64, 'base64').toString('utf8'));
     stderrParts.push(Buffer.from(r.stderrBase64, 'base64').toString('utf8'));
     exitCode = r.exitCode;
@@ -283,11 +229,11 @@ export interface HarvestedOutputFile {
 }
 
 /**
- * Harvest top-level `/agent/output` into blob storage: each file becomes a
- * stored blob plus a `fileMetadata` row (`source: 'agent'`, no documentId —
- * retention-eligible until a consumer such as a workflow `document.create`
- * claims it). Lane-neutral: chat run_code and the automation agent/script
- * hosts all settle their outputs through this one door.
+ * Harvest top-level `/agent/output` into the org's bucket: each file becomes
+ * a stored blob plus a `fileMetadata` row (`source: 'agent'`, no documentId
+ * — retention-eligible until a consumer such as a workflow `document.create`
+ * claims it). Lane-neutral: the task-agent and automation agent hosts settle
+ * their outputs through this one door.
  *
  * A file that CANNOT come back (over the read cap, workspace quota, storage
  * hiccup) is recorded in `harvestSkipped` and never fails the harvest — the
@@ -317,9 +263,17 @@ export async function harvestSessionOutput(
 }> {
   const { sessionId, organizationId, execId } = args;
   const outputDir = args.outputDir ?? OUTPUT_DIR;
-  // Backend routing for harvested outputs: the org's own bucket when
-  // configured, else Convex `_storage` (also the unresolvable-slug fallback).
+  // Harvested outputs land in the org's own bucket (`putBlob` routes a
+  // BYO-bucket org to its bucket). There is no other store: an org whose
+  // slug does not resolve is an infra fault (deleted mid-run), and a harvest
+  // that quietly skipped every file would launder it into "produced
+  // nothing" — fail loud before touching the session, like the 404s below.
   const orgSlug = await orgSlugFromIdOrNull(ctx, organizationId);
+  if (orgSlug === null) {
+    throw new Error(
+      `sandbox output harvest for session ${sessionId} has no bucket: organization ${organizationId} does not resolve to a slug`,
+    );
+  }
 
   const files: HarvestedOutputFile[] = [];
   const harvestSkipped: Array<{ path: string; reason: string }> = [];
@@ -413,11 +367,9 @@ export async function harvestSessionOutput(
       continue;
     }
     const buf = Buffer.from(read.bytes);
-    const sha256 = createHash('sha256').update(buf).digest('hex');
-    // The unchanged-file dedup consulted the thread-file index, which is
-    // offline while the chat backend is rebuilt — every harvested file is
-    // stored fresh. Costs duplicate blobs on re-runs, never correctness;
-    // the retention sweep reclaims unclaimed outputs.
+    // Every harvested file is stored fresh (no unchanged-file dedup). Costs
+    // duplicate blobs on re-runs, never correctness; the retention sweep
+    // reclaims unclaimed outputs.
     // The spawner serves the generic octet-stream — fall back to the
     // extension-derived type (sessionReadFile's documented contract). The
     // Blob MUST carry a non-empty type: the self-hosted backend rejects a
@@ -429,41 +381,15 @@ export async function harvestSessionOutput(
         ? read.contentType
         : inferContentType(absPath);
     // Backend-aware store: harvested outputs are org-user-persistent thread
-    // files — a BYO-bucket org's outputs land in its own bucket.
+    // files — a BYO-bucket org's outputs land in its own bucket. A rejected
+    // store (quota, validation) leaves no blob behind to reap.
     const ab = new ArrayBuffer(buf.byteLength);
     new Uint8Array(ab).set(buf);
     const harvestBytes = new Uint8Array(ab);
-    let storageId: BlobRef | null = null;
+    let storageId: string;
     try {
-      if (orgSlug !== null) {
-        storageId = await putBlob(ctx, orgSlug, harvestBytes, contentType);
-      } else {
-        storageId = await ctx.storage.store(
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a Uint8Array is a valid BlobPart at runtime (TS 5.7 ArrayBufferLike variance)
-          new Blob([harvestBytes], { type: contentType }),
-        );
-      }
-      // The thread-file mirror row is chat-thread bookkeeping; its module
-      // is offline while the chat backend is rebuilt. The blob above and the
-      // fileMetadata row below still land, so run outputs stay retrievable.
-      console.debug(
-        `[session_exec] thread-file mirror skipped for ${absPath} (session ${sessionId}, sha ${sha256.slice(0, 8)}) — chat backend offline`,
-      );
+      storageId = await putBlob(ctx, orgSlug, harvestBytes, contentType);
     } catch (err) {
-      // Quota/validation rejection after the blob copy — reap the orphan
-      // (mirrors workspace_uploads' filing reap).
-      if (storageId !== null) {
-        try {
-          const copyConvexId = convexStorageId(storageId);
-          if (copyConvexId !== null) {
-            await ctx.storage.delete(copyConvexId);
-          } else if (orgSlug !== null) {
-            await deleteBlob(ctx, orgSlug, storageId);
-          }
-        } catch (delErr) {
-          console.warn('[session_exec] harvest orphan cleanup failed:', delErr);
-        }
-      }
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[session_exec] harvest skipped ${absPath}: ${message}`);
       harvestSkipped.push({

--- a/services/platform/backend/core/node_only/sandbox/workspace_tool_shared.ts
+++ b/services/platform/backend/core/node_only/sandbox/workspace_tool_shared.ts
@@ -53,6 +53,20 @@ export function readCursor(raw: unknown): string | null {
   return typeof raw === 'string' && raw !== '' ? raw : null;
 }
 
+/** A caller-supplied OFFSET cursor (the document listing pages by row
+ * offset and hands back `cursor: <nextOffset>` as a number): a non-negative
+ * integer, or its decimal string spelling — a model relays numbers as text
+ * often enough — else page one (`undefined`). */
+export function readOffsetCursor(raw: unknown): number | undefined {
+  const n =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string' && /^\d+$/.test(raw.trim())
+        ? Number(raw.trim())
+        : Number.NaN;
+  return Number.isSafeInteger(n) && n >= 0 ? n : undefined;
+}
+
 /** A caller-supplied string arg: trimmed, else `undefined`. */
 export function readString(raw: unknown): string | undefined {
   return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : undefined;

--- a/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.test.ts
@@ -561,7 +561,11 @@ describe('dispatchWorkspaceToolImpl', () => {
           },
         },
       }).ctx,
-      { ...BASE, tool: 'document_find', callArgs: { extension: 'pdf' } },
+      {
+        ...BASE,
+        tool: 'document_find',
+        callArgs: { extension: 'pdf', cursor: 50 },
+      },
     );
     expect(result.status).toBe('ok');
     const [ref, qArgs] = readQuery.mock.calls[0] as [
@@ -575,8 +579,35 @@ describe('dispatchWorkspaceToolImpl', () => {
     expect(qArgs.teamIds).toEqual(['team_a']);
     expect(qArgs.projectIds).toEqual(['proj_1', 'proj_2']);
     expect(qArgs.projectId).toBeUndefined();
+    // The continuation the previous page handed back reaches the listing —
+    // it used to be dropped here, so the hub never paged past 50 documents.
+    expect(qArgs.cursor).toBe(50);
     // A binding read never carries a user id.
     expect(qArgs.userId).toBeUndefined();
+  });
+
+  it('document_find reads a numeric-string cursor and ignores a malformed one', async () => {
+    const { dispatch } = await getActions();
+    for (const [given, want] of [
+      ['100', 100],
+      [-1, undefined],
+      ['abc', undefined],
+      [12.5, undefined],
+    ] as const) {
+      const readQuery = vi.fn<(...a: unknown[]) => Promise<unknown>>(() =>
+        Promise.resolve({ documents: [] }),
+      );
+      await dispatch(createCtx({ readQuery }).ctx, {
+        ...BASE,
+        tool: 'document_find',
+        callArgs: { cursor: given },
+      });
+      const [, qArgs] = readQuery.mock.calls[0] as [
+        unknown,
+        Record<string, unknown>,
+      ];
+      expect(qArgs.cursor).toBe(want);
+    }
   });
 
   it('document_find on a USER session (no binding) falls back to the user list', async () => {
@@ -592,7 +623,11 @@ describe('dispatchWorkspaceToolImpl', () => {
         scope: { allowed: false, reason: 'no_access_context' },
         access: { allowed: true, role: 'member' },
       }).ctx,
-      { ...BASE, tool: 'document_find', callArgs: { extension: 'pdf' } },
+      {
+        ...BASE,
+        tool: 'document_find',
+        callArgs: { extension: 'pdf', cursor: 50 },
+      },
     );
     expect(result.status).toBe('ok');
     const [ref, qArgs] = readQuery.mock.calls[0] as [
@@ -602,6 +637,8 @@ describe('dispatchWorkspaceToolImpl', () => {
     expect(fnName(ref)).toBe('documents/internal_queries:listForAgent');
     expect(qArgs.organizationId).toBe('org_1');
     expect(qArgs.userId).toBe('user_1');
+    // The user door pages too.
+    expect(qArgs.cursor).toBe(50);
   });
 
   it('knowledge_entry_find lists active entries with topic filter and cursor', async () => {

--- a/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.ts
+++ b/services/platform/backend/core/node_only/sandbox/workspace_tools_bridge.ts
@@ -38,6 +38,7 @@ import {
   isRecord,
   readCursor,
   readLimit,
+  readOffsetCursor,
   type BridgeBlocker,
   type ToolResult,
 } from './workspace_tool_shared';
@@ -116,7 +117,9 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
     "returned nextOffset as offset until it's absent.",
   document_find:
     'List/browse documents in the organization Documents hub this user can ' +
-    'access. Args: {fileName?: string, extension?: string, limit?: number}.',
+    'access. Args: {fileName?: string, extension?: string, limit?: number, ' +
+    "cursor?: number}. Pass the previous result's cursor as cursor for the " +
+    'next page (hasMore tells you whether there is one).',
   knowledge_entry_find:
     "List the organization's curated knowledge entries (small per-topic " +
     'facts). Args: {topic?: string, limit?: number, cursor?: string} — topic ' +
@@ -390,7 +393,11 @@ async function runWorkspaceTool(
   if (args.tool === 'document_find') {
     // The Documents hub is scope-shaped (teams + project + hub), so the two
     // authority sources list through two doors onto ONE helper:
-    // binding → `listDocumentsForScope`, user → `listForAgent`.
+    // binding → `listDocumentsForScope`, user → `listForAgent`. Both page by
+    // offset and hand back `cursor: <nextOffset>`; the continuation the
+    // agent sends back must reach the helper, or a hub past the first ≤50
+    // documents is invisible and the agent concludes a file does not exist.
+    const cursor = readOffsetCursor(callArgs.cursor);
     const bound = await resolveKnowledgeAccess(
       ctx,
       { organizationId: args.organizationId, sessionId: args.sessionId },
@@ -414,6 +421,7 @@ async function runWorkspaceTool(
             ? { extension: callArgs.extension }
             : {}),
           limit: readLimit(callArgs.limit, 50),
+          ...(cursor !== undefined ? { cursor } : {}),
         },
       );
       return { status: 'ok', output: page };
@@ -450,6 +458,7 @@ async function runWorkspaceTool(
           ? { extension: callArgs.extension }
           : {}),
         limit: readLimit(callArgs.limit, 50),
+        ...(cursor !== undefined ? { cursor } : {}),
       },
     );
     return { status: 'ok', output: page };

--- a/services/platform/backend/core/tasks/agent_run_host.ts
+++ b/services/platform/backend/core/tasks/agent_run_host.ts
@@ -567,7 +567,11 @@ async function mintTurnServing(
       providerSlug: resolved.providerSlug,
       modelId: resolved.modelId,
     };
-    const routing = resolveGatewayRouting(target.providerSlug, target.modelId);
+    const routing = resolveGatewayRouting(
+      args.organizationId,
+      target.providerSlug,
+      target.modelId,
+    );
     // A text-only serving model still meets image inputs (task attachments,
     // scanned PDFs) — arm the vision polyfill so those route through the
     // gateway instead of 404ing the turn. Resolved once: the harness needs
@@ -580,8 +584,11 @@ async function mintTurnServing(
     );
     const visionModelRef =
       vision !== null
-        ? resolveGatewayRouting(vision.providerSlug, vision.modelId)
-            .gatewayModel
+        ? resolveGatewayRouting(
+            args.organizationId,
+            vision.providerSlug,
+            vision.modelId,
+          ).gatewayModel
         : undefined;
     const budgetCents = workflowAgentBudgetCents();
     const key = await provisionSessionGatewayKey(ctx, {

--- a/services/platform/backend/domains/connectors/bridge-routes.test.ts
+++ b/services/platform/backend/domains/connectors/bridge-routes.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+
+/**
+ * The connectors door bypasses the proxy like the tool door, so its
+ * request-body cap is the only size boundary. `execute` speaks the
+ * tool-result dialect (`{status, …}` relayed to the model); `hostcall`
+ * speaks the façade's `{error: {code, message}}` — an in-sandbox
+ * `ctx.http` call reads `error` to rethrow, so a `{status}` body there
+ * would be misread as an HTTP status. Each door refuses in its own shape.
+ */
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SANDBOX_DOOR_MAX_BODY_BYTES } from '../sandbox/door-body-limit.ts';
+
+const {
+  getSessionTokenByHash,
+  runBridgeConnectorImpl,
+  runConnectorAction,
+  verifyHostcallToken,
+} = vi.hoisted(() => ({
+  getSessionTokenByHash: vi.fn(),
+  runBridgeConnectorImpl: vi.fn(),
+  runConnectorAction: vi.fn(),
+  verifyHostcallToken: vi.fn(),
+}));
+
+vi.mock('../sandbox/sessions.ts', () => ({ getSessionTokenByHash }));
+vi.mock('../../core/node_only/sandbox/connectors_bridge.ts', () => ({
+  runBridgeConnectorImpl,
+  bridgeConnectorStatusImpl: vi.fn(),
+}));
+vi.mock('./service.ts', () => ({ runConnectorAction }));
+vi.mock('../connector_credentials/service.ts', () => ({
+  resolveConnectorCredential: vi.fn(),
+}));
+vi.mock('../../core/connectors/hostcall_token.ts', () => ({
+  verifyHostcallToken,
+}));
+
+const { createConnectorBridgeRoutes } = await import('./bridge-routes.ts');
+
+function post(
+  path: string,
+  body: string,
+  headers: Record<string, string> = {},
+) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the audit insert is the only sql use, and no test reaches it
+  const app = createConnectorBridgeRoutes({ sql: {} as Sql });
+  return app.request(path, {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer some-token',
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body,
+  });
+}
+
+const OVER_CAP = 'x'.repeat(SANDBOX_DOOR_MAX_BODY_BYTES + 1);
+
+describe('POST /api/connectors/* — request-body cap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionTokenByHash.mockResolvedValue({
+      organizationId: 'org_1',
+      sessionId: 'sess_1',
+      scope: { connectorGrants: ['slack'], userId: 'user_1' },
+      llmGatewayKeyId: null,
+    });
+    verifyHostcallToken.mockResolvedValue({
+      ok: true,
+      payload: { org: 'org_1', connector: 'slack', action: 'post' },
+    });
+  });
+
+  it('execute: refuses an over-cap body with 413 in the tool-result dialect and never dispatches', async () => {
+    const res = await post(
+      '/execute',
+      JSON.stringify({
+        slug: 'slack',
+        operation: 'post',
+        args: { t: OVER_CAP },
+      }),
+    );
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      status: 'invalid_args',
+      message: expect.stringContaining('Request body too large'),
+    });
+    expect(runBridgeConnectorImpl).not.toHaveBeenCalled();
+    expect(getSessionTokenByHash).not.toHaveBeenCalled();
+  });
+
+  it('hostcall: refuses an over-cap body with 413 in the façade error dialect', async () => {
+    const res = await post(
+      '/hostcall',
+      JSON.stringify({
+        kind: 'http',
+        method: 'POST',
+        url: 'https://slack.com/api/x',
+        req: { body: OVER_CAP },
+      }),
+    );
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+        message: expect.stringContaining('Request body too large'),
+      },
+    });
+    expect(verifyHostcallToken).not.toHaveBeenCalled();
+  });
+
+  it('status: a Content-Length over the cap is refused without reading the body', async () => {
+    const res = await post('/status', '{}', {
+      'content-length': String(SANDBOX_DOOR_MAX_BODY_BYTES + 1),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it('execute: a body under the cap reaches the dispatch intact', async () => {
+    runBridgeConnectorImpl.mockResolvedValue({ status: 'ok', output: {} });
+    const res = await post(
+      '/execute',
+      JSON.stringify({
+        slug: 'slack',
+        operation: 'post',
+        args: { text: 'hi' },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok', output: {} });
+    const [, call] = runBridgeConnectorImpl.mock.calls[0] as [
+      unknown,
+      { slug: string; operation: string; callArgs: Record<string, unknown> },
+    ];
+    expect(call).toMatchObject({
+      slug: 'slack',
+      operation: 'post',
+      callArgs: { text: 'hi' },
+    });
+  });
+});

--- a/services/platform/backend/domains/connectors/bridge-routes.ts
+++ b/services/platform/backend/domains/connectors/bridge-routes.ts
@@ -12,6 +12,11 @@ import {
   runBridgeConnectorImpl,
 } from '../../core/node_only/sandbox/connectors_bridge.ts';
 import { resolveConnectorCredential } from '../connector_credentials/service.ts';
+import {
+  hostcallTooLarge,
+  sandboxDoorBodyLimit,
+  toolResultTooLarge,
+} from '../sandbox/door-body-limit.ts';
 import { getSessionTokenByHash } from '../sandbox/sessions.ts';
 import { runConnectorAction } from './service.ts';
 
@@ -32,7 +37,8 @@ import { runConnectorAction } from './service.ts';
  *
  * The decision bodies are REUSED from the 0.4 bridge (one wording of every
  * refusal, for the model that relays it); only the dispatch and credential
- * seams differ.
+ * seams differ. Every body is capped before it is read (door-body-limit.ts)
+ * — this door bypasses the proxy, so nothing else bounds it.
  */
 
 const BEARER_PREFIX = 'Bearer ';
@@ -138,6 +144,9 @@ function isHostcallMethod(value: string): value is keyof typeof HTTP_VERBS {
 
 export function createConnectorBridgeRoutes(deps: { sql: Sql }): Hono {
   const app = new Hono();
+  app.use('/execute', sandboxDoorBodyLimit(toolResultTooLarge));
+  app.use('/status', sandboxDoorBodyLimit(toolResultTooLarge));
+  app.use('/hostcall', sandboxDoorBodyLimit(hostcallTooLarge));
 
   app.post('/execute', async (c) => {
     const auth = await authSessionToken(deps.sql, c.req.raw);

--- a/services/platform/backend/domains/retention/service.sweep.test.ts
+++ b/services/platform/backend/domains/retention/service.sweep.test.ts
@@ -173,3 +173,63 @@ describe('sweepOrgPhase2 — custodian holds', () => {
     expect(purge?.values).toEqual(['doc-unheld']);
   });
 });
+
+describe('sweepOrgPhase2 — sandbox provenance ledgers', () => {
+  // Both tables are append-only per agent turn (tool calls carry the acting
+  // user) and had no sweep at all; they ride the audit-log window because
+  // that is what the writers call them and where the settle copies their
+  // substance.
+  const auditOrg = {
+    organizationId: 'org_1',
+    config: {
+      auditLogEnabled: true,
+      auditLogRetentionDays: 365,
+      deletionGraceDays: 7,
+    },
+  };
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it('deletes aged rows of both ledgers under the audit window, skipping held actors in SQL', async () => {
+    const fake = fakeSweep({ documentsPassB: [] });
+    const before = Date.now();
+
+    await sweepOrgPhase2(fake.sql, auditOrg, {
+      orgHeld: false,
+      userMembershipIds: new Set(['held-user']),
+    });
+
+    const toolCalls = fake.statements.find((s) =>
+      s.text.startsWith('DELETE FROM app.sandbox_tool_calls'),
+    );
+    expect(toolCalls?.text).toContain('WHERE org_id = ? AND created_at_ms < ?');
+    expect(toolCalls?.text).toContain('user_id IS NULL OR user_id <> ALL(?)');
+    expect(toolCalls?.values).toContainEqual(['held-user']);
+    // The audit window carries no deletion grace: exactly days × DAY_MS.
+    const cutoff = toolCalls?.values[1];
+    expect(typeof cutoff).toBe('number');
+    expect(cutoff as number).toBeGreaterThanOrEqual(before - 365 * DAY_MS);
+    expect(cutoff as number).toBeLessThanOrEqual(Date.now() - 365 * DAY_MS);
+
+    const credentials = fake.statements.find((s) =>
+      s.text.startsWith('DELETE FROM app.sandbox_credential_access'),
+    );
+    expect(credentials?.text).toContain(
+      'WHERE org_id = ? AND fetched_at_ms < ?',
+    );
+    expect(credentials?.values.slice(0, 2)).toEqual(['org_1', cutoff]);
+  });
+
+  it('leaves both ledgers alone when the audit-log category is off', async () => {
+    const fake = fakeSweep({ documentsPassB: [] });
+
+    await sweepOrgPhase2(
+      fake.sql,
+      { organizationId: 'org_1', config: { auditLogEnabled: false } },
+      { orgHeld: false, userMembershipIds: new Set() },
+    );
+
+    expect(fake.statements.some((s) => s.text.includes('app.sandbox_'))).toBe(
+      false,
+    );
+  });
+});

--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -396,6 +396,7 @@ interface Phase2Stats {
   automationRuns: number;
   auditLogs: number;
   tempFiles: number;
+  sandboxLedgers: number;
 }
 
 /** A purge that could not remove every dead surface (corpus rows, bytes).
@@ -992,6 +993,55 @@ async function sweepAuditLogs(
   return removed.length;
 }
 
+/**
+ * The sandbox provenance ledgers — `app.sandbox_tool_calls` (every tool and
+ * connector call a container made, with the acting user) and
+ * `app.sandbox_credential_access` (every brokered credential grant). Both
+ * are written as audit trails, and the run ledger copies what a settle
+ * needs into `app.audit_logs` (itself under this window), so the raw rows
+ * ride the audit-log window rather than inventing a category; before this
+ * sweep they grew without bound, user id attached. The window's floor (a
+ * year) sits far above any live turn's settle read, so age alone is safe.
+ *
+ * Plain bounded row deletes — the hash chain lives on the audit log, not
+ * here. A held actor's tool calls are skipped in SQL like the usage
+ * ledger's (a user-less row stays a candidate); the credential table has
+ * no user column, so the org-wide hold (the caller's guard) is its whole
+ * custodian story.
+ */
+async function sweepSandboxLedgers(
+  sql: Sql,
+  org: OrgPolicy,
+  holds: ActiveHolds,
+): Promise<number> {
+  const cutoff = auditLogCutoffFor(org.config);
+  if (cutoff === null) return 0;
+  const protectedIds = [...holds.userMembershipIds];
+  const toolCalls = await sql<{ id: string }[]>`
+    DELETE FROM app.sandbox_tool_calls
+    WHERE id IN (
+      SELECT id FROM app.sandbox_tool_calls
+      WHERE org_id = ${org.organizationId}
+        AND created_at_ms < ${cutoff}
+        AND (${protectedIds.length === 0}
+             OR user_id IS NULL OR user_id <> ALL(${protectedIds}))
+      LIMIT ${BATCH_LIMIT}
+    )
+    RETURNING id
+  `;
+  const credentialAccess = await sql<{ id: string }[]>`
+    DELETE FROM app.sandbox_credential_access
+    WHERE id IN (
+      SELECT id FROM app.sandbox_credential_access
+      WHERE org_id = ${org.organizationId}
+        AND fetched_at_ms < ${cutoff}
+      LIMIT ${BATCH_LIMIT}
+    )
+    RETURNING id
+  `;
+  return toolCalls.length + credentialAccess.length;
+}
+
 async function sweepTempFiles(
   sql: Sql,
   org: OrgPolicy,
@@ -1066,6 +1116,7 @@ export async function sweepOrgPhase2(
     automationRuns: 0,
     auditLogs: 0,
     tempFiles: 0,
+    sandboxLedgers: 0,
   };
   if (holds.orgHeld) return stats;
   stats.documents = await sweepDocuments(sql, org, holds);
@@ -1082,5 +1133,6 @@ export async function sweepOrgPhase2(
   stats.tempFiles =
     (await sweepTempFiles(sql, org, 'user', holds)) +
     (await sweepTempFiles(sql, org, 'agent', holds));
+  stats.sandboxLedgers = await sweepSandboxLedgers(sql, org, holds);
   return stats;
 }

--- a/services/platform/backend/domains/sandbox/dispatch-routes.test.ts
+++ b/services/platform/backend/domains/sandbox/dispatch-routes.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+
+/**
+ * The tool door bypasses the proxy (backend-api is dual-homed onto the
+ * sandbox network), so its request-body cap is the only size boundary
+ * between a container and the shared API process. An oversized POST must
+ * be refused with a 413 in the door's own tool-result dialect BEFORE the
+ * body is parsed or the tool dispatched; a legitimate body must still reach
+ * the dispatch intact — including when no Content-Length header lets the
+ * cap decide up front and the stream has to be re-wrapped.
+ */
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SANDBOX_DOOR_MAX_BODY_BYTES } from './door-body-limit.ts';
+
+const { dispatchWorkspaceToolImpl, getSessionTokenByHash } = vi.hoisted(() => ({
+  dispatchWorkspaceToolImpl: vi.fn(),
+  getSessionTokenByHash: vi.fn(),
+}));
+
+vi.mock('../../core/node_only/sandbox/workspace_tools_bridge.ts', () => ({
+  dispatchWorkspaceToolImpl,
+  workspaceToolStatusImpl: vi.fn(() => ({ status: 'ok', tools: [] })),
+}));
+vi.mock('../../lib/ctx-shim.ts', () => ({ createCtxShim: vi.fn(() => ({})) }));
+vi.mock('./shim.ts', () => ({ sandboxToolShimHandlers: vi.fn(() => ({})) }));
+vi.mock('./sessions.ts', () => ({ getSessionTokenByHash }));
+
+const { createToolDispatchRoutes } = await import('./dispatch-routes.ts');
+
+const TOKEN_ROW = {
+  organizationId: 'org_1',
+  sessionId: 'sess_1',
+  scope: { toolGrants: ['document_find'], userId: 'user_1' },
+  llmGatewayKeyId: null,
+};
+
+function post(body: string, headers: Record<string, string> = {}) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the routes never touch sql directly; every db seam is mocked
+  const app = createToolDispatchRoutes({ sql: {} as Sql });
+  return app.request('/execute', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer vk-plaintext',
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body,
+  });
+}
+
+describe('POST /api/tools/execute — request-body cap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionTokenByHash.mockResolvedValue(TOKEN_ROW);
+    dispatchWorkspaceToolImpl.mockResolvedValue({ status: 'ok', output: {} });
+  });
+
+  it('refuses an over-cap body with 413 in the tool-result dialect and never dispatches', async () => {
+    const filler = 'x'.repeat(SANDBOX_DOOR_MAX_BODY_BYTES + 1);
+    const res = await post(
+      JSON.stringify({ tool: 'document_find', args: { fileName: filler } }),
+    );
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      status: 'invalid_args',
+      message: expect.stringContaining('Request body too large'),
+    });
+    expect(dispatchWorkspaceToolImpl).not.toHaveBeenCalled();
+  });
+
+  it('decides from Content-Length when the header is present, without reading the body', async () => {
+    const res = await post(
+      JSON.stringify({ tool: 'document_find', args: {} }),
+      {
+        'content-length': String(SANDBOX_DOOR_MAX_BODY_BYTES + 1),
+      },
+    );
+    expect(res.status).toBe(413);
+    expect(dispatchWorkspaceToolImpl).not.toHaveBeenCalled();
+  });
+
+  it('passes a body under the cap through to the dispatch intact', async () => {
+    const res = await post(
+      JSON.stringify({ tool: 'document_find', args: { extension: 'pdf' } }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok', output: {} });
+    expect(dispatchWorkspaceToolImpl).toHaveBeenCalledTimes(1);
+    const [, call] = dispatchWorkspaceToolImpl.mock.calls[0] as [
+      unknown,
+      {
+        tool: string;
+        callArgs: Record<string, unknown>;
+        organizationId: string;
+      },
+    ];
+    expect(call.tool).toBe('document_find');
+    expect(call.callArgs).toEqual({ extension: 'pdf' });
+    expect(call.organizationId).toBe('org_1');
+  });
+
+  it('still answers the auth refusal for an oversized body with no session token', async () => {
+    // The cap runs first: an anonymous flood must not even reach the token
+    // lookup, but the answer stays a refusal either way.
+    getSessionTokenByHash.mockResolvedValue(null);
+    const res = await post('x'.repeat(SANDBOX_DOOR_MAX_BODY_BYTES + 1));
+    expect(res.status).toBe(413);
+    expect(getSessionTokenByHash).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/sandbox/dispatch-routes.ts
+++ b/services/platform/backend/domains/sandbox/dispatch-routes.ts
@@ -8,6 +8,7 @@ import {
   workspaceToolStatusImpl,
 } from '../../core/node_only/sandbox/workspace_tools_bridge.ts';
 import { createCtxShim } from '../../lib/ctx-shim.ts';
+import { sandboxDoorBodyLimit, toolResultTooLarge } from './door-body-limit.ts';
 import { getSessionTokenByHash } from './sessions.ts';
 import { sandboxToolShimHandlers } from './shim.ts';
 
@@ -22,8 +23,9 @@ import { sandboxToolShimHandlers } from './shim.ts';
  * Auth: `Authorization: Bearer <session VK>` → sha256 → the session-token
  * row; the org, user, and grant set come FROM THAT ROW, never the body — a
  * container cannot spoof another org, widen its grants, or claim another
- * thread/user. The dispatch itself is the REUSED bridge running on the ctx
- * shim.
+ * thread/user. The body itself is capped before it is read (the 413 is the
+ * one other non-2xx; see door-body-limit.ts). The dispatch itself is the
+ * REUSED bridge running on the ctx shim.
  */
 
 const BEARER_PREFIX = 'Bearer ';
@@ -64,6 +66,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export function createToolDispatchRoutes(deps: { sql: Sql }): Hono {
   const app = new Hono();
+  app.use('*', sandboxDoorBodyLimit(toolResultTooLarge));
 
   app.post('/execute', async (c) => {
     const auth = await authSessionToken(deps.sql, c.req.raw);

--- a/services/platform/backend/domains/sandbox/door-body-limit.ts
+++ b/services/platform/backend/domains/sandbox/door-body-limit.ts
@@ -1,0 +1,49 @@
+import type { MiddlewareHandler } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+
+/**
+ * Request-body cap for the CONTAINER-FACING doors (`/api/tools/*`,
+ * `/api/connectors/*`). Those routes bypass the proxy — backend-api is
+ * dual-homed onto the sandbox network and SANDBOX_HTTP_API_BASE_URL points
+ * straight at it — so the proxy's `request_body` cap never applies, and
+ * `c.req.json()` would buffer whatever a prompt-injected or looping agent
+ * POSTs into the one API process every org shares. The doors treat the
+ * container as hostile in every other respect (org, user and grants come
+ * from the token row, never the body); the size is a boundary too.
+ *
+ * 8 MiB sits well above the largest legitimate body: document_create's
+ * inline content cap is 600k characters (≤ 2.4 MiB as UTF-8), and a
+ * connector hostcall relays JSON API requests (the live host caps
+ * RESPONSES at 5 MiB; attachment bytes ride ctx.files, not this door).
+ * Hono checks Content-Length first and otherwise stops reading the stream
+ * at the first byte over the cap, so an oversized body is never buffered
+ * whole.
+ */
+export const SANDBOX_DOOR_MAX_BODY_BYTES = 8 * 1024 * 1024;
+
+const TOO_LARGE_MESSAGE = `Request body too large: the sandbox doors accept at most ${SANDBOX_DOOR_MAX_BODY_BYTES / (1024 * 1024)} MB.`;
+
+/**
+ * The cap as middleware. `refusal` shapes the 413 body in the door's own
+ * dialect — `{status: 'invalid_args', message}` for the tool-result doors
+ * (relayed verbatim to the model), `{error: {code, message}}` for the
+ * hostcall door (the in-sandbox `ctx.http` façade rethrows `error`).
+ */
+export function sandboxDoorBodyLimit(
+  refusal: (message: string) => unknown,
+): MiddlewareHandler {
+  return bodyLimit({
+    maxSize: SANDBOX_DOOR_MAX_BODY_BYTES,
+    onError: (c) => c.json(refusal(TOO_LARGE_MESSAGE), 413),
+  });
+}
+
+/** The tool-result doors' refusal (`/api/tools/*`, `/api/connectors/{execute,status}`). */
+export function toolResultTooLarge(message: string): unknown {
+  return { status: 'invalid_args', message };
+}
+
+/** The hostcall door's refusal (`/api/connectors/hostcall`). */
+export function hostcallTooLarge(message: string): unknown {
+  return { error: { code: 'PAYLOAD_TOO_LARGE', message } };
+}

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -30944,6 +30944,24 @@ async function checkRetention(
        'rt-a2', 'success', ${now - 400 * 24 * 3_600_000 + 1}, 'fake-a2',
        'fake-a1')
   `;
+  // The sandbox provenance ledgers ride the same audit window: one aged and
+  // one fresh row per table, the aged pair must go and the fresh pair stay.
+  await sql`
+    INSERT INTO app.sandbox_tool_calls (
+      org_id, session_id, tool, user_id, outcome, created_at_ms
+    ) VALUES
+      (${orgId}, 'rt-sess', 'rag_search', ${userId}, 'ok',
+       ${now - 400 * 24 * 3_600_000}),
+      (${orgId}, 'rt-sess', 'rag_search', ${userId}, 'ok', ${now})
+  `;
+  await sql`
+    INSERT INTO app.sandbox_credential_access (
+      org_id, session_id, slug, kind, fetched_at_ms
+    ) VALUES
+      (${orgId}, 'rt-sess', 'rt-cred', 'bootstrap',
+       ${now - 400 * 24 * 3_600_000}),
+      (${orgId}, 'rt-sess', 'rt-cred', 'bootstrap', ${now})
+  `;
   const staleTemp = await sql<{ id: string }[]>`
     INSERT INTO app.file_metadata (
       org_id, storage_ref, file_name, content_type, size, source,
@@ -31083,20 +31101,35 @@ async function checkRetention(
     SELECT count(*)::text AS count FROM app.file_metadata
     WHERE id = ${staleTemp[0]?.id ?? ''}
   `;
+  const toolCallsLeft = await sql<{ createdAtMs: number }[]>`
+    SELECT created_at_ms::float8 AS "createdAtMs" FROM app.sandbox_tool_calls
+    WHERE org_id = ${orgId} AND session_id = 'rt-sess'
+  `;
+  const credentialAccessLeft = await sql<{ fetchedAtMs: number }[]>`
+    SELECT fetched_at_ms::float8 AS "fetchedAtMs"
+    FROM app.sandbox_credential_access
+    WHERE org_id = ${orgId} AND session_id = 'rt-sess'
+  `;
   record(
-    'retention phase-2: documents, chat lineage, runs, audit prefix, temp',
+    'retention phase-2: documents, chat lineage, runs, audit prefix, temp, sandbox ledgers',
     docGone[0]?.count === '0' &&
       threadGone[0]?.count === '0' &&
       msgGone[0]?.count === '0' &&
       runGone[0]?.count === '0' &&
       auditGone[0]?.count === '0' &&
       tempGone[0]?.count === '0' &&
+      // The aged tool-call and credential-access rows go with the audit
+      // window; the fresh ones (this run's own provenance) stay.
+      toolCallsLeft.length === 1 &&
+      toolCallsLeft[0]?.createdAtMs === now &&
+      credentialAccessLeft.length === 1 &&
+      credentialAccessLeft[0]?.fetchedAtMs === now &&
       // The workflow-log window takes the aged TERMINAL run and nothing
       // else: a `waiting` run is parked on a person and a `running` one is
       // mid-flight, so age alone must never make either a candidate.
       automationRunsLeft.map((row) => row.name).join(',') ===
         'rt-wf-running,rt-wf-waiting',
-    `doc=${docGone[0]?.count} thread=${threadGone[0]?.count} msgs=${msgGone[0]?.count} run=${runGone[0]?.count} audit=${auditGone[0]?.count} temp=${tempGone[0]?.count} (all want 0), automationRuns=${automationRunsLeft.map((row) => row.name).join(',')} (want rt-wf-running,rt-wf-waiting)`,
+    `doc=${docGone[0]?.count} thread=${threadGone[0]?.count} msgs=${msgGone[0]?.count} run=${runGone[0]?.count} audit=${auditGone[0]?.count} temp=${tempGone[0]?.count} (all want 0), toolCalls=${toolCallsLeft.length} credentialAccess=${credentialAccessLeft.length} (both want 1 fresh), automationRuns=${automationRunsLeft.map((row) => row.name).join(',')} (want rt-wf-running,rt-wf-waiting)`,
   );
 
   const convLeft = await sql<{ subject: string }[]>`


### PR DESCRIPTION
## Summary

Hardens the sandbox bridge — the surface where in-container agents and the LLM gateway meet the shared backend:

- **Per-org gateway records** — a custom connector's gateway record was named `<slug>__<model>` with no org component, so two orgs defining the same connector name collapsed onto one record and the last provision rewrote the other org's `base_url` (and an apiFormat flip deleted its key). Records are now `<orgId>__<slug>__<model>`; standard providers keep the shared native record.
- **Fail-closed session mint** — `provisionProviders` swallowed a failed key PUT and the session mint then resolved the PRE-rotation key by name. The session provisioner now refuses (`Provider "<slug>" cannot serve this session: …`) before the auth-posture apply and the mint. The caller-less `reprovisionProvider` and its "eager push" docs are gone.
- **Body limits on the container doors** — `/api/tools/*` and `/api/connectors/*` bypass the proxy (backend-api is dual-homed on the sandbox network) and read the body unbounded. One shared `bodyLimit` middleware (8 MiB) answers 413 in each door's dialect.
- **document_find pages** — both doors dropped `callArgs.cursor`; the agent got a continuation it could not use. The cursor is forwarded and documented.
- **Dead code** — the never-reachable pip/npm install lane in `runStepsInSession`, four spawner verbs nothing calls (`sessionEnvPatch`, `sessionBrowser*`), and the harvest's unreachable reap branch + Convex `_storage` fallbacks the 0.5 ctx shim cannot serve (harvest now fails loud when the org slug does not resolve, like its 404 paths).
- **Sandbox ledgers under retention** — `app.sandbox_tool_calls` and `app.sandbox_credential_access` were append-only per agent turn with no sweep; they now ride the audit-log window in the daily phase-2 sweep (held actors skipped in SQL).

## Findings fixed

- node-only-sandbox-bridge-1 — org-scoped custom gateway record names across the provisioner, mint, task-agent and automation agent hosts (3ac8987e6)
- node-only-sandbox-bridge-3 — `provisionProviders` returns failures; `provisionSessionGatewayKey` refuses to mint on a failed needed provider (64f4667bd)
- node-only-sandbox-bridge-5 — `reprovisionProvider` deleted; doc comments say session create is the only push (64f4667bd)
- node-only-sandbox-bridge-2 — `sandboxDoorBodyLimit` on both sub-apps, 413 in each door's dialect (01ed66910)
- node-only-sandbox-bridge-8 — `readOffsetCursor` + cursor forwarded by both document_find doors; TOOL_DESCRIPTIONS names `cursor?` (0546c04e2)
- node-only-sandbox-bridge-6 — `packagesByLang` install lane removed with its tests (73bbe11d0)
- node-only-sandbox-bridge-7 — `sessionEnvPatch`, `sessionBrowserRestart/Reset/ClosePages`, `BrowserRecycleResult` removed (73bbe11d0)
- node-only-sandbox-bridge-9 — harvest: unreachable reap branch, stale debug line and Convex store/delete fallbacks removed; null org slug fails loud (73bbe11d0)
- node-only-sandbox-bridge-10 — `sweepSandboxLedgers` in the phase-2 retention sweep under the audit window; itest seeds aged + fresh rows per table (8953fa392)

## Skipped

- node-only-sandbox-bridge-4 — owned by the documents theme (fx-documents, `fix/documents-integrity`), per the theme README.

## Tests & gates observed

All run inside the worktree on the branch head (8953fa392):

- `bunx tsc --noEmit` — exit 0
- `bunx oxlint --type-aware` — exit 0; via `bun run check`: `@tale/platform:lint: Found 0 warnings and 0 errors.`
- `bunx vitest --run --project server` — `Test Files  495 passed (495)` / `Tests  5983 passed (5983)`
- `bun run check` — exit 0, `Tasks:    8 successful, 8 total`
- `bun run knip:check` — exit 0 (one pre-existing configuration hint: `cron-parser … Remove from ignoreDependencies`, untouched by this PR)
- Real-Postgres integration proof (`run-itest.sh`, with PR #3222's aa3d1d7a9 applied temporarily and reset afterwards, per the campaign brief): `[itest] 464/466 checks passed across 133/133 lanes`, no `RUN TRUNCATED`.
  - `PASS  retention phase-2: documents, chat lineage, runs, audit prefix, temp, sandbox ledgers — … toolCalls=1 credentialAccess=1 (both want 1 fresh) …` (the new check)
  - `FAIL  webdav re-home …` — red on main before this campaign (known, not WebDAV-themed).
  - `FAIL  knowledge: corpus scope drift is corrected and reported — drifted=null, first=corrected 0/scanned 12 …` — the lane the temporary cherry-pick unblocks (it truncated on main); it now runs and fails its own assertion. Nothing in this branch touches knowledge/corpus code; it belongs to PR #3222's lane.

## Notes for the reviewer

- Old-style `<slug>__<model>` gateway records are left in place on purpose: in-flight turns keep their minted keys and new turns route to the org-scoped record. An operator sweep of the orphaned records is a follow-up if the gateway's record count matters.
- The body cap is 8 MiB — above document_create's 600k-character inline cap and the live host's 5 MiB response cap. `Content-Length` decides when present; otherwise reading stops at the first byte over the cap.
- The sandbox-ledger sweep reuses `auditLogCutoffFor` (no deletion grace, 365-day floor). `app.sandbox_credential_access` has an `(org_id)` index only; the bounded delete walks the org's rows in heap (≈insertion) order and stops after 1000 matches, and the table receives a handful of rows per session, so no new index/migration was added — say so if you want the composite index anyway.
- `stage_url.ts` still resolves Convex `_storage` ids (the review's optional "consider the same"); left as is — I could not prove no non-`s3:` refs survive on upgraded deployments.
- PR #3226 (fx-sandbox-domain-harnesses) touches `domains/sandbox/**` but not `dispatch-routes.ts`; this change is additive to it.
