### PR TITLE
fix(docs): compose page titles from the breadcrumb trail

### DIFF
--- a/docs/fr/tutorials/admin/meeting-transcription.md
+++ b/docs/fr/tutorials/admin/meeting-transcription.md
@@ -1,5 +1,5 @@
 ---
-title: Piper les transcriptions de réunions dans la Base de connaissances
+title: Acheminer les transcriptions de réunions
 description: Câble Meetily (ou un outil local de transcription de réunions similaire) dans la Base de connaissances d'un projet Tale pour que les transcriptions atterrissent toutes seules comme documents, sans que personne ne charge un fichier.
 ---
 

--- a/packages/ui/src/seo/document-meta.ts
+++ b/packages/ui/src/seo/document-meta.ts
@@ -96,4 +96,4 @@ export function useDocumentMeta(meta: DocumentMeta): void {
 // Re-exported so the SSR entry points import the capture seam + serialiser
 // from one place (`@tale/ui/seo/document-meta`).
 export { HeadSinkContext, createHeadSink } from './head-sink';
-export { renderHeadToHtml } from './head-tags';
+export { renderHeadToHtml, resolveFullTitle } from './head-tags';

--- a/packages/ui/src/seo/head-tags.ts
+++ b/packages/ui/src/seo/head-tags.ts
@@ -59,6 +59,15 @@ export type HeadTag =
   | { tag: 'script'; jsonLd: string };
 
 /**
+ * The rendered `<title>`: a page title already naming the site stands on
+ * its own, otherwise the site name is appended. Exported so length budgets
+ * can be asserted against the string a crawler actually sees.
+ */
+export function resolveFullTitle(title: string, siteName = 'Tale'): string {
+  return title.includes(siteName) ? title : `${title} | ${siteName}`;
+}
+
+/**
  * Resolve a page's declared meta into the ordered tag list. Pure — no DOM,
  * no React — so it runs identically on the server and the client.
  */
@@ -82,7 +91,7 @@ export function resolveDocumentHead(meta: DocumentHeadInput): HeadTag[] {
     jsonLd,
   } = meta;
 
-  const fullTitle = title.includes(siteName) ? title : `${title} | ${siteName}`;
+  const fullTitle = resolveFullTitle(title, siteName);
   const resolvedOgImage = ogImage ?? defaultOgImage;
   const tags: HeadTag[] = [];
 

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -147,7 +147,7 @@
     "slug": "tutorials/admin/meeting-transcription",
     "locale": "fr",
     "frontmatter": {
-      "title": "Piper les transcriptions de réunions dans la Base de connaissances",
+      "title": "Acheminer les transcriptions de réunions",
       "description": "Câble Meetily (ou un outil local de transcription de réunions similaire) dans la Base de connaissances d'un projet Tale pour que les transcriptions atterrissent toutes seules comme documents, sans que personne ne charge un fichier."
     }
   },

