### PR TITLE
fix(web,ui): bring marketing seo titles and descriptions into range

### DIFF
--- a/packages/ui/src/seo/document-meta.ts
+++ b/packages/ui/src/seo/document-meta.ts
@@ -96,4 +96,4 @@ export function useDocumentMeta(meta: DocumentMeta): void {
 // Re-exported so the SSR entry points import the capture seam + serialiser
 // from one place (`@tale/ui/seo/document-meta`).
 export { HeadSinkContext, createHeadSink } from './head-sink';
-export { renderHeadToHtml } from './head-tags';
+export { renderHeadToHtml, resolveFullTitle } from './head-tags';

--- a/packages/ui/src/seo/head-tags.ts
+++ b/packages/ui/src/seo/head-tags.ts
@@ -59,6 +59,15 @@ export type HeadTag =
   | { tag: 'script'; jsonLd: string };
 
 /**
+ * The rendered `<title>`: a page title already naming the site stands on
+ * its own, otherwise the site name is appended. Exported so length budgets
+ * can be asserted against the string a crawler actually sees.
+ */
+export function resolveFullTitle(title: string, siteName = 'Tale'): string {
+  return title.includes(siteName) ? title : `${title} | ${siteName}`;
+}
+
+/**
  * Resolve a page's declared meta into the ordered tag list. Pure — no DOM,
  * no React — so it runs identically on the server and the client.
  */
@@ -82,7 +91,7 @@ export function resolveDocumentHead(meta: DocumentHeadInput): HeadTag[] {
     jsonLd,
   } = meta;
 
-  const fullTitle = title.includes(siteName) ? title : `${title} | ${siteName}`;
+  const fullTitle = resolveFullTitle(title, siteName);
   const resolvedOgImage = ogImage ?? defaultOgImage;
   const tags: HeadTag[] = [];
 

--- a/services/web/lib/seo/meta-lengths.test.ts
+++ b/services/web/lib/seo/meta-lengths.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Length budgets for the marketing `seo` catalog, asserted against the
+ * strings a crawler sees: the rendered `<title>` (which only gains
+ * ` | Tale` when the title does not already name the site) and the raw
+ * meta description.
+ *
+ * Regression: 12 German and French descriptions ran past 160 characters
+ * and the three changelog descriptions sat under 110, which Ahrefs reports
+ * as "Meta description too long" and "too short"; several page titles
+ * rendered under 30.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { resolveFullTitle } from '@tale/ui/seo/document-meta';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import { SUPPORTED_LOCALES } from '../i18n/locales';
+
+const TITLE_MIN = 30;
+const TITLE_MAX = 60;
+const DESCRIPTION_MIN = 110;
+const DESCRIPTION_MAX = 160;
+
+interface SeoEntry {
+  title: string;
+  description: string;
+}
+
+function seoNamespace(locale: string): Record<string, SeoEntry> {
+  const path = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    'messages',
+    `${locale}.yml`,
+  );
+  const catalog: unknown = parse(readFileSync(path, 'utf8'));
+  const seo =
+    catalog !== null && typeof catalog === 'object' && 'seo' in catalog
+      ? catalog.seo
+      : undefined;
+  if (seo === null || typeof seo !== 'object') {
+    throw new Error(`${locale}.yml has no "seo" namespace`);
+  }
+  const out: Record<string, SeoEntry> = {};
+  for (const [key, value] of Object.entries(seo as Record<string, unknown>)) {
+    if (value === null || typeof value !== 'object') continue;
+    const { title, description } = value as Partial<SeoEntry>;
+    if (typeof title === 'string' && typeof description === 'string') {
+      out[key] = { title, description };
+    }
+  }
+  return out;
+}
+
+describe('marketing seo meta lengths', () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    describe(locale, () => {
+      const entries = Object.entries(seoNamespace(locale));
+
+      it('has an seo entry for every page', () => {
+        expect(entries.length).toBeGreaterThan(0);
+      });
+
+      for (const [key, entry] of entries) {
+        it(`${key} title renders within ${TITLE_MIN}-${TITLE_MAX} characters`, () => {
+          const rendered = resolveFullTitle(entry.title);
+          expect(
+            rendered.length,
+            `${locale}.${key}: "${rendered}"`,
+          ).toBeGreaterThanOrEqual(TITLE_MIN);
+          expect(
+            rendered.length,
+            `${locale}.${key}: "${rendered}"`,
+          ).toBeLessThanOrEqual(TITLE_MAX);
+        });
+
+        it(`${key} description is within ${DESCRIPTION_MIN}-${DESCRIPTION_MAX} characters`, () => {
+          expect(
+            entry.description.length,
+            `${locale}.${key}: "${entry.description}"`,
+          ).toBeGreaterThanOrEqual(DESCRIPTION_MIN);
+          expect(
+            entry.description.length,
+            `${locale}.${key}: "${entry.description}"`,
+          ).toBeLessThanOrEqual(DESCRIPTION_MAX);
+        });
+      }
+    });
+  }
+});

