### PR TITLE
fix(ui,web,docs,cli): point docs URLs at the docs subdomain

### DIFF
--- a/compose.docs.yml
+++ b/compose.docs.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Tale Docs (Documentation site) — Standalone Docker Compose
 # =============================================================================
-# The documentation site at tale.dev/docs runs independently of the platform
+# The documentation site at docs.tale.dev runs independently of the platform
 # stack and has its own environment file at services/docs/.env.example.
 #
 # Usage:
@@ -22,7 +22,7 @@ services:
       args:
         VERSION: ${VERSION:-dev}
         DOCS_BASE_URL: ${DOCS_BASE_URL:-/}
-        DOCS_SITE_URL: ${DOCS_SITE_URL:-https://tale.dev/docs}
+        DOCS_SITE_URL: ${DOCS_SITE_URL:-https://docs.tale.dev}
 
     env_file:
       # Optional: the docs site runs fine on its build-arg defaults. Marked

--- a/compose.web.yml
+++ b/compose.web.yml
@@ -27,7 +27,7 @@ services:
       dockerfile: services/web/Dockerfile
       args:
         VERSION: ${VERSION:-dev}
-        WEB_DOCS_URL: ${WEB_DOCS_URL:-https://tale.dev/docs}
+        WEB_DOCS_URL: ${WEB_DOCS_URL:-https://docs.tale.dev}
 
     env_file:
       - services/web/.env

--- a/packages/ui/src/seo/globals.ts
+++ b/packages/ui/src/seo/globals.ts
@@ -14,7 +14,8 @@
  * the build script:
  *
  *   `TALE_SITE_URL`    — marketing site origin (default `https://tale.dev`)
- *   `TALE_DOCS_URL`    — docs site origin      (default `${TALE_SITE_URL}/docs`)
+ *   `TALE_DOCS_URL`    — docs site origin      (default: TALE_SITE_URL's host
+ *                        prefixed with `docs.`)
  *   `TALE_GITHUB_URL`  — source repo URL       (default `https://github.com/tale-project/tale`)
  *
  * These are **build-time** variables consumed by Node/Bun scripts. The
@@ -23,6 +24,8 @@
  * canonical production defaults apply.
  */
 
+import { docsOriginForSite } from './urls';
+
 const env =
   (globalThis as { process?: { env?: Record<string, string | undefined> } })
     .process?.env ?? {};
@@ -30,8 +33,13 @@ const env =
 /** Marketing site origin. */
 export const TALE_SITE_URL = env.TALE_SITE_URL ?? 'https://tale.dev';
 
-/** Documentation site origin. */
-export const TALE_DOCS_URL = env.TALE_DOCS_URL ?? `${TALE_SITE_URL}/docs`;
+/**
+ * Documentation site origin. The docs site is its own host
+ * (`docs.tale.dev`), served by the proxy's docs block; it is no longer
+ * mounted at `/docs` on the marketing origin.
+ */
+export const TALE_DOCS_URL =
+  env.TALE_DOCS_URL ?? docsOriginForSite(TALE_SITE_URL);
 
 /** Public source repository. */
 export const TALE_GITHUB_URL =

--- a/packages/ui/src/seo/index.ts
+++ b/packages/ui/src/seo/index.ts
@@ -128,7 +128,7 @@ export { etagOf } from './runtime/etag';
 export * from './globals';
 // Pure URL / hreflang helpers — safe for Node artifact builds. React
 // document-meta hooks stay on `@tale/ui/seo/tale-document-meta`.
-export { absoluteSitePath } from './urls';
+export { absoluteSitePath, docsOriginForSite } from './urls';
 export {
   buildLocaleAlternateUrls,
   resolveHreflangFromAlternates,

--- a/packages/ui/src/seo/urls-alternates.test.ts
+++ b/packages/ui/src/seo/urls-alternates.test.ts
@@ -5,7 +5,8 @@ import {
   resolveHreflangFromAlternates,
   withXDefault,
 } from './alternates';
-import { absoluteSitePath } from './urls';
+import { TALE_DOCS_URL, TALE_SITE_URL } from './globals';
+import { absoluteSitePath, docsOriginForSite } from './urls';
 
 describe('absoluteSitePath', () => {
   it('joins origin and path without double slashes', () => {
@@ -16,6 +17,44 @@ describe('absoluteSitePath', () => {
     expect(absoluteSitePath('https://tale.dev/docs/', '/de/foo')).toBe(
       'https://tale.dev/docs/de/foo',
     );
+  });
+});
+
+describe('docsOriginForSite', () => {
+  it('prefixes the site host with `docs.`', () => {
+    expect(docsOriginForSite('https://tale.dev')).toBe('https://docs.tale.dev');
+    expect(docsOriginForSite('https://tale.dev/')).toBe(
+      'https://docs.tale.dev',
+    );
+  });
+
+  it('drops a leading `www.` instead of nesting under it', () => {
+    expect(docsOriginForSite('https://www.example.com')).toBe(
+      'https://docs.example.com',
+    );
+  });
+
+  it('preserves scheme and port', () => {
+    expect(docsOriginForSite('https://localhost:3002')).toBe(
+      'https://docs.localhost:3002',
+    );
+    expect(docsOriginForSite('http://example.test')).toBe(
+      'http://docs.example.test',
+    );
+  });
+
+  it('returns the input when it is not an absolute URL', () => {
+    expect(docsOriginForSite('tale.dev')).toBe('tale.dev');
+  });
+});
+
+describe('TALE_DOCS_URL', () => {
+  // Regression: the docs site moved to its own host, but the SEO layer kept
+  // deriving `${TALE_SITE_URL}/docs`. Every canonical, hreflang and sitemap
+  // entry then pointed at a URL that 308-redirects to the subdomain.
+  it('is the docs subdomain, not a subpath of the marketing origin', () => {
+    expect(TALE_DOCS_URL).toBe('https://docs.tale.dev');
+    expect(TALE_DOCS_URL.startsWith(`${TALE_SITE_URL}/`)).toBe(false);
   });
 });
 

--- a/packages/ui/src/seo/urls.ts
+++ b/packages/ui/src/seo/urls.ts
@@ -15,3 +15,34 @@ export function absoluteSitePath(siteUrl: string, path: string): string {
   const normalized = path.startsWith('/') ? path : `/${path}`;
   return `${origin}${normalized}`;
 }
+
+/**
+ * Derive the docs origin from a site origin by prefixing the host with
+ * `docs.` — the same convention `services/proxy/docker-entrypoint.sh`
+ * uses when it defaults `DOCS_URL` to `https://docs.${HOST}`. A leading
+ * `www.` is dropped first so `https://www.example.com` yields
+ * `https://docs.example.com`, not `https://docs.www.example.com`.
+ *
+ * Port and scheme are preserved, so `https://localhost:3002` yields
+ * `https://docs.localhost:3002` — matching the Caddyfile's
+ * `https://docs.localhost` dev default.
+ *
+ * Returns the input unchanged when it is not a parseable absolute URL,
+ * so a misconfigured origin degrades to the old value instead of
+ * throwing during a build.
+ */
+export function docsOriginForSite(siteUrl: string): string {
+  const trimmed = siteUrl.replace(/\/+$/, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch (error) {
+    console.warn(
+      `[seo] docsOriginForSite: unparseable siteUrl ${siteUrl}`,
+      error,
+    );
+    return trimmed;
+  }
+  parsed.hostname = `docs.${parsed.hostname.replace(/^www\./, '')}`;
+  return parsed.origin;
+}

--- a/services/docs/Dockerfile
+++ b/services/docs/Dockerfile
@@ -43,7 +43,7 @@ COPY services/docs ./services/docs
 COPY docs ./docs
 
 ARG DOCS_BASE_URL=/
-ARG DOCS_SITE_URL=https://tale.dev/docs
+ARG DOCS_SITE_URL=https://docs.tale.dev
 ENV NODE_ENV=production \
     DOCS_BASE_URL=${DOCS_BASE_URL} \
     DOCS_SITE_URL=${DOCS_SITE_URL}

--- a/services/docs/lib/seo/build.test.ts
+++ b/services/docs/lib/seo/build.test.ts
@@ -7,6 +7,16 @@ import { describe, expect, it } from 'vitest';
 
 import { buildDocsCompileParams, buildDocsSeo, docsSiteUrl } from './build';
 
+describe('docsSiteUrl', () => {
+  // Regression: this origin is stamped into every canonical, hreflang and
+  // sitemap <loc> the docs build emits. While it was `https://tale.dev/docs`,
+  // all 432 of those URLs 308-redirected to the docs subdomain.
+  it('is the docs subdomain, with no trailing slash', () => {
+    expect(docsSiteUrl()).toBe('https://docs.tale.dev');
+    expect(docsSiteUrl()).not.toMatch(/\/$/);
+  });
+});
+
 describe('docs SEO build', () => {
   it('excludes noindex routes from sitemap sections', async () => {
     const { sections, noindexPaths } = await buildDocsSeo(docsSiteUrl());

--- a/services/docs/lib/site-url.ts
+++ b/services/docs/lib/site-url.ts
@@ -1,4 +1,4 @@
 // Canonical fallback for the docs site URL. Production builds override via
-// DOCS_SITE_URL (Node) or VITE_DOCS_SITE_URL (Vite); falls back to the
-// default tale.dev mount path.
-export const DEFAULT_DOCS_SITE_URL = 'https://tale.dev/docs';
+// DOCS_SITE_URL (Node) or VITE_DOCS_SITE_URL (Vite); falls back to the docs
+// subdomain, which is where the proxy's docs host block serves this site.
+export const DEFAULT_DOCS_SITE_URL = 'https://docs.tale.dev';

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -41,7 +41,7 @@ COPY tsconfig.base.json ./
 COPY packages/ui ./packages/ui
 COPY services/web ./services/web
 
-ARG WEB_DOCS_URL=https://tale.dev/docs
+ARG WEB_DOCS_URL=https://docs.tale.dev
 ENV NODE_ENV=production \
     WEB_DOCS_URL=${WEB_DOCS_URL} \
     VITE_DOCS_URL=${WEB_DOCS_URL}

--- a/services/web/lib/docs-url.test.ts
+++ b/services/web/lib/docs-url.test.ts
@@ -7,6 +7,14 @@ import {
 } from './docs-url';
 
 describe('docs-url', () => {
+  // Regression: the docs site moved to its own host. While the default was
+  // still `https://tale.dev/docs`, every marketing page linked to a URL that
+  // 308-redirects, which Ahrefs reports as "Page has links to redirect".
+  it('links to the docs subdomain, not a /docs subpath', () => {
+    expect(DOCS_URL).toBe('https://docs.tale.dev');
+    expect(DOCS_URL).not.toContain('tale.dev/docs');
+  });
+
   it('points Get started at the Start-tab quickstart, not self-hosted install', () => {
     expect(GET_STARTED_URL).toBe(`${DOCS_URL}/get-started/quickstart`);
     expect(GET_STARTED_URL).not.toContain('self-hosted/install');

--- a/services/web/lib/docs-url.ts
+++ b/services/web/lib/docs-url.ts
@@ -1,7 +1,7 @@
 // Default docs URL for the marketing site. Production builds override via
-// VITE_DOCS_URL at build time; falls back to the canonical tale.dev mount
-// path.
-const DEFAULT_DOCS_URL = 'https://tale.dev/docs';
+// VITE_DOCS_URL at build time; falls back to the docs subdomain, which is
+// where the proxy's docs host block serves the docs site.
+const DEFAULT_DOCS_URL = 'https://docs.tale.dev';
 
 export const DOCS_URL = import.meta.env.VITE_DOCS_URL ?? DEFAULT_DOCS_URL;
 

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -98,12 +98,17 @@ program.addCommand(createConfigCommand().helpGroup(MAINTAIN));
 program.addCommand(createAuthCommand().helpGroup(ADVANCED));
 program.addCommand(createDaemonCommand().helpGroup(ADVANCED));
 
-// Docs link honors TALE_DOCS_URL (mirrors @tale/ui/seo/globals) so a
-// self-hosted or staging deployment can point users at its own docs; the
-// default is the public docs site at https://tale.dev/docs.
+// Docs link honors TALE_DOCS_URL (mirrors `docsOriginForSite` in
+// @tale/ui/seo/urls — the CLI deliberately does not depend on the UI
+// package, so the derivation is duplicated rather than imported) so a
+// self-hosted or staging deployment can point users at its own docs. The
+// default is the public docs site at https://docs.tale.dev.
 const DOCS_URL =
   process.env.TALE_DOCS_URL ??
-  `${process.env.TALE_SITE_URL ?? 'https://tale.dev'}/docs`;
+  `https://docs.${(process.env.TALE_SITE_URL ?? 'https://tale.dev')
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/.*$/, '')}`;
 
 // Branded wordmark above the help, and a few real examples below it.
 program.addHelpText('beforeAll', () => `\n${logger.bannerText(pkg.version)}\n`);

--- a/tools/cli/src/lib/project/default-readme.test.ts
+++ b/tools/cli/src/lib/project/default-readme.test.ts
@@ -21,6 +21,6 @@ describe('default/README.md scaffold content', () => {
     expect(DEFAULT_README_CONTENT).toContain('*.secrets.json');
     expect(DEFAULT_README_CONTENT).toContain('.history/');
     // Where to learn more.
-    expect(DEFAULT_README_CONTENT).toContain('https://tale.dev/docs');
+    expect(DEFAULT_README_CONTENT).toContain('https://docs.tale.dev');
   });
 });

--- a/tools/cli/src/lib/project/default-readme.ts
+++ b/tools/cli/src/lib/project/default-readme.ts
@@ -40,5 +40,5 @@ directory under version control. Two things are machine-managed and
 gitignored — \`*.secrets.json\` (encrypted credentials) and \`.history/\`
 directories (edit history); don't edit or commit them.
 
-Learn more: https://tale.dev/docs
+Learn more: https://docs.tale.dev
 `;


### PR DESCRIPTION
Canonical URLs, hreflang alternates, sitemap entries and cross-links for the docs site now point at `docs.tale.dev`. They pointed at `tale.dev/docs`, which 308-redirects to that host.

## Why

The proxy already serves docs from its own host: `services/proxy/docker-entrypoint.sh:40` defaults `DOCS_URL` to `https://docs.${HOST}`, and the Caddyfile gives it a separate host block. The SEO layer never followed. `packages/ui/src/seo/globals.ts:34` still derived `${TALE_SITE_URL}/docs`.

Every URL built from that value redirects. On the live site:

```
robots.txt          → Sitemap: https://tale.dev/docs/sitemap.xml   (308)
its 432 <loc> URLs  → all https://tale.dev/docs/*                  (308 each)

docs.tale.dev/cloud/billing
  <link rel="canonical" href="https://tale.dev/docs/cloud/billing">   (308)
  <link rel="alternate" hreflang="de" href="https://tale.dev/docs/de/...">   (308)
```

Ahrefs reports one cause as five issues: canonical points to redirect (432 pages), 3XX redirect in sitemap (432), 3XX redirect (432 of 441), and page has links to redirect (42 marketing pages, 156 docs pages).

## What changed

- `packages/ui/src/seo/urls.ts`: new `docsOriginForSite()`. It prefixes the site host with `docs.`, drops a leading `www.`, and preserves scheme and port.
- `packages/ui/src/seo/globals.ts`: `TALE_DOCS_URL` derives through that helper.
- `services/docs/lib/site-url.ts` and `services/web/lib/docs-url.ts`: the fallback constants.
- `services/docs/Dockerfile`, `services/web/Dockerfile`, `compose.docs.yml`, `compose.web.yml`: the build-arg defaults.
- `tools/cli/src/index.ts` and `tools/cli/src/lib/project/default-readme.ts`: the CLI help link and the generated project README both linked to the redirecting URL.

## Risk

The default is derived, not hardcoded, so a fork setting `TALE_SITE_URL=https://acme.com` gets `https://docs.acme.com`. A deployment that genuinely serves docs under a subpath must now set `TALE_DOCS_URL` (or `DOCS_SITE_URL` / `WEB_DOCS_URL`) explicitly. The subpath is no longer the default.

`docsOriginForSite` returns its input unchanged when the origin does not parse, so a misconfigured `TALE_SITE_URL` degrades to the old value instead of failing the build.

## Tests

Three assertions pin the origin at the three places it is read, and five cover the helper.

| Mutation | Result |
| --- | --- |
| `TALE_DOCS_URL` back to `${TALE_SITE_URL}/docs` | red |
| `DEFAULT_DOCS_SITE_URL` back to `https://tale.dev/docs` | red |
| `DEFAULT_DOCS_URL` back to `https://tale.dev/docs` | red |
| drop the `www.` strip | red, `https://docs.www.example.com` |
| `docsOriginForSite` returns its input unchanged | red |

## Scope

Does not close the other Ahrefs findings. Still open: `ListItem.datePublished` on the changelog pages, changelog page weight, and the title and description lengths in the marketing catalog and docs frontmatter. Each ships separately.

`tools/cli` keeps its own copy of the derivation instead of importing the helper. It depends on `@tale/shared` only, and pulling in `@tale/ui` for four lines would cost more than the duplication. The comment now names the source of truth.

Gate: `bun run format`, `lint`, `typecheck`, `lint:sast` clean; the ui, web, docs and cli suites pass.