--- a/services/docs/app/pages/build-meta-title.test.ts
+++ b/services/docs/app/pages/build-meta-title.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression: the docs `<title>` was the bare frontmatter title. That name
+ * also labels the sidebar entry, the breadcrumb and the H1, so it is short
+ * on purpose — "Chat", "Admin", "Teams", "Cloud". As a title it rendered as
+ * little as 11 characters and repeated across sections, which Ahrefs reports
+ * as "Title too short".
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildMetaTitle } from './docs-page';
+
+const SITE = 'Tale documentation';
+const crumbs = (...labels: string[]) => labels.map((label) => ({ label }));
+
+describe('buildMetaTitle', () => {
+  it('trails the top-level section so short names carry context', () => {
+    expect(buildMetaTitle(crumbs('Platform', 'Chat', 'Chat'), SITE)).toBe(
+      'Chat | Platform',
+    );
+    expect(buildMetaTitle(crumbs('Cloud', 'Billing'), SITE)).toBe(
+      'Billing | Cloud',
+    );
+  });
+
+  it('gives a section landing page the site title instead', () => {
+    expect(buildMetaTitle(crumbs('Cloud'), SITE)).toBe(
+      'Cloud | Tale documentation',
+    );
+    expect(buildMetaTitle(crumbs('Develop', 'Develop'), SITE)).toBe(
+      'Develop | Tale documentation',
+    );
+  });
+
+  it('does not repeat a section the page name already carries', () => {
+    expect(
+      buildMetaTitle(
+        crumbs('Self-hosted', 'Install', 'Self-hosted quickstart'),
+        SITE,
+      ),
+    ).toBe('Self-hosted quickstart');
+  });
+
+  it('drops the section rather than overflow 60 rendered characters', () => {
+    const long = 'Pipe meeting transcripts into the Knowledge Base';
+    expect(buildMetaTitle(crumbs('Tutorials', 'Admin', long), SITE)).toBe(long);
+    // `${long} | Tutorials | Tale` would be 67.
+    expect(`${long} | Tale`.length).toBeLessThanOrEqual(60);
+  });
+
+  it('falls back to the site title at the docs root', () => {
+    expect(buildMetaTitle([], SITE)).toBe(SITE);
+  });
+});

--- a/services/docs/app/pages/docs-page.tsx
+++ b/services/docs/app/pages/docs-page.tsx
@@ -8,6 +8,7 @@ import {
   buildWebSiteJsonLd,
 } from '@tale/ui/seo/builders/json-ld';
 import { pageAsMarkdown } from '@tale/ui/seo/builders/page-as-markdown';
+import { resolveFullTitle } from '@tale/ui/seo/document-meta';
 import { useMemo } from 'react';
 
 import { DocsBreadcrumbs } from '@/app/components/docs/docs-breadcrumbs';
@@ -69,6 +70,46 @@ function buildBreadcrumbs(
   });
 }
 