--- a/services/web/messages/de.yml
+++ b/services/web/messages/de.yml
@@ -11,22 +11,23 @@ seo:
       gratis bei Jahresabrechnung. Community ist unter MIT kostenlos selbst
       gehostet.'
   contact:
-    title: Kontakt zum Tale-Team
-    description: Sprich mit dem Tale-Team über selbst gehostete KI für deine
-      Organisation — Plattform, Preise, Hardware oder eine geführte Demo.
-      Antwort innerhalb eines Werktags.
+    title: Kontakt zum Tale-Team — Vertrieb, Support, Demos
+    description: Sprich mit dem Tale-Team über selbst gehostete KI — Plattform,
+      Preise, Hardware oder eine geführte Demo. Antwort innerhalb eines
+      Werktags.
   about:
     title: Wer steht hinter Tale? — Über die Ruler GmbH
     description: Hinter Tale steht die Ruler GmbH, ein Schweizer Unternehmen aus
-      Spiez, gegründet 2020 — herstellerneutral, ISO 27001 & SOC 2 Type II
-      zertifiziert und vollständig Open Source unter MIT.
+      Spiez — herstellerneutral, ISO 27001 & SOC 2 Type II zertifiziert und Open
+      Source unter MIT.
   requestDemo:
-    title: Demo anfragen
-    description: 'Buch eine geführte Tale-Demo: selbst gehostete KI-Agents,
-      Automatisierungen und Governance in Aktion. Für datensensible
-      Organisationen in der Schweiz und der EU.'
+    title: Tale-Demo anfragen — geführter Rundgang
+    description:
+      'Buch eine geführte Tale-Demo: selbst gehostete KI-Agents,
+      Automatisierungen und Governance in Aktion — für datensensible Teams in
+      der Schweiz und der EU.'
   hardwarePricing:
-    title: Was kostet Tale-AI-Hardware?
+    title: Was kostet Tale-AI-Hardware? — mieten, leasen, kaufen
     description: Geräuscharme Inference-Hardware von einzelnen Nodes bis Racks —
       mieten, leasen oder kaufen. Vor Ort mit Remote-Wartung oder in sicheren
       Rechenzentren.
@@ -37,41 +38,43 @@ seo:
       steuert jede Aktion — selbst gehostet für datensensible Teams in der
       Schweiz und der EU.
   platformAgents:
-    title: Was sind Agents in Tale?
+    title: Was sind Agents in Tale? — Anweisungen, Tools, Modell
     description:
       Tale-Agents kombinieren Anweisungen, Wissen, Tools und ein Modell.
       Verbinde Claude Code, Codex, Hermes und OpenClaw unter einem Orchestrator,
       den du hostest.
   platformChat:
-    title: Chats in Tale
+    title: Was ist Chat in Tale? — Zitate, Tool-Aufrufe, Freigaben
     description:
       'Tale Chat ist der Alltagseinstieg: Agent wählen, Nachricht senden,
       gestreamte Antwort lesen — mit Zitaten, Tool-Aufrufen, Arena-Modus und
       Freigaben im Chat.'
   platformAutomations:
-    title: Was sind Automations in Tale?
-    description: Tale Automations bündeln Connectors, Agents und typisierte
-      Workflow-Schritte — Trigger, Bedingungen, Aktionen und menschliche
-      Freigaben auf deiner Infrastruktur.
+    title: Was sind Automations in Tale? — vom Trigger zur Freigabe
+    description:
+      'Tale Automations bündeln Connectors, Agents und typisierte
+      Workflow-Schritte: Trigger, Bedingungen, Aktionen und menschliche
+      Freigaben auf deiner Infrastruktur.'
   platformKnowledge:
