### PR TITLE
perf(web): prerender a bounded set of changelog release bodies

### DIFF
--- a/services/web/app/pages/changelog-page.tsx
+++ b/services/web/app/pages/changelog-page.tsx
@@ -2,7 +2,7 @@ import {
   buildBreadcrumbListJsonLd,
   buildItemListJsonLd,
 } from '@tale/ui/seo/builders/json-ld';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { ReleaseBody } from '@/app/components/blocks/changelog/release-body';
 import { useActiveRelease } from '@/app/components/blocks/changelog/use-active-release';
@@ -33,6 +33,15 @@ import { absoluteLocalizedUrl } from '@/lib/seo/absolute-url';
 import { useDocumentMeta } from '@/lib/seo/use-document-meta';
 
 const DISPLAY_LIMIT = 40;
+
+/**
+ * How many release bodies the prerendered HTML carries. Rendering all 40
+ * put ~250 KB of GitHub release notes into `dist/changelog/index.html`,
+ * and it grew with every release; Ahrefs flags the page as slow. The rest
+ * mount on hydration from `RELEASES`, which the JS bundle already ships,
+ * so a visitor sees the same page.
+ */
+const PRERENDERED_BODY_COUNT = 12;
 
 /** True when the GitHub release name is more than a version restatement. */
 function distinctiveReleaseName(release: Release): string | null {
@@ -72,6 +81,13 @@ export function ChangelogPage() {
     () => feed.releases.slice(0, DISPLAY_LIMIT) as Release[],
     [feed.releases],
   );
+
+  // False for the prerendered HTML and for the first client render (so
+  // hydration matches), then true for every render after mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
 
   const tags = useMemo(() => releases.map((r) => r.tag), [releases]);
   const activeTag = useActiveRelease(tags);
@@ -166,9 +182,11 @@ export function ChangelogPage() {
               </h2>
             )}
             {release.body ? (
-              <div className="mt-5">
-                <ReleaseBody markdown={release.body} />
-              </div>
+              hydrated || index < PRERENDERED_BODY_COUNT ? (
+                <div className="mt-5">
+                  <ReleaseBody markdown={release.body} />
+                </div>
+              ) : null
             ) : (
               <p className="text-fg-muted mt-4 text-sm">{t('emptyBody')}</p>
             )}

--- a/services/web/tests/prerender/seo.test.ts
+++ b/services/web/tests/prerender/seo.test.ts
@@ -132,6 +132,42 @@ describe('prerender SEO suite', () => {
     });
   });
 
+  // Regression: the changelog prerendered all 40 release bodies, putting
+  // ~400 KB of GitHub release notes into the HTML and growing with every
+  // release. Ahrefs flags it as a slow page. Every release stays in the
+  // stream; bodies past `PRERENDERED_BODY_COUNT` mount on hydration from
+  // the manifest the JS bundle already ships.
+  describe('changelog page weight', () => {
+    // Mirrors DISPLAY_LIMIT / PRERENDERED_BODY_COUNT in
+    // app/pages/changelog-page.tsx. Update both together.
+    const RELEASES_IN_STREAM = 40;
+    const PRERENDERED_BODIES = 12;
+    // The prose wrapper ReleaseBody renders — one per rendered body.
+    const BODY_MARKER = /max-w-none text-\[15px\]/g;
+
+    for (const url of ['/changelog', '/de/changelog', '/fr/changelog']) {
+      it(`${url} lists every release but prerenders a bounded set of bodies`, () => {
+        const html = readHtml(url);
+        expect(html, `missing ${distIndex(url)}`).not.toBeNull();
+        const found = html ?? '';
+
+        expect((found.match(/<article/g) ?? []).length).toBe(
+          RELEASES_IN_STREAM,
+        );
+        expect((found.match(BODY_MARKER) ?? []).length).toBe(
+          PRERENDERED_BODIES,
+        );
+      });
+
+      it(`${url} stays under the HTML size budget`, () => {
+        const html = readHtml(url);
+        if (!html) return;
+        // Was 407 KB with every body prerendered; 216 KB after.
+        expect(html.length).toBeLessThan(300_000);
+      });
+    }
+  });
+
   // The server computes CSP script-src sha256 hashes once, from dist/index.html.
   // That's only safe if every prerendered page's inline scripts are a subset of
   // the template's — otherwise a page's theme script would be CSP-blocked.


### PR DESCRIPTION
The three changelog pages drop from 407 KB to 216 KB of prerendered HTML, and from 63 KB to 31 KB on the wire. The stream still lists all 40 releases.

## Why

`changelog-page.tsx` rendered the full GitHub release body for all 40 releases it displays. Those bodies are 151,000 characters of markdown containing 658 PR links, and the set grows with every release. Ahrefs flags `/changelog`, `/de/changelog` and `/fr/changelog` as slow pages, all four of its "Slow page" findings being new this crawl.

Measured against the live site, page weight is what separates a flagged page from a clean one. Server time does not vary with size:

```
warm connection, same TLS session:
  /pricing    ttfb 0.239s   16 KB gz    not flagged
  /changelog  ttfb 0.210s   63 KB gz    flagged

transfer time after first byte:
  /pricing    ~0.15s
  /changelog  ~0.35s
```

## What changed

`services/web/app/pages/changelog-page.tsx`: a `hydrated` flag is false for the prerendered HTML and for the first client render, then true afterwards. Release bodies past the first 12 render only once it flips.

Nothing is fetched to fill them in. `RELEASES` is imported from the generated manifest, so the JS bundle already carries every body; the prerendered HTML was duplicating them. A visitor sees the same page.

Built output, before and after:

| File | Before | After | Gzipped after |
| --- | --- | --- | --- |
| `dist/changelog/index.html` | 407,310 | 216,357 | 31,206 |
| `dist/de/changelog/index.html` | 407,790 | 216,837 | 31,410 |
| `dist/fr/changelog/index.html` | 407,845 | 216,895 | 31,434 |

## Risk

A crawler that does not run JS now sees 12 release bodies instead of 40. That is the intent: the hidden content is generated commit subjects and PR links, and each release already links to its GitHub page. All 40 releases keep their heading, version, date, anchor and outbound link in the HTML.

Setting the initial state to `true` would silently restore the old size. The prerender suite fails on that, in both the count and the size budget.

## Tests

`tests/prerender/seo.test.ts` gains two assertions per changelog locale, run against `dist/` after a build.

| Mutation | Result |
| --- | --- |
| `useState(true)`, so the prerender renders every body | red, 6 failures: `expected 40 to be 12` and `expected 406805 to be less than 300000` |

## Scope

Does not close the fourth slow page. The homepage is 252 KB of prerendered HTML, 49% of it inline SVG across 226 elements in 63 distinct shapes. Gzip already collapses that repetition to 34 KB. De-duplicating the icons into `<symbol>` and `<use>` would save little on the wire, so this PR leaves them alone.

The larger term in every page's load time is connection setup, not bytes: a cold request spends 0.6s of its 0.85s time-to-first-byte in TCP and TLS, against 0.21s of server time. That is provisioning, not code.

Gate: `bun run format`, `lint`, `typecheck`, `lint:sast` clean; web suite 113 passing, prerender suite 74 passing.