+/**
+ * The `<title>` a crawler sees, before `resolveFullTitle` appends `| Tale`.
+ *
+ * A bare page name is often both too short and not unique: "Chat", "Admin",
+ * "Teams" and "Overview" each name several pages in different sections, so
+ * they render identical titles. Trailing the top-level section disambiguates
+ * them and lifts the shortest ones out of the range Ahrefs reports as
+ * "Title too short".
+ *
+ * The section is dropped when the page name already contains it, so
+ * `self-hosted/install/quickstart` stays "Self-hosted quickstart" instead of
+ * repeating itself. A section landing page has no section to add, so it takes
+ * the localized site title.
+ */
+/** Longest rendered `<title>` a search result will show in full. */
+const TITLE_MAX = 60;
+
+export function buildMetaTitle(
+  breadcrumbs: readonly { label: string }[],
+  siteTitle: string,
+): string {
+  if (breadcrumbs.length === 0) return siteTitle;
+  const page = breadcrumbs[breadcrumbs.length - 1].label;
+  const section = breadcrumbs.length > 1 ? breadcrumbs[0].label : null;
+  // Adding context is only worth it while the result still fits. A page name
+  // long enough to overflow already describes itself.
+  const withinBudget = (candidate: string) =>
+    resolveFullTitle(candidate).length <= TITLE_MAX ? candidate : page;
+  // A section landing page ("Cloud", "Platform") has no section above it, or
+  // repeats its own name as one. Neither has anything to disambiguate with,
+  // so those take the site title instead.
+  if (section === null || section.toLowerCase() === page.toLowerCase()) {
+    return withinBudget(`${page} | ${siteTitle}`);
+  }
+  // The page name already carries the section ("Self-hosted quickstart");
+  // appending it again would only repeat.
+  if (page.toLowerCase().includes(section.toLowerCase())) return page;
+  return withinBudget(`${page} | ${section}`);
+}
+
 function findPrevNext(slug: string): {
   prev: string | null;
   next: string | null;
@@ -94,6 +135,7 @@ function buildAlternates(
 
 export function DocsPage({ locale, slug }: DocsPageProps) {
   const { t } = useT('docs');
+  const { t: tSeo } = useT('seo');
   const doc = getDocPage(locale, slug);
   const breadcrumbs = useMemo(
     () => buildBreadcrumbs(locale, slug),
@@ -168,7 +210,7 @@ export function DocsPage({ locale, slug }: DocsPageProps) {
   }, [doc, url, breadcrumbs, locale, slug]);
 
   useDocumentMeta({
-    title: doc?.frontmatter.title ?? 'Tale documentation',
+    title: buildMetaTitle(breadcrumbs, tSeo('siteTitle')),
     description: doc?.frontmatter.description ?? '',
     canonicalPath: path,
     locale,

--- a/services/docs/messages/de.yml
+++ b/services/docs/messages/de.yml
@@ -1,4 +1,5 @@
 seo:
+  siteTitle: Tale-Dokumentation
   ogImageAlt: Tale — Der Orchestrator für KI-Agents
 nav:
   homeAriaLabel: Tale Dokumentation Startseite

--- a/services/docs/messages/en.yml
+++ b/services/docs/messages/en.yml
@@ -1,4 +1,5 @@
 seo:
+  siteTitle: Tale documentation
   ogImageAlt: Tale — The Orchestrator for AI Agents
 nav:
   homeAriaLabel: Tale documentation home

--- a/services/docs/messages/fr.yml
+++ b/services/docs/messages/fr.yml
@@ -1,4 +1,5 @@
 seo:
+  siteTitle: Documentation Tale
   ogImageAlt: Tale — l’orchestrateur pour agents IA
 nav:
   homeAriaLabel: Accueil de la documentation Tale

--- a/services/docs/tests/prerender/seo.test.ts
+++ b/services/docs/tests/prerender/seo.test.ts
@@ -24,6 +24,58 @@ describe('docs prerender SEO suite', () => {
     expect(existsSync(DIST)).toBe(true);
   });
 
+  // Regression: the `<title>` was the bare frontmatter title, which also
+  // labels the sidebar, breadcrumb and H1 and is therefore short on purpose.
+  // Pages rendered as little as 11 characters ("Chat | Tale"), which Ahrefs
+  // reports as "Title too short". Titles now trail their top-level section.
+  describe('title lengths', () => {
+    // Rendered bounds. The floor sits below the docs root title
+    // ("Tale documentation", 18) and well above the 11-character titles
+    // that regressed; the ceiling is what a search result shows in full.
+    const MIN = 15;
+    const MAX = 60;
+
+    function indexablePages(): { path: string; title: string }[] {
+      const out: { path: string; title: string }[] = [];
+      const walk = (dir: string) => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const full = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(full);
+            continue;
+          }
+          if (entry.name !== 'index.html') continue;
+          const html = readFileSync(full, 'utf8');
+          // Redirect stubs and /404 are noindex; they are not results.
+          if (/name="robots"[^>]*content="[^"]*noindex/i.test(html)) continue;
+          const match = /<title>([\s\S]*?)<\/title>/.exec(html);
+          if (!match) continue;
+          out.push({
+            path: full.slice(DIST.length),
+            title: match[1]
+              .replaceAll('&amp;', '&')
+              .replaceAll('&lt;', '<')
+              .replaceAll('&gt;', '>')
+              .replaceAll('&#39;', "'")
+              .replaceAll('&quot;', '"'),
+          });
+        }
+      };
+      walk(DIST);
+      return out;
+    }
+
+    it('renders every indexable title within the bounds', () => {
+      if (!existsSync(DIST)) return;
+      const pages = indexablePages();
+      expect(pages.length).toBeGreaterThan(100);
+      const offenders = pages
+        .filter((p) => p.title.length < MIN || p.title.length > MAX)
+        .map((p) => `${p.path} (${p.title.length}): ${p.title}`);
+      expect(offenders).toEqual([]);
+    });
+  });
+
   it('prerenders /404 with noindex', () => {
     const html = readHtml('/404');
     expect(html).not.toBeNull();

--- a/services/web/lib/seo/meta-lengths.test.ts
+++ b/services/web/lib/seo/meta-lengths.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Length budgets for the marketing `seo` catalog, asserted against the
+ * strings a crawler sees: the rendered `<title>` (which only gains
+ * ` | Tale` when the title does not already name the site) and the raw
+ * meta description.
+ *
+ * Regression: 12 German and French descriptions ran past 160 characters
+ * and the three changelog descriptions sat under 110, which Ahrefs reports
+ * as "Meta description too long" and "too short"; several page titles
+ * rendered under 30.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { resolveFullTitle } from '@tale/ui/seo/document-meta';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import { SUPPORTED_LOCALES } from '../i18n/locales';
+
+const TITLE_MIN = 30;
+const TITLE_MAX = 60;
+const DESCRIPTION_MIN = 110;
+const DESCRIPTION_MAX = 160;
+
+interface SeoEntry {
+  title: string;
+  description: string;
+}
+
+function seoNamespace(locale: string): Record<string, SeoEntry> {
+  const path = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    'messages',
+    `${locale}.yml`,
+  );
+  const catalog: unknown = parse(readFileSync(path, 'utf8'));
+  const seo =
+    catalog !== null && typeof catalog === 'object' && 'seo' in catalog
+      ? catalog.seo
+      : undefined;
+  if (seo === null || typeof seo !== 'object') {
+    throw new Error(`${locale}.yml has no "seo" namespace`);
+  }
+  const out: Record<string, SeoEntry> = {};
+  for (const [key, value] of Object.entries(seo as Record<string, unknown>)) {
+    if (value === null || typeof value !== 'object') continue;
+    const { title, description } = value as Partial<SeoEntry>;
+    if (typeof title === 'string' && typeof description === 'string') {
+      out[key] = { title, description };
+    }
+  }
+  return out;
+}
+
+describe('marketing seo meta lengths', () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    describe(locale, () => {
+      const entries = Object.entries(seoNamespace(locale));
+
+      it('has an seo entry for every page', () => {
+        expect(entries.length).toBeGreaterThan(0);
+      });
+
+      for (const [key, entry] of entries) {
+        it(`${key} title renders within ${TITLE_MIN}-${TITLE_MAX} characters`, () => {
+          const rendered = resolveFullTitle(entry.title);
+          expect(
+            rendered.length,
+            `${locale}.${key}: "${rendered}"`,
+          ).toBeGreaterThanOrEqual(TITLE_MIN);
+          expect(
+            rendered.length,
+            `${locale}.${key}: "${rendered}"`,
+          ).toBeLessThanOrEqual(TITLE_MAX);
+        });
+
+        it(`${key} description is within ${DESCRIPTION_MIN}-${DESCRIPTION_MAX} characters`, () => {
+          expect(
+            entry.description.length,
+            `${locale}.${key}: "${entry.description}"`,
+          ).toBeGreaterThanOrEqual(DESCRIPTION_MIN);
+          expect(
+            entry.description.length,
+            `${locale}.${key}: "${entry.description}"`,
+          ).toBeLessThanOrEqual(DESCRIPTION_MAX);
+        });
+      }
+    });
+  }
+});