-    title: Was ist Knowledge in Tale?
+    title: Was ist Knowledge in Tale? — indexiert und zitiert
     description: Tale Knowledge indexiert Dokumente, Websites und typisierte
       Datensätze, damit Agents deine Realität abrufen und zitieren — nicht nur
       Trainingsdaten.
   platformGovernance:
-    title: Was ist Governance in Tale?
+    title: Was ist Governance in Tale? — Freigaben und Audit-Log
     description: Tale Governance hält Agent-Aktionen hinter Freigabe-Karten,
       schreibt jeden Entscheid ins Audit-Log und filtert PII und unsichere
       Inhalte in beide Richtungen.
   platformProjects:
-    title: Was sind Projekte in Tale?
+    title: Was sind Projekte in Tale? — geteilte Arbeitsbereiche
     description: Tale-Projekte bündeln Chats, Dateien, Anweisungen und ein
-      Task-Board in einem geteilten Arbeitsbereich — weise eine Aufgabe einem
-      Agent zu und prüfe das Ergebnis, bevor es rausgeht.
+      Task-Board — weise eine Aufgabe einem Agent zu und prüfe das Ergebnis,
+      bevor es rausgeht.
   changelog:
     title: Was ist neu in Tale? — Changelog
-    description: Release Notes zu jeder Tale-Version, neueste zuerst —
-      veröffentlicht aus GitHub Releases.
+    description: Release Notes zu jeder Tale-Version, neueste zuerst — Features,
+      Fixes und Breaking Changes jeder Version, veröffentlicht aus GitHub
+      Releases.
 notFound:
   title: Diese Seite gibt es nicht
   body: Die Adresse ist vielleicht vertippt, oder die Seite ist umgezogen. Am

--- a/services/web/messages/en.yml
+++ b/services/web/messages/en.yml
@@ -11,7 +11,7 @@ seo:
       Tale Enterprise is CHF 12 (EUR 14) per user/month, two months free
       on yearly billing. Community is free to self-host under MIT.
   contact:
-    title: Contact the Tale team
+    title: Contact the Tale team — sales, support, demos
     description:
       Talk to the Tale team about self-hosted AI for your organization —
       platform, pricing, hardware, or a guided demo. Replies land within one
@@ -22,7 +22,7 @@ seo:
       in 2020 — vendor-neutral, ISO 27001 & SOC 2 Type II certified, and fully
       open source under MIT.
   requestDemo:
-    title: Request a demo
+    title: Request a Tale demo — a guided walkthrough
     description:
       'Book a guided Tale demo: see self-hosted AI agents, automations,
       and governance in action. Built for data-sensitive organizations in
@@ -39,44 +39,44 @@ seo:
       governs every action — self-hosted for data-sensitive teams in Switzerland
       and the EU.
   platformAgents:
-    title: What are agents in Tale?
+    title: What are agents in Tale? — instructions, tools, models
     description:
       Tale agents combine instructions, knowledge, tools, and a model.
       Connect Claude Code, Codex, Hermes, and OpenClaw under one orchestrator
       you host.
   platformChat:
-    title: Chats in Tale
+    title: What is Chat in Tale? — agents, citations, approvals
     description: 'Tale Chat is the everyday entry point: pick an agent, send a
       message, and read a streamed reply with citations, tool calls, Arena mode,
       and in-chat approvals.'
   platformAutomations:
-    title: What are Automations in Tale?
+    title: What are Automations in Tale? — triggers to approvals
     description: Tale Automations bundle connectors, agents, and typed workflow
       steps — triggers, conditions, actions, and human approvals on
       infrastructure you run.
   platformKnowledge:
-    title: What is Knowledge in Tale?
+    title: What is Knowledge in Tale? — indexed and cited sources
     description:
       Tale Knowledge indexes documents, websites, and typed records so
       agents retrieve and cite your reality instead of model training data
       alone.
   platformGovernance:
-    title: What is Governance in Tale?
+    title: What is Governance in Tale? — approvals and audit trail
     description:
       Tale Governance holds agent actions behind approval cards, writes
       every decision to the audit log, and filters PII and unsafe content in
       both directions.
   platformProjects:
-    title: What are Projects in Tale?
+    title: What are Projects in Tale? — shared agent workspaces
     description:
       Tale Projects bundle chats, files, instructions, and a task board
       into one shared workspace — assign a task to an agent and review the
       result before it ships.
   changelog:
     title: What's new in Tale? — Changelog
