### PR TITLE
fix(ui): nest ItemList entries under item for valid schema.org

### DIFF
--- a/packages/ui/src/seo/builders/json-ld.test.ts
+++ b/packages/ui/src/seo/builders/json-ld.test.ts
@@ -249,9 +249,41 @@ describe('buildItemListJsonLd', () => {
     expect(parsed.itemListElement[0]).toMatchObject({
       '@type': 'ListItem',
       position: 1,
-      name: 'v1.0.0',
-      datePublished: '2026-01-02',
+      item: {
+        '@type': 'CreativeWork',
+        name: 'v1.0.0',
+        url: 'https://github.com/tale-project/tale/releases/tag/v1.0.0',
+        datePublished: '2026-01-02',
+      },
     });
-    expect(parsed.itemListElement[1].datePublished).toBeUndefined();
+
+    const second = parsed.itemListElement[1].item;
+    if (!isJsonObject(second)) {
+      throw new Error('Expected the second entry to nest an item object');
+    }
+    expect(second.datePublished).toBeUndefined();
+    expect(second.name).toBe('v0.9.0');
+  });
+
+  // Regression: `datePublished` is a CreativeWork property. Emitting it on
+  // the ListItem itself made every changelog locale fail schema.org
+  // validation (Ahrefs: "Structured data has schema.org validation error").
+  it('keeps datePublished off the ListItem itself', () => {
+    const parsed = parse(
+      buildItemListJsonLd([
+        {
+          name: 'v1.0.0',
+          url: 'https://example.test/v1',
+          datePublished: '2026-01-02',
+        },
+      ]),
+    );
+    if (!isJsonObjectArray(parsed.itemListElement)) {
+      throw new Error('Expected itemListElement to be an array of objects');
+    }
+    const [first] = parsed.itemListElement;
+    expect(first.datePublished).toBeUndefined();
+    expect(first.name).toBeUndefined();
+    expect(first.url).toBeUndefined();
   });
 });

--- a/packages/ui/src/seo/builders/json-ld.ts
+++ b/packages/ui/src/seo/builders/json-ld.ts
@@ -322,6 +322,13 @@ export interface ItemListEntry {
 /**
  * `ItemList` block for visible ordered collections (changelog releases,
  * compare hubs, etc.). Emit only for items rendered on the page.
+ *
+ * Each entry nests its subject under `ListItem.item` rather than putting
+ * `name` / `url` / `datePublished` on the `ListItem` itself. `ListItem` is
+ * an `Intangible`, so it has no `datePublished` — that property is defined
+ * on `CreativeWork`, and emitting it directly on the `ListItem` is a
+ * schema.org validation error. The nested form is also one of the two
+ * shapes Google documents for `ItemList`.
  */
 export function buildItemListJsonLd(
   items: readonly ItemListEntry[],
@@ -332,12 +339,15 @@ export function buildItemListJsonLd(
     '@type': 'ItemList',
     ...(opts?.name ? { name: opts.name } : {}),
     numberOfItems: items.length,
-    itemListElement: items.map((item, i) => ({
+    itemListElement: items.map((entry, i) => ({
       '@type': 'ListItem',
       position: i + 1,
-      name: item.name,
-      url: item.url,
-      ...(item.datePublished ? { datePublished: item.datePublished } : {}),
+      item: {
+        '@type': 'CreativeWork',
+        name: entry.name,
+        url: entry.url,
+        ...(entry.datePublished ? { datePublished: entry.datePublished } : {}),
+      },
     })),
   });
 }


### PR DESCRIPTION
The three changelog pages now emit valid schema.org structured data. `buildItemListJsonLd` put `datePublished` directly on each `ListItem`, and `ListItem` has no such property.

## Why

`datePublished` is defined on `CreativeWork`. `ListItem` is an `Intangible`, so the property does not apply to it, and a validator rejects the block.

Live output from `/changelog` before this change:

```json
{
  "@type": "ListItem",
  "position": 1,
  "name": "v0.4.16",
  "url": "https://github.com/tale-project/tale/releases/tag/v0.4.16",
  "datePublished": "2026-08-26T03:04:26Z"
}
```

`/changelog` is the only page using the builder, and it ships in en, de and fr. That is exactly the three pages Ahrefs reports under "Structured data has schema.org validation error".

## What changed

`packages/ui/src/seo/builders/json-ld.ts`: each entry nests its subject under `ListItem.item` as a `CreativeWork`, carrying `name`, `url` and the optional `datePublished`. The `ListItem` keeps only `@type` and `position`.

```json
{
  "@type": "ListItem",
  "position": 1,
  "item": {
    "@type": "CreativeWork",
    "name": "v0.4.16",
    "url": "https://github.com/tale-project/tale/releases/tag/v0.4.16",
    "datePublished": "2026-08-26T03:04:26Z"
  }
}
```

This is one of the two shapes Google documents for `ItemList`, so the date signal survives the fix.

## Risk

The emitted JSON changes shape. `changelog-page.tsx` is the only caller and passes the same entry objects, so no call site changes. Nothing reads the block back inside the app; it exists for crawlers.

## Tests

| Mutation | Result |
| --- | --- |
| put `datePublished` back on the `ListItem` | red |
| keep `item` but also leak `datePublished` onto the `ListItem` | red |

The second mutation matters: it is the permissive direction, where the nested form looks right but the invalid property is still emitted alongside it.

## Scope

Does not close the other Ahrefs findings. The docs subdomain URLs ship in #3231; changelog page weight and the title and description lengths ship separately.

Gate: `bun run format`, `lint`, `typecheck`, `lint:sast` clean; ui JSON-LD suite 12 passing, full web suite 113 passing.