--- a/services/web/messages/de.yml
+++ b/services/web/messages/de.yml
@@ -11,22 +11,23 @@ seo:
       gratis bei Jahresabrechnung. Community ist unter MIT kostenlos selbst
       gehostet.'
   contact:
-    title: Kontakt zum Tale-Team
-    description: Sprich mit dem Tale-Team über selbst gehostete KI für deine
-      Organisation — Plattform, Preise, Hardware oder eine geführte Demo.
-      Antwort innerhalb eines Werktags.
+    title: Kontakt zum Tale-Team — Vertrieb, Support, Demos
+    description: Sprich mit dem Tale-Team über selbst gehostete KI — Plattform,
+      Preise, Hardware oder eine geführte Demo. Antwort innerhalb eines
+      Werktags.
   about:
     title: Wer steht hinter Tale? — Über die Ruler GmbH
     description: Hinter Tale steht die Ruler GmbH, ein Schweizer Unternehmen aus
-      Spiez, gegründet 2020 — herstellerneutral, ISO 27001 & SOC 2 Type II
-      zertifiziert und vollständig Open Source unter MIT.
+      Spiez — herstellerneutral, ISO 27001 & SOC 2 Type II zertifiziert und Open
+      Source unter MIT.
   requestDemo:
-    title: Demo anfragen
-    description: 'Buch eine geführte Tale-Demo: selbst gehostete KI-Agents,
-      Automatisierungen und Governance in Aktion. Für datensensible
-      Organisationen in der Schweiz und der EU.'
+    title: Tale-Demo anfragen — geführter Rundgang
+    description:
+      'Buch eine geführte Tale-Demo: selbst gehostete KI-Agents,
+      Automatisierungen und Governance in Aktion — für datensensible Teams in
+      der Schweiz und der EU.'
   hardwarePricing:
-    title: Was kostet Tale-AI-Hardware?
+    title: Was kostet Tale-AI-Hardware? — mieten, leasen, kaufen
     description: Geräuscharme Inference-Hardware von einzelnen Nodes bis Racks —
       mieten, leasen oder kaufen. Vor Ort mit Remote-Wartung oder in sicheren
       Rechenzentren.
@@ -37,41 +38,43 @@ seo:
       steuert jede Aktion — selbst gehostet für datensensible Teams in der
       Schweiz und der EU.
   platformAgents:
-    title: Was sind Agents in Tale?
+    title: Was sind Agents in Tale? — Anweisungen, Tools, Modell
     description:
       Tale-Agents kombinieren Anweisungen, Wissen, Tools und ein Modell.
       Verbinde Claude Code, Codex, Hermes und OpenClaw unter einem Orchestrator,
       den du hostest.
   platformChat:
-    title: Chats in Tale
+    title: Was ist Chat in Tale? — Zitate, Tool-Aufrufe, Freigaben
     description:
       'Tale Chat ist der Alltagseinstieg: Agent wählen, Nachricht senden,
       gestreamte Antwort lesen — mit Zitaten, Tool-Aufrufen, Arena-Modus und
       Freigaben im Chat.'
   platformAutomations:
-    title: Was sind Automations in Tale?
-    description: Tale Automations bündeln Connectors, Agents und typisierte
-      Workflow-Schritte — Trigger, Bedingungen, Aktionen und menschliche
-      Freigaben auf deiner Infrastruktur.
+    title: Was sind Automations in Tale? — vom Trigger zur Freigabe
+    description:
+      'Tale Automations bündeln Connectors, Agents und typisierte
+      Workflow-Schritte: Trigger, Bedingungen, Aktionen und menschliche
+      Freigaben auf deiner Infrastruktur.'
   platformKnowledge:
-    title: Was ist Knowledge in Tale?
+    title: Was ist Knowledge in Tale? — indexiert und zitiert
     description: Tale Knowledge indexiert Dokumente, Websites und typisierte
       Datensätze, damit Agents deine Realität abrufen und zitieren — nicht nur
       Trainingsdaten.
   platformGovernance:
-    title: Was ist Governance in Tale?
+    title: Was ist Governance in Tale? — Freigaben und Audit-Log
     description: Tale Governance hält Agent-Aktionen hinter Freigabe-Karten,
       schreibt jeden Entscheid ins Audit-Log und filtert PII und unsichere
       Inhalte in beide Richtungen.
   platformProjects:
-    title: Was sind Projekte in Tale?
+    title: Was sind Projekte in Tale? — geteilte Arbeitsbereiche
     description: Tale-Projekte bündeln Chats, Dateien, Anweisungen und ein
-      Task-Board in einem geteilten Arbeitsbereich — weise eine Aufgabe einem
-      Agent zu und prüfe das Ergebnis, bevor es rausgeht.
+      Task-Board — weise eine Aufgabe einem Agent zu und prüfe das Ergebnis,
+      bevor es rausgeht.
   changelog:
     title: Was ist neu in Tale? — Changelog