-    description:
-      Release notes for every Tale version, newest first — published from
-      GitHub Releases.
+    description: Release notes for every Tale version, newest first — the
+      features, fixes, and breaking changes in each one, published from GitHub
+      Releases.
 notFound:
   title: This page doesn't exist
   body: The address may be mistyped, or the page has moved. The homepage is the

--- a/services/web/messages/fr.yml
+++ b/services/web/messages/fr.yml
@@ -11,33 +11,33 @@ seo:
       'Tale Enterprise : CHF 12 (EUR 14) par utilisateur/mois, deux mois
       offerts en annuel. Community est gratuite en auto-hébergement sous MIT.'
   contact:
-    title: Contacter l’équipe Tale
+    title: Contacter l’équipe Tale — ventes, support, démos
     description:
       Parle à l’équipe Tale de l’IA auto-hébergée pour ton organisation —
       plateforme, tarifs, matériel ou une démo guidée. Réponse sous un jour
       ouvrable.
   about:
     title: Qui est derrière Tale ? — À propos de Ruler GmbH
-    description: Tale est construit par Ruler GmbH, une entreprise suisse de
-      Spiez fondée en 2020 — neutre vis-à-vis des fournisseurs, certifiée ISO
-      27001 & SOC 2 Type II et entièrement open source sous MIT.
+    description: Tale est construit par Ruler GmbH, entreprise suisse de Spiez —
+      neutre vis-à-vis des fournisseurs, certifiée ISO 27001 & SOC 2 Type II,
+      open source sous MIT.
   requestDemo:
-    title: Demander une démo
-    description: 'Réserve une démo guidée de Tale : agents IA auto-hébergés,
-      automatisations et gouvernance en action. Pour les organisations sensibles
-      aux données, en Suisse et dans l’UE.'
+    title: Demander une démo Tale — visite guidée
+    description:
+      'Réserve une démo guidée de Tale : agents IA auto-hébergés,
+      automatisations et gouvernance en action, pour les équipes sensibles aux
+      données.'
   hardwarePricing:
     title: Combien coûte le hardware AI Tale ?
     description:
-      Hardware d’inférence silencieux, du nœud unique au rack — location,
-      leasing ou achat. Déployé sur site avec maintenance à distance, ou hébergé
-      en centres de données sécurisés.
+      'Hardware d’inférence silencieux, du nœud unique au rack : location,
+      leasing ou achat. Sur site avec maintenance à distance, ou en centres de
+      données sécurisés.'
   platform:
     title: Comment fonctionne la plateforme Tale ?
-    description:
-      Tale connecte les agents, regroupe les connaissances, exécute les
-      automations et gouverne chaque action — auto-hébergé pour les équipes
-      sensibles aux données en Suisse et dans l’UE.
+    description: Tale connecte les agents, regroupe les connaissances, exécute
+      les automations et gouverne chaque action — auto-hébergé, en Suisse et
+      dans l’UE.
   platformAgents:
     title: Que sont les agents dans Tale ?
     description:
@@ -45,15 +45,15 @@ seo:
       modèle. Connecte Claude Code, Codex, Hermes et OpenClaw sous un
       orchestrateur que tu héberges.
   platformChat:
-    title: Chats dans Tale
+    title: Qu’est-ce que Chat dans Tale ? — citations et outils
     description: 'Tale Chat, l’entrée du quotidien : choisis un agent, envoie un
       message, lis la réponse — citations, appels d’outils, Arena et
       approbations dans le fil.'
   platformAutomations:
     title: Que sont les Automations dans Tale ?
-    description: Les Automations Tale regroupent connectors, agents et étapes de
-      workflow typées — déclencheurs, conditions, actions et approbations
-      humaines sur ton infrastructure.
+    description:
+      'Les Automations Tale regroupent connectors, agents et étapes de workflow
+      typées : déclencheurs, conditions, actions et approbations humaines.'
   platformKnowledge:
     title: Qu’est-ce que Knowledge dans Tale ?
     description: Tale Knowledge indexe documents, sites et enregistrements typés
@@ -62,18 +62,18 @@ seo:
   platformGovernance:
     title: Qu’est-ce que la gouvernance dans Tale ?
     description: Tale Governance retient les actions des agents sur des cartes