-    description: Release Notes zu jeder Tale-Version, neueste zuerst —
-      veröffentlicht aus GitHub Releases.
+    description: Release Notes zu jeder Tale-Version, neueste zuerst — Features,
+      Fixes und Breaking Changes jeder Version, veröffentlicht aus GitHub
+      Releases.
 notFound:
   title: Diese Seite gibt es nicht
   body: Die Adresse ist vielleicht vertippt, oder die Seite ist umgezogen. Am

--- a/services/web/messages/en.yml
+++ b/services/web/messages/en.yml
@@ -11,7 +11,7 @@ seo:
       Tale Enterprise is CHF 12 (EUR 14) per user/month, two months free
       on yearly billing. Community is free to self-host under MIT.
   contact:
-    title: Contact the Tale team
+    title: Contact the Tale team — sales, support, demos
     description:
       Talk to the Tale team about self-hosted AI for your organization —
       platform, pricing, hardware, or a guided demo. Replies land within one
@@ -22,7 +22,7 @@ seo:
       in 2020 — vendor-neutral, ISO 27001 & SOC 2 Type II certified, and fully
       open source under MIT.
   requestDemo:
-    title: Request a demo
+    title: Request a Tale demo — a guided walkthrough
     description:
       'Book a guided Tale demo: see self-hosted AI agents, automations,
       and governance in action. Built for data-sensitive organizations in
@@ -39,44 +39,44 @@ seo:
       governs every action — self-hosted for data-sensitive teams in Switzerland
       and the EU.
   platformAgents:
-    title: What are agents in Tale?
+    title: What are agents in Tale? — instructions, tools, models
     description:
       Tale agents combine instructions, knowledge, tools, and a model.
       Connect Claude Code, Codex, Hermes, and OpenClaw under one orchestrator
       you host.
   platformChat:
-    title: Chats in Tale
+    title: What is Chat in Tale? — agents, citations, approvals
     description: 'Tale Chat is the everyday entry point: pick an agent, send a
       message, and read a streamed reply with citations, tool calls, Arena mode,
       and in-chat approvals.'
   platformAutomations:
-    title: What are Automations in Tale?
+    title: What are Automations in Tale? — triggers to approvals
     description: Tale Automations bundle connectors, agents, and typed workflow
       steps — triggers, conditions, actions, and human approvals on
       infrastructure you run.
   platformKnowledge:
-    title: What is Knowledge in Tale?
+    title: What is Knowledge in Tale? — indexed and cited sources
     description:
       Tale Knowledge indexes documents, websites, and typed records so
       agents retrieve and cite your reality instead of model training data
       alone.
   platformGovernance:
-    title: What is Governance in Tale?
+    title: What is Governance in Tale? — approvals and audit trail
     description:
       Tale Governance holds agent actions behind approval cards, writes
       every decision to the audit log, and filters PII and unsafe content in
       both directions.
   platformProjects:
-    title: What are Projects in Tale?
+    title: What are Projects in Tale? — shared agent workspaces
     description:
       Tale Projects bundle chats, files, instructions, and a task board
       into one shared workspace — assign a task to an agent and review the
       result before it ships.
   changelog:
     title: What's new in Tale? — Changelog
-    description:
-      Release notes for every Tale version, newest first — published from
-      GitHub Releases.
+    description: Release notes for every Tale version, newest first — the
+      features, fixes, and breaking changes in each one, published from GitHub
+      Releases.
 notFound:
   title: This page doesn't exist
   body: The address may be mistyped, or the page has moved. The homepage is the

--- a/services/web/messages/fr.yml
+++ b/services/web/messages/fr.yml
@@ -11,33 +11,33 @@ seo:
       'Tale Enterprise : CHF 12 (EUR 14) par utilisateur/mois, deux mois
       offerts en annuel. Community est gratuite en auto-hébergement sous MIT.'
   contact:
-    title: Contacter l’équipe Tale
+    title: Contacter l’équipe Tale — ventes, support, démos
     description:
       Parle à l’équipe Tale de l’IA auto-hébergée pour ton organisation —
       plateforme, tarifs, matériel ou une démo guidée. Réponse sous un jour
       ouvrable.
   about:
     title: Qui est derrière Tale ? — À propos de Ruler GmbH
-    description: Tale est construit par Ruler GmbH, une entreprise suisse de
-      Spiez fondée en 2020 — neutre vis-à-vis des fournisseurs, certifiée ISO
-      27001 & SOC 2 Type II et entièrement open source sous MIT.
+    description: Tale est construit par Ruler GmbH, entreprise suisse de Spiez —
+      neutre vis-à-vis des fournisseurs, certifiée ISO 27001 & SOC 2 Type II,
+      open source sous MIT.
   requestDemo:
-    title: Demander une démo
-    description: 'Réserve une démo guidée de Tale : agents IA auto-hébergés,
-      automatisations et gouvernance en action. Pour les organisations sensibles
-      aux données, en Suisse et dans l’UE.'
+    title: Demander une démo Tale — visite guidée
+    description:
+      'Réserve une démo guidée de Tale : agents IA auto-hébergés,
+      automatisations et gouvernance en action, pour les équipes sensibles aux
+      données.'
   hardwarePricing:
     title: Combien coûte le hardware AI Tale ?
     description:
-      Hardware d’inférence silencieux, du nœud unique au rack — location,
-      leasing ou achat. Déployé sur site avec maintenance à distance, ou hébergé
-      en centres de données sécurisés.
+      'Hardware d’inférence silencieux, du nœud unique au rack : location,
+      leasing ou achat. Sur site avec maintenance à distance, ou en centres de
+      données sécurisés.'
   platform:
     title: Comment fonctionne la plateforme Tale ?
-    description:
-      Tale connecte les agents, regroupe les connaissances, exécute les
-      automations et gouverne chaque action — auto-hébergé pour les équipes
-      sensibles aux données en Suisse et dans l’UE.
+    description: Tale connecte les agents, regroupe les connaissances, exécute
+      les automations et gouverne chaque action — auto-hébergé, en Suisse et
+      dans l’UE.
   platformAgents:
     title: Que sont les agents dans Tale ?
     description:
@@ -45,15 +45,15 @@ seo:
       modèle. Connecte Claude Code, Codex, Hermes et OpenClaw sous un
       orchestrateur que tu héberges.
   platformChat:
-    title: Chats dans Tale
+    title: Qu’est-ce que Chat dans Tale ? — citations et outils
     description: 'Tale Chat, l’entrée du quotidien : choisis un agent, envoie un
       message, lis la réponse — citations, appels d’outils, Arena et
       approbations dans le fil.'
   platformAutomations:
     title: Que sont les Automations dans Tale ?
-    description: Les Automations Tale regroupent connectors, agents et étapes de
-      workflow typées — déclencheurs, conditions, actions et approbations
-      humaines sur ton infrastructure.
+    description:
+      'Les Automations Tale regroupent connectors, agents et étapes de workflow
+      typées : déclencheurs, conditions, actions et approbations humaines.'
   platformKnowledge:
     title: Qu’est-ce que Knowledge dans Tale ?
     description: Tale Knowledge indexe documents, sites et enregistrements typés
@@ -62,18 +62,18 @@ seo:
   platformGovernance:
     title: Qu’est-ce que la gouvernance dans Tale ?
     description: Tale Governance retient les actions des agents sur des cartes
-      d’approbation, écrit chaque décision au journal d’audit et filtre PII et
-      contenus à risque dans les deux sens.
+      d’approbation, journalise chaque décision et filtre PII et contenus à
+      risque.
   platformProjects:
     title: Que sont les Projets dans Tale ?
     description: Les Projets Tale réunissent chats, fichiers, instructions et
-      tableau de tâches dans un espace de travail partagé — assigne une tâche à
-      un agent et relis le résultat avant qu’il parte.
+      tableau de tâches — assigne une tâche à un agent et relis le résultat
+      avant qu’il parte.
   changelog:
     title: Quoi de neuf dans Tale ? — Changelog