-      d’approbation, écrit chaque décision au journal d’audit et filtre PII et
-      contenus à risque dans les deux sens.
+      d’approbation, journalise chaque décision et filtre PII et contenus à
+      risque.
   platformProjects:
     title: Que sont les Projets dans Tale ?
     description: Les Projets Tale réunissent chats, fichiers, instructions et
-      tableau de tâches dans un espace de travail partagé — assigne une tâche à
-      un agent et relis le résultat avant qu’il parte.
+      tableau de tâches — assigne une tâche à un agent et relis le résultat
+      avant qu’il parte.
   changelog:
     title: Quoi de neuf dans Tale ? — Changelog
-    description:
-      Les notes de version de Tale, de la plus récente à la plus ancienne
-      — publiées depuis GitHub Releases.
+    description: Les notes de version de Tale, de la plus récente à la plus
+      ancienne — fonctionnalités, correctifs et changements de rupture, publiés
+      depuis GitHub Releases.
 notFound:
   title: Cette page n’existe pas
   body:


### PR DESCRIPTION
Every page title and meta description in the marketing catalog now lands in range. Titles run 30 to 60 characters, descriptions 110 to 160. A new test holds them there.

## Why

Ahrefs reports three findings against the marketing site, and all three come from the same catalog:

| Finding | Pages | What was wrong |
| --- | --- | --- |
| Meta description too long | 12 | 5 German and 7 French descriptions ran to 161-190 characters |
| Meta description too short | 3 | the changelog description in all three locales, 84 to 102 characters |
| Title too short | 18 | titles rendering as short as 13 characters |

The rendered `<title>` is not always the catalog title. `packages/ui/src/seo/head-tags.ts` appends ` | Tale` only when the title does not already name the site, so `Chats in Tale` rendered as 13 characters while `Demo anfragen` rendered as 20. Both read as short titles to a crawler, for different reasons.

## What changed

`services/web/messages/{en,de,fr}.yml`, `seo` namespace only. 30 values across 14 route keys.

Titles gained a clause that names what the page covers, in the em-dash form the catalog already used for `pricing`, `about` and `changelog`:

```
Chats in Tale                    ->  What is Chat in Tale? — agents, citations, approvals
Chats in Tale                    ->  Was ist Chat in Tale? — Zitate, Tool-Aufrufe, Freigaben
Chats dans Tale                  ->  Qu’est-ce que Chat dans Tale ? — citations et outils
```

Over-long descriptions lost their least load-bearing clause, never the differentiator. The German and French rewrites are written in those languages, not trimmed from the English. They keep `du` and `tu` throughout, carry no `Sie` or `vous`, avoid `Découvre` and `clé en main`, and keep compounds whole (`Tool-Aufrufe`, `Workflow-Schritte`, `Audit-Log`).

The three changelog descriptions gained the fact they were missing, which is what each entry contains:

```
Release notes for every Tale version, newest first — published from GitHub Releases.
->
Release notes for every Tale version, newest first — the features, fixes, and
breaking changes in each one, published from GitHub Releases.
```

`resolveFullTitle` moves out of the body of `resolveDocumentHead` and is re-exported from `@tale/ui/seo/document-meta`, so the budget asserts the string a crawler sees instead of a second copy of the rule.

## Risk

French punctuation follows what `fr.yml` already does rather than what typographic French prefers: NBSP before `?`, an ordinary space before `:`, and the typographic apostrophe. New values were written by an emitter and parsed back to confirm each one round-trips byte for byte.

`de-CH.yml` carries no `seo` block, so it inherits the German values and needed no edit.

## Tests

`services/web/lib/seo/meta-lengths.test.ts` asserts both budgets for every `seo` entry in every supported locale. 87 assertions.

| Mutation | Result |
| --- | --- |
| restore the 190-character French `about` description | red |
| restore `Chats in Tale` as the German chat title | red |
| `resolveFullTitle` always appends the site name | red, in the ui head-tags suite |

## Scope

Covers the marketing catalog only. The docs frontmatter has the same two problems at larger scale, 281 descriptions over 160 characters and 125 titles rendering under 20; that ships separately.

Gate: `bun run format`, `lint`, `typecheck`, `lint:sast` clean; web suite 113 passing, ui i18n framework 60 passing, ui head-tags 12 passing.