-    description:
-      Les notes de version de Tale, de la plus récente à la plus ancienne
-      — publiées depuis GitHub Releases.
+    description: Les notes de version de Tale, de la plus récente à la plus
+      ancienne — fonctionnalités, correctifs et changements de rupture, publiés
+      depuis GitHub Releases.
 notFound:
   title: Cette page n’existe pas
   body:


### PR DESCRIPTION
Docs pages now put their section in the `<title>`: `Chat` becomes `Chat | Platform | Tale`. Indexable pages rendering under 14 characters go from 27 to 0, and the one page over 60 characters is fixed.

> Stacked on #3234, which extracts `resolveFullTitle`. Review that first; this branch is based on it.

## Why

The `<title>` was the bare frontmatter `title`. That same string labels the sidebar entry, the breadcrumb and the `<h1>`, so it is deliberately short: `Chat`, `Admin`, `Teams`, `Cloud`, `Trash`. As a title it rendered as little as 11 characters, and the same string appeared on pages in different sections.

Lengthening the frontmatter is the wrong lever, because it would push those strings into the sidebar and the page heading. The section context already exists in `buildBreadcrumbs`, in scope at the `useDocumentMeta` call.

Reverting this change and rebuilding lists 25 offending pages. Ahrefs reports 25 notices plus 2 warnings under "Title too short".

## What changed

`services/docs/app/pages/docs-page.tsx` gains `buildMetaTitle`, which the meta binding uses in place of `doc.frontmatter.title`:

| Case | Result |
| --- | --- |
| page under a section | `Billing \| Cloud` |
| section repeats the page name (`develop/overview`) | `Develop \| Tale documentation` |
| section landing page (`cloud/index`) | `Cloud \| Tale documentation` |
| page name already carries the section | `Self-hosted quickstart` |
| composed title would pass 60 characters | the page name alone |
| docs root | the site title |

`seo.siteTitle` is new in the three docs catalogs: `Tale documentation`, `Tale-Dokumentation`, `Documentation Tale`. The docs root title was a hardcoded English string on every locale; it now follows the catalog.

One frontmatter title changed. The French tutorial title was `Piper les transcriptions de réunions dans la Base de connaissances`, 66 characters. It also opened on `piper`, a calque of the English `pipe`. It is now `Acheminer les transcriptions de réunions`, which is native French and fits.

Measured across the built `dist/`, indexable pages only:

| | Before | After |
| --- | --- | --- |
| under 14 characters | 27 | 0 |
| over 60 characters | 1 | 0 |
| repeated title strings | 30 | 5 |

The 5 remaining repeats are the en/de/fr variants of `Connectors`, `Webhooks` and `Quickstart`, whose names are loanwords kept in all three languages. They sit on different URLs with hreflang between them.

## Risk

Sidebar labels, breadcrumbs and `<h1>` are untouched. `buildMetaTitle` feeds only `useDocumentMeta`.

The 60-character cap drops the section rather than truncating, so a long page name keeps its full text and simply gains no context.

`services/docs/app/content/frontmatter.json` is generated, and a fresh build rewrites all 2,017 entries in a different key order. This commit carries only the one line that actually changed; the ordering instability is pre-existing and untouched here.

## Tests

`app/pages/build-meta-title.test.ts` covers the rule; `tests/prerender/seo.test.ts` sweeps every indexable page in `dist/` for a rendered title of 15 to 60 characters.

| Mutation | Result |
| --- | --- |
| return the bare page title | red in units; red in the sweep, 25 offenders listed |
| drop the 60-character cap | red |
| section landing page returns the bare name | red |

## Scope

Titles only. The docs descriptions are the other half of the frontmatter problem, 281 of them over 160 characters, and they ship separately.

Gate: `bun run format`, `lint`, `typecheck`, `lint:sast` clean; docs suite 199 passing, docs prerender suite 9 passing.
